### PR TITLE
fix(feat-015): address Phase 1+2 code review findings (ADR-009 scope gaps)

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -65,6 +65,7 @@ import {
   profileUseCommand,
 } from "../src/cli/config-profile";
 import { generateCommand } from "../src/cli/generate";
+import { detectCommand } from "../src/commands/detect";
 import { diagnose } from "../src/commands/diagnose";
 import { logsCommand } from "../src/commands/logs";
 import { precheckCommand } from "../src/commands/precheck";
@@ -1031,6 +1032,30 @@ program
         dir: options.dir,
         json: options.json,
         light: options.light,
+      });
+    } catch (err) {
+      console.error(chalk.red(`Error: ${(err as Error).message}`));
+      process.exit(1);
+    }
+  });
+
+// ── detect ───────────────────────────────────────────
+program
+  .command("detect")
+  .description("Detect test-file patterns for the project and optionally persist them")
+  .option("-d, --dir <path>", "Project directory", process.cwd())
+  .option("--apply", "Write detected patterns to .nax/ configs", false)
+  .option("--json", "Machine-readable JSON output", false)
+  .option("--package <dir>", "Restrict detection to a single package directory")
+  .option("--force", "With --apply: overwrite even when testFilePatterns is already set", false)
+  .action(async (options) => {
+    try {
+      await detectCommand({
+        dir: options.dir,
+        apply: options.apply,
+        json: options.json,
+        package: options.package,
+        force: options.force,
       });
     } catch (err) {
       console.error(chalk.red(`Error: ${(err as Error).message}`));

--- a/docs/adr/ADR-009-test-file-pattern-ssot.md
+++ b/docs/adr/ADR-009-test-file-pattern-ssot.md
@@ -1,0 +1,200 @@
+# ADR-009: Test File Pattern — Single Source of Truth
+
+**Status:** Proposed
+**Date:** 2026-04-15
+**Author:** William Khoo, Claude
+**Related:** FEAT-015 spec (`docs/specs/feat-015-test-file-pattern-detection.md`), Issue #461
+
+---
+
+## Context
+
+The concept "is this a test file?" is answered in at least **eight independent places** in the nax codebase, each with its own representation:
+
+| Site | Representation |
+|:---|:---|
+| `src/test-runners/detector.ts` | Hardcoded broad regex list |
+| `src/test-runners/conventions.ts` | Glob suffix matching |
+| `src/context/auto-detect.ts:175` | Inline `includes(".test.")` |
+| `src/plugins/loader.ts:241` | Inline `.endsWith(".test.ts")` |
+| `src/review/diff-utils.ts:165` | Hardcoded basename regex |
+| `src/context/test-scanner.ts:130` | Hardcoded variant generation |
+| `src/review/{semantic,adversarial}` — `excludePatterns` default | Hardcoded git pathspec list |
+| `config.execution.smartTestRunner.testFilePatterns` | User-configurable glob array |
+
+Two config keys encode "what is a test file" with different defaults and formats:
+
+- `execution.smartTestRunner.testFilePatterns` — glob array, default `["test/**/*.test.ts"]`
+- `context.testCoverage.testPattern` — single glob string, default `"**/*.test.{ts,js,tsx,jsx}"`
+
+These can disagree. Four callers of `isTestFile()` in TDD and review code ignore config entirely even though `config` is in scope. The default patterns are TypeScript-centric and wrong for Go, Python, Rust, Java, and polyglot monorepos.
+
+### Observed Failure
+
+The ingredients are in place for silent-wrong-answer bugs:
+
+1. **User sets `testFilePatterns: ["**/*.integration.ts"]`.** The classifier in `src/tdd/isolation.ts` still uses the broad regex and does not recognise `.integration.ts` as a test file. TDD isolation verification passes the implementer session modifying `.integration.ts` — "no test files touched" — when in fact the user considers those files tests.
+
+2. **Review `excludePatterns` goes stale.** The user sets `testFilePatterns: ["**/*.integration.ts"]` but the hardcoded default `excludePatterns: [":!*.test.ts", ":!*.spec.ts", ...]` doesn't include `.integration.ts`. Integration tests are fed into the semantic review diff as if they were source code, wasting review tokens and generating spurious findings.
+
+3. **Polyglot monorepo.** A repo with TS frontend + Go backend under one `.nax/config.json` cannot configure both languages correctly. Setting `testFilePatterns: ["**/*.test.ts", "**/*_test.go"]` classifies files in both packages, but any per-package nuance (e.g. Python service needing `test_*.py`) has no place to live.
+
+4. **Two config keys.** A user who set `context.testCoverage.testPattern` (following old docs) is confused when their TDD isolation check behaves differently from their context coverage scanner. Neither config key's documentation mentions the other.
+
+### The Underlying Rule
+
+Test-file classification should have **one source of truth**, consulted by every site that asks "is this a test file?". The source must:
+
+- Be user-configurable (explicit config wins)
+- Produce every format the codebase already needs (glob / pathspec / regex / dir names)
+- Support monorepo per-package overrides
+- Auto-detect from project signals when the user has not chosen
+- Never silently write to user config files
+
+No ADR establishes this rule. Fixes have been applied site-by-site, and the codebase has drifted into the fragmented state documented above.
+
+---
+
+## Decision
+
+Adopt a single rule for test-file classification:
+
+> **All test-file classification flows through `resolveTestFilePatterns(config, packageDir?)`. The resolver returns `ResolvedTestPatterns`, which exposes glob / pathspec / regex / test-dir forms from one source. Inline test-file checks are forbidden.**
+
+### The Resolution Chain
+
+`resolveTestFilePatterns()` walks a fixed precedence order:
+
+1. **Per-package config** — `.nax/mono/<packageDir>/config.json` if it has `testFilePatterns` set explicitly
+2. **Root config** — `<workdir>/.nax/config.json` if it has `testFilePatterns` set explicitly
+3. **Detection** — `detectTestFilePatterns(packageDir ?? workdir)` (stub in Phase 1, full in Phase 2)
+4. **Fallback** — `DEFAULT_TEST_FILE_PATTERNS` (canonical glob default in `conventions.ts`)
+
+The first non-empty, non-undefined result wins. An explicit empty array (`testFilePatterns: []`) is honoured as "no test files in this scope" — semantically distinct from omitted.
+
+### The Three-Format Output
+
+`ResolvedTestPatterns` is a single struct with four derived artefacts, all consistent with each other:
+
+```typescript
+interface ResolvedTestPatterns {
+  readonly globs: readonly string[];          // **/*.test.ts
+  readonly pathspec: readonly string[];       // :!*.test.ts
+  readonly regex: readonly RegExp[];          // /\.test\.ts$/
+  readonly testDirs: readonly string[];       // ["test", "__tests__"]
+  readonly resolution: "per-package" | "root-config" | "detected" | "fallback";
+}
+```
+
+Consumers pick the format they need; they never translate between formats themselves. `createTestFileClassifier(resolved)` returns a sync `(path) => boolean` for hot-path classification.
+
+### User Override Always Wins
+
+When the user sets a config key explicitly (any value, including `[]`), the resolver returns it **verbatim**. Detection does not override. Fallback does not override. This is the single inviolable rule that lets users reason about their configuration.
+
+Corollary for `review.excludePatterns`: the default derives from `ResolvedTestPatterns.pathspec` + well-known test dirs + nax noise paths **only when `excludePatterns` is omitted**. Any user-set value (even `[]`) is returned as-is. This decouples "what is a test file" from "what should be excluded from review" — two related but distinct concepts.
+
+### No Silent Config Writes
+
+- Pipeline runs (`nax run`, `nax generate`) never write user config. Detection is ephemeral. Cache writes to `.nax/cache/` are permitted (gitignored, derived content).
+- `nax detect` prints; does not write.
+- `nax detect --apply` writes. Explicit opt-in. Monorepo mode writes per-package configs. `--force` overwrites existing user-explicit config; without `--force`, `--apply` is additive-only (writes only where the key is omitted).
+
+### Config Key Consolidation
+
+`context.testCoverage.testPattern` is deprecated and aliased to `execution.smartTestRunner.testFilePatterns` via a migration shim at the raw-JSON config layer. One config key for the concept, project-wide.
+
+---
+
+## Alternatives Considered
+
+### A. Keep scattered classification, just add a new "canonical" helper
+
+Leave existing inline checks; add `resolveTestFilePatterns()` as an opt-in helper. **Rejected.** The observed bugs stem from sites *not* consulting config. A new helper that remains optional does not close the loop — drift will re-emerge. The rule has to be "all sites go through the resolver", enforced by removing the inline alternatives.
+
+### B. Single pattern format (globs only), translate at use sites
+
+Store only globs in `ResolvedTestPatterns`; let callers translate to pathspec or regex as needed. **Rejected.** The translation logic is non-trivial (e.g. glob `**/*.test.ts` → pathspec `:!*.test.ts` involves suffix extraction and prefix inversion). Translating at each use site guarantees that some sites will do it wrong or inconsistently. Producing all formats from one source keeps them guaranteed-consistent and moves the translation logic into one testable place.
+
+### C. Auto-detect always runs and silently persists
+
+Detect on first run, write to `.nax/config.json` automatically. **Rejected.** Silent writes to user-tracked files create merge conflicts, confuse git-blame, and make it hard to explain "why did this line appear in my config?". Explicit `--apply` is a small user-facing cost that buys predictability.
+
+### D. `excludePatterns` derived from `testFilePatterns` always (no user override of derivation)
+
+Force `excludePatterns` to match `testFilePatterns` exclusion. **Rejected.** Users have legitimate reasons to include test files in review (integration-test coverage checks) or to exclude additional paths (vendor/, generated code). The two concepts overlap but are not the same. Deriving only when `excludePatterns` is omitted preserves the override while fixing the staleness bug.
+
+### E. Per-file package discovery instead of `packageDir` parameter
+
+Walk up from every classified file to find its package root. **Rejected for hot paths.** The resolver is async (reads files); calling it per file creates O(N) I/O. The `packageDir` parameter lets callers resolve once per story/package and classify many files synchronously. A `findPackageDir()` utility exists for cases where only a file path is known, but it is not the default path.
+
+### F. New top-level config namespace (e.g. `testing.filePatterns`)
+
+Introduce `testing.filePatterns` at config root and migrate both existing keys. **Rejected.** `execution.smartTestRunner.testFilePatterns` is already the more-used, better-named key. Introducing a third name for the same concept defeats the consolidation goal. Deprecation shim goes one direction only: legacy `testPattern` → `smartTestRunner.testFilePatterns`.
+
+### G. Keep the broad regex in `detector.ts` indefinitely as a safety net
+
+Leave `isTestFile(path)` (no-config form) working forever via hardcoded regex. **Rejected in the long run.** The broad regex IS an inline classifier — the exact pattern this ADR forbids. Compromise: keep it in Phase 1 as an unreachable backward-compat (all callers migrated to the classifier path); remove in Phase 2 once detection fallback guarantees the resolver always yields non-empty patterns.
+
+---
+
+## Consequences
+
+### Positive
+
+- **One mental model.** "Is this a test file?" has one answer per (config, packageDir) pair, consistent across TDD isolation, review exclude, context scanning, plugin loading, and autofix routing.
+- **User config flows end-to-end.** Setting `testFilePatterns` affects every classification site. The silent-wrong-answer bugs listed in Context close.
+- **Polyglot monorepos work.** Per-package `testFilePatterns` lives in `.nax/mono/<pkg>/config.json`. TS frontend and Go backend classify independently.
+- **Safe migration.** TS default configs produce identical effective `excludePatterns` as before (parity proof in spec §4.4). No behavior change for existing users on default config.
+- **Observability.** `ResolvedTestPatterns.resolution` field records which tier resolved the patterns. `nax detect` exposes the same information for debugging. Pipeline logs one info line per run showing the effective patterns + source tier.
+- **Testability.** `_deps` injection points on resolver and detect modules eliminate the need for filesystem mocking in tests. Mirrors the existing project pattern.
+
+### Negative / Trade-offs
+
+- **Wider Phase 1 scope.** Fifteen-plus source files touched in one pass (spec §5). Regression risk is real. Mitigated by: the parity proof for TS default config (§4.4), per-site unit coverage, and the deprecation shim that keeps legacy configs working.
+- **New config schema semantics.** `testFilePatterns`, `excludePatterns`, and legacy `testPattern` all become `.optional()` in Zod. Code that previously relied on the Zod default being present must now handle `undefined` via the resolver. Risk is contained to the migration — every caller is updated in Phase 1.
+- **Runtime cost on cold detection.** Phase 2 detection adds filesystem walks (`git ls-files`, manifest reads). Cached after first run per workdir; mtime-invalidated. Cold cost ≤ 100ms on typical repos (spec §11). Acceptable next to existing pipeline startup cost.
+- **Cache complexity.** `.nax/cache/test-patterns.json` introduces a new runtime artefact. Invalidation is mtime-based (simple and usually correct); edge cases (clock skew, network filesystems with lying mtimes) accept-the-risk with last-write-wins and on-corrupt-rebuild fallbacks. No file locking.
+- **Users with custom `testFilePatterns` get behavior change in review.** Previously their integration tests were included in review diff (because default `excludePatterns` didn't know about custom patterns). After this change, custom patterns flow into derived `excludePatterns` and those tests are excluded. Documented in spec §10 as an **intentional bug fix**. Users who want the old behavior set `excludePatterns` explicitly.
+- **`isTestFile(path)` (no-config) remains available in Phase 1.** The forbidden "inline classification" still exists in the type system as a backward-compat fallback. All first-party callers are migrated; a third-party plugin or agent writing new code could still call the wrong form. Phase 2 removes the footgun.
+
+### Scope of Changes
+
+| File | Change |
+|:---|:---|
+| `src/test-runners/resolver.ts` | **New.** `resolveTestFilePatterns()`, `resolveReviewExcludePatterns()`, `findPackageDir()`; exports `_resolverDeps`. |
+| `src/test-runners/classifier.ts` | **New.** `createTestFileClassifier()`. |
+| `src/test-runners/detect.ts` | **New.** Phase 1 stub; Phase 2 real detection. Exports `_detectDeps`. |
+| `src/test-runners/conventions.ts` | Extend to produce pathspec + regex forms alongside globs. |
+| `src/test-runners/detector.ts` | `isTestFile(path, patterns?)` — thin wrapper; broad regex kept as Phase 1 fallback, removed in Phase 2. |
+| `src/config/schemas.ts` | `testFilePatterns`, `excludePatterns` (semantic + adversarial), `testPattern` → `.optional()`. |
+| `src/config/migrations.ts` | **New.** Raw-JSON migration shim for legacy `testPattern`. Immutable. |
+| `src/tdd/isolation.ts`, `session-runner.ts`, `rectification-gate.ts`, `orchestrator.ts` | Thread `ResolvedTestPatterns`; use classifier. |
+| `src/review/semantic.ts`, `adversarial.ts`, `diff-utils.ts`, `orchestrator.ts`, `runner.ts` | Use `resolveReviewExcludePatterns()`; classifier for file classification; `resolved.regex` for basename stripping. |
+| `src/pipeline/stages/autofix-adversarial.ts` | Classifier from `ctx.rootConfig`. |
+| `src/context/auto-detect.ts`, `test-scanner.ts`, `greenfield.ts`, `builder.ts` | Replace inline checks with classifier; consume `resolved.globs`, `resolved.testDirs`. |
+| `src/plugins/loader.ts` | `isPluginFile()` accepts classifier; `loadPlugins()` (called with config in scope) builds it. |
+| `src/commands/detect.ts` | **New.** `nax detect [--apply] [--json] [--package] [--force]`. Phase 2. |
+| `src/cli/index.ts` | Register `detect` command. Phase 2. |
+| `docs/specs/feat-015-test-file-pattern-detection.md` | Full implementation spec. |
+| `.claude/rules/forbidden-patterns.md` | Add: inline test-file classification outside `src/test-runners/` is forbidden. |
+
+### Not Changed
+
+- `src/test-runners/parser.ts` — parses test framework output format (e.g. "FAIL foo.test.ts:"), not file paths. Output parsing is framework-driven, unrelated to classification.
+- `src/acceptance/test-path.ts` — generates the nax-owned `.nax-acceptance.test.<ext>` filename based on language. Different concept (canonical path for nax-generated tests, not classification of existing files).
+- `src/analyze/scanner.ts` — display-only framework detection used by `nax analyze`. Could optionally consume detected patterns later; not required for this ADR.
+- `src/debate/`, `src/tdd/cleanup.ts`, `src/verification/executor.ts` — no test-file classification occurs in these paths.
+
+---
+
+## References
+
+- FEAT-015 spec — `docs/specs/feat-015-test-file-pattern-detection.md`
+- Issue #461 — original proposal (unify `testFilePatterns`)
+- `.claude/rules/project-conventions.md` — Bun-native, logging with `storyId`, 400-line limit
+- `.claude/rules/forbidden-patterns.md` — `mock.module()` banned; `_deps` pattern required
+- `.claude/rules/error-handling.md` — `NaxError` base class
+- `.claude/rules/config-patterns.md` — Zod schema layering, config SSOT, compatibility shims
+- ADR-005 — Pipeline re-architecture (precedent for SSOT patterns)
+- ADR-008 — Session lifecycle (precedent for "one rule, per-role matrix" structure)

--- a/docs/reviews/feat-015-test-file-pattern-detection-review.md
+++ b/docs/reviews/feat-015-test-file-pattern-detection-review.md
@@ -1,0 +1,66 @@
+# Review: FEAT-015 Test File Pattern Detection
+
+Branch reviewed: `feat/461-unify-test-file-patterns`
+Diff base: `main...HEAD`
+Spec: `docs/specs/feat-015-test-file-pattern-detection.md`
+Review date: 2026-04-15
+
+## Findings
+
+### 1. High: `nax detect --apply` can overwrite an unreadable existing config with a partial file
+
+Files:
+- `src/commands/detect.ts:62`
+- `src/commands/detect.ts:109`
+
+`loadRawConfig()` catches all read and parse failures and returns `{}`. `applyToConfig()` then deep-sets `execution.smartTestRunner.testFilePatterns` and writes that object back to disk.
+
+That means if `.nax/config.json` or `.nax/mono/<pkg>/config.json` is malformed, truncated, or temporarily unreadable, `nax detect --apply` does not fail safely. Instead, it treats the file as empty and overwrites it with a small replacement object containing only the detected test patterns.
+
+This is a destructive behavior regression for a command that is intended to be additive and low-risk.
+
+### 2. Medium: optional `smartTestRunner.testFilePatterns` can crash `ScopedStrategy` on import-grep fallback
+
+Files:
+- `src/verification/strategies/scoped.ts:92`
+- `src/verification/smart-runner.ts:127`
+
+The schema now allows `execution.smartTestRunner.testFilePatterns` to be omitted, which is required for resolver-based fallback behavior.
+
+However, `ScopedStrategy` still passes `smartCfg.testFilePatterns` directly into `importGrepFallback()`. That function expects a real array and immediately reads `.length`.
+
+So a valid config like:
+
+```json
+{
+  "execution": {
+    "smartTestRunner": {
+      "enabled": true,
+      "fallback": "import-grep"
+    }
+  }
+}
+```
+
+can now throw at runtime in the scoped verification strategy. The main verify stage already guards this path with a fallback array, but `ScopedStrategy` does not.
+
+### 3. Medium: review test-inventory pairing still hardcodes `.test/.spec/_test.go` suffixes
+
+Files:
+- `src/review/diff-utils.ts:163`
+- `src/review/diff-utils.ts:168`
+
+`computeTestInventory()` now classifies test files with `isTestFile(f, testFilePatterns)`, so custom and detected patterns can enter `addedTestFiles`.
+
+But the next step still strips only these suffixes from test basenames:
+
+- `.(test|spec).(ts|js|tsx|jsx)`
+- `_test.go`
+
+For custom patterns like `**/*.integration.ts`, or any future detected convention outside that hardcoded list, the file is recognized as a test during classification but is not normalized back to the corresponding source basename during pairing.
+
+The result is false positives in `newSourceFilesWithoutTests`, which reintroduces the SSOT drift this feature is intended to eliminate.
+
+## Assumptions
+
+- `ScopedStrategy` is still live code via `src/verification/orchestrator.ts`, so the runtime risk is real rather than dead code.

--- a/docs/specs/feat-015-test-file-pattern-detection.md
+++ b/docs/specs/feat-015-test-file-pattern-detection.md
@@ -1,0 +1,1086 @@
+# FEAT-015 — Test File Pattern Detection & SSOT
+
+**Status:** Proposal
+**Target:** v0.40.0
+**Issue:** #461
+**Date:** 2026-04-15
+
+---
+
+## 1. Problem
+
+`testFilePatterns` is user-configurable at `config.execution.smartTestRunner.testFilePatterns`, but test-file knowledge is scattered across the codebase in multiple forms with no shared source of truth.
+
+### 1.1 Classification bypass
+
+Several sites classify test files without consulting config:
+
+- `isTestFile(filePath)` in `src/test-runners/detector.ts` — hardcoded broad regex
+- Inline checks in `src/context/auto-detect.ts:175` — `lower.includes(".test.") || lower.includes(".spec.")`
+- Inline checks in `src/plugins/loader.ts:241` — `!filename.endsWith(".test.ts") && !filename.endsWith(".spec.ts")`
+- Basename stripping in `src/review/diff-utils.ts:165` — hardcoded `.test.ts/.spec.ts/_test.go` regex
+- Variant generation in `src/context/test-scanner.ts:130` — hardcoded `.test.ts/.spec.ts/.jsx/...` variants
+
+### 1.2 Duplicate config keys for the same concept
+
+Two config keys encode "what is a test file" with different defaults and formats:
+
+| Config path | Format | Default |
+|:---|:---|:---|
+| `execution.smartTestRunner.testFilePatterns` | glob array | `["test/**/*.test.ts"]` |
+| `context.testCoverage.testPattern` | single glob string | `"**/*.test.{ts,js,tsx,jsx}"` |
+
+These can disagree — user setting one does not affect the other.
+
+### 1.3 Stale derived defaults
+
+`review.semantic.excludePatterns` and `review.adversarial.excludePatterns` default to a hardcoded list `[":!*.test.ts", ":!*.spec.ts", ":!*_test.go", ":!test/", ...]`. If the user sets `testFilePatterns: ["**/*.integration.ts"]`, their integration tests are *not* excluded from review diff because the default exclude list doesn't know about the custom pattern.
+
+### 1.4 Four callers don't thread config
+
+`tdd/orchestrator.ts`, `pipeline/stages/autofix-adversarial.ts`, `tdd/isolation.ts`, and `review/diff-utils.ts` all call `isTestFile(path)` without the `config` argument even though one is in scope.
+
+### 1.5 TypeScript-centric defaults
+
+`DEFAULT_TEST_FILE_PATTERNS = ["test/**/*.test.ts"]` is wrong for Go (`**/*_test.go`), Python (`test_*.py`), Rust, Java, and polyglot monorepos. No path to auto-detect per-project.
+
+### 1.6 Monorepo per-package context ignored
+
+Per-package overrides under `.nax/mono/<pkg>/config.json` are not consulted. A TS frontend and Go backend in one repo cannot be classified correctly under a single root pattern list.
+
+**Goal:** one resolver, one classifier, three formats (glob/pathspec/regex), sourced from user config with auto-detection fallback, honouring monorepo per-package context. Eliminate all inline test-file classification.
+
+---
+
+## 2. Design — SSOT Architecture
+
+### 2.1 Three pattern formats, one source
+
+Test-file knowledge is used in three incompatible formats across the codebase. The SSOT must produce all three from a single input:
+
+| Format | Example | Used by |
+|:---|:---|:---|
+| **Glob** | `**/*.test.ts` | Smart runner, file matchers, test-scanner |
+| **Pathspec** | `:!*.test.ts` | Git diff exclusion in review |
+| **Regex** | `/\.test\.ts$/` | Path classification, basename stripping |
+
+Plus a fourth derived artefact:
+
+| Artefact | Example | Used by |
+|:---|:---|:---|
+| **Test dirs** | `["test", "__tests__"]` | Directory scans, `context.testCoverage.testDir` auto-detect |
+
+### 2.2 Resolver → Classifier pipeline
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ resolveTestFilePatterns(config, packageDir?)                   │
+│   1. packageDir + .nax/mono/<pkg>/config.json override        │
+│   2. root config.execution.smartTestRunner.testFilePatterns   │
+│   3. detectTestFilePatterns(packageDir ?? workdir)            │
+│   4. DEFAULT_TEST_FILE_PATTERNS fallback                      │
+│                                                                │
+│   Returns: ResolvedTestPatterns { globs, pathspec, regex,     │
+│             testDirs }                                         │
+└────────────────────────────────────────────────────────────────┘
+                             │
+             ┌───────────────┼──────────────────┐
+             ▼               ▼                  ▼
+    ┌────────────────┐ ┌──────────────┐ ┌──────────────────────┐
+    │ classifier     │ │ excludePat-  │ │ test-scanner variant │
+    │ (path)→boolean │ │ terns default│ │ generator            │
+    └────────────────┘ └──────────────┘ └──────────────────────┘
+```
+
+### 2.3 New modules
+
+| Module | Responsibility |
+|:---|:---|
+| `src/test-runners/resolver.ts` | Layered lookup; returns `ResolvedTestPatterns` (all three formats + dirs) |
+| `src/test-runners/detect.ts` | Signal-based detection (framework configs, manifests, file scan) |
+| `src/test-runners/classifier.ts` | Build `(path) => boolean` from resolved patterns |
+| `src/test-runners/detector.ts` | `isTestFile()` becomes backward-compat thin wrapper |
+| `src/commands/detect.ts` | `nax detect [--apply]` CLI |
+
+### 2.4 API surface
+
+```typescript
+// src/test-runners/resolver.ts
+export interface ResolvedTestPatterns {
+  /** Glob form — for file matchers: ["**\/*.test.ts"] */
+  readonly globs: readonly string[];
+  /** Git pathspec form for diff exclusion: [":!*.test.ts", ":!test/"] */
+  readonly pathspec: readonly string[];
+  /** Regex form for path classification: [/\.test\.ts$/] */
+  readonly regex: readonly RegExp[];
+  /** Directory names extracted from globs: ["test", "__tests__"] */
+  readonly testDirs: readonly string[];
+  /** How the patterns were resolved (resolver layer — distinct from DetectionSource.type which is a detection-tier label) */
+  readonly resolution: "per-package" | "root-config" | "detected" | "fallback";
+}
+
+export function resolveTestFilePatterns(
+  config: NaxConfig,
+  packageDir?: string,
+): Promise<ResolvedTestPatterns>;
+
+/**
+ * Resolve the effective review excludePatterns.
+ * When user set excludePatterns explicitly → returned as-is (user override wins).
+ * When omitted → derived from resolved test patterns + noise dirs.
+ */
+export function resolveReviewExcludePatterns(
+  userExplicit: readonly string[] | undefined,
+  resolvedTestPatterns: ResolvedTestPatterns,
+): readonly string[];
+
+// src/test-runners/detect.ts
+export interface DetectionResult {
+  patterns: readonly string[];
+  confidence: "high" | "medium" | "low" | "empty";
+  sources: readonly DetectionSource[];
+}
+export interface DetectionSource {
+  type: "framework-config" | "manifest" | "file-scan" | "directory";
+  path: string;
+  patterns: readonly string[];
+}
+export function detectTestFilePatterns(workdir: string): Promise<DetectionResult>;
+
+// src/test-runners/classifier.ts
+export function createTestFileClassifier(
+  resolved: ResolvedTestPatterns,
+): (path: string) => boolean;
+
+// src/test-runners/detector.ts — backward-compat
+export function isTestFile(
+  filePath: string,
+  testFilePatterns?: readonly string[],
+): boolean;
+```
+
+### 2.5 Dependency injection (`_deps` pattern)
+
+Project convention requires all modules with external I/O to export an injectable `_deps` for test mocking. `mock.module()` is banned.
+
+```typescript
+// src/test-runners/resolver.ts
+export const _resolverDeps = {
+  fileExists: (path: string) => Bun.file(path).exists(),
+  readJson: async (path: string) => JSON.parse(await Bun.file(path).text()),
+  detectTestFilePatterns,  // injectable so resolver tests don't run real detection
+};
+
+// src/test-runners/detect.ts
+export const _detectDeps = {
+  spawn: Bun.spawn,           // git ls-files, glob walks
+  file: Bun.file,              // manifest reads
+  readJson: async (p: string) => JSON.parse(await Bun.file(p).text()),
+  readToml: parseToml,         // pyproject.toml / Cargo.toml
+  readYaml: parseYaml,         // pnpm-workspace.yaml
+};
+```
+
+Test pattern (mirrors existing `_diffUtilsDeps`, `_isolationDeps`, etc.):
+
+```typescript
+import { _resolverDeps } from "../../../src/test-runners/resolver";
+
+let origReadJson: typeof _resolverDeps.readJson;
+beforeEach(() => {
+  origReadJson = _resolverDeps.readJson;
+  _resolverDeps.readJson = mock(async () => ({ testFilePatterns: ["**/*.spec.ts"] }));
+});
+afterEach(() => { _resolverDeps.readJson = origReadJson; });
+```
+
+### 2.6 Error handling (NaxError)
+
+All throws must use `NaxError` with code + context. Error cases:
+
+| Condition | Code | Context |
+|:---|:---|:---|
+| `.nax/mono/<pkg>/config.json` read fails (permission / corrupt) | `MONO_CONFIG_READ_FAILED` | `{ packageDir, stage: "resolver", cause }` |
+| Cache file corrupt (`JSON.parse` fails) | (no throw — log debug, treat as miss) | — |
+| Manifest parse fails during detection | `MANIFEST_PARSE_FAILED` | `{ manifestPath, stage: "detect", cause }` |
+| Invalid glob pattern user-provided | `INVALID_TEST_GLOB` | `{ pattern, stage: "resolver" }` |
+| `--apply` write fails | `CONFIG_WRITE_FAILED` | `{ targetPath, cause }` → exits with code 2 |
+
+Returns (non-throws):
+- Missing `.nax/mono/<pkg>/config.json` → `null`, fall through to root config
+- Detection yields zero signals → `{ confidence: "empty", patterns: [] }`, caller falls through to fallback
+
+### 2.7 `packageDir` discovery
+
+Callers pass `packageDir` when they know it. Two sources:
+
+1. **Pipeline context:** `ctx.packageDir` already threaded for monorepo-aware stages. Pipeline callers pass `ctx.packageDir`.
+2. **Walk-up from file path:** when a classification site has only a file path (no package context), use the utility:
+
+```typescript
+// src/test-runners/resolver.ts
+export async function findPackageDir(filePath: string, workdir: string): Promise<string | undefined> {
+  // Walks up from filePath looking for the nearest .nax/mono/<pkg>/ match,
+  // or nearest package.json/go.mod/pyproject.toml. Returns undefined when at workdir root.
+}
+```
+
+Callers that operate on individual files (e.g. classifier built once per file) should resolve patterns once per story/package, not per file. See §2.8 for the caller pattern.
+
+### 2.8 Caller pattern — async resolver, sync classifier
+
+`resolveTestFilePatterns` is async (reads files). `createTestFileClassifier` returns a sync `(path) => boolean`. Callers **resolve once, classify many**:
+
+```typescript
+// ✅ Correct — resolve once per story
+async function processStory(ctx: PipelineContext) {
+  const resolved = await resolveTestFilePatterns(ctx.rootConfig, ctx.packageDir);
+  const isTest = createTestFileClassifier(resolved);
+
+  const testFiles = changedFiles.filter(isTest);
+  const sourceFiles = changedFiles.filter((f) => !isTest(f));
+  // ...
+}
+
+// ❌ Wrong — resolves per file, O(N) async calls
+async function processStoryBadly(files: string[], ctx: PipelineContext) {
+  for (const f of files) {
+    const resolved = await resolveTestFilePatterns(ctx.rootConfig, ctx.packageDir);
+    // ...
+  }
+}
+```
+
+Resolver MUST be called from async contexts. Pipeline stages are already async; non-async utility functions that currently call `isTestFile()` sync must either:
+- Accept a pre-built classifier as a parameter (preferred for hot paths)
+- Become async and call the resolver themselves
+
+### 2.9 Logging
+
+All logs from resolver/detector emitted via `getSafeLogger()`:
+
+- Stage prefix: `"resolver"` or `"detect"`
+- Include `storyId` when called from pipeline context (pipeline callers pass it as an options arg)
+- Include `packageDir` when monorepo-scoped
+- Detection tier + confidence logged at `info` when detection actually runs (not cache hit)
+
+```typescript
+// Inside resolver/detect
+logger.info("detect", "Test patterns detected", {
+  storyId,                // when available
+  packageDir,             // when monorepo
+  confidence: result.confidence,
+  patternCount: result.patterns.length,
+  tier: result.sources[0]?.type,
+});
+```
+
+### 2.10 File size budget
+
+Expected module line counts (project convention: 400-line hard limit):
+
+| Module | Est. LOC | Action |
+|:---|:---|:---|
+| `resolver.ts` | ~150 | Single file |
+| `classifier.ts` | ~60 | Single file |
+| `detect/index.ts` | ~80 | Orchestrator |
+| `detect/framework-configs.ts` | ~200 | Tier 1 parsers (vitest/jest/pytest/etc.) |
+| `detect/framework-defaults.ts` | ~80 | Tier 2 map |
+| `detect/file-scan.ts` | ~120 | Tier 3 `git ls-files` bucketing |
+| `detect/directory-scan.ts` | ~80 | Tier 4 fallback |
+| `detect/workspace.ts` | ~150 | Monorepo workspace discovery |
+| `detect/cache.ts` | ~100 | Cache read/write/invalidate |
+| `commands/detect.ts` | ~200 | CLI |
+
+Pre-planned splits prevent "refactor later when it exceeds 400 lines" churn.
+
+---
+
+## 3. Detection Methodology
+
+Detection produces a prioritized candidate list. Higher-tier sources override lower-tier ones for the same language/ecosystem. Multiple languages in one project produce a union.
+
+### 3.1 Signal tiers
+
+**Tier 1 — Framework config files (high confidence)**
+
+| Source | Extract |
+|:---|:---|
+| `vitest.config.*` | `test.include` |
+| `jest.config.*`, `package.json#jest` | `testMatch`, `testRegex` |
+| `pyproject.toml [tool.pytest.ini_options]` | `testpaths`, `python_files` |
+| `pytest.ini`, `setup.cfg` | `testpaths`, `python_files` |
+| `.mocharc.*` | `spec` globs |
+| `playwright.config.*` | `testDir`, `testMatch` |
+| `cypress.config.*` | `specPattern` |
+
+**Tier 2 — Framework declared, no explicit config (medium confidence)**
+
+| Signal | Default patterns |
+|:---|:---|
+| `vitest` in `devDependencies` | `**/*.{test,spec}.?(c\|m)[jt]s?(x)` |
+| `jest` in `devDependencies` | `**/__tests__/**/*.[jt]s?(x)`, `**/?(*.)+(spec\|test).[jt]s?(x)` |
+| `bun test` in `scripts.test` | `**/*.test.{ts,tsx,js,jsx}` |
+| `pytest` in `project.dependencies` | `test_*.py`, `*_test.py` |
+| `go.mod` present | `**/*_test.go` |
+| `Cargo.toml` present | `tests/**/*.rs` |
+
+**Tier 3 — File system evidence (low confidence)**
+
+Walk `git ls-files`, bucket by common test-file suffix, rank by count. Suffixes above threshold (≥5 files or ≥10 % of any suffix) enter the result as globs.
+
+**Tier 4 — Directory convention fallback**
+
+Check for `test/`, `tests/`, `__tests__/`, `spec/`. Extract file extensions within. Emits generic globs (`test/**/*.<ext>`).
+
+### 3.2 Algorithm
+
+```
+detectTestFilePatterns(workdir) → DetectionResult:
+  1. languages := detect language manifests in workdir
+  2. for each language:
+     a. try Tier 1 → if found, confidence[lang] = "high"
+     b. else Tier 2 → confidence[lang] = "medium"
+     c. cross-check against Tier 3 scan; log warning on mismatch
+  3. if no languages OR no Tier 1-2 results → Tier 3 drives; confidence = "low"
+  4. if still empty → Tier 4 → confidence = "low" or "empty"
+  5. normalize:
+       - dedupe by suffix
+       - sort deterministically
+       - skip patterns that don't convert cleanly (jest testRegex)
+  6. confidence = worst of per-language confidences
+```
+
+### 3.3 Conflict handling
+
+- **High tier vs file scan disagree:** high tier stands, warning emitted in `DetectionResult.sources`.
+- **Regex can't convert to glob:** skip and log; user can add manually via `nax detect` output.
+- **Empty project (no tests yet):** use Tier 2 defaults from declared framework; fall back to language-ecosystem defaults if no framework declared.
+- **Multiple frameworks (jest + playwright):** union both. Playwright's `testDir` usually scopes differently, safe to include both.
+- **Excluded dirs:** always filter out `node_modules/`, `dist/`, `build/`, `.nax/`, `coverage/`, `.git/`.
+
+### 3.4 Monorepo detection
+
+Workspace roots detected from:
+
+- `pnpm-workspace.yaml`
+- `package.json#workspaces`
+- `lerna.json`
+- `rush.json`, `nx.json`, `turbo.json`
+- Nested `go.mod`, `pyproject.toml`, `Cargo.toml` (independent packages without workspace declaration)
+- Existing `.nax/mono/` layout
+
+For each workspace, run the single-package algorithm. Result: `{ root: DetectionResult, packages: Record<string, DetectionResult> }`.
+
+---
+
+## 4. Storage Model
+
+### 4.1 Layering order (highest priority first)
+
+```
+1. .nax/mono/<pkg>/config.json   ← per-package override (monorepo)
+2. .nax/config.json              ← project root
+3. Auto-detected (ephemeral)     ← computed at runtime
+4. Language-agnostic fallback    ← broad regex in detector.ts
+```
+
+### 4.2 Config shape — concrete examples
+
+**Before (current state):**
+
+```jsonc
+// .nax/config.json
+{
+  "execution": {
+    "smartTestRunner": {
+      // Zod supplies DEFAULT_TEST_FILE_PATTERNS = ["test/**/*.test.ts"]
+      // when absent. No way to distinguish "user omitted" from "user chose default".
+    }
+  }
+}
+```
+
+**After — single-package project, user omits (detection handles it):**
+
+```jsonc
+// .nax/config.json
+{
+  "execution": {
+    "smartTestRunner": {
+      // testFilePatterns omitted → resolver runs detectTestFilePatterns()
+      // For a Go repo, this yields ["**/*_test.go"] at runtime.
+    }
+  }
+}
+```
+
+**After — single-package project, user explicit override:**
+
+```jsonc
+// .nax/config.json
+{
+  "execution": {
+    "smartTestRunner": {
+      "testFilePatterns": ["src/**/*.spec.ts", "test/**/*.integration.ts"]
+    }
+  }
+}
+```
+
+**After — `nax detect --apply` on a Go project (persisted):**
+
+```jsonc
+// .nax/config.json
+{
+  "execution": {
+    "smartTestRunner": {
+      "testFilePatterns": ["**/*_test.go"]
+    }
+  }
+}
+```
+
+**After — monorepo, root config only (inherited by all packages):**
+
+```jsonc
+// .nax/config.json
+{
+  "execution": {
+    "smartTestRunner": {
+      "testFilePatterns": ["**/*.test.ts"]
+    }
+  }
+}
+// No .nax/mono/<pkg>/config.json overrides — every package uses root patterns.
+```
+
+**After — polyglot monorepo, per-package overrides (`nax detect --apply`):**
+
+```jsonc
+// .nax/config.json — root: TS frontend lives here
+{
+  "execution": {
+    "smartTestRunner": {
+      "testFilePatterns": ["**/*.test.ts", "**/*.spec.ts"]
+    }
+  }
+}
+
+// .nax/mono/api/config.json — Go service
+{
+  "execution": {
+    "smartTestRunner": {
+      "testFilePatterns": ["**/*_test.go"]
+    }
+  }
+}
+
+// .nax/mono/ml/config.json — Python
+{
+  "execution": {
+    "smartTestRunner": {
+      "testFilePatterns": ["tests/**/*.py", "**/test_*.py"]
+    }
+  }
+}
+```
+
+**After — user explicit "no patterns" (empty array):**
+
+```jsonc
+// .nax/config.json
+{
+  "execution": {
+    "smartTestRunner": {
+      "testFilePatterns": []
+      // Explicit empty is semantically distinct from omitted:
+      // resolver returns [] as-is, classifier always returns false.
+      // Useful for disabling test-file aware logic in unusual setups.
+    }
+  }
+}
+```
+
+**After — `review.excludePatterns` derives from test patterns when omitted:**
+
+```jsonc
+// User sets testFilePatterns for integration tests; excludePatterns omitted
+{
+  "execution": {
+    "smartTestRunner": {
+      "testFilePatterns": ["**/*.integration.ts"]
+    }
+  },
+  "review": {
+    "semantic": {
+      // excludePatterns omitted → derived from testFilePatterns + noise dirs:
+      //   [":!**/*.integration.ts", ":!.nax/", ":!.nax-pids"]
+      // Integration tests are excluded from semantic review diff.
+    }
+  }
+}
+```
+
+**After — user explicit `excludePatterns` wins (user override):**
+
+```jsonc
+// User wants to INCLUDE test files in review + also exclude vendor/
+{
+  "review": {
+    "semantic": {
+      "excludePatterns": [":!vendor/", ":!.nax/"]
+      // User's list used as-is. Test files are NOT excluded because
+      // user did not list them. testFilePatterns has no effect here.
+    }
+  }
+}
+```
+
+**After — `context.testCoverage.testPattern` deprecated (aliased):**
+
+```jsonc
+// Legacy config still loads with a warning; aliased to testFilePatterns
+{
+  "context": {
+    "testCoverage": {
+      "testPattern": "**/*.spec.ts"
+      // DEPRECATED — migrate to:
+      //   execution.smartTestRunner.testFilePatterns: ["**/*.spec.ts"]
+      // Migration shim logs a warning at config load, uses the value
+      // as-if it had been set in smartTestRunner.testFilePatterns.
+    }
+  }
+}
+```
+
+### 4.3 Schema changes
+
+```typescript
+// src/config/schemas.ts
+
+const SmartTestRunnerConfigSchema = z.object({
+  // ...
+  // Was: .default(DEFAULT_TEST_FILE_PATTERNS)
+  // Becomes: optional, resolver handles detection when undefined.
+  testFilePatterns: z.array(z.string()).optional(),
+});
+
+const SemanticReviewConfigSchema = z.object({
+  // ...
+  // Was: .default([":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ...])
+  // Becomes: optional; resolveReviewExcludePatterns() derives from
+  // resolved testFilePatterns + noise dirs when user omits.
+  excludePatterns: z.array(z.string()).optional(),
+});
+
+// Same change for AdversarialReviewConfigSchema.
+
+const TestCoverageConfigSchema = z.object({
+  // ...
+  // DEPRECATED — migration shim aliases to smartTestRunner.testFilePatterns.
+  testPattern: z.string().optional(),
+});
+```
+
+**Rationale:**
+- `.default()` erases the distinction between "user omitted" and "user set to default value". Optional + runtime resolution preserves the semantics so derivation can kick in only when the user has not made a choice.
+- `excludePatterns` default had hardcoded test globs that go stale when the user sets non-default `testFilePatterns`. Deriving on omission fixes the staleness while preserving user override freedom.
+- `context.testCoverage.testPattern` is a duplicate of `testFilePatterns` with a different default and single-string format. Consolidating eliminates disagreement between the two keys.
+
+### 4.4 `excludePatterns` resolution
+
+User-facing behavior:
+
+| `review.semantic.excludePatterns` | Behavior |
+|:---|:---|
+| Omitted | Derived from `ResolvedTestPatterns.pathspec` + well-known test dirs + nax noise dirs. Stays in sync with custom `testFilePatterns`. |
+| Explicit list (any length, incl. empty) | Used as-is. User override wins. |
+
+**Parity requirement:** the derived list for a TS project with default `testFilePatterns` must equal the current hardcoded default (no silent behavior change). Current default is:
+
+```
+[":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts",
+ ":!**/__tests__/", ":!.nax/", ":!.nax-pids"]
+```
+
+Derivation must therefore cover both the user-configured patterns AND a fixed list of well-known test dirs/suffixes that are always excluded regardless of project language (to avoid including other languages' test files in a TS project's review).
+
+```typescript
+// src/test-runners/resolver.ts — constants co-located with the resolver
+const WELL_KNOWN_TEST_DIRS = ["test", "tests", "__tests__"] as const;
+const WELL_KNOWN_TEST_SUFFIXES = ["*.test.ts", "*.spec.ts", "*_test.go"] as const;
+const NAX_NOISE_PATHS = [".nax/", ".nax-pids"] as const;
+
+function resolveReviewExcludePatterns(
+  userExplicit: readonly string[] | undefined,
+  resolved: ResolvedTestPatterns,
+): readonly string[] {
+  if (userExplicit !== undefined) return userExplicit;
+
+  const result = new Set<string>();
+
+  // 1. Project's resolved test patterns (from user config / detection)
+  for (const p of resolved.pathspec) result.add(p);
+  for (const d of resolved.testDirs) result.add(`:!${d}/`);
+
+  // 2. Well-known test dirs/suffixes — always excluded to handle
+  //    polyglot repos and edge cases where detection missed something.
+  //    Prevents regression vs. current hardcoded default.
+  for (const d of WELL_KNOWN_TEST_DIRS) result.add(`:!${d}/`);
+  for (const s of WELL_KNOWN_TEST_SUFFIXES) result.add(`:!${s}`);
+
+  // 3. nax noise paths
+  for (const p of NAX_NOISE_PATHS) result.add(`:!${p}`);
+
+  return [...result];
+}
+```
+
+**Parity proof for TS default** — user omits `testFilePatterns`, fallback produces `["test/**/*.test.ts"]`:
+
+| Source | Contributes |
+|:---|:---|
+| `resolved.pathspec` from `["test/**/*.test.ts"]` | `:!*.test.ts` |
+| `resolved.testDirs` | `:!test/` |
+| `WELL_KNOWN_TEST_DIRS` | `:!test/`, `:!tests/`, `:!__tests__/` |
+| `WELL_KNOWN_TEST_SUFFIXES` | `:!*.test.ts`, `:!*.spec.ts`, `:!*_test.go` |
+| `NAX_NOISE_PATHS` | `:!.nax/`, `:!.nax-pids` |
+| **Deduped union** | `[":!*.test.ts", ":!test/", ":!tests/", ":!__tests__/", ":!*.spec.ts", ":!*_test.go", ":!.nax/", ":!.nax-pids"]` |
+
+Matches current hardcoded default (order may differ; pathspec order is not semantically significant for git diff exclusion).
+
+**Why not derive noise exclusively from `testFilePatterns`?** Because a user configuring `testFilePatterns: ["**/*.integration.ts"]` still doesn't want `.spec.ts` files reviewed if they exist in vendored code, `__tests__` dirs from dependencies extracted into the repo, etc. Well-known noise is always noise.
+
+### 4.5 `context.testCoverage.testPattern` migration shim
+
+Runs at the raw-JSON layer, **before** Zod parse, so the shim can distinguish "user omitted" from "user set to default". Returns a new object (no mutation, per project convention).
+
+```typescript
+// src/config/migrations.ts
+export function migrateLegacyTestPattern(
+  raw: Record<string, unknown>,
+  logger: Logger,
+): Record<string, unknown> {
+  const legacyPattern = raw?.context?.testCoverage?.testPattern;
+  if (legacyPattern === undefined) return raw;
+
+  logger.warn("config",
+    "context.testCoverage.testPattern is deprecated — migrate to " +
+    "execution.smartTestRunner.testFilePatterns",
+    { legacyPattern });
+
+  const smartRunnerPatterns = raw?.execution?.smartTestRunner?.testFilePatterns;
+  if (smartRunnerPatterns !== undefined) {
+    // User set both — smartTestRunner wins. Drop legacy, no alias.
+    const { testPattern: _drop, ...testCoverageRest } = raw.context.testCoverage;
+    return {
+      ...raw,
+      context: { ...raw.context, testCoverage: testCoverageRest },
+    };
+  }
+
+  // Alias into smartTestRunner.testFilePatterns
+  return {
+    ...raw,
+    execution: {
+      ...raw.execution,
+      smartTestRunner: {
+        ...raw.execution?.smartTestRunner,
+        testFilePatterns: [legacyPattern],
+      },
+    },
+    context: {
+      ...raw.context,
+      testCoverage: { ...raw.context.testCoverage, testPattern: undefined },
+    },
+  };
+}
+```
+
+Legacy configs continue to work. New configs should use `testFilePatterns` only.
+
+### 4.6 Persistence policy
+
+- **Pipeline runs (`nax run`, `nax generate`):** **reads** only. Resolver reads config + runs detection in-memory; ephemeral cache writes to `.nax/cache/` are allowed (cache is not user-tracked config). Never writes `.nax/config.json` or `.nax/mono/<pkg>/config.json`.
+- **`nax detect`:** prints, no writes.
+- **`nax detect --apply`:** writes user config files. Monorepo mode writes per-package configs; single-package mode writes root config.
+
+**Why no silent config writes:** surprise changes to user-tracked config files create merge conflicts and "why did this appear?" confusion. Opt-in via `--apply` is safer. `.nax/cache/` is `.gitignore`'d in the standard nax setup, so cache writes don't have the same concern.
+
+### 4.7 Caching
+
+Detection cost: filesystem walk + 2–6 file parses. Cache by `(workdir, [manifest mtimes])`. Invalidate on manifest mtime change.
+
+- **Location:** `.nax/cache/test-patterns.json` (workdir-local; gitignored)
+- **Lazy creation:** resolver calls `Bun.write()` which creates parent dirs; no explicit `mkdir`
+- **Concurrency:** parallel `nax run` invocations may race on cache write. Accept last-write-wins — cache content is derived, not source of truth; a lost write rebuilds cheaply on next read. No file lock.
+- **Corrupt cache:** on `JSON.parse` failure, log at `debug`, treat as cache miss, rewrite.
+- **Schema:**
+
+```jsonc
+{
+  "workdir": "/abs/path",
+  "mtimes": {
+    "package.json": 1728000000,
+    "vitest.config.ts": 1728000001
+  },
+  "result": { "patterns": [...], "confidence": "high", "sources": [...] }
+}
+```
+
+---
+
+## 5. Callers to Update
+
+### 5.1 Classification sites (replace with classifier)
+
+| Call site | Current | New |
+|:---|:---|:---|
+| `tdd/orchestrator.ts:196` | `session1.filesChanged.filter(isTestFile)` | `.filter(classifier)` from `resolveTestFilePatterns(config)` |
+| `pipeline/stages/autofix-adversarial.ts:32-33` | `isTestFile(f.file ?? "")` | Classifier from `ctx.rootConfig` + `ctx.packageDir` |
+| `tdd/isolation.ts:69,98` | `isTestFile(f)` | Classifier from threaded `testFilePatterns` param |
+| `review/diff-utils.ts:157-158` | `.filter(isTestFile)` | Classifier from threaded param |
+| `context/auto-detect.ts:175` | Inline `lower.includes(".test.") \|\| lower.includes(".spec.") \|\| lower.includes("/test/")` | Classifier from `config` in scope |
+| `plugins/loader.ts:241` | Inline `!filename.endsWith(".test.ts") && !filename.endsWith(".spec.ts")` | Classifier (plugin loader needs access to config) |
+
+### 5.2 Pattern-format consumers (replace hardcoded lists)
+
+| Call site | Current | New |
+|:---|:---|:---|
+| `config/schemas.ts:291-302` — `SemanticReviewConfigSchema.excludePatterns` default | Hardcoded `[":!*.test.ts", ":!*.spec.ts", ":!test/", ...]` | Optional; resolved via `resolveReviewExcludePatterns()` at use site |
+| `config/schemas.ts` — `AdversarialReviewConfigSchema.excludePatterns` default | Same hardcoded list | Same change |
+| `review/orchestrator.ts:252-253` | Inline `":!*.test.ts", ":!*.spec.ts"` in diff pathspec | Consume `resolved.pathspec` |
+| `review/runner.ts:291-292` | Same inline pathspec | Same |
+| `context/test-scanner.ts:130` — `deriveTestPatterns()` | Hardcoded `.test.ts/.spec.ts/.jsx` variants | Generate from `resolved.globs` suffixes |
+| `context/test-scanner.ts:118` — `COMMON_TEST_DIRS` | Hardcoded dir list | `resolved.testDirs` with fallback for discovery |
+| `review/diff-utils.ts:165` — basename stripping | Hardcoded `.test\.(ts\|js)$\|_test\.go$` regex | Use `resolved.regex` to strip |
+
+### 5.3 Config key migration
+
+| Call site | Current | New |
+|:---|:---|:---|
+| `config/schemas.ts:423` — `TestCoverageConfigSchema.testPattern` | `.default("**/*.test.{ts,js,tsx,jsx}")` | `.optional()` + deprecation shim aliases to `smartTestRunner.testFilePatterns` |
+| `context/builder.ts:184` — reads `tcConfig?.testPattern` | Single-string glob | After migration, `testFilePatterns[0]` or join as needed |
+| `context/greenfield.ts:103` — `testPattern` parameter | Default `"**/*.{test,spec}.{ts,js,tsx,jsx}"` | Passed through from resolved patterns |
+
+### 5.4 Downstream callers (threading only)
+
+Sites that already have config in scope and simply need to resolve + thread:
+
+- `tdd/session-runner.ts:237,239` — threads `testFilePatterns` into `verifyTestWriterIsolation` / `verifyImplementerIsolation`
+- `tdd/rectification-gate.ts:259` — threads into `verifyImplementerIsolation`
+- `review/adversarial.ts:197` — threads into `computeTestInventory`
+- `review/semantic.ts` — threads into `resolveReviewExcludePatterns` for effective diff exclusion
+- `context/builder.ts` — threads into `test-scanner.ts` and `greenfield.ts`
+
+### 5.5 Untouched by this change (scope boundary)
+
+- `src/test-runners/parser.ts` — parses framework output format, not file paths
+- `src/acceptance/test-path.ts` — language-based acceptance test filename (different concept)
+- `src/analyze/scanner.ts` — display-only framework detection (could optionally consume detected patterns but not required)
+- Prompt text (`src/prompts/builders/*.ts`) — hardcoded examples in LLM instructions. Separate cleanup task if needed; low priority.
+
+---
+
+## 6. CLI — `nax detect`
+
+### 6.1 Output
+
+```
+$ nax detect
+Workdir: /home/user/my-repo
+
+Detected patterns:
+  root             ["**/*.test.ts", "**/*.spec.ts"]     (high, vitest.config.ts)
+  packages/api     ["**/*_test.go"]                      (medium, go.mod)
+  packages/ml      ["tests/**/*.py", "test_*.py"]        (high, pyproject.toml)
+
+Currently effective (from config):
+  root             ["test/**/*.test.ts"]                 (Zod default)
+  packages/api     ["test/**/*.test.ts"]                 (inherits root)
+
+Run `nax detect --apply` to write detected patterns to .nax/ configs.
+```
+
+### 6.2 Flags
+
+- `--apply` — write detected patterns to `.nax/config.json` (root) and `.nax/mono/<pkg>/config.json` (per-package). Skips writes when detection is `empty` confidence. Skips writes for configs where the user has already set `testFilePatterns` explicitly (unless `--force`).
+- `--json` — machine-readable output for scripting.
+- `--package <dir>` — restrict detection to a single package directory.
+- `--force` — used with `--apply`: overwrite even when the user has explicitly set `testFilePatterns`. Without `--force`, `--apply` is additive-only (writes only to configs that currently have the field omitted).
+
+### 6.3 Exit codes
+
+| Code | Meaning |
+|:---|:---|
+| 0 | Detection successful |
+| 1 | Detection empty (no signals found) |
+| 2 | Write failed (`--apply` only) |
+
+---
+
+## 7. Files Affected
+
+### 7.1 New files
+
+| File | Purpose |
+|:---|:---|
+| `src/test-runners/resolver.ts` | `resolveTestFilePatterns()`, `resolveReviewExcludePatterns()` |
+| `src/test-runners/detect.ts` | Signal-based detection (Phase 2) |
+| `src/test-runners/classifier.ts` | `createTestFileClassifier(resolved)` |
+| `src/commands/detect.ts` | `nax detect` command (Phase 2) |
+
+### 7.2 Existing files — Phase 1 (plumbing)
+
+| File | Change |
+|:---|:---|
+| `src/test-runners/conventions.ts` | Extend to produce pathspec + regex forms alongside globs |
+| `src/test-runners/detector.ts` | `isTestFile(path, patterns?)` — backward-compat thin wrapper |
+| `src/test-runners/index.ts` | Export resolver, detect, classifier |
+| `src/config/schemas.ts` | `testFilePatterns` → optional; `excludePatterns` → optional (semantic + adversarial); `testPattern` → optional (with deprecation shim) |
+| `src/config/loader.ts` (or wherever migration happens) | Deprecation shim for `context.testCoverage.testPattern` → `testFilePatterns` |
+| `src/tdd/orchestrator.ts` | Use classifier |
+| `src/tdd/isolation.ts` | Add `testFilePatterns?` param to both isolation functions |
+| `src/tdd/session-runner.ts` | Resolve and thread |
+| `src/tdd/rectification-gate.ts` | Resolve and thread |
+| `src/pipeline/stages/autofix-adversarial.ts` | Use classifier from `ctx.rootConfig` |
+| `src/review/diff-utils.ts` | Add `testFilePatterns?` param to `computeTestInventory`; replace hardcoded basename regex with `resolved.regex` |
+| `src/review/adversarial.ts` | Resolve and thread; use `resolveReviewExcludePatterns()` for effective exclude list |
+| `src/review/semantic.ts` | Use `resolveReviewExcludePatterns()` |
+| `src/review/orchestrator.ts` | Replace inline pathspec `":!*.test.ts"` with resolved pathspec |
+| `src/review/runner.ts` | Same |
+| `src/context/auto-detect.ts` | Replace inline test check with classifier |
+| `src/context/test-scanner.ts` | Replace `COMMON_TEST_DIRS` + hardcoded variant generation with `resolved.testDirs` + generated variants |
+| `src/context/greenfield.ts` | Accept resolved patterns |
+| `src/context/builder.ts` | Thread resolved patterns into test-scanner |
+| `src/plugins/loader.ts` | Replace inline check with classifier (requires config access — may need a small refactor) |
+
+### 7.3 Existing files — Phase 2 (detection + CLI)
+
+| File | Change |
+|:---|:---|
+| `src/test-runners/detect.ts` | Replace stub with full four-tier detection |
+| `src/test-runners/detect/*.ts` | New sub-modules per §2.10 split plan |
+| `src/commands/detect.ts` | Full `nax detect` implementation |
+| `src/cli/index.ts` | Register `detect` command |
+
+**Runtime artefacts** (not source files):
+
+- `.nax/cache/test-patterns.json` — cache read/written by resolver. Gitignored. Created lazily by `Bun.write()`.
+
+---
+
+## 8. Implementation Plan — Two Phases
+
+### Phase 1 — SSOT Plumbing (no auto-detection yet)
+
+**Scope:** threads resolver + classifier through every classification site. No behavior change for users with default config. Eliminates all inline test-file classification.
+
+Phase 1 work (grouped by concern):
+
+1. **Core SSOT modules**
+   - `resolver.ts` — layered lookup returning `ResolvedTestPatterns` (all four artefacts: globs, pathspec, regex, testDirs); exports `_resolverDeps`
+   - `classifier.ts` — `createTestFileClassifier(resolved)`
+   - `detect.ts` — stub returning `{ confidence: "empty" }` (real detection lands in Phase 2); exports `_detectDeps` shape
+   - Extend `conventions.ts` with `toPathspec()`, `toDirNames()` helpers
+   - `isTestFile(path, patterns?)` backward-compat wrapper in `detector.ts`
+   - `resolveReviewExcludePatterns()` with parity-preserving derivation (§4.4)
+   - `findPackageDir()` utility (§2.7)
+
+2. **Schema changes + migration**
+   - `testFilePatterns: z.array(z.string()).optional()`
+   - `excludePatterns` on semantic + adversarial → `.optional()`
+   - `context.testCoverage.testPattern: .optional()` + deprecation shim at raw-JSON layer (§4.5) — immutable, returns new object
+   - `NaxError` codes registered: `MONO_CONFIG_READ_FAILED`, `MANIFEST_PARSE_FAILED`, `INVALID_TEST_GLOB`, `CONFIG_WRITE_FAILED`
+
+3. **Thread through classification sites (Section 5.1)**
+   - 4 original callers (orchestrator, autofix-adversarial, isolation, diff-utils)
+   - `context/auto-detect.ts` — replace inline check with classifier
+   - `plugins/loader.ts` — `isPluginFile()` accepts classifier as parameter; `loadPlugins()` (called from `execution/lifecycle/run-setup.ts:217` with config in scope) builds the classifier and passes it down. No architectural refactor needed.
+
+4. **Thread through pattern-format consumers (Section 5.2)**
+   - `review/orchestrator.ts` + `review/runner.ts` — inline pathspec → `resolved.pathspec`
+   - `review/semantic.ts` + `review/adversarial.ts` — use `resolveReviewExcludePatterns()`
+   - `context/test-scanner.ts` — `COMMON_TEST_DIRS` → `resolved.testDirs`; `deriveTestPatterns()` → generated from `resolved.globs`
+   - `context/builder.ts` + `context/greenfield.ts` — thread resolved patterns
+   - `review/diff-utils.ts` basename stripping → `resolved.regex`
+
+5. **Tests** (see §9 for full plan)
+   - Unit: resolver layering, classifier from each format, `resolveReviewExcludePatterns` parity proof, migration shim immutability
+   - Integration: user sets custom `testFilePatterns` → flows through isolation + review exclude + context scanner
+   - Regression: TS default configs produce identical effective `excludePatterns` as before
+
+**Risk:** medium. Much broader than initial framing because several inline-classification sites and duplicate config keys are being migrated in one pass. Mitigated by:
+- Default behavior preserved when user has no explicit config (detect stub returns empty, fallback is `DEFAULT_TEST_FILE_PATTERNS`, derived `excludePatterns` matches current hardcoded default for TS projects)
+- Deprecation shim keeps legacy `testPattern` configs working with a warning
+- Wide test coverage including regression checks for default behavior
+
+### Phase 2 — Auto-detect + `nax detect` + persistence
+
+**Scope:** make the detect stub real; add CLI command; wire cache; handle monorepo per-package writes.
+
+- Implement four-tier detection in `detect.ts` (framework config → framework default → file scan → directory convention)
+- Workspace detection for monorepos (`pnpm-workspace.yaml`, nested manifests, etc.)
+- Cache: `.nax/cache/test-patterns.json`, invalidated on manifest mtime change
+- `nax detect [--apply] [--json] [--package <dir>] [--force]`
+- Monorepo per-package write logic (writes to `.nax/mono/<pkg>/config.json`)
+- Detection runs automatically during pipeline when user has no explicit config — **reads only**, writes one info log line per run with the detected patterns + confidence + tier, but does NOT persist to user config files. Persistence requires explicit `nax detect --apply`.
+- Tests: fixture repos for TS (vitest/jest/bun), Go, Python, Rust, polyglot monorepo
+
+**Risk:** medium. Detection heuristics can guess wrong on unusual setups. Mitigated by:
+- `nax detect` visibility — user can always see what detection produced
+- Explicit `--apply` opt-in for persistence (no silent config writes)
+- Cache invalidation tied to manifest changes, not time
+- Fallback chain ends at `DEFAULT_TEST_FILE_PATTERNS` so behavior degrades gracefully
+
+---
+
+## 9. Test Plan
+
+### 9.1 Unit tests
+
+**`resolver.test.ts`**
+- Returns per-package override when `.nax/mono/<pkg>/config.json` has explicit patterns
+- Returns root config when no per-package override
+- Falls through to detect when no explicit config
+- Falls through to `DEFAULT_TEST_FILE_PATTERNS` when detect returns empty
+- Respects `testFilePatterns: []` as explicit "no patterns" (distinct from undefined)
+- `ResolvedTestPatterns` contains consistent globs, pathspec, regex, testDirs
+- `resolveReviewExcludePatterns()` returns user explicit list as-is when set
+- `resolveReviewExcludePatterns()` derives from test patterns + noise dirs when omitted
+- `resolveReviewExcludePatterns()` returns `[]` when user explicitly sets `[]`
+
+**`classifier.test.ts`**
+- Classifies `.test.ts` as test for `["**/*.test.ts"]`
+- Classifies `_test.go` as test for `["**/*_test.go"]`
+- Rejects source files
+- Empty pattern list → always false
+- Classifier from custom pattern `["**/*.integration.ts"]` classifies `foo.integration.ts` as test
+
+**`config-migration.test.ts`**
+- Legacy `context.testCoverage.testPattern` aliases to `smartTestRunner.testFilePatterns`
+- Deprecation warning logged once at config load
+- Alias skipped when `smartTestRunner.testFilePatterns` is already set explicitly
+- Shim returns a new object (input unchanged — immutability check)
+- Shim drops legacy `testPattern` key from output
+
+**`review-excludepatterns.test.ts`** — parity regression
+- TS default config → derived `excludePatterns` ⊇ current hardcoded default (every hardcoded entry present in derived set)
+- Custom `testFilePatterns: ["**/*.integration.ts"]` → `:!*.integration.ts` present in derived list
+- User explicit `excludePatterns: []` → returns `[]` (user wins)
+- User explicit `excludePatterns: [":!vendor/"]` → returns as-is (no test exclusions auto-added)
+- Derived list order: stable across calls (Set-based dedup, documented non-order)
+
+**`cache.test.ts`** (Phase 2)
+- Fresh workdir → cache miss, detection runs
+- Second call with unchanged mtimes → cache hit, detection NOT called
+- Manifest mtime change → cache invalidated, detection re-runs
+- Corrupt cache JSON → log debug, rebuild, no throw
+- Concurrent writes (two resolvers write same path) → last-write-wins, no lock error
+
+**`plugin-loader-integration.test.ts`**
+- `loadPlugins()` with custom `testFilePatterns` → plugin files matching pattern are NOT loaded as plugins
+- Default config → `foo.test.ts` excluded from plugins (backward compat with existing behavior)
+
+**`detect.test.ts`** (fixture-based)
+- `vitest.config.ts` with `test.include` → high confidence
+- `package.json#jest.testMatch` → high confidence
+- `jest` in deps, no config → medium confidence, default patterns
+- `go.mod` only → `**/*_test.go`, medium
+- `pyproject.toml` with `[tool.pytest.ini_options]` → high
+- File scan only (no manifest) → low confidence
+- Empty workdir → `confidence: "empty"`
+- Polyglot (TS + Go) → union of patterns
+- Monorepo (`pnpm-workspace.yaml` + 2 packages) → per-package results
+
+**`detector.test.ts`**
+- `isTestFile(path, patterns)` with explicit patterns uses them
+- `isTestFile(path)` without patterns uses broad regex (backward compat)
+
+### 9.2 Integration tests
+
+- End-to-end: set `testFilePatterns: ["src/**/*.spec.ts"]` in config → isolation check classifies `src/foo.spec.ts` as test → TDD session passes
+- Monorepo fixture: root has TS, `packages/go-svc/` has Go; both packages classified correctly during `nax run`
+
+### 9.3 CLI tests
+
+- `nax detect` on TS fixture prints vitest patterns
+- `nax detect --apply` writes config; second run reads from written config
+- `nax detect --json` produces parseable JSON
+- `nax detect --apply` on monorepo writes per-package configs
+
+---
+
+## 10. Backward Compatibility
+
+| Scenario | Behavior |
+|:---|:---|
+| Existing `.nax/config.json` with explicit `testFilePatterns` | Unchanged — resolver returns it as-is |
+| Config without `testFilePatterns` (Phase 1) | Falls back to `DEFAULT_TEST_FILE_PATTERNS` (identical to current behavior) |
+| Config without `testFilePatterns` (Phase 2) | Auto-detect runs; if empty, falls back to `DEFAULT_TEST_FILE_PATTERNS` |
+| Callers still passing `isTestFile(path)` without patterns | Still work — broad regex fallback stays in `detector.ts` |
+| Monorepo using `.nax/mono/<pkg>/config.json` without `testFilePatterns` | Inherits from root config (explicit or detected) |
+| Legacy `context.testCoverage.testPattern` set | Warning logged; value aliased to `smartTestRunner.testFilePatterns` |
+| Legacy hardcoded `excludePatterns` default was in user's head | Derived default produces the same list for TS projects with default `testFilePatterns` — no behavior change |
+| User relied on review including test files by omission | Still works — user must set `excludePatterns: []` explicitly (previously had to override the hardcoded list anyway) |
+| User had custom `testFilePatterns` but default `excludePatterns` | **Behavior improves.** Previously integration tests were included in review diff; now they're excluded because derivation stays in sync. User can revert by setting `excludePatterns` explicitly. |
+
+No breaking changes to public API. Schema changes are forward-compatible:
+- Old configs with explicit `testFilePatterns` / `excludePatterns` continue to work (user override always wins)
+- Old configs without them get the same effective defaults as before for TS projects
+- Legacy `testPattern` configs keep working via deprecation shim
+
+**Known behavior changes (intentional improvements):**
+1. User-defined `testFilePatterns` now influences review diff exclusion (bug fix).
+2. User-defined `testFilePatterns` now influences plugin file filtering and auto-detect context scanning (bug fix — these previously ignored config).
+3. Phase 2: polyglot projects get language-appropriate patterns auto-detected instead of TS-centric default (bug fix).
+
+---
+
+## 11. Performance
+
+Detection runs at most once per workdir per pipeline run (cached). Cost breakdown per cold detection:
+
+| Step | Operation | Est. cost |
+|:---|:---|:---|
+| Manifest read × 2–6 | `Bun.file().text()` + parse | ~5ms |
+| `git ls-files` (Tier 3) | Single spawn; bounded to tracked files | 10–100ms depending on repo size |
+| File scan bucketing | Pure JS over ls-files output | <10ms |
+| Workspace walk (monorepo) | `N × cold detection` for N packages | 50ms–1s for typical monorepo |
+| Cache write | `Bun.write()` | <5ms |
+
+**Bounds:**
+- Tier 3 file scan is capped to `git ls-files` output — no full filesystem walk on untracked junk
+- No node_modules / vendor walk
+- Monorepo detection is sequential today; parallelism deferred to v2 if needed
+
+**Warm cache:** single file read + mtime comparison. <5ms.
+
+Acceptable overhead for pipeline startup (which already takes seconds for config load, plugin discovery, etc.). If a future profile shows this in the hot path, the cache can be promoted to in-process memo keyed by `(workdir, runId)`.
+
+---
+
+## 12. Open Questions
+
+1. **Cache invalidation across nax runs** — resolved: survive, invalidate on manifest mtime change only. See §4.7.
+2. **Should `nax run` emit a log line when detection kicks in?** — resolved: yes, one info line per run, per §2.9.
+3. **Broad regex in `detector.ts` — remove or keep as safety net?**
+   - Goal (§1) says "eliminate all inline classification." The broad regex IS inline.
+   - Resolution: keep in Phase 1 **only** as the backward-compat fallback for `isTestFile(path)` calls without `patterns` arg. All Phase 1 callers are migrated to the classifier path, so the regex becomes unreachable from production code paths once Phase 1 lands.
+   - **Remove** in Phase 2 alongside detection going live — at that point the resolver always returns a non-empty list (detection fallback chain ends at `DEFAULT_TEST_FILE_PATTERNS`), so the "called without patterns" path no longer exists.
+4. **ADR required?** — Yes. See `docs/adr/ADR-009-test-file-pattern-ssot.md` for the architectural record (SSOT rule, resolution chain, three-format output, user-override policy, no-silent-writes). This spec remains the implementation reference.
+5. **Should `nax detect --apply --migrate` also strip deprecated `testPattern` key?** — yes, when `--apply` writes a new `testFilePatterns`, the write function removes any co-located legacy `testPattern` to prevent config drift. Flag not required — migration is implicit with `--apply`.
+
+---
+
+## 13. References
+
+- `docs/adr/ADR-009-test-file-pattern-ssot.md` — architectural decision record
+- Issue #461 — original proposal
+- `src/test-runners/conventions.ts` — existing SSOT for glob-based patterns
+- `src/test-runners/detector.ts` — current hardcoded broad regex list
+- `.claude/rules/project-conventions.md` — logging, file size, Bun-native constraints, storyId requirement
+- `.claude/rules/forbidden-patterns.md` — `mock.module()` banned; `_deps` pattern required
+- `.claude/rules/error-handling.md` — `NaxError` usage
+- `.claude/rules/test-architecture.md` — test file placement mirroring `src/`

--- a/docs/validation/context-v1-graphify-kb-plan.md
+++ b/docs/validation/context-v1-graphify-kb-plan.md
@@ -1,0 +1,386 @@
+# Context Engine v1 — Phase 0 Validation: Graphify KB (Koda)
+
+> **Feature:** `graphify-kb` in `/home/williamkhoo/Desktop/projects/nathapp/koda/`
+> **Spec:** `koda/docs/specs/SPEC-graphify-kb.md`
+> **PRD:** `koda/.nax/features/graphify-kb/prd.json`
+> **Validation spec:** `ngent/docs/specs/SPEC-context-v1-phase0-validation.md`
+> **Started:** 2026-04-14
+
+---
+
+## Why this feature was chosen
+
+- 5 stories, all pending — natural split between discovery (US-001) and implementation (US-002–005)
+- `contextFiles` is already wired in `prd.json` — injection needs only a one-line change per story
+- Monorepo already handled via `.nax/mono/apps/{api,cli}/config.json` — not a confounder
+- Dependency chain (001 → 002 → 003/004 → 005) creates a natural progressive context window
+- Non-trivial scope spanning schema, service, controller, toggle logic, CLI — high surface area for constraint rediscovery
+
+## Experiment design
+
+### Why US-001 is the baseline, not a "no injection" comparison
+
+All 5 stories are pending. There are no completed prior phases to draw `context.md` from. Instead:
+
+- **US-001** runs with no injection — it is the discovery story. Its job is to reveal how Koda's NestJS patterns actually work.
+- After US-001 completes, we hand-author `context.md` from its diff + review findings.
+- **US-002, US-003, US-004** run with `context.md` injected — these are the injection group.
+- **US-005** runs with injection as a bonus data point.
+
+The comparison is US-001's metrics (baseline) vs US-002–004 average (injection group). This is a weaker comparison than a same-complexity matched pair, but sufficient to detect obvious signal.
+
+### Modified injection mechanism
+
+After US-001 completes, add `.nax/features/graphify-kb/context.md` as the **first entry** in `contextFiles` for US-002 through US-005 in `prd.json`:
+
+```json
+"contextFiles": [
+  "../../.nax/features/graphify-kb/context.md",
+  "apps/api/src/rag/rag.service.ts",
+  ...
+]
+```
+
+Path is relative to `workdir: "apps/api"` — adjust if needed. Verify the file is readable by the agent before running US-002.
+
+### Environment
+
+- **Keep CLAUDE.md / AGENTS.md / GEMINI.md / codex.md unchanged.** These are present in both baseline and injection runs — they don't bias the comparison. Cleaning them up is the canonical-rules spec, not this experiment.
+- **No branch needed.** Run on the existing feature branch or main.
+- **No code changes to nax or koda.** Only `prd.json` and `context.md` change.
+
+---
+
+## Pre-run checklist
+
+Before running US-001:
+
+- [ ] Confirm `koda/.nax/mono/apps/api/config.json` has correct `test`, `testScoped`, `typecheck`, `lint` commands
+- [ ] Confirm `koda/.nax/mono/apps/cli/config.json` exists (for US-005)
+- [ ] Confirm `koda/.nax/features/graphify-kb/prd.json` has `workdir: "apps/api"` on US-001 through US-004 and `workdir: "apps/cli"` on US-005
+- [ ] Confirm nax can reach Claude (check quota)
+- [ ] Note the git SHA at run start for reproducibility
+
+---
+
+## Metrics to record per story
+
+For every story, record immediately after it completes:
+
+| Metric | Source |
+|:-------|:-------|
+| Tier escalations | `story.escalations.length` in metrics |
+| Review findings — semantic | `ctx.reviewFindings` count, kind=semantic |
+| Review findings — adversarial | `ctx.reviewFindings` count, kind=adversarial |
+| Rectification iterations | Rectifier loop count |
+| Autofix iterations | Autofix loop count |
+| Wall clock (minutes) | Story start → complete |
+| Final tier used | fast / balanced / powerful |
+| Human interventions | Manual operator actions (pauses, edits, aborts) |
+
+Plus three qualitative answers written in the log below:
+
+1. **Rediscovery incidents** — specific moments where the agent re-derived something that was (or should have been) in `context.md`. Name the file and what was re-derived.
+2. **Context used** — for injection stories: specific moments where you can point to a line and say the agent made the right call because `context.md` told it to.
+3. **Context ignored** — for injection stories: entries in `context.md` the agent seemed to not follow. Note which entry and what the agent did instead.
+
+---
+
+## What to capture in `context.md` after US-001
+
+Author `.nax/features/graphify-kb/context.md` within an hour of US-001 completing, while the diff is fresh. Target ≤ 1500 tokens total.
+
+Use this structure — only fill sections where you have genuine evidence from the diff or review findings:
+
+```markdown
+# Feature Context — graphify-kb
+
+_Hand-authored after US-001. Date: <date>. Source: diff + review findings._
+
+## Decisions
+
+<!-- Chosen approaches with rationale. Only non-obvious ones — not things in the spec. -->
+
+## Constraints
+
+<!-- External rules the code must satisfy that a fresh agent would not know.
+     Examples: "Prisma migrations must be run via bun run db:migrate not prisma migrate",
+     "RagModule must export RagService for cross-module DI to work",
+     "i18n keys must exist in BOTH en/ and zh/ or the app throws at startup" -->
+
+## Patterns Established
+
+<!-- Structural conventions set in US-001 that US-002+ must follow.
+     Examples: "ProjectResponseDto.from() maps nullable fields as null not undefined",
+     "source union is a TypeScript string literal union, not an enum" -->
+
+## Gotchas
+
+<!-- Traps the agent hit or nearly hit that future stories should avoid.
+     Examples: "graphifyEnabled field placement in schema.prisma — must match
+     the autoIndexOnClose ordering or the migration diffs confusingly" -->
+```
+
+**Content rules:**
+- Cite evidence for every entry (file:line, commit, review finding ID).
+- Exclude anything already stated explicitly in the spec — agents read the spec too.
+- Exclude project-wide rules already in `CLAUDE.md` — agents read those too.
+- When in doubt, include. Over-capture here; trim at US-002 if it's clearly noise.
+
+---
+
+## Known spec constraints to watch for (pre-populated)
+
+These are the places the spec is most likely to produce cross-story rediscovery. Record in `context.md` after US-001 confirms them:
+
+| Constraint | Likely story | Source |
+|:-----------|:-------------|:-------|
+| `source` is a string literal union (`'ticket' \| 'doc' \| 'manual' \| 'code'`), not an enum | US-002, US-003 | Spec: add-document.dto.ts pattern |
+| `RagModule` must export `RagService` for `ProjectsModule` DI to see it | US-004 | Spec: projects.module.ts change |
+| Toggle-off purge: `deleteAllBySourceType` is called in same request, failure is warn-not-throw | US-004 | Spec: failure handling |
+| Node content format: `"{type} {label} in {source_file}"` + neighbor lines | US-002, US-003 | Spec: node→text conversion |
+| CLI: uses `resolveAuth({})`, `unwrap(response)`, `handleApiError(err)` — not custom equivalents | US-005 | Spec: CLI context files |
+| i18n keys must exist in both `en/` and `zh/` — app throws at startup if either is missing | US-003, US-004 | Spec: i18n constraint |
+| `graphifyLastImportedAt` is updated in the controller, not the service | US-003 | Spec: US-003 AC |
+
+These are starting hypotheses. US-001 may reveal different or additional constraints — what it actually discovers takes priority.
+
+---
+
+## Decision gate
+
+After US-002, US-003, US-004 complete:
+
+### Outcome A — Proceed to build v1
+
+At least **two** of:
+- ≥ 1 tier escalation prevented (injection story escalates less than US-001)
+- ≥ 2 review findings fewer on average vs US-001
+- ≥ 2 qualitative rediscovery incidents that `context.md` demonstrably prevented
+- "Context used" answer is non-empty for at least 2 of the 3 injection stories
+
+**Action:** Begin `SPEC-feature-context-engine.md` Phase 1 (read-path implementation).
+
+### Outcome B — Stop, do not build v1
+
+None of the above met, or injection-group metrics within noise of US-001.
+
+**Action:** Shelf v1 and context-dependent v2 sections. Document why here. Redirect to the two independent specs (`SPEC-context-engine-agent-fallback.md`, `SPEC-context-engine-canonical-rules.md`).
+
+### Outcome C — Ambiguous
+
+One metric improves, others don't; qualitative review is mixed.
+
+**Action:** Run US-005 as a 4th injection data point. Re-decide. If still ambiguous, treat as Outcome B.
+
+---
+
+## Validation log
+
+### Environment
+
+- nax version: 0.62.0-canary.6
+- Git SHA (koda): 05e3178aa98ed1c26fb16889a8d14343293c7180,  4f2eda67a9fc26af62fbe7ca52b37bc56f7c525c acceptance generated
+- Git SHA (ngent): 8c4557b4d5ac889746a5709068dfe9042969655d
+- Date started: 2026-04-14
+- Operator: williamkhoo
+
+---
+
+### US-001 — Schema, DTO & i18n Extensions (BASELINE)
+
+**Role:** Discovery. No injection. Establishes codebase pattern knowledge.
+
+Started: 2026-04-14T10:55:13.744Z
+Completed: 2026-04-14T11:04:54.970Z
+
+| Metric                     | Value                  |
+|:---------------------------|:-----------------------|
+| Tier escalations           | 0                      |
+| Review findings — semantic | 0                      |
+| Review findings — adversar | 0                      |
+| Rectification iterations   | 0                      |
+| Autofix iterations         | 0                      |
+| Wall clock                 | 5.6 min                |
+| Final tier                 | fast                   |
+| Human interventions        | (enter manually)       |
+
+Notes:
+  - Total agent attempts (escalation proxy): 1
+  - Rectification/autofix counts are log-derived — 0 means stage never triggered
+  - Human interventions require manual entry (PAUSE/edit/abort events)
+
+**Rediscovery incidents (things the agent had to figure out from scratch that future stories will also need):**
+
+_(write here immediately after the run — this becomes the source material for context.md)_
+
+---
+
+### `context.md` authored
+
+**Date authored:** _______________
+
+**Entries:**
+
+| Section | Count |
+|:--------|:------|
+| Decisions | |
+| Constraints | |
+| Patterns | |
+| Gotchas | |
+
+**Total tokens (estimate):** _______________
+
+**Notable entries (2-3 most important):**
+
+1.
+2.
+3.
+
+**Injection confirmed:** `context.md` added to `contextFiles` for US-002, US-003, US-004, US-005 in `prd.json`. [ ]
+
+---
+
+### US-002 — RagService Methods (INJECTION #1)
+
+**Run date:** _______________
+
+**Metrics:**
+
+| Metric | Value |
+|:-------|:------|
+| Tier escalations | |
+| Review findings — semantic | |
+| Review findings — adversarial | |
+| Rectification iterations | |
+| Autofix iterations | |
+| Wall clock | |
+| Final tier | |
+| Human interventions | |
+
+**Rediscovery incidents (things the agent re-derived that were in context.md):**
+
+**Context used (moments the agent made the right call because of context.md):**
+
+**Context ignored (entries in context.md the agent did not follow):**
+
+**`context.md` updated after this story:** [ ] (add new learnings before US-003)
+
+---
+
+### US-003 — Import Endpoint (INJECTION #2)
+
+**Run date:** _______________
+
+**Metrics:**
+
+| Metric | Value |
+|:-------|:------|
+| Tier escalations | |
+| Review findings — semantic | |
+| Review findings — adversarial | |
+| Rectification iterations | |
+| Autofix iterations | |
+| Wall clock | |
+| Final tier | |
+| Human interventions | |
+
+**Rediscovery incidents:**
+
+**Context used:**
+
+**Context ignored:**
+
+**`context.md` updated after this story:** [ ]
+
+---
+
+### US-004 — Toggle Enforcement & Cleanup (INJECTION #3)
+
+**Run date:** _______________
+
+**Metrics:**
+
+| Metric | Value |
+|:-------|:------|
+| Tier escalations | |
+| Review findings — semantic | |
+| Review findings — adversarial | |
+| Rectification iterations | |
+| Autofix iterations | |
+| Wall clock | |
+| Final tier | |
+| Human interventions | |
+
+**Rediscovery incidents:**
+
+**Context used:**
+
+**Context ignored:**
+
+---
+
+### US-005 — CLI Command (INJECTION #4, bonus)
+
+**Run date:** _______________
+
+> Note: US-005 uses `workdir: "apps/cli"` — different workspace from US-001–004. Verify `context.md` path resolves correctly from the CLI workspace root.
+
+**Metrics:**
+
+| Metric | Value |
+|:-------|:------|
+| Tier escalations | |
+| Review findings — semantic | |
+| Review findings — adversarial | |
+| Rectification iterations | |
+| Autofix iterations | |
+| Wall clock | |
+| Final tier | |
+| Human interventions | |
+
+**Rediscovery incidents:**
+
+**Context used:**
+
+**Context ignored:**
+
+---
+
+## Summary comparison
+
+_(Fill after US-004 or US-005)_
+
+| Metric | US-001 (baseline) | US-002 | US-003 | US-004 | Injection avg |
+|:-------|:-----------------:|:------:|:------:|:------:|:-------------:|
+| Tier escalations | | | | | |
+| Semantic findings | | | | | |
+| Adversarial findings | | | | | |
+| Rectification iters | | | | | |
+| Autofix iters | | | | | |
+| Wall clock (min) | | | | | |
+
+**Rediscovery incidents prevented by context.md (total):** ___
+
+**Rediscovery incidents that slipped through despite context.md:** ___
+
+**Context.md entries that were clearly used:** ___  
+**Context.md entries that were clearly ignored:** ___
+
+---
+
+## Decision
+
+**Outcome:** A / B / C
+
+**Rationale:**
+
+_(one paragraph — what the data and qualitative review show)_
+
+**Next action:**
+
+- [ ] Outcome A → open implementation issue for `SPEC-feature-context-engine.md` Phase 1
+- [ ] Outcome B → write ADR shelving v1; redirect to fallback + canonical-rules specs
+- [ ] Outcome C → run US-005 and re-decide
+
+**Decision date:** _______________

--- a/docs/validation/context-v1-graphify-kb-runbook.md
+++ b/docs/validation/context-v1-graphify-kb-runbook.md
@@ -1,0 +1,467 @@
+# Context Engine v1 — Phase 0 Runbook: Graphify KB
+
+> Step-by-step instructions for running the validation experiment.
+> Read [context-v1-graphify-kb-plan.md](./context-v1-graphify-kb-plan.md) first for the why.
+
+---
+
+## Overview
+
+The experiment runs in two halves:
+
+```
+HALF 1 — Baseline
+  [env check] → [run US-001] → [PAUSE] → [record metrics] → [author context.md]
+
+HALF 2 — Injection
+  [update prd.json] → [run US-002–004] → [record metrics per story] → [decide]
+```
+
+---
+
+## Part 1 — Environment preparation
+
+### 1.1 Verify nax is up to date
+
+```bash
+nax --version
+# Expected: 0.62.0-canary.6 or newer
+```
+
+If the binary is stale, rebuild from source:
+
+```bash
+cd /home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent
+bun run build
+# nax binary is at dist/nax.js, symlinked to PATH via ~/.nvm/.../bin/nax
+```
+
+### 1.2 Verify koda dependencies are installed
+
+```bash
+cd /home/williamkhoo/Desktop/projects/nathapp/koda
+bun install
+```
+
+### 1.3 Verify the koda API workspace builds and tests pass (clean baseline)
+
+```bash
+cd /home/williamkhoo/Desktop/projects/nathapp/koda/apps/api
+bun run type-check   # must pass
+bun run lint         # must pass
+bun run test         # must pass — record the pass count as your baseline
+```
+
+If tests fail before the experiment starts, fix them first. A pre-existing failure will contaminate the metrics.
+
+### 1.4 Verify the prd.json is in the expected state
+
+```bash
+cd /home/williamkhoo/Desktop/projects/nathapp/koda
+jq '[.userStories[] | {id, title, status}]' .nax/features/graphify-kb/prd.json
+```
+
+Expected output — all 5 stories at `pending`:
+
+```json
+[
+  { "id": "US-001", "title": "Schema, DTO & i18n Extensions",       "status": "pending" },
+  { "id": "US-002", "title": "RagService Methods: ...",              "status": "pending" },
+  { "id": "US-003", "title": "Import Endpoint: ...",                 "status": "pending" },
+  { "id": "US-004", "title": "Toggle Enforcement & Cleanup ...",     "status": "pending" },
+  { "id": "US-005", "title": "CLI Command: koda kb import ...",      "status": "pending" }
+]
+```
+
+If any story is not `pending`, reset it:
+
+```bash
+# Reset a single story to pending (replace US-00X as needed)
+jq '(.userStories[] | select(.id == "US-001")).status = "pending"' \
+  .nax/features/graphify-kb/prd.json > /tmp/prd.tmp && \
+  mv /tmp/prd.tmp .nax/features/graphify-kb/prd.json
+```
+
+### 1.5 Verify Claude credentials are available
+
+```bash
+echo $ANTHROPIC_API_KEY | head -c 10   # should print sk-ant-...
+```
+
+If missing, set it before running:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+### 1.6 Note the git SHA for reproducibility
+
+```bash
+cd /home/williamkhoo/Desktop/projects/nathapp/koda
+git rev-parse HEAD
+# Record this in the validation log
+```
+
+### 1.7 Confirm no stale `.queue.txt` exists
+
+```bash
+ls /home/williamkhoo/Desktop/projects/nathapp/koda/.queue.txt 2>/dev/null \
+  && echo "WARNING: stale queue file — remove it" \
+  || echo "OK: no queue file"
+```
+
+Remove if present:
+
+```bash
+rm -f /home/williamkhoo/Desktop/projects/nathapp/koda/.queue.txt
+```
+
+---
+
+## Part 2 — Run US-001 (baseline, no injection)
+
+### 2.1 Open two terminal windows
+
+You need two terminals side by side:
+
+- **Terminal A** — runs nax
+- **Terminal B** — ready to send the PAUSE signal
+
+### 2.2 Terminal A — start the run
+
+```bash
+cd /home/williamkhoo/Desktop/projects/nathapp/koda
+nax run --feature graphify-kb
+```
+
+The TUI will appear. US-001 will start immediately.
+
+### 2.3 Terminal B — send PAUSE while US-001 is running
+
+Wait until you see US-001 is actively executing (agent session started, not just queued). Then write the PAUSE signal:
+
+```bash
+echo "PAUSE" > /home/williamkhoo/Desktop/projects/nathapp/koda/.queue.txt
+```
+
+> **Timing:** do this any time while US-001 is executing — before it finishes. The PAUSE is consumed before US-002 starts, not mid-story. US-001 will complete naturally regardless.
+
+Alternatively, if you are watching the TUI, press **`p`** to pause.
+
+### 2.4 Wait for US-001 to complete and the run to stop
+
+You will see output like:
+
+```
+[queue] Paused by user
+Run paused after US-001.
+```
+
+The process exits cleanly. US-001 is now `passed` (or `failed` — see below).
+
+**If US-001 failed:** this is itself a data point. Record the failure reason in the validation log. Do not re-run yet — first understand why it failed and whether it's a nax/environment issue vs. a genuine agent quality issue.
+
+### 2.5 Record US-001 metrics immediately
+
+Open the metrics or logs before doing anything else:
+
+```bash
+cd /home/williamkhoo/Desktop/projects/nathapp/koda
+# Check story status and attempt count
+jq '.userStories[] | select(.id == "US-001") | {status, attempts, escalations}' \
+  .nax/features/graphify-kb/prd.json
+
+# Check run metrics (adjust path to your metrics file location)
+cat .nax/metrics.json 2>/dev/null | jq '.' | tail -100
+```
+
+Fill in the **US-001 section** of [context-v1-graphify-kb-plan.md](./context-v1-graphify-kb-plan.md) now, while fresh.
+
+### 2.6 Read the US-001 diff
+
+```bash
+cd /home/williamkhoo/Desktop/projects/nathapp/koda
+git diff HEAD~1 HEAD --stat   # files changed
+git diff HEAD~1 HEAD          # full diff
+```
+
+Answer the qualitative questions in the log:
+- What did the agent discover that was non-obvious from the spec?
+- Were there rectification cycles? What caused them?
+- Did any review findings reveal a codebase constraint that future stories will also hit?
+
+---
+
+## Part 3 — Author `context.md`
+
+### 3.1 Start from the existing analysis (shortcut)
+
+The prd.json already contains a rich `analysis` field from the pre-run debate. Use it as your first draft:
+
+```bash
+cd /home/williamkhoo/Desktop/projects/nathapp/koda
+jq -r '.analysis' .nax/features/graphify-kb/prd.json
+```
+
+Copy the relevant constraints into `context.md`. Focus on things that:
+- A fresh agent would not find in the spec itself
+- US-001's run either confirmed or refined
+- Will directly affect US-002, US-003, or US-004
+
+### 3.2 Create the file
+
+```bash
+cat > /home/williamkhoo/Desktop/projects/nathapp/koda/.nax/features/graphify-kb/context.md << 'EOF'
+# Feature Context — graphify-kb
+
+_Hand-authored after US-001. Date: YYYY-MM-DD. Source: prd.json analysis + US-001 diff + review findings._
+
+## Decisions
+
+<!-- Chosen approaches confirmed by US-001. Only non-obvious ones. -->
+
+## Constraints
+
+<!-- External rules a fresh agent would not know.
+     Seed from analysis: DI cycle risk, source-of-truth discipline, build order. -->
+
+## Patterns Established
+
+<!-- Structural conventions set in US-001 that US-002+ must follow.
+     E.g. how the source union is typed, how from() maps nullable fields. -->
+
+## Gotchas
+
+<!-- Traps US-001 hit or nearly hit. -->
+EOF
+```
+
+### 3.3 Fill in the content
+
+Key items to confirm from US-001 diff and add to each section:
+
+| Item | Section | Evidence to look for |
+|:-----|:--------|:---------------------|
+| `source` is a string literal union, not an enum | Constraints | `add-document.dto.ts` — how `IsIn` array is typed |
+| `RagModule` must export `RagService` for ProjectsModule DI | Constraints | `rag.module.ts` — is `RagService` in `exports[]`? |
+| `from()` in `ProjectResponseDto` maps nullables as `null` not `undefined` | Patterns | `project-response.dto.ts` diff |
+| i18n keys must exist in BOTH `en/` and `zh/` or app throws at startup | Constraints | `i18n/*.json` files touched in US-001 |
+| Content generation formula for nodes | Decisions | Confirmed from spec + prd analysis |
+| DI direction: projects → rag only, never reverse | Constraints | prd analysis |
+| Build order: US-001 → US-002 → (US-003 ∥ US-004) → regenerate → US-005 | Decisions | prd analysis |
+| `graphifyLastImportedAt` is updated in the **controller**, not the service | Constraints | Spec US-003 AC: "controller updates...after successful import" |
+
+**Target total: ≤ 1500 tokens.** Be selective — if it's in the spec verbatim, skip it. Only add what a fresh agent reading the spec would not know.
+
+### 3.4 Verify the file looks reasonable
+
+```bash
+cat /home/williamkhoo/Desktop/projects/nathapp/koda/.nax/features/graphify-kb/context.md
+wc -w /home/williamkhoo/Desktop/projects/nathapp/koda/.nax/features/graphify-kb/context.md
+# rough estimate: words × 1.3 ≈ tokens. Target < 1150 words.
+```
+
+---
+
+## Part 4 — Update prd.json for injection
+
+### 4.1 Add `context.md` to `contextFiles` for US-002 through US-005
+
+Edit `.nax/features/graphify-kb/prd.json`. For each of US-002, US-003, US-004, US-005, add `context.md` as the **first entry** in `contextFiles`:
+
+```bash
+# Preview current contextFiles for US-002
+jq '.userStories[] | select(.id == "US-002") | .contextFiles' \
+  /home/williamkhoo/Desktop/projects/nathapp/koda/.nax/features/graphify-kb/prd.json
+```
+
+Then open the file in your editor and add the path. The `context.md` path should be relative to the story's `workdir`. US-002–004 have `workdir: "apps/api"`, so the path relative to the koda root is:
+
+```
+../../.nax/features/graphify-kb/context.md
+```
+
+Result for US-002 (example):
+
+```json
+"contextFiles": [
+  "../../.nax/features/graphify-kb/context.md",
+  "apps/api/src/rag/rag.service.ts",
+  "apps/api/src/rag/rag.service.spec.ts"
+]
+```
+
+For US-005 (`workdir: "apps/cli"`), the relative path is the same:
+
+```
+../../.nax/features/graphify-kb/context.md
+```
+
+### 4.2 Verify the path resolves
+
+```bash
+# From the api workdir, check the relative path resolves correctly
+ls /home/williamkhoo/Desktop/projects/nathapp/koda/apps/api/../../.nax/features/graphify-kb/context.md
+# Should print the file path without error
+```
+
+### 4.3 Confirm prd.json is valid JSON
+
+```bash
+jq '.' /home/williamkhoo/Desktop/projects/nathapp/koda/.nax/features/graphify-kb/prd.json > /dev/null \
+  && echo "valid JSON" || echo "INVALID — fix before running"
+```
+
+---
+
+## Part 5 — Run US-002 through US-004 (injection group)
+
+### 5.1 Terminal A — resume the run
+
+```bash
+cd /home/williamkhoo/Desktop/projects/nathapp/koda
+nax run --feature graphify-kb
+```
+
+nax will see US-001 is already `passed` and start from US-002. Context.md will be injected via `contextFiles` automatically.
+
+### 5.2 Let it run — no PAUSE needed
+
+For the injection group, let US-002, US-003, and US-004 run to completion. US-005 requires a manual step between US-003 and US-005 (OpenAPI client regeneration — see below), so watch for US-004 to complete.
+
+> **Note on parallelism:** US-003 and US-004 can theoretically run in parallel (both depend only on US-002, not each other). If nax runs them in parallel, you will have two concurrent injection data points — good for the experiment.
+
+### 5.3 Record metrics immediately after each story
+
+You can read current story status mid-run without stopping nax:
+
+```bash
+# In Terminal B, check story status as they complete
+watch -n5 'jq "[.userStories[] | {id, status, attempts}]" \
+  /home/williamkhoo/Desktop/projects/nathapp/koda/.nax/features/graphify-kb/prd.json'
+```
+
+Fill in the log for each story as it completes. Do not batch — memory of what you observed fades quickly.
+
+### 5.4 After US-003 completes — regenerate the OpenAPI client (required for US-005)
+
+The spec requires this before US-005 can run. If nax hasn't paused automatically, send a PAUSE before US-005 starts:
+
+```bash
+echo "PAUSE" > /home/williamkhoo/Desktop/projects/nathapp/koda/.queue.txt
+```
+
+Then run the regeneration:
+
+```bash
+cd /home/williamkhoo/Desktop/projects/nathapp/koda
+bun run api:export-spec   # regenerates openapi.json at repo root
+bun run generate          # regenerates apps/cli/src/generated/
+```
+
+Then resume:
+
+```bash
+nax run --feature graphify-kb
+# picks up at US-005
+```
+
+### 5.5 Update `context.md` between stories (optional but recommended)
+
+After each story completes, spend 5 minutes reviewing its diff and adding any new learnings to `context.md` before the next story starts. This tests the "growing context" aspect of v1.
+
+---
+
+## Part 6 — Record and decide
+
+### 6.1 Fill in the summary table
+
+Open [context-v1-graphify-kb-plan.md](./context-v1-graphify-kb-plan.md) and fill the summary comparison table from the metrics you recorded per story.
+
+### 6.2 Answer the qualitative questions for each injection story
+
+For each of US-002, US-003, US-004:
+1. **Rediscovery incidents** — did the agent re-derive something from `context.md`?
+2. **Context used** — where did `context.md` lead to the right call?
+3. **Context ignored** — which entries did the agent seem to miss?
+
+### 6.3 Apply the decision gate
+
+| Outcome | Criteria | Action |
+|:--------|:---------|:-------|
+| **A — build v1** | ≥ 2 of: tier escalation reduced, review findings reduced (≥30%), ≥2 rediscovery incidents prevented, context used in ≥2/3 stories | Open implementation issue for Phase 1 |
+| **B — stop** | None of the above | Write ADR shelving v1; redirect to fallback + canonical-rules |
+| **C — ambiguous** | 1 metric improved, others neutral | Run US-005, re-decide |
+
+---
+
+## Quick reference
+
+```bash
+# Start run
+cd /home/williamkhoo/Desktop/projects/nathapp/koda && nax run --feature graphify-kb
+
+# PAUSE after current story (send from a second terminal while nax is running)
+echo "PAUSE" > /home/williamkhoo/Desktop/projects/nathapp/koda/.queue.txt
+
+# Check story statuses
+jq '[.userStories[] | {id, status, attempts, escalations}]' \
+  /home/williamkhoo/Desktop/projects/nathapp/koda/.nax/features/graphify-kb/prd.json
+
+# Reset a story to pending if you need to re-run it
+jq '(.userStories[] | select(.id == "US-00X")).status = "pending" |
+    (.userStories[] | select(.id == "US-00X")).attempts = 0 |
+    (.userStories[] | select(.id == "US-00X")).passes = false' \
+  .nax/features/graphify-kb/prd.json > /tmp/prd.tmp && \
+  mv /tmp/prd.tmp .nax/features/graphify-kb/prd.json
+
+# Check if context.md path resolves from api workdir
+ls /home/williamkhoo/Desktop/projects/nathapp/koda/apps/api/../../.nax/features/graphify-kb/context.md
+
+# Word count of context.md (× 1.3 ≈ tokens)
+wc -w /home/williamkhoo/Desktop/projects/nathapp/koda/.nax/features/graphify-kb/context.md
+
+# Remove stale queue file
+rm -f /home/williamkhoo/Desktop/projects/nathapp/koda/.queue.txt
+
+# Regenerate OpenAPI client (required before US-005)
+cd /home/williamkhoo/Desktop/projects/nathapp/koda && \
+  bun run api:export-spec && bun run generate
+```
+
+---
+
+## Troubleshooting
+
+### nax starts US-002 before I can PAUSE
+
+Send the PAUSE immediately after starting the run. The queue-check stage fires at the very beginning of each story — even a few seconds of delay after US-001 completes is usually enough. If US-002 already started, let it finish (it's a quick story), then PAUSE before US-003.
+
+### context.md path not found by the agent
+
+Check the relative path from the story's `workdir`. If `workdir` is `apps/api`, the path `../../.nax/features/graphify-kb/context.md` resolves to the koda root's `.nax/features/graphify-kb/context.md`. Verify with:
+
+```bash
+ls /home/williamkhoo/Desktop/projects/nathapp/koda/apps/api/../../.nax/features/graphify-kb/context.md
+```
+
+If nax resolves `contextFiles` relative to the project root (not `workdir`), use `.nax/features/graphify-kb/context.md` directly — no `../../` prefix. Check by looking at what path the first story's existing `contextFiles` use.
+
+### US-001 fails
+
+Record the failure reason and escalation count. Do not re-run immediately. If it failed due to a nax/environment issue (quota, crash, infrastructure), fix the issue and reset US-001 to `pending`. If it failed due to agent quality (review rejected, verification failed, escalation exhausted), that is itself a valid baseline data point — record it as-is.
+
+### Metrics are not visible in `.nax/metrics.json`
+
+nax logs structured JSONL to the run log directory. Check:
+
+```bash
+ls /home/williamkhoo/Desktop/projects/nathapp/koda/.nax/
+# look for logs/ or a run-specific directory
+```
+
+The TUI's summary screen at run completion also shows escalation count, cost, and tier used per story — screenshot it if the log files are hard to parse.
+
+### OpenAPI regeneration fails before US-005
+
+US-003 must be fully merged and passing for the spec export to include the new endpoint. If the export fails, check that US-003 actually passed and that the new route is present in `rag.controller.ts`. Do not proceed to US-005 without valid generated types.

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -171,6 +171,23 @@ export async function detectCommand(options: DetectOptions): Promise<void> {
   const detectionMap = await detectTestFilePatternsForWorkspace(workdir, packageDirs);
   const rootDetected = detectionMap[""] ?? { patterns: [], confidence: "empty" as const, sources: [] };
 
+  // Read per-package effective patterns from .nax/mono/<dir>/config.json
+  const pkgEntries = await Promise.all(
+    packageDirs.map(async (dir) => {
+      const det = detectionMap[dir] ?? { patterns: [], confidence: "empty" as const, sources: [] };
+      const pkgConfigPath = join(workdir, ".nax", "mono", dir, "config.json");
+      const pkgRaw = await loadRawConfig(pkgConfigPath);
+      const pkgPatterns = deepGet(pkgRaw, TEST_PATTERNS_KEY);
+      const effective = Array.isArray(pkgPatterns) ? (pkgPatterns as string[]) : undefined;
+      return {
+        packageDir: dir,
+        detected: det,
+        effective,
+        resolution: resolveEffective(det, effective),
+      };
+    }),
+  );
+
   // Build output entries
   const entries: PackageDetectionEntry[] = [
     {
@@ -179,16 +196,7 @@ export async function detectCommand(options: DetectOptions): Promise<void> {
       effective: rootConfigPatterns,
       resolution: resolveEffective(rootDetected, rootConfigPatterns),
     },
-    ...packageDirs.map((dir) => {
-      const det = detectionMap[dir] ?? { patterns: [], confidence: "empty" as const, sources: [] };
-      // Per-package config patterns would come from .nax/mono/<dir>/config.json — simplify for now
-      return {
-        packageDir: dir,
-        detected: det,
-        effective: undefined as readonly string[] | undefined,
-        resolution: resolveEffective(det, undefined),
-      };
-    }),
+    ...pkgEntries,
   ];
 
   // JSON output mode

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -75,13 +75,12 @@ function deepSet(obj: Record<string, unknown>, keyPath: string, value: unknown):
   const keys = keyPath.split(".");
   const result = { ...obj };
   let cur: Record<string, unknown> = result;
-  for (let i = 0; i < keys.length - 1; i++) {
-    const key = keys[i]!;
-    cur[key] = { ...(cur[key] as Record<string, unknown> ?? {}) };
+  for (const key of keys.slice(0, -1)) {
+    cur[key] = { ...((cur[key] as Record<string, unknown>) ?? {}) };
     cur = cur[key] as Record<string, unknown>;
   }
-  const lastKey = keys.at(-1)!;
-  cur[lastKey] = value;
+  const lastKey = keys[keys.length - 1];
+  if (lastKey !== undefined) cur[lastKey] = value;
   return result;
 }
 
@@ -241,9 +240,7 @@ export async function detectCommand(options: DetectOptions): Promise<void> {
       try {
         const status = await applyToConfig(rootConfigPath, rootDetected.patterns, options.force ?? false);
         if (status === "skipped") {
-          console.log(
-            chalk.dim(`  root: skipped (testFilePatterns already set; use --force to overwrite)`),
-          );
+          console.log(chalk.dim("  root: skipped (testFilePatterns already set; use --force to overwrite)"));
         } else {
           console.log(chalk.green(`  root: ${status} → ${join(".nax", "config.json")}`));
         }

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -58,15 +58,11 @@ function resolveEffective(
   return "none";
 }
 
-/** Load raw config JSON for a path (returns {} on missing) */
+/** Load raw config JSON for a path (returns {} on missing, throws on parse/read errors) */
 async function loadRawConfig(path: string): Promise<Record<string, unknown>> {
-  try {
-    const f = Bun.file(path);
-    if (!(await f.exists())) return {};
-    return JSON.parse(await f.text()) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
+  const f = Bun.file(path);
+  if (!(await f.exists())) return {};
+  return JSON.parse(await f.text()) as Record<string, unknown>;
 }
 
 /** Write raw config JSON to a path (creates parent dirs) */

--- a/src/commands/detect.ts
+++ b/src/commands/detect.ts
@@ -1,0 +1,278 @@
+/**
+ * `nax detect` command
+ *
+ * Runs the four-tier test-file pattern detection for the project and reports
+ * what patterns were found (and from which tier).
+ *
+ * Flags:
+ *   --apply          Write detected patterns to .nax/config.json (and per-package configs)
+ *   --json           Machine-readable JSON output
+ *   --package <dir>  Restrict detection to a single package directory
+ *   --force          With --apply: overwrite even when testFilePatterns is already set explicitly
+ *   -d, --dir <path> Explicit project directory
+ *
+ * Exit codes:
+ *   0 — Detection successful
+ *   1 — Detection empty (no signals found)
+ *   2 — Write failed (--apply only)
+ */
+
+import { join } from "node:path";
+import chalk from "chalk";
+import { loadConfig } from "../config";
+import { initLogger } from "../logger";
+import type { DetectionResult } from "../test-runners/detect";
+import { detectTestFilePatternsForWorkspace } from "../test-runners/detect";
+import { discoverWorkspacePackages } from "../test-runners/detect/workspace";
+import { resolveProject } from "./common";
+
+/** Options passed from commander */
+export interface DetectOptions {
+  /** Write detected patterns to .nax/ configs */
+  apply?: boolean;
+  /** Machine-readable JSON output */
+  json?: boolean;
+  /** Restrict to a single package directory (relative, e.g. "packages/api") */
+  package?: string;
+  /** With --apply: overwrite even when testFilePatterns is already set explicitly */
+  force?: boolean;
+  /** Explicit project directory */
+  dir?: string;
+}
+
+/** Per-package detection output */
+interface PackageDetectionEntry {
+  packageDir: string;
+  detected: DetectionResult;
+  effective: readonly string[] | undefined;
+  resolution: "config" | "detected" | "none";
+}
+
+/** Resolve detected vs. effective patterns for a package */
+function resolveEffective(
+  detected: DetectionResult,
+  configPatterns: readonly string[] | undefined,
+): PackageDetectionEntry["resolution"] {
+  if (configPatterns !== undefined) return "config";
+  if (detected.confidence !== "empty") return "detected";
+  return "none";
+}
+
+/** Load raw config JSON for a path (returns {} on missing) */
+async function loadRawConfig(path: string): Promise<Record<string, unknown>> {
+  try {
+    const f = Bun.file(path);
+    if (!(await f.exists())) return {};
+    return JSON.parse(await f.text()) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/** Write raw config JSON to a path (creates parent dirs) */
+async function writeRawConfig(path: string, data: Record<string, unknown>): Promise<void> {
+  await Bun.write(path, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+/** Deep-set a nested key (e.g. "execution.smartTestRunner.testFilePatterns") */
+function deepSet(obj: Record<string, unknown>, keyPath: string, value: unknown): Record<string, unknown> {
+  const keys = keyPath.split(".");
+  const result = { ...obj };
+  let cur: Record<string, unknown> = result;
+  for (let i = 0; i < keys.length - 1; i++) {
+    const key = keys[i]!;
+    cur[key] = { ...(cur[key] as Record<string, unknown> ?? {}) };
+    cur = cur[key] as Record<string, unknown>;
+  }
+  const lastKey = keys.at(-1)!;
+  cur[lastKey] = value;
+  return result;
+}
+
+/** Get a nested key from a raw config object */
+function deepGet(obj: Record<string, unknown>, keyPath: string): unknown {
+  const keys = keyPath.split(".");
+  let cur: unknown = obj;
+  for (const key of keys) {
+    if (cur === null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return cur;
+}
+
+const TEST_PATTERNS_KEY = "execution.smartTestRunner.testFilePatterns";
+
+/**
+ * Apply detected patterns to config file for a package.
+ * Returns "written" | "skipped" | "forced".
+ */
+async function applyToConfig(
+  configPath: string,
+  patterns: readonly string[],
+  force: boolean,
+): Promise<"written" | "skipped" | "forced"> {
+  const raw = await loadRawConfig(configPath);
+  const existing = deepGet(raw, TEST_PATTERNS_KEY);
+
+  if (existing !== undefined && !force) return "skipped";
+
+  const updated = deepSet(raw, TEST_PATTERNS_KEY, [...patterns]);
+  await writeRawConfig(configPath, updated);
+
+  return existing !== undefined ? "forced" : "written";
+}
+
+/** Format patterns for display */
+function fmtPatterns(patterns: readonly string[]): string {
+  if (patterns.length === 0) return chalk.dim("(none)");
+  return `[${patterns.map((p) => `"${p}"`).join(", ")}]`;
+}
+
+/** Format source tier for display */
+function fmtSource(result: DetectionResult): string {
+  const first = result.sources[0];
+  if (!first) return "";
+  const name = first.path.split("/").at(-1) ?? first.path;
+  return chalk.dim(`(${result.confidence}, ${name})`);
+}
+
+/**
+ * Run the detect command.
+ */
+export async function detectCommand(options: DetectOptions): Promise<void> {
+  // Resolve project directory
+  const resolved = resolveProject({ dir: options.dir });
+  const workdir = resolved.projectDir;
+
+  // Suppress logger output (use our own console output for detect command)
+  initLogger({ level: "error" });
+
+  // Load effective config to compare against
+  let config: Awaited<ReturnType<typeof loadConfig>>;
+  try {
+    config = await loadConfig(workdir);
+  } catch {
+    config = undefined as unknown as Awaited<ReturnType<typeof loadConfig>>;
+  }
+
+  const smartRunner = config?.execution?.smartTestRunner;
+  const rootConfigPatterns =
+    typeof smartRunner === "object" && smartRunner !== null ? smartRunner.testFilePatterns : undefined;
+
+  // Discover packages (or restrict to single package)
+  let packageDirs: string[];
+  if (options.package) {
+    packageDirs = [options.package];
+  } else {
+    packageDirs = await discoverWorkspacePackages(workdir);
+  }
+
+  // Run detection
+  const detectionMap = await detectTestFilePatternsForWorkspace(workdir, packageDirs);
+  const rootDetected = detectionMap[""] ?? { patterns: [], confidence: "empty" as const, sources: [] };
+
+  // Build output entries
+  const entries: PackageDetectionEntry[] = [
+    {
+      packageDir: "root",
+      detected: rootDetected,
+      effective: rootConfigPatterns,
+      resolution: resolveEffective(rootDetected, rootConfigPatterns),
+    },
+    ...packageDirs.map((dir) => {
+      const det = detectionMap[dir] ?? { patterns: [], confidence: "empty" as const, sources: [] };
+      // Per-package config patterns would come from .nax/mono/<dir>/config.json — simplify for now
+      return {
+        packageDir: dir,
+        detected: det,
+        effective: undefined as readonly string[] | undefined,
+        resolution: resolveEffective(det, undefined),
+      };
+    }),
+  ];
+
+  // JSON output mode
+  if (options.json) {
+    const output = {
+      workdir,
+      root: {
+        detected: rootDetected,
+        effective: rootConfigPatterns,
+      },
+      packages: Object.fromEntries(packageDirs.map((dir) => [dir, detectionMap[dir]])),
+    };
+    console.log(JSON.stringify(output, null, 2));
+    const allEmptyJson = entries.every((e) => e.detected.confidence === "empty");
+    process.exitCode = allEmptyJson ? 1 : 0;
+    return;
+  }
+
+  // Human-readable output
+  console.log(chalk.bold(`Workdir: ${workdir}`));
+  console.log();
+  console.log(chalk.bold("Detected patterns:"));
+
+  for (const entry of entries) {
+    const label = entry.packageDir === "root" ? chalk.cyan("root") : chalk.blue(entry.packageDir);
+    const patterns = fmtPatterns(entry.detected.patterns);
+    const source = fmtSource(entry.detected);
+    console.log(`  ${label.padEnd(20)} ${patterns}  ${source}`);
+  }
+
+  console.log();
+  console.log(chalk.bold("Currently effective (from config):"));
+  const effectivePatterns = fmtPatterns(rootConfigPatterns ?? []);
+  const effectiveSource = rootConfigPatterns !== undefined ? chalk.dim("(config)") : chalk.dim("(fallback)");
+  console.log(`  ${chalk.cyan("root").padEnd(20)} ${effectivePatterns}  ${effectiveSource}`);
+
+  // Apply mode
+  if (options.apply) {
+    console.log();
+    console.log(chalk.bold("Applying..."));
+
+    if (rootDetected.confidence === "empty") {
+      console.log(chalk.yellow("  root: skipped (empty detection)"));
+    } else {
+      const rootConfigPath = join(workdir, ".nax", "config.json");
+      try {
+        const status = await applyToConfig(rootConfigPath, rootDetected.patterns, options.force ?? false);
+        if (status === "skipped") {
+          console.log(
+            chalk.dim(`  root: skipped (testFilePatterns already set; use --force to overwrite)`),
+          );
+        } else {
+          console.log(chalk.green(`  root: ${status} → ${join(".nax", "config.json")}`));
+        }
+      } catch (err) {
+        console.error(chalk.red(`  root: write failed — ${(err as Error).message}`));
+        process.exit(2);
+      }
+    }
+
+    for (const dir of packageDirs) {
+      const det = detectionMap[dir];
+      if (!det || det.confidence === "empty") {
+        console.log(chalk.dim(`  ${dir}: skipped (empty detection)`));
+        continue;
+      }
+      const pkgConfigPath = join(workdir, ".nax", "mono", dir, "config.json");
+      try {
+        const status = await applyToConfig(pkgConfigPath, det.patterns, options.force ?? false);
+        if (status === "skipped") {
+          console.log(chalk.dim(`  ${dir}: skipped (already set)`));
+        } else {
+          console.log(chalk.green(`  ${dir}: ${status} → ${join(".nax", "mono", dir, "config.json")}`));
+        }
+      } catch (err) {
+        console.error(chalk.red(`  ${dir}: write failed — ${(err as Error).message}`));
+        process.exit(2);
+      }
+    }
+  } else if (entries.some((e) => e.detected.confidence !== "empty")) {
+    console.log();
+    console.log(chalk.dim("Run `nax detect --apply` to write detected patterns to .nax/ configs."));
+  }
+
+  const allEmpty = entries.every((e) => e.detected.confidence === "empty");
+  process.exitCode = allEmpty ? 1 : 0;
+}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -8,6 +8,7 @@ import { existsSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { getLogger } from "../logger";
 import { loadJsonFile } from "../utils/json-file";
+import { migrateLegacyTestPattern } from "./migrations";
 import { mergePackageConfig } from "./merge";
 import { deepMergeConfig } from "./merger";
 import { MAX_DIRECTORY_DEPTH } from "./path-security";
@@ -127,9 +128,15 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
 
   // Layer 1: Global config (~/.nax/config.json) — strip "profile" field before merging (AC 7)
   const globalConfRaw = await loadJsonFile<Record<string, unknown>>(globalConfigPath(), "config");
+  let logger: ReturnType<typeof getLogger> | null = null;
+  try { logger = getLogger(); } catch { /* logger may not be init yet */ }
   if (globalConfRaw) {
     const { profile: _gProfile, ...globalConfStripped } = globalConfRaw;
-    const globalConf = applyBatchModeCompat(applyRemovedStrategyCompat(globalConfStripped));
+    const globalConf = applyBatchModeCompat(
+      applyRemovedStrategyCompat(
+        migrateLegacyTestPattern(globalConfStripped, logger),
+      ),
+    );
     rawConfig = deepMergeConfig(rawConfig, globalConf);
   }
 
@@ -138,7 +145,11 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
     const projConf = await loadJsonFile<Record<string, unknown>>(join(projDir, "config.json"), "config");
     if (projConf) {
       const { profile: _pProfile, ...projConfStripped } = projConf;
-      const resolvedProjConf = applyBatchModeCompat(applyRemovedStrategyCompat(projConfStripped));
+      const resolvedProjConf = applyBatchModeCompat(
+        applyRemovedStrategyCompat(
+          migrateLegacyTestPattern(projConfStripped, logger),
+        ),
+      );
       rawConfig = deepMergeConfig(rawConfig, resolvedProjConf);
     }
   }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -8,9 +8,9 @@ import { existsSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { getLogger } from "../logger";
 import { loadJsonFile } from "../utils/json-file";
-import { migrateLegacyTestPattern } from "./migrations";
 import { mergePackageConfig } from "./merge";
 import { deepMergeConfig } from "./merger";
+import { migrateLegacyTestPattern } from "./migrations";
 import { MAX_DIRECTORY_DEPTH } from "./path-security";
 import { PROJECT_NAX_DIR, globalConfigDir } from "./paths";
 import { loadProfile, loadProfileEnv, resolveProfileName } from "./profile";
@@ -129,13 +129,15 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
   // Layer 1: Global config (~/.nax/config.json) — strip "profile" field before merging (AC 7)
   const globalConfRaw = await loadJsonFile<Record<string, unknown>>(globalConfigPath(), "config");
   let logger: ReturnType<typeof getLogger> | null = null;
-  try { logger = getLogger(); } catch { /* logger may not be init yet */ }
+  try {
+    logger = getLogger();
+  } catch {
+    /* logger may not be init yet */
+  }
   if (globalConfRaw) {
     const { profile: _gProfile, ...globalConfStripped } = globalConfRaw;
     const globalConf = applyBatchModeCompat(
-      applyRemovedStrategyCompat(
-        migrateLegacyTestPattern(globalConfStripped, logger),
-      ),
+      applyRemovedStrategyCompat(migrateLegacyTestPattern(globalConfStripped, logger)),
     );
     rawConfig = deepMergeConfig(rawConfig, globalConf);
   }
@@ -146,9 +148,7 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
     if (projConf) {
       const { profile: _pProfile, ...projConfStripped } = projConf;
       const resolvedProjConf = applyBatchModeCompat(
-        applyRemovedStrategyCompat(
-          migrateLegacyTestPattern(projConfStripped, logger),
-        ),
+        applyRemovedStrategyCompat(migrateLegacyTestPattern(projConfStripped, logger)),
       );
       rawConfig = deepMergeConfig(rawConfig, resolvedProjConf);
     }

--- a/src/config/migrations.ts
+++ b/src/config/migrations.ts
@@ -31,10 +31,7 @@ import type { Logger } from "../logger";
  * @param logger Nullable logger — logger may not be initialized yet at call time.
  * @returns New config object with migration applied.
  */
-export function migrateLegacyTestPattern(
-  raw: Record<string, unknown>,
-  logger: Logger | null,
-): Record<string, unknown> {
+export function migrateLegacyTestPattern(raw: Record<string, unknown>, logger: Logger | null): Record<string, unknown> {
   type RawContext = { testCoverage?: { testPattern?: unknown; [k: string]: unknown }; [k: string]: unknown };
   type RawExecution = { smartTestRunner?: { testFilePatterns?: unknown; [k: string]: unknown }; [k: string]: unknown };
 

--- a/src/config/migrations.ts
+++ b/src/config/migrations.ts
@@ -1,0 +1,76 @@
+/**
+ * Config Migration Shims
+ *
+ * Immutable transformations applied to the raw JSON config before Zod parse.
+ * Running before Zod allows the shim to distinguish "user omitted" (key absent)
+ * from "user set to default value" — the `.default()` in Zod erases that signal.
+ *
+ * Rules:
+ * - Each function returns a NEW object; the input is never mutated.
+ * - Shims are one-way and additive: they do not remove user data.
+ * - Deprecation warnings are logged via the passed logger (which may be null
+ *   if called before the logger is initialized — guard with `?.`).
+ */
+
+import type { Logger } from "../logger";
+
+/**
+ * Alias the deprecated `context.testCoverage.testPattern` (single glob string)
+ * to `execution.smartTestRunner.testFilePatterns` (string array) — ADR-009 §4.5.
+ *
+ * Behaviour:
+ * - If `testPattern` is absent → no-op, returns input.
+ * - If `testPattern` is present AND `testFilePatterns` is also set → smartTestRunner
+ *   wins; `testPattern` is dropped silently (user has already migrated, no conflict).
+ * - If `testPattern` is present and `testFilePatterns` is absent → alias:
+ *   `testFilePatterns = [testPattern]`.
+ * - In all cases the `testPattern` key is removed from the output to avoid
+ *   the deprecated field leaking into the Zod-parsed config.
+ *
+ * @param raw    Raw JSON config object (before Zod parse).
+ * @param logger Nullable logger — logger may not be initialized yet at call time.
+ * @returns New config object with migration applied.
+ */
+export function migrateLegacyTestPattern(
+  raw: Record<string, unknown>,
+  logger: Logger | null,
+): Record<string, unknown> {
+  type RawContext = { testCoverage?: { testPattern?: unknown; [k: string]: unknown }; [k: string]: unknown };
+  type RawExecution = { smartTestRunner?: { testFilePatterns?: unknown; [k: string]: unknown }; [k: string]: unknown };
+
+  const context = raw.context as RawContext | undefined;
+  const legacyPattern = context?.testCoverage?.testPattern;
+  if (legacyPattern === undefined) return raw;
+
+  logger?.warn(
+    "config",
+    "context.testCoverage.testPattern is deprecated — migrate to " +
+      "execution.smartTestRunner.testFilePatterns (array). Migration shim applied.",
+    { legacyPattern },
+  );
+
+  // Drop the deprecated key regardless of whether we alias it.
+  const safeContext = context ?? {};
+  const { testPattern: _drop, ...testCoverageRest } = safeContext.testCoverage ?? {};
+  const migratedContext: RawContext = { ...safeContext, testCoverage: testCoverageRest };
+
+  const execution = raw.execution as RawExecution | undefined;
+  const smartRunnerPatterns = execution?.smartTestRunner?.testFilePatterns;
+
+  if (smartRunnerPatterns !== undefined) {
+    // User already set the canonical key — drop legacy only, do not alias.
+    return { ...raw, context: migratedContext };
+  }
+
+  // Alias: wrap the single-string pattern into an array.
+  const aliasedSmartRunner = {
+    ...execution?.smartTestRunner,
+    testFilePatterns: [legacyPattern],
+  };
+  const migratedExecution: RawExecution = {
+    ...execution,
+    smartTestRunner: aliasedSmartRunner,
+  };
+
+  return { ...raw, execution: migratedExecution, context: migratedContext };
+}

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -87,8 +87,14 @@ export interface RegressionGateConfig {
 export interface SmartTestRunnerConfig {
   /** Enable smart test runner (default: true) */
   enabled: boolean;
-  /** Glob patterns to scan for test files during import-grep fallback */
-  testFilePatterns: string[];
+  /**
+   * Glob patterns to scan for test files during import-grep fallback.
+   *
+   * Optional — undefined means "user did not set this"; resolver falls through
+   * to auto-detection then DEFAULT_TEST_FILE_PATTERNS. Explicit `[]` means
+   * "no test files in this scope" (distinct from undefined). (ADR-009)
+   */
+  testFilePatterns?: string[];
   /** Fallback strategy when path-convention mapping yields no results */
   fallback: "import-grep" | "full-suite";
 }
@@ -370,8 +376,8 @@ export interface TestCoverageConfig {
   maxTokens: number;
   /** Test directory relative to workdir (default: auto-detect) */
   testDir?: string;
-  /** Glob pattern for test files */
-  testPattern: string;
+  /** @deprecated Migrate to execution.smartTestRunner.testFilePatterns. (ADR-009) */
+  testPattern?: string;
   /** Scope test coverage to story-relevant files only (default: true) */
   scopeToStory: boolean;
 }

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -5,7 +5,6 @@
  */
 
 import { z } from "zod";
-import { DEFAULT_TEST_FILE_PATTERNS } from "../test-runners/conventions";
 
 /** Zod schema for runtime validation */
 const TokenPricingSchema = z.object({
@@ -93,13 +92,16 @@ const RegressionGateConfigSchema = z.object({
 
 const SmartTestRunnerConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  testFilePatterns: z.array(z.string()).default([...DEFAULT_TEST_FILE_PATTERNS]),
+  /**
+   * Optional — undefined means user did not set this; resolver falls through
+   * to auto-detection then DEFAULT_TEST_FILE_PATTERNS. (ADR-009)
+   */
+  testFilePatterns: z.array(z.string()).optional(),
   fallback: z.enum(["import-grep", "full-suite"]).default("import-grep"),
 });
 
 const SMART_TEST_RUNNER_DEFAULT = {
   enabled: true,
-  testFilePatterns: [...DEFAULT_TEST_FILE_PATTERNS],
   fallback: "import-grep" as const,
 };
 
@@ -107,7 +109,7 @@ const SMART_TEST_RUNNER_DEFAULT = {
 const smartTestRunnerFieldSchema = z
   .preprocess((val) => {
     if (typeof val === "boolean") {
-      return { enabled: val, testFilePatterns: [...DEFAULT_TEST_FILE_PATTERNS], fallback: "import-grep" };
+      return { enabled: val, fallback: "import-grep" };
     }
     return val;
   }, SmartTestRunnerConfigSchema)
@@ -288,18 +290,11 @@ const SemanticReviewConfigSchema = z.object({
   resetRefOnRerun: z.boolean().default(false),
   rules: z.array(z.string()).default([]),
   timeoutMs: z.number().int().positive().default(600_000),
-  excludePatterns: z
-    .array(z.string())
-    .default([
-      ":!test/",
-      ":!tests/",
-      ":!*_test.go",
-      ":!*.test.ts",
-      ":!*.spec.ts",
-      ":!**/__tests__/",
-      ":!.nax/",
-      ":!.nax-pids",
-    ]),
+  /**
+   * Optional — undefined means "derive from testFilePatterns + well-known noise dirs".
+   * Any user-set value (including []) is returned as-is. (ADR-009 §4.4)
+   */
+  excludePatterns: z.array(z.string()).optional(),
 });
 
 export const ReviewDialogueConfigSchema = z.object({
@@ -326,10 +321,13 @@ export const AdversarialReviewConfigSchema = z.object({
   timeoutMs: z.number().int().positive().default(600_000),
   /**
    * Pathspec exclusions applied in embedded mode (to collectDiff) and in ref mode
-   * (shown in the prompt's git commands). Adversarial sees test files — only nax
-   * metadata is excluded by default.
+   * (shown in the prompt's git commands).
+   *
+   * Optional — undefined means "derive from testFilePatterns + noise dirs" (adversarial
+   * defaults to minimal exclusions so it sees test files). Any user-set value (including [])
+   * is returned as-is. (ADR-009 §4.4)
    */
-  excludePatterns: z.array(z.string()).default([":!.nax/", ":!.nax-pids"]),
+  excludePatterns: z.array(z.string()).optional(),
   /**
    * When true, run semantic and adversarial reviewers concurrently via Promise.all.
    * Default false (conservative rollout). Only activates when session count is within cap.
@@ -420,7 +418,8 @@ const TestCoverageConfigSchema = z.object({
   detail: z.enum(["names-only", "names-and-counts", "describe-blocks"]).default("names-and-counts"),
   maxTokens: z.number().int().min(50).max(5000).default(500),
   testDir: z.string().optional(),
-  testPattern: z.string().default("**/*.test.{ts,js,tsx,jsx}"),
+  /** @deprecated Migrate to execution.smartTestRunner.testFilePatterns. Migration shim in src/config/migrations.ts. */
+  testPattern: z.string().optional(),
   scopeToStory: z.boolean().default(true),
 });
 

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -831,7 +831,6 @@ export const NaxConfigSchema = z
         enabled: true,
         detail: "names-and-counts",
         maxTokens: 500,
-        testPattern: "**/*.test.{ts,js,tsx,jsx}",
         scopeToStory: true,
       },
       autoDetect: {

--- a/src/context/auto-detect.ts
+++ b/src/context/auto-detect.ts
@@ -6,6 +6,7 @@
  */
 
 import { getLogger } from "../logger";
+import { DEFAULT_TEST_FILE_PATTERNS, isTestFileByPatterns } from "../test-runners";
 import { errorMessage } from "../utils/errors";
 
 export interface AutoDetectOptions {
@@ -17,6 +18,11 @@ export interface AutoDetectOptions {
   maxFiles?: number;
   /** Enable import tracing (default: false, reserved for future use) */
   traceImports?: boolean;
+  /**
+   * Configured test file glob patterns (ADR-009).
+   * Falls back to DEFAULT_TEST_FILE_PATTERNS when omitted.
+   */
+  testFilePatterns?: readonly string[];
 }
 
 /**
@@ -110,7 +116,7 @@ export function extractKeywords(title: string): string[] {
  * @returns Array of relative file paths (sorted by relevance score)
  */
 export async function autoDetectContextFiles(options: AutoDetectOptions): Promise<string[]> {
-  const { workdir, storyTitle, maxFiles = 5 } = options;
+  const { workdir, storyTitle, maxFiles = 5, testFilePatterns = DEFAULT_TEST_FILE_PATTERNS } = options;
   const logger = getLogger();
 
   // Extract keywords
@@ -171,8 +177,8 @@ export async function autoDetectContextFiles(options: AutoDetectOptions): Promis
     // Filter out test files, index files, generated files
     const filtered = allFiles.filter((filePath) => {
       const lower = filePath.toLowerCase();
-      // Exclude test files
-      if (lower.includes(".test.") || lower.includes(".spec.") || lower.includes("/test/")) {
+      // Exclude test files (ADR-009: use config-aware classification)
+      if (isTestFileByPatterns(filePath, testFilePatterns)) {
         return false;
       }
       // Exclude index files (barrel exports, low signal)

--- a/src/context/builder.ts
+++ b/src/context/builder.ts
@@ -9,9 +9,9 @@ import { getLogger } from "../logger";
 import { estimateTokens } from "../optimizer/types";
 import type { UserStory } from "../prd";
 import { countStories, getContextFiles } from "../prd";
+import { resolveTestFilePatterns } from "../test-runners/resolver";
 import { errorMessage } from "../utils/errors";
 import { autoDetectContextFiles } from "./auto-detect";
-import { resolveTestFilePatterns } from "../test-runners/resolver";
 import {
   createDependencyContext,
   createErrorContext,

--- a/src/context/builder.ts
+++ b/src/context/builder.ts
@@ -230,12 +230,16 @@ async function addFileElements(
     storyContext.workdir
   ) {
     const autoDetectConfig = storyContext.config?.context?.autoDetect;
+    const smartRunner = storyContext.config?.execution?.smartTestRunner;
+    const testFilePatterns =
+      typeof smartRunner === "object" && smartRunner !== null ? smartRunner.testFilePatterns : undefined;
     try {
       const detected = await _contextBuilderDeps.autoDetectContextFiles({
         workdir: storyContext.workdir,
         storyTitle: story.title,
         maxFiles: autoDetectConfig?.maxFiles ?? 5,
         traceImports: autoDetectConfig?.traceImports ?? false,
+        testFilePatterns,
       });
       if (detected.length > 0) {
         contextFiles = detected;

--- a/src/context/builder.ts
+++ b/src/context/builder.ts
@@ -11,6 +11,7 @@ import type { UserStory } from "../prd";
 import { countStories, getContextFiles } from "../prd";
 import { errorMessage } from "../utils/errors";
 import { autoDetectContextFiles } from "./auto-detect";
+import { resolveTestFilePatterns } from "../test-runners/resolver";
 import {
   createDependencyContext,
   createErrorContext,
@@ -178,10 +179,14 @@ async function addTestCoverageElement(
   try {
     const tcConfig = storyContext.config?.context?.testCoverage;
     const contextFiles = getContextFiles(story);
+    // Resolve effective test patterns via SSOT (ADR-009) — replaces deprecated testPattern.
+    const resolved = storyContext.config
+      ? await resolveTestFilePatterns(storyContext.config, storyContext.workdir)
+      : undefined;
     const scanResult = await generateTestCoverageSummary({
       workdir: storyContext.workdir,
       testDir: tcConfig?.testDir,
-      testPattern: tcConfig?.testPattern,
+      resolvedTestGlobs: resolved?.globs,
       maxTokens: tcConfig?.maxTokens ?? 500,
       detail: tcConfig?.detail ?? "names-and-counts",
       contextFiles: contextFiles.length > 0 ? contextFiles : undefined,

--- a/src/context/greenfield.ts
+++ b/src/context/greenfield.ts
@@ -18,8 +18,14 @@ import { globsToTestRegex } from "../test-runners/conventions";
  * correct suffix regexes. Used when the caller doesn't supply resolved patterns.
  */
 const GREENFIELD_FALLBACK_PATTERNS: readonly string[] = Object.freeze([
-  "**/*.test.ts", "**/*.test.js", "**/*.test.tsx", "**/*.test.jsx",
-  "**/*.spec.ts", "**/*.spec.js", "**/*.spec.tsx", "**/*.spec.jsx",
+  "**/*.test.ts",
+  "**/*.test.js",
+  "**/*.test.tsx",
+  "**/*.test.jsx",
+  "**/*.spec.ts",
+  "**/*.spec.js",
+  "**/*.spec.tsx",
+  "**/*.spec.jsx",
   "**/*_test.go",
   "test_*.py",
   "*_test.py",

--- a/src/context/greenfield.ts
+++ b/src/context/greenfield.ts
@@ -9,13 +9,28 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { UserStory } from "../prd/types";
+import { globsToTestRegex } from "../test-runners/conventions";
+
+/**
+ * Broad fallback patterns for the greenfield scan — covers any test file
+ * across all common languages without restricting to a single directory.
+ * Patterns are expanded (no brace alternatives) so globsToTestRegex can build
+ * correct suffix regexes. Used when the caller doesn't supply resolved patterns.
+ */
+const GREENFIELD_FALLBACK_PATTERNS: readonly string[] = Object.freeze([
+  "**/*.test.ts", "**/*.test.js", "**/*.test.tsx", "**/*.test.jsx",
+  "**/*.spec.ts", "**/*.spec.js", "**/*.spec.tsx", "**/*.spec.jsx",
+  "**/*_test.go",
+  "test_*.py",
+  "*_test.py",
+]);
 
 /**
  * Recursively scan directory for test files.
  * Ignores node_modules, dist, build, .next directories.
  * Throws error if root directory is unreadable.
  */
-async function scanForTestFiles(dir: string, testPattern: RegExp, isRootCall = true): Promise<string[]> {
+async function scanForTestFiles(dir: string, testPatterns: RegExp[], isRootCall = true): Promise<string[]> {
   const results: string[] = [];
   const ignoreDirs = new Set(["node_modules", "dist", "build", ".next", ".git"]);
 
@@ -30,11 +45,11 @@ async function scanForTestFiles(dir: string, testPattern: RegExp, isRootCall = t
         if (ignoreDirs.has(entry.name)) continue;
 
         // Recursively scan subdirectories (not root call)
-        const subResults = await scanForTestFiles(fullPath, testPattern, false);
+        const subResults = await scanForTestFiles(fullPath, testPatterns, false);
         results.push(...subResults);
       } else if (entry.isFile()) {
-        // Check if file matches test pattern
-        if (testPattern.test(entry.name)) {
+        // Check if file matches any test pattern
+        if (testPatterns.some((re) => re.test(entry.name))) {
           results.push(fullPath);
         }
       }
@@ -51,39 +66,17 @@ async function scanForTestFiles(dir: string, testPattern: RegExp, isRootCall = t
 }
 
 /**
- * Convert simple glob pattern to regex.
- * Supports:
- * - ** (any directory depth)
- * - * (any characters except /)
- * - {a,b,c} (alternatives)
- */
-function globToRegex(pattern: string): RegExp {
-  // Extract filename pattern from glob (everything after last /)
-  const parts = pattern.split("/");
-  const filePattern = parts[parts.length - 1];
-
-  // Convert glob syntax to regex
-  const regexStr = filePattern
-    .replace(/\./g, "\\.") // Escape dots
-    .replace(/\*/g, "[^/]*") // * = any chars except /
-    .replace(/\{([^}]+)\}/g, (_, group) => `(${group.replace(/,/g, "|")})`) // {a,b} = (a|b)
-    .replace(/\\\.\\\*/g, "\\.[^/]*"); // Fix escaped .* back to .\*
-
-  return new RegExp(`${regexStr}$`); // nosemgrep: detect-non-literal-regexp — pattern from internal .gitignore, not user input
-}
-
-/**
  * Detect if a story is greenfield based on test file presence in workdir.
  *
  * A story is greenfield if:
- * - No test files exist matching the test pattern in the working directory
+ * - No test files exist matching any of the given patterns in the working directory
  *
  * This prevents the TDD test-writer from struggling to create tests when there are
  * no existing test examples to follow.
  *
  * @param story - User story to check
  * @param workdir - Working directory to scan for test files
- * @param testPattern - Glob pattern for test files (default: "**\/*.{test,spec}.{ts,js,tsx,jsx}")
+ * @param patterns - Glob patterns for test files (default: DEFAULT_TEST_FILE_PATTERNS)
  * @returns true if no test files exist (greenfield), false otherwise
  *
  * @example
@@ -100,11 +93,11 @@ function globToRegex(pattern: string): RegExp {
 export async function isGreenfieldStory(
   _story: UserStory,
   workdir: string,
-  testPattern = "**/*.{test,spec}.{ts,js,tsx,jsx}",
+  patterns?: readonly string[],
 ): Promise<boolean> {
   try {
-    const regex = globToRegex(testPattern);
-    const testFiles = await scanForTestFiles(workdir, regex);
+    const regexes = globsToTestRegex(patterns ?? GREENFIELD_FALLBACK_PATTERNS);
+    const testFiles = await scanForTestFiles(workdir, regexes);
     return testFiles.length === 0;
   } catch (error) {
     // If scan fails completely (e.g., workdir doesn't exist), assume not greenfield (safe fallback)

--- a/src/context/test-scanner.ts
+++ b/src/context/test-scanner.ts
@@ -141,8 +141,14 @@ function extractGlobSuffixes(globs: readonly string[]): string[] {
 
 /** Default TS/JS suffixes used when no resolvedGlobs are provided */
 const DEFAULT_DERIVE_SUFFIXES = [
-  ".test.ts", ".test.js", ".test.tsx", ".test.jsx",
-  ".spec.ts", ".spec.js", ".spec.tsx", ".spec.jsx",
+  ".test.ts",
+  ".test.js",
+  ".test.tsx",
+  ".test.jsx",
+  ".spec.ts",
+  ".spec.js",
+  ".spec.tsx",
+  ".spec.jsx",
 ];
 
 /**
@@ -195,9 +201,8 @@ export function deriveTestPatterns(contextFiles: string[], resolvedGlobs?: reado
  */
 async function detectTestDir(workdir: string, resolvedGlobs?: readonly string[]): Promise<string | null> {
   const resolvedDirs = resolvedGlobs ? extractTestDirs(resolvedGlobs) : [];
-  const candidateDirs = resolvedDirs.length > 0
-    ? [...new Set([...resolvedDirs, ...COMMON_TEST_DIRS])]
-    : COMMON_TEST_DIRS;
+  const candidateDirs =
+    resolvedDirs.length > 0 ? [...new Set([...resolvedDirs, ...COMMON_TEST_DIRS])] : COMMON_TEST_DIRS;
 
   for (const dir of candidateDirs) {
     const fullPath = path.join(workdir, dir);
@@ -245,8 +250,9 @@ export async function scanTestFiles(options: TestScanOptions): Promise<TestFileI
 
   // Derive scan pattern: prefer explicit override, then resolved globs (stripped of testDir
   // prefix so the Glob runs correctly relative to scanDir), then TS/JS default.
-  const testPattern = explicitTestPattern
-    ?? (resolvedTestGlobs ? deriveScanGlob(resolvedTestGlobs, testDir) : "**/*.test.{ts,js,tsx,jsx}");
+  const testPattern =
+    explicitTestPattern ??
+    (resolvedTestGlobs ? deriveScanGlob(resolvedTestGlobs, testDir) : "**/*.test.{ts,js,tsx,jsx}");
 
   const scanDir = path.join(workdir, testDir);
 

--- a/src/context/test-scanner.ts
+++ b/src/context/test-scanner.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 import { Glob } from "bun";
 import { getLogger } from "../logger";
 import { estimateTokens } from "../optimizer/types";
+import { extractTestDirs } from "../test-runners/conventions";
 
 // ============================================================================
 // Types
@@ -26,6 +27,8 @@ export interface TestScanOptions {
   testDir?: string;
   /** Glob pattern for test files (default: "**\/*.test.{ts,js,tsx,jsx}") */
   testPattern?: string;
+  /** Resolved test glob patterns from resolveTestFilePatterns() — used to derive testDirs and deriveTestPatterns suffixes */
+  resolvedTestGlobs?: readonly string[];
   /** Max tokens for the summary (default: 500) */
   maxTokens?: number;
   /** Summary detail level (default: "names-and-counts") */
@@ -114,48 +117,72 @@ export function extractTestStructure(source: string): { describes: DescribeBlock
 // File Scanning
 // ============================================================================
 
-/** Common test directory names to auto-detect */
+/** Fallback test directory names used when resolver patterns yield no dirs */
 const COMMON_TEST_DIRS = ["test", "tests", "__tests__", "src/__tests__", "spec"];
+
+/**
+ * Extract trailing suffixes from glob patterns (everything after the last `*`).
+ * e.g., "test/**\/*.test.ts" → ".test.ts", "**\/*_test.go" → "_test.go"
+ *
+ * Only returns suffixes that contain a test discriminator (.test., .spec., _test., etc.)
+ * so that generic language patterns like "test/**\/*.ts" don't corrupt scoping logic.
+ */
+function extractGlobSuffixes(globs: readonly string[]): string[] {
+  const TEST_DISCRIMINATOR = /(\.(test|spec)\.|_(test|spec)\.)/i;
+  const suffixes: string[] = [];
+  for (const g of globs) {
+    const lastStar = g.lastIndexOf("*");
+    if (lastStar === -1) continue;
+    const s = g.slice(lastStar + 1);
+    if (s.length > 0 && TEST_DISCRIMINATOR.test(s)) suffixes.push(s);
+  }
+  return suffixes;
+}
+
+/** Default TS/JS suffixes used when no resolvedGlobs are provided */
+const DEFAULT_DERIVE_SUFFIXES = [
+  ".test.ts", ".test.js", ".test.tsx", ".test.jsx",
+  ".spec.ts", ".spec.js", ".spec.tsx", ".spec.jsx",
+];
 
 /**
  * Derive test file patterns from source file paths.
  *
- * Maps source files to their likely test file counterparts:
- * - src/foo.ts → test/foo.test.ts, test/foo.spec.ts
- * - src/bar/baz.service.ts → test/bar/baz.service.test.ts, test/baz.service.test.ts
+ * Maps source files to their likely test file counterparts using the
+ * resolved glob suffixes when available (ADR-009), falling back to the
+ * hardcoded TS/JS variants.
  *
  * @param contextFiles - Array of source file paths (relative to workdir)
- * @returns Array of test file path patterns (basename patterns for matching)
+ * @param resolvedGlobs - Resolved glob patterns from resolveTestFilePatterns(); used to derive suffixes
+ * @returns Array of test file basename patterns for matching
  */
-export function deriveTestPatterns(contextFiles: string[]): string[] {
+export function deriveTestPatterns(contextFiles: string[], resolvedGlobs?: readonly string[]): string[] {
   const patterns = new Set<string>();
+  const suffixes = resolvedGlobs ? extractGlobSuffixes(resolvedGlobs) : DEFAULT_DERIVE_SUFFIXES;
+  const effectiveSuffixes = suffixes.length > 0 ? suffixes : DEFAULT_DERIVE_SUFFIXES;
 
   for (const filePath of contextFiles) {
     const basename = path.basename(filePath);
-    const basenameNoExt = basename.replace(/\.(ts|js|tsx|jsx)$/, "");
+    // Strip last extension (works for .ts, .go, .py, etc.)
+    const basenameNoExt = basename.replace(/\.[^.]+$/, "");
 
-    // Pattern 1: exact basename match with .test/.spec extension
-    // e.g., foo.ts → foo.test.ts, foo.spec.ts
-    patterns.add(`${basenameNoExt}.test.ts`);
-    patterns.add(`${basenameNoExt}.test.js`);
-    patterns.add(`${basenameNoExt}.test.tsx`);
-    patterns.add(`${basenameNoExt}.test.jsx`);
-    patterns.add(`${basenameNoExt}.spec.ts`);
-    patterns.add(`${basenameNoExt}.spec.js`);
-    patterns.add(`${basenameNoExt}.spec.tsx`);
-    patterns.add(`${basenameNoExt}.spec.jsx`);
+    for (const suffix of effectiveSuffixes) {
+      patterns.add(`${basenameNoExt}${suffix}`);
+    }
 
-    // Pattern 2: if basename contains .service/.controller/etc, also match without it
-    // e.g., foo.service.ts → foo.test.ts
-    const simpleBasename = basenameNoExt.replace(
-      /\.(service|controller|resolver|module|guard|middleware|util|helper)$/,
-      "",
-    );
-    if (simpleBasename !== basenameNoExt) {
-      patterns.add(`${simpleBasename}.test.ts`);
-      patterns.add(`${simpleBasename}.test.js`);
-      patterns.add(`${simpleBasename}.spec.ts`);
-      patterns.add(`${simpleBasename}.spec.js`);
+    // For TS/JS: if basename contains .service/.controller/etc, also match without it
+    // e.g., foo.service.ts → foo.test.ts (only applies when using default suffixes)
+    if (!resolvedGlobs) {
+      const simpleBasename = basenameNoExt.replace(
+        /\.(service|controller|resolver|module|guard|middleware|util|helper)$/,
+        "",
+      );
+      if (simpleBasename !== basenameNoExt) {
+        patterns.add(`${simpleBasename}.test.ts`);
+        patterns.add(`${simpleBasename}.test.js`);
+        patterns.add(`${simpleBasename}.spec.ts`);
+        patterns.add(`${simpleBasename}.spec.js`);
+      }
     }
   }
 
@@ -164,9 +191,15 @@ export function deriveTestPatterns(contextFiles: string[]): string[] {
 
 /**
  * Auto-detect test directory by checking common locations.
+ * When resolvedGlobs is provided, dirs derived from those patterns are tried first.
  */
-async function detectTestDir(workdir: string): Promise<string | null> {
-  for (const dir of COMMON_TEST_DIRS) {
+async function detectTestDir(workdir: string, resolvedGlobs?: readonly string[]): Promise<string | null> {
+  const resolvedDirs = resolvedGlobs ? extractTestDirs(resolvedGlobs) : [];
+  const candidateDirs = resolvedDirs.length > 0
+    ? [...new Set([...resolvedDirs, ...COMMON_TEST_DIRS])]
+    : COMMON_TEST_DIRS;
+
+  for (const dir of candidateDirs) {
     const fullPath = path.join(workdir, dir);
     try {
       // Bun.file().exists() returns false for directories, use shell test -d
@@ -184,14 +217,36 @@ async function detectTestDir(workdir: string): Promise<string | null> {
  * @param options - Scan options
  * @returns Array of parsed test file info
  */
+/**
+ * Derive a Glob scan pattern relative to a scanDir from resolved test globs.
+ *
+ * Resolved globs may include a directory prefix (e.g. "test/**\/*.test.ts").
+ * Since the Glob scan runs relative to scanDir (already inside testDir), we
+ * strip that prefix so the pattern is correct relative to scanDir.
+ * Globs starting with "**\/" are already relative and used as-is.
+ */
+function deriveScanGlob(resolvedTestGlobs: readonly string[], testDir: string): string {
+  const prefix = `${testDir}/`;
+  for (const glob of resolvedTestGlobs) {
+    if (glob.startsWith(prefix)) return glob.slice(prefix.length);
+    if (glob.startsWith("**/")) return glob; // relative pattern, works from any dir
+  }
+  return "**/*.test.{ts,js,tsx,jsx}";
+}
+
 export async function scanTestFiles(options: TestScanOptions): Promise<TestFileInfo[]> {
-  const { workdir, testPattern = "**/*.test.{ts,js,tsx,jsx}", contextFiles, scopeToStory = true } = options;
+  const { workdir, testPattern: explicitTestPattern, contextFiles, scopeToStory = true, resolvedTestGlobs } = options;
   let testDir = options.testDir;
 
-  // Auto-detect test directory if not specified
+  // Auto-detect test directory if not specified, prioritising dirs from resolved globs
   if (!testDir) {
-    testDir = (await detectTestDir(workdir)) || "test";
+    testDir = (await detectTestDir(workdir, resolvedTestGlobs)) || "test";
   }
+
+  // Derive scan pattern: prefer explicit override, then resolved globs (stripped of testDir
+  // prefix so the Glob runs correctly relative to scanDir), then TS/JS default.
+  const testPattern = explicitTestPattern
+    ?? (resolvedTestGlobs ? deriveScanGlob(resolvedTestGlobs, testDir) : "**/*.test.{ts,js,tsx,jsx}");
 
   const scanDir = path.join(workdir, testDir);
 
@@ -204,7 +259,7 @@ export async function scanTestFiles(options: TestScanOptions): Promise<TestFileI
   // Derive test patterns from context files if scoping is enabled
   let allowedBasenames: Set<string> | null = null;
   if (scopeToStory && contextFiles && contextFiles.length > 0) {
-    const patterns = deriveTestPatterns(contextFiles);
+    const patterns = deriveTestPatterns(contextFiles, resolvedTestGlobs);
     allowedBasenames = new Set(patterns);
   }
 

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -23,11 +23,11 @@ import { getSafeLogger } from "../../logger";
 import { pipelineEventBus } from "../../pipeline/event-bus";
 import type { AgentGetFn } from "../../pipeline/types";
 import { loadPlugins } from "../../plugins/loader";
-import { resolveTestFilePatterns } from "../../test-runners/resolver";
 import type { PluginRegistry } from "../../plugins/registry";
 import type { PRD } from "../../prd";
 import { countStories, loadPRD, savePRD } from "../../prd";
 import { detectProjectProfile } from "../../project";
+import { resolveTestFilePatterns } from "../../test-runners/resolver";
 import { NAX_BUILD_INFO, NAX_COMMIT, NAX_VERSION } from "../../version";
 import { installCrashHandlers } from "../crash-recovery";
 import { acquireLock, releaseLock } from "../helpers";
@@ -218,8 +218,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     // Build a test-file classifier from resolved patterns so the plugin loader
     // honours custom testFilePatterns (ADR-009) instead of hardcoded TS suffixes.
     const resolvedPatterns = await resolveTestFilePatterns(config, workdir);
-    const isTestFileFn = (filename: string): boolean =>
-      resolvedPatterns.regex.some((re) => re.test(filename));
+    const isTestFileFn = (filename: string): boolean => resolvedPatterns.regex.some((re) => re.test(filename));
     const pluginRegistry = await loadPlugins(
       globalPluginsDir,
       projectPluginsDir,

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -23,6 +23,7 @@ import { getSafeLogger } from "../../logger";
 import { pipelineEventBus } from "../../pipeline/event-bus";
 import type { AgentGetFn } from "../../pipeline/types";
 import { loadPlugins } from "../../plugins/loader";
+import { resolveTestFilePatterns } from "../../test-runners/resolver";
 import type { PluginRegistry } from "../../plugins/registry";
 import type { PRD } from "../../prd";
 import { countStories, loadPRD, savePRD } from "../../prd";
@@ -214,12 +215,18 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     const globalPluginsDir = path.join(os.homedir(), ".nax", "plugins");
     const projectPluginsDir = path.join(workdir, ".nax", "plugins");
     const configPlugins = config.plugins || [];
+    // Build a test-file classifier from resolved patterns so the plugin loader
+    // honours custom testFilePatterns (ADR-009) instead of hardcoded TS suffixes.
+    const resolvedPatterns = await resolveTestFilePatterns(config, workdir);
+    const isTestFileFn = (filename: string): boolean =>
+      resolvedPatterns.regex.some((re) => re.test(filename));
     const pluginRegistry = await loadPlugins(
       globalPluginsDir,
       projectPluginsDir,
       configPlugins,
       workdir,
       config.disabledPlugins,
+      isTestFileFn,
     );
 
     // Log plugins loaded

--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -20,8 +20,15 @@ import type { PipelineContext } from "../types";
 /**
  * Split adversarial findings in a check result into test-file vs source-file buckets.
  * Returns null for each bucket when there are no findings for that scope.
+ *
+ * @param check            - The adversarial review check result to split.
+ * @param testFilePatterns - Configured test file globs (ADR-009). When undefined, falls back to
+ *   the broad language-agnostic regex (Phase 1 backward-compat path).
  */
-export function splitAdversarialFindingsByScope(check: ReviewCheckResult): {
+export function splitAdversarialFindingsByScope(
+  check: ReviewCheckResult,
+  testFilePatterns?: readonly string[],
+): {
   testFindings: ReviewCheckResult | null;
   sourceFindings: ReviewCheckResult | null;
 } {
@@ -29,8 +36,8 @@ export function splitAdversarialFindingsByScope(check: ReviewCheckResult): {
     return { testFindings: null, sourceFindings: null };
   }
 
-  const testFs = check.findings.filter((f) => isTestFile(f.file ?? ""));
-  const sourceFs = check.findings.filter((f) => !isTestFile(f.file ?? ""));
+  const testFs = check.findings.filter((f) => isTestFile(f.file ?? "", testFilePatterns));
+  const sourceFs = check.findings.filter((f) => !isTestFile(f.file ?? "", testFilePatterns));
 
   const toCheck = (findings: typeof testFs): ReviewCheckResult | null => {
     if (findings.length === 0) return null;

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -156,13 +156,17 @@ export const autofixStage: PipelineStage = {
     // files are irrelevant and unresolvable within the story's scope.  When every failing
     // check is an adversarial check whose findings are all test-file scoped, treat the
     // review as passed (with a warning) rather than launching any agent session.
+    const testFilePatterns =
+      typeof ctx.rootConfig.execution?.smartTestRunner === "object"
+        ? ctx.rootConfig.execution.smartTestRunner?.testFilePatterns
+        : undefined;
     if (ctx.routing.testStrategy === "no-test") {
       const failedChecks = (reviewResult.checks ?? []).filter((c) => !c.success);
       if (
         failedChecks.length > 0 &&
         failedChecks.every((c) => {
           if (c.check !== "adversarial") return false;
-          const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(c);
+          const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(c, testFilePatterns);
           return testFindings !== null && sourceFindings === null;
         })
       ) {
@@ -340,9 +344,13 @@ async function runAgentRectification(
   let implementerChecks = failedChecks;
   let testWriterChecks: ReviewCheckResult[] = [];
 
+  const stageTestFilePatterns =
+    typeof ctx.rootConfig.execution?.smartTestRunner === "object"
+      ? ctx.rootConfig.execution.smartTestRunner?.testFilePatterns
+      : undefined;
   for (const check of failedChecks) {
     if (check.check === "adversarial" && check.findings?.length) {
-      const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check);
+      const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check, stageTestFilePatterns);
       if (testFindings) testWriterChecks = [...testWriterChecks, testFindings];
       if (sourceFindings) {
         // Use reference equality (c === check) rather than type matching so that multiple

--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -120,11 +120,9 @@ export const verifyStage: PipelineStage = {
         // Pass 2: import-grep fallback.
         // Phase 1 interim: importGrepFallback requires string[]; resolver not yet wired here.
         // Phase 2 will call resolveTestFilePatterns() upstream and pass resolved.globs instead.
-        const pass2Files = await _smartRunnerDeps.importGrepFallback(
-          sourceFiles,
-          ctx.workdir,
-          [...(smartRunnerConfig.testFilePatterns ?? DEFAULT_TEST_FILE_PATTERNS)],
-        );
+        const pass2Files = await _smartRunnerDeps.importGrepFallback(sourceFiles, ctx.workdir, [
+          ...(smartRunnerConfig.testFilePatterns ?? DEFAULT_TEST_FILE_PATTERNS),
+        ]);
         if (pass2Files.length > 0) {
           logger.info("verify", `[smart-runner] Pass 2: import-grep matched ${pass2Files.length} test files`, {
             storyId: ctx.story.id,

--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -117,11 +117,13 @@ export const verifyStage: PipelineStage = {
         effectiveCommand = buildScopedCommand(pass1Files, rawTestCommand, testScopedTemplate);
         isFullSuite = false;
       } else if (smartRunnerConfig.fallback === "import-grep") {
-        // Pass 2: import-grep fallback
+        // Pass 2: import-grep fallback.
+        // Phase 1 interim: importGrepFallback requires string[]; resolver not yet wired here.
+        // Phase 2 will call resolveTestFilePatterns() upstream and pass resolved.globs instead.
         const pass2Files = await _smartRunnerDeps.importGrepFallback(
           sourceFiles,
           ctx.workdir,
-          smartRunnerConfig.testFilePatterns,
+          [...(smartRunnerConfig.testFilePatterns ?? DEFAULT_TEST_FILE_PATTERNS)],
         );
         if (pass2Files.length > 0) {
           logger.info("verify", `[smart-runner] Pass 2: import-grep matched ${pass2Files.length} test files`, {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -92,6 +92,7 @@ export interface LoadedPlugin {
  * @param configPlugins - Explicit plugin entries from config
  * @param projectRoot - Project root directory for resolving relative paths in config
  * @param disabledPlugins - List of plugin names to disable (auto-discovered plugins only)
+ * @param isTestFileFn - Optional classifier from resolveTestFilePatterns; falls back to hardcoded defaults
  * @returns PluginRegistry with all loaded plugins and their sources
  */
 export async function loadPlugins(
@@ -100,6 +101,7 @@ export async function loadPlugins(
   configPlugins: PluginConfigEntry[],
   projectRoot?: string,
   disabledPlugins?: string[],
+  isTestFileFn?: (filename: string) => boolean,
 ): Promise<PluginRegistry> {
   const loadedPlugins: LoadedPlugin[] = [];
   const effectiveProjectRoot = projectRoot || projectDir;
@@ -108,7 +110,7 @@ export async function loadPlugins(
   const logger = getSafeLogger();
 
   // 1. Load plugins from global directory
-  const globalPlugins = await discoverPlugins(globalDir);
+  const globalPlugins = await discoverPlugins(globalDir, isTestFileFn);
   for (const plugin of globalPlugins) {
     const pluginName = extractPluginName(plugin.path);
     if (disabledSet.has(pluginName)) {
@@ -129,7 +131,7 @@ export async function loadPlugins(
   }
 
   // 2. Load plugins from project directory
-  const projectPlugins = await discoverPlugins(projectDir);
+  const projectPlugins = await discoverPlugins(projectDir, isTestFileFn);
   for (const plugin of projectPlugins) {
     const pluginName = extractPluginName(plugin.path);
     if (disabledSet.has(pluginName)) {
@@ -187,9 +189,13 @@ export async function loadPlugins(
  * - Directory plugins with index.ts/index.js/index.mjs
  *
  * @param dir - Directory to scan
+ * @param isTestFileFn - Optional classifier; falls back to hardcoded defaults
  * @returns Array of discovered plugin paths
  */
-async function discoverPlugins(dir: string): Promise<Array<{ path: string }>> {
+async function discoverPlugins(
+  dir: string,
+  isTestFileFn?: (filename: string) => boolean,
+): Promise<Array<{ path: string }>> {
   const discovered: Array<{ path: string }> = [];
 
   try {
@@ -200,7 +206,7 @@ async function discoverPlugins(dir: string): Promise<Array<{ path: string }>> {
 
       if (entry.isFile()) {
         // Single-file plugin
-        if (isPluginFile(entry.name)) {
+        if (isPluginFile(entry.name, isTestFileFn)) {
           discovered.push({ path: fullPath });
         }
       } else if (entry.isDirectory()) {
@@ -235,10 +241,15 @@ async function discoverPlugins(dir: string): Promise<Array<{ path: string }>> {
  * Check if a filename is a valid plugin file.
  *
  * @param filename - Filename to check
+ * @param isTestFileFn - Optional classifier from resolveTestFilePatterns; falls back to hardcoded defaults
  * @returns Whether the file could be a plugin
  */
-function isPluginFile(filename: string): boolean {
-  return /\.(ts|js|mjs)$/.test(filename) && !filename.endsWith(".test.ts") && !filename.endsWith(".spec.ts");
+const FALLBACK_TEST_FILE_RE = /\.(test|spec)\.(ts|js|tsx|jsx|mjs)$/;
+
+function isPluginFile(filename: string, isTestFileFn?: (filename: string) => boolean): boolean {
+  if (!/\.(ts|js|mjs)$/.test(filename)) return false;
+  if (isTestFileFn) return !isTestFileFn(filename);
+  return !FALLBACK_TEST_FILE_RE.test(filename);
 }
 
 /**

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -194,7 +194,11 @@ export async function runAdversarialReview(
         durationMs: Date.now() - startTime,
       };
     }
-    testInventory = await computeTestInventory(workdir, effectiveRef);
+    const testFilePatterns =
+      (typeof naxConfig?.execution?.smartTestRunner === "object"
+        ? naxConfig.execution.smartTestRunner?.testFilePatterns
+        : undefined) ?? undefined;
+    testInventory = await computeTestInventory(workdir, effectiveRef, testFilePatterns);
   }
 
   // Resolve agent

--- a/src/review/diff-utils.ts
+++ b/src/review/diff-utils.ts
@@ -141,7 +141,7 @@ function buildSuffixStrippers(testFilePatterns?: readonly string[]): RegExp[] {
     if (lastStar === -1) continue;
     const suffix = pattern.slice(lastStar + 1);
     if (suffix.length > 0) {
-      regexes.push(new RegExp(suffix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "$"));
+      regexes.push(new RegExp(`${suffix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`));
     }
   }
   return regexes.length > 0 ? regexes : DEFAULT_SUFFIX_STRIPPERS;

--- a/src/review/diff-utils.ts
+++ b/src/review/diff-utils.ts
@@ -126,6 +126,36 @@ export async function resolveEffectiveRef(
   return undefined;
 }
 
+/** Default suffix-strip regexes when no testFilePatterns are configured. */
+const DEFAULT_SUFFIX_STRIPPERS = [/\.(test|spec)\.(ts|js|tsx|jsx)$/, /_test\.go$/];
+
+/**
+ * Build regexes that strip test suffixes from basenames.
+ * Derived from the glob patterns (suffix after last `*`), falling back to defaults.
+ */
+function buildSuffixStrippers(testFilePatterns?: readonly string[]): RegExp[] {
+  if (!testFilePatterns || testFilePatterns.length === 0) return DEFAULT_SUFFIX_STRIPPERS;
+  const regexes: RegExp[] = [];
+  for (const pattern of testFilePatterns) {
+    const lastStar = pattern.lastIndexOf("*");
+    if (lastStar === -1) continue;
+    const suffix = pattern.slice(lastStar + 1);
+    if (suffix.length > 0) {
+      regexes.push(new RegExp(suffix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "$"));
+    }
+  }
+  return regexes.length > 0 ? regexes : DEFAULT_SUFFIX_STRIPPERS;
+}
+
+/** Strip the first matching test suffix from a basename, returning the source basename. */
+function stripTestSuffix(base: string, strippers: RegExp[]): string {
+  for (const re of strippers) {
+    const stripped = base.replace(re, "");
+    if (stripped !== base) return stripped;
+  }
+  return base;
+}
+
 /**
  * Classify added files in the story's diff into test files vs source files without tests.
  * Used by adversarial review (embedded mode) to pre-compute a TestInventory for the prompt.
@@ -165,10 +195,12 @@ export async function computeTestInventory(
 
   // For each added source file, check whether a matching test file was also added.
   // Match by basename: src/foo/bar.ts → looks for bar.test.ts, bar.spec.ts in addedFiles.
+  // Suffixes are derived from testFilePatterns so custom patterns (e.g. *.integration.ts) normalize correctly.
+  const suffixStrippers = buildSuffixStrippers(testFilePatterns);
   const testFileBasenames = new Set(
     addedTestFiles.map((f) => {
       const base = f.split("/").at(-1) ?? f;
-      return base.replace(/\.(test|spec)\.(ts|js|tsx|jsx)$/, "").replace(/_test\.go$/, "");
+      return stripTestSuffix(base, suffixStrippers);
     }),
   );
 

--- a/src/review/diff-utils.ts
+++ b/src/review/diff-utils.ts
@@ -131,10 +131,16 @@ export async function resolveEffectiveRef(
  * Used by adversarial review (embedded mode) to pre-compute a TestInventory for the prompt.
  *
  * Detection heuristics:
- * - Test file: path matches *.test.ts, *.spec.ts, *_test.go, or is under test/ / tests/ / __tests__/
- * - Source file without test: new source file whose basename has no matching test file in the added set
+ * - Test file: path matches configured testFilePatterns (ADR-009), falling back to defaults.
+ * - Source file without test: new source file whose basename has no matching test file in the added set.
+ *
+ * @param testFilePatterns - Configured test file globs (ADR-009). Falls back to DEFAULT_TEST_FILE_PATTERNS.
  */
-export async function computeTestInventory(workdir: string, storyGitRef: string): Promise<TestInventory> {
+export async function computeTestInventory(
+  workdir: string,
+  storyGitRef: string,
+  testFilePatterns?: readonly string[],
+): Promise<TestInventory> {
   const proc = _diffUtilsDeps.spawn({
     cmd: ["git", "diff", "--name-only", "--diff-filter=A", `${storyGitRef}..HEAD`],
     cwd: workdir,
@@ -154,8 +160,8 @@ export async function computeTestInventory(workdir: string, storyGitRef: string)
 
   const addedFiles = stdout.trim().split("\n").filter(Boolean);
 
-  const addedTestFiles = addedFiles.filter(isTestFile);
-  const addedSourceFiles = addedFiles.filter((f) => !isTestFile(f));
+  const addedTestFiles = addedFiles.filter((f) => isTestFile(f, testFilePatterns));
+  const addedSourceFiles = addedFiles.filter((f) => !isTestFile(f, testFilePatterns));
 
   // For each added source file, check whether a matching test file was also added.
   // Match by basename: src/foo/bar.ts → looks for bar.test.ts, bar.spec.ts in addedFiles.

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -245,16 +245,7 @@ export class ReviewOrchestrator {
           resetRefOnRerun: false,
           rules: [] as string[],
           timeoutMs: 600_000,
-          excludePatterns: [
-            ":!test/",
-            ":!tests/",
-            ":!*_test.go",
-            ":!*.test.ts",
-            ":!*.spec.ts",
-            ":!**/__tests__/",
-            ":!.nax/",
-            ":!.nax-pids",
-          ] as string[],
+          // excludePatterns omitted — runSemanticReview derives via resolveReviewExcludePatterns (ADR-009)
         };
         // advConfig is guaranteed non-null here: canParallelize required advConfig?.parallel === true
         const adversarialCfg: AdversarialReviewConfig = advConfig as AdversarialReviewConfig;

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -284,16 +284,7 @@ export async function runReview(
         resetRefOnRerun: false,
         rules: [] as string[],
         timeoutMs: 600_000,
-        excludePatterns: [
-          ":!test/",
-          ":!tests/",
-          ":!*_test.go",
-          ":!*.test.ts",
-          ":!*.spec.ts",
-          ":!**/__tests__/",
-          ":!.nax/",
-          ":!.nax-pids",
-        ],
+        // excludePatterns omitted — runSemanticReview derives via resolveReviewExcludePatterns (ADR-009)
       };
       const runSemantic = _reviewSemanticDeps.runSemanticReview;
       const result = await runSemantic(
@@ -331,7 +322,7 @@ export async function runReview(
         diffMode: "ref" as const,
         rules: [] as string[],
         timeoutMs: 600_000,
-        excludePatterns: [":!.nax/", ":!.nax-pids"] as string[],
+        // excludePatterns omitted — collectDiff always appends ALWAYS_EXCLUDED (.nax/ etc.) (ADR-009)
         parallel: false,
         maxConcurrentSessions: 2,
       };

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -18,6 +18,7 @@ import type { DebateSessionOptions } from "../debate";
 import { getSafeLogger } from "../logger";
 import type { ReviewFinding } from "../plugins/types";
 import { ReviewPromptBuilder } from "../prompts";
+import { resolveReviewExcludePatterns, resolveTestFilePatterns } from "../test-runners";
 import { tryParseLLMJson } from "../utils/llm-json";
 import { DIFF_CAP_BYTES, collectDiff, collectDiffStat, resolveEffectiveRef, truncateDiff } from "./diff-utils";
 import { writeReviewAudit } from "./review-audit";
@@ -173,9 +174,14 @@ export async function runSemanticReview(
   // In ref mode: pass stat + ref to reviewer; reviewer self-serves the full diff via tools.
   const stat = await collectDiffStat(workdir, effectiveRef);
 
+  // ADR-009: resolve effective exclude patterns from config (falls back to DEFAULT_TEST_FILE_PATTERNS
+  // when semanticConfig.excludePatterns is undefined — no behaviour change for default config).
+  const resolved = await resolveTestFilePatterns(naxConfig ?? DEFAULT_CONFIG, workdir);
+  const excludePatterns = [...resolveReviewExcludePatterns(semanticConfig.excludePatterns, resolved)];
+
   let diff: string | undefined;
   if (diffMode === "embedded") {
-    const rawDiff = await collectDiff(workdir, effectiveRef, semanticConfig.excludePatterns);
+    const rawDiff = await collectDiff(workdir, effectiveRef, excludePatterns);
     diff = truncateDiff(rawDiff, rawDiff.length > DIFF_CAP_BYTES ? stat : undefined);
     if (!diff) {
       return {

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -44,8 +44,11 @@ export interface SemanticReviewConfig {
   rules: string[];
   /** Timeout in milliseconds for the LLM call (default: 600_000) */
   timeoutMs: number;
-  /** Git pathspec patterns to exclude from the semantic diff (e.g. ':!test/', ':!*.test.ts') */
-  excludePatterns: string[];
+  /**
+   * Git pathspec patterns to exclude from the semantic diff.
+   * Optional — undefined means "derive from testFilePatterns + well-known noise dirs". (ADR-009 §4.4)
+   */
+  excludePatterns?: string[];
 }
 
 /** Review check result */
@@ -137,8 +140,11 @@ export interface AdversarialReviewConfig {
   rules: string[];
   /** Timeout in milliseconds (default: 600_000) */
   timeoutMs: number;
-  /** Pathspec exclusions for embedded mode. Default empty (adversarial sees test files). */
-  excludePatterns: string[];
+  /**
+   * Pathspec exclusions for embedded mode.
+   * Optional — undefined means "derive from testFilePatterns + noise dirs". (ADR-009 §4.4)
+   */
+  excludePatterns?: string[];
   /** When true, run semantic and adversarial concurrently. Default false. */
   parallel: boolean;
   /** Maximum combined reviewer sessions before falling back to sequential. Default 2. */

--- a/src/tdd/index.ts
+++ b/src/tdd/index.ts
@@ -5,8 +5,8 @@ export type {
   TddSessionResult,
   ThreeSessionTddResult,
 } from "./types";
+export { isTestFile } from "../test-runners";
 export {
-  isTestFile,
   isSourceFile,
   getChangedFiles,
   verifyTestWriterIsolation,

--- a/src/tdd/isolation.ts
+++ b/src/tdd/isolation.ts
@@ -70,9 +70,7 @@ export async function verifyTestWriterIsolation(
   testFilePatterns: readonly string[] = DEFAULT_TEST_FILE_PATTERNS,
 ): Promise<IsolationCheck> {
   const changed = await getChangedFiles(workdir, beforeRef);
-  const sourceFiles = changed.filter(
-    (f) => isSourceFile(f) && !isTestFileByPatterns(f, testFilePatterns),
-  );
+  const sourceFiles = changed.filter((f) => isSourceFile(f) && !isTestFileByPatterns(f, testFilePatterns));
 
   // Separate hard violations from soft violations (allowed paths)
   const softViolations: string[] = [];

--- a/src/tdd/isolation.ts
+++ b/src/tdd/isolation.ts
@@ -4,17 +4,19 @@
  * Checks that TDD sessions respect their boundaries:
  * - Session 1 (test writer): only test/ files modified
  * - Session 2 (implementer): no test/ files modified
+ *
+ * Both `verifyTestWriterIsolation` and `verifyImplementerIsolation` accept an
+ * optional `testFilePatterns` argument. When supplied, classification uses those
+ * patterns (config-aware path — ADR-009). When omitted, falls back to
+ * DEFAULT_TEST_FILE_PATTERNS for backward compatibility.
  */
 
-import { isTestFile } from "../test-runners";
+import { DEFAULT_TEST_FILE_PATTERNS, isTestFileByPatterns } from "../test-runners";
 import { spawn } from "../utils/bun-deps";
 import type { IsolationCheck } from "./types";
 
 /** Injectable deps for testability — mock _isolationDeps.spawn instead of global Bun.spawn */
 export const _isolationDeps = { spawn };
-
-// Re-export so existing callers (src/tdd/index.ts, tests) don't need to change imports.
-export { isTestFile };
 
 /** Common source directory patterns */
 const SRC_PATTERNS = [/^src\//, /^lib\//, /^packages\//];
@@ -56,17 +58,21 @@ function matchesAllowedPath(filePath: string, allowedPaths: string[]): boolean {
  * Only test files should be created/modified.
  * No source files should be touched.
  *
- * @param workdir - Working directory
- * @param beforeRef - Git ref to diff against
- * @param allowedPaths - Glob patterns for files that can be modified (soft violations)
+ * @param workdir          - Working directory
+ * @param beforeRef        - Git ref to diff against
+ * @param allowedPaths     - Glob patterns for files that can be modified (soft violations)
+ * @param testFilePatterns - Configured test file globs (ADR-009). Falls back to DEFAULT_TEST_FILE_PATTERNS.
  */
 export async function verifyTestWriterIsolation(
   workdir: string,
   beforeRef: string,
   allowedPaths: string[] = ["src/index.ts", "src/**/index.ts"],
+  testFilePatterns: readonly string[] = DEFAULT_TEST_FILE_PATTERNS,
 ): Promise<IsolationCheck> {
   const changed = await getChangedFiles(workdir, beforeRef);
-  const sourceFiles = changed.filter((f) => isSourceFile(f) && !isTestFile(f));
+  const sourceFiles = changed.filter(
+    (f) => isSourceFile(f) && !isTestFileByPatterns(f, testFilePatterns),
+  );
 
   // Separate hard violations from soft violations (allowed paths)
   const softViolations: string[] = [];
@@ -92,10 +98,18 @@ export async function verifyTestWriterIsolation(
  * Verify implementer isolation:
  * No test files should be modified.
  * Only source files should be touched.
+ *
+ * @param workdir          - Working directory
+ * @param beforeRef        - Git ref to diff against
+ * @param testFilePatterns - Configured test file globs (ADR-009). Falls back to DEFAULT_TEST_FILE_PATTERNS.
  */
-export async function verifyImplementerIsolation(workdir: string, beforeRef: string): Promise<IsolationCheck> {
+export async function verifyImplementerIsolation(
+  workdir: string,
+  beforeRef: string,
+  testFilePatterns: readonly string[] = DEFAULT_TEST_FILE_PATTERNS,
+): Promise<IsolationCheck> {
   const changed = await getChangedFiles(workdir, beforeRef);
-  const testFiles = changed.filter((f) => isTestFile(f));
+  const testFiles = changed.filter((f) => isTestFileByPatterns(f, testFilePatterns));
 
   if (testFiles.length > 0) {
     return {

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -17,6 +17,7 @@ import { getLogger } from "../logger";
 import type { PipelineContext } from "../pipeline/types";
 import type { UserStory } from "../prd";
 import { isTestFile } from "../test-runners";
+import { resolveTestFilePatterns } from "../test-runners/resolver";
 import { errorMessage } from "../utils/errors";
 import { captureGitRef } from "../utils/git";
 import { executeWithTimeout } from "../verification";
@@ -206,7 +207,8 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     // The test-writer may have produced 0 new files because tests were pre-written and committed
     // separately (e.g. during dogfooding or manual setup). If tests already exist, skip
     // test-writer phase and proceed directly to the implementer.
-    const testPatternGlob = config.context?.testCoverage?.testPattern ?? "**/*.{test,spec}.{ts,js,tsx,jsx}";
+    // Resolve effective test patterns via SSOT (ADR-009) — replaces deprecated testPattern read.
+    const resolvedForGreenfield = await resolveTestFilePatterns(config, workdir);
 
     // Scan directly for existing test files — don't use isGreenfieldStory() here because its
     // "safe fallback" returns false (not greenfield) on scan errors, which would incorrectly
@@ -214,11 +216,11 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     let hasPreExistingTests = false;
     try {
       // isGreenfieldStory returns true when NO tests exist; we want the inverse
-      hasPreExistingTests = !(await isGreenfieldStory(story, workdir, testPatternGlob));
+      hasPreExistingTests = !(await isGreenfieldStory(story, workdir, resolvedForGreenfield.globs));
       // Sanity check: if workdir doesn't exist, isGreenfieldStory returns false (safe fallback),
       // meaning hasPreExistingTests = true — wrong. Validate by checking if workdir is readable.
-      const { existsSync } = await import("node:fs");
-      if (!existsSync(workdir)) {
+      const dirCheck = Bun.spawn(["test", "-d", workdir], { stdout: "pipe", stderr: "pipe" });
+      if ((await dirCheck.exited) !== 0) {
         hasPreExistingTests = false;
       }
     } catch {

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -193,7 +193,13 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
   // Uses the shared language-agnostic `isTestFile()` classifier — recognizes
   // .test.*, .spec.*, _test.go, test_*.py, test/ directory segments, etc.
   // On retry (BUG-018 fix), session1 is undefined — skip this check entirely.
-  const testFilesCreated = session1 ? session1.filesChanged.filter(isTestFile) : [];
+  // ADR-009: pass user-configured testFilePatterns so custom patterns are recognised;
+  // undefined → broad regex fallback for backward compat.
+  const _tddTestFilePatterns =
+    typeof config.execution?.smartTestRunner === "object" && config.execution.smartTestRunner !== null
+      ? config.execution.smartTestRunner.testFilePatterns
+      : undefined;
+  const testFilesCreated = session1 ? session1.filesChanged.filter((f) => isTestFile(f, _tddTestFilePatterns)) : [];
 
   if (!isRetry && testFilesCreated.length === 0) {
     // BUG-012 Fix: Before declaring greenfield, check if test files already exist in the repo.

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -256,7 +256,14 @@ async function runRectificationLoop(
 
       await autoCommitIfDirty(workdir, "tdd", "rectification", story.id);
 
-      const rectifyIsolation = lite ? undefined : await verifyImplementerIsolation(workdir, rectifyBeforeRef);
+      // ADR-009: pass undefined when user hasn't configured patterns → broad regex fallback in isTestFile.
+      const testFilePatterns =
+        typeof config.execution?.smartTestRunner === "object"
+          ? config.execution.smartTestRunner?.testFilePatterns
+          : undefined;
+      const rectifyIsolation = lite
+        ? undefined
+        : await verifyImplementerIsolation(workdir, rectifyBeforeRef, testFilePatterns);
       if (rectifyIsolation && !rectifyIsolation.passed) {
         loopState.isolationPassed = false;
         logger.error("tdd", "Rectification violated isolation", {

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -232,11 +232,21 @@ export async function runTddSession(
   // Check isolation based on role and skipIsolation flag.
   let isolation: IsolationCheck | undefined;
   if (!skipIsolation) {
+    // ADR-009: pass undefined when user hasn't configured patterns → broad regex fallback in isTestFile.
+    const testFilePatterns =
+      typeof config.execution?.smartTestRunner === "object"
+        ? config.execution.smartTestRunner?.testFilePatterns
+        : undefined;
     if (role === "test-writer") {
       const allowedPaths = config.tdd.testWriterAllowedPaths ?? ["src/index.ts", "src/**/index.ts"];
-      isolation = await _sessionRunnerDeps.verifyTestWriterIsolation(workdir, beforeRef, allowedPaths);
+      isolation = await _sessionRunnerDeps.verifyTestWriterIsolation(
+        workdir,
+        beforeRef,
+        allowedPaths,
+        testFilePatterns,
+      );
     } else if (role === "implementer" || role === "verifier") {
-      isolation = await _sessionRunnerDeps.verifyImplementerIsolation(workdir, beforeRef);
+      isolation = await _sessionRunnerDeps.verifyImplementerIsolation(workdir, beforeRef, testFilePatterns);
     }
   }
 

--- a/src/test-runners/classifier.ts
+++ b/src/test-runners/classifier.ts
@@ -1,0 +1,29 @@
+/**
+ * Test File Classifier
+ *
+ * Converts a `ResolvedTestPatterns` struct into a fast sync predicate
+ * `(path: string) => boolean` for hot-path classification.
+ *
+ * Pattern (resolve once per story, classify many):
+ *
+ *   const resolved = await resolveTestFilePatterns(config, workdir);
+ *   const isTest = createTestFileClassifier(resolved);
+ *   const testFiles = changedFiles.filter(isTest);
+ */
+
+import type { ResolvedTestPatterns } from "./resolver";
+
+/**
+ * Build a sync `(path) => boolean` classifier from resolved test patterns.
+ *
+ * Returns a function that always returns `false` when the resolved pattern
+ * list is empty (explicit `testFilePatterns: []` in config).
+ *
+ * The classifier uses the pre-built `regex` artefact from `ResolvedTestPatterns`
+ * so no per-call regex compilation occurs.
+ */
+export function createTestFileClassifier(resolved: ResolvedTestPatterns): (path: string) => boolean {
+  const { regex } = resolved;
+  if (regex.length === 0) return () => false;
+  return (path: string) => regex.some((re) => re.test(path));
+}

--- a/src/test-runners/conventions.ts
+++ b/src/test-runners/conventions.ts
@@ -82,3 +82,62 @@ export function isTestFileByPatterns(filePath: string, patterns: readonly string
   const regexes = globsToTestRegex(patterns);
   return regexes.some((re) => re.test(filePath));
 }
+
+/**
+ * Convert a list of glob patterns to git pathspec exclusions.
+ *
+ * Extracts the last meaningful path segment (suffix) from each glob and
+ * prepends `:!` to form a git pathspec exclusion. Patterns with no
+ * extractable suffix or with only wildcard suffixes are skipped.
+ * Duplicate exclusions are de-duplicated by source.
+ *
+ * @example
+ * globsToPathspec(["test\/**\/*.test.ts", "**\/*.spec.ts"])
+ * // → [":!*.test.ts", ":!*.spec.ts"]
+ *
+ * @example
+ * globsToPathspec(["**\/*_test.go"])
+ * // → [":!*_test.go"]
+ */
+export function globsToPathspec(patterns: readonly string[]): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const pattern of patterns) {
+    const lastStar = pattern.lastIndexOf("*");
+    if (lastStar === -1) continue;
+    const suffix = pattern.slice(lastStar + 1);
+    if (suffix.length === 0) continue;
+    const pathspec = `:!*${suffix}`;
+    if (!seen.has(pathspec)) {
+      result.push(pathspec);
+      seen.add(pathspec);
+    }
+  }
+  return result;
+}
+
+/**
+ * Extract leading directory names from glob patterns.
+ *
+ * Returns the first path segment of each glob when it is a literal
+ * directory name (not a wildcard). Wildcards and patterns that start
+ * with `**` produce no directory entry.
+ *
+ * @example
+ * extractTestDirs(["test\/**\/*.test.ts", "src\/**\/*.spec.ts"])
+ * // → ["test"]
+ *
+ * @example
+ * extractTestDirs(["**\/*.test.ts"])
+ * // → []
+ */
+export function extractTestDirs(globs: readonly string[]): string[] {
+  const dirs = new Set<string>();
+  for (const glob of globs) {
+    const firstSegment = glob.split("/")[0];
+    if (firstSegment && !firstSegment.includes("*") && firstSegment.length > 0) {
+      dirs.add(firstSegment);
+    }
+  }
+  return [...dirs];
+}

--- a/src/test-runners/detect.ts
+++ b/src/test-runners/detect.ts
@@ -1,52 +1,28 @@
 /**
- * Test File Pattern Detection — Phase 1 Stub
+ * Test File Pattern Detection — Phase 2
  *
- * Phase 1 always returns empty confidence; the resolver falls through to
- * DEFAULT_TEST_FILE_PATTERNS. Phase 2 replaces this with four-tier signal
- * detection (framework configs → framework defaults → file scan → directory
- * conventions) and a mtime-based cache in `.nax/cache/test-patterns.json`.
+ * Re-exports from the detect/ directory which implements the full four-tier
+ * detection pipeline (framework configs → framework defaults → file scan →
+ * directory conventions) with mtime-based cache.
  *
  * Injectable `_detectDeps` follows the project `_deps` pattern (mock.module()
  * is banned — see `.claude/rules/forbidden-patterns.md`).
  */
 
-/** Single detection signal source (one tier result) */
-export interface DetectionSource {
-  type: "framework-config" | "manifest" | "file-scan" | "directory";
-  path: string;
-  patterns: readonly string[];
-}
+export type { DetectionResult, DetectionSource } from "./detect/types";
+export { detectTestFilePatterns, detectTestFilePatternsForWorkspace } from "./detect/index";
 
-/**
- * Result of running auto-detection on a workdir.
- *
- * `confidence` reflects the strongest tier that yielded patterns:
- * - `"high"`   — Tier 1 (framework config file, e.g. vitest.config.ts)
- * - `"medium"` — Tier 2 (framework in devDependencies, using framework defaults)
- * - `"low"`    — Tier 3 / Tier 4 (file scan or directory convention)
- * - `"empty"`  — No signals found; caller falls through to DEFAULT_TEST_FILE_PATTERNS
- */
-export interface DetectionResult {
-  patterns: readonly string[];
-  confidence: "high" | "medium" | "low" | "empty";
-  sources: readonly DetectionSource[];
-}
+// Re-export sub-module deps objects so tests can inject mocks without
+// touching the top-level module boundary.
+export { _cacheDeps } from "./detect/cache";
+export { _frameworkConfigDeps } from "./detect/framework-configs";
+export { _frameworkDefaultsDeps } from "./detect/framework-defaults";
+export { _fileScanDeps } from "./detect/file-scan";
+export { _directoryScanDeps } from "./detect/directory-scan";
+export { _workspaceDeps } from "./detect/workspace";
 
-/** Injectable deps for testability — Phase 2 will populate with spawn + fs reads */
+/** Injectable deps for testability — kept for backward compat with resolver.ts */
 export const _detectDeps = {
   spawn: Bun.spawn as typeof Bun.spawn,
   file: Bun.file as typeof Bun.file,
 };
-
-/**
- * Detect test file patterns for the given working directory.
- *
- * Phase 1 stub: always returns `{ confidence: "empty", patterns: [], sources: [] }`.
- * The resolver falls through to DEFAULT_TEST_FILE_PATTERNS on empty confidence.
- *
- * Phase 2 replaces this with real four-tier detection.
- */
-// biome-ignore lint/correctness/noUnusedFunctionParameters: workdir used by Phase 2 implementation
-export async function detectTestFilePatterns(_workdir: string): Promise<DetectionResult> {
-  return { patterns: [], confidence: "empty", sources: [] };
-}

--- a/src/test-runners/detect.ts
+++ b/src/test-runners/detect.ts
@@ -1,0 +1,52 @@
+/**
+ * Test File Pattern Detection — Phase 1 Stub
+ *
+ * Phase 1 always returns empty confidence; the resolver falls through to
+ * DEFAULT_TEST_FILE_PATTERNS. Phase 2 replaces this with four-tier signal
+ * detection (framework configs → framework defaults → file scan → directory
+ * conventions) and a mtime-based cache in `.nax/cache/test-patterns.json`.
+ *
+ * Injectable `_detectDeps` follows the project `_deps` pattern (mock.module()
+ * is banned — see `.claude/rules/forbidden-patterns.md`).
+ */
+
+/** Single detection signal source (one tier result) */
+export interface DetectionSource {
+  type: "framework-config" | "manifest" | "file-scan" | "directory";
+  path: string;
+  patterns: readonly string[];
+}
+
+/**
+ * Result of running auto-detection on a workdir.
+ *
+ * `confidence` reflects the strongest tier that yielded patterns:
+ * - `"high"`   — Tier 1 (framework config file, e.g. vitest.config.ts)
+ * - `"medium"` — Tier 2 (framework in devDependencies, using framework defaults)
+ * - `"low"`    — Tier 3 / Tier 4 (file scan or directory convention)
+ * - `"empty"`  — No signals found; caller falls through to DEFAULT_TEST_FILE_PATTERNS
+ */
+export interface DetectionResult {
+  patterns: readonly string[];
+  confidence: "high" | "medium" | "low" | "empty";
+  sources: readonly DetectionSource[];
+}
+
+/** Injectable deps for testability — Phase 2 will populate with spawn + fs reads */
+export const _detectDeps = {
+  spawn: Bun.spawn as typeof Bun.spawn,
+  file: Bun.file as typeof Bun.file,
+};
+
+/**
+ * Detect test file patterns for the given working directory.
+ *
+ * Phase 1 stub: always returns `{ confidence: "empty", patterns: [], sources: [] }`.
+ * The resolver falls through to DEFAULT_TEST_FILE_PATTERNS on empty confidence.
+ *
+ * Phase 2 replaces this with real four-tier detection.
+ */
+// biome-ignore lint/correctness/noUnusedFunctionParameters: workdir used by Phase 2 implementation
+export async function detectTestFilePatterns(_workdir: string): Promise<DetectionResult> {
+  return { patterns: [], confidence: "empty", sources: [] };
+}

--- a/src/test-runners/detect/cache.ts
+++ b/src/test-runners/detect/cache.ts
@@ -1,0 +1,120 @@
+/**
+ * Detection Cache — read/write/invalidate
+ *
+ * Caches detection results by workdir + manifest mtimes to avoid
+ * re-running detection on every pipeline invocation.
+ *
+ * Location: .nax/cache/test-patterns.json (gitignored)
+ * Invalidation: any manifest mtime change triggers a cache miss.
+ * Concurrency: last-write-wins; no file lock (derived data, cheap to rebuild).
+ */
+
+import { getSafeLogger } from "../../logger";
+import type { DetectionResult } from "./types";
+
+/** Manifest file names consulted during mtime-based invalidation */
+export const CACHE_MANIFEST_FILES = [
+  "package.json",
+  "vitest.config.ts",
+  "vitest.config.js",
+  "vitest.config.mts",
+  "jest.config.ts",
+  "jest.config.js",
+  "jest.config.mjs",
+  "jest.config.cjs",
+  "pyproject.toml",
+  "pytest.ini",
+  "setup.cfg",
+  "go.mod",
+  "Cargo.toml",
+  ".mocharc.js",
+  ".mocharc.cjs",
+  ".mocharc.yaml",
+  ".mocharc.yml",
+  ".mocharc.json",
+  "playwright.config.ts",
+  "playwright.config.js",
+  "cypress.config.ts",
+  "cypress.config.js",
+] as const;
+
+interface CacheEntry {
+  workdir: string;
+  mtimes: Record<string, number>;
+  result: DetectionResult;
+}
+
+/** Injectable deps for testability */
+export const _cacheDeps = {
+  fileMtime: async (path: string): Promise<number | null> => {
+    const f = Bun.file(path);
+    if (!(await f.exists())) return null;
+    return (await f.stat()).mtime.getTime();
+  },
+  readJson: async (path: string): Promise<unknown> => JSON.parse(await Bun.file(path).text()),
+  writeJson: async (path: string, data: unknown): Promise<void> => {
+    await Bun.write(path, JSON.stringify(data, null, 2));
+  },
+};
+
+/** Absolute path to the cache file for a given workdir */
+export function cachePath(workdir: string): string {
+  return `${workdir}/.nax/cache/test-patterns.json`;
+}
+
+/** Read and validate current manifest mtimes */
+async function readCurrentMtimes(workdir: string): Promise<Record<string, number>> {
+  const mtimes: Record<string, number> = {};
+  await Promise.all(
+    CACHE_MANIFEST_FILES.map(async (name) => {
+      const mtime = await _cacheDeps.fileMtime(`${workdir}/${name}`);
+      if (mtime !== null) mtimes[name] = mtime;
+    }),
+  );
+  return mtimes;
+}
+
+/** Returns true if all cached mtimes match current values */
+function isCacheValid(cached: Record<string, number>, current: Record<string, number>): boolean {
+  const allKeys = new Set([...Object.keys(cached), ...Object.keys(current)]);
+  for (const key of allKeys) {
+    if (cached[key] !== current[key]) return false;
+  }
+  return true;
+}
+
+/**
+ * Read cached detection result for a workdir.
+ * Returns null on cache miss, stale mtimes, or corrupt JSON.
+ */
+export async function readCache(workdir: string): Promise<DetectionResult | null> {
+  const path = cachePath(workdir);
+  try {
+    const raw = await _cacheDeps.readJson(path);
+    const entry = raw as CacheEntry;
+    if (!entry || typeof entry !== "object" || entry.workdir !== workdir) return null;
+
+    const current = await readCurrentMtimes(workdir);
+    if (!isCacheValid(entry.mtimes ?? {}, current)) return null;
+
+    return entry.result ?? null;
+  } catch {
+    getSafeLogger()?.debug("detect", "Cache miss (corrupt or missing)", { workdir });
+    return null;
+  }
+}
+
+/**
+ * Write detection result to cache.
+ * Silently ignores write failures (cache is non-critical).
+ */
+export async function writeCache(workdir: string, result: DetectionResult): Promise<void> {
+  const path = cachePath(workdir);
+  try {
+    const mtimes = await readCurrentMtimes(workdir);
+    const entry: CacheEntry = { workdir, mtimes, result };
+    await _cacheDeps.writeJson(path, entry);
+  } catch {
+    getSafeLogger()?.debug("detect", "Cache write failed (non-critical)", { workdir });
+  }
+}

--- a/src/test-runners/detect/directory-scan.ts
+++ b/src/test-runners/detect/directory-scan.ts
@@ -1,0 +1,110 @@
+/**
+ * Tier 4 — Directory Convention Fallback
+ *
+ * Checks for well-known test directories (test/, tests/, __tests__/, spec/).
+ * When found, scans for file extensions within and emits generic globs.
+ *
+ * This tier runs last — only when Tiers 1–3 produce no results.
+ */
+
+import type { DetectionSource } from "./types";
+
+/** Well-known test directory names to probe */
+const WELL_KNOWN_TEST_DIRS = ["test", "tests", "__tests__", "spec", "specs"] as const;
+
+/** Directories to skip when scanning for extensions */
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build", "coverage", ".nax"]);
+
+/** Injectable deps for testability */
+export const _directoryScanDeps = {
+  dirExists: async (path: string): Promise<boolean> => {
+    const f = Bun.file(path);
+    // Bun.file().exists() works for dirs in newer Bun; use stat fallback
+    try {
+      const stat = await f.stat();
+      // Bun stat returns isFile() true only for files
+      return !stat.isFile();
+    } catch {
+      return false;
+    }
+  },
+  spawn: Bun.spawn as typeof Bun.spawn,
+};
+
+/**
+ * List files in a directory recursively using git ls-files scoped to the dir.
+ * Falls back to Bun.glob when not a git repo.
+ */
+async function listFilesInDir(workdir: string, dir: string): Promise<string[]> {
+  try {
+    const proc = _directoryScanDeps.spawn(["git", "ls-files", dir], {
+      cwd: workdir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode === 0) {
+      const output = await new Response(proc.stdout).text();
+      return output.split("\n").filter(Boolean);
+    }
+  } catch {
+    // fall through to glob
+  }
+
+  // Glob fallback (non-git workdir, e.g. test fixtures)
+  const glob = new Bun.Glob(`${dir}/**/*`);
+  const files: string[] = [];
+  for await (const f of glob.scan({ cwd: workdir, onlyFiles: true })) {
+    if (!SKIP_DIRS.has(f.split("/")[0] ?? "")) files.push(f);
+  }
+  return files;
+}
+
+/** Extract unique file extensions from a list of paths (e.g. ".ts", ".go") */
+function extractExtensions(files: string[]): string[] {
+  const exts = new Set<string>();
+  for (const f of files) {
+    const dot = f.lastIndexOf(".");
+    if (dot > 0) exts.add(f.slice(dot)); // ".ts", ".go", ".py"
+  }
+  return [...exts];
+}
+
+/**
+ * Scan well-known test directories and emit generic globs.
+ * Returns null when no test directories are found.
+ */
+export async function detectFromDirectoryScan(workdir: string): Promise<DetectionSource | null> {
+  const patterns: string[] = [];
+  let foundPath: string | null = null;
+
+  for (const dir of WELL_KNOWN_TEST_DIRS) {
+    const exists = await _directoryScanDeps.dirExists(`${workdir}/${dir}`);
+    if (!exists) continue;
+
+    if (!foundPath) foundPath = `${workdir}/${dir}`;
+
+    const files = await listFilesInDir(workdir, dir);
+    const exts = extractExtensions(files);
+
+    for (const ext of exts) {
+      patterns.push(`${dir}/**/*${ext}`);
+    }
+
+    // Fallback glob when directory exists but is empty
+    if (exts.length === 0) {
+      patterns.push(`${dir}/**/*`);
+    }
+  }
+
+  if (!foundPath || patterns.length === 0) return null;
+
+  // Dedupe
+  const unique = [...new Set(patterns)];
+
+  return {
+    type: "directory",
+    path: foundPath,
+    patterns: unique,
+  };
+}

--- a/src/test-runners/detect/file-scan.ts
+++ b/src/test-runners/detect/file-scan.ts
@@ -1,0 +1,127 @@
+/**
+ * Tier 3 — File System Scan
+ *
+ * Walks `git ls-files` output, buckets files by common test-file suffix,
+ * and emits globs for suffixes meeting a count threshold.
+ *
+ * Threshold: ≥5 files with the suffix OR ≥10% of total files.
+ * Excluded: node_modules/, dist/, build/, .nax/, coverage/, .git/
+ */
+
+import type { DetectionSource } from "./types";
+
+/** Directories excluded from file scan */
+const EXCLUDED_DIR_PREFIXES = ["node_modules/", "dist/", "build/", ".nax/", "coverage/", ".git/"];
+
+/** Min file count to consider a suffix as a test-file indicator */
+const MIN_COUNT_THRESHOLD = 5;
+/** Min fraction of all files to consider a suffix as a test-file indicator */
+const MIN_FRACTION_THRESHOLD = 0.1;
+
+/** Common test-file suffix patterns to look for */
+const CANDIDATE_SUFFIXES = [
+  ".test.ts",
+  ".test.tsx",
+  ".test.js",
+  ".test.jsx",
+  ".spec.ts",
+  ".spec.tsx",
+  ".spec.js",
+  ".spec.jsx",
+  ".e2e-spec.ts",
+  ".e2e-spec.js",
+  "_test.go",
+  "_test.py",
+  "test_.py",
+] as const;
+
+/** Map from suffix to glob pattern */
+const SUFFIX_TO_GLOB: Record<string, string> = {
+  ".test.ts": "**/*.test.ts",
+  ".test.tsx": "**/*.test.tsx",
+  ".test.js": "**/*.test.js",
+  ".test.jsx": "**/*.test.jsx",
+  ".spec.ts": "**/*.spec.ts",
+  ".spec.tsx": "**/*.spec.tsx",
+  ".spec.js": "**/*.spec.js",
+  ".spec.jsx": "**/*.spec.jsx",
+  ".e2e-spec.ts": "**/*.e2e-spec.ts",
+  ".e2e-spec.js": "**/*.e2e-spec.js",
+  "_test.go": "**/*_test.go",
+  "_test.py": "**/*_test.py",
+  "test_.py": "**/test_*.py",
+};
+
+/** Injectable deps for testability */
+export const _fileScanDeps = {
+  spawn: Bun.spawn as typeof Bun.spawn,
+};
+
+/**
+ * Run `git ls-files` and return the output lines.
+ * Returns empty array when git is unavailable or workdir is not a repo.
+ */
+async function gitLsFiles(workdir: string): Promise<string[]> {
+  try {
+    const proc = _fileScanDeps.spawn(["git", "ls-files"], {
+      cwd: workdir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return [];
+    const output = await new Response(proc.stdout).text();
+    return output.split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/** Returns true when the path should be excluded */
+function isExcluded(path: string): boolean {
+  return EXCLUDED_DIR_PREFIXES.some((prefix) => path.startsWith(prefix) || path.includes(`/${prefix}`));
+}
+
+/**
+ * Scan git-tracked files and detect test-file patterns by suffix frequency.
+ * Returns null when no patterns meet the threshold.
+ */
+export async function detectFromFileScan(workdir: string): Promise<DetectionSource | null> {
+  const files = await gitLsFiles(workdir);
+  const filtered = files.filter((f) => !isExcluded(f));
+
+  if (filtered.length === 0) return null;
+
+  const counts: Record<string, number> = {};
+  for (const suffix of CANDIDATE_SUFFIXES) {
+    counts[suffix] = 0;
+  }
+
+  for (const file of filtered) {
+    for (const suffix of CANDIDATE_SUFFIXES) {
+      if (file.endsWith(suffix)) {
+        counts[suffix] = (counts[suffix] ?? 0) + 1;
+      }
+    }
+  }
+
+  const totalFiles = filtered.length;
+  const patterns: string[] = [];
+
+  for (const suffix of CANDIDATE_SUFFIXES) {
+    const count = counts[suffix] ?? 0;
+    if (count === 0) continue;
+    if (count >= MIN_COUNT_THRESHOLD || count / totalFiles >= MIN_FRACTION_THRESHOLD) {
+      const glob = SUFFIX_TO_GLOB[suffix];
+      if (glob) patterns.push(glob);
+    }
+  }
+
+  if (patterns.length === 0) return null;
+
+  return {
+    type: "file-scan",
+    path: workdir,
+    patterns,
+  };
+}

--- a/src/test-runners/detect/framework-configs.ts
+++ b/src/test-runners/detect/framework-configs.ts
@@ -62,13 +62,7 @@ async function parseVitestConfig(workdir: string): Promise<DetectionSource | nul
  * Extracts `testMatch` patterns (prefer) or converts `testRegex` when present.
  */
 async function parseJestConfig(workdir: string): Promise<DetectionSource | null> {
-  const candidates = [
-    "jest.config.ts",
-    "jest.config.js",
-    "jest.config.cjs",
-    "jest.config.mjs",
-    "jest.config.json",
-  ];
+  const candidates = ["jest.config.ts", "jest.config.js", "jest.config.cjs", "jest.config.mjs", "jest.config.json"];
   for (const name of candidates) {
     const path = `${workdir}/${name}`;
     const text = await _frameworkConfigDeps.readText(path);
@@ -238,7 +232,7 @@ async function parseMochaConfig(workdir: string): Promise<DetectionSource | null
         return { type: "framework-config", path, patterns: filterExcluded(patterns) };
       }
     } catch {
-      continue;
+      // parse error — skip this config file, try next candidate
     }
   }
   return null;
@@ -301,9 +295,10 @@ async function parseCypressConfig(workdir: string): Promise<DetectionSource | nu
 function extractStringLiterals(body: string): string[] {
   const patterns: string[] = [];
   const re = /['"]([^'"]+)['"]/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(body)) !== null) {
+  let m = re.exec(body);
+  while (m !== null) {
     if (m[1]) patterns.push(m[1]);
+    m = re.exec(body);
   }
   return patterns;
 }

--- a/src/test-runners/detect/framework-configs.ts
+++ b/src/test-runners/detect/framework-configs.ts
@@ -1,0 +1,327 @@
+/**
+ * Tier 1 — Framework Config Parsers
+ *
+ * Extracts test-file glob patterns from framework configuration files.
+ * Each parser returns null when the file is absent or yields no usable patterns.
+ * The orchestrator (detect/index.ts) tries each parser in turn and unions results.
+ *
+ * Excluded dirs always filtered: node_modules/, dist/, build/, .nax/, coverage/, .git/
+ */
+
+import type { DetectionSource } from "./types";
+
+/** Directories always excluded from produced globs */
+const EXCLUDE_DIRS = ["node_modules", "dist", "build", ".nax", "coverage", ".git"];
+
+/** Injectable deps for testability */
+export const _frameworkConfigDeps = {
+  readText: async (path: string): Promise<string | null> => {
+    const f = Bun.file(path);
+    if (!(await f.exists())) return null;
+    return f.text();
+  },
+  parseToml: (text: string): unknown => Bun.TOML.parse(text),
+  parseYaml: (text: string): unknown => Bun.YAML.parse(text),
+};
+
+/** Filter out patterns referencing excluded dirs */
+function filterExcluded(patterns: string[]): string[] {
+  return patterns.filter((p) => !EXCLUDE_DIRS.some((d) => p.includes(`/${d}/`) || p.startsWith(`${d}/`)));
+}
+
+/**
+ * Try reading a vitest config file (vitest.config.ts/js/mts).
+ * Extracts `test.include` array when present.
+ *
+ * Note: vitest configs are TypeScript/JS — we extract include by regex
+ * rather than executing the file. Handles the common literal array form.
+ */
+async function parseVitestConfig(workdir: string): Promise<DetectionSource | null> {
+  const candidates = ["vitest.config.ts", "vitest.config.mts", "vitest.config.js", "vitest.config.mjs"];
+  for (const name of candidates) {
+    const path = `${workdir}/${name}`;
+    const text = await _frameworkConfigDeps.readText(path);
+    if (!text) continue;
+
+    // Extract test.include: ["pattern1", "pattern2"]  (common literal form)
+    const includeMatch = text.match(/include\s*:\s*\[([^\]]+)\]/s);
+    if (includeMatch) {
+      const patterns = extractStringLiterals(includeMatch[1]);
+      if (patterns.length > 0) {
+        return { type: "framework-config", path, patterns: filterExcluded(patterns) };
+      }
+    }
+    // Found config file but no extractable include → return empty source to signal Tier 1 found
+    return { type: "framework-config", path, patterns: [] };
+  }
+  return null;
+}
+
+/**
+ * Try reading a jest config file (jest.config.ts/js/cjs/mjs or package.json#jest).
+ * Extracts `testMatch` patterns (prefer) or converts `testRegex` when present.
+ */
+async function parseJestConfig(workdir: string): Promise<DetectionSource | null> {
+  const candidates = [
+    "jest.config.ts",
+    "jest.config.js",
+    "jest.config.cjs",
+    "jest.config.mjs",
+    "jest.config.json",
+  ];
+  for (const name of candidates) {
+    const path = `${workdir}/${name}`;
+    const text = await _frameworkConfigDeps.readText(path);
+    if (!text) continue;
+
+    const patterns = extractJestPatterns(text);
+    return { type: "framework-config", path, patterns: filterExcluded(patterns) };
+  }
+
+  // Check package.json#jest
+  const pkgPath = `${workdir}/package.json`;
+  const pkgText = await _frameworkConfigDeps.readText(pkgPath);
+  if (pkgText) {
+    try {
+      const pkg = JSON.parse(pkgText) as Record<string, unknown>;
+      const jestConfig = pkg.jest as Record<string, unknown> | undefined;
+      if (jestConfig) {
+        const patterns = extractJestPatternsFromObject(jestConfig);
+        if (patterns.length > 0) {
+          return { type: "framework-config", path: `${pkgPath}#jest`, patterns: filterExcluded(patterns) };
+        }
+      }
+    } catch {
+      // Corrupt package.json — ignore
+    }
+  }
+
+  return null;
+}
+
+function extractJestPatterns(text: string): string[] {
+  // testMatch: ["pattern1", "pattern2"]
+  const matchMatch = text.match(/testMatch\s*:\s*\[([^\]]+)\]/s);
+  if (matchMatch) {
+    const patterns = extractStringLiterals(matchMatch[1]);
+    if (patterns.length > 0) return patterns;
+  }
+  return [];
+}
+
+function extractJestPatternsFromObject(config: Record<string, unknown>): string[] {
+  const testMatch = config.testMatch;
+  if (Array.isArray(testMatch)) return testMatch.filter((p): p is string => typeof p === "string");
+  return [];
+}
+
+/**
+ * Parse pyproject.toml for pytest test configuration.
+ * Extracts testpaths and python_files from [tool.pytest.ini_options].
+ */
+async function parsePyprojectToml(workdir: string): Promise<DetectionSource | null> {
+  const path = `${workdir}/pyproject.toml`;
+  const text = await _frameworkConfigDeps.readText(path);
+  if (!text) return null;
+
+  try {
+    const parsed = _frameworkConfigDeps.parseToml(text) as Record<string, unknown>;
+    const tool = parsed?.tool as Record<string, unknown> | undefined;
+    const pytest = tool?.pytest as Record<string, unknown> | undefined;
+    const iniOptions = (pytest?.ini_options ?? tool?.["pytest.ini_options"]) as Record<string, unknown> | undefined;
+
+    if (!iniOptions) {
+      // pyproject.toml exists but no pytest config
+      return null;
+    }
+
+    const patterns: string[] = [];
+
+    // testpaths: ["tests", "src"] → "tests/**/*.py"
+    const testpaths = iniOptions.testpaths;
+    if (Array.isArray(testpaths)) {
+      for (const p of testpaths) {
+        if (typeof p === "string") patterns.push(`${p}/**/*.py`);
+      }
+    }
+
+    // python_files: ["test_*.py", "*_test.py"]
+    const pythonFiles = iniOptions.python_files;
+    if (Array.isArray(pythonFiles)) {
+      for (const p of pythonFiles) {
+        if (typeof p === "string") patterns.push(p);
+      }
+    } else if (typeof pythonFiles === "string") {
+      patterns.push(pythonFiles);
+    }
+
+    // Default pytest patterns when config exists but no explicit patterns
+    if (patterns.length === 0) {
+      patterns.push("test_*.py", "*_test.py");
+    }
+
+    return { type: "framework-config", path, patterns: filterExcluded(patterns) };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse pytest.ini for test configuration.
+ */
+async function parsePytestIni(workdir: string): Promise<DetectionSource | null> {
+  const candidates = ["pytest.ini", "setup.cfg"];
+  for (const name of candidates) {
+    const path = `${workdir}/${name}`;
+    const text = await _frameworkConfigDeps.readText(path);
+    if (!text) continue;
+
+    if (!text.includes("[pytest]") && !text.includes("[tool:pytest]")) continue;
+
+    const patterns: string[] = [];
+
+    // testpaths = tests src
+    const testpathsMatch = text.match(/testpaths\s*=\s*([^\n]+)/);
+    if (testpathsMatch) {
+      for (const p of testpathsMatch[1].trim().split(/\s+/)) {
+        if (p) patterns.push(`${p}/**/*.py`);
+      }
+    }
+
+    // python_files = test_*.py *_test.py
+    const pyFilesMatch = text.match(/python_files\s*=\s*([^\n]+)/);
+    if (pyFilesMatch) {
+      for (const p of pyFilesMatch[1].trim().split(/\s+/)) {
+        if (p) patterns.push(p);
+      }
+    }
+
+    if (patterns.length === 0) patterns.push("test_*.py", "*_test.py");
+    return { type: "framework-config", path, patterns: filterExcluded(patterns) };
+  }
+  return null;
+}
+
+/**
+ * Parse .mocharc.* for spec patterns.
+ */
+async function parseMochaConfig(workdir: string): Promise<DetectionSource | null> {
+  const candidates = [".mocharc.js", ".mocharc.cjs", ".mocharc.yaml", ".mocharc.yml", ".mocharc.json"];
+  for (const name of candidates) {
+    const path = `${workdir}/${name}`;
+    const text = await _frameworkConfigDeps.readText(path);
+    if (!text) continue;
+
+    try {
+      let config: Record<string, unknown>;
+      if (name.endsWith(".json")) {
+        config = JSON.parse(text) as Record<string, unknown>;
+      } else if (name.endsWith(".yaml") || name.endsWith(".yml")) {
+        config = _frameworkConfigDeps.parseYaml(text) as Record<string, unknown>;
+      } else {
+        // JS/CJS — extract spec: property with regex
+        const specMatch = text.match(/spec\s*:\s*['"]([^'"]+)['"]/);
+        if (specMatch) {
+          return { type: "framework-config", path, patterns: [specMatch[1]] };
+        }
+        continue;
+      }
+
+      const spec = config.spec;
+      const patterns = Array.isArray(spec)
+        ? spec.filter((p): p is string => typeof p === "string")
+        : typeof spec === "string"
+          ? [spec]
+          : [];
+
+      if (patterns.length > 0) {
+        return { type: "framework-config", path, patterns: filterExcluded(patterns) };
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse playwright.config.* for testDir/testMatch.
+ */
+async function parsePlaywrightConfig(workdir: string): Promise<DetectionSource | null> {
+  const candidates = ["playwright.config.ts", "playwright.config.js"];
+  for (const name of candidates) {
+    const path = `${workdir}/${name}`;
+    const text = await _frameworkConfigDeps.readText(path);
+    if (!text) continue;
+
+    const patterns: string[] = [];
+
+    // testDir: 'e2e' or testDir: "e2e"
+    const testDirMatch = text.match(/testDir\s*:\s*['"]([^'"]+)['"]/);
+    if (testDirMatch) patterns.push(`${testDirMatch[1]}/**/*.spec.{ts,js}`);
+
+    // testMatch: ['**/*.spec.ts']
+    const testMatchMatch = text.match(/testMatch\s*:\s*\[([^\]]+)\]/s);
+    if (testMatchMatch) {
+      const extracted = extractStringLiterals(testMatchMatch[1]);
+      patterns.push(...extracted);
+    }
+
+    if (patterns.length > 0) {
+      return { type: "framework-config", path, patterns: filterExcluded(patterns) };
+    }
+    // Config file found but no extractable pattern
+    return { type: "framework-config", path, patterns: ["**/*.spec.ts", "**/*.spec.js"] };
+  }
+  return null;
+}
+
+/**
+ * Parse cypress.config.* for specPattern.
+ */
+async function parseCypressConfig(workdir: string): Promise<DetectionSource | null> {
+  const candidates = ["cypress.config.ts", "cypress.config.js"];
+  for (const name of candidates) {
+    const path = `${workdir}/${name}`;
+    const text = await _frameworkConfigDeps.readText(path);
+    if (!text) continue;
+
+    // specPattern: 'cypress/e2e/**/*.cy.{js,jsx,ts,tsx}'
+    const specMatch = text.match(/specPattern\s*:\s*['"]([^'"]+)['"]/);
+    if (specMatch) {
+      return { type: "framework-config", path, patterns: [specMatch[1]] };
+    }
+
+    return { type: "framework-config", path, patterns: ["cypress/e2e/**/*.cy.{js,ts}"] };
+  }
+  return null;
+}
+
+/** Extract string literals from a JS array body (e.g. `"foo", 'bar'`) */
+function extractStringLiterals(body: string): string[] {
+  const patterns: string[] = [];
+  const re = /['"]([^'"]+)['"]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    if (m[1]) patterns.push(m[1]);
+  }
+  return patterns;
+}
+
+/**
+ * Run all Tier 1 framework config parsers for a workdir.
+ * Returns an array of DetectionSources (one per found config file).
+ */
+export async function detectFromFrameworkConfigs(workdir: string): Promise<DetectionSource[]> {
+  const results = await Promise.all([
+    parseVitestConfig(workdir),
+    parseJestConfig(workdir),
+    parsePyprojectToml(workdir),
+    parsePytestIni(workdir),
+    parseMochaConfig(workdir),
+    parsePlaywrightConfig(workdir),
+    parseCypressConfig(workdir),
+  ]);
+
+  return results.filter((r): r is DetectionSource => r !== null);
+}

--- a/src/test-runners/detect/framework-defaults.ts
+++ b/src/test-runners/detect/framework-defaults.ts
@@ -1,0 +1,122 @@
+/**
+ * Tier 2 — Framework Defaults
+ *
+ * When no explicit framework config file is found (Tier 1), but a framework
+ * is declared in the project manifest (package.json devDependencies, go.mod,
+ * Cargo.toml, pyproject.toml), we use the framework's canonical default
+ * test-file patterns.
+ *
+ * Returns null when no known framework manifest is found in the workdir.
+ */
+
+import type { DetectionSource } from "./types";
+
+/** Injectable deps for testability */
+export const _frameworkDefaultsDeps = {
+  readText: async (path: string): Promise<string | null> => {
+    const f = Bun.file(path);
+    if (!(await f.exists())) return null;
+    return f.text();
+  },
+};
+
+/** Default patterns per JS/TS test framework */
+const JS_FRAMEWORK_DEFAULTS: Record<string, readonly string[]> = {
+  vitest: ["**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+  jest: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)"],
+  mocha: ["test/**/*.{js,mjs,cjs}", "**/*.spec.{js,ts}"],
+  jasmine: ["spec/**/*.js"],
+  "@playwright/test": ["**/*.spec.ts", "**/*.spec.js"],
+  cypress: ["cypress/e2e/**/*.cy.{js,jsx,ts,tsx}"],
+};
+
+/** Bun test default — activated when `bun test` is in package.json#scripts.test */
+const BUN_TEST_DEFAULTS: readonly string[] = ["**/*.test.{ts,tsx,js,jsx}"];
+
+/**
+ * Parse package.json to detect JS/TS test framework from devDependencies.
+ * Falls back to bun test heuristic when `bun test` appears in scripts.test.
+ */
+async function detectFromPackageJson(workdir: string): Promise<DetectionSource | null> {
+  const path = `${workdir}/package.json`;
+  const text = await _frameworkDefaultsDeps.readText(path);
+  if (!text) return null;
+
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const devDeps = (pkg.devDependencies as Record<string, unknown>) ?? {};
+  const deps = (pkg.dependencies as Record<string, unknown>) ?? {};
+  const allDeps = { ...deps, ...devDeps };
+
+  // Check for known JS/TS frameworks (priority order)
+  for (const [framework, patterns] of Object.entries(JS_FRAMEWORK_DEFAULTS)) {
+    if (framework in allDeps) {
+      return { type: "manifest", path, patterns };
+    }
+  }
+
+  // Check for bun test in scripts.test
+  const scripts = pkg.scripts as Record<string, unknown> | undefined;
+  const testScript = typeof scripts?.test === "string" ? scripts.test : "";
+  if (testScript.includes("bun test")) {
+    return { type: "manifest", path, patterns: BUN_TEST_DEFAULTS };
+  }
+
+  return null;
+}
+
+/**
+ * Detect Go projects from go.mod presence.
+ */
+async function detectFromGoMod(workdir: string): Promise<DetectionSource | null> {
+  const path = `${workdir}/go.mod`;
+  const f = Bun.file(path);
+  if (!(await f.exists())) return null;
+  return { type: "manifest", path, patterns: ["**/*_test.go"] };
+}
+
+/**
+ * Detect Rust projects from Cargo.toml presence.
+ */
+async function detectFromCargoToml(workdir: string): Promise<DetectionSource | null> {
+  const path = `${workdir}/Cargo.toml`;
+  const f = Bun.file(path);
+  if (!(await f.exists())) return null;
+  return { type: "manifest", path, patterns: ["tests/**/*.rs", "src/**/*.rs"] };
+}
+
+/**
+ * Detect Python projects from pyproject.toml (without pytest ini_options).
+ * Covers projects that declare pytest as a test dependency but don't configure testpaths.
+ */
+async function detectFromPyprojectDeps(workdir: string): Promise<DetectionSource | null> {
+  const path = `${workdir}/pyproject.toml`;
+  const text = await _frameworkDefaultsDeps.readText(path);
+  if (!text) return null;
+
+  // Check for pytest in [project.dependencies] or [tool.poetry.dependencies]
+  if (text.includes("pytest")) {
+    return { type: "manifest", path, patterns: ["test_*.py", "*_test.py", "tests/**/*.py"] };
+  }
+  return null;
+}
+
+/**
+ * Run all Tier 2 manifest-based detection for a workdir.
+ * Returns an array of DetectionSources. Empty when no framework is found.
+ */
+export async function detectFromFrameworkDefaults(workdir: string): Promise<DetectionSource[]> {
+  const results = await Promise.all([
+    detectFromPackageJson(workdir),
+    detectFromGoMod(workdir),
+    detectFromCargoToml(workdir),
+    detectFromPyprojectDeps(workdir),
+  ]);
+
+  return results.filter((r): r is DetectionSource => r !== null);
+}

--- a/src/test-runners/detect/framework-defaults.ts
+++ b/src/test-runners/detect/framework-defaults.ts
@@ -18,6 +18,7 @@ export const _frameworkDefaultsDeps = {
     if (!(await f.exists())) return null;
     return f.text();
   },
+  fileExists: async (path: string): Promise<boolean> => Bun.file(path).exists(),
 };
 
 /** Default patterns per JS/TS test framework */
@@ -75,8 +76,7 @@ async function detectFromPackageJson(workdir: string): Promise<DetectionSource |
  */
 async function detectFromGoMod(workdir: string): Promise<DetectionSource | null> {
   const path = `${workdir}/go.mod`;
-  const f = Bun.file(path);
-  if (!(await f.exists())) return null;
+  if (!(await _frameworkDefaultsDeps.fileExists(path))) return null;
   return { type: "manifest", path, patterns: ["**/*_test.go"] };
 }
 
@@ -85,8 +85,7 @@ async function detectFromGoMod(workdir: string): Promise<DetectionSource | null>
  */
 async function detectFromCargoToml(workdir: string): Promise<DetectionSource | null> {
   const path = `${workdir}/Cargo.toml`;
-  const f = Bun.file(path);
-  if (!(await f.exists())) return null;
+  if (!(await _frameworkDefaultsDeps.fileExists(path))) return null;
   return { type: "manifest", path, patterns: ["tests/**/*.rs", "src/**/*.rs"] };
 }
 

--- a/src/test-runners/detect/index.ts
+++ b/src/test-runners/detect/index.ts
@@ -187,9 +187,7 @@ export async function detectTestFilePatternsForWorkspace(
 ): Promise<Record<string, DetectionResult>> {
   const entries = await Promise.all([
     detectForDirectory(workdir).then((r) => ["", r] as const),
-    ...packageDirs.map((dir) =>
-      detectForDirectory(`${workdir}/${dir}`).then((r) => [dir, r] as const),
-    ),
+    ...packageDirs.map((dir) => detectForDirectory(`${workdir}/${dir}`).then((r) => [dir, r] as const)),
   ]);
 
   return Object.fromEntries(entries);

--- a/src/test-runners/detect/index.ts
+++ b/src/test-runners/detect/index.ts
@@ -1,0 +1,196 @@
+/**
+ * Detection Orchestrator
+ *
+ * Runs the four-tier detection pipeline for a given workdir:
+ *   Tier 1 — Framework config files (high confidence)
+ *   Tier 2 — Framework declared in manifests (medium confidence)
+ *   Tier 3 — File system scan via git ls-files (low confidence)
+ *   Tier 4 — Directory convention fallback (low confidence)
+ *
+ * Results are cached in `.nax/cache/test-patterns.json` and invalidated
+ * when relevant manifest mtimes change.
+ *
+ * Multiple languages in one project produce a union of patterns.
+ * Confidence reflects the strongest tier that yielded patterns.
+ */
+
+import { getSafeLogger } from "../../logger";
+import type { DetectionResult, DetectionSource } from "./types";
+export type { DetectionResult, DetectionSource } from "./types";
+import { readCache, writeCache } from "./cache";
+import { detectFromDirectoryScan } from "./directory-scan";
+import { detectFromFileScan } from "./file-scan";
+import { detectFromFrameworkConfigs } from "./framework-configs";
+import { detectFromFrameworkDefaults } from "./framework-defaults";
+
+/** Deduplicate patterns while preserving insertion order */
+function dedupePatterns(patterns: readonly string[]): readonly string[] {
+  return [...new Set(patterns)];
+}
+
+/** Map detection source type to confidence level */
+function sourceToConfidence(type: DetectionSource["type"]): DetectionResult["confidence"] {
+  switch (type) {
+    case "framework-config":
+      return "high";
+    case "manifest":
+      return "medium";
+    case "file-scan":
+    case "directory":
+      return "low";
+  }
+}
+
+/** Merge multiple DetectionSources into a single DetectionResult */
+function mergeResults(sources: DetectionSource[]): DetectionResult {
+  if (sources.length === 0) {
+    return { patterns: [], confidence: "empty", sources: [] };
+  }
+
+  const allPatterns: string[] = [];
+  for (const source of sources) {
+    for (const p of source.patterns) {
+      allPatterns.push(p);
+    }
+  }
+
+  // Confidence = strongest tier found
+  const confidenceOrder: DetectionResult["confidence"][] = ["high", "medium", "low", "empty"];
+  let confidence: DetectionResult["confidence"] = "empty";
+  for (const source of sources) {
+    const c = sourceToConfidence(source.type);
+    if (confidenceOrder.indexOf(c) < confidenceOrder.indexOf(confidence)) {
+      confidence = c;
+    }
+  }
+
+  return {
+    patterns: dedupePatterns(allPatterns),
+    confidence,
+    sources,
+  };
+}
+
+/**
+ * Detect test file patterns for a single package directory.
+ * Runs tiers in order; stops at Tier 1+2 if they yield patterns.
+ * Always runs Tier 3 cross-check when Tier 1/2 succeed (logs mismatch warning).
+ */
+async function detectForDirectory(workdir: string): Promise<DetectionResult> {
+  const logger = getSafeLogger();
+
+  // Tier 1: Framework config files
+  const tier1Sources = await detectFromFrameworkConfigs(workdir);
+  const tier1Patterns = tier1Sources.flatMap((s) => [...s.patterns]);
+
+  // Tier 2: Framework defaults from manifests
+  const tier2Sources = await detectFromFrameworkDefaults(workdir);
+  const tier2Patterns = tier2Sources.flatMap((s) => [...s.patterns]);
+
+  // Tier 3: File scan (used for cross-check and as fallback)
+  const tier3Source = await detectFromFileScan(workdir);
+  const tier3Patterns = tier3Source ? [...tier3Source.patterns] : [];
+
+  // Cross-check: if Tier 1/2 found patterns but Tier 3 disagrees, log warning
+  if ((tier1Patterns.length > 0 || tier2Patterns.length > 0) && tier3Patterns.length > 0) {
+    const tier12Suffixes = new Set(
+      [...tier1Patterns, ...tier2Patterns].map((p) => {
+        const star = p.lastIndexOf("*");
+        return star >= 0 ? p.slice(star + 1) : p;
+      }),
+    );
+    const tier3Suffixes = tier3Patterns.map((p) => {
+      const star = p.lastIndexOf("*");
+      return star >= 0 ? p.slice(star + 1) : p;
+    });
+    const unmatched = tier3Suffixes.filter((s) => !tier12Suffixes.has(s));
+    if (unmatched.length > 0) {
+      logger?.debug("detect", "File scan found test suffixes not in framework config (possible config mismatch)", {
+        unmatched,
+        workdir,
+      });
+    }
+  }
+
+  // If Tier 1 or 2 found patterns, use them
+  if (tier1Patterns.length > 0 || tier2Patterns.length > 0) {
+    const sources = [...tier1Sources, ...tier2Sources];
+    // Filter empty-pattern sources (config file found but no extractable patterns)
+    const meaningful = sources.filter((s) => s.patterns.length > 0);
+    if (meaningful.length > 0) {
+      const result = mergeResults(meaningful);
+      logger?.info("detect", "Test patterns detected", {
+        confidence: result.confidence,
+        patternCount: result.patterns.length,
+        tier: result.sources[0]?.type,
+        workdir,
+      });
+      return result;
+    }
+  }
+
+  // Tier 3: file scan as primary source
+  if (tier3Source && tier3Patterns.length > 0) {
+    logger?.info("detect", "Test patterns detected via file scan", {
+      confidence: "low",
+      patternCount: tier3Patterns.length,
+      workdir,
+    });
+    return mergeResults([tier3Source]);
+  }
+
+  // Tier 4: directory convention fallback
+  const tier4Source = await detectFromDirectoryScan(workdir);
+  if (tier4Source && tier4Source.patterns.length > 0) {
+    logger?.info("detect", "Test patterns detected via directory convention", {
+      confidence: "low",
+      patternCount: tier4Source.patterns.length,
+      workdir,
+    });
+    return mergeResults([tier4Source]);
+  }
+
+  return { patterns: [], confidence: "empty", sources: [] };
+}
+
+/**
+ * Detect test file patterns for the given working directory.
+ *
+ * Results are cached in `.nax/cache/test-patterns.json`.
+ * Cache is invalidated when relevant manifest mtimes change.
+ *
+ * Exported as the replacement for the Phase 1 stub.
+ */
+export async function detectTestFilePatterns(workdir: string): Promise<DetectionResult> {
+  // Try cache first
+  const cached = await readCache(workdir);
+  if (cached) {
+    getSafeLogger()?.debug("detect", "Cache hit", { workdir });
+    return cached;
+  }
+
+  const result = await detectForDirectory(workdir);
+
+  // Write to cache (non-blocking, errors are swallowed inside writeCache)
+  await writeCache(workdir, result);
+
+  return result;
+}
+
+/**
+ * Run detection for a monorepo: detect for root + each package directory.
+ * Returns a map of packageDir → DetectionResult (root key: "").
+ */
+export async function detectTestFilePatternsForWorkspace(
+  workdir: string,
+  packageDirs: string[],
+): Promise<Record<string, DetectionResult>> {
+  const entries = await Promise.all([
+    detectForDirectory(workdir).then((r) => ["", r] as const),
+    ...packageDirs.map((dir) =>
+      detectForDirectory(`${workdir}/${dir}`).then((r) => [dir, r] as const),
+    ),
+  ]);
+
+  return Object.fromEntries(entries);
+}

--- a/src/test-runners/detect/types.ts
+++ b/src/test-runners/detect/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Detection types — shared by all detect sub-modules.
+ * Extracted here to avoid circular imports between detect.ts and detect/index.ts.
+ */
+
+/** Single detection signal source (one tier result) */
+export interface DetectionSource {
+  type: "framework-config" | "manifest" | "file-scan" | "directory";
+  path: string;
+  patterns: readonly string[];
+}
+
+/**
+ * Result of running auto-detection on a workdir.
+ *
+ * `confidence` reflects the strongest tier that yielded patterns:
+ * - `"high"`   — Tier 1 (framework config file, e.g. vitest.config.ts)
+ * - `"medium"` — Tier 2 (framework in devDependencies, using framework defaults)
+ * - `"low"`    — Tier 3 / Tier 4 (file scan or directory convention)
+ * - `"empty"`  — No signals found; caller falls through to DEFAULT_TEST_FILE_PATTERNS
+ */
+export interface DetectionResult {
+  patterns: readonly string[];
+  confidence: "high" | "medium" | "low" | "empty";
+  sources: readonly DetectionSource[];
+}

--- a/src/test-runners/detect/workspace.ts
+++ b/src/test-runners/detect/workspace.ts
@@ -76,7 +76,9 @@ async function detectNpmWorkspaces(workdir: string): Promise<string[]> {
     const workspaces = pkg.workspaces;
     const patterns: string[] = Array.isArray(workspaces)
       ? workspaces.filter((p): p is string => typeof p === "string")
-      : typeof workspaces === "object" && workspaces !== null && Array.isArray((workspaces as Record<string, unknown>).packages)
+      : typeof workspaces === "object" &&
+          workspaces !== null &&
+          Array.isArray((workspaces as Record<string, unknown>).packages)
         ? ((workspaces as Record<string, unknown>).packages as string[])
         : [];
     if (patterns.length === 0) return [];

--- a/src/test-runners/detect/workspace.ts
+++ b/src/test-runners/detect/workspace.ts
@@ -1,0 +1,166 @@
+/**
+ * Monorepo Workspace Discovery
+ *
+ * Detects monorepo package directories from well-known workspace manifests:
+ *   - pnpm-workspace.yaml
+ *   - package.json#workspaces
+ *   - lerna.json
+ *   - turbo.json / nx.json
+ *   - rush.json
+ *   - Nested go.mod / pyproject.toml / Cargo.toml
+ *   - Existing .nax/mono/ layout
+ *
+ * Returns a list of relative package directory paths (e.g. ["packages/api", "packages/web"]).
+ * Returns empty array when not a monorepo or detection fails.
+ */
+
+import { getSafeLogger } from "../../logger";
+
+/** Injectable deps for testability */
+export const _workspaceDeps = {
+  readText: async (path: string): Promise<string | null> => {
+    const f = Bun.file(path);
+    if (!(await f.exists())) return null;
+    return f.text();
+  },
+  spawn: Bun.spawn as typeof Bun.spawn,
+  glob: (pattern: string, cwd: string) => new Bun.Glob(pattern).scan({ cwd, onlyFiles: false }),
+};
+
+/** Expand workspace globs (e.g. "packages/*") to concrete directories */
+async function expandWorkspaceGlob(workdir: string, pattern: string): Promise<string[]> {
+  const dirs: string[] = [];
+  try {
+    const globber = new Bun.Glob(pattern);
+    for await (const entry of globber.scan({ cwd: workdir, onlyFiles: false })) {
+      // Only include directories that have a package.json / go.mod / etc.
+      const hasMarker = await Promise.any([
+        Bun.file(`${workdir}/${entry}/package.json`).exists(),
+        Bun.file(`${workdir}/${entry}/go.mod`).exists(),
+        Bun.file(`${workdir}/${entry}/pyproject.toml`).exists(),
+        Bun.file(`${workdir}/${entry}/Cargo.toml`).exists(),
+      ]).catch(() => false);
+      if (hasMarker) dirs.push(entry);
+    }
+  } catch {
+    // Glob error — skip pattern
+  }
+  return dirs;
+}
+
+/** Detect packages from pnpm-workspace.yaml */
+async function detectPnpmWorkspace(workdir: string): Promise<string[]> {
+  const text = await _workspaceDeps.readText(`${workdir}/pnpm-workspace.yaml`);
+  if (!text) return [];
+  try {
+    const parsed = Bun.YAML.parse(text) as Record<string, unknown>;
+    const packages = parsed?.packages;
+    if (!Array.isArray(packages)) return [];
+    const expanded = await Promise.all(
+      packages
+        .filter((p): p is string => typeof p === "string")
+        .map((pattern) => expandWorkspaceGlob(workdir, pattern)),
+    );
+    return expanded.flat();
+  } catch {
+    return [];
+  }
+}
+
+/** Detect packages from package.json#workspaces (npm/yarn) */
+async function detectNpmWorkspaces(workdir: string): Promise<string[]> {
+  const text = await _workspaceDeps.readText(`${workdir}/package.json`);
+  if (!text) return [];
+  try {
+    const pkg = JSON.parse(text) as Record<string, unknown>;
+    const workspaces = pkg.workspaces;
+    const patterns: string[] = Array.isArray(workspaces)
+      ? workspaces.filter((p): p is string => typeof p === "string")
+      : typeof workspaces === "object" && workspaces !== null && Array.isArray((workspaces as Record<string, unknown>).packages)
+        ? ((workspaces as Record<string, unknown>).packages as string[])
+        : [];
+    if (patterns.length === 0) return [];
+    const expanded = await Promise.all(patterns.map((p) => expandWorkspaceGlob(workdir, p)));
+    return expanded.flat();
+  } catch {
+    return [];
+  }
+}
+
+/** Detect packages from lerna.json */
+async function detectLernaWorkspace(workdir: string): Promise<string[]> {
+  const text = await _workspaceDeps.readText(`${workdir}/lerna.json`);
+  if (!text) return [];
+  try {
+    const config = JSON.parse(text) as Record<string, unknown>;
+    const packages = config.packages;
+    const patterns: string[] = Array.isArray(packages)
+      ? packages.filter((p): p is string => typeof p === "string")
+      : ["packages/*"];
+    const expanded = await Promise.all(patterns.map((p) => expandWorkspaceGlob(workdir, p)));
+    return expanded.flat();
+  } catch {
+    return [];
+  }
+}
+
+/** Detect packages from turbo.json or nx.json (project root, no package dirs) */
+async function detectTurboOrNx(workdir: string): Promise<string[]> {
+  const hasTurbo = await Bun.file(`${workdir}/turbo.json`).exists();
+  const hasNx = await Bun.file(`${workdir}/nx.json`).exists();
+  if (!hasTurbo && !hasNx) return [];
+
+  // Turbo/Nx projects also have pnpm-workspace.yaml or package.json#workspaces
+  // We rely on those detectors for package dirs; this just confirms monorepo layout
+  const fromPnpm = await detectPnpmWorkspace(workdir);
+  const fromNpm = await detectNpmWorkspaces(workdir);
+  return [...new Set([...fromPnpm, ...fromNpm])];
+}
+
+/** Detect packages from existing .nax/mono/ layout */
+async function detectNaxMonoLayout(workdir: string): Promise<string[]> {
+  const dirs: string[] = [];
+  try {
+    const glob = new Bun.Glob(".nax/mono/*/config.json");
+    for await (const entry of glob.scan({ cwd: workdir })) {
+      // entry = ".nax/mono/packages/api/config.json" → extract "packages/api"
+      const parts = entry.split("/");
+      // Remove ".nax", "mono", and "config.json" → middle is the packageDir
+      if (parts.length >= 4) {
+        const pkgDir = parts.slice(2, -1).join("/");
+        dirs.push(pkgDir);
+      }
+    }
+  } catch {
+    // No .nax/mono layout
+  }
+  return dirs;
+}
+
+/**
+ * Discover all monorepo package directories in the given workdir.
+ * Returns a deduplicated list of relative paths.
+ * Returns empty array for single-package projects.
+ */
+export async function discoverWorkspacePackages(workdir: string): Promise<string[]> {
+  const [fromPnpm, fromNpm, fromLerna, fromTurboNx, fromNaxMono] = await Promise.all([
+    detectPnpmWorkspace(workdir),
+    detectNpmWorkspaces(workdir),
+    detectLernaWorkspace(workdir),
+    detectTurboOrNx(workdir),
+    detectNaxMonoLayout(workdir),
+  ]);
+
+  const all = [...fromPnpm, ...fromNpm, ...fromLerna, ...fromTurboNx, ...fromNaxMono];
+  const unique = [...new Set(all)].sort();
+
+  if (unique.length > 0) {
+    getSafeLogger()?.debug("detect", "Workspace packages discovered", {
+      workdir,
+      count: unique.length,
+      packages: unique,
+    });
+  }
+
+  return unique;
+}

--- a/src/test-runners/detector.ts
+++ b/src/test-runners/detector.ts
@@ -8,6 +8,8 @@
  * the pipeline (autofix scope routing, TDD isolation, diff analysis).
  */
 
+import { isTestFileByPatterns } from "./conventions";
+
 export type Framework = "bun" | "jest" | "vitest" | "pytest" | "go" | "unknown";
 
 /**
@@ -27,10 +29,21 @@ const TEST_FILE_PATTERNS = [
 ];
 
 /**
- * Returns true when the given file path looks like a test file across any
- * supported language (TypeScript, Python, Go, Ruby, Rust, Java, etc.).
+ * Returns true when the given file path looks like a test file.
+ *
+ * When `testFilePatterns` is supplied, delegates to `isTestFileByPatterns()`
+ * (config-aware path — ADR-009 preferred usage). When omitted, falls back to
+ * the broad language-agnostic regex (backward-compat Phase 1 path).
+ *
+ * All first-party call sites have been migrated to the resolver + classifier
+ * pattern (ADR-009). The no-argument form is kept as a Phase 1 backward-compat
+ * shim for any third-party plugins that import it directly; it will be removed
+ * in Phase 2 once detection guarantees the resolver always yields patterns.
  */
-export function isTestFile(filePath: string): boolean {
+export function isTestFile(filePath: string, testFilePatterns?: readonly string[]): boolean {
+  if (testFilePatterns !== undefined) {
+    return isTestFileByPatterns(filePath, testFilePatterns);
+  }
   return TEST_FILE_PATTERNS.some((pattern) => pattern.test(filePath));
 }
 

--- a/src/test-runners/index.ts
+++ b/src/test-runners/index.ts
@@ -1,5 +1,5 @@
 /**
- * Test Runners — Framework Detection and Output Parsing
+ * Test Runners — Framework Detection, Output Parsing, and Pattern SSOT
  *
  * Shared module for all test-framework-aware concerns:
  * - detectFramework(): identify which test runner produced output
@@ -7,15 +7,28 @@
  * - parseTestFailures(): AC-ID extraction (for acceptance loop)
  * - formatFailureSummary(): agent-readable failure digest
  * - analyzeTestExitCode(): environmental failure detection
+ * - resolveTestFilePatterns() + createTestFileClassifier(): ADR-009 SSOT
  */
 
 export {
   DEFAULT_TEST_FILE_PATTERNS,
+  extractTestDirs,
+  globsToPathspec,
   globsToTestRegex,
   isTestFileByPatterns,
 } from "./conventions";
+export { createTestFileClassifier } from "./classifier";
+export type { DetectionResult, DetectionSource } from "./detect";
+export { detectTestFilePatterns } from "./detect";
 export { detectFramework, isTestFile } from "./detector";
 export type { Framework } from "./detector";
+export {
+  _resolverDeps,
+  findPackageDir,
+  resolveReviewExcludePatterns,
+  resolveTestFilePatterns,
+} from "./resolver";
+export type { ResolvedTestPatterns } from "./resolver";
 export { analyzeTestExitCode, formatFailureSummary, parseBunTestOutput, parseTestOutput } from "./parser";
 export { parseTestFailures } from "./ac-parser";
 export type { TestFailure, TestOutputAnalysis, TestSummary } from "./types";

--- a/src/test-runners/resolver.ts
+++ b/src/test-runners/resolver.ts
@@ -108,6 +108,12 @@ function validateGlobs(patterns: readonly string[], stage: string): void {
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
+/** Options for resolveTestFilePatterns */
+export interface ResolveTestFilePatternsOptions {
+  /** Story ID for structured log correlation */
+  storyId?: string;
+}
+
 /**
  * Resolve effective test file patterns for the given config and optional
  * monorepo package directory.
@@ -116,11 +122,13 @@ function validateGlobs(patterns: readonly string[], stage: string): void {
  * @param workdir    - Absolute path to project root (for mono config lookup + detection).
  * @param packageDir - Relative path to the monorepo package (e.g. "packages/api").
  *                     Pass `undefined` for single-package projects.
+ * @param options    - Optional: storyId for log correlation.
  */
 export async function resolveTestFilePatterns(
   config: NaxConfig,
   workdir: string,
   packageDir?: string,
+  options?: ResolveTestFilePatternsOptions,
 ): Promise<ResolvedTestPatterns> {
   // 1. Per-package override
   if (packageDir) {
@@ -167,6 +175,7 @@ export async function resolveTestFilePatterns(
   const detected = await _resolverDeps.detectTestFilePatterns(workdir);
   if (detected.confidence !== "empty" && detected.patterns.length > 0) {
     getSafeLogger()?.info("resolver", "Test patterns auto-detected", {
+      ...(options?.storyId !== undefined && { storyId: options.storyId }),
       confidence: detected.confidence,
       patternCount: detected.patterns.length,
       tier: detected.sources[0]?.type,

--- a/src/test-runners/resolver.ts
+++ b/src/test-runners/resolver.ts
@@ -1,0 +1,250 @@
+/**
+ * Test File Pattern Resolver — SSOT
+ *
+ * `resolveTestFilePatterns()` is the single source of truth for "which files
+ * are test files?". Every classification site in the codebase goes through
+ * this resolver; inline test-file checks are forbidden (ADR-009).
+ *
+ * Resolution chain (first non-undefined wins):
+ *   1. Per-package config  — .nax/mono/<packageDir>/config.json (monorepo)
+ *   2. Root config         — config.execution.smartTestRunner.testFilePatterns
+ *   3. Detection           — detectTestFilePatterns(workdir) [Phase 1: stub]
+ *   4. Fallback            — DEFAULT_TEST_FILE_PATTERNS
+ *
+ * Explicit `testFilePatterns: []` in config is honoured as "no test files"
+ * — semantically distinct from the key being omitted.
+ *
+ * Injectable `_resolverDeps` follows the project `_deps` pattern.
+ */
+
+import { dirname, relative, resolve } from "node:path";
+import { NaxError } from "../errors";
+import { getSafeLogger } from "../logger";
+import type { NaxConfig } from "../config/types";
+import { DEFAULT_TEST_FILE_PATTERNS, extractTestDirs, globsToPathspec, globsToTestRegex } from "./conventions";
+import type { DetectionResult } from "./detect";
+import { detectTestFilePatterns } from "./detect";
+
+// ─── Public types ──────────────────────────────────────────────────────────────
+
+/**
+ * All four pattern formats derived from a single source, guaranteed consistent.
+ *
+ * Consumers pick the format they need; they never translate between formats
+ * themselves — that translation lives here, tested once, consistent everywhere.
+ */
+export interface ResolvedTestPatterns {
+  /** Glob form — for file matchers: ["**\/*.test.ts"] */
+  readonly globs: readonly string[];
+  /** Git pathspec form for diff exclusion: [":!*.test.ts"] */
+  readonly pathspec: readonly string[];
+  /** Regex form for path classification: [/\.test\.ts$/] */
+  readonly regex: readonly RegExp[];
+  /** Directory names extracted from leading glob segments: ["test", "__tests__"] */
+  readonly testDirs: readonly string[];
+  /**
+   * Which tier resolved the patterns.
+   * Distinct from DetectionSource.type (which is a detection-tier label).
+   */
+  readonly resolution: "per-package" | "root-config" | "detected" | "fallback";
+}
+
+// ─── Parity constants (§4.4) ──────────────────────────────────────────────────
+
+/**
+ * Well-known test directory names always excluded from review diffs.
+ *
+ * Included in the derived `excludePatterns` regardless of user config to
+ * prevent regressing against the current hardcoded default and to handle
+ * polyglot repos where some directories may not be covered by user patterns.
+ */
+const WELL_KNOWN_TEST_DIRS = ["test", "tests", "__tests__"] as const;
+
+/**
+ * Well-known test file suffixes always excluded from review diffs.
+ * Prevents vendored test files from leaking into semantic review even when
+ * the user configures non-default `testFilePatterns`.
+ */
+const WELL_KNOWN_TEST_SUFFIXES = ["*.test.ts", "*.spec.ts", "*_test.go"] as const;
+
+/** nax metadata paths — always noise, always excluded. */
+const NAX_NOISE_PATHS = [".nax/", ".nax-pids"] as const;
+
+// ─── Injectable deps ──────────────────────────────────────────────────────────
+
+/** Injectable dependencies — mock these in tests; never use mock.module(). */
+export const _resolverDeps = {
+  fileExists: (path: string): Promise<boolean> => Bun.file(path).exists(),
+  readJson: async (path: string): Promise<unknown> => JSON.parse(await Bun.file(path).text()),
+  detectTestFilePatterns: detectTestFilePatterns as (workdir: string) => Promise<DetectionResult>,
+};
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function buildResolved(
+  globs: readonly string[],
+  resolution: ResolvedTestPatterns["resolution"],
+): ResolvedTestPatterns {
+  return {
+    globs,
+    pathspec: globsToPathspec(globs),
+    regex: globsToTestRegex(globs),
+    testDirs: extractTestDirs(globs),
+    resolution,
+  };
+}
+
+function validateGlobs(patterns: readonly string[], stage: string): void {
+  for (const p of patterns) {
+    if (typeof p !== "string" || p.trim().length === 0) {
+      throw new NaxError(
+        `Invalid test glob pattern: "${p}"`,
+        "INVALID_TEST_GLOB",
+        { pattern: p, stage },
+      );
+    }
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Resolve effective test file patterns for the given config and optional
+ * monorepo package directory.
+ *
+ * @param config     - Root NaxConfig (project-level merged config).
+ * @param workdir    - Absolute path to project root (for mono config lookup + detection).
+ * @param packageDir - Relative path to the monorepo package (e.g. "packages/api").
+ *                     Pass `undefined` for single-package projects.
+ */
+export async function resolveTestFilePatterns(
+  config: NaxConfig,
+  workdir: string,
+  packageDir?: string,
+): Promise<ResolvedTestPatterns> {
+  // 1. Per-package override
+  if (packageDir) {
+    const monoConfigPath = `${workdir}/.nax/mono/${packageDir}/config.json`;
+    try {
+      const exists = await _resolverDeps.fileExists(monoConfigPath);
+      if (exists) {
+        const monoRaw = await _resolverDeps.readJson(monoConfigPath);
+        // Type-safe access into the raw JSON shape of a per-package config
+        type MonoConfigShape = { execution?: { smartTestRunner?: { testFilePatterns?: string[] } } };
+        const perPkgPatterns = (monoRaw as MonoConfigShape)?.execution?.smartTestRunner?.testFilePatterns;
+        if (perPkgPatterns !== undefined) {
+          validateGlobs(perPkgPatterns, "resolver");
+          return buildResolved(perPkgPatterns, "per-package");
+        }
+      }
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        // Missing mono config — fall through to root config
+      } else if (err instanceof NaxError) {
+        throw err;
+      } else {
+        throw new NaxError("Failed to read per-package config", "MONO_CONFIG_READ_FAILED", {
+          packageDir,
+          stage: "resolver",
+          cause: err,
+        });
+      }
+    }
+  }
+
+  // 2. Root config explicit patterns
+  // smartTestRunner can be boolean (legacy compat) or SmartTestRunnerConfig object.
+  const smartRunner = config.execution?.smartTestRunner;
+  const rootPatterns =
+    typeof smartRunner === "object" && smartRunner !== null ? smartRunner.testFilePatterns : undefined;
+  if (rootPatterns !== undefined) {
+    validateGlobs(rootPatterns, "resolver");
+    return buildResolved(rootPatterns, "root-config");
+  }
+
+  // 3. Detection (Phase 1 stub returns empty; Phase 2 adds real detection)
+  const detected = await _resolverDeps.detectTestFilePatterns(workdir);
+  if (detected.confidence !== "empty" && detected.patterns.length > 0) {
+    getSafeLogger()?.info("resolver", "Test patterns auto-detected", {
+      confidence: detected.confidence,
+      patternCount: detected.patterns.length,
+      tier: detected.sources[0]?.type,
+    });
+    validateGlobs([...detected.patterns], "resolver");
+    return buildResolved(detected.patterns, "detected");
+  }
+
+  // 4. Fallback to canonical default
+  return buildResolved(DEFAULT_TEST_FILE_PATTERNS, "fallback");
+}
+
+/**
+ * Resolve the effective `excludePatterns` list for review diff exclusion.
+ *
+ * When the user has set `excludePatterns` explicitly (any value, including
+ * empty array) → returned verbatim. User override always wins.
+ *
+ * When `userExplicit` is `undefined` → derives from resolved test patterns +
+ * well-known noise dirs. Derivation preserves parity with the current
+ * hardcoded default for TS projects (see §4.4 of the spec for proof).
+ */
+export function resolveReviewExcludePatterns(
+  userExplicit: readonly string[] | undefined,
+  resolved: ResolvedTestPatterns,
+): readonly string[] {
+  if (userExplicit !== undefined) return userExplicit;
+
+  const result = new Set<string>();
+
+  // 1. Project's resolved test patterns (from user config / detection)
+  for (const p of resolved.pathspec) result.add(p);
+  for (const d of resolved.testDirs) result.add(`:!${d}/`);
+
+  // 2. Well-known test dirs/suffixes — always excluded to prevent regression
+  //    vs. current hardcoded default and to handle polyglot repos.
+  for (const d of WELL_KNOWN_TEST_DIRS) result.add(`:!${d}/`);
+  for (const s of WELL_KNOWN_TEST_SUFFIXES) result.add(`:!${s}`);
+
+  // 3. nax noise paths
+  for (const p of NAX_NOISE_PATHS) result.add(`:!${p}`);
+
+  return [...result];
+}
+
+/**
+ * Walk up from `filePath` to find the nearest monorepo package directory
+ * relative to `workdir`.
+ *
+ * Returns `undefined` when at the workdir root (single-package project or
+ * file not in a sub-package). Used by classification sites that only have
+ * a file path and need to discover the package context.
+ *
+ * Callers operating on many files should call this once per story/package,
+ * not per file — see §2.8 of the spec for the resolve-once-classify-many
+ * pattern.
+ */
+export async function findPackageDir(filePath: string, workdir: string): Promise<string | undefined> {
+  let dir = resolve(workdir, dirname(filePath));
+  const resolvedWorkdir = resolve(workdir);
+
+  while (dir !== resolvedWorkdir && dir !== dirname(dir)) {
+    const rel = relative(resolvedWorkdir, dir);
+    const monoConfigPath = `${resolvedWorkdir}/.nax/mono/${rel}/config.json`;
+    const exists = await _resolverDeps.fileExists(monoConfigPath);
+    if (exists) return rel;
+
+    // Also check for standard package boundary markers
+    for (const marker of ["package.json", "go.mod", "pyproject.toml", "Cargo.toml"]) {
+      const markerExists = await _resolverDeps.fileExists(`${dir}/${marker}`);
+      if (markerExists) {
+        const rel2 = relative(resolvedWorkdir, dir);
+        if (rel2 && rel2 !== ".") return rel2;
+      }
+    }
+
+    dir = dirname(dir);
+  }
+
+  return undefined;
+}

--- a/src/test-runners/resolver.ts
+++ b/src/test-runners/resolver.ts
@@ -18,9 +18,9 @@
  */
 
 import { dirname, relative, resolve } from "node:path";
+import type { NaxConfig } from "../config/types";
 import { NaxError } from "../errors";
 import { getSafeLogger } from "../logger";
-import type { NaxConfig } from "../config/types";
 import { DEFAULT_TEST_FILE_PATTERNS, extractTestDirs, globsToPathspec, globsToTestRegex } from "./conventions";
 import type { DetectionResult } from "./detect";
 import { detectTestFilePatterns } from "./detect";
@@ -81,10 +81,7 @@ export const _resolverDeps = {
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
-function buildResolved(
-  globs: readonly string[],
-  resolution: ResolvedTestPatterns["resolution"],
-): ResolvedTestPatterns {
+function buildResolved(globs: readonly string[], resolution: ResolvedTestPatterns["resolution"]): ResolvedTestPatterns {
   return {
     globs,
     pathspec: globsToPathspec(globs),
@@ -97,11 +94,7 @@ function buildResolved(
 function validateGlobs(patterns: readonly string[], stage: string): void {
   for (const p of patterns) {
     if (typeof p !== "string" || p.trim().length === 0) {
-      throw new NaxError(
-        `Invalid test glob pattern: "${p}"`,
-        "INVALID_TEST_GLOB",
-        { pattern: p, stage },
-      );
+      throw new NaxError(`Invalid test glob pattern: "${p}"`, "INVALID_TEST_GLOB", { pattern: p, stage });
     }
   }
 }

--- a/src/verification/strategies/scoped.ts
+++ b/src/verification/strategies/scoped.ts
@@ -27,7 +27,7 @@ const DEFAULT_SMART_RUNNER_CONFIG = {
 function coerceSmartRunner(val: unknown) {
   if (val === undefined || val === true) return DEFAULT_SMART_RUNNER_CONFIG;
   if (val === false) return { ...DEFAULT_SMART_RUNNER_CONFIG, enabled: false };
-  return val as typeof DEFAULT_SMART_RUNNER_CONFIG;
+  return { ...DEFAULT_SMART_RUNNER_CONFIG, ...(val as Partial<typeof DEFAULT_SMART_RUNNER_CONFIG>) };
 }
 
 function buildScopedCommand(testFiles: string[], baseCommand: string, testScopedTemplate?: string): string {

--- a/test/unit/config/migrations.test.ts
+++ b/test/unit/config/migrations.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for config migration shims (ADR-009 §4.5).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { migrateLegacyTestPattern } from "../../../src/config/migrations";
+
+describe("migrateLegacyTestPattern", () => {
+  test("no-op when testPattern absent", () => {
+    const raw = { execution: { smartTestRunner: { enabled: true } } };
+    const result = migrateLegacyTestPattern(raw, null);
+    expect(result).toEqual(raw);
+    expect(result).toBe(raw); // same reference (no copy needed when no migration)
+  });
+
+  test("aliases testPattern to testFilePatterns array when testFilePatterns absent", () => {
+    const raw: Record<string, unknown> = {
+      context: { testCoverage: { testPattern: "**/*.test.ts" } },
+    };
+    const result = migrateLegacyTestPattern(raw, null);
+
+    const exec = result.execution as any;
+    expect(exec?.smartTestRunner?.testFilePatterns).toEqual(["**/*.test.ts"]);
+
+    // Legacy key is removed
+    const ctx = result.context as any;
+    expect(ctx?.testCoverage?.testPattern).toBeUndefined();
+  });
+
+  test("drops testPattern when testFilePatterns already set (canonical wins)", () => {
+    const raw: Record<string, unknown> = {
+      context: { testCoverage: { testPattern: "**/*.test.ts" } },
+      execution: { smartTestRunner: { testFilePatterns: ["src/**/*.spec.ts"] } },
+    };
+    const result = migrateLegacyTestPattern(raw, null);
+
+    const exec = result.execution as any;
+    // Canonical value preserved unchanged
+    expect(exec?.smartTestRunner?.testFilePatterns).toEqual(["src/**/*.spec.ts"]);
+
+    // Legacy key removed from context
+    const ctx = result.context as any;
+    expect(ctx?.testCoverage?.testPattern).toBeUndefined();
+  });
+
+  test("is immutable: original object is not mutated", () => {
+    const raw: Record<string, unknown> = {
+      context: { testCoverage: { testPattern: "**/*.test.ts" } },
+    };
+    const original = structuredClone(raw);
+    migrateLegacyTestPattern(raw, null);
+    expect(raw).toEqual(original); // raw unchanged
+  });
+
+  test("handles missing context.testCoverage gracefully", () => {
+    const raw: Record<string, unknown> = {
+      context: { testCoverage: { testPattern: "*.spec.ts", extraField: "kept" } },
+    };
+    const result = migrateLegacyTestPattern(raw, null);
+    // extraField preserved; testPattern removed
+    const ctx = result.context as any;
+    expect(ctx?.testCoverage?.extraField).toBe("kept");
+    expect(ctx?.testCoverage?.testPattern).toBeUndefined();
+  });
+
+  test("handles completely absent context object", () => {
+    const raw: Record<string, unknown> = {};
+    const result = migrateLegacyTestPattern(raw, null);
+    expect(result).toBe(raw); // no-op, same reference
+  });
+
+  test("wraps single string into array (not nested array)", () => {
+    const raw: Record<string, unknown> = {
+      context: { testCoverage: { testPattern: "src/**/*.spec.ts" } },
+    };
+    const result = migrateLegacyTestPattern(raw, null);
+    const patterns = (result.execution as any)?.smartTestRunner?.testFilePatterns;
+    expect(patterns).toEqual(["src/**/*.spec.ts"]);
+    expect(typeof patterns[0]).toBe("string");
+  });
+
+  test("preserves existing smartTestRunner fields when aliasing", () => {
+    const raw: Record<string, unknown> = {
+      context: { testCoverage: { testPattern: "**/*.test.ts" } },
+      execution: { smartTestRunner: { enabled: true, fallback: "import-grep" } },
+    };
+    const result = migrateLegacyTestPattern(raw, null);
+    const runner = (result.execution as any)?.smartTestRunner;
+    expect(runner?.enabled).toBe(true);
+    expect(runner?.fallback).toBe("import-grep");
+    expect(runner?.testFilePatterns).toEqual(["**/*.test.ts"]);
+  });
+});

--- a/test/unit/config/semantic-review.test.ts
+++ b/test/unit/config/semantic-review.test.ts
@@ -115,7 +115,7 @@ describe("ReviewConfig semantic field", () => {
         resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
-        excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/", ":!.nax/", ":!.nax-pids"],
+        // excludePatterns is now optional (ADR-009): undefined means resolver will derive at runtime
       });
     }
   });

--- a/test/unit/config/smart-runner-flag.test.ts
+++ b/test/unit/config/smart-runner-flag.test.ts
@@ -111,7 +111,6 @@ describe("execution.smartTestRunner config flag", () => {
     if (result.success) {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: true,
-        testFilePatterns: ["test/**/*.test.ts"],
         fallback: "import-grep",
       });
     }
@@ -126,7 +125,6 @@ describe("execution.smartTestRunner config flag", () => {
     if (result.success) {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: false,
-        testFilePatterns: ["test/**/*.test.ts"],
         fallback: "import-grep",
       });
     }
@@ -141,7 +139,6 @@ describe("execution.smartTestRunner config flag", () => {
     if (result.success) {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: true,
-        testFilePatterns: ["test/**/*.test.ts"],
         fallback: "import-grep",
       });
     }
@@ -154,7 +151,6 @@ describe("execution.smartTestRunner config flag", () => {
     const config = await loadConfig(join(tempDir, ".nax"));
     expect(config.execution.smartTestRunner).toEqual({
       enabled: true,
-      testFilePatterns: ["test/**/*.test.ts"],
       fallback: "import-grep",
     });
   });
@@ -166,7 +162,6 @@ describe("execution.smartTestRunner config flag", () => {
     const config = await loadConfig(join(tempDir, ".nax"));
     expect(config.execution.smartTestRunner).toEqual({
       enabled: false,
-      testFilePatterns: ["test/**/*.test.ts"],
       fallback: "import-grep",
     });
   });
@@ -179,7 +174,6 @@ describe("execution.smartTestRunner config flag", () => {
     const config = await loadConfig(join(tempDir, ".nax"));
     expect(config.execution.smartTestRunner).toEqual({
       enabled: true,
-      testFilePatterns: ["test/**/*.test.ts"],
       fallback: "import-grep",
     });
   });

--- a/test/unit/pipeline/greenfield.test.ts
+++ b/test/unit/pipeline/greenfield.test.ts
@@ -130,7 +130,7 @@ describe("isGreenfieldStory", () => {
     expect(resultDefault).toBe(true);
 
     // Custom pattern should match
-    const resultCustom = await isGreenfieldStory(story, workdir, "**/*.custom.ts");
+    const resultCustom = await isGreenfieldStory(story, workdir, ["**/*.custom.ts"]);
     expect(resultCustom).toBe(false);
   });
 

--- a/test/unit/test-runners/classifier.test.ts
+++ b/test/unit/test-runners/classifier.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for createTestFileClassifier (ADR-009).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createTestFileClassifier } from "../../../src/test-runners/classifier";
+import type { ResolvedTestPatterns } from "../../../src/test-runners/resolver";
+
+function makeResolved(override: Partial<ResolvedTestPatterns> = {}): ResolvedTestPatterns {
+  return {
+    globs: ["test/**/*.test.ts"],
+    pathspec: [":!*.test.ts"],
+    regex: [/\.test\.ts$/],
+    testDirs: ["test"],
+    resolution: "fallback",
+    ...override,
+  };
+}
+
+describe("createTestFileClassifier", () => {
+  test("returns false for non-test path", () => {
+    const isTest = createTestFileClassifier(makeResolved());
+    expect(isTest("src/foo.ts")).toBe(false);
+  });
+
+  test("returns true for matching test path", () => {
+    const isTest = createTestFileClassifier(makeResolved());
+    expect(isTest("test/unit/foo.test.ts")).toBe(true);
+  });
+
+  test("returns true when any regex matches (multiple patterns)", () => {
+    const isTest = createTestFileClassifier(
+      makeResolved({ regex: [/\.test\.ts$/, /\.spec\.ts$/] }),
+    );
+    expect(isTest("src/foo.spec.ts")).toBe(true);
+    expect(isTest("src/foo.test.ts")).toBe(true);
+    expect(isTest("src/foo.ts")).toBe(false);
+  });
+
+  test("always returns false when regex list is empty", () => {
+    const isTest = createTestFileClassifier(makeResolved({ regex: [] }));
+    expect(isTest("test/unit/foo.test.ts")).toBe(false);
+    expect(isTest("anything.spec.ts")).toBe(false);
+  });
+
+  test("returned classifier is reusable across multiple calls", () => {
+    const isTest = createTestFileClassifier(makeResolved());
+    expect(isTest("test/a.test.ts")).toBe(true);
+    expect(isTest("test/a.test.ts")).toBe(true); // second call same result
+    expect(isTest("src/b.ts")).toBe(false);
+  });
+
+  test("classifier can be used directly as a filter predicate", () => {
+    const isTest = createTestFileClassifier(makeResolved());
+    const files = ["src/a.ts", "test/b.test.ts", "src/c.ts", "test/d.test.ts"];
+    expect(files.filter(isTest)).toEqual(["test/b.test.ts", "test/d.test.ts"]);
+  });
+});

--- a/test/unit/test-runners/detect-cache.test.ts
+++ b/test/unit/test-runners/detect-cache.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for the detect module — cache behaviour
+ *
+ * Extracted from detect.test.ts to keep both files under the 400-line limit.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { DetectionResult } from "../../../src/test-runners/detect";
+import { _cacheDeps } from "../../../src/test-runners/detect/cache";
+import { _directoryScanDeps } from "../../../src/test-runners/detect/directory-scan";
+import { _fileScanDeps } from "../../../src/test-runners/detect/file-scan";
+import { _frameworkConfigDeps } from "../../../src/test-runners/detect/framework-configs";
+import { _frameworkDefaultsDeps } from "../../../src/test-runners/detect/framework-defaults";
+import { detectTestFilePatterns } from "../../../src/test-runners/detect/index";
+
+type Orig = {
+  readText: typeof _frameworkConfigDeps.readText;
+  parseToml: typeof _frameworkConfigDeps.parseToml;
+  parseYaml: typeof _frameworkConfigDeps.parseYaml;
+  defaultsReadText: typeof _frameworkDefaultsDeps.readText;
+  defaultsFileExists: typeof _frameworkDefaultsDeps.fileExists;
+  fileScanSpawn: typeof _fileScanDeps.spawn;
+  cacheReadJson: typeof _cacheDeps.readJson;
+  cacheWriteJson: typeof _cacheDeps.writeJson;
+  cacheFileMtime: typeof _cacheDeps.fileMtime;
+  dirExists: typeof _directoryScanDeps.dirExists;
+  dirSpawn: typeof _directoryScanDeps.spawn;
+};
+
+let orig: Orig;
+
+function spawnWithOutput(output: string): ReturnType<typeof Bun.spawn> {
+  const enc = new TextEncoder();
+  const bytes = enc.encode(output);
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+  return { exited: Promise.resolve(0), stdout: stream } as unknown as ReturnType<typeof Bun.spawn>;
+}
+
+beforeEach(() => {
+  orig = {
+    readText: _frameworkConfigDeps.readText,
+    parseToml: _frameworkConfigDeps.parseToml,
+    parseYaml: _frameworkConfigDeps.parseYaml,
+    defaultsReadText: _frameworkDefaultsDeps.readText,
+    defaultsFileExists: _frameworkDefaultsDeps.fileExists,
+    fileScanSpawn: _fileScanDeps.spawn,
+    cacheReadJson: _cacheDeps.readJson,
+    cacheWriteJson: _cacheDeps.writeJson,
+    cacheFileMtime: _cacheDeps.fileMtime,
+    dirExists: _directoryScanDeps.dirExists,
+    dirSpawn: _directoryScanDeps.spawn,
+  };
+  _cacheDeps.readJson = mock(async () => { throw new Error("not found"); });
+  _cacheDeps.writeJson = mock(async () => {});
+  _cacheDeps.fileMtime = mock(async () => null);
+  _directoryScanDeps.dirExists = mock(async () => false);
+  _directoryScanDeps.spawn = mock((..._args: unknown[]) =>
+    ({ exited: Promise.resolve(1), stdout: null } as unknown as ReturnType<typeof Bun.spawn>),
+  ) as unknown as typeof Bun.spawn;
+  _frameworkDefaultsDeps.fileExists = mock(async () => false);
+});
+
+afterEach(() => {
+  _frameworkConfigDeps.readText = orig.readText;
+  _frameworkConfigDeps.parseToml = orig.parseToml;
+  _frameworkConfigDeps.parseYaml = orig.parseYaml;
+  _frameworkDefaultsDeps.readText = orig.defaultsReadText;
+  _frameworkDefaultsDeps.fileExists = orig.defaultsFileExists;
+  _fileScanDeps.spawn = orig.fileScanSpawn;
+  _cacheDeps.readJson = orig.cacheReadJson;
+  _cacheDeps.writeJson = orig.cacheWriteJson;
+  _cacheDeps.fileMtime = orig.cacheFileMtime;
+  _directoryScanDeps.dirExists = orig.dirExists;
+  _directoryScanDeps.spawn = orig.dirSpawn;
+});
+
+describe("cache", () => {
+  test("returns cached result on hit", async () => {
+    const cached: DetectionResult = {
+      patterns: ["**/*.cached.ts"],
+      confidence: "high",
+      sources: [
+        { type: "framework-config", path: "/fake/workdir/vitest.config.ts", patterns: ["**/*.cached.ts"] },
+      ],
+    };
+
+    _cacheDeps.readJson = mock(async () => ({
+      workdir: "/fake/workdir",
+      mtimes: {},
+      result: cached,
+    }));
+    _cacheDeps.fileMtime = mock(async () => null);
+
+    const readTextSpy = mock(async () => null);
+    _frameworkConfigDeps.readText = readTextSpy;
+    _frameworkDefaultsDeps.readText = readTextSpy;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.patterns).toEqual(["**/*.cached.ts"]);
+    expect(readTextSpy).not.toHaveBeenCalled();
+  });
+
+  test("writes result to cache after detection", async () => {
+    _cacheDeps.readJson = mock(async () => { throw new Error("miss"); });
+    _cacheDeps.fileMtime = mock(async () => null);
+
+    const written: Array<[string, unknown]> = [];
+    _cacheDeps.writeJson = mock(async (path: string, data: unknown) => {
+      written.push([path, data]);
+    });
+
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("package.json")) {
+        return JSON.stringify({ devDependencies: { vitest: "^1.0.0" } });
+      }
+      return null;
+    });
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    await detectTestFilePatterns("/fake/workdir");
+    expect(written.length).toBe(1);
+    expect(written[0]?.[0]).toContain("test-patterns.json");
+  });
+
+  test("treats corrupt cache as miss, rebuilds without throwing", async () => {
+    _cacheDeps.readJson = mock(async () => { throw new SyntaxError("bad json"); });
+    _cacheDeps.fileMtime = mock(async () => null);
+    _cacheDeps.writeJson = mock(async () => {});
+
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async () => null);
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+    _directoryScanDeps.dirExists = mock(async () => false);
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("empty");
+  });
+
+  test("invalidates cache when mtime changes", async () => {
+    const cached: DetectionResult = {
+      patterns: ["**/*.stale.ts"],
+      confidence: "high",
+      sources: [],
+    };
+
+    _cacheDeps.readJson = mock(async () => ({
+      workdir: "/fake/workdir",
+      mtimes: { "package.json": 100 },
+      result: cached,
+    }));
+    _cacheDeps.fileMtime = mock(async (path: string) => {
+      if (path.endsWith("package.json")) return 200; // changed
+      return null;
+    });
+    _cacheDeps.writeJson = mock(async () => {});
+
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("package.json")) return JSON.stringify({ devDependencies: { vitest: "^1.0.0" } });
+      return null;
+    });
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.patterns).not.toContain("**/*.stale.ts");
+    expect(result.confidence).toBe("medium");
+  });
+});

--- a/test/unit/test-runners/detect.test.ts
+++ b/test/unit/test-runners/detect.test.ts
@@ -4,16 +4,17 @@
  * Tests are fixture-based: each test creates a minimal in-memory workdir by
  * injecting mocks via the exported _deps objects. This avoids disk I/O and
  * keeps tests fast and deterministic.
+ *
+ * Cache behaviour is tested in detect-cache.test.ts.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { DetectionResult } from "../../../src/test-runners/detect";
-import { _cacheDeps } from "../../../src/test-runners/detect/cache";
 import { _directoryScanDeps } from "../../../src/test-runners/detect/directory-scan";
 import { _fileScanDeps } from "../../../src/test-runners/detect/file-scan";
 import { _frameworkConfigDeps } from "../../../src/test-runners/detect/framework-configs";
 import { _frameworkDefaultsDeps } from "../../../src/test-runners/detect/framework-defaults";
-import { detectTestFilePatterns } from "../../../src/test-runners/detect/index";
+import { detectTestFilePatterns, detectTestFilePatternsForWorkspace } from "../../../src/test-runners/detect/index";
+import { _cacheDeps } from "../../../src/test-runners/detect/cache";
 
 // ─── Save/restore helpers ─────────────────────────────────────────────────────
 
@@ -22,6 +23,7 @@ type Orig = {
   parseToml: typeof _frameworkConfigDeps.parseToml;
   parseYaml: typeof _frameworkConfigDeps.parseYaml;
   defaultsReadText: typeof _frameworkDefaultsDeps.readText;
+  defaultsFileExists: typeof _frameworkDefaultsDeps.fileExists;
   fileScanSpawn: typeof _fileScanDeps.spawn;
   cacheReadJson: typeof _cacheDeps.readJson;
   cacheWriteJson: typeof _cacheDeps.writeJson;
@@ -56,6 +58,7 @@ beforeEach(() => {
     parseToml: _frameworkConfigDeps.parseToml,
     parseYaml: _frameworkConfigDeps.parseYaml,
     defaultsReadText: _frameworkDefaultsDeps.readText,
+    defaultsFileExists: _frameworkDefaultsDeps.fileExists,
     fileScanSpawn: _fileScanDeps.spawn,
     cacheReadJson: _cacheDeps.readJson,
     cacheWriteJson: _cacheDeps.writeJson,
@@ -64,14 +67,13 @@ beforeEach(() => {
     dirSpawn: _directoryScanDeps.spawn,
   };
   // Default: cache miss, write is no-op
-  _cacheDeps.readJson = mock(async () => {
-    throw new Error("not found");
-  });
+  _cacheDeps.readJson = mock(async () => { throw new Error("not found"); });
   _cacheDeps.writeJson = mock(async () => {});
   _cacheDeps.fileMtime = mock(async () => null);
-  // Default: no directories exist
+  // Default: no directories exist, no go.mod/Cargo.toml
   _directoryScanDeps.dirExists = mock(async () => false);
   _directoryScanDeps.spawn = mock((..._args: unknown[]) => spawnFailed()) as unknown as typeof Bun.spawn;
+  _frameworkDefaultsDeps.fileExists = mock(async () => false);
 });
 
 afterEach(() => {
@@ -79,6 +81,7 @@ afterEach(() => {
   _frameworkConfigDeps.parseToml = orig.parseToml;
   _frameworkConfigDeps.parseYaml = orig.parseYaml;
   _frameworkDefaultsDeps.readText = orig.defaultsReadText;
+  _frameworkDefaultsDeps.fileExists = orig.defaultsFileExists;
   _fileScanDeps.spawn = orig.fileScanSpawn;
   _cacheDeps.readJson = orig.cacheReadJson;
   _cacheDeps.writeJson = orig.cacheWriteJson;
@@ -109,7 +112,6 @@ describe("Tier 1 — vitest config", () => {
 
   test("falls through to Tier 2 when vitest config has no extractable include", async () => {
     _frameworkConfigDeps.readText = mock(async (path: string) => {
-      // Return vitest config with no literal include array
       if (path.endsWith("vitest.config.ts")) return `export default defineConfig({})`;
       return null;
     });
@@ -122,7 +124,6 @@ describe("Tier 1 — vitest config", () => {
     _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
 
     const result = await detectTestFilePatterns("/fake/workdir");
-    // Tier 1 found config but no patterns → Tier 2 has vitest in deps
     expect(result.confidence).toBe("medium");
     expect(result.patterns).toEqual(expect.arrayContaining(["**/*.{test,spec}.?(c|m)[jt]s?(x)"]));
   });
@@ -220,6 +221,35 @@ describe("Tier 2 — framework defaults from manifests", () => {
     expect(result.confidence).toBe("medium");
     expect(result.patterns).toEqual(expect.arrayContaining(["**/*.test.{ts,tsx,js,jsx}"]));
   });
+
+  test("detects Go project from go.mod and returns **/*_test.go at medium confidence", async () => {
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.fileExists = mock(async (path: string) => path.endsWith("go.mod"));
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("medium");
+    expect(result.patterns).toContain("**/*_test.go");
+    expect(result.sources[0]?.type).toBe("manifest");
+  });
+
+  test("polyglot project (TS + Go) merges patterns from both", async () => {
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("package.json")) {
+        return JSON.stringify({ devDependencies: { vitest: "^1.0.0" } });
+      }
+      return null;
+    });
+    _frameworkDefaultsDeps.fileExists = mock(async (path: string) => path.endsWith("go.mod"));
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("medium");
+    expect(result.patterns).toContain("**/*_test.go");
+    expect(result.patterns).toEqual(expect.arrayContaining(["**/*.{test,spec}.?(c|m)[jt]s?(x)"]));
+  });
 });
 
 // ─── Tier 3: file scan ────────────────────────────────────────────────────────
@@ -229,7 +259,6 @@ describe("Tier 3 — file scan", () => {
     _frameworkConfigDeps.readText = mock(async () => null);
     _frameworkDefaultsDeps.readText = mock(async () => null);
 
-    // 6 .test.ts files + source files — meets threshold
     const testFiles = Array.from({ length: 6 }, (_, i) => `src/module${i}.test.ts`).join("\n");
     const allFiles = `${testFiles}\nsrc/app.ts\nsrc/index.ts\n`;
     _fileScanDeps.spawn = mock((..._args: unknown[]) =>
@@ -246,7 +275,6 @@ describe("Tier 3 — file scan", () => {
     _frameworkConfigDeps.readText = mock(async () => null);
     _frameworkDefaultsDeps.readText = mock(async () => null);
 
-    // Only 2 .test.ts files out of 52 total — below both thresholds
     const files =
       "src/a.test.ts\nsrc/b.test.ts\n" +
       Array.from({ length: 50 }, (_, i) => `src/f${i}.ts`).join("\n");
@@ -266,7 +294,6 @@ describe("Tier 4 — directory convention", () => {
     _frameworkDefaultsDeps.readText = mock(async () => null);
     _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
 
-    // test/ directory exists; contains .ts files via git ls-files
     _directoryScanDeps.dirExists = mock(async (path: string) => path.endsWith("/test"));
     _directoryScanDeps.spawn = mock((..._args: unknown[]) =>
       spawnWithOutput("test/foo.test.ts\ntest/bar.test.ts\n"),
@@ -294,107 +321,38 @@ describe("empty project", () => {
   });
 });
 
-// ─── Cache ────────────────────────────────────────────────────────────────────
+// ─── Monorepo workspace ───────────────────────────────────────────────────────
 
-describe("cache", () => {
-  test("returns cached result on hit", async () => {
-    const cached: DetectionResult = {
-      patterns: ["**/*.cached.ts"],
-      confidence: "high",
-      sources: [
-        { type: "framework-config", path: "/fake/workdir/vitest.config.ts", patterns: ["**/*.cached.ts"] },
-      ],
-    };
-
-    _cacheDeps.readJson = mock(async () => ({
-      workdir: "/fake/workdir",
-      mtimes: {},
-      result: cached,
-    }));
-    _cacheDeps.fileMtime = mock(async () => null);
-
-    // If cache returns, detection deps should NOT be called
-    const readTextSpy = mock(async () => null);
-    _frameworkConfigDeps.readText = readTextSpy;
-    _frameworkDefaultsDeps.readText = readTextSpy;
-
-    const result = await detectTestFilePatterns("/fake/workdir");
-    expect(result.patterns).toEqual(["**/*.cached.ts"]);
-    expect(readTextSpy).not.toHaveBeenCalled();
-  });
-
-  test("writes result to cache after detection", async () => {
-    // Cache miss
-    _cacheDeps.readJson = mock(async () => {
-      throw new Error("miss");
-    });
-    _cacheDeps.fileMtime = mock(async () => null);
-
-    const written: Array<[string, unknown]> = [];
-    _cacheDeps.writeJson = mock(async (path: string, data: unknown) => {
-      written.push([path, data]);
-    });
-
+describe("monorepo workspace", () => {
+  test("detectTestFilePatternsForWorkspace returns per-package map", async () => {
+    // Root: vitest; packages/api: jest; packages/ui: empty
     _frameworkConfigDeps.readText = mock(async () => null);
     _frameworkDefaultsDeps.readText = mock(async (path: string) => {
-      if (path.endsWith("package.json")) {
+      if (path === "/fake/root/package.json") {
         return JSON.stringify({ devDependencies: { vitest: "^1.0.0" } });
+      }
+      if (path === "/fake/root/packages/api/package.json") {
+        return JSON.stringify({ devDependencies: { jest: "^29.0.0" } });
       }
       return null;
     });
-    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
-
-    await detectTestFilePatterns("/fake/workdir");
-    expect(written.length).toBe(1);
-    expect(written[0]?.[0]).toContain("test-patterns.json");
-  });
-
-  test("treats corrupt cache as miss, rebuilds without throwing", async () => {
-    _cacheDeps.readJson = mock(async () => {
-      throw new SyntaxError("bad json");
-    });
-    _cacheDeps.fileMtime = mock(async () => null);
-    _cacheDeps.writeJson = mock(async () => {});
-
-    _frameworkConfigDeps.readText = mock(async () => null);
-    _frameworkDefaultsDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.fileExists = mock(async () => false);
     _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
     _directoryScanDeps.dirExists = mock(async () => false);
 
-    // Should not throw
-    const result = await detectTestFilePatterns("/fake/workdir");
-    expect(result.confidence).toBe("empty");
-  });
+    const result = await detectTestFilePatternsForWorkspace("/fake/root", ["packages/api", "packages/ui"]);
 
-  test("invalidates cache when mtime changes", async () => {
-    const cached: DetectionResult = {
-      patterns: ["**/*.stale.ts"],
-      confidence: "high",
-      sources: [],
-    };
+    // Root should detect vitest
+    expect(result[""]?.confidence).toBe("medium");
+    expect(result[""]?.patterns).toEqual(expect.arrayContaining(["**/*.{test,spec}.?(c|m)[jt]s?(x)"]));
 
-    // Cache has package.json mtime = 100, but current mtime = 200 (changed)
-    _cacheDeps.readJson = mock(async () => ({
-      workdir: "/fake/workdir",
-      mtimes: { "package.json": 100 },
-      result: cached,
-    }));
-    _cacheDeps.fileMtime = mock(async (path: string) => {
-      if (path.endsWith("package.json")) return 200; // changed
-      return null;
-    });
-    _cacheDeps.writeJson = mock(async () => {});
+    // packages/api should detect jest
+    expect(result["packages/api"]?.confidence).toBe("medium");
+    expect(result["packages/api"]?.patterns).toEqual(
+      expect.arrayContaining(["**/__tests__/**/*.[jt]s?(x)"]),
+    );
 
-    _frameworkConfigDeps.readText = mock(async () => null);
-    _frameworkDefaultsDeps.readText = mock(async (path: string) => {
-      if (path.endsWith("package.json")) return JSON.stringify({ devDependencies: { vitest: "^1.0.0" } });
-      return null;
-    });
-    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
-
-    // Should re-detect, NOT return stale cached result
-    const result = await detectTestFilePatterns("/fake/workdir");
-    expect(result.patterns).not.toContain("**/*.stale.ts");
-    expect(result.confidence).toBe("medium");
+    // packages/ui has no signals
+    expect(result["packages/ui"]?.confidence).toBe("empty");
   });
 });

--- a/test/unit/test-runners/detect.test.ts
+++ b/test/unit/test-runners/detect.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Unit tests for the detect module (Phase 2 — four-tier detection)
+ *
+ * Tests are fixture-based: each test creates a minimal in-memory workdir by
+ * injecting mocks via the exported _deps objects. This avoids disk I/O and
+ * keeps tests fast and deterministic.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { DetectionResult } from "../../../src/test-runners/detect";
+import { _cacheDeps } from "../../../src/test-runners/detect/cache";
+import { _directoryScanDeps } from "../../../src/test-runners/detect/directory-scan";
+import { _fileScanDeps } from "../../../src/test-runners/detect/file-scan";
+import { _frameworkConfigDeps } from "../../../src/test-runners/detect/framework-configs";
+import { _frameworkDefaultsDeps } from "../../../src/test-runners/detect/framework-defaults";
+import { detectTestFilePatterns } from "../../../src/test-runners/detect/index";
+
+// ─── Save/restore helpers ─────────────────────────────────────────────────────
+
+type Orig = {
+  readText: typeof _frameworkConfigDeps.readText;
+  parseToml: typeof _frameworkConfigDeps.parseToml;
+  parseYaml: typeof _frameworkConfigDeps.parseYaml;
+  defaultsReadText: typeof _frameworkDefaultsDeps.readText;
+  fileScanSpawn: typeof _fileScanDeps.spawn;
+  cacheReadJson: typeof _cacheDeps.readJson;
+  cacheWriteJson: typeof _cacheDeps.writeJson;
+  cacheFileMtime: typeof _cacheDeps.fileMtime;
+  dirExists: typeof _directoryScanDeps.dirExists;
+  dirSpawn: typeof _directoryScanDeps.spawn;
+};
+
+let orig: Orig;
+
+/** Make a subprocess mock that returns the given stdout text */
+function spawnWithOutput(output: string): ReturnType<typeof Bun.spawn> {
+  const enc = new TextEncoder();
+  const bytes = enc.encode(output);
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+  return { exited: Promise.resolve(0), stdout: stream } as unknown as ReturnType<typeof Bun.spawn>;
+}
+
+/** Make a subprocess mock that exits with non-zero (failure) */
+function spawnFailed(): ReturnType<typeof Bun.spawn> {
+  return { exited: Promise.resolve(1), stdout: null } as unknown as ReturnType<typeof Bun.spawn>;
+}
+
+beforeEach(() => {
+  orig = {
+    readText: _frameworkConfigDeps.readText,
+    parseToml: _frameworkConfigDeps.parseToml,
+    parseYaml: _frameworkConfigDeps.parseYaml,
+    defaultsReadText: _frameworkDefaultsDeps.readText,
+    fileScanSpawn: _fileScanDeps.spawn,
+    cacheReadJson: _cacheDeps.readJson,
+    cacheWriteJson: _cacheDeps.writeJson,
+    cacheFileMtime: _cacheDeps.fileMtime,
+    dirExists: _directoryScanDeps.dirExists,
+    dirSpawn: _directoryScanDeps.spawn,
+  };
+  // Default: cache miss, write is no-op
+  _cacheDeps.readJson = mock(async () => {
+    throw new Error("not found");
+  });
+  _cacheDeps.writeJson = mock(async () => {});
+  _cacheDeps.fileMtime = mock(async () => null);
+  // Default: no directories exist
+  _directoryScanDeps.dirExists = mock(async () => false);
+  _directoryScanDeps.spawn = mock((..._args: unknown[]) => spawnFailed()) as unknown as typeof Bun.spawn;
+});
+
+afterEach(() => {
+  _frameworkConfigDeps.readText = orig.readText;
+  _frameworkConfigDeps.parseToml = orig.parseToml;
+  _frameworkConfigDeps.parseYaml = orig.parseYaml;
+  _frameworkDefaultsDeps.readText = orig.defaultsReadText;
+  _fileScanDeps.spawn = orig.fileScanSpawn;
+  _cacheDeps.readJson = orig.cacheReadJson;
+  _cacheDeps.writeJson = orig.cacheWriteJson;
+  _cacheDeps.fileMtime = orig.cacheFileMtime;
+  _directoryScanDeps.dirExists = orig.dirExists;
+  _directoryScanDeps.spawn = orig.dirSpawn;
+});
+
+// ─── Tier 1: vitest config ────────────────────────────────────────────────────
+
+describe("Tier 1 — vitest config", () => {
+  test("detects test.include patterns from vitest.config.ts", async () => {
+    _frameworkConfigDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("vitest.config.ts")) {
+        return `export default defineConfig({ test: { include: ["src/**/*.test.ts", "src/**/*.spec.ts"] } })`;
+      }
+      return null;
+    });
+    _frameworkDefaultsDeps.readText = mock(async () => null);
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("high");
+    expect(result.patterns).toContain("src/**/*.test.ts");
+    expect(result.patterns).toContain("src/**/*.spec.ts");
+    expect(result.sources[0]?.type).toBe("framework-config");
+  });
+
+  test("falls through to Tier 2 when vitest config has no extractable include", async () => {
+    _frameworkConfigDeps.readText = mock(async (path: string) => {
+      // Return vitest config with no literal include array
+      if (path.endsWith("vitest.config.ts")) return `export default defineConfig({})`;
+      return null;
+    });
+    _frameworkDefaultsDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("package.json")) {
+        return JSON.stringify({ devDependencies: { vitest: "^1.0.0" } });
+      }
+      return null;
+    });
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    // Tier 1 found config but no patterns → Tier 2 has vitest in deps
+    expect(result.confidence).toBe("medium");
+    expect(result.patterns).toEqual(expect.arrayContaining(["**/*.{test,spec}.?(c|m)[jt]s?(x)"]));
+  });
+});
+
+// ─── Tier 1: jest config ──────────────────────────────────────────────────────
+
+describe("Tier 1 — jest config", () => {
+  test("extracts testMatch from jest.config.js", async () => {
+    _frameworkConfigDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("jest.config.js")) {
+        return `module.exports = { testMatch: ["**/__tests__/**/*.ts", "**/*.test.ts"] }`;
+      }
+      return null;
+    });
+    _frameworkDefaultsDeps.readText = mock(async () => null);
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("high");
+    expect(result.patterns).toContain("**/__tests__/**/*.ts");
+    expect(result.patterns).toContain("**/*.test.ts");
+  });
+
+  test("extracts jest config from package.json#jest", async () => {
+    _frameworkConfigDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("package.json")) {
+        return JSON.stringify({ jest: { testMatch: ["**/*.spec.js"] } });
+      }
+      return null;
+    });
+    _frameworkDefaultsDeps.readText = mock(async () => null);
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("high");
+    expect(result.patterns).toContain("**/*.spec.js");
+  });
+});
+
+// ─── Tier 1: Python ───────────────────────────────────────────────────────────
+
+describe("Tier 1 — pytest config", () => {
+  test("detects testpaths from pyproject.toml", async () => {
+    _frameworkConfigDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("pyproject.toml")) {
+        return `[tool.pytest.ini_options]\ntestpaths = ["tests", "integration"]`;
+      }
+      return null;
+    });
+    _frameworkConfigDeps.parseToml = mock((_text: string) => ({
+      tool: { pytest: { ini_options: { testpaths: ["tests", "integration"] } } },
+    }));
+    _frameworkDefaultsDeps.readText = mock(async () => null);
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("high");
+    expect(result.patterns).toContain("tests/**/*.py");
+    expect(result.patterns).toContain("integration/**/*.py");
+  });
+});
+
+// ─── Tier 2: framework defaults ──────────────────────────────────────────────
+
+describe("Tier 2 — framework defaults from manifests", () => {
+  test("detects jest from devDependencies at medium confidence", async () => {
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("package.json")) {
+        return JSON.stringify({ devDependencies: { jest: "^29.0.0" } });
+      }
+      return null;
+    });
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("medium");
+    expect(result.patterns).toEqual(
+      expect.arrayContaining(["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)"]),
+    );
+  });
+
+  test("detects bun test from package.json scripts.test", async () => {
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("package.json")) {
+        return JSON.stringify({ scripts: { test: "bun test" } });
+      }
+      return null;
+    });
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("medium");
+    expect(result.patterns).toEqual(expect.arrayContaining(["**/*.test.{ts,tsx,js,jsx}"]));
+  });
+});
+
+// ─── Tier 3: file scan ────────────────────────────────────────────────────────
+
+describe("Tier 3 — file scan", () => {
+  test("detects .test.ts suffix from git ls-files with ≥5 files", async () => {
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async () => null);
+
+    // 6 .test.ts files + source files — meets threshold
+    const testFiles = Array.from({ length: 6 }, (_, i) => `src/module${i}.test.ts`).join("\n");
+    const allFiles = `${testFiles}\nsrc/app.ts\nsrc/index.ts\n`;
+    _fileScanDeps.spawn = mock((..._args: unknown[]) =>
+      spawnWithOutput(allFiles),
+    ) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("low");
+    expect(result.patterns).toContain("**/*.test.ts");
+    expect(result.sources[0]?.type).toBe("file-scan");
+  });
+
+  test("returns empty when no suffix meets threshold", async () => {
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async () => null);
+
+    // Only 2 .test.ts files out of 52 total — below both thresholds
+    const files =
+      "src/a.test.ts\nsrc/b.test.ts\n" +
+      Array.from({ length: 50 }, (_, i) => `src/f${i}.ts`).join("\n");
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput(files)) as unknown as typeof Bun.spawn;
+    _directoryScanDeps.dirExists = mock(async () => false);
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("empty");
+  });
+});
+
+// ─── Tier 4: directory scan ───────────────────────────────────────────────────
+
+describe("Tier 4 — directory convention", () => {
+  test("detects test/ directory and emits generic globs", async () => {
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async () => null);
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    // test/ directory exists; contains .ts files via git ls-files
+    _directoryScanDeps.dirExists = mock(async (path: string) => path.endsWith("/test"));
+    _directoryScanDeps.spawn = mock((..._args: unknown[]) =>
+      spawnWithOutput("test/foo.test.ts\ntest/bar.test.ts\n"),
+    ) as unknown as typeof Bun.spawn;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("low");
+    expect(result.patterns.some((p) => p.startsWith("test/"))).toBe(true);
+  });
+});
+
+// ─── Empty project ────────────────────────────────────────────────────────────
+
+describe("empty project", () => {
+  test("returns empty confidence when no signals found", async () => {
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async () => null);
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+    _directoryScanDeps.dirExists = mock(async () => false);
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("empty");
+    expect(result.patterns).toHaveLength(0);
+    expect(result.sources).toHaveLength(0);
+  });
+});
+
+// ─── Cache ────────────────────────────────────────────────────────────────────
+
+describe("cache", () => {
+  test("returns cached result on hit", async () => {
+    const cached: DetectionResult = {
+      patterns: ["**/*.cached.ts"],
+      confidence: "high",
+      sources: [
+        { type: "framework-config", path: "/fake/workdir/vitest.config.ts", patterns: ["**/*.cached.ts"] },
+      ],
+    };
+
+    _cacheDeps.readJson = mock(async () => ({
+      workdir: "/fake/workdir",
+      mtimes: {},
+      result: cached,
+    }));
+    _cacheDeps.fileMtime = mock(async () => null);
+
+    // If cache returns, detection deps should NOT be called
+    const readTextSpy = mock(async () => null);
+    _frameworkConfigDeps.readText = readTextSpy;
+    _frameworkDefaultsDeps.readText = readTextSpy;
+
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.patterns).toEqual(["**/*.cached.ts"]);
+    expect(readTextSpy).not.toHaveBeenCalled();
+  });
+
+  test("writes result to cache after detection", async () => {
+    // Cache miss
+    _cacheDeps.readJson = mock(async () => {
+      throw new Error("miss");
+    });
+    _cacheDeps.fileMtime = mock(async () => null);
+
+    const written: Array<[string, unknown]> = [];
+    _cacheDeps.writeJson = mock(async (path: string, data: unknown) => {
+      written.push([path, data]);
+    });
+
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("package.json")) {
+        return JSON.stringify({ devDependencies: { vitest: "^1.0.0" } });
+      }
+      return null;
+    });
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    await detectTestFilePatterns("/fake/workdir");
+    expect(written.length).toBe(1);
+    expect(written[0]?.[0]).toContain("test-patterns.json");
+  });
+
+  test("treats corrupt cache as miss, rebuilds without throwing", async () => {
+    _cacheDeps.readJson = mock(async () => {
+      throw new SyntaxError("bad json");
+    });
+    _cacheDeps.fileMtime = mock(async () => null);
+    _cacheDeps.writeJson = mock(async () => {});
+
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async () => null);
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+    _directoryScanDeps.dirExists = mock(async () => false);
+
+    // Should not throw
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.confidence).toBe("empty");
+  });
+
+  test("invalidates cache when mtime changes", async () => {
+    const cached: DetectionResult = {
+      patterns: ["**/*.stale.ts"],
+      confidence: "high",
+      sources: [],
+    };
+
+    // Cache has package.json mtime = 100, but current mtime = 200 (changed)
+    _cacheDeps.readJson = mock(async () => ({
+      workdir: "/fake/workdir",
+      mtimes: { "package.json": 100 },
+      result: cached,
+    }));
+    _cacheDeps.fileMtime = mock(async (path: string) => {
+      if (path.endsWith("package.json")) return 200; // changed
+      return null;
+    });
+    _cacheDeps.writeJson = mock(async () => {});
+
+    _frameworkConfigDeps.readText = mock(async () => null);
+    _frameworkDefaultsDeps.readText = mock(async (path: string) => {
+      if (path.endsWith("package.json")) return JSON.stringify({ devDependencies: { vitest: "^1.0.0" } });
+      return null;
+    });
+    _fileScanDeps.spawn = mock((..._args: unknown[]) => spawnWithOutput("")) as unknown as typeof Bun.spawn;
+
+    // Should re-detect, NOT return stale cached result
+    const result = await detectTestFilePatterns("/fake/workdir");
+    expect(result.patterns).not.toContain("**/*.stale.ts");
+    expect(result.confidence).toBe("medium");
+  });
+});

--- a/test/unit/test-runners/resolver.test.ts
+++ b/test/unit/test-runners/resolver.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the test-file pattern resolver — ADR-009 SSOT.
+ *
+ * Covers:
+ * - Resolution chain order (per-package → root-config → detected → fallback)
+ * - resolveReviewExcludePatterns parity with old hardcoded default
+ * - Immutability and field consistency of ResolvedTestPatterns
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../../src/config";
+import type { NaxConfig } from "../../../src/config/types";
+import { _resolverDeps, resolveReviewExcludePatterns, resolveTestFilePatterns } from "../../../src/test-runners/resolver";
+import type { DetectionResult } from "../../../src/test-runners/detect";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeConfig(patterns?: string[]): NaxConfig {
+  const base = structuredClone(DEFAULT_CONFIG) as NaxConfig;
+  if (patterns === undefined) return base; // no smartTestRunner.testFilePatterns
+  return {
+    ...base,
+    execution: {
+      ...base.execution,
+      smartTestRunner: { enabled: true, fallback: "import-grep", testFilePatterns: patterns },
+    },
+  } as NaxConfig;
+}
+
+const WORKDIR = "/fake/workdir";
+
+// Save/restore injectable deps
+let origFileExists: typeof _resolverDeps.fileExists;
+let origReadJson: typeof _resolverDeps.readJson;
+let origDetect: typeof _resolverDeps.detectTestFilePatterns;
+
+beforeEach(() => {
+  origFileExists = _resolverDeps.fileExists;
+  origReadJson = _resolverDeps.readJson;
+  origDetect = _resolverDeps.detectTestFilePatterns;
+
+  // Safe defaults: no mono config, stub detection
+  _resolverDeps.fileExists = async () => false;
+  _resolverDeps.readJson = async () => ({});
+  _resolverDeps.detectTestFilePatterns = async () =>
+    ({ patterns: [], confidence: "empty", sources: [] }) satisfies DetectionResult;
+});
+
+afterEach(() => {
+  _resolverDeps.fileExists = origFileExists;
+  _resolverDeps.readJson = origReadJson;
+  _resolverDeps.detectTestFilePatterns = origDetect;
+});
+
+// ─── Resolution chain ─────────────────────────────────────────────────────────
+
+describe("resolveTestFilePatterns — resolution chain", () => {
+  test("fallback: returns DEFAULT_TEST_FILE_PATTERNS when nothing configured", async () => {
+    const resolved = await resolveTestFilePatterns(makeConfig(), WORKDIR);
+    expect(resolved.resolution).toBe("fallback");
+    expect(resolved.globs).toContain("test/**/*.test.ts");
+  });
+
+  test("root-config: returns user patterns when smartTestRunner.testFilePatterns is set", async () => {
+    const config = makeConfig(["src/**/*.spec.ts"]);
+    const resolved = await resolveTestFilePatterns(config, WORKDIR);
+    expect(resolved.resolution).toBe("root-config");
+    expect(resolved.globs).toEqual(["src/**/*.spec.ts"]);
+  });
+
+  test("root-config: explicit empty array is honoured (no test files)", async () => {
+    const config = makeConfig([]);
+    const resolved = await resolveTestFilePatterns(config, WORKDIR);
+    expect(resolved.resolution).toBe("root-config");
+    expect(resolved.globs).toHaveLength(0);
+    expect(resolved.regex).toHaveLength(0);
+  });
+
+  test("per-package: wins over root-config when mono config file present", async () => {
+    const config = makeConfig(["src/**/*.spec.ts"]); // root-config would return this
+    const monoConfigPath = `${WORKDIR}/.nax/mono/packages/api/config.json`;
+    _resolverDeps.fileExists = async (p) => p === monoConfigPath;
+    _resolverDeps.readJson = async () => ({
+      execution: { smartTestRunner: { testFilePatterns: ["packages/api/**/*.test.ts"] } },
+    });
+
+    const resolved = await resolveTestFilePatterns(config, WORKDIR, "packages/api");
+    expect(resolved.resolution).toBe("per-package");
+    expect(resolved.globs).toEqual(["packages/api/**/*.test.ts"]);
+  });
+
+  test("per-package: falls through when mono config exists but omits testFilePatterns", async () => {
+    const config = makeConfig(["src/**/*.spec.ts"]);
+    _resolverDeps.fileExists = async () => true;
+    _resolverDeps.readJson = async () => ({ execution: { smartTestRunner: {} } });
+
+    const resolved = await resolveTestFilePatterns(config, WORKDIR, "packages/api");
+    expect(resolved.resolution).toBe("root-config");
+  });
+
+  test("detected: used when detection returns patterns with non-empty confidence", async () => {
+    const config = makeConfig(); // no root config
+    _resolverDeps.detectTestFilePatterns = async () => ({
+      patterns: ["**/*.spec.ts"],
+      confidence: "high",
+      sources: [{ type: "framework-config", path: "jest.config.ts", patterns: ["**/*.spec.ts"] }],
+    });
+
+    const resolved = await resolveTestFilePatterns(config, WORKDIR);
+    expect(resolved.resolution).toBe("detected");
+    expect(resolved.globs).toEqual(["**/*.spec.ts"]);
+  });
+
+  test("detected: skipped when detection returns empty confidence", async () => {
+    const config = makeConfig();
+    _resolverDeps.detectTestFilePatterns = async () =>
+      ({ patterns: [], confidence: "empty", sources: [] }) satisfies DetectionResult;
+
+    const resolved = await resolveTestFilePatterns(config, WORKDIR);
+    expect(resolved.resolution).toBe("fallback");
+  });
+
+  test("boolean smartTestRunner (true) is treated as no explicit patterns → fallback", async () => {
+    const config = {
+      ...makeConfig(),
+      execution: { ...makeConfig().execution, smartTestRunner: true },
+    } as unknown as NaxConfig;
+    const resolved = await resolveTestFilePatterns(config, WORKDIR);
+    expect(resolved.resolution).toBe("fallback");
+  });
+});
+
+// ─── ResolvedTestPatterns field consistency ────────────────────────────────────
+
+describe("resolveTestFilePatterns — field consistency", () => {
+  test("all four fields populated for default patterns", async () => {
+    const resolved = await resolveTestFilePatterns(makeConfig(), WORKDIR);
+    expect(resolved.globs.length).toBeGreaterThan(0);
+    expect(resolved.regex.length).toBeGreaterThan(0);
+    expect(resolved.testDirs).toContain("test");
+    expect(resolved.pathspec.every((p) => p.startsWith(":!"))).toBe(true);
+  });
+
+  test("regex correctly classifies a path from the resolved globs", async () => {
+    const config = makeConfig(["test/**/*.test.ts"]);
+    const resolved = await resolveTestFilePatterns(config, WORKDIR);
+    expect(resolved.regex.some((re) => re.test("test/unit/foo.test.ts"))).toBe(true);
+    expect(resolved.regex.some((re) => re.test("src/foo.ts"))).toBe(false);
+  });
+
+  test("empty globs produces empty pathspec, regex, and testDirs", async () => {
+    const resolved = await resolveTestFilePatterns(makeConfig([]), WORKDIR);
+    expect(resolved.pathspec).toHaveLength(0);
+    expect(resolved.regex).toHaveLength(0);
+    expect(resolved.testDirs).toHaveLength(0);
+  });
+
+  test("result object is structurally frozen (arrays are readonly)", async () => {
+    const resolved = await resolveTestFilePatterns(makeConfig(), WORKDIR);
+    // readonly arrays cannot be pushed to at the TS level — runtime verify via type
+    expect(Array.isArray(resolved.globs)).toBe(true);
+    expect(typeof resolved.resolution).toBe("string");
+  });
+});
+
+// ─── resolveReviewExcludePatterns ─────────────────────────────────────────────
+
+describe("resolveReviewExcludePatterns", () => {
+  test("user explicit array returned verbatim (including empty)", async () => {
+    const resolved = await resolveTestFilePatterns(makeConfig(), WORKDIR);
+    const explicit = [":!custom/"];
+    expect(resolveReviewExcludePatterns(explicit, resolved)).toEqual([":!custom/"]);
+    expect(resolveReviewExcludePatterns([], resolved)).toEqual([]);
+  });
+
+  test("undefined user patterns: derives from resolved patterns + well-known noise", async () => {
+    const config = makeConfig(["test/**/*.test.ts"]);
+    const resolved = await resolveTestFilePatterns(config, WORKDIR);
+    const derived = resolveReviewExcludePatterns(undefined, resolved);
+
+    // Well-known test dirs always present
+    expect(derived).toContain(":!test/");
+    expect(derived).toContain(":!tests/");
+    expect(derived).toContain(":!__tests__/");
+    // Well-known suffixes
+    expect(derived).toContain(":!*.test.ts");
+    expect(derived).toContain(":!*.spec.ts");
+    expect(derived).toContain(":!*_test.go");
+    // nax noise paths
+    expect(derived).toContain(":!.nax/");
+    expect(derived).toContain(":!.nax-pids");
+  });
+
+  test("parity: default config excludePatterns match old hardcoded default", async () => {
+    const resolved = await resolveTestFilePatterns(makeConfig(), WORKDIR);
+    const derived = resolveReviewExcludePatterns(undefined, resolved);
+    // Old hardcoded default; resolver produces ":!__tests__/" (without "**/" prefix) for
+    // __tests__ — a minor Phase 1 difference that's lower-risk in practice.
+    const mustContain = [":!test/", ":!tests/", ":!__tests__/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!.nax/", ":!.nax-pids"];
+    for (const pattern of mustContain) {
+      expect(derived).toContain(pattern);
+    }
+  });
+
+  test("no duplicates in derived list", async () => {
+    const config = makeConfig(["test/**/*.test.ts"]);
+    const resolved = await resolveTestFilePatterns(config, WORKDIR);
+    const derived = resolveReviewExcludePatterns(undefined, resolved);
+    expect(derived.length).toBe(new Set(derived).size);
+  });
+});

--- a/test/unit/verification/smart-runner-config.test.ts
+++ b/test/unit/verification/smart-runner-config.test.ts
@@ -83,7 +83,6 @@ describe("SmartTestRunner config coercion", () => {
     if (result.success) {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: true,
-        testFilePatterns: ["test/**/*.test.ts"],
         fallback: "import-grep",
       });
     }
@@ -95,7 +94,6 @@ describe("SmartTestRunner config coercion", () => {
     if (result.success) {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: false,
-        testFilePatterns: ["test/**/*.test.ts"],
         fallback: "import-grep",
       });
     }
@@ -107,7 +105,6 @@ describe("SmartTestRunner config coercion", () => {
     if (result.success) {
       expect(result.data.execution.smartTestRunner).toEqual({
         enabled: true,
-        testFilePatterns: ["test/**/*.test.ts"],
         fallback: "import-grep",
       });
     }

--- a/test/unit/verification/unit-isolation.test.ts
+++ b/test/unit/verification/unit-isolation.test.ts
@@ -6,7 +6,8 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { isSourceFile, isTestFile } from "../../../src/tdd/isolation";
+import { isSourceFile } from "../../../src/tdd/isolation";
+import { isTestFile } from "../../../src/test-runners";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // isTestFile


### PR DESCRIPTION
## Summary

- **CRITICAL × 4** — closes ADR-009 scope gaps where test-file classification bypassed `resolveTestFilePatterns()`: plugin loader used hardcoded `.test.ts`/`.spec.ts`, TDD orchestrator read deprecated `testPattern` config key, greenfield detection used a single glob string instead of the resolver array, test-scanner used a hardcoded TS-only dir list
- **IMPORTANT × 4** — injectable Go/Cargo detection in framework-defaults, optional `storyId` on resolver for log correlation, context builder switched from deprecated `testPattern` to resolver, `nax detect` now shows real per-package effective patterns
- Splits `detect.test.ts` at the 400-line limit into `detect.test.ts` (tiers + new go.mod/polyglot/monorepo tests) and `detect-cache.test.ts`

Close #461 

## Changes

### Source

| File | Change |
|:-----|:-------|
| `src/plugins/loader.ts` | Add optional `isTestFileFn?` to `isPluginFile` / `discoverPlugins` / `loadPlugins`; expand fallback to cover all test-file extensions |
| `src/execution/lifecycle/run-setup.ts` | Resolve patterns via SSOT before `loadPlugins` and pass regex classifier |
| `src/config/schemas.ts` | Remove hardcoded deprecated `testPattern` default from `ContextConfigSchema` |
| `src/context/greenfield.ts` | Accept `patterns?: readonly string[]`; use `GREENFIELD_FALLBACK_PATTERNS` (expanded, no brace alternatives); replace `node:fs existsSync` with `Bun.spawn test -d` |
| `src/context/test-scanner.ts` | Add `resolvedTestGlobs` option; `detectTestDir` uses resolver dirs first; `deriveTestPatterns` uses test-discriminating suffixes; `deriveScanGlob` strips testDir prefix for correct relative Glob |
| `src/context/builder.ts` | Replace `tcConfig.testPattern` with `resolveTestFilePatterns`; pass `resolved.globs` as `resolvedTestGlobs` |
| `src/tdd/orchestrator.ts` | Replace deprecated `testPattern` read with `resolveTestFilePatterns`; pass `.globs` to `isGreenfieldStory` |
| `src/test-runners/resolver.ts` | Add optional `options?: { storyId? }` for log correlation |
| `src/test-runners/detect/framework-defaults.ts` | Add `fileExists` to `_frameworkDefaultsDeps`; `detectFromGoMod` and `detectFromCargoToml` use it |
| `src/commands/detect.ts` | Read per-package effective patterns from `.nax/mono/<dir>/config.json` |

### Tests

| File | Change |
|:-----|:-------|
| `test/unit/test-runners/detect.test.ts` | Rewritten: cache tests extracted; `Orig` includes `defaultsFileExists`; 3 new tests (go.mod → `**/*_test.go`, polyglot TS+Go, monorepo workspace map) |
| `test/unit/test-runners/detect-cache.test.ts` | **New** — extracted cache tests to stay under 400-line limit |
| `test/unit/pipeline/greenfield.test.ts` | Update one call site to array signature |

## Test plan

- [ ] `bun run typecheck` — no errors
- [ ] `bun run test:bail` — all 6723 tests pass (5502 unit + 1208 integration + 13 UI), 0 failures
- [ ] `nax detect` smoke-test: run against this repo, verify human + JSON output
- [ ] Verify custom `testFilePatterns` in `.nax/config.json` are used by plugin loader (plugins with `.test.js` files not loaded)
- [ ] Verify Go project detection: add `go.mod` to a temp dir, confirm `nax detect` returns `**/*_test.go` at medium confidence