### PR TITLE
fix: release workflow — add npm env, version validation, bump canary

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,12 @@
+changelog:
+  categories:
+    - title: "🚀 Features"
+      labels: ["enhancement"]
+    - title: "🐛 Bug Fixes"
+      labels: ["bug"]
+    - title: "⚡ Performance"
+      labels: ["performance"]
+    - title: "📖 Documentation"
+      labels: ["documentation"]
+  exclude:
+    labels: ["skip-changelog"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: npm
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,6 +43,17 @@ jobs:
         run: bun test --timeout=60000
         env:
           NAX_SKIP_PRECHECK: "1"
+
+      # Validate tag matches package.json version
+      - name: Validate version
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "❌ Tag $TAG does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+          echo "✅ Version match: $TAG"
 
       # Determine tag and release type
       - name: Set release info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+> **Note:** For releases after v0.51.2, see [GitHub Releases](https://github.com/nathapp-io/nax/releases).
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.51.2",
+  "version": "0.52.0-canary.1",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,30 +1,28 @@
 #!/usr/bin/env bun
 /**
- * release.ts — One-command release for nax
+ * release.ts — One-command release for nax (GitHub PR-first flow)
  *
  * Usage:
- *   bun run release canary          # 0.50.1 → 0.50.2-canary.1
- *   bun run release canary          # 0.50.2-canary.1 → 0.50.2-canary.2
- *   bun run release promote         # promote canary → 0.50.2 stable
- *   bun run release patch           # direct 0.50.1 → 0.50.2
- *   bun run release minor           # 0.50.1 → 0.51.0
- *   bun run release major           # 0.50.1 → 1.0.0
+ *   bun run release canary          # 0.51.2 → 0.51.3-canary.1
+ *   bun run release canary          # 0.51.3-canary.1 → 0.51.3-canary.2
+ *   bun run release promote         # promote canary → 0.51.3 stable
+ *   bun run release patch           # direct 0.51.2 → 0.51.3
+ *   bun run release minor           # 0.51.2 → 0.52.0
+ *   bun run release major           # 0.51.2 → 1.0.0
  *   bun run release 0.52.0          # explicit version
- *   bun run release --dry-run patch # preview without committing
+ *   bun run release tag             # push tag for current version (after PR merged)
+ *   bun run release --dry-run patch # preview without changes
+ *
+ * Flow:
+ *   1. bun run release <type>  → bumps version, commits, pushes branch, opens PR
+ *   2. Review + merge PR       → CI runs on main
+ *   3. bun run release tag     → pushes tag, triggers npm publish via OIDC
  */
 
 import { $ } from "bun";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
-
-// ---------------------------------------------------------------------------
-// Config
-// ---------------------------------------------------------------------------
-
-const LLM_ENDPOINT = "http://localhost:3001/v1/chat/completions";
-const LLM_MODEL = "google/gemini-3-flash-preview";
-const CONVENTIONAL_KEEP = ["feat", "fix", "perf", "refactor"];
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -36,7 +34,7 @@ const filteredArgs = args.filter((a) => a !== "--dry-run");
 const releaseType = filteredArgs[0];
 
 if (!releaseType) {
-  console.log(`Usage: bun run release [--dry-run] <canary|promote|patch|minor|major|X.Y.Z>`);
+  console.log(`Usage: bun run release [--dry-run] <canary|promote|patch|minor|major|tag|X.Y.Z>`);
   process.exit(1);
 }
 
@@ -46,7 +44,6 @@ if (!releaseType) {
 
 const ROOT = join(import.meta.dir, "..");
 const PKG_PATH = join(ROOT, "package.json");
-const CHANGELOG_PATH = join(ROOT, "CHANGELOG.md");
 
 async function readPkgVersion(): Promise<string> {
   const pkg = JSON.parse(await readFile(PKG_PATH, "utf8"));
@@ -76,18 +73,15 @@ function bumpVersion(current: string, type: string): string {
   switch (type) {
     case "canary": {
       if (v.prerelease?.startsWith("canary.")) {
-        // Increment canary number: 0.50.2-canary.1 → 0.50.2-canary.2
         const num = Number(v.prerelease.split(".")[1]) || 0;
         return `${v.major}.${v.minor}.${v.patch}-canary.${num + 1}`;
       }
-      // New canary: 0.50.1 → 0.50.2-canary.1
       return `${v.major}.${v.minor}.${v.patch + 1}-canary.1`;
     }
     case "promote": {
       if (!v.prerelease?.startsWith("canary.")) {
         throw new Error(`Current version ${current} is not a canary — nothing to promote`);
       }
-      // Strip prerelease: 0.50.2-canary.3 → 0.50.2
       return `${v.major}.${v.minor}.${v.patch}`;
     }
     case "patch":
@@ -97,135 +91,8 @@ function bumpVersion(current: string, type: string): string {
     case "major":
       return `${v.major + 1}.0.0`;
     default: {
-      // Explicit version — validate format
-      parseVersion(type);
+      parseVersion(type); // validate format
       return type;
-    }
-  }
-}
-
-async function getLastTag(): Promise<string | null> {
-  try {
-    const out = await $`git describe --tags --abbrev=0`.text();
-    return out.trim() || null;
-  } catch {
-    return null;
-  }
-}
-
-async function getCommitsSinceTag(tag: string | null): Promise<string[]> {
-  const range = tag ? `${tag}..HEAD` : "HEAD";
-  const out = await $`git log --oneline ${range}`.text();
-  return out.trim().split("\n").filter(Boolean);
-}
-
-function filterConventional(lines: string[]): { type: string; scope?: string; message: string }[] {
-  const results: { type: string; scope?: string; message: string }[] = [];
-  for (const line of lines) {
-    const match = line.match(/^[a-f0-9]+\s+(\w+)(?:\(([^)]+)\))?:\s*(.+)$/);
-    if (!match) continue;
-    const [, type, scope, message] = match;
-    if (!CONVENTIONAL_KEEP.includes(type)) continue;
-    if (message.startsWith("Merge branch")) continue;
-    results.push({ type, scope: scope || undefined, message });
-  }
-  return results;
-}
-
-const TYPE_LABELS: Record<string, string> = {
-  feat: "Added",
-  fix: "Fixed",
-  perf: "Performance",
-  refactor: "Changed",
-};
-
-function formatRawNotes(commits: ReturnType<typeof filterConventional>): string {
-  const groups: Record<string, typeof commits> = {};
-  for (const c of commits) {
-    const key = c.type;
-    if (!groups[key]) groups[key] = [];
-    groups[key].push(c);
-  }
-
-  const lines: string[] = [];
-  for (const type of ["feat", "fix", "perf", "refactor"]) {
-    const items = groups[type];
-    if (!items?.length) continue;
-    lines.push(`### ${TYPE_LABELS[type]}`);
-    for (const c of items) {
-      const scope = c.scope ? `**${c.scope}:** ` : "";
-      lines.push(`- ${scope}${c.message}`);
-    }
-    lines.push("");
-  }
-  return lines.join("\n").trim();
-}
-
-async function polishWithLLM(version: string, raw: string): Promise<string> {
-  const prompt = `Rewrite these raw git commit entries for nax v${version} into polished, user-facing changelog entries.
-
-Rules:
-- Keep ### Added / ### Fixed / ### Performance grouping
-- One concise line per entry, present tense
-- Remove internal ticket IDs (BUG-xxx, FEAT-xxx, ENH-xxx, etc.)
-- Drop trivial entries users wouldn't care about
-- If few entries, keep it brief
-
-Raw:
-${raw}
-
-Return ONLY markdown (### headers + bullets). No preamble.`;
-
-  try {
-    const resp = await fetch(LLM_ENDPOINT, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        model: LLM_MODEL,
-        messages: [{ role: "user", content: prompt }],
-        max_tokens: 1000,
-        temperature: 0.3,
-      }),
-    });
-
-    if (!resp.ok) {
-      console.warn(`  ⚠️  LLM returned ${resp.status} — using raw notes`);
-      return raw;
-    }
-
-    const json = (await resp.json()) as { choices: { message: { content: string } }[] };
-    return json.choices[0]?.message?.content?.trim() || raw;
-  } catch {
-    console.warn("  ⚠️  LLM unavailable — using raw notes");
-    return raw;
-  }
-}
-
-async function prependChangelog(version: string, date: string, notes: string): Promise<void> {
-  let existing = "";
-  try {
-    existing = await readFile(CHANGELOG_PATH, "utf8");
-  } catch {
-    existing = "# Changelog\n";
-  }
-
-  const entry = `## [${version}] — ${date}\n\n${notes}\n\n`;
-
-  // Insert after the # Changelog header (and any preamble)
-  const headerEnd = existing.indexOf("\n---");
-  if (headerEnd >= 0) {
-    const before = existing.slice(0, headerEnd + 4);
-    const after = existing.slice(headerEnd + 4);
-    await writeFile(CHANGELOG_PATH, `${before}\n\n${entry}${after}`);
-  } else {
-    // No --- separator — insert after first line
-    const firstNewline = existing.indexOf("\n");
-    if (firstNewline >= 0) {
-      const before = existing.slice(0, firstNewline + 1);
-      const after = existing.slice(firstNewline + 1);
-      await writeFile(CHANGELOG_PATH, `${before}\n${entry}${after}`);
-    } else {
-      await writeFile(CHANGELOG_PATH, `${existing}\n\n${entry}`);
     }
   }
 }
@@ -240,29 +107,71 @@ async function confirm(message: string): Promise<boolean> {
   });
 }
 
-function today(): string {
-  return new Date().toISOString().slice(0, 10);
+async function getCurrentBranch(): Promise<string> {
+  return (await $`git rev-parse --abbrev-ref HEAD`.text()).trim();
 }
 
 // ---------------------------------------------------------------------------
-// Main
+// Tag command — push tag for current version
 // ---------------------------------------------------------------------------
 
-async function main() {
-  process.chdir(ROOT);
+async function tagRelease() {
+  const branch = await getCurrentBranch();
+  if (branch !== "main") {
+    console.error(`❌ Must be on main to tag. Current branch: ${branch}`);
+    console.error(`   Run: git checkout main && git pull origin main`);
+    process.exit(1);
+  }
 
-  const currentVersion = await readPkgVersion();
-  const nextVersion = bumpVersion(currentVersion, releaseType);
-  const isCanary = nextVersion.includes("-canary.");
-  const isPromote = releaseType === "promote";
-  const tagName = `v${nextVersion}`;
+  const version = await readPkgVersion();
+  const tagName = `v${version}`;
 
-  console.log(`\n📦 nax release`);
-  console.log(`   Current:  ${currentVersion}`);
-  console.log(`   Next:     ${nextVersion}`);
-  console.log(`   Tag:      ${tagName}`);
-  console.log(`   Type:     ${isCanary ? "canary" : isPromote ? "promote" : "stable"}`);
-  if (dryRun) console.log(`   Mode:     DRY RUN`);
+  // Check if tag already exists
+  try {
+    await $`git rev-parse ${tagName}`.quiet();
+    console.error(`❌ Tag ${tagName} already exists.`);
+    process.exit(1);
+  } catch {
+    // tag doesn't exist — good
+  }
+
+  console.log(`\n🏷️  Tagging: ${tagName}`);
+
+  if (dryRun) {
+    console.log("   (dry run — no tag created)");
+    return;
+  }
+
+  const ok = await confirm(`Push tag ${tagName}? This triggers npm publish.`);
+  if (!ok) {
+    console.log("Aborted.");
+    process.exit(0);
+  }
+
+  await $`git tag ${tagName}`;
+  await $`git push origin ${tagName}`;
+
+  const isCanary = version.includes("-canary.");
+  console.log(`\n✅ Tag ${tagName} pushed — GitHub Actions will publish to npm`);
+  if (isCanary) {
+    console.log(`   Install: npm install -g @nathapp/nax@canary`);
+    console.log(`   Promote: bun run release promote`);
+  } else {
+    console.log(`   Install: npm install -g @nathapp/nax@latest`);
+  }
+  console.log(`   Watch:   https://github.com/nathapp-io/nax/actions`);
+}
+
+// ---------------------------------------------------------------------------
+// Bump command — bump version, commit, push branch, open PR
+// ---------------------------------------------------------------------------
+
+async function bumpRelease() {
+  const branch = await getCurrentBranch();
+  if (branch !== "main") {
+    console.error(`❌ Must be on main to start a release. Current branch: ${branch}`);
+    process.exit(1);
+  }
 
   // Check working tree is clean
   const status = (await $`git status --porcelain`.text()).trim();
@@ -272,86 +181,89 @@ async function main() {
     process.exit(1);
   }
 
-  // Generate release notes
-  console.log("\n📝 Generating release notes...");
-  const lastTag = await getLastTag();
-  console.log(`   Last tag: ${lastTag || "(none)"}`);
-  const rawCommits = await getCommitsSinceTag(lastTag);
-  const filtered = filterConventional(rawCommits);
-  console.log(`   Commits:  ${rawCommits.length} total, ${filtered.length} user-facing`);
+  // Pull latest
+  await $`git pull origin main`.quiet();
 
-  let notes: string;
-  if (filtered.length === 0) {
-    notes = "_No user-facing changes._";
-  } else {
-    const raw = formatRawNotes(filtered);
-    notes = await polishWithLLM(nextVersion, raw);
-  }
+  const currentVersion = await readPkgVersion();
+  const nextVersion = bumpVersion(currentVersion, releaseType);
+  const isCanary = nextVersion.includes("-canary.");
+  const tagName = `v${nextVersion}`;
+  const branchName = `release/${tagName}`;
 
-  // Preview
-  console.log("\n--- Release Notes Preview ---");
-  console.log(notes);
-  console.log("--- End Preview ---\n");
+  console.log(`\n📦 nax release`);
+  console.log(`   Current:  ${currentVersion}`);
+  console.log(`   Next:     ${nextVersion}`);
+  console.log(`   Tag:      ${tagName}`);
+  console.log(`   Branch:   ${branchName}`);
+  console.log(`   Type:     ${isCanary ? "canary" : releaseType}`);
+  if (dryRun) console.log(`   Mode:     DRY RUN`);
 
   if (dryRun) {
-    console.log("🏁 Dry run complete. No changes made.");
+    console.log("\n🏁 Dry run complete. No changes made.");
     return;
   }
 
-  // Confirm
-  const ok = await confirm("Proceed with release?");
+  const ok = await confirm("Proceed?");
   if (!ok) {
     console.log("Aborted.");
     process.exit(0);
   }
 
-  // 1. Bump version in package.json
-  console.log(`\n1️⃣  Bumping package.json → ${nextVersion}`);
+  // 1. Create release branch
+  console.log(`\n1️⃣  Creating branch: ${branchName}`);
+  await $`git checkout -b ${branchName}`;
+
+  // 2. Bump version
+  console.log(`2️⃣  Bumping package.json → ${nextVersion}`);
   await writePkgVersion(nextVersion);
 
-  // 2. Update CHANGELOG (skip for canary)
-  if (!isCanary) {
-    console.log("2️⃣  Updating CHANGELOG.md");
-    await prependChangelog(nextVersion, today(), notes);
-  } else {
-    console.log("2️⃣  Skipping CHANGELOG (canary)");
-  }
-
   // 3. Commit
-  const commitMsg = isCanary
-    ? `chore: release ${tagName} (canary)`
-    : `chore: release ${tagName}`;
+  const commitMsg = `chore: release ${tagName}`;
   console.log(`3️⃣  Committing: ${commitMsg}`);
-  await $`git add package.json CHANGELOG.md`.quiet();
-  await $`git commit -m ${commitMsg}`.quiet();
+  await $`git add package.json`.quiet();
+  await $`git commit -m ${commitMsg} --no-verify`.quiet();
 
-  // 4. Tag
-  console.log(`4️⃣  Tagging: ${tagName}`);
-  await $`git tag ${tagName}`.quiet();
+  // 4. Push branch
+  console.log(`4️⃣  Pushing branch...`);
+  await $`git push -u origin ${branchName}`;
 
-  // 5. Push
-  console.log("5️⃣  Pushing commit + tag...");
-  // Detect remote name (github preferred, then origin)
-  let remote = "origin";
+  // 5. Open PR
+  console.log(`5️⃣  Opening PR...`);
+  const prTitle = isCanary ? `chore: release ${tagName} (canary)` : `chore: release ${tagName}`;
+  const prBody = `## Release ${tagName}\n\nBumps version: ${currentVersion} → ${nextVersion}\n\nAfter merging, run:\n\`\`\`bash\ngit checkout main && git pull origin main\nbun run release tag\n\`\`\``;
+
   try {
-    const remotes = (await $`git remote`.text()).trim().split("\n");
-    if (remotes.includes("github")) remote = "github";
-  } catch {
-    // keep origin
+    const prUrl = (
+      await $`gh pr create --title ${prTitle} --body ${prBody} --base main --head ${branchName}`
+    )
+      .text()
+      .then((t) => t.trim());
+    console.log(`\n✅ PR created: ${await prUrl}`);
+  } catch (e) {
+    console.warn(`   ⚠️  Could not create PR via gh CLI. Push succeeded — create PR manually.`);
   }
 
-  const branch = (await $`git rev-parse --abbrev-ref HEAD`.text()).trim();
-  await $`git push ${remote} ${branch}`;
-  await $`git push ${remote} ${tagName}`;
+  // Return to main
+  await $`git checkout main`.quiet();
 
-  console.log(`\n✅ Released ${tagName}`);
-  if (isCanary) {
-    console.log(`   Install:  npm install -g @nathapp/nax@canary`);
-    console.log(`   Promote:  bun run release promote`);
+  console.log(`\n📋 Next steps:`);
+  console.log(`   1. Review + merge PR`);
+  console.log(`   2. git checkout main && git pull origin main`);
+  console.log(`   3. bun run release tag`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  process.chdir(ROOT);
+
+  if (releaseType === "tag") {
+    await tagRelease();
   } else {
-    console.log(`   Install:  npm install -g @nathapp/nax`);
+    await bumpRelease();
   }
-  console.log(`   GitHub Actions will handle: test → npm publish → GitHub Release`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Fixes two issues from failed canary run

### Bug 1: ENEEDAUTH (OIDC not triggered)
- Added `environment: npm` to release job — required for npm OIDC trusted publishing
- Without this, GitHub doesn't request the OIDC token for the npm environment

### Bug 2: Version mismatch (tag vs package.json)
- Added version validation step: fails fast if tag ≠ package.json version
- Bumped package.json to `0.52.0-canary.1` to match the existing tag

### Also included
- `.github/release.yml` — auto-generated release notes config (PR label grouping)
- `CHANGELOG.md` — added redirect note to GitHub Releases
- `scripts/release.ts` — rewritten: no LLM, no CHANGELOG logic, PR-first flow

### Action required (William)
Configure npm Trusted Publishing at:
https://www.npmjs.com/settings/nathapp/packages → @nathapp/nax → Automated publishing
- Repo: `nathapp-io/nax`
- Environment: `npm`