### PR TITLE
fix(context): filter .nax/ bookkeeping paths from Session History

### DIFF
--- a/src/context/engine/providers/session-scratch.ts
+++ b/src/context/engine/providers/session-scratch.ts
@@ -18,6 +18,7 @@
 import { createHash } from "node:crypto";
 import type { ScratchEntry } from "../../../session/scratch-writer";
 import { scratchFilePath } from "../../../session/scratch-writer";
+import { filterNaxInternalPaths } from "../../../utils/path-filters";
 import { neutralizeForAgent } from "../scratch-neutralizer";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
@@ -84,7 +85,9 @@ function renderEntry(entry: ScratchEntry, targetAgentId?: string): string {
     case "rectify-attempt":
       return `**Rectify** attempt ${entry.attempt} at ${entry.timestamp}: ${entry.succeeded ? "succeeded" : "failed"}`;
     case "tdd-session": {
-      const changed = entry.filesChanged.length > 0 ? ` — changed: ${entry.filesChanged.join(", ")}` : "";
+      // #542: drop .nax/ bookkeeping noise so the prompt only surfaces real code changes.
+      const userChanged = filterNaxInternalPaths(entry.filesChanged);
+      const changed = userChanged.length > 0 ? ` — changed: ${userChanged.join(", ")}` : "";
       const lines = [
         `**TDD ${entry.role}** at ${entry.timestamp}: ${entry.success ? "succeeded" : "failed"}${changed}`,
       ];

--- a/src/utils/path-filters.ts
+++ b/src/utils/path-filters.ts
@@ -1,0 +1,36 @@
+/**
+ * Path filters for nax-internal bookkeeping files.
+ *
+ * When surfacing "changed files" lists to LLM prompts (e.g. Session History in
+ * SessionScratchProvider), nax-internal files (.nax/, nax.lock) are pure noise
+ * that wastes tokens and adds no signal for the agent. This module provides the
+ * single source of truth for which paths should be excluded from those views.
+ *
+ * See: #542
+ */
+
+/**
+ * Return true when the given repo-relative path is a nax-internal bookkeeping
+ * file and should be excluded from LLM-facing "changed files" listings.
+ *
+ * Matches:
+ *   - `.nax/...`                          — repo-root nax dir
+ *   - `any/prefix/.nax/...`               — per-package nax dir
+ *   - `nax.lock`                          — root lock
+ *   - `any/prefix/nax.lock`               — per-package lock
+ */
+export function isNaxInternalPath(path: string): boolean {
+  if (path.startsWith(".nax/") || path.startsWith("./.nax/")) return true;
+  if (path === "nax.lock" || path === "./nax.lock") return true;
+  if (path.includes("/.nax/")) return true;
+  if (path.endsWith("/nax.lock")) return true;
+  return false;
+}
+
+/**
+ * Filter a list of changed files, removing nax-internal bookkeeping entries.
+ * Preserves order and does not mutate the input array.
+ */
+export function filterNaxInternalPaths(paths: readonly string[]): string[] {
+  return paths.filter((p) => !isNaxInternalPath(p));
+}

--- a/test/unit/utils/path-filters.test.ts
+++ b/test/unit/utils/path-filters.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { filterNaxInternalPaths, isNaxInternalPath } from "../../../src/utils/path-filters";
+
+describe("path-filters (#542)", () => {
+  describe("isNaxInternalPath", () => {
+    test.each([
+      [".nax/cache/test-patterns.json", true],
+      [".nax/features/foo/prd.json", true],
+      [".nax/features/foo/sessions/sess-x/descriptor.json", true],
+      [".nax/prompt-audit/foo/bar.txt", true],
+      [".nax/status.json", true],
+      ["fixtures/tdd-calc/.nax/status.json", true],
+      ["packages/web/.nax/mono/packages/web/config.json", true],
+      ["nax.lock", true],
+      ["packages/web/nax.lock", true],
+      ["src/calc.ts", false],
+      ["src/calc.test.ts", false],
+      ["test/unit/foo.test.ts", false],
+      ["package.json", false],
+      ["docs/foo.md", false],
+      ["script/nax-runner.sh", false],
+    ])("%s → %s", (path, expected) => {
+      expect(isNaxInternalPath(path)).toBe(expected);
+    });
+  });
+
+  describe("filterNaxInternalPaths", () => {
+    test("preserves user paths, drops nax-internal", () => {
+      const input = [
+        ".nax/cache/test-patterns.json",
+        "src/calc.ts",
+        "fixtures/tdd-calc/.nax/status.json",
+        "src/calc.test.ts",
+        "nax.lock",
+        "package.json",
+      ];
+      expect(filterNaxInternalPaths(input)).toEqual(["src/calc.ts", "src/calc.test.ts", "package.json"]);
+    });
+
+    test("empty input → empty output", () => {
+      expect(filterNaxInternalPaths([])).toEqual([]);
+    });
+
+    test("all-internal input → empty output", () => {
+      expect(filterNaxInternalPaths([".nax/status.json", "nax.lock"])).toEqual([]);
+    });
+
+    test("does not mutate input", () => {
+      const input = [".nax/status.json", "src/foo.ts"];
+      const snapshot = [...input];
+      filterNaxInternalPaths(input);
+      expect(input).toEqual(snapshot);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add \`src/utils/path-filters.ts\` with \`isNaxInternalPath\` / \`filterNaxInternalPaths\` helpers
- Wire filter into \`SessionScratchProvider.renderEntry\` for \`tdd-session\` entries so the \`## Session History\` prompt block only surfaces real code changes

## Why

Before this change, the \`## Session History\` prompt block leaked every \`.nax/\` bookkeeping write (cache, descriptors, digests, prompt-audit, status.json) plus \`nax.lock\` churn from the prior TDD session. Pure noise — wastes tokens, zero signal.

Observed in T16.2 tdd-calc dogfood run:
\`\`\`
TDD test-writer ... changed: fixtures/tdd-calc/.nax/cache/test-patterns.json,
  fixtures/tdd-calc/.nax/features/tdd-calc/prd.json,
  fixtures/tdd-calc/.nax/features/tdd-calc/sessions/sess-.../descriptor.json,
  fixtures/tdd-calc/.nax/features/tdd-calc/sessions/sess-.../digest-tdd-test-writer.txt,
  ...,
  fixtures/tdd-calc/src/calc.test.ts
\`\`\`

After: only \`fixtures/tdd-calc/src/calc.test.ts\` remains.

## Test plan

- [x] \`bun test test/unit/utils/path-filters.test.ts\` — 19 new tests, all pass
- [x] \`bun test test/unit/context/engine/providers/session-scratch\` — existing tests pass
- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean

Fixes #542