### PR TITLE
feat(precheck): add --light flag for environment-only check (no PRD required)

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -971,12 +971,14 @@ program
   .option("-f, --feature <name>", "Feature name")
   .option("-d, --dir <path>", "Project directory", process.cwd())
   .option("--json", "Output machine-readable JSON", false)
+  .option("--light", "Environment-only check — skips PRD validation (use before nax plan)", false)
   .action(async (options) => {
     try {
       await precheckCommand({
         feature: options.feature,
         dir: options.dir,
         json: options.json,
+        light: options.light,
       });
     } catch (err) {
       console.error(chalk.red(`Error: ${(err as Error).message}`));

--- a/src/commands/precheck.ts
+++ b/src/commands/precheck.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 import chalk from "chalk";
 import { loadConfig } from "../config";
 import { loadPRD } from "../prd";
-import { EXIT_CODES, runPrecheck } from "../precheck";
+import { EXIT_CODES, runEnvironmentPrecheck, runPrecheck } from "../precheck";
 import { resolveProject } from "./common";
 
 /**
@@ -23,6 +23,8 @@ export interface PrecheckOptions {
   dir?: string;
   /** Output JSON format (from --json flag) */
   json?: boolean;
+  /** Light mode — environment checks only, no PRD required (use before nax plan) */
+  light?: boolean;
 }
 
 /**
@@ -32,11 +34,20 @@ export interface PrecheckOptions {
  * Exits with code 0 (pass), 1 (blocker), or 2 (invalid PRD).
  */
 export async function precheckCommand(options: PrecheckOptions): Promise<void> {
-  // Resolve project directory and feature
+  // Resolve project directory
   const resolved = resolveProject({
     dir: options.dir,
     feature: options.feature,
   });
+
+  const format = options.json ? "json" : "human";
+
+  // --light: environment-only check, no PRD required (use before nax plan)
+  if (options.light) {
+    const config = await loadConfig(resolved.projectDir);
+    const result = await runEnvironmentPrecheck(config, resolved.projectDir, { format });
+    process.exit(result.passed ? EXIT_CODES.SUCCESS : EXIT_CODES.BLOCKER);
+  }
 
   // Determine feature name (from flag or config)
   let featureName = options.feature;
@@ -74,8 +85,7 @@ export async function precheckCommand(options: PrecheckOptions): Promise<void> {
   const config = await loadConfig(resolved.projectDir);
   const prd = await loadPRD(prdPath);
 
-  // Run precheck
-  const format = options.json ? "json" : "human";
+  // Run full precheck
   const result = await runPrecheck(config, prd, {
     workdir: resolved.projectDir,
     format,


### PR DESCRIPTION
## What

Add `--light` flag to `nax precheck` that runs environment-only checks without requiring a `prd.json` file. Update `nax-launch.py` to use `--light` automatically when in `--plan` mode.

## Why

When using `nax run --plan --from <spec>`, `nax-launch.py` calls `nax precheck` before the plan step — but `prd.json` doesn't exist yet. This caused the precheck to output plain text (not JSON) and bail with "Precheck failed (could not parse output)", forcing a manual workaround (run `nax plan` separately, commit PRD, then launch).

Two precheck functions already exist in `src/precheck/index.ts`:
- `runPrecheck()` — full check, requires PRD
- `runEnvironmentPrecheck()` — environment only, no PRD needed

`--light` exposes `runEnvironmentPrecheck()` via the CLI so `nax-launch.py` can use it in plan mode.

## How

- `bin/nax.ts` — added `--light` option to `precheck` command
- `src/commands/precheck.ts` — when `light: true`, calls `runEnvironmentPrecheck()` and exits; skips all PRD loading/validation
- `nax-launch.py` (VPS + Mac01 via subrina-coder repo) — `run_precheck()` appends `--light` to the command when `args.plan` is set

## Testing

- [ ] Tests added/updated
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes

## Notes

`--light` is intentionally minimal — it just runs `runEnvironmentPrecheck()` which already handles JSON output via the existing `format` option. No feature directory or PRD needed when `--light` is passed.
