### PR TITLE
fix(acceptance): support non-Bun projects (BUG-076/077/078/079)

### DIFF
--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -19,6 +19,25 @@ import type {
 } from "./types";
 
 /**
+ * Build the test framework import line for skeleton/fallback tests.
+ *
+ * Returns the appropriate import statement based on the detected framework,
+ * or defaults to `bun:test` when none is specified.
+ */
+function skeletonImportLine(testFramework?: string): string {
+  if (!testFramework) return `import { describe, test, expect } from "bun:test";`;
+  const fw = testFramework.toLowerCase();
+  if (fw === "jest" || fw === "@jest/globals") {
+    return `import { describe, test, expect } from "@jest/globals";`;
+  }
+  if (fw === "vitest") {
+    return `import { describe, test, expect } from "vitest";`;
+  }
+  // For other frameworks (e.g. "@testing-library/react"), keep bun:test base
+  return `import { describe, test, expect } from "bun:test";`;
+}
+
+/**
  * Parse acceptance criteria from spec.md content.
  *
  * Extracts lines matching "AC-N: description" or "- AC-N: description" patterns.
@@ -119,7 +138,7 @@ Rules:
 - **NEVER use placeholder assertions** — no always-passing or always-failing stubs, no TODO comments as the only content, no empty test bodies
 - Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
 - Output raw code only — no markdown fences, start directly with the language's import or package declaration
-- **Path anchor (CRITICAL)**: This test file will be saved at \`<repo-root>/nax/features/${options.featureName}/acceptance.test.ts\` and will ALWAYS run from the repo root via \`bun test <absolute-path>\`. The repo root is exactly 3 \`../\` levels above \`__dirname\`: \`join(__dirname, '..', '..', '..')\`. Never use 4 or more \`../\` — that would escape the repo. For monorepo projects, navigate into packages from root (e.g. \`join(root, 'apps/api/src')\`).`;
+- **Path anchor (CRITICAL)**: This test file will be saved at \`<repo-root>/.nax/features/${options.featureName}/acceptance.test.ts\` and will ALWAYS run from the repo root. The repo root is exactly 4 \`../\` levels above \`__dirname\`: \`join(__dirname, '..', '..', '..', '..')\`. For monorepo projects, navigate into packages from root (e.g. \`join(root, 'apps/api/src')\`).`;
 
   const prompt = basePrompt;
 
@@ -131,7 +150,24 @@ Rules:
     timeoutMs: options.config?.acceptance?.timeoutMs ?? 1800000,
     workdir: options.workdir,
   });
-  const testCode = extractTestCode(rawOutput);
+  let testCode = extractTestCode(rawOutput);
+
+  // BUG-076: ACP adapters write files to disk directly and return a conversational
+  // summary rather than raw code. If extractTestCode() fails on the response text,
+  // check whether the adapter already wrote the file to the feature directory.
+  if (!testCode) {
+    const targetPath = join(options.featureDir, "acceptance.test.ts");
+    try {
+      const existing = await Bun.file(targetPath).text();
+      const recovered = extractTestCode(existing);
+      if (recovered) {
+        logger.info("acceptance", "Recovered acceptance test written to disk by ACP adapter", { targetPath });
+        testCode = recovered;
+      }
+    } catch {
+      // File doesn't exist — fall through to skeleton
+    }
+  }
 
   if (!testCode) {
     logger.warn("acceptance", "LLM returned non-code output for acceptance tests — falling back to skeleton", {
@@ -142,7 +178,10 @@ Rules:
       text: c.refined,
       lineNumber: i + 1,
     }));
-    return { testCode: generateSkeletonTests(options.featureName, skeletonCriteria), criteria: skeletonCriteria };
+    return {
+      testCode: generateSkeletonTests(options.featureName, skeletonCriteria, options.testFramework),
+      criteria: skeletonCriteria,
+    };
   }
 
   const refinedJsonContent = JSON.stringify(
@@ -249,7 +288,7 @@ Rules:
 - **NEVER use placeholder assertions** — no always-passing or always-failing stubs, no TODO comments as the only content, no empty test bodies
 - Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
 - Output raw code only — no markdown fences, start directly with the language's import or package declaration
-- **Path anchor (CRITICAL)**: This test file will be saved at \`<repo-root>/nax/features/${featureName}/acceptance.test.ts\` and will ALWAYS run from the repo root via \`bun test <absolute-path>\`. The repo root is exactly 3 \`../\` levels above \`__dirname\`: \`join(__dirname, '..', '..', '..')\`. Never use 4 or more \`../\` — that would escape the repo. For monorepo projects, navigate into packages from root (e.g. \`join(root, 'apps/api/src')\`).`;
+- **Path anchor (CRITICAL)**: This test file will be saved at \`<repo-root>/.nax/features/${featureName}/acceptance.test.ts\` and will ALWAYS run from the repo root. The repo root is exactly 4 \`../\` levels above \`__dirname\`: \`join(__dirname, '..', '..', '..', '..')\`. For monorepo projects, navigate into packages from root (e.g. \`join(root, 'apps/api/src')\`).`;
 }
 
 /**
@@ -290,7 +329,7 @@ export async function generateAcceptanceTests(
     // No AC found — generate empty skeleton
     logger.warn("acceptance", "⚠ No acceptance criteria found in spec.md");
     return {
-      testCode: generateSkeletonTests(options.featureName, []),
+      testCode: generateSkeletonTests(options.featureName, [], options.testFramework),
       criteria: [],
     };
   }
@@ -317,7 +356,7 @@ export async function generateAcceptanceTests(
         outputPreview: output.slice(0, 200),
       });
       return {
-        testCode: generateSkeletonTests(options.featureName, criteria),
+        testCode: generateSkeletonTests(options.featureName, criteria, options.testFramework),
         criteria,
       };
     }
@@ -330,7 +369,7 @@ export async function generateAcceptanceTests(
     logger.warn("acceptance", "⚠ Agent test generation error", { error: (error as Error).message });
     // Fall back to skeleton
     return {
-      testCode: generateSkeletonTests(options.featureName, criteria),
+      testCode: generateSkeletonTests(options.featureName, criteria, options.testFramework),
       criteria,
     };
   }
@@ -397,7 +436,11 @@ function extractTestCode(output: string): string | null {
  * // Generates test with TODO comment
  * ```
  */
-export function generateSkeletonTests(featureName: string, criteria: AcceptanceCriterion[]): string {
+export function generateSkeletonTests(
+  featureName: string,
+  criteria: AcceptanceCriterion[],
+  testFramework?: string,
+): string {
   const tests = criteria
     .map((ac) => {
       return `  test("${ac.id}: ${ac.text}", async () => {
@@ -408,7 +451,7 @@ export function generateSkeletonTests(featureName: string, criteria: AcceptanceC
     })
     .join("\n\n");
 
-  return `import { describe, test, expect } from "bun:test";
+  return `${skeletonImportLine(testFramework)}
 
 describe("${featureName} - Acceptance Tests", () => {
 ${tests || "  // No acceptance criteria found"}

--- a/src/acceptance/templates/e2e.ts
+++ b/src/acceptance/templates/e2e.ts
@@ -7,9 +7,18 @@
 
 import type { AcceptanceCriterion } from "../types";
 
+function buildTestImportLine(testFramework?: string): string {
+  const fw = testFramework?.toLowerCase() ?? "";
+  if (fw === "jest" || fw === "@jest/globals") return `import { describe, expect, test } from "@jest/globals";`;
+  if (fw === "vitest") return `import { describe, expect, test } from "vitest";`;
+  return `import { describe, expect, test } from "bun:test";`;
+}
+
 export interface E2eTemplateOptions {
   featureName: string;
   criteria: AcceptanceCriterion[];
+  /** Optional test framework override (e.g. "jest", "vitest") */
+  testFramework?: string;
 }
 
 const DEFAULT_PORT = 3000;
@@ -21,7 +30,8 @@ const DEFAULT_PORT = 3000;
  * @returns TypeScript test code string
  */
 export function buildE2eTemplate(options: E2eTemplateOptions): string {
-  const { featureName, criteria } = options;
+  const { featureName, criteria, testFramework } = options;
+  const importLine = buildTestImportLine(testFramework);
 
   const tests = criteria
     .map(
@@ -34,7 +44,7 @@ export function buildE2eTemplate(options: E2eTemplateOptions): string {
     )
     .join("\n\n");
 
-  return `import { describe, expect, test } from "bun:test";
+  return `${importLine}
 
 describe("${featureName} - Acceptance Tests", () => {
 ${tests}

--- a/src/acceptance/templates/snapshot.ts
+++ b/src/acceptance/templates/snapshot.ts
@@ -20,8 +20,16 @@ export interface SnapshotTemplateOptions {
  * @param options - Feature name, criteria, and optional test framework
  * @returns TypeScript test code string
  */
+function buildTestImportLine(testFramework?: string): string {
+  const fw = testFramework?.toLowerCase() ?? "";
+  if (fw === "jest" || fw === "@jest/globals") return `import { describe, expect, test } from "@jest/globals";`;
+  if (fw === "vitest") return `import { describe, expect, test } from "vitest";`;
+  return `import { describe, expect, test } from "bun:test";`;
+}
+
 export function buildSnapshotTemplate(options: SnapshotTemplateOptions): string {
-  const { featureName, criteria } = options;
+  const { featureName, criteria, testFramework } = options;
+  const importLine = buildTestImportLine(testFramework);
 
   const tests = criteria
     .map(
@@ -32,7 +40,7 @@ export function buildSnapshotTemplate(options: SnapshotTemplateOptions): string 
     )
     .join("\n\n");
 
-  return `import { describe, expect, test } from "bun:test";
+  return `${importLine}
 import { render } from "ink-testing-library";
 import { ${toPascalCase(featureName)} } from "../src/${featureName}";
 

--- a/src/acceptance/templates/unit.ts
+++ b/src/acceptance/templates/unit.ts
@@ -7,9 +7,18 @@
 
 import type { AcceptanceCriterion } from "../types";
 
+function buildTestImportLine(testFramework?: string): string {
+  const fw = testFramework?.toLowerCase() ?? "";
+  if (fw === "jest" || fw === "@jest/globals") return `import { describe, expect, test } from "@jest/globals";`;
+  if (fw === "vitest") return `import { describe, expect, test } from "vitest";`;
+  return `import { describe, expect, test } from "bun:test";`;
+}
+
 export interface UnitTemplateOptions {
   featureName: string;
   criteria: AcceptanceCriterion[];
+  /** Optional test framework override (e.g. "jest", "vitest") */
+  testFramework?: string;
 }
 
 /**
@@ -19,7 +28,8 @@ export interface UnitTemplateOptions {
  * @returns TypeScript test code string
  */
 export function buildUnitTemplate(options: UnitTemplateOptions): string {
-  const { featureName, criteria } = options;
+  const { featureName, criteria, testFramework } = options;
+  const importLine = buildTestImportLine(testFramework);
 
   const tests = criteria
     .map(
@@ -30,7 +40,7 @@ export function buildUnitTemplate(options: UnitTemplateOptions): string {
     )
     .join("\n\n");
 
-  return `import { describe, expect, test } from "bun:test";
+  return `${importLine}
 import { ${toCamelCase(featureName)} } from "../src/${toKebabCase(featureName)}";
 
 describe("${featureName} - Acceptance Tests", () => {

--- a/src/acceptance/types.ts
+++ b/src/acceptance/types.ts
@@ -114,6 +114,8 @@ export interface GenerateAcceptanceTestsOptions {
   modelDef: ModelDef;
   /** Global config for quality settings */
   config: NaxConfig;
+  /** Test framework for skeleton generation (e.g. "jest", "vitest") */
+  testFramework?: string;
 }
 
 /**

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -88,8 +88,21 @@ export const _acceptanceSetupDeps = {
   writeMeta: async (metaPath: string, meta: AcceptanceMeta): Promise<void> => {
     await Bun.write(metaPath, JSON.stringify(meta, null, 2));
   },
-  runTest: async (_testPath: string, _workdir: string): Promise<{ exitCode: number; output: string }> => {
-    const proc = Bun.spawn(["bun", "test", _testPath], {
+  runTest: async (
+    _testPath: string,
+    _workdir: string,
+    _testCmd?: string,
+  ): Promise<{ exitCode: number; output: string }> => {
+    // Use configured test command when available; fall back to bun test
+    let cmd: string[];
+    if (_testCmd) {
+      // Split the configured test command and append the test path
+      const parts = _testCmd.trim().split(/\s+/);
+      cmd = [...parts, _testPath];
+    } else {
+      cmd = ["bun", "test", _testPath];
+    }
+    const proc = Bun.spawn(cmd, {
       cwd: _workdir,
       stdout: "pipe",
       stderr: "pipe",
@@ -216,7 +229,8 @@ export const acceptanceSetupStage: PipelineStage = {
       return { action: "continue" };
     }
 
-    const { exitCode } = await _acceptanceSetupDeps.runTest(testPath, ctx.workdir);
+    const testCmd = ctx.config.quality?.commands?.test;
+    const { exitCode } = await _acceptanceSetupDeps.runTest(testPath, ctx.workdir, testCmd);
 
     if (exitCode === 0) {
       ctx.acceptanceSetup = { totalCriteria, testableCount, redFailCount: 0 };

--- a/src/pipeline/stages/acceptance.ts
+++ b/src/pipeline/stages/acceptance.ts
@@ -134,8 +134,13 @@ export const acceptanceStage: PipelineStage = {
     // Acceptance tests always run from repo root — covers both single repo and monorepo.
     // The test file uses __dirname-based paths to navigate into packages as needed.
 
-    // Run bun test on the acceptance test file
-    const proc = Bun.spawn(["bun", "test", testPath], {
+    // Run acceptance tests using the configured test command (respects Jest/Vitest/etc.)
+    // Fall back to `bun test` when no command is configured.
+    const configuredTestCmd = ctx.config.quality?.commands?.test;
+    const testCmdParts = configuredTestCmd
+      ? [...configuredTestCmd.trim().split(/\s+/), testPath]
+      : ["bun", "test", testPath];
+    const proc = Bun.spawn(testCmdParts, {
       cwd: ctx.workdir,
       stdout: "pipe",
       stderr: "pipe",

--- a/src/verification/parser.ts
+++ b/src/verification/parser.ts
@@ -25,6 +25,95 @@ import type { TestFailure, TestOutputAnalysis, TestSummary } from "./types";
  * ```
  */
 export function parseBunTestOutput(output: string): TestSummary {
+  // Detect Jest/Vitest output by the presence of their summary line format.
+  // Jest:   "Tests:       41 failed, 38 passed, 79 total"
+  // Vitest: "Test Files  1 failed | 2 passed (3)"
+  if (isJestLikeOutput(output)) {
+    return parseJestOutput(output);
+  }
+  return parseBunOutput(output);
+}
+
+/**
+ * Detect whether the output comes from Jest or Vitest rather than Bun.
+ * Looks for the Jest summary line format or Vitest's "Test Files" line.
+ */
+function isJestLikeOutput(output: string): boolean {
+  return /^\s*Tests:\s+\d+/m.test(output) || /^\s*Test Files\s+\d+/m.test(output);
+}
+
+/**
+ * Parse Jest / Vitest test output into a TestSummary.
+ *
+ * Jest summary line examples:
+ *   "Tests:       41 failed, 38 passed, 79 total"
+ *   "Tests:       38 passed, 38 total"
+ *
+ * Jest failure block example:
+ *   "  ● describe block > test name"
+ *   "    Expected: ..."
+ */
+function parseJestOutput(output: string): TestSummary {
+  const failures: TestFailure[] = [];
+  let passed = 0;
+  let failed = 0;
+
+  // Extract counts from the "Tests:" summary line (use the last occurrence)
+  const summaryMatches = Array.from(output.matchAll(/^\s*Tests:\s+(.*)/gm));
+  if (summaryMatches.length > 0) {
+    const summaryLine = summaryMatches[summaryMatches.length - 1][1];
+
+    const failedMatch = summaryLine.match(/(\d+)\s+failed/);
+    const passedMatch = summaryLine.match(/(\d+)\s+passed/);
+    if (failedMatch) failed = Number.parseInt(failedMatch[1], 10);
+    if (passedMatch) passed = Number.parseInt(passedMatch[1], 10);
+  }
+
+  // Extract failure test names from "  ● describe > test name" lines
+  // Jest marks failures with a bullet "●" character
+  let currentFile = "unknown";
+  const lines = output.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Track FAIL/PASS file headers: "FAIL hooks/usePositionSizer.spec.ts"
+    const fileMatch = line.match(/^\s*(?:FAIL|PASS)\s+(\S+\.[jt]sx?)/);
+    if (fileMatch) {
+      currentFile = fileMatch[1];
+      continue;
+    }
+
+    // Jest failure marker: "  ● test suite name > test name"
+    const bulletMatch = line.match(/^\s+●\s+(.+)$/);
+    if (bulletMatch) {
+      const testName = bulletMatch[1].trim();
+      // Skip bullet-summary headers that end with a block title (no ">" separator)
+      // and collect the error from the next non-blank line
+      let error = "";
+      for (let j = i + 1; j < lines.length && j < i + 10; j++) {
+        const next = lines[j].trim();
+        if (!next) continue;
+        // Stop at next bullet or PASS/FAIL header
+        if (next.startsWith("●") || /^(?:FAIL|PASS)\s/.test(next)) break;
+        error = next;
+        break;
+      }
+      failures.push({
+        file: currentFile,
+        testName,
+        error: error || "Unknown error",
+        stackTrace: [],
+      });
+    }
+  }
+
+  return { passed, failed, failures };
+}
+
+/**
+ * Original Bun test output parser (unchanged logic).
+ */
+function parseBunOutput(output: string): TestSummary {
   const lines = output.split("\n");
   const failures: TestFailure[] = [];
   let passed = 0;


### PR DESCRIPTION
## What

Fix acceptance test generation and verification for non-Bun projects (Jest, Vitest). Four bugs fixed in one batch: BUG-076, BUG-077, BUG-078, BUG-079.

## Why

nax acceptance testing was broken for any project using Jest or Vitest. Observed during an rs-calculator (React Native / Jest) run:
- Acceptance test was generated correctly by Claude Code on disk, then **overwritten with a skeleton** because `extractTestCode()` couldn't parse the ACP adapter's conversational response
- Skeleton hardcoded `bun:test` import regardless of the project's test framework
- RED gate and acceptance stage ran `bun test` instead of `npm test -- --no-coverage`
- Rectification gate reported "inconclusive — no test results parsed" on valid Jest output (`Tests: 41 failed, 38 passed`) because parser only handled Bun markers
- LLM prompt told Claude Code the file path was `nax/features/` (old), causing it to create a duplicate at the wrong path

## How

**BUG-076 — ACP adapter writes file to disk, `extractTestCode()` can't parse conversational response:**
- After `extractTestCode()` fails on the response text, check if the adapter already wrote the file to `featureDir/acceptance.test.ts`
- If found, recover the code from disk instead of falling back to skeleton

**BUG-077 — Skeleton hardcodes `bun:test`:**
- `generateSkeletonTests()` and all 3 templates (`e2e.ts`, `unit.ts`, `snapshot.ts`) now accept optional `testFramework` param
- Emits `@jest/globals` for jest, `vitest` for vitest, `bun:test` as default
- `GenerateAcceptanceTestsOptions` gains `testFramework` field

**BUG-078 — Hardcoded `bun test` runner + Bun-only parser:**
- `acceptance-setup.ts` RED gate now uses `quality.commands.test` (appends test path to the command)
- `acceptance.ts` run stage same fix
- `parseBunTestOutput()` detects Jest/Vitest output via `Tests: N failed, M passed` summary line and delegates to a dedicated `parseJestOutput()` function that extracts counts from the summary and failure names from `● test name` blocks

**BUG-079 — Stale `nax/features/` path in LLM prompt:**
- Path anchor in both prompt templates corrected: `nax/features/` → `.nax/features/` with 4 `../` levels up instead of 3

## Testing

- [x] Tests added/updated
- [x] `bun test` passes (366 tests, 0 fail across acceptance + verification suites)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

The `runTest` injectable in `_acceptanceSetupDeps` gains an optional `testCmd` parameter — existing tests that mock it are unaffected (parameter is optional, backward compatible).
