### PR TITLE
feat(acceptance): suggested criteria hardening pass

### DIFF
--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -214,7 +214,7 @@ Rules:
 - Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
 - **Prefer behavioral tests** — import functions and call them rather than reading source files. For example, to verify "getPostRunActions() returns empty array", import PluginRegistry and call getPostRunActions(), don't grep the source file for the method name.
 - **File output (REQUIRED)**: Write the acceptance test file DIRECTLY to the path shown below. Do NOT output the test code in your response. After writing the file, reply with a brief confirmation.
-- **Path anchor (CRITICAL)**: Write the test file to this exact path: \`${join(options.workdir, ".nax", "features", options.featureName, resolveAcceptanceTestFile(options.language, options.config?.acceptance?.testPath))}\`. Import from package sources using relative paths like \`../../../src/...\` (3 levels up from \`.nax/features/<name>/\` to the package root).
+- **Path anchor (CRITICAL)**: Write the test file to this exact path: \`${options.targetTestFile ?? join(options.workdir, ".nax", "features", options.featureName, resolveAcceptanceTestFile(options.language, options.config?.acceptance?.testPath))}\`. Import from package sources using relative paths like \`../../../src/...\` (3 levels up from \`.nax/features/<name>/\` to the package root).
 - **Process cwd**: When spawning child processes to invoke a CLI or binary, set the working directory to the **package root** (\`join(import.meta.dir, "../../..")\`) as your default — unless your Step 2 exploration reveals the CLI uses a different working directory convention (e.g. reads config from \`~/.config/\`, or resolves paths relative to a flag value). Always check how the CLI resolves file paths before assuming.`;
 
   const implementationSection =
@@ -252,13 +252,15 @@ Rules:
   // summary rather than raw code. If extractTestCode() fails on the response text,
   // check whether the adapter already wrote the file to the package-local feature directory.
   if (!testCode) {
-    const targetPath = join(
-      options.workdir,
-      ".nax",
-      "features",
-      options.featureName,
-      resolveAcceptanceTestFile(options.language, options.config?.acceptance?.testPath),
-    );
+    const targetPath =
+      options.targetTestFile ??
+      join(
+        options.workdir,
+        ".nax",
+        "features",
+        options.featureName,
+        resolveAcceptanceTestFile(options.language, options.config?.acceptance?.testPath),
+      );
     const backupPath = `${targetPath}.llm-recovery.bak`;
     let recoveryFailed = false;
 

--- a/src/acceptance/hardening.ts
+++ b/src/acceptance/hardening.ts
@@ -1,0 +1,194 @@
+/**
+ * Hardening Pass — test debater-suggested criteria after acceptance passes.
+ *
+ * Non-blocking: failures are informational, never block the pipeline.
+ * Passing criteria are promoted from suggestedCriteria → acceptanceCriteria.
+ */
+
+import type { AgentAdapter } from "../agents/types";
+import { type ModelDef, resolveModelForAgent } from "../config";
+import type { NaxConfig } from "../config";
+import { getSafeLogger } from "../logger";
+import { parseTestFailures } from "../pipeline/stages/acceptance";
+import { savePRD } from "../prd";
+import type { PRD } from "../prd/types";
+import { buildAcceptanceRunCommand } from "./generator";
+import { generateFromPRD } from "./generator";
+import { refineAcceptanceCriteria } from "./refinement";
+import { resolveSuggestedPackageFeatureTestPath } from "./test-path";
+import type { RefinedCriterion } from "./types";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface HardeningResult {
+  /** Suggested ACs that passed — promoted to acceptanceCriteria */
+  promoted: string[];
+  /** Suggested ACs that failed — discarded */
+  discarded: string[];
+  /** Total cost of the hardening pass (USD) */
+  costUsd: number;
+}
+
+export interface HardeningContext {
+  prd: PRD;
+  prdPath: string;
+  featureDir: string;
+  workdir: string;
+  config: NaxConfig;
+  agentGetFn?: (name: string) => AgentAdapter | undefined;
+}
+
+// ─── Injectable deps ────────────────────────────────────────────────────────
+
+export const _hardeningDeps = {
+  refine: refineAcceptanceCriteria,
+  generate: generateFromPRD,
+  savePRD: savePRD,
+  spawn: Bun.spawn as typeof Bun.spawn,
+  writeFile: async (p: string, c: string) => {
+    await Bun.write(p, c);
+  },
+};
+
+// ─── Main runner ────────────────────────────────────────────────────────────
+
+export async function runHardeningPass(ctx: HardeningContext): Promise<HardeningResult> {
+  const logger = getSafeLogger();
+  const result: HardeningResult = { promoted: [], discarded: [], costUsd: 0 };
+
+  // 1. Collect stories with suggestedCriteria
+  const storiesWithSuggested = ctx.prd.userStories.filter((s) => s.suggestedCriteria && s.suggestedCriteria.length > 0);
+  if (storiesWithSuggested.length === 0) return result;
+
+  logger?.info("acceptance", "Starting hardening pass", {
+    storyId: storiesWithSuggested[0].id,
+    storiesWithSuggested: storiesWithSuggested.length,
+    totalSuggestedACs: storiesWithSuggested.reduce((n, s) => n + (s.suggestedCriteria?.length ?? 0), 0),
+  });
+
+  try {
+    // 2. Refine suggested criteria
+    const allRefined: RefinedCriterion[] = [];
+    for (const story of storiesWithSuggested) {
+      const criteria = story.suggestedCriteria ?? [];
+      const refined = await _hardeningDeps.refine(criteria, {
+        storyId: story.id,
+        featureName: ctx.prd.feature,
+        workdir: ctx.workdir,
+        codebaseContext: "",
+        config: ctx.config,
+      });
+      allRefined.push(...refined);
+    }
+
+    // 3. Resolve test path
+    const language = ctx.config.project?.language;
+    const suggestedTestPath = resolveSuggestedPackageFeatureTestPath(
+      ctx.workdir,
+      ctx.prd.feature,
+      ctx.config.acceptance?.suggestedTestPath,
+      language,
+    );
+
+    // 4. Resolve model
+    let modelDef: ModelDef;
+    try {
+      modelDef = resolveModelForAgent(
+        ctx.config.models,
+        ctx.config.autoMode?.defaultAgent ?? "claude",
+        ctx.config.acceptance?.model ?? "fast",
+        ctx.config.autoMode?.defaultAgent ?? "claude",
+      );
+    } catch {
+      modelDef = { provider: "anthropic", model: "claude-haiku-4-5-20251001" };
+    }
+
+    // 5. Generate test file
+    const genResult = await _hardeningDeps.generate(storiesWithSuggested, allRefined, {
+      featureName: ctx.prd.feature,
+      workdir: ctx.workdir,
+      featureDir: ctx.featureDir,
+      codebaseContext: "",
+      modelTier: ctx.config.acceptance?.model ?? "fast",
+      modelDef,
+      config: ctx.config,
+      language,
+      targetTestFile: suggestedTestPath,
+    });
+    // 6. Write test file if returned as code (ACP writes directly)
+    if (genResult.testCode) {
+      await _hardeningDeps.writeFile(suggestedTestPath, genResult.testCode);
+    }
+
+    // 7. Run tests
+    const testCmd = buildAcceptanceRunCommand(
+      suggestedTestPath,
+      ctx.config.project?.testFramework,
+      ctx.config.acceptance?.command,
+    );
+    const proc = _hardeningDeps.spawn(testCmd, {
+      cwd: ctx.workdir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const output = `${stdout}\n${stderr}`;
+
+    // 8. Parse results and promote/discard
+    const failedACs = parseTestFailures(output);
+    const failedSet = new Set(failedACs.map((ac) => ac.toUpperCase()));
+
+    // Map AC indices back to suggested criteria
+    let acIndex = 0;
+    for (const story of storiesWithSuggested) {
+      const suggested = story.suggestedCriteria ?? [];
+      const toPromote: string[] = [];
+      const toDiscard: string[] = [];
+
+      for (const criterion of suggested) {
+        acIndex++;
+        const acId = `AC-${acIndex}`;
+        if (failedSet.has(acId) || (exitCode !== 0 && failedACs.length === 0)) {
+          // Failed or test crashed with no parsed ACs → discard all
+          toDiscard.push(criterion);
+        } else {
+          toPromote.push(criterion);
+        }
+      }
+
+      // Promote passing criteria
+      if (toPromote.length > 0) {
+        story.acceptanceCriteria = [...story.acceptanceCriteria, ...toPromote];
+        result.promoted.push(...toPromote);
+      }
+      result.discarded.push(...toDiscard);
+
+      // Clean up suggestedCriteria
+      story.suggestedCriteria = toDiscard.length > 0 ? toDiscard : undefined;
+    }
+
+    // 9. Save PRD with promotions
+    if (result.promoted.length > 0) {
+      await _hardeningDeps.savePRD(ctx.prd, ctx.prdPath);
+    }
+
+    logger?.info("acceptance", "Hardening pass complete", {
+      storyId: storiesWithSuggested[0].id,
+      promoted: result.promoted.length,
+      discarded: result.discarded.length,
+      costUsd: result.costUsd,
+    });
+  } catch (err) {
+    logger?.warn("acceptance", "Hardening pass failed (non-blocking)", {
+      storyId: storiesWithSuggested[0].id,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return result;
+}

--- a/src/acceptance/test-path.ts
+++ b/src/acceptance/test-path.ts
@@ -73,6 +73,44 @@ export function resolveAcceptanceTestCandidates(options: ResolveAcceptanceTestCa
   return [resolveAcceptanceFeatureTestPath(options.featureDir, options.testPathConfig, options.language)];
 }
 
+// ─── Suggested test path helpers (hardening pass) ───────────────────────────
+
+/**
+ * Return the suggested test filename for a given language.
+ * Mirrors acceptanceTestFilename() but with `.nax-suggested` prefix.
+ */
+export function suggestedTestFilename(language?: string): string {
+  switch (language?.toLowerCase()) {
+    case "go":
+      return ".nax-suggested_test.go";
+    case "python":
+      return ".nax-suggested.test.py";
+    case "rust":
+      return ".nax-suggested.rs";
+    default:
+      return ".nax-suggested.test.ts";
+  }
+}
+
+/**
+ * Resolve suggested test filename based on explicit config override and language.
+ */
+export function resolveSuggestedTestFile(language?: string, testPathConfig?: string): string {
+  return testPathConfig ?? suggestedTestFilename(language);
+}
+
+/**
+ * Resolve package-scoped suggested test absolute path (monorepo aware).
+ */
+export function resolveSuggestedPackageFeatureTestPath(
+  packageDir: string,
+  featureName: string,
+  testPathConfig?: string,
+  language?: string,
+): string {
+  return path.join(packageDir, ".nax", "features", featureName, resolveSuggestedTestFile(language, testPathConfig));
+}
+
 /**
  * Find the first existing acceptance test path from resolved candidates.
  */

--- a/src/acceptance/types.ts
+++ b/src/acceptance/types.ts
@@ -107,6 +107,8 @@ export interface GenerateFromPRDOptions {
   implementationContext?: Array<{ path: string; content: string }>;
   /** Previous failure message — included in prompt to help generator avoid the same mistake */
   previousFailure?: string;
+  /** Override the target test file path in the generator prompt — used by hardening pass for suggested test files */
+  targetTestFile?: string;
 }
 
 export interface GenerateAcceptanceTestsOptions {

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -295,6 +295,10 @@ export interface AcceptanceConfig {
   timeoutMs: number;
   /** Fix configuration for acceptance test failures (US-001) */
   fix: AcceptanceFixConfig;
+  /** Override filename for suggested acceptance tests (hardening pass) */
+  suggestedTestPath?: string;
+  /** Hardening pass configuration — test debater-suggested criteria after acceptance passes */
+  hardening?: { enabled: boolean };
 }
 
 /** Optimizer config (v0.10) */

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -344,6 +344,13 @@ export const AcceptanceConfigSchema = z.object({
     strategy: "diagnose-first",
     maxRetries: 2,
   }),
+  suggestedTestPath: z.string().min(1).optional(),
+  hardening: z
+    .object({
+      enabled: z.boolean().default(true),
+    })
+    .optional()
+    .default({ enabled: true }),
 });
 
 const TestCoverageConfigSchema = z.object({
@@ -755,6 +762,7 @@ export const NaxConfigSchema = z
         strategy: "diagnose-first",
         maxRetries: 2,
       },
+      hardening: { enabled: true },
     }),
     context: ContextConfigSchema.default({
       fileInjection: "disabled",

--- a/src/pipeline/stages/acceptance.ts
+++ b/src/pipeline/stages/acceptance.ts
@@ -29,11 +29,20 @@
  */
 
 import { buildAcceptanceRunCommand } from "../../acceptance/generator";
+import type { HardeningContext } from "../../acceptance/hardening";
 import { resolveAcceptanceFeatureTestPath } from "../../acceptance/test-path";
 import { getLogger } from "../../logger";
 import { countStories } from "../../prd";
 import { logTestOutput } from "../../utils/log-test-output";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
+
+/** Injectable deps for testability */
+export const _acceptanceStageDeps = {
+  runHardeningPass: async (ctx: HardeningContext) => {
+    const { runHardeningPass } = await import("../../acceptance/hardening");
+    return runHardeningPass(ctx);
+  },
+};
 
 /**
  * Parse bun test output to extract failed test names.
@@ -54,7 +63,7 @@ import type { PipelineContext, PipelineStage, StageResult } from "../types";
  * // Returns: ["AC-2"]
  * ```
  */
-function parseTestFailures(output: string): string[] {
+export function parseTestFailures(output: string): string[] {
   const failedACs: string[] = [];
   const lines = output.split("\n");
 
@@ -226,6 +235,34 @@ export const acceptanceStage: PipelineStage = {
     // All packages passed
     if (allFailedACs.length === 0) {
       logger.info("acceptance", "All acceptance tests passed", { storyId: ctx.story.id });
+
+      // Hardening pass: test debater-suggested criteria (non-blocking)
+      const hardeningEnabled = ctx.config.acceptance?.hardening?.enabled !== false;
+      const hasAnySuggested = ctx.prd.userStories.some((s) => s.suggestedCriteria && s.suggestedCriteria.length > 0);
+      if (hardeningEnabled && hasAnySuggested && ctx.featureDir) {
+        try {
+          const prdPath = ctx.prdPath ?? `${ctx.featureDir}/prd.json`;
+          const result = await _acceptanceStageDeps.runHardeningPass({
+            prd: ctx.prd,
+            prdPath,
+            featureDir: ctx.featureDir,
+            workdir: ctx.workdir,
+            config: ctx.config,
+            agentGetFn: ctx.agentGetFn,
+          });
+          logger.info("acceptance", "Hardening pass complete", {
+            storyId: ctx.story.id,
+            promoted: result.promoted.length,
+            discarded: result.discarded.length,
+          });
+        } catch (err) {
+          logger.warn("acceptance", "Hardening pass failed (non-blocking)", {
+            storyId: ctx.story.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
       return { action: "continue" };
     }
 

--- a/src/prd/schema.ts
+++ b/src/prd/schema.ts
@@ -93,6 +93,23 @@ function validateStory(raw: unknown, index: number, allIds: Set<string>): UserSt
     }
   }
 
+  // suggestedCriteria — optional, if present must be non-empty string[]
+  let suggestedCriteria: string[] | undefined;
+  if (s.suggestedCriteria !== undefined && s.suggestedCriteria !== null) {
+    if (!Array.isArray(s.suggestedCriteria)) {
+      throw new Error(`[schema] story[${index}].suggestedCriteria must be an array when present`);
+    }
+    if (s.suggestedCriteria.length > 0) {
+      for (let i = 0; i < s.suggestedCriteria.length; i++) {
+        if (typeof s.suggestedCriteria[i] !== "string") {
+          throw new Error(`[schema] story[${index}].suggestedCriteria[${i}] must be a string`);
+        }
+      }
+      suggestedCriteria = s.suggestedCriteria as string[];
+    }
+    // empty array → stripped to undefined
+  }
+
   // complexity — accept from routing.complexity (PRD format) or top-level complexity (legacy)
   const routing = typeof s.routing === "object" && s.routing !== null ? (s.routing as Record<string, unknown>) : {};
   const rawComplexity = routing.complexity ?? s.complexity;
@@ -194,6 +211,7 @@ function validateStory(raw: unknown, index: number, allIds: Set<string>): UserSt
     },
     ...(workdir !== undefined ? { workdir } : {}),
     ...(contextFiles.length > 0 ? { contextFiles } : {}),
+    ...(suggestedCriteria !== undefined ? { suggestedCriteria } : {}),
   };
 }
 

--- a/src/prd/types.ts
+++ b/src/prd/types.ts
@@ -99,6 +99,8 @@ export interface UserStory {
   description: string;
   /** Acceptance criteria */
   acceptanceCriteria: string[];
+  /** Debater-suggested criteria beyond the spec — tested in hardening pass, never blocks pipeline. */
+  suggestedCriteria?: string[];
   /** Tags for routing (e.g., ["security", "public-api"]) */
   tags: string[];
   /** Dependencies (story IDs that must complete first) */

--- a/test/unit/acceptance/hardening.test.ts
+++ b/test/unit/acceptance/hardening.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { type HardeningContext, _hardeningDeps, runHardeningPass } from "../../../src/acceptance/hardening";
+import type { NaxConfig } from "../../../src/config";
+import type { PRD } from "../../../src/prd/types";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+function makePRD(overrides: Partial<PRD> = {}): PRD {
+  return {
+    project: "test",
+    feature: "test-feature",
+    branchName: "feat/test",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    userStories: [],
+    ...overrides,
+  };
+}
+
+const TEST_CONFIG = {
+  autoMode: { defaultAgent: "claude" },
+  models: {},
+  acceptance: {
+    model: "fast",
+    hardening: { enabled: true },
+  },
+} as unknown as NaxConfig;
+
+function makeCtx(overrides: Partial<HardeningContext> = {}): HardeningContext {
+  return {
+    prd: makePRD(),
+    prdPath: "/tmp/prd.json",
+    featureDir: "/tmp/features/test",
+    workdir: "/tmp/workdir",
+    config: TEST_CONFIG,
+    ...overrides,
+  };
+}
+
+// ─── Dep save/restore ───────────────────────────────────────────────────────
+
+let origRefine: typeof _hardeningDeps.refine;
+let origGenerate: typeof _hardeningDeps.generate;
+let origSavePRD: typeof _hardeningDeps.savePRD;
+let origSpawn: typeof _hardeningDeps.spawn;
+let origWriteFile: typeof _hardeningDeps.writeFile;
+
+beforeEach(() => {
+  origRefine = _hardeningDeps.refine;
+  origGenerate = _hardeningDeps.generate;
+  origSavePRD = _hardeningDeps.savePRD;
+  origSpawn = _hardeningDeps.spawn;
+  origWriteFile = _hardeningDeps.writeFile;
+});
+
+afterEach(() => {
+  _hardeningDeps.refine = origRefine;
+  _hardeningDeps.generate = origGenerate;
+  _hardeningDeps.savePRD = origSavePRD;
+  _hardeningDeps.spawn = origSpawn;
+  _hardeningDeps.writeFile = origWriteFile;
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("runHardeningPass()", () => {
+  test("returns empty result when no stories have suggestedCriteria", async () => {
+    const ctx = makeCtx({
+      prd: makePRD({
+        userStories: [
+          {
+            id: "US-001",
+            title: "Story",
+            description: "Desc",
+            acceptanceCriteria: ["AC-1"],
+            tags: [],
+            dependencies: [],
+            status: "passed",
+            passes: true,
+            escalations: [],
+            attempts: 1,
+          },
+        ],
+      }),
+    });
+
+    const result = await runHardeningPass(ctx);
+
+    expect(result.promoted).toEqual([]);
+    expect(result.discarded).toEqual([]);
+    expect(result.costUsd).toBe(0);
+  });
+
+  test("promotes passing suggested criteria to acceptanceCriteria", async () => {
+    const story = {
+      id: "US-001",
+      title: "Story",
+      description: "Desc",
+      acceptanceCriteria: ["spec AC"],
+      suggestedCriteria: ["suggested edge case"],
+      tags: [],
+      dependencies: [],
+      status: "passed" as const,
+      passes: true,
+      escalations: [],
+      attempts: 1,
+    };
+    const prd = makePRD({ userStories: [story] });
+    const ctx = makeCtx({ prd });
+
+    _hardeningDeps.refine = mock(async (criteria: string[]) =>
+      criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: "US-001" })),
+    );
+    _hardeningDeps.generate = mock(async () => ({
+      testCode: 'test("AC-1", () => {})',
+      criteria: [{ id: "AC-1", text: "suggested edge case", lineNumber: 1 }],
+    }));
+    _hardeningDeps.writeFile = mock(async () => {});
+    _hardeningDeps.savePRD = mock(async () => {});
+    _hardeningDeps.spawn = mock(() => {
+      return {
+        exited: Promise.resolve(0),
+        stdout: new ReadableStream({
+          start(ctrl) {
+            ctrl.enqueue(new TextEncoder().encode("(pass) AC-1: suggested edge case\n"));
+            ctrl.close();
+          },
+        }),
+        stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+      } as ReturnType<typeof Bun.spawn>;
+    });
+
+    const result = await runHardeningPass(ctx);
+
+    expect(result.promoted).toEqual(["suggested edge case"]);
+    expect(result.discarded).toEqual([]);
+    expect(story.acceptanceCriteria).toContain("suggested edge case");
+    expect(story.suggestedCriteria).toBeUndefined();
+    expect(_hardeningDeps.savePRD).toHaveBeenCalledTimes(1);
+  });
+
+  test("discards failing suggested criteria", async () => {
+    const story = {
+      id: "US-001",
+      title: "Story",
+      description: "Desc",
+      acceptanceCriteria: ["spec AC"],
+      suggestedCriteria: ["failing edge case"],
+      tags: [],
+      dependencies: [],
+      status: "passed" as const,
+      passes: true,
+      escalations: [],
+      attempts: 1,
+    };
+    const prd = makePRD({ userStories: [story] });
+    const ctx = makeCtx({ prd });
+
+    _hardeningDeps.refine = mock(async (criteria: string[]) =>
+      criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: "US-001" })),
+    );
+    _hardeningDeps.generate = mock(async () => ({
+      testCode: 'test("AC-1", () => {})',
+      criteria: [{ id: "AC-1", text: "failing edge case", lineNumber: 1 }],
+    }));
+    _hardeningDeps.writeFile = mock(async () => {});
+    _hardeningDeps.savePRD = mock(async () => {});
+    _hardeningDeps.spawn = mock(() => {
+      return {
+        exited: Promise.resolve(1),
+        stdout: new ReadableStream({
+          start(ctrl) {
+            ctrl.enqueue(new TextEncoder().encode("(fail) AC-1: failing edge case\n"));
+            ctrl.close();
+          },
+        }),
+        stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+      } as ReturnType<typeof Bun.spawn>;
+    });
+
+    const result = await runHardeningPass(ctx);
+
+    expect(result.promoted).toEqual([]);
+    expect(result.discarded).toEqual(["failing edge case"]);
+    expect(story.acceptanceCriteria).toEqual(["spec AC"]);
+    expect(story.suggestedCriteria).toEqual(["failing edge case"]);
+    expect(_hardeningDeps.savePRD).not.toHaveBeenCalled();
+  });
+
+  test("does not throw on error — returns partial result", async () => {
+    const story = {
+      id: "US-001",
+      title: "Story",
+      description: "Desc",
+      acceptanceCriteria: ["spec AC"],
+      suggestedCriteria: ["edge case"],
+      tags: [],
+      dependencies: [],
+      status: "passed" as const,
+      passes: true,
+      escalations: [],
+      attempts: 1,
+    };
+    const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
+
+    _hardeningDeps.refine = mock(async () => {
+      throw new Error("refine failed");
+    });
+
+    const result = await runHardeningPass(ctx);
+
+    // Should not throw, returns empty result
+    expect(result.promoted).toEqual([]);
+    expect(result.discarded).toEqual([]);
+  });
+});

--- a/test/unit/acceptance/test-path.test.ts
+++ b/test/unit/acceptance/test-path.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveSuggestedPackageFeatureTestPath,
+  resolveSuggestedTestFile,
+  suggestedTestFilename,
+} from "../../../src/acceptance/test-path";
+
+describe("suggestedTestFilename()", () => {
+  test("returns .nax-suggested.test.ts for TypeScript (default)", () => {
+    expect(suggestedTestFilename()).toBe(".nax-suggested.test.ts");
+    expect(suggestedTestFilename("typescript")).toBe(".nax-suggested.test.ts");
+  });
+
+  test("returns .nax-suggested_test.go for Go", () => {
+    expect(suggestedTestFilename("go")).toBe(".nax-suggested_test.go");
+  });
+
+  test("returns .nax-suggested.test.py for Python", () => {
+    expect(suggestedTestFilename("python")).toBe(".nax-suggested.test.py");
+  });
+
+  test("returns .nax-suggested.rs for Rust", () => {
+    expect(suggestedTestFilename("rust")).toBe(".nax-suggested.rs");
+  });
+});
+
+describe("resolveSuggestedTestFile()", () => {
+  test("uses config override when provided", () => {
+    expect(resolveSuggestedTestFile("go", "custom-suggested.test.ts")).toBe("custom-suggested.test.ts");
+  });
+
+  test("falls back to language default when no config override", () => {
+    expect(resolveSuggestedTestFile("go")).toBe(".nax-suggested_test.go");
+    expect(resolveSuggestedTestFile()).toBe(".nax-suggested.test.ts");
+  });
+});
+
+describe("resolveSuggestedPackageFeatureTestPath()", () => {
+  test("returns correct monorepo path", () => {
+    const result = resolveSuggestedPackageFeatureTestPath("/project/apps/api", "auth-feature");
+    expect(result).toBe("/project/apps/api/.nax/features/auth-feature/.nax-suggested.test.ts");
+  });
+
+  test("respects language", () => {
+    const result = resolveSuggestedPackageFeatureTestPath("/project", "feat", undefined, "go");
+    expect(result).toBe("/project/.nax/features/feat/.nax-suggested_test.go");
+  });
+
+  test("respects config override", () => {
+    const result = resolveSuggestedPackageFeatureTestPath("/project", "feat", "custom.test.ts");
+    expect(result).toBe("/project/.nax/features/feat/custom.test.ts");
+  });
+});

--- a/test/unit/prd/schema.test.ts
+++ b/test/unit/prd/schema.test.ts
@@ -490,3 +490,40 @@ describe("validatePlanOutput — ENH-006 analysis and contextFiles", () => {
     expect(prd.userStories[0].contextFiles).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// suggestedCriteria validation
+// ---------------------------------------------------------------------------
+
+describe("suggestedCriteria", () => {
+  test("absent — validates and omits field", () => {
+    const prd = validatePlanOutput(makeInput([makeStory()]), "feat", "feat/feat");
+    expect(prd.userStories[0].suggestedCriteria).toBeUndefined();
+  });
+
+  test("valid string[] — passes through", () => {
+    const story = makeStory({ suggestedCriteria: ["edge case A", "edge case B"] });
+    const prd = validatePlanOutput(makeInput([story]), "feat", "feat/feat");
+    expect(prd.userStories[0].suggestedCriteria).toEqual(["edge case A", "edge case B"]);
+  });
+
+  test("empty array — stripped to undefined", () => {
+    const story = makeStory({ suggestedCriteria: [] });
+    const prd = validatePlanOutput(makeInput([story]), "feat", "feat/feat");
+    expect(prd.userStories[0].suggestedCriteria).toBeUndefined();
+  });
+
+  test("non-string elements — throws", () => {
+    const story = makeStory({ suggestedCriteria: ["valid", 42] });
+    expect(() => validatePlanOutput(makeInput([story]), "feat", "feat/feat")).toThrow(
+      "suggestedCriteria[1] must be a string",
+    );
+  });
+
+  test("non-array — throws", () => {
+    const story = makeStory({ suggestedCriteria: "not an array" });
+    expect(() => validatePlanOutput(makeInput([story]), "feat", "feat/feat")).toThrow(
+      "suggestedCriteria must be an array",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `suggestedCriteria?: string[]` to `UserStory` schema with validation (optional, empty array stripped)
- Add language-aware suggested test path helpers (`.nax-suggested.test.ts`, `_test.go`, `.test.py`, `.rs`)
- Add `acceptance.hardening` and `acceptance.suggestedTestPath` config fields
- Implement `runHardeningPass()` in `src/acceptance/hardening.ts` — refine → generate → run → parse → promote
- Wire hardening into acceptance stage after main pass (non-blocking, try/catch wrapped)
- Export `parseTestFailures()` from acceptance stage for reuse
- Add `targetTestFile` option to `GenerateFromPRDOptions` for path override

Closes #327

## Changes

| File | Change |
|------|--------|
| `src/prd/types.ts` | Add `suggestedCriteria?: string[]` to `UserStory` |
| `src/prd/schema.ts` | Add validation (optional, non-empty string[], empty → stripped) |
| `src/acceptance/test-path.ts` | Add `suggestedTestFilename()`, `resolveSuggestedTestFile()`, `resolveSuggestedPackageFeatureTestPath()` |
| `src/acceptance/types.ts` | Add `targetTestFile?: string` to `GenerateFromPRDOptions` |
| `src/acceptance/generator.ts` | Use `targetTestFile` in path anchor + BUG-076 fallback |
| `src/acceptance/hardening.ts` | **New** — `runHardeningPass()` + `_hardeningDeps` + `HardeningResult` |
| `src/config/schemas.ts` | Add `suggestedTestPath`, `hardening` to `AcceptanceConfigSchema` |
| `src/config/runtime-types.ts` | Add `suggestedTestPath?`, `hardening?` to `AcceptanceConfig` |
| `src/pipeline/stages/acceptance.ts` | Export `parseTestFailures()`, add `_acceptanceStageDeps`, wire hardening after main pass |

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test test/unit/prd/schema.test.ts` — 73 pass (+5 new)
- [x] `bun test test/unit/acceptance/test-path.test.ts` — 9 pass (new file)
- [x] `bun test test/unit/acceptance/hardening.test.ts` — 4 pass (new file)
- [x] `bun run test` — 1200+ pass, 0 fail
- [ ] Re-run bench with `suggestedCriteria` in PRD — verify hardening promotes passing ACs