### PR TITLE
[codex] Standardize configured model resolution

### DIFF
--- a/src/acceptance/fix-diagnosis.ts
+++ b/src/acceptance/fix-diagnosis.ts
@@ -7,8 +7,8 @@
 
 import { buildSessionName } from "../agents/acp/adapter";
 import type { AgentAdapter } from "../agents/types";
-import type { NaxConfig } from "../config/schema";
-import { resolveConfiguredModel } from "../config/schema-types";
+import type { NaxConfig } from "../config";
+import { resolveConfiguredModel } from "../config";
 import { AcceptancePromptBuilder, MAX_FILE_LINES } from "../prompts";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { DiagnosisResult, SemanticVerdict } from "./types";
@@ -99,7 +99,7 @@ export async function diagnoseAcceptanceFailure(
     const result = await agent.run({
       prompt,
       workdir,
-      modelTier: resolvedModel.modelTier,
+      modelTier: resolvedModel.modelTier ?? "fast",
       modelDef: resolvedModel.modelDef,
       timeoutSeconds,
       sessionRole: "diagnose",
@@ -107,7 +107,7 @@ export async function diagnoseAcceptanceFailure(
       featureName,
       storyId,
       config,
-    } as Parameters<AgentAdapter["run"]>[0]);
+    });
 
     const diagnosis = parseDiagnosisResult(result.output);
     if (diagnosis) {

--- a/src/acceptance/fix-diagnosis.ts
+++ b/src/acceptance/fix-diagnosis.ts
@@ -8,7 +8,7 @@
 import { buildSessionName } from "../agents/acp/adapter";
 import type { AgentAdapter } from "../agents/types";
 import type { NaxConfig } from "../config/schema";
-import { type ModelTier, resolveModelForAgent } from "../config/schema-types";
+import { resolveConfiguredModel } from "../config/schema-types";
 import { AcceptancePromptBuilder, MAX_FILE_LINES } from "../prompts";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { DiagnosisResult, SemanticVerdict } from "./types";
@@ -73,11 +73,10 @@ export async function diagnoseAcceptanceFailure(
 
   const sessionName = buildSessionName(workdir, featureName, storyId, "diagnose");
 
-  const diagnoseModelTier = config.acceptance.fix.diagnoseModel;
-  const modelDef = resolveModelForAgent(
+  const resolvedModel = resolveConfiguredModel(
     config.models,
     config.autoMode.defaultAgent,
-    diagnoseModelTier as ModelTier,
+    config.acceptance.fix.diagnoseModel,
     config.autoMode.defaultAgent,
   );
 
@@ -100,8 +99,8 @@ export async function diagnoseAcceptanceFailure(
     const result = await agent.run({
       prompt,
       workdir,
-      modelTier: undefined as unknown as "fast" | "balanced" | "powerful",
-      modelDef,
+      modelTier: resolvedModel.modelTier,
+      modelDef: resolvedModel.modelDef,
       timeoutSeconds,
       sessionRole: "diagnose",
       acpSessionName: sessionName,

--- a/src/acceptance/fix-executor.ts
+++ b/src/acceptance/fix-executor.ts
@@ -7,8 +7,8 @@
 
 import { buildSessionName } from "../agents/acp/adapter";
 import type { AgentAdapter, AgentRunOptions } from "../agents/types";
-import type { NaxConfig } from "../config/schema";
-import { resolveConfiguredModel } from "../config/schema-types";
+import type { NaxConfig } from "../config";
+import { resolveConfiguredModel } from "../config";
 import { AcceptancePromptBuilder } from "../prompts";
 import type { DiagnosisResult } from "./types";
 

--- a/src/acceptance/fix-executor.ts
+++ b/src/acceptance/fix-executor.ts
@@ -8,8 +8,7 @@
 import { buildSessionName } from "../agents/acp/adapter";
 import type { AgentAdapter, AgentRunOptions } from "../agents/types";
 import type { NaxConfig } from "../config/schema";
-import type { ModelTier } from "../config/schema-types";
-import { resolveModelForAgent } from "../config/schema-types";
+import { resolveConfiguredModel } from "../config/schema-types";
 import { AcceptancePromptBuilder } from "../prompts";
 import type { DiagnosisResult } from "./types";
 
@@ -39,7 +38,7 @@ export async function executeSourceFix(
 
   const { config, workdir, featureName, storyId } = options;
 
-  const modelDef = resolveModelForAgent(
+  const resolvedModel = resolveConfiguredModel(
     config.models,
     config.autoMode.defaultAgent,
     config.acceptance.fix.fixModel,
@@ -60,8 +59,8 @@ export async function executeSourceFix(
   const runOptions: AgentRunOptions = {
     prompt,
     workdir,
-    modelTier: undefined as unknown as ModelTier,
-    modelDef,
+    modelTier: resolvedModel.modelTier ?? "balanced",
+    modelDef: resolvedModel.modelDef,
     timeoutSeconds,
     sessionRole: "source-fix",
     acpSessionName: sessionName,
@@ -110,7 +109,7 @@ export async function executeTestFix(
 
   const { config, workdir, featureName, storyId } = options;
 
-  const modelDef = resolveModelForAgent(
+  const resolvedModel = resolveConfiguredModel(
     config.models,
     config.autoMode.defaultAgent,
     config.acceptance.fix.fixModel,
@@ -133,8 +132,8 @@ export async function executeTestFix(
   const runOptions: AgentRunOptions = {
     prompt,
     workdir,
-    modelTier: undefined as unknown as ModelTier,
-    modelDef,
+    modelTier: resolvedModel.modelTier ?? "balanced",
+    modelDef: resolvedModel.modelDef,
     timeoutSeconds,
     sessionRole: "test-fix",
     acpSessionName: sessionName,

--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -7,6 +7,7 @@
 
 import { join } from "node:path";
 import { createAgentRegistry } from "../agents/registry";
+import { resolveConfiguredModel } from "../config";
 import type { AgentAdapter } from "../agents/types";
 import { getLogger } from "../logger";
 import type { UserStory } from "../prd/types";
@@ -77,8 +78,14 @@ export const _generatorPRDDeps = {
       const config = options?.config;
       if (!config) throw new Error("Acceptance generator adapter requires config");
 
-      const adapter = createAgentRegistry(config).getAgent(config.autoMode.defaultAgent);
-      if (!adapter) throw new Error(`Agent "${config.autoMode.defaultAgent}" not found`);
+      const resolvedModel = resolveConfiguredModel(
+        config.models,
+        config.autoMode.defaultAgent,
+        config.acceptance?.model ?? "fast",
+        config.autoMode.defaultAgent,
+      );
+      const adapter = createAgentRegistry(config).getAgent(resolvedModel.agent);
+      if (!adapter) throw new Error(`Agent "${resolvedModel.agent}" not found`);
 
       return adapter.complete(...args);
     },

--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -7,8 +7,8 @@
 
 import { join } from "node:path";
 import { createAgentRegistry } from "../agents/registry";
-import { resolveConfiguredModel } from "../config";
 import type { AgentAdapter } from "../agents/types";
+import { resolveConfiguredModel } from "../config";
 import { getLogger } from "../logger";
 import type { UserStory } from "../prd/types";
 import { AcceptancePromptBuilder } from "../prompts/builders/acceptance-builder";

--- a/src/acceptance/hardening.ts
+++ b/src/acceptance/hardening.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AgentAdapter } from "../agents/types";
-import { type ModelDef, resolveModelForAgent } from "../config";
+import { type ModelDef, resolveConfiguredModel } from "../config";
 import type { NaxConfig } from "../config";
 import { getSafeLogger } from "../logger";
 import { savePRD } from "../prd";
@@ -95,13 +95,16 @@ export async function runHardeningPass(ctx: HardeningContext): Promise<Hardening
 
     // 4. Resolve model
     let modelDef: ModelDef;
+    let modelTier = "fast";
     try {
-      modelDef = resolveModelForAgent(
+      const resolvedModel = resolveConfiguredModel(
         ctx.config.models,
         ctx.config.autoMode?.defaultAgent ?? "claude",
         ctx.config.acceptance?.model ?? "fast",
         ctx.config.autoMode?.defaultAgent ?? "claude",
       );
+      modelDef = resolvedModel.modelDef;
+      modelTier = resolvedModel.modelTier ?? "fast";
     } catch {
       modelDef = { provider: "anthropic", model: "claude-haiku-4-5-20251001" };
     }
@@ -112,7 +115,7 @@ export async function runHardeningPass(ctx: HardeningContext): Promise<Hardening
       workdir: ctx.workdir,
       featureDir: ctx.featureDir,
       codebaseContext: "",
-      modelTier: ctx.config.acceptance?.model ?? "fast",
+      modelTier,
       modelDef,
       config: ctx.config,
       language,

--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -7,7 +7,7 @@
 
 import type { AgentAdapter } from "../agents";
 import { createAgentRegistry } from "../agents/registry";
-import { resolveModelForAgent } from "../config";
+import { resolveConfiguredModel } from "../config";
 import { getLogger } from "../logger";
 import { AcceptancePromptBuilder } from "../prompts";
 import { errorMessage } from "../utils/errors";
@@ -27,8 +27,14 @@ export const _refineDeps = {
       const config = options?.config;
       if (!config) throw new Error("Refinement adapter requires config");
 
-      const adapter = createAgentRegistry(config).getAgent(config.autoMode.defaultAgent);
-      if (!adapter) throw new Error(`Agent "${config.autoMode.defaultAgent}" not found`);
+      const resolvedModel = resolveConfiguredModel(
+        config.models,
+        config.autoMode.defaultAgent,
+        config.acceptance?.model ?? "fast",
+        config.autoMode.defaultAgent,
+      );
+      const adapter = createAgentRegistry(config).getAgent(resolvedModel.agent);
+      if (!adapter) throw new Error(`Agent "${resolvedModel.agent}" not found`);
 
       return adapter.complete(...args);
     },
@@ -95,11 +101,10 @@ export async function refineAcceptanceCriteria(criteria: string[], context: Refi
   } = context;
   const logger = getLogger();
 
-  const modelTier = config.acceptance?.model ?? "fast";
-  const modelDef = resolveModelForAgent(
+  const resolvedModel = resolveConfiguredModel(
     config.models,
     config.autoMode.defaultAgent,
-    modelTier,
+    config.acceptance?.model ?? "fast",
     config.autoMode.defaultAgent,
   );
   const prompt = new AcceptancePromptBuilder().buildRefinementPrompt(criteria, codebaseContext, {
@@ -115,7 +120,7 @@ export async function refineAcceptanceCriteria(criteria: string[], context: Refi
     const completeResult = await _refineDeps.adapter.complete(prompt, {
       jsonMode: true,
       maxTokens: 4096,
-      model: modelDef.model,
+      model: resolvedModel.modelDef.model,
       config,
       featureName,
       storyId,

--- a/src/analyze/index.ts
+++ b/src/analyze/index.ts
@@ -1,15 +1,8 @@
 /**
  * Analyze Module
  *
- * LLM-enhanced story classification with codebase scanning.
+ * Codebase scanning utilities used by planning.
  */
 
-export type {
-  CodebaseScan,
-  StoryClassification,
-  ClassifierResponse,
-  ClassificationMethod,
-  ClassificationResult,
-} from "./types";
-
+export type { CodebaseScan } from "./types";
 export { scanCodebase } from "./scanner";

--- a/src/analyze/types.ts
+++ b/src/analyze/types.ts
@@ -1,10 +1,8 @@
 /**
  * Analyze Module Types
  *
- * Types for codebase scanning and LLM-enhanced classification.
+ * Types for codebase scanning used by planning.
  */
-
-import type { Complexity } from "../config";
 
 /** Codebase scan result */
 export interface CodebaseScan {
@@ -16,36 +14,4 @@ export interface CodebaseScan {
   devDependencies: Record<string, string>;
   /** Detected test patterns */
   testPatterns: string[];
-}
-
-/** LLM classification result for a single story */
-export interface StoryClassification {
-  /** Story ID (e.g., "US-001") */
-  storyId: string;
-  /** Classified complexity */
-  complexity: Complexity;
-  /** Context files to inject into agent prompt before execution */
-  contextFiles: string[];
-  /** Reasoning for the classification */
-  reasoning: string;
-  /** Estimated lines of code to change */
-  estimatedLOC: number;
-  /** Potential implementation risks */
-  risks: string[];
-}
-
-/** LLM classifier response (array of classifications) */
-export type ClassifierResponse = StoryClassification[];
-
-/** Classification method used */
-export type ClassificationMethod = "llm" | "keyword-fallback";
-
-/** Classification result with metadata */
-export interface ClassificationResult {
-  /** Classification data */
-  classifications: StoryClassification[];
-  /** Method used (llm or keyword-fallback) */
-  method: ClassificationMethod;
-  /** Error message if LLM failed and fallback was used */
-  fallbackReason?: string;
 }

--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -165,7 +165,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "acceptance.command":
     "Override command to run acceptance tests. Use {{FILE}} as placeholder for the test file path (default: 'bun test {{FILE}} --timeout=60000')",
   "acceptance.model":
-    'Model selector for acceptance generation/refinement LLM calls. Accepts a tier string or an explicit object like { agent: "codex", model: "gpt-5.4" }. Default: "fast".',
+    'Model selector for acceptance generation/refinement LLM calls. Accepts a tier string such as "fast", "balanced", or "powerful", or an explicit object like { agent: "codex", model: "gpt-5.4" }. Default: "fast".',
   "acceptance.refinement":
     "Enable acceptance criteria refinement step before execution (default: true). Disable to skip refinement and use generated criteria as-is.",
   "acceptance.timeoutMs": "Timeout for acceptance test generation in milliseconds (default: 1800000 = 30 min)",

--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -125,14 +125,6 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "constitution.maxTokens": "Maximum tokens allowed for constitution content",
   "constitution.skipGlobal": "Skip loading global constitution",
 
-  // Analyze
-  analyze: "Feature analysis settings",
-  "analyze.llmEnhanced": "Enable LLM-enhanced analysis",
-  "analyze.model":
-    'Model selector for decompose and classify. Accepts a tier string or an explicit object like { agent: "codex", model: "gpt-5.4" }.',
-  "analyze.fallbackToKeywords": "Fall back to keyword matching on LLM failure",
-  "analyze.maxCodebaseSummaryTokens": "Max tokens for codebase summary",
-
   // Review
   review: "Review phase configuration",
   "review.enabled": "Enable review phase",

--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -49,7 +49,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "routing.adaptive.costThreshold": "Cost threshold for strategy switching (0-1)",
   "routing.adaptive.fallbackStrategy": "Fallback strategy if adaptive fails",
   "routing.llm": "LLM-based routing settings",
-  "routing.llm.model": "Model tier for routing decisions",
+  "routing.llm.model":
+    'Model selector for routing decisions. Accepts a tier string (for example "fast") or an explicit object like { agent: "codex", model: "gpt-5.4" }.',
   "routing.llm.fallbackToKeywords": "Fall back to keyword routing on LLM failure",
   "routing.llm.cacheDecisions": "Cache routing decisions per story ID",
   "routing.llm.mode": "Routing mode: one-shot | per-story | hybrid",
@@ -127,7 +128,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   // Analyze
   analyze: "Feature analysis settings",
   "analyze.llmEnhanced": "Enable LLM-enhanced analysis",
-  "analyze.model": "Model tier for decompose and classify",
+  "analyze.model":
+    'Model selector for decompose and classify. Accepts a tier string or an explicit object like { agent: "codex", model: "gpt-5.4" }.',
   "analyze.fallbackToKeywords": "Fall back to keyword matching on LLM failure",
   "analyze.maxCodebaseSummaryTokens": "Max tokens for codebase summary",
 
@@ -150,7 +152,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
 
   // Plan
   plan: "Planning phase configuration",
-  "plan.model": "Model tier for planning",
+  "plan.model":
+    'Model selector for planning. Accepts a tier string or an explicit object like { agent: "codex", model: "gpt-5.4" }.',
   "plan.outputPath": "Output path for generated spec (relative to nax/)",
 
   // Acceptance
@@ -162,7 +165,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "acceptance.command":
     "Override command to run acceptance tests. Use {{FILE}} as placeholder for the test file path (default: 'bun test {{FILE}} --timeout=60000')",
   "acceptance.model":
-    "Model tier for acceptance generation/refinement LLM calls (fast | balanced | powerful). Default: fast.",
+    'Model selector for acceptance generation/refinement LLM calls. Accepts a tier string or an explicit object like { agent: "codex", model: "gpt-5.4" }. Default: "fast".',
   "acceptance.refinement":
     "Enable acceptance criteria refinement step before execution (default: true). Disable to skip refinement and use generated criteria as-is.",
   "acceptance.timeoutMs": "Timeout for acceptance test generation in milliseconds (default: 1800000 = 30 min)",

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -41,13 +41,21 @@ import { mapDecomposedStoriesToUserStories } from "../prd/decompose-mapper";
 import { validatePlanOutput } from "../prd/schema";
 import type { PRD, StoryStatus, UserStory } from "../prd/types";
 import type { PrecheckResultWithCode } from "../precheck";
+import { errorMessage } from "../utils/errors";
 
 const DEFAULT_TIMEOUT_SECONDS = 600;
 
 function resolvePlanModelSelection(config: NaxConfig, preferredAgent: string) {
   const selection = config.plan?.model ?? "balanced";
   const defaultAgent = config.autoMode?.defaultAgent ?? preferredAgent;
-  return resolveConfiguredModel(config.models ?? DEFAULT_CONFIG.models, preferredAgent, selection, defaultAgent);
+  try {
+    return resolveConfiguredModel(config.models ?? DEFAULT_CONFIG.models, preferredAgent, selection, defaultAgent);
+  } catch (err) {
+    getLogger()?.warn("plan", "Failed to resolve plan model from config, falling back to defaults", {
+      error: errorMessage(err),
+    });
+    return resolveConfiguredModel(DEFAULT_CONFIG.models, preferredAgent, "balanced", defaultAgent);
+  }
 }
 // ─────────────────────────────────────────────────────────────────────────────
 // Dependency injection (_planDeps) — override in tests

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -19,6 +19,7 @@ import type { AgentAdapter } from "../agents/types";
 import { scanCodebase } from "../analyze/scanner";
 import type { CodebaseScan } from "../analyze/types";
 import type { NaxConfig } from "../config";
+import { DEFAULT_CONFIG, resolveConfiguredModel } from "../config";
 import { resolvePermissions } from "../config/permissions";
 import type { ProjectProfile } from "../config/runtime-types";
 import {
@@ -42,6 +43,12 @@ import type { PRD, StoryStatus, UserStory } from "../prd/types";
 import type { PrecheckResultWithCode } from "../precheck";
 
 const DEFAULT_TIMEOUT_SECONDS = 600;
+
+function resolvePlanModelSelection(config: NaxConfig, preferredAgent: string) {
+  const selection = config.plan?.model ?? "balanced";
+  const defaultAgent = config.autoMode?.defaultAgent ?? preferredAgent;
+  return resolveConfiguredModel(config.models ?? DEFAULT_CONFIG.models, preferredAgent, selection, defaultAgent);
+}
 // ─────────────────────────────────────────────────────────────────────────────
 // Dependency injection (_planDeps) — override in tests
 // ─────────────────────────────────────────────────────────────────────────────
@@ -162,7 +169,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
   const outputPath = join(outputDir, "prd.json");
   await _planDeps.mkdirp(outputDir);
 
-  const agentName = config?.autoMode?.defaultAgent ?? "claude";
+  const defaultAgentName = config?.autoMode?.defaultAgent ?? "claude";
 
   // Timeout: from plan config, or DEFAULT_TIMEOUT_SECONDS
   const timeoutSeconds = config?.plan?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
@@ -237,25 +244,15 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
     );
     const prompt = `${autoTaskCtx}\n\n${autoOutputFmt}`;
 
+    const resolvedPlanModel = resolvePlanModelSelection(config, defaultAgentName);
+    const agentName = resolvedPlanModel.agent;
     const adapter = _planDeps.getAgent(agentName, config);
     if (!adapter) throw new Error(`[plan] No agent adapter found for '${agentName}'`);
-
-    let autoModel: string | undefined;
-    try {
-      const planTier = config?.plan?.model ?? "balanced";
-      const { resolveModelForAgent } = await import("../config/schema");
-      if (config?.models) {
-        const defaultAgent = config.autoMode?.defaultAgent ?? "claude";
-        autoModel = resolveModelForAgent(config.models, defaultAgent, planTier, defaultAgent).model;
-      }
-    } catch {
-      // fall through — adapter will use its own fallback
-    }
 
     if (isAcp) {
       logger?.info("plan", "Starting ACP auto planning session", {
         agent: agentName,
-        model: autoModel ?? config?.plan?.model ?? "balanced",
+        model: resolvedPlanModel.modelDef.model,
         workdir,
         feature: options.feature,
         timeoutSeconds,
@@ -270,7 +267,8 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
             interactive: false,
             timeoutSeconds,
             config,
-            modelTier: config?.plan?.model ?? "balanced",
+            modelTier: resolvedPlanModel.modelTier,
+            modelDef: resolvedPlanModel.modelDef,
             dangerouslySkipPermissions: resolvePermissions(config, "plan").skipPermissions,
             maxInteractionTurns: config?.agent?.maxInteractionTurns,
             featureName: options.feature,
@@ -305,7 +303,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
       // CLI: one-shot complete() — simple and fast, no session overhead
       const timeoutMs = (config?.plan?.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS) * 1000;
       const completeResult = await adapter.complete(prompt, {
-        model: autoModel,
+        model: resolvedPlanModel.modelDef.model,
         jsonMode: true,
         workdir,
         config,
@@ -341,6 +339,8 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
       config?.project,
     );
     const prompt = `${interactiveTaskCtx}\n\n${interactiveOutputFmt}`;
+    const resolvedPlanModel = resolvePlanModelSelection(config, defaultAgentName);
+    const agentName = resolvedPlanModel.agent;
     const adapter = _planDeps.getAgent(agentName, config);
     if (!adapter) throw new Error(`[plan] No agent adapter found for '${agentName}'`);
     // Use configured interaction plugin (telegram/webhook/auto) if available;
@@ -356,10 +356,9 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
     const interactionBridge = configuredBridge ?? _planDeps.createInteractionBridge();
     const pidRegistry = new PidRegistry(workdir);
     const resolvedPerm = resolvePermissions(config, "plan");
-    const resolvedModel = config?.plan?.model ?? "balanced";
     logger?.info("plan", "Starting interactive planning session", {
       agent: agentName,
-      model: resolvedModel,
+      model: resolvedPlanModel.modelDef.model,
       permission: resolvedPerm.mode,
       workdir,
       feature: options.feature,
@@ -376,7 +375,8 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
           timeoutSeconds,
           interactionBridge,
           config,
-          modelTier: resolvedModel,
+          modelTier: resolvedPlanModel.modelTier,
+          modelDef: resolvedPlanModel.modelDef,
           dangerouslySkipPermissions: resolvedPerm.skipPermissions,
           maxInteractionTurns: config?.agent?.maxInteractionTurns,
           featureName: options.feature,
@@ -784,7 +784,9 @@ export async function planDecomposeCommand(
 
   const siblings = prd.userStories.filter((s) => s.id !== options.storyId);
 
-  const agentName = config?.autoMode?.defaultAgent ?? "claude";
+  const defaultAgentName = config?.autoMode?.defaultAgent ?? "claude";
+  const resolvedPlanModel = resolvePlanModelSelection(config, defaultAgentName);
+  const agentName = resolvedPlanModel.agent;
   const adapter = _planDeps.getAgent(agentName, config);
   if (!adapter) throw new Error(`[decompose] No agent adapter found for '${agentName}'`);
 
@@ -792,17 +794,7 @@ export async function planDecomposeCommand(
   const maxAcCount = config?.precheck?.storySizeGate?.maxAcCount ?? Number.POSITIVE_INFINITY;
   const maxReplanAttempts = config?.precheck?.storySizeGate?.maxReplanAttempts ?? 3;
 
-  let decomposeModelDef: import("../config").ModelDef | undefined;
-  try {
-    const decomposeTier = config?.plan?.model ?? "balanced";
-    const { resolveModelForAgent } = await import("../config/schema");
-    if (config?.models) {
-      const defaultAgent = config.autoMode?.defaultAgent ?? "claude";
-      decomposeModelDef = resolveModelForAgent(config.models, agentName, decomposeTier, defaultAgent);
-    }
-  } catch {
-    // fall through — adapter will use its own fallback
-  }
+  const decomposeModelDef: import("../config").ModelDef | undefined = resolvedPlanModel.modelDef;
 
   if (typeof (adapter as { decompose?: unknown }).decompose !== "function") {
     throw new NaxError(

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -16,6 +16,7 @@ export type {
   ModelDef,
   ModelEntry,
   ModelMap,
+  ResolvedConfiguredModel,
   AutoModeConfig,
   ExecutionConfig,
   QualityConfig,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -24,7 +24,14 @@ export type {
   RectificationConfig,
   ProjectProfile,
 } from "./schema";
-export { DEFAULT_CONFIG, resolveModel, resolveModelForAgent, NaxConfigSchema, AcceptanceConfigSchema } from "./schema";
+export {
+  DEFAULT_CONFIG,
+  resolveConfiguredModel,
+  resolveModel,
+  resolveModelForAgent,
+  NaxConfigSchema,
+  AcceptanceConfigSchema,
+} from "./schema";
 export { loadConfig, findProjectDir, globalConfigPath } from "./loader";
 export { validateConfig, type ValidationResult } from "./validate"; // @deprecated: Use NaxConfigSchema.safeParse() instead
 export { validateDirectory, validateFilePath, isWithinDirectory, MAX_DIRECTORY_DEPTH } from "./path-security";

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -16,6 +16,8 @@ export type {
   ModelDef,
   ModelEntry,
   ModelMap,
+  ConfiguredModel,
+  ConfiguredModelObject,
   ResolvedConfiguredModel,
   AutoModeConfig,
   ExecutionConfig,

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -238,18 +238,6 @@ export interface TddConfig {
 // Re-exported from constitution/types.ts to maintain single source of truth
 export type { ConstitutionConfig } from "../constitution/types";
 
-/** Analyze config */
-export interface AnalyzeConfig {
-  /** Enable LLM-enhanced analysis */
-  llmEnhanced: boolean;
-  /** Model selector for decompose+classify (tier string or explicit { agent, model }) */
-  model: ConfiguredModel;
-  /** Fall back to keyword matching on LLM failure */
-  fallbackToKeywords: boolean;
-  /** Max tokens for codebase summary */
-  maxCodebaseSummaryTokens: number;
-}
-
 // Re-exported from review/types.ts to maintain single source of truth
 export type { AdversarialReviewConfig, ReviewConfig } from "../review/types";
 
@@ -528,8 +516,6 @@ export interface NaxConfig {
   tdd: TddConfig;
   /** Constitution settings */
   constitution: ConstitutionConfig;
-  /** Analyze settings */
-  analyze: AnalyzeConfig;
   /** Review settings */
   review: ReviewConfig;
   /** Plan settings */

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -9,6 +9,7 @@ import type { ConstitutionConfig } from "../constitution/types";
 import type { ReviewConfig } from "../review/types";
 import type {
   Complexity,
+  ConfiguredModel,
   LlmRoutingMode,
   ModelTier,
   ModelsConfig,
@@ -241,8 +242,8 @@ export type { ConstitutionConfig } from "../constitution/types";
 export interface AnalyzeConfig {
   /** Enable LLM-enhanced analysis */
   llmEnhanced: boolean;
-  /** Model tier for decompose+classify (default: balanced) */
-  model: ModelTier;
+  /** Model selector for decompose+classify (tier string or explicit { agent, model }) */
+  model: ConfiguredModel;
   /** Fall back to keyword matching on LLM failure */
   fallbackToKeywords: boolean;
   /** Max tokens for codebase summary */
@@ -254,8 +255,8 @@ export type { AdversarialReviewConfig, ReviewConfig } from "../review/types";
 
 /** Plan config */
 export interface PlanConfig {
-  /** Model tier for planning (default: balanced) */
-  model: ModelTier;
+  /** Model selector for planning (tier string or explicit { agent, model }) */
+  model: ConfiguredModel;
   /** Output path for generated spec (relative to nax/ directory) */
   outputPath: string;
   /** Timeout for plan sessions in seconds (default: 600) */
@@ -269,10 +270,10 @@ export type AcceptanceTestStrategy = "unit" | "component" | "cli" | "e2e" | "sna
 
 /** Acceptance fix config (US-001) */
 export interface AcceptanceFixConfig {
-  /** Model tier for diagnosis (default: "fast") */
-  diagnoseModel: string;
-  /** Model tier for fix implementation (default: "balanced") */
-  fixModel: string;
+  /** Model selector for diagnosis (tier string or explicit { agent, model }) */
+  diagnoseModel: ConfiguredModel;
+  /** Model selector for fix implementation (tier string or explicit { agent, model }) */
+  fixModel: ConfiguredModel;
   /** Fix strategy (default: "diagnose-first") */
   strategy: "diagnose-first" | "implement-only";
   /** @deprecated Ignored — outer loop controls retries via acceptance.maxRetries. Kept for backward compat. */
@@ -289,8 +290,8 @@ export interface AcceptanceConfig {
   generateTests: boolean;
   /** Path to acceptance test file (relative to feature directory) */
   testPath: string;
-  /** Model tier for AC refinement LLM calls (default: "fast") */
-  model: ModelTier;
+  /** Model selector for AC refinement/generation calls (tier string or explicit { agent, model }) */
+  model: ConfiguredModel;
   /** Whether to LLM-refine acceptance criteria before generating tests (default: true) */
   refinement: boolean;
   /** Max concurrent refinement LLM calls (default: 3) */
@@ -429,8 +430,8 @@ export interface AdaptiveRoutingConfig {
 
 /** LLM routing config */
 export interface LlmRoutingConfig {
-  /** Model tier for routing call (default: "fast") */
-  model?: string;
+  /** Model selector for routing call (tier string or explicit { agent, model }) */
+  model?: ConfiguredModel;
   /** Fall back to keyword strategy on LLM failure (default: true) */
   fallbackToKeywords?: boolean;
   /** Max input tokens for story context (default: 2000) */

--- a/src/config/schema-types.ts
+++ b/src/config/schema-types.ts
@@ -28,6 +28,19 @@ export type ModelEntry = ModelDef | string;
 export type ModelMap = Record<ModelTier, ModelEntry>;
 export type ModelsConfig = Record<string, Record<ModelTier, ModelEntry>>;
 
+export interface ConfiguredModelObject {
+  agent: string;
+  model: string;
+}
+
+export type ConfiguredModel = ModelTier | ConfiguredModelObject;
+
+export interface ResolvedConfiguredModel {
+  agent: string;
+  modelDef: ModelDef;
+  modelTier?: ModelTier;
+}
+
 export interface TierConfig {
   tier: string;
   attempts: number;
@@ -37,6 +50,63 @@ export interface TierConfig {
 export type RoutingStrategyName = "keyword" | "llm" | "manual" | "adaptive" | "custom";
 
 export type LlmRoutingMode = "one-shot" | "per-story" | "hybrid";
+
+/** Common model shorthand aliases → tier mapping for config and debate convenience. */
+export const MODEL_SHORTHAND_TIERS: Record<string, ModelTier> = {
+  haiku: "fast",
+  sonnet: "balanced",
+  opus: "powerful",
+};
+
+export function isBuiltinModelTier(value: string): value is "fast" | "balanced" | "powerful" {
+  return value === "fast" || value === "balanced" || value === "powerful";
+}
+
+/**
+ * Resolve a config-level model selector into an effective agent + model definition.
+ *
+ * String selectors are always treated as tier labels and resolved through config.models.
+ * Object selectors use the embedded agent and interpret `model` as:
+ * - shorthand alias (haiku/sonnet/opus) -> mapped tier via config.models
+ * - builtin tier (fast/balanced/powerful) -> resolved via config.models
+ * - otherwise -> raw model id via resolveModel()
+ */
+export function resolveConfiguredModel(
+  models: ModelsConfig,
+  preferredAgent: string,
+  selection: ConfiguredModel,
+  defaultAgent: string,
+): ResolvedConfiguredModel {
+  if (typeof selection === "string") {
+    return {
+      agent: preferredAgent,
+      modelDef: resolveModelForAgent(models, preferredAgent, selection, defaultAgent),
+      modelTier: selection,
+    };
+  }
+
+  const aliasedTier = MODEL_SHORTHAND_TIERS[selection.model.toLowerCase()];
+  if (aliasedTier) {
+    return {
+      agent: selection.agent,
+      modelDef: resolveModelForAgent(models, selection.agent, aliasedTier, defaultAgent),
+      modelTier: aliasedTier,
+    };
+  }
+
+  if (isBuiltinModelTier(selection.model)) {
+    return {
+      agent: selection.agent,
+      modelDef: resolveModelForAgent(models, selection.agent, selection.model, defaultAgent),
+      modelTier: selection.model,
+    };
+  }
+
+  return {
+    agent: selection.agent,
+    modelDef: resolveModel(selection.model),
+  };
+}
 
 /** Resolve the correct ModelEntry for a given agent and tier, with defaultAgent fallback */
 export function resolveModelForAgent(

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -21,6 +21,8 @@ export type {
 // Types and resolveModel
 export type {
   Complexity,
+  ConfiguredModel,
+  ConfiguredModelObject,
   TestStrategy,
   TddStrategy,
   EscalationEntry,
@@ -29,6 +31,7 @@ export type {
   ModelDef,
   ModelEntry,
   ModelMap,
+  ResolvedConfiguredModel,
   TierConfig,
   AutoModeConfig,
   RectificationConfig,
@@ -63,7 +66,7 @@ export type {
   ProjectProfile,
 } from "./types";
 
-export { resolveModel, resolveModelForAgent } from "./types";
+export { MODEL_SHORTHAND_TIERS, isBuiltinModelTier, resolveConfiguredModel, resolveModel, resolveModelForAgent } from "./types";
 
 // Zod schemas
 export { NaxConfigSchema, AcceptanceConfigSchema } from "./schemas";

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -40,7 +40,6 @@ export type {
   QualityConfig,
   TddConfig,
   ConstitutionConfig,
-  AnalyzeConfig,
   ReviewConfig,
   PlanConfig,
   AcceptanceConfig,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -66,7 +66,13 @@ export type {
   ProjectProfile,
 } from "./types";
 
-export { MODEL_SHORTHAND_TIERS, isBuiltinModelTier, resolveConfiguredModel, resolveModel, resolveModelForAgent } from "./types";
+export {
+  MODEL_SHORTHAND_TIERS,
+  isBuiltinModelTier,
+  resolveConfiguredModel,
+  resolveModel,
+  resolveModelForAgent,
+} from "./types";
 
 // Zod schemas
 export { NaxConfigSchema, AcceptanceConfigSchema } from "./schemas";

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -43,6 +43,11 @@ const ModelMapSchema = z.preprocess((val) => {
 }, PerAgentModelMapSchema);
 
 const ModelTierSchema = z.string().min(1, "Tier name must be non-empty");
+const ConfiguredModelObjectSchema = z.object({
+  agent: z.string().min(1, "agent must be non-empty"),
+  model: z.string().min(1, "model must be non-empty"),
+});
+const ConfiguredModelSchema = z.union([ModelTierSchema, ConfiguredModelObjectSchema]);
 
 const TierConfigSchema = z.object({
   tier: z.string().min(1, "Tier name must be non-empty"),
@@ -268,7 +273,7 @@ const ConstitutionConfigSchema = z.object({
 
 const AnalyzeConfigSchema = z.object({
   llmEnhanced: z.boolean(),
-  model: ModelTierSchema,
+  model: ConfiguredModelSchema,
   fallbackToKeywords: z.boolean(),
   maxCodebaseSummaryTokens: z.number().int().positive(),
 });
@@ -361,7 +366,7 @@ const ReviewConfigSchema = z.object({
 });
 
 const PlanConfigSchema = z.object({
-  model: ModelTierSchema,
+  model: ConfiguredModelSchema,
   outputPath: z.string().min(1, "plan.outputPath must be non-empty"),
   timeoutSeconds: z.number().int().positive().default(600),
   /** Override timeout for decompose calls in seconds. Defaults to plan.timeoutSeconds. */
@@ -369,8 +374,8 @@ const PlanConfigSchema = z.object({
 });
 
 const AcceptanceFixConfigSchema = z.object({
-  diagnoseModel: z.string().min(1, "acceptance.fix.diagnoseModel must be non-empty").default("fast"),
-  fixModel: z.string().min(1, "acceptance.fix.fixModel must be non-empty").default("balanced"),
+  diagnoseModel: ConfiguredModelSchema.default("fast"),
+  fixModel: ConfiguredModelSchema.default("balanced"),
   strategy: z.enum(["diagnose-first", "implement-only"]).default("diagnose-first"),
   maxRetries: z.number().int().nonnegative().default(2),
 });
@@ -381,7 +386,7 @@ export const AcceptanceConfigSchema = z.object({
   generateTests: z.boolean(),
   testPath: z.string().min(1, "acceptance.testPath must be non-empty"),
   command: z.string().optional(),
-  model: z.enum(["fast", "balanced", "powerful"]).default("fast"),
+  model: ConfiguredModelSchema.default("fast"),
   refinement: z.boolean().default(true),
   refinementConcurrency: z.number().int().min(1).max(10).default(3),
   redGate: z.boolean().default(true),
@@ -425,7 +430,7 @@ const ContextConfigSchema = z.object({
 });
 
 const LlmRoutingConfigSchema = z.object({
-  model: z.string().optional(),
+  model: ConfiguredModelSchema.optional(),
   fallbackToKeywords: z.boolean().optional(),
   cacheDecisions: z.boolean().optional(),
   mode: z.enum(["one-shot", "per-story", "hybrid"]).optional(),

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -271,13 +271,6 @@ const ConstitutionConfigSchema = z.object({
   skipGlobal: z.boolean().optional(),
 });
 
-const AnalyzeConfigSchema = z.object({
-  llmEnhanced: z.boolean(),
-  model: ConfiguredModelSchema,
-  fallbackToKeywords: z.boolean(),
-  maxCodebaseSummaryTokens: z.number().int().positive(),
-});
-
 const SemanticReviewConfigSchema = z.object({
   modelTier: ModelTierSchema.default("balanced"),
   /**
@@ -765,12 +758,6 @@ export const NaxConfigSchema = z
       enabled: true,
       path: "constitution.md",
       maxTokens: 2000,
-    }),
-    analyze: AnalyzeConfigSchema.default({
-      llmEnhanced: true,
-      model: "balanced",
-      fallbackToKeywords: true,
-      maxCodebaseSummaryTokens: 5000,
     }),
     review: ReviewConfigSchema.default({
       enabled: true,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -47,7 +47,6 @@ export type {
   AcceptanceConfig,
   AcceptanceFixConfig,
   AcceptanceTestStrategy,
-  AnalyzeConfig,
   AutoModeConfig,
   ConstitutionConfig,
   ContextAutoDetectConfig,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -23,7 +23,13 @@ export type {
   TierConfig,
   TokenPricing,
 } from "./schema-types";
-export { MODEL_SHORTHAND_TIERS, isBuiltinModelTier, resolveConfiguredModel, resolveModel, resolveModelForAgent } from "./schema-types";
+export {
+  MODEL_SHORTHAND_TIERS,
+  isBuiltinModelTier,
+  resolveConfiguredModel,
+  resolveModel,
+  resolveModelForAgent,
+} from "./schema-types";
 
 // Debate types
 export type {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -8,19 +8,22 @@
 // Schema types
 export type {
   Complexity,
+  ConfiguredModel,
+  ConfiguredModelObject,
   LlmRoutingMode,
   ModelDef,
   ModelEntry,
   ModelMap,
   ModelsConfig,
   ModelTier,
+  ResolvedConfiguredModel,
   RoutingStrategyName,
   TddStrategy,
   TestStrategy,
   TierConfig,
   TokenPricing,
 } from "./schema-types";
-export { resolveModel, resolveModelForAgent } from "./schema-types";
+export { MODEL_SHORTHAND_TIERS, isBuiltinModelTier, resolveConfiguredModel, resolveModel, resolveModelForAgent } from "./schema-types";
 
 // Debate types
 export type {

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -1,7 +1,7 @@
 import { buildSessionName } from "../agents/acp/adapter";
 import { createAgentRegistry, getAgent } from "../agents/registry";
 import type { AgentAdapter, CompleteOptions, CompleteResult } from "../agents/types";
-import type { ModelTier, NaxConfig } from "../config";
+import type { ModelTier, NaxConfig, ResolvedConfiguredModel } from "../config";
 import { DEFAULT_CONFIG, resolveConfiguredModel, resolveModelForAgent } from "../config";
 import type { PipelineStage } from "../config/permissions";
 import type { ModelDef } from "../config/schema-types";
@@ -160,7 +160,12 @@ export function resolveModelDefForDebater(debater: Debater, tier: ModelTier, con
   const configDefaultAgent = config?.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent;
 
   try {
-    return resolveConfiguredModel(configModels, debater.agent, { agent: debater.agent, model: debater.model ?? tier }, configDefaultAgent).modelDef;
+    return resolveConfiguredModel(
+      configModels,
+      debater.agent,
+      { agent: debater.agent, model: debater.model ?? tier },
+      configDefaultAgent,
+    ).modelDef;
   } catch {
     // Fall through to secondary fallback strategies.
   }
@@ -293,15 +298,22 @@ export async function resolveOutcome(
     const agentName = resolverConfig.agent ?? RESOLVER_FALLBACK_AGENT;
     const adapter = _debateSessionDeps.getAgent(agentName, config);
     if (adapter) {
+      const configModels = config?.models ?? DEFAULT_CONFIG.models;
+      const configDefaultAgent = config?.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent;
       const synthesisSessionName =
         workdir !== undefined ? buildSessionName(workdir, featureName, storyId, "synthesis") : undefined;
       const resolverDebater: Debater = { agent: agentName, model: resolverConfig.model };
-      const resolvedResolverModel = resolveConfiguredModel(
-        config.models ?? DEFAULT_CONFIG.models,
-        agentName,
-        { agent: agentName, model: resolverConfig.model ?? "fast" },
-        config.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent,
-      );
+      const resolverSelection = { agent: agentName, model: resolverConfig.model ?? "fast" };
+      let resolvedResolverModel: ResolvedConfiguredModel;
+      try {
+        resolvedResolverModel = resolveConfiguredModel(configModels, agentName, resolverSelection, configDefaultAgent);
+      } catch {
+        resolvedResolverModel = {
+          agent: agentName,
+          modelDef: { provider: "unknown", model: resolverSelection.model } as ModelDef,
+          modelTier: modelTierFromDebater(resolverDebater),
+        };
+      }
       const resolverTier = resolvedResolverModel.modelTier ?? modelTierFromDebater(resolverDebater);
       const resolverResult = await synthesisResolver(proposalOutputs, critiqueOutputs, {
         adapter,
@@ -330,15 +342,22 @@ export async function resolveOutcome(
 
   if (resolverConfig.type === "custom") {
     const agentName = resolverConfig.agent ?? RESOLVER_FALLBACK_AGENT;
+    const configModels = config?.models ?? DEFAULT_CONFIG.models;
+    const configDefaultAgent = config?.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent;
     const judgeSessionName =
       workdir !== undefined ? buildSessionName(workdir, featureName, storyId, "judge") : undefined;
     const resolverDebater: Debater = { agent: agentName, model: resolverConfig.model };
-    const resolvedResolverModel = resolveConfiguredModel(
-      config.models ?? DEFAULT_CONFIG.models,
-      agentName,
-      { agent: agentName, model: resolverConfig.model ?? "fast" },
-      config.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent,
-    );
+    const resolverSelection = { agent: agentName, model: resolverConfig.model ?? "fast" };
+    let resolvedResolverModel: ResolvedConfiguredModel;
+    try {
+      resolvedResolverModel = resolveConfiguredModel(configModels, agentName, resolverSelection, configDefaultAgent);
+    } catch {
+      resolvedResolverModel = {
+        agent: agentName,
+        modelDef: { provider: "unknown", model: resolverSelection.model } as ModelDef,
+        modelTier: modelTierFromDebater(resolverDebater),
+      };
+    }
     const resolverTier = resolvedResolverModel.modelTier ?? modelTierFromDebater(resolverDebater);
     const resolverResult = await judgeResolver(proposalOutputs, critiqueOutputs, resolverConfig, {
       getAgent: (name: string) => _debateSessionDeps.getAgent(name, config),

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -2,7 +2,7 @@ import { buildSessionName } from "../agents/acp/adapter";
 import { createAgentRegistry, getAgent } from "../agents/registry";
 import type { AgentAdapter, CompleteOptions, CompleteResult } from "../agents/types";
 import type { ModelTier, NaxConfig } from "../config";
-import { DEFAULT_CONFIG, resolveModel, resolveModelForAgent } from "../config";
+import { DEFAULT_CONFIG, resolveConfiguredModel, resolveModelForAgent } from "../config";
 import type { PipelineStage } from "../config/permissions";
 import type { ModelDef } from "../config/schema-types";
 import { getSafeLogger } from "../logger";
@@ -91,12 +91,11 @@ export const _debateSessionDeps = {
 
 /** Resolve the model string for a debater. Defaults to "fast" tier; falls back to raw model string on config error. */
 export function resolveDebaterModel(debater: Debater, config: NaxConfig): string | undefined {
-  const tier = debater.model ?? "fast";
+  const modelSelection = { agent: debater.agent, model: debater.model ?? "fast" };
   if (!config?.models) return debater.model;
   try {
     const defaultAgent = config.autoMode?.defaultAgent ?? debater.agent;
-    const modelDef = resolveModelForAgent(config.models, debater.agent, tier, defaultAgent);
-    return modelDef.model;
+    return resolveConfiguredModel(config.models, debater.agent, modelSelection, defaultAgent).modelDef.model;
   } catch {
     // Config resolution failed — return raw model string as fallback (backward compat)
     return debater.model;
@@ -130,10 +129,6 @@ export function modelTierFromDebater(debater: Debater): ModelTier {
   return "fast";
 }
 
-export function isTierLabel(value: string): value is ModelTier {
-  return value === "fast" || value === "balanced" || value === "powerful";
-}
-
 export async function runComplete(
   adapter: AgentAdapter,
   prompt: string,
@@ -160,45 +155,23 @@ export function pipelineStageForDebate(stage: string): PipelineStage {
   }
 }
 
-/** Common model shorthand aliases → tier mapping for debater config convenience */
-const MODEL_SHORTHAND_TIERS: Record<string, ModelTier> = {
-  haiku: "fast",
-  sonnet: "balanced",
-  opus: "powerful",
-};
-
 export function resolveModelDefForDebater(debater: Debater, tier: ModelTier, config: NaxConfig): ModelDef {
-  const modelOverride = debater.model;
-  let effectiveTier = tier;
-  if (modelOverride) {
-    // Check alias first (haiku/sonnet/opus → fast/balanced/powerful).
-    const aliasedTier = MODEL_SHORTHAND_TIERS[modelOverride.toLowerCase()];
-    if (aliasedTier) {
-      // Shorthand alias — resolve through config.models with the mapped tier.
-      effectiveTier = aliasedTier;
-    } else if (!isTierLabel(modelOverride)) {
-      // Full model ID (e.g. "claude-haiku-4-5-20251001") — pass through directly.
-      return resolveModel(modelOverride);
-    }
-    // Explicit tier label (fast/balanced/powerful) — fall through to config-based resolution.
-  }
-
   const configModels = config?.models ?? DEFAULT_CONFIG.models;
   const configDefaultAgent = config?.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent;
 
   try {
-    return resolveModelForAgent(configModels, debater.agent, effectiveTier, configDefaultAgent);
+    return resolveConfiguredModel(configModels, debater.agent, { agent: debater.agent, model: debater.model ?? tier }, configDefaultAgent).modelDef;
   } catch {
     // Fall through to secondary fallback strategies.
   }
 
   try {
-    return resolveModelForAgent(
+    return resolveConfiguredModel(
       DEFAULT_CONFIG.models,
+      debater.agent,
+      { agent: debater.agent, model: debater.model ?? tier },
       DEFAULT_CONFIG.autoMode.defaultAgent,
-      effectiveTier,
-      DEFAULT_CONFIG.autoMode.defaultAgent,
-    );
+    ).modelDef;
   } catch {
     return resolveModelForAgent(configModels, debater.agent, "fast", configDefaultAgent);
   }
@@ -323,16 +296,19 @@ export async function resolveOutcome(
       const synthesisSessionName =
         workdir !== undefined ? buildSessionName(workdir, featureName, storyId, "synthesis") : undefined;
       const resolverDebater: Debater = { agent: agentName, model: resolverConfig.model };
-      const resolverTier: ModelTier =
-        (resolverConfig.model && MODEL_SHORTHAND_TIERS[resolverConfig.model.toLowerCase()]) ||
-        modelTierFromDebater(resolverDebater);
-      const resolverModelDef = resolveModelDefForDebater(resolverDebater, resolverTier, config);
+      const resolvedResolverModel = resolveConfiguredModel(
+        config.models ?? DEFAULT_CONFIG.models,
+        agentName,
+        { agent: agentName, model: resolverConfig.model ?? "fast" },
+        config.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent,
+      );
+      const resolverTier = resolvedResolverModel.modelTier ?? modelTierFromDebater(resolverDebater);
       const resolverResult = await synthesisResolver(proposalOutputs, critiqueOutputs, {
         adapter,
         promptSuffix,
         debaters,
         completeOptions: {
-          model: resolverModelDef.model,
+          model: resolvedResolverModel.modelDef.model,
           modelTier: resolverTier,
           config,
           storyId,
@@ -357,16 +333,19 @@ export async function resolveOutcome(
     const judgeSessionName =
       workdir !== undefined ? buildSessionName(workdir, featureName, storyId, "judge") : undefined;
     const resolverDebater: Debater = { agent: agentName, model: resolverConfig.model };
-    const resolverTier: ModelTier =
-      (resolverConfig.model && MODEL_SHORTHAND_TIERS[resolverConfig.model.toLowerCase()]) ||
-      modelTierFromDebater(resolverDebater);
-    const resolverModelDef = resolveModelDefForDebater(resolverDebater, resolverTier, config);
+    const resolvedResolverModel = resolveConfiguredModel(
+      config.models ?? DEFAULT_CONFIG.models,
+      agentName,
+      { agent: agentName, model: resolverConfig.model ?? "fast" },
+      config.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent,
+    );
+    const resolverTier = resolvedResolverModel.modelTier ?? modelTierFromDebater(resolverDebater);
     const resolverResult = await judgeResolver(proposalOutputs, critiqueOutputs, resolverConfig, {
       getAgent: (name: string) => _debateSessionDeps.getAgent(name, config),
       defaultAgentName: RESOLVER_FALLBACK_AGENT,
       debaters,
       completeOptions: {
-        model: resolverModelDef.model,
+        model: resolvedResolverModel.modelDef.model,
         modelTier: resolverTier,
         config,
         storyId,

--- a/src/execution/lifecycle/acceptance-fix.ts
+++ b/src/execution/lifecycle/acceptance-fix.ts
@@ -16,6 +16,7 @@ import { resolveAcceptanceFeatureTestPath } from "../../acceptance/test-path";
 import type { DiagnosisResult, SemanticVerdict } from "../../acceptance/types";
 import { getAgent } from "../../agents/registry";
 import type { AgentAdapter } from "../../agents/types";
+import { resolveConfiguredModel } from "../../config";
 import { getSafeLogger } from "../../logger";
 import { isTestLevelFailure } from "./acceptance-helpers";
 import type { AcceptanceLoopContext } from "./acceptance-loop";
@@ -24,6 +25,7 @@ import type { AcceptanceLoopContext } from "./acceptance-loop";
 
 export interface ResolveAcceptanceDiagnosisOptions {
   agent: AgentAdapter;
+  getAgent?: (name: string) => AgentAdapter | undefined;
   failures: { failedACs: string[]; testOutput: string };
   totalACs: number;
   strategy: "diagnose-first" | "implement-only";
@@ -89,7 +91,14 @@ export async function resolveAcceptanceDiagnosis(opts: ResolveAcceptanceDiagnosi
   }
 
   // Slow path: full LLM diagnosis with previousFailure context
-  return await diagnoseAcceptanceFailure(agent, {
+  const diagnosisAgentName = resolveConfiguredModel(
+    diagnosisOpts.config.models,
+    diagnosisOpts.config.autoMode.defaultAgent,
+    diagnosisOpts.config.acceptance.fix.diagnoseModel,
+    diagnosisOpts.config.autoMode.defaultAgent,
+  ).agent;
+  const diagnosisAgent = opts.getAgent?.(diagnosisAgentName) ?? agent;
+  return await diagnoseAcceptanceFailure(diagnosisAgent, {
     ...diagnosisOpts,
     semanticVerdicts,
     previousFailure,
@@ -132,10 +141,15 @@ export async function applyFix(opts: ApplyFixOptions): Promise<ApplyFixResult> {
   const { ctx, failures, diagnosis, previousFailure } = opts;
   const storyId = ctx.prd.userStories[0]?.id ?? "unknown";
 
-  const agentName = ctx.config.autoMode.defaultAgent;
-  const agent = (ctx.agentGetFn ?? _applyFixDeps.getAgent)(agentName);
+  const fixAgentName = resolveConfiguredModel(
+    ctx.config.models,
+    ctx.config.autoMode.defaultAgent,
+    ctx.config.acceptance.fix.fixModel,
+    ctx.config.autoMode.defaultAgent,
+  ).agent;
+  const agent = (ctx.agentGetFn ?? _applyFixDeps.getAgent)(fixAgentName);
   if (!agent) {
-    logger?.error("acceptance.applyFix", "Agent not found", { storyId, agentName });
+    logger?.error("acceptance.applyFix", "Agent not found", { storyId, agentName: fixAgentName });
     return { cost: 0 };
   }
 

--- a/src/execution/lifecycle/acceptance-loop.ts
+++ b/src/execution/lifecycle/acceptance-loop.ts
@@ -261,6 +261,7 @@ export async function runAcceptanceLoop(ctx: AcceptanceLoopContext): Promise<Acc
     const strategy = ctx.config.acceptance.fix?.strategy ?? "diagnose-first";
     const diagnosis = await resolveAcceptanceDiagnosis({
       agent,
+      getAgent: (name: string) => (ctx.agentGetFn ?? _acceptanceLoopDeps.getAgent)(name),
       failures,
       totalACs,
       strategy,

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -306,7 +306,10 @@ export const acceptanceSetupStage: PipelineStage = {
           modelDef = resolvedAcceptanceModel.modelDef;
         } else {
           const selection = ctx.config.acceptance.model ?? "fast";
-          modelDef = { provider: "unknown", model: typeof selection === "string" ? selection : selection.model } as ModelDef;
+          modelDef = {
+            provider: "unknown",
+            model: typeof selection === "string" ? selection : selection.model,
+          } as ModelDef;
         }
 
         const result = await _acceptanceSetupDeps.generate(group.stories, groupRefined, {

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -25,7 +25,7 @@ import { buildAcceptanceRunCommand } from "../../acceptance/generator";
 import { groupStoriesByPackage } from "../../acceptance/test-path";
 import type { RefinedCriterion } from "../../acceptance/types";
 import { getAgent } from "../../agents/registry";
-import { type ModelDef, resolveConfiguredModel } from "../../config";
+import { type ModelDef, type ResolvedConfiguredModel, resolveConfiguredModel } from "../../config";
 import { getSafeLogger } from "../../logger";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
@@ -225,13 +225,7 @@ export const acceptanceSetupStage: PipelineStage = {
     if (shouldGenerate) {
       totalCriteria = allCriteria.length;
 
-      let resolvedAcceptanceModel:
-        | {
-            agent: string;
-            modelDef: ModelDef;
-            modelTier?: string;
-          }
-        | undefined;
+      let resolvedAcceptanceModel: ResolvedConfiguredModel | undefined;
       try {
         resolvedAcceptanceModel = resolveConfiguredModel(
           ctx.rootConfig.models,

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -25,7 +25,7 @@ import { buildAcceptanceRunCommand } from "../../acceptance/generator";
 import { groupStoriesByPackage } from "../../acceptance/test-path";
 import type { RefinedCriterion } from "../../acceptance/types";
 import { getAgent } from "../../agents/registry";
-import { type ModelDef, resolveModelForAgent } from "../../config";
+import { type ModelDef, resolveConfiguredModel } from "../../config";
 import { getSafeLogger } from "../../logger";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
@@ -225,7 +225,25 @@ export const acceptanceSetupStage: PipelineStage = {
     if (shouldGenerate) {
       totalCriteria = allCriteria.length;
 
-      const agent = (ctx.agentGetFn ?? _acceptanceSetupDeps.getAgent)(ctx.rootConfig.autoMode.defaultAgent);
+      let resolvedAcceptanceModel:
+        | {
+            agent: string;
+            modelDef: ModelDef;
+            modelTier?: string;
+          }
+        | undefined;
+      try {
+        resolvedAcceptanceModel = resolveConfiguredModel(
+          ctx.rootConfig.models,
+          ctx.routing.agent ?? ctx.rootConfig.autoMode.defaultAgent,
+          ctx.config.acceptance.model ?? "fast",
+          ctx.rootConfig.autoMode.defaultAgent,
+        );
+      } catch {
+        resolvedAcceptanceModel = undefined;
+      }
+      const agentName = resolvedAcceptanceModel?.agent ?? ctx.rootConfig.autoMode.defaultAgent;
+      const agent = (ctx.agentGetFn ?? _acceptanceSetupDeps.getAgent)(agentName);
 
       // Refine criteria per-story (preserves storyId association for per-group filtering)
       let allRefinedCriteria: RefinedCriterion[];
@@ -284,16 +302,11 @@ export const acceptanceSetupStage: PipelineStage = {
         const groupRefined = allRefinedCriteria.filter((r) => groupStoryIds.has(r.storyId));
 
         let modelDef: ModelDef;
-        try {
-          modelDef = resolveModelForAgent(
-            ctx.rootConfig.models,
-            ctx.routing.agent ?? ctx.rootConfig.autoMode.defaultAgent,
-            ctx.config.acceptance.model ?? "fast",
-            ctx.rootConfig.autoMode.defaultAgent,
-          );
-        } catch {
-          const tier = ctx.config.acceptance.model ?? "fast";
-          modelDef = { provider: "anthropic", model: tier } as ModelDef;
+        if (resolvedAcceptanceModel) {
+          modelDef = resolvedAcceptanceModel.modelDef;
+        } else {
+          const selection = ctx.config.acceptance.model ?? "fast";
+          modelDef = { provider: "unknown", model: typeof selection === "string" ? selection : selection.model } as ModelDef;
         }
 
         const result = await _acceptanceSetupDeps.generate(group.stories, groupRefined, {
@@ -301,7 +314,7 @@ export const acceptanceSetupStage: PipelineStage = {
           workdir: packageDir,
           featureDir: ctx.featureDir,
           codebaseContext: "",
-          modelTier: ctx.config.acceptance.model ?? "fast",
+          modelTier: resolvedAcceptanceModel?.modelTier ?? "fast",
           modelDef,
           config: ctx.config,
           testStrategy: ctx.config.acceptance.testStrategy,

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -11,8 +11,9 @@
  * - `continue`: Routing determined, proceed to next stage
  */
 
-import { isGreenfieldStory } from "../../context/greenfield";
 import { resolveConfiguredModel } from "../../config";
+import { DEFAULT_CONFIG } from "../../config/defaults";
+import { isGreenfieldStory } from "../../context/greenfield";
 import { getLogger } from "../../logger";
 import { savePRD } from "../../prd";
 import { complexityToModelTier, resolveRouting } from "../../routing";
@@ -28,14 +29,11 @@ export const routingStage: PipelineStage = {
 
     const defaultRoutingAgent = ctx.config.execution?.agent ?? "claude";
     const routingModelSelection = ctx.config.routing.llm?.model ?? "fast";
+    const configModels = ctx.config.models ?? DEFAULT_CONFIG.models;
+    const configDefaultAgent = ctx.config.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent;
     const agentName =
       ctx.config.routing.strategy === "llm"
-        ? resolveConfiguredModel(
-            ctx.config.models,
-            defaultRoutingAgent,
-            routingModelSelection,
-            ctx.config.autoMode.defaultAgent,
-          ).agent
+        ? resolveConfiguredModel(configModels, defaultRoutingAgent, routingModelSelection, configDefaultAgent).agent
         : defaultRoutingAgent;
     // Only use adapter when explicitly provided via agentGetFn — prevents real LLM calls in tests
     const adapter = ctx.agentGetFn ? ctx.agentGetFn(agentName) : undefined;

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -12,6 +12,7 @@
  */
 
 import { isGreenfieldStory } from "../../context/greenfield";
+import { resolveConfiguredModel } from "../../config";
 import { getLogger } from "../../logger";
 import { savePRD } from "../../prd";
 import { complexityToModelTier, resolveRouting } from "../../routing";
@@ -25,7 +26,17 @@ export const routingStage: PipelineStage = {
   async execute(ctx: PipelineContext): Promise<StageResult> {
     const logger = getLogger();
 
-    const agentName = ctx.config.execution?.agent ?? "claude";
+    const defaultRoutingAgent = ctx.config.execution?.agent ?? "claude";
+    const routingModelSelection = ctx.config.routing.llm?.model ?? "fast";
+    const agentName =
+      ctx.config.routing.strategy === "llm"
+        ? resolveConfiguredModel(
+            ctx.config.models,
+            defaultRoutingAgent,
+            routingModelSelection,
+            ctx.config.autoMode.defaultAgent,
+          ).agent
+        : defaultRoutingAgent;
     // Only use adapter when explicitly provided via agentGetFn — prevents real LLM calls in tests
     const adapter = ctx.agentGetFn ? ctx.agentGetFn(agentName) : undefined;
 

--- a/src/routing/router.ts
+++ b/src/routing/router.ts
@@ -9,6 +9,7 @@
 import { createAgentRegistry } from "../agents/registry";
 import type { AgentAdapter } from "../agents/types";
 import type { Complexity, ModelTier, NaxConfig, TddStrategy, TestStrategy } from "../config";
+import { resolveConfiguredModel } from "../config";
 import { getSafeLogger } from "../logger";
 import type { PluginRegistry } from "../plugins/registry";
 import type { UserStory } from "../prd/types";
@@ -283,7 +284,14 @@ export async function tryLlmBatchRoute(
   // PRD wins: skip stories that already have routing set (from plan or previous run)
   const needsRouting = stories.filter((s) => !(s.routing?.complexity && s.routing?.testStrategy));
   if (needsRouting.length === 0) return;
-  const resolvedAdapter = _deps.getAgent(config.execution?.agent ?? "claude", config);
+  const preferredAgent = config.execution?.agent ?? "claude";
+  const routingAgent = resolveConfiguredModel(
+    config.models,
+    preferredAgent,
+    config.routing.llm?.model ?? "fast",
+    config.autoMode.defaultAgent,
+  ).agent;
+  const resolvedAdapter = _deps.getAgent(routingAgent, config);
   if (!resolvedAdapter) return;
 
   const logger = getSafeLogger();

--- a/src/routing/strategies/llm.ts
+++ b/src/routing/strategies/llm.ts
@@ -8,7 +8,7 @@
 
 import type { AgentAdapter } from "../../agents";
 import type { NaxConfig } from "../../config";
-import { resolveModelForAgent } from "../../config";
+import { resolveConfiguredModel } from "../../config";
 import { getLogger } from "../../logger";
 import type { UserStory } from "../../prd";
 import { OneShotPromptBuilder, type RoutingCandidate, type SchemaDescriptor } from "../../prompts";
@@ -133,18 +133,17 @@ export const _llmStrategyDeps = {
  */
 async function callLlmOnce(
   adapter: AgentAdapter,
-  modelTier: string,
+  modelSelection: string | { agent: string; model: string },
   prompt: string,
   config: NaxConfig,
   timeoutMs: number,
 ): Promise<string> {
-  const modelDef = resolveModelForAgent(
+  const resolvedModel = resolveConfiguredModel(
     config.models,
-    config.autoMode.defaultAgent,
-    modelTier,
+    adapter.name,
+    modelSelection,
     config.autoMode.defaultAgent,
   );
-  const modelArg = modelDef.model;
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
@@ -154,7 +153,7 @@ async function callLlmOnce(
   });
   timeoutPromise.catch(() => {});
 
-  const outputPromise = adapter.complete(prompt, { model: modelArg, config });
+  const outputPromise = adapter.complete(prompt, { model: resolvedModel.modelDef.model, config });
 
   try {
     const result = await Promise.race([outputPromise, timeoutPromise]);
@@ -170,7 +169,12 @@ async function callLlmOnce(
 /**
  * Call LLM via adapter.complete() with timeout and retry (BUG-033).
  */
-async function callLlm(adapter: AgentAdapter, modelTier: string, prompt: string, config: NaxConfig): Promise<string> {
+async function callLlm(
+  adapter: AgentAdapter,
+  modelSelection: string | { agent: string; model: string },
+  prompt: string,
+  config: NaxConfig,
+): Promise<string> {
   const llmConfig = config.routing.llm;
   const timeoutMs = llmConfig?.timeoutMs ?? 30000;
   const maxRetries = llmConfig?.retries ?? 1;
@@ -180,7 +184,7 @@ async function callLlm(adapter: AgentAdapter, modelTier: string, prompt: string,
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      return await callLlmOnce(adapter, modelTier, prompt, config, timeoutMs);
+      return await callLlmOnce(adapter, modelSelection, prompt, config, timeoutMs);
     } catch (err) {
       lastError = err as Error;
       if (attempt < maxRetries) {
@@ -216,11 +220,11 @@ export async function routeBatch(stories: UserStory[], context: RoutingContext):
     throw new Error("No agent adapter available for batch routing (AA-003)");
   }
 
-  const modelTier = llmConfig.model ?? "fast";
+  const modelSelection = llmConfig.model ?? "fast";
   const prompt = await buildBatchRoutingPromptAsync(stories);
 
   try {
-    const output = await callLlm(adapter, modelTier, prompt, config);
+    const output = await callLlm(adapter, modelSelection, prompt, config);
     const decisions = parseBatchResponse(output, stories, config);
 
     if (llmConfig.cacheDecisions) {
@@ -292,12 +296,12 @@ export async function classifyWithLlm(
     throw new Error("No agent adapter available for LLM routing (AA-003)");
   }
 
-  const modelTier = llmConfig.model ?? "fast";
+  const modelSelection = llmConfig.model ?? "fast";
   const prompt = await buildRoutingPromptAsync(story);
 
   let decision: RoutingDecision;
   try {
-    const output = await callLlm(effectiveAdapter, modelTier, prompt, config);
+    const output = await callLlm(effectiveAdapter, modelSelection, prompt, config);
     decision = parseRoutingResponse(output, story, config);
   } catch (err) {
     if (llmConfig.fallbackToKeywords) {

--- a/src/routing/strategies/llm.ts
+++ b/src/routing/strategies/llm.ts
@@ -7,7 +7,7 @@
  */
 
 import type { AgentAdapter } from "../../agents";
-import type { NaxConfig } from "../../config";
+import type { ConfiguredModel, NaxConfig } from "../../config";
 import { resolveConfiguredModel } from "../../config";
 import { getLogger } from "../../logger";
 import type { UserStory } from "../../prd";
@@ -133,7 +133,7 @@ export const _llmStrategyDeps = {
  */
 async function callLlmOnce(
   adapter: AgentAdapter,
-  modelSelection: string | { agent: string; model: string },
+  modelSelection: ConfiguredModel,
   prompt: string,
   config: NaxConfig,
   timeoutMs: number,
@@ -171,7 +171,7 @@ async function callLlmOnce(
  */
 async function callLlm(
   adapter: AgentAdapter,
-  modelSelection: string | { agent: string; model: string },
+  modelSelection: ConfiguredModel,
   prompt: string,
   config: NaxConfig,
 ): Promise<string> {

--- a/test/integration/cli/cli-config.test.ts
+++ b/test/integration/cli/cli-config.test.ts
@@ -397,17 +397,6 @@ describe("Config Command", () => {
       expect(output).toContain("path:");
     });
 
-    test("covers analyze section", async () => {
-      const config = await loadConfig(tempDir);
-      await configCommand(config, { explain: true });
-
-      const output = consoleOutput.join("\n");
-
-      expect(output).toContain("analyze:");
-      expect(output).toContain("llmEnhanced:");
-      expect(output).toContain("model:");
-    });
-
     test("covers review section", async () => {
       const config = await loadConfig(tempDir);
       await configCommand(config, { explain: true });
@@ -1345,7 +1334,6 @@ describe("nax config (default view) - edge cases", () => {
     expect(parsed).toHaveProperty("quality");
     expect(parsed).toHaveProperty("tdd");
     expect(parsed).toHaveProperty("constitution");
-    expect(parsed).toHaveProperty("analyze");
     expect(parsed).toHaveProperty("review");
     expect(parsed).toHaveProperty("plan");
     expect(parsed).toHaveProperty("acceptance");

--- a/test/unit/acceptance/fix-diagnosis.test.ts
+++ b/test/unit/acceptance/fix-diagnosis.test.ts
@@ -230,7 +230,7 @@ describe("AC-4: diagnoseAcceptanceFailure resolves diagnoseModel via resolveMode
     expect(runCall.modelDef).toEqual(expectedModelDef);
   });
 
-  test("never passes raw tier name to adapter — always resolved via resolveModelForAgent", async () => {
+  test("passes resolved model metadata to adapter rather than a raw unresolved tier string", async () => {
     const mockAgent = makeMockAgentAdapter();
     const config = makeMinimalConfig();
     await diagnoseAcceptanceFailure(mockAgent, {
@@ -242,7 +242,7 @@ describe("AC-4: diagnoseAcceptanceFailure resolves diagnoseModel via resolveMode
       storyId: "US-001",
     });
     const runCall = getRunMockCalls(mockAgent)[0][0];
-    expect(runCall.modelTier).toBeUndefined();
+    expect(runCall.modelTier).toBe("fast");
     expect(runCall.modelDef.provider).toBeDefined();
     expect(runCall.modelDef.model).toBeDefined();
   });

--- a/test/unit/acceptance/fix-executor.test.ts
+++ b/test/unit/acceptance/fix-executor.test.ts
@@ -304,7 +304,7 @@ describe("AC-4: executeSourceFix resolves fixModel via resolveModelForAgent", ()
     expect(runCall.modelDef).toEqual(expectedModelDef);
   });
 
-  test("never passes raw tier name to adapter — always resolved via resolveModelForAgent", async () => {
+  test("passes resolved model metadata to adapter rather than a raw unresolved tier string", async () => {
     const mockAgent = makeMockAgentAdapter();
     const config = makeMinimalConfig();
     await executeSourceFix(mockAgent, {
@@ -318,7 +318,7 @@ describe("AC-4: executeSourceFix resolves fixModel via resolveModelForAgent", ()
       acceptanceTestPath: "/tmp/test/acceptance.test.ts",
     });
     const runCall = getRunMockCalls(mockAgent)[0][0];
-    expect(runCall.modelTier).toBeUndefined();
+    expect(runCall.modelTier).toBe("balanced");
     expect(runCall.modelDef.provider).toBeDefined();
     expect(runCall.modelDef.model).toBeDefined();
   });

--- a/test/unit/cli/plan.test.ts
+++ b/test/unit/cli/plan.test.ts
@@ -11,6 +11,7 @@ import { mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _planDeps, buildPlanningPrompt, planCommand } from "../../../src/cli/plan";
+import { DEFAULT_CONFIG } from "../../../src/config";
 import type { PRD } from "../../../src/prd/types";
 import { makeTempDir } from "../../helpers/temp";
 
@@ -177,6 +178,50 @@ describe("planCommand", () => {
     const prompt = capturedCompleteArgs[0];
     expect(prompt).toContain("Codebase");
     expect(prompt).toContain("express");
+  });
+
+  test("uses explicit plan model selector to choose adapter and raw model id", async () => {
+    let receivedAgentName: string | undefined;
+    let receivedModel: string | undefined;
+
+    _planDeps.getAgent = mock((name: string) => {
+      receivedAgentName = name;
+      return {
+        complete: mock(async (_prompt: string, options?: { model?: string }) => {
+          receivedModel = options?.model;
+          return JSON.stringify(SAMPLE_PRD);
+        }),
+      } as ReturnType<typeof makeFakeAdapter> as never;
+    });
+
+    const config = {
+      ...DEFAULT_CONFIG,
+      agent: {
+        ...DEFAULT_CONFIG.agent,
+        protocol: "cli",
+      },
+      models: {
+        ...DEFAULT_CONFIG.models,
+        codex: {
+          fast: { provider: "openai", model: "gpt-5.4-mini" },
+          balanced: { provider: "openai", model: "gpt-5.4" },
+          powerful: { provider: "openai", model: "gpt-5.5" },
+        },
+      },
+      plan: {
+        ...DEFAULT_CONFIG.plan,
+        model: { agent: "codex", model: "gpt-5.3-codex" },
+      },
+    } as const;
+
+    await planCommand(tmpDir, config as never, {
+      from: "/spec.md",
+      feature: "url-shortener",
+      auto: true,
+    });
+
+    expect(receivedAgentName).toBe("codex");
+    expect(receivedModel).toBe("gpt-5.3-codex");
   });
 
   test("AC-2: prompt includes output schema with prd.json structure", async () => {

--- a/test/unit/config/schema-types.test.ts
+++ b/test/unit/config/schema-types.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, test } from "bun:test";
 import type { ModelsConfig, ModelTier } from "../../../src/config/schema-types";
-import { resolveModelForAgent } from "../../../src/config/schema-types";
+import { resolveConfiguredModel, resolveModelForAgent } from "../../../src/config/schema-types";
 import type { TierConfig } from "../../../src/config/schema-types";
 import type { StoryRouting } from "../../../src/prd/types";
 import { NaxError } from "../../../src/errors";
@@ -171,5 +171,51 @@ describe("resolveModelForAgent", () => {
 
   test("throws NaxError when defaultAgent itself is missing", () => {
     expect(() => resolveModelForAgent(models, "unknown-agent", "fast", "no-such-default")).toThrow(NaxError);
+  });
+});
+
+describe("resolveConfiguredModel", () => {
+  const models: ModelsConfig = {
+    claude: {
+      fast: "claude-haiku-4-5",
+      balanced: "claude-sonnet-4-5",
+      powerful: "claude-opus-4-5",
+    },
+    codex: {
+      fast: { provider: "openai", model: "gpt-5.4-mini" },
+      balanced: { provider: "openai", model: "gpt-5.4" },
+    },
+  };
+
+  test("resolves string selectors via resolveModelForAgent using the preferred agent", () => {
+    const result = resolveConfiguredModel(models, "claude", "balanced", "claude");
+
+    expect(result.agent).toBe("claude");
+    expect(result.modelTier).toBe("balanced");
+    expect(result.modelDef).toEqual({ provider: "anthropic", model: "claude-sonnet-4-5" });
+  });
+
+  test("resolves object selectors with tier labels through the object agent", () => {
+    const result = resolveConfiguredModel(models, "claude", { agent: "codex", model: "fast" }, "claude");
+
+    expect(result.agent).toBe("codex");
+    expect(result.modelTier).toBe("fast");
+    expect(result.modelDef).toEqual({ provider: "openai", model: "gpt-5.4-mini" });
+  });
+
+  test("resolves shorthand aliases to builtin tiers", () => {
+    const result = resolveConfiguredModel(models, "claude", { agent: "claude", model: "sonnet" }, "claude");
+
+    expect(result.agent).toBe("claude");
+    expect(result.modelTier).toBe("balanced");
+    expect(result.modelDef).toEqual({ provider: "anthropic", model: "claude-sonnet-4-5" });
+  });
+
+  test("passes through raw model ids from object selectors", () => {
+    const result = resolveConfiguredModel(models, "claude", { agent: "codex", model: "gpt-5.4" }, "claude");
+
+    expect(result.agent).toBe("codex");
+    expect(result.modelTier).toBeUndefined();
+    expect(result.modelDef).toEqual({ provider: "openai", model: "gpt-5.4" });
   });
 });

--- a/test/unit/config/schemas.test.ts
+++ b/test/unit/config/schemas.test.ts
@@ -331,6 +331,53 @@ describe("StorySizeGateConfigSchema — action and maxReplanAttempts (US-001)", 
   });
 });
 
+describe("configured model selector schema", () => {
+  test("accepts object form for plan.model", () => {
+    const result = NaxConfigSchema.safeParse({
+      ...(DEFAULT_CONFIG as Record<string, unknown>),
+      plan: {
+        ...(DEFAULT_CONFIG.plan as Record<string, unknown>),
+        model: { agent: "codex", model: "gpt-5.4" },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.plan.model).toEqual({ agent: "codex", model: "gpt-5.4" });
+  });
+
+  test("accepts object form for acceptance.model", () => {
+    const result = NaxConfigSchema.safeParse({
+      ...(DEFAULT_CONFIG as Record<string, unknown>),
+      acceptance: {
+        ...(DEFAULT_CONFIG.acceptance as Record<string, unknown>),
+        model: { agent: "codex", model: "fast" },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.acceptance.model).toEqual({ agent: "codex", model: "fast" });
+  });
+
+  test("accepts object form for routing.llm.model", () => {
+    const result = NaxConfigSchema.safeParse({
+      ...(DEFAULT_CONFIG as Record<string, unknown>),
+      routing: {
+        ...(DEFAULT_CONFIG.routing as Record<string, unknown>),
+        llm: {
+          ...((DEFAULT_CONFIG.routing.llm as Record<string, unknown>) ?? {}),
+          model: { agent: "claude", model: "sonnet" },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.routing.llm?.model).toEqual({ agent: "claude", model: "sonnet" });
+  });
+});
+
 describe("ModelsSchema — DEFAULT_CONFIG compatibility", () => {
   test("DEFAULT_CONFIG (legacy flat format) parses successfully after migration", () => {
     const result = NaxConfigSchema.safeParse(DEFAULT_CONFIG as Record<string, unknown>);


### PR DESCRIPTION
## What

Standardizes configured model resolution across planning, routing, acceptance, and debate-adjacent paths so tier strings and explicit `{ agent, model }` selectors are handled consistently.

## Why

The codebase had multiple model-selection paths with different semantics. Some config fields only accepted tier strings, while debate already supported richer resolution behavior. This made model selection inconsistent and caused follow-up regressions in sparse-config paths.

Closes #399

## How

Added a shared configured-model resolver and schema support for selector objects, then migrated the relevant config fields and call sites to use it.

Follow-up fixes restored fallback behavior for partial configs in debate and routing, updated acceptance fix expectations to match the new `modelTier` behavior, and closed the barrel export gap caught by pre-commit.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

This PR is opened as a draft. The branch contains two commits:
- `de688bf5` `feat(config): standardize configured model resolution`
- `93c68599` `fix(config): restore fallback model resolution paths`
