### PR TITLE
fix(autofix): retry on partial progress before escalating, use full maxTotalAttempts budget

### DIFF
--- a/docs/architecture/subsystems.md
+++ b/docs/architecture/subsystems.md
@@ -39,7 +39,7 @@ Runner.run()  [src/execution/runner.ts — thin orchestrator]
 | 8 | `verify` | `verify.ts` | Test verification (scoped via smart-runner) |
 | 9 | `rectify` | `rectify.ts` | Auto-fix test failures (inline retry loop) |
 | 10 | `review` | `review.ts` | Quality checks (lint, typecheck, format, plugin checks) |
-| 11 | `autofix` | `autofix.ts` | Auto-fix lint/format issues before escalating |
+| 11 | `autofix` | `autofix.ts` | Auto-fix quality failures: mechanical (lintFix/formatFix) then agent rectification; partial-progress retry before escalating |
 | 12 | `regression` | `regression.ts` | Full-suite gate (inline mode only) |
 | 13 | `completion` | `completion.ts` | Mark complete, fire hooks, save metrics |
 
@@ -98,6 +98,8 @@ The shared mutable state passed through all stages. Acts as the single source of
 **Stage inputs:** `prd`, `story`, `stories`, `routing`, `hooks`, `plugins`
 
 **Intermediate results:** `constitution`, `contextMarkdown`, `builtContext`, `prompt`, `agentResult`, `verifyResult`, `reviewResult`, `acceptanceFailures`, `tddFailureCategory`, `fullSuiteGatePassed`
+
+**Autofix state:** `retrySkipChecks` — set of check names (e.g. `"lint"`, `"semantic"`) that passed during a prior autofix cycle and should be skipped on the next review retry. Accumulated across partial-progress cycles; cleared implicitly when the story completes.
 
 **Metadata:** `storyStartTime`, `rectifyAttempt`, `autofixAttempt`, `storyGitRef`, `accumulatedAttemptCost`, `reviewFindings`
 
@@ -461,6 +463,22 @@ The orchestrator splits checks into **mechanical** (typecheck, lint, build, form
 - Finding categories: `input`, `error-path`, `abandonment`, `test-gap`, `convention`, `assumption`
 - Configurable parallel/sequential execution
 - **Scope-aware routing:** adversarial findings in test files are routed to a test-writer session via `autofix-adversarial.ts`, not the implementer (TDD isolation constraint)
+
+### Autofix Stage
+
+`src/pipeline/stages/autofix.ts`:
+
+Two-phase approach when review fails:
+
+1. **Mechanical fix** (lint/format only) — runs `lintFix`/`formatFix` commands, rechecks. Returns `retry fromStage:"review"` immediately if resolved.
+2. **Agent rectification** — spawns the implementer session with failed-check context. Runs up to `quality.autofix.maxAttempts` (default 3) per cycle, bounded by `quality.autofix.maxTotalAttempts` (default 12) across all cycles.
+
+**Partial-progress retry:** when a cycle fails (not all checks fixed) but at least one check was newly cleared, the cleared checks are added to `retrySkipChecks` and the stage returns `retry fromStage:"review"` rather than escalating. The next review run skips cleared checks; the next autofix cycle targets only remaining failures. This allows the 12-attempt global budget to be consumed across multiple focused cycles (e.g. lint cleared in cycle 1 → only typecheck+semantic in cycle 2).
+
+**Escalation conditions:**
+- Zero progress in a cycle (no checks cleared) — budget remaining but stuck → escalate
+- Global budget exhausted (`autofixAttempt >= maxTotalAttempts`) → escalate
+- `UNRESOLVED` signal from implementer (reviewer contradiction) → escalate
 
 ### Review Audit Trail
 

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -212,6 +212,26 @@ export const autofixStage: PipelineStage = {
       return { action: "retry", fromStage: "review", cost: agentCost };
     }
 
+    // Partial-progress retry: if the agent cleared at least one check this cycle but not all,
+    // and the global budget has not been exhausted, retry from review with cleared checks
+    // added to the skip list. The next cycle then targets only the remaining failures.
+    // Zero-progress → escalate immediately (stuck rule: no point burning more budget).
+    const maxTotal = ctx.config.quality.autofix?.maxTotalAttempts ?? 10;
+    const totalUsed = ctx.autofixAttempt ?? 0;
+    const currentlyFailing = new Set((ctx.reviewResult?.checks ?? []).filter((c) => !c.success).map((c) => c.check));
+    const nowPassing = [...failedCheckNames].filter((c) => !currentlyFailing.has(c));
+
+    if (nowPassing.length > 0 && totalUsed < maxTotal) {
+      ctx.retrySkipChecks = new Set([...(ctx.retrySkipChecks ?? []), ...nowPassing]);
+      logger.info("autofix", "Partial progress — retrying review with updated skip list", {
+        storyId: ctx.story.id,
+        nowPassing,
+        remaining: [...currentlyFailing],
+        budgetUsed: `${totalUsed}/${maxTotal}`,
+      });
+      return { action: "retry", fromStage: "review", cost: agentCost };
+    }
+
     logger.warn("autofix", "Autofix exhausted — escalating", { storyId: ctx.story.id });
     return {
       action: "escalate",

--- a/test/unit/pipeline/stages/autofix.test.ts
+++ b/test/unit/pipeline/stages/autofix.test.ts
@@ -194,6 +194,89 @@ describe("autofixStage", () => {
     expect(result.action).toBe("escalate");
   });
 
+  test("partial progress — cleared checks added to skip list, returns retry when budget remains", async () => {
+    const saved = { ..._autofixDeps };
+    _autofixDeps.runAgentRectification = async (mockCtx: PipelineContext) => {
+      // Simulate: lint cleared after 3 attempts, typecheck still failing. 3 of 12 budget used.
+      mockCtx.autofixAttempt = 3;
+      mockCtx.reviewResult = makeFailedReviewResult([{ check: "typecheck", output: "TS2345: Type error" }]);
+      return { succeeded: false, cost: 1.5 };
+    };
+
+    const ctx = makeCtx({
+      reviewResult: makeFailedReviewResult([{ check: "lint" }, { check: "typecheck" }]),
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test" },
+          autofix: { enabled: true, maxAttempts: 3, maxTotalAttempts: 12 },
+        },
+      } as any,
+    });
+    const result = await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(result.action).toBe("retry");
+    if (result.action === "retry") expect(result.fromStage).toBe("review");
+    expect(ctx.retrySkipChecks?.has("lint")).toBe(true);
+    expect(ctx.retrySkipChecks?.has("typecheck")).toBe(false);
+  });
+
+  test("zero progress — escalates immediately even when budget remains", async () => {
+    const saved = { ..._autofixDeps };
+    _autofixDeps.runAgentRectification = async (mockCtx: PipelineContext) => {
+      // Simulate: 3 attempts, nothing fixed — same checks still failing.
+      mockCtx.autofixAttempt = 3;
+      return { succeeded: false, cost: 1.5 };
+    };
+
+    const ctx = makeCtx({
+      reviewResult: makeFailedReviewResult([{ check: "lint" }, { check: "typecheck" }]),
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test" },
+          autofix: { enabled: true, maxAttempts: 3, maxTotalAttempts: 12 },
+        },
+      } as any,
+    });
+    const result = await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(result.action).toBe("escalate");
+  });
+
+  test("budget exhausted — escalates even when partial progress was made", async () => {
+    const saved = { ..._autofixDeps };
+    _autofixDeps.runAgentRectification = async (mockCtx: PipelineContext) => {
+      // Simulate: lint cleared but budget now fully consumed.
+      mockCtx.autofixAttempt = 12;
+      mockCtx.reviewResult = makeFailedReviewResult([{ check: "typecheck", output: "TS2345: Type error" }]);
+      return { succeeded: false, cost: 0.5 };
+    };
+
+    const ctx = makeCtx({
+      reviewResult: makeFailedReviewResult([{ check: "lint" }, { check: "typecheck" }]),
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test" },
+          autofix: { enabled: true, maxAttempts: 3, maxTotalAttempts: 12 },
+        },
+      } as any,
+    });
+    const result = await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(result.action).toBe("escalate");
+  });
+
   test("agent rectification skipped when review passes after mechanical fix", async () => {
     const saved = { ..._autofixDeps };
     let agentRectificationCalled = false;


### PR DESCRIPTION
## Summary

- When agent rectification clears some checks but not all, adds cleared checks to `retrySkipChecks` and returns `retry fromStage:"review"` instead of escalating immediately
- Only escalates when zero progress was made in a cycle (agent is stuck) or the global `maxTotalAttempts` budget is exhausted
- Updates `docs/architecture/subsystems.md`: new Autofix Stage subsection, `retrySkipChecks` field in PipelineContext, and stage table description

Closes #442

## Root cause

`autofixStage.execute()` returned `escalate` unconditionally when `runAgentRectification` yielded `succeeded: false`, regardless of partial progress or remaining budget. The `maxTotalAttempts: 12` cap only accumulated across successful cycles — a first-cycle failure with multiple check types always escalated after 3 attempts, leaving up to 9 attempts unused.

## Test plan

- [ ] Partial progress + budget remaining → returns `retry` with cleared checks in `retrySkipChecks`
- [ ] Zero progress (no checks cleared) → escalates even when budget remains
- [ ] Budget exhausted → escalates even when partial progress was made
- [ ] Existing escalation paths (UNRESOLVED signal, mechanical-only failure) unaffected
- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean
- [ ] `bun test test/unit/pipeline/stages/autofix.test.ts` — 33 pass (30 existing + 3 new)