### PR TITLE
feat(context-engine): AC-55 GitHistoryProvider historyScope option

### DIFF
--- a/src/context/engine/providers/git-history.ts
+++ b/src/context/engine/providers/git-history.ts
@@ -18,6 +18,20 @@ import { gitWithTimeout } from "../../../utils/git";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Options
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface GitHistoryProviderOptions {
+  /**
+   * Scope of the git working directory for history queries (AC-55).
+   * "repo" — runs git log in repoRoot (full repo history).
+   * "package" — runs git log in packageDir (monorepo package boundary).
+   * Default: "repo" (preserves Phase 3 behavior).
+   */
+  historyScope?: "repo" | "package";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Constants
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -75,11 +89,15 @@ export class GitHistoryProvider implements IContextProvider {
   readonly id = "git-history";
   readonly kind = "history" as const;
 
+  private readonly historyScope: "repo" | "package";
+
+  constructor(options: GitHistoryProviderOptions = {}) {
+    this.historyScope = options.historyScope ?? "repo";
+  }
+
   async fetch(request: ContextRequest): Promise<ContextProviderResult> {
     const { touchedFiles } = request;
-    // AC-55 (future): use request.packageDir for package-scoped git history.
-    // For now, default to repoRoot to preserve existing behavior.
-    const workdir = request.repoRoot;
+    const workdir = this.historyScope === "package" ? request.packageDir : request.repoRoot;
     if (!touchedFiles || touchedFiles.length === 0) {
       return { chunks: [], pullTools: [] };
     }

--- a/test/unit/context/engine/providers/git-history.test.ts
+++ b/test/unit/context/engine/providers/git-history.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { GitHistoryProvider, _gitHistoryDeps } from "../../../../../src/context/engine/providers/git-history";
+import type { GitHistoryProviderOptions } from "../../../../../src/context/engine/providers/git-history";
 import type { ContextRequest } from "../../../../../src/context/engine/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -45,6 +46,16 @@ function mockGit(responses: Map<string, { stdout: string; exitCode: number }>) {
     const fileArg = args[args.length - 1] ?? "";
     return responses.get(fileArg) ?? { stdout: "", exitCode: 0 };
   };
+}
+
+/** Installs a mock that captures workdirs and returns success for every file */
+function captureWorkdirs(): string[] {
+  const captured: string[] = [];
+  _gitHistoryDeps.gitWithTimeout = async (args: string[], workdir: string) => {
+    captured.push(workdir);
+    return { stdout: "abc1234 feat: something", exitCode: 0 };
+  };
+  return captured;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -175,5 +186,57 @@ describe("GitHistoryProvider", () => {
     const chunk = result.chunks[0]!;
     expect(chunk.content.length).toBeLessThanOrEqual(600 * 4);
     expect(chunk.tokens).toBe(Math.ceil(chunk.content.length / 4));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-55: historyScope option
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("GitHistoryProvider — AC-55 historyScope", () => {
+  const MONOREPO_REQUEST: ContextRequest = {
+    storyId: "US-002",
+    repoRoot: "/repo",
+    packageDir: "/repo/packages/api",
+    stage: "execution",
+    role: "implementer",
+    budgetTokens: 8_000,
+    touchedFiles: ["src/service.ts"],
+  };
+
+  test("default historyScope is 'repo' — uses repoRoot", async () => {
+    const workdirs = captureWorkdirs();
+    const p = new GitHistoryProvider();
+    await p.fetch(MONOREPO_REQUEST);
+    expect(workdirs[0]).toBe("/repo");
+  });
+
+  test("historyScope 'repo' — uses repoRoot", async () => {
+    const workdirs = captureWorkdirs();
+    const p = new GitHistoryProvider({ historyScope: "repo" } as GitHistoryProviderOptions);
+    await p.fetch(MONOREPO_REQUEST);
+    expect(workdirs[0]).toBe("/repo");
+  });
+
+  test("historyScope 'package' — uses packageDir", async () => {
+    const workdirs = captureWorkdirs();
+    const p = new GitHistoryProvider({ historyScope: "package" } as GitHistoryProviderOptions);
+    await p.fetch(MONOREPO_REQUEST);
+    expect(workdirs[0]).toBe("/repo/packages/api");
+  });
+
+  test("non-monorepo: historyScope 'package' uses repoRoot when packageDir === repoRoot", async () => {
+    const workdirs = captureWorkdirs();
+    const p = new GitHistoryProvider({ historyScope: "package" } as GitHistoryProviderOptions);
+    await p.fetch(makeRequest({ touchedFiles: ["src/foo.ts"] })); // packageDir === repoRoot === "/repo"
+    expect(workdirs[0]).toBe("/repo");
+  });
+
+  test("historyScope 'package' — chunk content still contains file history", async () => {
+    mockGit(new Map([["src/service.ts", { stdout: "abc1234 feat: service impl", exitCode: 0 }]]));
+    const p = new GitHistoryProvider({ historyScope: "package" } as GitHistoryProviderOptions);
+    const result = await p.fetch(MONOREPO_REQUEST);
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0]?.content).toContain("src/service.ts");
   });
 });


### PR DESCRIPTION
## Summary

- Adds `historyScope: "repo" | "package"` constructor option to `GitHistoryProvider`
- `"package"` — runs `git log` in `request.packageDir` (monorepo package boundary)
- `"repo"` — runs `git log` in `request.repoRoot` (default, preserves Phase 3 behavior)
- Non-monorepo projects (`packageDir === repoRoot`) unaffected regardless of setting

## Test plan

- [ ] `GitHistoryProvider — AC-55 historyScope` (5 new tests, all green)
  - default `historyScope` is `"repo"` — uses `repoRoot`
  - `historyScope: "repo"` — uses `repoRoot`
  - `historyScope: "package"` — uses `packageDir`
  - non-monorepo: `historyScope: "package"` uses `repoRoot` when `packageDir === repoRoot`
  - `historyScope: "package"` — chunk content still correct
- [ ] Full context engine suite: 290 pass, 0 fail
- [ ] `bun run typecheck`: clean