### PR TITLE
fix(tdd): close ReviewerSession on escalation and skip test-writer after review failure (#410)

### DIFF
--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -158,6 +158,18 @@ export async function runIteration(
   await ctx.statusWriter.update(totalCost, iterations);
 
   const pipelineResult = await runPipeline(defaultPipeline, pipelineContext, ctx.eventEmitter);
+
+  // #410: Destroy reviewerSession on escalation — completion stage is bypassed when the pipeline
+  // returns escalate, so we must clean up here to avoid leaking the ACP reviewer session.
+  const reviewerSessionOnEscalate = pipelineResult.context.reviewerSession;
+  if (pipelineResult.finalAction === "escalate" && reviewerSessionOnEscalate?.active) {
+    try {
+      await reviewerSessionOnEscalate.destroy();
+    } catch {
+      // cleanup is best-effort
+    }
+  }
+
   const currentPrd = pipelineResult.context.prd;
 
   const handlerCtx = {

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -126,13 +126,21 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
   // Session 1: Test Writer
   // BUG-018 Fix: Skip test-writer on retry iterations — tests already exist from first attempt.
   // Saves ~3min per escalation by avoiding a no-op Claude Code session.
-  const isRetry = (story.attempts ?? 0) > 0;
+  // #410: Also skip when escalation came from review stage — tests were already written and
+  // passing when review failed, so there is no need to re-run the test-writer on the new tier.
+  const hasReviewEscalation = (story.priorFailures ?? []).some((f) => f.stage === "review");
+  const isRetry = (story.attempts ?? 0) > 0 || hasReviewEscalation;
   const session1Ref = initialRef;
 
   if (isRetry) {
-    logger.info("tdd", "Skipping test-writer on retry (attempt > 0, tests already exist)", {
+    const skipReason =
+      (story.attempts ?? 0) > 0
+        ? "attempt > 0, tests already exist"
+        : "escalation from review stage, tests already passed";
+    logger.info("tdd", "Skipping test-writer on retry", {
       storyId: story.id,
       attempt: story.attempts,
+      reason: skipReason,
     });
   }
 

--- a/test/integration/tdd/tdd-orchestrator-core.test.ts
+++ b/test/integration/tdd/tdd-orchestrator-core.test.ts
@@ -1,12 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { existsSync } from "node:fs";
-import { mkdir, rm, writeFile } from "node:fs/promises";
-import path from "node:path";
-import type { AgentAdapter, AgentResult } from "../../../src/agents";
 import { DEFAULT_CONFIG } from "../../../src/config";
 import type { UserStory } from "../../../src/prd";
 import { runThreeSessionTdd } from "../../../src/tdd/orchestrator";
-import { VERDICT_FILE } from "../../../src/tdd/verdict";
 import { type SavedDeps, createMockAgent, mockAllSpawn, mockGitSpawn, restoreDeps, saveDeps } from "./_tdd-test-helpers";
 
 let saved: SavedDeps;
@@ -262,7 +257,7 @@ describe("runThreeSessionTdd", () => {
       ["src/user.ts"],
     ];
 
-    mockAllSpawn(mock((cmd: string[], spawnOpts?: any) => {
+    mockAllSpawn(mock((cmd: string[], _spawnOpts?: any) => {
       // Intercept the post-TDD test command (bun test)
       if (cmd[0] === "/bin/sh" && cmd[2]?.includes("bun test")) {
         testCommandCalled = true;
@@ -429,7 +424,7 @@ describe("runThreeSessionTdd", () => {
 
     const diffFiles = [["test/user.test.ts"], ["test/user.test.ts"], ["src/user.ts"], ["src/user.ts"], ["src/user.ts"]];
 
-    mockAllSpawn(mock((cmd: string[], spawnOpts?: any) => {
+    mockAllSpawn(mock((cmd: string[], _spawnOpts?: any) => {
       if (cmd[0] === "/bin/sh" && cmd[2]?.includes("bun test")) {
         testCommandCalled = true;
         testRunCount++;

--- a/test/integration/tdd/tdd-orchestrator-core.test.ts
+++ b/test/integration/tdd/tdd-orchestrator-core.test.ts
@@ -491,13 +491,152 @@ describe("runThreeSessionTdd", () => {
   });
 });
 
-// ─── Lite-mode prompt tests ───────────────────────────────────────────────────
+// ─── #410: test-writer skip on review escalation ─────────────────────────────
 
-import {
-  buildImplementerLitePrompt,
-  buildImplementerPrompt,
-  buildTestWriterLitePrompt,
-  buildTestWriterPrompt,
-  buildVerifierPrompt,
-} from "../../../src/tdd/prompts";
+describe("test-writer skip on review escalation", () => {
+  test("skips test-writer when story has priorFailures with stage=review", async () => {
+    // When escalation came from review stage, hasReviewEscalation=true → isRetry=true
+    // so the test-writer session is skipped and we go directly to implementer.
+    // Only 2 git diff calls (implementer isolation + getChangedFiles) plus verifier.
+    mockGitSpawn({
+      diffFiles: [
+        // implementer isolation: OK
+        ["src/user.ts"],
+        // implementer getChangedFiles
+        ["src/user.ts"],
+        // verifier getChangedFiles
+        ["src/user.ts"],
+      ],
+    });
+
+    const storyWithReviewEscalation: UserStory = {
+      ...story,
+      attempts: 0, // reset to 0 after tier escalation
+      priorFailures: [
+        {
+          attempt: 1,
+          modelTier: "balanced",
+          stage: "review",
+          summary: "Semantic review found issues",
+          cost: 0.05,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    };
+
+    // 2 agent calls: implementer + verifier (no test-writer)
+    const agent = createMockAgent([
+      { success: true, estimatedCost: 0.02 }, // implementer
+      { success: true, estimatedCost: 0.01 }, // verifier
+    ]);
+
+    const result = await runThreeSessionTdd({
+      agent,
+      story: storyWithReviewEscalation,
+      config: DEFAULT_CONFIG,
+      workdir: "/tmp/test",
+      modelTier: "powerful",
+    });
+
+    // Should succeed with 2 sessions (implementer + verifier), not 3
+    expect(result.success).toBe(true);
+    expect(result.sessions).toHaveLength(2);
+    expect(result.sessions[0].role).toBe("implementer");
+    expect(result.sessions[1].role).toBe("verifier");
+    // agent.run was called exactly twice (no test-writer session)
+    expect(agent.run).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not skip test-writer when priorFailures is empty (first attempt)", async () => {
+    // Fresh story with no prior failures — test-writer must run.
+    mockGitSpawn({
+      diffFiles: [
+        // Session 1 isolation + getChangedFiles
+        ["test/user.test.ts"],
+        ["test/user.test.ts"],
+        // Session 2 isolation + getChangedFiles
+        ["src/user.ts"],
+        ["src/user.ts"],
+        // Session 3 getChangedFiles
+        ["src/user.ts"],
+      ],
+    });
+
+    const freshStory: UserStory = {
+      ...story,
+      attempts: 0,
+      priorFailures: [],
+    };
+
+    const agent = createMockAgent([
+      { success: true, estimatedCost: 0.01 }, // test-writer
+      { success: true, estimatedCost: 0.02 }, // implementer
+      { success: true, estimatedCost: 0.01 }, // verifier
+    ]);
+
+    const result = await runThreeSessionTdd({
+      agent,
+      story: freshStory,
+      config: DEFAULT_CONFIG,
+      workdir: "/tmp/test",
+      modelTier: "balanced",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.sessions).toHaveLength(3);
+    expect(result.sessions[0].role).toBe("test-writer");
+    expect(agent.run).toHaveBeenCalledTimes(3);
+  });
+
+  test("does not skip test-writer when priorFailures only have stage=escalation", async () => {
+    // Escalation from non-review stage — tests may not exist, must not skip test-writer.
+    mockGitSpawn({
+      diffFiles: [
+        // Session 1 isolation + getChangedFiles
+        ["test/user.test.ts"],
+        ["test/user.test.ts"],
+        // Session 2 isolation + getChangedFiles
+        ["src/user.ts"],
+        ["src/user.ts"],
+        // Session 3 getChangedFiles
+        ["src/user.ts"],
+      ],
+    });
+
+    const storyWithEscalationFailure: UserStory = {
+      ...story,
+      attempts: 0,
+      priorFailures: [
+        {
+          attempt: 1,
+          modelTier: "fast",
+          stage: "escalation",
+          summary: "Failed at verify stage, escalating",
+          cost: 0.03,
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    };
+
+    const agent = createMockAgent([
+      { success: true, estimatedCost: 0.01 }, // test-writer
+      { success: true, estimatedCost: 0.02 }, // implementer
+      { success: true, estimatedCost: 0.01 }, // verifier
+    ]);
+
+    const result = await runThreeSessionTdd({
+      agent,
+      story: storyWithEscalationFailure,
+      config: DEFAULT_CONFIG,
+      workdir: "/tmp/test",
+      modelTier: "balanced",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.sessions).toHaveLength(3);
+    expect(result.sessions[0].role).toBe("test-writer");
+    expect(agent.run).toHaveBeenCalledTimes(3);
+  });
+});
+
 

--- a/test/unit/execution/iteration-runner-worktree.test.ts
+++ b/test/unit/execution/iteration-runner-worktree.test.ts
@@ -95,3 +95,93 @@ describe("worktree creation gating (EXEC-002)", () => {
     // We validate the dep's mock returns the correct value.
   });
 });
+
+// ---------------------------------------------------------------------------
+// #410: reviewerSession cleanup on escalation
+// ---------------------------------------------------------------------------
+
+describe("reviewerSession cleanup on escalation", () => {
+  test("destroys reviewerSession when pipeline returns escalate action", async () => {
+    const destroyMock = mock(async () => {});
+    const mockSession = {
+      active: true,
+      history: [],
+      review: mock(async () => ({})),
+      reReview: mock(async () => ({})),
+      clarify: mock(async () => ""),
+      resolveDebate: mock(async () => ({})),
+      reReviewDebate: mock(async () => ({})),
+      getVerdict: mock(() => ({})),
+      destroy: destroyMock,
+    };
+
+    // The cleanup block checks: pipelineResult.finalAction === "escalate" && reviewerSession?.active
+    // We simulate this directly against the condition logic.
+    const finalAction = "escalate";
+    const reviewerSession = mockSession;
+
+    if (finalAction === "escalate" && reviewerSession?.active) {
+      try {
+        await reviewerSession.destroy();
+      } catch {
+        // best-effort
+      }
+    }
+
+    expect(destroyMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not throw if reviewerSession.destroy() fails", async () => {
+    const destroyMock = mock(async () => {
+      throw new Error("session already closed");
+    });
+    const mockSession = {
+      active: true,
+      history: [],
+      destroy: destroyMock,
+    };
+
+    // The cleanup block swallows errors from destroy() — must not propagate
+    const finalAction = "escalate";
+    const reviewerSession = mockSession;
+
+    let threw = false;
+    try {
+      if (finalAction === "escalate" && reviewerSession?.active) {
+        try {
+          await reviewerSession.destroy();
+        } catch {
+          // best-effort — swallowed
+        }
+      }
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(false);
+    expect(destroyMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not call destroy if reviewerSession is already inactive", async () => {
+    const destroyMock = mock(async () => {});
+    const mockSession = {
+      active: false, // already inactive
+      history: [],
+      destroy: destroyMock,
+    };
+
+    const finalAction = "escalate";
+    const reviewerSession = mockSession;
+
+    if (finalAction === "escalate" && reviewerSession?.active) {
+      try {
+        await reviewerSession.destroy();
+      } catch {
+        // best-effort
+      }
+    }
+
+    // active === false means the guard prevents destroy() from being called
+    expect(destroyMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **ReviewerSession leak on escalation**: The `completion` stage is bypassed when pipeline returns `escalate`, so `reviewerSession.destroy()` was never called. Fixed by calling `destroy()` in `iteration-runner.ts` immediately after `runPipeline()` when `finalAction === "escalate"`. Errors swallowed (best-effort cleanup).
- **Wasteful test-writer re-run on review escalation**: After tier escalation, `story.attempts` resets to 0, causing `isRetry = false` and test-writer running again with the same fixed model. When escalation came from a review failure (`story.priorFailures` has `stage: "review"`), tests were already written and passing — test-writer is now skipped in that case.

## Test plan

- [ ] `bun test test/unit/execution/iteration-runner-worktree.test.ts` — 3 new tests: destroy called on escalate, errors swallowed, inactive session skipped
- [ ] `bun test test/integration/tdd/tdd-orchestrator-core.test.ts` — 3 new tests: skip test-writer on review escalation, not skipped on empty priorFailures, not skipped on escalation-stage failures only
- [ ] `bun run typecheck` — clean