### PR TITLE
fix: flaky Interaction Plugin Telegram Test

### DIFF
--- a/src/interaction/plugins/webhook.ts
+++ b/src/interaction/plugins/webhook.ts
@@ -35,7 +35,13 @@ interface WebhookConfig {
 /** Zod schema for validating webhook plugin config */
 const WebhookConfigSchema = z.object({
   url: z.string().url().optional(),
-  callbackPort: z.number().int().min(1024).max(65535).optional(),
+  callbackPort: z
+    .number()
+    .int()
+    .refine((p) => p === 0 || (p >= 1024 && p <= 65535), {
+      message: "Port must be 0 (auto-assign) or between 1024 and 65535",
+    })
+    .optional(),
   secret: z.string().optional(),
   maxPayloadBytes: z.number().int().positive().optional(),
 });
@@ -61,6 +67,12 @@ export class WebhookInteractionPlugin implements InteractionPlugin {
   private pendingResponses = new Map<string, InteractionResponse>();
   /** Event-driven callbacks: requestId → resolve fn (set by receive(), called by handleRequest) */
   private receiveCallbacks = new Map<string, (response: InteractionResponse) => void>();
+
+  /** The actual port the callback server is listening on; null if not yet started. */
+  get callbackServerPort(): number | null {
+    if (!this.server) return null;
+    return (this.server as unknown as { port: number }).port;
+  }
 
   async init(config: Record<string, unknown>): Promise<void> {
     const cfg = WebhookConfigSchema.parse(config);

--- a/test/unit/interaction/interaction-plugins.test.ts
+++ b/test/unit/interaction/interaction-plugins.test.ts
@@ -391,7 +391,7 @@ describe("WebhookInteractionPlugin - send() and HMAC validation", () => {
     const captured: { contentType: string | null; body: unknown } = { contentType: null, body: null };
 
     const testServer = Bun.serve({
-      port: 19977,
+      port: 0, // OS assigns an available port — avoids conflicts on rerun
       fetch: async (req) => {
         captured.contentType = req.headers.get("content-type");
         captured.body = await req.json();
@@ -401,7 +401,7 @@ describe("WebhookInteractionPlugin - send() and HMAC validation", () => {
 
     const plugin = new WebhookInteractionPlugin();
     try {
-      await plugin.init({ url: "http://localhost:19977/hook" });
+      await plugin.init({ url: `http://localhost:${testServer.port}/hook` });
 
       await plugin.send(makeWebhookRequest("wh-send-1"));
 
@@ -410,7 +410,7 @@ describe("WebhookInteractionPlugin - send() and HMAC validation", () => {
       // callbackUrl is injected by send()
       expect(typeof (captured.body as { callbackUrl: string }).callbackUrl).toBe("string");
     } finally {
-      testServer.stop();
+      testServer.stop(true);
       await plugin.destroy();
     }
   });
@@ -419,7 +419,7 @@ describe("WebhookInteractionPlugin - send() and HMAC validation", () => {
     const captured: { signature: string | null; body: string } = { signature: null, body: "" };
 
     const testServer = Bun.serve({
-      port: 19978,
+      port: 0, // OS assigns an available port — avoids conflicts on rerun
       fetch: async (req) => {
         captured.signature = req.headers.get("x-nax-signature");
         captured.body = await req.text();
@@ -429,7 +429,7 @@ describe("WebhookInteractionPlugin - send() and HMAC validation", () => {
 
     const plugin = new WebhookInteractionPlugin();
     try {
-      await plugin.init({ url: "http://localhost:19978/hook", secret: "my-secret" });
+      await plugin.init({ url: `http://localhost:${testServer.port}/hook`, secret: "my-secret" });
 
       await plugin.send(makeWebhookRequest("wh-sig-1"));
 
@@ -438,7 +438,7 @@ describe("WebhookInteractionPlugin - send() and HMAC validation", () => {
       const expected = createHmac("sha256", "my-secret").update(captured.body).digest("hex");
       expect(captured.signature).toBe(expected);
     } finally {
-      testServer.stop();
+      testServer.stop(true);
       await plugin.destroy();
     }
   });
@@ -447,20 +447,23 @@ describe("WebhookInteractionPlugin - send() and HMAC validation", () => {
     const plugin = new WebhookInteractionPlugin();
     // url won't be called in this test — we test the callback server
     await plugin.init({
-      url: "http://localhost:19900/unused",
+      url: "http://localhost/unused",
       secret: "test-secret",
-      callbackPort: 19988,
+      callbackPort: 0, // OS assigns an available port — avoids conflicts on rerun
     });
 
     // Start the callback server by calling receive() in the background
     const receivePromise = plugin.receive("wh-hmac-1", 4000);
 
-    // Give the server a moment to bind
+    // Drain microtasks so startServer() completes and the port is assigned
     await Promise.resolve();
+    await Promise.resolve();
+
+    const callbackPort = plugin.callbackServerPort!;
 
     try {
       // POST without signature → 401
-      const noSigResp = await fetch("http://localhost:19988/nax/interact/wh-hmac-1", {
+      const noSigResp = await fetch(`http://localhost:${callbackPort}/nax/interact/wh-hmac-1`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ requestId: "wh-hmac-1", action: "approve", respondedAt: Date.now() }),
@@ -468,7 +471,7 @@ describe("WebhookInteractionPlugin - send() and HMAC validation", () => {
       expect(noSigResp.status).toBe(401);
 
       // POST with wrong signature → 401
-      const badSigResp = await fetch("http://localhost:19988/nax/interact/wh-hmac-1", {
+      const badSigResp = await fetch(`http://localhost:${callbackPort}/nax/interact/wh-hmac-1`, {
         method: "POST",
         headers: { "Content-Type": "application/json", "X-Nax-Signature": "deadbeef" },
         body: JSON.stringify({ requestId: "wh-hmac-1", action: "approve", respondedAt: Date.now() }),
@@ -478,7 +481,7 @@ describe("WebhookInteractionPlugin - send() and HMAC validation", () => {
       // POST with correct HMAC signature → 200, receive() resolves
       const payload = JSON.stringify({ requestId: "wh-hmac-1", action: "approve", respondedAt: Date.now() });
       const sig = createHmac("sha256", "test-secret").update(payload).digest("hex");
-      const validResp = await fetch("http://localhost:19988/nax/interact/wh-hmac-1", {
+      const validResp = await fetch(`http://localhost:${callbackPort}/nax/interact/wh-hmac-1`, {
         method: "POST",
         headers: { "Content-Type": "application/json", "X-Nax-Signature": sig },
         body: payload,

--- a/test/unit/interaction/telegram-timeout.test.ts
+++ b/test/unit/interaction/telegram-timeout.test.ts
@@ -6,11 +6,22 @@
  * BUG-116: checkReviewGate ignores fallback on timeout (should auto-approve for fallback:"continue")
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { TelegramInteractionPlugin } from "../../../src/interaction/plugins/telegram";
 import type { InteractionRequest } from "../../../src/interaction/types";
 
 describe("TelegramInteractionPlugin - Regression BUG-116", () => {
+  let savedFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    savedFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    mock.restore();
+    globalThis.fetch = savedFetch;
+  });
+
   test("receive() returns respondedBy: 'timeout' on timeout", async () => {
     let editCalled = false;
     let editBody: Record<string, unknown> | null = null;


### PR DESCRIPTION
## What

Interaction Plugin Telegram Test having flaky Test

```
✗ WebhookInteractionPlugin - send() and HMAC validation > send() POSTs payload with correct Content-Type [3.00ms]
✗ WebhookInteractionPlugin - send() and HMAC validation > send() includes X-Nax-Signature header when secret is configured [2.00ms]
✗ WebhookInteractionPlugin - send() and HMAC validation > HMAC validation: tampered payload (no signature) is rejected with 401 [3.00ms]
```


## Why

Cause 1 (cross-file contamination) — `telegram-timeout.test.ts` set globalThis.fetch to a mock with a "not found" 404 catch-all but never restored it. Since Bun runs these files in a shared context, the leaked mock intercepted real fetch() calls in the webhook tests.

Fix: Added `beforeEach`/`afterEach` to save and restore `globalThis.fetch` in `telegram-timeout.test.ts`.

Cause 2 (port reuse on `--rerun-each` (to reproduce flaky test) — Tests 1/2 used hardcoded ports `19977`/`19978` for local capture servers; test 3 used `19988` for the plugin's callback server. On rerun, stop() doesn't guarantee the OS releases the port before the next iteration binds it.

## How

Tests 1/2: switched to `port: 0` (OS-assigned) and read `testServer.port` for the plugin URL; also changed `testServer.stop()` → `testServer.stop(true)` to force-close connections.
Test 3: switched to `callbackPort: 0` and read the actual port via a new `callbackServerPort` getter on the plugin; updated the schema to accept `0` as a valid "auto-assign" value.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
