### PR TITLE
fix(tdd): reuse context-stage session descriptor for implementer role

### DIFF
--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -534,14 +534,25 @@ export async function runThreeSessionTddFromCtx(
 
       let created: string | undefined;
       if (ctx.sessionManager && ctx.prd.feature) {
-        const descriptor = ctx.sessionManager.create({
-          role,
-          agent: ctx.routing.agent ?? ctx.rootConfig.autoMode.defaultAgent,
-          workdir: ctx.workdir,
-          projectDir: ctx.projectDir,
-          featureName: ctx.prd.feature,
-          storyId: ctx.story.id,
-        });
+        // #540: the context stage (src/pipeline/stages/context.ts) pre-creates an
+        // implementer-role descriptor that owns ctx.sessionId + ctx.sessionScratchDir.
+        // Reuse it here instead of creating a second implementer descriptor for the
+        // TDD implementer session — otherwise the run leaves two implementer
+        // descriptors on disk with only one ever binding protocolIds.
+        const reuseExisting =
+          role === "implementer" && ctx.sessionId && ctx.sessionScratchDir
+            ? ctx.sessionManager.get(ctx.sessionId)
+            : undefined;
+        const descriptor =
+          reuseExisting ??
+          ctx.sessionManager.create({
+            role,
+            agent: ctx.routing.agent ?? ctx.rootConfig.autoMode.defaultAgent,
+            workdir: ctx.workdir,
+            projectDir: ctx.projectDir,
+            featureName: ctx.prd.feature,
+            storyId: ctx.story.id,
+          });
         created = descriptor.scratchDir;
         // #541: remember the descriptor id so runTddSession can bind handle later.
         sessionIdByRole.set(role, descriptor.id);


### PR DESCRIPTION
## Summary

When TDD is enabled, the context stage [src/pipeline/stages/context.ts:64](src/pipeline/stages/context.ts#L64) pre-creates a session descriptor with \`role: \"implementer\"\` to own \`ctx.sessionId\` + \`ctx.sessionScratchDir\`. The TDD orchestrator's \`ensureRoleScratchDir()\` then created a **second** implementer descriptor for the actual TDD implementer session — leaving the run with 4 descriptors on disk (dup implementer + test-writer + verifier) instead of the expected 3.

Fix: when \`role === \"implementer\"\` and \`ctx.sessionId\` already resolves to an existing descriptor, reuse it instead of creating a new one.

## Stacked on

This PR builds on **#545** (TDD bindHandle) — the \`sessionIdByRole\` map introduced there is the exact place where descriptor reuse needs to record the existing id so \`bindHandle\` gets called on the right descriptor. Merge order: #545 → this.

## Test plan

- [x] \`bun run typecheck\`, \`bun run lint\` — clean
- [x] \`bun test test/unit/tdd\` — 11 pass
- [ ] End-to-end: re-run T16.2 tdd-calc fixture after merge → expect exactly 3 descriptors (test-writer, implementer, verifier) all with populated protocolIds

## Related

Paired with #541 / #545. Together the pair produces 1 descriptor per TDD role with recordId + sessionId captured.

Fixes #540