### PR TITLE
fix(semantic-review): persist storyGitRef in prd.json and add merge-base fallback (#114)

### DIFF
--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -13,8 +13,9 @@ import { runPipeline } from "../pipeline/runner";
 import type { PipelineRunResult } from "../pipeline/runner";
 import { defaultPipeline } from "../pipeline/stages";
 import type { PipelineContext } from "../pipeline/types";
+import { savePRD } from "../prd";
 import type { PRD } from "../prd/types";
-import { captureGitRef } from "../utils/git";
+import { captureGitRef, isGitRefValid } from "../utils/git";
 import { handleDryRun } from "./dry-run";
 import type { SequentialExecutionContext } from "./executor-types";
 import { handlePipelineFailure, handlePipelineSuccess } from "./pipeline-result-handler";
@@ -63,7 +64,21 @@ export async function runIteration(
   }
 
   const storyStartTime = Date.now();
-  const storyGitRef = await captureGitRef(ctx.workdir);
+
+  // BUG-114: Persist storyGitRef in prd.json so it survives crashes and restarts.
+  // On the first attempt we capture HEAD and save it. On resume we reuse the stored
+  // ref (after validating it still exists in git history), so semantic review always
+  // diffs from the true start of this story regardless of how many times nax restarted.
+  let storyGitRef: string | undefined;
+  if (story.storyGitRef && (await isGitRefValid(ctx.workdir, story.storyGitRef))) {
+    storyGitRef = story.storyGitRef;
+  } else {
+    storyGitRef = await captureGitRef(ctx.workdir);
+    if (storyGitRef) {
+      story.storyGitRef = storyGitRef;
+      await savePRD(prd, ctx.prdPath);
+    }
+  }
 
   // BUG-067: Accumulate cost from all prior failed attempts (stored in priorFailures by handleTierEscalation)
   const accumulatedAttemptCost = (story.priorFailures || []).reduce((sum, f) => sum + (f.cost || 0), 0);

--- a/src/prd/types.ts
+++ b/src/prd/types.ts
@@ -146,6 +146,13 @@ export interface UserStory {
    * Used to promote the parent from 'decomposed' → 'passed' once all sub-stories complete.
    */
   parentStoryId?: string;
+  /**
+   * Git SHA captured at the start of the first execution attempt for this story.
+   * Persisted to prd.json so that on resume/restart the semantic review diff
+   * covers the full range of commits made for this story (not just the new run).
+   * When absent, semantic review falls back to git merge-base with the default branch.
+   */
+  storyGitRef?: string;
 }
 
 // ============================================================================

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -13,6 +13,7 @@ import type { NaxConfig } from "../config";
 import type { ModelTier } from "../config/schema-types";
 import { getSafeLogger } from "../logger";
 import type { ReviewFinding } from "../plugins/types";
+import { getMergeBase, isGitRefValid } from "../utils/git";
 import type { ReviewCheckResult, SemanticReviewConfig } from "./types";
 
 /** Story fields required for semantic review */
@@ -29,6 +30,8 @@ export type ModelResolver = (tier: ModelTier) => AgentAdapter | null | undefined
 /** Injectable dependencies for semantic.ts — allows tests to mock spawn without mock.module() */
 export const _semanticDeps = {
   spawn: spawn as typeof spawn,
+  isGitRefValid,
+  getMergeBase,
 };
 
 /**
@@ -240,8 +243,27 @@ export async function runSemanticReview(
   const startTime = Date.now();
   const logger = getSafeLogger();
 
-  // Early exit when no git ref
-  if (!storyGitRef) {
+  // BUG-114: Resolve effective git ref for the diff range.
+  // Priority 1: use the supplied ref if valid (persisted from story start).
+  // Priority 2: fall back to merge-base with the default remote branch so that
+  //   the semantic reviewer always sees the full story diff even after a restart.
+  // Priority 3: skip review when no ref can be resolved (non-git workdir, etc.).
+  let effectiveRef: string | undefined;
+  if (storyGitRef && (await _semanticDeps.isGitRefValid(workdir, storyGitRef))) {
+    effectiveRef = storyGitRef;
+  } else {
+    const fallback = await _semanticDeps.getMergeBase(workdir);
+    if (fallback) {
+      logger?.info("review", "storyGitRef missing or invalid — using merge-base fallback", {
+        storyId: story.id,
+        storyGitRef,
+        fallback,
+      });
+      effectiveRef = fallback;
+    }
+  }
+
+  if (!effectiveRef) {
     return {
       check: "semantic",
       success: true,
@@ -259,11 +281,11 @@ export async function runSemanticReview(
   });
 
   // Collect production-only diff (test files excluded at git level via configurable patterns)
-  const rawDiff = await collectDiff(workdir, storyGitRef, semanticConfig.excludePatterns);
+  const rawDiff = await collectDiff(workdir, effectiveRef, semanticConfig.excludePatterns);
 
   // Truncate if over cap — collect stat summary (all files) when truncation needed
   const needsTruncation = rawDiff.length > DIFF_CAP_BYTES;
-  const stat = needsTruncation ? await collectDiffStat(workdir, storyGitRef) : undefined;
+  const stat = needsTruncation ? await collectDiffStat(workdir, effectiveRef) : undefined;
   const diff = truncateDiff(rawDiff, stat);
 
   // Resolve agent

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -83,6 +83,54 @@ export async function captureGitRef(workdir: string): Promise<string | undefined
 }
 
 /**
+ * Verify that a git ref (SHA or branch name) is reachable in the given workdir.
+ * Used to validate a persisted storyGitRef before using it in a diff range.
+ *
+ * @returns true if the ref resolves successfully, false otherwise
+ */
+export async function isGitRefValid(workdir: string, ref: string): Promise<boolean> {
+  try {
+    const { exitCode } = await gitWithTimeout(["cat-file", "-e", `${ref}^{commit}`], workdir);
+    return exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Return the merge-base SHA between HEAD and the default remote branch.
+ * Tries `origin/main` first, then `origin/master`.
+ * Falls back to the oldest reachable commit when no remote branch exists.
+ *
+ * Used as a fallback for storyGitRef when the stored ref is missing or invalid
+ * (e.g. after a rebase, or on a brand-new run where no ref was persisted yet).
+ */
+export async function getMergeBase(workdir: string): Promise<string | undefined> {
+  for (const branch of ["origin/main", "origin/master"]) {
+    try {
+      const { stdout, exitCode } = await gitWithTimeout(["merge-base", "HEAD", branch], workdir);
+      if (exitCode === 0) {
+        const sha = stdout.trim();
+        if (sha) return sha;
+      }
+    } catch {
+      // try next branch
+    }
+  }
+  // Last resort: oldest ancestor (initial commit)
+  try {
+    const { stdout, exitCode } = await gitWithTimeout(["rev-list", "--max-parents=0", "HEAD"], workdir);
+    if (exitCode === 0) {
+      const sha = stdout.trim().split("\n")[0];
+      if (sha) return sha;
+    }
+  } catch {
+    // ignore
+  }
+  return undefined;
+}
+
+/**
  * Check if a story ID appears in recent git commit messages.
  *
  * Searches the last N commits for commit messages containing the story ID.

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -61,9 +61,21 @@ function makeSpawnMock(stdout = "diff output", exitCode = 0) {
 
 describe("runSemanticReview — structured findings in result (US-003 AC-2)", () => {
   let origSpawn: typeof _semanticDeps.spawn;
+  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
+  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
 
-  beforeEach(() => { origSpawn = _semanticDeps.spawn; });
-  afterEach(() => { _semanticDeps.spawn = origSpawn; });
+  beforeEach(() => {
+    origSpawn = _semanticDeps.spawn;
+    origIsGitRefValid = _semanticDeps.isGitRefValid;
+    origGetMergeBase = _semanticDeps.getMergeBase;
+    _semanticDeps.isGitRefValid = mock(async () => true);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
+  });
+  afterEach(() => {
+    _semanticDeps.spawn = origSpawn;
+    _semanticDeps.isGitRefValid = origIsGitRefValid;
+    _semanticDeps.getMergeBase = origGetMergeBase;
+  });
 
   test("result.findings is defined and non-empty when LLM returns passed=false with findings", async () => {
     _semanticDeps.spawn = makeSpawnMock("some diff");

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -114,13 +114,22 @@ describe("runSemanticReview — signature", () => {
 
 describe("runSemanticReview — missing storyGitRef", () => {
   let origSpawn: typeof _semanticDeps.spawn;
+  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
+  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
 
   beforeEach(() => {
     origSpawn = _semanticDeps.spawn;
+    origIsGitRefValid = _semanticDeps.isGitRefValid;
+    origGetMergeBase = _semanticDeps.getMergeBase;
+    // No valid ref — getMergeBase also returns undefined so review is skipped
+    _semanticDeps.isGitRefValid = mock(async () => false);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
     _semanticDeps.spawn = origSpawn;
+    _semanticDeps.isGitRefValid = origIsGitRefValid;
+    _semanticDeps.getMergeBase = origGetMergeBase;
   });
 
   test("returns success=true when storyGitRef is undefined", async () => {
@@ -183,13 +192,22 @@ describe("runSemanticReview — missing storyGitRef", () => {
 
 describe("runSemanticReview — git diff invocation", () => {
   let origSpawn: typeof _semanticDeps.spawn;
+  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
+  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
 
   beforeEach(() => {
     origSpawn = _semanticDeps.spawn;
+    origIsGitRefValid = _semanticDeps.isGitRefValid;
+    origGetMergeBase = _semanticDeps.getMergeBase;
+    // Mark supplied storyGitRef as valid so tests proceed without a real git repo
+    _semanticDeps.isGitRefValid = mock(async () => true);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
     _semanticDeps.spawn = origSpawn;
+    _semanticDeps.isGitRefValid = origIsGitRefValid;
+    _semanticDeps.getMergeBase = origGetMergeBase;
   });
 
   test("calls spawn with git diff --unified=3 <storyGitRef>..HEAD and test exclusions", async () => {
@@ -254,13 +272,22 @@ function makeSpawnMockWithStat(diffStdout: string, statStdout: string, exitCode 
 
 describe("runSemanticReview — diff truncation", () => {
   let origSpawn: typeof _semanticDeps.spawn;
+  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
+  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
 
   beforeEach(() => {
     origSpawn = _semanticDeps.spawn;
+    origIsGitRefValid = _semanticDeps.isGitRefValid;
+    origGetMergeBase = _semanticDeps.getMergeBase;
+    // Mark supplied storyGitRef as valid so tests proceed without a real git repo
+    _semanticDeps.isGitRefValid = mock(async () => true);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
     _semanticDeps.spawn = origSpawn;
+    _semanticDeps.isGitRefValid = origIsGitRefValid;
+    _semanticDeps.getMergeBase = origGetMergeBase;
   });
 
   test("passes full diff to LLM prompt when diff is under 51200 bytes", async () => {
@@ -322,13 +349,22 @@ describe("runSemanticReview — diff truncation", () => {
 
 describe("runSemanticReview — LLM prompt construction", () => {
   let origSpawn: typeof _semanticDeps.spawn;
+  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
+  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
 
   beforeEach(() => {
     origSpawn = _semanticDeps.spawn;
+    origIsGitRefValid = _semanticDeps.isGitRefValid;
+    origGetMergeBase = _semanticDeps.getMergeBase;
+    // Mark supplied storyGitRef as valid so tests proceed without a real git repo
+    _semanticDeps.isGitRefValid = mock(async () => true);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
     _semanticDeps.spawn = origSpawn;
+    _semanticDeps.isGitRefValid = origIsGitRefValid;
+    _semanticDeps.getMergeBase = origGetMergeBase;
   });
 
   async function capturePrompt(
@@ -411,13 +447,22 @@ describe("runSemanticReview — LLM prompt construction", () => {
 
 describe("runSemanticReview — LLM response parsing (passed=false)", () => {
   let origSpawn: typeof _semanticDeps.spawn;
+  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
+  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
 
   beforeEach(() => {
     origSpawn = _semanticDeps.spawn;
+    origIsGitRefValid = _semanticDeps.isGitRefValid;
+    origGetMergeBase = _semanticDeps.getMergeBase;
+    // Mark supplied storyGitRef as valid so tests proceed without a real git repo
+    _semanticDeps.isGitRefValid = mock(async () => true);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
     _semanticDeps.spawn = origSpawn;
+    _semanticDeps.isGitRefValid = origIsGitRefValid;
+    _semanticDeps.getMergeBase = origGetMergeBase;
   });
 
   test("returns success=false when LLM returns passed=false", async () => {
@@ -509,13 +554,22 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
 
 describe("runSemanticReview — fail-open on invalid JSON", () => {
   let origSpawn: typeof _semanticDeps.spawn;
+  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
+  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
 
   beforeEach(() => {
     origSpawn = _semanticDeps.spawn;
+    origIsGitRefValid = _semanticDeps.isGitRefValid;
+    origGetMergeBase = _semanticDeps.getMergeBase;
+    // Mark supplied storyGitRef as valid so tests proceed without a real git repo
+    _semanticDeps.isGitRefValid = mock(async () => true);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
     _semanticDeps.spawn = origSpawn;
+    _semanticDeps.isGitRefValid = origIsGitRefValid;
+    _semanticDeps.getMergeBase = origGetMergeBase;
   });
 
   test("returns success=true when LLM returns invalid JSON", async () => {
@@ -560,13 +614,22 @@ describe("runSemanticReview — fail-open on invalid JSON", () => {
 
 describe("runSemanticReview — fail-closed on truncated JSON with passed:false (#105)", () => {
   let origSpawn: typeof _semanticDeps.spawn;
+  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
+  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
 
   beforeEach(() => {
     origSpawn = _semanticDeps.spawn;
+    origIsGitRefValid = _semanticDeps.isGitRefValid;
+    origGetMergeBase = _semanticDeps.getMergeBase;
+    // Mark supplied storyGitRef as valid so tests proceed without a real git repo
+    _semanticDeps.isGitRefValid = mock(async () => true);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
     _semanticDeps.spawn = origSpawn;
+    _semanticDeps.isGitRefValid = origIsGitRefValid;
+    _semanticDeps.getMergeBase = origGetMergeBase;
   });
 
   test("returns success=false when truncated JSON contains passed:false", async () => {
@@ -607,13 +670,22 @@ describe("runSemanticReview — fail-closed on truncated JSON with passed:false 
 
 describe("runSemanticReview — markdown fence stripping (BUG-090)", () => {
   let origSpawn: typeof _semanticDeps.spawn;
+  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
+  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
 
   beforeEach(() => {
     origSpawn = _semanticDeps.spawn;
+    origIsGitRefValid = _semanticDeps.isGitRefValid;
+    origGetMergeBase = _semanticDeps.getMergeBase;
+    // Mark supplied storyGitRef as valid so tests proceed without a real git repo
+    _semanticDeps.isGitRefValid = mock(async () => true);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
     _semanticDeps.spawn = origSpawn;
+    _semanticDeps.isGitRefValid = origIsGitRefValid;
+    _semanticDeps.getMergeBase = origGetMergeBase;
   });
 
   test("parses JSON wrapped in ```json fences", async () => {
@@ -650,5 +722,97 @@ describe("runSemanticReview — markdown fence stripping (BUG-090)", () => {
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
     expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BUG-114: storyGitRef fallback — merge-base when ref is missing or invalid
+// ---------------------------------------------------------------------------
+
+describe("runSemanticReview — BUG-114 storyGitRef fallback (merge-base)", () => {
+  let origSpawn: typeof _semanticDeps.spawn;
+  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
+  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+
+  beforeEach(() => {
+    origSpawn = _semanticDeps.spawn;
+    origIsGitRefValid = _semanticDeps.isGitRefValid;
+    origGetMergeBase = _semanticDeps.getMergeBase;
+  });
+
+  afterEach(() => {
+    _semanticDeps.spawn = origSpawn;
+    _semanticDeps.isGitRefValid = origIsGitRefValid;
+    _semanticDeps.getMergeBase = origGetMergeBase;
+  });
+
+  test("uses effectiveRef = storyGitRef when ref is valid", async () => {
+    const spawnMock = makeSpawnMock("diff content", 0);
+    _semanticDeps.spawn = spawnMock;
+    _semanticDeps.isGitRefValid = mock(async () => true);
+    _semanticDeps.getMergeBase = mock(async () => "merge-base-sha");
+    const agent = makeMockAgent(PASSING_LLM_RESPONSE);
+
+    await runSemanticReview("/tmp/wd", "valid-sha", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    expect(spawnMock).toHaveBeenCalled();
+    const call = (spawnMock as ReturnType<typeof mock>).mock.calls[0];
+    const spawnOpts = call[0] as { cmd: string[] };
+    // Should use the valid storyGitRef, not the merge-base
+    expect(spawnOpts.cmd).toContain("valid-sha..HEAD");
+    expect(_semanticDeps.getMergeBase).not.toHaveBeenCalled();
+  });
+
+  test("falls back to merge-base when storyGitRef is undefined", async () => {
+    const spawnMock = makeSpawnMock("diff content", 0);
+    _semanticDeps.spawn = spawnMock;
+    _semanticDeps.isGitRefValid = mock(async () => false);
+    _semanticDeps.getMergeBase = mock(async () => "abc-merge-base");
+    const agent = makeMockAgent(PASSING_LLM_RESPONSE);
+
+    await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    expect(spawnMock).toHaveBeenCalled();
+    const call = (spawnMock as ReturnType<typeof mock>).mock.calls[0];
+    const spawnOpts = call[0] as { cmd: string[] };
+    expect(spawnOpts.cmd).toContain("abc-merge-base..HEAD");
+  });
+
+  test("falls back to merge-base when storyGitRef is invalid (e.g. after rebase)", async () => {
+    const spawnMock = makeSpawnMock("diff content", 0);
+    _semanticDeps.spawn = spawnMock;
+    _semanticDeps.isGitRefValid = mock(async () => false);
+    _semanticDeps.getMergeBase = mock(async () => "fallback-merge-base-sha");
+    const agent = makeMockAgent(PASSING_LLM_RESPONSE);
+
+    await runSemanticReview("/tmp/wd", "stale-sha-after-rebase", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    expect(spawnMock).toHaveBeenCalled();
+    const call = (spawnMock as ReturnType<typeof mock>).mock.calls[0];
+    const spawnOpts = call[0] as { cmd: string[] };
+    expect(spawnOpts.cmd).toContain("fallback-merge-base-sha..HEAD");
+    expect(_semanticDeps.isGitRefValid).toHaveBeenCalledWith("/tmp/wd", "stale-sha-after-rebase");
+  });
+
+  test("skips review (success=true) when storyGitRef is undefined and merge-base is also unavailable", async () => {
+    _semanticDeps.spawn = makeSpawnMock("", 0);
+    _semanticDeps.isGitRefValid = mock(async () => false);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
+
+    const result = await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, () => null);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("skipped: no git ref");
+  });
+
+  test("skips review (success=true) when storyGitRef is invalid and merge-base is also unavailable", async () => {
+    _semanticDeps.spawn = makeSpawnMock("", 0);
+    _semanticDeps.isGitRefValid = mock(async () => false);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
+
+    const result = await runSemanticReview("/tmp/wd", "bad-sha", STORY, DEFAULT_SEMANTIC_CONFIG, () => null);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("skipped: no git ref");
   });
 });


### PR DESCRIPTION
## What

Fixes a crash-resume bug in semantic review where the git diff for a story was empty after a run restart, causing false AC violations.

**Root cause:** `captureGitRef()` in `iteration-runner.ts` snapshots `HEAD` at the start of each run. When nax is restarted (crash or manual stop+relaunch), the new `storyGitRef` points to a commit AFTER the previous run's implementation work. The semantic review diff (`storyGitRef..HEAD`) then only shows incremental config changes, missing the actual implementation.

## Why

Without this fix, semantic review fails with false "AC not implemented" errors whenever a story resumes after a crash or manual restart. The implementation existed — it was just committed before the restart, and the new run captured a different HEAD.

Fixes #114

## How

**Persist `storyGitRef` in prd.json** — the git SHA is now captured on the first story attempt and stored in `story.storyGitRef`. On resume, we reuse the stored ref (validated with `isGitRefValid`) so semantic review always diffs from the true start of this story's work.

**Merge-base fallback** — if the stored ref is missing or invalid (e.g. after a rebase), `runSemanticReview` falls back to `git merge-base origin/main HEAD`. This ensures the reviewer always sees some diff rather than silently skipping.

**Changes:**
- `src/prd/types.ts` — added `storyGitRef?: string` to `UserStory`
- `src/utils/git.ts` — added `isGitRefValid()` and `getMergeBase()` utilities
- `src/execution/iteration-runner.ts` — reuse stored ref on resume; persist to prd.json on first capture
- `src/review/semantic.ts` — resolve effective git ref: valid stored ref → merge-base fallback → skip
- Git helpers made injectable via `_semanticDeps` for unit testing

## Testing

- [x] Tests added/updated — 5 new BUG-114 tests in `semantic.test.ts`
- [x] `bun test` passes (4758 pass, 60 skip, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- `storyGitRef` field is optional (backward compatible — absent = use merge-base fallback)
- No schema migration needed (prd.json is read/write by nax, not external consumers)
- The merge-base fallback means semantic review on a freshly branched feature will diff from merge-base (correct behaviour — full feature diff from branch point)
