### PR TITLE
fix(config): reject legacy agent keys with migration pointer (ADR-012 Phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
-- `autoMode.defaultAgent` and `autoMode.fallbackOrder` config fields removed. Use `agent.default` and `agent.fallback.map` instead (ADR-012 Phase 6). Loading a legacy config now fails Zod validation.
+- `autoMode.defaultAgent`, `autoMode.fallbackOrder`, and `context.v2.fallback` config fields removed. Use `agent.default` and `agent.fallback.map` instead (ADR-012 Phase 6). Loading a config containing any of these keys throws `NaxError CONFIG_LEGACY_AGENT_KEYS` with a per-key migration pointer.
 
 ## [0.51.2] — 2026-03-22
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -6,6 +6,7 @@
 
 import { existsSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
+import { NaxError } from "../errors";
 import { getLogger } from "../logger";
 import { loadJsonFile } from "../utils/json-file";
 import { mergePackageConfig } from "./merge";
@@ -59,6 +60,54 @@ function applyRemovedStrategyCompat(conf: Record<string, unknown>): Record<strin
     return { ...conf, routing: { ...routing, strategy: "keyword" } };
   }
   return conf;
+}
+
+/**
+ * @internal ADR-012 Phase 6 — reject pre-migration agent keys with a migration pointer.
+ *
+ * Zod's default `.strip()` mode silently drops unknown keys, so pre-migration
+ * configs containing `autoMode.defaultAgent`, `autoMode.fallbackOrder`, or
+ * `context.v2.fallback` would otherwise run with the wrong default agent and
+ * no fallback chain — the exact "T16.3 silent no-op" failure mode ADR-012 was
+ * designed to prevent. Throw a NaxError that tells the user what to change.
+ *
+ * Called on the merged raw config at a single point (after defaults + global +
+ * project + profile + CLI merge) so one check catches keys from any source.
+ */
+function rejectLegacyAgentKeys(conf: Record<string, unknown>): void {
+  const legacyKeys: string[] = [];
+  const migrationHints: string[] = [];
+
+  const autoMode = conf.autoMode as Record<string, unknown> | undefined;
+  if (autoMode && typeof autoMode === "object") {
+    if ("defaultAgent" in autoMode) {
+      legacyKeys.push("autoMode.defaultAgent");
+      migrationHints.push("- Move `autoMode.defaultAgent` → `agent.default`");
+    }
+    if ("fallbackOrder" in autoMode) {
+      legacyKeys.push("autoMode.fallbackOrder");
+      migrationHints.push(
+        "- Move `autoMode.fallbackOrder: [primary, ...]` → `agent.fallback.map: { <primary>: [<rest>] }` and `agent.fallback.enabled: true`",
+      );
+    }
+  }
+
+  const context = conf.context as Record<string, unknown> | undefined;
+  const contextV2 = context?.v2 as Record<string, unknown> | undefined;
+  if (contextV2 && typeof contextV2 === "object" && "fallback" in contextV2) {
+    legacyKeys.push("context.v2.fallback");
+    migrationHints.push("- Move `context.v2.fallback` → `agent.fallback` (see ADR-012 Phase 6)");
+  }
+
+  if (legacyKeys.length === 0) return;
+
+  const message = [
+    `Invalid configuration — legacy agent keys detected: ${legacyKeys.join(", ")}.`,
+    "These were removed in ADR-012 Phase 6. Migrate to the canonical `agent.*` shape:",
+    ...migrationHints,
+    "See docs/adr/ADR-012-agent-manager-ownership.md for the full migration guide.",
+  ].join("\n");
+  throw new NaxError(message, "CONFIG_LEGACY_AGENT_KEYS", { stage: "config", legacyKeys });
 }
 
 /** @internal Backward compat: map deprecated routing.llm.batchMode to routing.llm.mode.
@@ -180,6 +229,10 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
     return structuredClone(DEFAULT_CONFIG as unknown as Record<string, unknown>) as unknown as NaxConfig;
   }
 
+  // ADR-012 Phase 6 — reject pre-migration agent keys with a migration pointer.
+  // Must run BEFORE Zod safeParse, otherwise .strip() silently drops the keys.
+  rejectLegacyAgentKeys(rawConfig);
+
   const result = NaxConfigSchema.safeParse(rawConfig);
   if (!result.success) {
     const errors = result.error.issues.map((err) => {
@@ -267,8 +320,13 @@ export async function loadConfigForWorkdir(
   if (packageProfile && packageProfile !== "default") {
     const packageRoot = join(repoRoot, packageDir);
     const profileData = await loadProfile(packageProfile, packageRoot);
-    const rawMerged = deepMergeConfig(merged as unknown as Record<string, unknown>, profileData);
+    const rawMerged = deepMergeConfig<Record<string, unknown>>(
+      merged as unknown as Record<string, unknown>,
+      profileData,
+    );
     rawMerged.profile = packageProfile;
+    // ADR-012 Phase 6 — legacy-key guard applies to per-package overlays too.
+    rejectLegacyAgentKeys(rawMerged);
     const result = NaxConfigSchema.safeParse(rawMerged);
     if (result.success) {
       merged = result.data as NaxConfig;

--- a/test/unit/config/legacy-agent-keys.test.ts
+++ b/test/unit/config/legacy-agent-keys.test.ts
@@ -1,0 +1,124 @@
+// test/unit/config/legacy-agent-keys.test.ts
+//
+// Regression guard for ADR-012 Phase 6: loading a pre-migration config with
+// legacy agent keys (autoMode.defaultAgent / autoMode.fallbackOrder /
+// context.v2.fallback) must throw with a clear migration message.
+//
+// Without this guard, Zod's default .strip() mode silently drops the unknown
+// keys and the run continues with agent.default="claude" — re-introducing
+// the exact silent-no-op failure mode the ADR was designed to prevent.
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NaxError } from "../../../src/errors";
+import { _clearRootConfigCache, loadConfig } from "../../../src/config/loader";
+
+function writeProjectConfig(contents: object): string {
+  const root = mkdtempSync(join(tmpdir(), "nax-legacy-cfg-"));
+  const naxDir = join(root, ".nax");
+  require("node:fs").mkdirSync(naxDir, { recursive: true });
+  writeFileSync(join(naxDir, "config.json"), JSON.stringify(contents, null, 2));
+  return root;
+}
+
+describe("ADR-012 Phase 6 — legacy config key guard", () => {
+  beforeEach(() => {
+    _clearRootConfigCache();
+  });
+
+  test("rejects autoMode.defaultAgent with migration pointer", async () => {
+    const root = writeProjectConfig({
+      autoMode: { defaultAgent: "codex" },
+    });
+    try {
+      await loadConfig(root);
+      throw new Error("expected loadConfig to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(NaxError);
+      const e = err as NaxError;
+      expect(e.code).toBe("CONFIG_LEGACY_AGENT_KEYS");
+      expect(e.message).toContain("autoMode.defaultAgent");
+      expect(e.message).toContain("agent.default");
+      expect(e.message).toContain("ADR-012");
+    }
+  });
+
+  test("rejects autoMode.fallbackOrder with migration pointer", async () => {
+    const root = writeProjectConfig({
+      autoMode: { fallbackOrder: ["claude", "codex"] },
+    });
+    try {
+      await loadConfig(root);
+      throw new Error("expected loadConfig to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(NaxError);
+      const e = err as NaxError;
+      expect(e.code).toBe("CONFIG_LEGACY_AGENT_KEYS");
+      expect(e.message).toContain("autoMode.fallbackOrder");
+      expect(e.message).toContain("agent.fallback.map");
+      expect(e.message).toContain("ADR-012");
+    }
+  });
+
+  test("rejects context.v2.fallback with migration pointer", async () => {
+    const root = writeProjectConfig({
+      context: { v2: { fallback: { enabled: true } } },
+    });
+    try {
+      await loadConfig(root);
+      throw new Error("expected loadConfig to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(NaxError);
+      const e = err as NaxError;
+      expect(e.code).toBe("CONFIG_LEGACY_AGENT_KEYS");
+      expect(e.message).toContain("context.v2.fallback");
+      expect(e.message).toContain("agent.fallback");
+      expect(e.message).toContain("ADR-012");
+    }
+  });
+
+  test("reports all legacy keys at once", async () => {
+    const root = writeProjectConfig({
+      autoMode: { defaultAgent: "codex", fallbackOrder: ["codex"] },
+      context: { v2: { fallback: { enabled: true } } },
+    });
+    try {
+      await loadConfig(root);
+      throw new Error("expected loadConfig to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(NaxError);
+      const e = err as NaxError;
+      expect(e.message).toContain("autoMode.defaultAgent");
+      expect(e.message).toContain("autoMode.fallbackOrder");
+      expect(e.message).toContain("context.v2.fallback");
+      const ctx = e.context as { legacyKeys?: string[] } | undefined;
+      expect(ctx?.legacyKeys).toEqual([
+        "autoMode.defaultAgent",
+        "autoMode.fallbackOrder",
+        "context.v2.fallback",
+      ]);
+    }
+  });
+
+  test("accepts canonical config — agent.default + agent.fallback.map", async () => {
+    const root = writeProjectConfig({
+      agent: {
+        default: "claude",
+        fallback: { enabled: true, map: { claude: ["codex"] } },
+      },
+    });
+    const config = await loadConfig(root);
+    expect(config.agent?.default).toBe("claude");
+    expect(config.agent?.fallback?.enabled).toBe(true);
+    expect(config.agent?.fallback?.map).toEqual({ claude: ["codex"] });
+  });
+
+  test("accepts config with no agent section (uses defaults)", async () => {
+    const root = writeProjectConfig({});
+    const config = await loadConfig(root);
+    expect(config.agent?.default).toBe("claude");
+    expect(config.agent?.fallback?.enabled).toBe(false);
+  });
+});

--- a/test/unit/config/phase6-invariants.test.ts
+++ b/test/unit/config/phase6-invariants.test.ts
@@ -55,7 +55,9 @@ describe("Phase 6 invariants — migration shim removal", () => {
     );
     const out = await new Response(proc.stdout).text();
     await proc.exited;
-    const offenders = out.trim().split("\n").filter((l) => l.length > 0);
+    // src/config/ is allowed to mention the string in the legacy-key rejection
+    // guard's error message (ADR-012 Phase 6).
+    const offenders = out.trim().split("\n").filter((l) => l.length > 0 && !l.includes("src/config/"));
     expect(offenders).toEqual([]);
   });
 
@@ -73,5 +75,13 @@ describe("Phase 6 invariants — migration shim removal", () => {
     const code = await readSrc("src/config/validate.ts");
     expect(code).not.toContain("autoMode.defaultAgent");
     expect(code).not.toContain("autoMode.fallbackOrder");
+  });
+
+  test("loader.ts rejects legacy keys (not just strips) — see legacy-agent-keys.test.ts for behaviour", async () => {
+    // Structural check: loader must actively reject legacy keys, not rely on Zod's default
+    // .strip() mode (which would silently drop them — the T16.3 failure mode ADR-012 prevents).
+    const code = await readSrc("src/config/loader.ts");
+    expect(code).toContain("rejectLegacyAgentKeys");
+    expect(code).toContain("CONFIG_LEGACY_AGENT_KEYS");
   });
 });


### PR DESCRIPTION
## Summary

Closes the last outstanding AC for ADR-012 Phase 6 — the guarantee that loading a pre-migration config produces a clear validation error.

**Problem:** Zod's default `.strip()` mode silently drops unknown keys. Configs containing `autoMode.defaultAgent`, `autoMode.fallbackOrder`, or `context.v2.fallback` would load without error, run with `agent.default = "claude"`, and lose their fallback chain — re-introducing the T16.3 silent-no-op failure mode the ADR was designed to prevent. The CHANGELOG's "Loading a legacy config now fails Zod validation" claim was factually wrong.

**Fix:** `rejectLegacyAgentKeys()` runs before `NaxConfigSchema.safeParse` in `loadConfig()` and `loadConfigForWorkdir()`'s per-package overlay path. Throws `NaxError CONFIG_LEGACY_AGENT_KEYS` with a per-key migration hint and ADR-012 pointer.

Example error:
```
Invalid configuration — legacy agent keys detected: autoMode.defaultAgent, autoMode.fallbackOrder.
These were removed in ADR-012 Phase 6. Migrate to the canonical `agent.*` shape:
- Move `autoMode.defaultAgent` → `agent.default`
- Move `autoMode.fallbackOrder: [primary, ...]` → `agent.fallback.map: { <primary>: [<rest>] }` and `agent.fallback.enabled: true`
See docs/adr/ADR-012-agent-manager-ownership.md for the full migration guide.
```

## Files

- `src/config/loader.ts` — new `rejectLegacyAgentKeys()` guard, wired at 2 call sites
- `test/unit/config/legacy-agent-keys.test.ts` — 6 TDD regression tests (4 reject + 2 accept)
- `test/unit/config/phase6-invariants.test.ts` — add structural assertion that the guard is in place
- `CHANGELOG.md` — correct the breaking-change note to reflect actual enforcement

## Context

This fix addresses finding **#1 (high severity)** in [`docs/reviews/ADR-012-implementation-review.md`](docs/reviews/ADR-012-implementation-review.md). Other findings from that review (`costUsd` threading, `RunSummary.fallback` aggregates, doc alignment, dead-code cleanup) are tracked separately and will land in follow-up PRs.

## Test Plan

- [x] RED-then-GREEN TDD on `legacy-agent-keys.test.ts` (4 reject cases, 2 accept cases)
- [x] `bun run test` — 6379 unit + 1187 integration, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Self-bootstrap: `loadConfig(".")` on this repo's own `.nax/config.json` still passes (repo was migrated in c38de367)
- [x] Profile overlays: `opencode` and `opencode-debate` still load
- [x] Manual smoke test: hand-crafted legacy config surfaces the expected multi-line error with the right `CONFIG_LEGACY_AGENT_KEYS` code

## Why not `NaxConfigSchema.strict()`?

Too wide — every test fixture with an unknown key (there are many — see issue #578) would break immediately. The targeted pre-parse check is surgical and specifically targets the three legacy keys ADR-012 retired.