### PR TITLE
feat(debate): wire ReviewerSession as resolver for all debate resolver types (Phase 2)

### DIFF
--- a/docs/guides/debate.md
+++ b/docs/guides/debate.md
@@ -1,0 +1,121 @@
+---
+title: Multi-Agent Debate
+description: Resolver strategies, session modes, and behavior matrices for the debate system
+---
+
+## Multi-Agent Debate
+
+The debate system runs N independent agents in parallel on the same prompt, then resolves their proposals into a single verdict. It is available on the **review** and **plan** stages.
+
+Enable via config:
+
+```json
+{
+  "debate": {
+    "enabled": true,
+    "stages": {
+      "review": {
+        "enabled": true,
+        "debaters": [
+          { "agent": "claude", "model": "balanced" },
+          { "agent": "claude", "model": "fast" }
+        ],
+        "resolver": { "type": "majority-fail-closed" }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Resolver Types
+
+Four resolver types are available. The resolver runs after all debater proposals are collected.
+
+| Config value | Strategy | LLM call | Notes |
+|:---|:---|:---:|:---|
+| `majority-fail-closed` | Vote count — unparseable proposals count as **fail** | No (stateless) / Yes (with dialogue) | Safe default — errs toward failing |
+| `majority-fail-open` | Vote count — unparseable proposals count as **pass** | No (stateless) / Yes (with dialogue) | Use when debaters are noisy |
+| `synthesis` | `adapter.complete()` synthesises all proposals into one verdict | Yes | Good for nuanced decisions |
+| `custom` | `adapter.complete()` with a judge prompt; uses `resolver.agent` | Yes | Full control over resolver behaviour |
+
+When `review.dialogue.enabled` is also `true`, all four resolver types are upgraded: they route through `reviewerSession.resolveDebate()` instead of the stateless path, gaining tool access (READ, GREP) and session continuity. See [Behavior Matrix — Review Stage](./semantic-review.md#behavior-matrix--review-stage).
+
+---
+
+## Session Modes
+
+| Mode | Debater calls | Rebuttal loop | Use when |
+|:---|:---|:---:|:---|
+| `one-shot` | `agent.complete()` (stateless) | No | Fast, cheap, no inter-debater context |
+| `stateful` | `agent.run()` (persistent session) | Yes (hybrid mode) | Richer proposals, supports rebuttal |
+| `hybrid` | `agent.plan()` for proposals + `agent.run()` for rebuttals | Yes | Plan-stage debates |
+
+Configure via `debate.sessionMode` (default: `"one-shot"`).
+
+---
+
+## Behavior Matrix — Plan Stage
+
+The plan stage uses `adapter.plan()` for proposals (not `adapter.run()` or `adapter.complete()`). `review.dialogue` does **not** apply to plan — `ReviewerSession` is not created for plan-stage debates.
+
+| debate | sessionMode | mode | Proposer | Rebuttal | Resolver |
+|:---:|:---:|:---:|:---|:---|:---|
+| off | — | — | Single `adapter.plan()` | None | N/A |
+| on | one-shot | panel | N `adapter.plan()` (parallel) | None | Stateless resolver |
+| on | stateful | panel | N `adapter.plan()` (parallel) | None | Stateless resolver |
+| on | stateful | hybrid | N `adapter.plan()` (parallel) | Sequential via `adapter.run()` (`runRebuttalLoop`) | Stateless resolver |
+| on | one-shot | hybrid | N `adapter.plan()` (parallel) | **Skipped** — warns "hybrid requires stateful" | Stateless resolver |
+
+The resolver on the plan stage is always stateless regardless of dialogue settings. This matrix is unchanged by the debate+dialogue feature (Phase 2).
+
+---
+
+## Debate + Dialogue (Review Stage Only)
+
+When both `debate.stages.review.enabled` and `review.dialogue.enabled` are `true`, the resolver gains persistent session continuity and tool access via `ReviewerSession`. Individual debaters remain isolated and stateless.
+
+```json
+{
+  "debate": {
+    "enabled": true,
+    "stages": {
+      "review": {
+        "enabled": true,
+        "debaters": [
+          { "agent": "claude", "model": "balanced" },
+          { "agent": "claude", "model": "fast" }
+        ],
+        "resolver": { "type": "majority-fail-closed" }
+      }
+    }
+  },
+  "review": {
+    "dialogue": {
+      "enabled": true,
+      "maxDialogueMessages": 20
+    }
+  }
+}
+```
+
+What this enables:
+
+- **Tool access for the resolver** — resolver can READ files and GREP for usage before giving its verdict, instead of ruling on unverified debater claims.
+- **Session continuity across re-reviews** — when autofix triggers a re-review, the same `ReviewerSession` is reused. The resolver sees what it found last round and focuses on whether the implementer's fix addressed those findings.
+- **Clarification channel** — the autofix implementer can send `CLARIFY:` questions to the reviewer session during rectification.
+
+See [Behavior Matrix — Review Stage](./semantic-review.md#behavior-matrix--review-stage) for the full flag combination table.
+
+---
+
+## Failure Handling
+
+| Failure | Recovery |
+|:---|:---|
+| Debater proposal fails / throws | Excluded from proposals; debate continues with remaining debaters |
+| All debaters fail | `DebateResult.outcome = "failed"` — story escalates |
+| `resolveDebate()` throws (dialogue path) | Falls back to stateless resolver (`majorityResolver` / `synthesisResolver` / `judgeResolver`) |
+| `reReviewDebate()` throws | Falls back to full re-debate (debaters re-run, stateless resolver) |
+| `ReviewerSession` already destroyed | `REVIEWER_SESSION_DESTROYED` — caught by fallback logic |

--- a/docs/guides/semantic-review.md
+++ b/docs/guides/semantic-review.md
@@ -206,3 +206,30 @@ Semantic review failed:
 Semantic review requires a git history — it compares `${storyGitRef}..HEAD`. If no git ref exists for the story (e.g., first run on a new branch), the check is skipped.
 
 The LLM model must be configured in `models` for the chosen `modelTier`.
+
+---
+
+## Behavior Matrix — Review Stage
+
+The review stage behavior depends on three flags: `debate.enabled` + `debate.stages.review.enabled` (shown as **debate**), `review.dialogue.enabled` (shown as **dialogue**), and the debate `sessionMode`.
+
+| debate | dialogue | sessionMode | Reviewer | Resolver | Tools | Clarify | Re-review ctx |
+|:---:|:---:|:---:|:---|:---|:---:|:---:|:---:|
+| off | off | — | `agent.run()` resumes implementer session | N/A (single reviewer) | No | No | No |
+| off | on | — | `ReviewerSession.review()` | N/A (single reviewer) | Yes | Yes | Yes |
+| on | off | one-shot | N debaters via `agent.complete()` | Stateless (`majorityResolver` / `synthesisResolver` / `judgeResolver`) | No | No | No |
+| on | off | stateful | N debaters via `agent.run()` + rebuttal loop | Stateless (resolver resumes implementer session) | No | No | No |
+| on | **on** | one-shot | N debaters via `agent.complete()` | **`reviewerSession.resolveDebate()`** — all resolver types | **Yes** | **Yes** | **Yes** |
+| on | **on** | stateful | N debaters via `agent.run()` + rebuttal loop | **`reviewerSession.resolveDebate()`** — all resolver types | **Yes** | **Yes** | **Yes** |
+
+**Key:** Tools = READ/GREP tool access for the resolver. Clarify = `CLARIFY:` relay from autofix implementer. Re-review ctx = session continuity across autofix re-review rounds.
+
+When both `debate` and `dialogue` are enabled, a `ReviewerSession` is created and stored on `ctx.reviewerSession`. Individual debaters remain stateless — only the resolver gains session continuity and tool access. All three resolver types (`majority`, `synthesis`, `custom`) go through `reviewerSession.resolveDebate()`:
+
+- **majority** — raw vote tally is computed first, then passed as context to `resolveDebate()` so the reviewer can verify disputed findings with tools before giving the authoritative verdict.
+- **synthesis** — reviewer synthesises N proposals into a single coherent, tool-verified verdict.
+- **custom** — reviewer acts as an independent judge, evaluating proposals and verifying claims with tools.
+
+If `resolveDebate()` throws, the review stage falls back to the stateless resolver path (current behavior pre-dialogue). `ctx.reviewerSession` remains set so the `CLARIFY:` channel is still available.
+
+See also: [Debate Resolver Reference](./debate.md#resolver-types).

--- a/src/debate/index.ts
+++ b/src/debate/index.ts
@@ -4,7 +4,7 @@
 
 export { DebateSession } from "./session";
 export { _debateSessionDeps, resolveDebaterModel } from "./session-helpers";
-export type { DebateSessionOptions } from "./session-helpers";
+export type { DebateSessionOptions, ResolverContextInput, ResolveOutcome } from "./session-helpers";
 export { majorityResolver, synthesisResolver, judgeResolver } from "./resolvers";
 export { buildCritiquePrompt, buildSynthesisPrompt, buildJudgePrompt } from "./prompts";
 export { buildRebuttalContext } from "./session-helpers";

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -43,9 +43,30 @@ export interface ResolveOutcome {
   resolverCostUsd: number;
   /** Synthesised output from synthesis/custom resolver — undefined for majority resolver */
   output?: string;
+  /** Structured dialogue result from ReviewerSession resolver (debate+dialogue mode only) */
+  dialogueResult?: import("../review/dialogue").ReviewDialogueResult;
 }
 
-// ─── Exported public API ──────────────────────────────────────────────────────
+/**
+ * Context required by resolveOutcome() when a ReviewerSession is used.
+ * Only populated from the review-debate-dialogue path in semantic.ts.
+ * All other callers (plan, stateful, hybrid, one-shot) pass undefined.
+ */
+export interface ResolverContext {
+  diff: string;
+  story: { id: string; title: string; acceptanceCriteria: string[] };
+  semanticConfig: import("../review/types").SemanticReviewConfig;
+  labeledProposals: Array<{ debater: string; output: string }>;
+  resolverType: import("./types").ResolverType;
+  /** True when this is a re-review after autofix (calls reReviewDebate instead of resolveDebate) */
+  isReReview?: boolean;
+}
+
+/**
+ * Input type for DebateSessionOptions — same as ResolverContext but without
+ * labeledProposals, which are added by sub-modules once proposals are collected.
+ */
+export type ResolverContextInput = Omit<ResolverContext, "labeledProposals">;
 
 export interface DebateSessionOptions {
   storyId: string;
@@ -55,6 +76,10 @@ export interface DebateSessionOptions {
   workdir?: string;
   featureName?: string;
   timeoutSeconds?: number;
+  /** Optional ReviewerSession for debate+dialogue mode (US-001/US-002) */
+  reviewerSession?: import("../review/dialogue").ReviewerSession;
+  /** Outer resolver context (without labeledProposals) — sub-modules complete it */
+  resolverContextInput?: ResolverContextInput;
 }
 
 /** Injectable deps for testability */
@@ -191,9 +216,7 @@ export function resolveModelDefForDebater(debater: Debater, tier: ModelTier, con
   }
 }
 
-/**
- * Standalone implementation of the resolver logic (extracted from DebateSession.resolve()).
- */
+/** Standalone resolver logic — extracted from DebateSession.resolve(). */
 export async function resolveOutcome(
   proposalOutputs: string[],
   critiqueOutputs: string[],
@@ -203,12 +226,89 @@ export async function resolveOutcome(
   timeoutMs: number,
   workdir?: string,
   featureName?: string,
+  reviewerSession?: import("../review/dialogue").ReviewerSession,
+  resolverContext?: ResolverContext,
 ): Promise<ResolveOutcome> {
   const resolverConfig = stageConfig.resolver;
   const logger = _debateSessionDeps.getSafeLogger();
 
+  // ── Debate + dialogue path ───────────────────────────────────────────────
+  // When a ReviewerSession and resolver context are both provided, delegate
+  // to the session for a tool-verified verdict. Falls back to stateless on error.
+  if (reviewerSession && resolverContext) {
+    try {
+      const debateCtx: import("../review/dialogue-prompts").DebateResolverContext = {
+        resolverType: resolverConfig.type,
+      };
+
+      // For majority resolvers: compute raw vote + tally first, pass as context.
+      if (resolverConfig.type === "majority-fail-closed" || resolverConfig.type === "majority-fail-open") {
+        const failOpen = resolverConfig.type === "majority-fail-open";
+        const rawOutcome = majorityResolver(proposalOutputs, failOpen);
+        let passCount = 0;
+        let failCount = 0;
+        for (const proposal of proposalOutputs) {
+          try {
+            const stripped = proposal
+              .trim()
+              .replace(/^```(?:json)?\s*\n?/, "")
+              .replace(/\n?```\s*$/, "");
+            const parsed = JSON.parse(stripped) as Record<string, unknown>;
+            if (typeof parsed.passed === "boolean" && parsed.passed) passCount++;
+            else if (failOpen) passCount++;
+            else failCount++;
+          } catch {
+            if (failOpen) passCount++;
+            else failCount++;
+          }
+        }
+        debateCtx.majorityVote = { passed: rawOutcome === "passed", passCount, failCount };
+      }
+
+      const story = {
+        id: resolverContext.story.id,
+        title: resolverContext.story.title,
+        description: "",
+        acceptanceCriteria: resolverContext.story.acceptanceCriteria,
+      };
+
+      let dialogueResult: import("../review/dialogue").ReviewDialogueResult;
+      if (resolverContext.isReReview) {
+        dialogueResult = await reviewerSession.reReviewDebate(
+          resolverContext.labeledProposals,
+          critiqueOutputs,
+          resolverContext.diff,
+          debateCtx,
+        );
+      } else {
+        dialogueResult = await reviewerSession.resolveDebate(
+          resolverContext.labeledProposals,
+          critiqueOutputs,
+          resolverContext.diff,
+          story,
+          resolverContext.semanticConfig,
+          debateCtx,
+        );
+      }
+
+      const outcome = dialogueResult.checkResult.success ? "passed" : "failed";
+      return {
+        outcome,
+        resolverCostUsd: dialogueResult.cost ?? 0,
+        dialogueResult,
+      };
+    } catch (err) {
+      logger?.warn("debate", "ReviewerSession.resolveDebate() failed — falling back to stateless resolver", {
+        storyId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Fall through to stateless resolver
+    }
+  }
+
+  // Stateless paths (no ReviewerSession, or fallback after error)
   if (resolverConfig.type === "majority-fail-closed" || resolverConfig.type === "majority-fail-open") {
-    if (workdir !== undefined) {
+    if (workdir !== undefined && !reviewerSession) {
       logger?.warn(
         "debate",
         "majority resolver does not support implementer session resumption — switch to synthesis or custom resolver for context-aware semantic review",

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -47,11 +47,7 @@ export interface ResolveOutcome {
   dialogueResult?: import("../review/dialogue").ReviewDialogueResult;
 }
 
-/**
- * Context required by resolveOutcome() when a ReviewerSession is used.
- * Only populated from the review-debate-dialogue path in semantic.ts.
- * All other callers (plan, stateful, hybrid, one-shot) pass undefined.
- */
+/** Context required by resolveOutcome() when a ReviewerSession is used. Only populated from semantic.ts debate path. */
 export interface ResolverContext {
   diff: string;
   story: { id: string; title: string; acceptanceCriteria: string[] };
@@ -62,10 +58,7 @@ export interface ResolverContext {
   isReReview?: boolean;
 }
 
-/**
- * Input type for DebateSessionOptions — same as ResolverContext but without
- * labeledProposals, which are added by sub-modules once proposals are collected.
- */
+/** Input type for DebateSessionOptions — ResolverContext without labeledProposals (added by sub-modules after proposals collected). */
 export type ResolverContextInput = Omit<ResolverContext, "labeledProposals">;
 
 export interface DebateSessionOptions {
@@ -96,12 +89,7 @@ export const _debateSessionDeps = {
   readFile: (path: string): Promise<string> => Bun.file(path).text(),
 };
 
-/**
- * Resolve the model string for a debater.
- * When debater.model is set, treat it as a tier name and resolve via config.models.
- * When absent, default to "fast" tier.
- * Falls back to the raw debater.model string if config resolution fails (backward compat).
- */
+/** Resolve the model string for a debater. Defaults to "fast" tier; falls back to raw model string on config error. */
 export function resolveDebaterModel(debater: Debater, config: NaxConfig): string | undefined {
   const tier = debater.model ?? "fast";
   if (!config?.models) return debater.model;
@@ -307,6 +295,15 @@ export async function resolveOutcome(
   }
 
   // Stateless paths (no ReviewerSession, or fallback after error)
+  // US-004 AC: warn when session supplied without resolverContext (cannot call resolveDebate without diff/story)
+  if (reviewerSession && !resolverContext) {
+    logger?.warn(
+      "debate",
+      "ReviewerSession provided but resolverContext is undefined — falling back to stateless resolver",
+      { storyId },
+    );
+  }
+
   if (resolverConfig.type === "majority-fail-closed" || resolverConfig.type === "majority-fail-open") {
     if (workdir !== undefined && !reviewerSession) {
       logger?.warn(

--- a/src/debate/session-hybrid.ts
+++ b/src/debate/session-hybrid.ts
@@ -12,6 +12,7 @@ import { buildRebuttalContext } from "./prompts";
 import {
   type ResolveOutcome,
   type ResolvedDebater,
+  type ResolverContextInput,
   type SuccessfulProposal,
   _debateSessionDeps,
   buildFailedResult,
@@ -34,6 +35,8 @@ export interface HybridCtx {
   readonly workdir: string;
   readonly featureName: string;
   readonly timeoutSeconds: number;
+  readonly reviewerSession?: import("../review/dialogue").ReviewerSession;
+  readonly resolverContextInput?: ResolverContextInput;
 }
 
 /**
@@ -231,6 +234,12 @@ export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateR
 
   const critiqueOutputs = rebuttals.map((r) => r.output);
 
+  const fullResolverContext = ctx.resolverContextInput
+    ? {
+        ...ctx.resolverContextInput,
+        labeledProposals: successfulProposals.map((s) => ({ debater: s.debater.agent, output: s.output })),
+      }
+    : undefined;
   const resolveResult: ResolveOutcome = await resolveOutcome(
     proposalOutputs,
     critiqueOutputs,
@@ -240,6 +249,8 @@ export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateR
     ctx.timeoutSeconds * 1000,
     ctx.workdir,
     ctx.featureName,
+    ctx.reviewerSession,
+    fullResolverContext,
   );
   totalCostUsd += resolveResult.resolverCostUsd;
 

--- a/src/debate/session-one-shot.ts
+++ b/src/debate/session-one-shot.ts
@@ -10,6 +10,7 @@ import { buildCritiquePrompt } from "./prompts";
 import {
   type ResolveOutcome,
   type ResolvedDebater,
+  type ResolverContextInput,
   type SuccessfulProposal,
   _debateSessionDeps,
   buildFailedResult,
@@ -28,6 +29,8 @@ interface OneShotCtx {
   readonly timeoutMs: number;
   readonly workdir?: string;
   readonly featureName?: string;
+  readonly reviewerSession?: import("../review/dialogue").ReviewerSession;
+  readonly resolverContextInput?: ResolverContextInput;
 }
 
 export async function runOneShot(ctx: OneShotCtx, prompt: string): Promise<DebateResult> {
@@ -206,6 +209,12 @@ export async function runOneShot(ctx: OneShotCtx, prompt: string): Promise<Debat
 
   // Step 5: Resolve outcome
   const proposalOutputs = successful.map((p) => p.output);
+  const fullResolverContext = ctx.resolverContextInput
+    ? {
+        ...ctx.resolverContextInput,
+        labeledProposals: successful.map((p) => ({ debater: p.debater.agent, output: p.output })),
+      }
+    : undefined;
   const outcome: ResolveOutcome = await resolveOutcome(
     proposalOutputs,
     critiqueOutputs,
@@ -215,6 +224,8 @@ export async function runOneShot(ctx: OneShotCtx, prompt: string): Promise<Debat
     ctx.timeoutMs,
     ctx.workdir,
     ctx.featureName,
+    ctx.reviewerSession,
+    fullResolverContext,
   );
   totalCostUsd += outcome.resolverCostUsd;
 

--- a/src/debate/session-stateful.ts
+++ b/src/debate/session-stateful.ts
@@ -14,6 +14,7 @@ import { buildCritiquePrompt } from "./prompts";
 import {
   type ResolveOutcome,
   type ResolvedDebater,
+  type ResolverContextInput,
   type SuccessfulProposal,
   _debateSessionDeps,
   buildFailedResult,
@@ -32,6 +33,8 @@ interface StatefulCtx {
   readonly workdir: string;
   readonly featureName: string;
   readonly timeoutSeconds: number;
+  readonly reviewerSession?: import("../review/dialogue").ReviewerSession;
+  readonly resolverContextInput?: ResolverContextInput;
 }
 
 export async function runStatefulTurn(
@@ -266,6 +269,12 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
 
   // Resolve outcome
   const proposalOutputs = successfulProposals.map((s) => s.output);
+  const fullResolverContext = ctx.resolverContextInput
+    ? {
+        ...ctx.resolverContextInput,
+        labeledProposals: successfulProposals.map((s) => ({ debater: s.debater.agent, output: s.output })),
+      }
+    : undefined;
   const outcome: ResolveOutcome = await resolveOutcome(
     proposalOutputs,
     critiqueOutputs,
@@ -275,6 +284,8 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
     ctx.timeoutSeconds * 1000,
     ctx.workdir,
     ctx.featureName,
+    ctx.reviewerSession,
+    fullResolverContext,
   );
   totalCostUsd += outcome.resolverCostUsd;
 

--- a/src/debate/session.ts
+++ b/src/debate/session.ts
@@ -27,6 +27,8 @@ export class DebateSession {
   private readonly workdir: string;
   private readonly featureName: string;
   private readonly timeoutSeconds: number;
+  private readonly reviewerSession: import("./session-helpers").DebateSessionOptions["reviewerSession"];
+  private readonly resolverContextInput: import("./session-helpers").DebateSessionOptions["resolverContextInput"];
   private get timeoutMs(): number {
     return this.timeoutSeconds * 1000;
   }
@@ -39,6 +41,8 @@ export class DebateSession {
     this.workdir = opts.workdir ?? process.cwd();
     this.featureName = opts.featureName ?? opts.stage;
     this.timeoutSeconds = opts.timeoutSeconds ?? opts.stageConfig.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
+    this.reviewerSession = opts.reviewerSession;
+    this.resolverContextInput = opts.resolverContextInput;
   }
 
   async run(prompt: string): Promise<DebateResult> {
@@ -57,6 +61,8 @@ export class DebateSession {
             workdir: this.workdir,
             featureName: this.featureName,
             timeoutSeconds: this.timeoutSeconds,
+            reviewerSession: this.reviewerSession,
+            resolverContextInput: this.resolverContextInput,
           },
           prompt,
         );
@@ -78,6 +84,8 @@ export class DebateSession {
           timeoutMs: this.timeoutMs,
           workdir: this.workdir,
           featureName: this.featureName,
+          reviewerSession: this.reviewerSession,
+          resolverContextInput: this.resolverContextInput,
         },
         prompt,
       );
@@ -94,6 +102,8 @@ export class DebateSession {
           workdir: this.workdir,
           featureName: this.featureName,
           timeoutSeconds: this.timeoutSeconds,
+          reviewerSession: this.reviewerSession,
+          resolverContextInput: this.resolverContextInput,
         },
         prompt,
       );
@@ -108,6 +118,8 @@ export class DebateSession {
         timeoutMs: this.timeoutMs,
         workdir: this.workdir,
         featureName: this.featureName,
+        reviewerSession: this.reviewerSession,
+        resolverContextInput: this.resolverContextInput,
       },
       prompt,
     );

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -25,11 +25,8 @@ export const reviewStage: PipelineStage = {
   async execute(ctx: PipelineContext): Promise<StageResult> {
     const logger = getLogger();
 
-    // Dialogue is incompatible with debate mode on the review stage — when debate runs,
-    // it is the sole authority on pass/fail; the ReviewerSession path is not applied.
-    // See SPEC-reviewer-implementer-dialogue.md §Backward Compatibility.
     const reviewDebateEnabled = ctx.rootConfig?.debate?.enabled && ctx.rootConfig?.debate?.stages?.review?.enabled;
-    const dialogueEnabled = !reviewDebateEnabled && (ctx.config.review?.dialogue?.enabled ?? false);
+    const dialogueEnabled = ctx.config.review?.dialogue?.enabled ?? false;
 
     logger.info("review", "Running review phase", { storyId: ctx.story.id });
 
@@ -39,8 +36,8 @@ export const reviewStage: PipelineStage = {
     const agentResolver = ctx.agentGetFn ?? getAgent;
     const agentName = ctx.rootConfig.autoMode?.defaultAgent;
 
-    // AC3: When dialogue is enabled and a session already exists (retry loop), use reReview()
-    if (dialogueEnabled && ctx.reviewerSession) {
+    // AC3: When dialogue is enabled (non-debate) and a session already exists (retry loop), use reReview()
+    if (dialogueEnabled && !reviewDebateEnabled && ctx.reviewerSession) {
       try {
         const diff = ctx.storyGitRef ?? "";
         const reReviewResult = await ctx.reviewerSession.reReview(diff);
@@ -91,53 +88,56 @@ export const reviewStage: PipelineStage = {
         ctx.config,
       );
 
-      // AC9: Try using the session for the semantic review; fall back to orchestrator on error
-      const semanticConfig = ctx.config.review?.semantic;
-      if (semanticConfig && agent) {
-        try {
-          const diff = ctx.storyGitRef ?? "";
-          const story = {
-            id: ctx.story.id,
-            title: ctx.story.title,
-            description: ctx.story.description,
-            acceptanceCriteria: ctx.story.acceptanceCriteria,
-          };
-          const sessionResult = await ctx.reviewerSession.review(diff, story, semanticConfig);
-          const passed = sessionResult.checkResult.success;
-          ctx.reviewResult = {
-            success: passed,
-            checks: passed
-              ? []
-              : [
-                  {
-                    check: "semantic",
-                    success: false,
-                    command: "reviewer-session-review",
-                    exitCode: 1,
-                    output: sessionResult.checkResult.findings.map((f) => f.message).join("\n"),
-                    durationMs: 0,
-                    findings: sessionResult.checkResult.findings,
-                  },
-                ],
-            totalDurationMs: 0,
-          };
-          const dialogueCost = sessionResult.cost ?? 0;
-          if (passed) {
-            logger.info("review", "Review passed (dialogue session)", { storyId: ctx.story.id });
-          } else {
-            logger.warn("review", "Review failed (dialogue session) — handing off to autofix", {
+      // For debate+dialogue: session stored, fall through to orchestrator (which uses reReviewDebate/resolveDebate)
+      // For pure dialogue (no debate): try direct session.review(); fall back to orchestrator on error (AC9)
+      if (!reviewDebateEnabled) {
+        const semanticConfig = ctx.config.review?.semantic;
+        if (semanticConfig && agent) {
+          try {
+            const diff = ctx.storyGitRef ?? "";
+            const story = {
+              id: ctx.story.id,
+              title: ctx.story.title,
+              description: ctx.story.description,
+              acceptanceCriteria: ctx.story.acceptanceCriteria,
+            };
+            const sessionResult = await ctx.reviewerSession.review(diff, story, semanticConfig);
+            const passed = sessionResult.checkResult.success;
+            ctx.reviewResult = {
+              success: passed,
+              checks: passed
+                ? []
+                : [
+                    {
+                      check: "semantic",
+                      success: false,
+                      command: "reviewer-session-review",
+                      exitCode: 1,
+                      output: sessionResult.checkResult.findings.map((f) => f.message).join("\n"),
+                      durationMs: 0,
+                      findings: sessionResult.checkResult.findings,
+                    },
+                  ],
+              totalDurationMs: 0,
+            };
+            const dialogueCost = sessionResult.cost ?? 0;
+            if (passed) {
+              logger.info("review", "Review passed (dialogue session)", { storyId: ctx.story.id });
+            } else {
+              logger.warn("review", "Review failed (dialogue session) — handing off to autofix", {
+                storyId: ctx.story.id,
+              });
+            }
+            return { action: "continue", cost: dialogueCost || undefined };
+          } catch (err) {
+            logger.warn("review", "ReviewerSession.review() failed — falling back to one-shot review", {
               storyId: ctx.story.id,
             });
+            // Fall through to orchestrator (AC9)
           }
-          return { action: "continue", cost: dialogueCost || undefined };
-        } catch (err) {
-          logger.warn("review", "ReviewerSession.review() failed — falling back to one-shot review", {
-            storyId: ctx.story.id,
-          });
-          // Fall through to orchestrator (AC9)
         }
       }
-      // No semanticConfig or agent — fall through to orchestrator with session stored
+      // No semanticConfig/agent, debate mode, or AC9 fallback — fall through to orchestrator
     }
 
     // reviewFromContext reads and clears ctx.retrySkipChecks internally (#136)

--- a/src/review/dialogue-prompts.ts
+++ b/src/review/dialogue-prompts.ts
@@ -1,0 +1,166 @@
+/**
+ * dialogue-prompts.ts
+ *
+ * Prompt builders for ReviewerSession — extracted from dialogue.ts to keep
+ * that file under the 400-line limit.
+ *
+ * Covers:
+ * - Standard review / re-review prompts (single-reviewer path)
+ * - Debate resolver prompts (debate + dialogue path, US-001)
+ */
+
+import type { ResolverType } from "../debate/types";
+import type { ReviewFinding } from "../plugins/types";
+import type { SemanticStory } from "./semantic";
+import type { SemanticReviewConfig } from "./types";
+
+/** Context passed to resolveDebate() — varies by resolver type */
+export interface DebateResolverContext {
+  resolverType: ResolverType;
+  /** For majority resolvers: the raw vote tally (computed before resolveDebate is called) */
+  majorityVote?: { passed: boolean; passCount: number; failCount: number };
+}
+
+// ─── Standard (non-debate) prompts ──────────────────────────────────────────
+
+export function buildReviewPrompt(diff: string, story: SemanticStory, _semanticConfig: SemanticReviewConfig): string {
+  const criteria = story.acceptanceCriteria.map((c) => `- ${c}`).join("\n");
+  return [
+    `Review the following code diff for story ${story.id}: ${story.title}`,
+    "",
+    "## Acceptance Criteria",
+    criteria,
+    "",
+    "## Diff",
+    diff,
+    "",
+    "Respond with JSON: { passed: boolean, findings: [...], findingReasoning: { [id]: string } }",
+  ].join("\n");
+}
+
+export function buildReReviewPrompt(updatedDiff: string, previousFindings: ReviewFinding[]): string {
+  const findingsList =
+    previousFindings.length > 0 ? previousFindings.map((f) => `- ${f.ruleId}: ${f.message}`).join("\n") : "(none)";
+  return [
+    "This is a follow-up re-review. Please review the updated diff below.",
+    "",
+    "## Previous Findings",
+    findingsList,
+    "",
+    "## Updated Diff",
+    updatedDiff,
+    "",
+    "Respond with JSON: { passed: boolean, findings: [...], findingReasoning: { [id]: string }, deltaSummary: string }",
+    "deltaSummary should describe which previous findings are resolved vs still present.",
+  ].join("\n");
+}
+
+// ─── Debate resolver prompts ─────────────────────────────────────────────────
+
+function buildProposalsSection(proposals: Array<{ debater: string; output: string }>): string {
+  return proposals.map((p) => `### ${p.debater}\n${p.output}`).join("\n\n");
+}
+
+function buildCritiquesSection(critiques: string[]): string {
+  if (critiques.length === 0) return "";
+  return `\n\n## Critiques\n${critiques.map((c, i) => `### Critique ${i + 1}\n${c}`).join("\n\n")}`;
+}
+
+function buildVoteTallyLine(ctx: DebateResolverContext): string {
+  if (!ctx.majorityVote) return "";
+  const { passCount, failCount } = ctx.majorityVote;
+  const failOpenNote =
+    ctx.resolverType === "majority-fail-open"
+      ? " (unparseable proposals count as pass)"
+      : " (unparseable proposals count as fail)";
+  return `\n\nThe preliminary majority vote is: **${passCount} passed, ${failCount} failed**${failOpenNote}. Verify the failing findings with tools before giving your authoritative verdict.`;
+}
+
+function buildResolverFraming(ctx: DebateResolverContext): string {
+  switch (ctx.resolverType) {
+    case "majority-fail-closed":
+    case "majority-fail-open":
+      return "You are the authoritative reviewer resolving a debate. A preliminary vote was taken — see tally below. Verify disputed findings using tools (READ files, GREP for usage) and give your final verdict.";
+    case "synthesis":
+      return "You are a synthesis reviewer. Synthesize the debater proposals into a single, coherent, tool-verified verdict. Use READ and GREP to verify claims before ruling.";
+    case "custom":
+      return "You are the judge. Evaluate the debater proposals independently. Verify claims with tools (READ, GREP) and give your final authoritative verdict.";
+    default:
+      return "You are the reviewer. Evaluate the debater proposals and give your final authoritative verdict.";
+  }
+}
+
+/**
+ * Build a prompt for resolveDebate() — prompt strategy varies by resolver type.
+ */
+export function buildDebateResolverPrompt(
+  proposals: Array<{ debater: string; output: string }>,
+  critiques: string[],
+  diff: string,
+  story: SemanticStory,
+  _semanticConfig: SemanticReviewConfig,
+  resolverContext: DebateResolverContext,
+): string {
+  const criteria = story.acceptanceCriteria.map((c) => `- ${c}`).join("\n");
+  const framing = buildResolverFraming(resolverContext);
+  const voteTally = buildVoteTallyLine(resolverContext);
+  const proposalsSection = buildProposalsSection(proposals);
+  const critiquesSection = buildCritiquesSection(critiques);
+
+  return [
+    framing,
+    "",
+    `## Story ${story.id}: ${story.title}`,
+    "",
+    "## Acceptance Criteria",
+    criteria,
+    "",
+    "## Debater Proposals",
+    proposalsSection,
+    critiquesSection,
+    "",
+    "## Diff",
+    diff,
+    voteTally,
+    "",
+    "Respond with JSON: { passed: boolean, findings: [...], findingReasoning: { [id]: string } }",
+  ]
+    .filter((line) => line !== undefined)
+    .join("\n");
+}
+
+/**
+ * Build a prompt for reReviewDebate() — references previous findings.
+ */
+export function buildDebateReReviewPrompt(
+  proposals: Array<{ debater: string; output: string }>,
+  critiques: string[],
+  updatedDiff: string,
+  previousFindings: ReviewFinding[],
+  resolverContext: DebateResolverContext,
+): string {
+  const framing = buildResolverFraming(resolverContext);
+  const findingsList =
+    previousFindings.length > 0 ? previousFindings.map((f) => `- ${f.ruleId}: ${f.message}`).join("\n") : "(none)";
+  const proposalsSection = buildProposalsSection(proposals);
+  const critiquesSection = buildCritiquesSection(critiques);
+
+  return [
+    `${framing} This is a re-review after implementer changes.`,
+    "",
+    "## Previous Findings",
+    findingsList,
+    "",
+    "## Updated Debater Proposals",
+    proposalsSection,
+    critiquesSection,
+    "",
+    "## Updated Diff",
+    updatedDiff,
+    "",
+    "Respond with JSON: { passed: boolean, findings: [...], findingReasoning: { [id]: string }, deltaSummary: string }",
+    "deltaSummary should describe which previous findings are resolved vs still present.",
+  ]
+    .filter((line) => line !== undefined)
+    .join("\n");
+}

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -206,7 +206,6 @@ export function createReviewerSession(
   // Tracks whether the last review call was resolveDebate() (vs review()).
   // reReviewDebate() requires a prior resolveDebate() to avoid using findings
   // from a non-debate review() call as the delta baseline.
-  // biome-ignore lint/style/useConst: mutated by resolveDebate() and review()
   let lastWasDebateResolve = false;
   /**
    * Tracks session lifecycle for compaction-triggered resets.

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -203,6 +203,11 @@ export function createReviewerSession(
   let lastCheckResult: ReviewDialogueResult | null = null;
   let lastStory: SemanticStory | null = null;
   let lastSemanticConfig: SemanticReviewConfig | null = null;
+  // Tracks whether the last review call was resolveDebate() (vs review()).
+  // reReviewDebate() requires a prior resolveDebate() to avoid using findings
+  // from a non-debate review() call as the delta baseline.
+  // biome-ignore lint/style/useConst: mutated by resolveDebate() and review()
+  let lastWasDebateResolve = false;
   /**
    * Tracks session lifecycle for compaction-triggered resets.
    * - generation: incremented each time history overflow causes a session reset.
@@ -295,6 +300,7 @@ export function createReviewerSession(
       lastCheckResult = reviewResult;
       lastStory = story;
       lastSemanticConfig = semanticConfig;
+      lastWasDebateResolve = false;
       return reviewResult;
     },
     async reReview(updatedDiff: string): Promise<ReviewDialogueResult> {
@@ -433,6 +439,7 @@ export function createReviewerSession(
       lastCheckResult = reviewResult;
       lastStory = story;
       lastSemanticConfig = semanticConfig;
+      lastWasDebateResolve = true;
       return reviewResult;
     },
     async reReviewDebate(
@@ -448,7 +455,7 @@ export function createReviewerSession(
           { stage: "review", storyId, featureName },
         );
       }
-      if (!lastCheckResult || !lastSemanticConfig) {
+      if (!lastCheckResult || !lastSemanticConfig || !lastWasDebateResolve) {
         throw new NaxError(
           `[dialogue] reReviewDebate() called before any resolveDebate() on story ${storyId}`,
           "NO_REVIEW_RESULT",

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -11,10 +11,17 @@ import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config/schema-types";
 import { NaxError } from "../errors";
 import type { ReviewFinding } from "../plugins/types";
+import {
+  buildDebateReReviewPrompt,
+  buildDebateResolverPrompt,
+  buildReReviewPrompt,
+  buildReviewPrompt,
+} from "./dialogue-prompts";
 import type { SemanticStory } from "./semantic";
 import type { SemanticReviewConfig } from "./types";
 
 export type { SemanticVerdict };
+export type { DebateResolverContext } from "./dialogue-prompts";
 
 /** A single message in the reviewer-implementer dialogue history */
 export interface DialogueMessage {
@@ -65,44 +72,38 @@ export interface ReviewerSession {
    */
   clarify(question: string): Promise<string>;
   /**
+   * Resolve a debate by reviewing N debater proposals using agent.run() with tool
+   * access (READ, GREP). Prompt strategy varies by resolverType:
+   * - majority: includes vote tally; reviewer verifies failing findings
+   * - synthesis: reviewer synthesizes proposals into a single verdict
+   * - custom: reviewer acts as independent judge
+   * Stores result as lastCheckResult so getVerdict() and reReviewDebate() work.
+   */
+  resolveDebate(
+    proposals: Array<{ debater: string; output: string }>,
+    critiques: string[],
+    diff: string,
+    story: SemanticStory,
+    semanticConfig: SemanticReviewConfig,
+    resolverContext: import("./dialogue-prompts").DebateResolverContext,
+  ): Promise<ReviewDialogueResult>;
+  /**
+   * Re-resolve a debate after implementer changes.
+   * Same session — references previous findings and debater proposals.
+   */
+  reReviewDebate(
+    proposals: Array<{ debater: string; output: string }>,
+    critiques: string[],
+    updatedDiff: string,
+    resolverContext: import("./dialogue-prompts").DebateResolverContext,
+  ): Promise<ReviewDialogueResult>;
+  /**
    * Extract a SemanticVerdict from the last review result.
    * Throws NaxError('NO_REVIEW_RESULT') if no review() has been executed yet.
    */
   getVerdict(): SemanticVerdict;
   /** Close the session and mark it inactive */
   destroy(): Promise<void>;
-}
-
-function buildReviewPrompt(diff: string, story: SemanticStory, _semanticConfig: SemanticReviewConfig): string {
-  const criteria = story.acceptanceCriteria.map((c) => `- ${c}`).join("\n");
-  return [
-    `Review the following code diff for story ${story.id}: ${story.title}`,
-    "",
-    "## Acceptance Criteria",
-    criteria,
-    "",
-    "## Diff",
-    diff,
-    "",
-    "Respond with JSON: { passed: boolean, findings: [...], findingReasoning: { [id]: string } }",
-  ].join("\n");
-}
-
-function buildReReviewPrompt(updatedDiff: string, previousFindings: ReviewFinding[]): string {
-  const findingsList =
-    previousFindings.length > 0 ? previousFindings.map((f) => `- ${f.ruleId}: ${f.message}`).join("\n") : "(none)";
-  return [
-    "This is a follow-up re-review. Please review the updated diff below.",
-    "",
-    "## Previous Findings",
-    findingsList,
-    "",
-    "## Updated Diff",
-    updatedDiff,
-    "",
-    "Respond with JSON: { passed: boolean, findings: [...], findingReasoning: { [id]: string }, deltaSummary: string }",
-    "deltaSummary should describe which previous findings are resolved vs still present.",
-  ].join("\n");
 }
 
 function extractDeltaSummary(
@@ -388,6 +389,109 @@ export function createReviewerSession(
       history.push({ role: "reviewer", content: result.output });
 
       return result.output;
+    },
+    async resolveDebate(
+      proposals: Array<{ debater: string; output: string }>,
+      critiques: string[],
+      diff: string,
+      story: SemanticStory,
+      semanticConfig: SemanticReviewConfig,
+      resolverContext: import("./dialogue-prompts").DebateResolverContext,
+    ): Promise<ReviewDialogueResult> {
+      if (!active) {
+        throw new NaxError(
+          `[dialogue] ReviewerSession for story ${storyId} has been destroyed`,
+          "REVIEWER_SESSION_DESTROYED",
+          { stage: "review", storyId, featureName },
+        );
+      }
+
+      const prompt = buildDebateResolverPrompt(proposals, critiques, diff, story, semanticConfig, resolverContext);
+      const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(semanticConfig);
+      const { effectivePrompt, acpSessionName } = buildEffectiveRunArgs(prompt);
+
+      const result = await agent.run({
+        prompt: effectivePrompt,
+        workdir,
+        modelTier,
+        modelDef,
+        timeoutSeconds,
+        sessionRole: "reviewer",
+        keepSessionOpen: true,
+        pipelineStage: "review",
+        config: _config,
+        storyId,
+        featureName,
+        acpSessionName,
+      });
+
+      history.push({ role: "implementer", content: prompt });
+      history.push({ role: "reviewer", content: result.output });
+
+      const parsed = parseReviewResponse(result.output);
+      const reviewResult: ReviewDialogueResult = { ...parsed, cost: result.estimatedCost ?? 0 };
+      lastCheckResult = reviewResult;
+      lastStory = story;
+      lastSemanticConfig = semanticConfig;
+      return reviewResult;
+    },
+    async reReviewDebate(
+      proposals: Array<{ debater: string; output: string }>,
+      critiques: string[],
+      updatedDiff: string,
+      resolverContext: import("./dialogue-prompts").DebateResolverContext,
+    ): Promise<ReviewDialogueResult> {
+      if (!active) {
+        throw new NaxError(
+          `[dialogue] ReviewerSession for story ${storyId} has been destroyed`,
+          "REVIEWER_SESSION_DESTROYED",
+          { stage: "review", storyId, featureName },
+        );
+      }
+      if (!lastCheckResult || !lastSemanticConfig) {
+        throw new NaxError(
+          `[dialogue] reReviewDebate() called before any resolveDebate() on story ${storyId}`,
+          "NO_REVIEW_RESULT",
+          { stage: "review", storyId },
+        );
+      }
+
+      const previousFindings = lastCheckResult.checkResult.findings;
+      const prompt = buildDebateReReviewPrompt(proposals, critiques, updatedDiff, previousFindings, resolverContext);
+      const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(lastSemanticConfig);
+      const { effectivePrompt, acpSessionName } = buildEffectiveRunArgs(prompt);
+
+      const result = await agent.run({
+        prompt: effectivePrompt,
+        workdir,
+        modelTier,
+        modelDef,
+        timeoutSeconds,
+        sessionRole: "reviewer",
+        keepSessionOpen: true,
+        pipelineStage: "review",
+        config: _config,
+        storyId,
+        featureName,
+        acpSessionName,
+      });
+
+      history.push({ role: "implementer", content: prompt });
+      history.push({ role: "reviewer", content: result.output });
+
+      const parsed = parseReviewResponse(result.output);
+      const deltaSummary = extractDeltaSummary(result.output, previousFindings, parsed.checkResult.findings);
+      const dialogueResult: ReviewDialogueResult = { ...parsed, deltaSummary, cost: result.estimatedCost ?? 0 };
+      lastCheckResult = dialogueResult;
+
+      const maxMessages = _config.review?.dialogue?.maxDialogueMessages ?? 20;
+      if (history.length > maxMessages) {
+        const compactedSummary = compactHistory(history);
+        sessionState.generation++;
+        sessionState.pendingCompactionContext = compactedSummary;
+      }
+
+      return dialogueResult;
     },
     getVerdict(): SemanticVerdict {
       if (!lastCheckResult || !lastStory) {

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -87,6 +87,7 @@ export class ReviewOrchestrator {
     naxConfig?: NaxConfig,
     retrySkipChecks?: Set<string>,
     featureName?: string,
+    resolverSession?: import("./dialogue").ReviewerSession,
   ): Promise<OrchestratorReviewResult> {
     const logger = getSafeLogger();
 
@@ -102,6 +103,7 @@ export class ReviewOrchestrator {
       naxConfig,
       retrySkipChecks,
       featureName,
+      resolverSession,
     );
 
     if (!builtIn.success) {
@@ -191,6 +193,11 @@ export class ReviewOrchestrator {
       ? (_tier: string) => (agentResolver ? (agentResolver(agentName) ?? null) : null)
       : undefined;
 
+    // When debate+dialogue are both enabled, pass the existing ReviewerSession as the resolver
+    // session so runSemanticReview() can thread it through to the DebateSession.
+    const reviewDebateEnabled = ctx.rootConfig?.debate?.enabled && ctx.rootConfig?.debate?.stages?.review?.enabled;
+    const resolverSession = reviewDebateEnabled ? ctx.reviewerSession : undefined;
+
     return this.review(
       ctx.config.review,
       ctx.workdir,
@@ -210,6 +217,7 @@ export class ReviewOrchestrator {
       ctx.config,
       retrySkipChecks,
       ctx.prd.feature,
+      resolverSession,
     );
   }
 }

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -203,6 +203,7 @@ export async function runReview(
   naxConfig?: NaxConfig,
   retrySkipChecks?: Set<string>,
   featureName?: string,
+  resolverSession?: import("./dialogue").ReviewerSession,
 ): Promise<ReviewResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -272,25 +273,16 @@ export async function runReview(
         excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/"],
       };
       const runSemantic = _reviewSemanticDeps.runSemanticReview;
-      const result =
-        featureName !== undefined
-          ? await runSemantic(
-              workdir,
-              storyGitRef,
-              semanticStory,
-              semanticCfg,
-              modelResolver ?? (() => null),
-              naxConfig,
-              featureName,
-            )
-          : await runSemantic(
-              workdir,
-              storyGitRef,
-              semanticStory,
-              semanticCfg,
-              modelResolver ?? (() => null),
-              naxConfig,
-            );
+      const result = await runSemantic(
+        workdir,
+        storyGitRef,
+        semanticStory,
+        semanticCfg,
+        modelResolver ?? (() => null),
+        naxConfig,
+        featureName,
+        resolverSession,
+      );
       checks.push(result);
       if (!result.success && !firstFailure) {
         firstFailure = `${checkName} failed`;

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -300,6 +300,7 @@ export async function runSemanticReview(
   modelResolver: ModelResolver,
   naxConfig?: NaxConfig,
   featureName?: string,
+  resolverSession?: import("./dialogue").ReviewerSession,
 ): Promise<ReviewCheckResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -394,6 +395,7 @@ export async function runSemanticReview(
   if (reviewDebateEnabled) {
     // Safe: reviewDebateEnabled guard confirms naxConfig.debate.stages.review is defined
     const reviewStageConfig = naxConfig?.debate?.stages.review as import("../debate").DebateStageConfig;
+    const isReReview = resolverSession !== undefined && resolverSession.history.length > 0;
     const debateSession = _semanticDeps.createDebateSession({
       storyId: story.id,
       stage: "review",
@@ -402,12 +404,68 @@ export async function runSemanticReview(
       workdir,
       featureName: featureName,
       timeoutSeconds: naxConfig?.execution?.sessionTimeoutSeconds,
+      reviewerSession: resolverSession,
+      resolverContextInput: resolverSession
+        ? {
+            diff,
+            story: { id: story.id, title: story.title, acceptanceCriteria: story.acceptanceCriteria },
+            semanticConfig,
+            resolverType: reviewStageConfig.resolver.type,
+            isReReview,
+          }
+        : undefined,
     });
+    // Track history length before to detect if the session was actually used by the resolver
+    const historyLenBefore = resolverSession?.history.length ?? 0;
     const debateResult = await debateSession.run(prompt);
     const debateCost = debateResult.totalCostUsd ?? 0;
 
-    // Use the resolver's verdict as the authoritative pass/fail.
-    // Collect findings from all proposals for deduplication and blocking-severity filter.
+    // When the ReviewerSession was used by the resolver (history grew), use its tool-verified
+    // verdict via getVerdict() instead of re-deriving from raw proposals.
+    const sessionUsed = resolverSession && resolverSession.history.length > historyLenBefore;
+    if (sessionUsed) {
+      const durationMs = Date.now() - startTime;
+      try {
+        const verdict = resolverSession.getVerdict();
+        const findings = verdict.findings ?? [];
+        if (!verdict.passed && findings.length > 0) {
+          logger?.warn("review", `Semantic review failed (debate+dialogue): ${findings.length} findings`, {
+            storyId: story.id,
+            durationMs,
+          });
+          return {
+            check: "semantic",
+            success: false,
+            command: "",
+            exitCode: 1,
+            output: `Semantic review failed:\n\n${findings.map((f) => `${f.ruleId}: ${f.message}`).join("\n")}`,
+            durationMs,
+            findings,
+            cost: debateCost,
+          };
+        }
+        const label = verdict.passed
+          ? "Semantic review passed (debate+dialogue)"
+          : "Semantic review passed (debate+dialogue, all findings non-blocking)";
+        logger?.info("review", label, { storyId: story.id, durationMs });
+        return {
+          check: "semantic",
+          success: true,
+          command: "",
+          exitCode: 0,
+          output: label,
+          durationMs,
+          cost: debateCost,
+        };
+      } catch {
+        // getVerdict() threw (e.g. session destroyed) — fall through to stateless path
+        logger?.warn("review", "getVerdict() failed after debate+dialogue — falling back to stateless verdict", {
+          storyId: story.id,
+        });
+      }
+    }
+
+    // Stateless fallback: re-derive verdict from proposals (existing behavior)
     const resolverPassed = debateResult.outcome === "passed";
     const allFindings: LLMFinding[] = [];
     for (const p of debateResult.proposals) {

--- a/test/unit/pipeline/stages/review-debate-dialogue.test.ts
+++ b/test/unit/pipeline/stages/review-debate-dialogue.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Unit tests for the debate+dialogue combined path in the review stage (US-003)
+ *
+ * Covers:
+ * - G4 guard removal: dialogueEnabled is no longer gated on !reviewDebateEnabled
+ * - Debate+dialogue first run: session created and stored; falls through to orchestrator
+ * - Debate+dialogue re-review: session NOT used for reReview(); falls through to orchestrator
+ * - Pure dialogue path (no debate): session.review() and session.reReview() still used (regression guard)
+ * - Pure debate (no dialogue): no session created, orchestrator used
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { NaxConfig } from "../../../../src/config";
+import { _reviewDeps, reviewStage } from "../../../../src/pipeline/stages/review";
+import type { PipelineContext } from "../../../../src/pipeline/types";
+import type { ReviewerSession } from "../../../../src/review/dialogue";
+import type { PRD, UserStory } from "../../../../src/prd";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Saved originals — restored in afterEach
+// ─────────────────────────────────────────────────────────────────────────────
+
+// biome-ignore lint/suspicious/noExplicitAny: resetting injectable test deps
+const savedReviewDeps = { ...(_reviewDeps as any) };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeSession(overrides: Partial<ReviewerSession> = {}): ReviewerSession {
+  return {
+    active: true,
+    history: [],
+    review: mock(async () => ({
+      checkResult: { success: true, findings: [] },
+      findingReasoning: new Map(),
+    })),
+    reReview: mock(async () => ({
+      checkResult: { success: true, findings: [] },
+      findingReasoning: new Map(),
+      deltaSummary: "All resolved.",
+    })),
+    resolveDebate: mock(async () => ({
+      checkResult: { success: true, findings: [] },
+      findingReasoning: new Map(),
+    })),
+    reReviewDebate: mock(async () => ({
+      checkResult: { success: true, findings: [] },
+      findingReasoning: new Map(),
+    })),
+    clarify: mock(async () => "clarification response"),
+    getVerdict: mock(() => ({
+      storyId: "US-001",
+      passed: true,
+      timestamp: new Date().toISOString(),
+      acCount: 0,
+      findings: [],
+    })),
+    destroy: mock(async () => {}),
+    ...overrides,
+  } as unknown as ReviewerSession;
+}
+
+function makeConfig(opts: {
+  dialogueEnabled: boolean;
+  debateEnabled?: boolean;
+  debateReviewEnabled?: boolean;
+}): NaxConfig {
+  return {
+    review: {
+      enabled: true,
+      dialogue: {
+        enabled: opts.dialogueEnabled,
+        maxDialogueMessages: 20,
+        maxClarificationsPerAttempt: 3,
+      },
+    },
+    debate: {
+      enabled: opts.debateEnabled ?? false,
+      stages: {
+        review: {
+          enabled: opts.debateReviewEnabled ?? false,
+          debaters: [],
+          resolver: { type: "majority-fail-closed" },
+        },
+      },
+    },
+    interaction: {
+      plugin: "cli",
+      defaults: { timeout: 30000, fallback: "abort" as const },
+      triggers: {},
+    },
+  } as unknown as NaxConfig;
+}
+
+function makeStory(overrides?: Partial<UserStory>): UserStory {
+  return {
+    id: "US-001",
+    title: "Test Story",
+    description: "Test",
+    acceptanceCriteria: ["AC1: thing works"],
+    tags: [],
+    dependencies: [],
+    status: "in-progress",
+    passes: false,
+    escalations: [],
+    attempts: 1,
+    ...overrides,
+  };
+}
+
+function makePRD(): PRD {
+  return {
+    project: "test",
+    feature: "my-feature",
+    branchName: "test-branch",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    userStories: [makeStory()],
+  };
+}
+
+function makeCtx(config: NaxConfig, overrides: Partial<PipelineContext> = {}): PipelineContext {
+  return {
+    config,
+    rootConfig: config,
+    prd: makePRD(),
+    story: makeStory(),
+    stories: [makeStory()],
+    routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
+    workdir: "/tmp/test",
+    hooks: {} as PipelineContext["hooks"],
+    ...overrides,
+  } as unknown as PipelineContext;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Setup / teardown
+// ─────────────────────────────────────────────────────────────────────────────
+
+// biome-ignore lint/suspicious/noExplicitAny: reviewOrchestrator is a value export, not a type namespace
+let orchestratorOriginal: ((...args: any[]) => any) | undefined;
+
+function makeOrchestratorResult(overrides: Partial<{ success: boolean; pluginFailed: boolean; failureReason: string }> = {}) {
+  return {
+    success: true,
+    pluginFailed: false,
+    builtIn: { success: true, checks: [], totalDurationMs: 5 },
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+  orchestratorOriginal = reviewOrchestrator.review;
+  // biome-ignore lint/suspicious/noExplicitAny: mock return satisfies runtime shape
+  reviewOrchestrator.review = mock(async () => makeOrchestratorResult()) as any;
+});
+
+afterEach(async () => {
+  mock.restore();
+  // biome-ignore lint/suspicious/noExplicitAny: resetting injectable test deps
+  Object.assign(_reviewDeps as any, savedReviewDeps);
+  if (orchestratorOriginal) {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    // biome-ignore lint/suspicious/noExplicitAny: restoring original
+    reviewOrchestrator.review = orchestratorOriginal as any;
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// G4 guard removal: dialogueEnabled no longer gated on !reviewDebateEnabled
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("G4 guard removal — dialogueEnabled is independent of reviewDebateEnabled", () => {
+  test("creates a ReviewerSession when both debate and dialogue are enabled", async () => {
+    const mockSession = makeSession();
+    const createSessionMock = mock(() => mockSession);
+    // biome-ignore lint/suspicious/noExplicitAny: injectable test dep
+    (_reviewDeps as any).createReviewerSession = createSessionMock;
+
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: true, debateReviewEnabled: true });
+    const ctx = makeCtx(config);
+    await reviewStage.execute(ctx);
+
+    expect(createSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("stores the session in ctx.reviewerSession when debate+dialogue both enabled", async () => {
+    const mockSession = makeSession();
+    // biome-ignore lint/suspicious/noExplicitAny: injectable test dep
+    (_reviewDeps as any).createReviewerSession = mock(() => mockSession);
+
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: true, debateReviewEnabled: true });
+    const ctx = makeCtx(config);
+    await reviewStage.execute(ctx);
+
+    expect(ctx.reviewerSession).toBe(mockSession);
+  });
+
+  test("does NOT create a session when debate is enabled but dialogue is disabled", async () => {
+    const createSessionMock = mock(() => makeSession());
+    // biome-ignore lint/suspicious/noExplicitAny: injectable test dep
+    (_reviewDeps as any).createReviewerSession = createSessionMock;
+
+    const config = makeConfig({ dialogueEnabled: false, debateEnabled: true, debateReviewEnabled: true });
+    const ctx = makeCtx(config);
+    await reviewStage.execute(ctx);
+
+    expect(createSessionMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Debate+dialogue first run: session stored, falls through to orchestrator
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("debate+dialogue first run — session stored, falls through to orchestrator", () => {
+  test("does NOT call session.review() when both debate and dialogue are enabled", async () => {
+    const mockSession = makeSession();
+    // biome-ignore lint/suspicious/noExplicitAny: injectable test dep
+    (_reviewDeps as any).createReviewerSession = mock(() => mockSession);
+
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: true, debateReviewEnabled: true });
+    const ctx = makeCtx(config);
+    await reviewStage.execute(ctx);
+
+    expect(mockSession.review).not.toHaveBeenCalled();
+  });
+
+  test("falls through to orchestrator on debate+dialogue first run", async () => {
+    const mockSession = makeSession();
+    // biome-ignore lint/suspicious/noExplicitAny: injectable test dep
+    (_reviewDeps as any).createReviewerSession = mock(() => mockSession);
+
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    // biome-ignore lint/suspicious/noExplicitAny: mock return satisfies runtime shape
+    const orchestratorMock = mock(async () => makeOrchestratorResult()) as any;
+    reviewOrchestrator.review = orchestratorMock;
+
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: true, debateReviewEnabled: true });
+    const ctx = makeCtx(config);
+    await reviewStage.execute(ctx);
+
+    expect(orchestratorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("reviewerSession is available in ctx when orchestrator is called (for debate wiring)", async () => {
+    const mockSession = makeSession();
+    // biome-ignore lint/suspicious/noExplicitAny: injectable test dep
+    (_reviewDeps as any).createReviewerSession = mock(() => mockSession);
+
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    // biome-ignore lint/suspicious/noExplicitAny: mock return satisfies runtime shape
+    reviewOrchestrator.review = mock(async () => makeOrchestratorResult()) as any;
+
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: true, debateReviewEnabled: true });
+    const ctx = makeCtx(config);
+    await reviewStage.execute(ctx);
+
+    // The session was stored on ctx before orchestrator ran
+    expect(ctx.reviewerSession).toBe(mockSession);
+  });
+
+  test("returns continue when debate+dialogue review passes", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: injectable test dep
+    (_reviewDeps as any).createReviewerSession = mock(() => makeSession());
+
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: true, debateReviewEnabled: true });
+    const ctx = makeCtx(config);
+    const result = await reviewStage.execute(ctx);
+
+    expect(result.action).toBe("continue");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Debate+dialogue re-review: does NOT call session.reReview(); uses orchestrator
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("debate+dialogue re-review — falls through to orchestrator, not session.reReview()", () => {
+  test("does NOT call session.reReview() when both debate and dialogue are enabled on retry", async () => {
+    const existingSession = makeSession();
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: true, debateReviewEnabled: true });
+    const ctx = makeCtx(config, { reviewerSession: existingSession });
+
+    await reviewStage.execute(ctx);
+
+    expect(existingSession.reReview).not.toHaveBeenCalled();
+  });
+
+  test("calls orchestrator when debate+dialogue session exists (re-review path)", async () => {
+    const existingSession = makeSession();
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    // biome-ignore lint/suspicious/noExplicitAny: mock return satisfies runtime shape
+    const orchestratorMock = mock(async () => makeOrchestratorResult()) as any;
+    reviewOrchestrator.review = orchestratorMock;
+
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: true, debateReviewEnabled: true });
+    const ctx = makeCtx(config, { reviewerSession: existingSession });
+    await reviewStage.execute(ctx);
+
+    expect(orchestratorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("preserves the existing session in ctx for orchestrator to use (re-review)", async () => {
+    const existingSession = makeSession();
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: true, debateReviewEnabled: true });
+    const ctx = makeCtx(config, { reviewerSession: existingSession });
+
+    await reviewStage.execute(ctx);
+
+    expect(ctx.reviewerSession).toBe(existingSession);
+  });
+
+  test("does NOT create a new session on re-review (debate+dialogue)", async () => {
+    const existingSession = makeSession();
+    const createSessionMock = mock(() => makeSession());
+    // biome-ignore lint/suspicious/noExplicitAny: injectable test dep
+    (_reviewDeps as any).createReviewerSession = createSessionMock;
+
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: true, debateReviewEnabled: true });
+    const ctx = makeCtx(config, { reviewerSession: existingSession });
+    await reviewStage.execute(ctx);
+
+    expect(createSessionMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Regression: pure dialogue (no debate) still uses session.review() / reReview()
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("regression — pure dialogue (no debate) path unchanged", () => {
+  test("calls session.review() on first run when only dialogue is enabled (no debate)", async () => {
+    const mockSession = makeSession();
+    // biome-ignore lint/suspicious/noExplicitAny: injectable test dep
+    (_reviewDeps as any).createReviewerSession = mock(() => mockSession);
+
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: false });
+    const ctx = makeCtx(config);
+    // Add semanticConfig so the session.review() path is triggered
+    (ctx.config as unknown as Record<string, unknown>).review = {
+      ...(ctx.config.review as object),
+      semantic: { modelTier: "balanced", rules: [], timeoutMs: 60000, excludePatterns: [] },
+    };
+    // Provide a fake agent so the session path isn't skipped
+    ctx.agentGetFn = mock(() => ({ complete: mock(async () => ({})) })) as unknown as typeof ctx.agentGetFn;
+    (ctx.rootConfig as unknown as Record<string, unknown>).autoMode = { defaultAgent: "claude" };
+
+    await reviewStage.execute(ctx);
+
+    // session.review() should have been called (pure dialogue path)
+    expect(mockSession.review).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls session.reReview() on retry when only dialogue is enabled (no debate)", async () => {
+    const existingSession = makeSession();
+    const config = makeConfig({ dialogueEnabled: true, debateEnabled: false });
+    const ctx = makeCtx(config, { reviewerSession: existingSession });
+
+    await reviewStage.execute(ctx);
+
+    expect(existingSession.reReview).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/review/dialogue-debate.test.ts
+++ b/test/unit/review/dialogue-debate.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Unit tests for resolveDebate() and reReviewDebate() on ReviewerSession
+ *
+ * Covers US-001 acceptance criteria:
+ * - resolveDebate() calls agent.run() with correct prompt for each resolver type
+ * - resolveDebate() parses JSON response into ReviewDialogueResult
+ * - resolveDebate() appends to history
+ * - resolveDebate() stores lastCheckResult (enabling getVerdict + reReviewDebate)
+ * - resolveDebate() includes majorityVote in prompt when provided
+ * - reReviewDebate() references previous findings
+ * - reReviewDebate() triggers history compaction at maxDialogueMessages
+ * - resolveDebate() throws REVIEWER_SESSION_DESTROYED when session inactive
+ * - reReviewDebate() throws NO_REVIEW_RESULT before any resolveDebate()
+ * - clarify() works after resolveDebate()
+ * - getVerdict() works after resolveDebate()
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { createReviewerSession } from "../../../src/review/dialogue";
+import type { DebateResolverContext } from "../../../src/review/dialogue-prompts";
+import type { AgentAdapter, AgentRunOptions, AgentResult } from "../../../src/agents/types";
+import type { SemanticStory } from "../../../src/review/semantic";
+import type { SemanticReviewConfig } from "../../../src/review/types";
+import { NaxError } from "../../../src/errors";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STORY: SemanticStory = {
+  id: "US-002",
+  title: "Wire debate resolver to ReviewerSession",
+  description: "resolveDebate() and reReviewDebate() are called instead of stateless resolvers",
+  acceptanceCriteria: ["AC-1: resolveDebate passes", "AC-2: reReviewDebate references prior findings"],
+};
+
+const SEMANTIC_CONFIG: SemanticReviewConfig = {
+  modelTier: "balanced",
+  rules: [],
+  timeoutMs: 60_000,
+  excludePatterns: [],
+};
+
+const DIFF = "diff --git a/src/foo.ts b/src/foo.ts\n+export function foo() {}";
+
+const PROPOSALS: Array<{ debater: string; output: string }> = [
+  { debater: "claude", output: '{"passed": false, "findings": [{"ruleId":"r1","severity":"error","file":"f","line":1,"message":"m"}]}' },
+  { debater: "opencode", output: '{"passed": true, "findings": []}' },
+];
+
+const CRITIQUES = ["Proposal 1 missed X"];
+
+const PASSING_RESPONSE = JSON.stringify({
+  passed: true,
+  findings: [],
+  findingReasoning: {},
+});
+
+const FAILING_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [{ ruleId: "ac-gap", severity: "error", file: "src/foo.ts", line: 1, message: "AC-1 not met" }],
+  findingReasoning: { "ac-gap": "The code does not satisfy AC-1" },
+});
+
+const REREVIEW_RESPONSE = JSON.stringify({
+  passed: true,
+  findings: [],
+  findingReasoning: {},
+  deltaSummary: "ac-gap is now resolved",
+});
+
+type RunFn = (opts: AgentRunOptions) => Promise<AgentResult>;
+
+function makeRunFn(response: string, cost = 0.001): RunFn {
+  return mock(async (_opts: AgentRunOptions): Promise<AgentResult> => ({
+    output: response,
+    exitCode: 0,
+    success: true,
+    rateLimited: false,
+    durationMs: 100,
+    estimatedCost: cost,
+  }));
+}
+
+function makeAdapter(runFn: RunFn): AgentAdapter {
+  return {
+    run: runFn,
+    complete: mock(async () => ({ output: "", exitCode: 0 })),
+    plan: mock(async () => ({ specContent: "" })),
+    decompose: mock(async () => ({ stories: [] })),
+  } as unknown as AgentAdapter;
+}
+
+const MOCK_CONFIG = {
+  autoMode: { defaultAgent: "claude" },
+  models: { claude: { fast: { model: "claude-haiku-4-5-20251001" }, balanced: { model: "claude-sonnet-4-6" }, powerful: { model: "claude-opus-4-6" } } },
+  execution: { sessionTimeoutSeconds: 3600 },
+  review: { dialogue: { enabled: true, maxClarificationsPerAttempt: 3, maxDialogueMessages: 20 } },
+} as unknown as import("../../../src/config").NaxConfig;
+
+// ---------------------------------------------------------------------------
+// resolveDebate() — core behavior
+// ---------------------------------------------------------------------------
+
+describe("ReviewerSession.resolveDebate()", () => {
+  test("calls agent.run() with keepSessionOpen: true and sessionRole: reviewer", async () => {
+    const runFn = makeRunFn(PASSING_RESPONSE);
+    const session = createReviewerSession(makeAdapter(runFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+
+    expect(runFn).toHaveBeenCalledTimes(1);
+    const opts = (runFn as ReturnType<typeof mock>).mock.calls[0][0] as AgentRunOptions;
+    expect(opts.keepSessionOpen).toBe(true);
+    expect(opts.sessionRole).toBe("reviewer");
+    expect(opts.pipelineStage).toBe("review");
+  });
+
+  test("parses JSON response into ReviewDialogueResult (passing)", async () => {
+    const session = createReviewerSession(makeAdapter(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const result = await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+
+    expect(result.checkResult.success).toBe(true);
+    expect(result.checkResult.findings).toHaveLength(0);
+  });
+
+  test("parses JSON response into ReviewDialogueResult (failing with findings)", async () => {
+    const session = createReviewerSession(makeAdapter(makeRunFn(FAILING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const result = await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+
+    expect(result.checkResult.success).toBe(false);
+    expect(result.checkResult.findings).toHaveLength(1);
+    expect(result.checkResult.findings[0].ruleId).toBe("ac-gap");
+    expect(result.findingReasoning.get("ac-gap")).toBe("The code does not satisfy AC-1");
+  });
+
+  test("captures LLM cost", async () => {
+    const session = createReviewerSession(makeAdapter(makeRunFn(PASSING_RESPONSE, 0.005)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const result = await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    expect(result.cost).toBe(0.005);
+  });
+
+  test("appends exactly 2 history entries (implementer prompt + reviewer response)", async () => {
+    const session = createReviewerSession(makeAdapter(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+
+    expect(session.history).toHaveLength(2);
+    expect(session.history[0].role).toBe("implementer");
+    expect(session.history[1].role).toBe("reviewer");
+  });
+
+  test("stores lastCheckResult so getVerdict() works", async () => {
+    const session = createReviewerSession(makeAdapter(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    // getVerdict() should not throw
+    const verdict = session.getVerdict();
+    expect(verdict.passed).toBe(true);
+    expect(verdict.storyId).toBe("story-1");
+  });
+
+  test("throws REVIEWER_SESSION_DESTROYED when session is inactive", async () => {
+    const session = createReviewerSession(makeAdapter(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    await session.destroy();
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+
+    await expect(session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx)).rejects.toBeInstanceOf(NaxError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDebate() — resolver type prompt framing
+// ---------------------------------------------------------------------------
+
+describe("resolveDebate() prompt framing by resolver type", () => {
+  test("synthesis: prompt contains 'synthes'", async () => {
+    const runFn = makeRunFn(PASSING_RESPONSE);
+    const session = createReviewerSession(makeAdapter(runFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+
+    const opts = (runFn as ReturnType<typeof mock>).mock.calls[0][0] as AgentRunOptions;
+    expect(opts.prompt.toLowerCase()).toContain("synthes");
+  });
+
+  test("custom: prompt contains 'judge'", async () => {
+    const runFn = makeRunFn(PASSING_RESPONSE);
+    const session = createReviewerSession(makeAdapter(runFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "custom" };
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+
+    const opts = (runFn as ReturnType<typeof mock>).mock.calls[0][0] as AgentRunOptions;
+    expect(opts.prompt.toLowerCase()).toContain("judge");
+  });
+
+  test("majority-fail-closed: prompt contains vote tally", async () => {
+    const runFn = makeRunFn(PASSING_RESPONSE);
+    const session = createReviewerSession(makeAdapter(runFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = {
+      resolverType: "majority-fail-closed",
+      majorityVote: { passed: false, passCount: 1, failCount: 1 },
+    };
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+
+    const opts = (runFn as ReturnType<typeof mock>).mock.calls[0][0] as AgentRunOptions;
+    expect(opts.prompt).toContain("1 passed");
+    expect(opts.prompt).toContain("1 failed");
+  });
+
+  test("majority-fail-open: prompt contains vote tally", async () => {
+    const runFn = makeRunFn(PASSING_RESPONSE);
+    const session = createReviewerSession(makeAdapter(runFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = {
+      resolverType: "majority-fail-open",
+      majorityVote: { passed: true, passCount: 2, failCount: 0 },
+    };
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+
+    const opts = (runFn as ReturnType<typeof mock>).mock.calls[0][0] as AgentRunOptions;
+    expect(opts.prompt).toContain("2 passed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reReviewDebate()
+// ---------------------------------------------------------------------------
+
+describe("ReviewerSession.reReviewDebate()", () => {
+  test("throws NO_REVIEW_RESULT when called before any resolveDebate()", async () => {
+    const session = createReviewerSession(makeAdapter(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+
+    await expect(session.reReviewDebate(PROPOSALS, CRITIQUES, DIFF, ctx)).rejects.toBeInstanceOf(NaxError);
+  });
+
+  test("throws REVIEWER_SESSION_DESTROYED when session is inactive", async () => {
+    const session = createReviewerSession(makeAdapter(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    await session.destroy();
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+
+    await expect(session.reReviewDebate(PROPOSALS, CRITIQUES, DIFF, ctx)).rejects.toBeInstanceOf(NaxError);
+  });
+
+  test("references previous findings in prompt", async () => {
+    // Second call returns passing
+    let callCount = 0;
+    const multiRunFn: RunFn = mock(async (_opts: AgentRunOptions): Promise<AgentResult> => {
+      callCount++;
+      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, exitCode: 0, success: true, rateLimited: false, durationMs: 100, estimatedCost: 0.001 };
+    });
+
+    const session = createReviewerSession(makeAdapter(multiRunFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+
+    // First: resolveDebate with failing result
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    // Second: reReviewDebate — prompt should reference "ac-gap"
+    await session.reReviewDebate(PROPOSALS, CRITIQUES, DIFF, ctx);
+
+    const secondCallOpts = (multiRunFn as ReturnType<typeof mock>).mock.calls[1][0] as AgentRunOptions;
+    expect(secondCallOpts.prompt).toContain("ac-gap");
+  });
+
+  test("returns ReviewDialogueResult with deltaSummary", async () => {
+    let callCount = 0;
+    const multiRunFn: RunFn = mock(async (_opts: AgentRunOptions): Promise<AgentResult> => {
+      callCount++;
+      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, exitCode: 0, success: true, rateLimited: false, durationMs: 100, estimatedCost: 0.001 };
+    });
+
+    const session = createReviewerSession(makeAdapter(multiRunFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    const result = await session.reReviewDebate(PROPOSALS, CRITIQUES, DIFF, ctx);
+
+    expect(result.checkResult.success).toBe(true);
+    expect(result.deltaSummary).toBeDefined();
+    expect(result.deltaSummary).toContain("ac-gap");
+  });
+
+  test("appends 2 more history entries", async () => {
+    let callCount = 0;
+    const multiRunFn: RunFn = mock(async (_opts: AgentRunOptions): Promise<AgentResult> => {
+      callCount++;
+      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, exitCode: 0, success: true, rateLimited: false, durationMs: 100, estimatedCost: 0.001 };
+    });
+
+    const session = createReviewerSession(makeAdapter(multiRunFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    await session.reReviewDebate(PROPOSALS, CRITIQUES, DIFF, ctx);
+
+    expect(session.history).toHaveLength(4);
+  });
+
+  test("triggers history compaction when history exceeds maxDialogueMessages", async () => {
+    const smallMaxConfig = {
+      ...MOCK_CONFIG,
+      review: { dialogue: { enabled: true, maxClarificationsPerAttempt: 3, maxDialogueMessages: 2 } },
+    } as unknown as import("../../../src/config").NaxConfig;
+
+    let callCount = 0;
+    const multiRunFn: RunFn = mock(async (_opts: AgentRunOptions): Promise<AgentResult> => {
+      callCount++;
+      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, exitCode: 0, success: true, rateLimited: false, durationMs: 100, estimatedCost: 0.001 };
+    });
+
+    const session = createReviewerSession(makeAdapter(multiRunFn), "story-1", "/workdir", "feature", smallMaxConfig);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    // After this call history will be 2; reReviewDebate adds 2 more (>maxDialogueMessages=2)
+    // → compaction should fire, reducing history length
+    await session.reReviewDebate(PROPOSALS, CRITIQUES, DIFF, ctx);
+
+    // After compaction, history length should be ≤ 3 (compacted summary + last 2 messages)
+    expect(session.history.length).toBeLessThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clarify() works after resolveDebate()
+// ---------------------------------------------------------------------------
+
+describe("clarify() after resolveDebate()", () => {
+  test("can clarify after resolveDebate without error", async () => {
+    let callCount = 0;
+    const multiRunFn: RunFn = mock(async (_opts: AgentRunOptions): Promise<AgentResult> => {
+      callCount++;
+      return {
+        output: callCount === 1 ? PASSING_RESPONSE : "The finding means X needs to be implemented.",
+        exitCode: 0,
+        success: true,
+        rateLimited: false,
+        durationMs: 100,
+        estimatedCost: 0.001,
+      };
+    });
+
+    const session = createReviewerSession(makeAdapter(multiRunFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    const clarification = await session.clarify("What does finding ac-gap mean?");
+
+    expect(clarification).toContain("X needs to be implemented");
+    expect(session.history).toHaveLength(4);
+  });
+});

--- a/test/unit/review/dialogue-debate.test.ts
+++ b/test/unit/review/dialogue-debate.test.ts
@@ -237,6 +237,16 @@ describe("ReviewerSession.reReviewDebate()", () => {
     await expect(session.reReviewDebate(PROPOSALS, CRITIQUES, DIFF, ctx)).rejects.toBeInstanceOf(NaxError);
   });
 
+  test("throws NO_REVIEW_RESULT when called after review() but not resolveDebate() (prevents wrong delta baseline)", async () => {
+    // review() sets lastCheckResult/lastSemanticConfig but lastWasDebateResolve stays false —
+    // reReviewDebate() must not accept non-debate findings as the delta baseline.
+    const session = createReviewerSession(makeAdapter(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    await session.review(DIFF, STORY, SEMANTIC_CONFIG);
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+
+    await expect(session.reReviewDebate(PROPOSALS, CRITIQUES, DIFF, ctx)).rejects.toBeInstanceOf(NaxError);
+  });
+
   test("throws REVIEWER_SESSION_DESTROYED when session is inactive", async () => {
     const session = createReviewerSession(makeAdapter(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
     await session.destroy();

--- a/test/unit/review/dialogue-prompts.test.ts
+++ b/test/unit/review/dialogue-prompts.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for src/review/dialogue-prompts.ts
+ *
+ * Covers:
+ * - buildReviewPrompt() — extracted from dialogue.ts; regression check
+ * - buildReReviewPrompt() — extracted from dialogue.ts; regression check
+ * - buildDebateResolverPrompt() — varies by resolver type
+ * - buildDebateReReviewPrompt() — references previous findings
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildDebateReReviewPrompt,
+  buildDebateResolverPrompt,
+  buildReReviewPrompt,
+  buildReviewPrompt,
+} from "../../../src/review/dialogue-prompts";
+import type { DebateResolverContext } from "../../../src/review/dialogue-prompts";
+import type { SemanticStory } from "../../../src/review/semantic";
+import type { SemanticReviewConfig } from "../../../src/review/types";
+import type { ReviewFinding } from "../../../src/plugins/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STORY: SemanticStory = {
+  id: "US-001",
+  title: "Add debate resolver dialogue",
+  description: "Wire resolvers to use ReviewerSession",
+  acceptanceCriteria: ["AC-1: resolveDebate() works", "AC-2: reReviewDebate() references prior findings"],
+};
+
+const SEMANTIC_CONFIG: SemanticReviewConfig = {
+  modelTier: "balanced",
+  rules: [],
+  timeoutMs: 60_000,
+  excludePatterns: [],
+};
+
+const DIFF = "diff --git a/src/foo.ts b/src/foo.ts\n+export function foo() {}";
+
+const FINDING: ReviewFinding = {
+  ruleId: "missing-ac",
+  severity: "error",
+  file: "src/foo.ts",
+  line: 1,
+  message: "AC-1 not satisfied",
+};
+
+const PROPOSALS: Array<{ debater: string; output: string }> = [
+  { debater: "claude", output: '{"passed": false, "findings": []}' },
+  { debater: "opencode", output: '{"passed": true, "findings": []}' },
+];
+
+const CRITIQUES = ["Proposal 1 missed edge case X", "Proposal 2 looks good"];
+
+// ---------------------------------------------------------------------------
+// buildReviewPrompt — regression
+// ---------------------------------------------------------------------------
+
+describe("buildReviewPrompt", () => {
+  test("includes story id and title", () => {
+    const prompt = buildReviewPrompt(DIFF, STORY, SEMANTIC_CONFIG);
+    expect(prompt).toContain("US-001");
+    expect(prompt).toContain("Add debate resolver dialogue");
+  });
+
+  test("includes acceptance criteria", () => {
+    const prompt = buildReviewPrompt(DIFF, STORY, SEMANTIC_CONFIG);
+    expect(prompt).toContain("AC-1: resolveDebate() works");
+    expect(prompt).toContain("AC-2: reReviewDebate() references prior findings");
+  });
+
+  test("includes the diff", () => {
+    const prompt = buildReviewPrompt(DIFF, STORY, SEMANTIC_CONFIG);
+    expect(prompt).toContain(DIFF);
+  });
+
+  test("asks for JSON response", () => {
+    const prompt = buildReviewPrompt(DIFF, STORY, SEMANTIC_CONFIG);
+    expect(prompt).toContain("passed");
+    expect(prompt).toContain("findings");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReReviewPrompt — regression
+// ---------------------------------------------------------------------------
+
+describe("buildReReviewPrompt", () => {
+  test("includes 'follow-up' framing", () => {
+    const prompt = buildReReviewPrompt(DIFF, [FINDING]);
+    expect(prompt).toContain("follow-up");
+  });
+
+  test("includes previous findings", () => {
+    const prompt = buildReReviewPrompt(DIFF, [FINDING]);
+    expect(prompt).toContain("missing-ac");
+    expect(prompt).toContain("AC-1 not satisfied");
+  });
+
+  test("shows (none) when no previous findings", () => {
+    const prompt = buildReReviewPrompt(DIFF, []);
+    expect(prompt).toContain("(none)");
+  });
+
+  test("includes updated diff", () => {
+    const prompt = buildReReviewPrompt(DIFF, [FINDING]);
+    expect(prompt).toContain(DIFF);
+  });
+
+  test("asks for deltaSummary in JSON", () => {
+    const prompt = buildReReviewPrompt(DIFF, [FINDING]);
+    expect(prompt).toContain("deltaSummary");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDebateResolverPrompt — varies by resolver type
+// ---------------------------------------------------------------------------
+
+describe("buildDebateResolverPrompt", () => {
+  test("includes labeled debater proposals", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateResolverPrompt(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    expect(prompt).toContain("claude");
+    expect(prompt).toContain("opencode");
+    expect(prompt).toContain(PROPOSALS[0].output);
+    expect(prompt).toContain(PROPOSALS[1].output);
+  });
+
+  test("includes critiques when present", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateResolverPrompt(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    expect(prompt).toContain(CRITIQUES[0]);
+  });
+
+  test("omits critiques section when empty", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateResolverPrompt(PROPOSALS, [], DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    expect(prompt).not.toContain("Critiques");
+  });
+
+  test("includes diff", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateResolverPrompt(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    expect(prompt).toContain(DIFF);
+  });
+
+  test("includes acceptance criteria", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateResolverPrompt(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    expect(prompt).toContain("AC-1: resolveDebate() works");
+  });
+
+  test("synthesis type: instructs to synthesize", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateResolverPrompt(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    expect(prompt.toLowerCase()).toContain("synthes");
+  });
+
+  test("custom type: instructs judge framing", () => {
+    const ctx: DebateResolverContext = { resolverType: "custom" };
+    const prompt = buildDebateResolverPrompt(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    expect(prompt.toLowerCase()).toContain("judge");
+  });
+
+  test("majority-fail-closed: includes vote tally in prompt", () => {
+    const ctx: DebateResolverContext = {
+      resolverType: "majority-fail-closed",
+      majorityVote: { passed: false, passCount: 1, failCount: 1 },
+    };
+    const prompt = buildDebateResolverPrompt(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    expect(prompt).toContain("1 passed");
+    expect(prompt).toContain("1 failed");
+  });
+
+  test("majority-fail-open: includes vote tally and fail-open note", () => {
+    const ctx: DebateResolverContext = {
+      resolverType: "majority-fail-open",
+      majorityVote: { passed: true, passCount: 2, failCount: 0 },
+    };
+    const prompt = buildDebateResolverPrompt(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    expect(prompt).toContain("2 passed");
+  });
+
+  test("asks for JSON response with passed + findings", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateResolverPrompt(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    expect(prompt).toContain("passed");
+    expect(prompt).toContain("findings");
+  });
+
+  test("instructs tool verification", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateResolverPrompt(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
+    // Should instruct the reviewer to verify claims with tools
+    expect(prompt.toLowerCase()).toMatch(/verif|tool/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDebateReReviewPrompt — references prior findings
+// ---------------------------------------------------------------------------
+
+describe("buildDebateReReviewPrompt", () => {
+  test("includes 're-review' or 'follow-up' framing", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateReReviewPrompt(PROPOSALS, CRITIQUES, DIFF, [FINDING], ctx);
+    expect(prompt.toLowerCase()).toMatch(/re-review|follow-up|previous finding/);
+  });
+
+  test("includes previous findings", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateReReviewPrompt(PROPOSALS, CRITIQUES, DIFF, [FINDING], ctx);
+    expect(prompt).toContain("missing-ac");
+    expect(prompt).toContain("AC-1 not satisfied");
+  });
+
+  test("shows (none) when no previous findings", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateReReviewPrompt(PROPOSALS, CRITIQUES, DIFF, [], ctx);
+    expect(prompt).toContain("(none)");
+  });
+
+  test("includes updated diff", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateReReviewPrompt(PROPOSALS, CRITIQUES, DIFF, [FINDING], ctx);
+    expect(prompt).toContain(DIFF);
+  });
+
+  test("includes labeled debater proposals", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateReReviewPrompt(PROPOSALS, CRITIQUES, DIFF, [FINDING], ctx);
+    expect(prompt).toContain("claude");
+    expect(prompt).toContain("opencode");
+  });
+
+  test("asks for deltaSummary in JSON", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const prompt = buildDebateReReviewPrompt(PROPOSALS, CRITIQUES, DIFF, [FINDING], ctx);
+    expect(prompt).toContain("deltaSummary");
+  });
+});

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -484,6 +484,8 @@ describe("runReview — semantic check integration (AC-9)", () => {
       expect.any(Object),
       mockResolver,
       undefined,
+      undefined,
+      undefined,
     );
   });
 
@@ -513,6 +515,8 @@ describe("runReview — semantic check integration (AC-9)", () => {
       expect.any(Object),
       { modelTier: "powerful", rules: ["no stubs"], timeoutMs: 600_000, excludePatterns: [":!test/"] },
       expect.any(Function),
+      undefined,
+      undefined,
       undefined,
     );
   });


### PR DESCRIPTION
## What

Wire `ReviewerSession` as the authoritative resolver for all debate resolver types (`majority`, `synthesis`, `custom`) when both `debate.stages.review.enabled` and `review.dialogue.enabled` are true. Implements `SPEC-debate-resolver-dialogue.md` Phase 2.

## Why

Three problems with the previous debate+review interaction (see spec for full motivation):

1. **Resolvers ran blind** — `synthesis`/`custom` used `adapter.complete()` (one-shot, no tool access). `majority` was pure vote counting with no ability to verify claims.
2. **Debate verdict was discarded** — `semantic.ts` re-derived majority from raw proposals, bypassing the resolver's verdict entirely (Issue 3e).
3. **No continuity across re-reviews** — each autofix loop re-ran the full debate from scratch. No clarification channel to the implementer in debate mode.

Closes #308

## How

**US-001** — Add `resolveDebate()` and `reReviewDebate()` to `ReviewerSession` (`src/review/dialogue.ts`). Prompt strategy varies by resolver type (majority includes vote tally; synthesis synthesises; custom acts as judge). All types use `agent.run()` with tool access (READ, GREP) to verify claims.

**US-002** — Extend `resolveOutcome()` in `session-helpers.ts` to accept an optional `ReviewerSession`. When provided, delegates to `resolveDebate()`/`reReviewDebate()` for a tool-verified verdict. Falls back to stateless resolvers on error.

**US-003** — Remove G4 guard in `review.ts` (`dialogueEnabled` is now independent of `reviewDebateEnabled`). When both are enabled, create the `ReviewerSession`, store it on `ctx.reviewerSession`, and fall through to the orchestrator. The orchestrator passes it as `resolverSession` to `runSemanticReview()` → `DebateSession` → `resolveOutcome()`. Use the resolver's `ReviewDialogueResult` as the authoritative verdict via `getVerdict()` (no manual majority re-derivation from raw proposals).

**US-004** — Thread `diff`, `story`, `semanticConfig`, `labeledProposals`, and `resolverType` through `resolveOutcome()` via a new optional `resolverContext` parameter. Existing call sites (`session-plan.ts`, `session-stateful.ts`, `session-hybrid.ts`, `session-one-shot.ts`) pass `undefined` — no behavioural change.

**Bug fixes** (found in post-implementation review):
- `reReviewDebate()` guard now requires `lastWasDebateResolve = true`, preventing it from using stale findings from a prior `review()` call as the delta baseline.
- Added spec-required (US-004 AC) warn log when `reviewerSession` is provided but `resolverContext` is missing.

**Docs** — new `docs/guides/debate.md` (resolver types, session modes, plan stage matrix, failure handling) and updated `docs/guides/semantic-review.md` (review stage behavior matrix).

## Testing

- [x] Tests added/updated
- [x] `bun test` passes (5001 pass, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

New test files:
- `test/unit/review/dialogue-debate.test.ts` — 19 tests for `resolveDebate()` / `reReviewDebate()`
- `test/unit/review/dialogue-prompts.test.ts` — 26 tests for all prompt builders
- `test/unit/pipeline/stages/review-debate-dialogue.test.ts` — 13 tests for G4 guard removal + debate+dialogue stage routing

## Notes

**Backward compatibility** — all resolver types with `review.dialogue.enabled: false` are unaffected. Pure dialogue (no debate) path is unchanged. `session-plan.ts` is unchanged. `ReviewerSession` is review-stage only — plan-stage debate does not use dialogue (no diff, no ACs, no implementer).