### PR TITLE
fix(context-engine): code-neighbor prefers colocated test when it exists on disk

### DIFF
--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -153,8 +153,27 @@ function resolveImport(specifier: string, fromFile: string, workdir: string): st
 }
 
 /**
- * Derive the sibling test file path for a source file.
- * Preserves the source extension for JSX/TSX files.
+ * Derive the colocated sibling test path for a source file.
+ * Returns the test file in the same directory as the source.
+ *   src/foo/bar.ts   → src/foo/bar.test.ts
+ *   src/foo/bar.tsx  → src/foo/bar.test.tsx
+ *   src/foo/bar.test.ts → null  (already a test file)
+ *
+ * Used by collectNeighbors to prefer colocated tests when they exist on disk,
+ * before falling back to the mirrored test/unit/ path. See #526 Bug 2.
+ */
+function colocalTestPath(filePath: string): string | null {
+  const match = filePath.match(/^(.+)\.(ts|tsx|js|jsx)$/);
+  if (!match) return null;
+  const base = match[1] ?? "";
+  if (base.endsWith(".test") || base.endsWith(".spec")) return null;
+  const ext = match[2] ?? "ts";
+  return `${base}.test.${ext}`;
+}
+
+/**
+ * Derive the mirrored sibling test file path for a source file.
+ * Maps src/ → test/unit/, preserving the source extension.
  *   src/foo/bar.ts       → test/unit/foo/bar.test.ts
  *   src/foo/bar.tsx      → test/unit/foo/bar.test.tsx
  *   src/foo/bar.test.ts  → null  (already a test file)
@@ -164,7 +183,7 @@ function resolveImport(specifier: string, fromFile: string, workdir: string): st
  * `.spec.spec.ts` hallucination that appeared when the provider was fed
  * a test file as a touched file (e.g. via PRD `contextFiles`). See #526.
  */
-function siblingTestPath(filePath: string): string | null {
+function mirroredTestPath(filePath: string): string | null {
   const srcMatch = filePath.match(/^src\/(.+)\.(ts|tsx|js|jsx)$/);
   if (!srcMatch) return null;
   const base = srcMatch[1] ?? "";
@@ -231,9 +250,16 @@ async function collectNeighbors(filePath: string, workdir: string, extraGlobWork
     }
   }
 
-  // Sibling test (JS/TS/JSX/TSX only)
-  const testPath = siblingTestPath(filePath);
-  if (testPath) neighbors.add(testPath);
+  // Sibling test (JS/TS/JSX/TSX only).
+  // Prefer colocated test (src/foo.test.ts) when it exists on disk (#526 Bug 2);
+  // fall back to the test/unit/ mirror hint for projects that use a separate test dir.
+  const colocal = colocalTestPath(filePath);
+  const mirrored = mirroredTestPath(filePath);
+  if (colocal && (await _codeNeighborDeps.fileExists(join(workdir, colocal)))) {
+    neighbors.add(colocal);
+  } else if (mirrored) {
+    neighbors.add(mirrored);
+  }
 
   return [...neighbors].slice(0, MAX_NEIGHBORS_PER_FILE);
 }

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -254,6 +254,47 @@ describe("CodeNeighborProvider", () => {
     expect(content).not.toContain("Button.test.ts\n");
   });
 
+  test("colocated test is preferred over test/unit/ mirror when it exists on disk (#526 Bug 2)", async () => {
+    // src/calc.test.ts exists on disk → use colocated path, not test/unit/calc.test.ts
+    setupDeps({
+      files: {
+        "src/calc.ts": "",
+        "src/calc.test.ts": "",
+      },
+      globFiles: [],
+    });
+    const result = await provider.fetch(makeRequest({ touchedFiles: ["src/calc.ts"] }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).toContain("src/calc.test.ts");
+    expect(content).not.toContain("test/unit/calc.test.ts");
+  });
+
+  test("falls back to test/unit/ mirror when no colocated test exists on disk (#526 Bug 2)", async () => {
+    // src/calc.test.ts does NOT exist → fall back to test/unit/calc.test.ts hint
+    setupDeps({
+      files: { "src/calc.ts": "" },
+      globFiles: [],
+    });
+    const result = await provider.fetch(makeRequest({ touchedFiles: ["src/calc.ts"] }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).toContain("test/unit/calc.test.ts");
+    expect(content).not.toContain("src/calc.test.ts");
+  });
+
+  test("colocated .tsx test preferred over test/unit/ mirror when it exists (#526 Bug 2)", async () => {
+    setupDeps({
+      files: {
+        "src/components/Button.tsx": "",
+        "src/components/Button.test.tsx": "",
+      },
+      globFiles: [],
+    });
+    const result = await provider.fetch(makeRequest({ touchedFiles: ["src/components/Button.tsx"] }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).toContain("src/components/Button.test.tsx");
+    expect(content).not.toContain("test/unit/components/Button.test.tsx");
+  });
+
   test("reverse-dep scan continues past self-reference (continue, not break)", async () => {
     // When the touched file appears in the glob results, the scan must continue
     // past it to find other reverse deps — a break would terminate early.


### PR DESCRIPTION
## Summary

- Fixes #526 Bug 2 — `siblingTestPath()` hardcoded `test/unit/` layout, injecting phantom paths for projects that colocate tests beside source files (`src/foo.test.ts`)
- Splits `siblingTestPath` into `colocalTestPath()` (same-dir) and `mirroredTestPath()` (test/unit/)
- `collectNeighbors` now does a `fileExists` check: prefers colocated when present, falls back to mirrored hint for separate-test-dir projects (existing behaviour preserved)
- Adds 3 tests: colocated preference, mirrored fallback, `.tsx` colocated

## Root cause

The original function returned `test/unit/<base>.test.<ext>` unconditionally. For the dogfood fixtures (`tdd-calc`, `fallback-probe`, `monorepo-tiny`) and many Bun-native projects that colocate tests, this injects a non-existent `test/unit/` path into the TDD agent's context — potentially directing test-writer to write tests in the wrong location.

## Behaviour after fix

| Scenario | Before | After |
|---|---|---|
| `src/calc.ts` + `src/calc.test.ts` exists | `test/unit/calc.test.ts` (phantom) | `src/calc.test.ts` (real) |
| `src/calc.ts`, no colocated test | `test/unit/calc.test.ts` | `test/unit/calc.test.ts` (unchanged) |
| `src/calc.test.ts` (input is test file) | `test/unit/calc.test.test.ts` (Bug 1, fixed in #527) | `null` (unchanged) |

## Test plan

- [x] 38/38 unit tests pass (`bun test test/unit/context/engine/providers/code-neighbor.test.ts`)
- [ ] Re-run `nax-dogfood/fixtures/tdd-calc` — verify prompt audit shows `src/calc.test.ts`, not `test/unit/calc.test.ts`
- [ ] Re-run `nax-dogfood/fixtures/hello-lint` — prompt audit shows `src/greeting.test.ts`, not `test/unit/greeting.test.ts`

## References

- Bug filed: #526
- Bug 1 fixed in: #527 (`.test.test.ts` hallucination)
- Dogfood fixtures affected: `tdd-calc`, `fallback-probe`, `monorepo-tiny`