### PR TITLE
feat(session-continuity): continuous implementer session across fix stages (PROMPT-001)

### DIFF
--- a/src/pipeline/stages/autofix-continuation.ts
+++ b/src/pipeline/stages/autofix-continuation.ts
@@ -1,0 +1,49 @@
+/**
+ * Continuation prompt for autofix retry attempts (PROMPT-001).
+ * Sent on attempt 2+ when the implementer session is confirmed open.
+ * Contains ONLY new error output + escalation preamble — NOT the full prompt.
+ */
+
+import type { ReviewCheckResult } from "../../review/types";
+import { CONTRADICTION_ESCAPE_HATCH } from "./autofix-prompts";
+
+export function buildReviewRectificationContinuation(
+  failedChecks: ReviewCheckResult[],
+  attempt: number,
+  rethinkAtAttempt: number,
+  urgencyAtAttempt: number,
+): string {
+  const parts: string[] = [];
+
+  parts.push("Your previous fix attempt did not resolve all issues. Here are the remaining failures:\n");
+
+  for (const check of failedChecks) {
+    parts.push(`### ${check.check} (exit ${check.exitCode})\n`);
+    const truncated = check.output.length > 4000;
+    const output = truncated
+      ? `${check.output.slice(0, 4000)}\n... (truncated — ${check.output.length} chars total)`
+      : check.output;
+    parts.push(`\`\`\`\n${output}\n\`\`\`\n`);
+    if (check.findings?.length) {
+      parts.push("Structured findings:\n");
+      for (const f of check.findings) {
+        parts.push(`- [${f.severity}] ${f.file}:${f.line} — ${f.message}\n`);
+      }
+    }
+  }
+
+  if (attempt >= rethinkAtAttempt) {
+    parts.push(
+      "\n**Rethink your approach.** The same strategy has failed multiple times. Consider a fundamentally different fix.\n",
+    );
+  }
+  if (attempt >= urgencyAtAttempt) {
+    parts.push(
+      "\n**URGENT: This is your final attempt.** If you cannot fix all issues, emit `UNRESOLVED: <reason>` to escalate.\n",
+    );
+  }
+
+  parts.push(CONTRADICTION_ESCAPE_HATCH);
+
+  return parts.join("\n");
+}

--- a/src/pipeline/stages/autofix-prompts.ts
+++ b/src/pipeline/stages/autofix-prompts.ts
@@ -26,7 +26,7 @@ export interface DialogueAwarePromptOptions {
  * "UNRESOLVED: <explanation>" in the agent output and escalates instead
  * of retrying — avoiding an infinite loop on an unresolvable conflict.
  */
-const CONTRADICTION_ESCAPE_HATCH = `
+export const CONTRADICTION_ESCAPE_HATCH = `
 If two findings in this list contradict each other and you cannot satisfy both, do not guess.
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>`;

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -19,6 +19,7 @@
  * - `escalate`                 — max attempts exhausted or agent unavailable
  */
 
+import { buildSessionName } from "../../agents/acp/adapter";
 import { createAgentRegistry } from "../../agents/registry";
 import { resolveModelForAgent } from "../../config";
 import type { NaxConfig } from "../../config";
@@ -32,6 +33,9 @@ import {
 } from "../../verification/shared-rectification-loop";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
+import { buildReviewRectificationContinuation } from "./autofix-continuation";
+import { buildReviewRectificationPrompt } from "./autofix-prompts";
+export { buildReviewRectificationPrompt };
 
 const CLARIFY_REGEX = /^CLARIFY:\s*(.+)$/ms;
 /** Matches the REVIEW-003 reviewer contradiction escape hatch emitted by the implementer. */
@@ -200,10 +204,6 @@ function collectFailedChecks(ctx: PipelineContext): ReviewCheckResult[] {
   return (ctx.reviewResult?.checks ?? []).filter((c) => !c.success);
 }
 
-// Re-export from extracted module for backward compatibility
-import { buildReviewRectificationPrompt } from "./autofix-prompts";
-export { buildReviewRectificationPrompt };
-
 function buildAutofixEscalationPreamble(
   attempt: number,
   maxAttempts: number,
@@ -276,6 +276,10 @@ async function runAgentRectification(
   let autofixCostAccum = 0;
   let unresolvedReason: string | undefined;
 
+  // Session continuity: execution + review came before us, so the implementer session is open.
+  const implementerSession = buildSessionName(ctx.workdir, ctx.prd.feature, ctx.story.id, "implementer");
+  let sessionConfirmedOpen = true; // execution + review came before us
+
   const succeeded = await runSharedRectificationLoop({
     stage: "autofix",
     storyId: ctx.story.id,
@@ -294,6 +298,21 @@ async function runAgentRectification(
     attemptData: { storyId: ctx.story.id },
     canContinue: (state) => state.failedChecks.length > 0 && state.attempt < maxAttempts,
     buildPrompt: (attempt, state) => {
+      // runSharedRectificationLoop increments attempt before calling buildPrompt,
+      // so attempt=1 on the first call. Continuation mode starts from attempt=2.
+      const isSessionContinuation = attempt > 1 && sessionConfirmedOpen;
+
+      if (isSessionContinuation) {
+        // Apply the same capping as buildProgressivePromptPreamble so the last attempt
+        // always triggers urgency even when urgencyAtAttempt > maxAttempts.
+        return buildReviewRectificationContinuation(
+          state.failedChecks,
+          attempt,
+          Math.min(rethinkAtAttempt, maxAttempts),
+          Math.min(urgencyAtAttempt, maxAttempts),
+        );
+      }
+
       let prompt = buildReviewRectificationPrompt(state.failedChecks, ctx.story);
       const escalationPreamble = buildAutofixEscalationPreamble(
         attempt,
@@ -322,21 +341,31 @@ async function runAgentRectification(
         modelTier,
         ctx.rootConfig.autoMode.defaultAgent,
       );
-      const result = await agent.run({
-        prompt,
-        workdir: ctx.workdir,
-        modelTier,
-        modelDef,
-        timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
-        dangerouslySkipPermissions: resolvePermissions(ctx.config, "rectification").skipPermissions,
-        pipelineStage: "rectification",
-        config: ctx.config,
-        projectDir: ctx.projectDir,
-        maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
-        featureName: ctx.prd.feature,
-        storyId: ctx.story.id,
-        sessionRole: "implementer",
-      });
+      const isLastAttempt = attempt >= maxAttempts;
+      let result: Awaited<ReturnType<typeof agent.run>>;
+      try {
+        result = await agent.run({
+          prompt,
+          workdir: ctx.workdir,
+          modelTier,
+          modelDef,
+          timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
+          dangerouslySkipPermissions: resolvePermissions(ctx.config, "rectification").skipPermissions,
+          pipelineStage: "rectification",
+          config: ctx.config,
+          projectDir: ctx.projectDir,
+          maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
+          featureName: ctx.prd.feature,
+          storyId: ctx.story.id,
+          sessionRole: "implementer",
+          acpSessionName: implementerSession,
+          keepSessionOpen: !isLastAttempt,
+        });
+        sessionConfirmedOpen = true;
+      } catch (err) {
+        sessionConfirmedOpen = false; // Session state unknown — next attempt uses full prompt
+        throw err;
+      }
 
       autofixCostAccum += result.estimatedCost ?? 0;
 

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -382,7 +382,7 @@ export async function runSemanticReview(
       prompt,
       workdir,
       acpSessionName: implementerSessionName,
-      keepSessionOpen: false,
+      keepSessionOpen: true,
       timeoutSeconds: semanticConfig.timeoutMs ? Math.ceil(semanticConfig.timeoutMs / 1000) : 3600,
       modelTier: semanticConfig.modelTier,
       modelDef: resolvedModelDef,

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -8,6 +8,7 @@
  */
 
 import { getAgent as _getAgent } from "../agents";
+import { buildSessionName } from "../agents/acp/adapter";
 import { estimateCostByDuration } from "../agents/cost";
 import { createAgentRegistry } from "../agents/registry";
 import type { AgentAdapter } from "../agents/types";
@@ -151,6 +152,7 @@ export async function runRectificationLoop(
   };
 
   let costAccum = 0;
+  const rectificationSessionName = buildSessionName(workdir, featureName, story.id, "implementer");
 
   const succeeded = await runSharedRectificationLoop({
     stage: "rectification",
@@ -239,6 +241,8 @@ export async function runRectificationLoop(
         config.autoMode.defaultAgent,
       );
 
+      const isLastAttempt = attempt >= rectificationConfig.maxRetries;
+
       const agentResult = await agent.run({
         prompt: rectificationPrompt,
         workdir,
@@ -253,6 +257,8 @@ export async function runRectificationLoop(
         featureName,
         storyId: story.id,
         sessionRole: "implementer",
+        acpSessionName: rectificationSessionName,
+        keepSessionOpen: !isLastAttempt,
       });
 
       costAccum += agentResult.estimatedCost ?? 0;

--- a/test/unit/pipeline/stages/autofix-continuation.test.ts
+++ b/test/unit/pipeline/stages/autofix-continuation.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for src/pipeline/stages/autofix-continuation.ts
+ *
+ * Tests cover:
+ * 1. Continuation prompt contains error output from failedChecks
+ * 2. Continuation prompt contains findings when present
+ * 3. Rethink preamble appears at rethinkAtAttempt
+ * 4. Urgency preamble appears at urgencyAtAttempt
+ * 5. CONTRADICTION_ESCAPE_HATCH is present in every continuation prompt
+ * 6. Continuation prompt does NOT contain "constitution", "acceptance criteria", "story"
+ *    (i.e. it is minimal — not the full prompt)
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildReviewRectificationContinuation } from "../../../../src/pipeline/stages/autofix-continuation";
+import type { ReviewCheckResult } from "../../../../src/review/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCheck(check: string, output: string, exitCode = 1): ReviewCheckResult {
+  return {
+    check: check as ReviewCheckResult["check"],
+    success: false,
+    command: `${check}-cmd`,
+    exitCode,
+    output,
+    durationMs: 100,
+  };
+}
+
+function makeCheckWithFindings(check: string, output: string): ReviewCheckResult {
+  return {
+    ...makeCheck(check, output),
+    findings: [
+      {
+        ruleId: "semantic",
+        severity: "error",
+        file: "src/foo.ts",
+        line: 42,
+        message: "Missing implementation for AC-1",
+        source: "semantic-review",
+      },
+    ],
+  };
+}
+
+const DEFAULTS = {
+  attempt: 1,
+  rethinkAtAttempt: 2,
+  urgencyAtAttempt: 3,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildReviewRectificationContinuation", () => {
+  test("contains opening signal that this is a follow-up attempt", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("lint", "Unexpected token at line 10")],
+      ...Object.values(DEFAULTS) as [number, number, number],
+    );
+
+    expect(prompt).toContain("Your previous fix attempt did not resolve all issues");
+  });
+
+  test("contains error output from failedChecks", () => {
+    const checks = [
+      makeCheck("lint", "error TS2345: Argument of type 'string' is not assignable"),
+      makeCheck("typecheck", "src/index.ts(10,3): error TS2304: Cannot find name 'foo'"),
+    ];
+
+    const prompt = buildReviewRectificationContinuation(
+      checks,
+      ...Object.values(DEFAULTS) as [number, number, number],
+    );
+
+    expect(prompt).toContain("error TS2345: Argument of type 'string' is not assignable");
+    expect(prompt).toContain("src/index.ts(10,3): error TS2304: Cannot find name 'foo'");
+  });
+
+  test("contains check name and exit code in section header", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("lint", "some lint error", 2)],
+      ...Object.values(DEFAULTS) as [number, number, number],
+    );
+
+    expect(prompt).toContain("### lint (exit 2)");
+  });
+
+  test("contains structured findings when present", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheckWithFindings("semantic", "Semantic review failed")],
+      ...Object.values(DEFAULTS) as [number, number, number],
+    );
+
+    expect(prompt).toContain("Structured findings:");
+    expect(prompt).toContain("[error] src/foo.ts:42 — Missing implementation for AC-1");
+  });
+
+  test("does NOT include findings section when findings are absent", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("lint", "some lint error")],
+      ...Object.values(DEFAULTS) as [number, number, number],
+    );
+
+    expect(prompt).not.toContain("Structured findings:");
+  });
+
+  test("does NOT include rethink preamble before rethinkAtAttempt", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("lint", "error")],
+      1, // attempt 1 — below rethinkAtAttempt (2)
+      2,
+      3,
+    );
+
+    expect(prompt).not.toContain("Rethink your approach");
+  });
+
+  test("includes rethink preamble at rethinkAtAttempt", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("lint", "error")],
+      2, // attempt == rethinkAtAttempt
+      2,
+      3,
+    );
+
+    expect(prompt).toContain("Rethink your approach");
+  });
+
+  test("includes rethink preamble after rethinkAtAttempt", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("lint", "error")],
+      3, // attempt > rethinkAtAttempt
+      2,
+      3,
+    );
+
+    expect(prompt).toContain("Rethink your approach");
+  });
+
+  test("does NOT include urgency preamble before urgencyAtAttempt", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("lint", "error")],
+      1, // attempt 1 — below urgencyAtAttempt (3)
+      2,
+      3,
+    );
+
+    expect(prompt).not.toContain("URGENT");
+  });
+
+  test("includes urgency preamble at urgencyAtAttempt", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("lint", "error")],
+      3, // attempt == urgencyAtAttempt
+      2,
+      3,
+    );
+
+    expect(prompt).toContain("URGENT");
+    expect(prompt).toContain("final attempt");
+  });
+
+  test("CONTRADICTION_ESCAPE_HATCH is present in every continuation prompt", () => {
+    const attempts = [1, 2, 3];
+    for (const attempt of attempts) {
+      const prompt = buildReviewRectificationContinuation(
+        [makeCheck("lint", "error")],
+        attempt,
+        2,
+        3,
+      );
+      // The escape hatch instructs the agent to emit UNRESOLVED: when findings conflict
+      expect(prompt).toContain("UNRESOLVED:");
+    }
+  });
+
+  test("continuation prompt does NOT contain constitution", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("lint", "error")],
+      ...Object.values(DEFAULTS) as [number, number, number],
+    );
+
+    expect(prompt.toLowerCase()).not.toContain("constitution");
+  });
+
+  test("continuation prompt does NOT contain 'acceptance criteria' section header", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("semantic", "AC-1 missing")],
+      ...Object.values(DEFAULTS) as [number, number, number],
+    );
+
+    // Should not have the full AC list or the "Acceptance Criteria" section found in full prompts
+    expect(prompt.toLowerCase()).not.toContain("acceptance criteria");
+  });
+
+  test("continuation prompt does NOT contain story title section", () => {
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("lint", "error")],
+      ...Object.values(DEFAULTS) as [number, number, number],
+    );
+
+    // Should not open with the full story context block
+    expect(prompt).not.toMatch(/^Story:/m);
+  });
+
+  test("truncates long output to 4000 chars per check", () => {
+    const longOutput = "z".repeat(10_000);
+    const prompt = buildReviewRectificationContinuation(
+      [makeCheck("lint", longOutput)],
+      ...Object.values(DEFAULTS) as [number, number, number],
+    );
+
+    // The truncated output slice should not contain the full 10000 chars
+    const zCount = (prompt.match(/z/g) ?? []).length;
+    expect(zCount).toBeLessThanOrEqual(4000);
+    // And the original 10000 chars were cut down
+    expect(zCount).toBeLessThan(10_000);
+  });
+
+  test("handles multiple failed checks", () => {
+    const checks = [
+      makeCheck("lint", "lint error output"),
+      makeCheck("typecheck", "typecheck error output"),
+      makeCheck("semantic", "semantic error output"),
+    ];
+
+    const prompt = buildReviewRectificationContinuation(
+      checks,
+      ...Object.values(DEFAULTS) as [number, number, number],
+    );
+
+    expect(prompt).toContain("### lint");
+    expect(prompt).toContain("### typecheck");
+    expect(prompt).toContain("### semantic");
+  });
+});

--- a/test/unit/pipeline/stages/autofix-session-wiring.test.ts
+++ b/test/unit/pipeline/stages/autofix-session-wiring.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for PROMPT-001: autofix session continuity wiring.
+ *
+ * Verifies that runAgentRectification passes the correct acpSessionName and
+ * keepSessionOpen values to agent.run(), and that continuation prompts are
+ * used on retry when the session is confirmed open.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { buildSessionName } from "../../../../src/agents/acp/adapter";
+import { DEFAULT_CONFIG } from "../../../../src/config";
+import { _autofixDeps } from "../../../../src/pipeline/stages/autofix";
+import type { PipelineContext } from "../../../../src/pipeline/types";
+import type { ReviewCheckResult } from "../../../../src/review/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKDIR = "/tmp/test-wd";
+const FEATURE = "my-feature";
+const STORY_ID = "US-001";
+
+function makeFailedCheck(check = "lint"): ReviewCheckResult {
+  return {
+    check: check as ReviewCheckResult["check"],
+    success: false,
+    command: `${check}-cmd`,
+    exitCode: 1,
+    output: `${check} error output`,
+    durationMs: 100,
+  };
+}
+
+function makeCtxWithAgent(
+  mockAgent: { run: ReturnType<typeof mock> },
+  autofixMaxAttempts = 1,
+): PipelineContext {
+  return {
+    config: {
+      ...DEFAULT_CONFIG,
+      quality: {
+        ...DEFAULT_CONFIG.quality,
+        autofix: { enabled: true, maxAttempts: autofixMaxAttempts },
+      },
+    } as any,
+    prd: { feature: FEATURE, stories: [] } as any,
+    story: { id: STORY_ID, title: "t", status: "in-progress", acceptanceCriteria: [] } as any,
+    stories: [],
+    routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
+    rootConfig: DEFAULT_CONFIG,
+    workdir: WORKDIR,
+    projectDir: WORKDIR,
+    hooks: {} as any,
+    reviewResult: {
+      success: false,
+      checks: [makeFailedCheck("lint")],
+      totalDurationMs: 100,
+    },
+    agentGetFn: () => mockAgent as any,
+  } as PipelineContext;
+}
+
+function makeMockAgent(succeed = true) {
+  return {
+    run: mock(async () => ({
+      success: succeed,
+      output: "",
+      exitCode: succeed ? 0 : 1,
+      durationMs: 100,
+      estimatedCost: 0,
+    })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("autofix session wiring (PROMPT-001)", () => {
+  test("agent.run() receives acpSessionName matching buildSessionName(..., 'implementer')", async () => {
+    const agent = makeMockAgent(true);
+    const ctx = makeCtxWithAgent(agent, 1);
+
+    const saved = {
+      recheckReview: _autofixDeps.recheckReview,
+    };
+    _autofixDeps.recheckReview = async () => true;
+
+    try {
+      await _autofixDeps.runAgentRectification(ctx, undefined, undefined, WORKDIR);
+    } finally {
+      _autofixDeps.recheckReview = saved.recheckReview;
+    }
+
+    expect(agent.run).toHaveBeenCalledTimes(1);
+    const runOpts = (agent.run.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
+    const expected = buildSessionName(WORKDIR, FEATURE, STORY_ID, "implementer");
+    expect(runOpts.acpSessionName).toBe(expected);
+  });
+
+  test("keepSessionOpen: false when maxAttempts=1 (single attempt is last attempt)", async () => {
+    const agent = makeMockAgent(true);
+    const ctx = makeCtxWithAgent(agent, 1);
+
+    const saved = { recheckReview: _autofixDeps.recheckReview };
+    _autofixDeps.recheckReview = async () => true;
+
+    try {
+      await _autofixDeps.runAgentRectification(ctx, undefined, undefined, WORKDIR);
+    } finally {
+      _autofixDeps.recheckReview = saved.recheckReview;
+    }
+
+    expect(agent.run).toHaveBeenCalledTimes(1);
+    const runOpts = (agent.run.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
+    expect(runOpts.keepSessionOpen).toBe(false);
+  });
+
+  test("keepSessionOpen: true on non-last attempt, false on last attempt", async () => {
+    const agent = makeMockAgent(false); // always fail so loop runs maxAttempts
+    const ctx = makeCtxWithAgent(agent, 2);
+    // Update review result after each attempt to keep failing
+    ctx.reviewResult = { success: false, checks: [makeFailedCheck("lint")], totalDurationMs: 100 };
+
+    const saved = { recheckReview: _autofixDeps.recheckReview };
+    _autofixDeps.recheckReview = async () => false; // always fail
+
+    try {
+      await _autofixDeps.runAgentRectification(ctx, undefined, undefined, WORKDIR);
+    } finally {
+      _autofixDeps.recheckReview = saved.recheckReview;
+    }
+
+    expect(agent.run).toHaveBeenCalledTimes(2);
+
+    const firstCallOpts = (agent.run.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
+    expect(firstCallOpts.keepSessionOpen).toBe(true); // attempt 0, not last
+
+    const secondCallOpts = (agent.run.mock.calls as unknown[][])[1][0] as Record<string, unknown>;
+    expect(secondCallOpts.keepSessionOpen).toBe(false); // attempt 1 == maxAttempts-1, is last
+  });
+
+  test("attempt 2 uses continuation prompt (shorter, no 'Story:' section header)", async () => {
+    const agent = makeMockAgent(false);
+    const ctx = makeCtxWithAgent(agent, 2);
+    ctx.reviewResult = { success: false, checks: [makeFailedCheck("lint")], totalDurationMs: 100 };
+
+    const saved = { recheckReview: _autofixDeps.recheckReview };
+    _autofixDeps.recheckReview = async () => false;
+
+    try {
+      await _autofixDeps.runAgentRectification(ctx, undefined, undefined, WORKDIR);
+    } finally {
+      _autofixDeps.recheckReview = saved.recheckReview;
+    }
+
+    expect(agent.run).toHaveBeenCalledTimes(2);
+
+    const firstPrompt = ((agent.run.mock.calls as unknown[][])[0][0] as Record<string, unknown>).prompt as string;
+    const secondPrompt = ((agent.run.mock.calls as unknown[][])[1][0] as Record<string, unknown>).prompt as string;
+
+    // First prompt is the full rectification prompt (not a continuation opener)
+    expect(firstPrompt).not.toContain("Your previous fix attempt did not resolve all issues");
+    // Second prompt is the continuation — opens with the follow-up signal
+    expect(secondPrompt).toContain("Your previous fix attempt did not resolve all issues");
+    // Continuation does not include the story section header present in the full prompt
+    expect(secondPrompt).not.toMatch(/^## Story/m);
+  });
+
+  test("sessionRole is 'implementer' on all attempts", async () => {
+    const agent = makeMockAgent(false);
+    const ctx = makeCtxWithAgent(agent, 2);
+    ctx.reviewResult = { success: false, checks: [makeFailedCheck("lint")], totalDurationMs: 100 };
+
+    const saved = { recheckReview: _autofixDeps.recheckReview };
+    _autofixDeps.recheckReview = async () => false;
+
+    try {
+      await _autofixDeps.runAgentRectification(ctx, undefined, undefined, WORKDIR);
+    } finally {
+      _autofixDeps.recheckReview = saved.recheckReview;
+    }
+
+    for (const call of agent.run.mock.calls as unknown[][]) {
+      const opts = call[0] as Record<string, unknown>;
+      expect(opts.sessionRole).toBe("implementer");
+    }
+  });
+});

--- a/test/unit/pipeline/stages/autofix.test.ts
+++ b/test/unit/pipeline/stages/autofix.test.ts
@@ -366,7 +366,7 @@ describe("autofixStage", () => {
     expect(prompts).toHaveLength(2);
     expect(prompts[0]).not.toContain("Rethink your approach");
     expect(prompts[1]).toContain("Rethink your approach");
-    expect(prompts[1]).toContain("Final Autofix Attempt Before Escalation");
+    expect(prompts[1]).toContain("URGENT");
   });
 
   test("injects urgency and rethink when urgencyAtAttempt is reached", async () => {
@@ -402,7 +402,7 @@ describe("autofixStage", () => {
     expect(prompts).toHaveLength(2);
     expect(prompts[0]).not.toContain("Rethink your approach");
     expect(prompts[1]).toContain("Rethink your approach");
-    expect(prompts[1]).toContain("Final Autofix Attempt Before Escalation");
+    expect(prompts[1]).toContain("URGENT");
   });
 
   test("uses default rethink and urgency thresholds when autofix escalation config is not set", async () => {
@@ -439,6 +439,6 @@ describe("autofixStage", () => {
     expect(prompts[0]).not.toContain("Rethink your approach");
     expect(prompts[0]).not.toContain("Final Autofix Attempt Before Escalation");
     expect(prompts[1]).toContain("Rethink your approach");
-    expect(prompts[1]).toContain("Final Autofix Attempt Before Escalation");
+    expect(prompts[1]).toContain("URGENT");
   });
 });

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -915,14 +915,14 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
     expect(runOpts.acpSessionName).toBe(expectedSession);
   });
 
-  test("agent.run() receives keepSessionOpen: false", async () => {
+  test("agent.run() receives keepSessionOpen: true (session stays alive for autofix)", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
     expect(agent.run).toHaveBeenCalled();
     const runOpts = (agent.run as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
-    expect(runOpts.keepSessionOpen).toBe(false);
+    expect(runOpts.keepSessionOpen).toBe(true);
   });
 
   test("acpSessionName encodes workdir hash in session name", async () => {


### PR DESCRIPTION
## Summary

- Wires the continuous implementer session into the two fix loops that were missing it (`autofix.ts`, `rectification-loop.ts`), so the agent that wrote the code also fixes it with full conversation history
- Adds a **continuation prompt** for autofix retries — sends only the delta (new error output + escalation preamble) instead of rebuilding the full prompt, cutting input tokens ~60-70% per retry
- Amends `semantic.ts` `keepSessionOpen: false` → `true` so the session survives into autofix when review fails

Closes #400

## What changed

**Phase 0 — Session wiring (pure plumbing)**

| File | Change |
|:-----|:-------|
| `src/review/semantic.ts` | `keepSessionOpen: false` → `true` |
| `src/verification/rectification-loop.ts` | Add `acpSessionName` + `keepSessionOpen: !isLastAttempt`; hoist `buildSessionName` above loop |
| `src/pipeline/stages/autofix.ts` | Add `acpSessionName`, `keepSessionOpen: !isLastAttempt`, `sessionConfirmedOpen` tracking |

**Phase 1 — Continuation prompt**

| File | Change |
|:-----|:-------|
| `src/pipeline/stages/autofix-continuation.ts` *(new)* | `buildReviewRectificationContinuation()` — delta-only prompt for attempt ≥ 2 |
| `src/pipeline/stages/autofix-prompts.ts` | Export `CONTRADICTION_ESCAPE_HATCH` for reuse |
| `src/pipeline/stages/autofix.ts` | Use continuation prompt on attempt ≥ 2 when session confirmed open; apply `Math.min(urgencyAtAttempt, maxAttempts)` capping |

**Tests**

| File | Change |
|:-----|:-------|
| `test/unit/pipeline/stages/autofix-continuation.test.ts` *(new)* | 16 unit tests for continuation builder |
| `test/unit/pipeline/stages/autofix-session-wiring.test.ts` *(new)* | 5 tests: `acpSessionName` value, `keepSessionOpen` toggle, continuation routing, `sessionRole` |
| `test/unit/pipeline/stages/autofix.test.ts` | Update escalation assertions for `prompts[1]` to match continuation wording |
| `test/unit/review/semantic.test.ts` | Update `keepSessionOpen` assertion to `true` |

## Session flow after this PR

```
execution          → keepSessionOpen: true
TDD rectification  → keepSessionOpen: !isLastAttempt  (already working)
semantic review    → keepSessionOpen: true             (amended ← this PR)
autofix attempt 1  → full prompt,        keepSessionOpen: true
autofix attempt 2+ → continuation prompt, keepSessionOpen: !isLastAttempt
verification rect  → keepSessionOpen: !isLastAttempt  (← this PR)
story completion   → sweepFeatureSessions() closes session
```

## Test plan

- [x] `bun run typecheck` — clean (pre-commit hook passed)
- [x] `bun run lint` — clean (pre-commit hook passed)
- [x] `bun run test` — **6595 pass, 54 skip, 0 fail** across 334 files
- [x] `autofix-continuation.test.ts` — 16/16 pass (prompt content, rethink/urgency thresholds, truncation indicator, CONTRADICTION_ESCAPE_HATCH)
- [x] `autofix-session-wiring.test.ts` — 5/5 pass (`acpSessionName`, `keepSessionOpen` toggle, continuation routing, `sessionRole`)
- [x] `semantic.test.ts` — updated `keepSessionOpen: true` assertion passes
- [x] Code review addressed: CRITICAL (failing test), HIGH (attempt guard off-by-one, session wiring tests), MEDIUM (session name hoist, truncation indicator, urgency capping)

## Known pre-existing issue (not introduced by this PR)

`autofix.ts` is 498 lines, exceeding the 400-line hard limit. The file was already ~470 lines before this PR. Extracting `runAgentRectification` into its own file is tracked separately.