### PR TITLE
refactor(adapter.complete): to add cost tracking on adapter.complete()

### DIFF
--- a/src/acceptance/fix-generator.ts
+++ b/src/acceptance/fix-generator.ts
@@ -291,7 +291,7 @@ export async function generateFixStories(
     const workdir = relatedStory?.workdir;
 
     try {
-      const fixDescription = await adapter.complete(prompt, {
+      const fixResult = await adapter.complete(prompt, {
         model: modelDef.model,
         config: options.config,
         featureName: options.prd.feature,
@@ -306,7 +306,7 @@ export async function generateFixStories(
         batchedACs,
         testOutput,
         relatedStories,
-        description: fixDescription,
+        description: typeof fixResult === "string" ? fixResult : fixResult.output,
         testFilePath,
         workdir,
       });

--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -203,7 +203,7 @@ Rules:
 
   logger.info("acceptance", "Generating tests from PRD refined criteria", { count: refinedCriteria.length });
 
-  const rawOutput = await (options.adapter ?? _generatorPRDDeps.adapter).complete(prompt, {
+  const completeResult = await (options.adapter ?? _generatorPRDDeps.adapter).complete(prompt, {
     model: options.modelDef.model,
     config: options.config,
     timeoutMs: options.config?.acceptance?.timeoutMs ?? 1800000,
@@ -211,6 +211,7 @@ Rules:
     featureName: options.featureName,
     sessionRole: "acceptance-gen",
   });
+  const rawOutput = typeof completeResult === "string" ? completeResult : completeResult.output;
   let testCode = extractTestCode(rawOutput);
 
   logger.debug("acceptance", "Received raw output from LLM", {
@@ -452,7 +453,7 @@ export async function generateAcceptanceTests(
 
   try {
     // Call adapter to generate tests
-    const output = await adapter.complete(prompt, {
+    const completeResult = await adapter.complete(prompt, {
       model: options.modelDef.model,
       config: options.config,
       timeoutMs: options.config?.acceptance?.timeoutMs ?? 1800000,
@@ -460,6 +461,7 @@ export async function generateAcceptanceTests(
       featureName: options.featureName,
       sessionRole: "acceptance-gen",
     });
+    const output = typeof completeResult === "string" ? completeResult : completeResult.output;
 
     // Extract test code from output
     const testCode = extractTestCode(output);

--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -187,7 +187,7 @@ export async function refineAcceptanceCriteria(
   let response: string;
 
   try {
-    response = await _refineDeps.adapter.complete(prompt, {
+    const completeResult = await _refineDeps.adapter.complete(prompt, {
       jsonMode: true,
       maxTokens: 4096,
       model: modelDef.model,
@@ -197,6 +197,7 @@ export async function refineAcceptanceCriteria(
       workdir,
       sessionRole: "refine",
     });
+    response = typeof completeResult === "string" ? completeResult : completeResult.output;
   } catch (error) {
     const reason = errorMessage(error);
     logger.warn("refinement", "adapter.complete() failed, falling back to original criteria", {

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -27,6 +27,7 @@ import type {
   AgentResult,
   AgentRunOptions,
   CompleteOptions,
+  CompleteResult,
   DecomposeOptions,
   DecomposeResult,
   PlanOptions,
@@ -846,7 +847,7 @@ export class AcpAgentAdapter implements AgentAdapter {
     };
   }
 
-  async complete(prompt: string, _options?: CompleteOptions): Promise<string> {
+  async complete(prompt: string, _options?: CompleteOptions): Promise<CompleteResult> {
     const timeoutMs = _options?.timeoutMs ?? 120_000;
     const permissionMode = resolvePermissions(_options?.config, "complete").mode;
     const workdir = _options?.workdir;
@@ -873,7 +874,7 @@ export class AcpAgentAdapter implements AgentAdapter {
     };
 
     // Attempt one call with the given agent; throws on any error
-    const tryOneAgent = async (agentName: string): Promise<string> => {
+    const tryOneAgent = async (agentName: string): Promise<CompleteResult> => {
       const model = await resolveModel(agentName);
       const cmdStr = `acpx --model ${model} ${agentName}`;
       const client = _acpAdapterDeps.createClient(cmdStr, workdir);
@@ -926,9 +927,26 @@ export class AcpAgentAdapter implements AgentAdapter {
 
         if (response.exactCostUsd !== undefined) {
           getSafeLogger()?.info("acp-adapter", "complete() cost", { costUsd: response.exactCostUsd, model });
+          return {
+            output: unwrapped,
+            costUsd: response.exactCostUsd,
+            source: "exact",
+          };
         }
 
-        return unwrapped;
+        if (response.cumulative_token_usage) {
+          return {
+            output: unwrapped,
+            costUsd: estimateCostFromTokenUsage(response.cumulative_token_usage, model),
+            source: "estimated",
+          };
+        }
+
+        return {
+          output: unwrapped,
+          costUsd: 0,
+          source: "fallback",
+        };
       } catch (err) {
         hadError = true;
         throw err;
@@ -1080,13 +1098,14 @@ export class AcpAgentAdapter implements AgentAdapter {
 
     let output: string;
     try {
-      output = await this.complete(prompt, {
+      const completeResult = await this.complete(prompt, {
         model,
         jsonMode: true,
         config: options.config as import("../../config").NaxConfig | undefined,
         workdir: options.workdir,
         sessionRole: "decompose",
       });
+      output = completeResult.output;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       throw new Error(`[acp-adapter] decompose() failed: ${msg}`, { cause: err });

--- a/src/agents/aider/adapter.ts
+++ b/src/agents/aider/adapter.ts
@@ -12,6 +12,7 @@ import type {
   AgentResult,
   AgentRunOptions,
   CompleteOptions,
+  CompleteResult,
   DecomposeOptions,
   DecomposeResult,
   PlanOptions,
@@ -82,7 +83,7 @@ export class AiderAdapter implements AgentAdapter {
     };
   }
 
-  async complete(prompt: string, options?: CompleteOptions): Promise<string> {
+  async complete(prompt: string, options?: CompleteOptions): Promise<CompleteResult> {
     const cmd = ["aider", "--message", prompt, "--yes"];
 
     if (options?.model) {
@@ -106,7 +107,11 @@ export class AiderAdapter implements AgentAdapter {
       throw new CompleteError("complete() returned empty output");
     }
 
-    return trimmed;
+    return {
+      output: trimmed,
+      costUsd: 0,
+      source: "fallback",
+    };
   }
 
   async plan(_options: PlanOptions): Promise<PlanResult> {

--- a/src/agents/claude/adapter.ts
+++ b/src/agents/claude/adapter.ts
@@ -9,6 +9,7 @@ import { PidRegistry } from "../../execution/pid-registry";
 import { withProcessTimeout } from "../../execution/timeout-handler";
 import { getLogger } from "../../logger";
 import { sleep, typedSpawn } from "../../utils/bun-deps";
+import { estimateCostByDuration } from "../cost/calculate";
 import { buildDecomposePrompt, parseDecomposeOutput } from "../shared/decompose";
 import type {
   AgentAdapter,
@@ -16,6 +17,7 @@ import type {
   AgentResult,
   AgentRunOptions,
   CompleteOptions,
+  CompleteResult,
   DecomposeOptions,
   DecomposeResult,
   InteractiveRunOptions,
@@ -149,8 +151,18 @@ export class ClaudeCodeAdapter implements AgentAdapter {
     }
   }
 
-  async complete(prompt: string, options?: CompleteOptions): Promise<string> {
-    return executeComplete(this.binary, prompt, options);
+  async complete(prompt: string, options?: CompleteOptions): Promise<CompleteResult> {
+    const startTime = Date.now();
+    const output = await executeComplete(this.binary, prompt, options);
+    const durationMs = Date.now() - startTime;
+    const modelTier = options?.modelTier ?? "balanced";
+    const estimate = estimateCostByDuration(modelTier, durationMs);
+
+    return {
+      output,
+      costUsd: estimate.cost,
+      source: estimate.confidence,
+    };
   }
 
   async plan(options: PlanOptions): Promise<PlanResult> {

--- a/src/agents/codex/adapter.ts
+++ b/src/agents/codex/adapter.ts
@@ -12,6 +12,7 @@ import type {
   AgentResult,
   AgentRunOptions,
   CompleteOptions,
+  CompleteResult,
   DecomposeOptions,
   DecomposeResult,
   PlanOptions,
@@ -87,7 +88,7 @@ export class CodexAdapter implements AgentAdapter {
     };
   }
 
-  async complete(prompt: string, _options?: CompleteOptions): Promise<string> {
+  async complete(prompt: string, _options?: CompleteOptions): Promise<CompleteResult> {
     const cmd = ["codex", "-q", "--prompt", prompt];
 
     const proc = _codexCompleteDeps.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
@@ -107,7 +108,11 @@ export class CodexAdapter implements AgentAdapter {
       throw new CompleteError("complete() returned empty output");
     }
 
-    return trimmed;
+    return {
+      output: trimmed,
+      costUsd: 0,
+      source: "fallback",
+    };
   }
 
   async plan(_options: PlanOptions): Promise<PlanResult> {

--- a/src/agents/gemini/adapter.ts
+++ b/src/agents/gemini/adapter.ts
@@ -12,6 +12,7 @@ import type {
   AgentResult,
   AgentRunOptions,
   CompleteOptions,
+  CompleteResult,
   DecomposeOptions,
   DecomposeResult,
   PlanOptions,
@@ -111,7 +112,7 @@ export class GeminiAdapter implements AgentAdapter {
     };
   }
 
-  async complete(prompt: string, _options?: CompleteOptions): Promise<string> {
+  async complete(prompt: string, _options?: CompleteOptions): Promise<CompleteResult> {
     const cmd = ["gemini", "-p", prompt];
 
     const proc = _geminiCompleteDeps.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
@@ -131,7 +132,11 @@ export class GeminiAdapter implements AgentAdapter {
       throw new CompleteError("complete() returned empty output");
     }
 
-    return trimmed;
+    return {
+      output: trimmed,
+      costUsd: 0,
+      source: "fallback",
+    };
   }
 
   async plan(_options: PlanOptions): Promise<PlanResult> {

--- a/src/agents/opencode/adapter.ts
+++ b/src/agents/opencode/adapter.ts
@@ -12,6 +12,7 @@ import type {
   AgentResult,
   AgentRunOptions,
   CompleteOptions,
+  CompleteResult,
   DecomposeOptions,
   DecomposeResult,
   PlanOptions,
@@ -57,7 +58,7 @@ export class OpenCodeAdapter implements AgentAdapter {
     throw new Error("OpenCodeAdapter.run() not implemented");
   }
 
-  async complete(prompt: string, _options?: CompleteOptions): Promise<string> {
+  async complete(prompt: string, _options?: CompleteOptions): Promise<CompleteResult> {
     const cmd = ["opencode", "--prompt", prompt];
 
     const proc = _opencodeCompleteDeps.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
@@ -77,7 +78,11 @@ export class OpenCodeAdapter implements AgentAdapter {
       throw new CompleteError("complete() returned empty output");
     }
 
-    return trimmed;
+    return {
+      output: trimmed,
+      costUsd: 0,
+      source: "fallback",
+    };
   }
 
   async plan(_options: PlanOptions): Promise<PlanResult> {

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -157,6 +157,18 @@ export interface CompleteOptions {
 }
 
 /**
+ * Result for one-shot completion calls that include normalized cost metadata.
+ */
+export interface CompleteResult {
+  /** Raw text output from the completion call */
+  output: string;
+  /** Cost for this completion call in USD */
+  costUsd: number;
+  /** How costUsd was derived */
+  source: "exact" | "estimated" | "fallback";
+}
+
+/**
  * Typed error thrown when complete() fails due to non-zero exit or empty output.
  */
 export class CompleteError extends Error {
@@ -215,10 +227,10 @@ export interface AgentAdapter {
   ): Promise<import("./shared/types-extended").DecomposeResult>;
 
   /**
-   * Run a one-shot LLM call and return the plain text response.
+   * Run a one-shot LLM call and return output with cost metadata.
    * Uses claude -p CLI for non-interactive completions.
    */
-  complete(prompt: string, options?: CompleteOptions): Promise<string>;
+  complete(prompt: string, options?: CompleteOptions): Promise<CompleteResult>;
 
   /**
    * Run the agent in interactive PTY mode for TUI embedding.

--- a/src/analyze/classifier.ts
+++ b/src/analyze/classifier.ts
@@ -117,12 +117,13 @@ async function classifyWithLLM(
   );
 
   // Make API call via adapter (uses config.models.fast tier)
-  const jsonText = await _classifyDeps.adapter.complete(prompt, {
+  const completeResult = await _classifyDeps.adapter.complete(prompt, {
     jsonMode: true,
     maxTokens: 4096,
     model: modelDef.model,
     config,
   });
+  const jsonText = typeof completeResult === "string" ? completeResult : completeResult.output;
 
   // Parse JSON response
   const parsed: unknown = JSON.parse(jsonText);

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -220,7 +220,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
         return await _planDeps.readFile(outputPath);
       }
       // CLI: one-shot complete() — simple and fast, no session overhead
-      let result = await adapter.complete(prompt, {
+      const completeResult = await adapter.complete(prompt, {
         model: autoModel,
         jsonMode: true,
         workdir,
@@ -228,6 +228,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
         featureName: options.feature,
         sessionRole: "plan",
       });
+      let result = typeof completeResult === "string" ? completeResult : completeResult.output;
       // CLI adapter returns {"type":"result","result":"..."} envelope — unwrap it
       try {
         const envelope = JSON.parse(result) as Record<string, unknown>;
@@ -758,22 +759,24 @@ export async function planDecomposeCommand(
     if (debateResult.outcome !== "failed" && debateResult.output) {
       rawResponse = debateResult.output;
     } else {
-      rawResponse = await adapter.complete(prompt, {
+      const completeResult = await adapter.complete(prompt, {
         jsonMode: true,
         workdir,
         sessionRole: "decompose",
         featureName: options.feature,
         storyId: options.storyId,
       });
+      rawResponse = typeof completeResult === "string" ? completeResult : completeResult.output;
     }
   } else {
-    rawResponse = await adapter.complete(prompt, {
+    const completeResult = await adapter.complete(prompt, {
       jsonMode: true,
       workdir,
       sessionRole: "decompose",
       featureName: options.feature,
       storyId: options.storyId,
     });
+    rawResponse = typeof completeResult === "string" ? completeResult : completeResult.output;
   }
 
   // Strip markdown code fences if the LLM wrapped JSON in backticks

--- a/src/debate/resolvers.ts
+++ b/src/debate/resolvers.ts
@@ -7,7 +7,7 @@
  * - judgeResolver: calls adapter.complete() with a judge prompt using resolver.agent
  */
 
-import type { AgentAdapter } from "../agents/types";
+import type { AgentAdapter, CompleteResult } from "../agents/types";
 import { buildJudgePrompt, buildSynthesisPrompt } from "./prompts";
 import type { ResolverConfig } from "./types";
 
@@ -60,13 +60,13 @@ export function majorityResolver(proposals: string[], failOpen: boolean): "passe
 
 /**
  * Synthesis resolver — calls adapter.complete() once with a synthesis prompt.
- * Returns the raw output string from the adapter.
+ * Returns the full completion result including output and cost metadata.
  */
 export async function synthesisResolver(
   proposals: string[],
   critiques: string[],
   opts: { adapter: AgentAdapter },
-): Promise<string> {
+): Promise<CompleteResult> {
   const prompt = buildSynthesisPrompt(proposals, critiques);
   return opts.adapter.complete(prompt);
 }
@@ -74,6 +74,7 @@ export async function synthesisResolver(
 /**
  * Judge resolver — calls adapter.complete() once with a judge prompt.
  * Uses resolver.agent (or defaultAgentName) to look up the judge adapter.
+ * Returns the full completion result including output and cost metadata.
  */
 export async function judgeResolver(
   proposals: string[],
@@ -83,7 +84,7 @@ export async function judgeResolver(
     getAgent: (name: string) => AgentAdapter | undefined;
     defaultAgentName?: string;
   },
-): Promise<string> {
+): Promise<CompleteResult> {
   const agentName = resolverConfig.agent ?? opts.defaultAgentName ?? DEFAULT_FALLBACK_AGENT;
   const adapter = opts.getAgent(agentName);
 

--- a/src/debate/session.ts
+++ b/src/debate/session.ts
@@ -7,8 +7,10 @@
 
 import type { AcpClient, AcpSession, AcpSessionResponse } from "../agents/acp/adapter";
 import { createSpawnAcpClient } from "../agents/acp/spawn-client";
+import { estimateCostByDuration } from "../agents/cost/calculate";
 import { getAgent } from "../agents/registry";
-import type { AgentAdapter } from "../agents/types";
+import type { AgentAdapter, CompleteOptions, CompleteResult } from "../agents/types";
+import type { ModelTier } from "../config";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config";
 import { getSafeLogger } from "../logger";
@@ -61,8 +63,13 @@ interface SuccessfulProposal {
   debater: Debater;
   adapter: AgentAdapter;
   output: string;
-  /** Cost for this complete() call in USD. Always 0 until complete() exposes cost metadata. */
+  /** Cost for this complete() call in USD. */
   cost: number;
+}
+
+interface ResolveOutcome {
+  outcome: "passed" | "failed" | "skipped";
+  resolverCostUsd: number;
 }
 
 function buildFailedResult(
@@ -87,6 +94,34 @@ function extractSessionOutput(response: AcpSessionResponse): string {
   const messages = response.messages ?? [];
   const last = [...messages].reverse().find((m) => m.role === "assistant");
   return last?.content ?? "";
+}
+
+function modelTierFromDebater(debater: Debater): ModelTier {
+  if (debater.model === "fast" || debater.model === "balanced" || debater.model === "powerful") {
+    return debater.model;
+  }
+  return "fast";
+}
+
+async function runComplete(
+  adapter: AgentAdapter,
+  prompt: string,
+  options: CompleteOptions,
+  modelTier: ModelTier,
+): Promise<CompleteResult> {
+  return adapter.complete(prompt, {
+    ...options,
+    modelTier,
+  });
+}
+
+function sessionResponseCostUsd(response: AcpSessionResponse, modelTier: ModelTier, durationMs: number): number {
+  if (response.exactCostUsd !== undefined) {
+    return response.exactCostUsd;
+  }
+
+  const estimate = estimateCostByDuration(modelTier, durationMs);
+  return estimate.cost;
 }
 
 export class DebateSession {
@@ -116,7 +151,7 @@ export class DebateSession {
     const logger = _debateSessionDeps.getSafeLogger();
     const config = this.stageConfig;
     const debaters = config.debaters ?? [];
-    const totalCostUsd = 0;
+    let totalCostUsd = 0;
 
     // Resolve adapters — skip unavailable agents
     const resolved: ResolvedDebater[] = [];
@@ -174,7 +209,9 @@ export class DebateSession {
             reason: "only 1 session created",
           });
           const solo = sessions[0];
+          const soloStart = Date.now();
           const response = await solo.session.prompt(prompt);
+          totalCostUsd += sessionResponseCostUsd(response, modelTierFromDebater(solo.debater), Date.now() - soloStart);
           const output = extractSessionOutput(response);
           logger?.info("debate", "debate:result", {
             storyId: this.storyId,
@@ -201,17 +238,31 @@ export class DebateSession {
       }
 
       // Proposal round — parallel via Promise.allSettled
-      const proposalSettled = await Promise.allSettled(sessions.map(({ session }) => session.prompt(prompt)));
+      const proposalSettled = await Promise.allSettled(
+        sessions.map(async (entry) => {
+          const startTime = Date.now();
+          const response = await entry.session.prompt(prompt);
+          return {
+            entry,
+            response,
+            output: extractSessionOutput(response),
+            cost: sessionResponseCostUsd(response, modelTierFromDebater(entry.debater), Date.now() - startTime),
+          };
+        }),
+      );
 
-      const successfulSessions: Array<{ entry: SessionEntry; output: string; originalIndex: number }> = [];
+      const successfulSessions: Array<{ entry: SessionEntry; output: string; cost: number; originalIndex: number }> =
+        [];
       for (let i = 0; i < proposalSettled.length; i++) {
         const r = proposalSettled[i];
         if (r.status === "fulfilled") {
           successfulSessions.push({
-            entry: sessions[i],
-            output: extractSessionOutput(r.value),
+            entry: r.value.entry,
+            output: r.value.output,
+            cost: r.value.cost,
             originalIndex: i,
           });
+          totalCostUsd += r.value.cost;
         }
       }
 
@@ -244,13 +295,21 @@ export class DebateSession {
       if (config.rounds > 1) {
         const proposalOutputs = successfulSessions.map((s) => s.output);
         const critiqueSettled = await Promise.allSettled(
-          successfulSessions.map(({ entry }, successfulIdx) =>
-            entry.session.prompt(buildCritiquePrompt(prompt, proposalOutputs, successfulIdx)),
-          ),
+          successfulSessions.map(async ({ entry }, successfulIdx) => {
+            const startTime = Date.now();
+            const response = await entry.session.prompt(buildCritiquePrompt(prompt, proposalOutputs, successfulIdx));
+            return {
+              output: extractSessionOutput(response),
+              cost: sessionResponseCostUsd(response, modelTierFromDebater(entry.debater), Date.now() - startTime),
+            };
+          }),
         );
         critiqueOutputs = critiqueSettled
-          .filter((r): r is PromiseFulfilledResult<AcpSessionResponse> => r.status === "fulfilled")
-          .map((r) => extractSessionOutput(r.value));
+          .filter((r): r is PromiseFulfilledResult<{ output: string; cost: number }> => r.status === "fulfilled")
+          .map((r) => {
+            totalCostUsd += r.value.cost;
+            return r.value.output;
+          });
       }
 
       // Resolve outcome
@@ -259,9 +318,10 @@ export class DebateSession {
         debater: s.entry.debater,
         adapter: s.entry.adapter,
         output: s.output,
-        cost: 0,
+        cost: s.cost,
       }));
       const outcome = await this.resolve(proposalOutputs, critiqueOutputs, successfulProposals);
+      totalCostUsd += outcome.resolverCostUsd;
 
       const proposals: Proposal[] = successfulSessions.map((s) => ({
         debater: s.entry.debater,
@@ -271,12 +331,12 @@ export class DebateSession {
       logger?.info("debate", "debate:result", {
         storyId: this.storyId,
         stage: this.stage,
-        outcome,
+        outcome: outcome.outcome,
       });
       return {
         storyId: this.storyId,
         stage: this.stage,
-        outcome,
+        outcome: outcome.outcome,
         rounds: config.rounds,
         debaters: successfulSessions.map((s) => s.entry.debater.agent),
         resolverType: config.resolver.type,
@@ -314,10 +374,12 @@ export class DebateSession {
     // Step 2: Proposal round — parallel via Promise.allSettled
     const proposalSettled = await Promise.allSettled(
       resolved.map(({ debater, adapter }) =>
-        adapter
-          .complete(prompt, { model: resolveDebaterModel(debater, this.config) })
-          // complete() returns string only — cost is 0 until the interface exposes cost metadata
-          .then((output) => ({ debater, adapter, output, cost: 0 })),
+        runComplete(
+          adapter,
+          prompt,
+          { model: resolveDebaterModel(debater, this.config) },
+          modelTierFromDebater(debater),
+        ).then((result) => ({ debater, adapter, output: result.output, cost: result.costUsd })),
       ),
     );
 
@@ -377,10 +439,13 @@ export class DebateSession {
           reason: "all debaters failed — retrying with first adapter",
         });
         try {
-          const fallbackOutput = await fallbackAdapter.complete(prompt, {
-            model: resolveDebaterModel(fallbackDebater, this.config),
-          });
-          // cost from fresh fallback call — 0 until complete() exposes cost metadata
+          const fallbackResult = await runComplete(
+            fallbackAdapter,
+            prompt,
+            { model: resolveDebaterModel(fallbackDebater, this.config) },
+            modelTierFromDebater(fallbackDebater),
+          );
+          totalCostUsd += fallbackResult.costUsd;
           logger?.info("debate", "debate:result", {
             storyId: this.storyId,
             stage: this.stage,
@@ -393,7 +458,7 @@ export class DebateSession {
             rounds: 1,
             debaters: [fallbackDebater.agent],
             resolverType: config.resolver.type,
-            proposals: [{ debater: fallbackDebater, output: fallbackOutput }],
+            proposals: [{ debater: fallbackDebater, output: fallbackResult.output }],
             totalCostUsd,
           };
         } catch {
@@ -410,27 +475,28 @@ export class DebateSession {
       const proposalOutputs = successful.map((p) => p.output);
       const critiqueSettled = await Promise.allSettled(
         successful.map(({ debater, adapter }, i) =>
-          adapter.complete(buildCritiquePrompt(prompt, proposalOutputs, i), {
-            model: resolveDebaterModel(debater, this.config),
-          }),
+          runComplete(
+            adapter,
+            buildCritiquePrompt(prompt, proposalOutputs, i),
+            { model: resolveDebaterModel(debater, this.config) },
+            modelTierFromDebater(debater),
+          ),
         ),
       );
-      // Accumulate critique round costs (0 until complete() exposes cost metadata)
       for (const r of critiqueSettled) {
         if (r.status === "fulfilled") {
-          totalCostUsd += 0;
+          totalCostUsd += r.value.costUsd;
         }
       }
       critiqueOutputs = critiqueSettled
-        .filter((r): r is PromiseFulfilledResult<string> => r.status === "fulfilled")
-        .map((r) => r.value);
+        .filter((r): r is PromiseFulfilledResult<CompleteResult> => r.status === "fulfilled")
+        .map((r) => r.value.output);
     }
 
     // Step 5: Resolve outcome
     const proposalOutputs = successful.map((p) => p.output);
     const outcome = await this.resolve(proposalOutputs, critiqueOutputs, successful);
-    // Accumulate resolver cost (0 until complete() exposes cost metadata)
-    totalCostUsd += 0;
+    totalCostUsd += outcome.resolverCostUsd;
 
     const proposals: Proposal[] = successful.map((p) => ({
       debater: p.debater,
@@ -440,12 +506,12 @@ export class DebateSession {
     logger?.info("debate", "debate:result", {
       storyId: this.storyId,
       stage: this.stage,
-      outcome,
+      outcome: outcome.outcome,
     });
     return {
       storyId: this.storyId,
       stage: this.stage,
-      outcome,
+      outcome: outcome.outcome,
       rounds: config.rounds,
       debaters: successful.map((p) => p.debater.agent),
       resolverType: config.resolver.type,
@@ -458,30 +524,46 @@ export class DebateSession {
     proposalOutputs: string[],
     critiqueOutputs: string[],
     _successful: SuccessfulProposal[],
-  ): Promise<"passed" | "failed" | "skipped"> {
+  ): Promise<ResolveOutcome> {
     const resolverConfig = this.stageConfig.resolver;
 
     if (resolverConfig.type === "majority-fail-closed" || resolverConfig.type === "majority-fail-open") {
-      return majorityResolver(proposalOutputs, resolverConfig.type === "majority-fail-open");
+      return {
+        outcome: majorityResolver(proposalOutputs, resolverConfig.type === "majority-fail-open"),
+        resolverCostUsd: 0,
+      };
     }
 
     if (resolverConfig.type === "synthesis") {
       const agentName = resolverConfig.agent ?? RESOLVER_FALLBACK_AGENT;
       const adapter = _debateSessionDeps.getAgent(agentName);
       if (adapter) {
-        await synthesisResolver(proposalOutputs, critiqueOutputs, { adapter });
+        const resolverResult = await synthesisResolver(proposalOutputs, critiqueOutputs, { adapter });
+        return {
+          outcome: "passed",
+          resolverCostUsd: resolverResult.costUsd,
+        };
       }
-      return "passed";
+      return {
+        outcome: "passed",
+        resolverCostUsd: 0,
+      };
     }
 
     if (resolverConfig.type === "custom") {
-      await judgeResolver(proposalOutputs, critiqueOutputs, resolverConfig, {
+      const resolverResult = await judgeResolver(proposalOutputs, critiqueOutputs, resolverConfig, {
         getAgent: _debateSessionDeps.getAgent,
         defaultAgentName: RESOLVER_FALLBACK_AGENT,
       });
-      return "passed";
+      return {
+        outcome: "passed",
+        resolverCostUsd: resolverResult.costUsd,
+      };
     }
 
-    return "passed";
+    return {
+      outcome: "passed",
+      resolverCostUsd: 0,
+    };
   }
 }

--- a/src/interaction/plugins/auto.ts
+++ b/src/interaction/plugins/auto.ts
@@ -155,7 +155,7 @@ export class AutoInteractionPlugin implements InteractionPlugin {
     }
 
     // Use adapter.complete() for one-shot LLM call
-    const output = await adapter.complete(prompt, {
+    const result = await adapter.complete(prompt, {
       ...(modelArg && { model: modelArg }),
       jsonMode: true,
       ...(this.config.naxConfig && { config: this.config.naxConfig }),
@@ -164,6 +164,7 @@ export class AutoInteractionPlugin implements InteractionPlugin {
       sessionRole: "auto",
     });
 
+    const output = typeof result === "string" ? result : result.output;
     return this.parseResponse(output);
   }
 

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -393,13 +393,14 @@ export async function runSemanticReview(
   // Call LLM
   let rawResponse: string;
   try {
-    rawResponse = await agent.complete(prompt, {
+    const completeResult = await agent.complete(prompt, {
       sessionName: `nax-semantic-${story.id}`,
       workdir,
       timeoutMs: semanticConfig.timeoutMs,
       modelTier: semanticConfig.modelTier,
       config: naxConfig,
     });
+    rawResponse = typeof completeResult === "string" ? completeResult : completeResult.output;
   } catch (err) {
     logger?.warn("semantic", "LLM call failed — fail-open", { cause: String(err) });
     return {

--- a/src/routing/strategies/llm.ts
+++ b/src/routing/strategies/llm.ts
@@ -104,7 +104,7 @@ async function callLlmOnce(
   try {
     const result = await Promise.race([outputPromise, timeoutPromise]);
     clearTimeout(timeoutId);
-    return result;
+    return typeof result === "string" ? result : result.output;
   } catch (err) {
     clearTimeout(timeoutId);
     outputPromise.catch(() => {});

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -69,7 +69,7 @@ async function _defaultRunDebate(
   const startMs = Date.now();
   const proposalSettled = await Promise.allSettled(
     resolved.map(({ debater, adapter }) =>
-      adapter.complete(prompt, { model: debater.model }).then((out: string) => out),
+      adapter.complete(prompt, { model: debater.model }).then((out) => (typeof out === "string" ? out : out.output)),
     ),
   );
   const durationMs = Date.now() - startMs;

--- a/test/unit/agents/acp/adapter-complete-fallback.test.ts
+++ b/test/unit/agents/acp/adapter-complete-fallback.test.ts
@@ -146,7 +146,7 @@ describe("complete() — happy path", () => {
     try {
       const adapter = new AcpAgentAdapter("claude");
       const result = await adapter.complete("prompt", { config: makeConfig([]) });
-      expect(result).toBe("hello world");
+      expect(result.output).toBe("hello world");
       expect(sleepMock).not.toHaveBeenCalled();
     } finally {
       restore();
@@ -194,7 +194,7 @@ describe("complete() — 429 rate-limit fallback", () => {
       });
 
       // Caller sees the successful result — retries are transparent
-      expect(result).toBe("fallback answer");
+      expect(result.output).toBe("fallback answer");
 
       // Verify a second agent was attempted (cmdStr should reference fallback agent)
       expect(capturedCmdStrs.length).toBeGreaterThanOrEqual(2);
@@ -218,7 +218,7 @@ describe("complete() — 429 rate-limit fallback", () => {
       const adapter = new AcpAgentAdapter("claude");
       // Single call to complete() — caller sees success, no retry count exposed
       const result = await adapter.complete("prompt", { config: makeConfig(["claude", "codex"]) });
-      expect(result).toBe("transparent result");
+      expect(result.output).toBe("transparent result");
     } finally {
       restore();
     }
@@ -245,7 +245,7 @@ describe("complete() — 401 auth fallback", () => {
         config: makeConfig(["claude", "codex"]),
       });
 
-      expect(result).toBe("auth-fallback result");
+      expect(result.output).toBe("auth-fallback result");
 
       // Primary agent "claude" was tried first, then fallback
       expect(capturedCmdStrs.length).toBeGreaterThanOrEqual(2);
@@ -270,7 +270,7 @@ describe("complete() — 401 auth fallback", () => {
       const result = await adapter.complete("prompt", {
         config: makeConfig(["claude", "gemini"]),
       });
-      expect(result).toBe("from-gemini");
+      expect(result.output).toBe("from-gemini");
     } finally {
       restore();
     }
@@ -322,7 +322,7 @@ describe("complete() — all fallbackOrder agents rate-limited", () => {
         config: makeConfig(["claude", "codex"]),
       });
 
-      expect(result).toBe("after-sleep result");
+      expect(result.output).toBe("after-sleep result");
       // sleep called once with min(60, 45)*1000 = 45_000
       expect(sleepMock).toHaveBeenCalledTimes(1);
       expect(sleepMock).toHaveBeenCalledWith(45_000);
@@ -349,7 +349,7 @@ describe("complete() — all fallbackOrder agents rate-limited", () => {
         config: makeConfig(["claude", "codex"]),
       });
 
-      expect(result).toBe("result after 30s");
+      expect(result.output).toBe("result after 30s");
       expect(sleepMock).toHaveBeenCalledTimes(1);
       expect(sleepMock).toHaveBeenCalledWith(30_000);
     } finally {
@@ -416,7 +416,7 @@ describe("complete() — single fallbackOrder agent rate-limited", () => {
         config: makeConfig(["claude", "codex"]),
       });
 
-      expect(result).toBe("single-fallback-retry");
+      expect(result.output).toBe("single-fallback-retry");
       expect(sleepMock).toHaveBeenCalledTimes(1);
       expect(sleepMock).toHaveBeenCalledWith(90_000);
 

--- a/test/unit/agents/acp/adapter-run-fallback.test.ts
+++ b/test/unit/agents/acp/adapter-run-fallback.test.ts
@@ -556,7 +556,7 @@ describe("run() — shared _unavailableAgents with complete()", () => {
     const completeClients = mockClientQueue(makeSuccessClient("complete from codex"));
     try {
       const result = await adapter.complete("prompt", { config: makeConfig(["claude", "codex"]) });
-      expect(result).toContain("complete from codex");
+      expect(result.output).toContain("complete from codex");
 
       // claude is unavailable, so codex should be used first
       const firstCmd = completeClients.capturedCmdStrs[0];

--- a/test/unit/agents/acp/adapter.test.ts
+++ b/test/unit/agents/acp/adapter.test.ts
@@ -171,7 +171,7 @@ describe("complete()", () => {
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
     const result = await new AcpAgentAdapter("claude").complete("What is the answer?");
-    expect(result).toBe("The answer is 42.");
+    expect(result.output).toBe("The answer is 42.");
   });
 
   test("sends the provided prompt to the ACP session", async () => {
@@ -246,7 +246,7 @@ describe("complete()", () => {
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
     const result = await new AcpAgentAdapter("claude").complete("Retry me");
-    expect(result).toBe("Retried OK.");
+    expect(result.output).toBe("Retried OK.");
     expect(calls).toBe(2);
     expect(_acpAdapterDeps.sleep).toHaveBeenCalledTimes(1);
   });

--- a/test/unit/agents/adapters/aider.test.ts
+++ b/test/unit/agents/adapters/aider.test.ts
@@ -124,7 +124,7 @@ describe("complete()", () => {
 
     const result = await adapter.complete("say hello");
 
-    expect(result).toContain("response from aider");
+    expect(result.output).toContain("response from aider");
   });
 
   test("trims trailing whitespace from output", async () => {
@@ -132,7 +132,7 @@ describe("complete()", () => {
 
     const result = await adapter.complete("test");
 
-    expect(result).toBe("trimmed output");
+    expect(result.output).toBe("trimmed output");
   });
 
   // ── CLI command structure — headless flags ──────────────────────────────

--- a/test/unit/agents/adapters/codex.test.ts
+++ b/test/unit/agents/adapters/codex.test.ts
@@ -296,7 +296,7 @@ describe("complete()", () => {
 
     const result = await adapter.complete("say hello");
 
-    expect(result).toContain("hello from codex");
+    expect(result.output).toContain("hello from codex");
   });
 
   test("trims trailing whitespace from output", async () => {
@@ -304,7 +304,7 @@ describe("complete()", () => {
 
     const result = await adapter.complete("test");
 
-    expect(result).toBe("trimmed output");
+    expect(result.output).toBe("trimmed output");
   });
 
   // ── CLI command structure ───────────────────────────────────────────────

--- a/test/unit/agents/adapters/gemini.test.ts
+++ b/test/unit/agents/adapters/gemini.test.ts
@@ -334,7 +334,7 @@ describe("complete()", () => {
 
     const result = await adapter.complete("say hello");
 
-    expect(result).toContain("hello from gemini");
+    expect(result.output).toContain("hello from gemini");
   });
 
   test("trims trailing whitespace from output", async () => {
@@ -342,7 +342,7 @@ describe("complete()", () => {
 
     const result = await adapter.complete("test");
 
-    expect(result).toBe("trimmed output");
+    expect(result.output).toBe("trimmed output");
   });
 
   // ── CLI command structure ───────────────────────────────────────────────

--- a/test/unit/agents/adapters/opencode.test.ts
+++ b/test/unit/agents/adapters/opencode.test.ts
@@ -116,7 +116,7 @@ describe("complete()", () => {
 
     const result = await adapter.complete("say hello");
 
-    expect(result).toContain("hello from opencode");
+    expect(result.output).toContain("hello from opencode");
   });
 
   test("trims trailing whitespace from output", async () => {
@@ -124,7 +124,7 @@ describe("complete()", () => {
 
     const result = await adapter.complete("test");
 
-    expect(result).toBe("trimmed output");
+    expect(result.output).toBe("trimmed output");
   });
 
   // ── CLI command structure ───────────────────────────────────────────────

--- a/test/unit/agents/claude-complete.test.ts
+++ b/test/unit/agents/claude-complete.test.ts
@@ -2,7 +2,7 @@
  * Tests for ClaudeCodeAdapter.complete() — one-shot LLM call
  *
  * Covers: AA-001
- * - AgentAdapter interface has complete(prompt, options?): Promise<string>
+ * - AgentAdapter interface has complete(prompt, options?): Promise<CompleteResult>
  * - ClaudeAdapter implements complete() using Bun.spawn(['claude', '-p', prompt, ...flags])
  * - jsonMode adds --output-format json flag
  * - model option passes --model flag
@@ -58,7 +58,7 @@ describe("complete()", () => {
 
     const result = await adapter.complete("say hello");
 
-    expect(result).toContain("hello from claude");
+    expect(result.output).toContain("hello from claude");
   });
 
   test("trims trailing whitespace from output", async () => {
@@ -66,7 +66,7 @@ describe("complete()", () => {
 
     const result = await adapter.complete("test");
 
-    expect(result).toBe("trimmed output");
+    expect(result.output).toBe("trimmed output");
   });
 
   // ── CLI command structure ───────────────────────────────────────────────

--- a/test/unit/debate/resolvers.test.ts
+++ b/test/unit/debate/resolvers.test.ts
@@ -10,15 +10,19 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
-import { judgeResolver, majorityResolver, synthesisResolver } from "../../../src/debate/resolvers";
-import type { AgentAdapter, CompleteOptions } from "../../../src/agents/types";
+import {
+  judgeResolver,
+  majorityResolver,
+  synthesisResolver,
+} from "../../../src/debate/resolvers";
+import type { AgentAdapter, CompleteOptions, CompleteResult } from "../../../src/agents/types";
 import type { ResolverConfig } from "../../../src/debate/types";
 
 // ─── Mock Helpers ──────────────────────────────────────────────────────────────
 
 function makeMockAdapter(
   name: string,
-  completeFn?: (prompt: string, opts?: CompleteOptions) => Promise<string>,
+  completeFn?: (prompt: string, opts?: CompleteOptions) => Promise<CompleteResult>,
 ): AgentAdapter {
   return {
     name,
@@ -41,7 +45,7 @@ function makeMockAdapter(
     buildCommand: () => [],
     plan: async () => ({ specContent: "" }),
     decompose: async () => ({ stories: [] }),
-    complete: completeFn ?? (async () => "default output"),
+    complete: completeFn ?? (async () => ({ output: "default output", costUsd: 0, source: "fallback" })),
   };
 }
 
@@ -208,7 +212,7 @@ describe("synthesisResolver()", () => {
     let callCount = 0;
     const adapter = makeMockAdapter("claude", async () => {
       callCount++;
-      return "synthesis output";
+      return { output: "synthesis output", costUsd: 0, source: "fallback" };
     });
 
     await synthesisResolver(["proposal 1", "proposal 2", "proposal 3"], [], { adapter });
@@ -220,7 +224,7 @@ describe("synthesisResolver()", () => {
     let capturedPrompt = "";
     const adapter = makeMockAdapter("claude", async (prompt) => {
       capturedPrompt = prompt;
-      return "synthesis output";
+      return { output: "synthesis output", costUsd: 0, source: "fallback" };
     });
 
     await synthesisResolver(
@@ -238,7 +242,7 @@ describe("synthesisResolver()", () => {
     let capturedPrompt = "";
     const adapter = makeMockAdapter("claude", async (prompt) => {
       capturedPrompt = prompt;
-      return "synthesis output";
+      return { output: "synthesis output", costUsd: 0, source: "fallback" };
     });
 
     await synthesisResolver(["proposal 1"], ["critique X", "critique Y"], { adapter });
@@ -247,20 +251,34 @@ describe("synthesisResolver()", () => {
     expect(capturedPrompt).toContain("critique Y");
   });
 
-  test("returns the string output from adapter.complete()", async () => {
-    const adapter = makeMockAdapter("claude", async () => "the synthesis result");
+  test("returns output and cost metadata from adapter.complete()", async () => {
+    const adapter = makeMockAdapter("claude", async () => ({ output: "the synthesis result", costUsd: 0, source: "fallback" }));
 
     const result = await synthesisResolver(["prop 1", "prop 2"], [], { adapter });
 
-    expect(result).toBe("the synthesis result");
+    expect(result.output).toBe("the synthesis result");
+    expect(result.costUsd).toBe(0);
+    expect(result.source).toBe("fallback");
   });
 
   test("works when critiques array is empty", async () => {
-    const adapter = makeMockAdapter("claude", async () => "synthesis without critiques");
+    const adapter = makeMockAdapter("claude", async () => ({ output: "synthesis without critiques", costUsd: 0, source: "fallback" }));
 
     const result = await synthesisResolver(["p1", "p2"], [], { adapter });
 
-    expect(result).toBe("synthesis without critiques");
+    expect(result.output).toBe("synthesis without critiques");
+    expect(result.costUsd).toBe(0);
+    expect(result.source).toBe("fallback");
+  });
+
+  test("preserves exact cost metadata from adapter.complete()", async () => {
+    const adapter = makeMockAdapter("claude", async () => ({ output: "exact synthesis", costUsd: 0.42, source: "exact" }));
+
+    const result = await synthesisResolver(["p1", "p2"], ["c1"], { adapter });
+
+    expect(result.output).toBe("exact synthesis");
+    expect(result.costUsd).toBeCloseTo(0.42, 6);
+    expect(result.source).toBe("exact");
   });
 });
 
@@ -272,7 +290,7 @@ describe("judgeResolver()", () => {
 
     const getAgentFn = mock((name: string) => {
       usedAgentName = name;
-      return makeMockAdapter(name, async () => "judge output");
+      return makeMockAdapter(name, async () => ({ output: "judge output", costUsd: 0, source: "fallback" }));
     });
 
     const resolverConfig: ResolverConfig = {
@@ -293,7 +311,7 @@ describe("judgeResolver()", () => {
     const getAgentFn = mock((_name: string) =>
       makeMockAdapter("judge", async () => {
         callCount++;
-        return "judge output";
+        return { output: "judge output", costUsd: 0, source: "fallback" };
       }),
     );
 
@@ -310,7 +328,7 @@ describe("judgeResolver()", () => {
     const getAgentFn = mock((_name: string) =>
       makeMockAdapter("judge", async (prompt) => {
         capturedPrompt = prompt;
-        return "judge output";
+        return { output: "judge output", costUsd: 0, source: "fallback" };
       }),
     );
 
@@ -331,7 +349,7 @@ describe("judgeResolver()", () => {
     const getAgentFn = mock((_name: string) =>
       makeMockAdapter("judge", async (prompt) => {
         capturedPrompt = prompt;
-        return "judge output";
+        return { output: "judge output", costUsd: 0, source: "fallback" };
       }),
     );
 
@@ -346,16 +364,32 @@ describe("judgeResolver()", () => {
     expect(capturedPrompt).toContain("critique two");
   });
 
-  test("returns the output from adapter.complete()", async () => {
+  test("returns output and cost metadata from adapter.complete()", async () => {
     const getAgentFn = mock((_name: string) =>
-      makeMockAdapter("judge", async () => "final judge verdict"),
+      makeMockAdapter("judge", async () => ({ output: "final judge verdict", costUsd: 0, source: "fallback" })),
     );
 
     const result = await judgeResolver(["p1"], [], { type: "custom", agent: "judge" }, {
       getAgent: getAgentFn,
     });
 
-    expect(result).toBe("final judge verdict");
+    expect(result.output).toBe("final judge verdict");
+    expect(result.costUsd).toBe(0);
+    expect(result.source).toBe("fallback");
+  });
+
+  test("preserves exact cost metadata from judge adapter complete()", async () => {
+    const getAgentFn = mock((_name: string) =>
+      makeMockAdapter("judge", async () => ({ output: "judge verdict", costUsd: 0.55, source: "exact" })),
+    );
+
+    const result = await judgeResolver(["p1"], ["c1"], { type: "custom", agent: "judge" }, {
+      getAgent: getAgentFn,
+    });
+
+    expect(result.output).toBe("judge verdict");
+    expect(result.costUsd).toBeCloseTo(0.55, 6);
+    expect(result.source).toBe("exact");
   });
 
   test("uses defaultAgentName when resolver.agent is not specified", async () => {
@@ -363,7 +397,7 @@ describe("judgeResolver()", () => {
 
     const getAgentFn = mock((name: string) => {
       usedAgentName = name;
-      return makeMockAdapter(name, async () => "judge output");
+      return makeMockAdapter(name, async () => ({ output: "judge output", costUsd: 0, source: "fallback" }));
     });
 
     const resolverConfig: ResolverConfig = {
@@ -384,7 +418,7 @@ describe("judgeResolver()", () => {
 
     const getAgentFn = mock((_name: string) => {
       wasCalled = true;
-      return makeMockAdapter("fallback", async () => "fallback judge output");
+      return makeMockAdapter("fallback", async () => ({ output: "fallback judge output", costUsd: 0, source: "fallback" }));
     });
 
     const resolverConfig: ResolverConfig = {
@@ -399,5 +433,6 @@ describe("judgeResolver()", () => {
 
     expect(wasCalled).toBe(true);
     expect(result).toBeDefined();
+    expect(result.output).toBe("fallback judge output");
   });
 });

--- a/test/unit/debate/session-stateful.test.ts
+++ b/test/unit/debate/session-stateful.test.ts
@@ -16,7 +16,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { DebateSession, _debateSessionDeps } from "../../../src/debate/session";
 import type { DebateStageConfig } from "../../../src/debate/types";
-import type { AgentAdapter, CompleteOptions } from "../../../src/agents/types";
+import type { AgentAdapter, CompleteOptions, CompleteResult } from "../../../src/agents/types";
 import type { AcpClient, AcpSession, AcpSessionResponse } from "../../../src/agents/acp/adapter";
 
 // ─── Extended deps type (US-003 adds createSpawnAcpClient) ───────────────────
@@ -32,7 +32,7 @@ const extDeps = _debateSessionDeps as ExtendedDeps;
 function makeMockAdapter(
   name: string,
   options: {
-    completeFn?: (prompt: string, opts?: CompleteOptions) => Promise<string>;
+    completeFn?: (prompt: string, opts?: CompleteOptions) => Promise<CompleteResult>;
   } = {},
 ): AgentAdapter {
   return {
@@ -56,7 +56,7 @@ function makeMockAdapter(
     buildCommand: () => [],
     plan: async () => ({ specContent: "" }),
     decompose: async () => ({ stories: [] }),
-    complete: options.completeFn ?? (async () => `output from ${name}`),
+    complete: options.completeFn ?? (async () => ({ output: `output from ${name}`, costUsd: 0, source: "fallback" })),
   };
 }
 
@@ -295,7 +295,7 @@ describe("DebateSession.run() — stateful mode: SpawnAcpClient creation (AC1)",
       makeMockAdapter(name, {
         completeFn: async (p) => {
           completeCalls.push(p);
-          return `complete from ${name}`;
+          return { output: `complete from ${name}`, costUsd: 0, source: "fallback" };
         },
       }),
     );
@@ -555,7 +555,7 @@ describe("DebateSession.run() — one-shot mode: no persistent sessions (AC4)", 
 
     _debateSessionDeps.getAgent = mock((name: string) =>
       makeMockAdapter(name, {
-        completeFn: async () => `{"passed": true}`,
+        completeFn: async () => ({ output: `{"passed": true}`, costUsd: 0, source: "fallback" }),
       }),
     );
 
@@ -856,5 +856,40 @@ describe("DebateSession.run() — independent sessionMode per stage (AC6)", () =
     // Session names should be unique per stage
     const uniqueNames = new Set(sessionNames);
     expect(uniqueNames.size).toBe(4);
+  });
+});
+
+describe("DebateSession.run() — stateful mode cost tracking", () => {
+  test("accumulates totalCostUsd from ACP exactCostUsd across rounds", async () => {
+    let sessionIndex = 0;
+
+    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
+      const idx = sessionIndex++;
+      return makeMockClient({
+        createSessionFn: async (_opts) =>
+          makeMockSession({
+            promptFn: async (_text) => ({
+              messages: [{ role: "assistant", content: `output from ${idx}` }],
+              stopReason: "end_turn",
+              exactCostUsd: 0.25,
+            }),
+          }),
+      });
+    });
+
+    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
+
+    const session = new DebateSession({
+      storyId: "US-003",
+      stage: "review",
+      stageConfig: makeStageConfig({
+        rounds: 2,
+        debaters: [{ agent: "claude" }, { agent: "opencode" }],
+      }),
+    });
+
+    const result = await session.run("test prompt");
+
+    expect(result.totalCostUsd).toBeCloseTo(1, 6);
   });
 });

--- a/test/unit/debate/session.test.ts
+++ b/test/unit/debate/session.test.ts
@@ -18,14 +18,14 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { DebateSession, _debateSessionDeps, resolveDebaterModel } from "../../../src/debate/session";
 import type { DebateStageConfig, Debater } from "../../../src/debate/types";
 import type { NaxConfig } from "../../../src/config";
-import type { AgentAdapter, CompleteOptions } from "../../../src/agents/types";
+import type { AgentAdapter, CompleteOptions, CompleteResult } from "../../../src/agents/types";
 
 // ─── Mock Helpers ──────────────────────────────────────────────────────────────
 
 function makeMockAdapter(
   name: string,
   options: {
-    completeFn?: (prompt: string, opts?: CompleteOptions) => Promise<string>;
+    completeFn?: (prompt: string, opts?: CompleteOptions) => Promise<CompleteResult>;
     isInstalledFn?: () => Promise<boolean>;
   } = {},
 ): AgentAdapter {
@@ -50,7 +50,12 @@ function makeMockAdapter(
     buildCommand: () => [],
     plan: async () => ({ specContent: "" }),
     decompose: async () => ({ stories: [] }),
-    complete: options.completeFn ?? (async (_p, _o) => `output from ${name}`),
+    complete: options.completeFn ??
+      (async (_p, _o) => ({
+        output: `output from ${name}`,
+        costUsd: 0,
+        source: "fallback",
+      })),
   };
 }
 
@@ -115,7 +120,7 @@ describe("DebateSession.run() — agent resolution", () => {
       makeMockAdapter(name, {
         completeFn: async (_prompt, opts) => {
           completeCalls.push({ agent: name, model: opts?.model });
-          return `{"passed": true}`;
+          return { output: `{"passed": true}`, costUsd: 0, source: "fallback" };
         },
       }),
     );
@@ -147,7 +152,7 @@ describe("DebateSession.run() — agent resolution", () => {
       makeMockAdapter(name, {
         completeFn: async (prompt) => {
           receivedPrompts.push(prompt);
-          return `{"passed": true}`;
+          return { output: `{"passed": true}`, costUsd: 0, source: "fallback" };
         },
       }),
     );
@@ -178,7 +183,7 @@ describe("DebateSession.run() — parallel execution", () => {
         completeFn: async () => {
           startTimes.push(Date.now());
           await new Promise<void>((resolve) => resolvers.push(resolve));
-          return `output from ${name}`;
+          return { output: `output from ${name}`, costUsd: 0, source: "fallback" };
         },
       }),
     );
@@ -208,7 +213,7 @@ describe("DebateSession.run() — parallel execution", () => {
       makeMockAdapter(name, {
         completeFn: async () => {
           if (name === "failing") throw new Error("agent error");
-          return `{"passed": true}`;
+          return { output: `{"passed": true}`, costUsd: 0, source: "fallback" };
         },
       }),
     );
@@ -238,7 +243,7 @@ describe("DebateSession.run() — unavailable agent handling", () => {
       return makeMockAdapter(name, {
         completeFn: async () => {
           completeCalls.push(name);
-          return `{"passed": true}`;
+          return { output: `{"passed": true}`, costUsd: 0, source: "fallback" };
         },
       });
     });
@@ -298,7 +303,7 @@ describe("DebateSession.run() — unavailable agent handling", () => {
       return makeMockAdapter(name, {
         completeFn: async () => {
           completeCalls.push(name);
-          return `{"passed": true}`;
+          return { output: `{"passed": true}`, costUsd: 0, source: "fallback" };
         },
       });
     });
@@ -324,7 +329,7 @@ describe("DebateSession.run() — single-agent fallback", () => {
     _debateSessionDeps.getAgent = mock((name: string) => {
       if (name === "claude") {
         return makeMockAdapter("claude", {
-          completeFn: async () => "the single successful proposal",
+          completeFn: async () => ({ output: "the single successful proposal", costUsd: 0, source: "fallback" }),
         });
       }
       // Other debaters unavailable
@@ -398,7 +403,7 @@ describe("DebateSession.run() — critique rounds (rounds === 2)", () => {
       makeMockAdapter(name, {
         completeFn: async () => {
           callCounts[name] = (callCounts[name] ?? 0) + 1;
-          return `proposal from ${name}`;
+          return { output: `proposal from ${name}`, costUsd: 0, source: "fallback" };
         },
       }),
     );
@@ -427,7 +432,7 @@ describe("DebateSession.run() — critique rounds (rounds === 2)", () => {
         completeFn: async (prompt) => {
           if (!promptsByAgent[name]) promptsByAgent[name] = [];
           promptsByAgent[name].push(prompt);
-          return `proposal from ${name}`;
+          return { output: `proposal from ${name}`, costUsd: 0, source: "fallback" };
         },
       }),
     );
@@ -458,7 +463,7 @@ describe("DebateSession.run() — critique rounds (rounds === 2)", () => {
         completeFn: async (prompt) => {
           if (!promptsByAgent[name]) promptsByAgent[name] = [];
           promptsByAgent[name].push(prompt);
-          return `proposal from ${name}`;
+          return { output: `proposal from ${name}`, costUsd: 0, source: "fallback" };
         },
       }),
     );
@@ -488,7 +493,7 @@ describe("DebateSession.run() — critique rounds (rounds === 2)", () => {
         completeFn: async (prompt) => {
           if (!promptsByAgent[name]) promptsByAgent[name] = [];
           promptsByAgent[name].push(prompt);
-          return `proposal from ${name}`;
+          return { output: `proposal from ${name}`, costUsd: 0, source: "fallback" };
         },
       }),
     );
@@ -521,7 +526,7 @@ describe("DebateSession.run() — no critique round (rounds === 1)", () => {
       makeMockAdapter(name, {
         completeFn: async () => {
           callCounts[name] = (callCounts[name] ?? 0) + 1;
-          return `{"passed": true}`;
+          return { output: `{"passed": true}`, costUsd: 0, source: "fallback" };
         },
       }),
     );
@@ -545,23 +550,30 @@ describe("DebateSession.run() — no critique round (rounds === 1)", () => {
 // ─── AC11: totalCostUsd is aggregated ─────────────────────────────────────────
 
 describe("DebateSession.run() — cost tracking", () => {
-  test("DebateResult.totalCostUsd is a non-negative number", async () => {
+  test("DebateResult.totalCostUsd aggregates proposal, critique, and resolver costs", async () => {
     _debateSessionDeps.getAgent = mock((name: string) =>
       makeMockAdapter(name, {
-        completeFn: async () => `{"passed": true}`,
+        completeFn: async () => ({
+          output: `{"passed": true}`,
+          costUsd: 0.1,
+          source: "exact",
+        }),
       }),
     );
 
     const session = new DebateSession({
       storyId: "US-002",
       stage: "review",
-      stageConfig: makeStageConfig(),
+      stageConfig: makeStageConfig({
+        rounds: 2,
+        resolver: { type: "synthesis", agent: "claude" },
+      }),
     });
 
     const result = await session.run("test prompt");
 
     expect(typeof result.totalCostUsd).toBe("number");
-    expect(result.totalCostUsd).toBeGreaterThanOrEqual(0);
+    expect(result.totalCostUsd).toBeCloseTo(0.7, 6);
   });
 
   test("DebateResult has totalCostUsd field", async () => {
@@ -585,7 +597,7 @@ describe("DebateSession.run() — proposals structure", () => {
   test("DebateResult.proposals contains one entry per successful debater", async () => {
     _debateSessionDeps.getAgent = mock((name: string) =>
       makeMockAdapter(name, {
-        completeFn: async () => `output from ${name}`,
+        completeFn: async () => ({ output: `output from ${name}`, costUsd: 0, source: "fallback" }),
       }),
     );
 
@@ -608,7 +620,7 @@ describe("DebateSession.run() — proposals structure", () => {
   test("each proposal entry contains debater identity (agent name)", async () => {
     _debateSessionDeps.getAgent = mock((name: string) =>
       makeMockAdapter(name, {
-        completeFn: async () => `output from ${name}`,
+        completeFn: async () => ({ output: `output from ${name}`, costUsd: 0, source: "fallback" }),
       }),
     );
 
@@ -633,7 +645,7 @@ describe("DebateSession.run() — proposals structure", () => {
   test("each proposal entry contains the output from complete()", async () => {
     _debateSessionDeps.getAgent = mock((name: string) =>
       makeMockAdapter(name, {
-        completeFn: async () => `output from ${name}`,
+        completeFn: async () => ({ output: `output from ${name}`, costUsd: 0, source: "fallback" }),
       }),
     );
 
@@ -659,7 +671,7 @@ describe("DebateSession.run() — proposals structure", () => {
 
   test("DebateResult includes storyId, stage, and resolverType", async () => {
     _debateSessionDeps.getAgent = mock((name: string) =>
-      makeMockAdapter(name, { completeFn: async () => `{"passed": true}` }),
+      makeMockAdapter(name, { completeFn: async () => ({ output: `{"passed": true}`, costUsd: 0, source: "fallback" }) }),
     );
 
     const session = new DebateSession({


### PR DESCRIPTION
## What

Add debate cost accounting for one-shot and stateful debate flows by introducing a non-breaking cost-aware completion API on adapters and aggregating costs across proposal, critique, fallback, and resolver calls.

## Why

Issue #153 reports that `DebateResult.totalCostUsd` is always `0` because adapter one-shot completions returned text only, with no cost metadata surfaced to debate session logic.

Closes #153

## How

- Refactored `AgentAdapter.complete()` to return `CompleteResult` directly in `src/agents/types.ts`.
- Updated adapter `complete()` implementations to return output+cost metadata:
  - `src/agents/acp/adapter.ts` (prefers `exactCostUsd`, then token-estimated cost, else fallback 0)
  - `src/agents/claude/adapter.ts` (duration-based fallback estimate)
  - `src/agents/aider/adapter.ts`, `src/agents/codex/adapter.ts`, `src/agents/gemini/adapter.ts`, `src/agents/opencode/adapter.ts` (fallback metadata)
- Updated debate session cost plumbing in `src/debate/session.ts`:
  - One-shot mode now accumulates costs from proposal, critique, fallback, and resolver calls.
  - Stateful mode now accumulates cost from ACP prompt responses (`exactCostUsd` when present, duration fallback otherwise).
  - Resolver step now returns and includes resolver call cost.
- Updated resolver and debate flows to consume structured `complete()` results while preserving existing resolver behavior.
- Updated tests:
  - `test/unit/debate/session.test.ts` (stronger aggregate cost assertion)
  - `test/unit/debate/session-stateful.test.ts` (stateful exact-cost aggregation assertion)
  - `test/unit/debate/resolvers.test.ts` (new tests for cost-aware resolver variants)

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes


## Notes

- This intentionally changes the `complete()` contract from string to `CompleteResult` and updates all callsites.
- Exact provider cost is used where available (ACP), with fallback estimation/metadata where exact data is unavailable.
