### PR TITLE
fix(autofix): global budget cap prevents unbounded retry cycles (#106)

### DIFF
--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -147,8 +147,10 @@ export interface QualityConfig {
   autofix?: {
     /** Whether to auto-fix lint/format errors before escalating (default: true) */
     enabled?: boolean;
-    /** Max auto-fix attempts (default: 2) */
+    /** Max auto-fix attempts per review-autofix cycle (default: 2) */
     maxAttempts?: number;
+    /** Max total auto-fix attempts across all review-autofix cycles per story (default: 10) */
+    maxTotalAttempts?: number;
   };
   /** Append --forceExit to test command to prevent open handle hangs (default: false) */
   forceExit: boolean;

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -193,7 +193,9 @@ Commit your fixes when done.${scopeConstraint}`;
 async function runAgentRectification(ctx: PipelineContext): Promise<boolean> {
   const logger = getLogger();
   const effectiveConfig = ctx.effectiveConfig ?? ctx.config;
-  const maxAttempts = effectiveConfig.quality.autofix?.maxAttempts ?? 2;
+  const maxPerCycle = effectiveConfig.quality.autofix?.maxAttempts ?? 2;
+  const maxTotal = effectiveConfig.quality.autofix?.maxTotalAttempts ?? 10;
+  const consumed = ctx.autofixAttempt ?? 0;
   const failedChecks = collectFailedChecks(ctx);
 
   if (failedChecks.length === 0) {
@@ -201,16 +203,33 @@ async function runAgentRectification(ctx: PipelineContext): Promise<boolean> {
     return false;
   }
 
+  // Global budget check — escalate if total attempts exhausted across all cycles
+  if (consumed >= maxTotal) {
+    logger.warn("autofix", "Global autofix budget exhausted — escalating", {
+      storyId: ctx.story.id,
+      totalAttempts: consumed,
+      maxTotalAttempts: maxTotal,
+    });
+    return false;
+  }
+
+  // Cap this cycle's attempts to not exceed global budget
+  const remainingBudget = maxTotal - consumed;
+  const maxAttempts = Math.min(maxPerCycle, remainingBudget);
+
   logger.info("autofix", "Starting agent rectification for review failures", {
     storyId: ctx.story.id,
     failedChecks: failedChecks.map((c) => c.check),
     maxAttempts,
+    totalUsed: consumed,
+    maxTotalAttempts: maxTotal,
   });
 
   const agentGetFn = ctx.agentGetFn ?? _autofixDeps.getAgent;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    logger.info("autofix", `Agent rectification attempt ${attempt}/${maxAttempts}`, { storyId: ctx.story.id });
+    ctx.autofixAttempt = consumed + attempt;
+    logger.info("autofix", `Agent rectification attempt ${ctx.autofixAttempt}/${maxTotal}`, { storyId: ctx.story.id });
 
     const agent = agentGetFn(ctx.config.autoMode.defaultAgent);
     if (!agent) {

--- a/test/unit/pipeline/stages/autofix.test.ts
+++ b/test/unit/pipeline/stages/autofix.test.ts
@@ -277,4 +277,58 @@ describe("autofixStage", () => {
 
     expect(prompt).not.toContain("Only modify files within");
   });
+
+  test("#106: global autofix budget — ctx.autofixAttempt persists across cycles", async () => {
+    const saved = { ..._autofixDeps };
+    // Agent always "fails" so we exhaust attempts
+    let agentSpawnCount = 0;
+    _autofixDeps.getAgent = () =>
+      ({
+        run: async () => {
+          agentSpawnCount++;
+          return { success: false };
+        },
+      }) as any;
+    _autofixDeps.recheckReview = async () => false;
+    _autofixDeps.loadConfigForWorkdir = async () => null;
+
+    const ctx = makeCtx({
+      reviewResult: makeFailedReviewResult([{ check: "typecheck", output: "TS error" }]),
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test" },
+          autofix: { enabled: true, maxAttempts: 2, maxTotalAttempts: 5 },
+        },
+        autoMode: { ...DEFAULT_CONFIG.autoMode, defaultAgent: "claude" },
+      } as any,
+    });
+
+    // Simulate 3 review→autofix cycles by calling execute repeatedly
+    // Cycle 1: should use 2 attempts (total: 2)
+    await autofixStage.execute(ctx);
+    expect(ctx.autofixAttempt).toBe(2);
+    expect(agentSpawnCount).toBe(2);
+
+    // Cycle 2: reset review failure, call again — should use 2 more (total: 4)
+    ctx.reviewResult = makeFailedReviewResult([{ check: "typecheck", output: "TS error" }]);
+    await autofixStage.execute(ctx);
+    expect(ctx.autofixAttempt).toBe(4);
+    expect(agentSpawnCount).toBe(4);
+
+    // Cycle 3: only 1 remaining in budget (5 - 4 = 1)
+    ctx.reviewResult = makeFailedReviewResult([{ check: "typecheck", output: "TS error" }]);
+    await autofixStage.execute(ctx);
+    expect(ctx.autofixAttempt).toBe(5);
+    expect(agentSpawnCount).toBe(5); // only 1 more, not 2
+
+    // Cycle 4: budget exhausted — no more spawns
+    ctx.reviewResult = makeFailedReviewResult([{ check: "typecheck", output: "TS error" }]);
+    await autofixStage.execute(ctx);
+    expect(ctx.autofixAttempt).toBe(5); // unchanged
+    expect(agentSpawnCount).toBe(5); // no more spawns
+
+    Object.assign(_autofixDeps, saved);
+  });
 });


### PR DESCRIPTION
## What

Add a global autofix budget (`maxTotalAttempts`) that caps total agent rectification spawns per story across all review→autofix cycles.

## Why

Closes #106

The per-cycle `maxAttempts` counter reset each time autofix stage re-executed after a review retry, allowing unbounded agent spawns. With PR #137's skip optimization making each cycle cheaper, a hard global ceiling provides cost safety without limiting legitimate multi-cycle fixes.

## How

**Hybrid approach:** keep existing per-cycle `maxAttempts` (default: 2) + new global `maxTotalAttempts` (default: 10).

1. **`runtime-types.ts`**: added `maxTotalAttempts?: number` to autofix config
2. **`autofix.ts`**: `runAgentRectification` now reads/writes `ctx.autofixAttempt` to track cumulative attempts. Before entering the loop, checks global budget. Per-cycle attempts are capped to remaining budget.
3. **`autofix.test.ts`**: new test simulates 4 review→autofix cycles with `maxTotalAttempts: 5`, verifies:
   - Cycles 1-2: 2 attempts each (total: 4)
   - Cycle 3: only 1 attempt (budget capped)
   - Cycle 4: zero spawns (budget exhausted)

**Config:**

| Field | Default | Purpose |
|:------|:--------|:--------|
| `quality.autofix.maxAttempts` | 2 | Per-cycle budget (existing) |
| `quality.autofix.maxTotalAttempts` | 10 | Global ceiling per story (new) |

## Testing
- [x] Tests added/updated (1 new test covering multi-cycle budget tracking)
- [x] `bun test` passes (4924 pass / 55 skip / 3 pre-existing webhook fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
- `ctx.autofixAttempt` field already existed on `PipelineContext` but was never wired up — now functional
- Default of 10 allows up to 5 full cycles (5 × 2) before ceiling, generous enough for normal use
