### PR TITLE
refactor(prompts): remove hardcoded 'bun test' fallbacks

### DIFF
--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -300,12 +300,19 @@ Commit your fixes when done.${scopeConstraint}`;
     const maxChars = config?.maxFailureSummaryChars ?? 2000;
     const failureSummary = formatFailureSummary(failures, maxChars);
 
-    const cmd = testCommand ?? "bun test";
+    // #543: do not invent a `bun test` command for Go / Python / Rust packages.
+    // If no testCommand is configured, surface the file without a command so the
+    // agent uses its project's native test runner rather than a wrong default.
+    const cmd = testCommand ?? "";
 
     const failingFiles = Array.from(new Set(failures.map((f) => f.file)));
     const testCommands = failingFiles
       .map((file) => {
-        const scopedCmd = testScopedTemplate ? testScopedTemplate.replace("{{files}}", file) : `${cmd} ${file}`;
+        const scopedCmd = testScopedTemplate
+          ? testScopedTemplate.replace("{{files}}", file)
+          : cmd
+            ? `${cmd} ${file}`
+            : file;
         return `  ${scopedCmd}`;
       })
       .join("\n");
@@ -376,7 +383,7 @@ ${testCommands}
 - Do NOT modify test files unless there is a legitimate bug in the test itself.
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements.
-- When running tests, run ONLY the failing test files shown above — NEVER run \`${cmd}\` without a file filter.
+- When running tests, run ONLY the failing test files shown above${cmd ? ` — NEVER run \`${cmd}\` without a file filter` : " — never run the full test suite without a file filter"}.
 `;
   }
 

--- a/src/prompts/sections/conventions.ts
+++ b/src/prompts/sections/conventions.ts
@@ -1,7 +1,7 @@
 /**
  * Conventions Section
  *
- * Includes bun test scoping warning and commit message instructions (non-overridable).
+ * Commit message and security instructions (non-overridable).
  */
 
 export function buildConventionsSection(): string {

--- a/src/prompts/sections/isolation.ts
+++ b/src/prompts/sections/isolation.ts
@@ -13,10 +13,12 @@
  * - buildIsolationSection("lite") → test-writer, lite
  */
 
-const DEFAULT_TEST_CMD = "bun test";
-
 function buildTestFilterRule(testCommand: string): string {
-  return `When running tests, run ONLY test files related to your changes (e.g. \`${testCommand} <path/to/test-file>\`). NEVER run the full test suite without a filter — full suite output will flood your context window and cause failures.`;
+  // #543: do not invent a `bun test` example for Go / Python / Rust packages.
+  const example = testCommand
+    ? `e.g. \`${testCommand} <path/to/test-file>\``
+    : "scope each run to the files you changed";
+  return `When running tests, run ONLY test files related to your changes (${example}). NEVER run the full test suite without a filter — full suite output will flood your context window and cause failures.`;
 }
 
 export function buildIsolationSection(
@@ -46,7 +48,7 @@ export function buildIsolationSection(
     | "single-session"
     | "tdd-simple"
     | "batch";
-  const testCmd = testCommand ?? DEFAULT_TEST_CMD;
+  const testCmd = testCommand ?? "";
 
   const header = "# Isolation Rules";
   const footer = `\n\n${buildTestFilterRule(testCmd)}`;

--- a/src/prompts/sections/role-task.ts
+++ b/src/prompts/sections/role-task.ts
@@ -15,8 +15,6 @@
 
 import { buildTestFrameworkHint } from "../../test-runners";
 
-const DEFAULT_TEST_CMD = "bun test";
-
 export function buildRoleTaskSection(
   roleOrVariant:
     | "no-test"
@@ -46,7 +44,7 @@ export function buildRoleTaskSection(
     | "single-session"
     | "tdd-simple"
     | "batch";
-  const testCmd = testCommand ?? DEFAULT_TEST_CMD;
+  const testCmd = testCommand ?? "";
   const frameworkHint = buildTestFrameworkHint(testCmd);
 
   if (role === "no-test") {
@@ -161,6 +159,9 @@ Instructions:
   }
 
   if (role === "batch") {
+    const verifyCmdLine = testCmd
+      ? `  - Verify all tests pass: ${testCmd}`
+      : "  - Verify all tests pass using your project's test command";
     return `# Role: Batch Implementer
 
 Your task: Implement each story in order using TDD — write tests first, then implement, then verify.
@@ -171,7 +172,7 @@ Instructions:
   - Write failing tests FIRST covering the acceptance criteria
   - Run tests to confirm they fail (RED phase)
   - Implement the minimum code to make tests pass (GREEN phase)
-  - Verify all tests pass: ${testCmd}
+${verifyCmdLine}
   - Commit the story with its story ID in the commit message: git commit -m 'feat(<story-id>): <description>'
 - ${frameworkHint}
 - Do NOT commit multiple stories together — each story gets its own commit

--- a/src/test-runners/detector.ts
+++ b/src/test-runners/detector.ts
@@ -55,7 +55,10 @@ export function isTestFile(filePath: string, testFilePatterns?: readonly string[
  */
 export function buildTestFrameworkHint(testCommand: string): string {
   const cmd = testCommand.trim();
-  if (!cmd || cmd.startsWith("bun test")) return "Use Bun test (describe/test/expect)";
+  // #543: do not assume Bun when no command is configured — that falsely tells
+  // Go / Python / Rust packages to run `bun test`.
+  if (!cmd) return "Use your project's test framework";
+  if (cmd.startsWith("bun test")) return "Use Bun test (describe/test/expect)";
   if (cmd.startsWith("pytest") || cmd.startsWith("python -m pytest")) return "Use pytest";
   if (cmd.startsWith("cargo test")) return "Use Rust's cargo test";
   if (cmd.startsWith("go test")) return "Use Go's testing package";

--- a/test/unit/execution/rectification.test.ts
+++ b/test/unit/execution/rectification.test.ts
@@ -369,7 +369,7 @@ describe("createEscalatedRectificationPrompt", () => {
     expect(prompt).not.toContain("NEVER run `bun test`");
   });
 
-  test("defaults to bun test in filter instruction when no testCommand provided", () => {
+  test("uses neutral filter instruction when no testCommand provided (#543)", () => {
     const prompt = RectifierPromptBuilder.escalated(
       mockFailures,
       mockStory,
@@ -378,6 +378,20 @@ describe("createEscalatedRectificationPrompt", () => {
       "powerful",
       baseConfig,
     );
-    expect(prompt).toContain("NEVER run `bun test` without a file filter");
+    expect(prompt).toContain("never run the full test suite without a file filter");
+    expect(prompt).not.toContain("bun test");
+  });
+
+  test("references configured test command when provided", () => {
+    const prompt = RectifierPromptBuilder.escalated(
+      mockFailures,
+      mockStory,
+      1,
+      "balanced",
+      "powerful",
+      baseConfig,
+      "go test",
+    );
+    expect(prompt).toContain("NEVER run `go test` without a file filter");
   });
 });

--- a/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
@@ -222,7 +222,7 @@ Message: Expected counter to be 0, received 3
 
 isolation scope: Implement source code in src/ to make tests pass. Do not modify test files. Run tests frequently to track progress.
 
-When running tests, run ONLY test files related to your changes (e.g. \`bun test <path/to/test-file>\`). NEVER run the full test suite without a filter — full suite output will flood your context window and cause failures.
+When running tests, run ONLY test files related to your changes (scope each run to the files you changed). NEVER run the full test suite without a filter — full suite output will flood your context window and cause failures.
 
 ---
 
@@ -318,7 +318,7 @@ Message: Race condition: counter increment is not atomic
 
 isolation scope: Implement source code in src/ to make tests pass. Do not modify test files. Run tests frequently to track progress.
 
-When running tests, run ONLY test files related to your changes (e.g. \`bun test <path/to/test-file>\`). NEVER run the full test suite without a filter — full suite output will flood your context window and cause failures.
+When running tests, run ONLY test files related to your changes (scope each run to the files you changed). NEVER run the full test suite without a filter — full suite output will flood your context window and cause failures.
 
 ---
 

--- a/test/unit/prompts/sections/isolation.test.ts
+++ b/test/unit/prompts/sections/isolation.test.ts
@@ -19,11 +19,17 @@ describe("buildIsolationSection — test-writer role", () => {
     expect(result).toContain("stub");
   });
 
-  test("both modes include test filtering rule", () => {
-    const strictResult = buildIsolationSection("test-writer", "strict");
-    const liteResult = buildIsolationSection("test-writer", "lite");
+  test("both modes include test filtering rule with configured command", () => {
+    const strictResult = buildIsolationSection("test-writer", "strict", "bun test");
+    const liteResult = buildIsolationSection("test-writer", "lite", "bun test");
     expect(strictResult).toContain("bun test");
     expect(liteResult).toContain("bun test");
+  });
+
+  test("omits command example when no test command configured (#543)", () => {
+    const result = buildIsolationSection("test-writer", "strict");
+    expect(result).toContain("scope each run to the files you changed");
+    expect(result).not.toContain("bun test");
   });
 
   test("defaults to strict mode when no mode provided", () => {
@@ -45,8 +51,8 @@ describe("buildIsolationSection — implementer role", () => {
     expect(result.toLowerCase()).toMatch(/do not modify.*test|test.*do not modify/i);
   });
 
-  test("includes test filtering rule", () => {
-    const result = buildIsolationSection("implementer");
+  test("includes test filtering rule when command configured", () => {
+    const result = buildIsolationSection("implementer", undefined, "bun test");
     expect(result).toContain("bun test");
   });
 });
@@ -57,8 +63,8 @@ describe("buildIsolationSection — verifier role", () => {
     expect(result.toLowerCase()).toMatch(/read|inspect|review/);
   });
 
-  test("includes test filtering rule", () => {
-    const result = buildIsolationSection("verifier");
+  test("includes test filtering rule when command configured", () => {
+    const result = buildIsolationSection("verifier", undefined, "bun test");
     expect(result).toContain("bun test");
   });
 });
@@ -70,8 +76,8 @@ describe("buildIsolationSection — single-session role", () => {
     expect(result).toContain("src/");
   });
 
-  test("includes test filtering rule", () => {
-    const result = buildIsolationSection("single-session");
+  test("includes test filtering rule when command configured", () => {
+    const result = buildIsolationSection("single-session", undefined, "bun test");
     expect(result).toContain("bun test");
   });
 });

--- a/test/unit/test-runners/detector.test.ts
+++ b/test/unit/test-runners/detector.test.ts
@@ -6,8 +6,8 @@ import { describe, expect, test } from "bun:test";
 import { buildTestFrameworkHint } from "../../../src/test-runners/detector";
 
 describe("buildTestFrameworkHint", () => {
-  test("returns Bun hint for empty command", () => {
-    expect(buildTestFrameworkHint("")).toBe("Use Bun test (describe/test/expect)");
+  test("returns neutral hint for empty command (#543)", () => {
+    expect(buildTestFrameworkHint("")).toBe("Use your project's test framework");
   });
 
   test("returns Bun hint for bun test command", () => {


### PR DESCRIPTION
## Summary

Follow-up to #536 (closed) which fixed language detection in \`role-task.ts\` only. This pass removes the remaining \`DEFAULT_TEST_CMD = \"bun test\"\` fallbacks and literal \`bun test\` strings that leaked into Go / Python / Rust prompts when no \`testCommand\` was configured.

## Changes

- [src/prompts/sections/role-task.ts](src/prompts/sections/role-task.ts) — drop \`DEFAULT_TEST_CMD\`; empty command → neutral framework hint; batch role omits verify-command line when no command configured
- [src/prompts/sections/isolation.ts](src/prompts/sections/isolation.ts) — drop \`DEFAULT_TEST_CMD\`; no command → \"scope each run to the files you changed\" instead of a wrong \`bun test\` example
- [src/prompts/sections/conventions.ts](src/prompts/sections/conventions.ts) — fix stale \"bun test scoping\" doc comment
- [src/prompts/builders/rectifier-builder.ts](src/prompts/builders/rectifier-builder.ts) — remove \`?? \"bun test\"\` default; empty command → emit file path without an invented test runner, neutral \"full test suite\" warning

## Test plan

- [x] \`bun test test/unit/prompts\` — 485 pass (2 snapshot updates)
- [x] \`bun run test:bail\` — 4393 tests pass
- [x] \`bun run typecheck\` / \`bun run lint\` — clean
- [x] New test: \`rectification.test.ts\` — neutral wording when no command; named command when \`go test\` provided

## Context

Observed in T16.2 tdd-calc dogfood prompt audit:
> 6. \`bun test\` exits with code 0 and reports all tests passing.
> When running tests, run ONLY test files related to your changes (e.g. \`bun test ...\`)

For tdd-calc (TS) this is correct — but for a Go / Python fixture with no \`quality.commands.test\` configured, the same prompt would wrongly tell the agent to invoke \`bun test\`.

## Related

- #536 (closed) — partial fix, language detection only
- ADR-009 — test-file pattern SSOT
- \`.claude/rules/monorepo-awareness.md\` §3

Fixes #543