### PR TITLE
fix: eliminate flaky timeout test race condition

### DIFF
--- a/test/integration/cli/cli-precheck.test.ts
+++ b/test/integration/cli/cli-precheck.test.ts
@@ -2090,16 +2090,21 @@ describe("Agent Validation and Retry Logic", () => {
       const adapter = new ClaudeCodeAdapter();
       let attemptCount = 0;
 
-      // Mock timeout
+      // Mock a process that hangs until killed — resolves only on SIGTERM/SIGKILL.
+      // Using a long-running promise (never resolves naturally) avoids the race
+      // between the 50ms JS timeout and a short setTimeout mock, which caused
+      // intermittent failures on slow CI machines.
       _runOnceDeps.spawn = mock((cmd: string[], opts: { cwd: string; stdout: string; stderr: string; env: Record<string, string | undefined> }) => {
         attemptCount++;
-        let killed = false;
+        let resolveExited: (code: number) => void;
+        const exitedPromise = new Promise<number>((resolve) => {
+          resolveExited = resolve;
+        });
         return {
-          exited: new Promise((resolve) => {
-            setTimeout(() => resolve(killed ? 143 : 0), 100);
-          }),
+          exited: exitedPromise,
           kill: (signal: string) => {
-            if (signal === "SIGTERM") killed = true;
+            if (signal === "SIGTERM") resolveExited(143);
+            else if (signal === "SIGKILL") resolveExited(137);
           },
           stdout: new Response("").body,
           stderr: new Response("").body,


### PR DESCRIPTION
## What

Fix flaky test: `ClaudeCodeAdapter retry logic > does not retry on timeout (exit code 124)`

## Why

The test used a mock process that resolved via `setTimeout(..., 100)` while the timeout fired at 50ms. On slow CI machines, the JS event loop could schedule the mock's 100ms timer before the `kill()` callback, causing the process to exit with code `0` instead of `143`. The test then saw a successful exit instead of a timeout, failing the assertion.

Seen in PR #22 CI: failed on attempt 1 and 2, passed on attempt 3 — classic timing race.

## How

Replace the `setTimeout`-based mock with a promise that only resolves when `kill()` is called:

```ts
// Before: resolves after 100ms regardless of kill timing
exited: new Promise((resolve) => {
  setTimeout(() => resolve(killed ? 143 : 0), 100);
}),

// After: hangs until SIGTERM/SIGKILL — no race possible
exited: exitedPromise, // resolved only inside kill()
kill: (signal) => {
  if (signal === "SIGTERM") resolveExited(143);
  else if (signal === "SIGKILL") resolveExited(137);
},
```

## Testing

- [x] Test runs 3× consecutively without failure
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Single test file change, no source changes.
