### PR TITLE
fix(review): raise DIFF_CAP_BYTES 12KB→100KB, fail-closed on truncated passed:false

### DIFF
--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -27,8 +27,8 @@ export const _semanticDeps = {
   spawn: spawn as typeof spawn,
 };
 
-/** Maximum diff size in bytes before truncation */
-const DIFF_CAP_BYTES = 12_288;
+/** Maximum diff size in bytes before truncation (100KB — ~25K tokens, well within LLM context) */
+const DIFF_CAP_BYTES = 102_400;
 
 /** Default review rules applied to every semantic check */
 const DEFAULT_RULES = [
@@ -64,17 +64,46 @@ async function collectDiff(workdir: string, storyGitRef: string): Promise<string
 }
 
 /**
- * Truncate diff to stay within token budget.
+ * Collect git diff --stat summary (file names + line counts).
+ * Used as a preamble when the full diff is truncated so the reviewer
+ * always knows which files changed even if the content is cut off.
  */
-function truncateDiff(diff: string): string {
+async function collectDiffStat(workdir: string, storyGitRef: string): Promise<string> {
+  const proc = _semanticDeps.spawn({
+    cmd: ["git", "diff", "--stat", `${storyGitRef}..HEAD`],
+    cwd: workdir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [exitCode, stdout] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+
+  return exitCode === 0 ? stdout.trim() : "";
+}
+
+/**
+ * Truncate diff to stay within token budget.
+ * When truncated, prepends a --stat summary so the reviewer knows all changed files.
+ */
+function truncateDiff(diff: string, stat?: string): string {
   if (diff.length <= DIFF_CAP_BYTES) {
     return diff;
   }
 
   const truncated = diff.slice(0, DIFF_CAP_BYTES);
-  // Count approximate file count from diff headers
-  const fileCount = (truncated.match(/^diff --git/gm) ?? []).length;
-  return `${truncated}\n... (truncated, showing first ${fileCount} files)`;
+  // Count files visible vs total
+  const visibleFiles = (truncated.match(/^diff --git/gm) ?? []).length;
+  const totalFiles = (diff.match(/^diff --git/gm) ?? []).length;
+
+  const statPreamble = stat
+    ? `## File Summary (all changed files)\n${stat}\n\n## Diff (truncated — ${visibleFiles}/${totalFiles} files shown)\n`
+    : "";
+
+  return `${statPreamble}${truncated}\n... (truncated at ${DIFF_CAP_BYTES} bytes, showing ${visibleFiles}/${totalFiles} files)`;
 }
 
 /**
@@ -222,8 +251,10 @@ export async function runSemanticReview(
   // AC-2: Collect git diff
   const rawDiff = await collectDiff(workdir, storyGitRef);
 
-  // AC-3: Truncate if over cap
-  const diff = truncateDiff(rawDiff);
+  // AC-3: Truncate if over cap — collect stat summary when truncation needed
+  const needsTruncation = rawDiff.length > DIFF_CAP_BYTES;
+  const stat = needsTruncation ? await collectDiffStat(workdir, storyGitRef) : undefined;
+  const diff = truncateDiff(rawDiff, stat);
 
   // Resolve agent
   const agent = modelResolver(semanticConfig.modelTier);
@@ -264,9 +295,28 @@ export async function runSemanticReview(
     };
   }
 
-  // AC-6 + AC-8: Parse response, fail-open on invalid JSON
+  // AC-6 + AC-8: Parse response — fail-closed when LLM clearly intended to fail,
+  // fail-open only when response is truly unparseable with no signal.
   const parsed = parseLLMResponse(rawResponse);
   if (!parsed) {
+    // Check if truncated response contains "passed": false — LLM intended to fail the review
+    // but output was cut off mid-response. Treating this as a pass is incorrect (#105).
+    const looksLikeFail = /"passed"\s*:\s*false/.test(rawResponse);
+    if (looksLikeFail) {
+      logger?.warn("semantic", "LLM returned truncated JSON with passed:false — treating as failure", {
+        rawResponse: rawResponse.slice(0, 200),
+      });
+      return {
+        check: "semantic",
+        success: false,
+        command: "",
+        exitCode: 1,
+        output:
+          "semantic review: LLM response truncated but indicated failure (passed:false found in partial response)",
+        durationMs: Date.now() - startTime,
+      };
+    }
+
     logger?.warn("semantic", "LLM returned invalid JSON — fail-open", { rawResponse: rawResponse.slice(0, 200) });
     return {
       check: "semantic",

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -220,8 +220,31 @@ describe("runSemanticReview — git diff invocation", () => {
 });
 
 // ---------------------------------------------------------------------------
-// AC-3: Diff truncation at 12288 bytes
+// AC-3: Diff truncation at 102400 bytes (100KB)
 // ---------------------------------------------------------------------------
+
+/** Spawn mock that returns different output for diff vs diff --stat */
+function makeSpawnMockWithStat(diffStdout: string, statStdout: string, exitCode = 0) {
+  return mock((opts: { cmd?: string[] }) => {
+    const isStatCall = opts.cmd?.includes("--stat");
+    const stdout = isStatCall ? statStdout : diffStdout;
+    return {
+      exited: Promise.resolve(exitCode),
+      stdout: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(stdout));
+          controller.close();
+        },
+      }),
+      stderr: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      kill: () => {},
+    };
+  }) as unknown as typeof _semanticDeps.spawn;
+}
 
 describe("runSemanticReview — diff truncation", () => {
   let origSpawn: typeof _semanticDeps.spawn;
@@ -234,7 +257,7 @@ describe("runSemanticReview — diff truncation", () => {
     _semanticDeps.spawn = origSpawn;
   });
 
-  test("passes full diff to LLM prompt when diff is under 12288 bytes", async () => {
+  test("passes full diff to LLM prompt when diff is under 102400 bytes", async () => {
     const smallDiff = "a".repeat(100);
     _semanticDeps.spawn = makeSpawnMock(smallDiff, 0);
     let capturedPrompt = "";
@@ -249,9 +272,10 @@ describe("runSemanticReview — diff truncation", () => {
     expect(capturedPrompt).toContain(smallDiff);
   });
 
-  test("truncates diff and appends truncation marker when diff exceeds 12288 bytes", async () => {
-    const largeDiff = "x".repeat(15_000);
-    _semanticDeps.spawn = makeSpawnMock(largeDiff, 0);
+  test("truncates diff and appends truncation marker when diff exceeds 102400 bytes", async () => {
+    const largeDiff = "x".repeat(110_000);
+    const statOutput = " src/foo.ts | 100 +\n src/bar.ts | 50 +\n 2 files changed";
+    _semanticDeps.spawn = makeSpawnMockWithStat(largeDiff, statOutput, 0);
     let capturedPrompt = "";
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
     (agent.complete as ReturnType<typeof mock>).mockImplementation(async (prompt: string) => {
@@ -261,15 +285,16 @@ describe("runSemanticReview — diff truncation", () => {
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
-    expect(capturedPrompt).toContain("... (truncated, showing first");
-    // The diff in the prompt must not exceed the cap
-    const diffInPrompt = capturedPrompt.match(/```diff\n([\s\S]*?)```/)?.[1] ?? "";
-    expect(diffInPrompt.length).toBeLessThanOrEqual(12_288 + 100); // cap + marker overhead
+    expect(capturedPrompt).toContain("truncated at 102400 bytes");
+    // The diff in the prompt must not exceed the cap (plus stat preamble + marker overhead)
+    const diffSection = capturedPrompt.match(/```diff\n([\s\S]*?)```/)?.[1] ?? "";
+    expect(diffSection.length).toBeLessThanOrEqual(102_400 + 500); // cap + stat preamble + marker
   });
 
-  test("truncation marker contains 'truncated, showing first N files'", async () => {
-    const largeDiff = "y".repeat(20_000);
-    _semanticDeps.spawn = makeSpawnMock(largeDiff, 0);
+  test("truncation includes file summary from git diff --stat", async () => {
+    const largeDiff = "y".repeat(110_000);
+    const statOutput = " src/foo.ts | 100 +\n src/bar.ts | 50 +\n 2 files changed";
+    _semanticDeps.spawn = makeSpawnMockWithStat(largeDiff, statOutput, 0);
     let capturedPrompt = "";
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
     (agent.complete as ReturnType<typeof mock>).mockImplementation(async (prompt: string) => {
@@ -279,7 +304,9 @@ describe("runSemanticReview — diff truncation", () => {
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
-    expect(capturedPrompt).toMatch(/\.\.\. \(truncated, showing first \d+ files?\)/);
+    expect(capturedPrompt).toContain("File Summary (all changed files)");
+    expect(capturedPrompt).toContain("src/foo.ts");
+    expect(capturedPrompt).toContain("src/bar.ts");
   });
 });
 
@@ -515,6 +542,53 @@ describe("runSemanticReview — fail-open on invalid JSON", () => {
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
     expect(result.check).toBe("semantic");
+  });
+});
+
+// #105: Truncated JSON with "passed": false should fail-closed
+// ---------------------------------------------------------------------------
+
+describe("runSemanticReview — fail-closed on truncated JSON with passed:false (#105)", () => {
+  let origSpawn: typeof _semanticDeps.spawn;
+
+  beforeEach(() => {
+    origSpawn = _semanticDeps.spawn;
+  });
+
+  afterEach(() => {
+    _semanticDeps.spawn = origSpawn;
+  });
+
+  test("returns success=false when truncated JSON contains passed:false", async () => {
+    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    // Simulates LLM output cut off mid-response — JSON is invalid but clearly says passed:false
+    const truncatedResponse = '```json\n{"passed": false, "findings": [{"severity": "error", "file": "test.ts", "line": 1, "issue": "Test file is 78';
+    const agent = makeMockAgent(truncatedResponse);
+
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    expect(result.success).toBe(false);
+  });
+
+  test("output mentions truncated response on fail-closed", async () => {
+    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    const truncatedResponse = '{"passed": false, "findings": [{"severity": "error"';
+    const agent = makeMockAgent(truncatedResponse);
+
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    expect(result.output).toContain("truncated");
+    expect(result.output).toContain("passed:false");
+  });
+
+  test("still fail-open when truncated JSON contains passed:true", async () => {
+    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    const truncatedResponse = '{"passed": true, "findings": [';
+    const agent = makeMockAgent(truncatedResponse);
+
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    expect(result.success).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What

Fix two semantic review bugs that caused a review-autofix death loop during the PARALLEL-UNIFY-001 self-dev run, ultimately leading to story escalation.

## Why

During the nax self-dev run on Mac01, US-001 got stuck in a semantic review loop:
- The full story diff was **199KB** (22 files, 3387 insertions)
- `DIFF_CAP_BYTES` at 12KB truncated everything after the acceptance test file (alphabetically first)
- The semantic reviewer correctly flagged "implementation files absent" — but autofix couldn't resolve a truncation bug
- Additionally, when the LLM returned truncated JSON with `"passed": false`, nax treated it as a pass (fail-open), wasting an autofix attempt

The story went through 6 review rounds (8→7→fail-open→5→5→4 findings) before escalating to the `powerful` tier.

Closes #105
Closes #107

## How

**#107 — Diff truncation:**
- Raise `DIFF_CAP_BYTES` from 12,288 to 102,400 (100KB, ~25K tokens)
- Add `collectDiffStat()` to capture `git diff --stat` summary
- When diff is truncated, prepend a file summary so the reviewer always knows which files changed even when content is cut off

**#105 — Fail-open on truncated JSON:**
- Before applying fail-open, check if truncated response contains `"passed": false` via regex
- If found: return `success: false` (fail-closed) — LLM clearly intended to fail
- If not found: keep existing fail-open behavior for truly unparseable responses

## Testing
- [x] Tests added/updated (3 new fail-closed tests, updated truncation tests with stat preamble)
- [x] `bun test` passes (4746 pass, 60 skip, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
- #106 (autofix counter resets across retry cycles) is deferred — medium complexity, needs state tracking on pipeline context
- The 100KB cap (~25K tokens) is conservative; modern LLMs handle 100K+ tokens. Can raise further if needed.
