### PR TITLE
feat(context-engine): AC-41 fallback observability — record agent-swap hops in StoryMetrics (closes #505)

### DIFF
--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -169,6 +169,7 @@ export async function collectStoryMetrics(ctx: PipelineContext, storyStartTime: 
       scopeTestFallback: ctx.verifyResult.scopeTestFallback,
     }),
     ...(contextMetrics !== undefined && { context: contextMetrics }),
+    ...(ctx.agentFallbacks?.length && { fallback: { hops: ctx.agentFallbacks } }),
   };
 }
 

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -70,6 +70,22 @@ export interface ContextProviderMetrics {
 }
 
 /**
+ * A single agent-swap hop recorded by the execution stage (AC-41).
+ * Collected into ctx.agentFallbacks and surfaced in StoryMetrics.fallback.hops.
+ */
+export interface AgentFallbackHop {
+  storyId: string;
+  priorAgent: string;
+  newAgent: string;
+  /** adapterFailure.outcome — machine-readable failure code */
+  outcome: string;
+  /** adapterFailure.category — "availability" | "quality" */
+  category: string;
+  /** 1-indexed hop counter within this story's pipeline run */
+  hop: number;
+}
+
+/**
  * Per-story execution metrics
  */
 export interface StoryMetrics {
@@ -139,6 +155,13 @@ export interface StoryMetrics {
        */
       pollutionRatio: number;
     };
+  };
+  /**
+   * Agent-swap (fallback) hops recorded during execution (AC-41).
+   * Absent when no swaps occurred.
+   */
+  fallback?: {
+    hops: AgentFallbackHop[];
   };
   /**
    * Per-reviewer metrics for the review stage.

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -267,7 +267,19 @@ export const executionStage: PipelineStage = {
             adapterFailure,
             ctx.story.id,
           );
-          ctx.agentSwapCount = (ctx.agentSwapCount ?? 0) + 1;
+          const hopNumber = (ctx.agentSwapCount ?? 0) + 1;
+          ctx.agentSwapCount = hopNumber;
+          ctx.agentFallbacks = [
+            ...(ctx.agentFallbacks ?? []),
+            {
+              storyId: ctx.story.id,
+              priorAgent: currentAgentId,
+              newAgent: swapTarget,
+              outcome: adapterFailure.outcome,
+              category: adapterFailure.category,
+              hop: hopNumber,
+            },
+          ];
           logger.info("execution", "Agent-swap triggered", {
             storyId: ctx.story.id,
             fromAgent: currentAgentId,

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -187,6 +187,12 @@ export interface PipelineContext {
    */
   agentSwapCount?: number;
   /**
+   * Ordered log of agent-swap hops for this story (AC-41).
+   * Each entry captures the agents involved, the failure that triggered the swap,
+   * and the 1-indexed hop number. Surfaced in StoryMetrics.fallback.hops.
+   */
+  agentFallbacks?: import("../metrics/types").AgentFallbackHop[];
+  /**
    * Set of review check names that already passed in a previous review pass within this
    * pipeline run. When autofix retries from "review", checks in this set are skipped to
    * avoid redundant re-runs (e.g. a 45s semantic check after a lint-only fix). (#136)

--- a/test/unit/metrics/tracker.test.ts
+++ b/test/unit/metrics/tracker.test.ts
@@ -358,3 +358,59 @@ describe("collectStoryMetrics - scopeTestFallback field (US-002)", () => {
     expect(metrics.scopeTestFallback).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// AC-41: collectStoryMetrics maps ctx.agentFallbacks to StoryMetrics.fallback
+// ---------------------------------------------------------------------------
+
+describe("collectStoryMetrics - AC-41 fallback.hops field", () => {
+  test("includes fallback.hops when ctx.agentFallbacks is non-empty", async () => {
+    const story = makeStory();
+    const ctx = makeCtx(story);
+    ctx.agentFallbacks = [
+      { storyId: "US-001", priorAgent: "claude", newAgent: "codex", outcome: "fail-quota", category: "availability", hop: 1 },
+    ];
+
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+
+    expect(metrics.fallback).toBeDefined();
+    expect(metrics.fallback!.hops).toHaveLength(1);
+    expect(metrics.fallback!.hops[0].priorAgent).toBe("claude");
+    expect(metrics.fallback!.hops[0].newAgent).toBe("codex");
+    expect(metrics.fallback!.hops[0].hop).toBe(1);
+  });
+
+  test("fallback is absent when ctx.agentFallbacks is empty", async () => {
+    const story = makeStory();
+    const ctx = makeCtx(story);
+    ctx.agentFallbacks = [];
+
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+
+    expect(metrics.fallback).toBeUndefined();
+  });
+
+  test("fallback is absent when ctx.agentFallbacks is undefined", async () => {
+    const story = makeStory();
+    const ctx = makeCtx(story);
+
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+
+    expect(metrics.fallback).toBeUndefined();
+  });
+
+  test("fallback.hops preserves all hop fields", async () => {
+    const story = makeStory();
+    const ctx = makeCtx(story);
+    ctx.agentFallbacks = [
+      { storyId: "US-001", priorAgent: "claude", newAgent: "codex", outcome: "fail-service-down", category: "availability", hop: 1 },
+      { storyId: "US-001", priorAgent: "codex", newAgent: "opencode", outcome: "fail-rate-limit", category: "availability", hop: 2 },
+    ];
+
+    const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+
+    expect(metrics.fallback!.hops).toHaveLength(2);
+    expect(metrics.fallback!.hops[1].hop).toBe(2);
+    expect(metrics.fallback!.hops[1].category).toBe("availability");
+  });
+});

--- a/test/unit/pipeline/stages/execution-agent-swap-metrics.test.ts
+++ b/test/unit/pipeline/stages/execution-agent-swap-metrics.test.ts
@@ -1,0 +1,262 @@
+/**
+ * AC-41 — fallback observability: execution stage records AgentFallbackHop
+ * in ctx.agentFallbacks whenever an agent-swap is triggered.
+ *
+ * Each hop captures storyId, priorAgent, newAgent, category, outcome, and the
+ * 1-indexed hop number so downstream collectors (tracker.ts) can surface the
+ * data without re-reading ctx.agentSwapCount.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { _executionDeps, executionStage } from "../../../../src/pipeline/stages/execution";
+import type { PipelineContext } from "../../../../src/pipeline/types";
+import type { NaxConfig } from "../../../../src/config";
+import type { PRD, UserStory } from "../../../../src/prd";
+import type { ContextBundle } from "../../../../src/context/engine/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeStory(overrides: Partial<UserStory> = {}): UserStory {
+  return {
+    id: "US-001",
+    title: "Test story",
+    description: "desc",
+    acceptanceCriteria: [],
+    tags: [],
+    dependencies: [],
+    status: "in-progress",
+    passes: false,
+    attempts: 1,
+    escalations: [],
+    ...overrides,
+  };
+}
+
+function makeConfig(): NaxConfig {
+  return {
+    autoMode: { defaultAgent: "claude" },
+    execution: { sessionTimeoutSeconds: 30, verificationTimeoutSeconds: 60 },
+    models: {
+      claude: { fast: "claude-haiku", balanced: "claude-sonnet", powerful: "claude-opus" },
+      codex: { fast: "codex-mini", balanced: "codex-full", powerful: "codex-full" },
+    },
+    quality: { requireTests: false, commands: { test: "bun test" } },
+    agent: {},
+    context: {
+      v2: {
+        enabled: true,
+        fallback: {
+          enabled: true,
+          maxHopsPerStory: 2,
+          map: { claude: ["codex"] },
+          onQualityFailure: false,
+        },
+      },
+    },
+  } as unknown as NaxConfig;
+}
+
+function makeBundle(): ContextBundle {
+  return {
+    pushMarkdown: "context",
+    digest: "abc123",
+    packedChunks: [],
+    pullTools: [],
+    manifest: {
+      requestId: "r1",
+      stage: "execution",
+      totalBudgetTokens: 0,
+      usedTokens: 0,
+      includedChunks: [],
+      excludedChunks: [],
+      floorItems: [],
+      digestTokens: 0,
+      buildMs: 0,
+    },
+  } as unknown as ContextBundle;
+}
+
+function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  const story = makeStory();
+  const config = makeConfig();
+  return {
+    config,
+    rootConfig: config,
+    prd: { project: "p", feature: "f", branchName: "b", createdAt: "", updatedAt: "", userStories: [story] } as PRD,
+    story,
+    stories: [story],
+    routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
+    workdir: "/repo",
+    hooks: {},
+    prompt: "Do the thing",
+    contextBundle: makeBundle(),
+    ...overrides,
+  } as unknown as PipelineContext;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Saved deps for restoration
+// ─────────────────────────────────────────────────────────────────────────────
+
+const origGetAgent = _executionDeps.getAgent;
+const origValidate = _executionDeps.validateAgentForTier;
+const origDetect = _executionDeps.detectMergeConflict;
+const origShouldSwap = _executionDeps.shouldAttemptSwap;
+const origResolveSwap = _executionDeps.resolveSwapTarget;
+const origRebuild = _executionDeps.rebuildForSwap;
+
+afterEach(() => {
+  _executionDeps.getAgent = origGetAgent;
+  _executionDeps.validateAgentForTier = origValidate;
+  _executionDeps.detectMergeConflict = origDetect;
+  _executionDeps.shouldAttemptSwap = origShouldSwap;
+  _executionDeps.resolveSwapTarget = origResolveSwap;
+  _executionDeps.rebuildForSwap = origRebuild;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC-41: execution stage records AgentFallbackHop
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("execution stage — AC-41 fallback observability", () => {
+  test("records hop in ctx.agentFallbacks when swap succeeds", async () => {
+    _executionDeps.validateAgentForTier = () => true;
+    _executionDeps.detectMergeConflict = () => false;
+    _executionDeps.shouldAttemptSwap = () => true;
+    _executionDeps.resolveSwapTarget = () => "codex";
+    _executionDeps.rebuildForSwap = () => makeBundle();
+
+    _executionDeps.getAgent = (agentId: string) =>
+      ({
+        name: agentId,
+        capabilities: { supportedTiers: ["fast"] },
+        run: async () => {
+          if (agentId === "claude") {
+            return {
+              success: false,
+              exitCode: 1,
+              output: "",
+              rateLimited: false,
+              durationMs: 0,
+              adapterFailure: { category: "availability", outcome: "fail-quota" },
+            };
+          }
+          return { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0 };
+        },
+        deriveSessionName: () => "nax-test-session",
+      }) as unknown as ReturnType<typeof _executionDeps.getAgent>;
+
+    const ctx = makeCtx();
+    await executionStage.execute(ctx);
+
+    expect(ctx.agentFallbacks).toHaveLength(1);
+    const hop = ctx.agentFallbacks![0];
+    expect(hop.storyId).toBe("US-001");
+    expect(hop.priorAgent).toBe("claude");
+    expect(hop.newAgent).toBe("codex");
+    expect(hop.category).toBe("availability");
+    expect(hop.outcome).toBe("fail-quota");
+    expect(hop.hop).toBe(1);
+  });
+
+  test("records hop in ctx.agentFallbacks even when swap also fails", async () => {
+    _executionDeps.validateAgentForTier = () => true;
+    _executionDeps.detectMergeConflict = () => false;
+    _executionDeps.shouldAttemptSwap = () => true;
+    _executionDeps.resolveSwapTarget = () => "codex";
+    _executionDeps.rebuildForSwap = () => makeBundle();
+
+    _executionDeps.getAgent = (_agentId: string) =>
+      ({
+        name: "claude",
+        capabilities: { supportedTiers: ["fast"] },
+        run: async () => ({
+          success: false,
+          exitCode: 1,
+          output: "",
+          rateLimited: false,
+          durationMs: 0,
+          adapterFailure: { category: "availability", outcome: "fail-service-down" },
+        }),
+        deriveSessionName: () => "nax-test-session",
+      }) as unknown as ReturnType<typeof _executionDeps.getAgent>;
+
+    const ctx = makeCtx();
+    await executionStage.execute(ctx);
+
+    expect(ctx.agentFallbacks).toHaveLength(1);
+    const hop = ctx.agentFallbacks![0];
+    expect(hop.newAgent).toBe("codex");
+    expect(hop.outcome).toBe("fail-service-down");
+    expect(hop.hop).toBe(1);
+  });
+
+  test("does not push to agentFallbacks when shouldAttemptSwap returns false", async () => {
+    _executionDeps.validateAgentForTier = () => true;
+    _executionDeps.detectMergeConflict = () => false;
+    _executionDeps.shouldAttemptSwap = () => false;
+
+    _executionDeps.getAgent = () =>
+      ({
+        name: "claude",
+        capabilities: { supportedTiers: ["fast"] },
+        run: async () => ({
+          success: false,
+          exitCode: 1,
+          output: "",
+          rateLimited: false,
+          durationMs: 0,
+          adapterFailure: { category: "availability", outcome: "fail-quota" },
+        }),
+        deriveSessionName: () => "nax-test-session",
+      }) as unknown as ReturnType<typeof _executionDeps.getAgent>;
+
+    const ctx = makeCtx();
+    await executionStage.execute(ctx);
+
+    expect(ctx.agentFallbacks ?? []).toHaveLength(0);
+  });
+
+  test("hop number increments correctly across multiple swaps", async () => {
+    _executionDeps.validateAgentForTier = () => true;
+    _executionDeps.detectMergeConflict = () => false;
+    // shouldAttemptSwap is called twice — first by the original fail, second by
+    // swapResult fail. We return true only for the first call so execution halts.
+    let swapAttempts = 0;
+    _executionDeps.shouldAttemptSwap = () => {
+      swapAttempts++;
+      return swapAttempts === 1;
+    };
+    _executionDeps.resolveSwapTarget = () => "codex";
+    _executionDeps.rebuildForSwap = () => makeBundle();
+
+    _executionDeps.getAgent = () =>
+      ({
+        name: "claude",
+        capabilities: { supportedTiers: ["fast"] },
+        run: async () => ({
+          success: false,
+          exitCode: 1,
+          output: "",
+          rateLimited: false,
+          durationMs: 0,
+          adapterFailure: { category: "availability", outcome: "fail-rate-limit" },
+        }),
+        deriveSessionName: () => "nax-test-session",
+      }) as unknown as ReturnType<typeof _executionDeps.getAgent>;
+
+    const ctx = makeCtx();
+    ctx.agentFallbacks = [
+      // Pre-seed a hop to simulate a prior swap in a previous iteration
+      { storyId: "US-001", priorAgent: "codex", newAgent: "claude", outcome: "fail-quota", category: "availability", hop: 1 },
+    ];
+    ctx.agentSwapCount = 1;
+    await executionStage.execute(ctx);
+
+    // The new hop should be hop=2
+    expect(ctx.agentFallbacks).toHaveLength(2);
+    expect(ctx.agentFallbacks![1].hop).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `AgentFallbackHop` interface to `src/metrics/types.ts` with fields: `storyId`, `priorAgent`, `newAgent`, `outcome`, `category`, `hop`
- Adds `agentFallbacks?: AgentFallbackHop[]` to `PipelineContext` (pipeline/types.ts)
- Adds `fallback?: { hops: AgentFallbackHop[] }` to `StoryMetrics` (metrics/types.ts)
- Records a hop in `ctx.agentFallbacks` in `execution.ts` immediately after `ctx.agentSwapCount` increment, capturing the failure details from `adapterFailure`
- Surfaces accumulated hops in `collectStoryMetrics` via `StoryMetrics.fallback.hops`

## Test plan

- [ ] `test/unit/pipeline/stages/execution-agent-swap-metrics.test.ts` — 4 new tests: hop recorded on successful swap, hop recorded when swap also fails, no push when `shouldAttemptSwap` false, hop number increments correctly across multiple swaps
- [ ] `test/unit/metrics/tracker.test.ts` — 4 new tests: `fallback.hops` populated from `ctx.agentFallbacks`, absent when empty, absent when undefined, all hop fields preserved
- [ ] All 6209 unit tests pass; lint and typecheck clean