### PR TITLE
chore: release v0.62.0-canary.6 (canary)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.62.0-canary.5",
+  "version": "0.62.0-canary.6",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.62.0-canary.6

Bumps version: 0.62.0-canary.5 → 0.62.0-canary.6

After merging, run:
```bash
git checkout main && git pull origin main
bun run release tag
```