### PR TITLE
chore: release v0.53.0-canary.1 (canary)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.52.0",
-  "description": "AI Coding Agent Orchestrator \u2014 loops until done",
+  "version": "0.53.0-canary.1",
+  "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {
     "nax": "./dist/nax.js"


### PR DESCRIPTION
## Release v0.53.0-canary.1

Bumps version: 0.52.0 → 0.53.0-canary.1

After merging, run:
```bash
git checkout main && git pull origin main
bun run release tag
```