### PR TITLE
docs(rules): add error handling, config, and async/Bun pattern rules

### DIFF
--- a/.claude/rules/05-error-handling.md
+++ b/.claude/rules/05-error-handling.md
@@ -1,0 +1,100 @@
+# Error Handling Patterns
+
+Project-specific error handling conventions for nax.
+
+## NaxError Base Class
+
+All errors must use `NaxError` (v0.38.0+). Do **not** use plain `Error`.
+
+```typescript
+import { NaxError } from "../../src/errors";
+
+throw new NaxError(
+  `story[${index}].id is required and must be non-empty`,
+  "SCHEMA_VALIDATION_FAILED",
+  { stage: "schema", storyId: story.id }
+);
+
+throw new NaxError(
+  `Agent "${agentName}" not found in registry`,
+  "AGENT_NOT_FOUND",
+  { agentName, availableAgents, stage: "decompose" }
+);
+```
+
+`NaxError` fields:
+- `message` — human-readable description
+- `code` — machine-readable error code (string), e.g. `SCHEMA_VALIDATION_FAILED`, `AGENT_NOT_FOUND`
+- `context` — additional structured data for debugging; **always include `stage`**
+
+## Error Cause Chaining
+
+Always chain errors with `cause: err` to preserve the original error chain:
+
+```typescript
+// ✅ Correct
+throw new NaxError(
+  `Failed to parse JSON`,
+  "SCHEMA_PARSE_FAILED",
+  { stage: "schema", cause: parseErr }
+);
+
+// ❌ Wrong — lost cause
+throw new NaxError(
+  `Failed to parse JSON: ${parseErr.message}`,
+  "SCHEMA_PARSE_FAILED",
+  {}
+);
+```
+
+## errorMessage Utility
+
+Use `errorMessage()` from `src/utils/errors` to safely extract messages from unknown errors:
+
+```typescript
+import { errorMessage } from "../../src/utils/errors";
+
+const msg = errorMessage(err); // Safe for unknown, Error, string, undefined
+```
+
+## Return vs Throw
+
+| Situation | Action |
+|:----------|:-------|
+| Critical (invalid config, security) | `throw new NaxError()` |
+| Expected "not found" | `return null` or `?? null` |
+| Validation failures | Return `{ errors: string[] }` |
+| Recoverable warnings | `logger.warn()` + continue |
+
+```typescript
+// ✅ Not found — return null
+const item = items.find((i) => i.storyId === storyId) ?? null;
+
+// ✅ Validation errors — return structured result
+return { errors: ["name is required", "email is invalid"] };
+
+// ✅ Critical config error — use NaxError
+throw new NaxError(
+  "Invalid configuration: missing required field",
+  "CONFIG_INVALID",
+  { stage: "config", field: "agents" }
+);
+
+// ❌ Wrong — throwing for expected condition
+if (!item) throw new NaxError("Item not found", "NOT_FOUND", {}); // Don't throw for flow control
+```
+
+## Error Recovery in Loops
+
+When iterating and one item fails, log and continue unless it's critical:
+
+```typescript
+for (const story of stories) {
+  try {
+    await processStory(story);
+  } catch (err) {
+    logger.error("batch", "Story failed", { storyId: story.id, error: errorMessage(err) });
+    // Continue processing other stories, or break if this is fatal
+  }
+}
+```

--- a/.claude/rules/06-config-patterns.md
+++ b/.claude/rules/06-config-patterns.md
@@ -1,0 +1,110 @@
+# Config Patterns
+
+Project-specific configuration patterns for nax.
+
+## Zod Schema Validation
+
+Use Zod `safeParse()` for all runtime config validation:
+
+```typescript
+import { NaxConfigSchema } from "./schema";
+
+const result = NaxConfigSchema.safeParse(rawConfig);
+if (!result.success) {
+  const errors = result.error.issues.map((err) => {
+    const path = String(err.path.join("."));
+    return path ? `${path}: ${err.message}` : err.message;
+  });
+  throw new Error(`Invalid configuration:\n${errors.join("\n")}`);
+}
+config = result.data;
+```
+
+**Never** use `parse()` without catching — it throws on validation failure. Use `safeParse()`.
+
+## Config Schema Structure
+
+Define defaults in the Zod schema itself using `.default()`:
+
+```typescript
+const NaxConfigSchema = z.object({
+  timeout: z.number().min(1000).default(30000),
+  retries: z.number().int().min(0).max(5).default(3),
+  agents: z.record(z.object({
+    protocol: z.enum(["acp", "cli"]).default("acp"),
+  })).default({}),
+});
+```
+
+## Config Layering Order
+
+Config loads in priority order (later overrides earlier):
+
+1. **Defaults** — Zod schema defaults
+2. **Global** — `~/.nax/config.json`
+3. **Project** — `<workdir>/.nax/config.json`
+4. **CLI overrides** — command-line arguments
+
+```typescript
+const layered = {
+  ...schemaDefaults,
+  ...globalConfig,
+  ...projectConfig,
+  ...cliOverrides,
+};
+```
+
+## Compatibility Shim Pattern
+
+For backward compatibility with deprecated config keys, use a migration shim:
+
+```typescript
+function applyRemovedStrategyCompat(conf: Record<string, unknown>): Record<string, unknown> {
+  const migrated = { ...conf };
+
+  if ("removedStrategy" in conf) {
+    logger.warn("config", "removedStrategy is deprecated, use strategies.active instead");
+    migrated.strategies = { ...(migrated.strategies as object || {}) };
+    (migrated.strategies as Record<string, unknown>)["active"] = conf.removedStrategy;
+    delete migrated.removedStrategy;
+  }
+
+  return migrated;
+}
+```
+
+## Type-Only Imports for Config
+
+Use `import type` for schema types to avoid runtime overhead:
+
+```typescript
+import type { NaxConfig } from "./schema";
+// Not: import { NaxConfig } from "./schema"
+```
+
+## Accessing Config Values
+
+Always access through the parsed config object, never reach into raw JSON:
+
+```typescript
+// ✅ Correct
+const timeout = config.execution?.timeout ?? DEFAULT_TIMEOUT;
+
+// ❌ Wrong — reaching into raw
+const timeout = rawConfig.execution?.timeout ?? DEFAULT_TIMEOUT;
+```
+
+## Environment Variable Access
+
+For environment variables, validate and coerce at config boundaries:
+
+```typescript
+const envTimeout = process.env.NAX_TIMEOUT;
+if (envTimeout !== undefined) {
+  const parsed = parseInt(envTimeout, 10);
+  if (isNaN(parsed) || parsed < 1000) {
+    throw new Error("NAX_TIMEOUT must be a positive integer >= 1000");
+  }
+  config.timeout = parsed;
+}
+```

--- a/.claude/rules/07-async-bun-patterns.md
+++ b/.claude/rules/07-async-bun-patterns.md
@@ -7,15 +7,16 @@ Project-specific async and Bun-native patterns for nax.
 **Always** await `.exited` on Bun.spawn processes:
 
 ```typescript
-// ✅ Correct
+// ✅ Correct — simple await
 const proc = Bun.spawn(argv, { stdout: "pipe", stderr: "pipe" });
 const exitCode = await proc.exited;
 
-// ❌ Wrong — using Promise.race with setTimeout
+// ✅ Also correct — timeout enforcement via Promise.race
 const exitCode = await Promise.race([
   proc.exited,
   new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 5000)),
 ]);
+// Always .catch(() => {}) the losing promise to avoid unhandled rejections
 ```
 
 ## Concurrent Output Draining
@@ -50,13 +51,17 @@ if (exitCode !== 0) {
 
 ## Bun.sleep for Delays
 
-Use `Bun.sleep()` instead of `setTimeout` for delays in async functions:
+Use `Bun.sleep()` for simple delays. **Exception:** `Bun.sleep()` is uncancellable — use `setTimeout` when cancellation is needed (e.g., `Promise.race` timeout patterns).
 
 ```typescript
-// ✅ Correct
+// ✅ Simple delay
 await Bun.sleep(1000);
 
-// ❌ Wrong
+// ✅ Cancellable timeout (setTimeout is correct here)
+const timer = setTimeout(() => reject(new Error("timeout")), 5000);
+// ... on success: clearTimeout(timer)
+
+// ❌ Wrong — setTimeout for simple delay
 await new Promise((resolve) => setTimeout(resolve, 1000));
 ```
 
@@ -133,17 +138,16 @@ if (result === undefined) {
 }
 ```
 
-## No Node.js Globals
+## Globals & Environment
 
-Bun does not include all Node.js globals. Avoid:
-- `global` (use `globalThis`)
-- `process.env` — use `Bun.env` instead
-- `Buffer` — use `Uint8Array` or `btoa/atob`
+Prefer Bun-native globals where available:
+- `global` → use `globalThis`
+- `Buffer` → prefer `Uint8Array` or `btoa/atob`
+
+For environment variables, both `process.env` and `Bun.env` work (they are aliases in Bun). Existing code uses `process.env` — no need to migrate. Prefer `Bun.env` in new code for consistency.
 
 ```typescript
-// ✅ Correct
+// ✅ Both are fine
 const apiKey = Bun.env.OPENAI_API_KEY;
-
-// ❌ Wrong
 const apiKey = process.env.OPENAI_API_KEY;
 ```

--- a/.claude/rules/07-async-bun-patterns.md
+++ b/.claude/rules/07-async-bun-patterns.md
@@ -1,0 +1,149 @@
+# Async & Bun Patterns
+
+Project-specific async and Bun-native patterns for nax.
+
+## Bun.spawn Exit Handling
+
+**Always** await `.exited` on Bun.spawn processes:
+
+```typescript
+// ✅ Correct
+const proc = Bun.spawn(argv, { stdout: "pipe", stderr: "pipe" });
+const exitCode = await proc.exited;
+
+// ❌ Wrong — using Promise.race with setTimeout
+const exitCode = await Promise.race([
+  proc.exited,
+  new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 5000)),
+]);
+```
+
+## Concurrent Output Draining
+
+When capturing stdout/stderr, drain concurrently to avoid deadlock:
+
+```typescript
+// ✅ Correct — concurrent drain
+const [exitCode, stdout, stderr] = await Promise.all([
+  proc.exited,
+  new Response(proc.stdout).text(),
+  new Response(proc.stderr).text(),
+]);
+
+// ❌ Wrong — sequential can deadlock if stderr fills buffer
+const exitCode = await proc.exited;
+const stdout = await new Response(proc.stdout).text();
+const stderr = await new Response(proc.stderr).text();
+```
+
+## Exit Code Checking
+
+Check exit codes explicitly — zero ≠ success only if the command defines it:
+
+```typescript
+const exitCode = await proc.exited;
+if (exitCode !== 0) {
+  const stderr = await new Response(proc.stderr).text();
+  throw new Error(`[execution] Command failed with exit ${exitCode}: ${stderr}`);
+}
+```
+
+## Bun.sleep for Delays
+
+Use `Bun.sleep()` instead of `setTimeout` for delays in async functions:
+
+```typescript
+// ✅ Correct
+await Bun.sleep(1000);
+
+// ❌ Wrong
+await new Promise((resolve) => setTimeout(resolve, 1000));
+```
+
+## Bun-native File APIs
+
+Use Bun's file APIs throughout — no Node.js equivalents:
+
+| ❌ Forbidden | ✅ Use Instead |
+|:-------------|:---------------|
+| `fs.readFileSync` | `Bun.file()` + `.text()` / `.json()` |
+| `fs.writeFileSync` | `Bun.write()` |
+| `fs.readFile` | `Bun.file().text()` |
+| `fs.writeFile` | `Bun.write()` |
+| `child_process.spawn` | `Bun.spawn()` |
+| `child_process.spawnSync` | `Bun.spawnSync()` |
+
+```typescript
+// ✅ Correct — read
+const content = await Bun.file("config.json").text();
+const json = await Bun.file("config.json").json();
+
+// ✅ Correct — write
+await Bun.write("output.json", JSON.stringify(data));
+```
+
+## Bun.spawn Options
+
+Use `stdout: "pipe"` and `stderr: "pipe"` when you need to capture output:
+
+```typescript
+const proc = Bun.spawn(
+  ["git", "diff", "--staged"],
+  {
+    cwd: repoDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  }
+);
+```
+
+Use `stdout: "inherit"` when you want output to flow to the terminal:
+
+```typescript
+const proc = Bun.spawn(
+  ["git", "status"],
+  { stdout: "inherit", stderr: "inherit" }
+);
+```
+
+## Process Lifecycle
+
+Always ensure processes are awaited or explicitly discarded:
+
+```typescript
+// ✅ Correct — explicitly await exit
+await proc.exited;
+
+// ✅ Correct — discard with void
+void proc.exited; // fire-and-forget background process
+```
+
+## Promise.race Safety
+
+When using `Promise.race` with timeouts, ensure the winning path cleans up the loser:
+
+```typescript
+const timeout = Bun.sleep(5000);
+const work = doSomething();
+
+const result = await Promise.race([work, timeout]);
+if (result === undefined) {
+  // timeout won — work is still running in background
+  // ensure it doesn't cause resource leaks
+}
+```
+
+## No Node.js Globals
+
+Bun does not include all Node.js globals. Avoid:
+- `global` (use `globalThis`)
+- `process.env` — use `Bun.env` instead
+- `Buffer` — use `Uint8Array` or `btoa/atob`
+
+```typescript
+// ✅ Correct
+const apiKey = Bun.env.OPENAI_API_KEY;
+
+// ❌ Wrong
+const apiKey = process.env.OPENAI_API_KEY;
+```

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -165,37 +165,38 @@ This was the root cause of 38 test failures (March 2026) — fixed in commit `a1
 
 ## 3. Error Handling
 
-### Current Pattern (Transitional)
+### NaxError (v0.38.0+) — Standard Pattern
 
-Until `NaxError` class is introduced (v0.38.0), follow these rules:
+Use `NaxError` for all errors. It provides a machine-readable `code`, structured `context`, and preserves the error chain via `cause`.
 
 ```typescript
-// ✅ Descriptive message with context
-throw new Error(`[routing] LLM strategy failed for story ${story.id}: ${err.message}`);
+import { NaxError } from "../../src/errors";
 
-// ✅ Include stage prefix in brackets
-throw new Error(`[verify] Test command timed out after ${timeoutMs}ms`);
-
-// ❌ Vague message
-throw new Error("Something went wrong");
-
-// ❌ No context
-throw new Error("Failed");
+throw new NaxError(
+  `LLM strategy failed for story ${story.id}`,
+  "ROUTING_LLM_FAILED",
+  { storyId: story.id, stage: "routing", cause: err }
+);
 ```
 
 ### Rules
 
-1. **Always include stage prefix** in error messages: `[routing]`, `[verify]`, `[execution]`
-2. **Include identifiers** — story ID, file path, command that failed
-3. **Wrap external errors** — catch and re-throw with context, preserving original as `cause`
-4. **Never swallow errors silently** — at minimum, log them
+1. **Always use `NaxError`** — not plain `Error`
+2. **Use descriptive error codes** — `ROUTING_LLM_FAILED`, `AGENT_NOT_FOUND`, `VERIFICATION_TIMEOUT`
+3. **Include `storyId` in context** — for all pipeline stage errors
+4. **Preserve the error chain** — pass `cause: err`
+5. **Never swallow errors silently** — at minimum, log them
 
 ```typescript
 // ✅ Wrapping external errors
 try {
   await externalCall();
 } catch (err) {
-  throw new Error(`[execution] Agent spawn failed for ${storyId}`, { cause: err });
+  throw new NaxError(
+    `Agent spawn failed for ${storyId}`,
+    "AGENT_SPAWN_FAILED",
+    { storyId, stage: "execution", cause: err }
+  );
 }
 
 // ❌ Swallowing
@@ -206,16 +207,9 @@ try {
 }
 ```
 
-### Future: NaxError (v0.38.0)
+### Legacy Pattern (pre-v0.38.0)
 
-```typescript
-// Target pattern — not yet implemented
-throw new NaxError("ROUTING_LLM_FAILED", {
-  stage: "routing",
-  storyId: story.id,
-  cause: err,
-});
-```
+The old `throw new Error("[stage] message")` pattern is deprecated. Do not use it for new code.
 
 ---
 


### PR DESCRIPTION
## What

Add three new `.claude/rules/` files (05–07) codifying error handling, config patterns, and async/Bun-native patterns. Update `ARCHITECTURE.md` to promote NaxError from "future" to standard pattern.

## Why

Codify existing conventions as machine-readable rules so Claude Code (and nax self-dev agents) follow consistent patterns. Prepares for incremental NaxError migration (184 `throw new Error` → `NaxError`).

## How

**New rules:**
- `05-error-handling.md` — NaxError base class, error cause chaining, `errorMessage()` utility, return-vs-throw guidelines
- `06-config-patterns.md` — Zod safeParse, config layering order, compat shim pattern, type-only imports
- `07-async-bun-patterns.md` — Bun.spawn exit handling, concurrent output draining, Bun.sleep (with cancellation exception), file APIs, environment variables

**ARCHITECTURE.md update:**
- Error handling section: NaxError is now the standard (was "future"), old `[stage] message` pattern deprecated

**Review fixes applied to 07:**
- Promise.race + setTimeout is valid for timeout enforcement (was incorrectly marked ❌)
- Bun.sleep cancellation exception documented (uncancellable — use setTimeout for cancellable timeouts)
- `process.env` accepted (alias of `Bun.env` in Bun); soft preference for `Bun.env` in new code

## Testing
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- N/A — docs-only change, no test changes needed

## Notes
- NaxError migration is aspirational — codebase is ~94% plain `Error` still. Rules set the goal for incremental adoption.
