### PR TITLE
docs(github): add issue template config + documentation template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Ask a question
+    url: https://discord.com/invite/clawd
+    about: Not sure how something works? Ask in the community Discord.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,23 @@
+---
+name: Documentation
+about: Report missing, incorrect, or unclear documentation
+title: 'docs: '
+labels: documentation
+assignees: ''
+---
+
+## What's wrong
+
+<!-- Is it missing, incorrect, outdated, or unclear? -->
+
+## Where
+
+<!-- Link to the specific page, file, or section -->
+
+## Suggested fix
+
+<!-- What should it say instead? A draft is welcome but not required -->
+
+## Additional context
+
+<!-- Screenshots, links, related issues -->


### PR DESCRIPTION
## What

Adds two missing GitHub issue template files:

- **`config.yml`** — controls the "New Issue" picker: disables blank (unstructured) issues and adds a Discord link for questions
- **`documentation.md`** — template for reporting missing, incorrect, or unclear docs

## Why

Without `config.yml`, GitHub shows no titles or labels on the template picker and allows blank unstructured issues. Questions filed as bugs create noise.

Without a docs template, users have no structured way to report documentation gaps — they either file a generic bug or nothing at all.

## How

Minimal additions — no source code changes.

## Testing

- [x] `bun test` passes (no source changes)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- `blank_issues_enabled: false` means users must pick a template — no freeform issues
- Discord link points to the existing community invite
- Existing `bug_report.md` and `feature_request.md` templates are unchanged
