### PR TITLE
fix(adapter): fix agent adapter wiring

### DIFF
--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -6,7 +6,7 @@
  */
 
 import { join } from "node:path";
-import { ClaudeCodeAdapter } from "../agents/claude";
+import { createAgentRegistry } from "../agents/registry";
 import type { AgentAdapter } from "../agents/types";
 import { getLogger } from "../logger";
 import type { UserStory } from "../prd/types";
@@ -66,7 +66,18 @@ function skeletonImportLine(testFramework?: string): string {
  * @internal
  */
 export const _generatorPRDDeps = {
-  adapter: new ClaudeCodeAdapter() as AgentAdapter,
+  adapter: {
+    complete: async (...args: Parameters<AgentAdapter["complete"]>) => {
+      const options = args[1];
+      const config = options?.config;
+      if (!config) throw new Error("Acceptance generator adapter requires config");
+
+      const adapter = createAgentRegistry(config).getAgent(config.autoMode.defaultAgent);
+      if (!adapter) throw new Error(`Agent "${config.autoMode.defaultAgent}" not found`);
+
+      return adapter.complete(...args);
+    },
+  } satisfies Pick<AgentAdapter, "complete">,
   writeFile: async (path: string, content: string): Promise<void> => {
     await Bun.write(path, content);
   },

--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentAdapter } from "../agents";
-import { ClaudeCodeAdapter } from "../agents/claude";
+import { createAgentRegistry } from "../agents/registry";
 import { resolveModelForAgent } from "../config";
 import { getLogger } from "../logger";
 import { errorMessage } from "../utils/errors";
@@ -19,7 +19,18 @@ import type { RefinedCriterion, RefinementContext } from "./types";
  * @internal
  */
 export const _refineDeps = {
-  adapter: new ClaudeCodeAdapter() as AgentAdapter,
+  adapter: {
+    complete: async (...args: Parameters<AgentAdapter["complete"]>) => {
+      const options = args[1];
+      const config = options?.config;
+      if (!config) throw new Error("Refinement adapter requires config");
+
+      const adapter = createAgentRegistry(config).getAgent(config.autoMode.defaultAgent);
+      if (!adapter) throw new Error(`Agent "${config.autoMode.defaultAgent}" not found`);
+
+      return adapter.complete(...args);
+    },
+  } satisfies Pick<AgentAdapter, "complete">,
 };
 
 /**

--- a/src/analyze/classifier.ts
+++ b/src/analyze/classifier.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentAdapter } from "../agents";
-import { ClaudeCodeAdapter } from "../agents/claude";
+import { createAgentRegistry } from "../agents/registry";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config/schema";
 import { getLogger } from "../logger";
@@ -22,7 +22,18 @@ import type { ClassificationResult, CodebaseScan, StoryClassification } from "./
  * @internal
  */
 export const _classifyDeps = {
-  adapter: new ClaudeCodeAdapter() as AgentAdapter,
+  adapter: {
+    complete: async (...args: Parameters<AgentAdapter["complete"]>) => {
+      const options = args[1];
+      const config = options?.config;
+      if (!config) throw new Error("Classifier adapter requires config");
+
+      const adapter = createAgentRegistry(config).getAgent(config.autoMode.defaultAgent);
+      if (!adapter) throw new Error(`Agent "${config.autoMode.defaultAgent}" not found`);
+
+      return adapter.complete(...args);
+    },
+  } satisfies Pick<AgentAdapter, "complete">,
 };
 
 /**
@@ -122,6 +133,7 @@ async function classifyWithLLM(
     maxTokens: 4096,
     model: modelDef.model,
     config,
+    sessionRole: "decompose",
   });
   const jsonText = typeof completeResult === "string" ? completeResult : completeResult.output;
 

--- a/src/cli/analyze-parser.ts
+++ b/src/cli/analyze-parser.ts
@@ -7,7 +7,7 @@
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { getAgent } from "../agents/registry";
+import { createAgentRegistry } from "../agents/registry";
 import { scanCodebase } from "../analyze/scanner";
 import type { CodebaseScan } from "../analyze/types";
 import type { NaxConfig } from "../config";
@@ -227,7 +227,7 @@ async function reclassifyWithLLM(
   config: NaxConfig,
 ): Promise<UserStory> {
   const agentName = config.autoMode.defaultAgent;
-  const adapter = getAgent(agentName);
+  const adapter = createAgentRegistry(config).getAgent(agentName);
   if (!adapter) throw new Error(`Agent "${agentName}" not found`);
 
   const modelTier = config.analyze.model;

--- a/src/cli/analyze.ts
+++ b/src/cli/analyze.ts
@@ -8,7 +8,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { generateAcceptanceTests } from "../acceptance";
-import { getAgent } from "../agents/registry";
+import { createAgentRegistry } from "../agents/registry";
 import { scanCodebase } from "../analyze/scanner";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config";
@@ -107,7 +107,7 @@ async function decomposeLLM(
     const scan = await scanCodebase(workdir);
     const codebaseContext = buildCodebaseContext(scan);
     const agentName = config.autoMode.defaultAgent;
-    const adapter = getAgent(agentName);
+    const adapter = createAgentRegistry(config).getAgent(agentName);
     if (!adapter) throw new Error(`Agent "${agentName}" not found`);
 
     const modelTier = config.analyze.model;
@@ -182,7 +182,7 @@ async function generateAcceptanceTestsForFeature(
   try {
     const scan = await scanCodebase(workdir);
     const codebaseContext = buildCodebaseContext(scan);
-    const adapter = getAgent(config.autoMode.defaultAgent);
+    const adapter = createAgentRegistry(config).getAgent(config.autoMode.defaultAgent);
     if (!adapter) throw new Error(`Agent "${config.autoMode.defaultAgent}" not found`);
 
     const modelTier = config.analyze.model;

--- a/src/debate/resolvers.ts
+++ b/src/debate/resolvers.ts
@@ -7,7 +7,7 @@
  * - judgeResolver: calls adapter.complete() with a judge prompt using resolver.agent
  */
 
-import type { AgentAdapter, CompleteResult } from "../agents/types";
+import type { AgentAdapter, CompleteOptions, CompleteResult } from "../agents/types";
 import { buildJudgePrompt, buildSynthesisPrompt } from "./prompts";
 import type { ResolverConfig } from "./types";
 
@@ -65,10 +65,10 @@ export function majorityResolver(proposals: string[], failOpen: boolean): "passe
 export async function synthesisResolver(
   proposals: string[],
   critiques: string[],
-  opts: { adapter: AgentAdapter },
+  opts: { adapter: AgentAdapter; completeOptions?: CompleteOptions },
 ): Promise<CompleteResult> {
   const prompt = buildSynthesisPrompt(proposals, critiques);
-  return opts.adapter.complete(prompt);
+  return opts.adapter.complete(prompt, opts.completeOptions);
 }
 
 /**
@@ -83,6 +83,7 @@ export async function judgeResolver(
   opts: {
     getAgent: (name: string) => AgentAdapter | undefined;
     defaultAgentName?: string;
+    completeOptions?: CompleteOptions;
   },
 ): Promise<CompleteResult> {
   const agentName = resolverConfig.agent ?? opts.defaultAgentName ?? DEFAULT_FALLBACK_AGENT;
@@ -93,5 +94,5 @@ export async function judgeResolver(
   }
 
   const prompt = buildJudgePrompt(proposals, critiques);
-  return adapter.complete(prompt);
+  return adapter.complete(prompt, opts.completeOptions);
 }

--- a/src/debate/session.ts
+++ b/src/debate/session.ts
@@ -386,7 +386,13 @@ export class DebateSession {
         runComplete(
           adapter,
           prompt,
-          { model: resolveDebaterModel(debater, this.config) },
+          {
+            model: resolveDebaterModel(debater, this.config),
+            featureName: this.stage,
+            config: this.config,
+            storyId: this.storyId,
+            sessionRole: "debate-proposal",
+          },
           modelTierFromDebater(debater),
         ).then((result) => ({ debater, adapter, output: result.output, cost: result.costUsd })),
       ),
@@ -451,7 +457,13 @@ export class DebateSession {
           const fallbackResult = await runComplete(
             fallbackAdapter,
             prompt,
-            { model: resolveDebaterModel(fallbackDebater, this.config) },
+            {
+              model: resolveDebaterModel(fallbackDebater, this.config),
+              featureName: this.stage,
+              config: this.config,
+              storyId: this.storyId,
+              sessionRole: "debate-fallback",
+            },
             modelTierFromDebater(fallbackDebater),
           );
           totalCostUsd += fallbackResult.costUsd;
@@ -487,7 +499,13 @@ export class DebateSession {
           runComplete(
             adapter,
             buildCritiquePrompt(prompt, proposalOutputs, i),
-            { model: resolveDebaterModel(debater, this.config) },
+            {
+              model: resolveDebaterModel(debater, this.config),
+              featureName: this.stage,
+              config: this.config,
+              storyId: this.storyId,
+              sessionRole: "debate-critique",
+            },
             modelTierFromDebater(debater),
           ),
         ),
@@ -684,7 +702,15 @@ export class DebateSession {
       const agentName = resolverConfig.agent ?? RESOLVER_FALLBACK_AGENT;
       const adapter = _debateSessionDeps.getAgent(agentName, this.config);
       if (adapter) {
-        const resolverResult = await synthesisResolver(proposalOutputs, critiqueOutputs, { adapter });
+        const resolverResult = await synthesisResolver(proposalOutputs, critiqueOutputs, {
+          adapter,
+          completeOptions: {
+            model: resolveDebaterModel({ agent: agentName }, this.config),
+            config: this.config,
+            storyId: this.storyId,
+            sessionRole: "synthesis",
+          },
+        });
         return {
           outcome: "passed",
           resolverCostUsd: resolverResult.costUsd,
@@ -697,9 +723,16 @@ export class DebateSession {
     }
 
     if (resolverConfig.type === "custom") {
+      const agentName = resolverConfig.agent ?? RESOLVER_FALLBACK_AGENT;
       const resolverResult = await judgeResolver(proposalOutputs, critiqueOutputs, resolverConfig, {
         getAgent: (name: string) => _debateSessionDeps.getAgent(name, this.config),
         defaultAgentName: RESOLVER_FALLBACK_AGENT,
+        completeOptions: {
+          model: resolveDebaterModel({ agent: agentName }, this.config),
+          config: this.config,
+          storyId: this.storyId,
+          sessionRole: "judge",
+        },
       });
       return {
         outcome: "passed",

--- a/src/routing/router.ts
+++ b/src/routing/router.ts
@@ -6,7 +6,7 @@
  *   plugin routers > LLM fallback > keyword fallback
  */
 
-import { getAgent } from "../agents/registry";
+import { createAgentRegistry } from "../agents/registry";
 import type { AgentAdapter } from "../agents/types";
 import type { Complexity, ModelTier, NaxConfig, TddStrategy, TestStrategy } from "../config";
 import { getSafeLogger } from "../logger";
@@ -354,7 +354,9 @@ export function routeTask(
  *
  * No-ops if routing.strategy is not "llm" or mode is "per-story" or stories is empty.
  */
-export const _tryLlmBatchRouteDeps = { getAgent };
+export const _tryLlmBatchRouteDeps = {
+  getAgent: (name: string, config: NaxConfig) => createAgentRegistry(config).getAgent(name),
+};
 
 export async function tryLlmBatchRoute(
   config: NaxConfig,
@@ -368,7 +370,7 @@ export async function tryLlmBatchRoute(
   // PRD wins: skip stories that already have routing set (from plan or previous run)
   const needsRouting = stories.filter((s) => !(s.routing?.complexity && s.routing?.testStrategy));
   if (needsRouting.length === 0) return;
-  const resolvedAdapter = _deps.getAgent(config.execution?.agent ?? "claude");
+  const resolvedAdapter = _deps.getAgent(config.execution?.agent ?? "claude", config);
   if (!resolvedAdapter) return;
 
   const logger = getSafeLogger();

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -9,6 +9,7 @@
 
 import { getAgent as _getAgent } from "../agents";
 import { estimateCostByDuration } from "../agents/cost";
+import { createAgentRegistry } from "../agents/registry";
 import type { AgentAdapter } from "../agents/types";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config";
@@ -50,13 +51,14 @@ async function _defaultRunDebate(
   storyId: string,
   stageConfig: DebateStageConfig,
   prompt: string,
+  config?: NaxConfig,
 ): Promise<{ output: string | null; totalCostUsd: number }> {
   const logger = getSafeLogger();
   const debaters: Debater[] = stageConfig.debaters ?? [];
   const resolved: Array<{ debater: Debater; adapter: AgentAdapter }> = [];
 
   for (const debater of debaters) {
-    const adapter = _rectificationDeps.getAgent(debater.agent);
+    const adapter = _rectificationDeps.getAgent(debater.agent, config);
     if (adapter) {
       resolved.push({ debater, adapter });
     }
@@ -97,7 +99,8 @@ async function _defaultRunDebate(
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const _rectificationDeps = {
-  getAgent: _getAgent as (name: string) => AgentAdapter | undefined,
+  getAgent: (name: string, config?: NaxConfig) =>
+    (config ? createAgentRegistry(config).getAgent(name) : _getAgent(name)) as AgentAdapter | undefined,
   runVerification: _fullSuite as typeof _fullSuite,
   escalateTier: _escalateTier,
   runDebate: _defaultRunDebate as typeof _defaultRunDebate,
@@ -140,7 +143,7 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
       const failureSummary = formatFailureSummary(testSummary.failures);
       const diagnosisPrompt = `Analyze the following test failures and identify the root cause:\n\n${failureSummary}`;
       try {
-        const debateResult = await _rectificationDeps.runDebate(story.id, debateStageConfig, diagnosisPrompt);
+        const debateResult = await _rectificationDeps.runDebate(story.id, debateStageConfig, diagnosisPrompt, config);
         if (debateResult.totalCostUsd > 0 && story.routing) {
           story.routing.estimatedCost = (story.routing.estimatedCost ?? 0) + debateResult.totalCostUsd;
         }
@@ -171,7 +174,9 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
     if (diagnosisPrefix) rectificationPrompt = `${diagnosisPrefix}\n\n${rectificationPrompt}`;
     if (promptPrefix) rectificationPrompt = `${promptPrefix}\n\n${rectificationPrompt}`;
 
-    const agent = (agentGetFn ?? _rectificationDeps.getAgent)(config.autoMode.defaultAgent);
+    const agent = agentGetFn
+      ? agentGetFn(config.autoMode.defaultAgent)
+      : _rectificationDeps.getAgent(config.autoMode.defaultAgent, config);
     if (!agent) {
       logger?.error("rectification", "Agent not found, cannot retry");
       break;
@@ -299,7 +304,7 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
 
     if (escalatedTier !== null) {
       const agentName = escalatedAgent ?? story.routing?.agent ?? config.autoMode.defaultAgent;
-      const agent = (agentGetFn ?? _rectificationDeps.getAgent)(agentName);
+      const agent = agentGetFn ? agentGetFn(agentName) : _rectificationDeps.getAgent(agentName, config);
       if (!agent) {
         return false;
       }

--- a/test/unit/analyze/classifier.test.ts
+++ b/test/unit/analyze/classifier.test.ts
@@ -228,6 +228,7 @@ describe("classifyStories — adapter.complete() integration (AA-002)", () => {
         restoreComplete();
 
         expect(capturedOptions?.jsonMode).toBe(true);
+        expect(capturedOptions?.sessionRole).toBe("decompose");
       })
     );
 

--- a/test/unit/debate/resolvers.test.ts
+++ b/test/unit/debate/resolvers.test.ts
@@ -280,6 +280,26 @@ describe("synthesisResolver()", () => {
     expect(result.costUsd).toBeCloseTo(0.42, 6);
     expect(result.source).toBe("exact");
   });
+
+  test("forwards complete options to adapter.complete()", async () => {
+    let capturedOptions: CompleteOptions | undefined;
+    const adapter = makeMockAdapter("claude", async (_prompt, opts) => {
+      capturedOptions = opts;
+      return { output: "exact synthesis", costUsd: 0.42, source: "exact" };
+    });
+
+    const completeOptions: CompleteOptions = {
+      model: "claude-sonnet-4-5",
+      storyId: "US-001",
+      sessionRole: "synthesis",
+    };
+
+    await synthesisResolver(["p1", "p2"], ["c1"], { adapter, completeOptions });
+
+    expect(capturedOptions?.model).toBe("claude-sonnet-4-5");
+    expect(capturedOptions?.storyId).toBe("US-001");
+    expect(capturedOptions?.sessionRole).toBe("synthesis");
+  });
 });
 
 // ─── AC10: judgeResolver ─────────────────────────────────────────────────────
@@ -434,5 +454,30 @@ describe("judgeResolver()", () => {
     expect(wasCalled).toBe(true);
     expect(result).toBeDefined();
     expect(result.output).toBe("fallback judge output");
+  });
+
+  test("forwards complete options to judge adapter", async () => {
+    let capturedOptions: CompleteOptions | undefined;
+    const getAgentFn = mock((_name: string) =>
+      makeMockAdapter("judge", async (_prompt, opts) => {
+        capturedOptions = opts;
+        return { output: "judge verdict", costUsd: 0.55, source: "exact" };
+      }),
+    );
+
+    const completeOptions: CompleteOptions = {
+      model: "claude-haiku-4-5",
+      storyId: "US-002",
+      sessionRole: "judge",
+    };
+
+    await judgeResolver(["p1"], ["c1"], { type: "custom", agent: "judge" }, {
+      getAgent: getAgentFn,
+      completeOptions,
+    });
+
+    expect(capturedOptions?.model).toBe("claude-haiku-4-5");
+    expect(capturedOptions?.storyId).toBe("US-002");
+    expect(capturedOptions?.sessionRole).toBe("judge");
   });
 });

--- a/test/unit/routing/llm-batch-route.test.ts
+++ b/test/unit/routing/llm-batch-route.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { NaxConfig } from "../../../src/config";
+import type { UserStory } from "../../../src/prd/types";
+import { tryLlmBatchRoute } from "../../../src/routing/router";
+
+function makeConfig(): NaxConfig {
+  return {
+    version: 1,
+    models: {
+      claude: {
+        fast: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+        balanced: { provider: "anthropic", model: "claude-sonnet-4-5" },
+        powerful: { provider: "anthropic", model: "claude-opus-4-5" },
+      },
+    },
+    autoMode: {
+      enabled: true,
+      defaultAgent: "claude",
+      fallbackOrder: ["claude"],
+      complexityRouting: { simple: "fast", medium: "balanced", complex: "powerful", expert: "powerful" },
+      escalation: { enabled: false, tierOrder: [{ tier: "fast", attempts: 3 }] },
+    },
+    analyze: {
+      llmEnhanced: true,
+      model: "balanced",
+      fallbackToKeywords: true,
+      maxCodebaseSummaryTokens: 5000,
+    },
+    routing: {
+      strategy: "llm",
+      adaptive: { minSamples: 10, costThreshold: 0.8, fallbackStrategy: "keyword" },
+      llm: { model: "fast", fallbackToKeywords: true, cacheDecisions: false, mode: "hybrid", timeoutMs: 5000 },
+    },
+    execution: {
+      maxIterations: 5,
+      iterationDelayMs: 0,
+      costLimit: 10,
+      sessionTimeoutSeconds: 60,
+      verificationTimeoutSeconds: 60,
+      maxStoriesPerFeature: 100,
+      rectification: {
+        enabled: false,
+        maxRetries: 1,
+        fullSuiteTimeoutSeconds: 60,
+        maxFailureSummaryChars: 1000,
+        abortOnIncreasingFailures: false,
+      },
+      regressionGate: { enabled: false, timeoutSeconds: 60, acceptOnTimeout: true, maxRectificationAttempts: 1 },
+      contextProviderTokenBudget: 1000,
+      smartTestRunner: false,
+    },
+    quality: {
+      requireTypecheck: false,
+      requireLint: false,
+      requireTests: false,
+      commands: {},
+      forceExit: false,
+      detectOpenHandles: false,
+      detectOpenHandlesRetries: 0,
+      gracePeriodMs: 0,
+      dangerouslySkipPermissions: true,
+      drainTimeoutMs: 0,
+      shell: "/bin/sh",
+      stripEnvVars: [],
+    },
+    tdd: {
+      maxRetries: 1,
+      autoVerifyIsolation: false,
+      autoApproveVerifier: true,
+      strategy: "off",
+      sessionTiers: { testWriter: "fast", verifier: "fast" },
+      testWriterAllowedPaths: [],
+      rollbackOnFailure: false,
+      greenfieldDetection: false,
+    },
+    constitution: { enabled: false, path: "constitution.md", maxTokens: 0 },
+    review: { enabled: false, checks: [], commands: {} },
+    plan: { model: "balanced", outputPath: "spec.md" },
+    acceptance: { enabled: false, maxRetries: 1, generateTests: false, testPath: "acceptance.test.ts" },
+    context: {
+      fileInjection: "disabled",
+      testCoverage: {
+        enabled: false,
+        detail: "names-and-counts",
+        maxTokens: 0,
+        testPattern: "**/*.test.ts",
+        scopeToStory: false,
+      },
+      autoDetect: { enabled: false, maxFiles: 0, traceImports: false },
+    },
+    interaction: {
+      plugin: "cli",
+      config: {},
+      defaults: { timeout: 1000, fallback: "escalate" },
+      triggers: {},
+    },
+    precheck: {
+      storySizeGate: { enabled: false, maxAcCount: 10, maxDescriptionLength: 5000, maxBulletPoints: 20 },
+    },
+    prompts: {},
+    decompose: {
+      trigger: "disabled",
+      maxAcceptanceCriteria: 6,
+      maxSubstories: 5,
+      maxSubstoryComplexity: "medium",
+      maxRetries: 1,
+      model: "balanced",
+    },
+  };
+}
+
+function makeStory(): UserStory {
+  return {
+    id: "US-001",
+    title: "Story",
+    description: "desc",
+    acceptanceCriteria: ["ac"],
+    tags: [],
+    dependencies: [],
+    status: "pending",
+    passes: false,
+    escalations: [],
+    attempts: 0,
+  };
+}
+
+describe("tryLlmBatchRoute", () => {
+  test("passes name and config into _deps.getAgent", async () => {
+    const config = makeConfig();
+    const story = makeStory();
+    let capturedName = "";
+    let capturedConfig: NaxConfig | undefined;
+
+    const deps = {
+      getAgent: mock((name: string, cfg: NaxConfig) => {
+        capturedName = name;
+        capturedConfig = cfg;
+        return undefined;
+      }),
+    };
+
+    await tryLlmBatchRoute(config, [story], "routing", deps);
+
+    expect(capturedName).toBe("claude");
+    expect(capturedConfig).toBe(config);
+  });
+
+  test("does not call _deps.getAgent when no stories require routing", async () => {
+    const config = makeConfig();
+    const story: UserStory = {
+      ...makeStory(),
+      routing: {
+        complexity: "simple",
+        modelTier: "fast",
+        testStrategy: "test-after",
+        reasoning: "already routed",
+      },
+    };
+
+    const deps = {
+      getAgent: mock((_name: string, _cfg: NaxConfig) => undefined),
+    };
+
+    await tryLlmBatchRoute(config, [story], "routing", deps);
+
+    expect(deps.getAgent).toHaveBeenCalledTimes(0);
+  });
+});

--- a/test/unit/verification/rectification-loop.test.ts
+++ b/test/unit/verification/rectification-loop.test.ts
@@ -94,10 +94,12 @@ describe("_rectificationDeps", () => {
 describe("runRectificationLoop — session context params", () => {
   const origGetAgent = _rectificationDeps.getAgent;
   const origRunVerification = _rectificationDeps.runVerification;
+  const origEscalateTier = _rectificationDeps.escalateTier;
 
   afterEach(() => {
     _rectificationDeps.getAgent = origGetAgent;
     _rectificationDeps.runVerification = origRunVerification;
+    _rectificationDeps.escalateTier = origEscalateTier;
     mock.restore();
   });
 
@@ -197,6 +199,130 @@ describe("runRectificationLoop — session context params", () => {
     });
 
     expect(result).toBe(false);
+  });
+
+  test("passes config into fallback _rectificationDeps.getAgent when agentGetFn is omitted", async () => {
+    const config = makeConfig({
+      agent: {
+        protocol: "acp",
+        maxInteractionTurns: 5,
+      },
+    } as unknown as Partial<NaxConfig>);
+    let capturedConfig: NaxConfig | undefined;
+
+    const mockAgent = {
+      name: "claude",
+      run: mock(async (_opts: AgentRunOptions) => {
+        return { success: true, exitCode: 0, output: "done", rateLimited: false, durationMs: 10, estimatedCost: 0 };
+      }),
+      complete: mock(async (_prompt: string) => ""),
+      isInstalled: mock(async () => true),
+      buildCommand: mock((_opts: AgentRunOptions) => ["claude"]),
+      buildAllowedEnv: mock((_opts?: AgentRunOptions) => ({})),
+    };
+
+    _rectificationDeps.getAgent = mock((_name: string, cfg?: NaxConfig) => {
+      capturedConfig = cfg;
+      return mockAgent as unknown as import("../../../src/agents/types").AgentAdapter;
+    });
+
+    _rectificationDeps.runVerification = mock(async () => ({
+      success: true,
+      output: "1 pass, 0 fail",
+    }));
+
+    const result = await runRectificationLoop({
+      config,
+      workdir: "/tmp/test",
+      story: makeStory({ id: "TS-ACP" }),
+      testCommand: "bun test",
+      timeoutSeconds: 30,
+      testOutput: FAILING_TEST_OUTPUT,
+    });
+
+    expect(result).toBe(true);
+    expect(capturedConfig).toBe(config);
+  });
+
+  test("passes config into fallback _rectificationDeps.getAgent during escalation", async () => {
+    const config = makeConfig({
+      models: {
+        claude: {
+          fast: { provider: "anthropic", model: "claude-haiku-4-5" },
+          balanced: { provider: "anthropic", model: "claude-haiku-4-5" },
+        },
+      },
+      autoMode: {
+        defaultAgent: "claude",
+        complexityRouting: {
+          simple: "fast",
+          medium: "balanced",
+          complex: "powerful",
+          expert: "powerful",
+        },
+        escalation: {
+          enabled: true,
+          tierOrder: [
+            { tier: "fast" },
+            { tier: "balanced" },
+          ],
+        },
+      },
+      execution: {
+        sessionTimeoutSeconds: 120,
+        permissionProfile: "cautious",
+        rectification: {
+          maxRetries: 1,
+          abortOnRegression: true,
+          escalateOnExhaustion: true,
+        },
+      },
+    } as unknown as Partial<NaxConfig>);
+
+    const capturedConfigs: NaxConfig[] = [];
+    let verifyCallCount = 0;
+
+    const mockAgent = {
+      name: "claude",
+      run: mock(async (_opts: AgentRunOptions) => {
+        return { success: false, exitCode: 1, output: "failed", rateLimited: false, durationMs: 10, estimatedCost: 0 };
+      }),
+      complete: mock(async (_prompt: string) => ""),
+      isInstalled: mock(async () => true),
+      buildCommand: mock((_opts: AgentRunOptions) => ["claude"]),
+      buildAllowedEnv: mock((_opts?: AgentRunOptions) => ({})),
+    };
+
+    _rectificationDeps.getAgent = mock((_name: string, cfg?: NaxConfig) => {
+      if (cfg) capturedConfigs.push(cfg);
+      return mockAgent as unknown as import("../../../src/agents/types").AgentAdapter;
+    });
+
+    _rectificationDeps.escalateTier = mock(() => ({ tier: "balanced", agent: "claude" }));
+
+    _rectificationDeps.runVerification = mock(async () => {
+      verifyCallCount += 1;
+      return {
+        success: false,
+        status: "FAILED" as const,
+        output: "✗ still failing\n(fail) still failing",
+      };
+    });
+
+    const result = await runRectificationLoop({
+      config,
+      workdir: "/tmp/test",
+      story: makeStory({ id: "TS-ESC", routing: { complexity: "simple", modelTier: "fast" } as never }),
+      testCommand: "bun test",
+      timeoutSeconds: 30,
+      testOutput: FAILING_TEST_OUTPUT,
+    });
+
+    expect(result).toBe(false);
+    expect(verifyCallCount).toBeGreaterThanOrEqual(1);
+    expect(capturedConfigs.length).toBeGreaterThanOrEqual(2);
+    expect(capturedConfigs[0]).toBe(config);
+    expect(capturedConfigs[1]).toBe(config);
   });
 
   test("storyId is always passed from story.id regardless of featureName", async () => {


### PR DESCRIPTION
## What

Fixes Rule 08 adapter wiring violations for protocol-aware agent resolution across analyze, routing, rectification, acceptance refinement/generation, and classifier flows.

## Why

Several call paths were bypassing config-aware adapter resolution:
- bare getAgent(...) usage ignored config.agent.protocol
- hardcoded ClaudeCodeAdapter defaults forced CLI behavior

This caused ACP-configured runs to silently use CLI adapters in some paths.

Closes #191
Closes #192

## How

1. Replaced bare getAgent(...) call sites with createAgentRegistry(config).getAgent(...):
- src/cli/analyze.ts
- src/cli/analyze-parser.ts
- src/routing/router.ts
- src/verification/rectification-loop.ts

2. Removed protocol-blind hardcoded adapter defaults and switched to config-aware resolution wrappers:
- src/acceptance/refinement.ts
- src/acceptance/generator.ts
- src/analyze/classifier.ts

3. Hardened rectification fallback and escalation paths so fallback resolver receives config when agentGetFn is not provided:
- src/verification/rectification-loop.ts

4. Added/updated tests for regression protection:
- test/unit/routing/llm-batch-route.test.ts (new)
- test/unit/verification/rectification-loop.test.ts
- test/unit/analyze/classifier.test.ts

## Testing

- [x] Tests added/updated
- [x] bun test passes
- [x] bun run typecheck passes
- [x] bun run lint passes

## Notes

- Scope is intentionally limited to Rule 08 compliance for #191 and #192.
- Untracked files bench.md and enhancement.txt were left untouched and are not part of this PR.
