### PR TITLE
fix(headless): improve stdout logging for headless mode

### DIFF
--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -153,17 +153,25 @@ export async function executeUnified(
           ctx.onBeforeStory?.();
           // Emit story:started for each batch story before dispatch (AC-5)
           for (const story of batch) {
+            const modelTier =
+              story.routing?.modelTier ??
+              ctx.config.autoMode.complexityRouting?.[story.routing?.complexity ?? "medium"] ??
+              "balanced";
             pipelineEventBus.emit({
               type: "story:started",
               storyId: story.id,
               story: { id: story.id, title: story.title, status: story.status, attempts: story.attempts },
               workdir: ctx.workdir,
-              modelTier:
-                story.routing?.modelTier ??
-                ctx.config.autoMode.complexityRouting?.[story.routing?.complexity ?? "medium"] ??
-                "balanced",
+              modelTier,
               agent: ctx.config.autoMode.defaultAgent,
               iteration: iterations,
+            });
+            logger?.info("story.start", `${story.title}`, {
+              storyId: story.id,
+              storyTitle: story.title,
+              complexity: story.routing?.complexity ?? "unknown",
+              modelTier,
+              attempt: story.attempts + 1,
             });
           }
 
@@ -328,6 +336,7 @@ export async function executeUnified(
           }
 
           ctx.onBeforeStory?.();
+          const modelTier = singleSelection.routing.modelTier;
           pipelineEventBus.emit({
             type: "story:started",
             storyId: singleStory.id,
@@ -338,9 +347,16 @@ export async function executeUnified(
               attempts: singleStory.attempts,
             },
             workdir: ctx.workdir,
-            modelTier: singleSelection.routing.modelTier,
+            modelTier,
             agent: ctx.config.autoMode.defaultAgent,
             iteration: iterations,
+          });
+          logger?.info("story.start", `${singleStory.title}`, {
+            storyId: singleStory.id,
+            storyTitle: singleStory.title,
+            complexity: singleSelection.routing.complexity ?? "unknown",
+            modelTier,
+            attempt: singleStory.attempts + 1,
           });
 
           const singleIter = await _unifiedExecutorDeps.runIteration(
@@ -410,6 +426,7 @@ export async function executeUnified(
       }
 
       ctx.onBeforeStory?.();
+      const modelTier = selection.routing.modelTier;
       pipelineEventBus.emit({
         type: "story:started",
         storyId: selection.story.id,
@@ -420,9 +437,16 @@ export async function executeUnified(
           attempts: selection.story.attempts,
         },
         workdir: ctx.workdir,
-        modelTier: selection.routing.modelTier,
+        modelTier,
         agent: ctx.config.autoMode.defaultAgent,
         iteration: iterations,
+      });
+      logger?.info("story.start", `${selection.story.title}`, {
+        storyId: selection.story.id,
+        storyTitle: selection.story.title,
+        complexity: selection.routing.complexity ?? "unknown",
+        modelTier,
+        attempt: selection.story.attempts + 1,
       });
 
       const iter = await _unifiedExecutorDeps.runIteration(ctx, prd, selection, iterations, totalCost, allStoryMetrics);

--- a/src/logging/formatter.ts
+++ b/src/logging/formatter.ts
@@ -265,7 +265,7 @@ function formatDefault(entry: LogEntry, c: ChalkLike, timestamp: string, mode: s
     if (typeof data.durationMs === "number" && data.durationMs > 0)
       meta.push(`${EMOJI.duration} ${formatDuration(data.durationMs)}`);
     if (typeof data.action === "string") meta.push(`action: ${data.action}`);
-    if (typeof data.reason === "string" && mode !== "quiet") meta.push(c.gray(data.reason));
+    if (typeof data.reason === "string" && mode !== "quiet") meta.push(data.reason);
     if (meta.length > 0) {
       output += `  ${c.gray(meta.join("  "))}`;
     }

--- a/src/logging/formatter.ts
+++ b/src/logging/formatter.ts
@@ -70,8 +70,10 @@ function shouldDisplay(entry: LogEntry, mode: string): boolean {
   }
   if (mode === "verbose") return true;
 
-  // Normal mode: filter out debug logs
-  return entry.level !== "debug";
+  // Normal mode: filter out debug logs, but always show story.start
+  if (entry.level === "debug") return false;
+  if (entry.stage === "story.start" || entry.stage === "iteration.start") return true;
+  return true;
 }
 
 /**
@@ -255,9 +257,27 @@ function formatDefault(entry: LogEntry, c: ChalkLike, timestamp: string, mode: s
 
   let output = parts.join(" ");
 
-  // Include data in verbose mode
-  if (mode === "verbose" && entry.data && Object.keys(entry.data).length > 0) {
-    output += `\n${c.gray(JSON.stringify(entry.data, null, 2))}`;
+  // Always show key data fields (cost, duration, action, reason) in normal+ modes
+  const data = entry.data;
+  if (data && typeof data === "object") {
+    const meta: string[] = [];
+    if (typeof data.cost === "number" && data.cost > 0) meta.push(`${EMOJI.cost} ${formatCost(data.cost)}`);
+    if (typeof data.durationMs === "number" && data.durationMs > 0)
+      meta.push(`${EMOJI.duration} ${formatDuration(data.durationMs)}`);
+    if (typeof data.action === "string") meta.push(`action: ${data.action}`);
+    if (typeof data.reason === "string" && mode !== "quiet") meta.push(c.gray(data.reason));
+    if (meta.length > 0) {
+      output += `  ${c.gray(meta.join("  "))}`;
+    }
+
+    // Full data dump only in verbose mode
+    if (mode === "verbose") {
+      // biome-ignore lint/suspicious/noExplicitAny: Intentional spread to filter known fields
+      const { cost: _c, durationMs: _d, action: _a, reason: _r, ...filtered } = data as any;
+      if (Object.keys(filtered).length > 0) {
+        output += `\n${c.gray(JSON.stringify(filtered, null, 2))}`;
+      }
+    }
   }
 
   return {

--- a/src/logging/formatter.ts
+++ b/src/logging/formatter.ts
@@ -70,10 +70,9 @@ function shouldDisplay(entry: LogEntry, mode: string): boolean {
   }
   if (mode === "verbose") return true;
 
-  // Normal mode: filter out debug logs, but always show story.start
-  if (entry.level === "debug") return false;
+  // Normal mode: filter out debug logs, but always show story.start/iteration.start
   if (entry.stage === "story.start" || entry.stage === "iteration.start") return true;
-  return true;
+  return entry.level !== "debug";
 }
 
 /**

--- a/test/unit/execution/unified-executor.test.ts
+++ b/test/unit/execution/unified-executor.test.ts
@@ -16,8 +16,9 @@
  *   AC-11 runner.ts has no reference to _runnerDeps.runParallelExecution
  */
 
-import { beforeEach, afterEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { join } from "node:path";
+import * as loggerModule from "../../../src/logger";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -655,6 +656,218 @@ describe("AC-11 — runner.ts has no reference to _runnerDeps.runParallelExecuti
     const src = await readSrc("execution/runner.ts");
     // Check that the _runnerDeps object does not wire runParallelExecution
     expect(src).not.toMatch(/_runnerDeps[\s\S]{0,200}runParallelExecution/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// story.start logging — logger.info("story.start", …) emitted in both dispatch paths
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("story.start logging — parallel batch dispatch", () => {
+  let deps: Record<string, unknown>;
+  let origRunParallelBatch: unknown;
+  let origSelectIndependentBatch: unknown;
+  let loggerSpy: ReturnType<typeof spyOn>;
+
+  interface LogCall {
+    stage: string;
+    message: string;
+    data?: Record<string, unknown>;
+  }
+
+  beforeEach(async () => {
+    const mod = await import("../../../src/execution/unified-executor");
+    deps = (mod as Record<string, unknown>)._unifiedExecutorDeps as Record<string, unknown>;
+    origRunParallelBatch = deps.runParallelBatch;
+    origSelectIndependentBatch = deps.selectIndependentBatch;
+  });
+
+  afterEach(() => {
+    if (deps) {
+      deps.runParallelBatch = origRunParallelBatch;
+      deps.selectIndependentBatch = origSelectIndependentBatch;
+    }
+    loggerSpy?.mockRestore();
+    mock.restore();
+  });
+
+  test("logger.info is called with stage 'story.start' for each story in a parallel batch", async () => {
+    const story1 = makePendingStory("US-001");
+    const story2 = makePendingStory("US-002");
+
+    const infoCalls: LogCall[] = [];
+    const logger = {
+      info: mock((stage: string, message: string, data?: Record<string, unknown>) => {
+        infoCalls.push({ stage, message, data });
+      }),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+      debug: mock(() => {}),
+    };
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as ReturnType<typeof loggerModule.getSafeLogger>);
+
+    deps.selectIndependentBatch = mock(() => [story1, story2]);
+    deps.runParallelBatch = mock(async () => ({
+      completed: [story1, story2],
+      failed: [],
+      mergeConflicts: [],
+      storyCosts: new Map([[story1.id, 0], [story2.id, 0]]),
+      totalCost: 0,
+    }));
+
+    const { executeUnified } = await import("../../../src/execution/unified-executor");
+    const prd = makePrd([story1, story2]);
+    const ctx = makeCtx({ parallelCount: 2 });
+
+    await executeUnified(ctx as never, prd as never).catch(() => {});
+
+    const storyStartCalls = infoCalls.filter((c) => c.stage === "story.start");
+    expect(storyStartCalls.length).toBeGreaterThanOrEqual(2);
+
+    const ids = storyStartCalls.map((c) => c.data?.storyId);
+    expect(ids).toContain("US-001");
+    expect(ids).toContain("US-002");
+  });
+
+  test("story.start log data includes storyId, storyTitle, complexity, modelTier, attempt for batch stories", async () => {
+    const story1 = makePendingStory("US-001");
+
+    const infoCalls: LogCall[] = [];
+    const logger = {
+      info: mock((stage: string, message: string, data?: Record<string, unknown>) => {
+        infoCalls.push({ stage, message, data });
+      }),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+      debug: mock(() => {}),
+    };
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as ReturnType<typeof loggerModule.getSafeLogger>);
+
+    deps.selectIndependentBatch = mock(() => [story1, makePendingStory("US-002")]);
+    deps.runParallelBatch = mock(async () => ({
+      completed: [story1],
+      failed: [],
+      mergeConflicts: [],
+      storyCosts: new Map([[story1.id, 0]]),
+      totalCost: 0,
+    }));
+
+    const { executeUnified } = await import("../../../src/execution/unified-executor");
+    const prd = makePrd([story1, makePendingStory("US-002")]);
+    const ctx = makeCtx({ parallelCount: 2 });
+
+    await executeUnified(ctx as never, prd as never).catch(() => {});
+
+    const call = infoCalls.find((c) => c.stage === "story.start" && c.data?.storyId === "US-001");
+    expect(call).toBeDefined();
+    expect(call?.data).toMatchObject({
+      storyId: "US-001",
+      storyTitle: "Story US-001",
+      attempt: 1,
+    });
+    expect(call?.data).toHaveProperty("complexity");
+    expect(call?.data).toHaveProperty("modelTier");
+  });
+});
+
+describe("story.start logging — sequential (single-story) dispatch", () => {
+  let deps: Record<string, unknown>;
+  let origRunIteration: unknown;
+  let origSelectIndependentBatch: unknown;
+  let loggerSpy: ReturnType<typeof spyOn>;
+
+  interface LogCall {
+    stage: string;
+    message: string;
+    data?: Record<string, unknown>;
+  }
+
+  beforeEach(async () => {
+    const mod = await import("../../../src/execution/unified-executor");
+    deps = (mod as Record<string, unknown>)._unifiedExecutorDeps as Record<string, unknown>;
+    origRunIteration = deps.runIteration;
+    origSelectIndependentBatch = deps.selectIndependentBatch;
+  });
+
+  afterEach(() => {
+    if (deps) {
+      deps.runIteration = origRunIteration;
+      deps.selectIndependentBatch = origSelectIndependentBatch;
+    }
+    loggerSpy?.mockRestore();
+    mock.restore();
+  });
+
+  test("logger.info is called with stage 'story.start' for a single-story sequential dispatch", async () => {
+    const story1 = makePendingStory("US-001");
+
+    const infoCalls: LogCall[] = [];
+    const logger = {
+      info: mock((stage: string, message: string, data?: Record<string, unknown>) => {
+        infoCalls.push({ stage, message, data });
+      }),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+      debug: mock(() => {}),
+    };
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as ReturnType<typeof loggerModule.getSafeLogger>);
+
+    deps.selectIndependentBatch = mock(() => [story1]);
+    deps.runIteration = mock(async () => ({
+      prd: makePrd([]),
+      storiesCompletedDelta: 1,
+      costDelta: 0,
+      prdDirty: false,
+    }));
+
+    const { executeUnified } = await import("../../../src/execution/unified-executor");
+    const prd = makePrd([story1]);
+    const ctx = makeCtx({ parallelCount: 2 });
+
+    await executeUnified(ctx as never, prd as never).catch(() => {});
+
+    const storyStartCalls = infoCalls.filter((c) => c.stage === "story.start");
+    expect(storyStartCalls.length).toBeGreaterThanOrEqual(1);
+    expect(storyStartCalls[0].data?.storyId).toBe("US-001");
+  });
+
+  test("story.start log data includes storyId, storyTitle, complexity, modelTier, attempt for sequential dispatch", async () => {
+    const story1 = makePendingStory("US-001");
+
+    const infoCalls: LogCall[] = [];
+    const logger = {
+      info: mock((stage: string, message: string, data?: Record<string, unknown>) => {
+        infoCalls.push({ stage, message, data });
+      }),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+      debug: mock(() => {}),
+    };
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as ReturnType<typeof loggerModule.getSafeLogger>);
+
+    deps.selectIndependentBatch = mock(() => [story1]);
+    deps.runIteration = mock(async () => ({
+      prd: makePrd([]),
+      storiesCompletedDelta: 1,
+      costDelta: 0,
+      prdDirty: false,
+    }));
+
+    const { executeUnified } = await import("../../../src/execution/unified-executor");
+    const prd = makePrd([story1]);
+    const ctx = makeCtx({ parallelCount: 2 });
+
+    await executeUnified(ctx as never, prd as never).catch(() => {});
+
+    const call = infoCalls.find((c) => c.stage === "story.start" && c.data?.storyId === "US-001");
+    expect(call).toBeDefined();
+    expect(call?.data).toMatchObject({
+      storyId: "US-001",
+      storyTitle: "Story US-001",
+      attempt: 1,
+    });
+    expect(call?.data).toHaveProperty("complexity");
+    expect(call?.data).toHaveProperty("modelTier");
   });
 });
 


### PR DESCRIPTION
## What
Improves console output for `nax run --headless` in normal (non-verbose) mode.

## Why
Headless output was too sparse, missing story titles, complexity, and key metrics like cost and duration for intermediate stages (verify, rectify).

## How
1. **Added `story.start` logging**: Explicitly call `logger.info("story.start", ...)` in `unified-executor.ts` so story titles and complexity are visible.
2. **Updated `shouldDisplay`**: Ensured `story.start` and `iteration.start` stages are visible in normal mode.
3. **Enhanced `formatDefault`**: Updated the default formatter to extract and display `cost`, `durationMs`, `action`, and `reason` from the log entry's `data` payload if present, even in normal mode.
4. **Cleaned up verbose output**: Used rest/spread to filter out fields already displayed inline before doing the full JSON dump in verbose mode.

## Testing
- [x] `bun test` passes (6587 pass)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
The `delete` operator was replaced with a destructuring spread to satisfy Biome's performance rules.
