### PR TITLE
fix(context-engine): #508 Batch 4 — M3 + M12 spec-review findings

### DIFF
--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -490,13 +490,12 @@ const ContextV2RulesConfigSchema = z
   .object({
     /**
      * Fall back to reading CLAUDE.md + .claude/rules/ when .nax/rules/ is absent.
-     * Default true for one version (migration period); set false once canonical
-     * store is populated to enforce strict canonical-only rules loading.
-     * Phase 5.1: true (default). Removed after next minor version.
+     * Default false — legacy fallback must be explicitly opted in.
+     * Set true only during migration to the canonical .nax/rules/ store.
      */
-    allowLegacyClaudeMd: z.boolean().default(true),
+    allowLegacyClaudeMd: z.boolean().default(false),
   })
-  .default(() => ({ allowLegacyClaudeMd: true }));
+  .default(() => ({ allowLegacyClaudeMd: false }));
 
 // Context Engine plugin provider config (Phase 7)
 const ContextPluginProviderConfigSchema = z.object({
@@ -629,7 +628,7 @@ export const ContextV2ConfigSchema = z
     enabled: false,
     minScore: 0.1,
     pull: { enabled: false, allowedTools: [], maxCallsPerSession: 5, maxCallsPerRun: 50 },
-    rules: { allowLegacyClaudeMd: true },
+    rules: { allowLegacyClaudeMd: false },
     fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
     pluginProviders: [],
     stages: {},
@@ -1055,7 +1054,7 @@ export const NaxConfigSchema = z
         enabled: false,
         minScore: 0.1,
         pull: { enabled: false, allowedTools: [], maxCallsPerSession: 5, maxCallsPerRun: 50 },
-        rules: { allowLegacyClaudeMd: true },
+        rules: { allowLegacyClaudeMd: false },
         fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
         pluginProviders: [],
         stages: {},

--- a/src/context/engine/orchestrator-factory.ts
+++ b/src/context/engine/orchestrator-factory.ts
@@ -37,7 +37,7 @@ export function createDefaultOrchestrator(
   storyScratchDirs?: string[],
   additionalProviders: IContextProvider[] = [],
 ): ContextOrchestrator {
-  const allowLegacyClaudeMd = config.context?.v2?.rules?.allowLegacyClaudeMd ?? true;
+  const allowLegacyClaudeMd = config.context?.v2?.rules?.allowLegacyClaudeMd ?? false;
   const providers: IContextProvider[] = [
     new StaticRulesProvider({ allowLegacyClaudeMd }),
     new FeatureContextProviderV2(story, config),

--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -233,6 +233,16 @@ export class ContextOrchestrator {
       (p) => allowedIds.includes(p.id) && !(request.deterministic === true && p.deterministic === false),
     );
 
+    // AC-16: detect providerIds that matched no registered provider.
+    const registeredIds = new Set(this.providers.map((p) => p.id));
+    const unknownProviderIds = allowedIds.filter((id) => !registeredIds.has(id));
+    if (unknownProviderIds.length > 0) {
+      logger.warn("context-v2", "Unknown provider IDs in request — no matching provider registered", {
+        storyId: request.storyId,
+        unknownProviderIds,
+      });
+    }
+
     // Step 2: parallel fetch with timeout — failures return empty, never throw.
     // Per-provider status is recorded for manifest auditability (Finding 3).
     const fetchResults = await Promise.all(
@@ -389,6 +399,7 @@ export class ContextOrchestrator {
       packageDir: request.packageDir,
       ...(Object.keys(chunkSummaries).length > 0 && { chunkSummaries }),
       ...(staleChunkIds.length > 0 && { staleChunks: staleChunkIds }),
+      ...(unknownProviderIds.length > 0 && { unknownProviderIds }),
     };
 
     logger.debug("context-v2", "Bundle assembled", {

--- a/src/context/engine/providers/static-rules.ts
+++ b/src/context/engine/providers/static-rules.ts
@@ -48,8 +48,8 @@ const LEGACY_CANDIDATE_FILES = ["CLAUDE.md", ".cursorrules", "AGENTS.md"];
 export interface StaticRulesProviderOptions {
   /**
    * Fall back to reading CLAUDE.md / .cursorrules / AGENTS.md when
-   * .nax/rules/ is absent. Default: true (migration period).
-   * Set false to enforce strict canonical-only rules loading.
+   * .nax/rules/ is absent. Default: false — opt-in only.
+   * Set true only during migration to the canonical .nax/rules/ store.
    */
   allowLegacyClaudeMd?: boolean;
 }
@@ -77,7 +77,7 @@ export class StaticRulesProvider implements IContextProvider {
   private readonly allowLegacyClaudeMd: boolean;
 
   constructor(options: StaticRulesProviderOptions = {}) {
-    this.allowLegacyClaudeMd = options.allowLegacyClaudeMd ?? true;
+    this.allowLegacyClaudeMd = options.allowLegacyClaudeMd ?? false;
   }
 
   async fetch(request: ContextRequest): Promise<ContextProviderResult> {

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -229,6 +229,11 @@ export interface ContextManifest {
     newChunkIds: string[];
   };
   /**
+   * Provider IDs in request.providerIds that matched no registered provider (AC-16).
+   * Absent when all IDs are known or providerIds is empty.
+   */
+  unknownProviderIds?: string[];
+  /**
    * First 300 chars of each included chunk's content (Amendment A AC-45).
    * Written at assemble() time; used by annotateManifestEffectiveness() post-story
    * to compare chunk content against agent output / diff / review findings.

--- a/test/unit/context/engine/orchestrator-unknown-providers.test.ts
+++ b/test/unit/context/engine/orchestrator-unknown-providers.test.ts
@@ -1,0 +1,77 @@
+/**
+ * ContextOrchestrator — #508-M12 unknown providerIds validation tests
+ *
+ * AC-16/AC-23: When request.providerIds contains an ID that matches no
+ * registered provider, the orchestrator must warn and record it in
+ * manifest.unknownProviderIds. Unknown IDs must not silently disappear.
+ *
+ * Kept in a separate file because orchestrator.test.ts exceeds 400 lines.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { ContextOrchestrator } from "../../../../src/context/engine/orchestrator";
+import type { ContextRequest, IContextProvider, ContextProviderResult } from "../../../../src/context/engine/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const BASE_REQUEST: ContextRequest = {
+  storyId: "US-001",
+  repoRoot: "/repo",
+  packageDir: "/repo",
+  stage: "tdd-implementer",
+  role: "implementer",
+  budgetTokens: 8_000,
+};
+
+function makeProvider(id: string): IContextProvider {
+  return {
+    id,
+    kind: "feature",
+    fetch: async (): Promise<ContextProviderResult> => ({ chunks: [], pullTools: [] }),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-M12: AC-16/AC-23 unknown provider ID validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("ContextOrchestrator — #508-M12 unknown providerIds validation", () => {
+  test("manifest.unknownProviderIds contains ID when it matches no registered provider", async () => {
+    const orch = new ContextOrchestrator([makeProvider("real-provider")]);
+    const result = await orch.assemble({ ...BASE_REQUEST, providerIds: ["does-not-exist"] });
+
+    // RED: field does not exist yet.
+    // GREEN: manifest records the unknown ID.
+    expect(result.manifest.unknownProviderIds).toEqual(["does-not-exist"]);
+  });
+
+  test("manifest.unknownProviderIds is undefined when all providerIds are known", async () => {
+    const orch = new ContextOrchestrator([makeProvider("real-provider")]);
+    const result = await orch.assemble({ ...BASE_REQUEST, providerIds: ["real-provider"] });
+
+    expect(result.manifest.unknownProviderIds).toBeUndefined();
+  });
+
+  test("manifest.unknownProviderIds lists only the unknown IDs (mix of known and unknown)", async () => {
+    const orch = new ContextOrchestrator([makeProvider("known-a"), makeProvider("known-b")]);
+    const result = await orch.assemble({
+      ...BASE_REQUEST,
+      providerIds: ["known-a", "ghost-id", "known-b", "phantom-id"],
+    });
+
+    const unknown = result.manifest.unknownProviderIds ?? [];
+    expect(unknown).toContain("ghost-id");
+    expect(unknown).toContain("phantom-id");
+    expect(unknown).not.toContain("known-a");
+    expect(unknown).not.toContain("known-b");
+  });
+
+  test("manifest.unknownProviderIds is undefined when providerIds is empty", async () => {
+    const orch = new ContextOrchestrator([makeProvider("p1")]);
+    const result = await orch.assemble({ ...BASE_REQUEST, providerIds: [] });
+
+    expect(result.manifest.unknownProviderIds).toBeUndefined();
+  });
+});

--- a/test/unit/context/engine/providers/static-rules-legacy-default.test.ts
+++ b/test/unit/context/engine/providers/static-rules-legacy-default.test.ts
@@ -1,0 +1,81 @@
+/**
+ * StaticRulesProvider — #508-M3 allowLegacyClaudeMd default tests
+ *
+ * AC-28/AC-31: The default for allowLegacyClaudeMd must be false.
+ * Legacy CLAUDE.md fallback must be opt-in, not opt-out.
+ *
+ * Kept in a separate file because static-rules.test.ts exceeds 400 lines.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { StaticRulesProvider, _staticRulesDeps } from "../../../../../src/context/engine/providers/static-rules";
+import { NaxConfigSchema } from "../../../../../src/config/schemas";
+import type { ContextRequest } from "../../../../../src/context/engine/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dep injection helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origReadFile: typeof _staticRulesDeps.readFile;
+let origFileExists: typeof _staticRulesDeps.fileExists;
+let origLoadCanonicalRules: typeof _staticRulesDeps.loadCanonicalRules;
+
+beforeEach(() => {
+  origReadFile = _staticRulesDeps.readFile;
+  origFileExists = _staticRulesDeps.fileExists;
+  origLoadCanonicalRules = _staticRulesDeps.loadCanonicalRules;
+  _staticRulesDeps.loadCanonicalRules = async () => [];
+});
+
+afterEach(() => {
+  _staticRulesDeps.readFile = origReadFile;
+  _staticRulesDeps.fileExists = origFileExists;
+  _staticRulesDeps.loadCanonicalRules = origLoadCanonicalRules;
+});
+
+const BASE_REQUEST: ContextRequest = {
+  storyId: "US-001",
+  repoRoot: "/project",
+  packageDir: "/project",
+  stage: "execution",
+  role: "implementer",
+  budgetTokens: 8_000,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #508-M3: AC-28/AC-31 allowLegacyClaudeMd defaults to false
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("StaticRulesProvider — #508-M3 allowLegacyClaudeMd defaults to false", () => {
+  test("returns empty chunks by default when no canonical rules and CLAUDE.md exists", async () => {
+    // Canonical rules: empty (no .nax/rules/)
+    _staticRulesDeps.loadCanonicalRules = async () => [];
+    // CLAUDE.md exists and has content — legacy fallback would pick this up
+    _staticRulesDeps.fileExists = async (path: string) => path.endsWith("CLAUDE.md");
+    _staticRulesDeps.readFile = async () => "# Project rules\n\nUse async/await.";
+
+    // RED: current default is true — provider falls back to CLAUDE.md and returns a chunk.
+    // GREEN: default false — no legacy fallback, returns empty.
+    const provider = new StaticRulesProvider(); // no options
+    const result = await provider.fetch(BASE_REQUEST);
+    expect(result.chunks).toHaveLength(0);
+  });
+
+  test("returns legacy chunks when explicitly opted in with allowLegacyClaudeMd: true", async () => {
+    _staticRulesDeps.loadCanonicalRules = async () => [];
+    _staticRulesDeps.fileExists = async (path: string) => path.endsWith("CLAUDE.md");
+    _staticRulesDeps.readFile = async () => "# Rules\n\nUse async/await.";
+
+    const provider = new StaticRulesProvider({ allowLegacyClaudeMd: true });
+    const result = await provider.fetch(BASE_REQUEST);
+    // Explicit opt-in must still work
+    expect(result.chunks.length).toBeGreaterThan(0);
+  });
+
+  test("NaxConfigSchema default for allowLegacyClaudeMd is false", () => {
+    const config = NaxConfigSchema.parse({});
+    // RED: current schema default is true.
+    // GREEN: flipped to false.
+    expect(config.context?.v2?.rules?.allowLegacyClaudeMd).toBe(false);
+  });
+});

--- a/test/unit/context/engine/providers/static-rules.test.ts
+++ b/test/unit/context/engine/providers/static-rules.test.ts
@@ -168,11 +168,11 @@ describe("StaticRulesProvider — allowLegacyClaudeMd", () => {
     expect(result.chunks[0]?.content).toContain("Use bun.");
   });
 
-  test("default allowLegacyClaudeMd is true (migration period)", async () => {
+  test("default allowLegacyClaudeMd is false — no legacy fallback without opt-in", async () => {
     setupLegacyFiles({ "/project/CLAUDE.md": "# Project Rules\n\nLegacy." });
-    const provider = new StaticRulesProvider(); // no option — defaults to true
+    const provider = new StaticRulesProvider(); // no option — defaults to false
     const result = await provider.fetch(BASE_REQUEST);
-    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- **M3 (AC-28/AC-31):** Flip `allowLegacyClaudeMd` default from `true` → `false` in `schemas.ts`, `static-rules.ts`, and `orchestrator-factory.ts`. Legacy CLAUDE.md fallback is now strictly opt-in; removes the "migration period" language from comments. Updated one existing test that asserted the old default.
- **M12 (AC-16/AC-23):** Detect `providerIds` entries that match no registered provider in `ContextOrchestrator.assemble()`. Emits `logger.warn` and records them in `manifest.unknownProviderIds`. Added `unknownProviderIds?: string[]` to `ContextManifest` type.

## Test plan

- [ ] RED tests written first in two new files (400-line file limit splits):
  - `test/unit/context/engine/providers/static-rules-legacy-default.test.ts` (M3, 3 tests)
  - `test/unit/context/engine/orchestrator-unknown-providers.test.ts` (M12, 4 tests)
- [ ] Full test suite: 0 failures across 6255+ tests
- [ ] `bun run typecheck` clean
- [ ] **Do NOT merge** — awaiting review