### PR TITLE
feat(cli): AC-19 nax context inspect — rich manifest formatter

### DIFF
--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -2,7 +2,9 @@
  * `nax context` CLI commands
  */
 
+import chalk from "chalk";
 import { loadContextManifests } from "../context/engine";
+import type { StoredContextManifest } from "../context/engine/manifest-store";
 
 export interface ContextInspectOptions {
   dir?: string;
@@ -10,6 +12,79 @@ export interface ContextInspectOptions {
   json?: boolean;
   storyId: string;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Formatter (pure — testable without disk I/O)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function formatContextInspect(storyId: string, manifests: StoredContextManifest[]): string[] {
+  const lines: string[] = [];
+
+  if (manifests.length === 0) {
+    lines.push(chalk.yellow(`No context manifests found for story ${storyId}.`));
+    return lines;
+  }
+
+  lines.push(
+    chalk.bold(
+      `\nContext manifests for story ${storyId}  (${manifests.length} stage${manifests.length === 1 ? "" : "s"})\n`,
+    ),
+  );
+
+  for (const item of manifests) {
+    const { manifest, featureId, stage } = item;
+    const pct =
+      manifest.totalBudgetTokens > 0 ? Math.round((manifest.usedTokens / manifest.totalBudgetTokens) * 100) : 0;
+
+    lines.push(chalk.bold(`  Stage: ${stage}`) + chalk.dim(`  [feature: ${featureId}]`));
+    lines.push(chalk.dim(`  ${"─".repeat(50)}`));
+
+    lines.push(`    Budget   ${manifest.usedTokens} / ${manifest.totalBudgetTokens} tokens (${pct}%)`);
+    lines.push(`    Build    ${manifest.buildMs}ms    Digest ${manifest.digestTokens} tokens`);
+    lines.push(
+      `    Chunks   ${chalk.green(`${manifest.includedChunks.length} included`)}  ${chalk.dim(`${manifest.excludedChunks.length} excluded`)}`,
+    );
+
+    if (manifest.floorItems.length > 0) {
+      const overageCount = manifest.floorOverageItems?.length ?? 0;
+      const overageNote = overageCount > 0 ? chalk.yellow(`  (${overageCount} overage)`) : "";
+      lines.push(`    Floor    ${manifest.floorItems.length} items${overageNote}`);
+    }
+
+    if (manifest.providerResults && manifest.providerResults.length > 0) {
+      lines.push("");
+      lines.push(chalk.dim("    Providers:"));
+      for (const pr of manifest.providerResults) {
+        const statusColor =
+          pr.status === "ok"
+            ? chalk.green(pr.status)
+            : pr.status === "empty"
+              ? chalk.dim(pr.status)
+              : chalk.red(pr.status);
+        const errorNote = pr.error ? chalk.red(`  error=${pr.error}`) : "";
+        lines.push(
+          `      ${pr.providerId.padEnd(22)} ${statusColor.padEnd(10)}  chunks=${pr.chunkCount}  tokens=${pr.tokensProduced}  ${pr.durationMs}ms${errorNote}`,
+        );
+      }
+    }
+
+    if (manifest.excludedChunks.length > 0) {
+      lines.push("");
+      lines.push(chalk.dim("    Excluded chunks:"));
+      for (const ex of manifest.excludedChunks) {
+        lines.push(`      ${chalk.dim(ex.id)}  reason=${ex.reason}`);
+      }
+    }
+
+    lines.push("");
+  }
+
+  return lines;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command
+// ─────────────────────────────────────────────────────────────────────────────
 
 export async function contextInspectCommand(options: ContextInspectOptions): Promise<void> {
   const workdir = options.dir ?? process.cwd();
@@ -20,15 +95,8 @@ export async function contextInspectCommand(options: ContextInspectOptions): Pro
     return;
   }
 
-  if (manifests.length === 0) {
-    console.log(`No context manifests found for story ${options.storyId}.`);
-    return;
-  }
-
-  console.log(`Context manifests for ${options.storyId}:`);
-  for (const item of manifests) {
-    console.log(
-      `- ${item.featureId} / ${item.stage}: included=${item.manifest.includedChunks.length}, excluded=${item.manifest.excludedChunks.length}, usedTokens=${item.manifest.usedTokens}, path=${item.path}`,
-    );
+  const output = formatContextInspect(options.storyId, manifests);
+  for (const line of output) {
+    console.log(line);
   }
 }

--- a/test/unit/cli/context.test.ts
+++ b/test/unit/cli/context.test.ts
@@ -1,0 +1,191 @@
+/**
+ * AC-19: nax context inspect — formatContextInspect
+ *
+ * Tests the human-readable formatter for context manifests.
+ * Passes StoredContextManifest[] directly to avoid disk I/O.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { formatContextInspect } from "../../../src/cli/context";
+import type { StoredContextManifest } from "../../../src/context/engine/manifest-store";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeManifest(overrides: Partial<StoredContextManifest["manifest"]> = {}): StoredContextManifest["manifest"] {
+  return {
+    requestId: "req-001",
+    stage: "verify",
+    totalBudgetTokens: 2000,
+    usedTokens: 1200,
+    includedChunks: ["provider-a:chunk-1", "provider-a:chunk-2", "provider-b:chunk-3"],
+    excludedChunks: [
+      { id: "provider-a:chunk-4", reason: "budget" },
+      { id: "provider-b:chunk-5", reason: "below-min-score" },
+    ],
+    floorItems: [],
+    digestTokens: 120,
+    buildMs: 42,
+    providerResults: [
+      { providerId: "provider-a", status: "ok", chunkCount: 2, durationMs: 25, tokensProduced: 800 },
+      { providerId: "provider-b", status: "ok", chunkCount: 1, durationMs: 17, tokensProduced: 400 },
+    ],
+    ...overrides,
+  };
+}
+
+function makeEntry(stage: string, overrides: Partial<StoredContextManifest["manifest"]> = {}): StoredContextManifest {
+  return {
+    featureId: "my-feature",
+    stage,
+    path: `/repo/.nax/features/my-feature/stories/US-001/context-manifest-${stage}.json`,
+    manifest: makeManifest({ stage, ...overrides }),
+  };
+}
+
+function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1B\[[0-9;]*m/g, "");
+}
+
+function lines(output: string[]): string[] {
+  return output.map(stripAnsi);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("formatContextInspect", () => {
+  test("shows 'No context manifests found' when list is empty", () => {
+    const output = lines(formatContextInspect("US-001", []));
+    const joined = output.join("\n");
+    expect(joined).toContain("No context manifests found");
+    expect(joined).toContain("US-001");
+  });
+
+  test("shows story ID in header", () => {
+    const output = lines(formatContextInspect("US-001", [makeEntry("verify")]));
+    expect(output.join("\n")).toContain("US-001");
+  });
+
+  test("shows feature ID and stage", () => {
+    const output = lines(formatContextInspect("US-001", [makeEntry("verify")]));
+    const joined = output.join("\n");
+    expect(joined).toContain("my-feature");
+    expect(joined).toContain("verify");
+  });
+
+  test("shows token budget: used / total", () => {
+    const output = lines(formatContextInspect("US-001", [makeEntry("verify")]));
+    const joined = output.join("\n");
+    expect(joined).toContain("1200");
+    expect(joined).toContain("2000");
+  });
+
+  test("shows included chunk count", () => {
+    const output = lines(formatContextInspect("US-001", [makeEntry("verify")]));
+    expect(output.join("\n")).toContain("3");
+  });
+
+  test("shows excluded chunk count", () => {
+    const output = lines(formatContextInspect("US-001", [makeEntry("verify")]));
+    expect(output.join("\n")).toContain("2");
+  });
+
+  test("shows buildMs", () => {
+    const output = lines(formatContextInspect("US-001", [makeEntry("verify")]));
+    expect(output.join("\n")).toContain("42");
+  });
+
+  test("shows provider ID, status, chunkCount, tokensProduced, durationMs", () => {
+    const output = lines(formatContextInspect("US-001", [makeEntry("verify")]));
+    const joined = output.join("\n");
+    expect(joined).toContain("provider-a");
+    expect(joined).toContain("ok");
+    expect(joined).toContain("800");
+    expect(joined).toContain("25");
+  });
+
+  test("shows failed provider status", () => {
+    const entry = makeEntry("verify", {
+      providerResults: [
+        { providerId: "git-history", status: "failed", chunkCount: 0, durationMs: 5, tokensProduced: 0, error: "timeout exceeded" },
+      ],
+    });
+    const output = lines(formatContextInspect("US-001", [entry]));
+    const joined = output.join("\n");
+    expect(joined).toContain("failed");
+    expect(joined).toContain("git-history");
+  });
+
+  test("shows timeout provider status", () => {
+    const entry = makeEntry("verify", {
+      providerResults: [
+        { providerId: "git-history", status: "timeout", chunkCount: 0, durationMs: 5000, tokensProduced: 0 },
+      ],
+    });
+    const output = lines(formatContextInspect("US-001", [entry]));
+    expect(output.join("\n")).toContain("timeout");
+  });
+
+  test("shows excluded chunk IDs and reasons", () => {
+    const output = lines(formatContextInspect("US-001", [makeEntry("verify")]));
+    const joined = output.join("\n");
+    expect(joined).toContain("provider-a:chunk-4");
+    expect(joined).toContain("budget");
+    expect(joined).toContain("provider-b:chunk-5");
+    expect(joined).toContain("below-min-score");
+  });
+
+  test("shows multiple stages separately", () => {
+    const manifests = [makeEntry("context"), makeEntry("verify")];
+    const output = lines(formatContextInspect("US-001", manifests));
+    const joined = output.join("\n");
+    expect(joined).toContain("context");
+    expect(joined).toContain("verify");
+  });
+
+  test("omits excluded section when excludedChunks is empty", () => {
+    const entry = makeEntry("verify", { excludedChunks: [] });
+    const output = lines(formatContextInspect("US-001", [entry]));
+    expect(output.join("\n")).not.toContain("Excluded");
+  });
+
+  test("omits providers section when providerResults is absent", () => {
+    const entry = makeEntry("verify", { providerResults: undefined });
+    const output = lines(formatContextInspect("US-001", [entry]));
+    expect(output.join("\n")).not.toContain("Providers");
+  });
+
+  test("shows floor items when present", () => {
+    const entry = makeEntry("verify", { floorItems: ["static:chunk-1", "static:chunk-2"] });
+    const output = lines(formatContextInspect("US-001", [entry]));
+    expect(output.join("\n")).toContain("Floor");
+  });
+
+  test("shows floorOverageItems when present", () => {
+    const entry = makeEntry("verify", {
+      floorItems: ["static:chunk-1"],
+      floorOverageItems: ["static:chunk-1"],
+    });
+    const output = lines(formatContextInspect("US-001", [entry]));
+    expect(output.join("\n")).toContain("overage");  // shown in floor line
+  });
+
+  test("shows digestTokens", () => {
+    const output = lines(formatContextInspect("US-001", [makeEntry("verify")]));
+    expect(output.join("\n")).toContain("120");
+  });
+
+  test("shows provider error message when present", () => {
+    const entry = makeEntry("verify", {
+      providerResults: [
+        { providerId: "git-history", status: "failed", chunkCount: 0, durationMs: 5, tokensProduced: 0, error: "ENOENT: file not found" },
+      ],
+    });
+    const output = lines(formatContextInspect("US-001", [entry]));
+    expect(output.join("\n")).toContain("ENOENT");
+  });
+});


### PR DESCRIPTION
## Summary

- Implements AC-19 from issue #478: `nax context inspect <storyId>` human-readable output
- Replaces the stub single-line formatter with rich per-stage display
- Extracts `formatContextInspect(storyId, manifests)` as a pure function (testable without disk I/O)

Per-stage display includes:
- Budget: used / total tokens + percentage
- Build time and digest token count
- Included / excluded chunk counts
- Per-provider: id, status (ok/empty/failed/timeout), chunkCount, tokensProduced, durationMs, error message
- Excluded chunks with reasons (budget, below-min-score, dedupe, role-filter, stale)
- Floor items and overage count when present

`--json` flag continues to print raw manifest JSON unchanged.

## Test plan

- [ ] `bun test test/unit/cli/context.test.ts` — 18 tests covering all display branches: empty state, header, budget, chunks, providers (ok/failed/timeout), excluded reasons, floor/overage, multi-stage, missing optional sections
- [ ] `bun run typecheck` — clean
- [ ] `bun run build` — clean
- [ ] `bun run test` — 0 failures across full suite