### PR TITLE
fix(routing): resolve security override ambiguity in plan prompt

### DIFF
--- a/src/config/test-strategy.ts
+++ b/src/config/test-strategy.ts
@@ -61,12 +61,17 @@ export const TEST_STRATEGY_GUIDE = `## Test Strategy Guide
 
 Assign testStrategy based on complexity and content:
 
-| Complexity | Default Strategy         | Override when                          |
-|------------|--------------------------|----------------------------------------|
-| simple     | tdd-simple               | —                                      |
-| medium     | tdd-simple               | —                                      |
-| complex    | three-session-tdd-lite   | three-session-tdd if security-critical |
-| expert     | three-session-tdd        | —                                      |
+| Complexity | Default Strategy         | Override when                                        |
+|------------|--------------------------|------------------------------------------------------|
+| simple     | tdd-simple               | three-session-tdd if security-critical (see below)   |
+| medium     | tdd-simple               | three-session-tdd if security-critical (see below)   |
+| complex    | three-session-tdd-lite   | three-session-tdd if security-critical (see below)   |
+| expert     | three-session-tdd        | —                                                    |
+
+**Security override (applies to ALL complexity levels):** If a story involves authentication,
+access control, role checks, credentials, tokens, sessions, cryptography, or password hashing,
+set testStrategy to three-session-tdd regardless of the default strategy for that complexity level.
+This ensures strict test-implementation isolation for security-critical code paths.
 
 ### Strategy descriptions
 
@@ -81,6 +86,7 @@ Assign testStrategy based on complexity and content:
 - three-session-tdd: 3 sessions with strict isolation: (1) test-writer writes failing tests —
   no src/ changes allowed, (2) implementer makes them pass without modifying test files,
   (3) verifier confirms correctness. Use for expert stories and security-critical code.
+  **Examples:** ADMIN-guarded endpoints, JWT validation, RBAC enforcement, password reset flows.
 - test-after: Write implementation first, then tests. Use only when the story is exploratory
   or prototyping and strict TDD would be counterproductive.`;
 


### PR DESCRIPTION
## Summary

- The `TEST_STRATEGY_GUIDE` table showed `—` in the override column for simple/medium complexity, contradicting the `COMPLEXITY_GUIDE` prose that says "regardless of complexity"
- This ambiguity caused 5/7 plan LLM runs to misclassify an ADMIN-guarded endpoint (US-003 in a Graphify KB feature) as `tdd-simple` or `three-session-tdd-lite` instead of `three-session-tdd`
- Now every table row shows the security override, a bold paragraph restates the rule after the table, and `three-session-tdd` includes concrete examples (ADMIN endpoints, JWT, RBAC)

## Context

Evaluated 7 PRDs generated by `nax plan` from the same spec. Only 2/7 correctly applied `three-session-tdd` to the security-critical endpoint story. Root cause: LLMs that followed the table (not the prose) saw `—` for simple/medium override and skipped the security escalation.

## Test plan

- [x] `bun test test/unit/config/test-strategy.test.ts` — 30/30 pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Re-run `nax plan` on the same spec to verify the security-critical story now gets `three-session-tdd`