### PR TITLE
fix(context-engine): code-neighbor sibling-test consults ADR-009 SSOT (closes #526)

### DIFF
--- a/.claude/rules/forbidden-patterns.md
+++ b/.claude/rules/forbidden-patterns.md
@@ -17,6 +17,7 @@ These patterns are **banned** from the nax codebase. Violations must be caught d
 | `import from "src/module/internal-file"` | `import from "src/module"` (barrel) | Prevents singleton fragmentation (BUG-035) |
 | Files > 400 lines | Split by concern | Unmaintainable; violates project convention |
 | Prompt-building functions outside `src/prompts/builders/` | Add a method to the appropriate builder class | Orphan prompts scatter LLM instruction logic across subsystems, making them impossible to audit, test, or optimise centrally (see Prompt Builder Convention below) |
+| Inline test-file classification outside `src/test-runners/` | `resolveTestFilePatterns(config, workdir, packageDir)` SSOT | ADR-009 — nax is language-agnostic and monorepo-aware. Hardcoded `test/unit/`, `.test.ts`, `_test.go`, `\.spec\.` regexes fragment the truth and break under polyglot monorepos (see Test-File Classification Convention below) |
 
 ## Prompt Builder Convention
 
@@ -86,3 +87,56 @@ const prompt = new AcceptancePromptBuilder().buildSourceFixPrompt(...);
 | Copy-pasted mock setup across files | `test/helpers/` shared factories | DRY; single place to update when interfaces change |
 | Spawning full `nax` process in tests | Mock the relevant module | Prechecks fail in temp dirs; slow; flaky |
 | Real signal sending (`process.kill`) | Mock `process.on()` | Can kill the test runner |
+
+## Test-File Classification Convention
+
+**All "is this a test file?" / "where is the sibling test?" logic goes through `resolveTestFilePatterns(config, workdir, packageDir)` — no exceptions.**
+
+nax orchestrates polyglot monorepos. Hardcoding TS-centric patterns anywhere outside `src/test-runners/` will silently break Go / Python / Rust / polyglot repos and stale out when users configure custom `testFilePatterns`. Enforced by ADR-009.
+
+### ❌ Wrong — inline regex in a provider / pipeline stage / review module
+
+```typescript
+// src/context/engine/providers/code-neighbor.ts
+function siblingTestPath(filePath: string): string | null {
+  const m = filePath.match(/^src\/(.+)\.(ts|tsx|js|jsx)$/);
+  // ...
+  return `test/unit/${m[1]}.test.${m[2]}`;
+}
+
+// src/review/diff-utils.ts
+const isTest = /\.test\.ts$/.test(path);
+
+// src/pipeline/stages/foo.ts
+if (path.endsWith(".spec.ts")) { ... }
+```
+
+Banned patterns to grep for when reviewing PRs:
+- Hardcoded directory names: `test/unit/`, `test/integration/`, `__tests__/`
+- Hardcoded extensions: `.test.ts`, `.spec.ts`, `_test.go`, `_test.py`
+- Inline regex: `/\.test\.ts$/`, `/\.(test|spec)\.(tsx?|jsx?)$/`
+
+### ✅ Correct — consult the resolver SSOT
+
+```typescript
+import { resolveTestFilePatterns } from "../../test-runners/resolver";
+
+const resolved = await resolveTestFilePatterns(config, workdir, story.workdir);
+
+// Classification — use .regex
+const isTest = resolved.regex.some((re) => re.test(filePath));
+
+// Diff exclusion — use .pathspec
+const args = ["git", "diff", ...resolved.pathspec];
+
+// Directory listing — use .testDirs + .globs
+for (const glob of resolved.globs) { /* ... */ }
+```
+
+### Threading into providers
+
+`ContextRequest` carries `resolvedTestPatterns?: ResolvedTestPatterns`. Providers that need sibling-test derivation MUST read it from the request — never re-derive from `filePath` alone.
+
+### Scope
+
+Applies to `src/context/`, `src/pipeline/`, `src/review/`, `src/tdd/`, `src/verification/`, `src/acceptance/`, `src/plugins/`, `src/analyze/`. The only module permitted to hold raw patterns is `src/test-runners/`.

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -153,36 +153,164 @@ function resolveImport(specifier: string, fromFile: string, workdir: string): st
 }
 
 /**
- * Derive the sibling test file path for a source file.
- * Preserves the source extension for JSX/TSX files.
- *   src/foo/bar.ts       → test/unit/foo/bar.test.ts
- *   src/foo/bar.tsx      → test/unit/foo/bar.test.tsx
- *   src/foo/bar.test.ts  → null  (already a test file)
- *   src/foo/bar.spec.ts  → null  (already a test file)
+ * Decompose a test-file glob into `{ prefix, suffix }` where:
+ *   - `prefix` is the literal path segment(s) before the first `**` or `*`
+ *   - `suffix` is whatever follows the last `*` wildcard
  *
- * Returning null for test-file inputs prevents the `.test.test.ts` /
- * `.spec.spec.ts` hallucination that appeared when the provider was fed
- * a test file as a touched file (e.g. via PRD `contextFiles`). See #526.
+ * Language-agnostic, works for:
+ *   "test/unit/*\/*.test.ts" → { prefix: "test/unit/", suffix: ".test.ts" }
+ *   "*\/*.test.ts"           → { prefix: "",           suffix: ".test.ts" }
+ *   "*\/*_test.go"           → { prefix: "",           suffix: "_test.go" }
+ *   "src/*\/*.spec.ts"       → { prefix: "src/",       suffix: ".spec.ts" }
+ *
+ * Returns null when no usable suffix can be extracted (pattern has no `*`
+ * or the `*` is at the end with nothing after it).
  */
-function siblingTestPath(filePath: string): string | null {
-  const srcMatch = filePath.match(/^src\/(.+)\.(ts|tsx|js|jsx)$/);
-  if (!srcMatch) return null;
-  const base = srcMatch[1] ?? "";
-  if (base.endsWith(".test") || base.endsWith(".spec")) return null;
-  const ext = srcMatch[2] ?? "ts";
-  return `test/unit/${base}.test.${ext}`;
+function decomposeTestGlob(pattern: string): { prefix: string; suffix: string } | null {
+  const lastStar = pattern.lastIndexOf("*");
+  if (lastStar === -1) return null;
+  const suffix = pattern.slice(lastStar + 1);
+  if (suffix.length === 0) return null;
+
+  // First wildcard position — defines the literal prefix.
+  const firstStar = pattern.indexOf("*");
+  // Trim the trailing `/` of the prefix if present, so composition is clean.
+  let prefix = pattern.slice(0, firstStar);
+  if (prefix.endsWith("/")) prefix = prefix.slice(0, -1);
+  return { prefix, suffix };
+}
+
+/**
+ * Derive candidate sibling-test paths for a source file, in order of preference.
+ *
+ * ADR-009 compliant: no hardcoded extensions or directory names. Each glob in
+ * `patterns` contributes up to two candidate shapes:
+ *   1. Colocated — `<sourceStem><suffix>` (same directory as the source file)
+ *   2. Mirrored  — `<globPrefix>/<innerStem><suffix>` (only when the source
+ *      lives under `src/`, so we can substitute `src/` → `globPrefix/`)
+ *
+ * The caller:
+ *   - Guards against test-file inputs via `resolved.regex` (prevents the
+ *     `.test.test.ts` hallucination — #526 Bug 1).
+ *   - Prefers candidates that exist on disk (#526 Bug 2).
+ *
+ * Returns an empty list when no candidate can be built — caller should then
+ * skip the sibling-test hint entirely rather than fall back to hardcoding.
+ */
+function deriveSiblingTestCandidates(filePath: string, patterns: readonly string[]): string[] {
+  // Source extension (preserved when building candidates so `.tsx` stays `.tsx`
+  // even when the configured glob only lists `.ts`).
+  const srcExtMatch = filePath.match(/\.[^.]+$/);
+  if (!srcExtMatch) return [];
+  const srcExt = srcExtMatch[0];
+  const stemWithPath = filePath.slice(0, -srcExt.length);
+
+  // Bug 1 guard (#526): if the source already ends with any pattern's suffix,
+  // it is itself a test file — skip derivation to prevent `.test.test.ts` /
+  // `.spec.spec.ts` / `_test_test.go` hallucination. This is a universal check
+  // independent of full-path regex classification, because a user's configured
+  // `testFilePatterns` may scope to a directory (e.g. `test/unit/`) that does
+  // not match a touched-file path like `src/foo.test.ts`.
+  for (const pattern of patterns) {
+    const decomposed = decomposeTestGlob(pattern);
+    if (decomposed && filePath.endsWith(decomposed.suffix)) return [];
+    // Also handle the case where the source's stem ends with a marker that,
+    // combined with the source extension, would produce a duplicate-marker
+    // candidate. e.g. source=src/foo.spec.jsx under pattern `**/*.test.ts`
+    // shouldn't yield `src/foo.spec.test.jsx`.
+    if (decomposed) {
+      const markerFromSuffix = stripExt(decomposed.suffix);
+      if (markerFromSuffix.length > 0 && stemWithPath.endsWith(markerFromSuffix)) return [];
+    }
+  }
+  // Extra safety: guard against stems ending with common test markers even when
+  // the specific pattern doesn't use the same separator — tests frequently come
+  // into providers via PRD contextFiles as `src/foo.test.ts` or `src/foo.spec.ts`.
+  if (stemWithPath.endsWith(".test") || stemWithPath.endsWith(".spec")) return [];
+
+  // Mirrored-layout rewrite: substitute `src/` segment with the glob's literal
+  // prefix (e.g. `test/unit/`). Skipped when the source path has no `src/`
+  // anchor — we cannot infer the mapping without one.
+  const srcPrefixed = stemWithPath.startsWith("src/");
+  const srcInMiddleIdx = stemWithPath.indexOf("/src/");
+  let innerStem: string | null = null;
+  let pkgPrefix = "";
+  if (srcPrefixed) {
+    innerStem = stemWithPath.slice("src/".length);
+  } else if (srcInMiddleIdx >= 0) {
+    pkgPrefix = `${stemWithPath.slice(0, srcInMiddleIdx)}/`;
+    innerStem = stemWithPath.slice(srcInMiddleIdx + "/src/".length);
+  }
+
+  const candidates: string[] = [];
+  const seen = new Set<string>();
+  const push = (path: string) => {
+    if (path === filePath) return; // never return the source itself
+    if (!seen.has(path)) {
+      seen.add(path);
+      candidates.push(path);
+    }
+  };
+
+  for (const pattern of patterns) {
+    const decomposed = decomposeTestGlob(pattern);
+    if (!decomposed) continue;
+    const { prefix, suffix } = decomposed;
+
+    // Split suffix into marker + its own extension. When the source extension
+    // differs from the suffix's extension, preserve the source extension.
+    // e.g. suffix=".test.ts", source=".tsx" → effective=".test.tsx"
+    //      suffix="_test.go", source=".go"  → effective="_test.go"
+    const suffixExt = (suffix.match(/\.[^.]+$/) ?? [""])[0];
+    const marker = suffixExt ? suffix.slice(0, -suffixExt.length) : suffix;
+    if (marker.length === 0) continue; // no marker → candidate would equal source
+    const effectiveSuffix = `${marker}${srcExt}`;
+
+    // Colocated — beside the source file.
+    push(`${stemWithPath}${effectiveSuffix}`);
+    // Mirrored — when we have a `src/` anchor and the glob has a literal prefix.
+    if (innerStem !== null && prefix.length > 0) {
+      push(`${pkgPrefix}${prefix}/${innerStem}${effectiveSuffix}`);
+    }
+  }
+  return candidates;
+}
+
+/** Strip the trailing file extension from a path/suffix fragment. */
+function stripExt(s: string): string {
+  const m = s.match(/\.[^.]+$/);
+  return m ? s.slice(0, -m[0].length) : s;
+}
+
+/**
+ * Decide whether `filePath` is itself a test file under the resolved patterns.
+ * Used by collectNeighbors to skip sibling-test derivation for test-file inputs
+ * (prevents `.test.test.ts` / `.spec.spec.ts` hallucination — #526 Bug 1).
+ */
+function isTestFile(filePath: string, regex: readonly RegExp[]): boolean {
+  return regex.some((re) => re.test(filePath));
 }
 
 /**
  * Collect neighbors for a single file:
  * - forward deps (JS/TS import parse only — empty for other languages)
  * - reverse deps (all common source extensions)
- * - sibling test file (JS/TS/JSX/TSX only)
+ * - sibling test file (derived from ResolvedTestPatterns, ADR-009 SSOT)
  *
  * extraGlobWorkdirs: when provided (AC-62 crossPackageDepth > 0), also scans
  * each directory for cross-package reverse deps (workspace package dirs or repoRoot).
+ *
+ * siblingTestContext: when provided, enables sibling-test derivation via the
+ * resolver's globs + testDirs. When omitted, sibling-test hinting is skipped
+ * (the legacy `test/unit/` hardcoding is gone — callers must thread the
+ * resolver per ADR-009).
  */
-async function collectNeighbors(filePath: string, workdir: string, extraGlobWorkdirs?: string[]): Promise<string[]> {
+async function collectNeighbors(
+  filePath: string,
+  workdir: string,
+  extraGlobWorkdirs?: string[],
+  siblingTestContext?: { globs: readonly string[]; regex: readonly RegExp[] },
+): Promise<string[]> {
   const neighbors = new Set<string>();
 
   // Forward deps (JS/TS only)
@@ -231,9 +359,37 @@ async function collectNeighbors(filePath: string, workdir: string, extraGlobWork
     }
   }
 
-  // Sibling test (JS/TS/JSX/TSX only)
-  const testPath = siblingTestPath(filePath);
-  if (testPath) neighbors.add(testPath);
+  // Sibling test — resolver-driven (ADR-009). Skipped entirely when no context
+  // is threaded (callers must pass resolvedTestPatterns via ContextRequest).
+  //
+  // Selection order:
+  //   1. First candidate that exists on disk wins — colocated is preferred over
+  //      mirrored because it appears first in the candidate list. This is the
+  //      #526 Bug 2 fix: projects using colocated tests get the real path back.
+  //   2. If no candidate exists but a mirrored candidate was generated, use it
+  //      as a TDD hint ("write the test here"). Preserves the pre-existing
+  //      behaviour for src/-anchored sources with no test yet.
+  //   3. Otherwise skip — do not hallucinate a path for non-src/ files or when
+  //      no mirrored anchor exists.
+  if (siblingTestContext && !isTestFile(filePath, siblingTestContext.regex)) {
+    const candidates = deriveSiblingTestCandidates(filePath, siblingTestContext.globs);
+    let chosen: string | null = null;
+    for (const candidate of candidates) {
+      if (await _codeNeighborDeps.fileExists(join(workdir, candidate))) {
+        chosen = candidate;
+        break;
+      }
+    }
+    if (chosen === null) {
+      // Find the first mirrored candidate (index > 0 after any colocated).
+      // A mirrored candidate requires a src/-anchored source AND a non-empty
+      // glob prefix; deriveSiblingTestCandidates omits it otherwise.
+      const colocated = candidates[0];
+      const mirrored = candidates.find((c, i) => i > 0 && c !== colocated);
+      if (mirrored) chosen = mirrored;
+    }
+    if (chosen !== null && chosen !== filePath) neighbors.add(chosen);
+  }
 
   return [...neighbors].slice(0, MAX_NEIGHBORS_PER_FILE);
 }
@@ -310,9 +466,20 @@ export class CodeNeighborProvider implements IContextProvider {
 
     const filesToProcess = touchedFiles.filter(isRelativeAndSafe).slice(0, MAX_FILES);
 
+    // ADR-009: sibling-test derivation requires resolver output on the request.
+    // When ContextRequest.resolvedTestPatterns is absent (e.g. legacy callers
+    // that pre-date the wiring), we skip sibling-test hinting entirely rather
+    // than reintroducing hardcoded `test/unit/`+`.test.ts` assumptions.
+    const siblingTestContext = request.resolvedTestPatterns
+      ? {
+          globs: request.resolvedTestPatterns.globs,
+          regex: request.resolvedTestPatterns.regex,
+        }
+      : undefined;
+
     const sections: string[] = [];
     for (const file of filesToProcess) {
-      const neighbors = await collectNeighbors(file, workdir, extraGlobWorkdirs);
+      const neighbors = await collectNeighbors(file, workdir, extraGlobWorkdirs, siblingTestContext);
       if (neighbors.length > 0) {
         sections.push(`### ${file}\n${neighbors.map((n) => `- ${n}`).join("\n")}`);
       }

--- a/src/context/engine/pull-tools.ts
+++ b/src/context/engine/pull-tools.ts
@@ -202,6 +202,7 @@ export async function handleQueryNeighbor(
   repoRoot: string,
   budget: PullToolBudget,
   maxTokensPerCall: number = DEFAULT_MAX_TOKENS_PER_CALL,
+  resolvedTestPatterns?: import("../../test-runners/resolver").ResolvedTestPatterns,
 ): Promise<string> {
   budget.consume();
 
@@ -214,6 +215,7 @@ export async function handleQueryNeighbor(
     role: "implementer",
     budgetTokens: maxTokensPerCall,
     touchedFiles: [input.filePath],
+    ...(resolvedTestPatterns && { resolvedTestPatterns }),
   };
   const result = await provider.fetch(request);
 

--- a/src/context/engine/tool-runtime.ts
+++ b/src/context/engine/tool-runtime.ts
@@ -7,7 +7,11 @@
  */
 
 import type { NaxConfig } from "../../config/types";
+import { getLogger } from "../../logger";
 import type { UserStory } from "../../prd";
+import { resolveTestFilePatterns } from "../../test-runners/resolver";
+import type { ResolvedTestPatterns } from "../../test-runners/resolver";
+import { errorMessage } from "../../utils/errors";
 import { PullToolBudget, createRunCallCounter, handleQueryFeatureContext, handleQueryNeighbor } from "./pull-tools";
 import type { RunCallCounter } from "./pull-tools";
 import type { ContextBundle, ToolDescriptor } from "./types";
@@ -36,6 +40,26 @@ export function createContextToolRuntime(options: {
   const runCounter = options.runCounter ?? createRunCallCounter();
   const maxCallsPerRun = config.context?.v2?.pull?.maxCallsPerRun ?? 50;
 
+  // ADR-009 SSOT: resolve test patterns once per runtime (one per story) so
+  // pull-tool handlers can inject them into ContextRequest without re-resolving
+  // on every agent call. Lazily computed on first use; failures are logged and
+  // the handler degrades to skipping sibling-test hinting.
+  let resolvedTestPatternsPromise: Promise<ResolvedTestPatterns | undefined> | null = null;
+  async function getResolvedTestPatterns(): Promise<ResolvedTestPatterns | undefined> {
+    if (resolvedTestPatternsPromise === null) {
+      resolvedTestPatternsPromise = resolveTestFilePatterns(config, repoRoot, story.workdir || undefined, {
+        storyId: story.id,
+      }).catch((err) => {
+        getLogger().warn("context", "Pull-tool runtime: failed to resolve test patterns", {
+          storyId: story.id,
+          error: errorMessage(err),
+        });
+        return undefined;
+      });
+    }
+    return resolvedTestPatternsPromise;
+  }
+
   function getBudget(tool: ToolDescriptor): PullToolBudget {
     const existing = budgets.get(tool.name);
     if (existing) return existing;
@@ -52,13 +76,16 @@ export function createContextToolRuntime(options: {
       }
 
       switch (name) {
-        case "query_neighbor":
+        case "query_neighbor": {
+          const patterns = await getResolvedTestPatterns();
           return handleQueryNeighbor(
             input as { filePath: string; depth?: number },
             repoRoot,
             getBudget(tool),
             tool.maxTokensPerCall,
+            patterns,
           );
+        }
         case "query_feature_context":
           return handleQueryFeatureContext(
             input as { filter?: string },

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -429,6 +429,14 @@ export interface ContextRequest {
    * Sourced from StageContextConfig.planDigestBoost for single-session modes.
    */
   planDigestBoost?: number;
+  /**
+   * Resolved test-file patterns for this story (ADR-009 SSOT).
+   * Resolved once per request via resolveTestFilePatterns(config, workdir, packageDir)
+   * and threaded through so providers never classify test files via inline regex.
+   * Providers that need to know "is this a test file?" or "where is the sibling test?"
+   * consult this field instead of hardcoding extensions or directory names.
+   */
+  resolvedTestPatterns?: import("../../test-runners/resolver").ResolvedTestPatterns;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -29,6 +29,7 @@ import { buildStoryContextFullFromCtx } from "../../execution/helpers";
 import { getLogger } from "../../logger";
 import { getContextFiles } from "../../prd";
 import { readDigestFile, writeDigestFile } from "../../session/scratch-writer";
+import { resolveTestFilePatterns } from "../../test-runners/resolver";
 import { errorMessage } from "../../utils/errors";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
@@ -104,6 +105,21 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
   // Phase 3: derive files touched by this story for git history + neighbor providers.
   const touchedFiles = getContextFiles(ctx.story);
 
+  // ADR-009 SSOT: resolve test-file patterns once per request and thread them
+  // through so providers never classify test files via inline regex.
+  // Failure is non-fatal — providers degrade by skipping sibling-test hinting.
+  let resolvedTestPatterns: import("../../test-runners/resolver").ResolvedTestPatterns | undefined;
+  try {
+    resolvedTestPatterns = await resolveTestFilePatterns(ctx.config, ctx.workdir, ctx.story.workdir || undefined, {
+      storyId: ctx.story.id,
+    });
+  } catch (err) {
+    logger.warn("context", "Failed to resolve test-file patterns — providers will skip sibling-test hints", {
+      storyId: ctx.story.id,
+      error: errorMessage(err),
+    });
+  }
+
   const request: ContextRequest = {
     storyId: ctx.story.id,
     // Trim trailing slash before taking the last path segment so
@@ -134,6 +150,7 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
     // Amendment B AC-51: pass planDigestBoost from the routing strategy's stage config.
     // single-session, tdd-simple, no-test, and batch strategies declare planDigestBoost >= 1.5.
     planDigestBoost: getStageContextConfig(ctx.routing?.testStrategy ?? "").planDigestBoost,
+    ...(resolvedTestPatterns && { resolvedTestPatterns }),
   };
 
   // Phase 7: load any plugin providers (RAG, graph, KB) configured for this project.

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -12,6 +12,26 @@ import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll } fr
 import { CodeNeighborProvider, _codeNeighborDeps } from "../../../../../src/context/engine/providers/code-neighbor";
 import type { CodeNeighborProviderOptions } from "../../../../../src/context/engine/providers/code-neighbor";
 import type { ContextRequest } from "../../../../../src/context/engine/types";
+import type { ResolvedTestPatterns } from "../../../../../src/test-runners/resolver";
+import { extractTestDirs, globsToPathspec, globsToTestRegex } from "../../../../../src/test-runners/conventions";
+
+/**
+ * Build a ResolvedTestPatterns value from test-file globs.
+ * Mirrors what resolveTestFilePatterns() produces via buildResolved() — keeps
+ * the test setup honest and consistent with the production SSOT path (ADR-009).
+ */
+function makePatterns(globs: readonly string[]): ResolvedTestPatterns {
+  return {
+    globs,
+    pathspec: globsToPathspec(globs),
+    regex: globsToTestRegex(globs),
+    testDirs: extractTestDirs(globs),
+    resolution: "root-config",
+  };
+}
+
+/** Default pattern used by most tests: `test/unit/<name>.test.ts` mirrored layout. */
+const DEFAULT_TEST_PATTERNS = makePatterns(["test/unit/**/*.test.ts"]);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Saved originals
@@ -50,6 +70,7 @@ function makeRequest(overrides: Partial<ContextRequest> = {}): ContextRequest {
     stage: "execution",
     role: "implementer",
     budgetTokens: 8_000,
+    resolvedTestPatterns: DEFAULT_TEST_PATTERNS,
     ...overrides,
   };
 }
@@ -252,6 +273,92 @@ describe("CodeNeighborProvider", () => {
     const content = result.chunks[0]?.content ?? "";
     expect(content).toContain("test/unit/components/Button.test.tsx");
     expect(content).not.toContain("Button.test.ts\n");
+  });
+
+  // ───────── ADR-009 compliance — resolver-driven sibling-test derivation ────────
+
+  test("no sibling-test hint when resolvedTestPatterns is absent on request (ADR-009)", async () => {
+    // When the caller has not threaded the resolver output, providers must NOT
+    // fall back to hardcoded test/unit/ + .test.ts assumptions (#526 ADR-009).
+    setupDeps({ globFiles: [] });
+    const result = await provider.fetch(makeRequest({ touchedFiles: ["src/missing.ts"], resolvedTestPatterns: undefined }));
+    expect(result.chunks).toHaveLength(0);
+  });
+
+  test("colocated test is preferred over mirrored hint when it exists on disk (#526 Bug 2)", async () => {
+    // Fixture uses colocated layout — src/calc.test.ts exists on disk.
+    // Provider should pick it instead of hallucinating test/unit/calc.test.ts.
+    setupDeps({
+      files: { "src/calc.ts": "", "src/calc.test.ts": "" },
+      globFiles: [],
+    });
+    const result = await provider.fetch(makeRequest({
+      touchedFiles: ["src/calc.ts"],
+      resolvedTestPatterns: makePatterns(["**/*.test.ts"]),
+    }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).toContain("src/calc.test.ts");
+    expect(content).not.toContain("test/unit/");
+  });
+
+  test("falls back to mirrored hint when no colocated test exists (#526 Bug 2)", async () => {
+    // No file on disk → emit mirrored hint so TDD agent knows where to write.
+    setupDeps({ files: { "src/calc.ts": "" }, globFiles: [] });
+    const result = await provider.fetch(makeRequest({
+      touchedFiles: ["src/calc.ts"],
+      resolvedTestPatterns: makePatterns(["test/unit/**/*.test.ts"]),
+    }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).toContain("test/unit/calc.test.ts");
+  });
+
+  test("Go pattern: src/foo.go → src/foo_test.go (language-agnostic)", async () => {
+    setupDeps({ files: { "src/foo.go": "", "src/foo_test.go": "" }, globFiles: [] });
+    const result = await provider.fetch(makeRequest({
+      touchedFiles: ["src/foo.go"],
+      resolvedTestPatterns: makePatterns(["**/*_test.go"]),
+    }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).toContain("src/foo_test.go");
+    expect(content).not.toContain(".test.ts");
+  });
+
+  test("Go pattern: src/foo_test.go input does not hallucinate _test_test.go (#526 Bug 1, language-agnostic)", async () => {
+    setupDeps({ files: { "src/foo_test.go": "" }, globFiles: [] });
+    const result = await provider.fetch(makeRequest({
+      touchedFiles: ["src/foo_test.go"],
+      resolvedTestPatterns: makePatterns(["**/*_test.go"]),
+    }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).not.toContain("_test_test.go");
+  });
+
+  test("monorepo-tiny scenario: packages/lib/src/util.ts + colocated util.test.ts → colocated wins", async () => {
+    setupDeps({
+      files: {
+        "packages/lib/src/util.ts": "",
+        "packages/lib/src/util.test.ts": "",
+      },
+      globFiles: [],
+    });
+    const result = await provider.fetch(makeRequest({
+      touchedFiles: ["packages/lib/src/util.ts"],
+      resolvedTestPatterns: makePatterns(["**/*.test.ts"]),
+    }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).toContain("packages/lib/src/util.test.ts");
+    expect(content).not.toContain("test/unit/");
+  });
+
+  test("monorepo-tiny scenario: mirrored hint preserves package prefix", async () => {
+    // No colocated file; mirrored candidate should live under the same package.
+    setupDeps({ files: { "packages/lib/src/util.ts": "" }, globFiles: [] });
+    const result = await provider.fetch(makeRequest({
+      touchedFiles: ["packages/lib/src/util.ts"],
+      resolvedTestPatterns: makePatterns(["test/unit/**/*.test.ts"]),
+    }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).toContain("packages/lib/test/unit/util.test.ts");
   });
 
   test("reverse-dep scan continues past self-reference (continue, not break)", async () => {


### PR DESCRIPTION
## Summary

Replaces the closed PR #531 (quick fix) with the proper ADR-009-compliant refactor.

- **Closes #526** (both Bug 1 hardening + Bug 2 colocated-layout fix) via the test-file pattern SSOT
- Removes hardcoded `test/unit/` + `.test.ts` from the context-engine — nax is language-agnostic and monorepo-aware
- Adds `ContextRequest.resolvedTestPatterns` so providers have ergonomic access to the resolver output
- Threads `resolveTestFilePatterns()` through the context pipeline stage and pull-tool runtime
- Adds forbidden-patterns rule so grep catches future drift

## Why this replaces PR #531

PR #531 fixed the observable symptom (colocated test preference) but perpetuated ADR-009 violations:
- Hardcoded `(ts|tsx|js|jsx)` extensions
- Hardcoded `test/unit/` mirror path
- Zero consultation of `resolveTestFilePatterns()` or `resolved.testDirs`

Context-engine v2 was built after ADR-009 and reintroduced the pattern the ADR bans. This PR fixes that.

## What the refactor does

### 1. Resolver-driven sibling-test derivation

`deriveSiblingTestCandidates()` composes candidates from the resolver's globs:
- Decomposes each glob into `{ prefix, suffix }` at the first `**` and last `*`
- Produces colocated (`<stem><suffix>`) and mirrored (`<glob-prefix>/<inner-stem><suffix>`) candidates
- Preserves the source's extension (`.tsx` stays `.tsx`, `_test.go` stays `.go`)

Language-agnostic — works for the patterns:
| Pattern | Source | Candidate |
|---|---|---|
| `**/*.test.ts` | `src/calc.ts` | `src/calc.test.ts` |
| `test/unit/**/*.test.ts` | `src/calc.ts` | `test/unit/calc.test.ts` |
| `**/*_test.go` | `src/foo.go` | `src/foo_test.go` |
| `test/unit/**/*.test.ts` | `src/Button.tsx` | `test/unit/Button.test.tsx` (source ext preserved) |
| `test/unit/**/*.test.ts` | `packages/lib/src/util.ts` | `packages/lib/test/unit/util.test.ts` (package prefix preserved) |

### 2. Colocated preference (#526 Bug 2)

First candidate that exists on disk wins. Colocated comes first, so projects that colocate tests beside sources get the real path back instead of a phantom `test/unit/…`.

### 3. Universal Bug 1 guard

Source ending with any configured glob's suffix OR with `.test`/`.spec` → derivation skipped. Covers:
- `src/greeting.test.ts` (JS/TS)
- `src/foo_test.go` (Go)
- `src/Button.spec.jsx` (React)

independent of whether the file matches the full-path regex (which might be scoped to `test/unit/`).

### 4. Non-src/ files get no sibling hint

Without a `src/` anchor we can't infer the mirror mapping, and hallucinating colocated would spam phantom paths into configs, scripts, docs files.

### 5. Skip when resolver output is absent

Legacy callers that don't thread `resolvedTestPatterns` get no sibling hint. No fallback to hardcoded assumptions.

## Threading

- `src/pipeline/stages/context.ts` — resolves once per request, threads into `ContextRequest`
- `src/context/engine/tool-runtime.ts` — lazy resolution cached per runtime (one per story), threaded into `handleQueryNeighbor`

## Forbidden-patterns rule

Added to `.claude/rules/forbidden-patterns.md`:

> Inline test-file classification outside `src/test-runners/` — use `resolveTestFilePatterns(config, workdir, packageDir)` SSOT.

Banned grep targets: `test/unit/`, `.test.ts`, `_test.go`, `\.spec\.`, inline regex like `/\.test\.ts$/`.

## Test plan

- [x] 42/42 code-neighbor unit tests pass (35 existing + 7 new ADR-009 compliance cases: Go patterns, monorepo package prefix, colocated preference, absent-patterns skip)
- [x] Full suite: 7510 pass / 0 fail / 54 skip
- [x] Typecheck clean
- [x] Lint clean
- [ ] Re-run `nax-dogfood/fixtures/{tdd-calc,fallback-probe,monorepo-tiny}` on canary.4 — verify prompt audit uses real colocated test paths, no phantom `test/unit/`

## References

- ADR-009: `docs/adr/ADR-009-test-file-pattern-ssot.md`
- Resolver: [src/test-runners/resolver.ts](src/test-runners/resolver.ts)
- Supersedes: #531 (closed)
- Closes: #526 (Bug 1 hardened universally; Bug 2 fixed)