### PR TITLE
fix(acp): discard crash-orphaned sessions via in-flight sidecar status

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -360,7 +360,7 @@ export async function clearAcpSession(
 ): Promise<void> {
   try {
     const path = acpSessionsPath(workdir, featureName);
-    let data: Record<string, string> = {};
+    let data: Record<string, SidecarEntry> = {};
     try {
       const existing = await Bun.file(path).text();
       data = JSON.parse(existing);
@@ -931,6 +931,11 @@ export class AcpAgentAdapter implements AgentAdapter {
       } else if (isSessionBroken) {
         getSafeLogger()?.debug("acp-adapter", "Closing broken session for retry", { sessionName });
         await closeAcpSession(session);
+        // Clear the sidecar so the next run does not see an "in-flight" marker and
+        // emit a misleading crash-orphan warning — a broken session is a clean exit.
+        if (options.featureName && options.storyId) {
+          await clearAcpSession(options.workdir, options.featureName, options.storyId, options.sessionRole);
+        }
       } else if (!runState.succeeded) {
         // BUG-456: Promote from "in-flight" → "open" so the next run knows this
         // is a legitimate retry (not a crash survivor) and safely resumes the session.

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -296,8 +296,19 @@ function acpSessionsPath(workdir: string, featureName: string): string {
   return join(workdir, ".nax", "features", featureName, "acp-sessions.json");
 }
 
-/** Sidecar entry — session name + agent name for correct sweep/close. */
-type SidecarEntry = string | { sessionName: string; agentName: string };
+/**
+ * Sidecar entry — session name, agent name, and lifecycle status.
+ *
+ * status:
+ *   "in-flight"  — session is actively running. If found on the next run, the
+ *                  previous process crashed without reaching the finally block.
+ *                  Treat as stale: discard and create a fresh session.
+ *   "open"       — session was intentionally kept open for retry (e.g. rectification
+ *                  loop). Safe to resume on the next run.
+ *   (absent)     — legacy entry written before this field existed. Treat as "open".
+ */
+type SidecarStatus = "in-flight" | "open";
+type SidecarEntry = string | { sessionName: string; agentName: string; status?: SidecarStatus };
 
 /** Extract sessionName from a sidecar entry (handles legacy string format). */
 function sidecarSessionName(entry: SidecarEntry): string {
@@ -309,6 +320,12 @@ function sidecarAgentName(entry: SidecarEntry): string {
   return typeof entry === "string" ? "claude" : entry.agentName;
 }
 
+/** Extract status from a sidecar entry (absent/legacy entries treated as "open"). */
+function sidecarStatus(entry: SidecarEntry): SidecarStatus {
+  if (typeof entry === "string") return "open";
+  return entry.status ?? "open";
+}
+
 /** Persist a session name to the sidecar file. Best-effort — errors are swallowed. */
 export async function saveAcpSession(
   workdir: string,
@@ -316,6 +333,7 @@ export async function saveAcpSession(
   storyId: string,
   sessionName: string,
   agentName = "claude",
+  status: SidecarStatus = "open",
 ): Promise<void> {
   try {
     const path = acpSessionsPath(workdir, featureName);
@@ -326,7 +344,7 @@ export async function saveAcpSession(
     } catch {
       // File doesn't exist yet — start fresh
     }
-    data[storyId] = { sessionName, agentName };
+    data[storyId] = { sessionName, agentName, status };
     await Bun.write(path, JSON.stringify(data, null, 2));
   } catch (err) {
     getSafeLogger()?.warn("acp-adapter", "Failed to save session to sidecar", { error: String(err) });
@@ -359,12 +377,24 @@ export async function clearAcpSession(
 
 /** Read a persisted session name from the sidecar file. Returns null if not found. */
 export async function readAcpSession(workdir: string, featureName: string, storyId: string): Promise<string | null> {
+  const entry = await readAcpSessionEntry(workdir, featureName, storyId);
+  return entry ? sidecarSessionName(entry) : null;
+}
+
+/**
+ * Read a full sidecar entry (name + agent + status). Returns null if not found.
+ * Use this when you need to inspect the lifecycle status of a persisted session.
+ */
+export async function readAcpSessionEntry(
+  workdir: string,
+  featureName: string,
+  storyId: string,
+): Promise<SidecarEntry | null> {
   try {
     const path = acpSessionsPath(workdir, featureName);
     const existing = await Bun.file(path).text();
     const data: Record<string, SidecarEntry> = JSON.parse(existing);
-    const entry = data[storyId];
-    return entry ? sidecarSessionName(entry) : null;
+    return data[storyId] ?? null;
   } catch {
     return null;
   }
@@ -742,11 +772,26 @@ export class AcpAgentAdapter implements AgentAdapter {
     await client.start();
 
     // 1. Resolve session name: explicit > sidecar > derived
+    // BUG-456: Guard against crash-orphaned sessions. A sidecar entry with
+    // status "in-flight" means the previous run never reached its finally block
+    // (process crashed). Resuming such a session is unsafe — the agent's prior
+    // turn may claim success, causing the implementer to skip re-implementation.
+    // Discard the entry and start with a fresh session name instead.
     let sessionName = options.acpSessionName;
     if (!sessionName && options.featureName && options.storyId) {
       // #90: Key sidecar by storyId:role to prevent verifier resuming implementer's session
       const sidecarKey = options.sessionRole ? `${options.storyId}:${options.sessionRole}` : options.storyId;
-      sessionName = (await readAcpSession(options.workdir, options.featureName, sidecarKey)) ?? undefined;
+      const existingEntry = await readAcpSessionEntry(options.workdir, options.featureName, sidecarKey);
+      if (existingEntry && sidecarStatus(existingEntry) === "in-flight") {
+        getSafeLogger()?.warn("acp-adapter", "Discarding crash-orphaned session — previous run never completed", {
+          sessionName: sidecarSessionName(existingEntry),
+          storyId: options.storyId,
+          sessionRole: options.sessionRole,
+        });
+        await clearAcpSession(options.workdir, options.featureName, options.storyId, options.sessionRole);
+      } else if (existingEntry) {
+        sessionName = sidecarSessionName(existingEntry);
+      }
     }
     sessionName ??= buildSessionName(options.workdir, options.featureName, options.storyId, options.sessionRole);
 
@@ -758,14 +803,16 @@ export class AcpAgentAdapter implements AgentAdapter {
       stage: options.pipelineStage ?? "run",
     });
 
-    // 3. Ensure session (resume existing or create new)
-    const { session, resumed: sessionResumed } = await ensureAcpSession(client, sessionName, agentName, permissionMode);
-
-    // 4. Persist for plan→run continuity
+    // 3. Write "in-flight" marker BEFORE the session starts. If the process
+    // crashes, the finally block never runs, leaving this marker intact.
+    // On the next run the guard above detects "in-flight" and discards the entry.
     if (options.featureName && options.storyId) {
       const sidecarKey = options.sessionRole ? `${options.storyId}:${options.sessionRole}` : options.storyId;
-      await saveAcpSession(options.workdir, options.featureName, sidecarKey, sessionName, agentName);
+      await saveAcpSession(options.workdir, options.featureName, sidecarKey, sessionName, agentName, "in-flight");
     }
+
+    // 5. Ensure session (resume existing or create new)
+    const { session, resumed: sessionResumed } = await ensureAcpSession(client, sessionName, agentName, permissionMode);
 
     let lastResponse: AcpSessionResponse | null = null;
     let timedOut = false;
@@ -885,9 +932,20 @@ export class AcpAgentAdapter implements AgentAdapter {
         getSafeLogger()?.debug("acp-adapter", "Closing broken session for retry", { sessionName });
         await closeAcpSession(session);
       } else if (!runState.succeeded) {
+        // BUG-456: Promote from "in-flight" → "open" so the next run knows this
+        // is a legitimate retry (not a crash survivor) and safely resumes the session.
         getSafeLogger()?.info("acp-adapter", "Keeping session open for retry", { sessionName });
+        if (options.featureName && options.storyId) {
+          const sidecarKey = options.sessionRole ? `${options.storyId}:${options.sessionRole}` : options.storyId;
+          await saveAcpSession(options.workdir, options.featureName, sidecarKey, sessionName, agentName, "open");
+        }
       } else {
+        // keepSessionOpen=true success: also promote to "open" so the next turn resumes safely.
         getSafeLogger()?.debug("acp-adapter", "Keeping session open (keepSessionOpen=true)", { sessionName });
+        if (options.featureName && options.storyId) {
+          const sidecarKey = options.sessionRole ? `${options.storyId}:${options.sessionRole}` : options.storyId;
+          await saveAcpSession(options.workdir, options.featureName, sidecarKey, sessionName, agentName, "open");
+        }
       }
       await client.close().catch(() => {});
     }

--- a/test/unit/agents/acp/adapter-lifecycle.test.ts
+++ b/test/unit/agents/acp/adapter-lifecycle.test.ts
@@ -609,4 +609,21 @@ describe("crash-orphaned session guard", () => {
       expect((entry as { status?: string }).status).toBe("open");
     }
   });
+
+  test("on session error (broken session), sidecar is cleared — not left as in-flight", async () => {
+    // stopReason "error" = broken connection; session is closed but a subsequent run
+    // must NOT see an "in-flight" marker and emit a misleading crash-orphan warning.
+    const session = makeSession({
+      promptFn: async (_: string) => ({
+        messages: [],
+        stopReason: "error",
+      }),
+    });
+    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
+
+    await new AcpAgentAdapter("claude", DEFAULT_CONFIG).run({ ...BASE, workdir: tmpDir });
+
+    const entry = await readAcpSessionEntry(tmpDir, "feat", "US-001");
+    expect(entry).toBeNull();
+  });
 });

--- a/test/unit/agents/acp/adapter-lifecycle.test.ts
+++ b/test/unit/agents/acp/adapter-lifecycle.test.ts
@@ -15,11 +15,13 @@ import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "b
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
 import {
   AcpAgentAdapter,
   _acpAdapterDeps,
   clearAcpSession,
   readAcpSession,
+  readAcpSessionEntry,
   runSessionPrompt,
   saveAcpSession,
   sweepFeatureSessions,
@@ -428,5 +430,183 @@ describe("clearAcpSession — sessionRole key", () => {
 
     const entry = await readAcpSession(tmpDir, featureName, storyId);
     expect(entry).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SidecarEntry status field — readAcpSessionEntry + saveAcpSession
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("sidecar status field", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "nax-sidecar-status-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("saveAcpSession writes in-flight status; readAcpSessionEntry returns it", async () => {
+    await saveAcpSession(tmpDir, "feat", "US-001", "session-abc", "claude", "in-flight");
+    const entry = await readAcpSessionEntry(tmpDir, "feat", "US-001");
+    expect(entry).not.toBeNull();
+    expect(typeof entry).toBe("object");
+    if (entry && typeof entry === "object") {
+      expect((entry as { status?: string }).status).toBe("in-flight");
+    }
+  });
+
+  test("saveAcpSession writes open status; readAcpSessionEntry returns it", async () => {
+    await saveAcpSession(tmpDir, "feat", "US-001", "session-abc", "claude", "open");
+    const entry = await readAcpSessionEntry(tmpDir, "feat", "US-001");
+    expect(entry).not.toBeNull();
+    if (entry && typeof entry === "object") {
+      expect((entry as { status?: string }).status).toBe("open");
+    }
+  });
+
+  test("readAcpSession still returns session name regardless of status", async () => {
+    await saveAcpSession(tmpDir, "feat", "US-002", "session-xyz", "claude", "in-flight");
+    const name = await readAcpSession(tmpDir, "feat", "US-002");
+    expect(name).toBe("session-xyz");
+  });
+
+  test("readAcpSessionEntry returns null when no entry exists", async () => {
+    const entry = await readAcpSessionEntry(tmpDir, "feat", "US-missing");
+    expect(entry).toBeNull();
+  });
+
+  test("legacy string entry treated as open by sidecar (readAcpSessionEntry returns it)", async () => {
+    // Simulate a legacy sidecar written before status field existed
+    const sidecarPath = join(tmpDir, ".nax", "features", "feat", "acp-sessions.json");
+    await Bun.write(sidecarPath, JSON.stringify({ "US-003": "session-legacy" }));
+
+    const entry = await readAcpSessionEntry(tmpDir, "feat", "US-003");
+    expect(entry).toBe("session-legacy"); // legacy string format preserved
+    const name = await readAcpSession(tmpDir, "feat", "US-003");
+    expect(name).toBe("session-legacy");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Crash-orphaned session guard — in-flight detection in _runWithClient
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("crash-orphaned session guard", () => {
+  const origCreateClient = _acpAdapterDeps.createClient;
+  const origSleep = _acpAdapterDeps.sleep;
+
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "nax-crash-guard-test-"));
+    _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
+  });
+
+  afterEach(() => {
+    _acpAdapterDeps.createClient = origCreateClient;
+    _acpAdapterDeps.sleep = origSleep;
+    rmSync(tmpDir, { recursive: true, force: true });
+    mock.restore();
+  });
+
+  const BASE = {
+    prompt: "implement feature",
+    workdir: "",          // set per-test
+    modelTier: "balanced" as const,
+    modelDef: { provider: "anthropic", model: "claude-haiku-4-5" },
+    timeoutSeconds: 30,
+    config: DEFAULT_CONFIG,
+    featureName: "feat",
+    storyId: "US-001",
+  };
+
+  test("creates new session when sidecar entry has status in-flight (crash survivor)", async () => {
+    const loadedNames: string[] = [];
+    const createdNames: string[] = [];
+    const session = makeSession();
+
+    _acpAdapterDeps.createClient = mock((_cmd: string) =>
+      makeClient(session, {
+        createSessionFn: async (opts) => {
+          createdNames.push(opts.sessionName ?? "");
+          return session;
+        },
+        loadSessionFn: async (name: string) => {
+          loadedNames.push(name);
+          return null; // Simulate: no matching session exists in acpx
+        },
+      }),
+    );
+
+    // Pre-seed the sidecar with a stale in-flight entry
+    const staleSessionName = "nax-deadbeef-feat-us-001";
+    await saveAcpSession(tmpDir, "feat", "US-001", staleSessionName, "claude", "in-flight");
+
+    await new AcpAgentAdapter("claude", DEFAULT_CONFIG).run({ ...BASE, workdir: tmpDir });
+
+    // The stale session name must never have been loaded or created
+    expect(loadedNames).not.toContain(staleSessionName);
+    expect(createdNames).not.toContain(staleSessionName);
+    // A fresh session must have been created with a different name
+    expect(createdNames.length).toBeGreaterThan(0);
+    expect(createdNames[0]).not.toBe(staleSessionName);
+  });
+
+  test("stale in-flight sidecar entry is cleared before new session is created", async () => {
+    const session = makeSession();
+    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
+
+    await saveAcpSession(tmpDir, "feat", "US-001", "nax-stale-session", "claude", "in-flight");
+
+    await new AcpAgentAdapter("claude", DEFAULT_CONFIG).run({ ...BASE, workdir: tmpDir });
+
+    // After the run completes successfully, the sidecar should be cleared (success path clears it)
+    const entry = await readAcpSession(tmpDir, "feat", "US-001");
+    expect(entry).toBeNull();
+  });
+
+  test("resumes open session (intentional retry — not a crash)", async () => {
+    const capturedLoads: string[] = [];
+    const session = makeSession();
+
+    _acpAdapterDeps.createClient = mock((_cmd: string) =>
+      makeClient(session, {
+        loadSessionFn: async (name: string) => {
+          capturedLoads.push(name);
+          return session;
+        },
+      }),
+    );
+
+    const openSessionName = "nax-aabbccdd-feat-us-001";
+    await saveAcpSession(tmpDir, "feat", "US-001", openSessionName, "claude", "open");
+
+    await new AcpAgentAdapter("claude", DEFAULT_CONFIG).run({ ...BASE, workdir: tmpDir });
+
+    // loadSession should have been called with the open session name
+    expect(capturedLoads).toContain(openSessionName);
+  });
+
+  test("on intentional failure, sidecar is promoted from in-flight to open", async () => {
+    const session = makeSession({
+      promptFn: async (_: string) => ({
+        messages: [{ role: "assistant", content: "Tests failed." }],
+        stopReason: "cancelled",
+        cumulative_token_usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+    });
+    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
+
+    await new AcpAgentAdapter("claude", DEFAULT_CONFIG).run({ ...BASE, workdir: tmpDir });
+
+    // After a non-success run, entry should exist with status "open" (safe to resume)
+    const entry = await readAcpSessionEntry(tmpDir, "feat", "US-001");
+    expect(entry).not.toBeNull();
+    if (entry && typeof entry === "object") {
+      expect((entry as { status?: string }).status).toBe("open");
+    }
   });
 });

--- a/test/unit/agents/acp/adapter.test.ts
+++ b/test/unit/agents/acp/adapter.test.ts
@@ -34,6 +34,7 @@ export interface MockAcpSession {
 export interface MockAcpClient {
   start(): Promise<void>;
   createSession(opts: { agentName: string; permissionMode: string }): Promise<MockAcpSession>;
+  loadSession?: (name: string, agentName: string, permissionMode: string) => Promise<MockAcpSession | null>;
   close(): Promise<void>;
   cancelActivePrompt(): Promise<void>;
 }
@@ -63,11 +64,13 @@ export function makeClient(
   overrides: {
     startFn?: () => Promise<void>;
     createSessionFn?: (opts: { agentName: string; permissionMode: string; sessionName?: string }) => Promise<MockAcpSession>;
+    loadSessionFn?: (name: string, agentName: string, permissionMode: string) => Promise<MockAcpSession | null>;
   } = {},
 ): MockAcpClient {
   return {
     start: overrides.startFn ?? (async () => {}),
     createSession: overrides.createSessionFn ?? (async (_opts) => session),
+    loadSession: overrides.loadSessionFn,
     close: async () => {},
     cancelActivePrompt: async () => {},
   };


### PR DESCRIPTION
Closes #456.

## Summary

- Adds a two-phase `status` field (`"in-flight"` | `"open"`) to `SidecarEntry` in the ACP session sidecar
- Before a session starts, the sidecar is written with `status: "in-flight"`; if the process crashes, the finally block never runs and this marker persists
- In the finally block, intentional failure and `keepSessionOpen` paths promote the entry to `status: "open"` so the next run safely resumes
- On re-run, an `"in-flight"` entry is detected as a crash survivor — the entry is cleared and a fresh session name is built instead of resuming the stale session
- Legacy sidecar entries (plain string or no status field) are treated as `"open"` for backward compatibility
- `isSessionBroken` path (`stopReason === "error"`) now explicitly clears the sidecar so the next run does not see a misleading `"in-flight"` marker
- Fixed `clearAcpSession` internal type annotation from `Record<string, string>` to `Record<string, SidecarEntry>`
- Added `readAcpSessionEntry()` to return the full sidecar entry (name + agent + status)
- Extended `makeClient` test helper to support `loadSessionFn` override

## Test plan

- [ ] `bun test test/unit/agents/acp/adapter-lifecycle.test.ts` — all new tests pass (sidecar status field, crash-orphaned guard, broken-session sidecar cleared)
- [ ] `bun test test/unit/agents/acp/adapter-session.test.ts test/unit/agents/acp/adapter.test.ts` — no regressions
- [ ] `bun run test:bail` — 1208/1208 pass
- [ ] `bun run typecheck` — clean
- [ ] Manual: run a story, kill the bun process mid-session (SIGKILL), re-run — confirm a fresh session is created and implementer does not skip