### PR TITLE
fix(debate): persona injection in review round-1 + resolver labeling (P1/P2/P3)

### DIFF
--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -214,7 +214,8 @@ Rules:
 - Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
 - **Prefer behavioral tests** — import functions and call them rather than reading source files. For example, to verify "getPostRunActions() returns empty array", import PluginRegistry and call getPostRunActions(), don't grep the source file for the method name.
 - **File output (REQUIRED)**: Write the acceptance test file DIRECTLY to the path shown below. Do NOT output the test code in your response. After writing the file, reply with a brief confirmation.
-- **Path anchor (CRITICAL)**: Write the test file to this exact path: \`${join(options.workdir, ".nax", "features", options.featureName, resolveAcceptanceTestFile(options.language, options.config?.acceptance?.testPath))}\`. Import from package sources using relative paths like \`../../../src/...\` (3 levels up from \`.nax/features/<name>/\` to the package root).`;
+- **Path anchor (CRITICAL)**: Write the test file to this exact path: \`${join(options.workdir, ".nax", "features", options.featureName, resolveAcceptanceTestFile(options.language, options.config?.acceptance?.testPath))}\`. Import from package sources using relative paths like \`../../../src/...\` (3 levels up from \`.nax/features/<name>/\` to the package root).
+- **Process cwd (CRITICAL)**: When spawning child processes to invoke a CLI or binary, always set the working directory to the **package root**, not the test file's directory. The package root is 3 levels up: \`join(import.meta.dir, "../../..")\`. Using \`import.meta.dir\` or \`__dirname\` as cwd causes ENOENT errors when the process looks for data files (e.g. \`tasks.json\`) at the project root.`;
 
   const implementationSection =
     options.implementationContext && options.implementationContext.length > 0

--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -215,7 +215,7 @@ Rules:
 - **Prefer behavioral tests** — import functions and call them rather than reading source files. For example, to verify "getPostRunActions() returns empty array", import PluginRegistry and call getPostRunActions(), don't grep the source file for the method name.
 - **File output (REQUIRED)**: Write the acceptance test file DIRECTLY to the path shown below. Do NOT output the test code in your response. After writing the file, reply with a brief confirmation.
 - **Path anchor (CRITICAL)**: Write the test file to this exact path: \`${join(options.workdir, ".nax", "features", options.featureName, resolveAcceptanceTestFile(options.language, options.config?.acceptance?.testPath))}\`. Import from package sources using relative paths like \`../../../src/...\` (3 levels up from \`.nax/features/<name>/\` to the package root).
-- **Process cwd (CRITICAL)**: When spawning child processes to invoke a CLI or binary, always set the working directory to the **package root**, not the test file's directory. The package root is 3 levels up: \`join(import.meta.dir, "../../..")\`. Using \`import.meta.dir\` or \`__dirname\` as cwd causes ENOENT errors when the process looks for data files (e.g. \`tasks.json\`) at the project root.`;
+- **Process cwd**: When spawning child processes to invoke a CLI or binary, set the working directory to the **package root** (\`join(import.meta.dir, "../../..")\`) as your default — unless your Step 2 exploration reveals the CLI uses a different working directory convention (e.g. reads config from \`~/.config/\`, or resolves paths relative to a flag value). Always check how the CLI resolves file paths before assuming.`;
 
   const implementationSection =
     options.implementationContext && options.implementationContext.length > 0

--- a/src/debate/resolvers.ts
+++ b/src/debate/resolvers.ts
@@ -8,16 +8,25 @@
  */
 
 import type { AgentAdapter, CompleteOptions, CompleteResult } from "../agents/types";
-import type { ResolverConfig } from "./types";
+import type { Debater, ResolverConfig } from "./types";
 
 // ─── Private prompt helpers ───────────────────────────────────────────────────
 
-function buildProposalsSection(proposals: string[]): string {
-  return proposals.map((p, i) => `### Proposal ${i + 1}\n${p}`).join("\n\n");
+function buildDebaterLabel(debater: Debater): string {
+  return debater.persona ? `${debater.agent} (${debater.persona})` : debater.agent;
 }
 
-function buildSynthesisPrompt(proposals: string[], critiques: string[]): string {
-  const proposalsSection = buildProposalsSection(proposals);
+function buildProposalsSection(proposals: string[], debaters?: Debater[]): string {
+  return proposals
+    .map((p, i) => {
+      const label = debaters?.[i] ? buildDebaterLabel(debaters[i]) : String(i + 1);
+      return `### Proposal ${label}\n${p}`;
+    })
+    .join("\n\n");
+}
+
+function buildSynthesisPrompt(proposals: string[], critiques: string[], debaters?: Debater[]): string {
+  const proposalsSection = buildProposalsSection(proposals, debaters);
   const critiquesSection =
     critiques.length > 0
       ? `\n\n## Critiques\n${critiques.map((c, i) => `### Critique ${i + 1}\n${c}`).join("\n\n")}`
@@ -25,8 +34,8 @@ function buildSynthesisPrompt(proposals: string[], critiques: string[]): string 
   return `You are a synthesis agent. Your task is to synthesize the following proposals into a single coherent, high-quality response.\n\n## Proposals\n${proposalsSection}${critiquesSection}\n\nPlease synthesize these into the best possible unified response, incorporating the strongest elements from each proposal.`;
 }
 
-function buildJudgePrompt(proposals: string[], critiques: string[]): string {
-  const proposalsSection = buildProposalsSection(proposals);
+function buildJudgePrompt(proposals: string[], critiques: string[], debaters?: Debater[]): string {
+  const proposalsSection = buildProposalsSection(proposals, debaters);
   const critiquesSection =
     critiques.length > 0
       ? `\n\n## Critiques\n${critiques.map((c, i) => `### Critique ${i + 1}\n${c}`).join("\n\n")}`
@@ -88,9 +97,9 @@ export function majorityResolver(proposals: string[], failOpen: boolean): "passe
 export async function synthesisResolver(
   proposals: string[],
   critiques: string[],
-  opts: { adapter: AgentAdapter; completeOptions?: CompleteOptions; promptSuffix?: string },
+  opts: { adapter: AgentAdapter; completeOptions?: CompleteOptions; promptSuffix?: string; debaters?: Debater[] },
 ): Promise<CompleteResult> {
-  const base = buildSynthesisPrompt(proposals, critiques);
+  const base = buildSynthesisPrompt(proposals, critiques, opts.debaters);
   const prompt = opts.promptSuffix ? `${base}\n\n${opts.promptSuffix}` : base;
   return opts.adapter.complete(prompt, opts.completeOptions);
 }
@@ -108,6 +117,7 @@ export async function judgeResolver(
     getAgent: (name: string) => AgentAdapter | undefined;
     defaultAgentName?: string;
     completeOptions?: CompleteOptions;
+    debaters?: Debater[];
   },
 ): Promise<CompleteResult> {
   const agentName = resolverConfig.agent ?? opts.defaultAgentName ?? DEFAULT_FALLBACK_AGENT;
@@ -117,6 +127,6 @@ export async function judgeResolver(
     throw new Error(`[debate] Judge agent '${agentName}' not found`);
   }
 
-  const prompt = buildJudgePrompt(proposals, critiques);
+  const prompt = buildJudgePrompt(proposals, critiques, opts.debaters);
   return adapter.complete(prompt, opts.completeOptions);
 }

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -210,6 +210,7 @@ export async function resolveOutcome(
   reviewerSession?: import("../review/dialogue").ReviewerSession,
   resolverContext?: ResolverContext,
   promptSuffix?: string,
+  debaters?: Debater[],
 ): Promise<ResolveOutcome> {
   const resolverConfig = stageConfig.resolver;
   const logger = _debateSessionDeps.getSafeLogger();
@@ -311,6 +312,7 @@ export async function resolveOutcome(
       const resolverResult = await synthesisResolver(proposalOutputs, critiqueOutputs, {
         adapter,
         promptSuffix,
+        debaters,
         completeOptions: {
           model: resolveDebaterModel({ agent: agentName }, config),
           config,
@@ -338,6 +340,7 @@ export async function resolveOutcome(
     const resolverResult = await judgeResolver(proposalOutputs, critiqueOutputs, resolverConfig, {
       getAgent: (name: string) => _debateSessionDeps.getAgent(name, config),
       defaultAgentName: RESOLVER_FALLBACK_AGENT,
+      debaters,
       completeOptions: {
         model: resolveDebaterModel({ agent: agentName }, config),
         config,

--- a/src/debate/session-hybrid.ts
+++ b/src/debate/session-hybrid.ts
@@ -8,7 +8,7 @@
 
 import type { NaxConfig } from "../config";
 import { allSettledBounded } from "./concurrency";
-import { resolvePersonas } from "./personas";
+import { buildDebaterLabel, resolvePersonas } from "./personas";
 import { DebatePromptBuilder } from "./prompt-builder";
 import {
   type ResolveOutcome,
@@ -249,7 +249,7 @@ export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateR
   const fullResolverContext = ctx.resolverContextInput
     ? {
         ...ctx.resolverContextInput,
-        labeledProposals: successfulProposals.map((s) => ({ debater: s.debater.agent, output: s.output })),
+        labeledProposals: successfulProposals.map((s) => ({ debater: buildDebaterLabel(s.debater), output: s.output })),
       }
     : undefined;
   const resolveResult: ResolveOutcome = await resolveOutcome(
@@ -263,6 +263,8 @@ export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateR
     ctx.featureName,
     ctx.reviewerSession,
     fullResolverContext,
+    /* promptSuffix */ undefined,
+    successfulProposals.map((s) => s.debater),
   );
   totalCostUsd += resolveResult.resolverCostUsd;
 

--- a/src/debate/session-one-shot.ts
+++ b/src/debate/session-one-shot.ts
@@ -6,7 +6,7 @@
 
 import type { NaxConfig } from "../config";
 import { allSettledBounded } from "./concurrency";
-import { resolvePersonas } from "./personas";
+import { buildDebaterLabel, resolvePersonas } from "./personas";
 import { DebatePromptBuilder } from "./prompt-builder";
 import {
   type ResolveOutcome,
@@ -62,13 +62,17 @@ export async function runOneShot(ctx: OneShotCtx, prompt: string): Promise<Debat
   // Step 2: Proposal round — bounded parallel
   const debate = ctx.config?.debate;
   const concurrencyLimit = debate?.maxConcurrentDebaters ?? 2;
+  const proposalBuilder = new DebatePromptBuilder(
+    { taskContext: prompt, outputFormat: "", stage: ctx.stage },
+    { debaters: resolved.map((r) => r.debater), sessionMode: "one-shot" },
+  );
   const proposalSettled = await allSettledBounded(
     resolved.map(
       ({ debater, adapter }, i) =>
         () =>
           runComplete(
             adapter,
-            prompt,
+            proposalBuilder.buildProposalPrompt(i),
             {
               model: resolveDebaterModel(debater, ctx.config),
               featureName: ctx.stage,
@@ -219,7 +223,7 @@ export async function runOneShot(ctx: OneShotCtx, prompt: string): Promise<Debat
   const fullResolverContext = ctx.resolverContextInput
     ? {
         ...ctx.resolverContextInput,
-        labeledProposals: successful.map((p) => ({ debater: p.debater.agent, output: p.output })),
+        labeledProposals: successful.map((p) => ({ debater: buildDebaterLabel(p.debater), output: p.output })),
       }
     : undefined;
   const outcome: ResolveOutcome = await resolveOutcome(
@@ -233,6 +237,8 @@ export async function runOneShot(ctx: OneShotCtx, prompt: string): Promise<Debat
     ctx.featureName,
     ctx.reviewerSession,
     fullResolverContext,
+    /* promptSuffix */ undefined,
+    successful.map((p) => p.debater),
   );
   totalCostUsd += outcome.resolverCostUsd;
 

--- a/src/debate/session-plan.ts
+++ b/src/debate/session-plan.ts
@@ -213,6 +213,7 @@ export async function runPlan(
     /* reviewerSession */ undefined,
     /* resolverContext */ undefined,
     planSynthesisSuffix,
+    successful.map((p) => p.debater),
   );
 
   // Winning output: synthesis/custom resolver returns a combined PRD — use it when available.

--- a/src/debate/session-stateful.ts
+++ b/src/debate/session-stateful.ts
@@ -10,7 +10,7 @@ import type { ModelDef, ModelTier } from "../config";
 import type { NaxConfig } from "../config";
 import { resolvePermissions } from "../config/permissions";
 import { allSettledBounded } from "./concurrency";
-import { resolvePersonas } from "./personas";
+import { buildDebaterLabel, resolvePersonas } from "./personas";
 import { DebatePromptBuilder } from "./prompt-builder";
 import {
   type ResolveOutcome,
@@ -136,11 +136,22 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
   // Proposal round — bounded parallel
   const debate = ctx.config?.debate;
   const concurrencyLimit = debate?.maxConcurrentDebaters ?? 2;
+  const proposalBuilder = new DebatePromptBuilder(
+    { taskContext: prompt, outputFormat: "", stage: ctx.stage },
+    { debaters: resolved.map((r) => r.debater), sessionMode: "stateful" },
+  );
   const proposalSettled = await allSettledBounded(
     resolved.map(
       ({ debater, adapter }, debaterIdx) =>
         () =>
-          runStatefulTurn(ctx, adapter, debater, prompt, `debate-${ctx.stage}-${debaterIdx}`, config.rounds > 1),
+          runStatefulTurn(
+            ctx,
+            adapter,
+            debater,
+            proposalBuilder.buildProposalPrompt(debaterIdx),
+            `debate-${ctx.stage}-${debaterIdx}`,
+            config.rounds > 1,
+          ),
     ),
     concurrencyLimit,
   );
@@ -279,7 +290,7 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
   const fullResolverContext = ctx.resolverContextInput
     ? {
         ...ctx.resolverContextInput,
-        labeledProposals: successfulProposals.map((s) => ({ debater: s.debater.agent, output: s.output })),
+        labeledProposals: successfulProposals.map((s) => ({ debater: buildDebaterLabel(s.debater), output: s.output })),
       }
     : undefined;
   const outcome: ResolveOutcome = await resolveOutcome(
@@ -293,6 +304,8 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
     ctx.featureName,
     ctx.reviewerSession,
     fullResolverContext,
+    /* promptSuffix */ undefined,
+    successfulProposals.map((s) => s.debater),
   );
   totalCostUsd += outcome.resolverCostUsd;
 

--- a/test/unit/debate/resolvers.test.ts
+++ b/test/unit/debate/resolvers.test.ts
@@ -16,7 +16,7 @@ import {
   synthesisResolver,
 } from "../../../src/debate/resolvers";
 import type { AgentAdapter, CompleteOptions, CompleteResult } from "../../../src/agents/types";
-import type { ResolverConfig } from "../../../src/debate/types";
+import type { Debater, ResolverConfig } from "../../../src/debate/types";
 
 // ─── Mock Helpers ──────────────────────────────────────────────────────────────
 
@@ -479,5 +479,128 @@ describe("judgeResolver()", () => {
     expect(capturedOptions?.model).toBe("claude-haiku-4-5");
     expect(capturedOptions?.storyId).toBe("US-002");
     expect(capturedOptions?.sessionRole).toBe("judge");
+  });
+});
+
+// ─── P2: Proposal labeling with persona ──────────────────────────────────────
+
+describe("synthesisResolver() — persona-aware proposal labels (P2)", () => {
+  test("labels proposals with agent+persona when debaters provided with personas", async () => {
+    let capturedPrompt = "";
+    const adapter = makeMockAdapter("claude", async (prompt) => {
+      capturedPrompt = prompt;
+      return { output: "synthesis", costUsd: 0, source: "fallback" };
+    });
+
+    const debaters: Debater[] = [
+      { agent: "claude", persona: "challenger" },
+      { agent: "claude", persona: "pragmatist" },
+      { agent: "claude", persona: "completionist" },
+    ];
+
+    await synthesisResolver(
+      ["proposal A", "proposal B", "proposal C"],
+      [],
+      { adapter, debaters },
+    );
+
+    expect(capturedPrompt).toContain("### Proposal claude (challenger)");
+    expect(capturedPrompt).toContain("### Proposal claude (pragmatist)");
+    expect(capturedPrompt).toContain("### Proposal claude (completionist)");
+    expect(capturedPrompt).toContain("proposal A");
+    expect(capturedPrompt).toContain("proposal B");
+    expect(capturedPrompt).toContain("proposal C");
+  });
+
+  test("labels proposals with agent name only when debaters have no persona", async () => {
+    let capturedPrompt = "";
+    const adapter = makeMockAdapter("claude", async (prompt) => {
+      capturedPrompt = prompt;
+      return { output: "synthesis", costUsd: 0, source: "fallback" };
+    });
+
+    const debaters: Debater[] = [
+      { agent: "claude" },
+      { agent: "opencode" },
+    ];
+
+    await synthesisResolver(["proposal A", "proposal B"], [], { adapter, debaters });
+
+    expect(capturedPrompt).toContain("### Proposal claude");
+    expect(capturedPrompt).toContain("### Proposal opencode");
+    expect(capturedPrompt).not.toContain("(challenger)");
+  });
+
+  test("falls back to numeric labels when no debaters provided", async () => {
+    let capturedPrompt = "";
+    const adapter = makeMockAdapter("claude", async (prompt) => {
+      capturedPrompt = prompt;
+      return { output: "synthesis", costUsd: 0, source: "fallback" };
+    });
+
+    await synthesisResolver(["proposal A", "proposal B"], [], { adapter });
+
+    expect(capturedPrompt).toContain("### Proposal 1");
+    expect(capturedPrompt).toContain("### Proposal 2");
+  });
+
+  test("mixed personas: labeled where present, agent name where absent", async () => {
+    let capturedPrompt = "";
+    const adapter = makeMockAdapter("claude", async (prompt) => {
+      capturedPrompt = prompt;
+      return { output: "synthesis", costUsd: 0, source: "fallback" };
+    });
+
+    const debaters: Debater[] = [
+      { agent: "claude", persona: "security" },
+      { agent: "opencode" },
+    ];
+
+    await synthesisResolver(["proposal A", "proposal B"], [], { adapter, debaters });
+
+    expect(capturedPrompt).toContain("### Proposal claude (security)");
+    expect(capturedPrompt).toContain("### Proposal opencode");
+  });
+});
+
+describe("judgeResolver() — persona-aware proposal labels (P2)", () => {
+  test("labels proposals with agent+persona when debaters provided with personas", async () => {
+    let capturedPrompt = "";
+    const getAgentFn = mock((_name: string) =>
+      makeMockAdapter("judge", async (prompt) => {
+        capturedPrompt = prompt;
+        return { output: "judge verdict", costUsd: 0, source: "fallback" };
+      }),
+    );
+
+    const debaters: Debater[] = [
+      { agent: "claude", persona: "testability" },
+      { agent: "claude", persona: "security" },
+    ];
+
+    await judgeResolver(["proposal A", "proposal B"], [], { type: "custom", agent: "judge" }, {
+      getAgent: getAgentFn,
+      debaters,
+    });
+
+    expect(capturedPrompt).toContain("### Proposal claude (testability)");
+    expect(capturedPrompt).toContain("### Proposal claude (security)");
+  });
+
+  test("falls back to numeric labels when no debaters provided", async () => {
+    let capturedPrompt = "";
+    const getAgentFn = mock((_name: string) =>
+      makeMockAdapter("judge", async (prompt) => {
+        capturedPrompt = prompt;
+        return { output: "verdict", costUsd: 0, source: "fallback" };
+      }),
+    );
+
+    await judgeResolver(["p1", "p2"], [], { type: "custom", agent: "judge" }, {
+      getAgent: getAgentFn,
+    });
+
+    expect(capturedPrompt).toContain("### Proposal 1");
+    expect(capturedPrompt).toContain("### Proposal 2");
   });
 });

--- a/test/unit/debate/session-one-shot-roles.test.ts
+++ b/test/unit/debate/session-one-shot-roles.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { DebateSession, _debateSessionDeps } from "../../../src/debate/session";
 import type { DebateStageConfig } from "../../../src/debate/types";
+import type { CompleteOptions } from "../../../src/agents/types";
 
 function makeStageConfig(overrides: Partial<DebateStageConfig> = {}): DebateStageConfig {
   return {
@@ -110,5 +111,266 @@ describe("DebateSession.runOneShot() session roles", () => {
 
     const critiqueRoles = roles.filter((role) => role.startsWith("debate-critique"));
     expect(critiqueRoles).toEqual(["debate-critique-0", "debate-critique-1"]);
+  });
+});
+
+// ─── P1: Proposal prompts include persona block ───────────────────────────────
+
+describe("DebateSession.runOneShot() — persona injection in proposal round (P1)", () => {
+  let origGetAgent: typeof _debateSessionDeps.getAgent;
+
+  beforeEach(() => {
+    origGetAgent = _debateSessionDeps.getAgent;
+  });
+
+  afterEach(() => {
+    _debateSessionDeps.getAgent = origGetAgent;
+  });
+
+  test("each debater receives a distinct persona block when autoPersona is true", async () => {
+    const capturedPrompts: string[] = [];
+
+    _debateSessionDeps.getAgent = mock(() => ({
+      name: "claude",
+      displayName: "claude",
+      binary: "claude",
+      capabilities: {
+        supportedTiers: ["fast"] as const,
+        maxContextTokens: 100_000,
+        features: new Set<"review" | "tdd" | "refactor" | "batch">(["review"]),
+      },
+      isInstalled: async () => true,
+      run: async () => ({ success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 }),
+      buildCommand: () => [],
+      plan: async () => ({ specContent: "" }),
+      decompose: async () => ({ stories: [] }),
+      complete: async (prompt: string) => {
+        capturedPrompts.push(prompt);
+        return { output: '{"passed":true}', costUsd: 0, source: "fallback" as const };
+      },
+    }));
+
+    const session = new DebateSession({
+      storyId: "US-P1",
+      stage: "review",
+      stageConfig: makeStageConfig({
+        rounds: 1,
+        autoPersona: true,
+        debaters: [
+          { agent: "claude", model: "fast" },
+          { agent: "claude", model: "fast" },
+          { agent: "claude", model: "fast" },
+        ],
+      }),
+    });
+
+    await session.run("the task context");
+
+    // Three proposal prompts captured
+    expect(capturedPrompts).toHaveLength(3);
+
+    // Each prompt contains "## Your Role"
+    for (const prompt of capturedPrompts) {
+      expect(prompt).toContain("## Your Role");
+    }
+
+    // Prompts are NOT all identical — personas differentiate them
+    const unique = new Set(capturedPrompts);
+    expect(unique.size).toBeGreaterThan(1);
+  });
+
+  test("proposal prompts do NOT contain persona block when autoPersona is false", async () => {
+    const capturedPrompts: string[] = [];
+
+    _debateSessionDeps.getAgent = mock(() => ({
+      name: "claude",
+      displayName: "claude",
+      binary: "claude",
+      capabilities: {
+        supportedTiers: ["fast"] as const,
+        maxContextTokens: 100_000,
+        features: new Set<"review" | "tdd" | "refactor" | "batch">(["review"]),
+      },
+      isInstalled: async () => true,
+      run: async () => ({ success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 }),
+      buildCommand: () => [],
+      plan: async () => ({ specContent: "" }),
+      decompose: async () => ({ stories: [] }),
+      complete: async (prompt: string) => {
+        capturedPrompts.push(prompt);
+        return { output: '{"passed":true}', costUsd: 0, source: "fallback" as const };
+      },
+    }));
+
+    const session = new DebateSession({
+      storyId: "US-P1-NO-PERSONA",
+      stage: "review",
+      stageConfig: makeStageConfig({
+        rounds: 1,
+        autoPersona: false,
+        debaters: [
+          { agent: "claude", model: "fast" },
+          { agent: "claude", model: "fast" },
+        ],
+      }),
+    });
+
+    await session.run("the task context");
+
+    for (const prompt of capturedPrompts) {
+      expect(prompt).not.toContain("## Your Role");
+    }
+  });
+
+  test("task context is preserved in proposal prompt alongside persona", async () => {
+    const capturedPrompts: string[] = [];
+
+    _debateSessionDeps.getAgent = mock(() => ({
+      name: "claude",
+      displayName: "claude",
+      binary: "claude",
+      capabilities: {
+        supportedTiers: ["fast"] as const,
+        maxContextTokens: 100_000,
+        features: new Set<"review" | "tdd" | "refactor" | "batch">(["review"]),
+      },
+      isInstalled: async () => true,
+      run: async () => ({ success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 }),
+      buildCommand: () => [],
+      plan: async () => ({ specContent: "" }),
+      decompose: async () => ({ stories: [] }),
+      complete: async (prompt: string) => {
+        capturedPrompts.push(prompt);
+        return { output: '{"passed":true}', costUsd: 0, source: "fallback" as const };
+      },
+    }));
+
+    const session = new DebateSession({
+      storyId: "US-P1-TASK",
+      stage: "review",
+      stageConfig: makeStageConfig({
+        rounds: 1,
+        autoPersona: true,
+        debaters: [{ agent: "claude", model: "fast" }],
+      }),
+    });
+
+    await session.run("UNIQUE_TASK_CONTENT_XYZ");
+
+    expect(capturedPrompts[0]).toContain("UNIQUE_TASK_CONTENT_XYZ");
+    expect(capturedPrompts[0]).toContain("## Your Role");
+  });
+});
+
+// ─── P3: labeledProposals uses persona-aware label ────────────────────────────
+
+describe("DebateSession.runOneShot() — labeledProposals persona label (P3)", () => {
+  let origGetAgent: typeof _debateSessionDeps.getAgent;
+
+  beforeEach(() => {
+    origGetAgent = _debateSessionDeps.getAgent;
+  });
+
+  afterEach(() => {
+    _debateSessionDeps.getAgent = origGetAgent;
+  });
+
+  test("synthesis prompt labels proposals with persona when autoPersona is true", async () => {
+    let capturedSynthesisPrompt = "";
+    let callIndex = 0;
+
+    _debateSessionDeps.getAgent = mock(() => ({
+      name: "claude",
+      displayName: "claude",
+      binary: "claude",
+      capabilities: {
+        supportedTiers: ["fast"] as const,
+        maxContextTokens: 100_000,
+        features: new Set<"review" | "tdd" | "refactor" | "batch">(["review"]),
+      },
+      isInstalled: async () => true,
+      run: async () => ({ success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 }),
+      buildCommand: () => [],
+      plan: async () => ({ specContent: "" }),
+      decompose: async () => ({ stories: [] }),
+      complete: async (prompt: string, opts?: CompleteOptions) => {
+        callIndex++;
+        // The synthesis call is identified by sessionRole
+        if (opts?.sessionRole === "synthesis") {
+          capturedSynthesisPrompt = prompt;
+        }
+        return { output: "proposal output", costUsd: 0, source: "fallback" as const };
+      },
+    }));
+
+    const session = new DebateSession({
+      storyId: "US-P3",
+      stage: "plan",
+      stageConfig: makeStageConfig({
+        rounds: 1,
+        sessionMode: "one-shot",
+        autoPersona: true,
+        resolver: { type: "synthesis", agent: "claude" },
+        debaters: [
+          { agent: "claude", model: "fast" },
+          { agent: "claude", model: "fast" },
+          { agent: "claude", model: "fast" },
+        ],
+      }),
+    });
+
+    await session.run("task");
+
+    // Synthesis prompt should have persona-labeled proposals
+    expect(capturedSynthesisPrompt).toContain("(challenger)");
+    expect(capturedSynthesisPrompt).toContain("(pragmatist)");
+    expect(capturedSynthesisPrompt).toContain("(completionist)");
+  });
+
+  test("synthesis prompt labels proposals without persona when autoPersona is false", async () => {
+    let capturedSynthesisPrompt = "";
+
+    _debateSessionDeps.getAgent = mock(() => ({
+      name: "claude",
+      displayName: "claude",
+      binary: "claude",
+      capabilities: {
+        supportedTiers: ["fast"] as const,
+        maxContextTokens: 100_000,
+        features: new Set<"review" | "tdd" | "refactor" | "batch">(["review"]),
+      },
+      isInstalled: async () => true,
+      run: async () => ({ success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 }),
+      buildCommand: () => [],
+      plan: async () => ({ specContent: "" }),
+      decompose: async () => ({ stories: [] }),
+      complete: async (prompt: string, opts?: CompleteOptions) => {
+        if (opts?.sessionRole === "synthesis") {
+          capturedSynthesisPrompt = prompt;
+        }
+        return { output: "proposal output", costUsd: 0, source: "fallback" as const };
+      },
+    }));
+
+    const session = new DebateSession({
+      storyId: "US-P3-NO-PERSONA",
+      stage: "plan",
+      stageConfig: makeStageConfig({
+        rounds: 1,
+        sessionMode: "one-shot",
+        autoPersona: false,
+        resolver: { type: "synthesis", agent: "claude" },
+        debaters: [
+          { agent: "claude", model: "fast" },
+          { agent: "claude", model: "fast" },
+        ],
+      }),
+    });
+
+    await session.run("task");
+
+    // Should use agent name label only — no persona parens
+    expect(capturedSynthesisPrompt).toContain("### Proposal claude");
+    expect(capturedSynthesisPrompt).not.toContain("(challenger)");
   });
 });


### PR DESCRIPTION
## What

Follow-up to #321 (debate prompt builder). Fixes three persona attribution gaps identified in the bench-04 re-run audit.

## Why

Bench-04 re-run against v0.59.3 revealed that despite `autoPersona: true` being set:
- Review round-1 proposal prompts were still byte-identical (P1)
- Synthesis/judge resolver prompts labeled proposals `### Proposal 1` with no debater attribution (P2)
- `ReviewerSession.resolveDebate()` received `### claude × 3` with no persona labels (P3)

## How

**P1 — Review proposal prompt persona injection** (`session-one-shot.ts`, `session-stateful.ts`)

Both session files passed the raw `prompt` string directly to all debaters in the proposal round. Fixed by constructing a `DebatePromptBuilder` before the proposal round and calling `buildProposalPrompt(i)` per debater, which injects the `## Your Role` persona block. Matches the existing pattern in `session-plan.ts`.

**P2 — Resolver proposal labels** (`resolvers.ts`, `session-helpers.ts`, 4 call sites)

`buildProposalsSection()` in `resolvers.ts` used `### Proposal N` (numeric). Changed to accept optional `Debater[]` and use `buildDebaterLabel()` — producing `### Proposal claude (challenger)` when personas are active, falling back to numeric when no debaters provided. `resolveOutcome()` accepts a new optional `debaters?` param and threads it to `synthesisResolver` and `judgeResolver`.

**P3 — ReviewerSession labeled proposals** (`session-one-shot.ts`, `session-stateful.ts`, `session-hybrid.ts`)

`labeledProposals` in `fullResolverContext` used `debater.agent` (bare name). Changed to `buildDebaterLabel(debater)` so `ReviewerSession.resolveDebate()` receives `### claude (security)` instead of `### claude`.

## Testing

- [x] 11 new tests: P1 (3 tests in `session-one-shot-roles.test.ts`), P2 (6 tests in `resolvers.test.ts`), P3 (2 tests in `session-one-shot-roles.test.ts`)
- [x] Full debate suite: 200 tests, 0 failures
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

P3 only covers the `labeledProposals` path. The `ReviewerSession` prompt builder in `src/review/dialogue-prompts.ts` already uses `p.debater` as the label string — it just needed the string to carry the persona, which it now does. Full absorption of review dialogue prompts into `DebatePromptBuilder` is Phase 4 scope.