### PR TITLE
fix(acp): surface real codex error when session exits with code 1

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -590,7 +590,10 @@ export class AcpAgentAdapter implements AgentAdapter {
         const result = await this._runWithClient(options, startTime, currentAgent);
 
         if (!result.success) {
-          getSafeLogger()?.warn("acp-adapter", `Run failed for ${currentAgent}`, { exitCode: result.exitCode });
+          getSafeLogger()?.warn("acp-adapter", `Run failed for ${currentAgent}`, {
+            exitCode: result.exitCode,
+            ...(result.output ? { output: result.output.slice(0, 500) } : {}),
+          });
 
           // BUG-122: session error (acpx exit code 4 — stale/locked session) — retry once
           // with a fresh session when _acpAdapterDeps.shouldRetrySessionError is set.

--- a/src/agents/acp/parser.ts
+++ b/src/agents/acp/parser.ts
@@ -83,6 +83,20 @@ export function parseAcpxJsonLine(line: string, state: AcpxParseState): void {
         }
       }
 
+      // JSON-RPC error response — capture the actual failure reason from acpx/codex
+      if (event.error && typeof event.error === "object") {
+        const err = event.error as Record<string, unknown>;
+        let errorMsg = typeof err.message === "string" ? err.message : JSON.stringify(event.error);
+        // Append acpxCode/detailCode from data for richer context
+        if (err.data && typeof err.data === "object") {
+          const data = err.data as Record<string, unknown>;
+          const suffix = [data.acpxCode, data.detailCode].filter(Boolean).join("/");
+          if (suffix) errorMsg = `${errorMsg} [${suffix}]`;
+        }
+        // First error wins — preserves the root cause if acpx emits a cascade of errors
+        if (!state.error) state.error = errorMsg;
+      }
+
       return;
     }
 

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -201,13 +201,22 @@ class SpawnAcpSession implements AcpSession {
       ]);
 
       if (exitCode !== 0) {
+        // Prefer parsed stdout error (JSON-RPC error response from acpx) over raw stderr.
+        // stderr at this point is typically the acpx session banner ("agent needs reconnect")
+        // which describes connection state, not the actual failure reason.
+        const parsedOnError = finalizeParseState(parseState);
+        // Prefer the parsed JSON-RPC error from stdout over raw stderr.
+        // Do NOT fall back to parsedOnError.text — it may be partial streaming content
+        // accumulated before the crash and would mislead error classification callers.
+        const errorContent = parsedOnError.error || stderr || `Exit code ${exitCode}`;
         getSafeLogger()?.warn("acp-adapter", `Session prompt exited with code ${exitCode}`, {
           exitCode,
-          stderr: stderr.slice(0, 500),
+          error: errorContent.slice(0, 500),
+          ...(stderr && stderr !== errorContent ? { banner: stderr.trim().slice(0, 200) } : {}),
         });
         // Return error response so the adapter can handle it
         return {
-          messages: [{ role: "assistant", content: stderr || `Exit code ${exitCode}` }],
+          messages: [{ role: "assistant", content: errorContent }],
           stopReason: "error",
         };
       }

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -213,6 +213,7 @@ export async function runTddSession(
       storyId: story.id,
       durationMs: Date.now() - startTime,
       exitCode: result.exitCode,
+      ...(result.output ? { output: result.output.slice(0, 500) } : {}),
     });
   }
 


### PR DESCRIPTION
Closes #358

## Summary

- `parseAcpxJsonLine` now captures JSON-RPC error responses (`event.error`) from acpx stdout into `state.error`, with first-error-wins semantics to preserve root cause
- `spawn-client.ts` exit-error path now calls `finalizeParseState` to extract the real error from stdout before falling back to stderr; log distinguishes `error` (actual reason) from `banner` (acpx connection status line)
- `adapter.ts` and `session-runner.ts` "Run failed" / "Session failed" logs now include `result.output` so the actual reason is visible at all log levels

## Root cause

acpx writes the actual failure as a JSON-RPC error on **stdout**:
```json
{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"..."}}
```
`parseAcpxJsonLine` had branches for JSON-RPC notifications and results but not errors — they fell through silently. The `exitCode !== 0` path in `spawn-client.ts` then discarded stdout entirely and returned the stderr banner (`agent needs reconnect`) as the error content.

## Test plan

- [ ] Run nax with codex against a prompt that triggers a mid-session exit (e.g. context overflow, API error)
- [ ] Confirm `Session prompt exited with code 1` log now shows `error: "<actual reason>"` instead of only the `agent needs reconnect` banner
- [ ] Confirm `Run failed for codex` log includes `output: "<actual reason>"`
- [ ] Confirm `Session failed: implementer` log includes `output: "<actual reason>"`
- [ ] Confirm no regression when codex exits cleanly (exit 0 path unchanged)