### PR TITLE
feat(context): feature context engine v1 read path (CONTEXT-001)

### DIFF
--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -388,10 +388,16 @@ export interface ContextAutoDetectConfig {
   traceImports: boolean;
 }
 
+export interface FeatureContextEngineConfig {
+  enabled: boolean;
+  budgetTokens: number;
+}
+
 export interface ContextConfig {
   testCoverage: TestCoverageConfig;
   autoDetect: ContextAutoDetectConfig;
   fileInjection?: "keyword" | "disabled";
+  featureEngine?: FeatureContextEngineConfig; // NEW — Context Engine v1
 }
 
 /** Story size gate thresholds (v0.16.0) */

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -429,10 +429,16 @@ const ContextAutoDetectConfigSchema = z.object({
   traceImports: z.boolean().default(false),
 });
 
+const FeatureContextEngineConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  budgetTokens: z.number().int().min(256).default(2048),
+});
+
 const ContextConfigSchema = z.object({
   testCoverage: TestCoverageConfigSchema,
   autoDetect: ContextAutoDetectConfigSchema,
   fileInjection: z.enum(["keyword", "disabled"]).default("disabled"),
+  featureEngine: FeatureContextEngineConfigSchema.optional(),
 });
 
 const LlmRoutingConfigSchema = z.object({

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -53,6 +53,7 @@ export type {
   ContextConfig,
   EscalationEntry,
   ExecutionConfig,
+  FeatureContextEngineConfig,
   RawHooksConfig,
   InteractionConfig,
   LlmRoutingConfig,

--- a/src/context/feature-context-filter.ts
+++ b/src/context/feature-context-filter.ts
@@ -1,0 +1,220 @@
+/**
+ * Feature Context Filter — role-based audience filtering for context.md entries.
+ *
+ * Each entry in context.md carries an inline audience tag at the end of its
+ * headline: `[implementer]`, `[all]`, `[test-writer, implementer]`, etc.
+ * This module parses those tags and filters entries for the current role.
+ */
+import { getLogger } from "../logger";
+import type { PromptRole } from "../prompts/core/types";
+
+/** Audience tags recognized in context.md entries */
+type AudienceTag =
+  | "all"
+  | "implementer"
+  | "test-writer"
+  | "verifier"
+  | "reviewer"
+  | "reviewer-semantic"
+  | "reviewer-adversarial";
+
+/**
+ * Map from PromptRole to the set of audience tags that role should receive.
+ * Entries tagged [all] are always included regardless of role.
+ * Roles introduced in v2 (rectifier, autofixer, planner, etc.) are not listed
+ * here — they fall through to direct tag matching (the role string is compared
+ * against audience tags literally, and [all] is always included).
+ */
+const ROLE_AUDIENCE_MAP: Record<PromptRole, AudienceTag[]> = {
+  implementer: ["all", "implementer"],
+  "test-writer": ["all", "test-writer"],
+  verifier: ["all", "verifier"],
+  "single-session": ["all", "implementer", "test-writer"],
+  "tdd-simple": ["all", "implementer", "test-writer"],
+  "no-test": ["all", "implementer"],
+  batch: ["all", "implementer", "test-writer"],
+};
+
+/** Reviewer role → tags map */
+const REVIEWER_AUDIENCE_MAP: Record<string, AudienceTag[]> = {
+  "reviewer-semantic": ["all", "reviewer", "reviewer-semantic"],
+  "reviewer-adversarial": ["all", "reviewer", "reviewer-adversarial"],
+  reviewer: ["all", "reviewer", "reviewer-semantic", "reviewer-adversarial"],
+};
+
+/**
+ * Parse audience tags from an entry headline.
+ * Returns the tags as lowercase strings.
+ * If no tag is found, returns ["all"] (backward-compatible default).
+ *
+ * Matches `[tag]` or `[tag1, tag2]` at the END of the line, after the heading text.
+ * Case-insensitive. The tag block is the LAST `[...]` on the line.
+ */
+export function parseAudienceTags(headline: string): string[] {
+  // Match the last occurrence of [...] on the headline
+  const matches = [...headline.matchAll(/\[([^\]]+)\]/g)];
+  if (matches.length === 0) return ["all"];
+
+  const lastMatch = matches[matches.length - 1];
+  const tagStr = lastMatch[1];
+  return tagStr
+    .split(",")
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Determine if an entry (identified by its audience tags) should be included
+ * for the given role.
+ */
+export function shouldIncludeEntry(tags: string[], role: PromptRole | string): boolean {
+  // Get the allowed tags for this role
+  const allowedTags: string[] = ROLE_AUDIENCE_MAP[role as PromptRole] ?? REVIEWER_AUDIENCE_MAP[role] ?? ["all", role]; // v2 roles: always include [all] + direct match
+
+  // Include if any of the entry's tags appear in the allowed set
+  return tags.some((tag) => allowedTags.includes(tag));
+}
+
+/**
+ * Filter context.md entries by audience tag for the current role.
+ * Parses the Markdown, keeps entries whose audience matches the role.
+ * Entries without a tag default to [all] (backward-compatible).
+ * Empty sections are removed.
+ */
+export function filterContextByRole(contextMd: string, role: PromptRole | string): string {
+  if (!contextMd.trim()) return "";
+
+  const lines = contextMd.split("\n");
+  const outputSections: string[] = [];
+
+  let currentSectionHeader = "";
+  let currentSectionLines: string[] = [];
+  let inEntry = false;
+  let entryLines: string[] = [];
+  let entryIncluded = false;
+  let pendingEntries: string[] = [];
+
+  function flushEntry() {
+    if (entryLines.length === 0) return;
+    if (entryIncluded) {
+      pendingEntries.push(...entryLines);
+    }
+    entryLines = [];
+    inEntry = false;
+    entryIncluded = false;
+  }
+
+  function flushSection() {
+    flushEntry();
+    if (pendingEntries.length > 0) {
+      const section = currentSectionHeader
+        ? [currentSectionHeader, "", ...pendingEntries].join("\n")
+        : pendingEntries.join("\n");
+      outputSections.push(section);
+    } else if (currentSectionLines.length > 0 && !currentSectionHeader.startsWith("##")) {
+      // Non-section content (e.g., title, metadata line) — always keep
+      outputSections.push(currentSectionLines.join("\n"));
+    }
+    currentSectionLines = [];
+    pendingEntries = [];
+  }
+
+  for (const line of lines) {
+    // Top-level heading (# ...) — not a section, always keep
+    if (line.startsWith("# ")) {
+      flushSection();
+      currentSectionHeader = "";
+      currentSectionLines = [line];
+      continue;
+    }
+
+    // Metadata / italic lines directly under title (e.g., _Last updated: ..._)
+    if (!currentSectionHeader && line.startsWith("_") && line.endsWith("_")) {
+      currentSectionLines.push(line);
+      continue;
+    }
+
+    // Empty line between sections or between entries — buffered
+    if (line.trim() === "") {
+      if (inEntry) {
+        // Empty line might continue the entry (indented body follows) or end it
+        // We'll handle it by checking next line — for now, buffer in entryLines
+        entryLines.push(line);
+      }
+      continue;
+    }
+
+    // Section heading (## ...) — flush previous section, start new one
+    if (line.startsWith("## ")) {
+      flushSection();
+      currentSectionHeader = line;
+      continue;
+    }
+
+    // Entry start: a bullet beginning with "- **"
+    if (line.startsWith("- **") || line.startsWith("- ")) {
+      // Flush any previous entry first
+      flushEntry();
+
+      inEntry = true;
+      entryLines = [line];
+
+      // Determine audience from headline
+      const tags = parseAudienceTags(line);
+      entryIncluded = shouldIncludeEntry(tags, role);
+      continue;
+    }
+
+    // Entry body (continuation — indented or narrative line after bullet)
+    if (inEntry) {
+      entryLines.push(line);
+      continue;
+    }
+
+    // Anything else in a section (non-entry text)
+    if (currentSectionHeader) {
+      currentSectionLines.push(line);
+    } else {
+      currentSectionLines.push(line);
+    }
+  }
+
+  // Flush final section
+  flushSection();
+
+  return outputSections.join("\n\n").trim();
+}
+
+/**
+ * Estimate token count for a string (rough: 1 token ≈ 4 chars).
+ * Used for budget enforcement only — not for billing.
+ */
+export function estimateContextTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Truncate context to fit within budgetTokens.
+ * Tail-biased: keeps the most recent entries (bottom of file).
+ * Logs a warning when truncation is applied.
+ */
+export function truncateToContextBudget(filteredMd: string, budgetTokens: number, featureId: string): string {
+  const logger = getLogger();
+  const estimated = estimateContextTokens(filteredMd);
+
+  if (estimated <= budgetTokens) return filteredMd;
+
+  logger.warn("feature-context", "Feature context exceeds budget, truncating (tail-biased)", {
+    featureId,
+    estimatedTokens: estimated,
+    budgetTokens,
+  });
+
+  // Tail-biased: keep as many chars from the END as the budget allows
+  const maxChars = budgetTokens * 4;
+  const truncated = filteredMd.slice(filteredMd.length - maxChars);
+
+  // Trim to a clean line boundary to avoid splitting mid-entry
+  const newlineIdx = truncated.indexOf("\n");
+  return newlineIdx > 0 ? truncated.slice(newlineIdx + 1) : truncated;
+}

--- a/src/context/feature-context-filter.ts
+++ b/src/context/feature-context-filter.ts
@@ -80,6 +80,15 @@ export function shouldIncludeEntry(tags: string[], role: PromptRole | string): b
  * Parses the Markdown, keeps entries whose audience matches the role.
  * Entries without a tag default to [all] (backward-compatible).
  * Empty sections are removed.
+ *
+ * **Format constraint:** Only bullet entries (lines starting with `- `) inside
+ * `## Section` headings are filtered. Free-form narrative paragraphs inside a
+ * `## Section` (non-bullet text) are silently dropped, because `context.md`
+ * is spec-defined as bullet-only within sections. The `# Title` line and
+ * `_metadata_` lines at the top of the file (before any `## Section`) are
+ * always preserved. The `## Rationale Archive` section uses bullets too.
+ * If a future version needs to support paragraph text inside sections,
+ * the emit logic in `flushSection()` must be extended.
  */
 export function filterContextByRole(contextMd: string, role: PromptRole | string): string {
   if (!contextMd.trim()) return "";
@@ -97,7 +106,14 @@ export function filterContextByRole(contextMd: string, role: PromptRole | string
   function flushEntry() {
     if (entryLines.length === 0) return;
     if (entryIncluded) {
-      pendingEntries.push(...entryLines);
+      // Drop trailing blank lines buffered as "possible continuation" markers.
+      // Without this, an included entry immediately followed by an excluded entry
+      // leaks the inter-entry blank line into the output.
+      const trimmed = [...entryLines];
+      while (trimmed.length > 0 && (trimmed[trimmed.length - 1] ?? "").trim() === "") {
+        trimmed.pop();
+      }
+      pendingEntries.push(...trimmed);
     }
     entryLines = [];
     inEntry = false;

--- a/src/context/feature-resolver.ts
+++ b/src/context/feature-resolver.ts
@@ -1,0 +1,97 @@
+/**
+ * Feature ID resolver for the Context Engine v1.
+ *
+ * Walks .nax/features/<id>/prd.json to find which feature a story belongs to.
+ * Caches results per workdir so the glob scan only runs once per run.
+ */
+import { Glob } from "bun";
+import { getLogger } from "../logger";
+import type { UserStory } from "../prd";
+import { errorMessage } from "../utils/errors";
+
+// Per-workdir cache: Map<workdir, Map<storyId, featureId | null>>
+const _cache = new Map<string, Map<string, string | null>>();
+
+/** Injectable deps for testing */
+export const _resolverDeps = {
+  glob: (pattern: string, opts: { cwd: string }) => new Glob(pattern).scan({ ...opts, dot: true }),
+  readFile: (path: string) => Bun.file(path).text(),
+};
+
+/**
+ * Clear the cache. For testing only.
+ */
+export function clearFeatureResolverCache(): void {
+  _cache.clear();
+}
+
+/**
+ * Resolve which feature a story belongs to by scanning .nax/features/<id>/prd.json.
+ * Returns the feature directory name (featureId) or null if the story is unattached.
+ * Results are cached per workdir.
+ */
+export async function resolveFeatureId(story: UserStory, workdir: string): Promise<string | null> {
+  const logger = getLogger();
+
+  // Check cache
+  let wdCache = _cache.get(workdir);
+  if (wdCache?.has(story.id)) {
+    return wdCache.get(story.id) ?? null;
+  }
+
+  if (!wdCache) {
+    wdCache = new Map();
+    _cache.set(workdir, wdCache);
+  }
+
+  const matches: string[] = [];
+
+  try {
+    // Scan for all prd.json files under .nax/features/*/
+    const scanner = _resolverDeps.glob(".nax/features/*/prd.json", { cwd: workdir });
+    for await (const relPath of scanner) {
+      let prdData: { userStories?: Array<{ id: string }> };
+      try {
+        const raw = await _resolverDeps.readFile(`${workdir}/${relPath}`);
+        prdData = JSON.parse(raw) as typeof prdData;
+      } catch {
+        logger.warn("feature-resolver", "Malformed prd.json — skipping", {
+          path: relPath,
+          storyId: story.id,
+        });
+        continue;
+      }
+
+      const storyIds = (prdData.userStories ?? []).map((s) => s.id);
+      if (storyIds.includes(story.id)) {
+        // Extract feature ID: ".nax/features/<featureId>/prd.json"
+        const parts = relPath.split("/");
+        const featureId = parts[2]; // index 2 in ".nax/features/<id>/prd.json"
+        if (featureId) matches.push(featureId);
+      }
+    }
+  } catch (err) {
+    logger.warn("feature-resolver", "Failed to scan feature directories", {
+      storyId: story.id,
+      error: errorMessage(err),
+    });
+    wdCache.set(story.id, null);
+    return null;
+  }
+
+  if (matches.length === 0) {
+    wdCache.set(story.id, null);
+    return null;
+  }
+
+  if (matches.length > 1) {
+    logger.warn("feature-resolver", "Story appears in multiple features — using first match", {
+      storyId: story.id,
+      matches,
+    });
+  }
+
+  const featureId = matches[0];
+  wdCache.set(story.id, featureId);
+  return featureId;
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -4,6 +4,17 @@
 
 export type { ContextElement, ContextBudget, StoryContext, BuiltContext } from "./types";
 
+export { resolveFeatureId, clearFeatureResolverCache } from "./feature-resolver";
+export {
+  filterContextByRole,
+  parseAudienceTags,
+  shouldIncludeEntry,
+  estimateContextTokens,
+  truncateToContextBudget,
+} from "./feature-context-filter";
+export { FeatureContextProvider } from "./providers/feature-context";
+export type { FeatureContextResult } from "./providers/feature-context";
+
 export {
   createStoryContext,
   createDependencyContext,

--- a/src/context/providers/feature-context.ts
+++ b/src/context/providers/feature-context.ts
@@ -1,0 +1,89 @@
+import type { NaxConfig } from "../../config/types";
+/**
+ * FeatureContextProvider — reads context.md for the current feature and
+ * returns its raw contents for role-filtered injection at prompt-build time.
+ *
+ * v1 scope: read path only. Returns full (unfiltered) context.md content.
+ * Role filtering and budget enforcement happen in the prompt builders.
+ */
+import { getLogger } from "../../logger";
+import type { UserStory } from "../../prd";
+import { errorMessage } from "../../utils/errors";
+import { resolveFeatureId } from "../feature-resolver";
+
+/** Injectable deps for testing */
+export const _featureContextDeps = {
+  resolveFeatureId,
+  readFile: async (path: string) => Bun.file(path).text(),
+  fileExists: async (path: string) => Bun.file(path).exists(),
+};
+
+/** Result returned by the provider (null when not applicable) */
+export interface FeatureContextResult {
+  /** Raw (unfiltered) content of context.md, wrapped in injection header */
+  content: string;
+  /** Estimated tokens for the raw content */
+  estimatedTokens: number;
+  /** Label for logging/display */
+  label: string;
+  /** Feature ID for downstream budget enforcement */
+  featureId: string;
+}
+
+const INJECTION_HEADER = `## Feature Context
+
+The following context was accumulated by prior stories in this feature. Use it to avoid re-discovering known constraints and decisions. This context is scoped to this feature — not a global project rule.`;
+
+/**
+ * Format the raw context.md content with an injection header.
+ */
+function formatForInjection(content: string, featureId: string): string {
+  return `${INJECTION_HEADER}\n\n_Feature: ${featureId}_\n\n${content.trim()}`;
+}
+
+export class FeatureContextProvider {
+  /**
+   * Fetch the feature context for the given story.
+   * Returns null when: feature engine disabled, story unattached, no context.md.
+   */
+  async getContext(story: UserStory, workdir: string, config: NaxConfig): Promise<FeatureContextResult | null> {
+    const logger = getLogger();
+
+    if (!config.context?.featureEngine?.enabled) return null;
+
+    const featureId = await _featureContextDeps.resolveFeatureId(story, workdir);
+    if (!featureId) return null;
+
+    const contextPath = `${workdir}/.nax/features/${featureId}/context.md`;
+
+    try {
+      const exists = await _featureContextDeps.fileExists(contextPath);
+      if (!exists) return null;
+
+      const content = await _featureContextDeps.readFile(contextPath);
+      if (!content.trim()) return null;
+
+      const formatted = formatForInjection(content, featureId);
+
+      logger.info("feature-context", "Loaded feature context", {
+        storyId: story.id,
+        featureId,
+        estimatedTokens: Math.ceil(formatted.length / 4),
+      });
+
+      return {
+        content: formatted,
+        estimatedTokens: Math.ceil(formatted.length / 4),
+        label: `feature-context:${featureId}`,
+        featureId,
+      };
+    } catch (err) {
+      logger.warn("feature-context", "Failed to read feature context — skipping", {
+        storyId: story.id,
+        featureId,
+        error: errorMessage(err),
+      });
+      return null;
+    }
+  }
+}

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -20,6 +20,7 @@
  * ```
  */
 
+import { FeatureContextProvider } from "../../context/providers/feature-context";
 import type { ContextElement } from "../../context/types";
 import { buildStoryContextFullFromCtx } from "../../execution/helpers";
 import { getLogger } from "../../logger";
@@ -111,6 +112,13 @@ export const contextStage: PipelineStage = {
           );
         }
       }
+    }
+
+    // Feature context engine (v1 read path): load feature context.md if enabled
+    const featureContextProvider = new FeatureContextProvider();
+    const featureResult = await featureContextProvider.getContext(ctx.story, ctx.workdir, ctx.config);
+    if (featureResult) {
+      ctx.featureContextMarkdown = featureResult.content;
     }
 
     return { action: "continue" };

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -51,7 +51,7 @@ export const contextStage: PipelineStage = {
     if (ctx.plugins) {
       const providers = ctx.plugins.getContextProviders();
       if (providers.length > 0) {
-        logger.info("context", `Running ${providers.length} plugin context provider(s)`);
+        logger.info("context", `Running ${providers.length} plugin context provider(s)`, { storyId: ctx.story.id });
 
         const pluginElements: ContextElement[] = [];
         let pluginTokensUsed = 0;
@@ -60,17 +60,21 @@ export const contextStage: PipelineStage = {
         for (const provider of providers) {
           // Check if we have budget remaining
           if (pluginTokensUsed >= tokenBudget) {
-            logger.info("context", "Plugin context budget exhausted, skipping remaining providers");
+            logger.info("context", "Plugin context budget exhausted, skipping remaining providers", {
+              storyId: ctx.story.id,
+            });
             break;
           }
 
           try {
-            logger.info("context", `Fetching context from plugin: ${provider.name}`);
+            logger.info("context", `Fetching context from plugin: ${provider.name}`, { storyId: ctx.story.id });
             const providerResult = await provider.getContext(ctx.story);
 
             // Check if adding this provider's content would exceed budget
             if (pluginTokensUsed + providerResult.estimatedTokens > tokenBudget) {
-              logger.info("context", `Skipping plugin ${provider.name}: would exceed budget`);
+              logger.info("context", `Skipping plugin ${provider.name}: would exceed budget`, {
+                storyId: ctx.story.id,
+              });
               break;
             }
 
@@ -86,9 +90,13 @@ export const contextStage: PipelineStage = {
             logger.info(
               "context",
               `Added context from plugin ${provider.name} (${providerResult.estimatedTokens} tokens)`,
+              {
+                storyId: ctx.story.id,
+              },
             );
           } catch (error) {
             logger.error("context", `Plugin context provider error: ${provider.name}`, {
+              storyId: ctx.story.id,
               error: errorMessage(error),
             });
             // Continue with other providers on error (soft failure)
@@ -109,6 +117,9 @@ export const contextStage: PipelineStage = {
           logger.info(
             "context",
             `Added ${pluginElements.length} plugin context element(s) (${pluginTokensUsed} tokens total)`,
+            {
+              storyId: ctx.story.id,
+            },
           );
         }
       }

--- a/src/pipeline/stages/prompt.ts
+++ b/src/pipeline/stages/prompt.ts
@@ -75,6 +75,7 @@ export const promptStage: PipelineStage = {
         .withLoader(ctx.workdir, ctx.config)
         .stories(ctx.stories)
         .context(ctx.contextMarkdown)
+        .featureContext(ctx.featureContextMarkdown)
         .constitution(ctx.constitution?.content)
         .testCommand(ctx.config.quality?.commands?.test)
         .hermeticConfig(ctx.config.quality?.testing);
@@ -87,6 +88,7 @@ export const promptStage: PipelineStage = {
         .withLoader(ctx.workdir, ctx.config)
         .story(ctx.story)
         .context(ctx.contextMarkdown)
+        .featureContext(ctx.featureContextMarkdown)
         .constitution(ctx.constitution?.content)
         .testCommand(ctx.config.quality?.commands?.test)
         .hermeticConfig(ctx.config.quality?.testing)

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -108,6 +108,8 @@ export interface PipelineContext {
   constitution?: ConstitutionResult;
   /** Context markdown for the agent (set by contextStage) */
   contextMarkdown?: string;
+  /** Raw (unfiltered) feature context markdown — populated by context stage, used by prompt builders */
+  featureContextMarkdown?: string;
   /** Built context with element-level token tracking (set by contextStage) */
   builtContext?: BuiltContext;
   /** Final prompt sent to agent (set by promptStage) */

--- a/src/prompts/builders/tdd-builder.ts
+++ b/src/prompts/builders/tdd-builder.ts
@@ -22,6 +22,7 @@
  */
 
 import type { NaxConfig } from "../../config/types";
+import { filterContextByRole, truncateToContextBudget } from "../../context/feature-context-filter";
 import type { UserStory } from "../../prd";
 import { SectionAccumulator } from "../core";
 import type { PromptOptions, PromptRole, PromptSection } from "../core";
@@ -47,6 +48,7 @@ export class TddPromptBuilder {
   private stories_: UserStory[] | undefined;
   private constitution_: string | undefined;
   private contextMd_: string | undefined;
+  private featureContextMd_: string | undefined;
   private overridePath_: string | undefined;
   private loaderWorkdir_: string | undefined;
   private loaderConfig_: NaxConfig | undefined;
@@ -76,6 +78,11 @@ export class TddPromptBuilder {
 
   context(md: string | undefined): this {
     if (md) this.contextMd_ = md;
+    return this;
+  }
+
+  featureContext(md: string | undefined): this {
+    if (md) this.featureContextMd_ = md;
     return this;
   }
 
@@ -137,6 +144,18 @@ export class TddPromptBuilder {
 
     // (2) Role task body — disk override or default template
     acc.add(this.s("role-task", await this.resolveRoleBody()));
+
+    // (2.5) Feature-level context (feature engine v1) — between role task and story
+    if (this.featureContextMd_) {
+      const budgetTokens = this.loaderConfig_?.context?.featureEngine?.budgetTokens ?? 2048;
+      const filtered = filterContextByRole(this.featureContextMd_, this.role);
+      if (filtered.trim()) {
+        const truncated = truncateToContextBudget(filtered, budgetTokens, "feature");
+        if (truncated.trim()) {
+          acc.add(this.s("feature-context", truncated));
+        }
+      }
+    }
 
     // (3) Story context
     if (this.role === "batch" && this.stories_ && this.stories_.length > 0) {

--- a/src/prompts/builders/tdd-builder.ts
+++ b/src/prompts/builders/tdd-builder.ts
@@ -22,7 +22,7 @@
  */
 
 import type { NaxConfig } from "../../config/types";
-import { filterContextByRole, truncateToContextBudget } from "../../context/feature-context-filter";
+import { filterContextByRole, truncateToContextBudget } from "../../context";
 import type { UserStory } from "../../prd";
 import { SectionAccumulator } from "../core";
 import type { PromptOptions, PromptRole, PromptSection } from "../core";
@@ -150,7 +150,11 @@ export class TddPromptBuilder {
       const budgetTokens = this.loaderConfig_?.context?.featureEngine?.budgetTokens ?? 2048;
       const filtered = filterContextByRole(this.featureContextMd_, this.role);
       if (filtered.trim()) {
-        const truncated = truncateToContextBudget(filtered, budgetTokens, "feature");
+        // Extract featureId from the injection header ("_Feature: <id>_") so the
+        // truncation warning log names the actual feature instead of a placeholder.
+        const headerMatch = this.featureContextMd_.match(/^_Feature: (.+?)_$/m);
+        const logFeatureId = headerMatch?.[1] ?? "unknown";
+        const truncated = truncateToContextBudget(filtered, budgetTokens, logFeatureId);
         if (truncated.trim()) {
           acc.add(this.s("feature-context", truncated));
         }

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -19,7 +19,7 @@ import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config/schema-types";
 import type { ModelTier } from "../config/schema-types";
-import { filterContextByRole } from "../context/feature-context-filter";
+import { filterContextByRole } from "../context";
 import { getSafeLogger } from "../logger";
 import type { ReviewFinding } from "../plugins/types";
 import { AdversarialReviewPromptBuilder } from "../prompts/builders/adversarial-review-builder";

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -19,6 +19,7 @@ import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config/schema-types";
 import type { ModelTier } from "../config/schema-types";
+import { filterContextByRole } from "../context/feature-context-filter";
 import { getSafeLogger } from "../logger";
 import type { ReviewFinding } from "../plugins/types";
 import { AdversarialReviewPromptBuilder } from "../prompts/builders/adversarial-review-builder";
@@ -137,6 +138,7 @@ export async function runAdversarialReview(
   featureName?: string,
   priorFailures?: Array<{ stage: string; modelTier: string }>,
   blockingThreshold?: "error" | "warning" | "info",
+  featureContextMarkdown?: string,
 ): Promise<ReviewCheckResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -218,8 +220,15 @@ export async function runAdversarialReview(
     };
   }
 
+  // Filter feature context for reviewer-adversarial role
+  let featureCtxBlock = "";
+  if (featureContextMarkdown) {
+    const filtered = filterContextByRole(featureContextMarkdown, "reviewer-adversarial");
+    if (filtered.trim()) featureCtxBlock = `${filtered}\n\n---\n\n`;
+  }
+
   // Build prompt
-  const prompt = new AdversarialReviewPromptBuilder().buildAdversarialReviewPrompt(story, adversarialConfig, {
+  const basePrompt = new AdversarialReviewPromptBuilder().buildAdversarialReviewPrompt(story, adversarialConfig, {
     mode: diffMode,
     diff,
     storyGitRef: effectiveRef,
@@ -228,6 +237,7 @@ export async function runAdversarialReview(
     testInventory,
     excludePatterns: adversarialConfig.excludePatterns,
   });
+  const prompt = featureCtxBlock ? `${featureCtxBlock}${basePrompt}` : basePrompt;
 
   // Resolve model definition
   const defaultAgent = naxConfig?.autoMode?.defaultAgent ?? "claude";

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -128,6 +128,7 @@ export class ReviewOrchestrator {
     featureName?: string,
     resolverSession?: import("./dialogue").ReviewerSession,
     priorFailures?: Array<{ stage: string; modelTier: string }>,
+    featureContextMarkdown?: string,
   ): Promise<OrchestratorReviewResult> {
     const logger = getSafeLogger();
 
@@ -186,6 +187,7 @@ export class ReviewOrchestrator {
         featureName,
         resolverSession,
         priorFailures,
+        featureContextMarkdown,
       );
     } else {
       // Always split: mechanical checks first, then LLM checks independently.
@@ -213,6 +215,7 @@ export class ReviewOrchestrator {
         featureName,
         resolverSession,
         priorFailures,
+        featureContextMarkdown,
       );
 
       // Step 2: Run LLM checks regardless of mechanical result (fail-fast within LLM).
@@ -263,6 +266,7 @@ export class ReviewOrchestrator {
             resolverSession,
             priorFailures,
             reviewConfig.blockingThreshold,
+            featureContextMarkdown,
           ),
           _orchestratorDeps.runAdversarialReview(
             workdir,
@@ -274,6 +278,7 @@ export class ReviewOrchestrator {
             featureName,
             priorFailures,
             reviewConfig.blockingThreshold,
+            featureContextMarkdown,
           ),
         ]);
         llmCheckResults = [semResult, advResult];
@@ -295,6 +300,7 @@ export class ReviewOrchestrator {
           featureName,
           resolverSession,
           priorFailures,
+          featureContextMarkdown,
         );
         llmCheckResults = llmResult.checks;
       }
@@ -472,6 +478,7 @@ export class ReviewOrchestrator {
       ctx.prd.feature,
       resolverSession,
       ctx.story.priorFailures,
+      ctx.featureContextMarkdown,
     );
   }
 }

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -216,6 +216,7 @@ export async function runReview(
   featureName?: string,
   resolverSession?: import("./dialogue").ReviewerSession,
   priorFailures?: Array<{ stage: string; modelTier: string }>,
+  featureContextMarkdown?: string,
 ): Promise<ReviewResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -298,6 +299,7 @@ export async function runReview(
         resolverSession,
         priorFailures,
         config.blockingThreshold,
+        featureContextMarkdown,
       );
       checks.push(result);
       if (!result.success && !firstFailure) {
@@ -337,6 +339,7 @@ export async function runReview(
         featureName,
         priorFailures,
         config.blockingThreshold,
+        featureContextMarkdown,
       );
       checks.push(result);
       if (!result.success && !firstFailure) {

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -13,7 +13,7 @@ import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config/schema-types";
 import type { ModelTier } from "../config/schema-types";
-import { filterContextByRole } from "../context/feature-context-filter";
+import { filterContextByRole } from "../context";
 import { DebateSession } from "../debate";
 import type { DebateSessionOptions } from "../debate";
 import { getSafeLogger } from "../logger";

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -13,6 +13,7 @@ import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config/schema-types";
 import type { ModelTier } from "../config/schema-types";
+import { filterContextByRole } from "../context/feature-context-filter";
 import { DebateSession } from "../debate";
 import type { DebateSessionOptions } from "../debate";
 import { getSafeLogger } from "../logger";
@@ -137,6 +138,7 @@ export async function runSemanticReview(
   resolverSession?: import("./dialogue").ReviewerSession,
   priorFailures?: Array<{ stage: string; modelTier: string }>,
   blockingThreshold?: "error" | "warning" | "info",
+  featureContextMarkdown?: string,
 ): Promise<ReviewCheckResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -224,8 +226,15 @@ export async function runSemanticReview(
     };
   }
 
+  // Filter feature context for reviewer-semantic role
+  let featureCtxBlock = "";
+  if (featureContextMarkdown) {
+    const filtered = filterContextByRole(featureContextMarkdown, "reviewer-semantic");
+    if (filtered.trim()) featureCtxBlock = `${filtered}\n\n---\n\n`;
+  }
+
   // Build prompt — mode determines whether diff is embedded or reviewer self-serves via tools.
-  const prompt = new ReviewPromptBuilder().buildSemanticReviewPrompt(story, semanticConfig, {
+  const basePrompt = new ReviewPromptBuilder().buildSemanticReviewPrompt(story, semanticConfig, {
     mode: diffMode,
     diff,
     storyGitRef: effectiveRef,
@@ -233,6 +242,7 @@ export async function runSemanticReview(
     priorFailures,
     excludePatterns: semanticConfig.excludePatterns,
   });
+  const prompt = featureCtxBlock ? `${featureCtxBlock}${basePrompt}` : basePrompt;
 
   // Debate path: when debate is enabled for review stage, use DebateSession instead of agent.complete()
   const reviewDebateEnabled = naxConfig?.debate?.enabled && naxConfig?.debate?.stages?.review?.enabled;

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -36,6 +36,8 @@ export interface ThreeSessionTddOptions {
   /** Feature name — used for ACP session naming (nax-<hash>-<feature>-<story>-<role>) */
   featureName?: string;
   contextMarkdown?: string;
+  /** Raw (unfiltered) feature context markdown from context engine v1 */
+  featureContextMarkdown?: string;
   constitution?: string;
   dryRun?: boolean;
   lite?: boolean;
@@ -58,6 +60,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     modelTier,
     featureName,
     contextMarkdown,
+    featureContextMarkdown,
     constitution,
     dryRun = false,
     lite = false,
@@ -168,6 +171,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
       featureName,
       buildInteractionBridge(interactionChain, { featureName, storyId: story.id, stage: "execution" }),
       projectDir,
+      featureContextMarkdown,
     );
     sessions.push(session1);
   }
@@ -284,6 +288,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     featureName,
     buildInteractionBridge(interactionChain, { featureName, storyId: story.id, stage: "execution" }),
     projectDir,
+    featureContextMarkdown,
   );
   sessions.push(session2);
 
@@ -334,6 +339,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     featureName,
     undefined,
     projectDir,
+    featureContextMarkdown,
   );
   sessions.push(session3);
 
@@ -462,6 +468,7 @@ export function runThreeSessionTddFromCtx(
     modelTier: ctx.routing.modelTier,
     featureName: ctx.prd.feature,
     contextMarkdown: ctx.contextMarkdown,
+    featureContextMarkdown: ctx.featureContextMarkdown,
     constitution: ctx.constitution?.content,
     dryRun: opts.dryRun ?? false,
     lite: opts.lite ?? false,

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -44,6 +44,7 @@ export const _sessionRunnerDeps = {
         contextMarkdown?: string,
         lite?: boolean,
         constitution?: string,
+        featureContextMarkdown?: string,
       ) => Promise<string>),
 };
 import { buildSessionName } from "../agents/acp/adapter";
@@ -121,13 +122,23 @@ export async function runTddSession(
   featureName?: string,
   interactionBridge?: InteractionBridge,
   projectDir?: string,
+  featureContextMarkdown?: string,
 ): Promise<TddSessionResult> {
   const startTime = Date.now();
 
   // Build prompt — use injectable buildPrompt if set, otherwise default PromptBuilder
   let prompt: string;
   if (_sessionRunnerDeps.buildPrompt) {
-    prompt = await _sessionRunnerDeps.buildPrompt(role, config, story, workdir, contextMarkdown, lite, constitution);
+    prompt = await _sessionRunnerDeps.buildPrompt(
+      role,
+      config,
+      story,
+      workdir,
+      contextMarkdown,
+      lite,
+      constitution,
+      featureContextMarkdown,
+    );
   } else {
     switch (role) {
       case "test-writer":
@@ -135,6 +146,7 @@ export async function runTddSession(
           .withLoader(workdir, config)
           .story(story)
           .context(contextMarkdown)
+          .featureContext(featureContextMarkdown)
           .constitution(constitution)
           .testCommand(config.quality?.commands?.test)
           .hermeticConfig(config.quality?.testing)
@@ -145,6 +157,7 @@ export async function runTddSession(
           .withLoader(workdir, config)
           .story(story)
           .context(contextMarkdown)
+          .featureContext(featureContextMarkdown)
           .constitution(constitution)
           .testCommand(config.quality?.commands?.test)
           .hermeticConfig(config.quality?.testing)
@@ -155,6 +168,7 @@ export async function runTddSession(
           .withLoader(workdir, config)
           .story(story)
           .context(contextMarkdown)
+          .featureContext(featureContextMarkdown)
           .constitution(constitution)
           .testCommand(config.quality?.commands?.test)
           .hermeticConfig(config.quality?.testing)

--- a/test/integration/context/feature-engine-read-path.test.ts
+++ b/test/integration/context/feature-engine-read-path.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Integration test: Feature Engine v1 read path.
+ *
+ * Sets up a real temp directory with .nax/features/<id>/prd.json and context.md,
+ * then verifies end-to-end feature context loading + role filtering.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { filterContextByRole, truncateToContextBudget } from "../../../src/context/feature-context-filter";
+import { FeatureContextProvider } from "../../../src/context/providers/feature-context";
+import { clearFeatureResolverCache } from "../../../src/context/feature-resolver";
+import { DEFAULT_CONFIG } from "../../../src/config";
+import type { NaxConfig } from "../../../src/config/types";
+import type { UserStory } from "../../../src/prd";
+import { makeTempDir, cleanupTempDir } from "../../helpers/temp";
+
+function makeStory(id: string): UserStory {
+  return {
+    id,
+    title: `Story ${id}`,
+    description: "Test story",
+    acceptanceCriteria: ["AC1"],
+    tags: [],
+    dependencies: [],
+    status: "pending",
+    passes: false,
+    escalations: [],
+    attempts: 0,
+  };
+}
+
+function makeConfig(enabled: boolean, budgetTokens = 2048): NaxConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    context: {
+      ...DEFAULT_CONFIG.context,
+      featureEngine: {
+        enabled,
+        budgetTokens,
+      },
+    },
+  };
+}
+
+const CONTEXT_MD = `# Feature Context
+
+_Last updated: 2024-01-01_
+
+## Implementation Notes
+
+- **Database schema defined.** \`[implementer]\`
+  Use the schema in src/db/schema.ts.
+  _Established in: US-001_
+
+- **Test fixtures available.** \`[test-writer]\`
+  Use the fixtures in test/fixtures/.
+  _Established in: US-001_
+
+- **Shared constraint.** \`[all]\`
+  Always validate input before processing.
+  _Established in: US-001_
+
+## Review Notes
+
+- **Security concern.** \`[reviewer-semantic]\`
+  Check for SQL injection in all queries.
+  _Established in: US-001_
+`;
+
+describe("Feature Engine v1 read path (integration)", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-feat-engine-");
+    clearFeatureResolverCache();
+
+    // Set up .nax/features/auth-feature/prd.json
+    const featDir = join(tempDir, ".nax", "features", "auth-feature");
+    mkdirSync(featDir, { recursive: true });
+    writeFileSync(
+      join(featDir, "prd.json"),
+      JSON.stringify({
+        userStories: [
+          { id: "US-001", title: "Implement auth" },
+          { id: "US-002", title: "Add tests" },
+        ],
+      }),
+    );
+    writeFileSync(join(featDir, "context.md"), CONTEXT_MD);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+    clearFeatureResolverCache();
+  });
+
+  test("disabled engine returns null", async () => {
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-001");
+    const config = makeConfig(false);
+    const result = await provider.getContext(story, tempDir, config);
+    expect(result).toBeNull();
+  });
+
+  test("enabled engine with attached story returns FeatureContextResult", async () => {
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-001");
+    const config = makeConfig(true);
+    const result = await provider.getContext(story, tempDir, config);
+
+    expect(result).not.toBeNull();
+    expect(result!.featureId).toBe("auth-feature");
+    expect(result!.label).toBe("feature-context:auth-feature");
+    expect(result!.content).toContain("## Feature Context");
+    expect(result!.content).toContain("_Feature: auth-feature_");
+    expect(result!.content).toContain("Database schema defined");
+    expect(result!.estimatedTokens).toBeGreaterThan(0);
+  });
+
+  test("enabled engine with unattached story returns null", async () => {
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-999"); // not in any feature prd.json
+    const config = makeConfig(true);
+    const result = await provider.getContext(story, tempDir, config);
+    expect(result).toBeNull();
+  });
+
+  test("enabled engine without context.md returns null", async () => {
+    const provider = new FeatureContextProvider();
+    // Set up a second feature without context.md
+    const featDir2 = join(tempDir, ".nax", "features", "empty-feature");
+    mkdirSync(featDir2, { recursive: true });
+    writeFileSync(
+      join(featDir2, "prd.json"),
+      JSON.stringify({
+        userStories: [{ id: "US-010", title: "Story 010" }],
+      }),
+    );
+
+    clearFeatureResolverCache();
+
+    const story = makeStory("US-010");
+    const config = makeConfig(true);
+    const result = await provider.getContext(story, tempDir, config);
+    expect(result).toBeNull();
+  });
+
+  test("role filtering: implementer sees [implementer] and [all], not [test-writer] or [reviewer-semantic]", async () => {
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-001");
+    const config = makeConfig(true);
+    const result = await provider.getContext(story, tempDir, config);
+
+    expect(result).not.toBeNull();
+    const filtered = filterContextByRole(result!.content, "implementer");
+
+    expect(filtered).toContain("Database schema defined");
+    expect(filtered).toContain("Shared constraint");
+    expect(filtered).not.toContain("Test fixtures available");
+    expect(filtered).not.toContain("Security concern");
+  });
+
+  test("role filtering: test-writer sees [test-writer] and [all], not [implementer] or [reviewer-semantic]", async () => {
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-001");
+    const config = makeConfig(true);
+    const result = await provider.getContext(story, tempDir, config);
+
+    expect(result).not.toBeNull();
+    const filtered = filterContextByRole(result!.content, "test-writer");
+
+    expect(filtered).toContain("Test fixtures available");
+    expect(filtered).toContain("Shared constraint");
+    expect(filtered).not.toContain("Database schema defined");
+    expect(filtered).not.toContain("Security concern");
+  });
+
+  test("role filtering: reviewer-semantic sees [reviewer-semantic] and [all], not [implementer] or [test-writer]", async () => {
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-001");
+    const config = makeConfig(true);
+    const result = await provider.getContext(story, tempDir, config);
+
+    expect(result).not.toBeNull();
+    const filtered = filterContextByRole(result!.content, "reviewer-semantic");
+
+    expect(filtered).toContain("Security concern");
+    expect(filtered).toContain("Shared constraint");
+    expect(filtered).not.toContain("Database schema defined");
+    expect(filtered).not.toContain("Test fixtures available");
+  });
+
+  test("budget enforcement: truncate when filtered content exceeds budget", async () => {
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-001");
+    const config = makeConfig(true, 10); // very small budget (10 tokens = 40 chars)
+    const result = await provider.getContext(story, tempDir, config);
+
+    expect(result).not.toBeNull();
+    const filtered = filterContextByRole(result!.content, "implementer");
+    const truncated = truncateToContextBudget(filtered, 10, result!.featureId);
+
+    // Truncated should be shorter than filtered
+    expect(truncated.length).toBeLessThan(filtered.length);
+    expect(truncated.length).toBeGreaterThan(0);
+  });
+});

--- a/test/unit/context/feature-context-filter.test.ts
+++ b/test/unit/context/feature-context-filter.test.ts
@@ -287,3 +287,51 @@ describe("truncateToContextBudget", () => {
     expect(result).not.toContain("HEADER-TEXT");
   });
 });
+
+describe("filterContextByRole — edge cases", () => {
+  test("no trailing blank line leaks from excluded into included entry", () => {
+    // When an included entry is immediately followed by an excluded entry,
+    // the blank line separating them must NOT appear in the output.
+    const md = [
+      "## Constraints",
+      "",
+      "- **Included entry.** `[implementer]`",
+      "  Body of included entry.",
+      "",
+      "- **Excluded entry.** `[test-writer]`",
+      "  Body of excluded entry.",
+    ].join("\n");
+
+    const result = filterContextByRole(md, "implementer");
+
+    // The included entry should be present
+    expect(result).toContain("Included entry");
+    // The excluded entry must not appear
+    expect(result).not.toContain("Excluded entry");
+    // The result must not end with a blank line (leaked from between entries)
+    expect(result.trimEnd()).toBe(result);
+    // Specifically: no double newline trailing
+    expect(result).not.toMatch(/\n\s*$/);
+  });
+
+  test("narrative text under ## section heading is dropped (bullet-only format)", () => {
+    // context.md entries are spec-defined as bullet form.
+    // Free-form narrative paragraphs inside a ## Section are silently dropped.
+    // This test documents the intentional behavior.
+    const md = [
+      "## Decisions",
+      "",
+      "This is a narrative paragraph, not a bullet entry.",
+      "",
+      "- **Bullet entry.** `[all]`",
+      "  Body text.",
+    ].join("\n");
+
+    const result = filterContextByRole(md, "implementer");
+
+    // Bullet entry is kept
+    expect(result).toContain("Bullet entry");
+    // Narrative paragraph is dropped (by design — not a supported format)
+    expect(result).not.toContain("This is a narrative paragraph");
+  });
+});

--- a/test/unit/context/feature-context-filter.test.ts
+++ b/test/unit/context/feature-context-filter.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for feature-context-filter.ts
+ *
+ * Covers role filtering, tag parsing, and budget enforcement.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  estimateContextTokens,
+  filterContextByRole,
+  parseAudienceTags,
+  shouldIncludeEntry,
+  truncateToContextBudget,
+} from "../../../src/context/feature-context-filter";
+
+describe("parseAudienceTags", () => {
+  test("returns ['all'] when no tag present", () => {
+    expect(parseAudienceTags("- **No tag here.**")).toEqual(["all"]);
+  });
+
+  test("returns ['all'] for plain text", () => {
+    expect(parseAudienceTags("Some text without brackets")).toEqual(["all"]);
+  });
+
+  test("parses single tag", () => {
+    expect(parseAudienceTags("- **Entry.** `[implementer]`")).toEqual(["implementer"]);
+  });
+
+  test("parses multi-tag", () => {
+    expect(parseAudienceTags("- **Entry.** `[implementer, test-writer]`")).toEqual([
+      "implementer",
+      "test-writer",
+    ]);
+  });
+
+  test("parses all tag", () => {
+    expect(parseAudienceTags("- **Entry.** `[all]`")).toEqual(["all"]);
+  });
+
+  test("is case insensitive", () => {
+    expect(parseAudienceTags("- **Entry.** `[IMPLEMENTER]`")).toEqual(["implementer"]);
+  });
+
+  test("trims whitespace in multi-tag", () => {
+    expect(parseAudienceTags("- **Entry.** `[ reviewer , reviewer-semantic ]`")).toEqual([
+      "reviewer",
+      "reviewer-semantic",
+    ]);
+  });
+});
+
+describe("shouldIncludeEntry", () => {
+  test("[all] entry included for every role", () => {
+    const roles = [
+      "implementer",
+      "test-writer",
+      "verifier",
+      "single-session",
+      "tdd-simple",
+      "no-test",
+      "batch",
+      "reviewer-semantic",
+      "reviewer-adversarial",
+    ];
+    for (const role of roles) {
+      expect(shouldIncludeEntry(["all"], role)).toBe(true);
+    }
+  });
+
+  test("[implementer] included for implementer", () => {
+    expect(shouldIncludeEntry(["implementer"], "implementer")).toBe(true);
+  });
+
+  test("[implementer] included for single-session", () => {
+    expect(shouldIncludeEntry(["implementer"], "single-session")).toBe(true);
+  });
+
+  test("[implementer] included for tdd-simple", () => {
+    expect(shouldIncludeEntry(["implementer"], "tdd-simple")).toBe(true);
+  });
+
+  test("[implementer] included for no-test", () => {
+    expect(shouldIncludeEntry(["implementer"], "no-test")).toBe(true);
+  });
+
+  test("[implementer] included for batch", () => {
+    expect(shouldIncludeEntry(["implementer"], "batch")).toBe(true);
+  });
+
+  test("[implementer] excluded for test-writer", () => {
+    expect(shouldIncludeEntry(["implementer"], "test-writer")).toBe(false);
+  });
+
+  test("[implementer] excluded for verifier", () => {
+    expect(shouldIncludeEntry(["implementer"], "verifier")).toBe(false);
+  });
+
+  test("[implementer] excluded for reviewer-semantic", () => {
+    expect(shouldIncludeEntry(["implementer"], "reviewer-semantic")).toBe(false);
+  });
+
+  test("[test-writer] included for test-writer", () => {
+    expect(shouldIncludeEntry(["test-writer"], "test-writer")).toBe(true);
+  });
+
+  test("[test-writer] included for single-session", () => {
+    expect(shouldIncludeEntry(["test-writer"], "single-session")).toBe(true);
+  });
+
+  test("[test-writer] included for tdd-simple", () => {
+    expect(shouldIncludeEntry(["test-writer"], "tdd-simple")).toBe(true);
+  });
+
+  test("[test-writer] included for batch", () => {
+    expect(shouldIncludeEntry(["test-writer"], "batch")).toBe(true);
+  });
+
+  test("[test-writer] excluded for implementer", () => {
+    expect(shouldIncludeEntry(["test-writer"], "implementer")).toBe(false);
+  });
+
+  test("[test-writer] excluded for verifier", () => {
+    expect(shouldIncludeEntry(["test-writer"], "verifier")).toBe(false);
+  });
+
+  test("[test-writer] excluded for reviewer-semantic", () => {
+    expect(shouldIncludeEntry(["test-writer"], "reviewer-semantic")).toBe(false);
+  });
+
+  test("[reviewer] included for reviewer-semantic", () => {
+    expect(shouldIncludeEntry(["reviewer"], "reviewer-semantic")).toBe(true);
+  });
+
+  test("[reviewer] included for reviewer-adversarial", () => {
+    expect(shouldIncludeEntry(["reviewer"], "reviewer-adversarial")).toBe(true);
+  });
+
+  test("[reviewer-semantic] included for reviewer-semantic only", () => {
+    expect(shouldIncludeEntry(["reviewer-semantic"], "reviewer-semantic")).toBe(true);
+    expect(shouldIncludeEntry(["reviewer-semantic"], "reviewer-adversarial")).toBe(false);
+  });
+
+  test("[reviewer-adversarial] included for reviewer-adversarial only", () => {
+    expect(shouldIncludeEntry(["reviewer-adversarial"], "reviewer-adversarial")).toBe(true);
+    expect(shouldIncludeEntry(["reviewer-adversarial"], "reviewer-semantic")).toBe(false);
+  });
+
+  test("multi-tag [implementer, test-writer] included for implementer", () => {
+    expect(shouldIncludeEntry(["implementer", "test-writer"], "implementer")).toBe(true);
+  });
+
+  test("multi-tag [implementer, test-writer] included for test-writer", () => {
+    expect(shouldIncludeEntry(["implementer", "test-writer"], "test-writer")).toBe(true);
+  });
+
+  test("multi-tag [implementer, test-writer] excluded for verifier", () => {
+    expect(shouldIncludeEntry(["implementer", "test-writer"], "verifier")).toBe(false);
+  });
+});
+
+describe("filterContextByRole", () => {
+  const contextMd = `# Feature Context
+
+_Last updated: 2024-01-01_
+
+## Implementation Notes
+
+- **Database schema defined.** \`[implementer]\`
+  Use the schema in src/db/schema.ts.
+  _Established in: US-001_
+
+- **Test fixtures available.** \`[test-writer]\`
+  Use the fixtures in test/fixtures/.
+
+- **Shared constraint.** \`[all]\`
+  Always validate input before processing.
+
+## Review Notes
+
+- **Security concern.** \`[reviewer-semantic]\`
+  Check for SQL injection in all queries.
+`;
+
+  test("implementer sees [implementer] and [all] entries, not [test-writer]", () => {
+    const result = filterContextByRole(contextMd, "implementer");
+    expect(result).toContain("Database schema defined");
+    expect(result).toContain("Shared constraint");
+    expect(result).not.toContain("Test fixtures available");
+    expect(result).not.toContain("Security concern");
+  });
+
+  test("test-writer sees [test-writer] and [all] entries, not [implementer]", () => {
+    const result = filterContextByRole(contextMd, "test-writer");
+    expect(result).toContain("Test fixtures available");
+    expect(result).toContain("Shared constraint");
+    expect(result).not.toContain("Database schema defined");
+    expect(result).not.toContain("Security concern");
+  });
+
+  test("single-session sees [all], [implementer], and [test-writer] entries", () => {
+    const result = filterContextByRole(contextMd, "single-session");
+    expect(result).toContain("Database schema defined");
+    expect(result).toContain("Test fixtures available");
+    expect(result).toContain("Shared constraint");
+    expect(result).not.toContain("Security concern");
+  });
+
+  test("tdd-simple sees [all], [implementer], and [test-writer] entries", () => {
+    const result = filterContextByRole(contextMd, "tdd-simple");
+    expect(result).toContain("Database schema defined");
+    expect(result).toContain("Test fixtures available");
+    expect(result).toContain("Shared constraint");
+  });
+
+  test("reviewer-semantic sees [all], [reviewer], and [reviewer-semantic] entries", () => {
+    const result = filterContextByRole(contextMd, "reviewer-semantic");
+    expect(result).toContain("Shared constraint");
+    expect(result).toContain("Security concern");
+    expect(result).not.toContain("Database schema defined");
+    expect(result).not.toContain("Test fixtures available");
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(filterContextByRole("", "implementer")).toBe("");
+    expect(filterContextByRole("   ", "implementer")).toBe("");
+  });
+
+  test("entry without tag treated as [all] — included for every role", () => {
+    const md = `## Notes
+
+- **No tag entry.**
+  This has no audience tag.
+`;
+    for (const role of ["implementer", "test-writer", "verifier", "reviewer-semantic"]) {
+      const result = filterContextByRole(md, role);
+      expect(result).toContain("No tag entry");
+    }
+  });
+
+  test("empty section is dropped when all entries filtered out", () => {
+    const md = `## Implementation Notes
+
+- **Implementer only.** \`[implementer]\`
+  Only for implementers.
+
+## Review Notes
+
+- **Reviewer only.** \`[reviewer-semantic]\`
+  Only for reviewers.
+`;
+    const result = filterContextByRole(md, "implementer");
+    expect(result).toContain("Implementation Notes");
+    expect(result).toContain("Implementer only");
+    expect(result).not.toContain("Review Notes");
+    expect(result).not.toContain("Reviewer only");
+  });
+});
+
+describe("estimateContextTokens", () => {
+  test("estimates 1 token per 4 chars (ceil)", () => {
+    expect(estimateContextTokens("abcd")).toBe(1); // 4 chars
+    expect(estimateContextTokens("abcde")).toBe(2); // 5 chars → ceil(5/4) = 2
+    expect(estimateContextTokens("")).toBe(0);
+  });
+});
+
+describe("truncateToContextBudget", () => {
+  test("returns unchanged when within budget", () => {
+    const text = "short text";
+    const result = truncateToContextBudget(text, 100, "my-feature");
+    expect(result).toBe(text);
+  });
+
+  test("truncates when over budget — result is shorter", () => {
+    const text = "a".repeat(1000); // 1000 chars = 250 tokens
+    const result = truncateToContextBudget(text, 10, "my-feature"); // budget: 10 tokens = 40 chars
+    expect(result.length).toBeLessThan(text.length);
+  });
+
+  test("truncated result is tail of original (tail-biased)", () => {
+    const text = "HEADER-TEXT\nLINE-ONE\nLINE-TWO\nLINE-THREE\nLINE-FOUR\nTAIL-TEXT";
+    // Small budget so we get tail portion
+    const result = truncateToContextBudget(text, 5, "feat"); // 5 tokens = 20 chars
+    // Should contain some tail content
+    expect(result.length).toBeGreaterThan(0);
+    // Should not start with the very beginning of the text
+    expect(result).not.toContain("HEADER-TEXT");
+  });
+});

--- a/test/unit/context/feature-context.test.ts
+++ b/test/unit/context/feature-context.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for feature-context provider.
+ *
+ * Uses _featureContextDeps injection pattern — no mock.module().
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  FeatureContextProvider,
+  _featureContextDeps,
+} from "../../../src/context/providers/feature-context";
+import type { NaxConfig } from "../../../src/config/types";
+import type { UserStory } from "../../../src/prd";
+import { DEFAULT_CONFIG } from "../../../src/config";
+
+function makeStory(id: string): UserStory {
+  return {
+    id,
+    title: `Story ${id}`,
+    description: "Test story",
+    acceptanceCriteria: ["AC1"],
+    tags: [],
+    dependencies: [],
+    status: "pending",
+    passes: false,
+    escalations: [],
+    attempts: 0,
+  };
+}
+
+function makeConfig(enabled: boolean, budgetTokens = 2048): NaxConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    context: {
+      ...DEFAULT_CONFIG.context,
+      featureEngine: {
+        enabled,
+        budgetTokens,
+      },
+    },
+  };
+}
+
+describe("FeatureContextProvider", () => {
+  let origResolveFeatureId: typeof _featureContextDeps.resolveFeatureId;
+  let origReadFile: typeof _featureContextDeps.readFile;
+  let origFileExists: typeof _featureContextDeps.fileExists;
+
+  beforeEach(() => {
+    origResolveFeatureId = _featureContextDeps.resolveFeatureId;
+    origReadFile = _featureContextDeps.readFile;
+    origFileExists = _featureContextDeps.fileExists;
+  });
+
+  afterEach(() => {
+    _featureContextDeps.resolveFeatureId = origResolveFeatureId;
+    _featureContextDeps.readFile = origReadFile;
+    _featureContextDeps.fileExists = origFileExists;
+  });
+
+  test("returns null when feature engine disabled", async () => {
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-001");
+    const config = makeConfig(false);
+    const result = await provider.getContext(story, "/workdir", config);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when story not attached to any feature", async () => {
+    _featureContextDeps.resolveFeatureId = async () => null;
+
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-001");
+    const config = makeConfig(true);
+    const result = await provider.getContext(story, "/workdir", config);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when context.md does not exist", async () => {
+    _featureContextDeps.resolveFeatureId = async () => "my-feature";
+    _featureContextDeps.fileExists = async () => false;
+
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-001");
+    const config = makeConfig(true);
+    const result = await provider.getContext(story, "/workdir", config);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when context.md is empty", async () => {
+    _featureContextDeps.resolveFeatureId = async () => "my-feature";
+    _featureContextDeps.fileExists = async () => true;
+    _featureContextDeps.readFile = async () => "   \n  ";
+
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-001");
+    const config = makeConfig(true);
+    const result = await provider.getContext(story, "/workdir", config);
+    expect(result).toBeNull();
+  });
+
+  test("returns FeatureContextResult with correct label and featureId when context.md exists", async () => {
+    const contextContent = "## Notes\n\n- **Entry.** `[all]`\n  Some context here.\n";
+    _featureContextDeps.resolveFeatureId = async () => "auth-feature";
+    _featureContextDeps.fileExists = async () => true;
+    _featureContextDeps.readFile = async () => contextContent;
+
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-005");
+    const config = makeConfig(true);
+    const result = await provider.getContext(story, "/workdir", config);
+
+    expect(result).not.toBeNull();
+    expect(result!.label).toBe("feature-context:auth-feature");
+    expect(result!.featureId).toBe("auth-feature");
+    expect(result!.content).toContain("## Feature Context");
+    expect(result!.content).toContain("_Feature: auth-feature_");
+    expect(result!.content).toContain("Some context here.");
+    expect(result!.estimatedTokens).toBeGreaterThan(0);
+  });
+
+  test("returns null and warns when file read throws an error", async () => {
+    _featureContextDeps.resolveFeatureId = async () => "broken-feature";
+    _featureContextDeps.fileExists = async () => true;
+    _featureContextDeps.readFile = async () => {
+      throw new Error("Permission denied");
+    };
+
+    const provider = new FeatureContextProvider();
+    const story = makeStory("US-001");
+    const config = makeConfig(true);
+    const result = await provider.getContext(story, "/workdir", config);
+    expect(result).toBeNull();
+  });
+});

--- a/test/unit/context/feature-resolver.test.ts
+++ b/test/unit/context/feature-resolver.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for feature-resolver.ts
+ *
+ * Uses _resolverDeps injection pattern — no mock.module().
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { clearFeatureResolverCache, resolveFeatureId, _resolverDeps } from "../../../src/context/feature-resolver";
+import type { UserStory } from "../../../src/prd";
+import { makeTempDir, cleanupTempDir } from "../../helpers/temp";
+
+function makeStory(id: string): UserStory {
+  return {
+    id,
+    title: `Story ${id}`,
+    description: "Test story",
+    acceptanceCriteria: ["AC1"],
+    tags: [],
+    dependencies: [],
+    status: "pending",
+    passes: false,
+    escalations: [],
+    attempts: 0,
+  };
+}
+
+function makePrd(storyIds: string[]): string {
+  return JSON.stringify({
+    userStories: storyIds.map((id) => ({ id, title: `Story ${id}` })),
+  });
+}
+
+describe("resolveFeatureId", () => {
+  let tempDir: string;
+  let origGlob: typeof _resolverDeps.glob;
+  let origReadFile: typeof _resolverDeps.readFile;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-feature-resolver-");
+    clearFeatureResolverCache();
+    origGlob = _resolverDeps.glob;
+    origReadFile = _resolverDeps.readFile;
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+    _resolverDeps.glob = origGlob;
+    _resolverDeps.readFile = origReadFile;
+  });
+
+  test("returns featureId when story found in one feature", async () => {
+    // Set up .nax/features/my-feature/prd.json
+    const featDir = join(tempDir, ".nax", "features", "my-feature");
+    mkdirSync(featDir, { recursive: true });
+    writeFileSync(join(featDir, "prd.json"), makePrd(["US-001", "US-002"]));
+
+    const story = makeStory("US-001");
+    const result = await resolveFeatureId(story, tempDir);
+    expect(result).toBe("my-feature");
+  });
+
+  test("returns null when story not found in any feature", async () => {
+    // Set up .nax/features/other-feature/prd.json with different stories
+    const featDir = join(tempDir, ".nax", "features", "other-feature");
+    mkdirSync(featDir, { recursive: true });
+    writeFileSync(join(featDir, "prd.json"), makePrd(["US-010", "US-011"]));
+
+    const story = makeStory("US-001");
+    const result = await resolveFeatureId(story, tempDir);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when .nax/features dir does not exist", async () => {
+    const story = makeStory("US-001");
+    const result = await resolveFeatureId(story, tempDir);
+    expect(result).toBeNull();
+  });
+
+  test("returns first match and logs warning when story appears in multiple features", async () => {
+    const feat1Dir = join(tempDir, ".nax", "features", "feature-a");
+    const feat2Dir = join(tempDir, ".nax", "features", "feature-b");
+    mkdirSync(feat1Dir, { recursive: true });
+    mkdirSync(feat2Dir, { recursive: true });
+    writeFileSync(join(feat1Dir, "prd.json"), makePrd(["US-001"]));
+    writeFileSync(join(feat2Dir, "prd.json"), makePrd(["US-001"]));
+
+    const story = makeStory("US-001");
+    const result = await resolveFeatureId(story, tempDir);
+    // Should return one of the matches (first glob hit)
+    expect(result).toMatch(/^feature-[ab]$/);
+  });
+
+  test("skips malformed prd.json and continues scanning", async () => {
+    const feat1Dir = join(tempDir, ".nax", "features", "broken-feature");
+    const feat2Dir = join(tempDir, ".nax", "features", "good-feature");
+    mkdirSync(feat1Dir, { recursive: true });
+    mkdirSync(feat2Dir, { recursive: true });
+    writeFileSync(join(feat1Dir, "prd.json"), "{ invalid json !!!");
+    writeFileSync(join(feat2Dir, "prd.json"), makePrd(["US-001"]));
+
+    const story = makeStory("US-001");
+    const result = await resolveFeatureId(story, tempDir);
+    expect(result).toBe("good-feature");
+  });
+
+  test("returns cached result on second call without re-reading files", async () => {
+    const featDir = join(tempDir, ".nax", "features", "cached-feature");
+    mkdirSync(featDir, { recursive: true });
+    writeFileSync(join(featDir, "prd.json"), makePrd(["US-005"]));
+
+    const story = makeStory("US-005");
+
+    // First call — populates cache
+    const result1 = await resolveFeatureId(story, tempDir);
+    expect(result1).toBe("cached-feature");
+
+    let readCount = 0;
+    const originalReadFile = _resolverDeps.readFile;
+    _resolverDeps.readFile = async (path: string) => {
+      readCount++;
+      return originalReadFile(path);
+    };
+
+    // Second call — should use cache, not call readFile
+    const result2 = await resolveFeatureId(story, tempDir);
+    expect(result2).toBe("cached-feature");
+    expect(readCount).toBe(0);
+
+    _resolverDeps.readFile = originalReadFile;
+  });
+
+  test("clearFeatureResolverCache clears all cached results", async () => {
+    const featDir = join(tempDir, ".nax", "features", "some-feature");
+    mkdirSync(featDir, { recursive: true });
+    writeFileSync(join(featDir, "prd.json"), makePrd(["US-007"]));
+
+    const story = makeStory("US-007");
+
+    // Populate cache
+    const result1 = await resolveFeatureId(story, tempDir);
+    expect(result1).toBe("some-feature");
+
+    // Clear cache
+    clearFeatureResolverCache();
+
+    // Remove the feature directory — if cache was cleared, it should re-scan and return null
+    const { rmSync } = await import("node:fs");
+    rmSync(featDir, { recursive: true });
+
+    const result2 = await resolveFeatureId(story, tempDir);
+    expect(result2).toBeNull();
+  });
+});

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -488,6 +488,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
       undefined,
       undefined,
       undefined, // blockingThreshold
+      undefined, // featureContextMarkdown
     );
   });
 
@@ -522,6 +523,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
       undefined,
       undefined,
       undefined, // blockingThreshold
+      undefined, // featureContextMarkdown
     );
   });
 });


### PR DESCRIPTION
## Summary

Implements the **Context Engine v1 read path** ([SPEC-feature-context-engine.md](docs/specs/SPEC-feature-context-engine.md), Phase 1). Human-authored `.nax/features/<id>/context.md` files are automatically loaded, role-filtered by audience tag, and injected into agent prompts between the role-task body and the story brief.

The write path (extractor, fragment merge, summarization gate, promotion gate) is explicitly deferred to v2. v1 is read-path only.

### What changed

**3 new source modules:**
- `src/context/feature-resolver.ts` — `resolveFeatureId()` scans `.nax/features/*/prd.json` via Bun `Glob` with per-workdir cache; warns on multi-feature matches or malformed JSON
- `src/context/feature-context-filter.ts` — `filterContextByRole()` parses `[audience]` tags from entry headlines and filters by role; `truncateToContextBudget()` enforces `budgetTokens` after filtering (tail-biased, budget measured post-filter)
- `src/context/providers/feature-context.ts` — `FeatureContextProvider` coordinates resolver + file read + injection header; returns `null` when disabled, unattached, or file absent

**Pipeline wiring (12 modified files):**
- Config: `FeatureContextEngineConfigSchema` added to `ContextConfigSchema` (`enabled: false`, `budgetTokens: 2048`)
- `PipelineContext`: new `featureContextMarkdown?: string` field
- `context.ts` stage: calls `FeatureContextProvider.getContext()`, stores raw result separately from `ctx.contextMarkdown`; all existing logger calls retrofitted with `storyId`
- `TddPromptBuilder`: new `featureContext()` setter + section 2.5 (role-filters + budget-enforces between role-task and story sections)
- `pipeline/stages/prompt.ts`, `tdd/session-runner.ts`, `tdd/orchestrator.ts`: thread `featureContextMarkdown` through all TDD session roles
- `review/semantic.ts`, `review/adversarial.ts`: filter for `reviewer-semantic` / `reviewer-adversarial` role and prepend to prompt
- `review/orchestrator.ts`, `review/runner.ts`: thread from `ctx.featureContextMarkdown` through full call chain

**65 new tests:**
- `test/unit/context/feature-resolver.test.ts` (7 tests)
- `test/unit/context/feature-context-filter.test.ts` (44 tests — includes edge cases for blank-line leakage and bullet-only format contract)
- `test/unit/context/feature-context.test.ts` (6 tests)
- `test/integration/context/feature-engine-read-path.test.ts` (8 tests — real temp directory, end-to-end)

### Design decisions

- Feature context is stored in `ctx.featureContextMarkdown` separately from `ctx.contextMarkdown` (PRD context) so role-filtering can happen at prompt-build time where `PromptRole` is known
- `context.md` is spec-defined as bullet-only within `## Section` headings; narrative paragraphs inside sections are silently dropped (documented in JSDoc + test)
- All imports from new modules use the `src/context` barrel to prevent Bun singleton fragmentation (BUG-035)

### How to enable

Add to a project's `.nax/config.json`:
```json
{
  "context": {
    "featureEngine": {
      "enabled": true
    }
  }
}
```

Then write `.nax/features/<feature-id>/context.md` with tagged entries. The engine is opt-in (`enabled: false` by default).

## Test plan

- [ ] `bun run typecheck` — passes (no type errors)
- [ ] `bun run lint` — passes (no Biome errors)
- [ ] `bun test test/unit/context/` — 57 pass, 0 fail
- [ ] `bun test test/integration/context/feature-engine-read-path.test.ts` — 8 pass, 0 fail
- [ ] `bun test test/unit/` — 5,589 pass, 13 skip, 0 fail (full unit suite)
- [ ] Manually verify: create a `.nax/features/test-feature/context.md` with `[implementer]` and `[test-writer]` tagged entries, enable the engine, run a story, confirm role-filtered context appears in the agent prompt audit file

Closes #472