### PR TITLE
fix(monorepo): per-package config inheritance in decomposed stories

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -870,8 +870,12 @@ export async function planDecomposeCommand(
     decompStories = undefined;
   }
 
-  // biome-ignore lint/style/noNonNullAssertion: loop guarantees decompStories is set (maxReplanAttempts >= 1 per schema)
-  const subStoriesWithParent: UserStory[] = mapDecomposedStoriesToUserStories(decompStories!, options.storyId);
+  const subStoriesWithParent: UserStory[] = mapDecomposedStoriesToUserStories(
+    // biome-ignore lint/style/noNonNullAssertion: loop guarantees decompStories is set
+    decompStories!,
+    options.storyId,
+    targetStory.workdir,
+  );
 
   const updatedStories = prd.userStories.map((s) =>
     s.id === options.storyId ? { ...s, status: "decomposed" as StoryStatus } : s,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -209,7 +209,7 @@ export async function loadConfigForWorkdir(rootConfigPath: string, packageDir?: 
   const packageOverride = await loadJsonFile<Partial<NaxConfig>>(packageConfigPath, "config");
 
   if (!packageOverride) {
-    logger.debug("config", "Per-package config not found — falling back to root config", {
+    logger.info("config", "Per-package config not found — falling back to root config", {
       packageConfigPath,
       packageDir,
     });

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -291,6 +291,8 @@ const ReviewConfigSchema = z.object({
     lint: z.string().optional(),
     test: z.string().optional(),
     build: z.string().optional(),
+    lintFix: z.string().optional(),
+    formatFix: z.string().optional(),
   }),
   pluginMode: z.enum(["per-story", "deferred"]).default("per-story"),
   semantic: SemanticReviewConfigSchema.optional(),

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -61,8 +61,10 @@ export const autofixStage: PipelineStage = {
 
     // PKG-004: use centrally resolved effective config (ctx.effectiveConfig set once per story)
     const effectiveConfig = ctx.effectiveConfig ?? ctx.config;
-    const lintFixCmd = effectiveConfig.quality.commands.lintFix;
-    const formatFixCmd = effectiveConfig.quality.commands.formatFix;
+    // Check quality.commands first, then fall back to review.commands — users often define
+    // lintFix/formatFix in review.commands alongside other review commands (lint, typecheck).
+    const lintFixCmd = effectiveConfig.quality.commands.lintFix ?? effectiveConfig.review.commands.lintFix;
+    const formatFixCmd = effectiveConfig.quality.commands.formatFix ?? effectiveConfig.review.commands.formatFix;
 
     // Effective workdir for running commands (scoped to package if monorepo)
     const effectiveWorkdir = ctx.story.workdir ? join(ctx.workdir, ctx.story.workdir) : ctx.workdir;

--- a/src/prd/decompose-mapper.ts
+++ b/src/prd/decompose-mapper.ts
@@ -15,13 +15,19 @@ import type { UserStory } from "./types";
  * - Moves complexity, testStrategy, and reasoning into routing sub-object
  * - Sets lifecycle defaults: status='pending', passes=false, escalations=[], attempts=0
  * - Validates required fields (id, contextFiles) and throws with entry index on failure
+ * - Inherits workdir from parent story so per-package config is applied to sub-stories
  *
  * @param stories - Flat decompose output from adapter
  * @param parentStoryId - ID of the parent story being decomposed
+ * @param parentWorkdir - workdir of the parent story (inherited by all sub-stories)
  * @returns Mapped UserStory array ready for PRD insertion
  * @throws {NaxError} code=DECOMPOSE_VALIDATION_FAILED when required fields are missing
  */
-export function mapDecomposedStoriesToUserStories(stories: DecomposedStory[], parentStoryId: string): UserStory[] {
+export function mapDecomposedStoriesToUserStories(
+  stories: DecomposedStory[],
+  parentStoryId: string,
+  parentWorkdir?: string,
+): UserStory[] {
   return stories.map((story, entryIndex) => {
     if (!story.id) {
       throw new NaxError(`Entry at index ${entryIndex} is missing required field: id`, "DECOMPOSE_VALIDATION_FAILED", {
@@ -53,6 +59,7 @@ export function mapDecomposedStoriesToUserStories(stories: DecomposedStory[], pa
       escalations: [],
       attempts: 0,
       parentStoryId,
+      ...(parentWorkdir !== undefined && { workdir: parentWorkdir }),
       routing: {
         complexity: story.complexity,
         testStrategy: story.testStrategy ?? ("test-after" as const),

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -89,6 +89,10 @@ export interface ReviewConfig {
     lint?: string;
     test?: string;
     build?: string;
+    /** Auto-fix lint errors — used by autofix stage when lint fails */
+    lintFix?: string;
+    /** Auto-fix formatting — used by autofix stage when lint fails */
+    formatFix?: string;
   };
   /** When to run plugin reviewers: per-story (default) or deferred (skip per-story, run once at end) */
   pluginMode?: "per-story" | "deferred";

--- a/test/unit/config/loader-workdir.test.ts
+++ b/test/unit/config/loader-workdir.test.ts
@@ -94,25 +94,25 @@ describe("loadConfigForWorkdir", () => {
     expect(result.quality.commands.test).toBe("bun test");
   });
 
-  test("BUG-134: logs debug when package config not found (fallback to root)", async () => {
+  test("BUG-134: logs info when package config not found (fallback to root)", async () => {
     writeFileSync(
       join(tempDir, ".nax", "config.json"),
       JSON.stringify({ quality: { commands: { test: "bun test" } } }),
     );
 
     const logger = getLogger();
-    const debugSpy = spyOn(logger, "debug");
+    const infoSpy = spyOn(logger, "info");
 
     const rootConfigPath = join(tempDir, ".nax", "config.json");
     await loadConfigForWorkdir(rootConfigPath, "packages/missing");
 
-    const fallbackCall = debugSpy.mock.calls.find(
+    const fallbackCall = infoSpy.mock.calls.find(
       (args) => typeof args[1] === "string" && args[1].includes("Per-package config not found"),
     );
     expect(fallbackCall).toBeDefined();
     expect(fallbackCall?.[2]).toMatchObject({ packageDir: "packages/missing" });
 
-    debugSpy.mockRestore();
+    infoSpy.mockRestore();
   });
 
   test("BUG-134: logs debug when packageDir is undefined (no per-package resolution)", async () => {

--- a/test/unit/config/quality-commands-schema.test.ts
+++ b/test/unit/config/quality-commands-schema.test.ts
@@ -8,9 +8,9 @@
  * template was never applied and scoped tests fell back to buildSmartTestCommand.
  */
 
-import { describe, test, expect } from "bun:test";
-import { NaxConfigSchema } from "../../../src/config/schemas";
+import { describe, expect, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../../src/config/defaults";
+import { NaxConfigSchema } from "../../../src/config/schemas";
 
 function buildConfigWithCommands(commands: Record<string, unknown>) {
   return {
@@ -80,5 +80,46 @@ describe("quality.commands schema", () => {
     const input = buildConfigWithCommands({});
     const result = NaxConfigSchema.parse(input);
     expect(result.quality.commands.build).toBeUndefined();
+  });
+});
+
+describe("review.commands schema — lintFix/formatFix not stripped by Zod", () => {
+  function buildConfigWithReviewCommands(commands: Record<string, unknown>) {
+    return {
+      ...DEFAULT_CONFIG,
+      review: {
+        ...DEFAULT_CONFIG.review,
+        commands: {
+          ...DEFAULT_CONFIG.review.commands,
+          ...commands,
+        },
+      },
+    };
+  }
+
+  test("lintFix in review.commands is preserved after schema parse", () => {
+    const input = buildConfigWithReviewCommands({ lintFix: "bun run lint:fix" });
+    const result = NaxConfigSchema.parse(input);
+    expect(result.review.commands.lintFix).toBe("bun run lint:fix");
+  });
+
+  test("formatFix in review.commands is preserved after schema parse", () => {
+    const input = buildConfigWithReviewCommands({ formatFix: "bun run format --write" });
+    const result = NaxConfigSchema.parse(input);
+    expect(result.review.commands.formatFix).toBe("bun run format --write");
+  });
+
+  test("lintFix and formatFix coexist with standard review commands", () => {
+    const input = buildConfigWithReviewCommands({
+      lint: "bun run lint",
+      typecheck: "bun run typecheck",
+      lintFix: "bun run lint:fix",
+      formatFix: "bun run format --write",
+    });
+    const result = NaxConfigSchema.parse(input);
+    expect(result.review.commands.lint).toBe("bun run lint");
+    expect(result.review.commands.typecheck).toBe("bun run typecheck");
+    expect(result.review.commands.lintFix).toBe("bun run lint:fix");
+    expect(result.review.commands.formatFix).toBe("bun run format --write");
   });
 });

--- a/test/unit/pipeline/effective-config.test.ts
+++ b/test/unit/pipeline/effective-config.test.ts
@@ -13,6 +13,7 @@ import { mergePackageConfig } from "../../../src/config/merge";
 import type { NaxConfig } from "../../../src/config/schema";
 import type { PipelineContext } from "../../../src/pipeline/types";
 import type { PRD, UserStory } from "../../../src/prd/types";
+import type { ReviewResult } from "../../../src/review/types";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -207,7 +208,12 @@ describe("stage effectiveConfig fallback", () => {
       prd: makePrd(),
       story: makeStory(),
       stories: [makeStory()],
-      routing: { complexity: "simple" as const, modelTier: "fast" as const, testStrategy: "test-after" as const, reasoning: "" },
+      routing: {
+        complexity: "simple" as const,
+        modelTier: "fast" as const,
+        testStrategy: "test-after" as const,
+        reasoning: "",
+      },
       workdir: "/tmp/test",
       hooks: { hooks: {} },
     } as Parameters<typeof verifyStage.execute>[0];
@@ -338,5 +344,129 @@ describe("effectiveConfig per-story isolation", () => {
     // No workdir means effectiveConfig === root
     const result = mergePackageConfig(root, {});
     expect(result).toBe(root);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// autofix stage reads lintFix/formatFix from review.commands as fallback
+// ---------------------------------------------------------------------------
+
+describe("autofix stage lintFix source", () => {
+  test("uses quality.commands.lintFix when defined", async () => {
+    const { autofixStage, _autofixDeps } = await import("../../../src/pipeline/stages/autofix");
+
+    const saved = { ..._autofixDeps };
+    const commandsRun: string[] = [];
+    _autofixDeps.runQualityCommand = async (opts) => {
+      commandsRun.push(opts.commandName);
+      return {
+        commandName: opts.commandName,
+        command: opts.command,
+        success: true,
+        exitCode: 0,
+        output: "",
+        durationMs: 0,
+        timedOut: false,
+      };
+    };
+    _autofixDeps.recheckReview = async () => true;
+
+    const config = makeBaseConfig({
+      quality: { ...DEFAULT_CONFIG.quality, commands: { lintFix: "bun run lint:fix" }, autofix: { enabled: true } },
+      review: { ...DEFAULT_CONFIG.review, commands: {} },
+    });
+    const ctx = makeCtx({
+      effectiveConfig: config,
+      reviewResult: {
+        success: false,
+        checks: [
+          { check: "lint", success: false, command: "bun run lint", exitCode: 1, output: "lint error", durationMs: 0 },
+        ],
+        totalDurationMs: 0,
+      } satisfies ReviewResult,
+    });
+
+    await autofixStage.execute(ctx);
+    Object.assign(_autofixDeps, saved);
+
+    expect(commandsRun).toContain("lintFix");
+  });
+
+  test("falls back to review.commands.lintFix when quality.commands.lintFix is absent", async () => {
+    const { autofixStage, _autofixDeps } = await import("../../../src/pipeline/stages/autofix");
+
+    const saved = { ..._autofixDeps };
+    const commandsRun: string[] = [];
+    _autofixDeps.runQualityCommand = async (opts) => {
+      commandsRun.push(opts.commandName);
+      return {
+        commandName: opts.commandName,
+        command: opts.command,
+        success: true,
+        exitCode: 0,
+        output: "",
+        durationMs: 0,
+        timedOut: false,
+      };
+    };
+    _autofixDeps.recheckReview = async () => true;
+
+    const config = makeBaseConfig({
+      quality: { ...DEFAULT_CONFIG.quality, commands: {}, autofix: { enabled: true } },
+      review: { ...DEFAULT_CONFIG.review, commands: { lintFix: "bun run lint:fix" } },
+    });
+    const ctx = makeCtx({
+      effectiveConfig: config,
+      reviewResult: {
+        success: false,
+        checks: [
+          { check: "lint", success: false, command: "bun run lint", exitCode: 1, output: "lint error", durationMs: 0 },
+        ],
+      } as any,
+    });
+
+    await autofixStage.execute(ctx);
+    Object.assign(_autofixDeps, saved);
+
+    expect(commandsRun).toContain("lintFix");
+  });
+
+  test("skips mechanical fix when neither quality.commands nor review.commands defines lintFix", async () => {
+    const { autofixStage, _autofixDeps } = await import("../../../src/pipeline/stages/autofix");
+
+    const saved = { ..._autofixDeps };
+    let qualityCommandCalled = false;
+    _autofixDeps.runQualityCommand = async (opts) => {
+      qualityCommandCalled = true;
+      return {
+        commandName: opts.commandName,
+        command: opts.command,
+        success: true,
+        exitCode: 0,
+        output: "",
+        durationMs: 0,
+        timedOut: false,
+      };
+    };
+    _autofixDeps.runAgentRectification = async () => false;
+
+    const config = makeBaseConfig({
+      quality: { ...DEFAULT_CONFIG.quality, commands: {}, autofix: { enabled: true } },
+      review: { ...DEFAULT_CONFIG.review, commands: {} },
+    });
+    const ctx = makeCtx({
+      effectiveConfig: config,
+      reviewResult: {
+        success: false,
+        checks: [
+          { check: "lint", success: false, command: "bun run lint", exitCode: 1, output: "lint error", durationMs: 0 },
+        ],
+      } as any,
+    });
+
+    await autofixStage.execute(ctx);
+    Object.assign(_autofixDeps, saved);
+
+    expect(qualityCommandCalled).toBe(false);
   });
 });

--- a/test/unit/prd/decompose-mapper.test.ts
+++ b/test/unit/prd/decompose-mapper.test.ts
@@ -162,6 +162,44 @@ describe("mapDecomposedStoriesToUserStories — direct field mapping", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// workdir inheritance — sub-stories must inherit parent workdir (PKG-003)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("mapDecomposedStoriesToUserStories — workdir inheritance", () => {
+  test("sub-stories inherit parentWorkdir when provided", () => {
+    const stories = [
+      makeDecomposedStory({ id: "US-002-A" }),
+      makeDecomposedStory({ id: "US-002-B" }),
+    ];
+    const result = mapDecomposedStoriesToUserStories(stories, "US-002", "apps/api");
+    expect(result[0].workdir).toBe("apps/api");
+    expect(result[1].workdir).toBe("apps/api");
+  });
+
+  test("workdir is absent when parentWorkdir is not provided", () => {
+    const [result] = mapDecomposedStoriesToUserStories([makeDecomposedStory()], "US-001");
+    expect(result.workdir).toBeUndefined();
+  });
+
+  test("workdir is absent when parentWorkdir is undefined", () => {
+    const [result] = mapDecomposedStoriesToUserStories([makeDecomposedStory()], "US-001", undefined);
+    expect(result.workdir).toBeUndefined();
+  });
+
+  test("all sub-stories get the same workdir as the parent", () => {
+    const stories = [
+      makeDecomposedStory({ id: "VCS-P1-002-A" }),
+      makeDecomposedStory({ id: "VCS-P1-002-B" }),
+      makeDecomposedStory({ id: "VCS-P1-002-C" }),
+    ];
+    const result = mapDecomposedStoriesToUserStories(stories, "VCS-P1-002", "apps/api");
+    for (const story of result) {
+      expect(story.workdir).toBe("apps/api");
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // AC3: validation — missing id
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes two inter-related monorepo per-package configuration bugs that caused verify and autofix to use root-level commands instead of per-package commands.

- **Bug 1 (autofix lintFix not called)**: `lintFix`/`formatFix` were silently stripped from `review.commands` by Zod validation. Autofix now falls back from `quality.commands.lintFix` → `review.commands.lintFix`
- **Bug 2 (verify uses root test command)**: Sub-stories from `nax plan --decompose` don't inherit parent's `workdir`, so `loadConfigForWorkdir` never loads `.nax/mono/<workdir>/config.json`

Closes #274

## Root Causes

**Bug 1:** `ReviewConfigSchema.commands` was missing `lintFix`/`formatFix` fields — Zod stripped them from the parsed root config. Additionally, autofix only checked `quality.commands.lintFix` with no fallback to `review.commands.lintFix` (where users commonly define fix commands alongside other review commands).

**Bug 2:** `mapDecomposedStoriesToUserStories()` didn't propagate parent `workdir` to sub-stories. When a story with `workdir: "apps/api"` is decomposed, sub-stories got `workdir: undefined`, causing `iteration-runner` to use root config instead of the per-package merged config.

## Changes

| File | Change |
|------|--------|
| `src/config/schemas.ts` | Added `lintFix`/`formatFix` to `ReviewConfigSchema.commands` |
| `src/review/types.ts` | Added `lintFix?`/`formatFix?` to `ReviewConfig.commands` TS interface |
| `src/pipeline/stages/autofix.ts` | Fallback: `quality.commands.lintFix ?? review.commands.lintFix` |
| `src/config/loader.ts` | Upgraded "per-package config not found" log from `debug` → `info` |
| `src/prd/decompose-mapper.ts` | Added `parentWorkdir?` param — sub-stories inherit parent workdir |
| `src/cli/plan.ts` | Passes `targetStory.workdir` to `mapDecomposedStoriesToUserStories` |

## Test Plan

- [x] `bun test test/unit/prd/decompose-mapper.test.ts` — 28 pass (4 new: workdir inheritance)
- [x] `bun test test/unit/pipeline/effective-config.test.ts` — 29 pass (3 new: lintFix source resolution)
- [x] `bun test test/unit/config/quality-commands-schema.test.ts` — 29 pass (3 new: review.commands schema)
- [x] `bun test test/unit/config/loader-workdir.test.ts` — 7 pass (updated log level assertion)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Manual: decompose a monorepo story with `workdir` set, verify sub-stories inherit it in prd.json
- [ ] Manual: confirm verify uses per-package test command and autofix calls per-package lintFix