### PR TITLE
refactor(prompts): extract ReviewPromptBuilder from semantic.ts (phase 3)

### DIFF
--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -1,0 +1,91 @@
+/**
+ * ReviewPromptBuilder — centralises semantic review prompt construction.
+ *
+ * Owns the prompt for `src/review/semantic.ts:runSemanticReview()`.
+ * Extracted from the inline `buildPrompt()` function in semantic.ts.
+ *
+ * Imports types from src/review/types.ts (not src/review/semantic.ts) to
+ * avoid a circular dependency: semantic.ts imports ReviewPromptBuilder from
+ * src/prompts, so importing semantic.ts here would form a cycle.
+ */
+
+import type { SemanticReviewConfig, SemanticStory } from "../../review/types";
+import { wrapJsonPrompt } from "../../utils/llm-json";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SEMANTIC_ROLE =
+  "You are a semantic code reviewer with access to the repository files. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.";
+
+const SEMANTIC_INSTRUCTIONS = `## Instructions
+
+For each acceptance criterion, verify the diff implements it correctly.
+
+**Before reporting any finding as "error", you MUST verify it using your tools:**
+- If you suspect a key, function, import, or variable is missing, READ the relevant file to confirm before flagging.
+- If you suspect a code path is not wired in, GREP for its usage to confirm.
+- Do NOT flag something as missing based solely on its absence from the diff — it may already exist in the codebase. Check the actual file first.
+- If you cannot verify a claim even after checking, use "unverifiable" severity instead of "error".
+
+Flag issues only when you have confirmed:
+1. An AC is not implemented or partially implemented (verified by reading the actual files)
+2. The implementation contradicts what the AC specifies
+3. New code has dead paths that will never execute (stubs, noops, unreachable branches)
+4. New code is not wired into callers/exports (verified by grepping for usage)
+
+Do NOT flag: style issues, naming conventions, import ordering, file length, or anything lint handles.`;
+
+const SEMANTIC_OUTPUT_SCHEMA = `Respond with JSON only — no explanation text before or after:
+{
+  "passed": boolean,
+  "findings": [
+    {
+      "severity": "error" | "warn" | "info" | "unverifiable",
+      "file": "path/to/file",
+      "line": 42,
+      "issue": "description of the issue",
+      "suggestion": "how to fix it"
+    }
+  ]
+}
+
+If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.`;
+
+// ─── Class ────────────────────────────────────────────────────────────────────
+
+export class ReviewPromptBuilder {
+  /**
+   * Build the LLM prompt for a one-shot semantic review.
+   *
+   * Produces output byte-identical to the old inline `buildPrompt()` in
+   * src/review/semantic.ts. The `_stat` parameter that existed there was
+   * never used (diff already incorporates the stat preamble via truncateDiff).
+   */
+  buildSemanticReviewPrompt(story: SemanticStory, semanticConfig: SemanticReviewConfig, diff: string): string {
+    const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
+    const customRulesBlock =
+      semanticConfig.rules.length > 0
+        ? `\n## Additional Review Rules\n${semanticConfig.rules.map((r, i) => `${i + 1}. ${r}`).join("\n")}\n`
+        : "";
+
+    const core = `${SEMANTIC_ROLE}
+
+## Story: ${story.title}
+
+### Description
+${story.description}
+
+### Acceptance Criteria
+${acList}
+${customRulesBlock}
+## Git Diff (production code only — test files excluded)
+
+\`\`\`diff
+${diff}\`\`\`
+
+${SEMANTIC_INSTRUCTIONS}
+${SEMANTIC_OUTPUT_SCHEMA}`;
+
+    return wrapJsonPrompt(core);
+  }
+}

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -17,5 +17,8 @@ export { TddPromptBuilder as PromptBuilder } from "./builders/tdd-builder";
 export { DebatePromptBuilder } from "./builders/debate-builder";
 export type { StageContext, PromptBuilderOptions, ReviewStoryContext } from "./builders/debate-builder";
 
+// Review prompt builder — semantic review prompt construction.
+export { ReviewPromptBuilder } from "./builders/review-builder";
+
 // Core types — re-exported for callsites that need them
 export type { PromptRole, PromptSection, PromptOptions } from "./core/types";

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -18,17 +18,13 @@ import { DebateSession } from "../debate";
 import type { DebateSessionOptions } from "../debate";
 import { getSafeLogger } from "../logger";
 import type { ReviewFinding } from "../plugins/types";
+import { ReviewPromptBuilder } from "../prompts";
 import { getMergeBase, isGitRefValid } from "../utils/git";
-import { tryParseLLMJson, wrapJsonPrompt } from "../utils/llm-json";
-import type { ReviewCheckResult, SemanticReviewConfig } from "./types";
+import { tryParseLLMJson } from "../utils/llm-json";
+import type { ReviewCheckResult, SemanticReviewConfig, SemanticStory } from "./types";
 
-/** Story fields required for semantic review */
-export interface SemanticStory {
-  id: string;
-  title: string;
-  description: string;
-  acceptanceCriteria: string[];
-}
+// Re-export so existing callers (`import type { SemanticStory } from "./semantic"`) keep working.
+export type { SemanticStory };
 
 /** Function that resolves an AgentAdapter for a given model tier */
 export type ModelResolver = (tier: ModelTier) => AgentAdapter | null | undefined;
@@ -122,72 +118,6 @@ function truncateDiff(diff: string, stat?: string): string {
     : "";
 
   return `${statPreamble}${truncated}\n... (truncated at ${DIFF_CAP_BYTES} bytes, showing ${visibleFiles}/${totalFiles} files)`;
-}
-
-/**
- * Build the LLM prompt for semantic review.
- * @param stat - Optional git diff --stat output (all files, including tests). Always included
- *               as context so the LLM knows which test files were modified even when their
- *               content is excluded from the diff.
- */
-function buildPrompt(story: SemanticStory, semanticConfig: SemanticReviewConfig, diff: string, _stat?: string): string {
-  const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
-
-  const customRulesSection =
-    semanticConfig.rules.length > 0
-      ? `\n## Additional Review Rules\n${semanticConfig.rules.map((r, i) => `${i + 1}. ${r}`).join("\n")}\n`
-      : "";
-
-  const core = `You are a semantic code reviewer with access to the repository files. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.
-
-## Story: ${story.title}
-
-### Description
-${story.description}
-
-### Acceptance Criteria
-${acList}
-${customRulesSection}
-## Git Diff (production code only — test files excluded)
-
-\`\`\`diff
-${diff}\`\`\`
-
-## Instructions
-
-For each acceptance criterion, verify the diff implements it correctly.
-
-**Before reporting any finding as "error", you MUST verify it using your tools:**
-- If you suspect a key, function, import, or variable is missing, READ the relevant file to confirm before flagging.
-- If you suspect a code path is not wired in, GREP for its usage to confirm.
-- Do NOT flag something as missing based solely on its absence from the diff — it may already exist in the codebase. Check the actual file first.
-- If you cannot verify a claim even after checking, use "unverifiable" severity instead of "error".
-
-Flag issues only when you have confirmed:
-1. An AC is not implemented or partially implemented (verified by reading the actual files)
-2. The implementation contradicts what the AC specifies
-3. New code has dead paths that will never execute (stubs, noops, unreachable branches)
-4. New code is not wired into callers/exports (verified by grepping for usage)
-
-Do NOT flag: style issues, naming conventions, import ordering, file length, or anything lint handles.
-
-Respond with JSON only — no explanation text before or after:
-{
-  "passed": boolean,
-  "findings": [
-    {
-      "severity": "error" | "warn" | "info" | "unverifiable",
-      "file": "path/to/file",
-      "line": 42,
-      "issue": "description of the issue",
-      "suggestion": "how to fix it"
-    }
-  ]
-}
-
-If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.`;
-
-  return wrapJsonPrompt(core);
 }
 
 interface LLMFinding {
@@ -358,9 +288,8 @@ export async function runSemanticReview(
     };
   }
 
-  // Build prompt — pass stat so LLM can see which test files changed even though
-  // test file content is excluded from the diff (satisfies test-only AC verification)
-  const prompt = buildPrompt(story, semanticConfig, diff, stat || undefined);
+  // Build prompt — stat is already incorporated into diff via truncateDiff() when needed.
+  const prompt = new ReviewPromptBuilder().buildSemanticReviewPrompt(story, semanticConfig, diff);
 
   // Debate path: when debate is enabled for review stage, use DebateSession instead of agent.complete()
   const reviewDebateEnabled = naxConfig?.debate?.enabled && naxConfig?.debate?.stages?.review?.enabled;

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -7,6 +7,14 @@
 /** Review check name */
 export type ReviewCheckName = "typecheck" | "lint" | "test" | "build" | "semantic";
 
+/** Story fields required for semantic review */
+export interface SemanticStory {
+  id: string;
+  title: string;
+  description: string;
+  acceptanceCriteria: string[];
+}
+
 /** Semantic review configuration */
 export interface SemanticReviewConfig {
   /** Model tier for semantic review (default: 'balanced') */

--- a/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
@@ -1,0 +1,117 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`ReviewPromptBuilder.buildSemanticReviewPrompt() snapshot stability no custom rules — output is stable 1`] = `
+"IMPORTANT: Your entire response must be a single JSON object or array. Do not explain your reasoning. Do not use markdown formatting. Output ONLY the JSON.
+
+You are a semantic code reviewer with access to the repository files. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.
+
+## Story: Add semantic review
+
+### Description
+Implement LLM-based semantic review for story diffs.
+
+### Acceptance Criteria
+1. LLM is called with story diff
+2. Findings are returned as structured JSON
+
+## Git Diff (production code only — test files excluded)
+
+\`\`\`diff
+diff --git a/src/review/semantic.ts b/src/review/semantic.ts
++export async function runSemanticReview() {}\`\`\`
+
+## Instructions
+
+For each acceptance criterion, verify the diff implements it correctly.
+
+**Before reporting any finding as "error", you MUST verify it using your tools:**
+- If you suspect a key, function, import, or variable is missing, READ the relevant file to confirm before flagging.
+- If you suspect a code path is not wired in, GREP for its usage to confirm.
+- Do NOT flag something as missing based solely on its absence from the diff — it may already exist in the codebase. Check the actual file first.
+- If you cannot verify a claim even after checking, use "unverifiable" severity instead of "error".
+
+Flag issues only when you have confirmed:
+1. An AC is not implemented or partially implemented (verified by reading the actual files)
+2. The implementation contradicts what the AC specifies
+3. New code has dead paths that will never execute (stubs, noops, unreachable branches)
+4. New code is not wired into callers/exports (verified by grepping for usage)
+
+Do NOT flag: style issues, naming conventions, import ordering, file length, or anything lint handles.
+Respond with JSON only — no explanation text before or after:
+{
+  "passed": boolean,
+  "findings": [
+    {
+      "severity": "error" | "warn" | "info" | "unverifiable",
+      "file": "path/to/file",
+      "line": 42,
+      "issue": "description of the issue",
+      "suggestion": "how to fix it"
+    }
+  ]
+}
+
+If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.
+
+YOUR RESPONSE MUST START WITH { OR [ AND END WITH } OR ]. No other text."
+`;
+
+exports[`ReviewPromptBuilder.buildSemanticReviewPrompt() snapshot stability with custom rules — output is stable 1`] = `
+"IMPORTANT: Your entire response must be a single JSON object or array. Do not explain your reasoning. Do not use markdown formatting. Output ONLY the JSON.
+
+You are a semantic code reviewer with access to the repository files. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.
+
+## Story: Add semantic review
+
+### Description
+Implement LLM-based semantic review for story diffs.
+
+### Acceptance Criteria
+1. LLM is called with story diff
+2. Findings are returned as structured JSON
+
+## Additional Review Rules
+1. Do not flag style issues
+2. Verify AC 1 using GREP before flagging
+
+## Git Diff (production code only — test files excluded)
+
+\`\`\`diff
+diff --git a/src/review/semantic.ts b/src/review/semantic.ts
++export async function runSemanticReview() {}\`\`\`
+
+## Instructions
+
+For each acceptance criterion, verify the diff implements it correctly.
+
+**Before reporting any finding as "error", you MUST verify it using your tools:**
+- If you suspect a key, function, import, or variable is missing, READ the relevant file to confirm before flagging.
+- If you suspect a code path is not wired in, GREP for its usage to confirm.
+- Do NOT flag something as missing based solely on its absence from the diff — it may already exist in the codebase. Check the actual file first.
+- If you cannot verify a claim even after checking, use "unverifiable" severity instead of "error".
+
+Flag issues only when you have confirmed:
+1. An AC is not implemented or partially implemented (verified by reading the actual files)
+2. The implementation contradicts what the AC specifies
+3. New code has dead paths that will never execute (stubs, noops, unreachable branches)
+4. New code is not wired into callers/exports (verified by grepping for usage)
+
+Do NOT flag: style issues, naming conventions, import ordering, file length, or anything lint handles.
+Respond with JSON only — no explanation text before or after:
+{
+  "passed": boolean,
+  "findings": [
+    {
+      "severity": "error" | "warn" | "info" | "unverifiable",
+      "file": "path/to/file",
+      "line": 42,
+      "issue": "description of the issue",
+      "suggestion": "how to fix it"
+    }
+  ]
+}
+
+If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.
+
+YOUR RESPONSE MUST START WITH { OR [ AND END WITH } OR ]. No other text."
+`;

--- a/test/unit/prompts/review-builder.test.ts
+++ b/test/unit/prompts/review-builder.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for ReviewPromptBuilder (Phase 3)
+ *
+ * Covers:
+ * - buildSemanticReviewPrompt: snapshot stability + structural contract
+ * - Story block: title, description, numbered ACs
+ * - Custom rules: included when present, omitted when empty
+ * - Diff block: fenced verbatim in the prompt
+ * - JSON wrapping: wrapJsonPrompt framing applied
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ReviewPromptBuilder } from "../../../src/prompts";
+import type { SemanticReviewConfig, SemanticStory } from "../../../src/review/types";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const STORY: SemanticStory = {
+  id: "US-001",
+  title: "Add semantic review",
+  description: "Implement LLM-based semantic review for story diffs.",
+  acceptanceCriteria: ["LLM is called with story diff", "Findings are returned as structured JSON"],
+};
+
+const CONFIG_NO_RULES: SemanticReviewConfig = {
+  modelTier: "balanced",
+  rules: [],
+  timeoutMs: 60_000,
+  excludePatterns: [],
+};
+
+const CONFIG_WITH_RULES: SemanticReviewConfig = {
+  ...CONFIG_NO_RULES,
+  rules: ["Do not flag style issues", "Verify AC 1 using GREP before flagging"],
+};
+
+const DIFF = `diff --git a/src/review/semantic.ts b/src/review/semantic.ts
++export async function runSemanticReview() {}`;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("ReviewPromptBuilder.buildSemanticReviewPrompt()", () => {
+  const builder = new ReviewPromptBuilder();
+
+  describe("snapshot stability", () => {
+    test("no custom rules — output is stable", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      expect(result).toMatchSnapshot();
+    });
+
+    test("with custom rules — output is stable", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_WITH_RULES, DIFF);
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe("story block", () => {
+    test("includes story title", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      expect(result).toContain(`## Story: ${STORY.title}`);
+    });
+
+    test("includes story description", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      expect(result).toContain(STORY.description);
+    });
+
+    test("numbers acceptance criteria", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      expect(result).toContain("1. LLM is called with story diff");
+      expect(result).toContain("2. Findings are returned as structured JSON");
+    });
+  });
+
+  describe("custom rules", () => {
+    test("omitted when rules array is empty", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      expect(result).not.toContain("## Additional Review Rules");
+    });
+
+    test("included and numbered when rules are present", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_WITH_RULES, DIFF);
+      expect(result).toContain("## Additional Review Rules");
+      expect(result).toContain("1. Do not flag style issues");
+      expect(result).toContain("2. Verify AC 1 using GREP before flagging");
+    });
+  });
+
+  describe("diff block", () => {
+    test("diff is included verbatim in a fenced code block", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      expect(result).toContain("```diff\n" + DIFF);
+    });
+  });
+
+  describe("JSON wrapping", () => {
+    test("applies wrapJsonPrompt framing", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      // wrapJsonPrompt prepends and appends sentinel strings
+      expect(result).toContain("IMPORTANT: Your entire response must be a single JSON object or array");
+      expect(result).toContain("YOUR RESPONSE MUST START WITH { OR [");
+    });
+  });
+
+  describe("role declaration", () => {
+    test("includes semantic reviewer role", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      expect(result).toContain("You are a semantic code reviewer");
+      expect(result).toContain("NOT a linter or style checker");
+    });
+  });
+
+  describe("instructions block", () => {
+    test("includes tool-verification requirement", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      expect(result).toContain("you MUST verify it using your tools");
+    });
+
+    test("instructs not to flag style issues", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      expect(result).toContain("Do NOT flag: style issues");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts the inline `buildPrompt()` function from `src/review/semantic.ts` into `ReviewPromptBuilder.buildSemanticReviewPrompt()` in `src/prompts/builders/review-builder.ts`
- Moves `SemanticStory` interface from `semantic.ts` → `src/review/types.ts`; re-exported from `semantic.ts` for backward compatibility
- Output is **byte-identical** to the original (verified by snapshot tests)

## Circular dependency handling

`review-builder.ts` imports `SemanticStory` and `SemanticReviewConfig` from `src/review/types.ts` (not `src/review/semantic.ts`). `semantic.ts` imports `ReviewPromptBuilder` from `src/prompts`. Chain: `semantic.ts` → `src/prompts/builders/review-builder.ts` → `src/review/types.ts`. `types.ts` does not import from `src/prompts` — no cycle.

## Success criteria met

- `src/review/semantic.ts` contains no `buildPrompt()` function ✓
- `ReviewPromptBuilder` is 80 lines — well under 200-line limit ✓
- `src/review/dialogue.ts` already had zero template literals >5 lines (from Phase 2) ✓

## Test plan

- [ ] `bun run typecheck` — exits 0
- [ ] `bun run lint` — exits 0
- [ ] `bun run test` — 0 fail; snapshot tests written for both with/without custom rules