### PR TITLE
feat(context-engine): wire rebuildForAgent for agent-swap on availability failure (#474)

### DIFF
--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -352,16 +352,13 @@ export class ContextOrchestrator {
   /**
    * Re-render from prior.chunks without fetching providers.
    *
-   * ⚠ STATUS: library-only today. No caller in the runner or escalation paths
-   * currently invokes this method on an availability failure — adapters do not
-   * yet emit AdapterFailure, so Phase 5.5's agent-swap story is not observable
-   * from a production run. See the tracking issue for the runner wiring plan.
-   *
    * Phase 5.5: accepts an optional RebuildOptions object. When options.newAgentId
    * and options.failure are provided this is an availability-fallback rebuild —
    * a failure-note chunk is injected and the push markdown is rendered under the
    * new agent's profile. When they are absent the behaviour matches the original
    * Phase 0 signature (re-render, same agent, optional digest update).
+   *
+   * Wired into the execution stage via rebuildForSwap() (Issue #474).
    *
    * Target latency: ≤100ms (no I/O, no provider fetching, no LLM calls).
    *

--- a/src/execution/escalation/agent-swap.ts
+++ b/src/execution/escalation/agent-swap.ts
@@ -1,0 +1,79 @@
+/**
+ * Agent-swap escalation — Phase 5.5 (Issue #474)
+ *
+ * Pure logic for resolving the next agent candidate and rebuilding the context
+ * bundle after an availability failure. No I/O — callers (execution stage) own
+ * the retry loop and state mutations.
+ */
+
+import type { ContextV2FallbackConfig } from "../../config/runtime-types";
+import { ContextOrchestrator } from "../../context/engine";
+import type { AdapterFailure, ContextBundle } from "../../context/engine/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Swappable deps (for testing without mock.module())
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const _agentSwapDeps = {
+  rebuildForAgent: (prior: ContextBundle, opts: { newAgentId?: string; failure?: AdapterFailure }): ContextBundle =>
+    new ContextOrchestrator([]).rebuildForAgent(prior, opts),
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the next agent id to try from the fallback map.
+ *
+ * `swapCount` is the number of swaps already completed (0 = first swap).
+ * The candidates array is indexed by swapCount so each hop picks the next
+ * agent in the configured order.
+ *
+ * Returns null when no candidate is available at the current hop.
+ */
+export function resolveSwapTarget(
+  currentAgentId: string,
+  fallbackMap: Record<string, string[]>,
+  swapCount: number,
+): string | null {
+  const candidates = fallbackMap[currentAgentId];
+  if (!candidates || candidates.length === 0) return null;
+  return candidates[swapCount] ?? null;
+}
+
+/**
+ * Determine whether an agent-swap should be attempted for this failure.
+ *
+ * Conditions:
+ * - Config enabled
+ * - A context bundle exists (nothing to rebuild otherwise)
+ * - Under the per-story hop cap
+ * - Failure category is "availability" (or "quality" when onQualityFailure is set)
+ */
+export function shouldAttemptSwap(
+  failure: AdapterFailure | undefined,
+  fallbackConfig: ContextV2FallbackConfig,
+  swapCount: number,
+  currentBundle: ContextBundle | undefined,
+): boolean {
+  if (!failure) return false;
+  if (!fallbackConfig.enabled) return false;
+  if (!currentBundle) return false;
+  if (swapCount >= fallbackConfig.maxHopsPerStory) return false;
+  if (failure.category === "availability") return true;
+  return fallbackConfig.onQualityFailure;
+}
+
+/**
+ * Rebuild the context bundle for a new agent after an availability failure.
+ *
+ * Delegates to ContextOrchestrator.rebuildForAgent() which:
+ * - Re-renders prior.chunks without fetching providers (≤100ms)
+ * - Injects a failure-note chunk so the new agent sees why it took over
+ * - Stamps manifest.rebuildInfo with priorAgentId/newAgentId/failure
+ * - Strips pull tools when the new agent's profile lacks supportsToolCalls
+ */
+export function rebuildForSwap(prior: ContextBundle, newAgentId: string, failure: AdapterFailure): ContextBundle {
+  return _agentSwapDeps.rebuildForAgent(prior, { newAgentId, failure });
+}

--- a/src/execution/escalation/index.ts
+++ b/src/execution/escalation/index.ts
@@ -11,3 +11,9 @@ export {
   type EscalationHandlerContext,
   type EscalationHandlerResult,
 } from "./tier-escalation";
+export {
+  resolveSwapTarget,
+  shouldAttemptSwap,
+  rebuildForSwap,
+  _agentSwapDeps,
+} from "./agent-swap";

--- a/src/pipeline/stages/execution-helpers.ts
+++ b/src/pipeline/stages/execution-helpers.ts
@@ -1,0 +1,81 @@
+/**
+ * Execution Stage — pure helper functions.
+ * Extracted to keep execution.ts under the 400-line limit.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { FailureCategory } from "../../tdd";
+import type { PipelineContext, StageResult } from "../types";
+
+/**
+ * Resolve the effective working directory for a story.
+ * When story.workdir is set, returns join(repoRoot, story.workdir).
+ * Otherwise returns the repo root unchanged.
+ *
+ * MW-001 runtime check: throws if the resolved workdir does not exist on disk.
+ */
+export function resolveStoryWorkdir(repoRoot: string, storyWorkdir?: string): string {
+  if (!storyWorkdir) return repoRoot;
+  const resolved = join(repoRoot, storyWorkdir);
+  if (!existsSync(resolved)) {
+    throw new Error(`[execution] story.workdir "${storyWorkdir}" does not exist at "${resolved}"`);
+  }
+  return resolved;
+}
+
+/**
+ * Detect if agent output contains ambiguity signals.
+ * Checks for keywords that indicate the agent is unsure about the implementation.
+ */
+export function isAmbiguousOutput(output: string): boolean {
+  if (!output) return false;
+  const ambiguityKeywords = [
+    "unclear",
+    "ambiguous",
+    "need clarification",
+    "please clarify",
+    "which one",
+    "not sure which",
+  ];
+  const lowerOutput = output.toLowerCase();
+  return ambiguityKeywords.some((keyword) => lowerOutput.includes(keyword));
+}
+
+/**
+ * Determine the pipeline action for a failed TDD result, based on its failureCategory.
+ *
+ * Pure routing function — mutates only ctx.retryAsLite when needed.
+ * Exported for unit testing.
+ */
+export function routeTddFailure(
+  failureCategory: FailureCategory | undefined,
+  isLiteMode: boolean,
+  ctx: Pick<PipelineContext, "retryAsLite">,
+  reviewReason?: string,
+): StageResult {
+  if (failureCategory === "isolation-violation") {
+    if (!isLiteMode) {
+      ctx.retryAsLite = true;
+    }
+    return { action: "escalate" };
+  }
+
+  if (
+    failureCategory === "session-failure" ||
+    failureCategory === "tests-failing" ||
+    failureCategory === "verifier-rejected"
+  ) {
+    return { action: "escalate" };
+  }
+
+  // S5: greenfield-no-tests → escalate so tier-escalation can switch to test-after
+  if (failureCategory === "greenfield-no-tests") {
+    return { action: "escalate" };
+  }
+
+  return {
+    action: "pause",
+    reason: reviewReason || "Three-session TDD requires review",
+  };
+}

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -3,128 +3,24 @@
  *
  * Spawns the agent session(s) to execute the story/stories.
  * Handles both single-session (test-after) and three-session TDD.
- *
- * @returns
- * - `continue`: Agent session succeeded
- * - `fail`: Agent not found or prompt missing
- * - `escalate`: Agent session failed (will retry with higher tier)
- * - `pause`: Three-session TDD fallback (backward compatible, no failureCategory)
- *
- * TDD failure routing by failureCategory:
- * - `isolation-violation` (strict mode) → escalate + ctx.retryAsLite=true
- * - `isolation-violation` (lite mode)   → escalate
- * - `session-failure`                   → escalate
- * - `tests-failing`                     → escalate
- * - `verifier-rejected`                 → escalate
- * - `greenfield-no-tests`               → escalate (tier-escalation switches to test-after)
- * - no category / unknown               → pause (backward compatible)
- *
- * @example
- * ```ts
- * // Single session (test-after)
- * await executionStage.execute(ctx);
- * // ctx.agentResult: { success: true, estimatedCost: 0.05, ... }
- *
- * // Three-session TDD
- * await executionStage.execute(ctx);
- * // ctx.agentResult: { success: true, estimatedCost: 0.15, ... }
- * ```
+ * On availability failure, attempts agent-swap (Phase 5.5) before tier escalation.
  */
 
-import { existsSync } from "node:fs";
-import { join } from "node:path";
 import { getAgent, validateAgentForTier } from "../../agents";
 import { resolveModelForAgent } from "../../config";
 import { resolvePermissions } from "../../config/permissions";
 import { createContextToolRuntime } from "../../context/engine";
+import { rebuildForSwap, resolveSwapTarget, shouldAttemptSwap } from "../../execution/escalation/agent-swap";
 import { buildInteractionBridge } from "../../interaction/bridge-builder";
 import { checkMergeConflict, checkStoryAmbiguity, isTriggerEnabled } from "../../interaction/triggers";
 import { getLogger } from "../../logger";
-import type { FailureCategory } from "../../tdd";
 import { runThreeSessionTddFromCtx } from "../../tdd";
 import { autoCommitIfDirty, detectMergeConflict } from "../../utils/git";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
+import { isAmbiguousOutput, routeTddFailure } from "./execution-helpers";
 
-/**
- * Resolve the effective working directory for a story.
- * When story.workdir is set, returns join(repoRoot, story.workdir).
- * Otherwise returns the repo root unchanged.
- *
- * MW-001 runtime check: throws if the resolved workdir does not exist on disk.
- */
-export function resolveStoryWorkdir(repoRoot: string, storyWorkdir?: string): string {
-  if (!storyWorkdir) return repoRoot;
-  const resolved = join(repoRoot, storyWorkdir);
-  if (!existsSync(resolved)) {
-    throw new Error(`[execution] story.workdir "${storyWorkdir}" does not exist at "${resolved}"`);
-  }
-  return resolved;
-}
-
-/**
- * Detect if agent output contains ambiguity signals
- * Checks for keywords that indicate the agent is unsure about the implementation
- */
-export function isAmbiguousOutput(output: string): boolean {
-  if (!output) return false;
-
-  const ambiguityKeywords = [
-    "unclear",
-    "ambiguous",
-    "need clarification",
-    "please clarify",
-    "which one",
-    "not sure which",
-  ];
-
-  const lowerOutput = output.toLowerCase();
-  return ambiguityKeywords.some((keyword) => lowerOutput.includes(keyword));
-}
-
-/**
- * Determine the pipeline action for a failed TDD result, based on its failureCategory.
- *
- * This is a pure routing function — it mutates only `ctx.retryAsLite` when needed.
- * Exported for unit testing.
- *
- * @param failureCategory  - Category set by the TDD orchestrator (or undefined)
- * @param isLiteMode       - Whether the story was running in tdd-lite mode
- * @param ctx              - Pipeline context (mutated: ctx.retryAsLite may be set)
- * @param reviewReason     - Human-readable reason string from the TDD result
- */
-export function routeTddFailure(
-  failureCategory: FailureCategory | undefined,
-  isLiteMode: boolean,
-  ctx: Pick<PipelineContext, "retryAsLite">,
-  reviewReason?: string,
-): StageResult {
-  if (failureCategory === "isolation-violation") {
-    // Strict mode: request a lite-mode retry on next attempt
-    if (!isLiteMode) {
-      ctx.retryAsLite = true;
-    }
-    return { action: "escalate" };
-  }
-
-  if (
-    failureCategory === "session-failure" ||
-    failureCategory === "tests-failing" ||
-    failureCategory === "verifier-rejected"
-  ) {
-    return { action: "escalate" };
-  }
-
-  // S5: greenfield-no-tests → escalate so tier-escalation can switch to test-after
-  if (failureCategory === "greenfield-no-tests") {
-    return { action: "escalate" };
-  }
-
-  // Default: no category or unknown — backward-compatible pause for human review
-  return {
-    action: "pause",
-    reason: reviewReason || "Three-session TDD requires review",
-  };
-}
+// Re-export helpers so existing importers continue to work.
+export { isAmbiguousOutput, resolveStoryWorkdir, routeTddFailure } from "./execution-helpers";
 
 export const executionStage: PipelineStage = {
   name: "execution",
@@ -349,6 +245,81 @@ export const executionStage: PipelineStage = {
     }
 
     if (!result.success) {
+      // Phase 5.5: agent-swap on availability failure, before tier escalation
+      const fallbackConfig = ctx.config.context?.v2?.fallback;
+      const { adapterFailure } = result;
+      if (
+        fallbackConfig &&
+        adapterFailure &&
+        _executionDeps.shouldAttemptSwap(adapterFailure, fallbackConfig, ctx.agentSwapCount ?? 0, ctx.contextBundle)
+      ) {
+        const currentAgentId = ctx.routing.agent ?? ctx.rootConfig.autoMode.defaultAgent;
+        const swapTarget = _executionDeps.resolveSwapTarget(
+          currentAgentId,
+          fallbackConfig.map,
+          ctx.agentSwapCount ?? 0,
+        );
+        const swapAgent = swapTarget ? (ctx.agentGetFn ?? _executionDeps.getAgent)(swapTarget) : null;
+        if (swapAgent && swapTarget && ctx.contextBundle) {
+          ctx.contextBundle = _executionDeps.rebuildForSwap(ctx.contextBundle, swapTarget, adapterFailure);
+          ctx.agentSwapCount = (ctx.agentSwapCount ?? 0) + 1;
+          logger.info("execution", "Agent-swap triggered", {
+            storyId: ctx.story.id,
+            fromAgent: currentAgentId,
+            toAgent: swapTarget,
+            failureOutcome: result.adapterFailure?.outcome,
+          });
+          const swapResult = await swapAgent.run({
+            prompt: ctx.prompt,
+            workdir: ctx.workdir,
+            modelTier: effectiveTier,
+            modelDef: resolveModelForAgent(
+              ctx.rootConfig.models,
+              swapTarget,
+              effectiveTier,
+              ctx.rootConfig.autoMode.defaultAgent,
+            ),
+            timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
+            dangerouslySkipPermissions: resolvePermissions(ctx.config, "run").skipPermissions,
+            pipelineStage: "run",
+            config: ctx.config,
+            projectDir: ctx.projectDir,
+            maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
+            pidRegistry: ctx.pidRegistry,
+            featureName: ctx.prd.feature,
+            storyId: ctx.story.id,
+            sessionRole: "implementer",
+            keepSessionOpen,
+            contextPullTools: ctx.contextBundle.pullTools,
+            contextToolRuntime: createContextToolRuntime({
+              bundle: ctx.contextBundle,
+              story: ctx.story,
+              config: ctx.config,
+              workdir: ctx.workdir,
+              projectDir: ctx.projectDir,
+              runCounter: ctx.contextToolRunCounter,
+            }),
+            interactionBridge: buildInteractionBridge(ctx.interaction, {
+              featureName: ctx.prd.feature,
+              storyId: ctx.story.id,
+              stage: "execution",
+            }),
+          });
+          ctx.agentResult = swapResult;
+          if (swapResult.success) {
+            logger.info("execution", "Agent-swap succeeded", {
+              storyId: ctx.story.id,
+              toAgent: swapTarget,
+            });
+            return { action: "continue" };
+          }
+          logger.warn("execution", "Agent-swap retry also failed — escalating", {
+            storyId: ctx.story.id,
+            toAgent: swapTarget,
+          });
+        }
+      }
+
       logger.error("execution", "Agent session failed", {
         exitCode: result.exitCode,
         stderr: result.stderr || "",
@@ -379,4 +350,7 @@ export const _executionDeps = {
   checkMergeConflict,
   isAmbiguousOutput,
   checkStoryAmbiguity,
+  shouldAttemptSwap,
+  resolveSwapTarget,
+  rebuildForSwap,
 };

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -181,6 +181,12 @@ export interface PipelineContext {
   /** Accumulated cost across all prior escalation attempts (BUG-067) */
   accumulatedAttemptCost?: number;
   /**
+   * Number of agent-swap hops completed for this story (Phase 5.5).
+   * Incremented by executionStage each time rebuildForSwap triggers a new agent.
+   * Checked against config.context.v2.fallback.maxHopsPerStory to cap swaps.
+   */
+  agentSwapCount?: number;
+  /**
    * Set of review check names that already passed in a previous review pass within this
    * pipeline run. When autofix retries from "review", checks in this set are skipped to
    * avoid redundant re-runs (e.g. a 45s semantic check after a lint-only fix). (#136)

--- a/test/integration/execution/agent-swap.test.ts
+++ b/test/integration/execution/agent-swap.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Integration test: agent-swap via execution stage (Issue #474 / Phase 5.5)
+ *
+ * Simulates an availability failure from the primary agent (fail-quota) and
+ * verifies that the execution stage:
+ *   - Calls rebuildForAgent to produce a rebuilt bundle
+ *   - The rebuilt bundle carries rebuildInfo (priorAgentId, newAgentId)
+ *   - A failure-note chunk is present in the rebuilt bundle
+ *   - The retry runs under the new agent
+ *   - Stage returns { action: "continue" } when the swap agent succeeds
+ *   - Stage returns { action: "escalate" } when the swap agent also fails
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ContextOrchestrator } from "../../../src/context/engine/orchestrator";
+import type { AdapterFailure, ContextBundle, ContextProviderResult, IContextProvider } from "../../../src/context/engine/types";
+import { DEFAULT_CONFIG } from "../../../src/config";
+import type { NaxConfig } from "../../../src/config";
+import { executionStage, _executionDeps } from "../../../src/pipeline/stages/execution";
+import type { PipelineContext } from "../../../src/pipeline/types";
+import type { PRD, UserStory } from "../../../src/prd";
+import type { AgentAdapter } from "../../../src/agents/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Saved deps for restoration
+// ─────────────────────────────────────────────────────────────────────────────
+
+const origGetAgent = _executionDeps.getAgent;
+const origValidateAgent = _executionDeps.validateAgentForTier;
+const origDetectMerge = _executionDeps.detectMergeConflict;
+const origShouldSwap = _executionDeps.shouldAttemptSwap;
+const origResolveSwap = _executionDeps.resolveSwapTarget;
+const origRebuildForSwap = _executionDeps.rebuildForSwap;
+
+afterEach(() => {
+  _executionDeps.getAgent = origGetAgent;
+  _executionDeps.validateAgentForTier = origValidateAgent;
+  _executionDeps.detectMergeConflict = origDetectMerge;
+  _executionDeps.shouldAttemptSwap = origShouldSwap;
+  _executionDeps.resolveSwapTarget = origResolveSwap;
+  _executionDeps.rebuildForSwap = origRebuildForSwap;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const QUOTA_FAILURE: AdapterFailure = {
+  category: "availability",
+  outcome: "fail-quota",
+  message: "daily quota exhausted",
+  retriable: false,
+};
+
+function makeProvider(): IContextProvider {
+  const result: ContextProviderResult = {
+    chunks: [
+      {
+        id: "chunk:abc",
+        kind: "feature",
+        scope: "project",
+        role: ["all"],
+        content: "Feature rule: use async/await.",
+        tokens: 20,
+        rawScore: 0.8,
+      },
+    ],
+  };
+  return { id: "p1", kind: "feature", fetch: async () => result };
+}
+
+async function makeBundle(): Promise<ContextBundle> {
+  const orch = new ContextOrchestrator([makeProvider()]);
+  return orch.assemble({
+    storyId: "US-001",
+    workdir: "/repo",
+    stage: "run",
+    role: "implementer",
+    budgetTokens: 8_000,
+    providerIds: [],
+    agentId: "claude",
+  });
+}
+
+function makeStory(): UserStory {
+  return {
+    id: "US-001",
+    title: "Test Story",
+    description: "Test",
+    acceptanceCriteria: [],
+    tags: [],
+    dependencies: [],
+    status: "in-progress",
+    passes: false,
+    escalations: [],
+    attempts: 1,
+  };
+}
+
+function makePRD(): PRD {
+  return {
+    project: "test",
+    feature: "my-feature",
+    branchName: "test-branch",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    userStories: [makeStory()],
+  };
+}
+
+function makeConfig(swapEnabled: boolean): NaxConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    autoMode: { defaultAgent: "claude" },
+    models: {
+      claude: { fast: "claude-haiku-4-5", balanced: "claude-sonnet-4-5", powerful: "claude-opus-4-5" },
+      codex: { fast: "codex-fast", balanced: "codex-balanced", powerful: "codex-powerful" },
+    },
+    context: {
+      ...DEFAULT_CONFIG.context,
+      v2: {
+        ...DEFAULT_CONFIG.context.v2,
+        fallback: {
+          enabled: swapEnabled,
+          onQualityFailure: false,
+          maxHopsPerStory: 1,
+          map: { claude: ["codex"] },
+        },
+      },
+    },
+  } as unknown as NaxConfig;
+}
+
+function makeCtx(config: NaxConfig, bundle: ContextBundle): PipelineContext {
+  return {
+    config,
+    prd: makePRD(),
+    story: makeStory(),
+    stories: [makeStory()],
+    routing: {
+      complexity: "simple",
+      modelTier: "fast",
+      testStrategy: "test-after",
+      agent: "claude",
+      reasoning: "",
+    },
+    rootConfig: { ...DEFAULT_CONFIG, autoMode: { defaultAgent: "claude" }, models: config.models } as unknown as NaxConfig,
+    workdir: "/tmp/test",
+    projectDir: "/tmp/test",
+    prompt: "Do something useful",
+    hooks: {} as PipelineContext["hooks"],
+    contextBundle: bundle,
+  } as unknown as PipelineContext;
+}
+
+function makeFailingAgent(name: string): AgentAdapter {
+  return {
+    name,
+    capabilities: { supportedTiers: ["fast", "balanced", "powerful"] },
+    run: mock(async () => ({
+      success: false,
+      exitCode: 1,
+      output: "",
+      stderr: "quota exceeded",
+      rateLimited: false,
+      durationMs: 100,
+      estimatedCost: 0.0,
+      adapterFailure: QUOTA_FAILURE,
+    })),
+    closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
+    deriveSessionName: mock(() => `nax-session-${name}`),
+  } as unknown as AgentAdapter;
+}
+
+function makeSucceedingAgent(name: string): AgentAdapter {
+  return {
+    name,
+    capabilities: { supportedTiers: ["fast", "balanced", "powerful"] },
+    run: mock(async () => ({
+      success: true,
+      exitCode: 0,
+      output: "done",
+      stderr: "",
+      rateLimited: false,
+      durationMs: 200,
+      estimatedCost: 0.02,
+    })),
+    closeSession: mock(async () => {}),
+    closePhysicalSession: mock(async () => {}),
+    deriveSessionName: mock(() => `nax-session-${name}`),
+  } as unknown as AgentAdapter;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("execution stage — agent-swap on availability failure (Phase 5.5)", () => {
+  let bundle: ContextBundle;
+
+  beforeEach(async () => {
+    bundle = await makeBundle();
+    _executionDeps.validateAgentForTier = mock(() => true);
+    _executionDeps.detectMergeConflict = mock(() => false);
+  });
+
+  test("swaps agent and returns continue when swap agent succeeds", async () => {
+    const primaryAgent = makeFailingAgent("claude");
+    const swapAgent = makeSucceedingAgent("codex");
+    const config = makeConfig(true);
+    const ctx = makeCtx(config, bundle);
+
+    _executionDeps.getAgent = mock((name: string) => (name === "codex" ? swapAgent : primaryAgent));
+    ctx.agentGetFn = (name: string) => (name === "codex" ? swapAgent : primaryAgent) as AgentAdapter;
+
+    const result = await executionStage.execute(ctx);
+
+    expect(result).toEqual({ action: "continue" });
+    expect(ctx.agentSwapCount).toBe(1);
+    // Swap agent ran
+    expect((swapAgent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+  });
+
+  test("rebuilt bundle carries rebuildInfo with correct agents and failure", async () => {
+    const primaryAgent = makeFailingAgent("claude");
+    const swapAgent = makeSucceedingAgent("codex");
+    const config = makeConfig(true);
+    const ctx = makeCtx(config, bundle);
+
+    _executionDeps.getAgent = mock((name: string) => (name === "codex" ? swapAgent : primaryAgent));
+    ctx.agentGetFn = (name: string) => (name === "codex" ? swapAgent : primaryAgent) as AgentAdapter;
+
+    await executionStage.execute(ctx);
+
+    const rebuildInfo = ctx.contextBundle?.manifest.rebuildInfo;
+    expect(rebuildInfo).toBeDefined();
+    expect(rebuildInfo?.priorAgentId).toBe("claude");
+    expect(rebuildInfo?.newAgentId).toBe("codex");
+    expect(rebuildInfo?.failureCategory).toBe("availability");
+    expect(rebuildInfo?.failureOutcome).toBe("fail-quota");
+  });
+
+  test("rebuilt bundle contains a failure-note chunk", async () => {
+    const primaryAgent = makeFailingAgent("claude");
+    const swapAgent = makeSucceedingAgent("codex");
+    const config = makeConfig(true);
+    const ctx = makeCtx(config, bundle);
+
+    _executionDeps.getAgent = mock((name: string) => (name === "codex" ? swapAgent : primaryAgent));
+    ctx.agentGetFn = (name: string) => (name === "codex" ? swapAgent : primaryAgent) as AgentAdapter;
+
+    await executionStage.execute(ctx);
+
+    const failureChunk = ctx.contextBundle?.chunks.find((c) => c.id.startsWith("failure-note:"));
+    expect(failureChunk).toBeDefined();
+    expect(failureChunk?.kind).toBe("session");
+  });
+
+  test("escalates when swap is disabled in config", async () => {
+    const primaryAgent = makeFailingAgent("claude");
+    const config = makeConfig(false); // disabled
+    const ctx = makeCtx(config, bundle);
+
+    _executionDeps.getAgent = mock(() => primaryAgent);
+    ctx.agentGetFn = () => primaryAgent as AgentAdapter;
+
+    const result = await executionStage.execute(ctx);
+
+    expect(result).toEqual({ action: "escalate" });
+    expect(ctx.agentSwapCount).toBeUndefined();
+  });
+
+  test("escalates when swap agent also fails", async () => {
+    const primaryAgent = makeFailingAgent("claude");
+    const swapAgent = makeFailingAgent("codex");
+    const config = makeConfig(true);
+    const ctx = makeCtx(config, bundle);
+
+    _executionDeps.getAgent = mock((name: string) => (name === "codex" ? swapAgent : primaryAgent));
+    ctx.agentGetFn = (name: string) => (name === "codex" ? swapAgent : primaryAgent) as AgentAdapter;
+
+    const result = await executionStage.execute(ctx);
+
+    expect(result).toEqual({ action: "escalate" });
+    expect(ctx.agentSwapCount).toBe(1);
+    expect((swapAgent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+  });
+
+  test("does not swap when no context bundle exists", async () => {
+    const primaryAgent = makeFailingAgent("claude");
+    const config = makeConfig(true);
+    const ctx = makeCtx(config, bundle);
+    ctx.contextBundle = undefined; // no bundle
+
+    _executionDeps.getAgent = mock(() => primaryAgent);
+    ctx.agentGetFn = () => primaryAgent as AgentAdapter;
+
+    const result = await executionStage.execute(ctx);
+
+    expect(result).toEqual({ action: "escalate" });
+    expect(ctx.agentSwapCount).toBeUndefined();
+  });
+
+  test("respects maxHopsPerStory cap — does not swap when already at limit", async () => {
+    const primaryAgent = makeFailingAgent("claude");
+    const config = makeConfig(true);
+    const ctx = makeCtx(config, bundle);
+    ctx.agentSwapCount = 1; // already used the one allowed hop
+
+    _executionDeps.getAgent = mock(() => primaryAgent);
+    ctx.agentGetFn = () => primaryAgent as AgentAdapter;
+
+    const result = await executionStage.execute(ctx);
+
+    expect(result).toEqual({ action: "escalate" });
+    expect(ctx.agentSwapCount).toBe(1); // unchanged
+  });
+});

--- a/test/unit/execution/escalation/agent-swap.test.ts
+++ b/test/unit/execution/escalation/agent-swap.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for src/execution/escalation/agent-swap.ts
+ *
+ * Covers: resolveSwapTarget, shouldAttemptSwap, rebuildForSwap
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { ContextOrchestrator } from "../../../../src/context/engine/orchestrator";
+import type {
+  AdapterFailure,
+  ContextBundle,
+  ContextProviderResult,
+  IContextProvider,
+} from "../../../../src/context/engine/types";
+import type { ContextV2FallbackConfig } from "../../../../src/config/runtime-types";
+import {
+  resolveSwapTarget,
+  shouldAttemptSwap,
+  rebuildForSwap,
+  _agentSwapDeps,
+} from "../../../../src/execution/escalation/agent-swap";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const QUOTA_FAILURE: AdapterFailure = {
+  category: "availability",
+  outcome: "fail-quota",
+  message: "Quota exhausted",
+  retriable: false,
+};
+
+const RATE_LIMIT_FAILURE: AdapterFailure = {
+  category: "availability",
+  outcome: "fail-rate-limit",
+  message: "Rate limited",
+  retriable: true,
+  retryAfterSeconds: 60,
+};
+
+const QUALITY_FAILURE: AdapterFailure = {
+  category: "quality",
+  outcome: "fail-timeout",
+  message: "Timed out",
+  retriable: true,
+};
+
+const FALLBACK_CONFIG: ContextV2FallbackConfig = {
+  enabled: true,
+  onQualityFailure: false,
+  maxHopsPerStory: 2,
+  map: { claude: ["codex", "gemini"] },
+};
+
+const DISABLED_CONFIG: ContextV2FallbackConfig = {
+  enabled: false,
+  onQualityFailure: false,
+  maxHopsPerStory: 2,
+  map: { claude: ["codex"] },
+};
+
+function makeProvider(id: string, result: ContextProviderResult): IContextProvider {
+  return { id, kind: "feature", fetch: async () => result };
+}
+
+function makeChunkResult(): ContextProviderResult {
+  return {
+    chunks: [
+      {
+        id: "chunk:abc",
+        kind: "feature",
+        scope: "project",
+        role: ["all"],
+        content: "Feature rule: use async/await.",
+        tokens: 20,
+        rawScore: 0.8,
+      },
+    ],
+  };
+}
+
+async function makeBundle(agentId = "claude"): Promise<ContextBundle> {
+  const orch = new ContextOrchestrator([makeProvider("p1", makeChunkResult())]);
+  return orch.assemble({
+    storyId: "US-001",
+    workdir: "/repo",
+    stage: "run",
+    role: "implementer",
+    budgetTokens: 8_000,
+    providerIds: [],
+    agentId,
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveSwapTarget
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("resolveSwapTarget", () => {
+  test("returns first candidate on first swap (swapCount=0)", () => {
+    expect(resolveSwapTarget("claude", { claude: ["codex", "gemini"] }, 0)).toBe("codex");
+  });
+
+  test("returns second candidate on second swap (swapCount=1)", () => {
+    expect(resolveSwapTarget("claude", { claude: ["codex", "gemini"] }, 1)).toBe("gemini");
+  });
+
+  test("returns null when swapCount exhausts candidates", () => {
+    expect(resolveSwapTarget("claude", { claude: ["codex"] }, 1)).toBeNull();
+  });
+
+  test("returns null when agent has no fallback entry", () => {
+    expect(resolveSwapTarget("codex", { claude: ["codex"] }, 0)).toBeNull();
+  });
+
+  test("returns null for empty candidate list", () => {
+    expect(resolveSwapTarget("claude", { claude: [] }, 0)).toBeNull();
+  });
+
+  test("returns null for empty map", () => {
+    expect(resolveSwapTarget("claude", {}, 0)).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// shouldAttemptSwap
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("shouldAttemptSwap", () => {
+  let bundle: ContextBundle;
+
+  beforeEach(async () => {
+    bundle = await makeBundle();
+  });
+
+  test("returns true for availability failure when enabled and within hops", () => {
+    expect(shouldAttemptSwap(QUOTA_FAILURE, FALLBACK_CONFIG, 0, bundle)).toBe(true);
+  });
+
+  test("returns true for rate-limit failure", () => {
+    expect(shouldAttemptSwap(RATE_LIMIT_FAILURE, FALLBACK_CONFIG, 0, bundle)).toBe(true);
+  });
+
+  test("returns false when config.enabled is false", () => {
+    expect(shouldAttemptSwap(QUOTA_FAILURE, DISABLED_CONFIG, 0, bundle)).toBe(false);
+  });
+
+  test("returns false when no failure", () => {
+    expect(shouldAttemptSwap(undefined, FALLBACK_CONFIG, 0, bundle)).toBe(false);
+  });
+
+  test("returns false when swapCount >= maxHopsPerStory", () => {
+    expect(shouldAttemptSwap(QUOTA_FAILURE, FALLBACK_CONFIG, 2, bundle)).toBe(false);
+  });
+
+  test("returns false for quality failure when onQualityFailure is false", () => {
+    expect(shouldAttemptSwap(QUALITY_FAILURE, FALLBACK_CONFIG, 0, bundle)).toBe(false);
+  });
+
+  test("returns true for quality failure when onQualityFailure is true", () => {
+    const config: ContextV2FallbackConfig = { ...FALLBACK_CONFIG, onQualityFailure: true };
+    expect(shouldAttemptSwap(QUALITY_FAILURE, config, 0, bundle)).toBe(true);
+  });
+
+  test("returns false when no context bundle exists", () => {
+    expect(shouldAttemptSwap(QUOTA_FAILURE, FALLBACK_CONFIG, 0, undefined)).toBe(false);
+  });
+
+  test("returns true when swapCount is one less than maxHopsPerStory", () => {
+    expect(shouldAttemptSwap(QUOTA_FAILURE, FALLBACK_CONFIG, 1, bundle)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// rebuildForSwap
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("rebuildForSwap", () => {
+  let bundle: ContextBundle;
+
+  beforeEach(async () => {
+    bundle = await makeBundle("claude");
+  });
+
+  test("returns a ContextBundle with pushMarkdown and chunks", () => {
+    const result = rebuildForSwap(bundle, "codex", QUOTA_FAILURE);
+    expect(result).toBeDefined();
+    expect(typeof result.pushMarkdown).toBe("string");
+    expect(Array.isArray(result.chunks)).toBe(true);
+  });
+
+  test("result carries rebuildInfo with priorAgentId and newAgentId", () => {
+    const result = rebuildForSwap(bundle, "codex", QUOTA_FAILURE);
+    expect(result.manifest.rebuildInfo).toBeDefined();
+    expect(result.manifest.rebuildInfo?.priorAgentId).toBe("claude");
+    expect(result.manifest.rebuildInfo?.newAgentId).toBe("codex");
+  });
+
+  test("result contains a failure-note chunk (kind=session, id starts with failure-note:)", () => {
+    const result = rebuildForSwap(bundle, "codex", QUOTA_FAILURE);
+    const failureChunk = result.chunks.find((c) => c.id.startsWith("failure-note:"));
+    expect(failureChunk).toBeDefined();
+    expect(failureChunk?.kind).toBe("session");
+  });
+
+  test("rebuildInfo carries failure category and outcome", () => {
+    const result = rebuildForSwap(bundle, "codex", QUOTA_FAILURE);
+    expect(result.manifest.rebuildInfo?.failureCategory).toBe("availability");
+    expect(result.manifest.rebuildInfo?.failureOutcome).toBe("fail-quota");
+  });
+
+  test("result agentId is set to newAgentId", () => {
+    const result = rebuildForSwap(bundle, "codex", QUOTA_FAILURE);
+    expect(result.agentId).toBe("codex");
+  });
+
+  test("uses injectable rebuildForAgent dep", () => {
+    const called: Array<{ prior: ContextBundle; opts: unknown }> = [];
+    const fakeBundle: ContextBundle = { ...bundle, agentId: "codex" };
+    const origRebuild = _agentSwapDeps.rebuildForAgent;
+    _agentSwapDeps.rebuildForAgent = (prior, opts) => {
+      called.push({ prior, opts });
+      return fakeBundle;
+    };
+
+    const result = rebuildForSwap(bundle, "codex", QUOTA_FAILURE);
+
+    _agentSwapDeps.rebuildForAgent = origRebuild;
+    expect(called).toHaveLength(1);
+    expect(called[0]!.opts).toMatchObject({ newAgentId: "codex", failure: QUOTA_FAILURE });
+    expect(result).toBe(fakeBundle);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements Phase 5.5 (Issue #474): when primary agent hits an availability failure (quota/auth/rate-limit), swap to next agent in `context.v2.fallback.map`, rebuild context bundle with `rebuildForAgent()`, and retry
- `rebuildForAgent()` injects a failure-note chunk so the new agent sees why it took over, stamps `manifest.rebuildInfo` with `priorAgentId`/`newAgentId`/`failureCategory`/`failureOutcome`
- Per-story hop cap enforced via `PipelineContext.agentSwapCount` + `maxHopsPerStory`
- Removes "library-only today" warning from `ContextOrchestrator.rebuildForAgent` docstring

## Changes

- `src/execution/escalation/agent-swap.ts` — new: `resolveSwapTarget`, `shouldAttemptSwap`, `rebuildForSwap` (pure functions, injectable `_deps`)
- `src/pipeline/stages/execution-helpers.ts` — new: extracted helpers from execution.ts to stay under 400-line limit
- `src/pipeline/stages/execution.ts` — wire agent-swap block in failure path; update `_executionDeps`
- `src/pipeline/types.ts` — add `agentSwapCount?: number` to PipelineContext
- `src/execution/escalation/index.ts` — export new swap functions
- `src/context/engine/orchestrator.ts` — update docstring

## Test plan

- [ ] `bun test test/unit/execution/escalation/agent-swap.test.ts` — 21 unit tests
- [ ] `bun test test/integration/execution/agent-swap.test.ts` — 7 integration tests (swap succeed, rebuildInfo fields, failure-note chunk, swap disabled, swap agent fails, no bundle, hop cap)
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `bun run test` — full suite passes