### PR TITLE
feat(context-engine): AC-57 per-package canonical rules overlay

### DIFF
--- a/src/context/engine/providers/static-rules.ts
+++ b/src/context/engine/providers/static-rules.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import { getLogger } from "../../../logger";
 import { errorMessage } from "../../../utils/errors";
 import { loadCanonicalRules } from "../../rules/canonical-loader";
+import type { CanonicalRule } from "../../rules/canonical-loader";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -82,11 +83,24 @@ export class StaticRulesProvider implements IContextProvider {
   async fetch(request: ContextRequest): Promise<ContextProviderResult> {
     const logger = getLogger();
 
-    // Phase 5.1: try canonical store first
+    // Phase 5.1 + AC-57: try canonical store first, then overlay package rules if monorepo
     try {
-      const canonicalRules = await _staticRulesDeps.loadCanonicalRules(request.repoRoot);
-      if (canonicalRules.length > 0) {
-        const chunks = canonicalRules.map((rule) => {
+      const repoRules = await _staticRulesDeps.loadCanonicalRules(request.repoRoot);
+
+      // AC-57: in monorepos, load package-level rules and overlay (package wins on same fileName)
+      let mergedRules: CanonicalRule[] = repoRules;
+      if (request.packageDir !== request.repoRoot) {
+        const packageRules = await _staticRulesDeps.loadCanonicalRules(request.packageDir);
+        if (packageRules.length > 0) {
+          const merged = new Map<string, CanonicalRule>();
+          for (const rule of repoRules) merged.set(rule.fileName, rule);
+          for (const rule of packageRules) merged.set(rule.fileName, rule);
+          mergedRules = [...merged.values()];
+        }
+      }
+
+      if (mergedRules.length > 0) {
+        const chunks = mergedRules.map((rule) => {
           const hash = contentHash8(rule.content);
           const tokens = estimateTokens(rule.content);
           return {

--- a/test/unit/context/engine/providers/static-rules.test.ts
+++ b/test/unit/context/engine/providers/static-rules.test.ts
@@ -143,7 +143,7 @@ describe("StaticRulesProvider — canonical store (Phase 5.1)", () => {
     } catch (e) {
       threw = e;
     }
-    expect(threw).toBeInstanceOf(NaxError);
+    expect(threw).toBeInstanceOf(NeutralityLintError);
     expect((threw as NaxError).code).toBe("NEUTRALITY_LINT_FAILED");
   });
 });
@@ -341,7 +341,7 @@ describe("StaticRulesProvider — AC-57 per-package overlay", () => {
     } catch (e) {
       threw = e;
     }
-    expect(threw).toBeInstanceOf(NaxError);
+    expect(threw).toBeInstanceOf(NeutralityLintError);
     expect((threw as NaxError).code).toBe("NEUTRALITY_LINT_FAILED");
   });
 
@@ -360,7 +360,7 @@ describe("StaticRulesProvider — AC-57 per-package overlay", () => {
     } catch (e) {
       threw = e;
     }
-    expect(threw).toBeInstanceOf(NaxError);
+    expect(threw).toBeInstanceOf(NeutralityLintError);
     expect((threw as NaxError).code).toBe("NEUTRALITY_LINT_FAILED");
   });
 

--- a/test/unit/context/engine/providers/static-rules.test.ts
+++ b/test/unit/context/engine/providers/static-rules.test.ts
@@ -254,3 +254,124 @@ describe("StaticRulesProvider — legacy path", () => {
     expect(result.chunks[0]?.tokens).toBeGreaterThanOrEqual(100);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-57: per-package canonical rules overlay
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MONOREPO_REQUEST: ContextRequest = {
+  storyId: "US-002",
+  repoRoot: "/repo",
+  packageDir: "/repo/packages/api",
+  stage: "execution",
+  role: "implementer",
+  budgetTokens: 8000,
+};
+
+describe("StaticRulesProvider — AC-57 per-package overlay", () => {
+  test("non-monorepo: loadCanonicalRules called once with repoRoot", async () => {
+    const calls: string[] = [];
+    _staticRulesDeps.loadCanonicalRules = async (workdir: string) => {
+      calls.push(workdir);
+      return [{ fileName: "style.md", content: "Repo rules." }];
+    };
+    const provider = new StaticRulesProvider();
+    await provider.fetch(BASE_REQUEST); // packageDir === repoRoot === "/project"
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe("/project");
+  });
+
+  test("monorepo: package rules overlay repo rules — same filename: package wins", async () => {
+    _staticRulesDeps.loadCanonicalRules = async (workdir: string) => {
+      if (workdir === "/repo") return [{ fileName: "style.md", content: "Repo style." }];
+      if (workdir === "/repo/packages/api") return [{ fileName: "style.md", content: "Package style." }];
+      return [];
+    };
+    const provider = new StaticRulesProvider();
+    const result = await provider.fetch(MONOREPO_REQUEST);
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0]?.content).toContain("Package style.");
+    expect(result.chunks[0]?.content).not.toContain("Repo style.");
+  });
+
+  test("monorepo: package-only file is added alongside repo rules", async () => {
+    _staticRulesDeps.loadCanonicalRules = async (workdir: string) => {
+      if (workdir === "/repo") return [{ fileName: "testing.md", content: "Repo testing." }];
+      if (workdir === "/repo/packages/api") return [{ fileName: "api-conventions.md", content: "API conventions." }];
+      return [];
+    };
+    const provider = new StaticRulesProvider();
+    const result = await provider.fetch(MONOREPO_REQUEST);
+    expect(result.chunks).toHaveLength(2);
+    const fileNames = result.chunks.map((c) => c.content).join("\n");
+    expect(fileNames).toContain("Repo testing.");
+    expect(fileNames).toContain("API conventions.");
+  });
+
+  test("monorepo: repo-only file included when package has no override", async () => {
+    _staticRulesDeps.loadCanonicalRules = async (workdir: string) => {
+      if (workdir === "/repo") return [
+        { fileName: "style.md", content: "Repo style." },
+        { fileName: "security.md", content: "Repo security." },
+      ];
+      if (workdir === "/repo/packages/api") return [{ fileName: "style.md", content: "Package style." }];
+      return [];
+    };
+    const provider = new StaticRulesProvider();
+    const result = await provider.fetch(MONOREPO_REQUEST);
+    expect(result.chunks).toHaveLength(2);
+    const contents = result.chunks.map((c) => c.content).join("\n");
+    expect(contents).toContain("Package style.");
+    expect(contents).toContain("Repo security.");
+    expect(contents).not.toContain("Repo style.");
+  });
+
+  test("monorepo: NeutralityLintError from repo-level rules propagates without fallback", async () => {
+    _staticRulesDeps.loadCanonicalRules = async (workdir: string) => {
+      if (workdir === "/repo") {
+        throw new NeutralityLintError([{ file: "bad.md", lineNumber: 1, line: "CLAUDE.md", pattern: "agent-specific" }]);
+      }
+      return [];
+    };
+    setupLegacyFiles({ "/repo/CLAUDE.md": "Legacy." });
+    const provider = new StaticRulesProvider();
+    let threw: unknown;
+    try {
+      await provider.fetch(MONOREPO_REQUEST);
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toBeInstanceOf(NaxError);
+    expect((threw as NaxError).code).toBe("NEUTRALITY_LINT_FAILED");
+  });
+
+  test("monorepo: NeutralityLintError from package-level rules propagates", async () => {
+    _staticRulesDeps.loadCanonicalRules = async (workdir: string) => {
+      if (workdir === "/repo") return [{ fileName: "style.md", content: "Repo style." }];
+      if (workdir === "/repo/packages/api") {
+        throw new NeutralityLintError([{ file: "pkg.md", lineNumber: 2, line: "AGENTS.md", pattern: "agent-specific" }]);
+      }
+      return [];
+    };
+    const provider = new StaticRulesProvider();
+    let threw: unknown;
+    try {
+      await provider.fetch(MONOREPO_REQUEST);
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toBeInstanceOf(NaxError);
+    expect((threw as NaxError).code).toBe("NEUTRALITY_LINT_FAILED");
+  });
+
+  test("monorepo: empty package rules falls through to repo rules only", async () => {
+    _staticRulesDeps.loadCanonicalRules = async (workdir: string) => {
+      if (workdir === "/repo") return [{ fileName: "style.md", content: "Repo style." }];
+      return []; // package has no rules
+    };
+    const provider = new StaticRulesProvider();
+    const result = await provider.fetch(MONOREPO_REQUEST);
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0]?.content).toContain("Repo style.");
+  });
+});


### PR DESCRIPTION
## Summary

- `StaticRulesProvider` now loads both repo-level (`.nax/rules/`) and package-level (`<packageDir>/.nax/rules/`) canonical rules in monorepos
- Package rules overlay repo rules via `Map<fileName, CanonicalRule>` — same filename: package wins, unique files from both levels included
- `NeutralityLintError` from either repo or package level propagates without falling back to legacy files
- Non-monorepo projects (`packageDir === repoRoot`) unchanged — single `loadCanonicalRules` call

> Re-targets #489 (which was accidentally merged to `feat/context-engine-v2`) to `main`.

## Test plan

- [ ] `StaticRulesProvider — AC-57 per-package overlay` (7 new tests, all green)
- [ ] Full context engine suite: 285 pass, 0 fail
- [ ] `bun run typecheck`: clean