### PR TITLE
chore: release v0.54.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.54.6",
+  "version": "0.54.7",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Release v0.54.7 — patch release with semantic review fixes.

## Why

This release contains two bug fixes that caused review loops during self-development:

- **#105** — semantic fail-open on truncated JSON with `"passed": false`
- **#107** — `DIFF_CAP_BYTES` (12KB) truncating multi-file story diffs

## Changes

- Raise `DIFF_CAP_BYTES` from 12,288 to 102,400 (100KB)
- Add `git diff --stat` preamble when diff is truncated
- Fail-closed when truncated JSON contains `passed: false`
- 3 new tests, 0 regressions

## Install

```bash
npm install -g @nathapp/nax@latest
```

Full Changelog: https://github.com/nathapp-io/nax/compare/v0.54.6...v0.54.7
