### PR TITLE
fix(review): parallel LLM dispatch now honours retrySkipChecks (#427)

### DIFF
--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -23,12 +23,16 @@ import { runSemanticReview } from "./semantic";
 import type { AdversarialReviewConfig, ReviewCheckResult, ReviewConfig, ReviewResult } from "./types";
 
 /**
- * Injectable dependencies for getChangedFiles() — allows tests to intercept
- * spawn calls without requiring the git binary.
+ * Injectable dependencies for orchestrator internals — allows tests to intercept
+ * spawn and parallel LLM dispatch calls without mock.module() (BUG-035 pattern).
  *
  * @internal
  */
-export const _orchestratorDeps = { spawn };
+export const _orchestratorDeps = {
+  spawn,
+  runSemanticReview,
+  runAdversarialReview,
+};
 
 async function getChangedFiles(workdir: string, baseRef?: string): Promise<string[]> {
   try {
@@ -184,12 +188,24 @@ export class ReviewOrchestrator {
         priorFailures,
       );
 
-      // Step 2: Run LLM checks regardless of mechanical result (fail-fast within LLM)
+      // Step 2: Run LLM checks regardless of mechanical result (fail-fast within LLM).
+      // #136: Filter out checks that already passed in a previous review pass — retrySkipChecks
+      // must be honoured here in the parallel path, not just in runReview (sequential path).
+      const activeLlmCheckNames = llmCheckNames.filter((c) => !retrySkipChecks?.has(c));
+
       const llmStart = Date.now();
       let llmCheckResults: ReviewCheckResult[];
 
-      if (canParallelize) {
-        // semantic + adversarial concurrently
+      if (activeLlmCheckNames.length === 0) {
+        // All LLM checks already passed — skip Step 2 entirely.
+        logger?.debug("review", "Skipping LLM checks (all already passed in previous review pass)", { storyId });
+        llmCheckResults = [];
+      } else if (
+        canParallelize &&
+        activeLlmCheckNames.includes("semantic") &&
+        activeLlmCheckNames.includes("adversarial")
+      ) {
+        // semantic + adversarial concurrently (both active)
         const semanticStory: SemanticStory = {
           id: storyId ?? "",
           title: story?.title ?? "",
@@ -209,7 +225,7 @@ export class ReviewOrchestrator {
 
         logger?.debug("review", "Running semantic + adversarial in parallel", { storyId });
         const [semResult, advResult] = await Promise.all([
-          runSemanticReview(
+          _orchestratorDeps.runSemanticReview(
             workdir,
             storyGitRef,
             semanticStory,
@@ -220,7 +236,7 @@ export class ReviewOrchestrator {
             resolverSession,
             priorFailures,
           ),
-          runAdversarialReview(
+          _orchestratorDeps.runAdversarialReview(
             workdir,
             storyGitRef,
             semanticStory,
@@ -233,8 +249,9 @@ export class ReviewOrchestrator {
         ]);
         llmCheckResults = [semResult, advResult];
       } else {
-        // Sequential LLM run via runReview (handles semantic and adversarial in-loop)
-        const llmConfig = { ...reviewConfig, checks: llmCheckNames };
+        // Sequential LLM run via runReview — one or both reviewers active, or parallel disabled.
+        // retrySkipChecks is passed through so runner.ts skips already-passed checks.
+        const llmConfig = { ...reviewConfig, checks: activeLlmCheckNames };
         const llmResult = await runReview(
           llmConfig,
           workdir,

--- a/test/unit/review/orchestrator.test.ts
+++ b/test/unit/review/orchestrator.test.ts
@@ -15,6 +15,7 @@ import type { NaxConfig } from "../../../src/config";
 import type { PluginRegistry } from "../../../src/plugins";
 import type { IReviewPlugin } from "../../../src/plugins/extensions";
 import { ReviewOrchestrator, _orchestratorDeps } from "../../../src/review/orchestrator";
+import type { AdversarialReviewConfig } from "../../../src/review/types";
 import { _reviewAdversarialDeps, _reviewGitDeps as _runnerDeps, _reviewSemanticDeps } from "../../../src/review/runner";
 import type { ReviewCheckResult, ReviewConfig } from "../../../src/review/types";
 import { withDepsRestore } from "../../helpers/deps";
@@ -24,7 +25,7 @@ import { withDepsRestore } from "../../helpers/deps";
 // ─────────────────────────────────────────────────────────────────────────────
 
 withDepsRestore(_runnerDeps, ["getUncommittedFiles"]);
-withDepsRestore(_orchestratorDeps, ["spawn"]);
+withDepsRestore(_orchestratorDeps, ["spawn", "runSemanticReview", "runAdversarialReview"]);
 withDepsRestore(_reviewSemanticDeps, ["runSemanticReview"]);
 withDepsRestore(_reviewAdversarialDeps, ["runAdversarialReview"]);
 
@@ -312,5 +313,149 @@ describe("ReviewOrchestrator — mechanical / LLM isolation (#405)", () => {
     const checkNames = result.builtIn.checks.map((c) => c.check);
     expect(checkNames).toContain("semantic");
     expect(result.success).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// retrySkipChecks — parallel LLM dispatch (#136 / issue-9)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeParallelConfig(): ReviewConfig {
+  return {
+    enabled: true,
+    checks: ["semantic", "adversarial"],
+    commands: {},
+    pluginMode: "deferred",
+    adversarial: {
+      enabled: true,
+      parallel: true,
+      maxConcurrentSessions: 2,
+    } as unknown as AdversarialReviewConfig,
+  } as unknown as ReviewConfig;
+}
+
+function makePassedCheck(check: "semantic" | "adversarial"): ReviewCheckResult {
+  return { check, success: true, command: "", exitCode: 0, output: "", durationMs: 50 };
+}
+
+describe("ReviewOrchestrator — retrySkipChecks in parallel LLM dispatch (#136)", () => {
+  beforeEach(() => {
+    _runnerDeps.getUncommittedFiles = mock(async () => []);
+    _orchestratorDeps.runSemanticReview = mock(async () => makePassedCheck("semantic"));
+    _orchestratorDeps.runAdversarialReview = mock(async () => makePassedCheck("adversarial"));
+  });
+
+  test("skips both LLM reviewers when both are in retrySkipChecks", async () => {
+    const orchestrator = new ReviewOrchestrator();
+    const retrySkipChecks = new Set(["semantic", "adversarial"]);
+
+    const result = await orchestrator.review(
+      makeParallelConfig(),
+      "/tmp/workdir",
+      minimalExecConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      retrySkipChecks,
+    );
+
+    expect(_orchestratorDeps.runSemanticReview).not.toHaveBeenCalled();
+    expect(_orchestratorDeps.runAdversarialReview).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+  });
+
+  test("skips only semantic when semantic is in retrySkipChecks — adversarial runs via sequential path", async () => {
+    // Only adversarial is active → canParallelize condition (needs both) fails → sequential path.
+    // Sequential path calls _reviewAdversarialDeps.runAdversarialReview (runner.ts), not _orchestratorDeps.
+    _reviewAdversarialDeps.runAdversarialReview = mock(async () => makePassedCheck("adversarial"));
+    const orchestrator = new ReviewOrchestrator();
+    const retrySkipChecks = new Set(["semantic"]);
+
+    await orchestrator.review(
+      makeParallelConfig(),
+      "/tmp/workdir",
+      minimalExecConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      retrySkipChecks,
+    );
+
+    expect(_orchestratorDeps.runSemanticReview).not.toHaveBeenCalled();
+    expect(_orchestratorDeps.runAdversarialReview).not.toHaveBeenCalled();
+    expect(_reviewAdversarialDeps.runAdversarialReview).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips only adversarial when adversarial is in retrySkipChecks — semantic runs via sequential path", async () => {
+    // Only semantic is active → canParallelize condition (needs both) fails → sequential path.
+    // Sequential path calls _reviewSemanticDeps.runSemanticReview (runner.ts), not _orchestratorDeps.
+    _reviewSemanticDeps.runSemanticReview = mock(async () => makePassedCheck("semantic"));
+    const orchestrator = new ReviewOrchestrator();
+    const retrySkipChecks = new Set(["adversarial"]);
+
+    await orchestrator.review(
+      makeParallelConfig(),
+      "/tmp/workdir",
+      minimalExecConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      retrySkipChecks,
+    );
+
+    expect(_orchestratorDeps.runAdversarialReview).not.toHaveBeenCalled();
+    expect(_orchestratorDeps.runSemanticReview).not.toHaveBeenCalled();
+    expect(_reviewSemanticDeps.runSemanticReview).toHaveBeenCalledTimes(1);
+  });
+
+  test("runs both reviewers when retrySkipChecks is empty", async () => {
+    const orchestrator = new ReviewOrchestrator();
+
+    await orchestrator.review(
+      makeParallelConfig(),
+      "/tmp/workdir",
+      minimalExecConfig,
+    );
+
+    expect(_orchestratorDeps.runSemanticReview).toHaveBeenCalledTimes(1);
+    expect(_orchestratorDeps.runAdversarialReview).toHaveBeenCalledTimes(1);
+  });
+
+  test("runs both reviewers when retrySkipChecks does not include LLM checks", async () => {
+    const orchestrator = new ReviewOrchestrator();
+    const retrySkipChecks = new Set(["lint", "build"]);
+
+    await orchestrator.review(
+      makeParallelConfig(),
+      "/tmp/workdir",
+      minimalExecConfig,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      retrySkipChecks,
+    );
+
+    expect(_orchestratorDeps.runSemanticReview).toHaveBeenCalledTimes(1);
+    expect(_orchestratorDeps.runAdversarialReview).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## What

In the parallel LLM review dispatch path, `retrySkipChecks` was not consulted before launching `runSemanticReview` and `runAdversarialReview`. Both reviewers re-ran on every retry regardless of the skip set.

## Why

When all checks pass in a review cycle (including via fail-open), autofix sets `retrySkipChecks` to all passed check names and retries from the review stage. The sequential path honoured this via `runReview()` → `runner.ts:266`, but the parallel path bypassed it entirely — calling the LLM reviewers unconditionally.

Closes #427

## How

- Compute `activeLlmCheckNames = llmCheckNames.filter(c => !retrySkipChecks?.has(c))` before entering the parallel/sequential branch
- Three dispatch cases:
  - `activeLlmCheckNames.length === 0` → skip LLM step entirely, log debug, return empty results
  - Both active + `canParallelize` → original `Promise.all` path (unchanged)
  - One active, or parallel disabled → sequential path via `runReview` (runner's per-check skip handles it)
- Moved `runSemanticReview` / `runAdversarialReview` into `_orchestratorDeps` so the parallel path is testable without `mock.module()` (BUG-035 pattern)

## Testing

- [x] Tests added/updated — 5 new cases in `test/unit/review/orchestrator.test.ts`
- [x] `bun test` passes (315 tests in review suite, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Observed in `logs/koda-graphify/graphify-kb-mm/` (v0.62.0-canary.4). The adversarial reviewer returned truncated JSON → fail-open → all checks passed → skip set populated → retry → both LLM reviewers re-ran anyway (~$5.50 wasted) → adversarial found new findings → autofix loop restarted. This fix cuts the unnecessary re-run entirely when the skip set covers all LLM checks.