### PR TITLE
fix: BUG-085/086/087/089 — semantic review options+logging, per-story AC storyId, stale ACP cleanup

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -93,7 +93,7 @@ export interface AcpSessionResponse {
 
 export interface AcpSession {
   prompt(text: string): Promise<AcpSessionResponse>;
-  close(): Promise<void>;
+  close(options?: { forceTerminate?: boolean }): Promise<void>;
   cancelActivePrompt(): Promise<void>;
 }
 
@@ -720,6 +720,7 @@ export class AcpAgentAdapter implements AgentAdapter {
       await client.start();
 
       let session: AcpSession | null = null;
+      let hadError = false;
       try {
         // complete() is one-shot — ephemeral session, no sidecar
         // Use caller-provided sessionName if available (aids tracing), otherwise timestamp-based
@@ -781,6 +782,7 @@ export class AcpAgentAdapter implements AgentAdapter {
 
         return unwrapped;
       } catch (err) {
+        hadError = true;
         const error = err instanceof Error ? err : new Error(String(err));
         lastError = error;
 
@@ -795,7 +797,7 @@ export class AcpAgentAdapter implements AgentAdapter {
         await _acpAdapterDeps.sleep(backoffMs);
       } finally {
         if (session) {
-          await session.close().catch(() => {});
+          await session.close({ forceTerminate: hadError }).catch(() => {});
         }
         await client.close().catch(() => {});
       }

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -191,7 +191,7 @@ class SpawnAcpSession implements AcpSession {
     }
   }
 
-  async close(): Promise<void> {
+  async close(options?: { forceTerminate?: boolean }): Promise<void> {
     // Kill in-flight prompt process first (if any)
     if (this.activeProc) {
       try {
@@ -215,6 +215,15 @@ class SpawnAcpSession implements AcpSession {
         sessionName: this.sessionName,
         stderr: stderr.slice(0, 200),
       });
+    }
+
+    if (options?.forceTerminate) {
+      try {
+        const stopProc = _spawnClientDeps.spawn(["acpx", this.agentName, "stop"], { stdout: "pipe", stderr: "pipe" });
+        await stopProc.exited;
+      } catch (err) {
+        getSafeLogger()?.debug("acp-adapter", "acpx stop failed (swallowed)", { cause: String(err) });
+      }
     }
   }
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -153,6 +153,7 @@ export const DEFAULT_CONFIG: NaxConfig = {
     semantic: {
       modelTier: "balanced",
       rules: [],
+      timeoutMs: 600_000,
     },
   },
   plan: {

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -236,6 +236,7 @@ const AnalyzeConfigSchema = z.object({
 const SemanticReviewConfigSchema = z.object({
   modelTier: ModelTierSchema.default("balanced"),
   rules: z.array(z.string()).default([]),
+  timeoutMs: z.number().int().positive().default(600_000),
 });
 
 const ReviewConfigSchema = z.object({

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -179,21 +179,29 @@ export const acceptanceSetupStage: PipelineStage = {
 
       let refinedCriteria: RefinedCriterion[];
 
+      const nonFixStories = ctx.prd.userStories.filter((s) => !s.id.startsWith("US-FIX-"));
+
       if (ctx.config.acceptance.refinement) {
-        refinedCriteria = await _acceptanceSetupDeps.refine(allCriteria, {
-          storyId: ctx.prd.userStories[0]?.id ?? "US-001",
-          codebaseContext: "",
-          config: ctx.config,
-          testStrategy: ctx.config.acceptance.testStrategy,
-          testFramework: ctx.config.acceptance.testFramework,
-        });
+        refinedCriteria = [];
+        for (const story of nonFixStories) {
+          const storyRefined = await _acceptanceSetupDeps.refine(story.acceptanceCriteria, {
+            storyId: story.id,
+            codebaseContext: "",
+            config: ctx.config,
+            testStrategy: ctx.config.acceptance.testStrategy,
+            testFramework: ctx.config.acceptance.testFramework,
+          });
+          refinedCriteria = refinedCriteria.concat(storyRefined);
+        }
       } else {
-        refinedCriteria = allCriteria.map((c) => ({
-          original: c,
-          refined: c,
-          testable: true,
-          storyId: ctx.prd.userStories[0]?.id ?? "US-001",
-        }));
+        refinedCriteria = nonFixStories.flatMap((story) =>
+          story.acceptanceCriteria.map((c) => ({
+            original: c,
+            refined: c,
+            testable: true,
+            storyId: story.id,
+          })),
+        );
       }
 
       testableCount = refinedCriteria.filter((r) => r.testable).length;

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -313,7 +313,11 @@ export async function runReview(
         description: story?.description ?? "",
         acceptanceCriteria: story?.acceptanceCriteria ?? [],
       };
-      const semanticCfg = config.semantic ?? { modelTier: "balanced" as const, rules: [] as string[] };
+      const semanticCfg = config.semantic ?? {
+        modelTier: "balanced" as const,
+        rules: [] as string[],
+        timeoutMs: 600_000,
+      };
       const result = await _reviewSemanticDeps.runSemanticReview(
         workdir,
         storyGitRef,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -213,6 +213,8 @@ export async function runSemanticReview(
     };
   }
 
+  logger?.info("review", "Running semantic check", { storyId: story.id, modelTier: semanticConfig.modelTier });
+
   // AC-2: Collect git diff
   const rawDiff = await collectDiff(workdir, storyGitRef);
 
@@ -241,7 +243,11 @@ export async function runSemanticReview(
   // Call LLM
   let rawResponse: string;
   try {
-    rawResponse = await agent.complete(prompt);
+    rawResponse = await agent.complete(prompt, {
+      sessionName: `nax-semantic-${story.id}`,
+      workdir,
+      timeoutMs: semanticConfig.timeoutMs,
+    });
   } catch (err) {
     logger?.warn("semantic", "LLM call failed — fail-open", { cause: String(err) });
     return {
@@ -270,6 +276,11 @@ export async function runSemanticReview(
 
   // AC-7: Format findings and populate structured ReviewFinding[] (US-003 AC-2)
   if (!parsed.passed && parsed.findings.length > 0) {
+    const durationMs = Date.now() - startTime;
+    logger?.warn("review", `Semantic review failed: ${parsed.findings.length} findings`, {
+      storyId: story.id,
+      durationMs,
+    });
     const output = `Semantic review failed:\n\n${formatFindings(parsed.findings)}`;
     return {
       check: "semantic",
@@ -277,17 +288,21 @@ export async function runSemanticReview(
       command: "",
       exitCode: 1,
       output,
-      durationMs: Date.now() - startTime,
+      durationMs,
       findings: toReviewFindings(parsed.findings),
     };
   }
 
+  const durationMs = Date.now() - startTime;
+  if (parsed.passed) {
+    logger?.info("review", "Semantic review passed", { storyId: story.id, durationMs });
+  }
   return {
     check: "semantic",
     success: parsed.passed,
     command: "",
     exitCode: parsed.passed ? 0 : 1,
     output: parsed.passed ? "Semantic review passed" : "Semantic review failed (no findings)",
-    durationMs: Date.now() - startTime,
+    durationMs,
   };
 }

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -13,6 +13,8 @@ export interface SemanticReviewConfig {
   modelTier: import("../config/schema-types").ModelTier;
   /** Custom semantic review rules */
   rules: string[];
+  /** Timeout in milliseconds for the LLM call (default: 600_000) */
+  timeoutMs: number;
 }
 
 /** Review check result */

--- a/test/unit/config/semantic-review.test.ts
+++ b/test/unit/config/semantic-review.test.ts
@@ -51,6 +51,7 @@ describe("SemanticReviewConfig", () => {
     const config: SemanticReviewConfig = {
       modelTier: "balanced",
       rules: [],
+      timeoutMs: 600_000,
     };
     expect(config.modelTier).toBe("balanced");
     expect(typeof config.modelTier).toBe("string");
@@ -60,6 +61,7 @@ describe("SemanticReviewConfig", () => {
     const config: SemanticReviewConfig = {
       modelTier: "balanced",
       rules: ["rule1", "rule2"],
+      timeoutMs: 600_000,
     };
     expect(Array.isArray(config.rules)).toBe(true);
     expect(config.rules.every((r) => typeof r === "string")).toBe(true);
@@ -76,6 +78,7 @@ describe("SemanticReviewConfig", () => {
       const config: SemanticReviewConfig = {
         modelTier: tier,
         rules: [],
+        timeoutMs: 600_000,
       };
       expect(config.modelTier).toBe(tier);
     });
@@ -100,6 +103,7 @@ describe("ReviewConfig semantic field", () => {
       expect(result.data.review.semantic).toEqual({
         modelTier: "balanced",
         rules: [],
+        timeoutMs: 600_000,
       });
     }
   });
@@ -208,10 +212,11 @@ describe("DEFAULT_CONFIG.review.semantic", () => {
     expect(DEFAULT_CONFIG.review.semantic?.rules).toEqual([]);
   });
 
-  test("DEFAULT_CONFIG.review.semantic equals { modelTier: 'balanced', rules: [] }", () => {
+  test("DEFAULT_CONFIG.review.semantic equals { modelTier: 'balanced', rules: [], timeoutMs: 600_000 }", () => {
     expect(DEFAULT_CONFIG.review.semantic).toEqual({
       modelTier: "balanced",
       rules: [],
+      timeoutMs: 600_000,
     });
   });
 });

--- a/test/unit/pipeline/stages/acceptance-setup.test.ts
+++ b/test/unit/pipeline/stages/acceptance-setup.test.ts
@@ -578,12 +578,13 @@ describe("acceptanceSetupStage.enabled()", () => {
 describe("acceptanceSetup context: testableCount", () => {
   test("testableCount counts only testable criteria", async () => {
     _acceptanceSetupDeps.fileExists = async () => false;
-    _acceptanceSetupDeps.refine = async (criteria) =>
-      criteria.map((c, i) => ({
+    // With per-story calls: US-001 has 2 testable criteria, US-002 has 1 non-testable
+    _acceptanceSetupDeps.refine = async (criteria, context) =>
+      criteria.map((c) => ({
         original: c,
         refined: c,
-        testable: i < 2, // first 2 are testable, last is not
-        storyId: "US-001",
+        testable: context.storyId === "US-001",
+        storyId: context.storyId,
       }));
     _acceptanceSetupDeps.generate = async () => ({
       testCode: 'test("AC-1", () => { throw new Error("red") })',


### PR DESCRIPTION
## What

Fixes 3 bugs observed during the koda VCS-integration nax run (v0.54.1):

1. **BUG-085 (#46)**: `agent.complete()` in semantic review called with no options — VCS-002 timed out at 2 min default and was silently skipped
2. **BUG-086 (#47)**: Semantic review has no info-level logging — only warn on failure
3. **BUG-087 (#48)**: `acceptance-refined.json` maps all 24 ACs to the first story's ID (VCS-001) instead of per-story IDs
4. **BUG-089 (#50)**: `complete()` timeout leaves stale ACP server process in "agent needs reconnect" state

## Why

- **BUG-085/086**: Semantic review for VCS-002 timed out at the default 2 min LLM timeout, silently producing no review output. No logging existed to surface this.
- **BUG-087**: Acceptance refinement called `refine()` once for all ACs with `storyId: ctx.prd.userStories[0]?.id` — every AC was attributed to VCS-001 regardless of which story defined it.
- **BUG-089**: When `complete()` timed out, `session.close()` ran `acpx sessions close` but the ACP server remained in "agent needs reconnect" state indefinitely.

## How

**BUG-085/086 — Semantic review `complete()` options + logging** (`src/review/semantic.ts`, `src/config/schemas.ts`, `src/config/defaults.ts`):
- Added `timeoutMs: number` to `SemanticReviewConfig` (default: 600,000 ms = 10 min) in types, schema, and defaults
- Pass `sessionName`, `workdir`, and `timeoutMs` to `agent.complete()` call
- Added `logger?.info()` at start of semantic check and on success; `logger?.warn()` on failure

**BUG-087 — Per-story storyId in acceptance refinement** (`src/pipeline/stages/acceptance-setup.ts`):
- Replaced single `refine()` call with per-story loop — each story's `acceptanceCriteria` refined with its own `storyId`
- Non-LLM fallback path fixed identically

**BUG-089 — Stale ACP server on timeout** (`src/agents/acp/adapter.ts`, `src/agents/acp/spawn-client.ts`):
- Added `forceTerminate?: boolean` option to `AcpSession.close()` interface
- `SpawnAcpSession.close({ forceTerminate: true })` runs `acpx <agentName> stop` after `sessions close`
- `complete()` tracks `hadError` flag in catch block, passes `forceTerminate: hadError` in finally

## Testing

- [x] Tests added/updated (`test/unit/config/semantic-review.test.ts`, `test/unit/pipeline/stages/acceptance-setup.test.ts`)
- [x] `bun test` passes — 4682 pass, 60 skip, 0 fail
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- BUG-088 (acceptance test monorepo module resolution) is **descoped** — tracked separately in issue #49 and spec `SPEC-acceptance-per-package.md`
- Semantic review timeout default raised from ~2 min (LLM default) to 10 min — appropriate for large diffs
- ACP `acpx stop` on timeout is best-effort (errors swallowed at debug level)

Closes #46
Closes #47
Closes #48
Closes #50
