### PR TITLE
refactor(quality): extract shared runQualityCommand() utility

### DIFF
--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -26,6 +26,7 @@ import { loadConfigForWorkdir } from "../../config/loader";
 import { resolvePermissions } from "../../config/permissions";
 import { getLogger } from "../../logger";
 import type { UserStory } from "../../prd";
+import { runQualityCommand } from "../../quality";
 import type { ReviewCheckResult } from "../../review/types";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
@@ -75,7 +76,12 @@ export const autofixStage: PipelineStage = {
     if (hasLintFailure && (lintFixCmd || formatFixCmd)) {
       if (lintFixCmd) {
         pipelineEventBus.emit({ type: "autofix:started", storyId: ctx.story.id, command: lintFixCmd });
-        const lintResult = await _autofixDeps.runCommand(lintFixCmd, effectiveWorkdir);
+        const lintResult = await _autofixDeps.runQualityCommand({
+          commandName: "lintFix",
+          command: lintFixCmd,
+          workdir: effectiveWorkdir,
+          storyId: ctx.story.id,
+        });
         logger.debug("autofix", `lintFix exit=${lintResult.exitCode}`, { storyId: ctx.story.id, command: lintFixCmd });
         if (lintResult.exitCode !== 0) {
           logger.warn("autofix", "lintFix command failed — may not have fixed all issues", {
@@ -87,7 +93,12 @@ export const autofixStage: PipelineStage = {
 
       if (formatFixCmd) {
         pipelineEventBus.emit({ type: "autofix:started", storyId: ctx.story.id, command: formatFixCmd });
-        const fmtResult = await _autofixDeps.runCommand(formatFixCmd, effectiveWorkdir);
+        const fmtResult = await _autofixDeps.runQualityCommand({
+          commandName: "formatFix",
+          command: formatFixCmd,
+          workdir: effectiveWorkdir,
+          storyId: ctx.story.id,
+        });
         logger.debug("autofix", `formatFix exit=${fmtResult.exitCode}`, {
           storyId: ctx.story.id,
           command: formatFixCmd,
@@ -140,22 +151,6 @@ export const autofixStage: PipelineStage = {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-interface CommandResult {
-  exitCode: number;
-  output: string;
-}
-
-async function runCommand(cmd: string, cwd: string): Promise<CommandResult> {
-  const parts = cmd.split(/\s+/);
-  const proc = Bun.spawn(parts, { cwd, stdout: "pipe", stderr: "pipe" });
-  const [exitCode, stdout, stderr] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  return { exitCode, output: `${stdout}\n${stderr}` };
-}
 
 async function recheckReview(ctx: PipelineContext): Promise<boolean> {
   // Import reviewStage lazily to avoid circular deps
@@ -272,7 +267,7 @@ async function runAgentRectification(ctx: PipelineContext): Promise<boolean> {
  */
 export const _autofixDeps = {
   getAgent,
-  runCommand,
+  runQualityCommand,
   recheckReview,
   runAgentRectification,
   loadConfigForWorkdir,

--- a/src/quality/index.ts
+++ b/src/quality/index.ts
@@ -1,0 +1,5 @@
+export {
+  runQualityCommand,
+  _qualityRunnerDeps,
+} from "./runner.js";
+export type { QualityCommandOptions, QualityCommandResult } from "./runner.js";

--- a/src/quality/index.ts
+++ b/src/quality/index.ts
@@ -1,5 +1,8 @@
-export {
-  runQualityCommand,
-  _qualityRunnerDeps,
-} from "./runner.js";
-export type { QualityCommandOptions, QualityCommandResult } from "./runner.js";
+/**
+ * Quality Module
+ *
+ * Shared utilities for running quality commands (lint, typecheck, build, lintFix, etc.)
+ */
+
+export { runQualityCommand } from "./runner";
+export type { QualityCommandOptions, QualityCommandResult } from "./runner";

--- a/src/quality/runner.ts
+++ b/src/quality/runner.ts
@@ -1,0 +1,155 @@
+/**
+ * Quality Command Runner
+ *
+ * Shared utility for spawning quality check processes (lint, typecheck, build,
+ * lintFix, formatFix) with a hard timeout, concurrent stdout/stderr draining,
+ * and structured logging.
+ *
+ * All callers that previously spawned quality processes inline should use
+ * runQualityCommand() instead. (#135)
+ */
+
+import { spawn } from "bun";
+import { getSafeLogger } from "../logger";
+import { errorMessage } from "../utils/errors";
+
+/** Default timeout for quality commands — matches legacy REVIEW_CHECK_TIMEOUT_MS. */
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+/** Grace period between SIGTERM and SIGKILL on timeout. */
+const SIGKILL_GRACE_PERIOD_MS = 5_000;
+
+export interface QualityCommandOptions {
+  /** Short name used in logs (e.g. "lint", "typecheck", "lintFix"). */
+  commandName: string;
+  /** Full shell command string (e.g. "bun run lint"). */
+  command: string;
+  /** Working directory for the spawned process. */
+  workdir: string;
+  /** Optional story ID for log correlation. */
+  storyId?: string;
+  /** Hard timeout in milliseconds. Defaults to 120 000 ms. */
+  timeoutMs?: number;
+}
+
+export interface QualityCommandResult {
+  commandName: string;
+  command: string;
+  success: boolean;
+  exitCode: number;
+  output: string;
+  durationMs: number;
+  timedOut: boolean;
+}
+
+/**
+ * Injectable dependencies — allows tests to swap out Bun.spawn without
+ * mock.module() (BUG-035 pattern).
+ *
+ * @internal
+ */
+export const _qualityRunnerDeps = {
+  spawn: spawn as typeof Bun.spawn,
+};
+
+/**
+ * Spawn a quality-check command, collect its output, and enforce a hard
+ * timeout with SIGTERM → SIGKILL escalation.
+ *
+ * stdout and stderr are drained concurrently with proc.exited via Promise.all
+ * to avoid deadlocking on output larger than the OS pipe buffer (~64 KB).
+ */
+export async function runQualityCommand(opts: QualityCommandOptions): Promise<QualityCommandResult> {
+  const { commandName, command, workdir, storyId, timeoutMs = DEFAULT_TIMEOUT_MS } = opts;
+  const startTime = Date.now();
+  const logger = getSafeLogger();
+
+  logger?.info("quality", `Running ${commandName}`, { storyId, commandName, command, workdir });
+
+  try {
+    const parts = command.split(/\s+/);
+    const [executable, ...args] = parts;
+
+    const proc = _qualityRunnerDeps.spawn({
+      cmd: [executable, ...args],
+      cwd: workdir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    let timedOut = false;
+    const killTimer = setTimeout(() => {
+      timedOut = true;
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        /* already exited */
+      }
+      setTimeout(() => {
+        try {
+          proc.kill("SIGKILL");
+        } catch {
+          /* already exited */
+        }
+      }, SIGKILL_GRACE_PERIOD_MS);
+    }, timeoutMs);
+
+    // Drain stdout and stderr concurrently with proc.exited to avoid deadlock
+    // when process output exceeds the OS pipe buffer (~64 KB).
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+
+    clearTimeout(killTimer);
+
+    const durationMs = Date.now() - startTime;
+
+    if (timedOut) {
+      logger?.warn("quality", `${commandName} timed out`, {
+        storyId,
+        commandName,
+        command,
+        workdir,
+        durationMs,
+        timedOut: true,
+      });
+      return {
+        commandName,
+        command,
+        success: false,
+        exitCode: -1,
+        output: `[nax] ${commandName} timed out after ${timeoutMs / 1000}s`,
+        durationMs,
+        timedOut: true,
+      };
+    }
+
+    const output = [stdout, stderr].filter(Boolean).join("\n");
+    const success = exitCode === 0;
+
+    logger?.info("quality", `${commandName} completed`, {
+      storyId,
+      commandName,
+      command,
+      workdir,
+      exitCode,
+      durationMs,
+      timedOut: false,
+    });
+
+    return { commandName, command, success, exitCode, output, durationMs, timedOut: false };
+  } catch (error) {
+    const durationMs = Date.now() - startTime;
+    return {
+      commandName,
+      command,
+      success: false,
+      exitCode: -1,
+      output: errorMessage(error),
+      durationMs,
+      timedOut: false,
+    };
+  }
+}

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -4,13 +4,12 @@
  * Runs configurable quality checks after story implementation
  */
 
-import { spawn } from "bun";
 import type { AgentAdapter } from "../agents/types";
 import type { NaxConfig } from "../config";
 import type { ExecutionConfig, QualityConfig } from "../config/schema";
 import type { ModelTier } from "../config/schema-types";
 import { getSafeLogger } from "../logger";
-import { errorMessage } from "../utils/errors";
+import { runQualityCommand } from "../quality";
 import { autoCommitIfDirty } from "../utils/git";
 import { resolveLanguageCommand } from "./language-commands";
 import { runSemanticReview as _runSemanticReviewImpl } from "./semantic";
@@ -32,12 +31,11 @@ export const _reviewSemanticDeps = {
 
 /**
  * Injectable dependencies for runner internals — allows tests to intercept
- * Bun.file and spawn calls without mock.module().
+ * Bun.file and Bun.which calls without mock.module().
  *
  * @internal
  */
 export const _reviewRunnerDeps = {
-  spawn,
   file: Bun.file,
   which: Bun.which as (command: string) => string | null,
 };
@@ -133,105 +131,27 @@ export async function resolveCommand(
   return null;
 }
 
-/** Default timeout for review checks (lint, typecheck). BUG-039. */
-const REVIEW_CHECK_TIMEOUT_MS = 120_000;
-
-/** Grace period between SIGTERM and SIGKILL for review check cleanup. */
-const SIGKILL_GRACE_PERIOD_MS = 5_000;
-
 /**
- * Run a single review check with a hard timeout.
+ * Run a single review check by delegating to the shared runQualityCommand
+ * utility. Maps QualityCommandResult back to the ReviewCheckResult shape.
  *
- * BUG-039: Added SIGTERM + SIGKILL cleanup to prevent orphan lint/typecheck processes.
+ * BUG-039: Timeout + SIGTERM/SIGKILL handling lives in runQualityCommand.
  */
-async function runCheck(check: ReviewCheckName, command: string, workdir: string): Promise<ReviewCheckResult> {
-  const startTime = Date.now();
-  const logger = getSafeLogger();
-
-  logger?.info("review", `Running ${check} check`, { check, command, workdir });
-
-  try {
-    // Parse command into executable and args
-    const parts = command.split(/\s+/);
-    const executable = parts[0];
-    const args = parts.slice(1);
-
-    // Spawn the process
-    const proc = _reviewRunnerDeps.spawn({
-      cmd: [executable, ...args],
-      cwd: workdir,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    // BUG-039: Hard timeout — kill the process if it hangs
-    let timedOut = false;
-    const timerId = setTimeout(() => {
-      timedOut = true;
-      try {
-        proc.kill("SIGTERM");
-      } catch {
-        /* already exited */
-      }
-      setTimeout(() => {
-        try {
-          proc.kill("SIGKILL");
-        } catch {
-          /* already exited */
-        }
-      }, SIGKILL_GRACE_PERIOD_MS);
-    }, REVIEW_CHECK_TIMEOUT_MS);
-
-    // Wait for completion
-    const exitCode = await proc.exited;
-    clearTimeout(timerId);
-
-    if (timedOut) {
-      return {
-        check,
-        command,
-        success: false,
-        exitCode: -1,
-        output: `[nax] ${check} timed out after ${REVIEW_CHECK_TIMEOUT_MS / 1000}s`,
-        durationMs: Date.now() - startTime,
-      };
-    }
-
-    // Collect output
-    const stdout = await new Response(proc.stdout).text();
-    const stderr = await new Response(proc.stderr).text();
-    const output = [stdout, stderr].filter(Boolean).join("\n");
-
-    if (exitCode !== 0) {
-      logger?.warn("review", `${check} check failed`, {
-        check,
-        command,
-        workdir,
-        exitCode,
-        output: output.slice(0, 2000),
-      });
-    } else {
-      logger?.debug("review", `${check} check passed`, { check, command, durationMs: Date.now() - startTime });
-    }
-
-    return {
-      check,
-      command,
-      success: exitCode === 0,
-      exitCode,
-      output,
-      durationMs: Date.now() - startTime,
-    };
-  } catch (error) {
-    return {
-      check,
-      command,
-      success: false,
-      exitCode: -1,
-      output: errorMessage(error),
-      durationMs: Date.now() - startTime,
-    };
-  }
+async function runCheck(
+  check: ReviewCheckName,
+  command: string,
+  workdir: string,
+  storyId?: string,
+): Promise<ReviewCheckResult> {
+  const result = await runQualityCommand({ commandName: check, command, workdir, storyId });
+  return {
+    check,
+    command: result.command,
+    success: result.success,
+    exitCode: result.exitCode,
+    output: result.output,
+    durationMs: result.durationMs,
+  };
 }
 
 /**
@@ -240,7 +160,7 @@ async function runCheck(check: ReviewCheckName, command: string, workdir: string
  */
 async function getUncommittedFilesImpl(workdir: string): Promise<string[]> {
   try {
-    const proc = _reviewRunnerDeps.spawn({
+    const proc = Bun.spawn({
       cmd: ["git", "diff", "--name-only", "HEAD"],
       cwd: workdir,
       stdout: "pipe",
@@ -378,7 +298,7 @@ export async function runReview(
     }
 
     // Run the check
-    const result = await runCheck(checkName, command, workdir);
+    const result = await runCheck(checkName, command, workdir, storyId);
     checks.push(result);
 
     // Track first failure

--- a/test/unit/pipeline/stages/autofix.test.ts
+++ b/test/unit/pipeline/stages/autofix.test.ts
@@ -89,7 +89,7 @@ describe("autofixStage", () => {
 
   test("returns retry when recheck passes", async () => {
     const saved = { ..._autofixDeps };
-    _autofixDeps.runCommand = async () => ({ exitCode: 0, output: "" });
+    _autofixDeps.runQualityCommand = async () => ({ commandName: "lintFix", command: "", success: true, exitCode: 0, output: "", durationMs: 0, timedOut: false });
     _autofixDeps.recheckReview = async () => true;
 
     // Must have a lint failure to trigger Phase 1 (mechanical fix)
@@ -104,7 +104,7 @@ describe("autofixStage", () => {
 
   test("escalates when recheck still fails and agent rectification also fails", async () => {
     const saved = { ..._autofixDeps };
-    _autofixDeps.runCommand = async () => ({ exitCode: 1, output: "lint error" });
+    _autofixDeps.runQualityCommand = async () => ({ commandName: "lintFix", command: "", success: false, exitCode: 1, output: "lint error", durationMs: 0, timedOut: false });
     _autofixDeps.recheckReview = async () => false;
     _autofixDeps.runAgentRectification = async () => false;
 
@@ -147,7 +147,7 @@ describe("autofixStage", () => {
   test("agent rectification runs when mechanical fix fails", async () => {
     const saved = { ..._autofixDeps };
     let agentRectificationCalled = false;
-    _autofixDeps.runCommand = async () => ({ exitCode: 0, output: "" });
+    _autofixDeps.runQualityCommand = async () => ({ commandName: "lintFix", command: "", success: true, exitCode: 0, output: "", durationMs: 0, timedOut: false });
     _autofixDeps.recheckReview = async () => false;
     _autofixDeps.runAgentRectification = async () => {
       agentRectificationCalled = true;
@@ -164,7 +164,7 @@ describe("autofixStage", () => {
 
   test("agent rectification succeeds → returns retry fromStage review", async () => {
     const saved = { ..._autofixDeps };
-    _autofixDeps.runCommand = async () => ({ exitCode: 1, output: "" });
+    _autofixDeps.runQualityCommand = async () => ({ commandName: "lintFix", command: "", success: false, exitCode: 1, output: "", durationMs: 0, timedOut: false });
     _autofixDeps.recheckReview = async () => false;
     _autofixDeps.runAgentRectification = async () => true;
 
@@ -179,7 +179,7 @@ describe("autofixStage", () => {
 
   test("agent rectification exhausted → returns escalate", async () => {
     const saved = { ..._autofixDeps };
-    _autofixDeps.runCommand = async () => ({ exitCode: 1, output: "" });
+    _autofixDeps.runQualityCommand = async () => ({ commandName: "lintFix", command: "", success: false, exitCode: 1, output: "", durationMs: 0, timedOut: false });
     _autofixDeps.recheckReview = async () => false;
     _autofixDeps.runAgentRectification = async () => false;
 
@@ -194,7 +194,7 @@ describe("autofixStage", () => {
   test("agent rectification skipped when review passes after mechanical fix", async () => {
     const saved = { ..._autofixDeps };
     let agentRectificationCalled = false;
-    _autofixDeps.runCommand = async () => ({ exitCode: 0, output: "" });
+    _autofixDeps.runQualityCommand = async () => ({ commandName: "lintFix", command: "", success: true, exitCode: 0, output: "", durationMs: 0, timedOut: false });
     _autofixDeps.recheckReview = async () => true;
     _autofixDeps.runAgentRectification = async () => {
       agentRectificationCalled = true;
@@ -213,11 +213,11 @@ describe("autofixStage", () => {
 
   test("typecheck failure skips mechanical fix and goes straight to agent rectification", async () => {
     const saved = { ..._autofixDeps };
-    let runCommandCalled = false;
+    let runQualityCommandCalled = false;
     let agentRectificationCalled = false;
-    _autofixDeps.runCommand = async () => {
-      runCommandCalled = true;
-      return { exitCode: 0, output: "" };
+    _autofixDeps.runQualityCommand = async () => {
+      runQualityCommandCalled = true;
+      return { commandName: "lintFix", command: "", success: true, exitCode: 0, output: "", durationMs: 0, timedOut: false };
     };
     _autofixDeps.runAgentRectification = async () => {
       agentRectificationCalled = true;
@@ -230,7 +230,7 @@ describe("autofixStage", () => {
 
     Object.assign(_autofixDeps, saved);
 
-    expect(runCommandCalled).toBe(false); // lintFix/formatFix not called
+    expect(runQualityCommandCalled).toBe(false); // lintFix/formatFix not called
     expect(agentRectificationCalled).toBe(true); // went straight to agent
   });
 

--- a/test/unit/quality/runner.test.ts
+++ b/test/unit/quality/runner.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for src/quality/runner.ts (#135)
+ *
+ * Covers:
+ * - Success path (exit 0)
+ * - Failure path (non-zero exit)
+ * - Timeout → SIGTERM → SIGKILL flow
+ * - storyId threaded into log calls via injectable deps
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _qualityRunnerDeps, runQualityCommand } from "../../../src/quality/runner";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function makeSpawnMock(exitCode: number, stdout = "", stderr = "") {
+  return mock((_args: unknown) => ({
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(controller) {
+        if (stdout) controller.enqueue(new TextEncoder().encode(stdout));
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        if (stderr) controller.enqueue(new TextEncoder().encode(stderr));
+        controller.close();
+      },
+    }),
+    kill: mock(() => {}),
+  } as unknown as ReturnType<typeof Bun.spawn>));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runQualityCommand — success (exit 0)", () => {
+  let originalSpawn: typeof _qualityRunnerDeps.spawn;
+
+  beforeEach(() => {
+    originalSpawn = _qualityRunnerDeps.spawn;
+  });
+
+  afterEach(() => {
+    _qualityRunnerDeps.spawn = originalSpawn;
+  });
+
+  test("returns success=true and exitCode=0", async () => {
+    _qualityRunnerDeps.spawn = makeSpawnMock(0, "all good", "") as typeof Bun.spawn;
+
+    const result = await runQualityCommand({
+      commandName: "lint",
+      command: "bun run lint",
+      workdir: "/tmp/project",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+    expect(result.commandName).toBe("lint");
+    expect(result.command).toBe("bun run lint");
+  });
+
+  test("captures combined stdout and stderr in output", async () => {
+    _qualityRunnerDeps.spawn = makeSpawnMock(0, "stdout line", "stderr line") as unknown as typeof Bun.spawn;
+
+    const result = await runQualityCommand({
+      commandName: "typecheck",
+      command: "bun run typecheck",
+      workdir: "/tmp/project",
+    });
+
+    expect(result.output).toContain("stdout line");
+    expect(result.output).toContain("stderr line");
+  });
+
+  test("durationMs is non-negative", async () => {
+    _qualityRunnerDeps.spawn = makeSpawnMock(0) as unknown as typeof Bun.spawn;
+
+    const result = await runQualityCommand({
+      commandName: "build",
+      command: "bun run build",
+      workdir: "/tmp/project",
+    });
+
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("runQualityCommand — failure (non-zero exit)", () => {
+  let originalSpawn: typeof _qualityRunnerDeps.spawn;
+
+  beforeEach(() => {
+    originalSpawn = _qualityRunnerDeps.spawn;
+  });
+
+  afterEach(() => {
+    _qualityRunnerDeps.spawn = originalSpawn;
+  });
+
+  test("returns success=false and captures exit code", async () => {
+    _qualityRunnerDeps.spawn = makeSpawnMock(1, "", "Lint error on line 42") as unknown as typeof Bun.spawn;
+
+    const result = await runQualityCommand({
+      commandName: "lint",
+      command: "bun run lint",
+      workdir: "/tmp/project",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.timedOut).toBe(false);
+    expect(result.output).toContain("Lint error on line 42");
+  });
+
+  test("exit code 2 is surfaced correctly", async () => {
+    _qualityRunnerDeps.spawn = makeSpawnMock(2) as unknown as typeof Bun.spawn;
+
+    const result = await runQualityCommand({
+      commandName: "typecheck",
+      command: "tsc --noEmit",
+      workdir: "/tmp/project",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(2);
+  });
+});
+
+describe("runQualityCommand — timeout flow", () => {
+  let originalSpawn: typeof _qualityRunnerDeps.spawn;
+
+  beforeEach(() => {
+    originalSpawn = _qualityRunnerDeps.spawn;
+  });
+
+  afterEach(() => {
+    _qualityRunnerDeps.spawn = originalSpawn;
+  });
+
+  test("returns timedOut=true and exitCode=-1 when process exceeds timeoutMs", async () => {
+    const killMock = mock(() => {});
+
+    // Process hangs: exited resolves only after kill is called (simulate via resolved promise
+    // that races with the short timeout we set below).
+    let resolveExited!: (code: number) => void;
+    const exitedPromise = new Promise<number>((res) => {
+      resolveExited = res;
+    });
+
+    _qualityRunnerDeps.spawn = mock((_args: unknown) => ({
+      exited: exitedPromise,
+      stdout: new ReadableStream({ start(c) { c.close(); } }),
+      stderr: new ReadableStream({ start(c) { c.close(); } }),
+      kill: mock((signal: string) => {
+        killMock(signal);
+        // Simulate process dying after SIGTERM
+        if (signal === "SIGTERM") resolveExited(143);
+      }),
+    } as unknown as ReturnType<typeof Bun.spawn>)) as typeof Bun.spawn;
+
+    const result = await runQualityCommand({
+      commandName: "lint",
+      command: "bun run lint",
+      workdir: "/tmp/project",
+      timeoutMs: 50, // very short timeout for testing
+    });
+
+    expect(result.timedOut).toBe(true);
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(-1);
+    expect(result.output).toContain("timed out");
+    expect(result.output).toContain("lint");
+    expect(killMock).toHaveBeenCalledWith("SIGTERM");
+  });
+});
+
+describe("runQualityCommand — storyId correlation", () => {
+  let originalSpawn: typeof _qualityRunnerDeps.spawn;
+
+  beforeEach(() => {
+    originalSpawn = _qualityRunnerDeps.spawn;
+  });
+
+  afterEach(() => {
+    _qualityRunnerDeps.spawn = originalSpawn;
+  });
+
+  test("result includes commandName and command from options", async () => {
+    _qualityRunnerDeps.spawn = makeSpawnMock(0) as unknown as typeof Bun.spawn;
+
+    const result = await runQualityCommand({
+      commandName: "lint",
+      command: "biome check --write",
+      workdir: "/tmp/project",
+      storyId: "US-042",
+    });
+
+    // storyId flows through to logger; we verify the result shape here
+    expect(result.commandName).toBe("lint");
+    expect(result.command).toBe("biome check --write");
+    expect(result.success).toBe(true);
+  });
+
+  test("spawn is called with parsed command parts", async () => {
+    const spawnMock = makeSpawnMock(0);
+    _qualityRunnerDeps.spawn = spawnMock as unknown as typeof Bun.spawn;
+
+    await runQualityCommand({
+      commandName: "typecheck",
+      command: "bun run typecheck",
+      workdir: "/tmp/project",
+      storyId: "US-007",
+    });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const callArg = (spawnMock.mock.calls[0] as unknown[])[0] as { cmd: string[]; cwd: string };
+    expect(callArg.cmd).toEqual(["bun", "run", "typecheck"]);
+    expect(callArg.cwd).toBe("/tmp/project");
+  });
+});

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -9,10 +9,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   _reviewGitDeps as _deps,
-  _reviewRunnerDeps as _runnerDeps,
   _reviewSemanticDeps as _semanticDeps,
   runReview,
 } from "../../../src/review/runner";
+import { _qualityRunnerDeps as _runnerDeps } from "../../../src/quality/runner";
 import type { ReviewConfig } from "../../../src/review/types";
 
 /** Minimal ReviewConfig with typecheck enabled but command set to disable via executionConfig */


### PR DESCRIPTION
## What

Extract a shared `runQualityCommand()` utility (`src/quality/runner.ts`) used by both `review/runner.ts` and `autofix.ts`, consolidating duplicated process-spawning logic into a single well-tested abstraction.

## Why

Quality command execution (lint, typecheck, lintFix, formatFix) was implemented independently in two places with diverging behaviour:

- `review/runner.ts` `runCheck()` — had timeout + SIGTERM/SIGKILL, but no `storyId` in logs, inconsistent log fields
- `autofix.ts` `runCommand()` — no timeout (a hung `lintFix` would block the pipeline indefinitely), no logging at all

Closes #135

## How

- **`src/quality/runner.ts`** — new shared utility with `runQualityCommand()`:
  - `QualityCommandOptions` / `QualityCommandResult` interfaces
  - Concurrent `stdout` + `stderr` drain via `Promise.all` (avoids deadlock on >64KB output)
  - SIGTERM → SIGKILL with 5s grace period timeout
  - Structured logging on start + completion: `{ storyId, commandName, command, workdir, exitCode, durationMs }`
  - Injectable `_qualityRunnerDeps = { spawn }` for testing

- **`src/review/runner.ts`** — `runCheck()` is now a thin wrapper that delegates to `runQualityCommand()`; `storyId` threaded through (partial fix for #133); `spawn` removed from `_reviewRunnerDeps`

- **`src/pipeline/stages/autofix.ts`** — private `runCommand()` replaced with `runQualityCommand()` import; gains timeout handling that was previously missing

- **`src/pipeline/stages/verify.ts`** — not touched; it delegates to `regression()` which is a different abstraction layer (smart-runner, crash detection, pass/fail counting)

## Testing

- [x] Tests added/updated — 8 new unit tests in `test/unit/quality/runner.test.ts` (success, failure, timeout/SIGTERM, storyId correlation)
- [x] `bun test` passes — 4933 pass, 55 skip, 3 fail (3 pre-existing webhook failures unrelated to this PR)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

The 3 failing webhook tests (`WebhookInteractionPlugin - send() and HMAC validation`) are pre-existing failures unrelated to this refactor — they fail on `main` too.
