### PR TITLE
fix(acp): prevent silent nax crash on SIGPIPE and Bun stream hang

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -252,6 +252,9 @@ export async function runSessionPrompt(
   const winner = await Promise.race([promptPromise, timeoutPromise]);
 
   if (winner === "timeout") {
+    // Suppress the pending prompt rejection to prevent unhandled rejection after
+    // cancelActivePrompt kills the acpx process (which causes an EPIPE rejection).
+    promptPromise.catch(() => {});
     try {
       await session.cancelActivePrompt();
     } catch {

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -23,7 +23,9 @@ import { parseAcpxJsonOutput } from "./parser";
 // Constants
 // ─────────────────────────────────────────────────────────────────────────────
 
-const ACPX_WATCHDOG_BUFFER_MS = 30_000;
+// Grace period for stream drain after acpx exits — handles Bun bug where
+// piped streams may not close after SIGTERM (e.g. cancelActivePrompt).
+const ACPX_STREAM_DRAIN_TIMEOUT_MS = 5_000;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Spawn helper (injectable for future testing if needed)
@@ -31,6 +33,8 @@ const ACPX_WATCHDOG_BUFFER_MS = 30_000;
 
 export const _spawnClientDeps = {
   spawn: typedSpawn,
+  /** Stream drain timeout after proc.exited — injectable so tests can use a short value. */
+  streamDrainTimeoutMs: ACPX_STREAM_DRAIN_TIMEOUT_MS,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -118,15 +122,31 @@ class SpawnAcpSession implements AcpSession {
     await this.pidRegistry?.register(processPid);
 
     try {
-      proc.stdin?.write(text);
-      proc.stdin?.end();
+      try {
+        proc.stdin?.write(text);
+        proc.stdin?.end();
+      } catch {
+        // acpx exited before nax could write the prompt (EPIPE / broken pipe).
+        // This is expected when the subprocess crashes on startup.
+        // Do not rethrow — let proc.exited report the real exit code and stderr.
+        getSafeLogger()?.warn("acp-adapter", "Failed to write prompt to acpx stdin (subprocess exited early)", {
+          session: this.sessionName,
+        });
+      }
 
-      // Drain stdout/stderr while waiting for process exit to avoid pipe-buffer deadlocks
-      // on large outputs (e.g. planning PRD generation).
-      const [exitCode, stdout, stderr] = await Promise.all([
-        proc.exited,
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
+      // Start reads before proc.exited to prevent pipe-buffer deadlock on large output.
+      // .catch(() => "") guards against stream errors (e.g. acpx crash mid-run).
+      const stdoutPromise = new Response(proc.stdout).text().catch(() => "");
+      const stderrPromise = new Response(proc.stderr).text().catch(() => "");
+
+      const exitCode = await proc.exited;
+
+      // Bun bug: piped streams may not close after kill (e.g. cancelActivePrompt SIGTERM).
+      // Race drain against a 5 s deadline so prompt() always resolves instead of hanging.
+      const drained = Bun.sleep(_spawnClientDeps.streamDrainTimeoutMs).then(() => "");
+      const [stdout, stderr] = await Promise.all([
+        Promise.race([stdoutPromise, drained]),
+        Promise.race([stderrPromise, drained]),
       ]);
 
       if (exitCode !== 0) {
@@ -175,8 +195,8 @@ class SpawnAcpSession implements AcpSession {
     try {
       const [exitCode, stdout, stderr] = await Promise.all([
         proc.exited,
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
+        new Response(proc.stdout).text().catch(() => ""),
+        new Response(proc.stderr).text().catch(() => ""),
       ]);
       return { exitCode, stdout, stderr };
     } finally {
@@ -288,8 +308,8 @@ export class SpawnAcpClient implements AcpClient {
     try {
       const [exitCode, stdout, stderr] = await Promise.all([
         proc.exited,
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
+        new Response(proc.stdout).text().catch(() => ""),
+        new Response(proc.stderr).text().catch(() => ""),
       ]);
       return { exitCode, stdout, stderr };
     } finally {

--- a/src/execution/crash-signals.ts
+++ b/src/execution/crash-signals.ts
@@ -151,10 +151,17 @@ export function installSignalHandlers(ctx: SignalHandlerContext): () => void {
   const sigtermHandler = () => signalHandler("SIGTERM");
   const sigintHandler = () => signalHandler("SIGINT");
   const sighupHandler = () => signalHandler("SIGHUP");
+  // SIGPIPE: Bun (unlike Node.js) does not set SIG_IGN for SIGPIPE at startup.
+  // Writing to a broken pipe — e.g. acpx exits before nax writes its stdin —
+  // would otherwise kill nax silently before any crash handler runs.
+  const sigpipeHandler = () => {
+    getSafeLogger()?.warn("crash-recovery", "Received SIGPIPE (subprocess exited before stdin write — suppressed)");
+  };
 
   process.on("SIGTERM", sigtermHandler);
   process.on("SIGINT", sigintHandler);
   process.on("SIGHUP", sighupHandler);
+  process.on("SIGPIPE", sigpipeHandler);
   process.on("uncaughtException", uncaughtExceptionHandler);
   const rejectionWrapper = (reason: unknown) => unhandledRejectionHandler(reason);
   process.on("unhandledRejection", rejectionWrapper);
@@ -165,6 +172,7 @@ export function installSignalHandlers(ctx: SignalHandlerContext): () => void {
     process.removeListener("SIGTERM", sigtermHandler);
     process.removeListener("SIGINT", sigintHandler);
     process.removeListener("SIGHUP", sighupHandler);
+    process.removeListener("SIGPIPE", sigpipeHandler);
     process.removeListener("uncaughtException", uncaughtExceptionHandler);
     process.removeListener("unhandledRejection", rejectionWrapper);
     logger?.debug("crash-recovery", "Signal handlers unregistered");

--- a/test/unit/agents/acp/spawn-client.test.ts
+++ b/test/unit/agents/acp/spawn-client.test.ts
@@ -5,7 +5,7 @@
  *        It must use the client's stored permissionMode ("approve-reads" by default).
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { SpawnAcpClient, _spawnClientDeps } from "../../../../src/agents/acp/spawn-client";
 import { withDepsRestore } from "../../../helpers/deps";
 
@@ -147,6 +147,155 @@ describe("SpawnAcpClient — PID registration (#228)", () => {
   });
 });
 
+describe("SpawnAcpClient — prompt EPIPE resilience", () => {
+  withDepsRestore(_spawnClientDeps, ["spawn"]);
+
+  test("prompt survives EPIPE on stdin write (acpx exits before nax writes stdin)", async () => {
+    let callCount = 0;
+    const enc = new TextEncoder();
+
+    _spawnClientDeps.spawn = (_cmd, _opts) => {
+      callCount++;
+      if (callCount === 1) return makeSpawnResult(0); // ensure session
+
+      // Second call: acpx exits immediately, stdin.write throws EPIPE
+      return {
+        stdout: new ReadableStream<Uint8Array>({ start(c) { c.close(); } }),
+        stderr: new ReadableStream<Uint8Array>({
+          start(c) { c.enqueue(enc.encode("connection failed")); c.close(); }
+        }),
+        stdin: {
+          write: () => { throw new Error("EPIPE: broken pipe"); },
+          end: () => {},
+          flush: () => {},
+        },
+        exited: Promise.resolve(1),
+        pid: 12345,
+        kill: () => {},
+      };
+    };
+
+    const client = new SpawnAcpClient("acpx claude", "/tmp");
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    expect(session).not.toBeNull();
+
+    // Must not throw — EPIPE is swallowed, error response from exit code returned
+    const response = await session!.prompt("hello");
+    expect(response.stopReason).toBe("error");
+    expect(response.messages[0]?.content).toContain("connection failed");
+  });
+
+  test("prompt survives stdin.end() throwing EPIPE after successful write", async () => {
+    let callCount = 0;
+
+    _spawnClientDeps.spawn = (_cmd, _opts) => {
+      callCount++;
+      if (callCount === 1) return makeSpawnResult(0);
+
+      const enc = new TextEncoder();
+      return {
+        stdout: new ReadableStream<Uint8Array>({ start(c) { c.close(); } }),
+        stderr: new ReadableStream<Uint8Array>({
+          start(c) { c.enqueue(enc.encode("write error")); c.close(); }
+        }),
+        stdin: {
+          write: () => 0,
+          end: () => { throw new Error("EPIPE: broken pipe"); },
+          flush: () => {},
+        },
+        exited: Promise.resolve(1),
+        pid: 12345,
+        kill: () => {},
+      };
+    };
+
+    const client = new SpawnAcpClient("acpx claude", "/tmp");
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    const response = await session!.prompt("hello");
+    expect(response.stopReason).toBe("error");
+  });
+});
+
+describe("SpawnAcpClient — stream drain resilience", () => {
+  withDepsRestore(_spawnClientDeps, ["spawn", "streamDrainTimeoutMs"]);
+
+  test("prompt returns error response when stdout stream emits an error (not throw)", async () => {
+    let callCount = 0;
+    const enc = new TextEncoder();
+
+    _spawnClientDeps.spawn = (_cmd, _opts) => {
+      callCount++;
+      if (callCount === 1) return makeSpawnResult(0); // ensure session
+
+      // stdout emits an error mid-stream (e.g. acpx runtime crash)
+      const errStream = new ReadableStream<Uint8Array>({
+        start(c) { c.error(new Error("stream error")); },
+      });
+      const stderrStream = new ReadableStream<Uint8Array>({
+        start(c) { c.enqueue(enc.encode("acpx crashed")); c.close(); },
+      });
+      return {
+        stdout: errStream,
+        stderr: stderrStream,
+        stdin: { write: () => 0, end: () => {}, flush: () => {} },
+        exited: Promise.resolve(1),
+        pid: 12345,
+        kill: () => {},
+      };
+    };
+
+    const client = new SpawnAcpClient("acpx claude", "/tmp");
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    expect(session).not.toBeNull();
+
+    // .catch(() => "") guards must swallow the stream error — prompt resolves, not rejects
+    const response = await session!.prompt("hello");
+    expect(response.stopReason).toBe("error");
+  });
+
+  test("prompt completes within drain timeout when stdout stream never closes (Bun stream hang bug)", async () => {
+    let callCount = 0;
+
+    // Use a short drain timeout so the test doesn't take 5 s
+    _spawnClientDeps.streamDrainTimeoutMs = 80;
+
+    _spawnClientDeps.spawn = (_cmd, _opts) => {
+      callCount++;
+      if (callCount === 1) return makeSpawnResult(0); // ensure session
+
+      // stdout never closes — simulates Bun stream hang after SIGTERM
+      const hangingStream = new ReadableStream<Uint8Array>({ start() { /* never closes */ } });
+      return {
+        stdout: hangingStream,
+        stderr: new ReadableStream<Uint8Array>({ start(c) { c.close(); } }),
+        stdin: { write: () => 0, end: () => {}, flush: () => {} },
+        exited: Promise.resolve(1),
+        pid: 12345,
+        kill: () => {},
+      };
+    };
+
+    const client = new SpawnAcpClient("acpx claude", "/tmp");
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    expect(session).not.toBeNull();
+
+    const MARGIN_MS = 500;
+    const timed = Symbol("timed");
+    const result = await Promise.race([
+      session!.prompt("hello"),
+      new Promise<typeof timed>((resolve) =>
+        setTimeout(() => resolve(timed), _spawnClientDeps.streamDrainTimeoutMs + MARGIN_MS),
+      ),
+    ]);
+
+    // prompt() must resolve within drain timeout — not hang indefinitely
+    expect(result).not.toBe(timed);
+    if (result !== timed) {
+      expect(result.stopReason).toBe("error");
+    }
+  });
+});
+
 describe("SpawnAcpClient — loadSession (SEC-3)", () => {
   withDepsRestore(_spawnClientDeps, ["spawn"]);
 
@@ -155,7 +304,7 @@ describe("SpawnAcpClient — loadSession (SEC-3)", () => {
       makeSpawnResult(0);
 
     const client = new SpawnAcpClient("acpx --model claude-sonnet-4-5 claude", "/tmp");
-    const session = await client.loadSession("test-session", "claude");
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
     expect(session).not.toBeNull();
   });
 
@@ -164,7 +313,7 @@ describe("SpawnAcpClient — loadSession (SEC-3)", () => {
       makeSpawnResult(1);
 
     const client = new SpawnAcpClient("acpx --model claude-sonnet-4-5 claude", "/tmp");
-    const session = await client.loadSession("test-session", "claude");
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
     expect(session).toBeNull();
   });
 
@@ -185,7 +334,7 @@ describe("SpawnAcpClient — loadSession (SEC-3)", () => {
     };
 
     const client = new SpawnAcpClient("acpx --model claude-sonnet-4-5 claude", "/tmp");
-    const session = await client.loadSession("test-session", "claude");
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
     expect(session).not.toBeNull();
 
     if (session) {
@@ -210,7 +359,7 @@ describe("SpawnAcpClient — loadSession (SEC-3)", () => {
     };
 
     const client = new SpawnAcpClient("acpx --model claude-sonnet-4-5 claude", "/tmp");
-    const session = await client.loadSession("test-session", "claude");
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
     expect(session).not.toBeNull();
 
     const timed = Symbol("timed");

--- a/test/unit/execution/crash-signals.test.ts
+++ b/test/unit/execution/crash-signals.test.ts
@@ -70,4 +70,18 @@ describe("installSignalHandlers", () => {
     cleanup = undefined;
     expect(process.listenerCount("uncaughtException")).toBe(before);
   });
+
+  test("SIGPIPE listener is registered after install (prevents silent crash on broken pipe)", () => {
+    const before = process.listenerCount("SIGPIPE");
+    cleanup = installSignalHandlers(minimalCtx);
+    expect(process.listenerCount("SIGPIPE")).toBe(before + 1);
+  });
+
+  test("SIGPIPE listener is removed after cleanup", () => {
+    const before = process.listenerCount("SIGPIPE");
+    cleanup = installSignalHandlers(minimalCtx);
+    cleanup();
+    cleanup = undefined;
+    expect(process.listenerCount("SIGPIPE")).toBe(before);
+  });
 });


### PR DESCRIPTION
## What

Fixes two categories of silent nax process death that produce zero log output after `[acp-adapter] Sending prompt`.

## Why

The nax process was dying silently with no crash handler output in two scenarios:

- **Immediate (seconds):** `acpx` exits before nax writes its stdin → SIGPIPE kills nax (Bun doesn't set `SIG_IGN` unlike Node.js).
- **Delayed (10–20 min):** `new Response(proc.stdout).text()` either throws an unhandled rejection when `acpx` crashes mid-run, or hangs indefinitely when Bun's piped streams don't close after SIGTERM (known Bun bug).

Closes #251

## How

Four targeted fixes in `spawn-client.ts`, `crash-signals.ts`, and `adapter.ts`:

| Change | Effect |
|--------|--------|
| `crash-signals.ts`: register `SIGPIPE` handler | Broken-pipe writes no longer kill nax silently |
| `spawn-client.ts` `prompt()`: wrap stdin write in try-catch | Absorbs EPIPE when `acpx` exits during `pidRegistry.register()` await gap |
| `spawn-client.ts` `prompt()`: restructure drain — start reads early, `await proc.exited`, then race drains against 5 s deadline | Handles Bun bug where streams don't close after SIGTERM; `.catch(()=>"")` prevents unhandled rejections |
| `spawn-client.ts` both `trackedSpawn()`: add `.catch(()=>"")` | Stream errors from quick CLI calls can't become unhandled rejections |
| `adapter.ts` `runSessionPrompt()`: `promptPromise.catch(()=>{})` on timeout | Dangling rejection from cancelled `acpx` is silenced |

The drain pattern mirrors the existing solution in `src/verification/executor.ts` lines 86–123.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

`streamDrainTimeoutMs` is exposed on `_spawnClientDeps` (injectable, default 5 s) so the drain-timeout test can run in ~80 ms without a long `Bun.sleep`.