### PR TITLE
fix(parallel): per-package config, worktree node_modules, and rectification infra

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -296,7 +296,12 @@ export async function saveAcpSession(
 }
 
 /** Clear a session name from the sidecar file. Best-effort — errors are swallowed. */
-export async function clearAcpSession(workdir: string, featureName: string, storyId: string): Promise<void> {
+export async function clearAcpSession(
+  workdir: string,
+  featureName: string,
+  storyId: string,
+  sessionRole?: string,
+): Promise<void> {
   try {
     const path = acpSessionsPath(workdir, featureName);
     let data: Record<string, string> = {};
@@ -306,7 +311,8 @@ export async function clearAcpSession(workdir: string, featureName: string, stor
     } catch {
       return; // File doesn't exist — nothing to clear
     }
-    delete data[storyId];
+    const sidecarKey = sessionRole ? `${storyId}:${sessionRole}` : storyId;
+    delete data[sidecarKey];
     await Bun.write(path, JSON.stringify(data, null, 2));
   } catch (err) {
     getSafeLogger()?.warn("acp-adapter", "Failed to clear session from sidecar", { error: String(err) });
@@ -560,7 +566,9 @@ export class AcpAgentAdapter implements AgentAdapter {
     // 1. Resolve session name: explicit > sidecar > derived
     let sessionName = options.acpSessionName;
     if (!sessionName && options.featureName && options.storyId) {
-      sessionName = (await readAcpSession(options.workdir, options.featureName, options.storyId)) ?? undefined;
+      // #90: Key sidecar by storyId:role to prevent verifier resuming implementer's session
+      const sidecarKey = options.sessionRole ? `${options.storyId}:${options.sessionRole}` : options.storyId;
+      sessionName = (await readAcpSession(options.workdir, options.featureName, sidecarKey)) ?? undefined;
     }
     sessionName ??= buildSessionName(options.workdir, options.featureName, options.storyId, options.sessionRole);
 
@@ -577,7 +585,8 @@ export class AcpAgentAdapter implements AgentAdapter {
 
     // 4. Persist for plan→run continuity
     if (options.featureName && options.storyId) {
-      await saveAcpSession(options.workdir, options.featureName, options.storyId, sessionName, this.name);
+      const sidecarKey = options.sessionRole ? `${options.storyId}:${options.sessionRole}` : options.storyId;
+      await saveAcpSession(options.workdir, options.featureName, sidecarKey, sessionName, this.name);
     }
 
     let lastResponse: AcpSessionResponse | null = null;

--- a/src/execution/parallel-coordinator.ts
+++ b/src/execution/parallel-coordinator.ts
@@ -2,9 +2,11 @@
  * Parallel coordinator — Orchestrates parallel story execution
  */
 
+import { existsSync, symlinkSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
 import type { NaxConfig } from "../config";
+import { loadConfigForWorkdir } from "../config/loader";
 import type { LoadedHooksConfig } from "../hooks";
 import type { InteractionChain } from "../interaction/chain";
 import { getSafeLogger } from "../logger";
@@ -166,6 +168,9 @@ export async function executeParallel(
     // Create worktrees for all stories in batch
     const worktreePaths = new Map<string, string>();
 
+    // #93: Pre-resolve per-story effective config (PKG-003) — parallel was always using root config
+    const storyEffectiveConfigs = new Map<string, NaxConfig>();
+
     for (const story of batch) {
       const worktreePath = join(projectRoot, ".nax-wt", story.id);
       try {
@@ -176,6 +181,32 @@ export async function executeParallel(
           storyId: story.id,
           worktreePath,
         });
+
+        // #88: Symlink workspace package node_modules so per-package test runners (jest, vitest) resolve correctly.
+        // Root node_modules is already symlinked by WorktreeManager; this covers sub-package node_modules.
+        if (story.workdir) {
+          const pkgNodeModulesSrc = join(projectRoot, story.workdir, "node_modules");
+          const pkgNodeModulesDst = join(worktreePath, story.workdir, "node_modules");
+          if (existsSync(pkgNodeModulesSrc) && !existsSync(pkgNodeModulesDst)) {
+            try {
+              symlinkSync(pkgNodeModulesSrc, pkgNodeModulesDst, "dir");
+              logger?.debug("parallel", "Symlinked package node_modules", {
+                storyId: story.id,
+                src: pkgNodeModulesSrc,
+              });
+            } catch (symlinkError) {
+              logger?.warn("parallel", "Failed to symlink package node_modules — test runner may not find deps", {
+                storyId: story.id,
+                error: errorMessage(symlinkError),
+              });
+            }
+          }
+        }
+
+        // #93: Resolve per-package effective config so testScoped/test overrides apply (same as iteration-runner PKG-003)
+        const rootConfigPath = join(projectRoot, ".nax", "config.json");
+        const effectiveConfig = story.workdir ? await loadConfigForWorkdir(rootConfigPath, story.workdir) : config;
+        storyEffectiveConfigs.set(story.id, effectiveConfig);
       } catch (error) {
         markStoryFailed(currentPrd, story.id, undefined, undefined);
         logger?.error("parallel", "Failed to create worktree", {
@@ -194,6 +225,7 @@ export async function executeParallel(
       worktreePaths,
       maxConcurrency,
       eventEmitter,
+      storyEffectiveConfigs,
     );
 
     totalCost += batchResult.totalCost;

--- a/src/execution/parallel-worker.ts
+++ b/src/execution/parallel-worker.ts
@@ -85,6 +85,8 @@ export async function executeParallelBatch(
   worktreePaths: Map<string, string>,
   maxConcurrency: number,
   eventEmitter?: PipelineEventEmitter,
+  // #93: Per-story effective configs (PKG-003) — if absent falls back to context.effectiveConfig
+  storyEffectiveConfigs?: Map<string, NaxConfig>,
 ): Promise<ParallelBatchResult> {
   const logger = getSafeLogger();
   const results: ParallelBatchResult = {
@@ -111,7 +113,17 @@ export async function executeParallelBatch(
 
     const routing = routeTask(story.title, story.description, story.acceptanceCriteria, story.tags, config);
 
-    const executePromise = executeStoryInWorktree(story, worktreePath, context, routing as RoutingResult, eventEmitter)
+    // #93: Override effectiveConfig with per-story resolved config (PKG-003) if available
+    const storyConfig = storyEffectiveConfigs?.get(story.id);
+    const storyContext = storyConfig ? { ...context, effectiveConfig: storyConfig } : context;
+
+    const executePromise = executeStoryInWorktree(
+      story,
+      worktreePath,
+      storyContext,
+      routing as RoutingResult,
+      eventEmitter,
+    )
       .then((result) => {
         results.totalCost += result.cost;
         results.storyCosts.set(story.id, result.cost);

--- a/src/verification/orchestrator-types.ts
+++ b/src/verification/orchestrator-types.ts
@@ -71,6 +71,8 @@ export interface VerifyResult {
   rawOutput?: string;
   durationMs: number;
   countsTowardEscalation: boolean;
+  /** #89: Exit code from the test command (to distinguish passing from infra failure) */
+  exitCode?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -112,6 +114,7 @@ export function makeFailResult(
     failCount?: number;
     durationMs?: number;
     countsTowardEscalation?: boolean;
+    exitCode?: number;
   } = {},
 ): VerifyResult {
   return {
@@ -126,6 +129,7 @@ export function makeFailResult(
     rawOutput: opts.rawOutput,
     durationMs: opts.durationMs ?? 0,
     countsTowardEscalation: opts.countsTowardEscalation ?? true,
+    exitCode: opts.exitCode,
   };
 }
 

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -61,6 +61,7 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
     attempt: 0,
     initialFailures: testSummary.failed,
     currentFailures: testSummary.failed,
+    lastExitCode: 1, // Assume failure since we entered the loop
   };
 
   logger?.info("rectification", `Starting ${label} loop`, {
@@ -149,6 +150,7 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
     if (retryVerification.output) {
       const newTestSummary = parseBunTestOutput(retryVerification.output);
       rectificationState.currentFailures = newTestSummary.failed;
+      rectificationState.lastExitCode = retryVerification.status === "SUCCESS" ? 0 : 1; // Basic mapping
       testSummary.failures = newTestSummary.failures;
       testSummary.failed = newTestSummary.failed;
       testSummary.passed = newTestSummary.passed;

--- a/src/verification/rectification.ts
+++ b/src/verification/rectification.ts
@@ -29,7 +29,13 @@ export function shouldRetryRectification(state: RectificationState, config: Rect
     return false;
   }
 
-  // Stop if all tests passing
+  // #89: Handle unparseable failures (non-zero exit but 0 parsed failures).
+  // Treat as infrastructure failure and retry until maxRetries reached.
+  if (state.lastExitCode !== undefined && state.lastExitCode !== 0 && state.currentFailures === 0) {
+    return true;
+  }
+
+  // Stop if all tests passing (and exit code was 0)
   if (state.currentFailures === 0) {
     return false;
   }

--- a/src/verification/strategies/scoped.ts
+++ b/src/verification/strategies/scoped.ts
@@ -11,7 +11,7 @@
  */
 
 import { getLogger } from "../../logger";
-import type { IVerificationStrategy, VerifyContext, VerifyResult } from "../orchestrator-types";
+import type { IVerificationStrategy, StructuredTestFailure, VerifyContext, VerifyResult } from "../orchestrator-types";
 import { makeFailResult, makePassResult, makeSkippedResult } from "../orchestrator-types";
 import { parseBunTestOutput } from "../parser";
 import { regression } from "../runners";
@@ -136,8 +136,10 @@ export class ScopedStrategy implements IVerificationStrategy {
       rawOutput: result.output,
       passCount: parsed.passed,
       failCount: parsed.failed,
-      failures: parsed.failures,
+      failures: parsed.failures as StructuredTestFailure[],
       durationMs,
+      // #89: Pass through exit code to detect unparseable infra failures
+      exitCode: result.status === "TEST_FAILURE" ? 1 : undefined,
     });
   }
 }

--- a/src/verification/types.ts
+++ b/src/verification/types.ts
@@ -85,6 +85,8 @@ export interface RectificationState {
   initialFailures: number;
   /** Number of test failures on current run */
   currentFailures: number;
+  /** #89: Exit code from the last test run */
+  lastExitCode?: number;
 }
 
 /** Verification gate options */


### PR DESCRIPTION
## What

Fix four bugs in parallel mode, verification, and ACP session handling.

## Why

- **#88** — Parallel worktrees were missing package-level `node_modules` (only root was symlinked). Per-package test runners (jest, vitest) couldn't find their deps when `cwd` was a workspace sub-package.
- **#89** — Rectification exhausted retries instantly for non-bun projects (jest/vitest/turbo). `parseBunTestOutput` returns 0 failures for non-bun output; `shouldRetryRectification` treated 0 failures as "all passing" and stopped — silently burning the retry budget without attempting any fix.
- **#90** — ACP session sidecar was keyed by `storyId` only. In parallel mode, the verifier would resume the implementer's session instead of starting its own.
- **#93** — Parallel mode always used root config (`effectiveConfig: config`), ignoring per-package config overrides (PKG-003). Sequential mode correctly applied `loadConfigForWorkdir` per story. Impact: monorepo projects in parallel mode got the wrong `testScoped`/`test` command.

Closes #88
Closes #89
Closes #90
Closes #93

## How

**#88** (`parallel-coordinator.ts`): After `worktreeManager.create()`, if `story.workdir` is set, symlink `projectRoot/story.workdir/node_modules` into the worktree if it exists. Non-fatal — logs warn on failure.

**#89** (`rectification.ts`, `rectification-loop.ts`, `orchestrator-types.ts`, `types.ts`): Added `exitCode` field to `VerifyResult` and `lastExitCode` to `RectificationState`. `shouldRetryRectification` now returns `true` when `lastExitCode !== 0 && currentFailures === 0` — treats as infra failure and retries up to maxRetries. `rectificationState.lastExitCode` seeds to `1` on entry (we only enter the loop on test failure) and is updated per re-run via `status === "SUCCESS" ? 0 : 1`.

**#90** (`adapter.ts`): Changed sidecar key from `storyId` to `${storyId}:${sessionRole}` in `saveAcpSession`, `readAcpSession`, and `clearAcpSession`. Implementer and verifier now get isolated sidecar entries.

**#93** (`parallel-coordinator.ts`, `parallel-worker.ts`): Pre-resolves a `Map<storyId, NaxConfig>` using `loadConfigForWorkdir` for each story with a `workdir`. Passes the map to `executeParallelBatch` as optional `storyEffectiveConfigs`. Worker overrides `context.effectiveConfig` per story before calling `executeStoryInWorktree`.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- **#90 sidecar migration**: Existing sidecar files use the old `storyId`-only key. On first parallel run after this change, stale entries won't be read (miss) — new sessions will be created, which is safe. No migration needed.
- **#89 exit code mapping**: `VerifyResult.exitCode` is set in `makeFailResult` opts; `ScopedStrategy` passes `exitCode: 1` for `TEST_FAILURE` status. Downstream callers that don't set `exitCode` get `undefined`, which preserves existing behaviour (only `lastExitCode !== undefined && lastExitCode !== 0` triggers retry).
