### PR TITLE
fix(context-engine): address code review findings for #474 agent-swap

### DIFF
--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -366,12 +366,13 @@ export class ContextOrchestrator {
    * @param options - optional: newAgentId, failure (for agent-swap), priorStageDigest
    */
   rebuildForAgent(prior: ContextBundle, options: RebuildOptions = {}): ContextBundle {
-    const { newAgentId, failure, priorStageDigest } = options;
+    const { newAgentId, failure, priorStageDigest, storyId } = options;
     const targetAgentId = newAgentId ?? prior.agentId ?? DEFAULT_REBUILD_AGENT_ID;
     const logger = getLogger();
 
     if (newAgentId && !AGENT_PROFILES[newAgentId]) {
       logger.warn("context-v2", "rebuildForAgent: unknown agent id — using conservative defaults", {
+        ...(storyId && { storyId }),
         stage: prior.manifest.stage,
         agentId: newAgentId,
       });

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -243,6 +243,8 @@ export interface RebuildOptions {
   failure?: AdapterFailure;
   /** Digest from the prior pipeline stage (optional preamble) */
   priorStageDigest?: string;
+  /** Story id for log correlation — passed through to orchestrator warn logs */
+  storyId?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/execution/escalation/agent-swap.ts
+++ b/src/execution/escalation/agent-swap.ts
@@ -15,8 +15,12 @@ import type { AdapterFailure, ContextBundle } from "../../context/engine/types";
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const _agentSwapDeps = {
-  rebuildForAgent: (prior: ContextBundle, opts: { newAgentId?: string; failure?: AdapterFailure }): ContextBundle =>
-    new ContextOrchestrator([]).rebuildForAgent(prior, opts),
+  // Empty providers array is intentional and safe: rebuildForAgent() re-renders
+  // prior.chunks without fetching any providers — no provider calls are made.
+  rebuildForAgent: (
+    prior: ContextBundle,
+    opts: { newAgentId?: string; failure?: AdapterFailure; storyId?: string },
+  ): ContextBundle => new ContextOrchestrator([]).rebuildForAgent(prior, opts),
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -74,6 +78,11 @@ export function shouldAttemptSwap(
  * - Stamps manifest.rebuildInfo with priorAgentId/newAgentId/failure
  * - Strips pull tools when the new agent's profile lacks supportsToolCalls
  */
-export function rebuildForSwap(prior: ContextBundle, newAgentId: string, failure: AdapterFailure): ContextBundle {
-  return _agentSwapDeps.rebuildForAgent(prior, { newAgentId, failure });
+export function rebuildForSwap(
+  prior: ContextBundle,
+  newAgentId: string,
+  failure: AdapterFailure,
+  storyId?: string,
+): ContextBundle {
+  return _agentSwapDeps.rebuildForAgent(prior, { newAgentId, failure, storyId });
 }

--- a/src/pipeline/stages/execution-helpers.ts
+++ b/src/pipeline/stages/execution-helpers.ts
@@ -5,6 +5,7 @@
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { NaxError } from "../../errors";
 import type { FailureCategory } from "../../tdd";
 import type { PipelineContext, StageResult } from "../types";
 
@@ -19,7 +20,11 @@ export function resolveStoryWorkdir(repoRoot: string, storyWorkdir?: string): st
   if (!storyWorkdir) return repoRoot;
   const resolved = join(repoRoot, storyWorkdir);
   if (!existsSync(resolved)) {
-    throw new Error(`[execution] story.workdir "${storyWorkdir}" does not exist at "${resolved}"`);
+    throw new NaxError(
+      `[execution] story.workdir "${storyWorkdir}" does not exist at "${resolved}"`,
+      "WORKDIR_NOT_FOUND",
+      { stage: "execution", storyWorkdir, resolved },
+    );
   }
   return resolved;
 }

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -261,7 +261,13 @@ export const executionStage: PipelineStage = {
         );
         const swapAgent = swapTarget ? (ctx.agentGetFn ?? _executionDeps.getAgent)(swapTarget) : null;
         if (swapAgent && swapTarget && ctx.contextBundle) {
-          ctx.contextBundle = _executionDeps.rebuildForSwap(ctx.contextBundle, swapTarget, adapterFailure);
+          const originalBundle = ctx.contextBundle;
+          ctx.contextBundle = _executionDeps.rebuildForSwap(
+            ctx.contextBundle,
+            swapTarget,
+            adapterFailure,
+            ctx.story.id,
+          );
           ctx.agentSwapCount = (ctx.agentSwapCount ?? 0) + 1;
           logger.info("execution", "Agent-swap triggered", {
             storyId: ctx.story.id,
@@ -313,6 +319,7 @@ export const executionStage: PipelineStage = {
             });
             return { action: "continue" };
           }
+          ctx.contextBundle = originalBundle;
           logger.warn("execution", "Agent-swap retry also failed — escalating", {
             storyId: ctx.story.id,
             toAgent: swapTarget,
@@ -321,10 +328,10 @@ export const executionStage: PipelineStage = {
       }
 
       logger.error("execution", "Agent session failed", {
+        storyId: ctx.story.id,
         exitCode: result.exitCode,
         stderr: result.stderr || "",
         rateLimited: result.rateLimited,
-        storyId: ctx.story.id,
       });
       if (result.rateLimited) {
         logger.warn("execution", "Rate limited — will retry", { storyId: ctx.story.id });

--- a/test/integration/execution/agent-swap.test.ts
+++ b/test/integration/execution/agent-swap.test.ts
@@ -20,6 +20,7 @@ import { executionStage, _executionDeps } from "../../../src/pipeline/stages/exe
 import type { PipelineContext } from "../../../src/pipeline/types";
 import type { PRD, UserStory } from "../../../src/prd";
 import type { AgentAdapter } from "../../../src/agents/types";
+import { _gitDeps } from "../../../src/utils/git";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Saved deps for restoration
@@ -31,6 +32,7 @@ const origDetectMerge = _executionDeps.detectMergeConflict;
 const origShouldSwap = _executionDeps.shouldAttemptSwap;
 const origResolveSwap = _executionDeps.resolveSwapTarget;
 const origRebuildForSwap = _executionDeps.rebuildForSwap;
+const origGitSpawn = _gitDeps.spawn;
 
 afterEach(() => {
   _executionDeps.getAgent = origGetAgent;
@@ -39,6 +41,7 @@ afterEach(() => {
   _executionDeps.shouldAttemptSwap = origShouldSwap;
   _executionDeps.resolveSwapTarget = origResolveSwap;
   _executionDeps.rebuildForSwap = origRebuildForSwap;
+  _gitDeps.spawn = origGitSpawn;
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -203,6 +206,8 @@ describe("execution stage — agent-swap on availability failure (Phase 5.5)", (
     bundle = await makeBundle();
     _executionDeps.validateAgentForTier = mock(() => true);
     _executionDeps.detectMergeConflict = mock(() => false);
+    // Prevent autoCommitIfDirty from spawning real git processes against /tmp/test
+    _gitDeps.spawn = mock(() => ({ exited: Promise.resolve(1), stdout: null, stderr: null } as unknown as ReturnType<typeof Bun.spawn>));
   });
 
   test("swaps agent and returns continue when swap agent succeeds", async () => {

--- a/test/unit/execution/escalation/agent-swap.test.ts
+++ b/test/unit/execution/escalation/agent-swap.test.ts
@@ -178,9 +178,15 @@ describe("shouldAttemptSwap", () => {
 
 describe("rebuildForSwap", () => {
   let bundle: ContextBundle;
+  let origRebuildForAgent: typeof _agentSwapDeps.rebuildForAgent;
 
   beforeEach(async () => {
     bundle = await makeBundle("claude");
+    origRebuildForAgent = _agentSwapDeps.rebuildForAgent;
+  });
+
+  afterEach(() => {
+    _agentSwapDeps.rebuildForAgent = origRebuildForAgent;
   });
 
   test("returns a ContextBundle with pushMarkdown and chunks", () => {
@@ -199,7 +205,7 @@ describe("rebuildForSwap", () => {
 
   test("result contains a failure-note chunk (kind=session, id starts with failure-note:)", () => {
     const result = rebuildForSwap(bundle, "codex", QUOTA_FAILURE);
-    const failureChunk = result.chunks.find((c) => c.id.startsWith("failure-note:"));
+    const failureChunk = result.chunks.find((c: { id: string }) => c.id.startsWith("failure-note:"));
     expect(failureChunk).toBeDefined();
     expect(failureChunk?.kind).toBe("session");
   });
@@ -218,15 +224,13 @@ describe("rebuildForSwap", () => {
   test("uses injectable rebuildForAgent dep", () => {
     const called: Array<{ prior: ContextBundle; opts: unknown }> = [];
     const fakeBundle: ContextBundle = { ...bundle, agentId: "codex" };
-    const origRebuild = _agentSwapDeps.rebuildForAgent;
-    _agentSwapDeps.rebuildForAgent = (prior, opts) => {
+    _agentSwapDeps.rebuildForAgent = (prior: ContextBundle, opts: { newAgentId?: string; failure?: AdapterFailure }) => {
       called.push({ prior, opts });
       return fakeBundle;
     };
 
     const result = rebuildForSwap(bundle, "codex", QUOTA_FAILURE);
 
-    _agentSwapDeps.rebuildForAgent = origRebuild;
     expect(called).toHaveLength(1);
     expect(called[0]!.opts).toMatchObject({ newAgentId: "codex", failure: QUOTA_FAILURE });
     expect(result).toBe(fakeBundle);


### PR DESCRIPTION
## Summary

Addresses 7 findings from post-merge code review of #486 (Phase 5.5 agent-swap).

- **C1** `execution-helpers.ts:22` — throw `NaxError("WORKDIR_NOT_FOUND")` instead of plain `Error`
- **C2** `execution.ts:323` — move `storyId` to first key in `logger.error` data object (parallel log correlation)
- **C3** `execution.ts:264` — save `originalBundle` before swap, restore it when swap agent also fails so tier-escalation retries start with the original bundle, not the failure-note-injected one
- **I4** `agent-swap.ts:18` — add comment explaining why `new ContextOrchestrator([])` empty providers array is intentionally safe
- **I5** `agent-swap.test.ts` (integration) — mock `_gitDeps.spawn` in `beforeEach` to prevent real git spawns from `autoCommitIfDirty` against non-git `/tmp/test` workdir
- **I6** `agent-swap.test.ts` (unit) — move inline `_agentSwapDeps.rebuildForAgent` restore to `afterEach` so dep leak cannot occur when test throws before the restore line
- **I7** `RebuildOptions` / `rebuildForSwap` — add `storyId?: string` so orchestrator warn logs include `storyId` for parallel-run log correlation

## Test plan

- [ ] `bun test test/unit/execution/escalation/agent-swap.test.ts test/integration/execution/agent-swap.test.ts` — 28 pass, 0 fail
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `bun run test` — 1184 pass, 39 skip, 0 fail