### PR TITLE
fix(acp): surface session ID in prompt audit header (#413)

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -102,6 +102,8 @@ export interface AcpSession {
   prompt(text: string): Promise<AcpSessionResponse>;
   close(options?: { forceTerminate?: boolean }): Promise<void>;
   cancelActivePrompt(): Promise<void>;
+  /** Session ID returned by the ACP provider (e.g. acpx UUID). Undefined when not available. */
+  readonly id?: string;
 }
 
 export interface AcpClient {
@@ -784,6 +786,7 @@ export class AcpAgentAdapter implements AgentAdapter {
           void writePromptAudit({
             prompt: currentPrompt,
             sessionName,
+            sessionId: session.id,
             workdir: options.workdir,
             projectDir: options.projectDir,
             auditDir: _runAuditConfig.agent.promptAudit.dir,
@@ -979,6 +982,7 @@ export class AcpAgentAdapter implements AgentAdapter {
           void writePromptAudit({
             prompt,
             sessionName: completeSessionName,
+            sessionId: session.id,
             workdir: workdir ?? process.cwd(),
             auditDir: _completeAuditConfig.agent.promptAudit.dir,
             storyId: _options?.storyId,

--- a/src/agents/acp/prompt-audit.ts
+++ b/src/agents/acp/prompt-audit.ts
@@ -48,6 +48,8 @@ export interface PromptAuditEntry {
   callType: "run" | "complete";
   /** 1-indexed turn number — only set for run() multi-turn entries. */
   turn?: number;
+  /** Session ID returned by the ACP provider (e.g. acpx UUID). Undefined when not available. */
+  sessionId?: string;
   /** Whether the ACP session was resumed from a prior run (true) or freshly created (false/undefined). */
   resumed?: boolean;
 }
@@ -101,6 +103,7 @@ function buildAuditContent(entry: PromptAuditEntry, epochMs: number): string {
   const lines = [
     `Timestamp: ${ts}`,
     `Session:   ${entry.sessionName}`,
+    ...(entry.sessionId ? [`SessionId: ${entry.sessionId}`] : []),
     `Type:      ${typeLabel}`,
     `StoryId:   ${entry.storyId ?? "(none)"}`,
     `Feature:   ${entry.featureName ?? "(none)"}`,

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -98,6 +98,7 @@ class SpawnAcpSession implements AcpSession {
   private readonly env: Record<string, string | undefined>;
   private readonly pidRegistry?: PidRegistry;
   private activeProc: { pid: number; kill(signal?: number): void } | null = null;
+  readonly id?: string;
 
   constructor(opts: {
     agentName: string;
@@ -108,6 +109,7 @@ class SpawnAcpSession implements AcpSession {
     permissionMode: string;
     env: Record<string, string | undefined>;
     pidRegistry?: PidRegistry;
+    id?: string;
   }) {
     this.agentName = opts.agentName;
     this.sessionName = opts.sessionName;
@@ -117,6 +119,7 @@ class SpawnAcpSession implements AcpSession {
     this.permissionMode = opts.permissionMode;
     this.env = opts.env;
     this.pidRegistry = opts.pidRegistry;
+    this.id = opts.id;
   }
 
   async prompt(text: string): Promise<AcpSessionResponse> {
@@ -317,6 +320,33 @@ class SpawnAcpSession implements AcpSession {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Session ID parser
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse the session UUID from `acpx --format json sessions ensure` stdout.
+ *
+ * acpx --format json outputs a JSON line:
+ *   {"action":"session_ensured","created":true,"acpxSessionId":"<uuid>","name":"<name>"}
+ *
+ * Returns the UUID string, or undefined if the output doesn't contain valid JSON with acpxSessionId.
+ */
+function parseSessionId(stdout: string): string | undefined {
+  for (const line of stdout.split("\n").reverse()) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      const id = parsed.acpxSessionId;
+      if (typeof id === "string" && id.length > 0) return id;
+    } catch {
+      // not valid JSON — skip
+    }
+  }
+  return undefined;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // SpawnAcpClient
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -383,11 +413,11 @@ export class SpawnAcpClient implements AcpClient {
   }): Promise<AcpSession> {
     const sessionName = opts.sessionName || `nax-${Date.now()}`;
 
-    // Ensure session exists via CLI
-    const cmd = ["acpx", "--cwd", this.cwd, opts.agentName, "sessions", "ensure", "--name", sessionName];
+    // Ensure session exists via CLI — --format json surfaces the session UUID in stdout
+    const cmd = ["acpx", "--cwd", this.cwd, "--format", "json", opts.agentName, "sessions", "ensure", "--name", sessionName];
     getSafeLogger()?.debug("acp-adapter", `Ensuring session: ${sessionName}`);
 
-    const { exitCode, stderr } = await this.trackedSpawn(cmd);
+    const { exitCode, stdout, stderr } = await this.trackedSpawn(cmd);
 
     if (exitCode !== 0) {
       throw new Error(`[acp-adapter] Failed to create session: ${stderr || `exit code ${exitCode}`}`);
@@ -402,14 +432,15 @@ export class SpawnAcpClient implements AcpClient {
       permissionMode: opts.permissionMode,
       env: this.env,
       pidRegistry: this.pidRegistry,
+      id: parseSessionId(stdout),
     });
   }
 
   async loadSession(sessionName: string, agentName: string, permissionMode: string): Promise<AcpSession | null> {
-    // Try to ensure session exists — if it does, acpx returns success
-    const cmd = ["acpx", "--cwd", this.cwd, agentName, "sessions", "ensure", "--name", sessionName];
+    // Try to ensure session exists — --format json surfaces the session UUID in stdout
+    const cmd = ["acpx", "--cwd", this.cwd, "--format", "json", agentName, "sessions", "ensure", "--name", sessionName];
 
-    const { exitCode } = await this.trackedSpawn(cmd);
+    const { exitCode, stdout } = await this.trackedSpawn(cmd);
 
     if (exitCode !== 0) {
       return null; // Session doesn't exist or can't be resumed
@@ -424,6 +455,7 @@ export class SpawnAcpClient implements AcpClient {
       permissionMode,
       env: this.env,
       pidRegistry: this.pidRegistry,
+      id: parseSessionId(stdout),
     });
   }
 

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -414,7 +414,18 @@ export class SpawnAcpClient implements AcpClient {
     const sessionName = opts.sessionName || `nax-${Date.now()}`;
 
     // Ensure session exists via CLI — --format json surfaces the session UUID in stdout
-    const cmd = ["acpx", "--cwd", this.cwd, "--format", "json", opts.agentName, "sessions", "ensure", "--name", sessionName];
+    const cmd = [
+      "acpx",
+      "--cwd",
+      this.cwd,
+      "--format",
+      "json",
+      opts.agentName,
+      "sessions",
+      "ensure",
+      "--name",
+      sessionName,
+    ];
     getSafeLogger()?.debug("acp-adapter", `Ensuring session: ${sessionName}`);
 
     const { exitCode, stdout, stderr } = await this.trackedSpawn(cmd);


### PR DESCRIPTION
## Summary

- `acpx --format json sessions ensure` outputs `{"acpxSessionId":"<uuid>",...}` in stdout — parsed to get the unique session ID
- `AcpSession` interface gains `readonly id?: string`
- `SpawnAcpSession` stores and exposes the UUID from `acpx sessions ensure` (both `createSession` and `loadSession` paths)
- `PromptAuditEntry` gains `sessionId?: string` field
- `buildAuditContent` outputs `SessionId:` line immediately after `Session:` when available — omitted when not present (graceful degradation)
- `session.id` threaded into `writePromptAudit` in both `run()` and `complete()` call paths

### Audit header before

```
Timestamp: 2026-04-13T09:07:30.147Z
Session:   nax-5166d743-graphify-kb-graphify-kb-plan-1
Type:      run / turn 1
StoryId:   graphify-kb
Feature:   graphify-kb
Stage:     plan
Resumed:   yes
```

### Audit header after

```
Timestamp: 2026-04-13T09:07:30.147Z
Session:   nax-5166d743-graphify-kb-graphify-kb-plan-1
SessionId: ad908b20-908a-42ff-b39e-2acc29af9922
Type:      run / turn 1
StoryId:   graphify-kb
Feature:   graphify-kb
Stage:     plan
Resumed:   yes
```

Closes #413

## Test plan

- [ ] 323 ACP unit tests pass
- [ ] `parseSessionId` returns UUID from JSON line, undefined on malformed input
- [ ] `SessionId` line appears in audit file when session ID is available
- [ ] `SessionId` line absent when session ID is not available (graceful degradation)
- [ ] Both `run()` and `complete()` audit entries include `SessionId`