### PR TITLE
fix: remove registry-url from setup-node (breaks npm OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Root cause
`setup-node` with `registry-url` sets `NODE_AUTH_TOKEN` as an env var in the publish step. When no `secrets.NODE_AUTH_TOKEN` exists, it sends a blank token — overriding OIDC and causing the 404.

## Fix
Remove `registry-url` from `setup-node`. Node is still available for the version validation step. Without `registry-url`, `setup-node` does not configure `.npmrc` and does not set `NODE_AUTH_TOKEN`, allowing npm OIDC to work naturally via `id-token: write` + `environment: npm`.