### PR TITLE
fix(parallel): prevent acp-sessions.json merge conflicts via .git/info/exclude (#121)

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -9,6 +9,7 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { globalConfigDir, projectConfigDir } from "../config/paths";
 import { getLogger } from "../logger";
+import { NAX_GITIGNORE_ENTRIES } from "../utils/gitignore";
 import { initContext, initPackage } from "./init-context";
 import { buildInitConfig, detectStack } from "./init-detect";
 import type { ProjectStack } from "./init-detect";
@@ -34,26 +35,6 @@ export interface InitProjectOptions {
   /** Force overwrite of existing files */
   force?: boolean;
 }
-
-/**
- * Gitignore entries added by nax init
- */
-const NAX_GITIGNORE_ENTRIES = [
-  ".nax-verifier-verdict.json",
-  "nax.lock",
-  ".nax/**/runs/",
-  ".nax/metrics.json",
-  ".nax/features/*/status.json",
-  ".nax/features/*/plan/",
-  ".nax/features/*/acp-sessions.json",
-  ".nax/features/*/interactions/",
-  ".nax/features/*/progress.txt",
-  ".nax/features/*/acceptance-refined.json",
-  ".nax-pids",
-  ".nax-wt/",
-  "**/.nax-acceptance*",
-  "**/.nax/features/*/",
-];
 
 /**
  * Add nax-specific entries to .gitignore if not already present.

--- a/src/execution/parallel-coordinator.ts
+++ b/src/execution/parallel-coordinator.ts
@@ -122,6 +122,12 @@ export async function executeParallel(
       interaction: interactionChain ?? undefined,
     };
 
+    // #121: Ensure nax runtime files (acp-sessions.json, etc.) are excluded from
+    // git across all worktrees. Writes to .git/info/exclude — never committed.
+    // Must run before any worktrees are created so the exclude rules are in place
+    // when each story's auto-commit runs.
+    await worktreeManager.ensureGitExcludes(projectRoot);
+
     // Create worktrees for all stories in batch
     const worktreePaths = new Map<string, string>();
 

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared nax gitignore entries — runtime files that must never be committed.
+ *
+ * Used by:
+ *  - `nax init` → appends to project .gitignore
+ *  - `WorktreeManager.ensureGitExcludes()` → writes to .git/info/exclude (no commit, all worktrees)
+ */
+export const NAX_GITIGNORE_ENTRIES = [
+  ".nax-verifier-verdict.json",
+  "nax.lock",
+  ".nax/**/runs/",
+  ".nax/metrics.json",
+  ".nax/features/*/status.json",
+  ".nax/features/*/plan/",
+  ".nax/features/*/acp-sessions.json",
+  ".nax/features/*/interactions/",
+  ".nax/features/*/progress.txt",
+  ".nax/features/*/acceptance-refined.json",
+  ".nax-pids",
+  ".nax-wt/",
+  "**/.nax-acceptance*",
+  "**/.nax/features/*/",
+];

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -1,9 +1,11 @@
 import { existsSync, symlinkSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { getSafeLogger } from "../logger";
 import { validateStoryId } from "../prd/validate";
 import { spawn } from "../utils/bun-deps";
 import { errorMessage } from "../utils/errors";
+import { NAX_GITIGNORE_ENTRIES } from "../utils/gitignore";
 import type { WorktreeInfo } from "./types";
 
 /** Injectable deps for testability — mock _managerDeps.spawn instead of global Bun.spawn */
@@ -12,6 +14,48 @@ export const _managerDeps = {
 };
 
 export class WorktreeManager {
+  /**
+   * Ensures nax runtime files are excluded from git in all worktrees by writing
+   * to .git/info/exclude — which is never committed and applies across all linked
+   * worktrees sharing this repo.
+   *
+   * This prevents acp-sessions.json and other nax runtime files from being
+   * committed in parallel story worktrees, which causes merge conflicts even when
+   * the actual implementation files don't overlap.
+   *
+   * Call once before creating worktrees for a parallel batch.
+   */
+  async ensureGitExcludes(projectRoot: string): Promise<void> {
+    const logger = getSafeLogger();
+    const infoDir = join(projectRoot, ".git", "info");
+    const excludePath = join(infoDir, "exclude");
+
+    try {
+      await mkdir(infoDir, { recursive: true });
+
+      let existing = "";
+      if (existsSync(excludePath)) {
+        existing = await Bun.file(excludePath).text();
+      }
+
+      const missing = NAX_GITIGNORE_ENTRIES.filter((entry) => !existing.includes(entry));
+      if (missing.length === 0) return;
+
+      const section = `\n# nax — generated files (auto-added by nax parallel)\n${missing.join("\n")}\n`;
+      await Bun.write(excludePath, existing + section);
+
+      logger?.info("worktree", "Updated .git/info/exclude with nax entries", {
+        added: missing.length,
+      });
+    } catch (error) {
+      // Non-fatal — log warning and continue. Worktrees may still get conflicts
+      // if the project's .gitignore is also missing these entries.
+      logger?.warn("worktree", "Failed to update .git/info/exclude", {
+        error: errorMessage(error),
+      });
+    }
+  }
+
   /**
    * Creates a git worktree at .nax-wt/<storyId>/ with branch nax/<storyId>
    * and symlinks node_modules and .env from project root

--- a/test/integration/worktree/manager.test.ts
+++ b/test/integration/worktree/manager.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { WorktreeManager } from "../../../src/worktree/manager";
+import { NAX_GITIGNORE_ENTRIES } from "../../../src/utils/gitignore";
 import { makeTempDir } from "../../helpers/temp";
 
 describe("WorktreeManager", () => {
@@ -179,6 +179,77 @@ describe("WorktreeManager", () => {
       await expect(manager.remove(projectRoot, storyId)).rejects.toThrow(
         /not found|does not exist|no such worktree|worktree not found/i,
       );
+    });
+  });
+
+  describe("ensureGitExcludes", () => {
+    test("writes nax entries to .git/info/exclude", async () => {
+      const manager = new WorktreeManager();
+
+      await manager.ensureGitExcludes(projectRoot);
+
+      const excludePath = join(projectRoot, ".git", "info", "exclude");
+      expect(existsSync(excludePath)).toBe(true);
+
+      const content = await Bun.file(excludePath).text();
+      expect(content).toContain(".nax/features/*/acp-sessions.json");
+      expect(content).toContain("nax.lock");
+      expect(content).toContain(".nax-wt/");
+    });
+
+    test("is idempotent — does not duplicate entries on repeated calls", async () => {
+      const manager = new WorktreeManager();
+
+      await manager.ensureGitExcludes(projectRoot);
+      await manager.ensureGitExcludes(projectRoot);
+
+      const excludePath = join(projectRoot, ".git", "info", "exclude");
+      const content = await Bun.file(excludePath).text();
+
+      // Count occurrences of a known entry — must appear exactly once
+      const occurrences = content.split(".nax/features/*/acp-sessions.json").length - 1;
+      expect(occurrences).toBe(1);
+    });
+
+    test("creates .git/info/ directory if it does not exist", async () => {
+      const manager = new WorktreeManager();
+
+      const infoDir = join(projectRoot, ".git", "info");
+      rmSync(infoDir, { recursive: true, force: true });
+      expect(existsSync(infoDir)).toBe(false);
+
+      await manager.ensureGitExcludes(projectRoot);
+
+      expect(existsSync(join(infoDir, "exclude"))).toBe(true);
+    });
+
+    test("preserves existing content in exclude file", async () => {
+      const manager = new WorktreeManager();
+
+      const infoDir = join(projectRoot, ".git", "info");
+      mkdirSync(infoDir, { recursive: true });
+      const excludePath = join(infoDir, "exclude");
+      writeFileSync(excludePath, "# existing user rule\n*.log\n");
+
+      await manager.ensureGitExcludes(projectRoot);
+
+      const content = await Bun.file(excludePath).text();
+      expect(content).toContain("# existing user rule");
+      expect(content).toContain("*.log");
+      expect(content).toContain(".nax/features/*/acp-sessions.json");
+    });
+
+    test("all NAX_GITIGNORE_ENTRIES are written to exclude", async () => {
+      const manager = new WorktreeManager();
+
+      await manager.ensureGitExcludes(projectRoot);
+
+      const excludePath = join(projectRoot, ".git", "info", "exclude");
+      const content = await Bun.file(excludePath).text();
+
+      for (const entry of NAX_GITIGNORE_ENTRIES) {
+        expect(content).toContain(entry);
+      }
     });
   });
 


### PR DESCRIPTION
## What
Prevents `acp-sessions.json` from causing merge conflicts when running stories in parallel.

## Why
When nax runs stories in parallel, each story executes in its own git worktree branched from the same base commit. The ACP adapter writes `.nax/features/<feature>/acp-sessions.json` and it gets committed via auto-commit. Since all worktrees branch from the same point and all modify the same path, only the first story to merge succeeds — the remaining 3 all conflict on `acp-sessions.json`, even when their actual implementation files have zero overlap.

Closes #121

## How
Introduces `WorktreeManager.ensureGitExcludes(projectRoot)`, called once in `parallel-coordinator.ts` before any worktrees are created. It writes all `NAX_GITIGNORE_ENTRIES` to `.git/info/exclude` — a file that:
- Is **never committed** to git
- Applies **across all linked worktrees** sharing the repository
- Is **idempotent** (safe to call multiple times)
- Is **non-fatal** on error (logs warning, continues)

`NAX_GITIGNORE_ENTRIES` is extracted from `src/cli/init.ts` into a shared `src/utils/gitignore.ts` module so both `nax init` and `WorktreeManager` use the same authoritative list.

## Testing
- [x] 5 new integration tests for `ensureGitExcludes` (idempotent, preserves existing, creates dir, all entries written)
- [x] All existing worktree manager tests pass (16 total)
- [x] `bun test test/integration/` — 1187 pass, 40 skip, 0 fail
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
The only test failures in `bun test test/unit/` are 3 pre-existing flaky `WebhookInteractionPlugin` tests that fail due to port conflicts when run in the full suite (pass in isolation — confirmed on `main` branch before these changes).
