### PR TITLE
fix(worktree): use git worktree prune + branch -D for orphaned cleanup

### DIFF
--- a/src/execution/parallel-batch.ts
+++ b/src/execution/parallel-batch.ts
@@ -114,12 +114,21 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
 
   // 1. Create worktree manager and worktrees for each story
   // Record per-story start time at worktree creation (AC-2: worktree creation → merge completion)
+  const logger = getSafeLogger();
   const worktreeManager = await _parallelBatchDeps.createWorktreeManager();
   const worktreePaths = new Map<string, string>();
   const storyStartTimes = new Map<string, number>();
   for (const story of stories) {
     storyStartTimes.set(story.id, Date.now());
-    await worktreeManager.create(workdir, story.id);
+    try {
+      await worktreeManager.create(workdir, story.id);
+    } catch (error) {
+      logger?.error("parallel-batch", "Failed to create worktree for story", {
+        storyId: story.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
     worktreePaths.set(story.id, path.join(workdir, ".nax-wt", story.id));
   }
 

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -69,13 +69,40 @@ export class WorktreeManager {
     const worktreePath = join(projectRoot, ".nax-wt", storyId);
     const branchName = `nax/${storyId}`;
 
-    // Clean up any stale worktree/branch from a previous crashed run before creating.
-    // This handles the case where git still has a worktree reference (orphaned after
-    // a crash) but the directory was deleted, causing "already exists" errors.
+    // Clean up any stale worktree/branch from a previous crashed run.
+    // Three cleanup steps handle all orphaned-worktree scenarios:
+    // 1. `git worktree prune` — removes admin refs whose directories no longer exist
+    // 2. `git worktree remove --force` — removes worktree if directory still exists
+    // 3. `git branch -D` — removes leftover branch so `-b` flag doesn't conflict
     try {
+      // Step 1: Prune orphaned worktree references (dir deleted but .git/worktrees/ entry remains)
+      const pruneProc = _managerDeps.spawn(["git", "worktree", "prune"], {
+        cwd: projectRoot,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      await pruneProc.exited;
+    } catch {
+      // prune is best-effort
+    }
+
+    try {
+      // Step 2: Remove worktree if it still exists as a live worktree
       await this.remove(projectRoot, storyId);
     } catch {
-      // remove() throws if worktree doesn't exist — that's fine, we just want a clean slate
+      // remove() throws if worktree doesn't exist — that's fine
+    }
+
+    try {
+      // Step 3: Delete orphaned branch (may exist even after worktree is gone)
+      const branchProc = _managerDeps.spawn(["git", "branch", "-D", branchName], {
+        cwd: projectRoot,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      await branchProc.exited;
+    } catch {
+      // branch may not exist — that's fine
     }
 
     try {


### PR DESCRIPTION
## What
Proper fix for orphaned worktree cleanup in parallel mode.

## Why
The v0.54.11 fix (#125) called `remove()` before `create()`, but `remove()` uses `git worktree remove <path> --force` which **fails when the worktree directory has been deleted but git admin refs (`.git/worktrees/`) remain**. The branch `nax/<storyId>` also survives, causing `git worktree add -b` to fail.

The error was silently swallowed because `runParallelBatch` had no error logging around worktree creation, causing the parallel run to exit without any error message in the JSONL log.

Closes #126.

## How
Three-step cleanup in `WorktreeManager.create()`:
1. **`git worktree prune`** — cleans orphaned admin refs (directory gone but `.git/worktrees/` entry remains)
2. **`git worktree remove --force`** — removes live worktrees (directory still exists)
3. **`git branch -D`** — removes leftover branch so `-b` flag doesn't conflict

Also added error logging in `parallel-batch.ts` worktree creation loop so any future worktree errors are properly logged instead of silently swallowed.

## Testing
- [x] Tests added/updated (24 pass, 0 fail)
- [x] `bun test` passes (758 pass in execution suite)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
The parallel log showed NO error message — the process just exited silently after `getAllReadyStories`. The added logging in `parallel-batch.ts` ensures this class of error is always visible in future.
