### PR TITLE
fix(acceptance-setup): write test file to .nax/features/<name>/ not package root (#186)

### DIFF
--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -235,7 +235,6 @@ export const acceptanceSetupStage: PipelineStage = {
     if (shouldGenerate) {
       totalCriteria = allCriteria.length;
 
-      const { getAgent } = await import("../../agents");
       const agent = (ctx.agentGetFn ?? _acceptanceSetupDeps.getAgent)(ctx.config.autoMode.defaultAgent);
 
       // Refine criteria per-story (preserves storyId association for per-group filtering)
@@ -271,7 +270,13 @@ export const acceptanceSetupStage: PipelineStage = {
       // Generate one acceptance test file per workdir group
       for (const [workdir, group] of workdirGroups) {
         const packageDir = workdir ? path.join(ctx.workdir, workdir) : ctx.workdir;
-        const testPath = path.join(packageDir, resolveAcceptanceTestFile(language, testPathConfig));
+        const testPath = path.join(
+          packageDir,
+          ".nax",
+          "features",
+          featureName,
+          resolveAcceptanceTestFile(language, testPathConfig),
+        );
 
         // Filter refined criteria to this group's stories
         const groupStoryIds = new Set(group.stories.map((s) => s.id));

--- a/test/integration/acceptance/red-green-cycle.test.ts
+++ b/test/integration/acceptance/red-green-cycle.test.ts
@@ -121,7 +121,7 @@ afterEach(async () => {
 
 describe("RED to GREEN acceptance cycle", () => {
   test("acceptance-setup writes test file and RED gate detects failures", async () => {
-    const testPath = path.join(tmpDir, ".nax-acceptance.test.ts");
+    const testPath = path.join(tmpDir, ".nax", "features", "test-feature", ".nax-acceptance.test.ts");
 
     const generatedTestCode = [
       'import { test } from "bun:test";',
@@ -161,7 +161,7 @@ describe("RED to GREEN acceptance cycle", () => {
   });
 
   test("GREEN gate passes after implementation stubs are written", async () => {
-    const testPath = path.join(tmpDir, ".nax-acceptance.test.ts");
+    const testPath = path.join(tmpDir, ".nax", "features", "test-feature", ".nax-acceptance.test.ts");
 
     // Write a real passing acceptance test file (simulating post-implementation state)
     const passingTestCode = [
@@ -192,7 +192,7 @@ describe("RED to GREEN acceptance cycle", () => {
   });
 
   test("full RED then GREEN: setup stage continues on RED, acceptance stage continues on GREEN", async () => {
-    const testPath = path.join(tmpDir, ".nax-acceptance.test.ts");
+    const testPath = path.join(tmpDir, ".nax", "features", "test-feature", ".nax-acceptance.test.ts");
 
     // --- RED phase ---
     _acceptanceSetupDeps.fileExists = async () => false;
@@ -239,8 +239,8 @@ describe("RED to GREEN acceptance cycle", () => {
 // ---------------------------------------------------------------------------
 
 describe("edge case: pre-existing .nax-acceptance.test.ts", () => {
-  test("skips generation when .nax-acceptance.test.ts already exists at package root and fingerprint matches", async () => {
-    const testPath = path.join(tmpDir, ".nax-acceptance.test.ts");
+  test("skips generation when .nax-acceptance.test.ts already exists and fingerprint matches", async () => {
+    const testPath = path.join(tmpDir, ".nax", "features", "test-feature", ".nax-acceptance.test.ts");
 
     // Pre-write a test file as if from a previous nax analyze run
     await Bun.write(testPath, 'import { test } from "bun:test"; test("existing", () => {});');
@@ -290,7 +290,7 @@ describe("edge case: pre-existing .nax-acceptance.test.ts", () => {
   });
 
   test("does not overwrite the pre-existing .nax-acceptance.test.ts when fingerprint matches", async () => {
-    const testPath = path.join(tmpDir, ".nax-acceptance.test.ts");
+    const testPath = path.join(tmpDir, ".nax", "features", "test-feature", ".nax-acceptance.test.ts");
 
     const originalContent = "// pre-existing test content";
     await Bun.write(testPath, originalContent);

--- a/test/unit/pipeline/stages/acceptance-setup.test.ts
+++ b/test/unit/pipeline/stages/acceptance-setup.test.ts
@@ -223,7 +223,7 @@ describe("acceptance-setup: calls refinement and generation", () => {
 // ---------------------------------------------------------------------------
 
 describe("acceptance-setup: writes test file", () => {
-  test("writes .nax-acceptance.test.ts to package root (not featureDir)", async () => {
+  test("writes .nax-acceptance.test.ts under .nax/features/<featureName>/", async () => {
     const writtenPaths: string[] = [];
     const testCode = 'import { test } from "bun:test"; test("AC-1", () => { throw new Error("red") })';
 
@@ -241,10 +241,9 @@ describe("acceptance-setup: writes test file", () => {
     await acceptanceSetupStage.execute(ctx);
 
     expect(writtenPaths.length).toBe(1);
-    // US-001: file is at package root, not inside featureDir
-    expect(writtenPaths[0]).toContain(".nax-acceptance.test.ts");
+    // BUG-186 regression: file must be under .nax/features/<featureName>/, not the bare package root
+    expect(writtenPaths[0]).toContain(".nax/features/test-feature/.nax-acceptance.test.ts");
     expect(writtenPaths[0]).toContain("/tmp/test-workdir");
-    expect(writtenPaths[0]).not.toContain("features/test-feature");
   });
 
   test("written content matches generated testCode", async () => {
@@ -786,7 +785,7 @@ describe("US-001: per-package test file generation by workdir", () => {
     expect(writtenPaths.some((p) => p.includes("apps/cli") && p.includes(".nax-acceptance.test.ts"))).toBe(true);
   });
 
-  test("AC-2: single-package project generates one file at repo root", async () => {
+  test("AC-2: single-package project generates one file under .nax/features/<featureName>/", async () => {
     const writtenPaths: string[] = [];
 
     _acceptanceSetupDeps.fileExists = async () => false;
@@ -807,8 +806,8 @@ describe("US-001: per-package test file generation by workdir", () => {
     await acceptanceSetupStage.execute(ctx);
 
     expect(writtenPaths.length).toBe(1);
-    expect(writtenPaths[0]).toContain("/tmp/test-workdir/.nax-acceptance.test.ts");
-    expect(writtenPaths[0]).not.toContain("features");
+    // BUG-186 regression: file must be under .nax/features/<featureName>/ (not bare package root)
+    expect(writtenPaths[0]).toContain("/tmp/test-workdir/.nax/features/test-feature/.nax-acceptance.test.ts");
   });
 
   test("AC-4: RED gate runs each file from its package directory", async () => {


### PR DESCRIPTION
## What

Fix a path mismatch in `acceptance-setup.ts` where the generated acceptance test file was written to `<packageDir>/<filename>` instead of the correct `<packageDir>/.nax/features/<featureName>/<filename>`.

## Why

Three paths in the acceptance pipeline must agree on where the test file lives:

| Path computed | Location |
|---------------|----------|
| `testPaths` array (RED gate) | `<packageDir>/.nax/features/<featureName>/<filename>` ✓ |
| Generator prompt to agent | `<packageDir>/.nax/features/<featureName>/<filename>` ✓ |
| `testPath` in generation loop (old) | `<packageDir>/<filename>` ✗ |

For **non-ACP adapters**: `writeFile` silently wrote the test to the package root; the RED gate then ran on the `.nax/features/` path where no file existed, exiting non-zero for the wrong reason (missing file, not real RED failure). Downstream acceptance runner read from `ctx.acceptanceTestPaths` (correct path) and never found the file.

For **ACP adapters (BUG-076 path)**: the agent wrote directly to the correct location, BUG-076 recovery read it back, then `writeFile` produced an orphaned stale duplicate at the package root. This path worked only by accident.

Closes #186

## How

- `src/pipeline/stages/acceptance-setup.ts` line 274: add `.nax/features/<featureName>/` prefix to the `testPath` inside the generation loop, matching what `testPaths` already computed.
- Remove dead `const { getAgent }` import (was shadowed by `_acceptanceSetupDeps.getAgent` on the next line — TS6133).

## Testing

- [x] Tests added/updated — updated two existing tests that were asserting the old wrong path; both now assert `/.nax/features/test-feature/.nax-acceptance.test.ts`
- [x] `bun test` passes (35 tests, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

No breaking changes. Single path prefix correction. The ACP / BUG-076 flow is unaffected — `generator.ts` writes to the correct path already and that behaviour is unchanged.