### PR TITLE
feat(context-engine): Amendment A — context pollution prevention (AC-45 to AC-49)

### DIFF
--- a/src/cli/status-cost.ts
+++ b/src/cli/status-cost.ts
@@ -89,6 +89,20 @@ export async function displayLastRunMetrics(workdir: string): Promise<void> {
       })),
     });
   }
+
+  // Amendment A AC-48: warn when any story's pollution ratio exceeds threshold
+  const POLLUTION_WARN_THRESHOLD = 0.3;
+  for (const story of lastRun.stories) {
+    const ratio = story.context?.pollution?.pollutionRatio;
+    if (ratio !== undefined && ratio > POLLUTION_WARN_THRESHOLD) {
+      logger.warn("cli", "High context pollution detected — review context.md for stale entries", {
+        storyId: story.storyId,
+        pollutionRatio: ratio,
+        contradictedChunks: story.context?.pollution?.contradictedChunks ?? 0,
+        ignoredChunks: story.context?.pollution?.ignoredChunks ?? 0,
+      });
+    }
+  }
 }
 
 /**

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -477,6 +477,15 @@ export interface ContextV2Config {
     /** When true and the feature run fully completes, archive to _archive/ instead of deleting. */
     archiveOnFeatureArchive: boolean;
   };
+  /** Staleness detection for feature context entries (Amendment A AC-46/AC-47) */
+  staleness: {
+    /** Enable staleness detection. Default: true. */
+    enabled: boolean;
+    /** Stories after which a context entry is age-stale. Default: 10. */
+    maxStoryAge: number;
+    /** Score multiplier applied to stale chunks (0–1). Default: 0.4. */
+    scoreMultiplier: number;
+  };
 }
 
 export interface ContextConfig {

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -573,6 +573,30 @@ export const ContextV2ConfigSchema = z
         archiveOnFeatureArchive: z.boolean().default(true),
       })
       .default(() => ({ retentionDays: 7, archiveOnFeatureArchive: true })),
+    /**
+     * Staleness detection for feature context entries (Amendment A AC-46/AC-47).
+     * Downweights old or contradicted entries in context.md so stale advice
+     * does not crowd out fresh context. No chunks are auto-removed — humans
+     * must edit context.md to remove stale entries.
+     */
+    staleness: z
+      .object({
+        /** Enable staleness detection. Default: true. */
+        enabled: z.boolean().default(true),
+        /**
+         * Number of completed stories after which a context entry is considered
+         * age-stale. Measured by position in context.md (entries are appended
+         * in story order). Default: 10.
+         */
+        maxStoryAge: z.number().int().min(1).default(10),
+        /**
+         * Score multiplier applied to stale chunks (0–1).
+         * 0.4 = stale entry scores 40% of its normal weight, making it less
+         * likely to beat fresh context for the same budget slot.
+         */
+        scoreMultiplier: z.number().min(0).max(1).default(0.4),
+      })
+      .default(() => ({ enabled: true, maxStoryAge: 10, scoreMultiplier: 0.4 })),
   })
   .default(() => ({
     enabled: false,
@@ -584,6 +608,7 @@ export const ContextV2ConfigSchema = z
     stages: {},
     deterministic: false,
     session: { retentionDays: 7, archiveOnFeatureArchive: true },
+    staleness: { enabled: true, maxStoryAge: 10, scoreMultiplier: 0.4 },
   }));
 
 const ContextConfigSchema = z.object({
@@ -1008,6 +1033,7 @@ export const NaxConfigSchema = z
         stages: {},
         deterministic: false,
         session: { retentionDays: 7, archiveOnFeatureArchive: true },
+        staleness: { enabled: true, maxStoryAge: 10, scoreMultiplier: 0.4 },
       },
     }),
     optimizer: OptimizerConfigSchema.optional(),

--- a/src/context/engine/effectiveness.ts
+++ b/src/context/engine/effectiveness.ts
@@ -1,0 +1,206 @@
+/**
+ * Context Engine v2 — Effectiveness Signal
+ *
+ * Post-story annotation for kept context chunks (Amendment A AC-45).
+ * Classifies each chunk as followed/contradicted/ignored/unknown based on
+ * agent output, git diff, and review findings.
+ *
+ * All classification is deterministic (no LLM). Runs post-story and writes
+ * effectiveness signals back into stored context manifests.
+ *
+ * See: docs/specs/SPEC-context-engine-v2-amendments.md Amendment A.2
+ */
+
+import { _manifestStoreDeps, loadContextManifests } from "./manifest-store";
+import type { ChunkEffectiveness } from "./types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MIN_SIGNIFICANT_TERMS = 3;
+
+// Stopwords shared with staleness tokenizer — keep in sync.
+const STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "are",
+  "was",
+  "use",
+  "all",
+  "can",
+  "this",
+  "that",
+  "with",
+  "from",
+  "have",
+  "been",
+  "will",
+  "when",
+  "their",
+  "they",
+  "than",
+  "its",
+  "not",
+  "but",
+  "each",
+  "more",
+  "also",
+  "into",
+  "some",
+  "any",
+  "our",
+  "only",
+  "new",
+  "may",
+  "has",
+  "how",
+  "his",
+  "her",
+  "you",
+  "your",
+]);
+const MIN_TOKEN_LEN = 4;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tokenizer (local copy — avoids a circular dep between staleness ↔ effectiveness)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function tokenize(text: string): Set<string> {
+  if (!text) return new Set();
+  const raw = text
+    .toLowerCase()
+    .split(/[\s_\-./:,;()\[\]{}'"!?]+/)
+    .filter((t) => t.length >= MIN_TOKEN_LEN && !STOPWORDS.has(t));
+  return new Set(raw);
+}
+
+function sharedTermCount(a: Set<string>, b: Set<string>): number {
+  let count = 0;
+  for (const term of a) {
+    if (b.has(term)) count++;
+  }
+  return count;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Classification
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Classify a single chunk's effectiveness signal.
+ *
+ * Signal priority (first match wins):
+ *   1. contradicted — a review finding shares >= MIN_SIGNIFICANT_TERMS terms
+ *      with the chunk summary (finding contradicts the chunk's advice)
+ *   2. followed — the git diff shares >= MIN_SIGNIFICANT_TERMS terms with
+ *      the chunk summary (agent implemented what the chunk recommended)
+ *   3. ignored — the chunk terms appear in neither diff nor agent output
+ *   4. unknown — fallback (all inputs empty, or summary too short to compare)
+ *
+ * @param chunkSummary - first 300 chars of the chunk content
+ * @param agentOutput  - agent stdout from AgentResult.output
+ * @param diffText     - git diff text from `git diff <ref>..HEAD`
+ * @param findingMessages - review finding messages from ReviewFinding.message[]
+ */
+export function classifyEffectiveness(
+  chunkSummary: string,
+  agentOutput: string,
+  diffText: string,
+  findingMessages: string[],
+): ChunkEffectiveness {
+  const summaryTerms = tokenize(chunkSummary);
+
+  // Too few terms → cannot classify meaningfully
+  if (summaryTerms.size < MIN_SIGNIFICANT_TERMS) {
+    return { signal: "unknown" };
+  }
+
+  // 1. Contradicted: review finding text overlaps with chunk summary
+  for (const finding of findingMessages) {
+    const findingTerms = tokenize(finding);
+    if (sharedTermCount(summaryTerms, findingTerms) >= MIN_SIGNIFICANT_TERMS) {
+      return {
+        signal: "contradicted",
+        evidence: finding.slice(0, 200),
+      };
+    }
+  }
+
+  // 2. Followed: diff overlaps with chunk summary
+  if (diffText) {
+    const diffTerms = tokenize(diffText);
+    if (sharedTermCount(summaryTerms, diffTerms) >= MIN_SIGNIFICANT_TERMS) {
+      return {
+        signal: "followed",
+        evidence: "terms found in diff",
+      };
+    }
+  }
+
+  // 3. Ignored: terms appear in neither diff nor agent output
+  if (diffText || agentOutput) {
+    const combinedTerms = tokenize(`${diffText} ${agentOutput}`);
+    if (sharedTermCount(summaryTerms, combinedTerms) < MIN_SIGNIFICANT_TERMS) {
+      return { signal: "ignored" };
+    }
+  }
+
+  return { signal: "unknown" };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Post-story manifest annotation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Annotate all stored context manifests for a story with effectiveness signals.
+ * Called post-story (after story pipeline completes) — not on the hot path.
+ *
+ * For each manifest that has chunkSummaries, classifies each included chunk
+ * and writes chunkEffectiveness back via read-modify-write.
+ *
+ * Best-effort: if any single manifest fails to update, the error is swallowed
+ * so it does not block story completion.
+ */
+export async function annotateManifestEffectiveness(
+  projectDir: string,
+  featureId: string,
+  storyId: string,
+  {
+    agentOutput,
+    diffText,
+    findingMessages,
+  }: {
+    agentOutput: string;
+    diffText: string;
+    findingMessages: string[];
+  },
+): Promise<void> {
+  const stored = await loadContextManifests(projectDir, storyId, featureId);
+
+  for (const item of stored) {
+    const { manifest } = item;
+    if (!manifest.chunkSummaries || manifest.includedChunks.length === 0) continue;
+
+    const effectiveness: Record<string, ChunkEffectiveness> = {};
+    for (const id of manifest.includedChunks) {
+      const summary = manifest.chunkSummaries[id];
+      if (!summary) continue;
+      effectiveness[id] = classifyEffectiveness(summary, agentOutput, diffText, findingMessages);
+    }
+
+    if (Object.keys(effectiveness).length === 0) continue;
+
+    // Read-modify-write: reload the raw JSON to preserve unknown fields
+    try {
+      const raw = await _manifestStoreDeps.readFile(item.path);
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      parsed.chunkEffectiveness = effectiveness;
+      await _manifestStoreDeps.writeFile(item.path, `${JSON.stringify(parsed, null, 2)}\n`);
+    } catch {
+      // Best-effort — non-fatal
+    }
+  }
+}

--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -107,6 +107,7 @@ function toContextChunk(packed: PackedChunk): ContextChunk {
     rawScore: packed.rawScore,
     score: packed.score,
     reason: packed.reason,
+    ...(packed.staleCandidate && { staleCandidate: true }),
   };
 }
 
@@ -357,6 +358,14 @@ export class ContextOrchestrator {
 
     const buildMs = _orchestratorDeps.now() - startMs;
 
+    // Amendment A: collect stale chunk IDs and chunk content summaries for
+    // post-story effectiveness annotation. Both are optional and absent when empty.
+    const staleChunkIds = packed.filter((c) => c.staleCandidate).map((c) => c.id);
+    const chunkSummaries: Record<string, string> = {};
+    for (const c of packed) {
+      chunkSummaries[c.id] = c.content.slice(0, 300);
+    }
+
     // Build manifest
     const manifest: ContextManifest = {
       requestId,
@@ -377,6 +386,8 @@ export class ContextOrchestrator {
       providerResults,
       repoRoot: request.repoRoot,
       packageDir: request.packageDir,
+      ...(Object.keys(chunkSummaries).length > 0 && { chunkSummaries }),
+      ...(staleChunkIds.length > 0 && { staleChunks: staleChunkIds }),
     };
 
     logger.debug("context-v2", "Bundle assembled", {

--- a/src/context/engine/pollution.ts
+++ b/src/context/engine/pollution.ts
@@ -1,0 +1,76 @@
+/**
+ * Context Engine v2 — Pollution Metrics
+ *
+ * Aggregates context pollution indicators from stored manifests (Amendment A AC-48).
+ * Pure function — no I/O. Called from deriveContextMetrics in metrics/tracker.ts.
+ *
+ * Pollution metrics:
+ *   droppedBelowMinScore  — chunks excluded by noise gate
+ *   staleChunksInjected   — chunks that were stale but still included (downweighted)
+ *   contradictedChunks    — included chunks whose advice review findings contradicted
+ *   ignoredChunks         — included chunks that the agent apparently ignored
+ *   pollutionRatio        — (contradicted + ignored) / total included
+ *
+ * See: docs/specs/SPEC-context-engine-v2-amendments.md Amendment A.4
+ */
+
+import type { StoredContextManifest } from "./manifest-store";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface PollutionMetrics {
+  droppedBelowMinScore: number;
+  staleChunksInjected: number;
+  contradictedChunks: number;
+  ignoredChunks: number;
+  pollutionRatio: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Aggregation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute aggregate pollution metrics across all stored manifests for a story.
+ *
+ * - droppedBelowMinScore: sum of excludedChunks with reason "below-min-score"
+ * - staleChunksInjected: sum of staleChunks[] entries (included stale chunks)
+ * - contradictedChunks: sum of chunkEffectiveness entries with signal "contradicted"
+ * - ignoredChunks: sum of chunkEffectiveness entries with signal "ignored"
+ * - pollutionRatio: (contradicted + ignored) / max(totalIncluded, 1)
+ */
+export function computePollutionMetrics(manifests: StoredContextManifest[]): PollutionMetrics {
+  let droppedBelowMinScore = 0;
+  let staleChunksInjected = 0;
+  let contradictedChunks = 0;
+  let ignoredChunks = 0;
+  let totalIncluded = 0;
+
+  for (const { manifest } of manifests) {
+    for (const ex of manifest.excludedChunks) {
+      if (ex.reason === "below-min-score") droppedBelowMinScore++;
+    }
+
+    staleChunksInjected += manifest.staleChunks?.length ?? 0;
+    totalIncluded += manifest.includedChunks.length;
+
+    if (manifest.chunkEffectiveness) {
+      for (const signal of Object.values(manifest.chunkEffectiveness)) {
+        if (signal.signal === "contradicted") contradictedChunks++;
+        else if (signal.signal === "ignored") ignoredChunks++;
+      }
+    }
+  }
+
+  const pollutionRatio = totalIncluded > 0 ? (contradictedChunks + ignoredChunks) / totalIncluded : 0;
+
+  return {
+    droppedBelowMinScore,
+    staleChunksInjected,
+    contradictedChunks,
+    ignoredChunks,
+    pollutionRatio,
+  };
+}

--- a/src/context/engine/providers/feature-context.ts
+++ b/src/context/engine/providers/feature-context.ts
@@ -12,7 +12,7 @@
  * builds a fresh provider per assemble() call).
  *
  * Phase 0: behavioral parity with v1 — same file, same header, same tokens.
- * Phase 2+: staleness detection, effectiveness signal (Amendment A.2/A.3).
+ * Phase 2 (Amendment A): staleness detection (AC-46/AC-47).
  */
 
 import { createHash } from "node:crypto";
@@ -21,6 +21,7 @@ import { getLogger } from "../../../logger";
 import type { UserStory } from "../../../prd";
 import { errorMessage } from "../../../utils/errors";
 import { FeatureContextProvider as FeatureContextProviderV1 } from "../../providers/feature-context";
+import { applyStaleness, detectContradictions, parseFeatureContextEntries, selectStaleByAge } from "../staleness";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -60,6 +61,10 @@ export class FeatureContextProviderV2 implements IContextProvider {
    * Fetch feature context via the v1 provider and adapt the result into a
    * v2 RawChunk.  Returns empty chunks when the feature engine is disabled
    * or no context.md exists.
+   *
+   * When staleness detection is enabled (Amendment A AC-46/AC-47), the chunk
+   * is annotated with staleCandidate: true and a scoreMultiplier when any
+   * entries in the content are age-stale or contradiction-stale.
    */
   async fetch(request: ContextRequest): Promise<ContextProviderResult> {
     const logger = getLogger();
@@ -72,17 +77,38 @@ export class FeatureContextProviderV2 implements IContextProvider {
       }
 
       const hash = contentHash8(result.content);
-      const chunk: RawChunk = {
+      let chunk: RawChunk = {
         id: `feature-context:${hash}`,
         kind: "feature",
         scope: "feature",
-        // Feature context is relevant to both implementers and reviewers
         role: ["implementer", "reviewer", "tdd"],
         content: result.content,
         tokens: result.estimatedTokens,
-        // Full score — feature context is always maximally relevant
         rawScore: 1.0,
       };
+
+      // Amendment A AC-46/AC-47: staleness detection (read-time, no LLM).
+      const stalenessConfig = this.config.context?.v2?.staleness;
+      if (stalenessConfig?.enabled !== false) {
+        const maxStoryAge = stalenessConfig?.maxStoryAge ?? 10;
+        const scoreMultiplier = stalenessConfig?.scoreMultiplier ?? 0.4;
+
+        const entries = parseFeatureContextEntries(result.content);
+        if (entries.length > 0) {
+          const contradicted = detectContradictions(entries);
+          const ageStale = selectStaleByAge(entries, maxStoryAge);
+          const isStale = contradicted.size > 0 || ageStale.size > 0;
+          chunk = applyStaleness(chunk, { isStale, scoreMultiplier });
+
+          if (isStale) {
+            logger.debug("feature-context-v2", "Stale entries detected in feature context", {
+              storyId: request.storyId,
+              contradicted: contradicted.size,
+              ageStale: ageStale.size,
+            });
+          }
+        }
+      }
 
       logger.debug("feature-context-v2", "Loaded feature context chunk", {
         storyId: request.storyId,

--- a/src/context/engine/scoring.ts
+++ b/src/context/engine/scoring.ts
@@ -86,7 +86,11 @@ export function scoreChunk(chunk: RawChunk, callerRole: ChunkRole, minScore = MI
   const roleFiltered = rm === 0;
 
   const kindWeight = KIND_WEIGHTS[chunk.kind] ?? 0.5;
-  const freshnessMultiplier = stale ? STALENESS_PENALTY : 1.0;
+  // Amendment A AC-46: staleCandidate on chunk overrides the caller-supplied stale flag.
+  // scoreMultiplier from the chunk (set by FeatureContextProviderV2) takes precedence
+  // over the global STALENESS_PENALTY so config.staleness.scoreMultiplier is respected.
+  const isStale = chunk.staleCandidate === true || stale;
+  const freshnessMultiplier = isStale ? (chunk.scoreMultiplier ?? STALENESS_PENALTY) : 1.0;
 
   const score = chunk.rawScore * rm * kindWeight * freshnessMultiplier;
   const belowMinScore = !roleFiltered && score < minScore;

--- a/src/context/engine/staleness.ts
+++ b/src/context/engine/staleness.ts
@@ -1,0 +1,238 @@
+/**
+ * Context Engine v2 — Staleness Detection
+ *
+ * Pure helpers for Amendment A AC-46 (age-based staleness) and
+ * AC-47 (contradiction-based staleness) in feature context entries.
+ *
+ * All functions are deterministic (no LLM, no I/O).
+ * Called from FeatureContextProviderV2.fetch() at read time.
+ *
+ * See: docs/specs/SPEC-context-engine-v2-amendments.md Amendment A.3
+ */
+
+import type { RawChunk } from "./types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "are",
+  "was",
+  "use",
+  "all",
+  "can",
+  "this",
+  "that",
+  "with",
+  "from",
+  "have",
+  "been",
+  "will",
+  "when",
+  "their",
+  "they",
+  "than",
+  "its",
+  "not",
+  "but",
+  "each",
+  "more",
+  "also",
+  "into",
+  "some",
+  "any",
+  "our",
+  "only",
+  "new",
+  "may",
+  "has",
+  "how",
+  "his",
+  "her",
+  "you",
+  "your",
+]);
+
+const NEGATION_TERMS = ["no longer", "instead", "replaced", "removed", "deprecated"];
+
+const MIN_SHARED_TERMS = 3;
+const MIN_TOKEN_LEN = 4;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface FeatureContextEntry {
+  section: string;
+  index: number;
+  text: string;
+  establishedIn?: string;
+  terms: Set<string>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tokenizer
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Extract significant tokens from text.
+ * Lowercases, splits on whitespace and identifier separators,
+ * removes stopwords and short tokens, deduplicates.
+ */
+export function tokenize(text: string): string[] {
+  if (!text) return [];
+  const raw = text
+    .toLowerCase()
+    .split(/[\s_\-./:,;()\[\]{}'"!?]+/)
+    .filter((t) => t.length >= MIN_TOKEN_LEN && !STOPWORDS.has(t));
+  return [...new Set(raw)];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entry parsing
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ESTABLISHED_RE = /_Established in:\s*(US-\S+)_/i;
+const SECTION_RE = /^##\s+(.+)$/;
+
+/**
+ * Parse a feature context.md markdown string into a flat list of entries.
+ * Each `## Section` heading starts a new section; paragraphs within a section
+ * become individual entries (split on blank lines).
+ */
+export function parseFeatureContextEntries(markdown: string): FeatureContextEntry[] {
+  if (!markdown.trim()) return [];
+
+  const entries: FeatureContextEntry[] = [];
+  let currentSection = "";
+  let currentParagraph: string[] = [];
+  let index = 0;
+
+  function flushParagraph(): void {
+    const text = currentParagraph.join("\n").trim();
+    if (!text) return;
+    const match = ESTABLISHED_RE.exec(text);
+    entries.push({
+      section: currentSection,
+      index: index++,
+      text,
+      establishedIn: match ? match[1] : undefined,
+      terms: new Set(tokenize(text)),
+    });
+    currentParagraph = [];
+  }
+
+  for (const line of markdown.split("\n")) {
+    const sectionMatch = SECTION_RE.exec(line);
+    if (sectionMatch) {
+      flushParagraph();
+      currentSection = sectionMatch[1].trim();
+      continue;
+    }
+    if (line.trim() === "") {
+      flushParagraph();
+    } else {
+      currentParagraph.push(line);
+    }
+  }
+  flushParagraph();
+
+  return entries.filter((e) => e.text.length > 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Contradiction detection (AC-47)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function containsNegation(text: string): boolean {
+  const lower = text.toLowerCase();
+  return NEGATION_TERMS.some((term) => lower.includes(term));
+}
+
+function sharedTermCount(a: Set<string>, b: Set<string>): number {
+  let count = 0;
+  for (const term of a) {
+    if (b.has(term)) count++;
+  }
+  return count;
+}
+
+/**
+ * Find entries that are contradicted by a newer entry in the same section.
+ * Returns the indices of stale (older) entries.
+ *
+ * Rule (AC-47): Two entries in the same section share >= 3 significant terms
+ * AND the newer entry uses negation language → older entry is stale.
+ */
+export function detectContradictions(entries: FeatureContextEntry[]): Set<number> {
+  const stale = new Set<number>();
+
+  const bySection = new Map<string, FeatureContextEntry[]>();
+  for (const e of entries) {
+    const group = bySection.get(e.section);
+    if (group) {
+      group.push(e);
+    } else {
+      bySection.set(e.section, [e]);
+    }
+  }
+
+  for (const group of bySection.values()) {
+    for (let newer = 1; newer < group.length; newer++) {
+      if (!containsNegation(group[newer].text)) continue;
+      for (let older = 0; older < newer; older++) {
+        if (sharedTermCount(group[older].terms, group[newer].terms) >= MIN_SHARED_TERMS) {
+          stale.add(group[older].index);
+        }
+      }
+    }
+  }
+
+  return stale;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Age-based staleness (AC-46)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find entries older than maxStoryAge positions from the end of the list.
+ * Entries without an `_Established in:_` marker are not flagged.
+ *
+ * Age = entries that came after this entry. Stale when age > maxStoryAge.
+ */
+export function selectStaleByAge(entries: FeatureContextEntry[], maxStoryAge: number): Set<number> {
+  const stale = new Set<number>();
+  const total = entries.length;
+
+  for (const e of entries) {
+    if (!e.establishedIn) continue;
+    const age = total - 1 - e.index;
+    if (age > maxStoryAge) {
+      stale.add(e.index);
+    }
+  }
+
+  return stale;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chunk annotation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Return a new RawChunk with staleCandidate and scoreMultiplier set
+ * when the chunk is stale; otherwise returns the chunk unchanged.
+ * Does not mutate the input chunk.
+ */
+export function applyStaleness(
+  chunk: RawChunk,
+  { isStale, scoreMultiplier }: { isStale: boolean; scoreMultiplier: number },
+): RawChunk {
+  if (!isStale) return chunk;
+  return { ...chunk, staleCandidate: true, scoreMultiplier };
+}

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -108,6 +108,14 @@ export type ChunkRole = "implementer" | "reviewer" | "tdd" | "all";
 // Core data structures
 // ─────────────────────────────────────────────────────────────────────────────
 
+/** Effectiveness signal annotated on a chunk post-story (Amendment A AC-45). */
+export interface ChunkEffectiveness {
+  /** Whether the chunk's advice was followed, contradicted, ignored, or unknown. */
+  signal: "followed" | "contradicted" | "ignored" | "unknown";
+  /** Short evidence string (review finding text, diff excerpt, etc.) */
+  evidence?: string;
+}
+
 /** A single context chunk produced by a provider and packed into the bundle. */
 export interface ContextChunk {
   /** Stable id: `<providerId>:<contentHash8>` */
@@ -130,8 +138,12 @@ export interface ContextChunk {
   score: number;
   /** True when chunk is detected as stale (post-GA: staleness signal) */
   stale?: boolean;
+  /** True when chunk is a stale candidate (Amendment A AC-46) */
+  staleCandidate?: boolean;
   /** Reason recorded in manifest when chunk was floor-included despite budget overflow */
   reason?: string;
+  /** Effectiveness signal annotated post-story (Amendment A AC-45) */
+  effectiveness?: ChunkEffectiveness;
 }
 
 /**
@@ -212,6 +224,24 @@ export interface ContextManifest {
     failureCategory: AdapterFailure["category"];
     failureOutcome: AdapterFailure["outcome"];
   };
+  /**
+   * First 300 chars of each included chunk's content (Amendment A AC-45).
+   * Written at assemble() time; used by annotateManifestEffectiveness() post-story
+   * to compare chunk content against agent output / diff / review findings.
+   * Keyed by chunk ID.
+   */
+  chunkSummaries?: Record<string, string>;
+  /**
+   * IDs of included chunks that had staleCandidate: true (Amendment A AC-46).
+   * Populated by orchestrator at assemble() time when staleness detection fires.
+   */
+  staleChunks?: string[];
+  /**
+   * Per-chunk effectiveness signals written post-story (Amendment A AC-45).
+   * Keyed by chunk ID. Written by annotateManifestEffectiveness() after the
+   * story pipeline completes; absent until then.
+   */
+  chunkEffectiveness?: Record<string, ChunkEffectiveness>;
 }
 
 /**
@@ -422,6 +452,18 @@ export interface RawChunk {
    * Free providers (git, file-scan) omit this field.
    */
   costUsd?: number;
+  /**
+   * True when this chunk is a staleness candidate (Amendment A AC-46).
+   * Set by FeatureContextProviderV2 when an entry is older than maxStoryAge
+   * or contradicted by a newer entry in the same section (AC-47).
+   * The scorer applies scoreMultiplier to downweight stale chunks.
+   */
+  staleCandidate?: boolean;
+  /**
+   * Score multiplier applied by the scorer when staleCandidate is true.
+   * Comes from config.context.v2.staleness.scoreMultiplier (default: 0.4).
+   */
+  scoreMultiplier?: number;
 }
 
 /** What an IContextProvider returns from fetch(). */

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -7,6 +7,7 @@
 import path from "node:path";
 import { resolveModelForAgent } from "../config/schema";
 import { loadContextManifests } from "../context/engine/manifest-store";
+import { computePollutionMetrics } from "../context/engine/pollution";
 import type { PipelineContext } from "../pipeline/types";
 import { loadJsonFile, saveJsonFile } from "../utils/json-file";
 import type { ContextProviderMetrics, RunMetrics, StoryMetrics } from "./types";
@@ -76,7 +77,16 @@ async function deriveContextMetrics(
     }
   }
 
-  return Object.keys(providers).length === 0 ? undefined : { providers };
+  if (Object.keys(providers).length === 0) return undefined;
+
+  const pollution = computePollutionMetrics(stored);
+  const hasPollution =
+    pollution.droppedBelowMinScore > 0 ||
+    pollution.staleChunksInjected > 0 ||
+    pollution.contradictedChunks > 0 ||
+    pollution.ignoredChunks > 0;
+
+  return { providers, ...(hasPollution && { pollution }) };
 }
 
 export async function collectStoryMetrics(ctx: PipelineContext, storyStartTime: string): Promise<StoryMetrics> {

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -119,6 +119,26 @@ export interface StoryMetrics {
    */
   context?: {
     providers: Record<string, ContextProviderMetrics>;
+    /**
+     * Aggregate pollution indicators (Amendment A AC-48).
+     * Populated post-story when effectiveness annotation and staleness detection run.
+     * Absent when no manifests were found or no effectiveness data exists.
+     */
+    pollution?: {
+      /** Chunks dropped by the min-score threshold (noise gate). */
+      droppedBelowMinScore: number;
+      /** Included chunks flagged as staleness candidates (AC-46). */
+      staleChunksInjected: number;
+      /** Chunks whose advice was contradicted by a review finding (AC-45). */
+      contradictedChunks: number;
+      /** Chunks that appear to have been ignored by the agent (AC-45). */
+      ignoredChunks: number;
+      /**
+       * Ratio of polluted context: (contradicted + ignored) / total included.
+       * A value > 0.3 is surfaced as a warning in `nax status`.
+       */
+      pollutionRatio: number;
+    };
   };
   /**
    * Per-reviewer metrics for the review stage.

--- a/src/pipeline/stages/completion.ts
+++ b/src/pipeline/stages/completion.ts
@@ -14,11 +14,13 @@
 
 import { persistSemanticVerdict } from "../../acceptance/semantic-verdict";
 import type { SemanticVerdict } from "../../acceptance/types";
+import { annotateManifestEffectiveness } from "../../context/engine/effectiveness";
 import { appendProgress } from "../../execution/progress";
 import { checkReviewGate, isTriggerEnabled } from "../../interaction/triggers";
 import { getLogger } from "../../logger";
 import { collectBatchMetrics, collectStoryMetrics } from "../../metrics";
 import { countStories, markStoryPassed, savePRD } from "../../prd";
+import { errorMessage } from "../../utils/errors";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
@@ -42,6 +44,25 @@ export const completionStage: PipelineStage = {
       ctx.storyMetrics = collectBatchMetrics(ctx, storyStartTime);
     } else {
       ctx.storyMetrics = [await collectStoryMetrics(ctx, storyStartTime)];
+    }
+
+    // Amendment A AC-45: annotate context manifests with effectiveness signals.
+    // Best-effort — non-fatal if the annotation fails or v2 context was not active.
+    const featureId = ctx.prd?.feature;
+    if (!isBatch && ctx.projectDir && featureId && ctx.config.context?.v2?.enabled) {
+      try {
+        const diffText = await _completionDeps.getDiffText(ctx.workdir, ctx.storyGitRef);
+        await annotateManifestEffectiveness(ctx.projectDir, featureId, ctx.story.id, {
+          agentOutput: ctx.agentResult?.output ?? "",
+          diffText,
+          findingMessages: (ctx.reviewFindings ?? []).map((f) => f.message),
+        });
+      } catch (err) {
+        logger.debug("completion", "Effectiveness annotation failed — non-fatal", {
+          storyId: ctx.story.id,
+          error: errorMessage(err),
+        });
+      }
     }
 
     // Mark all stories in batch as passed
@@ -135,6 +156,19 @@ export const completionStage: PipelineStage = {
   },
 };
 
+/** Get a git diff text between baseRef and HEAD. Best-effort, returns "" on failure. */
+async function getDiffText(workdir: string, baseRef: string | undefined): Promise<string> {
+  if (!baseRef) return "";
+  try {
+    const proc = Bun.spawn(["git", "diff", `${baseRef}..HEAD`], { cwd: workdir, stdout: "pipe", stderr: "pipe" });
+    const output = await new Response(proc.stdout).text();
+    await proc.exited;
+    return output.slice(0, 8000); // cap to avoid bloating effectiveness inputs
+  } catch {
+    return "";
+  }
+}
+
 /**
  * Swappable dependencies for testing (avoids mock.module() which leaks in Bun 1.x).
  */
@@ -142,4 +176,5 @@ export const _completionDeps = {
   checkReviewGate,
   persistSemanticVerdict,
   savePRD,
+  getDiffText,
 };

--- a/test/unit/context/engine/effectiveness.test.ts
+++ b/test/unit/context/engine/effectiveness.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Amendment A AC-45: Effectiveness signal
+ *
+ * Unit tests for effectiveness.ts pure helpers:
+ *   - classifyEffectiveness (per-chunk signal based on diff / output / findings)
+ */
+
+import { describe, expect, test } from "bun:test";
+import { classifyEffectiveness } from "../../../../src/context/engine/effectiveness";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// classifyEffectiveness
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("classifyEffectiveness", () => {
+  test("returns 'contradicted' when review finding message shares >=3 significant terms with chunk", () => {
+    const result = classifyEffectiveness(
+      "Use JWT authentication tokens stored in secure cookies for session management",
+      "",
+      "",
+      ["JWT authentication tokens should not be stored in cookies — use Bearer headers"],
+    );
+    expect(result.signal).toBe("contradicted");
+  });
+
+  test("returns 'followed' when diff shares >=3 significant terms with chunk", () => {
+    const result = classifyEffectiveness(
+      "Use argon2 for password hashing in authentication module",
+      "argon2 password hashing authentication implementation complete",
+      "-old hash\n+argon2 password hashing authentication",
+      [],
+    );
+    expect(result.signal).toBe("followed");
+  });
+
+  test("returns 'ignored' when chunk terms appear in neither diff nor output", () => {
+    const result = classifyEffectiveness(
+      "Cache invalidation should use distributed Redis cluster for session storage invalidation",
+      "Updated the database connection pool settings",
+      "-old setting\n+new setting for connection pool",
+      [],
+    );
+    expect(result.signal).toBe("ignored");
+  });
+
+  test("returns 'unknown' when all inputs are empty", () => {
+    const result = classifyEffectiveness("Some context chunk content here", "", "", []);
+    expect(result.signal).toBe("unknown");
+  });
+
+  test("contradicted takes priority over followed", () => {
+    const result = classifyEffectiveness(
+      "Use JWT authentication tokens for session management validation",
+      "jwt authentication session management",
+      "-old\n+jwt authentication session management",
+      ["JWT authentication tokens are no longer valid for session management validation"],
+    );
+    expect(result.signal).toBe("contradicted");
+  });
+
+  test("returns 'unknown' when chunk summary is too short for meaningful comparison", () => {
+    const result = classifyEffectiveness("ok", "ok", "+ok", ["ok"]);
+    expect(result.signal).toBe("unknown");
+  });
+
+  test("includes evidence string when signal is not unknown", () => {
+    const result = classifyEffectiveness(
+      "Use JWT authentication tokens stored in secure cookies for session management",
+      "",
+      "",
+      ["JWT authentication tokens should not be stored in cookies — use Bearer headers"],
+    );
+    expect(result.evidence).toBeDefined();
+    expect(typeof result.evidence).toBe("string");
+  });
+});

--- a/test/unit/context/engine/pollution.test.ts
+++ b/test/unit/context/engine/pollution.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Amendment A AC-48: Pollution metrics
+ *
+ * Unit tests for pollution.ts:
+ *   - computePollutionMetrics (aggregates counts from stored manifests)
+ */
+
+import { describe, expect, test } from "bun:test";
+import { computePollutionMetrics } from "../../../../src/context/engine/pollution";
+import type { StoredContextManifest } from "../../../../src/context/engine/manifest-store";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeManifest(overrides: Partial<StoredContextManifest["manifest"]> = {}): StoredContextManifest {
+  return {
+    featureId: "feat-001",
+    stage: "context",
+    path: "/project/.nax/features/feat-001/stories/US-001/context-manifest-context.json",
+    manifest: {
+      requestId: "req-1",
+      stage: "context",
+      totalBudgetTokens: 8000,
+      usedTokens: 1000,
+      includedChunks: ["feature-context:abc", "session-scratch:def"],
+      excludedChunks: [],
+      floorItems: ["feature-context:abc"],
+      digestTokens: 50,
+      buildMs: 100,
+      ...overrides,
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computePollutionMetrics
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("computePollutionMetrics", () => {
+  test("returns zero metrics when no manifests provided", () => {
+    const metrics = computePollutionMetrics([]);
+    expect(metrics.droppedBelowMinScore).toBe(0);
+    expect(metrics.staleChunksInjected).toBe(0);
+    expect(metrics.contradictedChunks).toBe(0);
+    expect(metrics.ignoredChunks).toBe(0);
+    expect(metrics.pollutionRatio).toBe(0);
+  });
+
+  test("counts droppedBelowMinScore from excludedChunks", () => {
+    const manifest = makeManifest({
+      excludedChunks: [
+        { id: "chunk-1", reason: "below-min-score" },
+        { id: "chunk-2", reason: "below-min-score" },
+        { id: "chunk-3", reason: "budget" },
+      ],
+    });
+    const metrics = computePollutionMetrics([manifest]);
+    expect(metrics.droppedBelowMinScore).toBe(2);
+  });
+
+  test("counts staleChunksInjected from staleChunks manifest field", () => {
+    const manifest = makeManifest({
+      staleChunks: ["feature-context:abc"],
+    } as Partial<StoredContextManifest["manifest"]>);
+    const metrics = computePollutionMetrics([manifest]);
+    expect(metrics.staleChunksInjected).toBe(1);
+  });
+
+  test("counts contradictedChunks and ignoredChunks from chunkEffectiveness", () => {
+    const manifest = makeManifest({
+      chunkEffectiveness: {
+        "feature-context:abc": { signal: "contradicted", evidence: "review finding contradicted" },
+        "session-scratch:def": { signal: "ignored" },
+        "static-rules:ghi": { signal: "followed" },
+      },
+    } as Partial<StoredContextManifest["manifest"]>);
+    const metrics = computePollutionMetrics([manifest]);
+    expect(metrics.contradictedChunks).toBe(1);
+    expect(metrics.ignoredChunks).toBe(1);
+  });
+
+  test("computes pollutionRatio as (contradicted + ignored) / total included", () => {
+    const manifest = makeManifest({
+      includedChunks: ["a", "b", "c", "d"],
+      chunkEffectiveness: {
+        a: { signal: "contradicted" },
+        b: { signal: "ignored" },
+        c: { signal: "followed" },
+        d: { signal: "unknown" },
+      },
+    } as Partial<StoredContextManifest["manifest"]>);
+    const metrics = computePollutionMetrics([manifest]);
+    // 2 (contradicted+ignored) / 4 included = 0.5
+    expect(metrics.pollutionRatio).toBeCloseTo(0.5, 2);
+  });
+
+  test("aggregates across multiple manifests", () => {
+    const m1 = makeManifest({
+      excludedChunks: [{ id: "x", reason: "below-min-score" }],
+      staleChunks: ["feature-context:abc"],
+    } as Partial<StoredContextManifest["manifest"]>);
+    const m2 = makeManifest({
+      excludedChunks: [{ id: "y", reason: "below-min-score" }],
+      chunkEffectiveness: { "session-scratch:def": { signal: "ignored" } },
+    } as Partial<StoredContextManifest["manifest"]>);
+    const metrics = computePollutionMetrics([m1, m2]);
+    expect(metrics.droppedBelowMinScore).toBe(2);
+    expect(metrics.staleChunksInjected).toBe(1);
+    expect(metrics.ignoredChunks).toBe(1);
+  });
+
+  test("pollutionRatio is 0 when no included chunks", () => {
+    const manifest = makeManifest({ includedChunks: [] });
+    const metrics = computePollutionMetrics([manifest]);
+    expect(metrics.pollutionRatio).toBe(0);
+  });
+});

--- a/test/unit/context/engine/staleness.test.ts
+++ b/test/unit/context/engine/staleness.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Amendment A AC-46/AC-47: Staleness detection
+ *
+ * Unit tests for staleness.ts pure helpers:
+ *   - tokenize (term extraction, stopwords, length filter)
+ *   - parseFeatureContextEntries (section grouping)
+ *   - detectContradictions (AC-47: negation + shared terms)
+ *   - selectStaleByAge (AC-46: age-based staleness)
+ *   - applyStaleness (scoreMultiplier application)
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  applyStaleness,
+  detectContradictions,
+  parseFeatureContextEntries,
+  selectStaleByAge,
+  tokenize,
+} from "../../../../src/context/engine/staleness";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// tokenize
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("tokenize", () => {
+  test("lowercases and splits on whitespace", () => {
+    const tokens = tokenize("Auth Token Validation");
+    expect(tokens).toContain("auth");
+    expect(tokens).toContain("token");
+    expect(tokens).toContain("validation");
+  });
+
+  test("filters stopwords (the, and, use, for)", () => {
+    const tokens = tokenize("use the auth token for validation");
+    expect(tokens).not.toContain("the");
+    expect(tokens).not.toContain("and");
+    expect(tokens).not.toContain("use");
+    expect(tokens).not.toContain("for");
+  });
+
+  test("filters short tokens (len < 4)", () => {
+    const tokens = tokenize("add the db row to log");
+    expect(tokens).not.toContain("db");
+    expect(tokens).not.toContain("to");
+    expect(tokens).not.toContain("row");
+  });
+
+  test("splits on identifier separators (_, -, .)", () => {
+    const tokens = tokenize("auth-token_validation.helper");
+    expect(tokens).toContain("auth");
+    expect(tokens).toContain("token");
+    expect(tokens).toContain("validation");
+    expect(tokens).toContain("helper");
+  });
+
+  test("deduplicates tokens", () => {
+    const tokens = tokenize("authentication authentication auth");
+    const count = tokens.filter((t) => t === "authentication").length;
+    expect(count).toBe(1);
+  });
+
+  test("returns empty array for empty string", () => {
+    expect(tokenize("")).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parseFeatureContextEntries
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("parseFeatureContextEntries", () => {
+  const CONTEXT_MD = `## Authentication
+
+_Established in: US-001_
+Use JWT tokens for authentication. Store in secure httpOnly cookies.
+
+## Authorization
+
+_Established in: US-002_
+Role-based access control. Admin role has full access.
+
+_Established in: US-003_
+Regular users cannot access /admin routes.
+`;
+
+  test("returns one entry per paragraph-level block", () => {
+    const entries = parseFeatureContextEntries(CONTEXT_MD);
+    expect(entries.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("assigns correct section to each entry", () => {
+    const entries = parseFeatureContextEntries(CONTEXT_MD);
+    const authEntries = entries.filter((e) => e.section === "Authentication");
+    expect(authEntries.length).toBeGreaterThanOrEqual(1);
+    const authzEntries = entries.filter((e) => e.section === "Authorization");
+    expect(authzEntries.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("extracts establishing story from _Established in: US-XXX_", () => {
+    const entries = parseFeatureContextEntries(CONTEXT_MD);
+    const us001 = entries.find((e) => e.establishedIn === "US-001");
+    expect(us001).toBeDefined();
+  });
+
+  test("assigns sequential index", () => {
+    const entries = parseFeatureContextEntries(CONTEXT_MD);
+    entries.forEach((e, i) => expect(e.index).toBe(i));
+  });
+
+  test("returns empty array for empty markdown", () => {
+    expect(parseFeatureContextEntries("")).toEqual([]);
+  });
+
+  test("handles markdown with no ## sections", () => {
+    const md = "Some text without sections\nMore text";
+    const entries = parseFeatureContextEntries(md);
+    // May return 0 entries (sections-only parser) or 1 entry in "default" section
+    expect(Array.isArray(entries)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// detectContradictions (AC-47)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("detectContradictions", () => {
+  test("flags older entry when newer uses negation and shares >=3 significant terms", () => {
+    const entries = [
+      {
+        section: "Authentication",
+        index: 0,
+        text: "Use JWT authentication tokens stored in secure httpOnly cookies for session management",
+        establishedIn: "US-001",
+        terms: new Set(["jwt", "authentication", "tokens", "secure", "httpo", "cookies", "session", "management"]),
+      },
+      {
+        section: "Authentication",
+        index: 1,
+        text: "Authentication tokens are no longer stored in cookies. Instead use Bearer headers for JWT authentication session",
+        establishedIn: "US-005",
+        terms: new Set(["authentication", "tokens", "longer", "cookies", "instead", "bearer", "headers", "jwt", "session"]),
+      },
+    ];
+    const stale = detectContradictions(entries);
+    expect(stale.has(0)).toBe(true);
+    expect(stale.has(1)).toBe(false);
+  });
+
+  test("does not flag when shared terms < 3", () => {
+    const entries = [
+      {
+        section: "Auth",
+        index: 0,
+        text: "Use argon2 for password hashing",
+        establishedIn: "US-001",
+        terms: new Set(["argon2", "password", "hashing"]),
+      },
+      {
+        section: "Auth",
+        index: 1,
+        text: "Database schema removed and deprecated entirely",
+        establishedIn: "US-002",
+        terms: new Set(["database", "schema", "removed", "deprecated", "entirely"]),
+      },
+    ];
+    const stale = detectContradictions(entries);
+    expect(stale.size).toBe(0);
+  });
+
+  test("does not flag when newer entry lacks negation language", () => {
+    const entries = [
+      {
+        section: "Auth",
+        index: 0,
+        text: "Use JWT authentication tokens stored in secure cookies for session management",
+        establishedIn: "US-001",
+        terms: new Set(["jwt", "authentication", "tokens", "secure", "cookies", "session", "management"]),
+      },
+      {
+        section: "Auth",
+        index: 1,
+        text: "JWT authentication tokens rotate every 24 hours for improved security management",
+        establishedIn: "US-003",
+        terms: new Set(["jwt", "authentication", "tokens", "rotate", "hours", "security", "management"]),
+      },
+    ];
+    const stale = detectContradictions(entries);
+    expect(stale.size).toBe(0);
+  });
+
+  test("only flags entries within the same section", () => {
+    const entries = [
+      {
+        section: "Authentication",
+        index: 0,
+        text: "Use JWT tokens for authentication session management cookies",
+        establishedIn: "US-001",
+        terms: new Set(["jwt", "tokens", "authentication", "session", "management", "cookies"]),
+      },
+      {
+        section: "Authorization",
+        index: 1,
+        text: "JWT tokens are no longer valid for authentication session management cookies",
+        establishedIn: "US-003",
+        terms: new Set(["jwt", "tokens", "longer", "authentication", "session", "management", "cookies"]),
+      },
+    ];
+    // Different sections — should NOT flag
+    const stale = detectContradictions(entries);
+    expect(stale.size).toBe(0);
+  });
+
+  test("returns empty set for single entry", () => {
+    const entries = [
+      {
+        section: "Auth",
+        index: 0,
+        text: "Some auth text with tokens",
+        establishedIn: "US-001",
+        terms: new Set(["auth", "text", "tokens"]),
+      },
+    ];
+    expect(detectContradictions(entries).size).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// selectStaleByAge (AC-46)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("selectStaleByAge", () => {
+  const makeEntries = (ids: string[]) =>
+    ids.map((id, i) => ({
+      section: "Auth",
+      index: i,
+      text: `Entry from ${id}`,
+      establishedIn: id,
+      terms: new Set<string>(["auth", "entry"]),
+    }));
+
+  test("flags entries more than maxStoryAge positions behind latest", () => {
+    // 15 entries, maxStoryAge=10 → entries 0–4 are stale (at positions < 15-10=5)
+    const entries = makeEntries(["US-001", "US-002", "US-003", "US-004", "US-005", "US-006", "US-007", "US-008", "US-009", "US-010", "US-011", "US-012", "US-013", "US-014", "US-015"]);
+    const stale = selectStaleByAge(entries, 10);
+    // 15 entries total. age = (14 - index). Stale when age > 10.
+    // index 0 → age 14 (stale), index 3 → age 11 (stale), index 4 → age 10 (NOT stale)
+    expect(stale.has(0)).toBe(true);
+    expect(stale.has(3)).toBe(true);
+    expect(stale.has(4)).toBe(false);
+    expect(stale.has(14)).toBe(false);
+  });
+
+  test("no entries stale when count <= maxStoryAge", () => {
+    const entries = makeEntries(["US-001", "US-002", "US-003"]);
+    const stale = selectStaleByAge(entries, 10);
+    expect(stale.size).toBe(0);
+  });
+
+  test("entries without establishedIn are not flagged", () => {
+    const entries = [
+      { section: "Auth", index: 0, text: "Entry without established marker", establishedIn: undefined, terms: new Set<string>(["auth"]) },
+    ];
+    const stale = selectStaleByAge(entries, 0);
+    expect(stale.size).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// applyStaleness
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("applyStaleness", () => {
+  const baseChunk = {
+    id: "feature-context:abc123",
+    providerId: "feature-context",
+    kind: "feature" as const,
+    scope: "feature" as const,
+    role: ["implementer" as const],
+    content: "Some feature context content",
+    tokens: 10,
+    rawScore: 1.0,
+  };
+
+  test("sets staleCandidate and scoreMultiplier when staleness detected", () => {
+    const result = applyStaleness(baseChunk, { isStale: true, scoreMultiplier: 0.4 });
+    expect(result.staleCandidate).toBe(true);
+    expect(result.scoreMultiplier).toBe(0.4);
+  });
+
+  test("does not set staleCandidate when not stale", () => {
+    const result = applyStaleness(baseChunk, { isStale: false, scoreMultiplier: 0.4 });
+    expect(result.staleCandidate).toBeUndefined();
+    expect(result.scoreMultiplier).toBeUndefined();
+  });
+
+  test("does not mutate the original chunk", () => {
+    applyStaleness(baseChunk, { isStale: true, scoreMultiplier: 0.4 });
+    expect((baseChunk as Record<string, unknown>).staleCandidate).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **AC-45**: Post-story effectiveness signal — classifies each kept chunk as `followed`/`contradicted`/`ignored`/`unknown` using term overlap with git diff, agent output, and review findings. Deterministic (no LLM). Written back into stored manifests via read-modify-write in `annotateManifestEffectiveness()`.
- **AC-46/47**: Staleness detection in `FeatureContextProviderV2` — flags age-stale entries (story position > `maxStoryAge`) and contradiction-stale entries (negation terms + ≥3 shared terms with a newer entry). Stale chunks receive `scoreMultiplier` penalty (default 0.4) in the scoring layer.
- **AC-48**: `computePollutionMetrics()` aggregates `droppedBelowMinScore`, `staleChunksInjected`, `contradictedChunks`, `ignoredChunks`, and `pollutionRatio` from stored manifests. Surfaced in `StoryMetrics.context.pollution`. `nax status --cost --last` warns when `pollutionRatio > 0.3`.
- **AC-49**: All classification runs post-story (not on the hot path). Config-gated via `context.v2.staleness.enabled` (default: `true`).

## New Files

| File | Purpose |
|------|---------|
| `src/context/engine/staleness.ts` | Age + contradiction staleness detection |
| `src/context/engine/effectiveness.ts` | Post-story chunk effectiveness classification |
| `src/context/engine/pollution.ts` | Pollution metric aggregation from manifests |
| `test/unit/context/engine/staleness.test.ts` | 23 tests |
| `test/unit/context/engine/effectiveness.test.ts` | 7 tests |
| `test/unit/context/engine/pollution.test.ts` | 7 tests |

## Modified Files

- `src/context/engine/types.ts` — Added `ChunkEffectiveness`, `staleCandidate`, `chunkSummaries`, `staleChunks`, `chunkEffectiveness` to manifest/chunk types
- `src/context/engine/orchestrator.ts` — Stores `chunkSummaries` and `staleChunks` at manifest write time
- `src/context/engine/scoring.ts` — Applies `scoreMultiplier` from stale chunks
- `src/context/engine/providers/feature-context.ts` — Runs staleness detection, annotates chunks
- `src/config/schemas.ts` + `src/config/runtime-types.ts` — Added `staleness` config block
- `src/metrics/types.ts` + `src/metrics/tracker.ts` — Added `pollution` field to `StoryMetrics.context`
- `src/pipeline/stages/completion.ts` — Calls `annotateManifestEffectiveness` post-story (best-effort); fixed `ctx.config.context?.v2?.enabled` optional chaining
- `src/cli/status-cost.ts` — Warns when `pollutionRatio > 0.3`

## Test Plan

- [ ] `bun test test/unit/context/engine/staleness.test.ts` — 23 tests pass
- [ ] `bun test test/unit/context/engine/effectiveness.test.ts` — 7 tests pass
- [ ] `bun test test/unit/context/engine/pollution.test.ts` — 7 tests pass
- [ ] `bun run test` — 1184 pass, 0 fail (full suite)
- [ ] `bun run lint` — clean
- [ ] `bun run typecheck` — clean
- [ ] `bun run build` — clean (3.82 MB bundle, 995 modules)
- [ ] Verify `nax status --cost --last` emits pollution warning when ratio > 0.3
- [ ] Verify staleness detection respects `context.v2.staleness.enabled: false` config flag