### PR TITLE
fix(acp): BUG-097 interactionBridge false positive on code snippets

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -448,14 +448,18 @@ function extractQuestion(output: string): string | null {
   const text = output.trim();
   if (!text) return null;
 
-  const sentences = text.split(/(?<=[.!?])\s+/);
-  const questionSentences = sentences.filter((s) => s.trim().endsWith("?"));
-  if (questionSentences.length > 0) {
-    const q = questionSentences[questionSentences.length - 1].trim();
-    if (q.length > 10) return q;
+  // BUG-097: Only check the last non-empty line for question marks.
+  // Scanning all sentences caused false positives on code snippets mid-output
+  // containing ?. (optional chaining), ?? (nullish coalescing), or ternary ?.
+  const lines = text.split("\n").filter((l) => l.trim().length > 0);
+  const lastLine = lines.at(-1)?.trim() ?? "";
+
+  if (lastLine.endsWith("?") && lastLine.length > 10) {
+    return lastLine;
   }
 
-  const lower = text.toLowerCase();
+  // Keyword markers — also scoped to the last line to avoid mid-message false positives
+  const lower = lastLine.toLowerCase();
   const markers = [
     "please confirm",
     "please specify",
@@ -467,7 +471,7 @@ function extractQuestion(output: string): string | null {
   ];
   for (const marker of markers) {
     if (lower.includes(marker)) {
-      return text.slice(-200).trim();
+      return lastLine;
     }
   }
 

--- a/src/agents/acp/interaction-bridge.ts
+++ b/src/agents/acp/interaction-bridge.ts
@@ -32,10 +32,14 @@ type BridgeEventHandler = (event: unknown) => void;
 // Question pattern detection
 // ─────────────────────────────────────────────────────────────────────────────
 
-const QUESTION_PATTERNS = [/\?/, /\bwhich\b/i, /\bshould i\b/i, /\bunclear\b/i, /\bplease clarify\b/i];
+const QUESTION_PATTERNS = [/\?\s*$/, /\bwhich\b/i, /\bshould i\b/i, /\bunclear\b/i, /\bplease clarify\b/i];
 
 function containsQuestionPattern(content: string): boolean {
-  return QUESTION_PATTERNS.some((pattern) => pattern.test(content));
+  // BUG-097: Only check the last non-empty line to avoid false positives
+  // from code snippets containing ?. / ?? / ternary ? in the body.
+  const lines = content.split("\n").filter((l) => l.trim().length > 0);
+  const lastLine = lines.at(-1)?.trim() ?? "";
+  return QUESTION_PATTERNS.some((pattern) => pattern.test(lastLine));
 }
 
 function generateRequestId(): string {

--- a/src/interaction/bridge-builder.ts
+++ b/src/interaction/bridge-builder.ts
@@ -23,7 +23,8 @@ export interface BridgeContext {
   stage: InteractionStage;
 }
 
-const QUESTION_PATTERNS = [/\?/, /\bwhich\b/i, /\bshould i\b/i, /\bunclear\b/i, /\bplease clarify\b/i];
+// BUG-097: Use /\?\s*$/ instead of /\?/ to avoid false positives on code (?., ??, ternary)
+const QUESTION_PATTERNS = [/\?\s*$/, /\bwhich\b/i, /\bshould i\b/i, /\bunclear\b/i, /\bplease clarify\b/i];
 
 /** Default interaction timeout when config value is not available (2 minutes) */
 const DEFAULT_INTERACTION_TIMEOUT_MS = 120_000;

--- a/test/unit/agents/acp/interaction-bridge-detection.test.ts
+++ b/test/unit/agents/acp/interaction-bridge-detection.test.ts
@@ -91,6 +91,8 @@ describe("AcpInteractionBridge — question pattern detection", () => {
     ["code output", "function hello() { return 42; }"],
     ["progress report", "Wrote 3 files to disk."],
     ["empty content", ""],
+    ["BUG-097: nullish coalescing in code snippet", "Here's what was changed:\n\n**AC-2 fix**: Replaced with `batchResult.storyDurations?.get(story.id) ?? 0`"],
+    ["BUG-097: optional chaining in status update", "Updated src/foo.ts to use config?.timeout instead of hardcoded value."],
   ])("non-question ignored: %s", (_label, content) => {
     const notification = makeNotification(content);
     expect(bridge.isQuestion(notification)).toBe(false);


### PR DESCRIPTION
## What

Fix false positive in the ACP interactionBridge question detector. When an agent reported a code change containing `??` (nullish coalescing) or `?.` (optional chaining), the question detector misclassified it as a question and routed it to the interactionBridge.

Example false positive:
> "Here's what was changed in src/execution/unified-executor.ts:\n\n**AC-2 fix**: Replaced Date.now() - storyStartTime with `batchResult.storyDurations?.get(story.id) ??"

## Why

Closes #97

## How

Three detection points were updated to scope question detection to the **last non-empty line only**:

1. **`src/agents/acp/adapter.ts` — `extractQuestion()`**: Replaced full-sentence scan with last-line check. Real questions almost always appear at the end of a message; code snippets appear in the body.

2. **`src/agents/acp/interaction-bridge.ts` — `QUESTION_PATTERNS`**: Changed bare `/\?/` to `/\?\s*$/` (must end with `?`) and scoped detection to the last line.

3. **`src/interaction/bridge-builder.ts` — `QUESTION_PATTERNS`**: Same `/\?\s*$/` fix for consistency.

## Testing

- [x] Tests added/updated — 2 regression cases for BUG-097 (nullish coalescing + optional chaining in status updates)
- [x] `bun test test/unit/agents/` passes (371 pass, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

The `stopReason === "end_turn"` guard in the adapter was already preventing mid-stream false positives, but this fix additionally prevents the `extractQuestion()` from ever seeing code snippets in the body.
