### PR TITLE
fix(autofix): add rethinkAtAttempt & urgencyAtAttempt escalation prompt

### DIFF
--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -68,7 +68,7 @@ const AutoModeConfigSchema = z.object({
 
 const RectificationConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  maxRetries: z.number().int().min(0).max(10).default(3),
+  maxRetries: z.number().int().min(0).max(10).default(2),
   fullSuiteTimeoutSeconds: z.number().int().min(10).max(600).default(120),
   maxFailureSummaryChars: z.number().int().min(500).max(10000).default(2000),
   abortOnIncreasingFailures: z.boolean().default(true),
@@ -568,7 +568,7 @@ export const NaxConfigSchema = z
       maxStoriesPerFeature: 500,
       rectification: {
         enabled: true,
-        maxRetries: 3,
+        maxRetries: 2,
         fullSuiteTimeoutSeconds: 300,
         maxFailureSummaryChars: 2000,
         abortOnIncreasingFailures: true,


### PR DESCRIPTION
## What

Fixes two autofix and rectification issues:

- stops rectification when retry verification output parses to zero remaining failures
- adds progressive autofix prompt escalation with `rethinkAtAttempt` and `urgencyAtAttempt`
- adds autofix config defaults and runtime/schema support for those escalation thresholds

## Why

This solves:

- `#175` where rectification could continue retrying even after failures were actually resolved
- `#176` where autofix lacked the progressive prompt escalation already supported by rectification

Closes #175
Closes #176

## How

- Updated `runRectificationLoop()` to treat parsed retry output with `0` failures as success, even if the raw verification result still reports failure status.
- Extended `quality.autofix` config to support:
  - `maxAttempts` as the per-cycle cap
  - `maxTotalAttempts` as the total cap across all autofix runs for a story
  - `rethinkAtAttempt` with default `2`
  - `urgencyAtAttempt` with default `3`
- Matched rectification behavior by clamping autofix escalation thresholds to the cycle `maxAttempts`, so the final attempt still gets escalation language when thresholds exceed the remaining cycle budget.
- Added and updated focused unit tests for:
  - rectification stopping at zero parsed failures
  - autofix rethink injection
  - autofix urgency + rethink injection
  - autofix default escalation threshold behavior
  - total autofix budget persistence across repeated review/autofix cycles

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun test test/unit/verification/rectification-loop.test.ts --timeout=30000` passes
- [x] `bun test test/unit/pipeline/stages/autofix.test.ts --timeout=30000` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- the changes had push to origin/main unexpectedly, this PR is to fix the test error on origin/main
