### PR TITLE
chore: release v0.57.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.57.3",
+  "version": "0.57.4",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Patch release: 0.57.3 → 0.57.4

## Why

Includes all commits merged to main since v0.57.3.

## How

### Bug Fixes
- **fix(plan):** Reuse `maxReplanAttempts` as shared decompose AC-repair budget (#243) — Fixes #227
- **fix(semantic):** Harden LLM JSON parsing across review, refinement, and routing (#245)

### Chores / Docs
- docs: Update rules and split architectures.md
- doc: Update architecture.md

## Testing

- [x] Tests added/updated
- [x] `bun test` passes (CI)
- [x] `bun run typecheck` passes (CI)
- [x] `bun run lint` passes (CI)

## Notes

- No breaking changes.
