### PR TITLE
chore: release v0.58.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.58.3",
+  "version": "0.58.4",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -899,7 +899,9 @@ export class AcpAgentAdapter implements AgentAdapter {
   }
 
   async complete(prompt: string, _options?: CompleteOptions): Promise<CompleteResult> {
-    const timeoutMs = _options?.timeoutMs ?? 120_000;
+    // Use default when timeoutMs is undefined; 0 is used as sentinel (meaning "no timeout override")
+    // but must be coerced to the actual default so setTimeout(fn, 0) doesn't fire immediately.
+    const timeoutMs = _options?.timeoutMs || 120_000;
     const permissionMode = resolvePermissions(_options?.config, "complete").mode;
     const workdir = _options?.workdir;
     const config = _options?.config;

--- a/src/agents/acp/prompt-audit.ts
+++ b/src/agents/acp/prompt-audit.ts
@@ -16,8 +16,8 @@
  * an audit write failure can never interrupt an active run.
  */
 
-import { mkdirSync } from "node:fs";
-import { isAbsolute, join, sep } from "node:path";
+import { existsSync as fsExistsSync, mkdirSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve, sep } from "node:path";
 import { getSafeLogger } from "../../logger";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -52,6 +52,9 @@ export interface PromptAuditEntry {
 export const _promptAuditDeps = {
   mkdirSync(path: string): void {
     mkdirSync(path, { recursive: true });
+  },
+  existsSync(path: string): boolean {
+    return fsExistsSync(path);
   },
   async writeFile(path: string, content: string): Promise<void> {
     await Bun.write(path, content);
@@ -102,6 +105,32 @@ function buildAuditContent(entry: PromptAuditEntry, epochMs: number): string {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MAX_NAX_WALK_DEPTH = 10;
+
+/**
+ * Walk up from startDir to find the nearest ancestor that contains `.nax/config.json`.
+ * Returns that ancestor (the nax project root). Falls back to startDir if not found.
+ *
+ * This consolidates monorepo audit files at the project root even when individual
+ * stories run with a package subdir as their workdir (e.g. apps/api/).
+ */
+function findNaxProjectRoot(startDir: string): string {
+  let dir = resolve(startDir);
+  for (let depth = 0; depth < MAX_NAX_WALK_DEPTH; depth++) {
+    if (_promptAuditDeps.existsSync(join(dir, ".nax", "config.json"))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break; // filesystem root reached
+    dir = parent;
+  }
+  return startDir; // fallback: use workdir as-is
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Public API
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -112,17 +141,22 @@ function buildAuditContent(entry: PromptAuditEntry, epochMs: number): string {
 export async function writePromptAudit(entry: PromptAuditEntry): Promise<void> {
   try {
     // Resolve audit base directory.
-    // When running in a parallel worktree (path contains /.nax-wt/), always write to
-    // the main project root so audit files are consolidated in one place rather than
-    // scattered across worktree directories.
-    // Worktrees are always at <projectRoot>/.nax-wt/<storyId>/ (WorktreeManager convention).
+    // Two normalisations are applied when auditDir is absent:
+    //   1. Worktree strip: paths containing /.nax-wt/<storyId>/ are trimmed to the
+    //      project root so parallel-worktree audit files are not written to the
+    //      ephemeral worktree directory (WorktreeManager convention).
+    //   2. Monorepo walk-up: after stripping, walk up from the effective workdir to
+    //      the nearest ancestor containing .nax/config.json. This ensures monorepo
+    //      per-package stories (e.g. workdir=apps/api/) write to the project root
+    //      instead of the package subdirectory.
     let baseDir: string;
     if (entry.auditDir) {
       baseDir = isAbsolute(entry.auditDir) ? entry.auditDir : join(entry.workdir, entry.auditDir);
     } else {
       const wtMarker = `${sep}.nax-wt${sep}`;
       const wtIdx = entry.workdir.indexOf(wtMarker);
-      const projectRoot = wtIdx !== -1 ? entry.workdir.substring(0, wtIdx) : entry.workdir;
+      const strippedWorkdir = wtIdx !== -1 ? entry.workdir.substring(0, wtIdx) : entry.workdir;
+      const projectRoot = findNaxProjectRoot(strippedWorkdir);
       baseDir = join(projectRoot, ".nax", "prompt-audit");
     }
 

--- a/src/execution/story-context.ts
+++ b/src/execution/story-context.ts
@@ -204,6 +204,7 @@ export async function buildStoryContextFull(
  * @returns Array of stories that can be executed now
  */
 export function getAllReadyStories(prd: PRD): UserStory[] {
+  const storyIds = new Set(prd.userStories.map((s) => s.id));
   const completedIds = new Set(prd.userStories.filter((s) => s.passes || s.status === "skipped").map((s) => s.id));
 
   const logger = getSafeLogger();
@@ -219,7 +220,8 @@ export function getAllReadyStories(prd: PRD): UserStory[] {
       s.status !== "failed" &&
       s.status !== "paused" &&
       s.status !== "blocked" &&
-      s.dependencies.every((dep) => completedIds.has(dep)),
+      // A dep is fulfilled if it is not in this PRD (external/prior-phase) or it is completed.
+      s.dependencies.every((dep) => !storyIds.has(dep) || completedIds.has(dep)),
   );
 }
 

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -95,6 +95,7 @@ export function getNextStory(prd: PRD, currentStoryId?: string | null, maxRetrie
     }
   }
 
+  const storyIds = new Set(prd.userStories.map((s) => s.id));
   const completedIds = new Set(
     prd.userStories.filter((s) => s.passes || s.status === "passed" || s.status === "skipped").map((s) => s.id),
   );
@@ -109,7 +110,8 @@ export function getNextStory(prd: PRD, currentStoryId?: string | null, maxRetrie
         s.status !== "failed" &&
         s.status !== "paused" &&
         s.status !== "decomposed" &&
-        s.dependencies.every((dep) => completedIds.has(dep)),
+        // A dep is fulfilled if it is not in this PRD (external/prior-phase) or it is completed.
+        s.dependencies.every((dep) => !storyIds.has(dep) || completedIds.has(dep)),
     ) ?? null
   );
 }

--- a/test/unit/agents/acp/prompt-audit.test.ts
+++ b/test/unit/agents/acp/prompt-audit.test.ts
@@ -218,6 +218,39 @@ describe("writePromptAudit() — directory resolution", () => {
     expect(capturedDir).toBe(join(WORKDIR, "my-audit", "my-feature"));
   });
 
+  test("monorepo package subdir — walks up to find nax project root", async () => {
+    const projectRoot = "/project/koda";
+    const packageWorkdir = `${projectRoot}/apps/api`;
+    let capturedDir = "";
+    _promptAuditDeps.mkdirSync = mock((path: string) => {
+      capturedDir = path;
+    });
+    const origExistsSync = _promptAuditDeps.existsSync;
+    _promptAuditDeps.existsSync = mock((path: string) =>
+      path === `${projectRoot}/.nax/config.json`,
+    );
+
+    await writePromptAudit(makeEntry({ workdir: packageWorkdir, auditDir: undefined, featureName: "my-feature" }));
+
+    _promptAuditDeps.existsSync = origExistsSync;
+    expect(capturedDir).toBe(join(projectRoot, ".nax", "prompt-audit", "my-feature"));
+  });
+
+  test("monorepo — no .nax/config.json found anywhere, falls back to workdir", async () => {
+    const packageWorkdir = "/project/koda/apps/web";
+    let capturedDir = "";
+    _promptAuditDeps.mkdirSync = mock((path: string) => {
+      capturedDir = path;
+    });
+    const origExistsSync = _promptAuditDeps.existsSync;
+    _promptAuditDeps.existsSync = mock(() => false);
+
+    await writePromptAudit(makeEntry({ workdir: packageWorkdir, auditDir: undefined, featureName: "my-feature" }));
+
+    _promptAuditDeps.existsSync = origExistsSync;
+    expect(capturedDir).toBe(join(packageWorkdir, ".nax", "prompt-audit", "my-feature"));
+  });
+
   test("worktree workdir — strips /.nax-wt/<story>/ and writes to project root", async () => {
     const projectRoot = "/project/my-app";
     const worktreeWorkdir = `${projectRoot}/.nax-wt/vcs-p2-001`;
@@ -318,7 +351,7 @@ describe("writePromptAudit() — error resilience", () => {
     });
 
     // Must not throw
-    await expect(writePromptAudit(makeEntry())).resolves.toBeUndefined();
+    expect(await writePromptAudit(makeEntry())).toBeUndefined();
 
     _promptAuditDeps.writeFile = origWrite;
     _promptAuditDeps.mkdirSync = origMkdir;
@@ -336,7 +369,7 @@ describe("writePromptAudit() — error resilience", () => {
     });
     _promptAuditDeps.writeFile = mock(async () => {});
 
-    await expect(writePromptAudit(makeEntry())).resolves.toBeUndefined();
+    expect(await writePromptAudit(makeEntry())).toBeUndefined();
 
     _promptAuditDeps.writeFile = origWrite;
     _promptAuditDeps.mkdirSync = origMkdir;

--- a/test/unit/prd/prd-get-next-story.test.ts
+++ b/test/unit/prd/prd-get-next-story.test.ts
@@ -212,5 +212,40 @@ describe("getNextStory() — run order S1-I1 -> S1-I2 (retry) -> S2-I1", () => {
     const pick = getNextStory(prd, "US-002", maxRetries);
     expect(pick?.id).toBe("US-001");
   });
+});
 
+// ── External dependencies (prior-phase) ─────────────────────────────────────
+
+describe("getNextStory() — external dependencies treated as fulfilled", () => {
+  test("returns story whose only dependency is external (not in PRD)", () => {
+    // VCS-P2-001 is from a prior feature run and is absent from this PRD
+    const prd = makePrd([makeStory("VCS-P3-001-A", { dependencies: ["VCS-P2-001"] })]);
+    expect(getNextStory(prd)?.id).toBe("VCS-P3-001-A");
+  });
+
+  test("returns story with mix of external + satisfied internal dependency", () => {
+    const prd = makePrd([
+      makeStory("US-001", { status: "passed", passes: true }),
+      makeStory("US-002", { dependencies: ["EXT-PHASE1", "US-001"] }),
+    ]);
+    expect(getNextStory(prd)?.id).toBe("US-002");
+  });
+
+  test("does not return story when internal dependency is unsatisfied even if external is absent", () => {
+    const prd = makePrd([
+      makeStory("US-001"), // pending, not done
+      makeStory("US-002", { dependencies: ["EXT-PHASE1", "US-001"] }),
+    ]);
+    // US-001 should be picked (it has no unmet deps), not US-002
+    expect(getNextStory(prd)?.id).toBe("US-001");
+  });
+
+  test("skips decomposed stories that have only external deps", () => {
+    const prd = makePrd([
+      makeStory("VCS-P3-001", { status: "decomposed", dependencies: ["VCS-P2-001"] }),
+      makeStory("VCS-P3-001-A", { dependencies: ["VCS-P2-001"] }),
+    ]);
+    // VCS-P3-001 is decomposed → skipped; VCS-P3-001-A is pending and ready
+    expect(getNextStory(prd)?.id).toBe("VCS-P3-001-A");
+  });
 });

--- a/test/unit/utils/utils-helpers.test.ts
+++ b/test/unit/utils/utils-helpers.test.ts
@@ -157,6 +157,36 @@ describe("getAllReadyStories", () => {
     expect(ready.length).toBe(1);
     expect(ready[0].id).toBe("US-002");
   });
+
+  it("treats external dependencies (not in this PRD) as fulfilled", () => {
+    // VCS-P2-001 is from a prior phase and not in this PRD — US-001 should be ready
+    const prd = createMockPRD([mockStory("US-001", false, "pending", ["VCS-P2-001"])]);
+
+    const ready = getAllReadyStories(prd);
+    expect(ready.length).toBe(1);
+    expect(ready[0].id).toBe("US-001");
+  });
+
+  it("handles mix of external and internal dependencies — ready when internal dep is done", () => {
+    const prd = createMockPRD([
+      mockStory("US-001", true, "pending"), // internal dep, completed
+      mockStory("US-002", false, "pending", ["EXT-PHASE1-001", "US-001"]), // one external + one internal
+    ]);
+
+    const ready = getAllReadyStories(prd);
+    expect(ready.length).toBe(1);
+    expect(ready[0].id).toBe("US-002");
+  });
+
+  it("blocks story when internal dep is not yet done, even if external dep would pass", () => {
+    const prd = createMockPRD([
+      mockStory("US-001", false, "pending"), // internal dep, NOT done
+      mockStory("US-002", false, "pending", ["EXT-PHASE1-001", "US-001"]),
+    ]);
+
+    const ready = getAllReadyStories(prd);
+    expect(ready.map((s) => s.id)).toEqual(["US-001"]); // only US-001 is ready, not US-002
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Release v0.58.4 — patch release with 3 bug fixes since v0.58.3.

## Why

Contains only bug fixes. New features (config-resolution hardening) deferred to v0.59.0.

## What's Changed

### Bug Fixes
- **fix(acp):** treat timeoutMs=0 as default (120s) not immediate timeout (#293) — fixes debate plan synthesis crash
- **fix(acp):** consolidate prompt audit to nax project root in monorepos
- **fix:** treat external dependencies as fulfilled in getAllReadyStories and getNextStory (#290)

## Testing

- [x] CI (ci.yml) must pass before merging
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Install

```bash
npm install -g @nathapp/nax@latest
```

**Full Changelog**: https://github.com/nathapp-io/nax/compare/v0.58.3...v0.58.4
