### PR TITLE
chore(adr-012): dead-code cleanup + docs alignment (PR-3)

### DIFF
--- a/.claude/rules/config-patterns.md
+++ b/.claude/rules/config-patterns.md
@@ -85,9 +85,35 @@ rawConfig = deepMergeConfig(rawConfig, cliOverrides);
 const result = NaxConfigSchema.safeParse(rawConfig);
 ```
 
+## Agent Config Shape (ADR-012)
+
+The canonical agent-selection shape lives under `config.agent`:
+
+```typescript
+{
+  "agent": {
+    "protocol": "acp",
+    "default": "claude",           // primary agent — resolveDefaultAgent() reads this
+    "fallback": {
+      "enabled": true,
+      "map": { "codex": ["claude"], "claude": ["codex"] },
+      "maxHopsPerStory": 2,
+      "onQualityFailure": false,
+      "rebuildContext": true
+    }
+  }
+}
+```
+
+- `agent.default` — string name of the primary agent. Accessed via `resolveDefaultAgent(config)` from `src/agents`.
+- `agent.fallback.map` — per-agent chain. `{ primary: [next, ...] }`.
+- Old `autoMode.defaultAgent` and `autoMode.fallbackOrder` were **removed in ADR-012 Phase 6**. Loading a config with those keys throws `NaxError CONFIG_LEGACY_AGENT_KEYS` — silently stripping would mask the migration (see `rejectLegacyAgentKeys` in `src/config/loader.ts`).
+
+See `docs/adr/ADR-012-agent-manager-ownership.md` for the full migration.
+
 ## Compatibility Shim Pattern
 
-For backward compatibility with deprecated config keys, use a migration shim:
+For benign renames of deprecated config keys (no semantic change, no observable user impact), use a migration shim:
 
 ```typescript
 function applyRemovedStrategyCompat(conf: Record<string, unknown>): Record<string, unknown> {
@@ -101,6 +127,28 @@ function applyRemovedStrategyCompat(conf: Record<string, unknown>): Record<strin
   }
 
   return migrated;
+}
+```
+
+For **behaviour-changing removals** (e.g. fields whose semantic would silently drop if ignored), reject the key at parse time instead of stripping it. Zod's default `.strip()` mode would hide the migration — use a pre-parse guard that throws a `NaxError` with per-key migration hints:
+
+```typescript
+// src/config/loader.ts — ADR-012 Phase 6 legacy key guard
+function rejectLegacyAgentKeys(conf: Record<string, unknown>): void {
+  const legacyKeys: string[] = [];
+  const hints: string[] = [];
+  const autoMode = conf.autoMode as Record<string, unknown> | undefined;
+  if (autoMode && "defaultAgent" in autoMode) {
+    legacyKeys.push("autoMode.defaultAgent");
+    hints.push("- Move `autoMode.defaultAgent` → `agent.default`");
+  }
+  // ... additional keys
+  if (legacyKeys.length === 0) return;
+  throw new NaxError(
+    [`Invalid configuration — legacy keys: ${legacyKeys.join(", ")}.`, ...hints].join("\n"),
+    "CONFIG_LEGACY_AGENT_KEYS",
+    { stage: "config", legacyKeys },
+  );
 }
 ```
 

--- a/.nax/context.md
+++ b/.nax/context.md
@@ -103,7 +103,7 @@ Runner.run()  [src/execution/runner.ts — thin orchestrator]
 ## Agent Adapter & LLM Calls
 
 - **Two protocol modes:** CLI (`Bun.spawn`) and ACP (JSON-RPC via `acpx`), toggled by `agent.protocol` in config (default: `"acp"`)
-- **LLM fallback rule:** Any code needing LLM calls MUST use `getAgent(config.autoMode.defaultAgent)` from `src/agents/registry` — never inline stubs. Use `agent.complete(prompt, { jsonMode: true })` for one-shot calls.
+- **LLM fallback rule:** Any code needing LLM calls MUST resolve the agent via the canonical accessors — `ctx.agentManager?.getDefault() ?? "claude"` in pipeline stages, or `resolveDefaultAgent(config)` in standalone modules. Never inline stubs, never read `config.autoMode.defaultAgent` (removed in ADR-012 Phase 6). Use `agent.complete(prompt, { jsonMode: true })` for one-shot calls.
 - **Forward-compatible:** `getAgent()` returns the correct adapter for the active protocol — calling code doesn't need to know which mode is active.
 - See `docs/architecture/design-patterns.md` §11 (Adapter) for full pattern.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Runner.run()  [src/execution/runner.ts — thin orchestrator]
 ## Agent Adapter & LLM Calls
 
 - **Two protocol modes:** CLI (`Bun.spawn`) and ACP (JSON-RPC via `acpx`), toggled by `agent.protocol` in config (default: `"acp"`)
-- **LLM fallback rule:** Any code needing LLM calls MUST use `getAgent(config.autoMode.defaultAgent)` from `src/agents/registry` — never inline stubs. Use `agent.complete(prompt, { jsonMode: true })` for one-shot calls.
+- **LLM fallback rule:** Any code needing LLM calls MUST resolve the agent via the canonical accessors — `ctx.agentManager?.getDefault() ?? "claude"` in pipeline stages, or `resolveDefaultAgent(config)` in standalone modules. Never inline stubs, never read `config.autoMode.defaultAgent` (removed in ADR-012 Phase 6). Use `agent.complete(prompt, { jsonMode: true })` for one-shot calls.
 - **Forward-compatible:** `getAgent()` returns the correct adapter for the active protocol — calling code doesn't need to know which mode is active.
 - See `docs/architecture/design-patterns.md` §11 (Adapter) for full pattern.
 

--- a/docs/adr/ADR-012-agent-manager-ownership.md
+++ b/docs/adr/ADR-012-agent-manager-ownership.md
@@ -277,7 +277,7 @@ AgentManager exposes `runWithFallback(request)` in this ADR. A parallel `complet
 - [x] `applyAgentConfigMigration()` deleted from `src/config/loader.ts`.
 - [x] `defaultAgent`, `fallbackOrder` removed from `AutoModeConfigSchema`.
 - [x] `ContextV2FallbackConfigSchema` removed.
-- [x] Loading a pre-migration config → Zod validation error with clear "migrate to `agent.*` per ADR-012" message.
+- [x] Loading a pre-migration config → `NaxError CONFIG_LEGACY_AGENT_KEYS` with per-key migration hints (pre-parse guard `rejectLegacyAgentKeys` in `src/config/loader.ts`, #579). Zod `.strip()` alone would silently drop the keys — the guard runs before `safeParse`.
 - [ ] 3 canary releases have passed between Phase 2 and this phase. (N/A — internal project, no canary release process)
 - [x] CHANGELOG breaking-change note added.
 - [x] `docs/architecture/conventions.md` and `.claude/rules/config-patterns.md` updated.

--- a/docs/architecture/conventions.md
+++ b/docs/architecture/conventions.md
@@ -295,3 +295,37 @@ const TIMEOUT_MS = 60_000;
 // ❌ Hard to read
 const MAX_CONTEXT_TOKENS = 1000000;
 ```
+
+---
+
+## 5. Agent Resolution (ADR-012)
+
+### Rules
+
+Agent-selection state is owned by `AgentManager` (`src/agents/manager.ts`), constructed once per run in `src/execution/runner.ts`. All default-agent reads go through one of two canonical accessors — never reach into `config.autoMode` (removed in ADR-012 Phase 6):
+
+| Caller context | Accessor | Source |
+|:---|:---|:---|
+| Pipeline stages (have `ctx: PipelineContext`) | `ctx.agentManager?.getDefault() ?? "claude"` | `src/agents/manager.ts` |
+| Standalone modules (only have `NaxConfig`) | `resolveDefaultAgent(config)` | `src/agents/utils.ts` |
+
+```typescript
+// ✅ Pipeline stage — uses the run-scoped manager
+const defaultAgent = ctx.agentManager?.getDefault() ?? "claude";
+const agent = (ctx.agentGetFn ?? _deps.getAgent)(defaultAgent);
+
+// ✅ Standalone module — derives from config
+import { resolveDefaultAgent } from "../agents";
+const defaultAgent = resolveDefaultAgent(config);
+
+// ❌ Removed — autoMode.defaultAgent no longer exists
+const defaultAgent = config.autoMode.defaultAgent;  // TS error + CONFIG_LEGACY_AGENT_KEYS at load
+```
+
+### Per-story reset
+
+`AgentManager.reset()` runs once per story at `src/execution/iteration-runner.ts:196`, before each pipeline run. It is the SSOT for clearing per-story availability state — there is no separate adapter-level or registry-level reset hook.
+
+### Config shape
+
+The canonical `config.agent` shape — `default`, `protocol`, `fallback.map`, etc. — is documented in `.claude/rules/config-patterns.md` § Agent Config Shape (ADR-012).

--- a/docs/reviews/ADR-012-implementation-review.md
+++ b/docs/reviews/ADR-012-implementation-review.md
@@ -225,8 +225,8 @@ Recommended: delete `resetStoryState` + `clearUnavailableAgents` (one PR, ~30 li
 | Finding | PR | Status |
 |:---|:---|:---|
 | #1 Phase 6 silent-strip regression | #579 | ✅ Fixed — `rejectLegacyAgentKeys()` guard in `src/config/loader.ts` |
-| #2 `costUsd` dropped on `AgentFallbackHop` | PR-2 (this change) | ✅ Fixed — field added to `AgentFallbackHop`; preserved in `src/pipeline/stages/execution.ts` |
-| #3 `RunMetrics.fallback` aggregates never surfaced | PR-2 (this change) | ✅ Fixed — `deriveRunFallbackAggregates` in `src/metrics/aggregator.ts`; surfaced on `run:completed` event and saved `RunMetrics` |
-| #4 Doc-reality gap (`conventions.md` / `config-patterns.md`) | PR-3 (pending) | Open |
-| Dead-code cleanup (`clearUnavailableAgents` / `resetStoryState` / `onBeforeStory` hook) | PR-3 (pending) | Open |
+| #2 `costUsd` dropped on `AgentFallbackHop` | #580 | ✅ Fixed — field added to `AgentFallbackHop`; preserved in `src/pipeline/stages/execution.ts` |
+| #3 `RunMetrics.fallback` aggregates never surfaced | #580 | ✅ Fixed — `deriveRunFallbackAggregates` in `src/metrics/aggregator.ts`; surfaced on `run:completed` event and saved `RunMetrics` |
+| #4 Doc-reality gap (`conventions.md` / `config-patterns.md`) | PR-3 (this change) | ✅ Fixed — new §5 in `conventions.md`; new "Agent Config Shape (ADR-012)" in `config-patterns.md`; `CLAUDE.md` / `.nax/context.md` LLM-fallback rule updated; `SPEC-agent-manager-integration.md` marked shipped; `SPEC-per-agent-model-map.md` marked partially superseded |
+| Dead-code cleanup (`clearUnavailableAgents` / `resetStoryState` / `onBeforeStory` hook) | PR-3 (this change) | ✅ Fixed — plumbing deleted across `src/agents/acp/adapter.ts`, `src/agents/registry.ts`, `src/execution/runner.ts`, `src/execution/runner-execution.ts`, `src/execution/executor-types.ts`, `src/execution/unified-executor.ts` (-37 lines) |
 

--- a/docs/specs/SPEC-agent-manager-integration.md
+++ b/docs/specs/SPEC-agent-manager-integration.md
@@ -1,9 +1,10 @@
 # SPEC: Agent Manager — Ownership & Integration Design
 
-> **Status:** Draft. Companion to [ADR-012](../adr/ADR-012-agent-manager-ownership.md). Details how `AgentManager` takes ownership of agent lifecycle, fallback policy, and config resolution, and how it integrates with the existing `AgentAdapter` interface and `SessionManager`.
+> **Status:** Shipped (Phases 1–6 merged on main, April 2026). Historical design doc for `AgentManager` ownership, fallback policy, and config resolution. All six phases have landed; outstanding review findings are tracked in [`docs/reviews/ADR-012-implementation-review.md`](../reviews/ADR-012-implementation-review.md). For the current canonical behaviour, read `src/agents/manager.ts`, `src/config/schemas.ts`, and [ADR-012](../adr/ADR-012-agent-manager-ownership.md).
 >
 > **Tracking:** #552 · **ADR:** PR #551
 > **Related issues:** #523 (prompt-audit → SessionManager, non-blocking) · #529 (AgentRunOptions cleanup, blocks Phase 4) · #518 (credential pre-validation, folded into Phase 2) · #519 (fallback aggregates, folded into Phase 5)
+> **Shipped via:** #562 (P1) · #564 (P2) · #568 (P3) · #572 (P4) · #573 (P5) · #576 (P6) · #579 (P6 legacy-key guard) · #580 (P5 cost aggregates)
 
 ---
 

--- a/docs/specs/SPEC-per-agent-model-map.md
+++ b/docs/specs/SPEC-per-agent-model-map.md
@@ -1,5 +1,7 @@
 # SPEC: Per-Agent Model Map
 
+> **Partially superseded by [ADR-012](../adr/ADR-012-agent-manager-ownership.md).** The fallback-state design described below (`AcpAgentAdapter._unavailableAgents`, `AllAgentsUnavailableError`, `fallbackOrder`) was **re-owned by `AgentManager`** in ADR-012 Phase 4. Config also migrated from `autoMode.fallbackOrder` / `autoMode.defaultAgent` to `agent.fallback.map` / `agent.default` in Phase 6. References to those removed APIs below reflect the spec's original design, not current code. The **per-agent model map concept itself** (nested `models[agent][tier]`) remains live and is unchanged by ADR-012.
+
 ## Summary
 
 Restructure the `models` config from a flat tier→model map to a per-agent model map, making it the SSOT for resolving any `(agent, tier) → model` pair. Activate the existing dead-code `fallbackOrder` config as the rate-limit agent fallback chain. Add optional `routing.agent` field for manual per-story agent override.

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -1090,12 +1090,6 @@ export class AcpAgentAdapter implements AgentAdapter {
     return { stories };
   }
 
-  /**
-   * No-op: per-story availability state is now owned by AgentManager (ADR-012 Phase 4).
-   * Kept for interface compatibility; callers in AgentRegistry.resetStoryState() are harmless.
-   */
-  clearUnavailableAgents(): void {}
-
   async closePhysicalSession(handle: string, workdir: string, options?: { force?: boolean }): Promise<void> {
     const cmdStr = `acpx ${this.name}`;
     const client = _acpAdapterDeps.createClient(cmdStr, workdir, undefined, undefined);

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -53,12 +53,6 @@ export interface AgentRegistry {
   checkAgentHealth(): Promise<Array<{ name: string; displayName: string; installed: boolean }>>;
   /** Active protocol (always 'acp') */
   protocol: "acp";
-  /**
-   * Reset per-story state on all cached ACP adapters.
-   * Call at each story boundary so transient auth failures in one story
-   * do not permanently exclude agents for subsequent stories in the same run.
-   */
-  resetStoryState(): void;
 }
 
 /**
@@ -118,11 +112,5 @@ export function createAgentRegistry(config: NaxConfig): AgentRegistry {
     );
   }
 
-  function resetStoryState(): void {
-    for (const adapter of acpCache.values()) {
-      adapter.clearUnavailableAgents();
-    }
-  }
-
-  return { getAgent, getInstalledAgents, checkAgentHealth, protocol: "acp", resetStoryState };
+  return { getAgent, getInstalledAgents, checkAgentHealth, protocol: "acp" };
 }

--- a/src/execution/executor-types.ts
+++ b/src/execution/executor-types.ts
@@ -46,12 +46,6 @@ export interface SequentialExecutionContext {
   pidRegistry?: PidRegistry;
   /** Max parallel sessions: undefined=sequential, 0=auto-detect, N>0=cap at N */
   parallelCount?: number;
-  /**
-   * Called just before each story (or parallel batch) begins execution.
-   * Used to reset per-story adapter state (e.g. _unavailableAgents) so transient
-   * auth failures from a previous story do not carry over.
-   */
-  onBeforeStory?: () => void;
 }
 
 export interface SequentialExecutionResult {

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -47,8 +47,6 @@ export interface RunnerExecutionOptions {
   parallel?: number;
   /** Protocol-aware agent resolver — created once in runner.ts from createAgentRegistry(config) */
   agentGetFn?: AgentGetFn;
-  /** Called before each story starts — resets per-story adapter state (e.g. _unavailableAgents). */
-  onBeforeStory?: () => void;
   /** PID registry for crash recovery — passed to agent.run() to register child processes. */
   pidRegistry?: PidRegistry;
   /** Interaction chain for cost/pre-merge triggers during sequential execution. */
@@ -164,7 +162,6 @@ export async function runExecutionPhase(
       startTime: options.startTime,
       parallelCount: options.parallel,
       agentGetFn: options.agentGetFn,
-      onBeforeStory: options.onBeforeStory,
       pidRegistry: options.pidRegistry,
       interactionChain: options.interactionChain,
       agentManager: options.agentManager,

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -176,7 +176,6 @@ export async function run(options: RunOptions): Promise<RunResult> {
         headless,
         parallel,
         agentGetFn,
-        onBeforeStory: () => registry.resetStoryState(),
         pidRegistry,
         interactionChain,
         sessionManager,

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -164,8 +164,6 @@ export async function executeUnified(
         const batch = _unifiedExecutorDeps.selectIndependentBatch(readyStories, ctx.parallelCount as number);
 
         if (batch.length > 1) {
-          // Reset per-story adapter state before dispatching the batch
-          ctx.onBeforeStory?.();
           // Emit story:started for each batch story before dispatch (AC-5)
           for (const story of batch) {
             const modelTier =
@@ -361,7 +359,6 @@ export async function executeUnified(
             pipelineEventBus.emit({ type: "run:resumed", feature: ctx.feature });
           }
 
-          ctx.onBeforeStory?.();
           const modelTier = singleSelection.routing.modelTier;
           pipelineEventBus.emit({
             type: "story:started",
@@ -452,7 +449,6 @@ export async function executeUnified(
         pipelineEventBus.emit({ type: "run:resumed", feature: ctx.feature });
       }
 
-      ctx.onBeforeStory?.();
       const modelTier = selection.routing.modelTier;
       pipelineEventBus.emit({
         type: "story:started",

--- a/test/integration/execution/agent-swap.test.ts
+++ b/test/integration/execution/agent-swap.test.ts
@@ -150,7 +150,6 @@ function makeCtx(config: NaxConfig, bundle: ContextBundle): PipelineContext {
     getInstalledAgents: async () => [],
     checkAgentHealth: async () => [],
     protocol: "acp",
-    resetStoryState: () => {},
   };
   ctx.agentManager = new AgentManager(config, lazyRegistry);
   return ctx;

--- a/test/unit/agents/manager-credentials.test.ts
+++ b/test/unit/agents/manager-credentials.test.ts
@@ -39,7 +39,6 @@ describe("AgentManager.validateCredentials (#518)", () => {
       getInstalledAgents: async () => [],
       checkAgentHealth: async () => [],
       protocol: "acp" as const,
-      resetStoryState: () => {},
     };
     const warn = mock(() => {});
     const manager = new AgentManager(config, registry, { logger: { warn } });
@@ -57,7 +56,6 @@ describe("AgentManager.validateCredentials (#518)", () => {
       getInstalledAgents: async () => [],
       checkAgentHealth: async () => [],
       protocol: "acp" as const,
-      resetStoryState: () => {},
     };
     const manager = new AgentManager(config, registry);
     await expect(manager.validateCredentials()).rejects.toThrow(/credentials/i);
@@ -72,7 +70,6 @@ describe("AgentManager.validateCredentials (#518)", () => {
       getInstalledAgents: async () => [],
       checkAgentHealth: async () => [],
       protocol: "acp" as const,
-      resetStoryState: () => {},
     };
     const manager = new AgentManager(config, registry);
     await expect(manager.validateCredentials()).resolves.toBeUndefined();


### PR DESCRIPTION
## Summary

Closes the remaining findings from [docs/reviews/ADR-012-implementation-review.md](docs/reviews/ADR-012-implementation-review.md): dead-code cleanup (post-Phase-4 no-ops) and the doc-reality gap (finding #4).

### Part 1: dead code removal (1a9f8d9d)

Post-ADR-012 Phase 4, `AgentManager.reset()` at `src/execution/iteration-runner.ts:196` is the SSOT for per-story state. The older adapter-centric reset chain — `onBeforeStory → registry.resetStoryState() → adapter.clearUnavailableAgents()` — collapsed into a no-op but stayed wired "for interface compatibility".

**Deleted:**
- `AcpAgentAdapter.clearUnavailableAgents()` — no-op method
- `AgentRegistry.resetStoryState()` + interface member
- `runner.ts onBeforeStory: () => registry.resetStoryState()` wiring
- `RunnerExecutionOptions.onBeforeStory` + `SequentialExecutionOptions.onBeforeStory`
- 3 `ctx.onBeforeStory?.()` call sites in `unified-executor.ts`
- Stale `_unavailableAgents` comment in `executor-types.ts`
- 4 test stubs (`resetStoryState: () => {}`)

Net -37 lines, zero behaviour change. `agentManager.reset()` still runs every story.

### Part 2: docs alignment (9845ff10)

- **`docs/architecture/conventions.md` §5 (new)** — "Agent Resolution (ADR-012)": canonical accessors (`agentManager.getDefault()` in pipeline stages, `resolveDefaultAgent(config)` in standalone modules), per-story reset rule.
- **`.claude/rules/config-patterns.md`** — new "Agent Config Shape (ADR-012)" section; "Compatibility Shim Pattern" extended with a pre-parse-reject example (`rejectLegacyAgentKeys`) for behaviour-changing removals where Zod `.strip()` would silently mask the migration.
- **`CLAUDE.md` + `.nax/context.md`** — LLM-fallback rule rewritten. Was: `getAgent(config.autoMode.defaultAgent)`. Now: "resolve via the canonical accessors … never read `config.autoMode.defaultAgent` (removed in ADR-012 Phase 6)".
- **`docs/specs/SPEC-agent-manager-integration.md`** — status "Draft" → "Shipped" with PR references for all 6 phases + #579 + #580.
- **`docs/specs/SPEC-per-agent-model-map.md`** — flagged as "partially superseded" for the `AllAgentsUnavailableError` / `_unavailableAgents` design; per-agent model-map concept stays live.
- **`docs/adr/ADR-012-agent-manager-ownership.md`** — Phase 6 AC rewritten to accurately describe the shipped `NaxError CONFIG_LEGACY_AGENT_KEYS` guard. Was: "Zod validation error". Fact: Zod's default `.strip()` would silently drop the keys, so the guard runs **before** `safeParse`.
- **`docs/reviews/ADR-012-implementation-review.md`** — resolution log updated; all 5 tracked items marked ✅ Fixed.

## Test plan

- [x] `bun run test` — 6393 unit + 1187 integration pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `test/integration/execution/agent-swap.test.ts` — end-to-end swap flow still green (exercises the manager→execution path that replaced the removed plumbing)

## After this PR

All five findings from the ADR-012 implementation review are resolved:

| Finding | PR |
|:---|:---|
| #1 Phase 6 silent-strip regression | #579 ✅ |
| #2 `costUsd` dropped on `AgentFallbackHop` | #580 ✅ |
| #3 `RunMetrics.fallback` aggregates never surfaced | #580 ✅ |
| #4 Doc-reality gap | **this PR** ✅ |
| Dead-code cleanup | **this PR** ✅ |

ADR-012 is fully shipped and documented.