### PR TITLE
fix(context-engine): #508 batch-1 quick fixes — M7, M10, M11

### DIFF
--- a/src/context/engine/orchestrator-factory.ts
+++ b/src/context/engine/orchestrator-factory.ts
@@ -37,7 +37,7 @@ export function createDefaultOrchestrator(
   storyScratchDirs?: string[],
   additionalProviders: IContextProvider[] = [],
 ): ContextOrchestrator {
-  const allowLegacyClaudeMd = config.context.v2.rules.allowLegacyClaudeMd;
+  const allowLegacyClaudeMd = config.context?.v2?.rules?.allowLegacyClaudeMd ?? true;
   const providers: IContextProvider[] = [
     new StaticRulesProvider({ allowLegacyClaudeMd }),
     new FeatureContextProviderV2(story, config),

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -24,6 +24,7 @@
 import { createHash } from "node:crypto";
 import { join, relative, resolve } from "node:path";
 import { discoverWorkspacePackages } from "../../../test-runners/detect/workspace";
+import { getLogger } from "../../../logger";
 import { isRelativeAndSafe } from "../../../utils/path-security";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
@@ -77,14 +78,26 @@ export const _codeNeighborDeps = {
   fileExists: (path: string): Promise<boolean> => Bun.file(path).exists(),
   readFile: (path: string): Promise<string> => Bun.file(path).text(),
   discoverWorkspacePackages: (repoRoot: string): Promise<string[]> => discoverWorkspacePackages(repoRoot),
+  getLogger,
   glob: (pattern: string, cwd: string): string[] => {
     const g = new Bun.Glob(pattern);
     const results: string[] = [];
     let count = 0;
+    let truncated = false;
     for (const file of g.scanSync({ cwd, absolute: false })) {
-      if (count >= MAX_GLOB_FILES) break;
+      if (count >= MAX_GLOB_FILES) {
+        truncated = true;
+        break;
+      }
       results.push(file);
       count++;
+    }
+    if (truncated) {
+      _codeNeighborDeps.getLogger().debug("context-v2", "Glob cap reached — results truncated", {
+        pattern,
+        cwd,
+        cap: MAX_GLOB_FILES,
+      });
     }
     return results;
   },

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -23,8 +23,8 @@
 
 import { createHash } from "node:crypto";
 import { join, relative, resolve } from "node:path";
-import { discoverWorkspacePackages } from "../../../test-runners/detect/workspace";
 import { getLogger } from "../../../logger";
+import { discoverWorkspacePackages } from "../../../test-runners/detect/workspace";
 import { isRelativeAndSafe } from "../../../utils/path-security";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 

--- a/src/context/rules/canonical-loader.ts
+++ b/src/context/rules/canonical-loader.ts
@@ -44,6 +44,7 @@ export const _canonicalLoaderDeps = {
       return [];
     }
   },
+  getLogger,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -139,7 +140,7 @@ export interface CanonicalRule {
  * Returns an empty array if the `.nax/rules/` directory does not exist.
  */
 export async function loadCanonicalRules(workdir: string): Promise<CanonicalRule[]> {
-  const logger = getLogger();
+  const logger = _canonicalLoaderDeps.getLogger();
   const rulesDir = join(workdir, CANONICAL_RULES_DIR);
 
   const filePaths = _canonicalLoaderDeps.globInDir(rulesDir);
@@ -157,7 +158,6 @@ export async function loadCanonicalRules(workdir: string): Promise<CanonicalRule
       content = await _canonicalLoaderDeps.readFile(filePath);
     } catch {
       logger.warn("canonical-loader", "Failed to read rules file — skipping", {
-        storyId: "_rules",
         file: filePath,
       });
       continue;
@@ -179,7 +179,6 @@ export async function loadCanonicalRules(workdir: string): Promise<CanonicalRule
   }
 
   logger.debug("canonical-loader", "Loaded canonical rules", {
-    storyId: "_rules",
     fileCount: rules.length,
     files: rules.map((r) => r.fileName),
   });

--- a/test/unit/context/engine/orchestrator-factory.test.ts
+++ b/test/unit/context/engine/orchestrator-factory.test.ts
@@ -107,6 +107,26 @@ afterEach(() => {
 // #507: historyScope respected by GitHistoryProvider
 // ─────────────────────────────────────────────────────────────────────────────
 
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-M7: optional chaining on config.context.v2.rules
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("createDefaultOrchestrator — #508-M7 optional chaining on rules", () => {
+  test("does not throw when config.context.v2.rules is undefined", () => {
+    const configNoRules = {
+      ...makeConfig(),
+      context: {
+        v2: {
+          ...makeConfig().context.v2,
+          rules: undefined,
+        },
+      },
+    } as unknown as NaxConfig;
+
+    expect(() => createDefaultOrchestrator(makeStory(), configNoRules)).not.toThrow();
+  });
+});
+
 describe("createDefaultOrchestrator — #507 provider scope config", () => {
   test("GitHistoryProvider uses repoRoot workdir when historyScope is 'repo'", async () => {
     const capturedWorkdirs: string[] = [];

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -5,7 +5,10 @@
  * No real files are read.
  */
 
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
 import { CodeNeighborProvider, _codeNeighborDeps } from "../../../../../src/context/engine/providers/code-neighbor";
 import type { CodeNeighborProviderOptions } from "../../../../../src/context/engine/providers/code-neighbor";
 import type { ContextRequest } from "../../../../../src/context/engine/types";
@@ -396,5 +399,73 @@ describe("CodeNeighborProvider — SEC-503 path traversal prevention", () => {
 
     expect(readPaths.some((rp) => rp.includes("valid.ts"))).toBe(true);
     expect(readPaths.some((rp) => rp.includes("evil"))).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-M11: debug log when glob cap (MAX_GLOB_FILES=200) is reached
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("CodeNeighborProvider — #508-M11 glob cap debug logging", () => {
+  let tmpDir: string;
+  let origGetLogger: typeof _codeNeighborDeps.getLogger;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "nax-test-"));
+    const srcDir = join(tmpDir, "src");
+    mkdirSync(srcDir, { recursive: true });
+    // Create 201 files to exceed the 200-file cap
+    for (let i = 0; i < 201; i++) {
+      writeFileSync(join(srcDir, `file${i}.ts`), "");
+    }
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    origGetLogger = _codeNeighborDeps.getLogger;
+  });
+
+  afterEach(() => {
+    _codeNeighborDeps.getLogger = origGetLogger;
+  });
+
+  test("logs debug when glob results are truncated at MAX_GLOB_FILES cap", () => {
+    const debugCalls: Array<[string, string, Record<string, unknown>]> = [];
+    _codeNeighborDeps.getLogger = () =>
+      ({
+        debug: (stage: string, msg: string, ctx: Record<string, unknown>) =>
+          debugCalls.push([stage, msg, ctx]),
+        warn: () => {},
+        info: () => {},
+        error: () => {},
+      }) as unknown as ReturnType<typeof _codeNeighborDeps.getLogger>;
+
+    // Call the real default glob implementation directly (not the mock from setupDeps)
+    const results = _codeNeighborDeps.glob("src/**/*.ts", tmpDir);
+
+    expect(results).toHaveLength(200);
+    expect(debugCalls.length).toBeGreaterThan(0);
+    expect(debugCalls[0]?.[0]).toBe("context-v2");
+    expect(debugCalls[0]?.[2]).toMatchObject({ cap: 200 });
+  });
+
+  test("does not log debug when glob results are below the cap", () => {
+    const debugCalls: unknown[] = [];
+    _codeNeighborDeps.getLogger = () =>
+      ({
+        debug: (...args: unknown[]) => debugCalls.push(args),
+        warn: () => {},
+        info: () => {},
+        error: () => {},
+      }) as unknown as ReturnType<typeof _codeNeighborDeps.getLogger>;
+
+    // Only 1 file matches — well below cap
+    const results = _codeNeighborDeps.glob("src/file0.ts", tmpDir);
+
+    expect(results.length).toBeLessThan(200);
+    expect(debugCalls.length).toBe(0);
   });
 });

--- a/test/unit/context/rules/canonical-loader.test.ts
+++ b/test/unit/context/rules/canonical-loader.test.ts
@@ -15,6 +15,7 @@ import {
   _canonicalLoaderDeps,
 } from "../../../../src/context/rules/canonical-loader";
 
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Dep injection helpers
 // ─────────────────────────────────────────────────────────────────────────────
@@ -222,5 +223,57 @@ describe("loadCanonicalRules", () => {
     setupFiles({ "/project/.nax/rules/style.md": "\n\n## Style\n\nContent.\n\n" });
     const rules = await loadCanonicalRules("/project");
     expect(rules[0]?.content).toBe("## Style\n\nContent.");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-M10: logger calls must not carry sentinel storyId "_rules"
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("loadCanonicalRules — #508-M10 no sentinel storyId in logger calls", () => {
+  let origGetLogger: typeof _canonicalLoaderDeps.getLogger;
+
+  beforeEach(() => {
+    origGetLogger = _canonicalLoaderDeps.getLogger;
+  });
+
+  afterEach(() => {
+    _canonicalLoaderDeps.getLogger = origGetLogger;
+  });
+
+  function makeLoggerSpy(warnData: Array<Record<string, unknown>>, debugData: Array<Record<string, unknown>>) {
+    return () =>
+      ({
+        warn: (_stage: string, _msg: string, data: Record<string, unknown>) => warnData.push(data),
+        debug: (_stage: string, _msg: string, data: Record<string, unknown>) => debugData.push(data),
+        info: () => {},
+        error: () => {},
+      }) as unknown as ReturnType<typeof _canonicalLoaderDeps.getLogger>;
+  }
+
+  test("warn log data does not contain storyId when readFile fails", async () => {
+    const warnData: Array<Record<string, unknown>> = [];
+    _canonicalLoaderDeps.getLogger = makeLoggerSpy(warnData, []);
+    _canonicalLoaderDeps.globInDir = () => ["/project/.nax/rules/rules.md"];
+    _canonicalLoaderDeps.readFile = async () => {
+      throw new Error("disk error");
+    };
+
+    await loadCanonicalRules("/project");
+
+    expect(warnData).toHaveLength(1);
+    expect("storyId" in (warnData[0] ?? {})).toBe(false);
+  });
+
+  test("debug log data does not contain storyId when rules load successfully", async () => {
+    const debugData: Array<Record<string, unknown>> = [];
+    _canonicalLoaderDeps.getLogger = makeLoggerSpy([], debugData);
+    _canonicalLoaderDeps.globInDir = () => ["/project/.nax/rules/style.md"];
+    _canonicalLoaderDeps.readFile = async () => "## Style\n\nUse async/await.";
+
+    await loadCanonicalRules("/project");
+
+    expect(debugData).toHaveLength(1);
+    expect("storyId" in (debugData[0] ?? {})).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **M7**: Add optional chaining `config.context?.v2?.rules?.allowLegacyClaudeMd ?? true` in `createDefaultOrchestrator` — prevents a TypeError when the `rules` sub-object is absent from a partially-constructed config
- **M10**: Remove sentinel `storyId: "_rules"` from two `canonical-loader.ts` logger calls; add injectable `_canonicalLoaderDeps.getLogger` so the behaviour is testable without `mock.module()`
- **M11**: Add `logger.debug` in the default `_codeNeighborDeps.glob` implementation when the `MAX_GLOB_FILES` (200) cap is hit — truncation was previously silent; add injectable `_codeNeighborDeps.getLogger`

## Test plan

- [ ] `bun test test/unit/context/engine/orchestrator-factory.test.ts` — new M7 test passes
- [ ] `bun test test/unit/context/rules/canonical-loader.test.ts` — 2 new M10 tests pass (verify no `storyId` in warn/debug data)
- [ ] `bun test test/unit/context/engine/providers/code-neighbor.test.ts` — 2 new M11 tests pass (debug called at cap, not called below cap)
- [ ] `bun run test` — full suite 1184 pass, 0 fail