### PR TITLE
fix(review): adversarial findings no longer mislabeled as semantic in rectifier prompt (#433)

### DIFF
--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -338,6 +338,12 @@ ${testCommands}
   /**
    * Builds a rectification prompt for failed review checks (semantic, adversarial, or mechanical).
    *
+   * Routes to the correct prompt based on which check types failed:
+   *   - semantic only   → semanticRectification()
+   *   - adversarial only → adversarialRectification()
+   *   - mechanical only → mechanicalRectification()
+   *   - mixed           → combined prompt with labelled sections per check type
+   *
    * Migrated from buildReviewRectificationPrompt() in src/pipeline/stages/autofix-prompts.ts.
    */
   static reviewRectification(failedChecks: ReviewCheckResult[], story: UserStory): string {
@@ -345,20 +351,37 @@ ${testCommands}
       ? `\n\nIMPORTANT: Only modify files within \`${story.workdir}/\`. Do NOT touch files outside this directory.`
       : "";
 
-    const semanticChecks = failedChecks.filter((c) => c.check === "semantic" || c.check === "adversarial");
+    const semanticChecks = failedChecks.filter((c) => c.check === "semantic");
+    const adversarialChecks = failedChecks.filter((c) => c.check === "adversarial");
     const mechanicalChecks = failedChecks.filter((c) => c.check !== "semantic" && c.check !== "adversarial");
 
-    if (semanticChecks.length > 0 && mechanicalChecks.length === 0) {
-      return RectifierPromptBuilder.semanticRectification(semanticChecks, story, scopeConstraint);
+    const llmChecks = [...semanticChecks, ...adversarialChecks];
+
+    if (llmChecks.length > 0 && mechanicalChecks.length === 0) {
+      if (adversarialChecks.length === 0) {
+        return RectifierPromptBuilder.semanticRectification(semanticChecks, story, scopeConstraint);
+      }
+      if (semanticChecks.length === 0) {
+        return RectifierPromptBuilder.adversarialRectification(adversarialChecks, story, scopeConstraint);
+      }
+      // Both semantic and adversarial failed — combined LLM reviewer prompt.
+      return RectifierPromptBuilder.combinedLlmRectification(semanticChecks, adversarialChecks, story, scopeConstraint);
     }
 
-    if (mechanicalChecks.length > 0 && semanticChecks.length === 0) {
+    if (mechanicalChecks.length > 0 && llmChecks.length === 0) {
       return RectifierPromptBuilder.mechanicalRectification(mechanicalChecks, story, scopeConstraint);
     }
 
+    // Mixed: mechanical + one or more LLM reviewer checks.
     const mechanicalSection = RectifierPromptBuilder.formatCheckErrors(mechanicalChecks);
-    const semanticSection = RectifierPromptBuilder.formatCheckErrors(semanticChecks);
     const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
+
+    const llmSection =
+      semanticChecks.length > 0 && adversarialChecks.length > 0
+        ? `## Semantic Review Findings\n\n${RectifierPromptBuilder.formatCheckErrors(semanticChecks)}\n\n## Adversarial Review Findings\n\n${RectifierPromptBuilder.formatCheckErrors(adversarialChecks)}`
+        : semanticChecks.length > 0
+          ? `## Semantic Review Findings\n\n${RectifierPromptBuilder.formatCheckErrors(semanticChecks)}`
+          : `## Adversarial Review Findings\n\n${RectifierPromptBuilder.formatCheckErrors(adversarialChecks)}`;
 
     return `You are fixing issues from a code review.
 
@@ -370,17 +393,16 @@ ${mechanicalSection}
 
 Fix ALL lint/typecheck errors listed above.
 
-## Semantic Review Findings (AC Compliance)
+## LLM Review Findings (AC Compliance)
 
 ### Acceptance Criteria
 ${acList}
 
 ### Findings
-${semanticSection}
+${llmSection}
 
-**Important:** The semantic reviewer may have flagged false positives. Before making changes for semantic findings, read the relevant files to verify each finding is a real issue. Do NOT add keys, functions, or imports that already exist.
+**Important:** LLM reviewers may flag false positives. Before making changes for LLM review findings, read the relevant files to verify each finding is a real issue. Do NOT add keys, functions, or imports that already exist.
 
-Do NOT change test files or test behavior.
 Do NOT add new features — only fix the identified issues.
 Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
   }
@@ -463,6 +485,65 @@ ${errors}
 3. Do NOT add keys, functions, or imports that already exist — check first
 
 Do NOT change test files or test behavior.
+Do NOT add new features — only fix valid issues.
+Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
+  }
+
+  private static adversarialRectification(
+    checks: ReviewCheckResult[],
+    story: UserStory,
+    scopeConstraint: string,
+  ): string {
+    const errors = RectifierPromptBuilder.formatCheckErrors(checks);
+    const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
+
+    return `You are fixing issues found during an adversarial code review.
+
+Story: ${story.title} (${story.id})
+
+### Acceptance Criteria
+${acList}
+
+### Adversarial Review Findings
+${errors}
+
+**Important:** The adversarial reviewer probes for breakage, missing error paths, and edge cases. Before making any changes:
+1. Read the relevant files to verify each finding is a real issue
+2. Only fix findings that are actually valid problems
+3. Do NOT add keys, functions, or imports that already exist — check first
+
+Do NOT add new features — only fix valid issues.
+Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
+  }
+
+  private static combinedLlmRectification(
+    semanticChecks: ReviewCheckResult[],
+    adversarialChecks: ReviewCheckResult[],
+    story: UserStory,
+    scopeConstraint: string,
+  ): string {
+    const semanticErrors = RectifierPromptBuilder.formatCheckErrors(semanticChecks);
+    const adversarialErrors = RectifierPromptBuilder.formatCheckErrors(adversarialChecks);
+    const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
+
+    return `You are fixing issues found during LLM code review.
+
+Story: ${story.title} (${story.id})
+
+### Acceptance Criteria
+${acList}
+
+### Semantic Review Findings
+${semanticErrors}
+
+### Adversarial Review Findings
+${adversarialErrors}
+
+**Important:** LLM reviewers may flag false positives. Before making any changes:
+1. Read the relevant files to verify each finding is a real issue
+2. Only fix findings that are actually valid problems
+3. Do NOT add keys, functions, or imports that already exist — check first
+
 Do NOT add new features — only fix valid issues.
 Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
   }

--- a/test/unit/prompts/builders/rectifier-builder-review-labels.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder-review-labels.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for RectifierPromptBuilder.reviewRectification — label routing.
+ *
+ * Tests cover:
+ * - Adversarial-only failure uses "adversarial review" language, not "semantic review"
+ * - Semantic-only failure uses "semantic review" language
+ * - Combined semantic + adversarial failure uses distinct sections for each
+ * - Mechanical-only failure uses mechanical language
+ * - Mixed LLM + mechanical prompt uses "LLM Review Findings", not "Semantic Review Findings"
+ */
+
+import { describe, expect, test } from "bun:test";
+import { RectifierPromptBuilder } from "../../../../src/prompts/builders/rectifier-builder";
+import type { ReviewCheckResult } from "../../../../src/review/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCheck(check: ReviewCheckResult["check"], output: string): ReviewCheckResult {
+  return {
+    check,
+    success: false,
+    command: `${check}-cmd`,
+    exitCode: 1,
+    output,
+    durationMs: 100,
+  };
+}
+
+const STORY = {
+  id: "US-001",
+  title: "Add auth",
+  acceptanceCriteria: ["Users can log in", "Invalid credentials are rejected"],
+} as any;
+
+// ---------------------------------------------------------------------------
+// Adversarial-only failure
+// ---------------------------------------------------------------------------
+
+describe("RectifierPromptBuilder.reviewRectification — adversarial-only", () => {
+  test("does NOT say 'semantic review' when only adversarial check failed", () => {
+    const checks = [makeCheck("adversarial", "Missing error-path handling")];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).not.toContain("semantic review");
+    expect(prompt).not.toContain("Semantic Review Findings");
+    expect(prompt).not.toContain("semantic reviewer");
+  });
+
+  test("says 'adversarial' when only adversarial check failed", () => {
+    const checks = [makeCheck("adversarial", "Missing error-path handling")];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).toContain("adversarial");
+  });
+
+  test("includes 'Adversarial Review Findings' section header", () => {
+    const checks = [makeCheck("adversarial", "Missing error-path handling")];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).toContain("Adversarial Review Findings");
+  });
+
+  test("includes the finding output", () => {
+    const checks = [makeCheck("adversarial", "Missing error-path handling")];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).toContain("Missing error-path handling");
+  });
+
+  test("includes acceptance criteria", () => {
+    const checks = [makeCheck("adversarial", "edge case missing")];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).toContain("Users can log in");
+    expect(prompt).toContain("Invalid credentials are rejected");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Semantic-only failure
+// ---------------------------------------------------------------------------
+
+describe("RectifierPromptBuilder.reviewRectification — semantic-only", () => {
+  test("says 'semantic review' when only semantic check failed", () => {
+    const checks = [makeCheck("semantic", "AC-1 not implemented")];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).toContain("semantic review");
+  });
+
+  test("includes 'Semantic Review Findings' section header", () => {
+    const checks = [makeCheck("semantic", "AC-1 not implemented")];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).toContain("Semantic Review Findings");
+  });
+
+  test("does NOT say 'adversarial' when only semantic check failed", () => {
+    const checks = [makeCheck("semantic", "AC-1 not implemented")];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt.toLowerCase()).not.toContain("adversarial");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Combined semantic + adversarial failure
+// ---------------------------------------------------------------------------
+
+describe("RectifierPromptBuilder.reviewRectification — semantic + adversarial", () => {
+  test("includes both 'Semantic Review Findings' and 'Adversarial Review Findings' sections", () => {
+    const checks = [
+      makeCheck("semantic", "AC-1 not implemented"),
+      makeCheck("adversarial", "Missing error-path handling"),
+    ];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).toContain("Semantic Review Findings");
+    expect(prompt).toContain("Adversarial Review Findings");
+  });
+
+  test("includes findings from both checks", () => {
+    const checks = [
+      makeCheck("semantic", "AC-1 not implemented"),
+      makeCheck("adversarial", "Missing error-path handling"),
+    ];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).toContain("AC-1 not implemented");
+    expect(prompt).toContain("Missing error-path handling");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed LLM + mechanical failure
+// ---------------------------------------------------------------------------
+
+describe("RectifierPromptBuilder.reviewRectification — adversarial + mechanical", () => {
+  test("does NOT say 'Semantic Review Findings (AC Compliance)' when adversarial + lint both fail", () => {
+    const checks = [
+      makeCheck("adversarial", "Missing error handling"),
+      makeCheck("lint", "Unused variable"),
+    ];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).not.toContain("Semantic Review Findings (AC Compliance)");
+    expect(prompt).not.toContain("semantic reviewer");
+  });
+
+  test("uses 'LLM Review Findings' section for the adversarial part", () => {
+    const checks = [
+      makeCheck("adversarial", "Missing error handling"),
+      makeCheck("lint", "Unused variable"),
+    ];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).toContain("Adversarial Review Findings");
+  });
+
+  test("includes both lint and adversarial output in mixed prompt", () => {
+    const checks = [
+      makeCheck("adversarial", "Missing error handling"),
+      makeCheck("lint", "Unused variable"),
+    ];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).toContain("Missing error handling");
+    expect(prompt).toContain("Unused variable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mechanical-only failure (regression guard)
+// ---------------------------------------------------------------------------
+
+describe("RectifierPromptBuilder.reviewRectification — mechanical-only regression", () => {
+  test("uses mechanical language when only lint fails", () => {
+    const checks = [makeCheck("lint", "Unused variable")];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    expect(prompt).toContain("lint/typecheck");
+    expect(prompt).not.toContain("semantic review");
+    expect(prompt.toLowerCase()).not.toContain("adversarial");
+  });
+});


### PR DESCRIPTION
## Summary

- `reviewRectification()` previously routed all LLM review checks through `semanticRectification()`, producing "semantic review" and "Semantic Review Findings" even when only the adversarial check failed
- Added `adversarialRectification()` and `combinedLlmRectification()` private methods with correct labelling
- Fixed the mixed (LLM + mechanical) case to use per-type section headers instead of the former "Semantic Review Findings (AC Compliance)" misnomer

## Test plan

- [ ] Run `bun test test/unit/prompts/builders/` — 14 new label-routing tests covering all routing paths
- [ ] Run `bun test test/unit/pipeline/stages/autofix.test.ts` — existing autofix tests still pass
- [ ] Run `bun run typecheck` and `bun run lint` — clean

Closes #433