### PR TITLE
fix: exclude US-FIX-* stories from acceptance fingerprint

### DIFF
--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -133,8 +133,12 @@ export const acceptanceSetupStage: PipelineStage = {
     const testPath = path.join(ctx.featureDir, "acceptance.test.ts");
     const metaPath = path.join(ctx.featureDir, "acceptance-meta.json");
 
-    // All criteria from the PRD — used for fingerprint and generation
-    const allCriteria: string[] = ctx.prd.userStories.flatMap((s) => s.acceptanceCriteria);
+    // All criteria from original stories only — fix stories (US-FIX-*) are excluded
+    // so that the fingerprint remains stable when fix stories are added during the
+    // acceptance loop. This prevents unnecessary test regeneration on re-runs.
+    const allCriteria: string[] = ctx.prd.userStories
+      .filter((s) => !s.id.startsWith("US-FIX-"))
+      .flatMap((s) => s.acceptanceCriteria);
 
     let totalCriteria = 0;
     let testableCount = 0;

--- a/test/unit/pipeline/stages/acceptance-setup-regeneration.test.ts
+++ b/test/unit/pipeline/stages/acceptance-setup-regeneration.test.ts
@@ -285,6 +285,45 @@ describe("acceptance-setup: regenerates when fingerprint is stale (P2-A)", () =>
 });
 
 // ---------------------------------------------------------------------------
+// Fix-story exclusion: US-FIX-* stories don't affect fingerprint
+// ---------------------------------------------------------------------------
+
+describe("acceptance-setup: US-FIX-* stories excluded from fingerprint", () => {
+  test("adding fix stories does NOT trigger regeneration", async () => {
+    const storedFingerprint = computeACFingerprint(DEFAULT_CRITERIA);
+    let generateCalled = false;
+
+    _acceptanceSetupDeps.fileExists = async () => true;
+    _acceptanceSetupDeps.readMeta = async () => ({
+      generatedAt: "2026-01-01T00:00:00Z",
+      acFingerprint: storedFingerprint,
+      storyCount: 2,
+      acCount: 3,
+      generator: "nax",
+    });
+    _acceptanceSetupDeps.refine = async () => [];
+    _acceptanceSetupDeps.generate = async () => {
+      generateCalled = true;
+      return { testCode: "", criteria: [] };
+    };
+    _acceptanceSetupDeps.writeFile = async () => {};
+    _acceptanceSetupDeps.runTest = async () => ({ exitCode: 1, output: "1 fail" });
+
+    // PRD with original stories + a fix story added by acceptance loop
+    const stories = [
+      makeStory("US-001", ["AC-1: first criterion", "AC-2: second criterion"]),
+      makeStory("US-002", ["AC-3: third criterion"]),
+      makeStory("US-FIX-001", ["Fix the broken validation logic"]),
+    ];
+    const ctx = makeCtx({ prd: makePrd(stories) as any });
+
+    await acceptanceSetupStage.execute(ctx);
+
+    expect(generateCalled).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // P2-A: No regeneration when fingerprint matches (idempotent, AC-16)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Exclude `US-FIX-*` stories from acceptance test fingerprint computation.

## Why

When the acceptance loop adds fix stories (`US-FIX-001`, etc.) to the PRD, their `acceptanceCriteria` were included in the fingerprint hash. On re-run (e.g. after a story failure), the fingerprint no longer matched `acceptance-meta.json`, causing unnecessary acceptance test regeneration — wasting an LLM call and potentially producing different tests that don't match what the fix stories were designed to fix.

## How

Added `.filter((s) => !s.id.startsWith("US-FIX-"))` before `flatMap` when collecting criteria for fingerprint computation in `acceptance-setup.ts`. This matches the existing pattern used in `acceptance-loop.ts` (`isTestLevelFailure`).

## Testing

- [x] Tests added/updated (new test: "adding fix stories does NOT trigger regeneration")
- [x] `bun test` passes (14/14 acceptance-setup regeneration tests pass)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Related to PR #18 (skip pre-run pipeline when complete). This fix handles the case where stories are NOT all complete but acceptance tests should still be reused.
