### PR TITLE
fix(completion): write semantic verdict for every story in batch

### DIFF
--- a/src/pipeline/stages/completion.ts
+++ b/src/pipeline/stages/completion.ts
@@ -93,19 +93,20 @@ export const completionStage: PipelineStage = {
           logger.warn("completion", "Story marked for re-review", { storyId: completedStory.id });
         }
       }
-    }
 
-    // Persist semantic verdict if a semantic check was run (AC-4 through AC-7)
-    const semanticCheck = ctx.reviewResult?.checks?.find((c) => c.check === "semantic");
-    if (ctx.featureDir && semanticCheck) {
-      const verdict: SemanticVerdict = {
-        storyId: ctx.story.id,
-        passed: semanticCheck.success,
-        timestamp: new Date().toISOString(),
-        acCount: ctx.story.acceptanceCriteria?.length ?? 0,
-        findings: semanticCheck.success ? [] : (semanticCheck.findings ?? []),
-      };
-      await _completionDeps.persistSemanticVerdict(ctx.featureDir, ctx.story.id, verdict);
+      // Persist semantic verdict for this story (AC-4 through AC-7)
+      // Must be inside the loop so every story in a batch gets its own verdict file.
+      const semanticCheck = ctx.reviewResult?.checks?.find((c) => c.check === "semantic");
+      if (ctx.featureDir && semanticCheck) {
+        const verdict: SemanticVerdict = {
+          storyId: completedStory.id,
+          passed: semanticCheck.success,
+          timestamp: new Date().toISOString(),
+          acCount: completedStory.acceptanceCriteria?.length ?? 0,
+          findings: semanticCheck.success ? [] : (semanticCheck.findings ?? []),
+        };
+        await _completionDeps.persistSemanticVerdict(ctx.featureDir, completedStory.id, verdict);
+      }
     }
 
     // Save PRD

--- a/test/unit/pipeline/stages/completion-semantic.test.ts
+++ b/test/unit/pipeline/stages/completion-semantic.test.ts
@@ -159,6 +159,31 @@ describe("completionStage — semantic verdict persistence (AC-4)", () => {
     });
   });
 
+  test("writes a verdict file for each story in a batch (2 stories → 2 calls)", async () => {
+    await withTempDir(async (tempDir) => {
+      const { completionStage } = await import("../../../../src/pipeline/stages/completion");
+
+      const persistCalls: string[] = [];
+      _completionDeps.persistSemanticVerdict = mock(async (_dir, storyId) => {
+        persistCalls.push(storyId);
+      });
+
+      const story1 = makeStory("US-001");
+      const story2 = makeStory("US-002");
+      const prd: PRD = { ...makePRD(), userStories: [story1, story2] };
+      const ctx = makeCtx(tempDir, makeReviewResult({ semanticSuccess: true }));
+      ctx.story = story1;
+      (ctx as any).stories = [story1, story2];
+      (ctx as any).prd = prd;
+
+      await completionStage.execute(ctx);
+
+      expect(persistCalls).toHaveLength(2);
+      expect(persistCalls).toContain("US-001");
+      expect(persistCalls).toContain("US-002");
+    });
+  });
+
   test("passes verdict with correct storyId to persistSemanticVerdict", async () => {
     await withTempDir(async (tempDir) => {
       const { completionStage } = await import("../../../../src/pipeline/stages/completion");


### PR DESCRIPTION
## Summary

- Semantic verdict write block was outside the story loop, using `ctx.story.id` (batch leader) — only one file written per batch regardless of how many stories ran
- In bench-04 v0.60.2 (2 stories, both passing), only `US-002.json` existed in `semantic-verdicts/`; `US-001.json` was missing
- Downstream impact: `resolveAcceptanceDiagnosis()` fast-path ("all verdicts passed → test_bug") couldn't fire for stories with missing verdict files, causing an unnecessary LLM diagnosis call

Fixes #342

## Change

**`src/pipeline/stages/completion.ts`** — moved the `persistSemanticVerdict` call inside the `for (const completedStory of ctx.stories)` loop; replaced `ctx.story.id` and `ctx.story.acceptanceCriteria` with `completedStory.id` and `completedStory.acceptanceCriteria`.

**`test/unit/pipeline/stages/completion-semantic.test.ts`** — new batch test: `ctx.stories = [US-001, US-002]` → `persistSemanticVerdict` called twice, once per storyId.

## Test plan

- [x] `bun test test/unit/pipeline/stages/completion-semantic.test.ts` — 13 tests pass (1 new)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Re-run bench-04: both `semantic-verdicts/US-001.json` and `semantic-verdicts/US-002.json` exist after completion