### PR TITLE
fix(tdd): bind ACP protocolIds on TDD session descriptors

### DIFF
--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -56,6 +56,12 @@ export interface ThreeSessionTddOptions {
   getTddContextBundle?: (role: TddSessionRole) => Promise<import("../context/engine").ContextBundle | undefined>;
   /** Persist per-session outcomes (scratch, digests, metrics) as soon as they exist. */
   recordTddSessionOutcome?: (result: TddSessionResult) => Promise<void>;
+  /**
+   * #541: Bind a TDD session's ACP protocolIds to a pre-created session descriptor.
+   * Returns `{ sessionManager, sessionId }` when the orchestrator has a descriptor
+   * for this role; undefined when no sessionManager is configured.
+   */
+  getTddSessionBinding?: (role: TddSessionRole) => import("./session-runner").TddSessionBinding | undefined;
   constitution?: string;
   dryRun?: boolean;
   lite?: boolean;
@@ -82,6 +88,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     tddContextBundles,
     getTddContextBundle,
     recordTddSessionOutcome,
+    getTddSessionBinding,
     constitution,
     dryRun = false,
     lite = false,
@@ -195,6 +202,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
       projectDir,
       featureContextMarkdown,
       testWriterBundle,
+      getTddSessionBinding?.("test-writer"),
     );
     sessions.push(session1);
     await recordTddSessionOutcome?.(session1);
@@ -315,6 +323,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     projectDir,
     featureContextMarkdown,
     implementerBundle,
+    getTddSessionBinding?.("implementer"),
   );
   sessions.push(session2);
   await recordTddSessionOutcome?.(session2);
@@ -369,6 +378,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     projectDir,
     featureContextMarkdown,
     verifierBundle,
+    getTddSessionBinding?.("verifier"),
   );
   sessions.push(session3);
   await recordTddSessionOutcome?.(session3);
@@ -497,6 +507,14 @@ export async function runThreeSessionTddFromCtx(
   let tddContextBundles: ThreeSessionTddOptions["tddContextBundles"];
   let getTddContextBundle: ThreeSessionTddOptions["getTddContextBundle"];
   let recordTddSessionOutcome: ThreeSessionTddOptions["recordTddSessionOutcome"];
+  // #541: per-role session descriptor id, populated lazily when scratch dir is created.
+  const sessionIdByRole = new Map<TddSessionRole, string>();
+  const getTddSessionBinding: ThreeSessionTddOptions["getTddSessionBinding"] = (role) => {
+    if (!ctx.sessionManager) return undefined;
+    const id = sessionIdByRole.get(role);
+    if (!id) return undefined;
+    return { sessionManager: ctx.sessionManager, sessionId: id };
+  };
 
   // Defensive check: test fixtures may bypass Zod and omit `context.v2`.
   if (ctx.config.context?.v2?.enabled) {
@@ -514,17 +532,22 @@ export async function runThreeSessionTddFromCtx(
       const existing = scratchDirByRole.get(role);
       if (existing !== undefined) return existing;
 
-      const created =
-        ctx.sessionManager && ctx.prd.feature
-          ? ctx.sessionManager.create({
-              role,
-              agent: ctx.routing.agent ?? ctx.rootConfig.autoMode.defaultAgent,
-              workdir: ctx.workdir,
-              projectDir: ctx.projectDir,
-              featureName: ctx.prd.feature,
-              storyId: ctx.story.id,
-            }).scratchDir
-          : ctx.sessionScratchDir;
+      let created: string | undefined;
+      if (ctx.sessionManager && ctx.prd.feature) {
+        const descriptor = ctx.sessionManager.create({
+          role,
+          agent: ctx.routing.agent ?? ctx.rootConfig.autoMode.defaultAgent,
+          workdir: ctx.workdir,
+          projectDir: ctx.projectDir,
+          featureName: ctx.prd.feature,
+          storyId: ctx.story.id,
+        });
+        created = descriptor.scratchDir;
+        // #541: remember the descriptor id so runTddSession can bind handle later.
+        sessionIdByRole.set(role, descriptor.id);
+      } else {
+        created = ctx.sessionScratchDir;
+      }
       scratchDirByRole.set(role, created);
       if (created) storyScratchDirs.add(created);
       return created;
@@ -621,6 +644,7 @@ export async function runThreeSessionTddFromCtx(
     tddContextBundles,
     getTddContextBundle,
     recordTddSessionOutcome,
+    getTddSessionBinding,
     constitution: ctx.constitution?.content,
     dryRun: opts.dryRun ?? false,
     lite: opts.lite ?? false,

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -13,6 +13,7 @@ import type { InteractionBridge } from "../interaction/bridge-builder";
 import { getLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { PromptBuilder } from "../prompts";
+import type { ISessionManager } from "../session/types";
 import { autoCommitIfDirty as _autoCommitIfDirtyFn } from "../utils/git";
 import { captureGitRef as _captureGitRef } from "../utils/git";
 import { cleanupProcessTree as _cleanupProcessTree } from "./cleanup";
@@ -107,6 +108,15 @@ export async function rollbackToRef(workdir: string, ref: string): Promise<void>
   logger.info("tdd", "Successfully rolled back git changes", { ref });
 }
 
+/**
+ * Binding used to tie a TDD session's ACP protocolIds back to a pre-created
+ * session descriptor so the audit trail includes recordId/sessionId (#541).
+ */
+export interface TddSessionBinding {
+  sessionManager: ISessionManager;
+  sessionId: string;
+}
+
 /** Run a single TDD session */
 export async function runTddSession(
   role: TddSessionRole,
@@ -125,6 +135,7 @@ export async function runTddSession(
   projectDir?: string,
   featureContextMarkdown?: string,
   contextBundle?: import("../context/engine").ContextBundle,
+  sessionBinding?: TddSessionBinding,
 ): Promise<TddSessionResult> {
   const startTime = Date.now();
 
@@ -235,6 +246,20 @@ export async function runTddSession(
       : undefined,
     interactionBridge,
   });
+
+  // #541: bind ACP protocolIds to the pre-created session descriptor so the
+  // audit trail can correlate storyId → sess-<uuid> → recordId for TDD roles.
+  // Mirrors the pattern used in src/pipeline/stages/execution.ts:208.
+  if (sessionBinding && result.protocolIds) {
+    const descriptor = sessionBinding.sessionManager.get(sessionBinding.sessionId);
+    if (descriptor) {
+      sessionBinding.sessionManager.bindHandle(
+        sessionBinding.sessionId,
+        agent.deriveSessionName(descriptor),
+        result.protocolIds,
+      );
+    }
+  }
 
   // BUG-21 Fix: Clean up orphaned child processes if agent failed
   if (!result.success && result.pid) {

--- a/test/unit/tdd/session-runner-bindhandle.test.ts
+++ b/test/unit/tdd/session-runner-bindhandle.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for session-runner.ts — #541: TDD session binds protocolIds to the
+ * pre-created session descriptor so the audit trail is not left with null IDs.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AgentResult, AgentRunOptions } from "../../../src/agents/types";
+import type { NaxConfig } from "../../../src/config";
+import type { UserStory } from "../../../src/prd";
+import type { ISessionManager, SessionDescriptor } from "../../../src/session/types";
+import { _sessionRunnerDeps, runTddSession } from "../../../src/tdd/session-runner";
+
+function makeStory(): UserStory {
+  return {
+    id: "US-001",
+    title: "Impl story",
+    description: "Do the thing",
+    acceptanceCriteria: ["AC-1"],
+    status: "pending",
+  } as unknown as UserStory;
+}
+
+function makeConfig(): NaxConfig {
+  return {
+    models: {
+      claude: {
+        fast: { model: "fast-model" },
+        balanced: { model: "balanced-model" },
+        powerful: { model: "powerful-model" },
+      },
+    },
+    autoMode: { defaultAgent: "claude" },
+    execution: {
+      rectification: { enabled: false },
+      sessionTimeoutSeconds: 300,
+      dangerouslySkipPermissions: true,
+    },
+    quality: { commands: { test: "bun test" } },
+    tdd: { testWriterAllowedPaths: [] },
+  } as unknown as NaxConfig;
+}
+
+function makeAgent(protocolIds: { recordId: string | null; sessionId: string | null } | undefined) {
+  const run = mock(
+    async (_opts: AgentRunOptions): Promise<AgentResult> => ({
+      success: true,
+      exitCode: 0,
+      output: "done",
+      rateLimited: false,
+      durationMs: 100,
+      estimatedCost: 0,
+      ...(protocolIds ? { protocolIds } : {}),
+    }),
+  );
+  return {
+    run,
+    isInstalled: mock(async () => true),
+    complete: mock(async () => ""),
+    buildCommand: mock(() => []),
+    deriveSessionName: mock((_d: SessionDescriptor) => "nax-abc12345-feat-US-001-implementer"),
+  };
+}
+
+function makeSessionManager() {
+  const descriptor: SessionDescriptor = {
+    id: "sess-test",
+    role: "implementer",
+    state: "CREATED",
+    agent: "claude",
+    workdir: "/tmp/fake",
+    featureName: "feat",
+    storyId: "US-001",
+    protocolIds: { recordId: null, sessionId: null },
+    scratchDir: "/tmp/fake/scratch",
+    completedStages: [],
+    createdAt: new Date().toISOString(),
+    lastActivityAt: new Date().toISOString(),
+  };
+  const bindHandle = mock(
+    (_id: string, _handle: string, ids: { recordId: string | null; sessionId: string | null }) => {
+      descriptor.protocolIds = ids;
+      return descriptor;
+    },
+  );
+  const get = mock((id: string) => (id === "sess-test" ? descriptor : undefined));
+  return {
+    manager: { get, bindHandle } as unknown as ISessionManager,
+    bindHandle,
+    descriptor,
+  };
+}
+
+let origDeps: Record<string, unknown>;
+
+beforeEach(() => {
+  origDeps = {
+    autoCommitIfDirty: _sessionRunnerDeps.autoCommitIfDirty,
+    getChangedFiles: _sessionRunnerDeps.getChangedFiles,
+    verifyTestWriterIsolation: _sessionRunnerDeps.verifyTestWriterIsolation,
+    verifyImplementerIsolation: _sessionRunnerDeps.verifyImplementerIsolation,
+    captureGitRef: _sessionRunnerDeps.captureGitRef,
+    cleanupProcessTree: _sessionRunnerDeps.cleanupProcessTree,
+    buildPrompt: _sessionRunnerDeps.buildPrompt,
+  };
+  _sessionRunnerDeps.autoCommitIfDirty = mock(async () => {});
+  _sessionRunnerDeps.getChangedFiles = mock(async () => []);
+  _sessionRunnerDeps.verifyTestWriterIsolation = mock(async () => ({
+    passed: true,
+    violations: [],
+    softViolations: [],
+    description: "",
+  }));
+  _sessionRunnerDeps.verifyImplementerIsolation = mock(async () => ({
+    passed: true,
+    violations: [],
+    description: "",
+  }));
+  _sessionRunnerDeps.captureGitRef = mock(async () => "abc");
+  _sessionRunnerDeps.cleanupProcessTree = mock(async () => {});
+  _sessionRunnerDeps.buildPrompt = mock(async () => "mock prompt");
+});
+
+afterEach(() => {
+  Object.assign(_sessionRunnerDeps, origDeps);
+});
+
+describe("session-runner bindHandle (#541)", () => {
+  test("calls sessionManager.bindHandle with protocolIds when binding is provided", async () => {
+    const agent = makeAgent({ recordId: "rec-abc", sessionId: "acp-xyz" });
+    const { manager, bindHandle, descriptor } = makeSessionManager();
+
+    await runTddSession(
+      "implementer",
+      agent as never,
+      makeStory(),
+      makeConfig(),
+      "/tmp/fake",
+      "balanced",
+      "HEAD",
+      undefined,
+      false,
+      false,
+      undefined,
+      "feat",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { sessionManager: manager, sessionId: "sess-test" },
+    );
+
+    expect(bindHandle).toHaveBeenCalledTimes(1);
+    expect(bindHandle.mock.calls[0]?.[0]).toBe("sess-test");
+    expect(bindHandle.mock.calls[0]?.[2]).toEqual({ recordId: "rec-abc", sessionId: "acp-xyz" });
+    expect(descriptor.protocolIds).toEqual({ recordId: "rec-abc", sessionId: "acp-xyz" });
+  });
+
+  test("skips bindHandle when agent returns no protocolIds", async () => {
+    const agent = makeAgent(undefined);
+    const { manager, bindHandle } = makeSessionManager();
+
+    await runTddSession(
+      "test-writer",
+      agent as never,
+      makeStory(),
+      makeConfig(),
+      "/tmp/fake",
+      "balanced",
+      "HEAD",
+      undefined,
+      false,
+      false,
+      undefined,
+      "feat",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { sessionManager: manager, sessionId: "sess-test" },
+    );
+
+    expect(bindHandle).not.toHaveBeenCalled();
+  });
+
+  test("skips bindHandle when no binding is provided (backward compat)", async () => {
+    const agent = makeAgent({ recordId: "rec-abc", sessionId: "acp-xyz" });
+
+    // No throw — sessionBinding defaults to undefined.
+    const result = await runTddSession(
+      "verifier",
+      agent as never,
+      makeStory(),
+      makeConfig(),
+      "/tmp/fake",
+      "balanced",
+      "HEAD",
+    );
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Wire \`sessionManager.bindHandle()\` into \`runTddSession\` so \`test-writer\`, \`implementer\`, and \`verifier\` session descriptors capture their ACP \`recordId\` + \`sessionId\` after \`agent.run()\` — the same pattern used in \`execution.ts\`, \`autofix.ts\`, and \`rectification-loop.ts\`.

## Why

All TDD descriptors on disk froze at:
\`\`\`json
\"protocolIds\": { \"recordId\": null, \"sessionId\": null }
\`\`\`

Because \`session-runner.ts\` never called \`bindHandle()\` after \`agent.run()\` returned. This broke cross-invocation audit correlation (storyId → sess-&lt;uuid&gt; → recordId) and resume-after-crash for TDD roles.

## Changes

- New \`TddSessionBinding\` interface in [src/tdd/session-runner.ts](src/tdd/session-runner.ts)
- \`runTddSession\` accepts optional \`sessionBinding\` — after \`agent.run()\` succeeds with \`result.protocolIds\`, calls \`sessionManager.bindHandle(sessionId, agent.deriveSessionName(descriptor), protocolIds)\`
- [src/tdd/orchestrator.ts](src/tdd/orchestrator.ts) tracks \`sessionIdByRole\` inside \`ensureRoleScratchDir\` and exposes \`getTddSessionBinding(role)\` so each of the three \`runTddSession\` calls gets its own descriptor binding
- Unit tests: binding present → bindHandle called; no protocolIds → skipped; no binding → skipped (backward compat)

## Test plan

- [x] \`bun test test/unit/tdd/session-runner-bindhandle.test.ts\` — 3 new tests
- [x] \`bun test test/unit/tdd test/unit/pipeline test/unit/session test/unit/utils\` — 755 pass
- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean

## Related

Paired with #540 (dup session descriptors). Together they should produce 1 descriptor per TDD role with populated protocolIds after a run.

Fixes #541