### PR TITLE
fix: prevent debate session collisions and plan race

### DIFF
--- a/src/debate/session.ts
+++ b/src/debate/session.ts
@@ -467,7 +467,7 @@ export class DebateSession {
 
     // Step 2: Proposal round — parallel via Promise.allSettled
     const proposalSettled = await Promise.allSettled(
-      resolved.map(({ debater, adapter }) =>
+      resolved.map(({ debater, adapter }, i) =>
         runComplete(
           adapter,
           prompt,
@@ -476,7 +476,7 @@ export class DebateSession {
             featureName: this.stage,
             config: this.config,
             storyId: this.storyId,
-            sessionRole: "debate-proposal",
+            sessionRole: `debate-proposal-${i}`,
             timeoutMs: this.timeoutMs,
           },
           modelTierFromDebater(debater),
@@ -591,7 +591,7 @@ export class DebateSession {
               featureName: this.stage,
               config: this.config,
               storyId: this.storyId,
-              sessionRole: "debate-critique",
+              sessionRole: `debate-critique-${i}`,
               timeoutMs: this.timeoutMs,
             },
             modelTierFromDebater(debater),
@@ -679,13 +679,14 @@ export class DebateSession {
       debaters: resolved.map((r) => r.debater.agent),
     });
 
-    // Run plan() for each debater in parallel, each writing to a unique temp path
-    const planSettled = await Promise.allSettled(
-      resolved.map(async ({ debater, adapter }, i) => {
-        const tempOutputPath = join(opts.outputDir, `prd-debate-${i}.json`);
-        // Append file-write instruction pointing at this debater's temp path
-        const debaterPrompt = `${basePrompt}\n\nWrite the PRD JSON directly to this file path: ${tempOutputPath}\nDo NOT output the JSON to the conversation. Write the file, then reply with a brief confirmation.`;
+    // Run plan() turn-by-turn to avoid concurrent session races in ACP mode.
+    const successful: SuccessfulProposal[] = [];
+    for (let i = 0; i < resolved.length; i++) {
+      const { debater, adapter } = resolved[i];
+      const tempOutputPath = join(opts.outputDir, `prd-debate-${i}.json`);
+      const debaterPrompt = `${basePrompt}\n\nWrite the PRD JSON directly to this file path: ${tempOutputPath}\nDo NOT output the JSON to the conversation. Write the file, then reply with a brief confirmation.`;
 
+      try {
         await adapter.plan({
           prompt: debaterPrompt,
           workdir: opts.workdir,
@@ -696,17 +697,23 @@ export class DebateSession {
           dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
           maxInteractionTurns: opts.maxInteractionTurns,
           featureName: opts.feature,
-          sessionRole: "plan",
+          storyId: this.storyId,
+          sessionRole: `plan-${i}`,
         });
 
         const output = await _debateSessionDeps.readFile(tempOutputPath);
-        return { debater, adapter, output, cost: 0 } as SuccessfulProposal;
-      }),
-    );
-
-    const successful: SuccessfulProposal[] = planSettled
-      .filter((r): r is PromiseFulfilledResult<SuccessfulProposal> => r.status === "fulfilled")
-      .map((r) => r.value);
+        successful.push({ debater, adapter, output, cost: 0 });
+      } catch (err) {
+        logger?.warn("debate", "debate:debater-failed", {
+          storyId: this.storyId,
+          stage: this.stage,
+          debaterIndex: i,
+          agent: debater.agent,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        // Keep debate resilient: continue with remaining debaters when one fails.
+      }
+    }
 
     for (let i = 0; i < successful.length; i++) {
       logger?.info("debate", "debate:proposal", {

--- a/test/unit/debate/session-one-shot-roles.test.ts
+++ b/test/unit/debate/session-one-shot-roles.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { DebateSession, _debateSessionDeps } from "../../../src/debate/session";
+import type { DebateStageConfig } from "../../../src/debate/types";
+
+function makeStageConfig(overrides: Partial<DebateStageConfig> = {}): DebateStageConfig {
+  return {
+    enabled: true,
+    resolver: { type: "majority-fail-closed" },
+    sessionMode: "one-shot",
+    rounds: 1,
+    debaters: [{ agent: "opencode" }, { agent: "opencode" }],
+    timeoutSeconds: 60,
+    ...overrides,
+  };
+}
+
+describe("DebateSession.runOneShot() session roles", () => {
+  let origGetAgent: typeof _debateSessionDeps.getAgent;
+
+  beforeEach(() => {
+    origGetAgent = _debateSessionDeps.getAgent;
+  });
+
+  afterEach(() => {
+    _debateSessionDeps.getAgent = origGetAgent;
+  });
+
+  test("uses indexed session roles for proposal round", async () => {
+    const roles: string[] = [];
+
+    _debateSessionDeps.getAgent = mock(() => ({
+      name: "opencode",
+      displayName: "opencode",
+      binary: "opencode",
+      capabilities: {
+        supportedTiers: ["fast"] as const,
+        maxContextTokens: 100_000,
+        features: new Set<"review" | "tdd" | "refactor" | "batch">(["review"]),
+      },
+      isInstalled: async () => true,
+      run: async () => ({
+        success: true,
+        exitCode: 0,
+        output: "",
+        rateLimited: false,
+        durationMs: 0,
+        estimatedCost: 0,
+      }),
+      buildCommand: () => [],
+      plan: async () => ({ specContent: "" }),
+      decompose: async () => ({ stories: [] }),
+      complete: async (_prompt: string, options?: { sessionRole?: string }) => {
+        roles.push(options?.sessionRole ?? "");
+        return { output: "{\"passed\":true}", costUsd: 0, source: "fallback" as const };
+      },
+    }));
+
+    const session = new DebateSession({
+      storyId: "US-ROLE",
+      stage: "review",
+      stageConfig: makeStageConfig(),
+    });
+
+    await session.run("prompt");
+
+    const proposalRoles = roles.filter((role) => role.startsWith("debate-proposal"));
+    expect(proposalRoles).toEqual(["debate-proposal-0", "debate-proposal-1"]);
+  });
+
+  test("uses indexed session roles for critique round", async () => {
+    const roles: string[] = [];
+
+    _debateSessionDeps.getAgent = mock(() => ({
+      name: "opencode",
+      displayName: "opencode",
+      binary: "opencode",
+      capabilities: {
+        supportedTiers: ["fast"] as const,
+        maxContextTokens: 100_000,
+        features: new Set<"review" | "tdd" | "refactor" | "batch">(["review"]),
+      },
+      isInstalled: async () => true,
+      run: async () => ({
+        success: true,
+        exitCode: 0,
+        output: "",
+        rateLimited: false,
+        durationMs: 0,
+        estimatedCost: 0,
+      }),
+      buildCommand: () => [],
+      plan: async () => ({ specContent: "" }),
+      decompose: async () => ({ stories: [] }),
+      complete: async (_prompt: string, options?: { sessionRole?: string }) => {
+        roles.push(options?.sessionRole ?? "");
+        return { output: "{\"passed\":true}", costUsd: 0, source: "fallback" as const };
+      },
+    }));
+
+    const session = new DebateSession({
+      storyId: "US-ROLE",
+      stage: "review",
+      stageConfig: makeStageConfig({
+        rounds: 2,
+        resolver: { type: "synthesis" },
+      }),
+    });
+
+    await session.run("prompt");
+
+    const critiqueRoles = roles.filter((role) => role.startsWith("debate-critique"));
+    expect(critiqueRoles).toEqual(["debate-critique-0", "debate-critique-1"]);
+  });
+});

--- a/test/unit/debate/session-plan.test.ts
+++ b/test/unit/debate/session-plan.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { NaxConfig } from "../../../src/config";
+import { DebateSession, _debateSessionDeps } from "../../../src/debate/session";
+import type { DebateStageConfig } from "../../../src/debate/types";
+
+function makeStageConfig(overrides: Partial<DebateStageConfig> = {}): DebateStageConfig {
+  return {
+    enabled: true,
+    resolver: { type: "majority-fail-closed" },
+    sessionMode: "one-shot",
+    rounds: 1,
+    debaters: [{ agent: "opencode" }, { agent: "opencode" }],
+    timeoutSeconds: 60,
+    ...overrides,
+  };
+}
+
+const TEST_CONFIG = {
+  autoMode: { defaultAgent: "opencode" },
+} as NaxConfig;
+
+describe("DebateSession.runPlan()", () => {
+  let origGetAgent: typeof _debateSessionDeps.getAgent;
+  let origReadFile: typeof _debateSessionDeps.readFile;
+
+  beforeEach(() => {
+    origGetAgent = _debateSessionDeps.getAgent;
+    origReadFile = _debateSessionDeps.readFile;
+  });
+
+  afterEach(() => {
+    _debateSessionDeps.getAgent = origGetAgent;
+    _debateSessionDeps.readFile = origReadFile;
+  });
+
+  test("passes unique indexed sessionRole to each plan debater", async () => {
+    const planCalls: Array<{ sessionRole?: string; storyId?: string }> = [];
+
+    _debateSessionDeps.getAgent = mock(() => ({
+      name: "opencode",
+      displayName: "opencode",
+      binary: "opencode",
+      capabilities: {
+        supportedTiers: ["fast"] as const,
+        maxContextTokens: 100_000,
+        features: new Set<"review" | "tdd" | "refactor" | "batch">(["review"]),
+      },
+      isInstalled: async () => true,
+      run: async () => ({
+        success: true,
+        exitCode: 0,
+        output: "",
+        rateLimited: false,
+        durationMs: 0,
+        estimatedCost: 0,
+      }),
+      buildCommand: () => [],
+      plan: async (options: { sessionRole?: string; storyId?: string }) => {
+        planCalls.push({ sessionRole: options.sessionRole, storyId: options.storyId });
+        return { specContent: "ok" };
+      },
+      decompose: async () => ({ stories: [] }),
+      complete: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    }));
+
+    _debateSessionDeps.readFile = mock(async (path: string) => `output:${path}`);
+
+    const session = new DebateSession({
+      storyId: "config-ssot",
+      stage: "plan",
+      stageConfig: makeStageConfig({
+        debaters: [{ agent: "opencode" }, { agent: "opencode" }, { agent: "opencode" }],
+      }),
+      config: TEST_CONFIG,
+    });
+
+    await session.runPlan("base prompt", {
+      workdir: "/tmp/workdir",
+      feature: "config-ssot",
+      outputDir: "/tmp/out",
+    });
+
+    expect(planCalls).toHaveLength(3);
+    expect(planCalls[0]?.sessionRole).toBe("plan-0");
+    expect(planCalls[1]?.sessionRole).toBe("plan-1");
+    expect(planCalls[2]?.sessionRole).toBe("plan-2");
+  });
+
+  test("passes storyId through to each plan debater call", async () => {
+    const storyIds: string[] = [];
+
+    _debateSessionDeps.getAgent = mock(() => ({
+      name: "opencode",
+      displayName: "opencode",
+      binary: "opencode",
+      capabilities: {
+        supportedTiers: ["fast"] as const,
+        maxContextTokens: 100_000,
+        features: new Set<"review" | "tdd" | "refactor" | "batch">(["review"]),
+      },
+      isInstalled: async () => true,
+      run: async () => ({
+        success: true,
+        exitCode: 0,
+        output: "",
+        rateLimited: false,
+        durationMs: 0,
+        estimatedCost: 0,
+      }),
+      buildCommand: () => [],
+      plan: async (options: { storyId?: string }) => {
+        storyIds.push(options.storyId ?? "");
+        return { specContent: "ok" };
+      },
+      decompose: async () => ({ stories: [] }),
+      complete: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    }));
+
+    _debateSessionDeps.readFile = mock(async () => "{}");
+
+    const session = new DebateSession({
+      storyId: "config-ssot",
+      stage: "plan",
+      stageConfig: makeStageConfig(),
+      config: TEST_CONFIG,
+    });
+
+    await session.runPlan("base prompt", {
+      workdir: "/tmp/workdir",
+      feature: "config-ssot",
+      outputDir: "/tmp/out",
+    });
+
+    expect(storyIds).toEqual(["config-ssot", "config-ssot"]);
+  });
+
+  test("runs plan debaters turn-by-turn instead of in parallel", async () => {
+    const startedOrder: number[] = [];
+    const resolvers: Array<() => void> = [];
+
+    _debateSessionDeps.getAgent = mock(() => ({
+      name: "opencode",
+      displayName: "opencode",
+      binary: "opencode",
+      capabilities: {
+        supportedTiers: ["fast"] as const,
+        maxContextTokens: 100_000,
+        features: new Set<"review" | "tdd" | "refactor" | "batch">(["review"]),
+      },
+      isInstalled: async () => true,
+      run: async () => ({
+        success: true,
+        exitCode: 0,
+        output: "",
+        rateLimited: false,
+        durationMs: 0,
+        estimatedCost: 0,
+      }),
+      buildCommand: () => [],
+      plan: async (options: { sessionRole?: string }) => {
+        const index = Number((options.sessionRole ?? "").replace("plan-", ""));
+        startedOrder.push(index);
+        await new Promise<void>((resolve) => {
+          resolvers[index] = resolve;
+        });
+        return { specContent: "ok" };
+      },
+      decompose: async () => ({ stories: [] }),
+      complete: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    }));
+
+    _debateSessionDeps.readFile = mock(async () => "{}");
+
+    const session = new DebateSession({
+      storyId: "config-ssot",
+      stage: "plan",
+      stageConfig: makeStageConfig(),
+      config: TEST_CONFIG,
+    });
+
+    const runPromise = session.runPlan("base prompt", {
+      workdir: "/tmp/workdir",
+      feature: "config-ssot",
+      outputDir: "/tmp/out",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(startedOrder).toEqual([0]);
+
+    resolvers[0]?.();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(startedOrder).toEqual([0, 1]);
+
+    resolvers[1]?.();
+    await runPromise;
+  });
+});


### PR DESCRIPTION
## What

Fixes debate session isolation and race behavior in debate orchestration:
- index concurrent session roles in one-shot proposal/critique rounds
- run plan debate turn-by-turn to avoid concurrent ACP race collisions
- preserve debater failure visibility with structured warning logs
- add targeted unit coverage for session role indexing and sequential plan behavior

## Why

Concurrent debaters could collide on session identity and trigger premature fallback. This change ensures debaters are isolated and reduces race-induced failures in plan debate.

Closes #210

## How

- Updated one-shot proposal role to debate-proposal-<index>
- Updated one-shot critique role to debate-critique-<index>
- Replaced runPlan Promise.allSettled parallel execution with a sequential per-debater loop
- Added per-debater warning log event when a plan debater fails
- Added/updated tests:
  - test/unit/debate/session-plan.test.ts
  - test/unit/debate/session-one-shot-roles.test.ts

## Testing

- [x] Tests added/updated
- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Executed targeted suites:
- bun test test/unit/debate/session-plan.test.ts test/unit/debate/session-one-shot-roles.test.ts test/unit/debate/session.test.ts --timeout=30000
