### PR TITLE
fix(acceptance): pass timeoutMs to fix-gen complete() call

### DIFF
--- a/src/acceptance/fix-generator.ts
+++ b/src/acceptance/fix-generator.ts
@@ -87,6 +87,8 @@ export interface GenerateFixStoriesOptions {
   config: NaxConfig;
   /** Path to acceptance test file for agent context (P1-A) */
   testFilePath?: string;
+  /** Timeout for each complete() call (ms). Defaults to acceptance.timeoutMs config or 1800000. */
+  timeoutMs?: number;
 }
 
 /**
@@ -297,6 +299,7 @@ export async function generateFixStories(
         featureName: options.prd.feature,
         workdir: options.workdir,
         sessionRole: "fix-gen",
+        timeoutMs: options.timeoutMs ?? options.config?.acceptance?.timeoutMs ?? 1800000,
       });
 
       fixStories.push({

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -155,9 +155,59 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
   // Timeout: from config, or default to 600 seconds (10 min)
   const timeoutSeconds = config?.execution?.sessionTimeoutSeconds ?? 600;
 
-  // Route to auto (one-shot) or interactive (multi-turn) mode
+  // Route: debate > auto (one-shot) > interactive (multi-turn)
+  // Debate fires whenever config.debate.enabled + stages.plan.enabled — regardless of auto/interactive mode.
   let rawResponse: string;
-  if (options.auto) {
+
+  // Debate check is SSOT here — applies to both auto and interactive paths (Option A).
+  const debateEnabled = config?.debate?.enabled && config?.debate?.stages?.plan?.enabled;
+
+  if (debateEnabled) {
+    // Debate path: run N agents in parallel via DebateSession.runPlan().
+    // Each debater calls adapter.plan() writing to a temp path; resolver picks the best PRD.
+    // basePrompt has no file-write instruction — DebateSession.runPlan() injects per-debater paths.
+    const basePrompt = buildPlanningPrompt(
+      specContent,
+      codebaseContext,
+      undefined, // no file path — runPlan() appends per-debater temp path
+      relativePackages,
+      packageDetails,
+      config?.project,
+    );
+    const resolvedPerm = resolvePermissions(config, "plan");
+    // Safe: debateEnabled guard confirms config.debate.stages.plan is defined
+    const planStageConfig = config?.debate?.stages.plan as import("../debate").DebateStageConfig;
+    const debateSession = _planDeps.createDebateSession({
+      storyId: options.feature,
+      stage: "plan",
+      stageConfig: planStageConfig,
+      config,
+    });
+    logger?.info("plan", "Starting debate planning session", {
+      debaters: planStageConfig.debaters?.map((d) => d.agent),
+      rounds: planStageConfig.rounds,
+      feature: options.feature,
+    });
+    const debateResult = await debateSession.runPlan(basePrompt, {
+      workdir,
+      feature: options.feature,
+      outputDir: outputDir,
+      timeoutSeconds,
+      dangerouslySkipPermissions: resolvedPerm.skipPermissions,
+      maxInteractionTurns: config?.agent?.maxInteractionTurns,
+    });
+    if (debateResult.outcome !== "failed" && debateResult.output) {
+      rawResponse = debateResult.output;
+    } else {
+      logger?.warn("debate", "All plan debaters failed — falling back to single agent", {
+        stage: "plan",
+        event: "fallback",
+      });
+      // Fallback: interactive single-agent plan (most robust — writes to file)
+      rawResponse = await runInteractivePlan();
+    }
+  } else if (options.auto) {
+    // Auto (one-shot) path — no debate
     // #91: Respect agent.protocol — ACP protocol uses adapter.plan() (session-based),
     // CLI protocol uses adapter.complete() (one-shot). This matches how the run path works.
     const isAcp = config?.agent?.protocol === "acp";
@@ -185,40 +235,37 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
       // fall through — adapter will use its own fallback
     }
 
-    // runSingleAgentPlan: closure over adapter, isAcp, autoModel, prompt, outputPath, config, logger
-    const runSingleAgentPlan = async (): Promise<string> => {
-      if (isAcp) {
-        // ACP: run as a non-interactive session (no interactionBridge) — agent writes PRD to outputPath
-        logger?.info("plan", "Starting ACP auto planning session", {
-          agent: agentName,
-          model: autoModel ?? config?.plan?.model ?? "balanced",
+    if (isAcp) {
+      logger?.info("plan", "Starting ACP auto planning session", {
+        agent: agentName,
+        model: autoModel ?? config?.plan?.model ?? "balanced",
+        workdir,
+        feature: options.feature,
+        timeoutSeconds,
+      });
+      const pidRegistry = new PidRegistry(workdir);
+      try {
+        await adapter.plan({
+          prompt,
           workdir,
-          feature: options.feature,
+          interactive: false,
           timeoutSeconds,
+          config,
+          modelTier: config?.plan?.model ?? "balanced",
+          dangerouslySkipPermissions: resolvePermissions(config, "plan").skipPermissions,
+          maxInteractionTurns: config?.agent?.maxInteractionTurns,
+          featureName: options.feature,
+          pidRegistry,
+          sessionRole: "plan",
         });
-        const pidRegistry = new PidRegistry(workdir);
-        try {
-          await adapter.plan({
-            prompt,
-            workdir,
-            interactive: false,
-            timeoutSeconds,
-            config,
-            modelTier: config?.plan?.model ?? "balanced",
-            dangerouslySkipPermissions: resolvePermissions(config, "plan").skipPermissions,
-            maxInteractionTurns: config?.agent?.maxInteractionTurns,
-            featureName: options.feature,
-            pidRegistry,
-            sessionRole: "plan",
-          });
-        } finally {
-          await pidRegistry.killAll().catch(() => {});
-        }
-        if (!_planDeps.existsSync(outputPath)) {
-          throw new Error(`[plan] ACP agent did not write PRD to ${outputPath}. Check agent logs for errors.`);
-        }
-        return await _planDeps.readFile(outputPath);
+      } finally {
+        await pidRegistry.killAll().catch(() => {});
       }
+      if (!_planDeps.existsSync(outputPath)) {
+        throw new Error(`[plan] ACP agent did not write PRD to ${outputPath}. Check agent logs for errors.`);
+      }
+      rawResponse = await _planDeps.readFile(outputPath);
+    } else {
       // CLI: one-shot complete() — simple and fast, no session overhead
       let result = await adapter.complete(prompt, {
         model: autoModel,
@@ -237,34 +284,14 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
       } catch {
         // Not an envelope — use result as-is
       }
-      return result;
-    };
-
-    // Debate check hoisted above isAcp gate — runs regardless of protocol
-    const debateEnabled = config?.debate?.enabled && config?.debate?.stages?.plan?.enabled;
-    if (debateEnabled) {
-      // Safe: debateEnabled guard confirms config.debate.stages.plan is defined
-      const planStageConfig = config?.debate?.stages.plan as import("../debate").DebateStageConfig;
-      const debateSession = _planDeps.createDebateSession({
-        storyId: options.feature,
-        stage: "plan",
-        stageConfig: planStageConfig,
-        config,
-      });
-      const debateResult = await debateSession.run(prompt);
-      if (debateResult.outcome !== "failed" && debateResult.output) {
-        rawResponse = debateResult.output;
-      } else {
-        logger?.warn("debate", "All debaters failed — falling back to single agent", {
-          stage: "debate",
-          event: "fallback",
-        });
-        rawResponse = await runSingleAgentPlan();
-      }
-    } else {
-      rawResponse = await runSingleAgentPlan();
+      rawResponse = result;
     }
   } else {
+    rawResponse = await runInteractivePlan();
+  }
+
+  // ── Interactive plan helper (used by: interactive path + debate fallback) ──────────────────────
+  async function runInteractivePlan(): Promise<string> {
     // Interactive: agent writes PRD JSON directly to outputPath (avoids output truncation)
     const prompt = buildPlanningPrompt(
       specContent,
@@ -322,7 +349,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
     if (!_planDeps.existsSync(outputPath)) {
       throw new Error(`[plan] Agent did not write PRD to ${outputPath}. Check agent logs for errors.`);
     }
-    rawResponse = await _planDeps.readFile(outputPath);
+    return _planDeps.readFile(outputPath);
   }
 
   // Validate and normalize: handles markdown extraction, trailing commas, LLM quirks,

--- a/src/debate/session.ts
+++ b/src/debate/session.ts
@@ -5,9 +5,10 @@
  * Resolves adapters, runs proposal and critique rounds, and calls the configured resolver.
  */
 
+import { join } from "node:path";
 import type { AcpClient, AcpSession, AcpSessionResponse } from "../agents/acp/adapter";
 import { createSpawnAcpClient } from "../agents/acp/spawn-client";
-import { getAgent } from "../agents/registry";
+import { createAgentRegistry, getAgent } from "../agents/registry";
 import type { AgentAdapter } from "../agents/types";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config";
@@ -47,9 +48,17 @@ export interface DebateSessionOptions {
 
 /** Injectable deps for testability */
 export const _debateSessionDeps = {
-  getAgent: getAgent as (name: string) => AgentAdapter | undefined,
+  /**
+   * Resolve an agent adapter by name.
+   * When config is provided, uses createAgentRegistry(config) so that ACP agents
+   * are returned as AcpAgentAdapter (respecting agent.protocol).
+   * Falls back to bare getAgent() when config is absent (backward compat / tests).
+   */
+  getAgent: (name: string, config?: NaxConfig): AgentAdapter | undefined =>
+    config ? createAgentRegistry(config).getAgent(name) : getAgent(name),
   getSafeLogger: getSafeLogger as () => ReturnType<typeof getSafeLogger>,
   createSpawnAcpClient: (cmdStr: string, cwd?: string): AcpClient => createSpawnAcpClient(cmdStr, cwd),
+  readFile: (path: string): Promise<string> => Bun.file(path).text(),
 };
 
 interface ResolvedDebater {
@@ -121,7 +130,7 @@ export class DebateSession {
     // Resolve adapters — skip unavailable agents
     const resolved: ResolvedDebater[] = [];
     for (const debater of debaters) {
-      const adapter = _debateSessionDeps.getAgent(debater.agent);
+      const adapter = _debateSessionDeps.getAgent(debater.agent, this.config);
       if (!adapter) {
         logger?.warn("debate", `Agent '${debater.agent}' not found — skipping debater`);
         continue;
@@ -297,7 +306,7 @@ export class DebateSession {
     // Step 1: Resolve adapters — skip unavailable agents
     const resolved: ResolvedDebater[] = [];
     for (const debater of debaters) {
-      const adapter = _debateSessionDeps.getAgent(debater.agent);
+      const adapter = _debateSessionDeps.getAgent(debater.agent, this.config);
       if (!adapter) {
         logger?.warn("debate", `Agent '${debater.agent}' not found — skipping debater`);
         continue;
@@ -454,6 +463,143 @@ export class DebateSession {
     };
   }
 
+  /**
+   * Run a plan-mode debate.
+   *
+   * Each debater calls adapter.plan() writing its PRD to a unique temp path under outputDir.
+   * After all plans complete, the resolver picks the best PRD (or synthesises one).
+   * Returns a DebateResult whose `output` field contains the winning PRD JSON string.
+   *
+   * @param basePrompt - Planning prompt WITHOUT a file-write instruction (outputFilePath omitted).
+   *                     runPlan() appends the per-debater temp file path instruction itself.
+   * @param opts       - Plan options shared across all debaters.
+   */
+  async runPlan(
+    basePrompt: string,
+    opts: {
+      workdir: string;
+      feature: string;
+      outputDir: string;
+      timeoutSeconds?: number;
+      dangerouslySkipPermissions?: boolean;
+      maxInteractionTurns?: number;
+    },
+  ): Promise<DebateResult> {
+    const logger = _debateSessionDeps.getSafeLogger();
+    const config = this.stageConfig;
+    const debaters = config.debaters ?? [];
+    const totalCostUsd = 0;
+
+    // Resolve adapters — skip unavailable agents
+    const resolved: ResolvedDebater[] = [];
+    for (const debater of debaters) {
+      const adapter = _debateSessionDeps.getAgent(debater.agent, this.config);
+      if (!adapter) {
+        logger?.warn("debate", `Agent '${debater.agent}' not found — skipping debater`);
+        continue;
+      }
+      resolved.push({ debater, adapter });
+    }
+
+    logger?.info("debate", "debate:start", {
+      storyId: this.storyId,
+      stage: this.stage,
+      debaters: resolved.map((r) => r.debater.agent),
+    });
+
+    // Run plan() for each debater in parallel, each writing to a unique temp path
+    const planSettled = await Promise.allSettled(
+      resolved.map(async ({ debater, adapter }, i) => {
+        const tempOutputPath = join(opts.outputDir, `prd-debate-${i}.json`);
+        // Append file-write instruction pointing at this debater's temp path
+        const debaterPrompt = `${basePrompt}\n\nWrite the PRD JSON directly to this file path: ${tempOutputPath}\nDo NOT output the JSON to the conversation. Write the file, then reply with a brief confirmation.`;
+
+        await adapter.plan({
+          prompt: debaterPrompt,
+          workdir: opts.workdir,
+          interactive: false,
+          timeoutSeconds: opts.timeoutSeconds,
+          config: this.config,
+          modelTier: (debater.model ?? "balanced") as import("../config/schema-types").ModelTier,
+          dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
+          maxInteractionTurns: opts.maxInteractionTurns,
+          featureName: opts.feature,
+          sessionRole: "plan",
+        });
+
+        const output = await _debateSessionDeps.readFile(tempOutputPath);
+        return { debater, adapter, output, cost: 0 } as SuccessfulProposal;
+      }),
+    );
+
+    const successful: SuccessfulProposal[] = planSettled
+      .filter((r): r is PromiseFulfilledResult<SuccessfulProposal> => r.status === "fulfilled")
+      .map((r) => r.value);
+
+    for (let i = 0; i < successful.length; i++) {
+      logger?.info("debate", "debate:proposal", {
+        storyId: this.storyId,
+        stage: this.stage,
+        debaterIndex: i,
+        agent: successful[i].debater.agent,
+      });
+    }
+
+    if (successful.length === 0) {
+      logger?.warn("debate", "debate:fallback", {
+        storyId: this.storyId,
+        stage: this.stage,
+        reason: "all plan debaters failed",
+      });
+      return buildFailedResult(this.storyId, this.stage, config, totalCostUsd);
+    }
+
+    // Single success — use directly (no resolver needed)
+    if (successful.length === 1) {
+      logger?.warn("debate", "debate:fallback", {
+        storyId: this.storyId,
+        stage: this.stage,
+        reason: "only 1 plan debater succeeded — using as solo",
+      });
+      logger?.info("debate", "debate:result", { storyId: this.storyId, stage: this.stage, outcome: "passed" });
+      return {
+        storyId: this.storyId,
+        stage: this.stage,
+        outcome: "passed",
+        rounds: 1,
+        debaters: [successful[0].debater.agent],
+        resolverType: config.resolver.type,
+        proposals: [{ debater: successful[0].debater, output: successful[0].output }],
+        output: successful[0].output,
+        totalCostUsd,
+      };
+    }
+
+    // Multiple proposals — resolve to pick the winning PRD
+    const proposalOutputs = successful.map((p) => p.output);
+    const outcome = await this.resolve(proposalOutputs, [], successful);
+
+    // Winning output: synthesis resolver returns combined PRD via synthesisResolver output;
+    // for majority/custom, use the first proposal as the baseline winner.
+    // synthesisResolver currently does not return output — use first proposal for now.
+    const winningOutput = successful[0].output;
+
+    const proposals: Proposal[] = successful.map((p) => ({ debater: p.debater, output: p.output }));
+
+    logger?.info("debate", "debate:result", { storyId: this.storyId, stage: this.stage, outcome });
+    return {
+      storyId: this.storyId,
+      stage: this.stage,
+      outcome,
+      rounds: 1,
+      debaters: successful.map((p) => p.debater.agent),
+      resolverType: config.resolver.type,
+      proposals,
+      output: winningOutput,
+      totalCostUsd,
+    };
+  }
+
   private async resolve(
     proposalOutputs: string[],
     critiqueOutputs: string[],
@@ -467,7 +613,7 @@ export class DebateSession {
 
     if (resolverConfig.type === "synthesis") {
       const agentName = resolverConfig.agent ?? RESOLVER_FALLBACK_AGENT;
-      const adapter = _debateSessionDeps.getAgent(agentName);
+      const adapter = _debateSessionDeps.getAgent(agentName, this.config);
       if (adapter) {
         await synthesisResolver(proposalOutputs, critiqueOutputs, { adapter });
       }
@@ -476,7 +622,7 @@ export class DebateSession {
 
     if (resolverConfig.type === "custom") {
       await judgeResolver(proposalOutputs, critiqueOutputs, resolverConfig, {
-        getAgent: _debateSessionDeps.getAgent,
+        getAgent: (name: string) => _debateSessionDeps.getAgent(name, this.config),
         defaultAgentName: RESOLVER_FALLBACK_AGENT,
       });
       return "passed";

--- a/src/execution/lifecycle/acceptance-loop.ts
+++ b/src/execution/lifecycle/acceptance-loop.ts
@@ -129,6 +129,7 @@ async function generateAndAddFixStories(
     modelDef,
     config: ctx.config,
     testFilePath,
+    timeoutMs: ctx.config.acceptance?.timeoutMs,
   });
   if (fixStories.length === 0) {
     logger?.error("acceptance", "Failed to generate fix stories");

--- a/test/unit/cli/plan-debate.test.ts
+++ b/test/unit/cli/plan-debate.test.ts
@@ -2,9 +2,14 @@
  * Unit tests — planCommand debate integration (US-004)
  *
  * AC1: When debate.enabled=true and stages.plan.enabled=true,
- *      planCommand --auto uses DebateSession.run() instead of adapter.complete()
- * AC2: When debate.enabled=false, adapter.complete() called exactly once
- * AC6: When all debaters fail, fallback to adapter.complete() and log warning
+ *      planCommand uses DebateSession.runPlan() — regardless of auto/interactive mode
+ * AC2: When debate.enabled=false, adapter.complete() called exactly once (auto mode)
+ * AC6: When all debaters fail (runPlan returns failed), fallback to interactive plan path
+ *
+ * Design change (Option A, #172 fix):
+ *   - Debate is now SSOT: fires whenever debate.enabled + stages.plan.enabled, regardless of mode.
+ *   - DebateSession.runPlan() replaces DebateSession.run() for the plan stage.
+ *   - Fallback on debate failure uses the interactive plan path (adapter.plan()), not complete().
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -179,8 +184,24 @@ const origInitInteractionChain = _planDeps.initInteractionChain;
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-function makeFakeAdapter(prd: PRD = SAMPLE_PRD) {
+/** Adapter that simulates complete() for CLI/auto mode */
+function makeFakeCompleteAdapter(prd: PRD = SAMPLE_PRD) {
   return { complete: mock(async () => JSON.stringify(prd)) };
+}
+
+/** Adapter that simulates plan() for interactive/ACP mode (writes nothing — we mock readFile) */
+function makeFakePlanAdapter() {
+  return {
+    plan: mock(async () => ({ specContent: "" })),
+    complete: mock(async () => JSON.stringify(SAMPLE_PRD)),
+  };
+}
+
+/** Set up mocks for a successful interactive plan (adapter.plan() path) */
+function setupInteractivePlanMocks(adapter: ReturnType<typeof makeFakePlanAdapter>) {
+  _planDeps.getAgent = mock(() => adapter as never);
+  _planDeps.existsSync = mock((p: string) => p.includes(".nax"));
+  _planDeps.readFile = mock(async () => JSON.stringify(SAMPLE_PRD));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -209,7 +230,7 @@ describe("planCommand — debate integration (US-004)", () => {
     _planDeps.discoverWorkspacePackages = mock(async () => []);
     _planDeps.existsSync = mock(() => false);
     _planDeps.initInteractionChain = mock(async () => null);
-    _planDeps.getAgent = mock(() => makeFakeAdapter() as never);
+    _planDeps.getAgent = mock(() => makeFakeCompleteAdapter() as never);
     _planDeps.createDebateSession = origCreateDebateSession;
   });
 
@@ -231,12 +252,12 @@ describe("planCommand — debate integration (US-004)", () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────────
-  // AC1: debate.enabled=true and stages.plan.enabled=true → DebateSession used
+  // AC1: debate.enabled=true + stages.plan.enabled=true → DebateSession.runPlan() used
   // ─────────────────────────────────────────────────────────────────────────
 
   test("AC1: createDebateSession is called when debate.enabled=true and stages.plan.enabled=true", async () => {
-    const runMock = mock(async () => DEBATE_PASSED_RESULT);
-    _planDeps.createDebateSession = mock(() => ({ run: runMock }));
+    const runPlanMock = mock(async () => DEBATE_PASSED_RESULT);
+    _planDeps.createDebateSession = mock(() => ({ runPlan: runPlanMock }));
 
     await planCommand(tmpDir, DEBATE_PLAN_ENABLED_CONFIG, {
       from: "/spec.md",
@@ -247,9 +268,9 @@ describe("planCommand — debate integration (US-004)", () => {
     expect(_planDeps.createDebateSession).toHaveBeenCalled();
   });
 
-  test("AC1: DebateSession.run() is called with the planning prompt", async () => {
-    const runMock = mock(async () => DEBATE_PASSED_RESULT);
-    _planDeps.createDebateSession = mock(() => ({ run: runMock }));
+  test("AC1: DebateSession.runPlan() is called with the planning prompt and options", async () => {
+    const runPlanMock = mock(async () => DEBATE_PASSED_RESULT);
+    _planDeps.createDebateSession = mock(() => ({ runPlan: runPlanMock }));
 
     await planCommand(tmpDir, DEBATE_PLAN_ENABLED_CONFIG, {
       from: "/spec.md",
@@ -257,15 +278,17 @@ describe("planCommand — debate integration (US-004)", () => {
       auto: true,
     });
 
-    expect(runMock).toHaveBeenCalledTimes(1);
-    const [promptArg] = runMock.mock.calls[0];
+    expect(runPlanMock).toHaveBeenCalledTimes(1);
+    const [promptArg, optsArg] = runPlanMock.mock.calls[0];
     expect(typeof promptArg).toBe("string");
     expect(promptArg.length).toBeGreaterThan(100);
+    expect(optsArg.feature).toBe("debate-plan");
+    expect(optsArg.workdir).toBe(tmpDir);
   });
 
   test("AC1: createDebateSession receives the plan stage config", async () => {
-    const runMock = mock(async () => DEBATE_PASSED_RESULT);
-    const createMock = mock(() => ({ run: runMock }));
+    const runPlanMock = mock(async () => DEBATE_PASSED_RESULT);
+    const createMock = mock(() => ({ runPlan: runPlanMock }));
     _planDeps.createDebateSession = createMock;
 
     await planCommand(tmpDir, DEBATE_PLAN_ENABLED_CONFIG, {
@@ -284,7 +307,7 @@ describe("planCommand — debate integration (US-004)", () => {
     _planDeps.getAgent = mock(() => ({ complete: adapterComplete }) as never);
 
     _planDeps.createDebateSession = mock(() => ({
-      run: mock(async () => DEBATE_PASSED_RESULT),
+      runPlan: mock(async () => DEBATE_PASSED_RESULT),
     }));
 
     await planCommand(tmpDir, DEBATE_PLAN_ENABLED_CONFIG, {
@@ -296,6 +319,18 @@ describe("planCommand — debate integration (US-004)", () => {
     expect(adapterComplete).not.toHaveBeenCalled();
   });
 
+  test("AC1: debate fires in interactive mode (no --auto flag) when debate.enabled=true", async () => {
+    const runPlanMock = mock(async () => DEBATE_PASSED_RESULT);
+    _planDeps.createDebateSession = mock(() => ({ runPlan: runPlanMock }));
+    // No auto: true — interactive mode
+    await planCommand(tmpDir, DEBATE_PLAN_ENABLED_CONFIG, {
+      from: "/spec.md",
+      feature: "debate-plan",
+    });
+
+    expect(runPlanMock).toHaveBeenCalledTimes(1);
+  });
+
   // ─────────────────────────────────────────────────────────────────────────
   // AC2: debate disabled → adapter.complete() called exactly once, no debate
   // ─────────────────────────────────────────────────────────────────────────
@@ -304,7 +339,7 @@ describe("planCommand — debate integration (US-004)", () => {
     const adapterComplete = mock(async () => JSON.stringify(SAMPLE_PRD));
     _planDeps.getAgent = mock(() => ({ complete: adapterComplete }) as never);
 
-    const createDebateMock = mock(() => ({ run: mock(async () => DEBATE_PASSED_RESULT) }));
+    const createDebateMock = mock(() => ({ runPlan: mock(async () => DEBATE_PASSED_RESULT) }));
     _planDeps.createDebateSession = createDebateMock;
 
     await planCommand(
@@ -321,7 +356,7 @@ describe("planCommand — debate integration (US-004)", () => {
     const adapterComplete = mock(async () => JSON.stringify(SAMPLE_PRD));
     _planDeps.getAgent = mock(() => ({ complete: adapterComplete }) as never);
 
-    const createDebateMock = mock(() => ({ run: mock(async () => DEBATE_PASSED_RESULT) }));
+    const createDebateMock = mock(() => ({ runPlan: mock(async () => DEBATE_PASSED_RESULT) }));
     _planDeps.createDebateSession = createDebateMock;
 
     await planCommand(tmpDir, {} as NaxConfig, {
@@ -338,7 +373,7 @@ describe("planCommand — debate integration (US-004)", () => {
     const adapterComplete = mock(async () => JSON.stringify(SAMPLE_PRD));
     _planDeps.getAgent = mock(() => ({ complete: adapterComplete }) as never);
 
-    const createDebateMock = mock(() => ({ run: mock(async () => DEBATE_PASSED_RESULT) }));
+    const createDebateMock = mock(() => ({ runPlan: mock(async () => DEBATE_PASSED_RESULT) }));
     _planDeps.createDebateSession = createDebateMock;
 
     await planCommand(tmpDir, DEBATE_PLAN_STAGE_DISABLED_CONFIG, {
@@ -352,37 +387,37 @@ describe("planCommand — debate integration (US-004)", () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────────
-  // AC6: all debaters fail → fallback to adapter.complete() and log warning
+  // AC6: all debaters fail → fallback to interactive plan path (adapter.plan())
   // ─────────────────────────────────────────────────────────────────────────
 
-  test("AC6: falls back to adapter.complete() when DebateSession returns outcome=failed", async () => {
-    const adapterComplete = mock(async () => JSON.stringify(SAMPLE_PRD));
-    _planDeps.getAgent = mock(() => ({ complete: adapterComplete }) as never);
+  test("AC6: falls back to interactive plan path when DebateSession returns outcome=failed", async () => {
+    const adapter = makeFakePlanAdapter();
+    setupInteractivePlanMocks(adapter);
 
     _planDeps.createDebateSession = mock(() => ({
-      run: mock(async () => DEBATE_FAILED_RESULT),
+      runPlan: mock(async () => DEBATE_FAILED_RESULT),
     }));
 
     await planCommand(tmpDir, DEBATE_PLAN_ENABLED_CONFIG, {
       from: "/spec.md",
       feature: "debate-plan",
-      auto: true,
     });
 
-    expect(adapterComplete).toHaveBeenCalledTimes(1);
+    expect(adapter.plan).toHaveBeenCalledTimes(1);
   });
 
   test("AC6: planCommand succeeds (does not throw) when debate fails and fallback is used", async () => {
-    _planDeps.getAgent = mock(() => makeFakeAdapter() as never);
+    const adapter = makeFakePlanAdapter();
+    setupInteractivePlanMocks(adapter);
+
     _planDeps.createDebateSession = mock(() => ({
-      run: mock(async () => DEBATE_FAILED_RESULT),
+      runPlan: mock(async () => DEBATE_FAILED_RESULT),
     }));
 
     await expect(
       planCommand(tmpDir, DEBATE_PLAN_ENABLED_CONFIG, {
         from: "/spec.md",
         feature: "debate-plan",
-        auto: true,
       }),
     ).resolves.toBeDefined();
   });


### PR DESCRIPTION
## What

Fix `fix-generator.ts` ignoring `acceptance.timeoutMs` config — `complete()` was falling back to ACP adapter default of **2 minutes** instead of the configured **30 minutes**.

## Why

Observed in bench-04 run 2: acceptance fix generation timed out after 120,000ms despite `acceptance.timeoutMs: 1800000` in config.

```
2026-04-01T07:53:47  Killed active prompt process PID 95414
2026-04-01T07:53:48  [WARN] complete() timed out after 120000ms
```

`generator.ts` already correctly passes `timeoutMs: options.config?.acceptance?.timeoutMs ?? 1800000`. `fix-generator.ts` was missing the same.

Closes #187

## How

- Add `timeoutMs?: number` to `GenerateFixStoriesOptions`
- Pass `timeoutMs: options.timeoutMs ?? options.config?.acceptance?.timeoutMs ?? 1800000` to `complete()`
- Thread `ctx.config.acceptance?.timeoutMs` from `acceptance-loop.ts` call site

## Testing

- [x] Tests added/updated
- [x] `bun test test/unit/acceptance/` — 214 pass
- [x] `bun test test/unit/execution/` — 465 pass
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

`refinement.ts` also omits `timeoutMs` from its `complete()` call, but that's a short JSON call (maxTokens: 4096) — low risk. Can be addressed separately if needed.
