### PR TITLE
chore: release v0.55.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.54.12",
+  "version": "0.55.0",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Release v0.55.0 — includes all fixes from today:

- **PR #138** — Extract shared `runQualityCommand()` utility (#135)
- **PR #139** — Add storyId to all structured log entries (#133)
- **PR #140** — Per-package config ignored in parallel runs (#134)
- **PR #141** — Close stale ACP session before rectification + retry on session error (#122)

## Testing

- [x] CI passed on all 4 PRs
- [x] `bun test` — 3816 pass / 13 skip / 3 pre-existing webhook failures
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Full suite test count: 4933 pass / 55 skip (per PR #138 baseline).
