### PR TITLE
fix(agents): make rate-limit backoff cancellable + extract cancellableDelay helper

### DIFF
--- a/docs/architecture/coding-standards.md
+++ b/docs/architecture/coding-standards.md
@@ -76,17 +76,33 @@ const stdout = await new Response(proc.stdout).text(); // hangs!
 
 ### Stream Cancellation
 
+**Use `cancellableDelay(ms, signal?)` from `src/utils/bun-deps.ts`** — don't roll the `setTimeout + AbortController` pattern inline.
+
 ```typescript
-// ✅ Bun.sleep() is uncancellable — use setTimeout for cancellable delays
+import { cancellableDelay } from "../utils/bun-deps";
+
+// ✅ Canonical cancellable delay — drop-in for Bun.sleep with optional abort
 const controller = new AbortController();
+await cancellableDelay(5000, controller.signal); // rejects on abort
+
+// ✅ Without a signal, behaves identically to Bun.sleep(ms)
+await cancellableDelay(5000);
+
+// ❌ Cannot cancel Bun.sleep()
+await Bun.sleep(5000); // blocks for full 5s even if no longer needed
+
+// ❌ Don't re-roll the pattern at every call site
 const delay = new Promise<void>((resolve) => {
   const timer = setTimeout(resolve, ms);
   controller.signal.addEventListener("abort", () => clearTimeout(timer));
 });
-
-// ❌ Cannot cancel Bun.sleep()
-await Bun.sleep(5000); // blocks for full 5s even if no longer needed
 ```
+
+Reach for `cancellableDelay` at any site that:
+- Runs inside a retry/backoff loop and should respect aborts (rate-limit backoff, reconnect loops).
+- Has access to an `AbortSignal` today, or is likely to receive one via future plumbing.
+
+Use plain `Bun.sleep()` (or `_deps.sleep` in tests) only for short uninterruptible pauses where cancellation is neither possible nor meaningful — intra-tick yields, brief polling delays with no caller signal.
 
 ### Promise.race Safety
 

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -27,9 +27,39 @@ type LoggerLike = {
   info: (scope: string, msg: string, data?: Record<string, unknown>) => void;
 };
 
-/** Injectable deps for testability (sleep). */
+/**
+ * Cancellable delay — matches the canonical pattern from
+ * docs/architecture/coding-standards.md §6 (Stream Cancellation).
+ *
+ * Uses `setTimeout` (rather than `Bun.sleep`) so the timer can be cleared via
+ * `AbortController` when a caller supplies a signal. Without a signal, behaves
+ * identically to `Bun.sleep(ms)`. The rate-limit backoff in `runWithFallback`
+ * uses this so that future AbortSignal plumbing (issue #585) can interrupt an
+ * in-flight backoff without modifying this helper. This is a documented
+ * exception to `.claude/rules/forbidden-patterns.md` — setTimeout is permitted
+ * when the timer handle is cancelled mid-flight via `clearTimeout`.
+ */
+function cancellableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error("delay aborted"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error("delay aborted"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/** Injectable deps for testability. */
 export const _agentManagerDeps = {
-  sleep: (ms: number) => Bun.sleep(ms),
+  sleep: (ms: number, signal?: AbortSignal) => cancellableDelay(ms, signal),
 };
 
 export class AgentManager implements IAgentManager {

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -10,6 +10,7 @@ import type { NaxConfig } from "../config";
 import type { AdapterFailure, ContextBundle } from "../context/engine";
 import { NaxError } from "../errors";
 import { getSafeLogger } from "../logger";
+import { cancellableDelay } from "../utils/bun-deps";
 import type {
   AgentCompleteOutcome,
   AgentFallbackRecord,
@@ -27,38 +28,13 @@ type LoggerLike = {
   info: (scope: string, msg: string, data?: Record<string, unknown>) => void;
 };
 
-/**
- * Cancellable delay — matches the canonical pattern from
- * docs/architecture/coding-standards.md §6 (Stream Cancellation).
- *
- * Uses `setTimeout` (rather than `Bun.sleep`) so the timer can be cleared via
- * `AbortController` when a caller supplies a signal. Without a signal, behaves
- * identically to `Bun.sleep(ms)`. The rate-limit backoff in `runWithFallback`
- * uses this so that future AbortSignal plumbing (issue #585) can interrupt an
- * in-flight backoff without modifying this helper. This is a documented
- * exception to `.claude/rules/forbidden-patterns.md` — setTimeout is permitted
- * when the timer handle is cancelled mid-flight via `clearTimeout`.
- */
-function cancellableDelay(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    if (signal?.aborted) {
-      reject(signal.reason ?? new Error("delay aborted"));
-      return;
-    }
-    const timer = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      clearTimeout(timer);
-      reject(signal?.reason ?? new Error("delay aborted"));
-    };
-    signal?.addEventListener("abort", onAbort, { once: true });
-  });
-}
-
 /** Injectable deps for testability. */
 export const _agentManagerDeps = {
+  /**
+   * Cancellable backoff delay. Delegates to the canonical helper in
+   * `src/utils/bun-deps.ts` — see there for the rationale and the
+   * coding-standards §6 reference. Exposed on `_deps` so tests can mock it.
+   */
   sleep: (ms: number, signal?: AbortSignal) => cancellableDelay(ms, signal),
 };
 

--- a/src/utils/bun-deps.ts
+++ b/src/utils/bun-deps.ts
@@ -41,6 +41,43 @@ export function sleep(ms: number): Promise<void> {
   return Bun.sleep(ms);
 }
 
+/**
+ * Cancellable delay — `setTimeout`-based replacement for `Bun.sleep`.
+ *
+ * Without a signal, behaves identically to `Bun.sleep(ms)`. With an `AbortSignal`,
+ * aborting rejects the promise with `signal.reason` (or a generic Error if none)
+ * and clears the underlying timer instead of waiting the full delay.
+ *
+ * This is the canonical implementation of the pattern documented in
+ * `docs/architecture/coding-standards.md` §6 "Stream Cancellation". It is a
+ * documented exception to `.claude/rules/forbidden-patterns.md`'s ban on
+ * `setTimeout`-for-delays — the exception clause permits it precisely when the
+ * timer handle must be cancelled mid-flight via `clearTimeout`.
+ *
+ * Prefer this over `sleep()` at any site where:
+ * - The delay is part of a retry/backoff loop that should respect aborts.
+ * - The caller has access to an `AbortSignal` (or might in the future).
+ *
+ * When in doubt, reach for this helper rather than rolling the pattern inline.
+ */
+export function cancellableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error("delay aborted"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error("delay aborted"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 /** Injectable file — wraps Bun.file */
 export function file(path: string) {
   return Bun.file(path);

--- a/test/unit/agents/manager-cancellable-backoff.test.ts
+++ b/test/unit/agents/manager-cancellable-backoff.test.ts
@@ -1,0 +1,62 @@
+/**
+ * ADR-012 follow-up: verify the rate-limit backoff delay helper is cancellable.
+ *
+ * `AgentManager._agentManagerDeps.sleep` is the cancellable replacement for
+ * the original `Bun.sleep(ms)`. Without a signal it behaves identically; with
+ * an `AbortSignal` it resolves immediately on abort. This test pins the new
+ * contract so the canonical pattern from docs/architecture/coding-standards.md
+ * §6 cannot silently regress back to uncancellable `Bun.sleep`.
+ *
+ * Full abort-signal plumbing through `runWithFallback` is tracked in issue #585.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { _agentManagerDeps } from "../../../src/agents/manager";
+
+describe("AgentManager cancellable backoff helper", () => {
+  test("without a signal — resolves after the requested delay", async () => {
+    const start = performance.now();
+    await _agentManagerDeps.sleep(50);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(45);
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  test("with a signal — aborting mid-flight rejects quickly", async () => {
+    const controller = new AbortController();
+    // Schedule an abort well before the sleep would otherwise resolve.
+    setTimeout(() => controller.abort(new Error("cancelled mid-backoff")), 10);
+
+    const start = performance.now();
+    let error: unknown;
+    try {
+      await _agentManagerDeps.sleep(5_000, controller.signal);
+    } catch (err) {
+      error = err;
+    }
+    const elapsed = performance.now() - start;
+
+    expect(error).toBeDefined();
+    expect((error as Error).message).toBe("cancelled mid-backoff");
+    // Would be ~5000ms without cancellation — assert it settled before 1s.
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  test("already-aborted signal — rejects synchronously, no delay", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("aborted before sleep"));
+
+    const start = performance.now();
+    let error: unknown;
+    try {
+      await _agentManagerDeps.sleep(5_000, controller.signal);
+    } catch (err) {
+      error = err;
+    }
+    const elapsed = performance.now() - start;
+
+    expect(error).toBeDefined();
+    expect((error as Error).message).toBe("aborted before sleep");
+    expect(elapsed).toBeLessThan(100);
+  });
+});

--- a/test/unit/agents/manager-cancellable-backoff.test.ts
+++ b/test/unit/agents/manager-cancellable-backoff.test.ts
@@ -1,31 +1,22 @@
 /**
- * ADR-012 follow-up: verify the rate-limit backoff delay helper is cancellable.
+ * ADR-012 follow-up: verify `_agentManagerDeps.sleep` delegates to the
+ * cancellable helper in src/utils/bun-deps.ts rather than plain Bun.sleep.
  *
- * `AgentManager._agentManagerDeps.sleep` is the cancellable replacement for
- * the original `Bun.sleep(ms)`. Without a signal it behaves identically; with
- * an `AbortSignal` it resolves immediately on abort. This test pins the new
- * contract so the canonical pattern from docs/architecture/coding-standards.md
- * §6 cannot silently regress back to uncancellable `Bun.sleep`.
+ * This is a narrow wiring test — comprehensive coverage of the helper itself
+ * lives in test/unit/utils/bun-deps.test.ts. The role of this test is to
+ * prevent a silent regression back to uncancellable `Bun.sleep(ms)` at the
+ * manager layer (which would violate docs/architecture/coding-standards.md §6).
  *
- * Full abort-signal plumbing through `runWithFallback` is tracked in issue #585.
+ * Full AbortSignal plumbing through `runWithFallback` is tracked in #585.
  */
 
 import { describe, expect, test } from "bun:test";
 import { _agentManagerDeps } from "../../../src/agents/manager";
 
-describe("AgentManager cancellable backoff helper", () => {
-  test("without a signal — resolves after the requested delay", async () => {
-    const start = performance.now();
-    await _agentManagerDeps.sleep(50);
-    const elapsed = performance.now() - start;
-    expect(elapsed).toBeGreaterThanOrEqual(45);
-    expect(elapsed).toBeLessThan(200);
-  });
-
-  test("with a signal — aborting mid-flight rejects quickly", async () => {
+describe("AgentManager — rate-limit backoff wiring", () => {
+  test("_deps.sleep accepts an AbortSignal and aborts mid-flight", async () => {
     const controller = new AbortController();
-    // Schedule an abort well before the sleep would otherwise resolve.
-    setTimeout(() => controller.abort(new Error("cancelled mid-backoff")), 10);
+    setTimeout(() => controller.abort(new Error("aborted")), 10);
 
     const start = performance.now();
     let error: unknown;
@@ -37,26 +28,14 @@ describe("AgentManager cancellable backoff helper", () => {
     const elapsed = performance.now() - start;
 
     expect(error).toBeDefined();
-    expect((error as Error).message).toBe("cancelled mid-backoff");
-    // Would be ~5000ms without cancellation — assert it settled before 1s.
+    expect((error as Error).message).toBe("aborted");
     expect(elapsed).toBeLessThan(1_000);
   });
 
-  test("already-aborted signal — rejects synchronously, no delay", async () => {
-    const controller = new AbortController();
-    controller.abort(new Error("aborted before sleep"));
-
+  test("_deps.sleep resolves normally when no signal is passed", async () => {
     const start = performance.now();
-    let error: unknown;
-    try {
-      await _agentManagerDeps.sleep(5_000, controller.signal);
-    } catch (err) {
-      error = err;
-    }
+    await _agentManagerDeps.sleep(30);
     const elapsed = performance.now() - start;
-
-    expect(error).toBeDefined();
-    expect((error as Error).message).toBe("aborted before sleep");
-    expect(elapsed).toBeLessThan(100);
+    expect(elapsed).toBeGreaterThanOrEqual(25);
   });
 });

--- a/test/unit/utils/bun-deps.test.ts
+++ b/test/unit/utils/bun-deps.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for cross-cutting Bun-op wrappers in src/utils/bun-deps.ts.
+ *
+ * Currently covers `cancellableDelay` — the canonical implementation of the
+ * `setTimeout + AbortController` pattern from docs/architecture/coding-standards.md §6.
+ * This test pins the helper's contract so it can be reused safely across rate-limit
+ * backoffs, reconnect loops, and any future abort-aware delay site.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { cancellableDelay } from "../../../src/utils/bun-deps";
+
+describe("cancellableDelay", () => {
+  test("without a signal — resolves after the requested delay", async () => {
+    const start = performance.now();
+    await cancellableDelay(50);
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(45);
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  test("with a signal — aborting mid-flight rejects quickly", async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new Error("cancelled mid-delay")), 10);
+
+    const start = performance.now();
+    let error: unknown;
+    try {
+      await cancellableDelay(5_000, controller.signal);
+    } catch (err) {
+      error = err;
+    }
+    const elapsed = performance.now() - start;
+
+    expect(error).toBeDefined();
+    expect((error as Error).message).toBe("cancelled mid-delay");
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  test("already-aborted signal — rejects synchronously", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("aborted before delay"));
+
+    const start = performance.now();
+    let error: unknown;
+    try {
+      await cancellableDelay(5_000, controller.signal);
+    } catch (err) {
+      error = err;
+    }
+    const elapsed = performance.now() - start;
+
+    expect(error).toBeDefined();
+    expect((error as Error).message).toBe("aborted before delay");
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  test("abort after resolution is a no-op (no unhandled rejection)", async () => {
+    const controller = new AbortController();
+    const delayed = cancellableDelay(20, controller.signal);
+    await delayed;
+    // Aborting after the delay has already resolved should not throw.
+    controller.abort(new Error("too late"));
+    // Give event loop a tick to surface any unhandled rejection.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(true).toBe(true);
+  });
+
+  test("default rejection reason when signal.reason is undefined", async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 10);
+
+    let error: unknown;
+    try {
+      await cancellableDelay(5_000, controller.signal);
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeDefined();
+    // Some runtimes set signal.reason to DOMException("AbortError") when abort()
+    // is called without arguments — accept either shape.
+    const message = (error as Error).message ?? (error as { name?: string }).name ?? "";
+    expect(message.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses review recommendation #11 (nice-to-have) and silent-failure risk #4 from [docs/reviews/ADR-012-implementation-review.md](docs/reviews/ADR-012-implementation-review.md).

Two commits:

### `13baf890` — Switch AgentManager rate-limit backoff to the cancellable pattern

- Replaces the uncancellable `Bun.sleep(backoffMs)` in `runWithFallback` with the canonical `setTimeout + AbortController` pattern from [docs/architecture/coding-standards.md §6](docs/architecture/coding-standards.md).
- `_agentManagerDeps.sleep(ms, signal?)` — without a signal, byte-for-byte identical to `Bun.sleep`. With a signal, rejects on abort instead of waiting the full ~14s.

### `33ded274` — Extract `cancellableDelay` to `src/utils/bun-deps.ts`

Three existing consumers make this an obvious utility rather than an AgentManager-local helper:

| Site | Current pattern |
|:---|:---|
| `src/agents/manager.ts` (this PR) | Now uses `cancellableDelay` |
| `src/verification/executor.ts:113-118` | Already rolled a bespoke `Promise.race + setTimeout` with a literal comment saying "Bun.sleep is not cancellable" |
| `src/routing/strategies/llm.ts:198`, `src/interaction/plugins/telegram.ts:145` | Future candidates — `Bun.sleep` retry backoffs that would benefit when cancellation plumbing arrives |

Updates to go with the extraction:
- `docs/architecture/coding-standards.md §6` — rewritten to instruct \"use `cancellableDelay` from `src/utils/bun-deps.ts`\" and flag inline rolling as ❌. Also clarified when plain `Bun.sleep()` remains acceptable (short uninterruptible pauses with no caller signal).
- 5 dedicated tests at `test/unit/utils/bun-deps.test.ts` covering the primitive (no-signal baseline, mid-flight abort, pre-aborted signal, post-resolution abort safety, default rejection reason).
- Narrowed AgentManager test to 2 wiring assertions so the primitive is tested once.

## Scope clarification — still a half fix

This PR takes care of the mechanical-violation half of the review finding. The `runWithFallback` loop now *can* be cancelled but no caller feeds a signal yet — runtime behaviour is unchanged, rate-limit backoff still blocks up to ~14s. Threading an `AbortSignal` from the runner through to the manager is tracked in **#585** and is now a pure wiring exercise.

## Test plan

- [x] `bun run test` — 6400 unit + 1187 integration pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Existing `manager-swap-loop.test.ts` rate-limit-backoff tests still pass (they mock `_agentManagerDeps.sleep`, so the implementation switch is transparent)

## Why `setTimeout` — isn't that forbidden?

`.claude/rules/forbidden-patterns.md` bans `setTimeout` for delays *except* when the timer handle must be cancelled mid-flight via `clearTimeout`. This PR is the documented exception case, now codified once in the utility rather than justified at every future call site.