### PR TITLE
feat(context-engine): AC-25 provider cost accounting

### DIFF
--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -240,6 +240,7 @@ export class ContextOrchestrator {
           const durationMs = _orchestratorDeps.now() - providerStart;
           const status = result.chunks.length === 0 ? ("empty" as const) : ("ok" as const);
           const tokensProduced = result.chunks.reduce((sum, c) => sum + c.tokens, 0);
+          const rawCostUsd = result.chunks.reduce((sum, c) => sum + (c.costUsd ?? 0), 0);
           return {
             provider,
             result,
@@ -249,6 +250,7 @@ export class ContextOrchestrator {
               chunkCount: result.chunks.length,
               durationMs,
               tokensProduced,
+              ...(rawCostUsd > 0 && { costUsd: rawCostUsd }),
             },
           };
         } catch (err) {

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -181,6 +181,12 @@ export interface ContextManifest {
     durationMs: number;
     /** Total tokens across all chunks returned by this provider */
     tokensProduced: number;
+    /**
+     * Total LLM cost for this provider call in USD (AC-25).
+     * Sum of costUsd across all chunks returned. Absent when the provider
+     * reported no chunk costs (i.e. free providers such as git or file-scan).
+     */
+    costUsd?: number;
     error?: string;
   }>;
   /**
@@ -400,6 +406,12 @@ export interface RawChunk {
   tokens: number;
   /** Provider's raw relevance score (0–1 range) */
   rawScore: number;
+  /**
+   * LLM cost for producing this chunk in USD (AC-25).
+   * Only set by providers that invoke an LLM to generate context (e.g. KB-retrieval).
+   * Free providers (git, file-scan) omit this field.
+   */
+  costUsd?: number;
 }
 
 /** What an IContextProvider returns from fetch(). */

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -273,6 +273,12 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
     firstPassSuccess: sm.firstPassSuccess,
   }));
 
+  // AC-25: sum context provider cost across all stories
+  const contextCostUsd = allStoryMetrics.reduce((runSum, sm) => {
+    if (!sm.context?.providers) return runSum;
+    return runSum + Object.values(sm.context.providers).reduce((s, p) => s + (p.costUsd ?? 0), 0);
+  }, 0);
+
   logger?.info("run.complete", "Feature execution completed", {
     runId,
     feature,
@@ -283,6 +289,7 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
     storiesFailed: finalCounts.failed,
     storiesPending: finalCounts.pending,
     totalCost,
+    ...(contextCostUsd > 0 && { contextCostUsd }),
     durationMs,
     storyMetrics: storyMetricsSummary,
   });

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -61,6 +61,7 @@ async function deriveContextMetrics(
         existing.wallClockMs += pr.durationMs;
         if (pr.status === "timeout") existing.timedOut = true;
         if (pr.status === "failed") existing.failed = true;
+        if (pr.costUsd) existing.costUsd = (existing.costUsd ?? 0) + pr.costUsd;
       } else {
         providers[pr.providerId] = {
           tokensProduced: pr.tokensProduced,
@@ -69,6 +70,7 @@ async function deriveContextMetrics(
           wallClockMs: pr.durationMs,
           timedOut: pr.status === "timeout",
           failed: pr.status === "failed",
+          ...(pr.costUsd ? { costUsd: pr.costUsd } : {}),
         };
       }
     }

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -62,6 +62,11 @@ export interface ContextProviderMetrics {
   wallClockMs: number;
   timedOut: boolean;
   failed: boolean;
+  /**
+   * Total LLM cost in USD for this provider across all pipeline stages (AC-25).
+   * Absent when the provider reported no chunk costs (free providers).
+   */
+  costUsd?: number;
 }
 
 /**

--- a/test/unit/metrics/tracker-provider-cost.test.ts
+++ b/test/unit/metrics/tracker-provider-cost.test.ts
@@ -1,0 +1,226 @@
+/**
+ * AC-25: Provider cost accounting
+ *
+ * A provider reporting costUsd on a chunk contributes to
+ * StoryMetrics.context.providers[providerId].costUsd.
+ * Run total is surfaced in the run completion log.
+ *
+ * Tests use _manifestStoreDeps injection to avoid disk I/O.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { _manifestStoreDeps } from "../../../src/context/engine/manifest-store";
+import type { ContextManifest } from "../../../src/context/engine/types";
+import { collectStoryMetrics } from "../../../src/metrics/tracker";
+import type { PipelineContext } from "../../../src/pipeline/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Saved originals
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origListFeatureDirs: typeof _manifestStoreDeps.listFeatureDirs;
+let origListManifestFiles: typeof _manifestStoreDeps.listManifestFiles;
+let origFileExists: typeof _manifestStoreDeps.fileExists;
+let origReadFile: typeof _manifestStoreDeps.readFile;
+
+beforeEach(() => {
+  origListFeatureDirs = _manifestStoreDeps.listFeatureDirs;
+  origListManifestFiles = _manifestStoreDeps.listManifestFiles;
+  origFileExists = _manifestStoreDeps.fileExists;
+  origReadFile = _manifestStoreDeps.readFile;
+});
+
+afterEach(() => {
+  _manifestStoreDeps.listFeatureDirs = origListFeatureDirs;
+  _manifestStoreDeps.listManifestFiles = origListManifestFiles;
+  _manifestStoreDeps.fileExists = origFileExists;
+  _manifestStoreDeps.readFile = origReadFile;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeManifest(providerResults: ContextManifest["providerResults"]): ContextManifest {
+  return {
+    requestId: "req-001",
+    stage: "verify",
+    totalBudgetTokens: 2000,
+    usedTokens: 500,
+    includedChunks: ["llm-provider:abc123"],
+    excludedChunks: [],
+    floorItems: [],
+    digestTokens: 50,
+    buildMs: 10,
+    providerResults,
+  };
+}
+
+function setupManifest(featureId: string, _storyId: string, manifest: ContextManifest) {
+  _manifestStoreDeps.listFeatureDirs = async () => [featureId];
+  _manifestStoreDeps.listManifestFiles = async () => ["context-manifest-verify.json"];
+  _manifestStoreDeps.fileExists = async () => true;
+  _manifestStoreDeps.readFile = async () => JSON.stringify(manifest);
+}
+
+function makeCtx(id: string, featureId: string): PipelineContext {
+  return {
+    story: {
+      id,
+      title: "Test Story",
+      description: "",
+      acceptanceCriteria: [],
+      status: "pending",
+    },
+    prd: { feature: featureId, userStories: [], project: "test", branchName: "main", createdAt: "", updatedAt: "" },
+    config: { autoMode: { defaultAgent: "claude" } } as unknown as PipelineContext["config"],
+    projectDir: "/repo",
+    workdir: "/repo",
+    routing: { tier: "balanced" },
+    agentResult: { success: true, cost: 0 },
+  } as unknown as PipelineContext;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AC-25: provider cost accounting in StoryMetrics", () => {
+  test("costUsd is absent when provider reports no cost", async () => {
+    setupManifest("feat-1", "US-001", makeManifest([
+      { providerId: "git-history", status: "ok", chunkCount: 1, durationMs: 10, tokensProduced: 200 },
+    ]));
+    const metrics = await collectStoryMetrics(makeCtx("US-001", "feat-1"), new Date().toISOString());
+    const prov = metrics.context?.providers["git-history"];
+    expect(prov).toBeDefined();
+    expect(prov?.costUsd).toBeUndefined();
+  });
+
+  test("costUsd is aggregated when provider reports cost", async () => {
+    setupManifest("feat-1", "US-001", makeManifest([
+      { providerId: "llm-provider", status: "ok", chunkCount: 1, durationMs: 10, tokensProduced: 200, costUsd: 0.0025 },
+    ]));
+    const metrics = await collectStoryMetrics(makeCtx("US-001", "feat-1"), new Date().toISOString());
+    const prov = metrics.context?.providers["llm-provider"];
+    expect(prov?.costUsd).toBeCloseTo(0.0025, 6);
+  });
+
+  test("costUsd accumulates across multiple manifest stages", async () => {
+    const manifest1 = makeManifest([
+      { providerId: "llm-provider", status: "ok", chunkCount: 1, durationMs: 10, tokensProduced: 200, costUsd: 0.001 },
+    ]);
+    const manifest2: ContextManifest = { ...makeManifest([
+      { providerId: "llm-provider", status: "ok", chunkCount: 1, durationMs: 12, tokensProduced: 150, costUsd: 0.002 },
+    ]), stage: "execution" };
+
+    let callCount = 0;
+    _manifestStoreDeps.listFeatureDirs = async () => ["feat-1"];
+    _manifestStoreDeps.listManifestFiles = async () => ["context-manifest-verify.json", "context-manifest-execution.json"];
+    _manifestStoreDeps.fileExists = async () => true;
+    _manifestStoreDeps.readFile = async () => {
+      return JSON.stringify(callCount++ === 0 ? manifest1 : manifest2);
+    };
+
+    const metrics = await collectStoryMetrics(makeCtx("US-001", "feat-1"), new Date().toISOString());
+    expect(metrics.context?.providers["llm-provider"]?.costUsd).toBeCloseTo(0.003, 6);
+  });
+
+  test("costUsd is summed across multiple providers independently", async () => {
+    setupManifest("feat-1", "US-001", makeManifest([
+      { providerId: "provider-a", status: "ok", chunkCount: 1, durationMs: 5, tokensProduced: 100, costUsd: 0.001 },
+      { providerId: "provider-b", status: "ok", chunkCount: 1, durationMs: 5, tokensProduced: 100, costUsd: 0.004 },
+    ]));
+    const metrics = await collectStoryMetrics(makeCtx("US-001", "feat-1"), new Date().toISOString());
+    expect(metrics.context?.providers["provider-a"]?.costUsd).toBeCloseTo(0.001, 6);
+    expect(metrics.context?.providers["provider-b"]?.costUsd).toBeCloseTo(0.004, 6);
+  });
+
+  test("costUsd zero is treated as absent (not set)", async () => {
+    setupManifest("feat-1", "US-001", makeManifest([
+      { providerId: "git-history", status: "ok", chunkCount: 1, durationMs: 5, tokensProduced: 100, costUsd: 0 },
+    ]));
+    const metrics = await collectStoryMetrics(makeCtx("US-001", "feat-1"), new Date().toISOString());
+    expect(metrics.context?.providers["git-history"]?.costUsd).toBeUndefined();
+  });
+
+  test("mixed providers: only LLM provider gets costUsd", async () => {
+    setupManifest("feat-1", "US-001", makeManifest([
+      { providerId: "git-history", status: "ok", chunkCount: 1, durationMs: 5, tokensProduced: 100 },
+      { providerId: "llm-provider", status: "ok", chunkCount: 1, durationMs: 20, tokensProduced: 300, costUsd: 0.005 },
+    ]));
+    const metrics = await collectStoryMetrics(makeCtx("US-001", "feat-1"), new Date().toISOString());
+    expect(metrics.context?.providers["git-history"]?.costUsd).toBeUndefined();
+    expect(metrics.context?.providers["llm-provider"]?.costUsd).toBeCloseTo(0.005, 6);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Orchestrator: costUsd aggregated from chunk.costUsd
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AC-25: orchestrator aggregates chunk costUsd into providerResults", () => {
+  test("providerResults.costUsd is sum of chunk costUsd values", async () => {
+    const { ContextOrchestrator, _orchestratorDeps } = await import("../../../src/context/engine/orchestrator");
+    const orig = _orchestratorDeps.uuid;
+    let seq = 0;
+    _orchestratorDeps.uuid = () => `test-uuid-${++seq}` as `${string}-${string}-${string}-${string}-${string}`;
+    _orchestratorDeps.now = () => Date.now();
+
+    const provider = {
+      id: "llm-provider",
+      kind: "feature" as const,
+      fetch: async () => ({
+        chunks: [
+          { id: "llm-provider:c1", kind: "feature" as const, scope: "feature" as const, role: ["implementer" as const], content: "chunk 1", tokens: 100, rawScore: 1.0, costUsd: 0.001 },
+          { id: "llm-provider:c2", kind: "feature" as const, scope: "feature" as const, role: ["implementer" as const], content: "chunk 2", tokens: 100, rawScore: 1.0, costUsd: 0.002 },
+        ],
+      }),
+    };
+
+    const orch = new ContextOrchestrator([provider]);
+    const bundle = await orch.assemble({
+      storyId: "US-001",
+      repoRoot: "/project",
+      packageDir: "/project",
+      stage: "execution",
+      role: "implementer",
+      budgetTokens: 10_000,
+      providerIds: ["llm-provider"],
+    });
+
+    const pr = bundle.manifest.providerResults?.find((p) => p.providerId === "llm-provider");
+    expect(pr?.costUsd).toBeCloseTo(0.003, 6);
+
+    _orchestratorDeps.uuid = orig;
+  });
+
+  test("providerResults.costUsd is absent when no chunks have costUsd", async () => {
+    const { ContextOrchestrator, _orchestratorDeps } = await import("../../../src/context/engine/orchestrator");
+    let seq = 0;
+    _orchestratorDeps.uuid = () => `test-uuid-${++seq}` as `${string}-${string}-${string}-${string}-${string}`;
+
+    const provider = {
+      id: "git-history",
+      kind: "feature" as const,
+      fetch: async () => ({
+        chunks: [
+          { id: "git-history:c1", kind: "feature" as const, scope: "feature" as const, role: ["implementer" as const], content: "commit history", tokens: 200, rawScore: 1.0 },
+        ],
+      }),
+    };
+
+    const orch = new ContextOrchestrator([provider]);
+    const bundle = await orch.assemble({
+      storyId: "US-001",
+      repoRoot: "/project",
+      packageDir: "/project",
+      stage: "execution",
+      role: "implementer",
+      budgetTokens: 10_000,
+      providerIds: ["git-history"],
+    });
+
+    const pr = bundle.manifest.providerResults?.find((p) => p.providerId === "git-history");
+    expect(pr?.costUsd).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements AC-25 from issue #478: provider cost accounting for LLM-backed context providers.

**Changes:**
- `RawChunk.costUsd?: number` — providers that call an LLM to generate chunks set this per-chunk; free providers (git, file-scan) omit it
- `ContextManifest.providerResults[].costUsd?: number` — orchestrator sums `costUsd` across chunks in the success path; absent when all chunks have no cost
- `ContextProviderMetrics.costUsd?: number` — added to metrics interface; aggregated across all pipeline stages in `deriveContextMetrics`
- `run-completion.ts` — computes `contextCostUsd` from `allStoryMetrics` and logs it alongside `totalCost` when non-zero

## Test plan

- [ ] `bun test test/unit/metrics/tracker-provider-cost.test.ts` — 8 tests: absent when no cost, per-chunk sum in orchestrator, multi-stage accumulation, zero treated as absent, independent per-provider tracking, mixed free/LLM providers
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `bun run build` — clean
- [ ] `bun run test` — 0 failures (6108 pass)