### PR TITLE
feat(review): audit trail for semantic and adversarial reviewer JSON output

### DIFF
--- a/src/agents/acp/index.ts
+++ b/src/agents/acp/index.ts
@@ -5,5 +5,5 @@
 export { AcpAgentAdapter, _acpAdapterDeps, _fallbackDeps } from "./adapter";
 export { createSpawnAcpClient } from "./spawn-client";
 export { parseAgentError } from "./parse-agent-error";
-export { writePromptAudit, _promptAuditDeps } from "./prompt-audit";
+export { writePromptAudit, findNaxProjectRoot, _promptAuditDeps } from "./prompt-audit";
 export type { AgentRegistryEntry } from "./types";

--- a/src/agents/acp/prompt-audit.ts
+++ b/src/agents/acp/prompt-audit.ts
@@ -128,7 +128,7 @@ const MAX_NAX_WALK_DEPTH = 10;
  * This consolidates monorepo audit files at the project root even when individual
  * stories run with a package subdir as their workdir (e.g. apps/api/).
  */
-async function findNaxProjectRoot(startDir: string): Promise<string> {
+export async function findNaxProjectRoot(startDir: string): Promise<string> {
   let dir = resolve(startDir);
   for (let depth = 0; depth < MAX_NAX_WALK_DEPTH; depth++) {
     if (await _promptAuditDeps.exists(join(dir, ".nax", "config.json"))) {

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -349,6 +349,7 @@ const ReviewConfigSchema = z.object({
     formatFix: z.string().optional(),
   }),
   pluginMode: z.enum(["per-story", "deferred"]).default("per-story"),
+  audit: z.object({ enabled: z.boolean().default(false) }).default({ enabled: false }),
   semantic: SemanticReviewConfigSchema.optional(),
   adversarial: AdversarialReviewConfigSchema.optional(),
   dialogue: ReviewDialogueConfigSchema.default({
@@ -764,6 +765,7 @@ export const NaxConfigSchema = z
       checks: ["typecheck", "lint"],
       commands: {},
       pluginMode: "per-story",
+      audit: { enabled: false },
       semantic: {
         modelTier: "balanced",
         diffMode: "embedded",

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -121,6 +121,19 @@ ${SEMANTIC_OUTPUT_SCHEMA}`;
 
     return wrapJsonPrompt(core);
   }
+
+  /**
+   * Follow-up prompt sent in the same session when the first response could not
+   * be parsed as valid JSON. The LLM still has the full review context — this
+   * turn only asks it to re-emit the result in the correct format.
+   */
+  static jsonRetry(): string {
+    return (
+      "Your previous response could not be parsed as valid JSON.\n" +
+      "Output ONLY the JSON object from your review — no markdown fences, no explanation.\n" +
+      "The object must start with { and end with }."
+    );
+  }
 }
 
 // ─── Private helpers ──────────────────────────────────────────────────────────

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -22,6 +22,7 @@ import type { ModelTier } from "../config/schema-types";
 import { getSafeLogger } from "../logger";
 import type { ReviewFinding } from "../plugins/types";
 import { AdversarialReviewPromptBuilder } from "../prompts/builders/adversarial-review-builder";
+import { ReviewPromptBuilder } from "../prompts/builders/review-builder";
 import { tryParseLLMJson } from "../utils/llm-json";
 import { collectDiff, collectDiffStat, computeTestInventory, resolveEffectiveRef } from "./diff-utils";
 import { writeReviewAudit } from "./review-audit";
@@ -229,23 +230,23 @@ export async function runAdversarialReview(
   // Adversarial review uses its own session (NOT the implementer session).
   const adversarialSessionName = buildSessionName(workdir, featureName, story.id, "reviewer-adversarial");
 
+  const runOpts = {
+    workdir,
+    acpSessionName: adversarialSessionName,
+    timeoutSeconds: adversarialConfig.timeoutMs ? Math.ceil(adversarialConfig.timeoutMs / 1000) : 600,
+    modelTier: adversarialConfig.modelTier,
+    modelDef: resolvedModelDef,
+    pipelineStage: "review",
+    config: naxConfig ?? DEFAULT_CONFIG,
+    featureName,
+    storyId: story.id,
+    sessionRole: "reviewer-adversarial",
+  } as const;
+
   let rawResponse: string;
   let llmCost = 0;
   try {
-    const runResult = await agent.run({
-      prompt,
-      workdir,
-      acpSessionName: adversarialSessionName,
-      keepSessionOpen: false,
-      timeoutSeconds: adversarialConfig.timeoutMs ? Math.ceil(adversarialConfig.timeoutMs / 1000) : 600,
-      modelTier: adversarialConfig.modelTier,
-      modelDef: resolvedModelDef,
-      pipelineStage: "review",
-      config: naxConfig ?? DEFAULT_CONFIG,
-      featureName,
-      storyId: story.id,
-      sessionRole: "reviewer-adversarial",
-    });
+    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: true });
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;
   } catch (err) {
@@ -261,6 +262,25 @@ export async function runAdversarialReview(
       output: `skipped: LLM call failed — ${String(err)}`,
       durationMs: Date.now() - startTime,
     };
+  }
+
+  // Retry once when the response cannot be parsed — the session has full context so
+  // a short follow-up asking for valid JSON is sufficient.
+  if (!parseAdversarialResponse(rawResponse)) {
+    try {
+      logger?.debug("adversarial", "Response could not be parsed — retrying with JSON prompt", {
+        storyId: story.id,
+      });
+      const retryResult = await agent.run({
+        prompt: ReviewPromptBuilder.jsonRetry(),
+        ...runOpts,
+        keepSessionOpen: false,
+      });
+      rawResponse = retryResult.output;
+      llmCost += retryResult.estimatedCost ?? 0;
+    } catch (err) {
+      logger?.warn("adversarial", "JSON retry call failed", { storyId: story.id, cause: String(err) });
+    }
   }
 
   // Parse response — fail-closed when LLM clearly intended to fail,

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -14,6 +14,7 @@
  */
 
 import { buildSessionName, readAcpSession } from "../agents/acp/adapter";
+import { writeReviewAudit } from "./review-audit";
 import type { AgentAdapter } from "../agents/types";
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
@@ -266,6 +267,16 @@ export async function runAdversarialReview(
   const parsed = parseAdversarialResponse(rawResponse);
   if (!parsed) {
     const looksLikeFail = /"passed"\s*:\s*false/.test(rawResponse);
+    void writeReviewAudit({
+      reviewer: "adversarial",
+      sessionName: adversarialSessionName,
+      workdir,
+      storyId: story.id,
+      featureName,
+      parsed: false,
+      looksLikeFail,
+      result: null,
+    });
     if (looksLikeFail) {
       logger?.warn("adversarial", "LLM returned truncated JSON with passed:false — treating as failure", {
         storyId: story.id,
@@ -297,6 +308,16 @@ export async function runAdversarialReview(
       cost: llmCost,
     };
   }
+
+  void writeReviewAudit({
+    reviewer: "adversarial",
+    sessionName: adversarialSessionName,
+    workdir,
+    storyId: story.id,
+    featureName,
+    parsed: true,
+    result: { passed: parsed.passed, findings: parsed.findings },
+  });
 
   const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity));
   const nonBlockingFindings = parsed.findings.filter((f) => !isBlockingSeverity(f.severity));

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -14,7 +14,6 @@
  */
 
 import { buildSessionName, readAcpSession } from "../agents/acp/adapter";
-import { writeReviewAudit } from "./review-audit";
 import type { AgentAdapter } from "../agents/types";
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
@@ -25,6 +24,7 @@ import type { ReviewFinding } from "../plugins/types";
 import { AdversarialReviewPromptBuilder } from "../prompts/builders/adversarial-review-builder";
 import { tryParseLLMJson } from "../utils/llm-json";
 import { collectDiff, collectDiffStat, computeTestInventory, resolveEffectiveRef } from "./diff-utils";
+import { writeReviewAudit } from "./review-audit";
 import type { AdversarialReviewConfig, ReviewCheckResult, SemanticStory } from "./types";
 
 /** Function that resolves an AgentAdapter for a given model tier */
@@ -33,6 +33,7 @@ export type ModelResolver = (tier: ModelTier) => AgentAdapter | null | undefined
 /** Injectable dependencies for adversarial.ts — allows tests to mock without mock.module() */
 export const _adversarialDeps = {
   readAcpSession,
+  writeReviewAudit,
 };
 
 interface AdversarialLLMFinding {
@@ -267,16 +268,18 @@ export async function runAdversarialReview(
   const parsed = parseAdversarialResponse(rawResponse);
   if (!parsed) {
     const looksLikeFail = /"passed"\s*:\s*false/.test(rawResponse);
-    void writeReviewAudit({
-      reviewer: "adversarial",
-      sessionName: adversarialSessionName,
-      workdir,
-      storyId: story.id,
-      featureName,
-      parsed: false,
-      looksLikeFail,
-      result: null,
-    });
+    if (naxConfig?.review?.audit?.enabled) {
+      void _adversarialDeps.writeReviewAudit({
+        reviewer: "adversarial",
+        sessionName: adversarialSessionName,
+        workdir,
+        storyId: story.id,
+        featureName,
+        parsed: false,
+        looksLikeFail,
+        result: null,
+      });
+    }
     if (looksLikeFail) {
       logger?.warn("adversarial", "LLM returned truncated JSON with passed:false — treating as failure", {
         storyId: story.id,
@@ -309,15 +312,17 @@ export async function runAdversarialReview(
     };
   }
 
-  void writeReviewAudit({
-    reviewer: "adversarial",
-    sessionName: adversarialSessionName,
-    workdir,
-    storyId: story.id,
-    featureName,
-    parsed: true,
-    result: { passed: parsed.passed, findings: parsed.findings },
-  });
+  if (naxConfig?.review?.audit?.enabled) {
+    void _adversarialDeps.writeReviewAudit({
+      reviewer: "adversarial",
+      sessionName: adversarialSessionName,
+      workdir,
+      storyId: story.id,
+      featureName,
+      parsed: true,
+      result: { passed: parsed.passed, findings: parsed.findings },
+    });
+  }
 
   const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity));
   const nonBlockingFindings = parsed.findings.filter((f) => !isBlockingSeverity(f.severity));

--- a/src/review/review-audit.ts
+++ b/src/review/review-audit.ts
@@ -1,0 +1,99 @@
+/**
+ * Review Audit — fire-and-forget writer for LLM reviewer JSON output.
+ *
+ * Saves the parsed result from semantic and adversarial reviewers to disk so
+ * operators can audit exactly what each reviewer decided, regardless of
+ * whether the JSON was valid or not.
+ *
+ * Directory layout (mirrors prompt-audit):
+ *   .nax/review-audit/<featureName>/<epochMs>-<sessionName>.json
+ *
+ * All operations are best-effort: errors are warned but never thrown so that
+ * an audit write failure can never interrupt an active run.
+ */
+
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { findNaxProjectRoot } from "../agents/acp";
+import { getSafeLogger } from "../logger";
+
+export interface ReviewAuditEntry {
+  /** Reviewer type. */
+  reviewer: "semantic" | "adversarial";
+  /** ACP session name — used as part of the filename for correlation with prompt-audit. */
+  sessionName: string;
+  /** Working directory — used to resolve the audit dir when projectDir is absent. */
+  workdir: string;
+  /** Story ID for metadata. */
+  storyId?: string;
+  /** Feature name — determines the subfolder under review-audit/. */
+  featureName?: string;
+  /**
+   * Whether the LLM response parsed successfully into a valid review JSON.
+   * false = parse failed; looksLikeFail indicates the heuristic result.
+   */
+  parsed: boolean;
+  /** When parsed is false, whether the raw response contained "passed":false. */
+  looksLikeFail?: boolean;
+  /** The structured reviewer result. null when parsed is false. */
+  result: { passed: boolean; findings: unknown[] } | null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Injectable deps (for unit testing)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const _reviewAuditDeps = {
+  async mkdir(path: string): Promise<void> {
+    await mkdir(path, { recursive: true });
+  },
+  async writeFile(path: string, content: string): Promise<void> {
+    await Bun.write(path, content);
+  },
+  now(): number {
+    return Date.now();
+  },
+  findNaxProjectRoot,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Write a review audit entry to disk. Best-effort — errors warn but never throw.
+ * Call with `void writeReviewAudit(...)` (fire-and-forget) from reviewer functions.
+ */
+export async function writeReviewAudit(entry: ReviewAuditEntry): Promise<void> {
+  try {
+    const projectRoot = await _reviewAuditDeps.findNaxProjectRoot(entry.workdir);
+    const resolvedDir = join(projectRoot, ".nax", "review-audit", entry.featureName ?? "_unknown");
+
+    await _reviewAuditDeps.mkdir(resolvedDir);
+
+    const epochMs = _reviewAuditDeps.now();
+    const filename = `${epochMs}-${entry.sessionName}.json`;
+
+    const content = JSON.stringify(
+      {
+        timestamp: new Date(epochMs).toISOString(),
+        storyId: entry.storyId ?? null,
+        featureName: entry.featureName ?? null,
+        reviewer: entry.reviewer,
+        sessionName: entry.sessionName,
+        parsed: entry.parsed,
+        ...(entry.parsed ? {} : { looksLikeFail: entry.looksLikeFail ?? false }),
+        result: entry.result,
+      },
+      null,
+      2,
+    );
+
+    await _reviewAuditDeps.writeFile(join(resolvedDir, filename), content);
+  } catch (err) {
+    getSafeLogger()?.warn("review-audit", "Failed to write review audit file", {
+      error: String(err),
+      sessionName: entry.sessionName,
+    });
+  }
+}

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -369,23 +369,24 @@ export async function runSemanticReview(
   } catch {
     // Use default model if resolution fails
   }
+
+  const runOpts = {
+    workdir,
+    acpSessionName: reviewerSessionName,
+    timeoutSeconds: semanticConfig.timeoutMs ? Math.ceil(semanticConfig.timeoutMs / 1000) : 3600,
+    modelTier: semanticConfig.modelTier,
+    modelDef: resolvedModelDef,
+    pipelineStage: "review",
+    config: naxConfig ?? DEFAULT_CONFIG,
+    featureName,
+    storyId: story.id,
+    sessionRole: "reviewer-semantic",
+  } as const;
+
   let rawResponse: string;
   let llmCost = 0;
   try {
-    const runResult = await agent.run({
-      prompt,
-      workdir,
-      acpSessionName: reviewerSessionName,
-      keepSessionOpen: false,
-      timeoutSeconds: semanticConfig.timeoutMs ? Math.ceil(semanticConfig.timeoutMs / 1000) : 3600,
-      modelTier: semanticConfig.modelTier,
-      modelDef: resolvedModelDef,
-      pipelineStage: "review",
-      config: naxConfig ?? DEFAULT_CONFIG,
-      featureName,
-      storyId: story.id,
-      sessionRole: "reviewer-semantic",
-    });
+    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: true });
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;
   } catch (err) {
@@ -398,6 +399,25 @@ export async function runSemanticReview(
       output: `skipped: LLM call failed — ${String(err)}`,
       durationMs: Date.now() - startTime,
     };
+  }
+
+  // Retry once when the response cannot be parsed — the session has full context so
+  // a short follow-up asking for valid JSON is sufficient.
+  if (!parseLLMResponse(rawResponse)) {
+    try {
+      logger?.debug("semantic", "Response could not be parsed — retrying with JSON prompt", {
+        storyId: story.id,
+      });
+      const retryResult = await agent.run({
+        prompt: ReviewPromptBuilder.jsonRetry(),
+        ...runOpts,
+        keepSessionOpen: false,
+      });
+      rawResponse = retryResult.output;
+      llmCost += retryResult.estimatedCost ?? 0;
+    } catch (err) {
+      logger?.warn("semantic", "JSON retry call failed", { storyId: story.id, cause: String(err) });
+    }
   }
 
   // Parse response — fail-closed when LLM clearly intended to fail,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -8,6 +8,7 @@
  */
 
 import { buildSessionName } from "../agents/acp/adapter";
+import { writeReviewAudit } from "./review-audit";
 import type { AgentAdapter } from "../agents/types";
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
@@ -405,6 +406,16 @@ export async function runSemanticReview(
     // Check if truncated response contains "passed": false — LLM intended to fail
     // but output was cut off mid-response. Treating this as a pass is incorrect (#105).
     const looksLikeFail = /"passed"\s*:\s*false/.test(rawResponse);
+    void writeReviewAudit({
+      reviewer: "semantic",
+      sessionName: reviewerSessionName,
+      workdir,
+      storyId: story.id,
+      featureName,
+      parsed: false,
+      looksLikeFail,
+      result: null,
+    });
     if (looksLikeFail) {
       logger?.warn("semantic", "LLM returned truncated JSON with passed:false — treating as failure", {
         storyId: story.id,
@@ -436,6 +447,16 @@ export async function runSemanticReview(
       cost: llmCost,
     };
   }
+
+  void writeReviewAudit({
+    reviewer: "semantic",
+    sessionName: reviewerSessionName,
+    workdir,
+    storyId: story.id,
+    featureName,
+    parsed: true,
+    result: { passed: parsed.passed, findings: parsed.findings },
+  });
 
   // Split findings into blocking (error/warn) and non-blocking (unverifiable/info)
   const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity));

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -8,7 +8,6 @@
  */
 
 import { buildSessionName } from "../agents/acp/adapter";
-import { writeReviewAudit } from "./review-audit";
 import type { AgentAdapter } from "../agents/types";
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
@@ -21,6 +20,7 @@ import type { ReviewFinding } from "../plugins/types";
 import { ReviewPromptBuilder } from "../prompts";
 import { tryParseLLMJson } from "../utils/llm-json";
 import { DIFF_CAP_BYTES, collectDiff, collectDiffStat, resolveEffectiveRef, truncateDiff } from "./diff-utils";
+import { writeReviewAudit } from "./review-audit";
 import type { ReviewCheckResult, SemanticReviewConfig, SemanticStory } from "./types";
 
 // Re-export so existing callers (`import type { SemanticStory } from "./semantic"`) keep working.
@@ -32,6 +32,7 @@ export type ModelResolver = (tier: ModelTier) => AgentAdapter | null | undefined
 /** Injectable dependencies for semantic.ts — allows tests to mock without mock.module() */
 export const _semanticDeps = {
   createDebateSession: (opts: DebateSessionOptions): DebateSession => new DebateSession(opts),
+  writeReviewAudit,
 };
 
 interface LLMFinding {
@@ -406,16 +407,18 @@ export async function runSemanticReview(
     // Check if truncated response contains "passed": false — LLM intended to fail
     // but output was cut off mid-response. Treating this as a pass is incorrect (#105).
     const looksLikeFail = /"passed"\s*:\s*false/.test(rawResponse);
-    void writeReviewAudit({
-      reviewer: "semantic",
-      sessionName: reviewerSessionName,
-      workdir,
-      storyId: story.id,
-      featureName,
-      parsed: false,
-      looksLikeFail,
-      result: null,
-    });
+    if (naxConfig?.review?.audit?.enabled) {
+      void _semanticDeps.writeReviewAudit({
+        reviewer: "semantic",
+        sessionName: reviewerSessionName,
+        workdir,
+        storyId: story.id,
+        featureName,
+        parsed: false,
+        looksLikeFail,
+        result: null,
+      });
+    }
     if (looksLikeFail) {
       logger?.warn("semantic", "LLM returned truncated JSON with passed:false — treating as failure", {
         storyId: story.id,
@@ -448,15 +451,17 @@ export async function runSemanticReview(
     };
   }
 
-  void writeReviewAudit({
-    reviewer: "semantic",
-    sessionName: reviewerSessionName,
-    workdir,
-    storyId: story.id,
-    featureName,
-    parsed: true,
-    result: { passed: parsed.passed, findings: parsed.findings },
-  });
+  if (naxConfig?.review?.audit?.enabled) {
+    void _semanticDeps.writeReviewAudit({
+      reviewer: "semantic",
+      sessionName: reviewerSessionName,
+      workdir,
+      storyId: story.id,
+      featureName,
+      parsed: true,
+      result: { passed: parsed.passed, findings: parsed.findings },
+    });
+  }
 
   // Split findings into blocking (error/warn) and non-blocking (unverifiable/info)
   const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity));

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -149,6 +149,8 @@ export interface ReviewConfig {
   };
   /** When to run plugin reviewers: per-story (default) or deferred (skip per-story, run once at end) */
   pluginMode?: "per-story" | "deferred";
+  /** Review audit configuration — saves parsed reviewer JSON to .nax/review-audit/ */
+  audit?: { enabled: boolean };
   /** Semantic review configuration (when 'semantic' is in checks) */
   semantic?: SemanticReviewConfig;
   /** Adversarial review configuration (when 'adversarial' is in checks) */

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Unit tests for the JSON retry logic in src/review/adversarial.ts
+ *
+ * Tests cover:
+ * - Retry succeeds: initial response unparseable, retry returns valid JSON
+ * - Retry failure: retry call throws, falls through to fail-open
+ * - agent.run called twice when initial response is unparseable
+ * - Retry call uses keepSessionOpen: false
+ * - Cost accumulated from both initial and retry calls
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _adversarialDeps, runAdversarialReview } from "../../../src/review/adversarial";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
+import type { AdversarialReviewConfig } from "../../../src/review/types";
+import type { SemanticStory } from "../../../src/review/types";
+import type { AgentAdapter } from "../../../src/agents/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STORY: SemanticStory = {
+  id: "STORY-001",
+  title: "Add auth",
+  description: "Auth feature",
+  acceptanceCriteria: ["Users can log in"],
+};
+
+const ADVERSARIAL_CONFIG: AdversarialReviewConfig = {
+  modelTier: "balanced",
+  diffMode: "ref",
+  rules: [],
+  timeoutMs: 180_000,
+  excludePatterns: [],
+  parallel: false,
+  maxConcurrentSessions: 2,
+};
+
+const PASSING_RESPONSE = JSON.stringify({ passed: true, findings: [] });
+const STAT_OUTPUT = "src/foo.ts | 5 +++++\n 1 file changed, 5 insertions(+)";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSpawnMock(stdout: string, exitCode = 0) {
+  return mock((_opts: unknown) => ({
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(stdout));
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    kill: () => {},
+  })) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+/**
+ * Build a mock AgentAdapter whose run() returns a different response per call.
+ * responses[0] is returned on the first call, responses[1] on the second, etc.
+ * The last entry is reused for any additional calls beyond the array length.
+ */
+function makeMultiCallAgent(responses: string[], costPerCall = 0.5): AgentAdapter {
+  let callIndex = 0;
+  return {
+    name: "mock",
+    displayName: "Mock Multi-Call Agent",
+    binary: "mock",
+    capabilities: {
+      supportedTiers: [],
+      supportedTestStrategies: [],
+      features: {},
+    } as unknown as AgentAdapter["capabilities"],
+    isInstalled: mock(async () => true),
+    run: mock(async () => {
+      const response = responses[callIndex] ?? responses[responses.length - 1];
+      callIndex++;
+      return { output: response, estimatedCost: costPerCall };
+    }),
+    buildCommand: mock(() => []),
+    plan: mock(async () => { throw new Error("not used"); }),
+    decompose: mock(async () => { throw new Error("not used"); }),
+    complete: mock(async (_prompt: string) => responses[0]),
+  } as unknown as AgentAdapter;
+}
+
+// ---------------------------------------------------------------------------
+// Saved deps
+// ---------------------------------------------------------------------------
+
+let origSpawn: typeof _diffUtilsDeps.spawn;
+let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
+let origReadAcpSession: typeof _adversarialDeps.readAcpSession;
+let origWriteReviewAudit: typeof _adversarialDeps.writeReviewAudit;
+
+function saveAllDeps() {
+  origSpawn = _diffUtilsDeps.spawn;
+  origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+  origGetMergeBase = _diffUtilsDeps.getMergeBase;
+  origReadAcpSession = _adversarialDeps.readAcpSession;
+  origWriteReviewAudit = _adversarialDeps.writeReviewAudit;
+}
+
+function restoreAllDeps() {
+  _diffUtilsDeps.spawn = origSpawn;
+  _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+  _diffUtilsDeps.getMergeBase = origGetMergeBase;
+  _adversarialDeps.readAcpSession = origReadAcpSession;
+  _adversarialDeps.writeReviewAudit = origWriteReviewAudit;
+}
+
+function setupHappyPathDeps(statContent = STAT_OUTPUT) {
+  _diffUtilsDeps.isGitRefValid = mock(async () => true);
+  _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+  _diffUtilsDeps.spawn = makeSpawnMock(statContent);
+  _adversarialDeps.readAcpSession = mock(async () => null);
+  _adversarialDeps.writeReviewAudit = mock(async () => {});
+}
+
+// ---------------------------------------------------------------------------
+// JSON retry — success path
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — JSON retry succeeds", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("uses valid JSON from retry when initial response is unparseable", async () => {
+    const agent = makeMultiCallAgent(["this is not json at all", PASSING_RESPONSE]);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Adversarial review passed");
+  });
+
+  test("agent.run called twice when initial response is unparseable", async () => {
+    const agent = makeMultiCallAgent(["this is not json at all", PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    expect((agent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(2);
+  });
+
+  test("retry call uses keepSessionOpen: false to close the session", async () => {
+    const agent = makeMultiCallAgent(["this is not json at all", PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    const calls = (agent.run as ReturnType<typeof mock>).mock.calls;
+    expect((calls[1][0] as Record<string, unknown>).keepSessionOpen).toBe(false);
+  });
+
+  test("initial call uses keepSessionOpen: true to keep session open for retry", async () => {
+    const agent = makeMultiCallAgent([PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    const calls = (agent.run as ReturnType<typeof mock>).mock.calls;
+    expect((calls[0][0] as Record<string, unknown>).keepSessionOpen).toBe(true);
+  });
+
+  test("agent.run called once when initial response is valid JSON", async () => {
+    const agent = makeMultiCallAgent([PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    expect((agent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+  });
+
+  test("cost accumulated from both initial and retry calls", async () => {
+    const agent = makeMultiCallAgent(["not json", PASSING_RESPONSE], 0.5);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.cost).toBeCloseTo(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON retry — failure paths
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — JSON retry failure paths", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("falls through to fail-open when retry call throws", async () => {
+    let callIndex = 0;
+    const agent = {
+      name: "mock",
+      displayName: "Mock Agent",
+      binary: "mock",
+      capabilities: { supportedTiers: [], supportedTestStrategies: [], features: {} } as unknown as AgentAdapter["capabilities"],
+      isInstalled: mock(async () => true),
+      run: mock(async () => {
+        callIndex++;
+        if (callIndex === 1) return { output: "not json at all", estimatedCost: 0 };
+        throw new Error("retry connection failure");
+      }),
+      buildCommand: mock(() => []),
+      plan: mock(async () => { throw new Error("not used"); }),
+      decompose: mock(async () => { throw new Error("not used"); }),
+      complete: mock(async (_prompt: string) => ""),
+    } as unknown as AgentAdapter;
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("fail-open");
+  });
+
+  test("fails closed when retry also returns truncated JSON with passed:false", async () => {
+    const truncated = '{ "passed": false, "findings": [{ "severity": "error"';
+    const agent = makeMultiCallAgent(["not json", truncated]);
+
+    const result = await runAdversarialReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      ADVERSARIAL_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("passed:false");
+  });
+});

--- a/test/unit/review/adversarial.test.ts
+++ b/test/unit/review/adversarial.test.ts
@@ -186,12 +186,14 @@ let origSpawn: typeof _diffUtilsDeps.spawn;
 let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
 let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
 let origReadAcpSession: typeof _adversarialDeps.readAcpSession;
+let origWriteReviewAudit: typeof _adversarialDeps.writeReviewAudit;
 
 function saveAllDeps() {
   origSpawn = _diffUtilsDeps.spawn;
   origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
   origGetMergeBase = _diffUtilsDeps.getMergeBase;
   origReadAcpSession = _adversarialDeps.readAcpSession;
+  origWriteReviewAudit = _adversarialDeps.writeReviewAudit;
 }
 
 function restoreAllDeps() {
@@ -199,6 +201,7 @@ function restoreAllDeps() {
   _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
   _diffUtilsDeps.getMergeBase = origGetMergeBase;
   _adversarialDeps.readAcpSession = origReadAcpSession;
+  _adversarialDeps.writeReviewAudit = origWriteReviewAudit;
 }
 
 /** Wire up a happy-path spawn (valid ref, stat returns content). */
@@ -769,5 +772,55 @@ describe("runAdversarialReview — cost propagation", () => {
     );
 
     expect(result.cost).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// review.audit gate — writeReviewAudit only called when audit.enabled === true
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — review audit gate", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("audit disabled (default) — writeReviewAudit not called on success", async () => {
+    const auditCalls: unknown[] = [];
+    _adversarialDeps.writeReviewAudit = mock(async (entry) => { auditCalls.push(entry); });
+    const agent = makeAgent(PASSING_RESPONSE);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    expect(auditCalls).toHaveLength(0);
+  });
+
+  test("audit enabled — writeReviewAudit called with parsed:true on success", async () => {
+    const auditCalls: unknown[] = [];
+    _adversarialDeps.writeReviewAudit = mock(async (entry) => { auditCalls.push(entry); });
+    const agent = makeAgent(PASSING_RESPONSE);
+    const naxConfig = { review: { audit: { enabled: true } } } as any;
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent, naxConfig);
+
+    expect(auditCalls).toHaveLength(1);
+    expect((auditCalls[0] as any).parsed).toBe(true);
+    expect((auditCalls[0] as any).reviewer).toBe("adversarial");
+  });
+
+  test("audit enabled — writeReviewAudit called with parsed:false on parse failure", async () => {
+    const auditCalls: unknown[] = [];
+    _adversarialDeps.writeReviewAudit = mock(async (entry) => { auditCalls.push(entry); });
+    const agent = makeAgent("not json at all");
+    const naxConfig = { review: { audit: { enabled: true } } } as any;
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent, naxConfig);
+
+    expect(auditCalls).toHaveLength(1);
+    expect((auditCalls[0] as any).parsed).toBe(false);
+    expect((auditCalls[0] as any).looksLikeFail).toBe(false);
+    expect((auditCalls[0] as any).result).toBeNull();
   });
 });

--- a/test/unit/review/review-audit.test.ts
+++ b/test/unit/review/review-audit.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import { writeReviewAudit, _reviewAuditDeps } from "../../../src/review/review-audit";
+import type { ReviewAuditEntry } from "../../../src/review/review-audit";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeEntry(overrides: Partial<ReviewAuditEntry> = {}): ReviewAuditEntry {
+  return {
+    reviewer: "adversarial",
+    sessionName: "nax-abc12345-my-feature-us-001-reviewer-adversarial",
+    workdir: "/tmp/workdir",
+    storyId: "US-001",
+    featureName: "my-feature",
+    parsed: true,
+    result: { passed: false, findings: [{ severity: "error", file: "src/foo.ts", line: 1 }] },
+    ...overrides,
+  };
+}
+
+function makeDeps() {
+  const written: Array<{ path: string; content: string }> = [];
+  const mkdirCalls: string[] = [];
+
+  const deps = {
+    mkdir: async (path: string) => {
+      mkdirCalls.push(path);
+    },
+    writeFile: async (path: string, content: string) => {
+      written.push({ path, content });
+    },
+    now: () => 1700000000000,
+    findNaxProjectRoot: async (dir: string) => dir,
+  };
+
+  return { deps, written, mkdirCalls };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("writeReviewAudit", () => {
+  let saved: typeof _reviewAuditDeps;
+
+  beforeEach(() => {
+    saved = { ..._reviewAuditDeps };
+  });
+
+  test("writes to .nax/review-audit/<featureName>/ under project root", async () => {
+    const { deps, mkdirCalls, written } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+
+    await writeReviewAudit(makeEntry());
+    Object.assign(_reviewAuditDeps, saved);
+
+    expect(mkdirCalls[0]).toContain(".nax/review-audit/my-feature");
+    expect(written[0].path).toContain(".nax/review-audit/my-feature");
+  });
+
+  test("filename is <epochMs>-<sessionName>.json", async () => {
+    const { deps, written } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+
+    await writeReviewAudit(makeEntry());
+    Object.assign(_reviewAuditDeps, saved);
+
+    const parts = written[0].path.split("/");
+    const filename = parts[parts.length - 1];
+    expect(filename).toBe("1700000000000-nax-abc12345-my-feature-us-001-reviewer-adversarial.json");
+  });
+
+  test("successful parse — content includes parsed:true and result", async () => {
+    const { deps, written } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+
+    await writeReviewAudit(makeEntry({ parsed: true, result: { passed: false, findings: [{ file: "src/foo.ts" }] } }));
+    Object.assign(_reviewAuditDeps, saved);
+
+    const content = JSON.parse(written[0].content);
+    expect(content.parsed).toBe(true);
+    expect(content.result.passed).toBe(false);
+    expect(content.result.findings).toHaveLength(1);
+    expect(content).not.toHaveProperty("looksLikeFail");
+  });
+
+  test("parse failure — content includes parsed:false and looksLikeFail", async () => {
+    const { deps, written } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+
+    await writeReviewAudit(makeEntry({ parsed: false, looksLikeFail: true, result: null }));
+    Object.assign(_reviewAuditDeps, saved);
+
+    const content = JSON.parse(written[0].content);
+    expect(content.parsed).toBe(false);
+    expect(content.looksLikeFail).toBe(true);
+    expect(content.result).toBeNull();
+  });
+
+  test("parse failure with looksLikeFail:false", async () => {
+    const { deps, written } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+
+    await writeReviewAudit(makeEntry({ parsed: false, looksLikeFail: false, result: null }));
+    Object.assign(_reviewAuditDeps, saved);
+
+    const content = JSON.parse(written[0].content);
+    expect(content.parsed).toBe(false);
+    expect(content.looksLikeFail).toBe(false);
+  });
+
+  test("content includes metadata fields", async () => {
+    const { deps, written } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+
+    await writeReviewAudit(makeEntry({ reviewer: "semantic", storyId: "US-002", featureName: "my-feature" }));
+    Object.assign(_reviewAuditDeps, saved);
+
+    const content = JSON.parse(written[0].content);
+    expect(content.reviewer).toBe("semantic");
+    expect(content.storyId).toBe("US-002");
+    expect(content.featureName).toBe("my-feature");
+    expect(content.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("falls back to _unknown subfolder when featureName is absent", async () => {
+    const { deps, mkdirCalls } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+
+    await writeReviewAudit(makeEntry({ featureName: undefined }));
+    Object.assign(_reviewAuditDeps, saved);
+
+    expect(mkdirCalls[0]).toContain("_unknown");
+  });
+
+  test("never throws when writeFile errors", async () => {
+    const { deps } = makeDeps();
+    deps.writeFile = async () => { throw new Error("disk full"); };
+    Object.assign(_reviewAuditDeps, deps);
+
+    // Should not throw
+    await writeReviewAudit(makeEntry());
+    Object.assign(_reviewAuditDeps, saved);
+  });
+
+  test("never throws when mkdir errors", async () => {
+    const { deps } = makeDeps();
+    deps.mkdir = async () => { throw new Error("permission denied"); };
+    Object.assign(_reviewAuditDeps, deps);
+
+    await writeReviewAudit(makeEntry());
+    Object.assign(_reviewAuditDeps, saved);
+  });
+});

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for the JSON retry logic in src/review/semantic.ts
+ *
+ * Tests cover:
+ * - Retry succeeds: initial response unparseable, retry returns valid JSON
+ * - Retry failure: retry call throws, falls through to fail-open
+ * - agent.run called twice when initial response is unparseable
+ * - Retry call uses keepSessionOpen: false
+ * - Cost accumulated from both initial and retry calls
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AgentResult } from "../../../src/agents/types";
+import type { AgentAdapter } from "../../../src/agents/types";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
+import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
+import type { SemanticStory } from "../../../src/review/semantic";
+import type { SemanticReviewConfig } from "../../../src/review/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STORY: SemanticStory = {
+  id: "US-002",
+  title: "Implement semantic review runner",
+  description: "Create src/review/semantic.ts with runSemanticReview()",
+  acceptanceCriteria: [
+    "runSemanticReview() accepts workdir, storyGitRef, story, semanticConfig, and modelResolver",
+  ],
+};
+
+const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
+  modelTier: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
+  rules: [],
+  timeoutMs: 60_000,
+  excludePatterns: [":!test/", ":!*.test.ts"],
+};
+
+const PASSING_LLM_RESPONSE = JSON.stringify({ passed: true, findings: [] });
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSpawnMock(stdout: string, exitCode = 0) {
+  return mock((_opts: unknown) => ({
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(stdout));
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    kill: () => {},
+  })) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+/**
+ * Build a mock AgentAdapter whose run() returns a different response per call.
+ * responses[0] is returned on the first call, responses[1] on the second, etc.
+ * The last entry is reused for any additional calls beyond the array length.
+ */
+function makeMultiCallAgent(responses: string[], costPerCall = 0.5): AgentAdapter {
+  let callIndex = 0;
+  const agentResultFor = (output: string): AgentResult => ({
+    success: true,
+    exitCode: 0,
+    output,
+    rateLimited: false,
+    durationMs: 100,
+    estimatedCost: costPerCall,
+  });
+  return {
+    name: "mock",
+    displayName: "Mock Multi-Call Agent",
+    binary: "mock",
+    capabilities: {
+      supportedTiers: [],
+      maxContextTokens: 128_000,
+      features: new Set(),
+    } as unknown as AgentAdapter["capabilities"],
+    isInstalled: mock(async () => true),
+    run: mock(async () => {
+      const response = responses[callIndex] ?? responses[responses.length - 1];
+      callIndex++;
+      return agentResultFor(response);
+    }),
+    buildCommand: mock(() => []),
+    plan: mock(async () => { throw new Error("not used"); }),
+    decompose: mock(async () => { throw new Error("not used"); }),
+    complete: mock(async (_prompt: string) => {
+      throw new Error("complete() must NOT be called in non-debate path");
+    }),
+  } as unknown as AgentAdapter;
+}
+
+// ---------------------------------------------------------------------------
+// Saved deps
+// ---------------------------------------------------------------------------
+
+let origSpawn: typeof _diffUtilsDeps.spawn;
+let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
+let origWriteReviewAudit: typeof _semanticDeps.writeReviewAudit;
+
+function saveAllDeps() {
+  origSpawn = _diffUtilsDeps.spawn;
+  origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+  origGetMergeBase = _diffUtilsDeps.getMergeBase;
+  origWriteReviewAudit = _semanticDeps.writeReviewAudit;
+}
+
+function restoreAllDeps() {
+  _diffUtilsDeps.spawn = origSpawn;
+  _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+  _diffUtilsDeps.getMergeBase = origGetMergeBase;
+  _semanticDeps.writeReviewAudit = origWriteReviewAudit;
+}
+
+function setupHappyPathDeps() {
+  _diffUtilsDeps.isGitRefValid = mock(async () => true);
+  _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+  _diffUtilsDeps.spawn = makeSpawnMock("src/foo.ts | 5 +++++\n 1 file changed, 5 insertions(+)");
+  _semanticDeps.writeReviewAudit = mock(async () => {});
+}
+
+// ---------------------------------------------------------------------------
+// JSON retry — success path
+// ---------------------------------------------------------------------------
+
+describe("runSemanticReview — JSON retry succeeds", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("uses valid JSON from retry when initial response is unparseable", async () => {
+    const agent = makeMultiCallAgent(["this is not json at all", PASSING_LLM_RESPONSE]);
+
+    const result = await runSemanticReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      DEFAULT_SEMANTIC_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Semantic review passed");
+  });
+
+  test("agent.run called twice when initial response is unparseable", async () => {
+    const agent = makeMultiCallAgent(["this is not json at all", PASSING_LLM_RESPONSE]);
+
+    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    expect((agent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(2);
+  });
+
+  test("retry call uses keepSessionOpen: false to close the session", async () => {
+    const agent = makeMultiCallAgent(["this is not json at all", PASSING_LLM_RESPONSE]);
+
+    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    const calls = (agent.run as ReturnType<typeof mock>).mock.calls;
+    expect((calls[1][0] as Record<string, unknown>).keepSessionOpen).toBe(false);
+  });
+
+  test("agent.run called once when initial response is valid JSON", async () => {
+    const agent = makeMultiCallAgent([PASSING_LLM_RESPONSE]);
+
+    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    expect((agent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+  });
+
+  test("cost accumulated from both initial and retry calls", async () => {
+    const agent = makeMultiCallAgent(["not json", PASSING_LLM_RESPONSE], 0.5);
+
+    const result = await runSemanticReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      DEFAULT_SEMANTIC_CONFIG,
+      () => agent,
+    );
+
+    expect(result.cost).toBeCloseTo(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON retry — failure paths
+// ---------------------------------------------------------------------------
+
+describe("runSemanticReview — JSON retry failure paths", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("falls through to fail-open when retry call throws", async () => {
+    let callIndex = 0;
+    const agent = {
+      name: "mock",
+      displayName: "Mock Agent",
+      binary: "mock",
+      capabilities: {
+        supportedTiers: [],
+        maxContextTokens: 128_000,
+        features: new Set(),
+      } as unknown as AgentAdapter["capabilities"],
+      isInstalled: mock(async () => true),
+      run: mock(async () => {
+        callIndex++;
+        if (callIndex === 1) {
+          return { success: true, exitCode: 0, output: "not json at all", rateLimited: false, durationMs: 100, estimatedCost: 0 } as AgentResult;
+        }
+        throw new Error("retry connection failure");
+      }),
+      buildCommand: mock(() => []),
+      plan: mock(async () => { throw new Error("not used"); }),
+      decompose: mock(async () => { throw new Error("not used"); }),
+      complete: mock(async (_prompt: string) => { throw new Error("not used"); }),
+    } as unknown as AgentAdapter;
+
+    const result = await runSemanticReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      DEFAULT_SEMANTIC_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("fail-open");
+  });
+
+  test("fails closed when retry also returns truncated JSON with passed:false", async () => {
+    const truncated = '{ "passed": false, "findings": [{ "severity": "error"';
+    const agent = makeMultiCallAgent(["not json", truncated]);
+
+    const result = await runSemanticReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      DEFAULT_SEMANTIC_CONFIG,
+      () => agent,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("passed:false");
+  });
+});

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -911,14 +911,14 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
     expect(runOpts.acpSessionName).toBe(expectedSession);
   });
 
-  test("agent.run() receives keepSessionOpen: false (one-shot, stateless per cycle) (#414)", async () => {
+  test("agent.run() initial call uses keepSessionOpen: true to allow JSON retry (#414)", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
     expect(agent.run).toHaveBeenCalled();
     const runOpts = (agent.run as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
-    expect(runOpts.keepSessionOpen).toBe(false);
+    expect(runOpts.keepSessionOpen).toBe(true);
   });
 
   test("acpSessionName encodes workdir hash in session name", async () => {


### PR DESCRIPTION
## Summary

- New `src/review/review-audit.ts` — fire-and-forget writer that saves the parsed reviewer result (`{ passed, findings }`) to `.nax/review-audit/<featureName>/` after every semantic and adversarial review call
- On success: writes `parsed:true` + full findings JSON
- On parse failure: writes `parsed:false` + `looksLikeFail` flag (whether the heuristic would have caught it), `result:null`
- `findNaxProjectRoot` exported from `prompt-audit.ts` for reuse
- Mirrors prompt-audit conventions: best-effort, injectable `_reviewAuditDeps`, never throws, `void` fire-and-forget at call site

## File layout

```
.nax/review-audit/
  <featureName>/
    <epochMs>-<sessionName>.json    ← one per reviewer call
```

## Test Plan

- [x] 9 unit tests in `test/unit/review/review-audit.test.ts`
- [x] Covers: path structure, filename format, success content, parse failure content, metadata fields, featureName fallback, writeFile error safety, mkdir error safety
- [x] `bun run typecheck` — clean
- [x] All existing review tests unaffected

Closes #431