### PR TITLE
fix(context-engine): add observability + provider scope config (closes #506, #507)

### DIFF
--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -486,6 +486,15 @@ export interface ContextV2Config {
     /** Score multiplier applied to stale chunks (0–1). Default: 0.4. */
     scoreMultiplier: number;
   };
+  /** Built-in provider scope configuration (#507). */
+  providers: {
+    /** Working directory scope for GitHistoryProvider. Default: "package". */
+    historyScope: "repo" | "package";
+    /** Working directory scope for CodeNeighborProvider. Default: "package". */
+    neighborScope: "repo" | "package";
+    /** Cross-package scan depth for CodeNeighborProvider. Default: 1. */
+    crossPackageDepth: number;
+  };
 }
 
 export interface ContextConfig {

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -574,6 +574,33 @@ export const ContextV2ConfigSchema = z
       })
       .default(() => ({ retentionDays: 7, archiveOnFeatureArchive: true })),
     /**
+     * Built-in provider scope configuration (#507).
+     * Controls which working directory each built-in provider uses when
+     * executing git/glob queries in monorepo setups.
+     */
+    providers: z
+      .object({
+        /**
+         * Working directory scope for GitHistoryProvider (#507).
+         * "package" — run git log in packageDir (monorepo-safe default).
+         * "repo" — run git log in repoRoot (full repo history).
+         */
+        historyScope: z.enum(["repo", "package"]).default("package"),
+        /**
+         * Working directory scope for CodeNeighborProvider (#507).
+         * "package" — scan neighbours within packageDir (monorepo-safe default).
+         * "repo" — scan neighbours in repoRoot.
+         */
+        neighborScope: z.enum(["repo", "package"]).default("package"),
+        /**
+         * Cross-package scan depth for CodeNeighborProvider in monorepo mode (#507).
+         * 0 disables cross-package scanning. Default: 1 (one package level up).
+         * Only active when neighborScope is "package" and the story has a workdir.
+         */
+        crossPackageDepth: z.number().int().min(0).default(1),
+      })
+      .default({ historyScope: "package", neighborScope: "package", crossPackageDepth: 1 }),
+    /**
      * Staleness detection for feature context entries (Amendment A AC-46/AC-47).
      * Downweights old or contradicted entries in context.md so stale advice
      * does not crowd out fresh context. No chunks are auto-removed — humans
@@ -609,6 +636,7 @@ export const ContextV2ConfigSchema = z
     deterministic: false,
     session: { retentionDays: 7, archiveOnFeatureArchive: true },
     staleness: { enabled: true, maxStoryAge: 10, scoreMultiplier: 0.4 },
+    providers: { historyScope: "package" as const, neighborScope: "package" as const, crossPackageDepth: 1 },
   }));
 
 const ContextConfigSchema = z.object({
@@ -1034,6 +1062,7 @@ export const NaxConfigSchema = z
         deterministic: false,
         session: { retentionDays: 7, archiveOnFeatureArchive: true },
         staleness: { enabled: true, maxStoryAge: 10, scoreMultiplier: 0.4 },
+        providers: { historyScope: "package", neighborScope: "package", crossPackageDepth: 1 },
       },
     }),
     optimizer: OptimizerConfigSchema.optional(),

--- a/src/context/engine/effectiveness.ts
+++ b/src/context/engine/effectiveness.ts
@@ -11,8 +11,14 @@
  * See: docs/specs/SPEC-context-engine-v2-amendments.md Amendment A.2
  */
 
+import { getLogger } from "../../logger";
+import { errorMessage } from "../../utils/errors";
 import { _manifestStoreDeps, loadContextManifests } from "./manifest-store";
 import type { ChunkEffectiveness } from "./types";
+
+export const _effectivenessDeps = {
+  getLogger,
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -199,8 +205,11 @@ export async function annotateManifestEffectiveness(
       const parsed = JSON.parse(raw) as Record<string, unknown>;
       parsed.chunkEffectiveness = effectiveness;
       await _manifestStoreDeps.writeFile(item.path, `${JSON.stringify(parsed, null, 2)}\n`);
-    } catch {
-      // Best-effort — non-fatal
+    } catch (err) {
+      _effectivenessDeps.getLogger().warn("context-v2", "Failed to annotate chunk effectiveness", {
+        path: item.path,
+        error: errorMessage(err),
+      });
     }
   }
 }

--- a/src/context/engine/orchestrator-factory.ts
+++ b/src/context/engine/orchestrator-factory.ts
@@ -47,8 +47,15 @@ export function createDefaultOrchestrator(
   }
   // Phase 3: git history and code neighbors (always registered; active only when
   // request.touchedFiles is non-empty and the stage includes these provider IDs)
-  providers.push(new GitHistoryProvider());
-  providers.push(new CodeNeighborProvider());
+  // #507: scope is read from config so operators can tune for monorepo setups.
+  const providerConfig = config.context.v2.providers;
+  providers.push(new GitHistoryProvider({ historyScope: providerConfig.historyScope }));
+  providers.push(
+    new CodeNeighborProvider({
+      neighborScope: providerConfig.neighborScope,
+      crossPackageDepth: providerConfig.crossPackageDepth,
+    }),
+  );
   // Phase 7: plugin providers (RAG, graph, KB, etc.)
   providers.push(...additionalProviders);
   return new ContextOrchestrator(providers);

--- a/test/unit/context/engine/effectiveness.test.ts
+++ b/test/unit/context/engine/effectiveness.test.ts
@@ -5,8 +5,13 @@
  *   - classifyEffectiveness (per-chunk signal based on diff / output / findings)
  */
 
-import { describe, expect, test } from "bun:test";
-import { classifyEffectiveness } from "../../../../src/context/engine/effectiveness";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  _effectivenessDeps,
+  annotateManifestEffectiveness,
+  classifyEffectiveness,
+} from "../../../../src/context/engine/effectiveness";
+import { _manifestStoreDeps } from "../../../../src/context/engine/manifest-store";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // classifyEffectiveness
@@ -72,5 +77,106 @@ describe("classifyEffectiveness", () => {
     );
     expect(result.evidence).toBeDefined();
     expect(typeof result.evidence).toBe("string");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #506 — annotateManifestEffectiveness logs warn on read-modify-write failure
+// ─────────────────────────────────────────────────────────────────────────────
+
+const VALID_MANIFEST = JSON.stringify({
+  requestId: "r1",
+  stage: "execution",
+  totalBudgetTokens: 1000,
+  usedTokens: 100,
+  includedChunks: ["chunk-a"],
+  excludedChunks: [],
+  floorItems: [],
+  digestTokens: 10,
+  buildMs: 50,
+  chunkSummaries: {
+    "chunk-a": "Use JWT authentication for secure session management with tokens",
+  },
+});
+
+describe("annotateManifestEffectiveness — #506 catch block logging", () => {
+  let origReadFile: typeof _manifestStoreDeps.readFile;
+  let origListManifestFiles: typeof _manifestStoreDeps.listManifestFiles;
+  let origFileExists: typeof _manifestStoreDeps.fileExists;
+  let origGetLogger: typeof _effectivenessDeps.getLogger;
+
+  beforeEach(() => {
+    origReadFile = _manifestStoreDeps.readFile;
+    origListManifestFiles = _manifestStoreDeps.listManifestFiles;
+    origFileExists = _manifestStoreDeps.fileExists;
+    origGetLogger = _effectivenessDeps.getLogger;
+  });
+
+  afterEach(() => {
+    _manifestStoreDeps.readFile = origReadFile;
+    _manifestStoreDeps.listManifestFiles = origListManifestFiles;
+    _manifestStoreDeps.fileExists = origFileExists;
+    _effectivenessDeps.getLogger = origGetLogger;
+  });
+
+  test("calls logger.warn when manifest read-modify-write throws", async () => {
+    const warnArgs: Array<[string, string, Record<string, unknown>]> = [];
+    _effectivenessDeps.getLogger = () =>
+      ({
+        warn: (stage: string, msg: string, ctx: Record<string, unknown>) => warnArgs.push([stage, msg, ctx]),
+      }) as unknown as ReturnType<typeof _effectivenessDeps.getLogger>;
+
+    let readCount = 0;
+    _manifestStoreDeps.listManifestFiles = async () => ["context-manifest-execution.json"];
+    _manifestStoreDeps.fileExists = async () => true;
+    _manifestStoreDeps.readFile = async () => {
+      readCount++;
+      if (readCount === 1) return VALID_MANIFEST; // loadContextManifests pass
+      throw new Error("disk full");               // read-modify-write fails
+    };
+
+    await annotateManifestEffectiveness("/repo", "feat", "US-001", {
+      agentOutput: "jwt authentication session management tokens",
+      diffText: "+jwt auth",
+      findingMessages: [],
+    });
+
+    expect(warnArgs.length).toBeGreaterThan(0);
+    expect(warnArgs[0][0]).toBe("context-v2");
+    expect(typeof warnArgs[0][2].error).toBe("string");
+  });
+
+  test("continues processing remaining manifests when one read-modify-write fails", async () => {
+    _effectivenessDeps.getLogger = () =>
+      ({ warn: () => {} }) as unknown as ReturnType<typeof _effectivenessDeps.getLogger>;
+
+    const written: string[] = [];
+    let readCount = 0;
+    _manifestStoreDeps.listManifestFiles = async () => [
+      "context-manifest-execution.json",
+      "context-manifest-tdd.json",
+    ];
+    _manifestStoreDeps.fileExists = async () => true;
+    _manifestStoreDeps.readFile = async (path: string) => {
+      readCount++;
+      // First two reads: initial load for both manifests
+      if (readCount <= 2) return VALID_MANIFEST;
+      // Third read (execution rmw): throw
+      if (path.includes("execution")) throw new Error("disk full");
+      return VALID_MANIFEST; // tdd rmw succeeds
+    };
+    _manifestStoreDeps.writeFile = async (path: string) => {
+      written.push(path);
+      return 0;
+    };
+
+    await annotateManifestEffectiveness("/repo", "feat", "US-001", {
+      agentOutput: "jwt authentication session management tokens",
+      diffText: "+jwt auth",
+      findingMessages: [],
+    });
+
+    // At least one manifest was still written (the non-failing one)
+    expect(written.length).toBeGreaterThan(0);
   });
 });

--- a/test/unit/context/engine/orchestrator-factory.test.ts
+++ b/test/unit/context/engine/orchestrator-factory.test.ts
@@ -1,0 +1,153 @@
+/**
+ * #507 — historyScope / neighborScope / crossPackageDepth not in config schema.
+ *
+ * createDefaultOrchestrator() always constructed GitHistoryProvider and
+ * CodeNeighborProvider with their hardcoded defaults, ignoring any operator
+ * config. This tests that the factory reads these fields from config and
+ * passes them to the provider constructors.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { NaxConfig } from "../../../../src/config";
+import { createDefaultOrchestrator } from "../../../../src/context/engine/orchestrator-factory";
+import { _codeNeighborDeps } from "../../../../src/context/engine/providers/code-neighbor";
+import { _gitHistoryDeps } from "../../../../src/context/engine/providers/git-history";
+import type { ContextRequest } from "../../../../src/context/engine/types";
+import type { UserStory } from "../../../../src/prd";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeStory(): UserStory {
+  return {
+    id: "US-001",
+    title: "Test story",
+    description: "desc",
+    acceptanceCriteria: [],
+    tags: [],
+    dependencies: [],
+    status: "in-progress",
+    passes: false,
+    attempts: 1,
+    escalations: [],
+  };
+}
+
+function makeConfig(providerOverrides: {
+  historyScope?: "repo" | "package";
+  neighborScope?: "repo" | "package";
+  crossPackageDepth?: number;
+} = {}): NaxConfig {
+  return {
+    autoMode: { defaultAgent: "claude" },
+    context: {
+      v2: {
+        enabled: true,
+        minScore: 0.1,
+        deterministic: false,
+        pluginProviders: [],
+        stages: {},
+        pull: { enabled: false, allowedTools: [], maxCallsPerSession: 5 },
+        rules: { allowLegacyClaudeMd: true },
+        fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
+        session: { retentionDays: 7, archiveOnFeatureArchive: true },
+        staleness: { enabled: true, maxStoryAge: 10, scoreMultiplier: 0.4 },
+        providers: {
+          historyScope: providerOverrides.historyScope ?? "package",
+          neighborScope: providerOverrides.neighborScope ?? "package",
+          crossPackageDepth: providerOverrides.crossPackageDepth ?? 1,
+        },
+      },
+    },
+  } as unknown as NaxConfig;
+}
+
+function makeRequest(overrides: Partial<ContextRequest> = {}): ContextRequest {
+  return {
+    storyId: "US-001",
+    featureId: "test-feature",
+    repoRoot: "/repo",
+    packageDir: "/repo/packages/pkg-a",
+    stage: "execution",
+    role: "implementer",
+    budgetTokens: 10000,
+    touchedFiles: ["src/auth.ts"],
+    storyScratchDirs: [],
+    agentId: "claude",
+    ...overrides,
+  } as ContextRequest;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Saved deps for restoration
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origGitWithTimeout: typeof _gitHistoryDeps.gitWithTimeout;
+let origCodeNeighborReadFile: typeof _codeNeighborDeps.readFile;
+let origCodeNeighborGlob: typeof _codeNeighborDeps.glob;
+
+beforeEach(() => {
+  origGitWithTimeout = _gitHistoryDeps.gitWithTimeout;
+  origCodeNeighborReadFile = _codeNeighborDeps.readFile;
+  origCodeNeighborGlob = _codeNeighborDeps.glob;
+  // Default: suppress real FS/git calls
+  _gitHistoryDeps.gitWithTimeout = async () => ({ stdout: "", exitCode: 0, stderr: "" });
+  _codeNeighborDeps.readFile = async () => "";
+  _codeNeighborDeps.glob = () => [];
+});
+
+afterEach(() => {
+  _gitHistoryDeps.gitWithTimeout = origGitWithTimeout;
+  _codeNeighborDeps.readFile = origCodeNeighborReadFile;
+  _codeNeighborDeps.glob = origCodeNeighborGlob;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #507: historyScope respected by GitHistoryProvider
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("createDefaultOrchestrator — #507 provider scope config", () => {
+  test("GitHistoryProvider uses repoRoot workdir when historyScope is 'repo'", async () => {
+    const capturedWorkdirs: string[] = [];
+    _gitHistoryDeps.gitWithTimeout = async (_args, workdir) => {
+      capturedWorkdirs.push(workdir);
+      return { stdout: "abc def Fix auth bug", exitCode: 0, stderr: "" };
+    };
+
+    const config = makeConfig({ historyScope: "repo" });
+    const orchestrator = createDefaultOrchestrator(makeStory(), config);
+    await orchestrator.assemble(makeRequest());
+
+    expect(capturedWorkdirs.every((w) => w === "/repo")).toBe(true);
+  });
+
+  test("GitHistoryProvider uses packageDir workdir when historyScope is 'package' (default)", async () => {
+    const capturedWorkdirs: string[] = [];
+    _gitHistoryDeps.gitWithTimeout = async (_args, workdir) => {
+      capturedWorkdirs.push(workdir);
+      return { stdout: "abc def Fix auth bug", exitCode: 0, stderr: "" };
+    };
+
+    const config = makeConfig({ historyScope: "package" });
+    const orchestrator = createDefaultOrchestrator(makeStory(), config);
+    await orchestrator.assemble(makeRequest());
+
+    expect(capturedWorkdirs.every((w) => w === "/repo/packages/pkg-a")).toBe(true);
+  });
+
+  test("CodeNeighborProvider uses repoRoot workdir when neighborScope is 'repo'", async () => {
+    const capturedGlobDirs: string[] = [];
+    _codeNeighborDeps.glob = (_pattern, cwd) => {
+      capturedGlobDirs.push(cwd);
+      return ["src/auth.ts"];
+    };
+    _codeNeighborDeps.readFile = async () => "export function auth() {}";
+
+    const config = makeConfig({ neighborScope: "repo" });
+    const orchestrator = createDefaultOrchestrator(makeStory(), config);
+    await orchestrator.assemble(makeRequest());
+
+    expect(capturedGlobDirs.some((d) => d === "/repo")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

**#506 — effectiveness annotation silent failures:**
- `annotateManifestEffectiveness` catch block was a silent `// Best-effort — non-fatal` comment — operators had no visibility into write failures
- Adds `logger.warn("context-v2", "Failed to annotate chunk effectiveness", { path, error })` to the catch block
- Adds `_effectivenessDeps.getLogger` injectable so the warn call can be unit tested without global logger mocking

**#507 — historyScope / neighborScope / crossPackageDepth not in config schema:**
- `GitHistoryProvider` and `CodeNeighborProvider` always used their hardcoded defaults regardless of operator config
- Adds `config.context.v2.providers.{ historyScope, neighborScope, crossPackageDepth }` to `ContextV2ConfigSchema` and `ContextV2Config` runtime type
- `createDefaultOrchestrator` now reads these fields and passes them to the provider constructors so monorepo operators can scope git log and neighbour scans to the repo root or package directory

## Test plan

- [ ] `test/unit/context/engine/effectiveness.test.ts` — 2 new tests: `logger.warn` called on readFile throw; loop continues processing remaining manifests after one failure
- [ ] `test/unit/context/engine/orchestrator-factory.test.ts` (new file) — 3 tests: `historyScope: "repo"` causes GitHistoryProvider to use repoRoot; `historyScope: "package"` uses packageDir; `neighborScope: "repo"` causes CodeNeighborProvider to use repoRoot
- [ ] All 6214 unit tests pass; lint and typecheck clean