### PR TITLE
fix(logging): add storyId to all acceptance and completion log entries

### DIFF
--- a/.claude/rules/01-project-conventions.md
+++ b/.claude/rules/01-project-conventions.md
@@ -23,6 +23,34 @@
 - Use the project logger (`src/logger`). Never use `console.log` / `console.error` in source code.
 - Log format: no emojis. Use `[OK]`, `[WARN]`, `[FAIL]`, `->`. Machine-parseable.
 
+### Structured Log Fields — Mandatory
+
+Every `logger.info/debug/warn/error` call inside a pipeline stage **must** include `storyId` in its data object.
+
+```typescript
+// ✅ Correct
+logger.info("acceptance", "Running acceptance tests", { storyId: ctx.story.id });
+logger.warn("verify", "No test command configured", { storyId: ctx.story.id });
+
+// ❌ Wrong — missing storyId (breaks parallel log correlation)
+logger.info("acceptance", "Running acceptance tests");
+logger.warn("verify", "No test command configured", { command });
+```
+
+**Why:** In parallel mode, multiple stories emit log entries to the same JSONL file concurrently. Without `storyId` on every line, it is impossible to attribute a log entry to a specific story.
+
+**Rule:** `storyId` must be the **first key** in the data object. Other fields follow after it.
+
+```typescript
+// ✅ storyId first
+logger.error("acceptance", "Tests failed", { storyId: ctx.story.id, failedACs, packageDir });
+
+// ❌ storyId buried
+logger.error("acceptance", "Tests failed", { failedACs, packageDir, storyId: ctx.story.id });
+```
+
+**Scope:** Applies to `src/pipeline/stages/` and `src/review/`. Utility modules (`src/quality/runner.ts`, `src/verification/`) use `storyId` when it is passed in via options — no requirement to thread it independently.
+
 ## Commits
 
 - Conventional commits: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`.

--- a/src/pipeline/stages/acceptance.ts
+++ b/src/pipeline/stages/acceptance.ts
@@ -115,10 +115,10 @@ export const acceptanceStage: PipelineStage = {
     // PKG-004: use centrally resolved effective config
     const effectiveConfig = ctx.effectiveConfig ?? ctx.config;
 
-    logger.info("acceptance", "Running acceptance tests");
+    logger.info("acceptance", "Running acceptance tests", { storyId: ctx.story.id });
 
     if (!ctx.featureDir) {
-      logger.warn("acceptance", "No feature directory — skipping acceptance tests");
+      logger.warn("acceptance", "No feature directory — skipping acceptance tests", { storyId: ctx.story.id });
       return { action: "continue" };
     }
 
@@ -143,7 +143,7 @@ export const acceptanceStage: PipelineStage = {
       const exists = await testFile.exists();
 
       if (!exists) {
-        logger.warn("acceptance", "Acceptance test file not found — skipping", { testPath });
+        logger.warn("acceptance", "Acceptance test file not found — skipping", { storyId: ctx.story.id, testPath });
         continue;
       }
 
@@ -155,6 +155,7 @@ export const acceptanceStage: PipelineStage = {
         effectiveConfig.acceptance.command,
       );
       logger.info("acceptance", "Running acceptance command", {
+        storyId: ctx.story.id,
         cmd: testCmdParts.join(" "),
         packageDir,
       });
@@ -182,6 +183,7 @@ export const acceptanceStage: PipelineStage = {
 
       if (overriddenFailures.length > 0) {
         logger.warn("acceptance", "Skipped failures (overridden)", {
+          storyId: ctx.story.id,
           overriddenFailures,
           overrides: overriddenFailures.map((acId) => ({ acId, reason: overrides[acId] })),
         });
@@ -190,6 +192,7 @@ export const acceptanceStage: PipelineStage = {
       // Non-zero exit but no AC failures parsed — test crashed
       if (failedACs.length === 0 && exitCode !== 0) {
         logger.error("acceptance", "Tests errored with no AC failures parsed", {
+          storyId: ctx.story.id,
           exitCode,
           packageDir,
         });
@@ -208,12 +211,13 @@ export const acceptanceStage: PipelineStage = {
 
       if (actualFailures.length > 0) {
         logger.error("acceptance", "Acceptance tests failed", {
+          storyId: ctx.story.id,
           failedACs: actualFailures,
           packageDir,
         });
         logTestOutput(logger, "acceptance", output);
       } else if (exitCode === 0) {
-        logger.info("acceptance", "Package acceptance tests passed", { packageDir });
+        logger.info("acceptance", "Package acceptance tests passed", { storyId: ctx.story.id, packageDir });
       }
     }
 
@@ -221,7 +225,7 @@ export const acceptanceStage: PipelineStage = {
 
     // All packages passed
     if (allFailedACs.length === 0) {
-      logger.info("acceptance", "All acceptance tests passed");
+      logger.info("acceptance", "All acceptance tests passed", { storyId: ctx.story.id });
       return { action: "continue" };
     }
 

--- a/src/pipeline/stages/completion.ts
+++ b/src/pipeline/stages/completion.ts
@@ -92,6 +92,7 @@ export const completionStage: PipelineStage = {
     // Display progress
     const updatedCounts = countStories(ctx.prd);
     logger.info("completion", "Progress update", {
+      storyId: ctx.story.id,
       completed: updatedCounts.passed + updatedCounts.failed,
       total: updatedCounts.total,
       passed: updatedCounts.passed,


### PR DESCRIPTION
## What

1. Add `storyId` to all structured log entries in `acceptance.ts` and `completion.ts` that were missing it
2. Codify the structured logging rule in `.claude/rules/01-project-conventions.md`

## Why

In parallel mode, multiple stories emit log entries to the same JSONL file concurrently. Without `storyId` on every log line, it's impossible to attribute entries to a specific story.

Without a written rule, this gap will recur every time a new log call is added.

Closes #133

## How

**Fix (2 files):**
- **`acceptance.ts`** — 9 log calls missing `storyId`: "Running acceptance tests", "No feature directory", "Acceptance test file not found", "Running acceptance command", "Skipped failures (overridden)", "Tests errored with no AC failures parsed", "Acceptance tests failed", "Package acceptance tests passed", "All acceptance tests passed"
- **`completion.ts`** — "Progress update" log missing `storyId`

All other stages (`verify`, `review`, `rectify`, `regression`, `execution`, `autofix`) were already fully covered after audit.

**Rule (`.claude/rules/01-project-conventions.md`):**
- Every `logger.info/debug/warn/error` in `src/pipeline/stages/` and `src/review/` must include `storyId` as the **first key** in the data object
- Good/bad examples included
- Scope boundary documented (utility modules like `src/quality/runner.ts` pass `storyId` via options — no independent threading requirement)

## Testing

- [x] Tests added/updated — existing acceptance + completion tests pass
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Pure logging + docs change — no behaviour change.
