### PR TITLE
fix(parallel): per-package config ignored in all parallel runs (PKG-003 missing in runParallelBatch)

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -158,10 +158,12 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
  * @param packageDir - Package directory relative to repo root (e.g. "packages/api")
  */
 export async function loadConfigForWorkdir(rootConfigPath: string, packageDir?: string): Promise<NaxConfig> {
+  const logger = getLogger();
   const rootNaxDir = dirname(rootConfigPath);
   const rootConfig = await loadConfig(rootNaxDir);
 
   if (!packageDir) {
+    logger.debug("config", "No packageDir — using root config");
     return rootConfig;
   }
 
@@ -171,8 +173,13 @@ export async function loadConfigForWorkdir(rootConfigPath: string, packageDir?: 
   const packageOverride = await loadJsonFile<Partial<NaxConfig>>(packageConfigPath, "config");
 
   if (!packageOverride) {
+    logger.debug("config", "Per-package config not found — falling back to root config", {
+      packageConfigPath,
+      packageDir,
+    });
     return rootConfig;
   }
 
+  logger.debug("config", "Per-package config loaded", { packageConfigPath, packageDir });
   return mergePackageConfig(rootConfig, packageOverride);
 }

--- a/src/execution/parallel-batch.ts
+++ b/src/execution/parallel-batch.ts
@@ -12,6 +12,7 @@
 
 import path from "node:path";
 import type { NaxConfig } from "../config";
+import { loadConfigForWorkdir } from "../config/loader";
 import type { LoadedHooksConfig } from "../hooks";
 import { getSafeLogger } from "../logger";
 import type { PipelineEventEmitter } from "../pipeline/events";
@@ -76,6 +77,7 @@ export const _parallelBatchDeps = {
     _worktreePaths: Map<string, string>,
     _maxConcurrency: number,
     _eventEmitter?: PipelineEventEmitter,
+    _storyEffectiveConfigs?: Map<string, NaxConfig>,
   ): Promise<import("./parallel-worker").ParallelBatchResult> => {
     const { executeParallelBatch } = await import("./parallel-worker");
     return executeParallelBatch(
@@ -86,6 +88,7 @@ export const _parallelBatchDeps = {
       _worktreePaths,
       _maxConcurrency,
       _eventEmitter,
+      _storyEffectiveConfigs,
     );
   },
 
@@ -132,6 +135,18 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
     worktreePaths.set(story.id, path.join(workdir, ".nax-wt", story.id));
   }
 
+  // PKG-003 (parallel): Resolve per-story effective configs so per-package quality/review
+  // command overrides apply in parallel mode (same as iteration-runner does for sequential).
+  // Without this, all parallel stories use the root config regardless of story.workdir.
+  const rootConfigPath = path.join(workdir, ".nax", "config.json");
+  const storyEffectiveConfigs = new Map<string, NaxConfig>();
+  for (const story of stories) {
+    if (story.workdir) {
+      const effectiveConfig = await loadConfigForWorkdir(rootConfigPath, story.workdir);
+      storyEffectiveConfigs.set(story.id, effectiveConfig);
+    }
+  }
+
   // 2. Execute all stories in parallel
   const workerResult = await _parallelBatchDeps.executeParallelBatch(
     stories,
@@ -141,6 +156,7 @@ export async function runParallelBatch(options: RunParallelBatchOptions): Promis
     worktreePaths,
     maxConcurrency,
     eventEmitter,
+    storyEffectiveConfigs.size > 0 ? storyEffectiveConfigs : undefined,
   );
   // Batch execution complete — record end time for stories resolved in the batch
   const batchEndMs = Date.now();

--- a/src/execution/parallel-coordinator.ts
+++ b/src/execution/parallel-coordinator.ts
@@ -168,6 +168,11 @@ export async function executeParallel(
 
         // #93: Resolve per-package effective config so testScoped/test overrides apply (same as iteration-runner PKG-003)
         const rootConfigPath = join(projectRoot, ".nax", "config.json");
+        if (!story.workdir) {
+          logger?.debug("parallel", "No story.workdir — skipping per-package config, using root config", {
+            storyId: story.id,
+          });
+        }
         const effectiveConfig = story.workdir ? await loadConfigForWorkdir(rootConfigPath, story.workdir) : config;
         storyEffectiveConfigs.set(story.id, effectiveConfig);
       } catch (error) {

--- a/test/unit/config/loader-workdir.test.ts
+++ b/test/unit/config/loader-workdir.test.ts
@@ -1,13 +1,14 @@
 /**
- * Unit tests for loadConfigForWorkdir (MW-008)
+ * Unit tests for loadConfigForWorkdir (MW-008, BUG-134)
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { existsSync, renameSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { globalConfigPath, loadConfigForWorkdir } from "../../../src/config/loader";
+import { getLogger } from "../../../src/logger";
 import { makeTempDir } from "../../helpers/temp";
 
 describe("loadConfigForWorkdir", () => {
@@ -101,6 +102,47 @@ describe("loadConfigForWorkdir", () => {
     const result = await loadConfigForWorkdir(rootConfigPath);
 
     expect(result.quality.commands.test).toBe("bun test");
+  });
+
+  test("BUG-134: logs debug when package config not found (fallback to root)", async () => {
+    writeFileSync(
+      join(tempDir, ".nax", "config.json"),
+      JSON.stringify({ quality: { commands: { test: "bun test" } } }),
+    );
+
+    const logger = getLogger();
+    const debugSpy = spyOn(logger, "debug");
+
+    const rootConfigPath = join(tempDir, ".nax", "config.json");
+    await loadConfigForWorkdir(rootConfigPath, "packages/missing");
+
+    const fallbackCall = debugSpy.mock.calls.find(
+      (args) => typeof args[1] === "string" && args[1].includes("Per-package config not found"),
+    );
+    expect(fallbackCall).toBeDefined();
+    expect(fallbackCall?.[2]).toMatchObject({ packageDir: "packages/missing" });
+
+    debugSpy.mockRestore();
+  });
+
+  test("BUG-134: logs debug when packageDir is undefined (no per-package resolution)", async () => {
+    writeFileSync(
+      join(tempDir, ".nax", "config.json"),
+      JSON.stringify({ quality: { commands: { test: "bun test" } } }),
+    );
+
+    const logger = getLogger();
+    const debugSpy = spyOn(logger, "debug");
+
+    const rootConfigPath = join(tempDir, ".nax", "config.json");
+    await loadConfigForWorkdir(rootConfigPath);
+
+    const noWorkdirCall = debugSpy.mock.calls.find(
+      (args) => typeof args[1] === "string" && args[1].includes("No packageDir"),
+    );
+    expect(noWorkdirCall).toBeDefined();
+
+    debugSpy.mockRestore();
   });
 
   test("package config without quality.commands does not change test command", async () => {


### PR DESCRIPTION
## What

Two-part fix for #134:
1. **Real bug fix** — per-package config was completely ignored in all parallel runs (`runParallelBatch` path)
2. **Observability** — debug log when per-package config falls back to root

## Why

**Root cause:** `runParallelBatch` in `parallel-batch.ts` (called by `unified-executor.ts` — the only runtime path) never resolved per-story effective configs. Every story in parallel mode silently used root config regardless of `story.workdir`.

`parallel-coordinator.ts` had the correct PKG-003 fix, but it is no longer called at runtime — `unified-executor.ts` calls `runParallelBatch` directly.

Closes #134

## How

**`src/execution/parallel-batch.ts`** (real fix):
- After worktree creation, resolve `loadConfigForWorkdir` for each story that has a `workdir`
- Build `storyEffectiveConfigs` map and pass to `executeParallelBatch`
- Update `_parallelBatchDeps.executeParallelBatch` signature to accept and forward `storyEffectiveConfigs`
- Mirrors the PKG-003 fix already in `iteration-runner.ts` (sequential path)

**`src/config/loader.ts`** (observability):
- `debug` log on all 3 resolution paths: no `packageDir`, file not found (with `packageConfigPath`), file found

**`src/execution/parallel-coordinator.ts`** (observability):
- `debug` log when `story.workdir` is null — skipping per-package resolution

## Testing

- [x] Tests added/updated — 28/28 parallel-batch tests pass, 7/7 loader-workdir tests pass (2 new BUG-134 cases)
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

`parallel-coordinator.ts` still exists but is effectively dead code at runtime. The PKG-003 fix there is correct but unreachable — this PR fixes the live code path.
