### PR TITLE
fix(review): skip already-passed checks on autofix retry (#136)

### DIFF
--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -117,6 +117,17 @@ export const autofixStage: PipelineStage = {
     const agentFixed = await _autofixDeps.runAgentRectification(ctx);
     if (agentFixed) {
       if (ctx.reviewResult) ctx.reviewResult = { ...ctx.reviewResult, success: true };
+      // #136: Skip checks that already passed — only re-run checks that originally failed.
+      // Agent rectification fixes mechanical issues (lint/typecheck); passing checks like
+      // semantic (~45s) don't need to re-run unless they were the failing check.
+      const passedChecks = (ctx.reviewResult?.checks ?? []).filter((c) => c.success).map((c) => c.check);
+      if (passedChecks.length > 0) {
+        ctx.retrySkipChecks = new Set(passedChecks);
+        logger.debug("autofix", "Skipping already-passed checks on retry", {
+          storyId: ctx.story.id,
+          skippedChecks: passedChecks,
+        });
+      }
       logger.info("autofix", "Agent rectification succeeded — retrying review", { storyId: ctx.story.id });
       return { action: "retry", fromStage: "review" };
     }

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -40,6 +40,10 @@ export const reviewStage: PipelineStage = {
     const agentName = effectiveConfig.autoMode?.defaultAgent;
     const modelResolver = (_tier: string) => (agentName ? (agentResolver(agentName) ?? null) : null);
 
+    // #136: Consume retrySkipChecks once (cleared after use so subsequent retries re-evaluate)
+    const retrySkipChecks = ctx.retrySkipChecks;
+    ctx.retrySkipChecks = undefined;
+
     const result = await reviewOrchestrator.review(
       effectiveConfig.review,
       effectiveWorkdir,
@@ -57,6 +61,7 @@ export const reviewStage: PipelineStage = {
       },
       modelResolver,
       ctx.config,
+      retrySkipChecks,
     );
 
     ctx.reviewResult = result.builtIn;

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -141,6 +141,13 @@ export interface PipelineContext {
   reviewFindings?: import("../plugins/types").ReviewFinding[];
   /** Accumulated cost across all prior escalation attempts (BUG-067) */
   accumulatedAttemptCost?: number;
+  /**
+   * Set of review check names that already passed in a previous review pass within this
+   * pipeline run. When autofix retries from "review", checks in this set are skipped to
+   * avoid redundant re-runs (e.g. a 45s semantic check after a lint-only fix). (#136)
+   * Only checks that were NOT the cause of the retry are eligible to be skipped.
+   */
+  retrySkipChecks?: Set<string>;
 }
 
 /**

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -84,6 +84,7 @@ export class ReviewOrchestrator {
     story?: SemanticStory,
     modelResolver?: (tier: ModelTier) => AgentAdapter | null | undefined,
     naxConfig?: NaxConfig,
+    retrySkipChecks?: Set<string>,
   ): Promise<OrchestratorReviewResult> {
     const logger = getSafeLogger();
 
@@ -97,6 +98,7 @@ export class ReviewOrchestrator {
       story,
       modelResolver,
       naxConfig,
+      retrySkipChecks,
     );
 
     if (!builtIn.success) {

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -281,6 +281,7 @@ export async function runReview(
   story?: SemanticStory,
   modelResolver?: (tier: ModelTier) => AgentAdapter | null | undefined,
   naxConfig?: NaxConfig,
+  retrySkipChecks?: Set<string>,
 ): Promise<ReviewResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -326,6 +327,15 @@ export async function runReview(
   }
 
   for (const checkName of config.checks) {
+    // #136: Skip checks that already passed in a previous review pass within this pipeline run.
+    // Populated by autofix stage when retrying — only skips checks that were NOT the failing check.
+    if (retrySkipChecks?.has(checkName)) {
+      getSafeLogger()?.debug("review", `Skipping ${checkName} check (already passed in previous review pass)`, {
+        storyId,
+      });
+      continue;
+    }
+
     // Semantic check: delegate to LLM-based runner instead of shell command
     if (checkName === "semantic") {
       const semanticStory: SemanticStory = {


### PR DESCRIPTION
## What
Skip already-passed review checks when autofix retries from the review stage. Eliminates redundant semantic re-runs (~45s each) after lint/typecheck-only fixes.

## Why
Closes #136

When autofix agent rectification succeeds and retries from "review", ALL checks re-ran — including semantic (~45s, LLM cost) even though it already passed and only lint/typecheck changes were made.

## How

**`ctx.retrySkipChecks: Set<string>`** added to `PipelineContext` — carries the set of already-passed check names across the retry boundary.

Flow:
1. **`autofix.ts`**: after agent rectification succeeds, collect checks that passed from `ctx.reviewResult.checks` → set `ctx.retrySkipChecks`
2. **`review.ts`**: consume `retrySkipChecks` (clear after read so subsequent retries re-evaluate), pass to orchestrator
3. **`orchestrator.ts`**: thread through to `runReview()`
4. **`runner.ts`**: skip checks present in `retrySkipChecks` with a debug log entry

Only checks that already passed are skipped — if semantic was the failing check that triggered autofix, it is NOT in `retrySkipChecks` and re-runs normally.

## Testing
- [x] Tests added/updated
- [x] `bun test test/unit/` passes (pre-existing webhook failures only)
- [x] `bun test test/integration/` passes — 1147 pass, 40 skip, 0 fail
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
`retrySkipChecks` is cleared after each review pass (consumed once), so if the retry itself fails and autofix runs again, the set is re-evaluated from the new review results — no stale skip state.
