### PR TITLE
fix(acceptance): resolve monorepo per-package test paths in completion phase

### DIFF
--- a/src/acceptance/test-path.ts
+++ b/src/acceptance/test-path.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { PRD, UserStory } from "../prd/types";
 
 export interface AcceptanceTestPathEntry {
   testPath: string;
@@ -71,6 +72,70 @@ export function resolveAcceptanceTestCandidates(options: ResolveAcceptanceTestCa
   }
   if (!options.featureDir) return [];
   return [resolveAcceptanceFeatureTestPath(options.featureDir, options.testPathConfig, options.language)];
+}
+
+// ─── Per-package grouping (monorepo) ────────────────────────────────────────
+
+/**
+ * One acceptance test group per unique story.workdir value in the PRD.
+ * Returned by groupStoriesByPackage — used by both acceptance-setup (generation)
+ * and runner-completion (path resolution for the acceptance loop).
+ */
+export interface AcceptanceTestGroup {
+  testPath: string;
+  packageDir: string;
+  stories: UserStory[];
+  criteria: string[];
+}
+
+/**
+ * Group non-fix, non-decomposed PRD stories by story.workdir and compute the
+ * acceptance test path for each group.
+ *
+ * This is the SSOT for per-package test path computation. Call it from:
+ *   - acceptance-setup stage (to generate test files + set ctx.acceptanceTestPaths)
+ *   - runner-completion (to pass acceptanceTestPaths into runAcceptanceLoop)
+ *
+ * @param prd         - The loaded PRD
+ * @param workdir     - Absolute repo root (ctx.workdir / options.workdir)
+ * @param featureName - Feature name used in the test file path
+ * @param testPathConfig - Optional override filename from config.acceptance.testPath
+ * @param language    - Optional language from config.project.language
+ */
+export function groupStoriesByPackage(
+  prd: PRD,
+  workdir: string,
+  featureName: string,
+  testPathConfig?: string,
+  language?: string,
+): AcceptanceTestGroup[] {
+  const nonFixStories = prd.userStories.filter((s) => !s.id.startsWith("US-FIX-") && s.status !== "decomposed");
+
+  const groupMap = new Map<string, { stories: UserStory[]; criteria: string[] }>();
+  for (const story of nonFixStories) {
+    const wd = story.workdir ?? "";
+    if (!groupMap.has(wd)) {
+      groupMap.set(wd, { stories: [], criteria: [] });
+    }
+    const group = groupMap.get(wd);
+    if (group) {
+      group.stories.push(story);
+      group.criteria.push(...story.acceptanceCriteria);
+    }
+  }
+
+  // Fallback: always have at least the root group so RED gate runs
+  if (groupMap.size === 0) {
+    groupMap.set("", { stories: [], criteria: [] });
+  }
+
+  const groups: AcceptanceTestGroup[] = [];
+  for (const [wd, { stories, criteria }] of groupMap) {
+    const packageDir = wd ? path.join(workdir, wd) : workdir;
+    const testPath = resolveAcceptancePackageFeatureTestPath(packageDir, featureName, testPathConfig, language);
+    groups.push({ testPath, packageDir, stories, criteria });
+  }
+  return groups;
 }
 
 // ─── Suggested test path helpers (hardening pass) ───────────────────────────

--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -5,6 +5,7 @@
  * Extracted from runner.ts for better code organization.
  */
 
+import { groupStoriesByPackage } from "../acceptance/test-path";
 import type { NaxConfig } from "../config";
 import type { LoadedHooksConfig } from "../hooks";
 import { fireHook } from "../hooks";
@@ -105,6 +106,20 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
     } else if (options.config.acceptance.enabled && isComplete(options.prd)) {
       options.statusWriter.setPostRunPhase("acceptance", { status: "running" });
 
+      // Compute per-package acceptance test paths from PRD story workdirs.
+      // This is necessary because preRunCtx.acceptanceTestPaths is ephemeral and
+      // not propagated here; it's also skipped entirely when the PRD is already
+      // complete at run start (re-run). groupStoriesByPackage is the SSOT.
+      const acceptanceTestPaths = options.featureDir
+        ? groupStoriesByPackage(
+            options.prd,
+            options.workdir,
+            options.feature,
+            options.config.acceptance.testPath,
+            options.config.project?.language,
+          ).map((g) => ({ testPath: g.testPath, packageDir: g.packageDir }))
+        : undefined;
+
       const acceptanceResult = await _runnerCompletionDeps.runAcceptanceLoop({
         config: options.config,
         prd: options.prd,
@@ -121,6 +136,7 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
         eventEmitter: options.eventEmitter,
         statusWriter: options.statusWriter,
         agentGetFn: options.agentGetFn,
+        acceptanceTestPaths,
       });
 
       const lastRunAt = new Date().toISOString();

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -22,12 +22,11 @@
 
 import path from "node:path";
 import { buildAcceptanceRunCommand } from "../../acceptance/generator";
-import { resolveAcceptancePackageFeatureTestPath } from "../../acceptance/test-path";
+import { groupStoriesByPackage } from "../../acceptance/test-path";
 import type { RefinedCriterion } from "../../acceptance/types";
 import { getAgent } from "../../agents/registry";
 import { type ModelDef, resolveModelForAgent } from "../../config";
 import { getSafeLogger } from "../../logger";
-import type { UserStory } from "../../prd/types";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 /**
@@ -140,7 +139,7 @@ export const _acceptanceSetupDeps = {
     return (await refineAcceptanceCriteria(_criteria, _context)).criteria;
   },
   generate: async (
-    _stories: UserStory[],
+    _stories: import("../../prd/types").UserStory[],
     _refined: RefinedCriterion[],
     _options: import("../../acceptance/types").GenerateFromPRDOptions,
   ): Promise<import("../../acceptance/types").AcceptanceTestResult> => {
@@ -174,40 +173,11 @@ export const acceptanceSetupStage: PipelineStage = {
       .filter((s) => !s.id.startsWith("US-FIX-") && s.status !== "decomposed")
       .flatMap((s) => s.acceptanceCriteria);
 
-    // US-001: Group non-fix stories by story.workdir.
-    // Each group gets its own test file at <package-root>/.nax-acceptance.test.ts.
-    // Decomposed stories are parent containers whose ACs are fully covered by their
-    // children — including them causes duplicate refine LLM calls and duplicate
-    // acceptance test cases.
-    const nonFixStories = ctx.prd.userStories.filter((s) => !s.id.startsWith("US-FIX-") && s.status !== "decomposed");
-    const workdirGroups = new Map<string, { stories: UserStory[]; criteria: string[] }>();
-
-    for (const story of nonFixStories) {
-      const wd = story.workdir ?? "";
-      if (!workdirGroups.has(wd)) {
-        workdirGroups.set(wd, { stories: [], criteria: [] });
-      }
-      const group = workdirGroups.get(wd);
-      if (group) {
-        group.stories.push(story);
-        group.criteria.push(...story.acceptanceCriteria);
-      }
-    }
-
-    // Fallback: always have at least the root group so RED gate runs
-    if (workdirGroups.size === 0) {
-      workdirGroups.set("", { stories: [], criteria: [] });
-    }
-
-    // Build test paths for each workdir group — tests go under packageDir/.nax/features/<feature>/
-    // to avoid collisions between features targeting the same package.
+    // US-001: Group non-fix, non-decomposed stories by story.workdir — one test file per package.
+    // groupStoriesByPackage handles workdir grouping, path computation, and root fallback.
     const featureName = ctx.prd.feature ?? (ctx.prd as unknown as Record<string, string>).featureName;
-    const testPaths: Array<{ testPath: string; packageDir: string }> = [];
-    for (const [workdir] of workdirGroups) {
-      const packageDir = workdir ? path.join(ctx.workdir, workdir) : ctx.workdir;
-      const testPath = resolveAcceptancePackageFeatureTestPath(packageDir, featureName, testPathConfig, language);
-      testPaths.push({ testPath, packageDir });
-    }
+    const groups = groupStoriesByPackage(ctx.prd, ctx.workdir, featureName, testPathConfig, language);
+    const nonFixStories = groups.flatMap((g) => g.stories);
 
     let totalCriteria = 0;
     let testableCount = 0;
@@ -236,7 +206,7 @@ export const acceptanceSetupStage: PipelineStage = {
         });
       }
       // Back up and delete all existing per-package test files
-      for (const { testPath } of testPaths) {
+      for (const { testPath } of groups) {
         if (await _acceptanceSetupDeps.fileExists(testPath)) {
           await _acceptanceSetupDeps.copyFile(testPath, `${testPath}.bak`);
           await _acceptanceSetupDeps.deleteFile(testPath);
@@ -306,9 +276,8 @@ export const acceptanceSetupStage: PipelineStage = {
       testableCount = allRefinedCriteria.filter((r) => r.testable).length;
 
       // Generate one acceptance test file per workdir group
-      for (const [workdir, group] of workdirGroups) {
-        const packageDir = workdir ? path.join(ctx.workdir, workdir) : ctx.workdir;
-        const testPath = resolveAcceptancePackageFeatureTestPath(packageDir, featureName, testPathConfig, language);
+      for (const group of groups) {
+        const { testPath, packageDir } = group;
 
         // Filter refined criteria to this group's stories
         const groupStoryIds = new Set(group.stories.map((s) => s.id));
@@ -361,7 +330,7 @@ export const acceptanceSetupStage: PipelineStage = {
     }
 
     // Store per-package test paths in context for the acceptance runner (US-002)
-    ctx.acceptanceTestPaths = testPaths;
+    ctx.acceptanceTestPaths = groups.map((g) => ({ testPath: g.testPath, packageDir: g.packageDir }));
 
     if (ctx.config.acceptance.redGate === false) {
       ctx.acceptanceSetup = { totalCriteria, testableCount, redFailCount: 0 };
@@ -371,7 +340,7 @@ export const acceptanceSetupStage: PipelineStage = {
     // BUG-084: Use testFramework-aware single-file command (not quality.commands.test which runs full suite)
     // Run RED gate for each per-package test file from its package directory
     let redFailCount = 0;
-    for (const { testPath, packageDir } of testPaths) {
+    for (const { testPath, packageDir } of groups) {
       const runCmd = buildAcceptanceRunCommand(
         testPath,
         ctx.config.project?.testFramework,

--- a/test/unit/acceptance/test-path.test.ts
+++ b/test/unit/acceptance/test-path.test.ts
@@ -1,9 +1,118 @@
 import { describe, expect, test } from "bun:test";
 import {
+  groupStoriesByPackage,
   resolveSuggestedPackageFeatureTestPath,
   resolveSuggestedTestFile,
   suggestedTestFilename,
 } from "../../../src/acceptance/test-path";
+import type { PRD, UserStory } from "../../../src/prd";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeStory(id: string, workdir?: string, status: UserStory["status"] = "pending"): UserStory {
+  return {
+    id,
+    title: `Story ${id}`,
+    description: "",
+    acceptanceCriteria: [`AC-1 for ${id}`],
+    tags: [],
+    dependencies: [],
+    status,
+    passes: false,
+    escalations: [],
+    attempts: 0,
+    workdir,
+  };
+}
+
+function makePRD(stories: UserStory[]): PRD {
+  return {
+    project: "proj",
+    feature: "my-feature",
+    branchName: "feat/my-feature",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    userStories: stories,
+  };
+}
+
+const WORKDIR = "/repo";
+
+// ─── groupStoriesByPackage ───────────────────────────────────────────────────
+
+describe("groupStoriesByPackage()", () => {
+  test("single workdir — one group with correct testPath", () => {
+    const prd = makePRD([makeStory("US-001", "apps/api"), makeStory("US-002", "apps/api")]);
+    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].packageDir).toBe("/repo/apps/api");
+    expect(groups[0].testPath).toBe("/repo/apps/api/.nax/features/my-feature/.nax-acceptance.test.ts");
+    expect(groups[0].stories.map((s) => s.id)).toEqual(["US-001", "US-002"]);
+  });
+
+  test("multiple workdirs (monorepo) — one group per unique workdir", () => {
+    const prd = makePRD([
+      makeStory("US-001", "apps/api"),
+      makeStory("US-002", "apps/cli"),
+      makeStory("US-003", "apps/api"),
+    ]);
+    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    expect(groups).toHaveLength(2);
+    const dirs = groups.map((g) => g.packageDir).sort();
+    expect(dirs).toEqual(["/repo/apps/api", "/repo/apps/cli"]);
+  });
+
+  test("stories with no workdir are grouped at repo root", () => {
+    const prd = makePRD([makeStory("US-001"), makeStory("US-002")]);
+    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].packageDir).toBe(WORKDIR);
+    expect(groups[0].testPath).toBe("/repo/.nax/features/my-feature/.nax-acceptance.test.ts");
+  });
+
+  test("empty PRD — fallback to one root group", () => {
+    const prd = makePRD([]);
+    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].packageDir).toBe(WORKDIR);
+    expect(groups[0].stories).toHaveLength(0);
+  });
+
+  test("fix stories (US-FIX-*) are excluded", () => {
+    const prd = makePRD([makeStory("US-001", "apps/api"), makeStory("US-FIX-001", "apps/api")]);
+    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].stories.map((s) => s.id)).toEqual(["US-001"]);
+  });
+
+  test("decomposed stories are excluded", () => {
+    const prd = makePRD([
+      makeStory("US-001", "apps/api"),
+      makeStory("US-002", "apps/api", "decomposed" as UserStory["status"]),
+    ]);
+    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].stories.map((s) => s.id)).toEqual(["US-001"]);
+  });
+
+  test("respects language for file extension", () => {
+    const prd = makePRD([makeStory("US-001", "apps/api")]);
+    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature", undefined, "go");
+    expect(groups[0].testPath).toBe("/repo/apps/api/.nax/features/my-feature/.nax-acceptance_test.go");
+  });
+
+  test("respects testPathConfig override", () => {
+    const prd = makePRD([makeStory("US-001", "apps/api")]);
+    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature", "custom.test.ts");
+    expect(groups[0].testPath).toBe("/repo/apps/api/.nax/features/my-feature/custom.test.ts");
+  });
+
+  test("criteria are collected per group", () => {
+    const prd = makePRD([makeStory("US-001", "apps/api"), makeStory("US-002", "apps/api")]);
+    const groups = groupStoriesByPackage(prd, WORKDIR, "my-feature");
+    expect(groups[0].criteria).toEqual(["AC-1 for US-001", "AC-1 for US-002"]);
+  });
+});
 
 describe("suggestedTestFilename()", () => {
   test("returns .nax-suggested.test.ts for TypeScript (default)", () => {

--- a/test/unit/execution/runner-completion-postrun.test.ts
+++ b/test/unit/execution/runner-completion-postrun.test.ts
@@ -392,3 +392,79 @@ describe("runCompletionPhase - AC3: sets acceptance failed when loop fails", () 
     expect(callOrder.indexOf("running")).toBeLessThan(callOrder.indexOf("failed"));
   });
 });
+
+// ---------------------------------------------------------------------------
+// Monorepo: acceptanceTestPaths derived from PRD story workdirs (bug fix)
+// ---------------------------------------------------------------------------
+
+describe("runCompletionPhase - monorepo: acceptanceTestPaths passed to runAcceptanceLoop", () => {
+  test("passes acceptanceTestPaths derived from PRD workdirs when featureDir is set", async () => {
+    let capturedCtx: Parameters<typeof _runnerCompletionDeps.runAcceptanceLoop>[0] | undefined;
+
+    _runnerCompletionDeps.runAcceptanceLoop = mock(async (ctx): Promise<AcceptanceLoopResult> => {
+      capturedCtx = ctx;
+      return {
+        success: true,
+        prd: ctx.prd,
+        totalCost: 0,
+        iterations: 1,
+        storiesCompleted: 2,
+        prdDirty: false,
+      };
+    });
+
+    const prd: PRD = {
+      project: "proj",
+      feature: "graphify-kb-cc",
+      branchName: "feat/graphify-kb-cc",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      userStories: [
+        { ...makeStory("US-001", "passed"), workdir: "apps/api" },
+        { ...makeStory("US-002", "passed"), workdir: "apps/cli" },
+      ],
+    };
+
+    const config = makeConfig(true);
+    const statusWriter = makeStatusWriter();
+    const opts: RunnerCompletionOptions = {
+      ...makeOpts(config, prd, statusWriter),
+      featureDir: `${WORKDIR}/.nax/features/graphify-kb-cc`,
+    };
+
+    await runCompletionPhase(opts);
+
+    const paths = capturedCtx?.acceptanceTestPaths ?? [];
+    expect(paths.length).toBe(2);
+    const packageDirs = paths.map((p) => p.packageDir).sort();
+    expect(packageDirs).toEqual([`${WORKDIR}/apps/api`, `${WORKDIR}/apps/cli`]);
+  });
+
+  test("passes undefined acceptanceTestPaths when featureDir is not set", async () => {
+    let capturedCtx: Parameters<typeof _runnerCompletionDeps.runAcceptanceLoop>[0] | undefined;
+
+    _runnerCompletionDeps.runAcceptanceLoop = mock(async (ctx): Promise<AcceptanceLoopResult> => {
+      capturedCtx = ctx;
+      return {
+        success: true,
+        prd: ctx.prd,
+        totalCost: 0,
+        iterations: 1,
+        storiesCompleted: 1,
+        prdDirty: false,
+      };
+    });
+
+    const prd = makePRD([{ id: "US-001", status: "passed" }]);
+    const config = makeConfig(true);
+    const statusWriter = makeStatusWriter();
+    const opts: RunnerCompletionOptions = {
+      ...makeOpts(config, prd, statusWriter),
+      featureDir: undefined,
+    };
+
+    await runCompletionPhase(opts);
+
+    expect(capturedCtx?.acceptanceTestPaths).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #349

- **Root cause:** `acceptanceTestPaths` was computed only inside the ephemeral `preRunCtx` in the pre-run pipeline and never propagated to `runCompletionPhase`. On re-runs where the PRD is already complete, the pre-run pipeline is skipped entirely — so the paths were never computed at all. In both cases, the acceptance stage fell back to the repo-root `.nax-acceptance.test.ts`, which doesn't exist in monorepos, producing a silent "all tests passed" with zero tests actually executed.
- **Fix:** Extract `groupStoriesByPackage()` from `acceptance-setup.ts` into `src/acceptance/test-path.ts` as a shared SSOT helper, then call it in `runCompletionPhase()` before invoking `runAcceptanceLoop()` so per-package paths are always derived directly from PRD story workdirs.
- **Side effect:** `acceptance-setup.ts` drops from 403 → ~375 lines (back under the 400-line limit).

## Changes

| File | Change |
|------|--------|
| `src/acceptance/test-path.ts` | Add `AcceptanceTestGroup` interface + `groupStoriesByPackage()` |
| `src/pipeline/stages/acceptance-setup.ts` | Replace inline Map grouping with `groupStoriesByPackage()` call |
| `src/execution/runner-completion.ts` | Compute `acceptanceTestPaths` from PRD before `runAcceptanceLoop` |
| `test/unit/acceptance/test-path.test.ts` | 9 new tests for `groupStoriesByPackage` |
| `test/unit/execution/runner-completion-postrun.test.ts` | 2 new monorepo routing tests |

## Test plan

- [x] `bun test test/unit/acceptance/test-path.test.ts` — 9 new `groupStoriesByPackage` tests pass (single/multi workdir, no-workdir root fallback, empty PRD fallback, fix/decomposed exclusions, language + config overrides)
- [x] `bun test test/unit/execution/runner-completion-postrun.test.ts` — 2 new monorepo routing tests verify `acceptanceTestPaths` is derived from PRD workdirs and passed through to `runAcceptanceLoop`
- [x] `bun test test/unit/pipeline/stages/acceptance-setup.test.ts` — all existing acceptance-setup tests pass after refactor
- [x] Full suite: 1202 pass, 0 fail
- [ ] Manual: re-run `graphify-kb-cc` against koda monorepo and confirm both `apps/api` and `apps/cli` acceptance test paths appear in logs (not the repo-root fallback)