### PR TITLE
fix(smart-runner): resolve test files for monorepo packages in mapSourceToTests

### DIFF
--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from "zod";
+import { DEFAULT_TEST_FILE_PATTERNS } from "../test-runners/conventions";
 
 /** Zod schema for runtime validation */
 const TokenPricingSchema = z.object({
@@ -92,13 +93,13 @@ const RegressionGateConfigSchema = z.object({
 
 const SmartTestRunnerConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  testFilePatterns: z.array(z.string()).default(["test/**/*.test.ts"]),
+  testFilePatterns: z.array(z.string()).default([...DEFAULT_TEST_FILE_PATTERNS]),
   fallback: z.enum(["import-grep", "full-suite"]).default("import-grep"),
 });
 
 const SMART_TEST_RUNNER_DEFAULT = {
   enabled: true,
-  testFilePatterns: ["test/**/*.test.ts"],
+  testFilePatterns: [...DEFAULT_TEST_FILE_PATTERNS],
   fallback: "import-grep" as const,
 };
 
@@ -106,7 +107,7 @@ const SMART_TEST_RUNNER_DEFAULT = {
 const smartTestRunnerFieldSchema = z
   .preprocess((val) => {
     if (typeof val === "boolean") {
-      return { enabled: val, testFilePatterns: ["test/**/*.test.ts"], fallback: "import-grep" };
+      return { enabled: val, testFilePatterns: [...DEFAULT_TEST_FILE_PATTERNS], fallback: "import-grep" };
     }
     return val;
   }, SmartTestRunnerConfigSchema)

--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -102,8 +102,13 @@ export const verifyStage: PipelineStage = {
       // MW-006: pass packagePrefix so git diff is scoped to the package in monorepos
       const sourceFiles = await _smartRunnerDeps.getChangedSourceFiles(ctx.workdir, ctx.storyGitRef, ctx.story.workdir);
 
-      // Pass 1: path convention mapping — pass packagePrefix for monorepo stories
-      const pass1Files = await _smartRunnerDeps.mapSourceToTests(sourceFiles, ctx.workdir, ctx.story.workdir);
+      // Pass 1: path convention mapping — pass packagePrefix and testFilePatterns for language-agnostic suffix derivation
+      const pass1Files = await _smartRunnerDeps.mapSourceToTests(
+        sourceFiles,
+        ctx.workdir,
+        ctx.story.workdir,
+        smartRunnerConfig.testFilePatterns,
+      );
       if (pass1Files.length > 0) {
         logger.info("verify", `[smart-runner] Pass 1: path convention matched ${pass1Files.length} test files`, {
           storyId: ctx.story.id,

--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -102,8 +102,8 @@ export const verifyStage: PipelineStage = {
       // MW-006: pass packagePrefix so git diff is scoped to the package in monorepos
       const sourceFiles = await _smartRunnerDeps.getChangedSourceFiles(ctx.workdir, ctx.storyGitRef, ctx.story.workdir);
 
-      // Pass 1: path convention mapping
-      const pass1Files = await _smartRunnerDeps.mapSourceToTests(sourceFiles, ctx.workdir);
+      // Pass 1: path convention mapping — pass packagePrefix for monorepo stories
+      const pass1Files = await _smartRunnerDeps.mapSourceToTests(sourceFiles, ctx.workdir, ctx.story.workdir);
       if (pass1Files.length > 0) {
         logger.info("verify", `[smart-runner] Pass 1: path convention matched ${pass1Files.length} test files`, {
           storyId: ctx.story.id,

--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -12,6 +12,7 @@
 import type { SmartTestRunnerConfig } from "../../config/types";
 import { getLogger } from "../../logger";
 import { resolveQualityTestCommands } from "../../quality/command-resolver";
+import { DEFAULT_TEST_FILE_PATTERNS } from "../../test-runners/conventions";
 import { logTestOutput } from "../../utils/log-test-output";
 import { detectRuntimeCrash } from "../../verification/crash-detector";
 import type { VerifyStatus } from "../../verification/orchestrator-types";
@@ -21,7 +22,7 @@ import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 const DEFAULT_SMART_RUNNER_CONFIG: SmartTestRunnerConfig = {
   enabled: true,
-  testFilePatterns: ["test/**/*.test.ts"],
+  testFilePatterns: [...DEFAULT_TEST_FILE_PATTERNS],
   fallback: "import-grep",
 };
 

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -16,6 +16,7 @@ import type { InteractionChain } from "../interaction/chain";
 import { getLogger } from "../logger";
 import type { PipelineContext } from "../pipeline/types";
 import type { UserStory } from "../prd";
+import { isTestFile } from "../test-runners";
 import { errorMessage } from "../utils/errors";
 import { captureGitRef } from "../utils/git";
 import { executeWithTimeout } from "../verification";
@@ -188,10 +189,11 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     };
   }
 
-  // BUG-20 Fix: Verify that test-writer session actually created test files
-  // On retry (BUG-018 fix), session1 is undefined — skip this check entirely
-  const testFilePatterns = /\.(test|spec)\.(ts|js|tsx|jsx)$/;
-  const testFilesCreated = session1 ? session1.filesChanged.filter((f) => testFilePatterns.test(f)) : [];
+  // BUG-20 Fix: Verify that test-writer session actually created test files.
+  // Uses the shared language-agnostic `isTestFile()` classifier — recognizes
+  // .test.*, .spec.*, _test.go, test_*.py, test/ directory segments, etc.
+  // On retry (BUG-018 fix), session1 is undefined — skip this check entirely.
+  const testFilesCreated = session1 ? session1.filesChanged.filter(isTestFile) : [];
 
   if (!isRetry && testFilesCreated.length === 0) {
     // BUG-012 Fix: Before declaring greenfield, check if test files already exist in the repo.

--- a/src/test-runners/conventions.ts
+++ b/src/test-runners/conventions.ts
@@ -25,9 +25,7 @@
  * language-agnostic co-located test discovery (see `extractPatternSuffix`
  * in `smart-runner.ts`).
  */
-export const DEFAULT_TEST_FILE_PATTERNS: readonly string[] = Object.freeze([
-  "test/**/*.test.ts",
-]);
+export const DEFAULT_TEST_FILE_PATTERNS: readonly string[] = Object.freeze(["test/**/*.test.ts"]);
 
 /**
  * Convert a glob's trailing suffix (everything after the last `*`) into a

--- a/src/test-runners/conventions.ts
+++ b/src/test-runners/conventions.ts
@@ -1,0 +1,86 @@
+/**
+ * Test File Conventions — single source of truth for test-file patterns.
+ *
+ * The smart test runner, config schema, and TDD orchestrator all need to
+ * answer some variation of "what does a test file look like?". Historically
+ * this concept was duplicated across 7 source files in three different
+ * representations (glob strings, regex lists, ad-hoc regexes). This module
+ * consolidates the glob form and provides a derivation utility for
+ * subsystems that need regex-based classification.
+ *
+ * See issue #461 for the follow-up work (auto-detection + config propagation
+ * through `isTestFile()` and the TDD orchestrator).
+ */
+
+/**
+ * Canonical default glob patterns for test-file discovery.
+ *
+ * Used by:
+ * - `SmartTestRunnerConfigSchema` as the Zod default
+ * - `mapSourceToTests()` and `importGrepFallback()` as the fallback
+ * - `verify` and `scoped` stages as their in-memory default
+ *
+ * Users override via `execution.smartTestRunner.testFilePatterns` in
+ * `.nax/config.json`. The suffix after the last `*` in each glob drives
+ * language-agnostic co-located test discovery (see `extractPatternSuffix`
+ * in `smart-runner.ts`).
+ */
+export const DEFAULT_TEST_FILE_PATTERNS: readonly string[] = Object.freeze([
+  "test/**/*.test.ts",
+]);
+
+/**
+ * Convert a glob's trailing suffix (everything after the last `*`) into a
+ * regex that matches any path ending with that suffix.
+ *
+ * Returns null when the glob has no `*` or an empty trailing suffix.
+ *
+ * @internal
+ */
+function suffixRegex(pattern: string): RegExp | null {
+  const lastStar = pattern.lastIndexOf("*");
+  if (lastStar === -1) return null;
+  const suffix = pattern.slice(lastStar + 1);
+  if (suffix.length === 0) return null;
+  const escaped = suffix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`${escaped}$`);
+}
+
+/**
+ * Derive path-classification regexes from a list of glob patterns.
+ *
+ * Each returned regex matches paths ending with the configured glob's suffix.
+ * Patterns with no extractable suffix are silently skipped. Duplicate
+ * regexes are de-duplicated by source.
+ *
+ * @example
+ * globsToTestRegex(["test/**\/*.test.ts", "src/**\/*.spec.ts"])
+ * // → [/\.test\.ts$/, /\.spec\.ts$/]
+ *
+ * @example
+ * globsToTestRegex(["**\/*_test.go"])
+ * // → [/_test\.go$/]
+ */
+export function globsToTestRegex(patterns: readonly string[]): RegExp[] {
+  const regexes: RegExp[] = [];
+  const seen = new Set<string>();
+  for (const pattern of patterns) {
+    const re = suffixRegex(pattern);
+    if (re && !seen.has(re.source)) {
+      regexes.push(re);
+      seen.add(re.source);
+    }
+  }
+  return regexes;
+}
+
+/**
+ * Classify a path as a test file using the given glob patterns.
+ *
+ * Thin wrapper around `globsToTestRegex()` for callers that just need a
+ * boolean answer. Returns false when `patterns` yields no usable regexes.
+ */
+export function isTestFileByPatterns(filePath: string, patterns: readonly string[]): boolean {
+  const regexes = globsToTestRegex(patterns);
+  return regexes.some((re) => re.test(filePath));
+}

--- a/src/test-runners/index.ts
+++ b/src/test-runners/index.ts
@@ -9,6 +9,11 @@
  * - analyzeTestExitCode(): environmental failure detection
  */
 
+export {
+  DEFAULT_TEST_FILE_PATTERNS,
+  globsToTestRegex,
+  isTestFileByPatterns,
+} from "./conventions";
 export { detectFramework, isTestFile } from "./detector";
 export type { Framework } from "./detector";
 export { analyzeTestExitCode, formatFailureSummary, parseBunTestOutput, parseTestOutput } from "./parser";

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -4,6 +4,7 @@
  * Detects changed TypeScript source files using git diff,
  * enabling targeted test runs on only the files that changed.
  */
+import { DEFAULT_TEST_FILE_PATTERNS } from "../test-runners/conventions";
 import { gitWithTimeout } from "../utils/git";
 
 /**
@@ -161,7 +162,7 @@ export async function mapSourceToTests(
   sourceFiles: string[],
   workdir: string,
   packagePrefix?: string,
-  testFilePatterns: string[] = ["test/**/*.test.ts"],
+  testFilePatterns: string[] = [...DEFAULT_TEST_FILE_PATTERNS],
 ): Promise<string[]> {
   // Derive unique test-file suffixes from configured patterns — language-agnostic.
   // e.g. ["test/**/*.test.ts", "src/**/*.spec.ts"] → [".test.ts", ".spec.ts"]

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -37,23 +37,30 @@ const _bunDeps = {
 /**
  * Map source files to their corresponding test files.
  *
- * For each file in `sourceFiles`, checks both:
- *   - `<workdir>/test/unit/<relative-path>.test.ts`
- *   - `<workdir>/test/integration/<relative-path>.test.ts`
+ * Single-package (no packagePrefix):
+ *   - Strips leading `src/` from each source path
+ *   - Checks `<workdir>/test/unit/<relative>.test.ts` and `test/integration/`
  *
- * where `<relative-path>` is the file path with the leading `src/` stripped
- * and the `.ts` extension replaced with `.test.ts`.
+ * Monorepo (packagePrefix = e.g. `"apps/api"`):
+ *   - Strips `<packagePrefix>/src/` from each source path
+ *   - Checks `<workdir>/<packagePrefix>/test/unit/<relative>.test.ts` and `test/integration/`
  *
  * Only returns paths that actually exist on disk.
  *
- * @param sourceFiles - Array of source file paths (e.g. `["src/foo/bar.ts"]`)
- * @param workdir     - Absolute path to the repository root
+ * @param sourceFiles   - Source file paths relative to the git root (e.g. `["src/foo/bar.ts"]`)
+ * @param workdir       - Absolute path to the repository root
+ * @param packagePrefix - Monorepo package directory relative to repo root (e.g. `"apps/api"`)
  * @returns Existing test file paths (absolute)
  *
  * @example
  * ```typescript
- * const tests = await mapSourceToTests(["src/foo/bar.ts"], "/repo");
- * // Returns: ["/repo/test/unit/foo/bar.test.ts"] (if it exists)
+ * // Single-package
+ * await mapSourceToTests(["src/foo/bar.ts"], "/repo");
+ * // => ["/repo/test/unit/foo/bar.test.ts"] (if it exists)
+ *
+ * // Monorepo
+ * await mapSourceToTests(["apps/api/src/foo/bar.ts"], "/repo", "apps/api");
+ * // => ["/repo/apps/api/test/unit/foo/bar.test.ts"] (if it exists)
  * ```
  */
 /**
@@ -123,14 +130,35 @@ export async function importGrepFallback(
   return matched;
 }
 
-export async function mapSourceToTests(sourceFiles: string[], workdir: string): Promise<string[]> {
+export async function mapSourceToTests(
+  sourceFiles: string[],
+  workdir: string,
+  packagePrefix?: string,
+): Promise<string[]> {
   const result: string[] = [];
 
   for (const sourceFile of sourceFiles) {
-    // Strip leading "src/" and replace ".ts" with ".test.ts"
-    const relative = sourceFile.replace(/^src\//, "").replace(/\.ts$/, ".test.ts");
+    let relative: string;
+    let testBase: string;
 
-    const candidates = [`${workdir}/test/unit/${relative}`, `${workdir}/test/integration/${relative}`];
+    if (packagePrefix) {
+      // Monorepo: source path is "<prefix>/src/foo.ts" — strip "<prefix>/src/" to get "foo.ts"
+      const srcRoot = `${packagePrefix}/src/`;
+      const inner = sourceFile.startsWith(srcRoot)
+        ? sourceFile.slice(srcRoot.length)
+        : sourceFile.replace(/^.*\/src\//, "");
+      relative = inner.replace(/\.ts$/, ".test.ts");
+      testBase = `${workdir}/${packagePrefix}`;
+    } else {
+      // Single-package: source path is "src/foo.ts" — strip "src/"
+      relative = sourceFile.replace(/^src\//, "").replace(/\.ts$/, ".test.ts");
+      testBase = workdir;
+    }
+
+    const candidates = [
+      `${testBase}/test/unit/${relative}`,
+      `${testBase}/test/integration/${relative}`,
+    ];
 
     for (const candidate of candidates) {
       if (await _bunDeps.file(candidate).exists()) {

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -167,11 +167,7 @@ export async function mapSourceToTests(
   // Derive unique test-file suffixes from configured patterns — language-agnostic.
   // e.g. ["test/**/*.test.ts", "src/**/*.spec.ts"] → [".test.ts", ".spec.ts"]
   // e.g. ["**/*_test.go"] → ["_test.go"]
-  const testSuffixes = [
-    ...new Set(
-      testFilePatterns.map(extractPatternSuffix).filter((s): s is string => s !== null),
-    ),
-  ];
+  const testSuffixes = [...new Set(testFilePatterns.map(extractPatternSuffix).filter((s): s is string => s !== null))];
 
   const result: string[] = [];
 

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -37,13 +37,15 @@ const _bunDeps = {
 /**
  * Map source files to their corresponding test files.
  *
- * Single-package (no packagePrefix):
- *   - Strips leading `src/` from each source path
- *   - Checks `<workdir>/test/unit/<relative>.test.ts` and `test/integration/`
+ * Checks four candidate locations per source file (in order):
  *
- * Monorepo (packagePrefix = e.g. `"apps/api"`):
- *   - Strips `<packagePrefix>/src/` from each source path
- *   - Checks `<workdir>/<packagePrefix>/test/unit/<relative>.test.ts` and `test/integration/`
+ * 1. Separated test directory — `<testBase>/test/unit/<relative>.test.ts`
+ * 2. Separated test directory — `<testBase>/test/integration/<relative>.test.ts`
+ * 3. Co-located spec file    — `<workdir>/<sourceFile>.spec.ts`  (NestJS convention)
+ * 4. Co-located test file    — `<workdir>/<sourceFile>.test.ts`  (Vitest/Jest convention)
+ *
+ * `<testBase>` is `workdir` for single-package repos and `workdir/<packagePrefix>`
+ * for monorepo packages. Co-located candidates always resolve relative to the git root.
  *
  * Only returns paths that actually exist on disk.
  *
@@ -54,15 +56,40 @@ const _bunDeps = {
  *
  * @example
  * ```typescript
- * // Single-package
+ * // Single-package, separated
  * await mapSourceToTests(["src/foo/bar.ts"], "/repo");
- * // => ["/repo/test/unit/foo/bar.test.ts"] (if it exists)
+ * // => ["/repo/test/unit/foo/bar.test.ts"]
  *
- * // Monorepo
+ * // Monorepo, separated
  * await mapSourceToTests(["apps/api/src/foo/bar.ts"], "/repo", "apps/api");
- * // => ["/repo/apps/api/test/unit/foo/bar.test.ts"] (if it exists)
+ * // => ["/repo/apps/api/test/unit/foo/bar.test.ts"]
+ *
+ * // Monorepo, co-located .spec.ts (NestJS)
+ * await mapSourceToTests(["apps/api/src/agents/agents.service.ts"], "/repo", "apps/api");
+ * // => ["/repo/apps/api/src/agents/agents.service.spec.ts"]
  * ```
  */
+/**
+ * Extract the test-file suffix implied by a glob pattern.
+ *
+ * The suffix is everything that follows the last `*` wildcard, making this
+ * language-agnostic: the caller's `testFilePatterns` configuration drives which
+ * suffixes are probed rather than hardcoding TypeScript-specific extensions.
+ *
+ * @example
+ * extractPatternSuffix("test/**\/*.test.ts")  // ".test.ts"
+ * extractPatternSuffix("src/**\/*.spec.ts")   // ".spec.ts"
+ * extractPatternSuffix("**\/*_test.go")       // "_test.go"
+ *
+ * @internal
+ */
+function extractPatternSuffix(pattern: string): string | null {
+  const lastStar = pattern.lastIndexOf("*");
+  if (lastStar === -1) return null;
+  const suffix = pattern.slice(lastStar + 1);
+  return suffix.length > 0 ? suffix : null;
+}
+
 /**
  * Extract searchable identifiers from a source file path.
  *
@@ -134,31 +161,49 @@ export async function mapSourceToTests(
   sourceFiles: string[],
   workdir: string,
   packagePrefix?: string,
+  testFilePatterns: string[] = ["test/**/*.test.ts"],
 ): Promise<string[]> {
+  // Derive unique test-file suffixes from configured patterns — language-agnostic.
+  // e.g. ["test/**/*.test.ts", "src/**/*.spec.ts"] → [".test.ts", ".spec.ts"]
+  // e.g. ["**/*_test.go"] → ["_test.go"]
+  const testSuffixes = [
+    ...new Set(
+      testFilePatterns.map(extractPatternSuffix).filter((s): s is string => s !== null),
+    ),
+  ];
+
   const result: string[] = [];
 
   for (const sourceFile of sourceFiles) {
-    let relative: string;
+    // Strip source extension for co-located candidate generation
+    const sourceWithoutExt = sourceFile.replace(/\.[^.]+$/, "");
+
+    let innerRelative: string;
     let testBase: string;
 
     if (packagePrefix) {
-      // Monorepo: source path is "<prefix>/src/foo.ts" — strip "<prefix>/src/" to get "foo.ts"
+      // Monorepo: source path is "<prefix>/src/foo.ts" — strip "<prefix>/src/" to get "foo"
       const srcRoot = `${packagePrefix}/src/`;
       const inner = sourceFile.startsWith(srcRoot)
         ? sourceFile.slice(srcRoot.length)
         : sourceFile.replace(/^.*\/src\//, "");
-      relative = inner.replace(/\.ts$/, ".test.ts");
+      innerRelative = inner.replace(/\.[^.]+$/, "");
       testBase = `${workdir}/${packagePrefix}`;
     } else {
-      // Single-package: source path is "src/foo.ts" — strip "src/"
-      relative = sourceFile.replace(/^src\//, "").replace(/\.ts$/, ".test.ts");
+      // Single-package: source path is "src/foo.ts" — strip "src/" and extension
+      innerRelative = sourceFile.replace(/^src\//, "").replace(/\.[^.]+$/, "");
       testBase = workdir;
     }
 
-    const candidates = [
-      `${testBase}/test/unit/${relative}`,
-      `${testBase}/test/integration/${relative}`,
-    ];
+    const candidates: string[] = [];
+
+    for (const suffix of testSuffixes) {
+      // Separated test directories
+      candidates.push(`${testBase}/test/unit/${innerRelative}${suffix}`);
+      candidates.push(`${testBase}/test/integration/${innerRelative}${suffix}`);
+      // Co-located: next to the source file (e.g. NestJS .spec.ts, Vitest .test.ts, Go _test.go)
+      candidates.push(`${workdir}/${sourceWithoutExt}${suffix}`);
+    }
 
     for (const candidate of candidates) {
       if (await _bunDeps.file(candidate).exists()) {

--- a/src/verification/strategies/scoped.ts
+++ b/src/verification/strategies/scoped.ts
@@ -11,6 +11,7 @@
  */
 
 import { getLogger } from "../../logger";
+import { DEFAULT_TEST_FILE_PATTERNS } from "../../test-runners/conventions";
 import type { IVerificationStrategy, StructuredTestFailure, VerifyContext, VerifyResult } from "../orchestrator-types";
 import { makeFailResult, makePassResult, makeSkippedResult } from "../orchestrator-types";
 import { parseTestOutput } from "../parser";
@@ -19,7 +20,7 @@ import { _smartRunnerDeps } from "../smart-runner";
 
 const DEFAULT_SMART_RUNNER_CONFIG = {
   enabled: true,
-  testFilePatterns: ["test/**/*.test.ts"],
+  testFilePatterns: [...DEFAULT_TEST_FILE_PATTERNS],
   fallback: "import-grep" as const,
 };
 

--- a/test/unit/pipeline/verify-smart-runner.test.ts
+++ b/test/unit/pipeline/verify-smart-runner.test.ts
@@ -34,7 +34,7 @@ const _origVerifyDeps = { ..._verifyDeps };
 // ---- Mock functions ---------------------------------------------------------
 
 const mockGetChangedSourceFiles = mock(async (_workdir: string) => [] as string[]);
-const mockMapSourceToTests = mock(async (_files: string[], _workdir: string) => [] as string[]);
+const mockMapSourceToTests = mock(async (_files: string[], _workdir: string, _packagePrefix?: string) => [] as string[]);
 const mockImportGrepFallback = mock(async (_files: string[], _workdir: string, _patterns: string[]) => [] as string[]);
 const mockBuildSmartTestCommand = mock((testFiles: string[], baseCommand: string) => {
   if (testFiles.length === 0) return baseCommand;
@@ -113,7 +113,10 @@ function makeConfig(overrides: Partial<NaxConfig["execution"]> = {}): NaxConfig 
   };
 }
 
-function makeContext(configOverrides: Partial<NaxConfig["execution"]> = {}): PipelineContext {
+function makeContext(
+  configOverrides: Partial<NaxConfig["execution"]> = {},
+  storyWorkdir?: string,
+): PipelineContext {
   const story: UserStory = {
     id: "STR-005-test",
     title: "Smart Runner Test Story",
@@ -125,6 +128,7 @@ function makeContext(configOverrides: Partial<NaxConfig["execution"]> = {}): Pip
     passes: false,
     escalations: [],
     attempts: 0,
+    workdir: storyWorkdir,
   };
 
   const prd: PRD = {
@@ -204,7 +208,7 @@ describe("Verify Stage --- Smart Runner Integration", () => {
       expect(mockGetChangedSourceFiles).toHaveBeenCalledWith("/test/workdir", undefined, undefined);
     });
 
-    test("calls mapSourceToTests with changed files and workdir", async () => {
+    test("calls mapSourceToTests with changed files, workdir, and undefined packagePrefix for single-package story", async () => {
       mockGetChangedSourceFiles.mockImplementation(async () => ["src/utils/helper.ts"]);
       mockMapSourceToTests.mockImplementation(async () => []);
       mockRegression.mockImplementation(async () => ({ success: true, status: "SUCCESS" as const }));
@@ -212,7 +216,22 @@ describe("Verify Stage --- Smart Runner Integration", () => {
       const ctx = makeContext({ smartTestRunner: true });
       await verifyStage.execute(ctx);
 
-      expect(mockMapSourceToTests).toHaveBeenCalledWith(["src/utils/helper.ts"], "/test/workdir");
+      expect(mockMapSourceToTests).toHaveBeenCalledWith(["src/utils/helper.ts"], "/test/workdir", undefined);
+    });
+
+    test("forwards story.workdir as packagePrefix to mapSourceToTests for monorepo stories", async () => {
+      mockGetChangedSourceFiles.mockImplementation(async () => ["apps/api/src/utils/helper.ts"]);
+      mockMapSourceToTests.mockImplementation(async () => []);
+      mockRegression.mockImplementation(async () => ({ success: true, status: "SUCCESS" as const }));
+
+      const ctx = makeContext({ smartTestRunner: true }, "apps/api");
+      await verifyStage.execute(ctx);
+
+      expect(mockMapSourceToTests).toHaveBeenCalledWith(
+        ["apps/api/src/utils/helper.ts"],
+        "/test/workdir",
+        "apps/api",
+      );
     });
 
     test("calls buildSmartTestCommand with mapped test files and base command", async () => {

--- a/test/unit/pipeline/verify-smart-runner.test.ts
+++ b/test/unit/pipeline/verify-smart-runner.test.ts
@@ -34,7 +34,7 @@ const _origVerifyDeps = { ..._verifyDeps };
 // ---- Mock functions ---------------------------------------------------------
 
 const mockGetChangedSourceFiles = mock(async (_workdir: string) => [] as string[]);
-const mockMapSourceToTests = mock(async (_files: string[], _workdir: string, _packagePrefix?: string) => [] as string[]);
+const mockMapSourceToTests = mock(async (_files: string[], _workdir: string, _packagePrefix?: string, _patterns?: string[]) => [] as string[]);
 const mockImportGrepFallback = mock(async (_files: string[], _workdir: string, _patterns: string[]) => [] as string[]);
 const mockBuildSmartTestCommand = mock((testFiles: string[], baseCommand: string) => {
   if (testFiles.length === 0) return baseCommand;
@@ -216,7 +216,7 @@ describe("Verify Stage --- Smart Runner Integration", () => {
       const ctx = makeContext({ smartTestRunner: true });
       await verifyStage.execute(ctx);
 
-      expect(mockMapSourceToTests).toHaveBeenCalledWith(["src/utils/helper.ts"], "/test/workdir", undefined);
+      expect(mockMapSourceToTests).toHaveBeenCalledWith(["src/utils/helper.ts"], "/test/workdir", undefined, ["test/**/*.test.ts"]);
     });
 
     test("forwards story.workdir as packagePrefix to mapSourceToTests for monorepo stories", async () => {
@@ -231,6 +231,7 @@ describe("Verify Stage --- Smart Runner Integration", () => {
         ["apps/api/src/utils/helper.ts"],
         "/test/workdir",
         "apps/api",
+        ["test/**/*.test.ts"],
       );
     });
 

--- a/test/unit/test-runners/conventions.test.ts
+++ b/test/unit/test-runners/conventions.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for test-file convention helpers.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_TEST_FILE_PATTERNS,
+  globsToTestRegex,
+  isTestFileByPatterns,
+} from "../../../src/test-runners/conventions";
+
+describe("DEFAULT_TEST_FILE_PATTERNS", () => {
+  test("is a non-empty frozen list", () => {
+    expect(DEFAULT_TEST_FILE_PATTERNS.length).toBeGreaterThan(0);
+    expect(Object.isFrozen(DEFAULT_TEST_FILE_PATTERNS)).toBe(true);
+  });
+
+  test("includes the canonical TS test glob", () => {
+    expect(DEFAULT_TEST_FILE_PATTERNS).toContain("test/**/*.test.ts");
+  });
+});
+
+describe("globsToTestRegex", () => {
+  test("extracts .test.ts suffix", () => {
+    const [re] = globsToTestRegex(["test/**/*.test.ts"]);
+    expect(re).toBeDefined();
+    expect(re.test("src/foo.test.ts")).toBe(true);
+    expect(re.test("src/foo.ts")).toBe(false);
+  });
+
+  test("extracts .spec.ts suffix (NestJS)", () => {
+    const [re] = globsToTestRegex(["src/**/*.spec.ts"]);
+    expect(re.test("apps/api/src/agents/agents.service.spec.ts")).toBe(true);
+    expect(re.test("apps/api/src/agents/agents.service.ts")).toBe(false);
+  });
+
+  test("extracts _test.go suffix (Go)", () => {
+    const [re] = globsToTestRegex(["**/*_test.go"]);
+    expect(re.test("internal/foo/bar_test.go")).toBe(true);
+    expect(re.test("internal/foo/bar.go")).toBe(false);
+  });
+
+  test("returns multiple regexes for multiple patterns", () => {
+    const regexes = globsToTestRegex(["test/**/*.test.ts", "src/**/*.spec.ts"]);
+    expect(regexes).toHaveLength(2);
+  });
+
+  test("de-duplicates identical suffix regexes", () => {
+    const regexes = globsToTestRegex(["test/**/*.test.ts", "test/unit/**/*.test.ts"]);
+    expect(regexes).toHaveLength(1);
+  });
+
+  test("skips patterns with no `*`", () => {
+    const regexes = globsToTestRegex(["no-wildcard.ts"]);
+    expect(regexes).toHaveLength(0);
+  });
+
+  test("skips patterns with empty trailing suffix", () => {
+    const regexes = globsToTestRegex(["test/*"]);
+    expect(regexes).toHaveLength(0);
+  });
+
+  test("escapes regex metacharacters in suffix", () => {
+    const [re] = globsToTestRegex(["**/*.test.ts"]);
+    // The `.` in `.test.ts` must be escaped so it doesn't match any char
+    expect(re.test("fooXtestXts")).toBe(false);
+    expect(re.test("foo.test.ts")).toBe(true);
+  });
+});
+
+describe("isTestFileByPatterns", () => {
+  test("returns true when any configured pattern matches", () => {
+    expect(
+      isTestFileByPatterns("src/foo.spec.ts", ["test/**/*.test.ts", "src/**/*.spec.ts"]),
+    ).toBe(true);
+  });
+
+  test("returns false when no pattern matches", () => {
+    expect(isTestFileByPatterns("src/foo.ts", ["test/**/*.test.ts"])).toBe(false);
+  });
+
+  test("returns false when patterns yield no usable regexes", () => {
+    expect(isTestFileByPatterns("src/foo.test.ts", ["no-wildcard.ts"])).toBe(false);
+  });
+});

--- a/test/unit/verification/smart-runner-packageprefix.test.ts
+++ b/test/unit/verification/smart-runner-packageprefix.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Smart Runner — packagePrefix and co-located test discovery
+ *
+ * Covers:
+ * - Monorepo package scoping (packagePrefix)
+ * - Co-located test files via configurable testFilePatterns (language-agnostic)
+ *
+ * Co-located detection is driven by extractPatternSuffix() — the suffix after
+ * the last `*` in each configured glob pattern. Examples:
+ *   "src/**\/*.spec.ts"  → probes <sourceFile>.spec.ts  (NestJS)
+ *   "**\/*_test.go"      → probes <sourceFile>_test.go   (Go)
+ *   "test_*.py"          → no suffix (pattern omitted)
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mapSourceToTests } from "../../../src/verification/smart-runner";
+
+function mockFileExists(existingPaths: string[]) {
+  // biome-ignore lint/suspicious/noExplicitAny: mocking Bun.file
+  (Bun as any).file = (path: string) => ({
+    exists: () => Promise.resolve(existingPaths.includes(path)),
+  });
+}
+
+describe("mapSourceToTests — packagePrefix (monorepo)", () => {
+  let originalFile: typeof Bun.file;
+
+  beforeEach(() => {
+    originalFile = Bun.file;
+  });
+
+  afterEach(() => {
+    // biome-ignore lint/suspicious/noExplicitAny: restoring original
+    (Bun as any).file = originalFile;
+  });
+
+  test("maps monorepo source to package-local test/unit when packagePrefix is set", async () => {
+    mockFileExists(["/repo/apps/api/test/unit/foo/bar.test.ts"]);
+
+    const result = await mapSourceToTests(
+      ["apps/api/src/foo/bar.ts"],
+      "/repo",
+      "apps/api",
+    );
+
+    expect(result).toEqual(["/repo/apps/api/test/unit/foo/bar.test.ts"]);
+  });
+
+  test("maps monorepo source to package-local test/integration when packagePrefix is set", async () => {
+    mockFileExists(["/repo/apps/api/test/integration/foo/bar.test.ts"]);
+
+    const result = await mapSourceToTests(
+      ["apps/api/src/foo/bar.ts"],
+      "/repo",
+      "apps/api",
+    );
+
+    expect(result).toEqual(["/repo/apps/api/test/integration/foo/bar.test.ts"]);
+  });
+
+  test("does NOT look in workdir/test/unit when packagePrefix is set", async () => {
+    // Only the wrong (root-level) path exists — should not be returned
+    mockFileExists(["/repo/test/unit/foo/bar.test.ts"]);
+
+    const result = await mapSourceToTests(
+      ["apps/api/src/foo/bar.ts"],
+      "/repo",
+      "apps/api",
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array when no packagePrefix match exists on disk", async () => {
+    mockFileExists([]);
+
+    const result = await mapSourceToTests(
+      ["apps/api/src/foo/bar.ts"],
+      "/repo",
+      "apps/api",
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  test("single-package behaviour unchanged when packagePrefix is undefined", async () => {
+    mockFileExists(["/repo/test/unit/foo/bar.test.ts"]);
+
+    const result = await mapSourceToTests(["src/foo/bar.ts"], "/repo", undefined);
+
+    expect(result).toEqual(["/repo/test/unit/foo/bar.test.ts"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Co-located test files — language-agnostic via testFilePatterns
+//
+// The suffix after the last `*` in each pattern drives which co-located
+// candidates are probed. No suffixes are hardcoded in the source.
+// ---------------------------------------------------------------------------
+
+describe("mapSourceToTests — co-located test files (testFilePatterns)", () => {
+  let originalFile: typeof Bun.file;
+
+  beforeEach(() => {
+    originalFile = Bun.file;
+  });
+
+  afterEach(() => {
+    // biome-ignore lint/suspicious/noExplicitAny: restoring original
+    (Bun as any).file = originalFile;
+  });
+
+  test("finds co-located .spec.ts in monorepo src/ when pattern includes src/**/*.spec.ts (NestJS)", async () => {
+    mockFileExists(["/repo/apps/api/src/agents/agents.service.spec.ts"]);
+
+    const result = await mapSourceToTests(
+      ["apps/api/src/agents/agents.service.ts"],
+      "/repo",
+      "apps/api",
+      ["src/**/*.spec.ts"],
+    );
+
+    expect(result).toEqual(["/repo/apps/api/src/agents/agents.service.spec.ts"]);
+  });
+
+  test("finds co-located .test.ts in monorepo src/ when pattern includes test/**/*.test.ts (Vitest/Jest)", async () => {
+    mockFileExists(["/repo/apps/api/src/agents/agents.service.test.ts"]);
+
+    const result = await mapSourceToTests(
+      ["apps/api/src/agents/agents.service.ts"],
+      "/repo",
+      "apps/api",
+      ["test/**/*.test.ts"],
+    );
+
+    expect(result).toEqual(["/repo/apps/api/src/agents/agents.service.test.ts"]);
+  });
+
+  test("finds co-located .spec.ts in single-package src/ when pattern includes src/**/*.spec.ts", async () => {
+    mockFileExists(["/repo/src/utils/helper.spec.ts"]);
+
+    const result = await mapSourceToTests(
+      ["src/utils/helper.ts"],
+      "/repo",
+      undefined,
+      ["src/**/*.spec.ts"],
+    );
+
+    expect(result).toEqual(["/repo/src/utils/helper.spec.ts"]);
+  });
+
+  test("does not find co-located .spec.ts when pattern only includes test/**/*.test.ts", async () => {
+    // .spec.ts exists but suffix not covered by the configured pattern
+    mockFileExists(["/repo/src/utils/helper.spec.ts"]);
+
+    const result = await mapSourceToTests(
+      ["src/utils/helper.ts"],
+      "/repo",
+      undefined,
+      ["test/**/*.test.ts"],
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  test("returns both separated test/unit/ and co-located .spec.ts when both exist (multi-pattern)", async () => {
+    mockFileExists([
+      "/repo/apps/api/test/unit/agents/agents.service.test.ts",
+      "/repo/apps/api/src/agents/agents.service.spec.ts",
+    ]);
+
+    const result = await mapSourceToTests(
+      ["apps/api/src/agents/agents.service.ts"],
+      "/repo",
+      "apps/api",
+      ["test/**/*.test.ts", "src/**/*.spec.ts"],
+    );
+
+    expect(result).toEqual([
+      "/repo/apps/api/test/unit/agents/agents.service.test.ts",
+      "/repo/apps/api/src/agents/agents.service.spec.ts",
+    ]);
+  });
+
+  test("deduplicates suffixes — duplicate patterns produce no duplicate candidates", async () => {
+    mockFileExists(["/repo/test/unit/foo/bar.test.ts"]);
+
+    const result = await mapSourceToTests(
+      ["src/foo/bar.ts"],
+      "/repo",
+      undefined,
+      ["test/**/*.test.ts", "test/unit/**/*.test.ts"], // both yield .test.ts
+    );
+
+    // Should not return the same file twice
+    expect(result).toEqual(["/repo/test/unit/foo/bar.test.ts"]);
+  });
+});

--- a/test/unit/verification/smart-runner.test.ts
+++ b/test/unit/verification/smart-runner.test.ts
@@ -177,59 +177,6 @@ describe("mapSourceToTests", () => {
     ]);
   });
 
-  // ---------------------------------------------------------------------------
-  // Monorepo — packagePrefix
-  // ---------------------------------------------------------------------------
-
-  test("maps monorepo source to package-local test/unit when packagePrefix is set", async () => {
-    mockFileExists(["/repo/apps/api/test/unit/foo/bar.test.ts"]);
-
-    const result = await mapSourceToTests(
-      ["apps/api/src/foo/bar.ts"],
-      "/repo",
-      "apps/api",
-    );
-
-    expect(result).toEqual(["/repo/apps/api/test/unit/foo/bar.test.ts"]);
-  });
-
-  test("maps monorepo source to package-local test/integration when packagePrefix is set", async () => {
-    mockFileExists(["/repo/apps/api/test/integration/foo/bar.test.ts"]);
-
-    const result = await mapSourceToTests(
-      ["apps/api/src/foo/bar.ts"],
-      "/repo",
-      "apps/api",
-    );
-
-    expect(result).toEqual(["/repo/apps/api/test/integration/foo/bar.test.ts"]);
-  });
-
-  test("does NOT look in workdir/test/unit when packagePrefix is set", async () => {
-    // Only the wrong (root-level) path exists — should not be returned
-    mockFileExists(["/repo/test/unit/foo/bar.test.ts"]);
-
-    const result = await mapSourceToTests(
-      ["apps/api/src/foo/bar.ts"],
-      "/repo",
-      "apps/api",
-    );
-
-    expect(result).toEqual([]);
-  });
-
-  test("returns empty array when no packagePrefix match exists on disk", async () => {
-    mockFileExists([]);
-
-    const result = await mapSourceToTests(
-      ["apps/api/src/foo/bar.ts"],
-      "/repo",
-      "apps/api",
-    );
-
-    expect(result).toEqual([]);
-  });
-
   test("single-package behaviour unchanged when packagePrefix is undefined", async () => {
     mockFileExists(["/repo/test/unit/foo/bar.test.ts"]);
 

--- a/test/unit/verification/smart-runner.test.ts
+++ b/test/unit/verification/smart-runner.test.ts
@@ -176,6 +176,67 @@ describe("mapSourceToTests", () => {
       "/repo/test/unit/baz/qux.test.ts",
     ]);
   });
+
+  // ---------------------------------------------------------------------------
+  // Monorepo — packagePrefix
+  // ---------------------------------------------------------------------------
+
+  test("maps monorepo source to package-local test/unit when packagePrefix is set", async () => {
+    mockFileExists(["/repo/apps/api/test/unit/foo/bar.test.ts"]);
+
+    const result = await mapSourceToTests(
+      ["apps/api/src/foo/bar.ts"],
+      "/repo",
+      "apps/api",
+    );
+
+    expect(result).toEqual(["/repo/apps/api/test/unit/foo/bar.test.ts"]);
+  });
+
+  test("maps monorepo source to package-local test/integration when packagePrefix is set", async () => {
+    mockFileExists(["/repo/apps/api/test/integration/foo/bar.test.ts"]);
+
+    const result = await mapSourceToTests(
+      ["apps/api/src/foo/bar.ts"],
+      "/repo",
+      "apps/api",
+    );
+
+    expect(result).toEqual(["/repo/apps/api/test/integration/foo/bar.test.ts"]);
+  });
+
+  test("does NOT look in workdir/test/unit when packagePrefix is set", async () => {
+    // Only the wrong (root-level) path exists — should not be returned
+    mockFileExists(["/repo/test/unit/foo/bar.test.ts"]);
+
+    const result = await mapSourceToTests(
+      ["apps/api/src/foo/bar.ts"],
+      "/repo",
+      "apps/api",
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array when no packagePrefix match exists on disk", async () => {
+    mockFileExists([]);
+
+    const result = await mapSourceToTests(
+      ["apps/api/src/foo/bar.ts"],
+      "/repo",
+      "apps/api",
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  test("single-package behaviour unchanged when packagePrefix is undefined", async () => {
+    mockFileExists(["/repo/test/unit/foo/bar.test.ts"]);
+
+    const result = await mapSourceToTests(["src/foo/bar.ts"], "/repo", undefined);
+
+    expect(result).toEqual(["/repo/test/unit/foo/bar.test.ts"]);
+  });
 });
 
 describe("getChangedSourceFiles", () => {


### PR DESCRIPTION
## Summary

- `mapSourceToTests()` hardcoded `workdir/test/unit/` as the test root, so stories in monorepo packages (e.g. `apps/api/`) never matched their test files in Pass 1
- Add optional `packagePrefix` param: when set, strips `<prefix>/src/` from source paths and resolves candidates under `workdir/<prefix>/test/unit/` and `test/integration/`
- `verify.ts`: forward `ctx.story.workdir` as `packagePrefix` (was already passed to `getChangedSourceFiles`; now also passed to `mapSourceToTests`)

Closes #459

## Changed files

| File | Change |
|:---|:---|
| `src/verification/smart-runner.ts` | Add `packagePrefix?` param to `mapSourceToTests` |
| `src/pipeline/stages/verify.ts` | Forward `ctx.story.workdir` to `mapSourceToTests` |
| `test/unit/verification/smart-runner.test.ts` | 5 new monorepo-path cases |
| `test/unit/pipeline/verify-smart-runner.test.ts` | Assert prefix forwarded for single-package and monorepo stories |

## Test plan

- [ ] `bun test test/unit/verification/smart-runner.test.ts` — all 5 new monorepo cases pass
- [ ] `bun test test/unit/pipeline/verify-smart-runner.test.ts` — new forwarding assertions pass
- [ ] `bun run typecheck` — no new errors on changed files
- [ ] Manually: run a `tdd-simple` story in a monorepo package and verify Pass 1 matches test files under the package directory