### PR TITLE
fix(context-engine): propagate deterministic + planDigestBoost through stage-assembler (#504)

### DIFF
--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -41,6 +41,7 @@ export const _stageAssemblerDeps = {
     return f.json();
   },
   now: (): number => Date.now(),
+  createOrchestrator: createDefaultOrchestrator,
 };
 
 export interface StageAssembleOptions {
@@ -151,7 +152,12 @@ export async function assembleForStage(
       pluginConfigs.length > 0 ? await loadPluginProviders(pluginConfigs, ctx.projectDir ?? ctx.workdir) : [];
     const storyScratchDirs = await getStoryScratchDirs(ctx, options);
 
-    const orchestrator = createDefaultOrchestrator(ctx.story, ctx.config, storyScratchDirs, pluginProviders);
+    const orchestrator = _stageAssemblerDeps.createOrchestrator(
+      ctx.story,
+      ctx.config,
+      storyScratchDirs,
+      pluginProviders,
+    );
 
     // AC-54: resolve dual workdir fields. repoRoot is the project root (where .nax/ lives);
     // packageDir is the story's package directory (equals repoRoot for non-monorepo).
@@ -181,6 +187,11 @@ export async function assembleForStage(
       sessionId: ctx.sessionId,
       agentId:
         ctx.routing.agent ?? ctx.rootConfig?.autoMode?.defaultAgent ?? ctx.config.autoMode?.defaultAgent ?? "claude",
+      // AC-24: propagate determinism flag to every assembled stage, not just the context stage.
+      deterministic: ctx.config.context.v2.deterministic,
+      // AC-51: propagate planDigestBoost from the routing test strategy so the boost applies
+      // in every stage that assembleForStage() serves (execution, rectify, tdd-*, review-*, etc.).
+      planDigestBoost: getStageContextConfig(ctx.routing?.testStrategy ?? "").planDigestBoost,
     };
 
     const bundle = await orchestrator.assemble(request);

--- a/test/unit/context/engine/stage-assembler.test.ts
+++ b/test/unit/context/engine/stage-assembler.test.ts
@@ -1,6 +1,7 @@
 /**
  * Unit tests for src/context/engine/stage-assembler.ts — disk-backed session
- * scratch discovery (Finding 2 from the Context Engine v2 architecture review).
+ * scratch discovery (Finding 2 from the Context Engine v2 architecture review)
+ * and AC-24/AC-51 ContextRequest propagation (#504).
  *
  * Tests call `discoverSessionScratchDirsOnDisk` directly so the return value
  * is observable. The helper is exported from stage-assembler for this purpose.
@@ -9,8 +10,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   _stageAssemblerDeps,
+  assembleForStage,
   discoverSessionScratchDirsOnDisk,
 } from "../../../../src/context/engine/stage-assembler";
+import type { ContextBundle, ContextRequest } from "../../../../src/context/engine/types";
+import type { PipelineContext } from "../../../../src/pipeline/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -182,5 +186,129 @@ describe("discoverSessionScratchDirsOnDisk — Finding 2", () => {
 
     const result = await discoverSessionScratchDirsOnDisk(PROJECT_DIR, FEATURE, STORY, TTL_4H);
     expect(result).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-24 / AC-51 — deterministic + planDigestBoost propagation (#504)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Minimal PipelineContext for assembleForStage tests */
+function makeCtx(overrides: {
+  deterministic?: boolean;
+  testStrategy?: string;
+} = {}): PipelineContext {
+  return {
+    config: {
+      context: {
+        v2: {
+          enabled: true,
+          pluginProviders: [],
+          deterministic: overrides.deterministic,
+        },
+      },
+      autoMode: { defaultAgent: "claude" },
+    },
+    rootConfig: { autoMode: { defaultAgent: "claude" } },
+    prd: { feature: "test-feature", userStories: [] },
+    story: { id: "US-001" },
+    stories: [],
+    routing: { agent: undefined, testStrategy: overrides.testStrategy },
+    projectDir: undefined, // prevents manifest writing in tests
+    workdir: "/repo",
+    hooks: {},
+  } as unknown as PipelineContext;
+}
+
+/** Mock orchestrator that captures the last assemble() request via a mutable ref. */
+function makeMockOrchestrator() {
+  const ref: { captured: ContextRequest | null } = { captured: null };
+  const orchestrator = {
+    assemble: async (r: ContextRequest): Promise<ContextBundle> => {
+      ref.captured = r;
+      return {
+        pushMarkdown: "",
+        digest: "abc",
+        manifest: {
+          requestId: "req-1",
+          stage: "execution",
+          totalBudgetTokens: 0,
+          usedTokens: 0,
+          includedChunks: [],
+          excludedChunks: [],
+          floorItems: [],
+          digestTokens: 0,
+          buildMs: 0,
+        },
+        packedChunks: [],
+      } as unknown as ContextBundle;
+    },
+  };
+  return { ref, orchestrator };
+}
+
+describe("assembleForStage — AC-24/AC-51 ContextRequest propagation", () => {
+  let origReaddir: typeof _stageAssemblerDeps.readdir;
+  let origReadDescriptor: typeof _stageAssemblerDeps.readDescriptor;
+  let origCreateOrchestrator: typeof _stageAssemblerDeps.createOrchestrator;
+
+  beforeEach(() => {
+    origReaddir = _stageAssemblerDeps.readdir;
+    origReadDescriptor = _stageAssemblerDeps.readDescriptor;
+    origCreateOrchestrator = _stageAssemblerDeps.createOrchestrator;
+    // Suppress disk discovery
+    _stageAssemblerDeps.readdir = async () => { throw new Error("ENOENT"); };
+    _stageAssemblerDeps.readDescriptor = async () => null;
+  });
+
+  afterEach(() => {
+    _stageAssemblerDeps.readdir = origReaddir;
+    _stageAssemblerDeps.readDescriptor = origReadDescriptor;
+    _stageAssemblerDeps.createOrchestrator = origCreateOrchestrator;
+  });
+
+  test("AC-24: passes deterministic:true when config flag is set", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    await assembleForStage(makeCtx({ deterministic: true }), "execution");
+
+    expect(mock.ref.captured?.deterministic).toBe(true);
+  });
+
+  test("AC-24: passes deterministic:false when config flag is unset", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    await assembleForStage(makeCtx({ deterministic: false }), "execution");
+
+    expect(mock.ref.captured?.deterministic).toBe(false);
+  });
+
+  test("AC-51: passes planDigestBoost from routing testStrategy (tdd-simple → 1.5)", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    await assembleForStage(makeCtx({ testStrategy: "tdd-simple" }), "execution");
+
+    expect(mock.ref.captured?.planDigestBoost).toBe(1.5);
+  });
+
+  test("AC-51: planDigestBoost is undefined for three-session-tdd (uses multi-session digest)", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    await assembleForStage(makeCtx({ testStrategy: "three-session-tdd" }), "tdd-implementer");
+
+    expect(mock.ref.captured?.planDigestBoost).toBeUndefined();
+  });
+
+  test("AC-51: planDigestBoost 1.5 for no-test strategy", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    await assembleForStage(makeCtx({ testStrategy: "no-test" }), "execution");
+
+    expect(mock.ref.captured?.planDigestBoost).toBe(1.5);
   });
 });


### PR DESCRIPTION
## Summary

Closes #504.

AC-24 (determinism) and AC-51 (planDigestBoost) only engaged for the initial `context` stage. `stage-assembler.ts` — used by `execution`, `tdd-test-writer`, `tdd-implementer`, `verify`, `rectify`, `review-*`, `acceptance` — built the `ContextRequest` without these two fields.

**Changes:**
- `src/context/engine/stage-assembler.ts` — adds `createOrchestrator` to `_stageAssemblerDeps` (testability via `_deps` pattern, no `mock.module()`), sets `deterministic` from `ctx.config.context.v2.deterministic`, sets `planDigestBoost` from `getStageContextConfig(ctx.routing?.testStrategy)` so strategies like `tdd-simple` / `no-test` / `batch` get their 1.5× boost across every assembled stage.

## Test plan

- [ ] 5 new tests in `stage-assembler.test.ts`: `deterministic:true`, `deterministic:false`, `tdd-simple → 1.5`, `three-session-tdd → undefined`, `no-test → 1.5`
- [ ] `bun run test:bail` — full suite 1223 tests, 0 fail
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean