### PR TITLE
fix(context-engine): #508 batch-2 — H6, M1, M4

### DIFF
--- a/src/context/engine/agent-profiles.ts
+++ b/src/context/engine/agent-profiles.ts
@@ -84,11 +84,7 @@ export const CONSERVATIVE_DEFAULT_PROFILE: AgentProfile = {
 // Built-in profiles
 // ─────────────────────────────────────────────────────────────────────────────
 
-/**
- * Registry of built-in agent profiles.
- * Phase 5.5 ships claude + codex.
- * Phase 8 adds gemini, cursor, local.
- */
+/** Registry of built-in agent profiles (AC-27). */
 export const AGENT_PROFILES: Record<string, AgentProfile> = {
   claude: {
     caps: {
@@ -110,6 +106,39 @@ export const AGENT_PROFILES: Record<string, AgentProfile> = {
       supportsMarkdown: true,
       systemPromptStyle: "xml-tagged",
       toolSchemaDialect: "openai",
+    },
+  },
+  gemini: {
+    caps: {
+      maxContextTokens: 1_000_000,
+      preferredPromptTokens: 16_000,
+      supportsToolCalls: true,
+      supportsSystemPrompt: true,
+      supportsMarkdown: true,
+      systemPromptStyle: "markdown-sections",
+      toolSchemaDialect: "openai",
+    },
+  },
+  cursor: {
+    caps: {
+      maxContextTokens: 128_000,
+      preferredPromptTokens: 12_000,
+      supportsToolCalls: true,
+      supportsSystemPrompt: true,
+      supportsMarkdown: true,
+      systemPromptStyle: "markdown-sections",
+      toolSchemaDialect: "openai",
+    },
+  },
+  local: {
+    caps: {
+      maxContextTokens: 32_000,
+      preferredPromptTokens: 8_000,
+      supportsToolCalls: false,
+      supportsSystemPrompt: true,
+      supportsMarkdown: true,
+      systemPromptStyle: "plain",
+      toolSchemaDialect: "none",
     },
   },
 };

--- a/src/context/engine/providers/session-scratch.ts
+++ b/src/context/engine/providers/session-scratch.ts
@@ -76,7 +76,8 @@ function renderEntry(entry: ScratchEntry, targetAgentId?: string): string {
       const status = entry.success ? "PASS" : `FAIL (${entry.failCount} failures)`;
       const lines = [`**Verify** at ${entry.timestamp}: ${status} — ${entry.passCount} pass / ${entry.failCount} fail`];
       if (!entry.success && entry.rawOutputTail) {
-        lines.push("```", entry.rawOutputTail.trim(), "```");
+        const tail = neutralizeForAgent(entry.rawOutputTail.trim(), entry.writtenByAgent ?? "", targetAgentId ?? "");
+        lines.push("```", tail, "```");
       }
       return lines.join("\n");
     }

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -39,6 +39,37 @@ export const _runSetupDeps = {
   detectProjectProfile,
 };
 
+/**
+ * Emit a warning for each fallback candidate in config.context.v2.fallback.map
+ * that cannot be resolved by agentGetFn (AC-35 pre-flight check).
+ *
+ * Deduplicates warnings so each unconfigured candidate is reported once even
+ * if it appears under multiple primary agents.
+ */
+export function warnFallbackMisconfiguration(
+  config: NaxConfig,
+  agentGetFn: ((name: string) => unknown) | undefined,
+  logger: ReturnType<typeof getSafeLogger>,
+): void {
+  if (!agentGetFn) return;
+  const fallback = config.context?.v2?.fallback;
+  if (!fallback?.enabled || !fallback.map) return;
+
+  const warned = new Set<string>();
+  for (const [primaryAgent, candidates] of Object.entries(fallback.map)) {
+    for (const candidate of candidates) {
+      if (warned.has(candidate)) continue;
+      if (!agentGetFn(candidate)) {
+        logger?.warn("fallback", "Fallback candidate not available — will be skipped if triggered", {
+          primaryAgent,
+          candidate,
+        });
+        warned.add(candidate);
+      }
+    }
+  }
+}
+
 export interface RunSetupOptions {
   prdPath: string;
   workdir: string;
@@ -84,6 +115,10 @@ export interface RunSetupResult {
  */
 export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult> {
   const logger = getSafeLogger();
+
+  // AC-35: pre-flight warning for unconfigured fallback candidates
+  warnFallbackMisconfiguration(options.config, options.agentGetFn, logger);
+
   const {
     prdPath,
     workdir,

--- a/test/unit/context/engine/agent-profiles.test.ts
+++ b/test/unit/context/engine/agent-profiles.test.ts
@@ -120,3 +120,48 @@ describe("getAgentProfile", () => {
     expect(profile.caps.systemPromptStyle).toBe("plain");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-H6: AC-27 missing built-in profiles (gemini, cursor, local)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AGENT_PROFILES — #508-H6 AC-27 built-in profiles", () => {
+  test("contains gemini profile", () => {
+    expect("gemini" in AGENT_PROFILES).toBe(true);
+  });
+
+  test("contains cursor profile", () => {
+    expect("cursor" in AGENT_PROFILES).toBe(true);
+  });
+
+  test("contains local profile", () => {
+    expect("local" in AGENT_PROFILES).toBe(true);
+  });
+
+  test("getAgentProfile('gemini') returns isDefault: false", () => {
+    const { isDefault } = getAgentProfile("gemini");
+    expect(isDefault).toBe(false);
+  });
+
+  test("getAgentProfile('cursor') returns isDefault: false", () => {
+    const { isDefault } = getAgentProfile("cursor");
+    expect(isDefault).toBe(false);
+  });
+
+  test("getAgentProfile('local') returns isDefault: false", () => {
+    const { isDefault } = getAgentProfile("local");
+    expect(isDefault).toBe(false);
+  });
+
+  test("gemini has positive maxContextTokens", () => {
+    expect(AGENT_PROFILES["gemini"]?.caps.maxContextTokens).toBeGreaterThan(0);
+  });
+
+  test("local toolSchemaDialect is none (conservative default for local LLMs)", () => {
+    expect(AGENT_PROFILES["local"]?.caps.toolSchemaDialect).toBe("none");
+  });
+
+  test("local supportsToolCalls is false", () => {
+    expect(AGENT_PROFILES["local"]?.caps.supportsToolCalls).toBe(false);
+  });
+});

--- a/test/unit/context/engine/providers/session-scratch.test.ts
+++ b/test/unit/context/engine/providers/session-scratch.test.ts
@@ -262,7 +262,7 @@ describe("SessionScratchProvider — AC-42 cross-agent neutralization", () => {
     expect(result.chunks[0].content).toContain("the Read tool");
   });
 
-  test("verify-result entries are not neutralized (test runner output, not agent output)", async () => {
+  test("does not neutralize rawOutputTail in verify-result when writtenByAgent is absent (pure test runner output)", async () => {
     const entry = JSON.stringify({
       kind: "verify-result",
       timestamp: "2026-01-01T00:00:00.000Z",
@@ -273,13 +273,61 @@ describe("SessionScratchProvider — AC-42 cross-agent neutralization", () => {
       passCount: 0,
       failCount: 1,
       rawOutputTail: "Expected the Read tool to return value.",
+      // no writtenByAgent — pure test runner output
+    });
+    mockScratchFile(`${entry}\n`);
+    const provider = new SessionScratchProvider();
+    const result = await provider.fetch(makeRequest({ storyScratchDirs: ["/sess/dir"], agentId: "codex" }));
+
+    // No writtenByAgent → writtenByAgent ?? "" === targetAgentId ?? "" is false,
+    // but neutralizeForAgent("", "") is a no-op, so content preserved
+    expect(result.chunks[0].content).toContain("the Read tool");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-M1: AC-42 verify-result.rawOutputTail must also be neutralized
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SessionScratchProvider — #508-M1 verify-result rawOutputTail neutralization", () => {
+  test("neutralizes rawOutputTail in verify-result when writtenByAgent differs from target agent", async () => {
+    const entry = JSON.stringify({
+      kind: "verify-result",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      storyId: "US-001",
+      stage: "verify",
+      success: false,
+      status: "FAIL",
+      passCount: 0,
+      failCount: 1,
+      rawOutputTail: "I used the Read tool to inspect the file before failing.",
       writtenByAgent: "claude",
     });
     mockScratchFile(`${entry}\n`);
     const provider = new SessionScratchProvider();
     const result = await provider.fetch(makeRequest({ storyScratchDirs: ["/sess/dir"], agentId: "codex" }));
 
-    // rawOutputTail is test runner output — preserved as-is
+    expect(result.chunks[0].content).not.toContain("the Read tool");
+    expect(result.chunks[0].content).toContain("a file read");
+  });
+
+  test("does not neutralize rawOutputTail in verify-result when target matches source", async () => {
+    const entry = JSON.stringify({
+      kind: "verify-result",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      storyId: "US-001",
+      stage: "verify",
+      success: false,
+      status: "FAIL",
+      passCount: 0,
+      failCount: 1,
+      rawOutputTail: "I used the Read tool here.",
+      writtenByAgent: "claude",
+    });
+    mockScratchFile(`${entry}\n`);
+    const provider = new SessionScratchProvider();
+    const result = await provider.fetch(makeRequest({ storyScratchDirs: ["/sess/dir"], agentId: "claude" }));
+
     expect(result.chunks[0].content).toContain("the Read tool");
   });
 });

--- a/test/unit/execution/lifecycle/run-setup.test.ts
+++ b/test/unit/execution/lifecycle/run-setup.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { _runSetupDeps } from "../../../../src/execution/lifecycle/run-setup";
+import { _runSetupDeps, warnFallbackMisconfiguration } from "../../../../src/execution/lifecycle/run-setup";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -85,5 +85,105 @@ describe("setupRun — project detection logging (AC-4)", () => {
     // 'Detected: typescript/web (vitest, biome)'
     // 'Using explicit config: language=go, type=cli; detected: testFramework=go-test'
     expect(true).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-M4: AC-35 pre-flight fallback misconfiguration warning
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("warnFallbackMisconfiguration — #508-M4 AC-35 pre-flight warning", () => {
+  function makeConfig(fallbackMap: Record<string, string[]> = {}) {
+    return {
+      context: {
+        v2: {
+          fallback: {
+            enabled: Object.keys(fallbackMap).length > 0,
+            map: fallbackMap,
+          },
+        },
+      },
+    } as unknown as import("../../../../src/config").NaxConfig;
+  }
+
+  function makeLogger() {
+    const warns: Array<[string, string, Record<string, unknown>]> = [];
+    const logger = {
+      warn: (stage: string, msg: string, ctx: Record<string, unknown>) => warns.push([stage, msg, ctx]),
+      info: () => {},
+      debug: () => {},
+      error: () => {},
+    };
+    return { logger, warns };
+  }
+
+  test("emits warn for each fallback candidate not resolved by agentGetFn", () => {
+    const { logger, warns } = makeLogger();
+    const agentGetFn = (name: string) => (name === "codex" ? {} : undefined);
+
+    warnFallbackMisconfiguration(
+      makeConfig({ claude: ["codex", "gemini"] }),
+      agentGetFn as (name: string) => unknown,
+      logger as unknown as ReturnType<typeof import("../../../../src/logger").getSafeLogger>,
+    );
+
+    expect(warns.length).toBe(1);
+    expect(warns[0]?.[0]).toBe("fallback");
+    expect(warns[0]?.[2]).toMatchObject({ candidate: "gemini" });
+  });
+
+  test("does not warn when all candidates resolve", () => {
+    const { logger, warns } = makeLogger();
+    const agentGetFn = (_name: string) => ({});
+
+    warnFallbackMisconfiguration(
+      makeConfig({ claude: ["codex"] }),
+      agentGetFn as (name: string) => unknown,
+      logger as unknown as ReturnType<typeof import("../../../../src/logger").getSafeLogger>,
+    );
+
+    expect(warns).toHaveLength(0);
+  });
+
+  test("does not warn when fallback is disabled (enabled: false)", () => {
+    const { logger, warns } = makeLogger();
+    const agentGetFn = (_name: string) => undefined;
+    const config = {
+      context: { v2: { fallback: { enabled: false, map: { claude: ["gemini"] } } } },
+    } as unknown as import("../../../../src/config").NaxConfig;
+
+    warnFallbackMisconfiguration(
+      config,
+      agentGetFn as (name: string) => unknown,
+      logger as unknown as ReturnType<typeof import("../../../../src/logger").getSafeLogger>,
+    );
+
+    expect(warns).toHaveLength(0);
+  });
+
+  test("does not warn when agentGetFn is undefined (skip check when resolver unavailable)", () => {
+    const { logger, warns } = makeLogger();
+
+    warnFallbackMisconfiguration(
+      makeConfig({ claude: ["gemini"] }),
+      undefined,
+      logger as unknown as ReturnType<typeof import("../../../../src/logger").getSafeLogger>,
+    );
+
+    expect(warns).toHaveLength(0);
+  });
+
+  test("deduplicates warnings for the same candidate across multiple primary agents", () => {
+    const { logger, warns } = makeLogger();
+    const agentGetFn = (_name: string) => undefined;
+
+    warnFallbackMisconfiguration(
+      makeConfig({ claude: ["gemini"], codex: ["gemini"] }),
+      agentGetFn as (name: string) => unknown,
+      logger as unknown as ReturnType<typeof import("../../../../src/logger").getSafeLogger>,
+    );
+
+    const geminiWarns = warns.filter((w) => (w[2] as Record<string, unknown>).candidate === "gemini");
+    expect(geminiWarns).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- **H6** (AC-27): Add `gemini`, `cursor`, `local` built-in agent profiles to `AGENT_PROFILES`. Only `claude` and `codex` were registered; three named agents silently fell back to the conservative default. Gemini uses 1M context / openai dialect / markdown-sections; cursor mirrors codex with markdown-sections; local is conservative (no tool calls, plain style, 32K window) for Ollama-style LLMs.
- **M1** (AC-42): Apply `neutralizeForAgent` to `rawOutputTail` in `verify-result` scratch entries. Only `tdd-session.outputTail` was being neutralized; test output captured during an agent session can contain agent-specific tool references. Pure test runner output (no `writtenByAgent` set) is a no-op.
- **M4** (AC-35): Export `warnFallbackMisconfiguration` and call it early in `setupRun`. Emits `logger.warn` for each fallback candidate that cannot be resolved by `agentGetFn`, deduplicating across primary agents. When `agentGetFn` is absent, the check is skipped.

## Test plan

- [ ] `bun test test/unit/context/engine/agent-profiles.test.ts` — 9 new H6 tests pass (existence + isDefault:false + local caps)
- [ ] `bun test test/unit/context/engine/providers/session-scratch.test.ts` — 3 new/updated M1 tests pass (neutralize when writtenByAgent differs, no-op when absent, no-op when same agent)
- [ ] `bun test test/unit/execution/lifecycle/run-setup.test.ts` — 5 new M4 tests pass (warn on miss, no warn when all resolve, disabled, no agentGetFn, dedup)
- [ ] `bun test test/unit/` — 6222 pass, 0 fail