### PR TITLE
fix(review): promote retry logging to info, add rawHead and retry exhaustion context

### DIFF
--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -245,10 +245,16 @@ export async function runAdversarialReview(
 
   let rawResponse: string;
   let llmCost = 0;
+  let retryAttempted = false;
   try {
     const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: false });
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;
+    logger?.debug("adversarial", "LLM call complete", {
+      storyId: story.id,
+      responseLen: rawResponse.length,
+      estimatedCost: llmCost,
+    });
   } catch (err) {
     logger?.warn("adversarial", "LLM call failed — fail-open", {
       storyId: story.id,
@@ -267,10 +273,13 @@ export async function runAdversarialReview(
   // Retry once when the response cannot be parsed — the session has full context so
   // a short follow-up asking for valid JSON is sufficient.
   if (!parseAdversarialResponse(rawResponse)) {
+    retryAttempted = true;
+    logger?.info("adversarial", "JSON parse failed, retrying (1/1)", {
+      storyId: story.id,
+      rawHead: rawResponse.slice(0, 200),
+      responseLen: rawResponse.length,
+    });
     try {
-      logger?.debug("adversarial", "Response could not be parsed — retrying with JSON prompt", {
-        storyId: story.id,
-      });
       const retryResult = await agent.run({
         prompt: ReviewPromptBuilder.jsonRetry(),
         ...runOpts,
@@ -278,6 +287,12 @@ export async function runAdversarialReview(
       });
       rawResponse = retryResult.output;
       llmCost += retryResult.estimatedCost ?? 0;
+      if (parseAdversarialResponse(rawResponse)) {
+        logger?.info("adversarial", "JSON retry succeeded", {
+          storyId: story.id,
+          responseLen: rawResponse.length,
+        });
+      }
     } catch (err) {
       logger?.warn("adversarial", "JSON retry call failed", { storyId: story.id, cause: String(err) });
     }
@@ -303,7 +318,8 @@ export async function runAdversarialReview(
     if (looksLikeFail) {
       logger?.warn("adversarial", "LLM returned truncated JSON with passed:false — treating as failure", {
         storyId: story.id,
-        rawResponse: rawResponse.slice(0, 200),
+        retryAttempted,
+        rawHead: rawResponse.slice(0, 200),
       });
       return {
         check: "adversarial",
@@ -317,9 +333,11 @@ export async function runAdversarialReview(
       };
     }
 
-    logger?.warn("adversarial", "LLM returned invalid JSON — fail-open", {
+    logger?.warn("adversarial", "Retry exhausted — fail-open", {
       storyId: story.id,
-      rawResponse: rawResponse.slice(0, 200),
+      retries: retryAttempted ? 1 : 0,
+      rawHead: rawResponse.slice(0, 200),
+      responseLen: rawResponse.length,
     });
     return {
       check: "adversarial",

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -385,10 +385,16 @@ export async function runSemanticReview(
 
   let rawResponse: string;
   let llmCost = 0;
+  let retryAttempted = false;
   try {
     const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: false });
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;
+    logger?.debug("semantic", "LLM call complete", {
+      storyId: story.id,
+      responseLen: rawResponse.length,
+      estimatedCost: llmCost,
+    });
   } catch (err) {
     logger?.warn("semantic", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
     return {
@@ -404,10 +410,13 @@ export async function runSemanticReview(
   // Retry once when the response cannot be parsed — the session has full context so
   // a short follow-up asking for valid JSON is sufficient.
   if (!parseLLMResponse(rawResponse)) {
+    retryAttempted = true;
+    logger?.info("semantic", "JSON parse failed, retrying (1/1)", {
+      storyId: story.id,
+      rawHead: rawResponse.slice(0, 200),
+      responseLen: rawResponse.length,
+    });
     try {
-      logger?.debug("semantic", "Response could not be parsed — retrying with JSON prompt", {
-        storyId: story.id,
-      });
       const retryResult = await agent.run({
         prompt: ReviewPromptBuilder.jsonRetry(),
         ...runOpts,
@@ -415,6 +424,12 @@ export async function runSemanticReview(
       });
       rawResponse = retryResult.output;
       llmCost += retryResult.estimatedCost ?? 0;
+      if (parseLLMResponse(rawResponse)) {
+        logger?.info("semantic", "JSON retry succeeded", {
+          storyId: story.id,
+          responseLen: rawResponse.length,
+        });
+      }
     } catch (err) {
       logger?.warn("semantic", "JSON retry call failed", { storyId: story.id, cause: String(err) });
     }
@@ -442,7 +457,8 @@ export async function runSemanticReview(
     if (looksLikeFail) {
       logger?.warn("semantic", "LLM returned truncated JSON with passed:false — treating as failure", {
         storyId: story.id,
-        rawResponse: rawResponse.slice(0, 200),
+        retryAttempted,
+        rawHead: rawResponse.slice(0, 200),
       });
       return {
         check: "semantic",
@@ -456,9 +472,11 @@ export async function runSemanticReview(
       };
     }
 
-    logger?.warn("semantic", "LLM returned invalid JSON — fail-open", {
+    logger?.warn("semantic", "Retry exhausted — fail-open", {
       storyId: story.id,
-      rawResponse: rawResponse.slice(0, 200),
+      retries: retryAttempted ? 1 : 0,
+      rawHead: rawResponse.slice(0, 200),
+      responseLen: rawResponse.length,
     });
     return {
       check: "semantic",

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -7,14 +7,16 @@
  * - agent.run called twice when initial response is unparseable
  * - Retry call uses keepSessionOpen: false
  * - Cost accumulated from both initial and retry calls
+ * - Logging: info on parse fail + retry, info on retry success, warn on exhaustion
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { _adversarialDeps, runAdversarialReview } from "../../../src/review/adversarial";
 import { _diffUtilsDeps } from "../../../src/review/diff-utils";
 import type { AdversarialReviewConfig } from "../../../src/review/types";
 import type { SemanticStory } from "../../../src/review/types";
 import type { AgentAdapter } from "../../../src/agents/types";
+import * as loggerModule from "../../../src/logger";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -89,6 +91,40 @@ function makeMultiCallAgent(responses: string[], costPerCall = 0.5): AgentAdapte
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async (_prompt: string) => responses[0]),
   } as unknown as AgentAdapter;
+}
+
+// ---------------------------------------------------------------------------
+// Logger mock helpers
+// ---------------------------------------------------------------------------
+
+interface LogCall {
+  stage: string;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+interface MockLogger {
+  info: ReturnType<typeof mock>;
+  warn: ReturnType<typeof mock>;
+  debug: ReturnType<typeof mock>;
+  infoCalls: LogCall[];
+  warnCalls: LogCall[];
+}
+
+function makeLogger(): MockLogger {
+  const infoCalls: LogCall[] = [];
+  const warnCalls: LogCall[] = [];
+  return {
+    infoCalls,
+    warnCalls,
+    info: mock((stage: string, message: string, data?: Record<string, unknown>) => {
+      infoCalls.push({ stage, message, data });
+    }),
+    warn: mock((stage: string, message: string, data?: Record<string, unknown>) => {
+      warnCalls.push({ stage, message, data });
+    }),
+    debug: mock(() => {}),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -258,5 +294,112 @@ describe("runAdversarialReview — JSON retry failure paths", () => {
 
     expect(result.success).toBe(false);
     expect(result.output).toContain("passed:false");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Logging behaviour
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — retry logging", () => {
+  let loggerSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(() => {
+    restoreAllDeps();
+    loggerSpy?.mockRestore();
+  });
+
+  test("logs info 'JSON parse failed, retrying (1/1)' with rawHead when initial parse fails", async () => {
+    const logger = makeLogger();
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    const badOutput = "this is not json at all";
+    const agent = makeMultiCallAgent([badOutput, PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    const parseFailLog = logger.infoCalls.find((c) => c.message.includes("JSON parse failed"));
+    expect(parseFailLog).toBeDefined();
+    expect(parseFailLog?.stage).toBe("adversarial");
+    expect(parseFailLog?.data?.rawHead).toContain("not json");
+    expect(parseFailLog?.data?.responseLen).toBe(badOutput.length);
+  });
+
+  test("logs info 'JSON retry succeeded' when retry parse passes", async () => {
+    const logger = makeLogger();
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    const agent = makeMultiCallAgent(["not json", PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    const successLog = logger.infoCalls.find((c) => c.message.includes("JSON retry succeeded"));
+    expect(successLog).toBeDefined();
+    expect(successLog?.stage).toBe("adversarial");
+    expect(successLog?.data?.responseLen).toBeGreaterThan(0);
+  });
+
+  test("does not log 'JSON retry succeeded' when initial parse succeeds (no retry needed)", async () => {
+    const logger = makeLogger();
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    const agent = makeMultiCallAgent([PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    const retryLog = logger.infoCalls.find((c) => c.message.includes("retry"));
+    expect(retryLog).toBeUndefined();
+  });
+
+  test("logs warn 'Retry exhausted — fail-open' with retries:1 and rawHead when both attempts fail", async () => {
+    const logger = makeLogger();
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    const badOutput = "still not json after retry";
+    const agent = makeMultiCallAgent(["not json", badOutput]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    const exhaustLog = logger.warnCalls.find((c) => c.message.includes("Retry exhausted"));
+    expect(exhaustLog).toBeDefined();
+    expect(exhaustLog?.stage).toBe("adversarial");
+    expect(exhaustLog?.data?.retries).toBe(1);
+    expect(exhaustLog?.data?.rawHead).toContain("not json");
+    expect(exhaustLog?.data?.responseLen).toBe(badOutput.length);
+  });
+
+  test("logs warn 'Retry exhausted — fail-open' with retries:1 when initial parse fails and retry throws", async () => {
+    const logger = makeLogger();
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    // retryAttempted is set before the try block, so retries:1 even when the call throws
+    let callIndex = 0;
+    const agent = {
+      name: "mock",
+      displayName: "Mock",
+      binary: "mock",
+      capabilities: { supportedTiers: [], supportedTestStrategies: [], features: {} } as unknown as AgentAdapter["capabilities"],
+      isInstalled: mock(async () => true),
+      run: mock(async () => {
+        callIndex++;
+        if (callIndex === 1) return { output: "not json", estimatedCost: 0 };
+        throw new Error("retry network failure");
+      }),
+      buildCommand: mock(() => []),
+      plan: mock(async () => { throw new Error("not used"); }),
+      decompose: mock(async () => { throw new Error("not used"); }),
+      complete: mock(async () => ""),
+    } as unknown as AgentAdapter;
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    const exhaustLog = logger.warnCalls.find((c) => c.message.includes("Retry exhausted"));
+    expect(exhaustLog).toBeDefined();
+    expect(exhaustLog?.data?.retries).toBe(1);
   });
 });

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -7,11 +7,13 @@
  * - agent.run called twice when initial response is unparseable
  * - Retry call uses keepSessionOpen: false
  * - Cost accumulated from both initial and retry calls
+ * - Logging: info on parse fail + retry, info on retry success, warn on exhaustion
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import type { AgentResult } from "../../../src/agents/types";
 import type { AgentAdapter } from "../../../src/agents/types";
+import * as loggerModule from "../../../src/logger";
 import { _diffUtilsDeps } from "../../../src/review/diff-utils";
 import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
 import type { SemanticStory } from "../../../src/review/semantic";
@@ -100,6 +102,40 @@ function makeMultiCallAgent(responses: string[], costPerCall = 0.5): AgentAdapte
       throw new Error("complete() must NOT be called in non-debate path");
     }),
   } as unknown as AgentAdapter;
+}
+
+// ---------------------------------------------------------------------------
+// Logger mock helpers
+// ---------------------------------------------------------------------------
+
+interface LogCall {
+  stage: string;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+interface MockLogger {
+  info: ReturnType<typeof mock>;
+  warn: ReturnType<typeof mock>;
+  debug: ReturnType<typeof mock>;
+  infoCalls: LogCall[];
+  warnCalls: LogCall[];
+}
+
+function makeLogger(): MockLogger {
+  const infoCalls: LogCall[] = [];
+  const warnCalls: LogCall[] = [];
+  return {
+    infoCalls,
+    warnCalls,
+    info: mock((stage: string, message: string, data?: Record<string, unknown>) => {
+      infoCalls.push({ stage, message, data });
+    }),
+    warn: mock((stage: string, message: string, data?: Record<string, unknown>) => {
+      warnCalls.push({ stage, message, data });
+    }),
+    debug: mock(() => {}),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -262,5 +298,82 @@ describe("runSemanticReview — JSON retry failure paths", () => {
 
     expect(result.success).toBe(false);
     expect(result.output).toContain("passed:false");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Logging behaviour
+// ---------------------------------------------------------------------------
+
+describe("runSemanticReview — retry logging", () => {
+  let loggerSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(() => {
+    restoreAllDeps();
+    loggerSpy?.mockRestore();
+  });
+
+  test("logs info 'JSON parse failed, retrying (1/1)' with rawHead when initial parse fails", async () => {
+    const logger = makeLogger();
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    const badOutput = "this is not json at all";
+    const agent = makeMultiCallAgent([badOutput, PASSING_LLM_RESPONSE]);
+
+    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    const parseFailLog = logger.infoCalls.find((c) => c.message.includes("JSON parse failed"));
+    expect(parseFailLog).toBeDefined();
+    expect(parseFailLog?.stage).toBe("semantic");
+    expect(parseFailLog?.data?.rawHead).toContain("not json");
+    expect(parseFailLog?.data?.responseLen).toBe(badOutput.length);
+  });
+
+  test("logs info 'JSON retry succeeded' when retry parse passes", async () => {
+    const logger = makeLogger();
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    const agent = makeMultiCallAgent(["not json", PASSING_LLM_RESPONSE]);
+
+    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    const successLog = logger.infoCalls.find((c) => c.message.includes("JSON retry succeeded"));
+    expect(successLog).toBeDefined();
+    expect(successLog?.stage).toBe("semantic");
+    expect(successLog?.data?.responseLen).toBeGreaterThan(0);
+  });
+
+  test("does not log 'JSON retry succeeded' when initial parse succeeds (no retry needed)", async () => {
+    const logger = makeLogger();
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    const agent = makeMultiCallAgent([PASSING_LLM_RESPONSE]);
+
+    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    const retryLog = logger.infoCalls.find((c) => c.message.includes("retry"));
+    expect(retryLog).toBeUndefined();
+  });
+
+  test("logs warn 'Retry exhausted — fail-open' with retries:1 and rawHead when both attempts fail", async () => {
+    const logger = makeLogger();
+    loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    const badOutput = "still not json after retry";
+    const agent = makeMultiCallAgent(["not json", badOutput]);
+
+    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    const exhaustLog = logger.warnCalls.find((c) => c.message.includes("Retry exhausted"));
+    expect(exhaustLog).toBeDefined();
+    expect(exhaustLog?.stage).toBe("semantic");
+    expect(exhaustLog?.data?.retries).toBe(1);
+    expect(exhaustLog?.data?.rawHead).toContain("not json");
+    expect(exhaustLog?.data?.responseLen).toBe(badOutput.length);
   });
 });


### PR DESCRIPTION
Closes #446

## Summary

- `debug "Response could not be parsed — retrying"` → `info "JSON parse failed, retrying (1/1)"` with `rawHead` (first 200 chars) and `responseLen` — visible in production logs and contains the bad output for diagnosis
- New `info "JSON retry succeeded"` log when retry recovers — confirms the retry path worked
- `warn "LLM returned invalid JSON — fail-open"` → `warn "Retry exhausted — fail-open"` with `retries` (0 or 1) and `rawHead` — distinguishes a first-parse failure from a post-retry exhaustion
- New `debug "LLM call complete"` after initial LLM call with `responseLen` and `estimatedCost` for performance tracing
- Applies symmetrically to both `adversarial.ts` and `semantic.ts`

## Test plan

- [ ] `bun test test/unit/review/adversarial-retry.test.ts` — 13 tests pass (5 new logging tests)
- [ ] `bun test test/unit/review/semantic-retry.test.ts` — 11 tests pass (4 new logging tests)
- [ ] `bun test test/unit/review/` — 351 tests pass
- [ ] `bun run lint` — clean
- [ ] `bun run typecheck` — clean