### PR TITLE
fix(acceptance): wire previousFailure through test regeneration

### DIFF
--- a/src/execution/lifecycle/acceptance-loop.ts
+++ b/src/execution/lifecycle/acceptance-loop.ts
@@ -177,6 +177,7 @@ export const _acceptanceLoopDeps = {
   executeTestRegen: async (
     ctx: AcceptanceLoopContext,
     acceptanceContext: PipelineContext,
+    previousFailure?: string,
   ): Promise<"passed" | "failed" | "no_test_file"> => {
     const testPath = await findExistingAcceptanceTestPathFromOptions({
       acceptanceTestPaths: ctx.acceptanceTestPaths,
@@ -185,7 +186,7 @@ export const _acceptanceLoopDeps = {
       language: ctx.config.project?.language,
     });
     if (!testPath) return "no_test_file";
-    const regenerated = await regenerateAcceptanceTest(testPath, acceptanceContext);
+    const regenerated = await regenerateAcceptanceTest(testPath, acceptanceContext, previousFailure);
     if (!regenerated) return "failed";
     const { acceptanceStage } = await import("../../pipeline/stages/acceptance");
     const result = await acceptanceStage.execute(acceptanceContext);
@@ -315,7 +316,11 @@ async function executeFixStory(
  *
  * @returns true if regeneration succeeded, false otherwise
  */
-export async function regenerateAcceptanceTest(testPath: string, acceptanceContext: PipelineContext): Promise<boolean> {
+export async function regenerateAcceptanceTest(
+  testPath: string,
+  acceptanceContext: PipelineContext,
+  previousFailure?: string,
+): Promise<boolean> {
   const logger = getSafeLogger();
   const bakPath = `${testPath}.bak`;
 
@@ -376,9 +381,13 @@ export async function regenerateAcceptanceTest(testPath: string, acceptanceConte
     }
   }
 
-  const contextForSetup: PipelineContext & { implementationContext?: Array<{ path: string; content: string }> } = {
+  const contextForSetup: PipelineContext & {
+    implementationContext?: Array<{ path: string; content: string }>;
+    previousFailure?: string;
+  } = {
     ...acceptanceContext,
     ...(implementationContext ? { implementationContext } : {}),
+    ...(previousFailure ? { previousFailure } : {}),
   };
 
   await _regenerateDeps.acceptanceSetupExecute(contextForSetup as PipelineContext);
@@ -456,7 +465,8 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
       };
     }
 
-    const regenOutcome = await _acceptanceLoopDeps.executeTestRegen(ctx, acceptanceContext);
+    const semanticFailureContext = `All semantic verdicts passed (${verdictCount} stories) but acceptance tests failed. This is a test generation bug, not a source bug.\n\nFailing test output:\n${failures.testOutput}`;
+    const regenOutcome = await _acceptanceLoopDeps.executeTestRegen(ctx, acceptanceContext, semanticFailureContext);
     logger?.info("acceptance.test-regen", "Test regeneration completed", { storyId, outcome: regenOutcome });
 
     if (regenOutcome === "passed") {
@@ -652,7 +662,8 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
       return { fixed: false, cost: diagnosisCost, prdDirty: false };
     }
 
-    const regenerated = await regenerateAcceptanceTest(testPath, acceptanceContext as PipelineContext);
+    const failureContext = `Diagnosis: ${diagnosis.reasoning}\n\nFailing test output:\n${failures.testOutput}`;
+    const regenerated = await regenerateAcceptanceTest(testPath, acceptanceContext as PipelineContext, failureContext);
 
     logger?.info("acceptance.test-regen", "Test regeneration completed", {
       outcome: regenerated ? "success" : "failure",
@@ -765,7 +776,12 @@ export async function runFixRouting(options: FixRoutingOptions): Promise<FixRout
       return { fixed: false, cost: sourceFixCost + diagnosisCost, prdDirty: false };
     }
 
-    const regenerated = await regenerateAcceptanceTest(testPath, acceptanceContext as PipelineContext);
+    const bothFailureContext = `Diagnosis: ${diagnosis.reasoning}\n\nFailing test output:\n${failures.testOutput}`;
+    const regenerated = await regenerateAcceptanceTest(
+      testPath,
+      acceptanceContext as PipelineContext,
+      bothFailureContext,
+    );
 
     logger?.info("acceptance.test-regen", "Test regeneration completed", {
       outcome: regenerated ? "success" : "failure",
@@ -934,7 +950,8 @@ export async function runAcceptanceLoop(ctx: AcceptanceLoopContext): Promise<Acc
         language: ctx.config.project?.language,
       });
       if (testPath) {
-        const regenerated = await regenerateAcceptanceTest(testPath, acceptanceContext);
+        const testLevelFailureContext = `Test-level failure: ${failures.failedACs.length}/${totalACs} ACs failed.\n\nFailing test output:\n${failures.testOutput}`;
+        const regenerated = await regenerateAcceptanceTest(testPath, acceptanceContext, testLevelFailureContext);
         if (!regenerated) {
           return buildResult(
             false,

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -341,6 +341,9 @@ export const acceptanceSetupStage: PipelineStage = {
           ...("implementationContext" in ctx && ctx.implementationContext
             ? { implementationContext: ctx.implementationContext as Array<{ path: string; content: string }> }
             : {}),
+          ...("previousFailure" in ctx && ctx.previousFailure
+            ? { previousFailure: ctx.previousFailure as string }
+            : {}),
         });
 
         await _acceptanceSetupDeps.writeFile(testPath, result.testCode);


### PR DESCRIPTION
## Summary

- Thread `previousFailure` (diagnosis reasoning + test output) through all 4 `regenerateAcceptanceTest` call sites → `acceptance-setup.ts` → `generateFromPRD`
- The generator already supports `previousFailure` in its prompt (`"Previous test failed because: ..."`), but the wiring from diagnosis to generator was missing

## Problem

When acceptance tests fail and diagnosis correctly identifies `test_bug` (e.g. wrong JSON indentation assertion), the regeneration path calls `generateFromPRD` **without any context about what went wrong**. The LLM produces the same broken assertions every time — bench-04 showed AC-6/AC-7/AC-9 failing identically before and after regeneration.

## Fix

| Call site | Context passed |
|-----------|---------------|
| `test_bug` diagnosis path | `diagnosis.reasoning` + `failures.testOutput` |
| `both` (source + test) path | `diagnosis.reasoning` + `failures.testOutput` |
| Test-level failure (>80% ACs fail) | `failures.testOutput` (no diagnosis available) |
| Semantic verdict fast path | Verdict context + `failures.testOutput` |

## Changes

| File | Change |
|------|--------|
| `src/execution/lifecycle/acceptance-loop.ts` | Add `previousFailure?: string` param to `regenerateAcceptanceTest()` and `executeTestRegen()`, thread at all 4 call sites |
| `src/pipeline/stages/acceptance-setup.ts` | Forward `ctx.previousFailure` to `generateFromPRD` options (same pattern as `implementationContext`) |

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test test/unit/execution/ test/unit/acceptance/ test/unit/pipeline/` — 1361 pass
- [x] `bun run test` — 1200+ pass, 0 fail
- [ ] Re-run bench-04 — verify regenerated test avoids the same assertion bug