### PR TITLE
fix(paused-prompts): fix timeout skip, stale statusWriter ref, prompt injection

### DIFF
--- a/src/execution/lifecycle/paused-story-prompts.ts
+++ b/src/execution/lifecycle/paused-story-prompts.ts
@@ -1,0 +1,93 @@
+/**
+ * Paused Story Prompts
+ *
+ * On re-run, asks the user what to do with each paused story:
+ * - Resume: reset to pending, retried this run
+ * - Skip: mark as skipped, not retried
+ * - Keep paused: leave as-is, skipped for this run
+ *
+ * In headless mode the caller skips this entirely — paused stories stay paused.
+ */
+
+import type { InteractionChain } from "../../interaction/chain";
+import type { InteractionResponse } from "../../interaction/types";
+import { getSafeLogger } from "../../logger";
+import type { PRD } from "../../prd/types";
+
+export interface PausedStoryPromptSummary {
+  resumed: string[];
+  skipped: string[];
+  kept: string[];
+}
+
+/**
+ * Prompt the user for each paused story on re-run.
+ * Mutates prd.userStories statuses in place.
+ * Returns a summary of decisions so the caller can save + recount.
+ */
+export async function promptForPausedStories(
+  prd: PRD,
+  chain: InteractionChain,
+  featureName: string,
+): Promise<PausedStoryPromptSummary> {
+  const logger = getSafeLogger();
+  const summary: PausedStoryPromptSummary = { resumed: [], skipped: [], kept: [] };
+
+  const pausedStories = prd.userStories.filter((s) => s.status === "paused");
+
+  for (const story of pausedStories) {
+    // Sanitize: agent errors often contain multi-line stack traces (#356)
+    const lastReason = (story.priorErrors?.slice(-1)[0] ?? "no reason recorded").replace(/\n/g, " ").slice(0, 200);
+
+    logger?.info("run-initialization", "Paused story found — prompting user", {
+      storyId: story.id,
+      attempts: story.attempts,
+    });
+
+    const response: InteractionResponse = await chain.prompt({
+      id: `ix-${story.id}-paused-resume`,
+      type: "choose",
+      featureName,
+      storyId: story.id,
+      stage: "pre-flight",
+      summary: `Story ${story.id} is paused — how to proceed?`,
+      detail: `"${story.title}"\nLast reason: ${lastReason}\nAttempts so far: ${story.attempts}`,
+      options: [
+        { key: "resume", label: "Resume", description: "Reset to pending and retry on this run" },
+        { key: "skip", label: "Skip", description: "Mark as skipped, won't be retried" },
+        { key: "keep", label: "Keep paused", description: "Leave paused, skip for this run" },
+      ],
+      timeout: 300_000, // 5 minutes
+      fallback: "continue",
+      createdAt: Date.now(),
+    });
+
+    // Apply fallback so timeout → "approve" instead of "skip" (#356).
+    // Without this, a timed-out prompt hits case "skip" and permanently skips the story.
+    const effectiveAction = chain.applyFallback(response, "continue");
+    const resolvedKey = effectiveAction === "approve" ? "keep" : (response.action as string);
+
+    switch (resolvedKey) {
+      case "resume": {
+        story.status = "pending";
+        summary.resumed.push(story.id);
+        logger?.info("run-initialization", "User resumed paused story", { storyId: story.id });
+        break;
+      }
+      case "skip": {
+        story.status = "skipped";
+        summary.skipped.push(story.id);
+        logger?.info("run-initialization", "User skipped paused story", { storyId: story.id });
+        break;
+      }
+      default: {
+        // "keep" or timeout fallback — leave paused, excluded from this run
+        summary.kept.push(story.id);
+        logger?.info("run-initialization", "Keeping story paused", { storyId: story.id });
+        break;
+      }
+    }
+  }
+
+  return summary;
+}

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -25,7 +25,7 @@ import type { AgentGetFn } from "../../pipeline/types";
 import { loadPlugins } from "../../plugins/loader";
 import type { PluginRegistry } from "../../plugins/registry";
 import type { PRD } from "../../prd";
-import { loadPRD } from "../../prd";
+import { countStories, loadPRD, savePRD } from "../../prd";
 import { detectProjectProfile } from "../../project";
 import { NAX_BUILD_INFO, NAX_COMMIT, NAX_VERSION } from "../../version";
 import { installCrashHandlers } from "../crash-recovery";
@@ -252,7 +252,20 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
       agentGetFn: options.agentGetFn,
     });
     prd = initResult.prd;
-    const counts = initResult.storyCounts;
+    // initializeRun calls loadPRD() internally, producing a new object.
+    // Re-prime statusWriter so crash handlers during the prompt window see current state (#356).
+    statusWriter.setPrd(prd);
+    let counts = initResult.storyCounts;
+
+    // Prompt user for each paused story — skip in headless mode
+    if (counts.paused > 0 && interactionChain !== null) {
+      const { promptForPausedStories } = await import("./paused-story-prompts");
+      const pausedSummary = await promptForPausedStories(prd, interactionChain, feature);
+      if (pausedSummary.resumed.length > 0 || pausedSummary.skipped.length > 0) {
+        await savePRD(prd, prdPath);
+        counts = countStories(prd);
+      }
+    }
 
     return {
       statusWriter,


### PR DESCRIPTION
## Summary

Three bugs in the paused-story re-run interaction prompt (introduced in the feature on `main`). Identified via code review.

Closes #356

- **Timeout silently skipped stories** — `chain.applyFallback()` was never called, so a timed-out 5-minute prompt hit `case "skip"` and permanently marked the story as skipped. Now applies the `"continue"` fallback: timeout → `"keep"` → story stays paused.
- **`statusWriter` held a stale PRD reference** — `initializeRun` calls `loadPRD()` internally, producing a new deserialized object. `statusWriter.setPrd()` was never updated to point at it, so crash handlers during the prompt window wrote stale state to the status file. Fixed by re-priming `statusWriter` after `prd = initResult.prd`.
- **Unescaped `priorErrors` in prompt detail** — Agent error messages (often multi-line stack traces) were injected raw into the `detail` string, corrupting CLI and webhook prompt rendering. Now stripped of newlines and truncated to 200 chars.

## Test plan

- [ ] Re-run a PRD with a paused story — prompt appears for each paused story
- [ ] Select **Resume** → story resets to `pending`, retried this run
- [ ] Select **Skip** → story set to `skipped`, not retried
- [ ] Select **Keep paused** → story status unchanged
- [ ] Walk away from prompt for 5+ minutes (timeout) → story stays paused, NOT skipped
- [ ] Verify `bun run typecheck` and `bun run lint` pass (pre-commit hook confirms)
- [ ] Kill process during prompt window — status file reflects post-`initializeRun` story counts