### PR TITLE
fix(cost): wire LLM cost through all secondary agent call sites

### DIFF
--- a/src/acceptance/fix-diagnosis.ts
+++ b/src/acceptance/fix-diagnosis.ts
@@ -156,13 +156,14 @@ export async function diagnoseAcceptanceFailure(
 
     const diagnosis = parseDiagnosisResult(result.output);
     if (diagnosis) {
-      return diagnosis;
+      return { ...diagnosis, cost: result.estimatedCost ?? 0 };
     }
 
     return {
       verdict: "source_bug",
       reasoning: "diagnosis failed — falling back to source fix",
       confidence: 0,
+      cost: result.estimatedCost ?? 0,
     };
   } catch {
     return {

--- a/src/acceptance/types.ts
+++ b/src/acceptance/types.ts
@@ -179,4 +179,6 @@ export interface DiagnosisResult {
   testIssues?: string[];
   /** Issues found in the source code (optional) */
   sourceIssues?: string[];
+  /** LLM cost incurred for the diagnosis agent session */
+  cost?: number;
 }

--- a/src/debate/session-plan.ts
+++ b/src/debate/session-plan.ts
@@ -40,6 +40,8 @@ export async function runPlan(
   const logger = _debateSessionDeps.getSafeLogger();
   const config = ctx.stageConfig;
   const debaters = config.debaters ?? [];
+  // NOTE: adapter.plan() returns PlanResult which does not expose estimatedCost.
+  // Cost tracking for plan-mode debates requires PlanResult to include cost — tracked separately.
   const totalCostUsd = 0;
 
   // Resolve adapters — skip unavailable agents

--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -124,16 +124,6 @@ export async function runIteration(
   const pipelineResult = await runPipeline(defaultPipeline, pipelineContext, ctx.eventEmitter);
   const currentPrd = pipelineResult.context.prd;
 
-  // Release heavy context fields so the GC can collect LLM response buffers,
-  // prompts, and context markdown before the next story begins. See #253.
-  pipelineContext.agentResult = undefined;
-  pipelineContext.prompt = undefined;
-  pipelineContext.contextMarkdown = undefined;
-  pipelineContext.builtContext = undefined;
-  pipelineContext.verifyResult = undefined;
-  pipelineContext.reviewResult = undefined;
-  pipelineContext.constitution = undefined;
-
   const handlerCtx = {
     config: ctx.config,
     prd: currentPrd,
@@ -157,26 +147,42 @@ export async function runIteration(
     statusWriter: ctx.statusWriter,
   };
 
+  // Collect result from handlers BEFORE GC clearing — pipelineResult.context is the same
+  // object as pipelineContext, so clearing agentResult before handlers read
+  // agentResult.estimatedCost caused costDelta to always be 0. See #253.
+  let iterResult: IterationResult;
   if (pipelineResult.success) {
     const r = await handlePipelineSuccess(handlerCtx, pipelineResult);
-    return {
+    iterResult = {
       prd: r.prd,
       storiesCompletedDelta: r.storiesCompletedDelta,
       costDelta: r.costDelta,
       prdDirty: r.prdDirty,
       finalAction: pipelineResult.finalAction,
     };
+  } else {
+    const r = await handlePipelineFailure(handlerCtx, pipelineResult);
+    iterResult = {
+      prd: r.prd,
+      storiesCompletedDelta: 0,
+      costDelta: r.costDelta,
+      prdDirty: r.prdDirty,
+      finalAction: pipelineResult.finalAction,
+      reason: pipelineResult.reason,
+      subStoryCount: pipelineResult.subStoryCount,
+    };
   }
-  const r = await handlePipelineFailure(handlerCtx, pipelineResult);
-  return {
-    prd: r.prd,
-    storiesCompletedDelta: 0,
-    costDelta: r.costDelta,
-    prdDirty: r.prdDirty,
-    finalAction: pipelineResult.finalAction,
-    reason: pipelineResult.reason,
-    subStoryCount: pipelineResult.subStoryCount,
-  };
+
+  // Release heavy context fields after handlers are done reading them.
+  pipelineContext.agentResult = undefined;
+  pipelineContext.prompt = undefined;
+  pipelineContext.contextMarkdown = undefined;
+  pipelineContext.builtContext = undefined;
+  pipelineContext.verifyResult = undefined;
+  pipelineContext.reviewResult = undefined;
+  pipelineContext.constitution = undefined;
+
+  return iterResult;
 }
 
 /**

--- a/src/execution/lifecycle/acceptance-loop.ts
+++ b/src/execution/lifecycle/acceptance-loop.ts
@@ -558,6 +558,8 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
     semanticVerdicts: options.semanticVerdicts as import("../../acceptance/types").SemanticVerdict[] | undefined,
   });
 
+  const diagnosisCost = diagnosis.cost ?? 0;
+
   logger?.info("acceptance.diagnosis", "Diagnosis complete", {
     verdict: diagnosis.verdict,
     confidence: diagnosis.confidence,
@@ -569,7 +571,7 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
 
     if (!agent) {
       logger?.error("acceptance", "Agent not found for source fix execution");
-      return { fixed: false, cost: 0, prdDirty: false };
+      return { fixed: false, cost: diagnosisCost, prdDirty: false };
     }
 
     let fixAttempts = 0;
@@ -595,7 +597,7 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
       });
 
       if (fixResult.success) {
-        return { fixed: true, cost: fixResult.cost, prdDirty: false };
+        return { fixed: true, cost: fixResult.cost + diagnosisCost, prdDirty: false };
       }
       logger?.warn("acceptance.source-fix", "Source fix attempt failed", {
         attempt: fixAttempts,
@@ -610,7 +612,7 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
       }
     }
 
-    return { fixed: false, cost: 0, prdDirty: false };
+    return { fixed: false, cost: diagnosisCost, prdDirty: false };
   }
 
   if (diagnosis.verdict === "test_bug") {
@@ -618,7 +620,7 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
 
     if (!ctx.featureDir) {
       logger?.error("acceptance", "Cannot regenerate test without featureDir");
-      return { fixed: false, cost: 0, prdDirty: false };
+      return { fixed: false, cost: diagnosisCost, prdDirty: false };
     }
 
     const testPath = await findExistingAcceptanceTestPathFromOptions({
@@ -636,7 +638,7 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
           language: ctx.config.project?.language,
         }),
       });
-      return { fixed: false, cost: 0, prdDirty: false };
+      return { fixed: false, cost: diagnosisCost, prdDirty: false };
     }
 
     const regenerated = await regenerateAcceptanceTest(testPath, acceptanceContext as PipelineContext);
@@ -646,7 +648,7 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
     });
 
     if (!regenerated) {
-      return { fixed: false, cost: 0, prdDirty: false };
+      return { fixed: false, cost: diagnosisCost, prdDirty: false };
     }
 
     const { acceptanceStage } = await import("../../pipeline/stages/acceptance");
@@ -654,11 +656,11 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
 
     if (acceptanceResult.action === "continue") {
       logger?.info("acceptance", "Acceptance passed after test regeneration");
-      return { fixed: true, cost: 0, prdDirty: true };
+      return { fixed: true, cost: diagnosisCost, prdDirty: true };
     }
 
     logger?.warn("acceptance", "Acceptance still failing after test regeneration");
-    return { fixed: false, cost: 0, prdDirty: true };
+    return { fixed: false, cost: diagnosisCost, prdDirty: true };
   }
 
   if (diagnosis.verdict === "both") {
@@ -666,7 +668,7 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
 
     if (!agent) {
       logger?.error("acceptance", "Agent not found for source fix execution");
-      return { fixed: false, cost: 0, prdDirty: false };
+      return { fixed: false, cost: diagnosisCost, prdDirty: false };
     }
 
     let sourceFixSuccess = false;
@@ -714,7 +716,7 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
     }
 
     if (!sourceFixSuccess) {
-      return { fixed: false, cost: sourceFixCost, prdDirty: false };
+      return { fixed: false, cost: sourceFixCost + diagnosisCost, prdDirty: false };
     }
 
     logger?.info("acceptance", "Source fix succeeded — re-running acceptance to verify");
@@ -724,14 +726,14 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
 
     if (acceptanceResult.action === "continue") {
       logger?.info("acceptance", "Acceptance passed after source fix");
-      return { fixed: true, cost: sourceFixCost, prdDirty: false };
+      return { fixed: true, cost: sourceFixCost + diagnosisCost, prdDirty: false };
     }
 
     logger?.info("acceptance", "Acceptance still failing after source fix — regenerating test");
 
     if (!ctx.featureDir) {
       logger?.error("acceptance", "Cannot regenerate test without featureDir");
-      return { fixed: false, cost: sourceFixCost, prdDirty: false };
+      return { fixed: false, cost: sourceFixCost + diagnosisCost, prdDirty: false };
     }
 
     const testPath = await findExistingAcceptanceTestPathFromOptions({
@@ -749,7 +751,7 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
           language: ctx.config.project?.language,
         }),
       });
-      return { fixed: false, cost: sourceFixCost, prdDirty: false };
+      return { fixed: false, cost: sourceFixCost + diagnosisCost, prdDirty: false };
     }
 
     const regenerated = await regenerateAcceptanceTest(testPath, acceptanceContext as PipelineContext);
@@ -758,10 +760,10 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
       outcome: regenerated ? "success" : "failure",
     });
 
-    return { fixed: regenerated, cost: sourceFixCost, prdDirty: regenerated };
+    return { fixed: regenerated, cost: sourceFixCost + diagnosisCost, prdDirty: regenerated };
   }
 
-  return { fixed: false, cost: 0, prdDirty: false };
+  return { fixed: false, cost: diagnosisCost, prdDirty: false };
 }
 
 /**

--- a/src/execution/pipeline-result-handler.ts
+++ b/src/execution/pipeline-result-handler.ts
@@ -70,7 +70,7 @@ export async function handlePipelineSuccess(
   pipelineResult: PipelineRunResult,
 ): Promise<PipelineSuccessResult> {
   const logger = getSafeLogger();
-  const costDelta = pipelineResult.context.agentResult?.estimatedCost || 0;
+  const costDelta = (pipelineResult.context.agentResult?.estimatedCost ?? 0) + (pipelineResult.stageCost ?? 0);
   const prd = ctx.prd;
 
   if (pipelineResult.context.storyMetrics) {
@@ -142,7 +142,7 @@ export async function handlePipelineFailure(
   let prd = ctx.prd;
   let prdDirty = false;
   // Always capture cost even for failed stories — agent ran and spent tokens
-  const costDelta = pipelineResult.context.agentResult?.estimatedCost || 0;
+  const costDelta = (pipelineResult.context.agentResult?.estimatedCost ?? 0) + (pipelineResult.stageCost ?? 0);
 
   switch (pipelineResult.finalAction) {
     case "pause":

--- a/src/pipeline/runner.ts
+++ b/src/pipeline/runner.ts
@@ -26,6 +26,12 @@ export interface PipelineRunResult {
   stoppedAtStage?: string;
   /** Updated context after pipeline execution */
   context: PipelineContext;
+  /**
+   * Sum of cost reported by secondary agent calls within pipeline stages
+   * (e.g. rectification loops, semantic review, acceptance diagnosis).
+   * Distinct from context.agentResult.estimatedCost which holds the main execution cost.
+   */
+  stageCost?: number;
 }
 
 /** Maximum number of retries per stage to prevent infinite loops. */
@@ -48,6 +54,7 @@ export async function runPipeline(
   const logger = getLogger();
   const retryCountMap = new Map<string, number>();
   let i = 0;
+  let stageCostAccum = 0;
 
   while (i < stages.length) {
     const stage = stages[i];
@@ -71,9 +78,17 @@ export async function runPipeline(
         reason: `Stage "${stage.name}" threw error: ${errorMessage(error)}`,
       };
       eventEmitter?.emit("stage:exit", stage.name, failResult);
-      return { success: false, finalAction: "fail", reason: failResult.reason, stoppedAtStage: stage.name, context };
+      return {
+        success: false,
+        finalAction: "fail",
+        reason: failResult.reason,
+        stoppedAtStage: stage.name,
+        context,
+        stageCost: stageCostAccum > 0 ? stageCostAccum : undefined,
+      };
     }
 
+    if (result.cost) stageCostAccum += result.cost;
     eventEmitter?.emit("stage:exit", stage.name, result);
 
     switch (result.action) {
@@ -82,10 +97,24 @@ export async function runPipeline(
         continue;
 
       case "skip":
-        return { success: false, finalAction: "skip", reason: result.reason, stoppedAtStage: stage.name, context };
+        return {
+          success: false,
+          finalAction: "skip",
+          reason: result.reason,
+          stoppedAtStage: stage.name,
+          context,
+          stageCost: stageCostAccum > 0 ? stageCostAccum : undefined,
+        };
 
       case "fail":
-        return { success: false, finalAction: "fail", reason: result.reason, stoppedAtStage: stage.name, context };
+        return {
+          success: false,
+          finalAction: "fail",
+          reason: result.reason,
+          stoppedAtStage: stage.name,
+          context,
+          stageCost: stageCostAccum > 0 ? stageCostAccum : undefined,
+        };
 
       case "escalate":
         return {
@@ -94,10 +123,18 @@ export async function runPipeline(
           reason: result.reason ?? "Stage requested escalation to higher tier",
           stoppedAtStage: stage.name,
           context,
+          stageCost: stageCostAccum > 0 ? stageCostAccum : undefined,
         };
 
       case "pause":
-        return { success: false, finalAction: "pause", reason: result.reason, stoppedAtStage: stage.name, context };
+        return {
+          success: false,
+          finalAction: "pause",
+          reason: result.reason,
+          stoppedAtStage: stage.name,
+          context,
+          stageCost: stageCostAccum > 0 ? stageCostAccum : undefined,
+        };
 
       case "retry": {
         const retries = (retryCountMap.get(result.fromStage) ?? 0) + 1;
@@ -109,6 +146,7 @@ export async function runPipeline(
             reason: `Stage "${stage.name}" exceeded max retries (${MAX_STAGE_RETRIES}) for "${result.fromStage}"`,
             stoppedAtStage: stage.name,
             context,
+            stageCost: stageCostAccum > 0 ? stageCostAccum : undefined,
           };
         }
         retryCountMap.set(result.fromStage, retries);
@@ -121,6 +159,7 @@ export async function runPipeline(
             reason: `Retry target stage "${result.fromStage}" not found`,
             stoppedAtStage: stage.name,
             context,
+            stageCost: stageCostAccum > 0 ? stageCostAccum : undefined,
           };
         }
         logger.debug("pipeline", `Retrying from stage "${result.fromStage}" (attempt ${retries}/${MAX_STAGE_RETRIES})`);
@@ -135,5 +174,10 @@ export async function runPipeline(
     }
   }
 
-  return { success: true, finalAction: "complete", context };
+  return {
+    success: true,
+    finalAction: "complete",
+    context,
+    stageCost: stageCostAccum > 0 ? stageCostAccum : undefined,
+  };
 }

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -128,7 +128,12 @@ export const autofixStage: PipelineStage = {
     }
 
     // Phase 2: Agent rectification — spawn agent with review error context
-    const agentFixed = await _autofixDeps.runAgentRectification(ctx, lintFixCmd, formatFixCmd, ctx.workdir);
+    const { succeeded: agentFixed, cost: agentCost } = await _autofixDeps.runAgentRectification(
+      ctx,
+      lintFixCmd,
+      formatFixCmd,
+      ctx.workdir,
+    );
     if (agentFixed) {
       if (ctx.reviewResult) ctx.reviewResult = { ...ctx.reviewResult, success: true };
       // #136: Skip checks that already passed — only re-run checks that originally failed.
@@ -143,11 +148,15 @@ export const autofixStage: PipelineStage = {
         });
       }
       logger.info("autofix", "Agent rectification succeeded — retrying review", { storyId: ctx.story.id });
-      return { action: "retry", fromStage: "review" };
+      return { action: "retry", fromStage: "review", cost: agentCost };
     }
 
     logger.warn("autofix", "Autofix exhausted — escalating", { storyId: ctx.story.id });
-    return { action: "escalate", reason: "Autofix exhausted: review still failing after fix attempts" };
+    return {
+      action: "escalate",
+      reason: "Autofix exhausted: review still failing after fix attempts",
+      cost: agentCost,
+    };
   },
 };
 
@@ -210,7 +219,7 @@ async function runAgentRectification(
   lintFixCmd: string | undefined,
   formatFixCmd: string | undefined,
   effectiveWorkdir: string,
-): Promise<boolean> {
+): Promise<{ succeeded: boolean; cost: number }> {
   const logger = getLogger();
   const maxPerCycle = ctx.config.quality.autofix?.maxAttempts ?? 2;
   const maxTotal = ctx.config.quality.autofix?.maxTotalAttempts ?? 10;
@@ -221,7 +230,7 @@ async function runAgentRectification(
 
   if (failedChecks.length === 0) {
     logger.debug("autofix", "No failed checks found — skipping agent rectification", { storyId: ctx.story.id });
-    return false;
+    return { succeeded: false, cost: 0 };
   }
 
   // Global budget check — escalate if total attempts exhausted across all cycles
@@ -231,7 +240,7 @@ async function runAgentRectification(
       totalAttempts: consumed,
       maxTotalAttempts: maxTotal,
     });
-    return false;
+    return { succeeded: false, cost: 0 };
   }
 
   // Cap this cycle's attempts to not exceed global budget
@@ -243,8 +252,9 @@ async function runAgentRectification(
     attempt: 0,
     failedChecks,
   };
+  let autofixCostAccum = 0;
 
-  return runSharedRectificationLoop({
+  const succeeded = await runSharedRectificationLoop({
     stage: "autofix",
     storyId: ctx.story.id,
     maxAttempts,
@@ -304,6 +314,8 @@ async function runAgentRectification(
         storyId: ctx.story.id,
         sessionRole: "implementer",
       });
+
+      autofixCostAccum += result.estimatedCost ?? 0;
 
       // AC5/AC6/AC10: Detect CLARIFY blocks and relay to reviewerSession
       if (ctx.reviewerSession && result.output) {
@@ -395,6 +407,8 @@ async function runAgentRectification(
     }
     throw error;
   });
+
+  return { succeeded, cost: autofixCostAccum };
 }
 
 /**

--- a/src/pipeline/stages/rectify.ts
+++ b/src/pipeline/stages/rectify.ts
@@ -60,26 +60,27 @@ export const rectifyStage: PipelineStage = {
     });
 
     const testCommand = ctx.config.review?.commands?.test ?? ctx.config.quality.commands.test ?? "bun test";
-    const fixed = await _rectifyDeps.runRectificationLoop(ctx, { testCommand, testOutput });
+    const { succeeded, cost } = await _rectifyDeps.runRectificationLoop(ctx, { testCommand, testOutput });
 
     pipelineEventBus.emit({
       type: "rectify:completed",
       storyId: ctx.story.id,
       attempt: rectifyAttempt,
-      fixed,
+      fixed: succeeded,
     });
 
-    if (fixed) {
+    if (succeeded) {
       logger.info("rectify", "Rectification succeeded — retrying verify", { storyId: ctx.story.id });
       // Clear verifyResult so verify stage re-runs fresh
       ctx.verifyResult = undefined;
-      return { action: "retry", fromStage: "verify" };
+      return { action: "retry", fromStage: "verify", cost };
     }
 
     logger.warn("rectify", "Rectification exhausted — escalating", { storyId: ctx.story.id });
     return {
       action: "escalate",
       reason: `Rectification exhausted after ${maxRetries} attempts (${verifyResult.failCount} test failures)`,
+      cost,
     };
   },
 };

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -117,6 +117,7 @@ export const reviewStage: PipelineStage = {
                 ],
             totalDurationMs: 0,
           };
+          const dialogueCost = sessionResult.cost ?? 0;
           if (passed) {
             logger.info("review", "Review passed (dialogue session)", { storyId: ctx.story.id });
           } else {
@@ -124,7 +125,7 @@ export const reviewStage: PipelineStage = {
               storyId: ctx.story.id,
             });
           }
-          return { action: "continue" };
+          return { action: "continue", cost: dialogueCost || undefined };
         } catch (err) {
           logger.warn("review", "ReviewerSession.review() failed — falling back to one-shot review", {
             storyId: ctx.story.id,
@@ -139,6 +140,9 @@ export const reviewStage: PipelineStage = {
     const result = await reviewOrchestrator.reviewFromContext(ctx);
 
     ctx.reviewResult = result.builtIn;
+
+    // Sum LLM costs from checks (populated by semantic review)
+    const reviewCost = (result.builtIn.checks ?? []).reduce((sum, c) => sum + (c.cost ?? 0), 0) || undefined;
 
     if (!result.success) {
       // Collect structured findings from plugin reviewers for escalation context
@@ -162,14 +166,14 @@ export const reviewStage: PipelineStage = {
           );
           if (!shouldContinue) {
             logger.error("review", `Plugin reviewer failed: ${result.failureReason}`, { storyId: ctx.story.id });
-            return { action: "fail", reason: `Review failed: ${result.failureReason}` };
+            return { action: "fail", reason: `Review failed: ${result.failureReason}`, cost: reviewCost };
           }
           logger.warn("review", "Security-review trigger escalated — retrying story", { storyId: ctx.story.id });
-          return { action: "escalate", reason: `Review failed: ${result.failureReason}` };
+          return { action: "escalate", reason: `Review failed: ${result.failureReason}`, cost: reviewCost };
         }
 
         logger.error("review", `Plugin reviewer failed: ${result.failureReason}`, { storyId: ctx.story.id });
-        return { action: "fail", reason: `Review failed: ${result.failureReason}` };
+        return { action: "fail", reason: `Review failed: ${result.failureReason}`, cost: reviewCost };
       }
 
       logger.warn("review", "Review failed (built-in checks) — handing off to autofix", {
@@ -177,14 +181,14 @@ export const reviewStage: PipelineStage = {
         storyId: ctx.story.id,
       });
       // ctx.reviewResult is already set with success:false — autofixStage handles it next
-      return { action: "continue" };
+      return { action: "continue", cost: reviewCost };
     }
 
     logger.info("review", "Review passed", {
       durationMs: result.builtIn.totalDurationMs,
       storyId: ctx.story.id,
     });
-    return { action: "continue" };
+    return { action: "continue", cost: reviewCost };
   },
 };
 

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -40,6 +40,8 @@ export interface ReviewDialogueResult {
    * Populated by reReview() — undefined for the initial review() call.
    */
   deltaSummary?: string;
+  /** LLM cost incurred for this dialogue turn */
+  cost?: number;
 }
 
 /** A stateful reviewer session wrapping a persistent agent.run() call */
@@ -288,10 +290,11 @@ export function createReviewerSession(
       history.push({ role: "reviewer", content: result.output });
 
       const parsed = parseReviewResponse(result.output);
-      lastCheckResult = parsed;
+      const reviewResult: ReviewDialogueResult = { ...parsed, cost: result.estimatedCost ?? 0 };
+      lastCheckResult = reviewResult;
       lastStory = story;
       lastSemanticConfig = semanticConfig;
-      return parsed;
+      return reviewResult;
     },
     async reReview(updatedDiff: string): Promise<ReviewDialogueResult> {
       if (!active) {
@@ -333,7 +336,7 @@ export function createReviewerSession(
 
       const parsed = parseReviewResponse(result.output);
       const deltaSummary = extractDeltaSummary(result.output, previousFindings, parsed.checkResult.findings);
-      const dialogueResult: ReviewDialogueResult = { ...parsed, deltaSummary };
+      const dialogueResult: ReviewDialogueResult = { ...parsed, deltaSummary, cost: result.estimatedCost ?? 0 };
       lastCheckResult = dialogueResult;
 
       const maxMessages = _config.review?.dialogue?.maxDialogueMessages ?? 20;

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -404,6 +404,7 @@ export async function runSemanticReview(
       timeoutSeconds: naxConfig?.execution?.sessionTimeoutSeconds,
     });
     const debateResult = await debateSession.run(prompt);
+    const debateCost = debateResult.totalCostUsd ?? 0;
 
     // Compute majority vote and merge findings from all proposals
     let passCount = 0;
@@ -450,6 +451,7 @@ export async function runSemanticReview(
           output: `Semantic review failed:\n\n${formatFindings(debateBlocking)}`,
           durationMs,
           findings: toReviewFindings(debateBlocking),
+          cost: debateCost,
         };
       }
       // All findings were non-blocking — override to pass
@@ -464,6 +466,7 @@ export async function runSemanticReview(
         exitCode: 0,
         output: "Semantic review passed (debate, all findings were unverifiable or informational)",
         durationMs,
+        cost: debateCost,
       };
     }
     logger?.info("review", "Semantic review passed (debate)", { storyId: story.id, durationMs });
@@ -474,6 +477,7 @@ export async function runSemanticReview(
       exitCode: 0,
       output: "Semantic review passed",
       durationMs,
+      cost: debateCost,
     };
   }
 
@@ -498,6 +502,7 @@ export async function runSemanticReview(
     // Use default model if resolution fails
   }
   let rawResponse: string;
+  let llmCost = 0;
   try {
     let runErr: unknown;
     let runSucceeded = false;
@@ -514,6 +519,7 @@ export async function runSemanticReview(
         config: naxConfig ?? DEFAULT_CONFIG,
       });
       runOutput = runResult.output;
+      llmCost = runResult.estimatedCost ?? 0;
       runSucceeded = true;
     } catch (err) {
       runErr = err;
@@ -531,6 +537,7 @@ export async function runSemanticReview(
         config: naxConfig ?? DEFAULT_CONFIG,
       });
       rawResponse = typeof completeResult === "string" ? completeResult : completeResult.output;
+      llmCost = typeof completeResult === "string" ? 0 : (completeResult.costUsd ?? 0);
       void runErr;
     }
   } catch (err) {
@@ -564,6 +571,7 @@ export async function runSemanticReview(
         output:
           "semantic review: LLM response truncated but indicated failure (passed:false found in partial response)",
         durationMs: Date.now() - startTime,
+        cost: llmCost,
       };
     }
 
@@ -575,6 +583,7 @@ export async function runSemanticReview(
       exitCode: 0,
       output: "semantic review: could not parse LLM response (fail-open)",
       durationMs: Date.now() - startTime,
+      cost: llmCost,
     };
   }
 
@@ -619,6 +628,7 @@ export async function runSemanticReview(
       output,
       durationMs,
       findings: toReviewFindings(blockingFindings),
+      cost: llmCost,
     };
   }
 
@@ -633,6 +643,7 @@ export async function runSemanticReview(
       exitCode: 0,
       output: "Semantic review passed (all findings were unverifiable or informational)",
       durationMs,
+      cost: llmCost,
     };
   }
 
@@ -647,5 +658,6 @@ export async function runSemanticReview(
     exitCode: parsed.passed ? 0 : 1,
     output: parsed.passed ? "Semantic review passed" : "Semantic review failed (no findings)",
     durationMs,
+    cost: llmCost,
   };
 }

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -35,6 +35,8 @@ export interface ReviewCheckResult {
   durationMs: number;
   /** Structured findings (populated by semantic review when LLM returns findings) */
   findings?: import("../plugins/types").ReviewFinding[];
+  /** LLM cost incurred for this check (populated by semantic review) */
+  cost?: number;
 }
 
 /** Plugin reviewer result */

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -283,7 +283,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
   }
 
   // Full-Suite Gate (v0.11 Rectification)
-  const fullSuiteGatePassed = await runFullSuiteGate(
+  const { passed: fullSuiteGatePassed, cost: fullSuiteGateCost } = await runFullSuiteGate(
     story,
     config,
     workdir,
@@ -385,7 +385,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     }
   }
 
-  const totalCost = sessions.reduce((sum, s) => sum + s.estimatedCost, 0);
+  const totalCost = sessions.reduce((sum, s) => sum + s.estimatedCost, 0) + fullSuiteGateCost;
 
   logger.info("tdd", allSuccessful ? "[OK] Three-session TDD complete" : "[WARN] Three-session TDD needs review", {
     storyId: story.id,

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -47,9 +47,9 @@ export async function runFullSuiteGate(
   logger: ReturnType<typeof getLogger>,
   featureName?: string,
   projectDir?: string,
-): Promise<boolean> {
+): Promise<{ passed: boolean; cost: number }> {
   const rectificationEnabled = config.execution.rectification?.enabled ?? false;
-  if (!rectificationEnabled) return false;
+  if (!rectificationEnabled) return { passed: false, cost: 0 };
 
   const rectificationConfig = config.execution.rectification;
   const testCmd = config.quality?.commands?.test ?? "bun test";
@@ -98,7 +98,7 @@ export async function runFullSuiteGate(
         exitCode: fullSuiteResult.exitCode,
         passedTests: testSummary.passed,
       });
-      return true;
+      return { passed: true, cost: 0 };
     }
 
     // No tests passed AND no tests failed — output is likely truncated/crashed
@@ -108,17 +108,17 @@ export async function runFullSuiteGate(
       outputLength: fullSuiteResult.output.length,
       outputTail: fullSuiteResult.output.slice(-200),
     });
-    return false;
+    return { passed: false, cost: 0 };
   }
   if (fullSuitePassed) {
     logger.info("tdd", "Full suite gate passed", { storyId: story.id });
-    return true;
+    return { passed: true, cost: 0 };
   }
   logger.warn("tdd", "Full suite gate execution failed (no output)", {
     storyId: story.id,
     exitCode: fullSuiteResult.exitCode,
   });
-  return false;
+  return { passed: false, cost: 0 };
 }
 
 /** Run the rectification retry loop when full suite gate detects regressions. */
@@ -127,6 +127,7 @@ async function runRectificationLoop(
   config: NaxConfig,
   workdir: string,
   agent: AgentAdapter,
+
   implementerTier: ModelTier,
   contextMarkdown: string | undefined,
   lite: boolean,
@@ -137,7 +138,7 @@ async function runRectificationLoop(
   fullSuiteTimeout: number,
   featureName?: string,
   projectDir?: string,
-): Promise<boolean> {
+): Promise<{ passed: boolean; cost: number }> {
   const rectificationState: RectificationState = {
     attempt: 0,
     initialFailures: testSummary.failed,
@@ -162,6 +163,7 @@ async function runRectificationLoop(
     ...rectificationState,
     isolationPassed: true,
   };
+  let gateCostAccum = 0;
 
   const fixed = await runSharedRectificationLoop({
     stage: "tdd",
@@ -214,6 +216,8 @@ async function runRectificationLoop(
       if (!rectifyResult.success && rectifyResult.pid) {
         await cleanupProcessTree(rectifyResult.pid);
       }
+
+      gateCostAccum += rectifyResult.estimatedCost ?? 0;
 
       if (rectifyResult.success) {
         logger.info("tdd", "Rectification agent session complete", {
@@ -283,7 +287,7 @@ async function runRectificationLoop(
   });
 
   if (fixed) {
-    return true;
+    return { passed: true, cost: gateCostAccum };
   }
 
   const finalFullSuite = await _rectificationGateDeps.executeWithTimeout(testCmd, fullSuiteTimeout, undefined, {
@@ -297,8 +301,8 @@ async function runRectificationLoop(
       attempts: rectificationState.attempt,
       remainingFailures: rectificationState.currentFailures,
     });
-    return false;
+    return { passed: false, cost: gateCostAccum };
   }
   logger.info("tdd", "Full suite gate passed", { storyId: story.id });
-  return true;
+  return { passed: true, cost: gateCostAccum };
 }

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -118,8 +118,10 @@ export const _rectificationDeps = {
   runDebate: _defaultRunDebate as typeof _defaultRunDebate,
 };
 
-/** Run the rectification retry loop. Returns true if all failures were fixed. */
-export async function runRectificationLoop(opts: RectificationLoopOptions): Promise<boolean> {
+/** Run the rectification retry loop. Returns whether all failures were fixed and the accumulated agent cost. */
+export async function runRectificationLoop(
+  opts: RectificationLoopOptions,
+): Promise<{ succeeded: boolean; cost: number }> {
   const {
     config,
     workdir,
@@ -144,7 +146,9 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
     lastExitCode: 1, // Assume failure since we entered the loop
   };
 
-  return runSharedRectificationLoop({
+  let costAccum = 0;
+
+  const succeeded = await runSharedRectificationLoop({
     stage: "rectification",
     storyId: story.id,
     maxAttempts: rectificationConfig.maxRetries,
@@ -235,6 +239,7 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
         sessionRole: "implementer",
       });
 
+      costAccum += agentResult.estimatedCost ?? 0;
       if (agentResult.success) {
         logger?.info("rectification", `Agent ${label} session complete`, {
           storyId: story.id,
@@ -387,6 +392,7 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
         sessionRole: "implementer",
       });
 
+      costAccum += escalationRunResult.estimatedCost ?? 0;
       logger?.info("rectification", "escalated rectification attempt cost", {
         storyId: story.id,
         escalatedTier,
@@ -426,6 +432,8 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
     }
     throw error;
   });
+
+  return { succeeded, cost: costAccum };
 }
 
 /**
@@ -435,7 +443,7 @@ export async function runRectificationLoop(opts: RectificationLoopOptions): Prom
 export function runRectificationLoopFromCtx(
   ctx: PipelineContext,
   opts: { testCommand: string; testOutput: string; promptPrefix?: string },
-): Promise<boolean> {
+): Promise<{ succeeded: boolean; cost: number }> {
   return runRectificationLoop({
     config: ctx.config,
     workdir: ctx.workdir,

--- a/test/integration/agents/acp/tdd-flow.test.ts
+++ b/test/integration/agents/acp/tdd-flow.test.ts
@@ -731,7 +731,7 @@ describe("runFullSuiteGate with AcpAgentAdapter", () => {
       { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any,
     );
 
-    expect(result).toBe(false);
+    expect(result.passed).toBe(false);
   });
 
   test("returns true when full suite passes without regressions", async () => {
@@ -766,7 +766,7 @@ describe("runFullSuiteGate with AcpAgentAdapter", () => {
       { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any,
     );
 
-    expect(result).toBe(true);
+    expect(result.passed).toBe(true);
   });
 
   test("calls agent.run() via AcpAgentAdapter during rectification loop", async () => {
@@ -834,7 +834,7 @@ describe("runFullSuiteGate with AcpAgentAdapter", () => {
 
     // Rectification agent was invoked via AcpAgentAdapter
     expect(clientsCreated).toBeGreaterThanOrEqual(1);
-    expect(result).toBe(true);
+    expect(result.passed).toBe(true);
   });
 
   test("rectification gate returns false after max retries with persistent failures", async () => {
@@ -887,6 +887,6 @@ describe("runFullSuiteGate with AcpAgentAdapter", () => {
       { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any,
     );
 
-    expect(result).toBe(false);
+    expect(result.passed).toBe(false);
   });
 });

--- a/test/unit/pipeline/stages/autofix.test.ts
+++ b/test/unit/pipeline/stages/autofix.test.ts
@@ -69,7 +69,7 @@ describe("autofixStage", () => {
 
   test("escalates when no fix commands configured and agent rectification fails", async () => {
     const saved = { ..._autofixDeps };
-    _autofixDeps.runAgentRectification = async () => false;
+    _autofixDeps.runAgentRectification = async () => ({ succeeded: false, cost: 0 });
 
     const ctx = makeCtx({
       reviewResult: makeReviewResult(false),
@@ -108,7 +108,7 @@ describe("autofixStage", () => {
     const saved = { ..._autofixDeps };
     _autofixDeps.runQualityCommand = async () => ({ commandName: "lintFix", command: "", success: false, exitCode: 1, output: "lint error", durationMs: 0, timedOut: false });
     _autofixDeps.recheckReview = async () => false;
-    _autofixDeps.runAgentRectification = async () => false;
+    _autofixDeps.runAgentRectification = async () => ({ succeeded: false, cost: 0 });
 
     const ctx = makeCtx({ reviewResult: makeReviewResult(false) });
     const result = await autofixStage.execute(ctx);
@@ -125,7 +125,7 @@ describe("autofixStage", () => {
     let agentRectificationCalled = false;
     _autofixDeps.runAgentRectification = async () => {
       agentRectificationCalled = true;
-      return false;
+      return { succeeded: false, cost: 0 };
     };
 
     const ctx = makeCtx({
@@ -153,7 +153,7 @@ describe("autofixStage", () => {
     _autofixDeps.recheckReview = async () => false;
     _autofixDeps.runAgentRectification = async () => {
       agentRectificationCalled = true;
-      return false;
+      return { succeeded: false, cost: 0 };
     };
 
     const ctx = makeCtx({ reviewResult: makeReviewResult(false) });
@@ -168,7 +168,7 @@ describe("autofixStage", () => {
     const saved = { ..._autofixDeps };
     _autofixDeps.runQualityCommand = async () => ({ commandName: "lintFix", command: "", success: false, exitCode: 1, output: "", durationMs: 0, timedOut: false });
     _autofixDeps.recheckReview = async () => false;
-    _autofixDeps.runAgentRectification = async () => true;
+    _autofixDeps.runAgentRectification = async () => ({ succeeded: true, cost: 0 });
 
     const ctx = makeCtx({ reviewResult: makeReviewResult(false) });
     const result = await autofixStage.execute(ctx);
@@ -183,7 +183,7 @@ describe("autofixStage", () => {
     const saved = { ..._autofixDeps };
     _autofixDeps.runQualityCommand = async () => ({ commandName: "lintFix", command: "", success: false, exitCode: 1, output: "", durationMs: 0, timedOut: false });
     _autofixDeps.recheckReview = async () => false;
-    _autofixDeps.runAgentRectification = async () => false;
+    _autofixDeps.runAgentRectification = async () => ({ succeeded: false, cost: 0 });
 
     const ctx = makeCtx({ reviewResult: makeReviewResult(false) });
     const result = await autofixStage.execute(ctx);
@@ -200,7 +200,7 @@ describe("autofixStage", () => {
     _autofixDeps.recheckReview = async () => true;
     _autofixDeps.runAgentRectification = async () => {
       agentRectificationCalled = true;
-      return true;
+      return { succeeded: true, cost: 0 };
     };
 
     // Must have a lint failure to trigger Phase 1 (mechanical fix)
@@ -223,7 +223,7 @@ describe("autofixStage", () => {
     };
     _autofixDeps.runAgentRectification = async () => {
       agentRectificationCalled = true;
-      return false;
+      return { succeeded: false, cost: 0 };
     };
 
     // Only typecheck failed — no lint failure → Phase 1 (mechanical fix) should be skipped

--- a/test/unit/pipeline/stages/rectify.test.ts
+++ b/test/unit/pipeline/stages/rectify.test.ts
@@ -76,7 +76,7 @@ describe("rectifyStage", () => {
 
   test("returns retry when rectification succeeds", async () => {
     const saved = { ..._rectifyDeps };
-    _rectifyDeps.runRectificationLoop = async () => true;
+    _rectifyDeps.runRectificationLoop = async () => ({ succeeded: true, cost: 0 });
 
     const ctx = makeCtx({ verifyResult: makeVerifyResult(false) });
     const result = await rectifyStage.execute(ctx);
@@ -91,7 +91,7 @@ describe("rectifyStage", () => {
 
   test("returns escalate when rectification exhausted", async () => {
     const saved = { ..._rectifyDeps };
-    _rectifyDeps.runRectificationLoop = async () => false;
+    _rectifyDeps.runRectificationLoop = async () => ({ succeeded: false, cost: 0 });
 
     const ctx = makeCtx({ verifyResult: makeVerifyResult(false) });
     const result = await rectifyStage.execute(ctx);

--- a/test/unit/verification/rectification-loop-debate-cost.test.ts
+++ b/test/unit/verification/rectification-loop-debate-cost.test.ts
@@ -129,6 +129,6 @@ describe("runRectificationLoop — debate cost included in story total", () => {
       testOutput: FAILING_TEST_OUTPUT,
     });
 
-    expect(result).toBe(true);
+    expect(result.succeeded).toBe(true);
   });
 });

--- a/test/unit/verification/rectification-loop-debate.test.ts
+++ b/test/unit/verification/rectification-loop-debate.test.ts
@@ -307,6 +307,6 @@ describe("runRectificationLoop — debate fallback when all debaters fail", () =
       testOutput: FAILING_TEST_OUTPUT,
     });
 
-    expect(result).toBe(true);
+    expect(result.succeeded).toBe(true);
   });
 });

--- a/test/unit/verification/rectification-loop-escalation.test.ts
+++ b/test/unit/verification/rectification-loop-escalation.test.ts
@@ -278,7 +278,7 @@ describe("runRectificationLoop — escalation on exhaustion", () => {
 
     // Only maxRetries calls, no escalation
     expect(agentRunCalls.length).toBe(2); // maxRetries = 2
-    expect(result).toBe(false);
+    expect(result.succeeded).toBe(false);
   });
 
   test("returns true and logs info with both tier names when escalated verification succeeds", async () => {
@@ -318,7 +318,7 @@ describe("runRectificationLoop — escalation on exhaustion", () => {
       testOutput: FAILING_TEST_OUTPUT,
     });
 
-    expect(result).toBe(true);
+    expect(result.succeeded).toBe(true);
 
     // Should log info message containing both tier names
     const escalationSuccessLog = capturedInfos.find(
@@ -361,7 +361,7 @@ describe("runRectificationLoop — escalation on exhaustion", () => {
       testOutput: FAILING_TEST_OUTPUT,
     });
 
-    expect(result).toBe(false);
+    expect(result.succeeded).toBe(false);
 
     const warnLog = capturedWarns.find((w) =>
       String(w.message).includes("escalated rectification also failed"),
@@ -413,7 +413,7 @@ describe("runRectificationLoop — escalation on exhaustion", () => {
 
     // Only maxRetries calls, no escalation
     expect(agentRunCalls.length).toBe(2);
-    expect(result).toBe(false);
+    expect(result.succeeded).toBe(false);
   });
 
   test("no escalation when abortOnIncreasingFailures exits early (attempt < maxRetries)", async () => {
@@ -470,7 +470,7 @@ describe("runRectificationLoop — escalation on exhaustion", () => {
 
     // Should abort after 1 attempt (not maxRetries=3), so no escalation
     expect(agentRunCalls.length).toBe(1);
-    expect(result).toBe(false);
+    expect(result.succeeded).toBe(false);
   });
 
   test("total agent.run invocations equals maxRetries + 1 when escalation fires", async () => {

--- a/test/unit/verification/rectification-loop.test.ts
+++ b/test/unit/verification/rectification-loop.test.ts
@@ -138,7 +138,7 @@ describe("runRectificationLoop — session context params", () => {
       featureName: "my-feature",
     });
 
-    expect(result).toBe(true);
+    expect(result.succeeded).toBe(true);
     expect(capturedOptions).toHaveLength(1);
     expect(capturedOptions[0].featureName).toBe("my-feature");
     expect(capturedOptions[0].storyId).toBe("TS-001");
@@ -198,7 +198,7 @@ describe("runRectificationLoop — session context params", () => {
       featureName: "my-feature",
     });
 
-    expect(result).toBe(false);
+    expect(result.succeeded).toBe(false);
   });
 
   test("passes config into fallback _rectificationDeps.getAgent when agentGetFn is omitted", async () => {
@@ -240,7 +240,7 @@ describe("runRectificationLoop — session context params", () => {
       testOutput: FAILING_TEST_OUTPUT,
     });
 
-    expect(result).toBe(true);
+    expect(result.succeeded).toBe(true);
     expect(capturedConfig).toBe(config);
   });
 
@@ -318,7 +318,7 @@ describe("runRectificationLoop — session context params", () => {
       testOutput: FAILING_TEST_OUTPUT,
     });
 
-    expect(result).toBe(false);
+    expect(result.succeeded).toBe(false);
     expect(verifyCallCount).toBeGreaterThanOrEqual(1);
     expect(capturedConfigs.length).toBeGreaterThanOrEqual(2);
     expect(capturedConfigs[0]).toBe(config);
@@ -657,7 +657,7 @@ Error: Test failed
       testOutput: FAILING_TEST_OUTPUT,
     });
 
-    expect(result).toBe(true);
+    expect(result.succeeded).toBe(true);
     expect(agentRunCount).toBe(1);
     expect(verificationCalls).toBe(1);
   });


### PR DESCRIPTION
## What

Fixes \`totalCost: 0\` in exit summary logs by correcting a GC-ordering bug and wiring cost propagation through 7 secondary agent call sites.

## Why

\`logs/run.jsonl\` always reported \`totalCost: 0\` despite stories completing. Root cause: a GC-clearing block in \`iteration-runner.ts\` wiped \`pipelineContext.agentResult\` **before** \`handlePipelineSuccess/Failure\` could read \`agentResult.estimatedCost\`. Beyond the primary bug, 8+ secondary call sites (rectification, semantic review, acceptance diagnosis, review dialogue, debate) were silently dropping cost.

Closes #303

## How

**Fix 1 — Primary bug** (\`iteration-runner.ts\`): moved GC clearing to after handler calls return, so \`agentResult.estimatedCost\` is still readable.

**Fix 2 — Architectural hook** (\`runner.ts\`, \`pipeline-result-handler.ts\`): \`StageAction.cost?\` was already defined on every stage action type. The pipeline runner now accumulates these into \`PipelineRunResult.stageCost\`, which the handler adds to \`costDelta\`.

**Fix 3 — Rectification loops** (\`rectification-loop.ts\`, \`rectification-gate.ts\`, \`autofix.ts\`, \`rectify.ts\`): changed return type from \`Promise<boolean>\` to \`Promise<{succeeded/passed, cost}>\`; cost surfaces via \`StageAction.cost\`.

**Fix 4 — Semantic review** (\`semantic.ts\`, \`review/types.ts\`): added \`cost?\` to \`ReviewCheckResult\` and populated it from all three execution paths (debate, run, complete).

**Fix 5 — Debate session-plan** (\`session-plan.ts\`): documented limitation — \`adapter.plan()\` returns no cost field; cost remains 0 on this path.

**Fix 6 — Acceptance diagnosis** (\`fix-diagnosis.ts\`, \`acceptance/types.ts\`, \`acceptance-loop.ts\`): added \`cost?\` to \`DiagnosisResult\`; acceptance loop accumulates it alongside fix cost.

**Fix 7 — Review dialogue** (\`dialogue.ts\`): added \`cost?\` to \`ReviewDialogueResult\`; wired into review stage \`StageAction.cost\`.

## Testing

- [x] Tests added/updated (23 test assertions updated to match new return types)
- [x] \`bun test\` passes (6159 pass, 54 skip, 0 fail)
- [x] \`bun run typecheck\` passes
- [x] \`bun run lint\` passes

## Notes

\`estimatedCost\` is the unified field name for both adapters: CLI populates it from token-based estimation; ACP populates it from exact cost via \`acpx usage_update\` events. No rename needed — the fix is purely propagation.