### PR TITLE
fix(acceptance): pass acceptanceTestPaths + featureDir to post-run pipeline (#164)

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -170,7 +170,7 @@ export const DEFAULT_CONFIG: NaxConfig = {
     enabled: true,
     maxRetries: 2,
     generateTests: true,
-    testPath: "acceptance.test.ts",
+    testPath: ".nax-acceptance.test.ts",
     model: "fast" as const,
     refinement: true,
     redGate: true,

--- a/src/execution/sequential-executor.ts
+++ b/src/execution/sequential-executor.ts
@@ -199,7 +199,14 @@ export async function executeSequential(
     logger?.info("execution", "Running post-run pipeline (acceptance tests)");
     await runPipeline(
       postRunPipeline,
-      { config: ctx.config, prd, workdir: ctx.workdir, story: prd.userStories[0] } as unknown as PipelineContext,
+      {
+        config: ctx.config,
+        prd,
+        workdir: ctx.workdir,
+        featureDir: ctx.featureDir,
+        story: prd.userStories[0],
+        acceptanceTestPaths: preRunCtx.acceptanceTestPaths,
+      } as unknown as PipelineContext,
       ctx.eventEmitter,
     );
 

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -77,9 +77,10 @@ export async function executeUnified(
     }
 
     // Pre-run pipeline (acceptance test setup with RED gate) — only when acceptance is configured
+    let preRunCtx: PipelineContext | undefined;
     if (ctx.config.acceptance?.enabled) {
       logger?.info("execution", "Running pre-run pipeline (acceptance test setup)");
-      const preRunCtx: PipelineContext = {
+      preRunCtx = {
         config: ctx.config,
         effectiveConfig: ctx.config,
         prd,
@@ -423,7 +424,14 @@ export async function executeUnified(
       logger?.info("execution", "Running post-run pipeline (acceptance tests)");
       await runPipeline(
         postRunPipeline,
-        { config: ctx.config, prd, workdir: ctx.workdir, story: prd.userStories[0] } as unknown as PipelineContext,
+        {
+          config: ctx.config,
+          prd,
+          workdir: ctx.workdir,
+          featureDir: ctx.featureDir,
+          story: prd.userStories[0],
+          acceptanceTestPaths: preRunCtx?.acceptanceTestPaths,
+        } as unknown as PipelineContext,
         ctx.eventEmitter,
       );
     }

--- a/test/integration/pipeline/pipeline-acceptance.test.ts
+++ b/test/integration/pipeline/pipeline-acceptance.test.ts
@@ -136,7 +136,7 @@ describe("acceptanceStage.execute", () => {
     const ctx = createTestContext(prd);
 
     // Create passing acceptance test
-    const testPath = path.join(featureDir, "acceptance.test.ts");
+    const testPath = path.join(featureDir, ".nax-acceptance.test.ts");
     await Bun.write(
       testPath,
       `
@@ -160,7 +160,7 @@ describe("test-feature - Acceptance Tests", () => {
     const ctx = createTestContext(prd);
 
     // Create failing acceptance test
-    const testPath = path.join(featureDir, "acceptance.test.ts");
+    const testPath = path.join(featureDir, ".nax-acceptance.test.ts");
     await Bun.write(
       testPath,
       `
@@ -209,7 +209,7 @@ describe("test-feature - Acceptance Tests", () => {
     const ctx = createTestContext(prd);
 
     // Create failing acceptance test for AC-1
-    const testPath = path.join(featureDir, "acceptance.test.ts");
+    const testPath = path.join(featureDir, ".nax-acceptance.test.ts");
     await Bun.write(
       testPath,
       `
@@ -237,7 +237,7 @@ describe("test-feature - Acceptance Tests", () => {
     const ctx = createTestContext(prd);
 
     // Create tests: AC-1 and AC-2 fail, but AC-1 is overridden
-    const testPath = path.join(featureDir, "acceptance.test.ts");
+    const testPath = path.join(featureDir, ".nax-acceptance.test.ts");
     await Bun.write(
       testPath,
       `
@@ -269,7 +269,7 @@ describe("test-feature - Acceptance Tests", () => {
     const ctx = createTestContext(prd);
 
     // Create multiple failing tests
-    const testPath = path.join(featureDir, "acceptance.test.ts");
+    const testPath = path.join(featureDir, ".nax-acceptance.test.ts");
     await Bun.write(
       testPath,
       `
@@ -306,7 +306,7 @@ describe("test-feature - Acceptance Tests", () => {
     const ctx = createTestContext(prd);
 
     // Create a test file with a syntax error — bun exits non-zero but no (fail) AC-N lines
-    const testPath = path.join(featureDir, "acceptance.test.ts");
+    const testPath = path.join(featureDir, ".nax-acceptance.test.ts");
     await Bun.write(
       testPath,
       `
@@ -346,7 +346,7 @@ describe("BUG-083: acceptance command scoping", () => {
       },
     });
 
-    const testPath = path.join(featureDir, "acceptance.test.ts");
+    const testPath = path.join(featureDir, ".nax-acceptance.test.ts");
     await Bun.write(
       testPath,
       `import { describe, test, expect } from "bun:test";
@@ -372,7 +372,7 @@ describe("test-feature", () => {
       },
     });
 
-    const testPath = path.join(featureDir, "acceptance.test.ts");
+    const testPath = path.join(featureDir, ".nax-acceptance.test.ts");
     await Bun.write(
       testPath,
       `import { describe, test, expect } from "bun:test";
@@ -389,7 +389,7 @@ describe("test-feature", () => {
     const prd = createTestPRD([{ id: "US-001", status: "passed" }]);
 
     // Point to the real acceptance test file using absolute path in command
-    const testPath = path.join(featureDir, "acceptance.test.ts");
+    const testPath = path.join(featureDir, ".nax-acceptance.test.ts");
     await Bun.write(
       testPath,
       `import { describe, test, expect } from "bun:test";
@@ -418,7 +418,7 @@ describe("test-feature", () => {
       },
     });
 
-    const testPath = path.join(featureDir, "acceptance.test.ts");
+    const testPath = path.join(featureDir, ".nax-acceptance.test.ts");
     await Bun.write(
       testPath,
       `import { describe, test, expect } from "bun:test";


### PR DESCRIPTION
## What

Fix acceptance stage looking for wrong test filename (`acceptance.test.ts` instead of `.nax-acceptance.test.ts`).

## Why

Post-run acceptance stage builds a fresh `PipelineContext` without `acceptanceTestPaths` or `featureDir` from the pre-run context. This causes the fallback to `config.acceptance.testPath` default (`"acceptance.test.ts"`) — but the generator creates `.nax-acceptance.test.ts`.

Result: acceptance stage always skips with "test file not found" and falsely reports all tests passed.

Closes #164

## How

1. **`sequential-executor.ts`**: Forward `acceptanceTestPaths` + `featureDir` from `preRunCtx` to post-run pipeline context
2. **`unified-executor.ts`**: Hoist `preRunCtx` out of `if` block so it's accessible at post-run; forward same fields
3. **`defaults.ts`**: Update `testPath` default from `"acceptance.test.ts"` → `".nax-acceptance.test.ts"` (defense-in-depth)

## Testing

- [x] Tests added/updated — existing 66 tests pass (acceptance + acceptance-setup + sequential-executor)
- [x] `bun test` passes (1455 relevant tests, 0 failures)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Pre-existing flaky test: `interaction-plugins.test.ts` webhook 404 under full suite (port collision). Unrelated to this change.
