### PR TITLE
chore: release v0.54.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.54.10",
+  "version": "0.54.11",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What
Fix `WorktreeManager.create()` to handle orphaned git worktrees gracefully when running parallel stories.

## Why
When a previous parallel run crashes or is killed, git retains orphaned worktree references even after the `.nax-wt/<storyId>/` directories are deleted. A subsequent run then throws "Worktree already exists" and fails immediately, blocking all parallel execution until manual `git worktree prune` is run.

Closes #126.

## How
- `WorktreeManager.create()` now calls `remove()` before creating to clean up any stale worktree/branch for that storyId first
- Updated the test that expected "already exists" to throw — it now verifies that duplicate `create()` calls succeed by replacing the old worktree cleanly

## Testing
- [x] `WorktreeManager.create()` test updated — 24 pass, 0 fail
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] CI: 26s, all green

## Notes
Fixes BUG-121 regression introduced in v0.54.9.
