### PR TITLE
fix(autofix): route adversarial test-file findings to test-writer session

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -214,7 +214,7 @@ export async function ensureAcpSession(
   sessionName: string,
   agentName: string,
   permissionMode: string,
-): Promise<AcpSession> {
+): Promise<{ session: AcpSession; resumed: boolean }> {
   if (!agentName) {
     throw new Error("[acp-adapter] agentName is required for ensureAcpSession");
   }
@@ -225,7 +225,7 @@ export async function ensureAcpSession(
       const existing = await client.loadSession(sessionName, agentName, permissionMode);
       if (existing) {
         getSafeLogger()?.debug("acp-adapter", `Resumed existing session: ${sessionName}`);
-        return existing;
+        return { session: existing, resumed: true };
       }
     } catch {
       // loadSession failed — fall through to createSession
@@ -234,7 +234,7 @@ export async function ensureAcpSession(
 
   // Create a new named session
   getSafeLogger()?.debug("acp-adapter", `Creating new session: ${sessionName}`);
-  return client.createSession({ agentName, permissionMode, sessionName });
+  return { session: await client.createSession({ agentName, permissionMode, sessionName }), resumed: false };
 }
 
 /**
@@ -747,7 +747,7 @@ export class AcpAgentAdapter implements AgentAdapter {
     });
 
     // 3. Ensure session (resume existing or create new)
-    const session = await ensureAcpSession(client, sessionName, agentName, permissionMode);
+    const { session, resumed: sessionResumed } = await ensureAcpSession(client, sessionName, agentName, permissionMode);
 
     // 4. Persist for plan→run continuity
     if (options.featureName && options.storyId) {
@@ -792,6 +792,7 @@ export class AcpAgentAdapter implements AgentAdapter {
             pipelineStage: options.pipelineStage ?? "run",
             callType: "run",
             turn: turnCount,
+            resumed: sessionResumed,
           });
         }
 
@@ -984,6 +985,7 @@ export class AcpAgentAdapter implements AgentAdapter {
             featureName: _options?.featureName,
             pipelineStage: _options?.pipelineStage ?? "complete",
             callType: "complete",
+            resumed: false,
           });
         }
 

--- a/src/agents/acp/prompt-audit.ts
+++ b/src/agents/acp/prompt-audit.ts
@@ -48,6 +48,8 @@ export interface PromptAuditEntry {
   callType: "run" | "complete";
   /** 1-indexed turn number — only set for run() multi-turn entries. */
   turn?: number;
+  /** Whether the ACP session was resumed from a prior run (true) or freshly created (false/undefined). */
+  resumed?: boolean;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -103,6 +105,7 @@ function buildAuditContent(entry: PromptAuditEntry, epochMs: number): string {
     `StoryId:   ${entry.storyId ?? "(none)"}`,
     `Feature:   ${entry.featureName ?? "(none)"}`,
     `Stage:     ${entry.pipelineStage ?? entry.callType}`,
+    `Resumed:   ${entry.resumed === true ? "yes" : "no"}`,
     "---",
     entry.prompt,
   ];

--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -1,0 +1,99 @@
+/**
+ * Scope-aware adversarial rectification helpers (#409).
+ *
+ * When adversarial review flags issues in test files, the implementer session
+ * cannot fix them (isolation constraint). These helpers classify adversarial
+ * findings by file scope and route test-file findings to a test-writer session.
+ */
+
+import { buildSessionName } from "../../agents/acp/adapter";
+import type { createAgentRegistry } from "../../agents/registry";
+import { resolveModelForAgent } from "../../config";
+import { resolvePermissions } from "../../config/permissions";
+import { getLogger } from "../../logger";
+import type { UserStory } from "../../prd";
+import { RectifierPromptBuilder } from "../../prompts";
+import type { ReviewCheckResult } from "../../review/types";
+import type { PipelineContext } from "../types";
+
+/** Pattern matching test/spec files by extension. */
+export const TEST_FILE_PATTERN = /\.(test|spec)\.(ts|js|tsx|jsx)$/;
+
+/**
+ * Split adversarial findings in a check result into test-file vs source-file buckets.
+ * Returns null for each bucket when there are no findings for that scope.
+ */
+export function splitAdversarialFindingsByScope(check: ReviewCheckResult): {
+  testFindings: ReviewCheckResult | null;
+  sourceFindings: ReviewCheckResult | null;
+} {
+  if (check.check !== "adversarial" || !check.findings?.length) {
+    return { testFindings: null, sourceFindings: null };
+  }
+
+  const testFs = check.findings.filter((f) => TEST_FILE_PATTERN.test(f.file ?? ""));
+  const sourceFs = check.findings.filter((f) => !TEST_FILE_PATTERN.test(f.file ?? ""));
+
+  const toCheck = (findings: typeof testFs): ReviewCheckResult | null => {
+    if (findings.length === 0) return null;
+    return {
+      ...check,
+      findings,
+      output: findings.map((f) => `[${f.severity}] ${f.file}:${f.line} — ${f.message}`).join("\n"),
+    };
+  };
+
+  return { testFindings: toCheck(testFs), sourceFindings: toCheck(sourceFs) };
+}
+
+/**
+ * Run a test-writer session to fix adversarial review findings scoped to test files (#409).
+ * Returns the cost incurred, or 0 if the agent is unavailable.
+ */
+export async function runTestWriterRectification(
+  ctx: PipelineContext,
+  testWriterChecks: ReviewCheckResult[],
+  story: UserStory,
+  agentGetFn: (name: string) => ReturnType<ReturnType<typeof createAgentRegistry>["getAgent"]>,
+): Promise<number> {
+  const logger = getLogger();
+  const twAgent = agentGetFn(ctx.rootConfig.autoMode.defaultAgent);
+  if (!twAgent) {
+    logger.warn("autofix", "Agent not found — skipping test-writer rectification", { storyId: ctx.story.id });
+    return 0;
+  }
+  const testWriterSession = buildSessionName(ctx.workdir, ctx.prd.feature, ctx.story.id, "test-writer");
+  const twPrompt = RectifierPromptBuilder.testWriterRectification(testWriterChecks, story);
+  const modelTier = ctx.story.routing?.modelTier ?? ctx.rootConfig.autoMode.escalation.tierOrder[0]?.tier ?? "balanced";
+  const modelDef = resolveModelForAgent(
+    ctx.rootConfig.models,
+    ctx.routing.agent ?? ctx.rootConfig.autoMode.defaultAgent,
+    modelTier,
+    ctx.rootConfig.autoMode.defaultAgent,
+  );
+  try {
+    const twResult = await twAgent.run({
+      prompt: twPrompt,
+      workdir: ctx.workdir,
+      modelTier,
+      modelDef,
+      timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
+      dangerouslySkipPermissions: resolvePermissions(ctx.config, "rectification").skipPermissions,
+      pipelineStage: "rectification",
+      config: ctx.config,
+      projectDir: ctx.projectDir,
+      maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
+      featureName: ctx.prd.feature,
+      storyId: ctx.story.id,
+      sessionRole: "test-writer",
+      acpSessionName: testWriterSession,
+      keepSessionOpen: false,
+    });
+    return twResult.estimatedCost ?? 0;
+  } catch {
+    logger.warn("autofix", "Test-writer rectification failed — proceeding with implementer", {
+      storyId: ctx.story.id,
+    });
+    return 0;
+  }
+}

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -25,6 +25,7 @@ import { resolveModelForAgent } from "../../config";
 import type { NaxConfig } from "../../config";
 import { resolvePermissions } from "../../config/permissions";
 import { getLogger } from "../../logger";
+import type { UserStory } from "../../prd";
 import { RectifierPromptBuilder } from "../../prompts";
 import { runQualityCommand } from "../../quality";
 import type { ReviewCheckResult } from "../../review/types";
@@ -35,6 +36,7 @@ import {
 } from "../../verification/shared-rectification-loop";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
+import { runTestWriterRectification, splitAdversarialFindingsByScope } from "./autofix-adversarial";
 import { buildReviewRectificationPrompt } from "./autofix-prompts";
 export { buildReviewRectificationPrompt };
 
@@ -281,11 +283,49 @@ async function runAgentRectification(
   const maxAttempts = Math.min(maxPerCycle, remainingBudget);
 
   const agentGetFn = ctx.agentGetFn ?? ((name: string) => _autofixDeps.getAgent(name, ctx.rootConfig));
+
+  // #409: Split adversarial findings by file scope.
+  // Test-file findings cannot be fixed by the implementer (isolation constraint) —
+  // route them to a separate test-writer rectification call before the implementer loop.
+  let implementerChecks = failedChecks;
+  let testWriterChecks: ReviewCheckResult[] = [];
+
+  for (const check of failedChecks) {
+    if (check.check === "adversarial" && check.findings?.length) {
+      const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check);
+      if (testFindings) testWriterChecks = [...testWriterChecks, testFindings];
+      if (sourceFindings) {
+        implementerChecks = implementerChecks.map((c) => (c.check === "adversarial" ? sourceFindings : c));
+      } else {
+        // All adversarial findings are in test files — remove from implementer checks
+        implementerChecks = implementerChecks.filter((c) => c.check !== "adversarial");
+      }
+    }
+  }
+
+  let autofixCostAccum = 0;
+
+  if (testWriterChecks.length > 0) {
+    logger.info("autofix", "Routing test-file adversarial findings to test-writer session", {
+      storyId: ctx.story.id,
+      findingCount: testWriterChecks.flatMap((c) => c.findings ?? []).length,
+    });
+    autofixCostAccum += await _autofixDeps.runTestWriterRectification(ctx, testWriterChecks, ctx.story, agentGetFn);
+  }
+
+  // If all adversarial findings were test-file scoped and no other checks failed,
+  // skip the implementer loop — return for recheck after test-writer fixed the issues.
+  if (implementerChecks.length === 0) {
+    logger.info("autofix", "All adversarial findings routed to test-writer — skipping implementer loop", {
+      storyId: ctx.story.id,
+    });
+    return { succeeded: false, cost: autofixCostAccum };
+  }
+
   const loopState = {
     attempt: 0,
-    failedChecks,
+    failedChecks: implementerChecks,
   };
-  let autofixCostAccum = 0;
   let unresolvedReason: string | undefined;
   // #411: Track git HEAD before each agent attempt so checkResult can detect
   // whether the agent actually modified source files. When no files changed
@@ -305,7 +345,7 @@ async function runAgentRectification(
     startMessage: "Starting agent rectification for review failures",
     startData: {
       storyId: ctx.story.id,
-      failedChecks: failedChecks.map((check) => check.check),
+      failedChecks: implementerChecks.map((check) => check.check),
       maxAttempts,
       totalUsed: consumed,
       maxTotalAttempts: maxTotal,
@@ -537,4 +577,10 @@ export const _autofixDeps = {
     effectiveWorkdir: string,
   ): Promise<{ succeeded: boolean; cost: number; unresolvedReason?: string }> =>
     runAgentRectification(ctx, lintFixCmd, formatFixCmd, effectiveWorkdir),
+  runTestWriterRectification: (
+    ctx: PipelineContext,
+    testWriterChecks: ReviewCheckResult[],
+    story: UserStory,
+    agentGetFn: (name: string) => ReturnType<ReturnType<typeof createAgentRegistry>["getAgent"]>,
+  ): Promise<number> => runTestWriterRectification(ctx, testWriterChecks, story, agentGetFn),
 };

--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -198,6 +198,42 @@ export class RectifierPromptBuilder {
     return parts.join("\n");
   }
 
+  /**
+   * Prompt for the test-writer to fix test file issues flagged by adversarial review (#409).
+   *
+   * Sent when adversarial review found problems in test files that the implementer
+   * cannot fix (isolation constraint). The test-writer is allowed to modify test files.
+   */
+  static testWriterRectification(testFileFindings: ReviewCheckResult[], story: UserStory): string {
+    const scopeConstraint = story.workdir
+      ? `\n\nIMPORTANT: Only modify test files within \`${story.workdir}/\`. Do NOT touch source files.`
+      : "\n\nIMPORTANT: Only modify test files. Do NOT touch source implementation files.";
+
+    const findingLines = testFileFindings
+      .flatMap((c) => c.findings ?? [])
+      .map((f) => `- [${f.severity}] ${f.file}:${f.line} — ${f.message}`)
+      .join("\n");
+
+    const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
+
+    return `You are fixing test file issues flagged by an adversarial code reviewer.
+
+Story: ${story.title} (${story.id})
+
+### Acceptance Criteria
+${acList}
+
+### Test File Findings (adversarial review)
+${findingLines}
+
+**Important:** These findings are in test files. Before making any changes:
+1. Read the flagged test files to verify each finding is a real issue
+2. Only fix findings that are genuinely incorrect or missing — do NOT remove tests
+3. Do NOT modify source implementation files
+
+Commit your fixes when done.${scopeConstraint}`;
+  }
+
   private s(id: string, content: string): PromptSection {
     return { id, content, overridable: false };
   }

--- a/test/unit/agents/acp/adapter-session.test.ts
+++ b/test/unit/agents/acp/adapter-session.test.ts
@@ -370,8 +370,9 @@ describe("AcpAgentAdapter — session mode (run)", () => {
         createSession: async () => { createCalled = true; return makeSession(); },
       };
 
-      const session = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
-      expect(session).toBe(existingSession);
+      const result = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
+      expect(result.session).toBe(existingSession);
+      expect(result.resumed).toBe(true);
       expect(createCalled).toBe(false);
     });
 
@@ -385,8 +386,9 @@ describe("AcpAgentAdapter — session mode (run)", () => {
         createSession: async () => { createCalled = true; return newSession; },
       };
 
-      const session = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
-      expect(session).toBe(newSession);
+      const result = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
+      expect(result.session).toBe(newSession);
+      expect(result.resumed).toBe(false);
       expect(createCalled).toBe(true);
     });
 
@@ -399,8 +401,9 @@ describe("AcpAgentAdapter — session mode (run)", () => {
         createSession: async () => { createCalled = true; return newSession; },
       };
 
-      const session = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "default");
-      expect(session).toBe(newSession);
+      const result = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "default");
+      expect(result.session).toBe(newSession);
+      expect(result.resumed).toBe(false);
       expect(createCalled).toBe(true);
     });
 
@@ -414,8 +417,9 @@ describe("AcpAgentAdapter — session mode (run)", () => {
         createSession: async () => { createCalled = true; return newSession; },
       };
 
-      const session = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
-      expect(session).toBe(newSession);
+      const result = await ensureAcpSession(client, "nax-abc-feat-ST-001", "claude", "approve-all");
+      expect(result.session).toBe(newSession);
+      expect(result.resumed).toBe(false);
       expect(createCalled).toBe(true);
     });
   });

--- a/test/unit/agents/acp/prompt-audit.test.ts
+++ b/test/unit/agents/acp/prompt-audit.test.ts
@@ -4,7 +4,7 @@
  * Covers:
  * - run-turn filename uses epochMs prefix and -t01 suffix
  * - complete filename uses epochMs prefix, no turn suffix
- * - File content contains all 6 header fields + raw prompt
+ * - File content contains all 7 header fields + raw prompt (incl. Resumed field)
  * - enabled:false → writeFile never called (zero I/O)
  * - Custom absolute dir is used verbatim without joining workdir
  * - Absent dir defaults to <workdir>/.nax/prompt-audit/
@@ -99,7 +99,7 @@ describe("writePromptAudit() — file content", () => {
     mock.restore();
   });
 
-  test("writes file with all 6 header fields present", async () => {
+  test("writes file with all 7 header fields present", async () => {
     let capturedContent = "";
     _promptAuditDeps.writeFile = mock(async (_path: string, content: string) => {
       capturedContent = content;
@@ -113,6 +113,7 @@ describe("writePromptAudit() — file content", () => {
     expect(capturedContent).toContain("StoryId:   us-001");
     expect(capturedContent).toContain("Feature:   my-feature");
     expect(capturedContent).toContain("Stage:     run");
+    expect(capturedContent).toContain("Resumed:   no");
   });
 
   test("writes raw prompt text after the separator", async () => {
@@ -150,6 +151,39 @@ describe("writePromptAudit() — file content", () => {
 
     expect(capturedContent).toContain("StoryId:   (none)");
     expect(capturedContent).toContain("Feature:   (none)");
+  });
+
+  test("resumed:true renders as 'Resumed:   yes'", async () => {
+    let capturedContent = "";
+    _promptAuditDeps.writeFile = mock(async (_path: string, content: string) => {
+      capturedContent = content;
+    });
+
+    await writePromptAudit(makeEntry({ resumed: true }));
+
+    expect(capturedContent).toContain("Resumed:   yes");
+  });
+
+  test("resumed:false renders as 'Resumed:   no'", async () => {
+    let capturedContent = "";
+    _promptAuditDeps.writeFile = mock(async (_path: string, content: string) => {
+      capturedContent = content;
+    });
+
+    await writePromptAudit(makeEntry({ resumed: false }));
+
+    expect(capturedContent).toContain("Resumed:   no");
+  });
+
+  test("resumed:undefined renders as 'Resumed:   no'", async () => {
+    let capturedContent = "";
+    _promptAuditDeps.writeFile = mock(async (_path: string, content: string) => {
+      capturedContent = content;
+    });
+
+    await writePromptAudit(makeEntry({ resumed: undefined }));
+
+    expect(capturedContent).toContain("Resumed:   no");
   });
 });
 

--- a/test/unit/pipeline/stages/autofix.test.ts
+++ b/test/unit/pipeline/stages/autofix.test.ts
@@ -555,3 +555,161 @@ describe("autofixStage", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// #409: Scope-aware adversarial rectification
+// ---------------------------------------------------------------------------
+
+describe("#409 scope-aware adversarial routing", () => {
+  function makeAdversarialCheck(findings: Array<{ file: string; severity?: string; message?: string }>): ReviewCheckResult {
+    return {
+      check: "adversarial",
+      success: false,
+      command: "adversarial-review",
+      exitCode: 1,
+      output: "adversarial review output",
+      durationMs: 100,
+      findings: findings.map((f) => ({
+        ruleId: "adversarial",
+        severity: (f.severity ?? "error") as "error",
+        file: f.file,
+        line: 1,
+        message: f.message ?? "finding",
+        source: "adversarial-review",
+      })),
+    };
+  }
+
+  test("adversarial findings in test files only → test-writer session invoked, implementer skipped", async () => {
+    const saved = { ..._autofixDeps };
+    let testWriterCalled = false;
+    let agentRunCalled = false;
+
+    _autofixDeps.runTestWriterRectification = async () => {
+      testWriterCalled = true;
+      return 0;
+    };
+    _autofixDeps.getAgent = () =>
+      ({
+        run: async () => {
+          agentRunCalled = true;
+          return { success: false };
+        },
+      }) as any;
+    _autofixDeps.recheckReview = async () => false;
+
+    const adversarialCheck = makeAdversarialCheck([
+      { file: "test/unit/foo.test.ts" },
+      { file: "src/bar.spec.ts" },
+    ]);
+    const ctx = makeCtx({
+      // Pass reviewResult directly to preserve findings (makeFailedReviewResult drops them)
+      reviewResult: { success: false, checks: [adversarialCheck], summary: "" } as any,
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test" },
+          autofix: { enabled: true, maxAttempts: 1 },
+        },
+        autoMode: { ...DEFAULT_CONFIG.autoMode, defaultAgent: "claude" },
+      } as any,
+    });
+
+    await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(testWriterCalled).toBe(true);
+    // implementer loop is skipped when all adversarial findings are test-scoped
+    expect(agentRunCalled).toBe(false);
+  });
+
+  test("mixed findings (test + source) → both test-writer and implementer sessions invoked", async () => {
+    const saved = { ..._autofixDeps };
+    let testWriterCalled = false;
+    let implementerRunCalled = false;
+
+    _autofixDeps.runTestWriterRectification = async () => {
+      testWriterCalled = true;
+      return 0;
+    };
+    _autofixDeps.getAgent = () =>
+      ({
+        run: async () => {
+          implementerRunCalled = true;
+          return { success: false };
+        },
+      }) as any;
+    _autofixDeps.recheckReview = async () => false;
+
+    const adversarialCheck = makeAdversarialCheck([
+      { file: "test/unit/foo.test.ts" },   // test file → test-writer
+      { file: "src/implementation.ts" },    // source file → implementer
+    ]);
+    const ctx = makeCtx({
+      // Pass reviewResult directly to preserve findings (makeFailedReviewResult drops them)
+      reviewResult: { success: false, checks: [adversarialCheck], summary: "" } as any,
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test" },
+          autofix: { enabled: true, maxAttempts: 1 },
+        },
+        autoMode: { ...DEFAULT_CONFIG.autoMode, defaultAgent: "claude" },
+      } as any,
+    });
+
+    await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(testWriterCalled).toBe(true);
+    expect(implementerRunCalled).toBe(true);
+  });
+
+  test("all source findings → only implementer invoked (existing behavior)", async () => {
+    const saved = { ..._autofixDeps };
+    let testWriterCalled = false;
+    let implementerRunCalled = false;
+
+    _autofixDeps.runTestWriterRectification = async () => {
+      testWriterCalled = true;
+      return 0;
+    };
+    _autofixDeps.getAgent = () =>
+      ({
+        run: async () => {
+          implementerRunCalled = true;
+          return { success: false };
+        },
+      }) as any;
+    _autofixDeps.recheckReview = async () => false;
+
+    const adversarialCheck = makeAdversarialCheck([
+      { file: "src/foo.ts" },
+      { file: "src/bar.ts" },
+    ]);
+    const ctx = makeCtx({
+      // Pass reviewResult directly to preserve findings (makeFailedReviewResult drops them)
+      reviewResult: { success: false, checks: [adversarialCheck], summary: "" } as any,
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test" },
+          autofix: { enabled: true, maxAttempts: 1 },
+        },
+        autoMode: { ...DEFAULT_CONFIG.autoMode, defaultAgent: "claude" },
+      } as any,
+    });
+
+    await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(testWriterCalled).toBe(false);
+    expect(implementerRunCalled).toBe(true);
+  });
+});
+

--- a/test/unit/prompts/builders/rectifier-builder.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder.test.ts
@@ -355,3 +355,117 @@ describe("RectifierPromptBuilder.continuation", () => {
     expect(prompt).toContain("### semantic");
   });
 });
+
+// ---------------------------------------------------------------------------
+// RectifierPromptBuilder.testWriterRectification (#409)
+// ---------------------------------------------------------------------------
+
+describe("RectifierPromptBuilder.testWriterRectification", () => {
+  function makeTestFileCheck(file: string, message: string): import("../../../../src/review/types").ReviewCheckResult {
+    return {
+      check: "adversarial",
+      success: false,
+      command: "adversarial-review",
+      exitCode: 1,
+      output: "adversarial output",
+      durationMs: 100,
+      findings: [
+        {
+          ruleId: "adversarial",
+          severity: "error",
+          file,
+          line: 10,
+          message,
+          source: "adversarial-review",
+        },
+      ],
+    };
+  }
+
+  function makeStory(
+    overrides: Partial<{ id: string; title: string; workdir: string; acceptanceCriteria: string[] }> = {},
+  ) {
+    return {
+      id: overrides.id ?? "US-409",
+      title: overrides.title ?? "Fix deadlock",
+      workdir: overrides.workdir,
+      acceptanceCriteria: overrides.acceptanceCriteria ?? ["AC-1: Does the thing", "AC-2: Handles edge case"],
+    } as any;
+  }
+
+  test("contains the finding message", () => {
+    const checks = [makeTestFileCheck("test/unit/foo.test.ts", "Missing assertion for edge case")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory());
+
+    expect(prompt).toContain("Missing assertion for edge case");
+  });
+
+  test("contains the file path and severity in finding line", () => {
+    const checks = [makeTestFileCheck("test/unit/bar.test.ts", "Incomplete test coverage")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory());
+
+    expect(prompt).toContain("[error] test/unit/bar.test.ts:10 — Incomplete test coverage");
+  });
+
+  test("contains 'Only modify test files' constraint without workdir", () => {
+    const checks = [makeTestFileCheck("test/unit/foo.test.ts", "finding")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory({ workdir: undefined }));
+
+    expect(prompt).toContain("Only modify test files");
+    expect(prompt).toContain("Do NOT touch source implementation files");
+  });
+
+  test("contains workdir-scoped constraint when story.workdir is set", () => {
+    const checks = [makeTestFileCheck("test/unit/foo.test.ts", "finding")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory({ workdir: "packages/api" }));
+
+    expect(prompt).toContain("Only modify test files within `packages/api/`");
+    expect(prompt).toContain("Do NOT touch source files");
+  });
+
+  test("contains the acceptance criteria list", () => {
+    const checks = [makeTestFileCheck("test/unit/foo.test.ts", "finding")];
+    const story = makeStory({ acceptanceCriteria: ["AC-1: First criterion", "AC-2: Second criterion"] });
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, story);
+
+    expect(prompt).toContain("1. AC-1: First criterion");
+    expect(prompt).toContain("2. AC-2: Second criterion");
+  });
+
+  test("contains the story id and title", () => {
+    const checks = [makeTestFileCheck("test/unit/foo.test.ts", "finding")];
+    const story = makeStory({ id: "US-409", title: "Resolve deadlock" });
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, story);
+
+    expect(prompt).toContain("US-409");
+    expect(prompt).toContain("Resolve deadlock");
+  });
+
+  test("instructs not to remove tests or modify source files", () => {
+    const checks = [makeTestFileCheck("test/unit/foo.test.ts", "finding")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory());
+
+    expect(prompt).toContain("do NOT remove tests");
+    expect(prompt).toContain("Do NOT modify source implementation files");
+  });
+
+  test("instructs to commit fixes when done", () => {
+    const checks = [makeTestFileCheck("test/unit/foo.test.ts", "finding")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory());
+
+    expect(prompt).toContain("Commit your fixes when done");
+  });
+
+  test("handles multiple findings across multiple checks", () => {
+    const checks = [
+      makeTestFileCheck("test/unit/foo.test.ts", "First finding"),
+      makeTestFileCheck("test/unit/bar.test.ts", "Second finding"),
+    ];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory());
+
+    expect(prompt).toContain("First finding");
+    expect(prompt).toContain("Second finding");
+    expect(prompt).toContain("test/unit/foo.test.ts");
+    expect(prompt).toContain("test/unit/bar.test.ts");
+  });
+});


### PR DESCRIPTION
## Summary

- New `src/pipeline/stages/autofix-adversarial.ts` module: `splitAdversarialFindingsByScope()` splits adversarial `ReviewCheckResult` items into test-file vs source-file buckets using `*.test.ts` / `*.spec.ts` pattern matching
- `RectifierPromptBuilder.testWriterRectification()`: focused prompt for the test-writer session that constrains fixes to test files only, includes AC list and adversarial finding lines
- Autofix stage now routes adversarial review findings by scope — test-file findings go to the test-writer session before the implementer loop, source-file findings go to the implementer as before
- Prevents the implementer from receiving test-file findings it has no business touching (avoids spec deletions/weakening)

## Test plan

- [ ] `bun run typecheck` — clean
- [ ] `bun run test:bail` — 1227 unit + 14 integration tests pass
- [ ] Adversarial findings on `*.test.ts` files trigger test-writer rectification, not implementer
- [ ] Source-file adversarial findings still route to implementer unchanged
- [ ] Empty test-file bucket skips test-writer turn (no spurious empty prompts)