### PR TITLE
refactor(review): isolate mechanical checks from LLM reviews

### DIFF
--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -150,8 +150,19 @@ export const autofixStage: PipelineStage = {
       unresolvedReason,
     } = await _autofixDeps.runAgentRectification(ctx, lintFixCmd, formatFixCmd, ctx.workdir);
 
-    // REVIEW-003: Implementer signalled an unresolvable reviewer contradiction — escalate.
+    // REVIEW-003: Implementer signalled an unresolvable reviewer contradiction.
     if (unresolvedReason) {
+      // When only mechanical checks failed (LLM/semantic passed), the code is functionally
+      // correct — the agent cannot fix lint/typecheck errors in test files per its constraints.
+      // Suppress tier escalation and proceed; log a warning so the issue remains visible.
+      if (ctx.mechanicalFailedOnly) {
+        logger.warn("autofix", "Mechanical-only failure unfixable — proceeding (LLM review passed)", {
+          storyId: ctx.story.id,
+          unresolvedReason,
+        });
+        if (ctx.reviewResult) ctx.reviewResult = { ...ctx.reviewResult, success: true };
+        return { action: "continue", cost: agentCost };
+      }
       logger.warn("autofix", "Escalating due to reviewer contradiction", {
         storyId: ctx.story.id,
         unresolvedReason,

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -144,6 +144,7 @@ export const reviewStage: PipelineStage = {
     const result = await reviewOrchestrator.reviewFromContext(ctx);
 
     ctx.reviewResult = result.builtIn;
+    ctx.mechanicalFailedOnly = result.mechanicalFailedOnly;
 
     // Sum LLM costs from checks (populated by semantic review)
     const reviewCost = (result.builtIn.checks ?? []).reduce((sum, c) => sum + (c.cost ?? 0), 0) || undefined;

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -162,6 +162,13 @@ export interface PipelineContext {
    * Only checks that were NOT the cause of the retry are eligible to be skipped.
    */
   retrySkipChecks?: Set<string>;
+  /**
+   * True when only mechanical checks failed (build/typecheck/lint) but LLM checks
+   * (semantic/adversarial) passed in the most recent review pass. Signals to autofix
+   * that the code is functionally correct — UNRESOLVED should not trigger tier escalation
+   * for mechanical failures in files the agent cannot modify (e.g. lint in test files).
+   */
+  mechanicalFailedOnly?: boolean;
 }
 
 /**

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -71,6 +71,12 @@ export interface OrchestratorReviewResult {
   failureReason?: string;
   /** Plugin reviewer hard-failure flag (determines escalate vs fail) */
   pluginFailed: boolean;
+  /**
+   * True when only mechanical checks failed (build/typecheck/lint) but LLM checks
+   * (semantic/adversarial) passed. Signals to autofix that the code is functionally
+   * correct and UNRESOLVED should not trigger tier escalation.
+   */
+  mechanicalFailedOnly?: boolean;
 }
 
 export class ReviewOrchestrator {
@@ -98,7 +104,9 @@ export class ReviewOrchestrator {
     const hasSemantic = reviewConfig.checks.includes("semantic");
     const hasAdversarial = reviewConfig.checks.includes("adversarial");
 
-    if (hasSemantic || hasAdversarial) {
+    const hasLLMChecks = hasSemantic || hasAdversarial;
+
+    if (hasLLMChecks) {
       const active = [hasSemantic ? "semantic" : null, hasAdversarial ? "adversarial" : null]
         .filter(Boolean)
         .join(", ");
@@ -129,11 +137,37 @@ export class ReviewOrchestrator {
     })();
 
     let builtIn: ReviewResult;
+    let mechanicalFailedOnly: boolean | undefined;
 
-    if (canParallelize) {
-      // Run mechanical checks (non-LLM) first — fail-fast preserved for lint/typecheck/etc.
-      const mechanicalChecks = reviewConfig.checks.filter((c) => c !== "semantic" && c !== "adversarial");
-      const mechanicalConfig = { ...reviewConfig, checks: mechanicalChecks };
+    if (!hasLLMChecks) {
+      // No LLM checks configured — run everything flat (backward compatible)
+      builtIn = await runReview(
+        reviewConfig,
+        workdir,
+        executionConfig,
+        qualityCommands,
+        storyId,
+        storyGitRef,
+        story,
+        modelResolver,
+        naxConfig,
+        retrySkipChecks,
+        featureName,
+        resolverSession,
+        priorFailures,
+      );
+    } else {
+      // Always split: mechanical checks first, then LLM checks independently.
+      // This prevents mechanical failures (e.g. lint in a test file the agent cannot touch)
+      // from blocking semantic/adversarial review — and signals to autofix that the code
+      // is functionally correct when LLM checks pass despite mechanical failures.
+      const mechanicalCheckNames = reviewConfig.checks.filter((c) => c !== "semantic" && c !== "adversarial");
+      const llmCheckNames = reviewConfig.checks.filter(
+        (c): c is "semantic" | "adversarial" => c === "semantic" || c === "adversarial",
+      );
+
+      // Step 1: Run mechanical checks (fail-fast preserved within mechanical)
+      const mechanicalConfig = { ...reviewConfig, checks: mechanicalCheckNames };
       const mechanicalResult = await runReview(
         mechanicalConfig,
         workdir,
@@ -150,10 +184,12 @@ export class ReviewOrchestrator {
         priorFailures,
       );
 
-      if (!mechanicalResult.success) {
-        builtIn = mechanicalResult;
-      } else {
-        // Run semantic and adversarial concurrently
+      // Step 2: Run LLM checks regardless of mechanical result (fail-fast within LLM)
+      const llmStart = Date.now();
+      let llmCheckResults: ReviewCheckResult[];
+
+      if (canParallelize) {
+        // semantic + adversarial concurrently
         const semanticStory: SemanticStory = {
           id: storyId ?? "",
           title: story?.title ?? "",
@@ -172,8 +208,6 @@ export class ReviewOrchestrator {
         const adversarialCfg: AdversarialReviewConfig = advConfig as AdversarialReviewConfig;
 
         logger?.debug("review", "Running semantic + adversarial in parallel", { storyId });
-        const parallelStart = Date.now();
-
         const [semResult, advResult] = await Promise.all([
           runSemanticReview(
             workdir,
@@ -197,38 +231,57 @@ export class ReviewOrchestrator {
             priorFailures,
           ),
         ]);
-
-        const llmChecks: ReviewCheckResult[] = [semResult, advResult];
-        const allChecks = [...mechanicalResult.checks, ...llmChecks];
-        const allPassed = allChecks.every((c) => c.success);
-        const firstLlmFailure = llmChecks.find((c) => !c.success);
-        builtIn = {
-          success: allPassed,
-          checks: allChecks,
-          totalDurationMs: mechanicalResult.totalDurationMs + (Date.now() - parallelStart),
-          failureReason: firstLlmFailure ? `${firstLlmFailure.check} failed` : undefined,
-        };
+        llmCheckResults = [semResult, advResult];
+      } else {
+        // Sequential LLM run via runReview (handles semantic and adversarial in-loop)
+        const llmConfig = { ...reviewConfig, checks: llmCheckNames };
+        const llmResult = await runReview(
+          llmConfig,
+          workdir,
+          executionConfig,
+          qualityCommands,
+          storyId,
+          storyGitRef,
+          story,
+          modelResolver,
+          naxConfig,
+          retrySkipChecks,
+          featureName,
+          resolverSession,
+          priorFailures,
+        );
+        llmCheckResults = llmResult.checks;
       }
-    } else {
-      builtIn = await runReview(
-        reviewConfig,
-        workdir,
-        executionConfig,
-        qualityCommands,
-        storyId,
-        storyGitRef,
-        story,
-        modelResolver,
-        naxConfig,
-        retrySkipChecks,
-        featureName,
-        resolverSession,
-        priorFailures,
-      );
+
+      const allChecks = [...mechanicalResult.checks, ...llmCheckResults];
+      const mechanicalPassed = mechanicalResult.success;
+      const llmPassed = llmCheckResults.every((c) => c.success);
+      const firstFailure = allChecks.find((c) => !c.success);
+      const failureReason = firstFailure
+        ? firstFailure.check === "semantic" || firstFailure.check === "adversarial"
+          ? `${firstFailure.check} failed`
+          : `${firstFailure.check} failed (exit code ${firstFailure.exitCode})`
+        : undefined;
+
+      builtIn = {
+        success: mechanicalPassed && llmPassed,
+        checks: allChecks,
+        totalDurationMs: mechanicalResult.totalDurationMs + (Date.now() - llmStart),
+        failureReason,
+      };
+
+      // Signal to autofix that code is functionally correct (LLM passed) despite mechanical failure
+      mechanicalFailedOnly = !mechanicalPassed && llmPassed;
     }
 
     if (!builtIn.success) {
-      return { builtIn, success: false, failureReason: builtIn.failureReason, pluginFailed: false };
+      return {
+        builtIn,
+        success: false,
+        failureReason: builtIn.failureReason,
+        pluginFailed: false,
+        mechanicalFailedOnly,
+      };
     }
 
     if (reviewConfig.pluginMode === "deferred") {

--- a/test/unit/pipeline/stages/autofix-unresolved.test.ts
+++ b/test/unit/pipeline/stages/autofix-unresolved.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for autofixStage — UNRESOLVED suppression for mechanical-only failures.
+ *
+ * Covers nathapp-io/nax#405: when only mechanical checks (lint/typecheck) failed but
+ * LLM checks (semantic/adversarial) passed, the agent cannot fix unfixable errors in
+ * files it is not allowed to modify (e.g. lint in test files). In this case the
+ * UNRESOLVED signal from the agent should NOT trigger tier escalation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { _autofixDeps, autofixStage } from "../../../../src/pipeline/stages/autofix";
+import type { PipelineContext } from "../../../../src/pipeline/types";
+import { DEFAULT_CONFIG } from "../../../../src/config";
+import type { ReviewCheckResult } from "../../../../src/review/types";
+
+function makeFailedReviewResult(checks: Partial<ReviewCheckResult>[]) {
+  const fullChecks = checks.map((c) => ({
+    check: c.check ?? "lint",
+    success: false,
+    command: c.command ?? "biome check",
+    exitCode: c.exitCode ?? 1,
+    output: c.output ?? "error output",
+    durationMs: c.durationMs ?? 100,
+  }));
+  return { success: false, checks: fullChecks } as any;
+}
+
+function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  return {
+    config: {
+      ...DEFAULT_CONFIG,
+      quality: {
+        ...DEFAULT_CONFIG.quality,
+        commands: {
+          ...DEFAULT_CONFIG.quality.commands,
+          lintFix: "biome check --fix",
+          formatFix: "biome format --write",
+        },
+        autofix: { enabled: true, maxAttempts: 2 },
+      },
+    } as any,
+    prd: { stories: [] } as any,
+    story: { id: "US-001", title: "t", status: "in-progress", acceptanceCriteria: [] } as any,
+    stories: [],
+    routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
+    rootConfig: DEFAULT_CONFIG,
+    workdir: "/tmp",
+    projectDir: "/tmp",
+    hooks: {} as any,
+    ...overrides,
+  };
+}
+
+describe("autofixStage — UNRESOLVED suppression for mechanical-only failures (#405)", () => {
+  test("returns continue (not escalate) when UNRESOLVED and mechanicalFailedOnly=true", async () => {
+    const saved = { ..._autofixDeps };
+    _autofixDeps.recheckReview = async () => false;
+    _autofixDeps.runAgentRectification = async () => ({
+      succeeded: false,
+      cost: 0,
+      unresolvedReason: "lint error in test file cannot be fixed without modifying test files",
+    });
+
+    const ctx = makeCtx({
+      reviewResult: makeFailedReviewResult([{ check: "lint", output: "no-non-null-assertion in spec.ts" }]),
+      mechanicalFailedOnly: true,
+    });
+    const result = await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(result.action).toBe("continue");
+  });
+
+  test("marks reviewResult.success=true when suppressing UNRESOLVED for mechanical-only", async () => {
+    const saved = { ..._autofixDeps };
+    _autofixDeps.recheckReview = async () => false;
+    _autofixDeps.runAgentRectification = async () => ({
+      succeeded: false,
+      cost: 0,
+      unresolvedReason: "cannot fix lint in test file",
+    });
+
+    const ctx = makeCtx({
+      reviewResult: makeFailedReviewResult([{ check: "lint" }]),
+      mechanicalFailedOnly: true,
+    });
+    await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(ctx.reviewResult?.success).toBe(true);
+  });
+
+  test("still escalates when UNRESOLVED and mechanicalFailedOnly=false", async () => {
+    const saved = { ..._autofixDeps };
+    _autofixDeps.recheckReview = async () => false;
+    _autofixDeps.runAgentRectification = async () => ({
+      succeeded: false,
+      cost: 0,
+      unresolvedReason: "semantic findings contradict each other",
+    });
+
+    const ctx = makeCtx({
+      reviewResult: makeFailedReviewResult([{ check: "semantic" }]),
+      mechanicalFailedOnly: false,
+    });
+    const result = await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(result.action).toBe("escalate");
+  });
+
+  test("still escalates when UNRESOLVED and mechanicalFailedOnly is undefined", async () => {
+    const saved = { ..._autofixDeps };
+    _autofixDeps.recheckReview = async () => false;
+    _autofixDeps.runAgentRectification = async () => ({
+      succeeded: false,
+      cost: 0,
+      unresolvedReason: "conflicting instructions",
+    });
+
+    const ctx = makeCtx({
+      reviewResult: makeFailedReviewResult([{ check: "lint" }]),
+      // mechanicalFailedOnly not set
+    });
+    const result = await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(result.action).toBe("escalate");
+  });
+
+  test("recheckReview passing with mechanicalFailedOnly=true takes normal retry path", async () => {
+    // When recheckReview passes first, the suppression path is never reached —
+    // the stage should return retry, not trigger the mechanicalFailedOnly guard.
+    const saved = { ..._autofixDeps };
+    _autofixDeps.runQualityCommand = async () => ({
+      commandName: "lintFix",
+      command: "",
+      success: true,
+      exitCode: 0,
+      output: "",
+      durationMs: 0,
+      timedOut: false,
+    });
+    _autofixDeps.recheckReview = async () => true;
+
+    const ctx = makeCtx({
+      reviewResult: makeFailedReviewResult([{ check: "lint" }]),
+      mechanicalFailedOnly: true,
+    });
+    const result = await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(result.action).toBe("retry");
+    if (result.action === "retry") expect(result.fromStage).toBe("review");
+  });
+});

--- a/test/unit/pipeline/stages/autofix.test.ts
+++ b/test/unit/pipeline/stages/autofix.test.ts
@@ -442,3 +442,4 @@ describe("autofixStage", () => {
     expect(prompts[1]).toContain("URGENT");
   });
 });
+

--- a/test/unit/review/orchestrator.test.ts
+++ b/test/unit/review/orchestrator.test.ts
@@ -15,8 +15,8 @@ import type { NaxConfig } from "../../../src/config";
 import type { PluginRegistry } from "../../../src/plugins";
 import type { IReviewPlugin } from "../../../src/plugins/extensions";
 import { ReviewOrchestrator, _orchestratorDeps } from "../../../src/review/orchestrator";
-import { _reviewGitDeps as _runnerDeps } from "../../../src/review/runner";
-import type { ReviewConfig } from "../../../src/review/types";
+import { _reviewAdversarialDeps, _reviewGitDeps as _runnerDeps, _reviewSemanticDeps } from "../../../src/review/runner";
+import type { ReviewCheckResult, ReviewConfig } from "../../../src/review/types";
 import { withDepsRestore } from "../../helpers/deps";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -25,6 +25,8 @@ import { withDepsRestore } from "../../helpers/deps";
 
 withDepsRestore(_runnerDeps, ["getUncommittedFiles"]);
 withDepsRestore(_orchestratorDeps, ["spawn"]);
+withDepsRestore(_reviewSemanticDeps, ["runSemanticReview"]);
+withDepsRestore(_reviewAdversarialDeps, ["runAdversarialReview"]);
 
 function makeReviewConfig(pluginMode?: "per-story" | "deferred"): ReviewConfig {
   // pluginMode is added by DR-001 — cast until the type is updated
@@ -182,5 +184,133 @@ describe("ReviewOrchestrator — pluginMode undefined (no regression)", () => {
     await orchestrator.review(makeReviewConfig(undefined), "/tmp/workdir", minimalExecConfig, registry);
 
     expect(reviewer.check).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mechanical / LLM isolation (nathapp-io/nax#405)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeSemanticCheckResult(passed: boolean): ReviewCheckResult {
+  return {
+    check: "semantic",
+    success: passed,
+    command: "semantic-review",
+    exitCode: passed ? 0 : 1,
+    output: passed ? "" : "AC compliance issue",
+    durationMs: 100,
+  };
+}
+
+function makeConfigWithSemantic(mechanicalChecks: string[] = ["lint"]): ReviewConfig {
+  return {
+    enabled: true,
+    checks: [...mechanicalChecks, "semantic"],
+    commands: { lint: "biome check" },
+    pluginMode: "deferred",
+  } as unknown as ReviewConfig;
+}
+
+describe("ReviewOrchestrator — mechanical / LLM isolation (#405)", () => {
+  beforeEach(() => {
+    // Default: semantic passes
+    _reviewSemanticDeps.runSemanticReview = mock(async () => makeSemanticCheckResult(true));
+    _reviewAdversarialDeps.runAdversarialReview = mock(async () => makeSemanticCheckResult(true));
+  });
+
+  test("semantic review runs even when mechanical check fails", async () => {
+    // Simulate lint failure via dirty tree (forces runner to fail before running checks)
+    // Then override runner so lint actually fails
+    _runnerDeps.getUncommittedFiles = mock(async () => []);
+    // No lint command configured so it will be skipped — use a failing typecheck instead
+    const config: ReviewConfig = {
+      enabled: true,
+      checks: ["semantic"],
+      commands: {},
+      pluginMode: "deferred",
+    } as unknown as ReviewConfig;
+
+    // With no mechanical checks, semantic should still run
+    const orchestrator = new ReviewOrchestrator();
+    const result = await orchestrator.review(config, "/tmp/workdir", minimalExecConfig);
+
+    expect(_reviewSemanticDeps.runSemanticReview).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  test("mechanicalFailedOnly is true when mechanical fails but semantic passes", async () => {
+    // Dirty tree on the first call (mechanical run) → mechanical fails.
+    // Clean on the second call (LLM run) → LLM proceeds and runs semantic.
+    let callCount = 0;
+    _runnerDeps.getUncommittedFiles = mock(async () => {
+      callCount++;
+      return callCount === 1 ? ["src/changed.ts"] : [];
+    });
+    const orchestrator = new ReviewOrchestrator();
+
+    const result = await orchestrator.review(
+      makeConfigWithSemantic(["lint"]),
+      "/tmp/workdir",
+      minimalExecConfig,
+    );
+
+    // Mechanical failed (dirty tree), semantic mocked to pass
+    expect(result.success).toBe(false);
+    expect(result.mechanicalFailedOnly).toBe(true);
+    // Semantic should have been attempted despite mechanical failure
+    expect(_reviewSemanticDeps.runSemanticReview).toHaveBeenCalledTimes(1);
+  });
+
+  test("mechanicalFailedOnly is false when semantic also fails", async () => {
+    // Same call-counter trick: dirty for mechanical, clean for LLM so semantic actually runs.
+    let callCount = 0;
+    _runnerDeps.getUncommittedFiles = mock(async () => {
+      callCount++;
+      return callCount === 1 ? ["src/changed.ts"] : [];
+    });
+    _reviewSemanticDeps.runSemanticReview = mock(async () => makeSemanticCheckResult(false));
+    const orchestrator = new ReviewOrchestrator();
+
+    const result = await orchestrator.review(
+      makeConfigWithSemantic(["lint"]),
+      "/tmp/workdir",
+      minimalExecConfig,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.mechanicalFailedOnly).toBe(false);
+  });
+
+  test("mechanicalFailedOnly is undefined when no LLM checks configured", async () => {
+    _runnerDeps.getUncommittedFiles = mock(async () => ["src/changed.ts"]);
+    const config: ReviewConfig = {
+      enabled: true,
+      checks: ["lint"],
+      commands: { lint: "biome check" },
+      pluginMode: "deferred",
+    } as unknown as ReviewConfig;
+    const orchestrator = new ReviewOrchestrator();
+
+    const result = await orchestrator.review(config, "/tmp/workdir", minimalExecConfig);
+
+    expect(result.mechanicalFailedOnly).toBeUndefined();
+  });
+
+  test("both mechanical and semantic results appear in checks array", async () => {
+    _runnerDeps.getUncommittedFiles = mock(async () => []);
+    // No mechanical commands → mechanical phase produces no checks; semantic passes
+    const config: ReviewConfig = {
+      enabled: true,
+      checks: ["semantic"],
+      commands: {},
+      pluginMode: "deferred",
+    } as unknown as ReviewConfig;
+    const orchestrator = new ReviewOrchestrator();
+
+    const result = await orchestrator.review(config, "/tmp/workdir", minimalExecConfig);
+
+    const checkNames = result.builtIn.checks.map((c) => c.check);
+    expect(checkNames).toContain("semantic");
+    expect(result.success).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #405

## Problem

Mechanical checks (build/typecheck/lint) and LLM checks (semantic/adversarial) ran in a single fail-fast loop. When lint failed on a test file the agent cannot modify (per its "Do NOT change test files" constraint), the agent signalled `UNRESOLVED` and the story escalated to a more expensive model tier — even when the implementation was functionally correct.

Real example: `Forbidden non-null assertion` warning in `endpoint.e2e.spec.ts` with `--max-warnings=0` → lint `exit=1` → agent: "can't fix test file" → `UNRESOLVED` → escalation to `powerful` tier.

## Solution

Run mechanical and LLM checks as two independent phases. LLM checks always run regardless of mechanical result. A new `mechanicalFailedOnly` flag signals to autofix that the code is functionally correct — UNRESOLVED should not trigger tier escalation.

## Changes

| File | Change |
|------|--------|
| `src/review/orchestrator.ts` | Always split mechanical/LLM when LLM checks configured; sets `mechanicalFailedOnly` |
| `src/pipeline/types.ts` | Add `mechanicalFailedOnly?: boolean` to `PipelineContext` |
| `src/pipeline/stages/review.ts` | Pass `mechanicalFailedOnly` through to context |
| `src/pipeline/stages/autofix.ts` | Suppress UNRESOLVED escalation when `mechanicalFailedOnly=true` |
| `test/unit/review/orchestrator.test.ts` | 5 new tests for mechanical/LLM split |
| `test/unit/pipeline/stages/autofix-unresolved.test.ts` | 5 new tests for UNRESOLVED suppression |

## Flow After This Change

```
review:
  mechanical: build ✓ → typecheck ✓ → lint ✗ (test file)
  LLM:        semantic ✓              ← runs regardless of lint failure
  result:     success=false, mechanicalFailedOnly=true

autofix: lintFix → lint still fails → agent rectification
agent:  "cannot fix lint in test file" → UNRESOLVED
autofix: mechanicalFailedOnly=true → suppress escalation → continue ✓
```

## Test Plan

- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean  
- [ ] `bun test test/unit/review/orchestrator.test.ts` — 12 pass (5 new)
- [ ] `bun test test/unit/pipeline/stages/autofix-unresolved.test.ts` — 5 pass (new file)
- [ ] `bun run test:bail` — full suite green (1186 pass, 0 fail)