### PR TITLE
chore: enable auto-generated release notes from PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
           name: ${{ steps.info.outputs.tag }}
           body_path: /tmp/release-notes.md
           prerelease: ${{ steps.info.outputs.prerelease }}
-          generate_release_notes: false
+          generate_release_notes: true
 
       # Telegram notification (stable only)
       - name: Notify Telegram


### PR DESCRIPTION
Enable GitHub's auto-generated release notes in the release workflow. Notes will be grouped by PR labels per `.github/release.yml` (bug, enhancement, performance, documentation).