### PR TITLE
fix(resolver): detect test patterns from packageDir in monorepo runs

### DIFF
--- a/src/test-runners/resolver.ts
+++ b/src/test-runners/resolver.ts
@@ -17,7 +17,7 @@
  * Injectable `_resolverDeps` follows the project `_deps` pattern.
  */
 
-import { dirname, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import type { NaxConfig } from "../config/types";
 import { NaxError } from "../errors";
 import { getSafeLogger } from "../logger";
@@ -164,8 +164,12 @@ export async function resolveTestFilePatterns(
     return buildResolved(rootPatterns, "root-config");
   }
 
-  // 3. Detection (Phase 1 stub returns empty; Phase 2 adds real detection)
-  const detected = await _resolverDeps.detectTestFilePatterns(workdir);
+  // 3. Detection — scan from the package directory when available so auto-detected
+  // patterns are package-relative (e.g. "src/**/*.test.ts") rather than rooted
+  // at the repo (e.g. "packages/lib/src/**/*.test.ts"), which would produce
+  // doubled paths when joined with packageDir in code-neighbor.
+  const detectionWorkdir = packageDir ? join(workdir, packageDir) : workdir;
+  const detected = await _resolverDeps.detectTestFilePatterns(detectionWorkdir);
   if (detected.confidence !== "empty" && detected.patterns.length > 0) {
     getSafeLogger()?.info("resolver", "Test patterns auto-detected", {
       ...(options?.storyId !== undefined && { storyId: options.storyId }),

--- a/test/unit/test-runners/resolver.test.ts
+++ b/test/unit/test-runners/resolver.test.ts
@@ -120,6 +120,30 @@ describe("resolveTestFilePatterns — resolution chain", () => {
     expect(resolved.resolution).toBe("fallback");
   });
 
+  test("detected: uses packageDir as detection workdir so patterns are package-relative", async () => {
+    const config = makeConfig(); // no root config
+    let capturedWorkdir: string | undefined;
+    _resolverDeps.detectTestFilePatterns = async (wd) => {
+      capturedWorkdir = wd;
+      return { patterns: ["src/**/*.test.ts"], confidence: "medium", sources: [] };
+    };
+
+    await resolveTestFilePatterns(config, WORKDIR, "packages/lib");
+    expect(capturedWorkdir).toBe(`${WORKDIR}/packages/lib`);
+  });
+
+  test("detected: uses repo root as detection workdir when no packageDir", async () => {
+    const config = makeConfig();
+    let capturedWorkdir: string | undefined;
+    _resolverDeps.detectTestFilePatterns = async (wd) => {
+      capturedWorkdir = wd;
+      return { patterns: [], confidence: "empty", sources: [] };
+    };
+
+    await resolveTestFilePatterns(config, WORKDIR);
+    expect(capturedWorkdir).toBe(WORKDIR);
+  });
+
   test("boolean smartTestRunner (true) is treated as no explicit patterns → fallback", async () => {
     const config = {
       ...makeConfig(),


### PR DESCRIPTION
## Summary

- `resolveTestFilePatterns` was calling `detectTestFilePatterns(repoRoot)` even when a `packageDir` sub-package was specified
- Detection from the repo root found paths like `packages/lib/src/util.test.ts` and produced pattern `packages/lib/src/**/*.test.ts`
- `deriveSiblingTestCandidates` then joined that prefix with `packageDir`, producing `packages/lib/packages/lib/src/util.test.ts` (doubled path)
- This caused `Provider "code-neighbor" failed — ENOENT` on every monorepo story run

**Fix:** when `packageDir` is provided, detection now runs from `join(workdir, packageDir)` so patterns are package-relative (`src/**/*.test.ts`), eliminating the doubling.

Diagnosed via the `T16.4` monorepo-tiny fixture in `nax-dogfood` where the error appeared consistently in run logs.

## Test plan

- [ ] `bun test test/unit/test-runners/resolver.test.ts` — 18 tests pass (2 new covering detection workdir capture)
- [ ] `bun run typecheck` — clean
- [ ] Re-run T16.4 monorepo-tiny fixture and confirm `code-neighbor` no longer fails with doubled path ENOENT