### PR TITLE
Context engine v2 review follow-ups + session manager lifecycle hardening

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -53,6 +53,9 @@ import {
   pluginsListCommand,
   promptsCommand,
   promptsInitCommand,
+  rulesExportCommand,
+  rulesLintCommand,
+  rulesMigrateCommand,
   runReplanLoop,
   runsListCommand,
   runsShowCommand,
@@ -1296,6 +1299,84 @@ context
         feature: options.feature,
         json: options.json,
         storyId,
+      });
+    } catch (err) {
+      console.error(chalk.red(`Error: ${(err as Error).message}`));
+      process.exit(1);
+    }
+  });
+
+// ── rules ────────────────────────────────────────────
+const rules = program.command("rules").description("Manage canonical rules store (.nax/rules)");
+
+rules
+  .command("lint")
+  .description("Validate canonical rules neutrality/frontmatter (root + package overlays)")
+  .option("-d, --dir <path>", "Project directory", process.cwd())
+  .action(async (options) => {
+    let workdir: string;
+    try {
+      workdir = validateDirectory(options.dir);
+    } catch (err) {
+      console.error(chalk.red(`Invalid directory: ${(err as Error).message}`));
+      process.exit(1);
+      return;
+    }
+    try {
+      await rulesLintCommand({ dir: workdir });
+    } catch (err) {
+      console.error(chalk.red(`Error: ${(err as Error).message}`));
+      process.exit(1);
+    }
+  });
+
+rules
+  .command("export")
+  .description("Export canonical rules to an agent shim file (CLAUDE.md / AGENTS.md / GEMINI.md)")
+  .requiredOption("-a, --agent <id>", "Target agent (claude|codex|gemini|cursor)")
+  .option("-d, --dir <path>", "Project directory", process.cwd())
+  .option("--dry-run", "Preview output without writing", false)
+  .action(async (options) => {
+    let workdir: string;
+    try {
+      workdir = validateDirectory(options.dir);
+    } catch (err) {
+      console.error(chalk.red(`Invalid directory: ${(err as Error).message}`));
+      process.exit(1);
+      return;
+    }
+    try {
+      await rulesExportCommand({
+        dir: workdir,
+        agent: options.agent,
+        dryRun: options.dryRun,
+      });
+    } catch (err) {
+      console.error(chalk.red(`Error: ${(err as Error).message}`));
+      process.exit(1);
+    }
+  });
+
+rules
+  .command("migrate")
+  .description("Migrate legacy CLAUDE.md + .claude/rules/*.md into .nax/rules/")
+  .option("-d, --dir <path>", "Project directory", process.cwd())
+  .option("-f, --force", "Overwrite existing .nax/rules/* files", false)
+  .option("--dry-run", "Preview output without writing", false)
+  .action(async (options) => {
+    let workdir: string;
+    try {
+      workdir = validateDirectory(options.dir);
+    } catch (err) {
+      console.error(chalk.red(`Invalid directory: ${(err as Error).message}`));
+      process.exit(1);
+      return;
+    }
+    try {
+      await rulesMigrateCommand({
+        dir: workdir,
+        force: options.force,
+        dryRun: options.dryRun,
       });
     } catch (err) {
       console.error(chalk.red(`Error: ${(err as Error).message}`));

--- a/docs/adr/ADR-008-session-lifecycle.md
+++ b/docs/adr/ADR-008-session-lifecycle.md
@@ -1,6 +1,6 @@
 # ADR-008: Session Lifecycle Across All Agent Roles
 
-**Status:** Proposed
+**Status:** Partially superseded by [ADR-011](ADR-011-session-manager-ownership.md) — the per-role *policy* below is retained verbatim; the `keepSessionOpen` *primitive* is replaced by state-machine transitions. See ADR-011 §Mapping for the translation.
 **Date:** 2026-04-14
 **Author:** William Khoo, Claude
 **Supersedes:** ADR-007 (partial — the implementer portion is retained here verbatim; see §6)

--- a/docs/adr/ADR-010-context-engine.md
+++ b/docs/adr/ADR-010-context-engine.md
@@ -152,10 +152,74 @@ Write the assembled bundle to the session scratch directory so subsequent stages
 
 ---
 
+## Post-Acceptance Amendments
+
+The core decisions (D1–D8) have been extended by four amendment specs after this ADR was accepted. Each adds primitives on top of the existing architecture — none reverse a decision above.
+
+### Amendment A — Context pollution prevention (AC-44–49, Accepted 2026-04-17)
+
+Adds three deterministic post-hoc signals to the packer, none of which invoke an LLM:
+
+- **Min-score floor** (`config.context.v2.minScore`, default 0.1) — chunks scoring below threshold are dropped before packing; floor items (static rules, feature context) are exempt.
+- **Staleness flag** (`src/context/engine/staleness.ts`) — age-based + contradiction-based detection annotates chunks with `staleCandidate: true` and multiplies their score by a configured factor (default 0.4). Human removal is still required; the flag surfaces candidates.
+- **Pollution metrics** (`src/context/engine/pollution.ts`) — per-run aggregates (`droppedBelowMinScore`, `staleChunksInjected`, `pollutionRatio`) written to `StoryMetrics.context.pollution`, surfaced in `nax status` when ratio > 0.3.
+
+Effectiveness classification (`src/context/engine/effectiveness.ts`) annotates each chunk post-story as `followed | contradicted | ignored | unknown` based on deterministic signals (agent output, review findings, diff). Ops-facing only — no feedback loop into scoring.
+
+Spec: [SPEC-context-engine-v2-amendments.md](../specs/SPEC-context-engine-v2-amendments.md) §Amendment A.
+
+### Amendment B — Execution-mode stage sequences (AC-50–53, Accepted 2026-04-17)
+
+Adds `planDigestBoost: 1.5` to `STAGE_CONTEXT_MAP` for single-session, tdd-simple, no-test, and batch modes. The prior-stage plan digest's `rawScore` is multiplied by the boost when the stage opts in, giving it competitive footing against fresh provider chunks in scoring/packing. Does not change the digest content or threading mechanism (D4 preserved).
+
+Spec: [SPEC-context-engine-v2-amendments.md](../specs/SPEC-context-engine-v2-amendments.md) §Amendment B.
+
+### Amendment C — Monorepo scoping (AC-54–62, Accepted 2026-04-17)
+
+Introduces dual-workdir resolution in `ContextRequest`:
+
+- **`repoRoot`** (renamed from `workdir`) — absolute path to the git root.
+- **`packageDir`** (new) — absolute path to the story's target package; equals `repoRoot` in non-monorepo projects.
+
+Provider scopes become configurable:
+- `GitHistoryProvider.historyScope: "package" | "repo"` (default `package`)
+- `CodeNeighborProvider.neighborScope: "package" | "repo"` + `crossPackageDepth: 0 | 1 | 2` (defaults `package`, depth 1)
+- `StaticRulesProvider` overlays `<repoRoot>/.nax/rules/` with `<packageDir>/.nax/rules/`; same-filename entries → package wins (AC-57).
+
+`FeatureContextProviderV2` remains repo-scoped (AC-58) — features are cross-cutting. Manifest records both paths (AC-60) for audit.
+
+Spec: [SPEC-context-engine-v2-amendments.md](../specs/SPEC-context-engine-v2-amendments.md) §Amendment C.
+
+### Amendment D — Session Manager ownership (AC-63–78, Accepted 2026-04-18)
+
+Moves session lifecycle out of the adapter into a dedicated `SessionManager`. This is a cross-cutting architectural change with its own ADR; see **[ADR-011](ADR-011-session-manager-ownership.md)** for ownership boundary, 7-state machine, force-terminate (AC-83), handoff semantics, and mapping from ADR-008's `keepSessionOpen` primitive.
+
+Intersection with this ADR: `SessionScratchProvider` now reads `descriptor.scratchDir` from the manager rather than re-deriving it from `(workdir, feature, storyId)`. D4's digest threading continues to work unchanged because digests persist on the descriptor, not the physical session.
+
+Spec: [SPEC-session-manager-integration.md](../specs/SPEC-session-manager-integration.md).
+
+### Additional post-acceptance hardening (not amendment-level)
+
+- **AC-16 unknown provider validation** — `assemble()` throws `CONTEXT_UNKNOWN_PROVIDER_IDS` when a stage config references an unregistered provider. Test-override `request.providerIds` filters silently (intentional; test-only).
+- **AC-19 `nax context inspect`** — CLI manifest formatter ([src/cli/context.ts](../../src/cli/context.ts)).
+- **AC-20 scratch retention** — `purgeStaleScratch()` runs at run completion; retention days configurable.
+- **AC-24 determinism mode** — `request.deterministic: true` excludes providers marked `deterministic: false`.
+- **AC-25 provider cost accounting** — per-provider `costUsd` rolled up into `StoryMetrics.context.providers[*].costUsd`.
+- **AC-41 agent-swap observability** — `ctx.agentFallbacks[]` records every swap hop; surfaced as `StoryMetrics.fallback.hops[]`.
+- **AC-42 cross-agent scratch neutralization** — scratch entries are rewritten to drop agent-specific tooling references before being replayed for a fallback agent ([src/context/engine/scratch-neutralizer.ts](../../src/context/engine/scratch-neutralizer.ts)).
+
+---
+
 ## References
 
 - [SPEC-context-engine-v2.md](../specs/SPEC-context-engine-v2.md) — full implementation spec
+- [SPEC-context-engine-v2-amendments.md](../specs/SPEC-context-engine-v2-amendments.md) — Amendments A–D
+- [SPEC-context-engine-v2-compilation.md](../specs/SPEC-context-engine-v2-compilation.md) — compiled view
+- [SPEC-context-engine-agent-fallback.md](../specs/SPEC-context-engine-agent-fallback.md) — fallback taxonomy + handoff
+- [SPEC-context-engine-canonical-rules.md](../specs/SPEC-context-engine-canonical-rules.md) — canonical rules store design
+- [SPEC-session-manager-integration.md](../specs/SPEC-session-manager-integration.md) — Amendment D mechanism spec
 - [SPEC-feature-context-engine.md](../specs/SPEC-feature-context-engine.md) — v1 spec (superseded for new providers; storage layout unchanged)
 - `src/context/engine/` — implementation
-- `test/unit/context/engine/` — unit tests (473 tests, 26 files)
+- `test/unit/context/engine/` — unit tests (37 files)
 - ADR-007, ADR-008 — session lifecycle decisions that motivated Phase 5.5 availability fallback
+- [ADR-011](ADR-011-session-manager-ownership.md) — session manager ownership (Amendment D)

--- a/docs/adr/ADR-011-session-manager-ownership.md
+++ b/docs/adr/ADR-011-session-manager-ownership.md
@@ -1,0 +1,166 @@
+# ADR-011: Session Manager Ownership
+
+**Status:** Proposed
+**Date:** 2026-04-18
+**Author:** William Khoo, Claude
+**Partially supersedes:** ADR-008 — policy retained, `keepSessionOpen` primitive replaced by state-machine transitions (see §Mapping).
+
+---
+
+## Context
+
+ADR-008 decided *when* a session should stay warm per role (reviewer verdicts are independent, implementer iterations are stateful). That decision is still correct, but its primitive — `keepSessionOpen: boolean` passed from pipeline stage to adapter — has accumulated load it was not designed to carry.
+
+As nax added availability fallback, scratch-based context transfer, crash recovery, and cross-adapter portability (SPEC-context-engine-v2 Amendment D, SPEC-context-engine-agent-fallback, SPEC-session-manager-integration), the adapter has ended up owning:
+
+- Session naming (`buildSessionName()` from `(workdir, feature, storyId, role)`)
+- Session state (sidecar file `acp-sessions.json`, statuses `in-flight` / `open`)
+- Crash detection (sidecar mtime > 2h heuristic)
+- Cleanup policy (`finally` block decides close vs. promote-to-open based on `keepSessionOpen` + success)
+- Force-terminate intent (inferred from error state, not expressed)
+
+Five concrete problems this created, each reproduced in production:
+
+1. **Adapter decides close, pipeline can't override.** `keepSessionOpen` is a hint; the `finally` block still closes on certain error paths. Callers cannot reliably keep a session alive across adapter-level errors that the pipeline would classify as retryable.
+2. **Session state is protocol-specific.** Sidecars are keyed on ACP session names. A Codex or Gemini adapter would need a parallel sidecar format and parallel crash-detection heuristic.
+3. **No stable ID for the pipeline.** `ctx.sessionId` did not exist; every call site recomputed the ACP name. Fallback handoff and audit correlation had no persistent identifier to hang on to.
+4. **Scratch had nowhere to live.** Context-engine v2's `SessionScratchProvider` needs per-session disk state that survives a session close. The adapter owns no such thing.
+5. **Force-terminate was unreachable.** AC-83 requires `session.close({ forceTerminate: true })` for errored sessions, but the adapter's `finally` block has no access to the pipeline-level distinction between "done normally" and "failed terminally" — it only sees exit codes.
+
+The review-oscillation failure from ADR-008 was the canary. Fallback, scratch, and force-terminate are the forcing function.
+
+---
+
+## Decision
+
+Move session *lifecycle* out of the adapter into a dedicated `SessionManager`. The adapter keeps the *physical* session (acpx process, protocol calls). Policy (ADR-008) is preserved but re-expressed as state-machine transitions rather than a boolean flag.
+
+### Ownership boundary
+
+```
+SessionManager  (src/session/manager.ts)     Adapter  (src/agents/acp/adapter.ts)
+─────────────────────────────────────────    ─────────────────────────────────────
+Owns:                                        Owns:
+  - Stable session ID (sess-<uuid>)            - acpx process lifecycle
+  - State machine (7 states)                   - loadSession / createSession
+  - Scratch directory                          - sendPrompt / multi-turn loop
+  - index.json (sidecar replacement)           - token / cost tracking
+  - Close / resume / handoff decisions         - prompt audit
+  - Orphan detection (state-based)             - protocol-level retry on
+  - Agent-agnostic session naming                QUEUE_DISCONNECTED (AC-79)
+
+Does NOT own:                                Does NOT own:
+  - acpx process                               - session lifecycle decisions
+  - protocol-level retry                       - crash detection
+  - prompt audit                               - sidecar files
+```
+
+### State machine (7 states, terminal = COMPLETED | FAILED)
+
+```
+CREATED → RUNNING → { PAUSED | COMPLETED | FAILED | CLOSING }
+PAUSED  → { RESUMING | FAILED }
+RESUMING → { RUNNING | FAILED }
+CLOSING → { COMPLETED | FAILED }
+```
+
+Transitions are validated by the manager (`SESSION_TRANSITIONS` map). Terminal states cannot transition further.
+
+### Mapping ADR-008 policy to new primitives
+
+The per-role policy matrix from ADR-008 maps directly onto state transitions:
+
+| ADR-008 primitive | New primitive |
+|:---|:---|
+| `keepSessionOpen: true` after call | Stage does not transition to COMPLETED; caller may transition to PAUSED for mid-task pause, or leave RUNNING for the next call in the same pipeline |
+| `keepSessionOpen: false` after call | Stage transitions to COMPLETED at end of the call |
+| Reviewer "initial: true / retry: false" | Initial call leaves session RUNNING; JSON-retry transitions to COMPLETED |
+| Rectifier `!isLastAttempt` | All but last attempt leave RUNNING; last transitions to COMPLETED |
+| Escalation (new tier) | Current session transitions to FAILED; manager creates a fresh session for the next tier |
+
+The policy from ADR-008 is preserved verbatim. The change is the encoding: decisions are now explicit state transitions at call sites instead of a boolean the adapter interprets.
+
+### New architectural decisions (not in ADR-008)
+
+1. **Run-level centralization.** One `SessionManager` per run, threaded via `PipelineContext`. Sessions do not persist across runs in Phase 0; `index.json` is rewritten at run start.
+2. **AC-83 force-terminate on FAILED.** Adapter's `closePhysicalSession(handle, workdir, options?: { force?: boolean })` is the only way to hard-terminate. The runtime helper `session-manager-runtime.ts` sets `force = descriptor.state === "FAILED"`.
+3. **Orphan detection via state, not mtime.** `sweepOrphans(ttlMs)` walks `index.json` for sessions in non-terminal states older than TTL. Replaces the sidecar-mtime heuristic. Deterministic and adapter-agnostic.
+4. **Handoff preserves session identity.** `manager.handoff(id, newAgent)` updates the `agent` field but keeps `id`, `handle`, and `scratchDir` stable. The new agent inherits scratch history (with cross-agent neutralization, AC-42). Supports availability fallback without losing story context.
+5. **Explicit fail-and-close at point of terminal failure.** Because `listActive()` excludes terminal sessions, a failed session must be physically closed at the moment of transition — teardown will not see it. The `failAndClose(sessionManager, sessionId, agentGetFn)` helper performs transition + force-close atomically.
+
+---
+
+## Alternatives Considered
+
+### A. Extend the adapter's sidecar with more fields
+
+Keep adapter ownership; add `state`, `failure`, `scratchDir` columns to `acp-sessions.json`. **Rejected** — still protocol-specific; does not solve cross-adapter portability or run-level state queries. Every new adapter re-implements the same state machine.
+
+### B. Thread `keepSessionOpen` plus a `markFailed` flag
+
+Minimal change: add a `forceClose: boolean` parameter to `agent.run()`, let the adapter continue to own the rest. **Rejected** — does not address scratch ownership, handoff, or crash detection. Papers over symptoms.
+
+### C. Manager owns everything including physical session
+
+Push acpx process management into the manager. **Rejected** — the manager becomes protocol-aware, defeating the separation. Adapters are per-protocol for a reason (acpx vs. CLI vs. future OpenAI-native).
+
+### D. Use sidecar mtime for orphan detection (retain from old design)
+
+Keep the `>2h` mtime heuristic. **Rejected** — the failure mode in ADR-008's review oscillation surfaced because crashes within the window were invisible. State-based detection is strictly more accurate. Storage cost of `lastActivityAt` ISO timestamp is negligible.
+
+### E. Let `closeStory()` also return already-FAILED sessions for physical close
+
+Instead of `failAndClose` doing inline close, have `closeStory()` include terminal sessions in its return list so teardown handles them. **Rejected** — muddies the contract (`closeStory` returns "sessions closed by this call" vs. "sessions needing cleanup"). Inline close is more direct: the session is dead; release the handle now.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Adapter stays thin.** Codex / Gemini adapters implement `run()`, `complete()`, `closePhysicalSession()`, and `deriveSessionName()`. No state machine, no sidecar, no crash heuristic.
+- **Pipeline has a stable handle.** `ctx.sessionId` is constant across a story; audits, metrics, scratch, and handoff all hang on it.
+- **Availability fallback works.** Handoff preserves `scratchDir` and session identity; the new agent picks up from where the old agent left off.
+- **Force-terminate is reachable.** Explicit transition to FAILED + `failAndClose` guarantees AC-83 fires. Previously unreachable (see SPEC-session-manager review H-1).
+- **Orphan detection is deterministic.** State-based; no mtime races.
+
+### Negative / Trade-offs
+
+- **Two layers of cleanup.** A failed session is physically closed at the point of failure (`failAndClose`), AND run-completion teardown runs `closeAllRunSessions()`. The second is a no-op for already-FAILED sessions but must be correct under that assumption. Documented; tested.
+- **`keepSessionOpen` removal is a breaking change to `AgentRunOptions`.** Migration: old callers keep passing the flag during Phase 0 dual-write; it is ignored when a `session: SessionDescriptor` is present. Phase 5.5 removes the old parameter entirely. Captured in SPEC-session-manager-integration Interface Changes.
+- **State machine is enforceable but not enforced everywhere yet.** Only `CREATED → RUNNING` and implicit `RUNNING → COMPLETED` (via `closeStory`) are wired on main. The explicit `RUNNING → FAILED` transition is new in the H-1 fix. `PAUSED` / `RESUMING` are spec'd but not consumed by any call site yet (Phase 1+).
+
+### Scope of Changes
+
+| File | Change |
+|:---|:---|
+| `src/session/manager.ts` | New file — `SessionManager` class, 7-state machine |
+| `src/session/types.ts` | `SessionState`, `SessionRole`, `SessionDescriptor`, `ISessionManager` |
+| `src/session/scratch-purge.ts` | `purgeStaleScratch()` — AC-20 retention |
+| `src/execution/session-manager-runtime.ts` | `closeStorySessions`, `closeAllRunSessions`, `failAndClose` — orchestration helpers outside the manager to avoid protocol coupling |
+| `src/execution/runner.ts` | Creates the single `SessionManager` per run; threaded via `PipelineContext` |
+| `src/execution/lifecycle/run-completion.ts` | Calls `closeAllRunSessions` + `purgeStaleScratch` at run end |
+| `src/agents/types.ts` | `AgentRunOptions.session?: SessionDescriptor`; `AgentAdapter.closePhysicalSession(handle, workdir, options?: { force?: boolean })`; `AgentAdapter.deriveSessionName(descriptor)` |
+| `src/agents/acp/adapter.ts` | Uses `session` descriptor when present; legacy path retained during Phase 0 dual-write |
+| `src/pipeline/stages/execution.ts` | `CREATED → RUNNING` on start; `failAndClose` on terminal failure |
+| `src/pipeline/types.ts` | `PipelineContext.sessionManager`, `ctx.sessionId` |
+| `docs/adr/ADR-008-session-lifecycle.md` | Mark as "partially superseded by ADR-011; policy retained, primitive replaced" |
+
+### Not Changed
+
+- ADR-008's per-role policy matrix (kept verbatim — see §Mapping).
+- Adversarial vs. semantic reviewer session reset rules (still one reviewer session per `runReview()` call chain, closes by end of call).
+- Implementer session continuity across TDD → autofix → rectification (ADR-007 rules carried into ADR-008 §6 still apply).
+- `complete()` one-shot call sites — no session lifecycle concept applies.
+
+---
+
+## References
+
+- ADR-008 — session lifecycle policy (partially superseded by this ADR)
+- SPEC-session-manager-integration.md — mechanism spec (interface changes, migration phases)
+- SPEC-context-engine-v2-amendments.md Amendment D — motivating requirement (scratch, handoff, protocol IDs)
+- SPEC-context-engine-agent-fallback.md — AC-42 scratch neutralization, AC-83 force-terminate
+- `src/execution/session-manager-runtime.ts` — `failAndClose` implementation (H-1 fix)
+- `docs/reviews/context-engine-v2-deep-review-2026-04-18.md` — H-1 finding that surfaced the missing FAILED transition
+- `.claude/rules/adapter-wiring.md` — session role registry

--- a/docs/reviews/context-engine-review-followups-2026-04-17.md
+++ b/docs/reviews/context-engine-review-followups-2026-04-17.md
@@ -1,0 +1,112 @@
+# Context Engine Review Follow-ups — Fix Branch
+
+Date: 2026-04-17  
+Branch: `fix/context-engine-review-followups-2026-04-17`
+
+## Scope
+
+Follow-up fixes applied after review findings from:
+
+- `docs/reviews/today-commits-code-review-2026-04-17.md`
+- `docs/reviews/context-engine-v2-final-review-2026-04-17.md`
+
+## Implemented Fixes
+
+### 1. Fallback execution wiring and handoff
+
+- Multi-hop fallback traversal is now implemented in execution stage (tries next candidate when one swap fails).
+- Rebuilt swap context is injected into retry prompt.
+- Session handoff is persisted via `SessionManager.handoff(...)`.
+- Protocol IDs are rebound after fallback attempts.
+
+Files:
+
+- `src/pipeline/stages/execution.ts`
+- `src/session/manager.ts`
+- `src/session/types.ts`
+
+### 2. Canonical rules loader/spec parity improvements
+
+- Canonical loader now supports:
+  - `.nax/rules/*.md` and one-level nested files (`.nax/rules/*/*.md`)
+  - YAML frontmatter parsing for `priority` and `appliesTo`
+  - malformed frontmatter failure (`RULES_FRONTMATTER_INVALID`)
+  - line-level linter overrides via `<!-- nax-rules-allow: <rule-id> -->`
+- Added rule metadata (id/path/tokens/priority/appliesTo).
+- Rules are ordered by `priority` then id/path deterministically.
+
+Files:
+
+- `src/context/rules/canonical-loader.ts`
+
+### 3. Static rules provider wiring
+
+- Canonical rules are now filtered by `appliesTo` against `request.touchedFiles`.
+- Monorepo overlay now keys by canonical rule id (package override behavior retained).
+- Legacy mode now loads full legacy set:
+  - root shims (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`)
+  - `.claude/rules/**/*.md`
+  - no longer “first file only”.
+
+Files:
+
+- `src/context/engine/providers/static-rules.ts`
+
+### 4. Structured adapter failure classification (no free-text keyword inference)
+
+- `parseAgentError` now classifies from structured signals only:
+  - JSON fields (`type`, `statusCode`, `code`, `acpxCode`, `detailCode`)
+  - bracketed code suffixes
+  - explicit key/value code pairs
+- Free-text phrase inference is intentionally removed.
+
+Files:
+
+- `src/agents/acp/parse-agent-error.ts`
+
+### 5. `availableBudgetTokens` propagation from call sites
+
+- Added estimator and threaded `availableBudgetTokens` into `ContextRequest` in:
+  - context stage
+  - stage assembler
+
+Files:
+
+- `src/context/engine/available-budget.ts`
+- `src/pipeline/stages/context.ts`
+- `src/context/engine/stage-assembler.ts`
+
+## Tests Updated / Added
+
+- Canonical loader tests for nested loading, frontmatter, overrides, and malformed frontmatter.
+- Static rules tests for `appliesTo` filtering and full legacy set loading.
+- ACP parse tests rewritten for structured classification behavior.
+- ACP adapter tests updated to use structured rate-limit inputs.
+- Stage/context tests updated to assert `availableBudgetTokens` propagation.
+- Existing fallback/session tests retained for handoff + multi-hop flow.
+
+## Verification
+
+Executed:
+
+```bash
+bun test test/unit/context/rules/canonical-loader.test.ts \
+  test/unit/context/engine/providers/static-rules.test.ts \
+  test/unit/context/engine/providers/static-rules-legacy-default.test.ts \
+  test/unit/agents/acp/parse-agent-error.test.ts \
+  test/unit/agents/acp/adapter.test.ts \
+  test/unit/agents/acp/adapter-run.test.ts \
+  test/unit/agents/acp/adapter-failure.test.ts \
+  test/unit/context/engine/stage-assembler.test.ts \
+  test/unit/pipeline/stages/context-digest.test.ts
+
+bun run typecheck
+bun run lint
+```
+
+Result: passing.
+
+## Remaining Larger Items (Not Fully Closed Here)
+
+- Full run-level centralized SessionManager ownership (startup/shutdown sweep + complete lifecycle ownership) is still larger-scope work.
+- Some broader spec acceptance items outside these targeted fixes may still require separate follow-up slices.

--- a/docs/reviews/context-engine-review-followups-2026-04-17.md
+++ b/docs/reviews/context-engine-review-followups-2026-04-17.md
@@ -108,5 +108,5 @@ Result: passing.
 
 ## Remaining Larger Items (Not Fully Closed Here)
 
-- Full run-level centralized SessionManager ownership (startup/shutdown sweep + complete lifecycle ownership) is still larger-scope work.
+- ~~Full run-level centralized SessionManager ownership (startup/shutdown sweep + complete lifecycle ownership) is still larger-scope work.~~ **Landed** in `85de63ee` (centralize at run level), `a5adc21d` (close on shutdown/completion), `15620b9b` (terminal outcomes only).
 - Some broader spec acceptance items outside these targeted fixes may still require separate follow-up slices.

--- a/docs/reviews/context-engine-v2-deep-review-2026-04-18.md
+++ b/docs/reviews/context-engine-v2-deep-review-2026-04-18.md
@@ -1,0 +1,188 @@
+# Deep Code Review — Context Engine v2 + Session Manager Integration
+
+**Branch:** `fix/context-engine-review-followups-2026-04-17`
+**Base commit:** `f7f41d42cda59ed4466081e851c43d650b26d2c5`
+**Reviewed:** 2026-04-18
+**Scope:** 43 commits, 133 files changed, +10,863 / −1,564 lines
+
+**Specs covered:**
+1. [SPEC-context-engine-v2.md](../specs/SPEC-context-engine-v2.md) (AC-1 … AC-43)
+2. [SPEC-context-engine-v2-amendments.md](../specs/SPEC-context-engine-v2-amendments.md) (Amendments A–D, AC-44 … AC-78)
+3. [SPEC-context-engine-v2-compilation.md](../specs/SPEC-context-engine-v2-compilation.md) (compilation view)
+4. [SPEC-context-engine-agent-fallback.md](../specs/SPEC-context-engine-agent-fallback.md) (AC-1 … AC-18)
+5. [SPEC-context-engine-canonical-rules.md](../specs/SPEC-context-engine-canonical-rules.md) (AC-1 … AC-20)
+6. [SPEC-session-manager-integration.md](../specs/SPEC-session-manager-integration.md) (AC-79 … AC-83 + state machine)
+
+**Methodology:** Three parallel AC-by-AC audits + targeted manual verification of claims that looked wrong (rules export, purge wiring, FAILED transition, metrics events, credentials validation, retry loop).
+
+---
+
+## Executive Summary
+
+| Spec | ACs | Wired | Partial | Missing | Deferred |
+|------|-----|-------|---------|---------|----------|
+| v2 (AC-1 … AC-43) | 43 | 40 | 2 | 0 | 1 |
+| Amendments A–D (AC-44 … AC-78) | 35 | 30 | 4 | 0 | 1 |
+| Agent fallback (AC-1 … AC-18) | 18 | 14 | 2 | 2 | 0 |
+| Canonical rules (AC-1 … AC-20) | 20 | 19 | 0 | 0 | 1 |
+| Session manager (AC-79 … AC-83 + state) | ~10 | 6 | 3 | 0 | 1 |
+
+**Overall completeness: ~88% wired, 10% partial, 2% missing.**
+
+### Verdict
+
+The branch is **substantially complete** and ready for merge, with three concrete gaps worth tracking as follow-up tickets (not merge blockers). Previous review passes (`today-commits-code-review-2026-04-17.md`, `context-engine-v2-final-review-2026-04-17.md`, `context-engine-v2-session-manager-review-2026-04-18.md`) have already closed the CRITICAL and HIGH findings from the first three review iterations.
+
+The subsystems most heavily exercised (orchestrator, canonical loader, static rules, agent-swap loop, close-session lifecycle) are well-covered by tests and wired correctly.
+
+---
+
+## Wiring Verification Spot Checks
+
+The Explore agents flagged several items as "missing" that turned out to be wired. These are the ground-truth findings:
+
+| Claim | Agent verdict | Actual state | Evidence |
+|-------|---------------|--------------|----------|
+| AC-30 `nax rules export` missing | v2 agent said missing | **Wired** | [src/cli/rules.ts:95-173](../../src/cli/rules.ts#L95-L173) (`rulesExportCommand`, `AGENT_SHIM_FILES` registry for claude + codex) |
+| AC-31 `allowLegacyClaudeMd` flag missing | v2 agent said not found | **Wired** | [src/config/schemas.ts](../../src/config/schemas.ts), [src/context/engine/providers/static-rules.ts](../../src/context/engine/providers/static-rules.ts), [src/context/engine/orchestrator-factory.ts:42](../../src/context/engine/orchestrator-factory.ts#L42) |
+| AC-20 `purgeStaleScratch` not wired to lifecycle | v2 agent said unclear | **Wired** | [src/execution/lifecycle/run-completion.ts:255](../../src/execution/lifecycle/run-completion.ts#L255) calls `purgeStaleScratch(...)` on run completion |
+| AC-41 fallback observability missing | fallback agent said missing | **Wired (divergent shape)** | Spec says `metrics.events.push({ type: "agent.fallback.triggered", ... })`. Implementation uses structured `StoryMetrics.fallback.hops[]` via `AgentFallbackHop` in [src/metrics/types.ts:76](../../src/metrics/types.ts#L76), populated at [src/pipeline/stages/execution.ts:307-308](../../src/pipeline/stages/execution.ts#L307-L308), surfaced at [src/metrics/tracker.ts:172](../../src/metrics/tracker.ts#L172) |
+| AC-3 rate-limit retry not wired | fallback agent said partial | **Wired** | `retryAfterSeconds` parsed at [src/agents/acp/parse-agent-error.ts:57](../../src/agents/acp/parse-agent-error.ts#L57); honoured in adapter retry loop at [src/agents/acp/adapter.ts:552,592,1046](../../src/agents/acp/adapter.ts) |
+| AC-83 force-terminate | session agent said wired | **Wired** | [src/agents/types.ts:305](../../src/agents/types.ts#L305) signature with `options?: { force?: boolean }`; [src/execution/session-manager-runtime.ts:37,68](../../src/execution/session-manager-runtime.ts) sets `force = descriptor.state === "FAILED"` |
+
+---
+
+## Confirmed Gaps (sorted by severity)
+
+### HIGH
+
+#### H-1 — Session is never explicitly transitioned to `FAILED`
+
+**Spec:** SPEC-session-manager-integration.md §State machine says sessions move `RUNNING → FAILED` on a retriable failure, or `RUNNING → CLOSING → FAILED`.
+
+**Actual behaviour:** The only explicit transitions in the codebase are:
+- `CREATED → RUNNING` ([src/pipeline/stages/execution.ts:153](../../src/pipeline/stages/execution.ts#L153))
+- `RUNNING → COMPLETED` via [src/session/manager.ts:266](../../src/session/manager.ts#L266) inside `closeStory()` (unconditionally, for any non-terminal session)
+
+Failed stories are indistinguishable from successful stories in the final session state — both end up as `COMPLETED`. This breaks the audit trail and the force-terminate path: `session-manager-runtime.ts` checks `descriptor.state === "FAILED"` to decide whether to pass `force: true` to `closePhysicalSession`, but no code path ever sets `FAILED` on a live session.
+
+**Impact:** Real behaviour gap with concrete downstream effects:
+- AC-83 force-terminate never fires in practice (state is always `RUNNING` or `COMPLETED` at close time)
+- Orphan sweep / resume paths relying on `FAILED` marker won't see failed sessions
+- Metrics consumers of `SessionDescriptor.state` are misled
+
+**Remediation:** Add an explicit `FAILED` transition in the execution stage when `AgentResult.success === false` and/or `adapterFailure.category === "availability"` is terminal after fallback exhaustion. Roughly:
+
+```typescript
+// src/pipeline/stages/execution.ts, after agent.run()
+if (!result.success && ctx.sessionManager && ctx.sessionId) {
+  ctx.sessionManager.transition(ctx.sessionId, "FAILED", { reason: result.adapterFailure?.outcome });
+}
+```
+
+#### H-2 — Fallback credentials validation not performed at run start
+
+**Spec:** SPEC-context-engine-agent-fallback.md §Runner behaviour — "A fallback candidate configured in the map but missing credentials is logged as a warning and removed from the runtime map."
+
+**Actual:** No credential pre-validation. Missing API keys surface only at first swap attempt, causing a runtime adapter error instead of a clean startup warning.
+
+**Impact:** Operators can configure `fallbackMap: { claude: ["codex"] }` without `CODEX_API_KEY` set; the run proceeds normally until a swap is attempted, then the swap itself fails (double-failure). Not a correctness gap — the fallback loop still exhausts correctly — but an ergonomics / observability gap.
+
+**Remediation:** Add a validation pass in `runSetupPhase()` that reads the fallback map, checks credential availability per agent, logs warnings for misconfigured targets, and prunes them from the runtime map.
+
+### MEDIUM
+
+#### M-1 — `fallback.discardPartialWork` config option not implemented
+
+**Spec:** SPEC-context-engine-agent-fallback.md §11 — "`fallback.discardPartialWork: true` (default false) runs `git restore .` on fallback so the new agent starts clean."
+
+**Actual:** Not in schema ([src/config/schemas.ts](../../src/config/schemas.ts) `ContextV2FallbackConfigSchema`) or runtime types. No call site references it. Partial work is preserved unconditionally.
+
+**Impact:** Low operational impact — default (false) is the current behaviour — but operators cannot opt in to the "clean slate" policy the spec offers.
+
+#### M-2 — `handoff()` does not transition state to `HANDED_OFF`
+
+**Spec:** SPEC-session-manager-integration.md — sessions that are handed off to a fallback agent move to a `HANDED_OFF` state (listed in the target state enum).
+
+**Actual:** [src/session/manager.ts:214-239](../../src/session/manager.ts#L214-L239) updates `agent` and `lastActivityAt` but leaves `state` unchanged (typically `RUNNING`). Spec notes this state "may be deferred"; the branch acknowledges this in `docs/reviews/context-engine-v2-session-manager-review-2026-04-18.md` as deferred.
+
+**Impact:** Audit trail is weaker — callers cannot distinguish a running session from a session that was handed off mid-pipeline. Same dynamic as H-1: state field loses fidelity.
+
+#### M-3 — Fallback observability diverges from spec shape
+
+**Spec:** SPEC-context-engine-agent-fallback.md §14 calls for `metrics.events.push({ type: "agent.fallback.triggered", storyId, priorAgent, newAgent, outcome, category, hop })` with a run-summary section listing counts and exhaustion lists.
+
+**Actual:** Structured-per-story form ([src/metrics/types.ts:76](../../src/metrics/types.ts#L76) `AgentFallbackHop` → `StoryMetrics.fallback.hops[]`). Data content matches 1:1; format is an array per story rather than a run-level event stream.
+
+**Impact:** Downstream consumers that grep for `agent.fallback.triggered` won't find anything. Run-summary aggregation (exhaustion list, counts per agent) not implemented. Data is recoverable by walking per-story metrics, but not pre-aggregated.
+
+**Remediation (optional):** Add a run-completion pass that derives the per-run aggregates from `storyMetrics[].fallback.hops[]` and surfaces them in the final run summary.
+
+### LOW / DEFERRED
+
+- **Canonical rules dogfood (AC-19 of canonical-rules spec):** nax project has not migrated its own `.claude/rules/` to `.nax/rules/`. Process item, not a code gap.
+- **AC-52 no-test rectify scope:** Stage config correct; no integration test specifically verifies that no-test mode rectify reads only review findings (not verify output). Gap in test coverage, not behaviour.
+- **Per-package config integration test:** AC-59 relies on existing config merge logic with no dedicated integration test exercising a real monorepo layout (packages/api, packages/web).
+
+---
+
+## Verified Correct Wiring (sampled, not exhaustive)
+
+These are items I independently verified because they were either recent fixes or frequently mis-audited in previous reviews.
+
+| AC | Title | Evidence |
+|----|-------|----------|
+| AC-16 | Unknown provider ID validation scoped to `stageConfig.providerIds` only | [src/context/engine/orchestrator.ts:237-260](../../src/context/engine/orchestrator.ts#L237-L260); `request.providerIds` (test override) deliberately filters silently |
+| AC-19 | `nax context inspect` CLI | [src/cli/context.ts](../../src/cli/context.ts) with `formatContextInspect()`; tested in [test/unit/cli/context.test.ts](../../test/unit/cli/context.test.ts) |
+| AC-25 | Provider cost accounting | [test/unit/metrics/tracker-provider-cost.test.ts](../../test/unit/metrics/tracker-provider-cost.test.ts) (226 lines) |
+| AC-41 | Agent-swap per-hop metrics | Populated at [src/pipeline/stages/execution.ts:307-308](../../src/pipeline/stages/execution.ts#L307-L308), surfaced via `StoryMetrics.fallback.hops[]` |
+| AC-42 | Cross-agent scratch neutralization | [src/context/engine/scratch-neutralizer.ts](../../src/context/engine/scratch-neutralizer.ts); tests in [test/unit/context/engine/scratch-neutralizer.test.ts](../../test/unit/context/engine/scratch-neutralizer.test.ts) |
+| AC-51 | planDigestBoost single-session modes | [test/unit/context/engine/orchestrator-plan-digest-boost.test.ts](../../test/unit/context/engine/orchestrator-plan-digest-boost.test.ts) |
+| AC-54 / 60 / 61 | Dual workdir (`repoRoot` + `packageDir`) in `ContextRequest` + manifest | [src/context/engine/types.ts](../../src/context/engine/types.ts), manifest fields verified |
+| AC-55 | `GitHistoryProvider` historyScope option | [src/context/engine/providers/git-history.ts](../../src/context/engine/providers/git-history.ts) |
+| AC-56 / 62 | `CodeNeighborProvider` neighborScope + crossPackageDepth | [src/context/engine/providers/code-neighbor.ts](../../src/context/engine/providers/code-neighbor.ts) |
+| AC-57 | Per-package canonical rules overlay | [src/context/engine/providers/static-rules.ts](../../src/context/engine/providers/static-rules.ts) with package-wins same-name merge |
+| Amendment A AC-44–49 | Min-score / staleness / contradiction / pollution metrics | [src/context/engine/pollution.ts](../../src/context/engine/pollution.ts), [src/context/engine/staleness.ts](../../src/context/engine/staleness.ts), [src/context/engine/effectiveness.ts](../../src/context/engine/effectiveness.ts) |
+| Canonical rules AC-1–6 | Loader, neutrality linter, frontmatter, budget truncation | [src/context/rules/canonical-loader.ts](../../src/context/rules/canonical-loader.ts) |
+| Canonical rules AC-11–16 | Export + migrate CLI | [src/cli/rules.ts](../../src/cli/rules.ts) |
+| AC-83 | Force-terminate on FAILED | See H-1 note above re: it currently never fires because FAILED is never set |
+| Session idempotency | Repeated `closeAllRunSessions()` calls are a no-op | [test/unit/execution/session-manager-runtime.test.ts:108-124](../../test/unit/execution/session-manager-runtime.test.ts#L108-L124) |
+| Fallback exhaustion → escalate | Multi-hop fallback exhausts then returns `{ action: "escalate" }` | [test/integration/execution/agent-swap.test.ts](../../test/integration/execution/agent-swap.test.ts) |
+
+---
+
+## Test & Build Health
+
+| Check | Result |
+|-------|--------|
+| `bun run typecheck` | Clean |
+| `bun run lint` | 441 files, no issues |
+| `bun run test:unit` | 6274 pass / 0 fail / 13 skip |
+| `bun run test:integration` | 1187 pass / 0 fail / 39 skip |
+
+No snapshot drift, no flakiness observed across runs.
+
+---
+
+## Comparison to Prior Review Iterations
+
+| Review file | Date | Findings status |
+|-------------|------|-----------------|
+| `today-commits-code-review-2026-04-17.md` | 2026-04-17 | Closed in commit `59097685` |
+| `context-engine-v2-final-review-2026-04-17.md` | 2026-04-17 | Closed in commit `88f22c1d` |
+| `context-engine-review-followups-2026-04-17.md` | 2026-04-17 | All items landed |
+| `context-engine-v2-session-manager-review-2026-04-18.md` | 2026-04-18 | CRIT-1 / H-1 / H-4 / H-5 / MINORs closed in commits `2fc2ad49`, `d8bb51d5`, `f3bae3f3` |
+
+The branch has undergone four review passes. Each pass has landed its findings before the next pass was written.
+
+---
+
+## Recommendation
+
+**Merge-ready**, with the following three items opened as follow-up tickets (none block the current branch):
+
+1. **H-1 (FAILED state transition):** Highest priority because it directly affects AC-83 effectiveness. ~10 lines in `execution.ts`. Worth doing before the next release.
+2. **H-2 (Fallback credentials validation at run start):** Ergonomics, not correctness. Fit for a small standalone PR.
+3. **M-3 (Run-summary fallback aggregates):** Improves observability surface. Can piggy-back on the next metrics-export change.
+
+The deferred items (HANDED_OFF state, dogfood migration, no-test rectify integration test) are called out in prior review docs and do not need re-tracking here.

--- a/docs/reviews/context-engine-v2-final-review-2026-04-17.md
+++ b/docs/reviews/context-engine-v2-final-review-2026-04-17.md
@@ -1,0 +1,423 @@
+# Context Engine v2 — Final Code Review
+
+**Date:** 2026-04-17
+**Reviewer:** code-reviewer agent (Opus 4.7 1M)
+**Scope:** All context-engine commits from 2026-04-10 through 2026-04-17
+**Verdict:** **Block until CRITICAL + HIGH items are resolved.**
+
+## Summary
+
+Opus-1M review of the v2 context engine (commits `9457c120` … `5937b721`). Implementation
+is broadly on-spec and test coverage is substantive. However there are several
+**ship-blocking** issues:
+
+- AC-24 (determinism) and AC-51 (planDigestBoost) do not flow through most stages.
+- AC-41 (fallback observability metric) is entirely missing.
+- A **path-traversal vulnerability** exists in `CodeNeighborProvider` / `GitHistoryProvider`
+  reading user-supplied `touchedFiles`.
+- A silent error-swallow in effectiveness annotation hides real bugs.
+
+## Commits Reviewed
+
+| SHA | Subject |
+|:----|:--------|
+| `5937b721` | feat(context-engine): AC-42 cross-agent scratch neutralization |
+| `c0767776` | feat(context-engine): Amendment A — context pollution prevention (AC-45/46/47/48/49) |
+| `0a07f626` | feat(context-engine): Amendment B AC-51 — planDigestBoost |
+| `14d6b84e` | feat(context-engine): AC-25 provider cost accounting (#499) |
+| `421b392d` | feat(context-engine): AC-24 determinism mode (#498) |
+| `536c2ea7` | feat(cli): AC-19 nax context inspect (#497) |
+| `6d67c000` | feat(session): AC-20 session scratch retention (#496) |
+| `cbfaf4f3` | feat(metrics): AC-18 context.providers metrics (#495) |
+| `8b877fb4` | fix(context-engine): #479 post-review fixes — AC-62 workspace |
+| `e28ed70a` | feat(context-engine): AC-56/AC-62 CodeNeighborProvider |
+| `5e3b69f7` | feat(context-engine): AC-55 GitHistoryProvider historyScope |
+| `0b2d8536` | feat(context-engine): AC-57 per-package canonical rules (#490) |
+| `9457c120` | feat(context-engine): Amendment C AC-54/AC-60/AC-61 |
+
+---
+
+## CRITICAL (must fix before shipping v2)
+
+### C1. Path traversal via `touchedFiles` → arbitrary file read
+
+**File:** `src/context/engine/providers/code-neighbor.ts:167-168`
+(and `src/context/engine/providers/git-history.ts` equivalent call site)
+
+`collectNeighbors()` does `Bun.file(join(workdir, filePath)).exists()` and `.text()`
+with `filePath` coming straight from `request.touchedFiles`, which in turn comes
+from story `contextFiles` in the PRD. The PRD schema validator
+(`src/prd/schema.ts:200-204`) does **not** reject `..` or absolute paths for
+`contextFiles` (it does reject them for `workdir` at line 195).
+
+An LLM-generated or attacker-influenced PRD with
+`contextFiles: ["../../../etc/passwd"]` will read arbitrary files and echo
+fragments of their content into the neighbor chunk — and into the persisted
+context manifest.
+
+**Fix (both places):**
+- In `src/prd/schema.ts` apply the same `..`/absolute-path guard to `contextFiles` entries.
+- In `code-neighbor.ts` and `git-history.ts`, call a shared
+  `validateRelativePath(filePath, workdir)` helper and drop entries that escape
+  `workdir` before any `fs` / `Bun.file` / `git --` call.
+
+**Follow-up issue:** Create immediately. Label: `security`, `ship-blocker`.
+
+---
+
+## HIGH (ship-blocking quality issues)
+
+### H1. AC-24 determinism does not reach most stages
+
+**File:** `src/context/engine/stage-assembler.ts:160-184`
+
+`pipeline/stages/context.ts:131` sets `deterministic: ctx.config.context.v2.deterministic`,
+but `stage-assembler.ts` — used by `execution`, `tdd-test-writer`, `tdd-implementer`,
+`verify`, `rectify`, `review-*`, `acceptance` — does **not** pass `deterministic`
+on the `ContextRequest`. The orchestrator's `deterministic` filter at
+`orchestrator.ts:230-233` therefore only engages for the initial `context` stage.
+
+AC-24 says "two runs with identical inputs produce identical push blocks"; that
+guarantee does not hold across the rest of the pipeline.
+
+**Fix:** add `deterministic: ctx.config.context.v2.deterministic` to the
+`ContextRequest` in `assembleForStage()`.
+
+### H2. AC-51 `planDigestBoost` also not propagated from stage-assembler
+
+**File:** Same as H1 — `stage-assembler.ts:160-184`
+
+`planDigestBoost` is set only in `pipeline/stages/context.ts:134` (reading
+`ctx.routing?.testStrategy`). For stages re-assembled via `stage-assembler.ts`
+(execution / single-session / tdd-simple / no-test / batch / rectify) the
+orchestrator never sees `planDigestBoost`, so the boost chunk is only injected
+on the first assemble (the `context` stage). Tests only cover the orchestrator
+path, not the stage-assembler integration.
+
+**Fix:** in `assembleForStage()` look up `getStageContextConfig(stage).planDigestBoost`
+and pass it on the request.
+
+### H3. AC-41 — `context.fallback.triggered` metric never emitted
+
+**Files:** `src/execution/escalation/agent-swap.ts`, `src/metrics/tracker.ts`
+
+A repo-wide grep for `fallback.triggered` or any equivalent structured metric
+returns nothing. AC-41 mandates emission of
+`{ storyId, priorAgent, newAgent, outcome, category, hop }`. Without this,
+fallback behaviour cannot be observed in run summaries (the second half of AC-41
+is also unmet). `StoryMetrics` has no `fallback` field.
+
+**Fix:** emit the event from `rebuildForSwap()` (or the caller in `execution.ts`)
+and add a field to `RunMetrics` / `StoryMetrics` so the run summary can surface
+fallback counts.
+
+### H4. Effectiveness annotation silently swallows errors
+
+**File:** `src/context/engine/effectiveness.ts:197-204`
+
+```typescript
+try { … } catch { /* Best-effort — non-fatal */ }
+```
+
+No logging. A JSON-parse bug, write-permission issue, or schema drift will make
+every manifest appear un-annotated forever and no operator will ever know.
+Downstream consequence: pollution metrics silently report zero.
+
+**Fix:**
+
+```typescript
+logger.warn("effectiveness", "Failed to annotate manifest", {
+  storyId,
+  path: item.path,
+  error: errorMessage(err),
+});
+```
+
+### H5. `historyScope` / `neighborScope` / `crossPackageDepth` not exposed via config
+
+**Files:**
+- `src/context/engine/providers/git-history.ts:92-96`
+- `src/context/engine/providers/code-neighbor.ts:265-271`
+- `src/context/engine/orchestrator-factory.ts:50-51`
+
+The provider constructors accept these options but the factory instantiates both
+with no options, and there are zero references to any of these strings in
+`src/config/`. Whatever the user sets in config cannot influence behaviour.
+AC-55 / AC-56 / AC-62 list these as configurable. Defaults happen to satisfy the
+ACs today, but swapping to `"repo"` is impossible without code changes —
+partial AC.
+
+**Fix:** add fields to `ContextV2Config` schema, thread them through the
+factory — or document that these are constants and downgrade the spec.
+
+### H6. AC-27 agent profile registry missing 3 of 5 built-ins
+
+**File:** `src/context/engine/agent-profiles.ts:92-115`
+
+Only `claude` and `codex` are registered. AC-27 names `claude`, `codex`,
+`gemini`, `cursor`, `local`. The comment at line 90 acknowledges "Phase 8 adds
+gemini, cursor, local" — but the AC is in the v2 spec, not Phase 8. Either
+implement the three missing profiles, or amend the spec. As shipped, three of
+the named agents silently degrade to the conservative default profile.
+
+---
+
+## MEDIUM (worth a follow-up issue)
+
+### M1. AC-42 neutralization partial — `verify-result.rawOutputTail` not neutralized
+
+**File:** `src/context/engine/providers/session-scratch.ts:75-82`
+
+Only the `tdd-session` branch (line 91) neutralizes `outputTail`.
+`verify-result.rawOutputTail` is a Bun-test or pytest output tail that may
+contain captured agent-tool phrases (e.g. when tests log an agent's own prints).
+
+**Fix:** apply
+`neutralizeForAgent(entry.rawOutputTail, entry.writtenByAgent ?? "", targetAgentId ?? "")`
+consistently.
+
+### M2. AC-42 neutralization does not run on rebuild path
+
+**Files:** `src/context/engine/orchestrator.ts:442-502`, `src/context/engine/agent-renderer.ts`
+
+`rebuildForAgent` reuses already-rendered `prior.chunks`. If the prior assemble
+ran under Claude and the swap target is Codex, the content was neutralized for
+Claude → Claude (no-op) and never for Claude → Codex. The session-scratch chunk
+in the prior bundle still carries "the Read tool" phrasing.
+
+**Fix:** re-run neutralization per chunk when `prior.agentId !== targetAgentId`
+(requires tracking `sourceAgent` on `ContextChunk` or re-fetching scratch).
+
+### M3. AC-28 default violates spec — legacy CLAUDE.md read by default
+
+**Files:** `src/config/schemas.ts:497`, `src/context/engine/providers/static-rules.ts:80`
+
+`allowLegacyClaudeMd` defaults to `true`. AC-28 literally says the engine does
+not read `CLAUDE.md` at assembly time, and AC-31 says "with the flag off
+(default)". Either flip the default to `false` and gate on an explicit opt-in
+(breaks migration path) or amend the ACs. The current test fixture "remove
+CLAUDE.md and confirm push block unchanged" (per AC-28) only passes because the
+default fallback finds no file.
+
+### M4. AC-35 — unconfigured-fallback-candidate warning not emitted at run start
+
+No evidence anywhere (`src/execution/**`) of the pre-flight warning when
+`fallback.map.claude = ["codex", "gemini"]` but Gemini is not configured.
+Operators will only discover the bad config when fallback fires mid-run.
+
+**Fix:** add a pre-flight pass in `lifecycle/run-setup.ts`.
+
+### M5. AC-39 — no separate `rebuild-manifest.json` and no old→new chunk-ID mapping
+
+**File:** `src/context/engine/orchestrator.ts:478-487`
+
+The implementation stamps `rebuildInfo` on the regular manifest only; the AC
+asks for a distinct `rebuild-manifest.json` correlating old chunk IDs to new
+chunk IDs. Today `includedChunks` after rebuild is just
+`packedChunks.map(c => c.id)` — the orchestrator doesn't know which IDs changed.
+
+### M6. AC-46 granularity — whole chunk marked stale
+
+**File:** `src/context/engine/providers/feature-context.ts:96-101`
+
+`isStale = contradicted.size > 0 || ageStale.size > 0` taints the entire
+feature-context chunk if any entry is stale. The spec says "chunks from entries
+older than `maxStoryAge`". Today a 50-entry `context.md` with one old entry
+gets the whole chunk downweighted.
+
+**Fix:** split feature context into per-section chunks (larger change) or tune
+the threshold.
+
+### M7. `orchestrator-factory.ts:40` missing optional chaining
+
+**File:** `src/context/engine/orchestrator-factory.ts:40`
+
+Dereferences `config.context.v2.rules.allowLegacyClaudeMd` without optional
+chaining. Same regression class that was fixed in `completion.ts` with
+`ctx.config.context?.v2?.enabled`. Tests bypassing Zod will crash here.
+
+**Fix:** add `?.` or document the precondition.
+
+### M8. `appendScratchEntry` is read-modify-write, not append-atomic
+
+**File:** `src/session/scratch-writer.ts:127-133`
+
+Two stages writing to the same `scratch.jsonl` concurrently will drop entries.
+Phase 1 comment acknowledges "safe for Phase 1" but parallel batch mode already
+ships.
+
+**Fix:** use `Bun.write` with an append flag, or hold a per-file mutex.
+
+### M9. PRD `contextFiles` path validation missing
+
+**File:** `src/prd/schema.ts:200-204`
+
+Already listed as C1 but also tracked as a MEDIUM hardening item: add a Zod
+`.refine()` string validation.
+
+### M10. Rules-load logger uses sentinel `storyId: "_rules"`
+
+**File:** `src/context/rules/canonical-loader.ts:160, 182`
+
+Breaks the project convention "storyId first key with the real value" —
+downstream log filters looking for a real story won't match.
+
+**Fix:** pass the caller's `storyId` in, or omit the `storyId` field entirely
+for genuinely story-less context.
+
+### M11. `MAX_GLOB_FILES` is a silent truncation
+
+**File:** `src/context/engine/providers/code-neighbor.ts:84`
+
+No log / metric when the reverse-dep glob hits the 200-file cap. Large packages
+silently see partial neighbor data.
+
+### M12. AC-23 plugin provider warning for unknown `id`
+
+AC-16 says `context.providers` with unknown `id` must fail validation with a
+clear error listing available providers. The schema at `src/config/schemas.ts`
+treats plugin module specifiers, not provider IDs; there's no stage-configured
+allow-list validation.
+
+**Fix:** add a unit test that a config entry with a bogus
+`providerIds: ["does-not-exist"]` in a stage override is caught.
+
+---
+
+## AC Coverage Table
+
+Legend: ✅ satisfied · ⚠️ partial / needs review · ❌ missing or regression
+
+### SPEC-context-engine-v2.md (ACs 1–43)
+
+| AC | Status | Justification |
+|:--|:--|:--|
+| 1 Orchestrator contract | ✅ | `orchestrator.ts:200-410` returns `ContextBundle` with all fields; deterministic path verified in tests |
+| 2 Parity with v1 | ✅ | `FeatureContextProviderV2` delegates to v1 provider unchanged |
+| 3 Provider interface | ✅ | `IContextProvider` in `types.ts` + `plugin-loader.ts` registration |
+| 4 Parallel fetch | ✅ | `Promise.all` at `orchestrator.ts:237` |
+| 5 Per-provider timeout | ✅ | `fetchWithTimeout` at `orchestrator.ts:79-89`, 5000ms, logged-not-thrown |
+| 6 Budget enforcement | ✅ | `packing.ts` + tests for floor overage |
+| 7 Packing correctness | ✅ | Greedy in `packing.ts`; property tests exist |
+| 8 Role filtering | ✅ | `orchestrator.ts:330-340` with post-dedupe re-check |
+| 9 Dedup + audience union | ✅ | `dedupe.ts` + `orchestrator.ts:328-335` |
+| 10 Digest propagation | ✅ | `priorStageDigest` threaded through `stage-assembler` |
+| 11 Session scratch read | ✅ | `SessionScratchProvider` + tests |
+| 12 Manifest writing | ✅ | `writeContextManifest` at `stage-assembler.ts:188` |
+| 13 Pull tool registration | ✅ | `buildPullToolDescriptors` + registry |
+| 14 Pull tool budget | ✅ | Descriptor `maxCallsPerSession` enforced |
+| 15 Graceful degradation | ✅ | Agent-cap gate at `orchestrator.ts:316-318` |
+| 16 Config validation | ⚠️ | Plugin module validation exists; stage-level unknown provider ID not obviously errored — see M12 |
+| 17 No-op when disabled | ✅ | `stage-assembler.ts:142` early return |
+| 18 Provider metrics | ✅ | `deriveContextMetrics` populates all fields |
+| 19 `nax context inspect` | ✅ | CLI at `src/cli/context.ts` wired at `bin/nax.ts:1278` |
+| 20 Session scratch retention | ✅ | `purgeStaleScratch` wired in `run-completion.ts:246` |
+| 21 v1 read path preserved | ✅ | v1 provider still used inside V2 adapter |
+| 22 Builder migration | ✅ | bundles consumed via `getBundleMarkdown` |
+| 23 Plugin provider integration | ✅ | `plugin-loader.ts` + integration test |
+| 24 Determinism mode | ❌ | **H1** — only enabled in the `context` stage; other stages ignore it |
+| 25 Cost accounting | ✅ | `tracker.ts:65, 74` + provider result `costUsd` |
+| 26 Self-dogfooding | n/a | process directive |
+| 27 Agent profile registry | ⚠️ | **H6** — only `claude`, `codex`; `gemini`, `cursor`, `local` fall through |
+| 28 Canonical rules delivery | ⚠️ | **M3** — default `allowLegacyClaudeMd: true` means CLAUDE.md still read |
+| 29 Neutrality linter | ✅ | `canonical-loader.ts:78-98`, throws `NeutralityLintError` |
+| 30 Rules export | ✅ | `src/cli/rules.ts` |
+| 31 Legacy compat flag | ⚠️ | Works but default opposite of spec — M3 |
+| 32 Agent-dim budget resolution | ✅ | `orchestrator.ts:222-225` + `availableBudgetTokens` path in packing |
+| 33 Tool gating on capability | ✅ | `orchestrator.ts:316-318` |
+| 34 Fallback trigger categories | ✅ | `shouldAttemptSwap` at `agent-swap.ts:58-70` |
+| 35 Fallback map resolution | ⚠️ | Resolution present; **M4** — no start-of-run warning for unconfigured candidates |
+| 36 Fallback same tier | ✅ | tier is preserved by virtue of not running tier escalation on availability |
+| 37 Rebuild portable state | ✅ | `rebuildForAgent` preserves chunk IDs/hashes + injects failure note |
+| 38 Rebuild latency | ✅ | Pure in-memory, no I/O; covered by rebuild tests |
+| 39 Rebuild manifest | ⚠️ | **M5** — stamps `rebuildInfo` but no separate file and no old→new chunk ID map |
+| 40 Fallback hop bound | ✅ | `maxHopsPerStory` check at `agent-swap.ts:67` |
+| 41 Fallback observability | ❌ | **H3** — no `context.fallback.triggered` metric, no run-summary surfacing |
+| 42 Cross-agent scratch neutralization | ⚠️ | Works for `tdd-session.outputTail`; **M1** (verify-result not neutralized) and **M2** (not applied on rebuild) |
+| 43 Failure-note determinism | ✅ | `buildFailureNoteChunk` at `orchestrator.ts:141-172` is pure |
+
+### SPEC-context-engine-v2-amendments.md (Amendments A/B/C)
+
+| AC | Status | Justification |
+|:--|:--|:--|
+| 44 Min-score threshold | ✅ | `scoring.ts` + `packing.ts` floor exemption |
+| 45 Effectiveness signal | ✅ | `effectiveness.ts:107-151` deterministic classification |
+| 46 Staleness flag | ⚠️ | **M6** — whole chunk marked stale if any entry stale |
+| 47 Contradiction detection | ✅ | `staleness.ts:171-196` |
+| 48 Pollution metrics | ✅ | `pollution.ts` + `tracker.ts:82-89`; `nax status` warn clause not verified |
+| 49 No runtime cost | ✅ | Both paths are pure string ops |
+| 50 Stage sequences documented | ✅ | In spec |
+| 51 Plan digest boost | ❌ | **H2** — boost only applied in the `context` stage, not stage-assembler |
+| 52 Scratch write coverage | ✅ | Verified via `writtenByAgent` sites: `verify.ts`, `rectify.ts`, `tdd/orchestrator.ts` |
+| 53 No-test rectify scope | ✅ | Rectify config in `stage-config.ts:152-157` |
+| 54 Dual workdir | ✅ | `ContextRequest` has `repoRoot` + `packageDir`; `stage-assembler.ts:158` |
+| 55 GitHistory package scope | ⚠️ | Default is "package" ✅, but **H5** — not config-driven |
+| 56 CodeNeighbor package scope | ⚠️ | Same as 55 — **H5** |
+| 57 Per-package rules overlay | ✅ | `static-rules.ts:87-100` |
+| 58 Feature context repo-scoped | ✅ | `FeatureContextProviderV2` uses `request.repoRoot` |
+| 59 Per-package stage budgets | ✅ | `stage-assembler.ts:169` reads `ctx.config.context.v2.stages[stage].budgetTokens` |
+| 60 Manifest records package | ✅ | `orchestrator.ts:387-388` |
+| 61 Non-monorepo no-op | ✅ | `packageDir === repoRoot` when `story.workdir` unset |
+| 62 Cross-package neighbor | ✅ | `resolveExtraGlobWorkdirs` at `code-neighbor.ts:234-251`, with **H5** caveat |
+
+### Coverage Totals
+
+- **v2 spec (1–43):** 33 ✅ · 8 ⚠️ · 2 ❌
+- **Amendments A/B/C (44–62):** 16 ✅ · 3 ⚠️ · 1 ❌
+
+---
+
+## Files with Load-Bearing Findings
+
+- `src/context/engine/orchestrator.ts`
+- `src/context/engine/stage-assembler.ts`
+- `src/context/engine/orchestrator-factory.ts`
+- `src/context/engine/effectiveness.ts`
+- `src/context/engine/agent-profiles.ts`
+- `src/context/engine/providers/code-neighbor.ts`
+- `src/context/engine/providers/git-history.ts`
+- `src/context/engine/providers/session-scratch.ts`
+- `src/context/engine/providers/static-rules.ts`
+- `src/context/engine/providers/feature-context.ts`
+- `src/context/engine/scratch-neutralizer.ts`
+- `src/context/rules/canonical-loader.ts`
+- `src/session/scratch-writer.ts`
+- `src/session/scratch-purge.ts`
+- `src/pipeline/stages/context.ts`
+- `src/execution/escalation/agent-swap.ts`
+- `src/execution/lifecycle/run-completion.ts`
+- `src/prd/schema.ts`
+- `src/config/schemas.ts`
+- `src/cli/context.ts`
+- `bin/nax.ts`
+
+**Not reviewed exhaustively** (spot-checked, no obvious issues, next targets for
+line-by-line review): `manifest-store.ts`, `dedupe.ts`, `digest.ts`, `packing.ts`,
+`render-utils.ts`, `agent-renderer.ts`, `pull-tools.ts`, `scoring.ts`.
+
+---
+
+## Recommended Gating
+
+| Severity | Action |
+|:---------|:-------|
+| **C1** | Open immediately. Security-labelled. Fix before next release. |
+| **H1–H4** | Open this sprint. Block v2 "shipped" status. |
+| **H5, H6** | Release-with-known-issues acceptable if Phase 8 is scheduled and specs amended. |
+| **M1–M12** | Standard follow-up backlog. |
+
+## Suggested Follow-Up Issue Split
+
+1. **Security: PRD `contextFiles` path traversal** (C1 + M9) — hotfix.
+2. **AC-24/AC-51 propagation through stage-assembler** (H1 + H2) — one PR.
+3. **AC-41 fallback observability** (H3) — metric emission + run summary.
+4. **Effectiveness / rules logging hygiene** (H4 + M10) — small PR.
+5. **Config-drive history/neighbor scope options** (H5) — schema + threading.
+6. **Phase 8 agent profiles OR spec amendment** (H6) — decision + implementation.
+7. **AC-42 completeness** (M1 + M2) — neutralize `rawOutputTail`; handle rebuild path.
+8. **AC-28 default behaviour** (M3) — decide: flip default or amend spec.
+9. **AC-35 pre-flight warning** (M4).
+10. **AC-39 rebuild manifest** (M5).
+11. **AC-46 staleness granularity** (M6).
+12. **Scratch append atomicity under parallel** (M8).
+13. **Misc hardening**: M7, M11, M12.

--- a/docs/reviews/context-engine-v2-session-manager-review-2026-04-18.md
+++ b/docs/reviews/context-engine-v2-session-manager-review-2026-04-18.md
@@ -1,0 +1,184 @@
+# Context-Engine v2 + Session-Manager — Verification Review
+
+**Date:** 2026-04-18
+**Reviewer:** superpowers:code-reviewer (dispatched)
+**Branch:** `fix/context-engine-review-followups-2026-04-17`
+**Base:** `f7f41d42cda59ed4466081e851c43d650b26d2c5^` (parent of first commit)
+**Head:** `88f22c1dfe6672d8c8467819e35f6999ec26b9b1`
+**Main merge-base:** `b4888122ee276e996f4f0585274e56642e32770e` (main is behind by 10 commits)
+
+**Scope:** 39 commits · 164 files · ~21,753 insertions / 2,530 deletions (80 src + 54 test files).
+
+**Specs reviewed:**
+
+- `docs/specs/SPEC-context-engine-v2.md`
+- `docs/specs/SPEC-context-engine-v2-amendments.md`
+- `docs/specs/SPEC-context-engine-v2-compilation.md`
+- `docs/specs/SPEC-context-engine-agent-fallback.md`
+- `docs/specs/SPEC-context-engine-canonical-rules.md`
+- `docs/specs/SPEC-session-manager-integration.md`
+
+**Prior reviews considered:**
+
+- `docs/reviews/context-engine-v2-branch-review.md`
+- `docs/reviews/context-engine-v2-architecture-review.md`
+- `docs/reviews/context-engine-v2-final-review-2026-04-17.md`
+- `docs/reviews/context-engine-v2-findings-2-and-5-proposal.md`
+- `docs/reviews/context-engine-review-followups-2026-04-17.md`
+- `docs/reviews/today-commits-code-review-2026-04-17.md`
+
+---
+
+## Verdict: **needs-followups**
+
+Near-ready. The branch is extensively wired and the majority of prior-review findings are genuinely closed. However, one follow-up commit (`88f22c1d`) introduces a test regression that blocks merge, and the full `bun test` run crashes Bun mid-suite, which masks further potential regressions.
+
+---
+
+## Acceptance Criteria Summary
+
+| Spec | ✅ Met + wired | ⚠️ Partial | ❌ Missing / unwired | Total |
+|:-----|:-------------:|:----------:|:-------------------:|:-----:|
+| SPEC-context-engine-v2 (AC-1..43) | 40 | 3 | 0 | 43 |
+| Amendments A / B / C | 18 | 1 | 0 | 19 |
+| Agent fallback | 16 | 2 | 0 | 18 |
+| Canonical rules | 17 | 2 | 1 | 20 |
+| Session-manager additions (AC-79..83) | 2 | 2 | 1 | 5 |
+
+AC numbering in `context-engine-v2-final-review-2026-04-17.md` is authoritative for v2 + amendments; fallback and canonical-rules use each spec's own local numbering.
+
+---
+
+## CRITICAL Issues (block merge)
+
+### CRIT-1. AC-16 strict validation regresses 26+ existing tests
+
+**File:** `src/context/engine/orchestrator.ts:237-255`
+
+Commit `88f22c1d` added the fail-fast check:
+
+```typescript
+const unknownProviderIds = allowedIds.filter((id) => !registeredIds.has(id));
+if (unknownProviderIds.length > 0) { throw new NaxError(...) }
+```
+
+This correctly implements M12. But the existing test fixture in `test/unit/context/engine/orchestrator.test.ts:26` uses
+`providerIds: ["p1", "p2", "test-provider", "timeout-sim", "good"]` as a *"bypass stage filter"* override, and many tests only register `p1` or a single `test-provider`. Every such test now throws.
+
+**Impact (confirmed by running the suites):**
+
+- `test/unit/context/engine/orchestrator.test.ts`: 17 fail / 20 pass
+- `test/unit/context/engine/orchestrator-factory.test.ts`: 3 fail (#507 scope tests)
+- `test/unit/context/engine/providers/feature-context.test.ts`: several fail
+- `test/unit/context/engine/pull-tools.test.ts`: 3 fail (`handleQueryFeatureContext`)
+
+**Fix options:**
+
+1. Filter `BASE_REQUEST.providerIds` inside test fixtures to only include registered IDs (tests are wrong).
+2. **Preferred:** Limit the strict check to config-derived `stageConfig.providerIds`, not `request.providerIds` test overrides — the latter is documented as a test-only override and aligns with the fixture comments and the spec's user-facing purpose (catch bogus plugin IDs in config).
+
+### CRIT-2. Full `bun test` segfaults
+
+`timeout 600 bun test` core-dumps partway (Bun 1.3.8 instability). This masks the regression gate. Either split the suite or isolate the offending file before merge.
+
+---
+
+## HIGH / Important (should fix before merge)
+
+### H-1. Session-manager AC-83 (force-terminate on close) not implemented
+
+**File:** `src/execution/session-manager-runtime.ts:4-15`
+
+`closePhysicalSession(handle, workdir)` is called with two positional args; the spec requires `options.force: boolean` for hard termination of errored sessions. No call site passes `force`, and `src/agents/types.ts` does not declare it. `closeAllRunSessions` on SIGTERM shutdown would benefit from `force: true`.
+
+### H-2. Session state model divergence from spec
+
+Spec names states `created/active/suspended/failed/handed-off/completed/orphaned`. Implementation (`src/session/types.ts:26-34`) uses `CREATED/RUNNING/PAUSED/RESUMING/CLOSING/COMPLETED/FAILED`. `handoff()` updates the `agent` field but does not transition to a `HANDED_OFF` state — auditing whether a session was handed off vs normally completed requires reading `agentFallbacks[]` externally. Semantically equivalent but the spec should be amended or a `HANDED_OFF`/`ORPHANED` state added for trace clarity.
+
+### H-3. Canonical rules AC-19 dogfood migration not in this branch
+
+Spec AC-19: *"The nax project itself completes the migration: its own rules live in `.nax/rules/`…"* — the repo still has `.claude/rules/*.md` and no `.nax/rules/` directory. This is a process AC (not code) and the spec lists it as the final deprecation step. Flag for tracking.
+
+### H-4. Test coverage gap: agent-swap multi-hop exhaustion
+
+`test/integration/execution/agent-swap.test.ts` covers single-hop success/fail. No test asserts that when every candidate in `fallback.map[primary]` fails, the loop exits with a terminal outcome (fallback AC-5: "all-agents-unavailable"). The loop in `pipeline/stages/execution.ts:263-401` exits when the hop cap or candidate list is exhausted, but the terminal `outcome` is only logged — no `StoryMetrics.fallback.exhausted` flag or distinct escalation reason.
+
+### H-5. Integration risk: idempotency of `closeAllRunSessions`
+
+`src/execution/session-manager-runtime.ts:66-92` — `storyIds` is a `Set`, but `closeStorySessions` internally calls `sessionManager.closeStory(storyId)` which may miss late-binding sessions. The second pass iterates `activeSessions` to catch storyless sessions, but any descriptor whose state already changed to `COMPLETED` via the first pass would no longer be in `activeSessions` (good). Logic is OK but fragile — add a unit test asserting idempotency.
+
+---
+
+## MINOR
+
+- `src/context/engine/orchestrator-factory.ts:53` uses `config.context.v2.providers` without optional chaining (regression class of M7). Tests bypassing Zod defaults will crash. Add `?.providers`.
+- `src/context/rules/canonical-loader.ts` uses bare `logger.warn` without `storyId`. Canonical rules are genuinely story-less — acceptable but project-conventions says `storyId` must be first key. Document the exception or introduce a convention for story-less logs.
+- `src/session/scratch-writer.ts:18` imports `node:fs/promises` `appendFile` — correct for atomic `O_APPEND` but project rule forbids Node.js APIs. Document this as an intentional exception at the call site (same pattern as the `setTimeout`-for-cancellation exception).
+- `nax context inspect` CLI (AC-19) is wired at `bin/nax.ts` but has no integration test verifying end-to-end output. Nice-to-have.
+- `docs/reviews/context-engine-review-followups-2026-04-17.md:110-112` claims *"full run-level centralized SessionManager ownership … is still larger-scope work"* — that work has since landed in `85de63ee`, `a5adc21d`, `15620b9b`. Update the doc.
+
+---
+
+## Prior-review spot-check confirmations (verified resolved)
+
+| Finding | Resolved? | Evidence |
+|:--------|:---------:|:---------|
+| C1 path-traversal in `contextFiles` | ✅ | `src/prd/schema.ts:200-212` rejects absolute + `..` |
+| H1 AC-24 determinism not threaded | ✅ | `src/context/engine/stage-assembler.ts:195` |
+| H2 AC-51 planDigestBoost not threaded | ✅ | `src/context/engine/stage-assembler.ts:198` |
+| H3 AC-41 fallback observability missing | ✅ | `src/metrics/tracker.ts:172` surfaces `fallback.hops`; `pipeline/stages/execution.ts:308-318` records hops with structured metadata |
+| H4 effectiveness swallowed errors silently | ✅ | `src/context/engine/effectiveness.ts:208-213` logs `logger.warn` |
+| H5 scope options not config-driven | ✅ | `src/config/schemas.ts:592-606` + `orchestrator-factory.ts:53-59` threads them |
+| H6 only 2 of 5 agent profiles | ✅ | `src/context/engine/agent-profiles.ts:88-144` — all 5 (claude, codex, gemini, cursor, local) |
+| M3 AC-28 default `allowLegacyClaudeMd: true` | ✅ | `src/config/schemas.ts:496` flipped to `false` |
+| M4 AC-35 pre-flight warning missing | ✅ | `src/execution/lifecycle/run-setup.ts:51-73,123` |
+| M5 AC-39 rebuild manifest missing | ✅ | `src/context/engine/manifest-store.ts:53,86`; `writeRebuildManifest` wired from `pipeline/stages/execution.ts:287` |
+| M6 whole-chunk staleness | ✅ | `src/context/engine/providers/feature-context.ts:110-123` per-entry |
+| M7 missing optional chain on `allowLegacyClaudeMd` | ✅ | `orchestrator-factory.ts:41` |
+| M8 scratch append race | ✅ | `src/session/scratch-writer.ts:85` uses `fsAppendFile` (atomic `O_APPEND`) |
+| today-commits finding 1: rebuild not delivered to swap | ✅ | `pipeline/stages/execution.ts:333-370` uses `buildSwapPrompt(basePrompt, workingBundle.pushMarkdown)` |
+| today-commits finding 2: single-hop only | ✅ | `while` loop at `pipeline/stages/execution.ts:263-401` walks candidates |
+| today-commits finding 3: session-manager not central | ✅ | `runner.ts:149` creates once in setup; threaded via `runExecutionPhase` (`runner-execution.ts:160`) and `runCompletionPhase`; `closeAllRunSessions` called on SIGTERM (`run-setup.ts:177`) and completion (`run-completion.ts:206`) |
+| today-commits finding 5: free-text adapter classification | ✅ | `src/agents/acp/parse-agent-error.ts` classifies only from structured fields (verified by rewritten tests) |
+
+---
+
+## Wiring verification
+
+All new modules have call paths — **no dead exports found**:
+
+| Module | Call site |
+|:-------|:----------|
+| `src/context/engine/stage-assembler.ts` | imported by `pipeline/stages/context.ts` and every stage that needs a per-stage bundle |
+| `src/context/engine/manifest-store.ts` | imported by `stage-assembler.ts` (`writeContextManifest`) and `pipeline/stages/execution.ts` (`writeRebuildManifest`) |
+| `src/context/engine/orchestrator-factory.ts` | used as default factory in `stage-assembler.ts:47` |
+| `src/context/engine/providers/*` | registered in `orchestrator-factory.ts:43-60` + plugin loader |
+| `src/context/rules/canonical-loader.ts` | imported by `StaticRulesProvider`, `cli/rules.ts` |
+| `src/execution/escalation/agent-swap.ts` | called from `pipeline/stages/execution.ts:263-287` with hop loop |
+| `src/execution/session-manager-runtime.ts` | `closeStorySessions` called from `unified-executor.ts:40,260,264,402`; `closeAllRunSessions` from `run-setup.ts:178` (SIGTERM) and `run-completion.ts:207` |
+| `src/session/manager.ts` | instantiated once in `run-setup.ts:155`, threaded everywhere |
+
+---
+
+## Files with load-bearing findings
+
+- `src/context/engine/orchestrator.ts` — **CRIT-1**
+- `test/unit/context/engine/orchestrator.test.ts` — CRIT-1 fixture
+- `test/unit/context/engine/orchestrator-factory.test.ts` — CRIT-1
+- `test/unit/context/engine/pull-tools.test.ts` — CRIT-1
+- `test/unit/context/engine/providers/feature-context.test.ts` — CRIT-1
+- `src/execution/session-manager-runtime.ts` — H-1 force arg; H-5 idempotency
+- `src/session/types.ts` — H-2 state naming
+- `src/agents/types.ts` — H-1 `closePhysicalSession` needs `force`
+- `src/context/engine/orchestrator-factory.ts:53` — MINOR optional chain
+- `docs/reviews/context-engine-review-followups-2026-04-17.md` — outdated claim
+
+---
+
+## Recommended next steps
+
+1. **Fix CRIT-1** — restrict the unknown-provider-IDs check to stage-config-provided IDs, or normalize `request.providerIds` test overrides. One small PR.
+2. **Address H-1 (force-terminate)** — add optional `force` param to `closePhysicalSession` in `AgentAdapter` interface + adapter impl; call with `force: true` on crash-handler shutdown path.
+3. **Add regression tests** for `closeAllRunSessions` idempotency and for fallback exhaustion.
+4. **Split the test suite** or isolate the Bun-crashing file — full `bun test` must exit cleanly before merge.
+5. After those, the branch is ready. All ACs flagged as ❌ / ⚠️ in prior reviews are now ✅ with the exceptions noted above (AC-83 force, AC-19 dogfood, AC-16 regression).

--- a/docs/reviews/today-commits-code-review-2026-04-17.md
+++ b/docs/reviews/today-commits-code-review-2026-04-17.md
@@ -1,0 +1,214 @@
+# Code Review Report: Context Engine / Session Manager Stack
+
+Date: 2026-04-17
+
+## Scope
+
+Reviewed the commit range from `f7f41d42cda59ed4466081e851c43d650b26d2c5` through `b4888122ee276e996f4f0585274e56642e32770e`.
+
+Compared against the latest `main` branch as of 2026-04-17:
+
+- `HEAD`: `b4888122ee276e996f4f0585274e56642e32770e`
+- `origin/main`: `b4888122ee276e996f4f0585274e56642e32770e`
+
+Specs reviewed:
+
+- `docs/specs/SPEC-context-engine-agent-fallback.md`
+- `docs/specs/SPEC-context-engine-canonical-rules.md`
+- `docs/specs/SPEC-context-engine-v2-amendments.md`
+- `docs/specs/SPEC-context-engine-v2-compilation.md`
+- `docs/specs/SPEC-context-engine-v2.md`
+- `docs/specs/SPEC-session-manager-integration.md`
+
+## Overall Assessment
+
+This stack contains substantial, high-quality implementation work and good targeted test coverage for several slices of the design.
+
+However, I do **not** think it is accurate to conclude that all acceptance criteria are met or that all required functions are fully wired up end to end. The largest remaining gaps are in:
+
+- availability fallback execution/wiring
+- centralized session-manager ownership
+- canonical-rules completeness
+- structured fallback classification
+- manifest / protocol-correlation / budget threading completeness
+
+## Findings
+
+### 1. Critical: fallback rebuild is not actually delivered to the fallback agent, and session handoff is not persisted
+
+Files:
+
+- [src/pipeline/stages/execution.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/pipeline/stages/execution.ts:247)
+- [src/pipeline/stages/execution.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/pipeline/stages/execution.ts:289)
+- [src/pipeline/stages/execution.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/pipeline/stages/execution.ts:198)
+
+Why this matters:
+
+- The stage rebuilds `ctx.contextBundle` for the swap target, but the retry still runs with the original `ctx.prompt`.
+- The fallback agent therefore does not actually receive the rebuilt push block, failure note, or agent-specific rendering produced by `rebuildForAgent()`.
+- The swap path also does not call any `sessionManager.handoff()` equivalent and does not re-bind the swapped session handle/protocol IDs after the fallback run.
+
+Spec impact:
+
+- AC-37 `Rebuild portable state`
+- AC-41 `Fallback observability`
+- AC-67 `Handoff`
+- AC-76 `Protocol ID capture`
+
+Risk:
+
+- Fallback appears implemented in tests and manifests, but the runtime handoff is incomplete.
+- Operators may think Codex/Gemini received preserved context when the real prompt did not change.
+
+### 2. High: fallback traversal stops after a single alternate agent instead of walking the configured map
+
+Files:
+
+- [src/execution/escalation/agent-swap.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/execution/escalation/agent-swap.ts:39)
+- [src/pipeline/stages/execution.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/pipeline/stages/execution.ts:332)
+
+Why this matters:
+
+- `resolveSwapTarget()` chooses one candidate by index.
+- If that single swap attempt fails, execution escalates immediately.
+- There is no runtime loop that tries the next candidate in `fallback.map`, and there is no `all-agents-unavailable` terminal outcome once the configured map is exhausted.
+
+Spec impact:
+
+- AC-35 `Fallback map resolution`
+- AC-40 `Fallback hop bound`
+- Agent fallback spec AC-4/5/9
+
+Example:
+
+- With `claude -> [codex, gemini]`, a Claude availability failure can reach Codex.
+- If Codex also fails, Gemini is not attempted in the same flow.
+
+### 3. High: Session Manager is still partial and not yet the centralized lifecycle owner described by the spec
+
+Files:
+
+- [src/execution/iteration-runner.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/execution/iteration-runner.ts:148)
+- [src/execution/lifecycle/run-setup.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/execution/lifecycle/run-setup.ts:173)
+- [src/session/manager.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/session/manager.ts:82)
+- [src/session/manager.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/session/manager.ts:266)
+- [src/session/types.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/session/types.ts:26)
+- [src/tdd/session-runner.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/tdd/session-runner.ts:196)
+- [src/agents/types.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/agents/types.ts:104)
+
+Why this matters:
+
+- A new in-memory `SessionManager` is created per story, not as a run-level durable owner.
+- Startup/shutdown orphan sweep integration is explicitly deferred.
+- `sweepOrphans()` deletes old terminal sessions rather than marking stale active sessions orphaned.
+- The implemented state machine and types do not match the spec’s `created/active/suspended/failed/handed-off/completed/orphaned` model.
+- The public interface still lacks key spec functions like `handoff()` and `recordStage()`.
+- Many runtime paths still depend on legacy `acpSessionName`, `sessionRole`, `keepSessionOpen`, and `buildSessionName()` behavior.
+
+Spec impact:
+
+- AC-63 through AC-78 are only partially satisfied.
+- Session-manager follow-up AC-79 through AC-83 are also not fully complete.
+
+Assessment:
+
+- I would classify this as “good phase progress,” not “fully integrated central session manager.”
+
+### 4. Medium: canonical-rules implementation does not yet satisfy the full loader/scoping/export/migration spec
+
+Files:
+
+- [src/context/rules/canonical-loader.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/context/rules/canonical-loader.ts:38)
+- [src/context/rules/canonical-loader.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/context/rules/canonical-loader.ts:128)
+- [src/context/engine/providers/static-rules.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/context/engine/providers/static-rules.ts:83)
+- [src/context/engine/providers/static-rules.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/context/engine/providers/static-rules.ts:161)
+- [src/cli/rules.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/cli/rules.ts:84)
+- [src/cli/rules.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/cli/rules.ts:222)
+
+Why this matters:
+
+- The canonical loader only scans top-level `*.md` files.
+- There is no support for nested one-level directories, YAML frontmatter, `priority`, or `appliesTo`.
+- `StaticRulesProvider` injects every loaded canonical rule for every story with no path scoping.
+- The legacy fallback path reads only the first matching legacy shim file, not `CLAUDE.md + .claude/rules/*.md`.
+- `rules export` and `rules migrate` exist, but they are simpler than the spec’s stated behavior.
+
+Spec impact:
+
+- Canonical-rules AC-2, AC-3, AC-5, AC-6, AC-7, AC-9, AC-12, AC-14, AC-15, AC-16 are not fully met.
+- Context-engine AC-28 through AC-31 are only partially met.
+
+### 5. Medium: adapter failure classification still depends on free-text parsing
+
+Files:
+
+- [src/agents/acp/parse-agent-error.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/agents/acp/parse-agent-error.ts:13)
+- [src/agents/acp/adapter.ts](/home/williamkhoo/Desktop/projects/nathapp/ai-coder/ngent/src/agents/acp/adapter.ts:602)
+
+Why this matters:
+
+- The spec explicitly requires that classification not infer from free text.
+- The implementation still classifies by substring matches like `429`, `rate limit`, `401`, `403`, `unauthorized`, and `forbidden`.
+- Unrecognized failures are mapped to `category: "quality"` rather than a distinct `other` path.
+
+Spec impact:
+
+- Agent fallback AC-15 `Classification never infers from free text`
+- Agent fallback AC-1/2
+
+Risk:
+
+- The fallback/escalation decision boundary can still change based on wording rather than structured backend failure data.
+
+## Acceptance / Wiring Summary
+
+### Clearly implemented or largely in place
+
+- Context orchestrator core pipeline
+- provider registration model
+- greedy packing and budget-floor behavior
+- manifest writing per stage
+- stage-specific assembly helpers
+- monorepo `repoRoot` / `packageDir` support in the context engine
+- static-rules canonical path with package overlay
+- `nax context inspect`
+- targeted agent-swap tests for the currently implemented behavior
+
+### Not yet fully met or not fully wired
+
+- end-to-end fallback prompt rebuild delivery
+- multi-hop fallback candidate traversal
+- session-manager handoff ownership
+- orphan recovery semantics
+- stage digest persistence through session-manager APIs
+- protocol ID display in context inspection / manifests as specified
+- full canonical-rules frontmatter, scoping, and migration behavior
+- structured adapter-failure classification without message parsing
+- `availableBudgetTokens` propagation from prompt-building call sites
+
+## Verdict
+
+The implementation is materially advanced and includes many real improvements, but the full spec set is **not yet complete**.
+
+Most importantly:
+
+- fallback is not fully wired end to end
+- the session manager is not yet the single authoritative lifecycle owner
+- canonical rules are not yet implemented to the full spec contract
+
+## Verification Performed
+
+Targeted tests run:
+
+```bash
+bun test test/integration/execution/agent-swap.test.ts test/unit/session/manager.test.ts test/unit/context/engine/providers/static-rules.test.ts
+```
+
+Result:
+
+- 61 passing
+- 0 failing
+
+Note:
+
+These tests validate the current implementation behavior, but several acceptance criteria above remain broader than what the runtime wiring presently guarantees.

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -1187,7 +1187,7 @@ export class AcpAgentAdapter implements AgentAdapter {
     return !this._unavailableAgents.has(agentName);
   }
 
-  async closePhysicalSession(handle: string, workdir: string): Promise<void> {
+  async closePhysicalSession(handle: string, workdir: string, options?: { force?: boolean }): Promise<void> {
     const cmdStr = `acpx ${this.name}`;
     const client = _acpAdapterDeps.createClient(cmdStr, workdir, undefined, undefined);
     try {
@@ -1195,9 +1195,15 @@ export class AcpAgentAdapter implements AgentAdapter {
       try {
         if (client.closeSession) {
           await client.closeSession(handle, this.name);
+          // AC-83: hard-terminate (acpx stop) when force=true, e.g. for errored sessions
+          if (options?.force) {
+            await (client as { forceStop?: (agentName: string) => Promise<void> })
+              .forceStop?.(this.name)
+              .catch(() => {});
+          }
         } else if (client.loadSession) {
           const session = await client.loadSession(handle, this.name, "approve-reads");
-          if (session) await session.close().catch(() => {});
+          if (session) await session.close({ forceTerminate: options?.force }).catch(() => {});
         }
       } catch (err) {
         getSafeLogger()?.warn("acp-adapter", `[close] Failed to close session ${handle}`, { error: String(err) });

--- a/src/agents/acp/parse-agent-error.ts
+++ b/src/agents/acp/parse-agent-error.ts
@@ -1,45 +1,160 @@
 import type { AgentError } from "../types";
 
 /**
- * Parse stderr output to identify agent error type.
+ * Parse structured adapter error output to identify agent error type.
  *
- * Detects common error patterns:
- * - Rate limit errors: 429, "rate limit", "Rate limit"
- * - Auth errors: 401, 403, "unauthorized", "Unauthorized", "forbidden", "Forbidden"
- * - Unknown for unrecognized patterns
+ * Classification intentionally uses machine-readable signals only:
+ * - JSON fields (type/status/statusCode/code/acpxCode/detailCode)
+ * - bracketed code suffixes (e.g. "[ACPX_RATE_LIMIT/TOO_MANY_REQUESTS]")
+ * - explicit key=value codes (e.g. "statusCode=429")
  *
- * Optionally extracts retryAfterSeconds for rate limit errors.
+ * Free-text phrase inference is intentionally not supported.
  */
 export function parseAgentError(stderr: string): AgentError {
   if (!stderr) {
     return { type: "unknown" };
   }
 
-  // Check for rate limit patterns (429, "rate limit", "Rate limit")
-  if (stderr.includes("429") || stderr.includes("rate limit") || stderr.includes("Rate limit")) {
-    const result: AgentError = { type: "rate-limit" };
+  const parsedJson = parseJsonObject(stderr);
+  if (parsedJson) {
+    const direct = classifyDirectType(parsedJson);
+    if (direct) return direct;
 
-    // Try to extract retryAfterSeconds from "retry after N" patterns
-    const match = stderr.match(/retry\s+after\s+(\d+)/i);
-    if (match?.[1]) {
-      result.retryAfterSeconds = Number.parseInt(match[1], 10);
+    const structured = classifyFromCodeTokens(extractJsonCodeTokens(parsedJson), parsedJson);
+    if (structured) return structured;
+  }
+
+  const bracketed = extractBracketedCodes(stderr);
+  const fromBracketed = classifyFromCodeTokens(bracketed);
+  if (fromBracketed) return fromBracketed;
+
+  const fromKeyValue = classifyFromCodeTokens(extractKeyValueCodes(stderr));
+  if (fromKeyValue) return fromKeyValue;
+
+  return { type: "unknown" };
+}
+
+function parseJsonObject(stderr: string): Record<string, unknown> | null {
+  try {
+    const value = JSON.parse(stderr);
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function classifyDirectType(payload: Record<string, unknown>): AgentError | null {
+  const type = payload.type;
+  if (type !== "rate-limit" && type !== "auth" && type !== "timeout" && type !== "crash" && type !== "unknown") {
+    return null;
+  }
+
+  const result: AgentError = { type };
+  if (type === "rate-limit") {
+    const retryAfterSeconds = toNumber(payload.retryAfterSeconds ?? payload.retry_after_seconds ?? payload.retryAfter);
+    if (retryAfterSeconds !== undefined) {
+      result.retryAfterSeconds = retryAfterSeconds;
+    }
+  }
+
+  return result;
+}
+
+function extractJsonCodeTokens(payload: Record<string, unknown>): string[] {
+  const tokens: string[] = [];
+  const candidates = [
+    payload.code,
+    payload.status,
+    payload.statusCode,
+    payload.httpStatus,
+    payload.errorCode,
+    payload.acpxCode,
+    payload.detailCode,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "number" && Number.isFinite(candidate)) {
+      tokens.push(String(candidate));
+    } else if (typeof candidate === "string" && candidate.trim()) {
+      tokens.push(candidate.trim());
+    }
+  }
+
+  return tokens;
+}
+
+function extractBracketedCodes(stderr: string): string[] {
+  const tokens: string[] = [];
+  const matches = stderr.match(/\[([A-Z0-9_/\-]+)\]/g) ?? [];
+  for (const entry of matches) {
+    const inner = entry.slice(1, -1);
+    for (const token of inner.split("/")) {
+      const trimmed = token.trim();
+      if (trimmed) tokens.push(trimmed);
+    }
+  }
+  return tokens;
+}
+
+function extractKeyValueCodes(stderr: string): string[] {
+  const tokens: string[] = [];
+  const patterns = [
+    /(?:status|statusCode|httpStatus|code)\s*[:=]\s*(\d{3})/g,
+    /(?:acpxCode|detailCode|errorCode)\s*[:=]\s*([A-Z0-9_]+)/g,
+  ];
+
+  for (const pattern of patterns) {
+    while (true) {
+      const match = pattern.exec(stderr);
+      if (!match) break;
+      const code = match[1];
+      if (code) tokens.push(code);
+    }
+  }
+
+  return tokens;
+}
+
+function classifyFromCodeTokens(tokens: string[], payload?: Record<string, unknown>): AgentError | null {
+  for (const token of tokens.map((value) => value.toUpperCase())) {
+    if (
+      token === "429" ||
+      token === "TOO_MANY_REQUESTS" ||
+      token === "RATE_LIMIT" ||
+      token === "RATE_LIMITED" ||
+      token === "QUOTA_EXCEEDED" ||
+      token === "RESOURCE_EXHAUSTED"
+    ) {
+      const retryAfterSeconds = payload
+        ? toNumber(payload.retryAfterSeconds ?? payload.retry_after_seconds ?? payload.retryAfter)
+        : undefined;
+      return retryAfterSeconds !== undefined ? { type: "rate-limit", retryAfterSeconds } : { type: "rate-limit" };
     }
 
-    return result;
+    if (
+      token === "401" ||
+      token === "403" ||
+      token === "UNAUTHORIZED" ||
+      token === "FORBIDDEN" ||
+      token === "AUTH_FAILED" ||
+      token === "AUTHENTICATION_FAILED" ||
+      token === "PERMISSION_DENIED"
+    ) {
+      return { type: "auth" };
+    }
   }
 
-  // Check for auth patterns (401, 403, "unauthorized", "Unauthorized", "forbidden", "Forbidden")
-  if (
-    stderr.includes("401") ||
-    stderr.includes("403") ||
-    stderr.includes("unauthorized") ||
-    stderr.includes("Unauthorized") ||
-    stderr.includes("forbidden") ||
-    stderr.includes("Forbidden")
-  ) {
-    return { type: "auth" };
-  }
+  return null;
+}
 
-  // Unknown error type
-  return { type: "unknown" };
+function toNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return Math.trunc(value);
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
 }

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -300,8 +300,9 @@ export interface AgentAdapter {
    *
    * @param handle - The ACP session name (from descriptor.handle or deriveSessionName())
    * @param workdir - Working directory used when the session was created
+   * @param options.force - When true, uses hard termination (acpx stop) after close (AC-83)
    */
-  closePhysicalSession(handle: string, workdir: string): Promise<void>;
+  closePhysicalSession(handle: string, workdir: string, options?: { force?: boolean }): Promise<void>;
 
   /**
    * @deprecated Phase 3 (#477): use closePhysicalSession() instead.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -42,8 +42,10 @@ export { agentsListCommand } from "./agents";
 export { contextInspectCommand, type ContextInspectOptions } from "./context";
 export {
   rulesExportCommand,
+  rulesLintCommand,
   rulesMigrateCommand,
   neutralizeContent,
   type RulesExportOptions,
+  type RulesLintOptions,
   type RulesMigrateOptions,
 } from "./rules";

--- a/src/cli/rules.ts
+++ b/src/cli/rules.ts
@@ -1,7 +1,7 @@
 /**
  * `nax rules` CLI Commands (Phase 5.1)
  *
- * Provides two commands for managing the canonical rules store (.nax/rules/):
+ * Provides commands for managing the canonical rules store (.nax/rules/):
  *
  *   nax rules export --agent=<id>
  *     One-way generation of per-agent shim files (CLAUDE.md, AGENTS.md,
@@ -13,6 +13,10 @@
  *     with basic neutralization applied (removes Claude-specific phrasing).
  *     The operator reviews the diff before committing. Existing .nax/rules/
  *     files are preserved unless --force is passed.
+ *
+ *   nax rules lint
+ *     Validates neutrality/frontmatter for canonical rules in the repo root
+ *     and any package overlays.
  *
  * See: docs/specs/SPEC-context-engine-v2.md §Canonical rules delivery
  */
@@ -42,6 +46,13 @@ export const _rulesCLIDeps = {
   },
   mkdir: async (path: string): Promise<void> => {
     await mkdir(path, { recursive: true });
+  },
+  globCanonicalRuleFiles: (workdir: string): string[] => {
+    try {
+      return [...new Bun.Glob("**/.nax/rules/**/*.md").scanSync({ cwd: workdir, absolute: false })].sort();
+    } catch {
+      return [];
+    }
   },
   loadCanonicalRules,
 };
@@ -172,6 +183,11 @@ export interface RulesMigrateOptions {
   dryRun?: boolean;
 }
 
+export interface RulesLintOptions {
+  /** Project working directory (default: process.cwd()) */
+  dir?: string;
+}
+
 interface MigrateSource {
   sourcePath: string;
   targetFileName: string;
@@ -279,4 +295,39 @@ export async function rulesMigrateCommand(options: RulesMigrateOptions): Promise
       );
     }
   }
+}
+
+function collectCanonicalRuleRoots(workdir: string): string[] {
+  const roots = new Set<string>([workdir]);
+  const files = _rulesCLIDeps.globCanonicalRuleFiles(workdir);
+  for (const rel of files) {
+    const normalized = rel.replaceAll("\\", "/");
+    const marker = "/.nax/rules/";
+    const idx = normalized.indexOf(marker);
+    if (idx <= 0) continue; // root rules stay mapped to workdir
+    const packageRel = normalized.slice(0, idx);
+    if (!packageRel) continue;
+    roots.add(join(workdir, packageRel));
+  }
+  return [...roots].sort();
+}
+
+/**
+ * `nax rules lint`
+ *
+ * Validates canonical rules neutrality/frontmatter for the repository root
+ * and any package-local `.nax/rules/` stores found under the workdir.
+ */
+export async function rulesLintCommand(options: RulesLintOptions): Promise<void> {
+  const workdir = options.dir ?? process.cwd();
+  const roots = collectCanonicalRuleRoots(workdir);
+
+  let totalRuleFiles = 0;
+  for (const root of roots) {
+    const rules = await _rulesCLIDeps.loadCanonicalRules(root);
+    totalRuleFiles += rules.length;
+  }
+
+  const scopeLabel = roots.length === 1 ? "repo root" : `${roots.length} rule roots`;
+  console.log(`[OK] Canonical rules lint passed (${totalRuleFiles} file(s) across ${scopeLabel}).`);
 }

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -427,6 +427,8 @@ export interface ContextV2RulesConfig {
    * Default true during migration period; set false to enforce canonical-only.
    */
   allowLegacyClaudeMd: boolean;
+  /** Token budget ceiling for canonical rules chunks. */
+  budgetTokens: number;
 }
 
 /**

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -494,8 +494,13 @@ const ContextV2RulesConfigSchema = z
      * Set true only during migration to the canonical .nax/rules/ store.
      */
     allowLegacyClaudeMd: z.boolean().default(false),
+    /**
+     * Token ceiling for canonical rules. Lower-priority rules are tail-truncated
+     * when this budget is exceeded.
+     */
+    budgetTokens: z.number().int().min(512).default(8192),
   })
-  .default(() => ({ allowLegacyClaudeMd: false }));
+  .default(() => ({ allowLegacyClaudeMd: false, budgetTokens: 8192 }));
 
 // Context Engine plugin provider config (Phase 7)
 const ContextPluginProviderConfigSchema = z.object({
@@ -628,7 +633,7 @@ export const ContextV2ConfigSchema = z
     enabled: false,
     minScore: 0.1,
     pull: { enabled: false, allowedTools: [], maxCallsPerSession: 5, maxCallsPerRun: 50 },
-    rules: { allowLegacyClaudeMd: false },
+    rules: { allowLegacyClaudeMd: false, budgetTokens: 8192 },
     fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
     pluginProviders: [],
     stages: {},
@@ -1054,7 +1059,7 @@ export const NaxConfigSchema = z
         enabled: false,
         minScore: 0.1,
         pull: { enabled: false, allowedTools: [], maxCallsPerSession: 5, maxCallsPerRun: 50 },
-        rules: { allowLegacyClaudeMd: false },
+        rules: { allowLegacyClaudeMd: false, budgetTokens: 8192 },
         fallback: { enabled: false, onQualityFailure: false, maxHopsPerStory: 2, map: {} },
         pluginProviders: [],
         stages: {},

--- a/src/context/engine/available-budget.ts
+++ b/src/context/engine/available-budget.ts
@@ -1,0 +1,19 @@
+import { getAgentProfile } from "./agent-profiles";
+
+const RESERVED_NON_CONTEXT_TOKENS = 5_000;
+const CONTEXT_WINDOW_SAFETY_RATIO = 0.1;
+
+/**
+ * Estimate remaining prompt room for context injection.
+ *
+ * This is a conservative upper bound used to thread `availableBudgetTokens`
+ * into ContextRequest from prompt-building call sites.
+ */
+export function estimateAvailableBudgetTokens(agentId: string, existingPrompt?: string): number | undefined {
+  const { profile } = getAgentProfile(agentId);
+  const maxContextTokens = profile.caps.maxContextTokens;
+  const existingPromptTokens = existingPrompt ? Math.ceil(existingPrompt.length / 4) : 0;
+  const safetyMargin = Math.ceil(maxContextTokens * CONTEXT_WINDOW_SAFETY_RATIO);
+  const remaining = maxContextTokens - RESERVED_NON_CONTEXT_TOKENS - existingPromptTokens - safetyMargin;
+  return remaining > 0 ? remaining : undefined;
+}

--- a/src/context/engine/index.ts
+++ b/src/context/engine/index.ts
@@ -53,8 +53,14 @@ export { assembleForStage, getBundleMarkdown } from "./stage-assembler";
 export type { StageAssembleOptions } from "./stage-assembler";
 export { createContextToolRuntime } from "./tool-runtime";
 export type { ContextToolRuntime } from "./tool-runtime";
-export { writeContextManifest, loadContextManifests, contextManifestPath } from "./manifest-store";
-export type { StoredContextManifest } from "./manifest-store";
+export {
+  writeContextManifest,
+  writeRebuildManifest,
+  loadContextManifests,
+  contextManifestPath,
+  rebuildManifestPath,
+} from "./manifest-store";
+export type { StoredContextManifest, RebuildManifestEntry } from "./manifest-store";
 
 export type {
   AdapterFailure,

--- a/src/context/engine/manifest-store.ts
+++ b/src/context/engine/manifest-store.ts
@@ -49,6 +49,10 @@ export function contextManifestPath(projectDir: string, featureId: string, story
   return join(contextStoryDir(projectDir, featureId, storyId), `context-manifest-${stage}.json`);
 }
 
+export function rebuildManifestPath(projectDir: string, featureId: string, storyId: string): string {
+  return join(contextStoryDir(projectDir, featureId, storyId), "rebuild-manifest.json");
+}
+
 export async function writeContextManifest(
   projectDir: string,
   featureId: string,
@@ -59,6 +63,50 @@ export async function writeContextManifest(
   const filePath = contextManifestPath(projectDir, featureId, storyId, stage);
   await _manifestStoreDeps.mkdirp(dirname(filePath));
   await _manifestStoreDeps.writeFile(filePath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+export interface RebuildManifestEntry {
+  requestId: string;
+  stage: string;
+  priorAgentId: string;
+  newAgentId: string;
+  failureCategory: string;
+  failureOutcome: string;
+  priorChunkIds: string[];
+  newChunkIds: string[];
+  chunkIdMap: Array<{ priorChunkId: string; newChunkId: string }>;
+  createdAt: string;
+}
+
+interface RebuildManifestFile {
+  storyId: string;
+  events: RebuildManifestEntry[];
+}
+
+export async function writeRebuildManifest(
+  projectDir: string,
+  featureId: string,
+  storyId: string,
+  entry: RebuildManifestEntry,
+): Promise<void> {
+  const filePath = rebuildManifestPath(projectDir, featureId, storyId);
+  await _manifestStoreDeps.mkdirp(dirname(filePath));
+
+  const current: RebuildManifestFile = { storyId, events: [] };
+  if (await _manifestStoreDeps.fileExists(filePath)) {
+    try {
+      const raw = await _manifestStoreDeps.readFile(filePath);
+      const parsed = JSON.parse(raw) as RebuildManifestFile;
+      if (Array.isArray(parsed.events)) {
+        current.events = parsed.events;
+      }
+    } catch {
+      // Fall through — malformed files are replaced with a valid manifest.
+    }
+  }
+
+  current.events.push(entry);
+  await _manifestStoreDeps.writeFile(filePath, `${JSON.stringify(current, null, 2)}\n`);
 }
 
 export interface StoredContextManifest {

--- a/src/context/engine/orchestrator-factory.ts
+++ b/src/context/engine/orchestrator-factory.ts
@@ -52,12 +52,13 @@ export function createDefaultOrchestrator(
   // Phase 3: git history and code neighbors (always registered; active only when
   // request.touchedFiles is non-empty and the stage includes these provider IDs)
   // #507: scope is read from config so operators can tune for monorepo setups.
-  const providerConfig = config.context.v2.providers;
-  providers.push(new GitHistoryProvider({ historyScope: providerConfig.historyScope }));
+  // Optional-chain: tests that bypass Zod schema may omit the providers sub-object.
+  const providerConfig = config.context?.v2?.providers;
+  providers.push(new GitHistoryProvider({ historyScope: providerConfig?.historyScope ?? "package" }));
   providers.push(
     new CodeNeighborProvider({
-      neighborScope: providerConfig.neighborScope,
-      crossPackageDepth: providerConfig.crossPackageDepth,
+      neighborScope: providerConfig?.neighborScope ?? "package",
+      crossPackageDepth: providerConfig?.crossPackageDepth ?? 1,
     }),
   );
   // Phase 7: plugin providers (RAG, graph, KB, etc.)

--- a/src/context/engine/orchestrator-factory.ts
+++ b/src/context/engine/orchestrator-factory.ts
@@ -7,6 +7,7 @@
 
 import type { NaxConfig } from "../../config/types";
 import type { UserStory } from "../../prd";
+import { DEFAULT_CANONICAL_RULES_BUDGET_TOKENS } from "../rules/canonical-loader";
 import { ContextOrchestrator } from "./orchestrator";
 import { CodeNeighborProvider } from "./providers/code-neighbor";
 import { FeatureContextProviderV2 } from "./providers/feature-context";
@@ -38,8 +39,9 @@ export function createDefaultOrchestrator(
   additionalProviders: IContextProvider[] = [],
 ): ContextOrchestrator {
   const allowLegacyClaudeMd = config.context?.v2?.rules?.allowLegacyClaudeMd ?? false;
+  const rulesBudgetTokens = config.context?.v2?.rules?.budgetTokens ?? DEFAULT_CANONICAL_RULES_BUDGET_TOKENS;
   const providers: IContextProvider[] = [
-    new StaticRulesProvider({ allowLegacyClaudeMd }),
+    new StaticRulesProvider({ allowLegacyClaudeMd, budgetTokens: rulesBudgetTokens }),
     new FeatureContextProviderV2(story, config),
   ];
   if (storyScratchDirs && storyScratchDirs.length > 0) {

--- a/src/context/engine/orchestrator-factory.ts
+++ b/src/context/engine/orchestrator-factory.ts
@@ -20,8 +20,9 @@ import type { IContextProvider } from "./types";
  * Build a default orchestrator for Phase 0–7+.
  * Providers are constructed with story/config bound where needed.
  *
- * When storyScratchDirs is provided, `SessionScratchProvider` is registered
- * so the verify/rectify stages can see prior scratch observations.
+ * `SessionScratchProvider` is always registered; the provider itself reads
+ * scratch dirs from `ContextRequest.storyScratchDirs` at fetch time and
+ * returns an empty result when none are supplied.
  *
  * Phase 7: accepts pre-loaded plugin providers (RAG/graph/KB) via
  * `additionalProviders`. Callers are responsible for loading these via
@@ -29,13 +30,13 @@ import type { IContextProvider } from "./types";
  *
  * @param story              - current story (needed by FeatureContextProviderV2)
  * @param config             - nax config (needed by FeatureContextProviderV2)
- * @param storyScratchDirs   - scratch dirs for this story's sessions (Phase 1+)
+ * @param _storyScratchDirs  - retained for API compatibility; provider reads from request
  * @param additionalProviders - pre-loaded plugin providers (Phase 7+)
  */
 export function createDefaultOrchestrator(
   story: UserStory,
   config: NaxConfig,
-  storyScratchDirs?: string[],
+  _storyScratchDirs?: string[],
   additionalProviders: IContextProvider[] = [],
 ): ContextOrchestrator {
   const allowLegacyClaudeMd = config.context?.v2?.rules?.allowLegacyClaudeMd ?? false;
@@ -44,9 +45,10 @@ export function createDefaultOrchestrator(
     new StaticRulesProvider({ allowLegacyClaudeMd, budgetTokens: rulesBudgetTokens }),
     new FeatureContextProviderV2(story, config),
   ];
-  if (storyScratchDirs && storyScratchDirs.length > 0) {
-    providers.push(new SessionScratchProvider());
-  }
+  // SessionScratchProvider is always registered so stage-config references to
+  // "session-scratch" pass AC-16 validation. It returns empty chunks when
+  // request.storyScratchDirs is empty (verify/rectify stages supply dirs).
+  providers.push(new SessionScratchProvider());
   // Phase 3: git history and code neighbors (always registered; active only when
   // request.touchedFiles is non-empty and the stage includes these provider IDs)
   // #507: scope is read from config so operators can tune for monorepo setups.

--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -13,6 +13,7 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
+import { NaxError } from "../../errors";
 import { getLogger } from "../../logger";
 import { errorMessage } from "../../utils/errors";
 import { AGENT_PROFILES, getAgentProfile } from "./agent-profiles";
@@ -237,10 +238,20 @@ export class ContextOrchestrator {
     const registeredIds = new Set(this.providers.map((p) => p.id));
     const unknownProviderIds = allowedIds.filter((id) => !registeredIds.has(id));
     if (unknownProviderIds.length > 0) {
-      logger.warn("context-v2", "Unknown provider IDs in request — no matching provider registered", {
+      logger.error("context-v2", "Unknown provider IDs in request", {
         storyId: request.storyId,
+        stage: request.stage,
         unknownProviderIds,
+        availableProviderIds: [...registeredIds].sort(),
       });
+      throw new NaxError(
+        `Unknown context provider ID(s): ${unknownProviderIds.join(", ")}. Available providers: ${[...registeredIds].sort().join(", ")}`,
+        "CONTEXT_UNKNOWN_PROVIDER_IDS",
+        {
+          stage: "context-v2",
+          storyId: request.storyId,
+        },
+      );
     }
 
     // Step 2: parallel fetch with timeout — failures return empty, never throw.
@@ -399,7 +410,6 @@ export class ContextOrchestrator {
       packageDir: request.packageDir,
       ...(Object.keys(chunkSummaries).length > 0 && { chunkSummaries }),
       ...(staleChunkIds.length > 0 && { staleChunks: staleChunkIds }),
-      ...(unknownProviderIds.length > 0 && { unknownProviderIds }),
     };
 
     logger.debug("context-v2", "Bundle assembled", {
@@ -489,6 +499,12 @@ export class ContextOrchestrator {
             failureOutcome: failure.outcome,
             priorChunkIds,
             newChunkIds: packedChunks.map((c) => c.id),
+            chunkIdMap: priorChunkIds
+              .map((priorChunkId, index) => {
+                const newChunkId = packedChunks[index]?.id;
+                return newChunkId ? { priorChunkId, newChunkId } : null;
+              })
+              .filter((entry): entry is { priorChunkId: string; newChunkId: string } => entry !== null),
           }
         : undefined;
 

--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -234,24 +234,29 @@ export class ContextOrchestrator {
       (p) => allowedIds.includes(p.id) && !(request.deterministic === true && p.deterministic === false),
     );
 
-    // AC-16: detect providerIds that matched no registered provider.
-    const registeredIds = new Set(this.providers.map((p) => p.id));
-    const unknownProviderIds = allowedIds.filter((id) => !registeredIds.has(id));
-    if (unknownProviderIds.length > 0) {
-      logger.error("context-v2", "Unknown provider IDs in request", {
-        storyId: request.storyId,
-        stage: request.stage,
-        unknownProviderIds,
-        availableProviderIds: [...registeredIds].sort(),
-      });
-      throw new NaxError(
-        `Unknown context provider ID(s): ${unknownProviderIds.join(", ")}. Available providers: ${[...registeredIds].sort().join(", ")}`,
-        "CONTEXT_UNKNOWN_PROVIDER_IDS",
-        {
-          stage: "context-v2",
+    // AC-16: detect providerIds configured by the user that matched no registered provider.
+    // The check is scoped to config-derived IDs (stageConfig.providerIds) — request.providerIds
+    // is a test-only override and is intentionally permitted to reference unregistered IDs so
+    // tests can assert "unknown ID filters to empty" semantics without registering stubs.
+    if (request.providerIds === undefined) {
+      const registeredIds = new Set(this.providers.map((p) => p.id));
+      const unknownProviderIds = stageConfig.providerIds.filter((id) => !registeredIds.has(id));
+      if (unknownProviderIds.length > 0) {
+        logger.error("context-v2", "Unknown provider IDs in stage config", {
           storyId: request.storyId,
-        },
-      );
+          stage: request.stage,
+          unknownProviderIds,
+          availableProviderIds: [...registeredIds].sort(),
+        });
+        throw new NaxError(
+          `Unknown context provider ID(s): ${unknownProviderIds.join(", ")}. Available providers: ${[...registeredIds].sort().join(", ")}`,
+          "CONTEXT_UNKNOWN_PROVIDER_IDS",
+          {
+            stage: "context-v2",
+            storyId: request.storyId,
+          },
+        );
+      }
     }
 
     // Step 2: parallel fetch with timeout — failures return empty, never throw.

--- a/src/context/engine/providers/feature-context.ts
+++ b/src/context/engine/providers/feature-context.ts
@@ -40,6 +40,14 @@ function contentHash8(content: string): string {
   return createHash("sha256").update(content).digest("hex").slice(0, 8);
 }
 
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function renderEntryContent(section: string, text: string): string {
+  return section ? `### ${section}\n\n${text}` : text;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Provider
 // ─────────────────────────────────────────────────────────────────────────────
@@ -77,7 +85,7 @@ export class FeatureContextProviderV2 implements IContextProvider {
       }
 
       const hash = contentHash8(result.content);
-      let chunk: RawChunk = {
+      const baseChunk: RawChunk = {
         id: `feature-context:${hash}`,
         kind: "feature",
         scope: "feature",
@@ -87,6 +95,8 @@ export class FeatureContextProviderV2 implements IContextProvider {
         rawScore: 1.0,
       };
 
+      let chunks: RawChunk[] = [baseChunk];
+
       // Amendment A AC-46/AC-47: staleness detection (read-time, no LLM).
       const stalenessConfig = this.config.context?.v2?.staleness;
       if (stalenessConfig?.enabled !== false) {
@@ -94,22 +104,36 @@ export class FeatureContextProviderV2 implements IContextProvider {
         const scoreMultiplier = stalenessConfig?.scoreMultiplier ?? 0.4;
 
         const entries = parseFeatureContextEntries(result.content);
-        if (entries.length > 0) {
+        if (entries.length > 1) {
           const contradicted = detectContradictions(entries);
           const ageStale = selectStaleByAge(entries, maxStoryAge);
-          const staleCount = contradicted.size + ageStale.size;
-          const staleRatio = staleCount / entries.length;
-          const isStale = staleRatio > 0;
-          const effectiveMultiplier = isStale ? 1.0 - (1.0 - scoreMultiplier) * staleRatio : scoreMultiplier;
-          chunk = applyStaleness(chunk, { isStale, scoreMultiplier: effectiveMultiplier });
+          chunks = entries.map((entry) => {
+            const entryContent = renderEntryContent(entry.section, entry.text);
+            const entryChunk: RawChunk = {
+              id: `feature-context:${hash}:entry-${entry.index}`,
+              kind: "feature",
+              scope: "feature",
+              role: ["implementer", "reviewer", "tdd"],
+              content: entryContent,
+              tokens: estimateTokens(entryContent),
+              rawScore: 1.0,
+            };
+            const isStale = contradicted.has(entry.index) || ageStale.has(entry.index);
+            return applyStaleness(entryChunk, { isStale, scoreMultiplier });
+          });
 
-          if (isStale) {
+          if (chunks.some((chunk) => chunk.staleCandidate)) {
             logger.debug("feature-context-v2", "Stale entries detected in feature context", {
               storyId: request.storyId,
               contradicted: contradicted.size,
               ageStale: ageStale.size,
             });
           }
+        } else if (entries.length === 1) {
+          const contradicted = detectContradictions(entries);
+          const ageStale = selectStaleByAge(entries, maxStoryAge);
+          const isStale = contradicted.has(entries[0].index) || ageStale.has(entries[0].index);
+          chunks = [applyStaleness(baseChunk, { isStale, scoreMultiplier })];
         }
       }
 
@@ -119,7 +143,7 @@ export class FeatureContextProviderV2 implements IContextProvider {
         tokens: result.estimatedTokens,
       });
 
-      return { chunks: [chunk], pullTools: [] };
+      return { chunks, pullTools: [] };
     } catch (err) {
       logger.warn("feature-context-v2", "Failed to fetch feature context — returning empty", {
         storyId: request.storyId,

--- a/src/context/engine/providers/static-rules.ts
+++ b/src/context/engine/providers/static-rules.ts
@@ -17,7 +17,11 @@ import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { getLogger } from "../../../logger";
 import { errorMessage } from "../../../utils/errors";
-import { loadCanonicalRules } from "../../rules/canonical-loader";
+import {
+  DEFAULT_CANONICAL_RULES_BUDGET_TOKENS,
+  applyCanonicalRulesBudget,
+  loadCanonicalRules,
+} from "../../rules/canonical-loader";
 import type { CanonicalRule } from "../../rules/canonical-loader";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
@@ -60,6 +64,8 @@ export interface StaticRulesProviderOptions {
    * Set true only during migration to the canonical .nax/rules/ store.
    */
   allowLegacyClaudeMd?: boolean;
+  /** Token budget for static rules chunk emission. Default: 8192 */
+  budgetTokens?: number;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -148,9 +154,11 @@ export class StaticRulesProvider implements IContextProvider {
   readonly kind = "static" as const;
 
   private readonly allowLegacyClaudeMd: boolean;
+  private readonly budgetTokens: number;
 
   constructor(options: StaticRulesProviderOptions = {}) {
     this.allowLegacyClaudeMd = options.allowLegacyClaudeMd ?? false;
+    this.budgetTokens = options.budgetTokens ?? DEFAULT_CANONICAL_RULES_BUDGET_TOKENS;
   }
 
   async fetch(request: ContextRequest): Promise<ContextProviderResult> {
@@ -179,7 +187,35 @@ export class StaticRulesProvider implements IContextProvider {
 
       if (mergedRules.length > 0) {
         const scopedRules = mergedRules.filter((rule) => ruleMatchesTouchedFiles(rule.appliesTo, request.touchedFiles));
-        const chunks = scopedRules.map((rule) => {
+        const budgetResult = applyCanonicalRulesBudget(scopedRules, this.budgetTokens);
+        if (budgetResult.totalTokens >= Math.floor(this.budgetTokens * 0.75)) {
+          logger.warn("static-rules", "Canonical rules are approaching/exceeding static rules budget", {
+            storyId: request.storyId,
+            totalTokens: budgetResult.totalTokens,
+            budgetTokens: this.budgetTokens,
+            droppedCount: budgetResult.droppedCount,
+          });
+        }
+        if (budgetResult.droppedCount > 0) {
+          logger.warn("static-rules", "Canonical rules truncated by static rules budget", {
+            storyId: request.storyId,
+            totalTokens: budgetResult.totalTokens,
+            usedTokens: budgetResult.usedTokens,
+            budgetTokens: this.budgetTokens,
+            droppedCount: budgetResult.droppedCount,
+          });
+        }
+
+        const effectiveRules = budgetResult.rules;
+        if (effectiveRules.length === 0) {
+          logger.warn("static-rules", "No canonical rules fit in static rules budget", {
+            storyId: request.storyId,
+            budgetTokens: this.budgetTokens,
+            totalScopedRules: scopedRules.length,
+          });
+          return { chunks: [], pullTools: [] };
+        }
+        const chunks = effectiveRules.map((rule) => {
           const hash = contentHash8(rule.content);
           const tokens = estimateTokens(rule.content);
           const ruleId = canonicalRuleId(rule);
@@ -199,7 +235,7 @@ export class StaticRulesProvider implements IContextProvider {
 
         logger.debug("static-rules", "Loaded canonical rules", {
           storyId: request.storyId,
-          fileCount: scopedRules.length,
+          fileCount: effectiveRules.length,
           totalCanonicalRules: mergedRules.length,
         });
 

--- a/src/context/engine/providers/static-rules.ts
+++ b/src/context/engine/providers/static-rules.ts
@@ -28,6 +28,13 @@ import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk 
 export const _staticRulesDeps = {
   readFile: async (path: string): Promise<string> => Bun.file(path).text(),
   fileExists: async (path: string): Promise<boolean> => Bun.file(path).exists(),
+  globInDir: (dir: string): string[] => {
+    try {
+      return [...new Bun.Glob("**/*.md").scanSync({ cwd: dir, absolute: false })].sort().map((f) => join(dir, f));
+    } catch {
+      return [];
+    }
+  },
   loadCanonicalRules,
 };
 
@@ -40,6 +47,7 @@ export const _staticRulesDeps = {
  * Only used when .nax/rules/ is absent and allowLegacyClaudeMd is true.
  */
 const LEGACY_CANDIDATE_FILES = ["CLAUDE.md", ".cursorrules", "AGENTS.md"];
+const LEGACY_RULES_DIR = ".claude/rules";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Options
@@ -64,6 +72,71 @@ function contentHash8(content: string): string {
 
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
+}
+
+function canonicalRuleId(rule: CanonicalRule): string {
+  return rule.id ?? rule.fileName.replace(/\.md$/i, "");
+}
+
+function canonicalRulePath(rule: CanonicalRule): string {
+  return rule.path ?? rule.fileName;
+}
+
+function canonicalRulePriority(rule: CanonicalRule): number {
+  return rule.priority ?? 100;
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function globToRegex(pattern: string): RegExp {
+  let regex = "";
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i];
+    if (c === "*") {
+      if (pattern[i + 1] === "*") {
+        const beforeSlash = i > 0 && pattern[i - 1] === "/";
+        const afterSlash = pattern[i + 2] === "/";
+        if (beforeSlash && afterSlash) {
+          regex = `${regex.slice(0, -1)}(?:.*\\/)?`;
+          i += 3;
+        } else if (afterSlash) {
+          regex += "(?:.*\\/)?";
+          i += 3;
+        } else {
+          regex += ".*";
+          i += 2;
+        }
+        continue;
+      }
+      regex += "[^/]*";
+      i++;
+      continue;
+    }
+    if (c === "?") {
+      regex += "[^/]";
+      i++;
+      continue;
+    }
+    if (".+^${}()|[]\\".includes(c)) {
+      regex += `\\${c}`;
+    } else {
+      regex += c;
+    }
+    i++;
+  }
+  return new RegExp(`(?:^|/)${regex}$`);
+}
+
+function ruleMatchesTouchedFiles(appliesTo: string[] | undefined, touchedFiles: string[] | undefined): boolean {
+  if (!appliesTo || appliesTo.length === 0) return true;
+  if (!touchedFiles || touchedFiles.length === 0) return true;
+
+  const files = touchedFiles.map((f) => normalizePath(f));
+  const patterns = appliesTo.map((p) => globToRegex(normalizePath(p)));
+  return files.some((file) => patterns.some((pattern) => pattern.test(file)));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -93,24 +166,32 @@ export class StaticRulesProvider implements IContextProvider {
         const packageRules = await _staticRulesDeps.loadCanonicalRules(request.packageDir);
         if (packageRules.length > 0) {
           const merged = new Map<string, CanonicalRule>();
-          for (const rule of repoRules) merged.set(rule.fileName, rule);
-          for (const rule of packageRules) merged.set(rule.fileName, rule);
+          for (const rule of repoRules) merged.set(canonicalRuleId(rule), rule);
+          for (const rule of packageRules) merged.set(canonicalRuleId(rule), rule);
           mergedRules = [...merged.values()];
         }
       }
 
+      mergedRules.sort(
+        (a, b) =>
+          canonicalRulePriority(a) - canonicalRulePriority(b) || canonicalRuleId(a).localeCompare(canonicalRuleId(b)),
+      );
+
       if (mergedRules.length > 0) {
-        const chunks = mergedRules.map((rule) => {
+        const scopedRules = mergedRules.filter((rule) => ruleMatchesTouchedFiles(rule.appliesTo, request.touchedFiles));
+        const chunks = scopedRules.map((rule) => {
           const hash = contentHash8(rule.content);
           const tokens = estimateTokens(rule.content);
+          const ruleId = canonicalRuleId(rule);
+          const rulePath = canonicalRulePath(rule);
           return {
             // Include fileName so two rules with identical content but different names
             // are not deduplicated by the packing stage (content-hash collision).
-            id: `static-rules:${rule.fileName}:${hash}`,
+            id: `static-rules:${ruleId}:${hash}`,
             kind: "static" as const,
             scope: "project" as const,
             role: ["all"] as ["all"],
-            content: `### ${rule.fileName}\n\n${rule.content}`,
+            content: `### ${rulePath}\n\n${rule.content}`,
             tokens,
             rawScore: 1.0,
           } satisfies RawChunk;
@@ -118,7 +199,8 @@ export class StaticRulesProvider implements IContextProvider {
 
         logger.debug("static-rules", "Loaded canonical rules", {
           storyId: request.storyId,
-          fileCount: chunks.length,
+          fileCount: scopedRules.length,
+          totalCanonicalRules: mergedRules.length,
         });
 
         return { chunks, pullTools: [] };
@@ -182,8 +264,31 @@ export class StaticRulesProvider implements IContextProvider {
       });
     }
 
+    const legacySources: Array<{ sourceId: string; filePath: string; heading: string }> = [];
+
     for (const fileName of LEGACY_CANDIDATE_FILES) {
-      const filePath = join(rootDir, fileName);
+      legacySources.push({
+        sourceId: fileName,
+        filePath: join(rootDir, fileName),
+        heading: fileName,
+      });
+    }
+
+    const rulesDir = join(rootDir, LEGACY_RULES_DIR);
+    const nestedRulePaths = _staticRulesDeps.globInDir(rulesDir);
+    for (const filePath of nestedRulePaths) {
+      const normalized = normalizePath(filePath);
+      const rulesRoot = normalizePath(`${rulesDir}/`);
+      const rel = normalized.startsWith(rulesRoot) ? normalized.slice(rulesRoot.length) : normalized;
+      legacySources.push({
+        sourceId: `${LEGACY_RULES_DIR}/${rel}`,
+        filePath,
+        heading: `${LEGACY_RULES_DIR}/${rel}`,
+      });
+    }
+
+    for (const { sourceId, filePath, heading } of legacySources) {
+      const fileName = heading;
 
       try {
         const exists = await _staticRulesDeps.fileExists(filePath);
@@ -196,11 +301,11 @@ export class StaticRulesProvider implements IContextProvider {
         const tokens = estimateTokens(content);
 
         chunks.push({
-          id: `static-rules:${hash}`,
+          id: `static-rules:legacy:${sourceId}:${hash}`,
           kind: "static",
           scope: "project",
           role: ["all"],
-          content: `### ${fileName}\n\n${content.trim()}`,
+          content: `### ${heading}\n\n${content.trim()}`,
           tokens,
           rawScore: 1.0,
         });
@@ -210,9 +315,6 @@ export class StaticRulesProvider implements IContextProvider {
           file: fileName,
           tokens,
         });
-
-        // Only load the first candidate found
-        break;
       } catch (err) {
         logger.warn("static-rules", `Failed to read ${fileName} — skipping`, {
           storyId: request.storyId,

--- a/src/context/engine/pull-tools.ts
+++ b/src/context/engine/pull-tools.ts
@@ -228,17 +228,17 @@ export async function handleQueryNeighbor(
 
 /**
  * Filter feature context content by a keyword or section heading.
- * Splits on level-2 markdown headings (## ...) and keeps sections
- * whose text contains the keyword (case-insensitive).
- * When no ## headings are found, returns the full content unchanged
- * (section-based filtering is not possible on flat content).
- * Returns empty string when sections exist but none match the keyword.
+ * Splits on any markdown heading of level ≥ 2 (## ..., ### ..., …) and keeps
+ * sections whose text contains the keyword (case-insensitive). Providers may
+ * re-render top-level `##` headings as `###` when nesting content under a
+ * parent chunk heading, so the split must accept both.
+ * When no headings are found, returns the full content unchanged (section-based
+ * filtering is not possible on flat content). Returns empty string when
+ * sections exist but none match the keyword.
  */
 function filterByKeyword(content: string, keyword: string): string {
   const lower = keyword.toLowerCase();
-  // Split on level-2 headings; keep each "## ..." block together
-  const sections = content.split(/(?=^##\s)/m);
-  // No headings — can't section-filter flat content; return all
+  const sections = content.split(/(?=^#{2,}\s)/m);
   if (sections.length <= 1) return content;
   const matched = sections.filter((s) => s.toLowerCase().includes(lower));
   return matched.join("");

--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -16,6 +16,7 @@
 
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
+import { NaxError } from "../../errors";
 import { getLogger } from "../../logger";
 import type { PipelineContext } from "../../pipeline/types";
 import { getContextFiles } from "../../prd/types";
@@ -203,6 +204,9 @@ export async function assembleForStage(
     }
     return bundle;
   } catch (err) {
+    if (err instanceof NaxError && err.code === "CONTEXT_UNKNOWN_PROVIDER_IDS") {
+      throw err;
+    }
     logger.warn("context-v2", `assembleForStage failed for stage "${stage}"`, {
       storyId: ctx.story.id,
       error: errorMessage(err),

--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -20,6 +20,7 @@ import { getLogger } from "../../logger";
 import type { PipelineContext } from "../../pipeline/types";
 import { getContextFiles } from "../../prd/types";
 import { errorMessage } from "../../utils/errors";
+import { estimateAvailableBudgetTokens } from "./available-budget";
 import { writeContextManifest } from "./manifest-store";
 import { createDefaultOrchestrator } from "./orchestrator-factory";
 import { loadPluginProviders } from "./providers/plugin-loader";
@@ -162,6 +163,8 @@ export async function assembleForStage(
     // AC-54: resolve dual workdir fields. repoRoot is the project root (where .nax/ lives);
     // packageDir is the story's package directory (equals repoRoot for non-monorepo).
     const packageDir = ctx.story.workdir ? join(ctx.workdir, ctx.story.workdir) : ctx.workdir;
+    const targetAgentId =
+      ctx.routing.agent ?? ctx.rootConfig?.autoMode?.defaultAgent ?? ctx.config.autoMode?.defaultAgent ?? "claude";
 
     const request: ContextRequest = {
       storyId: ctx.story.id,
@@ -185,8 +188,8 @@ export async function assembleForStage(
           }
         : undefined,
       sessionId: ctx.sessionId,
-      agentId:
-        ctx.routing.agent ?? ctx.rootConfig?.autoMode?.defaultAgent ?? ctx.config.autoMode?.defaultAgent ?? "claude",
+      agentId: targetAgentId,
+      availableBudgetTokens: estimateAvailableBudgetTokens(targetAgentId, ctx.prompt),
       // AC-24: propagate determinism flag to every assembled stage, not just the context stage.
       deterministic: ctx.config.context.v2.deterministic,
       // AC-51: propagate planDigestBoost from the routing test strategy so the boost applies

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -227,12 +227,9 @@ export interface ContextManifest {
     priorChunkIds: string[];
     /** Chunk IDs in the rebuilt bundle, including any injected failure-note (AC-39). */
     newChunkIds: string[];
+    /** Best-effort correlation from prior chunk ID to rebuilt chunk ID (AC-39). */
+    chunkIdMap: Array<{ priorChunkId: string; newChunkId: string }>;
   };
-  /**
-   * Provider IDs in request.providerIds that matched no registered provider (AC-16).
-   * Absent when all IDs are known or providerIds is empty.
-   */
-  unknownProviderIds?: string[];
   /**
    * First 300 chars of each included chunk's content (Amendment A AC-45).
    * Written at assemble() time; used by annotateManifestEffectiveness() post-story

--- a/src/context/rules/canonical-loader.ts
+++ b/src/context/rules/canonical-loader.ts
@@ -91,6 +91,8 @@ const BANNED_PATTERNS: BannedPattern[] = [
 ];
 
 const FRONTMATTER_PRIORITY_DEFAULT = 100;
+export const DEFAULT_CANONICAL_RULES_BUDGET_TOKENS = 8_192;
+const RULES_BUDGET_WARNING_RATIO = 0.75;
 const RULE_ALLOW_MARKER = /<!--\s*nax-rules-allow:\s*([a-z0-9,\s-]+)\s*-->/gi;
 
 export interface NeutralityViolation {
@@ -263,6 +265,54 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
+export interface CanonicalRulesBudgetResult {
+  rules: CanonicalRule[];
+  totalTokens: number;
+  usedTokens: number;
+  droppedCount: number;
+}
+
+/**
+ * Apply tail-biased truncation using canonical ordering:
+ * lower priority first, then rule id/path alphabetical.
+ *
+ * Rules that exceed budget are dropped from the tail so higher-priority rules
+ * survive whenever possible.
+ */
+export function applyCanonicalRulesBudget(rules: CanonicalRule[], budgetTokens: number): CanonicalRulesBudgetResult {
+  if (!Number.isFinite(budgetTokens) || budgetTokens <= 0) {
+    return {
+      rules: [],
+      totalTokens: rules.reduce((sum, r) => sum + (r.tokens ?? estimateTokens(r.content)), 0),
+      usedTokens: 0,
+      droppedCount: rules.length,
+    };
+  }
+
+  const totalTokens = rules.reduce((sum, rule) => sum + (rule.tokens ?? estimateTokens(rule.content)), 0);
+  let usedTokens = 0;
+  const kept: CanonicalRule[] = [];
+
+  for (const rule of rules) {
+    const tokens = rule.tokens ?? estimateTokens(rule.content);
+    if (usedTokens + tokens > budgetTokens) continue;
+    kept.push(rule);
+    usedTokens += tokens;
+  }
+
+  return {
+    rules: kept,
+    totalTokens,
+    usedTokens,
+    droppedCount: Math.max(0, rules.length - kept.length),
+  };
+}
+
+export interface LoadCanonicalRulesOptions {
+  /** Optional ceiling for loaded canonical rules. When omitted, no truncation is applied. */
+  budgetTokens?: number;
+}
+
 /**
  * Load all `.md` files from `.nax/rules/` under the given workdir.
  * Files are sorted alphabetically to ensure deterministic ordering.
@@ -270,7 +320,10 @@ function estimateTokens(text: string): number {
  * Throws NeutralityLintError if any file contains banned markers.
  * Returns an empty array if the `.nax/rules/` directory does not exist.
  */
-export async function loadCanonicalRules(workdir: string): Promise<CanonicalRule[]> {
+export async function loadCanonicalRules(
+  workdir: string,
+  options: LoadCanonicalRulesOptions = {},
+): Promise<CanonicalRule[]> {
   const logger = _canonicalLoaderDeps.getLogger();
   const rulesDir = join(workdir, CANONICAL_RULES_DIR);
 
@@ -349,5 +402,30 @@ export async function loadCanonicalRules(workdir: string): Promise<CanonicalRule
     files: rules.map((r) => r.path),
   });
 
-  return rules;
+  if (options.budgetTokens === undefined) {
+    return rules;
+  }
+
+  const budgetResult = applyCanonicalRulesBudget(rules, options.budgetTokens);
+  const warningThreshold = Math.floor(options.budgetTokens * RULES_BUDGET_WARNING_RATIO);
+  if (budgetResult.totalTokens >= warningThreshold) {
+    logger.warn("canonical-loader", "Canonical rules are approaching/exceeding budget", {
+      fileCount: rules.length,
+      totalTokens: budgetResult.totalTokens,
+      budgetTokens: options.budgetTokens,
+      warningThreshold,
+      droppedCount: budgetResult.droppedCount,
+    });
+  }
+  if (budgetResult.droppedCount > 0) {
+    logger.warn("canonical-loader", "Canonical rules truncated by budget (tail-biased by priority)", {
+      droppedCount: budgetResult.droppedCount,
+      keptCount: budgetResult.rules.length,
+      totalTokens: budgetResult.totalTokens,
+      usedTokens: budgetResult.usedTokens,
+      budgetTokens: options.budgetTokens,
+    });
+  }
+
+  return budgetResult.rules;
 }

--- a/src/context/rules/canonical-loader.ts
+++ b/src/context/rules/canonical-loader.ts
@@ -39,7 +39,25 @@ export const _canonicalLoaderDeps = {
   readFile: async (path: string): Promise<string> => Bun.file(path).text(),
   globInDir: (dir: string): string[] => {
     try {
-      return [...new Bun.Glob("*.md").scanSync({ cwd: dir })].sort().map((f) => join(dir, f));
+      const logger = getLogger();
+      const files = [...new Bun.Glob("**/*.md").scanSync({ cwd: dir, absolute: false })].sort();
+      const kept: string[] = [];
+      const ignored: string[] = [];
+      for (const rel of files) {
+        const depth = rel.split("/").length - 1;
+        if (depth <= 1) {
+          kept.push(join(dir, rel));
+        } else {
+          ignored.push(rel);
+        }
+      }
+      if (ignored.length > 0) {
+        logger.warn("canonical-loader", "Ignoring canonical rule files deeper than one level", {
+          ignoredCount: ignored.length,
+          ignored: ignored.slice(0, 20),
+        });
+      }
+      return kept;
     } catch {
       return [];
     }
@@ -52,24 +70,50 @@ export const _canonicalLoaderDeps = {
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface BannedPattern {
+  id: string;
   regex: RegExp;
   description: string;
 }
 
 const BANNED_PATTERNS: BannedPattern[] = [
-  { regex: /<system-reminder>/i, description: "agent XML tag <system-reminder>" },
-  { regex: /CLAUDE\.md/, description: "agent-specific file reference CLAUDE.md" },
-  { regex: /\.claude\//, description: "agent-specific directory .claude/" },
-  { regex: /\bthe [A-Za-z]+ tool\b/i, description: "agent-specific tool-name phrasing" },
-  { regex: /\bIMPORTANT:/, description: "shouting-style IMPORTANT:" },
-  { regex: /\p{Extended_Pictographic}/u, description: "emoji character" },
+  { id: "xml-tag", regex: /<system-reminder>|<ide_diagnostics>/i, description: "agent-specific XML tag" },
+  { id: "claude-reference", regex: /CLAUDE\.md/, description: "agent-specific file reference CLAUDE.md" },
+  { id: "codex-reference", regex: /AGENTS\.md/, description: "agent-specific file reference AGENTS.md" },
+  { id: "gemini-reference", regex: /GEMINI\.md/, description: "agent-specific file reference GEMINI.md" },
+  { id: "agent-directory", regex: /\.claude\/|\.codex\/|\.gemini\//, description: "agent-specific directory path" },
+  {
+    id: "tool-phrasing",
+    regex: /\bthe [A-Za-z][A-Za-z0-9_-]* tool\b/i,
+    description: "agent-specific tool-name phrasing",
+  },
+  { id: "important-shouting", regex: /\bIMPORTANT:/, description: "shouting-style IMPORTANT:" },
+  { id: "emoji", regex: /\p{Extended_Pictographic}/u, description: "emoji character" },
 ];
+
+const FRONTMATTER_PRIORITY_DEFAULT = 100;
+const RULE_ALLOW_MARKER = /<!--\s*nax-rules-allow:\s*([a-z0-9,\s-]+)\s*-->/gi;
 
 export interface NeutralityViolation {
   file: string;
   lineNumber: number;
   line: string;
+  ruleId: string;
   pattern: string;
+}
+
+function parseRuleAllowMarker(line: string): Set<string> {
+  const allowed = new Set<string>();
+  RULE_ALLOW_MARKER.lastIndex = 0;
+  while (true) {
+    const match = RULE_ALLOW_MARKER.exec(line);
+    if (!match) break;
+    const body = match[1] ?? "";
+    for (const token of body.split(",")) {
+      const id = token.trim().toLowerCase();
+      if (id) allowed.add(id);
+    }
+  }
+  return allowed;
 }
 
 /**
@@ -82,12 +126,15 @@ export function lintForNeutrality(content: string, fileName: string): Neutrality
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? "";
-    for (const { regex, description } of BANNED_PATTERNS) {
+    const allowList = parseRuleAllowMarker(line);
+    for (const { id, regex, description } of BANNED_PATTERNS) {
+      if (allowList.has(id)) continue;
       if (regex.test(line)) {
         violations.push({
           file: fileName,
           lineNumber: i + 1,
           line: line.trim(),
+          ruleId: id,
           pattern: description,
         });
         break; // one violation per line is enough to flag it
@@ -121,15 +168,99 @@ export class NeutralityLintError extends NaxError {
   }
 }
 
+export class RulesFrontmatterError extends NaxError {
+  constructor(message: string, filePath: string) {
+    super(message, "RULES_FRONTMATTER_INVALID", {
+      stage: "canonical-loader",
+      filePath,
+    });
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Loader
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface CanonicalRule {
+  /** Rule identifier (relative path without extension, e.g. "frontend/style") */
+  id?: string;
   /** Filename (e.g. "coding-style.md") */
   fileName: string;
+  /** Relative path under .nax/rules (e.g. "frontend/style.md") */
+  path?: string;
   /** Full content of the file */
   content: string;
+  /** Approximate token count for this rule */
+  tokens?: number;
+  /** Priority for truncation/sorting (lower = more important) */
+  priority?: number;
+  /** Optional glob scopes that decide when this rule applies */
+  appliesTo?: string[];
+}
+
+interface ParsedFrontmatter {
+  content: string;
+  priority: number;
+  appliesTo?: string[];
+}
+
+function parseFrontmatter(raw: string, filePath: string): ParsedFrontmatter {
+  if (!raw.startsWith("---\n") && !raw.startsWith("---\r\n")) {
+    return { content: raw.trim(), priority: FRONTMATTER_PRIORITY_DEFAULT };
+  }
+
+  const close = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!close) {
+    throw new RulesFrontmatterError("Canonical rule frontmatter is missing closing '---'", filePath);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = Bun.YAML.parse(close[1] ?? "");
+  } catch (err) {
+    throw new RulesFrontmatterError(
+      `Failed to parse YAML frontmatter: ${err instanceof Error ? err.message : String(err)}`,
+      filePath,
+    );
+  }
+
+  if (parsed !== null && (typeof parsed !== "object" || Array.isArray(parsed))) {
+    throw new RulesFrontmatterError("Frontmatter must be a YAML object", filePath);
+  }
+
+  const doc = (parsed ?? {}) as Record<string, unknown>;
+  const priorityRaw = doc.priority;
+  let priority = FRONTMATTER_PRIORITY_DEFAULT;
+  if (priorityRaw !== undefined) {
+    if (typeof priorityRaw !== "number" || !Number.isFinite(priorityRaw)) {
+      throw new RulesFrontmatterError("frontmatter.priority must be a number", filePath);
+    }
+    priority = Math.trunc(priorityRaw);
+  }
+
+  const appliesRaw = doc.appliesTo;
+  let appliesTo: string[] | undefined;
+  if (appliesRaw !== undefined) {
+    if (typeof appliesRaw === "string") {
+      const trimmed = appliesRaw.trim();
+      if (!trimmed) throw new RulesFrontmatterError("frontmatter.appliesTo cannot be empty", filePath);
+      appliesTo = [trimmed];
+    } else if (Array.isArray(appliesRaw) && appliesRaw.every((v) => typeof v === "string" && v.trim())) {
+      appliesTo = appliesRaw.map((v) => v.trim());
+    } else {
+      throw new RulesFrontmatterError("frontmatter.appliesTo must be a string or string[]", filePath);
+    }
+  }
+
+  return {
+    content: raw.slice(close[0].length).trim(),
+    priority,
+    ...(appliesTo && { appliesTo }),
+  };
+}
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
 }
 
 /**
@@ -143,7 +274,20 @@ export async function loadCanonicalRules(workdir: string): Promise<CanonicalRule
   const logger = _canonicalLoaderDeps.getLogger();
   const rulesDir = join(workdir, CANONICAL_RULES_DIR);
 
-  const filePaths = _canonicalLoaderDeps.globInDir(rulesDir);
+  const allFilePaths = _canonicalLoaderDeps.globInDir(rulesDir);
+  const filePaths = allFilePaths.filter((filePath) => {
+    const normalized = filePath.replaceAll("\\", "/");
+    const normalizedRulesDir = rulesDir.replaceAll("\\", "/");
+    const relativePath = normalized.startsWith(`${normalizedRulesDir}/`)
+      ? normalized.slice(normalizedRulesDir.length + 1)
+      : basename(normalized);
+    return relativePath.split("/").length <= 2;
+  });
+  if (allFilePaths.length > filePaths.length) {
+    logger.warn("canonical-loader", "Ignoring canonical rule files deeper than one level", {
+      ignoredCount: allFilePaths.length - filePaths.length,
+    });
+  }
   if (filePaths.length === 0) {
     return [];
   }
@@ -152,6 +296,11 @@ export async function loadCanonicalRules(workdir: string): Promise<CanonicalRule
   const allViolations: NeutralityViolation[] = [];
 
   for (const filePath of filePaths) {
+    const normalizedPath = filePath.replaceAll("\\", "/");
+    const normalizedRulesDir = rulesDir.replaceAll("\\", "/");
+    const relativePath = normalizedPath.startsWith(`${normalizedRulesDir}/`)
+      ? normalizedPath.slice(normalizedRulesDir.length + 1)
+      : basename(normalizedPath);
     const fileName = basename(filePath);
     let content: string;
     try {
@@ -165,22 +314,39 @@ export async function loadCanonicalRules(workdir: string): Promise<CanonicalRule
 
     if (!content.trim()) continue;
 
-    const violations = lintForNeutrality(content, fileName);
+    const parsed = parseFrontmatter(content, filePath);
+    if (!parsed.content) continue;
+
+    const violations = lintForNeutrality(parsed.content, fileName);
     if (violations.length > 0) {
       allViolations.push(...violations);
       continue; // collect all violations before throwing
     }
 
-    rules.push({ fileName, content: content.trim() });
+    rules.push({
+      id: relativePath.replace(/\.md$/i, ""),
+      fileName,
+      path: relativePath,
+      content: parsed.content,
+      tokens: estimateTokens(parsed.content),
+      priority: parsed.priority,
+      ...(parsed.appliesTo && { appliesTo: parsed.appliesTo }),
+    });
   }
 
   if (allViolations.length > 0) {
     throw new NeutralityLintError(allViolations);
   }
 
+  rules.sort(
+    (a, b) =>
+      (a.priority ?? FRONTMATTER_PRIORITY_DEFAULT) - (b.priority ?? FRONTMATTER_PRIORITY_DEFAULT) ||
+      (a.id ?? a.fileName).localeCompare(b.id ?? b.fileName),
+  );
+
   logger.debug("canonical-loader", "Loaded canonical rules", {
     fileCount: rules.length,
-    files: rules.map((r) => r.fileName),
+    files: rules.map((r) => r.path),
   });
 
   return rules;

--- a/src/context/rules/canonical-loader.ts
+++ b/src/context/rules/canonical-loader.ts
@@ -24,6 +24,11 @@ import { basename, join } from "node:path";
 import { NaxError } from "../../errors";
 import { getLogger } from "../../logger";
 
+// storyId omission note: canonical-rules loading is a project-level operation
+// that runs outside any story context (project-conventions.md §Logging scopes
+// "pipeline/stages/ and review/" — this module is neither). Logger calls here
+// intentionally omit storyId.
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/execution/executor-types.ts
+++ b/src/execution/executor-types.ts
@@ -13,6 +13,7 @@ import type { RoutingResult } from "../pipeline/types";
 import type { AgentGetFn } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins";
 import type { PRD, UserStory } from "../prd/types";
+import type { ISessionManager } from "../session";
 import type { StoryBatch } from "./batching";
 import type { DeferredReviewResult } from "./deferred-review";
 import type { PidRegistry } from "./pid-registry";
@@ -31,6 +32,8 @@ export interface SequentialExecutionContext {
   eventEmitter?: PipelineEventEmitter;
   statusWriter: StatusWriter;
   logFilePath?: string;
+  /** Run-level SessionManager shared across all iterations in this run. */
+  sessionManager?: ISessionManager;
   runId: string;
   startTime: number;
   batchPlan: StoryBatch[];

--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -15,7 +15,6 @@ import { defaultPipeline } from "../pipeline/stages";
 import type { PipelineContext } from "../pipeline/types";
 import { savePRD } from "../prd";
 import type { PRD } from "../prd/types";
-import { SessionManager } from "../session";
 import { errorMessage } from "../utils/errors";
 import { captureGitRef, isGitRefValid } from "../utils/git";
 import { WorktreeManager } from "../worktree/manager";
@@ -145,7 +144,7 @@ export async function runIteration(
     interaction: ctx.interactionChain ?? undefined,
     agentGetFn: ctx.agentGetFn,
     pidRegistry: ctx.pidRegistry,
-    sessionManager: new SessionManager(),
+    sessionManager: ctx.sessionManager,
     accumulatedAttemptCost: accumulatedAttemptCost > 0 ? accumulatedAttemptCost : undefined,
   };
 
@@ -162,18 +161,6 @@ export async function runIteration(
   await ctx.statusWriter.update(totalCost, iterations);
 
   const pipelineResult = await runPipeline(defaultPipeline, pipelineContext, ctx.eventEmitter);
-
-  // G2: Close all non-terminal sessions — update in-memory state and close physical ACP sessions.
-  // closeStory() returns the descriptors it transitioned; for any with a handle we close
-  // the physical session so ACP doesn't accumulate orphaned sessions after abnormal exits
-  // (e.g. escalate with keepSessionOpen: true still set by the execution stage).
-  const closedSessionDescs = pipelineContext.sessionManager?.closeStory(story.id) ?? [];
-  for (const desc of closedSessionDescs) {
-    if (desc.handle) {
-      const adapter = pipelineContext.agentGetFn?.(desc.agent);
-      void adapter?.closePhysicalSession(desc.handle, desc.workdir).catch(() => {});
-    }
-  }
 
   // #410: Destroy reviewerSession on escalation — completion stage is bypassed when the pipeline
   // returns escalate, so we must clean up here to avoid leaking the ACP reviewer session.

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -18,7 +18,9 @@ import { pipelineEventBus } from "../../pipeline/event-bus";
 import type { AgentGetFn } from "../../pipeline/types";
 import { countStories, isComplete, isStalled } from "../../prd";
 import type { PRD } from "../../prd";
+import type { ISessionManager } from "../../session";
 import { purgeStaleScratch } from "../../session/scratch-purge";
+import { closeAllRunSessions } from "../session-manager-runtime";
 import type { StatusWriter } from "../status-writer";
 import { runDeferredRegression } from "./run-regression";
 
@@ -29,6 +31,7 @@ import { runDeferredRegression } from "./run-regression";
 export const _runCompletionDeps = {
   runDeferredRegression,
   fireHook,
+  closeAllRunSessions,
 };
 
 export interface RunCompletionOptions {
@@ -57,6 +60,8 @@ export interface RunCompletionOptions {
    * Used for session scratch purge (AC-20).
    */
   projectDir?: string;
+  /** Optional run-level session manager for final active-session teardown. */
+  sessionManager?: ISessionManager;
 }
 
 export interface RunCompletionResult {
@@ -197,6 +202,10 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
 
   const durationMs = Date.now() - startTime;
   const runCompletedAt = new Date().toISOString();
+
+  if (options.sessionManager) {
+    await _runCompletionDeps.closeAllRunSessions(options.sessionManager, options.agentGetFn);
+  }
 
   // Compute final story counts before emitting completion event (RL-002)
   const finalCounts = countStories(prd);

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -27,6 +27,7 @@ import type { PluginRegistry } from "../../plugins/registry";
 import type { PRD } from "../../prd";
 import { countStories, loadPRD, savePRD } from "../../prd";
 import { detectProjectProfile } from "../../project";
+import { SessionManager } from "../../session";
 import { resolveTestFilePatterns } from "../../test-runners/resolver";
 import { NAX_BUILD_INFO, NAX_COMMIT, NAX_VERSION } from "../../version";
 import { installCrashHandlers } from "../crash-recovery";
@@ -98,6 +99,7 @@ export interface RunSetupOptions {
 export interface RunSetupResult {
   statusWriter: StatusWriter;
   pidRegistry: PidRegistry;
+  sessionManager: SessionManager;
   cleanupCrashHandlers: () => void;
   pluginRegistry: PluginRegistry;
   prd: PRD;
@@ -149,6 +151,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
 
   // ── PID registry for orphan process cleanup (BUG-002) ───────
   const pidRegistry = new PidRegistry(workdir);
+  const sessionManager = new SessionManager();
 
   // Cleanup stale PIDs from previous crashed runs
   await pidRegistry.cleanupStale();
@@ -204,9 +207,11 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
   }
 
   // Phase 3 (#477): stale session sweep via sidecar removed.
-  // SessionManager.sweepOrphans() handles orphan detection at run boundaries.
-  // Per-story SessionManagers are created in iteration-runner.ts; a run-level
-  // manager (Phase 5.5) will allow sweepOrphans() to be called here at startup.
+  // Run-level SessionManager now owns orphan sweeps at startup.
+  const sweptOrphans = sessionManager.sweepOrphans();
+  if (sweptOrphans > 0) {
+    logger?.info("session", "Swept orphan sessions at run setup", { sweptOrphans });
+  }
 
   // Acquire lock to prevent concurrent execution
   const lockAcquired = await acquireLock(workdir);
@@ -316,6 +321,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     return {
       statusWriter,
       pidRegistry,
+      sessionManager,
       cleanupCrashHandlers,
       pluginRegistry,
       prd,

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -33,6 +33,7 @@ import { NAX_BUILD_INFO, NAX_COMMIT, NAX_VERSION } from "../../version";
 import { installCrashHandlers } from "../crash-recovery";
 import { acquireLock, releaseLock } from "../helpers";
 import { PidRegistry } from "../pid-registry";
+import { closeAllRunSessions } from "../session-manager-runtime";
 import { StatusWriter } from "../status-writer";
 
 /** Injectable deps for run-setup (enables testing without heavy side-effects) */
@@ -173,10 +174,9 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     emitError: (reason: string) => {
       pipelineEventBus.emit({ type: "run:errored", reason, feature: options.feature });
     },
-    // Per-story SessionManagers are local to iteration-runner.ts; closeStory() is
-    // called there after runPipeline() returns. A run-level manager (Phase 5.5) will
-    // enable closeStory for all in-flight sessions here on SIGTERM.
-    onShutdown: async () => {},
+    onShutdown: async () => {
+      await closeAllRunSessions(sessionManager, options.agentGetFn);
+    },
   });
 
   // Load PRD (before try block so it's accessible in finally for onRunEnd)

--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -16,6 +16,7 @@ import type { AgentGetFn } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins/registry";
 import { isComplete } from "../prd";
 import type { PRD } from "../prd";
+import type { ISessionManager } from "../session";
 import { autoCommitIfDirty } from "../utils/git";
 import { stopHeartbeat, writeExitSummary } from "./crash-recovery";
 import type { AcceptanceLoopContext, AcceptanceLoopResult } from "./lifecycle/acceptance-loop";
@@ -51,6 +52,8 @@ export interface RunnerCompletionOptions {
   agentGetFn?: AgentGetFn;
   /** Path to prd.json — required for acceptance fix story writes */
   prdPath: string;
+  /** Run-level SessionManager shared across this run. */
+  sessionManager?: ISessionManager;
 }
 
 /**
@@ -195,6 +198,7 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
     config: options.config,
     agentGetFn: options.agentGetFn,
     skipRegression: regressionAlreadyPassed,
+    sessionManager: options.sessionManager,
   });
 
   const { durationMs, runCompletedAt, finalCounts } = completionResult;

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -16,6 +16,8 @@ import type { PluginRegistry } from "../plugins/registry";
 import type { PRD } from "../prd";
 import { tryLlmBatchRoute } from "../routing";
 import { clearCache as clearLlmCache } from "../routing/strategies/llm";
+import { SessionManager } from "../session";
+import type { ISessionManager } from "../session";
 import { precomputeBatchPlan } from "./batching";
 import { getAllReadyStories } from "./helpers";
 import type { PidRegistry } from "./pid-registry";
@@ -51,6 +53,8 @@ export interface RunnerExecutionOptions {
   pidRegistry?: PidRegistry;
   /** Interaction chain for cost/pre-merge triggers during sequential execution. */
   interactionChain?: InteractionChain | null;
+  /** Run-level SessionManager shared across story iterations. */
+  sessionManager?: ISessionManager;
 }
 
 /**
@@ -153,6 +157,7 @@ export async function runExecutionPhase(
       eventEmitter: options.eventEmitter,
       statusWriter: options.statusWriter,
       logFilePath: options.logFilePath,
+      sessionManager: options.sessionManager ?? new SessionManager(),
       runId: options.runId,
       startTime: options.startTime,
       parallelCount: options.parallel,

--- a/src/execution/runner-setup.ts
+++ b/src/execution/runner-setup.ts
@@ -42,6 +42,7 @@ export interface RunnerSetupOptions {
 export interface RunnerSetupResult {
   statusWriter: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["statusWriter"];
   pidRegistry: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["pidRegistry"];
+  sessionManager: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["sessionManager"];
   cleanupCrashHandlers: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["cleanupCrashHandlers"];
   pluginRegistry: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["pluginRegistry"];
   storyCounts: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["storyCounts"];

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -227,6 +227,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
       pluginRegistry,
       eventEmitter,
       agentGetFn,
+      sessionManager,
     });
 
     const { durationMs, acceptancePassed } = completionResult;

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -146,7 +146,8 @@ export async function run(options: RunOptions): Promise<RunResult> {
     getTotalStories: () => (prd ? countStories(prd).total : 0),
   });
 
-  const { statusWriter, pidRegistry, cleanupCrashHandlers, pluginRegistry, interactionChain } = setupResult;
+  const { statusWriter, pidRegistry, sessionManager, cleanupCrashHandlers, pluginRegistry, interactionChain } =
+    setupResult;
   prd = setupResult.prd;
 
   try {
@@ -175,6 +176,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
         onBeforeStory: () => registry.resetStoryState(),
         pidRegistry,
         interactionChain,
+        sessionManager,
       },
       prd,
       pluginRegistry,

--- a/src/execution/session-manager-runtime.ts
+++ b/src/execution/session-manager-runtime.ts
@@ -17,6 +17,16 @@ async function closePhysicalSession(
   }
 }
 
+async function closeStorylessSession(
+  sessionManager: Pick<ISessionManager, "transition">,
+  descriptor: SessionDescriptor,
+  agentGetFn?: AgentGetFn,
+): Promise<number> {
+  sessionManager.transition(descriptor.id, "COMPLETED");
+  await closePhysicalSession(descriptor, agentGetFn);
+  return 1;
+}
+
 export async function closeStorySessions(
   sessionManager: Pick<ISessionManager, "closeStory">,
   storyId: string,
@@ -32,12 +42,14 @@ export async function closeStorySessions(
 }
 
 export async function closeAllRunSessions(
-  sessionManager: Pick<ISessionManager, "listActive" | "closeStory">,
+  sessionManager: Pick<ISessionManager, "listActive" | "closeStory" | "transition">,
   agentGetFn?: AgentGetFn,
 ): Promise<number> {
   const storyIds = new Set<string>();
+  const storylessSessionIds = new Set<string>();
+  const activeSessions = sessionManager.listActive();
 
-  for (const descriptor of sessionManager.listActive()) {
+  for (const descriptor of activeSessions) {
     if (descriptor.storyId) {
       storyIds.add(descriptor.storyId);
     }
@@ -46,6 +58,12 @@ export async function closeAllRunSessions(
   let totalClosed = 0;
   for (const storyId of storyIds) {
     totalClosed += await closeStorySessions(sessionManager, storyId, agentGetFn);
+  }
+
+  for (const descriptor of activeSessions) {
+    if (descriptor.storyId || storylessSessionIds.has(descriptor.id)) continue;
+    storylessSessionIds.add(descriptor.id);
+    totalClosed += await closeStorylessSession(sessionManager, descriptor, agentGetFn);
   }
 
   return totalClosed;

--- a/src/execution/session-manager-runtime.ts
+++ b/src/execution/session-manager-runtime.ts
@@ -72,6 +72,39 @@ export async function closeStorySessions(
   return closedSessions.length;
 }
 
+/**
+ * Transition a session to FAILED and force-close its physical handle.
+ *
+ * Called by the execution stage at terminal failure points (agent exhaustion,
+ * merge conflict abort). Preserves state fidelity for audit, orphan sweep, and
+ * metrics; ensures AC-83 force-terminate fires even though run-completion
+ * teardown skips FAILED sessions (listActive() filters them out as terminal).
+ *
+ * No-op if the session is unknown, already in a terminal state, or the
+ * transition is rejected. Physical close is best-effort.
+ */
+export async function failAndClose(
+  sessionManager: Pick<ISessionManager, "get" | "transition">,
+  sessionId: string,
+  agentGetFn?: AgentGetFn,
+): Promise<void> {
+  const descriptor = sessionManager.get(sessionId);
+  if (!descriptor) return;
+  if (descriptor.state === "FAILED" || descriptor.state === "COMPLETED") return;
+
+  try {
+    sessionManager.transition(sessionId, "FAILED");
+  } catch {
+    // Invalid transition — bail out; do not force-close a session in unknown state.
+    return;
+  }
+
+  const failed = sessionManager.get(sessionId);
+  if (failed) {
+    await closePhysicalSession(failed, agentGetFn, true);
+  }
+}
+
 export async function closeAllRunSessions(
   sessionManager: Pick<ISessionManager, "listActive" | "closeStory" | "transition">,
   agentGetFn?: AgentGetFn,

--- a/src/execution/session-manager-runtime.ts
+++ b/src/execution/session-manager-runtime.ts
@@ -1,0 +1,52 @@
+import type { AgentGetFn } from "../pipeline/types";
+import type { ISessionManager, SessionDescriptor } from "../session/types";
+
+async function closePhysicalSession(
+  descriptor: SessionDescriptor,
+  agentGetFn?: AgentGetFn,
+): Promise<void> {
+  if (!descriptor.handle) return;
+
+  const adapter = agentGetFn?.(descriptor.agent);
+  if (!adapter) return;
+
+  try {
+    await adapter.closePhysicalSession(descriptor.handle, descriptor.workdir);
+  } catch {
+    // Best-effort cleanup: session close errors must not block run teardown.
+  }
+}
+
+export async function closeStorySessions(
+  sessionManager: Pick<ISessionManager, "closeStory">,
+  storyId: string,
+  agentGetFn?: AgentGetFn,
+): Promise<number> {
+  const closedSessions = sessionManager.closeStory(storyId);
+
+  for (const descriptor of closedSessions) {
+    await closePhysicalSession(descriptor, agentGetFn);
+  }
+
+  return closedSessions.length;
+}
+
+export async function closeAllRunSessions(
+  sessionManager: Pick<ISessionManager, "listActive" | "closeStory">,
+  agentGetFn?: AgentGetFn,
+): Promise<number> {
+  const storyIds = new Set<string>();
+
+  for (const descriptor of sessionManager.listActive()) {
+    if (descriptor.storyId) {
+      storyIds.add(descriptor.storyId);
+    }
+  }
+
+  let totalClosed = 0;
+  for (const storyId of storyIds) {
+    totalClosed += await closeStorySessions(sessionManager, storyId, agentGetFn);
+  }
+
+  return totalClosed;
+}

--- a/src/execution/session-manager-runtime.ts
+++ b/src/execution/session-manager-runtime.ts
@@ -1,10 +1,7 @@
 import type { AgentGetFn } from "../pipeline/types";
 import type { ISessionManager, SessionDescriptor, SessionState } from "../session/types";
 
-async function closePhysicalSession(
-  descriptor: SessionDescriptor,
-  agentGetFn?: AgentGetFn,
-): Promise<void> {
+async function closePhysicalSession(descriptor: SessionDescriptor, agentGetFn?: AgentGetFn): Promise<void> {
   if (!descriptor.handle) return;
 
   const adapter = agentGetFn?.(descriptor.agent);

--- a/src/execution/session-manager-runtime.ts
+++ b/src/execution/session-manager-runtime.ts
@@ -1,5 +1,5 @@
 import type { AgentGetFn } from "../pipeline/types";
-import type { ISessionManager, SessionDescriptor } from "../session/types";
+import type { ISessionManager, SessionDescriptor, SessionState } from "../session/types";
 
 async function closePhysicalSession(
   descriptor: SessionDescriptor,
@@ -22,9 +22,34 @@ async function closeStorylessSession(
   descriptor: SessionDescriptor,
   agentGetFn?: AgentGetFn,
 ): Promise<number> {
-  sessionManager.transition(descriptor.id, "COMPLETED");
+  const transitionChain: SessionState[] = getStorylessCloseChain(descriptor.state);
+  for (const targetState of transitionChain) {
+    try {
+      sessionManager.transition(descriptor.id, targetState);
+    } catch {
+      // Best-effort cleanup: invalid transition states must not block teardown.
+    }
+  }
+
   await closePhysicalSession(descriptor, agentGetFn);
   return 1;
+}
+
+function getStorylessCloseChain(state: SessionState): SessionState[] {
+  switch (state) {
+    case "CREATED":
+      return ["RUNNING", "COMPLETED"];
+    case "PAUSED":
+      return ["RESUMING", "RUNNING", "COMPLETED"];
+    case "RESUMING":
+      return ["RUNNING", "COMPLETED"];
+    case "RUNNING":
+      return ["COMPLETED"];
+    case "CLOSING":
+      return ["COMPLETED"];
+    default:
+      return [];
+  }
 }
 
 export async function closeStorySessions(

--- a/src/execution/session-manager-runtime.ts
+++ b/src/execution/session-manager-runtime.ts
@@ -1,14 +1,19 @@
 import type { AgentGetFn } from "../pipeline/types";
 import type { ISessionManager, SessionDescriptor, SessionState } from "../session/types";
 
-async function closePhysicalSession(descriptor: SessionDescriptor, agentGetFn?: AgentGetFn): Promise<void> {
+async function closePhysicalSession(
+  descriptor: SessionDescriptor,
+  agentGetFn?: AgentGetFn,
+  force?: boolean,
+): Promise<void> {
   if (!descriptor.handle) return;
 
   const adapter = agentGetFn?.(descriptor.agent);
   if (!adapter) return;
 
   try {
-    await adapter.closePhysicalSession(descriptor.handle, descriptor.workdir);
+    // AC-83: pass force=true for errored sessions so the adapter can hard-terminate
+    await adapter.closePhysicalSession(descriptor.handle, descriptor.workdir, force ? { force: true } : undefined);
   } catch {
     // Best-effort cleanup: session close errors must not block run teardown.
   }
@@ -28,7 +33,9 @@ async function closeStorylessSession(
     }
   }
 
-  await closePhysicalSession(descriptor, agentGetFn);
+  // AC-83: force hard-terminate when the session was already in FAILED state
+  const force = descriptor.state === "FAILED";
+  await closePhysicalSession(descriptor, agentGetFn, force);
   return 1;
 }
 
@@ -57,7 +64,9 @@ export async function closeStorySessions(
   const closedSessions = sessionManager.closeStory(storyId);
 
   for (const descriptor of closedSessions) {
-    await closePhysicalSession(descriptor, agentGetFn);
+    // AC-83: force hard-terminate for sessions that were already in FAILED state
+    const force = descriptor.state === "FAILED";
+    await closePhysicalSession(descriptor, agentGetFn, force);
   }
 
   return closedSessions.length;

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -23,9 +23,23 @@ import { getAllReadyStories } from "./helpers";
 import { runIteration } from "./iteration-runner";
 import type { RunParallelBatchOptions, RunParallelBatchResult } from "./parallel-batch";
 import { handlePipelineFailure } from "./pipeline-result-handler";
+import { closeStorySessions } from "./session-manager-runtime";
 import { selectIndependentBatch, selectNextStories } from "./story-selector";
 
 export type { SequentialExecutionContext, SequentialExecutionResult } from "./executor-types";
+
+const TERMINAL_ACTIONS = new Set(["fail", "skip", "pause"]);
+
+async function closeStoryIfTerminal(
+  ctx: SequentialExecutionContext,
+  storyId: string,
+  iter: { storiesCompletedDelta: number; finalAction?: string },
+): Promise<void> {
+  if (!ctx.sessionManager) return;
+  if (iter.storiesCompletedDelta > 0 || (iter.finalAction && TERMINAL_ACTIONS.has(iter.finalAction))) {
+    await closeStorySessions(ctx.sessionManager, storyId, ctx.agentGetFn);
+  }
+}
 
 export async function executeUnified(
   ctx: SequentialExecutionContext,
@@ -241,6 +255,17 @@ export async function executeUnified(
           storiesCompleted += batchResult.completed.length;
           prdDirty = true;
 
+          if (ctx.sessionManager) {
+            for (const story of batchResult.completed) {
+              await closeStorySessions(ctx.sessionManager, story.id, ctx.agentGetFn);
+            }
+            for (const failed of batchResult.failed) {
+              if (failed.pipelineResult.finalAction && TERMINAL_ACTIONS.has(failed.pipelineResult.finalAction)) {
+                await closeStorySessions(ctx.sessionManager, failed.story.id, ctx.agentGetFn);
+              }
+            }
+          }
+
           // Build per-story metrics for completed parallel batch stories
           const batchCompletedAt = new Date().toISOString();
           for (const story of batchResult.completed) {
@@ -374,6 +399,7 @@ export async function executeUnified(
             totalCost + singleIter.costDelta,
             singleIter.prdDirty,
           ];
+          await closeStoryIfTerminal(ctx, singleStory.id, singleIter);
 
           if (singleIter.prdDirty) {
             prd = await loadPRD(ctx.prdPath);
@@ -457,6 +483,7 @@ export async function executeUnified(
         totalCost + iter.costDelta,
         iter.prdDirty,
       ];
+      await closeStoryIfTerminal(ctx, selection.story.id, iter);
 
       if (ctx.interactionChain && isTriggerEnabled("cost-warning", ctx.config) && !warningSent) {
         const triggerCfg = ctx.config.interaction?.triggers?.["cost-warning"];

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -19,6 +19,7 @@ import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { createDefaultOrchestrator, createRunCallCounter } from "../../context/engine";
 import type { ContextRequest, IContextProvider } from "../../context/engine";
+import { estimateAvailableBudgetTokens } from "../../context/engine/available-budget";
 import { writeContextManifest } from "../../context/engine/manifest-store";
 import { loadPluginProviders } from "../../context/engine/providers/plugin-loader";
 import { getStageContextConfig } from "../../context/engine/stage-config";
@@ -128,6 +129,7 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
       : undefined,
     sessionId: ctx.sessionId,
     agentId: agentName,
+    availableBudgetTokens: estimateAvailableBudgetTokens(agentName, ctx.prompt),
     deterministic: ctx.config.context.v2.deterministic,
     // Amendment B AC-51: pass planDigestBoost from the routing strategy's stage config.
     // single-session, tdd-simple, no-test, and batch strategies declare planDigestBoost >= 1.5.

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -10,6 +10,7 @@ import { getAgent, validateAgentForTier } from "../../agents";
 import { resolveModelForAgent } from "../../config";
 import { resolvePermissions } from "../../config/permissions";
 import { createContextToolRuntime } from "../../context/engine";
+import { writeRebuildManifest } from "../../context/engine/manifest-store";
 import { rebuildForSwap, resolveSwapTarget, shouldAttemptSwap } from "../../execution/escalation/agent-swap";
 import { buildInteractionBridge } from "../../interaction/bridge-builder";
 import { checkMergeConflict, checkStoryAmbiguity, isTriggerEnabled } from "../../interaction/triggers";
@@ -281,6 +282,27 @@ export const executionStage: PipelineStage = {
 
           // Rebuild context for the target agent profile before the retry run.
           workingBundle = _executionDeps.rebuildForSwap(workingBundle, swapTarget, failure, ctx.story.id);
+          if (ctx.projectDir && ctx.prd.feature && workingBundle.manifest.rebuildInfo) {
+            try {
+              await _executionDeps.writeRebuildManifest(ctx.projectDir, ctx.prd.feature, ctx.story.id, {
+                requestId: workingBundle.manifest.requestId,
+                stage: "execution",
+                priorAgentId: workingBundle.manifest.rebuildInfo.priorAgentId,
+                newAgentId: workingBundle.manifest.rebuildInfo.newAgentId,
+                failureCategory: workingBundle.manifest.rebuildInfo.failureCategory,
+                failureOutcome: workingBundle.manifest.rebuildInfo.failureOutcome,
+                priorChunkIds: workingBundle.manifest.rebuildInfo.priorChunkIds,
+                newChunkIds: workingBundle.manifest.rebuildInfo.newChunkIds,
+                chunkIdMap: workingBundle.manifest.rebuildInfo.chunkIdMap,
+                createdAt: new Date().toISOString(),
+              });
+            } catch (err) {
+              logger.warn("execution", "Failed to write rebuild manifest", {
+                storyId: ctx.story.id,
+                error: String(err),
+              });
+            }
+          }
           const hopNumber = (ctx.agentSwapCount ?? 0) + 1;
           ctx.agentSwapCount = hopNumber;
           ctx.agentFallbacks = [
@@ -412,4 +434,5 @@ export const _executionDeps = {
   shouldAttemptSwap,
   resolveSwapTarget,
   rebuildForSwap,
+  writeRebuildManifest,
 };

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -12,6 +12,7 @@ import { resolvePermissions } from "../../config/permissions";
 import { createContextToolRuntime } from "../../context/engine";
 import { writeRebuildManifest } from "../../context/engine/manifest-store";
 import { rebuildForSwap, resolveSwapTarget, shouldAttemptSwap } from "../../execution/escalation/agent-swap";
+import { failAndClose } from "../../execution/session-manager-runtime";
 import { buildInteractionBridge } from "../../interaction/bridge-builder";
 import { checkMergeConflict, checkStoryAmbiguity, isTriggerEnabled } from "../../interaction/triggers";
 import { getLogger } from "../../logger";
@@ -228,6 +229,10 @@ export const executionStage: PipelineStage = {
       );
       if (!shouldProceed) {
         logger.error("execution", "Merge conflict detected — aborting story", { storyId: ctx.story.id });
+        // H-1: mark session FAILED + force-close the physical handle (AC-83).
+        if (ctx.sessionManager && ctx.sessionId) {
+          await _executionDeps.failAndClose(ctx.sessionManager, ctx.sessionId, ctx.agentGetFn);
+        }
         return { action: "fail", reason: "Merge conflict detected" };
       }
     }
@@ -410,6 +415,11 @@ export const executionStage: PipelineStage = {
       if (result.rateLimited) {
         logger.warn("execution", "Rate limited — will retry", { storyId: ctx.story.id });
       }
+      // H-1: mark session FAILED + force-close the physical handle (AC-83).
+      // Fires after fallback exhaustion or when fallback is unconfigured.
+      if (ctx.sessionManager && ctx.sessionId) {
+        await _executionDeps.failAndClose(ctx.sessionManager, ctx.sessionId, ctx.agentGetFn);
+      }
       return { action: "escalate" };
     }
 
@@ -435,4 +445,5 @@ export const _executionDeps = {
   resolveSwapTarget,
   rebuildForSwap,
   writeRebuildManifest,
+  failAndClose,
 };

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -22,6 +22,12 @@ import { isAmbiguousOutput, routeTddFailure } from "./execution-helpers";
 // Re-export helpers so existing importers continue to work.
 export { isAmbiguousOutput, resolveStoryWorkdir, routeTddFailure } from "./execution-helpers";
 
+function buildSwapPrompt(basePrompt: string, pushMarkdown?: string): string {
+  const trimmed = pushMarkdown?.trim();
+  if (!trimmed) return basePrompt;
+  return `${trimmed}\n\n${basePrompt}`;
+}
+
 export const executionStage: PipelineStage = {
   name: "execution",
   enabled: () => true,
@@ -246,48 +252,65 @@ export const executionStage: PipelineStage = {
     if (!result.success) {
       // Phase 5.5: agent-swap on availability failure, before tier escalation
       const fallbackConfig = ctx.config.context?.v2?.fallback;
-      const { adapterFailure } = result;
-      if (
-        fallbackConfig &&
-        adapterFailure &&
-        _executionDeps.shouldAttemptSwap(adapterFailure, fallbackConfig, ctx.agentSwapCount ?? 0, ctx.contextBundle)
-      ) {
-        const currentAgentId = ctx.routing.agent ?? ctx.rootConfig.autoMode.defaultAgent;
-        const swapTarget = _executionDeps.resolveSwapTarget(
-          currentAgentId,
-          fallbackConfig.map,
-          ctx.agentSwapCount ?? 0,
-        );
-        const swapAgent = swapTarget ? (ctx.agentGetFn ?? _executionDeps.getAgent)(swapTarget) : null;
-        if (swapAgent && swapTarget && ctx.contextBundle) {
-          const originalBundle = ctx.contextBundle;
-          ctx.contextBundle = _executionDeps.rebuildForSwap(
-            ctx.contextBundle,
-            swapTarget,
-            adapterFailure,
-            ctx.story.id,
+      if (fallbackConfig && ctx.contextBundle) {
+        const primaryAgentId = ctx.routing.agent ?? ctx.rootConfig.autoMode.defaultAgent;
+        const basePrompt = ctx.prompt;
+        let priorAgentId = primaryAgentId;
+        let workingBundle = ctx.contextBundle;
+        let failure = result.adapterFailure;
+
+        while (_executionDeps.shouldAttemptSwap(failure, fallbackConfig, ctx.agentSwapCount ?? 0, workingBundle)) {
+          if (!failure) break;
+
+          const swapTarget = _executionDeps.resolveSwapTarget(
+            primaryAgentId,
+            fallbackConfig.map,
+            ctx.agentSwapCount ?? 0,
           );
+          if (!swapTarget) break;
+
+          const swapAgent = (ctx.agentGetFn ?? _executionDeps.getAgent)(swapTarget);
+          if (!swapAgent) {
+            logger.warn("execution", "Swap target unavailable — trying next candidate", {
+              storyId: ctx.story.id,
+              target: swapTarget,
+            });
+            ctx.agentSwapCount = (ctx.agentSwapCount ?? 0) + 1;
+            continue;
+          }
+
+          // Rebuild context for the target agent profile before the retry run.
+          workingBundle = _executionDeps.rebuildForSwap(workingBundle, swapTarget, failure, ctx.story.id);
           const hopNumber = (ctx.agentSwapCount ?? 0) + 1;
           ctx.agentSwapCount = hopNumber;
           ctx.agentFallbacks = [
             ...(ctx.agentFallbacks ?? []),
             {
               storyId: ctx.story.id,
-              priorAgent: currentAgentId,
+              priorAgent: priorAgentId,
               newAgent: swapTarget,
-              outcome: adapterFailure.outcome,
-              category: adapterFailure.category,
+              outcome: failure.outcome,
+              category: failure.category,
               hop: hopNumber,
             },
           ];
+
           logger.info("execution", "Agent-swap triggered", {
             storyId: ctx.story.id,
-            fromAgent: currentAgentId,
+            fromAgent: priorAgentId,
             toAgent: swapTarget,
-            failureOutcome: result.adapterFailure?.outcome,
+            failureOutcome: failure?.outcome,
+            hop: hopNumber,
           });
+
+          const handoffSession =
+            ctx.sessionManager && ctx.sessionId
+              ? ctx.sessionManager.handoff?.(ctx.sessionId, swapTarget, failure?.outcome)
+              : undefined;
+
+          const swapPrompt = buildSwapPrompt(basePrompt, workingBundle.pushMarkdown);
           const swapResult = await swapAgent.run({
-            prompt: ctx.prompt,
+            prompt: swapPrompt,
             workdir: ctx.workdir,
             modelTier: effectiveTier,
             modelDef: resolveModelForAgent(
@@ -307,9 +330,10 @@ export const executionStage: PipelineStage = {
             storyId: ctx.story.id,
             sessionRole: "implementer",
             keepSessionOpen,
-            contextPullTools: ctx.contextBundle.pullTools,
+            ...(handoffSession && { session: handoffSession }),
+            contextPullTools: workingBundle.pullTools,
             contextToolRuntime: createContextToolRuntime({
-              bundle: ctx.contextBundle,
+              bundle: workingBundle,
               story: ctx.story,
               config: ctx.config,
               repoRoot: ctx.workdir,
@@ -322,18 +346,36 @@ export const executionStage: PipelineStage = {
             }),
           });
           ctx.agentResult = swapResult;
+
+          if (ctx.sessionManager && ctx.sessionId && swapResult.protocolIds) {
+            const descriptor = ctx.sessionManager.get(ctx.sessionId);
+            if (descriptor) {
+              ctx.sessionManager.bindHandle(
+                ctx.sessionId,
+                swapAgent.deriveSessionName(descriptor),
+                swapResult.protocolIds,
+              );
+            }
+          }
+
           if (swapResult.success) {
+            ctx.contextBundle = workingBundle;
+            ctx.prompt = swapPrompt;
             logger.info("execution", "Agent-swap succeeded", {
               storyId: ctx.story.id,
               toAgent: swapTarget,
+              hop: hopNumber,
             });
             return { action: "continue" };
           }
-          ctx.contextBundle = originalBundle;
-          logger.warn("execution", "Agent-swap retry also failed — escalating", {
+
+          logger.warn("execution", "Agent-swap attempt failed — evaluating next candidate", {
             storyId: ctx.story.id,
             toAgent: swapTarget,
+            hop: hopNumber,
           });
+          priorAgentId = swapTarget;
+          failure = swapResult.adapterFailure;
         }
       }
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -211,6 +211,33 @@ export class SessionManager implements ISessionManager {
     return { ...updated };
   }
 
+  handoff(id: string, newAgent: string, reason?: string): SessionDescriptor {
+    const session = this._sessions.get(id);
+    if (!session) {
+      throw new NaxError(`Session "${id}" not found in registry`, "SESSION_NOT_FOUND", {
+        stage: "session",
+        sessionId: id,
+      });
+    }
+
+    const updated: SessionDescriptor = {
+      ...session,
+      agent: newAgent,
+      lastActivityAt: _sessionManagerDeps.now(),
+    };
+    this._sessions.set(id, updated);
+
+    getLogger().info("session", "Session handed off to fallback agent", {
+      storyId: session.storyId,
+      sessionId: id,
+      fromAgent: session.agent,
+      toAgent: newAgent,
+      ...(reason && { reason }),
+    });
+
+    return { ...updated };
+  }
+
   resume(storyId: string, role: import("./types").SessionRole): SessionDescriptor | null {
     const terminal: SessionState[] = ["COMPLETED", "FAILED"];
     for (const session of this._sessions.values()) {

--- a/src/session/scratch-writer.ts
+++ b/src/session/scratch-writer.ts
@@ -15,6 +15,9 @@
  * See: docs/specs/SPEC-context-engine-v2.md §Session model
  */
 
+// node:fs/promises exception: Bun has no native atomic-append or recursive-mkdir
+// equivalent. appendFile uses O_APPEND (atomic for concurrent writers); mkdir
+// uses { recursive: true } to avoid EEXIST races. Both are safe cross-platform.
 import { appendFile as fsAppendFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -191,6 +191,11 @@ export interface ISessionManager {
    */
   bindHandle(id: string, handle: string, protocolIds: ProtocolIds): SessionDescriptor;
   /**
+   * Update the session owner agent during availability fallback.
+   * Optional during the migration period; callers should guard with ?.handoff.
+   */
+  handoff?(id: string, newAgent: string, reason?: string): SessionDescriptor;
+  /**
    * Look up an existing non-terminal session by storyId + role (Phase 3).
    * Returns the descriptor if found, null otherwise.
    * Used by rectification loops to resume the implementer session across attempts.

--- a/test/integration/execution/agent-swap.test.ts
+++ b/test/integration/execution/agent-swap.test.ts
@@ -351,6 +351,35 @@ describe("execution stage — agent-swap on availability failure (Phase 5.5)", (
     expect(ctx.agentSwapCount).toBe(2);
   });
 
+  test("all fallback candidates fail — returns escalate (H-4 exhaustion)", async () => {
+    const primaryAgent = makeFailingAgent("claude");
+    const firstSwapAgent = makeFailingAgent("codex");
+    const secondSwapAgent = makeFailingAgent("gemini");
+    const config = makeConfig(true);
+    config.context.v2.fallback.map = { claude: ["codex", "gemini"] };
+    config.context.v2.fallback.maxHopsPerStory = 3;
+    const ctx = makeCtx(config, bundle);
+
+    _executionDeps.getAgent = mock((name: string) => {
+      if (name === "codex") return firstSwapAgent;
+      if (name === "gemini") return secondSwapAgent;
+      return primaryAgent;
+    });
+    ctx.agentGetFn = (name: string) => {
+      if (name === "codex") return firstSwapAgent as AgentAdapter;
+      if (name === "gemini") return secondSwapAgent as AgentAdapter;
+      return primaryAgent as AgentAdapter;
+    };
+
+    const result = await executionStage.execute(ctx);
+
+    expect(result).toEqual({ action: "escalate" });
+    expect((firstSwapAgent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect((secondSwapAgent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    // agentSwapCount reflects all hops attempted
+    expect(ctx.agentSwapCount).toBe(2);
+  });
+
   test("swap retry prompt includes rebuilt fallback context", async () => {
     const primaryAgent = makeFailingAgent("claude");
     const swapAgent = makeSucceedingAgent("codex");

--- a/test/integration/execution/agent-swap.test.ts
+++ b/test/integration/execution/agent-swap.test.ts
@@ -322,4 +322,49 @@ describe("execution stage — agent-swap on availability failure (Phase 5.5)", (
     expect(result).toEqual({ action: "escalate" });
     expect(ctx.agentSwapCount).toBe(1); // unchanged
   });
+
+  test("tries the next fallback candidate when the first swap candidate fails", async () => {
+    const primaryAgent = makeFailingAgent("claude");
+    const firstSwapAgent = makeFailingAgent("codex");
+    const secondSwapAgent = makeSucceedingAgent("gemini");
+    const config = makeConfig(true);
+    config.context.v2.fallback.map = { claude: ["codex", "gemini"] };
+    config.context.v2.fallback.maxHopsPerStory = 2;
+    const ctx = makeCtx(config, bundle);
+
+    _executionDeps.getAgent = mock((name: string) => {
+      if (name === "codex") return firstSwapAgent;
+      if (name === "gemini") return secondSwapAgent;
+      return primaryAgent;
+    });
+    ctx.agentGetFn = (name: string) => {
+      if (name === "codex") return firstSwapAgent as AgentAdapter;
+      if (name === "gemini") return secondSwapAgent as AgentAdapter;
+      return primaryAgent as AgentAdapter;
+    };
+
+    const result = await executionStage.execute(ctx);
+
+    expect(result).toEqual({ action: "continue" });
+    expect((firstSwapAgent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect((secondSwapAgent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(1);
+    expect(ctx.agentSwapCount).toBe(2);
+  });
+
+  test("swap retry prompt includes rebuilt fallback context", async () => {
+    const primaryAgent = makeFailingAgent("claude");
+    const swapAgent = makeSucceedingAgent("codex");
+    const config = makeConfig(true);
+    const ctx = makeCtx(config, bundle);
+
+    _executionDeps.getAgent = mock((name: string) => (name === "codex" ? swapAgent : primaryAgent));
+    ctx.agentGetFn = (name: string) => (name === "codex" ? swapAgent : primaryAgent) as AgentAdapter;
+
+    await executionStage.execute(ctx);
+
+    const swapRunCall = (swapAgent.run as ReturnType<typeof mock>).mock.calls[0]?.[0] as
+      | { prompt?: string }
+      | undefined;
+    expect(swapRunCall?.prompt).toContain("Agent swap (availability fallback)");
+  });
 });

--- a/test/unit/agents/acp/adapter-failure.test.ts
+++ b/test/unit/agents/acp/adapter-failure.test.ts
@@ -127,11 +127,11 @@ describe("AcpAgentAdapter — adapterFailure taxonomy", () => {
   });
 
   test("rate-limit exhausted (no fallback, legacy path) — fail-rate-limit, retriable: true", async () => {
-    // Rate-limit must come from a failed run (stopReason !== end_turn) whose output
-    // contains a 429 pattern. The legacy backoff path exhausts after 3 attempts.
+    // Rate-limit must come from a failed run (stopReason !== end_turn) with
+    // machine-readable structured output. The legacy backoff path exhausts after 3 attempts.
     const session = makeSession({
       promptFn: async () => ({
-        messages: [{ role: "assistant", content: "429 Rate limit exceeded. retry after 30" }],
+        messages: [{ role: "assistant", content: '{"statusCode":429,"retryAfterSeconds":30}' }],
         stopReason: "cancelled", // non-success so the output is parsed for rate-limit
       }),
     });

--- a/test/unit/agents/acp/adapter-run.test.ts
+++ b/test/unit/agents/acp/adapter-run.test.ts
@@ -232,7 +232,7 @@ describe("run() — rate limit retry", () => {
     const session = makeSession({
       promptFn: async (_: string) => {
         attempts++;
-        if (attempts < 3) throw new Error("Rate limit exceeded — 429 Too Many Requests");
+        if (attempts < 3) throw new Error("statusCode=429");
         return {
           messages: [{ role: "assistant", content: "Done." }],
           stopReason: "end_turn",
@@ -259,7 +259,7 @@ describe("run() — rate limit retry", () => {
     const session = makeSession({
       promptFn: async (_: string) => {
         attempts++;
-        if (attempts < 3) throw new Error("rate limit");
+        if (attempts < 3) throw new Error("statusCode=429");
         return {
           messages: [{ role: "assistant", content: "Done." }],
           stopReason: "end_turn",
@@ -283,7 +283,7 @@ describe("run() — rate limit retry", () => {
 
     const session = makeSession({
       promptFn: async (_: string) => {
-        throw new Error("rate limit exceeded");
+        throw new Error("statusCode=429");
       },
     });
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));

--- a/test/unit/agents/acp/adapter.test.ts
+++ b/test/unit/agents/acp/adapter.test.ts
@@ -242,7 +242,7 @@ describe("complete()", () => {
     const session = makeSession({
       promptFn: async (_: string) => {
         calls++;
-        if (calls === 1) throw new Error("rate limit exceeded");
+        if (calls === 1) throw new Error('{"statusCode":429}');
         return { messages: [{ role: "assistant", content: "Retried OK." }], stopReason: "end_turn" };
       },
     });
@@ -256,13 +256,13 @@ describe("complete()", () => {
 
   test("throws after exhausting all rate limit retries", async () => {
     const session = makeSession({
-      promptFn: async (_: string) => { throw new Error("rate limit exceeded"); },
+      promptFn: async (_: string) => { throw new Error('{"statusCode":429}'); },
     });
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
     await expect(
       new AcpAgentAdapter("claude").complete("Fail all"),
-    ).rejects.toThrow(/rate limit/i);
+    ).rejects.toThrow(/429/);
   });
 });
 

--- a/test/unit/agents/acp/parse-agent-error.test.ts
+++ b/test/unit/agents/acp/parse-agent-error.test.ts
@@ -2,82 +2,56 @@ import { describe, expect, test } from "bun:test";
 import { parseAgentError } from "../../../../src/agents/acp/parse-agent-error";
 
 describe("parseAgentError", () => {
-  test("detects 429 status code as rate-limit", () => {
-    const result = parseAgentError("429 Too Many Requests");
-    expect(result.type).toBe("rate-limit");
-    expect(result.retryAfterSeconds).toBeUndefined();
-  });
-
-  test("detects lowercase 'rate limit' as rate-limit", () => {
-    const result = parseAgentError("rate limit exceeded");
-    expect(result.type).toBe("rate-limit");
-  });
-
-  test("detects capitalized 'Rate limit' as rate-limit", () => {
-    const result = parseAgentError("Rate limit hit, retry after 60");
-    expect(result.type).toBe("rate-limit");
-  });
-
-  test("extracts retryAfterSeconds when present in rate limit message", () => {
-    const result = parseAgentError("Rate limit hit, retry after 60 seconds");
+  test("detects rate-limit from direct JSON type", () => {
+    const result = parseAgentError('{"type":"rate-limit","retryAfterSeconds":60}');
     expect(result.type).toBe("rate-limit");
     expect(result.retryAfterSeconds).toBe(60);
   });
 
-  test("extracts retryAfterSeconds from different numeric patterns", () => {
-    const result = parseAgentError("rate limit, please retry after 120 seconds");
+  test("detects auth from direct JSON type", () => {
+    const result = parseAgentError('{"type":"auth"}');
+    expect(result.type).toBe("auth");
+  });
+
+  test("detects rate-limit from JSON statusCode", () => {
+    const result = parseAgentError('{"statusCode":429}');
     expect(result.type).toBe("rate-limit");
-    expect(result.retryAfterSeconds).toBe(120);
   });
 
-  test("detects 401 status code as auth", () => {
-    const result = parseAgentError("401 Unauthorized");
+  test("detects auth from JSON statusCode", () => {
+    const result = parseAgentError('{"statusCode":401}');
     expect(result.type).toBe("auth");
   });
 
-  test("detects 403 status code as auth", () => {
-    const result = parseAgentError("403 Forbidden");
+  test("detects rate-limit from bracketed acpx codes", () => {
+    const result = parseAgentError("acpx session failed [ACPX_RATE_LIMIT/TOO_MANY_REQUESTS]");
+    expect(result.type).toBe("rate-limit");
+  });
+
+  test("detects auth from bracketed acpx codes", () => {
+    const result = parseAgentError("acpx auth failed [AUTH_FAILED/PERMISSION_DENIED]");
     expect(result.type).toBe("auth");
   });
 
-  test("detects lowercase 'unauthorized' as auth", () => {
-    const result = parseAgentError("unauthorized access");
-    expect(result.type).toBe("auth");
+  test("detects structured key-value status codes", () => {
+    const rateLimit = parseAgentError("statusCode=429");
+    const auth = parseAgentError("code=403");
+    expect(rateLimit.type).toBe("rate-limit");
+    expect(auth.type).toBe("auth");
   });
 
-  test("detects capitalized 'Unauthorized' as auth", () => {
+  test("does not infer rate-limit from free-text phrases", () => {
+    const result = parseAgentError("Rate limit hit, retry after 60");
+    expect(result.type).toBe("unknown");
+  });
+
+  test("does not infer auth from free-text phrases", () => {
     const result = parseAgentError("Unauthorized request");
-    expect(result.type).toBe("auth");
-  });
-
-  test("detects lowercase 'forbidden' as auth", () => {
-    const result = parseAgentError("forbidden resource");
-    expect(result.type).toBe("auth");
-  });
-
-  test("detects capitalized 'Forbidden' as auth", () => {
-    const result = parseAgentError("Forbidden access denied");
-    expect(result.type).toBe("auth");
-  });
-
-  test("returns unknown for unrecognized error patterns", () => {
-    const result = parseAgentError("process exited with code 1");
-    expect(result.type).toBe("unknown");
-    expect(result.retryAfterSeconds).toBeUndefined();
-  });
-
-  test("returns unknown for empty string", () => {
-    const result = parseAgentError("");
     expect(result.type).toBe("unknown");
   });
 
-  test("returns unknown for generic error message", () => {
-    const result = parseAgentError("something went wrong");
-    expect(result.type).toBe("unknown");
-  });
-
-  test("prioritizes first recognized pattern", () => {
-    const result = parseAgentError("rate limit and 401 auth error");
-    expect(result.type).toBe("rate-limit");
+  test("returns unknown for empty or unstructured errors", () => {
+    expect(parseAgentError("").type).toBe("unknown");
+    expect(parseAgentError("something went wrong").type).toBe("unknown");
   });
 });

--- a/test/unit/cli/rules.test.ts
+++ b/test/unit/cli/rules.test.ts
@@ -10,6 +10,7 @@ import { NaxError } from "../../../src/errors";
 import {
   neutralizeContent,
   rulesExportCommand,
+  rulesLintCommand,
   rulesMigrateCommand,
   _rulesCLIDeps,
 } from "../../../src/cli/rules";
@@ -22,6 +23,7 @@ let origReadFile: typeof _rulesCLIDeps.readFile;
 let origWriteFile: typeof _rulesCLIDeps.writeFile;
 let origFileExists: typeof _rulesCLIDeps.fileExists;
 let origGlobInDir: typeof _rulesCLIDeps.globInDir;
+let origGlobCanonicalRuleFiles: typeof _rulesCLIDeps.globCanonicalRuleFiles;
 let origMkdir: typeof _rulesCLIDeps.mkdir;
 let origLoadCanonicalRules: typeof _rulesCLIDeps.loadCanonicalRules;
 
@@ -32,6 +34,7 @@ beforeEach(() => {
   origWriteFile = _rulesCLIDeps.writeFile;
   origFileExists = _rulesCLIDeps.fileExists;
   origGlobInDir = _rulesCLIDeps.globInDir;
+  origGlobCanonicalRuleFiles = _rulesCLIDeps.globCanonicalRuleFiles;
   origMkdir = _rulesCLIDeps.mkdir;
   origLoadCanonicalRules = _rulesCLIDeps.loadCanonicalRules;
 
@@ -41,6 +44,7 @@ beforeEach(() => {
   _rulesCLIDeps.writeFile = async (path, content) => { written[path] = content; };
   _rulesCLIDeps.fileExists = async () => false;
   _rulesCLIDeps.globInDir = () => [];
+  _rulesCLIDeps.globCanonicalRuleFiles = () => [];
   _rulesCLIDeps.mkdir = async () => {};
   _rulesCLIDeps.loadCanonicalRules = async () => [];
 });
@@ -50,6 +54,7 @@ afterEach(() => {
   _rulesCLIDeps.writeFile = origWriteFile;
   _rulesCLIDeps.fileExists = origFileExists;
   _rulesCLIDeps.globInDir = origGlobInDir;
+  _rulesCLIDeps.globCanonicalRuleFiles = origGlobCanonicalRuleFiles;
   _rulesCLIDeps.mkdir = origMkdir;
   _rulesCLIDeps.loadCanonicalRules = origLoadCanonicalRules;
 });
@@ -270,5 +275,43 @@ describe("rulesMigrateCommand", () => {
     _rulesCLIDeps.readFile = async () => "## Style\n\nContent.";
     await rulesMigrateCommand({ dir: "/project" });
     expect(createdDirs.some((d) => d.includes(".nax/rules"))).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// rulesLintCommand
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("rulesLintCommand", () => {
+  test("lints repo root when no package overlays are present", async () => {
+    const calls: string[] = [];
+    _rulesCLIDeps.loadCanonicalRules = async (workdir: string) => {
+      calls.push(workdir);
+      return [];
+    };
+    _rulesCLIDeps.globCanonicalRuleFiles = () => [];
+
+    await rulesLintCommand({ dir: "/project" });
+
+    expect(calls).toEqual(["/project"]);
+  });
+
+  test("lints package overlays discovered from nested canonical rule paths", async () => {
+    const calls: string[] = [];
+    _rulesCLIDeps.loadCanonicalRules = async (workdir: string) => {
+      calls.push(workdir);
+      return [];
+    };
+    _rulesCLIDeps.globCanonicalRuleFiles = () => [
+      ".nax/rules/root.md",
+      "packages/api/.nax/rules/api.md",
+      "packages/web/.nax/rules/web.md",
+    ];
+
+    await rulesLintCommand({ dir: "/repo" });
+
+    expect(calls).toContain("/repo");
+    expect(calls).toContain("/repo/packages/api");
+    expect(calls).toContain("/repo/packages/web");
   });
 });

--- a/test/unit/context/engine/manifest-store.test.ts
+++ b/test/unit/context/engine/manifest-store.test.ts
@@ -3,7 +3,9 @@ import {
   _manifestStoreDeps,
   contextManifestPath,
   loadContextManifests,
+  rebuildManifestPath,
   writeContextManifest,
+  writeRebuildManifest,
 } from "../../../../src/context/engine/manifest-store";
 import { withDepsRestore } from "../../../helpers/deps";
 
@@ -46,5 +48,52 @@ describe("manifest-store", () => {
     expect(manifests[0]?.featureId).toBe("feat-auth");
     expect(manifests[0]?.stage).toBe("review-semantic");
     expect(manifests[0]?.manifest.includedChunks).toEqual(["chunk:1"]);
+  });
+
+  test("writeRebuildManifest appends rebuild events into rebuild-manifest.json", async () => {
+    const writes = new Map<string, string>();
+    _manifestStoreDeps.mkdirp = async () => undefined;
+    _manifestStoreDeps.writeFile = async (path, content) => {
+      writes.set(path, content);
+      return content.length;
+    };
+    _manifestStoreDeps.fileExists = async (path) => writes.has(path);
+    _manifestStoreDeps.readFile = async (path) => writes.get(path) ?? "";
+
+    expect(rebuildManifestPath("/repo", "feat-auth", "US-001")).toBe(
+      "/repo/.nax/features/feat-auth/stories/US-001/rebuild-manifest.json",
+    );
+
+    await writeRebuildManifest("/repo", "feat-auth", "US-001", {
+      requestId: "req-1",
+      stage: "execution",
+      priorAgentId: "claude",
+      newAgentId: "codex",
+      failureCategory: "availability",
+      failureOutcome: "fail-quota",
+      priorChunkIds: ["chunk:a"],
+      newChunkIds: ["chunk:a", "failure-note:1"],
+      chunkIdMap: [{ priorChunkId: "chunk:a", newChunkId: "chunk:a" }],
+      createdAt: "2026-04-18T00:00:00.000Z",
+    });
+    await writeRebuildManifest("/repo", "feat-auth", "US-001", {
+      requestId: "req-2",
+      stage: "execution",
+      priorAgentId: "codex",
+      newAgentId: "gemini",
+      failureCategory: "availability",
+      failureOutcome: "fail-service-down",
+      priorChunkIds: ["chunk:b"],
+      newChunkIds: ["chunk:b", "failure-note:2"],
+      chunkIdMap: [{ priorChunkId: "chunk:b", newChunkId: "chunk:b" }],
+      createdAt: "2026-04-18T00:01:00.000Z",
+    });
+
+    const path = rebuildManifestPath("/repo", "feat-auth", "US-001");
+    const parsed = JSON.parse(writes.get(path) ?? "{}") as { storyId: string; events: Array<{ requestId: string }> };
+    expect(parsed.storyId).toBe("US-001");
+    expect(parsed.events).toHaveLength(2);
+    expect(parsed.events[0]?.requestId).toBe("req-1");
+    expect(parsed.events[1]?.requestId).toBe("req-2");
   });
 });

--- a/test/unit/context/engine/orchestrator-rebuild.test.ts
+++ b/test/unit/context/engine/orchestrator-rebuild.test.ts
@@ -419,6 +419,20 @@ describe("rebuildForAgent — #508-M5 rebuildInfo chunk ID correlation", () => {
     expect(newIds.length).toBeGreaterThan(1);
   });
 
+  test("rebuildInfo contains prior→new chunk ID correlation map", async () => {
+    const provider = makeProvider("p1", makeChunkResult("chunk:abc"));
+    const orch = new ContextOrchestrator([provider]);
+    const original = await orch.assemble({ ...BASE_REQUEST, providerIds: ["p1"] });
+    const priorBundle = { ...original, agentId: "claude" };
+
+    const rebuilt = orch.rebuildForAgent(priorBundle, {
+      newAgentId: "codex",
+      failure: AVAILABILITY_FAILURE,
+    });
+
+    expect(rebuilt.manifest.rebuildInfo?.chunkIdMap).toEqual([{ priorChunkId: "chunk:abc", newChunkId: "chunk:abc" }]);
+  });
+
   test("rebuildInfo has no chunk ID fields when no failure (plain re-render)", async () => {
     const orch = new ContextOrchestrator([]);
     const original = await orch.assemble(BASE_REQUEST);

--- a/test/unit/context/engine/orchestrator-unknown-providers.test.ts
+++ b/test/unit/context/engine/orchestrator-unknown-providers.test.ts
@@ -2,8 +2,7 @@
  * ContextOrchestrator — #508-M12 unknown providerIds validation tests
  *
  * AC-16/AC-23: When request.providerIds contains an ID that matches no
- * registered provider, the orchestrator must warn and record it in
- * manifest.unknownProviderIds. Unknown IDs must not silently disappear.
+ * registered provider, the orchestrator must fail fast with a clear error.
  *
  * Kept in a separate file because orchestrator.test.ts exceeds 400 lines.
  */
@@ -38,40 +37,34 @@ function makeProvider(id: string): IContextProvider {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("ContextOrchestrator — #508-M12 unknown providerIds validation", () => {
-  test("manifest.unknownProviderIds contains ID when it matches no registered provider", async () => {
+  test("throws when providerIds contains an unknown ID", async () => {
     const orch = new ContextOrchestrator([makeProvider("real-provider")]);
-    const result = await orch.assemble({ ...BASE_REQUEST, providerIds: ["does-not-exist"] });
-
-    // RED: field does not exist yet.
-    // GREEN: manifest records the unknown ID.
-    expect(result.manifest.unknownProviderIds).toEqual(["does-not-exist"]);
+    await expect(orch.assemble({ ...BASE_REQUEST, providerIds: ["does-not-exist"] })).rejects.toMatchObject({
+      code: "CONTEXT_UNKNOWN_PROVIDER_IDS",
+    });
   });
 
-  test("manifest.unknownProviderIds is undefined when all providerIds are known", async () => {
+  test("succeeds when all providerIds are known", async () => {
     const orch = new ContextOrchestrator([makeProvider("real-provider")]);
     const result = await orch.assemble({ ...BASE_REQUEST, providerIds: ["real-provider"] });
-
-    expect(result.manifest.unknownProviderIds).toBeUndefined();
+    expect(result.manifest.includedChunks).toBeDefined();
   });
 
-  test("manifest.unknownProviderIds lists only the unknown IDs (mix of known and unknown)", async () => {
+  test("throws when providerIds mix known and unknown IDs", async () => {
     const orch = new ContextOrchestrator([makeProvider("known-a"), makeProvider("known-b")]);
-    const result = await orch.assemble({
-      ...BASE_REQUEST,
-      providerIds: ["known-a", "ghost-id", "known-b", "phantom-id"],
+    await expect(
+      orch.assemble({
+        ...BASE_REQUEST,
+        providerIds: ["known-a", "ghost-id", "known-b", "phantom-id"],
+      }),
+    ).rejects.toMatchObject({
+      code: "CONTEXT_UNKNOWN_PROVIDER_IDS",
     });
-
-    const unknown = result.manifest.unknownProviderIds ?? [];
-    expect(unknown).toContain("ghost-id");
-    expect(unknown).toContain("phantom-id");
-    expect(unknown).not.toContain("known-a");
-    expect(unknown).not.toContain("known-b");
   });
 
-  test("manifest.unknownProviderIds is undefined when providerIds is empty", async () => {
+  test("succeeds when providerIds is empty", async () => {
     const orch = new ContextOrchestrator([makeProvider("p1")]);
     const result = await orch.assemble({ ...BASE_REQUEST, providerIds: [] });
-
-    expect(result.manifest.unknownProviderIds).toBeUndefined();
+    expect(result.manifest.includedChunks).toBeDefined();
   });
 });

--- a/test/unit/context/engine/orchestrator-unknown-providers.test.ts
+++ b/test/unit/context/engine/orchestrator-unknown-providers.test.ts
@@ -1,15 +1,24 @@
 /**
  * ContextOrchestrator — #508-M12 unknown providerIds validation tests
  *
- * AC-16/AC-23: When request.providerIds contains an ID that matches no
- * registered provider, the orchestrator must fail fast with a clear error.
+ * AC-16: the orchestrator must fail fast when configured provider IDs (stage
+ * config or, via the factory, plugin providers) reference an ID that matches
+ * no registered provider. This catches operator typos such as `"static-ruls"`.
+ *
+ * `request.providerIds` is an intentional test-only override (see orchestrator.ts
+ * comment at assemble()). Unknown IDs in the override filter silently so that
+ * fixtures can use a known-superset of IDs without registering every stub.
  *
  * Kept in a separate file because orchestrator.test.ts exceeds 400 lines.
  */
 
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { ContextOrchestrator } from "../../../../src/context/engine/orchestrator";
-import type { ContextRequest, IContextProvider, ContextProviderResult } from "../../../../src/context/engine/types";
+import type {
+  ContextProviderResult,
+  ContextRequest,
+  IContextProvider,
+} from "../../../../src/context/engine/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -33,36 +42,46 @@ function makeProvider(id: string): IContextProvider {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// #508-M12: AC-16/AC-23 unknown provider ID validation
+// #508-M12: AC-16 validation is scoped to stage-config / registered providers
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("ContextOrchestrator — #508-M12 unknown providerIds validation", () => {
-  test("throws when providerIds contains an unknown ID", async () => {
-    const orch = new ContextOrchestrator([makeProvider("real-provider")]);
-    await expect(orch.assemble({ ...BASE_REQUEST, providerIds: ["does-not-exist"] })).rejects.toMatchObject({
-      code: "CONTEXT_UNKNOWN_PROVIDER_IDS",
-    });
+  test("throws when a stage references a provider ID that is not registered", async () => {
+    // The default "tdd-implementer" stage references static-rules, feature-context,
+    // session-scratch, git-history, and code-neighbor. Register none of them so
+    // the configured stage has unknown IDs.
+    const orch = new ContextOrchestrator([makeProvider("unrelated")]);
+    let threw: unknown;
+    try {
+      await orch.assemble(BASE_REQUEST);
+    } catch (e) {
+      threw = e;
+    }
+    expect(threw).toMatchObject({ code: "CONTEXT_UNKNOWN_PROVIDER_IDS" });
   });
 
-  test("succeeds when all providerIds are known", async () => {
+  test("does not throw when request.providerIds (test-only override) references unknown IDs", async () => {
+    // request.providerIds is a documented test-only override and unknown IDs
+    // must filter silently so fixtures can use a known superset without
+    // registering every stub.
     const orch = new ContextOrchestrator([makeProvider("real-provider")]);
-    const result = await orch.assemble({ ...BASE_REQUEST, providerIds: ["real-provider"] });
+    const result = await orch.assemble({
+      ...BASE_REQUEST,
+      providerIds: ["real-provider", "does-not-exist", "phantom-id"],
+    });
     expect(result.manifest.includedChunks).toBeDefined();
   });
 
-  test("throws when providerIds mix known and unknown IDs", async () => {
-    const orch = new ContextOrchestrator([makeProvider("known-a"), makeProvider("known-b")]);
-    await expect(
-      orch.assemble({
-        ...BASE_REQUEST,
-        providerIds: ["known-a", "ghost-id", "known-b", "phantom-id"],
-      }),
-    ).rejects.toMatchObject({
-      code: "CONTEXT_UNKNOWN_PROVIDER_IDS",
+  test("does not throw when request.providerIds override contains only unknown IDs", async () => {
+    const orch = new ContextOrchestrator([makeProvider("real-provider")]);
+    const result = await orch.assemble({
+      ...BASE_REQUEST,
+      providerIds: ["ghost-id"],
     });
+    expect(result.manifest.includedChunks).toBeDefined();
   });
 
-  test("succeeds when providerIds is empty", async () => {
+  test("succeeds when request.providerIds is empty", async () => {
     const orch = new ContextOrchestrator([makeProvider("p1")]);
     const result = await orch.assemble({ ...BASE_REQUEST, providerIds: [] });
     expect(result.manifest.includedChunks).toBeDefined();

--- a/test/unit/context/engine/orchestrator.test.ts
+++ b/test/unit/context/engine/orchestrator.test.ts
@@ -204,12 +204,14 @@ describe("ContextOrchestrator.assemble() — agent profile ceiling (AC-32)", () 
 
 describe("ContextOrchestrator.assemble() — pull tool capability gate (AC-33)", () => {
   test("conservative default profile (supportsToolCalls=false) surfaces zero pull tools", async () => {
+    // Pull-tool gate is orthogonal to provider registration — use an empty
+    // test-override providerIds list so AC-16 validation does not trip on the
+    // tdd-test-writer stage config (which references providers not registered here).
     const orch = new ContextOrchestrator([]);
     const bundle = await orch.assemble({
       ...BASE_REQUEST,
-      // tdd-test-writer has pull tools in stage-config.
       stage: "tdd-test-writer",
-      providerIds: undefined, // use stage-config default
+      providerIds: [],
       agentId: "some-unknown-agent", // → conservative default → supportsToolCalls=false
       pullConfig: {
         enabled: true,
@@ -225,7 +227,7 @@ describe("ContextOrchestrator.assemble() — pull tool capability gate (AC-33)",
     const bundle = await orch.assemble({
       ...BASE_REQUEST,
       stage: "tdd-test-writer",
-      providerIds: undefined,
+      providerIds: [],
       agentId: "claude",
       pullConfig: {
         enabled: true,

--- a/test/unit/context/engine/providers/feature-context.test.ts
+++ b/test/unit/context/engine/providers/feature-context.test.ts
@@ -133,10 +133,10 @@ describe("FeatureContextProviderV2", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// #508-M6: AC-46 proportional staleness scoring
+// #508-M6: AC-46 per-entry staleness scoring
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("FeatureContextProviderV2 — #508-M6 proportional staleness scoring", () => {
+describe("FeatureContextProviderV2 — #508-M6 per-entry staleness scoring", () => {
   // Content: 2 entries in same section. Entry 0 is contradicted by entry 1
   // (shares >= 3 significant terms, entry 1 has negation "no longer").
   // Stale entries: 1 of 2 → ratio = 0.5
@@ -169,7 +169,7 @@ describe("FeatureContextProviderV2 — #508-M6 proportional staleness scoring", 
     expect(chunk.staleCandidate).toBeFalsy();
   });
 
-  test("chunk gets proportional scoreMultiplier (~0.7) when half of entries are stale via contradiction", async () => {
+  test("only stale entry chunks get scoreMultiplier when one of two entries is contradicted", async () => {
     // 2 entries in same section. Entry 0 is contradicted by entry 1
     // (shares 7 significant terms, entry 1 has "no longer" negation).
     // stale count = 1, total = 2, ratio = 0.5
@@ -178,22 +178,22 @@ describe("FeatureContextProviderV2 — #508-M6 proportional staleness scoring", 
     const provider = new FeatureContextProviderV2(STORY, makeStaleConfig());
     const result = await provider.fetch(makeRequest());
 
-    const chunk = result.chunks[0];
-    expect(chunk).toBeDefined();
-    expect(chunk.staleCandidate).toBe(true);
-    // RED: old whole-chunk taint returns 0.4; GREEN: proportional returns 0.7
-    expect(chunk.scoreMultiplier).toBeCloseTo(0.7, 5);
+    expect(result.chunks).toHaveLength(2);
+    const staleChunks = result.chunks.filter((c) => c.staleCandidate);
+    const freshChunks = result.chunks.filter((c) => !c.staleCandidate);
+    expect(staleChunks).toHaveLength(1);
+    expect(freshChunks).toHaveLength(1);
+    expect(staleChunks[0]?.scoreMultiplier).toBeCloseTo(0.4, 5);
+    expect(freshChunks[0]?.scoreMultiplier).toBeUndefined();
   });
 
-  test("chunk scoreMultiplier is strictly less than full penalty when only some entries are stale", async () => {
+  test("entry chunk IDs are deterministic and indexed", async () => {
     mockV1Provider({ content: PARTIAL_STALE_CONTENT, estimatedTokens: 30 });
     const provider = new FeatureContextProviderV2(STORY, makeStaleConfig());
-    const result = await provider.fetch(makeRequest());
-
-    const chunk = result.chunks[0];
-    expect(chunk).toBeDefined();
-    expect(chunk.staleCandidate).toBe(true);
-    // Proportional penalty must be strictly less severe than full 0.4 penalty
-    expect(chunk.scoreMultiplier).toBeGreaterThan(0.4);
+    const r1 = await provider.fetch(makeRequest());
+    const r2 = await provider.fetch(makeRequest());
+    expect(r1.chunks.map((c) => c.id)).toEqual(r2.chunks.map((c) => c.id));
+    expect(r1.chunks[0]?.id).toMatch(/:entry-0$/);
+    expect(r1.chunks[1]?.id).toMatch(/:entry-1$/);
   });
 });

--- a/test/unit/context/engine/providers/static-rules-legacy-default.test.ts
+++ b/test/unit/context/engine/providers/static-rules-legacy-default.test.ts
@@ -18,18 +18,22 @@ import type { ContextRequest } from "../../../../../src/context/engine/types";
 
 let origReadFile: typeof _staticRulesDeps.readFile;
 let origFileExists: typeof _staticRulesDeps.fileExists;
+let origGlobInDir: typeof _staticRulesDeps.globInDir;
 let origLoadCanonicalRules: typeof _staticRulesDeps.loadCanonicalRules;
 
 beforeEach(() => {
   origReadFile = _staticRulesDeps.readFile;
   origFileExists = _staticRulesDeps.fileExists;
+  origGlobInDir = _staticRulesDeps.globInDir;
   origLoadCanonicalRules = _staticRulesDeps.loadCanonicalRules;
   _staticRulesDeps.loadCanonicalRules = async () => [];
+  _staticRulesDeps.globInDir = () => [];
 });
 
 afterEach(() => {
   _staticRulesDeps.readFile = origReadFile;
   _staticRulesDeps.fileExists = origFileExists;
+  _staticRulesDeps.globInDir = origGlobInDir;
   _staticRulesDeps.loadCanonicalRules = origLoadCanonicalRules;
 });
 

--- a/test/unit/context/engine/providers/static-rules.test.ts
+++ b/test/unit/context/engine/providers/static-rules.test.ts
@@ -162,6 +162,19 @@ describe("StaticRulesProvider — canonical store (Phase 5.1)", () => {
     expect(result.chunks[0]?.content).not.toContain("Legacy rules.");
   });
 
+  test("applies rules budget truncation tail-biased by priority", async () => {
+    setupCanonical([
+      { fileName: "a.md", id: "a", content: "A".repeat(800), tokens: 200, priority: 1 },
+      { fileName: "b.md", id: "b", content: "B".repeat(800), tokens: 200, priority: 2 },
+      { fileName: "c.md", id: "c", content: "C".repeat(800), tokens: 200, priority: 3 },
+    ]);
+    const provider = new StaticRulesProvider({ budgetTokens: 400 });
+    const result = await provider.fetch(BASE_REQUEST);
+    expect(result.chunks).toHaveLength(2);
+    expect(result.chunks[0]?.id).toContain("a");
+    expect(result.chunks[1]?.id).toContain("b");
+  });
+
   test("propagates NeutralityLintError without falling back to legacy", async () => {
     _staticRulesDeps.loadCanonicalRules = async () => {
       throw new NeutralityLintError([

--- a/test/unit/context/engine/providers/static-rules.test.ts
+++ b/test/unit/context/engine/providers/static-rules.test.ts
@@ -20,21 +20,25 @@ import type { CanonicalRule } from "../../../../../src/context/rules/canonical-l
 
 let origReadFile: typeof _staticRulesDeps.readFile;
 let origFileExists: typeof _staticRulesDeps.fileExists;
+let origGlobInDir: typeof _staticRulesDeps.globInDir;
 let origLoadCanonicalRules: typeof _staticRulesDeps.loadCanonicalRules;
 
 beforeEach(() => {
   origReadFile = _staticRulesDeps.readFile;
   origFileExists = _staticRulesDeps.fileExists;
+  origGlobInDir = _staticRulesDeps.globInDir;
   origLoadCanonicalRules = _staticRulesDeps.loadCanonicalRules;
   // Default: no canonical rules (so legacy tests run the legacy path)
   _staticRulesDeps.loadCanonicalRules = async () => [];
   _staticRulesDeps.fileExists = async () => false;
   _staticRulesDeps.readFile = async () => "";
+  _staticRulesDeps.globInDir = () => [];
 });
 
 afterEach(() => {
   _staticRulesDeps.readFile = origReadFile;
   _staticRulesDeps.fileExists = origFileExists;
+  _staticRulesDeps.globInDir = origGlobInDir;
   _staticRulesDeps.loadCanonicalRules = origLoadCanonicalRules;
 });
 
@@ -52,12 +56,14 @@ const BASE_REQUEST: ContextRequest = {
 };
 
 function setupLegacyFiles(files: Record<string, string | undefined>) {
+  const nestedRules = Object.keys(files).filter((path) => path.includes("/.claude/rules/") && path.endsWith(".md"));
   _staticRulesDeps.fileExists = async (path: string) => path in files && files[path] !== undefined;
   _staticRulesDeps.readFile = async (path: string) => {
     const content = files[path];
     if (content === undefined) throw new Error(`File not found: ${path}`);
     return content;
   };
+  _staticRulesDeps.globInDir = () => nestedRules;
 }
 
 function setupCanonical(rules: CanonicalRule[]) {
@@ -118,6 +124,33 @@ describe("StaticRulesProvider — canonical store (Phase 5.1)", () => {
     expect(r1.chunks[0]?.id).toBe(r2.chunks[0]?.id);
   });
 
+  test("filters canonical rules by appliesTo when touchedFiles are present", async () => {
+    setupCanonical([
+      { fileName: "agents.md", content: "Agent-specific coding rules", appliesTo: ["src/agents/**"] },
+      { fileName: "global.md", content: "Global rules" },
+    ]);
+    const provider = new StaticRulesProvider();
+    const result = await provider.fetch({
+      ...BASE_REQUEST,
+      touchedFiles: ["src/review/runner.ts"],
+    });
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0]?.content).toContain("Global rules");
+  });
+
+  test("includes appliesTo-scoped rule when touchedFiles match", async () => {
+    setupCanonical([
+      { fileName: "agents.md", content: "Agent-specific coding rules", appliesTo: ["src/agents/**"] },
+    ]);
+    const provider = new StaticRulesProvider();
+    const result = await provider.fetch({
+      ...BASE_REQUEST,
+      touchedFiles: ["src/agents/acp/adapter.ts"],
+    });
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0]?.content).toContain("Agent-specific coding rules");
+  });
+
   test("canonical path takes precedence over legacy files", async () => {
     setupCanonical([{ fileName: "canonical.md", content: "Canonical rules." }]);
     setupLegacyFiles({ "/project/CLAUDE.md": "Legacy rules." });
@@ -132,7 +165,7 @@ describe("StaticRulesProvider — canonical store (Phase 5.1)", () => {
   test("propagates NeutralityLintError without falling back to legacy", async () => {
     _staticRulesDeps.loadCanonicalRules = async () => {
       throw new NeutralityLintError([
-        { file: "bad.md", lineNumber: 1, line: "CLAUDE.md", pattern: "agent-specific" },
+        { file: "bad.md", lineNumber: 1, line: "CLAUDE.md", ruleId: "claude-reference", pattern: "agent-specific" },
       ]);
     };
     setupLegacyFiles({ "/project/CLAUDE.md": "Legacy rules." });
@@ -161,11 +194,15 @@ describe("StaticRulesProvider — allowLegacyClaudeMd", () => {
   });
 
   test("reads legacy files when allowLegacyClaudeMd is true and no canonical rules", async () => {
-    setupLegacyFiles({ "/project/CLAUDE.md": "# Project Rules\n\nUse bun." });
+    setupLegacyFiles({
+      "/project/CLAUDE.md": "# Project Rules\n\nUse bun.",
+      "/project/.claude/rules/testing.md": "Always write tests.",
+    });
     const provider = new StaticRulesProvider({ allowLegacyClaudeMd: true });
     const result = await provider.fetch(BASE_REQUEST);
-    expect(result.chunks).toHaveLength(1);
-    expect(result.chunks[0]?.content).toContain("Use bun.");
+    expect(result.chunks).toHaveLength(2);
+    expect(result.chunks.map((c) => c.content).join("\n")).toContain("Use bun.");
+    expect(result.chunks.map((c) => c.content).join("\n")).toContain("Always write tests.");
   });
 
   test("default allowLegacyClaudeMd is false — no legacy fallback without opt-in", async () => {
@@ -230,14 +267,30 @@ describe("StaticRulesProvider — legacy path", () => {
     expect(result.chunks[0]?.content).toContain("cursor rules here");
   });
 
-  test("reads only the first candidate found (CLAUDE.md wins over .cursorrules)", async () => {
+  test("reads all legacy candidate files when present", async () => {
     setupLegacyFiles({
       "/project/CLAUDE.md": "claude rules",
       "/project/.cursorrules": "cursor rules",
+      "/project/AGENTS.md": "agent rules",
     });
     const result = await provider.fetch(BASE_REQUEST);
-    expect(result.chunks).toHaveLength(1);
-    expect(result.chunks[0]?.content).toContain("claude rules");
+    expect(result.chunks).toHaveLength(3);
+    const all = result.chunks.map((c) => c.content).join("\n");
+    expect(all).toContain("claude rules");
+    expect(all).toContain("cursor rules");
+    expect(all).toContain("agent rules");
+  });
+
+  test("loads .claude/rules/*.md in legacy mode", async () => {
+    setupLegacyFiles({
+      "/project/.claude/rules/testing.md": "testing rules",
+      "/project/.claude/rules/typescript/style.md": "typescript style",
+    });
+    const result = await provider.fetch(BASE_REQUEST);
+    expect(result.chunks).toHaveLength(2);
+    const all = result.chunks.map((c) => c.content).join("\n");
+    expect(all).toContain(".claude/rules/testing.md");
+    expect(all).toContain(".claude/rules/typescript/style.md");
   });
 
   test("soft failure: read error is logged and returns empty", async () => {
@@ -329,7 +382,9 @@ describe("StaticRulesProvider — AC-57 per-package overlay", () => {
   test("monorepo: NeutralityLintError from repo-level rules propagates without fallback", async () => {
     _staticRulesDeps.loadCanonicalRules = async (workdir: string) => {
       if (workdir === "/repo") {
-        throw new NeutralityLintError([{ file: "bad.md", lineNumber: 1, line: "CLAUDE.md", pattern: "agent-specific" }]);
+        throw new NeutralityLintError([
+          { file: "bad.md", lineNumber: 1, line: "CLAUDE.md", ruleId: "claude-reference", pattern: "agent-specific" },
+        ]);
       }
       return [];
     };
@@ -349,7 +404,9 @@ describe("StaticRulesProvider — AC-57 per-package overlay", () => {
     _staticRulesDeps.loadCanonicalRules = async (workdir: string) => {
       if (workdir === "/repo") return [{ fileName: "style.md", content: "Repo style." }];
       if (workdir === "/repo/packages/api") {
-        throw new NeutralityLintError([{ file: "pkg.md", lineNumber: 2, line: "AGENTS.md", pattern: "agent-specific" }]);
+        throw new NeutralityLintError([
+          { file: "pkg.md", lineNumber: 2, line: "AGENTS.md", ruleId: "codex-reference", pattern: "agent-specific" },
+        ]);
       }
       return [];
     };
@@ -401,8 +458,8 @@ describe("StaticRulesProvider — AC-57 per-package overlay", () => {
     // Overlay: map has rule-a.md and rule-b.md — both kept since different filenames
     expect(result.chunks).toHaveLength(2);
     const ids = result.chunks.map((c) => c.id);
-    expect(ids.some((id) => id.includes("rule-a.md"))).toBe(true);
-    expect(ids.some((id) => id.includes("rule-b.md"))).toBe(true);
+    expect(ids.some((id) => id.includes("rule-a"))).toBe(true);
+    expect(ids.some((id) => id.includes("rule-b"))).toBe(true);
     // IDs must be distinct even though content hashes are identical
     expect(ids[0]).not.toBe(ids[1]);
   });

--- a/test/unit/context/engine/stage-assembler.test.ts
+++ b/test/unit/context/engine/stage-assembler.test.ts
@@ -311,4 +311,13 @@ describe("assembleForStage — AC-24/AC-51 ContextRequest propagation", () => {
 
     expect(mock.ref.captured?.planDigestBoost).toBe(1.5);
   });
+
+  test("threads availableBudgetTokens from stage assembly call site", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () => mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    await assembleForStage(makeCtx({ testStrategy: "tdd-simple" }), "execution");
+
+    expect(mock.ref.captured?.availableBudgetTokens).toBeGreaterThan(0);
+  });
 });

--- a/test/unit/context/rules/canonical-loader.test.ts
+++ b/test/unit/context/rules/canonical-loader.test.ts
@@ -11,6 +11,7 @@ import {
   lintForNeutrality,
   loadCanonicalRules,
   NeutralityLintError,
+  RulesFrontmatterError,
   CANONICAL_RULES_DIR,
   _canonicalLoaderDeps,
 } from "../../../../src/context/rules/canonical-loader";
@@ -71,19 +72,20 @@ describe("lintForNeutrality", () => {
   test("flags <system-reminder> tag", () => {
     const violations = lintForNeutrality("<system-reminder>Do this.</system-reminder>", "rules.md");
     expect(violations.length).toBeGreaterThan(0);
-    expect(violations[0]?.pattern).toContain("system-reminder");
+    expect(violations[0]?.pattern).toContain("XML tag");
   });
 
   test("flags CLAUDE.md reference", () => {
     const violations = lintForNeutrality("See CLAUDE.md for more info.", "rules.md");
     expect(violations.length).toBeGreaterThan(0);
     expect(violations[0]?.pattern).toContain("CLAUDE.md");
+    expect(violations[0]?.ruleId).toBe("claude-reference");
   });
 
   test("flags .claude/ directory reference", () => {
     const violations = lintForNeutrality("Rules are in .claude/rules/.", "rules.md");
     expect(violations.length).toBeGreaterThan(0);
-    expect(violations[0]?.pattern).toContain(".claude/");
+    expect(violations[0]?.pattern).toContain("directory");
   });
 
   test("flags 'the Grep tool' phrasing", () => {
@@ -115,6 +117,23 @@ describe("lintForNeutrality", () => {
     expect(violations[0]?.file).toBe("test-file.md");
   });
 
+  test("supports per-line override marker for CLAUDE.md reference", () => {
+    const violations = lintForNeutrality(
+      "<!-- nax-rules-allow: claude-reference --> See CLAUDE.md for migration notes.",
+      "rules.md",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("override applies only to the same line", () => {
+    const violations = lintForNeutrality(
+      "<!-- nax-rules-allow: claude-reference -->\nSee CLAUDE.md for migration notes.",
+      "rules.md",
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.ruleId).toBe("claude-reference");
+  });
+
   test("only flags one violation per line (most specific pattern wins)", () => {
     // Line has both CLAUDE.md and IMPORTANT: — only one violation per line
     const violations = lintForNeutrality("IMPORTANT: See CLAUDE.md", "rules.md");
@@ -129,14 +148,14 @@ describe("lintForNeutrality", () => {
 describe("NeutralityLintError", () => {
   test("is a NaxError", () => {
     const err = new NeutralityLintError([{
-      file: "a.md", lineNumber: 1, line: "CLAUDE.md", pattern: "agent-specific file",
+      file: "a.md", lineNumber: 1, line: "CLAUDE.md", ruleId: "claude-reference", pattern: "agent-specific file",
     }]);
     expect(err).toBeInstanceOf(NaxError);
     expect(err.code).toBe("NEUTRALITY_LINT_FAILED");
   });
 
   test("exposes violations array", () => {
-    const violation = { file: "a.md", lineNumber: 5, line: "IMPORTANT:", pattern: "shouting" };
+    const violation = { file: "a.md", lineNumber: 5, line: "IMPORTANT:", ruleId: "important-shouting", pattern: "shouting" };
     const err = new NeutralityLintError([violation]);
     expect(err.violations).toHaveLength(1);
     expect(err.violations[0]).toEqual(violation);
@@ -144,7 +163,7 @@ describe("NeutralityLintError", () => {
 
   test("message includes file and line number", () => {
     const err = new NeutralityLintError([{
-      file: "coding.md", lineNumber: 12, line: "CLAUDE.md", pattern: "agent-specific",
+      file: "coding.md", lineNumber: 12, line: "CLAUDE.md", ruleId: "claude-reference", pattern: "agent-specific",
     }]);
     expect(err.message).toContain("coding.md");
     expect(err.message).toContain("12");
@@ -172,6 +191,27 @@ describe("loadCanonicalRules", () => {
     // globInDir sorts alphabetically; fileName is the basename
     expect(rules[0]?.fileName).toBe("coding-style.md");
     expect(rules[1]?.fileName).toBe("testing.md");
+  });
+
+  test("loads nested one-level rule files", async () => {
+    setupFiles({
+      "/project/.nax/rules/core.md": "Core rule.",
+      "/project/.nax/rules/frontend/style.md": "Frontend style rule.",
+    });
+    const rules = await loadCanonicalRules("/project");
+    expect(rules).toHaveLength(2);
+    expect(rules.map((r) => r.path)).toContain("core.md");
+    expect(rules.map((r) => r.path)).toContain("frontend/style.md");
+  });
+
+  test("ignores files deeper than one nested level", async () => {
+    setupFiles({
+      "/project/.nax/rules/core.md": "Core rule.",
+      "/project/.nax/rules/frontend/react/style.md": "Too deep rule.",
+    });
+    const rules = await loadCanonicalRules("/project");
+    expect(rules).toHaveLength(1);
+    expect(rules[0]?.path).toBe("core.md");
   });
 
   test("each rule has fileName (basename) and content", async () => {
@@ -223,6 +263,32 @@ describe("loadCanonicalRules", () => {
     setupFiles({ "/project/.nax/rules/style.md": "\n\n## Style\n\nContent.\n\n" });
     const rules = await loadCanonicalRules("/project");
     expect(rules[0]?.content).toBe("## Style\n\nContent.");
+  });
+
+  test("parses frontmatter priority and appliesTo", async () => {
+    setupFiles({
+      "/project/.nax/rules/agents.md": `---
+priority: 50
+appliesTo:
+  - "src/agents/**"
+  - "test/agents/**"
+---
+Only for agent files.`,
+    });
+    const rules = await loadCanonicalRules("/project");
+    expect(rules[0]?.priority).toBe(50);
+    expect(rules[0]?.appliesTo).toEqual(["src/agents/**", "test/agents/**"]);
+    expect(rules[0]?.content).toBe("Only for agent files.");
+  });
+
+  test("throws RulesFrontmatterError on malformed frontmatter", async () => {
+    setupFiles({
+      "/project/.nax/rules/bad.md": `---
+priority: [not-a-number]
+---
+Broken`,
+    });
+    await expect(loadCanonicalRules("/project")).rejects.toBeInstanceOf(RulesFrontmatterError);
   });
 });
 

--- a/test/unit/context/rules/canonical-loader.test.ts
+++ b/test/unit/context/rules/canonical-loader.test.ts
@@ -8,6 +8,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { NaxError } from "../../../../src/errors";
 import {
+  applyCanonicalRulesBudget,
   lintForNeutrality,
   loadCanonicalRules,
   NeutralityLintError,
@@ -289,6 +290,40 @@ priority: [not-a-number]
 Broken`,
     });
     await expect(loadCanonicalRules("/project")).rejects.toBeInstanceOf(RulesFrontmatterError);
+  });
+
+  test("applies budget truncation when budgetTokens is provided", async () => {
+    setupFiles({
+      "/project/.nax/rules/a.md": `---
+priority: 1
+---
+${"A".repeat(800)}`,
+      "/project/.nax/rules/b.md": `---
+priority: 2
+---
+${"B".repeat(800)}`,
+      "/project/.nax/rules/c.md": `---
+priority: 3
+---
+${"C".repeat(800)}`,
+    });
+    const rules = await loadCanonicalRules("/project", { budgetTokens: 200 });
+    expect(rules.length).toBeGreaterThan(0);
+    expect(rules.length).toBeLessThan(3);
+  });
+});
+
+describe("applyCanonicalRulesBudget", () => {
+  test("keeps higher-priority rules first when truncating", () => {
+    const rules = [
+      { fileName: "a.md", id: "a", content: "A".repeat(400), tokens: 100, priority: 1 },
+      { fileName: "b.md", id: "b", content: "B".repeat(400), tokens: 100, priority: 2 },
+      { fileName: "c.md", id: "c", content: "C".repeat(400), tokens: 100, priority: 3 },
+    ];
+    const result = applyCanonicalRulesBudget(rules, 200);
+    expect(result.rules).toHaveLength(2);
+    expect(result.rules.map((r) => r.id)).toEqual(["a", "b"]);
+    expect(result.droppedCount).toBe(1);
   });
 });
 

--- a/test/unit/execution/lifecycle/run-completion-session-close.test.ts
+++ b/test/unit/execution/lifecycle/run-completion-session-close.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
+import { _runCompletionDeps, handleRunCompletion } from "../../../../src/execution/lifecycle/run-completion";
+import type { ISessionManager } from "../../../../src/session";
+
+const makeStatusWriter = () => ({
+  setPrd: mock(() => {}),
+  setCurrentStory: mock(() => {}),
+  setRunStatus: mock(() => {}),
+  setPostRunPhase: mock(() => {}),
+  update: mock(async () => {}),
+});
+
+const makePrd = () => ({
+  project: "test-project",
+  feature: "test-feature",
+  branchName: "test-branch",
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  userStories: [],
+});
+
+describe("handleRunCompletion session teardown", () => {
+  const originalCloseAllRunSessions = _runCompletionDeps.closeAllRunSessions;
+  const originalRunDeferredRegression = _runCompletionDeps.runDeferredRegression;
+
+  beforeEach(() => {
+    _runCompletionDeps.closeAllRunSessions = mock(async () => 0);
+    _runCompletionDeps.runDeferredRegression = mock(async () => ({
+      success: true,
+      failedTests: 0,
+      failedTestFiles: [],
+      passedTests: 0,
+      rectificationAttempts: 0,
+      affectedStories: [],
+    }));
+  });
+
+  afterEach(() => {
+    _runCompletionDeps.closeAllRunSessions = originalCloseAllRunSessions;
+    _runCompletionDeps.runDeferredRegression = originalRunDeferredRegression;
+    mock.restore();
+  });
+
+  test("calls closeAllRunSessions when sessionManager is provided", async () => {
+    await handleRunCompletion({
+      runId: "run-1",
+      feature: "test-feature",
+      startedAt: new Date().toISOString(),
+      prd: makePrd() as never,
+      allStoryMetrics: [],
+      totalCost: 0,
+      storiesCompleted: 0,
+      iterations: 1,
+      startTime: Date.now() - 100,
+      workdir: "/tmp/workdir",
+      statusWriter: makeStatusWriter() as never,
+      config: {
+        ...DEFAULT_CONFIG,
+        execution: {
+          ...DEFAULT_CONFIG.execution,
+          regressionGate: {
+            ...DEFAULT_CONFIG.execution.regressionGate,
+            mode: "disabled",
+          },
+        },
+      } as never,
+      sessionManager: { closeStory: mock(() => []), listActive: mock(() => []) } as unknown as ISessionManager,
+    });
+
+    expect(_runCompletionDeps.closeAllRunSessions).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not call closeAllRunSessions when sessionManager is omitted", async () => {
+    await handleRunCompletion({
+      runId: "run-1",
+      feature: "test-feature",
+      startedAt: new Date().toISOString(),
+      prd: makePrd() as never,
+      allStoryMetrics: [],
+      totalCost: 0,
+      storiesCompleted: 0,
+      iterations: 1,
+      startTime: Date.now() - 100,
+      workdir: "/tmp/workdir",
+      statusWriter: makeStatusWriter() as never,
+      config: {
+        ...DEFAULT_CONFIG,
+        execution: {
+          ...DEFAULT_CONFIG.execution,
+          regressionGate: {
+            ...DEFAULT_CONFIG.execution.regressionGate,
+            mode: "disabled",
+          },
+        },
+      } as never,
+    });
+
+    expect(_runCompletionDeps.closeAllRunSessions).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/execution/session-manager-runtime.test.ts
+++ b/test/unit/execution/session-manager-runtime.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { SessionDescriptor } from "../../../src/session/types";
+import { closeAllRunSessions, closeStorySessions } from "../../../src/execution/session-manager-runtime";
+
+type SessionManagerLike = {
+  closeStory(storyId: string): SessionDescriptor[];
+  listActive(): SessionDescriptor[];
+};
+
+const makeSessionDescriptor = (overrides: Partial<SessionDescriptor> = {}): SessionDescriptor =>
+  ({
+    id: "sess-1",
+    role: "implementer",
+    state: "RUNNING",
+    agent: "claude",
+    workdir: "/workdir",
+    protocolIds: { recordId: null, sessionId: null },
+    completedStages: [],
+    createdAt: "2025-01-01T00:00:00.000Z",
+    lastActivityAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  }) satisfies SessionDescriptor;
+
+describe("closeStorySessions()", () => {
+  test("closes physical handles returned by closeStory() only when handle exists", async () => {
+    const withHandle = makeSessionDescriptor({ id: "sess-1", handle: "nax-story-1", workdir: "/workdir/a" });
+    const withoutHandle = makeSessionDescriptor({ id: "sess-2" });
+    const sessionManager: SessionManagerLike = {
+      closeStory: mock(() => [withHandle, withoutHandle]),
+      listActive: mock(() => []),
+    };
+    const closePhysicalSession = mock(async () => {});
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    const closed = await closeStorySessions(sessionManager, "US-001", agentGetFn);
+
+    expect(closed).toBe(2);
+    expect(sessionManager.closeStory).toHaveBeenCalledTimes(1);
+    expect(sessionManager.closeStory).toHaveBeenCalledWith("US-001");
+    expect(agentGetFn).toHaveBeenCalledTimes(1);
+    expect(closePhysicalSession).toHaveBeenCalledTimes(1);
+    expect(closePhysicalSession).toHaveBeenCalledWith("nax-story-1", "/workdir/a");
+  });
+
+  test("does not close a physical session when the handle is missing", async () => {
+    const withoutHandle = makeSessionDescriptor({ id: "sess-1" });
+    const sessionManager: SessionManagerLike = {
+      closeStory: mock(() => [withoutHandle]),
+      listActive: mock(() => []),
+    };
+    const closePhysicalSession = mock(async () => {});
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    const closed = await closeStorySessions(sessionManager, "US-001", agentGetFn);
+
+    expect(closed).toBe(1);
+    expect(agentGetFn).not.toHaveBeenCalled();
+    expect(closePhysicalSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("closeAllRunSessions()", () => {
+  test("dedupes story IDs from listActive() before calling closeStory()", async () => {
+    const storyOneA = makeSessionDescriptor({ id: "sess-1", storyId: "US-001", handle: "nax-1" });
+    const storyOneB = makeSessionDescriptor({ id: "sess-2", storyId: "US-001", handle: "nax-2" });
+    const storyTwo = makeSessionDescriptor({ id: "sess-3", storyId: "US-002", handle: "nax-3" });
+    const sessionManager: SessionManagerLike = {
+      closeStory: mock(() => [storyOneA]),
+      listActive: mock(() => [storyOneA, storyOneB, storyTwo]),
+    };
+    const agentGetFn = mock(() => ({ closePhysicalSession: mock(async () => {}) }));
+
+    const closed = await closeAllRunSessions(sessionManager, agentGetFn);
+
+    expect(closed).toBe(2);
+    expect(sessionManager.closeStory).toHaveBeenCalledTimes(2);
+    expect(sessionManager.closeStory).toHaveBeenNthCalledWith(1, "US-001");
+    expect(sessionManager.closeStory).toHaveBeenNthCalledWith(2, "US-002");
+  });
+});

--- a/test/unit/execution/session-manager-runtime.test.ts
+++ b/test/unit/execution/session-manager-runtime.test.ts
@@ -115,4 +115,24 @@ describe("closeAllRunSessions()", () => {
     expect(closePhysicalSession).toHaveBeenNthCalledWith(1, "nax-1", "/workdir");
     expect(closePhysicalSession).toHaveBeenNthCalledWith(2, "nax-2", "/workdir/b");
   });
+
+  test("walks a valid transition chain for a storyless PAUSED session", async () => {
+    const storyless = makeSessionDescriptor({ id: "sess-2", state: "PAUSED", handle: "nax-2", workdir: "/workdir/b" });
+    const sessionManager: SessionManagerLike = {
+      closeStory: mock(() => []),
+      listActive: mock(() => [storyless]),
+      transition: mock(() => storyless),
+    };
+    const closePhysicalSession = mock(async () => {});
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    const closed = await closeAllRunSessions(sessionManager, agentGetFn);
+
+    expect(closed).toBe(1);
+    expect(sessionManager.transition).toHaveBeenNthCalledWith(1, "sess-2", "RESUMING");
+    expect(sessionManager.transition).toHaveBeenNthCalledWith(2, "sess-2", "RUNNING");
+    expect(sessionManager.transition).toHaveBeenNthCalledWith(3, "sess-2", "COMPLETED");
+    expect(closePhysicalSession).toHaveBeenCalledTimes(1);
+    expect(closePhysicalSession).toHaveBeenCalledWith("nax-2", "/workdir/b");
+  });
 });

--- a/test/unit/execution/session-manager-runtime.test.ts
+++ b/test/unit/execution/session-manager-runtime.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { SessionDescriptor } from "../../../src/session/types";
 import { closeAllRunSessions, closeStorySessions } from "../../../src/execution/session-manager-runtime";
+import type { SessionDescriptor, SessionState } from "../../../src/session/types";
 
 type SessionManagerLike = {
   closeStory(storyId: string): SessionDescriptor[];
   listActive(): SessionDescriptor[];
-  transition?(id: string, to: "COMPLETED"): SessionDescriptor;
+  transition?(id: string, to: SessionState): SessionDescriptor;
 };
 
 const makeSessionDescriptor = (overrides: Partial<SessionDescriptor> = {}): SessionDescriptor =>

--- a/test/unit/execution/session-manager-runtime.test.ts
+++ b/test/unit/execution/session-manager-runtime.test.ts
@@ -40,7 +40,7 @@ describe("closeStorySessions()", () => {
     expect(sessionManager.closeStory).toHaveBeenCalledWith("US-001");
     expect(agentGetFn).toHaveBeenCalledTimes(1);
     expect(closePhysicalSession).toHaveBeenCalledTimes(1);
-    expect(closePhysicalSession).toHaveBeenCalledWith("nax-story-1", "/workdir/a");
+    expect(closePhysicalSession).toHaveBeenCalledWith("nax-story-1", "/workdir/a", undefined);
   });
 
   test("does not close a physical session when the handle is missing", async () => {
@@ -72,6 +72,55 @@ describe("closeStorySessions()", () => {
 
     await expect(closeStorySessions(sessionManager, "US-001", agentGetFn)).resolves.toBe(1);
     expect(closePhysicalSession).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("closeStorySessions() — AC-83 force-terminate", () => {
+  test("passes force=true to closePhysicalSession when descriptor was FAILED", async () => {
+    const failedDescriptor = makeSessionDescriptor({ id: "sess-1", state: "FAILED", handle: "nax-1", workdir: "/workdir/a" });
+    const sessionManager: SessionManagerLike = {
+      closeStory: mock(() => [failedDescriptor]),
+      listActive: mock(() => []),
+    };
+    const closePhysicalSession = mock(async () => {});
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    await closeStorySessions(sessionManager, "US-001", agentGetFn);
+
+    expect(closePhysicalSession).toHaveBeenCalledWith("nax-1", "/workdir/a", { force: true });
+  });
+
+  test("does not pass force when descriptor was not FAILED", async () => {
+    const runningDescriptor = makeSessionDescriptor({ id: "sess-1", state: "RUNNING", handle: "nax-1", workdir: "/workdir/a" });
+    const sessionManager: SessionManagerLike = {
+      closeStory: mock(() => [runningDescriptor]),
+      listActive: mock(() => []),
+    };
+    const closePhysicalSession = mock(async () => {});
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    await closeStorySessions(sessionManager, "US-001", agentGetFn);
+
+    expect(closePhysicalSession).toHaveBeenCalledWith("nax-1", "/workdir/a", undefined);
+  });
+});
+
+describe("closeAllRunSessions() — idempotency (H-5)", () => {
+  test("second call is a no-op when sessionManager returns no active sessions", async () => {
+    const session = makeSessionDescriptor({ id: "sess-1", storyId: "US-001", handle: "nax-1" });
+    const closeStory = mock(() => [session]);
+    const listActive = mock()
+      .mockImplementationOnce(() => [session]) // first call — one active session
+      .mockImplementationOnce(() => []); // second call — already closed
+    const sessionManager: SessionManagerLike = { closeStory, listActive };
+    const agentGetFn = mock(() => ({ closePhysicalSession: mock(async () => {}) }));
+
+    const first = await closeAllRunSessions(sessionManager, agentGetFn);
+    const second = await closeAllRunSessions(sessionManager, agentGetFn);
+
+    expect(first).toBe(1);
+    expect(second).toBe(0);
+    expect(closeStory).toHaveBeenCalledTimes(1); // only called on first run
   });
 });
 
@@ -112,8 +161,9 @@ describe("closeAllRunSessions()", () => {
     expect(sessionManager.transition).toHaveBeenCalledTimes(1);
     expect(sessionManager.transition).toHaveBeenCalledWith("sess-2", "COMPLETED");
     expect(closePhysicalSession).toHaveBeenCalledTimes(2);
-    expect(closePhysicalSession).toHaveBeenNthCalledWith(1, "nax-1", "/workdir");
-    expect(closePhysicalSession).toHaveBeenNthCalledWith(2, "nax-2", "/workdir/b");
+    // RUNNING sessions are not force-terminated (undefined third arg)
+    expect(closePhysicalSession).toHaveBeenNthCalledWith(1, "nax-1", "/workdir", undefined);
+    expect(closePhysicalSession).toHaveBeenNthCalledWith(2, "nax-2", "/workdir/b", undefined);
   });
 
   test("walks a valid transition chain for a storyless PAUSED session", async () => {
@@ -133,6 +183,7 @@ describe("closeAllRunSessions()", () => {
     expect(sessionManager.transition).toHaveBeenNthCalledWith(2, "sess-2", "RUNNING");
     expect(sessionManager.transition).toHaveBeenNthCalledWith(3, "sess-2", "COMPLETED");
     expect(closePhysicalSession).toHaveBeenCalledTimes(1);
-    expect(closePhysicalSession).toHaveBeenCalledWith("nax-2", "/workdir/b");
+    // PAUSED sessions are not force-terminated (undefined third arg)
+    expect(closePhysicalSession).toHaveBeenCalledWith("nax-2", "/workdir/b", undefined);
   });
 });

--- a/test/unit/execution/session-manager-runtime.test.ts
+++ b/test/unit/execution/session-manager-runtime.test.ts
@@ -5,6 +5,7 @@ import { closeAllRunSessions, closeStorySessions } from "../../../src/execution/
 type SessionManagerLike = {
   closeStory(storyId: string): SessionDescriptor[];
   listActive(): SessionDescriptor[];
+  transition?(id: string, to: "COMPLETED"): SessionDescriptor;
 };
 
 const makeSessionDescriptor = (overrides: Partial<SessionDescriptor> = {}): SessionDescriptor =>
@@ -57,6 +58,21 @@ describe("closeStorySessions()", () => {
     expect(agentGetFn).not.toHaveBeenCalled();
     expect(closePhysicalSession).not.toHaveBeenCalled();
   });
+
+  test("swallows adapter.closePhysicalSession rejections", async () => {
+    const withHandle = makeSessionDescriptor({ id: "sess-1", handle: "nax-story-1", workdir: "/workdir/a" });
+    const sessionManager: SessionManagerLike = {
+      closeStory: mock(() => [withHandle]),
+      listActive: mock(() => []),
+    };
+    const closePhysicalSession = mock(async () => {
+      throw new Error("boom");
+    });
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    await expect(closeStorySessions(sessionManager, "US-001", agentGetFn)).resolves.toBe(1);
+    expect(closePhysicalSession).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("closeAllRunSessions()", () => {
@@ -76,5 +92,27 @@ describe("closeAllRunSessions()", () => {
     expect(sessionManager.closeStory).toHaveBeenCalledTimes(2);
     expect(sessionManager.closeStory).toHaveBeenNthCalledWith(1, "US-001");
     expect(sessionManager.closeStory).toHaveBeenNthCalledWith(2, "US-002");
+  });
+
+  test("closes storyless active sessions via transition and physical close", async () => {
+    const storyBound = makeSessionDescriptor({ id: "sess-1", storyId: "US-001", handle: "nax-1" });
+    const storyless = makeSessionDescriptor({ id: "sess-2", handle: "nax-2", workdir: "/workdir/b" });
+    const sessionManager: SessionManagerLike = {
+      closeStory: mock(() => [storyBound]),
+      listActive: mock(() => [storyBound, storyless]),
+      transition: mock(() => storyless),
+    };
+    const closePhysicalSession = mock(async () => {});
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    const closed = await closeAllRunSessions(sessionManager, agentGetFn);
+
+    expect(closed).toBe(2);
+    expect(sessionManager.closeStory).toHaveBeenCalledTimes(1);
+    expect(sessionManager.transition).toHaveBeenCalledTimes(1);
+    expect(sessionManager.transition).toHaveBeenCalledWith("sess-2", "COMPLETED");
+    expect(closePhysicalSession).toHaveBeenCalledTimes(2);
+    expect(closePhysicalSession).toHaveBeenNthCalledWith(1, "nax-1", "/workdir");
+    expect(closePhysicalSession).toHaveBeenNthCalledWith(2, "nax-2", "/workdir/b");
   });
 });

--- a/test/unit/execution/session-manager-runtime.test.ts
+++ b/test/unit/execution/session-manager-runtime.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, mock, test } from "bun:test";
-import { closeAllRunSessions, closeStorySessions } from "../../../src/execution/session-manager-runtime";
+import { closeAllRunSessions, closeStorySessions, failAndClose } from "../../../src/execution/session-manager-runtime";
 import type { SessionDescriptor, SessionState } from "../../../src/session/types";
 
 type SessionManagerLike = {
   closeStory(storyId: string): SessionDescriptor[];
   listActive(): SessionDescriptor[];
   transition?(id: string, to: SessionState): SessionDescriptor;
+  get?(id: string): SessionDescriptor | null;
 };
 
 const makeSessionDescriptor = (overrides: Partial<SessionDescriptor> = {}): SessionDescriptor =>
@@ -121,6 +122,79 @@ describe("closeAllRunSessions() — idempotency (H-5)", () => {
     expect(first).toBe(1);
     expect(second).toBe(0);
     expect(closeStory).toHaveBeenCalledTimes(1); // only called on first run
+  });
+});
+
+describe("failAndClose() — H-1", () => {
+  test("transitions session to FAILED and force-closes physical handle", async () => {
+    const runningSession = makeSessionDescriptor({ id: "sess-1", state: "RUNNING", handle: "nax-1", workdir: "/workdir/a" });
+    const failedSession = { ...runningSession, state: "FAILED" as SessionState };
+    const get = mock()
+      .mockImplementationOnce(() => runningSession) // initial guard check
+      .mockImplementationOnce(() => failedSession); // after transition
+    const transition = mock(() => failedSession);
+    const closePhysicalSession = mock(async () => {});
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    await failAndClose({ get, transition }, "sess-1", agentGetFn);
+
+    expect(transition).toHaveBeenCalledWith("sess-1", "FAILED");
+    expect(closePhysicalSession).toHaveBeenCalledWith("nax-1", "/workdir/a", { force: true });
+  });
+
+  test("is a no-op when session is already in a terminal state", async () => {
+    const terminalSession = makeSessionDescriptor({ id: "sess-1", state: "COMPLETED" });
+    const get = mock(() => terminalSession);
+    const transition = mock(() => terminalSession);
+    const closePhysicalSession = mock(async () => {});
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    await failAndClose({ get, transition }, "sess-1", agentGetFn);
+
+    expect(transition).not.toHaveBeenCalled();
+    expect(closePhysicalSession).not.toHaveBeenCalled();
+  });
+
+  test("is a no-op when session is unknown", async () => {
+    const get = mock(() => null);
+    const transition = mock();
+    const closePhysicalSession = mock(async () => {});
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    await failAndClose({ get, transition }, "sess-missing", agentGetFn);
+
+    expect(transition).not.toHaveBeenCalled();
+    expect(closePhysicalSession).not.toHaveBeenCalled();
+  });
+
+  test("swallows transition errors and skips physical close", async () => {
+    const runningSession = makeSessionDescriptor({ id: "sess-1", state: "RUNNING", handle: "nax-1" });
+    const get = mock(() => runningSession);
+    const transition = mock(() => {
+      throw new Error("invalid transition");
+    });
+    const closePhysicalSession = mock(async () => {});
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    await expect(failAndClose({ get, transition }, "sess-1", agentGetFn)).resolves.toBeUndefined();
+    expect(closePhysicalSession).not.toHaveBeenCalled();
+  });
+
+  test("skips physical close when the session has no handle", async () => {
+    const runningSession = makeSessionDescriptor({ id: "sess-1", state: "RUNNING", handle: undefined });
+    const failedSession = { ...runningSession, state: "FAILED" as SessionState };
+    const get = mock()
+      .mockImplementationOnce(() => runningSession)
+      .mockImplementationOnce(() => failedSession);
+    const transition = mock(() => failedSession);
+    const closePhysicalSession = mock(async () => {});
+    const agentGetFn = mock(() => ({ closePhysicalSession }));
+
+    await failAndClose({ get, transition }, "sess-1", agentGetFn);
+
+    expect(transition).toHaveBeenCalledTimes(1);
+    expect(agentGetFn).not.toHaveBeenCalled();
+    expect(closePhysicalSession).not.toHaveBeenCalled();
   });
 });
 

--- a/test/unit/execution/session-manager-wiring.test.ts
+++ b/test/unit/execution/session-manager-wiring.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const SRC_ROOT = join(import.meta.dir, "../../../src");
+
+async function readSrc(relPath: string): Promise<string> {
+  return Bun.file(join(SRC_ROOT, relPath)).text();
+}
+
+describe("run-level SessionManager wiring", () => {
+  test("runner-execution forwards options.sessionManager into executeUnified context", async () => {
+    const src = await readSrc("execution/runner-execution.ts");
+    expect(src).toContain("sessionManager: options.sessionManager ?? new SessionManager()");
+  });
+
+  test("iteration-runner uses ctx.sessionManager instead of creating a new SessionManager", async () => {
+    const src = await readSrc("execution/iteration-runner.ts");
+    expect(src).toContain("sessionManager: ctx.sessionManager");
+    expect(src).not.toContain("new SessionManager()");
+  });
+
+  test("run-setup creates and returns a run-level sessionManager", async () => {
+    const src = await readSrc("execution/lifecycle/run-setup.ts");
+    expect(src).toContain("const sessionManager = new SessionManager()");
+    expect(src).toContain("sessionManager,");
+  });
+});

--- a/test/unit/execution/unified-executor-session-close.test.ts
+++ b/test/unit/execution/unified-executor-session-close.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _unifiedExecutorDeps, executeUnified } from "../../../src/execution/unified-executor";
+import type { ISessionManager } from "../../../src/session";
+
+function makePendingStory(id: string) {
+  return {
+    id,
+    title: `Story ${id}`,
+    description: `Description for ${id}`,
+    acceptanceCriteria: [],
+    tags: [],
+    dependencies: [],
+    status: "pending" as const,
+    passes: false,
+    attempts: 0,
+    priorFailures: [],
+  };
+}
+
+function makePrd(stories: ReturnType<typeof makePendingStory>[]) {
+  return {
+    project: "test-project",
+    feature: "test-feature",
+    branchName: "test-branch",
+    createdAt: new Date().toISOString(),
+    userStories: stories,
+  };
+}
+
+function makeSessionManager(): ISessionManager {
+  return {
+    create: mock(() => {
+      throw new Error("unused");
+    }),
+    get: mock(() => null),
+    transition: mock(() => {
+      throw new Error("unused");
+    }),
+    bindHandle: mock(() => {
+      throw new Error("unused");
+    }),
+    handoff: mock(() => {
+      throw new Error("unused");
+    }),
+    resume: mock(() => null),
+    closeStory: mock(() => []),
+    listActive: mock(() => []),
+    getForStory: mock(() => []),
+    sweepOrphans: mock(() => 0),
+  };
+}
+
+function makeCtx(sessionManager: ISessionManager) {
+  return {
+    prdPath: "/tmp/test-prd.json",
+    workdir: "/tmp/test-workdir",
+    config: {
+      execution: {
+        maxIterations: 1,
+        costLimit: 10,
+        iterationDelayMs: 0,
+        rectification: { maxRetries: 2 },
+      },
+      autoMode: { defaultAgent: "claude-code" },
+      interaction: {},
+    },
+    hooks: {},
+    feature: "test-feature",
+    dryRun: false,
+    useBatch: false,
+    pluginRegistry: {
+      getReporters: () => [],
+      getContextProviders: () => [],
+    },
+    statusWriter: {
+      setPrd: mock(() => {}),
+      setCurrentStory: mock(() => {}),
+      setRunStatus: mock(() => {}),
+      update: mock(async () => {}),
+    },
+    runId: "run-test",
+    startTime: Date.now(),
+    batchPlan: [],
+    interactionChain: null,
+    sessionManager,
+  };
+}
+
+describe("unified-executor session close policy", () => {
+  let originalRunIteration: typeof _unifiedExecutorDeps.runIteration;
+
+  beforeEach(() => {
+    originalRunIteration = _unifiedExecutorDeps.runIteration;
+  });
+
+  afterEach(() => {
+    _unifiedExecutorDeps.runIteration = originalRunIteration;
+    mock.restore();
+  });
+
+  test("does not close story sessions when finalAction is escalate", async () => {
+    const sessionManager = makeSessionManager();
+    const story = makePendingStory("US-001");
+    const prd = makePrd([story]);
+    _unifiedExecutorDeps.runIteration = mock(async () => ({
+      prd,
+      storiesCompletedDelta: 0,
+      costDelta: 0,
+      prdDirty: false,
+      finalAction: "escalate",
+    }));
+
+    await executeUnified(makeCtx(sessionManager) as never, prd as never);
+
+    expect(sessionManager.closeStory).not.toHaveBeenCalled();
+  });
+
+  test("closes story sessions when finalAction is fail", async () => {
+    const sessionManager = makeSessionManager();
+    const story = makePendingStory("US-001");
+    const prd = makePrd([story]);
+    _unifiedExecutorDeps.runIteration = mock(async () => ({
+      prd,
+      storiesCompletedDelta: 0,
+      costDelta: 0,
+      prdDirty: false,
+      finalAction: "fail",
+    }));
+
+    await executeUnified(makeCtx(sessionManager) as never, prd as never);
+
+    expect(sessionManager.closeStory).toHaveBeenCalledWith("US-001");
+  });
+});

--- a/test/unit/pipeline/stages/context-digest.test.ts
+++ b/test/unit/pipeline/stages/context-digest.test.ts
@@ -245,4 +245,18 @@ describe("context stage — Phase 2 digest threading", () => {
     expect(ctx.contextBundle).toBe(bundle);
     expect(ctx.featureContextMarkdown).toBe(bundle.pushMarkdown);
   });
+
+  test("threads availableBudgetTokens into ContextRequest", async () => {
+    _contextStageDeps.readDigest = async () => "";
+    _contextStageDeps.writeDigest = async () => {};
+
+    let capturedRequest: ContextRequest | undefined;
+    mockOrchestrator(makeBundle(), (req) => {
+      capturedRequest = req;
+    });
+
+    await contextStage.execute(makeCtx());
+
+    expect(capturedRequest?.availableBudgetTokens).toBeGreaterThan(0);
+  });
 });

--- a/test/unit/pipeline/stages/execution-agent-swap-metrics.test.ts
+++ b/test/unit/pipeline/stages/execution-agent-swap-metrics.test.ts
@@ -106,6 +106,7 @@ const origDetect = _executionDeps.detectMergeConflict;
 const origShouldSwap = _executionDeps.shouldAttemptSwap;
 const origResolveSwap = _executionDeps.resolveSwapTarget;
 const origRebuild = _executionDeps.rebuildForSwap;
+const origWriteRebuildManifest = _executionDeps.writeRebuildManifest;
 
 afterEach(() => {
   _executionDeps.getAgent = origGetAgent;
@@ -114,6 +115,7 @@ afterEach(() => {
   _executionDeps.shouldAttemptSwap = origShouldSwap;
   _executionDeps.resolveSwapTarget = origResolveSwap;
   _executionDeps.rebuildForSwap = origRebuild;
+  _executionDeps.writeRebuildManifest = origWriteRebuildManifest;
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -127,6 +129,7 @@ describe("execution stage — AC-41 fallback observability", () => {
     _executionDeps.shouldAttemptSwap = () => true;
     _executionDeps.resolveSwapTarget = () => "codex";
     _executionDeps.rebuildForSwap = () => makeBundle();
+    _executionDeps.writeRebuildManifest = async () => {};
 
     _executionDeps.getAgent = (agentId: string) =>
       ({
@@ -164,9 +167,14 @@ describe("execution stage — AC-41 fallback observability", () => {
   test("records hop in ctx.agentFallbacks even when swap also fails", async () => {
     _executionDeps.validateAgentForTier = () => true;
     _executionDeps.detectMergeConflict = () => false;
-    _executionDeps.shouldAttemptSwap = () => true;
+    let shouldSwapCalls = 0;
+    _executionDeps.shouldAttemptSwap = () => {
+      shouldSwapCalls++;
+      return shouldSwapCalls === 1;
+    };
     _executionDeps.resolveSwapTarget = () => "codex";
     _executionDeps.rebuildForSwap = () => makeBundle();
+    _executionDeps.writeRebuildManifest = async () => {};
 
     _executionDeps.getAgent = (_agentId: string) =>
       ({
@@ -197,6 +205,7 @@ describe("execution stage — AC-41 fallback observability", () => {
     _executionDeps.validateAgentForTier = () => true;
     _executionDeps.detectMergeConflict = () => false;
     _executionDeps.shouldAttemptSwap = () => false;
+    _executionDeps.writeRebuildManifest = async () => {};
 
     _executionDeps.getAgent = () =>
       ({
@@ -231,6 +240,7 @@ describe("execution stage — AC-41 fallback observability", () => {
     };
     _executionDeps.resolveSwapTarget = () => "codex";
     _executionDeps.rebuildForSwap = () => makeBundle();
+    _executionDeps.writeRebuildManifest = async () => {};
 
     _executionDeps.getAgent = () =>
       ({
@@ -258,5 +268,60 @@ describe("execution stage — AC-41 fallback observability", () => {
     // The new hop should be hop=2
     expect(ctx.agentFallbacks).toHaveLength(2);
     expect(ctx.agentFallbacks![1].hop).toBe(2);
+  });
+
+  test("writes rebuild-manifest event when swap rebuildInfo exists", async () => {
+    _executionDeps.validateAgentForTier = () => true;
+    _executionDeps.detectMergeConflict = () => false;
+    _executionDeps.shouldAttemptSwap = () => true;
+    _executionDeps.resolveSwapTarget = () => "codex";
+    _executionDeps.rebuildForSwap = () =>
+      ({
+        ...makeBundle(),
+        manifest: {
+          ...makeBundle().manifest,
+          requestId: "req-rebuild",
+          rebuildInfo: {
+            priorAgentId: "claude",
+            newAgentId: "codex",
+            failureCategory: "availability",
+            failureOutcome: "fail-quota",
+            priorChunkIds: ["chunk:a"],
+            newChunkIds: ["chunk:a", "failure-note:1"],
+            chunkIdMap: [{ priorChunkId: "chunk:a", newChunkId: "chunk:a" }],
+          },
+        },
+      }) as ContextBundle;
+
+    const writes: Array<Record<string, unknown>> = [];
+    _executionDeps.writeRebuildManifest = async (_projectDir, _featureId, _storyId, entry) => {
+      writes.push(entry as unknown as Record<string, unknown>);
+    };
+
+    _executionDeps.getAgent = (agentId: string) =>
+      ({
+        name: agentId,
+        capabilities: { supportedTiers: ["fast"] },
+        run: async () => {
+          if (agentId === "claude") {
+            return {
+              success: false,
+              exitCode: 1,
+              output: "",
+              rateLimited: false,
+              durationMs: 0,
+              adapterFailure: { category: "availability", outcome: "fail-quota" },
+            };
+          }
+          return { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0 };
+        },
+        deriveSessionName: () => "nax-test-session",
+      }) as unknown as ReturnType<typeof _executionDeps.getAgent>;
+
+    const ctx = makeCtx({ projectDir: "/repo" });
+    await executionStage.execute(ctx);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.requestId).toBe("req-rebuild");
+    expect(writes[0]?.stage).toBe("execution");
   });
 });

--- a/test/unit/session/manager.test.ts
+++ b/test/unit/session/manager.test.ts
@@ -343,3 +343,22 @@ describe("SessionManager.getForStory()", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 // bindHandle() tests extracted to manager-bind-handle.test.ts to keep file under 400 lines.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// handoff() — fallback agent ownership
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SessionManager.handoff()", () => {
+  test("updates the session's agent owner", () => {
+    const mgr = new SessionManager();
+    const sess = mgr.create({ role: "main", agent: "claude", workdir: "/p", storyId: "US-001" });
+    const updated = mgr.handoff(sess.id, "codex", "fail-quota");
+    expect(updated.agent).toBe("codex");
+    expect(mgr.get(sess.id)?.agent).toBe("codex");
+  });
+
+  test("handoff on unknown session throws NaxError", () => {
+    const mgr = new SessionManager();
+    expect(() => mgr.handoff("sess-unknown", "codex", "fail-quota")).toThrow(NaxError);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the review follow-ups from four consecutive review passes against the context-engine v2 branch and hardens session-manager integration. Net: ~88% of the 6 context-engine specs are fully wired; remaining gaps (H-2, M-3) are tracked as separate issues and do not block merge.

Highlights of this 14-commit branch:

- **CRIT-1** AC-16 unknown-provider validation scoped to stage-config IDs only; fixes 26+ test regressions from the prior strict-validation rollout.
- **H-1** Session state machine now transitions to `FAILED` on terminal failure with atomic physical close — wires AC-83 force-terminate through end-to-end. Previously unreachable because `closeStory()` unconditionally moved any non-terminal session to `COMPLETED`.
- **H-4 / H-5** Fallback exhaustion and idempotent-close test coverage.
- **Amendments A–D** closed (pollution prevention, plan digest boost, monorepo dual-workdir, session-manager ownership).
- **ADR-011** new — session manager ownership boundary. Partially supersedes ADR-008 (policy retained, `keepSessionOpen` primitive replaced by state transitions).
- **ADR-010** updated with a Post-Acceptance Amendments section and ADR-011 cross-reference.

## Specs satisfied

- [SPEC-context-engine-v2.md](docs/specs/SPEC-context-engine-v2.md)
- [SPEC-context-engine-v2-amendments.md](docs/specs/SPEC-context-engine-v2-amendments.md)
- [SPEC-context-engine-v2-compilation.md](docs/specs/SPEC-context-engine-v2-compilation.md)
- [SPEC-context-engine-agent-fallback.md](docs/specs/SPEC-context-engine-agent-fallback.md)
- [SPEC-context-engine-canonical-rules.md](docs/specs/SPEC-context-engine-canonical-rules.md)
- [SPEC-session-manager-integration.md](docs/specs/SPEC-session-manager-integration.md)

## Review trail

Four review iterations on this branch, each landing its findings before the next pass:

- `docs/reviews/today-commits-code-review-2026-04-17.md`
- `docs/reviews/context-engine-v2-final-review-2026-04-17.md`
- `docs/reviews/context-engine-review-followups-2026-04-17.md`
- `docs/reviews/context-engine-v2-session-manager-review-2026-04-18.md`
- `docs/reviews/context-engine-v2-deep-review-2026-04-18.md` (this PR)

## Deferred follow-ups (tracked, do not block merge)

- **#518** H-2: validate fallback candidate credentials at run start (ergonomics)
- **#519** M-3: surface run-level fallback aggregates to match spec event shape

(#517 — H-1 FAILED transition — is fixed in this PR.)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 441 files, no issues
- [x] `bun run test:unit` — 6279 pass / 0 fail / 13 skip
- [x] `bun run test:integration` — 1187 pass / 0 fail / 39 skip
- [ ] Reviewer: spot-check ADR-011 ownership boundary against `src/session/manager.ts` + `src/agents/acp/adapter.ts`
- [ ] Reviewer: confirm Amendment C dual-workdir does not regress non-monorepo projects
- [ ] Reviewer: confirm `failAndClose` force-terminate path fires on a real failed run (end-to-end smoke)