### PR TITLE
fix(debate): correct adapter-wiring

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -182,6 +182,9 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
       stage: "plan",
       stageConfig: planStageConfig,
       config,
+      workdir,
+      featureName: options.feature,
+      timeoutSeconds,
     });
     logger?.info("plan", "Starting debate planning session", {
       debaters: planStageConfig.debaters?.map((d) => d.agent),
@@ -781,6 +784,10 @@ export async function planDecomposeCommand(
       storyId: options.storyId,
       stage: "decompose",
       stageConfig,
+      config,
+      workdir,
+      featureName: options.feature,
+      timeoutSeconds: config?.execution?.sessionTimeoutSeconds,
     });
     const debateResult = await debateSession.run(prompt);
     if (debateResult.outcome !== "failed" && debateResult.output) {

--- a/src/debate/session.ts
+++ b/src/debate/session.ts
@@ -6,14 +6,12 @@
  */
 
 import { join } from "node:path";
-import type { AcpClient, AcpSession, AcpSessionResponse } from "../agents/acp/adapter";
-import { createSpawnAcpClient } from "../agents/acp/spawn-client";
-import { estimateCostByDuration } from "../agents/cost/calculate";
 import { createAgentRegistry, getAgent } from "../agents/registry";
 import type { AgentAdapter, CompleteOptions, CompleteResult } from "../agents/types";
 import type { ModelTier } from "../config";
 import type { NaxConfig } from "../config";
-import { resolveModelForAgent } from "../config";
+import { DEFAULT_CONFIG, resolveModel, resolveModelForAgent } from "../config";
+import { resolvePermissions } from "../config/permissions";
 import { getSafeLogger } from "../logger";
 import { buildCritiquePrompt } from "./prompts";
 import { judgeResolver, majorityResolver, synthesisResolver } from "./resolvers";
@@ -46,6 +44,9 @@ export interface DebateSessionOptions {
   stage: string;
   stageConfig: DebateStageConfig;
   config?: NaxConfig;
+  workdir?: string;
+  featureName?: string;
+  timeoutSeconds?: number;
 }
 
 /** Injectable deps for testability */
@@ -59,7 +60,6 @@ export const _debateSessionDeps = {
   getAgent: (name: string, config?: NaxConfig): AgentAdapter | undefined =>
     config ? createAgentRegistry(config).getAgent(name) : getAgent(name),
   getSafeLogger: getSafeLogger as () => ReturnType<typeof getSafeLogger>,
-  createSpawnAcpClient: (cmdStr: string, cwd?: string): AcpClient => createSpawnAcpClient(cmdStr, cwd),
   readFile: (path: string): Promise<string> => Bun.file(path).text(),
 };
 
@@ -74,6 +74,7 @@ interface SuccessfulProposal {
   output: string;
   /** Cost for this complete() call in USD. */
   cost: number;
+  roleKey?: string;
 }
 
 interface ResolveOutcome {
@@ -99,17 +100,15 @@ function buildFailedResult(
   };
 }
 
-function extractSessionOutput(response: AcpSessionResponse): string {
-  const messages = response.messages ?? [];
-  const last = [...messages].reverse().find((m) => m.role === "assistant");
-  return last?.content ?? "";
-}
-
 function modelTierFromDebater(debater: Debater): ModelTier {
   if (debater.model === "fast" || debater.model === "balanced" || debater.model === "powerful") {
     return debater.model;
   }
   return "fast";
+}
+
+function isTierLabel(value: string): value is ModelTier {
+  return value === "fast" || value === "balanced" || value === "powerful";
 }
 
 async function runComplete(
@@ -124,26 +123,125 @@ async function runComplete(
   });
 }
 
-function sessionResponseCostUsd(response: AcpSessionResponse, modelTier: ModelTier, durationMs: number): number {
-  if (response.exactCostUsd !== undefined) {
-    return response.exactCostUsd;
-  }
-
-  const estimate = estimateCostByDuration(modelTier, durationMs);
-  return estimate.cost;
-}
-
 export class DebateSession {
   private readonly storyId: string;
   private readonly stage: string;
   private readonly stageConfig: DebateStageConfig;
   private readonly config: NaxConfig | undefined;
+  private readonly workdir: string;
+  private readonly featureName: string;
+  private readonly timeoutSeconds: number;
 
   constructor(opts: DebateSessionOptions) {
     this.storyId = opts.storyId;
     this.stage = opts.stage;
     this.stageConfig = opts.stageConfig;
     this.config = opts.config;
+    this.workdir = opts.workdir ?? process.cwd();
+    this.featureName = opts.featureName ?? opts.stage;
+    this.timeoutSeconds = opts.timeoutSeconds ?? opts.config?.execution?.sessionTimeoutSeconds ?? 600;
+  }
+
+  private pipelineStageForDebate(): import("../config/permissions").PipelineStage {
+    switch (this.stage) {
+      case "plan":
+      case "review":
+      case "rectification":
+      case "acceptance":
+        return this.stage;
+      default:
+        return "run";
+    }
+  }
+
+  private resolveModelDefForDebater(debater: Debater, tier: ModelTier) {
+    if (debater.model && !isTierLabel(debater.model)) {
+      return resolveModel(debater.model);
+    }
+
+    const configModels = this.config?.models ?? DEFAULT_CONFIG.models;
+    const configDefaultAgent = this.config?.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent;
+
+    try {
+      return resolveModelForAgent(configModels, debater.agent, tier, configDefaultAgent);
+    } catch {
+      // Fall through to secondary fallback strategies.
+    }
+
+    try {
+      return resolveModelForAgent(
+        DEFAULT_CONFIG.models,
+        DEFAULT_CONFIG.autoMode.defaultAgent,
+        tier,
+        DEFAULT_CONFIG.autoMode.defaultAgent,
+      );
+    } catch {
+      return resolveModelForAgent(configModels, debater.agent, "fast", configDefaultAgent);
+    }
+  }
+
+  private async runStatefulTurn(
+    adapter: AgentAdapter,
+    debater: Debater,
+    prompt: string,
+    roleKey: string,
+    keepSessionOpen: boolean,
+  ): Promise<SuccessfulProposal> {
+    const modelTier = modelTierFromDebater(debater);
+    const modelDef = this.resolveModelDefForDebater(debater, modelTier);
+    const pipelineStage = this.pipelineStageForDebate();
+
+    const runResult = await adapter.run({
+      prompt,
+      workdir: this.workdir,
+      modelTier,
+      modelDef,
+      timeoutSeconds: this.timeoutSeconds,
+      dangerouslySkipPermissions: resolvePermissions(this.config, pipelineStage).skipPermissions,
+      pipelineStage,
+      config: this.config,
+      featureName: this.featureName,
+      storyId: this.storyId,
+      sessionRole: roleKey,
+      maxInteractionTurns: this.config?.agent?.maxInteractionTurns,
+      keepSessionOpen,
+    });
+
+    if (!runResult.success) {
+      throw new Error(runResult.output || `Stateful debate turn failed for ${debater.agent}`);
+    }
+
+    return {
+      debater,
+      adapter,
+      output: runResult.output,
+      cost: runResult.estimatedCost,
+      roleKey,
+    };
+  }
+
+  private async closeStatefulSession(adapter: AgentAdapter, debater: Debater, roleKey: string): Promise<number> {
+    const modelTier = modelTierFromDebater(debater);
+    const modelDef = this.resolveModelDefForDebater(debater, modelTier);
+    const pipelineStage = this.pipelineStageForDebate();
+
+    const runResult = await adapter.run({
+      prompt: "Close this debate session.",
+      workdir: this.workdir,
+      modelTier,
+      modelDef,
+      timeoutSeconds: this.timeoutSeconds,
+      dangerouslySkipPermissions: resolvePermissions(this.config, pipelineStage).skipPermissions,
+      pipelineStage,
+      config: this.config,
+      featureName: this.featureName,
+      storyId: this.storyId,
+      sessionRole: roleKey,
+      maxInteractionTurns: this.config?.agent?.maxInteractionTurns,
+      keepSessionOpen: false,
+    });
+
+    return runResult.success ? runResult.estimatedCost : 0;
   }
 
   async run(prompt: string): Promise<DebateResult> {
@@ -179,49 +277,68 @@ export class DebateSession {
       debaters: resolved.map((r) => r.debater.agent),
     });
 
-    interface SessionEntry {
-      debater: Debater;
-      adapter: AgentAdapter;
-      session: AcpSession;
+    // Proposal round — parallel via Promise.allSettled
+    const proposalSettled = await Promise.allSettled(
+      resolved.map(({ debater, adapter }, debaterIdx) =>
+        this.runStatefulTurn(adapter, debater, prompt, `debate-${this.stage}-${debaterIdx}`, config.rounds > 1),
+      ),
+    );
+
+    const successfulProposals: SuccessfulProposal[] = proposalSettled
+      .filter((r): r is PromiseFulfilledResult<SuccessfulProposal> => r.status === "fulfilled")
+      .map((r) => r.value);
+
+    for (const r of proposalSettled) {
+      if (r.status === "fulfilled") {
+        totalCostUsd += r.value.cost;
+      }
     }
 
-    const sessions: SessionEntry[] = [];
-
-    try {
-      // Create SpawnAcpClient and session per debater
-      for (let i = 0; i < resolved.length; i++) {
-        const { debater, adapter } = resolved[i];
-        const resolvedModel = resolveDebaterModel(debater, this.config);
-        const cmdStr = resolvedModel ? `acpx --model ${resolvedModel} ${debater.agent}` : `acpx ${debater.agent}`;
-        const client = _debateSessionDeps.createSpawnAcpClient(cmdStr);
-        const sessionName = `nax-debate-${this.storyId}-${i}`;
-
-        try {
-          const session = await client.createSession({
-            agentName: debater.agent,
-            permissionMode: "approve-reads",
-            sessionName,
-          });
-          sessions.push({ debater, adapter, session });
-        } catch {
-          logger?.warn("debate", `Failed to create session for '${debater.agent}' — skipping`);
+    // Fewer than 2 succeeded — single-agent fallback for resiliency.
+    if (successfulProposals.length < 2) {
+      if (successfulProposals.length === 1) {
+        const solo = successfulProposals[0];
+        if (config.rounds > 1 && solo.roleKey) {
+          totalCostUsd += await this.closeStatefulSession(solo.adapter, solo.debater, solo.roleKey);
         }
+        logger?.warn("debate", "debate:fallback", {
+          storyId: this.storyId,
+          stage: this.stage,
+          reason: "only 1 debater succeeded",
+        });
+        logger?.info("debate", "debate:result", {
+          storyId: this.storyId,
+          stage: this.stage,
+          outcome: "passed",
+        });
+        return {
+          storyId: this.storyId,
+          stage: this.stage,
+          outcome: "passed",
+          rounds: 1,
+          debaters: [solo.debater.agent],
+          resolverType: config.resolver.type,
+          proposals: [{ debater: solo.debater, output: solo.output }],
+          totalCostUsd,
+        };
       }
 
-      // Fewer than 2 sessions created
-      if (sessions.length < 2) {
-        // Single-agent fallback — run the one successful session as solo
-        if (sessions.length === 1) {
-          logger?.warn("debate", "debate:fallback", {
-            storyId: this.storyId,
-            stage: this.stage,
-            reason: "only 1 session created",
-          });
-          const solo = sessions[0];
-          const soloStart = Date.now();
-          const response = await solo.session.prompt(prompt);
-          totalCostUsd += sessionResponseCostUsd(response, modelTierFromDebater(solo.debater), Date.now() - soloStart);
-          const output = extractSessionOutput(response);
+      if (resolved.length > 0) {
+        const { adapter: fallbackAdapter, debater: fallbackDebater } = resolved[0];
+        logger?.warn("debate", "debate:fallback", {
+          storyId: this.storyId,
+          stage: this.stage,
+          reason: "all debaters failed — retrying with first adapter",
+        });
+        try {
+          const fallbackResult = await this.runStatefulTurn(
+            fallbackAdapter,
+            fallbackDebater,
+            prompt,
+            `debate-${this.stage}-fallback`,
+            false,
+          );
+          totalCostUsd += fallbackResult.cost;
           logger?.info("debate", "debate:result", {
             storyId: this.storyId,
             stage: this.stage,
@@ -232,129 +349,90 @@ export class DebateSession {
             stage: this.stage,
             outcome: "passed",
             rounds: 1,
-            debaters: [solo.debater.agent],
+            debaters: [fallbackDebater.agent],
             resolverType: config.resolver.type,
-            proposals: [{ debater: solo.debater, output }],
+            proposals: [{ debater: fallbackDebater, output: fallbackResult.output }],
             totalCostUsd,
           };
+        } catch {
+          // Retry also failed — fall through to failed result.
         }
-        logger?.warn("debate", "debate:fallback", {
-          storyId: this.storyId,
-          stage: this.stage,
-          reason: "no sessions created",
-        });
-        return buildFailedResult(this.storyId, this.stage, config, totalCostUsd);
       }
 
-      // Proposal round — parallel via Promise.allSettled
-      const proposalSettled = await Promise.allSettled(
-        sessions.map(async (entry) => {
-          const startTime = Date.now();
-          const response = await entry.session.prompt(prompt);
-          return {
-            entry,
-            response,
-            output: extractSessionOutput(response),
-            cost: sessionResponseCostUsd(response, modelTierFromDebater(entry.debater), Date.now() - startTime),
-          };
-        }),
+      logger?.warn("debate", "debate:fallback", {
+        storyId: this.storyId,
+        stage: this.stage,
+        reason: "fewer than 2 proposal rounds succeeded",
+      });
+      return buildFailedResult(this.storyId, this.stage, config, totalCostUsd);
+    }
+
+    for (let i = 0; i < successfulProposals.length; i++) {
+      const s = successfulProposals[i];
+      logger?.info("debate", "debate:proposal", {
+        storyId: this.storyId,
+        stage: this.stage,
+        debaterIndex: i,
+        agent: s.debater.agent,
+      });
+    }
+
+    // Critique round (when rounds > 1)
+    // In stateful mode, send only OTHER debaters' proposals — session retains own history.
+    // proposalOutputs is indexed by position within successfulProposals (dense, 0..N-1),
+    // so we use successfulIdx when calling buildCritiquePrompt to correctly exclude
+    // each debater's own proposal from the critique context.
+    let critiqueOutputs: string[] = [];
+    if (config.rounds > 1) {
+      const proposalOutputs = successfulProposals.map((s) => s.output);
+      const critiqueSettled = await Promise.allSettled(
+        successfulProposals.map((proposal, successfulIdx) =>
+          this.runStatefulTurn(
+            proposal.adapter,
+            proposal.debater,
+            buildCritiquePrompt(prompt, proposalOutputs, successfulIdx),
+            proposal.roleKey ?? `debate-${this.stage}-${successfulIdx}`,
+            false,
+          ),
+        ),
       );
 
-      const successfulSessions: Array<{ entry: SessionEntry; output: string; cost: number; originalIndex: number }> =
-        [];
-      for (let i = 0; i < proposalSettled.length; i++) {
-        const r = proposalSettled[i];
+      for (const r of critiqueSettled) {
         if (r.status === "fulfilled") {
-          successfulSessions.push({
-            entry: r.value.entry,
-            output: r.value.output,
-            cost: r.value.cost,
-            originalIndex: i,
-          });
           totalCostUsd += r.value.cost;
         }
       }
 
-      // AC5: minimum 2 debaters required for a valid debate
-      if (successfulSessions.length < 2) {
-        logger?.warn("debate", "debate:fallback", {
-          storyId: this.storyId,
-          stage: this.stage,
-          reason: "fewer than 2 proposal rounds succeeded",
-        });
-        return buildFailedResult(this.storyId, this.stage, config, totalCostUsd);
-      }
-
-      for (let i = 0; i < successfulSessions.length; i++) {
-        const s = successfulSessions[i];
-        logger?.info("debate", "debate:proposal", {
-          storyId: this.storyId,
-          stage: this.stage,
-          debaterIndex: i,
-          agent: s.entry.debater.agent,
-        });
-      }
-
-      // Critique round (when rounds > 1)
-      // In stateful mode, send only OTHER debaters' proposals — session retains own history.
-      // proposalOutputs is indexed by position within successfulSessions (dense, 0..N-1),
-      // so we use successfulIdx (not originalIndex) when calling buildCritiquePrompt to
-      // correctly exclude each debater's own proposal from the critique context.
-      let critiqueOutputs: string[] = [];
-      if (config.rounds > 1) {
-        const proposalOutputs = successfulSessions.map((s) => s.output);
-        const critiqueSettled = await Promise.allSettled(
-          successfulSessions.map(async ({ entry }, successfulIdx) => {
-            const startTime = Date.now();
-            const response = await entry.session.prompt(buildCritiquePrompt(prompt, proposalOutputs, successfulIdx));
-            return {
-              output: extractSessionOutput(response),
-              cost: sessionResponseCostUsd(response, modelTierFromDebater(entry.debater), Date.now() - startTime),
-            };
-          }),
-        );
-        critiqueOutputs = critiqueSettled
-          .filter((r): r is PromiseFulfilledResult<{ output: string; cost: number }> => r.status === "fulfilled")
-          .map((r) => {
-            totalCostUsd += r.value.cost;
-            return r.value.output;
-          });
-      }
-
-      // Resolve outcome
-      const proposalOutputs = successfulSessions.map((s) => s.output);
-      const successfulProposals: SuccessfulProposal[] = successfulSessions.map((s) => ({
-        debater: s.entry.debater,
-        adapter: s.entry.adapter,
-        output: s.output,
-        cost: s.cost,
-      }));
-      const outcome = await this.resolve(proposalOutputs, critiqueOutputs, successfulProposals);
-      totalCostUsd += outcome.resolverCostUsd;
-
-      const proposals: Proposal[] = successfulSessions.map((s) => ({
-        debater: s.entry.debater,
-        output: s.output,
-      }));
-
-      logger?.info("debate", "debate:result", {
-        storyId: this.storyId,
-        stage: this.stage,
-        outcome: outcome.outcome,
-      });
-      return {
-        storyId: this.storyId,
-        stage: this.stage,
-        outcome: outcome.outcome,
-        rounds: config.rounds,
-        debaters: successfulSessions.map((s) => s.entry.debater.agent),
-        resolverType: config.resolver.type,
-        proposals,
-        totalCostUsd,
-      };
-    } finally {
-      await Promise.allSettled(sessions.map(({ session }) => session.close()));
+      critiqueOutputs = critiqueSettled
+        .filter((r): r is PromiseFulfilledResult<SuccessfulProposal> => r.status === "fulfilled")
+        .map((r) => r.value.output);
     }
+
+    // Resolve outcome
+    const proposalOutputs = successfulProposals.map((s) => s.output);
+    const outcome = await this.resolve(proposalOutputs, critiqueOutputs, successfulProposals);
+    totalCostUsd += outcome.resolverCostUsd;
+
+    const proposals: Proposal[] = successfulProposals.map((s) => ({
+      debater: s.debater,
+      output: s.output,
+    }));
+
+    logger?.info("debate", "debate:result", {
+      storyId: this.storyId,
+      stage: this.stage,
+      outcome: outcome.outcome,
+    });
+    return {
+      storyId: this.storyId,
+      stage: this.stage,
+      outcome: outcome.outcome,
+      rounds: config.rounds,
+      debaters: successfulProposals.map((s) => s.debater.agent),
+      resolverType: config.resolver.type,
+      proposals,
+      totalCostUsd,
+    };
   }
 
   private async runOneShot(prompt: string): Promise<DebateResult> {

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -323,6 +323,9 @@ export async function runSemanticReview(
       stage: "review",
       stageConfig: reviewStageConfig,
       config: naxConfig,
+      workdir,
+      featureName: story.id,
+      timeoutSeconds: naxConfig?.execution?.sessionTimeoutSeconds,
     });
     const debateResult = await debateSession.run(prompt);
 

--- a/test/unit/debate/session-stateful.test.ts
+++ b/test/unit/debate/session-stateful.test.ts
@@ -1,37 +1,12 @@
-/**
- * Tests for DebateSession — US-003: Stateful session mode
- *
- * Covers:
- * - AC1: When sessionMode='stateful', creates SpawnAcpClient per debater and calls
- *        client.createSession() with session name containing storyId and debater index
- * - AC2: When sessionMode='stateful', critique round sends only OTHER debaters' proposals
- *        (session retains its own history — no self-proposal pasted)
- * - AC3: When sessionMode='stateful', all sessions closed via session.close() in finally
- *        — even if debate fails mid-round
- * - AC4: When sessionMode='one-shot', uses adapter.complete() — no persistent sessions created
- * - AC5: When a stateful session fails to create, skip that debater; continue if >= 2 remain
- * - AC6: Two stages with different sessionMode values each use their own mode independently
- */
-
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { DebateSession, _debateSessionDeps } from "../../../src/debate/session";
+import type { AgentAdapter, AgentRunOptions, CompleteOptions, CompleteResult } from "../../../src/agents/types";
 import type { DebateStageConfig } from "../../../src/debate/types";
-import type { AgentAdapter, CompleteOptions, CompleteResult } from "../../../src/agents/types";
-import type { AcpClient, AcpSession, AcpSessionResponse } from "../../../src/agents/acp/adapter";
-
-// ─── Extended deps type (US-003 adds createSpawnAcpClient) ───────────────────
-
-type ExtendedDeps = typeof _debateSessionDeps & {
-  createSpawnAcpClient?: (cmdStr: string, cwd?: string) => AcpClient;
-};
-
-const extDeps = _debateSessionDeps as ExtendedDeps;
-
-// ─── Mock Helpers ─────────────────────────────────────────────────────────────
 
 function makeMockAdapter(
   name: string,
   options: {
+    runFn?: (opts: AgentRunOptions) => Promise<ReturnType<AgentAdapter["run"]> extends Promise<infer R> ? R : never>;
     completeFn?: (prompt: string, opts?: CompleteOptions) => Promise<CompleteResult>;
   } = {},
 ): AgentAdapter {
@@ -40,53 +15,26 @@ function makeMockAdapter(
     displayName: name,
     binary: name,
     capabilities: {
-      supportedTiers: ["fast"] as const,
+      supportedTiers: ["fast", "balanced", "powerful"],
       maxContextTokens: 100_000,
       features: new Set<"tdd" | "review" | "refactor" | "batch">(["review"]),
     },
     isInstalled: async () => true,
-    run: async () => ({
-      success: true,
-      exitCode: 0,
-      output: "",
-      rateLimited: false,
-      durationMs: 0,
-      estimatedCost: 0,
-    }),
+    run:
+      options.runFn ??
+      (async () => ({
+        success: true,
+        exitCode: 0,
+        output: `output from ${name}`,
+        rateLimited: false,
+        durationMs: 1,
+        estimatedCost: 0.01,
+      })),
     buildCommand: () => [],
+    buildAllowedEnv: () => ({}),
     plan: async () => ({ specContent: "" }),
     decompose: async () => ({ stories: [] }),
-    complete: options.completeFn ?? (async () => ({ output: `output from ${name}`, costUsd: 0, source: "fallback" })),
-  };
-}
-
-function makeMockSession(opts: {
-  promptFn?: (text: string) => Promise<AcpSessionResponse>;
-  closeFn?: () => Promise<void>;
-} = {}): AcpSession {
-  return {
-    prompt:
-      opts.promptFn ??
-      (async (_text: string): Promise<AcpSessionResponse> => ({
-        messages: [{ role: "assistant", content: "session response" }],
-        stopReason: "end_turn",
-      })),
-    close: opts.closeFn ?? (async () => {}),
-    cancelActivePrompt: async () => {},
-  };
-}
-
-function makeMockClient(opts: {
-  createSessionFn?: (o: { agentName: string; permissionMode: string; sessionName?: string }) => Promise<AcpSession>;
-  closeFn?: () => Promise<void>;
-} = {}): AcpClient {
-  return {
-    start: async () => {},
-    createSession:
-      opts.createSessionFn ??
-      (async (_opts) => makeMockSession()),
-    loadSession: async () => null,
-    close: opts.closeFn ?? (async () => {}),
+    complete: options.completeFn ?? (async () => ({ output: "", costUsd: 0, source: "fallback" })),
   };
 }
 
@@ -97,205 +45,40 @@ function makeStageConfig(overrides: Partial<DebateStageConfig> = {}): DebateStag
     sessionMode: "stateful",
     rounds: 1,
     debaters: [
-      { agent: "claude", model: "claude-3-5-haiku-20241022" },
-      { agent: "opencode", model: "gpt-4o-mini" },
+      { agent: "claude", model: "fast" },
+      { agent: "opencode", model: "balanced" },
     ],
     ...overrides,
   };
 }
 
-// ─── Setup / Teardown ─────────────────────────────────────────────────────────
-
 let origGetAgent: typeof _debateSessionDeps.getAgent;
-let origGetSafeLogger: typeof _debateSessionDeps.getSafeLogger;
-let origCreateSpawnAcpClient: ExtendedDeps["createSpawnAcpClient"];
 
 beforeEach(() => {
   origGetAgent = _debateSessionDeps.getAgent;
-  origGetSafeLogger = _debateSessionDeps.getSafeLogger;
-  origCreateSpawnAcpClient = extDeps.createSpawnAcpClient;
 });
 
 afterEach(() => {
   _debateSessionDeps.getAgent = origGetAgent;
-  _debateSessionDeps.getSafeLogger = origGetSafeLogger;
-  extDeps.createSpawnAcpClient = origCreateSpawnAcpClient;
+  mock.restore();
 });
 
-// ─── AC1: SpawnAcpClient creation and session naming ──────────────────────────
-
-describe("DebateSession.run() — stateful mode: SpawnAcpClient creation (AC1)", () => {
-  test("creates a SpawnAcpClient for each debater when sessionMode is 'stateful'", async () => {
-    const createClientCalls: string[] = [];
-
-    extDeps.createSpawnAcpClient = mock((cmdStr: string) => {
-      createClientCalls.push(cmdStr);
-      return makeMockClient();
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await session.run("test prompt");
-
-    expect(createClientCalls.length).toBe(2);
-  });
-
-  test("cmdStr passed to createSpawnAcpClient includes debater model and agent", async () => {
-    const createClientCalls: string[] = [];
-
-    extDeps.createSpawnAcpClient = mock((cmdStr: string) => {
-      createClientCalls.push(cmdStr);
-      return makeMockClient();
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await session.run("test prompt");
-
-    expect(createClientCalls.some((c) => c.includes("claude-3-5-haiku-20241022") && c.includes("claude"))).toBe(true);
-    expect(createClientCalls.some((c) => c.includes("gpt-4o-mini") && c.includes("opencode"))).toBe(true);
-  });
-
-  test("createSession is called with session name containing storyId", async () => {
-    const createSessionCalls: Array<{ agentName: string; sessionName?: string }> = [];
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) =>
-      makeMockClient({
-        createSessionFn: async (opts) => {
-          createSessionCalls.push({ agentName: opts.agentName, sessionName: opts.sessionName });
-          return makeMockSession();
-        },
-      }),
-    );
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await session.run("test prompt");
-
-    expect(createSessionCalls.length).toBe(2);
-    expect(createSessionCalls.every((c) => c.sessionName?.includes("US-003"))).toBe(true);
-  });
-
-  test("session name contains debater index (0 for first, 1 for second)", async () => {
-    const sessionNames: string[] = [];
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) =>
-      makeMockClient({
-        createSessionFn: async (opts) => {
-          if (opts.sessionName) sessionNames.push(opts.sessionName);
-          return makeMockSession();
-        },
-      }),
-    );
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await session.run("test prompt");
-
-    // Session names should contain the debater index (0 and 1)
-    expect(sessionNames.some((n) => n.includes("-0"))).toBe(true);
-    expect(sessionNames.some((n) => n.includes("-1"))).toBe(true);
-  });
-
-  test("session name matches pattern 'nax-debate-<storyId>-<debaterIndex>'", async () => {
-    const sessionNames: string[] = [];
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) =>
-      makeMockClient({
-        createSessionFn: async (opts) => {
-          if (opts.sessionName) sessionNames.push(opts.sessionName);
-          return makeMockSession();
-        },
-      }),
-    );
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await session.run("test prompt");
-
-    expect(sessionNames).toContain("nax-debate-US-003-0");
-    expect(sessionNames).toContain("nax-debate-US-003-1");
-  });
-
-  test("uses session.prompt() instead of adapter.complete() in stateful mode", async () => {
-    const promptCalls: string[] = [];
-    const completeCalls: string[] = [];
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) =>
-      makeMockClient({
-        createSessionFn: async (_opts) =>
-          makeMockSession({
-            promptFn: async (text) => {
-              promptCalls.push(text);
-              return {
-                messages: [{ role: "assistant", content: '{"passed": true}' }],
-                stopReason: "end_turn",
-              };
-            },
-          }),
-      }),
-    );
+describe("DebateSession.run() — stateful mode uses adapter.run SSOT", () => {
+  test("proposal round calls adapter.run for each debater with stable sessionRole", async () => {
+    const runCalls: AgentRunOptions[] = [];
 
     _debateSessionDeps.getAgent = mock((name: string) =>
       makeMockAdapter(name, {
-        completeFn: async (p) => {
-          completeCalls.push(p);
-          return { output: `complete from ${name}`, costUsd: 0, source: "fallback" };
+        runFn: async (opts) => {
+          runCalls.push(opts);
+          return {
+            success: true,
+            exitCode: 0,
+            output: `proposal-${name}`,
+            rateLimited: false,
+            durationMs: 1,
+            estimatedCost: 0.1,
+          };
         },
       }),
     );
@@ -303,593 +86,192 @@ describe("DebateSession.run() — stateful mode: SpawnAcpClient creation (AC1)",
     const session = new DebateSession({
       storyId: "US-003",
       stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await session.run("the stateful prompt");
-
-    expect(promptCalls.length).toBeGreaterThan(0);
-    // adapter.complete() should NOT be called for proposal round in stateful mode
-    expect(completeCalls.length).toBe(0);
-  });
-});
-
-// ─── AC2: Critique round — only other debaters' proposals ─────────────────────
-
-describe("DebateSession.run() — stateful mode: critique round isolation (AC2)", () => {
-  test("critique prompt contains only other debaters' proposals, not own", async () => {
-    const promptsBySession: Record<number, string[]> = {};
-    let sessionIndex = 0;
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
-      const idx = sessionIndex++;
-      return makeMockClient({
-        createSessionFn: async (_opts) => {
-          promptsBySession[idx] = [];
-          return makeMockSession({
-            promptFn: async (text) => {
-              promptsBySession[idx].push(text);
-              return {
-                messages: [{ role: "assistant", content: `proposal from debater ${idx}` }],
-                stopReason: "end_turn",
-              };
-            },
-          });
-        },
-      });
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        rounds: 2,
-        resolver: { type: "synthesis" },
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
+      stageConfig: makeStageConfig({ rounds: 1 }),
+      workdir: "/tmp/work",
+      featureName: "feat-a",
+      timeoutSeconds: 120,
     });
 
     await session.run("test prompt");
 
-    // Each session should be called twice (proposal + critique)
-    expect(Object.keys(promptsBySession).length).toBe(2);
-
-    // Session 0's critique prompt should contain session 1's proposal but NOT session 0's proposal
-    const session0CritiquePrompt = promptsBySession[0]?.[1];
-    expect(session0CritiquePrompt).toBeDefined();
-    expect(session0CritiquePrompt).toContain("proposal from debater 1");
-    expect(session0CritiquePrompt).not.toContain("proposal from debater 0");
+    expect(runCalls.length).toBe(2);
+    expect(runCalls[0].sessionRole).toBe("debate-plan-0");
+    expect(runCalls[1].sessionRole).toBe("debate-plan-1");
+    expect(runCalls[0].storyId).toBe("US-003");
+    expect(runCalls[0].featureName).toBe("feat-a");
+    expect(runCalls[0].workdir).toBe("/tmp/work");
+    expect(runCalls[0].keepSessionOpen).toBe(false);
+    expect(runCalls[0].modelDef.model).not.toBe("fast");
+    expect(runCalls[1].modelDef.model).not.toBe("balanced");
   });
 
-  test("in stateful mode, critique prompt is shorter than full all-proposals paste", async () => {
-    // In one-shot mode, the critique contains ALL proposals (including own)
-    // In stateful mode, it contains only OTHERS' proposals
-    const statefulCritiqueLengths: number[] = [];
-    let sessionIndex = 0;
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
-      const idx = sessionIndex++;
-      return makeMockClient({
-        createSessionFn: async (_opts) =>
-          makeMockSession({
-            promptFn: async (text) => {
-              // The 2nd prompt is the critique prompt
-              if (idx === 0) statefulCritiqueLengths.push(text.length);
-              return {
-                messages: [
-                  { role: "assistant", content: `long proposal output from debater ${idx} with extra content` },
-                ],
-                stopReason: "end_turn",
-              };
-            },
-          }),
-      });
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        rounds: 2,
-        resolver: { type: "synthesis" },
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-          { agent: "gemini", model: "gemini-flash" },
-        ],
-      }),
-    });
-
-    await session.run("test prompt");
-
-    // With 3 debaters, stateful critique for debater 0 should include 2 other proposals,
-    // not 3 (own would be excluded)
-    expect(statefulCritiqueLengths.length).toBeGreaterThan(0);
-  });
-});
-
-// ─── AC3: Sessions closed in finally block ────────────────────────────────────
-
-describe("DebateSession.run() — stateful mode: session cleanup (AC3)", () => {
-  test("calls session.close() for all sessions in finally block after successful run", async () => {
-    const closeCalls: number[] = [];
-    let sessionIndex = 0;
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
-      const idx = sessionIndex++;
-      return makeMockClient({
-        createSessionFn: async (_opts) =>
-          makeMockSession({
-            closeFn: async () => {
-              closeCalls.push(idx);
-            },
-          }),
-      });
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await session.run("test prompt");
-
-    expect(closeCalls.length).toBe(2);
-    expect(closeCalls).toContain(0);
-    expect(closeCalls).toContain(1);
-  });
-
-  test("calls session.close() even when a prompt round throws mid-debate", async () => {
-    const closeCalls: number[] = [];
-    let sessionIndex = 0;
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
-      const idx = sessionIndex++;
-      return makeMockClient({
-        createSessionFn: async (_opts) =>
-          makeMockSession({
-            promptFn: async (_text) => {
-              if (idx === 1) throw new Error("simulated mid-debate failure");
-              return {
-                messages: [{ role: "assistant", content: "response" }],
-                stopReason: "end_turn",
-              };
-            },
-            closeFn: async () => {
-              closeCalls.push(idx);
-            },
-          }),
-      });
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    // Should not throw — debate handles failures gracefully
-    await session.run("test prompt");
-
-    // Session 0 (the successful one) must have been closed
-    expect(closeCalls).toContain(0);
-  });
-
-  test("all successfully created sessions are closed even when debate throws", async () => {
-    const closeCalls: number[] = [];
-    let sessionIndex = 0;
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
-      const idx = sessionIndex++;
-      return makeMockClient({
-        createSessionFn: async (_opts) =>
-          makeMockSession({
-            promptFn: async (_text) => {
-              // All debaters fail during proposal
-              throw new Error(`debater ${idx} prompt failed`);
-            },
-            closeFn: async () => {
-              closeCalls.push(idx);
-            },
-          }),
-      });
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await session.run("test prompt");
-
-    // Both sessions were created, both must be closed
-    expect(closeCalls.length).toBe(2);
-  });
-});
-
-// ─── AC4: One-shot mode unchanged ─────────────────────────────────────────────
-
-describe("DebateSession.run() — one-shot mode: no persistent sessions (AC4)", () => {
-  test("does not call createSpawnAcpClient when sessionMode is 'one-shot'", async () => {
-    let createClientCallCount = 0;
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
-      createClientCallCount++;
-      return makeMockClient();
-    });
+  test("uses explicit non-tier debater model override for modelDef", async () => {
+    const runCalls: AgentRunOptions[] = [];
 
     _debateSessionDeps.getAgent = mock((name: string) =>
       makeMockAdapter(name, {
-        completeFn: async () => ({ output: `{"passed": true}`, costUsd: 0, source: "fallback" }),
+        runFn: async (opts) => {
+          runCalls.push(opts);
+          return {
+            success: true,
+            exitCode: 0,
+            output: `proposal-${name}`,
+            rateLimited: false,
+            durationMs: 1,
+            estimatedCost: 0.1,
+          };
+        },
       }),
     );
 
     const session = new DebateSession({
-      storyId: "US-003",
+      storyId: "US-003b",
+      stage: "plan",
+      stageConfig: makeStageConfig({
+        rounds: 1,
+        debaters: [
+          { agent: "claude", model: "claude-sonnet-4-5-20250514" },
+          { agent: "opencode", model: "balanced" },
+        ],
+      }),
+      workdir: "/tmp/work",
+      featureName: "feat-a",
+    });
+
+    await session.run("test prompt");
+
+    expect(runCalls[0].modelDef.model).toBe("claude-sonnet-4-5-20250514");
+  });
+
+  test("rounds > 1 keeps proposal session open and reuses same role in critique", async () => {
+    const runCalls: AgentRunOptions[] = [];
+
+    _debateSessionDeps.getAgent = mock((name: string) =>
+      makeMockAdapter(name, {
+        runFn: async (opts) => {
+          runCalls.push(opts);
+          return {
+            success: true,
+            exitCode: 0,
+            output: opts.prompt.includes("Critique") ? `critique-${name}` : `proposal-${name}`,
+            rateLimited: false,
+            durationMs: 1,
+            estimatedCost: 0.1,
+          };
+        },
+      }),
+    );
+
+    const session = new DebateSession({
+      storyId: "US-004",
       stage: "review",
-      stageConfig: makeStageConfig({
-        sessionMode: "one-shot",
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
+      stageConfig: makeStageConfig({ rounds: 2 }),
+      workdir: "/tmp/work",
+      featureName: "feat-b",
+      timeoutSeconds: 120,
     });
 
-    await session.run("test prompt");
+    await session.run("review prompt");
 
-    expect(createClientCallCount).toBe(0);
+    expect(runCalls.length).toBe(4);
+    expect(runCalls[0].keepSessionOpen).toBe(true);
+    expect(runCalls[1].keepSessionOpen).toBe(true);
+    expect(runCalls[2].keepSessionOpen).toBe(false);
+    expect(runCalls[3].keepSessionOpen).toBe(false);
+    expect(runCalls[2].sessionRole).toBe("debate-review-0");
+    expect(runCalls[3].sessionRole).toBe("debate-review-1");
   });
 
-  test("calls adapter.complete() when sessionMode is 'one-shot'", async () => {
-    const completeCalls: string[] = [];
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => makeMockClient());
+  test("falls back to single-agent passed when only one proposal run succeeds", async () => {
+    const runCalls: AgentRunOptions[] = [];
 
     _debateSessionDeps.getAgent = mock((name: string) =>
       makeMockAdapter(name, {
+        runFn: async (opts) => {
+          runCalls.push(opts);
+          if (opts.prompt === "Close this debate session.") {
+            return {
+              success: true,
+              exitCode: 0,
+              output: "closed",
+              rateLimited: false,
+              durationMs: 1,
+              estimatedCost: 0.05,
+            };
+          }
+          if (name === "opencode") {
+            return {
+              success: false,
+              exitCode: 1,
+              output: "failed",
+              rateLimited: false,
+              durationMs: 1,
+              estimatedCost: 0,
+            };
+          }
+          return {
+            success: true,
+            exitCode: 0,
+            output: `proposal-${name}`,
+            rateLimited: false,
+            durationMs: 1,
+            estimatedCost: 0.1,
+          };
+        },
+      }),
+    );
+
+    const session = new DebateSession({
+      storyId: "US-005",
+      stage: "review",
+      stageConfig: makeStageConfig({ rounds: 2 }),
+      workdir: "/tmp/work",
+      featureName: "feat-c",
+    });
+
+    const result = await session.run("review prompt");
+    expect(result.outcome).toBe("passed");
+    expect(result.debaters).toEqual(["claude"]);
+    expect(runCalls.some((c) => c.prompt === "Close this debate session." && c.keepSessionOpen === false)).toBe(true);
+  });
+});
+
+describe("DebateSession.run() — one-shot mode unchanged", () => {
+  test("one-shot does not use adapter.run for proposal path", async () => {
+    let runCount = 0;
+    let completeCount = 0;
+
+    _debateSessionDeps.getAgent = mock((name: string) =>
+      makeMockAdapter(name, {
+        runFn: async (_opts) => {
+          runCount += 1;
+          return {
+            success: true,
+            exitCode: 0,
+            output: `run-${name}`,
+            rateLimited: false,
+            durationMs: 1,
+            estimatedCost: 0.1,
+          };
+        },
         completeFn: async () => {
-          completeCalls.push(name);
-          return `{"passed": true}`;
+          completeCount += 1;
+          return { output: '{"passed": true}', costUsd: 0.1, source: "exact" };
         },
       }),
     );
 
     const session = new DebateSession({
-      storyId: "US-003",
-      stage: "review",
-      stageConfig: makeStageConfig({
-        sessionMode: "one-shot",
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await session.run("test prompt");
-
-    expect(completeCalls).toContain("claude");
-    expect(completeCalls).toContain("opencode");
-  });
-});
-
-// ─── AC5: Stateful session creation failure — skip debater ────────────────────
-
-describe("DebateSession.run() — stateful mode: session creation failure (AC5)", () => {
-  test("skips a debater when createSession throws, continues with remaining", async () => {
-    const successfulPromptCalls: number[] = [];
-    let sessionIndex = 0;
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
-      const idx = sessionIndex++;
-      return makeMockClient({
-        createSessionFn: async (_opts) => {
-          if (idx === 1) {
-            // Second debater's session creation fails
-            throw new Error("acpx: failed to create session");
-          }
-          return makeMockSession({
-            promptFn: async (_text) => {
-              successfulPromptCalls.push(idx);
-              return {
-                messages: [{ role: "assistant", content: `output from debater ${idx}` }],
-                stopReason: "end_turn",
-              };
-            },
-          });
-        },
-      });
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
+      storyId: "US-006",
       stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-          { agent: "gemini", model: "gemini-flash" },
-        ],
-      }),
+      stageConfig: makeStageConfig({ sessionMode: "one-shot", rounds: 1 }),
+      workdir: "/tmp/work",
+      featureName: "feat-d",
     });
 
-    const result = await session.run("test prompt");
+    await session.run("plan prompt");
 
-    // Session index 0 (claude) and 2 (gemini) succeed — debate proceeds
-    expect(result).toBeDefined();
-    expect(result.outcome).not.toBe("skipped");
-    // The failed debater should not have been prompted
-    expect(successfulPromptCalls).not.toContain(1);
-  });
-
-  test("falls back to single-agent when only 1 session succeeds creation", async () => {
-    let sessionIndex = 0;
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
-      const idx = sessionIndex++;
-      return makeMockClient({
-        createSessionFn: async (_opts) => {
-          if (idx !== 0) {
-            throw new Error("acpx: session creation error");
-          }
-          return makeMockSession({
-            promptFn: async (_text) => ({
-              messages: [{ role: "assistant", content: "solo output" }],
-              stopReason: "end_turn",
-            }),
-          });
-        },
-      });
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    const result = await session.run("test prompt");
-
-    // With only 1 successful session, falls back to single-agent
-    expect(result).toBeDefined();
-    expect(result.proposals.length).toBeGreaterThanOrEqual(1);
-  });
-
-  test("requires minimum 2 debaters — skips failed ones and still debates with remaining 2", async () => {
-    let sessionIndex = 0;
-    const promptCalls: number[] = [];
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
-      const idx = sessionIndex++;
-      return makeMockClient({
-        createSessionFn: async (_opts) => {
-          // Only first debater's session fails
-          if (idx === 0) {
-            throw new Error("acpx: first session failed");
-          }
-          return makeMockSession({
-            promptFn: async (_text) => {
-              promptCalls.push(idx);
-              return {
-                messages: [{ role: "assistant", content: `output ${idx}` }],
-                stopReason: "end_turn",
-              };
-            },
-          });
-        },
-      });
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-          { agent: "gemini", model: "gemini-flash" },
-        ],
-      }),
-    });
-
-    const result = await session.run("test prompt");
-
-    // 2 debaters still succeed — debate proceeds normally (not single-agent fallback)
-    expect(result.proposals.length).toBe(2);
-    expect(promptCalls).toContain(1);
-    expect(promptCalls).toContain(2);
-  });
-});
-
-// ─── AC6: Independent sessionMode per stage ────────────────────────────────────
-
-describe("DebateSession.run() — independent sessionMode per stage (AC6)", () => {
-  test("stateful stage creates sessions; one-shot stage in same run does not", async () => {
-    let statefulClientCallCount = 0;
-    let oneShotCompleteCallCount = 0;
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
-      statefulClientCallCount++;
-      return makeMockClient();
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) =>
-      makeMockAdapter(name, {
-        completeFn: async () => {
-          oneShotCompleteCallCount++;
-          return `{"passed": true}`;
-        },
-      }),
-    );
-
-    // Stateful stage
-    const statefulSession = new DebateSession({
-      storyId: "US-003",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        sessionMode: "stateful",
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await statefulSession.run("stateful plan prompt");
-
-    const clientsAfterStateful = statefulClientCallCount;
-    const completesAfterStateful = oneShotCompleteCallCount;
-
-    // One-shot stage
-    const oneShotSession = new DebateSession({
-      storyId: "US-003",
-      stage: "review",
-      stageConfig: makeStageConfig({
-        sessionMode: "one-shot",
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await oneShotSession.run("one-shot review prompt");
-
-    // Stateful stage used clients
-    expect(clientsAfterStateful).toBeGreaterThan(0);
-    // One-shot stage did NOT create new clients
-    expect(statefulClientCallCount).toBe(clientsAfterStateful);
-    // One-shot stage used adapter.complete()
-    expect(oneShotCompleteCallCount).toBeGreaterThan(completesAfterStateful);
-  });
-
-  test("each DebateSession instance uses its own sessionMode independently", async () => {
-    const sessionNames: string[] = [];
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) =>
-      makeMockClient({
-        createSessionFn: async (opts) => {
-          if (opts.sessionName) sessionNames.push(opts.sessionName);
-          return makeMockSession();
-        },
-      }),
-    );
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const statefulPlanSession = new DebateSession({
-      storyId: "PLAN-001",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        sessionMode: "stateful",
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    const statefulReviewSession = new DebateSession({
-      storyId: "REVIEW-001",
-      stage: "review",
-      stageConfig: makeStageConfig({
-        sessionMode: "stateful",
-        debaters: [
-          { agent: "claude", model: "claude-3-5-haiku-20241022" },
-          { agent: "opencode", model: "gpt-4o-mini" },
-        ],
-      }),
-    });
-
-    await statefulPlanSession.run("plan prompt");
-    await statefulReviewSession.run("review prompt");
-
-    // Both stages created their own independent sessions
-    expect(sessionNames.length).toBe(4); // 2 debaters × 2 stages
-    // Session names should be unique per stage
-    const uniqueNames = new Set(sessionNames);
-    expect(uniqueNames.size).toBe(4);
-  });
-});
-
-describe("DebateSession.run() — stateful mode cost tracking", () => {
-  test("accumulates totalCostUsd from ACP exactCostUsd across rounds", async () => {
-    let sessionIndex = 0;
-
-    extDeps.createSpawnAcpClient = mock((_cmdStr: string) => {
-      const idx = sessionIndex++;
-      return makeMockClient({
-        createSessionFn: async (_opts) =>
-          makeMockSession({
-            promptFn: async (_text) => ({
-              messages: [{ role: "assistant", content: `output from ${idx}` }],
-              stopReason: "end_turn",
-              exactCostUsd: 0.25,
-            }),
-          }),
-      });
-    });
-
-    _debateSessionDeps.getAgent = mock((name: string) => makeMockAdapter(name));
-
-    const session = new DebateSession({
-      storyId: "US-003",
-      stage: "review",
-      stageConfig: makeStageConfig({
-        rounds: 2,
-        debaters: [{ agent: "claude" }, { agent: "opencode" }],
-      }),
-    });
-
-    const result = await session.run("test prompt");
-
-    expect(result.totalCostUsd).toBeCloseTo(1, 6);
+    expect(runCount).toBe(0);
+    expect(completeCount).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What

Refactors only the debate `runStateful` flow to use `adapter.run(...)` as the single execution path.

Key updates in this PR:
- `runStateful` now executes proposal/critique turns through `adapter.run(...)` instead of local ACP session orchestration.
- Added stateful turn helpers to centralize model/permission/session-role wiring.
- Preserved degraded fallback behavior (single-success pass) for resiliency.
- Added close-path handling when `keepSessionOpen: true` sessions would otherwise be left open on early fallback.
- Hardened model resolution in stateful mode so explicit non-tier debater model overrides are honored.
- Reworked stateful unit tests to validate the new `adapter.run(...)` behavior.

## Why

`runStateful` had duplicated session handling logic that could drift from adapter-level behavior.
Moving stateful debate execution to `adapter.run(...)` makes execution semantics consistent with the adapter lifecycle and reduces protocol-specific divergence risk.

Closes #191

## How

Implementation highlights:
- Refactored `runStateful` in `src/debate/session.ts` to run proposal and critique rounds via `adapter.run(...)`.
- Threaded debate runtime context (`workdir`, `featureName`, `timeoutSeconds`) into stateful execution for stable adapter options.
- Added stateful model resolution safeguards:
  - Explicit non-tier `debater.model` now takes precedence.
  - Tier resolution uses config/default fallback paths to produce concrete model defs.
- Added fallback close handling to avoid leaving stateful sessions open when early return occurs.

Primary files touched:
- `src/debate/session.ts`
- `src/cli/plan.ts`
- `src/review/semantic.ts`
- `test/unit/debate/session-stateful.test.ts`

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

Targeted tests executed:
- `bun test test/unit/debate/session-stateful.test.ts test/unit/debate/session.test.ts test/unit/debate/resolvers.test.ts`

Static checks executed:
- `bun run typecheck`
- `bun run lint`

## Notes

- Scope is intentionally limited to debate `runStateful` refactor and its direct call-site/test updates.
