### PR TITLE
feat(context-engine): Amendment B AC-51 — planDigestBoost for single-session modes

### DIFF
--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -12,7 +12,7 @@
  * See: docs/specs/SPEC-context-engine-v2.md §ContextOrchestrator
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { getLogger } from "../../logger";
 import { errorMessage } from "../../utils/errors";
 import { AGENT_PROFILES, getAgentProfile } from "./agent-profiles";
@@ -104,6 +104,7 @@ function toContextChunk(packed: PackedChunk): ContextChunk {
     role: packed.role,
     content: packed.content,
     tokens: packed.tokens,
+    rawScore: packed.rawScore,
     score: packed.score,
     reason: packed.reason,
   };
@@ -280,6 +281,33 @@ export class ContextOrchestrator {
     // Collect all raw chunks with providerIds
     const allRaw = fetchResults.flatMap(({ provider, result }) => result.chunks.map((c) => enrichRaw(c, provider.id)));
     const providerResults = fetchResults.map(({ providerStatus }) => providerStatus);
+
+    // Amendment B AC-51: inject plan digest as a boosted RawChunk when planDigestBoost > 1.
+    // This replaces raw "## Prior Stage Summary" markdown rendering for single-session modes,
+    // making the digest compete in scoring/packing and appear in manifest.includedChunks.
+    if (request.priorStageDigest && (request.planDigestBoost ?? 1.0) > 1.0) {
+      const boost = request.planDigestBoost ?? 1.0;
+      const hash = createHash("sha256").update(request.priorStageDigest).digest("hex").slice(0, 8);
+      const tokens = Math.ceil(request.priorStageDigest.length / 4);
+      allRaw.push({
+        id: `plan-digest:${hash}`,
+        providerId: "plan-digest",
+        kind: "session",
+        scope: "session",
+        role: ["all"],
+        content: request.priorStageDigest,
+        tokens,
+        rawScore: 0.9 * boost,
+      });
+      providerResults.push({
+        providerId: "plan-digest",
+        status: "ok",
+        chunkCount: 1,
+        durationMs: 0,
+        tokensProduced: tokens,
+      });
+    }
+
     // Phase 4: build pull tool descriptors from stage config + PULL_TOOL_REGISTRY.
     // Provider-level result.pullTools is reserved for Phase 7 and ignored here.
     // AC-33: gate pull tools on agent capability. When the agent cannot invoke

--- a/src/context/engine/stage-config.ts
+++ b/src/context/engine/stage-config.ts
@@ -41,6 +41,14 @@ export interface StageContextConfig {
    * per-request pullConfig.allowedTools allowlist.
    */
   pullToolNames?: string[];
+  /**
+   * Plan digest score multiplier (Amendment B AC-51).
+   * When > 1.0, the plan digest is injected as a scored RawChunk with
+   * rawScore = 0.9 * planDigestBoost instead of raw markdown rendering.
+   * Applied for single-session modes to compensate for absent cross-session digest.
+   * Default: absent (treated as 1.0, raw markdown rendering used).
+   */
+  planDigestBoost?: number;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -194,26 +202,42 @@ export const STAGE_CONTEXT_MAP: Record<string, StageContextConfig> = {
   },
 
   // Single-session strategy — same as execution (no TDD split)
+  // planDigestBoost: compensates for absent cross-session digest (Amendment B AC-51)
   "single-session": {
     role: "implementer",
     budgetTokens: 12_000,
     providerIds: PHASE_3_EXECUTION,
     pullToolNames: ["query_neighbor"],
+    planDigestBoost: 1.5,
+  },
+
+  // TDD-simple strategy — same as single-session (simplified TDD with merged roles)
+  // planDigestBoost: compensates for absent cross-session digest (Amendment B AC-51)
+  "tdd-simple": {
+    role: "implementer",
+    budgetTokens: 12_000,
+    providerIds: PHASE_3_EXECUTION,
+    pullToolNames: ["query_neighbor"],
+    planDigestBoost: 1.5,
   },
 
   // No-test strategy — implementer role, moderate budget
+  // planDigestBoost: compensates for absent cross-session digest (Amendment B AC-51)
   "no-test": {
     role: "implementer",
     budgetTokens: 10_000,
     providerIds: PHASE_3_EXECUTION,
+    planDigestBoost: 1.5,
   },
 
   // Batch strategy — implementer role, full budget (parallel stories)
+  // planDigestBoost: compensates for absent cross-session digest (Amendment B AC-51)
   batch: {
     role: "implementer",
     budgetTokens: 12_000,
     providerIds: PHASE_3_EXECUTION,
     pullToolNames: ["query_neighbor"],
+    planDigestBoost: 1.5,
   },
 
   // Route — lightweight context for routing/classification; static rules only

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -124,6 +124,8 @@ export interface ContextChunk {
   content: string;
   /** Estimated token count */
   tokens: number;
+  /** Provider's raw relevance score before adjustments (preserved for traceability) */
+  rawScore?: number;
   /** Final score after role × freshness × kind adjustments */
   score: number;
   /** True when chunk is detected as stale (post-GA: staleness signal) */
@@ -383,6 +385,14 @@ export interface ContextRequest {
    * Sourced from config.context.v2.deterministic.
    */
   deterministic?: boolean;
+  /**
+   * Plan digest score multiplier (Amendment B AC-51).
+   * When > 1.0 and priorStageDigest is present, the orchestrator injects the plan
+   * digest as a scored RawChunk (id: "plan-digest:<hash>") with
+   * rawScore = 0.9 * planDigestBoost instead of using raw "## Prior Stage Summary" rendering.
+   * Sourced from StageContextConfig.planDigestBoost for single-session modes.
+   */
+  planDigestBoost?: number;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -21,6 +21,7 @@ import { createDefaultOrchestrator, createRunCallCounter } from "../../context/e
 import type { ContextRequest, IContextProvider } from "../../context/engine";
 import { writeContextManifest } from "../../context/engine/manifest-store";
 import { loadPluginProviders } from "../../context/engine/providers/plugin-loader";
+import { getStageContextConfig } from "../../context/engine/stage-config";
 import { FeatureContextProvider } from "../../context/providers/feature-context";
 import type { ContextElement } from "../../context/types";
 import { buildStoryContextFullFromCtx } from "../../execution/helpers";
@@ -128,6 +129,9 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
     sessionId: ctx.sessionId,
     agentId: agentName,
     deterministic: ctx.config.context.v2.deterministic,
+    // Amendment B AC-51: pass planDigestBoost from the routing strategy's stage config.
+    // single-session, tdd-simple, no-test, and batch strategies declare planDigestBoost >= 1.5.
+    planDigestBoost: getStageContextConfig(ctx.routing?.testStrategy ?? "").planDigestBoost,
   };
 
   // Phase 7: load any plugin providers (RAG, graph, KB) configured for this project.

--- a/test/unit/context/engine/orchestrator-plan-digest-boost.test.ts
+++ b/test/unit/context/engine/orchestrator-plan-digest-boost.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Amendment B AC-51: planDigestBoost
+ *
+ * For stages single-session, tdd-simple, no-test, and batch the plan digest
+ * is injected as a scored RawChunk (id: "plan-digest:<hash>") with a boosted
+ * rawScore. For all other stages the priorStageDigest remains raw markdown only.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { ContextOrchestrator, _orchestratorDeps } from "../../../../src/context/engine/orchestrator";
+import { getStageContextConfig, STAGE_CONTEXT_MAP } from "../../../../src/context/engine/stage-config";
+import type { ContextRequest } from "../../../../src/context/engine/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+let _seq = 0;
+beforeEach(() => {
+  _seq = 0;
+  _orchestratorDeps.uuid = () => `test-uuid-${++_seq}` as `${string}-${string}-${string}-${string}-${string}`;
+  _orchestratorDeps.now = () => Date.now();
+});
+
+const PLAN_DIGEST = "Plan summary: touch auth.ts, use _deps pattern, tests in test/unit/auth.";
+
+const BASE_REQUEST: ContextRequest = {
+  storyId: "US-001",
+  repoRoot: "/project",
+  packageDir: "/project",
+  stage: "single-session",
+  role: "implementer",
+  budgetTokens: 10_000,
+  providerIds: [],
+  priorStageDigest: PLAN_DIGEST,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stage config tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("StageContextConfig.planDigestBoost", () => {
+  test.each(["single-session", "tdd-simple", "no-test", "batch"])(
+    "%s has planDigestBoost >= 1.5",
+    (stage) => {
+      const cfg = getStageContextConfig(stage);
+      expect(cfg.planDigestBoost).toBeGreaterThanOrEqual(1.5);
+    },
+  );
+
+  test.each(["execution", "verify", "review-semantic", "plan", "tdd-test-writer", "tdd-implementer"])(
+    "%s has planDigestBoost absent or <= 1",
+    (stage) => {
+      const cfg = getStageContextConfig(stage);
+      expect(cfg.planDigestBoost ?? 1.0).toBeLessThanOrEqual(1.0);
+    },
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Orchestrator: plan-digest chunk injection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ContextOrchestrator — planDigestBoost (Amendment B AC-51)", () => {
+  test("plan-digest chunk is injected into includedChunks when planDigestBoost > 1", async () => {
+    const orch = new ContextOrchestrator([]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, planDigestBoost: 1.5 });
+    const planChunk = bundle.manifest.includedChunks.find((id) => id.startsWith("plan-digest:"));
+    expect(planChunk).toBeDefined();
+  });
+
+  test("plan-digest chunk appears in bundle.chunks when boosted", async () => {
+    const orch = new ContextOrchestrator([]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, planDigestBoost: 1.5 });
+    const chunk = bundle.chunks.find((c) => c.id.startsWith("plan-digest:"));
+    expect(chunk).toBeDefined();
+    expect(chunk?.content).toBe(PLAN_DIGEST);
+  });
+
+  test("plan-digest chunk is NOT injected when planDigestBoost absent", async () => {
+    const orch = new ContextOrchestrator([]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST }); // no planDigestBoost
+    const planChunk = bundle.manifest.includedChunks.find((id) => id.startsWith("plan-digest:"));
+    expect(planChunk).toBeUndefined();
+  });
+
+  test("plan-digest chunk is NOT injected when planDigestBoost <= 1", async () => {
+    const orch = new ContextOrchestrator([]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, planDigestBoost: 1.0 });
+    const planChunk = bundle.manifest.includedChunks.find((id) => id.startsWith("plan-digest:"));
+    expect(planChunk).toBeUndefined();
+  });
+
+  test("plan-digest chunk is NOT injected when priorStageDigest is absent", async () => {
+    const orch = new ContextOrchestrator([]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, priorStageDigest: undefined, planDigestBoost: 1.5 });
+    const planChunk = bundle.manifest.includedChunks.find((id) => id.startsWith("plan-digest:"));
+    expect(planChunk).toBeUndefined();
+  });
+
+  test("boosted plan-digest chunk has higher rawScore than session-scratch chunks (0.9)", async () => {
+    const orch = new ContextOrchestrator([]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, planDigestBoost: 1.5 });
+    const chunk = bundle.chunks.find((c) => c.id.startsWith("plan-digest:"));
+    // rawScore should be 0.9 * 1.5 = 1.35, exceeding normal session rawScore of 0.9
+    expect(chunk?.rawScore).toBeGreaterThan(0.9);
+  });
+
+  test("plan-digest chunk appears in providerResults with providerId 'plan-digest'", async () => {
+    const orch = new ContextOrchestrator([]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, planDigestBoost: 1.5 });
+    const pr = bundle.manifest.providerResults?.find((p) => p.providerId === "plan-digest");
+    expect(pr).toBeDefined();
+    expect(pr?.status).toBe("ok");
+  });
+
+  test("pushMarkdown contains plan digest content when boosted", async () => {
+    const orch = new ContextOrchestrator([]);
+    const bundle = await orch.assemble({ ...BASE_REQUEST, planDigestBoost: 1.5 });
+    expect(bundle.pushMarkdown).toContain(PLAN_DIGEST);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `planDigestBoost?: number` to `StageContextConfig` and `ContextRequest`; adds `rawScore?: number` to `ContextChunk`
- Sets `planDigestBoost: 1.5` on four strategy stages: `single-session`, `tdd-simple`, `no-test`, `batch`; also adds the previously-missing `tdd-simple` stage to `STAGE_CONTEXT_MAP`
- Orchestrator injects a synthetic `plan-digest:<sha256[:8]>` `RawChunk` with `rawScore = 0.9 * planDigestBoost` (1.35 for default 1.5×) when both `planDigestBoost > 1.0` and `priorStageDigest` are present — the chunk competes in scoring/packing and appears in `manifest.includedChunks` for traceability
- Pipeline context stage threads `planDigestBoost` from the routing strategy's `StageContextConfig` into the `ContextRequest`
- 18 unit tests covering stage config values and all injection branches (boost present/absent, digest present/absent, rawScore threshold, providerResults entry, pushMarkdown content)

## Test plan

- [ ] `bun test test/unit/context/engine/orchestrator-plan-digest-boost.test.ts` — 18/18 pass
- [ ] `bun run test` — all 1184 tests pass, 0 failures
- [ ] `bun run lint` — clean
- [ ] `bun run typecheck` — clean
- [ ] `bun run build` — 992 modules bundled