### PR TITLE
fix(context-engine): #508 batch-3 — M2, M5, M6, M8

### DIFF
--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -24,6 +24,7 @@ import type { PackedChunk } from "./packing";
 import { PULL_TOOL_REGISTRY } from "./pull-tools";
 import { renderChunks } from "./render";
 import { MIN_SCORE, scoreChunks } from "./scoring";
+import { neutralizeForAgent } from "./scratch-neutralizer";
 import { getStageContextConfig } from "./stage-config";
 import type {
   AdapterFailure,
@@ -438,18 +439,26 @@ export class ContextOrchestrator {
       });
     }
 
+    // Snapshot prior chunk IDs before any mutations (AC-39, M5)
+    const priorChunkIds = prior.chunks.map((c) => c.id);
+
     // Convert ContextChunks back to PackedChunk shape (adds ScoredChunk fields)
-    const packedChunks: import("./packing").PackedChunk[] = prior.chunks.map((c) => ({
-      ...c,
-      rawScore: c.score,
-      roleFiltered: false,
-      belowMinScore: false,
-    }));
+    const priorAgentForNeutralize = prior.agentId ?? "";
+    const packedChunks: import("./packing").PackedChunk[] = prior.chunks.map((c) => {
+      // M2 (AC-42): re-neutralize session-scratch chunk content when swapping agents.
+      // Session chunks carry free-text from renderEntry(); if the prior assemble ran
+      // under claude, tool-name references were preserved (no-op neutralization).
+      // On swap to a different agent we apply neutralization retroactively.
+      const content =
+        newAgentId && newAgentId !== priorAgentForNeutralize && c.kind === "session"
+          ? neutralizeForAgent(c.content, priorAgentForNeutralize, targetAgentId)
+          : c.content;
+      return { ...c, content, rawScore: c.score, roleFiltered: false, belowMinScore: false };
+    });
 
     // Inject failure-note chunk when this is an agent-swap rebuild
     if (failure && newAgentId) {
-      const priorAgentId = prior.agentId ?? "unknown";
-      packedChunks.push(buildFailureNoteChunk(priorAgentId, newAgentId, failure));
+      packedChunks.push(buildFailureNoteChunk(priorAgentForNeutralize || "unknown", newAgentId, failure));
     }
 
     // Re-render under the target agent's profile (or markdown-sections for same-agent rebuild)
@@ -467,6 +476,8 @@ export class ContextOrchestrator {
             newAgentId: targetAgentId,
             failureCategory: failure.category,
             failureOutcome: failure.outcome,
+            priorChunkIds,
+            newChunkIds: packedChunks.map((c) => c.id),
           }
         : undefined;
 

--- a/src/context/engine/providers/feature-context.ts
+++ b/src/context/engine/providers/feature-context.ts
@@ -97,8 +97,11 @@ export class FeatureContextProviderV2 implements IContextProvider {
         if (entries.length > 0) {
           const contradicted = detectContradictions(entries);
           const ageStale = selectStaleByAge(entries, maxStoryAge);
-          const isStale = contradicted.size > 0 || ageStale.size > 0;
-          chunk = applyStaleness(chunk, { isStale, scoreMultiplier });
+          const staleCount = contradicted.size + ageStale.size;
+          const staleRatio = staleCount / entries.length;
+          const isStale = staleRatio > 0;
+          const effectiveMultiplier = isStale ? 1.0 - (1.0 - scoreMultiplier) * staleRatio : scoreMultiplier;
+          chunk = applyStaleness(chunk, { isStale, scoreMultiplier: effectiveMultiplier });
 
           if (isStale) {
             logger.debug("feature-context-v2", "Stale entries detected in feature context", {

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -223,6 +223,10 @@ export interface ContextManifest {
     newAgentId: string;
     failureCategory: AdapterFailure["category"];
     failureOutcome: AdapterFailure["outcome"];
+    /** Chunk IDs from the prior bundle before the rebuild (AC-39). */
+    priorChunkIds: string[];
+    /** Chunk IDs in the rebuilt bundle, including any injected failure-note (AC-39). */
+    newChunkIds: string[];
   };
   /**
    * First 300 chars of each included chunk's content (Amendment A AC-45).

--- a/src/session/scratch-writer.ts
+++ b/src/session/scratch-writer.ts
@@ -15,7 +15,7 @@
  * See: docs/specs/SPEC-context-engine-v2.md §Session model
  */
 
-import { mkdir } from "node:fs/promises";
+import { appendFile as fsAppendFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -81,6 +81,8 @@ export const _scratchWriterDeps = {
   },
   /** Write (overwrite) the file at path */
   writeFile: (path: string, content: string): Promise<number> => Bun.write(path, content),
+  /** Append content to the file at path (atomic append — avoids read-modify-write race) */
+  appendFile: (path: string, content: string): Promise<void> => fsAppendFile(path, content, "utf8"),
   /** Create directory and parents */
   mkdirp: (path: string): Promise<string | undefined> => mkdir(path, { recursive: true }),
 };
@@ -127,9 +129,8 @@ function truncateOutputFields(entry: ScratchEntry): ScratchEntry {
 export async function appendScratchEntry(scratchDir: string, entry: ScratchEntry): Promise<void> {
   const filePath = scratchFilePath(scratchDir);
   await _scratchWriterDeps.mkdirp(dirname(filePath));
-  const existing = await _scratchWriterDeps.readFile(filePath);
   const line = JSON.stringify(truncateOutputFields(entry));
-  await _scratchWriterDeps.writeFile(filePath, existing ? `${existing}${line}\n` : `${line}\n`);
+  await _scratchWriterDeps.appendFile(filePath, `${line}\n`);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/context/engine/orchestrator-rebuild.test.ts
+++ b/test/unit/context/engine/orchestrator-rebuild.test.ts
@@ -13,6 +13,7 @@ import { describe, test, expect } from "bun:test";
 import { ContextOrchestrator } from "../../../../src/context/engine/orchestrator";
 import type {
   AdapterFailure,
+  ContextBundle,
   ContextRequest,
   ContextProviderResult,
   IContextProvider,
@@ -280,5 +281,148 @@ describe("rebuildForAgent — rendering style dispatch", () => {
 
     orch.rebuildForAgent(original, { newAgentId: "codex", failure: AVAILABILITY_FAILURE });
     expect(fetchCount).toBe(1); // no additional fetch
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-M2: AC-42 re-neutralize session-scratch chunks on agent-swap rebuild
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("rebuildForAgent — #508-M2 session-chunk re-neutralization on swap", () => {
+  function makeSessionBundle(sessionContent: string, priorAgentId = "claude"): ContextBundle {
+    return {
+      pushMarkdown: "",
+      pullTools: [],
+      digest: "",
+      agentId: priorAgentId,
+      chunks: [
+        {
+          id: "session-scratch:abc123",
+          providerId: "session-scratch",
+          kind: "session" as const,
+          scope: "session" as const,
+          role: ["all"],
+          content: sessionContent,
+          tokens: 20,
+          score: 0.9,
+        },
+      ],
+      manifest: {
+        requestId: "req-prior",
+        stage: "tdd-implementer",
+        totalBudgetTokens: 8_000,
+        usedTokens: 100,
+        includedChunks: ["session-scratch:abc123"],
+        excludedChunks: [],
+        floorItems: [],
+        digestTokens: 10,
+        buildMs: 5,
+      },
+    };
+  }
+
+  test("session chunk content is re-neutralized when swapping from claude to codex", () => {
+    const orch = new ContextOrchestrator([]);
+    const prior = makeSessionBundle("I used the Read tool to inspect and the Bash tool to run tests.");
+    const rebuilt = orch.rebuildForAgent(prior, { newAgentId: "codex", failure: AVAILABILITY_FAILURE });
+    expect(rebuilt.pushMarkdown).not.toContain("the Read tool");
+    expect(rebuilt.pushMarkdown).not.toContain("the Bash tool");
+    expect(rebuilt.pushMarkdown).toContain("a file read");
+    expect(rebuilt.pushMarkdown).toContain("a shell command");
+  });
+
+  test("session chunk is not re-neutralized on same-agent rebuild (claude → claude)", () => {
+    const orch = new ContextOrchestrator([]);
+    const prior = makeSessionBundle("I used the Read tool to inspect.", "claude");
+    const rebuilt = orch.rebuildForAgent(prior, { newAgentId: "claude", failure: AVAILABILITY_FAILURE });
+    expect(rebuilt.pushMarkdown).toContain("the Read tool");
+  });
+
+  test("non-session (feature) chunks are not touched by re-neutralization", () => {
+    const orch = new ContextOrchestrator([]);
+    const prior: ContextBundle = {
+      pushMarkdown: "",
+      pullTools: [],
+      digest: "",
+      agentId: "claude",
+      chunks: [
+        {
+          id: "feature:abc",
+          providerId: "feature-context",
+          kind: "feature" as const,
+          scope: "feature" as const,
+          role: ["all"],
+          content: "Feature: use the Read tool pattern.",
+          tokens: 10,
+          score: 0.8,
+        },
+      ],
+      manifest: {
+        requestId: "req-x",
+        stage: "tdd-implementer",
+        totalBudgetTokens: 8_000,
+        usedTokens: 50,
+        includedChunks: ["feature:abc"],
+        excludedChunks: [],
+        floorItems: [],
+        digestTokens: 5,
+        buildMs: 1,
+      },
+    };
+    const rebuilt = orch.rebuildForAgent(prior, { newAgentId: "codex", failure: AVAILABILITY_FAILURE });
+    // Feature chunks are not session history — must not be altered
+    expect(rebuilt.pushMarkdown).toContain("the Read tool");
+  });
+
+  test("no re-neutralization when no newAgentId (plain re-render)", () => {
+    const orch = new ContextOrchestrator([]);
+    const prior = makeSessionBundle("I used the Read tool to inspect.", "claude");
+    const rebuilt = orch.rebuildForAgent(prior);
+    // no newAgentId → no swap → no re-neutralization
+    expect(rebuilt.pushMarkdown).toContain("the Read tool");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-M5: AC-39 rebuildInfo chunk ID correlation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("rebuildForAgent — #508-M5 rebuildInfo chunk ID correlation", () => {
+  test("rebuildInfo contains priorChunkIds on agent-swap rebuild", async () => {
+    const provider = makeProvider("p1", makeChunkResult("chunk:abc"));
+    const orch = new ContextOrchestrator([provider]);
+    const original = await orch.assemble({ ...BASE_REQUEST, providerIds: ["p1"] });
+    const priorBundle = { ...original, agentId: "claude" };
+
+    const rebuilt = orch.rebuildForAgent(priorBundle, {
+      newAgentId: "codex",
+      failure: AVAILABILITY_FAILURE,
+    });
+
+    expect(rebuilt.manifest.rebuildInfo?.priorChunkIds).toEqual(["chunk:abc"]);
+  });
+
+  test("rebuildInfo contains newChunkIds including failure-note chunk", async () => {
+    const provider = makeProvider("p1", makeChunkResult("chunk:abc"));
+    const orch = new ContextOrchestrator([provider]);
+    const original = await orch.assemble({ ...BASE_REQUEST, providerIds: ["p1"] });
+    const priorBundle = { ...original, agentId: "claude" };
+
+    const rebuilt = orch.rebuildForAgent(priorBundle, {
+      newAgentId: "codex",
+      failure: AVAILABILITY_FAILURE,
+    });
+
+    const newIds = rebuilt.manifest.rebuildInfo?.newChunkIds ?? [];
+    expect(newIds).toContain("chunk:abc");
+    // failure-note chunk is added on swap → newChunkIds has more than priorChunkIds
+    expect(newIds.length).toBeGreaterThan(1);
+  });
+
+  test("rebuildInfo has no chunk ID fields when no failure (plain re-render)", async () => {
+    const orch = new ContextOrchestrator([]);
+    const original = await orch.assemble(BASE_REQUEST);
+    const rebuilt = orch.rebuildForAgent(original);
+    expect(rebuilt.manifest.rebuildInfo).toBeUndefined();
   });
 });

--- a/test/unit/context/engine/providers/feature-context.test.ts
+++ b/test/unit/context/engine/providers/feature-context.test.ts
@@ -131,3 +131,69 @@ describe("FeatureContextProviderV2", () => {
     expect(result.chunks).toHaveLength(0);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-M6: AC-46 proportional staleness scoring
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("FeatureContextProviderV2 — #508-M6 proportional staleness scoring", () => {
+  // Content: 2 entries in same section. Entry 0 is contradicted by entry 1
+  // (shares >= 3 significant terms, entry 1 has negation "no longer").
+  // Stale entries: 1 of 2 → ratio = 0.5
+  // Effective multiplier: 1.0 - (1.0 - 0.4) * 0.5 = 0.7
+  const PARTIAL_STALE_CONTENT = [
+    "## Authentication",
+    "",
+    "The service fetches data from postgres database using active connections.",
+    "",
+    "The service no longer fetches data from postgres database — removed active connections.",
+  ].join("\n");
+
+  // Plain content — no stale entries
+  const NO_STALE_CONTENT = "## Summary\n\nThe project is a standard TypeScript CLI.";
+
+  function makeStaleConfig(): NaxConfig {
+    return {
+      context: { v2: { staleness: { enabled: true, maxStoryAge: 10, scoreMultiplier: 0.4 } } },
+    } as unknown as NaxConfig;
+  }
+
+  test("chunk has no scoreMultiplier when no entries are stale", async () => {
+    mockV1Provider({ content: NO_STALE_CONTENT, estimatedTokens: 20 });
+    const provider = new FeatureContextProviderV2(STORY, makeStaleConfig());
+    const result = await provider.fetch(makeRequest());
+
+    const chunk = result.chunks[0];
+    expect(chunk).toBeDefined();
+    expect(chunk.scoreMultiplier).toBeUndefined();
+    expect(chunk.staleCandidate).toBeFalsy();
+  });
+
+  test("chunk gets proportional scoreMultiplier (~0.7) when half of entries are stale via contradiction", async () => {
+    // 2 entries in same section. Entry 0 is contradicted by entry 1
+    // (shares 7 significant terms, entry 1 has "no longer" negation).
+    // stale count = 1, total = 2, ratio = 0.5
+    // effective multiplier = 1.0 - (1.0 - 0.4) * 0.5 = 0.7
+    mockV1Provider({ content: PARTIAL_STALE_CONTENT, estimatedTokens: 30 });
+    const provider = new FeatureContextProviderV2(STORY, makeStaleConfig());
+    const result = await provider.fetch(makeRequest());
+
+    const chunk = result.chunks[0];
+    expect(chunk).toBeDefined();
+    expect(chunk.staleCandidate).toBe(true);
+    // RED: old whole-chunk taint returns 0.4; GREEN: proportional returns 0.7
+    expect(chunk.scoreMultiplier).toBeCloseTo(0.7, 5);
+  });
+
+  test("chunk scoreMultiplier is strictly less than full penalty when only some entries are stale", async () => {
+    mockV1Provider({ content: PARTIAL_STALE_CONTENT, estimatedTokens: 30 });
+    const provider = new FeatureContextProviderV2(STORY, makeStaleConfig());
+    const result = await provider.fetch(makeRequest());
+
+    const chunk = result.chunks[0];
+    expect(chunk).toBeDefined();
+    expect(chunk.staleCandidate).toBe(true);
+    // Proportional penalty must be strictly less severe than full 0.4 penalty
+    expect(chunk.scoreMultiplier).toBeGreaterThan(0.4);
+  });
+});

--- a/test/unit/session/scratch-writer.test.ts
+++ b/test/unit/session/scratch-writer.test.ts
@@ -112,21 +112,23 @@ describe("appendScratchEntry", () => {
     expect(exists).toBe(true);
   });
 
-  describe("throws on write failure (dep injection)", () => {
-    let origWrite: typeof _scratchWriterDeps.writeFile;
+  describe("throws on append failure (dep injection)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const deps = _scratchWriterDeps as any;
+    let origAppend: unknown;
 
     beforeEach(() => {
-      origWrite = _scratchWriterDeps.writeFile;
-      _scratchWriterDeps.writeFile = async () => {
+      origAppend = deps.appendFile;
+      deps.appendFile = async () => {
         throw new Error("disk full");
       };
     });
 
     afterEach(() => {
-      _scratchWriterDeps.writeFile = origWrite;
+      deps.appendFile = origAppend;
     });
 
-    test("propagates write error", async () => {
+    test("propagates append error", async () => {
       let threw = false;
       try {
         await appendScratchEntry(join(tmpDir, "sess-fail"), VERIFY_ENTRY);
@@ -135,6 +137,57 @@ describe("appendScratchEntry", () => {
       }
       expect(threw).toBe(true);
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-M8: append-atomic — replace read+writeFile with appendFile dep
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("appendScratchEntry — #508-M8 append-atomic dep injection", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const deps = _scratchWriterDeps as any;
+
+  test("_scratchWriterDeps exposes appendFile for injection", () => {
+    expect(typeof deps.appendFile).toBe("function");
+  });
+
+  test("appendScratchEntry calls appendFile dep (not read+writeFile) for append", async () => {
+    let appendPayload: string | undefined;
+    let writeCalled = false;
+
+    const origAppend = deps.appendFile;
+    const origWrite = _scratchWriterDeps.writeFile;
+    deps.appendFile = async (_path: string, content: string) => { appendPayload = content; return 0; };
+    _scratchWriterDeps.writeFile = async () => { writeCalled = true; return 0; };
+
+    try {
+      const scratchDir = join(tmpDir, "m8-atomic");
+      await appendScratchEntry(scratchDir, VERIFY_ENTRY);
+      expect(appendPayload).toBeDefined();
+      expect(appendPayload).toContain('"kind":"verify-result"');
+      expect(writeCalled).toBe(false);
+    } finally {
+      deps.appendFile = origAppend;
+      _scratchWriterDeps.writeFile = origWrite;
+    }
+  });
+
+  test("appendFile error propagates out of appendScratchEntry", async () => {
+    const origAppend = deps.appendFile;
+    deps.appendFile = async () => { throw new Error("disk full (append)"); };
+
+    try {
+      let threw = false;
+      try {
+        await appendScratchEntry(join(tmpDir, "m8-fail"), VERIFY_ENTRY);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(true);
+    } finally {
+      deps.appendFile = origAppend;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- **M2 (AC-42)**: `rebuildForAgent()` now re-neutralizes session-scratch chunk content when swapping to a different agent. Previously, a bundle assembled under `claude` preserved Claude tool-name references even after an agent-swap rebuild to `codex`. Tool names are now stripped retroactively.

- **M5 (AC-39)**: `rebuildInfo` on the manifest now includes `priorChunkIds` and `newChunkIds` so callers can correlate which chunks were present before and after the rebuild (including any injected failure-note chunk).

- **M6 (AC-46)**: `FeatureContextProviderV2` now applies proportional staleness penalty instead of whole-chunk taint. When only some entries are stale, the effective `scoreMultiplier` is interpolated: `1.0 - (1.0 - configMult) * staleRatio`. Previously any stale entry applied the full configured multiplier.

- **M8**: `appendScratchEntry` no longer does a read-modify-write; it now calls an injected `appendFile` dep (`fs.appendFile`) for atomic append, eliminating the concurrent-write race condition.

## Test plan

- [ ] `bun test test/unit/context/engine/orchestrator-rebuild.test.ts` — M2 + M5 tests pass (4 new M2 tests, 3 new M5 tests)
- [ ] `bun test test/unit/context/engine/providers/feature-context.test.ts` — M6 tests pass (3 new tests)
- [ ] `bun test test/unit/session/scratch-writer.test.ts` — M8 tests pass (3 new tests + updated "throws on append failure" test)
- [ ] `bun run lint` and `bun run typecheck` — clean
- [ ] Full context + session test suite: 665 pass, 0 fail