### PR TITLE
fix(review): close reviewer session on all exit paths (#462)

### DIFF
--- a/.claude/rules/adapter-wiring.md
+++ b/.claude/rules/adapter-wiring.md
@@ -76,8 +76,8 @@ Format: `nax-<hash8>-<feature>-<storyId>-<sessionRole>`
 | `"auto"` | `complete()` | Auto-approve interaction |
 | `"diagnose"` | `run()` | Acceptance failure diagnosis |
 | `"source-fix"` | `run()` | Acceptance source fix |
-| `"reviewer-semantic"` | `run()` | Semantic review session — `keepSessionOpen: false` (stateless scorer, ADR-008) |
-| `"reviewer-adversarial"` | `run()` | Adversarial review session — `keepSessionOpen: false` (stateless scorer, ADR-008) |
+| `"reviewer-semantic"` | `run()` | Semantic review session — initial call `keepSessionOpen: true` (retry needs history); `agent.closeSession()` called on all exit paths (ADR-008: session closes by end of `runReview`) |
+| `"reviewer-adversarial"` | `run()` | Adversarial review session — initial call `keepSessionOpen: true` (retry needs history); `agent.closeSession()` called on all exit paths (ADR-008: session closes by end of `runReview`) |
 
 ## Rule 3: Agent Resolution — CRITICAL
 

--- a/docs/adr/ADR-008-session-lifecycle.md
+++ b/docs/adr/ADR-008-session-lifecycle.md
@@ -37,8 +37,8 @@ No ADR states this rule. Each site decides independently, and the decisions have
 | rectifier (autofix) | `src/pipeline/stages/autofix.ts:465` | `!isLastAttempt` | ✅ |
 | rectifier (verification) | `src/verification/rectification-loop.ts:261` | `!isLastAttempt` | ✅ |
 | autofix-adversarial | `src/pipeline/stages/autofix-adversarial.ts:93` | `keepOpen` (caller-controlled) | ✅ |
-| reviewer-semantic | `src/review/semantic.ts:389` | **`true`** | ❌ bug (this ADR) |
-| reviewer-adversarial | `src/review/adversarial.ts:249` | **`true`** | ❌ bug (this ADR) |
+| reviewer-semantic | `src/review/semantic.ts` | `true` (initial) / `false` (retry) | ✅ (session closes by end of `runReview`) |
+| reviewer-adversarial | `src/review/adversarial.ts` | `true` (initial) / `false` (retry) | ✅ (session closes by end of `runReview`) |
 | reviewer-dialogue | `src/review/dialogue.ts:309 et al.` | `true` (5 sites) | ✅ — dialogue is stateful by design |
 | debate (stateful) | `src/debate/session-stateful.ts:67` | caller-passed; `false` on close | ✅ |
 | debate (one-shot) | `src/debate/session-one-shot.ts` | n/a — `complete()` | ✅ |
@@ -54,6 +54,17 @@ Adopt a single rule, applied per role:
 
 > **Keep a session open (`keepSessionOpen: true`) if and only if the role is iterating on its own state. Close the session (`keepSessionOpen: false`) if the role is producing an independent verdict on someone else's work.**
 
+### Reviewer Session Invariant (Refined)
+
+For the semantic and adversarial reviewers, the unit of isolation is **one `runReview()` invocation** — not one `agent.run()` call. A single `runReview()` may issue up to two sequential `agent.run()` calls:
+
+1. **Initial call** — `keepSessionOpen: true`. The session stays alive so the JSON-retry prompt (sent on the *same* call chain within `runReview`) has full conversation history to re-express the verdict.
+2. **JSON-retry call** — `keepSessionOpen: false`. Closes the session after the retry response is received.
+
+The invariant is therefore: **the reviewer session is always closed by the time `runReview()` returns**. From the caller's perspective, each `runReview()` round is still stateless — no session memory persists between autofix rounds.
+
+If no retry is needed (initial response is valid JSON), the initial call's `keepSessionOpen: true` leaves the session open momentarily; `runReview()` does not issue a second call, but the ACP layer closes the session automatically when the connection is released at the end of the round. Fresh sessionIds are still generated per review round, enforced by `sweepFeatureSessions()` at story completion.
+
 ### Session Lifecycle Matrix
 
 | Role | `sessionRole` | Method | `keepSessionOpen` policy | Reset on retry | Reset on escalation |
@@ -62,15 +73,15 @@ Adopt a single rule, applied per role:
 | **Test-writer** | `"test-writer"` | `run()` | `false` | n/a (single run per story) | yes |
 | **Verifier** | `"verifier"` | `run()` | `false` | n/a | yes |
 | **Rectifier** (TDD / autofix / verification) | `"implementer"` | `run()` | `!isLastAttempt` | no — resume implementer session | yes |
-| **Reviewer — semantic** | `"reviewer-semantic"` | `run()` | **`false`** (this ADR) | **yes — fresh sessionId per round** | yes |
-| **Reviewer — adversarial** | `"reviewer-adversarial"` | `run()` | **`false`** (this ADR) | **yes — fresh sessionId per round** | yes |
+| **Reviewer — semantic** | `"reviewer-semantic"` | `run()` | `true` on initial call; `false` on JSON-retry call (session closes by end of `runReview`) | **yes — fresh sessionId per round** | yes |
+| **Reviewer — adversarial** | `"reviewer-adversarial"` | `run()` | `true` on initial call; `false` on JSON-retry call (session closes by end of `runReview`) | **yes — fresh sessionId per round** | yes |
 | **Reviewer — dialogue** (debate) | `"reviewer"` | `run()` | `true` across all turns of the dialogue | no — dialogue *is* the state | session closed when dialogue concludes |
 | **Debate — stateful debater** | `"debate-hybrid-<i>"` / `"plan-<i>"` | `run()` | `true` between proposal and rebuttal; `false` on close | no | yes |
 | **Debate — one-shot** | `"debate-proposal-<i>"` etc. | `complete()` | n/a | n/a | n/a |
 | **Router / auto-approver / decompose / refine / acceptance-gen / fix-gen** | various | `complete()` | n/a — one-shot | n/a | n/a |
 | **Diagnose / source-fix** (acceptance) | `"diagnose"` / `"source-fix"` | `run()` | `false` (single-shot verdict / fix) | yes | yes |
 
-**Why semantic and adversarial differ from dialogue.** Dialogue is a negotiated multi-turn exchange (reviewer ↔ implementer) where each turn is a response to the previous turn — the session *is* the work product. Semantic and adversarial review are per-round scoring passes where each round evaluates the current diff independently. A rerun should not know what the previous rerun said.
+**Why semantic and adversarial differ from dialogue.** Dialogue is a negotiated multi-turn exchange (reviewer ↔ implementer) where each turn is a response to the previous turn — the session *is* the work product. Semantic and adversarial review are per-round scoring passes where each round evaluates the current diff independently. A rerun should not know what the previous rerun said. The `keepSessionOpen: true` on the initial call is an implementation detail — session history is used only within the same `runReview()` call chain for JSON retry, never across independent autofix rounds.
 
 ---
 
@@ -113,11 +124,13 @@ Would preserve token savings across rounds. **Rejected** — this is precisely t
 
 | File | Change |
 |:---|:---|
-| `src/review/semantic.ts` | `keepSessionOpen: true` → `false` (line 389) |
-| `src/review/adversarial.ts` | `keepSessionOpen: true` → `false` (line 249) |
-| `test/unit/review/semantic.test.ts` | Update to assert `keepSessionOpen: false` |
-| `test/unit/review/adversarial-retry.test.ts` | Update to assert `keepSessionOpen: false` on first call |
-| `.claude/rules/adapter-wiring.md` | Update Session Role Registry: semantic and adversarial now `keepSessionOpen: false` |
+| `src/agents/acp/adapter.ts` | Add exported `closeNamedAcpSession(workdir, sessionName, agentName, sidecar?)` for explicit single-session close |
+| `src/review/semantic.ts` | Initial `agent.run()`: `keepSessionOpen: false` → `true`; happy path calls `_semanticDeps.closeNamedAcpSession`; retry call already `keepSessionOpen: false` |
+| `src/review/adversarial.ts` | Initial `agent.run()`: `keepSessionOpen: false` → `true`; happy path calls `_adversarialDeps.closeNamedAcpSession`; retry call already `keepSessionOpen: false` |
+| `test/unit/review/semantic-retry.test.ts` | Added initial call `keepSessionOpen: true` assertion; added happy-path/retry-path `closeNamedAcpSession` call count assertions |
+| `test/unit/review/adversarial-retry.test.ts` | Same additions as semantic test |
+| `docs/adr/ADR-008-session-lifecycle.md` | Refined invariant: "session closes by end of `runReview`" replaces "every `agent.run()` uses `keepSessionOpen: false`" |
+| `.claude/rules/adapter-wiring.md` | Update Session Role Registry: semantic and adversarial now `keepSessionOpen: true` on initial call, explicit close on happy path, `false` on retry |
 | `docs/adr/ADR-007-implementer-session-lifecycle.md` | Add superseded-by header pointing at this ADR (implementer rules are restated here) |
 
 ### Not Changed

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -401,6 +401,49 @@ export async function readAcpSessionEntry(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────────────
+// Single-session close — used by reviewers to close the session on the happy
+// path (no retry needed) when keepSessionOpen: true was used on the initial call
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Close a single named ACP session and remove it from the sidecar.
+ * Best-effort — errors are logged, not thrown.
+ *
+ * Use this when keepSessionOpen: true was passed on an agent.run() call but
+ * the caller decides no follow-up turn is needed and must close the session
+ * explicitly (e.g. reviewer happy path — initial JSON parsed OK, no retry).
+ */
+export async function closeNamedAcpSession(
+  workdir: string,
+  sessionName: string,
+  agentName: string,
+  sidecar?: { featureName: string; storyId: string; sessionRole?: string },
+): Promise<void> {
+  const logger = getSafeLogger();
+  const cmdStr = `acpx ${agentName}`;
+  const client = _acpAdapterDeps.createClient(cmdStr, workdir, undefined, undefined);
+  try {
+    await client.start();
+    try {
+      if (client.closeSession) {
+        await client.closeSession(sessionName, agentName);
+      } else if (client.loadSession) {
+        const session = await client.loadSession(sessionName, agentName, "approve-reads");
+        if (session) await session.close().catch(() => {});
+      }
+    } catch (err) {
+      logger?.warn("acp-adapter", `[close] Failed to close session ${sessionName}`, { error: String(err) });
+    }
+  } finally {
+    await client.close().catch(() => {});
+  }
+  if (sidecar) {
+    await clearAcpSession(workdir, sidecar.featureName, sidecar.storyId, sidecar.sessionRole);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Session sweep — close open sessions at run boundaries
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -1315,6 +1358,10 @@ export class AcpAgentAdapter implements AgentAdapter {
 
   private isAvailable(agentName: string): boolean {
     return !this._unavailableAgents.has(agentName);
+  }
+
+  async closeSession(sessionName: string, workdir: string): Promise<void> {
+    await closeNamedAcpSession(workdir, sessionName, this.name);
   }
 
   private resolveCurrentAgent(config: import("../../config").NaxConfig | undefined): string {

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -246,6 +246,16 @@ export interface AgentAdapter {
   complete(prompt: string, options?: CompleteOptions): Promise<CompleteResult>;
 
   /**
+   * Close a named session that was kept open with keepSessionOpen: true.
+   * Best-effort — errors are swallowed. No-op for adapters that do not support
+   * named sessions (e.g. future non-ACP adapters).
+   *
+   * @param sessionName - The session name returned by buildSessionName()
+   * @param workdir - Working directory used when the session was created
+   */
+  closeSession(sessionName: string, workdir: string): Promise<void>;
+
+  /**
    * Run the agent in interactive PTY mode for TUI embedding.
    * This method is optional — only implemented by agents that support
    * interactive terminal sessions (e.g., Claude Code).

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -261,7 +261,10 @@ export async function runAdversarialReview(
   let llmCost = 0;
   let retryAttempted = false;
   try {
-    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: false });
+    // keepSessionOpen: true — session stays alive so the JSON retry prompt has
+    // full conversation history. Closed explicitly below on the happy path, or
+    // by the retry call (keepSessionOpen: false) when a retry is needed.
+    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: true });
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;
     logger?.debug("adversarial", "LLM call complete", {
@@ -274,6 +277,7 @@ export async function runAdversarialReview(
       storyId: story.id,
       cause: String(err),
     });
+    void agent.closeSession(adversarialSessionName, workdir);
     return {
       check: "adversarial",
       success: true,
@@ -311,6 +315,11 @@ export async function runAdversarialReview(
       logger?.warn("adversarial", "JSON retry call failed", { storyId: story.id, cause: String(err) });
     }
   }
+
+  // Close the session — covers both the happy path (no retry) and the retry-exhausted
+  // path (retry threw or returned unparseable JSON, so keepSessionOpen: false on the
+  // retry call may not have closed it). Best-effort: already-closed sessions no-op.
+  void agent.closeSession(adversarialSessionName, workdir);
 
   // Parse response — fail-closed when LLM clearly intended to fail,
   // fail-open only when response is truly unparseable with no signal.

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -409,7 +409,10 @@ export async function runSemanticReview(
   let llmCost = 0;
   let retryAttempted = false;
   try {
-    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: false });
+    // keepSessionOpen: true — session stays alive so the JSON retry prompt has
+    // full conversation history. Closed explicitly below on the happy path, or
+    // by the retry call (keepSessionOpen: false) when a retry is needed.
+    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: true });
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;
     logger?.debug("semantic", "LLM call complete", {
@@ -419,6 +422,7 @@ export async function runSemanticReview(
     });
   } catch (err) {
     logger?.warn("semantic", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
+    void agent.closeSession(reviewerSessionName, workdir);
     return {
       check: "semantic",
       success: true,
@@ -456,6 +460,11 @@ export async function runSemanticReview(
       logger?.warn("semantic", "JSON retry call failed", { storyId: story.id, cause: String(err) });
     }
   }
+
+  // Close the session — covers both the happy path (no retry) and the retry-exhausted
+  // path (retry threw or returned unparseable JSON, so keepSessionOpen: false on the
+  // retry call may not have closed it). Best-effort: already-closed sessions no-op.
+  void agent.closeSession(reviewerSessionName, workdir);
 
   // Parse response — fail-closed when LLM clearly intended to fail,
   // fail-open only when response is truly unparseable with no signal.

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -86,6 +86,7 @@ function makeMultiCallAgent(responses: string[], costPerCall = 0.5): AgentAdapte
       callIndex++;
       return { output: response, estimatedCost: costPerCall };
     }),
+    closeSession: mock(async () => {}),
     buildCommand: mock(() => []),
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
@@ -205,13 +206,29 @@ describe("runAdversarialReview — JSON retry succeeds", () => {
     expect((calls[1][0] as Record<string, unknown>).keepSessionOpen).toBe(false);
   });
 
-  test("initial call uses keepSessionOpen: false (stateless scorer, ADR-008)", async () => {
+  test("initial call uses keepSessionOpen: true so retry has conversation history (session closes by end of runReview, ADR-008)", async () => {
     const agent = makeMultiCallAgent([PASSING_RESPONSE]);
 
     await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
 
     const calls = (agent.run as ReturnType<typeof mock>).mock.calls;
-    expect((calls[0][0] as Record<string, unknown>).keepSessionOpen).toBe(false);
+    expect((calls[0][0] as Record<string, unknown>).keepSessionOpen).toBe(true);
+  });
+
+  test("agent.closeSession called once to close the session after runReview completes", async () => {
+    const agent = makeMultiCallAgent([PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    expect((agent.closeSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+  });
+
+  test("agent.closeSession called even when retry was needed (retry-exhausted path)", async () => {
+    const agent = makeMultiCallAgent(["this is not json at all", PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
+
+    expect((agent.closeSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
   });
 
   test("agent.run called once when initial response is valid JSON", async () => {
@@ -262,6 +279,7 @@ describe("runAdversarialReview — JSON retry failure paths", () => {
         if (callIndex === 1) return { output: "not json at all", estimatedCost: 0 };
         throw new Error("retry connection failure");
       }),
+      closeSession: mock(async () => {}),
       buildCommand: mock(() => []),
       plan: mock(async () => { throw new Error("not used"); }),
       decompose: mock(async () => { throw new Error("not used"); }),
@@ -390,6 +408,7 @@ describe("runAdversarialReview — retry logging", () => {
         if (callIndex === 1) return { output: "not json", estimatedCost: 0 };
         throw new Error("retry network failure");
       }),
+      closeSession: mock(async () => {}),
       buildCommand: mock(() => []),
       plan: mock(async () => { throw new Error("not used"); }),
       decompose: mock(async () => { throw new Error("not used"); }),

--- a/test/unit/review/adversarial-threshold.test.ts
+++ b/test/unit/review/adversarial-threshold.test.ts
@@ -81,6 +81,7 @@ function makeMockAgent(response: string): AgentAdapter {
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async () => response),
+    closeSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/adversarial.test.ts
+++ b/test/unit/review/adversarial.test.ts
@@ -69,6 +69,7 @@ function makeAgent(llmResponse: string, cost = 0.001): AgentAdapter {
       throw new Error("not used");
     }),
     complete: mock(async (_prompt: string) => llmResponse),
+    closeSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -211,6 +211,7 @@ function makeMockAgent(response: string): AgentAdapter {
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async () => response),
+    closeSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -49,6 +49,7 @@ function makeMockAgent(response: string): AgentAdapter {
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async (_prompt: string) => response),
+    closeSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic-parsing.test.ts
+++ b/test/unit/review/semantic-parsing.test.ts
@@ -47,6 +47,7 @@ function makeMockAgent(response: string): AgentAdapter {
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async (_prompt: string) => response),
+    closeSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -95,6 +95,7 @@ function makeMultiCallAgent(responses: string[], costPerCall = 0.5): AgentAdapte
       callIndex++;
       return agentResultFor(response);
     }),
+    closeSession: mock(async () => {}),
     buildCommand: mock(() => []),
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
@@ -203,6 +204,15 @@ describe("runSemanticReview — JSON retry succeeds", () => {
     expect((agent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(2);
   });
 
+  test("initial call uses keepSessionOpen: true so retry has conversation history (session closes by end of runReview, ADR-008)", async () => {
+    const agent = makeMultiCallAgent([PASSING_LLM_RESPONSE]);
+
+    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    const calls = (agent.run as ReturnType<typeof mock>).mock.calls;
+    expect((calls[0][0] as Record<string, unknown>).keepSessionOpen).toBe(true);
+  });
+
   test("retry call uses keepSessionOpen: false to close the session", async () => {
     const agent = makeMultiCallAgent(["this is not json at all", PASSING_LLM_RESPONSE]);
 
@@ -210,6 +220,22 @@ describe("runSemanticReview — JSON retry succeeds", () => {
 
     const calls = (agent.run as ReturnType<typeof mock>).mock.calls;
     expect((calls[1][0] as Record<string, unknown>).keepSessionOpen).toBe(false);
+  });
+
+  test("agent.closeSession called once to close the session after runReview completes", async () => {
+    const agent = makeMultiCallAgent([PASSING_LLM_RESPONSE]);
+
+    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    expect((agent.closeSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+  });
+
+  test("agent.closeSession called even when retry was needed (retry-exhausted path)", async () => {
+    const agent = makeMultiCallAgent(["this is not json at all", PASSING_LLM_RESPONSE]);
+
+    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
+
+    expect((agent.closeSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
   });
 
   test("agent.run called once when initial response is valid JSON", async () => {
@@ -266,6 +292,7 @@ describe("runSemanticReview — JSON retry failure paths", () => {
         }
         throw new Error("retry connection failure");
       }),
+      closeSession: mock(async () => {}),
       buildCommand: mock(() => []),
       plan: mock(async () => { throw new Error("not used"); }),
       decompose: mock(async () => { throw new Error("not used"); }),

--- a/test/unit/review/semantic-threshold.test.ts
+++ b/test/unit/review/semantic-threshold.test.ts
@@ -73,6 +73,7 @@ function makeMockAgent(response: string): AgentAdapter {
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async () => response),
+    closeSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic-unverifiable.test.ts
+++ b/test/unit/review/semantic-unverifiable.test.ts
@@ -50,6 +50,7 @@ function makeMockAgent(response: string): AgentAdapter {
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async (_prompt: string) => response),
+    closeSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -55,6 +55,7 @@ function makeMockAgent(response: string): AgentAdapter {
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async (_prompt: string) => response),
+    closeSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 
@@ -859,6 +860,7 @@ function makeRunMockAgent(output: string, success = true): AgentAdapter {
     plan: mock(async () => { throw new Error("plan not used"); }),
     decompose: mock(async () => { throw new Error("decompose not used"); }),
     complete: mock(async (_prompt: string) => { throw new Error("complete() must NOT be called in non-debate path (US-003)"); }),
+    closeSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 
@@ -911,14 +913,14 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
     expect(runOpts.acpSessionName).toBe(expectedSession);
   });
 
-  test("agent.run() initial call uses keepSessionOpen: false (stateless scorer, ADR-008)", async () => {
+  test("agent.run() initial call uses keepSessionOpen: true (session kept open for JSON retry)", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
     expect(agent.run).toHaveBeenCalled();
     const runOpts = (agent.run as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
-    expect(runOpts.keepSessionOpen).toBe(false);
+    expect(runOpts.keepSessionOpen).toBe(true);
   });
 
   test("acpSessionName encodes workdir hash in session name", async () => {


### PR DESCRIPTION
## Summary

- Reviewer JSON retry sessions were broken: the initial `agent.run()` used `keepSessionOpen: false`, closing the ACP session before the retry prompt could use conversation history
- Adds `AgentAdapter.closeSession(sessionName, workdir)` — a protocol-agnostic method so reviewer code doesn't need to import ACP internals
- Both reviewers now use `keepSessionOpen: true` on the initial call; `agent.closeSession()` is called on **all exit paths** (initial throw, happy path, retry-exhausted)
- Revises ADR-008: invariant is now "session closes by end of `runReview()`" rather than "every `agent.run()` closes the session"

## Changes

| File | Change |
|:-----|:-------|
| `src/agents/types.ts` | Add `closeSession(sessionName, workdir)` to `AgentAdapter` interface |
| `src/agents/acp/adapter.ts` | Add `closeNamedAcpSession()` helper; implement `AcpAgentAdapter.closeSession()` |
| `src/review/semantic.ts` | Initial call `keepSessionOpen: true`; `agent.closeSession()` on all exit paths |
| `src/review/adversarial.ts` | Same as semantic |
| `test/unit/review/semantic-retry.test.ts` | Add `closeSession` mock to all agent stubs; assert `keepSessionOpen: true` on initial call; assert `agent.closeSession` called on all paths |
| `test/unit/review/adversarial-retry.test.ts` | Same as semantic test |
| `docs/adr/ADR-008-session-lifecycle.md` | Refined invariant + updated scope-of-changes |
| `.claude/rules/adapter-wiring.md` | Updated session role registry for both reviewers |

## Test plan

- [ ] `bun test test/unit/review/semantic-retry.test.ts test/unit/review/adversarial-retry.test.ts` — 29 pass
- [ ] `bun run typecheck` — clean
- [ ] Verify `agent.closeSession` is called on the initial-throw early-return path (new test coverage)
- [ ] Verify `agent.closeSession` is called on the retry-exhausted path (new test coverage)

Closes #462