### PR TITLE
fix(context): correct ctx.workdir/projectDir contamination in monorepo ContextRequest

### DIFF
--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -150,8 +150,7 @@ export async function assembleForStage(
   try {
     // Defensive check: test fixtures may bypass Zod and omit `pluginProviders`.
     const pluginConfigs = ctx.config.context.v2.pluginProviders ?? [];
-    const pluginProviders =
-      pluginConfigs.length > 0 ? await loadPluginProviders(pluginConfigs, ctx.projectDir) : [];
+    const pluginProviders = pluginConfigs.length > 0 ? await loadPluginProviders(pluginConfigs, ctx.projectDir) : [];
     const storyScratchDirs = await getStoryScratchDirs(ctx, options);
 
     const orchestrator = _stageAssemblerDeps.createOrchestrator(

--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -151,7 +151,7 @@ export async function assembleForStage(
     // Defensive check: test fixtures may bypass Zod and omit `pluginProviders`.
     const pluginConfigs = ctx.config.context.v2.pluginProviders ?? [];
     const pluginProviders =
-      pluginConfigs.length > 0 ? await loadPluginProviders(pluginConfigs, ctx.projectDir ?? ctx.workdir) : [];
+      pluginConfigs.length > 0 ? await loadPluginProviders(pluginConfigs, ctx.projectDir) : [];
     const storyScratchDirs = await getStoryScratchDirs(ctx, options);
 
     const orchestrator = _stageAssemblerDeps.createOrchestrator(
@@ -163,15 +163,16 @@ export async function assembleForStage(
 
     // AC-54: resolve dual workdir fields. repoRoot is the project root (where .nax/ lives);
     // packageDir is the story's package directory (equals repoRoot for non-monorepo).
-    const packageDir = ctx.story.workdir ? join(ctx.workdir, ctx.story.workdir) : ctx.workdir;
+    // iteration-runner.ts already resolves ctx.workdir to the package dir (join(repoRoot, story.workdir));
+    // do not re-join story.workdir here or the path will be doubled in monorepo mode.
     const targetAgentId =
       ctx.routing.agent ?? ctx.rootConfig?.autoMode?.defaultAgent ?? ctx.config.autoMode?.defaultAgent ?? "claude";
 
     const request: ContextRequest = {
       storyId: ctx.story.id,
       featureId: ctx.prd.feature,
-      repoRoot: ctx.workdir,
-      packageDir,
+      repoRoot: ctx.projectDir,
+      packageDir: ctx.workdir,
       stage,
       role: stageConfig.role,
       // AC-59: per-package stage budget — reads from ctx.config which is already the

--- a/src/pipeline/stages/context.ts
+++ b/src/pipeline/stages/context.ts
@@ -16,7 +16,6 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { join } from "node:path";
 import { createDefaultOrchestrator, createRunCallCounter } from "../../context/engine";
 import type { ContextRequest, IContextProvider } from "../../context/engine";
 import { estimateAvailableBudgetTokens } from "../../context/engine/available-budget";
@@ -125,8 +124,8 @@ async function runV2Path(ctx: PipelineContext): Promise<void> {
     // Trim trailing slash before taking the last path segment so
     // "/features/my-feature/" resolves to "my-feature" not "".
     featureId: ctx.featureDir?.replace(/\/$/, "").split("/").pop(),
-    repoRoot: ctx.workdir,
-    packageDir: ctx.story.workdir ? join(ctx.workdir, ctx.story.workdir) : ctx.workdir,
+    repoRoot: ctx.projectDir,
+    packageDir: ctx.workdir,
     stage: "context", // initial assembly; execution stage overrides to "execution"
     role: "implementer",
     budgetTokens: ctx.config.context.featureEngine?.budgetTokens ?? 8_000,

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -85,7 +85,12 @@ export interface PipelineContext {
    * and in monorepo mode (where workdir may be joined with story.workdir).
    */
   projectDir: string;
-  /** Working directory (project root) */
+  /**
+   * Agent-spawn working directory. Equals `projectDir` for single-package repos;
+   * equals `join(projectDir, story.workdir)` in monorepo mode when the story targets
+   * a sub-package. Providers and pipeline stages that need the repo root must use
+   * `projectDir` — never re-join `story.workdir` onto this value.
+   */
   workdir: string;
   /** Absolute path to the prd.json file (used by routing stage to persist initial classification) */
   prdPath?: string;

--- a/test/unit/context/engine/stage-assembler.test.ts
+++ b/test/unit/context/engine/stage-assembler.test.ts
@@ -197,6 +197,12 @@ describe("discoverSessionScratchDirsOnDisk — Finding 2", () => {
 function makeCtx(overrides: {
   deterministic?: boolean;
   testStrategy?: string;
+  /** Override the agent-spawn workdir (ctx.workdir). Defaults to "/repo". */
+  workdir?: string;
+  /** Override the repo root (ctx.projectDir). Defaults to undefined to suppress manifest writes. */
+  projectDir?: string;
+  /** Override story.workdir (relative sub-package path). */
+  storyWorkdir?: string;
 } = {}): PipelineContext {
   return {
     config: {
@@ -211,11 +217,11 @@ function makeCtx(overrides: {
     },
     rootConfig: { autoMode: { defaultAgent: "claude" } },
     prd: { feature: "test-feature", userStories: [] },
-    story: { id: "US-001" },
+    story: { id: "US-001", ...(overrides.storyWorkdir && { workdir: overrides.storyWorkdir }) },
     stories: [],
     routing: { agent: undefined, testStrategy: overrides.testStrategy },
-    projectDir: undefined, // prevents manifest writing in tests
-    workdir: "/repo",
+    projectDir: overrides.projectDir, // undefined by default — prevents manifest writing in tests
+    workdir: overrides.workdir ?? "/repo",
     hooks: {},
   } as unknown as PipelineContext;
 }
@@ -319,5 +325,72 @@ describe("assembleForStage — AC-24/AC-51 ContextRequest propagation", () => {
     await assembleForStage(makeCtx({ testStrategy: "tdd-simple" }), "execution");
 
     expect(mock.ref.captured?.availableBudgetTokens).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #556 — monorepo ctx.workdir contamination regression
+//
+// iteration-runner.ts resolves ctx.workdir to join(repoRoot, story.workdir).
+// assembleForStage must NOT re-join story.workdir onto ctx.workdir — doing so
+// doubles the sub-package path (e.g. /repo/packages/lib/packages/lib).
+// repoRoot in the ContextRequest must come from ctx.projectDir.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("assembleForStage — Issue #556 monorepo workdir contamination", () => {
+  let origReaddir: typeof _stageAssemblerDeps.readdir;
+  let origReadDescriptor: typeof _stageAssemblerDeps.readDescriptor;
+  let origCreateOrchestrator: typeof _stageAssemblerDeps.createOrchestrator;
+
+  beforeEach(() => {
+    origReaddir = _stageAssemblerDeps.readdir;
+    origReadDescriptor = _stageAssemblerDeps.readDescriptor;
+    origCreateOrchestrator = _stageAssemblerDeps.createOrchestrator;
+    _stageAssemblerDeps.readdir = async () => { throw new Error("ENOENT"); };
+    _stageAssemblerDeps.readDescriptor = async () => null;
+  });
+
+  afterEach(() => {
+    _stageAssemblerDeps.readdir = origReaddir;
+    _stageAssemblerDeps.readDescriptor = origReadDescriptor;
+    _stageAssemblerDeps.createOrchestrator = origCreateOrchestrator;
+  });
+
+  test("repoRoot is ctx.projectDir and packageDir is ctx.workdir in monorepo mode", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    // Simulate what iteration-runner.ts sets on PipelineContext for a monorepo story:
+    //   projectDir = repo root (stable), workdir = join(repoRoot, story.workdir)
+    await assembleForStage(
+      makeCtx({
+        projectDir: "/repo",
+        workdir: "/repo/packages/lib",
+        storyWorkdir: "packages/lib",
+      }),
+      "execution",
+    );
+
+    expect(mock.ref.captured?.repoRoot).toBe("/repo");
+    expect(mock.ref.captured?.packageDir).toBe("/repo/packages/lib");
+  });
+
+  test("repoRoot and packageDir are equal for single-package repos", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    // Single-package: iteration-runner sets workdir === projectDir, story.workdir unset
+    await assembleForStage(
+      makeCtx({
+        projectDir: "/repo",
+        workdir: "/repo",
+      }),
+      "execution",
+    );
+
+    expect(mock.ref.captured?.repoRoot).toBe("/repo");
+    expect(mock.ref.captured?.packageDir).toBe("/repo");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #556 — `ctx.workdir` vs `ctx.projectDir` contamination in every `ContextRequest` built during monorepo runs.

**Root cause:** `iteration-runner.ts` correctly resolves `ctx.workdir` to `join(repoRoot, story.workdir)` (the agent-spawn cwd / package dir). But two sites treated `ctx.workdir` as if it were still the repo root and re-joined `story.workdir` onto it, producing:
- `repoRoot: /repo/packages/lib` (wrong — should be `/repo`)
- `packageDir: /repo/packages/lib/packages/lib` (doubled path)

This broke `loadCanonicalRules` (wrong repo root → "No .nax/rules/ found" warning), `GitHistoryProvider`, and `CodeNeighborProvider` in every monorepo run.

**Files changed:**
- `src/context/engine/stage-assembler.ts` — use `ctx.projectDir` as `repoRoot`, `ctx.workdir` directly as `packageDir`; remove `?? ctx.workdir` fallback (projectDir is always set)
- `src/pipeline/stages/context.ts` — same fix; remove now-unused `join` import
- `src/pipeline/types.ts` — clarify `workdir` doc to prevent future recurrence
- `test/unit/context/engine/stage-assembler.test.ts` — regression tests asserting `repoRoot == projectDir` and `packageDir == workdir` (non-doubled) in monorepo mode

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test test/unit/context/engine/stage-assembler.test.ts` — 18 pass (2 new regression tests)
- [x] `bun test test/unit/pipeline/stages/context-digest.test.ts` — 10 pass
- [ ] Verify monorepo-tiny dogfood fixture no longer logs "No .nax/rules/ found" or provider failures