### PR TITLE
refactor(#529): remove legacy AgentRunOptions session fields (buildSessionName, acpSessionName, keepSessionOpen)

### DIFF
--- a/.claude/rules/adapter-wiring.md
+++ b/.claude/rules/adapter-wiring.md
@@ -76,8 +76,8 @@ Format: `nax-<hash8>-<feature>-<storyId>-<sessionRole>`
 | `"auto"` | `complete()` | Auto-approve interaction |
 | `"diagnose"` | `run()` | Acceptance failure diagnosis |
 | `"source-fix"` | `run()` | Acceptance source fix |
-| `"reviewer-semantic"` | `run()` | Semantic review session — initial call `keepSessionOpen: true` (retry needs history); `agent.closeSession()` called on all exit paths (ADR-008: session closes by end of `runReview`) |
-| `"reviewer-adversarial"` | `run()` | Adversarial review session — initial call `keepSessionOpen: true` (retry needs history); `agent.closeSession()` called on all exit paths (ADR-008: session closes by end of `runReview`) |
+| `"reviewer-semantic"` | `run()` | Semantic review session — initial call `keepOpen: true` (retry needs history); `agent.closeSession()` called on all exit paths (ADR-008: session closes by end of `runReview`) |
+| `"reviewer-adversarial"` | `run()` | Adversarial review session — initial call `keepOpen: true` (retry needs history); `agent.closeSession()` called on all exit paths (ADR-008: session closes by end of `runReview`) |
 
 ## Rule 3: Agent Resolution — CRITICAL
 

--- a/src/acceptance/fix-diagnosis.ts
+++ b/src/acceptance/fix-diagnosis.ts
@@ -6,7 +6,6 @@
  */
 
 import { resolveDefaultAgent } from "../agents";
-import { computeAcpHandle } from "../agents/acp/adapter";
 import type { AgentAdapter } from "../agents/types";
 import type { NaxConfig } from "../config";
 import { resolveConfiguredModel } from "../config";
@@ -72,8 +71,6 @@ export async function diagnoseAcceptanceFailure(
 
   const { testOutput, testFileContent, config, workdir, featureName, storyId } = options;
 
-  const sessionName = computeAcpHandle(workdir, featureName, storyId, "diagnose");
-
   const resolvedModel = resolveConfiguredModel(
     config.models,
     resolveDefaultAgent(config),
@@ -104,7 +101,6 @@ export async function diagnoseAcceptanceFailure(
       modelDef: resolvedModel.modelDef,
       timeoutSeconds,
       sessionRole: "diagnose",
-      acpSessionName: sessionName,
       featureName,
       storyId,
       config,

--- a/src/acceptance/fix-diagnosis.ts
+++ b/src/acceptance/fix-diagnosis.ts
@@ -6,7 +6,7 @@
  */
 
 import { resolveDefaultAgent } from "../agents";
-import { buildSessionName } from "../agents/acp/adapter";
+import { computeAcpHandle } from "../agents/acp/adapter";
 import type { AgentAdapter } from "../agents/types";
 import type { NaxConfig } from "../config";
 import { resolveConfiguredModel } from "../config";
@@ -72,7 +72,7 @@ export async function diagnoseAcceptanceFailure(
 
   const { testOutput, testFileContent, config, workdir, featureName, storyId } = options;
 
-  const sessionName = buildSessionName(workdir, featureName, storyId, "diagnose");
+  const sessionName = computeAcpHandle(workdir, featureName, storyId, "diagnose");
 
   const resolvedModel = resolveConfiguredModel(
     config.models,

--- a/src/acceptance/fix-executor.ts
+++ b/src/acceptance/fix-executor.ts
@@ -6,7 +6,6 @@
  */
 
 import { resolveDefaultAgent } from "../agents";
-import { computeAcpHandle } from "../agents/acp/adapter";
 import type { AgentAdapter, AgentRunOptions } from "../agents/types";
 import type { NaxConfig } from "../config";
 import { resolveConfiguredModel } from "../config";
@@ -46,8 +45,6 @@ export async function executeSourceFix(
     resolveDefaultAgent(config),
   );
 
-  const sessionName = computeAcpHandle(workdir, featureName, storyId, "source-fix");
-
   const prompt = new AcceptancePromptBuilder().buildSourceFixPrompt({
     testOutput: options.testOutput,
     diagnosisReasoning: options.diagnosis.reasoning,
@@ -64,7 +61,6 @@ export async function executeSourceFix(
     modelDef: resolvedModel.modelDef,
     timeoutSeconds,
     sessionRole: "source-fix",
-    acpSessionName: sessionName,
     featureName,
     storyId,
     config,
@@ -117,8 +113,6 @@ export async function executeTestFix(
     resolveDefaultAgent(config),
   );
 
-  const sessionName = computeAcpHandle(workdir, featureName, storyId, "test-fix");
-
   const prompt = new AcceptancePromptBuilder().buildTestFixPrompt({
     testOutput: options.testOutput,
     diagnosisReasoning: options.diagnosis.reasoning,
@@ -137,7 +131,6 @@ export async function executeTestFix(
     modelDef: resolvedModel.modelDef,
     timeoutSeconds,
     sessionRole: "test-fix",
-    acpSessionName: sessionName,
     featureName,
     storyId,
     config,

--- a/src/acceptance/fix-executor.ts
+++ b/src/acceptance/fix-executor.ts
@@ -6,7 +6,7 @@
  */
 
 import { resolveDefaultAgent } from "../agents";
-import { buildSessionName } from "../agents/acp/adapter";
+import { computeAcpHandle } from "../agents/acp/adapter";
 import type { AgentAdapter, AgentRunOptions } from "../agents/types";
 import type { NaxConfig } from "../config";
 import { resolveConfiguredModel } from "../config";
@@ -46,7 +46,7 @@ export async function executeSourceFix(
     resolveDefaultAgent(config),
   );
 
-  const sessionName = buildSessionName(workdir, featureName, storyId, "source-fix");
+  const sessionName = computeAcpHandle(workdir, featureName, storyId, "source-fix");
 
   const prompt = new AcceptancePromptBuilder().buildSourceFixPrompt({
     testOutput: options.testOutput,
@@ -117,7 +117,7 @@ export async function executeTestFix(
     resolveDefaultAgent(config),
   );
 
-  const sessionName = buildSessionName(workdir, featureName, storyId, "test-fix");
+  const sessionName = computeAcpHandle(workdir, featureName, storyId, "test-fix");
 
   const prompt = new AcceptancePromptBuilder().buildTestFixPrompt({
     testOutput: options.testOutput,

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -178,7 +178,7 @@ function resolveRegistryEntry(agentName: string): AgentRegistryEntry {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Build a deterministic ACP session name.
+ * Compute a deterministic ACP session handle.
  *
  * Format: nax-<gitRootHash8>-<featureName>-<storyId>[-<sessionRole>]
  *
@@ -186,7 +186,7 @@ function resolveRegistryEntry(agentName: string): AgentRegistryEntry {
  * cross-worktree session name collisions. Each git worktree has a distinct
  * root path, so different worktrees of the same repo get different hashes.
  */
-export function buildSessionName(
+export function computeAcpHandle(
   workdir: string,
   featureName?: string,
   storyId?: string,
@@ -438,7 +438,7 @@ export class AcpAgentAdapter implements AgentAdapter {
   }
 
   deriveSessionName(descriptor: import("../../session/types").SessionDescriptor): string {
-    return buildSessionName(descriptor.workdir, descriptor.featureName, descriptor.storyId, descriptor.role);
+    return computeAcpHandle(descriptor.workdir, descriptor.featureName, descriptor.storyId, descriptor.role);
   }
 
   buildCommand(_options: AgentRunOptions): string[] {
@@ -636,7 +636,7 @@ export class AcpAgentAdapter implements AgentAdapter {
     const sessionName =
       (options.session ? this.deriveSessionName(options.session) : undefined) ??
       options.acpSessionName ??
-      buildSessionName(options.workdir, options.featureName, options.storyId, options.sessionRole);
+      computeAcpHandle(options.workdir, options.featureName, options.storyId, options.sessionRole);
 
     // 2. Resolve permission mode from config via single source of truth.
     const resolvedPerm = resolvePermissions(options.config, options.pipelineStage ?? "run");
@@ -915,7 +915,7 @@ export class AcpAgentAdapter implements AgentAdapter {
       try {
         const completeSessionName =
           _options?.sessionName ??
-          buildSessionName(workdir ?? process.cwd(), _options?.featureName, _options?.storyId, _options?.sessionRole);
+          computeAcpHandle(workdir ?? process.cwd(), _options?.featureName, _options?.storyId, _options?.sessionRole);
         session = await client.createSession({ agentName, permissionMode, sessionName: completeSessionName });
 
         // Audit: fire-and-forget prompt write — never blocks or throws

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -630,12 +630,12 @@ export class AcpAgentAdapter implements AgentAdapter {
     const client = _acpAdapterDeps.createClient(cmdStr, options.workdir, options.timeoutSeconds, options.pidRegistry);
     await client.start();
 
-    // 1. Resolve session name: descriptor.handle > explicit acpSessionName > derived from options
+    // 1. Resolve session name: descriptor.handle > explicit sessionHandle > derived from options
     // Phase 3 (#477): crash guard and sidecar lookup removed — SessionManager owns crash recovery
     // via the CREATED/RUNNING state machine (orphan detection via sweepOrphans()).
     const sessionName =
       (options.session ? this.deriveSessionName(options.session) : undefined) ??
-      options.acpSessionName ??
+      options.sessionHandle ??
       computeAcpHandle(options.workdir, options.featureName, options.storyId, options.sessionRole);
 
     // 2. Resolve permission mode from config via single source of truth.

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -783,10 +783,10 @@ export class AcpAgentAdapter implements AgentAdapter {
     } finally {
       // 6. Cleanup — close the physical ACP session on success or session-broken.
       // On failure (any), keep session open so retry can resume with context.
-      // On success with keepSessionOpen=true, keep open so the next turn resumes context.
+      // On success with keepOpen=true, keep open so the next turn resumes context.
       // Phase 3 (#477): sidecar writes removed — SessionManager owns persistence.
       const isSessionBroken = !runState.succeeded && lastResponse?.stopReason === "error";
-      if ((runState.succeeded && !options.keepSessionOpen) || isSessionBroken) {
+      if ((runState.succeeded && !options.keepOpen) || isSessionBroken) {
         if (isSessionBroken) {
           getSafeLogger()?.debug("acp-adapter", "Closing broken session for retry", { sessionName });
         }
@@ -794,7 +794,7 @@ export class AcpAgentAdapter implements AgentAdapter {
       } else if (!runState.succeeded) {
         getSafeLogger()?.info("acp-adapter", "Keeping session open for retry", { sessionName });
       } else {
-        getSafeLogger()?.debug("acp-adapter", "Keeping session open (keepSessionOpen=true)", { sessionName });
+        getSafeLogger()?.debug("acp-adapter", "Keeping session open (keepOpen=true)", { sessionName });
       }
       await client.close().catch(() => {});
     }

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -295,7 +295,7 @@ export interface AgentAdapter {
    * Derive the protocol-specific session name for the given descriptor (Phase 1 plumbing).
    * Used by pipeline stages to obtain the handle string for sessionManager.bindHandle().
    *
-   * ACP: "nax-<hash8>-<feature>-<storyId>-<role>" (same formula as buildSessionName)
+   * ACP: "nax-<hash8>-<feature>-<storyId>-<role>" (same formula as computeAcpHandle)
    * CLI: not applicable — returns empty string.
    */
   deriveSessionName(descriptor: SessionDescriptor): string;
@@ -317,7 +317,7 @@ export interface AgentAdapter {
    * Best-effort — errors are swallowed. No-op for adapters that do not support
    * named sessions (e.g. future non-ACP adapters).
    *
-   * @param sessionName - The session name returned by buildSessionName()
+   * @param sessionName - The session name returned by computeAcpHandle()
    * @param workdir - Working directory used when the session was created
    */
   closeSession(sessionName: string, workdir: string): Promise<void>;

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -128,11 +128,11 @@ export interface AgentRunOptions {
   projectDir?: string;
   /**
    * When true, the adapter will NOT close the session after a successful run.
-   * Use this for rectification loops where the same session must persist across
-   * multiple attempts so the agent retains full conversation context.
-   * The caller is responsible for closing the session when the loop is done.
+   * Use for multi-attempt loops (rectification, review) where the same session
+   * must persist across calls so the agent retains conversation context.
+   * The caller is responsible for closing the session when the loop ends.
    */
-  keepSessionOpen?: boolean;
+  keepOpen?: boolean;
   /** Context-engine pull tools to expose for this run (ACP text-tool protocol). */
   contextPullTools?: ToolDescriptor[];
   /** Server-side runtime for resolving context-engine pull tool calls. */
@@ -318,7 +318,7 @@ export interface AgentAdapter {
 
   /**
    * @deprecated Phase 3 (#477): use closePhysicalSession() instead.
-   * Close a named session that was kept open with keepSessionOpen: true.
+   * Close a named session that was kept open with keepOpen: true.
    * Best-effort — errors are swallowed. No-op for adapters that do not support
    * named sessions (e.g. future non-ACP adapters).
    *

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -101,8 +101,13 @@ export interface AgentRunOptions {
   };
   /** PID registry for cleanup on crash/SIGTERM */
   pidRegistry?: import("../execution/pid-registry").PidRegistry;
-  /** ACP session name to resume for plan→run session continuity */
-  acpSessionName?: string;
+  /**
+   * Explicit ACP session handle override. When set, the adapter uses this
+   * name instead of auto-deriving from featureName/storyId/sessionRole.
+   * Use only when a non-standard session name is required (e.g. generation-scoped
+   * reviewer sessions in dialogue.ts). Most callers should omit this field.
+   */
+  sessionHandle?: string;
   /** Feature name for ACP session naming and logging */
   featureName?: string;
   /** Story ID for ACP session naming and logging */
@@ -137,7 +142,7 @@ export interface AgentRunOptions {
   /**
    * Session descriptor from SessionManager (Phase 1 plumbing — optional for backward compat).
    * When provided, the adapter MAY use descriptor.id/role/handle for audit correlation.
-   * Phase 5.5: replaces acpSessionName, featureName, storyId, sessionRole, keepSessionOpen.
+   * Phase 5.5: replaces sessionHandle, featureName, storyId, sessionRole, keepOpen.
    */
   session?: SessionDescriptor;
 }

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -1,5 +1,5 @@
 import { resolveDefaultAgent } from "../agents";
-import { buildSessionName } from "../agents/acp/adapter";
+import { computeAcpHandle } from "../agents/acp/adapter";
 import { createAgentRegistry, getAgent } from "../agents/registry";
 import type { AgentAdapter, CompleteOptions, CompleteResult } from "../agents/types";
 import type { ModelTier, NaxConfig, ResolvedConfiguredModel } from "../config";
@@ -305,7 +305,7 @@ export async function resolveOutcome(
       const configDefaultAgent =
         config?.agent?.default ?? config?.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent;
       const synthesisSessionName =
-        workdir !== undefined ? buildSessionName(workdir, featureName, storyId, "synthesis") : undefined;
+        workdir !== undefined ? computeAcpHandle(workdir, featureName, storyId, "synthesis") : undefined;
       const resolverDebater: Debater = { agent: agentName, model: resolverConfig.model };
       const resolverSelection = { agent: agentName, model: resolverConfig.model ?? "fast" };
       let resolvedResolverModel: ResolvedConfiguredModel;
@@ -350,7 +350,7 @@ export async function resolveOutcome(
     const configDefaultAgent =
       config?.agent?.default ?? config?.autoMode?.defaultAgent ?? DEFAULT_CONFIG.autoMode.defaultAgent;
     const judgeSessionName =
-      workdir !== undefined ? buildSessionName(workdir, featureName, storyId, "judge") : undefined;
+      workdir !== undefined ? computeAcpHandle(workdir, featureName, storyId, "judge") : undefined;
     const resolverDebater: Debater = { agent: agentName, model: resolverConfig.model };
     const resolverSelection = { agent: agentName, model: resolverConfig.model ?? "fast" };
     let resolvedResolverModel: ResolvedConfiguredModel;

--- a/src/debate/session-hybrid.ts
+++ b/src/debate/session-hybrid.ts
@@ -121,7 +121,7 @@ export async function runRebuttalLoop(
  * Run a hybrid-mode debate session.
  *
  * Proposal phase: all debaters run in parallel via allSettledBounded with
- * sessionRole 'debate-hybrid-{debaterIndex}' and keepSessionOpen: true.
+ * sessionRole 'debate-hybrid-{debaterIndex}' and keepOpen: true.
  * If fewer than 2 proposals succeed, returns the single-agent fallback result.
  * Rebuttal loop delegates to runRebuttalLoop() (SSOT).
  *

--- a/src/debate/session-stateful.ts
+++ b/src/debate/session-stateful.ts
@@ -44,7 +44,7 @@ export async function runStatefulTurn(
   debater: Debater,
   prompt: string,
   roleKey: string,
-  keepSessionOpen: boolean,
+  keepOpen: boolean,
 ): Promise<SuccessfulProposal> {
   const modelTier = modelTierFromDebater(debater);
   const modelDef: ModelDef = resolveModelDefForDebater(debater, modelTier, ctx.config);
@@ -63,7 +63,7 @@ export async function runStatefulTurn(
     storyId: ctx.storyId,
     sessionRole: roleKey,
     maxInteractionTurns: ctx.config?.agent?.maxInteractionTurns,
-    keepSessionOpen,
+    keepOpen,
   });
 
   if (!runResult.success) {
@@ -102,7 +102,7 @@ export async function closeStatefulSession(
     storyId: ctx.storyId,
     sessionRole: roleKey,
     maxInteractionTurns: ctx.config?.agent?.maxInteractionTurns,
-    keepSessionOpen: false,
+    keepOpen: false,
   });
 
   return runResult.success ? runResult.estimatedCost : 0;

--- a/src/execution/merge-conflict-rectify.ts
+++ b/src/execution/merge-conflict-rectify.ts
@@ -104,11 +104,11 @@ export async function rectifyConflictedStory(options: RectifyConflictedStoryOpti
     const worktreePath = path.join(workdir, ".nax-wt", storyId);
 
     // BUG-122: Close stale ACP session from the original failed run before re-running.
-    // buildSessionName hashes the workdir path — same worktree path = same session name.
+    // computeAcpHandle hashes the workdir path — same worktree path = same session name.
     // The old Claude process may still be registered in acpx, causing prompt() to exit
     // with code 4 immediately. Close it explicitly so ensureAcpSession creates fresh.
-    const { buildSessionName } = await import("../agents/acp/adapter");
-    const staleSessionName = buildSessionName(worktreePath, prd.feature, storyId);
+    const { computeAcpHandle } = await import("../agents/acp/adapter");
+    const staleSessionName = computeAcpHandle(worktreePath, prd.feature, storyId);
     await closeStaleAcpSession(worktreePath, staleSessionName);
 
     // Step 3: Re-run the story pipeline

--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -6,7 +6,7 @@
  * findings by file scope and route test-file findings to a test-writer session.
  */
 
-import { buildSessionName } from "../../agents/acp/adapter";
+import { computeAcpHandle } from "../../agents/acp/adapter";
 import type { createAgentRegistry } from "../../agents/registry";
 import { resolveModelForAgent } from "../../config";
 import { resolvePermissions } from "../../config/permissions";
@@ -71,7 +71,7 @@ export async function runTestWriterRectification(
     logger.warn("autofix", "Agent not found — skipping test-writer rectification", { storyId: ctx.story.id });
     return 0;
   }
-  const testWriterSession = buildSessionName(ctx.workdir, ctx.prd.feature, ctx.story.id, "test-writer");
+  const testWriterSession = computeAcpHandle(ctx.workdir, ctx.prd.feature, ctx.story.id, "test-writer");
   const twPrompt = RectifierPromptBuilder.testWriterRectification(testWriterChecks, story);
   // Use the TDD test-writer tier from config — consistent with how the TDD orchestrator
   // selects the tier for the test-writer session (tdd.orchestrator.ts:150).

--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -6,7 +6,6 @@
  * findings by file scope and route test-file findings to a test-writer session.
  */
 
-import { computeAcpHandle } from "../../agents/acp/adapter";
 import type { createAgentRegistry } from "../../agents/registry";
 import { resolveModelForAgent } from "../../config";
 import { resolvePermissions } from "../../config/permissions";
@@ -71,7 +70,6 @@ export async function runTestWriterRectification(
     logger.warn("autofix", "Agent not found — skipping test-writer rectification", { storyId: ctx.story.id });
     return 0;
   }
-  const testWriterSession = computeAcpHandle(ctx.workdir, ctx.prd.feature, ctx.story.id, "test-writer");
   const twPrompt = RectifierPromptBuilder.testWriterRectification(testWriterChecks, story);
   // Use the TDD test-writer tier from config — consistent with how the TDD orchestrator
   // selects the tier for the test-writer session (tdd.orchestrator.ts:150).
@@ -92,7 +90,6 @@ export async function runTestWriterRectification(
       featureName: ctx.prd.feature,
       storyId: ctx.story.id,
       sessionRole: "test-writer",
-      acpSessionName: testWriterSession,
       keepSessionOpen: keepOpen,
     });
     return twResult.estimatedCost ?? 0;

--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -90,7 +90,7 @@ export async function runTestWriterRectification(
       featureName: ctx.prd.feature,
       storyId: ctx.story.id,
       sessionRole: "test-writer",
-      keepSessionOpen: keepOpen,
+      keepOpen,
     });
     return twResult.estimatedCost ?? 0;
   } catch {

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -512,7 +512,6 @@ async function runAgentRectification(
           featureName: ctx.prd.feature,
           storyId: ctx.story.id,
           sessionRole: "implementer",
-          acpSessionName: implementerSession,
           keepSessionOpen: !isLastAttempt,
         });
         sessionConfirmedOpen = true;

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -19,7 +19,7 @@
  * - `escalate`                 — max attempts exhausted or agent unavailable
  */
 
-import { buildSessionName } from "../../agents/acp/adapter";
+import { computeAcpHandle } from "../../agents/acp/adapter";
 import { createAgentRegistry } from "../../agents/registry";
 import { resolveModelForAgent } from "../../config";
 import type { NaxConfig } from "../../config";
@@ -410,7 +410,7 @@ async function runAgentRectification(
   // Session continuity: the implementer session is open only on the very first autofix call
   // (consumed === 0). On subsequent cycles (after a review retry), the previous loop's last
   // runAttempt used keepSessionOpen: false, so the session was closed before we re-enter.
-  const implementerSession = buildSessionName(ctx.workdir, ctx.prd.feature, ctx.story.id, "implementer");
+  const implementerSession = computeAcpHandle(ctx.workdir, ctx.prd.feature, ctx.story.id, "implementer");
   let sessionConfirmedOpen = consumed === 0;
 
   const succeeded = await runSharedRectificationLoop({

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -409,7 +409,7 @@ async function runAgentRectification(
 
   // Session continuity: the implementer session is open only on the very first autofix call
   // (consumed === 0). On subsequent cycles (after a review retry), the previous loop's last
-  // runAttempt used keepSessionOpen: false, so the session was closed before we re-enter.
+  // runAttempt used keepOpen: false, so the session was closed before we re-enter.
   const implementerSession = computeAcpHandle(ctx.workdir, ctx.prd.feature, ctx.story.id, "implementer");
   let sessionConfirmedOpen = consumed === 0;
 
@@ -512,7 +512,7 @@ async function runAgentRectification(
           featureName: ctx.prd.feature,
           storyId: ctx.story.id,
           sessionRole: "implementer",
-          keepSessionOpen: !isLastAttempt,
+          keepOpen: !isLastAttempt,
         });
         sessionConfirmedOpen = true;
       } catch (err) {

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -143,9 +143,7 @@ export const executionStage: PipelineStage = {
     }
 
     // Determine whether to keep session open for review or rectification
-    const keepSessionOpen = !!(
-      ctx.config.review?.enabled === true || ctx.config.execution.rectification?.enabled === true
-    );
+    const keepOpen = !!(ctx.config.review?.enabled === true || ctx.config.execution.rectification?.enabled === true);
 
     // G1: Advance state machine to RUNNING so resume() / listActive() see accurate state.
     // Guarded — ctx.sessionId may not have a manager entry when v2 context is disabled.
@@ -189,7 +187,7 @@ export const executionStage: PipelineStage = {
       featureName: ctx.prd.feature,
       storyId: ctx.story.id,
       sessionRole: "implementer",
-      keepSessionOpen,
+      keepOpen,
       // G3: pass descriptor so adapter uses it for session name derivation (Phase 1+).
       // Backward-compatible — featureName/storyId/sessionRole kept as fallback.
       ...(sessionDescriptor && { session: sessionDescriptor }),
@@ -357,7 +355,7 @@ export const executionStage: PipelineStage = {
             featureName: ctx.prd.feature,
             storyId: ctx.story.id,
             sessionRole: "implementer",
-            keepSessionOpen,
+            keepOpen,
             ...(handoffSession && { session: handoffSession }),
             contextPullTools: workingBundle.pullTools,
             contextToolRuntime: createContextToolRuntime({

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -13,7 +13,7 @@
  *   - Findings carry a `category` field (input, error-path, abandonment, etc.).
  */
 
-import { buildSessionName } from "../agents/acp/adapter";
+import { computeAcpHandle } from "../agents/acp/adapter";
 import type { AgentAdapter } from "../agents/types";
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
@@ -265,7 +265,7 @@ export async function runAdversarialReview(
   }
 
   // Adversarial review uses its own session (NOT the implementer session).
-  const adversarialSessionName = buildSessionName(workdir, featureName, story.id, "reviewer-adversarial");
+  const adversarialSessionName = computeAcpHandle(workdir, featureName, story.id, "reviewer-adversarial");
   const contextToolStory: UserStory = {
     id: story.id,
     title: story.title,

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -281,7 +281,6 @@ export async function runAdversarialReview(
 
   const runOpts = {
     workdir,
-    acpSessionName: adversarialSessionName,
     timeoutSeconds: adversarialConfig.timeoutMs ? Math.ceil(adversarialConfig.timeoutMs / 1000) : 600,
     modelTier: adversarialConfig.modelTier,
     modelDef: resolvedModelDef,

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -304,10 +304,10 @@ export async function runAdversarialReview(
   let llmCost = 0;
   let retryAttempted = false;
   try {
-    // keepSessionOpen: true — session stays alive so the JSON retry prompt has
+    // keepOpen: true — session stays alive so the JSON retry prompt has
     // full conversation history. Closed explicitly below on the happy path, or
-    // by the retry call (keepSessionOpen: false) when a retry is needed.
-    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: true });
+    // by the retry call (keepOpen: false) when a retry is needed.
+    const runResult = await agent.run({ prompt, ...runOpts, keepOpen: true });
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;
     logger?.debug("adversarial", "LLM call complete", {
@@ -344,7 +344,7 @@ export async function runAdversarialReview(
       const retryResult = await agent.run({
         prompt: ReviewPromptBuilder.jsonRetry(),
         ...runOpts,
-        keepSessionOpen: false,
+        keepOpen: false,
       });
       rawResponse = retryResult.output;
       llmCost += retryResult.estimatedCost ?? 0;
@@ -360,7 +360,7 @@ export async function runAdversarialReview(
   }
 
   // Close the session — covers both the happy path (no retry) and the retry-exhausted
-  // path (retry threw or returned unparseable JSON, so keepSessionOpen: false on the
+  // path (retry threw or returned unparseable JSON, so keepOpen: false on the
   // retry call may not have closed it). Best-effort: already-closed sessions no-op.
   void agent.closePhysicalSession(adversarialSessionName, workdir);
 

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -1,7 +1,7 @@
 /**
  * Reviewer-Implementer Dialogue
  *
- * Maintains a persistent reviewer session via agent.run() with keepSessionOpen: true.
+ * Maintains a persistent reviewer session via agent.run() with keepOpen: true.
  * The reviewer holds full conversation context across multiple review() calls.
  */
 
@@ -306,7 +306,7 @@ export function createReviewerSession(
         modelDef,
         timeoutSeconds,
         sessionRole: "reviewer",
-        keepSessionOpen: true,
+        keepOpen: true,
         pipelineStage: "review",
         config: _config,
         storyId,
@@ -352,7 +352,7 @@ export function createReviewerSession(
         modelDef,
         timeoutSeconds,
         sessionRole: "reviewer",
-        keepSessionOpen: true,
+        keepOpen: true,
         pipelineStage: "review",
         config: _config,
         storyId,
@@ -412,7 +412,7 @@ export function createReviewerSession(
         modelDef,
         timeoutSeconds,
         sessionRole: "reviewer",
-        keepSessionOpen: true,
+        keepOpen: true,
         pipelineStage: "review",
         config: _config,
         storyId,
@@ -452,7 +452,7 @@ export function createReviewerSession(
         modelDef,
         timeoutSeconds,
         sessionRole: "reviewer",
-        keepSessionOpen: true,
+        keepOpen: true,
         pipelineStage: "review",
         config: _config,
         storyId,
@@ -510,7 +510,7 @@ export function createReviewerSession(
         modelDef,
         timeoutSeconds,
         sessionRole: "reviewer",
-        keepSessionOpen: true,
+        keepOpen: true,
         pipelineStage: "review",
         config: _config,
         storyId,

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -229,7 +229,7 @@ export function createReviewerSession(
    * Tracks session lifecycle for compaction-triggered resets.
    * - generation: incremented each time history overflow causes a session reset.
    * - pendingCompactionContext: when non-null, the next agent.run() call must
-   *   inject this compacted context as initial context and use a new acpSessionName
+   *   inject this compacted context as initial context and use a new sessionHandle
    *   to start a fresh session (satisfying AC4 session destruction + recreation).
    */
   const sessionState = {
@@ -253,26 +253,26 @@ export function createReviewerSession(
   }
 
   /**
-   * Builds the effective prompt and acpSessionName for an agent.run() call.
+   * Builds the effective prompt and sessionHandle for an agent.run() call.
    *
    * When a compaction reset occurred (pendingCompactionContext is set), the
    * compacted context is prepended to the prompt so the fresh session receives
    * the full prior conversation summary as initial context (AC4).
-   * acpSessionName is set to a generation-scoped name so the adapter creates
+   * sessionHandle is set to a generation-scoped name so the adapter creates
    * a new session rather than reusing the previous one.
    */
-  function buildEffectiveRunArgs(prompt: string): { effectivePrompt: string; acpSessionName: string | undefined } {
+  function buildEffectiveRunArgs(prompt: string): { effectivePrompt: string; sessionHandle: string | undefined } {
     if (sessionState.pendingCompactionContext !== null) {
       const context = sessionState.pendingCompactionContext;
       sessionState.pendingCompactionContext = null;
       return {
         effectivePrompt: `${context}\n\n---\n\n${prompt}`,
-        acpSessionName: `nax-reviewer-${storyId}-gen${sessionState.generation}`,
+        sessionHandle: `nax-reviewer-${storyId}-gen${sessionState.generation}`,
       };
     }
-    const acpSessionName =
+    const sessionHandle =
       sessionState.generation > 1 ? `nax-reviewer-${storyId}-gen${sessionState.generation}` : undefined;
-    return { effectivePrompt: prompt, acpSessionName };
+    return { effectivePrompt: prompt, sessionHandle };
   }
 
   return {
@@ -297,7 +297,7 @@ export function createReviewerSession(
 
       const prompt = promptBuilder.buildReviewPrompt(diff, story);
       const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(semanticConfig);
-      const { effectivePrompt, acpSessionName } = buildEffectiveRunArgs(prompt);
+      const { effectivePrompt, sessionHandle } = buildEffectiveRunArgs(prompt);
 
       const result = await agent.run({
         prompt: effectivePrompt,
@@ -311,7 +311,7 @@ export function createReviewerSession(
         config: _config,
         storyId,
         featureName,
-        acpSessionName,
+        sessionHandle,
       });
 
       history.push({ role: "implementer", content: prompt });
@@ -343,7 +343,7 @@ export function createReviewerSession(
       const previousFindings = lastCheckResult.checkResult.findings;
       const prompt = promptBuilder.buildReReviewPrompt(updatedDiff, previousFindings);
       const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(lastSemanticConfig);
-      const { effectivePrompt, acpSessionName } = buildEffectiveRunArgs(prompt);
+      const { effectivePrompt, sessionHandle } = buildEffectiveRunArgs(prompt);
 
       const result = await agent.run({
         prompt: effectivePrompt,
@@ -357,7 +357,7 @@ export function createReviewerSession(
         config: _config,
         storyId,
         featureName,
-        acpSessionName,
+        sessionHandle,
       });
 
       history.push({ role: "implementer", content: prompt });
@@ -374,7 +374,7 @@ export function createReviewerSession(
         // compactHistory() returns the summary string; store it so the next
         // agent.run() call injects it as initial context for the new session.
         // Incrementing sessionState.generation causes buildEffectiveRunArgs()
-        // to use a new acpSessionName, which forces the adapter to create a
+        // to use a new sessionHandle, which forces the adapter to create a
         // fresh session rather than resuming the previous one.
         const compactedSummary = compactHistory(history);
         sessionState.generation++;
@@ -403,7 +403,7 @@ export function createReviewerSession(
           excludePatterns: [],
         } as SemanticReviewConfig);
       const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(effectiveSemanticConfig);
-      const { effectivePrompt, acpSessionName } = buildEffectiveRunArgs(question);
+      const { effectivePrompt, sessionHandle } = buildEffectiveRunArgs(question);
 
       const result = await agent.run({
         prompt: effectivePrompt,
@@ -417,7 +417,7 @@ export function createReviewerSession(
         config: _config,
         storyId,
         featureName,
-        acpSessionName,
+        sessionHandle,
       });
 
       history.push({ role: "implementer", content: question });
@@ -443,7 +443,7 @@ export function createReviewerSession(
 
       const prompt = promptBuilder.buildResolverPrompt(proposals, critiques, diffContext, story, resolverContext);
       const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(semanticConfig);
-      const { effectivePrompt, acpSessionName } = buildEffectiveRunArgs(prompt);
+      const { effectivePrompt, sessionHandle } = buildEffectiveRunArgs(prompt);
 
       const result = await agent.run({
         prompt: effectivePrompt,
@@ -457,7 +457,7 @@ export function createReviewerSession(
         config: _config,
         storyId,
         featureName,
-        acpSessionName,
+        sessionHandle,
       });
 
       history.push({ role: "implementer", content: prompt });
@@ -501,7 +501,7 @@ export function createReviewerSession(
         resolverContext,
       );
       const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(lastSemanticConfig);
-      const { effectivePrompt, acpSessionName } = buildEffectiveRunArgs(prompt);
+      const { effectivePrompt, sessionHandle } = buildEffectiveRunArgs(prompt);
 
       const result = await agent.run({
         prompt: effectivePrompt,
@@ -515,7 +515,7 @@ export function createReviewerSession(
         config: _config,
         storyId,
         featureName,
-        acpSessionName,
+        sessionHandle,
       });
 
       history.push({ role: "implementer", content: prompt });

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -432,7 +432,6 @@ export async function runSemanticReview(
 
   const runOpts = {
     workdir,
-    acpSessionName: reviewerSessionName,
     timeoutSeconds: semanticConfig.timeoutMs ? Math.ceil(semanticConfig.timeoutMs / 1000) : 3600,
     modelTier: semanticConfig.modelTier,
     modelDef: resolvedModelDef,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -455,10 +455,10 @@ export async function runSemanticReview(
   let llmCost = 0;
   let retryAttempted = false;
   try {
-    // keepSessionOpen: true — session stays alive so the JSON retry prompt has
+    // keepOpen: true — session stays alive so the JSON retry prompt has
     // full conversation history. Closed explicitly below on the happy path, or
-    // by the retry call (keepSessionOpen: false) when a retry is needed.
-    const runResult = await agent.run({ prompt, ...runOpts, keepSessionOpen: true });
+    // by the retry call (keepOpen: false) when a retry is needed.
+    const runResult = await agent.run({ prompt, ...runOpts, keepOpen: true });
     rawResponse = runResult.output;
     llmCost = runResult.estimatedCost ?? 0;
     logger?.debug("semantic", "LLM call complete", {
@@ -492,7 +492,7 @@ export async function runSemanticReview(
       const retryResult = await agent.run({
         prompt: ReviewPromptBuilder.jsonRetry(),
         ...runOpts,
-        keepSessionOpen: false,
+        keepOpen: false,
       });
       rawResponse = retryResult.output;
       llmCost += retryResult.estimatedCost ?? 0;
@@ -508,7 +508,7 @@ export async function runSemanticReview(
   }
 
   // Close the session — covers both the happy path (no retry) and the retry-exhausted
-  // path (retry threw or returned unparseable JSON, so keepSessionOpen: false on the
+  // path (retry threw or returned unparseable JSON, so keepOpen: false on the
   // retry call may not have closed it). Best-effort: already-closed sessions no-op.
   void agent.closePhysicalSession(reviewerSessionName, workdir);
 

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -7,7 +7,7 @@
  * is handled by lint/typecheck, not semantic review.
  */
 
-import { buildSessionName } from "../agents/acp/adapter";
+import { computeAcpHandle } from "../agents/acp/adapter";
 import type { AgentAdapter } from "../agents/types";
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
@@ -407,7 +407,7 @@ export async function runSemanticReview(
   // Call LLM via agent.run() with own reviewer session (not the implementer session).
   // The reviewer works from diff + tools, not from implementer conversation history.
   // See #414: supersedes #262 US-003 session-sharing design.
-  const reviewerSessionName = buildSessionName(workdir, featureName, story.id, "reviewer-semantic");
+  const reviewerSessionName = computeAcpHandle(workdir, featureName, story.id, "reviewer-semantic");
   const contextToolStory: UserStory = {
     id: story.id,
     title: story.title,

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -77,7 +77,7 @@ export const _sessionManagerDeps = {
  *      protocolIds extracted from AgentResult (Phase 0: best-effort)
  *
  * This means the manager tracks sessions but is not yet the authority
- * for session naming — the adapter still uses buildSessionName() internally.
+ * for session naming — the adapter still uses computeAcpHandle() internally.
  */
 export class SessionManager implements ISessionManager {
   private readonly _sessions = new Map<string, SessionDescriptor>();

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -66,8 +66,8 @@ export type SessionRole =
   | "auto" // Auto-approve interaction (complete())
   | "diagnose" // Acceptance failure diagnosis (run())
   | "source-fix" // Acceptance source fix (run())
-  | "reviewer-semantic" // Semantic review — keepSessionOpen: true
-  | "reviewer-adversarial"; // Adversarial review — keepSessionOpen: true
+  | "reviewer-semantic" // Semantic review — keepOpen: true
+  | "reviewer-adversarial"; // Adversarial review — keepOpen: true
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Protocol IDs

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -8,7 +8,7 @@
 
 import type { AgentAdapter } from "../agents";
 import { resolveDefaultAgent } from "../agents";
-import { buildSessionName } from "../agents/acp/adapter";
+import { computeAcpHandle } from "../agents/acp/adapter";
 import type { ModelTier, NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config";
 import { resolvePermissions } from "../config/permissions";
@@ -162,7 +162,7 @@ async function runRectificationLoop(
 
   // Build session name once so all rectification attempts share the same ACP session.
   // This preserves full conversation context across retries (the agent knows what it already tried).
-  const rectificationSessionName = buildSessionName(workdir, featureName, story.id, "implementer");
+  const rectificationSessionName = computeAcpHandle(workdir, featureName, story.id, "implementer");
   logger.debug("tdd", "Rectification session name (shared across all attempts)", {
     storyId: story.id,
     sessionName: rectificationSessionName,

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -231,7 +231,6 @@ async function runRectificationLoop(
         featureName,
         storyId: story.id,
         sessionRole: "implementer",
-        acpSessionName: rectificationSessionName,
         keepSessionOpen: !isLastAttempt,
       });
 

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -231,7 +231,7 @@ async function runRectificationLoop(
         featureName,
         storyId: story.id,
         sessionRole: "implementer",
-        keepSessionOpen: !isLastAttempt,
+        keepOpen: !isLastAttempt,
       });
 
       if (!rectifyResult.success && rectifyResult.pid) {

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -50,7 +50,7 @@ export const _sessionRunnerDeps = {
         featureContextMarkdown?: string,
       ) => Promise<string>),
 };
-import { buildSessionName } from "../agents/acp/adapter";
+import { computeAcpHandle } from "../agents/acp/adapter";
 import type { IsolationCheck } from "./types";
 import type { TddSessionResult, TddSessionRole } from "./types";
 
@@ -212,7 +212,7 @@ export async function runTddSession(
   // return a stale name from a prior run, causing the implementer to resume the wrong session
   // and breaking session continuity with the TDD gate and autofix. (ADR-008)
   const acpSessionName =
-    role === "implementer" && featureName ? buildSessionName(workdir, featureName, story.id, "implementer") : undefined;
+    role === "implementer" && featureName ? computeAcpHandle(workdir, featureName, story.id, "implementer") : undefined;
 
   // Run the agent
   const result = await agent.run({

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -204,7 +204,7 @@ export async function runTddSession(
   // The rectification gate uses the same session name and will resume it directly — so
   // the implementer retains full context of what it built.
   // The session sweep (or the last rectification attempt) handles final cleanup.
-  const keepSessionOpen = role === "implementer" && (config.execution.rectification?.enabled ?? false);
+  const keepOpen = role === "implementer" && (config.execution.rectification?.enabled ?? false);
 
   // Run the agent
   const result = await agent.run({
@@ -226,7 +226,7 @@ export async function runTddSession(
     featureName,
     storyId: story.id,
     sessionRole: role,
-    keepSessionOpen,
+    keepOpen,
     contextPullTools: contextBundle?.pullTools,
     contextToolRuntime: contextBundle
       ? createContextToolRuntime({

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -50,7 +50,6 @@ export const _sessionRunnerDeps = {
         featureContextMarkdown?: string,
       ) => Promise<string>),
 };
-import { computeAcpHandle } from "../agents/acp/adapter";
 import type { IsolationCheck } from "./types";
 import type { TddSessionResult, TddSessionRole } from "./types";
 
@@ -207,13 +206,6 @@ export async function runTddSession(
   // The session sweep (or the last rectification attempt) handles final cleanup.
   const keepSessionOpen = role === "implementer" && (config.execution.rectification?.enabled ?? false);
 
-  // Pin the implementer to an explicit session name derived from the same formula used by
-  // rectification-gate.ts. Without this, the adapter falls through to the sidecar which may
-  // return a stale name from a prior run, causing the implementer to resume the wrong session
-  // and breaking session continuity with the TDD gate and autofix. (ADR-008)
-  const acpSessionName =
-    role === "implementer" && featureName ? computeAcpHandle(workdir, featureName, story.id, "implementer") : undefined;
-
   // Run the agent
   const result = await agent.run({
     prompt,
@@ -234,7 +226,6 @@ export async function runTddSession(
     featureName,
     storyId: story.id,
     sessionRole: role,
-    acpSessionName,
     keepSessionOpen,
     contextPullTools: contextBundle?.pullTools,
     contextToolRuntime: contextBundle

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -8,7 +8,7 @@
  */
 
 import { getAgent as _getAgent, resolveDefaultAgent } from "../agents";
-import { buildSessionName } from "../agents/acp/adapter";
+import { computeAcpHandle } from "../agents/acp/adapter";
 import { estimateCostByDuration } from "../agents/cost";
 import { createAgentRegistry } from "../agents/registry";
 import type { AgentAdapter } from "../agents/types";
@@ -165,7 +165,7 @@ export async function runRectificationLoop(
   };
 
   let costAccum = 0;
-  const rectificationSessionName = buildSessionName(workdir, featureName, story.id, "implementer");
+  const rectificationSessionName = computeAcpHandle(workdir, featureName, story.id, "implementer");
 
   const succeeded = await runSharedRectificationLoop({
     stage: "rectification",

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -270,7 +270,7 @@ export async function runRectificationLoop(
         featureName,
         storyId: story.id,
         sessionRole: "implementer",
-        keepSessionOpen: !isLastAttempt,
+        keepOpen: !isLastAttempt,
       });
 
       costAccum += agentResult.estimatedCost ?? 0;

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -270,7 +270,6 @@ export async function runRectificationLoop(
         featureName,
         storyId: story.id,
         sessionRole: "implementer",
-        acpSessionName: rectificationSessionName,
         keepSessionOpen: !isLastAttempt,
       });
 

--- a/test/unit/acceptance/fix-diagnosis.test.ts
+++ b/test/unit/acceptance/fix-diagnosis.test.ts
@@ -4,7 +4,7 @@
  * Covers acceptance criteria:
  * 1. Receives agent adapter via parameter (never calls bare getAgent())
  * 2. Calls agent.run() with sessionRole 'diagnose'
- * 3. Session name follows pattern via buildSessionName()
+ * 3. Session name follows pattern via computeAcpHandle()
  * 4. Resolves diagnoseModel via resolveModelForAgent()
  * 5. Auto-detects source files from import statements
  * 6. Parses DiagnosisResult JSON from agent output
@@ -17,7 +17,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { diagnoseAcceptanceFailure } from "../../../src/acceptance/fix-diagnosis";
 import type { DiagnosisResult } from "../../../src/acceptance/types";
-import { buildSessionName } from "../../../src/agents/acp/adapter";
+import { computeAcpHandle } from "../../../src/agents/acp/adapter";
 import type { AgentAdapter, AgentResult } from "../../../src/agents/types";
 import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import type { NaxConfig } from "../../../src/config/schema";
@@ -163,14 +163,14 @@ describe("AC-2: diagnoseAcceptanceFailure calls agent.run() with sessionRole dia
 // ---------------------------------------------------------------------------
 
 describe("AC-3: Session name follows nax-<hash>-<feature>-<storyId>-diagnose pattern", () => {
-  test("buildSessionName returns correct pattern for diagnose session", () => {
-    const sessionName = buildSessionName("/tmp/test-workdir", "my-feature", "US-001", "diagnose");
+  test("computeAcpHandle returns correct pattern for diagnose session", () => {
+    const sessionName = computeAcpHandle("/tmp/test-workdir", "my-feature", "US-001", "diagnose");
     const hash = createHash("sha256").update("/tmp/test-workdir").digest("hex").slice(0, 8);
     expect(sessionName).toBe(`nax-${hash}-my-feature-us-001-diagnose`);
     expect(sessionName).toMatch(/^nax-[a-f0-9]+-.+-\d+-diagnose$/);
   });
 
-  test("diagnoseAcceptanceFailure uses buildSessionName with 'diagnose' role", async () => {
+  test("diagnoseAcceptanceFailure passes featureName, storyId, and sessionRole='diagnose' to adapter", async () => {
     const mockAgent = makeMockAgentAdapter();
     const config = makeMinimalConfig();
     await diagnoseAcceptanceFailure(mockAgent, {
@@ -182,11 +182,13 @@ describe("AC-3: Session name follows nax-<hash>-<feature>-<storyId>-diagnose pat
       storyId: "US-001",
     });
     const runCall = getRunMockCalls(mockAgent)[0][0];
-    const expectedSessionName = buildSessionName("/tmp/test-workdir", "test-feature", "US-001", "diagnose");
-    expect(runCall.acpSessionName).toBe(expectedSessionName);
+    // The adapter auto-derives the session handle from featureName + storyId + sessionRole.
+    expect(runCall.sessionRole).toBe("diagnose");
+    expect(runCall.featureName).toBe("test-feature");
+    expect(runCall.storyId).toBe("US-001");
   });
 
-  test("session name is visible in acpx list when protocol is ACP", async () => {
+  test("session name is visible in acpx list when protocol is ACP (adapter derives handle)", async () => {
     const mockAgent = makeMockAgentAdapter();
     const config = makeMinimalConfig();
     expect(config.agent?.protocol).toBe("acp");
@@ -199,7 +201,10 @@ describe("AC-3: Session name follows nax-<hash>-<feature>-<storyId>-diagnose pat
       storyId: "US-001",
     });
     const runCall = getRunMockCalls(mockAgent)[0][0];
-    expect(runCall.acpSessionName).toMatch(/^nax-[a-f0-9]+-test-feature-us-001-diagnose$/);
+    const expectedHandle = computeAcpHandle("/tmp/test-workdir", "test-feature", "US-001", "diagnose");
+    expect(expectedHandle).toMatch(/^nax-[a-f0-9]+-test-feature-us-001-diagnose$/);
+    expect(runCall.featureName).toBe("test-feature");
+    expect(runCall.sessionRole).toBe("diagnose");
   });
 });
 
@@ -562,10 +567,14 @@ describe("AC-10: ACP session visible in acpx list with correct session name", ()
     });
     const runCall = getRunMockCalls(mockAgent)[0][0];
     const hash = createHash("sha256").update("/tmp/test-workdir").digest("hex").slice(0, 8);
-    expect(runCall.acpSessionName).toBe(`nax-${hash}-my-feature-us-001-diagnose`);
+    // Adapter auto-derives handle; verify the formula is correct
+    const expectedHandle = computeAcpHandle("/tmp/test-workdir", "my-feature", "US-001", "diagnose");
+    expect(expectedHandle).toBe(`nax-${hash}-my-feature-us-001-diagnose`);
+    expect(runCall.featureName).toBe("my-feature");
+    expect(runCall.sessionRole).toBe("diagnose");
   });
 
-  test("ACP protocol ensures session appears in acpx list", async () => {
+  test("ACP protocol ensures session appears in acpx list (adapter derives handle)", async () => {
     const mockAgent = makeMockAgentAdapter();
     const config = makeMinimalConfig();
     config.agent = { protocol: "acp" };
@@ -578,7 +587,10 @@ describe("AC-10: ACP session visible in acpx list with correct session name", ()
       storyId: "US-001",
     });
     const runCall = getRunMockCalls(mockAgent)[0][0];
-    expect(runCall.acpSessionName).toMatch(/^nax-[a-f0-9]+-test-feature-us-001-diagnose$/);
+    const expectedHandle = computeAcpHandle("/tmp/test-workdir", "test-feature", "US-001", "diagnose");
+    expect(expectedHandle).toMatch(/^nax-[a-f0-9]+-test-feature-us-001-diagnose$/);
+    expect(runCall.featureName).toBe("test-feature");
+    expect(runCall.sessionRole).toBe("diagnose");
   });
 });
 

--- a/test/unit/acceptance/fix-executor.test.ts
+++ b/test/unit/acceptance/fix-executor.test.ts
@@ -4,7 +4,7 @@
  * Covers acceptance criteria:
  * 1. executeSourceFix() receives agent adapter via parameter (never calls bare getAgent())
  * 2. executeSourceFix() calls agent.run() with sessionRole 'source-fix'
- * 3. Session name follows pattern nax-<hash>-<feature>-<storyId>-source-fix via buildSessionName()
+ * 3. Session name follows pattern nax-<hash>-<feature>-<storyId>-source-fix via computeAcpHandle()
  * 4. executeSourceFix() resolves fixModel via resolveModelForAgent() — never passes raw tier
  * 5. executeSourceFix() includes failing test output and diagnosis reasoning in prompt
  * 6. executeSourceFix() does NOT use pipeline — calls adapter.run() directly
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { executeSourceFix } from "../../../src/acceptance/fix-executor";
 import type { DiagnosisResult } from "../../../src/acceptance/types";
-import { buildSessionName } from "../../../src/agents/acp/adapter";
+import { computeAcpHandle } from "../../../src/agents/acp/adapter";
 import type { AgentAdapter, AgentResult } from "../../../src/agents/types";
 import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import type { NaxConfig } from "../../../src/config/schema";
@@ -213,14 +213,14 @@ describe("AC-2: executeSourceFix calls agent.run() with sessionRole 'source-fix'
 // ---------------------------------------------------------------------------
 
 describe("AC-3: Session name follows nax-<hash>-<feature>-<storyId>-source-fix pattern", () => {
-  test("buildSessionName returns correct pattern for source-fix session", () => {
-    const sessionName = buildSessionName("/tmp/test-workdir", "my-feature", "US-001", "source-fix");
+  test("computeAcpHandle returns correct pattern for source-fix session", () => {
+    const sessionName = computeAcpHandle("/tmp/test-workdir", "my-feature", "US-001", "source-fix");
     const hash = createHash("sha256").update("/tmp/test-workdir").digest("hex").slice(0, 8);
     expect(sessionName).toBe(`nax-${hash}-my-feature-us-001-source-fix`);
     expect(sessionName).toMatch(/^nax-[a-f0-9]+-.+-\d+-source-fix$/);
   });
 
-  test("executeSourceFix uses buildSessionName with 'source-fix' role", async () => {
+  test("executeSourceFix passes featureName, storyId, and sessionRole='source-fix' to adapter", async () => {
     const mockAgent = makeMockAgentAdapter();
     const config = makeMinimalConfig();
     await executeSourceFix(mockAgent, {
@@ -234,11 +234,13 @@ describe("AC-3: Session name follows nax-<hash>-<feature>-<storyId>-source-fix p
       acceptanceTestPath: "/tmp/test/acceptance.test.ts",
     });
     const runCall = getRunMockCalls(mockAgent)[0][0];
-    const expectedSessionName = buildSessionName("/tmp/test-workdir", "test-feature", "US-001", "source-fix");
-    expect(runCall.acpSessionName).toBe(expectedSessionName);
+    // The adapter auto-derives the session handle from featureName + storyId + sessionRole.
+    expect(runCall.sessionRole).toBe("source-fix");
+    expect(runCall.featureName).toBe("test-feature");
+    expect(runCall.storyId).toBe("US-001");
   });
 
-  test("session name includes storyId when provided", async () => {
+  test("session includes storyId when provided (via featureName+storyId+sessionRole combo)", async () => {
     const mockAgent = makeMockAgentAdapter();
     const config = makeMinimalConfig();
     await executeSourceFix(mockAgent, {
@@ -252,11 +254,11 @@ describe("AC-3: Session name follows nax-<hash>-<feature>-<storyId>-source-fix p
       acceptanceTestPath: "/tmp/test/acceptance.test.ts",
     });
     const runCall = getRunMockCalls(mockAgent)[0][0];
-    expect(runCall.acpSessionName).toContain("us-042");
-    expect(runCall.acpSessionName).toContain("source-fix");
+    expect(runCall.storyId).toBe("US-042");
+    expect(runCall.sessionRole).toBe("source-fix");
   });
 
-  test("session name is visible in acpx list when protocol is ACP", async () => {
+  test("session name is visible in acpx list when protocol is ACP (adapter derives handle from featureName+storyId+sessionRole)", async () => {
     const mockAgent = makeMockAgentAdapter();
     const config = makeMinimalConfig();
     expect(config.agent?.protocol).toBe("acp");
@@ -271,7 +273,10 @@ describe("AC-3: Session name follows nax-<hash>-<feature>-<storyId>-source-fix p
       acceptanceTestPath: "/tmp/test/acceptance.test.ts",
     });
     const runCall = getRunMockCalls(mockAgent)[0][0];
-    expect(runCall.acpSessionName).toMatch(/^nax-[a-f0-9]+-test-feature-us-001-source-fix$/);
+    // Verify the adapter will derive a correct session name via computeAcpHandle
+    const expectedName = computeAcpHandle("/tmp/test-workdir", "test-feature", "US-001", "source-fix");
+    expect(expectedName).toMatch(/^nax-[a-f0-9]+-test-feature-us-001-source-fix$/);
+    expect(runCall.featureName).toBe("test-feature");
   });
 });
 
@@ -563,10 +568,14 @@ describe("AC-8: When config.agent.protocol is ACP, session appears in acpx list"
     });
     const runCall = getRunMockCalls(mockAgent)[0][0];
     const hash = createHash("sha256").update("/tmp/test-workdir").digest("hex").slice(0, 8);
-    expect(runCall.acpSessionName).toBe(`nax-${hash}-my-feature-us-001-source-fix`);
+    // The adapter auto-derives the session handle; verify the derivation formula is correct
+    const expectedHandle = computeAcpHandle("/tmp/test-workdir", "my-feature", "US-001", "source-fix");
+    expect(expectedHandle).toBe(`nax-${hash}-my-feature-us-001-source-fix`);
+    expect(runCall.featureName).toBe("my-feature");
+    expect(runCall.sessionRole).toBe("source-fix");
   });
 
-  test("ACP protocol ensures session appears in acpx list via acpSessionName", async () => {
+  test("ACP protocol ensures session appears in acpx list (adapter derives handle from featureName+storyId+sessionRole)", async () => {
     const mockAgent = makeMockAgentAdapter();
     const config = makeMinimalConfig();
     config.agent = { protocol: "acp" };
@@ -581,7 +590,10 @@ describe("AC-8: When config.agent.protocol is ACP, session appears in acpx list"
       acceptanceTestPath: "/tmp/test/acceptance.test.ts",
     });
     const runCall = getRunMockCalls(mockAgent)[0][0];
-    expect(runCall.acpSessionName).toMatch(/^nax-[a-f0-9]+-test-feature-us-001-source-fix$/);
+    const expectedHandle = computeAcpHandle("/tmp/test-workdir", "test-feature", "US-001", "source-fix");
+    expect(expectedHandle).toMatch(/^nax-[a-f0-9]+-test-feature-us-001-source-fix$/);
+    expect(runCall.featureName).toBe("test-feature");
+    expect(runCall.sessionRole).toBe("source-fix");
   });
 });
 
@@ -722,12 +734,15 @@ describe("executeTestFix()", () => {
     expect(calls[0]?.[0].sessionRole).toBe("test-fix");
   });
 
-  test("session name follows nax-<hash>-<feature>-<storyId>-test-fix pattern", async () => {
+  test("session name follows nax-<hash>-<feature>-<storyId>-test-fix pattern (adapter derives handle)", async () => {
     const agent = makeMockAgentAdapter();
     await executeTestFix(agent, makeTestFixOptions());
     const calls = getRunMockCalls(agent);
-    const expectedName = buildSessionName("/tmp/workdir", "test-feature", "US-001", "test-fix");
-    expect(calls[0]?.[0].acpSessionName).toBe(expectedName);
+    // Adapter auto-derives session handle from featureName + storyId + sessionRole
+    const expectedName = computeAcpHandle("/tmp/workdir", "test-feature", "US-001", "test-fix");
+    expect(expectedName).toMatch(/^nax-[a-f0-9]+-test-feature-us-001-test-fix$/);
+    expect(calls[0]?.[0].sessionRole).toBe("test-fix");
+    expect(calls[0]?.[0].featureName).toBe("test-feature");
   });
 
   test("resolves fixModel via resolveModelForAgent()", async () => {

--- a/test/unit/agents/acp/adapter-phase1.test.ts
+++ b/test/unit/agents/acp/adapter-phase1.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { AcpAgentAdapter, _acpAdapterDeps, buildSessionName } from "../../../../src/agents/acp/adapter";
+import { AcpAgentAdapter, _acpAdapterDeps, computeAcpHandle } from "../../../../src/agents/acp/adapter";
 import { withDepsRestore } from "../../../helpers/deps";
 import type { AgentRunOptions } from "../../../../src/agents/types";
 import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
@@ -101,17 +101,17 @@ describe("AcpAgentAdapter.deriveSessionName", () => {
     };
   }
 
-  test("produces same name as buildSessionName for implementer role", () => {
+  test("produces same name as computeAcpHandle for implementer role", () => {
     const descriptor = makeDescriptor({ role: "implementer" });
     const derived = adapter.deriveSessionName(descriptor);
-    const expected = buildSessionName(workdir, "my-feat", "US-001", "implementer");
+    const expected = computeAcpHandle(workdir, "my-feat", "US-001", "implementer");
     expect(derived).toBe(expected);
   });
 
-  test("produces same name as buildSessionName for reviewer-semantic role", () => {
+  test("produces same name as computeAcpHandle for reviewer-semantic role", () => {
     const descriptor = makeDescriptor({ role: "reviewer-semantic" });
     const derived = adapter.deriveSessionName(descriptor);
-    const expected = buildSessionName(workdir, "my-feat", "US-001", "reviewer-semantic");
+    const expected = computeAcpHandle(workdir, "my-feat", "US-001", "reviewer-semantic");
     expect(derived).toBe(expected);
   });
 
@@ -121,7 +121,7 @@ describe("AcpAgentAdapter.deriveSessionName", () => {
     // deriveSessionName(descriptor) must produce the same name.
     const descriptor = makeDescriptor({ role: "implementer" });
     const fromDescriptor = adapter.deriveSessionName(descriptor);
-    const fromRunOptions = buildSessionName(workdir, "my-feat", "US-001", "implementer");
+    const fromRunOptions = computeAcpHandle(workdir, "my-feat", "US-001", "implementer");
     expect(fromDescriptor).toBe(fromRunOptions);
   });
 });

--- a/test/unit/agents/acp/adapter-session.test.ts
+++ b/test/unit/agents/acp/adapter-session.test.ts
@@ -16,7 +16,7 @@
 
 import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { AcpAgentAdapter, _acpAdapterDeps, buildSessionName, ensureAcpSession } from "../../../../src/agents/acp/adapter";
+import { AcpAgentAdapter, _acpAdapterDeps, computeAcpHandle, ensureAcpSession } from "../../../../src/agents/acp/adapter";
 import { withDepsRestore } from "../../../helpers/deps";
 import type { AcpClient } from "../../../../src/agents/acp/adapter";
 import type { AgentRunOptions } from "../../../../src/agents/types";
@@ -178,7 +178,7 @@ describe("AcpAgentAdapter — session mode (run)", () => {
       expect(capturedCmds.length).toBeGreaterThan(0);
     });
 
-    test("acpSessionName option does not affect createClient invocation", async () => {
+    test("sessionHandle option does not affect createClient invocation", async () => {
       const capturedCmds: string[] = [];
       const session = makeSession();
       _acpAdapterDeps.createClient = mock((cmd: string) => {
@@ -186,7 +186,7 @@ describe("AcpAgentAdapter — session mode (run)", () => {
         return makeClient(session);
       });
 
-      await adapter.run({ ...BASE_OPTIONS, acpSessionName: "custom-session-xyz" });
+      await adapter.run({ ...BASE_OPTIONS, sessionHandle: "custom-session-xyz" });
 
       expect(capturedCmds.length).toBeGreaterThan(0);
     });
@@ -208,30 +208,30 @@ describe("AcpAgentAdapter — session mode (run)", () => {
     });
 
     test("different sessionRoles produce different session names", () => {
-      const writerName = buildSessionName("/proj/foo", "feat", "ST-001", "test-writer");
-      const implName   = buildSessionName("/proj/foo", "feat", "ST-001", "implementer");
-      const verName    = buildSessionName("/proj/foo", "feat", "ST-001", "verifier");
+      const writerName = computeAcpHandle("/proj/foo", "feat", "ST-001", "test-writer");
+      const implName   = computeAcpHandle("/proj/foo", "feat", "ST-001", "implementer");
+      const verName    = computeAcpHandle("/proj/foo", "feat", "ST-001", "verifier");
       expect(writerName).not.toBe(implName);
       expect(implName).not.toBe(verName);
       expect(writerName).not.toBe(verName);
     });
 
     test("different worktrees produce different session names", () => {
-      const main      = buildSessionName("/repos/nax",     "feat", "ST-001");
-      const worktree  = buildSessionName("/repos/nax-acp", "feat", "ST-001");
+      const main      = computeAcpHandle("/repos/nax",     "feat", "ST-001");
+      const worktree  = computeAcpHandle("/repos/nax-acp", "feat", "ST-001");
       expect(main).not.toBe(worktree);
     });
 
     test("same path always produces same session name (stable)", () => {
-      const a = buildSessionName("/repos/nax", "string-toolkit", "ST-001");
-      const b = buildSessionName("/repos/nax", "string-toolkit", "ST-001");
+      const a = computeAcpHandle("/repos/nax", "string-toolkit", "ST-001");
+      const b = computeAcpHandle("/repos/nax", "string-toolkit", "ST-001");
       expect(a).toBe(b);
     });
 
     test("session name contains 8-char cwd hash", () => {
       const workdir = "/repos/nax-test";
       const hash = createHash("sha256").update(workdir).digest("hex").slice(0, 8);
-      const name = buildSessionName(workdir, "feat", "ST-001");
+      const name = computeAcpHandle(workdir, "feat", "ST-001");
       expect(name).toContain(hash);
     });
   });

--- a/test/unit/agents/session-fields-invariants.test.ts
+++ b/test/unit/agents/session-fields-invariants.test.ts
@@ -1,0 +1,44 @@
+// test/unit/agents/session-fields-invariants.test.ts
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "../../..");
+
+function grepSrc(pattern: RegExp): string[] {
+  const hits: string[] = [];
+  function walk(dir: string) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) { walk(full); continue; }
+      if (!entry.name.endsWith(".ts") || entry.name.endsWith(".test.ts")) continue;
+      const src = readFileSync(full, "utf-8");
+      const lines = src.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (pattern.test(line) && !/^\s*(\/\/|\/?\*)/.test(line)) {
+          hits.push(`${full.replace(ROOT + "/", "")}:${i + 1}: ${line.trim()}`);
+        }
+      }
+    }
+  }
+  walk(join(ROOT, "src"));
+  return hits;
+}
+
+describe("Legacy session field cleanup (#529 invariants)", () => {
+  test("buildSessionName is not used in src/ (non-comment)", () => {
+    const hits = grepSrc(/buildSessionName/);
+    expect(hits).toEqual([]);
+  });
+
+  test("acpSessionName is not used in src/ (non-comment)", () => {
+    const hits = grepSrc(/acpSessionName/);
+    expect(hits).toEqual([]);
+  });
+
+  test("keepSessionOpen is not used in src/ (non-comment)", () => {
+    const hits = grepSrc(/keepSessionOpen/);
+    expect(hits).toEqual([]);
+  });
+});

--- a/test/unit/debate/session-helpers.test.ts
+++ b/test/unit/debate/session-helpers.test.ts
@@ -15,7 +15,7 @@ import { readdirSync } from "node:fs";
 // RED: These imports fail until session-helpers.ts is created
 import { _debateSessionDeps, resolveDebaterModel, resolveOutcome } from "../../../src/debate/session-helpers";
 import type { DebateSessionOptions } from "../../../src/debate/session-helpers";
-import { buildSessionName } from "../../../src/agents/acp/adapter";
+import { computeAcpHandle } from "../../../src/agents/acp/adapter";
 import type { AgentAdapter, CompleteOptions } from "../../../src/agents/types";
 import type { DebateStageConfig } from "../../../src/debate/types";
 
@@ -257,7 +257,7 @@ describe("resolveOutcome() — workdir and featureName parameters (US-004 AC1)",
 
 // ─── AC2: synthesisResolver receives sessionName=implementer when workdir set ─
 
-describe("resolveOutcome() — synthesis resolver acpSessionName (US-004 AC2)", () => {
+describe("resolveOutcome() — synthesis resolver sessionHandle (US-004 AC2)", () => {
   let origGetAgent: typeof _debateSessionDeps.getAgent;
 
   beforeEach(() => {
@@ -269,7 +269,7 @@ describe("resolveOutcome() — synthesis resolver acpSessionName (US-004 AC2)", 
     mock.restore();
   });
 
-  test("passes sessionName=buildSessionName(workdir,featureName,storyId,'implementer') in completeOptions", async () => {
+  test("passes sessionName=computeAcpHandle(workdir,featureName,storyId,'implementer') in completeOptions", async () => {
     const captured: { opts?: CompleteOptions }[] = [];
     _debateSessionDeps.getAgent = mock(() => makeCaptureAdapter(captured));
 
@@ -292,7 +292,7 @@ describe("resolveOutcome() — synthesis resolver acpSessionName (US-004 AC2)", 
 
     expect(captured.length).toBeGreaterThan(0);
     const capturedOpts = captured[0]?.opts;
-    const expectedSessionName = buildSessionName(workdir, featureName, storyId, "synthesis");
+    const expectedSessionName = computeAcpHandle(workdir, featureName, storyId, "synthesis");
     expect(capturedOpts?.sessionName).toBe(expectedSessionName);
   });
 
@@ -320,7 +320,7 @@ describe("resolveOutcome() — synthesis resolver acpSessionName (US-004 AC2)", 
 
 // ─── AC3: judgeResolver receives sessionName=judge when workdir set ─────
 
-describe("resolveOutcome() — custom/judge resolver acpSessionName (US-004 AC3)", () => {
+describe("resolveOutcome() — custom/judge resolver sessionHandle (US-004 AC3)", () => {
   let origGetAgent: typeof _debateSessionDeps.getAgent;
 
   beforeEach(() => {
@@ -332,7 +332,7 @@ describe("resolveOutcome() — custom/judge resolver acpSessionName (US-004 AC3)
     mock.restore();
   });
 
-  test("custom resolver: passes sessionName=buildSessionName(...,'judge') in completeOptions", async () => {
+  test("custom resolver: passes sessionName=computeAcpHandle(...,'judge') in completeOptions", async () => {
     const captured: { opts?: CompleteOptions }[] = [];
     _debateSessionDeps.getAgent = mock(() => makeCaptureAdapter(captured));
 
@@ -355,7 +355,7 @@ describe("resolveOutcome() — custom/judge resolver acpSessionName (US-004 AC3)
 
     expect(captured.length).toBeGreaterThan(0);
     const capturedOpts = captured[0]?.opts;
-    const expectedSessionName = buildSessionName(workdir, featureName, storyId, "judge");
+    const expectedSessionName = computeAcpHandle(workdir, featureName, storyId, "judge");
     expect(capturedOpts?.sessionName).toBe(expectedSessionName);
   });
 

--- a/test/unit/debate/session-hybrid-rebuttal.test.ts
+++ b/test/unit/debate/session-hybrid-rebuttal.test.ts
@@ -378,9 +378,9 @@ describe("runHybrid() — failed rebuttal turn is skipped with warning (AC5)", (
   });
 });
 
-// ─── AC6: rebuttal calls use same sessionRole as proposal and keepSessionOpen:true
+// ─── AC6: rebuttal calls use same sessionRole as proposal and keepOpen:true
 
-describe("runHybrid() — rebuttal calls use correct sessionRole and keepSessionOpen (AC6)", () => {
+describe("runHybrid() — rebuttal calls use correct sessionRole and keepOpen (AC6)", () => {
   test("every rebuttal runStatefulTurn call uses the same sessionRole as the proposal round for that debater", async () => {
     const rebuttalCalls: AgentRunOptions[] = [];
 
@@ -419,7 +419,7 @@ describe("runHybrid() — rebuttal calls use correct sessionRole and keepSession
     expect(roles).toContain("debate-hybrid-1");
   });
 
-  test("every rebuttal runStatefulTurn call has keepSessionOpen: true", async () => {
+  test("every rebuttal runStatefulTurn call has keepOpen: true", async () => {
     const rebuttalCalls: AgentRunOptions[] = [];
 
     _debateSessionDeps.getAgent = mock((name: string) =>
@@ -453,7 +453,7 @@ describe("runHybrid() — rebuttal calls use correct sessionRole and keepSession
 
     expect(rebuttalCalls).toHaveLength(2);
     for (const call of rebuttalCalls) {
-      expect(call.keepSessionOpen).toBe(true);
+      expect(call.keepOpen).toBe(true);
     }
   });
 });

--- a/test/unit/debate/session-hybrid.test.ts
+++ b/test/unit/debate/session-hybrid.test.ts
@@ -158,10 +158,10 @@ describe("runHybrid() — sessionRole for proposal calls (AC1)", () => {
   });
 });
 
-// ─── AC3: every proposal call uses keepSessionOpen: true ─────────────────────
+// ─── AC3: every proposal call uses keepOpen: true ─────────────────────
 
-describe("runHybrid() — keepSessionOpen for proposal calls (AC3)", () => {
-  test("all proposal run() calls have keepSessionOpen: true", async () => {
+describe("runHybrid() — keepOpen for proposal calls (AC3)", () => {
+  test("all proposal run() calls have keepOpen: true", async () => {
     const runCalls: AgentRunOptions[] = [];
 
     _debateSessionDeps.getAgent = mock((name: string) =>
@@ -194,7 +194,7 @@ describe("runHybrid() — keepSessionOpen for proposal calls (AC3)", () => {
     const proposalCalls = runCalls.filter((c) => c.prompt === "test prompt");
     expect(proposalCalls.length).toBeGreaterThanOrEqual(2);
     for (const call of proposalCalls) {
-      expect(call.keepSessionOpen).toBe(true);
+      expect(call.keepOpen).toBe(true);
     }
   });
 });

--- a/test/unit/debate/session-plan.test.ts
+++ b/test/unit/debate/session-plan.test.ts
@@ -136,7 +136,7 @@ describe("DebateSession.runPlan()", () => {
   });
 
   test("runs hybrid rebuttal loop when mode=hybrid and sessionMode=stateful", async () => {
-    const runCalls: Array<{ prompt: string; sessionRole?: string; keepSessionOpen?: boolean }> = [];
+    const runCalls: Array<{ prompt: string; sessionRole?: string; keepOpen?: boolean }> = [];
 
     _debateSessionDeps.getAgent = mock(() => ({
       name: "opencode",
@@ -148,11 +148,11 @@ describe("DebateSession.runPlan()", () => {
         features: new Set<"review" | "tdd" | "refactor" | "batch">(["review"]),
       },
       isInstalled: async () => true,
-      run: async (options: { prompt?: string; sessionRole?: string; keepSessionOpen?: boolean }) => {
+      run: async (options: { prompt?: string; sessionRole?: string; keepOpen?: boolean }) => {
         runCalls.push({
           prompt: options.prompt ?? "",
           sessionRole: options.sessionRole,
-          keepSessionOpen: options.keepSessionOpen,
+          keepOpen: options.keepOpen,
         });
         return {
           success: true,

--- a/test/unit/debate/session-stateful.test.ts
+++ b/test/unit/debate/session-stateful.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { DebateSession, _debateSessionDeps } from "../../../src/debate/session";
 import type { AgentAdapter, AgentRunOptions, CompleteOptions, CompleteResult } from "../../../src/agents/types";
 import type { DebateStageConfig } from "../../../src/debate/types";
-import { buildSessionName } from "../../../src/agents/acp/adapter";
+import { computeAcpHandle } from "../../../src/agents/acp/adapter";
 
 function makeMockAdapter(
   name: string,
@@ -101,7 +101,7 @@ describe("DebateSession.run() — stateful mode uses adapter.run SSOT", () => {
     expect(runCalls[0].storyId).toBe("US-003");
     expect(runCalls[0].featureName).toBe("feat-a");
     expect(runCalls[0].workdir).toBe("/tmp/work");
-    expect(runCalls[0].keepSessionOpen).toBe(false);
+    expect(runCalls[0].keepOpen).toBe(false);
     expect(runCalls[0].modelDef.model).not.toBe("fast");
     expect(runCalls[1].modelDef.model).not.toBe("balanced");
   });
@@ -175,10 +175,10 @@ describe("DebateSession.run() — stateful mode uses adapter.run SSOT", () => {
     await session.run("review prompt");
 
     expect(runCalls.length).toBe(4);
-    expect(runCalls[0].keepSessionOpen).toBe(true);
-    expect(runCalls[1].keepSessionOpen).toBe(true);
-    expect(runCalls[2].keepSessionOpen).toBe(false);
-    expect(runCalls[3].keepSessionOpen).toBe(false);
+    expect(runCalls[0].keepOpen).toBe(true);
+    expect(runCalls[1].keepOpen).toBe(true);
+    expect(runCalls[2].keepOpen).toBe(false);
+    expect(runCalls[3].keepOpen).toBe(false);
     expect(runCalls[2].sessionRole).toBe("debate-review-0");
     expect(runCalls[3].sessionRole).toBe("debate-review-1");
   });
@@ -233,7 +233,7 @@ describe("DebateSession.run() — stateful mode uses adapter.run SSOT", () => {
     const result = await session.run("review prompt");
     expect(result.outcome).toBe("passed");
     expect(result.debaters).toEqual(["claude"]);
-    expect(runCalls.some((c) => c.prompt === "Close this debate session." && c.keepSessionOpen === false)).toBe(true);
+    expect(runCalls.some((c) => c.prompt === "Close this debate session." && c.keepOpen === false)).toBe(true);
   });
 });
 
@@ -278,7 +278,7 @@ describe("runStateful() — resolveOutcome receives workdir and featureName (US-
     // The synthesis resolver's complete() should have been called with the synthesis sessionName.
     const synthesisCall = completeCalls.find((c) => c.opts !== undefined);
     expect(synthesisCall).toBeDefined();
-    const expectedSessionName = buildSessionName(workdir, featureName, storyId, "synthesis");
+    const expectedSessionName = computeAcpHandle(workdir, featureName, storyId, "synthesis");
     expect(synthesisCall?.opts?.sessionName).toBe(expectedSessionName);
   });
 });

--- a/test/unit/pipeline/stages/autofix-adversarial.test.ts
+++ b/test/unit/pipeline/stages/autofix-adversarial.test.ts
@@ -287,11 +287,11 @@ describe("runTestWriterRectification", () => {
   // Session continuity (#437)
   // ─────────────────────────────────────────────────────────────────────────
 
-  test("keepSessionOpen defaults to true so session survives across autofix cycles", async () => {
+  test("keepOpen defaults to true so session survives across autofix cycles", async () => {
     const testChecks = [makeAdversarialCheck([makeFinding("src/foo.test.ts")])];
     let capturedKeepSessionOpen: boolean | undefined;
     const mockRun = mock(async (opts: any) => {
-      capturedKeepSessionOpen = opts.keepSessionOpen;
+      capturedKeepSessionOpen = opts.keepOpen;
       return { estimatedCost: 0, success: true, output: "", exitCode: 0, rateLimited: false };
     });
     const agentGetFn = mock(() => ({ run: mockRun }));
@@ -302,11 +302,11 @@ describe("runTestWriterRectification", () => {
     expect(capturedKeepSessionOpen).toBe(true);
   });
 
-  test("keepSessionOpen is false when caller passes keepOpen=false", async () => {
+  test("keepOpen is false when caller passes keepOpen=false", async () => {
     const testChecks = [makeAdversarialCheck([makeFinding("src/foo.test.ts")])];
     let capturedKeepSessionOpen: boolean | undefined;
     const mockRun = mock(async (opts: any) => {
-      capturedKeepSessionOpen = opts.keepSessionOpen;
+      capturedKeepSessionOpen = opts.keepOpen;
       return { estimatedCost: 0, success: true, output: "", exitCode: 0, rateLimited: false };
     });
     const agentGetFn = mock(() => ({ run: mockRun }));
@@ -317,11 +317,11 @@ describe("runTestWriterRectification", () => {
     expect(capturedKeepSessionOpen).toBe(false);
   });
 
-  test("uses the same acpSessionName across two calls (session resumability)", async () => {
+  test("uses the same sessionRole across two calls (session resumability)", async () => {
     const testChecks = [makeAdversarialCheck([makeFinding("src/foo.test.ts")])];
-    const capturedSessionNames: string[] = [];
+    const capturedSessionRoles: string[] = [];
     const mockRun = mock(async (opts: any) => {
-      capturedSessionNames.push(opts.acpSessionName);
+      capturedSessionRoles.push(opts.sessionRole);
       return { estimatedCost: 0, success: true, output: "", exitCode: 0, rateLimited: false };
     });
     const agentGetFn = mock(() => ({ run: mockRun }));
@@ -330,7 +330,7 @@ describe("runTestWriterRectification", () => {
     await runTestWriterRectification(ctx, testChecks, story, agentGetFn as any);
     await runTestWriterRectification(ctx, testChecks, story, agentGetFn as any);
 
-    expect(capturedSessionNames).toHaveLength(2);
-    expect(capturedSessionNames[0]).toBe(capturedSessionNames[1]);
+    expect(capturedSessionRoles).toHaveLength(2);
+    expect(capturedSessionRoles[0]).toBe(capturedSessionRoles[1]);
   });
 });

--- a/test/unit/pipeline/stages/autofix-session-wiring.test.ts
+++ b/test/unit/pipeline/stages/autofix-session-wiring.test.ts
@@ -98,6 +98,7 @@ describe("autofix session wiring (PROMPT-001)", () => {
     // The adapter auto-derives the session handle from featureName + storyId + sessionRole.
     // The caller no longer sets sessionHandle explicitly; verify sessionRole is set correctly.
     expect(runOpts.sessionRole).toBe("implementer");
+    expect(runOpts.sessionHandle).toBeUndefined();
     // Verify computeAcpHandle produces the expected name for documentation purposes
     const expected = computeAcpHandle(WORKDIR, FEATURE, STORY_ID, "implementer");
     expect(expected).toMatch(/^nax-[a-f0-9]+-my-feature-us-001-implementer$/);

--- a/test/unit/pipeline/stages/autofix-session-wiring.test.ts
+++ b/test/unit/pipeline/stages/autofix-session-wiring.test.ts
@@ -1,13 +1,13 @@
 /**
  * Tests for PROMPT-001: autofix session continuity wiring.
  *
- * Verifies that runAgentRectification passes the correct acpSessionName and
- * keepSessionOpen values to agent.run(), and that continuation prompts are
- * used on retry when the session is confirmed open.
+ * Verifies that runAgentRectification passes the correct keepOpen values to
+ * agent.run(), and that continuation prompts are used on retry when the
+ * session is confirmed open.
  */
 
 import { describe, expect, mock, test } from "bun:test";
-import { buildSessionName } from "../../../../src/agents/acp/adapter";
+import { computeAcpHandle } from "../../../../src/agents/acp/adapter";
 import { DEFAULT_CONFIG } from "../../../../src/config";
 import { _autofixDeps } from "../../../../src/pipeline/stages/autofix";
 import type { PipelineContext } from "../../../../src/pipeline/types";
@@ -78,7 +78,7 @@ function makeMockAgent(succeed = true) {
 // ---------------------------------------------------------------------------
 
 describe("autofix session wiring (PROMPT-001)", () => {
-  test("agent.run() receives acpSessionName matching buildSessionName(..., 'implementer')", async () => {
+  test("agent.run() receives sessionRole='implementer' for rectification", async () => {
     const agent = makeMockAgent(true);
     const ctx = makeCtxWithAgent(agent, 1);
 
@@ -95,11 +95,15 @@ describe("autofix session wiring (PROMPT-001)", () => {
 
     expect(agent.run).toHaveBeenCalledTimes(1);
     const runOpts = (agent.run.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
-    const expected = buildSessionName(WORKDIR, FEATURE, STORY_ID, "implementer");
-    expect(runOpts.acpSessionName).toBe(expected);
+    // The adapter auto-derives the session handle from featureName + storyId + sessionRole.
+    // The caller no longer sets sessionHandle explicitly; verify sessionRole is set correctly.
+    expect(runOpts.sessionRole).toBe("implementer");
+    // Verify computeAcpHandle produces the expected name for documentation purposes
+    const expected = computeAcpHandle(WORKDIR, FEATURE, STORY_ID, "implementer");
+    expect(expected).toMatch(/^nax-[a-f0-9]+-my-feature-us-001-implementer$/);
   });
 
-  test("keepSessionOpen: false when maxAttempts=1 (single attempt is last attempt)", async () => {
+  test("keepOpen: false when maxAttempts=1 (single attempt is last attempt)", async () => {
     const agent = makeMockAgent(true);
     const ctx = makeCtxWithAgent(agent, 1);
 
@@ -114,10 +118,10 @@ describe("autofix session wiring (PROMPT-001)", () => {
 
     expect(agent.run).toHaveBeenCalledTimes(1);
     const runOpts = (agent.run.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
-    expect(runOpts.keepSessionOpen).toBe(false);
+    expect(runOpts.keepOpen).toBe(false);
   });
 
-  test("keepSessionOpen: true on non-last attempt, false on last attempt", async () => {
+  test("keepOpen: true on non-last attempt, false on last attempt", async () => {
     const agent = makeMockAgent(false); // always fail so loop runs maxAttempts
     const ctx = makeCtxWithAgent(agent, 2);
     // Update review result after each attempt to keep failing
@@ -135,10 +139,10 @@ describe("autofix session wiring (PROMPT-001)", () => {
     expect(agent.run).toHaveBeenCalledTimes(2);
 
     const firstCallOpts = (agent.run.mock.calls as unknown[][])[0][0] as Record<string, unknown>;
-    expect(firstCallOpts.keepSessionOpen).toBe(true); // attempt 0, not last
+    expect(firstCallOpts.keepOpen).toBe(true); // attempt 0, not last
 
     const secondCallOpts = (agent.run.mock.calls as unknown[][])[1][0] as Record<string, unknown>;
-    expect(secondCallOpts.keepSessionOpen).toBe(false); // attempt 1 == maxAttempts-1, is last
+    expect(secondCallOpts.keepOpen).toBe(false); // attempt 1 == maxAttempts-1, is last
   });
 
   test("attempt 2 uses continuation prompt (shorter, no 'Story:' section header)", async () => {

--- a/test/unit/pipeline/stages/execution-session-role.test.ts
+++ b/test/unit/pipeline/stages/execution-session-role.test.ts
@@ -2,10 +2,10 @@
  * Tests for session role normalization in execution stage (US-001)
  *
  * AC-1: agent.run() in execution.ts passes `sessionRole: "implementer"` for all test strategies
- * AC-2: When ctx.config.review.enabled is true, execution.ts passes `keepSessionOpen: true`
- * AC-3: When ctx.config.execution.rectification?.enabled is true, execution.ts passes `keepSessionOpen: true`
- * AC-4: When both review and rectification are falsy, execution.ts passes `keepSessionOpen: false`
- * AC-5: buildSessionName produces consistent names for identical inputs
+ * AC-2: When ctx.config.review.enabled is true, execution.ts passes `keepOpen: true`
+ * AC-3: When ctx.config.execution.rectification?.enabled is true, execution.ts passes `keepOpen: true`
+ * AC-4: When both review and rectification are falsy, execution.ts passes `keepOpen: false`
+ * AC-5: computeAcpHandle produces consistent names for identical inputs
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -133,19 +133,19 @@ describe("execution stage — session role normalization (AC-1)", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// AC-2: keepSessionOpen: true when review.enabled is true
+// AC-2: keepOpen: true when review.enabled is true
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("execution stage — keepSessionOpen when review enabled (AC-2)", () => {
-  test("passes keepSessionOpen: true when review.enabled is true", async () => {
+describe("execution stage — keepOpen when review enabled (AC-2)", () => {
+  test("passes keepOpen: true when review.enabled is true", async () => {
     let capturedKeepSessionOpen: boolean | undefined;
 
     _executionDeps.getAgent = () =>
       ({
         name: "claude",
         capabilities: { supportedTiers: ["fast"] },
-        run: async (opts: { keepSessionOpen?: boolean }) => {
-          capturedKeepSessionOpen = opts.keepSessionOpen;
+        run: async (opts: { keepOpen?: boolean }) => {
+          capturedKeepSessionOpen = opts.keepOpen;
           return { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 };
         },
       }) as unknown as ReturnType<typeof _executionDeps.getAgent>;
@@ -162,19 +162,19 @@ describe("execution stage — keepSessionOpen when review enabled (AC-2)", () =>
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// AC-3: keepSessionOpen: true when rectification.enabled is true
+// AC-3: keepOpen: true when rectification.enabled is true
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("execution stage — keepSessionOpen when rectification enabled (AC-3)", () => {
-  test("passes keepSessionOpen: true when rectification.enabled is true", async () => {
+describe("execution stage — keepOpen when rectification enabled (AC-3)", () => {
+  test("passes keepOpen: true when rectification.enabled is true", async () => {
     let capturedKeepSessionOpen: boolean | undefined;
 
     _executionDeps.getAgent = () =>
       ({
         name: "claude",
         capabilities: { supportedTiers: ["fast"] },
-        run: async (opts: { keepSessionOpen?: boolean }) => {
-          capturedKeepSessionOpen = opts.keepSessionOpen;
+        run: async (opts: { keepOpen?: boolean }) => {
+          capturedKeepSessionOpen = opts.keepOpen;
           return { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 };
         },
       }) as unknown as ReturnType<typeof _executionDeps.getAgent>;
@@ -193,19 +193,19 @@ describe("execution stage — keepSessionOpen when rectification enabled (AC-3)"
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// AC-4: keepSessionOpen: false when both review and rectification are falsy
+// AC-4: keepOpen: false when both review and rectification are falsy
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("execution stage — keepSessionOpen when review and rectification disabled (AC-4)", () => {
-  test("passes keepSessionOpen: false when both review and rectification are disabled", async () => {
+describe("execution stage — keepOpen when review and rectification disabled (AC-4)", () => {
+  test("passes keepOpen: false when both review and rectification are disabled", async () => {
     let capturedKeepSessionOpen: boolean | undefined;
 
     _executionDeps.getAgent = () =>
       ({
         name: "claude",
         capabilities: { supportedTiers: ["fast"] },
-        run: async (opts: { keepSessionOpen?: boolean }) => {
-          capturedKeepSessionOpen = opts.keepSessionOpen;
+        run: async (opts: { keepOpen?: boolean }) => {
+          capturedKeepSessionOpen = opts.keepOpen;
           return { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 };
         },
       }) as unknown as ReturnType<typeof _executionDeps.getAgent>;
@@ -225,22 +225,22 @@ describe("execution stage — keepSessionOpen when review and rectification disa
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// AC-5: buildSessionName consistency test
+// AC-5: computeAcpHandle consistency test
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("execution stage — buildSessionName consistency (AC-5)", () => {
-  test("buildSessionName produces same result for identical inputs", async () => {
-    // Import buildSessionName from ACP adapter
-    const { buildSessionName } = await import("../../../../src/agents/acp/adapter");
+describe("execution stage — computeAcpHandle consistency (AC-5)", () => {
+  test("computeAcpHandle produces same result for identical inputs", async () => {
+    // Import computeAcpHandle from ACP adapter
+    const { computeAcpHandle } = await import("../../../../src/agents/acp/adapter");
 
     const workdir = "/repo";
     const feature = "test-feature";
     const storyId = "US-001";
     const role = "implementer";
 
-    // Call buildSessionName twice with same inputs
-    const name1 = buildSessionName(workdir, feature, storyId, role);
-    const name2 = buildSessionName(workdir, feature, storyId, role);
+    // Call computeAcpHandle twice with same inputs
+    const name1 = computeAcpHandle(workdir, feature, storyId, role);
+    const name2 = computeAcpHandle(workdir, feature, storyId, role);
 
     // Should be identical
     expect(name1).toBe(name2);

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -5,7 +5,7 @@
  * - Retry succeeds: initial response unparseable, retry returns valid JSON
  * - Retry failure: retry call throws, falls through to fail-open
  * - agent.run called twice when initial response is unparseable
- * - Retry call uses keepSessionOpen: false
+ * - Retry call uses keepOpen: false
  * - Cost accumulated from both initial and retry calls
  * - Logging: info on parse fail + retry, info on retry success, warn on exhaustion
  */
@@ -198,22 +198,22 @@ describe("runAdversarialReview — JSON retry succeeds", () => {
     expect((agent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(2);
   });
 
-  test("retry call uses keepSessionOpen: false to close the session", async () => {
+  test("retry call uses keepOpen: false to close the session", async () => {
     const agent = makeMultiCallAgent(["this is not json at all", PASSING_RESPONSE]);
 
     await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
 
     const calls = (agent.run as ReturnType<typeof mock>).mock.calls;
-    expect((calls[1][0] as Record<string, unknown>).keepSessionOpen).toBe(false);
+    expect((calls[1][0] as Record<string, unknown>).keepOpen).toBe(false);
   });
 
-  test("initial call uses keepSessionOpen: true so retry has conversation history (session closes by end of runReview, ADR-008)", async () => {
+  test("initial call uses keepOpen: true so retry has conversation history (session closes by end of runReview, ADR-008)", async () => {
     const agent = makeMultiCallAgent([PASSING_RESPONSE]);
 
     await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, () => agent);
 
     const calls = (agent.run as ReturnType<typeof mock>).mock.calls;
-    expect((calls[0][0] as Record<string, unknown>).keepSessionOpen).toBe(true);
+    expect((calls[0][0] as Record<string, unknown>).keepOpen).toBe(true);
   });
 
   test("agent.closePhysicalSession called once to close the session after runReview completes", async () => {

--- a/test/unit/review/dialogue-debate.test.ts
+++ b/test/unit/review/dialogue-debate.test.ts
@@ -103,7 +103,7 @@ const MOCK_CONFIG = {
 // ---------------------------------------------------------------------------
 
 describe("ReviewerSession.resolveDebate()", () => {
-  test("calls agent.run() with keepSessionOpen: true and sessionRole: reviewer", async () => {
+  test("calls agent.run() with keepOpen: true and sessionRole: reviewer", async () => {
     const runFn = makeRunFn(PASSING_RESPONSE);
     const session = createReviewerSession(makeAdapter(runFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
@@ -111,7 +111,7 @@ describe("ReviewerSession.resolveDebate()", () => {
 
     expect(runFn).toHaveBeenCalledTimes(1);
     const opts = (runFn as ReturnType<typeof mock>).mock.calls[0][0] as AgentRunOptions;
-    expect(opts.keepSessionOpen).toBe(true);
+    expect(opts.keepOpen).toBe(true);
     expect(opts.sessionRole).toBe("reviewer");
     expect(opts.pipelineStage).toBe("review");
   });

--- a/test/unit/review/dialogue-re-review.test.ts
+++ b/test/unit/review/dialogue-re-review.test.ts
@@ -94,7 +94,7 @@ const RE_REVIEW_RESPONSE = JSON.stringify({
   deltaSummary: "AC-1-not-satisfied is now resolved. AC-2-not-satisfied is still present.",
 });
 
-const CLARIFY_RESPONSE = "AC-1 requires that reReview() calls agent.run() with keepSessionOpen: true and includes the previous findings in the prompt.";
+const CLARIFY_RESPONSE = "AC-1 requires that reReview() calls agent.run() with keepOpen: true and includes the previous findings in the prompt.";
 
 type RunFn = (opts: AgentRunOptions) => Promise<AgentResult>;
 
@@ -192,9 +192,9 @@ describe("ReviewerSession.reReview() — agent.run() call parameters", () => {
     mock.restore();
   });
 
-  test("calls agent.run() with keepSessionOpen: true", async () => {
+  test("calls agent.run() with keepOpen: true", async () => {
     await session.reReview(UPDATED_DIFF);
-    expect(capturedOpts?.keepSessionOpen).toBe(true);
+    expect(capturedOpts?.keepOpen).toBe(true);
   });
 
   test("calls agent.run() with sessionRole: 'reviewer'", async () => {
@@ -448,9 +448,9 @@ describe("ReviewerSession.clarify() — agent.run() call and return value", () =
     expect(result).toBe(CLARIFY_RESPONSE);
   });
 
-  test("calls agent.run() with keepSessionOpen: true", async () => {
+  test("calls agent.run() with keepOpen: true", async () => {
     await session.clarify("What does AC-1 require exactly?");
-    expect(capturedOpts?.keepSessionOpen).toBe(true);
+    expect(capturedOpts?.keepOpen).toBe(true);
   });
 
   test("calls agent.run() with sessionRole: 'reviewer'", async () => {

--- a/test/unit/review/dialogue.test.ts
+++ b/test/unit/review/dialogue.test.ts
@@ -6,7 +6,7 @@
  * AC2 — ReviewConfigSchema includes dialogue; DEFAULT_CONFIG.review.dialogue.enabled === false
  * AC3 — ReviewConfig interface includes dialogue? (compile-time check)
  * AC4 — createReviewerSession returns active session with empty history
- * AC5 — review() calls agent.run() with sessionRole='reviewer', keepSessionOpen=true, pipelineStage='review'
+ * AC5 — review() calls agent.run() with sessionRole='reviewer', keepOpen=true, pipelineStage='review'
  * AC6 — review() parses JSON into ReviewDialogueResult (checkResult + findingReasoning Map)
  * AC7 — review() appends exactly two DialogueMessage entries to history
  * AC8 — destroy() deactivates session; subsequent review() throws NaxError REVIEWER_SESSION_DESTROYED
@@ -34,7 +34,7 @@ const STORY: SemanticStory = {
   description: "Add ReviewDialogueConfig and implement ReviewerSession",
   acceptanceCriteria: [
     "createReviewerSession returns active session",
-    "review() calls agent.run() with keepSessionOpen: true",
+    "review() calls agent.run() with keepOpen: true",
   ],
 };
 
@@ -321,7 +321,7 @@ describe("createReviewerSession — initial state", () => {
 });
 
 // ---------------------------------------------------------------------------
-// AC5 — review() calls agent.run() with sessionRole='reviewer', keepSessionOpen=true, pipelineStage='review'
+// AC5 — review() calls agent.run() with sessionRole='reviewer', keepOpen=true, pipelineStage='review'
 // ---------------------------------------------------------------------------
 
 describe("ReviewerSession.review() — agent.run() call parameters", () => {
@@ -370,9 +370,9 @@ describe("ReviewerSession.review() — agent.run() call parameters", () => {
     expect(capturedOpts?.sessionRole).toBe("reviewer");
   });
 
-  test("passes keepSessionOpen: true to agent.run()", async () => {
+  test("passes keepOpen: true to agent.run()", async () => {
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
-    expect(capturedOpts?.keepSessionOpen).toBe(true);
+    expect(capturedOpts?.keepOpen).toBe(true);
   });
 
   test("passes pipelineStage: 'review' to agent.run()", async () => {

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -5,7 +5,7 @@
  * - Retry succeeds: initial response unparseable, retry returns valid JSON
  * - Retry failure: retry call throws, falls through to fail-open
  * - agent.run called twice when initial response is unparseable
- * - Retry call uses keepSessionOpen: false
+ * - Retry call uses keepOpen: false
  * - Cost accumulated from both initial and retry calls
  * - Logging: info on parse fail + retry, info on retry success, warn on exhaustion
  */
@@ -205,22 +205,22 @@ describe("runSemanticReview — JSON retry succeeds", () => {
     expect((agent.run as ReturnType<typeof mock>).mock.calls).toHaveLength(2);
   });
 
-  test("initial call uses keepSessionOpen: true so retry has conversation history (session closes by end of runReview, ADR-008)", async () => {
+  test("initial call uses keepOpen: true so retry has conversation history (session closes by end of runReview, ADR-008)", async () => {
     const agent = makeMultiCallAgent([PASSING_LLM_RESPONSE]);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
     const calls = (agent.run as ReturnType<typeof mock>).mock.calls;
-    expect((calls[0][0] as Record<string, unknown>).keepSessionOpen).toBe(true);
+    expect((calls[0][0] as Record<string, unknown>).keepOpen).toBe(true);
   });
 
-  test("retry call uses keepSessionOpen: false to close the session", async () => {
+  test("retry call uses keepOpen: false to close the session", async () => {
     const agent = makeMultiCallAgent(["this is not json at all", PASSING_LLM_RESPONSE]);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
     const calls = (agent.run as ReturnType<typeof mock>).mock.calls;
-    expect((calls[1][0] as Record<string, unknown>).keepSessionOpen).toBe(false);
+    expect((calls[1][0] as Record<string, unknown>).keepOpen).toBe(false);
   });
 
   test("agent.closePhysicalSession called once to close the session after runReview completes", async () => {

--- a/test/unit/review/semantic.test.ts
+++ b/test/unit/review/semantic.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { buildSessionName } from "../../../src/agents/acp/adapter";
+import { computeAcpHandle } from "../../../src/agents/acp/adapter";
 import type { AgentResult } from "../../../src/agents/types";
 import { _diffUtilsDeps } from "../../../src/review/diff-utils";
 import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
@@ -902,63 +902,74 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
     expect(agent.complete).not.toHaveBeenCalled();
   });
 
-  test("agent.run() receives acpSessionName targeting own reviewer-semantic session (#414)", async () => {
+  test("agent.run() receives sessionRole='reviewer-semantic' and featureName for own session (#414)", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
     const workdir = "/my/project";
     const featureName = "my-feature";
-    const expectedSession = buildSessionName(workdir, featureName, STORY.id, "reviewer-semantic");
 
     await runSemanticReview(workdir, "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, featureName);
 
     expect(agent.run).toHaveBeenCalled();
     const runOpts = (agent.run as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
-    expect(runOpts.acpSessionName).toBe(expectedSession);
+    // The adapter auto-derives the session handle from featureName + storyId + sessionRole.
+    expect(runOpts.sessionRole).toBe("reviewer-semantic");
+    expect(runOpts.featureName).toBe(featureName);
+    // Verify computeAcpHandle would derive the expected session name
+    const expectedSession = computeAcpHandle(workdir, featureName, STORY.id, "reviewer-semantic");
+    expect(expectedSession).toMatch(/^nax-[a-f0-9]+-my-feature-.+-reviewer-semantic$/);
   });
 
-  test("agent.run() initial call uses keepSessionOpen: true (session kept open for JSON retry)", async () => {
+  test("agent.run() initial call uses keepOpen: true (session kept open for JSON retry)", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent);
 
     expect(agent.run).toHaveBeenCalled();
     const runOpts = (agent.run as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
-    expect(runOpts.keepSessionOpen).toBe(true);
+    expect(runOpts.keepOpen).toBe(true);
   });
 
-  test("acpSessionName encodes workdir hash in session name", async () => {
+  test("session handle encodes workdir hash in session name (via computeAcpHandle)", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
     const workdirA = "/project/alpha";
     const workdirB = "/project/beta";
-    const sessionA = buildSessionName(workdirA, "feat", STORY.id, "reviewer-semantic");
-    const sessionB = buildSessionName(workdirB, "feat", STORY.id, "reviewer-semantic");
+    const sessionA = computeAcpHandle(workdirA, "feat", STORY.id, "reviewer-semantic");
+    const sessionB = computeAcpHandle(workdirB, "feat", STORY.id, "reviewer-semantic");
 
     await runSemanticReview(workdirA, "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, "feat");
     const runOptsA = (agent.run as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
 
-    expect(runOptsA.acpSessionName).toBe(sessionA);
-    expect(runOptsA.acpSessionName).not.toBe(sessionB);
+    // The derived handle for workdirA should differ from workdirB
+    expect(sessionA).not.toBe(sessionB);
+    // The caller passes featureName and storyId so adapter can derive the correct handle
+    expect(runOptsA.featureName).toBe("feat");
+    expect(runOptsA.storyId).toBe(STORY.id);
   });
 
-  test("acpSessionName encodes featureName in session name", async () => {
+  test("session handle encodes featureName in session name (via computeAcpHandle)", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
     const featureName = "semantic-continuity";
-    const expectedSession = buildSessionName("/tmp/wd", featureName, STORY.id, "reviewer-semantic");
+    const expectedSession = computeAcpHandle("/tmp/wd", featureName, STORY.id, "reviewer-semantic");
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, featureName);
 
     const runOpts = (agent.run as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
-    expect(runOpts.acpSessionName).toBe(expectedSession);
+    // Adapter derives session from featureName; verify correct featureName is passed
+    expect(runOpts.featureName).toBe(featureName);
+    expect(expectedSession).toContain("semantic-continuity");
   });
 
-  test("acpSessionName encodes storyId in session name", async () => {
+  test("session handle encodes storyId in session name (via computeAcpHandle)", async () => {
     const agent = makeRunMockAgent(PASSING_LLM_RESPONSE);
     const storyWithDifferentId: SemanticStory = { ...STORY, id: "US-999" };
-    const expectedSession = buildSessionName("/tmp/wd", "feat", "US-999", "reviewer-semantic");
+    const expectedSession = computeAcpHandle("/tmp/wd", "feat", "US-999", "reviewer-semantic");
 
     await runSemanticReview("/tmp/wd", "abc123", storyWithDifferentId, DEFAULT_SEMANTIC_CONFIG, () => agent, undefined, "feat");
 
     const runOpts = (agent.run as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
-    expect(runOpts.acpSessionName).toBe(expectedSession);
+    // Adapter derives session from storyId; verify correct storyId is passed
+    expect(runOpts.storyId).toBe("US-999");
+    expect(expectedSession).toContain("us-999");
   });
 
   test("extracts rawResponse from AgentRunResult.output field — passed=true", async () => {

--- a/test/unit/tdd/rectification-gate-session.test.ts
+++ b/test/unit/tdd/rectification-gate-session.test.ts
@@ -117,7 +117,7 @@ afterEach(() => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("rectification session reuse", () => {
-  test("all attempts use the same acpSessionName", async () => {
+  test("all attempts use the same sessionRole", async () => {
     const story = makeStory();
     const config = makeConfig(2); // maxRetries=2
     const agent = makeAgent();
@@ -138,13 +138,14 @@ describe("rectification session reuse", () => {
 
     expect(agent.calls.length).toBe(2); // both attempts ran
 
-    const sessionNames = agent.calls.map((c) => c.acpSessionName);
-    // Both attempts must share the same session name
-    expect(sessionNames[0]).toBeDefined();
-    expect(sessionNames[0]).toBe(sessionNames[1]);
+    // The adapter auto-derives session handle from featureName + storyId + sessionRole.
+    // Both attempts must share the same sessionRole so the adapter uses the same session.
+    const sessionRoles = agent.calls.map((c) => c.sessionRole);
+    expect(sessionRoles[0]).toBeDefined();
+    expect(sessionRoles[0]).toBe(sessionRoles[1]);
   });
 
-  test("keepSessionOpen=true for all attempts except the last", async () => {
+  test("keepOpen=true for all attempts except the last", async () => {
     const story = makeStory();
     const config = makeConfig(3); // maxRetries=3 — three attempts
     const agent = makeAgent();
@@ -165,14 +166,14 @@ describe("rectification session reuse", () => {
 
     expect(agent.calls.length).toBe(3);
 
-    // Attempts 1 and 2 (not last): keepSessionOpen=true
-    expect(agent.calls[0]!.keepSessionOpen).toBe(true);
-    expect(agent.calls[1]!.keepSessionOpen).toBe(true);
-    // Last attempt: keepSessionOpen=false so session closes normally
-    expect(agent.calls[2]!.keepSessionOpen).toBe(false);
+    // Attempts 1 and 2 (not last): keepOpen=true
+    expect(agent.calls[0]!.keepOpen).toBe(true);
+    expect(agent.calls[1]!.keepOpen).toBe(true);
+    // Last attempt: keepOpen=false so session closes normally
+    expect(agent.calls[2]!.keepOpen).toBe(false);
   });
 
-  test("session closes on the last attempt (keepSessionOpen=false or undefined)", async () => {
+  test("session closes on the last attempt (keepOpen=false or undefined)", async () => {
     const story = makeStory();
     const config = makeConfig(2);
     const agent = makeAgent();
@@ -191,11 +192,11 @@ describe("rectification session reuse", () => {
     } as any);
 
     expect(agent.calls.length).toBe(2);
-    // Last attempt must NOT set keepSessionOpen=true
-    expect(agent.calls[1]!.keepSessionOpen).not.toBe(true);
+    // Last attempt must NOT set keepOpen=true
+    expect(agent.calls[1]!.keepOpen).not.toBe(true);
   });
 
-  test("all attempts use the same session name even without featureName", async () => {
+  test("all attempts use the same sessionRole even without featureName", async () => {
     const story = makeStory({ id: "US-002" });
     const config = makeConfig(2);
     const agent = makeAgent();
@@ -214,8 +215,8 @@ describe("rectification session reuse", () => {
     } as any); // no featureName
 
     expect(agent.calls.length).toBe(2);
-    const [name1, name2] = agent.calls.map((c) => c.acpSessionName);
-    expect(name1).toBeDefined();
-    expect(name1).toBe(name2);
+    const [role1, role2] = agent.calls.map((c) => c.sessionRole);
+    expect(role1).toBeDefined();
+    expect(role1).toBe(role2);
   });
 });

--- a/test/unit/tdd/session-runner-keep-open.test.ts
+++ b/test/unit/tdd/session-runner-keep-open.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for session-runner.ts — keepSessionOpen for implementer role.
+ * Tests for session-runner.ts — keepOpen for implementer role.
  *
  * Uses injectable _sessionRunnerDeps instead of mock.module() to avoid
  * permanent module replacement that contaminates other test files.
@@ -99,40 +99,40 @@ afterEach(() => {
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("session-runner implementer keepSessionOpen", () => {
-  test("implementer sets keepSessionOpen=true when rectification is enabled", async () => {
+describe("session-runner implementer keepOpen", () => {
+  test("implementer sets keepOpen=true when rectification is enabled", async () => {
     const agent = makeAgent();
     const config = makeConfig(true);
 
     await runTddSession("implementer", agent as any, makeStory(), config, "/tmp/fake", "balanced", "HEAD");
 
-    expect(agent.capturedOpts?.keepSessionOpen).toBe(true);
+    expect(agent.capturedOpts?.keepOpen).toBe(true);
   });
 
-  test("implementer sets keepSessionOpen=false when rectification is disabled", async () => {
+  test("implementer sets keepOpen=false when rectification is disabled", async () => {
     const agent = makeAgent();
     const config = makeConfig(false);
 
     await runTddSession("implementer", agent as any, makeStory(), config, "/tmp/fake", "balanced", "HEAD");
 
-    expect(agent.capturedOpts?.keepSessionOpen).toBe(false);
+    expect(agent.capturedOpts?.keepOpen).toBe(false);
   });
 
-  test("test-writer never sets keepSessionOpen regardless of rectification config", async () => {
+  test("test-writer never sets keepOpen regardless of rectification config", async () => {
     const agent = makeAgent();
     const config = makeConfig(true);
 
     await runTddSession("test-writer", agent as any, makeStory(), config, "/tmp/fake", "balanced", "HEAD");
 
-    expect(agent.capturedOpts?.keepSessionOpen).toBeFalsy();
+    expect(agent.capturedOpts?.keepOpen).toBeFalsy();
   });
 
-  test("verifier never sets keepSessionOpen regardless of rectification config", async () => {
+  test("verifier never sets keepOpen regardless of rectification config", async () => {
     const agent = makeAgent();
     const config = makeConfig(true);
 
     await runTddSession("verifier", agent as any, makeStory(), config, "/tmp/fake", "balanced", "HEAD");
 
-    expect(agent.capturedOpts?.keepSessionOpen).toBeFalsy();
+    expect(agent.capturedOpts?.keepOpen).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Summary

- Renames `buildSessionName` → `computeAcpHandle` in `src/agents/acp/adapter.ts` and all 11 import sites
- Removes `acpSessionName` from `AgentRunOptions` — replaced with `sessionHandle` for the rare cases needing an explicit override (only `dialogue.ts`); all other callers now rely on adapter auto-derivation from `featureName`/`storyId`/`sessionRole`
- Renames `keepSessionOpen` → `keepOpen` in `AgentRunOptions`, the adapter finally block, and all 12 callers
- Adds source invariant tests (`test/unit/agents/session-fields-invariants.test.ts`) that grep `src/` and fail if any legacy symbol reappears
- Phase 4 gate (`grep -rn "buildSessionName\|keepSessionOpen\|acpSessionName" src/`) now returns 0 hits, unblocking Phase 4

## Architecture

Most callers that set `acpSessionName: buildSessionName(workdir, featureName, storyId, sessionRole)` were redundant — the adapter already auto-derives the identical name from those same fields. Removing the explicit pass simplifies call sites with no behavioural change. `sessionHandle` is now the explicit-override escape hatch, used only by `dialogue.ts` for generation-scoped names (`nax-reviewer-${storyId}-gen${n}`) that cannot be auto-derived.

## Test Plan

- [ ] `grep -rn "buildSessionName\|acpSessionName\|keepSessionOpen" src/` returns 0 hits
- [ ] `bun run typecheck` passes
- [ ] `bun run test:bail` passes (1226 tests, 0 failures)
- [ ] `bun run lint` clean
- [ ] Source invariant tests (`session-fields-invariants.test.ts`) all 3 pass