### PR TITLE
fix: skip pre-run pipeline when all stories are already complete

### DIFF
--- a/src/execution/sequential-executor.ts
+++ b/src/execution/sequential-executor.ts
@@ -68,6 +68,15 @@ export async function executeSequential(
   );
 
   try {
+    // Early exit: skip pre-run pipeline when all stories are already complete.
+    // Avoids unnecessary acceptance test regeneration (LLM cost) on re-runs
+    // where everything already passed.
+    if (isComplete(prd)) {
+      logger?.info("execution", "All stories already complete — skipping pre-run pipeline");
+      deferredReview = await runDeferredReview(ctx.workdir, ctx.config.review, ctx.pluginRegistry, runStartRef);
+      return buildResult("completed");
+    }
+
     // Pre-run pipeline (acceptance test setup with RED gate)
     logger?.info("execution", "Running pre-run pipeline (acceptance test setup)");
     const preRunCtx: PipelineContext = {


### PR DESCRIPTION
## What

Skip the pre-run pipeline (acceptance-setup) when all stories are already complete on re-run.

## Why

When re-running a feature where all stories have already passed, the sequential executor still ran the pre-run pipeline, which triggers acceptance test regeneration via LLM. This wastes ~44s and an LLM API call for no benefit — the tests were already generated and validated during the first run.

Observed in production: all 3 stories passed, `pendingStories: 0`, yet acceptance-setup regenerated 30 tests from PRD criteria.

## How

Added `isComplete(prd)` check before the pre-run pipeline in `sequential-executor.ts`. When all stories are already passed, exits early with `"completed"` status (including deferred review), matching the existing completion path inside the main loop.

## Testing

- [x] Tests added/updated (existing RL-002 + RL-007 tests all pass — they already exercise all-passed PRD scenarios)
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

This only affects the sequential executor. The parallel executor doesn't run `preRunPipeline` — but when parallel sees no ready stories, it falls through to sequential, which now catches the all-complete case early.
