### PR TITLE
ci+perf: split test invocations (144s → 24s) + parallel CI jobs + bun cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,5 +74,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Test
-        run: bun test test/ --timeout=60000 --bail
+      - name: Test (unit)
+        run: bun test test/unit/ --timeout=60000 --bail
+
+      - name: Test (integration)
+        run: bun test test/integration/ --timeout=60000 --bail
+
+      - name: Test (ui)
+        run: bun test test/ui/ --timeout=60000 --bail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,14 @@ on:
       - '.github/workflows/**'
 
 jobs:
-  test:
+  checks:
+    name: ${{ matrix.check }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
+    strategy:
+      fail-fast: true
+      matrix:
+        check: [typecheck, lint]
     steps:
       - uses: actions/checkout@v4
 
@@ -33,14 +38,41 @@ jobs:
         with:
           bun-version: "1.3.11"
 
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Typecheck
-        run: bun run typecheck
+      - name: Run ${{ matrix.check }}
+        run: bun run ${{ matrix.check }}
 
-      - name: Lint
-        run: bun run lint
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Test
-        run: bun test test/ --timeout=60000
+        run: bun test test/ --timeout=60000 --bail

--- a/docker-compose.test-bail.yml
+++ b/docker-compose.test-bail.yml
@@ -32,8 +32,12 @@ services:
         bun run typecheck
         echo "=== lint ==="
         bun run lint
-        echo "=== test ==="
-        CI=1 NAX_SKIP_PRECHECK=1 bun test test/ --timeout=60000 --bail
+        echo "=== test (unit) ==="
+        bun test test/unit/ --timeout=60000 --bail
+        echo "=== test (integration) ==="
+        bun test test/integration/ --timeout=60000 --bail
+        echo "=== test (ui) ==="
+        bun test test/ui/ --timeout=60000 --bail
         echo "=== DONE ==="
 
 volumes:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -31,8 +31,12 @@ services:
         bun run typecheck
         echo "=== lint ==="
         bun run lint
-        echo "=== test ==="
-        bun test --timeout=60000 || true
+        echo "=== test (unit) ==="
+        bun test test/unit/ --timeout=60000 || true
+        echo "=== test (integration) ==="
+        bun test test/integration/ --timeout=60000 || true
+        echo "=== test (ui) ==="
+        bun test test/ui/ --timeout=60000 || true
         echo "=== DONE ==="
 
 volumes:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -670,7 +670,7 @@ Stories classified as complex/expert with >6 acceptance criteria.
 - **PERM-002:** Scoped Tool Allowlists — per-stage `allowedTools` with glob patterns (e.g., `Write(src/**)`), `inherit` chain between stages, backend mapping to `--allowedTools` (CLI) and `--allowed-tools` (ACP). **Spec:** [`docs/specs/scoped-permissions.md`](specs/scoped-permissions.md)
 
 ### Planned
-- **CI Memory Optimization** — parallel test sharding to pass on 1GB runners (currently requires 8GB)
+- **CI Speed** — bun install cache + parallel jobs (checks/test run concurrently); target: 3-4 min → ~2.5 min
 - **Cost tracking dashboard** — visualize spend across features and agents
 - **Auto-decompose oversized stories** — when story size gate triggers, offer to auto-decompose via `nax analyse`
 - **Fire plugin hooks on plan failure** — load plugins before plan phase and emit `onRunEnd` with failure status when `nax run --plan` fails

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,30 +20,25 @@
 
 ---
 
-## v0.49.0 — Per-Package Config Override (Monorepo) 📋 Planned
+## v0.49.0 — Per-Package Config Override (Monorepo) ✅ Released
 
 **Theme:** Complete the per-package config override system — expand what's mergeable and wire effective config into all pipeline stages.
 **Spec:** [`docs/specs/SPEC-per-package-config.md`](specs/SPEC-per-package-config.md)
 
-### Context
-
-v0.47.0 shipped `mergePackageConfig` but only `quality.commands` is mergeable. Most pipeline stages still read from `ctx.config` (root) instead of the per-package resolved config — so fields like `review.enabled`, `acceptance.enabled`, and `execution.regressionGate` set in a package's `nax/config.json` are silently ignored.
-
-### What needs to change
-
-1. **Expand mergeable fields** — add `execution.smartTestRunner`, `execution.regressionGate`, `review.enabled`, `review.checks`, `acceptance.enabled`, and more to `mergePackageConfig`
-2. **Centralize config resolution** — add `effectiveConfig: NaxConfig` to `PipelineContext`, resolve once per story at pipeline entry, have all stages read from `ctx.effectiveConfig` instead of `ctx.config`
+- **feat(config):** Expanded `mergePackageConfig` — `execution.smartTestRunner`, `execution.regressionGate`, `review.enabled`, `review.checks`, `acceptance.enabled`, and more now mergeable from per-package `nax/config.json`
+- **feat(pipeline):** `effectiveConfig: NaxConfig` added to `PipelineContext` — resolved once per story at pipeline entry; all stages read from `ctx.effectiveConfig`
+- **fix(acceptance):** Strip markdown fences from `generateFromPRD` output
+- **fix(verify):** `TEST_FAILURE` hands off to rectify stage instead of escalating; `TIMEOUT`/`CRASH` still escalate
+- **fix(autofix):** Review hands off to autofix stage instead of escalating; uses per-package `lintFix`/`formatFix` command
 
 ---
 
-## v0.46.2 — Review Rectification (Agent-Driven Lint/Typecheck Fix) 📋 Planned
+## v0.46.2 — Review Rectification (Agent-Driven Lint/Typecheck Fix) ✅ Released
 
 **Theme:** When lint or typecheck fails in the review stage and mechanical autofix can't resolve it, spawn an agent rectification session with the error output as context.
 **Spec:** [`docs/specs/SPEC-v046-2-review-rectification.md`](specs/SPEC-v046-2-review-rectification.md)
 
-### What needs to change
-
-When mechanical `lintFix`/`formatFix` fails (or isn't configured), extend the autofix stage to spawn an agent session with the exact lint/typecheck errors — the agent fixes the code and commits. Re-run review to verify; repeat up to `maxAttempts`. Reuses existing `quality.autofix.enabled` and `quality.autofix.maxAttempts` config.
+- **fix(autofix):** Agent rectification fallback for lint/typecheck failures — spawns agent session with exact error output, re-runs review to verify, up to `maxAttempts`. Reuses `quality.autofix.enabled` and `quality.autofix.maxAttempts` config (AUTOFIX-001–004)
 
 ---
 
@@ -623,6 +618,8 @@ Stories classified as complex/expert with >6 acceptance criteria.
 
 | Version | Theme | Date |
 |:--------|:------|:-----|
+| v0.49.0 | Per-Package Config Override (expand mergeable fields, effectiveConfig in PipelineContext) | 2026-03-xx |
+| v0.46.2 | Review Rectification (agent-driven lint/typecheck fix fallback) | 2026-03-xx |
 | v0.41.0 | Slow Test Optimizations (105s → 23s, full suite 4min → 2.5min) | 2026-03-14 |
 | v0.40.1 | Acceptance UI Test Strategies (component/cli/e2e/snapshot) | 2026-03-14 |
 | v0.40.0 | Acceptance Test Pipeline (RED→GREEN gates, PRD-based AC generation) | 2026-03-12 |

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "bun x tsc --noEmit",
     "lint": "bun x biome check src/ bin/",
     "release": "bun scripts/release.ts",
-    "test": "bun test test/ --timeout=60000",
+    "test": "bun test test/unit/ --timeout=60000 && bun test test/integration/ --timeout=60000 && bun test test/ui/ --timeout=60000",
     "test:watch": "bun test --watch",
     "test:unit": "bun test ./test/unit/ --timeout=60000",
     "test:integration": "bun test ./test/integration/ --timeout=60000",


### PR DESCRIPTION
## What

Overhaul CI and local test performance — split test invocations, add caching, parallel jobs.

## Why

`bun test test/` with 317 files in one process causes module resolution overhead explosion: **144s**. Running unit/integration/ui as 3 separate `bun test` invocations: **24s** (6x faster).

Closes the "CI Memory Optimization" backlog item (renamed to "CI Speed").

## How

### Test split (biggest win: 144s → 24s)
- `package.json` `test` script: `bun test test/unit/ && bun test test/integration/ && bun test test/ui/`
- Root cause: bun module resolution overhead explodes when loading all 317 test files in a single process
- Each invocation stays fast (~8s unit, ~9s integration, ~1s ui)

### CI workflow (.github/workflows/ci.yml)
- Split into parallel jobs: `checks` (typecheck + lint matrix) and `test`
- `actions/cache@v4` for `~/.bun/install/cache` keyed on `bun.lock` hash
- `--bail` on test to fail fast
- Tightened timeouts: checks 5min, test 10min (was 15min)

### Docker compose
- `docker-compose.test.yml` and `docker-compose.test-bail.yml` updated to match split invocations

### Docs
- ROADMAP: v0.49.0 and v0.46.2 marked as released

## Testing

- [x] `bun run test` passes (4802 tests, 0 fail, 24s on VPS)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Expected CI time: **~3.5-4 min → ~1 min** (split test + bun cache + parallel jobs).
