### PR TITLE
fix(debate): wire ACP plan path, resolve model via config, add JSONL events

### DIFF
--- a/benchmark/configs/debate-haiku-haiku-minimax-override.json
+++ b/benchmark/configs/debate-haiku-haiku-minimax-override.json
@@ -1,0 +1,34 @@
+{
+  "debate": {
+    "enabled": true,
+    "agents": 2,
+    "stages": {
+      "plan": {
+        "enabled": true,
+        "resolver": {
+          "type": "synthesis",
+          "agent": "minimax"
+        },
+        "sessionMode": "stateful",
+        "rounds": 3,
+        "debaters": [
+          { "agent": "claude", "model": "fast" },
+          { "agent": "claude", "model": "fast" }
+        ]
+      },
+      "review": {
+        "enabled": true,
+        "resolver": {
+          "type": "majority-fail-closed",
+          "agent": "minimax"
+        },
+        "sessionMode": "one-shot",
+        "rounds": 2,
+        "debaters": [
+          { "agent": "claude", "model": "fast" },
+          { "agent": "claude", "model": "fast" }
+        ]
+      }
+    }
+  }
+}

--- a/benchmark/configs/debate-haiku-haiku.json
+++ b/benchmark/configs/debate-haiku-haiku.json
@@ -1,0 +1,28 @@
+{
+  "debate": {
+    "enabled": true,
+    "agents": 2,
+    "stages": {
+      "plan": {
+        "enabled": true,
+        "resolver": { "type": "synthesis" },
+        "sessionMode": "stateful",
+        "rounds": 3,
+        "debaters": [
+          { "agent": "claude", "model": "fast" },
+          { "agent": "claude", "model": "fast" }
+        ]
+      },
+      "review": {
+        "enabled": true,
+        "resolver": { "type": "majority-fail-closed" },
+        "sessionMode": "one-shot",
+        "rounds": 2,
+        "debaters": [
+          { "agent": "claude", "model": "fast" },
+          { "agent": "claude", "model": "fast" }
+        ]
+      }
+    }
+  }
+}

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -185,84 +185,84 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
       // fall through — adapter will use its own fallback
     }
 
-    if (isAcp) {
-      // ACP: run as a non-interactive session (no interactionBridge) — agent writes PRD to outputPath
-      logger?.info("plan", "Starting ACP auto planning session", {
-        agent: agentName,
-        model: autoModel ?? config?.plan?.model ?? "balanced",
-        workdir,
-        feature: options.feature,
-        timeoutSeconds,
-      });
-      const pidRegistry = new PidRegistry(workdir);
-      try {
-        await adapter.plan({
-          prompt,
+    // runSingleAgentPlan: closure over adapter, isAcp, autoModel, prompt, outputPath, config, logger
+    const runSingleAgentPlan = async (): Promise<string> => {
+      if (isAcp) {
+        // ACP: run as a non-interactive session (no interactionBridge) — agent writes PRD to outputPath
+        logger?.info("plan", "Starting ACP auto planning session", {
+          agent: agentName,
+          model: autoModel ?? config?.plan?.model ?? "balanced",
           workdir,
-          interactive: false,
+          feature: options.feature,
           timeoutSeconds,
-          config,
-          modelTier: config?.plan?.model ?? "balanced",
-          dangerouslySkipPermissions: resolvePermissions(config, "plan").skipPermissions,
-          maxInteractionTurns: config?.agent?.maxInteractionTurns,
-          featureName: options.feature,
-          pidRegistry,
-          sessionRole: "plan",
         });
-      } finally {
-        await pidRegistry.killAll().catch(() => {});
-      }
-      if (!_planDeps.existsSync(outputPath)) {
-        throw new Error(`[plan] ACP agent did not write PRD to ${outputPath}. Check agent logs for errors.`);
-      }
-      rawResponse = await _planDeps.readFile(outputPath);
-    } else {
-      // CLI: one-shot complete() — simple and fast, no session overhead
-      const debateEnabled = config?.debate?.enabled && config?.debate?.stages?.plan?.enabled;
-      if (debateEnabled) {
-        // Safe: debateEnabled guard confirms config.debate.stages.plan is defined
-        const planStageConfig = config.debate?.stages.plan as import("../debate").DebateStageConfig;
-        const debateSession = _planDeps.createDebateSession({
-          storyId: options.feature,
-          stage: "plan",
-          stageConfig: planStageConfig,
-        });
-        const debateResult = await debateSession.run(prompt);
-        if (debateResult.outcome !== "failed" && debateResult.output) {
-          rawResponse = debateResult.output;
-        } else {
-          logger?.warn("debate", "All debaters failed — falling back to single agent", {
-            stage: "debate",
-            event: "fallback",
-          });
-          rawResponse = await adapter.complete(prompt, {
-            model: autoModel,
-            jsonMode: true,
+        const pidRegistry = new PidRegistry(workdir);
+        try {
+          await adapter.plan({
+            prompt,
             workdir,
+            interactive: false,
+            timeoutSeconds,
             config,
+            modelTier: config?.plan?.model ?? "balanced",
+            dangerouslySkipPermissions: resolvePermissions(config, "plan").skipPermissions,
+            maxInteractionTurns: config?.agent?.maxInteractionTurns,
             featureName: options.feature,
+            pidRegistry,
             sessionRole: "plan",
           });
+        } finally {
+          await pidRegistry.killAll().catch(() => {});
         }
-      } else {
-        rawResponse = await adapter.complete(prompt, {
-          model: autoModel,
-          jsonMode: true,
-          workdir,
-          config,
-          featureName: options.feature,
-          sessionRole: "plan",
-        });
+        if (!_planDeps.existsSync(outputPath)) {
+          throw new Error(`[plan] ACP agent did not write PRD to ${outputPath}. Check agent logs for errors.`);
+        }
+        return await _planDeps.readFile(outputPath);
       }
+      // CLI: one-shot complete() — simple and fast, no session overhead
+      let result = await adapter.complete(prompt, {
+        model: autoModel,
+        jsonMode: true,
+        workdir,
+        config,
+        featureName: options.feature,
+        sessionRole: "plan",
+      });
       // CLI adapter returns {"type":"result","result":"..."} envelope — unwrap it
       try {
-        const envelope = JSON.parse(rawResponse) as Record<string, unknown>;
+        const envelope = JSON.parse(result) as Record<string, unknown>;
         if (envelope?.type === "result" && typeof envelope?.result === "string") {
-          rawResponse = envelope.result;
+          result = envelope.result;
         }
       } catch {
-        // Not an envelope — use rawResponse as-is
+        // Not an envelope — use result as-is
       }
+      return result;
+    };
+
+    // Debate check hoisted above isAcp gate — runs regardless of protocol
+    const debateEnabled = config?.debate?.enabled && config?.debate?.stages?.plan?.enabled;
+    if (debateEnabled) {
+      // Safe: debateEnabled guard confirms config.debate.stages.plan is defined
+      const planStageConfig = config?.debate?.stages.plan as import("../debate").DebateStageConfig;
+      const debateSession = _planDeps.createDebateSession({
+        storyId: options.feature,
+        stage: "plan",
+        stageConfig: planStageConfig,
+        config,
+      });
+      const debateResult = await debateSession.run(prompt);
+      if (debateResult.outcome !== "failed" && debateResult.output) {
+        rawResponse = debateResult.output;
+      } else {
+        logger?.warn("debate", "All debaters failed — falling back to single agent", {
+          stage: "debate",
+          event: "fallback",
+        });
+        rawResponse = await runSingleAgentPlan();
+      }
+    } else {
+      rawResponse = await runSingleAgentPlan();
     }
   } else {
     // Interactive: agent writes PRD JSON directly to outputPath (avoids output truncation)

--- a/src/debate/session.ts
+++ b/src/debate/session.ts
@@ -9,6 +9,8 @@ import type { AcpClient, AcpSession, AcpSessionResponse } from "../agents/acp/ad
 import { createSpawnAcpClient } from "../agents/acp/spawn-client";
 import { getAgent } from "../agents/registry";
 import type { AgentAdapter } from "../agents/types";
+import type { NaxConfig } from "../config";
+import { resolveModelForAgent } from "../config";
 import { getSafeLogger } from "../logger";
 import { buildCritiquePrompt } from "./prompts";
 import { judgeResolver, majorityResolver, synthesisResolver } from "./resolvers";
@@ -17,10 +19,30 @@ import type { DebateResult, DebateStageConfig, Debater, Proposal } from "./types
 /** Fallback agent name used when resolver.agent is not specified for synthesis/judge */
 const RESOLVER_FALLBACK_AGENT = "synthesis";
 
+/**
+ * Resolve the model string for a debater.
+ * When debater.model is set, treat it as a tier name and resolve via config.models.
+ * When absent, default to "fast" tier.
+ * Falls back to the raw debater.model string if config resolution fails (backward compat).
+ */
+export function resolveDebaterModel(debater: Debater, config?: NaxConfig): string | undefined {
+  const tier = debater.model ?? "fast";
+  if (!config?.models) return debater.model;
+  try {
+    const defaultAgent = config.autoMode?.defaultAgent ?? debater.agent;
+    const modelDef = resolveModelForAgent(config.models, debater.agent, tier, defaultAgent);
+    return modelDef.model;
+  } catch {
+    // Config resolution failed — return raw model string as fallback (backward compat)
+    return debater.model;
+  }
+}
+
 export interface DebateSessionOptions {
   storyId: string;
   stage: string;
   stageConfig: DebateStageConfig;
+  config?: NaxConfig;
 }
 
 /** Injectable deps for testability */
@@ -71,11 +93,13 @@ export class DebateSession {
   private readonly storyId: string;
   private readonly stage: string;
   private readonly stageConfig: DebateStageConfig;
+  private readonly config: NaxConfig | undefined;
 
   constructor(opts: DebateSessionOptions) {
     this.storyId = opts.storyId;
     this.stage = opts.stage;
     this.stageConfig = opts.stageConfig;
+    this.config = opts.config;
   }
 
   async run(prompt: string): Promise<DebateResult> {
@@ -105,6 +129,12 @@ export class DebateSession {
       resolved.push({ debater, adapter });
     }
 
+    logger?.info("debate", "debate:start", {
+      storyId: this.storyId,
+      stage: this.stage,
+      debaters: resolved.map((r) => r.debater.agent),
+    });
+
     interface SessionEntry {
       debater: Debater;
       adapter: AgentAdapter;
@@ -117,7 +147,8 @@ export class DebateSession {
       // Create SpawnAcpClient and session per debater
       for (let i = 0; i < resolved.length; i++) {
         const { debater, adapter } = resolved[i];
-        const cmdStr = `acpx --model ${debater.model} ${debater.agent}`;
+        const resolvedModel = resolveDebaterModel(debater, this.config);
+        const cmdStr = resolvedModel ? `acpx --model ${resolvedModel} ${debater.agent}` : `acpx ${debater.agent}`;
         const client = _debateSessionDeps.createSpawnAcpClient(cmdStr);
         const sessionName = `nax-debate-${this.storyId}-${i}`;
 
@@ -137,9 +168,19 @@ export class DebateSession {
       if (sessions.length < 2) {
         // Single-agent fallback — run the one successful session as solo
         if (sessions.length === 1) {
+          logger?.warn("debate", "debate:fallback", {
+            storyId: this.storyId,
+            stage: this.stage,
+            reason: "only 1 session created",
+          });
           const solo = sessions[0];
           const response = await solo.session.prompt(prompt);
           const output = extractSessionOutput(response);
+          logger?.info("debate", "debate:result", {
+            storyId: this.storyId,
+            stage: this.stage,
+            outcome: "passed",
+          });
           return {
             storyId: this.storyId,
             stage: this.stage,
@@ -151,6 +192,11 @@ export class DebateSession {
             totalCostUsd,
           };
         }
+        logger?.warn("debate", "debate:fallback", {
+          storyId: this.storyId,
+          stage: this.stage,
+          reason: "no sessions created",
+        });
         return buildFailedResult(this.storyId, this.stage, config, totalCostUsd);
       }
 
@@ -171,7 +217,22 @@ export class DebateSession {
 
       // AC5: minimum 2 debaters required for a valid debate
       if (successfulSessions.length < 2) {
+        logger?.warn("debate", "debate:fallback", {
+          storyId: this.storyId,
+          stage: this.stage,
+          reason: "fewer than 2 proposal rounds succeeded",
+        });
         return buildFailedResult(this.storyId, this.stage, config, totalCostUsd);
+      }
+
+      for (let i = 0; i < successfulSessions.length; i++) {
+        const s = successfulSessions[i];
+        logger?.info("debate", "debate:proposal", {
+          storyId: this.storyId,
+          stage: this.stage,
+          debaterIndex: i,
+          agent: s.entry.debater.agent,
+        });
       }
 
       // Critique round (when rounds > 1)
@@ -207,6 +268,11 @@ export class DebateSession {
         output: s.output,
       }));
 
+      logger?.info("debate", "debate:result", {
+        storyId: this.storyId,
+        stage: this.stage,
+        outcome,
+      });
       return {
         storyId: this.storyId,
         stage: this.stage,
@@ -239,11 +305,17 @@ export class DebateSession {
       resolved.push({ debater, adapter });
     }
 
+    logger?.info("debate", "debate:start", {
+      storyId: this.storyId,
+      stage: this.stage,
+      debaters: resolved.map((r) => r.debater.agent),
+    });
+
     // Step 2: Proposal round — parallel via Promise.allSettled
     const proposalSettled = await Promise.allSettled(
       resolved.map(({ debater, adapter }) =>
         adapter
-          .complete(prompt, { model: debater.model })
+          .complete(prompt, { model: resolveDebaterModel(debater, this.config) })
           // complete() returns string only — cost is 0 until the interface exposes cost metadata
           .then((output) => ({ debater, adapter, output, cost: 0 })),
       ),
@@ -260,10 +332,30 @@ export class DebateSession {
       }
     }
 
+    for (let i = 0; i < successful.length; i++) {
+      logger?.info("debate", "debate:proposal", {
+        storyId: this.storyId,
+        stage: this.stage,
+        debaterIndex: i,
+        agent: successful[i].debater.agent,
+        model: resolveDebaterModel(successful[i].debater, this.config),
+      });
+    }
+
     // Step 3: Fewer than 2 succeeded — single-agent fallback
     if (successful.length < 2) {
       if (successful.length === 1) {
+        logger?.warn("debate", "debate:fallback", {
+          storyId: this.storyId,
+          stage: this.stage,
+          reason: "only 1 debater succeeded",
+        });
         const solo = successful[0];
+        logger?.info("debate", "debate:result", {
+          storyId: this.storyId,
+          stage: this.stage,
+          outcome: "passed",
+        });
         return {
           storyId: this.storyId,
           stage: this.stage,
@@ -279,9 +371,21 @@ export class DebateSession {
       // All debaters failed — attempt fresh complete() on first resolved adapter (AC4)
       if (resolved.length > 0) {
         const { adapter: fallbackAdapter, debater: fallbackDebater } = resolved[0];
+        logger?.warn("debate", "debate:fallback", {
+          storyId: this.storyId,
+          stage: this.stage,
+          reason: "all debaters failed — retrying with first adapter",
+        });
         try {
-          const fallbackOutput = await fallbackAdapter.complete(prompt, { model: fallbackDebater.model });
+          const fallbackOutput = await fallbackAdapter.complete(prompt, {
+            model: resolveDebaterModel(fallbackDebater, this.config),
+          });
           // cost from fresh fallback call — 0 until complete() exposes cost metadata
+          logger?.info("debate", "debate:result", {
+            storyId: this.storyId,
+            stage: this.stage,
+            outcome: "passed",
+          });
           return {
             storyId: this.storyId,
             stage: this.stage,
@@ -307,7 +411,7 @@ export class DebateSession {
       const critiqueSettled = await Promise.allSettled(
         successful.map(({ debater, adapter }, i) =>
           adapter.complete(buildCritiquePrompt(prompt, proposalOutputs, i), {
-            model: debater.model,
+            model: resolveDebaterModel(debater, this.config),
           }),
         ),
       );
@@ -333,6 +437,11 @@ export class DebateSession {
       output: p.output,
     }));
 
+    logger?.info("debate", "debate:result", {
+      storyId: this.storyId,
+      stage: this.stage,
+      outcome,
+    });
     return {
       storyId: this.storyId,
       stage: this.stage,
@@ -348,7 +457,7 @@ export class DebateSession {
   private async resolve(
     proposalOutputs: string[],
     critiqueOutputs: string[],
-    successful: SuccessfulProposal[],
+    _successful: SuccessfulProposal[],
   ): Promise<"passed" | "failed" | "skipped"> {
     const resolverConfig = this.stageConfig.resolver;
 

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -322,6 +322,7 @@ export async function runSemanticReview(
       storyId: story.id,
       stage: "review",
       stageConfig: reviewStageConfig,
+      config: naxConfig,
     });
     const debateResult = await debateSession.run(prompt);
 

--- a/test/unit/debate/session.test.ts
+++ b/test/unit/debate/session.test.ts
@@ -10,11 +10,14 @@
  * - AC6: critique round is skipped when rounds === 1
  * - AC11: DebateResult.totalCostUsd aggregates all complete() call costs
  * - AC12: DebateResult.proposals contains debater identity alongside each output
+ * - resolveDebaterModel: explicit model, config lookup, missing config fallback
+ * - JSONL events: debate:start, debate:proposal, debate:result, debate:fallback
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { DebateSession, _debateSessionDeps } from "../../../src/debate/session";
-import type { DebateStageConfig } from "../../../src/debate/types";
+import { DebateSession, _debateSessionDeps, resolveDebaterModel } from "../../../src/debate/session";
+import type { DebateStageConfig, Debater } from "../../../src/debate/types";
+import type { NaxConfig } from "../../../src/config";
 import type { AgentAdapter, CompleteOptions } from "../../../src/agents/types";
 
 // ─── Mock Helpers ──────────────────────────────────────────────────────────────
@@ -670,5 +673,248 @@ describe("DebateSession.run() — proposals structure", () => {
     expect(result.storyId).toBe("US-002");
     expect(result.stage).toBe("review");
     expect(result.resolverType).toBe("majority-fail-closed");
+  });
+});
+
+// ─── resolveDebaterModel ─────────────────────────────────────────────────────
+
+describe("resolveDebaterModel()", () => {
+  test("returns debater.model as-is when no config provided", () => {
+    const debater: Debater = { agent: "claude", model: "fast" };
+    // No config → falls back to raw debater.model
+    expect(resolveDebaterModel(debater)).toBe("fast");
+  });
+
+  test("resolves debater.model as tier name via config.models", () => {
+    const debater: Debater = { agent: "claude", model: "fast" };
+    const config = {
+      models: { claude: { fast: "claude-haiku-4-5" } },
+      autoMode: { defaultAgent: "claude" },
+    } as unknown as NaxConfig;
+    // "fast" is resolved via config.models.claude.fast
+    expect(resolveDebaterModel(debater, config)).toBe("claude-haiku-4-5");
+  });
+
+  test("resolves balanced tier via config.models", () => {
+    const debater: Debater = { agent: "claude", model: "balanced" };
+    const config = {
+      models: { claude: { fast: "claude-haiku-4-5", balanced: "claude-sonnet-4-5" } },
+      autoMode: { defaultAgent: "claude" },
+    } as unknown as NaxConfig;
+    expect(resolveDebaterModel(debater, config)).toBe("claude-sonnet-4-5");
+  });
+
+  test("falls back to raw model string when tier not found in config", () => {
+    const debater: Debater = { agent: "claude", model: "custom-unknown-tier" };
+    const config = {
+      models: { claude: { fast: "claude-haiku-4-5" } },
+      autoMode: { defaultAgent: "claude" },
+    } as unknown as NaxConfig;
+    // "custom-unknown-tier" not in config → fallback to raw string
+    expect(resolveDebaterModel(debater, config)).toBe("custom-unknown-tier");
+  });
+
+  test("defaults to fast tier when model is absent", () => {
+    const debater: Debater = { agent: "claude" };
+    const config = {
+      models: { claude: { fast: "claude-haiku-4-5" } },
+      autoMode: { defaultAgent: "claude" },
+    } as unknown as NaxConfig;
+    expect(resolveDebaterModel(debater, config)).toBe("claude-haiku-4-5");
+  });
+
+  test("returns undefined when model absent and config has no models", () => {
+    const debater: Debater = { agent: "claude" };
+    expect(resolveDebaterModel(debater, undefined)).toBeUndefined();
+  });
+
+  test("returns undefined when model absent and config.models is undefined", () => {
+    const debater: Debater = { agent: "claude" };
+    const config = {} as NaxConfig;
+    expect(resolveDebaterModel(debater, config)).toBeUndefined();
+  });
+
+  test("falls back to defaultAgent model when agent has no entry in config.models", () => {
+    const debater: Debater = { agent: "unknown-agent" };
+    const config = {
+      models: { claude: { fast: "claude-haiku-4-5" } },
+      autoMode: { defaultAgent: "claude" },
+    } as unknown as NaxConfig;
+    // resolveModelForAgent falls back to defaultAgent
+    expect(resolveDebaterModel(debater, config)).toBe("claude-haiku-4-5");
+  });
+
+  test("returns undefined when agent and defaultAgent both missing from config.models", () => {
+    const debater: Debater = { agent: "unknown-agent" };
+    const config = {
+      models: {},
+      autoMode: { defaultAgent: "also-missing" },
+    } as unknown as NaxConfig;
+    // resolveModelForAgent throws → we catch and return undefined
+    expect(resolveDebaterModel(debater, config)).toBeUndefined();
+  });
+});
+
+// ─── JSONL log events ─────────────────────────────────────────────────────────
+
+describe("DebateSession.run() — JSONL log events", () => {
+  test("emits debate:start event with storyId, stage, and debaters", async () => {
+    const events: Array<{ stage: string; event: string; data: Record<string, unknown> }> = [];
+
+    _debateSessionDeps.getSafeLogger = mock(() => ({
+      info: (stage: string, event: string, data: Record<string, unknown>) => {
+        events.push({ stage, event, data });
+      },
+      debug: () => {},
+      warn: () => {},
+      error: () => {},
+    })) as never;
+
+    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
+
+    const session = new DebateSession({
+      storyId: "US-LOG",
+      stage: "plan",
+      stageConfig: makeStageConfig({
+        debaters: [{ agent: "claude" }, { agent: "opencode" }],
+        rounds: 1,
+      }),
+    });
+
+    await session.run("prompt");
+
+    const startEvent = events.find((e) => e.event === "debate:start");
+    expect(startEvent).toBeDefined();
+    expect(startEvent?.data.storyId).toBe("US-LOG");
+    expect(startEvent?.data.stage).toBe("plan");
+    expect(Array.isArray(startEvent?.data.debaters)).toBe(true);
+  });
+
+  test("emits debate:proposal events after proposal round", async () => {
+    const events: Array<{ stage: string; event: string; data: Record<string, unknown> }> = [];
+
+    _debateSessionDeps.getSafeLogger = mock(() => ({
+      info: (stage: string, event: string, data: Record<string, unknown>) => {
+        events.push({ stage, event, data });
+      },
+      debug: () => {},
+      warn: () => {},
+      error: () => {},
+    })) as never;
+
+    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
+
+    const session = new DebateSession({
+      storyId: "US-LOG",
+      stage: "review",
+      stageConfig: makeStageConfig({
+        debaters: [{ agent: "claude" }, { agent: "opencode" }],
+        rounds: 1,
+      }),
+    });
+
+    await session.run("prompt");
+
+    const proposalEvents = events.filter((e) => e.event === "debate:proposal");
+    expect(proposalEvents.length).toBe(2);
+    expect(proposalEvents[0]?.data.storyId).toBe("US-LOG");
+    expect(proposalEvents[0]?.data.debaterIndex).toBe(0);
+  });
+
+  test("emits debate:result event at the end of a successful debate", async () => {
+    const events: Array<{ stage: string; event: string; data: Record<string, unknown> }> = [];
+
+    _debateSessionDeps.getSafeLogger = mock(() => ({
+      info: (stage: string, event: string, data: Record<string, unknown>) => {
+        events.push({ stage, event, data });
+      },
+      debug: () => {},
+      warn: () => {},
+      error: () => {},
+    })) as never;
+
+    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
+
+    const session = new DebateSession({
+      storyId: "US-LOG",
+      stage: "review",
+      stageConfig: makeStageConfig({
+        debaters: [{ agent: "claude" }, { agent: "opencode" }],
+        rounds: 1,
+      }),
+    });
+
+    await session.run("prompt");
+
+    const resultEvent = events.find((e) => e.event === "debate:result");
+    expect(resultEvent).toBeDefined();
+    expect(resultEvent?.data.storyId).toBe("US-LOG");
+    expect(resultEvent?.data.outcome).toBeDefined();
+  });
+
+  test("emits debate:fallback warn event when only 1 debater succeeds", async () => {
+    const warnings: Array<{ stage: string; event: string; data: Record<string, unknown> }> = [];
+
+    _debateSessionDeps.getSafeLogger = mock(() => ({
+      info: () => {},
+      debug: () => {},
+      warn: (stage: string, event: string, data: Record<string, unknown>) => {
+        warnings.push({ stage, event, data });
+      },
+      error: () => {},
+    })) as never;
+
+    _debateSessionDeps.getAgent = mock((name: string) => {
+      if (name === "missing") return undefined;
+      return makeMockAdapter(name);
+    });
+
+    const session = new DebateSession({
+      storyId: "US-LOG",
+      stage: "review",
+      stageConfig: makeStageConfig({
+        debaters: [{ agent: "claude" }, { agent: "missing" }],
+        rounds: 1,
+      }),
+    });
+
+    await session.run("prompt");
+
+    const fallbackWarning = warnings.find((w) => w.event === "debate:fallback");
+    expect(fallbackWarning).toBeDefined();
+    expect(fallbackWarning?.data.storyId).toBe("US-LOG");
+  });
+
+  test("uses resolveDebaterModel to pass resolved model to complete()", async () => {
+    const completeCalls: Array<{ agent: string; model: string | undefined }> = [];
+
+    _debateSessionDeps.getAgent = mock((name: string) =>
+      makeMockAdapter(name, {
+        completeFn: async (_prompt, opts) => {
+          completeCalls.push({ agent: name, model: opts?.model });
+          return `output from ${name}`;
+        },
+      }),
+    );
+
+    const config = {
+      models: { claude: { fast: "claude-haiku-4-5" } },
+      autoMode: { defaultAgent: "claude" },
+    } as unknown as NaxConfig;
+
+    const session = new DebateSession({
+      storyId: "US-LOG",
+      stage: "review",
+      stageConfig: makeStageConfig({
+        debaters: [{ agent: "claude" }, { agent: "claude" }],
+        rounds: 1,
+      }),
+      config,
+    });
+
+    await session.run("prompt");
+
+    // Both debaters should have model resolved from config.models.claude.fast
+    expect(completeCalls.every((c) => c.model === "claude-haiku-4-5")).toBe(true);
   });
 });


### PR DESCRIPTION
## What

Fix three debate pipeline bugs and wire up proper model resolution:

1. **Plan debate dead code (#172):** Debate check was inside the CLI-only `else` branch — never fired for ACP protocol (the default). Hoisted debate check above the `isAcp` gate.
2. **Wrong model in debate (#173):** `resolveDebaterModel()` now treats `debater.model` as a tier name (e.g. `"fast"`) and resolves it via `resolveModelForAgent()` from the per-agent model map. Falls back to raw string if resolution fails (backward compat).
3. **No debate logs (#174):** Added structured JSONL events: `debate:start`, `debate:proposal`, `debate:result`, `debate:fallback`.

## Why

Debate was silently broken for all ACP configs (the default). Model resolution was passing raw tier names like `"fast"` to `--model` instead of resolving them through `config.models`. And debate runs left no trace in the JSONL log.

Closes #172, #173, #174

## How

### `src/debate/session.ts`
- `resolveDebaterModel(debater, config)` — treats `debater.model` as tier name, resolves via `resolveModelForAgent()`. When model absent, defaults to `"fast"` tier. Falls back to raw string when config resolution fails.
- Used in both `runOneShot` (`adapter.complete`) and `runStateful` (`acpx --model`)
- JSONL events added at: debate start, each proposal, result, and fallback points

### `src/cli/plan.ts`
- Extracted `runSingleAgentPlan()` closure from the existing `if(isAcp){...}else{...}` block
- Debate check hoisted above protocol gate — runs for both ACP and CLI
- `config` passed to `createDebateSession` for model resolution

### `src/review/semantic.ts`
- Pass `config: naxConfig` to `createDebateSession`

### Benchmark configs
- Both `debate-haiku-haiku.json` and `debate-haiku-haiku-minimax-override.json` use `"model": "fast"` (tier name) in debaters array — resolved at runtime via per-agent model map

## Testing
- [x] Tests added/updated — 7 `resolveDebaterModel` unit tests + 5 JSONL event tests
- [x] `bun test` passes (94 debate tests, full suite pending fire-back)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
- `resolveDebaterModel` follows the same `resolveModelForAgent()` pattern used by all 22 callsites in nax (per SPEC-per-agent-model-map)
- Backward compat: if `debater.model` is a literal model name not found as a tier, the raw string is returned as fallback
