### PR TITLE
fix(context-engine): code-neighbor sibling test path hallucinates .test.test.ts

### DIFF
--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -155,14 +155,22 @@ function resolveImport(specifier: string, fromFile: string, workdir: string): st
 /**
  * Derive the sibling test file path for a source file.
  * Preserves the source extension for JSX/TSX files.
- *   src/foo/bar.ts  → test/unit/foo/bar.test.ts
- *   src/foo/bar.tsx → test/unit/foo/bar.test.tsx
+ *   src/foo/bar.ts       → test/unit/foo/bar.test.ts
+ *   src/foo/bar.tsx      → test/unit/foo/bar.test.tsx
+ *   src/foo/bar.test.ts  → null  (already a test file)
+ *   src/foo/bar.spec.ts  → null  (already a test file)
+ *
+ * Returning null for test-file inputs prevents the `.test.test.ts` /
+ * `.spec.spec.ts` hallucination that appeared when the provider was fed
+ * a test file as a touched file (e.g. via PRD `contextFiles`). See #526.
  */
 function siblingTestPath(filePath: string): string | null {
   const srcMatch = filePath.match(/^src\/(.+)\.(ts|tsx|js|jsx)$/);
   if (!srcMatch) return null;
+  const base = srcMatch[1] ?? "";
+  if (base.endsWith(".test") || base.endsWith(".spec")) return null;
   const ext = srcMatch[2] ?? "ts";
-  return `test/unit/${srcMatch[1]}.test.${ext}`;
+  return `test/unit/${base}.test.${ext}`;
 }
 
 /**

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -209,6 +209,43 @@ describe("CodeNeighborProvider", () => {
     expect(result.chunks).toHaveLength(0);
   });
 
+  test("sibling test path: .test.ts input does not hallucinate .test.test.ts (#526)", async () => {
+    setupDeps({
+      files: { "src/greeting.test.ts": "" },
+      globFiles: [],
+    });
+    const result = await provider.fetch(makeRequest({ touchedFiles: ["src/greeting.test.ts"] }));
+    const content = result.chunks[0]?.content ?? "";
+    // Must not produce the hallucinated .test.test.ts path
+    expect(content).not.toContain("greeting.test.test.ts");
+    expect(content).not.toContain(".test.test.");
+  });
+
+  test("sibling test path: .spec.ts input does not hallucinate .spec.spec.ts (#526)", async () => {
+    setupDeps({
+      files: { "src/greeting.spec.ts": "" },
+      globFiles: [],
+    });
+    const result = await provider.fetch(makeRequest({ touchedFiles: ["src/greeting.spec.ts"] }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).not.toContain("greeting.spec.spec.ts");
+    expect(content).not.toContain(".spec.spec.");
+  });
+
+  test("sibling test path: .test.tsx / .spec.tsx also guarded (#526)", async () => {
+    setupDeps({
+      files: {
+        "src/components/Button.test.tsx": "",
+        "src/components/Button.spec.jsx": "",
+      },
+      globFiles: [],
+    });
+    const r1 = await provider.fetch(makeRequest({ touchedFiles: ["src/components/Button.test.tsx"] }));
+    const r2 = await provider.fetch(makeRequest({ touchedFiles: ["src/components/Button.spec.jsx"] }));
+    expect(r1.chunks[0]?.content ?? "").not.toContain("Button.test.test.");
+    expect(r2.chunks[0]?.content ?? "").not.toContain("Button.spec.spec.");
+  });
+
   test(".tsx file sibling maps to .test.tsx not .test.ts", async () => {
     setupDeps({ files: { "src/components/Button.tsx": "" }, globFiles: [] });
     const result = await provider.fetch(makeRequest({ touchedFiles: ["src/components/Button.tsx"] }));


### PR DESCRIPTION
## Summary

Closes the Bug 1 portion of #526. Surfaced in v0.63.0-canary.1 dogfood run of \`nax-dogfood/fixtures/hello-lint\`.

## Reproduction

Prompt audit captured during the run:

\`\`\`
## Code Neighbors
### src/greeting.test.ts
- src/greeting.ts
- test/unit/greeting.test.test.ts   ← HALLUCINATED
\`\`\`

PRD contextFiles were \`[\"src/greeting.ts\", \"src/greeting.test.ts\"]\`. Both files become touchedFiles; the sibling-test derivation runs on each. When fed \`src/greeting.test.ts\`, \`siblingTestPath\` treats the \`.test\` as part of the base name and emits \`test/unit/greeting.test.test.ts\` — a path that cannot exist.

## Root cause

\`\`\`ts
// src/context/engine/providers/code-neighbor.ts
function siblingTestPath(filePath: string): string | null {
  const srcMatch = filePath.match(/^src\\/(.+)\\.(ts|tsx|js|jsx)$/);
  if (!srcMatch) return null;
  const ext = srcMatch[2] ?? \"ts\";
  return \`test/unit/\${srcMatch[1]}.test.\${ext}\`;
}
\`\`\`

For \`src/greeting.test.ts\` the regex captures \`greeting.test\` as the base. The function doesn't check whether the input is already a test file.

## Fix

Guard \`.test\` / \`.spec\` bases at the top of \`siblingTestPath\` and return null. Pure additive behaviour: non-test inputs continue to produce the same hint; test inputs no longer fabricate a double-suffixed path.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — 441 files, no issues
- [x] \`bun run test:unit\` — 6287 pass / 0 fail (+3 new tests)
- [x] New tests: \`.test.ts\`, \`.spec.ts\`, \`.test.tsx\` / \`.spec.jsx\` all rejected
- [x] Existing tests continue to pass (incl. \"includes sibling test even when src file does not exist\" — this PR does not change that documented behaviour for non-test inputs)
- [ ] Re-run hello-lint dogfood; prompt audit shows no \`.test.test.ts\` / \`.spec.spec.ts\` entries.

## Out of scope (tracked in #526)

**Bug 2** — hardcoded \`test/unit/\` layout assumption. For colocated-test projects (like the hello-lint fixture itself), \`src/greeting.ts\` emits a \`test/unit/greeting.test.ts\` hint that will never be right; the real test lives at \`src/greeting.test.ts\`. That fix is a layout-classification change that touches a documented behaviour and deserves its own PR. Not blocking this fix.

## Related

- Issue: #526
- Surfaced during v0.63.0-canary.1 dogfood (adjacent to #522 / #525)