### PR TITLE
fix(plan): propagate sessionRole in interactive ACP planning

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -346,6 +346,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
         maxInteractionTurns: config?.agent?.maxInteractionTurns,
         featureName: options.feature,
         pidRegistry,
+        sessionRole: "plan",
       });
     } finally {
       await pidRegistry.killAll().catch(() => {});

--- a/test/unit/cli/plan-interactive.test.ts
+++ b/test/unit/cli/plan-interactive.test.ts
@@ -442,4 +442,23 @@ describe("planCommand — interactive mode (PLN-002)", () => {
 
     expect(bridgeHasRequiredMethods).toBe(true);
   });
+
+  test("AC-8: interactive planning passes sessionRole 'plan' to adapter.plan()", async () => {
+    let capturedSessionRole: string | undefined;
+    const fakeAdapter = {
+      plan: mock(async (planOpts: any) => {
+        capturedSessionRole = planOpts.sessionRole;
+        return { specContent: JSON.stringify(SAMPLE_PRD) };
+      }),
+    };
+
+    _deps.getAgent = mock((_name: string) => fakeAdapter as never);
+
+    await planCommand(tmpDir, {} as never, {
+      from: "/spec.md",
+      feature: "url-shortener",
+    });
+
+    expect(capturedSessionRole).toBe("plan");
+  });
 });


### PR DESCRIPTION
## What
Pass `sessionRole: "plan"` into the interactive planning path (`runInteractivePlan`) so ACP session naming includes explicit plan context.

## Why
Planning sessions created by `nax run --plan` were using generic names without role context in this path. This made plan/decompose investigations harder and inconsistent with session role usage elsewhere.

Closes #234

## How
- Updated `src/cli/plan.ts` interactive `adapter.plan(...)` call to include `sessionRole: "plan"`.
- Added unit coverage in `test/unit/cli/plan-interactive.test.ts`:
  - `AC-8: interactive planning passes sessionRole 'plan' to adapter.plan()`.

## Testing
- [x] Tests added/updated
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes

Targeted tests run:
- `bun test test/unit/cli/plan-interactive.test.ts test/unit/agents/acp/plan.test.ts --timeout=60000`

## Notes
This fix is scoped to interactive planning session metadata propagation only.
