### PR TITLE
fix(acp): capture acpxRecordId and acpxSessionId in prompt audit

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -102,8 +102,10 @@ export interface AcpSession {
   prompt(text: string): Promise<AcpSessionResponse>;
   close(options?: { forceTerminate?: boolean }): Promise<void>;
   cancelActivePrompt(): Promise<void>;
-  /** Session ID returned by the ACP provider (e.g. acpx UUID). Undefined when not available. */
+  /** Volatile session ID: updated by acpx on each Claude Code reconnect (acpxSessionId). */
   readonly id?: string;
+  /** Stable record ID: assigned at session creation, never changes across reconnects (acpxRecordId). */
+  readonly recordId?: string;
 }
 
 export interface AcpClient {
@@ -886,6 +888,7 @@ export class AcpAgentAdapter implements AgentAdapter {
           void writePromptAudit({
             prompt: currentPrompt,
             sessionName,
+            recordId: session.recordId,
             sessionId: session.id,
             workdir: options.workdir,
             projectDir: options.projectDir,
@@ -1098,6 +1101,7 @@ export class AcpAgentAdapter implements AgentAdapter {
           void writePromptAudit({
             prompt,
             sessionName: completeSessionName,
+            recordId: session.recordId,
             sessionId: session.id,
             workdir: workdir ?? process.cwd(),
             auditDir: _completeAuditConfig.agent.promptAudit.dir,

--- a/src/agents/acp/prompt-audit.ts
+++ b/src/agents/acp/prompt-audit.ts
@@ -48,8 +48,10 @@ export interface PromptAuditEntry {
   callType: "run" | "complete";
   /** 1-indexed turn number — only set for run() multi-turn entries. */
   turn?: number;
-  /** Session ID returned by the ACP provider (e.g. acpx UUID). Undefined when not available. */
+  /** Volatile session ID (acpxSessionId): updated by acpx on each Claude Code reconnect. */
   sessionId?: string;
+  /** Stable record ID (acpxRecordId): assigned at session creation, never changes across reconnects. */
+  recordId?: string;
   /** Whether the ACP session was resumed from a prior run (true) or freshly created (false/undefined). */
   resumed?: boolean;
 }
@@ -103,6 +105,7 @@ function buildAuditContent(entry: PromptAuditEntry, epochMs: number): string {
   const lines = [
     `Timestamp: ${ts}`,
     `Session:   ${entry.sessionName}`,
+    ...(entry.recordId ? [`RecordId:  ${entry.recordId}`] : []),
     ...(entry.sessionId ? [`SessionId: ${entry.sessionId}`] : []),
     `Type:      ${typeLabel}`,
     `StoryId:   ${entry.storyId ?? "(none)"}`,

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -98,7 +98,10 @@ class SpawnAcpSession implements AcpSession {
   private readonly env: Record<string, string | undefined>;
   private readonly pidRegistry?: PidRegistry;
   private activeProc: { pid: number; kill(signal?: number): void } | null = null;
+  /** Volatile Claude Code session ID (acpxSessionId) — updated on reconnect. */
   readonly id?: string;
+  /** Stable record ID (acpxRecordId) — assigned at creation, never changes. */
+  readonly recordId?: string;
 
   constructor(opts: {
     agentName: string;
@@ -110,6 +113,7 @@ class SpawnAcpSession implements AcpSession {
     env: Record<string, string | undefined>;
     pidRegistry?: PidRegistry;
     id?: string;
+    recordId?: string;
   }) {
     this.agentName = opts.agentName;
     this.sessionName = opts.sessionName;
@@ -120,6 +124,7 @@ class SpawnAcpSession implements AcpSession {
     this.env = opts.env;
     this.pidRegistry = opts.pidRegistry;
     this.id = opts.id;
+    this.recordId = opts.recordId;
   }
 
   async prompt(text: string): Promise<AcpSessionResponse> {
@@ -324,26 +329,35 @@ class SpawnAcpSession implements AcpSession {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Parse the session UUID from `acpx --format json sessions ensure` stdout.
+ * Parse both ACP session IDs from `acpx --format json sessions ensure` stdout.
  *
  * acpx --format json outputs a JSON line:
- *   {"action":"session_ensured","created":true,"acpxSessionId":"<uuid>","name":"<name>"}
+ *   {"action":"session_ensured","created":true,"acpxRecordId":"<uuid>","acpxSessionId":"<uuid>","name":"<name>"}
  *
- * Returns the UUID string, or undefined if the output doesn't contain valid JSON with acpxSessionId.
+ * - `acpxRecordId` — stable record identifier, assigned at creation, never changes across reconnects.
+ * - `acpxSessionId` — volatile Claude Code session ID, updated on each Claude Code reconnect.
+ *
+ * Returns an object with both IDs (undefined when not present in output).
  */
-function parseSessionId(stdout: string): string | undefined {
+function parseSessionIds(stdout: string): { sessionId: string | undefined; recordId: string | undefined } {
   for (const line of stdout.split("\n").reverse()) {
     const trimmed = line.trim();
     if (!trimmed.startsWith("{")) continue;
     try {
       const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-      const id = parsed.acpxSessionId;
-      if (typeof id === "string" && id.length > 0) return id;
+      const sessionId = parsed.acpxSessionId;
+      const recordId = parsed.acpxRecordId;
+      if (typeof sessionId === "string" && sessionId.length > 0) {
+        return {
+          sessionId,
+          recordId: typeof recordId === "string" && recordId.length > 0 ? recordId : undefined,
+        };
+      }
     } catch {
       // not valid JSON — skip
     }
   }
-  return undefined;
+  return { sessionId: undefined, recordId: undefined };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -434,6 +448,7 @@ export class SpawnAcpClient implements AcpClient {
       throw new Error(`[acp-adapter] Failed to create session: ${stderr || `exit code ${exitCode}`}`);
     }
 
+    const { sessionId, recordId } = parseSessionIds(stdout);
     return new SpawnAcpSession({
       agentName: opts.agentName,
       sessionName,
@@ -443,7 +458,8 @@ export class SpawnAcpClient implements AcpClient {
       permissionMode: opts.permissionMode,
       env: this.env,
       pidRegistry: this.pidRegistry,
-      id: parseSessionId(stdout),
+      id: sessionId,
+      recordId,
     });
   }
 
@@ -457,6 +473,7 @@ export class SpawnAcpClient implements AcpClient {
       return null; // Session doesn't exist or can't be resumed
     }
 
+    const { sessionId, recordId } = parseSessionIds(stdout);
     return new SpawnAcpSession({
       agentName,
       sessionName,
@@ -466,7 +483,8 @@ export class SpawnAcpClient implements AcpClient {
       permissionMode,
       env: this.env,
       pidRegistry: this.pidRegistry,
-      id: parseSessionId(stdout),
+      id: sessionId,
+      recordId,
     });
   }
 


### PR DESCRIPTION
## Summary

- When Claude Code exits with SIGTERM, acpx reconnects and updates `acpxSessionId` to a new UUID while `acpxRecordId` remains stable. The audit previously only captured `acpxSessionId`, so audits from the run stage and rectification stages showed different session IDs despite belonging to the same underlying session record.
- `parseSessionId()` replaced with `parseSessionIds()` — parses both `acpxRecordId` and `acpxSessionId` from `sessions ensure --format json` stdout in a single pass.
- `SpawnAcpSession` and `AcpSession` interface both gain a `recordId` field (stable) alongside the existing `id` field (volatile).
- `PromptAuditEntry` gains `recordId`, and `buildAuditContent` emits a `RecordId:` header line above `SessionId:` so both are visible in every audit file.

## Root cause

At session creation `acpxRecordId = acpxSessionId`. After a SIGTERM reconnect, acpx updates only `acpxSessionId`. Audit #1 (run stage) captured the pre-reconnect value; audits #2 and #3 (rectification) captured the post-reconnect value — making all three look like different sessions when `RecordId` would have shown them as one.

## Test plan

- [ ] Verify `bun run typecheck` passes (no regressions)
- [ ] Verify `bun test test/unit/agents/acp/` passes (330 tests)
- [ ] In a real run with a SIGTERM reconnect: audit files should show a stable `RecordId` across run + rectification stages, with `SessionId` changing after reconnect
- [ ] In a normal run (no reconnect): `RecordId` and `SessionId` should be identical in all audits