### PR TITLE
fix(review): standardize adversarial timeout to 600s to match semantic

### DIFF
--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -323,8 +323,8 @@ export const AdversarialReviewConfigSchema = z.object({
   diffMode: z.enum(["embedded", "ref"]).default("ref"),
   /** Custom adversarial heuristic rules to append to the prompt. */
   rules: z.array(z.string()).default([]),
-  /** LLM call timeout in milliseconds. Default 180s (shorter than semantic, no debate path). */
-  timeoutMs: z.number().int().positive().default(180_000),
+  /** LLM call timeout in milliseconds. Default 600s (matches semantic — no debate path but ref mode may need full tool traversal). */
+  timeoutMs: z.number().int().positive().default(600_000),
   /**
    * Pathspec exclusions applied only in embedded mode.
    * Default empty — adversarial sees test files (unlike semantic).

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -235,7 +235,7 @@ export async function runAdversarialReview(
       workdir,
       acpSessionName: adversarialSessionName,
       keepSessionOpen: false,
-      timeoutSeconds: adversarialConfig.timeoutMs ? Math.ceil(adversarialConfig.timeoutMs / 1000) : 180,
+      timeoutSeconds: adversarialConfig.timeoutMs ? Math.ceil(adversarialConfig.timeoutMs / 1000) : 600,
       modelTier: adversarialConfig.modelTier,
       modelDef: resolvedModelDef,
       pipelineStage: "review",

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -329,7 +329,7 @@ export async function runReview(
         modelTier: "balanced" as const,
         diffMode: "ref" as const,
         rules: [] as string[],
-        timeoutMs: 180_000,
+        timeoutMs: 600_000,
         excludePatterns: [] as string[],
         parallel: false,
         maxConcurrentSessions: 2,

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -120,7 +120,7 @@ export interface AdversarialReviewConfig {
   diffMode: "embedded" | "ref";
   /** Custom adversarial heuristic rules to append to the prompt */
   rules: string[];
-  /** Timeout in milliseconds (default: 180_000) */
+  /** Timeout in milliseconds (default: 600_000) */
   timeoutMs: number;
   /** Pathspec exclusions for embedded mode. Default empty (adversarial sees test files). */
   excludePatterns: string[];


### PR DESCRIPTION
## Summary

- Adversarial reviewer was defaulting to 180s timeout while semantic review uses 600s
- In `ref` mode (the adversarial default), the LLM self-serves the full diff via git tool calls — this can take as long as semantic review
- Standardized to 600s across all four locations: config schema default, `AdversarialReviewConfig` type comment, runner inline fallback, and `adversarial.ts` hardcoded fallback

## Test plan

- [ ] Verify `bun run typecheck` passes
- [ ] Verify `bun run lint` passes
- [ ] Run `bun test test/unit/review/adversarial.test.ts` — all adversarial tests pass
- [ ] Confirm adversarial log output now shows `--timeout 600` (not `--timeout 180`) when running a story with `"adversarial"` in `review.checks`