### PR TITLE
fix(debate): fix contradictory critique instructions, underspecified finding schema, inconsistent JSON fencing

### DIFF
--- a/src/debate/prompt-builder.ts
+++ b/src/debate/prompt-builder.ts
@@ -10,6 +10,15 @@ import type { ReviewFinding } from "../plugins/types";
 import { PERSONA_FRAGMENTS } from "./personas";
 import type { DebateResolverContext, Debater, Proposal, Rebuttal } from "./types";
 
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Canonical ReviewFinding schema for all LLM-facing JSON directives (issue #368). */
+const FINDING_SCHEMA = `{ ruleId: string; severity: "critical" | "error" | "warning" | "info" | "low"; file: string; line: number; message: string }`;
+
+const REVIEW_JSON_DIRECTIVE = `Respond with JSON: { passed: boolean; findings: Array<${FINDING_SCHEMA}>; findingReasoning: { [ruleId: string]: string } }`;
+
+const RE_REVIEW_JSON_DIRECTIVE = `Respond with JSON: { passed: boolean; findings: Array<${FINDING_SCHEMA}>; findingReasoning: { [ruleId: string]: string }; deltaSummary: string }`;
+
 // ─── Interfaces ───────────────────────────────────────────────────────────────
 
 /** Story fields required by review-specific prompt methods. */
@@ -55,21 +64,22 @@ export class DebatePromptBuilder {
   /**
    * Panel-mode critique (round 1+).
    * Excludes the calling debater's own proposal. No outputFormat block.
+   * Assembly order: persona → task → proposals (no prose directive after JSON-only gate).
    */
   buildCritiquePrompt(debaterIndex: number, proposals: Proposal[]): string {
     const otherProposals = proposals.filter((_, i) => i !== debaterIndex);
     const proposalsSection = this.buildProposalsSection(otherProposals);
     const personaBlock = this.buildPersonaBlock(debaterIndex);
 
-    return `You are reviewing proposals for a ${this.stageContext.stage} task.
+    // Issue 7: persona first, then task, then proposals.
+    // taskContext owns the output format — do not append a contradictory prose directive.
+    return `You are reviewing proposals for a ${this.stageContext.stage} task.${personaBlock}
 
 ## Task
-${this.stageContext.taskContext}${personaBlock}
+${this.stageContext.taskContext}
 
 ## Other Agents' Proposals
-${proposalsSection}
-
-Please critique these proposals and provide your refined analysis, identifying strengths, weaknesses, and your own updated position.`;
+${proposalsSection}`;
   }
 
   /**
@@ -189,7 +199,7 @@ ${this.stageContext.outputFormat}`;
       diff,
       "",
       "Also flag any changes in the diff not required by the acceptance criteria above as out-of-scope findings.",
-      "Respond with JSON: { passed: boolean, findings: [...], findingReasoning: { [id]: string } }",
+      REVIEW_JSON_DIRECTIVE,
     ].join("\n");
   }
 
@@ -206,7 +216,7 @@ ${this.stageContext.outputFormat}`;
       "## Updated Diff",
       updatedDiff,
       "",
-      "Respond with JSON: { passed: boolean, findings: [...], findingReasoning: { [id]: string }, deltaSummary: string }",
+      RE_REVIEW_JSON_DIRECTIVE,
       "deltaSummary should describe which previous findings are resolved vs still present.",
     ].join("\n");
   }
@@ -241,7 +251,7 @@ ${this.stageContext.outputFormat}`;
       diff,
       voteTally,
       "",
-      "Respond with JSON: { passed: boolean, findings: [...], findingReasoning: { [id]: string } }",
+      REVIEW_JSON_DIRECTIVE,
     ]
       .filter((line) => line !== undefined)
       .join("\n");
@@ -274,7 +284,7 @@ ${this.stageContext.outputFormat}`;
       "## Updated Diff",
       updatedDiff,
       "",
-      "Respond with JSON: { passed: boolean, findings: [...], findingReasoning: { [id]: string }, deltaSummary: string }",
+      RE_REVIEW_JSON_DIRECTIVE,
       "deltaSummary should describe which previous findings are resolved vs still present.",
     ]
       .filter((line) => line !== undefined)
@@ -308,7 +318,7 @@ ${this.stageContext.outputFormat}`;
   }
 
   private buildLabeledProposalsSection(proposals: Array<{ debater: string; output: string }>): string {
-    return proposals.map((p) => `### ${p.debater}\n${p.output}`).join("\n\n");
+    return proposals.map((p) => `### ${p.debater}\n\`\`\`json\n${p.output}\n\`\`\``).join("\n\n");
   }
 
   private buildLabeledCritiquesSection(critiques: string[]): string {

--- a/test/unit/debate/prompt-builder.test.ts
+++ b/test/unit/debate/prompt-builder.test.ts
@@ -552,3 +552,70 @@ describe("buildReResolverPrompt()", () => {
     expect(prompt).toContain("deltaSummary");
   });
 });
+
+// ─── Issue 7: critique prompt assembly order ──────────────────────────────────
+
+describe("buildCritiquePrompt() — issue 7: assembly order", () => {
+  const proposals: Proposal[] = [
+    makeProposal("agent-a", "proposal A"),
+    makeProposal("agent-b", "proposal B"),
+  ];
+
+  test("persona block appears before taskContext", () => {
+    const debater = makeDebater("claude", "challenger");
+    const builder = makeBuilder("TASK_CTX", "OUTPUT_FMT", [debater]);
+    const prompt = builder.buildCritiquePrompt(0, proposals);
+    const roleIdx = prompt.indexOf("## Your Role");
+    const taskIdx = prompt.indexOf("TASK_CTX");
+    expect(roleIdx).toBeGreaterThan(-1);
+    expect(roleIdx).toBeLessThan(taskIdx);
+  });
+
+  test("does not append prose critique instruction after JSON-only gate in taskContext", () => {
+    const taskCtxWithJsonGate =
+      "IMPORTANT: Your entire response must be a single JSON object.\nOutput ONLY the JSON.";
+    const builder = makeBuilder(taskCtxWithJsonGate, "OUTPUT_FMT", []);
+    const prompt = builder.buildCritiquePrompt(0, proposals);
+    expect(prompt).not.toContain("Please critique these proposals");
+  });
+});
+
+// ─── Issue 8: explicit finding schema ────────────────────────────────────────
+
+describe("finding schema — issue 8: explicit fields", () => {
+  const ctx: DebateResolverContext = { resolverType: "synthesis" };
+
+  test("buildReviewPrompt includes ruleId, severity, message in schema", () => {
+    const builder = makeBuilder();
+    const prompt = builder.buildReviewPrompt(DIFF, REVIEW_STORY);
+    expect(prompt).toContain("ruleId");
+    expect(prompt).toContain("severity");
+    expect(prompt).toContain("message");
+  });
+
+  test("buildResolverPrompt includes ruleId, severity, message in schema", () => {
+    const builder = makeBuilder();
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], DIFF, REVIEW_STORY, ctx);
+    expect(prompt).toContain("ruleId");
+    expect(prompt).toContain("severity");
+    expect(prompt).toContain("message");
+  });
+
+  test("findingReasoning key references ruleId not bare [id]", () => {
+    const builder = makeBuilder();
+    const prompt = builder.buildReviewPrompt(DIFF, REVIEW_STORY);
+    expect(prompt).toContain("[ruleId");
+  });
+});
+
+// ─── Issue 9: consistent JSON fencing in proposals section ───────────────────
+
+describe("buildResolverPrompt() — issue 9: consistent JSON fencing", () => {
+  test("each debater proposal is wrapped in ```json fencing", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const builder = makeBuilder();
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], DIFF, REVIEW_STORY, ctx);
+    const fenceCount = (prompt.match(/```json/g) ?? []).length;
+    expect(fenceCount).toBe(LABELED_PROPOSALS.length);
+  });
+});


### PR DESCRIPTION
## What

Fixes three prompt quality issues in `src/debate/prompt-builder.ts` that degraded debate review output (issue #368).

## Why

Closes #368

Three issues were surfaced by cross-correlating the `graphify-kb-debate` run log with prompt-audit files:

1. **Contradictory instructions** — `buildCritiquePrompt` appended a prose critique directive (`Please critique these proposals...`) after a JSON-only gate already present in `taskContext`. The persona block was also assembled after the JSON-only gate (wrong order).
2. **Underspecified finding schema** — all four review/resolver prompts used `findings: [...]` with no shape defined. LLMs inferred the `LLMFinding` shape (`issue`/`suggestion` fields) instead of `ReviewFinding` (`ruleId`/`message`). This was the upstream root cause of PR #366.
3. **Inconsistent JSON fencing** — `buildLabeledProposalsSection` emitted some proposals fenced and others bare within the same section.

## How

- **Issue 7**: Reordered `buildCritiquePrompt` to `persona → task → proposals`. Removed the trailing prose directive — `taskContext` owns the output format.
- **Issue 8**: Extracted a `FINDING_SCHEMA` constant with all required `ReviewFinding` fields (`ruleId`, `severity`, `file`, `line`, `message`). All four prompt methods now use `REVIEW_JSON_DIRECTIVE` / `RE_REVIEW_JSON_DIRECTIVE`. `findingReasoning` key is now explicitly `[ruleId: string]`.
- **Issue 9**: `buildLabeledProposalsSection` now consistently wraps every proposal in ` ```json ` fencing.

## Testing

- [x] Tests added/updated (6 new regression tests covering all three issues)
- [x] `bun test` passes (66/66)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

No breaking changes — prompt content improves, no interface changes. The `findingReasoning: { [id]: string }` → `{ [ruleId: string]: string }` change is a prompt-only clarification; `dialogue.ts` already maps by `ruleId` (see PR #366).