### PR TITLE
feat(context-engine): Amendment C AC-54/AC-60/AC-61 — dual workdir fields (repoRoot + packageDir)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,14 +1,15 @@
 # Bun Test Configuration
 
 [test]
+smol = true
+root = "./test"
 # Global test timeout: 30 seconds per test (unit/integration)
 # This prevents individual tests from hanging indefinitely
-timeout = 30000
+timeout = 5000
 
 # Preload: runs before any test file — clears env vars inherited from the nax harness
 preload = ["./test/preload.ts"]
 
 # Exclude nax dogfood feature directories (contain acceptance tests from nax runs, not source tests)
-exclude = ["nax/**"]
-
-concurrent = 1
+exclude = [".nax/**"]
+AGENT = 1

--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -328,6 +328,8 @@ export class ContextOrchestrator {
       digestTokens: dTokens,
       buildMs,
       providerResults,
+      repoRoot: request.repoRoot,
+      packageDir: request.packageDir,
     };
 
     logger.debug("context-v2", "Bundle assembled", {

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -192,7 +192,10 @@ export class CodeNeighborProvider implements IContextProvider {
   readonly kind = "neighbor" as const;
 
   async fetch(request: ContextRequest): Promise<ContextProviderResult> {
-    const { touchedFiles, workdir } = request;
+    const { touchedFiles } = request;
+    // AC-56 (future): use request.packageDir for package-scoped neighbor tracing.
+    // For now, default to repoRoot to preserve existing behavior.
+    const workdir = request.repoRoot;
     if (!touchedFiles || touchedFiles.length === 0) {
       return { chunks: [], pullTools: [] };
     }

--- a/src/context/engine/providers/feature-context.ts
+++ b/src/context/engine/providers/feature-context.ts
@@ -66,7 +66,7 @@ export class FeatureContextProviderV2 implements IContextProvider {
 
     try {
       const v1 = _featureContextV2Deps.createV1Provider();
-      const result = await v1.getContext(this.story, request.projectDir ?? request.workdir, this.config);
+      const result = await v1.getContext(this.story, request.repoRoot, this.config);
       if (!result) {
         return { chunks: [], pullTools: [] };
       }

--- a/src/context/engine/providers/git-history.ts
+++ b/src/context/engine/providers/git-history.ts
@@ -76,7 +76,10 @@ export class GitHistoryProvider implements IContextProvider {
   readonly kind = "history" as const;
 
   async fetch(request: ContextRequest): Promise<ContextProviderResult> {
-    const { touchedFiles, workdir } = request;
+    const { touchedFiles } = request;
+    // AC-55 (future): use request.packageDir for package-scoped git history.
+    // For now, default to repoRoot to preserve existing behavior.
+    const workdir = request.repoRoot;
     if (!touchedFiles || touchedFiles.length === 0) {
       return { chunks: [], pullTools: [] };
     }

--- a/src/context/engine/providers/static-rules.ts
+++ b/src/context/engine/providers/static-rules.ts
@@ -84,7 +84,7 @@ export class StaticRulesProvider implements IContextProvider {
 
     // Phase 5.1: try canonical store first
     try {
-      const canonicalRules = await _staticRulesDeps.loadCanonicalRules(request.projectDir ?? request.workdir);
+      const canonicalRules = await _staticRulesDeps.loadCanonicalRules(request.repoRoot);
       if (canonicalRules.length > 0) {
         const chunks = canonicalRules.map((rule) => {
           const hash = contentHash8(rule.content);
@@ -145,7 +145,7 @@ export class StaticRulesProvider implements IContextProvider {
   private async fetchLegacy(request: ContextRequest): Promise<ContextProviderResult> {
     const logger = getLogger();
     const chunks: RawChunk[] = [];
-    const rootDir = request.projectDir ?? request.workdir;
+    const rootDir = request.repoRoot;
 
     // Detect multiple candidates so operators know which one was chosen when more than one exists.
     const existingCandidates: string[] = [];

--- a/src/context/engine/pull-tools.ts
+++ b/src/context/engine/pull-tools.ts
@@ -199,18 +199,17 @@ export class PullToolBudget {
  */
 export async function handleQueryNeighbor(
   input: { filePath: string; depth?: number },
-  workdir: string,
+  repoRoot: string,
   budget: PullToolBudget,
   maxTokensPerCall: number = DEFAULT_MAX_TOKENS_PER_CALL,
-  projectDir?: string,
 ): Promise<string> {
   budget.consume();
 
   const provider = new CodeNeighborProvider();
   const request: ContextRequest = {
     storyId: "_pull-tool",
-    workdir,
-    projectDir,
+    repoRoot,
+    packageDir: repoRoot,
     stage: "pull-tool",
     role: "implementer",
     budgetTokens: maxTokensPerCall,
@@ -264,18 +263,17 @@ export async function handleQueryFeatureContext(
   input: { filter?: string },
   story: UserStory,
   config: NaxConfig,
-  workdir: string,
+  repoRoot: string,
   budget: PullToolBudget,
   maxTokensPerCall: number = DEFAULT_MAX_TOKENS_PER_CALL,
-  projectDir?: string,
 ): Promise<string> {
   budget.consume();
 
   const provider = new FeatureContextProviderV2(story, config);
   const request: ContextRequest = {
     storyId: story.id,
-    workdir,
-    projectDir,
+    repoRoot,
+    packageDir: repoRoot,
     stage: "pull-tool",
     role: "reviewer",
     budgetTokens: maxTokensPerCall,

--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -153,11 +153,15 @@ export async function assembleForStage(
 
     const orchestrator = createDefaultOrchestrator(ctx.story, ctx.config, storyScratchDirs, pluginProviders);
 
+    // AC-54: resolve dual workdir fields. repoRoot is the project root (where .nax/ lives);
+    // packageDir is the story's package directory (equals repoRoot for non-monorepo).
+    const packageDir = ctx.story.workdir ? join(ctx.workdir, ctx.story.workdir) : ctx.workdir;
+
     const request: ContextRequest = {
       storyId: ctx.story.id,
       featureId: ctx.prd.feature,
-      workdir: ctx.workdir,
-      projectDir: ctx.projectDir,
+      repoRoot: ctx.workdir,
+      packageDir,
       stage,
       role: stageConfig.role,
       budgetTokens: stageConfig.budgetTokens,

--- a/src/context/engine/tool-runtime.ts
+++ b/src/context/engine/tool-runtime.ts
@@ -24,12 +24,11 @@ export function createContextToolRuntime(options: {
   bundle: ContextBundle;
   story: UserStory;
   config: NaxConfig;
-  workdir: string;
-  /** Repo root — used for feature-context resolution under .nax in monorepos (Finding 1). */
-  projectDir?: string;
+  /** Absolute path to the repository root (AC-54). Used by all pull tool handlers. */
+  repoRoot: string;
   runCounter?: RunCallCounter;
 }): ContextToolRuntime | undefined {
-  const { bundle, story, config, workdir, projectDir } = options;
+  const { bundle, story, config, repoRoot } = options;
   if (bundle.pullTools.length === 0) return undefined;
 
   const descriptors = descriptorByName(bundle);
@@ -56,20 +55,18 @@ export function createContextToolRuntime(options: {
         case "query_neighbor":
           return handleQueryNeighbor(
             input as { filePath: string; depth?: number },
-            workdir,
+            repoRoot,
             getBudget(tool),
             tool.maxTokensPerCall,
-            projectDir,
           );
         case "query_feature_context":
           return handleQueryFeatureContext(
             input as { filter?: string },
             story,
             config,
-            workdir,
+            repoRoot,
             getBudget(tool),
             tool.maxTokensPerCall,
-            projectDir,
           );
         default:
           throw new Error(`No runtime handler for context tool: ${name}`);

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -182,6 +182,17 @@ export interface ContextManifest {
     error?: string;
   }>;
   /**
+   * Absolute path to the repository root at the time of assembly (AC-60).
+   * Populated from ContextRequest.repoRoot. Lets nax context inspect
+   * show which repo a manifest came from.
+   */
+  repoRoot?: string;
+  /**
+   * Absolute path to the story's package directory at the time of assembly (AC-60).
+   * Equals repoRoot for non-monorepo projects (AC-61).
+   */
+  packageDir?: string;
+  /**
    * Set by rebuildForAgent() when an agent-swap failure triggered the rebuild.
    * Records which agents were involved and why the swap occurred (Phase 5.5).
    */
@@ -260,15 +271,21 @@ export interface ContextRequest {
   storyId: string;
   /** Feature this story belongs to (optional — unattached stories omit this) */
   featureId?: string;
-  /** Working directory (package-scoped — used for git operations, neighbor graph) */
-  workdir: string;
   /**
-   * Repository root directory.
-   * In monorepos this differs from workdir (e.g. workdir = "packages/foo", projectDir = repo root).
-   * Providers that load .nax/ (canonical rules, feature context, plugin modules) must use
-   * projectDir when set, falling back to workdir for single-package repos.
+   * Absolute path to the repository root where `.nax/` lives (Amendment C AC-54).
+   * Replaces the former `workdir` field. Always set. For non-monorepo projects
+   * this equals `packageDir`.
    */
-  projectDir?: string;
+  repoRoot: string;
+  /**
+   * Absolute path to the story's package directory (Amendment C AC-54).
+   * Equals `repoRoot` for non-monorepo projects (AC-61 no-op guarantee).
+   * In monorepos: `join(repoRoot, story.workdir)`.
+   * Providers that scope to package paths (GitHistoryProvider, CodeNeighborProvider)
+   * use this field; repo-root providers (StaticRulesProvider, FeatureContextProvider)
+   * continue to use `repoRoot`.
+   */
+  packageDir: string;
   /** Pipeline stage name (e.g. "execution", "verify", "review") */
   stage: string;
   /** Caller role — used by role filter and score adjustments */
@@ -351,11 +368,6 @@ export interface ContextRequest {
    * (e.g. a rectify provider surfacing prior failure patterns).
    */
   failureHints?: string[];
-  /**
-   * Package directory for monorepo projects (Phase 7+).
-   * When set, providers scope their lookups to this directory rather than workdir.
-   */
-  packageDir?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -16,6 +16,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { join } from "node:path";
 import { createDefaultOrchestrator, createRunCallCounter } from "../../context/engine";
 import type { ContextRequest, IContextProvider } from "../../context/engine";
 import { writeContextManifest } from "../../context/engine/manifest-store";
@@ -106,8 +107,8 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
     // Trim trailing slash before taking the last path segment so
     // "/features/my-feature/" resolves to "my-feature" not "".
     featureId: ctx.featureDir?.replace(/\/$/, "").split("/").pop(),
-    workdir: ctx.workdir,
-    projectDir: ctx.projectDir,
+    repoRoot: ctx.workdir,
+    packageDir: ctx.story.workdir ? join(ctx.workdir, ctx.story.workdir) : ctx.workdir,
     stage: "context", // initial assembly; execution stage overrides to "execution"
     role: "implementer",
     budgetTokens: ctx.config.context.featureEngine?.budgetTokens ?? 8_000,

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -155,8 +155,7 @@ export const executionStage: PipelineStage = {
           bundle: ctx.contextBundle,
           story: ctx.story,
           config: ctx.config,
-          workdir: ctx.workdir,
-          projectDir: ctx.projectDir,
+          repoRoot: ctx.workdir,
           runCounter: ctx.contextToolRunCounter,
         })
       : undefined;
@@ -301,8 +300,7 @@ export const executionStage: PipelineStage = {
               bundle: ctx.contextBundle,
               story: ctx.story,
               config: ctx.config,
-              workdir: ctx.workdir,
-              projectDir: ctx.projectDir,
+              repoRoot: ctx.workdir,
               runCounter: ctx.contextToolRunCounter,
             }),
             interactionBridge: buildInteractionBridge(ctx.interaction, {

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -296,8 +296,7 @@ export async function runAdversarialReview(
           bundle: contextBundle,
           story: contextToolStory,
           config: naxConfig ?? DEFAULT_CONFIG,
-          workdir,
-          projectDir,
+          repoRoot: workdir,
         })
       : undefined,
   } as const;

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -447,8 +447,7 @@ export async function runSemanticReview(
           bundle: contextBundle,
           story: contextToolStory,
           config: naxConfig ?? DEFAULT_CONFIG,
-          workdir,
-          projectDir,
+          repoRoot: workdir,
         })
       : undefined,
   } as const;

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -230,8 +230,7 @@ export async function runTddSession(
           bundle: contextBundle,
           story,
           config,
-          workdir,
-          projectDir,
+          repoRoot: workdir,
         })
       : undefined,
     interactionBridge,

--- a/test/integration/execution/agent-swap.test.ts
+++ b/test/integration/execution/agent-swap.test.ts
@@ -76,7 +76,8 @@ async function makeBundle(): Promise<ContextBundle> {
   const orch = new ContextOrchestrator([makeProvider()]);
   return orch.assemble({
     storyId: "US-001",
-    workdir: "/repo",
+    repoRoot: "/repo",
+    packageDir: "/repo",
     stage: "run",
     role: "implementer",
     budgetTokens: 8_000,

--- a/test/unit/context/engine/orchestrator-rebuild.test.ts
+++ b/test/unit/context/engine/orchestrator-rebuild.test.ts
@@ -24,7 +24,8 @@ import type {
 
 const BASE_REQUEST: ContextRequest = {
   storyId: "US-001",
-  workdir: "/repo",
+  repoRoot: "/repo",
+  packageDir: "/repo",
   stage: "tdd-implementer",
   role: "implementer",
   budgetTokens: 8_000,

--- a/test/unit/context/engine/orchestrator.test.ts
+++ b/test/unit/context/engine/orchestrator.test.ts
@@ -16,7 +16,8 @@ beforeEach(() => {
 
 const BASE_REQUEST: ContextRequest = {
   storyId: "US-001",
-  workdir: "/project",
+  repoRoot: "/project",
+  packageDir: "/project",
   stage: "execution",
   role: "implementer",
   budgetTokens: 10_000,
@@ -294,7 +295,8 @@ describe("ContextOrchestrator.rebuildForAgent()", () => {
 describe("Phase 4: pull tools", () => {
   const TDD_IMPLEMENTER_REQUEST: ContextRequest = {
     storyId: "US-001",
-    workdir: "/project",
+    repoRoot: "/project",
+    packageDir: "/project",
     stage: "tdd-implementer",
     role: "implementer",
     budgetTokens: 8_000,
@@ -400,7 +402,8 @@ describe("Phase 4: pull tools", () => {
 describe("Phase 5: review stage pull tools", () => {
   const REVIEW_REQUEST: ContextRequest = {
     storyId: "US-001",
-    workdir: "/project",
+    repoRoot: "/project",
+    packageDir: "/project",
     stage: "review-semantic",
     role: "reviewer",
     budgetTokens: 6_000,
@@ -450,7 +453,8 @@ describe("Phase 5: review stage pull tools", () => {
     const orch = new ContextOrchestrator([]);
     const bundle = await orch.assemble({
       storyId: "US-001",
-      workdir: "/project",
+      repoRoot: "/project",
+      packageDir: "/project",
       stage: "tdd-implementer",
       role: "implementer",
       budgetTokens: 8_000,
@@ -469,5 +473,73 @@ describe("Phase 5: review stage pull tools", () => {
     });
     const names = bundle.pullTools.map((t) => t.name);
     expect(names).not.toContain("query_neighbor");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-54 / AC-60 / AC-61 — dual workdir fields (repoRoot + packageDir)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ContextOrchestrator — repoRoot + packageDir (Amendment C AC-54/AC-60/AC-61)", () => {
+  test("AC-54: ContextRequest accepts repoRoot and packageDir instead of workdir", async () => {
+    const orch = new ContextOrchestrator([]);
+    const bundle = await orch.assemble({
+      storyId: "US-001",
+      repoRoot: "/repo",
+      packageDir: "/repo",
+      stage: "execution",
+      role: "implementer",
+      budgetTokens: 4_000,
+      providerIds: [],
+    });
+    expect(bundle).toBeDefined();
+  });
+
+  test("AC-60: manifest records repoRoot and packageDir", async () => {
+    const orch = new ContextOrchestrator([]);
+    const bundle = await orch.assemble({
+      storyId: "US-001",
+      repoRoot: "/repo",
+      packageDir: "/repo/packages/api",
+      stage: "execution",
+      role: "implementer",
+      budgetTokens: 4_000,
+      providerIds: [],
+    });
+    expect(bundle.manifest.repoRoot).toBe("/repo");
+    expect(bundle.manifest.packageDir).toBe("/repo/packages/api");
+  });
+
+  test("AC-61: non-monorepo — packageDir equals repoRoot, behavior unchanged", async () => {
+    const provider = makeProvider("p1", makeChunkResult({ id: "chunk:nm" }));
+    const orch = new ContextOrchestrator([provider]);
+    const bundle = await orch.assemble({
+      storyId: "US-001",
+      repoRoot: "/repo",
+      packageDir: "/repo",
+      stage: "execution",
+      role: "implementer",
+      budgetTokens: 4_000,
+      providerIds: ["p1"],
+    });
+    expect(bundle.manifest.repoRoot).toBe("/repo");
+    expect(bundle.manifest.packageDir).toBe("/repo");
+    expect(bundle.chunks.some((c) => c.id === "chunk:nm")).toBe(true);
+  });
+
+  test("AC-60: rebuildForAgent preserves repoRoot and packageDir from prior manifest", async () => {
+    const orch = new ContextOrchestrator([]);
+    const prior = await orch.assemble({
+      storyId: "US-001",
+      repoRoot: "/repo",
+      packageDir: "/repo/packages/web",
+      stage: "execution",
+      role: "implementer",
+      budgetTokens: 4_000,
+      providerIds: [],
+    });
+    const rebuilt = orch.rebuildForAgent(prior, { newAgentId: "codex" });
+    expect(rebuilt.manifest.repoRoot).toBe("/repo");
+    expect(rebuilt.manifest.packageDir).toBe("/repo/packages/web");
   });
 });

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -36,7 +36,8 @@ afterEach(() => {
 function makeRequest(overrides: Partial<ContextRequest> = {}): ContextRequest {
   return {
     storyId: "US-001",
-    workdir: "/repo",
+    repoRoot: "/repo",
+    packageDir: "/repo",
     stage: "execution",
     role: "implementer",
     budgetTokens: 8_000,

--- a/test/unit/context/engine/providers/feature-context.test.ts
+++ b/test/unit/context/engine/providers/feature-context.test.ts
@@ -21,7 +21,8 @@ const CONFIG = {} as NaxConfig;
 function makeRequest(overrides: Partial<ContextRequest> = {}): ContextRequest {
   return {
     storyId: "story-001",
-    workdir: "/repo",
+    repoRoot: "/repo",
+    packageDir: "/repo",
     stage: "execution",
     role: "implementer",
     budgetTokens: 8_000,

--- a/test/unit/context/engine/providers/git-history.test.ts
+++ b/test/unit/context/engine/providers/git-history.test.ts
@@ -30,7 +30,8 @@ afterEach(() => {
 function makeRequest(overrides: Partial<ContextRequest> = {}): ContextRequest {
   return {
     storyId: "US-001",
-    workdir: "/repo",
+    repoRoot: "/repo",
+    packageDir: "/repo",
     stage: "execution",
     role: "implementer",
     budgetTokens: 8_000,

--- a/test/unit/context/engine/providers/session-scratch.test.ts
+++ b/test/unit/context/engine/providers/session-scratch.test.ts
@@ -9,7 +9,8 @@ import type { ContextRequest } from "../../../../../src/context/engine/types";
 function makeRequest(overrides: Partial<ContextRequest> = {}): ContextRequest {
   return {
     storyId: "US-001",
-    workdir: "/repo",
+    repoRoot: "/repo",
+    packageDir: "/repo",
     stage: "rectify",
     role: "implementer",
     budgetTokens: 4_000,

--- a/test/unit/context/engine/providers/static-rules.test.ts
+++ b/test/unit/context/engine/providers/static-rules.test.ts
@@ -44,7 +44,8 @@ afterEach(() => {
 
 const BASE_REQUEST: ContextRequest = {
   storyId: "US-001",
-  workdir: "/project",
+  repoRoot: "/project",
+  packageDir: "/project",
   stage: "execution",
   role: "implementer",
   budgetTokens: 8000,

--- a/test/unit/execution/escalation/agent-swap.test.ts
+++ b/test/unit/execution/escalation/agent-swap.test.ts
@@ -84,7 +84,8 @@ async function makeBundle(agentId = "claude"): Promise<ContextBundle> {
   const orch = new ContextOrchestrator([makeProvider("p1", makeChunkResult())]);
   return orch.assemble({
     storyId: "US-001",
-    workdir: "/repo",
+    repoRoot: "/repo",
+    packageDir: "/repo",
     stage: "run",
     role: "implementer",
     budgetTokens: 8_000,


### PR DESCRIPTION
## Summary

Implements the foundational rename from `SPEC-context-engine-v2-amendments.md` Amendment C, PR split step 1 (AC-54, AC-60, AC-61). This is a **breaking change on `ContextRequest`** — all other Amendment C PRs build on it.

- **AC-54**: `ContextRequest.workdir` → `repoRoot`; `projectDir?` removed; `packageDir` added as required field. For non-monorepo projects `packageDir === repoRoot` (AC-61 no-op guarantee). In monorepos: `join(repoRoot, story.workdir)`.
- **AC-60**: `ContextManifest` gains `repoRoot?` and `packageDir?` metadata fields populated by the orchestrator — enables `nax context inspect` to display which package a bundle targeted.
- **AC-61**: Non-monorepo projects see zero behavioral change — all existing single-package tests pass unchanged.

Provider behavior:
- `StaticRulesProvider`, `FeatureContextProvider` now read `request.repoRoot` (same value as old `projectDir ?? workdir`).
- `GitHistoryProvider`, `CodeNeighborProvider` temporarily use `request.repoRoot` (package-scoped variants come in AC-55/AC-56 PRs).

All callers updated: `stage-assembler.ts`, `context.ts` pipeline stage, `pull-tools.ts`, `tool-runtime.ts`, `execution.ts`, `adversarial.ts`, `semantic.ts`, `tdd/session-runner.ts`.

## Test plan

- [ ] `bun test test/unit/context/engine/ test/unit/execution/ test/integration/execution/agent-swap.test.ts` → 871 pass, 0 fail
- [ ] `bun run typecheck` → clean
- [ ] `bun run lint` → clean
- [ ] New AC-54/AC-60/AC-61 tests in `orchestrator.test.ts` verify `repoRoot`/`packageDir` in `ContextRequest` and manifest