### PR TITLE
fix(sessions): pass featureName/storyId/sessionRole to all complete() callers

### DIFF
--- a/src/acceptance/fix-generator.ts
+++ b/src/acceptance/fix-generator.ts
@@ -294,6 +294,9 @@ export async function generateFixStories(
       const fixDescription = await adapter.complete(prompt, {
         model: modelDef.model,
         config: options.config,
+        featureName: options.prd.feature,
+        workdir: options.workdir,
+        sessionRole: "fix-gen",
       });
 
       fixStories.push({

--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -208,6 +208,8 @@ Rules:
     config: options.config,
     timeoutMs: options.config?.acceptance?.timeoutMs ?? 1800000,
     workdir: options.workdir,
+    featureName: options.featureName,
+    sessionRole: "acceptance-gen",
   });
   let testCode = extractTestCode(rawOutput);
 
@@ -406,6 +408,8 @@ export async function generateAcceptanceTests(
       config: options.config,
       timeoutMs: options.config?.acceptance?.timeoutMs ?? 1800000,
       workdir: options.workdir,
+      featureName: options.featureName,
+      sessionRole: "acceptance-gen",
     });
 
     // Extract test code from output

--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -172,7 +172,7 @@ export async function refineAcceptanceCriteria(
     return [];
   }
 
-  const { storyId, codebaseContext, config, testStrategy, testFramework } = context;
+  const { storyId, featureName, workdir, codebaseContext, config, testStrategy, testFramework } = context;
   const logger = getLogger();
 
   const modelTier = config.acceptance?.model ?? "fast";
@@ -193,6 +193,10 @@ export async function refineAcceptanceCriteria(
       maxTokens: 4096,
       model: modelDef.model,
       config,
+      featureName,
+      storyId,
+      workdir,
+      sessionRole: "refine",
     });
   } catch (error) {
     const reason = errorMessage(error);

--- a/src/acceptance/types.ts
+++ b/src/acceptance/types.ts
@@ -27,6 +27,10 @@ export interface RefinedCriterion {
 export interface RefinementContext {
   /** Story ID for attribution on each RefinedCriterion */
   storyId: string;
+  /** Feature name for ACP session naming */
+  featureName?: string;
+  /** Working directory for ACP session naming */
+  workdir?: string;
   /** Codebase context string (file tree, dependencies, etc.) */
   codebaseContext: string;
   /** Global config — model tier resolved from config.acceptance.model */

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -723,11 +723,14 @@ export class AcpAgentAdapter implements AgentAdapter {
       let hadError = false;
       try {
         // complete() is one-shot — ephemeral session, no sidecar
-        // Use caller-provided sessionName if available (aids tracing), otherwise timestamp-based
+        // Use caller-provided sessionName if available; otherwise build from featureName/storyId/sessionRole
+        const completeSessionName =
+          _options?.sessionName ??
+          buildSessionName(workdir ?? process.cwd(), _options?.featureName, _options?.storyId, _options?.sessionRole);
         session = await client.createSession({
           agentName: this.name,
           permissionMode,
-          sessionName: _options?.sessionName,
+          sessionName: completeSessionName,
         });
 
         // Enforce timeout via Promise.race — session.prompt() can hang indefinitely
@@ -869,6 +872,8 @@ export class AcpAgentAdapter implements AgentAdapter {
         model,
         jsonMode: true,
         config: options.config as import("../../config").NaxConfig | undefined,
+        workdir: options.workdir,
+        sessionRole: "decompose",
       });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -140,6 +140,12 @@ export interface CompleteOptions {
    * Pass a meaningful name (e.g. "nax-decompose-us-001") to aid debugging.
    */
   sessionName?: string;
+  /** Feature name for ACP session naming — produces meaningful session IDs for debugging */
+  featureName?: string;
+  /** Story ID for ACP session naming — combined with featureName to form session key */
+  storyId?: string;
+  /** Session role for disambiguation when the same story has multiple concurrent sessions */
+  sessionRole?: string;
 }
 
 /**

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -229,7 +229,13 @@ async function runDecomposeDefault(
   }
   const adapter = {
     async decompose(prompt: string): Promise<string> {
-      return agent.complete(prompt, { jsonMode: true, config });
+      return agent.complete(prompt, {
+        jsonMode: true,
+        config,
+        featureName: prd.feature,
+        storyId: story.id,
+        sessionRole: "decompose",
+      });
     },
   };
   return DecomposeBuilder.for(story).prd(prd).config(builderConfig).decompose(adapter);

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -156,7 +156,14 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
     } catch {
       // fall through — complete() will use its own fallback
     }
-    rawResponse = await cliAdapter.complete(prompt, { model: autoModel, jsonMode: true, workdir, config });
+    rawResponse = await cliAdapter.complete(prompt, {
+      model: autoModel,
+      jsonMode: true,
+      workdir,
+      config,
+      featureName: options.feature,
+      sessionRole: "plan",
+    });
     // CLI adapter returns {"type":"result","result":"..."} envelope — unwrap it
     try {
       const envelope = JSON.parse(rawResponse) as Record<string, unknown>;

--- a/src/interaction/plugins/auto.ts
+++ b/src/interaction/plugins/auto.ts
@@ -157,6 +157,9 @@ export class AutoInteractionPlugin implements InteractionPlugin {
       ...(modelArg && { model: modelArg }),
       jsonMode: true,
       ...(this.config.naxConfig && { config: this.config.naxConfig }),
+      featureName: request.featureName,
+      storyId: request.storyId,
+      sessionRole: "auto",
     });
 
     return this.parseResponse(output);

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -229,6 +229,8 @@ export const acceptanceSetupStage: PipelineStage = {
         for (const story of nonFixStories) {
           const storyRefined = await _acceptanceSetupDeps.refine(story.acceptanceCriteria, {
             storyId: story.id,
+            featureName: ctx.prd.feature,
+            workdir: ctx.workdir,
             codebaseContext: "",
             config: ctx.config,
             testStrategy: ctx.config.acceptance.testStrategy,


### PR DESCRIPTION
## What

All `adapter.complete()` callers now pass `featureName`, `storyId`, and `sessionRole` so the ACP adapter builds meaningful session names instead of falling back to `nax-{timestamp}`.

## Why

When debugging ACP session logs, it's impossible to trace which session belongs to which feature/story when every session name is `nax-1743081234567`. Fixes #61.

## How

**`CompleteOptions`** — added 3 optional fields:
- `featureName?` — feature being worked on
- `storyId?` — story being processed (if applicable)
- `sessionRole?` — which stage produced this call (e.g. `"plan"`, `"refine"`, `"acceptance-gen"`, `"decompose"`, `"fix-gen"`, `"auto"`)

**`AcpAgentAdapter.complete()`** — when `sessionName` is not explicitly provided, calls `buildSessionName(workdir, featureName, storyId, sessionRole)` to produce a deterministic, human-readable name:
```
nax-<gitHash8>-<feature>-<story>-<role>
```

**Callers updated:**
| File | featureName | storyId | sessionRole |
|------|-------------|---------|-------------|
| `interaction/plugins/auto.ts` | `request.featureName` | `request.storyId` | `"auto"` |
| `cli/plan.ts` | `options.feature` | — | `"plan"` |
| `cli/analyze.ts` (decompose) | `prd.feature` | `story.id` | `"decompose"` |
| `acceptance/refinement.ts` | `context.featureName` | `context.storyId` | `"refine"` |
| `acceptance/fix-generator.ts` | `options.prd.feature` | — | `"fix-gen"` |
| `acceptance/generator.ts` (×2) | `options.featureName` | — | `"acceptance-gen"` |
| `agents/acp/adapter.ts` (decompose) | — | — | `"decompose"` |

**`RefinementContext`** — added `featureName?` and `workdir?` so acceptance-setup.ts can propagate them down to `refineAcceptanceCriteria()`.

## Testing

- [x] 3650 tests pass, 0 fail
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
