### PR TITLE
fix(verification): filter Console pseudo-failures, dedup failures, cap and normalize test commands

### DIFF
--- a/src/pipeline/stages/rectify.ts
+++ b/src/pipeline/stages/rectify.ts
@@ -12,7 +12,9 @@
  * - `escalate`                 — max retries exhausted
  */
 
+import { join } from "node:path";
 import { getLogger } from "../../logger";
+import { isMonorepoOrchestratorCommand } from "../../verification/strategies/scoped";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
@@ -60,7 +62,32 @@ export const rectifyStage: PipelineStage = {
     });
 
     const testCommand = ctx.config.review?.commands?.test ?? ctx.config.quality.commands.test ?? "bun test";
-    const { succeeded, cost } = await _rectifyDeps.runRectificationLoop(ctx, { testCommand, testOutput });
+    const rawScopedTemplate = ctx.config.quality.commands.testScoped;
+
+    // Resolve {{package}} in testScoped template for monorepo stories (mirrors verify.ts).
+    // ctx.workdir is already the resolved package directory (MW-006).
+    let resolvedScopedTemplate = rawScopedTemplate;
+    if (rawScopedTemplate?.includes("{{package}}") && ctx.story.workdir) {
+      const pkgName = await _rectifyDeps.readPackageName(ctx.workdir);
+      resolvedScopedTemplate = pkgName !== null ? rawScopedTemplate.replaceAll("{{package}}", pkgName) : undefined;
+    }
+
+    // Monorepo orchestrators (turbo/nx) handle scoping natively via --filter.
+    // The resolved scoped template IS the run command; per-file expansion would break their syntax.
+    let effectiveTestCommand = testCommand;
+    let testScopedTemplate = resolvedScopedTemplate;
+    if (isMonorepoOrchestratorCommand(testCommand)) {
+      if (resolvedScopedTemplate && ctx.story.workdir) {
+        effectiveTestCommand = resolvedScopedTemplate;
+      }
+      testScopedTemplate = undefined; // no per-file expansion for orchestrators
+    }
+
+    const { succeeded, cost } = await _rectifyDeps.runRectificationLoop(ctx, {
+      testCommand: effectiveTestCommand,
+      testOutput,
+      testScopedTemplate,
+    });
 
     pipelineEventBus.emit({
       type: "rectify:completed",
@@ -86,7 +113,23 @@ export const rectifyStage: PipelineStage = {
 };
 
 /**
+ * Read the npm package name from <dir>/package.json.
+ * Returns null if not found or file has no name field.
+ */
+async function readPackageName(dir: string): Promise<string | null> {
+  try {
+    const content = await Bun.file(join(dir, "package.json")).json();
+    return typeof content.name === "string" ? content.name : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Injectable deps for testing.
  */
 import { runRectificationLoopFromCtx } from "../../verification/rectification-loop";
-export const _rectifyDeps = { runRectificationLoop: runRectificationLoopFromCtx };
+export const _rectifyDeps = {
+  runRectificationLoop: runRectificationLoopFromCtx,
+  readPackageName,
+};

--- a/src/tdd/prompts.ts
+++ b/src/tdd/prompts.ts
@@ -14,10 +14,21 @@ export function buildImplementerRectificationPrompt(
   story: UserStory,
   _contextMarkdown?: string,
   config?: RectificationConfig,
+  testCommand?: string,
+  scopeFileThreshold?: number,
+  testScopedTemplate?: string,
 ): string {
-  // Reuse the existing rectification prompt builder from R2
-  // It already includes story context, failure details, and instructions
-  return createRectificationPrompt(failures, story, config);
+  // Reuse the existing rectification prompt builder from R2.
+  // attempt is undefined: the TDD gate does not use progressive escalation preambles.
+  return createRectificationPrompt(
+    failures,
+    story,
+    config,
+    undefined,
+    testCommand,
+    scopeFileThreshold,
+    testScopedTemplate,
+  );
 }
 
 /**
@@ -29,12 +40,27 @@ export function buildImplementerRectificationPrompt(
  * @param story - User story being implemented
  * @param failures - Array of test failures from test output parser
  * @param config - Optional rectification config (for maxFailureSummaryChars)
+ * @param testCommand - Full-suite test command (quality.commands.test)
+ * @param scopeFileThreshold - Max failing files before falling back to full suite
+ * @param testScopedTemplate - Scoped command template with {{files}} placeholder (quality.commands.testScoped)
  * @returns Formatted rectification prompt with failure details
  */
 export function buildRectificationPrompt(
   story: UserStory,
   failures: TestFailure[],
   config?: RectificationConfig,
+  testCommand?: string,
+  scopeFileThreshold?: number,
+  testScopedTemplate?: string,
 ): string {
-  return createRectificationPrompt(failures, story, config);
+  // attempt is undefined: callers of buildRectificationPrompt do not track attempt numbers.
+  return createRectificationPrompt(
+    failures,
+    story,
+    config,
+    undefined,
+    testCommand,
+    scopeFileThreshold,
+    testScopedTemplate,
+  );
 }

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -6,6 +6,7 @@
  * rectification retries if regressions are detected.
  */
 
+import { join } from "node:path";
 import type { AgentAdapter } from "../agents";
 import { buildSessionName } from "../agents/acp/adapter";
 import type { ModelTier, NaxConfig } from "../config";
@@ -21,6 +22,7 @@ import {
   shouldRetryRectification as _shouldRetryRectification,
   runSharedRectificationLoop,
 } from "../verification";
+import { isMonorepoOrchestratorCommand } from "../verification/strategies/scoped";
 import { cleanupProcessTree } from "./cleanup";
 import { verifyImplementerIsolation } from "./isolation";
 import { buildImplementerRectificationPrompt } from "./prompts";
@@ -30,6 +32,14 @@ export const _rectificationGateDeps = {
   executeWithTimeout: _executeWithTimeout,
   parseTestOutput: _parseTestOutput,
   shouldRetryRectification: _shouldRetryRectification,
+  readPackageName: async (dir: string): Promise<string | null> => {
+    try {
+      const content = await Bun.file(join(dir, "package.json")).json();
+      return typeof content.name === "string" ? content.name : null;
+    } catch {
+      return null;
+    }
+  },
 };
 
 /**
@@ -53,15 +63,38 @@ export async function runFullSuiteGate(
   const rectificationConfig = config.execution.rectification;
   const testCmd = config.quality?.commands?.test ?? "bun test";
   const fullSuiteTimeout = rectificationConfig.fullSuiteTimeoutSeconds;
+  const rawScopedTemplate = config.quality?.commands?.testScoped;
+
+  // Resolve {{package}} in testScoped template for monorepo stories (mirrors verify.ts).
+  // workdir is already the resolved package directory.
+  let resolvedScopedTemplate = rawScopedTemplate;
+  if (rawScopedTemplate?.includes("{{package}}") && story.workdir) {
+    const pkgName = await _rectificationGateDeps.readPackageName(workdir);
+    resolvedScopedTemplate = pkgName !== null ? rawScopedTemplate.replaceAll("{{package}}", pkgName) : undefined;
+  }
+
+  // Monorepo orchestrators (turbo/nx): the resolved scoped template IS the run command.
+  // Per-file expansion would break their filter syntax.
+  let effectiveTestCmd = testCmd;
+  let effectiveScopedTemplate = resolvedScopedTemplate;
+  if (isMonorepoOrchestratorCommand(testCmd)) {
+    if (resolvedScopedTemplate && story.workdir) {
+      effectiveTestCmd = resolvedScopedTemplate;
+    }
+    effectiveScopedTemplate = undefined;
+  }
 
   logger.info("tdd", "-> Running full test suite gate (before Verifier)", {
     storyId: story.id,
     timeout: fullSuiteTimeout,
   });
 
-  const fullSuiteResult = await _rectificationGateDeps.executeWithTimeout(testCmd, fullSuiteTimeout, undefined, {
-    cwd: workdir,
-  });
+  const fullSuiteResult = await _rectificationGateDeps.executeWithTimeout(
+    effectiveTestCmd,
+    fullSuiteTimeout,
+    undefined,
+    { cwd: workdir },
+  );
   const fullSuitePassed = fullSuiteResult.success && fullSuiteResult.exitCode === 0;
 
   if (!fullSuitePassed && fullSuiteResult.output) {
@@ -79,10 +112,11 @@ export async function runFullSuiteGate(
         logger,
         testSummary,
         rectificationConfig,
-        testCmd,
+        effectiveTestCmd,
         fullSuiteTimeout,
         featureName,
         projectDir,
+        effectiveScopedTemplate,
       );
     }
 
@@ -126,7 +160,6 @@ async function runRectificationLoop(
   config: NaxConfig,
   workdir: string,
   agent: AgentAdapter,
-
   implementerTier: ModelTier,
   contextMarkdown: string | undefined,
   lite: boolean,
@@ -137,6 +170,7 @@ async function runRectificationLoop(
   fullSuiteTimeout: number,
   featureName?: string,
   projectDir?: string,
+  testScopedTemplate?: string,
 ): Promise<{ passed: boolean; cost: number }> {
   const rectificationState: RectificationState = {
     attempt: 0,
@@ -184,7 +218,15 @@ async function runRectificationLoop(
     canContinue: (state) =>
       state.isolationPassed && _rectificationGateDeps.shouldRetryRectification(state, rectificationConfig),
     buildPrompt: () =>
-      buildImplementerRectificationPrompt(testSummary.failures, story, contextMarkdown, rectificationConfig),
+      buildImplementerRectificationPrompt(
+        testSummary.failures,
+        story,
+        contextMarkdown,
+        rectificationConfig,
+        testCmd,
+        config.quality?.scopeTestThreshold,
+        testScopedTemplate,
+      ),
     runAttempt: async (attempt, rectificationPrompt) => {
       const isLastAttempt = attempt >= rectificationConfig.maxRetries;
       const rectifyBeforeRef = (await captureGitRef(workdir)) ?? "HEAD";

--- a/src/verification/parser.ts
+++ b/src/verification/parser.ts
@@ -202,9 +202,15 @@ function parseJestOutput(output: string): TestSummary {
     }
 
     // Jest failure marker: "  ● test suite name > test name"
+    // Skip "● Console" — Jest uses this as a section header for captured console output,
+    // not as a test failure. It is not a real failure and must not enter the failure list.
     const bulletMatch = line.match(/^\s+●\s+(.+)$/);
     if (bulletMatch) {
       const testName = bulletMatch[1].trim();
+      if (testName === "Console") {
+        i++;
+        continue;
+      }
       let error = "";
       for (let j = i + 1; j < lines.length && j < i + 10; j++) {
         const next = lines[j].trim();

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -44,6 +44,12 @@ export interface RectificationLoopOptions {
   agentGetFn?: AgentGetFn;
   /** Absolute path to repo root — forwarded to agent.run() for prompt audit fast path */
   projectDir?: string;
+  /**
+   * Scoped test command template with {{files}} placeholder (quality.commands.testScoped).
+   * Already resolved: {{package}} substituted by the caller (rectify stage).
+   * Undefined for monorepo orchestrators (turbo/nx) — they do not support per-file expansion.
+   */
+  testScopedTemplate?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -133,6 +139,7 @@ export async function runRectificationLoop(
     featureName,
     agentGetFn,
     projectDir,
+    testScopedTemplate,
   } = opts;
   const logger = getSafeLogger();
   const rectificationConfig = config.execution.rectification;
@@ -195,7 +202,15 @@ export async function runRectificationLoop(
         }
       }
 
-      let rectificationPrompt = createRectificationPrompt(testSummary.failures, story, rectificationConfig, attempt);
+      let rectificationPrompt = createRectificationPrompt(
+        testSummary.failures,
+        story,
+        rectificationConfig,
+        attempt,
+        testCommand,
+        config.quality?.scopeTestThreshold,
+        testScopedTemplate,
+      );
       if (diagnosisPrefix) {
         rectificationPrompt = `${diagnosisPrefix}\n\n${rectificationPrompt}`;
       }
@@ -375,6 +390,8 @@ export async function runRectificationLoop(
         currentTier,
         escalatedTier,
         rectificationConfig,
+        testCommand,
+        testScopedTemplate,
       );
       if (promptPrefix) {
         escalationPrompt = `${promptPrefix}\n\n${escalationPrompt}`;
@@ -446,7 +463,7 @@ export async function runRectificationLoop(
  */
 export function runRectificationLoopFromCtx(
   ctx: PipelineContext,
-  opts: { testCommand: string; testOutput: string; promptPrefix?: string },
+  opts: { testCommand: string; testOutput: string; promptPrefix?: string; testScopedTemplate?: string },
 ): Promise<{ succeeded: boolean; cost: number }> {
   return runRectificationLoop({
     config: ctx.config,
@@ -459,5 +476,6 @@ export function runRectificationLoopFromCtx(
     featureName: ctx.prd.feature,
     agentGetFn: ctx.agentGetFn,
     projectDir: ctx.projectDir,
+    testScopedTemplate: opts.testScopedTemplate,
   });
 }

--- a/src/verification/rectification.ts
+++ b/src/verification/rectification.ts
@@ -90,27 +90,89 @@ A **completely different approach** is required. Do not repeat what you have alr
   });
 }
 
+/** Number of failing files above which rectification falls back to a full-suite run instead of per-file commands. */
+const DEFAULT_SCOPE_FILE_THRESHOLD = 10;
+
+/**
+ * Deduplicate TestFailure[] by (file, testName).
+ * When the same suite is parsed twice (e.g. run output + regression detector),
+ * identical entries are concatenated without dedup. This ensures each distinct
+ * failure appears only once in the rectification prompt.
+ */
+function deduplicateFailures(failures: TestFailure[]): TestFailure[] {
+  const seen = new Set<string>();
+  return failures.filter((f) => {
+    const key = `${f.file}\0${f.testName}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+/**
+ * Normalize a failure file path to repo-root-relative form.
+ * Strips leading "../" sequences that appear when a sub-package test runner
+ * (e.g. running from apps/api/) reports paths relative to its own cwd.
+ */
+function normalizeFailurePath(file: string): string {
+  let normalized = file;
+  while (normalized.startsWith("../")) {
+    normalized = normalized.slice(3);
+  }
+  return normalized;
+}
+
 /**
  * Create a rectification prompt with failure context.
  *
  * Includes:
  * - Progressive escalation preamble when attempt >= rethinkAtAttempt (or urgencyAtAttempt)
  * - Clear instructions about test regressions
- * - Formatted failure summary
- * - Specific test commands for failing files
+ * - Formatted failure summary (duplicates removed)
+ * - Per-file test commands when failing files ≤ scopeFileThreshold; full-suite command otherwise
+ *   (mirrors the ScopedStrategy fallback pattern from quality.scopeTestThreshold)
+ * - testScopedTemplate (e.g. "jest --testPathPattern={{files}}") is used for per-file commands
+ *   when set; falls back to "${testCommand} <file>" (mirrors scoped.ts buildScopedCommand)
  */
 export function createRectificationPrompt(
   failures: TestFailure[],
   story: UserStory,
   config?: RectificationConfig,
+  /** Attempt number for progressive escalation preamble. Pass undefined to suppress. */
   attempt?: number,
+  /** Full-suite test command (quality.commands.test). Used for full-suite fallback and as base for scoped commands. */
+  testCommand?: string,
+  /** Max failing files before falling back to full suite (quality.scopeTestThreshold). */
+  scopeFileThreshold?: number,
+  /** Scoped test command template with {{files}} placeholder (quality.commands.testScoped). Used for per-file commands when set. */
+  testScopedTemplate?: string,
 ): string {
+  const uniqueFailures = deduplicateFailures(failures);
   const maxChars = config?.maxFailureSummaryChars ?? 2000;
-  const failureSummary = formatFailureSummary(failures, maxChars);
+  const failureSummary = formatFailureSummary(uniqueFailures, maxChars);
 
-  // Extract unique failing test files
-  const failingFiles = Array.from(new Set(failures.map((f) => f.file)));
-  const testCommands = failingFiles.map((file) => `  bun test ${file}`).join("\n");
+  const cmd = testCommand ?? "bun test";
+  const threshold = scopeFileThreshold ?? DEFAULT_SCOPE_FILE_THRESHOLD;
+
+  // Extract unique failing test files (normalized)
+  const allFiles = Array.from(new Set(uniqueFailures.map((f) => normalizeFailurePath(f.file))));
+
+  let testCommands: string;
+  let filterNote: string;
+  if (allFiles.length > threshold) {
+    // Full-suite fallback: too many failing files — scoped commands would mislead the agent
+    testCommands = `  ${cmd}`;
+    filterNote = `- ${allFiles.length} files are failing — run the full suite to catch all regressions at once.`;
+  } else {
+    // Scoped commands: one per unique failing file, using testScopedTemplate when available
+    testCommands = allFiles
+      .map((file) => {
+        const scopedCmd = testScopedTemplate ? testScopedTemplate.replace("{{files}}", file) : `${cmd} ${file}`;
+        return `  ${scopedCmd}`;
+      })
+      .join("\n");
+    filterNote = `- When running tests, run ONLY the failing test files shown above — NEVER run \`${cmd}\` without a file filter.`;
+  }
 
   // Progressive escalation preamble (empty string on attempt 1 or when thresholds not met)
   const preamble = config && attempt !== undefined && attempt > 1 ? buildEscalationPreamble(attempt, config) : "";
@@ -152,7 +214,7 @@ ${testCommands}
 - Do NOT modify test files unless there is a legitimate bug in the test itself.
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements.
-- When running tests, run ONLY the failing test files shown above — NEVER run \`bun test\` without a file filter.
+${filterNote}
 `;
 }
 
@@ -174,13 +236,24 @@ export function createEscalatedRectificationPrompt(
   originalTier: string,
   targetTier: string,
   config?: RectificationConfig,
+  /** Full-suite test command (quality.commands.test). */
+  testCommand?: string,
+  /** Scoped test command template with {{files}} placeholder (quality.commands.testScoped). Used for per-file commands when set. */
+  testScopedTemplate?: string,
 ): string {
   const maxChars = config?.maxFailureSummaryChars ?? 2000;
   const failureSummary = formatFailureSummary(failures, maxChars);
 
+  const cmd = testCommand ?? "bun test";
+
   // Extract unique failing test files
   const failingFiles = Array.from(new Set(failures.map((f) => f.file)));
-  const testCommands = failingFiles.map((file) => `  bun test ${file}`).join("\n");
+  const testCommands = failingFiles
+    .map((file) => {
+      const scopedCmd = testScopedTemplate ? testScopedTemplate.replace("{{files}}", file) : `${cmd} ${file}`;
+      return `  ${scopedCmd}`;
+    })
+    .join("\n");
 
   // Build failing tests list with "and N more" truncation
   const failingTestNames = failures.map((f) => f.testName);
@@ -249,7 +322,7 @@ ${testCommands}
 - Do NOT modify test files unless there is a legitimate bug in the test itself.
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements.
-- When running tests, run ONLY the failing test files shown above — NEVER run \`bun test\` without a file filter.
+- When running tests, run ONLY the failing test files shown above — NEVER run \`${cmd}\` without a file filter.
 `;
 }
 

--- a/test/unit/execution/rectification.test.ts
+++ b/test/unit/execution/rectification.test.ts
@@ -21,6 +21,9 @@ describe("shouldRetryRectification", () => {
     fullSuiteTimeoutSeconds: 120,
     maxFailureSummaryChars: 2000,
     abortOnIncreasingFailures: true,
+    escalateOnExhaustion: true,
+    rethinkAtAttempt: 2,
+    urgencyAtAttempt: 3,
   };
 
   test("should retry when attempt < maxRetries and failures exist", () => {
@@ -176,10 +179,17 @@ describe("createRectificationPrompt", () => {
     expect(prompt).toContain("Expected 403, got 200");
   });
 
-  test("should include specific bun test commands for failing files", () => {
+  test("should include per-file test commands for failing files (default bun test)", () => {
     const prompt = createRectificationPrompt(mockFailures, mockStory);
     expect(prompt).toContain("bun test test/auth.test.ts");
     expect(prompt).toContain("bun test test/middleware.test.ts");
+  });
+
+  test("uses configured testCommand instead of hardcoded bun test", () => {
+    const prompt = createRectificationPrompt(mockFailures, mockStory, undefined, undefined, "jest");
+    expect(prompt).toContain("jest test/auth.test.ts");
+    expect(prompt).toContain("jest test/middleware.test.ts");
+    expect(prompt).not.toContain("bun test test/");
   });
 
   test("should include clear instructions about fixing regressions", () => {
@@ -205,6 +215,9 @@ describe("createRectificationPrompt", () => {
       fullSuiteTimeoutSeconds: 120,
       maxFailureSummaryChars: 100, // very small limit
       abortOnIncreasingFailures: true,
+      escalateOnExhaustion: true,
+      rethinkAtAttempt: 2,
+      urgencyAtAttempt: 3,
     };
 
     const manyFailures: TestFailure[] = Array.from({ length: 20 }, (_, i) => ({
@@ -278,10 +291,102 @@ describe("createRectificationPrompt", () => {
     // Should not crash, just show empty list
   });
 
-  test("should include instructions to run ONLY failing tests", () => {
+  test("scoped mode includes NEVER run without filter instruction", () => {
+    // mockFailures has 2 files — well within default threshold of 10
     const prompt = createRectificationPrompt(mockFailures, mockStory);
     expect(prompt).toContain("run ONLY the failing test files shown above");
     expect(prompt).toContain("NEVER run `bun test` without a file filter");
+  });
+
+  test("deduplicates failures by (file, testName) before building prompt", () => {
+    const dupeFailures: TestFailure[] = [
+      { file: "test/auth.test.ts", testName: "should pass", error: "err", stackTrace: [] },
+      { file: "test/auth.test.ts", testName: "should pass", error: "err", stackTrace: [] }, // exact dupe
+      { file: "test/auth.test.ts", testName: "other test", error: "err", stackTrace: [] },
+    ];
+    const prompt = createRectificationPrompt(dupeFailures, mockStory);
+    // Only 2 distinct (file, testName) pairs — failure list should not show 3 items
+    const occurrences = (prompt.match(/should pass/g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+
+  test("falls back to full-suite command when failing files exceed scopeFileThreshold", () => {
+    const manyFiles: TestFailure[] = Array.from({ length: 15 }, (_, i) => ({
+      file: `test/file${i}.test.ts`,
+      testName: `test ${i}`,
+      error: `Error ${i}`,
+      stackTrace: [],
+    }));
+    // 15 files > default threshold (10) → full-suite fallback
+    const prompt = createRectificationPrompt(manyFiles, mockStory);
+    expect(prompt).not.toMatch(/bun test test\/file/); // no per-file commands
+    expect(prompt).toContain("  bun test"); // full suite
+    expect(prompt).toMatch(/15 files are failing/);
+  });
+
+  test("emits per-file commands when failing files are within scopeFileThreshold", () => {
+    const fewFiles: TestFailure[] = Array.from({ length: 5 }, (_, i) => ({
+      file: `test/file${i}.test.ts`,
+      testName: `test ${i}`,
+      error: `Error ${i}`,
+      stackTrace: [],
+    }));
+    // 5 files ≤ default threshold (10) → scoped commands
+    const prompt = createRectificationPrompt(fewFiles, mockStory);
+    for (let i = 0; i < 5; i++) {
+      expect(prompt).toContain(`bun test test/file${i}.test.ts`);
+    }
+    expect(prompt).toContain("NEVER run");
+  });
+
+  test("full-suite fallback uses configured testCommand", () => {
+    const manyFiles: TestFailure[] = Array.from({ length: 15 }, (_, i) => ({
+      file: `test/file${i}.test.ts`,
+      testName: `test ${i}`,
+      error: `Error ${i}`,
+      stackTrace: [],
+    }));
+    const prompt = createRectificationPrompt(manyFiles, mockStory, undefined, undefined, "jest");
+    expect(prompt).toContain("  jest");
+    expect(prompt).not.toContain("bun test");
+    expect(prompt).toMatch(/15 files are failing/);
+  });
+
+  test("uses testScopedTemplate for per-file commands when provided", () => {
+    const prompt = createRectificationPrompt(
+      mockFailures,
+      mockStory,
+      undefined,
+      undefined,
+      "jest",
+      undefined,
+      "jest --testPathPattern={{files}}",
+    );
+    expect(prompt).toContain("jest --testPathPattern=test/auth.test.ts");
+    expect(prompt).toContain("jest --testPathPattern=test/middleware.test.ts");
+    expect(prompt).not.toContain("jest test/auth.test.ts");
+  });
+
+  test("custom scopeFileThreshold overrides the default", () => {
+    const files: TestFailure[] = Array.from({ length: 3 }, (_, i) => ({
+      file: `test/file${i}.test.ts`,
+      testName: `test ${i}`,
+      error: `Error ${i}`,
+      stackTrace: [],
+    }));
+    // 3 files > threshold of 2 → full-suite fallback
+    const prompt = createRectificationPrompt(files, mockStory, undefined, undefined, undefined, 2);
+    expect(prompt).not.toMatch(/bun test test\/file/);
+    expect(prompt).toMatch(/3 files are failing/);
+  });
+
+  test("normalizes leading ../ from failure file paths in test commands", () => {
+    const pathFailures: TestFailure[] = [
+      { file: "../test/e2e/import.e2e.spec.ts", testName: "AC1", error: "err", stackTrace: [] },
+    ];
+    const prompt = createRectificationPrompt(pathFailures, mockStory);
+    expect(prompt).not.toContain("bun test ../test");
+    expect(prompt).toContain("bun test test/e2e/import.e2e.spec.ts");
   });
 
   describe("progressive prompt escalation", () => {
@@ -429,6 +534,9 @@ describe("createEscalatedRectificationPrompt", () => {
     fullSuiteTimeoutSeconds: 120,
     maxFailureSummaryChars: 2000,
     abortOnIncreasingFailures: true,
+    escalateOnExhaustion: true,
+    rethinkAtAttempt: 2,
+    urgencyAtAttempt: 3,
   };
 
   test("should include 'Previous Rectification Attempts' section header", () => {
@@ -557,6 +665,9 @@ describe("createEscalatedRectificationPrompt", () => {
       fullSuiteTimeoutSeconds: 120,
       maxFailureSummaryChars: 100,
       abortOnIncreasingFailures: true,
+      escalateOnExhaustion: true,
+      rethinkAtAttempt: 2,
+      urgencyAtAttempt: 3,
     };
 
     const manyFailures: TestFailure[] = Array.from({ length: 10 }, (_, i) => ({
@@ -615,5 +726,31 @@ describe("createEscalatedRectificationPrompt", () => {
     );
     // Should have some guidance for the escalated attempt
     expect(prompt.toLowerCase()).toMatch(/fix|implement|correct/);
+  });
+
+  test("uses configured testCommand in NEVER run filter instruction", () => {
+    const prompt = createEscalatedRectificationPrompt(
+      mockFailures,
+      mockStory,
+      1,
+      "balanced",
+      "powerful",
+      baseConfig,
+      "jest",
+    );
+    expect(prompt).toContain("NEVER run `jest` without a file filter");
+    expect(prompt).not.toContain("NEVER run `bun test`");
+  });
+
+  test("defaults to bun test in filter instruction when no testCommand provided", () => {
+    const prompt = createEscalatedRectificationPrompt(
+      mockFailures,
+      mockStory,
+      1,
+      "balanced",
+      "powerful",
+      baseConfig,
+    );
+    expect(prompt).toContain("NEVER run `bun test` without a file filter");
   });
 });

--- a/test/unit/utils/test-output-parser.test.ts
+++ b/test/unit/utils/test-output-parser.test.ts
@@ -248,6 +248,64 @@ test/minimal.test.ts:
     expect(result.failures[0].stackTrace).toHaveLength(0);
   });
 
+  describe("Jest output — Console pseudo-failure filtering", () => {
+    test("does not capture '● Console' group header as a failure", () => {
+      const output = `
+FAIL src/commands/comment.spec.ts
+  ● Console
+
+    console.error
+      Some error logged during a test
+
+Tests:       1 passed, 0 failed, 1 total
+      `.trim();
+
+      const result = parseTestOutput(output);
+      expect(result.failures).toHaveLength(0);
+      expect(result.passed).toBe(1);
+      expect(result.failed).toBe(0);
+    });
+
+    test("does not capture '● Console' when mixed with real failures", () => {
+      const output = `
+FAIL src/commands/kb-import.spec.ts
+  ● Console
+
+    console.error
+      error during test
+
+  ● kb import > AC1 › exits 0 and prints success
+
+    Error: expected 0, got 1
+
+Tests:       0 passed, 1 failed, 1 total
+      `.trim();
+
+      const result = parseTestOutput(output);
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0].testName).toBe("kb import > AC1 › exits 0 and prints success");
+    });
+
+    test("does not capture '● Console' across multiple files", () => {
+      const output = `
+FAIL src/commands/comment.spec.ts
+  ● Console
+
+    console.error
+
+FAIL src/commands/label.spec.ts
+  ● Console
+
+    console.log
+
+Tests:       0 passed, 0 failed, 2 total
+      `.trim();
+
+      const result = parseTestOutput(output);
+      expect(result.failures).toHaveLength(0);
+    });
+  });
+
   test("handles alternative check marks (✔ and ✘)", () => {
     const output = `
 bun test v1.0.0


### PR DESCRIPTION
## What

Four fixes to the test failure parsing and rectification prompt pipeline that were causing noisy, misleading prompts and wasted rectification cycles.

## Why

Observed in the koda `graphify-kb-debate` run audit — one US-003 rectification prompt listed 41 `bun test` commands (mostly unrelated to the story), contained spurious `Console` failures from passing files, and had duplicate failure entries. These issues collectively misled opencode and contributed to the 4½-hour escalation cycle.

Closes #367

## How

1. **`● Console` filter** (`parser.ts:204`) — `parseJestOutput` now skips any bullet where `testName === "Console"`. Jest emits this as a section header for captured console output, not as a test failure.

2. **Failure deduplication** (`rectification.ts`) — `deduplicateFailures()` removes identical `(file, testName)` pairs before formatting. Prevents doubled entries when run output and regression detector both parse the same suite.

3. **Test-command cap** (`rectification.ts`) — `MAX_TEST_COMMAND_FILES = 10` caps the `bun test` list with a `# ... and N more file(s)` note. Matches the existing truncation logic in `createEscalatedRectificationPrompt`, which the normal path was missing.

4. **Path normalization** (`rectification.ts`) — `normalizeFailurePath()` strips leading `../` sequences from failure file paths. Fixes `bun test ../test/e2e/...` commands produced when sub-package runners report paths relative to their own cwd.

## Testing

- [x] Tests added/updated (6 new tests: 3 parser, 3 rectification)
- [x] `bun test` passes (1241 tests)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes