### PR TITLE
feat(debate): bounded concurrency for debate sessions

### DIFF
--- a/docs/specs/SPEC-debate-bounded-concurrency.md
+++ b/docs/specs/SPEC-debate-bounded-concurrency.md
@@ -1,0 +1,122 @@
+# SPEC: Debate Bounded Concurrency (Phase 1)
+
+## Summary
+
+Replace the sequential `runPlan` workaround (introduced in PR #211) with proper bounded parallel execution across all debate methods. Adds a `maxConcurrentDebaters` config field and a semaphore utility so all three debate paths — `runPlan`, `runOneShot`, `runReview` — use consistent parallel-with-limit execution. Session collisions are already solved by indexed `sessionRole` from PR #211; this restores parallelism while bounding resource usage.
+
+## Motivation
+
+PR #211 fixed ACP session collision by switching `runPlan` from `Promise.allSettled` to a sequential for-loop. This was a safe workaround but carries a cost: 2 debaters that could run in 1× wallclock now take 2×. The collision was caused by non-unique session IDs, which PR #211 also fixed via indexed `sessionRole: plan-${i}`. The sequential loop is no longer necessary.
+
+Additionally, `runOneShot` and `runReview` run proposal and critique rounds fully unbounded — all debaters fire in parallel with no concurrency cap. If a user configures 5+ debaters, all ACP sessions launch simultaneously, potentially exhausting system resources.
+
+After this change:
+- All three debate methods share a consistent bounded-parallel pattern
+- `runPlan` is restored to parallel (unique session IDs prevent collision)
+- Max concurrent sessions is controlled by `debate.maxConcurrentDebaters` (default: 2)
+- No external dependencies — semaphore implemented inline
+
+## Design
+
+### Semaphore utility
+
+A lightweight concurrency limiter in `src/debate/concurrency.ts`:
+
+```typescript
+/**
+ * Run tasks with bounded concurrency.
+ * Equivalent to Promise.allSettled but limits concurrent in-flight tasks.
+ */
+export async function allSettledBounded<T>(
+  tasks: Array<() => Promise<T>>,
+  limit: number,
+): Promise<PromiseSettledResult<T>[]> {
+  const results: PromiseSettledResult<T>[] = new Array(tasks.length);
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (next < tasks.length) {
+      const i = next++;
+      try {
+        results[i] = { status: "fulfilled", value: await tasks[i]() };
+      } catch (reason) {
+        results[i] = { status: "rejected", reason };
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, tasks.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+```
+
+### Config: `debate.maxConcurrentDebaters`
+
+New field on `DebateConfig` and `DebateConfigSchema`:
+
+```typescript
+// types.ts
+export interface DebateConfig {
+  maxConcurrentDebaters: number; // default: 2
+  // ...existing fields
+}
+
+// schemas.ts
+maxConcurrentDebaters: z.number().int().min(1).max(10).default(2),
+```
+
+### Call-site pattern
+
+All three methods replace their `Promise.allSettled(resolved.map(...))` with:
+
+```typescript
+const limit = this.stageConfig.maxConcurrentDebaters ?? this.config.debate?.maxConcurrentDebaters ?? 2;
+const settled = await allSettledBounded(
+  resolved.map(({ debater, adapter }, i) => () => runProposal(debater, adapter, i)),
+  limit,
+);
+```
+
+`runPlan` reverts its sequential `for` loop to `allSettledBounded` with the same indexed `sessionRole: plan-${i}` that PR #211 added (session isolation is preserved).
+
+### Failure handling
+
+Unchanged from current behavior — `allSettledBounded` mirrors `Promise.allSettled` semantics: one failure does not abort the rest. Each failed debater logs `debate:debater-failed` as before.
+
+## Stories
+
+### US-001: Semaphore utility + config field
+
+**Depends on:** none
+
+Add `src/debate/concurrency.ts` with `allSettledBounded`. Add `maxConcurrentDebaters` to `DebateConfig` type, `DebateConfigSchema`, and `DEFAULT_CONFIG.debate`.
+
+**Acceptance Criteria:**
+1. `allSettledBounded([...3 tasks], 2)` resolves all 3 results in a single call
+2. At no point during `allSettledBounded([...3 tasks], 2)` are more than 2 tasks in-flight concurrently
+3. A rejected task does not abort remaining tasks — all results are returned as `PromiseSettledResult`
+4. `DebateConfig.maxConcurrentDebaters` exists as a `number` field
+5. `NaxConfigSchema.parse({}).debate.maxConcurrentDebaters === 2` (default value)
+6. `DEFAULT_CONFIG.debate.maxConcurrentDebaters === 2`
+
+### US-002: Apply bounded concurrency to all three debate methods
+
+**Depends on:** US-001
+
+Replace `Promise.allSettled` in `runOneShot` (proposal + critique rounds) and `runReview` (proposal + critique rounds) with `allSettledBounded`. Revert `runPlan`'s sequential for-loop to `allSettledBounded` — preserve the indexed `sessionRole: plan-${i}` from PR #211.
+
+**Acceptance Criteria:**
+1. `runPlan` with 2 debaters calls both `adapter.plan()` concurrently (not sequentially) when `maxConcurrentDebaters >= 2`
+2. `runPlan` with `maxConcurrentDebaters: 1` calls `adapter.plan()` for debater 0 before debater 1 starts
+3. `runOneShot` proposal round uses `allSettledBounded` with the configured limit
+4. `runReview` proposal round uses `allSettledBounded` with the configured limit
+5. `runPlan` preserves `sessionRole: plan-${i}` on every `adapter.plan()` call (no regression from PR #211)
+6. When one debater fails, `runPlan` continues and includes remaining successful debaters in the result
+
+### Context Files
+- `src/debate/session.ts` — `runPlan`, `runOneShot`, `runReview` methods to update
+- `src/debate/types.ts` — `DebateConfig` interface, add `maxConcurrentDebaters`
+- `src/config/schemas.ts` — `DebateConfigSchema`, add `maxConcurrentDebaters`
+- `src/config/defaults.ts` — `DEFAULT_CONFIG.debate`, add `maxConcurrentDebaters: 2`
+- `test/unit/debate/session-plan.test.ts` — existing plan debate tests (must not regress)

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -226,6 +226,7 @@ export const DEFAULT_CONFIG: NaxConfig = {
   debate: {
     enabled: false,
     agents: 3,
+    maxConcurrentDebaters: 2,
     stages: {
       plan: {
         enabled: true,

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -472,6 +472,7 @@ const DebateConfigSchema = z.preprocess(
   z.object({
     enabled: z.boolean().default(false),
     agents: z.number().int().min(2).default(3),
+    maxConcurrentDebaters: z.number().int().min(1).max(10).default(2),
     stages: z.preprocess(
       toObject,
       z.object({

--- a/src/debate/concurrency.ts
+++ b/src/debate/concurrency.ts
@@ -1,0 +1,39 @@
+/**
+ * Debate Concurrency Utilities
+ *
+ * Bounded parallel execution for debate rounds.
+ */
+
+/**
+ * Run tasks with bounded concurrency, returning all results as PromiseSettledResult.
+ *
+ * Equivalent to Promise.allSettled but limits the number of concurrent in-flight tasks.
+ * A rejected task does not abort remaining tasks.
+ *
+ * @param tasks - Array of task factories (thunks). Called lazily as slots open.
+ * @param limit - Maximum number of concurrent in-flight tasks (min 1).
+ */
+export async function allSettledBounded<T>(
+  tasks: Array<() => Promise<T>>,
+  limit: number,
+): Promise<PromiseSettledResult<T>[]> {
+  if (tasks.length === 0) return [];
+
+  const results: PromiseSettledResult<T>[] = new Array(tasks.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < tasks.length) {
+      const i = nextIndex++;
+      try {
+        results[i] = { status: "fulfilled", value: await tasks[i]() };
+      } catch (reason) {
+        results[i] = { status: "rejected", reason };
+      }
+    }
+  }
+
+  const concurrency = Math.max(1, Math.min(limit, tasks.length));
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+  return results;
+}

--- a/src/debate/session.ts
+++ b/src/debate/session.ts
@@ -13,9 +13,10 @@ import type { NaxConfig } from "../config";
 import { DEFAULT_CONFIG, resolveModel, resolveModelForAgent } from "../config";
 import { resolvePermissions } from "../config/permissions";
 import { getSafeLogger } from "../logger";
+import { allSettledBounded } from "./concurrency";
 import { buildCritiquePrompt } from "./prompts";
 import { judgeResolver, majorityResolver, synthesisResolver } from "./resolvers";
-import type { DebateResult, DebateStageConfig, Debater, Proposal } from "./types";
+import type { DebateConfig, DebateResult, DebateStageConfig, Debater, Proposal } from "./types";
 
 /** Fallback agent name used when resolver.agent is not specified for synthesis/judge */
 const RESOLVER_FALLBACK_AGENT = "synthesis";
@@ -284,11 +285,17 @@ export class DebateSession {
       debaters: resolved.map((r) => r.debater.agent),
     });
 
-    // Proposal round — parallel via Promise.allSettled
-    const proposalSettled = await Promise.allSettled(
-      resolved.map(({ debater, adapter }, debaterIdx) =>
-        this.runStatefulTurn(adapter, debater, prompt, `debate-${this.stage}-${debaterIdx}`, config.rounds > 1),
+    // Proposal round — bounded parallel
+    const cfg = this.config;
+    const debate = cfg?.debate;
+    const concurrencyLimit = debate?.maxConcurrentDebaters ?? 2;
+    const proposalSettled = await allSettledBounded(
+      resolved.map(
+        ({ debater, adapter }, debaterIdx) =>
+          () =>
+            this.runStatefulTurn(adapter, debater, prompt, `debate-${this.stage}-${debaterIdx}`, config.rounds > 1),
       ),
+      concurrencyLimit,
     );
 
     const successfulProposals: SuccessfulProposal[] = proposalSettled
@@ -392,16 +399,18 @@ export class DebateSession {
     let critiqueOutputs: string[] = [];
     if (config.rounds > 1) {
       const proposalOutputs = successfulProposals.map((s) => s.output);
-      const critiqueSettled = await Promise.allSettled(
-        successfulProposals.map((proposal, successfulIdx) =>
-          this.runStatefulTurn(
-            proposal.adapter,
-            proposal.debater,
-            buildCritiquePrompt(prompt, proposalOutputs, successfulIdx),
-            proposal.roleKey ?? `debate-${this.stage}-${successfulIdx}`,
-            false,
-          ),
+      const critiqueSettled = await allSettledBounded(
+        successfulProposals.map(
+          (proposal, successfulIdx) => () =>
+            this.runStatefulTurn(
+              proposal.adapter,
+              proposal.debater,
+              buildCritiquePrompt(prompt, proposalOutputs, successfulIdx),
+              proposal.roleKey ?? `debate-${this.stage}-${successfulIdx}`,
+              false,
+            ),
         ),
+        concurrencyLimit,
       );
 
       for (const r of critiqueSettled) {
@@ -465,23 +474,29 @@ export class DebateSession {
       debaters: resolved.map((r) => r.debater.agent),
     });
 
-    // Step 2: Proposal round — parallel via Promise.allSettled
-    const proposalSettled = await Promise.allSettled(
-      resolved.map(({ debater, adapter }, i) =>
-        runComplete(
-          adapter,
-          prompt,
-          {
-            model: resolveDebaterModel(debater, this.config),
-            featureName: this.stage,
-            config: this.config,
-            storyId: this.storyId,
-            sessionRole: `debate-proposal-${i}`,
-            timeoutMs: this.timeoutMs,
-          },
-          modelTierFromDebater(debater),
-        ).then((result) => ({ debater, adapter, output: result.output, cost: result.costUsd })),
+    // Step 2: Proposal round — bounded parallel
+    const cfg = this.config;
+    const debate = cfg?.debate;
+    const concurrencyLimit = debate?.maxConcurrentDebaters ?? 2;
+    const proposalSettled = await allSettledBounded(
+      resolved.map(
+        ({ debater, adapter }, i) =>
+          () =>
+            runComplete(
+              adapter,
+              prompt,
+              {
+                model: resolveDebaterModel(debater, this.config),
+                featureName: this.stage,
+                config: this.config,
+                storyId: this.storyId,
+                sessionRole: `debate-proposal-${i}`,
+                timeoutMs: this.timeoutMs,
+              },
+              modelTierFromDebater(debater),
+            ).then((result) => ({ debater, adapter, output: result.output, cost: result.costUsd })),
       ),
+      concurrencyLimit,
     );
 
     const successful: SuccessfulProposal[] = proposalSettled
@@ -581,22 +596,25 @@ export class DebateSession {
     let critiqueOutputs: string[] = [];
     if (config.rounds > 1) {
       const proposalOutputs = successful.map((p) => p.output);
-      const critiqueSettled = await Promise.allSettled(
-        successful.map(({ debater, adapter }, i) =>
-          runComplete(
-            adapter,
-            buildCritiquePrompt(prompt, proposalOutputs, i),
-            {
-              model: resolveDebaterModel(debater, this.config),
-              featureName: this.stage,
-              config: this.config,
-              storyId: this.storyId,
-              sessionRole: `debate-critique-${i}`,
-              timeoutMs: this.timeoutMs,
-            },
-            modelTierFromDebater(debater),
-          ),
+      const critiqueSettled = await allSettledBounded(
+        successful.map(
+          ({ debater, adapter }, i) =>
+            () =>
+              runComplete(
+                adapter,
+                buildCritiquePrompt(prompt, proposalOutputs, i),
+                {
+                  model: resolveDebaterModel(debater, this.config),
+                  featureName: this.stage,
+                  config: this.config,
+                  storyId: this.storyId,
+                  sessionRole: `debate-critique-${i}`,
+                  timeoutMs: this.timeoutMs,
+                },
+                modelTierFromDebater(debater),
+              ),
         ),
+        concurrencyLimit,
       );
       for (const r of critiqueSettled) {
         if (r.status === "fulfilled") {
@@ -679,14 +697,15 @@ export class DebateSession {
       debaters: resolved.map((r) => r.debater.agent),
     });
 
-    // Run plan() turn-by-turn to avoid concurrent session races in ACP mode.
-    const successful: SuccessfulProposal[] = [];
-    for (let i = 0; i < resolved.length; i++) {
-      const { debater, adapter } = resolved[i];
-      const tempOutputPath = join(opts.outputDir, `prd-debate-${i}.json`);
-      const debaterPrompt = `${basePrompt}\n\nWrite the PRD JSON directly to this file path: ${tempOutputPath}\nDo NOT output the JSON to the conversation. Write the file, then reply with a brief confirmation.`;
+    // Run plan() bounded parallel (restores concurrency after PR #211 workaround)
+    const cfg = this.config;
+    const debate = cfg?.debate;
+    const concurrencyLimit = debate?.maxConcurrentDebaters ?? 2;
+    const settled = await allSettledBounded(
+      resolved.map(({ debater, adapter }, i) => async () => {
+        const tempOutputPath = join(opts.outputDir, `prd-debate-${i}.json`);
+        const debaterPrompt = `${basePrompt}\n\nWrite the PRD JSON directly to this file path: ${tempOutputPath}\nDo NOT output the JSON to the conversation. Write the file, then reply with a brief confirmation.`;
 
-      try {
         await adapter.plan({
           prompt: debaterPrompt,
           workdir: opts.workdir,
@@ -702,16 +721,25 @@ export class DebateSession {
         });
 
         const output = await _debateSessionDeps.readFile(tempOutputPath);
-        successful.push({ debater, adapter, output, cost: 0 });
-      } catch (err) {
+        return { debater, adapter, output, cost: 0 };
+      }),
+      concurrencyLimit,
+    );
+
+    const successful: SuccessfulProposal[] = [];
+    for (let i = 0; i < settled.length; i++) {
+      const res = settled[i];
+      if (res.status === "fulfilled") {
+        successful.push(res.value);
+      } else {
+        const { debater } = resolved[i];
         logger?.warn("debate", "debate:debater-failed", {
           storyId: this.storyId,
           stage: this.stage,
           debaterIndex: i,
           agent: debater.agent,
-          error: err instanceof Error ? err.message : String(err),
+          error: res.reason instanceof Error ? res.reason.message : String(res.reason),
         });
-        // Keep debate resilient: continue with remaining debaters when one fails.
       }
     }
 

--- a/src/debate/types.ts
+++ b/src/debate/types.ts
@@ -52,6 +52,8 @@ export interface DebateConfig {
   enabled: boolean;
   /** Default number of debating agents when no explicit debaters array is specified */
   agents: number;
+  /** Maximum number of debaters running concurrently per debate round (default: 2) */
+  maxConcurrentDebaters: number;
   /** Per-stage debate configuration */
   stages: {
     /** Planning phase debate */

--- a/test/unit/debate/session-plan.test.ts
+++ b/test/unit/debate/session-plan.test.ts
@@ -71,7 +71,7 @@ describe("DebateSession.runPlan()", () => {
       stageConfig: makeStageConfig({
         debaters: [{ agent: "opencode" }, { agent: "opencode" }, { agent: "opencode" }],
       }),
-      config: TEST_CONFIG,
+      config: { ...TEST_CONFIG, debate: { enabled: true, agents: 2, maxConcurrentDebaters: 2 } },
     });
 
     await session.runPlan("base prompt", {
@@ -122,7 +122,7 @@ describe("DebateSession.runPlan()", () => {
       storyId: "config-ssot",
       stage: "plan",
       stageConfig: makeStageConfig(),
-      config: TEST_CONFIG,
+      config: { ...TEST_CONFIG, debate: { enabled: true, agents: 2, maxConcurrentDebaters: 2 } },
     });
 
     await session.runPlan("base prompt", {
@@ -134,7 +134,7 @@ describe("DebateSession.runPlan()", () => {
     expect(storyIds).toEqual(["config-ssot", "config-ssot"]);
   });
 
-  test("runs plan debaters turn-by-turn instead of in parallel", async () => {
+  test("runs plan debaters in parallel (when limit >= agents)", async () => {
     const startedOrder: number[] = [];
     const resolvers: Array<() => void> = [];
 
@@ -175,7 +175,7 @@ describe("DebateSession.runPlan()", () => {
       storyId: "config-ssot",
       stage: "plan",
       stageConfig: makeStageConfig(),
-      config: TEST_CONFIG,
+      config: { ...TEST_CONFIG, debate: { enabled: true, agents: 2, maxConcurrentDebaters: 2 } },
     });
 
     const runPromise = session.runPlan("base prompt", {
@@ -185,12 +185,10 @@ describe("DebateSession.runPlan()", () => {
     });
 
     await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(startedOrder).toEqual([0]);
-
-    resolvers[0]?.();
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // Verify parallel execution (both started)
     expect(startedOrder).toEqual([0, 1]);
 
+    resolvers[0]?.();
     resolvers[1]?.();
     await runPromise;
   });


### PR DESCRIPTION
## What
Add bounded concurrency to debate sessions — semaphore utility + config field + apply to all three debate methods.

## Why
PR #211 fixed ACP session collision by switching runPlan to sequential. Session IDs are now unique (`plan-${i}`) so parallelism can be restored. Also caps unbounded parallelism in runOneShot/runReview proposal/critique rounds.

- Reverts sequential runPlan workaround (PR #211) while preserving session isolation
- Adds `debate.maxConcurrentDebaters` config (default: 2)
- No external deps — inline semaphore in `src/debate/concurrency.ts`

## How
- New `allSettledBounded(tasks, limit)` — Promise.allSettled with concurrency cap
- Config: `debate.maxConcurrentDebaters: 2` in defaults.ts + schemas.ts
- Type: `DebateConfig.maxConcurrentDebaters` in types.ts
- Applied to `runStateful`, `runOneShot`, `runReview` proposal/critique rounds
- Preserved `sessionRole: plan-${i}` from PR #211

## Testing
- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
Phase 1 complete. Phase 2 will introduce `debate.sessionMode: "panel" | "hybrid"` for true sequential debate.

Closes #212
