### PR TITLE
fix(session): re-persist descriptor on closeStory() terminal transition

### DIFF
--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -292,6 +292,7 @@ export class SessionManager implements ISessionManager {
 
       const updated: SessionDescriptor = { ...session, state: "COMPLETED", lastActivityAt: now };
       this._sessions.set(id, updated);
+      this._persistDescriptor(updated);
       closed.push({ ...updated });
 
       getLogger().debug("session", "Session closed by closeStory", {

--- a/test/unit/session/manager.test.ts
+++ b/test/unit/session/manager.test.ts
@@ -226,6 +226,29 @@ describe("SessionManager — descriptor re-persistence on mutation", () => {
     expect(writes[0]?.protocolIds).toEqual({ recordId: "rec-1", sessionId: "sid-1" });
   });
 
+  test("closeStory() re-persists the descriptor with state=COMPLETED", async () => {
+    const mgr = new SessionManager();
+    const s = mgr.create({
+      role: "main",
+      agent: "claude",
+      workdir: "/repo",
+      projectDir: "/repo",
+      featureName: "auth",
+      storyId: "US-001",
+    });
+    mgr.transition(s.id, "RUNNING");
+    await drainMicrotasks();
+    writes.length = 0;
+
+    const closed = mgr.closeStory("US-001");
+    await drainMicrotasks();
+
+    expect(closed).toHaveLength(1);
+    expect(closed[0]?.state).toBe("COMPLETED");
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.state).toBe("COMPLETED");
+  });
+
   test("handoff() re-persists the descriptor with the new agent", async () => {
     const mgr = new SessionManager();
     const s = mgr.create({


### PR DESCRIPTION
## Summary

Follow-up to #522 (merged in v0.63.0-canary.2). The prior fix covered \`transition()\`, \`bindHandle()\`, and \`handoff()\` but missed \`closeStory()\`.

## Reproduction

Dogfood re-run against v0.63.0-canary.2 using \`nax-dogfood/fixtures/hello-lint\` — story passed, descriptor.json showed populated protocolIds (bindHandle re-persists correctly), but state was still \`RUNNING\` instead of \`COMPLETED\`:

\`\`\`json
{
  \"state\": \"RUNNING\",
  \"protocolIds\": {
    \"recordId\": \"c50560d7-7da2-4fed-943c-93705311718e\",
    \"sessionId\": \"c50560d7-7da2-4fed-943c-93705311718e\"
  }
}
\`\`\`

## Root cause

\`closeStory()\` (src/session/manager.ts) has its own inline terminal transition instead of routing through the shared \`transition()\` helper:

\`\`\`ts
const updated: SessionDescriptor = { ...session, state: \"COMPLETED\", lastActivityAt: now };
this._sessions.set(id, updated);
// ← missing _persistDescriptor(updated) call
\`\`\`

The in-memory map was updated correctly, but the on-disk descriptor never saw the terminal transition.

## Fix

One line: \`this._persistDescriptor(updated)\` inside the \`closeStory()\` loop, matching the pattern in the three other mutation methods.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — 441 files, no issues
- [x] \`bun test test/unit/session/manager.test.ts\` — 35 pass / 0 fail (+1 new test)
- [ ] Re-run hello-lint dogfood against the next canary; confirm \`descriptor.json\` ends at \`state: COMPLETED\` with populated protocolIds.

## Related

- Prior PR: #522 (merged in canary.2)
- Surfaced during §T16.1 re-run of [docs/releases/release-test-plan-context-engine-session-manager.md](docs/releases/release-test-plan-context-engine-session-manager.md)
- A separate neighbor-hallucination finding from the same dogfood run is being filed in its own issue / PR.