### PR TITLE
fix(acp): eliminate memory growth in long-running ACP sessions

### DIFF
--- a/src/agents/acp/parser.ts
+++ b/src/agents/acp/parser.ts
@@ -3,6 +3,12 @@
  *
  * Extracted from adapter.ts to keep that file within the 800-line limit.
  * Used by SpawnAcpSession.prompt() to parse acpx stdout.
+ *
+ * Two APIs are provided:
+ * - Incremental: createParseState() + parseAcpxJsonLine() + finalizeParseState()
+ *   Used by the line-reader in spawn-client to avoid buffering the full stdout.
+ * - Batch: parseAcpxJsonOutput() delegates to the incremental API.
+ *   Kept for backward compatibility and direct use in tests.
  */
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -17,8 +23,106 @@ export interface AcpxTokenUsage {
   cache_creation_input_tokens?: number;
 }
 
+/** Mutable accumulator for incremental NDJSON line parsing. */
+export interface AcpxParseState {
+  text: string;
+  tokenUsage: AcpxTokenUsage | undefined;
+  exactCostUsd: number | undefined;
+  stopReason: string | undefined;
+  error: string | undefined;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
-// parseAcpxJsonOutput
+// Incremental API
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createParseState(): AcpxParseState {
+  return { text: "", tokenUsage: undefined, exactCostUsd: undefined, stopReason: undefined, error: undefined };
+}
+
+/**
+ * Process a single NDJSON line into the accumulator state.
+ * Handles JSON-RPC envelope format (acpx v0.3+) and legacy flat NDJSON.
+ */
+export function parseAcpxJsonLine(line: string, state: AcpxParseState): void {
+  try {
+    const event = JSON.parse(line);
+
+    // ── JSON-RPC envelope format (acpx v0.3+) ──────────────────────────────
+    if (event.jsonrpc === "2.0") {
+      if (event.method === "session/update" && event.params?.update) {
+        const update = event.params.update;
+
+        // Text chunks
+        if (update.sessionUpdate === "agent_message_chunk" && update.content?.type === "text" && update.content.text) {
+          state.text += update.content.text;
+        }
+
+        // Exact cost from usage_update
+        if (update.sessionUpdate === "usage_update" && typeof update.cost?.amount === "number") {
+          state.exactCostUsd = update.cost.amount;
+        }
+      }
+
+      // Final result with token breakdown
+      if (event.id !== undefined && event.result && typeof event.result === "object") {
+        const result = event.result as Record<string, unknown>;
+
+        if (result.stopReason) state.stopReason = result.stopReason as string;
+        if (result.stop_reason) state.stopReason = result.stop_reason as string;
+
+        if (result.usage && typeof result.usage === "object") {
+          const u = result.usage as Record<string, unknown>;
+          state.tokenUsage = {
+            input_tokens: (u.inputTokens as number) ?? (u.input_tokens as number) ?? 0,
+            output_tokens: (u.outputTokens as number) ?? (u.output_tokens as number) ?? 0,
+            cache_read_input_tokens: (u.cachedReadTokens as number) ?? (u.cache_read_input_tokens as number) ?? 0,
+            cache_creation_input_tokens:
+              (u.cachedWriteTokens as number) ?? (u.cache_creation_input_tokens as number) ?? 0,
+          };
+        }
+      }
+
+      return;
+    }
+
+    // ── Legacy flat NDJSON format ───────────────────────────────────────────
+    if (event.content && typeof event.content === "string") state.text += event.content;
+    if (event.text && typeof event.text === "string") state.text += event.text;
+    if (event.result && typeof event.result === "string") state.text = event.result;
+
+    if (event.cumulative_token_usage) state.tokenUsage = event.cumulative_token_usage;
+    if (event.usage) {
+      state.tokenUsage = {
+        input_tokens: event.usage.input_tokens ?? event.usage.prompt_tokens ?? 0,
+        output_tokens: event.usage.output_tokens ?? event.usage.completion_tokens ?? 0,
+      };
+    }
+
+    if (event.stopReason) state.stopReason = event.stopReason;
+    if (event.stop_reason) state.stopReason = event.stop_reason;
+    if (event.error) {
+      state.error =
+        typeof event.error === "string" ? event.error : (event.error.message ?? JSON.stringify(event.error));
+    }
+  } catch {
+    if (!state.text) state.text = line;
+  }
+}
+
+/** Produce the final parsed result from an accumulated state. */
+export function finalizeParseState(state: AcpxParseState): ReturnType<typeof parseAcpxJsonOutput> {
+  return {
+    text: state.text.trim(),
+    tokenUsage: state.tokenUsage,
+    exactCostUsd: state.exactCostUsd,
+    stopReason: state.stopReason,
+    error: state.error,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Batch API (delegates to incremental)
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -38,82 +142,9 @@ export function parseAcpxJsonOutput(rawOutput: string): {
   stopReason?: string;
   error?: string;
 } {
-  const lines = rawOutput.split("\n").filter((l) => l.trim());
-  let text = "";
-  let tokenUsage: AcpxTokenUsage | undefined;
-  let exactCostUsd: number | undefined;
-  let stopReason: string | undefined;
-  let error: string | undefined;
-
-  for (const line of lines) {
-    try {
-      const event = JSON.parse(line);
-
-      // ── JSON-RPC envelope format (acpx v0.3+) ──────────────────────────────
-      if (event.jsonrpc === "2.0") {
-        // session/update events
-        if (event.method === "session/update" && event.params?.update) {
-          const update = event.params.update;
-
-          // Text chunks
-          if (
-            update.sessionUpdate === "agent_message_chunk" &&
-            update.content?.type === "text" &&
-            update.content.text
-          ) {
-            text += update.content.text;
-          }
-
-          // Exact cost from usage_update
-          if (update.sessionUpdate === "usage_update" && typeof update.cost?.amount === "number") {
-            exactCostUsd = update.cost.amount;
-          }
-        }
-
-        // Final result with token breakdown
-        if (event.id !== undefined && event.result && typeof event.result === "object") {
-          const result = event.result as Record<string, unknown>;
-
-          if (result.stopReason) stopReason = result.stopReason as string;
-          if (result.stop_reason) stopReason = result.stop_reason as string;
-
-          if (result.usage && typeof result.usage === "object") {
-            const u = result.usage as Record<string, unknown>;
-            tokenUsage = {
-              input_tokens: (u.inputTokens as number) ?? (u.input_tokens as number) ?? 0,
-              output_tokens: (u.outputTokens as number) ?? (u.output_tokens as number) ?? 0,
-              cache_read_input_tokens: (u.cachedReadTokens as number) ?? (u.cache_read_input_tokens as number) ?? 0,
-              cache_creation_input_tokens:
-                (u.cachedWriteTokens as number) ?? (u.cache_creation_input_tokens as number) ?? 0,
-            };
-          }
-        }
-
-        continue;
-      }
-
-      // ── Legacy flat NDJSON format ───────────────────────────────────────────
-      if (event.content && typeof event.content === "string") text += event.content;
-      if (event.text && typeof event.text === "string") text += event.text;
-      if (event.result && typeof event.result === "string") text = event.result;
-
-      if (event.cumulative_token_usage) tokenUsage = event.cumulative_token_usage;
-      if (event.usage) {
-        tokenUsage = {
-          input_tokens: event.usage.input_tokens ?? event.usage.prompt_tokens ?? 0,
-          output_tokens: event.usage.output_tokens ?? event.usage.completion_tokens ?? 0,
-        };
-      }
-
-      if (event.stopReason) stopReason = event.stopReason;
-      if (event.stop_reason) stopReason = event.stop_reason;
-      if (event.error) {
-        error = typeof event.error === "string" ? event.error : (event.error.message ?? JSON.stringify(event.error));
-      }
-    } catch {
-      if (!text) text = line;
-    }
+  const state = createParseState();
+  for (const line of rawOutput.split("\n")) {
+    if (line.trim()) parseAcpxJsonLine(line, state);
   }
-
-  return { text: text.trim(), tokenUsage, exactCostUsd, stopReason, error };
+  return finalizeParseState(state);
 }

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -142,11 +142,22 @@ class SpawnAcpSession implements AcpSession {
       const exitCode = await proc.exited;
 
       // Bun bug: piped streams may not close after kill (e.g. cancelActivePrompt SIGTERM).
-      // Race drain against a 5 s deadline so prompt() always resolves instead of hanging.
-      const drained = Bun.sleep(_spawnClientDeps.streamDrainTimeoutMs).then(() => "");
+      // Race each stream against its own cancellable drain timer so prompt() always resolves
+      // instead of hanging. Timers are cancelled as soon as the stream resolves to avoid
+      // keeping uncancellable Bun.sleep timers alive across multi-turn sessions.
+      const makeDrain = (ms: number): { promise: Promise<string>; cancel: () => void } => {
+        let id: ReturnType<typeof setTimeout> | undefined;
+        const promise = new Promise<string>((resolve) => {
+          id = setTimeout(() => resolve(""), ms);
+        });
+        // Promise executor runs synchronously — id is set before return.
+        return { promise, cancel: () => clearTimeout(id) };
+      };
+      const drainA = makeDrain(_spawnClientDeps.streamDrainTimeoutMs);
+      const drainB = makeDrain(_spawnClientDeps.streamDrainTimeoutMs);
       const [stdout, stderr] = await Promise.all([
-        Promise.race([stdoutPromise, drained]),
-        Promise.race([stderrPromise, drained]),
+        Promise.race([stdoutPromise, drainA.promise]).finally(() => drainA.cancel()),
+        Promise.race([stderrPromise, drainB.promise]).finally(() => drainB.cancel()),
       ]);
 
       if (exitCode !== 0) {

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -17,7 +17,7 @@ import { getSafeLogger } from "../../logger";
 import { typedSpawn } from "../../utils/bun-deps";
 import { buildAllowedEnv } from "../shared/env";
 import type { AcpClient, AcpSession, AcpSessionResponse } from "./adapter";
-import { parseAcpxJsonOutput } from "./parser";
+import { type AcpxParseState, createParseState, finalizeParseState, parseAcpxJsonLine } from "./parser";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -36,6 +36,43 @@ export const _spawnClientDeps = {
   /** Stream drain timeout after proc.exited — injectable so tests can use a short value. */
   streamDrainTimeoutMs: ACPX_STREAM_DRAIN_TIMEOUT_MS,
 };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Line-reader helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Read chunks from a stream, split on newlines, and feed each complete line
+ * into an AcpxParseState incrementally. Discards raw bytes immediately after
+ * parsing so only the extracted fields (strings + numbers) are held in memory.
+ *
+ * The caller races this promise against a drain timeout to handle the Bun bug
+ * where piped streams may not close after SIGTERM.
+ */
+async function readAndParseLines(stream: ReadableStream<Uint8Array>, state: AcpxParseState): Promise<void> {
+  const decoder = new TextDecoder();
+  let remainder = "";
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      remainder += decoder.decode(value, { stream: true });
+      for (;;) {
+        const nl = remainder.indexOf("\n");
+        if (nl < 0) break;
+        const line = remainder.slice(0, nl);
+        remainder = remainder.slice(nl + 1);
+        if (line.trim()) parseAcpxJsonLine(line, state);
+      }
+    }
+    // Flush decoder and process any content after the last newline
+    remainder += decoder.decode();
+    if (remainder.trim()) parseAcpxJsonLine(remainder.trim(), state);
+  } finally {
+    reader.releaseLock();
+  }
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Env builder
@@ -134,9 +171,12 @@ class SpawnAcpSession implements AcpSession {
         });
       }
 
-      // Start reads before proc.exited to prevent pipe-buffer deadlock on large output.
-      // .catch(() => "") guards against stream errors (e.g. acpx crash mid-run).
-      const stdoutPromise = new Response(proc.stdout).text().catch(() => "");
+      // Line-reader: parse stdout incrementally as lines arrive instead of buffering
+      // the full NDJSON output. Only extracted fields (strings + numbers) are held in
+      // memory — raw bytes are discarded immediately after each line is processed.
+      // .catch(() => {}) guards against stream errors (e.g. acpx crash mid-run).
+      const parseState = createParseState();
+      const parsePromise = readAndParseLines(proc.stdout, parseState).catch(() => {});
       const stderrPromise = new Response(proc.stderr).text().catch(() => "");
 
       const exitCode = await proc.exited;
@@ -144,7 +184,7 @@ class SpawnAcpSession implements AcpSession {
       // Bun bug: piped streams may not close after kill (e.g. cancelActivePrompt SIGTERM).
       // Race each stream against its own cancellable drain timer so prompt() always resolves
       // instead of hanging. Timers are cancelled as soon as the stream resolves to avoid
-      // keeping uncancellable Bun.sleep timers alive across multi-turn sessions.
+      // keeping uncancellable timers alive across multi-turn sessions.
       const makeDrain = (ms: number): { promise: Promise<string>; cancel: () => void } => {
         let id: ReturnType<typeof setTimeout> | undefined;
         const promise = new Promise<string>((resolve) => {
@@ -155,8 +195,8 @@ class SpawnAcpSession implements AcpSession {
       };
       const drainA = makeDrain(_spawnClientDeps.streamDrainTimeoutMs);
       const drainB = makeDrain(_spawnClientDeps.streamDrainTimeoutMs);
-      const [stdout, stderr] = await Promise.all([
-        Promise.race([stdoutPromise, drainA.promise]).finally(() => drainA.cancel()),
+      const [, stderr] = await Promise.all([
+        Promise.race([parsePromise, drainA.promise]).finally(() => drainA.cancel()),
         Promise.race([stderrPromise, drainB.promise]).finally(() => drainB.cancel()),
       ]);
 
@@ -173,7 +213,7 @@ class SpawnAcpSession implements AcpSession {
       }
 
       try {
-        const parsed = parseAcpxJsonOutput(stdout);
+        const parsed = finalizeParseState(parseState);
         return {
           messages: [{ role: "assistant", content: parsed.text || "" }],
           stopReason: parsed.stopReason ?? "end_turn",

--- a/test/unit/agents/acp/parser.test.ts
+++ b/test/unit/agents/acp/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseAcpxJsonOutput } from "../../../../src/agents/acp/parser";
+import { createParseState, finalizeParseState, parseAcpxJsonLine, parseAcpxJsonOutput } from "../../../../src/agents/acp/parser";
 
 // Real acpx JSON-RPC envelope format (captured from live acpx v0.3.0)
 const REAL_ACPX_OUTPUT = [
@@ -72,5 +72,66 @@ describe("parseAcpxJsonOutput — legacy flat NDJSON format", () => {
     const result = parseAcpxJsonOutput(output);
     expect(result.tokenUsage?.input_tokens).toBe(100);
     expect(result.tokenUsage?.output_tokens).toBe(50);
+  });
+});
+
+describe("incremental API — createParseState / parseAcpxJsonLine / finalizeParseState", () => {
+  const LINES = [
+    '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"x","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello"}}}}',
+    '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"x","update":{"sessionUpdate":"usage_update","used":24848,"size":200000,"cost":{"amount":0.15539,"currency":"USD"}}}}',
+    '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn","usage":{"inputTokens":3,"outputTokens":4,"cachedReadTokens":0,"cachedWriteTokens":24844}}}',
+  ];
+
+  test("produces same result as batch parseAcpxJsonOutput", () => {
+    const state = createParseState();
+    for (const line of LINES) parseAcpxJsonLine(line, state);
+    const incremental = finalizeParseState(state);
+    const batch = parseAcpxJsonOutput(LINES.join("\n"));
+    expect(incremental).toEqual(batch);
+  });
+
+  test("state is empty before any lines are processed", () => {
+    const state = createParseState();
+    const result = finalizeParseState(state);
+    expect(result.text).toBe("");
+    expect(result.tokenUsage).toBeUndefined();
+    expect(result.exactCostUsd).toBeUndefined();
+    expect(result.stopReason).toBeUndefined();
+  });
+
+  test("text accumulates across multiple chunk lines", () => {
+    const state = createParseState();
+    parseAcpxJsonLine(LINES[0], state); // "hello"
+    parseAcpxJsonLine(
+      '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"x","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":" world"}}}}',
+      state,
+    );
+    expect(finalizeParseState(state).text).toBe("hello world");
+  });
+
+  test("cost and token fields are captured independently", () => {
+    const state = createParseState();
+    parseAcpxJsonLine(LINES[1], state); // usage_update
+    expect(finalizeParseState(state).exactCostUsd).toBe(0.15539);
+    expect(finalizeParseState(state).tokenUsage).toBeUndefined(); // not yet — comes in result line
+
+    parseAcpxJsonLine(LINES[2], state); // result
+    const final = finalizeParseState(state);
+    expect(final.stopReason).toBe("end_turn");
+    expect(final.tokenUsage?.input_tokens).toBe(3);
+    expect(final.tokenUsage?.output_tokens).toBe(4);
+  });
+
+  test("invalid JSON line is ignored if text already accumulated", () => {
+    const state = createParseState();
+    parseAcpxJsonLine(LINES[0], state);
+    parseAcpxJsonLine("not-json", state);
+    expect(finalizeParseState(state).text).toBe("hello");
+  });
+
+  test("invalid JSON line used as fallback text when state is empty", () => {
+    const state = createParseState();
+    parseAcpxJsonLine("bare fallback text", state);
+    expect(finalizeParseState(state).text).toBe("bare fallback text");
   });
 });


### PR DESCRIPTION
## What

Two fixes to `SpawnAcpSession.prompt()` that eliminate steady memory growth during long-running acpx sessions.

## Why

Observed ~35 MB/min memory growth while a session was active (76 MB → 218 MB over 7 minutes). Root cause: two issues in how stdout was read after spawning the acpx subprocess.

Closes #272

## How

**Fix 1 — cancellable drain timers** (`src/agents/acp/spawn-client.ts`)

The previous code created a single `Bun.sleep(5000)` promise shared across two `Promise.race()` calls (stdout + stderr drain). `Bun.sleep` cannot be cancelled, so the timer always ran the full 5 s even when both streams closed normally. In multi-turn sessions, multiple outstanding 5 s timers piled up.

Replaced with two independent `setTimeout`-based drain timers (one per stream), each cancelled via `clearTimeout()` in `.finally()` as soon as its stream resolves.

**Fix 2 — line-by-line NDJSON parser** (`src/agents/acp/parser.ts`, `src/agents/acp/spawn-client.ts`)

`new Response(proc.stdout).text()` buffered the entire acpx output as a single string for the session lifetime. acpx emits NDJSON — tool results, file reads, diffs, test output — which grows proportionally to what Claude Code does. The string was held in memory until `proc.exited` resolved.

Replaced with `readAndParseLines()`: an async line-reader that processes each NDJSON line through the incremental parser as it arrives off the pipe, discarding raw bytes immediately. Only the extracted fields (a few strings and numbers) are held in memory regardless of output volume.

To support this, `parser.ts` now exposes an incremental API:
- `createParseState()` — fresh accumulator
- `parseAcpxJsonLine(line, state)` — process one line in-place
- `finalizeParseState(state)` — produce the result

`parseAcpxJsonOutput()` delegates to these (no duplication). The returned `AcpSessionResponse` shape and all callers are unchanged.

The pipe-buffer deadlock concern from `2b142bd5` also disappears: the pipe is always being consumed, so it never fills up. The drain timeout is still needed for the SIGTERM stream-hang Bun bug.

## Testing

- [x] Tests added/updated — 7 new tests for the incremental parser API in `test/unit/agents/acp/parser.test.ts`; all 27 tests in parser + spawn-client pass
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

`parseAcpxJsonOutput()` is kept unchanged for any existing callers. It now delegates to the incremental API internally so there is no duplicated parsing logic.