### PR TITLE
feat(debate): add model field to ResolverConfig for asymmetric tier routing

### DIFF
--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -506,6 +506,7 @@ const makeResolverSchema = (defaultType: (typeof RESOLVER_TYPES)[number]) =>
     z.object({
       type: z.enum(RESOLVER_TYPES).default(defaultType),
       agent: z.string().min(1).optional(),
+      model: z.string().min(1).optional(),
       tieBreaker: z.string().min(1).optional(),
       maxPromptTokens: z.number().int().positive().optional(),
     }),

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -309,12 +309,18 @@ export async function resolveOutcome(
     if (adapter) {
       const synthesisSessionName =
         workdir !== undefined ? buildSessionName(workdir, featureName, storyId, "synthesis") : undefined;
+      const resolverDebater: Debater = { agent: agentName, model: resolverConfig.model };
+      const resolverTier: ModelTier =
+        (resolverConfig.model && MODEL_SHORTHAND_TIERS[resolverConfig.model.toLowerCase()]) ||
+        modelTierFromDebater(resolverDebater);
+      const resolverModelDef = resolveModelDefForDebater(resolverDebater, resolverTier, config);
       const resolverResult = await synthesisResolver(proposalOutputs, critiqueOutputs, {
         adapter,
         promptSuffix,
         debaters,
         completeOptions: {
-          model: resolveDebaterModel({ agent: agentName }, config),
+          model: resolverModelDef.model,
+          modelTier: resolverTier,
           config,
           storyId,
           featureName,
@@ -337,12 +343,18 @@ export async function resolveOutcome(
     const agentName = resolverConfig.agent ?? RESOLVER_FALLBACK_AGENT;
     const judgeSessionName =
       workdir !== undefined ? buildSessionName(workdir, featureName, storyId, "judge") : undefined;
+    const resolverDebater: Debater = { agent: agentName, model: resolverConfig.model };
+    const resolverTier: ModelTier =
+      (resolverConfig.model && MODEL_SHORTHAND_TIERS[resolverConfig.model.toLowerCase()]) ||
+      modelTierFromDebater(resolverDebater);
+    const resolverModelDef = resolveModelDefForDebater(resolverDebater, resolverTier, config);
     const resolverResult = await judgeResolver(proposalOutputs, critiqueOutputs, resolverConfig, {
       getAgent: (name: string) => _debateSessionDeps.getAgent(name, config),
       defaultAgentName: RESOLVER_FALLBACK_AGENT,
       debaters,
       completeOptions: {
-        model: resolveDebaterModel({ agent: agentName }, config),
+        model: resolverModelDef.model,
+        modelTier: resolverTier,
         config,
         storyId,
         featureName,

--- a/src/debate/types.ts
+++ b/src/debate/types.ts
@@ -32,6 +32,9 @@ export interface ResolverConfig {
   type: ResolverType;
   /** Optional agent to use as resolver (resolved from config.autoMode.defaultAgent when absent) */
   agent?: string;
+  /** Model override for the resolver agent — accepts tier labels ("fast"|"balanced"|"powerful"),
+   *  shorthand aliases ("haiku"|"sonnet"|"opus"), or a full model ID. Defaults to "fast" when absent. */
+  model?: string;
   /** Tie-breaker strategy when votes are tied */
   tieBreaker?: string;
   /** Max prompt tokens passed to the resolver agent */

--- a/test/unit/config/debate-schema.test.ts
+++ b/test/unit/config/debate-schema.test.ts
@@ -285,6 +285,46 @@ describe("debate config schema — AC-7: FIELD_DESCRIPTIONS contains debate entr
   });
 });
 
+describe("debate config schema — resolver.model field (#352)", () => {
+  test("accepts model: 'powerful' in plan resolver and preserves it", () => {
+    const result = NaxConfigSchema.safeParse({
+      ...baseConfig,
+      debate: { enabled: true, stages: { plan: { resolver: { type: "synthesis", model: "powerful" } } } },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.debate?.stages.plan.resolver.model).toBe("powerful");
+  });
+
+  test("accepts full model ID in plan resolver and preserves it", () => {
+    const result = NaxConfigSchema.safeParse({
+      ...baseConfig,
+      debate: { enabled: true, stages: { plan: { resolver: { type: "synthesis", model: "claude-opus-4-6" } } } },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.debate?.stages.plan.resolver.model).toBe("claude-opus-4-6");
+  });
+
+  test("rejects model: '' (empty string — min(1) check)", () => {
+    const result = NaxConfigSchema.safeParse({
+      ...baseConfig,
+      debate: { enabled: true, stages: { plan: { resolver: { type: "synthesis", model: "" } } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("model is optional — absent resolver parses without error", () => {
+    const result = NaxConfigSchema.safeParse({
+      ...baseConfig,
+      debate: { enabled: true, stages: { plan: { resolver: { type: "synthesis" } } } },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.debate?.stages.plan.resolver.model).toBeUndefined();
+  });
+});
+
 describe("DEFAULT_CONFIG includes debate section", () => {
   test("debate.enabled is false by default", () => {
     expect(DEFAULT_CONFIG.debate?.enabled).toBe(false);

--- a/test/unit/debate/session-helpers-resolver-model.test.ts
+++ b/test/unit/debate/session-helpers-resolver-model.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for resolver.model threading in resolveOutcome()
+ *
+ * Covers: resolver.model field for synthesis and judge resolvers (issue #352).
+ * Verifies that modelTier in completeOptions reflects resolver.model when set,
+ * and defaults to "fast" when absent — matching debater model resolution behavior.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _debateSessionDeps, resolveOutcome } from "../../../src/debate/session-helpers";
+import type { AgentAdapter, CompleteOptions } from "../../../src/agents/types";
+import type { DebateStageConfig } from "../../../src/debate/types";
+import type { NaxConfig } from "../../../src/config";
+
+// Tests use undefined config — resolveModelDefForDebater falls back to DEFAULT_CONFIG when config is absent
+const NO_CONFIG = undefined as unknown as NaxConfig;
+
+function makeStageConfig(
+  resolverType: "synthesis" | "custom",
+  resolverModel?: string,
+): DebateStageConfig {
+  return {
+    enabled: true,
+    resolver: { type: resolverType, agent: "claude", model: resolverModel },
+    sessionMode: "one-shot",
+    mode: "panel",
+    rounds: 1,
+    timeoutSeconds: 60,
+  } as DebateStageConfig;
+}
+
+function makeCaptureAdapter(captured: { opts?: CompleteOptions }[]): AgentAdapter {
+  return {
+    name: "mock",
+    displayName: "mock",
+    binary: "mock",
+    capabilities: {
+      supportedTiers: ["fast", "balanced", "powerful"] as const,
+      maxContextTokens: 100_000,
+      features: new Set<"tdd" | "review" | "refactor" | "batch">(["review"]),
+    },
+    isInstalled: async () => true,
+    run: async () => ({ success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 1, estimatedCost: 0 }),
+    buildCommand: () => [],
+    plan: async () => ({ specContent: "" }),
+    decompose: async () => ({ stories: [] }),
+    complete: async (_prompt: string, opts?: CompleteOptions) => {
+      captured.push({ opts });
+      return { output: "resolved", costUsd: 0.01, source: "exact" as const };
+    },
+  };
+}
+
+// ─── Synthesis resolver ───────────────────────────────────────────────────────
+
+describe("resolveOutcome() synthesis — resolver.model → modelTier (#352)", () => {
+  let origGetAgent: typeof _debateSessionDeps.getAgent;
+
+  beforeEach(() => {
+    origGetAgent = _debateSessionDeps.getAgent;
+  });
+
+  afterEach(() => {
+    _debateSessionDeps.getAgent = origGetAgent;
+    mock.restore();
+  });
+
+  test("passes modelTier='powerful' when resolver.model is 'powerful'", async () => {
+    const captured: { opts?: CompleteOptions }[] = [];
+    _debateSessionDeps.getAgent = mock(() => makeCaptureAdapter(captured));
+
+    await resolveOutcome(["proposal-a", "proposal-b"], [], makeStageConfig("synthesis", "powerful"), NO_CONFIG, "US-352", 30_000);
+
+    expect(captured.length).toBeGreaterThan(0);
+    expect(captured[0]?.opts?.modelTier).toBe("powerful");
+  });
+
+  test("passes modelTier='fast' when resolver.model is absent", async () => {
+    const captured: { opts?: CompleteOptions }[] = [];
+    _debateSessionDeps.getAgent = mock(() => makeCaptureAdapter(captured));
+
+    await resolveOutcome(["proposal-a", "proposal-b"], [], makeStageConfig("synthesis"), NO_CONFIG, "US-352", 30_000);
+
+    expect(captured.length).toBeGreaterThan(0);
+    expect(captured[0]?.opts?.modelTier).toBe("fast");
+  });
+
+  test("passes modelTier='balanced' when resolver.model is 'sonnet' (alias)", async () => {
+    const captured: { opts?: CompleteOptions }[] = [];
+    _debateSessionDeps.getAgent = mock(() => makeCaptureAdapter(captured));
+
+    await resolveOutcome(["proposal-a", "proposal-b"], [], makeStageConfig("synthesis", "sonnet"), NO_CONFIG, "US-352", 30_000);
+
+    expect(captured.length).toBeGreaterThan(0);
+    expect(captured[0]?.opts?.modelTier).toBe("balanced");
+  });
+});
+
+// ─── Judge / custom resolver ──────────────────────────────────────────────────
+
+describe("resolveOutcome() custom/judge — resolver.model → modelTier (#352)", () => {
+  let origGetAgent: typeof _debateSessionDeps.getAgent;
+
+  beforeEach(() => {
+    origGetAgent = _debateSessionDeps.getAgent;
+  });
+
+  afterEach(() => {
+    _debateSessionDeps.getAgent = origGetAgent;
+    mock.restore();
+  });
+
+  test("passes modelTier='powerful' when resolver.model is 'powerful'", async () => {
+    const captured: { opts?: CompleteOptions }[] = [];
+    _debateSessionDeps.getAgent = mock(() => makeCaptureAdapter(captured));
+
+    await resolveOutcome(["proposal-a"], [], makeStageConfig("custom", "powerful"), NO_CONFIG, "US-352", 30_000);
+
+    expect(captured.length).toBeGreaterThan(0);
+    expect(captured[0]?.opts?.modelTier).toBe("powerful");
+  });
+
+  test("passes modelTier='fast' when resolver.model is absent", async () => {
+    const captured: { opts?: CompleteOptions }[] = [];
+    _debateSessionDeps.getAgent = mock(() => makeCaptureAdapter(captured));
+
+    await resolveOutcome(["proposal-a"], [], makeStageConfig("custom"), NO_CONFIG, "US-352", 30_000);
+
+    expect(captured.length).toBeGreaterThan(0);
+    expect(captured[0]?.opts?.modelTier).toBe("fast");
+  });
+});


### PR DESCRIPTION
## Summary

- Resolvers (synthesis/judge) previously hardcoded the `"fast"` model tier regardless of config, making asymmetric tiering (cheap debaters → powerful synthesizer) impossible to configure
- Adds `model?: string` to `ResolverConfig` (interface + Zod schema) with the same semantics as `Debater.model`: tier labels, shorthand aliases (`"haiku"/"sonnet"/"opus"`), or full model IDs
- Threads `resolver.model` through `resolveOutcome()` synthesis and judge paths via `resolveModelDefForDebater`, setting both `model` (full ID) and `modelTier` in `CompleteOptions`

## Usage

```jsonc
"debate": {
  "stages": {
    "plan": {
      "resolver": {
        "type": "synthesis",
        "agent": "claude",
        "model": "powerful"
      }
    }
  }
}
```

## Test plan

- [x] `bun run typecheck` — no errors
- [x] `bun run lint` — no errors
- [x] `test/unit/debate/session-helpers-resolver-model.test.ts` — 5 new tests covering synthesis and judge resolver paths (modelTier: powerful, fast default, sonnet alias)
- [x] `test/unit/config/debate-schema.test.ts` — 4 new schema tests (tier label, full ID, empty string rejection, optional field)
- [x] 95 tests across 4 relevant files all pass

Closes #352