### PR TITLE
fix(execution): clamp tier mismatch, demote auto-commit/optimizer warns to debug

### DIFF
--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -222,12 +222,16 @@ export const executionStage: PipelineStage = {
       return { action: "fail", reason: "Prompt not built (prompt stage skipped?)" };
     }
 
-    // Validate agent supports the requested tier
+    // Validate agent supports the requested tier; clamp to first supported if not (issue #369)
+    let effectiveTier = ctx.routing.modelTier;
     if (!_executionDeps.validateAgentForTier(agent, ctx.routing.modelTier)) {
-      logger.warn("execution", "Agent tier mismatch", {
+      effectiveTier =
+        (agent.capabilities.supportedTiers[0] as typeof ctx.routing.modelTier | undefined) ?? ctx.routing.modelTier;
+      logger.debug("execution", "Agent tier mismatch — clamping to supported tier", {
         storyId: ctx.story.id,
         agentName: agent.name,
         requestedTier: ctx.routing.modelTier,
+        effectiveTier,
         supportedTiers: agent.capabilities.supportedTiers,
       });
     }
@@ -240,11 +244,11 @@ export const executionStage: PipelineStage = {
     const result = await agent.run({
       prompt: ctx.prompt,
       workdir: ctx.workdir,
-      modelTier: ctx.routing.modelTier,
+      modelTier: effectiveTier,
       modelDef: resolveModelForAgent(
         ctx.rootConfig.models,
         ctx.routing.agent ?? ctx.rootConfig.autoMode.defaultAgent,
-        ctx.routing.modelTier,
+        effectiveTier,
         ctx.rootConfig.autoMode.defaultAgent,
       ),
       timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,

--- a/src/pipeline/stages/optimizer.ts
+++ b/src/pipeline/stages/optimizer.ts
@@ -30,6 +30,14 @@ import { getLogger } from "../../logger/index.js";
 import { resolveOptimizer } from "../../optimizer/index.js";
 import type { PipelineContext, PipelineStage, StageResult } from "../types.js";
 
+/**
+ * Injectable dependencies for optimizer stage — allows tests to mock the logger
+ * without using mock.module() which leaks in Bun 1.x.
+ *
+ * @internal
+ */
+export const _optimizerDeps = { getLogger };
+
 export const optimizerStage: PipelineStage = {
   name: "optimizer",
   enabled: (_ctx) => {
@@ -38,11 +46,11 @@ export const optimizerStage: PipelineStage = {
   },
 
   async execute(ctx: PipelineContext): Promise<StageResult> {
-    const logger = getLogger();
+    const logger = _optimizerDeps.getLogger();
 
     // Ensure prompt exists
     if (!ctx.prompt) {
-      logger.warn("optimizer", "No prompt to optimize, skipping");
+      logger.debug("optimizer", "No prompt to optimize, skipping");
       return { action: "continue" };
     }
 

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -11,7 +11,7 @@ import { spawn } from "./bun-deps";
  *
  * @internal
  */
-export const _gitDeps = { spawn };
+export const _gitDeps = { spawn, getSafeLogger };
 
 /**
  * Default timeout for git subprocess calls.
@@ -200,7 +200,7 @@ export function detectMergeConflict(output: string): boolean {
  * @param storyId - Story ID for the commit message
  */
 export async function autoCommitIfDirty(workdir: string, stage: string, role: string, storyId: string): Promise<void> {
-  const logger = getSafeLogger();
+  const logger = _gitDeps.getSafeLogger();
   try {
     // Guard: only auto-commit if workdir IS the git repository root.
     // Without this, a workdir nested inside another git repo (e.g. a temp dir
@@ -246,7 +246,7 @@ export async function autoCommitIfDirty(workdir: string, stage: string, role: st
 
     if (!statusOutput.trim()) return;
 
-    logger?.warn(stage, `Agent did not commit after ${role} session — auto-committing`, {
+    logger?.debug(stage, `Agent did not commit after ${role} session — auto-committing`, {
       role,
       storyId,
       dirtyFiles: statusOutput.trim().split("\n").length,

--- a/test/unit/pipeline/stages/execution-agent-routing.test.ts
+++ b/test/unit/pipeline/stages/execution-agent-routing.test.ts
@@ -177,3 +177,57 @@ describe("execution stage — routing.agent overrides default agent for model re
     expect(capturedModelDef?.model).toBe("claude-opus");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue 6 — tier mismatch: clamp to first supported tier (issue #369)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("execution stage — tier mismatch clamps to first supported tier", () => {
+  test("passes first supported tier to agent.run() when requested tier is unsupported", async () => {
+    let capturedTier: string | undefined;
+
+    _executionDeps.getAgent = () =>
+      ({
+        name: "opencode",
+        capabilities: { supportedTiers: ["balanced"] },
+        run: async (opts: { modelTier?: string }) => {
+          capturedTier = opts.modelTier;
+          return { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0 };
+        },
+      }) as unknown as ReturnType<typeof _executionDeps.getAgent>;
+
+    // validateAgentForTier returns false → tier mismatch
+    _executionDeps.validateAgentForTier = () => false;
+    _executionDeps.detectMergeConflict = () => false;
+
+    const ctx = makeCtx({}, { modelTier: "fast" });
+    await executionStage.execute(ctx);
+
+    // Should be clamped to "balanced", not the original "fast"
+    expect(capturedTier).toBe("balanced");
+  });
+
+  test("no clamping occurs when tier is supported", async () => {
+    let capturedTier: string | undefined;
+
+    _executionDeps.getAgent = () =>
+      ({
+        name: "claude",
+        capabilities: { supportedTiers: ["fast", "balanced", "powerful"] },
+        run: async (opts: { modelTier?: string }) => {
+          capturedTier = opts.modelTier;
+          return { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0 };
+        },
+      }) as unknown as ReturnType<typeof _executionDeps.getAgent>;
+
+    // validateAgentForTier returns true → no mismatch
+    _executionDeps.validateAgentForTier = () => true;
+    _executionDeps.detectMergeConflict = () => false;
+
+    const ctx = makeCtx({}, { modelTier: "fast" });
+    await executionStage.execute(ctx);
+
+    // Original tier is preserved
+    expect(capturedTier).toBe("fast");
+  });
+});

--- a/test/unit/pipeline/stages/optimizer.test.ts
+++ b/test/unit/pipeline/stages/optimizer.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Optimizer Stage — issue #369 (Group C)
+ *
+ * Verifies that a null/falsy ctx.prompt logs at debug level, not warn.
+ * The warn demoted to debug because "No prompt to optimize" fires once per
+ * story and is a known no-op condition, not an actionable warning.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { _optimizerDeps, optimizerStage } from "../../../../src/pipeline/stages/optimizer";
+import type { PipelineContext } from "../../../../src/pipeline/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeMinimalCtx(prompt: string | undefined): PipelineContext {
+  return {
+    prompt,
+    config: {},
+    plugins: [],
+  } as unknown as PipelineContext;
+}
+
+const originalGetLogger = _optimizerDeps.getLogger;
+
+afterEach(() => {
+  _optimizerDeps.getLogger = originalGetLogger;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue 10 — optimizer no-op: warn → debug
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("optimizerStage — no-prompt path logs at debug not warn", () => {
+  test("does not call logger.warn when ctx.prompt is undefined", async () => {
+    let warnCalled = false;
+    let debugCalled = false;
+
+    _optimizerDeps.getLogger = mock(() => ({
+      warn: (_stage: string, _msg: string) => { warnCalled = true; },
+      debug: (_stage: string, _msg: string) => { debugCalled = true; },
+      info: () => {},
+      error: () => {},
+    })) as unknown as typeof _optimizerDeps.getLogger;
+
+    const result = await optimizerStage.execute(makeMinimalCtx(undefined));
+
+    expect(result.action).toBe("continue");
+    expect(warnCalled).toBe(false);
+    expect(debugCalled).toBe(true);
+  });
+
+  test("does not call logger.warn when ctx.prompt is empty string", async () => {
+    let warnCalled = false;
+    let debugCalled = false;
+
+    _optimizerDeps.getLogger = mock(() => ({
+      warn: (_stage: string, _msg: string) => { warnCalled = true; },
+      debug: (_stage: string, _msg: string) => { debugCalled = true; },
+      info: () => {},
+      error: () => {},
+    })) as unknown as typeof _optimizerDeps.getLogger;
+
+    // Empty string is falsy — same early-exit path
+    const result = await optimizerStage.execute(makeMinimalCtx(""));
+
+    expect(result.action).toBe("continue");
+    expect(warnCalled).toBe(false);
+    expect(debugCalled).toBe(true);
+  });
+});

--- a/test/unit/pipeline/storyid-events.test.ts
+++ b/test/unit/pipeline/storyid-events.test.ts
@@ -161,9 +161,9 @@ describe("storyId is present in JSONL event payloads", () => {
   // ── Execution stage ─────────────────────────────────────────────────────────
 
   describe("execution stage", () => {
-    test("agent tier mismatch warn includes storyId", async () => {
+    test("agent tier mismatch debug log includes storyId", async () => {
       const logger = getLogger();
-      const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+      const debugSpy = spyOn(logger, "debug").mockImplementation(() => {});
       spyOn(logger, "info").mockImplementation(() => {});
       spyOn(logger, "error").mockImplementation(() => {});
 
@@ -171,7 +171,7 @@ describe("storyId is present in JSONL event payloads", () => {
       ctx.prompt = "implement the feature";
       await executionStage.execute(ctx);
 
-      const call = warnSpy.mock.calls.find(([, msg]) => msg === "Agent tier mismatch");
+      const call = debugSpy.mock.calls.find(([, msg]) => msg === "Agent tier mismatch — clamping to supported tier");
       expect(call).toBeDefined();
       expect(call![2]).toEqual(
         expect.objectContaining({

--- a/test/unit/utils/auto-commit.test.ts
+++ b/test/unit/utils/auto-commit.test.ts
@@ -126,4 +126,31 @@ describe("autoCommitIfDirty", () => {
 
     expect(commands.some((c) => c.includes("commit"))).toBe(false);
   });
+
+  // Issue 5 (#369): warn→debug when auto-committing after agent session
+  test("logs at debug level (not warn) when auto-committing dirty files", async () => {
+    const gitRoot = "/repo";
+    _gitDeps.spawn = mock((cmd: string[]) => {
+      commands.push(cmd);
+      if (cmd.includes("rev-parse")) return makeProc(gitRoot + "\n");
+      if (cmd.includes("status")) return makeProc(" M src/foo.ts\n");
+      return makeProc("");
+    }) as typeof _gitDeps.spawn;
+
+    let warnCalled = false;
+    let debugCalled = false;
+    const origGetSafeLogger = _gitDeps.getSafeLogger;
+    _gitDeps.getSafeLogger = mock(() => ({
+      warn: () => { warnCalled = true; },
+      debug: () => { debugCalled = true; },
+    })) as typeof _gitDeps.getSafeLogger;
+
+    try {
+      await autoCommitIfDirty(gitRoot, "tdd", "implementer", "US-001");
+      expect(warnCalled).toBe(false);
+      expect(debugCalled).toBe(true);
+    } finally {
+      _gitDeps.getSafeLogger = origGetSafeLogger;
+    }
+  });
 });


### PR DESCRIPTION
## What

Three behavioural fixes from issue #369 (Group C of the graphify-kb-debate analysis):

1. **Agent tier mismatch clamping** (`execution.ts`): when the requested model tier is unsupported by the selected agent (e.g. opencode only supports `balanced` but router picks `fast`), clamp `effectiveTier` to the first supported tier instead of silently passing the unsupported tier through.
2. **Auto-commit warn → debug** (`git.ts`): demote "Agent did not commit after X session — auto-committing" from `warn` to `debug`.
3. **Optimizer no-op warn → debug** (`optimizer.ts`): demote "No prompt to optimize, skipping" from `warn` to `debug`.

## Why

Closes #369

The graphify-kb-debate run produced 30+ `warn tdd Agent did not commit` entries per run (opencode never self-commits — this is a known quirk), a repeated `warn execution Agent tier mismatch` that then silently used the wrong tier anyway, and 5× `warn optimizer No prompt to optimize` per run. All three were masking real issues in the run log.

## How

- `execution.ts`: introduce `effectiveTier` local variable — set to `agent.capabilities.supportedTiers[0]` when tier mismatch, otherwise unchanged. Pass `effectiveTier` to both `agent.run({ modelTier })` and `resolveModelForAgent(...)`. Log at `debug`.
- `git.ts`: add `getSafeLogger` to `_gitDeps` (injectable for tests); change `logger?.warn` → `logger?.debug` in `autoCommitIfDirty`.
- `optimizer.ts`: introduce `_optimizerDeps = { getLogger }` (injectable for tests); change `logger.warn` → `logger.debug` for the null-prompt early exit.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes (5163 pass, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

TDD: wrote 4 failing tests first (RED across 3 files), then implemented fixes to GREEN:
- `execution-agent-routing.test.ts`: tier clamping + no-clamp-when-supported
- `auto-commit.test.ts`: logs at `debug` not `warn` when auto-committing
- `optimizer.test.ts` (new file): logs at `debug` not `warn` for null-prompt path

Also updated the pre-existing `storyid-events.test.ts` tier-mismatch test to match the new `debug`-level message.

## Notes

The tier-clamping fix is the only behavioural change. The warn→debug changes are operational noise reduction — the auto-commit mechanism itself is unchanged.