### PR TITLE
fix(review): set keepSessionOpen: false on reviewers, pin implementer acpSessionName (ADR-008)

### DIFF
--- a/.claude/rules/adapter-wiring.md
+++ b/.claude/rules/adapter-wiring.md
@@ -76,8 +76,8 @@ Format: `nax-<hash8>-<feature>-<storyId>-<sessionRole>`
 | `"auto"` | `complete()` | Auto-approve interaction |
 | `"diagnose"` | `run()` | Acceptance failure diagnosis |
 | `"source-fix"` | `run()` | Acceptance source fix |
-| `"reviewer-semantic"` | `run()` | Semantic review session (targets implementer session via `acpSessionName`) |
-| `"reviewer-adversarial"` | `run()` | Adversarial review session (own fresh session, `keepSessionOpen: false`) |
+| `"reviewer-semantic"` | `run()` | Semantic review session — `keepSessionOpen: false` (stateless scorer, ADR-008) |
+| `"reviewer-adversarial"` | `run()` | Adversarial review session — `keepSessionOpen: false` (stateless scorer, ADR-008) |
 
 ## Rule 3: Agent Resolution — CRITICAL
 

--- a/docs/adr/ADR-007-implementer-session-lifecycle.md
+++ b/docs/adr/ADR-007-implementer-session-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR-007: Single Continuous Implementer Session Across Fix Stages
 
-**Status:** Proposed  
+**Status:** Superseded by ADR-008  
 **Date:** 2026-04-12  
 **Author:** William Khoo, Claude  
 

--- a/docs/adr/ADR-008-session-lifecycle.md
+++ b/docs/adr/ADR-008-session-lifecycle.md
@@ -1,0 +1,154 @@
+# ADR-008: Session Lifecycle Across All Agent Roles
+
+**Status:** Proposed
+**Date:** 2026-04-14
+**Author:** William Khoo, Claude
+**Supersedes:** ADR-007 (partial — the implementer portion is retained here verbatim; see §6)
+
+---
+
+## Context
+
+nax opens ACP sessions to run every agent role in the pipeline. Session lifecycle — whether a session stays warm (`keepSessionOpen: true`) across calls or closes after each call — has been decided role-by-role over the last three specs (SPEC-session-continuity, SPEC-semantic-session-continuity, SPEC-debate-session-mode). The decisions are correct individually but have drifted away from a single coherent rule.
+
+### Observed Failure
+
+A multi-round autofix loop oscillated across three adversarial-review rounds, with the reviewer flip-flopping between contradictory findings:
+
+- Round 1 flagged an issue as dead code
+- Round 2 instructed the implementer to add code that round 1 had already rejected, plus new unrelated findings
+- Round 3 flagged the newly-added code as incorrectly wired, while earlier round-1 findings resurfaced
+
+The review session was kept open (`keepSessionOpen: true` in `src/review/adversarial.ts:249` and `src/review/semantic.ts:389`). Between rounds the implementer modified the diff, but the reviewer re-entered with prior-round reasoning still in its conversation history — so it re-litigated decisions it had already argued about instead of scoring the current diff cleanly. ACP session audits confirmed that the reviewer sessionId was reused across rounds, proving the session was warm. Findings flip-flopped and autofix attempts were burned reacting to an unstable rubric.
+
+### The Underlying Rule
+
+Sessions are valuable when **the agent is iterating on its own work** — the conversation history is the work-in-progress. Sessions are harmful when **the agent is scoring someone else's work** — prior verdicts contaminate the next verdict on a different diff.
+
+No ADR states this rule. Each site decides independently, and the decisions have diverged:
+
+| Role | File | Current `keepSessionOpen` | Correct by rule? |
+|:---|:---|:---|:---|
+| implementer (main run) | `src/pipeline/stages/execution.ts` | `!!(…)` — true when rectification enabled | ✅ |
+| implementer (TDD run) | `src/tdd/session-runner.ts:172` | `true` when role=="implementer" && rectification enabled | ✅ |
+| test-writer | `src/tdd/session-runner.ts:172` | `false` (only implementer gets `true`) | ✅ |
+| verifier | `src/tdd/session-runner.ts:172` | `false` | ✅ |
+| rectifier (TDD) | `src/tdd/rectification-gate.ts:234` | `!isLastAttempt` | ✅ |
+| rectifier (autofix) | `src/pipeline/stages/autofix.ts:465` | `!isLastAttempt` | ✅ |
+| rectifier (verification) | `src/verification/rectification-loop.ts:261` | `!isLastAttempt` | ✅ |
+| autofix-adversarial | `src/pipeline/stages/autofix-adversarial.ts:93` | `keepOpen` (caller-controlled) | ✅ |
+| reviewer-semantic | `src/review/semantic.ts:389` | **`true`** | ❌ bug (this ADR) |
+| reviewer-adversarial | `src/review/adversarial.ts:249` | **`true`** | ❌ bug (this ADR) |
+| reviewer-dialogue | `src/review/dialogue.ts:309 et al.` | `true` (5 sites) | ✅ — dialogue is stateful by design |
+| debate (stateful) | `src/debate/session-stateful.ts:67` | caller-passed; `false` on close | ✅ |
+| debate (one-shot) | `src/debate/session-one-shot.ts` | n/a — `complete()` | ✅ |
+| router / auto-approver / decompose / refine / etc. | various | n/a — `complete()` (one-shot) | ✅ |
+
+The semantic reviewer was originally `keepSessionOpen: false`; ADR-007 flipped it to `true` under the theory that the reviewer would be resuming the *implementer* session and should survive into autofix. That theory was then reverted in #414 (reviewer-semantic got its own session), but the `keepSessionOpen: true` line stayed behind. The adversarial reviewer inherited the same flag by copy-paste. Both are now same-role continuations across independent review rounds — exactly the wrong case.
+
+---
+
+## Decision
+
+Adopt a single rule, applied per role:
+
+> **Keep a session open (`keepSessionOpen: true`) if and only if the role is iterating on its own state. Close the session (`keepSessionOpen: false`) if the role is producing an independent verdict on someone else's work.**
+
+### Session Lifecycle Matrix
+
+| Role | `sessionRole` | Method | `keepSessionOpen` policy | Reset on retry | Reset on escalation |
+|:---|:---|:---|:---|:---|:---|
+| **Implementer** (exec) | *(none)* / `"implementer"` | `run()` | `true` while rectification enabled | no — resume | yes — new tier, fresh session |
+| **Test-writer** | `"test-writer"` | `run()` | `false` | n/a (single run per story) | yes |
+| **Verifier** | `"verifier"` | `run()` | `false` | n/a | yes |
+| **Rectifier** (TDD / autofix / verification) | `"implementer"` | `run()` | `!isLastAttempt` | no — resume implementer session | yes |
+| **Reviewer — semantic** | `"reviewer-semantic"` | `run()` | **`false`** (this ADR) | **yes — fresh sessionId per round** | yes |
+| **Reviewer — adversarial** | `"reviewer-adversarial"` | `run()` | **`false`** (this ADR) | **yes — fresh sessionId per round** | yes |
+| **Reviewer — dialogue** (debate) | `"reviewer"` | `run()` | `true` across all turns of the dialogue | no — dialogue *is* the state | session closed when dialogue concludes |
+| **Debate — stateful debater** | `"debate-hybrid-<i>"` / `"plan-<i>"` | `run()` | `true` between proposal and rebuttal; `false` on close | no | yes |
+| **Debate — one-shot** | `"debate-proposal-<i>"` etc. | `complete()` | n/a | n/a | n/a |
+| **Router / auto-approver / decompose / refine / acceptance-gen / fix-gen** | various | `complete()` | n/a — one-shot | n/a | n/a |
+| **Diagnose / source-fix** (acceptance) | `"diagnose"` / `"source-fix"` | `run()` | `false` (single-shot verdict / fix) | yes | yes |
+
+**Why semantic and adversarial differ from dialogue.** Dialogue is a negotiated multi-turn exchange (reviewer ↔ implementer) where each turn is a response to the previous turn — the session *is* the work product. Semantic and adversarial review are per-round scoring passes where each round evaluates the current diff independently. A rerun should not know what the previous rerun said.
+
+---
+
+## Alternatives Considered
+
+### A. Leave `keepSessionOpen: true` on reviewers, add an explicit reset step
+
+Insert an explicit session-close call between autofix rounds. Complexity is higher and it duplicates what `keepSessionOpen: false` already does. **Rejected.**
+
+### B. Make `keepSessionOpen` a global config flag per role
+
+Expose per-role `keepSessionOpen` in `NaxConfig` for operator override. **Rejected for now** — the correct value is deterministic given the rule above; adding configuration creates room for misconfiguration without a corresponding use case. Revisit if evidence shows operators need to tune this.
+
+### C. Single ADR per role (test-writer, semantic, adversarial, debate each in its own file)
+
+Earlier draft plan. **Rejected** because session continuity is a cross-cutting policy with per-role parameters — readers need the comparison view, not six separate files restating the same rule.
+
+### D. Keep one session per story across all reviewer rounds, reset only on escalation
+
+Would preserve token savings across rounds. **Rejected** — this is precisely the configuration that caused the observed oscillation. Token savings on reviewers are marginal (one JSON verdict per call); correctness of the verdict is the dominant concern.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Deterministic reviewer verdicts per round.** Each autofix round starts from a clean reviewer state; findings depend only on the current diff, not prior conversation.
+- **Oscillation loops close.** The observed failure mode — a reviewer flip-flopping between "this is dead code" and "this was added-then-removed" across autofix rounds — cannot recur, because the reviewer no longer remembers the prior round.
+- **Consistent rule across the codebase.** One sentence describes the whole policy; new roles slot into the matrix without a new ADR.
+- **Observability.** Fresh sessionIds per round make the audit log readable: a reader can tell at a glance that round N and round N+1 are independent evaluations.
+
+### Negative / Trade-offs
+
+- **Reviewer token cost per round is slightly higher.** A fresh session means the full review prompt (diff + ACs + rubric) is sent each round instead of a short "recheck" prompt on a warm session. Rough estimate: ~2-4 KB extra input per recheck round. At Sonnet tier this is well under $0.01 per round. At the failure mode we're fixing (three rounds of oscillation), the saved *agent* tokens from a resolved loop dwarf this cost.
+- **No reviewer "memory" of prior rounds.** If a reviewer in round 1 spotted a subtle bug and round 2 misses it, the round-2 reviewer has no way to know. Mitigation: this is the correct behaviour — the round-2 diff is what matters. If bug persistence across rounds is needed, it belongs in the *rubric* (passed via prompt), not in session memory. The existing finding-category taxonomy can be extended for this if evidence shows the need.
+- **Debate/dialogue roles remain the exception.** The matrix has two patterns (stateful, stateless) and the reader has to know which roles are which. Mitigated by the explicit table in this ADR and the session role registry in `.claude/rules/adapter-wiring.md`.
+
+### Scope of Changes
+
+| File | Change |
+|:---|:---|
+| `src/review/semantic.ts` | `keepSessionOpen: true` → `false` (line 389) |
+| `src/review/adversarial.ts` | `keepSessionOpen: true` → `false` (line 249) |
+| `test/unit/review/semantic.test.ts` | Update to assert `keepSessionOpen: false` |
+| `test/unit/review/adversarial-retry.test.ts` | Update to assert `keepSessionOpen: false` on first call |
+| `.claude/rules/adapter-wiring.md` | Update Session Role Registry: semantic and adversarial now `keepSessionOpen: false` |
+| `docs/adr/ADR-007-implementer-session-lifecycle.md` | Add superseded-by header pointing at this ADR (implementer rules are restated here) |
+
+### Not Changed
+
+- `src/review/dialogue.ts` — stateful by design; all five `keepSessionOpen: true` sites remain correct.
+- `src/debate/session-stateful.ts` — caller decides per debater lifecycle phase; correct.
+- `src/tdd/session-runner.ts` — implementer continuity logic remains; test-writer and verifier already close.
+- All `complete()` call sites — no session lifecycle concept applies.
+
+---
+
+## 6. Implementer Rules Carried Forward from ADR-007
+
+This ADR supersedes ADR-007 structurally (one file covers all roles) but preserves its conclusions for the implementer role verbatim:
+
+1. Session name is `nax-<hash8>-<feature>-<storyId>-implementer` across all five execution strategies.
+2. The session stays open from the main execution run through TDD rectification, autofix, and verification rectification.
+3. Retry attempts within a fix loop send a **continuation prompt** (error output + escalation preamble), not a full rebuild.
+4. `sweepFeatureSessions()` at story completion is the single cleanup point.
+5. Tier escalation starts a fresh session — continuity is scoped to one tier's attempts.
+
+ADR-007 should be marked `Superseded by ADR-008` but left in place for historical context.
+
+---
+
+## References
+
+- ADR-007 — implementer session lifecycle (superseded by this ADR)
+- SPEC-session-continuity.md — implementer implementation spec
+- SPEC-semantic-session-continuity.md — prerequisite naming spec
+- SPEC-debate-session-mode.md — stateful debater lifecycle
+- `.claude/rules/adapter-wiring.md` — session role registry (to be updated)
+- `src/review/dialogue.ts` — reference implementation of stateful reviewer dialogue
+- `src/tdd/rectification-gate.ts` — reference implementation of per-attempt `keepSessionOpen: !isLastAttempt`

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -246,7 +246,7 @@ export async function runAdversarialReview(
   let rawResponse: string;
   let llmCost = 0;
   try {
-    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: true });
+    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: false });
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;
   } catch (err) {

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -386,7 +386,7 @@ export async function runSemanticReview(
   let rawResponse: string;
   let llmCost = 0;
   try {
-    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: true });
+    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: false });
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;
   } catch (err) {

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -177,9 +177,7 @@ export async function runTddSession(
   // return a stale name from a prior run, causing the implementer to resume the wrong session
   // and breaking session continuity with the TDD gate and autofix. (ADR-008)
   const acpSessionName =
-    role === "implementer" && featureName
-      ? buildSessionName(workdir, featureName, story.id, "implementer")
-      : undefined;
+    role === "implementer" && featureName ? buildSessionName(workdir, featureName, story.id, "implementer") : undefined;
 
   // Run the agent
   const result = await agent.run({

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -46,6 +46,7 @@ export const _sessionRunnerDeps = {
         constitution?: string,
       ) => Promise<string>),
 };
+import { buildSessionName } from "../agents/acp/adapter";
 import type { IsolationCheck } from "./types";
 import type { TddSessionResult, TddSessionRole } from "./types";
 
@@ -166,10 +167,19 @@ export async function runTddSession(
   logger.info("tdd", `-> Session: ${role}`, { role, storyId: story.id, lite });
 
   // When rectification is enabled, keep the implementer session open after it finishes.
-  // The rectification gate uses the same session name (buildSessionName + "implementer")
-  // and will resume it directly — so the implementer retains full context of what it built.
+  // The rectification gate uses the same session name and will resume it directly — so
+  // the implementer retains full context of what it built.
   // The session sweep (or the last rectification attempt) handles final cleanup.
   const keepSessionOpen = role === "implementer" && (config.execution.rectification?.enabled ?? false);
+
+  // Pin the implementer to an explicit session name derived from the same formula used by
+  // rectification-gate.ts. Without this, the adapter falls through to the sidecar which may
+  // return a stale name from a prior run, causing the implementer to resume the wrong session
+  // and breaking session continuity with the TDD gate and autofix. (ADR-008)
+  const acpSessionName =
+    role === "implementer" && featureName
+      ? buildSessionName(workdir, featureName, story.id, "implementer")
+      : undefined;
 
   // Run the agent
   const result = await agent.run({
@@ -191,6 +201,7 @@ export async function runTddSession(
     featureName,
     storyId: story.id,
     sessionRole: role,
+    acpSessionName,
     keepSessionOpen,
     interactionBridge,
   });

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -169,13 +169,13 @@ describe("runAdversarialReview — JSON retry succeeds", () => {
     expect((calls[1][0] as Record<string, unknown>).keepSessionOpen).toBe(false);
   });
 
-  test("initial call uses keepSessionOpen: true to keep session open for retry", async () => {
+  test("initial call uses keepSessionOpen: false (stateless scorer, ADR-008)", async () => {
     const agent = makeMultiCallAgent([PASSING_RESPONSE]);
 
     await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
 
     const calls = (agent.run as ReturnType<typeof mock>).mock.calls;
-    expect((calls[0][0] as Record<string, unknown>).keepSessionOpen).toBe(true);
+    expect((calls[0][0] as Record<string, unknown>).keepSessionOpen).toBe(false);
   });
 
   test("agent.run called once when initial response is valid JSON", async () => {

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -911,14 +911,14 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
     expect(runOpts.acpSessionName).toBe(expectedSession);
   });
 
-  test("agent.run() initial call uses keepSessionOpen: true to allow JSON retry (#414)", async () => {
+  test("agent.run() initial call uses keepSessionOpen: false (stateless scorer, ADR-008)", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
     expect(agent.run).toHaveBeenCalled();
     const runOpts = (agent.run as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
-    expect(runOpts.keepSessionOpen).toBe(true);
+    expect(runOpts.keepSessionOpen).toBe(false);
   });
 
   test("acpSessionName encodes workdir hash in session name", async () => {


### PR DESCRIPTION
## Summary

- Sets `keepSessionOpen: false` on `reviewer-semantic` and `reviewer-adversarial` — both are stateless scorers that must reset between autofix rounds to prevent oscillating findings
- Pins `acpSessionName` explicitly in `session-runner.ts` for the implementer role via `buildSessionName()`, closing the session drift gap where the sidecar could return a stale name from a prior run
- Adds ADR-008 as the unified session lifecycle policy document (supersedes ADR-007)
- Updates `.claude/rules/adapter-wiring.md` session role registry to reflect the corrected `keepSessionOpen` values

Closes #440

## Root cause

`src/review/semantic.ts` and `src/review/adversarial.ts` both had `keepSessionOpen: true`. Between autofix rounds, reviewers re-entered with prior-round reasoning in conversation history and re-litigated verdicts on a changed diff — producing flip-flopping findings. ACP session audits confirmed the reviewer `sessionId` was reused across rounds.

In `src/tdd/session-runner.ts`, the implementer role did not pass `acpSessionName` explicitly. The adapter fell through to the sidecar, which stores deterministic names keyed by workdir hash. On a re-run, the sidecar returned the same name from the prior run, causing the TDD implementer to resume a stale session while the TDD gate and autofix (both of which call `buildSessionName()` directly) opened a different one.

## Test plan

- [ ] `keepSessionOpen: false` on initial adversarial review call (`test/unit/review/adversarial-retry.test.ts`)
- [ ] `keepSessionOpen: false` on initial semantic review call (`test/unit/review/semantic.test.ts`)
- [ ] `acpSessionName` is set on implementer role with `featureName` present (`src/tdd/session-runner.ts`)
- [ ] `acpSessionName` is `undefined` for test-writer and verifier roles (no change to non-implementer roles)
- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean
- [ ] `bun test test/unit/review/semantic.test.ts` passes
- [ ] `bun test test/unit/review/adversarial-retry.test.ts` passes