### PR TITLE
refactor: share rectification loop utility

### DIFF
--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -28,6 +28,7 @@ import { getLogger } from "../../logger";
 import type { UserStory } from "../../prd";
 import { runQualityCommand } from "../../quality";
 import type { ReviewCheckResult } from "../../review/types";
+import { buildProgressivePromptPreamble, runSharedRectificationLoop } from "../../verification/shared-rectification-loop";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
@@ -196,43 +197,20 @@ function buildAutofixEscalationPreamble(
   rethinkAtAttempt?: number,
   urgencyAtAttempt?: number,
 ): string {
-  const logger = getLogger();
-  const rethinkAt = rethinkAtAttempt === undefined ? undefined : Math.min(rethinkAtAttempt, maxAttempts);
-  const urgencyAt = urgencyAtAttempt === undefined ? undefined : Math.min(urgencyAtAttempt, maxAttempts);
-
-  const shouldRethink = rethinkAt !== undefined && attempt >= rethinkAt;
-  const shouldUrgency = urgencyAt !== undefined && attempt >= urgencyAt;
-
-  if (!shouldRethink && !shouldUrgency) {
-    return "";
-  }
-
-  if (shouldUrgency) {
-    logger.info("autofix", "Progressive prompt escalation: urgency + rethink injected", {
-      attempt,
-      rethinkAtAttempt: rethinkAt,
-      urgencyAtAttempt: urgencyAt,
-      maxAttempts,
-    });
-  } else {
-    logger.info("autofix", "Progressive prompt escalation: rethink injected", {
-      attempt,
-      rethinkAtAttempt: rethinkAt,
-      maxAttempts,
-    });
-  }
-
-  const urgencySection = shouldUrgency
-    ? `## Final Autofix Attempt Before Escalation
+  return buildProgressivePromptPreamble({
+    attempt,
+    maxAttempts,
+    rethinkAtAttempt,
+    urgencyAtAttempt,
+    stage: "autofix",
+    logger: getLogger(),
+    urgencySection: `## Final Autofix Attempt Before Escalation
 
 This is attempt ${attempt}. If the review still fails after this, autofix will escalate instead of retrying.
 A different approach is required. Do not repeat the same fix.
 
-`
-    : "";
-
-  const rethinkSection = shouldRethink
-    ? `## Previous Attempt Did Not Fix the Failures
+`,
+    rethinkSection: `## Previous Attempt Did Not Fix the Failures
 
 Your previous fix attempt (attempt ${attempt}) did not resolve the quality errors. Rethink your approach.
 
@@ -240,10 +218,8 @@ Your previous fix attempt (attempt ${attempt}) did not resolve the quality error
 - Re-read the failing diagnostics carefully.
 - Try a fundamentally different fix strategy if the earlier one did not work.
 
-`
-    : "";
-
-  return `${urgencySection}${rethinkSection}`;
+`,
+  });
 }
 
 async function runAgentRectification(ctx: PipelineContext): Promise<boolean> {
@@ -275,77 +251,104 @@ async function runAgentRectification(ctx: PipelineContext): Promise<boolean> {
   const remainingBudget = maxTotal - consumed;
   const maxAttempts = Math.min(maxPerCycle, remainingBudget);
 
-  logger.info("autofix", "Starting agent rectification for review failures", {
-    storyId: ctx.story.id,
-    failedChecks: failedChecks.map((c) => c.check),
-    maxAttempts,
-    totalUsed: consumed,
-    maxTotalAttempts: maxTotal,
-  });
-
   const agentGetFn = ctx.agentGetFn ?? _autofixDeps.getAgent;
+  const loopState = {
+    attempt: 0,
+    failedChecks,
+  };
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    ctx.autofixAttempt = consumed + attempt;
-    logger.info("autofix", `Agent rectification attempt ${ctx.autofixAttempt}/${maxTotal}`, { storyId: ctx.story.id });
-
-    const agent = agentGetFn(ctx.config.autoMode.defaultAgent);
-    if (!agent) {
-      logger.error("autofix", "Agent not found — cannot run agent rectification", { storyId: ctx.story.id });
-      return false;
-    }
-
-    let prompt = buildReviewRectificationPrompt(failedChecks, ctx.story);
-    const escalationPreamble = buildAutofixEscalationPreamble(attempt, maxAttempts, rethinkAtAttempt, urgencyAtAttempt);
-    if (escalationPreamble) {
-      prompt = `${escalationPreamble}${prompt}`;
-    }
-    const modelTier = ctx.story.routing?.modelTier ?? ctx.config.autoMode.escalation.tierOrder[0]?.tier ?? "balanced";
-    const modelDef = resolveModelForAgent(
-      ctx.config.models,
-      ctx.routing.agent ?? ctx.config.autoMode.defaultAgent,
-      modelTier,
-      ctx.config.autoMode.defaultAgent,
-    );
-
-    // ENH-008: Scope agent to story.workdir for monorepo — prevents out-of-package changes
-    const rectificationWorkdir = ctx.story.workdir ? join(ctx.workdir, ctx.story.workdir) : ctx.workdir;
-
-    await agent.run({
-      prompt,
-      workdir: rectificationWorkdir,
-      modelTier,
-      modelDef,
-      timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
-      dangerouslySkipPermissions: resolvePermissions(ctx.config, "rectification").skipPermissions,
-      pipelineStage: "rectification",
-      config: ctx.config,
-      maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
+  return runSharedRectificationLoop({
+    stage: "autofix",
+    storyId: ctx.story.id,
+    maxAttempts,
+    state: loopState,
+    logger,
+    startMessage: "Starting agent rectification for review failures",
+    startData: {
       storyId: ctx.story.id,
-      sessionRole: "implementer",
-    });
+      failedChecks: failedChecks.map((check) => check.check),
+      maxAttempts,
+      totalUsed: consumed,
+      maxTotalAttempts: maxTotal,
+    },
+    attemptMessage: (attempt) => `Agent rectification attempt ${consumed + attempt}/${maxTotal}`,
+    attemptData: { storyId: ctx.story.id },
+    canContinue: (state) => state.failedChecks.length > 0 && state.attempt < maxAttempts,
+    buildPrompt: (attempt, state) => {
+      let prompt = buildReviewRectificationPrompt(state.failedChecks, ctx.story);
+      const escalationPreamble = buildAutofixEscalationPreamble(
+        attempt,
+        maxAttempts,
+        rethinkAtAttempt,
+        urgencyAtAttempt,
+      );
+      if (escalationPreamble) {
+        prompt = `${escalationPreamble}${prompt}`;
+      }
+      return prompt;
+    },
+    runAttempt: async (attempt, prompt) => {
+      ctx.autofixAttempt = consumed + attempt;
+      const agent = agentGetFn(ctx.config.autoMode.defaultAgent);
+      if (!agent) {
+        logger.error("autofix", "Agent not found — cannot run agent rectification", { storyId: ctx.story.id });
+        throw new Error("AUTOFIX_AGENT_NOT_FOUND");
+      }
 
-    const passed = await _autofixDeps.recheckReview(ctx);
-    if (passed) {
-      logger.info("autofix", `[OK] Agent rectification succeeded on attempt ${attempt}`, {
+      const modelTier = ctx.story.routing?.modelTier ?? ctx.config.autoMode.escalation.tierOrder[0]?.tier ?? "balanced";
+      const modelDef = resolveModelForAgent(
+        ctx.config.models,
+        ctx.routing.agent ?? ctx.config.autoMode.defaultAgent,
+        modelTier,
+        ctx.config.autoMode.defaultAgent,
+      );
+      const rectificationWorkdir = ctx.story.workdir ? join(ctx.workdir, ctx.story.workdir) : ctx.workdir;
+
+      await agent.run({
+        prompt,
+        workdir: rectificationWorkdir,
+        modelTier,
+        modelDef,
+        timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
+        dangerouslySkipPermissions: resolvePermissions(ctx.config, "rectification").skipPermissions,
+        pipelineStage: "rectification",
+        config: ctx.config,
+        maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
+        storyId: ctx.story.id,
+        sessionRole: "implementer",
+      });
+    },
+    checkResult: async (attempt, state) => {
+      const passed = await _autofixDeps.recheckReview(ctx);
+      if (passed) {
+        logger.info("autofix", `[OK] Agent rectification succeeded on attempt ${attempt}`, {
+          storyId: ctx.story.id,
+        });
+        return true;
+      }
+
+      const updatedFailed = collectFailedChecks(ctx);
+      if (updatedFailed.length > 0) {
+        state.failedChecks.splice(0, state.failedChecks.length, ...updatedFailed);
+      }
+      return false;
+    },
+    onAttemptFailure: (attempt) => {
+      logger.warn("autofix", `Agent rectification still failing after attempt ${attempt}`, {
         storyId: ctx.story.id,
       });
-      return true;
+    },
+    onLoopEnd: (state) => {
+      if (state.attempt >= maxAttempts) {
+        logger.warn("autofix", "Agent rectification exhausted", { storyId: ctx.story.id });
+      }
+    },
+  }).catch((error: unknown) => {
+    if (error instanceof Error && error.message === "AUTOFIX_AGENT_NOT_FOUND") {
+      return false;
     }
-
-    // Refresh failed checks for next attempt
-    const updatedFailed = collectFailedChecks(ctx);
-    if (updatedFailed.length > 0) {
-      failedChecks.splice(0, failedChecks.length, ...updatedFailed);
-    }
-
-    logger.warn("autofix", `Agent rectification still failing after attempt ${attempt}`, {
-      storyId: ctx.story.id,
-    });
-  }
-
-  logger.warn("autofix", "Agent rectification exhausted", { storyId: ctx.story.id });
-  return false;
+    throw error;
+  });
 }
 
 /**

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -28,7 +28,10 @@ import { getLogger } from "../../logger";
 import type { UserStory } from "../../prd";
 import { runQualityCommand } from "../../quality";
 import type { ReviewCheckResult } from "../../review/types";
-import { buildProgressivePromptPreamble, runSharedRectificationLoop } from "../../verification/shared-rectification-loop";
+import {
+  buildProgressivePromptPreamble,
+  runSharedRectificationLoop,
+} from "../../verification/shared-rectification-loop";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -19,8 +19,8 @@ import {
   type RectificationState,
   executeWithTimeout as _executeWithTimeout,
   parseBunTestOutput as _parseBunTestOutput,
-  runSharedRectificationLoop,
   shouldRetryRectification as _shouldRetryRectification,
+  runSharedRectificationLoop,
 } from "../verification";
 import { cleanupProcessTree } from "./cleanup";
 import { verifyImplementerIsolation } from "./isolation";

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -19,6 +19,7 @@ import {
   type RectificationState,
   executeWithTimeout as _executeWithTimeout,
   parseBunTestOutput as _parseBunTestOutput,
+  runSharedRectificationLoop,
   shouldRetryRectification as _shouldRetryRectification,
 } from "../verification";
 import { cleanupProcessTree } from "./cleanup";
@@ -154,111 +155,131 @@ async function runRectificationLoop(
     sessionName: rectificationSessionName,
   });
 
-  while (_rectificationGateDeps.shouldRetryRectification(rectificationState, rectificationConfig)) {
-    rectificationState.attempt++;
+  const loopState = {
+    ...rectificationState,
+    isolationPassed: true,
+  };
 
-    const isLastAttempt = rectificationState.attempt >= rectificationConfig.maxRetries;
-
-    logger.info(
-      "tdd",
-      `-> Implementer rectification attempt ${rectificationState.attempt}/${rectificationConfig.maxRetries}`,
-      { storyId: story.id, currentFailures: rectificationState.currentFailures },
-    );
-
-    const rectificationPrompt = buildImplementerRectificationPrompt(
-      testSummary.failures,
-      story,
-      contextMarkdown,
-      rectificationConfig,
-    );
-
-    const rectifyBeforeRef = (await captureGitRef(workdir)) ?? "HEAD";
-
-    const rectifyResult = await agent.run({
-      prompt: rectificationPrompt,
-      workdir,
-      modelTier: implementerTier,
-      modelDef: resolveModelForAgent(
-        config.models,
-        story.routing?.agent ?? config.autoMode.defaultAgent,
-        implementerTier,
-        config.autoMode.defaultAgent,
-      ),
-      timeoutSeconds: config.execution.sessionTimeoutSeconds,
-      dangerouslySkipPermissions: resolvePermissions(config, "rectification").skipPermissions,
-      pipelineStage: "rectification",
-      config,
-      maxInteractionTurns: config.agent?.maxInteractionTurns,
-      featureName,
+  const fixed = await runSharedRectificationLoop({
+    stage: "tdd",
+    storyId: story.id,
+    maxAttempts: rectificationConfig.maxRetries,
+    state: loopState,
+    logger,
+    startMessage: "Full suite gate detected regressions",
+    startData: {
       storyId: story.id,
-      sessionRole: "implementer",
-      // Reuse the same ACP session across all rectification attempts so the agent
-      // retains full conversation context (knows what it already tried).
-      acpSessionName: rectificationSessionName,
-      // Keep session open until the last attempt — the session sweep at run end
-      // will handle cleanup. On the last attempt, let the adapter close normally.
-      keepSessionOpen: !isLastAttempt,
-    });
-
-    if (!rectifyResult.success && rectifyResult.pid) {
-      await cleanupProcessTree(rectifyResult.pid);
-    }
-
-    if (rectifyResult.success) {
-      logger.info("tdd", "Rectification agent session complete", {
-        storyId: story.id,
-        attempt: rectificationState.attempt,
-        cost: rectifyResult.estimatedCost,
-      });
-    } else {
-      logger.warn("tdd", "Rectification agent session failed", {
-        storyId: story.id,
-        attempt: rectificationState.attempt,
-        exitCode: rectifyResult.exitCode,
-      });
-    }
-
-    // BUG-063: Auto-commit after rectification agent — prevents uncommitted changes
-    // from leaking into verifier/review stages. Same pattern as session-runner.ts.
-    await autoCommitIfDirty(workdir, "tdd", "rectification", story.id);
-
-    const rectifyIsolation = lite ? undefined : await verifyImplementerIsolation(workdir, rectifyBeforeRef);
-
-    if (rectifyIsolation && !rectifyIsolation.passed) {
-      logger.error("tdd", "Rectification violated isolation", {
-        storyId: story.id,
-        attempt: rectificationState.attempt,
-        violations: rectifyIsolation.violations,
-      });
-      break;
-    }
-
-    const retryFullSuite = await _rectificationGateDeps.executeWithTimeout(testCmd, fullSuiteTimeout, undefined, {
-      cwd: workdir,
-    });
-    const retrySuitePassed = retryFullSuite.success && retryFullSuite.exitCode === 0;
-
-    if (retrySuitePassed) {
-      logger.info("tdd", "Full suite gate passed after rectification!", {
-        storyId: story.id,
-        attempt: rectificationState.attempt,
-      });
-      return true;
-    }
-
-    if (retryFullSuite.output) {
-      const newTestSummary = _rectificationGateDeps.parseBunTestOutput(retryFullSuite.output);
-      rectificationState.currentFailures = newTestSummary.failed;
-      testSummary.failures = newTestSummary.failures;
-      testSummary.failed = newTestSummary.failed;
-      testSummary.passed = newTestSummary.passed;
-    }
-
-    logger.warn("tdd", "Full suite still failing after rectification attempt", {
+      failedTests: testSummary.failed,
+      passedTests: testSummary.passed,
+    },
+    attemptMessage: (attempt) => `-> Implementer rectification attempt ${attempt}/${rectificationConfig.maxRetries}`,
+    attemptData: (state) => ({
       storyId: story.id,
-      attempt: rectificationState.attempt,
-      remainingFailures: rectificationState.currentFailures,
-    });
+      currentFailures: state.currentFailures,
+    }),
+    canContinue: (state) =>
+      state.isolationPassed && _rectificationGateDeps.shouldRetryRectification(state, rectificationConfig),
+    buildPrompt: () =>
+      buildImplementerRectificationPrompt(testSummary.failures, story, contextMarkdown, rectificationConfig),
+    runAttempt: async (attempt, rectificationPrompt) => {
+      const isLastAttempt = attempt >= rectificationConfig.maxRetries;
+      const rectifyBeforeRef = (await captureGitRef(workdir)) ?? "HEAD";
+
+      const rectifyResult = await agent.run({
+        prompt: rectificationPrompt,
+        workdir,
+        modelTier: implementerTier,
+        modelDef: resolveModelForAgent(
+          config.models,
+          story.routing?.agent ?? config.autoMode.defaultAgent,
+          implementerTier,
+          config.autoMode.defaultAgent,
+        ),
+        timeoutSeconds: config.execution.sessionTimeoutSeconds,
+        dangerouslySkipPermissions: resolvePermissions(config, "rectification").skipPermissions,
+        pipelineStage: "rectification",
+        config,
+        maxInteractionTurns: config.agent?.maxInteractionTurns,
+        featureName,
+        storyId: story.id,
+        sessionRole: "implementer",
+        acpSessionName: rectificationSessionName,
+        keepSessionOpen: !isLastAttempt,
+      });
+
+      if (!rectifyResult.success && rectifyResult.pid) {
+        await cleanupProcessTree(rectifyResult.pid);
+      }
+
+      if (rectifyResult.success) {
+        logger.info("tdd", "Rectification agent session complete", {
+          storyId: story.id,
+          attempt,
+          cost: rectifyResult.estimatedCost,
+        });
+      } else {
+        logger.warn("tdd", "Rectification agent session failed", {
+          storyId: story.id,
+          attempt,
+          exitCode: rectifyResult.exitCode,
+        });
+      }
+
+      await autoCommitIfDirty(workdir, "tdd", "rectification", story.id);
+
+      const rectifyIsolation = lite ? undefined : await verifyImplementerIsolation(workdir, rectifyBeforeRef);
+      if (rectifyIsolation && !rectifyIsolation.passed) {
+        loopState.isolationPassed = false;
+        logger.error("tdd", "Rectification violated isolation", {
+          storyId: story.id,
+          attempt,
+          violations: rectifyIsolation.violations,
+        });
+      }
+    },
+    checkResult: async (attempt, state) => {
+      if (!state.isolationPassed) {
+        return false;
+      }
+
+      const retryFullSuite = await _rectificationGateDeps.executeWithTimeout(testCmd, fullSuiteTimeout, undefined, {
+        cwd: workdir,
+      });
+      const retrySuitePassed = retryFullSuite.success && retryFullSuite.exitCode === 0;
+
+      if (retrySuitePassed) {
+        logger.info("tdd", "Full suite gate passed after rectification!", {
+          storyId: story.id,
+          attempt,
+        });
+        return true;
+      }
+
+      if (retryFullSuite.output) {
+        const newTestSummary = _rectificationGateDeps.parseBunTestOutput(retryFullSuite.output);
+        state.currentFailures = newTestSummary.failed;
+        testSummary.failures = newTestSummary.failures;
+        testSummary.failed = newTestSummary.failed;
+        testSummary.passed = newTestSummary.passed;
+      }
+
+      return false;
+    },
+    onAttemptFailure: (attempt, state) => {
+      if (!state.isolationPassed) {
+        return;
+      }
+
+      logger.warn("tdd", "Full suite still failing after rectification attempt", {
+        storyId: story.id,
+        attempt,
+        remainingFailures: state.currentFailures,
+      });
+    },
+  });
+
+  if (fixed) {
+    return true;
   }
 
   const finalFullSuite = await _rectificationGateDeps.executeWithTimeout(testCmd, fullSuiteTimeout, undefined, {

--- a/src/verification/index.ts
+++ b/src/verification/index.ts
@@ -10,3 +10,4 @@ export * from "./executor";
 export * from "./parser";
 export * from "./runners";
 export * from "./rectification";
+export * from "./shared-rectification-loop";

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -340,7 +340,12 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
         return false;
       }
 
-      const escalatedModelDef = resolveModelForAgent(config.models, agentName, escalatedTier, config.autoMode.defaultAgent);
+      const escalatedModelDef = resolveModelForAgent(
+        config.models,
+        agentName,
+        escalatedTier,
+        config.autoMode.defaultAgent,
+      );
       let escalationPrompt = createEscalatedRectificationPrompt(
         testSummary.failures,
         story,

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -29,6 +29,7 @@ import {
   shouldRetryRectification,
 } from "./rectification";
 import { fullSuite as _fullSuite } from "./runners";
+import { runSharedRectificationLoop } from "./shared-rectification-loop";
 
 export interface RectificationLoopOptions {
   config: NaxConfig;
@@ -131,218 +132,226 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
     lastExitCode: 1, // Assume failure since we entered the loop
   };
 
-  logger?.info("rectification", `Starting ${label} loop`, {
+  return runSharedRectificationLoop({
+    stage: "rectification",
     storyId: story.id,
-    initialFailures: rectificationState.initialFailures,
-    maxRetries: rectificationConfig.maxRetries,
-  });
-
-  while (shouldRetryRectification(rectificationState, rectificationConfig)) {
-    rectificationState.attempt++;
-
-    logger?.info("rectification", `${label} attempt ${rectificationState.attempt}/${rectificationConfig.maxRetries}`, {
+    maxAttempts: rectificationConfig.maxRetries,
+    state: rectificationState,
+    logger,
+    startMessage: `Starting ${label} loop`,
+    startData: {
+      storyId: story.id,
+      initialFailures: rectificationState.initialFailures,
+      maxRetries: rectificationConfig.maxRetries,
+    },
+    attemptMessage: (attempt) => `${label} attempt ${attempt}/${rectificationConfig.maxRetries}`,
+    attemptData: () => ({
       storyId: story.id,
       currentFailures: rectificationState.currentFailures,
-    });
-
-    // Debate-based root cause diagnosis (when enabled)
-    let diagnosisPrefix: string | null = null;
-    const debateStageConfig = config.debate?.stages?.rectification;
-    if (debateStageConfig?.enabled) {
-      const failureSummary = formatFailureSummary(testSummary.failures);
-      const diagnosisPrompt = `Analyze the following test failures and identify the root cause:\n\n${failureSummary}`;
-      try {
-        const debateResult = await _rectificationDeps.runDebate(story.id, debateStageConfig, diagnosisPrompt, config);
-        if (debateResult.totalCostUsd > 0 && story.routing) {
-          story.routing.estimatedCost = (story.routing.estimatedCost ?? 0) + debateResult.totalCostUsd;
-        }
-        if (debateResult.output !== null) {
-          diagnosisPrefix = `## Root Cause Analysis\n\n${debateResult.output}`;
-        } else {
-          logger?.info("rectification", "debate diagnosis fallback — all debaters failed", {
+    }),
+    canContinue: (state) => shouldRetryRectification(state, rectificationConfig),
+    buildPrompt: async (attempt) => {
+      let diagnosisPrefix: string | null = null;
+      const debateStageConfig = config.debate?.stages?.rectification;
+      if (debateStageConfig?.enabled) {
+        const failureSummary = formatFailureSummary(testSummary.failures);
+        const diagnosisPrompt = `Analyze the following test failures and identify the root cause:\n\n${failureSummary}`;
+        try {
+          const debateResult = await _rectificationDeps.runDebate(story.id, debateStageConfig, diagnosisPrompt, config);
+          if (debateResult.totalCostUsd > 0 && story.routing) {
+            story.routing.estimatedCost = (story.routing.estimatedCost ?? 0) + debateResult.totalCostUsd;
+          }
+          if (debateResult.output !== null) {
+            diagnosisPrefix = `## Root Cause Analysis\n\n${debateResult.output}`;
+          } else {
+            logger?.info("rectification", "debate diagnosis fallback — all debaters failed", {
+              storyId: story.id,
+              attempt,
+              event: "fallback",
+            });
+          }
+        } catch (_error) {
+          logger?.info("rectification", "debate diagnosis fallback — debate threw error", {
             storyId: story.id,
-            attempt: rectificationState.attempt,
+            attempt,
             event: "fallback",
           });
         }
-      } catch (err) {
-        logger?.info("rectification", "debate diagnosis fallback — debate threw error", {
+      }
+
+      let rectificationPrompt = createRectificationPrompt(testSummary.failures, story, rectificationConfig, attempt);
+      if (diagnosisPrefix) {
+        rectificationPrompt = `${diagnosisPrefix}\n\n${rectificationPrompt}`;
+      }
+      if (promptPrefix) {
+        rectificationPrompt = `${promptPrefix}\n\n${rectificationPrompt}`;
+      }
+      return rectificationPrompt;
+    },
+    runAttempt: async (attempt, rectificationPrompt) => {
+      const agent = agentGetFn
+        ? agentGetFn(config.autoMode.defaultAgent)
+        : _rectificationDeps.getAgent(config.autoMode.defaultAgent, config);
+      if (!agent) {
+        logger?.error("rectification", "Agent not found, cannot retry");
+        throw new Error("RECTIFICATION_AGENT_NOT_FOUND");
+      }
+
+      const complexity = story.routing?.complexity ?? "medium";
+      const modelTier =
+        config.autoMode.complexityRouting?.[complexity] || config.autoMode.escalation.tierOrder[0]?.tier || "balanced";
+      const modelDef = resolveModelForAgent(
+        config.models,
+        story.routing?.agent ?? config.autoMode.defaultAgent,
+        modelTier,
+        config.autoMode.defaultAgent,
+      );
+
+      const agentResult = await agent.run({
+        prompt: rectificationPrompt,
+        workdir,
+        modelTier,
+        modelDef,
+        timeoutSeconds: config.execution.sessionTimeoutSeconds,
+        dangerouslySkipPermissions: resolvePermissions(config, "rectification").skipPermissions,
+        pipelineStage: "rectification",
+        config,
+        maxInteractionTurns: config.agent?.maxInteractionTurns,
+        featureName,
+        storyId: story.id,
+        sessionRole: "implementer",
+      });
+
+      if (agentResult.success) {
+        logger?.info("rectification", `Agent ${label} session complete`, {
           storyId: story.id,
-          attempt: rectificationState.attempt,
-          event: "fallback",
+          attempt,
+          cost: agentResult.estimatedCost,
+        });
+      } else {
+        logger?.warn("rectification", `Agent ${label} session failed`, {
+          storyId: story.id,
+          attempt,
+          exitCode: agentResult.exitCode,
         });
       }
-    }
-
-    let rectificationPrompt = createRectificationPrompt(
-      testSummary.failures,
-      story,
-      rectificationConfig,
-      rectificationState.attempt,
-    );
-    if (diagnosisPrefix) rectificationPrompt = `${diagnosisPrefix}\n\n${rectificationPrompt}`;
-    if (promptPrefix) rectificationPrompt = `${promptPrefix}\n\n${rectificationPrompt}`;
-
-    const agent = agentGetFn
-      ? agentGetFn(config.autoMode.defaultAgent)
-      : _rectificationDeps.getAgent(config.autoMode.defaultAgent, config);
-    if (!agent) {
-      logger?.error("rectification", "Agent not found, cannot retry");
-      break;
-    }
-
-    // story.routing.modelTier is not persisted (derived at runtime) — derive tier from
-    // persisted complexity via complexityRouting instead of falling back to tierOrder[0] (fast/haiku).
-    const complexity = story.routing?.complexity ?? "medium";
-    const modelTier =
-      config.autoMode.complexityRouting?.[complexity] || config.autoMode.escalation.tierOrder[0]?.tier || "balanced";
-    const modelDef = resolveModelForAgent(
-      config.models,
-      story.routing?.agent ?? config.autoMode.defaultAgent,
-      modelTier,
-      config.autoMode.defaultAgent,
-    );
-
-    const agentResult = await agent.run({
-      prompt: rectificationPrompt,
-      workdir,
-      modelTier,
-      modelDef,
-      timeoutSeconds: config.execution.sessionTimeoutSeconds,
-      dangerouslySkipPermissions: resolvePermissions(config, "rectification").skipPermissions,
-      pipelineStage: "rectification",
-      config,
-      maxInteractionTurns: config.agent?.maxInteractionTurns,
-      featureName,
-      storyId: story.id,
-      sessionRole: "implementer",
-    });
-
-    if (agentResult.success) {
-      logger?.info("rectification", `Agent ${label} session complete`, {
-        storyId: story.id,
-        attempt: rectificationState.attempt,
-        cost: agentResult.estimatedCost,
+    },
+    checkResult: async (attempt, state) => {
+      const retryVerification = await _rectificationDeps.runVerification({
+        workdir,
+        expectedFiles: getExpectedFiles(story),
+        command: testCommand,
+        timeoutSeconds,
+        forceExit: config.quality.forceExit,
+        detectOpenHandles: config.quality.detectOpenHandles,
+        detectOpenHandlesRetries: config.quality.detectOpenHandlesRetries,
+        timeoutRetryCount: 0,
+        gracePeriodMs: config.quality.gracePeriodMs,
+        drainTimeoutMs: config.quality.drainTimeoutMs,
+        shell: config.quality.shell,
+        stripEnvVars: config.quality.stripEnvVars,
       });
-    } else {
-      logger?.warn("rectification", `Agent ${label} session failed`, {
-        storyId: story.id,
-        attempt: rectificationState.attempt,
-        exitCode: agentResult.exitCode,
-      });
-    }
 
-    const retryVerification = await _rectificationDeps.runVerification({
-      workdir,
-      expectedFiles: getExpectedFiles(story),
-      command: testCommand,
-      timeoutSeconds,
-      forceExit: config.quality.forceExit,
-      detectOpenHandles: config.quality.detectOpenHandles,
-      detectOpenHandlesRetries: config.quality.detectOpenHandlesRetries,
-      timeoutRetryCount: 0,
-      gracePeriodMs: config.quality.gracePeriodMs,
-      drainTimeoutMs: config.quality.drainTimeoutMs,
-      shell: config.quality.shell,
-      stripEnvVars: config.quality.stripEnvVars,
-    });
-
-    if (retryVerification.success) {
-      logger?.info("rectification", `[OK] ${label} succeeded!`, {
-        storyId: story.id,
-        attempt: rectificationState.attempt,
-        initialFailures: rectificationState.initialFailures,
-      });
-      return true;
-    }
-
-    if (retryVerification.output) {
-      const newTestSummary = parseBunTestOutput(retryVerification.output);
-      rectificationState.currentFailures = newTestSummary.failed;
-      rectificationState.lastExitCode = retryVerification.status === "SUCCESS" ? 0 : 1; // Basic mapping
-      testSummary.failures = newTestSummary.failures;
-      testSummary.failed = newTestSummary.failed;
-      testSummary.passed = newTestSummary.passed;
-
-      if (newTestSummary.failed === 0) {
-        rectificationState.lastExitCode = 0;
-        logger?.info("rectification", `[OK] ${label} succeeded after parsing retry output`, {
+      if (retryVerification.success) {
+        logger?.info("rectification", `[OK] ${label} succeeded!`, {
           storyId: story.id,
-          attempt: rectificationState.attempt,
-          initialFailures: rectificationState.initialFailures,
+          attempt,
+          initialFailures: state.initialFailures,
         });
         return true;
       }
-    }
 
-    const failingTests = testSummary.failures.slice(0, 10).map((f) => f.testName);
-    const logData: Record<string, unknown> = {
-      storyId: story.id,
-      attempt: rectificationState.attempt,
-      remainingFailures: rectificationState.currentFailures,
-      failingTests,
-    };
+      if (retryVerification.output) {
+        const newTestSummary = parseBunTestOutput(retryVerification.output);
+        state.currentFailures = newTestSummary.failed;
+        state.lastExitCode = retryVerification.status === "SUCCESS" ? 0 : 1;
+        testSummary.failures = newTestSummary.failures;
+        testSummary.failed = newTestSummary.failed;
+        testSummary.passed = newTestSummary.passed;
 
-    // Include totalFailingTests if we have more than 10 structured failures
-    // OR if no structured failures exist but there are still failures reported
-    if (testSummary.failures.length > 10 || (testSummary.failures.length === 0 && testSummary.failed > 0)) {
-      logData.totalFailingTests = testSummary.failed;
-    }
+        if (newTestSummary.failed === 0) {
+          state.lastExitCode = 0;
+          logger?.info("rectification", `[OK] ${label} succeeded after parsing retry output`, {
+            storyId: story.id,
+            attempt,
+            initialFailures: state.initialFailures,
+          });
+          return true;
+        }
+      }
 
-    logger?.warn("rectification", `${label} still failing after attempt`, logData);
-  }
+      return false;
+    },
+    onAttemptFailure: (attempt, state) => {
+      const failingTests = testSummary.failures.slice(0, 10).map((failure) => failure.testName);
+      const logData: Record<string, unknown> = {
+        storyId: story.id,
+        attempt,
+        remainingFailures: state.currentFailures,
+        failingTests,
+      };
 
-  if (rectificationState.attempt >= rectificationConfig.maxRetries) {
-    logger?.warn("rectification", `${label} exhausted max retries`, {
-      storyId: story.id,
-      attempts: rectificationState.attempt,
-      remainingFailures: rectificationState.currentFailures,
-    });
-  } else if (rectificationState.currentFailures > rectificationState.initialFailures) {
-    logger?.warn("rectification", `${label} aborted due to further regression`, {
-      storyId: story.id,
-      initialFailures: rectificationState.initialFailures,
-      currentFailures: rectificationState.currentFailures,
-    });
-  }
+      if (testSummary.failures.length > 10 || (testSummary.failures.length === 0 && testSummary.failed > 0)) {
+        logData.totalFailingTests = testSummary.failed;
+      }
 
-  const shouldEscalate =
-    rectificationConfig.escalateOnExhaustion !== false &&
-    config.autoMode?.escalation?.enabled === true &&
-    rectificationState.attempt >= rectificationConfig.maxRetries &&
-    rectificationState.currentFailures > 0;
+      logger?.warn("rectification", `${label} still failing after attempt`, logData);
+    },
+    onLoopEnd: (state) => {
+      if (state.attempt >= rectificationConfig.maxRetries) {
+        logger?.warn("rectification", `${label} exhausted max retries`, {
+          storyId: story.id,
+          attempts: state.attempt,
+          remainingFailures: state.currentFailures,
+        });
+      } else if (state.currentFailures > state.initialFailures) {
+        logger?.warn("rectification", `${label} aborted due to further regression`, {
+          storyId: story.id,
+          initialFailures: state.initialFailures,
+          currentFailures: state.currentFailures,
+        });
+      }
+    },
+    onExhausted: async (state) => {
+      const shouldEscalate =
+        rectificationConfig.escalateOnExhaustion !== false &&
+        config.autoMode?.escalation?.enabled === true &&
+        state.currentFailures > 0;
 
-  if (shouldEscalate) {
-    const complexity = story.routing?.complexity ?? "medium";
-    const currentTier =
-      config.autoMode.complexityRouting?.[complexity] || config.autoMode.escalation.tierOrder[0]?.tier || "balanced";
-    const tierOrder = config.autoMode.escalation.tierOrder;
-    const escalationResult = _rectificationDeps.escalateTier(currentTier, tierOrder);
-    const escalatedTier = escalationResult?.tier ?? null;
-    const escalatedAgent = escalationResult?.agent;
+      if (!shouldEscalate) {
+        return false;
+      }
 
-    if (escalatedTier !== null) {
+      const complexity = story.routing?.complexity ?? "medium";
+      const currentTier =
+        config.autoMode.complexityRouting?.[complexity] || config.autoMode.escalation.tierOrder[0]?.tier || "balanced";
+      const tierOrder = config.autoMode.escalation.tierOrder;
+      const escalationResult = _rectificationDeps.escalateTier(currentTier, tierOrder);
+      const escalatedTier = escalationResult?.tier ?? null;
+      const escalatedAgent = escalationResult?.agent;
+
+      if (escalatedTier === null) {
+        return false;
+      }
+
       const agentName = escalatedAgent ?? story.routing?.agent ?? config.autoMode.defaultAgent;
       const agent = agentGetFn ? agentGetFn(agentName) : _rectificationDeps.getAgent(agentName, config);
       if (!agent) {
         return false;
       }
 
-      const escalatedModelDef = resolveModelForAgent(
-        config.models,
-        agentName,
-        escalatedTier,
-        config.autoMode.defaultAgent,
-      );
+      const escalatedModelDef = resolveModelForAgent(config.models, agentName, escalatedTier, config.autoMode.defaultAgent);
       let escalationPrompt = createEscalatedRectificationPrompt(
         testSummary.failures,
         story,
-        rectificationState.attempt,
+        state.attempt,
         currentTier,
         escalatedTier,
         rectificationConfig,
       );
-      if (promptPrefix) escalationPrompt = `${promptPrefix}\n\n${escalationPrompt}`;
+      if (promptPrefix) {
+        escalationPrompt = `${promptPrefix}\n\n${escalationPrompt}`;
+      }
 
       const escalationRunResult = await agent.run({
         prompt: escalationPrompt,
@@ -390,8 +399,12 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
       }
 
       logger?.warn("rectification", "escalated rectification also failed", { storyId: story.id, escalatedTier });
+      return false;
+    },
+  }).catch((error: unknown) => {
+    if (error instanceof Error && error.message === "RECTIFICATION_AGENT_NOT_FOUND") {
+      return false;
     }
-  }
-
-  return false;
+    throw error;
+  });
 }

--- a/src/verification/rectification.ts
+++ b/src/verification/rectification.ts
@@ -9,6 +9,7 @@ import type { RectificationConfig } from "../config";
 import { getSafeLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { formatFailureSummary } from "./parser";
+import { buildProgressivePromptPreamble } from "./shared-rectification-loop";
 import type { RectificationState, TestFailure } from "./types";
 
 /**
@@ -63,31 +64,14 @@ export function shouldRetryRectification(state: RectificationState, config: Rect
  * Returns an empty string when no injection is needed.
  */
 function buildEscalationPreamble(attempt: number, config: RectificationConfig): string {
-  const logger = getSafeLogger();
-  const rethinkAt = Math.min(config.rethinkAtAttempt ?? 2, config.maxRetries);
-  const urgencyAt = Math.min(config.urgencyAtAttempt ?? 3, config.maxRetries);
-
-  if (attempt < rethinkAt) return "";
-
-  const isUrgent = attempt >= urgencyAt;
-
-  // Log progressive prompt escalation (#147)
-  if (isUrgent) {
-    logger?.info("rectification", "Progressive prompt escalation: urgency + rethink injected", {
-      attempt,
-      urgencyAtAttempt: urgencyAt,
-      rethinkAtAttempt: rethinkAt,
-      maxRetries: config.maxRetries,
-    });
-  } else {
-    logger?.info("rectification", "Progressive prompt escalation: rethink injected", {
-      attempt,
-      rethinkAtAttempt: rethinkAt,
-      maxRetries: config.maxRetries,
-    });
-  }
-
-  const rethinkSection = `## ⚠️ Previous Attempt Did Not Fix the Failures
+  return buildProgressivePromptPreamble({
+    attempt,
+    maxAttempts: config.maxRetries,
+    rethinkAtAttempt: config.rethinkAtAttempt,
+    urgencyAtAttempt: config.urgencyAtAttempt,
+    stage: "rectification",
+    logger: getSafeLogger(),
+    rethinkSection: `## ⚠️ Previous Attempt Did Not Fix the Failures
 
 Your previous fix attempt (attempt ${attempt}) did not resolve all failures. **Step back and reconsider your approach.**
 
@@ -96,18 +80,14 @@ Your previous fix attempt (attempt ${attempt}) did not resolve all failures. **S
 - Re-read the story context and test failures carefully before making changes.
 - Consider: are there missing edge cases, incorrect assumptions, or a design flaw in the implementation?
 
-`;
-
-  const urgencySection = isUrgent
-    ? `## 🚨 Final Rectification Attempt Before Model Escalation
+`,
+    urgencySection: `## 🚨 Final Rectification Attempt Before Model Escalation
 
 This is attempt ${attempt} — if the tests still fail after this, the task will escalate to a stronger model tier.
 A **completely different approach** is required. Do not repeat what you have already tried.
 
-`
-    : "";
-
-  return `${urgencySection}${rethinkSection}`;
+`,
+  });
 }
 
 /**

--- a/src/verification/shared-rectification-loop.ts
+++ b/src/verification/shared-rectification-loop.ts
@@ -33,7 +33,10 @@ export interface SharedRectificationLoopOptions<State extends { attempt: number 
   onExhausted?: (state: State) => Promise<boolean> | boolean;
 }
 
-function resolveLogData<State>(data: LoopLogData<State> | undefined, state: State): Record<string, unknown> | undefined {
+function resolveLogData<State>(
+  data: LoopLogData<State> | undefined,
+  state: State,
+): Record<string, unknown> | undefined {
   if (!data) {
     return undefined;
   }

--- a/src/verification/shared-rectification-loop.ts
+++ b/src/verification/shared-rectification-loop.ts
@@ -1,0 +1,105 @@
+import type { StoryLogger } from "../logger/types";
+
+type LoopLogger = Pick<StoryLogger, "debug" | "error" | "info" | "warn"> | null;
+type LoopLogData<State> = Record<string, unknown> | ((state: State) => Record<string, unknown>);
+
+export interface ProgressivePromptPreambleOptions {
+  attempt: number;
+  maxAttempts: number;
+  rethinkAtAttempt?: number;
+  urgencyAtAttempt?: number;
+  stage: string;
+  logger?: LoopLogger;
+  rethinkSection: string;
+  urgencySection: string;
+}
+
+export interface SharedRectificationLoopOptions<State extends { attempt: number }> {
+  stage: string;
+  storyId: string;
+  maxAttempts: number;
+  state: State;
+  logger?: LoopLogger;
+  startMessage: string;
+  startData?: LoopLogData<State>;
+  attemptMessage: (attempt: number, maxAttempts: number, state: State) => string;
+  attemptData?: LoopLogData<State>;
+  canContinue: (state: State) => boolean;
+  buildPrompt: (attempt: number, state: State) => Promise<string> | string;
+  runAttempt: (attempt: number, prompt: string, state: State) => Promise<void>;
+  checkResult: (attempt: number, state: State) => Promise<boolean>;
+  onAttemptFailure?: (attempt: number, state: State) => Promise<void> | void;
+  onLoopEnd?: (state: State) => Promise<void> | void;
+  onExhausted?: (state: State) => Promise<boolean> | boolean;
+}
+
+function resolveLogData<State>(data: LoopLogData<State> | undefined, state: State): Record<string, unknown> | undefined {
+  if (!data) {
+    return undefined;
+  }
+  return typeof data === "function" ? data(state) : data;
+}
+
+export function buildProgressivePromptPreamble(opts: ProgressivePromptPreambleOptions): string {
+  const rethinkAt = Math.min(opts.rethinkAtAttempt ?? 2, opts.maxAttempts);
+  const urgencyAt = Math.min(opts.urgencyAtAttempt ?? 3, opts.maxAttempts);
+  const shouldRethink = opts.attempt >= rethinkAt;
+  const shouldUrgency = opts.attempt >= urgencyAt;
+
+  if (!shouldRethink && !shouldUrgency) {
+    return "";
+  }
+
+  if (shouldUrgency) {
+    opts.logger?.info(opts.stage, "Progressive prompt escalation: urgency + rethink injected", {
+      attempt: opts.attempt,
+      rethinkAtAttempt: rethinkAt,
+      urgencyAtAttempt: urgencyAt,
+      maxAttempts: opts.maxAttempts,
+    });
+  } else {
+    opts.logger?.info(opts.stage, "Progressive prompt escalation: rethink injected", {
+      attempt: opts.attempt,
+      rethinkAtAttempt: rethinkAt,
+      maxAttempts: opts.maxAttempts,
+    });
+  }
+
+  const urgencySection = shouldUrgency ? opts.urgencySection : "";
+  const rethinkSection = shouldRethink ? opts.rethinkSection : "";
+  return `${urgencySection}${rethinkSection}`;
+}
+
+export async function runSharedRectificationLoop<State extends { attempt: number }>(
+  opts: SharedRectificationLoopOptions<State>,
+): Promise<boolean> {
+  opts.logger?.info(opts.stage, opts.startMessage, resolveLogData(opts.startData, opts.state));
+
+  while (opts.canContinue(opts.state)) {
+    opts.state.attempt++;
+
+    opts.logger?.info(
+      opts.stage,
+      opts.attemptMessage(opts.state.attempt, opts.maxAttempts, opts.state),
+      resolveLogData(opts.attemptData, opts.state),
+    );
+
+    const prompt = await opts.buildPrompt(opts.state.attempt, opts.state);
+    await opts.runAttempt(opts.state.attempt, prompt, opts.state);
+
+    const passed = await opts.checkResult(opts.state.attempt, opts.state);
+    if (passed) {
+      return true;
+    }
+
+    await opts.onAttemptFailure?.(opts.state.attempt, opts.state);
+  }
+
+  await opts.onLoopEnd?.(opts.state);
+
+  if (opts.state.attempt >= opts.maxAttempts) {
+    return (await opts.onExhausted?.(opts.state)) ?? false;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## What

Extracts a shared `RectificationLoop` utility and moves the repeated retry orchestration into it.

This refactor now routes all three rectification-style flows through the shared loop:

- verify-stage rectification
- review-stage autofix agent rectification
- TDD full-suite rectification gate

It also centralizes the progressive prompt preamble builder used by rectification and autofix.

## Why

This addresses #177 by removing duplicated attempt-loop logic while preserving each caller's stage-specific behavior.

The shared utility keeps the common control flow in one place, while each caller still owns its own prompt content, verification checks, escalation behavior, ACP session reuse, and budget handling.

## Impact

There is no intended user-facing behavior change.

The main benefit is lower maintenance cost:

- future retry-loop changes only need to be implemented once
- autofix, rectification, and TDD rectification now stay aligned more easily
- progressive prompt escalation behavior is shared instead of reimplemented

## Validation

- `bun run typecheck`
- `bun test test/unit/tdd/rectification-gate-session.test.ts --timeout=30000`
- `bun test test/unit/verification/rectification-loop.test.ts --timeout=30000`
- `bun test test/unit/pipeline/stages/autofix.test.ts --timeout=30000`

Closes #177
