### PR TITLE
feat(review): two-tier review rubric with configurable blockingThreshold (#448)

### DIFF
--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -350,6 +350,17 @@ const ReviewConfigSchema = z.object({
   }),
   pluginMode: z.enum(["per-story", "deferred"]).default("per-story"),
   audit: z.object({ enabled: z.boolean().default(false) }).default({ enabled: false }),
+  /**
+   * Minimum severity that counts as a blocking finding.
+   * "error"   (default): only error/critical findings block; warnings are advisory.
+   * "warning": error, critical, AND warning findings block; info is advisory.
+   * "info":    all findings block (strictest mode).
+   *
+   * Hierarchy: info < warning < error < critical.
+   * Applies only to LLM-based checkers (semantic, adversarial).
+   * Mechanical checks (lint, typecheck, test, build) always block on failure.
+   */
+  blockingThreshold: z.enum(["error", "warning", "info"]).default("error"),
   semantic: SemanticReviewConfigSchema.optional(),
   adversarial: AdversarialReviewConfigSchema.optional(),
   dialogue: ReviewDialogueConfigSchema.default({
@@ -766,6 +777,7 @@ export const NaxConfigSchema = z
       commands: {},
       pluginMode: "per-story",
       audit: { enabled: false },
+      blockingThreshold: "error",
       semantic: {
         modelTier: "balanced",
         diffMode: "embedded",

--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -175,6 +175,12 @@ export async function runIteration(
     }
   }
 
+  // Propagate reviewSummary to status writer so it appears in status.json
+  const reviewSummaryFromPipeline = pipelineResult.context.reviewResult?.reviewSummary;
+  if (reviewSummaryFromPipeline) {
+    ctx.statusWriter.setReviewSummary(reviewSummaryFromPipeline);
+  }
+
   const currentPrd = pipelineResult.context.prd;
 
   const handlerCtx = {

--- a/src/execution/status-file.ts
+++ b/src/execution/status-file.ts
@@ -119,6 +119,11 @@ export interface NaxStatusFile {
     attempt: number;
     /** Current phase */
     phase: string;
+    /** Per-reviewer finding breakdown from the most recent review (populated after LLM review) */
+    reviewSummary?: {
+      semantic?: { blocking: number; advisory: number };
+      adversarial?: { blocking: number; advisory: number };
+    };
   } | null;
 
   /** Number of loop iterations completed */
@@ -210,6 +215,11 @@ export interface RunStateSnapshot {
     model: string;
     attempt: number;
     phase: string;
+    /** Per-reviewer finding breakdown from the most recent review */
+    reviewSummary?: {
+      semantic?: { blocking: number; advisory: number };
+      adversarial?: { blocking: number; advisory: number };
+    };
   } | null;
   /** Number of loop iterations */
   iterations: number;

--- a/src/execution/status-writer.ts
+++ b/src/execution/status-writer.ts
@@ -104,6 +104,12 @@ export class StatusWriter {
     this._currentStory = story;
   }
 
+  /** Merge reviewSummary into the current story (no-op if no current story) */
+  setReviewSummary(reviewSummary: NonNullable<RunStateSnapshot["currentStory"]>["reviewSummary"]): void {
+    if (!this._currentStory) return;
+    this._currentStory = { ...this._currentStory, reviewSummary };
+  }
+
   /**
    * Merge a partial update into the in-memory postRun state for a given phase.
    * The next update() call will write the merged state to disk.

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -90,12 +90,24 @@ function normalizeSeverity(sev: string): ReviewFinding["severity"] {
 }
 
 /**
- * Check whether a finding severity is blocking (counts toward pass/fail).
- * "unverifiable" and "info" are non-blocking per the adversarial output schema:
- *   passed may be true with findings if all findings are "info" or "unverifiable".
+ * Severity rank for threshold comparison.
+ * "unverifiable" is treated as info (non-blocking by default).
  */
-function isBlockingSeverity(sev: string): boolean {
-  return sev !== "unverifiable" && sev !== "info";
+const SEVERITY_RANK: Record<string, number> = {
+  info: 0,
+  unverifiable: 0,
+  low: 1,
+  warning: 1,
+  error: 2,
+  critical: 3,
+};
+
+/**
+ * Check whether a normalized finding severity meets or exceeds the blocking threshold.
+ * threshold defaults to "error" — only error/critical block unless configured stricter.
+ */
+function isBlockingSeverity(sev: string, threshold: "error" | "warning" | "info" = "error"): boolean {
+  return (SEVERITY_RANK[sev] ?? 0) >= (SEVERITY_RANK[threshold] ?? 2);
 }
 
 /** Convert AdversarialLLMFinding[] to ReviewFinding[] with adversarial-review metadata. */
@@ -124,6 +136,7 @@ export async function runAdversarialReview(
   naxConfig?: NaxConfig,
   featureName?: string,
   priorFailures?: Array<{ stage: string; modelTier: string }>,
+  blockingThreshold?: "error" | "warning" | "info",
 ): Promise<ReviewCheckResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -362,16 +375,17 @@ export async function runAdversarialReview(
     });
   }
 
-  const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity));
-  const nonBlockingFindings = parsed.findings.filter((f) => !isBlockingSeverity(f.severity));
+  const threshold = blockingThreshold ?? "error";
+  const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity, threshold));
+  const advisoryFindings = parsed.findings.filter((f) => !isBlockingSeverity(f.severity, threshold));
 
-  if (nonBlockingFindings.length > 0) {
+  if (advisoryFindings.length > 0) {
     logger?.debug(
       "review",
-      `Adversarial review: ${nonBlockingFindings.length} non-blocking findings (unverifiable/info)`,
+      `Adversarial review: ${advisoryFindings.length} advisory findings (below threshold '${threshold}')`,
       {
         storyId: story.id,
-        findings: nonBlockingFindings.map((f) => ({
+        findings: advisoryFindings.map((f) => ({
           severity: f.severity,
           category: f.category,
           file: f.file,
@@ -382,11 +396,11 @@ export async function runAdversarialReview(
   }
 
   // Findings take precedence over the passed field.
-  // The schema requires passed:false when any error/warn finding exists, but if the LLM
-  // contradicts itself (passed:true + error findings), trust the findings and fail-closed.
+  // The schema requires passed:false when any blocking finding exists, but if the LLM
+  // contradicts itself (passed:true + blocking findings), trust the findings and fail-closed.
   if (blockingFindings.length > 0) {
     const durationMs = Date.now() - startTime;
-    logger?.warn("review", `Adversarial review failed: ${blockingFindings.length} findings`, {
+    logger?.warn("review", `Adversarial review failed: ${blockingFindings.length} blocking findings`, {
       storyId: story.id,
       durationMs,
     });
@@ -408,14 +422,15 @@ export async function runAdversarialReview(
       output: `Adversarial review failed:\n\n${formatFindings(blockingFindings)}`,
       durationMs,
       findings: toAdversarialReviewFindings(blockingFindings),
+      advisoryFindings: advisoryFindings.length > 0 ? toAdversarialReviewFindings(advisoryFindings) : undefined,
       cost: llmCost,
     };
   }
 
-  // If all findings are non-blocking (unverifiable/info), override to pass regardless of passed field.
+  // If all findings are advisory (below threshold), override to pass regardless of passed field.
   if (!parsed.passed && blockingFindings.length === 0) {
     const durationMs = Date.now() - startTime;
-    logger?.info("review", "Adversarial review passed (all findings non-blocking)", {
+    logger?.info("review", "Adversarial review passed (all findings below blocking threshold)", {
       storyId: story.id,
       durationMs,
     });
@@ -424,8 +439,9 @@ export async function runAdversarialReview(
       success: true,
       command: "",
       exitCode: 0,
-      output: "Adversarial review passed (all findings were unverifiable or informational)",
+      output: "Adversarial review passed (all findings were advisory — below blocking threshold)",
       durationMs,
+      advisoryFindings: advisoryFindings.length > 0 ? toAdversarialReviewFindings(advisoryFindings) : undefined,
       cost: llmCost,
     };
   }
@@ -441,6 +457,7 @@ export async function runAdversarialReview(
     exitCode: parsed.passed ? 0 : 1,
     output: parsed.passed ? "Adversarial review passed" : "Adversarial review failed (no findings)",
     durationMs,
+    advisoryFindings: advisoryFindings.length > 0 ? toAdversarialReviewFindings(advisoryFindings) : undefined,
     cost: llmCost,
   };
 }

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -20,7 +20,14 @@ import { runAdversarialReview } from "./adversarial";
 import { runReview } from "./runner";
 import type { SemanticStory } from "./semantic";
 import { runSemanticReview } from "./semantic";
-import type { AdversarialReviewConfig, ReviewCheckResult, ReviewConfig, ReviewResult } from "./types";
+import type {
+  AdversarialReviewConfig,
+  ReviewCheckResult,
+  ReviewConfig,
+  ReviewResult,
+  ReviewerFindingSummary,
+} from "./types";
+import { writeReviewVerdict } from "./verdict-writer";
 
 /**
  * Injectable dependencies for orchestrator internals — allows tests to intercept
@@ -81,6 +88,26 @@ export interface OrchestratorReviewResult {
    * correct and UNRESOLVED should not trigger tier escalation.
    */
   mechanicalFailedOnly?: boolean;
+}
+
+/** Build per-reviewer finding summary from LLM check results. */
+function buildReviewSummary(checks: ReviewCheckResult[]): ReviewResult["reviewSummary"] {
+  const summary: ReviewResult["reviewSummary"] = {};
+  const semCheck = checks.find((c) => c.check === "semantic");
+  if (semCheck) {
+    summary.semantic = {
+      blocking: semCheck.findings?.length ?? 0,
+      advisory: semCheck.advisoryFindings?.length ?? 0,
+    } satisfies ReviewerFindingSummary;
+  }
+  const advCheck = checks.find((c) => c.check === "adversarial");
+  if (advCheck) {
+    summary.adversarial = {
+      blocking: advCheck.findings?.length ?? 0,
+      advisory: advCheck.advisoryFindings?.length ?? 0,
+    } satisfies ReviewerFindingSummary;
+  }
+  return summary;
 }
 
 export class ReviewOrchestrator {
@@ -235,6 +262,7 @@ export class ReviewOrchestrator {
             featureName,
             resolverSession,
             priorFailures,
+            reviewConfig.blockingThreshold,
           ),
           _orchestratorDeps.runAdversarialReview(
             workdir,
@@ -245,6 +273,7 @@ export class ReviewOrchestrator {
             naxConfig,
             featureName,
             priorFailures,
+            reviewConfig.blockingThreshold,
           ),
         ]);
         llmCheckResults = [semResult, advResult];
@@ -280,12 +309,45 @@ export class ReviewOrchestrator {
           : `${firstFailure.check} failed (exit code ${firstFailure.exitCode})`
         : undefined;
 
+      // Build per-reviewer finding summary from LLM check results
+      const reviewSummary = buildReviewSummary(llmCheckResults);
+
       builtIn = {
         success: mechanicalPassed && llmPassed,
         checks: allChecks,
         totalDurationMs: mechanicalResult.totalDurationMs + (Date.now() - llmStart),
         failureReason,
+        reviewSummary: reviewSummary && Object.keys(reviewSummary).length > 0 ? reviewSummary : undefined,
       };
+
+      // Write unified verdict file (fire-and-forget) when LLM checks ran
+      if (llmCheckResults.length > 0 && storyId) {
+        const threshold = reviewConfig.blockingThreshold ?? "error";
+        const verdictReviewers: Record<string, { blocking: number; advisory: number; passed: boolean }> = {};
+        const semCheck = llmCheckResults.find((c) => c.check === "semantic");
+        if (semCheck) {
+          verdictReviewers.semantic = {
+            blocking: semCheck.findings?.length ?? 0,
+            advisory: semCheck.advisoryFindings?.length ?? 0,
+            passed: semCheck.success,
+          };
+        }
+        const advCheck = llmCheckResults.find((c) => c.check === "adversarial");
+        if (advCheck) {
+          verdictReviewers.adversarial = {
+            blocking: advCheck.findings?.length ?? 0,
+            advisory: advCheck.advisoryFindings?.length ?? 0,
+            passed: advCheck.success,
+          };
+        }
+        void writeReviewVerdict({
+          storyId,
+          featureName,
+          timestamp: new Date().toISOString(),
+          blockingThreshold: threshold,
+          reviewers: verdictReviewers,
+        });
+      }
 
       // Signal to autofix that code is functionally correct (LLM passed) despite mechanical failure
       mechanicalFailedOnly = !mechanicalPassed && llmPassed;

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -306,6 +306,7 @@ export async function runReview(
         featureName,
         resolverSession,
         priorFailures,
+        config.blockingThreshold,
       );
       checks.push(result);
       if (!result.success && !firstFailure) {
@@ -344,6 +345,7 @@ export async function runReview(
         naxConfig,
         featureName,
         priorFailures,
+        config.blockingThreshold,
       );
       checks.push(result);
       if (!result.success && !firstFailure) {

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -89,9 +89,25 @@ function normalizeSeverity(sev: string): ReviewFinding["severity"] {
   return "info";
 }
 
-/** Check whether a finding severity is blocking (counts toward pass/fail). */
-function isBlockingSeverity(sev: string): boolean {
-  return sev !== "unverifiable";
+/**
+ * Severity rank for threshold comparison.
+ * "unverifiable" is treated as info (non-blocking by default).
+ */
+const SEVERITY_RANK: Record<string, number> = {
+  info: 0,
+  unverifiable: 0,
+  low: 1,
+  warning: 1,
+  error: 2,
+  critical: 3,
+};
+
+/**
+ * Check whether a normalized finding severity meets or exceeds the blocking threshold.
+ * threshold defaults to "error" — only error/critical block unless configured stricter.
+ */
+function isBlockingSeverity(sev: string, threshold: "error" | "warning" | "info" = "error"): boolean {
+  return (SEVERITY_RANK[sev] ?? 0) >= (SEVERITY_RANK[threshold] ?? 2);
 }
 
 /** Convert LLMFinding[] to ReviewFinding[] with semantic-review metadata. */
@@ -119,6 +135,7 @@ export async function runSemanticReview(
   featureName?: string,
   resolverSession?: import("./dialogue").ReviewerSession,
   priorFailures?: Array<{ stage: string; modelTier: string }>,
+  blockingThreshold?: "error" | "warning" | "info",
 ): Promise<ReviewCheckResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -308,13 +325,15 @@ export async function runSemanticReview(
       }
     }
 
-    // Filter non-blocking findings from debate results
-    const debateBlocking = deduped.filter((f) => isBlockingSeverity(f.severity));
+    // Split debate findings by blocking threshold
+    const debateThreshold = blockingThreshold ?? "error";
+    const debateBlocking = deduped.filter((f) => isBlockingSeverity(f.severity, debateThreshold));
+    const debateAdvisory = deduped.filter((f) => !isBlockingSeverity(f.severity, debateThreshold));
 
     const durationMs = Date.now() - startTime;
     if (!resolverPassed) {
       if (debateBlocking.length > 0) {
-        logger?.warn("review", `Semantic review failed (debate): ${debateBlocking.length} findings`, {
+        logger?.warn("review", `Semantic review failed (debate): ${debateBlocking.length} blocking findings`, {
           storyId: story.id,
           durationMs,
         });
@@ -326,11 +345,12 @@ export async function runSemanticReview(
           output: `Semantic review failed:\n\n${formatFindings(debateBlocking)}`,
           durationMs,
           findings: toReviewFindings(debateBlocking),
+          advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory) : undefined,
           cost: debateCost,
         };
       }
-      // All findings were non-blocking — override to pass
-      logger?.info("review", "Semantic review passed (debate, all findings non-blocking)", {
+      // All findings were advisory — override to pass
+      logger?.info("review", "Semantic review passed (debate, all findings below blocking threshold)", {
         storyId: story.id,
         durationMs,
       });
@@ -339,8 +359,9 @@ export async function runSemanticReview(
         success: true,
         command: "",
         exitCode: 0,
-        output: "Semantic review passed (debate, all findings were unverifiable or informational)",
+        output: "Semantic review passed (debate, all findings were advisory — below blocking threshold)",
         durationMs,
+        advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory) : undefined,
         cost: debateCost,
       };
     }
@@ -352,6 +373,7 @@ export async function runSemanticReview(
       exitCode: 0,
       output: "Semantic review passed",
       durationMs,
+      advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory) : undefined,
       cost: debateCost,
     };
   }
@@ -501,17 +523,18 @@ export async function runSemanticReview(
     });
   }
 
-  // Split findings into blocking (error/warn) and non-blocking (unverifiable/info)
-  const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity));
-  const nonBlockingFindings = parsed.findings.filter((f) => !isBlockingSeverity(f.severity));
+  // Split findings by blocking threshold
+  const threshold = blockingThreshold ?? "error";
+  const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity, threshold));
+  const advisoryFindings = parsed.findings.filter((f) => !isBlockingSeverity(f.severity, threshold));
 
-  if (nonBlockingFindings.length > 0) {
+  if (advisoryFindings.length > 0) {
     logger?.debug(
       "review",
-      `Semantic review: ${nonBlockingFindings.length} non-blocking findings (unverifiable/info)`,
+      `Semantic review: ${advisoryFindings.length} advisory findings (below threshold '${threshold}')`,
       {
         storyId: story.id,
-        findings: nonBlockingFindings.map((f) => ({ severity: f.severity, file: f.file, issue: f.issue })),
+        findings: advisoryFindings.map((f) => ({ severity: f.severity, file: f.file, issue: f.issue })),
       },
     );
   }
@@ -519,7 +542,7 @@ export async function runSemanticReview(
   // Format findings and populate structured ReviewFinding[]
   if (!parsed.passed && blockingFindings.length > 0) {
     const durationMs = Date.now() - startTime;
-    logger?.warn("review", `Semantic review failed: ${blockingFindings.length} findings`, {
+    logger?.warn("review", `Semantic review failed: ${blockingFindings.length} blocking findings`, {
       storyId: story.id,
       durationMs,
     });
@@ -542,21 +565,26 @@ export async function runSemanticReview(
       output,
       durationMs,
       findings: toReviewFindings(blockingFindings),
+      advisoryFindings: advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings) : undefined,
       cost: llmCost,
     };
   }
 
-  // If LLM said failed but all findings are non-blocking, override to pass
+  // If LLM said failed but all findings are advisory (below threshold), override to pass
   if (!parsed.passed && blockingFindings.length === 0) {
     const durationMs = Date.now() - startTime;
-    logger?.info("review", "Semantic review passed (all findings non-blocking)", { storyId: story.id, durationMs });
+    logger?.info("review", "Semantic review passed (all findings below blocking threshold)", {
+      storyId: story.id,
+      durationMs,
+    });
     return {
       check: "semantic",
       success: true,
       command: "",
       exitCode: 0,
-      output: "Semantic review passed (all findings were unverifiable or informational)",
+      output: "Semantic review passed (all findings were advisory — below blocking threshold)",
       durationMs,
+      advisoryFindings: advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings) : undefined,
       cost: llmCost,
     };
   }
@@ -572,6 +600,7 @@ export async function runSemanticReview(
     exitCode: parsed.passed ? 0 : 1,
     output: parsed.passed ? "Semantic review passed" : "Semantic review failed (no findings)",
     durationMs,
+    advisoryFindings: advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings) : undefined,
     cost: llmCost,
   };
 }

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -62,8 +62,10 @@ export interface ReviewCheckResult {
   output: string;
   /** Duration in milliseconds */
   durationMs: number;
-  /** Structured findings (populated by semantic review when LLM returns findings) */
+  /** Blocking findings — severity at or above blockingThreshold (populated by LLM reviewers) */
   findings?: import("../plugins/types").ReviewFinding[];
+  /** Advisory findings — severity below blockingThreshold (populated by LLM reviewers) */
+  advisoryFindings?: import("../plugins/types").ReviewFinding[];
   /** LLM cost incurred for this check (populated by semantic review) */
   cost?: number;
 }
@@ -84,6 +86,14 @@ export interface PluginReviewerResult {
   findings?: import("../plugins/types").ReviewFinding[];
 }
 
+/** Per-reviewer blocking/advisory finding counts for reviewSummary */
+export interface ReviewerFindingSummary {
+  /** Number of findings at or above blockingThreshold */
+  blocking: number;
+  /** Number of findings below blockingThreshold */
+  advisory: number;
+}
+
 /** Review phase result */
 export interface ReviewResult {
   /** All checks passed */
@@ -96,6 +106,11 @@ export interface ReviewResult {
   failureReason?: string;
   /** Plugin reviewer results (if any) */
   pluginReviewers?: PluginReviewerResult[];
+  /** Per-reviewer finding breakdown (populated when semantic/adversarial run) */
+  reviewSummary?: {
+    semantic?: ReviewerFindingSummary;
+    adversarial?: ReviewerFindingSummary;
+  };
 }
 
 /** Reviewer-implementer dialogue configuration */
@@ -151,6 +166,14 @@ export interface ReviewConfig {
   pluginMode?: "per-story" | "deferred";
   /** Review audit configuration — saves parsed reviewer JSON to .nax/review-audit/ */
   audit?: { enabled: boolean };
+  /**
+   * Minimum severity that counts as a blocking finding for LLM-based checkers.
+   * "error" (default): only error/critical block; warnings are advisory.
+   * "warning": error, critical, and warning block; info is advisory.
+   * "info": all findings block (strictest).
+   * Mechanical checks (lint, typecheck, test, build) always block on failure.
+   */
+  blockingThreshold?: "error" | "warning" | "info";
   /** Semantic review configuration (when 'semantic' is in checks) */
   semantic?: SemanticReviewConfig;
   /** Adversarial review configuration (when 'adversarial' is in checks) */

--- a/src/review/verdict-writer.ts
+++ b/src/review/verdict-writer.ts
@@ -1,0 +1,74 @@
+/**
+ * Review Verdict Writer
+ *
+ * Writes a unified verdict file to .nax/review-verdicts/<featureName>/<storyId>.json
+ * after each story's LLM review (semantic + adversarial) completes.
+ *
+ * The verdict file records per-reviewer blocking/advisory finding counts and
+ * whether each reviewer passed. Consumers (CI, dashboards) can read this to
+ * understand advisory signal without blocking the pipeline.
+ *
+ * All operations are best-effort: errors are warned but never thrown so that
+ * a verdict write failure can never interrupt an active run.
+ */
+
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { findNaxProjectRoot } from "../agents/acp";
+import { getSafeLogger } from "../logger";
+import type { ReviewerFindingSummary } from "./types";
+
+export interface ReviewVerdictEntry {
+  /** Story ID */
+  storyId: string;
+  /** Feature name */
+  featureName?: string;
+  /** ISO timestamp of when the verdict was written */
+  timestamp: string;
+  /** blockingThreshold used for this review run */
+  blockingThreshold: "error" | "warning" | "info";
+  /** Per-reviewer finding breakdown */
+  reviewers: {
+    semantic?: ReviewerFindingSummary & { passed: boolean };
+    adversarial?: ReviewerFindingSummary & { passed: boolean };
+  };
+}
+
+/** Injectable dependencies for verdict-writer.ts — allows tests to mock without mock.module() */
+export const _verdictWriterDeps = {
+  findNaxProjectRoot,
+  mkdir: mkdir as (path: string, opts?: { recursive?: boolean }) => Promise<string | undefined>,
+  writeFile: Bun.write as (path: string, body: string) => Promise<number>,
+};
+
+/**
+ * Write a unified review verdict file (fire-and-forget).
+ * Never throws — errors are logged at warn level.
+ */
+export async function writeReviewVerdict(entry: ReviewVerdictEntry): Promise<void> {
+  const logger = getSafeLogger();
+  try {
+    const projectDir = await _verdictWriterDeps.findNaxProjectRoot(entry.featureName ? join(entry.featureName) : ".");
+    const baseDir = projectDir ?? ".";
+    const verdictDir = entry.featureName
+      ? join(baseDir, ".nax", "review-verdicts", entry.featureName)
+      : join(baseDir, ".nax", "review-verdicts", "_unknown");
+
+    await _verdictWriterDeps.mkdir(verdictDir, { recursive: true });
+
+    const fileName = `${entry.storyId}.json`;
+    const filePath = join(verdictDir, fileName);
+
+    await _verdictWriterDeps.writeFile(filePath, JSON.stringify(entry, null, 2));
+
+    logger?.debug("review", "Review verdict written", {
+      storyId: entry.storyId,
+      filePath,
+    });
+  } catch (err) {
+    logger?.warn("review", "Failed to write review verdict (non-fatal)", {
+      storyId: entry.storyId,
+      cause: String(err),
+    });
+  }
+}

--- a/test/unit/review/adversarial-threshold.test.ts
+++ b/test/unit/review/adversarial-threshold.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for blockingThreshold in runAdversarialReview.
+ *
+ * Tests cover:
+ * - default ("error"): warnings are advisory, errors block
+ * - "warning" threshold: warnings become blocking
+ * - advisoryFindings populated with below-threshold findings
+ * - success=true when all findings below threshold
+ * - "info" threshold: all findings block
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AgentAdapter } from "../../../src/agents/types";
+import { _adversarialDeps, runAdversarialReview } from "../../../src/review/adversarial";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
+import type { AdversarialReviewConfig } from "../../../src/review/types";
+import type { SemanticStory } from "../../../src/review/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STORY: SemanticStory = {
+  id: "US-ADV-THR",
+  title: "Adversarial threshold tests",
+  description: "Validate blocking threshold logic for adversarial reviewer",
+  acceptanceCriteria: ["blockingThreshold controls which findings block"],
+};
+
+const BASE_CFG: AdversarialReviewConfig = {
+  modelTier: "balanced",
+  diffMode: "ref",
+  rules: [],
+  timeoutMs: 180_000,
+  excludePatterns: [],
+  parallel: false,
+  maxConcurrentSessions: 2,
+};
+
+const STAT_OUTPUT = "src/foo.ts | 5 +++++\n 1 file changed, 5 insertions(+)";
+
+// LLM responses
+const WARNING_ONLY_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    { severity: "warning", category: "input", file: "src/foo.ts", line: 1, issue: "A warning", suggestion: "Fix it" },
+  ],
+});
+
+const ERROR_ONLY_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    { severity: "error", category: "error-path", file: "src/bar.ts", line: 2, issue: "An error", suggestion: "Fix error" },
+  ],
+});
+
+const MIXED_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    { severity: "warning", category: "input", file: "src/foo.ts", line: 1, issue: "A warning", suggestion: "Fix w" },
+    { severity: "error", category: "error-path", file: "src/bar.ts", line: 2, issue: "An error", suggestion: "Fix e" },
+  ],
+});
+
+const INFO_ONLY_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    { severity: "info", category: "abandonment", file: "src/baz.ts", line: 3, issue: "Just info", suggestion: "FYI" },
+  ],
+});
+
+function makeMockAgent(response: string): AgentAdapter {
+  return {
+    name: "mock",
+    displayName: "Mock",
+    binary: "mock",
+    capabilities: { supportedTiers: [], supportedTestStrategies: [], features: {} } as unknown as AgentAdapter["capabilities"],
+    isInstalled: mock(async () => true),
+    run: mock(async () => ({ output: response, estimatedCost: 0 })),
+    buildCommand: mock(() => []),
+    plan: mock(async () => { throw new Error("not used"); }),
+    decompose: mock(async () => { throw new Error("not used"); }),
+    complete: mock(async () => response),
+  } as unknown as AgentAdapter;
+}
+
+function makeSpawnMock(stdout = STAT_OUTPUT) {
+  return mock((_opts: unknown) => ({
+    exited: Promise.resolve(0),
+    stdout: new ReadableStream({
+      start(c) { c.enqueue(new TextEncoder().encode(stdout)); c.close(); },
+    }),
+    stderr: new ReadableStream({ start(c) { c.close(); } }),
+    kill: () => {},
+  })) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+// ---------------------------------------------------------------------------
+// Saved deps
+// ---------------------------------------------------------------------------
+
+let origSpawn: typeof _diffUtilsDeps.spawn;
+let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
+let origReadAcpSession: typeof _adversarialDeps.readAcpSession;
+let origWriteReviewAudit: typeof _adversarialDeps.writeReviewAudit;
+
+beforeEach(() => {
+  origSpawn = _diffUtilsDeps.spawn;
+  origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+  origGetMergeBase = _diffUtilsDeps.getMergeBase;
+  origReadAcpSession = _adversarialDeps.readAcpSession;
+  origWriteReviewAudit = _adversarialDeps.writeReviewAudit;
+  _diffUtilsDeps.isGitRefValid = mock(async () => true);
+  _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+  _diffUtilsDeps.spawn = makeSpawnMock();
+  _adversarialDeps.readAcpSession = mock(async () => null);
+  _adversarialDeps.writeReviewAudit = mock(async () => {});
+});
+
+afterEach(() => {
+  _diffUtilsDeps.spawn = origSpawn;
+  _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+  _diffUtilsDeps.getMergeBase = origGetMergeBase;
+  _adversarialDeps.readAcpSession = origReadAcpSession;
+  _adversarialDeps.writeReviewAudit = origWriteReviewAudit;
+});
+
+// ---------------------------------------------------------------------------
+// Default threshold ("error")
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — blockingThreshold defaults to 'error'", () => {
+  test("warning finding goes to advisoryFindings, not findings, by default", async () => {
+    const result = await runAdversarialReview("/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(WARNING_ONLY_RESPONSE));
+
+    expect(result.success).toBe(true);
+    expect(!result.findings || result.findings.length === 0).toBe(true);
+    expect(result.advisoryFindings).toBeDefined();
+    expect(result.advisoryFindings![0].message).toBe("A warning");
+  });
+
+  test("error finding blocks by default", async () => {
+    const result = await runAdversarialReview("/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(ERROR_ONLY_RESPONSE));
+
+    expect(result.success).toBe(false);
+    expect(result.findings!.length).toBe(1);
+    expect(!result.advisoryFindings || result.advisoryFindings.length === 0).toBe(true);
+  });
+
+  test("mixed: error blocks, warning advisory by default", async () => {
+    const result = await runAdversarialReview("/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(MIXED_RESPONSE));
+
+    expect(result.success).toBe(false);
+    expect(result.findings!.length).toBe(1);
+    expect(result.findings![0].message).toBe("An error");
+    expect(result.advisoryFindings!.length).toBe(1);
+    expect(result.advisoryFindings![0].message).toBe("A warning");
+  });
+
+  test("info finding goes to advisoryFindings by default", async () => {
+    const result = await runAdversarialReview("/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(INFO_ONLY_RESPONSE));
+
+    expect(result.success).toBe(true);
+    expect(!result.findings || result.findings.length === 0).toBe(true);
+    expect(result.advisoryFindings!.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "warning" threshold
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — blockingThreshold: 'warning'", () => {
+  test("warning finding blocks when threshold is 'warning'", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(WARNING_ONLY_RESPONSE),
+      undefined, undefined, undefined, "warning",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.findings!.length).toBe(1);
+    expect(!result.advisoryFindings || result.advisoryFindings.length === 0).toBe(true);
+  });
+
+  test("info finding remains advisory when threshold is 'warning'", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(INFO_ONLY_RESPONSE),
+      undefined, undefined, undefined, "warning",
+    );
+
+    expect(result.success).toBe(true);
+    expect(!result.findings || result.findings.length === 0).toBe(true);
+    expect(result.advisoryFindings!.length).toBe(1);
+  });
+
+  test("both error and warning block when threshold is 'warning'", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(MIXED_RESPONSE),
+      undefined, undefined, undefined, "warning",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.findings!.length).toBe(2);
+    expect(!result.advisoryFindings || result.advisoryFindings.length === 0).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "info" threshold
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — blockingThreshold: 'info'", () => {
+  test("info finding blocks when threshold is 'info'", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(INFO_ONLY_RESPONSE),
+      undefined, undefined, undefined, "info",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.findings!.length).toBe(1);
+    expect(!result.advisoryFindings || result.advisoryFindings.length === 0).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// advisoryFindings absent when no advisory findings
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — advisoryFindings absent when no advisory findings", () => {
+  test("advisoryFindings is undefined when all findings block", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(MIXED_RESPONSE),
+      undefined, undefined, undefined, "warning",
+    );
+
+    expect(result.advisoryFindings).toBeUndefined();
+  });
+
+  test("advisoryFindings is undefined when passed=true with no findings", async () => {
+    const result = await runAdversarialReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG,
+      () => makeMockAgent(JSON.stringify({ passed: true, findings: [] })),
+    );
+
+    expect(result.advisoryFindings).toBeUndefined();
+  });
+});

--- a/test/unit/review/adversarial.test.ts
+++ b/test/unit/review/adversarial.test.ts
@@ -307,7 +307,7 @@ describe("runAdversarialReview — fail with warn finding", () => {
 
   afterEach(restoreAllDeps);
 
-  test("returns success=false when LLM returns findings with severity 'warn'", async () => {
+  test("returns success=true with advisory findings when LLM returns 'warn' severity (advisory at default threshold)", async () => {
     const agent = makeAgent(FAILING_WARN_RESPONSE);
 
     const result = await runAdversarialReview(
@@ -318,7 +318,10 @@ describe("runAdversarialReview — fail with warn finding", () => {
       () => agent,
     );
 
-    expect(result.success).toBe(false);
+    // warn is advisory at default "error" threshold — passes with advisory findings
+    expect(result.success).toBe(true);
+    expect(result.advisoryFindings).toBeDefined();
+    expect(result.advisoryFindings![0].message).toBe("Token never invalidated on logout");
   });
 });
 

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -487,6 +487,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
       undefined,
       undefined,
       undefined,
+      undefined, // blockingThreshold
     );
   });
 
@@ -520,6 +521,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
       undefined,
       undefined,
       undefined,
+      undefined, // blockingThreshold
     );
   });
 });

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -422,10 +422,12 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       DEBATE_REVIEW_ENABLED_CONFIG,
     );
 
-    const findings = result.findings ?? [];
-    const files = findings.map((f) => f.file);
-    // Expect both files to appear (no under-merging)
-    expect(files).toContain("src/review/semantic.ts");
-    expect(files).toContain("src/cli/plan.ts");
+    // PROPOSAL_FAIL_A has error finding (blocking), PROPOSAL_FAIL_B adds a warn finding (advisory at default threshold)
+    const blockingFiles = (result.findings ?? []).map((f) => f.file);
+    const advisoryFiles = (result.advisoryFindings ?? []).map((f) => f.file);
+    const allFiles = [...blockingFiles, ...advisoryFiles];
+    // Expect both files to appear (no under-merging) — one blocking, one advisory
+    expect(allFiles).toContain("src/review/semantic.ts");
+    expect(allFiles).toContain("src/cli/plan.ts");
   });
 });

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -116,13 +116,13 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
     expect(result.findings![0].message).toBe("Missing wiring in runner");
   });
 
-  test("sets source='semantic-review' on each ReviewFinding", async () => {
+  test("sets source='semantic-review' on blocking ReviewFindings", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
         { severity: "error", file: "src/a.ts", line: 1, issue: "An issue", suggestion: "Fix" },
-        { severity: "warn", file: "src/b.ts", line: 2, issue: "Another issue", suggestion: "Fix" },
+        { severity: "error", file: "src/b.ts", line: 2, issue: "Another issue", suggestion: "Fix" },
       ],
     });
     const agent = makeMockAgent(llmResponse);
@@ -134,7 +134,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
     }
   });
 
-  test("sets ruleId='semantic' on each ReviewFinding", async () => {
+  test("sets ruleId='semantic' on advisory ReviewFinding (info severity)", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
@@ -146,7 +146,8 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CFG, () => agent);
 
-    expect(result.findings![0].ruleId).toBe("semantic");
+    // info is advisory by default — check advisoryFindings
+    expect(result.advisoryFindings![0].ruleId).toBe("semantic");
   });
 
   test("maps finding.file to ReviewFinding.file", async () => {
@@ -194,7 +195,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
     expect(result.findings![0].severity).toBe("error");
   });
 
-  test("normalises severity 'warn' to 'warning' in ReviewFinding", async () => {
+  test("normalises severity 'warn' to 'warning' in advisoryFindings (advisory at default threshold)", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
@@ -206,10 +207,11 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CFG, () => agent);
 
-    expect(result.findings![0].severity).toBe("warning");
+    // warn → warning, placed in advisoryFindings at default "error" threshold
+    expect(result.advisoryFindings![0].severity).toBe("warning");
   });
 
-  test("maps 'info' severity as-is to ReviewFinding.severity", async () => {
+  test("maps 'info' severity as-is into advisoryFindings (advisory at default threshold)", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
@@ -221,10 +223,11 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CFG, () => agent);
 
-    expect(result.findings![0].severity).toBe("info");
+    // info is advisory at default "error" threshold
+    expect(result.advisoryFindings![0].severity).toBe("info");
   });
 
-  test("populates findings for all LLM findings when multiple are returned", async () => {
+  test("splits multiple findings into blocking (error) and advisory (warn/info) by default", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff");
     const llmResponse = JSON.stringify({
       passed: false,
@@ -238,10 +241,13 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
 
     const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CFG, () => agent);
 
-    expect(result.findings!.length).toBe(3);
-    expect(result.findings![1].message).toBe("Issue B");
-    expect(result.findings![1].file).toBe("src/b.ts");
-    expect(result.findings![1].severity).toBe("warning");
+    // Only error blocks by default
+    expect(result.findings!.length).toBe(1);
+    expect(result.findings![0].message).toBe("Issue A");
+    // warn + info are advisory
+    expect(result.advisoryFindings!.length).toBe(2);
+    expect(result.advisoryFindings![0].message).toBe("Issue B");
+    expect(result.advisoryFindings![0].severity).toBe("warning");
   });
 
   test("result.findings is empty or absent when LLM returns passed=true", async () => {

--- a/test/unit/review/semantic-threshold.test.ts
+++ b/test/unit/review/semantic-threshold.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Unit tests for blockingThreshold in runSemanticReview.
+ *
+ * Tests cover:
+ * - default ("error"): warnings are advisory, errors block
+ * - "warning" threshold: warnings become blocking
+ * - advisoryFindings is populated with below-threshold findings
+ * - success=true when all findings are below threshold
+ * - "info" threshold: all findings block
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AgentAdapter } from "../../../src/agents/types";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
+import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
+import type { SemanticStory } from "../../../src/review/semantic";
+import type { SemanticReviewConfig } from "../../../src/review/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STORY: SemanticStory = {
+  id: "US-THR",
+  title: "Threshold tests",
+  description: "Validate blocking threshold logic",
+  acceptanceCriteria: ["blockingThreshold controls which findings block"],
+};
+
+const BASE_CFG: SemanticReviewConfig = {
+  modelTier: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
+  rules: [],
+  excludePatterns: [":!test/"],
+  timeoutMs: 60_000,
+};
+
+// LLM response: one warning, one error
+const MIXED_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    { severity: "warning", file: "src/foo.ts", line: 1, issue: "A warning", suggestion: "Fix warning" },
+    { severity: "error", file: "src/bar.ts", line: 2, issue: "An error", suggestion: "Fix error" },
+  ],
+});
+
+// LLM response: only a warning
+const WARNING_ONLY_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    { severity: "warning", file: "src/foo.ts", line: 1, issue: "Just a warning", suggestion: "Fix it" },
+  ],
+});
+
+// LLM response: only an info finding
+const INFO_ONLY_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    { severity: "info", file: "src/foo.ts", line: 1, issue: "Just info", suggestion: "FYI" },
+  ],
+});
+
+function makeMockAgent(response: string): AgentAdapter {
+  return {
+    name: "mock",
+    displayName: "Mock",
+    binary: "mock",
+    capabilities: { supportedTiers: [], supportedTestStrategies: [], features: {} } as unknown as AgentAdapter["capabilities"],
+    isInstalled: mock(async () => true),
+    run: mock(async () => ({ output: response, estimatedCost: 0 })),
+    buildCommand: mock(() => []),
+    plan: mock(async () => { throw new Error("not used"); }),
+    decompose: mock(async () => { throw new Error("not used"); }),
+    complete: mock(async () => response),
+  } as unknown as AgentAdapter;
+}
+
+function makeSpawnMock(stdout = "src/foo.ts | 2 ++") {
+  return mock((_opts: unknown) => ({
+    exited: Promise.resolve(0),
+    stdout: new ReadableStream({
+      start(c) { c.enqueue(new TextEncoder().encode(stdout)); c.close(); },
+    }),
+    stderr: new ReadableStream({ start(c) { c.close(); } }),
+    kill: () => {},
+  })) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+// ---------------------------------------------------------------------------
+// Saved deps
+// ---------------------------------------------------------------------------
+
+let origSpawn: typeof _diffUtilsDeps.spawn;
+let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
+let origWriteReviewAudit: typeof _semanticDeps.writeReviewAudit;
+
+beforeEach(() => {
+  origSpawn = _diffUtilsDeps.spawn;
+  origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+  origGetMergeBase = _diffUtilsDeps.getMergeBase;
+  origWriteReviewAudit = _semanticDeps.writeReviewAudit;
+  _diffUtilsDeps.isGitRefValid = mock(async () => true);
+  _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+  _diffUtilsDeps.spawn = makeSpawnMock();
+  _semanticDeps.writeReviewAudit = mock(async () => {});
+});
+
+afterEach(() => {
+  _diffUtilsDeps.spawn = origSpawn;
+  _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+  _diffUtilsDeps.getMergeBase = origGetMergeBase;
+  _semanticDeps.writeReviewAudit = origWriteReviewAudit;
+});
+
+// ---------------------------------------------------------------------------
+// Default threshold ("error")
+// ---------------------------------------------------------------------------
+
+describe("runSemanticReview — blockingThreshold defaults to 'error'", () => {
+  test("warning finding goes to advisoryFindings, not findings, by default", async () => {
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(WARNING_ONLY_RESPONSE));
+
+    expect(result.success).toBe(true);
+    expect(!result.findings || result.findings.length === 0).toBe(true);
+    expect(result.advisoryFindings).toBeDefined();
+    expect(result.advisoryFindings!.length).toBe(1);
+    expect(result.advisoryFindings![0].message).toBe("Just a warning");
+  });
+
+  test("error finding blocks by default (goes to findings)", async () => {
+    const errorOnly = JSON.stringify({
+      passed: false,
+      findings: [{ severity: "error", file: "src/a.ts", line: 1, issue: "An error", suggestion: "Fix" }],
+    });
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(errorOnly));
+
+    expect(result.success).toBe(false);
+    expect(result.findings).toBeDefined();
+    expect(result.findings!.length).toBe(1);
+  });
+
+  test("mixed: error goes to findings, warning to advisoryFindings by default", async () => {
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(MIXED_RESPONSE));
+
+    expect(result.success).toBe(false);
+    expect(result.findings!.length).toBe(1);
+    expect(result.findings![0].message).toBe("An error");
+    expect(result.advisoryFindings!.length).toBe(1);
+    expect(result.advisoryFindings![0].message).toBe("A warning");
+  });
+
+  test("info finding goes to advisoryFindings by default", async () => {
+    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(INFO_ONLY_RESPONSE));
+
+    expect(result.success).toBe(true);
+    expect(!result.findings || result.findings.length === 0).toBe(true);
+    expect(result.advisoryFindings!.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "warning" threshold
+// ---------------------------------------------------------------------------
+
+describe("runSemanticReview — blockingThreshold: 'warning'", () => {
+  test("warning finding blocks when threshold is 'warning'", async () => {
+    const result = await runSemanticReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(WARNING_ONLY_RESPONSE),
+      undefined, undefined, undefined, undefined, "warning",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.findings!.length).toBe(1);
+    expect(!result.advisoryFindings || result.advisoryFindings.length === 0).toBe(true);
+  });
+
+  test("info finding remains advisory when threshold is 'warning'", async () => {
+    const result = await runSemanticReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(INFO_ONLY_RESPONSE),
+      undefined, undefined, undefined, undefined, "warning",
+    );
+
+    expect(result.success).toBe(true);
+    expect(!result.findings || result.findings.length === 0).toBe(true);
+    expect(result.advisoryFindings!.length).toBe(1);
+  });
+
+  test("both error and warning block when threshold is 'warning'", async () => {
+    const result = await runSemanticReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(MIXED_RESPONSE),
+      undefined, undefined, undefined, undefined, "warning",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.findings!.length).toBe(2);
+    expect(!result.advisoryFindings || result.advisoryFindings.length === 0).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "info" threshold
+// ---------------------------------------------------------------------------
+
+describe("runSemanticReview — blockingThreshold: 'info'", () => {
+  test("info finding blocks when threshold is 'info'", async () => {
+    const result = await runSemanticReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(INFO_ONLY_RESPONSE),
+      undefined, undefined, undefined, undefined, "info",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.findings!.length).toBe(1);
+    expect(!result.advisoryFindings || result.advisoryFindings.length === 0).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// advisoryFindings absent when no advisory findings
+// ---------------------------------------------------------------------------
+
+describe("runSemanticReview — advisoryFindings absent when no advisory findings", () => {
+  test("advisoryFindings is undefined when all findings block", async () => {
+    const result = await runSemanticReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG, () => makeMockAgent(MIXED_RESPONSE),
+      undefined, undefined, undefined, undefined, "warning",
+    );
+
+    // Both findings are blocking at "warning" threshold
+    expect(result.advisoryFindings).toBeUndefined();
+  });
+
+  test("advisoryFindings is undefined when passed=true with no findings", async () => {
+    const result = await runSemanticReview(
+      "/tmp/wd", "abc123", STORY, BASE_CFG,
+      () => makeMockAgent(JSON.stringify({ passed: true, findings: [] })),
+    );
+
+    expect(result.advisoryFindings).toBeUndefined();
+  });
+});

--- a/test/unit/review/semantic-unverifiable.test.ts
+++ b/test/unit/review/semantic-unverifiable.test.ts
@@ -121,7 +121,7 @@ describe("unverifiable finding handling", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(result.output).toContain("unverifiable or informational");
+    expect(result.output).toContain("advisory");
   });
 
   test("mixed blocking + unverifiable: only blocking findings cause failure", async () => {
@@ -162,7 +162,7 @@ describe("unverifiable finding handling", () => {
     expect(result.findings?.[0].message).toBe("AC not implemented");
   });
 
-  test("info findings are still blocking (only unverifiable is non-blocking)", async () => {
+  test("info findings are advisory at default 'error' threshold (below blocking threshold)", async () => {
     const response = JSON.stringify({
       passed: false,
       findings: [
@@ -184,8 +184,11 @@ describe("unverifiable finding handling", () => {
       () => agent,
     );
 
-    // info findings still count as blocking — only "unverifiable" is non-blocking
-    expect(result.success).toBe(false);
+    // With default 'error' threshold, info findings are advisory — not blocking
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("advisory");
+    expect(result.advisoryFindings).toBeDefined();
+    expect(result.advisoryFindings![0].message).toBe("Minor observation");
   });
 });
 

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -541,11 +541,11 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
     expect(result.success).toBe(true);
   });
 
-  test("multiple findings all appear in output", async () => {
+  test("multiple blocking findings all appear in output", async () => {
     const multiFindings = JSON.stringify({
       passed: false,
       findings: [
-        { severity: "warn", file: "src/a.ts", line: 1, issue: "Issue A", suggestion: "Fix A" },
+        { severity: "error", file: "src/a.ts", line: 1, issue: "Issue A", suggestion: "Fix A" },
         { severity: "error", file: "src/b.ts", line: 99, issue: "Issue B", suggestion: "Fix B" },
       ],
     });

--- a/test/unit/review/verdict-writer.test.ts
+++ b/test/unit/review/verdict-writer.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for src/review/verdict-writer.ts
+ *
+ * Tests cover:
+ * - Happy path: writes verdict JSON to .nax/review-verdicts/<featureName>/<storyId>.json
+ * - Correct content (storyId, threshold, reviewer breakdown)
+ * - Never throws on write failure (fire-and-forget)
+ * - Uses "_unknown" subfolder when featureName is missing
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _verdictWriterDeps, writeReviewVerdict } from "../../../src/review/verdict-writer";
+import type { ReviewVerdictEntry } from "../../../src/review/verdict-writer";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type WriteFileMock = ReturnType<typeof mock>;
+
+function makeWriteCapture(): { calls: Array<{ path: string; body: string }>; fn: WriteFileMock } {
+  const calls: Array<{ path: string; body: string }> = [];
+  const fn = mock(async (path: string, body: string) => {
+    calls.push({ path, body });
+    return 0;
+  });
+  return { calls, fn };
+}
+
+const ENTRY: ReviewVerdictEntry = {
+  storyId: "US-001",
+  featureName: "my-feature",
+  timestamp: "2026-04-14T00:00:00.000Z",
+  blockingThreshold: "error",
+  reviewers: {
+    semantic: { blocking: 1, advisory: 2, passed: false },
+    adversarial: { blocking: 0, advisory: 1, passed: true },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Saved deps
+// ---------------------------------------------------------------------------
+
+let origFindNaxProjectRoot: typeof _verdictWriterDeps.findNaxProjectRoot;
+let origMkdir: typeof _verdictWriterDeps.mkdir;
+let origWriteFile: typeof _verdictWriterDeps.writeFile;
+
+beforeEach(() => {
+  origFindNaxProjectRoot = _verdictWriterDeps.findNaxProjectRoot;
+  origMkdir = _verdictWriterDeps.mkdir;
+  origWriteFile = _verdictWriterDeps.writeFile;
+
+  // Default happy-path mocks
+  _verdictWriterDeps.findNaxProjectRoot = mock(async () => "/tmp/project");
+  _verdictWriterDeps.mkdir = mock(async () => undefined);
+});
+
+afterEach(() => {
+  _verdictWriterDeps.findNaxProjectRoot = origFindNaxProjectRoot;
+  _verdictWriterDeps.mkdir = origMkdir;
+  _verdictWriterDeps.writeFile = origWriteFile;
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("writeReviewVerdict — happy path", () => {
+  test("writes valid JSON to .nax/review-verdicts/<featureName>/<storyId>.json", async () => {
+    const { calls, fn } = makeWriteCapture();
+    _verdictWriterDeps.writeFile = fn as unknown as unknown as typeof _verdictWriterDeps.writeFile;
+
+    await writeReviewVerdict(ENTRY);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].path).toContain("review-verdicts");
+    expect(calls[0].path).toContain("my-feature");
+    expect(calls[0].path).toEndWith("US-001.json");
+  });
+
+  test("written JSON contains storyId, blockingThreshold and reviewer breakdown", async () => {
+    const { calls, fn } = makeWriteCapture();
+    _verdictWriterDeps.writeFile = fn as unknown as unknown as typeof _verdictWriterDeps.writeFile;
+
+    await writeReviewVerdict(ENTRY);
+
+    const parsed = JSON.parse(calls[0].body) as ReviewVerdictEntry;
+    expect(parsed.storyId).toBe("US-001");
+    expect(parsed.blockingThreshold).toBe("error");
+    expect(parsed.reviewers.semantic?.blocking).toBe(1);
+    expect(parsed.reviewers.semantic?.advisory).toBe(2);
+    expect(parsed.reviewers.adversarial?.blocking).toBe(0);
+    expect(parsed.reviewers.adversarial?.advisory).toBe(1);
+  });
+
+  test("creates directory recursively before writing", async () => {
+    const mkdirCalls: string[] = [];
+    _verdictWriterDeps.mkdir = mock(async (path: string) => {
+      mkdirCalls.push(path);
+      return undefined;
+    });
+    _verdictWriterDeps.writeFile = mock(async () => {}) as unknown as typeof _verdictWriterDeps.writeFile;
+
+    await writeReviewVerdict(ENTRY);
+
+    expect(mkdirCalls).toHaveLength(1);
+    expect(mkdirCalls[0]).toContain("my-feature");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fallback subfolder
+// ---------------------------------------------------------------------------
+
+describe("writeReviewVerdict — featureName missing", () => {
+  test("uses '_unknown' subfolder when featureName is undefined", async () => {
+    const { calls, fn } = makeWriteCapture();
+    _verdictWriterDeps.writeFile = fn as unknown as unknown as typeof _verdictWriterDeps.writeFile;
+
+    await writeReviewVerdict({ ...ENTRY, featureName: undefined });
+
+    expect(calls[0].path).toContain("_unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Never throws
+// ---------------------------------------------------------------------------
+
+describe("writeReviewVerdict — error resilience", () => {
+  test("does not throw when mkdir fails", async () => {
+    _verdictWriterDeps.mkdir = mock(async () => { throw new Error("permission denied"); });
+    _verdictWriterDeps.writeFile = mock(async () => {}) as unknown as typeof _verdictWriterDeps.writeFile;
+
+    await expect(writeReviewVerdict(ENTRY)).resolves.toBeUndefined();
+  });
+
+  test("does not throw when writeFile fails", async () => {
+    _verdictWriterDeps.writeFile = mock(async () => { throw new Error("disk full"); }) as unknown as typeof _verdictWriterDeps.writeFile;
+
+    await expect(writeReviewVerdict(ENTRY)).resolves.toBeUndefined();
+  });
+
+  test("does not throw when findNaxProjectRoot fails", async () => {
+    _verdictWriterDeps.findNaxProjectRoot = mock(async () => { throw new Error("not a git repo"); });
+    _verdictWriterDeps.writeFile = mock(async () => {}) as unknown as typeof _verdictWriterDeps.writeFile;
+
+    await expect(writeReviewVerdict(ENTRY)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `review.blockingThreshold` config (`"error" | "warning" | "info"`, default `"error"`) to split LLM reviewer findings into blocking vs advisory tiers
- Blocking findings fail the review and trigger autofix; advisory findings are surfaced but don't block
- New unified verdict file `.nax/review-verdicts/<featureName>/<storyId>.json` written after each LLM review
- Per-reviewer finding breakdown (`blocking`, `advisory`) in `status.json` under `current.reviewSummary`

## Key changes

| File | Change |
|:-----|:-------|
| `src/config/schemas.ts` | Add `blockingThreshold` with default `"error"` |
| `src/review/types.ts` | Add `advisoryFindings?`, `reviewSummary`, `ReviewerFindingSummary` |
| `src/review/adversarial.ts` + `semantic.ts` | `SEVERITY_RANK`-based threshold; populate `advisoryFindings` |
| `src/review/runner.ts` | Pass `blockingThreshold` to both LLM reviewers |
| `src/review/orchestrator.ts` | Parallel path passes threshold; computes `reviewSummary`; writes verdict |
| `src/review/verdict-writer.ts` (new) | Fire-and-forget verdict file writer with `_deps` injection |
| `src/execution/status-file.ts` + `status-writer.ts` | `reviewSummary` in `current` story; `setReviewSummary()` method |
| `src/execution/iteration-runner.ts` | Propagate `reviewSummary` after pipeline completes |

## Test plan

- [ ] `bun test test/unit/review/semantic-threshold.test.ts` — 10 new tests
- [ ] `bun test test/unit/review/adversarial-threshold.test.ts` — 10 new tests
- [ ] `bun test test/unit/review/verdict-writer.test.ts` — 7 new tests
- [ ] `bun run test` — 1202 pass, 0 fail
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] Closes nathapp-io/nax#448