### PR TITLE
fix(acp): treat timeoutMs=0 as default (120s) not immediate timeout

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -899,7 +899,9 @@ export class AcpAgentAdapter implements AgentAdapter {
   }
 
   async complete(prompt: string, _options?: CompleteOptions): Promise<CompleteResult> {
-    const timeoutMs = _options?.timeoutMs ?? 120_000;
+    // Use default when timeoutMs is undefined; 0 is used as sentinel (meaning "no timeout override")
+    // but must be coerced to the actual default so setTimeout(fn, 0) doesn't fire immediately.
+    const timeoutMs = _options?.timeoutMs || 120_000;
     const permissionMode = resolvePermissions(_options?.config, "complete").mode;
     const workdir = _options?.workdir;
     const config = _options?.config;


### PR DESCRIPTION
## What

Fix a critical bug where the debate plan synthesis resolver session was killed ~2ms after starting, causing all `debate-opencode-*` benchmark runs to fail silently.

## Why

The debate plan resolver was passing `timeoutMs=0` as a "sentinel" meaning "use the default timeout". However, `complete()` implemented this literally as `setTimeout(fn, 0)` which fires on the next event loop tick, immediately rejecting the prompt with "complete() timed out after 0ms".

**Root cause:** `src/debate/session-plan.ts` passes `timeoutMs=0` to `resolveOutcome()` for synthesis resolver calls, with a comment stating "timeoutMs not tracked per-plan — use 0 as sentinel for resolver calls".

**Effect:** The acpx synthesis resolver process is killed by `cancelActivePrompt()` ~2ms after starting, before it can produce any output. All benchmark runs using debate configs (debate-opencode-opencode, debate-haiku-*, etc.) fail at the plan synthesis stage.

## How

Changed `complete()` in `src/agents/acp/adapter.ts` to use `||` instead of `??`:

```typescript
// Before (buggy):
const timeoutMs = _options?.timeoutMs ?? 120_000;

// After (fixed):
const timeoutMs = _options?.timeoutMs || 120_000;
```

This ensures `timeoutMs=0` is coerced to the default 120s rather than treated as literal 0ms. The debate session has its own 600s outer timeout as the real boundary.

## Testing

- [x] `bun test test/unit/agents/acp/` — 318 pass, 0 fail
- [x] `bun test test/unit/debate/` — 154 pass, 0 fail
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

This bug only manifests when:
1. A debate stage uses `resolver.type: "synthesis"` (the default for plan stage)
2. Multiple debaters produce proposals (triggering the resolver path, not the single-success shortcut)
3. The config uses `timeoutMs=0` (which is the default from `session-plan.ts` for resolver calls)

Single-agent runs are unaffected because they don't go through `resolveOutcome()`.
