### PR TITLE
fix(autofix): skip adversarial test-file findings for no-test stories (STRAT-001)

### DIFF
--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -14,10 +14,8 @@ import { getLogger } from "../../logger";
 import type { UserStory } from "../../prd";
 import { RectifierPromptBuilder } from "../../prompts";
 import type { ReviewCheckResult } from "../../review/types";
+import { isTestFile } from "../../test-runners";
 import type { PipelineContext } from "../types";
-
-/** Pattern matching test/spec files by extension. */
-export const TEST_FILE_PATTERN = /\.(test|spec)\.(ts|js|tsx|jsx)$/;
 
 /**
  * Split adversarial findings in a check result into test-file vs source-file buckets.
@@ -31,8 +29,8 @@ export function splitAdversarialFindingsByScope(check: ReviewCheckResult): {
     return { testFindings: null, sourceFindings: null };
   }
 
-  const testFs = check.findings.filter((f) => TEST_FILE_PATTERN.test(f.file ?? ""));
-  const sourceFs = check.findings.filter((f) => !TEST_FILE_PATTERN.test(f.file ?? ""));
+  const testFs = check.findings.filter((f) => isTestFile(f.file ?? ""));
+  const sourceFs = check.findings.filter((f) => !isTestFile(f.file ?? ""));
 
   const toCheck = (findings: typeof testFs): ReviewCheckResult | null => {
     if (findings.length === 0) return null;

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -144,6 +144,30 @@ export const autofixStage: PipelineStage = {
       });
     }
 
+    // STRAT-001: no-test stories never write tests, so adversarial findings scoped to test
+    // files are irrelevant and unresolvable within the story's scope.  When every failing
+    // check is an adversarial check whose findings are all test-file scoped, treat the
+    // review as passed (with a warning) rather than launching any agent session.
+    if (ctx.routing.testStrategy === "no-test") {
+      const failedChecks = (reviewResult.checks ?? []).filter((c) => !c.success);
+      if (
+        failedChecks.length > 0 &&
+        failedChecks.every((c) => {
+          if (c.check !== "adversarial") return false;
+          const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(c);
+          return testFindings !== null && sourceFindings === null;
+        })
+      ) {
+        const skippedFindingCount = failedChecks.flatMap((c) => c.findings ?? []).length;
+        logger.warn("autofix", "Adversarial review found test-file issues — skipped (no-test strategy)", {
+          storyId: ctx.story.id,
+          skippedFindingCount,
+        });
+        if (ctx.reviewResult) ctx.reviewResult = { ...ctx.reviewResult, success: true };
+        return { action: "continue" };
+      }
+    }
+
     // Phase 2: Agent rectification — spawn agent with review error context
     const {
       succeeded: agentFixed,
@@ -307,11 +331,21 @@ async function runAgentRectification(
   let autofixCostAccum = 0;
 
   if (testWriterChecks.length > 0) {
-    logger.info("autofix", "Routing test-file adversarial findings to test-writer session", {
-      storyId: ctx.story.id,
-      findingCount: testWriterChecks.flatMap((c) => c.findings ?? []).length,
-    });
-    autofixCostAccum += await _autofixDeps.runTestWriterRectification(ctx, testWriterChecks, ctx.story, agentGetFn);
+    if (ctx.routing.testStrategy === "no-test") {
+      // STRAT-001: no-test stories must not modify test files — skip test-writer session.
+      // The execute()-level early exit handles the common case; this guard is a safety net
+      // for mixed failures (adversarial test-file + other checks) that bypass the early exit.
+      logger.warn("autofix", "Skipping test-writer rectification (no-test strategy)", {
+        storyId: ctx.story.id,
+        skippedFindingCount: testWriterChecks.flatMap((c) => c.findings ?? []).length,
+      });
+    } else {
+      logger.info("autofix", "Routing test-file adversarial findings to test-writer session", {
+        storyId: ctx.story.id,
+        findingCount: testWriterChecks.flatMap((c) => c.findings ?? []).length,
+      });
+      autofixCostAccum += await _autofixDeps.runTestWriterRectification(ctx, testWriterChecks, ctx.story, agentGetFn);
+    }
   }
 
   // If all adversarial findings were test-file scoped and no other checks failed,

--- a/src/review/diff-utils.ts
+++ b/src/review/diff-utils.ts
@@ -7,6 +7,7 @@
 
 import { spawn } from "bun";
 import { getSafeLogger } from "../logger";
+import { isTestFile } from "../test-runners";
 import { getMergeBase, isGitRefValid } from "../utils/git";
 
 /** Maximum diff size in bytes before truncation. 50KB keeps prompts within LLM context. */
@@ -153,14 +154,6 @@ export async function computeTestInventory(workdir: string, storyGitRef: string)
 
   const addedFiles = stdout.trim().split("\n").filter(Boolean);
 
-  const TEST_PATTERNS = [
-    /\.test\.(ts|js|tsx|jsx)$/,
-    /\.spec\.(ts|js|tsx|jsx)$/,
-    /_test\.go$/,
-    /(?:^|\/)(?:test|tests|__tests__)\//,
-  ];
-
-  const isTestFile = (f: string): boolean => TEST_PATTERNS.some((p) => p.test(f));
 
   const addedTestFiles = addedFiles.filter(isTestFile);
   const addedSourceFiles = addedFiles.filter((f) => !isTestFile(f));

--- a/src/review/diff-utils.ts
+++ b/src/review/diff-utils.ts
@@ -154,7 +154,6 @@ export async function computeTestInventory(workdir: string, storyGitRef: string)
 
   const addedFiles = stdout.trim().split("\n").filter(Boolean);
 
-
   const addedTestFiles = addedFiles.filter(isTestFile);
   const addedSourceFiles = addedFiles.filter((f) => !isTestFile(f));
 

--- a/src/tdd/isolation.ts
+++ b/src/tdd/isolation.ts
@@ -7,21 +7,17 @@
  */
 
 import { spawn } from "../utils/bun-deps";
+import { isTestFile } from "../test-runners";
 import type { IsolationCheck } from "./types";
 
 /** Injectable deps for testability — mock _isolationDeps.spawn instead of global Bun.spawn */
 export const _isolationDeps = { spawn };
 
-/** Common test directory patterns */
-const TEST_PATTERNS = [/^test\//, /^tests\//, /^__tests__\//, /\.spec\.\w+$/, /\.test\.\w+$/, /\.e2e-spec\.\w+$/];
+// Re-export so existing callers (src/tdd/index.ts, tests) don't need to change imports.
+export { isTestFile };
 
 /** Common source directory patterns */
 const SRC_PATTERNS = [/^src\//, /^lib\//, /^packages\//];
-
-/** Check if a file path is a test file */
-export function isTestFile(filePath: string): boolean {
-  return TEST_PATTERNS.some((pattern) => pattern.test(filePath));
-}
 
 /** Check if a file path is a source file */
 export function isSourceFile(filePath: string): boolean {

--- a/src/tdd/isolation.ts
+++ b/src/tdd/isolation.ts
@@ -6,8 +6,8 @@
  * - Session 2 (implementer): no test/ files modified
  */
 
-import { spawn } from "../utils/bun-deps";
 import { isTestFile } from "../test-runners";
+import { spawn } from "../utils/bun-deps";
 import type { IsolationCheck } from "./types";
 
 /** Injectable deps for testability — mock _isolationDeps.spawn instead of global Bun.spawn */

--- a/src/test-runners/detector.ts
+++ b/src/test-runners/detector.ts
@@ -3,9 +3,36 @@
  *
  * Single source of truth for identifying which test runner produced a given output.
  * Used by both parseTestOutput() (structured summary) and parseTestFailures() (AC-ID extraction).
+ *
+ * Also exports isTestFile() — language-agnostic test file classification used across
+ * the pipeline (autofix scope routing, TDD isolation, diff analysis).
  */
 
 export type Framework = "bun" | "jest" | "vitest" | "pytest" | "go" | "unknown";
+
+/**
+ * Language-agnostic patterns that identify test files. Covers:
+ * - Directory segments: test/, tests/, __tests__/, spec/, specs/
+ * - Extension-based: .test.<ext>, .spec.<ext>, .e2e-spec.<ext>
+ * - Go suffix: _test.go
+ * - Python prefix: test_<name>.py
+ */
+const TEST_FILE_PATTERNS = [
+  /(?:^|\/)(?:test|tests|__tests__|specs?)(?:\/|$)/, // dir segment — any language
+  /\.test\.\w+$/, // foo.test.ts, foo.test.py
+  /\.spec\.\w+$/, // foo.spec.ts, foo.spec.rb
+  /\.e2e-spec\.\w+$/, // foo.e2e-spec.ts
+  /_test\.go$/, // Go: foo_test.go
+  /(?:^|\/)test_[^/]+$/, // Python: test_foo.py
+];
+
+/**
+ * Returns true when the given file path looks like a test file across any
+ * supported language (TypeScript, Python, Go, Ruby, Rust, Java, etc.).
+ */
+export function isTestFile(filePath: string): boolean {
+  return TEST_FILE_PATTERNS.some((pattern) => pattern.test(filePath));
+}
 
 /**
  * Detect the test framework that produced the given output.

--- a/src/test-runners/index.ts
+++ b/src/test-runners/index.ts
@@ -9,7 +9,7 @@
  * - analyzeTestExitCode(): environmental failure detection
  */
 
-export { detectFramework } from "./detector";
+export { detectFramework, isTestFile } from "./detector";
 export type { Framework } from "./detector";
 export { analyzeTestExitCode, formatFailureSummary, parseBunTestOutput, parseTestOutput } from "./parser";
 export { parseTestFailures } from "./ac-parser";

--- a/test/unit/pipeline/stages/autofix-adversarial.test.ts
+++ b/test/unit/pipeline/stages/autofix-adversarial.test.ts
@@ -10,10 +10,10 @@
 
 import { describe, expect, mock, test, afterEach } from "bun:test";
 import {
-  TEST_FILE_PATTERN,
   splitAdversarialFindingsByScope,
   runTestWriterRectification,
 } from "../../../../src/pipeline/stages/autofix-adversarial";
+import { isTestFile } from "../../../../src/test-runners";
 import { _autofixDeps } from "../../../../src/pipeline/stages/autofix";
 import { DEFAULT_CONFIG } from "../../../../src/config";
 import type { ReviewCheckResult } from "../../../../src/review/types";
@@ -69,15 +69,18 @@ function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
 // TEST_FILE_PATTERN
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("TEST_FILE_PATTERN", () => {
+describe("isTestFile", () => {
   test.each([
     "src/foo.test.ts",
     "src/bar.spec.ts",
     "test/unit/foo.test.js",
     "src/foo.test.tsx",
     "src/bar.spec.jsx",
+    "rag_service_test.go",
+    "tests/integration/foo_test.rs",
+    "test_rag_service.py",
   ])("matches test file: %s", (file) => {
-    expect(TEST_FILE_PATTERN.test(file)).toBe(true);
+    expect(isTestFile(file)).toBe(true);
   });
 
   test.each([
@@ -87,7 +90,7 @@ describe("TEST_FILE_PATTERN", () => {
     "src/test-utils.ts",
     "src/testing/helpers.ts",
   ])("does not match source file: %s", (file) => {
-    expect(TEST_FILE_PATTERN.test(file)).toBe(false);
+    expect(isTestFile(file)).toBe(false);
   });
 });
 

--- a/test/unit/pipeline/stages/autofix.test.ts
+++ b/test/unit/pipeline/stages/autofix.test.ts
@@ -756,3 +756,150 @@ describe("#409 scope-aware adversarial routing", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// STRAT-001: no-test strategy adversarial skip (#429)
+// ---------------------------------------------------------------------------
+
+describe("STRAT-001 no-test adversarial skip", () => {
+  function makeAdversarialCheck(findings: Array<{ file: string }>): ReviewCheckResult {
+    return {
+      check: "adversarial",
+      success: false,
+      command: "adversarial-review",
+      exitCode: 1,
+      output: "adversarial review output",
+      durationMs: 100,
+      findings: findings.map((f) => ({
+        ruleId: "adversarial",
+        severity: "error" as const,
+        file: f.file,
+        line: 1,
+        message: "adversarial finding",
+        source: "adversarial-review",
+      })),
+    };
+  }
+
+  function makeNoTestCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
+    return makeCtx({
+      routing: { complexity: "simple", modelTier: "fast", testStrategy: "no-test", reasoning: "" },
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test" },
+          autofix: { enabled: true, maxAttempts: 2 },
+        },
+        autoMode: { ...DEFAULT_CONFIG.autoMode, defaultAgent: "claude" },
+      } as any,
+      ...overrides,
+    });
+  }
+
+  test("all adversarial test-file findings → returns continue, marks review passed, skips agent", async () => {
+    const saved = { ..._autofixDeps };
+    let agentRectificationCalled = false;
+    _autofixDeps.runAgentRectification = async () => {
+      agentRectificationCalled = true;
+      return { succeeded: false, cost: 0 };
+    };
+
+    const adversarialCheck = makeAdversarialCheck([
+      { file: "test/unit/foo.test.ts" },
+      { file: "src/bar.spec.ts" },
+    ]);
+    const ctx = makeNoTestCtx({
+      reviewResult: { success: false, checks: [adversarialCheck], summary: "" } as any,
+    });
+
+    const result = await autofixStage.execute(ctx);
+    Object.assign(_autofixDeps, saved);
+
+    expect(result.action).toBe("continue");
+    expect(ctx.reviewResult?.success).toBe(true);
+    expect(agentRectificationCalled).toBe(false);
+  });
+
+  test("adversarial test-file findings + lint failure → early exit skipped, agent rectification runs", async () => {
+    const saved = { ..._autofixDeps };
+    let agentRectificationCalled = false;
+    _autofixDeps.runAgentRectification = async () => {
+      agentRectificationCalled = true;
+      return { succeeded: false, cost: 0 };
+    };
+    _autofixDeps.recheckReview = async () => false;
+
+    const adversarialCheck = makeAdversarialCheck([{ file: "test/unit/foo.test.ts" }]);
+    const lintCheck: ReviewCheckResult = {
+      check: "lint",
+      success: false,
+      command: "biome check",
+      exitCode: 1,
+      output: "lint error",
+      durationMs: 50,
+    };
+    const ctx = makeNoTestCtx({
+      reviewResult: { success: false, checks: [adversarialCheck, lintCheck], summary: "" } as any,
+    });
+
+    await autofixStage.execute(ctx);
+    Object.assign(_autofixDeps, saved);
+
+    // Mixed failures → early exit guard does not trigger → agent rectification runs
+    expect(agentRectificationCalled).toBe(true);
+  });
+
+  test("adversarial source-file findings → early exit skipped, agent rectification runs", async () => {
+    const saved = { ..._autofixDeps };
+    let agentRectificationCalled = false;
+    _autofixDeps.runAgentRectification = async () => {
+      agentRectificationCalled = true;
+      return { succeeded: false, cost: 0 };
+    };
+
+    const adversarialCheck = makeAdversarialCheck([{ file: "src/rag/rag.service.ts" }]);
+    const ctx = makeNoTestCtx({
+      reviewResult: { success: false, checks: [adversarialCheck], summary: "" } as any,
+    });
+
+    await autofixStage.execute(ctx);
+    Object.assign(_autofixDeps, saved);
+
+    expect(agentRectificationCalled).toBe(true);
+  });
+
+  test("safety-net: mixed findings with no-test → test-writer skipped, implementer runs for source findings", async () => {
+    const saved = { ..._autofixDeps };
+    let testWriterCalled = false;
+    let implementerCalled = false;
+
+    _autofixDeps.runTestWriterRectification = async () => {
+      testWriterCalled = true;
+      return 0;
+    };
+    _autofixDeps.getAgent = () =>
+      ({
+        run: async () => {
+          implementerCalled = true;
+          return { success: false };
+        },
+      }) as any;
+    _autofixDeps.recheckReview = async () => false;
+
+    // Mixed findings: early exit does not fire (source + test), but safety-net blocks test-writer
+    const mixedCheck = makeAdversarialCheck([
+      { file: "test/unit/foo.test.ts" },
+      { file: "src/implementation.ts" },
+    ]);
+    const ctx = makeNoTestCtx({
+      reviewResult: { success: false, checks: [mixedCheck], summary: "" } as any,
+    });
+
+    await autofixStage.execute(ctx);
+    Object.assign(_autofixDeps, saved);
+
+    expect(testWriterCalled).toBe(false);
+    expect(implementerCalled).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary

- When `testStrategy === "no-test"` and **all** failing checks are adversarial with findings exclusively in test files, `autofixStage.execute()` now returns `{ action: "continue" }` with `reviewResult.success = true` instead of entering agent rectification
- Logs a `warn`-level entry with `skippedFindingCount` so the skipped findings remain visible
- Safety-net guard in `runAgentRectification` blocks the test-writer session from launching for `no-test` stories even if test-file adversarial findings somehow reach that code path

## Root Cause

`no-test` stories (STRAT-001) never produce test files. When the adversarial reviewer flags test-file issues (e.g. out-of-scope ACs in `.nax-acceptance.test.ts`), the existing code routed them to a test-writer session. That session had no winning move: it cannot create source methods (constrained to test files) and the implementer cannot modify test files. This caused an infinite rectification loop consuming ~$20 in the graphify-kb run before SIGINT.

## Test Plan

- [x] `all adversarial test-file findings → returns continue, marks review passed, skips agent`
- [x] `adversarial test-file findings + lint failure → early exit skipped, agent rectification runs`
- [x] `adversarial source-file findings → early exit skipped, agent rectification runs`
- [x] `safety-net: mixed findings with no-test → test-writer skipped, implementer runs for source findings`
- [x] `bun run typecheck` — clean
- [x] `bun test test/unit/pipeline/stages/autofix.test.ts` — 30 pass

Closes #429