### PR TITLE
fix(parallel): storyGitRef missing, storiesCompleted=0, semantic JSON fail-open (#129 #130 #131)

### DIFF
--- a/src/execution/parallel-batch.ts
+++ b/src/execution/parallel-batch.ts
@@ -145,10 +145,44 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
   // Batch execution complete — record end time for stories resolved in the batch
   const batchEndMs = Date.now();
 
-  // 3. Completed = stories merged to base.
-  // Note: we use workerResult.merged (stories that were actually merged to the base branch),
-  // NOT workerResult.pipelinePassed (stories that passed tests but may not have merged yet).
-  const completed: UserStory[] = workerResult.merged;
+  // 3. Merge pipeline-passed stories into the base branch in topological order.
+  // parallel-worker.ts only populates pipelinePassed (pipeline success) and merged=[].
+  // We must call mergeEngine.mergeAll here so that worktree branches are integrated
+  // into the project root before acceptance/regression stages run.
+  const completed: UserStory[] = [];
+  if (workerResult.pipelinePassed.length > 0) {
+    const mergeEngine = await _parallelBatchDeps.createMergeEngine(worktreeManager);
+    const successfulIds = workerResult.pipelinePassed.map((s) => s.id);
+    // Build dependency map for topological merge ordering
+    const deps: Record<string, string[]> = {};
+    for (const s of stories) deps[s.id] = s.dependencies ?? [];
+
+    const mergeResults = await mergeEngine.mergeAll(workdir, successfulIds, deps);
+
+    for (const mergeResult of mergeResults) {
+      const story = workerResult.pipelinePassed.find((s) => s.id === mergeResult.storyId);
+      if (!story) continue;
+
+      if (mergeResult.success) {
+        completed.push(story);
+        workerResult.merged.push(story);
+        logger?.info("parallel-batch", "Story merged successfully", {
+          storyId: mergeResult.storyId,
+        });
+      } else {
+        // Merge conflict — move to mergeConflicts for rectification below
+        workerResult.mergeConflicts.push({
+          storyId: mergeResult.storyId,
+          conflictFiles: mergeResult.conflictFiles || [],
+          originalCost: workerResult.storyCosts.get(mergeResult.storyId) ?? 0,
+        });
+        logger?.warn("parallel-batch", "Merge conflict — will attempt rectification", {
+          storyId: mergeResult.storyId,
+          conflictFiles: mergeResult.conflictFiles,
+        });
+      }
+    }
+  }
 
   // 4. Failed = stories whose pipeline did not pass.
   // executeParallelBatch returns failed items as { story, error, pipelineResult? }.

--- a/src/execution/parallel-worker.ts
+++ b/src/execution/parallel-worker.ts
@@ -13,6 +13,7 @@ import type { PipelineContext, RoutingResult } from "../pipeline/types";
 import type { UserStory } from "../prd";
 import { routeTask } from "../routing";
 import { errorMessage } from "../utils/errors";
+import { captureGitRef, isGitRefValid } from "../utils/git";
 
 /**
  * Execute a single story in its worktree
@@ -27,6 +28,20 @@ export async function executeStoryInWorktree(
   const logger = getSafeLogger();
 
   try {
+    // Capture storyGitRef from the worktree before execution (mirrors iteration-runner.ts BUG-114).
+    // In parallel mode, each story runs directly via runPipeline (bypassing iteration-runner),
+    // so we must capture the ref here to ensure review/verify stages can diff against the
+    // pre-execution HEAD.
+    let storyGitRef: string | undefined;
+    if (story.storyGitRef && (await isGitRefValid(worktreePath, story.storyGitRef))) {
+      storyGitRef = story.storyGitRef;
+    } else {
+      storyGitRef = await captureGitRef(worktreePath);
+      if (storyGitRef) {
+        story.storyGitRef = storyGitRef;
+      }
+    }
+
     const pipelineContext: PipelineContext = {
       ...context,
       effectiveConfig: context.effectiveConfig ?? context.config,
@@ -34,6 +49,7 @@ export async function executeStoryInWorktree(
       stories: [story],
       workdir: worktreePath,
       routing,
+      storyGitRef: storyGitRef ?? undefined,
     };
 
     logger?.debug("parallel", "Executing story in worktree", {

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -188,7 +188,9 @@ interface LLMResponse {
 function parseLLMResponse(raw: string): LLMResponse | null {
   try {
     let cleaned = raw.trim();
-    const fenceMatch = cleaned.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?\s*```$/);
+    // Match code fence even when the LLM appends explanation text after the closing fence.
+    // Use non-anchored end so trailing content (e.g. "All AC are met: ...") is ignored.
+    const fenceMatch = cleaned.match(/^```(?:json)?\s*\n([\s\S]*?)\n```/);
     if (fenceMatch) cleaned = fenceMatch[1].trim();
     const parsed = JSON.parse(cleaned) as unknown;
     if (typeof parsed !== "object" || parsed === null) return null;

--- a/test/integration/execution/parallel-batch.test.ts
+++ b/test/integration/execution/parallel-batch.test.ts
@@ -97,7 +97,7 @@ describe("AC-1: runParallelBatch completed stories", () => {
     const origMerge = _parallelBatchDeps.createMergeEngine;
 
     _parallelBatchDeps.createWorktreeManager = async () => ({ create: async () => {}, remove: async () => {} } as any);
-    _parallelBatchDeps.createMergeEngine = async () => ({} as any);
+    _parallelBatchDeps.createMergeEngine = async () => ({ mergeAll: async (_wd: string, ids: string[]) => ids.map(id => ({ success: true, storyId: id })) } as any);
     _parallelBatchDeps.executeParallelBatch = async () => ({
       pipelinePassed: stories,
       merged: stories,
@@ -151,7 +151,7 @@ describe("AC-2: runParallelBatch failed stories", () => {
     const origMerge = _parallelBatchDeps.createMergeEngine;
 
     _parallelBatchDeps.createWorktreeManager = async () => ({ create: async () => {}, remove: async () => {} } as any);
-    _parallelBatchDeps.createMergeEngine = async () => ({} as any);
+    _parallelBatchDeps.createMergeEngine = async () => ({ mergeAll: async (_wd: string, ids: string[]) => ids.map(id => ({ success: true, storyId: id })) } as any);
     _parallelBatchDeps.executeParallelBatch = async () => ({
       pipelinePassed: [],
       merged: [],
@@ -205,7 +205,7 @@ describe("AC-3: runParallelBatch merge conflicts", () => {
     const origRectify = _parallelBatchDeps.rectifyConflictedStory;
 
     _parallelBatchDeps.createWorktreeManager = async () => ({ create: async () => {}, remove: async () => {} } as any);
-    _parallelBatchDeps.createMergeEngine = async () => ({} as any);
+    _parallelBatchDeps.createMergeEngine = async () => ({ mergeAll: async (_wd: string, ids: string[]) => ids.map(id => ({ success: true, storyId: id })) } as any);
     _parallelBatchDeps.executeParallelBatch = async () => ({
       pipelinePassed: [],
       merged: [],
@@ -260,7 +260,7 @@ describe("AC-4: runParallelBatch per-story costs", () => {
     const origMerge = _parallelBatchDeps.createMergeEngine;
 
     _parallelBatchDeps.createWorktreeManager = async () => ({ create: async () => {}, remove: async () => {} } as any);
-    _parallelBatchDeps.createMergeEngine = async () => ({} as any);
+    _parallelBatchDeps.createMergeEngine = async () => ({ mergeAll: async (_wd: string, ids: string[]) => ids.map(id => ({ success: true, storyId: id })) } as any);
     _parallelBatchDeps.executeParallelBatch = async () => ({
       pipelinePassed: stories,
       merged: stories,
@@ -313,7 +313,7 @@ describe("AC-5: runParallelBatch totalCost", () => {
     const origMerge = _parallelBatchDeps.createMergeEngine;
 
     _parallelBatchDeps.createWorktreeManager = async () => ({ create: async () => {}, remove: async () => {} } as any);
-    _parallelBatchDeps.createMergeEngine = async () => ({} as any);
+    _parallelBatchDeps.createMergeEngine = async () => ({ mergeAll: async (_wd: string, ids: string[]) => ids.map(id => ({ success: true, storyId: id })) } as any);
     _parallelBatchDeps.executeParallelBatch = async () => ({
       pipelinePassed: stories,
       merged: stories,
@@ -366,7 +366,7 @@ describe("AC-6: runParallelBatch rectification success", () => {
     const origRectify = _parallelBatchDeps.rectifyConflictedStory;
 
     _parallelBatchDeps.createWorktreeManager = async () => ({ create: async () => {}, remove: async () => {} } as any);
-    _parallelBatchDeps.createMergeEngine = async () => ({} as any);
+    _parallelBatchDeps.createMergeEngine = async () => ({ mergeAll: async (_wd: string, ids: string[]) => ids.map(id => ({ success: true, storyId: id })) } as any);
     _parallelBatchDeps.executeParallelBatch = async () => ({
       pipelinePassed: [],
       merged: [],
@@ -413,7 +413,7 @@ describe("AC-6: runParallelBatch rectification success", () => {
     const origRectify = _parallelBatchDeps.rectifyConflictedStory;
 
     _parallelBatchDeps.createWorktreeManager = async () => ({ create: async () => {}, remove: async () => {} } as any);
-    _parallelBatchDeps.createMergeEngine = async () => ({} as any);
+    _parallelBatchDeps.createMergeEngine = async () => ({ mergeAll: async (_wd: string, ids: string[]) => ids.map(id => ({ success: true, storyId: id })) } as any);
     _parallelBatchDeps.executeParallelBatch = async () => ({
       pipelinePassed: [],
       merged: [],
@@ -463,7 +463,7 @@ describe("AC-7: runParallelBatch rectification failure", () => {
     const origRectify = _parallelBatchDeps.rectifyConflictedStory;
 
     _parallelBatchDeps.createWorktreeManager = async () => ({ create: async () => {}, remove: async () => {} } as any);
-    _parallelBatchDeps.createMergeEngine = async () => ({} as any);
+    _parallelBatchDeps.createMergeEngine = async () => ({ mergeAll: async (_wd: string, ids: string[]) => ids.map(id => ({ success: true, storyId: id })) } as any);
     _parallelBatchDeps.executeParallelBatch = async () => ({
       pipelinePassed: [],
       merged: [],

--- a/test/unit/execution/parallel-batch.test.ts
+++ b/test/unit/execution/parallel-batch.test.ts
@@ -254,10 +254,11 @@ describe("AC-3: runParallelBatch — merge conflicts", () => {
     const prd = makePrd([story]);
     const ctx = makeCtx(tmpDir);
 
+    // US-001 passed the pipeline; merge conflict is reported by mergeEngine.mergeAll (not pre-populated)
     const workerResult = makeWorkerBatchResult({
       pipelinePassed: [story],
       merged: [],
-      mergeConflicts: [{ storyId: "US-001", conflictFiles: ["src/foo.ts"], originalCost: 0.5 }],
+      mergeConflicts: [],
       storyCosts: new Map([["US-001", 0.5]]),
       totalCost: 0.5,
     });


### PR DESCRIPTION
## What
Fix three parallel-mode bugs discovered from the `v0.54.12` ts-utils dogfood run logs.

## Why
Closes #129 — Semantic reviewer logged `LLM returned invalid JSON — fail-open` even when JSON was valid, because the LLM appended explanation text after the closing code fence (``````), causing the end-anchored regex to miss it.

Closes #130 — In parallel mode, `storyGitRef` (pre-execution HEAD SHA) was never captured. Sequential mode captures it in `iteration-runner.ts`, but parallel mode dispatches stories directly via `executeStoryInWorktree` bypassing that step. This caused every parallel story to log `storyGitRef missing or invalid — using merge-base fallback`.

Closes #131 — `storiesCompleted` was always `0` in exit-summary and run metrics for parallel runs. Root cause: `createMergeEngine` was defined in `_parallelBatchDeps` but never called. After `executeParallelBatch`, the worktree branches were never merged into the project root, so `completed = workerResult.merged = []` always.

## How

**#129 — `src/review/semantic.ts`**
- Removed `$` end anchor from the code-fence regex: `/^```(?:json)?\s*\n([\s\S]*?)\n```/`
- Now matches even when the LLM appends explanation text after the closing fence

**#130 — `src/execution/parallel-worker.ts`**
- Added `captureGitRef(worktreePath)` call before building `pipelineContext` in `executeStoryInWorktree`
- Mirrors the BUG-114 fix in `iteration-runner.ts`; persists `storyGitRef` to `story.storyGitRef` for crash recovery

**#131 — `src/execution/parallel-batch.ts`**
- After `executeParallelBatch`, creates `MergeEngine` via existing `_parallelBatchDeps.createMergeEngine`
- Calls `mergeEngine.mergeAll(pipelinePassed)` with topological dependency ordering
- Successfully merged stories → `completed`; conflicts → `mergeConflicts` for rectification
- `storiesCompleted` now correctly reflects actual merged stories

## Testing
- [x] Tests added/updated (`test/unit/execution/parallel-batch.test.ts`, `test/integration/execution/parallel-batch.test.ts`)
- [x] `bun test` passes (4910 pass, 55 skip, 3 pre-existing webhook failures unrelated to this PR)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
The 3 pre-existing webhook test failures (`WebhookInteractionPlugin`) are not introduced by this PR — they exist on `main` and are unrelated to parallel execution.
