### PR TITLE
fix(context-engine): #479 post-review fixes — defaults, AC-62 workspace, AC-59 redesign, AC-57 chunk ID

### DIFF
--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -138,6 +138,15 @@ export function mergePackageConfig(root: NaxConfig, packageOverride: Partial<Nax
         ...root.context.testCoverage,
         ...packageOverride.context?.testCoverage,
       },
+      v2: {
+        ...root.context.v2,
+        // AC-59: per-package stage budget overrides — deep-merge so each package
+        // can independently override individual stage budgets without clobbering others.
+        stages: {
+          ...root.context.v2?.stages,
+          ...packageOverride.context?.v2?.stages,
+        },
+      },
     },
     project: packageOverride.project !== undefined ? { ...root.project, ...packageOverride.project } : root.project,
   };

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -459,6 +459,12 @@ export interface ContextV2Config {
   fallback: ContextV2FallbackConfig;
   /** External plugin providers to load (Phase 7+). Empty by default. */
   pluginProviders: ContextPluginProviderConfig[];
+  /**
+   * Per-stage token budget overrides (AC-59).
+   * Set via per-package config (<repoRoot>/.nax/mono/<packageDir>/config.json).
+   * Keys are stage names; value overrides the default stage budgetTokens.
+   */
+  stages: Record<string, { budgetTokens?: number }>;
 }
 
 export interface ContextConfig {

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -553,12 +553,7 @@ const ContextV2ConfigSchema = z
      *
      * Example: { "execution": { "budgetTokens": 15000 } }
      */
-    stages: z
-      .record(
-        z.string().min(1),
-        z.object({ budgetTokens: z.number().int().positive().optional() }),
-      )
-      .default({}),
+    stages: z.record(z.string().min(1), z.object({ budgetTokens: z.number().int().positive().optional() })).default({}),
   })
   .default(() => ({
     enabled: false,

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -545,6 +545,20 @@ const ContextV2ConfigSchema = z
      * Empty by default — operators add providers for RAG, graph, or KB use cases.
      */
     pluginProviders: z.array(ContextPluginProviderConfigSchema).default([]),
+    /**
+     * Per-stage token budget overrides (AC-59).
+     * Keys are pipeline stage names (e.g. "execution", "tdd-implementer").
+     * Set in per-package config (<repoRoot>/.nax/mono/<packageDir>/config.json)
+     * to override the default stage budget for a specific package.
+     *
+     * Example: { "execution": { "budgetTokens": 15000 } }
+     */
+    stages: z
+      .record(
+        z.string().min(1),
+        z.object({ budgetTokens: z.number().int().positive().optional() }),
+      )
+      .default({}),
   })
   .default(() => ({
     enabled: false,
@@ -553,6 +567,7 @@ const ContextV2ConfigSchema = z
     rules: { allowLegacyClaudeMd: true },
     fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
     pluginProviders: [],
+    stages: {},
   }));
 
 const ContextConfigSchema = z.object({
@@ -974,6 +989,7 @@ export const NaxConfigSchema = z
         rules: { allowLegacyClaudeMd: true },
         fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
         pluginProviders: [],
+        stages: {},
       },
     }),
     optimizer: OptimizerConfigSchema.optional(),

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -160,11 +160,7 @@ function siblingTestPath(filePath: string): string | null {
  * extraGlobWorkdirs: when provided (AC-62 crossPackageDepth > 0), also scans
  * each directory for cross-package reverse deps (workspace package dirs or repoRoot).
  */
-async function collectNeighbors(
-  filePath: string,
-  workdir: string,
-  extraGlobWorkdirs?: string[],
-): Promise<string[]> {
+async function collectNeighbors(filePath: string, workdir: string, extraGlobWorkdirs?: string[]): Promise<string[]> {
   const neighbors = new Set<string>();
 
   // Forward deps (JS/TS only)
@@ -248,9 +244,7 @@ async function resolveExtraGlobWorkdirs(
     const relPkgDirs = await _codeNeighborDeps.discoverWorkspacePackages(repoRoot);
     if (relPkgDirs.length === 0) return [repoRoot];
     // Convert relative workspace dirs to absolute, excluding the current package
-    return relPkgDirs
-      .map((rel) => join(repoRoot, rel))
-      .filter((abs) => abs !== packageDir);
+    return relPkgDirs.map((rel) => join(repoRoot, rel)).filter((abs) => abs !== packageDir);
   } catch {
     return [repoRoot];
   }

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -23,6 +23,7 @@
 
 import { createHash } from "node:crypto";
 import { join, relative, resolve } from "node:path";
+import { discoverWorkspacePackages } from "../../../test-runners/detect/workspace";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -74,6 +75,7 @@ const SOURCE_GLOB = "src/**/*.{ts,tsx,js,jsx,py,go,rs,java,rb,php,cs,cpp,c,h}";
 export const _codeNeighborDeps = {
   fileExists: (path: string): Promise<boolean> => Bun.file(path).exists(),
   readFile: (path: string): Promise<string> => Bun.file(path).text(),
+  discoverWorkspacePackages: (repoRoot: string): Promise<string[]> => discoverWorkspacePackages(repoRoot),
   glob: (pattern: string, cwd: string): string[] => {
     const g = new Bun.Glob(pattern);
     const results: string[] = [];
@@ -155,10 +157,14 @@ function siblingTestPath(filePath: string): string | null {
  * - reverse deps (all common source extensions)
  * - sibling test file (JS/TS/JSX/TSX only)
  *
- * extraGlobWorkdir: when provided (AC-62 crossPackageDepth > 0), also scans
- * this directory for cross-package reverse deps.
+ * extraGlobWorkdirs: when provided (AC-62 crossPackageDepth > 0), also scans
+ * each directory for cross-package reverse deps (workspace package dirs or repoRoot).
  */
-async function collectNeighbors(filePath: string, workdir: string, extraGlobWorkdir?: string): Promise<string[]> {
+async function collectNeighbors(
+  filePath: string,
+  workdir: string,
+  extraGlobWorkdirs?: string[],
+): Promise<string[]> {
   const neighbors = new Set<string>();
 
   // Forward deps (JS/TS only)
@@ -199,9 +205,12 @@ async function collectNeighbors(filePath: string, workdir: string, extraGlobWork
 
   await scanForReverseDeps(workdir);
 
-  // AC-62: cross-package reverse deps when extraGlobWorkdir is provided
-  if (extraGlobWorkdir) {
-    await scanForReverseDeps(extraGlobWorkdir);
+  // AC-62: cross-package reverse deps — scan each extra workdir (workspace packages)
+  if (extraGlobWorkdirs) {
+    for (const extraDir of extraGlobWorkdirs) {
+      if (neighbors.size >= MAX_NEIGHBORS_PER_FILE) break;
+      await scanForReverseDeps(extraDir);
+    }
   }
 
   // Sibling test (JS/TS/JSX/TSX only)
@@ -209,6 +218,42 @@ async function collectNeighbors(filePath: string, workdir: string, extraGlobWork
   if (testPath) neighbors.add(testPath);
 
   return [...neighbors].slice(0, MAX_NEIGHBORS_PER_FILE);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-62 workspace detection helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the extra glob workdirs for cross-package scanning (AC-62).
+ *
+ * When neighborScope is "package" and crossPackageDepth > 0 in a monorepo,
+ * detects workspace packages (pnpm-workspace.yaml, package.json#workspaces, etc.)
+ * and returns their absolute paths as scan roots (excluding the current packageDir).
+ * Falls back to [repoRoot] when workspace detection finds nothing — this scans
+ * the whole repo as a safe fallback for non-standard monorepo layouts.
+ *
+ * Returns undefined when cross-package scanning is not needed.
+ */
+async function resolveExtraGlobWorkdirs(
+  neighborScope: "repo" | "package",
+  crossPackageDepth: number,
+  repoRoot: string,
+  packageDir: string,
+): Promise<string[] | undefined> {
+  if (neighborScope !== "package" || crossPackageDepth <= 0 || packageDir === repoRoot) {
+    return undefined;
+  }
+  try {
+    const relPkgDirs = await _codeNeighborDeps.discoverWorkspacePackages(repoRoot);
+    if (relPkgDirs.length === 0) return [repoRoot];
+    // Convert relative workspace dirs to absolute, excluding the current package
+    return relPkgDirs
+      .map((rel) => join(repoRoot, rel))
+      .filter((abs) => abs !== packageDir);
+  } catch {
+    return [repoRoot];
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -234,11 +279,15 @@ export class CodeNeighborProvider implements IContextProvider {
   async fetch(request: ContextRequest): Promise<ContextProviderResult> {
     const { touchedFiles } = request;
     const workdir = this.neighborScope === "package" ? request.packageDir : request.repoRoot;
-    // AC-62: when neighborScope is "package" and crossPackageDepth > 0, also scan repoRoot
-    const extraGlobWorkdir =
-      this.neighborScope === "package" && this.crossPackageDepth > 0 && request.packageDir !== request.repoRoot
-        ? request.repoRoot
-        : undefined;
+    // AC-62: cross-package scanning — detect shared workspace dirs instead of scanning full repoRoot.
+    // Only active when neighborScope "package", crossPackageDepth > 0, and this is a monorepo
+    // (packageDir !== repoRoot). Falls back to [repoRoot] when no workspace packages are found.
+    const extraGlobWorkdirs = await resolveExtraGlobWorkdirs(
+      this.neighborScope,
+      this.crossPackageDepth,
+      request.repoRoot,
+      request.packageDir,
+    );
     if (!touchedFiles || touchedFiles.length === 0) {
       return { chunks: [], pullTools: [] };
     }
@@ -247,7 +296,7 @@ export class CodeNeighborProvider implements IContextProvider {
 
     const sections: string[] = [];
     for (const file of filesToProcess) {
-      const neighbors = await collectNeighbors(file, workdir, extraGlobWorkdir);
+      const neighbors = await collectNeighbors(file, workdir, extraGlobWorkdirs);
       if (neighbors.length > 0) {
         sections.push(`### ${file}\n${neighbors.map((n) => `- ${n}`).join("\n")}`);
       }

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -32,15 +32,15 @@ import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk 
 export interface CodeNeighborProviderOptions {
   /**
    * Scope of the working directory for neighbor discovery (AC-56).
-   * "repo" — scans from repoRoot (full repo, default).
-   * "package" — scans from packageDir (monorepo package boundary).
+   * "repo" — scans from repoRoot (full repo).
+   * "package" — scans from packageDir (monorepo package boundary, default).
    */
   neighborScope?: "repo" | "package";
   /**
    * Maximum neighbor traversal depth across the package boundary (AC-62).
    * Only applies when neighborScope is "package".
-   * 0 (default) — no cross-package scanning.
-   * N > 0 — additionally scans repoRoot for cross-package reverse deps.
+   * 0 — no cross-package scanning.
+   * 1 (default) — additionally scans repoRoot for cross-package reverse deps.
    */
   crossPackageDepth?: number;
 }
@@ -227,8 +227,8 @@ export class CodeNeighborProvider implements IContextProvider {
   private readonly crossPackageDepth: number;
 
   constructor(options: CodeNeighborProviderOptions = {}) {
-    this.neighborScope = options.neighborScope ?? "repo";
-    this.crossPackageDepth = options.crossPackageDepth ?? 0;
+    this.neighborScope = options.neighborScope ?? "package";
+    this.crossPackageDepth = options.crossPackageDepth ?? 1;
   }
 
   async fetch(request: ContextRequest): Promise<ContextProviderResult> {

--- a/src/context/engine/providers/git-history.ts
+++ b/src/context/engine/providers/git-history.ts
@@ -26,7 +26,7 @@ export interface GitHistoryProviderOptions {
    * Scope of the git working directory for history queries (AC-55).
    * "repo" — runs git log in repoRoot (full repo history).
    * "package" — runs git log in packageDir (monorepo package boundary).
-   * Default: "repo" (preserves Phase 3 behavior).
+   * Default: "package" (monorepo-safe; scopes history to the story's package).
    */
   historyScope?: "repo" | "package";
 }
@@ -92,7 +92,7 @@ export class GitHistoryProvider implements IContextProvider {
   private readonly historyScope: "repo" | "package";
 
   constructor(options: GitHistoryProviderOptions = {}) {
-    this.historyScope = options.historyScope ?? "repo";
+    this.historyScope = options.historyScope ?? "package";
   }
 
   async fetch(request: ContextRequest): Promise<ContextProviderResult> {

--- a/src/context/engine/providers/static-rules.ts
+++ b/src/context/engine/providers/static-rules.ts
@@ -104,7 +104,9 @@ export class StaticRulesProvider implements IContextProvider {
           const hash = contentHash8(rule.content);
           const tokens = estimateTokens(rule.content);
           return {
-            id: `static-rules:${hash}`,
+            // Include fileName so two rules with identical content but different names
+            // are not deduplicated by the packing stage (content-hash collision).
+            id: `static-rules:${rule.fileName}:${hash}`,
             kind: "static" as const,
             scope: "project" as const,
             role: ["all"] as ["all"],

--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -164,7 +164,9 @@ export async function assembleForStage(
       packageDir,
       stage,
       role: stageConfig.role,
-      budgetTokens: stageConfig.budgetTokens,
+      // AC-59: per-package stage budget — reads from ctx.config which is already the
+      // merged config (root + <repoRoot>/.nax/mono/<packageDir>/config.json overlay).
+      budgetTokens: ctx.config.context?.v2?.stages?.[stage]?.budgetTokens ?? stageConfig.budgetTokens,
       touchedFiles: options.touchedFiles ?? getContextFiles(ctx.story),
       storyScratchDirs,
       priorStageDigest: options.priorStageDigest ?? ctx.contextBundle?.digest,

--- a/test/unit/config/merge.test.ts
+++ b/test/unit/config/merge.test.ts
@@ -600,3 +600,61 @@ describe("mergePackageConfig — project field (US-001)", () => {
     expect(root.project?.language).toBe(origLang);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-59: per-package context.v2.stages budget overrides
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("mergePackageConfig — AC-59 context.v2.stages budget overrides", () => {
+  test("root context.v2.stages is preserved when no package override", () => {
+    const root = makeRoot();
+    const result = mergePackageConfig(root, { quality: { requireTests: false } } as Partial<NaxConfig>);
+    expect(result.context.v2.stages).toEqual({});
+  });
+
+  test("package override sets a stage budget", () => {
+    const root = makeRoot();
+    const result = mergePackageConfig(root, {
+      context: { v2: { stages: { execution: { budgetTokens: 15_000 } } } } as unknown as Partial<NaxConfig["context"]>,
+    } as Partial<NaxConfig>);
+    expect(result.context.v2.stages.execution?.budgetTokens).toBe(15_000);
+  });
+
+  test("package override does not clobber other stages from root", () => {
+    const root = {
+      ...makeRoot(),
+      context: {
+        ...makeRoot().context,
+        v2: { ...makeRoot().context.v2, stages: { verify: { budgetTokens: 4_000 } } },
+      },
+    };
+    const result = mergePackageConfig(root, {
+      context: { v2: { stages: { execution: { budgetTokens: 15_000 } } } } as unknown as Partial<NaxConfig["context"]>,
+    } as Partial<NaxConfig>);
+    expect(result.context.v2.stages.execution?.budgetTokens).toBe(15_000);
+    expect(result.context.v2.stages.verify?.budgetTokens).toBe(4_000);
+  });
+
+  test("package override wins over root for same stage", () => {
+    const root = {
+      ...makeRoot(),
+      context: {
+        ...makeRoot().context,
+        v2: { ...makeRoot().context.v2, stages: { execution: { budgetTokens: 8_000 } } },
+      },
+    };
+    const result = mergePackageConfig(root, {
+      context: { v2: { stages: { execution: { budgetTokens: 20_000 } } } } as unknown as Partial<NaxConfig["context"]>,
+    } as Partial<NaxConfig>);
+    expect(result.context.v2.stages.execution?.budgetTokens).toBe(20_000);
+  });
+
+  test("does not mutate root context.v2.stages", () => {
+    const root = makeRoot();
+    const origStages = root.context.v2.stages;
+    mergePackageConfig(root, {
+      context: { v2: { stages: { execution: { budgetTokens: 15_000 } } } } as unknown as Partial<NaxConfig["context"]>,
+    } as Partial<NaxConfig>);
+    expect(root.context.v2.stages).toBe(origStages);
+  });
+});

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -275,12 +275,12 @@ describe("CodeNeighborProvider — AC-56/AC-62 neighborScope + crossPackageDepth
     return captured;
   }
 
-  test("default neighborScope is 'repo' — glob runs in repoRoot", async () => {
+  test("default neighborScope is 'package' — glob runs in packageDir (and repoRoot via crossPackageDepth=1)", async () => {
     const cwds = captureGlobCwds();
     const p = new CodeNeighborProvider();
     await p.fetch(MONOREPO_REQUEST);
-    expect(cwds).toContain("/repo");
-    expect(cwds).not.toContain("/repo/packages/api");
+    expect(cwds).toContain("/repo/packages/api");
+    expect(cwds).toContain("/repo"); // crossPackageDepth defaults to 1
   });
 
   test("neighborScope 'repo' — glob runs in repoRoot", async () => {
@@ -291,9 +291,9 @@ describe("CodeNeighborProvider — AC-56/AC-62 neighborScope + crossPackageDepth
     expect(cwds).not.toContain("/repo/packages/api");
   });
 
-  test("neighborScope 'package' — glob runs in packageDir", async () => {
+  test("neighborScope 'package' crossPackageDepth 0 — glob only in packageDir", async () => {
     const cwds = captureGlobCwds();
-    const p = new CodeNeighborProvider({ neighborScope: "package" } as CodeNeighborProviderOptions);
+    const p = new CodeNeighborProvider({ neighborScope: "package", crossPackageDepth: 0 } as CodeNeighborProviderOptions);
     await p.fetch(MONOREPO_REQUEST);
     expect(cwds).toContain("/repo/packages/api");
     expect(cwds).not.toContain("/repo");
@@ -306,7 +306,7 @@ describe("CodeNeighborProvider — AC-56/AC-62 neighborScope + crossPackageDepth
     expect(cwds).toContain("/repo");
   });
 
-  test("crossPackageDepth 0 (default) with neighborScope 'package' — glob only in packageDir", async () => {
+  test("crossPackageDepth 0 with neighborScope 'package' — glob only in packageDir", async () => {
     const cwds = captureGlobCwds();
     const p = new CodeNeighborProvider({ neighborScope: "package", crossPackageDepth: 0 } as CodeNeighborProviderOptions);
     await p.fetch(MONOREPO_REQUEST);

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -17,17 +17,22 @@ import type { ContextRequest } from "../../../../../src/context/engine/types";
 let origFileExists: typeof _codeNeighborDeps.fileExists;
 let origReadFile: typeof _codeNeighborDeps.readFile;
 let origGlob: typeof _codeNeighborDeps.glob;
+let origDiscoverWorkspacePackages: typeof _codeNeighborDeps.discoverWorkspacePackages;
 
 beforeEach(() => {
   origFileExists = _codeNeighborDeps.fileExists;
   origReadFile = _codeNeighborDeps.readFile;
   origGlob = _codeNeighborDeps.glob;
+  origDiscoverWorkspacePackages = _codeNeighborDeps.discoverWorkspacePackages;
+  // Default: no workspace packages (non-monorepo fallback)
+  _codeNeighborDeps.discoverWorkspacePackages = async () => [];
 });
 
 afterEach(() => {
   _codeNeighborDeps.fileExists = origFileExists;
   _codeNeighborDeps.readFile = origReadFile;
   _codeNeighborDeps.glob = origGlob;
+  _codeNeighborDeps.discoverWorkspacePackages = origDiscoverWorkspacePackages;
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -314,11 +319,32 @@ describe("CodeNeighborProvider — AC-56/AC-62 neighborScope + crossPackageDepth
     expect(cwds).not.toContain("/repo");
   });
 
-  test("crossPackageDepth 1 with neighborScope 'package' — also scans repoRoot", async () => {
+  test("crossPackageDepth 1 with neighborScope 'package' — falls back to repoRoot when no workspace detected", async () => {
     const cwds = captureGlobCwds();
+    // discoverWorkspacePackages already returns [] from beforeEach → fallback to repoRoot
     const p = new CodeNeighborProvider({ neighborScope: "package", crossPackageDepth: 1 } as CodeNeighborProviderOptions);
     await p.fetch(MONOREPO_REQUEST);
     expect(cwds).toContain("/repo/packages/api");
     expect(cwds).toContain("/repo");
+  });
+
+  test("crossPackageDepth 1 — workspace detection scans detected package dirs (excludes current packageDir)", async () => {
+    const cwds = captureGlobCwds();
+    // Simulate workspace detection finding packages/api and packages/web
+    _codeNeighborDeps.discoverWorkspacePackages = async () => ["packages/api", "packages/web"];
+    const p = new CodeNeighborProvider({ neighborScope: "package", crossPackageDepth: 1 } as CodeNeighborProviderOptions);
+    await p.fetch(MONOREPO_REQUEST);
+    // packages/api is the current packageDir — excluded
+    expect(cwds).toContain("/repo/packages/api"); // primary workdir scan
+    expect(cwds).toContain("/repo/packages/web"); // cross-package scan
+    expect(cwds).not.toContain("/repo"); // not fallback — workspace was detected
+  });
+
+  test("crossPackageDepth 1 — non-monorepo (packageDir === repoRoot) skips cross-package scan", async () => {
+    const cwds = captureGlobCwds();
+    const p = new CodeNeighborProvider({ neighborScope: "package", crossPackageDepth: 1 } as CodeNeighborProviderOptions);
+    await p.fetch(makeRequest({ touchedFiles: ["src/a.ts"] })); // packageDir === repoRoot
+    // Only one glob call (primary workdir), no cross-package
+    expect(cwds.filter((c) => c === "/repo")).toHaveLength(1);
   });
 });

--- a/test/unit/context/engine/providers/git-history.test.ts
+++ b/test/unit/context/engine/providers/git-history.test.ts
@@ -51,7 +51,7 @@ function mockGit(responses: Map<string, { stdout: string; exitCode: number }>) {
 /** Installs a mock that captures workdirs and returns success for every file */
 function captureWorkdirs(): string[] {
   const captured: string[] = [];
-  _gitHistoryDeps.gitWithTimeout = async (args: string[], workdir: string) => {
+  _gitHistoryDeps.gitWithTimeout = async (_args: string[], workdir: string) => {
     captured.push(workdir);
     return { stdout: "abc1234 feat: something", exitCode: 0 };
   };
@@ -204,11 +204,11 @@ describe("GitHistoryProvider — AC-55 historyScope", () => {
     touchedFiles: ["src/service.ts"],
   };
 
-  test("default historyScope is 'repo' — uses repoRoot", async () => {
+  test("default historyScope is 'package' — uses packageDir", async () => {
     const workdirs = captureWorkdirs();
     const p = new GitHistoryProvider();
     await p.fetch(MONOREPO_REQUEST);
-    expect(workdirs[0]).toBe("/repo");
+    expect(workdirs[0]).toBe("/repo/packages/api");
   });
 
   test("historyScope 'repo' — uses repoRoot", async () => {

--- a/test/unit/context/engine/providers/static-rules.test.ts
+++ b/test/unit/context/engine/providers/static-rules.test.ts
@@ -374,4 +374,36 @@ describe("StaticRulesProvider — AC-57 per-package overlay", () => {
     expect(result.chunks).toHaveLength(1);
     expect(result.chunks[0]?.content).toContain("Repo style.");
   });
+
+  test("monorepo: loadCanonicalRules is called exactly twice (repo + package)", async () => {
+    const calls: string[] = [];
+    _staticRulesDeps.loadCanonicalRules = async (workdir: string) => {
+      calls.push(workdir);
+      if (workdir === "/repo") return [{ fileName: "style.md", content: "Repo style." }];
+      return [{ fileName: "pkg.md", content: "Pkg style." }];
+    };
+    const provider = new StaticRulesProvider();
+    await provider.fetch(MONOREPO_REQUEST);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toBe("/repo");
+    expect(calls[1]).toBe("/repo/packages/api");
+  });
+
+  test("chunk IDs include fileName to prevent dedup collision for same-content rules", async () => {
+    const sharedContent = "Identical content.";
+    _staticRulesDeps.loadCanonicalRules = async (workdir: string) => {
+      if (workdir === "/repo") return [{ fileName: "rule-a.md", content: sharedContent }];
+      if (workdir === "/repo/packages/api") return [{ fileName: "rule-b.md", content: sharedContent }];
+      return [];
+    };
+    const provider = new StaticRulesProvider();
+    const result = await provider.fetch(MONOREPO_REQUEST);
+    // Overlay: map has rule-a.md and rule-b.md — both kept since different filenames
+    expect(result.chunks).toHaveLength(2);
+    const ids = result.chunks.map((c) => c.id);
+    expect(ids.some((id) => id.includes("rule-a.md"))).toBe(true);
+    expect(ids.some((id) => id.includes("rule-b.md"))).toBe(true);
+    // IDs must be distinct even though content hashes are identical
+    expect(ids[0]).not.toBe(ids[1]);
+  });
 });


### PR DESCRIPTION
## Summary

Post-review fixes for issue #479 (Amendment C — monorepo scoping). Addresses all critical and important findings from the code review of PRs #490–#492:

- **Wrong defaults (critical)**: `historyScope`, `neighborScope`, `crossPackageDepth` had inverted defaults vs. spec. Fixed to `"package"`, `"package"`, `1` respectively.
- **AC-62 workspace detection**: Implement `discoverWorkspacePackages` integration in `CodeNeighborProvider` — uses detected workspace package dirs as cross-package scan roots instead of scanning the full `repoRoot`. Falls back to `repoRoot` when no workspace config is found.
- **AC-59 redesign**: Replace wrong global `packageBudgets` map approach with per-package config file pattern (`<repoRoot>/.nax/mono/<packageDir>/config.json`) following the existing quality config layering. Adds `context.v2.stages` to schema and `mergePackageConfig` deep-merge.
- **AC-57 chunk ID collision**: Include `fileName` in chunk ID (`static-rules:<fileName>:<hash>`) to prevent dedup when two rules share identical content.
- **Missing tests**: Two new AC-57 tests (two-level linter call count, chunk ID uniqueness), three new AC-62 tests (workspace detection, fallback, non-monorepo skip), five new AC-59 tests in `merge.test.ts`.

## Test plan

- [ ] `bun test test/unit/context/engine/` — 345 tests, 0 fail
- [ ] `bun test test/unit/config/merge.test.ts` — includes 5 new AC-59 tests
- [ ] `bun run typecheck` — clean
- [ ] Verify `historyScope` default = `"package"` in `git-history.ts:95`
- [ ] Verify `neighborScope` default = `"package"`, `crossPackageDepth` default = `1` in `code-neighbor.ts:230-231`
- [ ] Verify chunk ID format `static-rules:<fileName>:<hash>` in `static-rules.ts:111`
- [ ] Verify `context.v2.stages` schema in `schemas.ts` and `mergePackageConfig` in `merge.ts`