### PR TITLE
feat(acp): surface resumed flag in prompt audit entries

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -214,7 +214,7 @@ export async function ensureAcpSession(
   sessionName: string,
   agentName: string,
   permissionMode: string,
-): Promise<AcpSession> {
+): Promise<{ session: AcpSession; resumed: boolean }> {
   if (!agentName) {
     throw new Error("[acp-adapter] agentName is required for ensureAcpSession");
   }
@@ -225,7 +225,7 @@ export async function ensureAcpSession(
       const existing = await client.loadSession(sessionName, agentName, permissionMode);
       if (existing) {
         getSafeLogger()?.debug("acp-adapter", `Resumed existing session: ${sessionName}`);
-        return existing;
+        return { session: existing, resumed: true };
       }
     } catch {
       // loadSession failed — fall through to createSession
@@ -234,7 +234,7 @@ export async function ensureAcpSession(
 
   // Create a new named session
   getSafeLogger()?.debug("acp-adapter", `Creating new session: ${sessionName}`);
-  return client.createSession({ agentName, permissionMode, sessionName });
+  return { session: await client.createSession({ agentName, permissionMode, sessionName }), resumed: false };
 }
 
 /**
@@ -747,7 +747,7 @@ export class AcpAgentAdapter implements AgentAdapter {
     });
 
     // 3. Ensure session (resume existing or create new)
-    const session = await ensureAcpSession(client, sessionName, agentName, permissionMode);
+    const { session, resumed: sessionResumed } = await ensureAcpSession(client, sessionName, agentName, permissionMode);
 
     // 4. Persist for plan→run continuity
     if (options.featureName && options.storyId) {
@@ -792,6 +792,7 @@ export class AcpAgentAdapter implements AgentAdapter {
             pipelineStage: options.pipelineStage ?? "run",
             callType: "run",
             turn: turnCount,
+            resumed: sessionResumed,
           });
         }
 

--- a/src/agents/acp/prompt-audit.ts
+++ b/src/agents/acp/prompt-audit.ts
@@ -48,6 +48,8 @@ export interface PromptAuditEntry {
   callType: "run" | "complete";
   /** 1-indexed turn number — only set for run() multi-turn entries. */
   turn?: number;
+  /** Whether the ACP session was resumed (true) or freshly created (false/undefined). */
+  resumed?: boolean;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -103,6 +105,7 @@ function buildAuditContent(entry: PromptAuditEntry, epochMs: number): string {
     `StoryId:   ${entry.storyId ?? "(none)"}`,
     `Feature:   ${entry.featureName ?? "(none)"}`,
     `Stage:     ${entry.pipelineStage ?? entry.callType}`,
+    `Resumed:   ${entry.resumed === true ? "yes" : "no"}`,
     "---",
     entry.prompt,
   ];

--- a/test/unit/agents/acp/adapter-session.test.ts
+++ b/test/unit/agents/acp/adapter-session.test.ts
@@ -370,8 +370,9 @@ describe("AcpAgentAdapter — session mode (run)", () => {
         createSession: async () => { createCalled = true; return makeSession(); },
       };
 
-      const session = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
+      const { session, resumed } = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
       expect(session).toBe(existingSession);
+      expect(resumed).toBe(true);
       expect(createCalled).toBe(false);
     });
 
@@ -385,8 +386,9 @@ describe("AcpAgentAdapter — session mode (run)", () => {
         createSession: async () => { createCalled = true; return newSession; },
       };
 
-      const session = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
+      const { session, resumed } = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
       expect(session).toBe(newSession);
+      expect(resumed).toBe(false);
       expect(createCalled).toBe(true);
     });
 
@@ -399,8 +401,9 @@ describe("AcpAgentAdapter — session mode (run)", () => {
         createSession: async () => { createCalled = true; return newSession; },
       };
 
-      const session = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "default");
+      const { session, resumed } = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "default");
       expect(session).toBe(newSession);
+      expect(resumed).toBe(false);
       expect(createCalled).toBe(true);
     });
 
@@ -414,8 +417,9 @@ describe("AcpAgentAdapter — session mode (run)", () => {
         createSession: async () => { createCalled = true; return newSession; },
       };
 
-      const session = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
+      const { session, resumed } = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
       expect(session).toBe(newSession);
+      expect(resumed).toBe(false);
       expect(createCalled).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

- `ensureAcpSession` now returns `{ session, resumed }` instead of bare `AcpSession`, surfacing whether the session was loaded from an existing store or freshly created
- `PromptAuditEntry` gains an optional `resumed?: boolean` field; `buildAuditContent` emits a `Resumed: yes/no` line in the audit file header
- Adapter call site threads `resumed: sessionResumed` into every `writePromptAudit` call
- Four `ensureAcpSession` unit tests updated to destructure and assert the `resumed` boolean

## Test plan

- [ ] `bun test test/unit/agents/acp/adapter-session.test.ts` — all 41 pass
- [ ] `bun run typecheck` — clean
- [ ] Prompt audit files now include `Resumed: yes` on session resume and `Resumed: no` on fresh creation