### PR TITLE
test(config): isolate config-loader tests from real HOME config

### DIFF
--- a/test/integration/config/config-loader.test.ts
+++ b/test/integration/config/config-loader.test.ts
@@ -15,44 +15,34 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { existsSync, renameSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { globalConfigPath, loadConfig } from "../../../src/config/loader";
 import { makeTempDir } from "../../helpers/temp";
 
 describe("Config Loader - Backward Compatibility", () => {
   let tempDir: string;
-  let globalBackup: string | null = null;
+  let globalConfigDirBackup: string | undefined;
 
   beforeEach(() => {
     // Create a temporary test directory
     tempDir = makeTempDir("nax-test-");
     mkdirSync(join(tempDir, ".nax"), { recursive: true });
 
-    // Backup existing global config if present
-    const globalPath = globalConfigPath();
-    if (existsSync(globalPath)) {
-      globalBackup = `${globalPath}.test-backup-${Date.now()}`;
-      renameSync(globalPath, globalBackup);
-    }
+    // Isolate global config to test fixture (never touch real ~/.nax)
+    globalConfigDirBackup = process.env.NAX_GLOBAL_CONFIG_DIR;
+    process.env.NAX_GLOBAL_CONFIG_DIR = join(tempDir, ".nax-global");
   });
 
   afterEach(() => {
-    // Clean up temp directory
+    // Clean up temp directory (includes isolated global config dir)
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
     }
 
-    // Restore global config if we backed it up
-    if (globalBackup && existsSync(globalBackup)) {
-      const globalPath = globalConfigPath();
-      if (existsSync(globalPath)) {
-        rmSync(globalPath);
-      }
-      renameSync(globalBackup, globalPath);
-      globalBackup = null;
+    if (globalConfigDirBackup === undefined) {
+      delete process.env.NAX_GLOBAL_CONFIG_DIR;
+    } else {
+      process.env.NAX_GLOBAL_CONFIG_DIR = globalConfigDirBackup;
     }
   });
 
@@ -131,35 +121,28 @@ describe("Config Loader - Backward Compatibility", () => {
 
 describe("Config Loader - Plugin Configuration (US-007)", () => {
   let tempDir: string;
-  let globalBackup: string | null = null;
+  let globalConfigDirBackup: string | undefined;
 
   beforeEach(() => {
     // Create a temporary test directory
     tempDir = makeTempDir("nax-test-plugins-");
     mkdirSync(join(tempDir, ".nax"), { recursive: true });
 
-    // Backup existing global config if present
-    const globalPath = globalConfigPath();
-    if (existsSync(globalPath)) {
-      globalBackup = `${globalPath}.test-backup-${Date.now()}`;
-      renameSync(globalPath, globalBackup);
-    }
+    // Isolate global config to test fixture (never touch real ~/.nax)
+    globalConfigDirBackup = process.env.NAX_GLOBAL_CONFIG_DIR;
+    process.env.NAX_GLOBAL_CONFIG_DIR = join(tempDir, ".nax-global");
   });
 
   afterEach(() => {
-    // Clean up temp directory
+    // Clean up temp directory (includes isolated global config dir)
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
     }
 
-    // Restore global config if we backed it up
-    if (globalBackup && existsSync(globalBackup)) {
-      const globalPath = globalConfigPath();
-      if (existsSync(globalPath)) {
-        rmSync(globalPath);
-      }
-      renameSync(globalBackup, globalPath);
-      globalBackup = null;
+    if (globalConfigDirBackup === undefined) {
+      delete process.env.NAX_GLOBAL_CONFIG_DIR;
+    } else {
+      process.env.NAX_GLOBAL_CONFIG_DIR = globalConfigDirBackup;
     }
   });
 
@@ -218,7 +201,7 @@ describe("Config Loader - Plugin Configuration (US-007)", () => {
   test("merges plugins[] from global and project config", async () => {
     // Create global config with plugins
     const globalPath = globalConfigPath();
-    mkdirSync(join(homedir(), ".nax"), { recursive: true });
+    mkdirSync(join(tempDir, ".nax-global"), { recursive: true });
     const globalConfig = {
       plugins: [
         {


### PR DESCRIPTION
## What

Isolates `config-loader` integration tests from real user global config (`~/.nax/config.json`).

## Why

The test suite wrote to `globalConfigPath()` using the real HOME path. If a run was interrupted, it could leave stray plugin entries (like `global-plugin`) in the user’s actual global config.

Closes #

## How

- Replaced backup/restore of real global config with test-local isolation using `NAX_GLOBAL_CONFIG_DIR`.
- Scoped both describe blocks to a temp `.nax-global` directory under each test fixture.
- Updated the global plugin merge test to create global config in the isolated temp directory.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- Verified with: `bun test test/integration/config/config-loader.test.ts`
- Commit hook also ran full `tsc --noEmit` and `biome check src/ bin/` successfully.
