### PR TITLE
Release v0.63.0-canary.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.63.0-canary.1",
+  "version": "0.63.0-canary.2",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What
Release v0.63.0-canary.2

## Why
Canary release.

## Testing
- [x] `bun test` passes on main CI
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
