### PR TITLE
fix(security): code review hardening — path traversal, shell injection, memory leaks, Node.js API cleanup

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -561,11 +561,9 @@ export class AcpAgentAdapter implements AgentAdapter {
   }
 
   async run(options: AgentRunOptions): Promise<AgentResult> {
-    // TODO: _unavailableAgents persists across stories in a run because adapter instances
-    // are cached by createAgentRegistry(). A transient auth failure in story A can permanently
-    // exclude an agent for subsequent stories. The correct fix is to reset at story boundaries
-    // (runner.ts story loop), not here — clearing in run() would break the deliberate
-    // complete()→run() sharing that enables within-story fallback (see adapter-run-fallback tests).
+    // _unavailableAgents is reset between stories via AgentRegistry.resetStoryState(),
+    // called from the unified executor at each story boundary. Within a story,
+    // the set is intentionally shared between run() and complete() for fallback continuity.
     const startTime = Date.now();
     const config = options.config;
     const hasActiveFallbacks = (config?.autoMode?.fallbackOrder?.length ?? 0) > 0;
@@ -1191,6 +1189,15 @@ export class AcpAgentAdapter implements AgentAdapter {
     }
 
     return { stories };
+  }
+
+  /**
+   * Reset per-story availability state.
+   * Called by AgentRegistry.resetStoryState() at each story boundary so transient
+   * auth failures in one story do not carry over to the next.
+   */
+  clearUnavailableAgents(): void {
+    this._unavailableAgents.clear();
   }
 
   private markUnavailable(agentName: string): void {

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -561,6 +561,11 @@ export class AcpAgentAdapter implements AgentAdapter {
   }
 
   async run(options: AgentRunOptions): Promise<AgentResult> {
+    // TODO: _unavailableAgents persists across stories in a run because adapter instances
+    // are cached by createAgentRegistry(). A transient auth failure in story A can permanently
+    // exclude an agent for subsequent stories. The correct fix is to reset at story boundaries
+    // (runner.ts story loop), not here — clearing in run() would break the deliberate
+    // complete()→run() sharing that enables within-story fallback (see adapter-run-fallback tests).
     const startTime = Date.now();
     const config = options.config;
     const hasActiveFallbacks = (config?.autoMode?.fallbackOrder?.length ?? 0) > 0;

--- a/src/agents/claude/plan.ts
+++ b/src/agents/claude/plan.ts
@@ -1,12 +1,13 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 /**
  * Claude Code Plan Logic
  *
  * Extracted from claude.ts: plan(), buildPlanCommand()
  */
 
+import { validateFilePath } from "../../config/path-security";
 import { resolvePermissions } from "../../config/permissions";
 import type { PidRegistry } from "../../execution/pid-registry";
 import { withProcessTimeout } from "../../execution/timeout-handler";
@@ -46,17 +47,9 @@ export function buildPlanCommand(binary: string, options: PlanOptions): string[]
     fullPrompt = `${options.codebaseContext}\n\n${options.prompt}`;
   }
 
-  // For non-interactive mode, include input file content in the prompt
-  if (options.inputFile) {
-    try {
-      const inputContent = require("node:fs").readFileSync(
-        require("node:path").resolve(options.workdir, options.inputFile),
-        "utf-8",
-      );
-      fullPrompt = `${fullPrompt}\n\n## Input Requirements\n\n${inputContent}`;
-    } catch (error) {
-      throw new Error(`Failed to read input file ${options.inputFile}: ${(error as Error).message}`);
-    }
+  // Append pre-read input file content when provided (populated by runPlan before this call)
+  if (options.resolvedInputContent) {
+    fullPrompt = `${fullPrompt}\n\n## Input Requirements\n\n${options.resolvedInputContent}`;
   }
 
   if (!options.interactive) {
@@ -75,7 +68,16 @@ export function buildPlanCommand(binary: string, options: PlanOptions): string[]
 export async function runPlan(binary: string, options: PlanOptions, pidRegistry: PidRegistry): Promise<PlanResult> {
   const { resolveBalancedModelDef } = await import("../shared/model-resolution");
 
-  const cmd = buildPlanCommand(binary, options);
+  // Read inputFile here (async, with path boundary check) so buildPlanCommand
+  // stays synchronous and never touches the filesystem directly.
+  let resolvedOptions = options;
+  if (options.inputFile) {
+    const inputPath = validateFilePath(resolve(options.workdir, options.inputFile), options.workdir);
+    const resolvedInputContent = await Bun.file(inputPath).text();
+    resolvedOptions = { ...options, resolvedInputContent };
+  }
+
+  const cmd = buildPlanCommand(binary, resolvedOptions);
 
   // Resolve model: explicit modelDef > config.models.balanced > throw
   let modelDef = options.modelDef;

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -65,6 +65,12 @@ export interface AgentRegistry {
   checkAgentHealth(): Promise<Array<{ name: string; displayName: string; installed: boolean }>>;
   /** Active protocol ('acp' | 'cli') */
   protocol: "acp" | "cli";
+  /**
+   * Reset per-story state on all cached ACP adapters.
+   * Call at each story boundary so transient auth failures in one story
+   * do not permanently exclude agents for subsequent stories in the same run.
+   */
+  resetStoryState(): void;
 }
 
 /**
@@ -132,5 +138,11 @@ export function createAgentRegistry(config: NaxConfig): AgentRegistry {
     );
   }
 
-  return { getAgent, getInstalledAgents, checkAgentHealth, protocol };
+  function resetStoryState(): void {
+    for (const adapter of acpCache.values()) {
+      adapter.clearUnavailableAgents();
+    }
+  }
+
+  return { getAgent, getInstalledAgents, checkAgentHealth, protocol, resetStoryState };
 }

--- a/src/agents/shared/types-extended.ts
+++ b/src/agents/shared/types-extended.ts
@@ -24,6 +24,12 @@ export interface PlanOptions {
   codebaseContext?: string;
   /** Optional input file path for non-interactive mode */
   inputFile?: string;
+  /**
+   * Pre-read content of inputFile — populated by runPlan() before calling
+   * buildPlanCommand() so the command builder never touches the filesystem directly.
+   * @internal
+   */
+  resolvedInputContent?: string;
   /** Model tier to use for planning (default: "balanced") */
   modelTier?: ModelTier;
   /** Resolved model definition */

--- a/src/cli/init-detect.ts
+++ b/src/cli/init-detect.ts
@@ -5,6 +5,9 @@
  * for nax/config.json.
  */
 
+// existsSync / readFileSync: the entire detection chain is synchronous by design
+// (called once at CLI init time). Bun has no native sync equivalent for existsSync,
+// and async-ifying the chain would be significant churn for a one-shot startup scan.
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 

--- a/src/context/generator.ts
+++ b/src/context/generator.ts
@@ -5,8 +5,8 @@
  * Replaces the old constitution generator.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { existsSync } from "node:fs";
+import { join, relative } from "node:path";
 import type { NaxConfig } from "../config";
 import { validateFilePath } from "../config/path-security";
 import { aiderGenerator } from "./generators/aider";
@@ -25,7 +25,6 @@ import type { AgentContextGenerator, AgentType, ContextContent, GeneratorMap } f
  */
 export const _generatorDeps = {
   existsSync: (p: string) => existsSync(p),
-  readFileSync: (p: string, enc: BufferEncoding) => readFileSync(p, enc),
   readTextFile: (p: string) => Bun.file(p).text(),
   writeFile: (p: string, content: string) => Bun.write(p, content),
   buildProjectMetadata,
@@ -226,58 +225,52 @@ export async function discoverWorkspacePackages(repoRoot: string): Promise<strin
 
   // 2. turbo v2+: turbo.json top-level "packages" array
   const turboPath = join(repoRoot, "turbo.json");
-  if (_generatorDeps.existsSync(turboPath)) {
-    try {
-      const turbo = JSON.parse(_generatorDeps.readFileSync(turboPath, "utf-8")) as Record<string, unknown>;
-      if (Array.isArray(turbo.packages)) {
-        await resolveGlobs(turbo.packages as string[]);
-      }
-    } catch {
-      // malformed turbo.json — skip
+  try {
+    const turbo = JSON.parse(await _generatorDeps.readTextFile(turboPath)) as Record<string, unknown>;
+    if (Array.isArray(turbo.packages)) {
+      await resolveGlobs(turbo.packages as string[]);
     }
+  } catch {
+    // file absent or malformed turbo.json — skip
   }
 
   // 3. root package.json "workspaces" (npm/yarn/bun/turbo v1)
   const pkgPath = join(repoRoot, "package.json");
-  if (_generatorDeps.existsSync(pkgPath)) {
-    try {
-      const pkg = JSON.parse(_generatorDeps.readFileSync(pkgPath, "utf-8")) as Record<string, unknown>;
-      const ws = pkg.workspaces;
-      const patterns: string[] = Array.isArray(ws)
-        ? (ws as string[])
-        : Array.isArray((ws as Record<string, unknown>)?.packages)
-          ? ((ws as Record<string, unknown>).packages as string[])
-          : [];
-      if (patterns.length > 0) await resolveGlobs(patterns);
-    } catch {
-      // malformed package.json — skip
-    }
+  try {
+    const pkg = JSON.parse(await _generatorDeps.readTextFile(pkgPath)) as Record<string, unknown>;
+    const ws = pkg.workspaces;
+    const patterns: string[] = Array.isArray(ws)
+      ? (ws as string[])
+      : Array.isArray((ws as Record<string, unknown>)?.packages)
+        ? ((ws as Record<string, unknown>).packages as string[])
+        : [];
+    if (patterns.length > 0) await resolveGlobs(patterns);
+  } catch {
+    // file absent or malformed package.json — skip
   }
 
   // 4. pnpm-workspace.yaml
   const pnpmPath = join(repoRoot, "pnpm-workspace.yaml");
-  if (_generatorDeps.existsSync(pnpmPath)) {
-    try {
-      const raw = _generatorDeps.readFileSync(pnpmPath, "utf-8");
-      // Simple YAML parse for "packages:\n  - 'packages/*'" without full YAML dep
-      const lines = raw.split("\n");
-      let inPackages = false;
-      const patterns: string[] = [];
-      for (const line of lines) {
-        if (/^packages\s*:/.test(line)) {
-          inPackages = true;
-          continue;
-        }
-        if (inPackages && /^\s+-\s+/.test(line)) {
-          patterns.push(line.replace(/^\s+-\s+['"]?/, "").replace(/['"]?\s*$/, ""));
-        } else if (inPackages && !/^\s/.test(line)) {
-          break;
-        }
+  try {
+    const raw = await _generatorDeps.readTextFile(pnpmPath);
+    // Simple YAML parse for "packages:\n  - 'packages/*'" without full YAML dep
+    const lines = raw.split("\n");
+    let inPackages = false;
+    const patterns: string[] = [];
+    for (const line of lines) {
+      if (/^packages\s*:/.test(line)) {
+        inPackages = true;
+        continue;
       }
-      if (patterns.length > 0) await resolveGlobs(patterns);
-    } catch {
-      // malformed yaml — skip
+      if (inPackages && /^\s+-\s+/.test(line)) {
+        patterns.push(line.replace(/^\s+-\s+['"]?/, "").replace(/['"]?\s*$/, ""));
+      } else if (inPackages && !/^\s/.test(line)) {
+        break;
+      }
     }
+    if (patterns.length > 0) await resolveGlobs(patterns);
+  } catch {
+    // file absent or malformed yaml — skip
   }
 
   return results.sort();

--- a/src/execution/crash-heartbeat.ts
+++ b/src/execution/crash-heartbeat.ts
@@ -40,6 +40,8 @@ async function heartbeatLoop(
           },
         };
         const line = `${JSON.stringify(heartbeatEntry)}\n`;
+        // appendFileSync: Bun has no built-in async append API (Bun.write overwrites).
+        // Synchronous append is acceptable here since this loop ticks every 60s.
         appendFileSync(jsonlFilePath, line);
       }
 

--- a/src/execution/crash-recovery.ts
+++ b/src/execution/crash-recovery.ts
@@ -49,24 +49,30 @@ export interface CrashRecoveryContext {
   onShutdown?: () => Promise<void>;
 }
 
-let handlersInstalled = false;
+// Stores the active cleanup function so a second installCrashHandlers() call
+// can deregister the stale handlers before installing the new context's handlers,
+// rather than returning a silent no-op that leaves the old context registered.
+let activeCleanup: (() => void) | null = null;
 
 /**
  * Install crash handlers for recovery
  */
 export function installCrashHandlers(ctx: CrashRecoveryContext): () => void {
-  if (handlersInstalled) {
-    return () => {};
+  // Deregister any previous handlers so the new context replaces stale ones
+  // (guards against a prior run's cleanup never being called due to a crash).
+  if (activeCleanup) {
+    activeCleanup();
   }
 
   const cleanup = installSignalHandlers(ctx);
-  handlersInstalled = true;
 
-  return () => {
+  activeCleanup = () => {
     cleanup();
     stopHeartbeat();
-    handlersInstalled = false;
+    activeCleanup = null;
   };
+
+  return activeCleanup;
 }
 
 /**
@@ -74,6 +80,6 @@ export function installCrashHandlers(ctx: CrashRecoveryContext): () => void {
  * @internal
  */
 export function resetCrashHandlers(): void {
-  handlersInstalled = false;
+  activeCleanup = null;
   stopHeartbeat();
 }

--- a/src/execution/crash-writer.ts
+++ b/src/execution/crash-writer.ts
@@ -28,6 +28,9 @@ export async function writeFatalLog(jsonlFilePath: string | undefined, signal: s
     };
 
     const line = `${JSON.stringify(fatalEntry)}\n`;
+    // appendFileSync: intentional — called from signal/exception handlers where the async
+    // event loop may be in an inconsistent state. Sync write ensures the entry is flushed
+    // to disk before process.exit() is reached, regardless of loop state.
     appendFileSync(jsonlFilePath, line);
   } catch (err) {
     process.stderr.write(`[crash-recovery] Failed to write fatal log: ${String(err)}\n`);

--- a/src/execution/executor-types.ts
+++ b/src/execution/executor-types.ts
@@ -41,6 +41,12 @@ export interface SequentialExecutionContext {
   pidRegistry?: PidRegistry;
   /** Max parallel sessions: undefined=sequential, 0=auto-detect, N>0=cap at N */
   parallelCount?: number;
+  /**
+   * Called just before each story (or parallel batch) begins execution.
+   * Used to reset per-story adapter state (e.g. _unavailableAgents) so transient
+   * auth failures from a previous story do not carry over.
+   */
+  onBeforeStory?: () => void;
 }
 
 export interface SequentialExecutionResult {

--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -99,11 +99,9 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
 
   if (acceptanceAlreadyPassed && regressionAlreadyPassed) {
     logger?.info("execution", "Post-run phases already passed — skipping acceptance and regression");
-    console.info("Post-run phases already passed — skipping acceptance and regression");
   } else {
     if (acceptanceAlreadyPassed) {
       logger?.info("execution", "Acceptance already passed — skipping acceptance phase");
-      console.info("Acceptance already passed — skipping acceptance phase");
     } else if (options.config.acceptance.enabled && isComplete(options.prd)) {
       options.statusWriter.setPostRunPhase("acceptance", { status: "running" });
 

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -45,6 +45,8 @@ export interface RunnerExecutionOptions {
   parallel?: number;
   /** Protocol-aware agent resolver — created once in runner.ts from createAgentRegistry(config) */
   agentGetFn?: AgentGetFn;
+  /** Called before each story starts — resets per-story adapter state (e.g. _unavailableAgents). */
+  onBeforeStory?: () => void;
   /** PID registry for crash recovery — passed to agent.run() to register child processes. */
   pidRegistry?: PidRegistry;
   /** Interaction chain for cost/pre-merge triggers during sequential execution. */
@@ -155,6 +157,7 @@ export async function runExecutionPhase(
       startTime: options.startTime,
       parallelCount: options.parallel,
       agentGetFn: options.agentGetFn,
+      onBeforeStory: options.onBeforeStory,
       pidRegistry: options.pidRegistry,
       interactionChain: options.interactionChain,
       batchPlan,

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -175,6 +175,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
         headless,
         parallel,
         agentGetFn,
+        onBeforeStory: () => registry.resetStoryState(),
         pidRegistry,
         interactionChain,
       },

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -149,6 +149,8 @@ export async function executeUnified(
         const batch = _unifiedExecutorDeps.selectIndependentBatch(readyStories, ctx.parallelCount as number);
 
         if (batch.length > 1) {
+          // Reset per-story adapter state before dispatching the batch
+          ctx.onBeforeStory?.();
           // Emit story:started for each batch story before dispatch (AC-5)
           for (const story of batch) {
             pipelineEventBus.emit({
@@ -325,6 +327,7 @@ export async function executeUnified(
             pipelineEventBus.emit({ type: "run:resumed", feature: ctx.feature });
           }
 
+          ctx.onBeforeStory?.();
           pipelineEventBus.emit({
             type: "story:started",
             storyId: singleStory.id,
@@ -406,6 +409,7 @@ export async function executeUnified(
         pipelineEventBus.emit({ type: "run:resumed", feature: ctx.feature });
       }
 
+      ctx.onBeforeStory?.();
       pipelineEventBus.emit({
         type: "story:started",
         storyId: selection.story.id,

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -18,11 +18,11 @@ import type { NaxPlugin, PluginConfigEntry } from "./types";
 import { validatePlugin } from "./validator";
 
 /**
- * Swappable error sink — defaults to console.error.
+ * Swappable error sink — defaults to no-op; logger calls are sufficient in production.
  * Tests can replace this to capture plugin error output.
  * @internal
  */
-export let _pluginErrorSink: (...args: unknown[]) => void = (...args) => console.error(...args);
+export let _pluginErrorSink: (...args: unknown[]) => void = () => {};
 
 /** @internal — for testing only */
 export function _setPluginErrorSink(fn: (...args: unknown[]) => void): void {
@@ -31,7 +31,7 @@ export function _setPluginErrorSink(fn: (...args: unknown[]) => void): void {
 
 /** @internal — reset to default */
 export function _resetPluginErrorSink(): void {
-  _pluginErrorSink = (...args) => console.error(...args);
+  _pluginErrorSink = () => {};
 }
 
 /**

--- a/src/verification/executor.ts
+++ b/src/verification/executor.ts
@@ -109,8 +109,15 @@ export async function executeWithTimeout(
     // Send SIGTERM to process group to kill children too
     killProcessGroup(pid, "SIGTERM");
 
-    // Wait for graceful shutdown
-    await Bun.sleep(gracePeriodMs);
+    // Wait for graceful shutdown, but bail early if process already exited.
+    // Bun.sleep is not cancellable; use Promise.race so parallel kills in
+    // high-concurrency runs don't each block for the full grace period unnecessarily.
+    await Promise.race([
+      proc.exited,
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, gracePeriodMs);
+      }),
+    ]);
 
     // Force SIGKILL entire process group if still running
     killProcessGroup(pid, "SIGKILL");

--- a/src/verification/runners.ts
+++ b/src/verification/runners.ts
@@ -105,11 +105,20 @@ export async function fullSuite(options: VerificationGateOptions): Promise<Verif
   return runVerificationCore(options);
 }
 
+/**
+ * Single-quote a path for safe shell interpolation.
+ * Escapes any single quotes within the path so metacharacters can't break out.
+ */
+function shellQuotePath(p: string): string {
+  return `'${p.replace(/'/g, "'\\''")}'`;
+}
+
 /** Run tests scoped to modified files. */
 export async function scoped(options: VerificationGateOptions): Promise<VerificationResult> {
   let scopedCommand = options.command;
   if (options.scopedTestPaths && options.scopedTestPaths.length > 0) {
-    scopedCommand = `${options.command} ${options.scopedTestPaths.join(" ")}`;
+    const quotedPaths = options.scopedTestPaths.map(shellQuotePath).join(" ");
+    scopedCommand = `${options.command} ${quotedPaths}`;
   }
   return runVerificationCore({ ...options, command: scopedCommand });
 }


### PR DESCRIPTION
## What

Addresses all findings from a security, performance, and code-quality review across 12 source files. Two commits: one for the bulk of the findings, one specifically for the `_unavailableAgents` cross-story leak which required a more careful approach.

## Why

Several issues posed real security and reliability risk in production. See details below.

Closes #299

## How

**Security fixes**
- `plan.ts` — moved `inputFile` read out of the synchronous `buildPlanCommand()` into the async `runPlan()`, using `await Bun.file().text()` with `validateFilePath()` boundary check. Removed dynamic `require("node:fs")` / `require("node:path")` calls entirely. Added `resolvedInputContent?: string` to `PlanOptions` so `buildPlanCommand()` never touches the filesystem.
- `runners.ts` — added `shellQuotePath()` helper that single-quotes each path (escaping embedded quotes) before joining into the shell command string, preventing injection from git-diff-derived filenames.

**Cross-story auth leak (`_unavailableAgents`)**

The naive fix of clearing in `run()` broke existing tests that deliberately share unavailability state between `complete()` and `run()` on the same story (within-story fallback). The correct granularity is the story boundary:
- `AcpAgentAdapter.clearUnavailableAgents()` — new public reset method
- `AgentRegistry.resetStoryState()` — iterates `acpCache` and calls `clearUnavailableAgents()` on each adapter
- `SequentialExecutionContext.onBeforeStory?` — optional callback added to the context type
- `unified-executor.ts` — calls `ctx.onBeforeStory?.()` at all three story-start sites (parallel batch + two sequential paths)
- `runner-execution.ts` / `runner.ts` — wires `onBeforeStory: () => registry.resetStoryState()`

**Crash handler singleton (`handlersInstalled`)**
- Replaced the `let handlersInstalled = false` boolean with `let activeCleanup: (() => void) | null`. A second `installCrashHandlers()` call now deregisters the stale handlers before registering the new context, instead of silently returning a no-op.

**Grace period cancellability**
- `executor.ts` — replaced `await Bun.sleep(gracePeriodMs)` with `Promise.race([proc.exited, setTimeout])` so parallel kills don't each block for the full 5s if the process already exited.

**Node.js API cleanup**
- `context/generator.ts` — removed `readFileSync` from `_generatorDeps`; replaced all three monorepo-detection `existsSync + readFileSync` blocks with `await readTextFile()` inside try/catch.
- `crash-heartbeat.ts` / `crash-writer.ts` — added comments explaining why `appendFileSync` is intentional (no Bun async append API; sync write required in signal handlers).
- `cli/init-detect.ts` — added comment explaining sync detection chain trade-off.

**Convention cleanup**
- `plugins/loader.ts` — changed `_pluginErrorSink` default from `console.error` to `() => {}`; logger calls are sufficient.
- `runner-completion.ts` — removed two `console.info()` calls duplicating `logger.info()` output.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes (6207 tests across 389 files)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

**`_unavailableAgents` in parallel mode:** Stories in a parallel batch still share the same cached adapter instances during their execution. The `onBeforeStory` reset fires once per batch (before dispatch), which is the best achievable without per-story adapter isolation. True parallel isolation would require creating fresh adapter instances per story — a larger refactor out of scope here.

**`appendFileSync` in logger / crash paths:** These are intentional exceptions to the Bun-native rule. The logger uses synchronous appends to guarantee log lines are flushed before a crash; crash/signal handlers need sync writes because the async event loop may be in an inconsistent state during `process.exit()`.