### PR TITLE
fix(autofix): maintain test-writer session across rectification cycles (#437)

### DIFF
--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -46,12 +46,16 @@ export function splitAdversarialFindingsByScope(check: ReviewCheckResult): {
 /**
  * Run a test-writer session to fix adversarial review findings scoped to test files (#409).
  * Returns the cost incurred, or 0 if the agent is unavailable.
+ *
+ * @param keepOpen - Whether to keep the ACP session open after this call so subsequent
+ *   autofix cycles can resume it (default: true). Pass false only on the final call.
  */
 export async function runTestWriterRectification(
   ctx: PipelineContext,
   testWriterChecks: ReviewCheckResult[],
   story: UserStory,
   agentGetFn: (name: string) => ReturnType<ReturnType<typeof createAgentRegistry>["getAgent"]>,
+  keepOpen = true,
 ): Promise<number> {
   const logger = getLogger();
   const twAgent = agentGetFn(ctx.rootConfig.autoMode.defaultAgent);
@@ -86,7 +90,7 @@ export async function runTestWriterRectification(
       storyId: ctx.story.id,
       sessionRole: "test-writer",
       acpSessionName: testWriterSession,
-      keepSessionOpen: false,
+      keepSessionOpen: keepOpen,
     });
     return twResult.estimatedCost ?? 0;
   } catch {

--- a/test/unit/pipeline/stages/autofix-adversarial.test.ts
+++ b/test/unit/pipeline/stages/autofix-adversarial.test.ts
@@ -282,4 +282,55 @@ describe("runTestWriterRectification", () => {
 
     expect(capturedModelTier).toBe("balanced");
   });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Session continuity (#437)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  test("keepSessionOpen defaults to true so session survives across autofix cycles", async () => {
+    const testChecks = [makeAdversarialCheck([makeFinding("src/foo.test.ts")])];
+    let capturedKeepSessionOpen: boolean | undefined;
+    const mockRun = mock(async (opts: any) => {
+      capturedKeepSessionOpen = opts.keepSessionOpen;
+      return { estimatedCost: 0, success: true, output: "", exitCode: 0, rateLimited: false };
+    });
+    const agentGetFn = mock(() => ({ run: mockRun }));
+    const ctx = makeCtx();
+
+    await runTestWriterRectification(ctx, testChecks, story, agentGetFn as any);
+
+    expect(capturedKeepSessionOpen).toBe(true);
+  });
+
+  test("keepSessionOpen is false when caller passes keepOpen=false", async () => {
+    const testChecks = [makeAdversarialCheck([makeFinding("src/foo.test.ts")])];
+    let capturedKeepSessionOpen: boolean | undefined;
+    const mockRun = mock(async (opts: any) => {
+      capturedKeepSessionOpen = opts.keepSessionOpen;
+      return { estimatedCost: 0, success: true, output: "", exitCode: 0, rateLimited: false };
+    });
+    const agentGetFn = mock(() => ({ run: mockRun }));
+    const ctx = makeCtx();
+
+    await runTestWriterRectification(ctx, testChecks, story, agentGetFn as any, false);
+
+    expect(capturedKeepSessionOpen).toBe(false);
+  });
+
+  test("uses the same acpSessionName across two calls (session resumability)", async () => {
+    const testChecks = [makeAdversarialCheck([makeFinding("src/foo.test.ts")])];
+    const capturedSessionNames: string[] = [];
+    const mockRun = mock(async (opts: any) => {
+      capturedSessionNames.push(opts.acpSessionName);
+      return { estimatedCost: 0, success: true, output: "", exitCode: 0, rateLimited: false };
+    });
+    const agentGetFn = mock(() => ({ run: mockRun }));
+    const ctx = makeCtx();
+
+    await runTestWriterRectification(ctx, testChecks, story, agentGetFn as any);
+    await runTestWriterRectification(ctx, testChecks, story, agentGetFn as any);
+
+    expect(capturedSessionNames).toHaveLength(2);
+    expect(capturedSessionNames[0]).toBe(capturedSessionNames[1]);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `keepOpen` parameter (default `true`) to `runTestWriterRectification`
- Wires it to `keepSessionOpen` so the ACP session survives across outer autofix cycles
- Fixes the session continuity gap identified in the v0.62.0 adversarial review findings (Issue 2)

Closes #437

## Root cause

`keepSessionOpen: false` was hardcoded in `autofix-adversarial.ts`, closing the test-writer session after every call. The implementer session correctly stays alive between cycles via `keepSessionOpen: !isLastAttempt` — the test-writer now matches this behaviour.

All other `keepSessionOpen: false` values in the codebase are intentional (debate teardown call, final JSON retry turn in semantic/adversarial review).

## Test plan

- [ ] `keepSessionOpen` defaults to `true` (session survives across cycles)
- [ ] `keepSessionOpen` is `false` when `keepOpen=false` is explicitly passed
- [ ] `acpSessionName` is identical across two consecutive calls (session is resumable)
- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean