### PR TITLE
feat(rectification): progressive prompt escalation with rethink/urgency injection

### DIFF
--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -73,6 +73,10 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "execution.rectification.abortOnIncreasingFailures": "Abort if failure count increases",
   "execution.rectification.escalateOnExhaustion":
     "Enable model tier escalation when retries are exhausted with remaining failures",
+  "execution.rectification.rethinkAtAttempt":
+    "Attempt number at which 'rethink your approach' language is injected into the prompt (default: 2, set >= maxRetries to disable)",
+  "execution.rectification.urgencyAtAttempt":
+    "Attempt number at which 'final chance before escalation' urgency is added to the prompt (default: 3, set >= maxRetries to disable)",
   "execution.regressionGate": "Regression gate settings (full suite after scoped tests)",
   "execution.regressionGate.enabled": "Enable full-suite regression gate",
   "execution.regressionGate.timeoutSeconds": "Timeout for regression run in seconds",

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -58,6 +58,8 @@ export const DEFAULT_CONFIG: NaxConfig = {
       maxFailureSummaryChars: 2000,
       abortOnIncreasingFailures: true,
       escalateOnExhaustion: true,
+      rethinkAtAttempt: 2,
+      urgencyAtAttempt: 3,
     },
     regressionGate: {
       enabled: true,

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -47,6 +47,17 @@ export interface RectificationConfig {
   abortOnIncreasingFailures: boolean;
   /** Escalate to higher model tier after exhausting maxRetries (default: true) */
   escalateOnExhaustion: boolean;
+  /**
+   * Attempt number at which "rethink your approach" language is injected into the prompt.
+   * Nudges the agent to try a fundamentally different strategy instead of repeating the same fix.
+   * Set >= maxRetries to disable. (default: 2)
+   */
+  rethinkAtAttempt: number;
+  /**
+   * Attempt number at which "final chance before escalation" urgency is added to the prompt.
+   * Should be >= rethinkAtAttempt. Set >= maxRetries to disable. (default: 3)
+   */
+  urgencyAtAttempt: number;
 }
 
 /** Regression gate config (BUG-009, BUG-026) */

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -58,6 +58,8 @@ const RectificationConfigSchema = z.object({
   maxFailureSummaryChars: z.number().int().min(500).max(10000).default(2000),
   abortOnIncreasingFailures: z.boolean().default(true),
   escalateOnExhaustion: z.boolean().optional().default(true),
+  rethinkAtAttempt: z.number().int().min(1).default(2),
+  urgencyAtAttempt: z.number().int().min(1).default(3),
 });
 
 const RegressionGateConfigSchema = z.object({

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -78,7 +78,12 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
       currentFailures: rectificationState.currentFailures,
     });
 
-    let rectificationPrompt = createRectificationPrompt(testSummary.failures, story, rectificationConfig);
+    let rectificationPrompt = createRectificationPrompt(
+      testSummary.failures,
+      story,
+      rectificationConfig,
+      rectificationState.attempt,
+    );
     if (promptPrefix) rectificationPrompt = `${promptPrefix}\n\n${rectificationPrompt}`;
 
     const agent = (agentGetFn ?? _rectificationDeps.getAgent)(config.autoMode.defaultAgent);

--- a/src/verification/rectification.ts
+++ b/src/verification/rectification.ts
@@ -50,9 +50,49 @@ export function shouldRetryRectification(state: RectificationState, config: Rect
 }
 
 /**
+ * Build the progressive escalation preamble to prepend when attempt >= threshold.
+ *
+ * - rethink phase  (attempt >= rethinkAtAttempt):  nudge the agent to change strategy
+ * - urgency phase  (attempt >= urgencyAtAttempt):  add "final chance" pressure
+ *
+ * Returns an empty string when no injection is needed.
+ */
+function buildEscalationPreamble(attempt: number, config: RectificationConfig): string {
+  const rethinkAt = config.rethinkAtAttempt ?? 2;
+  const urgencyAt = config.urgencyAtAttempt ?? 3;
+
+  if (attempt < rethinkAt) return "";
+
+  const isUrgent = attempt >= urgencyAt;
+
+  const rethinkSection = `## ⚠️ Previous Attempt Did Not Fix the Failures
+
+Your previous fix attempt (attempt ${attempt}) did not resolve all failures. **Step back and reconsider your approach.**
+
+- The root cause may be different from what you assumed.
+- Avoid iterating on the same fix — try a **fundamentally different strategy**.
+- Re-read the story context and test failures carefully before making changes.
+- Consider: are there missing edge cases, incorrect assumptions, or a design flaw in the implementation?
+
+`;
+
+  const urgencySection = isUrgent
+    ? `## 🚨 Final Rectification Attempt Before Model Escalation
+
+This is attempt ${attempt} — if the tests still fail after this, the task will escalate to a stronger model tier.
+A **completely different approach** is required. Do not repeat what you have already tried.
+
+`
+    : "";
+
+  return `${urgencySection}${rethinkSection}`;
+}
+
+/**
  * Create a rectification prompt with failure context.
  *
  * Includes:
+ * - Progressive escalation preamble when attempt >= rethinkAtAttempt (or urgencyAtAttempt)
  * - Clear instructions about test regressions
  * - Formatted failure summary
  * - Specific test commands for failing files
@@ -61,6 +101,7 @@ export function createRectificationPrompt(
   failures: TestFailure[],
   story: UserStory,
   config?: RectificationConfig,
+  attempt?: number,
 ): string {
   const maxChars = config?.maxFailureSummaryChars ?? 2000;
   const failureSummary = formatFailureSummary(failures, maxChars);
@@ -69,7 +110,10 @@ export function createRectificationPrompt(
   const failingFiles = Array.from(new Set(failures.map((f) => f.file)));
   const testCommands = failingFiles.map((file) => `  bun test ${file}`).join("\n");
 
-  return `# Rectification Required
+  // Progressive escalation preamble (empty string on attempt 1 or when thresholds not met)
+  const preamble = config && attempt !== undefined && attempt > 1 ? buildEscalationPreamble(attempt, config) : "";
+
+  return `${preamble}# Rectification Required
 
 Your changes caused test regressions. Fix these without breaking existing logic.
 

--- a/test/unit/execution/rectification.test.ts
+++ b/test/unit/execution/rectification.test.ts
@@ -283,6 +283,94 @@ describe("createRectificationPrompt", () => {
     expect(prompt).toContain("run ONLY the failing test files shown above");
     expect(prompt).toContain("NEVER run `bun test` without a file filter");
   });
+
+  describe("progressive prompt escalation", () => {
+    const escalationConfig: RectificationConfig = {
+      enabled: true,
+      maxRetries: 4,
+      fullSuiteTimeoutSeconds: 120,
+      maxFailureSummaryChars: 2000,
+      abortOnIncreasingFailures: true,
+      escalateOnExhaustion: true,
+      rethinkAtAttempt: 2,
+      urgencyAtAttempt: 3,
+    };
+
+    test("attempt 1 — no preamble injected", () => {
+      const prompt = createRectificationPrompt(mockFailures, mockStory, escalationConfig, 1);
+      expect(prompt).not.toContain("Previous Attempt Did Not Fix");
+      expect(prompt).not.toContain("Final Rectification Attempt");
+      expect(prompt).toContain("# Rectification Required");
+    });
+
+    test("attempt 2 (= rethinkAtAttempt) — rethink section injected, no urgency", () => {
+      const prompt = createRectificationPrompt(mockFailures, mockStory, escalationConfig, 2);
+      expect(prompt).toContain("Previous Attempt Did Not Fix");
+      expect(prompt).toContain("fundamentally different strategy");
+      expect(prompt).not.toContain("Final Rectification Attempt");
+    });
+
+    test("attempt 3 (= urgencyAtAttempt) — both rethink and urgency injected", () => {
+      const prompt = createRectificationPrompt(mockFailures, mockStory, escalationConfig, 3);
+      expect(prompt).toContain("Previous Attempt Did Not Fix");
+      expect(prompt).toContain("Final Rectification Attempt");
+      expect(prompt).toContain("escalate to a stronger model tier");
+    });
+
+    test("attempt 4 (> urgencyAtAttempt) — both sections still present", () => {
+      const prompt = createRectificationPrompt(mockFailures, mockStory, escalationConfig, 4);
+      expect(prompt).toContain("Previous Attempt Did Not Fix");
+      expect(prompt).toContain("Final Rectification Attempt");
+      expect(prompt).toContain("attempt 4");
+    });
+
+    test("attempt number appears in preamble context", () => {
+      const prompt = createRectificationPrompt(mockFailures, mockStory, escalationConfig, 2);
+      expect(prompt).toContain("attempt 2");
+    });
+
+    test("no injection when attempt is undefined (backward compat)", () => {
+      const prompt = createRectificationPrompt(mockFailures, mockStory, escalationConfig, undefined);
+      expect(prompt).not.toContain("Previous Attempt Did Not Fix");
+      expect(prompt).not.toContain("Final Rectification Attempt");
+    });
+
+    test("no injection when config is undefined", () => {
+      const prompt = createRectificationPrompt(mockFailures, mockStory, undefined, 3);
+      expect(prompt).not.toContain("Previous Attempt Did Not Fix");
+      expect(prompt).not.toContain("Final Rectification Attempt");
+    });
+
+    test("rethink disabled when rethinkAtAttempt >= maxRetries", () => {
+      const disabledConfig: RectificationConfig = {
+        ...escalationConfig,
+        rethinkAtAttempt: 99,
+        urgencyAtAttempt: 99,
+      };
+      const prompt = createRectificationPrompt(mockFailures, mockStory, disabledConfig, 3);
+      expect(prompt).not.toContain("Previous Attempt Did Not Fix");
+      expect(prompt).not.toContain("Final Rectification Attempt");
+    });
+
+    test("rethink but no urgency when urgencyAtAttempt > attempt", () => {
+      const lateUrgencyConfig: RectificationConfig = {
+        ...escalationConfig,
+        rethinkAtAttempt: 2,
+        urgencyAtAttempt: 10, // effectively disabled
+      };
+      const prompt = createRectificationPrompt(mockFailures, mockStory, lateUrgencyConfig, 3);
+      expect(prompt).toContain("Previous Attempt Did Not Fix");
+      expect(prompt).not.toContain("Final Rectification Attempt");
+    });
+
+    test("core prompt structure still present when preamble is injected", () => {
+      const prompt = createRectificationPrompt(mockFailures, mockStory, escalationConfig, 3);
+      expect(prompt).toContain("# Rectification Required");
+      expect(prompt).toContain("## Story Context");
+      expect(prompt).toContain("## Test Failures");
+      expect(prompt).toContain("## Instructions");
+    });
+  });
 });
 
 describe("createEscalatedRectificationPrompt", () => {


### PR DESCRIPTION
## What

Add progressive prompt escalation to the rectification loop. When retry attempts fail, the agent now receives increasingly strong signals to change its strategy — a "rethink" nudge at a configurable attempt threshold, and a "final chance" urgency message at a second threshold.

## Why

Agents in the rectification loop often repeat the same failing approach across all retries, burning attempts without making progress. Without a mid-loop signal to rethink, the only recourse is exhausting all retries and escalating to a stronger model tier.

Closes #147

## How

Two new optional config fields added to `RectificationConfig`:

| Field | Default | Purpose |
|:------|:--------|:--------|
| `rethinkAtAttempt` | `2` | Attempt # where "rethink your approach" section is prepended |
| `urgencyAtAttempt` | `3` | Attempt # where "final chance before escalation" urgency is added |

**Prompt phases (with defaults, maxRetries: 4):**
- Attempt 1: standard prompt (no injection)
- Attempt 2+: rethink preamble — *"Your previous approach didn't work. Try a fundamentally different strategy."*
- Attempt 3+: urgency preamble — *"Final rectification attempt before model escalation. A completely different approach is needed."*

Set either threshold `>= maxRetries` to disable that injection entirely.

**Files changed:**
- `src/config/runtime-types.ts` — added fields to `RectificationConfig` interface
- `src/config/schemas.ts` — Zod validation for both fields
- `src/config/defaults.ts` — defaults: `rethinkAtAttempt: 2`, `urgencyAtAttempt: 3`
- `src/verification/rectification.ts` — `buildEscalationPreamble()` + updated `createRectificationPrompt(attempt?)`
- `src/verification/rectification-loop.ts` — passes `rectificationState.attempt` to prompt builder
- `src/cli/config-descriptions.ts` — CLI help text for both fields

## Testing

- [x] Tests added/updated — 10 new unit tests covering all phases + edge cases (disable via threshold, backward compat with undefined attempt/config)
- [x] `bun test` passes — 44/44 on rectification.test.ts, 196/196 on verification suite
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- Purely additive — no changes to retry logic, abort conditions, or model escalation behaviour
- Fully backward compatible: `attempt` param is optional, no injection when `undefined`
- Existing `createEscalatedRectificationPrompt` (post-exhaustion model escalation) is untouched
