### PR TITLE
docs: add autofix global budget (maxTotalAttempts) to guides and specs

### DIFF
--- a/docs/adr/ADR-005-pipeline-re-architecture.md
+++ b/docs/adr/ADR-005-pipeline-re-architecture.md
@@ -292,7 +292,8 @@ quality: {
   },
   autofix: {
     enabled: true,                      // NEW: master switch
-    maxAttempts: 2,                     // NEW: max auto-fix retries
+    maxAttempts: 2,                     // NEW: max auto-fix retries per review→autofix cycle
+    maxTotalAttempts: 10,               // NEW: global ceiling per story across all cycles
   }
 }
 ```

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -237,6 +237,34 @@ See [Semantic Review](semantic-review.md) for the behavioral review check.
 
 ---
 
+### Autofix Budget
+
+Control how many agent rectification attempts nax makes when review checks fail:
+
+```json
+{
+  "quality": {
+    "autofix": {
+      "enabled": true,
+      "maxAttempts": 2,
+      "maxTotalAttempts": 10
+    }
+  }
+}
+```
+
+| Field | Default | Description |
+|:------|:--------|:------------|
+| `enabled` | `true` | Master switch for autofix |
+| `maxAttempts` | `2` | Max agent rectification attempts per review→autofix cycle |
+| `maxTotalAttempts` | `10` | Global ceiling per story across all review→autofix cycles |
+
+**How it works:** When review fails, autofix spawns an agent up to `maxAttempts` times per cycle. If the agent fixes the issue but a subsequent review fails again, a new cycle starts. `maxTotalAttempts` caps the total agent spawns across all cycles to prevent runaway loops.
+
+Example with defaults: a story can cycle through review→autofix up to 5 times (5 × 2 = 10 spawns) before hitting the global ceiling and escalating.
+
+---
+
 ### Monorepo Acceptance Test Exclusion
 
 nax generates per-package acceptance test files at `<package-root>/.nax-acceptance.test.ts`. These files are meant to be run by nax only — **not** by your regular test suite.

--- a/docs/specs/SPEC-semantic-review.md
+++ b/docs/specs/SPEC-semantic-review.md
@@ -117,7 +117,7 @@ Same as lint/typecheck failures:
 1. Semantic review fails → review stage returns `continue` (built-in check failure = autofix handles it)
 2. Autofix stage receives the findings and retries the story
 3. Agent gets structured findings as `priorFailures` context
-4. If autofix exhausted → escalate (same as lint/typecheck exhaustion)
+4. If autofix exhausted (per-cycle `maxAttempts` or global `maxTotalAttempts`) → escalate
 
 ### Token Budget
 


### PR DESCRIPTION
## What

Document the new `maxTotalAttempts` autofix config field added in PR #144.

## Why

Closes the documentation gap from #106 fix — users need to know about the global budget config.

## How

| File | Change |
|:-----|:-------|
| `docs/guides/configuration.md` | New "Autofix Budget" section with config table and usage explanation |
| `docs/adr/ADR-005-pipeline-re-architecture.md` | Added `maxTotalAttempts` to config example |
| `docs/specs/SPEC-semantic-review.md` | Updated escalation note to mention both budget limits |

## Testing
- N/A — docs-only change

## Notes
- Follows PR #144 which implemented the feature
