### PR TITLE
Release v0.63.0-canary.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.62.0",
+  "version": "0.63.0-canary.1",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What
Release v0.63.0-canary.1 — includes context-engine-v2, session manager, and latest upstream fixes.

## Why
Canary release to validate recent main branch changes before promoting to stable.

## Testing
- [x] `bun test` passes on main CI
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes
Promotes all commits from `b4888122` to `3f8d3675` on main.
