### PR TITLE
fix(prompts): reduce prompt bloat from audit findings (P1, P2, P5, P7, P10)

### DIFF
--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -61,12 +61,11 @@ export function buildRefinementPrompt(
   const strategySection = buildStrategySection(options);
   const refinedExample = buildRefinedExample(options?.testStrategy);
 
+  const codebaseSection = codebaseContext ? `CODEBASE CONTEXT:\n${codebaseContext}\n` : "";
+
   const core = `You are an acceptance criteria refinement assistant. Your task is to convert raw acceptance criteria into concrete, machine-verifiable assertions.
 
-CODEBASE CONTEXT:
-${codebaseContext}
-${strategySection}
-ACCEPTANCE CRITERIA TO REFINE:
+${codebaseSection}${strategySection}ACCEPTANCE CRITERIA TO REFINE:
 ${criteriaList}
 
 For each criterion, produce a refined version that is concrete and automatically testable where possible.

--- a/src/context/elements.ts
+++ b/src/context/elements.ts
@@ -17,12 +17,34 @@ export function createStoryContext(story: UserStory, priority: number): ContextE
 
 /** Create context element from dependency story, including diff summary if available */
 export function createDependencyContext(story: UserStory, priority: number): ContextElement {
+  const content = isCompletedDependency(story) ? formatCompletedDependency(story) : formatFullDependency(story);
+  return { type: "dependency", storyId: story.id, content, priority, tokens: estimateTokens(content) };
+}
+
+/** Whether a dependency story is complete and should use the compact format */
+function isCompletedDependency(story: UserStory): boolean {
+  return story.status === "passed" || story.status === "decomposed" || story.status === "skipped";
+}
+
+/**
+ * Compact format for completed dependencies.
+ * The agent doesn't need to re-implement these — only needs to know what they produced.
+ */
+function formatCompletedDependency(story: UserStory): string {
+  const header = `## ${story.id} (${story.status}): ${story.title}`;
+  if (story.diffSummary) {
+    return `${header}\n\n**Changes made:**\n\`\`\`\n${story.diffSummary}\n\`\`\``;
+  }
+  return `${header}\n\nStatus: ${story.status} (no diff summary available)`;
+}
+
+/** Full format for incomplete/blocked dependencies — retains full AC list for reference */
+function formatFullDependency(story: UserStory): string {
   let content = formatStoryAsText(story);
-  // Inject diff summary so the agent knows what the dependency actually changed
   if (story.diffSummary) {
     content += `\n\n**Changes made by this story:**\n\`\`\`\n${story.diffSummary}\n\`\`\``;
   }
-  return { type: "dependency", storyId: story.id, content, priority, tokens: estimateTokens(content) };
+  return content;
 }
 
 /** Create context element from error */

--- a/src/execution/story-context.ts
+++ b/src/execution/story-context.ts
@@ -185,7 +185,12 @@ export async function buildStoryContextFull(
       return undefined;
     }
 
-    const baseMarkdown = built.elements.length > 0 ? formatContextAsMarkdown(built) : "";
+    // Exclude the current story element from context markdown — PromptBuilder.build() already
+    // injects it as a dedicated section (3) via buildStorySection(). Including it here too
+    // produces a duplicate "# Story Context" / "## Current Story" block in every run prompt.
+    const elementsForMarkdown = built.elements.filter((e) => e.type !== "story");
+    const baseMarkdown =
+      elementsForMarkdown.length > 0 ? formatContextAsMarkdown({ ...built, elements: elementsForMarkdown }) : "";
     const markdown = packageSection ? `${baseMarkdown}${packageSection}` : baseMarkdown;
 
     return { markdown, builtContext: built };

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -165,16 +165,21 @@ export const acceptanceSetupStage: PipelineStage = {
     const testPathConfig = ctx.config.acceptance.testPath;
     const metaPath = path.join(ctx.featureDir, "acceptance-meta.json");
 
-    // All criteria from original stories only — fix stories (US-FIX-*) are excluded
-    // so that the fingerprint remains stable when fix stories are added during the
-    // acceptance loop. This prevents unnecessary test regeneration on re-runs.
+    // All criteria from original stories only — fix stories (US-FIX-*) and decomposed
+    // parent stories are excluded. Fix stories are excluded so the fingerprint stays
+    // stable when fix stories are added during the acceptance loop. Decomposed stories
+    // are excluded because their ACs are fully covered by their children, and including
+    // them would inflate the fingerprint with duplicate criteria.
     const allCriteria: string[] = ctx.prd.userStories
-      .filter((s) => !s.id.startsWith("US-FIX-"))
+      .filter((s) => !s.id.startsWith("US-FIX-") && s.status !== "decomposed")
       .flatMap((s) => s.acceptanceCriteria);
 
     // US-001: Group non-fix stories by story.workdir.
     // Each group gets its own test file at <package-root>/.nax-acceptance.test.ts.
-    const nonFixStories = ctx.prd.userStories.filter((s) => !s.id.startsWith("US-FIX-"));
+    // Decomposed stories are parent containers whose ACs are fully covered by their
+    // children — including them causes duplicate refine LLM calls and duplicate
+    // acceptance test cases.
+    const nonFixStories = ctx.prd.userStories.filter((s) => !s.id.startsWith("US-FIX-") && s.status !== "decomposed");
     const workdirGroups = new Map<string, { stories: UserStory[]; criteria: string[] }>();
 
     for (const story of nonFixStories) {

--- a/src/prompts/sections/verdict.ts
+++ b/src/prompts/sections/verdict.ts
@@ -28,36 +28,10 @@ Set \`approved: false\` when ANY of these conditions are true:
 - Critical acceptance criteria are not met
 - Code quality is poor (security issues, severe bugs, etc.)
 
-**Full JSON schema example** (fill in all fields with real values):
+**JSON schema** (fill in all fields with real values):
 
 \`\`\`json
-{
-  "version": 1,
-  "approved": true,
-  "tests": {
-    "allPassing": true,
-    "passCount": 42,
-    "failCount": 0
-  },
-  "testModifications": {
-    "detected": false,
-    "files": [],
-    "legitimate": true,
-    "reasoning": "No test files were modified by the implementer"
-  },
-  "acceptanceCriteria": {
-    "allMet": true,
-    "criteria": [
-      { "criterion": "Example criterion", "met": true }
-    ]
-  },
-  "quality": {
-    "rating": "good",
-    "issues": []
-  },
-  "fixes": [],
-  "reasoning": "All tests pass, implementation is clean, all acceptance criteria are met."
-}
+{"version":1,"approved":true,"tests":{"allPassing":true,"passCount":42,"failCount":0},"testModifications":{"detected":false,"files":[],"legitimate":true,"reasoning":"..."},"acceptanceCriteria":{"allMet":true,"criteria":[{"criterion":"...","met":true}]},"quality":{"rating":"good","issues":[]},"fixes":[],"reasoning":"..."}
 \`\`\`
 
 **Field notes:**

--- a/test/integration/context/context-integration.test.ts
+++ b/test/integration/context/context-integration.test.ts
@@ -474,7 +474,8 @@ describe("Context Builder Integration", () => {
       expect(markdown).toContain("US-001");
       expect(markdown).toContain("US-002");
       expect(markdown).toContain("Test error");
-      expect(markdown).toContain("Dep description");
+      // US-001 is passed — compact format omits description, shows status instead
+      expect(markdown).toContain("US-001 (passed): Dependency");
       expect(markdown).toContain("Current description");
     });
 

--- a/test/unit/acceptance/refinement.test.ts
+++ b/test/unit/acceptance/refinement.test.ts
@@ -214,6 +214,17 @@ describe("buildRefinementPrompt", () => {
       expect(prompt).toContain(criterion);
     }
   });
+
+  test("omits CODEBASE CONTEXT section when codebaseContext is empty", () => {
+    const prompt = buildRefinementPrompt(SAMPLE_CRITERIA, "");
+    expect(prompt).not.toContain("CODEBASE CONTEXT:");
+  });
+
+  test("includes CODEBASE CONTEXT section when codebaseContext is provided", () => {
+    const prompt = buildRefinementPrompt(SAMPLE_CRITERIA, CODEBASE_CONTEXT);
+    expect(prompt).toContain("CODEBASE CONTEXT:");
+    expect(prompt).toContain(CODEBASE_CONTEXT);
+  });
 });
 
 describe("parseRefinementResponse", () => {

--- a/test/unit/context/context.test.ts
+++ b/test/unit/context/context.test.ts
@@ -243,8 +243,111 @@ describe("Context Builder", () => {
       expect(element.type).toBe("dependency");
       expect(element.storyId).toBe("US-002");
       expect(element.priority).toBe(50);
-      expect(element.content).toContain("US-002: Dependency Story");
+      expect(element.content).toContain("US-002 (passed): Dependency Story");
       expect(element.tokens).toBeGreaterThan(0);
+    });
+
+    test("passed dependency uses compact format — omits full AC list", () => {
+      const story: UserStory = {
+        id: "US-002",
+        title: "Add VcsPrStatus type",
+        description: "Define VcsPrStatus interface",
+        acceptanceCriteria: ["AC1", "AC2", "AC3", "AC4", "AC5"],
+        dependencies: [],
+        tags: [],
+        status: "passed",
+        passes: true,
+        escalations: [],
+        attempts: 0,
+      };
+
+      const element = createDependencyContext(story, 50);
+
+      expect(element.content).toContain("US-002 (passed): Add VcsPrStatus type");
+      expect(element.content).not.toContain("**Acceptance Criteria:**");
+      expect(element.content).not.toContain("**Description:**");
+    });
+
+    test("passed dependency with diffSummary includes changes block", () => {
+      const story: UserStory = {
+        id: "US-002",
+        title: "Add VcsPrStatus type",
+        description: "Define VcsPrStatus interface",
+        acceptanceCriteria: ["AC1"],
+        dependencies: [],
+        tags: [],
+        status: "passed",
+        passes: true,
+        escalations: [],
+        attempts: 0,
+        diffSummary: "src/vcs/types.ts | 12 ++",
+      };
+
+      const element = createDependencyContext(story, 50);
+
+      expect(element.content).toContain("**Changes made:**");
+      expect(element.content).toContain("src/vcs/types.ts | 12 ++");
+      expect(element.content).not.toContain("**Acceptance Criteria:**");
+    });
+
+    test("passed dependency without diffSummary shows fallback message", () => {
+      const story: UserStory = {
+        id: "US-002",
+        title: "Add VcsPrStatus type",
+        description: "Define VcsPrStatus interface",
+        acceptanceCriteria: ["AC1"],
+        dependencies: [],
+        tags: [],
+        status: "passed",
+        passes: true,
+        escalations: [],
+        attempts: 0,
+      };
+
+      const element = createDependencyContext(story, 50);
+
+      expect(element.content).toContain("no diff summary available");
+    });
+
+    test("decomposed dependency uses compact format", () => {
+      const story: UserStory = {
+        id: "US-001",
+        title: "Parent Story",
+        description: "Parent story description",
+        acceptanceCriteria: ["AC1", "AC2"],
+        dependencies: [],
+        tags: [],
+        status: "decomposed",
+        passes: false,
+        escalations: [],
+        attempts: 0,
+      };
+
+      const element = createDependencyContext(story, 50);
+
+      expect(element.content).toContain("US-001 (decomposed): Parent Story");
+      expect(element.content).not.toContain("**Acceptance Criteria:**");
+    });
+
+    test("pending dependency uses full format with AC list", () => {
+      const story: UserStory = {
+        id: "US-003",
+        title: "Pending Dependency",
+        description: "Not done yet",
+        acceptanceCriteria: ["AC1", "AC2"],
+        dependencies: [],
+        tags: [],
+        status: "pending",
+        passes: false,
+        escalations: [],
+        attempts: 0,
+      };
+
+      const element = createDependencyContext(story, 50);
+
+      expect(element.content).toContain("**Acceptance Criteria:**");
+      expect(element.content).toContain("AC1");
+      expect(element.content).toContain("AC2");
     });
   });
 

--- a/test/unit/pipeline/stages/acceptance-setup.test.ts
+++ b/test/unit/pipeline/stages/acceptance-setup.test.ts
@@ -246,6 +246,79 @@ describe("acceptance-setup: calls refinement and generation", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Decomposed story exclusion (P5 fix)
+// ---------------------------------------------------------------------------
+
+describe("acceptance-setup: decomposed story exclusion", () => {
+  function makeDecomposedCtx() {
+    const parentStory = {
+      ...makeStory("US-PARENT", ["parent AC-1", "child AC-1", "child AC-2"]),
+      status: "decomposed" as const,
+    } as unknown as ReturnType<typeof makeStory>;
+    const childA = makeStory("US-CHILD-A", ["child AC-1"]);
+    const childB = makeStory("US-CHILD-B", ["child AC-2"]);
+    return makeCtx({ prd: makePrd([parentStory, childA, childB]), stories: [parentStory, childA, childB] });
+  }
+
+  beforeEach(() => {
+    _acceptanceSetupDeps.fileExists = async () => false;
+    _acceptanceSetupDeps.readMeta = async () => null;
+    _acceptanceSetupDeps.writeFile = async () => {};
+    _acceptanceSetupDeps.runTest = async () => ({ exitCode: 1, output: "1 fail" });
+  });
+
+  test("decomposed story is not passed to refine", async () => {
+    const refinedStoryIds: string[] = [];
+    _acceptanceSetupDeps.refine = async (criteria, context) => {
+      refinedStoryIds.push(context.storyId);
+      return criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: context.storyId }));
+    };
+    _acceptanceSetupDeps.generate = async () => ({ testCode: 'test("x", () => {})', criteria: [] });
+
+    await acceptanceSetupStage.execute(makeDecomposedCtx());
+
+    expect(refinedStoryIds).not.toContain("US-PARENT");
+    expect(refinedStoryIds).toContain("US-CHILD-A");
+    expect(refinedStoryIds).toContain("US-CHILD-B");
+  });
+
+  test("decomposed story ACs are excluded from the fingerprint", async () => {
+    const capturedCriteria: string[] = [];
+    _acceptanceSetupDeps.refine = async (criteria, context) =>
+      criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: context.storyId }));
+    _acceptanceSetupDeps.generate = async () => ({ testCode: 'test("x", () => {})', criteria: [] });
+    _acceptanceSetupDeps.writeMeta = async (_path, meta) => {
+      capturedCriteria.push(...Array(meta.acCount).fill("x"));
+    };
+
+    await acceptanceSetupStage.execute(makeDecomposedCtx());
+
+    // Only child ACs (2 total) should be counted — not the 3 parent ACs
+    const ctx = makeDecomposedCtx();
+    const childOnlyCount = ctx.prd.userStories
+      .filter((s) => s.status !== "decomposed" && !s.id.startsWith("US-FIX-"))
+      .flatMap((s) => s.acceptanceCriteria).length;
+    expect(childOnlyCount).toBe(2);
+  });
+
+  test("decomposed story is not passed to generate", async () => {
+    let generatedStories: { id: string }[] = [];
+    _acceptanceSetupDeps.refine = async (criteria, context) =>
+      criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: context.storyId }));
+    _acceptanceSetupDeps.generate = async (stories) => {
+      generatedStories = stories as { id: string }[];
+      return { testCode: 'test("x", () => {})', criteria: [] };
+    };
+
+    await acceptanceSetupStage.execute(makeDecomposedCtx());
+
+    expect(generatedStories.map((s) => s.id)).not.toContain("US-PARENT");
+    expect(generatedStories.map((s) => s.id)).toContain("US-CHILD-A");
+    expect(generatedStories.map((s) => s.id)).toContain("US-CHILD-B");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Refinement bounded concurrency (#226)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Reduces prompt token waste identified in a structured audit of the `vcs-phase3-pr-status-sync` run. Five distinct sources of bloat fixed across the prompt assembly pipeline.

## Why

Prompt audit of v0.58.5 identified ~3,000–5,000 wasted tokens per run from redundant context, duplicate AC rendering, and verbose templates.

Closes #305

## How

**P1 — Eliminate duplicate story context** (`src/execution/story-context.ts`)
`buildStoryContextFull` was passing the full `BuiltContext` (including `type === "story"` elements) to `formatContextAsMarkdown`, while `PromptBuilder` section (3) already injects the story via `buildStorySection()`. Fix: filter out `type === "story"` elements before calling `formatContextAsMarkdown`.

**P2 — Compact dependency format for completed stories** (`src/context/elements.ts`)
`createDependencyContext` always rendered full description + all ACs for every dependency. Since execution is dependency-ordered, all dependencies are already `passed`/`decomposed`/`skipped` at prompt-build time. Fix: use compact format (`## ID (status): title` + `diffSummary` if available) for completed deps; full format only for incomplete deps.

**P5 — Skip decomposed stories in acceptance refinement/generation** (`src/pipeline/stages/acceptance-setup.ts`)
`nonFixStories` filter only excluded `US-FIX-*` stories, so decomposed parent stories were included in both AC fingerprint computation and LLM refine/generate calls. Their ACs are the exact union of their children's — entirely redundant. Fix: extend filter to also exclude `status === "decomposed"`. Also fixes P9 (acceptance-gen duplicate ACs) as a side effect.

**P7 — Suppress empty CODEBASE CONTEXT label** (`src/acceptance/refinement.ts`)
`buildRefinementPrompt` always rendered a `CODEBASE CONTEXT:` heading even when `codebaseContext` is `""`. Fix: omit the section entirely when empty.

**P10 — Compress verdict JSON schema** (`src/prompts/sections/verdict.ts`)
Replaced the 28-line multi-line JSON example with a single compact one-liner. Saves ~25 lines (~200 tokens) per verifier prompt.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Findings P3, P4, P6, P8, P11 were reviewed and marked as by-design or already fixed in main. Full audit findings in `logs/vcs-phase3-pr-status-sync/AUDIT-FINDINGS.md` (gitignored).