### PR TITLE
fix: add setup-node for npm OIDC auth in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           bun-version: "1.3.9"
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## Problem
npm publish fails with ENEEDAUTH — the OIDC token isn't being passed to npm.

## Root cause
`actions/setup-node` with `registry-url` is required for npm OIDC trusted publishing. It configures `.npmrc` and handles the OIDC token exchange. We had `oven-sh/setup-bun` but not `setup-node`.

## Fix
Added `actions/setup-node@v4` with `registry-url: https://registry.npmjs.org` before the install step.