### PR TITLE
fix(env): add OPENCODE_ and MINIMAX_ to agent subprocess env allowlist

### DIFF
--- a/src/agents/shared/env.ts
+++ b/src/agents/shared/env.ts
@@ -25,7 +25,18 @@ const API_KEY_VARS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "
  * Env var prefixes passed through in bulk.
  * Union of CLI and ACP adapter needs.
  */
-const ALLOWED_PREFIXES = ["CLAUDE_", "NAX_", "CLAW_", "TURBO_", "ACPX_", "CODEX_", "GEMINI_", "ANTHROPIC_"];
+const ALLOWED_PREFIXES = [
+  "CLAUDE_",
+  "NAX_",
+  "CLAW_",
+  "TURBO_",
+  "ACPX_",
+  "CODEX_",
+  "GEMINI_",
+  "ANTHROPIC_",
+  "OPENCODE_",
+  "MINIMAX_",
+];
 
 export interface BuildAllowedEnvOptions {
   /** Extra vars merged in last (highest priority). */


### PR DESCRIPTION
## What

Add `OPENCODE_` and `MINIMAX_` to `ALLOWED_PREFIXES` in `src/agents/shared/env.ts`.

## Why

- `OPENCODE_` env vars (including `OPENCODE_CONFIG_DIR`) were silently dropped when nax spawned agent subprocesses — OpenCode couldn't find its config directory
- `MINIMAX_` env vars were also stripped, preventing MiniMax API key/config from reaching agents
- `CODEX_` was already present; this completes the set of current agent providers

## How

Single-line change to `ALLOWED_PREFIXES` in the canonical shared env allowlist. Both prefixes are now passed through to all agent subprocesses (Claude adapter + ACP adapter) via `buildAllowedEnv()`.

## Testing
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Companion change: `nax-launch.py` on Mac01 updated separately to inject `OPENCODE_CONFIG_DIR=~/.local/share/opencode` into the nax launch environment.
