### PR TITLE
fix: reset failed stories to pending on re-run

### DIFF
--- a/src/execution/lifecycle/run-initialization.ts
+++ b/src/execution/lifecycle/run-initialization.ts
@@ -15,7 +15,7 @@ import type { NaxConfig } from "../../config";
 import { AgentNotFoundError, AgentNotInstalledError, StoryLimitExceededError } from "../../errors";
 import { getSafeLogger } from "../../logger";
 import type { AgentGetFn } from "../../pipeline/types";
-import { countStories, loadPRD, markStoryPassed, savePRD } from "../../prd";
+import { countStories, loadPRD, markStoryPassed, resetFailedStoriesToPending, savePRD } from "../../prd";
 import type { PRD } from "../../prd/types";
 import { runReview } from "../../review/runner";
 import type { ReviewConfig } from "../../review/types";
@@ -184,6 +184,16 @@ export async function initializeRun(ctx: InitializationContext): Promise<Initial
   // Load and reconcile PRD
   let prd = await loadPRD(ctx.prdPath);
   prd = await reconcileState(prd, ctx.prdPath, ctx.workdir, ctx.config);
+
+  // Reset failed stories to pending so they are retried on re-run.
+  // reconcileState runs first to promote failed→passed for git-committed stories;
+  // remaining failed stories (incomplete work) are reset here so they re-enter the queue.
+  const hadFailedStories = resetFailedStoriesToPending(prd);
+  if (hadFailedStories) {
+    const resetIds = prd.userStories.filter((s) => s.status === "pending" && (s.attempts ?? 0) > 0).map((s) => s.id);
+    logger?.info("run-initialization", "Reset failed stories to pending for re-run", { storyIds: resetIds });
+    await savePRD(prd, ctx.prdPath);
+  }
 
   // Validate story counts
   const counts = countStories(prd);

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -211,6 +211,23 @@ export function markStoryFailed(
   }
 }
 
+/**
+ * Reset all failed stories to pending so they are eligible for re-execution
+ * on a fresh run. Keeps `attempts` intact so the history is preserved.
+ *
+ * @returns true if any stories were reset (PRD is dirty and should be saved)
+ */
+export function resetFailedStoriesToPending(prd: PRD): boolean {
+  let modified = false;
+  for (const story of prd.userStories) {
+    if (story.status === "failed") {
+      story.status = "pending";
+      modified = true;
+    }
+  }
+  return modified;
+}
+
 /** Mark a story as skipped */
 export function markStorySkipped(prd: PRD, storyId: string): void {
   const story = prd.userStories.find((s) => s.id === storyId);

--- a/test/integration/pipeline/reporter-lifecycle.test.ts
+++ b/test/integration/pipeline/reporter-lifecycle.test.ts
@@ -719,8 +719,11 @@ describe("Reporter Lifecycle Events (US-004)", () => {
     expect(await Bun.file(workingRunEnd).exists()).toBe(true);
   });
 
-  test("AC6: Events fire even when the run fails or is aborted (onRunEnd still fires)", async () => {
-    // Create PRD with a story that will be marked as failed
+  test("AC6: Events fire even when the run exits with incomplete stories (onRunEnd still fires)", async () => {
+    // Use a paused story — paused is a terminal state that is not reset on re-run,
+    // so the run exits without executing anything. This verifies hooks fire on non-completion.
+    // Note: "failed" stories are now reset to "pending" on re-run (they are retried), so
+    // paused is used here to simulate a run that exits with unfinished stories.
     const prd = {
       feature: "test-feature",
       userStories: [
@@ -729,7 +732,7 @@ describe("Reporter Lifecycle Events (US-004)", () => {
           title: "Story 1",
           description: "Test story 1",
           acceptanceCriteria: ["AC1: Should work"],
-          status: "failed" as const,
+          status: "paused" as const,
           dependencies: [],
         },
       ],
@@ -739,7 +742,7 @@ describe("Reporter Lifecycle Events (US-004)", () => {
 
     const hooks = await loadHooksConfig(workdir);
 
-    // Run should complete even though story is already failed
+    // Run should complete even though no story can be executed
     await run({
       prdPath,
       workdir,
@@ -751,7 +754,7 @@ describe("Reporter Lifecycle Events (US-004)", () => {
       skipPrecheck: true,
     });
 
-    // Verify onRunStart and onRunEnd were still called
+    // Verify onRunStart and onRunEnd were still called regardless of story outcome
     const runStartFile = path.join(tmpDir, "run-start.json");
     const runEndFile = path.join(tmpDir, "run-end.json");
 
@@ -759,7 +762,7 @@ describe("Reporter Lifecycle Events (US-004)", () => {
     expect(await Bun.file(runEndFile).exists()).toBe(true);
 
     const runEndData = JSON.parse(await Bun.file(runEndFile).text());
-    expect(runEndData.storySummary.failed).toBeGreaterThan(0);
+    expect(runEndData.storySummary.paused).toBeGreaterThan(0);
   });
 
   test("onStoryComplete receives correct status for paused stories", async () => {

--- a/test/unit/execution/lifecycle/run-initialization.test.ts
+++ b/test/unit/execution/lifecycle/run-initialization.test.ts
@@ -1,10 +1,11 @@
 /**
  * Unit tests for run-initialization.ts — ENH-007
  *
- * Verifies reconcileState behavior:
- * - Only review/autofix failures are reconcilable (re-runs review gate)
- * - All other failure stages (execution, verify, etc.) are NOT reconciled
- * - No failureStage => NOT reconciled (unknown failure = not safe)
+ * Verifies reconcileState + resetFailedStoriesToPending behavior:
+ * - Only review/autofix failures are reconcilable (re-runs review gate → "passed")
+ * - All other failure stages (execution, verify, etc.) are NOT reconciled to "passed"
+ *   but ARE reset to "pending" for re-run
+ * - No failureStage => NOT reconciled to "passed", reset to "pending" for re-run
  */
 
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -99,14 +100,14 @@ describe("reconcileState", () => {
     }
   });
 
-  test("no failureStage + commits => NOT reconciled (unknown failure stage)", async () => {
+  test("no failureStage + commits => NOT reconciled to passed (unknown failure stage), reset to pending for re-run", async () => {
     _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(true));
     _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewSuccess()));
 
     const prd = makePrd({ status: "failed" }); // no failureStage
     const result = await runReconcile(prd, "-1");
 
-    expect(result.userStories[0].status).toBe("failed");
+    expect(result.userStories[0].status).toBe("pending");
     expect(_reconcileDeps.runReview).not.toHaveBeenCalled();
   });
 
@@ -121,14 +122,14 @@ describe("reconcileState", () => {
     expect(_reconcileDeps.runReview).toHaveBeenCalledTimes(1);
   });
 
-  test("failureStage=review + review still fails => NOT reconciled", async () => {
+  test("failureStage=review + review still fails => NOT reconciled to passed, reset to pending for re-run", async () => {
     _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(true));
     _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewFailure("typecheck failed")));
 
     const prd = makePrd({ status: "failed", failureStage: "review" });
     const result = await runReconcile(prd, "-3");
 
-    expect(result.userStories[0].status).toBe("failed");
+    expect(result.userStories[0].status).toBe("pending");
     expect(_reconcileDeps.runReview).toHaveBeenCalledTimes(1);
   });
 
@@ -143,47 +144,47 @@ describe("reconcileState", () => {
     expect(_reconcileDeps.runReview).toHaveBeenCalledTimes(1);
   });
 
-  test("failureStage=execution + commits => NOT reconciled", async () => {
+  test("failureStage=execution + commits => NOT reconciled to passed, reset to pending for re-run", async () => {
     _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(true));
     _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewSuccess()));
 
     const prd = makePrd({ status: "failed", failureStage: "execution" });
     const result = await runReconcile(prd, "-5");
 
-    expect(result.userStories[0].status).toBe("failed");
+    expect(result.userStories[0].status).toBe("pending");
     expect(_reconcileDeps.runReview).not.toHaveBeenCalled();
   });
 
-  test("failureStage=verify + commits => NOT reconciled", async () => {
+  test("failureStage=verify + commits => NOT reconciled to passed, reset to pending for re-run", async () => {
     _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(true));
     _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewSuccess()));
 
     const prd = makePrd({ status: "failed", failureStage: "verify" });
     const result = await runReconcile(prd, "-8");
 
-    expect(result.userStories[0].status).toBe("failed");
+    expect(result.userStories[0].status).toBe("pending");
     expect(_reconcileDeps.runReview).not.toHaveBeenCalled();
   });
 
-  test("failureStage=regression + commits => NOT reconciled", async () => {
+  test("failureStage=regression + commits => NOT reconciled to passed, reset to pending for re-run", async () => {
     _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(true));
     _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewSuccess()));
 
     const prd = makePrd({ status: "failed", failureStage: "regression" });
     const result = await runReconcile(prd, "-9");
 
-    expect(result.userStories[0].status).toBe("failed");
+    expect(result.userStories[0].status).toBe("pending");
     expect(_reconcileDeps.runReview).not.toHaveBeenCalled();
   });
 
-  test("no commits => NOT reconciled (existing behavior)", async () => {
+  test("no commits => NOT reconciled to passed, reset to pending for re-run", async () => {
     _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(false));
     _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewSuccess()));
 
     const prd = makePrd({ status: "failed", failureStage: "review" });
     const result = await runReconcile(prd, "-6");
 
-    expect(result.userStories[0].status).toBe("failed");
+    expect(result.userStories[0].status).toBe("pending");
     expect(_reconcileDeps.runReview).not.toHaveBeenCalled();
   });
 
@@ -200,5 +201,27 @@ describe("reconcileState", () => {
     await runReconcile(prd, "-7");
 
     expect(capturedWorkdir).toBe(join(tmpDir, "packages/api"));
+  });
+
+  test("re-run: failed story is reset to pending and attempts count is preserved", async () => {
+    _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(false));
+    _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewSuccess()));
+
+    const prd = makePrd({ status: "failed", failureStage: "execution", attempts: 2 });
+    const result = await runReconcile(prd, "-10");
+
+    expect(result.userStories[0].status).toBe("pending");
+    expect(result.userStories[0].attempts).toBe(2);
+  });
+
+  test("re-run: already-passed story is not touched", async () => {
+    _reconcileDeps.hasCommitsForStory = mock(() => Promise.resolve(false));
+    _reconcileDeps.runReview = mock(() => Promise.resolve(makeReviewSuccess()));
+
+    const prd = makePrd({ status: "passed", passes: true, attempts: 1 });
+    const result = await runReconcile(prd, "-11");
+
+    expect(result.userStories[0].status).toBe("passed");
+    expect(result.userStories[0].passes).toBe(true);
   });
 });

--- a/test/unit/prd/prd-reset-failed.test.ts
+++ b/test/unit/prd/prd-reset-failed.test.ts
@@ -1,0 +1,124 @@
+/**
+ * resetFailedStoriesToPending() Unit Tests
+ *
+ * Verifies that failed stories are reset to pending on re-run so the
+ * execution loop can pick them up again.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { resetFailedStoriesToPending } from "../../../src/prd";
+import type { PRD, UserStory } from "../../../src/prd/types";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeStory(id: string, overrides: Partial<UserStory> = {}): UserStory {
+  return {
+    id,
+    title: `Story ${id}`,
+    description: "Test story",
+    acceptanceCriteria: [],
+    tags: [],
+    dependencies: [],
+    status: "pending",
+    passes: false,
+    escalations: [],
+    attempts: 0,
+    ...overrides,
+  };
+}
+
+function makePrd(stories: UserStory[]): PRD {
+  return {
+    project: "test",
+    feature: "test-feature",
+    branchName: "feature/test",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    userStories: stories,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("resetFailedStoriesToPending()", () => {
+  test("resets a failed story to pending", () => {
+    const prd = makePrd([makeStory("US-001", { status: "failed", attempts: 1 })]);
+    resetFailedStoriesToPending(prd);
+    expect(prd.userStories[0].status).toBe("pending");
+  });
+
+  test("resets all failed stories when multiple exist", () => {
+    const prd = makePrd([
+      makeStory("US-001", { status: "failed", attempts: 2 }),
+      makeStory("US-002", { status: "failed", attempts: 1 }),
+    ]);
+    resetFailedStoriesToPending(prd);
+    expect(prd.userStories[0].status).toBe("pending");
+    expect(prd.userStories[1].status).toBe("pending");
+  });
+
+  test("preserves attempts count after reset", () => {
+    const prd = makePrd([makeStory("US-001", { status: "failed", attempts: 3 })]);
+    resetFailedStoriesToPending(prd);
+    expect(prd.userStories[0].attempts).toBe(3);
+  });
+
+  test("does not touch stories with status passed", () => {
+    const prd = makePrd([makeStory("US-001", { status: "passed", passes: true })]);
+    resetFailedStoriesToPending(prd);
+    expect(prd.userStories[0].status).toBe("passed");
+  });
+
+  test("does not touch stories with status pending", () => {
+    const prd = makePrd([makeStory("US-001", { status: "pending" })]);
+    resetFailedStoriesToPending(prd);
+    expect(prd.userStories[0].status).toBe("pending");
+  });
+
+  test("does not touch stories with status skipped", () => {
+    const prd = makePrd([makeStory("US-001", { status: "skipped" })]);
+    resetFailedStoriesToPending(prd);
+    expect(prd.userStories[0].status).toBe("skipped");
+  });
+
+  test("does not touch stories with status blocked", () => {
+    const prd = makePrd([makeStory("US-001", { status: "blocked" })]);
+    resetFailedStoriesToPending(prd);
+    expect(prd.userStories[0].status).toBe("blocked");
+  });
+
+  test("does not reset regression-failed stories (only exact 'failed' status)", () => {
+    const prd = makePrd([makeStory("US-001", { status: "regression-failed" as UserStory["status"] })]);
+    resetFailedStoriesToPending(prd);
+    expect(prd.userStories[0].status).toBe("regression-failed");
+  });
+
+  test("returns true when at least one story was reset", () => {
+    const prd = makePrd([makeStory("US-001", { status: "failed", attempts: 1 })]);
+    expect(resetFailedStoriesToPending(prd)).toBe(true);
+  });
+
+  test("returns false when no stories were reset", () => {
+    const prd = makePrd([makeStory("US-001", { status: "pending" })]);
+    expect(resetFailedStoriesToPending(prd)).toBe(false);
+  });
+
+  test("returns false for empty PRD", () => {
+    const prd = makePrd([]);
+    expect(resetFailedStoriesToPending(prd)).toBe(false);
+  });
+
+  test("mixed statuses — only failed stories are reset", () => {
+    const prd = makePrd([
+      makeStory("US-001", { status: "passed", passes: true }),
+      makeStory("US-002", { status: "failed", attempts: 1 }),
+      makeStory("US-003", { status: "pending" }),
+      makeStory("US-004", { status: "skipped" }),
+    ]);
+    resetFailedStoriesToPending(prd);
+    expect(prd.userStories[0].status).toBe("passed");
+    expect(prd.userStories[1].status).toBe("pending");
+    expect(prd.userStories[2].status).toBe("pending");
+    expect(prd.userStories[3].status).toBe("skipped");
+  });
+});


### PR DESCRIPTION
## What

Fixes failed stories not being retried on re-run. When a story fails and nax is re-invoked, the failed story is now reset to 'pending' so it can be executed again.

## Why

Story selection functions excluded `status === "failed"` stories, making them unreachable on re-run. The within-run retry mechanism (via `lastStoryId`) only works during the same session. Re-invocations of nax would find no stories to execute and exit immediately.

Fixes #282

## How

- Add `resetFailedStoriesToPending(prd)` to `src/prd/index.ts` — resets all failed stories to pending while preserving attempts count
- Wire it in `initializeRun()` after `reconcileState()` — reconciliation runs first (promotes succeeded stories), then reset handles remaining failures
- Comprehensive unit tests for the new function
- Updated integration tests reflecting new behavior (failed stories now retry instead of staying terminal)

## Testing

- [x] Tests added/updated — 12 new unit tests + 2 new integration tests
- [x] `bun test` passes — 1227 tests pass, 0 failures
- [x] `bun run typecheck` passes — no errors
- [x] `bun run lint` passes — no issues

## Notes

**Behavior change**: Failed stories from a previous run are now reset to 'pending' and retried. The 'attempts' counter is preserved to track retry history. This is the intended behavior for re-runs — if a user explicitly re-runs nax, they expect failed stories to be retried.