### PR TITLE
fix(execution): EXEC-002 post-merge review fixes

### DIFF
--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -112,11 +112,14 @@ export async function runIteration(
       )
     : ctx.config;
 
-  // EXEC-002: In worktree mode, effectiveWorkdir is the worktree path.
-  // In shared mode (or when story.workdir is set), resolve relative to project root.
+  // EXEC-002: In worktree mode, effectiveWorkdir is the worktree root.
+  // Monorepo subpackages (story.workdir) are resolved relative to the worktree root so
+  // the agent operates in the correct package directory within the isolated worktree.
   const resolvedWorkdir =
     ctx.config.execution.storyIsolation === "worktree"
-      ? effectiveWorkdir
+      ? story.workdir
+        ? join(effectiveWorkdir, story.workdir)
+        : effectiveWorkdir
       : story.workdir
         ? join(ctx.workdir, story.workdir)
         : ctx.workdir;

--- a/src/execution/lifecycle/paused-story-prompts.ts
+++ b/src/execution/lifecycle/paused-story-prompts.ts
@@ -69,7 +69,7 @@ export async function promptForPausedStories(
     // Apply fallback so timeout → "approve" instead of "skip" (#356).
     // Without this, a timed-out prompt hits case "skip" and permanently skips the story.
     const effectiveAction = chain.applyFallback(response, "continue");
-    const resolvedKey = effectiveAction === "approve" ? "keep" : (response.action as string);
+    const resolvedKey = effectiveAction === "approve" ? "keep" : (effectiveAction as string);
 
     switch (resolvedKey) {
       case "resume": {

--- a/src/execution/lifecycle/run-initialization.ts
+++ b/src/execution/lifecycle/run-initialization.ts
@@ -208,10 +208,24 @@ export async function initializeRun(ctx: InitializationContext): Promise<Initial
             stdout: "pipe",
             stderr: "pipe",
           });
-          await proc.exited;
-          logger?.info("worktree", "Cleaned up old branch for re-run", { storyId: story.id });
+          const exitCode = await proc.exited;
+          if (exitCode === 0) {
+            logger?.info("worktree", "Cleaned up old branch for re-run", { storyId: story.id });
+          } else {
+            const stderr = await new Response(proc.stderr).text();
+            if (!stderr.includes("not found")) {
+              // Unexpected failure — warn but continue. If branch still exists, worktreeManager.create()
+              // will crash on the next run with "branch already exists".
+              logger?.warn("worktree", "Failed to clean up old branch for re-run (non-fatal)", {
+                storyId: story.id,
+                branch: `nax/${story.id}`,
+                stderr: stderr.trim(),
+              });
+            }
+            // "not found" → branch never existed (story failed before worktree creation) — silently skip
+          }
         } catch {
-          // Branch may not exist (e.g. story failed before worktree was created) — non-fatal
+          // Spawn failure — non-fatal, log nothing (branch may not exist)
         }
       }
     }


### PR DESCRIPTION
## Summary

Three correctness issues found during code review of #390 (EXEC-002 sequential worktree isolation), addressed here as a follow-up.

- **`iteration-runner.ts`** — `resolvedWorkdir` in worktree mode ignored `story.workdir` for monorepo subpackages. Now correctly resolves as `join(effectiveWorkdir, story.workdir)` so agents operate in the right package directory within the isolated worktree.

- **`run-initialization.ts`** — `git branch -D` exit code was discarded; on failure the code logged a success message. Now checks exit code: `0` → log info; non-zero + `"not found"` in stderr → silently skip (branch never existed); non-zero + other stderr → warn with message so the stale branch is visible before the next `worktreeManager.create()` would crash.

- **`paused-story-prompts.ts`** — `resolvedKey` used raw `response.action` instead of `effectiveAction` (the fallback-normalized value). A timed-out prompt could retain a stale `response.action` of `"skip"` and permanently skip the story. Fixed to use `effectiveAction`.

## Test plan

- [ ] `bun test test/unit/execution/lifecycle/paused-story-prompts.test.ts` — 5 tests pass (includes timeout/fallback behaviour)
- [ ] `bun test test/unit/execution/lifecycle/run-initialization.test.ts` — passes
- [ ] `bun test test/unit/execution/iteration-runner-worktree.test.ts` — passes
- [ ] `bun run typecheck` — no errors