### PR TITLE
chore: release v0.52.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.52.0-canary.1",
-  "description": "AI Coding Agent Orchestrator \u2014 loops until done",
+  "version": "0.52.0",
+  "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {
     "nax": "./dist/nax.js"


### PR DESCRIPTION
## What

Promotes v0.52.0-canary.1 to stable v0.52.0.

## Why

GitHub migration complete. CI is stable. All smoke tests pass. Fixed an issue where the review gate was blocked by uncommitted lockfile changes after dependency installs. Time to cut the stable release.

## How

Version bump only — `package.json` 0.52.0-canary.1 → 0.52.0.

All changes were already merged to `main` and verified through CI prior to this release PR.

## Testing

- [x] Tests added/updated (CI stability fixes, review gate fix)
- [x] `bun test` passes (4346 pass, 60 skip, 0 fail — verified in Docker Debian/glibc 1c/2g)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

**What's in v0.52.0:**

### Bug Fixes
- **Review gate fix** — The review stage now auto-commits dirty files (e.g. `bun.lock`, `package.json` from `bun add`) before the clean-tree check. Previously, running `bun add` inside a story would leave the lockfile uncommitted and permanently block review with _"Uncommitted changes detected before review: bun.lock"_.

### CI / Infrastructure
- Bun upgraded to **v1.3.11** — fixes JSC segfault (exit 134) on GitHub Actions Ubuntu runners
- Test stability — replaced subprocess spawning with direct function calls in integration tests (eliminated 15s timeout failures on CI)
- `release.yml` — added `bun run build` step before npm publish
- docker-compose test images switched to `oven/bun:1.3.11` (Debian/glibc) to match GitHub runners

### Migration
- GitHub migration complete (OIDC npm publish, CI workflow, PR/issue templates, branch protection)