### PR TITLE
fix(acceptance): suggestedCriteria hardening follow-up gaps (#336)

### DIFF
--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -239,6 +239,7 @@ Rules:
     featureName: options.featureName,
     sessionRole: "acceptance-gen",
   });
+  const genCostUsd = typeof completeResult === "string" ? 0 : (completeResult.costUsd ?? 0);
   const rawOutput = typeof completeResult === "string" ? completeResult : completeResult.output;
   let testCode = extractTestCode(rawOutput);
 
@@ -366,6 +367,7 @@ Rules:
     return {
       testCode: generateSkeletonTests(options.featureName, skeletonCriteria, options.testFramework, options.language),
       criteria: skeletonCriteria,
+      costUsd: genCostUsd,
     };
   }
 
@@ -383,7 +385,7 @@ Rules:
 
   await _generatorPRDDeps.writeFile(join(options.featureDir, "acceptance-refined.json"), refinedJsonContent);
 
-  return { testCode, criteria };
+  return { testCode, criteria, costUsd: genCostUsd };
 }
 
 export function parseAcceptanceCriteria(specContent: string): AcceptanceCriterion[] {

--- a/src/acceptance/hardening.ts
+++ b/src/acceptance/hardening.ts
@@ -148,24 +148,31 @@ export async function runHardeningPass(ctx: HardeningContext): Promise<Hardening
     const failedACs = parseTestFailures(output);
     const failedSet = new Set(failedACs.map((ac) => ac.toUpperCase()));
 
-    // Map AC indices back to suggested criteria
-    // allRefined is in the same iteration order, so allRefined[acIndex - 1] is the
-    // refined version of criterion at position acIndex (1-based).
+    // Group allRefined by storyId so the mapping loop is driven by the refined
+    // criteria (not the original suggestedCriteria). This prevents AC index drift
+    // if refineAcceptanceCriteria ever changes the criterion count (#336 gap 4).
+    const refinedByStory = new Map<string, RefinedCriterion[]>();
+    for (const r of allRefined) {
+      const list = refinedByStory.get(r.storyId) ?? [];
+      list.push(r);
+      refinedByStory.set(r.storyId, list);
+    }
+
     let acIndex = 0;
     for (const story of storiesWithSuggested) {
-      const suggested = story.suggestedCriteria ?? [];
+      const storyRefined = refinedByStory.get(story.id) ?? [];
       const toPromote: string[] = [];
       const toDiscard: string[] = [];
 
-      for (const criterion of suggested) {
+      for (const refinedCriterion of storyRefined) {
         acIndex++;
         const acId = `AC-${acIndex}`;
-        const nonTestable = allRefined[acIndex - 1]?.testable === false;
+        const nonTestable = refinedCriterion.testable === false;
         if (nonTestable || failedSet.has(acId) || (exitCode !== 0 && failedACs.length === 0)) {
           // Discard: non-testable implementation detail, failed, or test crashed
-          toDiscard.push(criterion);
+          toDiscard.push(refinedCriterion.original);
         } else {
-          toPromote.push(criterion);
+          toPromote.push(refinedCriterion.original);
         }
       }
 

--- a/src/acceptance/hardening.ts
+++ b/src/acceptance/hardening.ts
@@ -176,9 +176,10 @@ export async function runHardeningPass(ctx: HardeningContext): Promise<Hardening
         }
       }
 
-      // Promote passing criteria
+      // Promote passing criteria — deduplicate against existing ACs (#336 gap 5)
       if (toPromote.length > 0) {
-        story.acceptanceCriteria = [...story.acceptanceCriteria, ...toPromote];
+        const existingACs = new Set(story.acceptanceCriteria);
+        story.acceptanceCriteria = [...story.acceptanceCriteria, ...toPromote.filter((ac) => !existingACs.has(ac))];
         result.promoted.push(...toPromote);
       }
       result.discarded.push(...toDiscard);

--- a/src/acceptance/hardening.ts
+++ b/src/acceptance/hardening.ts
@@ -71,7 +71,7 @@ export async function runHardeningPass(ctx: HardeningContext): Promise<Hardening
     const allRefined: RefinedCriterion[] = [];
     for (const story of storiesWithSuggested) {
       const criteria = story.suggestedCriteria ?? [];
-      const refined = await _hardeningDeps.refine(criteria, {
+      const refineResult = await _hardeningDeps.refine(criteria, {
         storyId: story.id,
         featureName: ctx.prd.feature,
         workdir: ctx.workdir,
@@ -80,7 +80,8 @@ export async function runHardeningPass(ctx: HardeningContext): Promise<Hardening
         storyTitle: story.title,
         storyDescription: story.description,
       });
-      allRefined.push(...refined);
+      allRefined.push(...refineResult.criteria);
+      result.costUsd += refineResult.costUsd;
     }
 
     // 3. Resolve test path
@@ -117,6 +118,8 @@ export async function runHardeningPass(ctx: HardeningContext): Promise<Hardening
       language,
       targetTestFile: suggestedTestPath,
     });
+    result.costUsd += genResult.costUsd ?? 0;
+
     // 6. Write test file if returned as code (ACP writes directly)
     if (genResult.testCode) {
       await _hardeningDeps.writeFile(suggestedTestPath, genResult.testCode);

--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -11,7 +11,7 @@ import { resolveModelForAgent } from "../config";
 import { getLogger } from "../logger";
 import { errorMessage } from "../utils/errors";
 import { extractJsonFromMarkdown, stripTrailingCommas, wrapJsonPrompt } from "../utils/llm-json";
-import type { RefinedCriterion, RefinementContext } from "./types";
+import type { RefineResult, RefinedCriterion, RefinementContext } from "./types";
 
 /**
  * Injectable dependencies — allows tests to mock adapter.complete()
@@ -187,12 +187,9 @@ export function parseRefinementResponse(response: string, criteria: string[]): R
  * @param context - Refinement context (storyId, codebase context, config)
  * @returns Promise resolving to array of refined criteria
  */
-export async function refineAcceptanceCriteria(
-  criteria: string[],
-  context: RefinementContext,
-): Promise<RefinedCriterion[]> {
+export async function refineAcceptanceCriteria(criteria: string[], context: RefinementContext): Promise<RefineResult> {
   if (criteria.length === 0) {
-    return [];
+    return { criteria: [], costUsd: 0 };
   }
 
   const {
@@ -236,22 +233,22 @@ export async function refineAcceptanceCriteria(
       sessionRole: "refine",
       timeoutMs: config.acceptance?.timeoutMs ?? 120_000,
     });
+    const costUsd = typeof completeResult === "string" ? 0 : (completeResult.costUsd ?? 0);
     response = typeof completeResult === "string" ? completeResult : completeResult.output;
+
+    const parsed = parseRefinementResponse(response, criteria);
+    return {
+      criteria: parsed.map((item) => ({ ...item, storyId: item.storyId || storyId })),
+      costUsd,
+    };
   } catch (error) {
     const reason = errorMessage(error);
     logger.warn("refinement", "adapter.complete() failed, falling back to original criteria", {
       storyId,
       error: reason,
     });
-    return fallbackCriteria(criteria, storyId);
+    return { criteria: fallbackCriteria(criteria, storyId), costUsd: 0 };
   }
-
-  const parsed = parseRefinementResponse(response, criteria);
-
-  return parsed.map((item) => ({
-    ...item,
-    storyId: item.storyId || storyId,
-  }));
 }
 
 /**

--- a/src/acceptance/types.ts
+++ b/src/acceptance/types.ts
@@ -8,6 +8,14 @@ import type { AgentAdapter } from "../agents/types";
 import type { AcceptanceTestStrategy, ModelDef, ModelTier, NaxConfig } from "../config/schema";
 
 /**
+ * Return value of refineAcceptanceCriteria — criteria plus cost metadata.
+ */
+export interface RefineResult {
+  criteria: RefinedCriterion[];
+  costUsd: number;
+}
+
+/**
  * A single refined acceptance criterion produced by the refinement module.
  */
 export interface RefinedCriterion {
@@ -153,6 +161,8 @@ export interface AcceptanceTestResult {
   testCode: string;
   /** Acceptance criteria that were processed */
   criteria: AcceptanceCriterion[];
+  /** LLM cost for this generation call in USD (0 when not available) */
+  costUsd?: number;
 }
 
 /**

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -137,7 +137,7 @@ export const _acceptanceSetupDeps = {
     _context: import("../../acceptance/types").RefinementContext,
   ): Promise<RefinedCriterion[]> => {
     const { refineAcceptanceCriteria } = await import("../../acceptance/refinement");
-    return refineAcceptanceCriteria(_criteria, _context);
+    return (await refineAcceptanceCriteria(_criteria, _context)).criteria;
   },
   generate: async (
     _stories: UserStory[],

--- a/src/pipeline/stages/acceptance.ts
+++ b/src/pipeline/stages/acceptance.ts
@@ -68,12 +68,33 @@ export function parseTestFailures(output: string): string[] {
   const lines = output.split("\n");
 
   for (const line of lines) {
-    // Look for Bun's (fail) marker followed by AC-N pattern
-    // Pattern: (fail) ... > AC-N: description
+    // Primary: Bun/Jest "(fail)" marker — "AC-N: description"
     if (line.includes("(fail)")) {
       const acMatch = line.match(/(AC-\d+):/i);
       if (acMatch) {
         const acId = acMatch[1].toUpperCase();
+        if (!failedACs.includes(acId)) {
+          failedACs.push(acId);
+        }
+      }
+    }
+
+    // Secondary: Go "--- FAIL: TestAC-1_desc (0.00s)" or "--- FAIL: TestAC1Desc"
+    if (line.includes("--- FAIL:")) {
+      const acMatch = line.match(/AC[-_]?(\d+)/i);
+      if (acMatch) {
+        const acId = `AC-${acMatch[1]}`;
+        if (!failedACs.includes(acId)) {
+          failedACs.push(acId);
+        }
+      }
+    }
+
+    // Secondary: pytest "FAILED tests/...::test_AC_1_desc"
+    if (/FAILED\s/.test(line)) {
+      const acMatch = line.match(/AC[-_]?(\d+)/i);
+      if (acMatch) {
+        const acId = `AC-${acMatch[1]}`;
         if (!failedACs.includes(acId)) {
           failedACs.push(acId);
         }

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -56,6 +56,9 @@ export async function loadPRD(path: string): Promise<PRD> {
     if (rawStatus === "done") story.status = "passed";
     story.status = story.status ?? "pending";
     story.acceptanceCriteria = story.acceptanceCriteria ?? [];
+    if (Array.isArray(story.suggestedCriteria) && story.suggestedCriteria.length === 0) {
+      story.suggestedCriteria = undefined;
+    }
     story.storyPoints = story.storyPoints ?? 1;
   }
 

--- a/test/unit/acceptance/hardening.test.ts
+++ b/test/unit/acceptance/hardening.test.ts
@@ -108,12 +108,14 @@ describe("runHardeningPass()", () => {
     const prd = makePRD({ userStories: [story] });
     const ctx = makeCtx({ prd });
 
-    _hardeningDeps.refine = mock(async (criteria: string[]) =>
-      criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: "US-001" })),
-    );
+    _hardeningDeps.refine = mock(async (criteria: string[]) => ({
+      criteria: criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: "US-001" })),
+      costUsd: 0.001,
+    }));
     _hardeningDeps.generate = mock(async () => ({
       testCode: 'test("AC-1", () => {})',
       criteria: [{ id: "AC-1", text: "suggested edge case", lineNumber: 1 }],
+      costUsd: 0.002,
     }));
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
@@ -156,12 +158,14 @@ describe("runHardeningPass()", () => {
     const prd = makePRD({ userStories: [story] });
     const ctx = makeCtx({ prd });
 
-    _hardeningDeps.refine = mock(async (criteria: string[]) =>
-      criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: "US-001" })),
-    );
+    _hardeningDeps.refine = mock(async (criteria: string[]) => ({
+      criteria: criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: "US-001" })),
+      costUsd: 0,
+    }));
     _hardeningDeps.generate = mock(async () => ({
       testCode: 'test("AC-1", () => {})',
       criteria: [{ id: "AC-1", text: "failing edge case", lineNumber: 1 }],
+      costUsd: 0,
     }));
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
@@ -205,12 +209,14 @@ describe("runHardeningPass()", () => {
     const ctx = makeCtx({ prd });
 
     // Refiner marks it non-testable (implementation detail)
-    _hardeningDeps.refine = mock(async (criteria: string[]) =>
-      criteria.map((c) => ({ original: c, refined: c, testable: false, storyId: "US-001" })),
-    );
+    _hardeningDeps.refine = mock(async (criteria: string[]) => ({
+      criteria: criteria.map((c) => ({ original: c, refined: c, testable: false, storyId: "US-001" })),
+      costUsd: 0,
+    }));
     _hardeningDeps.generate = mock(async () => ({
       testCode: 'test("AC-1", () => { expect(true).toBe(true); })',
       criteria: [{ id: "AC-1", text: "cli.ts contains an import of writeFileSync", lineNumber: 1 }],
+      costUsd: 0,
     }));
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
@@ -249,20 +255,22 @@ describe("runHardeningPass()", () => {
     const prd = makePRD({ userStories: [story] });
     const ctx = makeCtx({ prd });
 
-    _hardeningDeps.refine = mock(async (criteria: string[]) =>
-      criteria.map((c, i) => ({
+    _hardeningDeps.refine = mock(async (criteria: string[]) => ({
+      criteria: criteria.map((c, i) => ({
         original: c,
         refined: c,
         testable: i === 0, // first testable, second not
         storyId: "US-001",
       })),
-    );
+      costUsd: 0,
+    }));
     _hardeningDeps.generate = mock(async () => ({
       testCode: 'test("AC-1", () => {})\ntest("AC-2", () => { expect(true).toBe(true); })',
       criteria: [
         { id: "AC-1", text: "behavioral edge case", lineNumber: 1 },
         { id: "AC-2", text: "cli.ts contains an import", lineNumber: 2 },
       ],
+      costUsd: 0,
     }));
     _hardeningDeps.writeFile = mock(async () => {});
     _hardeningDeps.savePRD = mock(async () => {});
@@ -308,5 +316,43 @@ describe("runHardeningPass()", () => {
     // Should not throw, returns empty result
     expect(result.promoted).toEqual([]);
     expect(result.discarded).toEqual([]);
+  });
+
+  test("accumulates costUsd from refine and generate sub-calls (#336 gap 3)", async () => {
+    const story = {
+      id: "US-001",
+      title: "Story",
+      description: "Desc",
+      acceptanceCriteria: ["spec AC"],
+      suggestedCriteria: ["edge case"],
+      tags: [],
+      dependencies: [],
+      status: "passed" as const,
+      passes: true,
+      escalations: [],
+      attempts: 1,
+    };
+    const ctx = makeCtx({ prd: makePRD({ userStories: [story] }) });
+
+    _hardeningDeps.refine = mock(async (criteria: string[]) => ({
+      criteria: criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: "US-001" })),
+      costUsd: 0.005,
+    }));
+    _hardeningDeps.generate = mock(async () => ({
+      testCode: 'test("AC-1", () => {})',
+      criteria: [{ id: "AC-1", text: "edge case", lineNumber: 1 }],
+      costUsd: 0.010,
+    }));
+    _hardeningDeps.writeFile = mock(async () => {});
+    _hardeningDeps.savePRD = mock(async () => {});
+    _hardeningDeps.spawn = mock(() => ({
+      exited: Promise.resolve(0),
+      stdout: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+      stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+    } as ReturnType<typeof Bun.spawn>));
+
+    const result = await runHardeningPass(ctx);
+
+    expect(result.costUsd).toBeCloseTo(0.015);
   });
 });

--- a/test/unit/acceptance/hardening.test.ts
+++ b/test/unit/acceptance/hardening.test.ts
@@ -318,6 +318,56 @@ describe("runHardeningPass()", () => {
     expect(result.discarded).toEqual([]);
   });
 
+  test("mapping loop driven from allRefined prevents AC index drift when refine count changes (#336 gap 4)", async () => {
+    const story = {
+      id: "US-001",
+      title: "Story",
+      description: "Desc",
+      acceptanceCriteria: ["spec AC"],
+      // 3 suggested criteria, but refine deduplicates to 2
+      suggestedCriteria: ["dup criterion A", "dup criterion A", "passing criterion"],
+      tags: [],
+      dependencies: [],
+      status: "passed" as const,
+      passes: true,
+      escalations: [],
+      attempts: 1,
+    };
+    const prd = makePRD({ userStories: [story] });
+    const ctx = makeCtx({ prd });
+
+    // Refiner deduplicates: returns only 2 criteria instead of 3
+    _hardeningDeps.refine = mock(async () => ({
+      criteria: [
+        { original: "dup criterion A", refined: "dup criterion A", testable: true, storyId: "US-001" },
+        { original: "passing criterion", refined: "passing criterion", testable: true, storyId: "US-001" },
+      ],
+      costUsd: 0,
+    }));
+    _hardeningDeps.generate = mock(async () => ({
+      testCode: 'test("AC-1", () => {})\ntest("AC-2", () => {})',
+      criteria: [
+        { id: "AC-1", text: "dup criterion A", lineNumber: 1 },
+        { id: "AC-2", text: "passing criterion", lineNumber: 2 },
+      ],
+      costUsd: 0,
+    }));
+    _hardeningDeps.writeFile = mock(async () => {});
+    _hardeningDeps.savePRD = mock(async () => {});
+    // Both tests pass
+    _hardeningDeps.spawn = mock(() => ({
+      exited: Promise.resolve(0),
+      stdout: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+      stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+    } as ReturnType<typeof Bun.spawn>));
+
+    const result = await runHardeningPass(ctx);
+
+    // Both refined criteria pass — only the 2 returned by refine are promoted
+    expect(result.promoted).toEqual(["dup criterion A", "passing criterion"]);
+    expect(result.discarded).toEqual([]);
+  });
+
   test("accumulates costUsd from refine and generate sub-calls (#336 gap 3)", async () => {
     const story = {
       id: "US-001",

--- a/test/unit/acceptance/hardening.test.ts
+++ b/test/unit/acceptance/hardening.test.ts
@@ -368,6 +368,52 @@ describe("runHardeningPass()", () => {
     expect(result.discarded).toEqual([]);
   });
 
+  test("deduplicates against existing acceptanceCriteria when promoting (#336 gap 5)", async () => {
+    const story = {
+      id: "US-001",
+      title: "Story",
+      description: "Desc",
+      acceptanceCriteria: ["spec AC", "already promoted criterion"],
+      suggestedCriteria: ["already promoted criterion", "new criterion"],
+      tags: [],
+      dependencies: [],
+      status: "passed" as const,
+      passes: true,
+      escalations: [],
+      attempts: 1,
+    };
+    const prd = makePRD({ userStories: [story] });
+    const ctx = makeCtx({ prd });
+
+    _hardeningDeps.refine = mock(async (criteria: string[]) => ({
+      criteria: criteria.map((c) => ({ original: c, refined: c, testable: true, storyId: "US-001" })),
+      costUsd: 0,
+    }));
+    _hardeningDeps.generate = mock(async () => ({
+      testCode: 'test("AC-1", () => {})\ntest("AC-2", () => {})',
+      criteria: [
+        { id: "AC-1", text: "already promoted criterion", lineNumber: 1 },
+        { id: "AC-2", text: "new criterion", lineNumber: 2 },
+      ],
+      costUsd: 0,
+    }));
+    _hardeningDeps.writeFile = mock(async () => {});
+    _hardeningDeps.savePRD = mock(async () => {});
+    // Both tests pass
+    _hardeningDeps.spawn = mock(() => ({
+      exited: Promise.resolve(0),
+      stdout: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+      stderr: new ReadableStream({ start(ctrl) { ctrl.close(); } }),
+    } as ReturnType<typeof Bun.spawn>));
+
+    await runHardeningPass(ctx);
+
+    // "already promoted criterion" must not appear twice
+    const count = story.acceptanceCriteria.filter((ac) => ac === "already promoted criterion").length;
+    expect(count).toBe(1);
+    expect(story.acceptanceCriteria).toContain("new criterion");
+  });
+
   test("accumulates costUsd from refine and generate sub-calls (#336 gap 3)", async () => {
     const story = {
       id: "US-001",

--- a/test/unit/acceptance/refinement.test.ts
+++ b/test/unit/acceptance/refinement.test.ts
@@ -312,10 +312,10 @@ describe("refineAcceptanceCriteria — adapter.complete() integration", () => {
       config,
     });
 
-    expect(Array.isArray(result)).toBe(true);
-    expect(result).toHaveLength(SAMPLE_CRITERIA.length);
+    expect(Array.isArray(result.criteria)).toBe(true);
+    expect(result.criteria).toHaveLength(SAMPLE_CRITERIA.length);
     for (let i = 0; i < SAMPLE_CRITERIA.length; i++) {
-      expect(result[i].original).toBe(SAMPLE_CRITERIA[i]);
+      expect(result.criteria[i].original).toBe(SAMPLE_CRITERIA[i]);
     }
   });
 
@@ -332,7 +332,7 @@ describe("refineAcceptanceCriteria — adapter.complete() integration", () => {
       config,
     });
 
-    for (const item of result) {
+    for (const item of result.criteria) {
       expect(typeof item.refined).toBe("string");
       expect(item.refined.length).toBeGreaterThan(0);
     }
@@ -407,8 +407,8 @@ describe("refineAcceptanceCriteria — adapter.complete() integration", () => {
       config,
     });
 
-    expect(result).toHaveLength(SAMPLE_CRITERIA.length);
-    for (const item of result) {
+    expect(result.criteria).toHaveLength(SAMPLE_CRITERIA.length);
+    for (const item of result.criteria) {
       expect(item.testable).toBe(false);
     }
   });
@@ -427,7 +427,7 @@ describe("refineAcceptanceCriteria — adapter.complete() integration", () => {
       config,
     });
 
-    for (const item of result) {
+    for (const item of result.criteria) {
       expect(item.storyId).toBe(customStoryId);
     }
   });
@@ -447,7 +447,7 @@ describe("refineAcceptanceCriteria — adapter.complete() integration", () => {
       config,
     });
 
-    expect(result).toHaveLength(0);
+    expect(result.criteria).toHaveLength(0);
     expect(adapterCalled).toBe(false);
   });
 
@@ -462,10 +462,10 @@ describe("refineAcceptanceCriteria — adapter.complete() integration", () => {
       config,
     });
 
-    expect(result).toHaveLength(SAMPLE_CRITERIA.length);
+    expect(result.criteria).toHaveLength(SAMPLE_CRITERIA.length);
     for (let i = 0; i < SAMPLE_CRITERIA.length; i++) {
-      expect(result[i].original).toBe(SAMPLE_CRITERIA[i]);
-      expect(result[i].refined).toBe(SAMPLE_CRITERIA[i]);
+      expect(result.criteria[i].original).toBe(SAMPLE_CRITERIA[i]);
+      expect(result.criteria[i].refined).toBe(SAMPLE_CRITERIA[i]);
     }
   });
 
@@ -483,10 +483,10 @@ describe("refineAcceptanceCriteria — adapter.complete() integration", () => {
     });
 
     // Should return fallback results, not throw
-    expect(Array.isArray(result)).toBe(true);
-    expect(result).toHaveLength(SAMPLE_CRITERIA.length);
+    expect(Array.isArray(result.criteria)).toBe(true);
+    expect(result.criteria).toHaveLength(SAMPLE_CRITERIA.length);
     for (let i = 0; i < SAMPLE_CRITERIA.length; i++) {
-      expect(result[i].original).toBe(SAMPLE_CRITERIA[i]);
+      expect(result.criteria[i].original).toBe(SAMPLE_CRITERIA[i]);
     }
   });
 });

--- a/test/unit/pipeline/stages/acceptance.test.ts
+++ b/test/unit/pipeline/stages/acceptance.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { acceptanceStage } from "../../../../src/pipeline/stages/acceptance";
+import { acceptanceStage, parseTestFailures } from "../../../../src/pipeline/stages/acceptance";
 import type { PipelineContext } from "../../../../src/pipeline/types";
 import { DEFAULT_CONFIG } from "../../../../src/config";
 
@@ -199,5 +199,64 @@ describe("acceptanceStage.enabled()", () => {
       } as any,
     });
     expect(acceptanceStage.enabled(ctx)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTestFailures — multi-framework failure marker support (#336 gap 2)
+// ---------------------------------------------------------------------------
+
+describe("parseTestFailures()", () => {
+  test("Bun/Jest: extracts AC IDs from (fail) lines", () => {
+    const output = [
+      "  ✓ AC-1: TTL expiry",
+      "  (fail) AC-2: handles empty input",
+      "  ✓ AC-3: validates format",
+      "  (fail) AC-4: rejects null",
+    ].join("\n");
+
+    expect(parseTestFailures(output)).toEqual(["AC-2", "AC-4"]);
+  });
+
+  test("Go: extracts AC IDs from --- FAIL: lines", () => {
+    const output = [
+      "--- PASS: TestAC1TTLExpiry (0.00s)",
+      "--- FAIL: TestAC-2_handles_empty (0.01s)",
+      "--- PASS: TestAC3ValidatesFormat (0.00s)",
+      "--- FAIL: TestAC_4_rejects_null (0.00s)",
+    ].join("\n");
+
+    expect(parseTestFailures(output)).toEqual(["AC-2", "AC-4"]);
+  });
+
+  test("pytest: extracts AC IDs from FAILED lines", () => {
+    const output = [
+      "tests/test_feature.py::test_AC_1_ttl_expiry PASSED",
+      "FAILED tests/test_feature.py::test_AC_2_empty_input - AssertionError",
+      "tests/test_feature.py::test_AC_3_validates PASSED",
+      "FAILED tests/test_feature.py::test_AC_4_null",
+    ].join("\n");
+
+    expect(parseTestFailures(output)).toEqual(["AC-2", "AC-4"]);
+  });
+
+  test("deduplicates AC IDs across multiple matching lines", () => {
+    const output = [
+      "  (fail) AC-1: first failure",
+      "--- FAIL: TestAC_1_something (0.00s)",
+      "FAILED tests::test_AC_1_other",
+    ].join("\n");
+
+    expect(parseTestFailures(output)).toEqual(["AC-1"]);
+  });
+
+  test("returns empty array when no failures", () => {
+    const output = [
+      "  ✓ AC-1: passes",
+      "--- PASS: TestAC1Something (0.00s)",
+      "tests::test_AC_1_thing PASSED",
+    ].join("\n");
+
+    expect(parseTestFailures(output)).toEqual([]);
   });
 });

--- a/test/unit/prd/prd-auto-default.test.ts
+++ b/test/unit/prd/prd-auto-default.test.ts
@@ -215,6 +215,66 @@ describe("PRD Auto-Default — missing fields are defaulted on load", () => {
     expect(afterLoadContent).toBe(originalContent);
   });
 
+  test("strips suggestedCriteria: [] to undefined in loadPRD (#336 gap 1)", async () => {
+    const prd: PRD = {
+      project: "test-project",
+      feature: "test-feature",
+      branchName: "test-branch",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      userStories: [
+        {
+          id: "US-001",
+          title: "Test story",
+          description: "Test description",
+          acceptanceCriteria: ["AC1"],
+          suggestedCriteria: [] as string[],
+          tags: [],
+          dependencies: [],
+          status: "pending",
+          passes: false,
+          escalations: [],
+          attempts: 0,
+        } as any,
+      ],
+    };
+
+    await savePRD(prd, prdPath);
+    const loaded = await loadPRD(prdPath);
+
+    expect(loaded.userStories[0].suggestedCriteria).toBeUndefined();
+  });
+
+  test("preserves non-empty suggestedCriteria in loadPRD", async () => {
+    const prd: PRD = {
+      project: "test-project",
+      feature: "test-feature",
+      branchName: "test-branch",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      userStories: [
+        {
+          id: "US-001",
+          title: "Test story",
+          description: "Test description",
+          acceptanceCriteria: ["AC1"],
+          suggestedCriteria: ["edge case A", "edge case B"],
+          tags: [],
+          dependencies: [],
+          status: "pending",
+          passes: false,
+          escalations: [],
+          attempts: 0,
+        } as any,
+      ],
+    };
+
+    await savePRD(prd, prdPath);
+    const loaded = await loadPRD(prdPath);
+
+    expect(loaded.userStories[0].suggestedCriteria).toEqual(["edge case A", "edge case B"]);
+  });
+
   test("loadPRD handles all missing fields simultaneously", async () => {
     const prd: PRD = {
       project: "test-project",


### PR DESCRIPTION
## Summary

Fixes all 5 non-blocking gaps from the suggestedCriteria hardening audit tracked in #336.

- **Gap 1 (MEDIUM)** — `loadPRD()` now strips `suggestedCriteria: []` to `undefined`, matching the schema validation behaviour and restoring the `string[] | undefined` type contract
- **Gap 2 (MEDIUM)** — `parseTestFailures` extended with secondary matchers for Go (`--- FAIL:`) and pytest (`FAILED `) markers; `AC_1`/`AC1` normalised to `AC-1` to prevent silent promotion of all criteria when non-Bun test frameworks report failures
- **Gap 3 (LOW)** — Added `RefineResult` type; `refineAcceptanceCriteria` and `generateFromPRD` now capture `adapter.complete()` cost; `runHardeningPass` accumulates and returns a meaningful `costUsd`
- **Gap 4 (LOW)** — Hardening mapping loop driven from `allRefined` (grouped by `storyId`) rather than re-iterating `suggestedCriteria`; eliminates AC index drift if the refiner deduplicates or splits criteria
- **Gap 5 (LOW)** — Deduplicate `toPromote` against existing `acceptanceCriteria` via `Set` before appending; prevents duplicate test cases on subsequent runs

## Test plan

- [x] `bun test test/unit/prd/prd-auto-default.test.ts` — gap 1: strips empty array
- [x] `bun test test/unit/pipeline/stages/acceptance.test.ts` — gap 2: Go + pytest markers, dedup
- [x] `bun test test/unit/acceptance/hardening.test.ts` — gaps 3/4/5: costUsd, index safety, dedup promotion
- [x] `bun test test/unit/acceptance/refinement.test.ts` — RefineResult return type
- [x] `bun run test:bail` — full suite green (1200 tests, 0 failures)