### PR TITLE
fix(acceptance): run refinement with bounded concurrency

### DIFF
--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -278,6 +278,8 @@ export interface AcceptanceConfig {
   model: ModelTier;
   /** Whether to LLM-refine acceptance criteria before generating tests (default: true) */
   refinement: boolean;
+  /** Max concurrent refinement LLM calls (default: 3) */
+  refinementConcurrency: number;
   /** Whether to run RED gate check after generating acceptance tests (default: true) */
   redGate: boolean;
   /** Override command to run acceptance tests. Use {{FILE}} as placeholder for the test file path.

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -308,6 +308,7 @@ export const AcceptanceConfigSchema = z.object({
   command: z.string().optional(),
   model: z.enum(["fast", "balanced", "powerful"]).default("fast"),
   refinement: z.boolean().default(true),
+  refinementConcurrency: z.number().int().min(1).max(10).default(3),
   redGate: z.boolean().default(true),
   testStrategy: z.enum(["unit", "component", "cli", "e2e", "snapshot"]).optional(),
   testFramework: z.string().min(1, "acceptance.testFramework must be non-empty").optional(),
@@ -689,6 +690,7 @@ export const NaxConfigSchema = z
       testPath: ".nax-acceptance.test.ts",
       model: "fast",
       refinement: true,
+      refinementConcurrency: 3,
       redGate: true,
       timeoutMs: 1800000,
       fix: {

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -241,19 +241,37 @@ export const acceptanceSetupStage: PipelineStage = {
       let allRefinedCriteria: RefinedCriterion[];
 
       if (ctx.config.acceptance.refinement) {
-        allRefinedCriteria = [];
-        for (const story of nonFixStories) {
-          const storyRefined = await _acceptanceSetupDeps.refine(story.acceptanceCriteria, {
-            storyId: story.id,
-            featureName: ctx.prd.feature,
-            workdir: ctx.workdir,
-            codebaseContext: "",
-            config: ctx.config,
-            testStrategy: ctx.config.acceptance.testStrategy,
-            testFramework: ctx.config.acceptance.testFramework,
-          });
-          allRefinedCriteria = allRefinedCriteria.concat(storyRefined);
+        const maxConcurrency = ctx.config.acceptance.refinementConcurrency ?? 3;
+        const results: RefinedCriterion[][] = new Array(nonFixStories.length);
+        const executing = new Set<Promise<void>>();
+
+        for (let i = 0; i < nonFixStories.length; i++) {
+          const story = nonFixStories[i];
+          const task = _acceptanceSetupDeps
+            .refine(story.acceptanceCriteria, {
+              storyId: story.id,
+              featureName: ctx.prd.feature,
+              workdir: ctx.workdir,
+              codebaseContext: "",
+              config: ctx.config,
+              testStrategy: ctx.config.acceptance.testStrategy,
+              testFramework: ctx.config.acceptance.testFramework,
+            })
+            .then((refined) => {
+              results[i] = refined;
+            })
+            .finally(() => {
+              executing.delete(task);
+            });
+          executing.add(task);
+
+          if (executing.size >= maxConcurrency) {
+            await Promise.race(executing);
+          }
         }
+
+        await Promise.all(executing);
+        allRefinedCriteria = results.flat();
       } else {
         allRefinedCriteria = nonFixStories.flatMap((story) =>
           story.acceptanceCriteria.map((c) => ({

--- a/test/unit/pipeline/stages/acceptance-setup.test.ts
+++ b/test/unit/pipeline/stages/acceptance-setup.test.ts
@@ -219,6 +219,103 @@ describe("acceptance-setup: calls refinement and generation", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Refinement bounded concurrency (#226)
+// ---------------------------------------------------------------------------
+
+describe("acceptance-setup: refinement concurrency", () => {
+  function makeMultiStoryCtx(storyCount: number, refinementConcurrency?: number) {
+    const stories = Array.from({ length: storyCount }, (_, i) =>
+      makeStory(`US-${String(i + 1).padStart(3, "0")}`, [`AC-${i + 1}: criterion`]),
+    );
+    return makeCtx({
+      prd: makePrd(stories),
+      stories,
+      story: stories[0],
+      config: {
+        ...DEFAULT_CONFIG,
+        acceptance: {
+          ...DEFAULT_CONFIG.acceptance,
+          enabled: true,
+          refinement: true,
+          redGate: true,
+          ...(refinementConcurrency !== undefined ? { refinementConcurrency } : {}),
+        },
+      } as any,
+    });
+  }
+
+  function stubDeps() {
+    _acceptanceSetupDeps.fileExists = async () => false;
+    _acceptanceSetupDeps.readMeta = async () => null;
+    _acceptanceSetupDeps.generate = async () => ({
+      testCode: 'test("AC", () => { throw new Error("red") })',
+      criteria: [],
+    });
+    _acceptanceSetupDeps.writeFile = async () => {};
+    _acceptanceSetupDeps.writeMeta = async () => {};
+    _acceptanceSetupDeps.runTest = async () => ({ exitCode: 1, output: "1 fail" });
+  }
+
+  test("respects refinementConcurrency limit", async () => {
+    let concurrent = 0;
+    let peakConcurrent = 0;
+    stubDeps();
+    _acceptanceSetupDeps.refine = async (criteria, opts) => {
+      concurrent++;
+      peakConcurrent = Math.max(peakConcurrent, concurrent);
+      await Bun.sleep(10);
+      concurrent--;
+      return criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: opts.storyId }));
+    };
+
+    await acceptanceSetupStage.execute(makeMultiStoryCtx(5, 2));
+
+    expect(peakConcurrent).toBeLessThanOrEqual(2);
+    expect(peakConcurrent).toBeGreaterThan(1); // actually ran concurrently
+  });
+
+  test("preserves story order regardless of completion order", async () => {
+    const completionOrder: string[] = [];
+    stubDeps();
+    // Story 3 resolves fastest, story 1 slowest
+    const delays: Record<string, number> = { "US-001": 30, "US-002": 20, "US-003": 10 };
+    _acceptanceSetupDeps.refine = async (criteria, opts) => {
+      await Bun.sleep(delays[opts.storyId] ?? 10);
+      completionOrder.push(opts.storyId);
+      return criteria.map((c) => ({ original: c, refined: `R:${c}`, testable: true, storyId: opts.storyId }));
+    };
+
+    let capturedRefined: any[] = [];
+    _acceptanceSetupDeps.generate = async (_stories, refined) => {
+      capturedRefined = refined;
+      return { testCode: 'test("AC", () => { throw new Error("red") })', criteria: [] };
+    };
+
+    await acceptanceSetupStage.execute(makeMultiStoryCtx(3, 3));
+
+    // Completion order is non-deterministic, but output order must match story order
+    expect(capturedRefined.map((r: any) => r.storyId)).toEqual(["US-001", "US-002", "US-003"]);
+  });
+
+  test("DEFAULT_CONFIG.acceptance.refinementConcurrency is 3", () => {
+    expect((DEFAULT_CONFIG.acceptance as any).refinementConcurrency).toBe(3);
+  });
+
+  test("single story works without concurrency edge case", async () => {
+    let refineCalled = false;
+    stubDeps();
+    _acceptanceSetupDeps.refine = async (criteria, opts) => {
+      refineCalled = true;
+      return criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: opts.storyId }));
+    };
+
+    await acceptanceSetupStage.execute(makeMultiStoryCtx(1, 2));
+
+    expect(refineCalled).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // AC-3: acceptance-setup writes acceptance.test.ts to feature directory
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Run acceptance refinement with bounded concurrency instead of sequentially, and add `acceptance.refinementConcurrency` config field (default: 3).

## Why

Refinement calls `adapter.complete()` per story in a sequential loop. Each call incurs ~30-40s of LLM startup latency, so a 5-story feature adds ~3 minutes of serial waiting before execution starts. Since stories are independent, they can be refined concurrently.

Closes #226

## How

- Replace the sequential `for...of` loop in `acceptance-setup.ts` with the `Set<Promise>` + `Promise.race` bounded concurrency pattern (same as `parallel-worker.ts`)
- Use an indexed `results[]` array to preserve story ordering deterministically regardless of completion order
- Add `refinementConcurrency` to `AcceptanceConfigSchema` (Zod `.default(3)`, range 1-10) and `AcceptanceConfig` interface

## Testing

- [x] Tests added/updated (4 new: concurrency limit enforcement, story order preservation, default config value, single-story edge case)
- [x] `bun test` passes (4227 unit tests, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- No breaking changes. Existing configs without `refinementConcurrency` default to 3 via Zod schema default + `?? 3` fallback.
- Integration test suite has a pre-existing Bun runtime crash (`std::span` assertion) unrelated to these changes.