### PR TITLE
debug: add checkpoints to diagnose post-completion hang (#205)

### DIFF
--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -67,6 +67,11 @@ export interface RunnerCompletionResult {
 export async function runCompletionPhase(options: RunnerCompletionOptions): Promise<RunnerCompletionResult> {
   const logger = getSafeLogger();
 
+  logger?.debug("execution", "Completion phase started", {
+    acceptanceEnabled: options.config.acceptance?.enabled,
+    isComplete: isComplete(options.prd),
+  });
+
   // Check if we need acceptance retry loop
   if (options.config.acceptance.enabled && isComplete(options.prd)) {
     const { runAcceptanceLoop } = await import("./lifecycle/acceptance-loop");
@@ -152,6 +157,7 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
   }
 
   // Stop heartbeat and write exit summary (US-007)
+  logger?.debug("execution", "Completion phase — stopping heartbeat and writing exit summary");
   stopHeartbeat();
   await writeExitSummary(
     options.logFilePath,
@@ -162,7 +168,9 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
   );
 
   // Commit status.json and any other nax runtime files left dirty at run end
+  logger?.debug("execution", "Completion phase — auto-committing dirty files");
   await autoCommitIfDirty(options.workdir, "run.complete", "run-summary", options.feature);
+  logger?.debug("execution", "Completion phase done — returning to runner");
 
   return {
     durationMs,

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -185,5 +185,11 @@ export async function runExecutionPhase(
 
   // Always let Phase 3 (runCompletionPhase) run to handle setRunStatus,
   // metrics, hooks, and cleanup — the unified executor does not perform these.
+  logger?.debug("execution", "Execution phase complete — handing off to completion phase", {
+    exitReason: unifiedResult.exitReason,
+    iterations,
+    storiesCompleted,
+    totalCost,
+  });
   return { prd, iterations, storiesCompleted, totalCost, allStoryMetrics };
 }

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -234,13 +234,17 @@ export async function run(options: RunOptions): Promise<RunResult> {
       durationMs,
     };
   } finally {
+    const logger = getSafeLogger();
+    logger?.debug("execution", "Runner finally block — starting cleanup");
     // Stop heartbeat on any exit (US-007)
     stopHeartbeat();
     // Cleanup crash handlers (MEM-1 fix)
     cleanupCrashHandlers();
 
     // Sweep any remaining open ACP sessions for this feature
+    logger?.debug("execution", "Runner finally — sweeping ACP sessions");
     await sweepFeatureSessions(workdir, feature).catch(() => {});
+    logger?.debug("execution", "Runner finally — ACP sweep done");
 
     // Resolve current branch at runtime
     let branch = "";
@@ -252,6 +256,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
     }
 
     // Execute cleanup operations
+    logger?.debug("execution", "Runner finally — running cleanupRun");
     const { cleanupRun } = await import("./lifecycle/run-cleanup");
     await cleanupRun({
       runId,
@@ -267,6 +272,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
       branch,
       version: NAX_VERSION,
     });
+    logger?.debug("execution", "Runner finally — cleanupRun done, run() returning");
   }
 }
 

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -12,7 +12,7 @@ import { wireInteraction } from "../pipeline/subscribers/interaction";
 import { wireRegistry } from "../pipeline/subscribers/registry";
 import { wireReporters } from "../pipeline/subscribers/reporters";
 import type { PipelineContext } from "../pipeline/types";
-import { isComplete, isStalled, loadPRD } from "../prd";
+import { countStories, isComplete, isStalled, loadPRD } from "../prd";
 import type { PRD } from "../prd/types";
 import { startHeartbeat, stopHeartbeat } from "./crash-recovery";
 import { captureRunStartRef, runDeferredReview } from "./deferred-review";
@@ -103,7 +103,17 @@ export async function executeUnified(
         prd = await loadPRD(ctx.prdPath);
         prdDirty = false;
       }
+      const storyCounts = countStories(prd);
+      logger?.debug("execution", "Loop iteration", {
+        iteration: iterations,
+        isComplete: isComplete(prd),
+        passed: storyCounts.passed,
+        pending: storyCounts.pending,
+        failed: storyCounts.failed,
+        total: storyCounts.total,
+      });
       if (isComplete(prd)) {
+        logger?.debug("execution", "All stories complete — entering completion path");
         if (ctx.interactionChain && isTriggerEnabled("pre-merge", ctx.config)) {
           const shouldProceed = await checkPreMerge(
             { featureName: ctx.feature, totalStories: prd.userStories.length, cost: totalCost },
@@ -112,7 +122,9 @@ export async function executeUnified(
           );
           if (!shouldProceed) return buildResult("pre-merge-aborted");
         }
+        logger?.debug("execution", "Running deferred review");
         deferredReview = await runDeferredReview(ctx.workdir, ctx.config.review, ctx.pluginRegistry, runStartRef);
+        logger?.debug("execution", "Deferred review done — returning completed");
         return buildResult("completed");
       }
 


### PR DESCRIPTION
## What

Add `debug`-level log lines at every key checkpoint in the post-story-completion flow to pinpoint exactly where the process hangs at 100% CPU.

## Why

After all stories complete successfully, nax occasionally hangs at 100% CPU for 10+ minutes before being killed manually. The last JSONL entries are the final `story.complete` + `progress` log lines — nothing after that. This makes it impossible to know whether the hang is in the executor loop, the completion phase, or the finally-block cleanup.

Closes #205

## How

Added `logger?.debug(...)` checkpoints at:

1. **`unified-executor.ts`** — top of every `while` loop iteration: logs `isComplete`, story counts (`passed/pending/failed/total`); before/after `runDeferredReview`
2. **`runner-execution.ts`** — after `executeUnified` returns: logs `exitReason` + final counters
3. **`runner-completion.ts`** — on entry; before `stopHeartbeat`/`writeExitSummary`; before/after `autoCommitIfDirty`
4. **`runner.ts` finally block** — on entry; before ACP sweep; after ACP sweep; before `cleanupRun`; after `cleanupRun` (last line before `run()` returns)

Since these are `debug` level they go to the JSONL log but not stdout. The gap in the log will pinpoint the exact hang location.

## Testing

- [ ] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

This is a diagnostic-only change — no behaviour changes. The debug logs will be removed or converted to permanent debug traces once the root cause is identified and fixed.
