### PR TITLE
fix(config): expose acceptance model/refinement settings in config descriptions

### DIFF
--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -155,6 +155,10 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "acceptance.testPath": "Path to acceptance test file (relative to feature dir)",
   "acceptance.command":
     "Override command to run acceptance tests. Use {{FILE}} as placeholder for the test file path (default: 'bun test {{FILE}} --timeout=60000')",
+  "acceptance.model":
+    "Model tier for acceptance generation/refinement LLM calls (fast | balanced | powerful). Default: fast.",
+  "acceptance.refinement":
+    "Enable acceptance criteria refinement step before execution (default: true). Disable to skip refinement and use generated criteria as-is.",
   "acceptance.timeoutMs": "Timeout for acceptance test generation in milliseconds (default: 1800000 = 30 min)",
 
   // Context

--- a/test/unit/acceptance/refinement.test.ts
+++ b/test/unit/acceptance/refinement.test.ts
@@ -320,6 +320,24 @@ describe("refineAcceptanceCriteria — adapter.complete() integration", () => {
     expect(callCount).toBe(1);
   });
 
+  test("uses config.acceptance.model tier to resolve adapter model", async () => {
+    const config = makeConfig({ model: "balanced" });
+    let receivedModel: string | undefined;
+
+    _refineDeps.adapter.complete = mock(async (_prompt, options) => {
+      receivedModel = options?.model;
+      return makeLLMResponse(SAMPLE_CRITERIA, STORY_ID);
+    });
+
+    await refineAcceptanceCriteria(SAMPLE_CRITERIA, {
+      storyId: STORY_ID,
+      codebaseContext: CODEBASE_CONTEXT,
+      config,
+    });
+
+    expect(receivedModel).toBe("claude-sonnet-4-5");
+  });
+
   test("does NOT call Bun.spawn directly — uses adapter.complete()", async () => {
     const config = makeConfig();
     const spawnCalls: unknown[] = [];

--- a/test/unit/cli/acceptance-config-descriptions.test.ts
+++ b/test/unit/cli/acceptance-config-descriptions.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { FIELD_DESCRIPTIONS } from "../../../src/cli/config-descriptions";
+
+describe("FIELD_DESCRIPTIONS acceptance model discoverability (issue #225)", () => {
+  test("acceptance.model description exists and mentions model tiers", () => {
+    const description = FIELD_DESCRIPTIONS["acceptance.model"];
+    expect(typeof description).toBe("string");
+    expect(description.length).toBeGreaterThan(0);
+    expect(description.toLowerCase()).toContain("fast");
+    expect(description.toLowerCase()).toContain("balanced");
+    expect(description.toLowerCase()).toContain("powerful");
+  });
+
+  test("acceptance.refinement description exists and explains behavior", () => {
+    const description = FIELD_DESCRIPTIONS["acceptance.refinement"];
+    expect(typeof description).toBe("string");
+    expect(description.length).toBeGreaterThan(0);
+    expect(description.toLowerCase()).toContain("refinement");
+    expect(description.toLowerCase()).toContain("default");
+  });
+});

--- a/test/unit/pipeline/stages/acceptance-setup.test.ts
+++ b/test/unit/pipeline/stages/acceptance-setup.test.ts
@@ -216,6 +216,31 @@ describe("acceptance-setup: calls refinement and generation", () => {
     // Refined text should be used (prefixed with "R:")
     expect((generateArgs!.refined[0] as any).refined).toStartWith("R:");
   });
+
+  test("passes acceptance.model tier into generator options", async () => {
+    let receivedModelTier: string | undefined;
+
+    _acceptanceSetupDeps.fileExists = async () => false;
+    _acceptanceSetupDeps.readMeta = async () => null;
+    _acceptanceSetupDeps.refine = async (criteria) =>
+      criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: "US-001" }));
+    _acceptanceSetupDeps.generate = async (_stories, _refined, options) => {
+      receivedModelTier = options?.modelTier;
+      return { testCode: 'test("AC-1", () => { throw new Error("") })', criteria: [] };
+    };
+    _acceptanceSetupDeps.writeFile = async () => {};
+    _acceptanceSetupDeps.runTest = async () => ({ exitCode: 1, output: "1 fail" });
+
+    const ctx = makeCtx({
+      config: {
+        ...DEFAULT_CONFIG,
+        acceptance: { ...DEFAULT_CONFIG.acceptance, enabled: true, refinement: true, model: "balanced" },
+      } as any,
+    });
+    await acceptanceSetupStage.execute(ctx);
+
+    expect(receivedModelTier).toBe("balanced");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Expose acceptance model controls in config display by adding missing field descriptions for:
- `acceptance.model`
- `acceptance.refinement`

Also add focused unit coverage to prevent regressions.

## Why

Acceptance generation/refinement behavior defaults to `fast` tier unless users discover `acceptance.model`, but this setting was not surfaced in config descriptions.

Closes #225

## How

- Updated `src/cli/config-descriptions.ts` with explicit descriptions for:
  - `acceptance.model` (fast | balanced | powerful)
  - `acceptance.refinement` (on/off behavior and default)
- Added `test/unit/cli/acceptance-config-descriptions.test.ts` to assert both keys exist and contain expected guidance.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Small docs/config-surface fix only; no runtime behavior changes.
