### PR TITLE
refactor(prompts): AcceptancePromptBuilder — Phase 4

### DIFF
--- a/src/acceptance/fix-diagnosis.ts
+++ b/src/acceptance/fix-diagnosis.ts
@@ -9,6 +9,7 @@ import { buildSessionName } from "../agents/acp/adapter";
 import type { AgentAdapter } from "../agents/types";
 import type { NaxConfig } from "../config/schema";
 import { type ModelTier, resolveModelForAgent } from "../config/schema-types";
+import { AcceptancePromptBuilder } from "../prompts/builders/acceptance-builder";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { DiagnosisResult, SemanticVerdict } from "./types";
 
@@ -90,29 +91,14 @@ export function buildDiagnosisPrompt(options: {
     previousFailureSection = `\nPREVIOUS FIX ATTEMPTS:\n${options.previousFailure}\n`;
   }
 
-  return `You are a debugging expert. An acceptance test has failed.
-
-TASK: Diagnose whether the failure is due to a bug in the SOURCE CODE or a bug in the TEST CODE.
-
-FAILING TEST OUTPUT:
-${truncatedOutput}
-
-ACCEPTANCE TEST FILE CONTENT:
-\`\`\`typescript
-${options.testFileContent}
-\`\`\`
-
-SOURCE FILES (auto-detected from imports, up to ${MAX_FILE_LINES} lines each):
-${sourceFilesSection}
-${verdictSection}${previousFailureSection}
-Respond with ONLY a JSON object in this exact format (no markdown, no extra text):
-{
-  "verdict": "source_bug" | "test_bug" | "both",
-  "reasoning": "Your analysis explaining why this is a source_bug, test_bug, or both",
-  "confidence": 0.0-1.0,
-  "testIssues": ["Issue in test code if any"],
-  "sourceIssues": ["Issue in source code if any"]
-}`;
+  return new AcceptancePromptBuilder().buildDiagnosisPromptTemplate({
+    truncatedOutput,
+    testFileContent: options.testFileContent,
+    sourceFilesSection,
+    verdictSection,
+    previousFailureSection,
+    maxFileLines: MAX_FILE_LINES,
+  });
 }
 
 export async function diagnoseAcceptanceFailure(

--- a/src/acceptance/fix-executor.ts
+++ b/src/acceptance/fix-executor.ts
@@ -10,6 +10,7 @@ import type { AgentAdapter, AgentRunOptions } from "../agents/types";
 import type { NaxConfig } from "../config/schema";
 import type { ModelTier } from "../config/schema-types";
 import { resolveModelForAgent } from "../config/schema-types";
+import { AcceptancePromptBuilder } from "../prompts/builders/acceptance-builder";
 import type { DiagnosisResult } from "./types";
 
 export interface ExecuteSourceFixOptions {
@@ -29,23 +30,12 @@ export interface ExecuteSourceFixResult {
 }
 
 export function buildSourceFixPrompt(options: ExecuteSourceFixOptions): string {
-  const { testOutput, diagnosis, acceptanceTestPath, testFileContent } = options;
-
-  let prompt = `ACCEPTANCE TEST FAILURE:\n${testOutput}\n\n`;
-
-  if (diagnosis.reasoning) {
-    prompt += `DIAGNOSIS:\n${diagnosis.reasoning}\n\n`;
-  }
-
-  prompt += `ACCEPTANCE TEST FILE: ${acceptanceTestPath}\n\n`;
-
-  if (testFileContent && testFileContent.length > 0) {
-    prompt += `\`\`\`typescript\n${testFileContent}\n\`\`\`\n\n`;
-  }
-
-  prompt += "Fix the source implementation. Do NOT modify the test file.";
-
-  return prompt;
+  return new AcceptancePromptBuilder().buildSourceFixPrompt({
+    testOutput: options.testOutput,
+    diagnosisReasoning: options.diagnosis.reasoning,
+    acceptanceTestPath: options.acceptanceTestPath,
+    testFileContent: options.testFileContent,
+  });
 }
 
 export async function executeSourceFix(
@@ -115,27 +105,14 @@ export interface ExecuteTestFixResult {
 }
 
 export function buildTestFixPrompt(options: ExecuteTestFixOptions): string {
-  const { testOutput, diagnosis, acceptanceTestPath, testFileContent, failedACs, previousFailure } = options;
-
-  let prompt = "ACCEPTANCE TEST BUG — surgical fix required.\n\n";
-  prompt += `FAILING ACS: ${failedACs.join(", ")}\n\n`;
-  prompt += `TEST OUTPUT:\n${testOutput}\n\n`;
-
-  if (diagnosis.reasoning) {
-    prompt += `DIAGNOSIS:\n${diagnosis.reasoning}\n\n`;
-  }
-
-  if (previousFailure && previousFailure.length > 0) {
-    prompt += `PREVIOUS FAILED ATTEMPTS:\n${previousFailure}\n\n`;
-  }
-
-  prompt += `ACCEPTANCE TEST FILE: ${acceptanceTestPath}\n\n`;
-  prompt += `\`\`\`typescript\n${testFileContent}\n\`\`\`\n\n`;
-  prompt += "Fix ONLY the failing test assertions for the ACs listed above. ";
-  prompt += "Do NOT modify passing tests. Do NOT modify source code. ";
-  prompt += "Edit the test file in place.";
-
-  return prompt;
+  return new AcceptancePromptBuilder().buildTestFixPrompt({
+    testOutput: options.testOutput,
+    diagnosisReasoning: options.diagnosis.reasoning,
+    failedACs: options.failedACs,
+    previousFailure: options.previousFailure,
+    acceptanceTestPath: options.acceptanceTestPath,
+    testFileContent: options.testFileContent,
+  });
 }
 
 export async function executeTestFix(

--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -10,6 +10,7 @@ import { createAgentRegistry } from "../agents/registry";
 import type { AgentAdapter } from "../agents/types";
 import { getLogger } from "../logger";
 import type { UserStory } from "../prd/types";
+import { AcceptancePromptBuilder } from "../prompts/builders/acceptance-builder";
 import {
   acceptanceTestFilename as defaultAcceptanceTestFilename,
   resolveAcceptanceTestFile as defaultResolveAcceptanceTestFile,
@@ -180,54 +181,22 @@ export async function generateFromPRD(
     ? `\n[FRAMEWORK OVERRIDE: Use ${options.testFramework} as the test framework regardless of what you detect.]`
     : "";
 
-  const basePrompt = `You are a senior test engineer. Your task is to generate a complete acceptance test file for the "${options.featureName}" feature.
-
-## Step 1: Understand and Classify the Acceptance Criteria
-
-Read each AC below and classify its verification type (prefer runtime-check):
-- **runtime-check** (PREFERRED): Import the module, call the function, assert on return values, thrown errors, or observable side effects. This is the strongest verification — use it whenever possible.
-- **integration-check**: Requires a running service (e.g. HTTP endpoint returns 200, database query succeeds). Use setup blocks.
-- **file-check** (LAST RESORT): Only for ACs that genuinely cannot be verified at runtime (e.g. "no banned imports in file X", "config file exists"). Never use file-check when a runtime import + assertion would work.
-
-ACCEPTANCE CRITERIA:
-${criteriaList}
-
-## Step 2: Explore the Project
-
-Before writing any tests, examine the project to understand:
-1. **Language and test framework** — check dependency manifests (package.json, go.mod, Gemfile, pyproject.toml, Cargo.toml, build.gradle, etc.) to identify the language and test runner
-2. **Existing test patterns** — read 1-2 existing test files to understand import style, describe/test/it conventions, and available helpers
-3. **Project structure** — identify relevant source directories to determine correct import or load paths
-
-${frameworkOverrideLine}
-
-## Step 3: Generate the Acceptance Test File
-
-Write the complete acceptance test file using the framework identified in Step 2.
-
-Rules:
-- **One test per AC**, named exactly "AC-N: <description>"
-- **runtime-check ACs** (default) → import the module directly, call functions with test inputs, assert on return values or observable side effects (log calls, thrown errors, state changes)
-- **integration-check ACs** → use the language's HTTP client or existing test helpers; add a clear setup block (beforeAll/setup/TestMain/etc.) explaining what must be running
-- **file-check ACs** (last resort only) → read source files using the language's standard file I/O, assert with string or regex checks. Only use when the AC explicitly asks about file contents or imports — never use file-check to verify behavior that can be tested by calling the function
-- **NEVER use placeholder assertions** — no always-passing or always-failing stubs, no TODO comments as the only content, no empty test bodies
-- Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
-- **Prefer behavioral tests** — import functions and call them rather than reading source files. For example, to verify "getPostRunActions() returns empty array", import PluginRegistry and call getPostRunActions(), don't grep the source file for the method name.
-- **File output (REQUIRED)**: Write the acceptance test file DIRECTLY to the path shown below. Do NOT output the test code in your response. After writing the file, reply with a brief confirmation.
-- **Path anchor (CRITICAL)**: Write the test file to this exact path: \`${options.targetTestFile ?? join(options.workdir, ".nax", "features", options.featureName, resolveAcceptanceTestFile(options.language, options.config?.acceptance?.testPath))}\`. Import from package sources using relative paths like \`../../../src/...\` (3 levels up from \`.nax/features/<name>/\` to the package root).
-- **Process cwd**: When spawning child processes to invoke a CLI or binary, set the working directory to the **package root** (\`join(import.meta.dir, "../../..")\`) as your default — unless your Step 2 exploration reveals the CLI uses a different working directory convention (e.g. reads config from \`~/.config/\`, or resolves paths relative to a flag value). Always check how the CLI resolves file paths before assuming.`;
-
-  const implementationSection =
-    options.implementationContext && options.implementationContext.length > 0
-      ? `\n\n## Implementation (already exists)\n\n${options.implementationContext.map((f) => `### ${f.path}\n\`\`\`\n${f.content}\n\`\`\``).join("\n\n")}`
-      : "";
-
-  const previousFailureSection =
-    options.previousFailure && options.previousFailure.length > 0
-      ? `\n\nPrevious test failed because: ${options.previousFailure}`
-      : "";
-
-  const prompt = basePrompt + implementationSection + previousFailureSection;
+  const prompt = new AcceptancePromptBuilder().buildGeneratorFromPRDPrompt({
+    featureName: options.featureName,
+    criteriaList,
+    frameworkOverrideLine,
+    targetTestFilePath:
+      options.targetTestFile ??
+      join(
+        options.workdir,
+        ".nax",
+        "features",
+        options.featureName,
+        resolveAcceptanceTestFile(options.language, options.config?.acceptance?.testPath),
+      ),
+    implementationContext: options.implementationContext,
+    previousFailure: options.previousFailure,
+  });
 
   logger.info("acceptance", "Generating tests from PRD refined criteria", { count: refinedCriteria.length });
 
@@ -446,40 +415,11 @@ export function buildAcceptanceTestPrompt(
   const criteriaList = criteria.map((ac) => `${ac.id}: ${ac.text}`).join("\n");
   const resolvedTestPath = resolveAcceptanceTestFile(language, testPathConfig);
 
-  return `You are a senior test engineer. Your task is to generate a complete acceptance test file for the "${featureName}" feature.
-
-## Step 1: Understand and Classify the Acceptance Criteria
-
-Read each AC below and classify its verification type (prefer runtime-check):
-- **runtime-check** (PREFERRED): Import the module, call the function, assert on return values, thrown errors, or observable side effects. This is the strongest verification — use it whenever possible.
-- **integration-check**: Requires a running service (e.g. HTTP endpoint returns 200, database query succeeds). Use setup blocks.
-- **file-check** (LAST RESORT): Only for ACs that genuinely cannot be verified at runtime (e.g. "no banned imports in file X", "config file exists"). Never use file-check when a runtime import + assertion would work.
-
-ACCEPTANCE CRITERIA:
-${criteriaList}
-
-## Step 2: Explore the Project
-
-Before writing any tests, examine the project to understand:
-1. **Language and test framework** — check dependency manifests (package.json, go.mod, Gemfile, pyproject.toml, Cargo.toml, build.gradle, etc.) to identify the language and test runner
-2. **Existing test patterns** — read 1-2 existing test files to understand import style, describe/test/it conventions, and available helpers
-3. **Project structure** — identify relevant source directories to determine correct import or load paths
-
-
-## Step 3: Generate the Acceptance Test File
-
-Write the complete acceptance test file using the framework identified in Step 2.
-
-Rules:
-- **One test per AC**, named exactly "AC-N: <description>"
-- **runtime-check ACs** (default) → import the module directly, call functions with test inputs, assert on return values or observable side effects (log calls, thrown errors, state changes)
-- **integration-check ACs** → use the language's HTTP client or existing test helpers; add a clear setup block (beforeAll/setup/TestMain/etc.) explaining what must be running
-- **file-check ACs** (last resort only) → read source files using the language's standard file I/O, assert with string or regex checks. Only use when the AC explicitly asks about file contents or imports — never use file-check to verify behavior that can be tested by calling the function
-- **NEVER use placeholder assertions** — no always-passing or always-failing stubs, no TODO comments as the only content, no empty test bodies
-- Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
-- **Prefer behavioral tests** — import functions and call them rather than reading source files. For example, to verify "getPostRunActions() returns empty array", import PluginRegistry and call getPostRunActions(), don't grep the source file for the method name.
-- Output raw code only — no markdown fences, start directly with the language's import or package declaration
-- **Path anchor (CRITICAL)**: This test file will be saved at \`<repo-root>/.nax/features/${featureName}/${resolvedTestPath}\` and will ALWAYS run from the repo root. The repo root is exactly 3 \`../\` levels above \`__dirname\`: \`join(__dirname, '..', '..', '..')\`. For monorepo projects, navigate into packages from root (e.g. \`join(root, 'apps/api/src')\`).`;
+  return new AcceptancePromptBuilder().buildGeneratorFromSpecPrompt({
+    featureName,
+    criteriaList,
+    resolvedTestPath,
+  });
 }
 
 /**

--- a/src/prompts/builders/acceptance-builder.ts
+++ b/src/prompts/builders/acceptance-builder.ts
@@ -1,0 +1,189 @@
+/**
+ * AcceptancePromptBuilder
+ *
+ * Centralises all prompt construction for src/acceptance/:
+ *   - generator.ts  → buildGeneratorFromPRDPrompt, buildGeneratorFromSpecPrompt
+ *   - fix-diagnosis.ts → buildDiagnosisPromptTemplate
+ *   - fix-executor.ts  → buildSourceFixPrompt, buildTestFixPrompt
+ *
+ * Instance methods (not static) — required by Biome's noStaticOnlyClass rule.
+ * Instantiation cost is negligible; builders are short-lived call-and-discard.
+ */
+
+export type AcceptanceRole = "generator" | "diagnoser" | "fix-executor";
+
+// ─── Shared generator step text ───────────────────────────────────────────────
+
+const STEP1 = `## Step 1: Understand and Classify the Acceptance Criteria
+
+Read each AC below and classify its verification type (prefer runtime-check):
+- **runtime-check** (PREFERRED): Import the module, call the function, assert on return values, thrown errors, or observable side effects. This is the strongest verification — use it whenever possible.
+- **integration-check**: Requires a running service (e.g. HTTP endpoint returns 200, database query succeeds). Use setup blocks.
+- **file-check** (LAST RESORT): Only for ACs that genuinely cannot be verified at runtime (e.g. "no banned imports in file X", "config file exists"). Never use file-check when a runtime import + assertion would work.`;
+
+const STEP2 = `## Step 2: Explore the Project
+
+Before writing any tests, examine the project to understand:
+1. **Language and test framework** — check dependency manifests (package.json, go.mod, Gemfile, pyproject.toml, Cargo.toml, build.gradle, etc.) to identify the language and test runner
+2. **Existing test patterns** — read 1-2 existing test files to understand import style, describe/test/it conventions, and available helpers
+3. **Project structure** — identify relevant source directories to determine correct import or load paths`;
+
+const STEP3_HEADER = `## Step 3: Generate the Acceptance Test File
+
+Write the complete acceptance test file using the framework identified in Step 2.
+
+Rules:`;
+
+const STEP3_SHARED_RULES = `- **One test per AC**, named exactly "AC-N: <description>"
+- **runtime-check ACs** (default) → import the module directly, call functions with test inputs, assert on return values or observable side effects (log calls, thrown errors, state changes)
+- **integration-check ACs** → use the language's HTTP client or existing test helpers; add a clear setup block (beforeAll/setup/TestMain/etc.) explaining what must be running
+- **file-check ACs** (last resort only) → read source files using the language's standard file I/O, assert with string or regex checks. Only use when the AC explicitly asks about file contents or imports — never use file-check to verify behavior that can be tested by calling the function
+- **NEVER use placeholder assertions** — no always-passing or always-failing stubs, no TODO comments as the only content, no empty test bodies
+- Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
+- **Prefer behavioral tests** — import functions and call them rather than reading source files. For example, to verify "getPostRunActions() returns empty array", import PluginRegistry and call getPostRunActions(), don't grep the source file for the method name.`;
+
+// ─── Parameter interfaces ─────────────────────────────────────────────────────
+
+export interface GeneratorFromPRDParams {
+  featureName: string;
+  criteriaList: string;
+  frameworkOverrideLine: string;
+  /** Fully resolved absolute path for the test file output. */
+  targetTestFilePath: string;
+  implementationContext?: Array<{ path: string; content: string }>;
+  previousFailure?: string;
+}
+
+export interface GeneratorFromSpecParams {
+  featureName: string;
+  criteriaList: string;
+  resolvedTestPath: string;
+}
+
+export interface DiagnosisTemplateParams {
+  truncatedOutput: string;
+  testFileContent: string;
+  sourceFilesSection: string;
+  verdictSection: string;
+  previousFailureSection: string;
+  maxFileLines: number;
+}
+
+export interface SourceFixParams {
+  testOutput: string;
+  diagnosisReasoning?: string;
+  acceptanceTestPath: string;
+  testFileContent?: string;
+}
+
+export interface TestFixParams {
+  testOutput: string;
+  diagnosisReasoning?: string;
+  failedACs: string[];
+  previousFailure?: string;
+  acceptanceTestPath: string;
+  testFileContent: string;
+}
+
+// ─── Builder ──────────────────────────────────────────────────────────────────
+
+export class AcceptancePromptBuilder {
+  /** Prompt for generateFromPRD() — agent writes file directly to targetTestFilePath. */
+  buildGeneratorFromPRDPrompt(p: GeneratorFromPRDParams): string {
+    const frameworkLine = p.frameworkOverrideLine ? `\n${p.frameworkOverrideLine}` : "";
+    const implSection =
+      p.implementationContext && p.implementationContext.length > 0
+        ? `\n\n## Implementation (already exists)\n\n${p.implementationContext.map((f) => `### ${f.path}\n\`\`\`\n${f.content}\n\`\`\``).join("\n\n")}`
+        : "";
+    const prevFailureSection =
+      p.previousFailure && p.previousFailure.length > 0 ? `\n\nPrevious test failed because: ${p.previousFailure}` : "";
+
+    return `You are a senior test engineer. Your task is to generate a complete acceptance test file for the "${p.featureName}" feature.
+
+${STEP1}
+
+ACCEPTANCE CRITERIA:
+${p.criteriaList}
+
+${STEP2}${frameworkLine}
+
+${STEP3_HEADER}
+${STEP3_SHARED_RULES}
+- **File output (REQUIRED)**: Write the acceptance test file DIRECTLY to the path shown below. Do NOT output the test code in your response. After writing the file, reply with a brief confirmation.
+- **Path anchor (CRITICAL)**: Write the test file to this exact path: \`${p.targetTestFilePath}\`. Import from package sources using relative paths like \`../../../src/...\` (3 levels up from \`.nax/features/<name>/\` to the package root).
+- **Process cwd**: When spawning child processes to invoke a CLI or binary, set the working directory to the **package root** (\`join(import.meta.dir, "../../..")\`) as your default — unless your Step 2 exploration reveals the CLI uses a different working directory convention (e.g. reads config from \`~/.config/\`, or resolves paths relative to a flag value). Always check how the CLI resolves file paths before assuming.${implSection}${prevFailureSection}`;
+  }
+
+  /** Prompt for generateAcceptanceTests() — agent returns raw test code. */
+  buildGeneratorFromSpecPrompt(p: GeneratorFromSpecParams): string {
+    return `You are a senior test engineer. Your task is to generate a complete acceptance test file for the "${p.featureName}" feature.
+
+${STEP1}
+
+ACCEPTANCE CRITERIA:
+${p.criteriaList}
+
+${STEP2}
+
+${STEP3_HEADER}
+${STEP3_SHARED_RULES}
+- Output raw code only — no markdown fences, start directly with the language's import or package declaration
+- **Path anchor (CRITICAL)**: This test file will be saved at \`<repo-root>/.nax/features/${p.featureName}/${p.resolvedTestPath}\` and will ALWAYS run from the repo root. The repo root is exactly 3 \`../\` levels above \`__dirname\`: \`join(__dirname, '..', '..', '..')\`. For monorepo projects, navigate into packages from root (e.g. \`join(root, 'apps/api/src')\`).`;
+  }
+
+  /** Template assembly for buildDiagnosisPrompt() — receives pre-processed strings. */
+  buildDiagnosisPromptTemplate(p: DiagnosisTemplateParams): string {
+    return `You are a debugging expert. An acceptance test has failed.
+
+TASK: Diagnose whether the failure is due to a bug in the SOURCE CODE or a bug in the TEST CODE.
+
+FAILING TEST OUTPUT:
+${p.truncatedOutput}
+
+ACCEPTANCE TEST FILE CONTENT:
+\`\`\`typescript
+${p.testFileContent}
+\`\`\`
+
+SOURCE FILES (auto-detected from imports, up to ${p.maxFileLines} lines each):
+${p.sourceFilesSection}
+${p.verdictSection}${p.previousFailureSection}
+Respond with ONLY a JSON object in this exact format (no markdown, no extra text):
+{
+  "verdict": "source_bug" | "test_bug" | "both",
+  "reasoning": "Your analysis explaining why this is a source_bug, test_bug, or both",
+  "confidence": 0.0-1.0,
+  "testIssues": ["Issue in test code if any"],
+  "sourceIssues": ["Issue in source code if any"]
+}`;
+  }
+
+  /** Prompt for executeSourceFix() — instructs agent to fix source implementation. */
+  buildSourceFixPrompt(p: SourceFixParams): string {
+    let prompt = `ACCEPTANCE TEST FAILURE:\n${p.testOutput}\n\n`;
+    if (p.diagnosisReasoning) prompt += `DIAGNOSIS:\n${p.diagnosisReasoning}\n\n`;
+    prompt += `ACCEPTANCE TEST FILE: ${p.acceptanceTestPath}\n\n`;
+    if (p.testFileContent && p.testFileContent.length > 0) {
+      prompt += `\`\`\`typescript\n${p.testFileContent}\n\`\`\`\n\n`;
+    }
+    prompt += "Fix the source implementation. Do NOT modify the test file.";
+    return prompt;
+  }
+
+  /** Prompt for executeTestFix() — instructs agent to fix failing test assertions. */
+  buildTestFixPrompt(p: TestFixParams): string {
+    let prompt = "ACCEPTANCE TEST BUG — surgical fix required.\n\n";
+    prompt += `FAILING ACS: ${p.failedACs.join(", ")}\n\n`;
+    prompt += `TEST OUTPUT:\n${p.testOutput}\n\n`;
+    if (p.diagnosisReasoning) prompt += `DIAGNOSIS:\n${p.diagnosisReasoning}\n\n`;
+    if (p.previousFailure && p.previousFailure.length > 0) {
+      prompt += `PREVIOUS FAILED ATTEMPTS:\n${p.previousFailure}\n\n`;
+    }
+    prompt += `ACCEPTANCE TEST FILE: ${p.acceptanceTestPath}\n\n`;
+    prompt += `\`\`\`typescript\n${p.testFileContent}\n\`\`\`\n\n`;
+    prompt += "Fix ONLY the failing test assertions for the ACs listed above. ";
+    prompt += "Do NOT modify passing tests. Do NOT modify source code. ";
+    prompt += "Edit the test file in place.";
+    return prompt;
+  }
+}

--- a/src/prompts/core/sections/index.ts
+++ b/src/prompts/core/sections/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Prompt Core Sections
+ *
+ * Section builders shared across multiple prompt builders.
+ * Builders import from here — consumers import from src/prompts (public barrel).
+ */
+
+export { priorFailuresSection } from "./prior-failures";
+export type { FailureRecord } from "./prior-failures";

--- a/src/prompts/core/sections/prior-failures.ts
+++ b/src/prompts/core/sections/prior-failures.ts
@@ -1,0 +1,34 @@
+/**
+ * Prior Failures Section
+ *
+ * Builds the "PRIOR FAILURES" section used by acceptance and rectifier builders.
+ * Exported from core/sections so both AcceptancePromptBuilder (Phase 4) and
+ * RectifierPromptBuilder (Phase 5) can import without duplication.
+ */
+
+import type { PromptSection } from "../types";
+
+export interface FailureRecord {
+  test?: string;
+  file?: string;
+  message: string;
+  output?: string;
+}
+
+export function priorFailuresSection(failures: FailureRecord[]): PromptSection | null {
+  if (failures.length === 0) return null;
+  const body = failures
+    .map((f, i) => {
+      const head = `## Failure ${i + 1}${f.test ? ` — ${f.test}` : ""}`;
+      const loc = f.file ? `File: ${f.file}` : "";
+      const msg = `Message: ${f.message}`;
+      const out = f.output ? `\n\nOutput:\n\`\`\`\n${f.output}\n\`\`\`` : "";
+      return [head, loc, msg].filter(Boolean).join("\n") + out;
+    })
+    .join("\n\n");
+  return {
+    id: "prior-failures",
+    overridable: false,
+    content: `# PRIOR FAILURES\n\n${body}`,
+  };
+}

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -20,5 +20,10 @@ export type { StageContext, PromptBuilderOptions, ReviewStoryContext } from "./b
 // Review prompt builder — semantic review prompt construction.
 export { ReviewPromptBuilder } from "./builders/review-builder";
 
+// Acceptance prompt builder — generator, diagnoser, and fix-executor prompt construction.
+export { AcceptancePromptBuilder } from "./builders/acceptance-builder";
+// AcceptanceRole reserved for Phase 5 (RectifierPromptBuilder) dispatch.
+export type { AcceptanceRole } from "./builders/acceptance-builder";
+
 // Core types — re-exported for callsites that need them
 export type { PromptRole, PromptSection, PromptOptions } from "./core/types";

--- a/test/unit/prompts/__snapshots__/acceptance-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/acceptance-builder.test.ts.snap
@@ -1,0 +1,221 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`builder.buildGeneratorFromPRDPrompt() snapshot stability no framework override, no implementation context, no previous failure 1`] = `
+"You are a senior test engineer. Your task is to generate a complete acceptance test file for the "url-shortener" feature.
+
+## Step 1: Understand and Classify the Acceptance Criteria
+
+Read each AC below and classify its verification type (prefer runtime-check):
+- **runtime-check** (PREFERRED): Import the module, call the function, assert on return values, thrown errors, or observable side effects. This is the strongest verification — use it whenever possible.
+- **integration-check**: Requires a running service (e.g. HTTP endpoint returns 200, database query succeeds). Use setup blocks.
+- **file-check** (LAST RESORT): Only for ACs that genuinely cannot be verified at runtime (e.g. "no banned imports in file X", "config file exists"). Never use file-check when a runtime import + assertion would work.
+
+ACCEPTANCE CRITERIA:
+AC-1: handles empty input
+AC-2: returns short URL
+
+## Step 2: Explore the Project
+
+Before writing any tests, examine the project to understand:
+1. **Language and test framework** — check dependency manifests (package.json, go.mod, Gemfile, pyproject.toml, Cargo.toml, build.gradle, etc.) to identify the language and test runner
+2. **Existing test patterns** — read 1-2 existing test files to understand import style, describe/test/it conventions, and available helpers
+3. **Project structure** — identify relevant source directories to determine correct import or load paths
+
+## Step 3: Generate the Acceptance Test File
+
+Write the complete acceptance test file using the framework identified in Step 2.
+
+Rules:
+- **One test per AC**, named exactly "AC-N: <description>"
+- **runtime-check ACs** (default) → import the module directly, call functions with test inputs, assert on return values or observable side effects (log calls, thrown errors, state changes)
+- **integration-check ACs** → use the language's HTTP client or existing test helpers; add a clear setup block (beforeAll/setup/TestMain/etc.) explaining what must be running
+- **file-check ACs** (last resort only) → read source files using the language's standard file I/O, assert with string or regex checks. Only use when the AC explicitly asks about file contents or imports — never use file-check to verify behavior that can be tested by calling the function
+- **NEVER use placeholder assertions** — no always-passing or always-failing stubs, no TODO comments as the only content, no empty test bodies
+- Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
+- **Prefer behavioral tests** — import functions and call them rather than reading source files. For example, to verify "getPostRunActions() returns empty array", import PluginRegistry and call getPostRunActions(), don't grep the source file for the method name.
+- **File output (REQUIRED)**: Write the acceptance test file DIRECTLY to the path shown below. Do NOT output the test code in your response. After writing the file, reply with a brief confirmation.
+- **Path anchor (CRITICAL)**: Write the test file to this exact path: \`/project/.nax/features/url-shortener/.nax-acceptance.test.ts\`. Import from package sources using relative paths like \`../../../src/...\` (3 levels up from \`.nax/features/<name>/\` to the package root).
+- **Process cwd**: When spawning child processes to invoke a CLI or binary, set the working directory to the **package root** (\`join(import.meta.dir, "../../..")\`) as your default — unless your Step 2 exploration reveals the CLI uses a different working directory convention (e.g. reads config from \`~/.config/\`, or resolves paths relative to a flag value). Always check how the CLI resolves file paths before assuming."
+`;
+
+exports[`builder.buildGeneratorFromPRDPrompt() snapshot stability with framework override 1`] = `
+"You are a senior test engineer. Your task is to generate a complete acceptance test file for the "url-shortener" feature.
+
+## Step 1: Understand and Classify the Acceptance Criteria
+
+Read each AC below and classify its verification type (prefer runtime-check):
+- **runtime-check** (PREFERRED): Import the module, call the function, assert on return values, thrown errors, or observable side effects. This is the strongest verification — use it whenever possible.
+- **integration-check**: Requires a running service (e.g. HTTP endpoint returns 200, database query succeeds). Use setup blocks.
+- **file-check** (LAST RESORT): Only for ACs that genuinely cannot be verified at runtime (e.g. "no banned imports in file X", "config file exists"). Never use file-check when a runtime import + assertion would work.
+
+ACCEPTANCE CRITERIA:
+AC-1: handles empty input
+AC-2: returns short URL
+
+## Step 2: Explore the Project
+
+Before writing any tests, examine the project to understand:
+1. **Language and test framework** — check dependency manifests (package.json, go.mod, Gemfile, pyproject.toml, Cargo.toml, build.gradle, etc.) to identify the language and test runner
+2. **Existing test patterns** — read 1-2 existing test files to understand import style, describe/test/it conventions, and available helpers
+3. **Project structure** — identify relevant source directories to determine correct import or load paths
+
+[FRAMEWORK OVERRIDE: Use vitest as the test framework regardless of what you detect.]
+
+## Step 3: Generate the Acceptance Test File
+
+Write the complete acceptance test file using the framework identified in Step 2.
+
+Rules:
+- **One test per AC**, named exactly "AC-N: <description>"
+- **runtime-check ACs** (default) → import the module directly, call functions with test inputs, assert on return values or observable side effects (log calls, thrown errors, state changes)
+- **integration-check ACs** → use the language's HTTP client or existing test helpers; add a clear setup block (beforeAll/setup/TestMain/etc.) explaining what must be running
+- **file-check ACs** (last resort only) → read source files using the language's standard file I/O, assert with string or regex checks. Only use when the AC explicitly asks about file contents or imports — never use file-check to verify behavior that can be tested by calling the function
+- **NEVER use placeholder assertions** — no always-passing or always-failing stubs, no TODO comments as the only content, no empty test bodies
+- Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
+- **Prefer behavioral tests** — import functions and call them rather than reading source files. For example, to verify "getPostRunActions() returns empty array", import PluginRegistry and call getPostRunActions(), don't grep the source file for the method name.
+- **File output (REQUIRED)**: Write the acceptance test file DIRECTLY to the path shown below. Do NOT output the test code in your response. After writing the file, reply with a brief confirmation.
+- **Path anchor (CRITICAL)**: Write the test file to this exact path: \`/project/.nax/features/url-shortener/.nax-acceptance.test.ts\`. Import from package sources using relative paths like \`../../../src/...\` (3 levels up from \`.nax/features/<name>/\` to the package root).
+- **Process cwd**: When spawning child processes to invoke a CLI or binary, set the working directory to the **package root** (\`join(import.meta.dir, "../../..")\`) as your default — unless your Step 2 exploration reveals the CLI uses a different working directory convention (e.g. reads config from \`~/.config/\`, or resolves paths relative to a flag value). Always check how the CLI resolves file paths before assuming."
+`;
+
+exports[`builder.buildGeneratorFromPRDPrompt() snapshot stability with implementation context and previous failure 1`] = `
+"You are a senior test engineer. Your task is to generate a complete acceptance test file for the "url-shortener" feature.
+
+## Step 1: Understand and Classify the Acceptance Criteria
+
+Read each AC below and classify its verification type (prefer runtime-check):
+- **runtime-check** (PREFERRED): Import the module, call the function, assert on return values, thrown errors, or observable side effects. This is the strongest verification — use it whenever possible.
+- **integration-check**: Requires a running service (e.g. HTTP endpoint returns 200, database query succeeds). Use setup blocks.
+- **file-check** (LAST RESORT): Only for ACs that genuinely cannot be verified at runtime (e.g. "no banned imports in file X", "config file exists"). Never use file-check when a runtime import + assertion would work.
+
+ACCEPTANCE CRITERIA:
+AC-1: handles empty input
+AC-2: returns short URL
+
+## Step 2: Explore the Project
+
+Before writing any tests, examine the project to understand:
+1. **Language and test framework** — check dependency manifests (package.json, go.mod, Gemfile, pyproject.toml, Cargo.toml, build.gradle, etc.) to identify the language and test runner
+2. **Existing test patterns** — read 1-2 existing test files to understand import style, describe/test/it conventions, and available helpers
+3. **Project structure** — identify relevant source directories to determine correct import or load paths
+
+## Step 3: Generate the Acceptance Test File
+
+Write the complete acceptance test file using the framework identified in Step 2.
+
+Rules:
+- **One test per AC**, named exactly "AC-N: <description>"
+- **runtime-check ACs** (default) → import the module directly, call functions with test inputs, assert on return values or observable side effects (log calls, thrown errors, state changes)
+- **integration-check ACs** → use the language's HTTP client or existing test helpers; add a clear setup block (beforeAll/setup/TestMain/etc.) explaining what must be running
+- **file-check ACs** (last resort only) → read source files using the language's standard file I/O, assert with string or regex checks. Only use when the AC explicitly asks about file contents or imports — never use file-check to verify behavior that can be tested by calling the function
+- **NEVER use placeholder assertions** — no always-passing or always-failing stubs, no TODO comments as the only content, no empty test bodies
+- Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
+- **Prefer behavioral tests** — import functions and call them rather than reading source files. For example, to verify "getPostRunActions() returns empty array", import PluginRegistry and call getPostRunActions(), don't grep the source file for the method name.
+- **File output (REQUIRED)**: Write the acceptance test file DIRECTLY to the path shown below. Do NOT output the test code in your response. After writing the file, reply with a brief confirmation.
+- **Path anchor (CRITICAL)**: Write the test file to this exact path: \`/project/.nax/features/url-shortener/.nax-acceptance.test.ts\`. Import from package sources using relative paths like \`../../../src/...\` (3 levels up from \`.nax/features/<name>/\` to the package root).
+- **Process cwd**: When spawning child processes to invoke a CLI or binary, set the working directory to the **package root** (\`join(import.meta.dir, "../../..")\`) as your default — unless your Step 2 exploration reveals the CLI uses a different working directory convention (e.g. reads config from \`~/.config/\`, or resolves paths relative to a flag value). Always check how the CLI resolves file paths before assuming.
+
+## Implementation (already exists)
+
+### src/index.ts
+\`\`\`
+export function shorten() {}
+\`\`\`
+
+Previous test failed because: AC-1 assertion error: expected 1 but got null"
+`;
+
+exports[`builder.buildGeneratorFromSpecPrompt() snapshot stability standard generator from spec 1`] = `
+"You are a senior test engineer. Your task is to generate a complete acceptance test file for the "url-shortener" feature.
+
+## Step 1: Understand and Classify the Acceptance Criteria
+
+Read each AC below and classify its verification type (prefer runtime-check):
+- **runtime-check** (PREFERRED): Import the module, call the function, assert on return values, thrown errors, or observable side effects. This is the strongest verification — use it whenever possible.
+- **integration-check**: Requires a running service (e.g. HTTP endpoint returns 200, database query succeeds). Use setup blocks.
+- **file-check** (LAST RESORT): Only for ACs that genuinely cannot be verified at runtime (e.g. "no banned imports in file X", "config file exists"). Never use file-check when a runtime import + assertion would work.
+
+ACCEPTANCE CRITERIA:
+AC-1: handles empty input
+AC-2: returns short URL
+
+## Step 2: Explore the Project
+
+Before writing any tests, examine the project to understand:
+1. **Language and test framework** — check dependency manifests (package.json, go.mod, Gemfile, pyproject.toml, Cargo.toml, build.gradle, etc.) to identify the language and test runner
+2. **Existing test patterns** — read 1-2 existing test files to understand import style, describe/test/it conventions, and available helpers
+3. **Project structure** — identify relevant source directories to determine correct import or load paths
+
+## Step 3: Generate the Acceptance Test File
+
+Write the complete acceptance test file using the framework identified in Step 2.
+
+Rules:
+- **One test per AC**, named exactly "AC-N: <description>"
+- **runtime-check ACs** (default) → import the module directly, call functions with test inputs, assert on return values or observable side effects (log calls, thrown errors, state changes)
+- **integration-check ACs** → use the language's HTTP client or existing test helpers; add a clear setup block (beforeAll/setup/TestMain/etc.) explaining what must be running
+- **file-check ACs** (last resort only) → read source files using the language's standard file I/O, assert with string or regex checks. Only use when the AC explicitly asks about file contents or imports — never use file-check to verify behavior that can be tested by calling the function
+- **NEVER use placeholder assertions** — no always-passing or always-failing stubs, no TODO comments as the only content, no empty test bodies
+- Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
+- **Prefer behavioral tests** — import functions and call them rather than reading source files. For example, to verify "getPostRunActions() returns empty array", import PluginRegistry and call getPostRunActions(), don't grep the source file for the method name.
+- Output raw code only — no markdown fences, start directly with the language's import or package declaration
+- **Path anchor (CRITICAL)**: This test file will be saved at \`<repo-root>/.nax/features/url-shortener/.nax-acceptance.test.ts\` and will ALWAYS run from the repo root. The repo root is exactly 3 \`../\` levels above \`__dirname\`: \`join(__dirname, '..', '..', '..')\`. For monorepo projects, navigate into packages from root (e.g. \`join(root, 'apps/api/src')\`)."
+`;
+
+exports[`builder.buildDiagnosisPromptTemplate() snapshot stability no verdicts, no previous failure 1`] = `
+"You are a debugging expert. An acceptance test has failed.
+
+TASK: Diagnose whether the failure is due to a bug in the SOURCE CODE or a bug in the TEST CODE.
+
+FAILING TEST OUTPUT:
+FAIL: AC-1 assertion error
+
+ACCEPTANCE TEST FILE CONTENT:
+\`\`\`typescript
+import { test } from "bun:test"; test("AC-1: x", () => {});
+\`\`\`
+
+SOURCE FILES (auto-detected from imports, up to 500 lines each):
+(No source files could be resolved from imports)
+
+Respond with ONLY a JSON object in this exact format (no markdown, no extra text):
+{
+  "verdict": "source_bug" | "test_bug" | "both",
+  "reasoning": "Your analysis explaining why this is a source_bug, test_bug, or both",
+  "confidence": 0.0-1.0,
+  "testIssues": ["Issue in test code if any"],
+  "sourceIssues": ["Issue in source code if any"]
+}"
+`;
+
+exports[`builder.buildDiagnosisPromptTemplate() snapshot stability with verdict section and previous failure section 1`] = `
+"You are a debugging expert. An acceptance test has failed.
+
+TASK: Diagnose whether the failure is due to a bug in the SOURCE CODE or a bug in the TEST CODE.
+
+FAILING TEST OUTPUT:
+FAIL: AC-1 assertion error
+
+ACCEPTANCE TEST FILE CONTENT:
+\`\`\`typescript
+import { test } from "bun:test"; test("AC-1: x", () => {});
+\`\`\`
+
+SOURCE FILES (auto-detected from imports, up to 500 lines each):
+(No source files could be resolved from imports)
+
+SEMANTIC VERDICTS:
+- US-001: likely test bug (semantic review confirmed AC implementation)
+
+PREVIOUS FIX ATTEMPTS:
+Failed to fix null pointer
+
+Respond with ONLY a JSON object in this exact format (no markdown, no extra text):
+{
+  "verdict": "source_bug" | "test_bug" | "both",
+  "reasoning": "Your analysis explaining why this is a source_bug, test_bug, or both",
+  "confidence": 0.0-1.0,
+  "testIssues": ["Issue in test code if any"],
+  "sourceIssues": ["Issue in source code if any"]
+}"
+`;

--- a/test/unit/prompts/acceptance-builder.test.ts
+++ b/test/unit/prompts/acceptance-builder.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for AcceptancePromptBuilder (Phase 4)
+ *
+ * Covers:
+ * - buildGeneratorFromPRDPrompt: snapshot + structural contract
+ * - buildGeneratorFromSpecPrompt: snapshot + structural contract
+ * - buildDiagnosisPromptTemplate: snapshot + structural contract
+ * - buildSourceFixPrompt: structural contract
+ * - buildTestFixPrompt: structural contract
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AcceptancePromptBuilder } from "../../../src/prompts";
+
+const builder = new AcceptancePromptBuilder();
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const FEATURE = "url-shortener";
+const CRITERIA_LIST = "AC-1: handles empty input\nAC-2: returns short URL";
+const TARGET_PATH = "/project/.nax/features/url-shortener/.nax-acceptance.test.ts";
+const RESOLVED_TEST_PATH = ".nax-acceptance.test.ts";
+
+// ─── buildGeneratorFromPRDPrompt ──────────────────────────────────────────────
+
+describe("builder.buildGeneratorFromPRDPrompt()", () => {
+  const base = {
+    featureName: FEATURE,
+    criteriaList: CRITERIA_LIST,
+    frameworkOverrideLine: "",
+    targetTestFilePath: TARGET_PATH,
+  };
+
+  describe("snapshot stability", () => {
+    test("no framework override, no implementation context, no previous failure", () => {
+      expect(builder.buildGeneratorFromPRDPrompt(base)).toMatchSnapshot();
+    });
+
+    test("with framework override", () => {
+      expect(
+        builder.buildGeneratorFromPRDPrompt({
+          ...base,
+          frameworkOverrideLine: "\n[FRAMEWORK OVERRIDE: Use vitest as the test framework regardless of what you detect.]",
+        }),
+      ).toMatchSnapshot();
+    });
+
+    test("with implementation context and previous failure", () => {
+      expect(
+        builder.buildGeneratorFromPRDPrompt({
+          ...base,
+          implementationContext: [{ path: "src/index.ts", content: "export function shorten() {}" }],
+          previousFailure: "AC-1 assertion error: expected 1 but got null",
+        }),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe("structural contract", () => {
+    test("includes feature name", () => {
+      const result = builder.buildGeneratorFromPRDPrompt(base);
+      expect(result).toContain(`"${FEATURE}" feature`);
+    });
+
+    test("includes acceptance criteria list", () => {
+      const result = builder.buildGeneratorFromPRDPrompt(base);
+      expect(result).toContain(CRITERIA_LIST);
+    });
+
+    test("includes step headers", () => {
+      const result = builder.buildGeneratorFromPRDPrompt(base);
+      expect(result).toContain("## Step 1");
+      expect(result).toContain("## Step 2");
+      expect(result).toContain("## Step 3");
+    });
+
+    test("includes target test file path in path anchor", () => {
+      const result = builder.buildGeneratorFromPRDPrompt(base);
+      expect(result).toContain(TARGET_PATH);
+    });
+
+    test("includes file output requirement", () => {
+      const result = builder.buildGeneratorFromPRDPrompt(base);
+      expect(result).toContain("File output (REQUIRED)");
+    });
+
+    test("includes implementation context when provided", () => {
+      const result = builder.buildGeneratorFromPRDPrompt({
+        ...base,
+        implementationContext: [{ path: "src/index.ts", content: "export function shorten() {}" }],
+      });
+      expect(result).toContain("## Implementation (already exists)");
+      expect(result).toContain("src/index.ts");
+    });
+
+    test("omits implementation section when not provided", () => {
+      const result = builder.buildGeneratorFromPRDPrompt(base);
+      expect(result).not.toContain("## Implementation");
+    });
+
+    test("includes previous failure when provided", () => {
+      const msg = "AC-1 assertion error: expected 1 but got null";
+      const result = builder.buildGeneratorFromPRDPrompt({ ...base, previousFailure: msg });
+      expect(result).toContain(msg);
+    });
+
+    test("omits previous failure section when not provided", () => {
+      const result = builder.buildGeneratorFromPRDPrompt(base);
+      expect(result).not.toContain("Previous test failed because:");
+    });
+
+    test("includes framework override when non-empty", () => {
+      const line = "\n[FRAMEWORK OVERRIDE: Use vitest as the test framework regardless of what you detect.]";
+      const result = builder.buildGeneratorFromPRDPrompt({ ...base, frameworkOverrideLine: line });
+      expect(result).toContain("FRAMEWORK OVERRIDE");
+    });
+  });
+});
+
+// ─── buildGeneratorFromSpecPrompt ────────────────────────────────────────────
+
+describe("builder.buildGeneratorFromSpecPrompt()", () => {
+  const base = {
+    featureName: FEATURE,
+    criteriaList: CRITERIA_LIST,
+    resolvedTestPath: RESOLVED_TEST_PATH,
+  };
+
+  describe("snapshot stability", () => {
+    test("standard generator from spec", () => {
+      expect(builder.buildGeneratorFromSpecPrompt(base)).toMatchSnapshot();
+    });
+  });
+
+  describe("structural contract", () => {
+    test("includes feature name", () => {
+      expect(builder.buildGeneratorFromSpecPrompt(base)).toContain(`"${FEATURE}" feature`);
+    });
+
+    test("includes criteria list", () => {
+      expect(builder.buildGeneratorFromSpecPrompt(base)).toContain(CRITERIA_LIST);
+    });
+
+    test("includes raw code output instruction", () => {
+      expect(builder.buildGeneratorFromSpecPrompt(base)).toContain("Output raw code only");
+    });
+
+    test("includes resolved test path in path anchor", () => {
+      const result = builder.buildGeneratorFromSpecPrompt(base);
+      expect(result).toContain(RESOLVED_TEST_PATH);
+    });
+
+    test("does NOT include file output (REQUIRED) directive (raw output mode)", () => {
+      const result = builder.buildGeneratorFromSpecPrompt(base);
+      expect(result).not.toContain("File output (REQUIRED)");
+    });
+  });
+});
+
+// ─── buildDiagnosisPromptTemplate ────────────────────────────────────────────
+
+describe("builder.buildDiagnosisPromptTemplate()", () => {
+  const base = {
+    truncatedOutput: "FAIL: AC-1 assertion error",
+    testFileContent: 'import { test } from "bun:test"; test("AC-1: x", () => {});',
+    sourceFilesSection: "(No source files could be resolved from imports)",
+    verdictSection: "",
+    previousFailureSection: "",
+    maxFileLines: 500,
+  };
+
+  describe("snapshot stability", () => {
+    test("no verdicts, no previous failure", () => {
+      expect(builder.buildDiagnosisPromptTemplate(base)).toMatchSnapshot();
+    });
+
+    test("with verdict section and previous failure section", () => {
+      expect(
+        builder.buildDiagnosisPromptTemplate({
+          ...base,
+          verdictSection: "\nSEMANTIC VERDICTS:\n- US-001: likely test bug (semantic review confirmed AC implementation)\n",
+          previousFailureSection: "\nPREVIOUS FIX ATTEMPTS:\nFailed to fix null pointer\n",
+        }),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe("structural contract", () => {
+    test("includes test output", () => {
+      const result = builder.buildDiagnosisPromptTemplate(base);
+      expect(result).toContain(base.truncatedOutput);
+    });
+
+    test("includes test file content in fenced block", () => {
+      const result = builder.buildDiagnosisPromptTemplate(base);
+      expect(result).toContain("```typescript");
+      expect(result).toContain(base.testFileContent);
+    });
+
+    test("includes source files section", () => {
+      const result = builder.buildDiagnosisPromptTemplate(base);
+      expect(result).toContain(base.sourceFilesSection);
+    });
+
+    test("includes maxFileLines in source files header", () => {
+      const result = builder.buildDiagnosisPromptTemplate(base);
+      expect(result).toContain(`up to ${base.maxFileLines} lines each`);
+    });
+
+    test("includes JSON response schema", () => {
+      const result = builder.buildDiagnosisPromptTemplate(base);
+      expect(result).toContain('"verdict"');
+      expect(result).toContain('"reasoning"');
+      expect(result).toContain('"confidence"');
+    });
+
+    test("includes verdict section when provided", () => {
+      const result = builder.buildDiagnosisPromptTemplate({
+        ...base,
+        verdictSection: "\nSEMANTIC VERDICTS:\n- US-001: likely test bug\n",
+      });
+      expect(result).toContain("SEMANTIC VERDICTS");
+    });
+
+    test("does not include SEMANTIC VERDICTS when verdictSection is empty", () => {
+      const result = builder.buildDiagnosisPromptTemplate(base);
+      expect(result).not.toContain("SEMANTIC VERDICTS");
+    });
+  });
+});
+
+// ─── buildSourceFixPrompt ─────────────────────────────────────────────────────
+
+describe("builder.buildSourceFixPrompt()", () => {
+  const base = {
+    testOutput: "FAIL: AC-1 null pointer",
+    diagnosisReasoning: "Source file has uninitialized field",
+    acceptanceTestPath: "/project/.nax/features/feat/.nax-acceptance.test.ts",
+    testFileContent: 'test("AC-1: x", () => { expect(foo()).toBe(1); });',
+  };
+
+  test("includes test output", () => {
+    expect(builder.buildSourceFixPrompt(base)).toContain(base.testOutput);
+  });
+
+  test("includes diagnosis reasoning", () => {
+    expect(builder.buildSourceFixPrompt(base)).toContain(base.diagnosisReasoning);
+  });
+
+  test("includes acceptance test path", () => {
+    expect(builder.buildSourceFixPrompt(base)).toContain(base.acceptanceTestPath);
+  });
+
+  test("includes test file content in fenced typescript block", () => {
+    const result = builder.buildSourceFixPrompt(base);
+    expect(result).toContain("```typescript");
+    expect(result).toContain(base.testFileContent);
+  });
+
+  test("omits fenced block when testFileContent is empty", () => {
+    const result = builder.buildSourceFixPrompt({ ...base, testFileContent: "" });
+    expect(result).not.toContain("```typescript");
+  });
+
+  test("instructs not to modify test file", () => {
+    expect(builder.buildSourceFixPrompt(base)).toContain("Do NOT modify the test file");
+  });
+});
+
+// ─── buildTestFixPrompt ───────────────────────────────────────────────────────
+
+describe("builder.buildTestFixPrompt()", () => {
+  const base = {
+    testOutput: "FAIL: AC-1 assertion error",
+    diagnosisReasoning: "Test uses wrong assertion type",
+    failedACs: ["AC-1", "AC-3"],
+    acceptanceTestPath: "/project/.nax/features/feat/.nax-acceptance.test.ts",
+    testFileContent: 'test("AC-1: x", () => { expect(foo()).toBe(1); });',
+  };
+
+  test("includes failing ACs", () => {
+    const result = builder.buildTestFixPrompt(base);
+    expect(result).toContain("AC-1");
+    expect(result).toContain("AC-3");
+  });
+
+  test("includes test output", () => {
+    expect(builder.buildTestFixPrompt(base)).toContain(base.testOutput);
+  });
+
+  test("includes diagnosis reasoning", () => {
+    expect(builder.buildTestFixPrompt(base)).toContain(base.diagnosisReasoning);
+  });
+
+  test("includes test file content in fenced typescript block", () => {
+    const result = builder.buildTestFixPrompt(base);
+    expect(result).toContain("```typescript");
+    expect(result).toContain(base.testFileContent);
+  });
+
+  test("includes previous failure when provided", () => {
+    const result = builder.buildTestFixPrompt({ ...base, previousFailure: "patch1 failed" });
+    expect(result).toContain("patch1 failed");
+    expect(result).toContain("PREVIOUS FAILED ATTEMPTS");
+  });
+
+  test("omits previous failure section when not provided", () => {
+    const result = builder.buildTestFixPrompt(base);
+    expect(result).not.toContain("PREVIOUS FAILED ATTEMPTS");
+  });
+
+  test("instructs to fix only failing ACs and not source code", () => {
+    const result = builder.buildTestFixPrompt(base);
+    expect(result).toContain("Fix ONLY the failing test assertions");
+    expect(result).toContain("Do NOT modify source code");
+  });
+});

--- a/test/unit/prompts/core/sections/prior-failures.test.ts
+++ b/test/unit/prompts/core/sections/prior-failures.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for priorFailuresSection() in src/prompts/core/sections/prior-failures.ts
+ *
+ * This section is reserved for use by AcceptancePromptBuilder (Phase 4, unused)
+ * and RectifierPromptBuilder (Phase 5).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { priorFailuresSection } from "../../../../../src/prompts/core/sections/prior-failures";
+
+describe("priorFailuresSection()", () => {
+  test("returns null when failures array is empty", () => {
+    expect(priorFailuresSection([])).toBeNull();
+  });
+
+  test("returns a PromptSection with id 'prior-failures' for non-empty input", () => {
+    const result = priorFailuresSection([{ message: "assertion failed" }]);
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe("prior-failures");
+    expect(result?.overridable).toBe(false);
+  });
+
+  test("includes the failure message in content", () => {
+    const result = priorFailuresSection([{ message: "null pointer exception" }]);
+    expect(result?.content).toContain("null pointer exception");
+  });
+
+  test("includes PRIOR FAILURES header", () => {
+    const result = priorFailuresSection([{ message: "x" }]);
+    expect(result?.content).toContain("# PRIOR FAILURES");
+  });
+
+  test("numbers multiple failures sequentially", () => {
+    const result = priorFailuresSection([{ message: "first" }, { message: "second" }]);
+    expect(result?.content).toContain("## Failure 1");
+    expect(result?.content).toContain("## Failure 2");
+  });
+
+  test("includes test name in heading when provided", () => {
+    const result = priorFailuresSection([{ test: "AC-1: handles empty input", message: "x" }]);
+    expect(result?.content).toContain("## Failure 1 — AC-1: handles empty input");
+  });
+
+  test("includes file path when provided", () => {
+    const result = priorFailuresSection([{ file: "src/foo.ts", message: "x" }]);
+    expect(result?.content).toContain("File: src/foo.ts");
+  });
+
+  test("includes output in fenced code block when provided", () => {
+    const result = priorFailuresSection([{ message: "x", output: "stderr: panic" }]);
+    expect(result?.content).toContain("```\nstderr: panic\n```");
+  });
+
+  test("omits file line when file is not provided", () => {
+    const result = priorFailuresSection([{ message: "x" }]);
+    expect(result?.content).not.toContain("File:");
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts all LLM prompt template literals from `src/acceptance/` into a new `AcceptancePromptBuilder` in `src/prompts/builders/acceptance-builder.ts`
- Adds `src/prompts/core/sections/prior-failures.ts` (`FailureRecord` + `priorFailuresSection`) for reuse in Phase 5
- Pure structural refactor — zero behavioral changes

## What changed

**New:**
- `src/prompts/builders/acceptance-builder.ts` (190 lines) — 5 instance methods covering generator-from-PRD, generator-from-spec, diagnosis template, source fix, test fix
- `src/prompts/core/sections/prior-failures.ts` — shared section builder, reserved for Phase 5 RectifierPromptBuilder
- `test/unit/prompts/acceptance-builder.test.ts` — 41 tests (snapshot + structural contract)
- `test/unit/prompts/core/sections/prior-failures.test.ts` — 9 smoke tests

**Modified:**
- `src/acceptance/generator.ts` — two large inline prompts (34–36 lines each) replaced with `new AcceptancePromptBuilder().buildGeneratorFromPRDPrompt()` and `.buildGeneratorFromSpecPrompt()`
- `src/acceptance/fix-diagnosis.ts` — 22-line template literal in `buildDiagnosisPrompt()` replaced with `.buildDiagnosisPromptTemplate()`
- `src/acceptance/fix-executor.ts` — `buildSourceFixPrompt()` and `buildTestFixPrompt()` delegate to builder
- `src/prompts/index.ts` — exports `AcceptancePromptBuilder`, `AcceptanceRole`

## Success criteria

- [x] Zero template literals >5 lines in `src/acceptance/generator.ts`, `fix-diagnosis.ts`, `fix-executor.ts`
- [x] `AcceptancePromptBuilder` ≤200 lines (190)
- [x] All 1200+ tests pass, lint clean, typecheck clean
- [x] Snapshot tests establish stable baselines

## Notes

- **Instance methods, not static**: Biome's `noStaticOnlyClass` rule requires instance methods when the class has no state. All 5 methods are instance methods; callsites use `new AcceptancePromptBuilder().buildXxx(...)`.
- **`AcceptanceRole` type** is exported but currently unused — reserved for Phase 5 dispatch.
- **`priorFailuresSection`** is introduced here but not yet called by the builder — Phase 5 (RectifierPromptBuilder) will wire it in.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test test/unit/prompts/acceptance-builder.test.ts` — 41 pass, 6 snapshots
- [x] `bun test test/unit/acceptance/` — 374 pass (existing behavioral tests unchanged)
- [x] `bun run test` — 1200+ pass, 0 fail