### PR TITLE
feat(metrics): thread costUsd + surface RunMetrics.fallback aggregate (ADR-012 PR-2)

### DIFF
--- a/docs/reviews/ADR-012-implementation-review.md
+++ b/docs/reviews/ADR-012-implementation-review.md
@@ -218,3 +218,15 @@ Recommended: delete `resetStoryState` + `clearUnavailableAgents` (one PR, ~30 li
 12. If follow-up #577 / #578 exist for aggregates or credential-pre-flight surfacing, link them from the ADR's "Phase 5 follow-ups" section so the doc-vs-code drift is at least traceable.
 13. Recover the codemod artefact (Phase 3 AC) or remove the AC from the ADR. Either is fine; the discrepancy is what matters.
 
+---
+
+## Resolution log
+
+| Finding | PR | Status |
+|:---|:---|:---|
+| #1 Phase 6 silent-strip regression | #579 | ✅ Fixed — `rejectLegacyAgentKeys()` guard in `src/config/loader.ts` |
+| #2 `costUsd` dropped on `AgentFallbackHop` | PR-2 (this change) | ✅ Fixed — field added to `AgentFallbackHop`; preserved in `src/pipeline/stages/execution.ts` |
+| #3 `RunMetrics.fallback` aggregates never surfaced | PR-2 (this change) | ✅ Fixed — `deriveRunFallbackAggregates` in `src/metrics/aggregator.ts`; surfaced on `run:completed` event and saved `RunMetrics` |
+| #4 Doc-reality gap (`conventions.md` / `config-patterns.md`) | PR-3 (pending) | Open |
+| Dead-code cleanup (`clearUnavailableAgents` / `resetStoryState` / `onBeforeStory` hook) | PR-3 (pending) | Open |
+

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -13,7 +13,7 @@ import { fireHook } from "../../hooks/runner";
 import type { HooksConfig } from "../../hooks/types";
 import { getSafeLogger } from "../../logger";
 import type { StoryMetrics } from "../../metrics";
-import { saveRunMetrics } from "../../metrics";
+import { deriveRunFallbackAggregates, saveRunMetrics } from "../../metrics";
 import { pipelineEventBus } from "../../pipeline/event-bus";
 import type { AgentGetFn } from "../../pipeline/types";
 import { countStories, isComplete, isStalled } from "../../prd";
@@ -210,6 +210,11 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
   // Compute final story counts before emitting completion event (RL-002)
   const finalCounts = countStories(prd);
 
+  // ADR-012 PR-2: aggregate agent-swap cost/hop data for run-level visibility.
+  // Undefined when no hops occurred — conditionally spread into both the event
+  // and the saved metrics so consumers see the field only when meaningful.
+  const fallbackAggregate = deriveRunFallbackAggregates(allStoryMetrics);
+
   // Emit run:completed after regression gate with real story counts (RL-002)
   pipelineEventBus.emit({
     type: "run:completed",
@@ -220,6 +225,7 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
     pausedStories: finalCounts.paused,
     durationMs,
     totalCost,
+    ...(fallbackAggregate && { fallback: fallbackAggregate }),
   });
   // Drain async subscriber Promises (reporter.onRunEnd file writes, etc.) before
   // proceeding. Without this, run:completed handlers may not finish before caller returns.
@@ -237,6 +243,7 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
     storiesFailed: finalCounts.failed,
     totalDurationMs: durationMs,
     stories: allStoryMetrics,
+    ...(fallbackAggregate && { fallback: fallbackAggregate }),
   };
 
   try {

--- a/src/metrics/aggregator.ts
+++ b/src/metrics/aggregator.ts
@@ -4,7 +4,7 @@
  * Calculates aggregate metrics across all runs.
  */
 
-import type { AggregateMetrics, RunMetrics, StoryMetrics } from "./types";
+import type { AggregateMetrics, RunFallbackAggregate, RunMetrics, StoryMetrics } from "./types";
 
 /**
  * Calculate aggregate metrics across all runs.
@@ -188,4 +188,54 @@ export function getLastRun(runs: RunMetrics[]): RunMetrics | null {
 
   // Runs are appended chronologically, so last element is most recent
   return runs[runs.length - 1];
+}
+
+/**
+ * Derive run-level fallback aggregates from per-story metrics.
+ *
+ * Pure function — inspects `story.fallback?.hops` on every story and returns:
+ *   - totalHops: sum of hops
+ *   - perPair:  hops grouped by `${priorAgent}->${newAgent}`
+ *   - exhaustedStories: stories where the final hop was an availability failure
+ *                       and the story itself did not succeed (proxy for
+ *                       `onSwapExhausted` emission from AgentManager)
+ *   - totalWastedCostUsd: Σ `hop.costUsd` across every hop
+ *
+ * Returns `undefined` when no story has any fallback hops. Callers attach the
+ * result to `RunMetrics.fallback` conditionally.
+ *
+ * @see docs/adr/ADR-012-agent-manager-ownership.md
+ * @see docs/reviews/ADR-012-implementation-review.md — review findings #2 and #3
+ */
+export function deriveRunFallbackAggregates(stories: StoryMetrics[]): RunFallbackAggregate | undefined {
+  if (stories.length === 0) return undefined;
+
+  let totalHops = 0;
+  const perPair: Record<string, number> = {};
+  const exhaustedStories: string[] = [];
+  let totalWastedCostUsd = 0;
+
+  for (const story of stories) {
+    const hops = story.fallback?.hops;
+    if (!hops || hops.length === 0) continue;
+
+    totalHops += hops.length;
+
+    for (const h of hops) {
+      const key = `${h.priorAgent}->${h.newAgent}`;
+      perPair[key] = (perPair[key] ?? 0) + 1;
+      totalWastedCostUsd += h.costUsd ?? 0;
+    }
+
+    // Exhausted = failed story whose last hop was an availability failure.
+    // Mirrors AgentManager's onSwapExhausted emission condition.
+    const lastHop = hops[hops.length - 1];
+    if (!story.success && lastHop && lastHop.category === "availability") {
+      exhaustedStories.push(story.storyId);
+    }
+  }
+
+  if (totalHops === 0) return undefined;
+
+  return { totalHops, perPair, exhaustedStories, totalWastedCostUsd };
 }

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -4,11 +4,18 @@
  * Per-story and per-run cost tracking for data-driven routing optimization.
  */
 
-export type { StoryMetrics, RunMetrics, AggregateMetrics, TokenUsage } from "./types";
+export type {
+  AgentFallbackHop,
+  AggregateMetrics,
+  RunFallbackAggregate,
+  RunMetrics,
+  StoryMetrics,
+  TokenUsage,
+} from "./types";
 export {
   collectStoryMetrics,
   collectBatchMetrics,
   saveRunMetrics,
   loadRunMetrics,
 } from "./tracker";
-export { calculateAggregateMetrics, getLastRun } from "./aggregator";
+export { calculateAggregateMetrics, deriveRunFallbackAggregates, getLastRun } from "./aggregator";

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -83,6 +83,13 @@ export interface AgentFallbackHop {
   category: string;
   /** 1-indexed hop counter within this story's pipeline run */
   hop: number;
+  /**
+   * Cost incurred on the hop that FAILED (the attempt on `priorAgent` that triggered
+   * the swap to `newAgent`). Sourced from the failing agent's `AgentResult.estimatedCost`.
+   * Zero when the adapter did not report a cost. Summed across hops into
+   * `RunMetrics.fallback.totalWastedCostUsd` (ADR-012 / review #2).
+   */
+  costUsd: number;
 }
 
 /**
@@ -187,6 +194,35 @@ export interface StoryMetrics {
 }
 
 /**
+ * Run-level fallback aggregates (ADR-012 / review #3).
+ *
+ * Derived from `StoryMetrics.fallback.hops` via `deriveRunFallbackAggregates`.
+ * Absent on `RunMetrics` when no swaps occurred in the run.
+ */
+export interface RunFallbackAggregate {
+  /** Total number of hops across all stories in this run. */
+  totalHops: number;
+  /**
+   * Hop count per `priorAgent->newAgent` transition. Key format is `${prior}->${new}`
+   * (e.g. "codex->claude"). Useful for spotting adapter-specific instability.
+   */
+  perPair: Record<string, number>;
+  /**
+   * Story IDs where `AgentManager.runWithFallback` emitted `onSwapExhausted`
+   * (i.e. ran out of candidates). Detected by the last hop's `outcome` being
+   * an availability failure on a story that ultimately did not succeed.
+   * Empty array when nothing exhausted.
+   */
+  exhaustedStories: string[];
+  /**
+   * Sum of `AgentFallbackHop.costUsd` across every hop in the run — the cost
+   * the user paid on failed attempts that led to a swap. Never includes the
+   * final (successful or last-attempted) hop's cost; that lives on `StoryMetrics.cost`.
+   */
+  totalWastedCostUsd: number;
+}
+
+/**
  * Per-run execution metrics
  */
 export interface RunMetrics {
@@ -212,6 +248,11 @@ export interface RunMetrics {
   stories: StoryMetrics[];
   /** Total token usage for the run */
   totalTokens?: TokenUsage;
+  /**
+   * Run-level agent-swap aggregates (ADR-012).
+   * Absent when no swaps occurred in this run.
+   */
+  fallback?: RunFallbackAggregate;
 }
 
 /**

--- a/src/pipeline/event-bus.ts
+++ b/src/pipeline/event-bus.ts
@@ -118,6 +118,12 @@ export interface RunCompletedEvent {
   pausedStories: number;
   durationMs: number;
   totalCost?: number;
+  /**
+   * Run-level agent-swap aggregates (ADR-012).
+   * Absent when no swaps occurred in this run. Subscribers (reporters,
+   * events writer, TUI) should treat it as an optional enrichment.
+   */
+  fallback?: import("../metrics/types").RunFallbackAggregate;
 }
 
 export interface HumanReviewRequestedEvent {

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -307,6 +307,7 @@ export const executionStage: PipelineStage = {
         outcome: f.outcome,
         category: f.category,
         hop: f.hop,
+        costUsd: f.costUsd,
       }));
     }
 

--- a/test/unit/execution/lifecycle/run-completion-fallback.test.ts
+++ b/test/unit/execution/lifecycle/run-completion-fallback.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for RunFallbackAggregate wiring in handleRunCompletion (ADR-012 PR-2).
+ *
+ * Verifies that handleRunCompletion computes RunFallbackAggregate from story
+ * metrics and attaches it to (a) the emitted run:completed event and
+ * (b) the saved RunMetrics JSONL payload.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
+import type { NaxConfig } from "../../../../src/config";
+import {
+  _runCompletionDeps,
+  handleRunCompletion,
+  type RunCompletionOptions,
+} from "../../../../src/execution/lifecycle/run-completion";
+import type { DeferredRegressionResult } from "../../../../src/execution/lifecycle/run-regression";
+import type { AgentFallbackHop, StoryMetrics } from "../../../../src/metrics";
+import { pipelineEventBus } from "../../../../src/pipeline/event-bus";
+import type { RunCompletedEvent } from "../../../../src/pipeline/event-bus";
+import type { PRD, UserStory } from "../../../../src/prd";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStory(id: string, status: UserStory["status"]): UserStory {
+  return {
+    id,
+    title: `Story ${id}`,
+    description: "Test story",
+    acceptanceCriteria: [],
+    tags: [],
+    dependencies: [],
+    status,
+    passes: status === "passed",
+    escalations: [],
+    attempts: 1,
+  };
+}
+
+function makePRD(stories: Array<{ id: string; status: UserStory["status"] }>): PRD {
+  return {
+    project: "test-project",
+    feature: "test-feature",
+    branchName: "test-branch",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    userStories: stories.map(({ id, status }) => makeStory(id, status)),
+  };
+}
+
+function makeStatusWriter() {
+  return {
+    setPrd: mock(() => {}),
+    setCurrentStory: mock(() => {}),
+    setRunStatus: mock(() => {}),
+    setPostRunPhase: mock((_phase: string, _update: Record<string, unknown>) => {}),
+    update: mock(async () => {}),
+    writeFeatureStatus: mock(async () => {}),
+  };
+}
+
+function makeStoryMetrics(storyId: string, success: boolean, hops: AgentFallbackHop[]): StoryMetrics {
+  return {
+    storyId,
+    complexity: "medium",
+    modelTier: "balanced",
+    modelUsed: "claude-sonnet",
+    attempts: 1,
+    finalTier: "balanced",
+    success,
+    cost: 0,
+    durationMs: 1000,
+    firstPassSuccess: success,
+    startedAt: "2026-04-20T00:00:00.000Z",
+    completedAt: "2026-04-20T00:00:01.000Z",
+    ...(hops.length > 0 && { fallback: { hops } }),
+  };
+}
+
+const WORKDIR = `/tmp/nax-test-pr2-fallback-${randomUUID()}`;
+
+function makeOpts(
+  prd: PRD,
+  allStoryMetrics: StoryMetrics[],
+): RunCompletionOptions {
+  const config: NaxConfig = {
+    ...DEFAULT_CONFIG,
+    execution: {
+      ...DEFAULT_CONFIG.execution,
+      regressionGate: { ...DEFAULT_CONFIG.execution.regressionGate, mode: "disabled" },
+    },
+  };
+  return {
+    runId: "run-001",
+    feature: "test-feature",
+    startedAt: new Date().toISOString(),
+    prd,
+    allStoryMetrics,
+    totalCost: 0,
+    storiesCompleted: allStoryMetrics.filter((s) => s.success).length,
+    iterations: 1,
+    startTime: Date.now() - 1000,
+    workdir: WORKDIR,
+    statusWriter: makeStatusWriter() as unknown as RunCompletionOptions["statusWriter"],
+    config,
+    isSequential: true,
+  };
+}
+
+const origDeps = { ..._runCompletionDeps };
+let capturedEvent: RunCompletedEvent | undefined;
+let unsub: (() => void) | undefined;
+
+beforeEach(() => {
+  _runCompletionDeps.runDeferredRegression = mock(
+    async (): Promise<DeferredRegressionResult> => ({
+      success: true,
+      failedTests: 0,
+      failedTestFiles: [],
+      passedTests: 0,
+      rectificationAttempts: 0,
+      affectedStories: [],
+    }),
+  );
+  capturedEvent = undefined;
+  unsub = pipelineEventBus.on("run:completed", (ev) => {
+    capturedEvent = ev;
+  });
+});
+
+afterEach(() => {
+  Object.assign(_runCompletionDeps, origDeps);
+  unsub?.();
+  pipelineEventBus.clear();
+  mock.restore();
+});
+
+// ---------------------------------------------------------------------------
+
+describe("handleRunCompletion — fallback aggregate wiring (ADR-012 PR-2)", () => {
+  test("emits run:completed with fallback aggregate when swaps occurred", async () => {
+    const story = makeStoryMetrics("US-001", true, [
+      {
+        storyId: "US-001",
+        priorAgent: "codex",
+        newAgent: "claude",
+        outcome: "fail-auth",
+        category: "availability",
+        hop: 1,
+        costUsd: 0.05,
+      },
+    ]);
+    const prd = makePRD([{ id: "US-001", status: "passed" }]);
+
+    await handleRunCompletion(makeOpts(prd, [story]));
+
+    expect(capturedEvent).toBeDefined();
+    expect(capturedEvent?.fallback).toBeDefined();
+    expect(capturedEvent?.fallback?.totalHops).toBe(1);
+    expect(capturedEvent?.fallback?.perPair).toEqual({ "codex->claude": 1 });
+    expect(capturedEvent?.fallback?.totalWastedCostUsd).toBeCloseTo(0.05, 5);
+    expect(capturedEvent?.fallback?.exhaustedStories).toEqual([]);
+  });
+
+  test("omits fallback from event when no swaps occurred", async () => {
+    const story = makeStoryMetrics("US-001", true, []);
+    const prd = makePRD([{ id: "US-001", status: "passed" }]);
+
+    await handleRunCompletion(makeOpts(prd, [story]));
+
+    expect(capturedEvent).toBeDefined();
+    expect(capturedEvent?.fallback).toBeUndefined();
+  });
+
+  test("marks story as exhausted when run failed and last hop was availability", async () => {
+    const story = makeStoryMetrics("US-001", false, [
+      {
+        storyId: "US-001",
+        priorAgent: "codex",
+        newAgent: "claude",
+        outcome: "fail-auth",
+        category: "availability",
+        hop: 1,
+        costUsd: 0.02,
+      },
+      {
+        storyId: "US-001",
+        priorAgent: "claude",
+        newAgent: "opencode",
+        outcome: "fail-rate-limit",
+        category: "availability",
+        hop: 2,
+        costUsd: 0.03,
+      },
+    ]);
+    const prd = makePRD([{ id: "US-001", status: "failed" }]);
+
+    await handleRunCompletion(makeOpts(prd, [story]));
+
+    expect(capturedEvent?.fallback?.exhaustedStories).toEqual(["US-001"]);
+    expect(capturedEvent?.fallback?.totalHops).toBe(2);
+    expect(capturedEvent?.fallback?.totalWastedCostUsd).toBeCloseTo(0.05, 5);
+  });
+});

--- a/test/unit/metrics/fallback-aggregates.test.ts
+++ b/test/unit/metrics/fallback-aggregates.test.ts
@@ -1,0 +1,183 @@
+// test/unit/metrics/fallback-aggregates.test.ts
+//
+// PR-2 (ADR-012 review): Cover `deriveRunFallbackAggregates` and AgentFallbackHop.costUsd.
+// The helper is a pure function over StoryMetrics[] → RunFallbackAggregate | undefined.
+
+import { describe, expect, test } from "bun:test";
+import { deriveRunFallbackAggregates } from "../../../src/metrics/aggregator";
+import type { AgentFallbackHop, RunFallbackAggregate, RunMetrics, StoryMetrics } from "../../../src/metrics/types";
+
+function storyWithHops(storyId: string, hops: AgentFallbackHop[], extra: Partial<StoryMetrics> = {}): StoryMetrics {
+  return {
+    storyId,
+    complexity: "medium",
+    modelTier: "balanced",
+    modelUsed: "claude-sonnet",
+    attempts: 1,
+    finalTier: "balanced",
+    success: true,
+    cost: 0,
+    durationMs: 0,
+    firstPassSuccess: true,
+    startedAt: "2026-04-20T00:00:00.000Z",
+    completedAt: "2026-04-20T00:00:01.000Z",
+    ...extra,
+    ...(hops.length > 0 && { fallback: { hops } }),
+  };
+}
+
+function hop(
+  storyId: string,
+  priorAgent: string,
+  newAgent: string,
+  costUsd: number,
+  overrides: Partial<AgentFallbackHop> = {},
+): AgentFallbackHop {
+  return {
+    storyId,
+    priorAgent,
+    newAgent,
+    outcome: "fail-auth",
+    category: "availability",
+    hop: 1,
+    costUsd,
+    ...overrides,
+  };
+}
+
+describe("AgentFallbackHop.costUsd (PR-2 type change)", () => {
+  test("hop literal accepts costUsd field", () => {
+    const h: AgentFallbackHop = {
+      storyId: "US-001",
+      priorAgent: "codex",
+      newAgent: "claude",
+      outcome: "fail-auth",
+      category: "availability",
+      hop: 1,
+      costUsd: 0.42,
+    };
+    expect(h.costUsd).toBe(0.42);
+  });
+});
+
+describe("RunFallbackAggregate shape (PR-2 type change)", () => {
+  test("exposes totalHops, perPair, exhaustedStories, totalWastedCostUsd", () => {
+    const agg: RunFallbackAggregate = {
+      totalHops: 3,
+      perPair: { "codex->claude": 2, "claude->opencode": 1 },
+      exhaustedStories: ["US-007"],
+      totalWastedCostUsd: 0.17,
+    };
+    expect(agg.totalHops).toBe(3);
+    expect(agg.perPair["codex->claude"]).toBe(2);
+    expect(agg.exhaustedStories).toEqual(["US-007"]);
+    expect(agg.totalWastedCostUsd).toBeCloseTo(0.17, 5);
+  });
+
+  test("RunMetrics accepts optional fallback field", () => {
+    const run: RunMetrics = {
+      runId: "r1",
+      feature: "f1",
+      startedAt: "2026-04-20T00:00:00.000Z",
+      completedAt: "2026-04-20T00:00:10.000Z",
+      totalCost: 0,
+      totalStories: 1,
+      storiesCompleted: 1,
+      storiesFailed: 0,
+      totalDurationMs: 10_000,
+      stories: [],
+      fallback: { totalHops: 0, perPair: {}, exhaustedStories: [], totalWastedCostUsd: 0 },
+    };
+    expect(run.fallback?.totalHops).toBe(0);
+  });
+});
+
+describe("deriveRunFallbackAggregates", () => {
+  test("returns undefined when no stories have fallback hops", () => {
+    const s = storyWithHops("US-001", []);
+    expect(deriveRunFallbackAggregates([s])).toBeUndefined();
+  });
+
+  test("returns undefined for empty story list", () => {
+    expect(deriveRunFallbackAggregates([])).toBeUndefined();
+  });
+
+  test("totals hops across all stories", () => {
+    const s1 = storyWithHops("US-001", [hop("US-001", "codex", "claude", 0.05)]);
+    const s2 = storyWithHops("US-002", [
+      hop("US-002", "codex", "claude", 0.03),
+      hop("US-002", "claude", "opencode", 0.02, { hop: 2 }),
+    ]);
+    const agg = deriveRunFallbackAggregates([s1, s2]);
+    expect(agg).toBeDefined();
+    expect(agg?.totalHops).toBe(3);
+  });
+
+  test("groups hops by priorAgent->newAgent pair", () => {
+    const s1 = storyWithHops("US-001", [hop("US-001", "codex", "claude", 0.01)]);
+    const s2 = storyWithHops("US-002", [hop("US-002", "codex", "claude", 0.01)]);
+    const s3 = storyWithHops("US-003", [hop("US-003", "claude", "opencode", 0.01)]);
+    const agg = deriveRunFallbackAggregates([s1, s2, s3]);
+    expect(agg?.perPair).toEqual({
+      "codex->claude": 2,
+      "claude->opencode": 1,
+    });
+  });
+
+  test("sums costUsd across all hops into totalWastedCostUsd", () => {
+    const s1 = storyWithHops("US-001", [hop("US-001", "codex", "claude", 0.07)]);
+    const s2 = storyWithHops("US-002", [
+      hop("US-002", "codex", "claude", 0.03),
+      hop("US-002", "claude", "opencode", 0.11, { hop: 2 }),
+    ]);
+    const agg = deriveRunFallbackAggregates([s1, s2]);
+    expect(agg?.totalWastedCostUsd).toBeCloseTo(0.21, 5);
+  });
+
+  test("treats missing costUsd as 0 (defensive — old saved metrics may lack field)", () => {
+    // Force a hop without costUsd to simulate deserialized-from-disk records.
+    const legacyHop = {
+      storyId: "US-001",
+      priorAgent: "codex",
+      newAgent: "claude",
+      outcome: "fail-auth",
+      category: "availability",
+      hop: 1,
+    } as unknown as AgentFallbackHop;
+    const s = storyWithHops("US-001", [legacyHop]);
+    const agg = deriveRunFallbackAggregates([s]);
+    expect(agg?.totalWastedCostUsd).toBe(0);
+  });
+
+  test("reports exhausted stories — last hop is availability failure AND story.success=false", () => {
+    const s1 = storyWithHops(
+      "US-001",
+      [
+        hop("US-001", "codex", "claude", 0.01, { outcome: "fail-auth", category: "availability" }),
+        hop("US-001", "claude", "opencode", 0.01, {
+          hop: 2,
+          outcome: "fail-rate-limit",
+          category: "availability",
+        }),
+      ],
+      { success: false },
+    );
+    const s2 = storyWithHops(
+      "US-002",
+      [hop("US-002", "codex", "claude", 0.01, { outcome: "fail-auth", category: "availability" })],
+      { success: true },
+    );
+    const agg = deriveRunFallbackAggregates([s1, s2]);
+    expect(agg?.exhaustedStories).toEqual(["US-001"]);
+  });
+
+  test("does not mark a story as exhausted when a swap eventually succeeded", () => {
+    const s = storyWithHops(
+      "US-001",
+      [hop("US-001", "codex", "claude", 0.01, { outcome: "fail-auth", category: "availability" })],
+      { success: true },
+    );
+    const agg = deriveRunFallbackAggregates([s]);
+    expect(agg?.exhaustedStories).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes findings **#2** (`costUsd` dropped) and **#3** (`RunMetrics.fallback` aggregates never surfaced) from [docs/reviews/ADR-012-implementation-review.md](docs/reviews/ADR-012-implementation-review.md). Honestly delivers on #519's cost-visibility promise.

### Problem

- `AgentFallbackRecord.costUsd` is populated by `AgentManager` but dropped when copied to `ctx.agentFallbacks` in the execution stage.
- `AgentFallbackHop` has no `costUsd` field, so the metric can't flow to disk even if preserved.
- No run-level aggregator exists; `RunMetrics` has no `fallback` field. The `run:completed` event is silent about swap cost.

### Fix

- Add `costUsd: number` to `AgentFallbackHop`; preserve it in the execution-stage copy.
- Add `RunFallbackAggregate` type and `RunMetrics.fallback?` field.
- New pure helper `deriveRunFallbackAggregates(stories)` in `src/metrics/aggregator.ts` — computes `totalHops`, `perPair`, `exhaustedStories`, `totalWastedCostUsd`.
- Wire into `src/execution/lifecycle/run-completion.ts`: attach to saved `RunMetrics` and emit on `run:completed`.
- Conditionally spread — field is absent (not empty) when no hops occurred, so clean runs stay clean.

### Files changed

| Category | Files |
|:---|:---|
| Types | `src/metrics/types.ts` (+ `AgentFallbackHop.costUsd`, + `RunFallbackAggregate`, + `RunMetrics.fallback`) |
| Propagation | `src/pipeline/stages/execution.ts` (preserve `costUsd`), `src/pipeline/event-bus.ts` (extend `RunCompletedEvent`) |
| Aggregator | `src/metrics/aggregator.ts` (new `deriveRunFallbackAggregates`), `src/metrics/index.ts` (export) |
| Wiring | `src/execution/lifecycle/run-completion.ts` |
| Tests | `test/unit/metrics/fallback-aggregates.test.ts` (11 tests), `test/unit/execution/lifecycle/run-completion-fallback.test.ts` (3 tests) |
| Docs | `docs/reviews/ADR-012-implementation-review.md` (resolution log) |

## Test plan

- [x] `bun run test` — 6393 unit + 1187 integration pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `test/integration/execution/agent-swap.test.ts` — end-to-end swap flow still green
- [x] Canonical "exhausted story" classification covered by dedicated test
- [x] Legacy-missing-costUsd field treated as 0 (defensive for old saved metrics)

## Exhausted-story semantics

A story is reported as "exhausted" when:
1. `story.success === false` AND
2. The last recorded hop's `category === "availability"`

This mirrors `AgentManager`'s `onSwapExhausted` emission condition without requiring the event-subscription plumbing to be wired end-to-end. If a swap eventually succeeded (or the last failure was a quality failure), the story is **not** exhausted.

## Follow-ups

Finding #4 (docs alignment: `conventions.md` / `config-patterns.md`) and dead-code cleanup (`clearUnavailableAgents`, `resetStoryState`, `onBeforeStory` hook) ship in PR-3.