### PR TITLE
fix(semantic): harden LLM JSON parsing across review, refinement, and routing

### DIFF
--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -10,6 +10,7 @@ import { createAgentRegistry } from "../agents/registry";
 import { resolveModelForAgent } from "../config";
 import { getLogger } from "../logger";
 import { errorMessage } from "../utils/errors";
+import { extractJsonFromMarkdown, stripTrailingCommas } from "../utils/llm-json";
 import type { RefinedCriterion, RefinementContext } from "./types";
 
 /**
@@ -151,7 +152,9 @@ export function parseRefinementResponse(response: string, criteria: string[]): R
   }
 
   try {
-    const parsed: unknown = JSON.parse(response);
+    const fromFence = extractJsonFromMarkdown(response);
+    const cleaned = stripTrailingCommas(fromFence !== response ? fromFence : response);
+    const parsed: unknown = JSON.parse(cleaned);
 
     if (!Array.isArray(parsed)) {
       return fallbackCriteria(criteria);

--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -10,7 +10,7 @@ import { createAgentRegistry } from "../agents/registry";
 import { resolveModelForAgent } from "../config";
 import { getLogger } from "../logger";
 import { errorMessage } from "../utils/errors";
-import { extractJsonFromMarkdown, stripTrailingCommas } from "../utils/llm-json";
+import { extractJsonFromMarkdown, stripTrailingCommas, wrapJsonPrompt } from "../utils/llm-json";
 import type { RefinedCriterion, RefinementContext } from "./types";
 
 /**
@@ -61,7 +61,7 @@ export function buildRefinementPrompt(
   const strategySection = buildStrategySection(options);
   const refinedExample = buildRefinedExample(options?.testStrategy);
 
-  return `You are an acceptance criteria refinement assistant. Your task is to convert raw acceptance criteria into concrete, machine-verifiable assertions.
+  const core = `You are an acceptance criteria refinement assistant. Your task is to convert raw acceptance criteria into concrete, machine-verifiable assertions.
 
 CODEBASE CONTEXT:
 ${codebaseContext}
@@ -70,7 +70,7 @@ ACCEPTANCE CRITERIA TO REFINE:
 ${criteriaList}
 
 For each criterion, produce a refined version that is concrete and automatically testable where possible.
-Respond with ONLY a JSON array (no markdown code fences):
+Respond with a JSON array:
 [{
   "original": "<exact original criterion text>",
   "refined": "<concrete, machine-verifiable description>",
@@ -82,8 +82,9 @@ Rules:
 - "original" must match the input criterion text exactly
 - "refined" must be a concrete assertion (e.g., ${refinedExample})
 - "testable" is false only if the criterion cannot be automatically verified (e.g., "UX feels responsive", "design looks good")
-- "storyId" leave as empty string — it will be assigned by the caller
-- Respond with ONLY the JSON array`;
+- "storyId" leave as empty string — it will be assigned by the caller`;
+
+  return wrapJsonPrompt(core);
 }
 
 /**

--- a/src/prd/schema.ts
+++ b/src/prd/schema.ts
@@ -6,6 +6,8 @@
 
 import type { Complexity, TestStrategy } from "../config";
 import { resolveTestStrategy } from "../config/test-strategy";
+import { extractJsonFromMarkdown, stripTrailingCommas } from "../utils/llm-json";
+export { extractJsonFromMarkdown };
 import type { PRD, UserStory } from "./types";
 import { validateStoryId } from "./validate";
 
@@ -17,35 +19,6 @@ const VALID_COMPLEXITY: Complexity[] = ["simple", "medium", "complex", "expert"]
 
 /** Pattern matching ST001 → ST-001 style IDs (prefix letters + digits, no separator) */
 const STORY_ID_NO_SEPARATOR = /^([A-Za-z]+)(\d+)$/;
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
-/**
- * Extract JSON from a markdown code block.
- *
- * Handles:
- *   ```json ... ```
- *   ``` ... ```
- *
- * Returns the input unchanged if no code block is detected.
- */
-export function extractJsonFromMarkdown(text: string): string {
-  const match = text.match(/```(?:json)?\s*\n([\s\S]*?)\n?\s*```/);
-  if (match) {
-    return match[1] ?? text;
-  }
-  return text;
-}
-
-/**
- * Strip trailing commas before closing braces/brackets to handle a common LLM quirk.
- * e.g. `{"a":1,}` → `{"a":1}`
- */
-function stripTrailingCommas(text: string): string {
-  return text.replace(/,\s*([}\]])/g, "$1");
-}
 
 /**
  * Normalize a story ID: convert e.g. ST001 → ST-001.

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -16,6 +16,7 @@ import type { DebateSessionOptions } from "../debate";
 import { getSafeLogger } from "../logger";
 import type { ReviewFinding } from "../plugins/types";
 import { getMergeBase, isGitRefValid } from "../utils/git";
+import { extractJsonFromMarkdown, extractJsonObject, stripTrailingCommas } from "../utils/llm-json";
 import type { ReviewCheckResult, SemanticReviewConfig } from "./types";
 
 /** Story fields required for semantic review */
@@ -131,7 +132,9 @@ function buildPrompt(story: SemanticStory, semanticConfig: SemanticReviewConfig,
       ? `\n## Additional Review Rules\n${semanticConfig.rules.map((r, i) => `${i + 1}. ${r}`).join("\n")}\n`
       : "";
 
-  return `You are a semantic code reviewer with access to the repository files. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.
+  return `IMPORTANT: Your entire response must be a single JSON object. Do not explain your reasoning. Do not use markdown formatting. Output ONLY the JSON object.
+
+You are a semantic code reviewer with access to the repository files. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.
 
 ## Story: ${story.title}
 
@@ -178,7 +181,9 @@ Respond with JSON only — no explanation text before or after:
   ]
 }
 
-If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.`;
+If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.
+
+YOUR RESPONSE MUST START WITH { AND END WITH }. No other text.`;
 }
 
 interface LLMFinding {
@@ -196,26 +201,56 @@ interface LLMResponse {
 }
 
 /**
- * Parse and validate LLM JSON response.
- * Strips markdown fences if present (LLMs frequently add them despite instructions).
- * Returns null if truly unparseable.
+ * Validate parsed JSON matches the expected LLM response shape.
+ */
+function validateLLMShape(parsed: unknown): LLMResponse | null {
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.passed !== "boolean") return null;
+  if (!Array.isArray(obj.findings)) return null;
+  return { passed: obj.passed, findings: obj.findings as LLMFinding[] };
+}
+
+/**
+ * Parse and validate LLM JSON response using multi-tier extraction.
+ *
+ * Tier 1: Direct JSON.parse (clean responses)
+ * Tier 2: Markdown fence extraction — non-anchored, handles preamble text before fence
+ * Tier 3: Bare JSON object extraction — handles JSON embedded in narration
+ *
+ * Returns null only when all tiers fail.
  */
 function parseLLMResponse(raw: string): LLMResponse | null {
+  const text = raw.trim();
+
+  // Tier 1: direct parse
   try {
-    let cleaned = raw.trim();
-    // Match code fence even when the LLM appends explanation text after the closing fence.
-    // Use non-anchored end so trailing content (e.g. "All AC are met: ...") is ignored.
-    const fenceMatch = cleaned.match(/^```(?:json)?\s*\n([\s\S]*?)\n```/);
-    if (fenceMatch) cleaned = fenceMatch[1].trim();
-    const parsed = JSON.parse(cleaned) as unknown;
-    if (typeof parsed !== "object" || parsed === null) return null;
-    const obj = parsed as Record<string, unknown>;
-    if (typeof obj.passed !== "boolean") return null;
-    if (!Array.isArray(obj.findings)) return null;
-    return { passed: obj.passed, findings: obj.findings as LLMFinding[] };
+    return validateLLMShape(JSON.parse(text));
   } catch {
-    return null;
+    /* not raw JSON */
   }
+
+  // Tier 2: extract from markdown fences (non-anchored — handles preamble)
+  const fromFence = extractJsonFromMarkdown(text);
+  if (fromFence !== text) {
+    try {
+      return validateLLMShape(JSON.parse(stripTrailingCommas(fromFence)));
+    } catch {
+      /* fence content not valid JSON */
+    }
+  }
+
+  // Tier 3: extract bare JSON object from narration
+  const bareJson = extractJsonObject(text);
+  if (bareJson) {
+    try {
+      return validateLLMShape(JSON.parse(stripTrailingCommas(bareJson)));
+    } catch {
+      /* extracted text not valid JSON */
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -16,7 +16,7 @@ import type { DebateSessionOptions } from "../debate";
 import { getSafeLogger } from "../logger";
 import type { ReviewFinding } from "../plugins/types";
 import { getMergeBase, isGitRefValid } from "../utils/git";
-import { extractJsonFromMarkdown, extractJsonObject, stripTrailingCommas } from "../utils/llm-json";
+import { extractJsonFromMarkdown, extractJsonObject, stripTrailingCommas, wrapJsonPrompt } from "../utils/llm-json";
 import type { ReviewCheckResult, SemanticReviewConfig } from "./types";
 
 /** Story fields required for semantic review */
@@ -132,9 +132,7 @@ function buildPrompt(story: SemanticStory, semanticConfig: SemanticReviewConfig,
       ? `\n## Additional Review Rules\n${semanticConfig.rules.map((r, i) => `${i + 1}. ${r}`).join("\n")}\n`
       : "";
 
-  return `IMPORTANT: Your entire response must be a single JSON object. Do not explain your reasoning. Do not use markdown formatting. Output ONLY the JSON object.
-
-You are a semantic code reviewer with access to the repository files. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.
+  const core = `You are a semantic code reviewer with access to the repository files. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.
 
 ## Story: ${story.title}
 
@@ -181,9 +179,9 @@ Respond with JSON only — no explanation text before or after:
   ]
 }
 
-If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.
+If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.`;
 
-YOUR RESPONSE MUST START WITH { AND END WITH }. No other text.`;
+  return wrapJsonPrompt(core);
 }
 
 interface LLMFinding {

--- a/src/routing/strategies/llm-prompts.ts
+++ b/src/routing/strategies/llm-prompts.ts
@@ -7,7 +7,7 @@
 
 import type { Complexity, ModelTier, NaxConfig, TddStrategy, TestStrategy } from "../../config";
 import type { UserStory } from "../../prd/types";
-import { extractJsonFromMarkdown } from "../../utils/llm-json";
+import { extractJsonFromMarkdown, wrapJsonPrompt } from "../../utils/llm-json";
 import { determineTestStrategy } from "../router";
 import type { RoutingDecision } from "../router";
 
@@ -22,7 +22,7 @@ export function buildRoutingPrompt(story: UserStory, config: NaxConfig): string 
   const { title, description, acceptanceCriteria, tags } = story;
   const criteria = acceptanceCriteria.map((c, i) => `${i + 1}. ${c}`).join("\n");
 
-  return `You are a code task router. Classify a user story's complexity and select the cheapest model tier that will succeed.
+  const core = `You are a code task router. Classify a user story's complexity and select the cheapest model tier that will succeed.
 
 ## Story
 Title: ${title}
@@ -48,8 +48,10 @@ Tags: ${tags.join(", ")}
 - Many files ≠ complex — copy-paste refactors across files are simple.
 - Pure refactoring/deletion with no new behavior → simple.
 
-Respond with ONLY this JSON (no markdown, no explanation):
+Respond with:
 {"complexity":"simple|medium|complex|expert","modelTier":"fast|balanced|powerful","reasoning":"<one line>"}`;
+
+  return wrapJsonPrompt(core);
 }
 
 /**
@@ -71,7 +73,7 @@ ${criteria}
     })
     .join("\n\n");
 
-  return `You are a code task router. Classify each story's complexity and select the cheapest model tier that will succeed.
+  const batchCore = `You are a code task router. Classify each story's complexity and select the cheapest model tier that will succeed.
 
 ## Stories
 ${storyBlocks}
@@ -93,8 +95,10 @@ ${storyBlocks}
 - Many files ≠ complex — copy-paste refactors across files are simple.
 - Pure refactoring/deletion with no new behavior → simple.
 
-Respond with ONLY a JSON array (no markdown, no explanation):
+Respond with a JSON array:
 [{"id":"US-001","complexity":"simple|medium|complex|expert","modelTier":"fast|balanced|powerful","reasoning":"<one line>"}]`;
+
+  return wrapJsonPrompt(batchCore);
 }
 
 /**

--- a/src/routing/strategies/llm-prompts.ts
+++ b/src/routing/strategies/llm-prompts.ts
@@ -7,6 +7,7 @@
 
 import type { Complexity, ModelTier, NaxConfig, TddStrategy, TestStrategy } from "../../config";
 import type { UserStory } from "../../prd/types";
+import { extractJsonFromMarkdown } from "../../utils/llm-json";
 import { determineTestStrategy } from "../router";
 import type { RoutingDecision } from "../router";
 
@@ -147,17 +148,19 @@ export function validateRoutingDecision(
   };
 }
 
-/** Strip markdown code fences from LLM output. */
+/**
+ * Strip markdown code fences from LLM output.
+ * @deprecated Use extractJsonFromMarkdown from utils/llm-json directly.
+ */
 export function stripCodeFences(text: string): string {
-  let result = text.trim();
-  if (result.startsWith("```")) {
-    const lines = result.split("\n");
-    result = lines.slice(1, -1).join("\n").trim();
+  const trimmed = text.trim();
+  const fromFence = extractJsonFromMarkdown(trimmed);
+  if (fromFence !== trimmed) return fromFence;
+  // Handle bare 'json\n...' pattern (LLM outputs language hint without backticks)
+  if (trimmed.startsWith("json")) {
+    return trimmed.slice(4).trim();
   }
-  if (result.startsWith("json")) {
-    result = result.slice(4).trim();
-  }
-  return result;
+  return trimmed;
 }
 
 /**
@@ -170,7 +173,7 @@ export function stripCodeFences(text: string): string {
  * @throws Error if JSON parsing or validation fails
  */
 export function parseRoutingResponse(output: string, story: UserStory, config: NaxConfig): RoutingDecision {
-  const jsonText = stripCodeFences(output);
+  const jsonText = extractJsonFromMarkdown(output.trim());
   const parsed = JSON.parse(jsonText);
   return validateRoutingDecision(parsed, config, story);
 }
@@ -189,17 +192,7 @@ export function parseBatchResponse(
   stories: UserStory[],
   config: NaxConfig,
 ): Map<string, RoutingDecision> {
-  // Strip markdown code blocks if present
-  let jsonText = output.trim();
-  if (jsonText.startsWith("```")) {
-    const lines = jsonText.split("\n");
-    jsonText = lines.slice(1, -1).join("\n").trim();
-  }
-  if (jsonText.startsWith("json")) {
-    jsonText = jsonText.slice(4).trim();
-  }
-
-  const parsed = JSON.parse(jsonText);
+  const parsed = JSON.parse(extractJsonFromMarkdown(output.trim()));
 
   if (!Array.isArray(parsed)) {
     throw new Error("Batch LLM response must be a JSON array");

--- a/src/utils/llm-json.ts
+++ b/src/utils/llm-json.ts
@@ -1,7 +1,9 @@
 /**
  * LLM JSON Extraction Utilities
  *
- * Shared utilities for extracting and cleaning JSON from LLM responses.
+ * Shared utilities for extracting and cleaning JSON from LLM responses,
+ * and for building prompts that request JSON output.
+ *
  * LLMs frequently wrap JSON in markdown fences, add preamble/postamble text,
  * or include trailing commas — these utilities handle all common patterns.
  */
@@ -69,4 +71,19 @@ export function extractJsonObject(text: string): string | null {
   if (end <= start) return null;
 
   return text.slice(start, end + 1);
+}
+
+/**
+ * Wrap a prompt to instruct the LLM to respond with JSON only.
+ *
+ * Adds a JSON-only instruction at the top (primacy) and a reinforcement
+ * reminder at the bottom (recency) — both improve compliance on cheap models.
+ *
+ * Pair with the multi-tier extraction functions above to parse the response.
+ *
+ * @param prompt - The core prompt content
+ * @returns The prompt wrapped with JSON-only framing
+ */
+export function wrapJsonPrompt(prompt: string): string {
+  return `IMPORTANT: Your entire response must be a single JSON object or array. Do not explain your reasoning. Do not use markdown formatting. Output ONLY the JSON.\n\n${prompt.trim()}\n\nYOUR RESPONSE MUST START WITH { OR [ AND END WITH } OR ]. No other text.`;
 }

--- a/src/utils/llm-json.ts
+++ b/src/utils/llm-json.ts
@@ -1,0 +1,72 @@
+/**
+ * LLM JSON Extraction Utilities
+ *
+ * Shared utilities for extracting and cleaning JSON from LLM responses.
+ * LLMs frequently wrap JSON in markdown fences, add preamble/postamble text,
+ * or include trailing commas — these utilities handle all common patterns.
+ */
+
+/**
+ * Extract JSON from a markdown code block.
+ *
+ * Non-anchored — handles preamble text before the fence (common LLM behavior).
+ *
+ * Handles:
+ *   ```json ... ```
+ *   ``` ... ```
+ *
+ * Returns the input unchanged if no code block is detected.
+ */
+export function extractJsonFromMarkdown(text: string): string {
+  const match = text.match(/```(?:json)?\s*\n([\s\S]*?)\n?\s*```/);
+  if (match) {
+    return match[1] ?? text;
+  }
+  return text;
+}
+
+/**
+ * Strip trailing commas before closing braces/brackets.
+ * e.g. `{"a":1,}` → `{"a":1}`
+ *
+ * Common LLM quirk especially in truncated or partial responses.
+ */
+export function stripTrailingCommas(text: string): string {
+  return text.replace(/,\s*([}\]])/g, "$1");
+}
+
+/**
+ * Extract the first top-level JSON object or array from free-form text.
+ *
+ * Useful when the LLM embeds valid JSON inside narration text without fences.
+ * Finds the first `{` or `[` and the last matching `}` or `]`.
+ *
+ * Returns null if no JSON container is found.
+ */
+export function extractJsonObject(text: string): string | null {
+  const objStart = text.indexOf("{");
+  const arrStart = text.indexOf("[");
+
+  // Determine which comes first
+  let start: number;
+  let closeChar: string;
+  if (objStart === -1 && arrStart === -1) return null;
+  if (objStart === -1) {
+    start = arrStart;
+    closeChar = "]";
+  } else if (arrStart === -1) {
+    start = objStart;
+    closeChar = "}";
+  } else if (objStart < arrStart) {
+    start = objStart;
+    closeChar = "}";
+  } else {
+    start = arrStart;
+    closeChar = "]";
+  }
+
+  const end = text.lastIndexOf(closeChar);
+  if (end <= start) return null;
+
+  return text.slice(start, end + 1);
+}

--- a/test/unit/review/semantic-parsing.test.ts
+++ b/test/unit/review/semantic-parsing.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for semantic.ts — multi-tier JSON parsing hardening
+ *
+ * Tests cover the two observed production failure modes:
+ * 1. Preamble + fenced JSON (LLM narrates before ```json block)
+ * 2. Bare JSON embedded in narration (no fences)
+ * 3. Trailing commas in JSON (common LLM quirk)
+ * 4. Pure narration — still fail-open (no regression)
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
+import type { SemanticStory } from "../../../src/review/semantic";
+import type { SemanticReviewConfig } from "../../../src/review/types";
+import type { AgentAdapter } from "../../../src/agents/types";
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors semantic.test.ts patterns)
+// ---------------------------------------------------------------------------
+
+const STORY: SemanticStory = {
+  id: "US-parse-01",
+  title: "Parsing hardening test",
+  description: "Ensure LLM response parser handles all output patterns",
+  acceptanceCriteria: ["Parser handles preamble + fenced JSON", "Parser handles bare JSON in narration"],
+};
+
+const CONFIG: SemanticReviewConfig = {
+  modelTier: "balanced",
+  rules: [],
+  excludePatterns: [],
+  timeoutMs: 60_000,
+};
+
+function makeMockAgent(response: string): AgentAdapter {
+  return {
+    name: "mock",
+    displayName: "Mock Agent",
+    binary: "mock",
+    capabilities: { supportedTiers: [], supportedTestStrategies: [], features: {} } as unknown as AgentAdapter["capabilities"],
+    isInstalled: mock(async () => true),
+    run: mock(async () => { throw new Error("not used"); }),
+    buildCommand: mock(() => []),
+    plan: mock(async () => { throw new Error("not used"); }),
+    decompose: mock(async () => { throw new Error("not used"); }),
+    complete: mock(async (_prompt: string) => response),
+  } as unknown as AgentAdapter;
+}
+
+function makeSpawnMock(stdout: string, exitCode = 0) {
+  return mock((_opts: unknown) => ({
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(stdout));
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) { controller.close(); },
+    }),
+    kill: () => {},
+  })) as unknown as typeof _semanticDeps.spawn;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("runSemanticReview — multi-tier JSON parsing", () => {
+  let origSpawn: typeof _semanticDeps.spawn;
+  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
+  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+
+  beforeEach(() => {
+    origSpawn = _semanticDeps.spawn;
+    origIsGitRefValid = _semanticDeps.isGitRefValid;
+    origGetMergeBase = _semanticDeps.getMergeBase;
+    _semanticDeps.isGitRefValid = mock(async () => true);
+    _semanticDeps.getMergeBase = mock(async () => undefined);
+  });
+
+  afterEach(() => {
+    _semanticDeps.spawn = origSpawn;
+    _semanticDeps.isGitRefValid = origIsGitRefValid;
+    _semanticDeps.getMergeBase = origGetMergeBase;
+  });
+
+  // Failure mode 2: preamble + fenced JSON (production log pattern)
+  test("parses passed=true from preamble + ```json fence", async () => {
+    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    const response =
+      "I'll verify each acceptance criterion by reading the actual implementation files.\n" +
+      "```json\n" +
+      JSON.stringify({ passed: true, findings: [] }) +
+      "\n```";
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
+    expect(result.success).toBe(true);
+    expect(result.output).not.toContain("could not parse");
+  });
+
+  test("parses passed=false with findings from preamble + fence", async () => {
+    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    const payload = {
+      passed: false,
+      findings: [{ severity: "error", file: "src/foo.ts", line: 10, issue: "missing impl", suggestion: "implement it" }],
+    };
+    const response =
+      "Let me check the implementation.\n```json\n" + JSON.stringify(payload) + "\n```";
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Semantic review failed");
+  });
+
+  test("parses from preamble + plain ``` fence", async () => {
+    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    const response =
+      "After reviewing the diff:\n" +
+      "```\n" +
+      JSON.stringify({ passed: true, findings: [] }) +
+      "\n```";
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
+    expect(result.success).toBe(true);
+    expect(result.output).not.toContain("could not parse");
+  });
+
+  // Bare JSON embedded in narration (tier 3)
+  test("parses passed=true from JSON embedded in narration", async () => {
+    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    const response =
+      'After analysis: {"passed":true,"findings":[]} All ACs are correctly implemented.';
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
+    expect(result.success).toBe(true);
+    expect(result.output).not.toContain("could not parse");
+  });
+
+  test("parses passed=false from JSON embedded in narration", async () => {
+    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    const payload = {
+      passed: false,
+      findings: [{ severity: "error", file: "src/bar.ts", line: 5, issue: "stub", suggestion: "implement" }],
+    };
+    const response = "I found issues. " + JSON.stringify(payload) + " That concludes my review.";
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
+    expect(result.success).toBe(false);
+  });
+
+  // Trailing commas
+  test("parses JSON with trailing commas in fence", async () => {
+    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    const response = '```json\n{"passed":true,"findings":[],}\n```';
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
+    expect(result.success).toBe(true);
+    expect(result.output).not.toContain("could not parse");
+  });
+
+  // Failure mode 1: pure narration — must still fail-open
+  test("still fails-open on pure narration with no JSON", async () => {
+    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    const response =
+      "I'll verify each acceptance criterion by examining the actual files to ensure all i18n keys exist and are correctly wired.";
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("fail-open");
+  });
+
+  // Tier 1: clean JSON still works
+  test("tier 1 still parses clean JSON directly", async () => {
+    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    const response = JSON.stringify({ passed: true, findings: [] });
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
+    expect(result.success).toBe(true);
+  });
+});

--- a/test/unit/utils/llm-json.test.ts
+++ b/test/unit/utils/llm-json.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for src/utils/llm-json.ts
+ *
+ * Tests cover:
+ * - extractJsonFromMarkdown: fence stripping with/without preamble
+ * - stripTrailingCommas: trailing comma removal
+ * - extractJsonObject: bare JSON extraction from narration
+ */
+
+import { describe, expect, test } from "bun:test";
+import { extractJsonFromMarkdown, extractJsonObject, stripTrailingCommas } from "../../../src/utils/llm-json";
+
+// ---------------------------------------------------------------------------
+// extractJsonFromMarkdown
+// ---------------------------------------------------------------------------
+
+describe("extractJsonFromMarkdown", () => {
+  test("returns input unchanged when no fence present", () => {
+    const input = '{"passed":true,"findings":[]}';
+    expect(extractJsonFromMarkdown(input)).toBe(input);
+  });
+
+  test("extracts JSON from ```json fence", () => {
+    const json = '{"passed":true,"findings":[]}';
+    const input = "```json\n" + json + "\n```";
+    expect(extractJsonFromMarkdown(input)).toBe(json);
+  });
+
+  test("extracts JSON from plain ``` fence", () => {
+    const json = '{"passed":true,"findings":[]}';
+    const input = "```\n" + json + "\n```";
+    expect(extractJsonFromMarkdown(input)).toBe(json);
+  });
+
+  test("handles preamble text before fence (failure mode 2)", () => {
+    const json = '{"passed":true,"findings":[]}';
+    const input = "I'll verify each AC by reading the implementation files.\n```json\n" + json + "\n```";
+    expect(extractJsonFromMarkdown(input)).toBe(json);
+  });
+
+  test("handles trailing text after closing fence", () => {
+    const json = '{"passed":true,"findings":[]}';
+    const input = "```json\n" + json + "\n```\nAll ACs are met.";
+    expect(extractJsonFromMarkdown(input)).toBe(json);
+  });
+
+  test("handles both preamble and trailing text", () => {
+    const json = '{"passed":false,"findings":[]}';
+    const input = "Let me check.\n```json\n" + json + "\n```\nThat's my analysis.";
+    expect(extractJsonFromMarkdown(input)).toBe(json);
+  });
+
+  test("returns input unchanged when fence is unclosed", () => {
+    const input = "```json\n{";
+    // No closing fence — returns input unchanged
+    expect(extractJsonFromMarkdown(input)).toBe(input);
+  });
+
+  test("handles multiline JSON in fence", () => {
+    const json = '{\n  "passed": true,\n  "findings": []\n}';
+    const input = "```json\n" + json + "\n```";
+    expect(extractJsonFromMarkdown(input)).toBe(json);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripTrailingCommas
+// ---------------------------------------------------------------------------
+
+describe("stripTrailingCommas", () => {
+  test("removes trailing comma before }", () => {
+    expect(stripTrailingCommas('{"a":1,}')).toBe('{"a":1}');
+  });
+
+  test("removes trailing comma before ]", () => {
+    expect(stripTrailingCommas("[1,2,3,]")).toBe("[1,2,3]");
+  });
+
+  test("removes trailing comma with whitespace", () => {
+    expect(stripTrailingCommas('{"a":1,  }')).toBe('{"a":1}');
+  });
+
+  test("handles nested trailing commas", () => {
+    expect(stripTrailingCommas('{"a":[1,2,],"b":3,}')).toBe('{"a":[1,2],"b":3}');
+  });
+
+  test("leaves valid JSON unchanged", () => {
+    const json = '{"passed":true,"findings":[]}';
+    expect(stripTrailingCommas(json)).toBe(json);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractJsonObject
+// ---------------------------------------------------------------------------
+
+describe("extractJsonObject", () => {
+  test("returns null when no JSON container found", () => {
+    expect(extractJsonObject("just plain text, no JSON here")).toBeNull();
+  });
+
+  test("extracts object from pure JSON string", () => {
+    const json = '{"passed":true,"findings":[]}';
+    expect(extractJsonObject(json)).toBe(json);
+  });
+
+  test("extracts object from narration with preamble", () => {
+    const json = '{"passed":true,"findings":[]}';
+    const input = "After analysis: " + json + " All ACs met.";
+    expect(extractJsonObject(input)).toBe(json);
+  });
+
+  test("extracts JSON array from text", () => {
+    const json = '[{"id":"1"},{"id":"2"}]';
+    const input = "Here are the results: " + json;
+    expect(extractJsonObject(input)).toBe(json);
+  });
+
+  test("prefers object when { appears before [", () => {
+    const input = '{"key":[1,2,3]}';
+    expect(extractJsonObject(input)).toBe('{"key":[1,2,3]}');
+  });
+
+  test("prefers array when [ appears before {", () => {
+    const input = '[{"key":"val"}]';
+    expect(extractJsonObject(input)).toBe('[{"key":"val"}]');
+  });
+
+  test("returns null when only open brace with no close", () => {
+    expect(extractJsonObject("{ no closing brace")).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(extractJsonObject("")).toBeNull();
+  });
+});

--- a/test/unit/utils/llm-json.test.ts
+++ b/test/unit/utils/llm-json.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { extractJsonFromMarkdown, extractJsonObject, stripTrailingCommas } from "../../../src/utils/llm-json";
+import { extractJsonFromMarkdown, extractJsonObject, stripTrailingCommas, wrapJsonPrompt } from "../../../src/utils/llm-json";
 
 // ---------------------------------------------------------------------------
 // extractJsonFromMarkdown
@@ -132,5 +132,38 @@ describe("extractJsonObject", () => {
 
   test("returns null for empty string", () => {
     expect(extractJsonObject("")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wrapJsonPrompt
+// ---------------------------------------------------------------------------
+
+describe("wrapJsonPrompt", () => {
+  test("prepends JSON-only instruction", () => {
+    const result = wrapJsonPrompt("my prompt");
+    expect(result).toContain("IMPORTANT:");
+    expect(result).toContain("single JSON object or array");
+    expect(result).toContain("my prompt");
+  });
+
+  test("appends JSON boundary reminder", () => {
+    const result = wrapJsonPrompt("my prompt");
+    expect(result).toContain("YOUR RESPONSE MUST START WITH");
+  });
+
+  test("trims whitespace from core prompt", () => {
+    const result = wrapJsonPrompt("  spaced prompt  ");
+    expect(result).toContain("spaced prompt");
+    expect(result).not.toContain("  spaced prompt  ");
+  });
+
+  test("core prompt appears between preamble and suffix", () => {
+    const result = wrapJsonPrompt("core content");
+    const coreIdx = result.indexOf("core content");
+    const importantIdx = result.indexOf("IMPORTANT:");
+    const mustStartIdx = result.indexOf("YOUR RESPONSE MUST START WITH");
+    expect(importantIdx).toBeLessThan(coreIdx);
+    expect(coreIdx).toBeLessThan(mustStartIdx);
   });
 });


### PR DESCRIPTION
## What

Create a shared `src/utils/llm-json.ts` utility with multi-tier JSON extraction and a `wrapJsonPrompt` helper, then apply both across all modules that call the LLM and expect JSON back.

## Why

The semantic review stage frequently silently skips checks due to `"LLM returned invalid JSON — fail-open"`. The root cause was a `^`-anchored regex that couldn't find JSON fences when the LLM prefixes its response with narrative text — a common cheap-model behavior. The same class of bug existed in three other modules.

Closes #62
Closes #244

## How

**`src/utils/llm-json.ts`** (new) — shared extraction + prompt utilities:
- `extractJsonFromMarkdown` — non-anchored regex, handles preamble before fences
- `stripTrailingCommas` — removes `,}` / `,]` (common LLM quirk)
- `extractJsonObject` — finds bare JSON embedded in narration (first `{`/`[` to last `}`/`]`)
- `wrapJsonPrompt` — wraps any prompt with JSON-only framing at top (primacy) and bottom (recency)

**Multi-tier parser in `src/review/semantic.ts`:**
1. Direct `JSON.parse` (clean responses)
2. Fence extraction → parse (preamble + fenced JSON)
3. Bare object extraction → parse (JSON embedded in narration)

**Other callers updated:**
- `src/acceptance/refinement.ts` — was doing raw `JSON.parse` with zero fence stripping
- `src/routing/strategies/llm-prompts.ts` — replaced `startsWith("```")` with shared utility; removed inline duplicate in `parseBatchResponse`
- `src/prd/schema.ts` — re-exports `extractJsonFromMarkdown` from shared module (backward compatible)

All JSON-expecting prompts (`semantic`, `refinement`, `routing` single + batch) now use `wrapJsonPrompt` for consistent framing.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

**New tests:**
- `test/unit/utils/llm-json.test.ts` — 25 unit tests for all utility functions including preamble, bare JSON, trailing commas, `wrapJsonPrompt` structure
- `test/unit/review/semantic-parsing.test.ts` — 8 integration tests covering both observed production failure modes (preamble + fence, bare JSON, trailing commas, pure narration still fail-open)

278 tests pass across all affected files.

## Notes

- `stripCodeFences` in `llm-prompts.ts` is kept as a thin wrapper (still exported, some tests cover it) but marked `@deprecated` — callers should use `extractJsonFromMarkdown` directly.
- `jsonMode` on `CompleteOptions`/ACP adapter is misleading (doesn't actually affect model output format) — tracked separately for cleanup.