### PR TITLE
feat(context-engine): AC-59 per-package stage budget overrides

### DIFF
--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -459,6 +459,12 @@ export interface ContextV2Config {
   fallback: ContextV2FallbackConfig;
   /** External plugin providers to load (Phase 7+). Empty by default. */
   pluginProviders: ContextPluginProviderConfig[];
+  /**
+   * Per-package token budget overrides (AC-59).
+   * Keys are relative package paths from repoRoot (e.g. "packages/api").
+   * Values map stage names to token counts.
+   */
+  packageBudgets: Record<string, Record<string, number>>;
 }
 
 export interface ContextConfig {

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -545,6 +545,19 @@ const ContextV2ConfigSchema = z
      * Empty by default — operators add providers for RAG, graph, or KB use cases.
      */
     pluginProviders: z.array(ContextPluginProviderConfigSchema).default([]),
+    /**
+     * Per-package token budget overrides (AC-59).
+     * Keys are relative package paths from repoRoot (e.g. "packages/api").
+     * Use "" for the root package (non-monorepo or repo-level override).
+     * Values are per-stage budget maps: { "<stage>": <tokens> }.
+     * Absent stages fall back to the default stage budget in STAGE_CONTEXT_MAP.
+     *
+     * Example:
+     *   { "packages/api": { "execution": 15000, "tdd-implementer": 10000 } }
+     */
+    packageBudgets: z
+      .record(z.string(), z.record(z.string().min(1), z.number().int().positive()))
+      .default({}),
   })
   .default(() => ({
     enabled: false,
@@ -553,6 +566,7 @@ const ContextV2ConfigSchema = z
     rules: { allowLegacyClaudeMd: true },
     fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
     pluginProviders: [],
+    packageBudgets: {},
   }));
 
 const ContextConfigSchema = z.object({
@@ -974,6 +988,7 @@ export const NaxConfigSchema = z
         rules: { allowLegacyClaudeMd: true },
         fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
         pluginProviders: [],
+        packageBudgets: {},
       },
     }),
     optimizer: OptimizerConfigSchema.optional(),

--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -15,7 +15,7 @@
  */
 
 import { readdir } from "node:fs/promises";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { getLogger } from "../../logger";
 import type { PipelineContext } from "../../pipeline/types";
 import { getContextFiles } from "../../prd/types";
@@ -32,6 +32,28 @@ import type { ContextBundle, ContextRequest } from "./types";
  * ignored — prevents stale scratch from long-past runs contaminating context.
  */
 const DISK_DISCOVERY_TTL_MS = 4 * 60 * 60 * 1000;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-59: per-package budget resolution
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the effective token budget for a stage, applying any per-package
+ * override from config.context.v2.packageBudgets (AC-59).
+ *
+ * packageBudgets keys are relative paths from repoRoot (e.g. "packages/api").
+ * An empty key "" matches non-monorepo or repo-root overrides.
+ */
+export function resolvePackageBudget(
+  packageBudgets: Record<string, Record<string, number>>,
+  packageDir: string,
+  repoRoot: string,
+  stage: string,
+  defaultBudget: number,
+): number {
+  const relKey = relative(repoRoot, packageDir);
+  return packageBudgets[relKey]?.[stage] ?? defaultBudget;
+}
 
 export const _stageAssemblerDeps = {
   readdir: (path: string): Promise<string[]> => readdir(path),
@@ -157,6 +179,9 @@ export async function assembleForStage(
     // packageDir is the story's package directory (equals repoRoot for non-monorepo).
     const packageDir = ctx.story.workdir ? join(ctx.workdir, ctx.story.workdir) : ctx.workdir;
 
+    const packageBudgets = ctx.config.context.v2.packageBudgets ?? {};
+    const budgetTokens = resolvePackageBudget(packageBudgets, packageDir, ctx.workdir, stage, stageConfig.budgetTokens);
+
     const request: ContextRequest = {
       storyId: ctx.story.id,
       featureId: ctx.prd.feature,
@@ -164,7 +189,7 @@ export async function assembleForStage(
       packageDir,
       stage,
       role: stageConfig.role,
-      budgetTokens: stageConfig.budgetTokens,
+      budgetTokens,
       touchedFiles: options.touchedFiles ?? getContextFiles(ctx.story),
       storyScratchDirs,
       priorStageDigest: options.priorStageDigest ?? ctx.contextBundle?.digest,

--- a/test/unit/context/engine/stage-assembler.test.ts
+++ b/test/unit/context/engine/stage-assembler.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   _stageAssemblerDeps,
   discoverSessionScratchDirsOnDisk,
+  resolvePackageBudget,
 } from "../../../../src/context/engine/stage-assembler";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -182,5 +183,59 @@ describe("discoverSessionScratchDirsOnDisk — Finding 2", () => {
 
     const result = await discoverSessionScratchDirsOnDisk(PROJECT_DIR, FEATURE, STORY, TTL_4H);
     expect(result).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-59: resolvePackageBudget
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("resolvePackageBudget — AC-59 per-package stage budgets", () => {
+  const DEFAULT = 8_000;
+  const REPO_ROOT = "/repo";
+
+  test("returns default budget when packageBudgets is empty", () => {
+    const result = resolvePackageBudget({}, "/repo", REPO_ROOT, "execution", DEFAULT);
+    expect(result).toBe(DEFAULT);
+  });
+
+  test("returns default budget for non-monorepo (packageDir === repoRoot)", () => {
+    const budgets = { "": { execution: 15_000 } };
+    const result = resolvePackageBudget(budgets, "/repo", REPO_ROOT, "execution", DEFAULT);
+    expect(result).toBe(15_000);
+  });
+
+  test("returns package override when matching package path and stage", () => {
+    const budgets = { "packages/api": { execution: 15_000 } };
+    const result = resolvePackageBudget(budgets, "/repo/packages/api", REPO_ROOT, "execution", DEFAULT);
+    expect(result).toBe(15_000);
+  });
+
+  test("returns default when package is known but stage has no override", () => {
+    const budgets = { "packages/api": { execution: 15_000 } };
+    const result = resolvePackageBudget(budgets, "/repo/packages/api", REPO_ROOT, "tdd-implementer", DEFAULT);
+    expect(result).toBe(DEFAULT);
+  });
+
+  test("returns default when package is not in packageBudgets", () => {
+    const budgets = { "packages/api": { execution: 15_000 } };
+    const result = resolvePackageBudget(budgets, "/repo/packages/core", REPO_ROOT, "execution", DEFAULT);
+    expect(result).toBe(DEFAULT);
+  });
+
+  test("different packages get independent overrides", () => {
+    const budgets = {
+      "packages/api": { execution: 15_000 },
+      "packages/core": { execution: 6_000 },
+    };
+    expect(resolvePackageBudget(budgets, "/repo/packages/api", REPO_ROOT, "execution", DEFAULT)).toBe(15_000);
+    expect(resolvePackageBudget(budgets, "/repo/packages/core", REPO_ROOT, "execution", DEFAULT)).toBe(6_000);
+  });
+
+  test("different stages get independent overrides for same package", () => {
+    const budgets = { "packages/api": { execution: 15_000, "tdd-implementer": 10_000 } };
+    expect(resolvePackageBudget(budgets, "/repo/packages/api", REPO_ROOT, "execution", DEFAULT)).toBe(15_000);
+    expect(resolvePackageBudget(budgets, "/repo/packages/api", REPO_ROOT, "tdd-implementer", DEFAULT)).toBe(10_000);
+    expect(resolvePackageBudget(budgets, "/repo/packages/api", REPO_ROOT, "verify", DEFAULT)).toBe(DEFAULT);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `packageBudgets` to `config.context.v2` — allows monorepo packages to override the default token budget per pipeline stage
- Config shape: `{ "packages/api": { "execution": 15000, "tdd-implementer": 10000 } }`
- Keys are relative paths from `repoRoot`; `""` overrides the repo root / non-monorepo
- `resolvePackageBudget()` exported as a pure function for testability
- `assembleForStage()` applies the override when building `ContextRequest.budgetTokens`
- Absent stage entries fall through to `STAGE_CONTEXT_MAP` defaults

## Test plan

- [ ] `resolvePackageBudget — AC-59 per-package stage budgets` (7 new tests, all green)
  - default budget when `packageBudgets` is empty
  - non-monorepo (`""` key) override
  - matching package + stage → override applied
  - known package, unknown stage → default
  - unknown package → default
  - independent overrides per package
  - independent overrides per stage within same package
- [ ] Full context engine suite: 303 pass, 0 fail
- [ ] `bun run typecheck`: clean