### PR TITLE
feat(metrics): AC-18 context.providers metrics from manifests

### DIFF
--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -236,10 +236,17 @@ export class ContextOrchestrator {
           const result = await fetchWithTimeout(provider, request);
           const durationMs = _orchestratorDeps.now() - providerStart;
           const status = result.chunks.length === 0 ? ("empty" as const) : ("ok" as const);
+          const tokensProduced = result.chunks.reduce((sum, c) => sum + c.tokens, 0);
           return {
             provider,
             result,
-            providerStatus: { providerId: provider.id, status, chunkCount: result.chunks.length, durationMs },
+            providerStatus: {
+              providerId: provider.id,
+              status,
+              chunkCount: result.chunks.length,
+              durationMs,
+              tokensProduced,
+            },
           };
         } catch (err) {
           const durationMs = _orchestratorDeps.now() - providerStart;
@@ -252,7 +259,14 @@ export class ContextOrchestrator {
           return {
             provider,
             result: { chunks: [], pullTools: [] },
-            providerStatus: { providerId: provider.id, status, chunkCount: 0, durationMs, error: errMsg },
+            providerStatus: {
+              providerId: provider.id,
+              status,
+              chunkCount: 0,
+              durationMs,
+              tokensProduced: 0,
+              error: errMsg,
+            },
           };
         }
       }),

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -179,6 +179,8 @@ export interface ContextManifest {
     status: "ok" | "empty" | "failed" | "timeout";
     chunkCount: number;
     durationMs: number;
+    /** Total tokens across all chunks returned by this provider */
+    tokensProduced: number;
     error?: string;
   }>;
   /**

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -6,9 +6,10 @@
 
 import path from "node:path";
 import { resolveModelForAgent } from "../config/schema";
+import { loadContextManifests } from "../context/engine/manifest-store";
 import type { PipelineContext } from "../pipeline/types";
 import { loadJsonFile, saveJsonFile } from "../utils/json-file";
-import type { RunMetrics, StoryMetrics } from "./types";
+import type { ContextProviderMetrics, RunMetrics, StoryMetrics } from "./types";
 import { TokenUsage } from "./types";
 
 /**
@@ -38,7 +39,45 @@ import { TokenUsage } from "./types";
  * // }
  * ```
  */
-export function collectStoryMetrics(ctx: PipelineContext, storyStartTime: string): StoryMetrics {
+async function deriveContextMetrics(
+  projectDir: string,
+  storyId: string,
+  featureId: string,
+): Promise<StoryMetrics["context"] | undefined> {
+  const stored = await loadContextManifests(projectDir, storyId, featureId);
+  if (stored.length === 0) return undefined;
+
+  const providers: Record<string, ContextProviderMetrics> = {};
+
+  for (const { manifest } of stored) {
+    if (!manifest.providerResults) continue;
+    for (const pr of manifest.providerResults) {
+      const existing = providers[pr.providerId];
+      const kept = manifest.includedChunks.filter((id) => id.startsWith(`${pr.providerId}:`)).length;
+      if (existing) {
+        existing.tokensProduced += pr.tokensProduced;
+        existing.chunksProduced += pr.chunkCount;
+        existing.chunksKept += kept;
+        existing.wallClockMs += pr.durationMs;
+        if (pr.status === "timeout") existing.timedOut = true;
+        if (pr.status === "failed") existing.failed = true;
+      } else {
+        providers[pr.providerId] = {
+          tokensProduced: pr.tokensProduced,
+          chunksProduced: pr.chunkCount,
+          chunksKept: kept,
+          wallClockMs: pr.durationMs,
+          timedOut: pr.status === "timeout",
+          failed: pr.status === "failed",
+        };
+      }
+    }
+  }
+
+  return Object.keys(providers).length === 0 ? undefined : { providers };
+}
+
+export async function collectStoryMetrics(ctx: PipelineContext, storyStartTime: string): Promise<StoryMetrics> {
   const story = ctx.story;
   const routing = ctx.routing;
   const agentResult = ctx.agentResult;
@@ -79,6 +118,10 @@ export function collectStoryMetrics(ctx: PipelineContext, storyStartTime: string
     routing.testStrategy === "three-session-tdd" || routing.testStrategy === "three-session-tdd-lite";
   const fullSuiteGatePassed = isTddStrategy ? (ctx.fullSuiteGatePassed ?? false) : false;
 
+  const featureId = ctx.prd.feature;
+  const contextMetrics =
+    ctx.projectDir && featureId ? await deriveContextMetrics(ctx.projectDir, story.id, featureId) : undefined;
+
   return {
     storyId: story.id,
     complexity: routing.complexity,
@@ -113,6 +156,7 @@ export function collectStoryMetrics(ctx: PipelineContext, storyStartTime: string
     ...(ctx.verifyResult?.scopeTestFallback !== undefined && {
       scopeTestFallback: ctx.verifyResult.scopeTestFallback,
     }),
+    ...(contextMetrics !== undefined && { context: contextMetrics }),
   };
 }
 

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -53,6 +53,18 @@ export class TokenUsage {
 }
 
 /**
+ * Aggregated context provider metrics across all pipeline stages for a story.
+ */
+export interface ContextProviderMetrics {
+  tokensProduced: number;
+  chunksProduced: number;
+  chunksKept: number;
+  wallClockMs: number;
+  timedOut: boolean;
+  failed: boolean;
+}
+
+/**
  * Per-story execution metrics
  */
 export interface StoryMetrics {
@@ -96,6 +108,13 @@ export interface StoryMetrics {
   tokens?: TokenUsage;
   /** When ScopedStrategy.verify() falls back to full suite due to threshold (US-002) */
   scopeTestFallback?: boolean;
+  /**
+   * Per-provider context engine metrics aggregated across all pipeline stages.
+   * Absent when context engine v2 was not active or no manifests were found.
+   */
+  context?: {
+    providers: Record<string, ContextProviderMetrics>;
+  };
   /**
    * Per-reviewer metrics for the review stage.
    * Populated when semantic or adversarial review runs.

--- a/src/pipeline/stages/completion.ts
+++ b/src/pipeline/stages/completion.ts
@@ -41,7 +41,7 @@ export const completionStage: PipelineStage = {
     if (isBatch) {
       ctx.storyMetrics = collectBatchMetrics(ctx, storyStartTime);
     } else {
-      ctx.storyMetrics = [collectStoryMetrics(ctx, storyStartTime)];
+      ctx.storyMetrics = [await collectStoryMetrics(ctx, storyStartTime)];
     }
 
     // Mark all stories in batch as passed

--- a/test/unit/metrics/tracker-context-metrics.test.ts
+++ b/test/unit/metrics/tracker-context-metrics.test.ts
@@ -1,0 +1,257 @@
+/**
+ * AC-18: StoryMetrics.context.providers populated from context manifests.
+ *
+ * Verifies that collectStoryMetrics() reads on-disk context manifests for the
+ * story and aggregates per-provider metrics (tokensProduced, chunksProduced,
+ * chunksKept, wallClockMs, timedOut, failed) across all pipeline stages.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { _manifestStoreDeps } from "../../../src/context/engine/manifest-store";
+import { collectStoryMetrics } from "../../../src/metrics/tracker";
+import type { PipelineContext } from "../../../src/pipeline/types";
+import type { ContextManifest } from "../../../src/context/engine/types";
+import { DEFAULT_CONFIG } from "../../../src/config/defaults";
+import type { PRD, UserStory } from "../../../src/prd";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PROJECT_DIR = "/repo";
+const FEATURE = "test-feature";
+const STORY_ID = "US-001";
+
+function makeStory(): UserStory {
+  return {
+    id: STORY_ID,
+    title: "Test Story",
+    description: "Test",
+    acceptanceCriteria: [],
+    tags: [],
+    dependencies: [],
+    status: "passed",
+    passes: true,
+    escalations: [],
+    attempts: 1,
+  };
+}
+
+function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
+  const story = makeStory();
+  return {
+    config: DEFAULT_CONFIG,
+    prd: {
+      project: "test",
+      feature: FEATURE,
+      branchName: "feat/test",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      userStories: [story],
+    } satisfies PRD,
+    story,
+    stories: [story],
+    routing: { complexity: "medium", modelTier: "balanced", testStrategy: "test-after", reasoning: "test" },
+    workdir: PROJECT_DIR,
+    projectDir: PROJECT_DIR,
+    hooks: { hooks: {} },
+    agentResult: { success: true, output: "", estimatedCost: 0.01, durationMs: 5000 },
+    ...overrides,
+  } as unknown as PipelineContext;
+}
+
+function makeManifest(overrides?: Partial<ContextManifest>): ContextManifest {
+  return {
+    requestId: "req-001",
+    stage: "execution",
+    totalBudgetTokens: 8000,
+    usedTokens: 500,
+    includedChunks: [],
+    excludedChunks: [],
+    floorItems: [],
+    digestTokens: 50,
+    buildMs: 120,
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock manifest store deps
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origListFeatureDirs: typeof _manifestStoreDeps.listFeatureDirs;
+let origListManifestFiles: typeof _manifestStoreDeps.listManifestFiles;
+let origFileExists: typeof _manifestStoreDeps.fileExists;
+let origReadFile: typeof _manifestStoreDeps.readFile;
+
+function mockManifests(manifests: Record<string, ContextManifest>) {
+  // manifests: key = "<featureId>/<stage>" → manifest
+  _manifestStoreDeps.listFeatureDirs = async () => [FEATURE];
+  _manifestStoreDeps.listManifestFiles = async () =>
+    Object.keys(manifests)
+      .filter((k) => k.startsWith(`${FEATURE}/`))
+      .map((k) => `context-manifest-${k.split("/")[1]}.json`);
+  _manifestStoreDeps.fileExists = async () => true;
+  _manifestStoreDeps.readFile = async (path: string) => {
+    const stage = path.replace(/.*context-manifest-/, "").replace(/\.json$/, "");
+    const m = manifests[`${FEATURE}/${stage}`];
+    return m ? JSON.stringify(m) : "{}";
+  };
+}
+
+beforeEach(() => {
+  origListFeatureDirs = _manifestStoreDeps.listFeatureDirs;
+  origListManifestFiles = _manifestStoreDeps.listManifestFiles;
+  origFileExists = _manifestStoreDeps.fileExists;
+  origReadFile = _manifestStoreDeps.readFile;
+});
+
+afterEach(() => {
+  _manifestStoreDeps.listFeatureDirs = origListFeatureDirs;
+  _manifestStoreDeps.listManifestFiles = origListManifestFiles;
+  _manifestStoreDeps.fileExists = origFileExists;
+  _manifestStoreDeps.readFile = origReadFile;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("collectStoryMetrics — AC-18 context.providers", () => {
+  test("context is undefined when projectDir is absent", async () => {
+    const ctx = makeCtx({ projectDir: undefined } as Partial<PipelineContext>);
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+    expect(metrics.context).toBeUndefined();
+  });
+
+  test("context is undefined when no manifests exist", async () => {
+    mockManifests({});
+    const ctx = makeCtx();
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+    expect(metrics.context).toBeUndefined();
+  });
+
+  test("populates chunksProduced from providerResults.chunkCount", async () => {
+    mockManifests({
+      [`${FEATURE}/execution`]: makeManifest({
+        providerResults: [
+          { providerId: "static-rules", status: "ok", chunkCount: 3, durationMs: 50, tokensProduced: 300 },
+        ],
+        includedChunks: ["static-rules:a:001", "static-rules:b:002", "static-rules:c:003"],
+      }),
+    });
+    const ctx = makeCtx();
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+    expect(metrics.context?.providers["static-rules"]?.chunksProduced).toBe(3);
+  });
+
+  test("populates chunksKept by counting included chunks matching provider prefix", async () => {
+    mockManifests({
+      [`${FEATURE}/execution`]: makeManifest({
+        providerResults: [
+          { providerId: "static-rules", status: "ok", chunkCount: 3, durationMs: 50, tokensProduced: 300 },
+          { providerId: "git-history", status: "ok", chunkCount: 2, durationMs: 30, tokensProduced: 150 },
+        ],
+        includedChunks: [
+          "static-rules:a:001",
+          "static-rules:b:002",
+          "git-history:c:003", // only 1 of 2 git-history chunks kept
+        ],
+      }),
+    });
+    const ctx = makeCtx();
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+    expect(metrics.context?.providers["static-rules"]?.chunksKept).toBe(2);
+    expect(metrics.context?.providers["git-history"]?.chunksKept).toBe(1);
+  });
+
+  test("populates wallClockMs from providerResults.durationMs", async () => {
+    mockManifests({
+      [`${FEATURE}/execution`]: makeManifest({
+        providerResults: [
+          { providerId: "code-neighbor", status: "ok", chunkCount: 1, durationMs: 80, tokensProduced: 40 },
+        ],
+        includedChunks: ["code-neighbor:x:001"],
+      }),
+    });
+    const ctx = makeCtx();
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+    expect(metrics.context?.providers["code-neighbor"]?.wallClockMs).toBe(80);
+  });
+
+  test("timedOut is true when any stage shows timeout for that provider", async () => {
+    mockManifests({
+      [`${FEATURE}/execution`]: makeManifest({
+        providerResults: [
+          { providerId: "pull-tool", status: "timeout", chunkCount: 0, durationMs: 5000, tokensProduced: 0 },
+        ],
+        includedChunks: [],
+      }),
+    });
+    const ctx = makeCtx();
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+    expect(metrics.context?.providers["pull-tool"]?.timedOut).toBe(true);
+    expect(metrics.context?.providers["pull-tool"]?.failed).toBe(false);
+  });
+
+  test("failed is true when any stage shows failed for that provider", async () => {
+    mockManifests({
+      [`${FEATURE}/execution`]: makeManifest({
+        providerResults: [
+          { providerId: "plugin-rag", status: "failed", chunkCount: 0, durationMs: 20, tokensProduced: 0, error: "oops" },
+        ],
+        includedChunks: [],
+      }),
+    });
+    const ctx = makeCtx();
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+    expect(metrics.context?.providers["plugin-rag"]?.failed).toBe(true);
+    expect(metrics.context?.providers["plugin-rag"]?.timedOut).toBe(false);
+  });
+
+  test("aggregates metrics across multiple stages for the same provider", async () => {
+    mockManifests({
+      [`${FEATURE}/execution`]: makeManifest({
+        stage: "execution",
+        providerResults: [
+          { providerId: "static-rules", status: "ok", chunkCount: 2, durationMs: 40, tokensProduced: 200 },
+        ],
+        includedChunks: ["static-rules:a:001", "static-rules:b:002"],
+      }),
+      [`${FEATURE}/tdd-implementer`]: makeManifest({
+        stage: "tdd-implementer",
+        providerResults: [
+          { providerId: "static-rules", status: "ok", chunkCount: 2, durationMs: 35, tokensProduced: 200 },
+        ],
+        includedChunks: ["static-rules:a:001"], // only 1 kept in this stage
+      }),
+    });
+    const ctx = makeCtx();
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+    const p = metrics.context?.providers["static-rules"];
+    expect(p?.chunksProduced).toBe(4); // 2 + 2
+    expect(p?.chunksKept).toBe(3);     // 2 + 1
+    expect(p?.wallClockMs).toBe(75);   // 40 + 35
+    expect(p?.tokensProduced).toBe(400); // 200 + 200
+  });
+
+  test("tokensProduced sums across stages", async () => {
+    mockManifests({
+      [`${FEATURE}/execution`]: makeManifest({
+        providerResults: [
+          { providerId: "code-neighbor", status: "ok", chunkCount: 1, durationMs: 10, tokensProduced: 120 },
+        ],
+        includedChunks: ["code-neighbor:x:001"],
+      }),
+      [`${FEATURE}/verify`]: makeManifest({
+        providerResults: [
+          { providerId: "code-neighbor", status: "ok", chunkCount: 1, durationMs: 8, tokensProduced: 100 },
+        ],
+        includedChunks: ["code-neighbor:x:001"],
+      }),
+    });
+    const ctx = makeCtx();
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+    expect(metrics.context?.providers["code-neighbor"]?.tokensProduced).toBe(220);
+  });
+});

--- a/test/unit/metrics/tracker-escalation.test.ts
+++ b/test/unit/metrics/tracker-escalation.test.ts
@@ -148,7 +148,7 @@ describe("collectStoryMetrics — firstPassSuccess is false when escalation occu
     },
   ])(
     "$name",
-    ({
+    async ({
       attempts,
       hasPriorFailures,
       hasEscalations,
@@ -202,7 +202,7 @@ describe("collectStoryMetrics — firstPassSuccess is false when escalation occu
         },
       });
 
-      const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+      const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
       expect(metrics.firstPassSuccess).toBe(expectedFirstPassSuccess);
     },
   );
@@ -243,7 +243,7 @@ describe("collectStoryMetrics — attempt count includes all cross-tier attempts
       priorFailuresCount: 1,
       expectedAttempts: 2,
     },
-  ])("$name", ({ attempts, priorFailuresCount, expectedAttempts }) => {
+  ])("$name", async ({ attempts, priorFailuresCount, expectedAttempts }) => {
     const priorFailures = Array.from({ length: priorFailuresCount }, (_, i) => ({
       attempt: i + 1,
       modelTier: "fast" as const,
@@ -258,7 +258,7 @@ describe("collectStoryMetrics — attempt count includes all cross-tier attempts
     });
 
     const ctx = makeCtx(story);
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.attempts).toBe(expectedAttempts);
   });
@@ -302,7 +302,7 @@ describe("collectStoryMetrics — cost accumulates across all tier escalations",
     },
   ])(
     "$name",
-    ({
+    async ({
       priorFailuresCount,
       priorAttemptCost,
       currentAttemptCost,
@@ -347,7 +347,7 @@ describe("collectStoryMetrics — cost accumulates across all tier escalations",
         accumulatedAttemptCost: priorAttemptCost,
       } as any);
 
-      const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+      const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
       expect(metrics.cost).toBeCloseTo(expectedCost, 5);
     },
   );

--- a/test/unit/metrics/tracker-full-suite-gate.test.ts
+++ b/test/unit/metrics/tracker-full-suite-gate.test.ts
@@ -82,11 +82,11 @@ function makeCtx(
 // ---------------------------------------------------------------------------
 
 describe("StoryMetrics type - fullSuiteGatePassed field", () => {
-  test("StoryMetrics includes fullSuiteGatePassed field", () => {
+  test("StoryMetrics includes fullSuiteGatePassed field", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { testStrategy: "three-session-tdd" }, { fullSuiteGatePassed: true });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect("fullSuiteGatePassed" in metrics).toBe(true);
   });
@@ -97,39 +97,39 @@ describe("StoryMetrics type - fullSuiteGatePassed field", () => {
 // ---------------------------------------------------------------------------
 
 describe("collectStoryMetrics - fullSuiteGatePassed for TDD strategies", () => {
-  test("returns true for three-session-tdd when ctx.fullSuiteGatePassed is true", () => {
+  test("returns true for three-session-tdd when ctx.fullSuiteGatePassed is true", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { testStrategy: "three-session-tdd" }, { fullSuiteGatePassed: true });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.fullSuiteGatePassed).toBe(true);
   });
 
-  test("returns true for three-session-tdd-lite when ctx.fullSuiteGatePassed is true", () => {
+  test("returns true for three-session-tdd-lite when ctx.fullSuiteGatePassed is true", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { testStrategy: "three-session-tdd-lite" }, { fullSuiteGatePassed: true });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.fullSuiteGatePassed).toBe(true);
   });
 
-  test("returns false for three-session-tdd when ctx.fullSuiteGatePassed is false", () => {
+  test("returns false for three-session-tdd when ctx.fullSuiteGatePassed is false", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { testStrategy: "three-session-tdd" }, { fullSuiteGatePassed: false });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.fullSuiteGatePassed).toBe(false);
   });
 
-  test("returns false for three-session-tdd when ctx.fullSuiteGatePassed is undefined", () => {
+  test("returns false for three-session-tdd when ctx.fullSuiteGatePassed is undefined", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { testStrategy: "three-session-tdd" });
     // fullSuiteGatePassed not set in ctx
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.fullSuiteGatePassed).toBe(false);
   });
@@ -140,38 +140,38 @@ describe("collectStoryMetrics - fullSuiteGatePassed for TDD strategies", () => {
 // ---------------------------------------------------------------------------
 
 describe("collectStoryMetrics - fullSuiteGatePassed always false for non-TDD strategies", () => {
-  test("returns false for test-after even when ctx.fullSuiteGatePassed is true", () => {
+  test("returns false for test-after even when ctx.fullSuiteGatePassed is true", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { testStrategy: "test-after" }, { fullSuiteGatePassed: true });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.fullSuiteGatePassed).toBe(false);
   });
 
-  test("returns false for tdd-simple even when ctx.fullSuiteGatePassed is true", () => {
+  test("returns false for tdd-simple even when ctx.fullSuiteGatePassed is true", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { testStrategy: "tdd-simple" }, { fullSuiteGatePassed: true });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.fullSuiteGatePassed).toBe(false);
   });
 
-  test("returns false for test-after when ctx.fullSuiteGatePassed is false", () => {
+  test("returns false for test-after when ctx.fullSuiteGatePassed is false", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { testStrategy: "test-after" }, { fullSuiteGatePassed: false });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.fullSuiteGatePassed).toBe(false);
   });
 
-  test("returns false for tdd-simple when ctx.fullSuiteGatePassed is false", () => {
+  test("returns false for tdd-simple when ctx.fullSuiteGatePassed is false", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { testStrategy: "tdd-simple" }, { fullSuiteGatePassed: false });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.fullSuiteGatePassed).toBe(false);
   });
@@ -182,7 +182,7 @@ describe("collectStoryMetrics - fullSuiteGatePassed always false for non-TDD str
 // ---------------------------------------------------------------------------
 
 describe("collectBatchMetrics - fullSuiteGatePassed always false", () => {
-  test("batch metrics always have fullSuiteGatePassed: false", () => {
+  test("batch metrics always have fullSuiteGatePassed: false", async () => {
     const story1 = makeStory({ id: "US-001" });
     const story2 = makeStory({ id: "US-002" });
     const prd: PRD = {

--- a/test/unit/metrics/tracker-runtime-crashes.test.ts
+++ b/test/unit/metrics/tracker-runtime-crashes.test.ts
@@ -82,44 +82,34 @@ const STORY_START_TIME = "2026-03-10T10:00:00.000Z";
 // ---------------------------------------------------------------------------
 
 describe("collectStoryMetrics - runtimeCrashes field", () => {
-  test("runtimeCrashes is 0 when no crashes occurred", () => {
+  test("runtimeCrashes is 0 when no crashes occurred", async () => {
     const story = makeStory();
     const ctx = makeContext(story);
 
-    const metrics = collectStoryMetrics(ctx, STORY_START_TIME);
+    const metrics = await collectStoryMetrics(ctx, STORY_START_TIME);
 
-    // RED: runtimeCrashes field does not exist in StoryMetrics yet
-    // When implemented, a story with no crashes should report 0
-    expect((metrics as Record<string, unknown>).runtimeCrashes).toBe(0);
+    expect(metrics.runtimeCrashes).toBe(0);
   });
 
-  test("runtimeCrashes reflects count from ctx.storyRuntimeCrashes", () => {
+  test("runtimeCrashes reflects count from ctx.storyRuntimeCrashes", async () => {
     const story = makeStory({ status: "passed", passes: true });
-    // RED: storyRuntimeCrashes does not exist in PipelineContext yet
-    const ctx = makeContext(story, {
-      // @ts-expect-error: storyRuntimeCrashes not in PipelineContext until BUG-070 is implemented
-      storyRuntimeCrashes: 2,
-    });
+    const ctx = makeContext(story, { storyRuntimeCrashes: 2 });
 
-    const metrics = collectStoryMetrics(ctx, STORY_START_TIME);
+    const metrics = await collectStoryMetrics(ctx, STORY_START_TIME);
 
-    // RED: runtimeCrashes not in StoryMetrics yet — will be undefined
-    expect((metrics as Record<string, unknown>).runtimeCrashes).toBe(2);
+    expect(metrics.runtimeCrashes).toBe(2);
   });
 
-  test("runtimeCrashes is 1 for a single crash retry", () => {
+  test("runtimeCrashes is 1 for a single crash retry", async () => {
     const story = makeStory({ status: "passed", passes: true });
-    const ctx = makeContext(story, {
-      // @ts-expect-error: storyRuntimeCrashes not in PipelineContext until BUG-070 is implemented
-      storyRuntimeCrashes: 1,
-    });
+    const ctx = makeContext(story, { storyRuntimeCrashes: 1 });
 
-    const metrics = collectStoryMetrics(ctx, STORY_START_TIME);
+    const metrics = await collectStoryMetrics(ctx, STORY_START_TIME);
 
-    expect((metrics as Record<string, unknown>).runtimeCrashes).toBe(1);
+    expect(metrics.runtimeCrashes).toBe(1);
   });
 
-  test("runtimeCrashes is independent of story.escalations count", () => {
+  test("runtimeCrashes is independent of story.escalations count", async () => {
     // A story can have 2 escalations (tier changes) AND 3 crash retries — tracked separately
     const story = makeStory({
       status: "passed",
@@ -129,28 +119,22 @@ describe("collectStoryMetrics - runtimeCrashes field", () => {
         { fromTier: "balanced", toTier: "thorough", reason: "tests-failing", timestamp: new Date().toISOString() },
       ],
     });
-    const ctx = makeContext(story, {
-      // @ts-expect-error: storyRuntimeCrashes not in PipelineContext until BUG-070 is implemented
-      storyRuntimeCrashes: 3,
-    });
+    const ctx = makeContext(story, { storyRuntimeCrashes: 3 });
 
-    const metrics = collectStoryMetrics(ctx, STORY_START_TIME);
+    const metrics = await collectStoryMetrics(ctx, STORY_START_TIME);
 
-    // escalations are counted separately from crashes
-    expect((metrics as Record<string, unknown>).runtimeCrashes).toBe(3);
+    expect(metrics.runtimeCrashes).toBe(3);
     expect(metrics.attempts).toBeGreaterThan(0); // escalations still recorded
   });
 
-  test("runtimeCrashes defaults to 0 when ctx.storyRuntimeCrashes is undefined", () => {
+  test("runtimeCrashes defaults to 0 when ctx.storyRuntimeCrashes is undefined", async () => {
     const story = makeStory();
     const ctx = makeContext(story);
-    // No storyRuntimeCrashes set — should default to 0
 
-    const metrics = collectStoryMetrics(ctx, STORY_START_TIME);
+    const metrics = await collectStoryMetrics(ctx, STORY_START_TIME);
 
-    // Must be 0, not undefined
-    expect((metrics as Record<string, unknown>).runtimeCrashes ?? undefined).not.toBeUndefined();
-    expect((metrics as Record<string, unknown>).runtimeCrashes).toBe(0);
+    expect(metrics.runtimeCrashes).not.toBeUndefined();
+    expect(metrics.runtimeCrashes).toBe(0);
   });
 });
 
@@ -159,15 +143,14 @@ describe("collectStoryMetrics - runtimeCrashes field", () => {
 // ---------------------------------------------------------------------------
 
 describe("StoryMetrics type — runtimeCrashes field", () => {
-  test("collectStoryMetrics output includes runtimeCrashes as a number", () => {
+  test("collectStoryMetrics output includes runtimeCrashes as a number", async () => {
     const story = makeStory();
     const ctx = makeContext(story);
 
-    const metrics = collectStoryMetrics(ctx, STORY_START_TIME);
+    const metrics = await collectStoryMetrics(ctx, STORY_START_TIME);
 
     // Must be a number (0 when no crashes), not undefined or string
-    const crashes = (metrics as Record<string, unknown>).runtimeCrashes;
-    expect(typeof crashes).toBe("number");
+    expect(typeof metrics.runtimeCrashes).toBe("number");
   });
 });
 
@@ -199,8 +182,7 @@ describe("collectBatchMetrics - runtimeCrashes per story", () => {
     const batchMetrics = collectBatchMetrics(ctx, STORY_START_TIME);
 
     for (const m of batchMetrics) {
-      // RED: runtimeCrashes not in StoryMetrics yet
-      expect((m as Record<string, unknown>).runtimeCrashes).toBe(0);
+      expect(m.runtimeCrashes).toBe(0);
     }
   });
 });

--- a/test/unit/metrics/tracker.test.ts
+++ b/test/unit/metrics/tracker.test.ts
@@ -88,7 +88,7 @@ function makeCtx(
 // ---------------------------------------------------------------------------
 
 describe("collectStoryMetrics - initialComplexity field", () => {
-  test("includes initialComplexity from story.routing.initialComplexity", () => {
+  test("includes initialComplexity from story.routing.initialComplexity", async () => {
     const routing: StoryRouting = {
       complexity: "medium",
       initialComplexity: "simple", // original prediction before potential escalation
@@ -98,12 +98,12 @@ describe("collectStoryMetrics - initialComplexity field", () => {
     const story = makeStory({ routing });
     const ctx = makeCtx(story, { complexity: "medium" });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.initialComplexity).toBe("simple");
   });
 
-  test("initialComplexity differs from complexity when story was escalated", () => {
+  test("initialComplexity differs from complexity when story was escalated", async () => {
     const routing: StoryRouting = {
       complexity: "medium", // complexity as classified
       initialComplexity: "simple", // original first-classify prediction
@@ -125,14 +125,14 @@ describe("collectStoryMetrics - initialComplexity field", () => {
     });
     const ctx = makeCtx(story, { complexity: "medium", modelTier: "balanced" });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.initialComplexity).toBe("simple");
     // complexity field unchanged (backward compat)
     expect(metrics.complexity).toBe("medium");
   });
 
-  test("falls back to routing.complexity when story.routing.initialComplexity is absent", () => {
+  test("falls back to routing.complexity when story.routing.initialComplexity is absent", async () => {
     // Backward compat: story.routing exists but has no initialComplexity
     const routing: StoryRouting = {
       complexity: "complex",
@@ -143,16 +143,16 @@ describe("collectStoryMetrics - initialComplexity field", () => {
     const story = makeStory({ routing });
     const ctx = makeCtx(story, { complexity: "complex" });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.initialComplexity).toBe("complex");
   });
 
-  test("falls back to routing.complexity when story.routing is undefined", () => {
+  test("falls back to routing.complexity when story.routing is undefined", async () => {
     const story = makeStory({ routing: undefined });
     const ctx = makeCtx(story, { complexity: "simple" });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.initialComplexity).toBe("simple");
   });
@@ -163,7 +163,7 @@ describe("collectStoryMetrics - initialComplexity field", () => {
 // ---------------------------------------------------------------------------
 
 describe("StoryMetrics type - initialComplexity field", () => {
-  test("StoryMetrics includes initialComplexity field", () => {
+  test("StoryMetrics includes initialComplexity field", async () => {
     const routing: StoryRouting = {
       complexity: "medium",
       initialComplexity: "simple",
@@ -173,13 +173,13 @@ describe("StoryMetrics type - initialComplexity field", () => {
     const story = makeStory({ routing });
     const ctx = makeCtx(story, { complexity: "medium" });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     // TypeScript will error at compile time if initialComplexity is not on StoryMetrics
     expect("initialComplexity" in metrics).toBe(true);
   });
 
-  test("initialComplexity is a string when present", () => {
+  test("initialComplexity is a string when present", async () => {
     const routing: StoryRouting = {
       complexity: "expert",
       initialComplexity: "expert",
@@ -189,7 +189,7 @@ describe("StoryMetrics type - initialComplexity field", () => {
     const story = makeStory({ routing });
     const ctx = makeCtx(story, { complexity: "expert" });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(typeof metrics.initialComplexity).toBe("string");
   });
@@ -200,29 +200,29 @@ describe("StoryMetrics type - initialComplexity field", () => {
 // ---------------------------------------------------------------------------
 
 describe("collectStoryMetrics - agentUsed field", () => {
-  test("agentUsed is defaultAgent when routing.agent is unset", () => {
+  test("agentUsed is defaultAgent when routing.agent is unset", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { modelTier: "balanced" });
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.agentUsed).toBe("claude");
   });
 
-  test("agentUsed is routing.agent when set", () => {
+  test("agentUsed is routing.agent when set", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { modelTier: "fast", agent: "codex" } as Partial<PipelineContext["routing"]>);
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.agentUsed).toBe("codex");
   });
 
-  test("agentUsed field exists on StoryMetrics", () => {
+  test("agentUsed field exists on StoryMetrics", async () => {
     const story = makeStory();
     const ctx = makeCtx(story);
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect("agentUsed" in metrics).toBe(true);
   });
@@ -233,7 +233,7 @@ describe("collectStoryMetrics - agentUsed field", () => {
 // ---------------------------------------------------------------------------
 
 describe("collectStoryMetrics - tokenUsage field", () => {
-  test("sets storyMetrics.tokens when ctx.agentResult.tokenUsage is defined", () => {
+  test("sets storyMetrics.tokens when ctx.agentResult.tokenUsage is defined", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { modelTier: "balanced" });
     ctx.agentResult = {
@@ -249,14 +249,14 @@ describe("collectStoryMetrics - tokenUsage field", () => {
       },
     };
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.tokens).toBeDefined();
     expect(metrics.tokens?.input_tokens).toBe(1000);
     expect(metrics.tokens?.output_tokens).toBe(500);
   });
 
-  test("sets storyMetrics.tokens with cache fields when present in tokenUsage", () => {
+  test("sets storyMetrics.tokens with cache fields when present in tokenUsage", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { modelTier: "balanced" });
     ctx.agentResult = {
@@ -274,7 +274,7 @@ describe("collectStoryMetrics - tokenUsage field", () => {
       } as unknown as { inputTokens: number; outputTokens: number },
     };
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.tokens).toBeDefined();
     expect(metrics.tokens?.input_tokens).toBe(1000);
@@ -283,7 +283,7 @@ describe("collectStoryMetrics - tokenUsage field", () => {
     expect(metrics.tokens?.cache_creation_input_tokens).toBe(50);
   });
 
-  test("storyMetrics.tokens is undefined when ctx.agentResult.tokenUsage is undefined", () => {
+  test("storyMetrics.tokens is undefined when ctx.agentResult.tokenUsage is undefined", async () => {
     const story = makeStory();
     const ctx = makeCtx(story, { modelTier: "balanced" });
     ctx.agentResult = {
@@ -295,7 +295,7 @@ describe("collectStoryMetrics - tokenUsage field", () => {
       durationMs: 5000,
     };
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.tokens).toBeUndefined();
   });
@@ -306,7 +306,7 @@ describe("collectStoryMetrics - tokenUsage field", () => {
 // ---------------------------------------------------------------------------
 
 describe("collectStoryMetrics - scopeTestFallback field (US-002)", () => {
-  test("scopeTestFallback is propagated from verifyResult to StoryMetrics when set", () => {
+  test("scopeTestFallback is propagated from verifyResult to StoryMetrics when set", async () => {
     const story = makeStory();
     const verifyResult: VerifyResult = {
       success: true,
@@ -323,12 +323,12 @@ describe("collectStoryMetrics - scopeTestFallback field (US-002)", () => {
     };
     const ctx = makeCtx(story, {}, verifyResult);
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.scopeTestFallback).toBe(true);
   });
 
-  test("scopeTestFallback is absent from StoryMetrics when verifyResult does not have it", () => {
+  test("scopeTestFallback is absent from StoryMetrics when verifyResult does not have it", async () => {
     const story = makeStory();
     const verifyResult: VerifyResult = {
       success: true,
@@ -344,16 +344,16 @@ describe("collectStoryMetrics - scopeTestFallback field (US-002)", () => {
     };
     const ctx = makeCtx(story, {}, verifyResult);
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.scopeTestFallback).toBeUndefined();
   });
 
-  test("scopeTestFallback is absent from StoryMetrics when verifyResult is undefined", () => {
+  test("scopeTestFallback is absent from StoryMetrics when verifyResult is undefined", async () => {
     const story = makeStory();
     const ctx = makeCtx(story);
 
-    const metrics = collectStoryMetrics(ctx, new Date().toISOString());
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.scopeTestFallback).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- `ContextManifest.providerResults` gains `tokensProduced: number` (sum of chunk tokens, computed in the orchestrator)
- `StoryMetrics` gains `context?: { providers: Record<string, ContextProviderMetrics> }` aggregated across all pipeline stages
- `collectStoryMetrics` is now `async`; a new `deriveContextMetrics` helper loads on-disk manifests and aggregates per-provider metrics (chunksProduced, chunksKept, wallClockMs, tokensProduced, timedOut, failed)
- `completion.ts` updated to `await` the now-async call
- Existing metrics tests updated to `await collectStoryMetrics`

## Test plan

- [ ] `bun test test/unit/metrics/tracker-context-metrics.test.ts` — 9 new AC-18 tests pass
- [ ] `bun run test` — full suite (6000+ tests) passes with 0 failures
- [ ] `bun run typecheck` — clean
- [ ] `bun run build` — clean