### PR TITLE
refactor(quality): resolveQualityTestCommands SSOT

### DIFF
--- a/src/pipeline/stages/rectify.ts
+++ b/src/pipeline/stages/rectify.ts
@@ -12,9 +12,8 @@
  * - `escalate`                 — max retries exhausted
  */
 
-import { join } from "node:path";
 import { getLogger } from "../../logger";
-import { isMonorepoOrchestratorCommand } from "../../verification/strategies/scoped";
+import { resolveQualityTestCommands } from "../../quality/command-resolver";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
@@ -61,30 +60,15 @@ export const rectifyStage: PipelineStage = {
       testOutput,
     });
 
-    const testCommand = ctx.config.review?.commands?.test ?? ctx.config.quality.commands.test ?? "bun test";
-    const rawScopedTemplate = ctx.config.quality.commands.testScoped;
-
-    // Resolve {{package}} in testScoped template for monorepo stories (mirrors verify.ts).
-    // ctx.workdir is already the resolved package directory (MW-006).
-    let resolvedScopedTemplate = rawScopedTemplate;
-    if (rawScopedTemplate?.includes("{{package}}") && ctx.story.workdir) {
-      const pkgName = await _rectifyDeps.readPackageName(ctx.workdir);
-      resolvedScopedTemplate = pkgName !== null ? rawScopedTemplate.replaceAll("{{package}}", pkgName) : undefined;
-    }
-
-    // Monorepo orchestrators (turbo/nx) handle scoping natively via --filter.
-    // The resolved scoped template IS the run command; per-file expansion would break their syntax.
-    let effectiveTestCommand = testCommand;
-    let testScopedTemplate = resolvedScopedTemplate;
-    if (isMonorepoOrchestratorCommand(testCommand)) {
-      if (resolvedScopedTemplate && ctx.story.workdir) {
-        effectiveTestCommand = resolvedScopedTemplate;
-      }
-      testScopedTemplate = undefined; // no per-file expansion for orchestrators
-    }
+    // Resolve test commands via SSOT — handles priority, {{package}}, and orchestrator promotion.
+    const { testCommand: effectiveTestCommand, testScopedTemplate } = await _rectifyDeps.resolveTestCommands(
+      ctx.config,
+      ctx.workdir,
+      ctx.story.workdir,
+    );
 
     const { succeeded, cost } = await _rectifyDeps.runRectificationLoop(ctx, {
-      testCommand: effectiveTestCommand,
+      testCommand: effectiveTestCommand ?? "bun test",
       testOutput,
       testScopedTemplate,
     });
@@ -113,23 +97,10 @@ export const rectifyStage: PipelineStage = {
 };
 
 /**
- * Read the npm package name from <dir>/package.json.
- * Returns null if not found or file has no name field.
- */
-async function readPackageName(dir: string): Promise<string | null> {
-  try {
-    const content = await Bun.file(join(dir, "package.json")).json();
-    return typeof content.name === "string" ? content.name : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Injectable deps for testing.
  */
 import { runRectificationLoopFromCtx } from "../../verification/rectification-loop";
 export const _rectifyDeps = {
   runRectificationLoop: runRectificationLoopFromCtx,
-  readPackageName,
+  resolveTestCommands: resolveQualityTestCommands,
 };

--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -9,15 +9,14 @@
  * - `escalate`: TIMEOUT or RUNTIME_CRASH (structural — rectify can't fix these)
  */
 
-import { join } from "node:path";
 import type { SmartTestRunnerConfig } from "../../config/types";
 import { getLogger } from "../../logger";
+import { resolveQualityTestCommands } from "../../quality/command-resolver";
 import { logTestOutput } from "../../utils/log-test-output";
 import { detectRuntimeCrash } from "../../verification/crash-detector";
 import type { VerifyStatus } from "../../verification/orchestrator-types";
 import { regression } from "../../verification/runners";
 import { _smartRunnerDeps } from "../../verification/smart-runner";
-import { isMonorepoOrchestratorCommand } from "../../verification/strategies/scoped";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 const DEFAULT_SMART_RUNNER_CONFIG: SmartTestRunnerConfig = {
@@ -47,41 +46,6 @@ function buildScopedCommand(testFiles: string[], baseCommand: string, testScoped
   return _smartRunnerDeps.buildSmartTestCommand(testFiles, baseCommand);
 }
 
-/**
- * Read the npm package name from <dir>/package.json.
- * Returns null if not found or file has no name field.
- */
-async function readPackageName(dir: string): Promise<string | null> {
-  try {
-    const content = await Bun.file(join(dir, "package.json")).json();
-    return typeof content.name === "string" ? content.name : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Substitute {{package}} placeholder in a testScoped template.
- *
- * Reads the npm package name from <packageDir>/package.json.
- * Returns null when package.json is absent or has no name field — callers
- * should skip the template entirely in that case (non-JS/non-Node projects
- * have no package identity to inject, so don't fall back to a dir name guess).
- *
- * @param template   - Template string (e.g. "bunx turbo test --filter={{package}}")
- * @param packageDir - Absolute path to the package directory
- * @returns Resolved template, or null if {{package}} cannot be resolved
- */
-async function resolvePackageTemplate(template: string, packageDir: string): Promise<string | null> {
-  if (!template.includes("{{package}}")) return template;
-  const name = await _verifyDeps.readPackageName(packageDir);
-  if (name === null) {
-    // No package.json or no name field — skip template, can't resolve {{package}}
-    return null;
-  }
-  return template.replaceAll("{{package}}", name);
-}
-
 export const verifyStage: PipelineStage = {
   name: "verify",
   enabled: (ctx: PipelineContext) => !ctx.fullSuiteGatePassed,
@@ -96,10 +60,11 @@ export const verifyStage: PipelineStage = {
       return { action: "continue" };
     }
 
-    // Skip verification if no test command is configured
-    const testCommand = ctx.config.review?.commands?.test ?? ctx.config.quality.commands.test;
-    const testScopedTemplate = ctx.config.quality.commands.testScoped;
-    if (!testCommand) {
+    // Resolve test commands via SSOT — handles priority, {{package}}, and orchestrator promotion.
+    const { rawTestCommand, testCommand, testScopedTemplate, isMonorepoOrchestrator } =
+      await _verifyDeps.resolveTestCommands(ctx.config, ctx.workdir, ctx.story.workdir);
+
+    if (!rawTestCommand) {
       logger.debug("verify", "Skipping verification (no test command configured)", { storyId: ctx.story.id });
       return { action: "continue" };
     }
@@ -109,28 +74,19 @@ export const verifyStage: PipelineStage = {
     // MW-006: workdir is already resolved to the package directory at context creation
 
     // Determine effective test command (smart runner or full suite)
-    let effectiveCommand = testCommand;
+    let effectiveCommand = rawTestCommand;
     let isFullSuite = true;
     const smartRunnerConfig = coerceSmartTestRunner(ctx.config.execution.smartTestRunner);
     const regressionMode = ctx.config.execution.regressionGate?.mode ?? "deferred";
 
-    // Resolve {{package}} in testScoped template for monorepo stories.
-    // Returns null if package.json is absent (non-JS project) — falls through to smart-runner.
-    let resolvedTestScopedTemplate: string | undefined = testScopedTemplate;
-    if (testScopedTemplate && ctx.story.workdir) {
-      const resolved = await resolvePackageTemplate(testScopedTemplate, ctx.workdir);
-      resolvedTestScopedTemplate = resolved ?? undefined; // null → skip template
-    }
-
     // Monorepo orchestrators (turbo, nx) handle change-aware scoping natively via their own
     // filter syntax. Skip nax's smart runner — appending file paths would produce invalid syntax.
-    // Instead, use the testScoped template (with {{package}} resolved) to scope per-story.
-    const isMonorepoOrchestrator = isMonorepoOrchestratorCommand(testCommand);
-
+    // When storyWorkdir is set, testCommand is the promoted scoped template (e.g. "bunx turbo test --filter=@pkg").
     if (isMonorepoOrchestrator) {
-      if (resolvedTestScopedTemplate && ctx.story.workdir) {
-        // Use the resolved scoped template (e.g. "bunx turbo test --filter=@koda/cli")
-        effectiveCommand = resolvedTestScopedTemplate;
+      if (testCommand !== rawTestCommand) {
+        // Promoted: use the resolved scoped template (e.g. "bunx turbo test --filter=@koda/cli")
+        // testCommand is defined here: promotion only happens when resolvedScopedTemplate is non-null
+        effectiveCommand = testCommand as string;
         isFullSuite = false;
         logger.info("verify", "Monorepo orchestrator — using testScoped template", {
           storyId: ctx.story.id,
@@ -152,7 +108,7 @@ export const verifyStage: PipelineStage = {
         logger.info("verify", `[smart-runner] Pass 1: path convention matched ${pass1Files.length} test files`, {
           storyId: ctx.story.id,
         });
-        effectiveCommand = buildScopedCommand(pass1Files, testCommand, resolvedTestScopedTemplate);
+        effectiveCommand = buildScopedCommand(pass1Files, rawTestCommand, testScopedTemplate);
         isFullSuite = false;
       } else if (smartRunnerConfig.fallback === "import-grep") {
         // Pass 2: import-grep fallback
@@ -165,7 +121,7 @@ export const verifyStage: PipelineStage = {
           logger.info("verify", `[smart-runner] Pass 2: import-grep matched ${pass2Files.length} test files`, {
             storyId: ctx.story.id,
           });
-          effectiveCommand = buildScopedCommand(pass2Files, testCommand, resolvedTestScopedTemplate);
+          effectiveCommand = buildScopedCommand(pass2Files, rawTestCommand, testScopedTemplate);
           isFullSuite = false;
         }
       }
@@ -273,5 +229,5 @@ export const verifyStage: PipelineStage = {
  */
 export const _verifyDeps = {
   regression,
-  readPackageName,
+  resolveTestCommands: resolveQualityTestCommands,
 };

--- a/src/quality/command-resolver.ts
+++ b/src/quality/command-resolver.ts
@@ -1,0 +1,91 @@
+/**
+ * Quality Test Command Resolver
+ *
+ * Single source of truth for resolving quality test commands across pipeline stages.
+ * Handles: review.commands.test ?? quality.commands.test priority, {{package}} resolution,
+ * and monorepo orchestrator promotion (turbo/nx → scoped template becomes testCommand).
+ */
+
+import { join } from "node:path";
+import type { NaxConfig } from "../config";
+import { isMonorepoOrchestratorCommand } from "../verification/strategies/scoped";
+
+export interface ResolvedTestCommands {
+  /**
+   * Configured base command (review.commands.test ?? quality.commands.test).
+   * undefined = no test command configured; callers should skip testing.
+   */
+  rawTestCommand: string | undefined;
+  /**
+   * Effective command after orchestrator promotion.
+   * - Non-orchestrators: same as rawTestCommand.
+   * - Orchestrators with storyWorkdir set: the resolved testScoped template (e.g. "bunx turbo test --filter=@pkg").
+   * - Orchestrators without storyWorkdir: same as rawTestCommand (full suite).
+   */
+  testCommand: string | undefined;
+  /**
+   * Resolved testScoped template ({{package}} substituted for monorepo stories).
+   * undefined for monorepo orchestrators (cleared after promotion — they scope natively).
+   * undefined when no testScoped command is configured.
+   */
+  testScopedTemplate: string | undefined;
+  /** True when rawTestCommand is a monorepo orchestrator (turbo/nx). */
+  isMonorepoOrchestrator: boolean;
+  /** Max failing files before falling back to the full suite (quality.scopeTestThreshold). */
+  scopeFileThreshold: number;
+}
+
+/** Injectable deps for testability — avoids mock.module() contamination */
+export const _commandResolverDeps = {
+  readPackageName: async (dir: string): Promise<string | null> => {
+    try {
+      const content = await Bun.file(join(dir, "package.json")).json();
+      return typeof content.name === "string" ? content.name : null;
+    } catch {
+      return null;
+    }
+  },
+};
+
+/**
+ * Resolve quality test commands for a story, applying:
+ * 1. review.commands.test ?? quality.commands.test priority
+ * 2. {{package}} resolution in testScoped template (monorepo stories)
+ * 3. Monorepo orchestrator promotion (turbo/nx + storyWorkdir → scoped template becomes testCommand)
+ *
+ * @param config       - Project config
+ * @param workdir      - Resolved package directory (already resolved per MW-006)
+ * @param storyWorkdir - story.workdir — set for monorepo stories, undefined for single-package
+ */
+export async function resolveQualityTestCommands(
+  config: NaxConfig,
+  workdir: string,
+  storyWorkdir?: string,
+): Promise<ResolvedTestCommands> {
+  const rawTestCommand = config.review?.commands?.test ?? config.quality?.commands?.test;
+  const rawScopedTemplate = config.quality?.commands?.testScoped;
+  const scopeFileThreshold = config.quality?.scopeTestThreshold ?? 10;
+  const isMonorepoOrchestrator = rawTestCommand ? isMonorepoOrchestratorCommand(rawTestCommand) : false;
+
+  // Resolve {{package}} in testScoped template for monorepo stories.
+  // Returns null if package.json is absent (non-JS project) — callers skip template.
+  let resolvedScopedTemplate = rawScopedTemplate;
+  if (rawScopedTemplate?.includes("{{package}}") && storyWorkdir) {
+    const pkgName = await _commandResolverDeps.readPackageName(workdir);
+    resolvedScopedTemplate = pkgName !== null ? rawScopedTemplate.replaceAll("{{package}}", pkgName) : undefined;
+  }
+
+  // Monorepo orchestrator promotion: turbo/nx handle scoping natively via their own filter syntax.
+  // Appending individual file paths would produce invalid syntax for these tools.
+  // When a resolved scoped template is available and story has a workdir, promote it to testCommand.
+  let testCommand = rawTestCommand;
+  let testScopedTemplate = resolvedScopedTemplate;
+  if (isMonorepoOrchestrator) {
+    if (resolvedScopedTemplate && storyWorkdir) {
+      testCommand = resolvedScopedTemplate;
+    }
+    testScopedTemplate = undefined; // never do per-file expansion for orchestrators
+  }
+
+  return { rawTestCommand, testCommand, testScopedTemplate, isMonorepoOrchestrator, scopeFileThreshold };
+}

--- a/src/quality/index.ts
+++ b/src/quality/index.ts
@@ -6,3 +6,5 @@
 
 export { runQualityCommand } from "./runner";
 export type { QualityCommandOptions, QualityCommandResult } from "./runner";
+export { resolveQualityTestCommands, _commandResolverDeps } from "./command-resolver";
+export type { ResolvedTestCommands } from "./command-resolver";

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -6,7 +6,6 @@
  * rectification retries if regressions are detected.
  */
 
-import { join } from "node:path";
 import type { AgentAdapter } from "../agents";
 import { buildSessionName } from "../agents/acp/adapter";
 import type { ModelTier, NaxConfig } from "../config";
@@ -14,6 +13,7 @@ import { resolveModelForAgent } from "../config";
 import { resolvePermissions } from "../config/permissions";
 import type { getLogger } from "../logger";
 import type { UserStory } from "../prd";
+import { resolveQualityTestCommands } from "../quality/command-resolver";
 import { autoCommitIfDirty, captureGitRef } from "../utils/git";
 import {
   type RectificationState,
@@ -22,7 +22,6 @@ import {
   shouldRetryRectification as _shouldRetryRectification,
   runSharedRectificationLoop,
 } from "../verification";
-import { isMonorepoOrchestratorCommand } from "../verification/strategies/scoped";
 import { cleanupProcessTree } from "./cleanup";
 import { verifyImplementerIsolation } from "./isolation";
 import { buildImplementerRectificationPrompt } from "./prompts";
@@ -32,14 +31,7 @@ export const _rectificationGateDeps = {
   executeWithTimeout: _executeWithTimeout,
   parseTestOutput: _parseTestOutput,
   shouldRetryRectification: _shouldRetryRectification,
-  readPackageName: async (dir: string): Promise<string | null> => {
-    try {
-      const content = await Bun.file(join(dir, "package.json")).json();
-      return typeof content.name === "string" ? content.name : null;
-    } catch {
-      return null;
-    }
-  },
+  resolveTestCommands: resolveQualityTestCommands,
 };
 
 /**
@@ -61,28 +53,12 @@ export async function runFullSuiteGate(
   if (!rectificationEnabled) return { passed: false, cost: 0 };
 
   const rectificationConfig = config.execution.rectification;
-  const testCmd = config.quality?.commands?.test ?? "bun test";
   const fullSuiteTimeout = rectificationConfig.fullSuiteTimeoutSeconds;
-  const rawScopedTemplate = config.quality?.commands?.testScoped;
 
-  // Resolve {{package}} in testScoped template for monorepo stories (mirrors verify.ts).
-  // workdir is already the resolved package directory.
-  let resolvedScopedTemplate = rawScopedTemplate;
-  if (rawScopedTemplate?.includes("{{package}}") && story.workdir) {
-    const pkgName = await _rectificationGateDeps.readPackageName(workdir);
-    resolvedScopedTemplate = pkgName !== null ? rawScopedTemplate.replaceAll("{{package}}", pkgName) : undefined;
-  }
-
-  // Monorepo orchestrators (turbo/nx): the resolved scoped template IS the run command.
-  // Per-file expansion would break their filter syntax.
-  let effectiveTestCmd = testCmd;
-  let effectiveScopedTemplate = resolvedScopedTemplate;
-  if (isMonorepoOrchestratorCommand(testCmd)) {
-    if (resolvedScopedTemplate && story.workdir) {
-      effectiveTestCmd = resolvedScopedTemplate;
-    }
-    effectiveScopedTemplate = undefined;
-  }
+  // Resolve test commands via SSOT — handles priority, {{package}}, and orchestrator promotion.
+  const { testCommand: resolvedTestCmd, testScopedTemplate: effectiveScopedTemplate } =
+    await _rectificationGateDeps.resolveTestCommands(config, workdir, story.workdir);
+  const effectiveTestCmd = resolvedTestCmd ?? "bun test";
 
   logger.info("tdd", "-> Running full test suite gate (before Verifier)", {
     storyId: story.id,

--- a/test/unit/pipeline/stages/verify.test.ts
+++ b/test/unit/pipeline/stages/verify.test.ts
@@ -16,6 +16,7 @@ import type { NaxConfig } from "../../../../src/config";
 import type { PRD, UserStory } from "../../../../src/prd";
 import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
 import type { VerificationResult } from "../../../../src/verification";
+import type { ResolvedTestCommands } from "../../../../src/quality/command-resolver";
 
 const WORKDIR = `/tmp/nax-test-verify-${randomUUID()}`;
 
@@ -321,9 +322,18 @@ describe("verifyStage — monorepo orchestrator + {{package}}", () => {
 
     let capturedCommand: string | undefined;
     const origRegression = _verifyDeps.regression;
-    const origReadPkgName = _verifyDeps.readPackageName;
+    const origResolve = _verifyDeps.resolveTestCommands;
 
-    _verifyDeps.readPackageName = mock(() => Promise.resolve("@koda/cli"));
+    // Simulate SSOT returning a promoted orchestrator command (package found)
+    _verifyDeps.resolveTestCommands = mock((): Promise<ResolvedTestCommands> =>
+      Promise.resolve({
+        rawTestCommand: "bunx turbo test",
+        testCommand: "bunx turbo test --filter=@koda/cli",
+        testScopedTemplate: undefined,
+        isMonorepoOrchestrator: true,
+        scopeFileThreshold: 10,
+      }),
+    );
     _verifyDeps.regression = mock((opts: { command: string }): Promise<VerificationResult> => {
       capturedCommand = opts.command;
       return Promise.resolve(SUCCESS_RESULT);
@@ -331,32 +341,33 @@ describe("verifyStage — monorepo orchestrator + {{package}}", () => {
 
     try {
       const ctx = makeMonorepoContext();
-      await verifyStage.execute(ctx as Parameters<typeof verifyStage.execute>[0]);
+      await verifyStage.execute(ctx as unknown as Parameters<typeof verifyStage.execute>[0]);
       expect(capturedCommand).toBe("bunx turbo test --filter=@koda/cli");
     } finally {
       _verifyDeps.regression = origRegression;
-      _verifyDeps.readPackageName = origReadPkgName;
+      _verifyDeps.resolveTestCommands = origResolve;
     }
   });
 
-  test("no package.json (non-JS project) — skips testScoped template, falls to full suite", async () => {
+  test("no package.json (non-JS project) — skips testScoped template, falls to deferred", async () => {
     const { verifyStage, _verifyDeps } = await import(
       "../../../../src/pipeline/stages/verify"
-    );
-    const { _smartRunnerDeps } = await import(
-      "../../../../src/verification/smart-runner"
     );
 
     let capturedCommand: string | undefined;
     const origRegression = _verifyDeps.regression;
-    const origReadPkgName = _verifyDeps.readPackageName;
-    const origGetChanged = _smartRunnerDeps.getChangedSourceFiles;
-    const origMapSource = _smartRunnerDeps.mapSourceToTests;
+    const origResolve = _verifyDeps.resolveTestCommands;
 
-    // No package.json → readPackageName returns null
-    _verifyDeps.readPackageName = mock(() => Promise.resolve(null));
-    _smartRunnerDeps.getChangedSourceFiles = mock(() => Promise.resolve([]));
-    _smartRunnerDeps.mapSourceToTests = mock(() => Promise.resolve([]));
+    // Simulate SSOT returning no promotion (package.json absent → no resolved template)
+    _verifyDeps.resolveTestCommands = mock((): Promise<ResolvedTestCommands> =>
+      Promise.resolve({
+        rawTestCommand: "bunx turbo test",
+        testCommand: "bunx turbo test", // same as raw — no promotion
+        testScopedTemplate: undefined,
+        isMonorepoOrchestrator: true,
+        scopeFileThreshold: 10,
+      }),
+    );
     _verifyDeps.regression = mock((opts: { command: string }): Promise<VerificationResult> => {
       capturedCommand = opts.command;
       return Promise.resolve(SUCCESS_RESULT);
@@ -364,16 +375,14 @@ describe("verifyStage — monorepo orchestrator + {{package}}", () => {
 
     try {
       const ctx = makeMonorepoContext(null);
-      // mode is deferred by default → full suite deferred → continue without regression
-      const result = await verifyStage.execute(ctx as Parameters<typeof verifyStage.execute>[0]);
-      // No package.json → template skipped → no scoped turbo command, falls to deferred
+      // mode is deferred → full suite skipped → continue without regression
+      const result = await verifyStage.execute(ctx as unknown as Parameters<typeof verifyStage.execute>[0]);
+      // No promotion → isFullSuite=true → deferred mode → skip
       expect(result.action).toBe("continue");
       expect(capturedCommand).toBeUndefined();
     } finally {
       _verifyDeps.regression = origRegression;
-      _verifyDeps.readPackageName = origReadPkgName;
-      _smartRunnerDeps.getChangedSourceFiles = origGetChanged;
-      _smartRunnerDeps.mapSourceToTests = origMapSource;
+      _verifyDeps.resolveTestCommands = origResolve;
     }
   });
 
@@ -381,26 +390,28 @@ describe("verifyStage — monorepo orchestrator + {{package}}", () => {
     const { verifyStage, _verifyDeps } = await import(
       "../../../../src/pipeline/stages/verify"
     );
-    const { _smartRunnerDeps } = await import(
-      "../../../../src/verification/smart-runner"
-    );
 
     let capturedCommand: string | undefined;
     const origRegression = _verifyDeps.regression;
-    const origReadPkgName = _verifyDeps.readPackageName;
-    const origGetChanged = _smartRunnerDeps.getChangedSourceFiles;
-    const origMapSource = _smartRunnerDeps.mapSourceToTests;
+    const origResolve = _verifyDeps.resolveTestCommands;
 
-    _verifyDeps.readPackageName = mock(() => Promise.resolve(null));
-    _smartRunnerDeps.getChangedSourceFiles = mock(() => Promise.resolve([]));
-    _smartRunnerDeps.mapSourceToTests = mock(() => Promise.resolve([]));
+    // No workdir on story → SSOT returns no promotion
+    _verifyDeps.resolveTestCommands = mock((): Promise<ResolvedTestCommands> =>
+      Promise.resolve({
+        rawTestCommand: "bunx turbo test",
+        testCommand: "bunx turbo test", // same as raw — no promotion
+        testScopedTemplate: undefined,
+        isMonorepoOrchestrator: true,
+        scopeFileThreshold: 10,
+      }),
+    );
     _verifyDeps.regression = mock((opts: { command: string }): Promise<VerificationResult> => {
       capturedCommand = opts.command;
       return Promise.resolve(SUCCESS_RESULT);
     });
 
     try {
-      // No workdir on story — uses root turbo test, deferred mode skips
+      // No workdir on story — mode per-story forces full suite run
       const story = makeStory(); // no workdir
       const config: NaxConfig = {
         ...DEFAULT_CONFIG,
@@ -425,14 +436,12 @@ describe("verifyStage — monorepo orchestrator + {{package}}", () => {
         workdir: WORKDIR,
         hooks: { hooks: {} },
       };
-      await verifyStage.execute(ctx as Parameters<typeof verifyStage.execute>[0]);
-      // No workdir → falls to full suite path, runs "bunx turbo test"
+      await verifyStage.execute(ctx as unknown as Parameters<typeof verifyStage.execute>[0]);
+      // No promotion → isFullSuite=true → per-story mode → runs "bunx turbo test"
       expect(capturedCommand).toBe("bunx turbo test");
     } finally {
       _verifyDeps.regression = origRegression;
-      _verifyDeps.readPackageName = origReadPkgName;
-      _smartRunnerDeps.getChangedSourceFiles = origGetChanged;
-      _smartRunnerDeps.mapSourceToTests = origMapSource;
+      _verifyDeps.resolveTestCommands = origResolve;
     }
   });
 });

--- a/test/unit/quality/command-resolver.test.ts
+++ b/test/unit/quality/command-resolver.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Quality Command Resolver — unit tests
+ *
+ * Covers: priority resolution, {{package}} substitution, orchestrator promotion.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../../src/config/defaults";
+import type { NaxConfig } from "../../../src/config";
+import { _commandResolverDeps, resolveQualityTestCommands } from "../../../src/quality/command-resolver";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides?: Partial<NaxConfig>): NaxConfig {
+  return { ...DEFAULT_CONFIG, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Priority resolution
+// ---------------------------------------------------------------------------
+
+describe("resolveQualityTestCommands — priority", () => {
+  test("uses quality.commands.test when review.commands.test is absent", async () => {
+    const config = makeConfig({ quality: { ...DEFAULT_CONFIG.quality, commands: { test: "jest" } } });
+    const result = await resolveQualityTestCommands(config, "/workdir");
+    expect(result.rawTestCommand).toBe("jest");
+    expect(result.testCommand).toBe("jest");
+  });
+
+  test("review.commands.test takes priority over quality.commands.test", async () => {
+    const config = makeConfig({
+      quality: { ...DEFAULT_CONFIG.quality, commands: { test: "bun test" } },
+      review: { ...DEFAULT_CONFIG.review, commands: { ...DEFAULT_CONFIG.review.commands, test: "jest" } },
+    });
+    const result = await resolveQualityTestCommands(config, "/workdir");
+    expect(result.rawTestCommand).toBe("jest");
+  });
+
+  test("returns undefined rawTestCommand when neither is configured", async () => {
+    const config = makeConfig({ quality: { ...DEFAULT_CONFIG.quality, commands: {} }, review: undefined });
+    const result = await resolveQualityTestCommands(config, "/workdir");
+    expect(result.rawTestCommand).toBeUndefined();
+    expect(result.testCommand).toBeUndefined();
+  });
+
+  test("scopeFileThreshold defaults to 10 when not configured", async () => {
+    const config = makeConfig({ quality: { ...DEFAULT_CONFIG.quality, scopeTestThreshold: undefined } });
+    const result = await resolveQualityTestCommands(config, "/workdir");
+    expect(result.scopeFileThreshold).toBe(10);
+  });
+
+  test("scopeFileThreshold uses configured value", async () => {
+    const config = makeConfig({ quality: { ...DEFAULT_CONFIG.quality, scopeTestThreshold: 5 } });
+    const result = await resolveQualityTestCommands(config, "/workdir");
+    expect(result.scopeFileThreshold).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// {{package}} resolution
+// ---------------------------------------------------------------------------
+
+describe("resolveQualityTestCommands — {{package}} substitution", () => {
+  test("resolves {{package}} when storyWorkdir is set and package.json exists", async () => {
+    const origRead = _commandResolverDeps.readPackageName;
+    _commandResolverDeps.readPackageName = mock(() => Promise.resolve("@acme/api"));
+    try {
+      const config = makeConfig({
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test", testScoped: "bun test --filter={{package}}" },
+        },
+      });
+      const result = await resolveQualityTestCommands(config, "/workdir", "packages/api");
+      expect(result.testScopedTemplate).toBe("bun test --filter=@acme/api");
+    } finally {
+      _commandResolverDeps.readPackageName = origRead;
+    }
+  });
+
+  test("skips {{package}} resolution when storyWorkdir is absent", async () => {
+    const origRead = _commandResolverDeps.readPackageName;
+    _commandResolverDeps.readPackageName = mock(() => Promise.resolve("@acme/api"));
+    try {
+      const config = makeConfig({
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test", testScoped: "bun test --filter={{package}}" },
+        },
+      });
+      // no storyWorkdir → template kept as-is
+      const result = await resolveQualityTestCommands(config, "/workdir");
+      expect(result.testScopedTemplate).toBe("bun test --filter={{package}}");
+      expect(_commandResolverDeps.readPackageName).not.toHaveBeenCalled();
+    } finally {
+      _commandResolverDeps.readPackageName = origRead;
+    }
+  });
+
+  test("clears testScopedTemplate when package.json is absent", async () => {
+    const origRead = _commandResolverDeps.readPackageName;
+    _commandResolverDeps.readPackageName = mock(() => Promise.resolve(null));
+    try {
+      const config = makeConfig({
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test", testScoped: "bun test --filter={{package}}" },
+        },
+      });
+      const result = await resolveQualityTestCommands(config, "/workdir", "packages/api");
+      expect(result.testScopedTemplate).toBeUndefined();
+    } finally {
+      _commandResolverDeps.readPackageName = origRead;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Monorepo orchestrator promotion
+// ---------------------------------------------------------------------------
+
+describe("resolveQualityTestCommands — orchestrator promotion", () => {
+  test("promotes resolved scoped template to testCommand for turbo + storyWorkdir", async () => {
+    const origRead = _commandResolverDeps.readPackageName;
+    _commandResolverDeps.readPackageName = mock(() => Promise.resolve("@koda/cli"));
+    try {
+      const config = makeConfig({
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bunx turbo test", testScoped: "bunx turbo test --filter={{package}}" },
+        },
+      });
+      const result = await resolveQualityTestCommands(config, "/workdir", "apps/cli");
+      expect(result.rawTestCommand).toBe("bunx turbo test");
+      expect(result.testCommand).toBe("bunx turbo test --filter=@koda/cli");
+      expect(result.testScopedTemplate).toBeUndefined(); // cleared for orchestrators
+      expect(result.isMonorepoOrchestrator).toBe(true);
+    } finally {
+      _commandResolverDeps.readPackageName = origRead;
+    }
+  });
+
+  test("no promotion when storyWorkdir is absent (full monorepo suite)", async () => {
+    const origRead = _commandResolverDeps.readPackageName;
+    _commandResolverDeps.readPackageName = mock(() => Promise.resolve("@koda/cli"));
+    try {
+      const config = makeConfig({
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bunx turbo test", testScoped: "bunx turbo test --filter={{package}}" },
+        },
+      });
+      const result = await resolveQualityTestCommands(config, "/workdir"); // no storyWorkdir
+      expect(result.testCommand).toBe("bunx turbo test"); // not promoted
+      expect(result.isMonorepoOrchestrator).toBe(true);
+    } finally {
+      _commandResolverDeps.readPackageName = origRead;
+    }
+  });
+
+  test("no promotion when package.json is absent for turbo command", async () => {
+    const origRead = _commandResolverDeps.readPackageName;
+    _commandResolverDeps.readPackageName = mock(() => Promise.resolve(null));
+    try {
+      const config = makeConfig({
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bunx turbo test", testScoped: "bunx turbo test --filter={{package}}" },
+        },
+      });
+      const result = await resolveQualityTestCommands(config, "/workdir", "apps/cli");
+      expect(result.testCommand).toBe("bunx turbo test"); // not promoted — template resolved to undefined
+      expect(result.testScopedTemplate).toBeUndefined();
+    } finally {
+      _commandResolverDeps.readPackageName = origRead;
+    }
+  });
+
+  test("always clears testScopedTemplate for orchestrators regardless of promotion", async () => {
+    const origRead = _commandResolverDeps.readPackageName;
+    _commandResolverDeps.readPackageName = mock(() => Promise.resolve("@koda/cli"));
+    try {
+      const config = makeConfig({
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bunx nx test", testScoped: "bunx nx test my-app" },
+        },
+      });
+      const result = await resolveQualityTestCommands(config, "/workdir", "apps/my-app");
+      // testScoped has no {{package}} → no readPackageName call, but still cleared
+      expect(result.testScopedTemplate).toBeUndefined();
+      expect(result.isMonorepoOrchestrator).toBe(true);
+    } finally {
+      _commandResolverDeps.readPackageName = origRead;
+    }
+  });
+
+  test("non-orchestrator commands preserve testScopedTemplate", async () => {
+    const config = makeConfig({
+      quality: {
+        ...DEFAULT_CONFIG.quality,
+        commands: { test: "jest", testScoped: "jest --testPathPattern={{files}}" },
+      },
+    });
+    const result = await resolveQualityTestCommands(config, "/workdir", "packages/api");
+    expect(result.testScopedTemplate).toBe("jest --testPathPattern={{files}}");
+    expect(result.isMonorepoOrchestrator).toBe(false);
+    expect(result.testCommand).toBe("jest"); // not promoted
+  });
+});


### PR DESCRIPTION
## Summary

- Eliminates three independent copies of test-command resolution logic (priority lookup, `{{package}}` substitution, monorepo orchestrator promotion) that were duplicated across `verify.ts`, `rectify.ts`, and `rectification-gate.ts`
- Introduces `src/quality/command-resolver.ts` with `resolveQualityTestCommands(config, workdir, storyWorkdir?)` as the single source of truth
- `_commandResolverDeps.readPackageName` is injectable for testing (no `mock.module()`)
- Removes the `DEFAULT_SCOPE_FILE_THRESHOLD = 10` magic constant — threshold now reads directly from `config.quality.scopeTestThreshold` (schema default is 10)

## What `ResolvedTestCommands` carries

| Field | Description |
|---|---|
| `rawTestCommand` | `review.commands.test ?? quality.commands.test` — undefined if unconfigured |
| `testCommand` | Effective command after orchestrator promotion |
| `testScopedTemplate` | `{{package}}`-resolved per-file template; `undefined` for orchestrators |
| `isMonorepoOrchestrator` | Whether to skip smart runner |
| `scopeFileThreshold` | From `quality.scopeTestThreshold` |

## Test plan

- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `bun test test/unit/quality/command-resolver.test.ts` — 13 new tests (priority, `{{package}}`, orchestrator promotion)
- [ ] `bun test test/unit/pipeline/stages/verify.test.ts` — 3 monorepo tests updated to mock `resolveTestCommands`
- [ ] `bun run test:bail` — full suite 1227 tests, 0 failures