### PR TITLE
Release v0.63.0-canary.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.63.0-canary.2",
+  "version": "0.63.0-canary.3",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What
Release v0.63.0-canary.3

## Why
Canary release.

## Testing
- [x] CI passes on main
