### PR TITLE
feat(session): AC-20 session scratch retention — purgeStaleScratch

### DIFF
--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -465,6 +465,13 @@ export interface ContextV2Config {
    * Keys are stage names; value overrides the default stage budgetTokens.
    */
   stages: Record<string, { budgetTokens?: number }>;
+  /** Session scratch retention settings (AC-20) */
+  session: {
+    /** Days to retain completed session scratch dirs before purging. */
+    retentionDays: number;
+    /** When true and the feature run fully completes, archive to _archive/ instead of deleting. */
+    archiveOnFeatureArchive: boolean;
+  };
 }
 
 export interface ContextConfig {

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -554,6 +554,18 @@ const ContextV2ConfigSchema = z
      * Example: { "execution": { "budgetTokens": 15000 } }
      */
     stages: z.record(z.string().min(1), z.object({ budgetTokens: z.number().int().positive().optional() })).default({}),
+    /**
+     * Session scratch retention settings (AC-20).
+     * Controls how long completed session scratch dirs are kept on disk.
+     */
+    session: z
+      .object({
+        /** Days to keep completed session scratch dirs before purging. Default: 7. */
+        retentionDays: z.number().int().min(1).default(7),
+        /** When true and the feature run completes fully, archive scratch to _archive/ instead of deleting. Default: true. */
+        archiveOnFeatureArchive: z.boolean().default(true),
+      })
+      .default(() => ({ retentionDays: 7, archiveOnFeatureArchive: true })),
   })
   .default(() => ({
     enabled: false,
@@ -563,6 +575,7 @@ const ContextV2ConfigSchema = z
     fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
     pluginProviders: [],
     stages: {},
+    session: { retentionDays: 7, archiveOnFeatureArchive: true },
   }));
 
 const ContextConfigSchema = z.object({
@@ -985,6 +998,7 @@ export const NaxConfigSchema = z
         fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
         pluginProviders: [],
         stages: {},
+        session: { retentionDays: 7, archiveOnFeatureArchive: true },
       },
     }),
     optimizer: OptimizerConfigSchema.optional(),

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -18,6 +18,7 @@ import { pipelineEventBus } from "../../pipeline/event-bus";
 import type { AgentGetFn } from "../../pipeline/types";
 import { countStories, isComplete, isStalled } from "../../prd";
 import type { PRD } from "../../prd";
+import { purgeStaleScratch } from "../../session/scratch-purge";
 import type { StatusWriter } from "../status-writer";
 import { runDeferredRegression } from "./run-regression";
 
@@ -50,6 +51,12 @@ export interface RunCompletionOptions {
   skipRegression?: boolean;
   /** Protocol-aware agent resolver (ACP wiring). Falls back to static getAgent when absent. */
   agentGetFn?: AgentGetFn;
+  /**
+   * Absolute path to the project root (where .nax/ lives).
+   * Defaults to workdir when absent (non-monorepo).
+   * Used for session scratch purge (AC-20).
+   */
+  projectDir?: string;
 }
 
 export interface RunCompletionResult {
@@ -227,6 +234,27 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
     await saveRunMetrics(workdir, runMetrics);
   } catch (err) {
     logger?.warn("run.complete", "Failed to save run metrics", { error: String(err) });
+  }
+
+  // AC-20: purge stale session scratch dirs
+  const effectiveProjectDir = options.projectDir ?? workdir;
+  const sessionCfg = config.context?.v2?.session;
+  if (sessionCfg?.retentionDays) {
+    const featureComplete = isComplete(prd);
+    const archiveInsteadOfDelete = sessionCfg.archiveOnFeatureArchive && featureComplete;
+    try {
+      const purged = await purgeStaleScratch(
+        effectiveProjectDir,
+        feature,
+        sessionCfg.retentionDays,
+        archiveInsteadOfDelete,
+      );
+      if (purged > 0) {
+        logger?.info("run.complete", "Purged stale session scratch dirs", { feature, purged });
+      }
+    } catch (err) {
+      logger?.warn("run.complete", "Failed to purge stale session scratch", { error: String(err) });
+    }
   }
 
   // Log run completion

--- a/src/session/scratch-purge.ts
+++ b/src/session/scratch-purge.ts
@@ -1,0 +1,95 @@
+/**
+ * Session Scratch Retention — AC-20
+ *
+ * purgeStaleScratch() scans on-disk session directories for a feature and
+ * deletes (or archives) those whose lastActivityAt is older than retentionDays.
+ *
+ * Called from run-completion.ts at the end of each run.
+ */
+
+import { mkdir, rename, rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Injectable deps
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const _scratchPurgeDeps = {
+  /** List session IDs (directory names) under the sessions dir */
+  listSessionDirs: async (sessionsDir: string): Promise<string[]> => {
+    try {
+      const ids: string[] = [];
+      for await (const entry of new Bun.Glob("*").scan({ cwd: sessionsDir, absolute: false })) {
+        ids.push(entry);
+      }
+      return ids;
+    } catch {
+      return [];
+    }
+  },
+  fileExists: (path: string): Promise<boolean> => Bun.file(path).exists(),
+  readFile: (path: string): Promise<string> => Bun.file(path).text(),
+  remove: (path: string): Promise<void> => rm(path, { recursive: true, force: true }),
+  move: async (src: string, dest: string): Promise<void> => {
+    await mkdir(dirname(dest), { recursive: true });
+    await rename(src, dest);
+  },
+  now: () => Date.now(),
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Purge session scratch directories older than retentionDays.
+ *
+ * @param projectDir    Absolute path to the project root (where .nax/ lives)
+ * @param featureName   Feature name — scans .nax/features/<featureName>/sessions/
+ * @param retentionDays Sessions with lastActivityAt older than this are purged
+ * @param archiveInsteadOfDelete  When true, move to _archive/ instead of deleting
+ * @returns Number of session dirs that were purged or archived
+ */
+export async function purgeStaleScratch(
+  projectDir: string,
+  featureName: string,
+  retentionDays: number,
+  archiveInsteadOfDelete = false,
+): Promise<number> {
+  const sessionsDir = join(projectDir, ".nax", "features", featureName, "sessions");
+  const sessionIds = await _scratchPurgeDeps.listSessionDirs(sessionsDir);
+
+  const cutoffMs = _scratchPurgeDeps.now() - retentionDays * 86_400_000;
+  let purged = 0;
+
+  for (const sessionId of sessionIds) {
+    const sessionDir = join(sessionsDir, sessionId);
+    const descriptorPath = join(sessionDir, "descriptor.json");
+
+    if (!(await _scratchPurgeDeps.fileExists(descriptorPath))) continue;
+
+    let lastActivityAt: string | undefined;
+    try {
+      const raw = await _scratchPurgeDeps.readFile(descriptorPath);
+      const descriptor = JSON.parse(raw) as Record<string, unknown>;
+      lastActivityAt = descriptor.lastActivityAt as string | undefined;
+    } catch {
+      continue;
+    }
+
+    if (!lastActivityAt) continue;
+
+    // Skip sessions still within the retention window (boundary is non-inclusive)
+    if (new Date(lastActivityAt).getTime() >= cutoffMs) continue;
+
+    if (archiveInsteadOfDelete) {
+      const archiveDest = join(projectDir, ".nax", "features", featureName, "_archive", "sessions", sessionId);
+      await _scratchPurgeDeps.move(sessionDir, archiveDest);
+    } else {
+      await _scratchPurgeDeps.remove(sessionDir);
+    }
+    purged++;
+  }
+
+  return purged;
+}

--- a/test/unit/session/scratch-purge.test.ts
+++ b/test/unit/session/scratch-purge.test.ts
@@ -1,0 +1,226 @@
+/**
+ * AC-20: Session scratch retention — purgeStaleScratch
+ *
+ * purgeStaleScratch() scans <projectDir>/.nax/features/<featureName>/sessions/,
+ * reads each session's descriptor.json for lastActivityAt, and:
+ *   - Deletes dirs older than retentionDays (default behaviour)
+ *   - Moves to _archive/sessions/<id> when archiveInsteadOfDelete=true
+ *
+ * All I/O is injected via _scratchPurgeDeps for test isolation.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { _scratchPurgeDeps, purgeStaleScratch } from "../../../src/session/scratch-purge";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Saved originals
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origListSessionDirs: typeof _scratchPurgeDeps.listSessionDirs;
+let origFileExists: typeof _scratchPurgeDeps.fileExists;
+let origReadFile: typeof _scratchPurgeDeps.readFile;
+let origRemove: typeof _scratchPurgeDeps.remove;
+let origMove: typeof _scratchPurgeDeps.move;
+let origNow: typeof _scratchPurgeDeps.now;
+
+beforeEach(() => {
+  origListSessionDirs = _scratchPurgeDeps.listSessionDirs;
+  origFileExists = _scratchPurgeDeps.fileExists;
+  origReadFile = _scratchPurgeDeps.readFile;
+  origRemove = _scratchPurgeDeps.remove;
+  origMove = _scratchPurgeDeps.move;
+  origNow = _scratchPurgeDeps.now;
+});
+
+afterEach(() => {
+  _scratchPurgeDeps.listSessionDirs = origListSessionDirs;
+  _scratchPurgeDeps.fileExists = origFileExists;
+  _scratchPurgeDeps.readFile = origReadFile;
+  _scratchPurgeDeps.remove = origRemove;
+  _scratchPurgeDeps.move = origMove;
+  _scratchPurgeDeps.now = origNow;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PROJECT_DIR = "/repo";
+const FEATURE = "test-feature";
+const NOW_MS = 1_000_000_000_000; // fixed "now"
+const DAY_MS = 86_400_000;
+
+function daysAgo(days: number): string {
+  return new Date(NOW_MS - days * DAY_MS).toISOString();
+}
+
+interface FakeSession {
+  id: string;
+  lastActivityAt: string;
+}
+
+function setupDeps(sessions: FakeSession[], removed: string[] = [], moved: Array<[string, string]> = []) {
+  _scratchPurgeDeps.now = () => NOW_MS;
+  _scratchPurgeDeps.listSessionDirs = async () => sessions.map((s) => s.id);
+  _scratchPurgeDeps.fileExists = async (path: string) => {
+    return sessions.some((s) => path.includes(s.id));
+  };
+  _scratchPurgeDeps.readFile = async (path: string) => {
+    const session = sessions.find((s) => path.includes(s.id));
+    if (!session) throw new Error(`file not found: ${path}`);
+    return JSON.stringify({ lastActivityAt: session.lastActivityAt });
+  };
+  _scratchPurgeDeps.remove = async (path: string) => {
+    removed.push(path);
+  };
+  _scratchPurgeDeps.move = async (src: string, dest: string) => {
+    moved.push([src, dest]);
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("purgeStaleScratch", () => {
+  test("returns 0 when no session dirs exist", async () => {
+    setupDeps([]);
+    const count = await purgeStaleScratch(PROJECT_DIR, FEATURE, 7);
+    expect(count).toBe(0);
+  });
+
+  test("returns 0 when all sessions are within retention window", async () => {
+    setupDeps([
+      { id: "sess-aaa", lastActivityAt: daysAgo(3) },
+      { id: "sess-bbb", lastActivityAt: daysAgo(6) },
+    ]);
+    const count = await purgeStaleScratch(PROJECT_DIR, FEATURE, 7);
+    expect(count).toBe(0);
+  });
+
+  test("deletes session dir when lastActivityAt is older than retentionDays", async () => {
+    const removed: string[] = [];
+    setupDeps([{ id: "sess-old", lastActivityAt: daysAgo(10) }], removed);
+    const count = await purgeStaleScratch(PROJECT_DIR, FEATURE, 7);
+    expect(count).toBe(1);
+    expect(removed).toHaveLength(1);
+    expect(removed[0]).toContain("sess-old");
+  });
+
+  test("skips sessions exactly at the retention boundary (age < retentionDays)", async () => {
+    const removed: string[] = [];
+    // exactly 7 days ago — not yet expired (boundary is strictly >)
+    setupDeps([{ id: "sess-boundary", lastActivityAt: daysAgo(7) }], removed);
+    const count = await purgeStaleScratch(PROJECT_DIR, FEATURE, 7);
+    expect(count).toBe(0);
+    expect(removed).toHaveLength(0);
+  });
+
+  test("returns count of deleted sessions", async () => {
+    const removed: string[] = [];
+    setupDeps(
+      [
+        { id: "sess-old1", lastActivityAt: daysAgo(8) },
+        { id: "sess-new", lastActivityAt: daysAgo(2) },
+        { id: "sess-old2", lastActivityAt: daysAgo(14) },
+      ],
+      removed,
+    );
+    const count = await purgeStaleScratch(PROJECT_DIR, FEATURE, 7);
+    expect(count).toBe(2);
+    expect(removed).toHaveLength(2);
+  });
+
+  test("moves to _archive/ when archiveInsteadOfDelete=true", async () => {
+    const moved: Array<[string, string]> = [];
+    setupDeps([{ id: "sess-old", lastActivityAt: daysAgo(10) }], [], moved);
+    const count = await purgeStaleScratch(PROJECT_DIR, FEATURE, 7, true);
+    expect(count).toBe(1);
+    expect(moved).toHaveLength(1);
+    const [src, dest] = moved[0]!;
+    expect(src).toContain("sess-old");
+    expect(dest).toContain("_archive");
+    expect(dest).toContain("sess-old");
+  });
+
+  test("archive destination path: <projectDir>/.nax/features/<feature>/_archive/sessions/<id>", async () => {
+    const moved: Array<[string, string]> = [];
+    setupDeps([{ id: "sess-abc", lastActivityAt: daysAgo(9) }], [], moved);
+    await purgeStaleScratch(PROJECT_DIR, FEATURE, 7, true);
+    const [_src, dest] = moved[0]!;
+    expect(dest).toBe(`${PROJECT_DIR}/.nax/features/${FEATURE}/_archive/sessions/sess-abc`);
+  });
+
+  test("does not call remove when archiveInsteadOfDelete=true", async () => {
+    const removed: string[] = [];
+    setupDeps([{ id: "sess-old", lastActivityAt: daysAgo(10) }], removed);
+    await purgeStaleScratch(PROJECT_DIR, FEATURE, 7, true);
+    expect(removed).toHaveLength(0);
+  });
+
+  test("skips session dir when descriptor.json does not exist", async () => {
+    _scratchPurgeDeps.now = () => NOW_MS;
+    _scratchPurgeDeps.listSessionDirs = async () => ["sess-nodesc"];
+    _scratchPurgeDeps.fileExists = async () => false;
+    _scratchPurgeDeps.readFile = async () => {
+      throw new Error("should not be called");
+    };
+    const removed: string[] = [];
+    _scratchPurgeDeps.remove = async (path: string) => {
+      removed.push(path);
+    };
+    _scratchPurgeDeps.move = async () => {};
+    const count = await purgeStaleScratch(PROJECT_DIR, FEATURE, 7);
+    expect(count).toBe(0);
+    expect(removed).toHaveLength(0);
+  });
+
+  test("skips session dir with unparseable descriptor.json", async () => {
+    _scratchPurgeDeps.now = () => NOW_MS;
+    _scratchPurgeDeps.listSessionDirs = async () => ["sess-bad"];
+    _scratchPurgeDeps.fileExists = async () => true;
+    _scratchPurgeDeps.readFile = async () => "NOT JSON {{{";
+    const removed: string[] = [];
+    _scratchPurgeDeps.remove = async (path: string) => {
+      removed.push(path);
+    };
+    _scratchPurgeDeps.move = async () => {};
+    const count = await purgeStaleScratch(PROJECT_DIR, FEATURE, 7);
+    expect(count).toBe(0);
+    expect(removed).toHaveLength(0);
+  });
+
+  test("skips session dir with missing lastActivityAt in descriptor", async () => {
+    _scratchPurgeDeps.now = () => NOW_MS;
+    _scratchPurgeDeps.listSessionDirs = async () => ["sess-nots"];
+    _scratchPurgeDeps.fileExists = async () => true;
+    _scratchPurgeDeps.readFile = async () => JSON.stringify({ id: "sess-nots" });
+    const removed: string[] = [];
+    _scratchPurgeDeps.remove = async (path: string) => {
+      removed.push(path);
+    };
+    _scratchPurgeDeps.move = async () => {};
+    const count = await purgeStaleScratch(PROJECT_DIR, FEATURE, 7);
+    expect(count).toBe(0);
+    expect(removed).toHaveLength(0);
+  });
+
+  test("processes only sessions older than retentionDays — mixed batch", async () => {
+    const removed: string[] = [];
+    setupDeps(
+      [
+        { id: "sess-fresh", lastActivityAt: daysAgo(1) },
+        { id: "sess-stale1", lastActivityAt: daysAgo(8) },
+        { id: "sess-stale2", lastActivityAt: daysAgo(30) },
+        { id: "sess-recent", lastActivityAt: daysAgo(6) },
+      ],
+      removed,
+    );
+    const count = await purgeStaleScratch(PROJECT_DIR, FEATURE, 7);
+    expect(count).toBe(2);
+    expect(removed.some((p) => p.includes("sess-stale1"))).toBe(true);
+    expect(removed.some((p) => p.includes("sess-stale2"))).toBe(true);
+    expect(removed.every((p) => !p.includes("sess-fresh"))).toBe(true);
+    expect(removed.every((p) => !p.includes("sess-recent"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements AC-20 from issue #478: session scratch directory retention policy
- Adds `purgeStaleScratch()` in `src/session/scratch-purge.ts` — scans `.nax/features/<feature>/sessions/`, reads each `descriptor.json` for `lastActivityAt`, and deletes (or archives) dirs older than `retentionDays`
- Adds `context.v2.session` config block (`retentionDays: 7`, `archiveOnFeatureArchive: true`) to schema and runtime types
- Calls `purgeStaleScratch` from `run-completion.ts` after `saveRunMetrics`; archives instead of deletes when `archiveOnFeatureArchive=true` and feature is fully complete (`isComplete(prd)`)

## Test plan

- [ ] Run `bun test test/unit/session/scratch-purge.test.ts` — 12 tests covering: no sessions, within-retention skip, boundary skip (non-inclusive), delete stale, count return, archive flag, archive path correctness, no-remove when archiving, missing descriptor, bad JSON, missing field, mixed batch
- [ ] Run `bun run typecheck` — confirms `ContextV2Config.session` type and Zod schema are consistent
- [ ] Run `bun run build` — confirms clean build
- [ ] Full test suite: `bun run test` — confirm 0 failures