### PR TITLE
fix(static-rules): improve canonical rules log clarity

### DIFF
--- a/src/context/engine/providers/static-rules.ts
+++ b/src/context/engine/providers/static-rules.ts
@@ -282,6 +282,7 @@ export class StaticRulesProvider implements IContextProvider {
           storyId: request.storyId,
           fileCount: effectiveRules.length,
           totalCanonicalRules: mergedRules.length,
+          files: effectiveRules.map((r) => canonicalRulePath(r)),
         });
 
         return { chunks, pullTools: [] };

--- a/src/context/rules/canonical-loader.ts
+++ b/src/context/rules/canonical-loader.ts
@@ -421,7 +421,7 @@ export async function loadCanonicalRules(
       (a.id ?? a.fileName).localeCompare(b.id ?? b.fileName),
   );
 
-  logger.debug("canonical-loader", "Loaded canonical rules", {
+  logger.debug("canonical-loader", "Scanned canonical rules store", {
     fileCount: rules.length,
     files: rules.map((r) => r.path),
   });


### PR DESCRIPTION
## Summary

- Renames `canonical-loader` debug message from `"Loaded canonical rules"` to `"Scanned canonical rules store"` — this message fires before the `paths:` package filter in `static-rules`, so sharing the same name with static-rules' own `"Loaded canonical rules"` message was misleading (users saw `fileCount:2` then `fileCount:1` from two messages with the same name)
- Adds `files[]` to static-rules `"Loaded canonical rules"` so the log shows exactly which rule files are applied after all filtering, not just a count

## Before

```jsonl
{"stage":"canonical-loader","message":"Loaded canonical rules","data":{"fileCount":2,"files":["core.md","lib-rules.md"]}}
{"stage":"static-rules","message":"Package-scope filter applied","data":{"total":2,"matched":1}}
{"stage":"static-rules","message":"Loaded canonical rules","data":{"fileCount":1}}
```

## After

```jsonl
{"stage":"canonical-loader","message":"Scanned canonical rules store","data":{"fileCount":2,"files":["core.md","lib-rules.md"]}}
{"stage":"static-rules","message":"Package-scope filter applied","data":{"total":2,"matched":1}}
{"stage":"static-rules","message":"Loaded canonical rules","data":{"fileCount":1,"files":["core.md"]}}
```

## Test plan

- [ ] Run with a monorepo that has `paths:`-scoped rules and confirm the log shows only the rules that apply to the current package