### PR TITLE
fix(plan): add spec anchor rules to non-debate plan prompt

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -20,7 +20,13 @@ import type { CodebaseScan } from "../analyze/types";
 import type { NaxConfig } from "../config";
 import { resolvePermissions } from "../config/permissions";
 import type { ProjectProfile } from "../config/runtime-types";
-import { COMPLEXITY_GUIDE, GROUPING_RULES, TEST_STRATEGY_GUIDE, getAcQualityRules } from "../config/test-strategy";
+import {
+  COMPLEXITY_GUIDE,
+  GROUPING_RULES,
+  SPEC_ANCHOR_RULES,
+  TEST_STRATEGY_GUIDE,
+  getAcQualityRules,
+} from "../config/test-strategy";
 import { discoverWorkspacePackages } from "../context/generator";
 import { DebateSession } from "../debate";
 import type { DebateSessionOptions, DebateStageConfig } from "../debate";
@@ -635,6 +641,8 @@ export function buildPlanningPrompt(
     ? `\n      "workdir": "string — optional, relative path to package (e.g. \\"packages/api\\"). Omit for root-level stories.",`
     : "";
 
+  const specAnchorSection = specContent.trim() ? `\n\n${SPEC_ANCHOR_RULES}` : "";
+
   const taskContext = `You are a senior software architect generating a product requirements document (PRD) as JSON.
 
 ## Step 1: Understand the Spec
@@ -675,7 +683,7 @@ Based on your Step 2 analysis, create stories that produce CODE CHANGES.
 
 ${GROUPING_RULES}
 
-${getAcQualityRules(projectProfile)}
+${getAcQualityRules(projectProfile)}${specAnchorSection}
 
 For each story, set "contextFiles" to the key source files the agent should read before implementing (max 5 per story). Use your Step 2 analysis to identify the most relevant files. Leave empty for greenfield stories with no existing files to reference.
 
@@ -699,7 +707,7 @@ Generate a JSON object with this exact structure (no markdown, no explanation �
       "id": "string — e.g. US-001",
       "title": "string — concise story title",
       "description": "string — detailed description of the story",
-      "acceptanceCriteria": ["string — behavioral, testable criteria. Format: 'When [X], then [Y]'. One assertion per AC. Never include quality gates."],
+      "acceptanceCriteria": ["string — behavioral, testable criteria. Format: 'When [X], then [Y]'. One assertion per AC. Never include quality gates."],${specContent.trim() ? `\n      "suggestedCriteria": ["string — optional. Behavioral edge cases or negative paths you identified that are NOT in the spec. Plain assertions only — observable outputs, return values, state changes, or error conditions. No implementation details or vague descriptions. Omit this field if empty."],` : ""}
       "contextFiles": ["string — key source files the agent should read (max 5, relative paths)"],
       "tags": ["string — routing tags, e.g. feature, security, api"],
       "dependencies": ["string — story IDs this story depends on"],${workdirField}

--- a/src/config/test-strategy.ts
+++ b/src/config/test-strategy.ts
@@ -152,6 +152,19 @@ export function getAcQualityRules(profile?: ProjectProfile): string {
   return `${AC_QUALITY_RULES}\n\n${extras}`;
 }
 
+/**
+ * Spec fidelity rules — injected into buildPlanningPrompt() when a spec is provided.
+ * Mirrors the synthesis anchor in session-plan.ts (debate mode) but for non-debate plan runs.
+ */
+export const SPEC_ANCHOR_RULES = `## Spec Fidelity Rules
+
+When a spec is provided, these rules govern acceptance criteria generation:
+
+1. **Preserve spec ACs.** Every acceptance criterion stated in the spec must appear in \`acceptanceCriteria\`, verbatim or lightly rephrased for testability. Never silently drop a spec AC.
+2. **Do not invent spec ACs.** If you identify useful behavioral edge cases or negative paths that the spec did not explicitly list, place them in \`suggestedCriteria\` (a string array on the same story object) — never in \`acceptanceCriteria\`. These go through a separate hardening pass.
+3. **Respect story scope.** Each story's criteria must only cover what the spec says for that story. Do not assign criteria that belong to a different story's scope (wrong feature area, wrong file, wrong dependency chain).
+4. **\`suggestedCriteria\` format.** Each element must be a plain behavioral assertion — an observable output, return value, state change, or error condition that a test can assert. Never include implementation details (imports, internal structure), design suggestions, or vague descriptions.`;
+
 export const GROUPING_RULES = `## Story Rules
 
 - Every story must produce code changes verifiable by tests or review.

--- a/test/unit/cli/plan.test.ts
+++ b/test/unit/cli/plan.test.ts
@@ -610,3 +610,45 @@ describe("buildPlanningPrompt (ENH-006)", () => {
     expect(outputFormat).not.toContain("Step 1");
   });
 });
+
+// ─── fix #346: spec anchor rules (non-debate plan mode) ──────────────────────
+
+describe("buildPlanningPrompt — spec anchor (fix #346)", () => {
+  const spec = "## Acceptance Criteria\n- AC-1: Returns 200 when project exists";
+  const ctx = "## Codebase Structure\nsrc/projects/projects.service.ts";
+
+  test("spec anchor rules included in taskContext when specContent is non-empty", () => {
+    const { taskContext } = buildPlanningPrompt(spec, ctx);
+    expect(taskContext).toContain("Preserve spec ACs");
+  });
+
+  test("spec anchor rules NOT included when specContent is empty string", () => {
+    const { taskContext } = buildPlanningPrompt("", ctx);
+    expect(taskContext).not.toContain("Preserve spec ACs");
+  });
+
+  test("taskContext tells planner to put invented ACs in suggestedCriteria", () => {
+    const { taskContext } = buildPlanningPrompt(spec, ctx);
+    expect(taskContext).toContain("suggestedCriteria");
+  });
+
+  test("outputFormat schema includes suggestedCriteria field when spec is provided", () => {
+    const { outputFormat } = buildPlanningPrompt(spec, ctx);
+    expect(outputFormat).toContain("suggestedCriteria");
+  });
+
+  test("outputFormat schema does NOT include suggestedCriteria when spec is empty", () => {
+    const { outputFormat } = buildPlanningPrompt("", ctx);
+    expect(outputFormat).not.toContain("suggestedCriteria");
+  });
+
+  test("taskContext instructs planner to never drop a spec AC", () => {
+    const { taskContext } = buildPlanningPrompt(spec, ctx);
+    expect(taskContext).toContain("Never silently drop");
+  });
+
+  test("taskContext instructs planner to keep story scope — no cross-story ACs", () => {
+    const { taskContext } = buildPlanningPrompt(spec, ctx);
+    expect(taskContext).toContain("story scope");
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause:** `buildPlanningPrompt()` had AC quality rules (format, no vague verbs) but no constraint on *which* ACs to generate — the LLM was free to drop spec ACs, invent new ones, and leak criteria across stories
- **Fix:** Added `SPEC_ANCHOR_RULES` to `src/config/test-strategy.ts` and injected it into `buildPlanningPrompt()` when `specContent` is non-empty; also added `suggestedCriteria` to the output schema so the LLM has a sanctioned channel for edge cases it identifies
- **Scope:** Only activates when a spec is provided (`nax run --plan --spec`); zero impact on spec-free plan calls

## Observed symptoms (bench-04 v0.60.2)

US-001 in SPEC-graphify-kb.md had 8 spec ACs; the generated PRD had 11:
- 1 spec AC silently dropped (`IndexDocumentInput.source` type union)
- 2 ACs invented and promoted directly to `acceptanceCriteria` (negative validation case, `graphifyImportSuccess` i18n — the latter belonging to US-003)
- `suggestedCriteria` was `null` — no hardening gate applied

## Test plan

- [x] `bun test test/unit/cli/plan.test.ts` — 39 tests pass (7 new spec-anchor tests)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Re-run `nax run --plan --spec docs/specs/SPEC-graphify-kb.md` and verify US-001 has exactly the spec's 8 ACs in `acceptanceCriteria` and any edge cases land in `suggestedCriteria`

Fixes #346