### PR TITLE
chore: release v0.57.1-canary.1 (canary)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.57.0",
+  "version": "0.57.1-canary.1",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Canary release v0.57.1-canary.1 — includes debug checkpoints for post-completion hang diagnosis (#205).

## Why

Need a canary build on Mac01 so the next bench-05 run captures the debug logs that pinpoint the hang location.

Closes #205 (partial — diagnostic only)

## How

Version bump only. Debug changes are in PR #206 (`debug/post-completion-hang-205`), merged into main via the recent merge.

## Testing

- [ ] Tests added/updated
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Canary build — install via `npm install -g @nathapp/nax@canary` after tag is pushed.
