### PR TITLE
refactor(prompts): migrate acceptance orphan prompt functions into AcceptancePromptBuilder

### DIFF
--- a/.claude/rules/forbidden-patterns.md
+++ b/.claude/rules/forbidden-patterns.md
@@ -16,6 +16,63 @@ These patterns are **banned** from the nax codebase. Violations must be caught d
 | Hardcoded timeouts in logic | Config values from schema | Hardcoded values can't be tuned per-environment |
 | `import from "src/module/internal-file"` | `import from "src/module"` (barrel) | Prevents singleton fragmentation (BUG-035) |
 | Files > 400 lines | Split by concern | Unmaintainable; violates project convention |
+| Prompt-building functions outside `src/prompts/builders/` | Add a method to the appropriate builder class | Orphan prompts scatter LLM instruction logic across subsystems, making them impossible to audit, test, or optimise centrally (see Prompt Builder Convention below) |
+
+## Prompt Builder Convention
+
+**All LLM prompt-building logic lives in `src/prompts/builders/` — no exceptions.**
+
+An "orphan prompt" is any function or template string outside `src/prompts/builders/` that:
+- Returns a multi-line string sent to an LLM agent
+- Contains `You are`, `## Instructions`, `Fix `, `Your task`, `IMPORTANT:`, or similar instructional text
+- Is named `build*Prompt`, `create*Prompt`, `make*Prompt`, or similar
+
+### ❌ Wrong — prompt assembled in a pipeline stage
+
+```typescript
+// src/pipeline/stages/autofix.ts
+function buildFixPrompt(checks: ReviewCheckResult[]): string {
+  return `You are fixing lint errors.\n\n${checks.map(...).join("\n")}`;
+}
+```
+
+### ✅ Correct — static method on the relevant builder
+
+```typescript
+// src/prompts/builders/rectifier-builder.ts
+export class RectifierPromptBuilder {
+  static continuation(checks: ReviewCheckResult[], ...): string {
+    // prompt assembly lives here
+  }
+}
+```
+
+### Builder registry
+
+| Builder class | Handles |
+|:---|:---|
+| `RectifierPromptBuilder` | All rectification prompts: TDD failures, verify failures, review findings, autofix retries |
+| `ReviewPromptBuilder` | Semantic and adversarial review prompts |
+| `TddPromptBuilder` | TDD session prompts (test-writer, implementer, verifier) |
+| `AcceptancePromptBuilder` | Acceptance test generation, diagnosis, refinement, fix execution |
+| `DebatePromptBuilder` | Multi-agent debate and review-dialogue prompts |
+| `OneShotPromptBuilder` | Single-turn utility prompts (router, decomposer, auto-approver) |
+
+If no existing builder fits, create `src/prompts/builders/<domain>-builder.ts` and export from `src/prompts/index.ts`.
+
+### Wrapper functions are also banned
+
+Thin wrappers that do nothing but delegate to a builder add indirection without value:
+
+```typescript
+// ❌ Wrong — pointless wrapper in src/acceptance/fix-executor.ts
+function buildSourceFixPrompt(...): string {
+  return new AcceptancePromptBuilder().buildSourceFixPrompt(...);
+}
+
+// ✅ Correct — call the builder directly at the use site
+const prompt = new AcceptancePromptBuilder().buildSourceFixPrompt(...);
+```
 
 ## Test Files
 

--- a/.claude/rules/project-conventions.md
+++ b/.claude/rules/project-conventions.md
@@ -53,6 +53,12 @@ logger.error("acceptance", "Tests failed", { failedACs, packageDir, storyId: ctx
 
 **Scope:** Applies to `src/pipeline/stages/` and `src/review/`. Utility modules (`src/quality/runner.ts`, `src/verification/`) use `storyId` when it is passed in via options — no requirement to thread it independently.
 
+## Prompt Building
+
+- **All LLM prompt-building logic lives in `src/prompts/builders/`.** Never write `build*Prompt` functions in pipeline stages, verification, execution, review, or any other subsystem directory.
+- Import from the barrel (`src/prompts`), never from internal paths (`src/prompts/builders/rectifier-builder`).
+- See `forbidden-patterns.md` → **Prompt Builder Convention** for the full builder registry and examples.
+
 ## Commits
 
 - Conventional commits: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`.

--- a/src/acceptance/fix-diagnosis.ts
+++ b/src/acceptance/fix-diagnosis.ts
@@ -9,7 +9,7 @@ import { buildSessionName } from "../agents/acp/adapter";
 import type { AgentAdapter } from "../agents/types";
 import type { NaxConfig } from "../config/schema";
 import { type ModelTier, resolveModelForAgent } from "../config/schema-types";
-import { AcceptancePromptBuilder } from "../prompts/builders/acceptance-builder";
+import { AcceptancePromptBuilder, MAX_FILE_LINES } from "../prompts";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { DiagnosisResult, SemanticVerdict } from "./types";
 
@@ -26,8 +26,6 @@ export interface DiagnoseOptions {
 }
 
 const MAX_SOURCE_FILES = 5;
-const MAX_FILE_LINES = 500;
-const MAX_TEST_OUTPUT_CHARS = 2000;
 
 function parseImportStatements(content: string): string[] {
   const importRegex = /import\s+(?:{[^}]+}|[^;]+)\s+from\s+["']([^"']+)["']/g;
@@ -63,44 +61,6 @@ async function readSourceFileContent(
   }
 }
 
-export function buildDiagnosisPrompt(options: {
-  testOutput: string;
-  testFileContent: string;
-  sourceFiles: Array<{ path: string; content: string }>;
-  semanticVerdicts?: SemanticVerdict[];
-  previousFailure?: string;
-}): string {
-  const truncatedOutput = options.testOutput.slice(0, MAX_TEST_OUTPUT_CHARS);
-
-  const sourceFilesSection =
-    options.sourceFiles.length > 0
-      ? options.sourceFiles.map((f) => `FILE: ${f.path}\n\`\`\`\n${f.content}\n\`\`\``).join("\n\n")
-      : "(No source files could be resolved from imports)";
-
-  let verdictSection = "";
-  if (options.semanticVerdicts && options.semanticVerdicts.length > 0) {
-    const lines = options.semanticVerdicts.map((v) => {
-      const status = v.passed ? "likely test bug (semantic review confirmed AC implementation)" : "unconfirmed";
-      return `- ${v.storyId}: ${status}`;
-    });
-    verdictSection = `\nSEMANTIC VERDICTS:\n${lines.join("\n")}\n`;
-  }
-
-  let previousFailureSection = "";
-  if (options.previousFailure && options.previousFailure.length > 0) {
-    previousFailureSection = `\nPREVIOUS FIX ATTEMPTS:\n${options.previousFailure}\n`;
-  }
-
-  return new AcceptancePromptBuilder().buildDiagnosisPromptTemplate({
-    truncatedOutput,
-    testFileContent: options.testFileContent,
-    sourceFilesSection,
-    verdictSection,
-    previousFailureSection,
-    maxFileLines: MAX_FILE_LINES,
-  });
-}
-
 export async function diagnoseAcceptanceFailure(
   agent: AgentAdapter,
   options: DiagnoseOptions,
@@ -126,7 +86,7 @@ export async function diagnoseAcceptanceFailure(
   const sourceFiles = await Promise.all(relativeImports.map((imp) => readSourceFileContent(imp, workdir)));
   const validSourceFiles = sourceFiles.filter((f): f is { path: string; content: string } => f !== null);
 
-  const prompt = buildDiagnosisPrompt({
+  const prompt = new AcceptancePromptBuilder().buildDiagnosisPrompt({
     testOutput,
     testFileContent,
     sourceFiles: validSourceFiles,

--- a/src/acceptance/fix-executor.ts
+++ b/src/acceptance/fix-executor.ts
@@ -10,7 +10,7 @@ import type { AgentAdapter, AgentRunOptions } from "../agents/types";
 import type { NaxConfig } from "../config/schema";
 import type { ModelTier } from "../config/schema-types";
 import { resolveModelForAgent } from "../config/schema-types";
-import { AcceptancePromptBuilder } from "../prompts/builders/acceptance-builder";
+import { AcceptancePromptBuilder } from "../prompts";
 import type { DiagnosisResult } from "./types";
 
 export interface ExecuteSourceFixOptions {
@@ -27,15 +27,6 @@ export interface ExecuteSourceFixOptions {
 export interface ExecuteSourceFixResult {
   success: boolean;
   cost: number;
-}
-
-export function buildSourceFixPrompt(options: ExecuteSourceFixOptions): string {
-  return new AcceptancePromptBuilder().buildSourceFixPrompt({
-    testOutput: options.testOutput,
-    diagnosisReasoning: options.diagnosis.reasoning,
-    acceptanceTestPath: options.acceptanceTestPath,
-    testFileContent: options.testFileContent,
-  });
 }
 
 export async function executeSourceFix(
@@ -57,7 +48,12 @@ export async function executeSourceFix(
 
   const sessionName = buildSessionName(workdir, featureName, storyId, "source-fix");
 
-  const prompt = buildSourceFixPrompt(options);
+  const prompt = new AcceptancePromptBuilder().buildSourceFixPrompt({
+    testOutput: options.testOutput,
+    diagnosisReasoning: options.diagnosis.reasoning,
+    acceptanceTestPath: options.acceptanceTestPath,
+    testFileContent: options.testFileContent,
+  });
 
   const timeoutSeconds = config.execution?.sessionTimeoutSeconds ?? 3600;
 
@@ -104,17 +100,6 @@ export interface ExecuteTestFixResult {
   cost: number;
 }
 
-export function buildTestFixPrompt(options: ExecuteTestFixOptions): string {
-  return new AcceptancePromptBuilder().buildTestFixPrompt({
-    testOutput: options.testOutput,
-    diagnosisReasoning: options.diagnosis.reasoning,
-    failedACs: options.failedACs,
-    previousFailure: options.previousFailure,
-    acceptanceTestPath: options.acceptanceTestPath,
-    testFileContent: options.testFileContent,
-  });
-}
-
 export async function executeTestFix(
   agent: AgentAdapter,
   options: ExecuteTestFixOptions,
@@ -134,7 +119,14 @@ export async function executeTestFix(
 
   const sessionName = buildSessionName(workdir, featureName, storyId, "test-fix");
 
-  const prompt = buildTestFixPrompt(options);
+  const prompt = new AcceptancePromptBuilder().buildTestFixPrompt({
+    testOutput: options.testOutput,
+    diagnosisReasoning: options.diagnosis.reasoning,
+    failedACs: options.failedACs,
+    previousFailure: options.previousFailure,
+    acceptanceTestPath: options.acceptanceTestPath,
+    testFileContent: options.testFileContent,
+  });
 
   const timeoutSeconds = config.execution?.sessionTimeoutSeconds ?? 3600;
 

--- a/src/acceptance/fix-generator.ts
+++ b/src/acceptance/fix-generator.ts
@@ -11,6 +11,7 @@ import type { AgentAdapter } from "../agents/types";
 import type { ModelDef, NaxConfig } from "../config/schema";
 import { getLogger } from "../logger";
 import type { PRD, UserStory } from "../prd/types";
+import { AcceptancePromptBuilder } from "../prompts";
 import { resolveAcceptanceTestFile } from "./test-path";
 
 const MAX_FIX_STORIES = 8;
@@ -185,62 +186,6 @@ export function groupACsByRelatedStories(
 }
 
 /**
- * Build LLM prompt for generating a batched fix story.
- *
- * @param batchedACs - Batch of failed AC identifiers
- * @param acTextMap - Map of AC ID to text from spec
- * @param testOutput - Test failure output
- * @param relatedStories - Related story IDs
- * @param prd - Current PRD
- * @param testFilePath - Path to acceptance test file (P1-A)
- * @returns Formatted prompt string
- */
-export function buildFixPrompt(
-  batchedACs: string[],
-  acTextMap: Record<string, string>,
-  testOutput: string,
-  relatedStories: string[],
-  prd: PRD,
-  testFilePath?: string,
-): string {
-  const acList = batchedACs.map((ac) => `${ac}: ${acTextMap[ac] || "No description available"}`).join("\n");
-
-  const relatedStoriesText = relatedStories
-    .map((id) => {
-      const story = prd.userStories.find((s) => s.id === id);
-      if (!story) return "";
-      return `${story.id}: ${story.title}\n  ${story.description}`;
-    })
-    .filter(Boolean)
-    .join("\n\n");
-
-  const testFileSection = testFilePath
-    ? `\nACCEPTANCE TEST FILE: ${testFilePath}\n(Read this file first to understand what each test expects)\n`
-    : "";
-
-  return `You are a debugging expert. Feature acceptance tests have failed.${testFileSection}
-FAILED ACCEPTANCE CRITERIA (${batchedACs.length} total):
-${acList}
-
-TEST FAILURE OUTPUT:
-${testOutput.slice(0, 2000)}
-
-RELATED STORIES (implemented this functionality):
-${relatedStoriesText}
-
-Your task: Generate a fix description that will make these acceptance tests pass.
-
-Requirements:
-1. Read the acceptance test file first to understand what each failing test expects
-2. Identify the root cause based on the test failure output
-3. Find and fix the relevant implementation code (do NOT modify the test file)
-4. Write a clear, actionable fix description (2-4 sentences)
-5. Reference the relevant story IDs if needed
-
-Respond with ONLY the fix description (no JSON, no markdown, just the description text).`;
-}
-
-/**
  * Generate fix stories from failed acceptance criteria.
  *
  * Groups ACs by related stories (D1), generates one fix story per group,
@@ -287,7 +232,14 @@ export async function generateFixStories(
 
     logger.info("acceptance", "Generating fix for AC group", { batchedACs });
 
-    const prompt = buildFixPrompt(batchedACs, acTextMap, testOutput, relatedStories, prd, testFilePath);
+    const prompt = new AcceptancePromptBuilder().buildFixGeneratorPrompt({
+      batchedACs,
+      acTextMap,
+      testOutput,
+      relatedStories,
+      prd,
+      testFilePath,
+    });
 
     // D4: inherit workdir from first related story that has one set
     const relatedStory = prd.userStories.find((s) => relatedStories.includes(s.id) && s.workdir);

--- a/src/acceptance/index.ts
+++ b/src/acceptance/index.ts
@@ -14,7 +14,6 @@ export type {
 } from "./types";
 
 export {
-  buildRefinementPrompt,
   parseRefinementResponse,
   refineAcceptanceCriteria,
   _refineDeps,

--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -9,8 +9,9 @@ import type { AgentAdapter } from "../agents";
 import { createAgentRegistry } from "../agents/registry";
 import { resolveModelForAgent } from "../config";
 import { getLogger } from "../logger";
+import { AcceptancePromptBuilder } from "../prompts";
 import { errorMessage } from "../utils/errors";
-import { extractJsonFromMarkdown, stripTrailingCommas, wrapJsonPrompt } from "../utils/llm-json";
+import { extractJsonFromMarkdown, stripTrailingCommas } from "../utils/llm-json";
 import type { RefineResult, RefinedCriterion, RefinementContext } from "./types";
 
 /**
@@ -33,117 +34,6 @@ export const _refineDeps = {
     },
   } satisfies Pick<AgentAdapter, "complete">,
 };
-
-/**
- * Strategy-specific context for the refinement prompt.
- */
-export interface RefinementPromptOptions {
-  /** Test strategy — controls strategy-specific prompt instructions */
-  testStrategy?: "unit" | "component" | "cli" | "e2e" | "snapshot";
-  /** Test framework — informs LLM which testing library syntax to use */
-  testFramework?: string;
-  /** Story title — anchors the refiner to the correct subject function/entity */
-  storyTitle?: string;
-  /** Story description — provides additional function/entity context */
-  storyDescription?: string;
-}
-
-/**
- * Build the LLM prompt for refining acceptance criteria.
- *
- * @param criteria - Raw AC strings from PRD
- * @param codebaseContext - File tree / dependency context
- * @param options - Optional strategy/framework context
- * @returns Formatted prompt string
- */
-export function buildRefinementPrompt(
-  criteria: string[],
-  codebaseContext: string,
-  options?: RefinementPromptOptions,
-): string {
-  const criteriaList = criteria.map((c, i) => `${i + 1}. ${c}`).join("\n");
-  const strategySection = buildStrategySection(options);
-  const refinedExample = buildRefinedExample(options?.testStrategy);
-
-  const storyLines: string[] = [];
-  if (options?.storyTitle) storyLines.push(`Title: ${options.storyTitle}`);
-  if (options?.storyDescription) storyLines.push(`Description: ${options.storyDescription}`);
-  const storySection = storyLines.length > 0 ? `STORY CONTEXT:\n${storyLines.join("\n")}\n\n` : "";
-
-  const codebaseSection = codebaseContext ? `CODEBASE CONTEXT:\n${codebaseContext}\n` : "";
-
-  const core = `You are an acceptance criteria refinement assistant. Your task is to convert raw acceptance criteria into concrete, machine-verifiable assertions.
-
-${storySection}${codebaseSection}${strategySection}ACCEPTANCE CRITERIA TO REFINE:
-${criteriaList}
-
-For each criterion, produce a refined version that is concrete and automatically testable where possible.
-Respond with a JSON array:
-[{
-  "original": "<exact original criterion text>",
-  "refined": "<concrete, machine-verifiable description>",
-  "testable": true,
-  "storyId": ""
-}]
-
-Rules:
-- "original" must match the input criterion text exactly
-- "refined" must be a concrete assertion (e.g., ${refinedExample})
-- "testable" is false only if the criterion cannot be automatically verified (e.g., "UX feels responsive", "design looks good")
-- "storyId" leave as empty string — it will be assigned by the caller`;
-
-  return wrapJsonPrompt(core);
-}
-
-/**
- * Build strategy-specific instructions section for the prompt.
- */
-function buildStrategySection(options?: RefinementPromptOptions): string {
-  if (!options?.testStrategy) {
-    return "";
-  }
-
-  const framework = options.testFramework ? ` Use ${options.testFramework} testing library syntax.` : "";
-
-  switch (options.testStrategy) {
-    case "component":
-      return `
-TEST STRATEGY: component
-Focus assertions on rendered output visible on screen — text content, visible elements, and screen state.
-Assert what the user sees rendered in the component, not what internal functions produce.${framework}
-`;
-    case "cli":
-      return `
-TEST STRATEGY: cli
-Focus assertions on stdout and stderr text output from the CLI command.
-Assert about terminal output content, exit codes, and standard output/standard error streams.${framework}
-`;
-    case "e2e":
-      return `
-TEST STRATEGY: e2e
-Focus assertions on HTTP response content — status codes, response bodies, and endpoint behavior.
-Assert about HTTP responses, status codes, and API endpoint output.${framework}
-`;
-    default:
-      return framework ? `\nTEST FRAMEWORK: ${options.testFramework}\n` : "";
-  }
-}
-
-/**
- * Build the "refined" example string based on the test strategy.
- */
-function buildRefinedExample(testStrategy?: RefinementPromptOptions["testStrategy"]): string {
-  switch (testStrategy) {
-    case "component":
-      return '"Text content visible on screen matches expected", "Rendered output contains expected element"';
-    case "cli":
-      return '"stdout contains expected text", "stderr is empty on success", "exit code is 0"';
-    case "e2e":
-      return '"HTTP status 200 returned", "Response body contains expected field", "Endpoint returns JSON"';
-    default:
-      return '"Array of length N returned", "HTTP status 200 returned"';
-  }
-}
 
 /**
  * Parse the LLM JSON response into RefinedCriterion[].
@@ -212,7 +102,7 @@ export async function refineAcceptanceCriteria(criteria: string[], context: Refi
     modelTier,
     config.autoMode.defaultAgent,
   );
-  const prompt = buildRefinementPrompt(criteria, codebaseContext, {
+  const prompt = new AcceptancePromptBuilder().buildRefinementPrompt(criteria, codebaseContext, {
     testStrategy,
     testFramework,
     storyTitle,

--- a/src/prompts/builders/acceptance-builder.ts
+++ b/src/prompts/builders/acceptance-builder.ts
@@ -10,7 +10,16 @@
  * Instantiation cost is negligible; builders are short-lived call-and-discard.
  */
 
+import type { PRD } from "../../prd/types";
+import { wrapJsonPrompt } from "../../utils/llm-json";
+
 export type AcceptanceRole = "generator" | "diagnoser" | "fix-executor";
+
+/**
+ * Maximum source file lines included in the diagnosis prompt.
+ * Exported so fix-diagnosis.ts can use the same cap when reading files.
+ */
+export const MAX_FILE_LINES = 500;
 
 // ─── Shared generator step text ───────────────────────────────────────────────
 
@@ -41,6 +50,33 @@ const STEP3_SHARED_RULES = `- **One test per AC**, named exactly "AC-N: <descrip
 - **NEVER use placeholder assertions** — no always-passing or always-failing stubs, no TODO comments as the only content, no empty test bodies
 - Every test MUST have real assertions that PASS when the feature is correctly implemented and FAIL when it is broken
 - **Prefer behavioral tests** — import functions and call them rather than reading source files. For example, to verify "getPostRunActions() returns empty array", import PluginRegistry and call getPostRunActions(), don't grep the source file for the method name.`;
+
+// ─── Additional parameter interfaces (moved from acceptance domain) ───────────
+
+export interface FixGeneratorParams {
+  batchedACs: string[];
+  acTextMap: Record<string, string>;
+  testOutput: string;
+  relatedStories: string[];
+  prd: PRD;
+  testFilePath?: string;
+}
+
+export interface DiagnosisPromptParams {
+  testOutput: string;
+  testFileContent: string;
+  sourceFiles: Array<{ path: string; content: string }>;
+  /** Minimal shape — avoids importing SemanticVerdict across layers */
+  semanticVerdicts?: Array<{ storyId: string; passed: boolean }>;
+  previousFailure?: string;
+}
+
+export interface RefinementPromptOptions {
+  testStrategy?: "unit" | "component" | "cli" | "e2e" | "snapshot";
+  testFramework?: string;
+  storyTitle?: string;
+  storyDescription?: string;
+}
 
 // ─── Parameter interfaces ─────────────────────────────────────────────────────
 
@@ -168,6 +204,164 @@ Respond with ONLY a JSON object in this exact format (no markdown, no extra text
     }
     prompt += "Fix the source implementation. Do NOT modify the test file.";
     return prompt;
+  }
+
+  /**
+   * Prompt for generateFixStories() — asks the LLM to produce a fix description
+   * for a batch of failed acceptance criteria.
+   */
+  buildFixGeneratorPrompt(p: FixGeneratorParams): string {
+    const acList = p.batchedACs.map((ac) => `${ac}: ${p.acTextMap[ac] || "No description available"}`).join("\n");
+
+    const relatedStoriesText = p.relatedStories
+      .map((id) => {
+        const story = p.prd.userStories.find((s) => s.id === id);
+        if (!story) return "";
+        return `${story.id}: ${story.title}\n  ${story.description}`;
+      })
+      .filter(Boolean)
+      .join("\n\n");
+
+    const testFileSection = p.testFilePath
+      ? `\nACCEPTANCE TEST FILE: ${p.testFilePath}\n(Read this file first to understand what each test expects)\n`
+      : "";
+
+    return `You are a debugging expert. Feature acceptance tests have failed.${testFileSection}
+FAILED ACCEPTANCE CRITERIA (${p.batchedACs.length} total):
+${acList}
+
+TEST FAILURE OUTPUT:
+${p.testOutput.slice(0, 2000)}
+
+RELATED STORIES (implemented this functionality):
+${relatedStoriesText}
+
+Your task: Generate a fix description that will make these acceptance tests pass.
+
+Requirements:
+1. Read the acceptance test file first to understand what each failing test expects
+2. Identify the root cause based on the test failure output
+3. Find and fix the relevant implementation code (do NOT modify the test file)
+4. Write a clear, actionable fix description (2-4 sentences)
+5. Reference the relevant story IDs if needed
+
+Respond with ONLY the fix description (no JSON, no markdown, just the description text).`;
+  }
+
+  /**
+   * Prompt for diagnoseAcceptanceFailure() — pre-processes raw data and assembles
+   * the full diagnosis prompt via buildDiagnosisPromptTemplate().
+   */
+  buildDiagnosisPrompt(p: DiagnosisPromptParams): string {
+    const MAX_TEST_OUTPUT_CHARS = 2000;
+    const truncatedOutput = p.testOutput.slice(0, MAX_TEST_OUTPUT_CHARS);
+
+    const sourceFilesSection =
+      p.sourceFiles.length > 0
+        ? p.sourceFiles.map((f) => `FILE: ${f.path}\n\`\`\`\n${f.content}\n\`\`\``).join("\n\n")
+        : "(No source files could be resolved from imports)";
+
+    let verdictSection = "";
+    if (p.semanticVerdicts && p.semanticVerdicts.length > 0) {
+      const lines = p.semanticVerdicts.map((v) => {
+        const status = v.passed ? "likely test bug (semantic review confirmed AC implementation)" : "unconfirmed";
+        return `- ${v.storyId}: ${status}`;
+      });
+      verdictSection = `\nSEMANTIC VERDICTS:\n${lines.join("\n")}\n`;
+    }
+
+    const previousFailureSection =
+      p.previousFailure && p.previousFailure.length > 0 ? `\nPREVIOUS FIX ATTEMPTS:\n${p.previousFailure}\n` : "";
+
+    return this.buildDiagnosisPromptTemplate({
+      truncatedOutput,
+      testFileContent: p.testFileContent,
+      sourceFilesSection,
+      verdictSection,
+      previousFailureSection,
+      maxFileLines: MAX_FILE_LINES,
+    });
+  }
+
+  /**
+   * Prompt for refineAcceptanceCriteria() — converts raw ACs into concrete
+   * machine-verifiable assertions, with optional strategy-specific instructions.
+   */
+  buildRefinementPrompt(criteria: string[], codebaseContext: string, options?: RefinementPromptOptions): string {
+    const criteriaList = criteria.map((c, i) => `${i + 1}. ${c}`).join("\n");
+    const strategySection = this.buildStrategySection(options);
+    const refinedExample = this.buildRefinedExample(options?.testStrategy);
+
+    const storyLines: string[] = [];
+    if (options?.storyTitle) storyLines.push(`Title: ${options.storyTitle}`);
+    if (options?.storyDescription) storyLines.push(`Description: ${options.storyDescription}`);
+    const storySection = storyLines.length > 0 ? `STORY CONTEXT:\n${storyLines.join("\n")}\n\n` : "";
+
+    const codebaseSection = codebaseContext ? `CODEBASE CONTEXT:\n${codebaseContext}\n` : "";
+
+    const core = `You are an acceptance criteria refinement assistant. Your task is to convert raw acceptance criteria into concrete, machine-verifiable assertions.
+
+${storySection}${codebaseSection}${strategySection}ACCEPTANCE CRITERIA TO REFINE:
+${criteriaList}
+
+For each criterion, produce a refined version that is concrete and automatically testable where possible.
+Respond with a JSON array:
+[{
+  "original": "<exact original criterion text>",
+  "refined": "<concrete, machine-verifiable description>",
+  "testable": true,
+  "storyId": ""
+}]
+
+Rules:
+- "original" must match the input criterion text exactly
+- "refined" must be a concrete assertion (e.g., ${refinedExample})
+- "testable" is false only if the criterion cannot be automatically verified (e.g., "UX feels responsive", "design looks good")
+- "storyId" leave as empty string — it will be assigned by the caller`;
+
+    return wrapJsonPrompt(core);
+  }
+
+  private buildStrategySection(options?: RefinementPromptOptions): string {
+    if (!options?.testStrategy) return "";
+
+    const framework = options.testFramework ? ` Use ${options.testFramework} testing library syntax.` : "";
+
+    switch (options.testStrategy) {
+      case "component":
+        return `
+TEST STRATEGY: component
+Focus assertions on rendered output visible on screen — text content, visible elements, and screen state.
+Assert what the user sees rendered in the component, not what internal functions produce.${framework}
+`;
+      case "cli":
+        return `
+TEST STRATEGY: cli
+Focus assertions on stdout and stderr text output from the CLI command.
+Assert about terminal output content, exit codes, and standard output/standard error streams.${framework}
+`;
+      case "e2e":
+        return `
+TEST STRATEGY: e2e
+Focus assertions on HTTP response content — status codes, response bodies, and endpoint behavior.
+Assert about HTTP responses, status codes, and API endpoint output.${framework}
+`;
+      default:
+        return framework ? `\nTEST FRAMEWORK: ${options.testFramework}\n` : "";
+    }
+  }
+
+  private buildRefinedExample(testStrategy?: RefinementPromptOptions["testStrategy"]): string {
+    switch (testStrategy) {
+      case "component":
+        return '"Text content visible on screen matches expected", "Rendered output contains expected element"';
+      case "cli":
+        return '"stdout contains expected text", "stderr is empty on success", "exit code is 0"';
+      case "e2e":
+        return '"HTTP status 200 returned", "Response body contains expected field", "Endpoint returns JSON"';
+      default:
+        return '"Array of length N returned", "HTTP status 200 returned"';
+    }
   }
 
   /** Prompt for executeTestFix() — instructs agent to fix failing test assertions. */

--- a/src/prompts/builders/acceptance-builder.ts
+++ b/src/prompts/builders/acceptance-builder.ts
@@ -261,14 +261,10 @@ Respond with ONLY the fix description (no JSON, no markdown, just the descriptio
         ? p.sourceFiles.map((f) => `FILE: ${f.path}\n\`\`\`\n${f.content}\n\`\`\``).join("\n\n")
         : "(No source files could be resolved from imports)";
 
-    let verdictSection = "";
-    if (p.semanticVerdicts && p.semanticVerdicts.length > 0) {
-      const lines = p.semanticVerdicts.map((v) => {
-        const status = v.passed ? "likely test bug (semantic review confirmed AC implementation)" : "unconfirmed";
-        return `- ${v.storyId}: ${status}`;
-      });
-      verdictSection = `\nSEMANTIC VERDICTS:\n${lines.join("\n")}\n`;
-    }
+    const verdictSection =
+      p.semanticVerdicts && p.semanticVerdicts.length > 0
+        ? `\nSEMANTIC VERDICTS:\n${p.semanticVerdicts.map((v) => `- ${v.storyId}: ${v.passed ? "likely test bug (semantic review confirmed AC implementation)" : "unconfirmed"}`).join("\n")}\n`
+        : "";
 
     const previousFailureSection =
       p.previousFailure && p.previousFailure.length > 0 ? `\nPREVIOUS FIX ATTEMPTS:\n${p.previousFailure}\n` : "";

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -21,8 +21,13 @@ export type { StageContext, PromptBuilderOptions, ReviewStoryContext } from "./b
 export { ReviewPromptBuilder } from "./builders/review-builder";
 
 // Acceptance prompt builder — generator, diagnoser, and fix-executor prompt construction.
-export { AcceptancePromptBuilder } from "./builders/acceptance-builder";
-export type { AcceptanceRole } from "./builders/acceptance-builder";
+export { AcceptancePromptBuilder, MAX_FILE_LINES } from "./builders/acceptance-builder";
+export type {
+  AcceptanceRole,
+  FixGeneratorParams,
+  DiagnosisPromptParams,
+  RefinementPromptOptions,
+} from "./builders/acceptance-builder";
 
 // Rectifier prompt builder — cross-domain rectification for TDD, verify, and review triggers.
 export { RectifierPromptBuilder, CONTRADICTION_ESCAPE_HATCH } from "./builders/rectifier-builder";

--- a/test/unit/acceptance/fix-diagnosis-prompt.test.ts
+++ b/test/unit/acceptance/fix-diagnosis-prompt.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { AcceptancePromptBuilder } from "../../../src/prompts/builders/acceptance-builder";
+import { AcceptancePromptBuilder } from "../../../src/prompts";
 import type { SemanticVerdict } from "../../../src/acceptance/types";
 
 const builder = new AcceptancePromptBuilder();

--- a/test/unit/acceptance/fix-diagnosis-prompt.test.ts
+++ b/test/unit/acceptance/fix-diagnosis-prompt.test.ts
@@ -10,8 +10,12 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { buildDiagnosisPrompt } from "../../../src/acceptance/fix-diagnosis";
+import { AcceptancePromptBuilder } from "../../../src/prompts/builders/acceptance-builder";
 import type { SemanticVerdict } from "../../../src/acceptance/types";
+
+const builder = new AcceptancePromptBuilder();
+const buildDiagnosisPrompt = (opts: Parameters<AcceptancePromptBuilder["buildDiagnosisPrompt"]>[0]) =>
+  builder.buildDiagnosisPrompt(opts);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixtures

--- a/test/unit/acceptance/fix-executor.test.ts
+++ b/test/unit/acceptance/fix-executor.test.ts
@@ -679,7 +679,7 @@ describe("Edge cases", () => {
 // ---------------------------------------------------------------------------
 
 import { type ExecuteTestFixOptions, executeTestFix } from "../../../src/acceptance/fix-executor";
-import { AcceptancePromptBuilder } from "../../../src/prompts/builders/acceptance-builder";
+import { AcceptancePromptBuilder } from "../../../src/prompts";
 
 function callBuildTestFixPrompt(options: ExecuteTestFixOptions): string {
   return new AcceptancePromptBuilder().buildTestFixPrompt({

--- a/test/unit/acceptance/fix-executor.test.ts
+++ b/test/unit/acceptance/fix-executor.test.ts
@@ -678,7 +678,19 @@ describe("Edge cases", () => {
 // executeTestFix() — surgical test fix (US-001)
 // ---------------------------------------------------------------------------
 
-import { type ExecuteTestFixOptions, buildTestFixPrompt, executeTestFix } from "../../../src/acceptance/fix-executor";
+import { type ExecuteTestFixOptions, executeTestFix } from "../../../src/acceptance/fix-executor";
+import { AcceptancePromptBuilder } from "../../../src/prompts/builders/acceptance-builder";
+
+function callBuildTestFixPrompt(options: ExecuteTestFixOptions): string {
+  return new AcceptancePromptBuilder().buildTestFixPrompt({
+    testOutput: options.testOutput,
+    diagnosisReasoning: options.diagnosis.reasoning,
+    failedACs: options.failedACs,
+    previousFailure: options.previousFailure,
+    acceptanceTestPath: options.acceptanceTestPath,
+    testFileContent: options.testFileContent,
+  });
+}
 
 function makeTestFixOptions(overrides: Partial<ExecuteTestFixOptions> = {}): ExecuteTestFixOptions {
   return {
@@ -795,17 +807,17 @@ describe("executeTestFix()", () => {
 
 describe("buildTestFixPrompt()", () => {
   test("includes failing ACs in 'FAILING ACS:' section", () => {
-    const prompt = buildTestFixPrompt(makeTestFixOptions({ failedACs: ["AC-1", "AC-2"] }));
+    const prompt = callBuildTestFixPrompt(makeTestFixOptions({ failedACs: ["AC-1", "AC-2"] }));
     expect(prompt).toContain("FAILING ACS: AC-1, AC-2");
   });
 
   test("omits previousFailure section when not provided", () => {
-    const prompt = buildTestFixPrompt(makeTestFixOptions({ previousFailure: undefined }));
+    const prompt = callBuildTestFixPrompt(makeTestFixOptions({ previousFailure: undefined }));
     expect(prompt).not.toContain("PREVIOUS FAILED ATTEMPTS");
   });
 
   test("includes previousFailure section when provided", () => {
-    const prompt = buildTestFixPrompt(makeTestFixOptions({ previousFailure: "attempt 1 failed" }));
+    const prompt = callBuildTestFixPrompt(makeTestFixOptions({ previousFailure: "attempt 1 failed" }));
     expect(prompt).toContain("PREVIOUS FAILED ATTEMPTS:\nattempt 1 failed");
   });
 });

--- a/test/unit/acceptance/refinement-strategy.test.ts
+++ b/test/unit/acceptance/refinement-strategy.test.ts
@@ -15,9 +15,15 @@
 import { describe, expect, mock, test } from "bun:test";
 import {
   _refineDeps,
-  buildRefinementPrompt,
   refineAcceptanceCriteria,
 } from "../../../src/acceptance/refinement";
+import { AcceptancePromptBuilder } from "../../../src/prompts/builders/acceptance-builder";
+
+const buildRefinementPrompt = (
+  criteria: string[],
+  ctx: string,
+  opts?: Parameters<AcceptancePromptBuilder["buildRefinementPrompt"]>[2],
+) => new AcceptancePromptBuilder().buildRefinementPrompt(criteria, ctx, opts);
 import type { RefinementContext } from "../../../src/acceptance/types";
 import type { NaxConfig } from "../../../src/config";
 

--- a/test/unit/acceptance/refinement-strategy.test.ts
+++ b/test/unit/acceptance/refinement-strategy.test.ts
@@ -17,7 +17,7 @@ import {
   _refineDeps,
   refineAcceptanceCriteria,
 } from "../../../src/acceptance/refinement";
-import { AcceptancePromptBuilder } from "../../../src/prompts/builders/acceptance-builder";
+import { AcceptancePromptBuilder } from "../../../src/prompts";
 
 const buildRefinementPrompt = (
   criteria: string[],

--- a/test/unit/acceptance/refinement.test.ts
+++ b/test/unit/acceptance/refinement.test.ts
@@ -14,10 +14,16 @@ import { describe, expect, mock, test } from "bun:test";
 import { withDepsRestore } from "../../helpers/deps";
 import {
   _refineDeps,
-  buildRefinementPrompt,
   parseRefinementResponse,
   refineAcceptanceCriteria,
 } from "../../../src/acceptance/refinement";
+import { AcceptancePromptBuilder } from "../../../src/prompts/builders/acceptance-builder";
+
+const buildRefinementPrompt = (
+  criteria: string[],
+  ctx: string,
+  opts?: Parameters<AcceptancePromptBuilder["buildRefinementPrompt"]>[2],
+) => new AcceptancePromptBuilder().buildRefinementPrompt(criteria, ctx, opts);
 import { DEFAULT_CONFIG } from "../../../src/config";
 import type { NaxConfig } from "../../../src/config";
 import type { RefinedCriterion } from "../../../src/acceptance/types";

--- a/test/unit/acceptance/refinement.test.ts
+++ b/test/unit/acceptance/refinement.test.ts
@@ -17,7 +17,7 @@ import {
   parseRefinementResponse,
   refineAcceptanceCriteria,
 } from "../../../src/acceptance/refinement";
-import { AcceptancePromptBuilder } from "../../../src/prompts/builders/acceptance-builder";
+import { AcceptancePromptBuilder } from "../../../src/prompts";
 
 const buildRefinementPrompt = (
   criteria: string[],

--- a/test/unit/verification/fix-generator.test.ts
+++ b/test/unit/verification/fix-generator.test.ts
@@ -10,7 +10,7 @@ import {
   groupACsByRelatedStories,
   parseACTextFromSpec,
 } from "../../../src/acceptance/fix-generator";
-import { AcceptancePromptBuilder } from "../../../src/prompts/builders/acceptance-builder";
+import { AcceptancePromptBuilder } from "../../../src/prompts";
 
 function buildFixPrompt(
   batchedACs: string[],

--- a/test/unit/verification/fix-generator.test.ts
+++ b/test/unit/verification/fix-generator.test.ts
@@ -5,12 +5,30 @@
 
 import { describe, expect, test } from "bun:test";
 import {
-  buildFixPrompt,
   convertFixStoryToUserStory,
   findRelatedStories,
   groupACsByRelatedStories,
   parseACTextFromSpec,
 } from "../../../src/acceptance/fix-generator";
+import { AcceptancePromptBuilder } from "../../../src/prompts/builders/acceptance-builder";
+
+function buildFixPrompt(
+  batchedACs: string[],
+  acTextMap: Record<string, string>,
+  testOutput: string,
+  relatedStories: string[],
+  prd: PRD,
+  testFilePath?: string,
+): string {
+  return new AcceptancePromptBuilder().buildFixGeneratorPrompt({
+    batchedACs,
+    acTextMap,
+    testOutput,
+    relatedStories,
+    prd,
+    testFilePath,
+  });
+}
 import type { PRD, UserStory } from "../../../src/prd/types";
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Migrates 4 orphan prompt-building locations in `src/acceptance/` into `AcceptancePromptBuilder`, following the convention established in #403
- Removes thin wrapper functions (`buildSourceFixPrompt`, `buildTestFixPrompt`, `buildDiagnosisPrompt`) that were delegating straight to the builder with no added value
- Removes standalone prompt functions (`buildRefinementPrompt`, `buildFixPrompt`) that lived in pipeline/domain files instead of the builder
- Adds the new methods to `AcceptancePromptBuilder`: `buildFixGeneratorPrompt`, `buildDiagnosisPrompt`, `buildRefinementPrompt` (+ private `buildStrategySection`/`buildRefinedExample` helpers)
- Exports `MAX_FILE_LINES`, `FixGeneratorParams`, `DiagnosisPromptParams`, `RefinementPromptOptions` from the `src/prompts` barrel
- Updates all 5 affected test files to import from `AcceptancePromptBuilder` directly

No behaviour changes — pure structural refactor.

## Test plan

- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `bun test test/unit/acceptance/refinement.test.ts test/unit/acceptance/refinement-strategy.test.ts test/unit/acceptance/fix-diagnosis-prompt.test.ts test/unit/acceptance/fix-executor.test.ts test/unit/acceptance/fix-executor-prompt.test.ts test/unit/verification/fix-generator.test.ts test/unit/prompts/acceptance-builder.test.ts` — 183 pass
- [ ] `bun run test` — full suite green (6595 pass, 0 fail)