### PR TITLE
fix(BUG-083): scope acceptance tests to feature file only

### DIFF
--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -145,6 +145,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "acceptance.maxRetries": "Max retry loops for fix stories",
   "acceptance.generateTests": "Generate acceptance tests during analyze",
   "acceptance.testPath": "Path to acceptance test file (relative to feature dir)",
+  "acceptance.command":
+    "Override command to run acceptance tests. Use {{FILE}} as placeholder for the test file path (default: 'bun test {{FILE}} --timeout=60000')",
   "acceptance.timeoutMs": "Timeout for acceptance test generation in milliseconds (default: 1800000 = 30 min)",
 
   // Context

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -262,6 +262,9 @@ export interface AcceptanceConfig {
   refinement: boolean;
   /** Whether to run RED gate check after generating acceptance tests (default: true) */
   redGate: boolean;
+  /** Override command to run acceptance tests. Use {{FILE}} as placeholder for the test file path.
+   *  Default: "bun test {{FILE}} --timeout=60000" */
+  command?: string;
   /** Test strategy for acceptance tests (default: auto-detect) */
   testStrategy?: AcceptanceTestStrategy;
   /** Test framework for acceptance tests (default: auto-detect) */

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -260,6 +260,7 @@ export const AcceptanceConfigSchema = z.object({
   maxRetries: z.number().int().nonnegative(),
   generateTests: z.boolean(),
   testPath: z.string().min(1, "acceptance.testPath must be non-empty"),
+  command: z.string().optional(),
   model: z.enum(["fast", "balanced", "powerful"]).default("fast"),
   refinement: z.boolean().default(true),
   redGate: z.boolean().default(true),

--- a/src/pipeline/stages/acceptance.ts
+++ b/src/pipeline/stages/acceptance.ts
@@ -134,12 +134,18 @@ export const acceptanceStage: PipelineStage = {
     // Acceptance tests always run from repo root — covers both single repo and monorepo.
     // The test file uses __dirname-based paths to navigate into packages as needed.
 
-    // Run acceptance tests using the configured test command (respects Jest/Vitest/etc.)
-    // Fall back to `bun test` when no command is configured.
-    const configuredTestCmd = ctx.config.quality?.commands?.test;
-    const testCmdParts = configuredTestCmd
-      ? [...configuredTestCmd.trim().split(/\s+/), testPath]
-      : ["bun", "test", testPath];
+    // BUG-083: Run ONLY the acceptance test file, not the full project test suite.
+    // The full suite is covered by the regression gate; acceptance is a separate concern.
+    // Resolution order: acceptance.command override → default "bun test <file> --timeout=60000"
+    const acceptanceCmd = effectiveConfig.acceptance.command;
+    let testCmdParts: string[];
+    if (acceptanceCmd) {
+      // Support {{FILE}} placeholder or verbatim command
+      const resolved = acceptanceCmd.includes("{{FILE}}") ? acceptanceCmd.replace("{{FILE}}", testPath) : acceptanceCmd;
+      testCmdParts = resolved.trim().split(/\s+/);
+    } else {
+      testCmdParts = ["bun", "test", testPath, "--timeout=60000"];
+    }
     const proc = Bun.spawn(testCmdParts, {
       cwd: ctx.workdir,
       stdout: "pipe",

--- a/test/integration/pipeline/pipeline-acceptance.test.ts
+++ b/test/integration/pipeline/pipeline-acceptance.test.ts
@@ -334,3 +334,102 @@ describe("broken", () => {
     expect(ctx.acceptanceFailures!.failedACs).toContain("AC-ERROR");
   });
 });
+
+// BUG-083: Acceptance test scoping — runs only acceptance.test.ts, not full project suite
+describe("BUG-083: acceptance command scoping", () => {
+  test("AC-1: runs bun test <acceptance-file> --timeout=60000 by default (not quality.commands.test)", async () => {
+    const prd = createTestPRD([{ id: "US-001", status: "passed" }]);
+    const ctx = createTestContext(prd, {
+      quality: {
+        ...DEFAULT_CONFIG.quality,
+        commands: { test: "echo 'full-suite-ran'" }, // This must NOT be used
+      },
+    });
+
+    const testPath = path.join(featureDir, "acceptance.test.ts");
+    await Bun.write(
+      testPath,
+      `import { describe, test, expect } from "bun:test";
+describe("test-feature", () => {
+  test("AC-1: passes", () => { expect(true).toBe(true); });
+});`,
+    );
+
+    const result = await acceptanceStage.execute(ctx);
+
+    // Must pass (the acceptance test itself passes)
+    expect(result.action).toBe("continue");
+    // ctx.acceptanceFailures must not be set (no failures)
+    expect(ctx.acceptanceFailures).toBeUndefined();
+  });
+
+  test("AC-3: acceptance.command with {{FILE}} is substituted and executed", async () => {
+    const prd = createTestPRD([{ id: "US-001", status: "passed" }]);
+    const ctx = createTestContext(prd, {
+      acceptance: {
+        ...DEFAULT_CONFIG.acceptance,
+        command: "bun test {{FILE}} --timeout=60000",
+      },
+    });
+
+    const testPath = path.join(featureDir, "acceptance.test.ts");
+    await Bun.write(
+      testPath,
+      `import { describe, test, expect } from "bun:test";
+describe("test-feature", () => {
+  test("AC-1: passes", () => { expect(true).toBe(true); });
+});`,
+    );
+
+    const result = await acceptanceStage.execute(ctx);
+    expect(result.action).toBe("continue");
+  });
+
+  test("AC-4: acceptance.command without {{FILE}} is executed verbatim", async () => {
+    const prd = createTestPRD([{ id: "US-001", status: "passed" }]);
+
+    // Point to the real acceptance test file using absolute path in command
+    const testPath = path.join(featureDir, "acceptance.test.ts");
+    await Bun.write(
+      testPath,
+      `import { describe, test, expect } from "bun:test";
+describe("test-feature", () => {
+  test("AC-1: passes", () => { expect(true).toBe(true); });
+});`,
+    );
+
+    const ctx = createTestContext(prd, {
+      acceptance: {
+        ...DEFAULT_CONFIG.acceptance,
+        command: `bun test ${testPath} --timeout=60000`,
+      },
+    });
+
+    const result = await acceptanceStage.execute(ctx);
+    expect(result.action).toBe("continue");
+  });
+
+  test("AC-6: quality.commands.test has no effect on acceptance runner", async () => {
+    const prd = createTestPRD([{ id: "US-001", status: "passed" }]);
+    const ctx = createTestContext(prd, {
+      quality: {
+        ...DEFAULT_CONFIG.quality,
+        commands: { test: "exit 1" }, // Would fail if used — must be ignored
+      },
+    });
+
+    const testPath = path.join(featureDir, "acceptance.test.ts");
+    await Bun.write(
+      testPath,
+      `import { describe, test, expect } from "bun:test";
+describe("test-feature", () => {
+  test("AC-1: passes", () => { expect(true).toBe(true); });
+});`,
+    );
+
+    const result = await acceptanceStage.execute(ctx);
+
+    // Would be "fail" if quality.commands.test ("exit 1") was used instead of bun test
+    expect(result.action).toBe("continue");
+  });
+});


### PR DESCRIPTION
## What

Fix acceptance stage to run only the feature's `acceptance.test.ts` instead of the full project test suite.

## Why

Closes BUG-083. Evidence from REVIEW-001 run (2026-03-25): 3/3 stories passed but acceptance gate failed with `"Tests errored with no AC failures parsed"` because it ran `bun test` (4517 tests, 14 unrelated failures → exit code 1) instead of just the acceptance file.

The full project suite is already covered by the regression gate. Acceptance has one job: verify the feature against its ACs.

## How

- Replace `[...configuredTestCmd.split(), testPath]` (prepends project test command) with `["bun", "test", testPath, "--timeout=60000"]` directly
- Add `acceptance.command` config override with `{{FILE}}` placeholder for custom runners
- `quality.commands.test` is no longer consulted by the acceptance stage

## Testing

- [x] 4 new integration tests in `pipeline-acceptance.test.ts` covering AC-1, AC-3, AC-4, AC-6
- [x] Full suite: 4474 pass, 60 skip, 0 fail

## Notes

Phase 2 (language-agnostic runner for Go/Rust/Python acceptance tests) is tracked in QUALITY-002 US-008.
