### PR TITLE
Release v0.63.0-canary.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.63.0-canary.5",
+  "version": "0.63.0-canary.6",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What
Release v0.63.0-canary.6

## Why
Canary release.

## Testing
- [x] CI passes on main
