### PR TITLE
fix(acp): restore prompt audit for all stages by adding config fallback

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -165,12 +165,6 @@ function resolveRegistryEntry(agentName: string): AgentRegistryEntry {
   return AGENT_REGISTRY[agentName] ?? DEFAULT_ENTRY;
 }
 
-function isRateLimitError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  const msg = err.message.toLowerCase();
-  return msg.includes("rate limit") || msg.includes("rate_limit") || msg.includes("429");
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Session naming
 // ─────────────────────────────────────────────────────────────────────────────
@@ -534,7 +528,10 @@ export class AcpAgentAdapter implements AgentAdapter {
   readonly capabilities: AgentCapabilities;
   private _unavailableAgents: Set<string>;
 
-  constructor(agentName: string) {
+  constructor(
+    agentName: string,
+    private readonly naxConfig?: import("../../config").NaxConfig,
+  ) {
     const entry = resolveRegistryEntry(agentName);
     this.name = agentName;
     this.displayName = entry.displayName;
@@ -759,12 +756,13 @@ export class AcpAgentAdapter implements AgentAdapter {
         getSafeLogger()?.debug("acp-adapter", `Session turn ${turnCount}/${MAX_TURNS}`, { sessionName });
 
         // Audit: fire-and-forget prompt write — never blocks or throws
-        if (options.config?.agent?.promptAudit?.enabled) {
+        const _runAuditConfig = options.config ?? this.naxConfig;
+        if (_runAuditConfig?.agent?.promptAudit?.enabled) {
           void writePromptAudit({
             prompt: currentPrompt,
             sessionName,
             workdir: options.workdir,
-            auditDir: options.config.agent.promptAudit.dir,
+            auditDir: _runAuditConfig.agent.promptAudit.dir,
             storyId: options.storyId,
             featureName: options.featureName,
             pipelineStage: options.pipelineStage ?? "run",
@@ -943,15 +941,16 @@ export class AcpAgentAdapter implements AgentAdapter {
         session = await client.createSession({ agentName, permissionMode, sessionName: completeSessionName });
 
         // Audit: fire-and-forget prompt write — never blocks or throws
-        if (config?.agent?.promptAudit?.enabled) {
+        const _completeAuditConfig = config ?? this.naxConfig;
+        if (_completeAuditConfig?.agent?.promptAudit?.enabled) {
           void writePromptAudit({
             prompt,
             sessionName: completeSessionName,
             workdir: workdir ?? process.cwd(),
-            auditDir: config.agent.promptAudit.dir,
+            auditDir: _completeAuditConfig.agent.promptAudit.dir,
             storyId: _options?.storyId,
             featureName: _options?.featureName,
-            pipelineStage: "complete",
+            pipelineStage: _options?.pipelineStage ?? "complete",
             callType: "complete",
           });
         }

--- a/src/agents/acp/prompt-audit.ts
+++ b/src/agents/acp/prompt-audit.ts
@@ -17,7 +17,7 @@
  */
 
 import { mkdirSync } from "node:fs";
-import { isAbsolute, join } from "node:path";
+import { isAbsolute, join, sep } from "node:path";
 import { getSafeLogger } from "../../logger";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -111,12 +111,19 @@ function buildAuditContent(entry: PromptAuditEntry, epochMs: number): string {
  */
 export async function writePromptAudit(entry: PromptAuditEntry): Promise<void> {
   try {
-    // Resolve audit base directory
+    // Resolve audit base directory.
+    // When running in a parallel worktree (path contains /.nax-wt/), always write to
+    // the main project root so audit files are consolidated in one place rather than
+    // scattered across worktree directories.
+    // Worktrees are always at <projectRoot>/.nax-wt/<storyId>/ (WorktreeManager convention).
     let baseDir: string;
     if (entry.auditDir) {
       baseDir = isAbsolute(entry.auditDir) ? entry.auditDir : join(entry.workdir, entry.auditDir);
     } else {
-      baseDir = join(entry.workdir, ".nax", "prompt-audit");
+      const wtMarker = `${sep}.nax-wt${sep}`;
+      const wtIdx = entry.workdir.indexOf(wtMarker);
+      const projectRoot = wtIdx !== -1 ? entry.workdir.substring(0, wtIdx) : entry.workdir;
+      baseDir = join(projectRoot, ".nax", "prompt-audit");
     }
 
     // Organise by feature name so each feature has its own subfolder.

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -87,7 +87,7 @@ export function createAgentRegistry(config: NaxConfig): AgentRegistry {
       const known = ALL_AGENTS.find((a) => a.name === name);
       if (!known) return undefined;
       if (!acpCache.has(name)) {
-        acpCache.set(name, new AcpAgentAdapter(name));
+        acpCache.set(name, new AcpAgentAdapter(name, config));
         logger?.debug("agents", `Created AcpAgentAdapter for ${name}`, { name, protocol });
       }
       return acpCache.get(name);
@@ -104,7 +104,7 @@ export function createAgentRegistry(config: NaxConfig): AgentRegistry {
       protocol === "acp"
         ? ALL_AGENTS.map((a) => {
             if (!acpCache.has(a.name)) {
-              acpCache.set(a.name, new AcpAgentAdapter(a.name));
+              acpCache.set(a.name, new AcpAgentAdapter(a.name, config));
             }
             return acpCache.get(a.name) as AcpAgentAdapter;
           })
@@ -118,7 +118,7 @@ export function createAgentRegistry(config: NaxConfig): AgentRegistry {
       protocol === "acp"
         ? ALL_AGENTS.map((a) => {
             if (!acpCache.has(a.name)) {
-              acpCache.set(a.name, new AcpAgentAdapter(a.name));
+              acpCache.set(a.name, new AcpAgentAdapter(a.name, config));
             }
             return acpCache.get(a.name) as AcpAgentAdapter;
           })

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -154,6 +154,11 @@ export interface CompleteOptions {
    * instead of using the default. Has no effect when `model` is explicitly set.
    */
   modelTier?: ModelTier;
+  /**
+   * Pipeline stage label for prompt audit logs.
+   * Defaults to "complete" when not provided.
+   */
+  pipelineStage?: import("../config/permissions").PipelineStage;
 }
 
 /**

--- a/test/unit/agents/acp/prompt-audit.test.ts
+++ b/test/unit/agents/acp/prompt-audit.test.ts
@@ -218,6 +218,46 @@ describe("writePromptAudit() — directory resolution", () => {
     expect(capturedDir).toBe(join(WORKDIR, "my-audit", "my-feature"));
   });
 
+  test("worktree workdir — strips /.nax-wt/<story>/ and writes to project root", async () => {
+    const projectRoot = "/project/my-app";
+    const worktreeWorkdir = `${projectRoot}/.nax-wt/vcs-p2-001`;
+    let capturedDir = "";
+    _promptAuditDeps.mkdirSync = mock((path: string) => {
+      capturedDir = path;
+    });
+
+    await writePromptAudit(makeEntry({ workdir: worktreeWorkdir, auditDir: undefined, featureName: "my-feature" }));
+
+    expect(capturedDir).toBe(join(projectRoot, ".nax", "prompt-audit", "my-feature"));
+  });
+
+  test("worktree workdir with no auditDir — falls back to project root not worktree", async () => {
+    const projectRoot = "/home/user/project";
+    const worktreeWorkdir = `${projectRoot}/.nax-wt/feat-story-id`;
+    let capturedDir = "";
+    _promptAuditDeps.mkdirSync = mock((path: string) => {
+      capturedDir = path;
+    });
+
+    await writePromptAudit(makeEntry({ workdir: worktreeWorkdir, auditDir: undefined, featureName: undefined }));
+
+    expect(capturedDir).toBe(join(projectRoot, ".nax", "prompt-audit", "_unknown"));
+  });
+
+  test("absolute auditDir in worktree context — still uses the explicit absolute dir", async () => {
+    const worktreeWorkdir = "/project/.nax-wt/some-story";
+    let capturedDir = "";
+    _promptAuditDeps.mkdirSync = mock((path: string) => {
+      capturedDir = path;
+    });
+
+    await writePromptAudit(
+      makeEntry({ workdir: worktreeWorkdir, auditDir: "/custom/audit", featureName: "my-feature" }),
+    );
+
+    expect(capturedDir).toBe("/custom/audit/my-feature");
+  });
+
   test("writeFile is called with path inside resolved dir", async () => {
     let capturedPath = "";
     _promptAuditDeps.mkdirSync = mock(() => {});


### PR DESCRIPTION
## Summary

Fixes #267: Prompt audit was only saving 4 files (plan + acceptance refinement) instead of capturing all pipeline stages (implement, semantic review, etc.).

**Root cause**: `AcpAgentAdapter` stored no config reference, so audit silently skipped when callers omitted `options.config` or `_options`. The `complete()` method also always hardcoded `pipelineStage: "complete"` regardless of actual calling context.

**Solution**: Store config in adapter constructor (with parameter shorthand), use as fallback when options lack config, add stage awareness to `complete()`, and detect worktree paths to write audit files to project root.

## Changes

### `src/agents/acp/adapter.ts`
- Added `naxConfig` as constructor parameter property (`private readonly naxConfig?`)
- Updated `run()` audit: use `options.config ?? this.naxConfig` before checking enabled flag
- Updated `complete()` audit: use `config ?? this.naxConfig` + respect `_options?.pipelineStage`
- Removed unused `isRateLimitError()` helper function (TS6133 cleanup)

### `src/agents/acp/prompt-audit.ts`
- Added worktree detection: if workdir contains `/.nax-wt/<storyId>/`, strip to project root
- Ensures audit files consolidate in project root even when adapter runs in parallel worktrees

### `src/agents/registry.ts`
- Updated all 3 `new AcpAgentAdapter(name, config)` sites to pass config for fallback availability

### `src/agents/types.ts`
- Added `pipelineStage?: PipelineStage` to `CompleteOptions` interface
- Allows callers to label audit entries with their actual stage (not just "complete")

### `test/unit/agents/acp/prompt-audit.test.ts`
- Added 3 worktree tests verifying audit files go to project root not worktree subdirs
- All 20 tests pass, coverage preserved

## Test Plan

- [x] TypeScript check passes (`bun run typecheck`)
- [x] Biome lint passes (`bun run lint`)
- [x] Unit tests pass: 20/20 worktree + directory resolution tests ✓
- [x] Pre-commit hooks pass

## Verification

After merge, enable `agent.promptAudit.enabled: true` and run a full pipeline (plan → implement → semantic → acceptance). Audit files should appear under `.nax/prompt-audit/<featureName>/` for all stages:
- `*-plan-*` from plan stage
- `*-run-*` from run/implement stage
- `*-review-*` from semantic review stage
- `*-refine-*` from acceptance refinement

Closes #267