### PR TITLE
fix: restrict auto-reconcile to review/autofix failures only

### DIFF
--- a/src/execution/lifecycle/run-initialization.ts
+++ b/src/execution/lifecycle/run-initialization.ts
@@ -72,24 +72,34 @@ async function reconcileState(prd: PRD, prdPath: string, workdir: string, config
     const hasCommits = await _reconcileDeps.hasCommitsForStory(workdir, story.id);
     if (!hasCommits) continue;
 
-    // Gate: re-run review for stories that failed at review/autofix stage
-    if (story.failureStage === "review" || story.failureStage === "autofix") {
-      const effectiveWorkdir = story.workdir ? join(workdir, story.workdir) : workdir;
-      try {
-        const reviewResult = await _reconcileDeps.runReview(config.review, effectiveWorkdir, config.execution);
-        if (!reviewResult.success) {
-          logger?.warn("reconciliation", "Review still fails — not reconciling story", {
-            storyId: story.id,
-            failureReason: reviewResult.failureReason,
-          });
-          continue;
-        }
-        logger?.info("reconciliation", "Review now passes — reconciling story", { storyId: story.id });
-      } catch {
-        // Non-fatal: if review check errors, skip reconciliation for this story
-        logger?.warn("reconciliation", "Review check errored — not reconciling story", { storyId: story.id });
+    // Only reconcile stories that failed at review/autofix stage — these have
+    // completed code that just failed quality checks. All other failure stages
+    // (execution, verify, regression, etc.) may have incomplete work despite
+    // having commits in git history (e.g. rate limit mid-execution).
+    if (story.failureStage !== "review" && story.failureStage !== "autofix") {
+      logger?.debug("reconciliation", "Skipping non-review/autofix failure — not reconcilable", {
+        storyId: story.id,
+        failureStage: story.failureStage,
+      });
+      continue;
+    }
+
+    // Re-run review to confirm the quality issues were actually fixed
+    const effectiveWorkdir = story.workdir ? join(workdir, story.workdir) : workdir;
+    try {
+      const reviewResult = await _reconcileDeps.runReview(config.review, effectiveWorkdir, config.execution);
+      if (!reviewResult.success) {
+        logger?.warn("reconciliation", "Review still fails — not reconciling story", {
+          storyId: story.id,
+          failureReason: reviewResult.failureReason,
+        });
         continue;
       }
+      logger?.info("reconciliation", "Review now passes — reconciling story", { storyId: story.id });
+    } catch {
+      // Non-fatal: if review check errors, skip reconciliation for this story
+      logger?.warn("reconciliation", "Review check errored — not reconciling story", { storyId: story.id });
+      continue;
     }
 
     logger?.warn("reconciliation", "Failed story has commits in git history, marking as passed", {

--- a/test/unit/execution/lifecycle/run-initialization.test.ts
+++ b/test/unit/execution/lifecycle/run-initialization.test.ts
@@ -1,10 +1,10 @@
 /**
  * Unit tests for run-initialization.ts — ENH-007
  *
- * Verifies reconcileState review gate behavior:
- * - Backward compat: no failureStage => reconcile as before
- * - review/autofix failureStage => re-run review before reconciling
- * - other failureStage => trust commits, no review re-run
+ * Verifies reconcileState behavior:
+ * - Only review/autofix failures are reconcilable (re-runs review gate)
+ * - All other failure stages (execution, verify, etc.) are NOT reconciled
+ * - No failureStage => NOT reconciled (unknown failure = not safe)
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -98,15 +98,14 @@ describe("reconcileState", () => {
     }
   });
 
-  test("backward compat: no failureStage + commits => reconciles as passed", async () => {
+  test("no failureStage + commits => NOT reconciled (unknown failure stage)", async () => {
     _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(true));
     _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewSuccess()));
 
     const prd = makePrd({ status: "failed" }); // no failureStage
     const result = await runReconcile(prd, "-1");
 
-    expect(result.userStories[0].status).toBe("passed");
-    // Review must NOT be called for non-review-stage failures
+    expect(result.userStories[0].status).toBe("failed");
     expect(_reconcileDeps.runReview).not.toHaveBeenCalled();
   });
 
@@ -143,14 +142,36 @@ describe("reconcileState", () => {
     expect(_reconcileDeps.runReview).toHaveBeenCalledTimes(1);
   });
 
-  test("failureStage=coding + commits => reconciles without calling review", async () => {
+  test("failureStage=execution + commits => NOT reconciled", async () => {
     _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(true));
     _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewSuccess()));
 
-    const prd = makePrd({ status: "failed", failureStage: "coding" });
+    const prd = makePrd({ status: "failed", failureStage: "execution" });
     const result = await runReconcile(prd, "-5");
 
-    expect(result.userStories[0].status).toBe("passed");
+    expect(result.userStories[0].status).toBe("failed");
+    expect(_reconcileDeps.runReview).not.toHaveBeenCalled();
+  });
+
+  test("failureStage=verify + commits => NOT reconciled", async () => {
+    _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(true));
+    _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewSuccess()));
+
+    const prd = makePrd({ status: "failed", failureStage: "verify" });
+    const result = await runReconcile(prd, "-8");
+
+    expect(result.userStories[0].status).toBe("failed");
+    expect(_reconcileDeps.runReview).not.toHaveBeenCalled();
+  });
+
+  test("failureStage=regression + commits => NOT reconciled", async () => {
+    _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(true));
+    _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewSuccess()));
+
+    const prd = makePrd({ status: "failed", failureStage: "regression" });
+    const result = await runReconcile(prd, "-9");
+
+    expect(result.userStories[0].status).toBe("failed");
     expect(_reconcileDeps.runReview).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What

Restrict auto-reconcile to only review/autofix failure stages. Previously, any failed story with commits in git history would be auto-reconciled to "passed" on re-run, regardless of why it failed.

## Why

Stories that failed mid-execution due to external factors (rate limit, timeout, crash) could have partial/incomplete commits in git. The old logic would see those commits and mark the story as passed — even though the work was never completed.

Example: a story fails due to API rate limit (subscription quota full). The agent made some commits before being cut off. On re-run, `reconcileState` finds those commits and marks the story passed without any validation.

## How

- Flipped the condition in `reconcileState`: instead of gating only review/autofix behind a review re-check (and letting everything else through), now **only** review/autofix failures are eligible for reconciliation at all.
- All other failure stages (`execution`, `verify`, `regression`, `routing`, etc.) skip reconciliation — the story stays failed and gets retried normally.
- Stories with no `failureStage` set (e.g. from tier exhaustion) are also not reconciled.

## Testing

- [x] Tests added/updated (9 tests — updated backward-compat case, added execution/verify/regression cases)
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

This is a behavior change: stories that previously would have been auto-reconciled (e.g. execution failures with commits) will now stay failed and be retried. This is the safer/correct behavior.
