### PR TITLE
feat(review): adversarial code review (REVIEW-003)

### DIFF
--- a/.claude/rules/adapter-wiring.md
+++ b/.claude/rules/adapter-wiring.md
@@ -76,6 +76,8 @@ Format: `nax-<hash8>-<feature>-<storyId>-<sessionRole>`
 | `"auto"` | `complete()` | Auto-approve interaction |
 | `"diagnose"` | `run()` | Acceptance failure diagnosis |
 | `"source-fix"` | `run()` | Acceptance source fix |
+| `"reviewer-semantic"` | `run()` | Semantic review session (targets implementer session via `acpSessionName`) |
+| `"reviewer-adversarial"` | `run()` | Adversarial review session (own fresh session, `keepSessionOpen: false`) |
 
 ## Rule 3: Agent Resolution — CRITICAL
 

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -250,7 +250,7 @@ export interface AnalyzeConfig {
 }
 
 // Re-exported from review/types.ts to maintain single source of truth
-export type { ReviewConfig } from "../review/types";
+export type { AdversarialReviewConfig, ReviewConfig } from "../review/types";
 
 /** Plan config */
 export interface PlanConfig {

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -309,9 +309,39 @@ export const ReviewDialogueConfigSchema = z.object({
   maxDialogueMessages: z.number().int().min(5).max(100).default(20),
 });
 
+/**
+ * Adversarial review config — ships off by default (opt-in via review.checks).
+ * Destructive heuristics: finds what is missing or broken, not what is present.
+ */
+export const AdversarialReviewConfigSchema = z.object({
+  modelTier: ModelTierSchema.default("balanced"),
+  /**
+   * "ref" (default): reviewer self-serves the full diff via git tools — no 50KB cap,
+   *   test files included. Instructs reviewer to run git diff commands.
+   * "embedded": pre-collected full diff (no excludePatterns) embedded in prompt.
+   */
+  diffMode: z.enum(["embedded", "ref"]).default("ref"),
+  /** Custom adversarial heuristic rules to append to the prompt. */
+  rules: z.array(z.string()).default([]),
+  /** LLM call timeout in milliseconds. Default 180s (shorter than semantic, no debate path). */
+  timeoutMs: z.number().int().positive().default(180_000),
+  /**
+   * Pathspec exclusions applied only in embedded mode.
+   * Default empty — adversarial sees test files (unlike semantic).
+   */
+  excludePatterns: z.array(z.string()).default([]),
+  /**
+   * When true, run semantic and adversarial reviewers concurrently via Promise.all.
+   * Default false (conservative rollout). Only activates when session count is within cap.
+   */
+  parallel: z.boolean().default(false),
+  /** Maximum combined reviewer sessions before falling back to sequential. Default 2. */
+  maxConcurrentSessions: z.number().int().min(1).max(4).default(2),
+});
+
 const ReviewConfigSchema = z.object({
   enabled: z.boolean(),
-  checks: z.array(z.enum(["typecheck", "lint", "test", "build", "semantic"])),
+  checks: z.array(z.enum(["typecheck", "lint", "test", "build", "semantic", "adversarial"])),
   commands: z.object({
     typecheck: z.string().optional(),
     lint: z.string().optional(),
@@ -322,6 +352,7 @@ const ReviewConfigSchema = z.object({
   }),
   pluginMode: z.enum(["per-story", "deferred"]).default("per-story"),
   semantic: SemanticReviewConfigSchema.optional(),
+  adversarial: AdversarialReviewConfigSchema.optional(),
   dialogue: ReviewDialogueConfigSchema.default({
     enabled: false,
     maxClarificationsPerAttempt: 2,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -57,6 +57,7 @@ export type {
   QualityConfig,
   RectificationConfig,
   RegressionGateConfig,
+  AdversarialReviewConfig,
   ReviewConfig,
   RoutingConfig,
   SmartTestRunnerConfig,

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -82,13 +82,24 @@ export class Logger {
    * Internal log method — writes to console (if level permits) and file (always)
    */
   private log(level: LogLevel, stage: string, message: string, data?: Record<string, unknown>, storyId?: string): void {
+    // Promote sessionRole from data to first-class LogEntry field for parallel log correlation.
+    // Callers pass sessionRole in data: { storyId, sessionRole: "reviewer-adversarial", ... }
+    let sessionRole: string | undefined;
+    let strippedData = data;
+    if (data?.sessionRole !== undefined && typeof data.sessionRole === "string") {
+      sessionRole = data.sessionRole;
+      const { sessionRole: _omit, ...rest } = data;
+      strippedData = Object.keys(rest).length > 0 ? rest : undefined;
+    }
+
     const entry: LogEntry = {
       timestamp: new Date().toISOString(),
       level,
       stage,
       message,
       ...(storyId && { storyId }),
-      ...(data && { data }),
+      ...(sessionRole && { sessionRole }),
+      ...(strippedData && { data: strippedData }),
     };
 
     // Console output (level-gated)

--- a/src/logger/types.ts
+++ b/src/logger/types.ts
@@ -15,6 +15,12 @@ export interface LogEntry {
   stage: string;
   /** Optional story identifier for context */
   storyId?: string;
+  /**
+   * Optional session role for parallel review log correlation.
+   * Set to "reviewer-semantic" or "reviewer-adversarial" on review-stage log entries
+   * so parallel sessions can be attributed in JSONL output without ambiguity.
+   */
+  sessionRole?: string;
   /** Human-readable message */
   message: string;
   /** Optional structured metadata */

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -96,6 +96,27 @@ export interface StoryMetrics {
   tokens?: TokenUsage;
   /** When ScopedStrategy.verify() falls back to full suite due to threshold (US-002) */
   scopeTestFallback?: boolean;
+  /**
+   * Per-reviewer metrics for the review stage.
+   * Populated when semantic or adversarial review runs.
+   * Both sub-buckets are optional — callers only populate the ones they ran.
+   */
+  reviewMetrics?: {
+    semantic?: {
+      cost: number;
+      wallClockMs: number;
+      findingsCount: number;
+      findingsBySeverity: Record<string, number>;
+    };
+    adversarial?: {
+      cost: number;
+      wallClockMs: number;
+      findingsCount: number;
+      findingsBySeverity: Record<string, number>;
+      /** Adversarial-only: findings broken down by heuristic category */
+      findingsByCategory: Record<string, number>;
+    };
+  };
 }
 
 /**

--- a/src/pipeline/stages/autofix-prompts.ts
+++ b/src/pipeline/stages/autofix-prompts.ts
@@ -18,6 +18,19 @@ export interface DialogueAwarePromptOptions {
   maxHistoryMessages?: number;
 }
 
+/**
+ * Reviewer contradiction escape hatch (REVIEW-003).
+ *
+ * Appended to all rectification prompts so the implementer can signal
+ * when two findings cannot both be satisfied. The autofix stage detects
+ * "UNRESOLVED: <explanation>" in the agent output and escalates instead
+ * of retrying — avoiding an infinite loop on an unresolvable conflict.
+ */
+const CONTRADICTION_ESCAPE_HATCH = `
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>`;
+
 function formatCheckErrors(checks: ReviewCheckResult[]): string {
   return checks.map((c) => `## ${c.check} errors (exit code ${c.exitCode})\n\`\`\`\n${c.output}\n\`\`\``).join("\n\n");
 }
@@ -47,7 +60,7 @@ ${errors}
 
 Do NOT change test files or test behavior.
 Do NOT add new features — only fix valid issues.
-Commit your fixes when done.${scopeConstraint}`;
+Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
 }
 
 function buildMechanicalRectificationPrompt(
@@ -67,7 +80,7 @@ ${errors}
 
 Fix ALL errors listed above. Do NOT change test files or test behavior.
 Do NOT add new features — only fix the quality check errors.
-Commit your fixes when done.${scopeConstraint}`;
+Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
 }
 
 export function buildReviewRectificationPrompt(failedChecks: ReviewCheckResult[], story: UserStory): string {
@@ -76,8 +89,9 @@ export function buildReviewRectificationPrompt(failedChecks: ReviewCheckResult[]
     ? `\n\nIMPORTANT: Only modify files within \`${story.workdir}/\`. Do NOT touch files outside this directory.`
     : "";
 
-  const semanticChecks = failedChecks.filter((c) => c.check === "semantic");
-  const mechanicalChecks = failedChecks.filter((c) => c.check !== "semantic");
+  // Both semantic and adversarial failures need AC-aware rectification — not the mechanical prompt.
+  const semanticChecks = failedChecks.filter((c) => c.check === "semantic" || c.check === "adversarial");
+  const mechanicalChecks = failedChecks.filter((c) => c.check !== "semantic" && c.check !== "adversarial");
 
   // Pure semantic failure — use AC-focused prompt
   if (semanticChecks.length > 0 && mechanicalChecks.length === 0) {
@@ -116,7 +130,7 @@ ${semanticSection}
 
 Do NOT change test files or test behavior.
 Do NOT add new features — only fix the identified issues.
-Commit your fixes when done.${scopeConstraint}`;
+Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
 }
 
 export function buildDialogueAwareRectificationPrompt(
@@ -162,5 +176,5 @@ ${errors}${reasoningSection}${historySection}
 
 Do NOT change test files or test behavior.
 Do NOT add new features — only fix valid issues.
-Commit your fixes when done.${scopeConstraint}`;
+Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
 }

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -34,6 +34,8 @@ import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 const CLARIFY_REGEX = /^CLARIFY:\s*(.+)$/ms;
+/** Matches the REVIEW-003 reviewer contradiction escape hatch emitted by the implementer. */
+const UNRESOLVED_REGEX = /^UNRESOLVED:\s*(.+)$/ms;
 
 export const autofixStage: PipelineStage = {
   name: "autofix",
@@ -138,12 +140,21 @@ export const autofixStage: PipelineStage = {
     }
 
     // Phase 2: Agent rectification — spawn agent with review error context
-    const { succeeded: agentFixed, cost: agentCost } = await _autofixDeps.runAgentRectification(
-      ctx,
-      lintFixCmd,
-      formatFixCmd,
-      ctx.workdir,
-    );
+    const {
+      succeeded: agentFixed,
+      cost: agentCost,
+      unresolvedReason,
+    } = await _autofixDeps.runAgentRectification(ctx, lintFixCmd, formatFixCmd, ctx.workdir);
+
+    // REVIEW-003: Implementer signalled an unresolvable reviewer contradiction — escalate.
+    if (unresolvedReason) {
+      logger.warn("autofix", "Escalating due to reviewer contradiction", {
+        storyId: ctx.story.id,
+        unresolvedReason,
+      });
+      return { action: "escalate", reason: `Reviewer contradiction: ${unresolvedReason}`, cost: agentCost };
+    }
+
     if (agentFixed) {
       if (ctx.reviewResult) ctx.reviewResult = { ...ctx.reviewResult, success: true };
       // #136: Skip checks that already passed — only re-run checks that originally failed.
@@ -229,7 +240,7 @@ async function runAgentRectification(
   lintFixCmd: string | undefined,
   formatFixCmd: string | undefined,
   effectiveWorkdir: string,
-): Promise<{ succeeded: boolean; cost: number }> {
+): Promise<{ succeeded: boolean; cost: number; unresolvedReason?: string }> {
   const logger = getLogger();
   const maxPerCycle = ctx.config.quality.autofix?.maxAttempts ?? 2;
   const maxTotal = ctx.config.quality.autofix?.maxTotalAttempts ?? 10;
@@ -263,6 +274,7 @@ async function runAgentRectification(
     failedChecks,
   };
   let autofixCostAccum = 0;
+  let unresolvedReason: string | undefined;
 
   const succeeded = await runSharedRectificationLoop({
     stage: "autofix",
@@ -327,6 +339,20 @@ async function runAgentRectification(
       });
 
       autofixCostAccum += result.estimatedCost ?? 0;
+
+      // REVIEW-003: Detect UNRESOLVED signal — reviewer findings contradict each other.
+      // Escalate immediately rather than retrying an unresolvable conflict.
+      if (result.output) {
+        const unresolvedMatch = UNRESOLVED_REGEX.exec(result.output);
+        if (unresolvedMatch) {
+          unresolvedReason = (unresolvedMatch[1] ?? "reviewer findings contradicted each other").trim();
+          logger.warn("autofix", "Implementer signalled reviewer contradiction — escalating", {
+            storyId: ctx.story.id,
+            unresolvedReason,
+          });
+          throw new Error("AUTOFIX_UNRESOLVED");
+        }
+      }
 
       // AC5/AC6/AC10: Detect CLARIFY blocks and relay to reviewerSession
       if (ctx.reviewerSession && result.output) {
@@ -416,10 +442,13 @@ async function runAgentRectification(
     if (error instanceof Error && error.message === "AUTOFIX_AGENT_NOT_FOUND") {
       return false;
     }
+    if (error instanceof Error && error.message === "AUTOFIX_UNRESOLVED") {
+      return false;
+    }
     throw error;
   });
 
-  return { succeeded, cost: autofixCostAccum };
+  return { succeeded, cost: autofixCostAccum, unresolvedReason };
 }
 
 /**
@@ -435,5 +464,6 @@ export const _autofixDeps = {
     lintFixCmd: string | undefined,
     formatFixCmd: string | undefined,
     effectiveWorkdir: string,
-  ) => runAgentRectification(ctx, lintFixCmd, formatFixCmd, effectiveWorkdir),
+  ): Promise<{ succeeded: boolean; cost: number; unresolvedReason?: string }> =>
+    runAgentRectification(ctx, lintFixCmd, formatFixCmd, effectiveWorkdir),
 };

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -1,0 +1,235 @@
+/**
+ * Adversarial Review Prompt Builder (REVIEW-003)
+ *
+ * Builds the LLM prompt for the adversarial reviewer.
+ * Distinct cognitive stance from semantic review:
+ *   - Semantic asks: "Does this satisfy the acceptance criteria?"
+ *   - Adversarial asks: "Where does this break? What is missing?"
+ *
+ * Reuses PriorFailure and buildAttemptContextBlock from review-builder.ts.
+ */
+
+import type { AdversarialReviewConfig } from "../../review/types";
+import type { SemanticStory } from "../../review/types";
+import { buildAttemptContextBlock } from "./review-builder";
+import type { PriorFailure } from "./review-builder";
+
+export type { PriorFailure };
+
+export interface TestInventory {
+  /** Source files added in this story that have a matching test file */
+  addedTestFiles: string[];
+  /** Source files added in this story with NO matching test file */
+  newSourceFilesWithoutTests: string[];
+}
+
+export interface AdversarialReviewPromptOptions {
+  /** Diff access mode */
+  mode: "embedded" | "ref";
+  /** Used when mode === "embedded": full diff (no excludePatterns) */
+  diff?: string;
+  /** Used when mode === "ref": git ref for self-serve diff commands */
+  storyGitRef?: string;
+  /** Diff stat summary (used in both modes when available) */
+  stat?: string;
+  /** Prior failure context for escalation attempts */
+  priorFailures?: PriorFailure[];
+  /** Used when mode === "embedded": pre-computed test file audit */
+  testInventory?: TestInventory;
+}
+
+const ADVERSARIAL_ROLE = `You are an adversarial code reviewer with full access to the repository.
+
+Your job is NOT to confirm correctness — semantic review handles that.
+Your job is to find what is WRONG, what is MISSING, and what the implementer stopped short of finishing.
+
+Be systematic and specific. Vague concerns ("this could be improved") are not useful.
+Pinpoint the exact file and line where the problem exists.`;
+
+const ADVERSARIAL_INSTRUCTIONS = `## Adversarial Review Heuristics
+
+Apply each heuristic to every changed file. Flag any instance you find:
+
+### 1. Input Handling
+What inputs will this mishandle?
+- Empty string, null, undefined, zero, negative numbers
+- Unicode characters, very large inputs, concurrent calls
+- Malformed data that passes type checks but violates invariants
+
+### 2. Error Paths
+What failure modes exist but are not exercised or surfaced?
+- catch blocks that swallow errors silently
+- Error values returned but never checked by callers
+- Async operations with no timeout or cancellation
+- Resource leaks on the unhappy path (file handles, connections)
+
+### 3. Abandonment Signals
+What did the implementer accept but not actually use?
+- Parameters prefixed with \`_\` that are never referenced in the body
+- Options passed in constructor/function that are stored but never read
+- TODOs or FIXMEs introduced or left unaddressed
+- Return values from called functions that are silently discarded
+
+### 4. Test Audit Gap
+What new exported units lack corresponding test files?
+- New \`src/foo/bar.ts\` with exports but no \`test/**/bar.test.ts\`
+- New public functions that only appear in implementation, not in tests
+- Acceptance criteria that touch a code path with no test coverage
+
+### 5. Convention Breaks
+What pattern exists elsewhere that this code does not follow?
+- Logger calls missing \`storyId\` as first key in data object
+- Injectable \`_deps\` pattern missing from a function that calls external APIs
+- Barrel exports missing from \`index.ts\` for new public symbols
+- Error not wrapped in \`NaxError\` with \`stage\` context
+
+### 6. Load-Bearing Assumptions
+What assumption is critical but unchecked?
+- "This array will always have at least one element"
+- "This environment variable will always be set"
+- "This git command will always succeed in CI"
+- Race conditions in async code that is assumed to be sequential`;
+
+const OUTPUT_SCHEMA = `## Output Format
+
+Respond with ONLY a JSON object — no preamble, no explanation outside the JSON.
+
+\`\`\`json
+{
+  "passed": true | false,
+  "findings": [
+    {
+      "severity": "error" | "warn" | "info" | "unverifiable",
+      "category": "input" | "error-path" | "abandonment" | "test-gap" | "convention" | "assumption",
+      "file": "relative/path/to/file.ts",
+      "line": 42,
+      "issue": "Precise description of the weakness",
+      "suggestion": "Concrete fix or mitigation"
+    }
+  ]
+}
+\`\`\`
+
+Severity guide:
+- \`"error"\`: confident this will cause real failure or regression
+- \`"warn"\`: fragile or incomplete but may ship without immediate breakage
+- \`"info"\`: noteworthy but not actionable as a blocker
+- \`"unverifiable"\`: suspect problem but couldn't confirm from available artifacts
+
+\`passed\` must be \`false\` if any finding has severity \`"error"\` or \`"warn"\`.
+\`passed\` may be \`true\` with findings if all findings are \`"info"\` or \`"unverifiable"\`.`;
+
+/**
+ * Build the diff section for "ref" mode.
+ * Instructs the reviewer to self-serve the full diff (including tests) via git commands.
+ */
+function buildAdversarialRefDiffSection(storyGitRef: string, stat?: string): string {
+  const statBlock = stat ? `## Changed Files Summary\n\n\`\`\`\n${stat}\n\`\`\`\n\n` : "";
+
+  return `${statBlock}## Diff Access
+
+You have access to git commands. Fetch the diff yourself — do NOT ask for it to be provided.
+
+**Baseline ref (story start):** \`${storyGitRef}\`
+
+Recommended commands:
+
+\`\`\`bash
+# Full diff including tests (adversarial review sees everything):
+git diff --unified=3 ${storyGitRef}..HEAD
+
+# Commit history for this story:
+git log --oneline ${storyGitRef}..HEAD
+
+# Files added in this story (for test audit gap):
+git diff --name-only --diff-filter=A ${storyGitRef}..HEAD
+
+# Show a specific file's full content:
+cat path/to/file.ts
+\`\`\`
+
+**Test audit workflow:**
+1. Run: \`git diff --name-only --diff-filter=A ${storyGitRef}..HEAD\`
+2. For each new \`src/**.ts\` file, check whether a matching \`test/**/**.test.ts\` was also added.
+3. If a new exported module has no test file, flag it as \`"test-gap"\`.
+
+`;
+}
+
+/**
+ * Build the diff section for "embedded" mode.
+ * Includes full diff (no excludePatterns — adversarial sees test files) + TestInventory.
+ */
+function buildAdversarialEmbeddedDiffSection(diff: string, testInventory?: TestInventory): string {
+  const inventoryBlock =
+    testInventory && testInventory.newSourceFilesWithoutTests.length > 0
+      ? `## Test Audit
+
+The following NEW source files were added but have no matching test file:
+${testInventory.newSourceFilesWithoutTests.map((f) => `  - ${f}`).join("\n")}
+
+${testInventory.addedTestFiles.length > 0 ? `Test files added:\n${testInventory.addedTestFiles.map((f) => `  - ${f}`).join("\n")}\n\n` : ""}Flag each untested source file as a test-gap finding.
+
+`
+      : "";
+
+  return `${inventoryBlock}## Git Diff (full — includes test files)
+
+\`\`\`diff
+${diff}\`\`\`
+
+`;
+}
+
+/**
+ * Build an adversarial review prompt for the given story and diff context.
+ */
+export class AdversarialReviewPromptBuilder {
+  buildAdversarialReviewPrompt(
+    story: SemanticStory,
+    config: AdversarialReviewConfig,
+    options: AdversarialReviewPromptOptions,
+  ): string {
+    const { mode, diff, storyGitRef, stat, priorFailures, testInventory } = options;
+
+    const storyBlock = `## Story Under Review
+
+**ID:** ${story.id}
+**Title:** ${story.title}
+**Description:** ${story.description || "(none)"}
+
+**Acceptance Criteria:**
+${story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n")}
+
+`;
+
+    const customRulesBlock =
+      config.rules.length > 0
+        ? `## Project-Specific Adversarial Rules\n\n${config.rules.map((r) => `- ${r}`).join("\n")}\n\n`
+        : "";
+
+    const attemptBlock = buildAttemptContextBlock(priorFailures);
+
+    let diffBlock: string;
+    if (mode === "ref" && storyGitRef) {
+      diffBlock = buildAdversarialRefDiffSection(storyGitRef, stat);
+    } else if (mode === "embedded" && diff) {
+      diffBlock = buildAdversarialEmbeddedDiffSection(diff, testInventory);
+    } else {
+      diffBlock = "## Diff\n\n(No diff available — review based on story context only)\n\n";
+    }
+
+    return [
+      ADVERSARIAL_ROLE,
+      "\n\n",
+      storyBlock,
+      ADVERSARIAL_INSTRUCTIONS,
+      "\n\n",
+      customRulesBlock,
+      OUTPUT_SCHEMA,
+      "\n\n",
+      attemptBlock,
+      diffBlock,
+    ].join("");
+  }
+}

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -129,7 +129,7 @@ ${SEMANTIC_OUTPUT_SCHEMA}`;
  * Build the attempt context section.
  * Emitted only when priorFailures is non-empty.
  */
-function buildAttemptContextBlock(priorFailures?: PriorFailure[]): string {
+export function buildAttemptContextBlock(priorFailures?: PriorFailure[]): string {
   if (!priorFailures || priorFailures.length === 0) return "";
 
   const attemptNumber = priorFailures.length + 1;

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -1,0 +1,382 @@
+/**
+ * Adversarial Review Runner (REVIEW-003)
+ *
+ * Runs an LLM-based adversarial review against the story diff.
+ * Distinct cognitive stance from semantic review:
+ *   - Semantic asks: "Does this satisfy the acceptance criteria?"
+ *   - Adversarial asks: "Where does this break? What is missing?"
+ *
+ * Key differences from semantic runner:
+ *   - No debate path — adversarial review is always one-shot.
+ *   - Own ACP session (reviewer-adversarial), NOT the implementer session.
+ *   - Default diffMode is "ref" (no 50KB cap; reviewer self-serves via git tools).
+ *   - Findings carry a `category` field (input, error-path, abandonment, etc.).
+ */
+
+import { buildSessionName, readAcpSession } from "../agents/acp/adapter";
+import type { AgentAdapter } from "../agents/types";
+import { DEFAULT_CONFIG } from "../config";
+import type { NaxConfig } from "../config";
+import { resolveModelForAgent } from "../config/schema-types";
+import type { ModelTier } from "../config/schema-types";
+import { getSafeLogger } from "../logger";
+import type { ReviewFinding } from "../plugins/types";
+import { AdversarialReviewPromptBuilder } from "../prompts/builders/adversarial-review-builder";
+import { tryParseLLMJson } from "../utils/llm-json";
+import { collectDiff, collectDiffStat, computeTestInventory, resolveEffectiveRef } from "./diff-utils";
+import type { AdversarialReviewConfig, ReviewCheckResult, SemanticStory } from "./types";
+
+/** Function that resolves an AgentAdapter for a given model tier */
+export type ModelResolver = (tier: ModelTier) => AgentAdapter | null | undefined;
+
+/** Injectable dependencies for adversarial.ts — allows tests to mock without mock.module() */
+export const _adversarialDeps = {
+  readAcpSession,
+};
+
+interface AdversarialLLMFinding {
+  severity: string;
+  category: string;
+  file: string;
+  line: number;
+  issue: string;
+  suggestion: string;
+}
+
+interface AdversarialLLMResponse {
+  passed: boolean;
+  findings: AdversarialLLMFinding[];
+}
+
+/**
+ * Validate parsed JSON matches the expected adversarial LLM response shape.
+ */
+function validateAdversarialShape(parsed: unknown): AdversarialLLMResponse | null {
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.passed !== "boolean") return null;
+  if (!Array.isArray(obj.findings)) return null;
+  return { passed: obj.passed, findings: obj.findings as AdversarialLLMFinding[] };
+}
+
+/**
+ * Parse and validate adversarial LLM JSON response.
+ * Returns null only when all extraction tiers fail or shape validation fails.
+ */
+function parseAdversarialResponse(raw: string): AdversarialLLMResponse | null {
+  try {
+    return validateAdversarialShape(tryParseLLMJson(raw));
+  } catch {
+    return null;
+  }
+}
+
+/** Format findings into readable text output. */
+function formatFindings(findings: AdversarialLLMFinding[]): string {
+  return findings
+    .map((f) => `[${f.severity}][${f.category}] ${f.file}:${f.line} — ${f.issue}\n  Suggestion: ${f.suggestion}`)
+    .join("\n");
+}
+
+/** Normalize LLM severity values to ReviewFinding severity union. */
+function normalizeSeverity(sev: string): ReviewFinding["severity"] {
+  if (sev === "warn") return "warning";
+  if (sev === "unverifiable") return "info";
+  if (sev === "critical" || sev === "error" || sev === "warning" || sev === "info" || sev === "low") return sev;
+  return "info";
+}
+
+/**
+ * Check whether a finding severity is blocking (counts toward pass/fail).
+ * "unverifiable" and "info" are non-blocking per the adversarial output schema:
+ *   passed may be true with findings if all findings are "info" or "unverifiable".
+ */
+function isBlockingSeverity(sev: string): boolean {
+  return sev !== "unverifiable" && sev !== "info";
+}
+
+/** Convert AdversarialLLMFinding[] to ReviewFinding[] with adversarial-review metadata. */
+function toAdversarialReviewFindings(findings: AdversarialLLMFinding[]): ReviewFinding[] {
+  return findings.map((f) => ({
+    ruleId: "adversarial",
+    severity: normalizeSeverity(f.severity),
+    file: f.file,
+    line: f.line,
+    message: f.issue,
+    source: "adversarial-review",
+    category: f.category,
+  }));
+}
+
+/**
+ * Run an adversarial review using an LLM against the story diff.
+ * Ships off by default — enabled only when "adversarial" is in review.checks.
+ */
+export async function runAdversarialReview(
+  workdir: string,
+  storyGitRef: string | undefined,
+  story: SemanticStory,
+  adversarialConfig: AdversarialReviewConfig,
+  modelResolver: ModelResolver,
+  naxConfig?: NaxConfig,
+  featureName?: string,
+  priorFailures?: Array<{ stage: string; modelTier: string }>,
+): Promise<ReviewCheckResult> {
+  const startTime = Date.now();
+  const logger = getSafeLogger();
+
+  // BUG-114: Resolve effective git ref via shared fallback chain (diff-utils.ts).
+  const effectiveRef = await resolveEffectiveRef(workdir, storyGitRef, story.id);
+
+  if (!effectiveRef) {
+    return {
+      check: "adversarial",
+      success: true,
+      command: "",
+      exitCode: 0,
+      output: "skipped: no git ref",
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  const diffMode = adversarialConfig.diffMode ?? "ref";
+  logger?.info("review", "Running adversarial check", {
+    storyId: story.id,
+    modelTier: adversarialConfig.modelTier,
+    diffMode,
+  });
+
+  // Collect stat summary (used by both modes as a quick overview).
+  // In ref mode: stat + ref passed to reviewer; reviewer self-serves the full diff via git tools.
+  // In embedded mode: also collect full diff (no excludePatterns — adversarial sees test files).
+  const stat = await collectDiffStat(workdir, effectiveRef);
+
+  if (!stat) {
+    return {
+      check: "adversarial",
+      success: true,
+      command: "",
+      exitCode: 0,
+      output: "skipped: no changes detected",
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  let diff: string | undefined;
+  let testInventory: import("./diff-utils").TestInventory | undefined;
+
+  if (diffMode === "embedded") {
+    // Adversarial embedded mode: no excludePatterns — sees test files too.
+    diff = await collectDiff(workdir, effectiveRef, adversarialConfig.excludePatterns ?? []);
+    if (!diff) {
+      return {
+        check: "adversarial",
+        success: true,
+        command: "",
+        exitCode: 0,
+        output: "skipped: no code changes",
+        durationMs: Date.now() - startTime,
+      };
+    }
+    testInventory = await computeTestInventory(workdir, effectiveRef);
+  }
+
+  // Resolve agent
+  const agent = modelResolver(adversarialConfig.modelTier);
+  if (!agent) {
+    logger?.warn("adversarial", "No agent available for adversarial review — skipping", {
+      storyId: story.id,
+      modelTier: adversarialConfig.modelTier,
+    });
+    return {
+      check: "adversarial",
+      success: true,
+      command: "",
+      exitCode: 0,
+      output: "skipped: no agent available for model tier",
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  // Build prompt
+  const prompt = new AdversarialReviewPromptBuilder().buildAdversarialReviewPrompt(story, adversarialConfig, {
+    mode: diffMode,
+    diff,
+    storyGitRef: effectiveRef,
+    stat,
+    priorFailures,
+    testInventory,
+  });
+
+  // Resolve model definition
+  const defaultAgent = naxConfig?.autoMode?.defaultAgent ?? "claude";
+  let resolvedModelDef = { provider: "anthropic", model: "claude-sonnet-4-5-20250514" };
+  try {
+    if (naxConfig?.models) {
+      resolvedModelDef = resolveModelForAgent(
+        naxConfig.models,
+        defaultAgent,
+        adversarialConfig.modelTier,
+        defaultAgent,
+      );
+    }
+  } catch {
+    // Use default model if resolution fails
+  }
+
+  // Adversarial review uses its own session (NOT the implementer session).
+  const adversarialSessionName = buildSessionName(workdir, featureName, story.id, "reviewer-adversarial");
+
+  let rawResponse: string;
+  let llmCost = 0;
+  try {
+    const runResult = await agent.run({
+      prompt,
+      workdir,
+      acpSessionName: adversarialSessionName,
+      keepSessionOpen: false,
+      timeoutSeconds: adversarialConfig.timeoutMs ? Math.ceil(adversarialConfig.timeoutMs / 1000) : 180,
+      modelTier: adversarialConfig.modelTier,
+      modelDef: resolvedModelDef,
+      pipelineStage: "review",
+      config: naxConfig ?? DEFAULT_CONFIG,
+      featureName,
+      storyId: story.id,
+      sessionRole: "reviewer-adversarial",
+    });
+    rawResponse = runResult.output;
+    llmCost = runResult.estimatedCost ?? 0;
+  } catch (err) {
+    logger?.warn("adversarial", "LLM call failed — fail-open", {
+      storyId: story.id,
+      cause: String(err),
+    });
+    return {
+      check: "adversarial",
+      success: true,
+      command: "",
+      exitCode: 0,
+      output: `skipped: LLM call failed — ${String(err)}`,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  // Parse response — fail-closed when LLM clearly intended to fail,
+  // fail-open only when response is truly unparseable with no signal.
+  const parsed = parseAdversarialResponse(rawResponse);
+  if (!parsed) {
+    const looksLikeFail = /"passed"\s*:\s*false/.test(rawResponse);
+    if (looksLikeFail) {
+      logger?.warn("adversarial", "LLM returned truncated JSON with passed:false — treating as failure", {
+        storyId: story.id,
+        rawResponse: rawResponse.slice(0, 200),
+      });
+      return {
+        check: "adversarial",
+        success: false,
+        command: "",
+        exitCode: 1,
+        output:
+          "adversarial review: LLM response truncated but indicated failure (passed:false found in partial response)",
+        durationMs: Date.now() - startTime,
+        cost: llmCost,
+      };
+    }
+
+    logger?.warn("adversarial", "LLM returned invalid JSON — fail-open", {
+      storyId: story.id,
+      rawResponse: rawResponse.slice(0, 200),
+    });
+    return {
+      check: "adversarial",
+      success: true,
+      command: "",
+      exitCode: 0,
+      output: "adversarial review: could not parse LLM response (fail-open)",
+      durationMs: Date.now() - startTime,
+      cost: llmCost,
+    };
+  }
+
+  const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity));
+  const nonBlockingFindings = parsed.findings.filter((f) => !isBlockingSeverity(f.severity));
+
+  if (nonBlockingFindings.length > 0) {
+    logger?.debug(
+      "review",
+      `Adversarial review: ${nonBlockingFindings.length} non-blocking findings (unverifiable/info)`,
+      {
+        storyId: story.id,
+        findings: nonBlockingFindings.map((f) => ({
+          severity: f.severity,
+          category: f.category,
+          file: f.file,
+          issue: f.issue,
+        })),
+      },
+    );
+  }
+
+  // Findings take precedence over the passed field.
+  // The schema requires passed:false when any error/warn finding exists, but if the LLM
+  // contradicts itself (passed:true + error findings), trust the findings and fail-closed.
+  if (blockingFindings.length > 0) {
+    const durationMs = Date.now() - startTime;
+    logger?.warn("review", `Adversarial review failed: ${blockingFindings.length} findings`, {
+      storyId: story.id,
+      durationMs,
+    });
+    logger?.debug("review", "Adversarial review findings", {
+      storyId: story.id,
+      findings: blockingFindings.map((f) => ({
+        severity: f.severity,
+        category: f.category,
+        file: f.file,
+        line: f.line,
+        issue: f.issue,
+      })),
+    });
+    return {
+      check: "adversarial",
+      success: false,
+      command: "",
+      exitCode: 1,
+      output: `Adversarial review failed:\n\n${formatFindings(blockingFindings)}`,
+      durationMs,
+      findings: toAdversarialReviewFindings(blockingFindings),
+      cost: llmCost,
+    };
+  }
+
+  // If all findings are non-blocking (unverifiable/info), override to pass regardless of passed field.
+  if (!parsed.passed && blockingFindings.length === 0) {
+    const durationMs = Date.now() - startTime;
+    logger?.info("review", "Adversarial review passed (all findings non-blocking)", {
+      storyId: story.id,
+      durationMs,
+    });
+    return {
+      check: "adversarial",
+      success: true,
+      command: "",
+      exitCode: 0,
+      output: "Adversarial review passed (all findings were unverifiable or informational)",
+      durationMs,
+      cost: llmCost,
+    };
+  }
+
+  const durationMs = Date.now() - startTime;
+  if (parsed.passed) {
+    logger?.info("review", "Adversarial review passed", { storyId: story.id, durationMs });
+  }
+  return {
+    check: "adversarial",
+    success: parsed.passed,
+    command: "",
+    exitCode: parsed.passed ? 0 : 1,
+    output: parsed.passed ? "Adversarial review passed" : "Adversarial review failed (no findings)",
+    durationMs,
+    cost: llmCost,
+  };
+}

--- a/src/review/diff-utils.ts
+++ b/src/review/diff-utils.ts
@@ -1,0 +1,183 @@
+/**
+ * Shared diff utilities for review runners (semantic + adversarial).
+ *
+ * Extracted from semantic.ts to avoid duplication.
+ * BUG-114 ref fallback chain lives here as resolveEffectiveRef().
+ */
+
+import { spawn } from "bun";
+import { getSafeLogger } from "../logger";
+import { getMergeBase, isGitRefValid } from "../utils/git";
+
+/** Maximum diff size in bytes before truncation. 50KB keeps prompts within LLM context. */
+export const DIFF_CAP_BYTES = 51_200;
+
+/** nax metadata paths — always excluded from diffs (never production code). */
+export const ALWAYS_EXCLUDED = [":!.nax/", ":!.nax-pids"];
+
+/** Injectable dependencies for diff-utils — avoids mock.module() in tests. */
+export const _diffUtilsDeps = {
+  spawn: spawn as typeof spawn,
+  isGitRefValid,
+  getMergeBase,
+};
+
+export interface TestInventory {
+  addedTestFiles: string[];
+  newSourceFilesWithoutTests: string[];
+}
+
+/**
+ * Collect git diff for the story range.
+ * excludePatterns: pathspec exclusions (e.g. test files for semantic). Pass [] for adversarial (sees all).
+ * Always excludes .nax/ and .nax-pids regardless of caller config.
+ */
+export async function collectDiff(workdir: string, storyGitRef: string, excludePatterns: string[]): Promise<string> {
+  const merged = [...new Set([...excludePatterns, ...ALWAYS_EXCLUDED])];
+  const cmd = ["git", "diff", "--unified=3", `${storyGitRef}..HEAD`, "--", ".", ...merged];
+  const proc = _diffUtilsDeps.spawn({
+    cmd,
+    cwd: workdir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [exitCode, stdout] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+
+  return exitCode === 0 ? stdout : "";
+}
+
+/**
+ * Collect git diff --stat summary (all files including tests — for context).
+ * Used as a preamble when the full diff is truncated so the reviewer
+ * always knows which files changed even if content is cut off.
+ */
+export async function collectDiffStat(workdir: string, storyGitRef: string): Promise<string> {
+  const proc = _diffUtilsDeps.spawn({
+    cmd: ["git", "diff", "--stat", `${storyGitRef}..HEAD`],
+    cwd: workdir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [exitCode, stdout] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+
+  return exitCode === 0 ? stdout.trim() : "";
+}
+
+/**
+ * Truncate diff to stay within token budget.
+ * When truncated, prepends a --stat summary so the reviewer knows all changed files.
+ */
+export function truncateDiff(diff: string, stat?: string): string {
+  if (diff.length <= DIFF_CAP_BYTES) {
+    return diff;
+  }
+
+  const truncated = diff.slice(0, DIFF_CAP_BYTES);
+  const visibleFiles = (truncated.match(/^diff --git/gm) ?? []).length;
+  const totalFiles = (diff.match(/^diff --git/gm) ?? []).length;
+
+  const statPreamble = stat
+    ? `## File Summary (all changed files)\n${stat}\n\n## Diff (truncated — ${visibleFiles}/${totalFiles} files shown)\n`
+    : "";
+
+  return `${statPreamble}${truncated}\n... (truncated at ${DIFF_CAP_BYTES} bytes, showing ${visibleFiles}/${totalFiles} files)`;
+}
+
+/**
+ * BUG-114: Resolve the effective git ref for a story's diff range.
+ *
+ * Priority 1: use supplied ref if valid (persisted from story start).
+ * Priority 2: fall back to merge-base with default remote branch so
+ *   reviewers always see the full story diff even after a restart.
+ * Priority 3: return undefined — caller should skip review.
+ */
+export async function resolveEffectiveRef(
+  workdir: string,
+  storyGitRef: string | undefined,
+  storyId: string,
+): Promise<string | undefined> {
+  const logger = getSafeLogger();
+
+  if (storyGitRef && (await _diffUtilsDeps.isGitRefValid(workdir, storyGitRef))) {
+    return storyGitRef;
+  }
+
+  const fallback = await _diffUtilsDeps.getMergeBase(workdir);
+  if (fallback) {
+    logger?.info("review", "storyGitRef missing or invalid — using merge-base fallback", {
+      storyId,
+      storyGitRef,
+      fallback,
+    });
+    return fallback;
+  }
+
+  return undefined;
+}
+
+/**
+ * Classify added files in the story's diff into test files vs source files without tests.
+ * Used by adversarial review (embedded mode) to pre-compute a TestInventory for the prompt.
+ *
+ * Detection heuristics:
+ * - Test file: path matches *.test.ts, *.spec.ts, *_test.go, or is under test/ / tests/ / __tests__/
+ * - Source file without test: new source file whose basename has no matching test file in the added set
+ */
+export async function computeTestInventory(workdir: string, storyGitRef: string): Promise<TestInventory> {
+  const proc = _diffUtilsDeps.spawn({
+    cmd: ["git", "diff", "--name-only", "--diff-filter=A", `${storyGitRef}..HEAD`],
+    cwd: workdir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [exitCode, stdout] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+
+  if (exitCode !== 0) {
+    return { addedTestFiles: [], newSourceFilesWithoutTests: [] };
+  }
+
+  const addedFiles = stdout.trim().split("\n").filter(Boolean);
+
+  const TEST_PATTERNS = [
+    /\.test\.(ts|js|tsx|jsx)$/,
+    /\.spec\.(ts|js|tsx|jsx)$/,
+    /_test\.go$/,
+    /(?:^|\/)(?:test|tests|__tests__)\//,
+  ];
+
+  const isTestFile = (f: string): boolean => TEST_PATTERNS.some((p) => p.test(f));
+
+  const addedTestFiles = addedFiles.filter(isTestFile);
+  const addedSourceFiles = addedFiles.filter((f) => !isTestFile(f));
+
+  // For each added source file, check whether a matching test file was also added.
+  // Match by basename: src/foo/bar.ts → looks for bar.test.ts, bar.spec.ts in addedFiles.
+  const testFileBasenames = new Set(
+    addedTestFiles.map((f) => {
+      const base = f.split("/").at(-1) ?? f;
+      return base.replace(/\.(test|spec)\.(ts|js|tsx|jsx)$/, "").replace(/_test\.go$/, "");
+    }),
+  );
+
+  const newSourceFilesWithoutTests = addedSourceFiles.filter((f) => {
+    const base = (f.split("/").at(-1) ?? f).replace(/\.(ts|js|tsx|jsx|go)$/, "");
+    return !testFileBasenames.has(base);
+  });
+
+  return { addedTestFiles, newSourceFilesWithoutTests };
+}

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -4,5 +4,7 @@
  * Post-implementation quality verification
  */
 
+export * from "./adversarial";
+export * from "./diff-utils";
 export * from "./types";
 export * from "./runner";

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -16,9 +16,11 @@ import { getSafeLogger } from "../logger";
 import type { PipelineContext } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins";
 import { errorMessage } from "../utils/errors";
+import { runAdversarialReview } from "./adversarial";
 import { runReview } from "./runner";
 import type { SemanticStory } from "./semantic";
-import type { ReviewConfig, ReviewResult } from "./types";
+import { runSemanticReview } from "./semantic";
+import type { AdversarialReviewConfig, ReviewCheckResult, ReviewConfig, ReviewResult } from "./types";
 
 /**
  * Injectable dependencies for getChangedFiles() — allows tests to intercept
@@ -92,21 +94,138 @@ export class ReviewOrchestrator {
   ): Promise<OrchestratorReviewResult> {
     const logger = getSafeLogger();
 
-    const builtIn = await runReview(
-      reviewConfig,
-      workdir,
-      executionConfig,
-      qualityCommands,
-      storyId,
-      storyGitRef,
-      story,
-      modelResolver,
-      naxConfig,
-      retrySkipChecks,
-      featureName,
-      resolverSession,
-      priorFailures,
-    );
+    // Detect which LLM-based reviewers are active (groundwork for Phase 4 parallel dispatch).
+    const hasSemantic = reviewConfig.checks.includes("semantic");
+    const hasAdversarial = reviewConfig.checks.includes("adversarial");
+
+    if (hasSemantic || hasAdversarial) {
+      const active = [hasSemantic ? "semantic" : null, hasAdversarial ? "adversarial" : null]
+        .filter(Boolean)
+        .join(", ");
+      logger?.debug("review", `LLM reviewers active: ${active}`, { storyId });
+    }
+
+    // Phase 4: Parallel dispatch for semantic + adversarial when advConfig.parallel === true
+    // and the combined session count does not exceed maxConcurrentSessions.
+    const advConfig = reviewConfig.adversarial;
+    const canParallelize = (() => {
+      if (!hasSemantic || !hasAdversarial || !advConfig?.parallel) return false;
+      const semSessions =
+        naxConfig?.debate?.enabled && naxConfig?.debate?.stages?.review?.enabled
+          ? (naxConfig.debate.stages.review.debaters?.length ?? 2) + 1
+          : 1;
+      const advSessions = 1;
+      const cap = advConfig.maxConcurrentSessions ?? 2;
+      if (semSessions + advSessions > cap) {
+        logger?.warn("review", "Parallel mode disabled — session cap exceeded", {
+          storyId,
+          semSessions,
+          advSessions,
+          cap,
+        });
+        return false;
+      }
+      return true;
+    })();
+
+    let builtIn: ReviewResult;
+
+    if (canParallelize) {
+      // Run mechanical checks (non-LLM) first — fail-fast preserved for lint/typecheck/etc.
+      const mechanicalChecks = reviewConfig.checks.filter((c) => c !== "semantic" && c !== "adversarial");
+      const mechanicalConfig = { ...reviewConfig, checks: mechanicalChecks };
+      const mechanicalResult = await runReview(
+        mechanicalConfig,
+        workdir,
+        executionConfig,
+        qualityCommands,
+        storyId,
+        storyGitRef,
+        story,
+        modelResolver,
+        naxConfig,
+        retrySkipChecks,
+        featureName,
+        resolverSession,
+        priorFailures,
+      );
+
+      if (!mechanicalResult.success) {
+        builtIn = mechanicalResult;
+      } else {
+        // Run semantic and adversarial concurrently
+        const semanticStory: SemanticStory = {
+          id: storyId ?? "",
+          title: story?.title ?? "",
+          description: story?.description ?? "",
+          acceptanceCriteria: story?.acceptanceCriteria ?? [],
+        };
+        const semanticCfg = reviewConfig.semantic ?? {
+          modelTier: "balanced" as const,
+          diffMode: "embedded" as const,
+          resetRefOnRerun: false,
+          rules: [] as string[],
+          timeoutMs: 600_000,
+          excludePatterns: [] as string[],
+        };
+        // advConfig is guaranteed non-null here: canParallelize required advConfig?.parallel === true
+        const adversarialCfg: AdversarialReviewConfig = advConfig as AdversarialReviewConfig;
+
+        logger?.debug("review", "Running semantic + adversarial in parallel", { storyId });
+        const parallelStart = Date.now();
+
+        const [semResult, advResult] = await Promise.all([
+          runSemanticReview(
+            workdir,
+            storyGitRef,
+            semanticStory,
+            semanticCfg,
+            modelResolver ?? (() => null),
+            naxConfig,
+            featureName,
+            resolverSession,
+            priorFailures,
+          ),
+          runAdversarialReview(
+            workdir,
+            storyGitRef,
+            semanticStory,
+            adversarialCfg,
+            modelResolver ?? (() => null),
+            naxConfig,
+            featureName,
+            priorFailures,
+          ),
+        ]);
+
+        const llmChecks: ReviewCheckResult[] = [semResult, advResult];
+        const allChecks = [...mechanicalResult.checks, ...llmChecks];
+        const allPassed = allChecks.every((c) => c.success);
+        const firstLlmFailure = llmChecks.find((c) => !c.success);
+        builtIn = {
+          success: allPassed,
+          checks: allChecks,
+          totalDurationMs: mechanicalResult.totalDurationMs + (Date.now() - parallelStart),
+          failureReason: firstLlmFailure ? `${firstLlmFailure.check} failed` : undefined,
+        };
+      }
+    } else {
+      builtIn = await runReview(
+        reviewConfig,
+        workdir,
+        executionConfig,
+        qualityCommands,
+        storyId,
+        storyGitRef,
+        story,
+        modelResolver,
+        naxConfig,
+        retrySkipChecks,
+        featureName,
+        resolverSession,
+        priorFailures,
+      );
+    }
 
     if (!builtIn.success) {
       return { builtIn, success: false, failureReason: builtIn.failureReason, pluginFailed: false };

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -11,6 +11,7 @@ import type { ModelTier } from "../config/schema-types";
 import { getSafeLogger } from "../logger";
 import { runQualityCommand } from "../quality";
 import { autoCommitIfDirty } from "../utils/git";
+import { runAdversarialReview as _runAdversarialReviewImpl } from "./adversarial";
 import { resolveLanguageCommand } from "./language-commands";
 import { runSemanticReview as _runSemanticReviewImpl } from "./semantic";
 import type { SemanticStory } from "./semantic";
@@ -27,6 +28,16 @@ export { resolveLanguageCommand };
  */
 export const _reviewSemanticDeps = {
   runSemanticReview: _runSemanticReviewImpl,
+};
+
+/**
+ * Injectable dependency for the adversarial review call — allows tests to
+ * intercept runAdversarialReview() without mock.module() (BUG-035 pattern).
+ *
+ * @internal
+ */
+export const _reviewAdversarialDeps = {
+  runAdversarialReview: _runAdversarialReviewImpl,
 };
 
 /**
@@ -81,8 +92,8 @@ export async function resolveCommand(
   qualityCommands?: QualityConfig["commands"],
   profile?: { language?: string },
 ): Promise<string | null> {
-  // Semantic checks don't have CLI commands — they're handled separately by the review orchestrator
-  if (check === "semantic") {
+  // Semantic and adversarial checks are LLM-based — handled separately by the review orchestrator
+  if (check === "semantic" || check === "adversarial") {
     return null;
   }
 
@@ -294,6 +305,44 @@ export async function runReview(
         naxConfig,
         featureName,
         resolverSession,
+        priorFailures,
+      );
+      checks.push(result);
+      if (!result.success && !firstFailure) {
+        firstFailure = `${checkName} failed`;
+      }
+      if (!result.success) {
+        break;
+      }
+      continue;
+    }
+
+    // Adversarial check: delegate to LLM-based adversarial runner
+    if (checkName === "adversarial") {
+      const adversarialStory: SemanticStory = {
+        id: storyId ?? "",
+        title: story?.title ?? "",
+        description: story?.description ?? "",
+        acceptanceCriteria: story?.acceptanceCriteria ?? [],
+      };
+      const adversarialCfg = config.adversarial ?? {
+        modelTier: "balanced" as const,
+        diffMode: "ref" as const,
+        rules: [] as string[],
+        timeoutMs: 180_000,
+        excludePatterns: [] as string[],
+        parallel: false,
+        maxConcurrentSessions: 2,
+      };
+      const runAdversarial = _reviewAdversarialDeps.runAdversarialReview;
+      const result = await runAdversarial(
+        workdir,
+        storyGitRef,
+        adversarialStory,
+        adversarialCfg,
+        modelResolver ?? (() => null),
+        naxConfig,
+        featureName,
         priorFailures,
       );
       checks.push(result);

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -7,7 +7,6 @@
  * is handled by lint/typecheck, not semantic review.
  */
 
-import { spawn } from "bun";
 import { buildSessionName, readAcpSession } from "../agents/acp/adapter";
 import type { AgentAdapter } from "../agents/types";
 import { DEFAULT_CONFIG } from "../config";
@@ -19,8 +18,8 @@ import type { DebateSessionOptions } from "../debate";
 import { getSafeLogger } from "../logger";
 import type { ReviewFinding } from "../plugins/types";
 import { ReviewPromptBuilder } from "../prompts";
-import { getMergeBase, isGitRefValid } from "../utils/git";
 import { tryParseLLMJson } from "../utils/llm-json";
+import { DIFF_CAP_BYTES, collectDiff, collectDiffStat, resolveEffectiveRef, truncateDiff } from "./diff-utils";
 import type { ReviewCheckResult, SemanticReviewConfig, SemanticStory } from "./types";
 
 // Re-export so existing callers (`import type { SemanticStory } from "./semantic"`) keep working.
@@ -29,96 +28,11 @@ export type { SemanticStory };
 /** Function that resolves an AgentAdapter for a given model tier */
 export type ModelResolver = (tier: ModelTier) => AgentAdapter | null | undefined;
 
-/** Injectable dependencies for semantic.ts — allows tests to mock spawn without mock.module() */
+/** Injectable dependencies for semantic.ts — allows tests to mock without mock.module() */
 export const _semanticDeps = {
-  spawn: spawn as typeof spawn,
-  isGitRefValid,
-  getMergeBase,
   createDebateSession: (opts: DebateSessionOptions): DebateSession => new DebateSession(opts),
   readAcpSession,
 };
-
-/**
- * Maximum diff size in bytes before truncation.
- * 50KB keeps the prompt well within LLM context and reduces output truncation risk.
- * Test files are excluded from the diff, so the budget goes entirely to production code.
- */
-const DIFF_CAP_BYTES = 51_200;
-
-/** Patterns always excluded from semantic diff — nax metadata is never production code. */
-const ALWAYS_EXCLUDED = [":!.nax/", ":!.nax-pids"];
-
-/**
- * Collect git diff for the story range (production code only).
- * Excludes test files via configurable pathspec patterns — semantic review
- * validates behavior against ACs, not test style or conventions.
- * Always excludes .nax/ metadata regardless of user config.
- */
-async function collectDiff(workdir: string, storyGitRef: string, excludePatterns: string[]): Promise<string> {
-  const merged = [...new Set([...excludePatterns, ...ALWAYS_EXCLUDED])];
-  const cmd = ["git", "diff", "--unified=3", `${storyGitRef}..HEAD`, "--", ".", ...merged];
-  const proc = _semanticDeps.spawn({
-    cmd,
-    cwd: workdir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [exitCode, stdout] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-
-  if (exitCode !== 0) {
-    return "";
-  }
-
-  return stdout;
-}
-
-/**
- * Collect git diff --stat summary (all files including tests — for context).
- * Used as a preamble when the full diff is truncated so the reviewer
- * always knows which files changed even if the content is cut off.
- */
-async function collectDiffStat(workdir: string, storyGitRef: string): Promise<string> {
-  const proc = _semanticDeps.spawn({
-    cmd: ["git", "diff", "--stat", `${storyGitRef}..HEAD`],
-    cwd: workdir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [exitCode, stdout] = await Promise.all([
-    proc.exited,
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-
-  return exitCode === 0 ? stdout.trim() : "";
-}
-
-/**
- * Truncate diff to stay within token budget.
- * When truncated, prepends a --stat summary so the reviewer knows all changed files.
- */
-function truncateDiff(diff: string, stat?: string): string {
-  if (diff.length <= DIFF_CAP_BYTES) {
-    return diff;
-  }
-
-  const truncated = diff.slice(0, DIFF_CAP_BYTES);
-  // Count files visible vs total
-  const visibleFiles = (truncated.match(/^diff --git/gm) ?? []).length;
-  const totalFiles = (diff.match(/^diff --git/gm) ?? []).length;
-
-  const statPreamble = stat
-    ? `## File Summary (all changed files)\n${stat}\n\n## Diff (truncated — ${visibleFiles}/${totalFiles} files shown)\n`
-    : "";
-
-  return `${statPreamble}${truncated}\n... (truncated at ${DIFF_CAP_BYTES} bytes, showing ${visibleFiles}/${totalFiles} files)`;
-}
 
 interface LLMFinding {
   severity: string;
@@ -214,25 +128,8 @@ export async function runSemanticReview(
     });
   }
 
-  // BUG-114: Resolve effective git ref for the diff range.
-  // Priority 1: use the supplied ref if valid (persisted from story start).
-  // Priority 2: fall back to merge-base with the default remote branch so that
-  //   the semantic reviewer always sees the full story diff even after a restart.
-  // Priority 3: skip review when no ref can be resolved (non-git workdir, etc.).
-  let effectiveRef: string | undefined;
-  if (storyGitRef && (await _semanticDeps.isGitRefValid(workdir, storyGitRef))) {
-    effectiveRef = storyGitRef;
-  } else {
-    const fallback = await _semanticDeps.getMergeBase(workdir);
-    if (fallback) {
-      logger?.info("review", "storyGitRef missing or invalid — using merge-base fallback", {
-        storyId: story.id,
-        storyGitRef,
-        fallback,
-      });
-      effectiveRef = fallback;
-    }
-  }
+  // BUG-114: Resolve effective git ref via shared fallback chain (diff-utils.ts).
+  const effectiveRef = await resolveEffectiveRef(workdir, storyGitRef, story.id);
 
   if (!effectiveRef) {
     return {
@@ -493,6 +390,7 @@ export async function runSemanticReview(
       config: naxConfig ?? DEFAULT_CONFIG,
       featureName,
       storyId: story.id,
+      sessionRole: "reviewer-semantic",
     });
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -5,7 +5,7 @@
  */
 
 /** Review check name */
-export type ReviewCheckName = "typecheck" | "lint" | "test" | "build" | "semantic";
+export type ReviewCheckName = "typecheck" | "lint" | "test" | "build" | "semantic" | "adversarial";
 
 /**
  * Diff context passed to debate resolver and prompt builders.
@@ -108,6 +108,28 @@ export interface ReviewDialogueConfig {
   maxDialogueMessages: number;
 }
 
+/** Adversarial review configuration (when 'adversarial' is in checks) */
+export interface AdversarialReviewConfig {
+  /** Model tier for adversarial review (default: 'balanced') */
+  modelTier: import("../config/schema-types").ModelTier;
+  /**
+   * "ref" (default): reviewer self-serves the full diff via git tools — no 50KB cap,
+   *   test files included.
+   * "embedded": full diff (no excludePatterns) embedded in prompt.
+   */
+  diffMode: "embedded" | "ref";
+  /** Custom adversarial heuristic rules to append to the prompt */
+  rules: string[];
+  /** Timeout in milliseconds (default: 180_000) */
+  timeoutMs: number;
+  /** Pathspec exclusions for embedded mode. Default empty (adversarial sees test files). */
+  excludePatterns: string[];
+  /** When true, run semantic and adversarial concurrently. Default false. */
+  parallel: boolean;
+  /** Maximum combined reviewer sessions before falling back to sequential. Default 2. */
+  maxConcurrentSessions: number;
+}
+
 /** Review configuration */
 export interface ReviewConfig {
   /** Enable review phase */
@@ -129,6 +151,8 @@ export interface ReviewConfig {
   pluginMode?: "per-story" | "deferred";
   /** Semantic review configuration (when 'semantic' is in checks) */
   semantic?: SemanticReviewConfig;
+  /** Adversarial review configuration (when 'adversarial' is in checks) */
+  adversarial?: AdversarialReviewConfig;
   /** Reviewer-implementer dialogue configuration */
   dialogue?: ReviewDialogueConfig;
 }

--- a/test/unit/prompts/adversarial-review-builder.test.ts
+++ b/test/unit/prompts/adversarial-review-builder.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Unit tests for src/prompts/builders/adversarial-review-builder.ts
+ *
+ * Covers:
+ * - ref mode: story block, git diff command with storyGitRef, stat block
+ * - embedded mode: full diff code block, testInventory untested files, diff without inventory
+ * - custom rules: included in prompt when present
+ * - prior failures: escalation attempt context included
+ * - output schema: passed field and severity values present
+ * - role section: adversarial cognitive stance ("find what is WRONG")
+ * - no diff available: fallback message when neither diff nor storyGitRef provided
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AdversarialReviewPromptBuilder } from "../../../src/prompts/builders/adversarial-review-builder";
+import type { AdversarialReviewConfig } from "../../../src/review/types";
+import type { SemanticStory } from "../../../src/review/types";
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+const STORY: SemanticStory = {
+  id: "STORY-001",
+  title: "Add user auth",
+  description: "Implements authentication",
+  acceptanceCriteria: ["Users can log in", "Sessions expire after 24h"],
+};
+
+const CONFIG: AdversarialReviewConfig = {
+  modelTier: "balanced",
+  diffMode: "ref",
+  rules: [],
+  timeoutMs: 180_000,
+  excludePatterns: [],
+  parallel: false,
+  maxConcurrentSessions: 2,
+};
+
+const STORY_GIT_REF = "abc1234def";
+
+const DIFF = `diff --git a/src/auth/login.ts b/src/auth/login.ts
++export async function login(user: string, pass: string) {}`;
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+const builder = new AdversarialReviewPromptBuilder();
+
+// ─── ref mode ─────────────────────────────────────────────────────────────────
+
+describe("AdversarialReviewPromptBuilder — ref mode", () => {
+  test("prompt contains story title", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).toContain(STORY.title);
+  });
+
+  test("prompt contains story id", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).toContain(STORY.id);
+  });
+
+  test("prompt contains acceptance criteria", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).toContain("Users can log in");
+    expect(result).toContain("Sessions expire after 24h");
+  });
+
+  test("prompt contains the ref-based diff section with git diff command", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).toContain(`git diff --unified=3 ${STORY_GIT_REF}..HEAD`);
+  });
+
+  test("prompt contains the storyGitRef as baseline ref label", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).toContain(STORY_GIT_REF);
+  });
+
+  test("prompt contains stat block when stat is provided", () => {
+    const stat = "src/auth/login.ts | 10 ++++++++++\n 1 file changed";
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      stat,
+    });
+
+    expect(result).toContain(stat);
+    expect(result).toContain("Changed Files Summary");
+  });
+
+  test("stat block is omitted when stat is not provided", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).not.toContain("Changed Files Summary");
+  });
+});
+
+// ─── embedded mode ────────────────────────────────────────────────────────────
+
+describe("AdversarialReviewPromptBuilder — embedded mode", () => {
+  test("prompt contains the full diff in a diff code block", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "embedded",
+      diff: DIFF,
+    });
+
+    expect(result).toContain("```diff\n" + DIFF);
+  });
+
+  test("prompt includes untested source files from testInventory", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "embedded",
+      diff: DIFF,
+      testInventory: {
+        addedTestFiles: [],
+        newSourceFilesWithoutTests: ["src/auth/login.ts", "src/auth/session.ts"],
+      },
+    });
+
+    expect(result).toContain("src/auth/login.ts");
+    expect(result).toContain("src/auth/session.ts");
+    expect(result).toContain("## Test Audit");
+  });
+
+  test("prompt still contains diff when testInventory is not provided", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "embedded",
+      diff: DIFF,
+    });
+
+    expect(result).toContain(DIFF);
+  });
+
+  test("test audit block is omitted when all source files have matching tests", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "embedded",
+      diff: DIFF,
+      testInventory: {
+        addedTestFiles: ["test/unit/auth/login.test.ts"],
+        newSourceFilesWithoutTests: [],
+      },
+    });
+
+    // The dynamic "## Test Audit" section (from TestInventory) should not appear
+    // when newSourceFilesWithoutTests is empty. Note: the static heuristics block
+    // contains "Test Audit Gap" — we check for the dynamic section header specifically.
+    expect(result).not.toContain("## Test Audit");
+  });
+});
+
+// ─── custom rules ─────────────────────────────────────────────────────────────
+
+describe("AdversarialReviewPromptBuilder — custom rules", () => {
+  test("prompt contains custom rule text when rules are set in config", () => {
+    const configWithRules: AdversarialReviewConfig = {
+      ...CONFIG,
+      rules: ["Always check for missing storyId in logger calls", "Flag any direct spawn() without _deps"],
+    };
+
+    const result = builder.buildAdversarialReviewPrompt(STORY, configWithRules, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).toContain("Always check for missing storyId in logger calls");
+    expect(result).toContain("Flag any direct spawn() without _deps");
+  });
+
+  test("custom rules section is omitted when rules array is empty", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).not.toContain("Project-Specific Adversarial Rules");
+  });
+});
+
+// ─── prior failures ───────────────────────────────────────────────────────────
+
+describe("AdversarialReviewPromptBuilder — prior failures", () => {
+  test("prompt contains escalation attempt text when priorFailures are provided", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      priorFailures: [
+        {
+          attempt: 1,
+          tier: "fast",
+          findings: [{ severity: "error", description: "Missing null check" }],
+        },
+      ],
+    });
+
+    expect(result).toContain("escalation attempt");
+  });
+
+  test("no escalation block when priorFailures is empty", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      priorFailures: [],
+    });
+
+    expect(result).not.toContain("escalation attempt");
+  });
+});
+
+// ─── output schema ────────────────────────────────────────────────────────────
+
+describe("AdversarialReviewPromptBuilder — output schema", () => {
+  test('prompt contains "passed" field in output schema', () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).toContain('"passed"');
+  });
+
+  test("prompt contains severity values in output schema", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).toContain('"error"');
+    expect(result).toContain('"warn"');
+    expect(result).toContain('"info"');
+    expect(result).toContain('"unverifiable"');
+  });
+});
+
+// ─── role section ─────────────────────────────────────────────────────────────
+
+describe("AdversarialReviewPromptBuilder — role section", () => {
+  test('prompt contains adversarial role description ("find what is WRONG")', () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).toContain("find what is WRONG");
+  });
+
+  test("prompt contains adversarial reviewer identity declaration", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+
+    expect(result).toContain("adversarial code reviewer");
+  });
+});
+
+// ─── no diff available ────────────────────────────────────────────────────────
+
+describe("AdversarialReviewPromptBuilder — no diff available", () => {
+  test("fallback message appears when neither diff nor storyGitRef are provided", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "embedded",
+      // no diff, no storyGitRef
+    });
+
+    expect(result).toContain("No diff available");
+  });
+
+  test("fallback message present when mode is ref but no storyGitRef provided", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      // storyGitRef intentionally omitted
+    });
+
+    expect(result).toContain("No diff available");
+  });
+});

--- a/test/unit/review/adversarial.test.ts
+++ b/test/unit/review/adversarial.test.ts
@@ -1,0 +1,773 @@
+/**
+ * Unit tests for src/review/adversarial.ts
+ *
+ * Tests cover:
+ * - runAdversarialReview() early exits (no ref, no stat, no agent)
+ * - Passing review (LLM returns passed:true)
+ * - Failing review with blocking findings (error, warn)
+ * - Non-blocking only → override to pass
+ * - Fail-open on invalid JSON (cannot parse, no pass:false signal)
+ * - Fail-closed on truncated JSON containing "passed": false
+ * - Fail-open when LLM call throws
+ * - Category field forwarded in ReviewFinding
+ * - Embedded diffMode triggers collectDiff spawn call
+ * - Cost propagation from LLM result
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _adversarialDeps, runAdversarialReview } from "../../../src/review/adversarial";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
+import type { AdversarialReviewConfig } from "../../../src/review/types";
+import type { SemanticStory } from "../../../src/review/types";
+import type { AgentAdapter } from "../../../src/agents/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STORY: SemanticStory = {
+  id: "STORY-001",
+  title: "Add auth",
+  description: "Auth feature",
+  acceptanceCriteria: ["Users can log in"],
+};
+
+const ADVERSARIAL_CONFIG: AdversarialReviewConfig = {
+  modelTier: "balanced",
+  diffMode: "ref",
+  rules: [],
+  timeoutMs: 180_000,
+  excludePatterns: [],
+  parallel: false,
+  maxConcurrentSessions: 2,
+};
+
+const STAT_OUTPUT = "src/foo.ts | 5 +++++\n 1 file changed, 5 insertions(+)";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a mock AgentAdapter whose run() resolves to the supplied JSON string */
+function makeAgent(llmResponse: string, cost = 0.001): AgentAdapter {
+  return {
+    name: "mock",
+    displayName: "Mock Agent",
+    binary: "mock",
+    capabilities: {
+      supportedTiers: [],
+      supportedTestStrategies: [],
+      features: {},
+    } as unknown as AgentAdapter["capabilities"],
+    isInstalled: mock(async () => true),
+    run: mock(async () => ({ output: llmResponse, estimatedCost: cost })),
+    buildCommand: mock(() => []),
+    plan: mock(async () => {
+      throw new Error("not used");
+    }),
+    decompose: mock(async () => {
+      throw new Error("not used");
+    }),
+    complete: mock(async (_prompt: string) => llmResponse),
+  } as unknown as AgentAdapter;
+}
+
+/** Build a mock spawn returning given stdout with exit code 0 */
+function makeSpawnMock(stdout: string, exitCode = 0) {
+  return mock((_opts: unknown) => ({
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(stdout));
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    kill: () => {},
+  })) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+const PASSING_RESPONSE = JSON.stringify({ passed: true, findings: [] });
+
+const FAILING_ERROR_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "error",
+      category: "error-path",
+      file: "src/auth.ts",
+      line: 10,
+      issue: "No error handling on login",
+      suggestion: "Add try/catch",
+    },
+  ],
+});
+
+const FAILING_WARN_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "warn",
+      category: "abandonment",
+      file: "src/auth.ts",
+      line: 20,
+      issue: "Token never invalidated on logout",
+      suggestion: "Call revokeToken()",
+    },
+  ],
+});
+
+const UNVERIFIABLE_ONLY_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "unverifiable",
+      category: "input",
+      file: "src/auth.ts",
+      line: 5,
+      issue: "Cannot verify external service behaviour",
+      suggestion: "N/A",
+    },
+  ],
+});
+
+const INFO_ONLY_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "info",
+      category: "convention",
+      file: "src/auth.ts",
+      line: 8,
+      issue: "Could add more inline comments",
+      suggestion: "Add JSDoc",
+    },
+  ],
+});
+
+// LLM incorrectly says passed:true but includes a blocking finding (schema violation by LLM)
+const PASSED_TRUE_WITH_ERROR_RESPONSE = JSON.stringify({
+  passed: true,
+  findings: [
+    {
+      severity: "error",
+      category: "error-path",
+      file: "src/auth.ts",
+      line: 15,
+      issue: "Unhandled promise rejection",
+      suggestion: "Add .catch()",
+    },
+  ],
+});
+
+const CATEGORY_FINDING_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "error",
+      category: "test-gap",
+      file: "src/auth.ts",
+      line: 30,
+      issue: "Missing test for edge case",
+      suggestion: "Add test",
+    },
+  ],
+});
+
+// ---------------------------------------------------------------------------
+// Shared saved deps
+// ---------------------------------------------------------------------------
+
+let origSpawn: typeof _diffUtilsDeps.spawn;
+let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
+let origReadAcpSession: typeof _adversarialDeps.readAcpSession;
+
+function saveAllDeps() {
+  origSpawn = _diffUtilsDeps.spawn;
+  origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+  origGetMergeBase = _diffUtilsDeps.getMergeBase;
+  origReadAcpSession = _adversarialDeps.readAcpSession;
+}
+
+function restoreAllDeps() {
+  _diffUtilsDeps.spawn = origSpawn;
+  _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+  _diffUtilsDeps.getMergeBase = origGetMergeBase;
+  _adversarialDeps.readAcpSession = origReadAcpSession;
+}
+
+/** Wire up a happy-path spawn (valid ref, stat returns content). */
+function setupHappyPathDeps(statContent = STAT_OUTPUT) {
+  _diffUtilsDeps.isGitRefValid = mock(async () => true);
+  _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+  _diffUtilsDeps.spawn = makeSpawnMock(statContent);
+  _adversarialDeps.readAcpSession = mock(async () => null);
+}
+
+// ---------------------------------------------------------------------------
+// AC-1: Pass — LLM returns passed:true with no findings
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — pass", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("returns success=true when LLM returns passed:true", async () => {
+    const agent = makeAgent(PASSING_RESPONSE);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test("check field is 'adversarial'", async () => {
+    const agent = makeAgent(PASSING_RESPONSE);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.check).toBe("adversarial");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2: Fail with error finding
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — fail with error finding", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("returns success=false when LLM returns findings with severity 'error'", async () => {
+    const agent = makeAgent(FAILING_ERROR_RESPONSE);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(false);
+  });
+
+  test("findings array is populated on failure", async () => {
+    const agent = makeAgent(FAILING_ERROR_RESPONSE);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.findings).toBeDefined();
+    expect(result.findings!.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3: Fail with warn finding
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — fail with warn finding", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("returns success=false when LLM returns findings with severity 'warn'", async () => {
+    const agent = makeAgent(FAILING_WARN_RESPONSE);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-4: Non-blocking only (unverifiable) → override to pass
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — non-blocking only findings", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("returns success=true when all findings are unverifiable", async () => {
+    const agent = makeAgent(UNVERIFIABLE_ONLY_RESPONSE);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test("returns success=true when all findings are info severity", async () => {
+    const agent = makeAgent(INFO_ONLY_RESPONSE);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test("returns success=false when LLM says passed:true but includes error findings (findings take precedence)", async () => {
+    const agent = makeAgent(PASSED_TRUE_WITH_ERROR_RESPONSE);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    // LLM schema violation: passed:true with error findings — trust findings, fail-closed
+    expect(result.success).toBe(false);
+    expect(result.findings).toBeDefined();
+    expect(result.findings!.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-5: Skip when no git ref
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — skip on no git ref", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    // resolveEffectiveRef returns undefined when both ref and merge-base are unavailable
+    _diffUtilsDeps.isGitRefValid = mock(async () => false);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.spawn = makeSpawnMock("");
+    _adversarialDeps.readAcpSession = mock(async () => null);
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("returns success=true when resolveEffectiveRef returns undefined", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      undefined,
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => makeAgent(PASSING_RESPONSE),
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test("output contains 'skipped' when resolveEffectiveRef returns undefined", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      undefined,
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => makeAgent(PASSING_RESPONSE),
+    );
+
+    expect(result.output).toContain("skipped");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-6: Skip when stat is empty
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — skip when no stat", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+    // Stat returns empty string
+    _diffUtilsDeps.spawn = makeSpawnMock("");
+    _adversarialDeps.readAcpSession = mock(async () => null);
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("returns success=true when diff stat is empty", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => makeAgent(PASSING_RESPONSE),
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test("output contains 'skipped: no changes detected' when stat is empty", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => makeAgent(PASSING_RESPONSE),
+    );
+
+    expect(result.output).toContain("skipped: no changes detected");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-7: Fail-open on invalid JSON
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — fail-open on unparseable JSON", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("returns success=true when LLM returns garbage JSON with no passed:false signal", async () => {
+    const agent = makeAgent("this is not json at all");
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test("output contains 'fail-open' on garbage JSON", async () => {
+    const agent = makeAgent("this is not json at all");
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.output).toContain("fail-open");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-8: Fail-closed on truncated JSON containing "passed": false
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — fail-closed on truncated JSON with passed:false", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("returns success=false when raw response has passed:false but is malformed JSON", async () => {
+    // Malformed JSON that cannot be fully parsed but contains "passed": false signal
+    const truncatedResponse = '{ "passed": false, "findings": [{ "severity": "error"';
+    const agent = makeAgent(truncatedResponse);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-9: Fail-open when no agent
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — fail-open when modelResolver returns null", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("returns success=true when modelResolver returns null", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => null,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test("output contains 'skipped' when modelResolver returns null", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => null,
+    );
+
+    expect(result.output).toContain("skipped");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-10: Fail-open on LLM error
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — fail-open on LLM error", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("returns success=true when agent.run() throws", async () => {
+    const throwingAgent = {
+      ...makeAgent(PASSING_RESPONSE),
+      run: mock(async () => {
+        throw new Error("LLM connection timeout");
+      }),
+    } as unknown as AgentAdapter;
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => throwingAgent,
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test("output contains 'skipped' when agent.run() throws", async () => {
+    const throwingAgent = {
+      ...makeAgent(PASSING_RESPONSE),
+      run: mock(async () => {
+        throw new Error("LLM connection timeout");
+      }),
+    } as unknown as AgentAdapter;
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => throwingAgent,
+    );
+
+    expect(result.output).toContain("skipped");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-11: Category field in findings
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — finding category and metadata", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("finding has ruleId 'adversarial'", async () => {
+    const agent = makeAgent(CATEGORY_FINDING_RESPONSE);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.findings).toBeDefined();
+    expect(result.findings![0].ruleId).toBe("adversarial");
+  });
+
+  test("finding has source 'adversarial-review'", async () => {
+    const agent = makeAgent(CATEGORY_FINDING_RESPONSE);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.findings![0].source).toBe("adversarial-review");
+  });
+
+  test("finding carries category field from LLM response", async () => {
+    const agent = makeAgent(CATEGORY_FINDING_RESPONSE);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.findings![0].category).toBe("test-gap");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-12: Embedded diffMode triggers collectDiff spawn call
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — embedded diffMode", () => {
+  let spawnMock: ReturnType<typeof makeSpawnMock>;
+
+  beforeEach(() => {
+    saveAllDeps();
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+    // Returns stat content for both stat and diff calls
+    spawnMock = makeSpawnMock(STAT_OUTPUT);
+    _diffUtilsDeps.spawn = spawnMock;
+    _adversarialDeps.readAcpSession = mock(async () => null);
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("spawn is called when diffMode is 'embedded'", async () => {
+    const embeddedConfig: AdversarialReviewConfig = {
+      ...ADVERSARIAL_CONFIG,
+      diffMode: "embedded",
+    };
+    const agent = makeAgent(PASSING_RESPONSE);
+
+    await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      embeddedConfig,
+      () => agent,
+    );
+
+    expect(spawnMock).toHaveBeenCalled();
+  });
+
+  test("spawn is called multiple times (stat + diff) in embedded mode", async () => {
+    const embeddedConfig: AdversarialReviewConfig = {
+      ...ADVERSARIAL_CONFIG,
+      diffMode: "embedded",
+    };
+    const agent = makeAgent(PASSING_RESPONSE);
+
+    await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      embeddedConfig,
+      () => agent,
+    );
+
+    // In embedded mode: at least stat call + diff call + computeTestInventory call
+    const callCount = (spawnMock as ReturnType<typeof mock>).mock.calls.length;
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-13: Cost propagation
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — cost propagation", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("result.cost is populated from LLM estimatedCost", async () => {
+    const agent = makeAgent(PASSING_RESPONSE, 0.042);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.cost).toBe(0.042);
+  });
+
+  test("result.cost is 0 when estimatedCost is 0", async () => {
+    const agent = makeAgent(PASSING_RESPONSE, 0);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.cost).toBe(0);
+  });
+});

--- a/test/unit/review/diff-utils.test.ts
+++ b/test/unit/review/diff-utils.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Unit tests for src/review/diff-utils.ts
+ *
+ * Covers:
+ * - resolveEffectiveRef: valid ref, merge-base fallback, both-invalid undefined
+ * - collectDiff: correct spawn args, non-zero exit returns ""
+ * - collectDiffStat: --stat flag passed to spawn
+ * - truncateDiff: passthrough under cap, truncation with stat preamble
+ * - computeTestInventory: test file classification, untested source detection, non-zero exit
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  DIFF_CAP_BYTES,
+  _diffUtilsDeps,
+  collectDiff,
+  collectDiffStat,
+  computeTestInventory,
+  resolveEffectiveRef,
+  truncateDiff,
+} from "../../../src/review/diff-utils";
+
+// ─── Mock helpers ──────────────────────────────────────────────────────────────
+
+/** Build a mock spawn that returns the provided stdout with the given exit code. */
+function makeSpawnMock(stdout: string, exitCode = 0) {
+  return mock((_opts: unknown) => ({
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(stdout));
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    kill: () => {},
+  })) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+/** Build a mock spawn that captures cmd args and returns stdout. */
+function makeCapturingSpawnMock(stdout: string, capturedCmd: { value?: string[] }) {
+  return mock((opts: unknown) => {
+    capturedCmd.value = (opts as { cmd: string[] }).cmd;
+    return {
+      exited: Promise.resolve(0),
+      stdout: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(stdout));
+          controller.close();
+        },
+      }),
+      stderr: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      kill: () => {},
+    };
+  }) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+// ─── Dep originals ─────────────────────────────────────────────────────────────
+
+let origSpawn: typeof _diffUtilsDeps.spawn;
+let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
+
+beforeEach(() => {
+  origSpawn = _diffUtilsDeps.spawn;
+  origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+  origGetMergeBase = _diffUtilsDeps.getMergeBase;
+
+  // Default stubs — individual tests override as needed
+  _diffUtilsDeps.spawn = makeSpawnMock("");
+  _diffUtilsDeps.isGitRefValid = mock(async () => true);
+  _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+});
+
+afterEach(() => {
+  _diffUtilsDeps.spawn = origSpawn;
+  _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+  _diffUtilsDeps.getMergeBase = origGetMergeBase;
+});
+
+// ─── resolveEffectiveRef ───────────────────────────────────────────────────────
+
+describe("resolveEffectiveRef()", () => {
+  test("returns supplied ref when isGitRefValid returns true", async () => {
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+
+    const result = await resolveEffectiveRef("/repo", "abc123", "STORY-001");
+
+    expect(result).toBe("abc123");
+  });
+
+  test("falls back to merge-base when supplied ref is invalid", async () => {
+    _diffUtilsDeps.isGitRefValid = mock(async () => false);
+    _diffUtilsDeps.getMergeBase = mock(async () => "merge-base-sha");
+
+    const result = await resolveEffectiveRef("/repo", "bad-ref", "STORY-001");
+
+    expect(result).toBe("merge-base-sha");
+  });
+
+  test("returns undefined when ref is invalid and no merge-base exists", async () => {
+    _diffUtilsDeps.isGitRefValid = mock(async () => false);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+
+    const result = await resolveEffectiveRef("/repo", "bad-ref", "STORY-001");
+
+    expect(result).toBeUndefined();
+  });
+
+  test("returns merge-base when storyGitRef is undefined", async () => {
+    _diffUtilsDeps.getMergeBase = mock(async () => "merge-base-sha");
+
+    const result = await resolveEffectiveRef("/repo", undefined, "STORY-001");
+
+    expect(result).toBe("merge-base-sha");
+  });
+});
+
+// ─── collectDiff ──────────────────────────────────────────────────────────────
+
+describe("collectDiff()", () => {
+  test("calls spawn with correct args: ref..HEAD, excludePatterns, and always-excluded paths", async () => {
+    const captured: { value?: string[] } = {};
+    _diffUtilsDeps.spawn = makeCapturingSpawnMock("diff output", captured);
+
+    await collectDiff("/repo", "abc123", [":!test/"]);
+
+    expect(captured.value).toBeDefined();
+    expect(captured.value).toContain("git");
+    expect(captured.value).toContain("diff");
+    expect(captured.value).toContain("abc123..HEAD");
+    expect(captured.value).toContain(":!test/");
+    // Always-excluded paths
+    expect(captured.value).toContain(":!.nax/");
+    expect(captured.value).toContain(":!.nax-pids");
+  });
+
+  test("returns stdout string when exit code is 0", async () => {
+    _diffUtilsDeps.spawn = makeSpawnMock("diff content");
+
+    const result = await collectDiff("/repo", "abc123", []);
+
+    expect(result).toBe("diff content");
+  });
+
+  test("returns empty string when spawn exits with non-zero", async () => {
+    _diffUtilsDeps.spawn = makeSpawnMock("some output", 1);
+
+    const result = await collectDiff("/repo", "abc123", []);
+
+    expect(result).toBe("");
+  });
+});
+
+// ─── collectDiffStat ──────────────────────────────────────────────────────────
+
+describe("collectDiffStat()", () => {
+  test("calls spawn with --stat flag", async () => {
+    const captured: { value?: string[] } = {};
+    _diffUtilsDeps.spawn = makeCapturingSpawnMock("stat output", captured);
+
+    await collectDiffStat("/repo", "abc123");
+
+    expect(captured.value).toBeDefined();
+    expect(captured.value).toContain("--stat");
+    expect(captured.value).toContain("abc123..HEAD");
+  });
+
+  test("returns trimmed stdout on success", async () => {
+    _diffUtilsDeps.spawn = makeSpawnMock("  stat output  ");
+
+    const result = await collectDiffStat("/repo", "abc123");
+
+    expect(result).toBe("stat output");
+  });
+
+  test("returns empty string when exit code is non-zero", async () => {
+    _diffUtilsDeps.spawn = makeSpawnMock("stat output", 2);
+
+    const result = await collectDiffStat("/repo", "abc123");
+
+    expect(result).toBe("");
+  });
+});
+
+// ─── truncateDiff ─────────────────────────────────────────────────────────────
+
+describe("truncateDiff()", () => {
+  test("returns diff unchanged when under DIFF_CAP_BYTES", () => {
+    const smallDiff = "diff --git a/foo.ts b/foo.ts\n+export const x = 1;";
+
+    const result = truncateDiff(smallDiff);
+
+    expect(result).toBe(smallDiff);
+  });
+
+  test("truncates diff when over DIFF_CAP_BYTES", () => {
+    const largeDiff = "diff --git a/foo.ts b/foo.ts\n" + "x".repeat(DIFF_CAP_BYTES + 1000);
+
+    const result = truncateDiff(largeDiff);
+
+    expect(result.length).toBeLessThan(largeDiff.length);
+    expect(result).toContain("truncated");
+  });
+
+  test("includes stat preamble when stat is provided and diff is truncated", () => {
+    const largeDiff = "diff --git a/foo.ts b/foo.ts\n" + "x".repeat(DIFF_CAP_BYTES + 1000);
+    const stat = "foo.ts | 10 ++++++++++";
+
+    const result = truncateDiff(largeDiff, stat);
+
+    expect(result).toContain("File Summary");
+    expect(result).toContain(stat);
+  });
+
+  test("omits stat preamble when stat is not provided even if truncated", () => {
+    const largeDiff = "diff --git a/foo.ts b/foo.ts\n" + "x".repeat(DIFF_CAP_BYTES + 1000);
+
+    const result = truncateDiff(largeDiff);
+
+    expect(result).not.toContain("File Summary");
+  });
+});
+
+// ─── computeTestInventory ─────────────────────────────────────────────────────
+
+describe("computeTestInventory()", () => {
+  test("classifies .test.ts files as addedTestFiles", async () => {
+    _diffUtilsDeps.spawn = makeSpawnMock("src/foo/bar.ts\ntest/unit/foo/bar.test.ts\n");
+
+    const result = await computeTestInventory("/repo", "abc123");
+
+    expect(result.addedTestFiles).toContain("test/unit/foo/bar.test.ts");
+  });
+
+  test("classifies .spec.ts files as addedTestFiles", async () => {
+    _diffUtilsDeps.spawn = makeSpawnMock("src/utils.ts\nsrc/utils.spec.ts\n");
+
+    const result = await computeTestInventory("/repo", "abc123");
+
+    expect(result.addedTestFiles).toContain("src/utils.spec.ts");
+  });
+
+  test("classifies source files with no matching test as newSourceFilesWithoutTests", async () => {
+    _diffUtilsDeps.spawn = makeSpawnMock("src/foo/orphan.ts\n");
+
+    const result = await computeTestInventory("/repo", "abc123");
+
+    expect(result.newSourceFilesWithoutTests).toContain("src/foo/orphan.ts");
+  });
+
+  test("does not flag source file as untested when a matching test file was added", async () => {
+    _diffUtilsDeps.spawn = makeSpawnMock("src/foo/bar.ts\ntest/unit/foo/bar.test.ts\n");
+
+    const result = await computeTestInventory("/repo", "abc123");
+
+    expect(result.newSourceFilesWithoutTests).not.toContain("src/foo/bar.ts");
+  });
+
+  test("returns empty arrays on non-zero exit code", async () => {
+    _diffUtilsDeps.spawn = makeSpawnMock("src/foo/bar.ts\n", 1);
+
+    const result = await computeTestInventory("/repo", "abc123");
+
+    expect(result.addedTestFiles).toHaveLength(0);
+    expect(result.newSourceFilesWithoutTests).toHaveLength(0);
+  });
+});

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AgentAdapter } from "../../../src/agents/types";
 import type { NaxConfig } from "../../../src/config";
 import type { DebateResult } from "../../../src/debate/types";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
 import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
 import type { SemanticStory } from "../../../src/review/semantic";
 import type { SemanticReviewConfig } from "../../../src/review/types";
@@ -171,9 +172,9 @@ const DEBATE_DUPLICATE_FINDINGS_RESULT: DebateResult = {
 // Save originals
 // ─────────────────────────────────────────────────────────────────────────────
 
-const origSpawn = _semanticDeps.spawn;
-const origIsGitRefValid = _semanticDeps.isGitRefValid;
-const origGetMergeBase = _semanticDeps.getMergeBase;
+const origSpawn = _diffUtilsDeps.spawn;
+const origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+const origGetMergeBase = _diffUtilsDeps.getMergeBase;
 const origCreateDebateSession = _semanticDeps.createDebateSession;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -195,7 +196,7 @@ function makeSpawnMock(stdout = "", exitCode = 0) {
       },
     }),
     kill: () => {},
-  })) as unknown as typeof _semanticDeps.spawn;
+  })) as unknown as typeof _diffUtilsDeps.spawn;
 }
 
 function makeMockAgent(response: string): AgentAdapter {
@@ -222,17 +223,17 @@ describe("runSemanticReview — debate integration (US-004)", () => {
   const STORY_GIT_REF = "abc123";
 
   beforeEach(() => {
-    _semanticDeps.spawn = makeSpawnMock("diff content");
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => null);
+    _diffUtilsDeps.spawn = makeSpawnMock("diff content");
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => null);
     _semanticDeps.createDebateSession = origCreateDebateSession;
   });
 
   afterEach(() => {
     mock.restore();
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
     _semanticDeps.createDebateSession = origCreateDebateSession;
   });
 

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
 import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
 import type { SemanticStory } from "../../../src/review/semantic";
 import type { SemanticReviewConfig } from "../../../src/review/types";
@@ -59,7 +60,7 @@ function makeSpawnMock(stdout = "diff output", exitCode = 0) {
     }),
     stderr: new ReadableStream({ start(c) { c.close(); } }),
     kill: () => {},
-  })) as unknown as typeof _semanticDeps.spawn;
+  })) as unknown as typeof _diffUtilsDeps.spawn;
 }
 
 // ---------------------------------------------------------------------------
@@ -67,25 +68,25 @@ function makeSpawnMock(stdout = "diff output", exitCode = 0) {
 // ---------------------------------------------------------------------------
 
 describe("runSemanticReview — structured findings in result (US-003 AC-2)", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
   });
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
   test("result.findings is defined and non-empty when LLM returns passed=false with findings", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
@@ -101,7 +102,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("maps finding.issue to ReviewFinding.message", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
@@ -116,7 +117,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("sets source='semantic-review' on each ReviewFinding", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
@@ -134,7 +135,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("sets ruleId='semantic' on each ReviewFinding", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
@@ -149,7 +150,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("maps finding.file to ReviewFinding.file", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
@@ -164,7 +165,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("maps finding.line to ReviewFinding.line", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
@@ -179,7 +180,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("maps finding.severity 'error' directly to ReviewFinding.severity", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
@@ -194,7 +195,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("normalises severity 'warn' to 'warning' in ReviewFinding", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
@@ -209,7 +210,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("maps 'info' severity as-is to ReviewFinding.severity", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
@@ -224,7 +225,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("populates findings for all LLM findings when multiple are returned", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
@@ -244,7 +245,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("result.findings is empty or absent when LLM returns passed=true", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const agent = makeMockAgent(JSON.stringify({ passed: true, findings: [] }));
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CFG, () => agent);
@@ -253,7 +254,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("result.findings is empty or absent on fail-open (invalid JSON)", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff");
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const agent = makeMockAgent("not valid json {{");
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CFG, () => agent);
@@ -262,7 +263,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   });
 
   test("result.findings is empty or absent when storyGitRef is missing (skipped)", async () => {
-    _semanticDeps.spawn = makeSpawnMock("", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("", 0);
 
     const result = await runSemanticReview("/tmp/wd", undefined, STORY, CFG, () => null);
 

--- a/test/unit/review/semantic-parsing.test.ts
+++ b/test/unit/review/semantic-parsing.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
 import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
 import type { SemanticStory } from "../../../src/review/semantic";
 import type { SemanticReviewConfig } from "../../../src/review/types";
@@ -62,7 +63,7 @@ function makeSpawnMock(stdout: string, exitCode = 0) {
       start(controller) { controller.close(); },
     }),
     kill: () => {},
-  })) as unknown as typeof _semanticDeps.spawn;
+  })) as unknown as typeof _diffUtilsDeps.spawn;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,27 +71,27 @@ function makeSpawnMock(stdout: string, exitCode = 0) {
 // ---------------------------------------------------------------------------
 
 describe("runSemanticReview — multi-tier JSON parsing", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
   // Failure mode 2: preamble + fenced JSON (production log pattern)
   test("parses passed=true from preamble + ```json fence", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const response =
       "I'll verify each acceptance criterion by reading the actual implementation files.\n" +
       "```json\n" +
@@ -102,7 +103,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
   });
 
   test("parses passed=false with findings from preamble + fence", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const payload = {
       passed: false,
       findings: [{ severity: "error", file: "src/foo.ts", line: 10, issue: "missing impl", suggestion: "implement it" }],
@@ -115,7 +116,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
   });
 
   test("parses from preamble + plain ``` fence", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const response =
       "After reviewing the diff:\n" +
       "```\n" +
@@ -128,7 +129,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
 
   // Bare JSON embedded in narration (tier 3)
   test("parses passed=true from JSON embedded in narration", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const response =
       'After analysis: {"passed":true,"findings":[]} All ACs are correctly implemented.';
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
@@ -137,7 +138,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
   });
 
   test("parses passed=false from JSON embedded in narration", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const payload = {
       passed: false,
       findings: [{ severity: "error", file: "src/bar.ts", line: 5, issue: "stub", suggestion: "implement" }],
@@ -149,7 +150,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
 
   // Trailing commas
   test("parses JSON with trailing commas in fence", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const response = '```json\n{"passed":true,"findings":[],}\n```';
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
     expect(result.success).toBe(true);
@@ -158,7 +159,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
 
   // Failure mode 1: pure narration — must still fail-open
   test("still fails-open on pure narration with no JSON", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const response =
       "I'll verify each acceptance criterion by examining the actual files to ensure all i18n keys exist and are correctly wired.";
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
@@ -168,7 +169,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
 
   // Tier 1: clean JSON still works
   test("tier 1 still parses clean JSON directly", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const response = JSON.stringify({ passed: true, findings: [] });
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, () => makeMockAgent(response));
     expect(result.success).toBe(true);

--- a/test/unit/review/semantic-unverifiable.test.ts
+++ b/test/unit/review/semantic-unverifiable.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
 import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
 import type { SemanticStory } from "../../../src/review/semantic";
 import type { SemanticReviewConfig } from "../../../src/review/types";
@@ -65,31 +66,31 @@ function makeSpawnMock(stdout: string, exitCode = 0) {
       start(controller) { controller.close(); },
     }),
     kill: () => {},
-  })) as unknown as typeof _semanticDeps.spawn;
+  })) as unknown as typeof _diffUtilsDeps.spawn;
 }
 
 // ---------------------------------------------------------------------------
 // Setup / Teardown
 // ---------------------------------------------------------------------------
 
-let origSpawn: typeof _semanticDeps.spawn;
-let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+let origSpawn: typeof _diffUtilsDeps.spawn;
+let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
 beforeEach(() => {
-  origSpawn = _semanticDeps.spawn;
-  origIsGitRefValid = _semanticDeps.isGitRefValid;
-  origGetMergeBase = _semanticDeps.getMergeBase;
+  origSpawn = _diffUtilsDeps.spawn;
+  origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+  origGetMergeBase = _diffUtilsDeps.getMergeBase;
 
-  _semanticDeps.isGitRefValid = mock(async () => true);
-  _semanticDeps.getMergeBase = mock(async () => "abc123");
-  _semanticDeps.spawn = makeSpawnMock("diff --git a/foo.vue b/foo.vue\n+import { useI18n } from 'vue-i18n'");
+  _diffUtilsDeps.isGitRefValid = mock(async () => true);
+  _diffUtilsDeps.getMergeBase = mock(async () => "abc123");
+  _diffUtilsDeps.spawn = makeSpawnMock("diff --git a/foo.vue b/foo.vue\n+import { useI18n } from 'vue-i18n'");
 });
 
 afterEach(() => {
-  _semanticDeps.spawn = origSpawn;
-  _semanticDeps.isGitRefValid = origIsGitRefValid;
-  _semanticDeps.getMergeBase = origGetMergeBase;
+  _diffUtilsDeps.spawn = origSpawn;
+  _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+  _diffUtilsDeps.getMergeBase = origGetMergeBase;
 });
 
 // ---------------------------------------------------------------------------

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -13,6 +13,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { buildSessionName } from "../../../src/agents/acp/adapter";
 import type { AgentResult } from "../../../src/agents/types";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
 import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
 import type { SemanticStory } from "../../../src/review/semantic";
 import type { SemanticReviewConfig } from "../../../src/review/types";
@@ -73,7 +74,7 @@ function makeSpawnMock(stdout: string, exitCode = 0) {
       },
     }),
     kill: () => {},
-  })) as unknown as typeof _semanticDeps.spawn;
+  })) as unknown as typeof _diffUtilsDeps.spawn;
 }
 
 const PASSING_LLM_RESPONSE = JSON.stringify({ passed: true, findings: [] });
@@ -118,27 +119,27 @@ describe("runSemanticReview — signature", () => {
 // ---------------------------------------------------------------------------
 
 describe("runSemanticReview — missing storyGitRef", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
     // No valid ref — getMergeBase also returns undefined so review is skipped
-    _semanticDeps.isGitRefValid = mock(async () => false);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.isGitRefValid = mock(async () => false);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
   test("returns success=true when storyGitRef is undefined", async () => {
-    _semanticDeps.spawn = makeSpawnMock("", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("", 0);
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
 
     const result = await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -147,7 +148,7 @@ describe("runSemanticReview — missing storyGitRef", () => {
   });
 
   test("returns output containing 'skipped: no git ref' when storyGitRef is undefined", async () => {
-    _semanticDeps.spawn = makeSpawnMock("", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("", 0);
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
 
     const result = await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -156,7 +157,7 @@ describe("runSemanticReview — missing storyGitRef", () => {
   });
 
   test("returns success=true when storyGitRef is empty string", async () => {
-    _semanticDeps.spawn = makeSpawnMock("", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("", 0);
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
 
     const result = await runSemanticReview("/tmp/wd", "", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -165,7 +166,7 @@ describe("runSemanticReview — missing storyGitRef", () => {
   });
 
   test("returns output containing 'skipped: no git ref' when storyGitRef is empty string", async () => {
-    _semanticDeps.spawn = makeSpawnMock("", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("", 0);
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
 
     const result = await runSemanticReview("/tmp/wd", "", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -175,7 +176,7 @@ describe("runSemanticReview — missing storyGitRef", () => {
 
   test("does not invoke spawn when storyGitRef is undefined", async () => {
     const spawnMock = makeSpawnMock("", 0);
-    _semanticDeps.spawn = spawnMock;
+    _diffUtilsDeps.spawn = spawnMock;
 
     await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, () => null);
 
@@ -183,7 +184,7 @@ describe("runSemanticReview — missing storyGitRef", () => {
   });
 
   test("result.check is 'semantic' when storyGitRef is undefined", async () => {
-    _semanticDeps.spawn = makeSpawnMock("", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("", 0);
 
     const result = await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, () => null);
 
@@ -196,28 +197,28 @@ describe("runSemanticReview — missing storyGitRef", () => {
 // ---------------------------------------------------------------------------
 
 describe("runSemanticReview — git diff invocation", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
     // Mark supplied storyGitRef as valid so tests proceed without a real git repo
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
   test("calls spawn with git diff --unified=3 <storyGitRef>..HEAD and test exclusions", async () => {
     const spawnMock = makeSpawnMock("diff output", 0);
-    _semanticDeps.spawn = spawnMock;
+    _diffUtilsDeps.spawn = spawnMock;
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -241,7 +242,7 @@ describe("runSemanticReview — git diff invocation", () => {
 
   test("passes workdir as cwd to spawn", async () => {
     const spawnMock = makeSpawnMock("diff output", 0);
-    _semanticDeps.spawn = spawnMock;
+    _diffUtilsDeps.spawn = spawnMock;
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
 
     await runSemanticReview("/my/project", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -276,32 +277,32 @@ function makeSpawnMockWithStat(diffStdout: string, statStdout: string, exitCode 
       }),
       kill: () => {},
     };
-  }) as unknown as typeof _semanticDeps.spawn;
+  }) as unknown as typeof _diffUtilsDeps.spawn;
 }
 
 describe("runSemanticReview — diff truncation", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
     // Mark supplied storyGitRef as valid so tests proceed without a real git repo
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
   test("passes full diff to LLM prompt when diff is under 51200 bytes", async () => {
     const smallDiff = "a".repeat(100);
-    _semanticDeps.spawn = makeSpawnMock(smallDiff, 0);
+    _diffUtilsDeps.spawn = makeSpawnMock(smallDiff, 0);
     let capturedPrompt = "";
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
     (agent.run as ReturnType<typeof mock>).mockImplementation(async (args: { prompt: string }) => {
@@ -317,7 +318,7 @@ describe("runSemanticReview — diff truncation", () => {
   test("truncates diff and appends truncation marker when diff exceeds 51200 bytes", async () => {
     const largeDiff = "x".repeat(60_000);
     const statOutput = " src/foo.ts | 100 +\n src/bar.ts | 50 +\n 2 files changed";
-    _semanticDeps.spawn = makeSpawnMockWithStat(largeDiff, statOutput, 0);
+    _diffUtilsDeps.spawn = makeSpawnMockWithStat(largeDiff, statOutput, 0);
     let capturedPrompt = "";
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
     (agent.run as ReturnType<typeof mock>).mockImplementation(async (args: { prompt: string }) => {
@@ -336,7 +337,7 @@ describe("runSemanticReview — diff truncation", () => {
   test("truncation includes file summary from git diff --stat", async () => {
     const largeDiff = "y".repeat(60_000);
     const statOutput = " src/foo.ts | 100 +\n src/bar.ts | 50 +\n 2 files changed";
-    _semanticDeps.spawn = makeSpawnMockWithStat(largeDiff, statOutput, 0);
+    _diffUtilsDeps.spawn = makeSpawnMockWithStat(largeDiff, statOutput, 0);
     let capturedPrompt = "";
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
     (agent.run as ReturnType<typeof mock>).mockImplementation(async (args: { prompt: string }) => {
@@ -357,23 +358,23 @@ describe("runSemanticReview — diff truncation", () => {
 // ---------------------------------------------------------------------------
 
 describe("runSemanticReview — LLM prompt construction", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
     // Mark supplied storyGitRef as valid so tests proceed without a real git repo
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
   async function capturePrompt(
@@ -381,7 +382,7 @@ describe("runSemanticReview — LLM prompt construction", () => {
     config: SemanticReviewConfig = DEFAULT_SEMANTIC_CONFIG,
     diff = "- old line\n+ new line\n",
   ): Promise<string> {
-    _semanticDeps.spawn = makeSpawnMock(diff, 0);
+    _diffUtilsDeps.spawn = makeSpawnMock(diff, 0);
     let capturedPrompt = "";
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
     (agent.run as ReturnType<typeof mock>).mockImplementation(async (args: { prompt: string }) => {
@@ -458,27 +459,27 @@ describe("runSemanticReview — LLM prompt construction", () => {
 // ---------------------------------------------------------------------------
 
 describe("runSemanticReview — LLM response parsing (passed=false)", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
     // Mark supplied storyGitRef as valid so tests proceed without a real git repo
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
   test("returns success=false when LLM returns passed=false", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent(FAILING_LLM_RESPONSE);
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -487,7 +488,7 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
   });
 
   test("output contains finding's file", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent(FAILING_LLM_RESPONSE);
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -496,7 +497,7 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
   });
 
   test("output contains finding's line number", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent(FAILING_LLM_RESPONSE);
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -505,7 +506,7 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
   });
 
   test("output contains finding's severity", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent(FAILING_LLM_RESPONSE);
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -514,7 +515,7 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
   });
 
   test("output contains finding's issue description", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent(FAILING_LLM_RESPONSE);
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -523,7 +524,7 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
   });
 
   test("output contains finding's suggestion", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent(FAILING_LLM_RESPONSE);
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -532,7 +533,7 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
   });
 
   test("returns success=true when LLM returns passed=true with empty findings", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -548,7 +549,7 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
         { severity: "error", file: "src/b.ts", line: 99, issue: "Issue B", suggestion: "Fix B" },
       ],
     });
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent(multiFindings);
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -565,27 +566,27 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
 // ---------------------------------------------------------------------------
 
 describe("runSemanticReview — fail-open on invalid JSON", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
     // Mark supplied storyGitRef as valid so tests proceed without a real git repo
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
   test("returns success=true when LLM returns invalid JSON", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent("this is not json at all }{");
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -594,7 +595,7 @@ describe("runSemanticReview — fail-open on invalid JSON", () => {
   });
 
   test("returns success=true when LLM returns empty string", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent("");
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -603,7 +604,7 @@ describe("runSemanticReview — fail-open on invalid JSON", () => {
   });
 
   test("returns success=true when LLM returns JSON missing 'passed' field", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent(JSON.stringify({ findings: [] }));
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -612,7 +613,7 @@ describe("runSemanticReview — fail-open on invalid JSON", () => {
   });
 
   test("result check is 'semantic' on invalid JSON", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agent = makeMockAgent("not json");
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -625,27 +626,27 @@ describe("runSemanticReview — fail-open on invalid JSON", () => {
 // ---------------------------------------------------------------------------
 
 describe("runSemanticReview — fail-closed on truncated JSON with passed:false (#105)", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
     // Mark supplied storyGitRef as valid so tests proceed without a real git repo
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
   test("returns success=false when truncated JSON contains passed:false", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     // Simulates LLM output cut off mid-response — JSON is invalid but clearly says passed:false
     const truncatedResponse = '```json\n{"passed": false, "findings": [{"severity": "error", "file": "test.ts", "line": 1, "issue": "Test file is 78';
     const agent = makeMockAgent(truncatedResponse);
@@ -656,7 +657,7 @@ describe("runSemanticReview — fail-closed on truncated JSON with passed:false 
   });
 
   test("output mentions truncated response on fail-closed", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const truncatedResponse = '{"passed": false, "findings": [{"severity": "error"';
     const agent = makeMockAgent(truncatedResponse);
 
@@ -667,7 +668,7 @@ describe("runSemanticReview — fail-closed on truncated JSON with passed:false 
   });
 
   test("still fail-open when truncated JSON contains passed:true", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const truncatedResponse = '{"passed": true, "findings": [';
     const agent = makeMockAgent(truncatedResponse);
 
@@ -681,27 +682,27 @@ describe("runSemanticReview — fail-closed on truncated JSON with passed:false 
 // ---------------------------------------------------------------------------
 
 describe("runSemanticReview — markdown fence stripping (BUG-090)", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
     // Mark supplied storyGitRef as valid so tests proceed without a real git repo
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
   test("parses JSON wrapped in ```json fences", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const fencedResponse = "```json\n" + JSON.stringify({ passed: true, findings: [] }) + "\n```";
     const agent = makeMockAgent(fencedResponse);
 
@@ -712,7 +713,7 @@ describe("runSemanticReview — markdown fence stripping (BUG-090)", () => {
   });
 
   test("parses JSON wrapped in plain ``` fences", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const fencedResponse = "```\n" + JSON.stringify({ passed: true, findings: [] }) + "\n```";
     const agent = makeMockAgent(fencedResponse);
 
@@ -723,7 +724,7 @@ describe("runSemanticReview — markdown fence stripping (BUG-090)", () => {
   });
 
   test("parses fenced JSON with findings and returns success=false", async () => {
-    _semanticDeps.spawn = makeSpawnMock("some diff", 0);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const payload = {
       passed: false,
       findings: [{ severity: "error", file: "src/foo.ts", line: 1, issue: "bad code", suggestion: "fix it" }],
@@ -742,27 +743,27 @@ describe("runSemanticReview — markdown fence stripping (BUG-090)", () => {
 // ---------------------------------------------------------------------------
 
 describe("runSemanticReview — BUG-114 storyGitRef fallback (merge-base)", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
   test("uses effectiveRef = storyGitRef when ref is valid", async () => {
     const spawnMock = makeSpawnMock("diff content", 0);
-    _semanticDeps.spawn = spawnMock;
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => "merge-base-sha");
+    _diffUtilsDeps.spawn = spawnMock;
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => "merge-base-sha");
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
 
     await runSemanticReview("/tmp/wd", "valid-sha", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -772,14 +773,14 @@ describe("runSemanticReview — BUG-114 storyGitRef fallback (merge-base)", () =
     const spawnOpts = call[0] as { cmd: string[] };
     // Should use the valid storyGitRef, not the merge-base
     expect(spawnOpts.cmd).toContain("valid-sha..HEAD");
-    expect(_semanticDeps.getMergeBase).not.toHaveBeenCalled();
+    expect(_diffUtilsDeps.getMergeBase).not.toHaveBeenCalled();
   });
 
   test("falls back to merge-base when storyGitRef is undefined", async () => {
     const spawnMock = makeSpawnMock("diff content", 0);
-    _semanticDeps.spawn = spawnMock;
-    _semanticDeps.isGitRefValid = mock(async () => false);
-    _semanticDeps.getMergeBase = mock(async () => "abc-merge-base");
+    _diffUtilsDeps.spawn = spawnMock;
+    _diffUtilsDeps.isGitRefValid = mock(async () => false);
+    _diffUtilsDeps.getMergeBase = mock(async () => "abc-merge-base");
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
 
     await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -792,9 +793,9 @@ describe("runSemanticReview — BUG-114 storyGitRef fallback (merge-base)", () =
 
   test("falls back to merge-base when storyGitRef is invalid (e.g. after rebase)", async () => {
     const spawnMock = makeSpawnMock("diff content", 0);
-    _semanticDeps.spawn = spawnMock;
-    _semanticDeps.isGitRefValid = mock(async () => false);
-    _semanticDeps.getMergeBase = mock(async () => "fallback-merge-base-sha");
+    _diffUtilsDeps.spawn = spawnMock;
+    _diffUtilsDeps.isGitRefValid = mock(async () => false);
+    _diffUtilsDeps.getMergeBase = mock(async () => "fallback-merge-base-sha");
     const agent = makeMockAgent(PASSING_LLM_RESPONSE);
 
     await runSemanticReview("/tmp/wd", "stale-sha-after-rebase", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
@@ -803,13 +804,13 @@ describe("runSemanticReview — BUG-114 storyGitRef fallback (merge-base)", () =
     const call = (spawnMock as ReturnType<typeof mock>).mock.calls[0];
     const spawnOpts = call[0] as { cmd: string[] };
     expect(spawnOpts.cmd).toContain("fallback-merge-base-sha..HEAD");
-    expect(_semanticDeps.isGitRefValid).toHaveBeenCalledWith("/tmp/wd", "stale-sha-after-rebase");
+    expect(_diffUtilsDeps.isGitRefValid).toHaveBeenCalledWith("/tmp/wd", "stale-sha-after-rebase");
   });
 
   test("skips review (success=true) when storyGitRef is undefined and merge-base is also unavailable", async () => {
-    _semanticDeps.spawn = makeSpawnMock("", 0);
-    _semanticDeps.isGitRefValid = mock(async () => false);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.spawn = makeSpawnMock("", 0);
+    _diffUtilsDeps.isGitRefValid = mock(async () => false);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
 
     const result = await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, () => null);
 
@@ -818,9 +819,9 @@ describe("runSemanticReview — BUG-114 storyGitRef fallback (merge-base)", () =
   });
 
   test("skips review (success=true) when storyGitRef is invalid and merge-base is also unavailable", async () => {
-    _semanticDeps.spawn = makeSpawnMock("", 0);
-    _semanticDeps.isGitRefValid = mock(async () => false);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.spawn = makeSpawnMock("", 0);
+    _diffUtilsDeps.isGitRefValid = mock(async () => false);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
 
     const result = await runSemanticReview("/tmp/wd", "bad-sha", STORY, DEFAULT_SEMANTIC_CONFIG, () => null);
 
@@ -862,26 +863,26 @@ function makeRunMockAgent(output: string, success = true): AgentAdapter {
 }
 
 describe("runSemanticReview — uses agent.run() instead of agent.complete() (US-003)", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
   let origReadAcpSession: typeof _semanticDeps.readAcpSession;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
     origReadAcpSession = _semanticDeps.readAcpSession;
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
-    _semanticDeps.spawn = makeSpawnMock("some diff content", 0);
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff content", 0);
     _semanticDeps.readAcpSession = mock(async () => "nax-abc123-feature-us-003-implementer");
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
     _semanticDeps.readAcpSession = origReadAcpSession;
   });
 
@@ -1034,25 +1035,25 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
 // ---------------------------------------------------------------------------
 
 describe("runSemanticReview — reads implementer session sidecar before run() (US-003 AC-5)", () => {
-  let origSpawn: typeof _semanticDeps.spawn;
-  let origIsGitRefValid: typeof _semanticDeps.isGitRefValid;
-  let origGetMergeBase: typeof _semanticDeps.getMergeBase;
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
   let origReadAcpSession: typeof _semanticDeps.readAcpSession;
 
   beforeEach(() => {
-    origSpawn = _semanticDeps.spawn;
-    origIsGitRefValid = _semanticDeps.isGitRefValid;
-    origGetMergeBase = _semanticDeps.getMergeBase;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
     origReadAcpSession = _semanticDeps.readAcpSession;
-    _semanticDeps.isGitRefValid = mock(async () => true);
-    _semanticDeps.getMergeBase = mock(async () => undefined);
-    _semanticDeps.spawn = makeSpawnMock("some diff content", 0);
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff content", 0);
   });
 
   afterEach(() => {
-    _semanticDeps.spawn = origSpawn;
-    _semanticDeps.isGitRefValid = origIsGitRefValid;
-    _semanticDeps.getMergeBase = origGetMergeBase;
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
     _semanticDeps.readAcpSession = origReadAcpSession;
   });
 


### PR DESCRIPTION
## Summary

- Adds an adversarial reviewer as a second independently-prompted lens alongside semantic review. Semantic confirms AC satisfaction; adversarial asks "where does this break? what is missing?" Ships off by default — enabled via `review.checks: ["adversarial"]`.
- Extracts shared diff utilities (`collectDiff`, `collectDiffStat`, `truncateDiff`, `resolveEffectiveRef`, `computeTestInventory`) from `semantic.ts` into `src/review/diff-utils.ts`, eliminating duplication between the two runners.
- Adds rectifier arbitration escape hatch: when the implementer cannot satisfy contradicting reviewer findings, it emits `UNRESOLVED: <reason>` and autofix escalates instead of retrying infinitely.

## What's in this PR

**New files**
- `src/review/adversarial.ts` — adversarial runner; own ACP session, fail-open/fail-closed policy matching semantic
- `src/review/diff-utils.ts` — shared diff utilities; `_diffUtilsDeps` injectable for testing
- `src/prompts/builders/adversarial-review-builder.ts` — prompt builder with 6 heuristics and `category` field in findings schema
- `test/unit/review/adversarial.test.ts` — 26 tests
- `test/unit/review/diff-utils.test.ts` — 19 tests
- `test/unit/prompts/adversarial-review-builder.test.ts` — 21 tests

**Config** (`src/config/schemas.ts`, `types.ts`, `runtime-types.ts`)
- `AdversarialReviewConfigSchema`: `modelTier`, `diffMode` (default `"ref"`), `rules`, `timeoutMs`, `excludePatterns`, `parallel`, `maxConcurrentSessions`
- `"adversarial"` added to `ReviewCheckName` union

**Runner wiring** (`src/review/runner.ts`, `orchestrator.ts`)
- `_reviewAdversarialDeps` injectable; adversarial case in checks for-loop after semantic
- Phase 4 parallel dispatch in orchestrator: `Promise.all([semantic, adversarial])` when `parallel: true` and `semSessions + advSessions <= maxConcurrentSessions`; falls back to sequential with a warning when cap exceeded

**Rectifier** (`src/pipeline/stages/autofix.ts`, `autofix-prompts.ts`)
- `CONTRADICTION_ESCAPE_HATCH` text appended to all rectification prompts
- `UNRESOLVED_REGEX` detects the signal from agent output → `{ action: "escalate", reason: "Reviewer contradiction: ..." }`
- Adversarial failures now route to the AC-aware rectification prompt (same as semantic), not the mechanical lint/typecheck prompt

**Infrastructure**
- `LogEntry.sessionRole` is now a first-class field (extracted from `data` at log time for parallel log correlation)
- `reviewMetrics` optional sub-buckets in `StoryMetrics` (semantic + adversarial cost/duration/findings)
- `reviewer-adversarial` + `reviewer-semantic` added to session role registry in `.claude/rules/adapter-wiring.md`

## Code review fixes applied

Post-review fixes before merging:
- `isBlockingSeverity` now excludes `"info"` alongside `"unverifiable"` (the schema allows `passed:true` with info/unverifiable findings)
- Findings take precedence over the `passed` field — if LLM returns `passed:true` with `error`/`warn` findings (schema violation), the runner fails-closed based on findings
- Adversarial failures routed to AC-aware rectification prompt, not the mechanical lint/typecheck prompt

## Test plan

- [ ] `bun run typecheck` — no errors
- [ ] `bun run lint` — clean
- [ ] `bun run test` — 1225 pass, 0 fail
- [ ] Manual: add `"adversarial"` to `review.checks` in `.nax/config.json`, run `nax run` on a story — verify adversarial findings appear in output
- [ ] Manual: verify JSONL log output contains `"sessionRole": "reviewer-adversarial"` at top level of `LogEntry`
- [ ] Manual: verify `retrySkipChecks` — when adversarial passes and lint fails, confirm only lint re-runs on retry
- [ ] Manual parallel mode: set `adversarial.parallel: true` and `maxConcurrentSessions: 2`, confirm both reviewers run concurrently