### PR TITLE
fix(review): align excludePatterns across adversarial and semantic reviewers

### DIFF
--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -324,8 +324,9 @@ export const AdversarialReviewConfigSchema = z.object({
   /** LLM call timeout in milliseconds. Default 600s (matches semantic — no debate path but ref mode may need full tool traversal). */
   timeoutMs: z.number().int().positive().default(600_000),
   /**
-   * Pathspec exclusions applied only in embedded mode.
-   * Default empty — adversarial sees test files (unlike semantic).
+   * Pathspec exclusions applied in embedded mode (to collectDiff) and in ref mode
+   * (shown in the prompt's git commands). Adversarial sees test files — only nax
+   * metadata is excluded by default.
    */
   excludePatterns: z.array(z.string()).default([":!.nax/", ":!.nax-pids"]),
   /**

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -26,7 +26,7 @@ export interface TestInventory {
 export interface AdversarialReviewPromptOptions {
   /** Diff access mode */
   mode: "embedded" | "ref";
-  /** Used when mode === "embedded": full diff (no excludePatterns) */
+  /** Used when mode === "embedded": full diff (excludes .nax/ metadata; includes test files) */
   diff?: string;
   /** Used when mode === "ref": git ref for self-serve diff commands */
   storyGitRef?: string;
@@ -36,6 +36,12 @@ export interface AdversarialReviewPromptOptions {
   priorFailures?: PriorFailure[];
   /** Used when mode === "embedded": pre-computed test file audit */
   testInventory?: TestInventory;
+  /**
+   * Pathspec exclusions for mode === "ref" git commands shown in prompt.
+   * Always merged with ':!.nax/' and ':!.nax-pids'.
+   * Adversarial does NOT exclude test files (unlike semantic).
+   */
+  excludePatterns?: string[];
 }
 
 const ADVERSARIAL_ROLE = `You are an adversarial code reviewer with full access to the repository.
@@ -122,8 +128,11 @@ Severity guide:
 /**
  * Build the diff section for "ref" mode.
  * Instructs the reviewer to self-serve the full diff (including tests) via git commands.
+ * Always excludes .nax/ and .nax-pids metadata paths; test files are included.
  */
-function buildAdversarialRefDiffSection(storyGitRef: string, stat?: string): string {
+function buildAdversarialRefDiffSection(storyGitRef: string, stat?: string, excludePatterns: string[] = []): string {
+  const merged = [...new Set([...excludePatterns, ":!.nax/", ":!.nax-pids"])];
+  const excludeArgs = merged.map((p) => `'${p}'`).join(" ");
   const statBlock = stat ? `## Changed Files Summary\n\n\`\`\`\n${stat}\n\`\`\`\n\n` : "";
 
   return `${statBlock}## Diff Access
@@ -135,21 +144,21 @@ You have access to git commands. Fetch the diff yourself — do NOT ask for it t
 Recommended commands:
 
 \`\`\`bash
-# Full diff including tests (adversarial review sees everything):
-git diff --unified=3 ${storyGitRef}..HEAD
+# Full diff including tests (adversarial review sees everything except nax metadata):
+git diff --unified=3 ${storyGitRef}..HEAD -- . ${excludeArgs}
 
 # Commit history for this story:
 git log --oneline ${storyGitRef}..HEAD
 
 # Files added in this story (for test audit gap):
-git diff --name-only --diff-filter=A ${storyGitRef}..HEAD
+git diff --name-only --diff-filter=A ${storyGitRef}..HEAD -- . ${excludeArgs}
 
 # Show a specific file's full content:
 cat path/to/file.ts
 \`\`\`
 
 **Test audit workflow:**
-1. Run: \`git diff --name-only --diff-filter=A ${storyGitRef}..HEAD\`
+1. Run: \`git diff --name-only --diff-filter=A ${storyGitRef}..HEAD -- . ${excludeArgs}\`
 2. For each new \`src/**.ts\` file, check whether a matching \`test/**/**.test.ts\` was also added.
 3. If a new exported module has no test file, flag it as \`"test-gap"\`.
 
@@ -190,7 +199,7 @@ export class AdversarialReviewPromptBuilder {
     config: AdversarialReviewConfig,
     options: AdversarialReviewPromptOptions,
   ): string {
-    const { mode, diff, storyGitRef, stat, priorFailures, testInventory } = options;
+    const { mode, diff, storyGitRef, stat, priorFailures, testInventory, excludePatterns } = options;
 
     const storyBlock = `## Story Under Review
 
@@ -212,7 +221,7 @@ ${story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n")}
 
     let diffBlock: string;
     if (mode === "ref" && storyGitRef) {
-      diffBlock = buildAdversarialRefDiffSection(storyGitRef, stat);
+      diffBlock = buildAdversarialRefDiffSection(storyGitRef, stat, excludePatterns ?? []);
     } else if (mode === "embedded" && diff) {
       diffBlock = buildAdversarialEmbeddedDiffSection(diff, testInventory);
     } else {

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -182,7 +182,7 @@ export async function runAdversarialReview(
   let testInventory: import("./diff-utils").TestInventory | undefined;
 
   if (diffMode === "embedded") {
-    // Adversarial embedded mode: no excludePatterns — sees test files too.
+    // Adversarial embedded mode: excludes .nax/ metadata but sees test files (unlike semantic).
     diff = await collectDiff(workdir, effectiveRef, adversarialConfig.excludePatterns ?? []);
     if (!diff) {
       return {
@@ -222,6 +222,7 @@ export async function runAdversarialReview(
     stat,
     priorFailures,
     testInventory,
+    excludePatterns: adversarialConfig.excludePatterns,
   });
 
   // Resolve model definition

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -245,7 +245,16 @@ export class ReviewOrchestrator {
           resetRefOnRerun: false,
           rules: [] as string[],
           timeoutMs: 600_000,
-          excludePatterns: [] as string[],
+          excludePatterns: [
+            ":!test/",
+            ":!tests/",
+            ":!*_test.go",
+            ":!*.test.ts",
+            ":!*.spec.ts",
+            ":!**/__tests__/",
+            ":!.nax/",
+            ":!.nax-pids",
+          ] as string[],
         };
         // advConfig is guaranteed non-null here: canParallelize required advConfig?.parallel === true
         const adversarialCfg: AdversarialReviewConfig = advConfig as AdversarialReviewConfig;

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -331,7 +331,7 @@ export async function runReview(
         diffMode: "ref" as const,
         rules: [] as string[],
         timeoutMs: 600_000,
-        excludePatterns: [] as string[],
+        excludePatterns: [":!.nax/", ":!.nax-pids"] as string[],
         parallel: false,
         maxConcurrentSessions: 2,
       };


### PR DESCRIPTION
## What

Fixes three `excludePatterns` inconsistencies in adversarial and semantic review. Closes #452.

## Why

- Adversarial **ref mode** was showing git diff commands in the prompt without any pathspec exclusions — the reviewer could self-serve `.nax/` metadata noise into its analysis.
- The adversarial **runner fallback** (`excludePatterns: []`) and the **parallel semantic fallback** in orchestrator both had empty exclude lists instead of the proper defaults, meaning `.nax/` files (and test files for semantic) could appear in embedded diffs.
- A stale comment claimed adversarial embedded mode used "no excludePatterns" when the code always passed them.

## How

- `buildAdversarialRefDiffSection`: now accepts `excludePatterns`, merges with `:!.nax/` and `:!.nax-pids` (hardcoded, matching `buildRefDiffSection` for semantic), and injects them into all git diff commands in the prompt.
- `AdversarialReviewPromptOptions`: added `excludePatterns?: string[]` field.
- `runAdversarialReview`: passes `adversarialConfig.excludePatterns` to the prompt builder.
- `runner.ts` adversarial fallback: `[]` → `[":!.nax/", ":!.nax-pids"]`.
- `orchestrator.ts` parallel semantic fallback: `[]` → full test-file + nax exclusion list (matching `runner.ts`).
- `schemas.ts`: fixed stale adversarial `excludePatterns` comment.
- `adversarial.ts`: fixed misleading "no excludePatterns" comment.

## Testing

- [ ] Tests added/updated
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes

## Notes

`collectDiff` always merges with `ALWAYS_EXCLUDED` regardless of caller config, so embedded diffs were never at risk of including `.nax/` content. The ref mode prompt is where the gap was real — the reviewer's self-served git commands had no exclusions.