### PR TITLE
fix(acp): gate Q&A detection on stopReason === end_turn (#92)

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -634,9 +634,13 @@ export class AcpAgentAdapter implements AgentAdapter {
           totalExactCostUsd = (totalExactCostUsd ?? 0) + lastResponse.exactCostUsd;
         }
 
-        // Check for agent question → route to interaction bridge
+        // Check for agent question → route to interaction bridge.
+        // Only attempt question detection when stopReason === "end_turn": the agent
+        // intentionally stopped and may be waiting for input. For max_tokens (truncated
+        // output) or tool_use (mid-tool-call), skip detection to avoid false positives.
         const outputText = extractOutput(lastResponse);
-        const question = extractQuestion(outputText);
+        const isEndTurn = lastResponse.stopReason === "end_turn";
+        const question = isEndTurn ? extractQuestion(outputText) : null;
         if (!question || !options.interactionBridge) break;
 
         getSafeLogger()?.debug("acp-adapter", "Agent asked question, routing to interactionBridge", { question });

--- a/test/unit/agents/acp/adapter-session.test.ts
+++ b/test/unit/agents/acp/adapter-session.test.ts
@@ -141,6 +141,31 @@ describe("AcpAgentAdapter — session mode (run)", () => {
       expect(result.output).toContain("GitHub OAuth");
     });
 
+    test("skips question detection when stopReason is max_tokens (not end_turn)", async () => {
+      let promptCallCount = 0;
+      const bridge = {
+        onQuestionDetected: async (_q: string) => "answer",
+      };
+
+      const session = makeSession({
+        promptFn: async (_: string) => {
+          promptCallCount++;
+          return {
+            messages: [{ role: "assistant", content: "Which OAuth provider should I use?" }],
+            stopReason: "max_tokens",
+            cumulative_token_usage: { input_tokens: 100, output_tokens: 50 },
+          };
+        },
+      });
+      _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
+
+      const result = await adapter.run({ ...BASE_OPTIONS, interactionBridge: bridge });
+
+      // Question text present but stopReason is max_tokens → no Q&A routing, loop exits
+      expect(promptCallCount).toBe(1);
+      expect(result.success).toBe(false); // max_tokens is not end_turn → success=false
+    });
+
     test("stops loop when interactionBridge throws (interaction timeout)", async () => {
       let promptCallCount = 0;
 


### PR DESCRIPTION
## What
Gate Q&A question detection on `stopReason === "end_turn"` in the ACP adapter multi-turn loop.

## Why
The agent intentionally stops (`end_turn`) when waiting for user input. Other stop reasons have no semantic connection to asking a question:
- `max_tokens` — agent was truncated mid-output, not asking
- `tool_use` — agent is mid-tool-call, not asking
- `stop_sequence` — agent hit a sequence stop, not asking

Previously, `extractQuestion()` ran on every turn regardless of `stopReason`, causing false-positive Q&A routing on truncated responses.

Confirmed via live acpx trace: `stopReason` is always `"end_turn"` when the agent asks a question, and the final `result` object contains no message content (content only comes via streaming `agent_message_chunk` events). See #92 investigation comment.

Closes #92

## How
In `_runWithClient` multi-turn loop (`adapter.ts`):
```ts
// Before:
const question = extractQuestion(outputText);

// After:
const isEndTurn = lastResponse.stopReason === "end_turn";
const question = isEndTurn ? extractQuestion(outputText) : null;
```

## Testing
- [x] Tests added/updated — new test: `max_tokens` response with question text does not route to `interactionBridge.onQuestionDetected()`
- [x] `bun test test/unit/agents/acp/` passes (175 pass, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
This is a targeted, low-risk fix. `extractQuestion()` heuristic logic is unchanged — only the gate condition is new. Further improvements (e.g. `[QUESTION]` marker convention) tracked separately in #92.
