### PR TITLE
feat(review): add build command to quality gates (BUILD-001)

### DIFF
--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -80,7 +80,6 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "quality.requireTypecheck": "Require typecheck to pass",
   "quality.requireLint": "Require lint to pass",
   "quality.requireTests": "Require tests to pass",
-  "quality.requireBuild": "Require build to pass",
   "quality.commands": "Custom quality commands",
   "quality.commands.typecheck": "Custom typecheck command",
   "quality.commands.lint": "Custom lint command",
@@ -125,7 +124,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   // Review
   review: "Review phase configuration",
   "review.enabled": "Enable review phase",
-  "review.checks": "List of checks to run (typecheck, lint, test)",
+  "review.checks": "List of checks to run (typecheck, lint, test, build)",
   "review.commands": "Custom commands per check",
   "review.commands.typecheck": "Custom typecheck command for review",
   "review.commands.lint": "Custom lint command for review",

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -71,7 +71,6 @@ export const DEFAULT_CONFIG: NaxConfig = {
     requireTypecheck: true,
     requireLint: true,
     requireTests: true,
-    requireBuild: false,
     commands: {},
     forceExit: false,
     detectOpenHandles: true,

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -88,7 +88,6 @@ export function mergePackageConfig(root: NaxConfig, packageOverride: Partial<Nax
       requireTests: packageOverride.quality?.requireTests ?? root.quality.requireTests,
       requireTypecheck: packageOverride.quality?.requireTypecheck ?? root.quality.requireTypecheck,
       requireLint: packageOverride.quality?.requireLint ?? root.quality.requireLint,
-      requireBuild: packageOverride.quality?.requireBuild ?? root.quality.requireBuild,
       commands: {
         ...root.quality.commands,
         ...packageOverride.quality?.commands,

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -125,8 +125,6 @@ export interface QualityConfig {
   requireLint: boolean;
   /** Require tests to pass */
   requireTests: boolean;
-  /** Require build to pass */
-  requireBuild: boolean;
   /** Custom quality commands */
   commands: {
     typecheck?: string;

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -127,7 +127,6 @@ const QualityConfigSchema = z.object({
   requireTypecheck: z.boolean(),
   requireLint: z.boolean(),
   requireTests: z.boolean(),
-  requireBuild: z.boolean().default(false),
   commands: z.object({
     typecheck: z.string().optional(),
     lint: z.string().optional(),

--- a/test/unit/config/defaults.test.ts
+++ b/test/unit/config/defaults.test.ts
@@ -111,40 +111,4 @@ describe("schema: 'build' is a valid review check (BUILD-001)", () => {
   });
 });
 
-describe("quality.requireBuild default (BUILD-001)", () => {
-  test("quality.requireBuild defaults to false", () => {
-    expect(DEFAULT_CONFIG.quality.requireBuild).toBe(false);
-  });
 
-  test("schema accepts quality.requireBuild set to true", () => {
-    const config = {
-      ...DEFAULT_CONFIG,
-      quality: {
-        ...DEFAULT_CONFIG.quality,
-        requireBuild: true,
-        commands: {},
-      },
-    };
-    const result = NaxConfigSchema.safeParse(config);
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.quality.requireBuild).toBe(true);
-    }
-  });
-
-  test("schema accepts quality.requireBuild set to false", () => {
-    const config = {
-      ...DEFAULT_CONFIG,
-      quality: {
-        ...DEFAULT_CONFIG.quality,
-        requireBuild: false,
-        commands: {},
-      },
-    };
-    const result = NaxConfigSchema.safeParse(config);
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.quality.requireBuild).toBe(false);
-    }
-  });
-});

--- a/test/unit/config/merge.test.ts
+++ b/test/unit/config/merge.test.ts
@@ -424,17 +424,6 @@ describe("mergePackageConfig", () => {
       expect(result.quality.requireLint).toBe(false);
     });
 
-    test("overrides quality.requireBuild per package (BUILD-001)", () => {
-      const root: NaxConfig = {
-        ...makeRoot(),
-        quality: { ...DEFAULT_CONFIG.quality, requireBuild: false, commands: {} },
-      };
-      const result = mergePackageConfig(root, {
-        quality: { requireBuild: true } as Partial<NaxConfig["quality"]>,
-      } as Partial<NaxConfig>);
-
-      expect(result.quality.requireBuild).toBe(true);
-    });
   });
 
   describe("context.testCoverage deep merge", () => {


### PR DESCRIPTION
## What

Add `build` as a review check in nax's quality gates (BUILD-001), plus code review fixes.

## Why

BUILD-001: Users need build verification as part of the review pipeline, alongside typecheck, lint, and test. Previously, build failures were only caught manually.

Code review also identified `quality.requireBuild` as a dead config field (declared but never consumed by runtime code) — removed it to avoid user confusion.

Closes #

## How

**BUILD-001 (feat):**
- Extended `ReviewCheckName` type to include `"build"`
- Wired PKG-006 bridge so `resolveCommand("build")` resolves correctly
- Review runner executes build check when listed in `review.checks`

**Dead code removal (fix):**
- Removed `quality.requireBuild` from runtime-types, schema, defaults, merge, and config-descriptions (never consumed — functional no-op)
- Removed `DEFAULT_COMMANDS` dead code from review runner

**Doc fix:**
- Updated `review.checks` config description to include `build`

## Testing

- [x] Tests added/updated
- [x] `bun test` passes (174 config tests, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- `quality.requireBuild` was pure config plumbing with no runtime consumer. Build gate is controlled by explicitly adding `"build"` to `review.checks` — single mechanism, no ambiguity.
- The `setTimeout` usage in review/runner.ts (flagged in code review) is intentional — it's a cancellable process kill timer, same pattern as `execution/timeout-handler.ts`. `Bun.sleep()` is uncancellable and wrong for this use case.
