### PR TITLE
fix(security): prevent path traversal via PRD contextFiles (#503)

### DIFF
--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -24,6 +24,7 @@
 import { createHash } from "node:crypto";
 import { join, relative, resolve } from "node:path";
 import { discoverWorkspacePackages } from "../../../test-runners/detect/workspace";
+import { isRelativeAndSafe } from "../../../utils/path-security";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -286,7 +287,7 @@ export class CodeNeighborProvider implements IContextProvider {
       return { chunks: [], pullTools: [] };
     }
 
-    const filesToProcess = touchedFiles.slice(0, MAX_FILES);
+    const filesToProcess = touchedFiles.filter(isRelativeAndSafe).slice(0, MAX_FILES);
 
     const sections: string[] = [];
     for (const file of filesToProcess) {

--- a/src/context/engine/providers/git-history.ts
+++ b/src/context/engine/providers/git-history.ts
@@ -15,6 +15,7 @@
 
 import { createHash } from "node:crypto";
 import { gitWithTimeout } from "../../../utils/git";
+import { isRelativeAndSafe } from "../../../utils/path-security";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -102,7 +103,7 @@ export class GitHistoryProvider implements IContextProvider {
       return { chunks: [], pullTools: [] };
     }
 
-    const filesToProcess = touchedFiles.slice(0, MAX_FILES);
+    const filesToProcess = touchedFiles.filter(isRelativeAndSafe).slice(0, MAX_FILES);
 
     const sections: string[] = [];
     for (const file of filesToProcess) {

--- a/src/prd/schema.ts
+++ b/src/prd/schema.ts
@@ -199,9 +199,19 @@ function validateStory(raw: unknown, index: number, allIds: Set<string>): UserSt
 
   // contextFiles — optional array of relative file paths from LLM analysis
   const rawContextFiles = s.contextFiles;
-  const contextFiles: string[] = Array.isArray(rawContextFiles)
-    ? (rawContextFiles as unknown[]).filter((f): f is string => typeof f === "string" && f.trim() !== "")
-    : [];
+  const contextFiles: string[] = [];
+  if (Array.isArray(rawContextFiles)) {
+    for (const f of rawContextFiles as unknown[]) {
+      if (typeof f !== "string" || f.trim() === "") continue;
+      if (f.startsWith("/")) {
+        throw new Error(`[schema] story[${index}].contextFiles entry must be relative (no absolute paths): "${f}"`);
+      }
+      if (f.includes("..")) {
+        throw new Error(`[schema] story[${index}].contextFiles entry must not contain '..': "${f}"`);
+      }
+      contextFiles.push(f);
+    }
+  }
 
   return {
     id,

--- a/src/utils/path-security.ts
+++ b/src/utils/path-security.ts
@@ -41,6 +41,18 @@ function safeRealpathForComparison(p: string): string {
   }
 }
 
+/**
+ * Returns true when filePath is safe to use as a relative file path — i.e. it
+ * contains no `..` segments and is not an absolute path.  Used by context-engine
+ * providers to gate user-supplied paths before any filesystem or git call.
+ */
+export function isRelativeAndSafe(filePath: string): boolean {
+  if (!filePath) return false;
+  if (isAbsolute(filePath)) return false;
+  if (filePath.includes("..")) return false;
+  return true;
+}
+
 export function validateModulePath(modulePath: string, allowedRoots: string[]): PathValidationResult {
   if (!modulePath) {
     return { valid: false, error: "Module path is empty" };

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -348,3 +348,53 @@ describe("CodeNeighborProvider — AC-56/AC-62 neighborScope + crossPackageDepth
     expect(cwds.filter((c) => c === "/repo")).toHaveLength(1);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SEC-503: path traversal prevention
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("CodeNeighborProvider — SEC-503 path traversal prevention", () => {
+  test("drops touchedFiles with '..' traversal — never reads them", async () => {
+    const readPaths: string[] = [];
+    _codeNeighborDeps.fileExists = async (p: string) => {
+      readPaths.push(p);
+      return false;
+    };
+    _codeNeighborDeps.glob = () => [];
+
+    const p = new CodeNeighborProvider();
+    await p.fetch(makeRequest({ touchedFiles: ["../../../etc/passwd", "src/valid.ts"] }));
+
+    expect(readPaths.some((p) => p.includes("etc/passwd"))).toBe(false);
+  });
+
+  test("drops touchedFiles with absolute paths — never reads them", async () => {
+    const readPaths: string[] = [];
+    _codeNeighborDeps.fileExists = async (p: string) => {
+      readPaths.push(p);
+      return false;
+    };
+    _codeNeighborDeps.glob = () => [];
+
+    const p = new CodeNeighborProvider();
+    await p.fetch(makeRequest({ touchedFiles: ["/etc/passwd", "src/valid.ts"] }));
+
+    expect(readPaths.some((rp) => rp.includes("etc/passwd"))).toBe(false);
+  });
+
+  test("still processes safe files when unsafe ones are present", async () => {
+    const readPaths: string[] = [];
+    _codeNeighborDeps.fileExists = async (p: string) => {
+      readPaths.push(p);
+      return true;
+    };
+    _codeNeighborDeps.readFile = async () => "";
+    _codeNeighborDeps.glob = () => [];
+
+    const p = new CodeNeighborProvider();
+    await p.fetch(makeRequest({ touchedFiles: ["../evil", "src/valid.ts"] }));
+
+    expect(readPaths.some((rp) => rp.includes("valid.ts"))).toBe(true);
+    expect(readPaths.some((rp) => rp.includes("evil"))).toBe(false);
+  });
+});

--- a/test/unit/context/engine/providers/git-history.test.ts
+++ b/test/unit/context/engine/providers/git-history.test.ts
@@ -240,3 +240,51 @@ describe("GitHistoryProvider — AC-55 historyScope", () => {
     expect(result.chunks[0]?.content).toContain("src/service.ts");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SEC-503: path traversal prevention
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("GitHistoryProvider — SEC-503 path traversal prevention", () => {
+  test("drops touchedFiles with '..' traversal — never calls git for them", async () => {
+    const queriedFiles: string[] = [];
+    _gitHistoryDeps.gitWithTimeout = async (args: string[]) => {
+      queriedFiles.push(args[args.length - 1] ?? "");
+      return { stdout: "abc1234 feat: something", exitCode: 0 };
+    };
+
+    const p = new GitHistoryProvider();
+    await p.fetch(makeRequest({ touchedFiles: ["../../../etc/passwd", "src/service.ts"] }));
+
+    expect(queriedFiles.some((f) => f.includes("etc/passwd"))).toBe(false);
+    expect(queriedFiles).toContain("src/service.ts");
+  });
+
+  test("drops absolute path touchedFiles — never calls git for them", async () => {
+    const queriedFiles: string[] = [];
+    _gitHistoryDeps.gitWithTimeout = async (args: string[]) => {
+      queriedFiles.push(args[args.length - 1] ?? "");
+      return { stdout: "abc1234 feat: something", exitCode: 0 };
+    };
+
+    const p = new GitHistoryProvider();
+    await p.fetch(makeRequest({ touchedFiles: ["/etc/passwd", "src/service.ts"] }));
+
+    expect(queriedFiles.some((f) => f.includes("etc/passwd"))).toBe(false);
+    expect(queriedFiles).toContain("src/service.ts");
+  });
+
+  test("returns empty when all touchedFiles are unsafe", async () => {
+    let gitCalled = false;
+    _gitHistoryDeps.gitWithTimeout = async () => {
+      gitCalled = true;
+      return { stdout: "", exitCode: 0 };
+    };
+
+    const p = new GitHistoryProvider();
+    const result = await p.fetch(makeRequest({ touchedFiles: ["../evil", "/absolute/path"] }));
+
+    expect(gitCalled).toBe(false);
+    expect(result.chunks).toHaveLength(0);
+  });
+});

--- a/test/unit/prd/schema.test.ts
+++ b/test/unit/prd/schema.test.ts
@@ -492,6 +492,45 @@ describe("validatePlanOutput — ENH-006 analysis and contextFiles", () => {
 });
 
 // ---------------------------------------------------------------------------
+// SEC-503: contextFiles path traversal prevention
+// ---------------------------------------------------------------------------
+
+describe("validatePlanOutput — SEC-503 contextFiles path security", () => {
+  test("throws when a contextFiles entry contains '..'", () => {
+    const story = makeStory({ contextFiles: ["../../../etc/passwd"] });
+    expect(() => validatePlanOutput(makeInput([story]), "feat", "feat/feat")).toThrow(
+      /contextFiles.*\.\./i,
+    );
+  });
+
+  test("throws when a contextFiles entry is an absolute path", () => {
+    const story = makeStory({ contextFiles: ["/etc/passwd"] });
+    expect(() => validatePlanOutput(makeInput([story]), "feat", "feat/feat")).toThrow(
+      /contextFiles.*absolute/i,
+    );
+  });
+
+  test("throws on subtle traversal: foo/../../../etc/passwd", () => {
+    const story = makeStory({ contextFiles: ["foo/../../../etc/passwd"] });
+    expect(() => validatePlanOutput(makeInput([story]), "feat", "feat/feat")).toThrow(
+      /contextFiles.*\.\./i,
+    );
+  });
+
+  test("accepts valid relative contextFiles paths", () => {
+    const story = makeStory({ contextFiles: ["src/auth.ts", "test/auth.test.ts"] });
+    const prd = validatePlanOutput(makeInput([story]), "feat", "feat/feat");
+    expect(prd.userStories[0].contextFiles).toEqual(["src/auth.ts", "test/auth.test.ts"]);
+  });
+
+  test("accepts nested relative paths without traversal", () => {
+    const story = makeStory({ contextFiles: ["packages/api/src/index.ts"] });
+    const prd = validatePlanOutput(makeInput([story]), "feat", "feat/feat");
+    expect(prd.userStories[0].contextFiles).toEqual(["packages/api/src/index.ts"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // suggestedCriteria validation
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #503.

Fixes a path-traversal vulnerability where an LLM-generated PRD with `contextFiles: ["../../../etc/passwd"]` could cause `CodeNeighborProvider` and `GitHistoryProvider` to read arbitrary files on the host and echo fragments into the context manifest.

- **`src/utils/path-security.ts`** — adds `isRelativeAndSafe(filePath)`: returns `false` for any path that is absolute or contains `..`
- **`src/prd/schema.ts`** — each `contextFiles` entry is now validated (throw on `..` or absolute), matching the guard already on `story.workdir`
- **`src/context/engine/providers/code-neighbor.ts`** — filters `touchedFiles` through `isRelativeAndSafe` before any `Bun.file` call
- **`src/context/engine/providers/git-history.ts`** — same filter before any `git log` call

Defence-in-depth: schema throws at the boundary; providers silently drop any paths that somehow bypass schema.

## Test plan

- [ ] `bun test test/unit/prd/schema.test.ts` — 5 new SEC-503 cases: `..` throws, absolute throws, subtle traversal throws, valid paths accepted
- [ ] `bun test test/unit/context/engine/providers/code-neighbor.test.ts` — 3 new cases: `..` never read, absolute never read, safe files still processed
- [ ] `bun test test/unit/context/engine/providers/git-history.test.ts` — 3 new cases: `..` never queried, absolute never queried, all-unsafe returns empty
- [ ] `bun run test:bail` — full suite 1223 tests, 0 fail
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean