### PR TITLE
fix(plan): respect agent.protocol in --auto mode

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -138,17 +138,21 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
   // Route to auto (one-shot) or interactive (multi-turn) mode
   let rawResponse: string;
   if (options.auto) {
-    // One-shot: use CLI adapter directly — simple completion doesn't need ACP session overhead
+    // #91: Respect agent.protocol — ACP protocol uses adapter.plan() (session-based),
+    // CLI protocol uses adapter.complete() (one-shot). This matches how the run path works.
+    const isAcp = config?.agent?.protocol === "acp";
     const prompt = buildPlanningPrompt(
       specContent,
       codebaseContext,
-      undefined,
+      isAcp ? outputPath : undefined, // ACP writes directly to file; CLI returns inline
       relativePackages,
       packageDetails,
       config?.project,
     );
-    const cliAdapter = _planDeps.getAgent(agentName);
-    if (!cliAdapter) throw new Error(`[plan] No agent adapter found for '${agentName}'`);
+
+    const adapter = _planDeps.getAgent(agentName, config);
+    if (!adapter) throw new Error(`[plan] No agent adapter found for '${agentName}'`);
+
     let autoModel: string | undefined;
     try {
       const planTier = config?.plan?.model ?? "balanced";
@@ -157,24 +161,59 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
       const entry = models?.[planTier] ?? models?.balanced;
       if (entry) autoModel = resolveModel(entry as Parameters<typeof resolveModel>[0]).model;
     } catch {
-      // fall through — complete() will use its own fallback
+      // fall through — adapter will use its own fallback
     }
-    rawResponse = await cliAdapter.complete(prompt, {
-      model: autoModel,
-      jsonMode: true,
-      workdir,
-      config,
-      featureName: options.feature,
-      sessionRole: "plan",
-    });
-    // CLI adapter returns {"type":"result","result":"..."} envelope — unwrap it
-    try {
-      const envelope = JSON.parse(rawResponse) as Record<string, unknown>;
-      if (envelope?.type === "result" && typeof envelope?.result === "string") {
-        rawResponse = envelope.result;
+
+    if (isAcp) {
+      // ACP: run as a non-interactive session (no interactionBridge) — agent writes PRD to outputPath
+      logger?.info("plan", "Starting ACP auto planning session", {
+        agent: agentName,
+        model: autoModel ?? config?.plan?.model ?? "balanced",
+        workdir,
+        feature: options.feature,
+        timeoutSeconds,
+      });
+      const pidRegistry = new PidRegistry(workdir);
+      try {
+        await adapter.plan({
+          prompt,
+          workdir,
+          interactive: false,
+          timeoutSeconds,
+          config,
+          modelTier: config?.plan?.model ?? "balanced",
+          dangerouslySkipPermissions: resolvePermissions(config, "plan").skipPermissions,
+          maxInteractionTurns: config?.agent?.maxInteractionTurns,
+          featureName: options.feature,
+          pidRegistry,
+          sessionRole: "plan",
+        });
+      } finally {
+        await pidRegistry.killAll().catch(() => {});
       }
-    } catch {
-      // Not an envelope — use rawResponse as-is
+      if (!_planDeps.existsSync(outputPath)) {
+        throw new Error(`[plan] ACP agent did not write PRD to ${outputPath}. Check agent logs for errors.`);
+      }
+      rawResponse = await _planDeps.readFile(outputPath);
+    } else {
+      // CLI: one-shot complete() — simple and fast, no session overhead
+      rawResponse = await adapter.complete(prompt, {
+        model: autoModel,
+        jsonMode: true,
+        workdir,
+        config,
+        featureName: options.feature,
+        sessionRole: "plan",
+      });
+      // CLI adapter returns {"type":"result","result":"..."} envelope — unwrap it
+      try {
+        const envelope = JSON.parse(rawResponse) as Record<string, unknown>;
+        if (envelope?.type === "result" && typeof envelope?.result === "string") {
+          rawResponse = envelope.result;
+        }
+      } catch {
+        // Not an envelope — use rawResponse as-is
+      }
     }
   } else {
     // Interactive: agent writes PRD JSON directly to outputPath (avoids output truncation)


### PR DESCRIPTION
## What

Fix `nax plan --from` (auto mode) to respect `agent.protocol` from config. Previously it always used the CLI adapter regardless of protocol setting.

## Why

The `--auto` path called `getAgent(agentName)` **without config**, always receiving a CLI adapter, then called `cliAdapter.complete()`. This bypassed ACP entirely even when `config.agent.protocol = "acp"` was set.

The interactive path correctly called `getAgent(agentName, config)` to get the protocol-aware adapter.

Closes #91

## How

In the `--auto` block:

1. Call `getAgent(agentName, config)` (with config) to get the correct adapter.
2. Check `config?.agent?.protocol === "acp"`:
   - **ACP**: call `adapter.plan()` with `interactive: false` (no interactionBridge) — agent writes PRD directly to `outputPath`, same as interactive mode but without Q&A turns.
   - **CLI**: keep existing `adapter.complete()` one-shot path unchanged.

The `outputPath` is now passed to `buildPlanningPrompt` for ACP (so the agent knows where to write), and omitted for CLI (returns inline).

## Testing

- [x] Tests added/updated
- [x] `bun test` passes (71 pass, 0 fail across plan test suite)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- CLI adapter path is **unchanged** — no behaviour change for projects not using ACP.
- ACP auto path reuses the same `adapter.plan()` call as interactive mode, just without an `interactionBridge`. This means the agent gets the full session context but won't pause to ask questions.
