### PR TITLE
feat(review): configurable semantic review diff mode (REVIEW-002)

### DIFF
--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -140,6 +140,10 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "review.commands.build": "Custom build command for review",
   "review.semantic": "Semantic review configuration (code quality analysis)",
   "review.semantic.modelTier": "Model tier for semantic review (default: balanced)",
+  "review.semantic.diffMode":
+    "How the semantic reviewer accesses the git diff. 'embedded' (default) includes the diff in the prompt (truncated at 50KB). 'ref' passes only the git ref and file list — the reviewer fetches the full diff via tools. Use 'ref' for large stories or multi-tier escalations where truncation loses context.",
+  "review.semantic.resetRefOnRerun":
+    "When true, clears storyGitRef on failed stories during re-run initialization so the ref is re-captured at the next story start. Prevents cross-story diff pollution when multiple stories exhaust all tiers and are re-run. Default: false.",
   "review.semantic.rules": "Custom semantic review rules to enforce",
 
   // Plan

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -274,6 +274,18 @@ const AnalyzeConfigSchema = z.object({
 
 const SemanticReviewConfigSchema = z.object({
   modelTier: ModelTierSchema.default("balanced"),
+  /**
+   * How the semantic reviewer accesses the git diff.
+   * "embedded" (default): pre-collected diff truncated at 50KB and embedded in prompt.
+   * "ref": only stat summary + storyGitRef passed; reviewer fetches full diff via tools.
+   */
+  diffMode: z.enum(["embedded", "ref"]).default("embedded"),
+  /**
+   * When true, clears storyGitRef on failed stories during re-run initialization so
+   * the ref is re-captured at the next story start. Prevents cross-story diff pollution
+   * when multiple stories exhaust all tiers and are re-run. Default false (current behaviour).
+   */
+  resetRefOnRerun: z.boolean().default(false),
   rules: z.array(z.string()).default([]),
   timeoutMs: z.number().int().positive().default(600_000),
   excludePatterns: z
@@ -729,6 +741,8 @@ export const NaxConfigSchema = z
       pluginMode: "per-story",
       semantic: {
         modelTier: "balanced",
+        diffMode: "embedded",
+        resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
         excludePatterns: [

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -42,7 +42,12 @@ export interface ResolveOutcome {
 
 /** Context required by resolveOutcome() when a ReviewerSession is used. Only populated from semantic.ts debate path. */
 export interface ResolverContext {
-  diff: string;
+  /** Pre-collected diff (embedded mode — mutually exclusive with storyGitRef/stat) */
+  diff?: string;
+  /** Git baseline ref (ref mode — mutually exclusive with diff) */
+  storyGitRef?: string;
+  /** Git diff --stat summary (ref mode) */
+  stat?: string;
   story: { id: string; title: string; acceptanceCriteria: string[] };
   semanticConfig: import("../review/types").SemanticReviewConfig;
   labeledProposals: Array<{ debater: string; output: string }>;
@@ -246,19 +251,26 @@ export async function resolveOutcome(
         acceptanceCriteria: resolverContext.story.acceptanceCriteria,
       };
 
+      // Build diffContext from resolverContext — one of diff (embedded) or storyGitRef+stat (ref).
+      const diffContext: import("../review/types").DiffContext = {
+        diff: resolverContext.diff,
+        storyGitRef: resolverContext.storyGitRef,
+        stat: resolverContext.stat,
+      };
+
       let dialogueResult: import("../review/dialogue").ReviewDialogueResult;
       if (resolverContext.isReReview) {
         dialogueResult = await reviewerSession.reReviewDebate(
           resolverContext.labeledProposals,
           critiqueOutputs,
-          resolverContext.diff,
+          diffContext,
           debateCtx,
         );
       } else {
         dialogueResult = await reviewerSession.resolveDebate(
           resolverContext.labeledProposals,
           critiqueOutputs,
-          resolverContext.diff,
+          diffContext,
           story,
           resolverContext.semanticConfig,
           debateCtx,

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -42,9 +42,11 @@ export interface ResolveOutcome {
 
 /** Context required by resolveOutcome() when a ReviewerSession is used. Only populated from semantic.ts debate path. */
 export interface ResolverContext {
-  /** Pre-collected diff (embedded mode — mutually exclusive with storyGitRef/stat) */
+  /** How the diff is provided — drives DiffContext construction for the dialogue path */
+  diffMode: "embedded" | "ref";
+  /** Pre-collected diff (embedded mode) */
   diff?: string;
-  /** Git baseline ref (ref mode — mutually exclusive with diff) */
+  /** Git baseline ref (ref mode) */
   storyGitRef?: string;
   /** Git diff --stat summary (ref mode) */
   stat?: string;
@@ -251,12 +253,11 @@ export async function resolveOutcome(
         acceptanceCriteria: resolverContext.story.acceptanceCriteria,
       };
 
-      // Build diffContext from resolverContext — one of diff (embedded) or storyGitRef+stat (ref).
-      const diffContext: import("../review/types").DiffContext = {
-        diff: resolverContext.diff,
-        storyGitRef: resolverContext.storyGitRef,
-        stat: resolverContext.stat,
-      };
+      // Build diffContext from resolverContext — discriminated on diffMode.
+      const diffContext: import("../review/types").DiffContext =
+        resolverContext.diffMode === "ref"
+          ? { mode: "ref", storyGitRef: resolverContext.storyGitRef ?? "", stat: resolverContext.stat }
+          : { mode: "embedded", diff: resolverContext.diff ?? "" };
 
       let dialogueResult: import("../review/dialogue").ReviewDialogueResult;
       if (resolverContext.isReReview) {

--- a/src/execution/lifecycle/run-initialization.ts
+++ b/src/execution/lifecycle/run-initialization.ts
@@ -184,7 +184,8 @@ export async function initializeRun(ctx: InitializationContext): Promise<Initial
   // Reset failed stories to pending so they are retried on re-run.
   // reconcileState runs first to promote failed→passed for git-committed stories;
   // remaining failed stories (incomplete work) are reset here so they re-enter the queue.
-  const hadFailedStories = resetFailedStoriesToPending(prd);
+  const resetRef = ctx.config.review?.semantic?.resetRefOnRerun ?? false;
+  const hadFailedStories = resetFailedStoriesToPending(prd, resetRef);
   if (hadFailedStories) {
     const resetIds = prd.userStories.filter((s) => s.status === "pending" && (s.attempts ?? 0) > 0).map((s) => s.id);
     logger?.info("run-initialization", "Reset failed stories to pending for re-run", { storyIds: resetIds });

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -220,13 +220,19 @@ export function markStoryFailed(
  * Reset all failed stories to pending so they are eligible for re-execution
  * on a fresh run. Keeps `attempts` intact so the history is preserved.
  *
+ * @param resetRef - When true, also clears `storyGitRef` so it is re-captured at the
+ *   next story start. Prevents cross-story diff pollution when multiple stories exhausted
+ *   all tiers across a run and are now re-queued. Default: false (current behaviour).
  * @returns true if any stories were reset (PRD is dirty and should be saved)
  */
-export function resetFailedStoriesToPending(prd: PRD): boolean {
+export function resetFailedStoriesToPending(prd: PRD, resetRef = false): boolean {
   let modified = false;
   for (const story of prd.userStories) {
     if (story.status === "failed") {
       story.status = "pending";
+      if (resetRef) {
+        story.storyGitRef = undefined;
+      }
       modified = true;
     }
   }

--- a/src/prompts/builders/debate-builder.ts
+++ b/src/prompts/builders/debate-builder.ts
@@ -341,7 +341,7 @@ ${this.stageContext.outputFormat}`;
  * ref mode: emits stat summary + git ref + self-serve commands.
  */
 function buildDebateDiffSection(ctx: DiffContext): string {
-  if (ctx.storyGitRef) {
+  if (ctx.mode === "ref") {
     // ref mode: reviewer self-serves the full diff via tools
     const stat = ctx.stat ?? "(no stat available)";
     const ref = ctx.storyGitRef;
@@ -362,5 +362,5 @@ function buildDebateDiffSection(ctx: DiffContext): string {
     ].join("\n");
   }
   // embedded mode: emit the diff block
-  return ["## Diff", ctx.diff ?? ""].join("\n");
+  return ["## Diff", ctx.diff].join("\n");
 }

--- a/src/prompts/builders/debate-builder.ts
+++ b/src/prompts/builders/debate-builder.ts
@@ -14,6 +14,7 @@
 import { PERSONA_FRAGMENTS } from "../../debate/personas";
 import type { DebateResolverContext, Debater, Proposal, Rebuttal } from "../../debate/types";
 import type { ReviewFinding } from "../../plugins/types";
+import type { DiffContext } from "../../review/types";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -230,7 +231,7 @@ ${this.stageContext.outputFormat}`;
   buildResolverPrompt(
     proposals: Array<{ debater: string; output: string }>,
     critiques: string[],
-    diff: string,
+    diffContext: DiffContext,
     story: ReviewStoryContext,
     resolverContext: DebateResolverContext,
   ): string {
@@ -239,6 +240,7 @@ ${this.stageContext.outputFormat}`;
     const voteTally = this.buildVoteTallyLine(resolverContext);
     const proposalsSection = this.buildLabeledProposalsSection(proposals);
     const critiquesSection = this.buildLabeledCritiquesSection(critiques);
+    const diffSection = buildDebateDiffSection(diffContext);
 
     return [
       framing,
@@ -252,8 +254,7 @@ ${this.stageContext.outputFormat}`;
       proposalsSection,
       critiquesSection,
       "",
-      "## Diff",
-      diff,
+      diffSection,
       voteTally,
       "",
       REVIEW_JSON_DIRECTIVE,
@@ -266,7 +267,7 @@ ${this.stageContext.outputFormat}`;
   buildReResolverPrompt(
     proposals: Array<{ debater: string; output: string }>,
     critiques: string[],
-    updatedDiff: string,
+    diffContext: DiffContext,
     previousFindings: ReviewFinding[],
     resolverContext: DebateResolverContext,
   ): string {
@@ -275,6 +276,7 @@ ${this.stageContext.outputFormat}`;
       previousFindings.length > 0 ? previousFindings.map((f) => `- ${f.ruleId}: ${f.message}`).join("\n") : "(none)";
     const proposalsSection = this.buildLabeledProposalsSection(proposals);
     const critiquesSection = this.buildLabeledCritiquesSection(critiques);
+    const diffSection = buildDebateDiffSection(diffContext);
 
     return [
       `${framing} This is a re-review after implementer changes.`,
@@ -286,8 +288,7 @@ ${this.stageContext.outputFormat}`;
       proposalsSection,
       critiquesSection,
       "",
-      "## Updated Diff",
-      updatedDiff,
+      diffSection,
       "",
       RE_REVIEW_JSON_DIRECTIVE,
       "deltaSummary should describe which previous findings are resolved vs still present.",
@@ -330,4 +331,36 @@ ${this.stageContext.outputFormat}`;
     if (critiques.length === 0) return "";
     return `\n\n## Critiques\n${critiques.map((c, i) => `### Critique ${i + 1}\n${c}`).join("\n\n")}`;
   }
+}
+
+// ─── Private helpers ─────────────────────────────────────────────────────────���
+
+/**
+ * Build the diff section for debate resolver prompts.
+ * embedded mode: emits the diff block (same as original behaviour).
+ * ref mode: emits stat summary + git ref + self-serve commands.
+ */
+function buildDebateDiffSection(ctx: DiffContext): string {
+  if (ctx.storyGitRef) {
+    // ref mode: reviewer self-serves the full diff via tools
+    const stat = ctx.stat ?? "(no stat available)";
+    const ref = ctx.storyGitRef;
+    return [
+      "## Changed Files",
+      "```",
+      stat,
+      "```",
+      "",
+      `## Git Baseline: \`${ref}\``,
+      "",
+      "To inspect the implementation:",
+      `- Full diff: \`git diff --unified=3 ${ref}..HEAD\``,
+      `- Production diff: \`git diff --unified=3 ${ref}..HEAD -- . ':!test/' ':!tests/' ':!*.test.ts' ':!*.spec.ts' ':!.nax/' ':!.nax-pids'\``,
+      `- Commit history: \`git log --oneline ${ref}..HEAD\``,
+      "",
+      "Use these commands to inspect the code. Do NOT rely solely on the file list above.",
+    ].join("\n");
+  }
+  // embedded mode: emit the diff block
+  return ["## Diff", ctx.diff ?? ""].join("\n");
 }

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -51,22 +51,60 @@ const SEMANTIC_OUTPUT_SCHEMA = `Respond with JSON only — no explanation text b
 
 If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.`;
 
+// ─── Options ──────────────────────────────────────────────────────────────────
+
+/** Prior failure entry for attempt context */
+export interface PriorFailure {
+  stage: string;
+  modelTier: string;
+}
+
+/** Options for buildSemanticReviewPrompt */
+export interface SemanticReviewPromptOptions {
+  /** Diff mode: embedded includes diff in prompt, ref includes git ref + stat */
+  mode: "embedded" | "ref";
+  /** Pre-collected diff (used when mode = "embedded") */
+  diff?: string;
+  /** Git baseline ref (used when mode = "ref") */
+  storyGitRef?: string;
+  /** Git diff --stat output (used when mode = "ref") */
+  stat?: string;
+  /** Prior failure context for attempt awareness */
+  priorFailures?: PriorFailure[];
+  /** Exclude patterns for the self-serve diff command (mode = "ref") */
+  excludePatterns?: string[];
+}
+
 // ─── Class ────────────────────────────────────────────────────────────────────
 
 export class ReviewPromptBuilder {
   /**
    * Build the LLM prompt for a one-shot semantic review.
    *
-   * Produces output byte-identical to the old inline `buildPrompt()` in
-   * src/review/semantic.ts. The `_stat` parameter that existed there was
-   * never used (diff already incorporates the stat preamble via truncateDiff).
+   * Supports two modes:
+   * - "embedded": diff is embedded in the prompt (truncated at DIFF_CAP_BYTES in semantic.ts)
+   * - "ref": stat summary + storyGitRef + self-serve diff commands; reviewer fetches full diff via tools
+   *
+   * Both modes include an attempt context section when priorFailures is non-empty.
    */
-  buildSemanticReviewPrompt(story: SemanticStory, semanticConfig: SemanticReviewConfig, diff: string): string {
+  buildSemanticReviewPrompt(
+    story: SemanticStory,
+    semanticConfig: SemanticReviewConfig,
+    options: SemanticReviewPromptOptions,
+  ): string {
     const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
     const customRulesBlock =
       semanticConfig.rules.length > 0
         ? `\n## Additional Review Rules\n${semanticConfig.rules.map((r, i) => `${i + 1}. ${r}`).join("\n")}\n`
         : "";
+    const attemptContextBlock = buildAttemptContextBlock(options.priorFailures);
+
+    let diffSection: string;
+    if (options.mode === "ref") {
+      diffSection = buildRefDiffSection(options.storyGitRef ?? "", options.stat ?? "", options.excludePatterns ?? []);
+    } else {
+      diffSection = buildEmbeddedDiffSection(options.diff ?? "");
+    }
 
     const core = `${SEMANTIC_ROLE}
 
@@ -77,15 +115,69 @@ ${story.description}
 
 ### Acceptance Criteria
 ${acList}
-${customRulesBlock}
-## Git Diff (production code only — test files excluded)
-
-\`\`\`diff
-${diff}\`\`\`
-
+${customRulesBlock}${attemptContextBlock}${diffSection}
 ${SEMANTIC_INSTRUCTIONS}
 ${SEMANTIC_OUTPUT_SCHEMA}`;
 
     return wrapJsonPrompt(core);
   }
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Build the attempt context section.
+ * Emitted only when priorFailures is non-empty.
+ */
+function buildAttemptContextBlock(priorFailures?: PriorFailure[]): string {
+  if (!priorFailures || priorFailures.length === 0) return "";
+
+  const attemptNumber = priorFailures.length + 1;
+  const stages = priorFailures.map((f) => f.stage).join(", ");
+
+  return `## Attempt Context
+This is escalation attempt ${attemptNumber}. Prior attempts failed at stages: ${stages}.
+The diff shows the NET result of all changes since story start — verify against the current codebase state.
+
+`;
+}
+
+/**
+ * Build the diff section for "embedded" mode.
+ */
+function buildEmbeddedDiffSection(diff: string): string {
+  return `## Git Diff (production code only — test files excluded)
+
+\`\`\`diff
+${diff}\`\`\`
+
+`;
+}
+
+/**
+ * Build the diff section for "ref" mode.
+ * Includes stat summary, git baseline ref, and pre-built self-serve commands.
+ */
+function buildRefDiffSection(storyGitRef: string, stat: string, excludePatterns: string[]): string {
+  const merged = [...new Set([...excludePatterns, ":!.nax/", ":!.nax-pids"])];
+  const excludeArgs = merged.map((p) => `'${p}'`).join(" ");
+  const productionDiffCmd = `git diff --unified=3 ${storyGitRef}..HEAD -- . ${excludeArgs}`;
+  const fullDiffCmd = `git diff --unified=3 ${storyGitRef}..HEAD`;
+  const logCmd = `git log --oneline ${storyGitRef}..HEAD`;
+
+  return `## Changed Files
+\`\`\`
+${stat}
+\`\`\`
+
+## Git Baseline: \`${storyGitRef}\`
+
+To inspect the implementation:
+- Full production diff: \`${productionDiffCmd}\`
+- Full diff (including tests): \`${fullDiffCmd}\`
+- Commit history: \`${logCmd}\`
+
+Use these commands to inspect the code. Do NOT rely solely on the file list above — read the actual diff and files to verify each AC.
+
+`;
 }

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -15,7 +15,7 @@ import type { ReviewFinding } from "../plugins/types";
 import { DebatePromptBuilder } from "../prompts";
 import { parseLLMJson, tryParseLLMJson } from "../utils/llm-json";
 import type { SemanticStory } from "./semantic";
-import type { SemanticReviewConfig } from "./types";
+import type { DiffContext, SemanticReviewConfig } from "./types";
 
 export type { SemanticVerdict };
 export type { DebateResolverContext } from "../debate/types";
@@ -79,7 +79,7 @@ export interface ReviewerSession {
   resolveDebate(
     proposals: Array<{ debater: string; output: string }>,
     critiques: string[],
-    diff: string,
+    diffContext: DiffContext,
     story: SemanticStory,
     semanticConfig: SemanticReviewConfig,
     resolverContext: DebateResolverContext,
@@ -91,7 +91,7 @@ export interface ReviewerSession {
   reReviewDebate(
     proposals: Array<{ debater: string; output: string }>,
     critiques: string[],
-    updatedDiff: string,
+    diffContext: DiffContext,
     resolverContext: DebateResolverContext,
   ): Promise<ReviewDialogueResult>;
   /**
@@ -394,7 +394,14 @@ export function createReviewerSession(
 
       const effectiveSemanticConfig =
         lastSemanticConfig ??
-        ({ modelTier: "balanced", rules: [], timeoutMs: 60_000, excludePatterns: [] } as SemanticReviewConfig);
+        ({
+          modelTier: "balanced",
+          diffMode: "embedded",
+          resetRefOnRerun: false,
+          rules: [],
+          timeoutMs: 60_000,
+          excludePatterns: [],
+        } as SemanticReviewConfig);
       const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(effectiveSemanticConfig);
       const { effectivePrompt, acpSessionName } = buildEffectiveRunArgs(question);
 
@@ -421,7 +428,7 @@ export function createReviewerSession(
     async resolveDebate(
       proposals: Array<{ debater: string; output: string }>,
       critiques: string[],
-      diff: string,
+      diffContext: DiffContext,
       story: SemanticStory,
       semanticConfig: SemanticReviewConfig,
       resolverContext: DebateResolverContext,
@@ -434,7 +441,7 @@ export function createReviewerSession(
         );
       }
 
-      const prompt = promptBuilder.buildResolverPrompt(proposals, critiques, diff, story, resolverContext);
+      const prompt = promptBuilder.buildResolverPrompt(proposals, critiques, diffContext, story, resolverContext);
       const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(semanticConfig);
       const { effectivePrompt, acpSessionName } = buildEffectiveRunArgs(prompt);
 
@@ -467,7 +474,7 @@ export function createReviewerSession(
     async reReviewDebate(
       proposals: Array<{ debater: string; output: string }>,
       critiques: string[],
-      updatedDiff: string,
+      diffContext: DiffContext,
       resolverContext: DebateResolverContext,
     ): Promise<ReviewDialogueResult> {
       if (!active) {
@@ -489,7 +496,7 @@ export function createReviewerSession(
       const prompt = promptBuilder.buildReResolverPrompt(
         proposals,
         critiques,
-        updatedDiff,
+        diffContext,
         previousFindings,
         resolverContext,
       );

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -88,6 +88,7 @@ export class ReviewOrchestrator {
     retrySkipChecks?: Set<string>,
     featureName?: string,
     resolverSession?: import("./dialogue").ReviewerSession,
+    priorFailures?: Array<{ stage: string; modelTier: string }>,
   ): Promise<OrchestratorReviewResult> {
     const logger = getSafeLogger();
 
@@ -104,6 +105,7 @@ export class ReviewOrchestrator {
       retrySkipChecks,
       featureName,
       resolverSession,
+      priorFailures,
     );
 
     if (!builtIn.success) {
@@ -218,6 +220,7 @@ export class ReviewOrchestrator {
       retrySkipChecks,
       ctx.prd.feature,
       resolverSession,
+      ctx.story.priorFailures,
     );
   }
 }

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -204,6 +204,7 @@ export async function runReview(
   retrySkipChecks?: Set<string>,
   featureName?: string,
   resolverSession?: import("./dialogue").ReviewerSession,
+  priorFailures?: Array<{ stage: string; modelTier: string }>,
 ): Promise<ReviewResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -268,6 +269,8 @@ export async function runReview(
       };
       const semanticCfg = config.semantic ?? {
         modelTier: "balanced" as const,
+        diffMode: "embedded" as const,
+        resetRefOnRerun: false,
         rules: [] as string[],
         timeoutMs: 600_000,
         excludePatterns: [
@@ -291,6 +294,7 @@ export async function runReview(
         naxConfig,
         featureName,
         resolverSession,
+        priorFailures,
       );
       checks.push(result);
       if (!result.success && !firstFailure) {

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -290,6 +290,7 @@ export async function runSemanticReview(
   const agent = modelResolver(semanticConfig.modelTier);
   if (!agent) {
     logger?.warn("semantic", "No agent available for semantic review — skipping", {
+      storyId: story.id,
       modelTier: semanticConfig.modelTier,
     });
     return {
@@ -329,6 +330,7 @@ export async function runSemanticReview(
       reviewerSession: resolverSession,
       resolverContextInput: resolverSession
         ? {
+            diffMode,
             ...(diffMode === "ref" ? { storyGitRef: effectiveRef, stat } : { diff }),
             story: { id: story.id, title: story.title, acceptanceCriteria: story.acceptanceCriteria },
             semanticConfig,
@@ -487,6 +489,7 @@ export async function runSemanticReview(
       timeoutSeconds: semanticConfig.timeoutMs ? Math.ceil(semanticConfig.timeoutMs / 1000) : 3600,
       modelTier: semanticConfig.modelTier,
       modelDef: resolvedModelDef,
+      pipelineStage: "review",
       config: naxConfig ?? DEFAULT_CONFIG,
       featureName,
       storyId: story.id,
@@ -494,7 +497,7 @@ export async function runSemanticReview(
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;
   } catch (err) {
-    logger?.warn("semantic", "LLM call failed — fail-open", { cause: String(err) });
+    logger?.warn("semantic", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
     return {
       check: "semantic",
       success: true,
@@ -514,6 +517,7 @@ export async function runSemanticReview(
     const looksLikeFail = /"passed"\s*:\s*false/.test(rawResponse);
     if (looksLikeFail) {
       logger?.warn("semantic", "LLM returned truncated JSON with passed:false — treating as failure", {
+        storyId: story.id,
         rawResponse: rawResponse.slice(0, 200),
       });
       return {
@@ -528,7 +532,7 @@ export async function runSemanticReview(
       };
     }
 
-    logger?.warn("semantic", "LLM returned invalid JSON — fail-open", { rawResponse: rawResponse.slice(0, 200) });
+    logger?.warn("semantic", "LLM returned invalid JSON — fail-open", { storyId: story.id, rawResponse: rawResponse.slice(0, 200) });
     return {
       check: "semantic",
       success: true,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -203,6 +203,7 @@ export async function runSemanticReview(
   naxConfig?: NaxConfig,
   featureName?: string,
   resolverSession?: import("./dialogue").ReviewerSession,
+  priorFailures?: Array<{ stage: string; modelTier: string }>,
 ): Promise<ReviewCheckResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -244,32 +245,45 @@ export async function runSemanticReview(
     };
   }
 
+  const diffMode = semanticConfig.diffMode ?? "embedded";
   logger?.info("review", "Running semantic check", {
     storyId: story.id,
     modelTier: semanticConfig.modelTier,
+    diffMode,
     configProvided: !!naxConfig,
   });
 
-  // Collect production-only diff (test files excluded at git level via configurable patterns)
-  // Collect stat summary (all files including tests) unconditionally so the LLM can verify
-  // test-related ACs even though test file content is excluded from the diff.
-  const [rawDiff, stat] = await Promise.all([
-    collectDiff(workdir, effectiveRef, semanticConfig.excludePatterns),
-    collectDiffStat(workdir, effectiveRef),
-  ]);
+  // Collect stat summary (used by both modes).
+  // In embedded mode: also collect full diff, truncate if needed.
+  // In ref mode: pass stat + ref to reviewer; reviewer self-serves the full diff via tools.
+  const stat = await collectDiffStat(workdir, effectiveRef);
 
-  // Truncate diff if over cap — stat summary is always included for context
-  const diff = truncateDiff(rawDiff, rawDiff.length > DIFF_CAP_BYTES ? stat : undefined);
-
-  if (!diff) {
-    return {
-      check: "semantic",
-      success: true,
-      command: "",
-      exitCode: 0,
-      output: "skipped: no production code changes",
-      durationMs: Date.now() - startTime,
-    };
+  let diff: string | undefined;
+  if (diffMode === "embedded") {
+    const rawDiff = await collectDiff(workdir, effectiveRef, semanticConfig.excludePatterns);
+    diff = truncateDiff(rawDiff, rawDiff.length > DIFF_CAP_BYTES ? stat : undefined);
+    if (!diff) {
+      return {
+        check: "semantic",
+        success: true,
+        command: "",
+        exitCode: 0,
+        output: "skipped: no production code changes",
+        durationMs: Date.now() - startTime,
+      };
+    }
+  } else {
+    // ref mode: if stat is empty there are no changes at all
+    if (!stat) {
+      return {
+        check: "semantic",
+        success: true,
+        command: "",
+        exitCode: 0,
+        output: "skipped: no changes detected",
+        durationMs: Date.now() - startTime,
+      };
+    }
   }
 
   // Resolve agent
@@ -288,8 +302,15 @@ export async function runSemanticReview(
     };
   }
 
-  // Build prompt — stat is already incorporated into diff via truncateDiff() when needed.
-  const prompt = new ReviewPromptBuilder().buildSemanticReviewPrompt(story, semanticConfig, diff);
+  // Build prompt — mode determines whether diff is embedded or reviewer self-serves via tools.
+  const prompt = new ReviewPromptBuilder().buildSemanticReviewPrompt(story, semanticConfig, {
+    mode: diffMode,
+    diff,
+    storyGitRef: effectiveRef,
+    stat,
+    priorFailures,
+    excludePatterns: semanticConfig.excludePatterns,
+  });
 
   // Debate path: when debate is enabled for review stage, use DebateSession instead of agent.complete()
   const reviewDebateEnabled = naxConfig?.debate?.enabled && naxConfig?.debate?.stages?.review?.enabled;
@@ -308,7 +329,7 @@ export async function runSemanticReview(
       reviewerSession: resolverSession,
       resolverContextInput: resolverSession
         ? {
-            diff,
+            ...(diffMode === "ref" ? { storyGitRef: effectiveRef, stat } : { diff }),
             story: { id: story.id, title: story.title, acceptanceCriteria: story.acceptanceCriteria },
             semanticConfig,
             resolverType: reviewStageConfig.resolver.type,
@@ -458,46 +479,20 @@ export async function runSemanticReview(
   let rawResponse: string;
   let llmCost = 0;
   try {
-    let runErr: unknown;
-    let runSucceeded = false;
-    let runOutput = "";
-    try {
-      const runResult = await agent.run({
-        prompt,
-        workdir,
-        acpSessionName: implementerSessionName,
-        keepSessionOpen: false,
-        timeoutSeconds: semanticConfig.timeoutMs ? Math.ceil(semanticConfig.timeoutMs / 1000) : 3600,
-        modelTier: semanticConfig.modelTier,
-        modelDef: resolvedModelDef,
-        config: naxConfig ?? DEFAULT_CONFIG,
-        featureName,
-        storyId: story.id,
-      });
-      runOutput = runResult.output;
-      llmCost = runResult.estimatedCost ?? 0;
-      runSucceeded = true;
-    } catch (err) {
-      runErr = err;
-    }
-
-    if (runSucceeded) {
-      rawResponse = runOutput;
-    } else {
-      // Fallback to complete() when run() is unavailable (e.g. CLI adapter without run() support)
-      const completeResult = await agent.complete(prompt, {
-        sessionName: buildSessionName(workdir, featureName, story.id, "semantic"),
-        workdir,
-        timeoutMs: semanticConfig.timeoutMs,
-        modelTier: semanticConfig.modelTier,
-        config: naxConfig ?? DEFAULT_CONFIG,
-        featureName,
-        storyId: story.id,
-      });
-      rawResponse = typeof completeResult === "string" ? completeResult : completeResult.output;
-      llmCost = typeof completeResult === "string" ? 0 : (completeResult.costUsd ?? 0);
-      void runErr;
-    }
+    const runResult = await agent.run({
+      prompt,
+      workdir,
+      acpSessionName: implementerSessionName,
+      keepSessionOpen: false,
+      timeoutSeconds: semanticConfig.timeoutMs ? Math.ceil(semanticConfig.timeoutMs / 1000) : 3600,
+      modelTier: semanticConfig.modelTier,
+      modelDef: resolvedModelDef,
+      config: naxConfig ?? DEFAULT_CONFIG,
+      featureName,
+      storyId: story.id,
+    });
+    rawResponse = runResult.output;
+    llmCost = runResult.estimatedCost ?? 0;
   } catch (err) {
     logger?.warn("semantic", "LLM call failed — fail-open", { cause: String(err) });
     return {

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -532,7 +532,10 @@ export async function runSemanticReview(
       };
     }
 
-    logger?.warn("semantic", "LLM returned invalid JSON — fail-open", { storyId: story.id, rawResponse: rawResponse.slice(0, 200) });
+    logger?.warn("semantic", "LLM returned invalid JSON — fail-open", {
+      storyId: story.id,
+      rawResponse: rawResponse.slice(0, 200),
+    });
     return {
       check: "semantic",
       success: true,

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -7,6 +7,19 @@
 /** Review check name */
 export type ReviewCheckName = "typecheck" | "lint" | "test" | "build" | "semantic";
 
+/**
+ * Diff context passed to debate resolver and prompt builders.
+ * Exactly one of diff (embedded mode) or storyGitRef+stat (ref mode) is present.
+ */
+export interface DiffContext {
+  /** Pre-collected diff (embedded mode) */
+  diff?: string;
+  /** Git baseline ref (ref mode) */
+  storyGitRef?: string;
+  /** Git diff --stat summary (ref mode) */
+  stat?: string;
+}
+
 /** Story fields required for semantic review */
 export interface SemanticStory {
   id: string;
@@ -19,6 +32,18 @@ export interface SemanticStory {
 export interface SemanticReviewConfig {
   /** Model tier for semantic review (default: 'balanced') */
   modelTier: import("../config/schema-types").ModelTier;
+  /**
+   * How the semantic reviewer accesses the git diff.
+   * "embedded" (default): pre-collected diff truncated at 50KB and embedded in prompt.
+   * "ref": only stat summary + storyGitRef passed; reviewer fetches full diff via tools.
+   */
+  diffMode: "embedded" | "ref";
+  /**
+   * When true, clears storyGitRef on failed stories during re-run initialization so
+   * the ref is re-captured at the next story start. Prevents cross-story diff pollution
+   * when multiple stories exhaust all tiers and are re-run. Default false.
+   */
+  resetRefOnRerun: boolean;
   /** Custom semantic review rules */
   rules: string[];
   /** Timeout in milliseconds for the LLM call (default: 600_000) */

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -9,16 +9,12 @@ export type ReviewCheckName = "typecheck" | "lint" | "test" | "build" | "semanti
 
 /**
  * Diff context passed to debate resolver and prompt builders.
- * Exactly one of diff (embedded mode) or storyGitRef+stat (ref mode) is present.
+ * Discriminated on `mode` — prevents ambiguous routing when both
+ * `diff` and `storyGitRef` might be present in a ResolverContext spread.
  */
-export interface DiffContext {
-  /** Pre-collected diff (embedded mode) */
-  diff?: string;
-  /** Git baseline ref (ref mode) */
-  storyGitRef?: string;
-  /** Git diff --stat summary (ref mode) */
-  stat?: string;
-}
+export type DiffContext =
+  | { mode: "embedded"; diff: string; storyGitRef?: never; stat?: never }
+  | { mode: "ref"; storyGitRef: string; stat?: string; diff?: never };
 
 /** Story fields required for semantic review */
 export interface SemanticStory {

--- a/test/unit/config/semantic-review.test.ts
+++ b/test/unit/config/semantic-review.test.ts
@@ -50,6 +50,8 @@ describe("SemanticReviewConfig", () => {
   test("SemanticReviewConfig has modelTier field of type ModelTier", () => {
     const config: SemanticReviewConfig = {
       modelTier: "balanced",
+      diffMode: "embedded",
+      resetRefOnRerun: false,
       rules: [],
       timeoutMs: 600_000,
       excludePatterns: [],
@@ -61,6 +63,8 @@ describe("SemanticReviewConfig", () => {
   test("SemanticReviewConfig has rules field of type string[]", () => {
     const config: SemanticReviewConfig = {
       modelTier: "balanced",
+      diffMode: "embedded",
+      resetRefOnRerun: false,
       rules: ["rule1", "rule2"],
       timeoutMs: 600_000,
       excludePatterns: [],
@@ -79,6 +83,8 @@ describe("SemanticReviewConfig", () => {
     tiers.forEach((tier) => {
       const config: SemanticReviewConfig = {
         modelTier: tier,
+        diffMode: "embedded",
+        resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
         excludePatterns: [],
@@ -105,6 +111,8 @@ describe("ReviewConfig semantic field", () => {
     if (result.success) {
       expect(result.data.review.semantic).toEqual({
         modelTier: "balanced",
+        diffMode: "embedded",
+        resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
         excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/", ":!.nax/", ":!.nax-pids"],
@@ -219,6 +227,8 @@ describe("DEFAULT_CONFIG.review.semantic", () => {
   test("DEFAULT_CONFIG.review.semantic has correct defaults", () => {
     expect(DEFAULT_CONFIG.review.semantic).toEqual({
       modelTier: "balanced",
+      diffMode: "embedded",
+      resetRefOnRerun: false,
       rules: [],
       timeoutMs: 600_000,
       excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/", ":!.nax/", ":!.nax-pids"],

--- a/test/unit/debate/prompt-builder.test.ts
+++ b/test/unit/debate/prompt-builder.test.ts
@@ -419,7 +419,7 @@ describe("buildResolverPrompt()", () => {
   test("includes labeled debater proposals", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("claude");
     expect(prompt).toContain("opencode");
     expect(prompt).toContain(LABELED_PROPOSALS[0].output);
@@ -429,42 +429,42 @@ describe("buildResolverPrompt()", () => {
   test("includes critiques when present", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain(CRITIQUES_STRINGS[0]);
   });
 
   test("omits critiques section when empty", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).not.toContain("Critiques");
   });
 
   test("includes diff", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain(DIFF);
   });
 
   test("includes acceptance criteria", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("AC-1: resolveDebate() works");
   });
 
   test("synthesis type: instructs to synthesize", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt.toLowerCase()).toContain("synthes");
   });
 
   test("custom type: instructs judge framing", () => {
     const ctx: DebateResolverContext = { resolverType: "custom" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt.toLowerCase()).toContain("judge");
   });
 
@@ -474,7 +474,7 @@ describe("buildResolverPrompt()", () => {
       majorityVote: { passed: false, passCount: 1, failCount: 1 },
     };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("1 passed");
     expect(prompt).toContain("1 failed");
   });
@@ -485,14 +485,14 @@ describe("buildResolverPrompt()", () => {
       majorityVote: { passed: true, passCount: 2, failCount: 0 },
     };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("2 passed");
   });
 
   test("asks for JSON response with passed + findings", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("passed");
     expect(prompt).toContain("findings");
   });
@@ -500,7 +500,7 @@ describe("buildResolverPrompt()", () => {
   test("instructs tool verification", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt.toLowerCase()).toMatch(/verif|tool/);
   });
 });
@@ -511,14 +511,14 @@ describe("buildReResolverPrompt()", () => {
   test("includes re-review framing", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, [FINDING], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [FINDING], ctx);
     expect(prompt.toLowerCase()).toMatch(/re-review|follow-up|previous finding/);
   });
 
   test("includes previous findings", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, [FINDING], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [FINDING], ctx);
     expect(prompt).toContain("missing-ac");
     expect(prompt).toContain("AC-1 not satisfied");
   });
@@ -526,14 +526,14 @@ describe("buildReResolverPrompt()", () => {
   test("shows (none) when no previous findings", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, [], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [], ctx);
     expect(prompt).toContain("(none)");
   });
 
   test("includes labeled debater proposals", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, [FINDING], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [FINDING], ctx);
     expect(prompt).toContain("claude");
     expect(prompt).toContain("opencode");
   });
@@ -541,14 +541,14 @@ describe("buildReResolverPrompt()", () => {
   test("includes updated diff", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, [FINDING], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [FINDING], ctx);
     expect(prompt).toContain(DIFF);
   });
 
   test("asks for deltaSummary in JSON", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, DIFF, [FINDING], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [FINDING], ctx);
     expect(prompt).toContain("deltaSummary");
   });
 });
@@ -595,7 +595,7 @@ describe("finding schema — issue 8: explicit fields", () => {
 
   test("buildResolverPrompt includes ruleId, severity, message in schema", () => {
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], { diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("ruleId");
     expect(prompt).toContain("severity");
     expect(prompt).toContain("message");
@@ -614,7 +614,7 @@ describe("buildResolverPrompt() — issue 9: consistent JSON fencing", () => {
   test("each debater proposal is wrapped in ```json fencing", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], DIFF, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], { diff: DIFF }, REVIEW_STORY, ctx);
     const fenceCount = (prompt.match(/```json/g) ?? []).length;
     expect(fenceCount).toBe(LABELED_PROPOSALS.length);
   });

--- a/test/unit/debate/prompt-builder.test.ts
+++ b/test/unit/debate/prompt-builder.test.ts
@@ -419,7 +419,7 @@ describe("buildResolverPrompt()", () => {
   test("includes labeled debater proposals", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("claude");
     expect(prompt).toContain("opencode");
     expect(prompt).toContain(LABELED_PROPOSALS[0].output);
@@ -429,42 +429,42 @@ describe("buildResolverPrompt()", () => {
   test("includes critiques when present", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain(CRITIQUES_STRINGS[0]);
   });
 
   test("omits critiques section when empty", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).not.toContain("Critiques");
   });
 
   test("includes diff", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain(DIFF);
   });
 
   test("includes acceptance criteria", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("AC-1: resolveDebate() works");
   });
 
   test("synthesis type: instructs to synthesize", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt.toLowerCase()).toContain("synthes");
   });
 
   test("custom type: instructs judge framing", () => {
     const ctx: DebateResolverContext = { resolverType: "custom" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt.toLowerCase()).toContain("judge");
   });
 
@@ -474,7 +474,7 @@ describe("buildResolverPrompt()", () => {
       majorityVote: { passed: false, passCount: 1, failCount: 1 },
     };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("1 passed");
     expect(prompt).toContain("1 failed");
   });
@@ -485,14 +485,14 @@ describe("buildResolverPrompt()", () => {
       majorityVote: { passed: true, passCount: 2, failCount: 0 },
     };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("2 passed");
   });
 
   test("asks for JSON response with passed + findings", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("passed");
     expect(prompt).toContain("findings");
   });
@@ -500,7 +500,7 @@ describe("buildResolverPrompt()", () => {
   test("instructs tool verification", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt.toLowerCase()).toMatch(/verif|tool/);
   });
 });
@@ -511,14 +511,14 @@ describe("buildReResolverPrompt()", () => {
   test("includes re-review framing", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [FINDING], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, [FINDING], ctx);
     expect(prompt.toLowerCase()).toMatch(/re-review|follow-up|previous finding/);
   });
 
   test("includes previous findings", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [FINDING], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, [FINDING], ctx);
     expect(prompt).toContain("missing-ac");
     expect(prompt).toContain("AC-1 not satisfied");
   });
@@ -526,14 +526,14 @@ describe("buildReResolverPrompt()", () => {
   test("shows (none) when no previous findings", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, [], ctx);
     expect(prompt).toContain("(none)");
   });
 
   test("includes labeled debater proposals", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [FINDING], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, [FINDING], ctx);
     expect(prompt).toContain("claude");
     expect(prompt).toContain("opencode");
   });
@@ -541,14 +541,14 @@ describe("buildReResolverPrompt()", () => {
   test("includes updated diff", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [FINDING], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, [FINDING], ctx);
     expect(prompt).toContain(DIFF);
   });
 
   test("asks for deltaSummary in JSON", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { diff: DIFF }, [FINDING], ctx);
+    const prompt = builder.buildReResolverPrompt(LABELED_PROPOSALS, CRITIQUES_STRINGS, { mode: "embedded" as const, diff: DIFF }, [FINDING], ctx);
     expect(prompt).toContain("deltaSummary");
   });
 });
@@ -595,7 +595,7 @@ describe("finding schema — issue 8: explicit fields", () => {
 
   test("buildResolverPrompt includes ruleId, severity, message in schema", () => {
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     expect(prompt).toContain("ruleId");
     expect(prompt).toContain("severity");
     expect(prompt).toContain("message");
@@ -614,7 +614,7 @@ describe("buildResolverPrompt() — issue 9: consistent JSON fencing", () => {
   test("each debater proposal is wrapped in ```json fencing", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();
-    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], { diff: DIFF }, REVIEW_STORY, ctx);
+    const prompt = builder.buildResolverPrompt(LABELED_PROPOSALS, [], { mode: "embedded" as const, diff: DIFF }, REVIEW_STORY, ctx);
     const fenceCount = (prompt.match(/```json/g) ?? []).length;
     expect(fenceCount).toBe(LABELED_PROPOSALS.length);
   });

--- a/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
@@ -13,12 +13,12 @@ Implement LLM-based semantic review for story diffs.
 ### Acceptance Criteria
 1. LLM is called with story diff
 2. Findings are returned as structured JSON
-
 ## Git Diff (production code only — test files excluded)
 
 \`\`\`diff
 diff --git a/src/review/semantic.ts b/src/review/semantic.ts
 +export async function runSemanticReview() {}\`\`\`
+
 
 ## Instructions
 
@@ -73,12 +73,12 @@ Implement LLM-based semantic review for story diffs.
 ## Additional Review Rules
 1. Do not flag style issues
 2. Verify AC 1 using GREP before flagging
-
 ## Git Diff (production code only — test files excluded)
 
 \`\`\`diff
 diff --git a/src/review/semantic.ts b/src/review/semantic.ts
 +export async function runSemanticReview() {}\`\`\`
+
 
 ## Instructions
 

--- a/test/unit/prompts/review-builder.test.ts
+++ b/test/unit/prompts/review-builder.test.ts
@@ -24,6 +24,8 @@ const STORY: SemanticStory = {
 
 const CONFIG_NO_RULES: SemanticReviewConfig = {
   modelTier: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
   rules: [],
   timeoutMs: 60_000,
   excludePatterns: [],
@@ -44,29 +46,29 @@ describe("ReviewPromptBuilder.buildSemanticReviewPrompt()", () => {
 
   describe("snapshot stability", () => {
     test("no custom rules — output is stable", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toMatchSnapshot();
     });
 
     test("with custom rules — output is stable", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_WITH_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_WITH_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toMatchSnapshot();
     });
   });
 
   describe("story block", () => {
     test("includes story title", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toContain(`## Story: ${STORY.title}`);
     });
 
     test("includes story description", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toContain(STORY.description);
     });
 
     test("numbers acceptance criteria", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toContain("1. LLM is called with story diff");
       expect(result).toContain("2. Findings are returned as structured JSON");
     });
@@ -74,12 +76,12 @@ describe("ReviewPromptBuilder.buildSemanticReviewPrompt()", () => {
 
   describe("custom rules", () => {
     test("omitted when rules array is empty", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       expect(result).not.toContain("## Additional Review Rules");
     });
 
     test("included and numbered when rules are present", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_WITH_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_WITH_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toContain("## Additional Review Rules");
       expect(result).toContain("1. Do not flag style issues");
       expect(result).toContain("2. Verify AC 1 using GREP before flagging");
@@ -88,14 +90,14 @@ describe("ReviewPromptBuilder.buildSemanticReviewPrompt()", () => {
 
   describe("diff block", () => {
     test("diff is included verbatim in a fenced code block", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toContain("```diff\n" + DIFF);
     });
   });
 
   describe("JSON wrapping", () => {
     test("applies wrapJsonPrompt framing", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       // wrapJsonPrompt prepends and appends sentinel strings
       expect(result).toContain("IMPORTANT: Your entire response must be a single JSON object or array");
       expect(result).toContain("YOUR RESPONSE MUST START WITH { OR [");
@@ -104,7 +106,7 @@ describe("ReviewPromptBuilder.buildSemanticReviewPrompt()", () => {
 
   describe("role declaration", () => {
     test("includes semantic reviewer role", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toContain("You are a semantic code reviewer");
       expect(result).toContain("NOT a linter or style checker");
     });
@@ -112,12 +114,12 @@ describe("ReviewPromptBuilder.buildSemanticReviewPrompt()", () => {
 
   describe("instructions block", () => {
     test("includes tool-verification requirement", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toContain("you MUST verify it using your tools");
     });
 
     test("instructs not to flag style issues", () => {
-      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, DIFF);
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toContain("Do NOT flag: style issues");
     });
   });

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -486,6 +486,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
       undefined,
       undefined,
       undefined,
+      undefined,
     );
   });
 
@@ -504,7 +505,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
 
     const configWithSemantic: ReviewConfig = {
       ...semanticConfig,
-      semantic: { modelTier: "powerful", rules: ["no stubs"], timeoutMs: 600_000, excludePatterns: [":!test/"] },
+      semantic: { modelTier: "powerful", rules: ["no stubs"], timeoutMs: 600_000, excludePatterns: [":!test/"], diffMode: "embedded" as const, resetRefOnRerun: false },
     };
 
     await runReview(configWithSemantic, "/tmp/fake-workdir");
@@ -513,8 +514,9 @@ describe("runReview — semantic check integration (AC-9)", () => {
       "/tmp/fake-workdir",
       undefined,
       expect.any(Object),
-      { modelTier: "powerful", rules: ["no stubs"], timeoutMs: 600_000, excludePatterns: [":!test/"] },
+      { modelTier: "powerful", rules: ["no stubs"], timeoutMs: 600_000, excludePatterns: [":!test/"], diffMode: "embedded", resetRefOnRerun: false },
       expect.any(Function),
+      undefined,
       undefined,
       undefined,
       undefined,

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -31,6 +31,8 @@ const STORY: SemanticStory = {
 
 const SEMANTIC_CONFIG: SemanticReviewConfig = {
   modelTier: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
   rules: [],
   timeoutMs: 30000,
   excludePatterns: [":!test/", ":!*.test.ts"],
@@ -203,7 +205,7 @@ function makeMockAgent(response: string): AgentAdapter {
     binary: "mock",
     capabilities: {} as AgentAdapter["capabilities"],
     isInstalled: mock(async () => true),
-    run: mock(async () => { throw new Error("not used"); }),
+    run: mock(async () => ({ output: response, estimatedCost: 0 })),
     buildCommand: mock(() => []),
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
@@ -297,15 +299,14 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     expect(agentCompleteMock).not.toHaveBeenCalled();
   });
 
-  test("AC3: agent.complete() called once when debate is disabled", async () => {
+  test("AC3: agent.run() called once when debate is disabled", async () => {
     const createDebateMock = mock(() => ({
       run: mock(async () => DEBATE_MAJORITY_PASS_RESULT),
     }));
     _semanticDeps.createDebateSession = createDebateMock;
 
-    const agentCompleteMock = mock(async () => PROPOSAL_PASS);
     const mockAgent = makeMockAgent(PROPOSAL_PASS);
-    (mockAgent.complete as ReturnType<typeof mock>) = agentCompleteMock;
+    const agentRunMock = mockAgent.run as ReturnType<typeof mock>;
 
     await runSemanticReview(
       WORKDIR,
@@ -316,7 +317,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       { debate: { enabled: false, agents: 0, stages: {} as never } } as NaxConfig,
     );
 
-    expect(agentCompleteMock).toHaveBeenCalledTimes(1);
+    expect(agentRunMock).toHaveBeenCalledTimes(1);
     expect(createDebateMock).not.toHaveBeenCalled();
   });
 

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -27,7 +27,14 @@ const STORY: SemanticStory = {
   acceptanceCriteria: ["ctx.reviewFindings is populated when semantic fails"],
 };
 
-const CFG: SemanticReviewConfig = { modelTier: "balanced", rules: [], excludePatterns: [":!test/"] };
+const CFG: SemanticReviewConfig = {
+  modelTier: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
+  rules: [],
+  excludePatterns: [":!test/"],
+  timeoutMs: 60_000,
+};
 
 function makeMockAgent(response: string): AgentAdapter {
   return {
@@ -36,7 +43,7 @@ function makeMockAgent(response: string): AgentAdapter {
     binary: "mock",
     capabilities: { supportedTiers: [], supportedTestStrategies: [], features: {} } as unknown as AgentAdapter["capabilities"],
     isInstalled: mock(async () => true),
-    run: mock(async () => { throw new Error("not used"); }),
+    run: mock(async () => ({ output: response, estimatedCost: 0 })),
     buildCommand: mock(() => []),
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),

--- a/test/unit/review/semantic-parsing.test.ts
+++ b/test/unit/review/semantic-parsing.test.ts
@@ -27,6 +27,8 @@ const STORY: SemanticStory = {
 
 const CONFIG: SemanticReviewConfig = {
   modelTier: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
   rules: [],
   excludePatterns: [],
   timeoutMs: 60_000,
@@ -39,7 +41,7 @@ function makeMockAgent(response: string): AgentAdapter {
     binary: "mock",
     capabilities: { supportedTiers: [], supportedTestStrategies: [], features: {} } as unknown as AgentAdapter["capabilities"],
     isInstalled: mock(async () => true),
-    run: mock(async () => { throw new Error("not used"); }),
+    run: mock(async () => ({ output: response, estimatedCost: 0 })),
     buildCommand: mock(() => []),
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),

--- a/test/unit/review/semantic-unverifiable.test.ts
+++ b/test/unit/review/semantic-unverifiable.test.ts
@@ -30,6 +30,8 @@ const STORY: SemanticStory = {
 
 const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
   modelTier: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
   rules: [],
   excludePatterns: [":!test/", ":!tests/"],
   timeoutMs: 600_000,
@@ -42,7 +44,7 @@ function makeMockAgent(response: string): AgentAdapter {
     binary: "mock",
     capabilities: { supportedTiers: [], supportedTestStrategies: [], features: {} } as unknown as AgentAdapter["capabilities"],
     isInstalled: mock(async () => true),
-    run: mock(async () => { throw new Error("not used"); }),
+    run: mock(async () => ({ output: response, estimatedCost: 0 })),
     buildCommand: mock(() => []),
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
@@ -189,13 +191,11 @@ describe("unverifiable finding handling", () => {
 describe("semantic prompt includes tool-access instructions", () => {
   test("prompt instructs agent to verify with tools before flagging", async () => {
     let capturedPrompt = "";
-    const agent = {
-      ...makeMockAgent(JSON.stringify({ passed: true, findings: [] })),
-      complete: mock(async (prompt: string) => {
-        capturedPrompt = prompt;
-        return JSON.stringify({ passed: true, findings: [] });
-      }),
-    } as unknown as AgentAdapter;
+    const agent = makeMockAgent(JSON.stringify({ passed: true, findings: [] }));
+    (agent.run as ReturnType<typeof mock>).mockImplementation(async (args: { prompt: string }) => {
+      capturedPrompt = args.prompt;
+      return { output: JSON.stringify({ passed: true, findings: [] }), estimatedCost: 0 };
+    });
 
     await runSemanticReview(
       "/tmp/repo",

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -34,11 +34,14 @@ const STORY: SemanticStory = {
 
 const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
   modelTier: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
   rules: [],
+  timeoutMs: 60_000,
   excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/", ":!.nax/", ":!.nax-pids"],
 };
 
-/** Build a mock AgentAdapter whose complete() resolves to the supplied JSON string */
+/** Build a mock AgentAdapter whose run() resolves to the supplied JSON string */
 function makeMockAgent(response: string): AgentAdapter {
   return {
     name: "mock",
@@ -46,7 +49,7 @@ function makeMockAgent(response: string): AgentAdapter {
     binary: "mock",
     capabilities: { supportedTiers: [], supportedTestStrategies: [], features: {} } as unknown as AgentAdapter["capabilities"],
     isInstalled: mock(async () => true),
-    run: mock(async () => { throw new Error("not used"); }),
+    run: mock(async () => ({ output: response, estimatedCost: 0 })),
     buildCommand: mock(() => []),
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
@@ -220,8 +223,12 @@ describe("runSemanticReview — git diff invocation", () => {
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
     expect(spawnMock).toHaveBeenCalled();
-    const call = (spawnMock as ReturnType<typeof mock>).mock.calls[0];
-    const spawnOpts = call[0] as { cmd: string[] };
+    // Find the unified diff call (stat call is first, unified diff call follows)
+    const allCalls = (spawnMock as ReturnType<typeof mock>).mock.calls;
+    const unifiedCallOpts = allCalls.map((c) => c[0] as { cmd: string[] })
+      .find((opts) => opts.cmd?.includes("--unified=3"));
+    expect(unifiedCallOpts).toBeDefined();
+    const spawnOpts = unifiedCallOpts!;
     expect(spawnOpts.cmd).toContain("git");
     expect(spawnOpts.cmd).toContain("diff");
     expect(spawnOpts.cmd).toContain("--unified=3");
@@ -297,9 +304,9 @@ describe("runSemanticReview — diff truncation", () => {
     _semanticDeps.spawn = makeSpawnMock(smallDiff, 0);
     let capturedPrompt = "";
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
-    (agent.complete as ReturnType<typeof mock>).mockImplementation(async (prompt: string) => {
-      capturedPrompt = prompt;
-      return PASSING_LLM_RESPONSE;
+    (agent.run as ReturnType<typeof mock>).mockImplementation(async (args: { prompt: string }) => {
+      capturedPrompt = args.prompt;
+      return { output: PASSING_LLM_RESPONSE, estimatedCost: 0 };
     });
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -313,9 +320,9 @@ describe("runSemanticReview — diff truncation", () => {
     _semanticDeps.spawn = makeSpawnMockWithStat(largeDiff, statOutput, 0);
     let capturedPrompt = "";
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
-    (agent.complete as ReturnType<typeof mock>).mockImplementation(async (prompt: string) => {
-      capturedPrompt = prompt;
-      return PASSING_LLM_RESPONSE;
+    (agent.run as ReturnType<typeof mock>).mockImplementation(async (args: { prompt: string }) => {
+      capturedPrompt = args.prompt;
+      return { output: PASSING_LLM_RESPONSE, estimatedCost: 0 };
     });
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -332,9 +339,9 @@ describe("runSemanticReview — diff truncation", () => {
     _semanticDeps.spawn = makeSpawnMockWithStat(largeDiff, statOutput, 0);
     let capturedPrompt = "";
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
-    (agent.complete as ReturnType<typeof mock>).mockImplementation(async (prompt: string) => {
-      capturedPrompt = prompt;
-      return PASSING_LLM_RESPONSE;
+    (agent.run as ReturnType<typeof mock>).mockImplementation(async (args: { prompt: string }) => {
+      capturedPrompt = args.prompt;
+      return { output: PASSING_LLM_RESPONSE, estimatedCost: 0 };
     });
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -377,9 +384,9 @@ describe("runSemanticReview — LLM prompt construction", () => {
     _semanticDeps.spawn = makeSpawnMock(diff, 0);
     let capturedPrompt = "";
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
-    (agent.complete as ReturnType<typeof mock>).mockImplementation(async (prompt: string) => {
-      capturedPrompt = prompt;
-      return PASSING_LLM_RESPONSE;
+    (agent.run as ReturnType<typeof mock>).mockImplementation(async (args: { prompt: string }) => {
+      capturedPrompt = args.prompt;
+      return { output: PASSING_LLM_RESPONSE, estimatedCost: 0 };
     });
     await runSemanticReview("/tmp/wd", "abc123", story, config, () => agent);
     return capturedPrompt;
@@ -414,6 +421,9 @@ describe("runSemanticReview — LLM prompt construction", () => {
   test("prompt includes custom rules from semanticConfig.rules", async () => {
     const config: SemanticReviewConfig = {
       modelTier: "balanced",
+      diffMode: "embedded",
+      resetRefOnRerun: false,
+      timeoutMs: 60_000,
       rules: ["Never use console.log", "All exports must be typed"],
       excludePatterns: [":!test/"],
     };


### PR DESCRIPTION
## What

Implements REVIEW-002: adds a `diffMode` config option (`"embedded"` | `"ref"`) and `resetRefOnRerun` boolean to semantic review. Resolves the 50KB diff truncation problem for large stories and enables tool-verified reviews for agentic reviewers.

## Why

Embedded diff mode hard-caps at 50KB, silently truncating large stories. Agentic reviewers (Claude Code, Gemini) can read files natively — handing them a static diff snapshot wastes that capability.

Closes #387

## How

**5 user stories across 12 source files:**

- **US-001** — `diffMode` and `resetRefOnRerun` added to `SemanticReviewConfigSchema` (Zod defaults: `"embedded"` / `false`), `SemanticReviewConfig` type, `DiffContext` interface in `review/types.ts`, and config description strings.

- **US-002** — `ReviewPromptBuilder.buildSemanticReviewPrompt()` now takes a `SemanticReviewPromptOptions` object instead of a bare `diff` string. Branches on `mode`:
  - `embedded`: embeds the diff in a fenced code block (existing behaviour)
  - `ref`: emits a `--stat` summary + `## Git Baseline: \`{ref}\`` + self-serve git commands
  - Adds an attempt-context block when `priorFailures` is non-empty (escalation history for the reviewer)

- **US-003** — `semantic.ts` branches on `diffMode` (only collects full diff in embedded mode), removes the deprecated `agent.complete()` fallback entirely (ACP/`agent.run()` is the only path), and threads `priorFailures` as a 9th parameter from orchestrator → runner → semantic → prompt builder.

- **US-004** — Debate `resolverContextInput` passes `{ storyGitRef, stat }` in ref mode and `{ diff }` in embedded mode. `DebatePromptBuilder.buildResolverPrompt` / `buildReResolverPrompt` accept `DiffContext` instead of `string`. `buildDebateDiffSection()` helper handles mode dispatch.

- **US-005** — `resetFailedStoriesToPending(prd, resetRef?)` clears `story.storyGitRef` when `resetRef=true`, wired from `run-initialization.ts` via `config.review.semantic.resetRefOnRerun`.

## Testing

- [x] Tests added/updated (9 test files updated)
- [x] `bun test` passes — 5281 pass, 0 fail
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

`diffMode: "ref"` requires the reviewer agent to have live tool access to the repository (shell / file read). If it doesn't, the review degrades gracefully — the `--stat` summary is still present so the reviewer knows which files changed. No breaking change: `diffMode` defaults to `"embedded"`, preserving existing behaviour for all current users.