### PR TITLE
fix(lifecycle): unify run lifecycle ownership via event bus

### DIFF
--- a/src/execution/lifecycle/run-cleanup.ts
+++ b/src/execution/lifecycle/run-cleanup.ts
@@ -32,6 +32,13 @@ export interface RunCleanupOptions {
   prdPath: string;
   branch: string;
   version: string;
+  /**
+   * True when run:completed was already emitted (success path).
+   * When true, skip the direct onRunEnd call — the reporters.ts subscriber
+   * handles it via the event. Only fire directly for abnormal exits where
+   * run:completed was never emitted.
+   */
+  runCompleted?: boolean;
 }
 
 /**
@@ -69,27 +76,33 @@ export async function cleanupRun(options: RunCleanupOptions): Promise<void> {
   const logger = getSafeLogger();
   const { runId, startTime, totalCost, storiesCompleted, prd, pluginRegistry, workdir, interactionChain } = options;
 
-  // Fire onRunEnd for reporters (even on failure/abort)
   const durationMs = Date.now() - startTime;
-  const finalCounts = countStories(prd);
-  const reporters = pluginRegistry.getReporters();
 
-  for (const reporter of reporters) {
-    if (reporter.onRunEnd) {
-      try {
-        await reporter.onRunEnd({
-          runId,
-          totalDurationMs: durationMs,
-          totalCost,
-          storySummary: {
-            completed: storiesCompleted,
-            failed: finalCounts.failed,
-            skipped: finalCounts.skipped,
-            paused: finalCounts.paused,
-          },
-        });
-      } catch (error) {
-        logger?.warn("plugins", `Reporter '${reporter.name}' onRunEnd failed`, { error });
+  // Fire onRunEnd for reporters only on abnormal exits (failure/abort/SIGTERM).
+  // On the success path, run:completed is emitted by run-completion.ts and the
+  // reporters.ts subscriber handles onRunEnd via the event — so we skip the
+  // direct call to avoid duplicate notifications.
+  if (!options.runCompleted) {
+    const finalCounts = countStories(prd);
+    const reporters = pluginRegistry.getReporters();
+
+    for (const reporter of reporters) {
+      if (reporter.onRunEnd) {
+        try {
+          await reporter.onRunEnd({
+            runId,
+            totalDurationMs: durationMs,
+            totalCost,
+            storySummary: {
+              completed: storiesCompleted,
+              failed: finalCounts.failed,
+              skipped: finalCounts.skipped,
+              paused: finalCounts.paused,
+            },
+          });
+        } catch (error) {
+          logger?.warn("plugins", `Reporter '${reporter.name}' onRunEnd failed`, { error });
+        }
       }
     }
   }

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -173,6 +173,8 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
     totalStories: finalCounts.total,
     passedStories: finalCounts.passed,
     failedStories: finalCounts.failed,
+    skippedStories: finalCounts.skipped,
+    pausedStories: finalCounts.paused,
     durationMs,
     totalCost,
   });

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -17,7 +17,6 @@ import path from "node:path";
 import type { NaxConfig } from "../../config";
 import { LockAcquisitionError } from "../../errors";
 import type { LoadedHooksConfig } from "../../hooks";
-import { fireHook } from "../../hooks";
 import type { InteractionChain } from "../../interaction";
 import { initInteractionChain } from "../../interaction";
 import { getSafeLogger } from "../../logger";
@@ -30,7 +29,7 @@ import { loadPRD } from "../../prd";
 import { detectProjectProfile } from "../../project";
 import { NAX_BUILD_INFO, NAX_COMMIT, NAX_VERSION } from "../../version";
 import { installCrashHandlers } from "../crash-recovery";
-import { acquireLock, hookCtx, releaseLock } from "../helpers";
+import { acquireLock, releaseLock } from "../helpers";
 import { PidRegistry } from "../pid-registry";
 import { StatusWriter } from "../status-writer";
 
@@ -88,7 +87,6 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     prdPath,
     workdir,
     config,
-    hooks,
     feature,
     dryRun,
     statusFile,
@@ -241,8 +239,8 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
       naxCommit: NAX_COMMIT,
     });
 
-    // Fire on-start hook
-    await fireHook(hooks, "on-start", hookCtx(feature), workdir);
+    // on-start hook is now fired by the hooks.ts subscriber via the run:started event
+    // emitted inside executeUnified/executeSequential after bus wiring.
 
     // Initialize run: check agent, reconcile state, validate limits
     const { initializeRun } = await import("./run-initialization");

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -102,22 +102,8 @@ export async function runExecutionPhase(
   options.statusWriter.setCurrentStory(null);
   await options.statusWriter.update(totalCost, iterations);
 
-  // Update reporters with correct totalStories count
-  const reporters = pluginRegistry.getReporters();
-  for (const reporter of reporters) {
-    if (reporter.onRunStart) {
-      try {
-        await reporter.onRunStart({
-          runId: options.runId,
-          feature: options.feature,
-          totalStories: prd.userStories.length,
-          startTime: options.startedAt,
-        });
-      } catch (error) {
-        logger?.warn("plugins", `Reporter '${reporter.name}' onRunStart failed`, { error });
-      }
-    }
-  }
+  // onRunStart is now handled by the reporters.ts subscriber via the run:started event
+  // emitted inside executeUnified/executeSequential after bus wiring.
 
   logger?.info("execution", `Starting ${options.feature}`, {
     totalStories: prd.userStories.length,

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -188,7 +188,11 @@ export async function run(options: RunOptions): Promise<RunResult> {
     totalCost = executionResult.totalCost;
     allStoryMetrics.push(...executionResult.allStoryMetrics);
 
-    // Return early if parallel execution completed everything
+    // Return early if parallel execution completed everything.
+    // NOTE: This path skips runCompletionPhase, so run:completed is never emitted
+    // and runCompleted stays false. cleanupRun will fire onRunEnd directly (correct).
+    // If this path is ever activated, also wire run:completed emission here so
+    // reporter subscribers and the on-complete hook fire consistently.
     if (executionResult.completedEarly && executionResult.durationMs !== undefined) {
       return {
         success: isComplete(prd),

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -110,6 +110,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
   let iterations = 0;
   let storiesCompleted = 0;
   let totalCost = 0;
+  let runCompleted = false;
   // biome-ignore lint/suspicious/noExplicitAny: Metrics array type varies
   const allStoryMetrics: any[] = [];
 
@@ -225,6 +226,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
     });
 
     const { durationMs } = completionResult;
+    runCompleted = true;
 
     return {
       success: isComplete(prd),
@@ -271,6 +273,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
       prdPath,
       branch,
       version: NAX_VERSION,
+      runCompleted,
     });
     logger?.debug("execution", "Runner finally — cleanupRun done, run() returning");
   }

--- a/src/execution/sequential-executor.ts
+++ b/src/execution/sequential-executor.ts
@@ -50,6 +50,15 @@ export async function executeSequential(
   wireEventsWriter(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir);
   wireRegistry(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir);
 
+  // Emit run:started once — subscribers (hooks.ts, reporters.ts) own the fan-out.
+  // Direct fireHook("on-start") and reporter.onRunStart() calls have been removed.
+  pipelineEventBus.emit({
+    type: "run:started",
+    feature: ctx.feature,
+    totalStories: initialPrd.userStories.length,
+    workdir: ctx.workdir,
+  });
+
   const buildResult = (exitReason: SequentialExecutionResult["exitReason"]): SequentialExecutionResult => ({
     prd,
     iterations,

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -52,6 +52,15 @@ export async function executeUnified(
   wireEventsWriter(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir);
   wireRegistry(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir);
 
+  // Emit run:started once — subscribers (hooks.ts, reporters.ts) own the fan-out.
+  // Direct fireHook("on-start") and reporter.onRunStart() calls have been removed.
+  pipelineEventBus.emit({
+    type: "run:started",
+    feature: ctx.feature,
+    totalStories: initialPrd.userStories.length,
+    workdir: ctx.workdir,
+  });
+
   const buildResult = (exitReason: SequentialExecutionResult["exitReason"]): SequentialExecutionResult => ({
     prd,
     iterations,

--- a/src/pipeline/event-bus.ts
+++ b/src/pipeline/event-bus.ts
@@ -102,6 +102,8 @@ export interface RunCompletedEvent {
   totalStories: number;
   passedStories: number;
   failedStories: number;
+  skippedStories: number;
+  pausedStories: number;
   durationMs: number;
   totalCost?: number;
 }

--- a/src/pipeline/subscribers/reporters.ts
+++ b/src/pipeline/subscribers/reporters.ts
@@ -157,8 +157,8 @@ export function wireReporters(
                 storySummary: {
                   completed: ev.passedStories,
                   failed: ev.failedStories,
-                  skipped: 0,
-                  paused: 0,
+                  skipped: ev.skippedStories,
+                  paused: ev.pausedStories,
                 },
               });
             } catch (err) {


### PR DESCRIPTION
## What

Fixes two lifecycle defects caused by the incomplete ADR-005 event-bus migration: `onRunStart`/`on-start` firing via dead-code direct calls, and `onRunEnd` firing twice on the success path.

## Why

Closes #221

The architecture review (2026-04-03) identified that:
- `run:started` was subscribed to in `hooks.ts` and `reporters.ts` but **never emitted** — both subscribers were dead code
- `reporter.onRunEnd()` was called by **two independent paths** on a successful run (event subscriber + direct call in finally block), producing duplicate notifications to reporter plugins

## How

**`run:started` emission** (`unified-executor.ts`, `sequential-executor.ts`):
Emit `run:started` once after the bus is wired in both executors. The existing subscribers in `hooks.ts` (→ `on-start` hook) and `reporters.ts` (→ `reporter.onRunStart()`) now own the fan-out.

**Remove direct calls** (`runner-execution.ts`, `run-setup.ts`):
- Removed the `reporter.onRunStart()` loop from `runner-execution.ts` — it fired before the bus was even wired, so it was bypassing subscribers entirely
- Removed `fireHook("on-start")` from `run-setup.ts` for the same reason; cleaned up the now-unused `fireHook`/`hookCtx` imports

**Guard direct `onRunEnd`** (`run-cleanup.ts`, `runner.ts`):
- Added `runCompleted?: boolean` to `RunCleanupOptions`
- The direct `reporter.onRunEnd()` call in the `finally` block now only runs when `runCompleted === false` (abnormal exits: exceptions, SIGTERM before completion phase)
- `runner.ts` sets `runCompleted = true` after `runCompletionPhase` succeeds and passes it to `cleanupRun`

## Testing

- [x] Tests added/updated
- [x] `bun test` passes (1174 pass, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

This is Phase 1 of the architecture remediation plan from the 2026-04-03 review. Subsequent phases (audit remaining direct calls, per-run bus instantiation, executor consolidation, file decomposition) are tracked separately.

No breaking changes to public APIs. `RunCleanupOptions` gains an optional `runCompleted` field — existing callers that don't pass it default to the previous behavior (direct `onRunEnd` fires, safe fallback).