### PR TITLE
feat(context-engine): AC-42 cross-agent scratch neutralization

### DIFF
--- a/src/context/engine/providers/session-scratch.ts
+++ b/src/context/engine/providers/session-scratch.ts
@@ -9,6 +9,8 @@
  *
  * Phase 1: reads verify-result and rectify-attempt entries.
  * Phase 2+: additional entry kinds (review findings, tool call results).
+ * AC-42: neutralizes agent-specific tool references when entry.writtenByAgent
+ *        differs from the target agent (request.agentId).
  *
  * See: docs/specs/SPEC-context-engine-v2.md §SessionScratchProvider
  */
@@ -16,6 +18,7 @@
 import { createHash } from "node:crypto";
 import type { ScratchEntry } from "../../../session/scratch-writer";
 import { scratchFilePath } from "../../../session/scratch-writer";
+import { neutralizeForAgent } from "../scratch-neutralizer";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -60,8 +63,14 @@ function parseJsonl(raw: string): ScratchEntry[] {
   return entries;
 }
 
-/** Render a ScratchEntry to human-readable Markdown for the push block */
-function renderEntry(entry: ScratchEntry): string {
+/**
+ * Render a ScratchEntry to human-readable Markdown for the push block.
+ *
+ * When entry.writtenByAgent is set and differs from targetAgentId, free-text
+ * fields (outputTail) are passed through neutralizeForAgent() to strip
+ * agent-specific tool-name references (AC-42).
+ */
+function renderEntry(entry: ScratchEntry, targetAgentId?: string): string {
   switch (entry.kind) {
     case "verify-result": {
       const status = entry.success ? "PASS" : `FAIL (${entry.failCount} failures)`;
@@ -79,7 +88,8 @@ function renderEntry(entry: ScratchEntry): string {
         `**TDD ${entry.role}** at ${entry.timestamp}: ${entry.success ? "succeeded" : "failed"}${changed}`,
       ];
       if (entry.outputTail.trim()) {
-        lines.push("```", entry.outputTail.trim(), "```");
+        const tail = neutralizeForAgent(entry.outputTail.trim(), entry.writtenByAgent ?? "", targetAgentId ?? "");
+        lines.push("```", tail, "```");
       }
       return lines.join("\n");
     }
@@ -92,7 +102,7 @@ function renderEntry(entry: ScratchEntry): string {
  * Read a scratch dir and produce a RawChunk for its most recent entries.
  * Returns null when the dir has no scratch file or the file is empty.
  */
-async function readScratchDir(scratchDir: string): Promise<RawChunk | null> {
+async function readScratchDir(scratchDir: string, targetAgentId?: string): Promise<RawChunk | null> {
   const filePath = scratchFilePath(scratchDir);
   if (!(await _sessionScratchDeps.fileExists(filePath))) return null;
 
@@ -102,7 +112,7 @@ async function readScratchDir(scratchDir: string): Promise<RawChunk | null> {
 
   // Take most recent N entries (tail of the JSONL)
   const entries = allEntries.slice(-MAX_ENTRIES_PER_DIR);
-  const content = entries.map(renderEntry).join("\n\n");
+  const content = entries.map((e) => renderEntry(e, targetAgentId)).join("\n\n");
 
   // Truncate content to the token ceiling so the reported token count
   // matches the actual content length. Without truncation the packing stage
@@ -144,7 +154,7 @@ export class SessionScratchProvider implements IContextProvider {
 
     const chunks: RawChunk[] = [];
     for (const dir of dirs) {
-      const chunk = await readScratchDir(dir);
+      const chunk = await readScratchDir(dir, request.agentId);
       if (chunk) chunks.push(chunk);
     }
 

--- a/src/context/engine/scratch-neutralizer.ts
+++ b/src/context/engine/scratch-neutralizer.ts
@@ -1,0 +1,60 @@
+/**
+ * Context Engine v2 — Cross-Agent Scratch Neutralizer (AC-42)
+ *
+ * Strips or generalizes agent-specific tool-name references from scratch
+ * entry free-text fields when the content was written by one agent and is
+ * being read by a different one.
+ *
+ * Only Claude-originated tool names are substituted today (Claude Code is
+ * the primary writer). Non-claude source agents pass through unchanged.
+ *
+ * Pure function — no I/O. Called from SessionScratchProvider.renderEntry().
+ *
+ * See: docs/specs/SPEC-context-engine-v2.md §AC-42
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Substitution table for Claude Code tool names
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CLAUDE_TOOL_SUBSTITUTIONS: [RegExp, string][] = [
+  [/\bthe\s+Read\s+tool\b/gi, "a file read"],
+  [/\bthe\s+Edit\s+tool\b/gi, "a file edit"],
+  [/\bthe\s+Write\s+tool\b/gi, "a file write"],
+  [/\bthe\s+Bash\s+tool\b/gi, "a shell command"],
+  [/\bthe\s+Grep\s+tool\b/gi, "a code search"],
+  [/\bthe\s+Glob\s+tool\b/gi, "a file search"],
+  [/\bthe\s+Agent\s+tool\b/gi, "a sub-agent"],
+  [/\bthe\s+Task\s+tool\b/gi, "a sub-agent"],
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Neutralize agent-specific tool references in scratch content.
+ *
+ * When sourceAgent === targetAgent (or either is empty), the content is
+ * returned unchanged — same-agent reads never need neutralization.
+ *
+ * When sourceAgent is "claude" and targetAgent differs, Claude Code tool
+ * name patterns (e.g. "the Read tool") are replaced with generic equivalents.
+ *
+ * Non-claude source agents are left unchanged — only Claude's tool names
+ * are known to appear in outputTail content today.
+ *
+ * @param content     - free-text content to neutralize
+ * @param sourceAgent - agent id that originally wrote the content
+ * @param targetAgent - agent id that will read the content
+ */
+export function neutralizeForAgent(content: string, sourceAgent: string, targetAgent: string): string {
+  if (!content || !sourceAgent || !targetAgent || sourceAgent === targetAgent) return content;
+  if (sourceAgent.toLowerCase() !== "claude") return content;
+
+  let result = content;
+  for (const [pattern, replacement] of CLAUDE_TOOL_SUBSTITUTIONS) {
+    result = result.replace(pattern, replacement);
+  }
+  return result;
+}

--- a/src/pipeline/stages/rectify.ts
+++ b/src/pipeline/stages/rectify.ts
@@ -92,6 +92,7 @@ export const rectifyStage: PipelineStage = {
           stage: "rectify",
           attempt: rectifyAttempt,
           succeeded,
+          writtenByAgent: ctx.routing?.agent ?? ctx.config.autoMode.defaultAgent,
         });
       } catch (scratchErr) {
         logger.warn("rectify", "Failed to write scratch entry — continuing", {

--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -202,6 +202,7 @@ export const verifyStage: PipelineStage = {
           passCount: result.passCount ?? 0,
           failCount: result.failCount ?? 0,
           rawOutputTail: (result.output ?? "").slice(-500),
+          writtenByAgent: ctx.routing?.agent ?? ctx.config.autoMode.defaultAgent,
         });
       } catch (scratchErr) {
         logger.warn("verify", "Failed to write scratch entry — continuing", {

--- a/src/session/scratch-writer.ts
+++ b/src/session/scratch-writer.ts
@@ -35,6 +35,8 @@ export interface VerifyScratchEntry {
   failCount: number;
   /** Last 500 chars of raw test output — enough for a rectifier to see what failed */
   rawOutputTail: string;
+  /** Agent id that produced this entry. For cross-agent scratch neutralization (AC-42). */
+  writtenByAgent?: string;
 }
 
 /** Entry written after each rectification attempt */
@@ -45,6 +47,8 @@ export interface RectifyScratchEntry {
   stage: string;
   attempt: number;
   succeeded: boolean;
+  /** Agent id that produced this entry. For cross-agent scratch neutralization (AC-42). */
+  writtenByAgent?: string;
 }
 
 /** Entry written after each TDD sub-session to carry discoveries forward */
@@ -58,6 +62,8 @@ export interface TddSessionScratchEntry {
   filesChanged: string[];
   /** Tail of agent output for lightweight cross-session continuity */
   outputTail: string;
+  /** Agent id that produced this entry. For cross-agent scratch neutralization (AC-42). */
+  writtenByAgent?: string;
 }
 
 export type ScratchEntry = VerifyScratchEntry | RectifyScratchEntry | TddSessionScratchEntry;

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -592,6 +592,7 @@ export async function runThreeSessionTddFromCtx(
           success: result.success,
           filesChanged: result.filesChanged,
           outputTail: result.outputTail ?? "",
+          writtenByAgent: ctx.routing?.agent ?? ctx.config.autoMode.defaultAgent,
         });
 
         const digest = priorDigestByRole.get(result.role);

--- a/test/unit/context/engine/providers/session-scratch.test.ts
+++ b/test/unit/context/engine/providers/session-scratch.test.ts
@@ -192,3 +192,94 @@ describe("SessionScratchProvider", () => {
     expect(result.pullTools).toEqual([]);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-42: cross-agent scratch neutralization
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SessionScratchProvider — AC-42 cross-agent neutralization", () => {
+  const TDD_CLAUDE_ENTRY = JSON.stringify({
+    kind: "tdd-session",
+    timestamp: "2026-01-01T00:02:00.000Z",
+    storyId: "US-001",
+    stage: "tdd-implementer",
+    role: "implementer",
+    success: true,
+    filesChanged: ["src/index.ts"],
+    outputTail: "I used the Read tool to inspect and the Bash tool to run tests.",
+    writtenByAgent: "claude",
+  });
+
+  const TDD_NO_AGENT_ENTRY = JSON.stringify({
+    kind: "tdd-session",
+    timestamp: "2026-01-01T00:02:00.000Z",
+    storyId: "US-001",
+    stage: "tdd-implementer",
+    role: "implementer",
+    success: true,
+    filesChanged: [],
+    outputTail: "I used the Read tool to inspect.",
+  });
+
+  test("neutralizes claude tool references when target agent differs", async () => {
+    mockScratchFile(`${TDD_CLAUDE_ENTRY}\n`);
+    const provider = new SessionScratchProvider();
+    const result = await provider.fetch(makeRequest({ storyScratchDirs: ["/sess/dir"], agentId: "codex" }));
+
+    expect(result.chunks).toHaveLength(1);
+    const content = result.chunks[0].content;
+    expect(content).not.toContain("the Read tool");
+    expect(content).not.toContain("the Bash tool");
+    expect(content).toContain("a file read");
+    expect(content).toContain("a shell command");
+  });
+
+  test("does not neutralize when target agent matches source agent", async () => {
+    mockScratchFile(`${TDD_CLAUDE_ENTRY}\n`);
+    const provider = new SessionScratchProvider();
+    const result = await provider.fetch(makeRequest({ storyScratchDirs: ["/sess/dir"], agentId: "claude" }));
+
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0].content).toContain("the Read tool");
+    expect(result.chunks[0].content).toContain("the Bash tool");
+  });
+
+  test("does not neutralize when no agentId on request", async () => {
+    mockScratchFile(`${TDD_CLAUDE_ENTRY}\n`);
+    const provider = new SessionScratchProvider();
+    const result = await provider.fetch(makeRequest({ storyScratchDirs: ["/sess/dir"] }));
+
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0].content).toContain("the Read tool");
+  });
+
+  test("does not neutralize when entry has no writtenByAgent", async () => {
+    mockScratchFile(`${TDD_NO_AGENT_ENTRY}\n`);
+    const provider = new SessionScratchProvider();
+    const result = await provider.fetch(makeRequest({ storyScratchDirs: ["/sess/dir"], agentId: "codex" }));
+
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0].content).toContain("the Read tool");
+  });
+
+  test("verify-result entries are not neutralized (test runner output, not agent output)", async () => {
+    const entry = JSON.stringify({
+      kind: "verify-result",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      storyId: "US-001",
+      stage: "verify",
+      success: false,
+      status: "FAIL",
+      passCount: 0,
+      failCount: 1,
+      rawOutputTail: "Expected the Read tool to return value.",
+      writtenByAgent: "claude",
+    });
+    mockScratchFile(`${entry}\n`);
+    const provider = new SessionScratchProvider();
+    const result = await provider.fetch(makeRequest({ storyScratchDirs: ["/sess/dir"], agentId: "codex" }));
+
+    // rawOutputTail is test runner output — preserved as-is
+    expect(result.chunks[0].content).toContain("the Read tool");
+  });
+});

--- a/test/unit/context/engine/scratch-neutralizer.test.ts
+++ b/test/unit/context/engine/scratch-neutralizer.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect } from "bun:test";
+import { neutralizeForAgent } from "../../../../src/context/engine/scratch-neutralizer";
+
+describe("neutralizeForAgent", () => {
+  describe("same agent — no-op", () => {
+    test("returns content unchanged when source and target are the same", () => {
+      const content = "I'll use the Read tool to check the file and then the Bash tool to run tests.";
+      expect(neutralizeForAgent(content, "claude", "claude")).toBe(content);
+    });
+
+    test("returns content unchanged when both are empty string", () => {
+      expect(neutralizeForAgent("some content", "", "")).toBe("some content");
+    });
+  });
+
+  describe("claude → other agent neutralization", () => {
+    test("replaces 'the Read tool' with 'a file read'", () => {
+      const result = neutralizeForAgent("I used the Read tool to inspect the file.", "claude", "codex");
+      expect(result).toBe("I used a file read to inspect the file.");
+    });
+
+    test("replaces 'the Edit tool' with 'a file edit'", () => {
+      const result = neutralizeForAgent("Applied the Edit tool to fix the bug.", "claude", "gemini");
+      expect(result).toBe("Applied a file edit to fix the bug.");
+    });
+
+    test("replaces 'the Write tool' with 'a file write'", () => {
+      const result = neutralizeForAgent("Used the Write tool to create the file.", "claude", "codex");
+      expect(result).toBe("Used a file write to create the file.");
+    });
+
+    test("replaces 'the Bash tool' with 'a shell command'", () => {
+      const result = neutralizeForAgent("Ran the Bash tool to execute tests.", "claude", "codex");
+      expect(result).toBe("Ran a shell command to execute tests.");
+    });
+
+    test("replaces 'the Grep tool' with 'a code search'", () => {
+      const result = neutralizeForAgent("Used the Grep tool to find usages.", "claude", "gemini");
+      expect(result).toBe("Used a code search to find usages.");
+    });
+
+    test("replaces 'the Glob tool' with 'a file search'", () => {
+      const result = neutralizeForAgent("Called the Glob tool to list files.", "claude", "codex");
+      expect(result).toBe("Called a file search to list files.");
+    });
+
+    test("replaces 'the Agent tool' with 'a sub-agent'", () => {
+      const result = neutralizeForAgent("Delegated via the Agent tool.", "claude", "codex");
+      expect(result).toBe("Delegated via a sub-agent.");
+    });
+
+    test("replaces 'the Task tool' with 'a sub-agent'", () => {
+      const result = neutralizeForAgent("Launched the Task tool for analysis.", "claude", "gemini");
+      expect(result).toBe("Launched a sub-agent for analysis.");
+    });
+
+    test("handles multiple replacements in one string", () => {
+      const input = "I used the Read tool then the Bash tool to verify.";
+      const result = neutralizeForAgent(input, "claude", "codex");
+      expect(result).toBe("I used a file read then a shell command to verify.");
+    });
+
+    test("replacement is case-insensitive", () => {
+      const result = neutralizeForAgent("used THE READ TOOL here", "claude", "codex");
+      expect(result).toBe("used a file read here");
+    });
+
+    test("does not replace 'Read' when not preceded by 'the '", () => {
+      const result = neutralizeForAgent("Read the file carefully.", "claude", "codex");
+      expect(result).toBe("Read the file carefully.");
+    });
+  });
+
+  describe("non-claude source — no tool substitution", () => {
+    test("returns content unchanged when source is not claude", () => {
+      const content = "Used the Read tool to inspect.";
+      expect(neutralizeForAgent(content, "codex", "gemini")).toBe(content);
+    });
+
+    test("returns content unchanged when source is empty", () => {
+      const content = "Used the Bash tool here.";
+      expect(neutralizeForAgent(content, "", "claude")).toBe(content);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("returns empty string unchanged", () => {
+      expect(neutralizeForAgent("", "claude", "codex")).toBe("");
+    });
+
+    test("handles string with no tool references cleanly", () => {
+      const content = "Tests passed. All files modified correctly.";
+      expect(neutralizeForAgent(content, "claude", "codex")).toBe(content);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **AC-42**: Scratch entries tagged `writtenByAgent` are neutralized in rendering when read for a different target agent — Claude Code tool-name references (`the Read tool`, `the Bash tool`, `the Grep tool`, etc.) in `TddSessionScratchEntry.outputTail` are replaced with agent-agnostic equivalents so agent-specific phrasing does not confuse a different target agent after an agent-swap (Phase 5.5 / #474).

## Changes

| File | Change |
|------|--------|
| `src/session/scratch-writer.ts` | Added `writtenByAgent?: string` to all three `ScratchEntry` interfaces |
| `src/context/engine/scratch-neutralizer.ts` *(new)* | Pure `neutralizeForAgent(content, sourceAgent, targetAgent)` — 8 Claude Code tool-name substitutions; no-op for same-agent reads or non-claude source |
| `src/context/engine/providers/session-scratch.ts` | Threads `request.agentId` into `renderEntry()`; applies neutralization to `outputTail` when `writtenByAgent !== targetAgentId`; `rawOutputTail` (test runner output) intentionally excluded |
| `src/pipeline/stages/verify.ts` | Populates `writtenByAgent` on each scratch append |
| `src/pipeline/stages/rectify.ts` | Populates `writtenByAgent` on each scratch append |
| `src/tdd/orchestrator.ts` | Populates `writtenByAgent` on each scratch append |

## Design Notes

- Only Claude-originated tool names are substituted today — Claude Code is the primary scratch writer; other agent sources pass through unchanged
- `verify-result.rawOutputTail` is test runner output (not agent output) — excluded from neutralization by design
- Pure function with no I/O; no performance impact on hot path

## Test Plan

- [ ] `bun test test/unit/context/engine/scratch-neutralizer.test.ts` — 17 tests pass
- [ ] `bun test test/unit/context/engine/providers/session-scratch.test.ts` — 17 pass (12 existing + 5 new AC-42 tests)
- [ ] `bun run test` — 1223 tests, 0 fail
- [ ] `bun run lint` — clean
- [ ] `bun run typecheck` — clean
- [ ] `bun run build` — clean (3.82 MB, 996 modules)