### PR TITLE
fix(review): own session for semantic review + skip passed checks in rectification

### DIFF
--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -28,6 +28,7 @@ import { getLogger } from "../../logger";
 import { RectifierPromptBuilder } from "../../prompts";
 import { runQualityCommand } from "../../quality";
 import type { ReviewCheckResult } from "../../review/types";
+import { captureGitRef } from "../../utils/git";
 import {
   buildProgressivePromptPreamble,
   runSharedRectificationLoop,
@@ -286,6 +287,10 @@ async function runAgentRectification(
   };
   let autofixCostAccum = 0;
   let unresolvedReason: string | undefined;
+  // #411: Track git HEAD before each agent attempt so checkResult can detect
+  // whether the agent actually modified source files. When no files changed
+  // (e.g. UNRESOLVED signal, lint-only fix), passed LLM checks are skipped.
+  let refBeforeAttempt: string | undefined;
 
   // Session continuity: execution + review came before us, so the implementer session is open.
   const implementerSession = buildSessionName(ctx.workdir, ctx.prd.feature, ctx.story.id, "implementer");
@@ -337,6 +342,8 @@ async function runAgentRectification(
       return prompt;
     },
     runAttempt: async (attempt, prompt) => {
+      // #411: Capture HEAD before agent runs so checkResult can detect file changes.
+      refBeforeAttempt = await captureGitRef(ctx.workdir);
       ctx.autofixAttempt = consumed + attempt;
       const agent = agentGetFn(ctx.rootConfig.autoMode.defaultAgent);
       if (!agent) {
@@ -417,6 +424,22 @@ async function runAgentRectification(
       }
     },
     checkResult: async (attempt, state) => {
+      // #411: Detect whether the agent modified source files since the attempt started.
+      // When no files changed (e.g. UNRESOLVED signal, lint-only), skip LLM checks
+      // that already passed — they'll return the same result on the unchanged diff.
+      const refAfterAttempt = await captureGitRef(ctx.workdir);
+      const sourceFilesChanged = refBeforeAttempt !== refAfterAttempt;
+      if (!sourceFilesChanged) {
+        const passedChecks = (ctx.reviewResult?.checks ?? []).filter((c) => c.success).map((c) => c.check);
+        if (passedChecks.length > 0) {
+          ctx.retrySkipChecks = new Set(passedChecks);
+          logger.debug("autofix", "No source changes — skipping already-passed checks on recheck", {
+            storyId: ctx.story.id,
+            skippedChecks: passedChecks,
+          });
+        }
+      }
+
       const passed = await _autofixDeps.recheckReview(ctx);
       if (passed) {
         logger.info("autofix", `[OK] Agent rectification succeeded on attempt ${attempt}`, {

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -7,7 +7,7 @@
  * is handled by lint/typecheck, not semantic review.
  */
 
-import { buildSessionName, readAcpSession } from "../agents/acp/adapter";
+import { buildSessionName } from "../agents/acp/adapter";
 import type { AgentAdapter } from "../agents/types";
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
@@ -31,7 +31,6 @@ export type ModelResolver = (tier: ModelTier) => AgentAdapter | null | undefined
 /** Injectable dependencies for semantic.ts — allows tests to mock without mock.module() */
 export const _semanticDeps = {
   createDebateSession: (opts: DebateSessionOptions): DebateSession => new DebateSession(opts),
-  readAcpSession,
 };
 
 interface LLMFinding {
@@ -355,17 +354,10 @@ export async function runSemanticReview(
     };
   }
 
-  // Check if implementer session exists (fail-open — proceed regardless)
-  const implementerSidecarKey = `${story.id}:implementer`;
-  const existingSession = await _semanticDeps.readAcpSession(workdir, featureName ?? "", implementerSidecarKey);
-  if (!existingSession) {
-    logger?.debug("semantic", "implementer session not found — semantic review running in new session", {
-      storyId: story.id,
-    });
-  }
-
-  // Call LLM via agent.run() targeting the implementer session
-  const implementerSessionName = buildSessionName(workdir, featureName, story.id, "implementer");
+  // Call LLM via agent.run() with own reviewer session (not the implementer session).
+  // The reviewer works from diff + tools, not from implementer conversation history.
+  // See #414: supersedes #262 US-003 session-sharing design.
+  const reviewerSessionName = buildSessionName(workdir, featureName, story.id, "reviewer-semantic");
   const defaultAgent = naxConfig?.autoMode?.defaultAgent ?? "claude";
   let resolvedModelDef = { provider: "anthropic", model: "claude-sonnet-4-5-20250514" };
   try {
@@ -381,8 +373,8 @@ export async function runSemanticReview(
     const runResult = await agent.run({
       prompt,
       workdir,
-      acpSessionName: implementerSessionName,
-      keepSessionOpen: true,
+      acpSessionName: reviewerSessionName,
+      keepSessionOpen: false,
       timeoutSeconds: semanticConfig.timeoutMs ? Math.ceil(semanticConfig.timeoutMs / 1000) : 3600,
       modelTier: semanticConfig.modelTier,
       modelDef: resolvedModelDef,

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -866,24 +866,20 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
   let origSpawn: typeof _diffUtilsDeps.spawn;
   let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
   let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
-  let origReadAcpSession: typeof _semanticDeps.readAcpSession;
 
   beforeEach(() => {
     origSpawn = _diffUtilsDeps.spawn;
     origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
     origGetMergeBase = _diffUtilsDeps.getMergeBase;
-    origReadAcpSession = _semanticDeps.readAcpSession;
     _diffUtilsDeps.isGitRefValid = mock(async () => true);
     _diffUtilsDeps.getMergeBase = mock(async () => undefined);
     _diffUtilsDeps.spawn = makeSpawnMock("some diff content", 0);
-    _semanticDeps.readAcpSession = mock(async () => "nax-abc123-feature-us-003-implementer");
   });
 
   afterEach(() => {
     _diffUtilsDeps.spawn = origSpawn;
     _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
     _diffUtilsDeps.getMergeBase = origGetMergeBase;
-    _semanticDeps.readAcpSession = origReadAcpSession;
   });
 
   test("calls agent.run() for the non-debate path", async () => {
@@ -902,11 +898,11 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
     expect(agent.complete).not.toHaveBeenCalled();
   });
 
-  test("agent.run() receives acpSessionName targeting the implementer session", async () => {
+  test("agent.run() receives acpSessionName targeting own reviewer-semantic session (#414)", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
     const workdir = "/my/project";
     const featureName = "my-feature";
-    const expectedSession = buildSessionName(workdir, featureName, STORY.id, "implementer");
+    const expectedSession = buildSessionName(workdir, featureName, STORY.id, "reviewer-semantic");
 
     await runSemanticReview(workdir, "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, featureName);
 
@@ -915,22 +911,22 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
     expect(runOpts.acpSessionName).toBe(expectedSession);
   });
 
-  test("agent.run() receives keepSessionOpen: true (session stays alive for autofix)", async () => {
+  test("agent.run() receives keepSessionOpen: false (one-shot, stateless per cycle) (#414)", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
     expect(agent.run).toHaveBeenCalled();
     const runOpts = (agent.run as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
-    expect(runOpts.keepSessionOpen).toBe(true);
+    expect(runOpts.keepSessionOpen).toBe(false);
   });
 
   test("acpSessionName encodes workdir hash in session name", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
     const workdirA = "/project/alpha";
     const workdirB = "/project/beta";
-    const sessionA = buildSessionName(workdirA, "feat", STORY.id, "implementer");
-    const sessionB = buildSessionName(workdirB, "feat", STORY.id, "implementer");
+    const sessionA = buildSessionName(workdirA, "feat", STORY.id, "reviewer-semantic");
+    const sessionB = buildSessionName(workdirB, "feat", STORY.id, "reviewer-semantic");
 
     await runSemanticReview(workdirA, "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, "feat");
     const runOptsA = (agent.run as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
@@ -942,7 +938,7 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
   test("acpSessionName encodes featureName in session name", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
     const featureName = "semantic-continuity";
-    const expectedSession = buildSessionName("/tmp/wd", featureName, STORY.id, "implementer");
+    const expectedSession = buildSessionName("/tmp/wd", featureName, STORY.id, "reviewer-semantic");
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, featureName);
 
@@ -953,7 +949,7 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
   test("acpSessionName encodes storyId in session name", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
     const storyWithDifferentId: SemanticStory = { ...STORY, id: "US-999" };
-    const expectedSession = buildSessionName("/tmp/wd", "feat", "US-999", "implementer");
+    const expectedSession = buildSessionName("/tmp/wd", "feat", "US-999", "reviewer-semantic");
 
     await runSemanticReview("/tmp/wd", "abc123", storyWithDifferentId, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, "feat");
 
@@ -1031,76 +1027,6 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
 });
 
 // ---------------------------------------------------------------------------
-// US-003 AC-5: debug log when implementer session not found
+// #414: Semantic review uses own session, not implementer session
+// (supersedes US-003 AC-5 readAcpSession sidecar check — removed)
 // ---------------------------------------------------------------------------
-
-describe("runSemanticReview — reads implementer session sidecar before run() (US-003 AC-5)", () => {
-  let origSpawn: typeof _diffUtilsDeps.spawn;
-  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
-  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
-  let origReadAcpSession: typeof _semanticDeps.readAcpSession;
-
-  beforeEach(() => {
-    origSpawn = _diffUtilsDeps.spawn;
-    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
-    origGetMergeBase = _diffUtilsDeps.getMergeBase;
-    origReadAcpSession = _semanticDeps.readAcpSession;
-    _diffUtilsDeps.isGitRefValid = mock(async () => true);
-    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
-    _diffUtilsDeps.spawn = makeSpawnMock("some diff content", 0);
-  });
-
-  afterEach(() => {
-    _diffUtilsDeps.spawn = origSpawn;
-    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
-    _diffUtilsDeps.getMergeBase = origGetMergeBase;
-    _semanticDeps.readAcpSession = origReadAcpSession;
-  });
-
-  test("calls readAcpSession to check if implementer session exists", async () => {
-    _semanticDeps.readAcpSession = mock(async () => null);
-    const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
-
-    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, "my-feature");
-
-    expect(_semanticDeps.readAcpSession).toHaveBeenCalled();
-  });
-
-  test("still calls agent.run() when implementer session is not found (fail-open)", async () => {
-    _semanticDeps.readAcpSession = mock(async () => null);
-    const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
-
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, "my-feature");
-
-    expect(agent.run).toHaveBeenCalled();
-    expect(result.success).toBe(true);
-  });
-
-  test("still calls agent.run() when implementer session exists (happy path)", async () => {
-    _semanticDeps.readAcpSession = mock(async () => "nax-abc12345-feature-us-002-implementer");
-    const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
-
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, "my-feature");
-
-    expect(agent.run).toHaveBeenCalled();
-    expect(result.success).toBe(true);
-  });
-
-  test("checks sidecar with implementer role key for the story", async () => {
-    const readMock = mock(async () => null);
-    _semanticDeps.readAcpSession = readMock;
-    const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
-
-    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, "my-feature");
-
-    // readAcpSession should be called with workdir and featureName and a key containing storyId and "implementer"
-    expect(readMock).toHaveBeenCalled();
-    const callArgs = readMock.mock.calls[0] as unknown[];
-    expect(callArgs[0]).toBe("/tmp/wd");
-    expect(callArgs[1]).toBe("my-feature");
-    // The sidecar key should include storyId and implementer role
-    const sidecarKey = callArgs[2] as string;
-    expect(sidecarKey).toContain(STORY.id);
-    expect(sidecarKey.toLowerCase()).toContain("implementer");
-  });
-});


### PR DESCRIPTION
## Summary

Two independent fixes from v0.62.0-canary.2 post-run analysis (`docs/findings/FINDING-review-loop-v0.62.md`):

- **#414**: Move non-dialogue semantic review to its own session (`reviewer-semantic`) instead of sharing the implementer session. Supersedes #262 US-003 session-sharing design.
- **#411**: Skip passed LLM review checks inside rectification loop when no source files changed during the attempt.

## Changes

### #414 — Semantic review own session (`src/review/semantic.ts`)

- `acpSessionName` changed from `implementerSessionName` to `buildSessionName(..., "reviewer-semantic")`
- `keepSessionOpen` changed from `true` to `false` (one-shot, stateless per cycle)
- Removed `readAcpSession` sidecar check and import (no longer needed)
- Removed `readAcpSession` from `_semanticDeps`

**Why:** The semantic reviewer should not pollute the implementer session with reviewer turns. Own session keeps the implementer context clean for rectification, simplifies escalation cleanup (#410), and prevents reviewer bias from implementer reasoning. All reviewers (semantic, adversarial) now follow the same pattern: own session, `keepSessionOpen: false`.

### #411 — Skip passed checks in rectification (`src/pipeline/stages/autofix.ts`)

- Captures `git rev-parse HEAD` before each agent attempt (`refBeforeAttempt`)
- After attempt, compares HEAD — if unchanged, sets `ctx.retrySkipChecks` with passed checks
- `recheckReview()` then skips those checks via existing `retrySkipChecks` mechanism (#136)

**Why:** When one LLM check fails (e.g. adversarial) but the other passes (e.g. semantic), the inner `recheckReview()` re-runs both. If the agent made no code changes (e.g. UNRESOLVED signal), the passed check will return the same result. Saves ~15s + LLM cost per redundant check per rectification cycle.

| Rectification outcome | Files changed? | Skip passed checks? |
|----------------------|---------------|---------------------|
| UNRESOLVED (no fix) | No | Yes |
| Lint/format fix only | No | Yes |
| Implementer fixed code | Yes | No — must re-verify |

## Test plan

- [x] Typecheck clean
- [x] Lint clean
- [x] `test/unit/review/semantic.test.ts` — 59 pass, 0 fail (updated session name + keepSessionOpen assertions, removed sidecar tests)
- [x] `test/unit/pipeline/stages/autofix.test.ts` — 19 pass, 0 fail
- [x] Full suite — 1185 pass, 0 fail, 39 skip

Closes #414, closes #411