### PR TITLE
fix(smart-runner): detect changed test files directly, fix mapSourceToTests repoRoot (#557)

### DIFF
--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -106,26 +106,29 @@ export const verifyStage: PipelineStage = {
       // Resolve test file patterns via ADR-009 SSOT — language-agnostic, config-driven,
       // per-package override-aware. ctx.projectDir is the repo root; story.workdir is the
       // package-relative path (e.g. "packages/lib").
-      const resolvedPatterns = await resolveTestFilePatterns(
-        ctx.config,
-        ctx.projectDir,
-        ctx.story.workdir,
-      );
+      // Guard: ctx.projectDir may be undefined in test fixtures; fall back to ctx.workdir
+      // (absolute path) to prevent a "undefined/.nax/..." relative-path write.
+      const repoRoot = ctx.projectDir ?? ctx.workdir;
+      const resolvedPatterns = await _verifyDeps.resolveTestFilePatterns(ctx.config, repoRoot, ctx.story.workdir);
 
       // Pass 0: detect changed test files directly from git diff (#557).
       // Test files are already tests — no source→test mapping needed. They are returned
-      // as absolute paths using ctx.projectDir as the repo root anchor.
+      // as absolute paths using repoRoot as the anchor.
       const changedTestFiles = await _smartRunnerDeps.getChangedTestFiles(
         ctx.workdir,
-        ctx.projectDir,
+        repoRoot,
         ctx.storyGitRef,
         ctx.story.workdir,
         [...resolvedPatterns.regex],
       );
       if (changedTestFiles.length > 0) {
-        logger.info("verify", `[smart-runner] Pass 0: ${changedTestFiles.length} changed test file(s) detected directly`, {
-          storyId: ctx.story.id,
-        });
+        logger.info(
+          "verify",
+          `[smart-runner] Pass 0: ${changedTestFiles.length} changed test file(s) detected directly`,
+          {
+            storyId: ctx.story.id,
+          },
+        );
         effectiveCommand = buildScopedCommand(changedTestFiles, rawTestCommand, testScopedTemplate);
         isFullSuite = false;
       } else {
@@ -140,12 +143,9 @@ export const verifyStage: PipelineStage = {
 
         // Pass 1: path convention mapping — pass packagePrefix and testFilePatterns for language-agnostic suffix derivation.
         // ctx.projectDir is the repo root; mapSourceToTests uses it as the absolute base for test path construction.
-        const pass1Files = await _smartRunnerDeps.mapSourceToTests(
-          sourceFiles,
-          ctx.projectDir,
-          ctx.story.workdir,
-          [...resolvedPatterns.globs],
-        );
+        const pass1Files = await _smartRunnerDeps.mapSourceToTests(sourceFiles, ctx.projectDir, ctx.story.workdir, [
+          ...resolvedPatterns.globs,
+        ]);
         if (pass1Files.length > 0) {
           logger.info("verify", `[smart-runner] Pass 1: path convention matched ${pass1Files.length} test files`, {
             storyId: ctx.story.id,
@@ -300,4 +300,5 @@ export const _verifyDeps = {
   regression,
   resolveTestCommands: resolveQualityTestCommands,
   appendScratch: appendScratchEntry,
+  resolveTestFilePatterns,
 };

--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -14,6 +14,7 @@ import { getLogger } from "../../logger";
 import { resolveQualityTestCommands } from "../../quality/command-resolver";
 import { appendScratchEntry } from "../../session/scratch-writer";
 import { DEFAULT_TEST_FILE_PATTERNS } from "../../test-runners/conventions";
+import { resolveTestFilePatterns } from "../../test-runners/resolver";
 import { errorMessage } from "../../utils/errors";
 import { logTestOutput } from "../../utils/log-test-output";
 import { detectRuntimeCrash } from "../../verification/crash-detector";
@@ -102,35 +103,68 @@ export const verifyStage: PipelineStage = {
         });
       }
     } else if (smartRunnerConfig.enabled) {
-      // MW-006: pass packagePrefix so git diff is scoped to the package in monorepos
-      const sourceFiles = await _smartRunnerDeps.getChangedSourceFiles(ctx.workdir, ctx.storyGitRef, ctx.story.workdir);
-
-      // Pass 1: path convention mapping — pass packagePrefix and testFilePatterns for language-agnostic suffix derivation
-      const pass1Files = await _smartRunnerDeps.mapSourceToTests(
-        sourceFiles,
-        ctx.workdir,
+      // Resolve test file patterns via ADR-009 SSOT — language-agnostic, config-driven,
+      // per-package override-aware. ctx.projectDir is the repo root; story.workdir is the
+      // package-relative path (e.g. "packages/lib").
+      const resolvedPatterns = await resolveTestFilePatterns(
+        ctx.config,
+        ctx.projectDir,
         ctx.story.workdir,
-        smartRunnerConfig.testFilePatterns,
       );
-      if (pass1Files.length > 0) {
-        logger.info("verify", `[smart-runner] Pass 1: path convention matched ${pass1Files.length} test files`, {
+
+      // Pass 0: detect changed test files directly from git diff (#557).
+      // Test files are already tests — no source→test mapping needed. They are returned
+      // as absolute paths using ctx.projectDir as the repo root anchor.
+      const changedTestFiles = await _smartRunnerDeps.getChangedTestFiles(
+        ctx.workdir,
+        ctx.projectDir,
+        ctx.storyGitRef,
+        ctx.story.workdir,
+        [...resolvedPatterns.regex],
+      );
+      if (changedTestFiles.length > 0) {
+        logger.info("verify", `[smart-runner] Pass 0: ${changedTestFiles.length} changed test file(s) detected directly`, {
           storyId: ctx.story.id,
         });
-        effectiveCommand = buildScopedCommand(pass1Files, rawTestCommand, testScopedTemplate);
+        effectiveCommand = buildScopedCommand(changedTestFiles, rawTestCommand, testScopedTemplate);
         isFullSuite = false;
-      } else if (smartRunnerConfig.fallback === "import-grep") {
-        // Pass 2: import-grep fallback.
-        // Phase 1 interim: importGrepFallback requires string[]; resolver not yet wired here.
-        // Phase 2 will call resolveTestFilePatterns() upstream and pass resolved.globs instead.
-        const pass2Files = await _smartRunnerDeps.importGrepFallback(sourceFiles, ctx.workdir, [
-          ...(smartRunnerConfig.testFilePatterns ?? DEFAULT_TEST_FILE_PATTERNS),
-        ]);
-        if (pass2Files.length > 0) {
-          logger.info("verify", `[smart-runner] Pass 2: import-grep matched ${pass2Files.length} test files`, {
+      } else {
+        // MW-006: pass packagePrefix so git diff is scoped to the package in monorepos.
+        // Exclude test files (already handled above) so mapSourceToTests only receives source files.
+        const sourceFiles = await _smartRunnerDeps.getChangedSourceFiles(
+          ctx.workdir,
+          ctx.storyGitRef,
+          ctx.story.workdir,
+          [...resolvedPatterns.regex],
+        );
+
+        // Pass 1: path convention mapping — pass packagePrefix and testFilePatterns for language-agnostic suffix derivation.
+        // ctx.projectDir is the repo root; mapSourceToTests uses it as the absolute base for test path construction.
+        const pass1Files = await _smartRunnerDeps.mapSourceToTests(
+          sourceFiles,
+          ctx.projectDir,
+          ctx.story.workdir,
+          [...resolvedPatterns.globs],
+        );
+        if (pass1Files.length > 0) {
+          logger.info("verify", `[smart-runner] Pass 1: path convention matched ${pass1Files.length} test files`, {
             storyId: ctx.story.id,
           });
-          effectiveCommand = buildScopedCommand(pass2Files, rawTestCommand, testScopedTemplate);
+          effectiveCommand = buildScopedCommand(pass1Files, rawTestCommand, testScopedTemplate);
           isFullSuite = false;
+        } else if (smartRunnerConfig.fallback === "import-grep") {
+          // Pass 2: import-grep fallback — scan package dir for test files importing the changed sources.
+          // ctx.workdir (package dir) keeps the scan scoped to the story's package.
+          const pass2Files = await _smartRunnerDeps.importGrepFallback(sourceFiles, ctx.workdir, [
+            ...resolvedPatterns.globs,
+          ]);
+          if (pass2Files.length > 0) {
+            logger.info("verify", `[smart-runner] Pass 2: import-grep matched ${pass2Files.length} test files`, {
+              storyId: ctx.story.id,
+            });
+            effectiveCommand = buildScopedCommand(pass2Files, rawTestCommand, testScopedTemplate);
+            isFullSuite = false;
+          }
         }
       }
     }

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -4,6 +4,7 @@
  * Detects changed TypeScript source files using git diff,
  * enabling targeted test runs on only the files that changed.
  */
+import { join } from "node:path";
 import { DEFAULT_SEPARATED_TEST_DIRS, DEFAULT_TEST_FILE_PATTERNS } from "../test-runners/conventions";
 import { gitWithTimeout } from "../utils/git";
 
@@ -19,22 +20,6 @@ const _bunDeps = {
   file: (path: string) => Bun.file(path),
 };
 
-/**
- * Get TypeScript source files changed since the previous commit.
- *
- * Runs `git diff --name-only HEAD~1` in the given workdir and filters
- * results to only `.ts` files under `src/`. Returns an empty array on
- * any git error (not a repo, no previous commit, etc.).
- *
- * @param workdir - Working directory to run git command in
- * @returns Array of changed .ts file paths relative to the repo root
- *
- * @example
- * ```typescript
- * const files = await getChangedSourceFiles("/path/to/repo");
- * // Returns: ["src/foo/bar.ts", "src/utils/git.ts"]
- * ```
- */
 /**
  * Map source files to their corresponding test files.
  *
@@ -276,15 +261,22 @@ export function buildSmartTestCommand(testFiles: string[], baseCommand: string):
  * story's workdir (e.g. `"packages/api"`), the filter is scoped to
  * `<packagePrefix>/src/` instead of just `src/`.
  *
+ * When `testFileRegex` is provided, files matching any of those regexes are
+ * excluded from the return value (they are test files, not source files).
+ * Callers should pass `resolvedTestPatterns.regex` from `resolveTestFilePatterns()`
+ * so classification is language-agnostic and config-driven (ADR-009).
+ *
  * @param workdir       - Working directory to run git command in
  * @param baseRef       - Git ref for diff base (default: HEAD~1)
  * @param packagePrefix - Story workdir relative to repo root (e.g. "packages/api")
+ * @param testFileRegex - Optional regexes to exclude test files from the result
  * @returns Array of changed .ts file paths relative to the git root
  */
 export async function getChangedSourceFiles(
   workdir: string,
   baseRef?: string,
   packagePrefix?: string,
+  testFileRegex: RegExp[] = [],
 ): Promise<string[]> {
   try {
     // FEAT-010: Use per-attempt baseRef for precise diff; fall back to HEAD~1 if not provided
@@ -297,7 +289,54 @@ export async function getChangedSourceFiles(
 
     // MW-006: scope filter to package prefix in monorepo
     const srcPrefix = packagePrefix ? `${packagePrefix}/src/` : "src/";
-    return lines.filter((f) => f.startsWith(srcPrefix) && f.endsWith(".ts"));
+    const tsFiles = lines.filter((f) => f.startsWith(srcPrefix) && f.endsWith(".ts"));
+    if (testFileRegex.length === 0) return tsFiles;
+    // Exclude test files so they don't get passed to source→test mapping (#557)
+    return tsFiles.filter((f) => !testFileRegex.some((re) => re.test(f)));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get test files changed since the given git ref, scoped to the package.
+ *
+ * Unlike `getChangedSourceFiles`, this function scans the ENTIRE package directory
+ * (not just `src/`) so it catches both co-located test files (e.g. `src/foo.test.ts`)
+ * and separated test files (e.g. `test/unit/foo.test.ts`). Changed test files are
+ * returned as absolute paths ready for direct execution — no source→test mapping
+ * needed since they are already tests.
+ *
+ * Classification uses `testFileRegex` from `resolveTestFilePatterns()` so the
+ * detection is language-agnostic and config-driven (ADR-009).
+ *
+ * @param workdir       - Working directory to run git command in (package dir or repo root)
+ * @param repoRoot      - Absolute path to the repository root (for constructing absolute paths)
+ * @param baseRef       - Git ref for diff base (default: HEAD~1)
+ * @param packagePrefix - Story workdir relative to repo root (e.g. "packages/lib")
+ * @param testFileRegex - Regexes identifying test files (from resolveTestFilePatterns().regex)
+ * @returns Absolute paths of changed test files
+ */
+export async function getChangedTestFiles(
+  workdir: string,
+  repoRoot: string,
+  baseRef?: string,
+  packagePrefix?: string,
+  testFileRegex: RegExp[] = [],
+): Promise<string[]> {
+  if (testFileRegex.length === 0) return [];
+  try {
+    const ref = baseRef ?? "HEAD~1";
+    const { stdout, exitCode } = await gitWithTimeout(["diff", "--name-only", ref], workdir);
+    if (exitCode !== 0) return [];
+
+    const lines = stdout.trim().split("\n").filter(Boolean);
+
+    // Scope to package directory — covers both co-located (src/) and separated (test/) layouts
+    const scoped = packagePrefix ? lines.filter((f) => f.startsWith(`${packagePrefix}/`)) : lines;
+    return scoped
+      .filter((f) => testFileRegex.some((re) => re.test(f)))
+      .map((f) => join(repoRoot, f));
   } catch {
     return [];
   }
@@ -373,6 +412,7 @@ export const _smartRunnerDeps = {
   /** Wraps Bun.file — injectable for testing. */
   file: _bunDeps.file,
   getChangedSourceFiles,
+  getChangedTestFiles,
   mapSourceToTests,
   importGrepFallback,
   buildSmartTestCommand,

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -334,9 +334,7 @@ export async function getChangedTestFiles(
 
     // Scope to package directory — covers both co-located (src/) and separated (test/) layouts
     const scoped = packagePrefix ? lines.filter((f) => f.startsWith(`${packagePrefix}/`)) : lines;
-    return scoped
-      .filter((f) => testFileRegex.some((re) => re.test(f)))
-      .map((f) => join(repoRoot, f));
+    return scoped.filter((f) => testFileRegex.some((re) => re.test(f))).map((f) => join(repoRoot, f));
   } catch {
     return [];
   }

--- a/test/unit/pipeline/stages/verify.test.ts
+++ b/test/unit/pipeline/stages/verify.test.ts
@@ -15,8 +15,19 @@ import { randomUUID } from "node:crypto";
 import type { NaxConfig } from "../../../../src/config";
 import type { PRD, UserStory } from "../../../../src/prd";
 import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
+import { DEFAULT_TEST_FILE_PATTERNS, globsToTestRegex, globsToPathspec, extractTestDirs } from "../../../../src/test-runners/conventions";
+import type { ResolvedTestPatterns } from "../../../../src/test-runners/resolver";
 import type { VerificationResult } from "../../../../src/verification";
 import type { ResolvedTestCommands } from "../../../../src/quality/command-resolver";
+
+/** Pre-built fallback patterns used to mock resolveTestFilePatterns without disk access */
+const MOCK_RESOLVED_PATTERNS: ResolvedTestPatterns = {
+  globs: DEFAULT_TEST_FILE_PATTERNS,
+  pathspec: globsToPathspec(DEFAULT_TEST_FILE_PATTERNS),
+  regex: globsToTestRegex(DEFAULT_TEST_FILE_PATTERNS),
+  testDirs: extractTestDirs(DEFAULT_TEST_FILE_PATTERNS),
+  resolution: "fallback",
+};
 
 const WORKDIR = `/tmp/nax-test-verify-${randomUUID()}`;
 
@@ -117,9 +128,13 @@ describe("verifyStage - deferred mode skips per-story regression", () => {
 
     let regressionCalled = false;
     const origRegression = _verifyDeps.regression;
+    const origResolvePatterns = _verifyDeps.resolveTestFilePatterns;
+    const origGetChangedTest = _smartRunnerDeps.getChangedTestFiles;
     const origGetChanged = _smartRunnerDeps.getChangedSourceFiles;
     const origMapSource = _smartRunnerDeps.mapSourceToTests;
 
+    _verifyDeps.resolveTestFilePatterns = mock(() => Promise.resolve(MOCK_RESOLVED_PATTERNS));
+    _smartRunnerDeps.getChangedTestFiles = mock(() => Promise.resolve([]));
     _smartRunnerDeps.getChangedSourceFiles = mock(() => Promise.resolve([]));
     _smartRunnerDeps.mapSourceToTests = mock(() => Promise.resolve([]));
     _verifyDeps.regression = mock((): Promise<VerificationResult> => {
@@ -135,6 +150,8 @@ describe("verifyStage - deferred mode skips per-story regression", () => {
       expect(result.action).toBe("continue");
     } finally {
       _verifyDeps.regression = origRegression;
+      _verifyDeps.resolveTestFilePatterns = origResolvePatterns;
+      _smartRunnerDeps.getChangedTestFiles = origGetChangedTest;
       _smartRunnerDeps.getChangedSourceFiles = origGetChanged;
       _smartRunnerDeps.mapSourceToTests = origMapSource;
     }
@@ -150,9 +167,13 @@ describe("verifyStage - deferred mode skips per-story regression", () => {
 
     let regressionCalled = false;
     const origRegression = _verifyDeps.regression;
+    const origResolvePatterns = _verifyDeps.resolveTestFilePatterns;
+    const origGetChangedTest = _smartRunnerDeps.getChangedTestFiles;
     const origGetChanged = _smartRunnerDeps.getChangedSourceFiles;
     const origMapSource = _smartRunnerDeps.mapSourceToTests;
 
+    _verifyDeps.resolveTestFilePatterns = mock(() => Promise.resolve(MOCK_RESOLVED_PATTERNS));
+    _smartRunnerDeps.getChangedTestFiles = mock(() => Promise.resolve([]));
     _smartRunnerDeps.getChangedSourceFiles = mock(() => Promise.resolve([]));
     _smartRunnerDeps.mapSourceToTests = mock(() => Promise.resolve([]));
     _verifyDeps.regression = mock((): Promise<VerificationResult> => {
@@ -169,6 +190,8 @@ describe("verifyStage - deferred mode skips per-story regression", () => {
       expect(result.action).toBe("continue");
     } finally {
       _verifyDeps.regression = origRegression;
+      _verifyDeps.resolveTestFilePatterns = origResolvePatterns;
+      _smartRunnerDeps.getChangedTestFiles = origGetChangedTest;
       _smartRunnerDeps.getChangedSourceFiles = origGetChanged;
       _smartRunnerDeps.mapSourceToTests = origMapSource;
     }
@@ -184,9 +207,13 @@ describe("verifyStage - deferred mode skips per-story regression", () => {
 
     let regressionCalled = false;
     const origRegression = _verifyDeps.regression;
+    const origResolvePatterns = _verifyDeps.resolveTestFilePatterns;
+    const origGetChangedTest = _smartRunnerDeps.getChangedTestFiles;
     const origGetChanged = _smartRunnerDeps.getChangedSourceFiles;
     const origMapSource = _smartRunnerDeps.mapSourceToTests;
 
+    _verifyDeps.resolveTestFilePatterns = mock(() => Promise.resolve(MOCK_RESOLVED_PATTERNS));
+    _smartRunnerDeps.getChangedTestFiles = mock(() => Promise.resolve([]));
     _smartRunnerDeps.getChangedSourceFiles = mock(() => Promise.resolve([]));
     _smartRunnerDeps.mapSourceToTests = mock(() => Promise.resolve([]));
     _verifyDeps.regression = mock((): Promise<VerificationResult> => {
@@ -201,6 +228,8 @@ describe("verifyStage - deferred mode skips per-story regression", () => {
       expect(regressionCalled).toBe(true);
     } finally {
       _verifyDeps.regression = origRegression;
+      _verifyDeps.resolveTestFilePatterns = origResolvePatterns;
+      _smartRunnerDeps.getChangedTestFiles = origGetChangedTest;
       _smartRunnerDeps.getChangedSourceFiles = origGetChanged;
       _smartRunnerDeps.mapSourceToTests = origMapSource;
     }
@@ -216,9 +245,13 @@ describe("verifyStage - deferred mode skips per-story regression", () => {
 
     let regressionCalled = false;
     const origRegression = _verifyDeps.regression;
+    const origResolvePatterns = _verifyDeps.resolveTestFilePatterns;
+    const origGetChangedTest = _smartRunnerDeps.getChangedTestFiles;
     const origGetChanged = _smartRunnerDeps.getChangedSourceFiles;
     const origMapSource = _smartRunnerDeps.mapSourceToTests;
 
+    _verifyDeps.resolveTestFilePatterns = mock(() => Promise.resolve(MOCK_RESOLVED_PATTERNS));
+    _smartRunnerDeps.getChangedTestFiles = mock(() => Promise.resolve([]));
     _smartRunnerDeps.getChangedSourceFiles = mock(() => Promise.resolve([]));
     _smartRunnerDeps.mapSourceToTests = mock(() => Promise.resolve([]));
     _verifyDeps.regression = mock((): Promise<VerificationResult> => {
@@ -233,6 +266,8 @@ describe("verifyStage - deferred mode skips per-story regression", () => {
       expect(regressionCalled).toBe(true);
     } finally {
       _verifyDeps.regression = origRegression;
+      _verifyDeps.resolveTestFilePatterns = origResolvePatterns;
+      _smartRunnerDeps.getChangedTestFiles = origGetChangedTest;
       _smartRunnerDeps.getChangedSourceFiles = origGetChanged;
       _smartRunnerDeps.mapSourceToTests = origMapSource;
     }
@@ -247,9 +282,13 @@ describe("verifyStage - deferred mode skips per-story regression", () => {
     );
 
     const origRegression = _verifyDeps.regression;
+    const origResolvePatterns = _verifyDeps.resolveTestFilePatterns;
+    const origGetChangedTest = _smartRunnerDeps.getChangedTestFiles;
     const origGetChanged = _smartRunnerDeps.getChangedSourceFiles;
     const origMapSource = _smartRunnerDeps.mapSourceToTests;
 
+    _verifyDeps.resolveTestFilePatterns = mock(() => Promise.resolve(MOCK_RESOLVED_PATTERNS));
+    _smartRunnerDeps.getChangedTestFiles = mock(() => Promise.resolve([]));
     _smartRunnerDeps.getChangedSourceFiles = mock(() => Promise.resolve([]));
     _smartRunnerDeps.mapSourceToTests = mock(() => Promise.resolve([]));
     // regression throws to ensure it's truly not called
@@ -264,6 +303,8 @@ describe("verifyStage - deferred mode skips per-story regression", () => {
       expect(result.action).toBe("continue");
     } finally {
       _verifyDeps.regression = origRegression;
+      _verifyDeps.resolveTestFilePatterns = origResolvePatterns;
+      _smartRunnerDeps.getChangedTestFiles = origGetChangedTest;
       _smartRunnerDeps.getChangedSourceFiles = origGetChanged;
       _smartRunnerDeps.mapSourceToTests = origMapSource;
     }

--- a/test/unit/pipeline/verify-smart-runner.test.ts
+++ b/test/unit/pipeline/verify-smart-runner.test.ts
@@ -15,12 +15,22 @@ import { initLogger, resetLogger } from "../../../src/logger";
 import type { NaxConfig } from "../../../src/config";
 import type { PipelineContext } from "../../../src/pipeline/types";
 import type { PRD, UserStory } from "../../../src/prd/types";
+import { DEFAULT_TEST_FILE_PATTERNS, extractTestDirs, globsToPathspec, globsToTestRegex } from "../../../src/test-runners/conventions";
+import type { ResolvedTestPatterns } from "../../../src/test-runners/resolver";
 
 // ---- Module mocks ------------------------------------------------------------
 // We avoid mock.module() for smart-runner entirely --- it leaks across test files
 // in Bun 1.x. Instead we mutate the _smartRunnerDeps object exported by the module.
 // verify.ts accesses all smart-runner functions via _smartRunnerDeps.fn(), so
 // mutations here take effect immediately with no module registry involvement.
+
+const MOCK_RESOLVED_PATTERNS: ResolvedTestPatterns = {
+  globs: [...DEFAULT_TEST_FILE_PATTERNS],
+  pathspec: globsToPathspec([...DEFAULT_TEST_FILE_PATTERNS]),
+  regex: globsToTestRegex([...DEFAULT_TEST_FILE_PATTERNS]),
+  testDirs: extractTestDirs([...DEFAULT_TEST_FILE_PATTERNS]),
+  resolution: "fallback",
+};
 
 const mockRegression = mock(async () => ({ success: true, status: "SUCCESS" as const }));
 
@@ -33,6 +43,8 @@ const _origVerifyDeps = { ..._verifyDeps };
 
 // ---- Mock functions ---------------------------------------------------------
 
+const mockGetChangedTestFiles = mock(async () => [] as string[]);
+const mockResolveTestFilePatterns = mock(async () => MOCK_RESOLVED_PATTERNS);
 const mockGetChangedSourceFiles = mock(async (_workdir: string) => [] as string[]);
 const mockMapSourceToTests = mock(async (_files: string[], _workdir: string, _packagePrefix?: string, _patterns?: string[]) => [] as string[]);
 const mockImportGrepFallback = mock(async (_files: string[], _workdir: string, _patterns: string[]) => [] as string[]);
@@ -152,6 +164,7 @@ function makeContext(
       reasoning: "Test routing",
     },
     workdir: "/test/workdir",
+    projectDir: "/test/workdir",
     hooks: { hooks: {} },
   };
 }
@@ -161,12 +174,16 @@ function makeContext(
 describe("Verify Stage --- Smart Runner Integration", () => {
   beforeEach(() => {
     initLogger({ level: "error", useChalk: false });
+    _smartRunnerDeps.getChangedTestFiles = mockGetChangedTestFiles as typeof _smartRunnerDeps.getChangedTestFiles;
     _smartRunnerDeps.getChangedSourceFiles = mockGetChangedSourceFiles;
     _smartRunnerDeps.mapSourceToTests = mockMapSourceToTests;
     _smartRunnerDeps.importGrepFallback = mockImportGrepFallback;
     _smartRunnerDeps.buildSmartTestCommand = mockBuildSmartTestCommand;
     _verifyDeps.regression = mockRegression as typeof _verifyDeps.regression;
+    _verifyDeps.resolveTestFilePatterns = mockResolveTestFilePatterns as typeof _verifyDeps.resolveTestFilePatterns;
     mockRegression.mockClear();
+    mockGetChangedTestFiles.mockClear();
+    mockResolveTestFilePatterns.mockClear();
     mockGetChangedSourceFiles.mockClear();
     mockMapSourceToTests.mockClear();
     mockImportGrepFallback.mockClear();
@@ -205,7 +222,7 @@ describe("Verify Stage --- Smart Runner Integration", () => {
       const ctx = makeContext({ smartTestRunner: true });
       await verifyStage.execute(ctx);
 
-      expect(mockGetChangedSourceFiles).toHaveBeenCalledWith("/test/workdir", undefined, undefined);
+      expect(mockGetChangedSourceFiles).toHaveBeenCalledWith("/test/workdir", undefined, undefined, expect.any(Array));
     });
 
     test("calls mapSourceToTests with changed files, workdir, and undefined packagePrefix for single-package story", async () => {
@@ -216,7 +233,7 @@ describe("Verify Stage --- Smart Runner Integration", () => {
       const ctx = makeContext({ smartTestRunner: true });
       await verifyStage.execute(ctx);
 
-      expect(mockMapSourceToTests).toHaveBeenCalledWith(["src/utils/helper.ts"], "/test/workdir", undefined, ["test/**/*.test.ts"]);
+      expect(mockMapSourceToTests).toHaveBeenCalledWith(["src/utils/helper.ts"], "/test/workdir", undefined, expect.any(Array));
     });
 
     test("forwards story.workdir as packagePrefix to mapSourceToTests for monorepo stories", async () => {
@@ -231,7 +248,7 @@ describe("Verify Stage --- Smart Runner Integration", () => {
         ["apps/api/src/utils/helper.ts"],
         "/test/workdir",
         "apps/api",
-        ["test/**/*.test.ts"],
+        expect.any(Array),
       );
     });
 

--- a/test/unit/verification/smart-runner.test.ts
+++ b/test/unit/verification/smart-runner.test.ts
@@ -4,6 +4,7 @@ import { withDepsRestore } from "../../helpers/deps";
 import {
   buildSmartTestCommand,
   getChangedSourceFiles,
+  getChangedTestFiles,
   mapSourceToTests,
 } from "../../../src/verification/smart-runner";
 
@@ -290,5 +291,169 @@ describe("getChangedSourceFiles", () => {
     const result = await getChangedSourceFiles("/fake/repo", undefined, "packages/api");
 
     expect(result).toEqual([]);
+  });
+
+  // Issue #557 — co-located test files should be excluded when testFileRegex is provided
+  test("excludes co-located test files when testFileRegex is provided", async () => {
+    const gitOutput = [
+      "packages/lib/src/util.ts",
+      "packages/lib/src/util.test.ts",
+    ].join("\n");
+
+    // biome-ignore lint/suspicious/noExplicitAny: mocking _gitDeps
+    _gitDeps.spawn = mock(() => makeProc(gitOutput, 0)) as unknown as typeof _gitDeps.spawn;
+
+    const result = await getChangedSourceFiles("/fake/repo", undefined, "packages/lib", [/\.test\.ts$/]);
+
+    expect(result).toEqual(["packages/lib/src/util.ts"]);
+  });
+
+  test("returns all .ts files when testFileRegex is empty (backward-compatible)", async () => {
+    const gitOutput = [
+      "packages/lib/src/util.ts",
+      "packages/lib/src/util.test.ts",
+    ].join("\n");
+
+    // biome-ignore lint/suspicious/noExplicitAny: mocking _gitDeps
+    _gitDeps.spawn = mock(() => makeProc(gitOutput, 0)) as unknown as typeof _gitDeps.spawn;
+
+    const result = await getChangedSourceFiles("/fake/repo", undefined, "packages/lib");
+
+    // Without testFileRegex: both returned (existing behavior)
+    expect(result).toContain("packages/lib/src/util.ts");
+    expect(result).toContain("packages/lib/src/util.test.ts");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getChangedTestFiles — Issue #557
+// ---------------------------------------------------------------------------
+
+describe("getChangedTestFiles", () => {
+  withDepsRestore(_gitDeps, ["spawn"]);
+  afterEach(() => {
+    mock.restore();
+  });
+
+  const TS_TEST_REGEX = [/\.test\.ts$/, /\.spec\.ts$/];
+
+  test("returns absolute paths of changed co-located test files", async () => {
+    const gitOutput = [
+      "packages/lib/src/util.ts",
+      "packages/lib/src/util.test.ts",
+    ].join("\n");
+
+    // biome-ignore lint/suspicious/noExplicitAny: mocking _gitDeps
+    _gitDeps.spawn = mock(() => makeProc(gitOutput, 0)) as unknown as typeof _gitDeps.spawn;
+
+    const result = await getChangedTestFiles("/fake/repo/packages/lib", "/fake/repo", undefined, "packages/lib", TS_TEST_REGEX);
+
+    expect(result).toEqual(["/fake/repo/packages/lib/src/util.test.ts"]);
+  });
+
+  test("returns absolute paths of changed separated test files", async () => {
+    const gitOutput = [
+      "packages/lib/src/util.ts",
+      "packages/lib/test/unit/util.test.ts",
+    ].join("\n");
+
+    // biome-ignore lint/suspicious/noExplicitAny: mocking _gitDeps
+    _gitDeps.spawn = mock(() => makeProc(gitOutput, 0)) as unknown as typeof _gitDeps.spawn;
+
+    const result = await getChangedTestFiles("/fake/repo/packages/lib", "/fake/repo", undefined, "packages/lib", TS_TEST_REGEX);
+
+    expect(result).toEqual(["/fake/repo/packages/lib/test/unit/util.test.ts"]);
+  });
+
+  test("detects both co-located and separated test files in the same diff", async () => {
+    const gitOutput = [
+      "packages/lib/src/util.test.ts",
+      "packages/lib/test/unit/other.test.ts",
+    ].join("\n");
+
+    // biome-ignore lint/suspicious/noExplicitAny: mocking _gitDeps
+    _gitDeps.spawn = mock(() => makeProc(gitOutput, 0)) as unknown as typeof _gitDeps.spawn;
+
+    const result = await getChangedTestFiles("/fake/repo/packages/lib", "/fake/repo", undefined, "packages/lib", TS_TEST_REGEX);
+
+    expect(result).toHaveLength(2);
+    expect(result).toContain("/fake/repo/packages/lib/src/util.test.ts");
+    expect(result).toContain("/fake/repo/packages/lib/test/unit/other.test.ts");
+  });
+
+  test("scopes to packagePrefix — ignores test files from other packages", async () => {
+    const gitOutput = [
+      "packages/lib/src/util.test.ts",
+      "packages/app/src/index.test.ts",
+    ].join("\n");
+
+    // biome-ignore lint/suspicious/noExplicitAny: mocking _gitDeps
+    _gitDeps.spawn = mock(() => makeProc(gitOutput, 0)) as unknown as typeof _gitDeps.spawn;
+
+    const result = await getChangedTestFiles("/fake/repo/packages/lib", "/fake/repo", undefined, "packages/lib", TS_TEST_REGEX);
+
+    expect(result).toEqual(["/fake/repo/packages/lib/src/util.test.ts"]);
+  });
+
+  test("returns empty when no test files changed", async () => {
+    const gitOutput = ["packages/lib/src/util.ts"].join("\n");
+
+    // biome-ignore lint/suspicious/noExplicitAny: mocking _gitDeps
+    _gitDeps.spawn = mock(() => makeProc(gitOutput, 0)) as unknown as typeof _gitDeps.spawn;
+
+    const result = await getChangedTestFiles("/fake/repo/packages/lib", "/fake/repo", undefined, "packages/lib", TS_TEST_REGEX);
+
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty when testFileRegex is empty", async () => {
+    const gitOutput = ["packages/lib/src/util.test.ts"].join("\n");
+
+    // biome-ignore lint/suspicious/noExplicitAny: mocking _gitDeps
+    _gitDeps.spawn = mock(() => makeProc(gitOutput, 0)) as unknown as typeof _gitDeps.spawn;
+
+    const result = await getChangedTestFiles("/fake/repo/packages/lib", "/fake/repo", undefined, "packages/lib", []);
+
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty when git exits with non-zero code", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: mocking _gitDeps
+    _gitDeps.spawn = mock(() => makeProc("", 128)) as unknown as typeof _gitDeps.spawn;
+
+    const result = await getChangedTestFiles("/fake/repo", "/fake/repo", undefined, undefined, TS_TEST_REGEX);
+
+    expect(result).toEqual([]);
+  });
+
+  test("works without packagePrefix for single-package repos", async () => {
+    const gitOutput = ["src/util.ts", "test/unit/util.test.ts"].join("\n");
+
+    // biome-ignore lint/suspicious/noExplicitAny: mocking _gitDeps
+    _gitDeps.spawn = mock(() => makeProc(gitOutput, 0)) as unknown as typeof _gitDeps.spawn;
+
+    const result = await getChangedTestFiles("/repo", "/repo", undefined, undefined, TS_TEST_REGEX);
+
+    expect(result).toEqual(["/repo/test/unit/util.test.ts"]);
+  });
+
+  test("is language-agnostic — detects Go test files via regex", async () => {
+    const gitOutput = [
+      "packages/backend/pkg/auth/auth.go",
+      "packages/backend/pkg/auth/auth_test.go",
+    ].join("\n");
+
+    // biome-ignore lint/suspicious/noExplicitAny: mocking _gitDeps
+    _gitDeps.spawn = mock(() => makeProc(gitOutput, 0)) as unknown as typeof _gitDeps.spawn;
+
+    const result = await getChangedTestFiles(
+      "/repo/packages/backend",
+      "/repo",
+      undefined,
+      "packages/backend",
+      [/_test\.go$/],
+    );
+
+    expect(result).toEqual(["/repo/packages/backend/pkg/auth/auth_test.go"]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #557 — smart-runner emitting "No mapped tests" even when the agent wrote both a source file and its co-located test in the same session.

**Two root bugs:**

1. **Changed test files treated as source files.** `getChangedSourceFiles` returns `src/util.test.ts` (it passes the `.ts` + `srcPrefix` filter). That file then enters `mapSourceToTests`, which tries to find a test for `util.test.ts` → looks for `util.test.test.ts` → nothing exists → defers.

2. **`mapSourceToTests` called with wrong workdir.** After PR #559, `ctx.workdir` is the package dir (e.g. `/repo/packages/lib`). `mapSourceToTests` uses `workdir` as the repo-root anchor: `testBase = join(ctx.workdir, story.workdir)` = `/repo/packages/lib/packages/lib` (doubled) → no candidates exist.

**Fix:**

- **Pass 0 (new):** `getChangedTestFiles(workdir, repoRoot, baseRef, packagePrefix, testFileRegex)` — detects changed test files directly from git diff, scoped to the package, returned as absolute paths. Test files are already tests; no source→test mapping needed.
- **Language-agnostic via ADR-009:** classification uses `resolveTestFilePatterns(config, projectDir, story.workdir).regex` — not hardcoded patterns. Go `_test.go`, Python `_test.py`, TS `.test.ts` / `.spec.ts` all work the same way.
- **`getChangedSourceFiles` extended** with optional `testFileRegex` parameter to exclude test files (backward-compatible: empty default preserves existing behavior).
- **`mapSourceToTests` workdir fixed:** now receives `ctx.projectDir` (repo root) instead of `ctx.workdir` (package dir) in verify.ts.
- **`importGrepFallback` unchanged:** correctly uses `ctx.workdir` (package dir) for package-scoped glob scanning.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test test/unit/verification/smart-runner.test.ts` — 34 pass (12 new tests)
- [x] Full suite `bun test test/unit/verification/ test/unit/pipeline/stages/` — 650 pass
- [ ] Verify monorepo-tiny dogfood run no longer emits "No mapped tests" for US-001/US-002