### PR TITLE
feat(context-engine): AC-24 determinism mode

### DIFF
--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -465,6 +465,11 @@ export interface ContextV2Config {
    * Keys are stage names; value overrides the default stage budgetTokens.
    */
   stages: Record<string, { budgetTokens?: number }>;
+  /**
+   * Determinism mode (AC-24).
+   * When true, providers declaring `deterministic: false` are excluded from assembly.
+   */
+  deterministic: boolean;
   /** Session scratch retention settings (AC-20) */
   session: {
     /** Days to retain completed session scratch dirs before purging. */

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -519,7 +519,7 @@ const ContextPluginProviderConfigSchema = z.object({
 });
 
 // Context Engine config (Phase 6: selective on; operators opt in per project)
-const ContextV2ConfigSchema = z
+export const ContextV2ConfigSchema = z
   .object({
     /**
      * Enable Context Engine orchestrator.
@@ -555,6 +555,13 @@ const ContextV2ConfigSchema = z
      */
     stages: z.record(z.string().min(1), z.object({ budgetTokens: z.number().int().positive().optional() })).default({}),
     /**
+     * Determinism mode (AC-24).
+     * When true, providers that declare `deterministic: false` are excluded from assembly.
+     * Guarantees two runs with identical inputs produce identical push blocks.
+     * Default: false — all providers run regardless of determinism declaration.
+     */
+    deterministic: z.boolean().default(false),
+    /**
      * Session scratch retention settings (AC-20).
      * Controls how long completed session scratch dirs are kept on disk.
      */
@@ -575,6 +582,7 @@ const ContextV2ConfigSchema = z
     fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
     pluginProviders: [],
     stages: {},
+    deterministic: false,
     session: { retentionDays: 7, archiveOnFeatureArchive: true },
   }));
 
@@ -998,6 +1006,7 @@ export const NaxConfigSchema = z
         fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
         pluginProviders: [],
         stages: {},
+        deterministic: false,
         session: { retentionDays: 7, archiveOnFeatureArchive: true },
       },
     }),

--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -225,7 +225,10 @@ export class ContextOrchestrator {
     // Step 1: filter providers to those applicable for this stage.
     // request.providerIds (test-only override) takes precedence; otherwise stageConfig.providerIds.
     const allowedIds = request.providerIds ?? stageConfig.providerIds;
-    const activeProviders = this.providers.filter((p) => allowedIds.includes(p.id));
+    // AC-24: determinism mode — skip providers that declare deterministic: false.
+    const activeProviders = this.providers.filter(
+      (p) => allowedIds.includes(p.id) && !(request.deterministic === true && p.deterministic === false),
+    );
 
     // Step 2: parallel fetch with timeout — failures return empty, never throw.
     // Per-provider status is recorded for manifest auditability (Finding 3).

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -370,6 +370,13 @@ export interface ContextRequest {
    * (e.g. a rectify provider surfacing prior failure patterns).
    */
   failureHints?: string[];
+  /**
+   * Determinism mode (AC-24).
+   * When true, the orchestrator skips providers that declare `deterministic: false`.
+   * Ensures two runs with identical inputs produce identical push blocks.
+   * Sourced from config.context.v2.deterministic.
+   */
+  deterministic?: boolean;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -416,6 +423,12 @@ export interface IContextProvider {
   readonly id: string;
   /** Chunk kind produced by this provider */
   readonly kind: ChunkKind;
+  /**
+   * Whether this provider produces deterministic output (AC-24).
+   * Absent or true = deterministic. false = non-deterministic (e.g. LLM-based, random sampling).
+   * When ContextRequest.deterministic is true, non-deterministic providers are skipped.
+   */
+  readonly deterministic?: boolean;
   /**
    * Fetch context chunks for the given request.
    * Must not throw — return empty chunks array on failure and log internally.

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -127,6 +127,7 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
       : undefined,
     sessionId: ctx.sessionId,
     agentId: agentName,
+    deterministic: ctx.config.context.v2.deterministic,
   };
 
   // Phase 7: load any plugin providers (RAG, graph, KB) configured for this project.

--- a/test/unit/context/engine/orchestrator-determinism.test.ts
+++ b/test/unit/context/engine/orchestrator-determinism.test.ts
@@ -1,0 +1,136 @@
+/**
+ * AC-24: Determinism mode
+ *
+ * When ContextRequest.deterministic === true, the orchestrator skips any
+ * provider that declares `deterministic: false`. Deterministic providers
+ * (no field or deterministic: true) are always included.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { ContextOrchestrator, _orchestratorDeps } from "../../../../src/context/engine/orchestrator";
+import type { ContextRequest, IContextProvider, ContextProviderResult } from "../../../../src/context/engine/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+let _seq = 0;
+beforeEach(() => {
+  _seq = 0;
+  _orchestratorDeps.uuid = () => `test-uuid-${++_seq}` as `${string}-${string}-${string}-${string}-${string}`;
+  _orchestratorDeps.now = () => Date.now();
+});
+
+const BASE_REQUEST: ContextRequest = {
+  storyId: "US-001",
+  repoRoot: "/project",
+  packageDir: "/project",
+  stage: "execution",
+  role: "implementer",
+  budgetTokens: 10_000,
+  providerIds: ["det-provider", "non-det-provider", "implicit-det"],
+};
+
+function makeChunk(id: string): ContextProviderResult {
+  return {
+    chunks: [
+      {
+        id,
+        kind: "feature",
+        scope: "feature",
+        role: ["implementer"],
+        content: `content for ${id}`,
+        tokens: 100,
+        rawScore: 1.0,
+      },
+    ],
+  };
+}
+
+function makeProvider(id: string, deterministic?: boolean): IContextProvider {
+  const provider: IContextProvider = {
+    id,
+    kind: "feature",
+    fetch: async () => makeChunk(id),
+  };
+  if (deterministic !== undefined) {
+    (provider as IContextProvider & { deterministic: boolean }).deterministic = deterministic;
+  }
+  return provider;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ContextOrchestrator — determinism mode (AC-24)", () => {
+  test("non-deterministic: false request does not skip any providers", async () => {
+    const det = makeProvider("det-provider", true);
+    const nonDet = makeProvider("non-det-provider", false);
+    const orch = new ContextOrchestrator([det, nonDet]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, deterministic: false });
+
+    const providerIds = bundle.manifest.providerResults?.map((p) => p.providerId) ?? [];
+    expect(providerIds).toContain("det-provider");
+    expect(providerIds).toContain("non-det-provider");
+  });
+
+  test("deterministic: true skips provider with deterministic: false", async () => {
+    const det = makeProvider("det-provider", true);
+    const nonDet = makeProvider("non-det-provider", false);
+    const orch = new ContextOrchestrator([det, nonDet]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, deterministic: true });
+
+    const providerIds = bundle.manifest.providerResults?.map((p) => p.providerId) ?? [];
+    expect(providerIds).toContain("det-provider");
+    expect(providerIds).not.toContain("non-det-provider");
+  });
+
+  test("deterministic: true keeps provider with no deterministic field (default: deterministic)", async () => {
+    const implicit = makeProvider("implicit-det"); // no deterministic field
+    const orch = new ContextOrchestrator([implicit]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, deterministic: true });
+
+    const providerIds = bundle.manifest.providerResults?.map((p) => p.providerId) ?? [];
+    expect(providerIds).toContain("implicit-det");
+  });
+
+  test("deterministic: true keeps provider with deterministic: true", async () => {
+    const det = makeProvider("det-provider", true);
+    const orch = new ContextOrchestrator([det]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, deterministic: true });
+
+    const providerIds = bundle.manifest.providerResults?.map((p) => p.providerId) ?? [];
+    expect(providerIds).toContain("det-provider");
+  });
+
+  test("deterministic: undefined (absent) does not skip non-deterministic providers", async () => {
+    const nonDet = makeProvider("non-det-provider", false);
+    const orch = new ContextOrchestrator([nonDet]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST }); // no deterministic field
+
+    const providerIds = bundle.manifest.providerResults?.map((p) => p.providerId) ?? [];
+    expect(providerIds).toContain("non-det-provider");
+  });
+
+  test("deterministic mode: included chunks come only from deterministic providers", async () => {
+    const det = makeProvider("det-provider", true);
+    const nonDet = makeProvider("non-det-provider", false);
+    const orch = new ContextOrchestrator([det, nonDet]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, deterministic: true });
+
+    expect(bundle.manifest.includedChunks.every((id) => id.startsWith("det-provider"))).toBe(true);
+  });
+
+  test("schema: ContextV2ConfigSchema includes deterministic field defaulting to false", async () => {
+    const { ContextV2ConfigSchema } = await import("../../../../src/config/schemas");
+    const parsed = ContextV2ConfigSchema.parse({});
+    expect(parsed.deterministic).toBe(false);
+  });
+
+  test("schema: ContextV2ConfigSchema accepts deterministic: true", async () => {
+    const { ContextV2ConfigSchema } = await import("../../../../src/config/schemas");
+    const parsed = ContextV2ConfigSchema.parse({ deterministic: true });
+    expect(parsed.deterministic).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements AC-24 from issue #478: `context.deterministic: true` excludes providers declaring `deterministic: false`
- Two runs with identical inputs now produce identical push blocks when determinism mode is enabled

**Changes:**
- `IContextProvider.deterministic?: boolean` — providers declare non-determinism (absent/true = deterministic, false = non-deterministic)
- `ContextRequest.deterministic?: boolean` — orchestrator skips non-deterministic providers when true
- `config.context.v2.deterministic: boolean` (default: `false`) — config flag, propagated to ContextRequest by the pipeline context stage
- Orchestrator: single-line filter after stage-provider filtering, no hot path impact when disabled
- `ContextV2ConfigSchema` now exported for direct schema testing

## Test plan

- [ ] `bun test test/unit/context/engine/orchestrator-determinism.test.ts` — 8 tests: skip non-det provider, keep det provider, keep implicit provider, absent flag is no-op, included chunks only from det providers, schema default=false, schema accepts true
- [ ] `bun run typecheck` — clean
- [ ] `bun run build` — clean
- [ ] `bun run test` — 0 failures (6087 pass)