### PR TITLE
fix(session-manager): align implementation with SPEC + ADR-008

### DIFF
--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -163,9 +163,17 @@ export async function runIteration(
 
   const pipelineResult = await runPipeline(defaultPipeline, pipelineContext, ctx.eventEmitter);
 
-  // C1: Force-close all non-terminal sessions for this story so listActive()
-  // reflects the true state. Physical close is handled per-stage (closePhysicalSession).
-  pipelineContext.sessionManager?.closeStory(story.id);
+  // G2: Close all non-terminal sessions — update in-memory state and close physical ACP sessions.
+  // closeStory() returns the descriptors it transitioned; for any with a handle we close
+  // the physical session so ACP doesn't accumulate orphaned sessions after abnormal exits
+  // (e.g. escalate with keepSessionOpen: true still set by the execution stage).
+  const closedSessionDescs = pipelineContext.sessionManager?.closeStory(story.id) ?? [];
+  for (const desc of closedSessionDescs) {
+    if (desc.handle) {
+      const adapter = pipelineContext.agentGetFn?.(desc.agent);
+      void adapter?.closePhysicalSession(desc.handle, desc.workdir).catch(() => {});
+    }
+  }
 
   // #410: Destroy reviewerSession on escalation — completion stage is bypassed when the pipeline
   // returns escalate, so we must clean up here to avoid leaking the ACP reviewer session.

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -522,6 +522,19 @@ async function runAgentRectification(
 
       autofixCostAccum += result.estimatedCost ?? 0;
 
+      // G5: bind updated protocolIds after each autofix attempt so the session descriptor
+      // reflects the session that actually ran (may change after internal session retries).
+      if (ctx.sessionManager && ctx.sessionId && result.protocolIds) {
+        try {
+          const desc = ctx.sessionManager.get(ctx.sessionId);
+          if (desc) {
+            ctx.sessionManager.bindHandle(ctx.sessionId, implementerSession, result.protocolIds);
+          }
+        } catch {
+          // Best-effort — never block the autofix loop.
+        }
+      }
+
       // REVIEW-003: Detect UNRESOLVED signal — reviewer findings contradict each other.
       // Escalate immediately rather than retrying an unresolvable conflict.
       if (result.output) {

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -241,6 +241,19 @@ export const executionStage: PipelineStage = {
     const keepSessionOpen = !!(
       ctx.config.review?.enabled === true || ctx.config.execution.rectification?.enabled === true
     );
+
+    // G1: Advance state machine to RUNNING so resume() / listActive() see accurate state.
+    // Guarded — ctx.sessionId may not have a manager entry when v2 context is disabled.
+    if (ctx.sessionManager && ctx.sessionId) {
+      const pre = ctx.sessionManager.get(ctx.sessionId);
+      if (pre?.state === "CREATED") {
+        ctx.sessionManager.transition(ctx.sessionId, "RUNNING");
+      }
+    }
+
+    // G3: Resolve descriptor for Phase 1+ session tracking.
+    const sessionDescriptor = ctx.sessionManager && ctx.sessionId ? ctx.sessionManager.get(ctx.sessionId) : undefined;
+
     const contextToolRuntime = ctx.contextBundle
       ? createContextToolRuntime({
           bundle: ctx.contextBundle,
@@ -273,6 +286,9 @@ export const executionStage: PipelineStage = {
       storyId: ctx.story.id,
       sessionRole: "implementer",
       keepSessionOpen,
+      // G3: pass descriptor so adapter uses it for session name derivation (Phase 1+).
+      // Backward-compatible — featureName/storyId/sessionRole kept as fallback.
+      ...(sessionDescriptor && { session: sessionDescriptor }),
       contextPullTools: ctx.contextBundle?.pullTools,
       contextToolRuntime,
       interactionBridge: buildInteractionBridge(ctx.interaction, {

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -322,7 +322,7 @@ export async function runAdversarialReview(
       storyId: story.id,
       cause: String(err),
     });
-    void agent.closeSession(adversarialSessionName, workdir);
+    void agent.closePhysicalSession(adversarialSessionName, workdir);
     return {
       check: "adversarial",
       success: true,
@@ -364,7 +364,7 @@ export async function runAdversarialReview(
   // Close the session — covers both the happy path (no retry) and the retry-exhausted
   // path (retry threw or returned unparseable JSON, so keepSessionOpen: false on the
   // retry call may not have closed it). Best-effort: already-closed sessions no-op.
-  void agent.closeSession(adversarialSessionName, workdir);
+  void agent.closePhysicalSession(adversarialSessionName, workdir);
 
   // Parse response — fail-closed when LLM clearly intended to fail,
   // fail-open only when response is truly unparseable with no signal.

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -470,7 +470,7 @@ export async function runSemanticReview(
     });
   } catch (err) {
     logger?.warn("semantic", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
-    void agent.closeSession(reviewerSessionName, workdir);
+    void agent.closePhysicalSession(reviewerSessionName, workdir);
     return {
       check: "semantic",
       success: true,
@@ -512,7 +512,7 @@ export async function runSemanticReview(
   // Close the session — covers both the happy path (no retry) and the retry-exhausted
   // path (retry threw or returned unparseable JSON, so keepSessionOpen: false on the
   // retry call may not have closed it). Best-effort: already-closed sessions no-op.
-  void agent.closeSession(reviewerSessionName, workdir);
+  void agent.closePhysicalSession(reviewerSessionName, workdir);
 
   // Parse response — fail-closed when LLM clearly intended to fail,
   // fail-open only when response is truly unparseable with no signal.

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -48,6 +48,17 @@ export interface RectificationLoopOptions {
    * Undefined for monorepo orchestrators (turbo/nx) — they do not support per-file expansion.
    */
   testScopedTemplate?: string;
+  /**
+   * In-process session registry (Phase 1+ plumbing). When provided, each rectification
+   * attempt's protocolIds are bound to the descriptor so the audit trail stays current
+   * across retries (G5: bindHandle after each agent.run() in the rectification loop).
+   */
+  sessionManager?: import("../session").ISessionManager;
+  /**
+   * nax session ID for the implementer session (sess-<uuid>).
+   * Required alongside sessionManager for bindHandle to work.
+   */
+  sessionId?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -138,6 +149,8 @@ export async function runRectificationLoop(
     agentGetFn,
     projectDir,
     testScopedTemplate,
+    sessionManager,
+    sessionId,
   } = opts;
   const logger = getSafeLogger();
   const rectificationConfig = config.execution.rectification;
@@ -262,6 +275,17 @@ export async function runRectificationLoop(
       });
 
       costAccum += agentResult.estimatedCost ?? 0;
+
+      // G5: update session descriptor with latest protocolIds so the audit trail
+      // reflects the session that actually ran (may differ after internal retries).
+      if (sessionManager && sessionId && agentResult.protocolIds) {
+        try {
+          sessionManager.bindHandle(sessionId, rectificationSessionName, agentResult.protocolIds);
+        } catch {
+          // Session may not exist in manager (e.g. v2 context disabled) — ignore.
+        }
+      }
+
       if (agentResult.success) {
         logger?.info("rectification", `Agent ${label} session complete`, {
           storyId: story.id,
@@ -484,5 +508,7 @@ export function runRectificationLoopFromCtx(
     agentGetFn: ctx.agentGetFn,
     projectDir: ctx.projectDir,
     testScopedTemplate: opts.testScopedTemplate,
+    sessionManager: ctx.sessionManager,
+    sessionId: ctx.sessionId,
   });
 }

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -87,6 +87,7 @@ function makeMultiCallAgent(responses: string[], costPerCall = 0.5): AgentAdapte
       return { output: response, estimatedCost: costPerCall };
     }),
     closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
     buildCommand: mock(() => []),
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
@@ -215,20 +216,20 @@ describe("runAdversarialReview — JSON retry succeeds", () => {
     expect((calls[0][0] as Record<string, unknown>).keepSessionOpen).toBe(true);
   });
 
-  test("agent.closeSession called once to close the session after runReview completes", async () => {
+  test("agent.closePhysicalSession called once to close the session after runReview completes", async () => {
     const agent = makeMultiCallAgent([PASSING_RESPONSE]);
 
     await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
 
-    expect((agent.closeSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect((agent.closePhysicalSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
   });
 
-  test("agent.closeSession called even when retry was needed (retry-exhausted path)", async () => {
+  test("agent.closePhysicalSession called even when retry was needed (retry-exhausted path)", async () => {
     const agent = makeMultiCallAgent(["this is not json at all", PASSING_RESPONSE]);
 
     await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
 
-    expect((agent.closeSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect((agent.closePhysicalSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
   });
 
   test("agent.run called once when initial response is valid JSON", async () => {
@@ -280,6 +281,7 @@ describe("runAdversarialReview — JSON retry failure paths", () => {
         throw new Error("retry connection failure");
       }),
       closeSession: mock(async () => {}),
+      closePhysicalSession: mock(async () => {}),
       buildCommand: mock(() => []),
       plan: mock(async () => { throw new Error("not used"); }),
       decompose: mock(async () => { throw new Error("not used"); }),
@@ -409,6 +411,7 @@ describe("runAdversarialReview — retry logging", () => {
         throw new Error("retry network failure");
       }),
       closeSession: mock(async () => {}),
+      closePhysicalSession: mock(async () => {}),
       buildCommand: mock(() => []),
       plan: mock(async () => { throw new Error("not used"); }),
       decompose: mock(async () => { throw new Error("not used"); }),

--- a/test/unit/review/adversarial-threshold.test.ts
+++ b/test/unit/review/adversarial-threshold.test.ts
@@ -82,6 +82,7 @@ function makeMockAgent(response: string): AgentAdapter {
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async () => response),
     closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/adversarial.test.ts
+++ b/test/unit/review/adversarial.test.ts
@@ -70,6 +70,7 @@ function makeAgent(llmResponse: string, cost = 0.001): AgentAdapter {
     }),
     complete: mock(async (_prompt: string) => llmResponse),
     closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -212,6 +212,7 @@ function makeMockAgent(response: string): AgentAdapter {
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async () => response),
     closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -50,6 +50,7 @@ function makeMockAgent(response: string): AgentAdapter {
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async (_prompt: string) => response),
     closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic-parsing.test.ts
+++ b/test/unit/review/semantic-parsing.test.ts
@@ -48,6 +48,7 @@ function makeMockAgent(response: string): AgentAdapter {
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async (_prompt: string) => response),
     closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -96,6 +96,7 @@ function makeMultiCallAgent(responses: string[], costPerCall = 0.5): AgentAdapte
       return agentResultFor(response);
     }),
     closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
     buildCommand: mock(() => []),
     plan: mock(async () => { throw new Error("not used"); }),
     decompose: mock(async () => { throw new Error("not used"); }),
@@ -222,20 +223,20 @@ describe("runSemanticReview — JSON retry succeeds", () => {
     expect((calls[1][0] as Record<string, unknown>).keepSessionOpen).toBe(false);
   });
 
-  test("agent.closeSession called once to close the session after runReview completes", async () => {
+  test("agent.closePhysicalSession called once to close the session after runReview completes", async () => {
     const agent = makeMultiCallAgent([PASSING_LLM_RESPONSE]);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
-    expect((agent.closeSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect((agent.closePhysicalSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
   });
 
-  test("agent.closeSession called even when retry was needed (retry-exhausted path)", async () => {
+  test("agent.closePhysicalSession called even when retry was needed (retry-exhausted path)", async () => {
     const agent = makeMultiCallAgent(["this is not json at all", PASSING_LLM_RESPONSE]);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
-    expect((agent.closeSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect((agent.closePhysicalSession as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
   });
 
   test("agent.run called once when initial response is valid JSON", async () => {
@@ -293,6 +294,7 @@ describe("runSemanticReview — JSON retry failure paths", () => {
         throw new Error("retry connection failure");
       }),
       closeSession: mock(async () => {}),
+      closePhysicalSession: mock(async () => {}),
       buildCommand: mock(() => []),
       plan: mock(async () => { throw new Error("not used"); }),
       decompose: mock(async () => { throw new Error("not used"); }),

--- a/test/unit/review/semantic-threshold.test.ts
+++ b/test/unit/review/semantic-threshold.test.ts
@@ -74,6 +74,7 @@ function makeMockAgent(response: string): AgentAdapter {
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async () => response),
     closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic-unverifiable.test.ts
+++ b/test/unit/review/semantic-unverifiable.test.ts
@@ -51,6 +51,7 @@ function makeMockAgent(response: string): AgentAdapter {
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async (_prompt: string) => response),
     closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -56,6 +56,7 @@ function makeMockAgent(response: string): AgentAdapter {
     decompose: mock(async () => { throw new Error("not used"); }),
     complete: mock(async (_prompt: string) => response),
     closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 
@@ -861,6 +862,7 @@ function makeRunMockAgent(output: string, success = true): AgentAdapter {
     decompose: mock(async () => { throw new Error("decompose not used"); }),
     complete: mock(async (_prompt: string) => { throw new Error("complete() must NOT be called in non-debate path (US-003)"); }),
     closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
   } as unknown as AgentAdapter;
 }
 


### PR DESCRIPTION
## Summary

- **G1**: Advance `SessionManager` state to `RUNNING` before `agent.run()` in execution stage — was stuck in `CREATED` during live execution
- **G2**: Wire `closePhysicalSession()` for each descriptor returned by `closeStory()` in `iteration-runner` — previously leaked open ACP sessions
- **G3**: Pass `session: descriptor` to `agent.run()` so the ACP adapter can derive the session name from the `SessionManager` record (Phase 1+)
- **G5**: Call `bindHandle()` after each rectification and autofix attempt to persist `protocolIds` for post-run audit correlation
- **A1 (ADR-008)**: Replace deprecated `closeSession()` with `closePhysicalSession()` in `semantic.ts` and `adversarial.ts` — reviewer sessions now physically closed on all exit paths as required by ADR-008

## Test plan

- [ ] All 10 affected review test fixtures updated with `closePhysicalSession: mock(async () => {})`
- [ ] 4 `closeSession`-call-count assertions updated to assert on `closePhysicalSession`
- [ ] Full unit test suite: 1188 pass, 0 fail
- [ ] `bun run typecheck`: clean
- [ ] `bun run lint`: clean