### PR TITLE
fix(review): revise semantic review — AC-focused, configurable test exclusion

### DIFF
--- a/docs/guides/semantic-review.md
+++ b/docs/guides/semantic-review.md
@@ -14,27 +14,67 @@ Semantic review uses an LLM to compare the actual git diff against a story's acc
 ## How It Works
 
 ```
-Story ACs + git diff → LLM prompt → { passed: bool, findings: [...] }
+Story ACs + production diff → LLM prompt → { passed: bool, findings: [...] }
 ```
 
-1. Collects the git diff from the story's starting commit to `HEAD`
-2. Builds a prompt containing the story title, description, ACs, and review rules
-3. Calls the LLM with a structured output schema
-4. Parses the response and reports findings
+1. Collects the git diff from the story's starting commit to `HEAD` (**production code only** — test files excluded)
+2. Builds a prompt containing the story title, description, and ACs
+3. Calls the LLM to verify each AC is correctly implemented
+4. Parses the structured JSON response and reports findings
 
 Semantic review runs **after** the story passes all other checks (typecheck, lint, test). It is a final behavioral gate.
 
 ---
 
-## Default Rules
+## What Semantic Review Checks
 
-Every semantic review evaluates against these 5 rules:
+Semantic review verifies **acceptance criteria implementation**:
 
-1. **No stubs or noops** — No empty implementations, placeholder functions, or TODO comments left in production code
-2. **No placeholder values** — No hardcoded dummy data, magic numbers, or test-only constants in production paths
-3. **No out-of-scope changes** — No unrelated changes outside the story's feature boundary
-4. **All new code is wired** — New functions/classes are properly exported and called by their callers
-5. **No silent error swallowing** — No `catch` blocks that silently discard errors without logging
+1. **AC coverage** — each acceptance criterion is implemented, not partially or missing
+2. **AC correctness** — the implementation does what the AC specifies, not something different
+3. **Dead code** — new code with stubs, noops, or unreachable branches
+4. **Wiring** — new functions/classes are exported and called by their callers
+
+Semantic review does **NOT** check:
+
+- Style, naming, or formatting (handled by lint)
+- Import ordering or file length (handled by lint)
+- Type correctness (handled by typecheck)
+- Test quality or test conventions (handled by lint)
+
+---
+
+## Test File Exclusion
+
+Test files are **excluded from the diff** sent to the LLM via configurable git pathspec patterns. The default patterns cover common test directory conventions across languages:
+
+```json
+{
+  "review": {
+    "semantic": {
+      "excludePatterns": [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/"]
+    }
+  }
+}
+```
+
+Override for your project's test layout:
+
+```json
+{
+  "review": {
+    "semantic": {
+      "excludePatterns": [":!src/test/", ":!*Test.java", ":!*_test.py", ":!test_*.py"]
+    }
+  }
+}
+```
+
+Set to `[]` to include test files in the review.
+
+This is intentional — semantic review validates production behavior against ACs. Test style and conventions are enforced by lint.
+
+The `git diff --stat` summary (shown on truncation) still includes all files for full context.
 
 ---
 
@@ -59,8 +99,8 @@ Add `"semantic"` to `review.checks` in `.nax/config.json`:
 {
   "review": {
     "semantic": {
-      "modelTier": "fast",     // Model tier for LLM calls (default: "balanced")
-      "rules": []              // Custom rules appended to default rules
+      "modelTier": "fast",
+      "rules": []
     }
   }
 }
@@ -82,7 +122,6 @@ Append project-specific rules to the default set:
     "semantic": {
       "modelTier": "fast",
       "rules": [
-        "No new console.log / console.error statements in production code",
         "All public APIs must have JSDoc comments",
         "Error responses must use the project's standard error shape"
       ]
@@ -114,19 +153,38 @@ Semantic review runs per-story by default (`review.pluginMode: "per-story"`). Se
 
 ---
 
-## Fail-Open Behavior
+## Fail-Open / Fail-Closed Behavior
 
-Semantic review **fails open** — if the LLM call fails or returns unparseable output, the review passes with a warning in the output. This prevents a flaky LLM response from blocking a valid implementation.
+Semantic review **fails open** by default — if the LLM call fails or returns truly unparseable output, the review passes with a warning. This prevents flaky LLM responses from blocking valid implementations.
 
 ```
 semantic review: could not parse LLM response (fail-open)
+```
+
+**Exception:** If the LLM returns truncated JSON that contains `"passed": false`, the review **fails closed** — the LLM clearly intended to fail the review but output was cut off mid-response. Treating this as a pass would be incorrect.
+
+```
+semantic review: LLM response truncated but indicated failure (passed:false found in partial response)
 ```
 
 ---
 
 ## Diff Truncation
 
-Diffs are truncated to ~12 KB to stay within the LLM token budget. If truncated, the review covers the first files in the diff only.
+Production diffs are truncated to **~50 KB** to stay within LLM context and reduce output truncation risk. When truncated, a `git diff --stat` summary (all files including tests) is prepended so the reviewer always knows which files changed.
+
+```
+## File Summary (all changed files)
+ src/execution/parallel-batch.ts        | 200 +++
+ src/execution/merge-conflict-rectify.ts |  45 +
+ test/integration/parallel.test.ts      | 120 ++
+ 3 files changed, 365 insertions(+)
+
+## Diff (truncated — 2/3 files shown)
+...
+```
+
+Since test files are excluded from the diff, the 50KB budget goes entirely to production code — equivalent to ~100KB of mixed diff.
 
 ---
 
@@ -135,10 +193,10 @@ Diffs are truncated to ~12 KB to stay within the LLM token budget. If truncated,
 ```
 Semantic review failed:
 
-[error] src/auth/login.ts:42 — catch block silently swallows the error
-  Suggestion: Add logger.error("Login failed", { err }) or re-throw
-[warn] src/auth/session.ts:18 — hardcoded 3600 used instead of SESSION_TTL constant
-  Suggestion: Extract to config constant SESSION_TTL
+[error] src/auth/login.ts:42 — AC-2 not implemented: catch block silently swallows login errors instead of returning error response
+  Suggestion: Add error handling that returns the standard error shape per AC-2
+[warn] src/auth/session.ts:18 — createSession() is defined but never called from the login flow
+  Suggestion: Wire createSession() into the login handler after successful auth
 ```
 
 ---

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -724,7 +724,22 @@ export class AcpAgentAdapter implements AgentAdapter {
   }
 
   async complete(prompt: string, _options?: CompleteOptions): Promise<string> {
-    const model = _options?.model ?? "default";
+    // Resolve model: explicit option > config.models[tier] > "default"
+    let model = _options?.model;
+    if (!model && _options?.modelTier && _options?.config?.models) {
+      const tier = _options.modelTier;
+      const { resolveModel } = await import("../../config/schema");
+      const models = _options.config.models as Record<string, unknown>;
+      const entry = models[tier] ?? models.balanced;
+      if (entry) {
+        try {
+          model = resolveModel(entry as Parameters<typeof resolveModel>[0]).model;
+        } catch {
+          // resolveModel can throw on malformed entries — fall through to "default"
+        }
+      }
+    }
+    model ??= "default";
     const timeoutMs = _options?.timeoutMs ?? 120_000; // 2-min safety net by default
     const permissionMode = resolvePermissions(_options?.config, "complete").mode;
     const workdir = _options?.workdir;

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -146,6 +146,12 @@ export interface CompleteOptions {
   storyId?: string;
   /** Session role for disambiguation when the same story has multiple concurrent sessions */
   sessionRole?: string;
+  /**
+   * Model tier hint for adapters that resolve model from config (e.g. ACP adapter).
+   * When set alongside `config`, the adapter resolves the model from `config.models[modelTier]`
+   * instead of using the default. Has no effect when `model` is explicitly set.
+   */
+  modelTier?: ModelTier;
 }
 
 /**

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -154,6 +154,7 @@ export const DEFAULT_CONFIG: NaxConfig = {
       modelTier: "balanced",
       rules: [],
       timeoutMs: 600_000,
+      excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/"],
     },
   },
   plan: {

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -237,6 +237,9 @@ const SemanticReviewConfigSchema = z.object({
   modelTier: ModelTierSchema.default("balanced"),
   rules: z.array(z.string()).default([]),
   timeoutMs: z.number().int().positive().default(600_000),
+  excludePatterns: z
+    .array(z.string())
+    .default([":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/"]),
 });
 
 const ReviewConfigSchema = z.object({

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -56,6 +56,7 @@ export const reviewStage: PipelineStage = {
         acceptanceCriteria: ctx.story.acceptanceCriteria,
       },
       modelResolver,
+      ctx.config,
     );
 
     ctx.reviewResult = result.builtIn;

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -83,6 +83,7 @@ export class ReviewOrchestrator {
     storyId?: string,
     story?: SemanticStory,
     modelResolver?: (tier: ModelTier) => AgentAdapter | null | undefined,
+    naxConfig?: NaxConfig,
   ): Promise<OrchestratorReviewResult> {
     const logger = getSafeLogger();
 
@@ -95,6 +96,7 @@ export class ReviewOrchestrator {
       storyGitRef,
       story,
       modelResolver,
+      naxConfig,
     );
 
     if (!builtIn.success) {

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -6,6 +6,7 @@
 
 import { spawn } from "bun";
 import type { AgentAdapter } from "../agents/types";
+import type { NaxConfig } from "../config";
 import type { ExecutionConfig, QualityConfig } from "../config/schema";
 import type { ModelTier } from "../config/schema-types";
 import { getSafeLogger } from "../logger";
@@ -279,6 +280,7 @@ export async function runReview(
   storyGitRef?: string,
   story?: SemanticStory,
   modelResolver?: (tier: ModelTier) => AgentAdapter | null | undefined,
+  naxConfig?: NaxConfig,
 ): Promise<ReviewResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -344,6 +346,7 @@ export async function runReview(
         semanticStory,
         semanticCfg,
         modelResolver ?? (() => null),
+        naxConfig,
       );
       checks.push(result);
       if (!result.success && !firstFailure) {

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -336,6 +336,7 @@ export async function runReview(
         modelTier: "balanced" as const,
         rules: [] as string[],
         timeoutMs: 600_000,
+        excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/"],
       };
       const result = await _reviewSemanticDeps.runSemanticReview(
         workdir,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -2,6 +2,9 @@
  * Semantic Review Runner
  *
  * Runs an LLM-based semantic review against the git diff for a story.
+ * Validates behavior — checks that the implementation satisfies the
+ * story's acceptance criteria. Code quality (lint, style, conventions)
+ * is handled by lint/typecheck, not semantic review.
  */
 
 import { spawn } from "bun";
@@ -27,24 +30,25 @@ export const _semanticDeps = {
   spawn: spawn as typeof spawn,
 };
 
-/** Maximum diff size in bytes before truncation (100KB — ~25K tokens, well within LLM context) */
-const DIFF_CAP_BYTES = 102_400;
-
-/** Default review rules applied to every semantic check */
-const DEFAULT_RULES = [
-  "No stubs or noops left in production code paths",
-  "No placeholder values (TODO, FIXME, hardcoded dummy data)",
-  "No unrelated changes outside the story scope",
-  "All new code is properly wired into callers and exports",
-  "No silent error swallowing (catch blocks that discard errors without logging)",
-];
+/**
+ * Maximum diff size in bytes before truncation.
+ * 50KB keeps the prompt well within LLM context and reduces output truncation risk.
+ * Test files are excluded from the diff, so the budget goes entirely to production code.
+ */
+const DIFF_CAP_BYTES = 51_200;
 
 /**
- * Collect git diff for the story range.
+ * Collect git diff for the story range (production code only).
+ * Excludes test files via configurable pathspec patterns — semantic review
+ * validates behavior against ACs, not test style or conventions.
  */
-async function collectDiff(workdir: string, storyGitRef: string): Promise<string> {
+async function collectDiff(workdir: string, storyGitRef: string, excludePatterns: string[]): Promise<string> {
+  const cmd = ["git", "diff", "--unified=3", `${storyGitRef}..HEAD`];
+  if (excludePatterns.length > 0) {
+    cmd.push("--", ".", ...excludePatterns);
+  }
   const proc = _semanticDeps.spawn({
-    cmd: ["git", "diff", "--unified=3", `${storyGitRef}..HEAD`],
+    cmd,
     cwd: workdir,
     stdout: "pipe",
     stderr: "pipe",
@@ -64,7 +68,7 @@ async function collectDiff(workdir: string, storyGitRef: string): Promise<string
 }
 
 /**
- * Collect git diff --stat summary (file names + line counts).
+ * Collect git diff --stat summary (all files including tests — for context).
  * Used as a preamble when the full diff is truncated so the reviewer
  * always knows which files changed even if the content is cut off.
  */
@@ -112,14 +116,12 @@ function truncateDiff(diff: string, stat?: string): string {
 function buildPrompt(story: SemanticStory, semanticConfig: SemanticReviewConfig, diff: string): string {
   const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
 
-  const defaultRulesText = DEFAULT_RULES.map((r, i) => `${i + 1}. ${r}`).join("\n");
-
   const customRulesSection =
     semanticConfig.rules.length > 0
-      ? `\n## Custom Rules\n${semanticConfig.rules.map((r, i) => `${i + 1}. ${r}`).join("\n")}\n`
+      ? `\n## Additional Review Rules\n${semanticConfig.rules.map((r, i) => `${i + 1}. ${r}`).join("\n")}\n`
       : "";
 
-  return `You are a code reviewer. Review the following git diff against the story requirements and rules.
+  return `You are a semantic code reviewer. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.
 
 ## Story: ${story.title}
 
@@ -128,27 +130,29 @@ ${story.description}
 
 ### Acceptance Criteria
 ${acList}
-
-## Review Rules
-
-### Default Rules
-${defaultRulesText}
 ${customRulesSection}
-## Git Diff
+## Git Diff (production code only — test files excluded)
 
 \`\`\`diff
 ${diff}\`\`\`
 
 ## Instructions
 
-Respond with JSON only. No markdown fences around the JSON response itself.
-Format:
+For each acceptance criterion, verify the diff implements it correctly. Flag issues only when:
+1. An AC is not implemented or partially implemented
+2. The implementation contradicts what the AC specifies
+3. New code has dead paths that will never execute (stubs, noops, unreachable branches)
+4. New code is not wired into callers/exports (written but never used)
+
+Do NOT flag: style issues, naming conventions, import ordering, file length, or anything lint handles.
+
+Respond in JSON format:
 {
   "passed": boolean,
   "findings": [
     {
       "severity": "error" | "warn" | "info",
-      "file": "path/to/file.ts",
+      "file": "path/to/file",
       "line": 42,
       "issue": "description of the issue",
       "suggestion": "how to fix it"
@@ -156,7 +160,7 @@ Format:
   ]
 }
 
-If the implementation looks correct, respond with { "passed": true, "findings": [] }.`;
+If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.`;
 }
 
 interface LLMFinding {
@@ -174,11 +178,11 @@ interface LLMResponse {
 
 /**
  * Parse and validate LLM JSON response.
- * Returns null if invalid.
+ * Strips markdown fences if present (LLMs frequently add them despite instructions).
+ * Returns null if truly unparseable.
  */
 function parseLLMResponse(raw: string): LLMResponse | null {
   try {
-    // Strip markdown fences if present — LLMs frequently wrap JSON in ```json ... ``` despite instructions
     let cleaned = raw.trim();
     const fenceMatch = cleaned.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/);
     if (fenceMatch) cleaned = fenceMatch[1].trim();
@@ -234,7 +238,7 @@ export async function runSemanticReview(
   const startTime = Date.now();
   const logger = getSafeLogger();
 
-  // AC-4: Early exit when no git ref
+  // Early exit when no git ref
   if (!storyGitRef) {
     return {
       check: "semantic",
@@ -248,10 +252,10 @@ export async function runSemanticReview(
 
   logger?.info("review", "Running semantic check", { storyId: story.id, modelTier: semanticConfig.modelTier });
 
-  // AC-2: Collect git diff
-  const rawDiff = await collectDiff(workdir, storyGitRef);
+  // Collect production-only diff (test files excluded at git level via configurable patterns)
+  const rawDiff = await collectDiff(workdir, storyGitRef, semanticConfig.excludePatterns);
 
-  // AC-3: Truncate if over cap — collect stat summary when truncation needed
+  // Truncate if over cap — collect stat summary (all files) when truncation needed
   const needsTruncation = rawDiff.length > DIFF_CAP_BYTES;
   const stat = needsTruncation ? await collectDiffStat(workdir, storyGitRef) : undefined;
   const diff = truncateDiff(rawDiff, stat);
@@ -272,7 +276,7 @@ export async function runSemanticReview(
     };
   }
 
-  // AC-5: Build prompt
+  // Build prompt
   const prompt = buildPrompt(story, semanticConfig, diff);
 
   // Call LLM
@@ -295,11 +299,11 @@ export async function runSemanticReview(
     };
   }
 
-  // AC-6 + AC-8: Parse response — fail-closed when LLM clearly intended to fail,
+  // Parse response — fail-closed when LLM clearly intended to fail,
   // fail-open only when response is truly unparseable with no signal.
   const parsed = parseLLMResponse(rawResponse);
   if (!parsed) {
-    // Check if truncated response contains "passed": false — LLM intended to fail the review
+    // Check if truncated response contains "passed": false — LLM intended to fail
     // but output was cut off mid-response. Treating this as a pass is incorrect (#105).
     const looksLikeFail = /"passed"\s*:\s*false/.test(rawResponse);
     if (looksLikeFail) {
@@ -328,7 +332,7 @@ export async function runSemanticReview(
     };
   }
 
-  // AC-7: Format findings and populate structured ReviewFinding[] (US-003 AC-2)
+  // Format findings and populate structured ReviewFinding[]
   if (!parsed.passed && parsed.findings.length > 0) {
     const durationMs = Date.now() - startTime;
     logger?.warn("review", `Semantic review failed: ${parsed.findings.length} findings`, {

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -9,6 +9,7 @@
 
 import { spawn } from "bun";
 import type { AgentAdapter } from "../agents/types";
+import type { NaxConfig } from "../config";
 import type { ModelTier } from "../config/schema-types";
 import { getSafeLogger } from "../logger";
 import type { ReviewFinding } from "../plugins/types";
@@ -234,6 +235,7 @@ export async function runSemanticReview(
   story: SemanticStory,
   semanticConfig: SemanticReviewConfig,
   modelResolver: ModelResolver,
+  naxConfig?: NaxConfig,
 ): Promise<ReviewCheckResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -250,7 +252,11 @@ export async function runSemanticReview(
     };
   }
 
-  logger?.info("review", "Running semantic check", { storyId: story.id, modelTier: semanticConfig.modelTier });
+  logger?.info("review", "Running semantic check", {
+    storyId: story.id,
+    modelTier: semanticConfig.modelTier,
+    configProvided: !!naxConfig,
+  });
 
   // Collect production-only diff (test files excluded at git level via configurable patterns)
   const rawDiff = await collectDiff(workdir, storyGitRef, semanticConfig.excludePatterns);
@@ -286,6 +292,8 @@ export async function runSemanticReview(
       sessionName: `nax-semantic-${story.id}`,
       workdir,
       timeoutMs: semanticConfig.timeoutMs,
+      modelTier: semanticConfig.modelTier,
+      config: naxConfig,
     });
   } catch (err) {
     logger?.warn("semantic", "LLM call failed — fail-open", { cause: String(err) });

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -15,6 +15,8 @@ export interface SemanticReviewConfig {
   rules: string[];
   /** Timeout in milliseconds for the LLM call (default: 600_000) */
   timeoutMs: number;
+  /** Git pathspec patterns to exclude from the semantic diff (e.g. ':!test/', ':!*.test.ts') */
+  excludePatterns: string[];
 }
 
 /** Review check result */

--- a/test/unit/agents/acp/adapter.test.ts
+++ b/test/unit/agents/acp/adapter.test.ts
@@ -263,6 +263,83 @@ describe("complete()", () => {
   });
 });
 
+// complete() — model resolution from config + modelTier
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("complete() — model resolution", () => {
+  const origCreateClient = _acpAdapterDeps.createClient;
+  const origSleep = _acpAdapterDeps.sleep;
+
+  beforeEach(() => {
+    _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
+  });
+
+  afterEach(() => {
+    _acpAdapterDeps.createClient = origCreateClient;
+    _acpAdapterDeps.sleep = origSleep;
+    mock.restore();
+  });
+
+  function makePassSession() {
+    const session = makeSession();
+    return makeClient(session);
+  }
+
+  test("uses 'default' when no model or config provided", async () => {
+    let capturedCmd = "";
+    const client = makePassSession();
+    _acpAdapterDeps.createClient = mock((cmd: string) => {
+      capturedCmd = cmd;
+      return client as unknown as ReturnType<typeof _acpAdapterDeps.createClient>;
+    });
+
+    await new AcpAgentAdapter("claude").complete("test");
+    expect(capturedCmd).toContain("--model default");
+  });
+
+  test("uses explicit model string when provided", async () => {
+    let capturedCmd = "";
+    const client = makePassSession();
+    _acpAdapterDeps.createClient = mock((cmd: string) => {
+      capturedCmd = cmd;
+      return client as unknown as ReturnType<typeof _acpAdapterDeps.createClient>;
+    });
+
+    await new AcpAgentAdapter("claude").complete("test", { model: "claude-haiku-4-5" });
+    expect(capturedCmd).toContain("--model claude-haiku-4-5");
+  });
+
+  test("resolves model from config.models[modelTier] when model not explicit", async () => {
+    let capturedCmd = "";
+    const client = makePassSession();
+    _acpAdapterDeps.createClient = mock((cmd: string) => {
+      capturedCmd = cmd;
+      return client as unknown as ReturnType<typeof _acpAdapterDeps.createClient>;
+    });
+
+    const naxConfig = {
+      models: { fast: "claude-haiku-4-5-20250514", balanced: "claude-sonnet-4-5-20250514" },
+    } as unknown as Parameters<AcpAgentAdapter["complete"]>[1]["config"];
+
+    await new AcpAgentAdapter("claude").complete("test", { modelTier: "fast", config: naxConfig });
+    expect(capturedCmd).toContain("--model claude-haiku-4-5-20250514");
+  });
+
+  test("falls back to 'default' when config has no matching tier", async () => {
+    let capturedCmd = "";
+    const client = makePassSession();
+    _acpAdapterDeps.createClient = mock((cmd: string) => {
+      capturedCmd = cmd;
+      return client as unknown as ReturnType<typeof _acpAdapterDeps.createClient>;
+    });
+
+    const naxConfig = { models: {} } as unknown as Parameters<AcpAgentAdapter["complete"]>[1]["config"];
+
+    await new AcpAgentAdapter("claude").complete("test", { modelTier: "powerful", config: naxConfig });
+    expect(capturedCmd).toContain("--model default");
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // _acpAdapterDeps — injectable dependency surface
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/config/semantic-review.test.ts
+++ b/test/unit/config/semantic-review.test.ts
@@ -52,6 +52,7 @@ describe("SemanticReviewConfig", () => {
       modelTier: "balanced",
       rules: [],
       timeoutMs: 600_000,
+      excludePatterns: [],
     };
     expect(config.modelTier).toBe("balanced");
     expect(typeof config.modelTier).toBe("string");
@@ -62,6 +63,7 @@ describe("SemanticReviewConfig", () => {
       modelTier: "balanced",
       rules: ["rule1", "rule2"],
       timeoutMs: 600_000,
+      excludePatterns: [],
     };
     expect(Array.isArray(config.rules)).toBe(true);
     expect(config.rules.every((r) => typeof r === "string")).toBe(true);
@@ -79,6 +81,7 @@ describe("SemanticReviewConfig", () => {
         modelTier: tier,
         rules: [],
         timeoutMs: 600_000,
+        excludePatterns: [],
       };
       expect(config.modelTier).toBe(tier);
     });
@@ -104,6 +107,7 @@ describe("ReviewConfig semantic field", () => {
         modelTier: "balanced",
         rules: [],
         timeoutMs: 600_000,
+        excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/"],
       });
     }
   });
@@ -212,11 +216,12 @@ describe("DEFAULT_CONFIG.review.semantic", () => {
     expect(DEFAULT_CONFIG.review.semantic?.rules).toEqual([]);
   });
 
-  test("DEFAULT_CONFIG.review.semantic equals { modelTier: 'balanced', rules: [], timeoutMs: 600_000 }", () => {
+  test("DEFAULT_CONFIG.review.semantic has correct defaults", () => {
     expect(DEFAULT_CONFIG.review.semantic).toEqual({
       modelTier: "balanced",
       rules: [],
       timeoutMs: 600_000,
+      excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/"],
     });
   });
 });

--- a/test/unit/precheck/checks-warnings.test.ts
+++ b/test/unit/precheck/checks-warnings.test.ts
@@ -124,7 +124,7 @@ function makeBugConfig(overrides: Partial<NaxConfig> = {}): NaxConfig {
     review: {
       checks: ["typecheck", "lint"],
       commands: {},
-      semantic: { enabled: false, rules: [], modelTier: "fast", timeoutMs: 600000 },
+      semantic: { enabled: false, rules: [], modelTier: "fast", timeoutMs: 600000, excludePatterns: [] },
     },
     quality: { commands: {} },
     ...overrides,
@@ -153,7 +153,7 @@ describe("checkBuildCommandInReviewChecks (BUG-092)", () => {
         review: {
           checks: ["typecheck", "lint"],
           commands: { build: "bun run build" },
-          semantic: { enabled: false, rules: [], modelTier: "fast", timeoutMs: 600000 },
+          semantic: { enabled: false, rules: [], modelTier: "fast", timeoutMs: 600000, excludePatterns: [] },
         },
       } as Partial<NaxConfig>),
     );
@@ -168,7 +168,7 @@ describe("checkBuildCommandInReviewChecks (BUG-092)", () => {
         review: {
           checks: ["typecheck", "lint", "build"],
           commands: {},
-          semantic: { enabled: false, rules: [], modelTier: "fast", timeoutMs: 600000 },
+          semantic: { enabled: false, rules: [], modelTier: "fast", timeoutMs: 600000, excludePatterns: [] },
         },
       } as Partial<NaxConfig>),
     );

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -483,6 +483,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
       expect.objectContaining({ id: "US-001", title: "My story", acceptanceCriteria: ["AC1"] }),
       expect.any(Object),
       mockResolver,
+      undefined,
     );
   });
 
@@ -512,6 +513,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
       expect.any(Object),
       { modelTier: "powerful", rules: ["no stubs"], timeoutMs: 600_000, excludePatterns: [":!test/"] },
       expect.any(Function),
+      undefined,
     );
   });
 });

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -501,7 +501,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
 
     const configWithSemantic: ReviewConfig = {
       ...semanticConfig,
-      semantic: { modelTier: "powerful", rules: ["no stubs"] },
+      semantic: { modelTier: "powerful", rules: ["no stubs"], timeoutMs: 600_000, excludePatterns: [":!test/"] },
     };
 
     await runReview(configWithSemantic, "/tmp/fake-workdir");
@@ -510,7 +510,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
       "/tmp/fake-workdir",
       undefined,
       expect.any(Object),
-      { modelTier: "powerful", rules: ["no stubs"] },
+      { modelTier: "powerful", rules: ["no stubs"], timeoutMs: 600_000, excludePatterns: [":!test/"] },
       expect.any(Function),
     );
   });

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -27,7 +27,7 @@ const STORY: SemanticStory = {
   acceptanceCriteria: ["ctx.reviewFindings is populated when semantic fails"],
 };
 
-const CFG: SemanticReviewConfig = { modelTier: "balanced", rules: [] };
+const CFG: SemanticReviewConfig = { modelTier: "balanced", rules: [], excludePatterns: [":!test/"] };
 
 function makeMockAgent(response: string): AgentAdapter {
   return {

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -1,12 +1,13 @@
 /**
  * Unit tests for src/review/semantic.ts
  *
- * Tests cover all acceptance criteria for US-002:
+ * Tests cover:
  * - runSemanticReview() signature and early-exit on missing git ref
- * - git diff collection and 12 KB truncation
- * - LLM prompt construction (title, description, ACs, default rules, custom rules, diff)
+ * - git diff collection (production code only — test files excluded)
+ * - Diff truncation at 50KB with stat preamble
+ * - LLM prompt construction (title, description, ACs, custom rules, diff)
  * - JSON response parsing (passed=true, passed=false with findings)
- * - Fail-open behaviour on invalid JSON
+ * - Fail-open / fail-closed behaviour on invalid JSON
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -32,6 +33,7 @@ const STORY: SemanticStory = {
 const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
   modelTier: "balanced",
   rules: [],
+  excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/"],
 };
 
 /** Build a mock AgentAdapter whose complete() resolves to the supplied JSON string */
@@ -190,7 +192,7 @@ describe("runSemanticReview — git diff invocation", () => {
     _semanticDeps.spawn = origSpawn;
   });
 
-  test("calls spawn with git diff --unified=3 <storyGitRef>..HEAD", async () => {
+  test("calls spawn with git diff --unified=3 <storyGitRef>..HEAD and test exclusions", async () => {
     const spawnMock = makeSpawnMock("diff output", 0);
     _semanticDeps.spawn = spawnMock;
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
@@ -204,6 +206,10 @@ describe("runSemanticReview — git diff invocation", () => {
     expect(spawnOpts.cmd).toContain("diff");
     expect(spawnOpts.cmd).toContain("--unified=3");
     expect(spawnOpts.cmd).toContain("abc123..HEAD");
+    // Test file exclusion pathspecs
+    expect(spawnOpts.cmd).toContain(":!test/");
+    expect(spawnOpts.cmd).toContain(":!*.test.ts");
+    expect(spawnOpts.cmd).toContain(":!*.spec.ts");
   });
 
   test("passes workdir as cwd to spawn", async () => {
@@ -220,7 +226,7 @@ describe("runSemanticReview — git diff invocation", () => {
 });
 
 // ---------------------------------------------------------------------------
-// AC-3: Diff truncation at 102400 bytes (100KB)
+// Diff truncation at 51200 bytes (50KB)
 // ---------------------------------------------------------------------------
 
 /** Spawn mock that returns different output for diff vs diff --stat */
@@ -257,7 +263,7 @@ describe("runSemanticReview — diff truncation", () => {
     _semanticDeps.spawn = origSpawn;
   });
 
-  test("passes full diff to LLM prompt when diff is under 102400 bytes", async () => {
+  test("passes full diff to LLM prompt when diff is under 51200 bytes", async () => {
     const smallDiff = "a".repeat(100);
     _semanticDeps.spawn = makeSpawnMock(smallDiff, 0);
     let capturedPrompt = "";
@@ -272,8 +278,8 @@ describe("runSemanticReview — diff truncation", () => {
     expect(capturedPrompt).toContain(smallDiff);
   });
 
-  test("truncates diff and appends truncation marker when diff exceeds 102400 bytes", async () => {
-    const largeDiff = "x".repeat(110_000);
+  test("truncates diff and appends truncation marker when diff exceeds 51200 bytes", async () => {
+    const largeDiff = "x".repeat(60_000);
     const statOutput = " src/foo.ts | 100 +\n src/bar.ts | 50 +\n 2 files changed";
     _semanticDeps.spawn = makeSpawnMockWithStat(largeDiff, statOutput, 0);
     let capturedPrompt = "";
@@ -285,14 +291,14 @@ describe("runSemanticReview — diff truncation", () => {
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
-    expect(capturedPrompt).toContain("truncated at 102400 bytes");
+    expect(capturedPrompt).toContain("truncated at 51200 bytes");
     // The diff in the prompt must not exceed the cap (plus stat preamble + marker overhead)
     const diffSection = capturedPrompt.match(/```diff\n([\s\S]*?)```/)?.[1] ?? "";
-    expect(diffSection.length).toBeLessThanOrEqual(102_400 + 500); // cap + stat preamble + marker
+    expect(diffSection.length).toBeLessThanOrEqual(51_200 + 500); // cap + stat preamble + marker
   });
 
   test("truncation includes file summary from git diff --stat", async () => {
-    const largeDiff = "y".repeat(110_000);
+    const largeDiff = "y".repeat(60_000);
     const statOutput = " src/foo.ts | 100 +\n src/bar.ts | 50 +\n 2 files changed";
     _semanticDeps.spawn = makeSpawnMockWithStat(largeDiff, statOutput, 0);
     let capturedPrompt = "";
@@ -359,22 +365,19 @@ describe("runSemanticReview — LLM prompt construction", () => {
     });
   });
 
-  test("prompt includes 5 default review rules", async () => {
+  test("prompt includes AC-focused review criteria", async () => {
     const prompt = await capturePrompt();
-    // These are the 5 known default rules
-    const expectedRules = ["stubs", "placeholder", "unrelated", "wiring", "error"];
-    let ruleCount = 0;
-    for (const keyword of expectedRules) {
-      if (prompt.toLowerCase().includes(keyword)) ruleCount++;
-    }
-    // At least 4 of 5 rule keywords must appear (some may be phrased differently)
-    expect(ruleCount).toBeGreaterThanOrEqual(4);
+    // The prompt should instruct the LLM to verify ACs, flag dead code, and check wiring
+    expect(prompt).toContain("acceptance criterion");
+    expect(prompt).toContain("dead paths");
+    expect(prompt).toContain("wired into callers");
   });
 
   test("prompt includes custom rules from semanticConfig.rules", async () => {
     const config: SemanticReviewConfig = {
       modelTier: "balanced",
       rules: ["Never use console.log", "All exports must be typed"],
+      excludePatterns: [":!test/"],
     };
     const prompt = await capturePrompt(STORY, config);
     expect(prompt).toContain("Never use console.log");
@@ -392,6 +395,13 @@ describe("runSemanticReview — LLM prompt construction", () => {
     const prompt = await capturePrompt(STORY, DEFAULT_SEMANTIC_CONFIG);
     // Should still work — just verifying no crash and prompt is well-formed
     expect(prompt.length).toBeGreaterThan(100);
+  });
+
+  test("prompt states diff is production code only", async () => {
+    const prompt = await capturePrompt();
+    expect(prompt).toContain("production code only");
+    expect(prompt).toContain("Do NOT flag");
+    expect(prompt).toContain("lint handles");
   });
 });
 


### PR DESCRIPTION
## What

Revise semantic review to be an AC-focused behavioral validator, with configurable language-agnostic test file exclusion.

## Why

Three problems identified during the PARALLEL-UNIFY-001 self-dev run:

1. **Test files reviewed as production code** — full diff including tests was sent to the LLM, which flagged test style issues (400-line limit, unused imports). These aren't AC violations, and autofix can't resolve them → death loop.

2. **DEFAULT_RULES overlap with lint** — 5 hardcoded code quality rules (no stubs, no placeholders, no silent error swallowing) duplicate what lint already checks. The guide says semantic review validates *behavior against ACs*.

3. **TS-specific assumptions** — hardcoded `*.test.ts` exclusions wouldn't work for Python (`tests/`, `*_test.py`), Go (`*_test.go`), Java (`src/test/`), etc.

4. **100KB diff cap → LLM output truncation** — large prompts cause the LLM to produce truncated JSON → fail-open.

Closes #111

## How

**`src/review/semantic.ts`:**
- Exclude test files at `git diff` level via `semanticConfig.excludePatterns` (configurable)
- Remove `DEFAULT_RULES` array — prompt now has 4 inline AC-focused criteria
- Rewrite prompt: verify each AC is implemented correctly, flag dead code and unwired exports
- Reduce `DIFF_CAP_BYTES` 100KB → 50KB (test exclusion = budget goes to production code)
- Remove redundant "No markdown fences" instruction (parser already strips them)
- Language-agnostic prompt (no `.ts` in examples)

**Config (`schema + defaults + types`):**
- New `review.semantic.excludePatterns: string[]` field
- Default: `[":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/"]`
- Users override for their language: Java `[":!src/test/"]`, Python `[":!*_test.py"]`, etc.
- Set to `[]` to include test files

**`docs/guides/semantic-review.md`:**
- New "What Semantic Review Checks" section (does/does NOT check)
- New "Test File Exclusion" section with config override examples
- Updated diff truncation (50KB), fail-open/fail-closed section

## Testing
- [x] Tests added/updated (11 files changed)
- [x] `bun test` passes (4732 pass, 60 skip, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
- ACP adapter `--model default` vs `modelTier` is a separate bug
- `git diff --stat` (truncation preamble) still shows all files including tests for context
