### PR TITLE
fix(execution+agents): signal idempotency, AbortController plumbing, runWithFallback cancellation (#593, #585)

### DIFF
--- a/docs/findings/2026-04-20-v0.63.0-canary.8-run-issues.md
+++ b/docs/findings/2026-04-20-v0.63.0-canary.8-run-issues.md
@@ -1,0 +1,389 @@
+# v0.63.0-canary.8 — Run Issue Diagnosis
+
+**Date:** 2026-04-20
+**Version:** 0.63.0-canary.8 (`77bc933f`)
+**Reporter:** williamkhoo
+**Scope:** Five concurrent issues observed across `tdd-calc`, `hello-lint`, and `fallback-probe` dogfood fixtures.
+
+This is a diagnostic report only. No fixes written. Each section identifies the minimal root cause and a fix shape, not an implementation.
+
+---
+
+## Issue 1 — Misleading `Session closed by closeStory, priorState: CREATED`
+
+### Symptom
+
+On successful TDD run (`tdd-calc`), story end emits:
+
+```jsonl
+{"stage":"session","message":"Session closed by closeStory","data":{"sessionId":"sess-a347…","priorState":"CREATED"}}
+{"stage":"session","message":"Session closed by closeStory","data":{"sessionId":"sess-9da9…","priorState":"CREATED"}}
+{"stage":"session","message":"Session closed by closeStory","data":{"sessionId":"sess-51fb…","priorState":"CREATED"}}
+{"stage":"acp-adapter","message":"Session close failed (ignored)","data":{"sessionName":"nax-51a4d03c-tdd-calc-us-001-test-writer","stderr":"No named session \"nax-…-test-writer\" for cwd …"}}
+{"stage":"acp-adapter","message":"Session close failed (ignored)","data":{"sessionName":"nax-51a4d03c-tdd-calc-us-001-verifier"}}
+```
+
+Three sessions show `priorState: CREATED` as if they never ran, then the follow-up ACP close fails with *No named session* for test-writer and verifier.
+
+### Root cause
+
+The TDD path **never transitions descriptors through the state machine**.
+
+- `runTddSession` in [`src/tdd/session-runner.ts:210-254`](../../src/tdd/session-runner.ts) calls `agent.run()` and `sessionManager.bindHandle(...)`, but never `sessionManager.transition(id, "RUNNING")` or `"COMPLETED"`.
+- `bindHandle` in [`src/session/manager.ts:212-238`](../../src/session/manager.ts) updates `handle`, `protocolIds`, and `lastActivityAt` only — it does not touch `state`.
+- Single-session path in [`src/pipeline/stages/execution.ts:145-150`](../../src/pipeline/stages/execution.ts) does `transition(ctx.sessionId, "RUNNING")`. TDD has no equivalent.
+
+Result: every TDD descriptor stays `CREATED` until `closeStory` at story completion atomically jumps `CREATED → COMPLETED` and logs `priorState: CREATED` — correct code, misleading story.
+
+Disk evidence (`fixtures/tdd-calc/.nax/features/tdd-calc/sessions/sess-*/descriptor.json`): all three descriptors have `"completedStages": []`, confirming no transitions were recorded.
+
+### Secondary symptom — `No named session` on close
+
+`closeStory` ends with `closeStorySessions` calling `agent.closeSession(descriptor)`. The physical ACP session was already auto-closed inside the adapter's `finally` block ([`src/agents/acp/adapter.ts:750-767`](../../src/agents/acp/adapter.ts)) because `keepOpen: false` for test-writer and verifier (correct per ADR-008). `closeStory` then tries to close a session that acpx has already discarded.
+
+Not an ADR-008 violation. Log noise only.
+
+### Fix shape
+
+1. Add `transition(sessionId, "RUNNING")` before `agent.run()` and `transition(sessionId, "COMPLETED")` on success inside `runTddSession`. Match the single-session pattern.
+2. Have `closeStory` / `closeStorySessions` skip the ACP close when `keepOpen` was `false` for that role (the ACP session is known to be gone). Alternatively downgrade "No named session" from `debug` to `trace` since it is expected.
+
+### Does not affect correctness
+
+Sessions run fine. This is observability debt, not broken behaviour.
+
+---
+
+## Issue 2 — TDD metrics missing `tokens`
+
+### Symptom
+
+Compare:
+
+**`fixtures/hello-lint/.nax/metrics.json`** (single-session path):
+
+```json
+{
+  "tokens": { "input_tokens": 35244, "output_tokens": 810, "cache_read_input_tokens": 212032 },
+  "totalTokens": { … }
+}
+```
+
+**`fixtures/tdd-calc/.nax/metrics.json`** (TDD path):
+
+```json
+{ "cost": 2.441134, "durationMs": 0, "context": { … } }
+```
+
+No `tokens` field. No `totalTokens`. `durationMs` is also 0.
+
+### Root cause
+
+`TddSessionResult` in [`src/tdd/session-runner.ts:334-342`](../../src/tdd/session-runner.ts) drops `tokenUsage` — it returns only `estimatedCost` and `outputTail`:
+
+```ts
+return {
+  role,
+  success: …,
+  isolation,
+  filesChanged,
+  durationMs,
+  estimatedCost: result.estimatedCost,
+  outputTail: result.output.slice(-500),
+};
+```
+
+Then in [`src/pipeline/stages/execution.ts:59-66`](../../src/pipeline/stages/execution.ts) the TDD branch builds a stub `AgentResult`:
+
+```ts
+ctx.agentResult = {
+  success: tddResult.success,
+  estimatedCost: tddResult.totalCost,
+  rateLimited: false,
+  output: "",
+  exitCode: tddResult.success ? 0 : 1,
+  durationMs: 0,
+};
+```
+
+No `tokenUsage`. [`src/metrics/tracker.ts:155-166`](../../src/metrics/tracker.ts) reads `agentResult.tokenUsage` → `undefined` → omits the `tokens` block entirely.
+
+Single-session writes `ctx.agentResult = r` with the full `AgentResult` (including `tokenUsage`), so its metrics include tokens.
+
+### Fix shape
+
+1. Sum `result.tokenUsage` across the three TDD sessions in `runTddSession` or in `runThreeSessionTdd`. Add `tokenUsage` to `TddSessionResult` and `totalTokenUsage` to `ThreeSessionTddResult`.
+2. Propagate on `ctx.agentResult.tokenUsage` in the TDD branch of `execution.ts`.
+3. Also populate `durationMs` — currently hardcoded `0`.
+
+### Does not affect correctness
+
+Cost accounting uses `estimatedCost` which is still populated. This is metrics completeness only.
+
+---
+
+## Issue 3 — Session descriptor `protocolIds: { recordId: null, sessionId: null }`
+
+### Symptom
+
+Descriptor on disk (`fixtures/fallback-probe/.nax/features/fallback-probe/sessions/sess-1b1bac4c-…/descriptor.json`):
+
+```json
+{
+  "state": "COMPLETED",
+  "protocolIds": { "recordId": null, "sessionId": null }
+}
+```
+
+Created at `03:58:01.452`, transitioned to RUNNING at `03:58:01.467`, then killed by SIGINT at `04:00:13.024` before the adapter could return. `bindHandle` never fired.
+
+Contrast with `sess-8aa4b36b-…/descriptor.json` from the same run, created earlier when the adapter *did* complete (with failure) — it has `protocolIds: { recordId: "bc3d7d42-…", sessionId: "bc3d7d42-…" }`.
+
+### Root cause
+
+`bindHandle` is called **after** `agent.run()` returns:
+
+- [`src/pipeline/stages/execution.ts:292-297`](../../src/pipeline/stages/execution.ts) (single-session)
+- [`src/tdd/session-runner.ts:245-253`](../../src/tdd/session-runner.ts) (TDD)
+
+If the run is interrupted before return — SIGINT, crash, hang, first-turn acpx failure — the descriptor freezes with `NULL_PROTOCOL_IDS` and becomes un-resumable.
+
+**The protocolIds are already available much earlier.** [`src/agents/acp/adapter.ts:619-624`](../../src/agents/acp/adapter.ts) captures them immediately after `ensureAcpSession` succeeds, *before any prompt runs*:
+
+```ts
+const { session, resumed } = await ensureAcpSession(client, sessionName, agentName, permissionMode);
+
+const protocolIds = {
+  recordId: (session as { recordId?: string }).recordId ?? null,
+  sessionId: (session as { id?: string }).id ?? null,
+};
+```
+
+They just aren't reported back to SessionManager until `agent.run()` returns.
+
+### Fix shape
+
+Option A — **Callback.** Add `onSessionEstablished?: (protocolIds: ProtocolIds, sessionName: string) => void` to `AgentRunOptions`. Callers pass a closure that calls `sessionManager.bindHandle(sessionId, sessionName, protocolIds)`. Fired by the adapter right after `ensureAcpSession`.
+
+Option B — **Direct manager reference.** Pass `sessionManager` + `sessionId` into `AgentRunOptions` and have the adapter call `bindHandle` directly. Cleaner wiring but couples the adapter to session-manager internals.
+
+Option A preferred — keeps the adapter framework-agnostic.
+
+### Impact
+
+Resume-after-crash requires `protocolIds.sessionId` to find the acpx session record. Without it, the next invocation starts a fresh ACP session and loses context.
+
+---
+
+## Issue 4 — No fallback to codex after claude auth (401) failure
+
+### Symptom
+
+In `fixtures/fallback-probe` the config has:
+
+```json
+"agent": {
+  "default": "claude",
+  "fallback": { "enabled": true, "map": { "claude": ["codex"] } }
+}
+```
+
+claude fails with 401 auth error. Log shows:
+
+```
+Run failed for claude ... "Internal error: Failed to authenticate. API Error: 401 …"
+Session error — retrying with fresh session   // same claude agent
+Run failed for claude ... (same 401)
+Agent session failed                            // execution.ts — no swap logged
+Escalating story to next tier                   // balanced tier, still claude
+```
+
+No `Agent swap triggered` log entry. `nextCandidate` never called. Codex is ignored.
+
+### Root cause — two-layer classifier mismatch
+
+**Layer 1 — adapter's internal retry loop** ([`src/agents/acp/adapter.ts:466-534`](../../src/agents/acp/adapter.ts)):
+
+1. Every `stopReason === "error"` is treated as `sessionError` and retries are consumed. Auth failures come through this path too.
+2. After retries exhausted, adapter tries to reclassify via `parseAgentError(result.output)`.
+
+**Layer 2 — `parseAgentError`** ([`src/agents/acp/parse-agent-error.ts`](../../src/agents/acp/parse-agent-error.ts)) requires structured input:
+
+- Root JSON object (`JSON.parse(stderr)` must succeed on the full string)
+- Bracketed codes (`[401]`, `[AUTH_FAILED]`)
+- Key-value codes (`code=401`, `statusCode: 401`)
+
+The actual acpx output is free text with embedded JSON:
+
+```
+Internal error: Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"login fail: …"}}
+```
+
+- Full-string JSON parse: fails (prefixed by `"Internal error: …"`).
+- Bracketed code regex `/\[([A-Z0-9_/\-]+)\]/`: no match.
+- Key-value regex `/(?:status|statusCode|httpStatus|code)\s*[:=]\s*(\d{3})/`: no match — the `401` is preceded by `"API Error: "`, not a recognised key.
+
+Result: `parseAgentError` returns `{ type: "unknown" }`. Adapter falls through and returns the original `adapterFailure: { category: "quality", outcome: "fail-adapter-error" }` from the `isSessionError` branch at [`src/agents/acp/adapter.ts:815-829`](../../src/agents/acp/adapter.ts).
+
+**Layer 3 — `AgentManager.shouldSwap`** ([`src/agents/manager.ts:114-122`](../../src/agents/manager.ts)):
+
+```ts
+if (failure.category === "availability") return true;
+return fallback.onQualityFailure ?? false;
+```
+
+Category is `"quality"`, `onQualityFailure` is unset (defaults to `false`) → no swap. Tier escalation runs instead, still targeting claude.
+
+### Fix shape
+
+Preferred — **structured error contract at acpx boundary.** Have acpx emit a JSON error event with fields like `{ type: "auth", code: 401, message: "…" }`. The parser already recognises root-level `type` and `code`; no regex heroics needed.
+
+Alternative — extend `parseAgentError` to recognise bare patterns like `API Error: 4\d\d` or to scan for embedded JSON objects (not just root). Carries false-positive risk if agent-written text happens to contain those patterns in a prompt, so this is second choice.
+
+Either way, verify `AgentManager.shouldSwap` sees `category: "availability"` for the 401 case, triggering `nextCandidate(primaryAgent, hopsSoFar)` → `"codex"`.
+
+### Also — confirm `ctx.contextBundle` is set
+
+`shouldSwap` also has a `!bundle` guard. `fixtures/fallback-probe` has `context.v2.enabled: true` and the log shows `v2 context bundle assembled`, so this passes. But in any repro where v2 is disabled, swap won't trigger — worth calling out in docs.
+
+### Impact
+
+Fallback map is dead weight until claude-auth errors land in the `availability` category. Users with configured fallback chains silently get tier escalation on the same failing agent.
+
+---
+
+## Issue 5 — SIGINT in `nax run --headless` cascades into crash / duplicate `run.complete` / retry during shutdown
+
+### Symptom (from `fixtures/fallback-probe/.../runs/2026-04-20T03-51-09.jsonl`)
+
+```
+04:00:13.023  Received SIGINT, shutting down...
+04:00:13.024  Session closed by closeStory (sess-1b1bac4c, RUNNING → COMPLETED)
+04:00:13.024  Killing 1 registered processes          [PID 152736]
+04:00:13.027  Session prompt exited with code 130
+04:00:13.033  Closing broken session for retry        ← adapter STILL RETRYING
+04:00:13.189  Received SIGTERM, shutting down...      ← new signal
+04:00:13.189  Killing 1 registered processes          [PID 155620 — registered AFTER SIGINT]
+04:00:13.229  Registered PID 155620                   ← spawned mid-shutdown
+04:00:13.260  Failed to kill PID 152736 (exitCode 1)
+04:00:13.260  Process terminated by SIGINT
+04:00:13.261  run.complete  exitReason=sigint
+04:00:13.276  Received SIGHUP
+04:00:13.281  Process terminated by SIGHUP
+04:00:13.282  run.complete  exitReason=sighup         ← DUPLICATE #2
+04:00:13.282  Received SIGHUP
+04:00:13.282  Process terminated by SIGHUP
+04:00:13.282  run.complete  exitReason=sighup         ← DUPLICATE #3
+04:00:13.283  Process terminated by SIGTERM
+04:00:13.283  run.complete  exitReason=sigterm        ← DUPLICATE #4
+```
+
+One Ctrl+C produces five `run.complete` events across five signals, with new PIDs registered between signals.
+
+### Root cause — three compounding bugs
+
+**5a. Signal handler is not idempotent.**
+
+[`src/execution/crash-signals.ts:37-66`](../../src/execution/crash-signals.ts) has no "already shutting down" guard:
+
+```ts
+function createSignalHandler(ctx): (signal) => Promise<void> {
+  return async (signal) => {
+    const hardDeadline = setTimeout(() => process.exit(128 + getSignalNumber(signal)), 10_000);
+    …
+    await ctx.onShutdown();
+    await ctx.pidRegistry.killAll();
+    ctx.emitError?.(signal.toLowerCase());
+    await writeFatalLog(…);
+    await writeRunComplete(ctx, signal.toLowerCase());
+    await updateStatusToCrashed(…);
+    process.exit(128 + getSignalNumber(signal));
+  };
+}
+```
+
+Every signal — SIGINT, SIGTERM, SIGHUP, second SIGHUP, second SIGTERM — runs the full body. Each writes a `run.complete` event and attempts `killAll`.
+
+**5b. No `AbortSignal` into `adapter.run`.**
+
+Adapter's `while (true)` loop at [`src/agents/acp/adapter.ts:466-588`](../../src/agents/acp/adapter.ts) has no cancellation input. When SIGINT kills PID 152736, the adapter sees `exitCode 130`, enters the `sessionError` retry path at line 755-765:
+
+```ts
+const isSessionBroken = !runState.succeeded && lastResponse?.stopReason === "error";
+if ((runState.succeeded && !options.keepOpen) || isSessionBroken) {
+  if (isSessionBroken) getLogger()?.debug("Closing broken session for retry", { sessionName });
+  await closeAcpSession(session);   // spawns `acpx session close` → PID 155620
+}
+```
+
+`closeAcpSession` spawns a new acpx process during shutdown. That PID is registered. Then the adapter would re-enter its `while (true)` loop — except `process.exit` from 5a eventually wins the race.
+
+**5c. `onShutdown` + `pidRegistry.killAll` race against in-flight retry.**
+
+`await ctx.onShutdown()` waits on `closeAllRunSessions`. During that wait, the adapter's interrupted promise runs its `finally` block, registers a new PID (155620), and schedules a new spawn. `killAll()` then runs but PID 155620 was registered *after* `killAll`'s snapshot, so it may be missed — or killed while still starting, producing the "Failed to kill PID" lines.
+
+### Evidence
+
+- `run.complete` events: 5 (expected: 1).
+- New PID (155620) registered 165 ms *after* SIGINT.
+- Second SIGTERM, two SIGHUP signals arrive *during* shutdown and each trigger a full handler run.
+
+### Fix shape
+
+1. **Atomic `shuttingDown` flag in the signal handler.**
+
+   ```ts
+   let shuttingDown = false;
+   function createSignalHandler(ctx) {
+     return async (signal) => {
+       if (shuttingDown) {
+         getSafeLogger()?.warn("crash-recovery", "Signal ignored — shutdown already in progress", { signal });
+         return;
+       }
+       shuttingDown = true;
+       …
+     };
+   }
+   ```
+
+   First signal wins; subsequent signals log once and no-op. The 10 s hard deadline remains as a last-resort kill.
+
+2. **AbortController plumbed through `AgentRunOptions`.**
+
+   - `SignalHandlerContext` owns an `AbortController`.
+   - On first signal: `controller.abort()` before awaiting `onShutdown`.
+   - `AgentRunOptions.abortSignal?: AbortSignal` — adapter's `while (true)` checks `abortSignal.aborted` before each retry and before spawning close processes. On abort, return a clean `{ success: false, exitCode: 130, adapterFailure: { outcome: "fail-aborted", retriable: false } }` without spawning anything new.
+
+3. **PID registry stop-accepting-new-registrations on shutdown.**
+
+   `PidRegistry.freeze()` flips a flag so `register()` becomes a no-op + warning after shutdown begins. Prevents late spawns from being tracked against a registry that is already flushed.
+
+### Impact
+
+- **Data integrity:** 5× `run.complete` events in the JSONL stream break downstream log consumers that expect exactly one per run.
+- **Process hygiene:** PIDs spawned during shutdown may survive — orphan acpx processes.
+- **Ctrl+C UX:** user presses Ctrl+C once but must hit it multiple times because the adapter keeps retrying; each retry spawns a new process.
+
+---
+
+## Recommended order
+
+1. **#5** — signal idempotency + AbortController. Ship first: fixes data-integrity (run.complete duplicates) and orphan-process risk. Unblocks clean Ctrl+C in headless mode.
+2. **#4** — fallback classifier. Second priority: fallback map is currently dead for the most common failure mode (auth). Prefer the structured-acpx-error-contract route over regex widening.
+3. **#1 / #2 / #3** — bundle as one coordinated SessionManager-bookkeeping change:
+   - Add `transition(..., "RUNNING")` / `transition(..., "COMPLETED")` in TDD path (fixes #1).
+   - Add `tokenUsage` to `TddSessionResult` + propagate on `ctx.agentResult` (fixes #2).
+   - Add `onSessionEstablished` callback to `AgentRunOptions` and bind handle early in the adapter (fixes #3).
+   All three touch the same session/adapter wiring; one PR is cheaper than three.
+
+---
+
+## Appendix — Evidence pointers
+
+| Issue | Primary evidence |
+|:---|:---|
+| #1 | [`fixtures/tdd-calc/.nax/features/tdd-calc/sessions/sess-*/descriptor.json`](/) — all have `completedStages: []` |
+| #2 | `tdd-calc/.nax/metrics.json` vs `hello-lint/.nax/metrics.json` |
+| #3 | `fallback-probe/…/sess-1b1bac4c-…/descriptor.json` with null protocolIds |
+| #4 | `fallback-probe/…/runs/2026-04-20T03-51-09.jsonl` lines 53-87 |
+| #5 | `fallback-probe/…/runs/2026-04-20T03-51-09.jsonl` lines 121-150 |

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -464,6 +464,30 @@ export class AcpAgentAdapter implements AgentAdapter {
     });
 
     while (true) {
+      // Fix for v0.63.0-canary.8 Issue 5: honour the shutdown abort signal
+      // BEFORE issuing any new work. Without this, hitting Ctrl+C while the
+      // adapter is in its session-error retry path would spawn a fresh acpx
+      // session during shutdown, register a new PID, and race with teardown.
+      if (options.abortSignal?.aborted) {
+        getSafeLogger()?.warn("acp-adapter", `Run aborted for ${this.name} (shutdown in progress)`, {
+          storyId: options.storyId,
+          featureName: options.featureName,
+        });
+        return {
+          success: false,
+          exitCode: 130,
+          output: "Run aborted — shutdown in progress",
+          rateLimited: false,
+          durationMs: Date.now() - startTime,
+          estimatedCost: 0,
+          adapterFailure: {
+            category: "availability",
+            outcome: "fail-aborted",
+            retriable: false,
+            message: "Run aborted — shutdown in progress",
+          },
+        };
+      }
       try {
         const result = await this._runWithClient(options, startTime, this.name);
 
@@ -482,7 +506,8 @@ export class AcpAgentAdapter implements AgentAdapter {
           if (
             result.sessionError &&
             _acpAdapterDeps.shouldRetrySessionError &&
-            sessionErrorRetries < maxSessionRetries
+            sessionErrorRetries < maxSessionRetries &&
+            !options.abortSignal?.aborted
           ) {
             sessionErrorRetries += 1;
             getSafeLogger()?.warn("acp-adapter", "Session error — retrying with fresh session", {

--- a/src/agents/manager-types.ts
+++ b/src/agents/manager-types.ts
@@ -46,6 +46,12 @@ export interface AgentRunRequest {
   bundle?: ContextBundle;
   sessionId?: string;
   /**
+   * Shutdown / cancellation signal (#585 Path B). When aborted, runWithFallback
+   * races the rate-limit backoff sleep against it and returns `fail-aborted`
+   * without issuing further hops. Fires on SIGTERM / SIGINT / user abort.
+   */
+  signal?: AbortSignal;
+  /**
    * Per-hop executor. When provided, replaces the internal adapter.run() call for every hop
    * (primary AND fallback). Called with:
    *   - agentName: which agent to use for this hop

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -113,6 +113,9 @@ export class AgentManager implements IAgentManager {
 
   shouldSwap(failure: AdapterFailure | undefined, hopsSoFar: number, bundle: ContextBundle | undefined): boolean {
     if (!failure) return false;
+    // Aborted runs (shutdown in progress) must not trigger fallback —
+    // swapping to another agent would spawn fresh work during teardown.
+    if (failure.outcome === "fail-aborted") return false;
     const fallback = this._config.agent?.fallback;
     if (!fallback?.enabled) return false;
     if (!bundle) return false;

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -197,8 +197,16 @@ export class AgentManager implements IAgentManager {
       const bundleForSwapCheck = updatedBundle ?? request.bundle;
 
       if (!this.shouldSwap(result.adapterFailure, hopsSoFar, bundleForSwapCheck)) {
-        // Preserve legacy rate-limit backoff when no swap candidates are available
+        // Preserve legacy rate-limit backoff when no swap candidates are available.
+        // #585 Path B: race the sleep against the shutdown signal — an abort during
+        // backoff settles within milliseconds instead of the full exponential wait.
         if (result.adapterFailure?.outcome === "fail-rate-limit" && rateLimitRetry < MAX_RATE_LIMIT_RETRIES) {
+          if (request.signal?.aborted) {
+            logger?.info("agent-manager", "Rate-limited backoff aborted — shutdown in progress", {
+              storyId: request.runOptions.storyId,
+            });
+            return { result, fallbacks, finalBundle: updatedBundle, finalPrompt };
+          }
           rateLimitRetry += 1;
           const backoffMs = 2 ** rateLimitRetry * 1000;
           logger?.info("agent-manager", "Rate-limited with no swap candidate — backing off", {
@@ -206,7 +214,10 @@ export class AgentManager implements IAgentManager {
             attempt: rateLimitRetry,
             backoffMs,
           });
-          await _agentManagerDeps.sleep(backoffMs);
+          await _agentManagerDeps.sleep(backoffMs, request.signal);
+          if (request.signal?.aborted) {
+            return { result, fallbacks, finalBundle: updatedBundle, finalPrompt };
+          }
           continue;
         }
         if (hopsSoFar > 0) {

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -145,6 +145,16 @@ export interface AgentRunOptions {
    * Phase 5.5: replaces sessionHandle, featureName, storyId, sessionRole, keepOpen.
    */
   session?: SessionDescriptor;
+  /**
+   * Shutdown signal (fix for v0.63.0-canary.8 Issue 5).
+   * When aborted, the adapter's retry loop must stop issuing new work:
+   *   - no new session prompts
+   *   - no new `closeAcpSession` spawns for "broken session retry"
+   *   - return a clean failure result so the caller can unwind.
+   * Owned by the crash-recovery signal handler; fires on SIGINT/SIGTERM/SIGHUP.
+   * Optional for backward compat — adapters that ignore it stay functional.
+   */
+  abortSignal?: AbortSignal;
 }
 
 /**

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -29,14 +29,18 @@ export interface AdapterFailure {
   category: "availability" | "quality";
   /**
    * Machine-readable outcome code.
-   * availability: fail-quota | fail-service-down | fail-auth | fail-rate-limit
+   * availability: fail-quota | fail-service-down | fail-auth | fail-rate-limit | fail-aborted
    * quality:      fail-timeout | fail-adapter-error | fail-quality | fail-unknown
+   *
+   * `fail-aborted` — the run was cancelled via AgentRunOptions.abortSignal
+   * (shutdown in progress). Not retriable; fallback chains should not fire.
    */
   outcome:
     | "fail-quota"
     | "fail-service-down"
     | "fail-auth"
     | "fail-rate-limit"
+    | "fail-aborted"
     | "fail-timeout"
     | "fail-adapter-error"
     | "fail-quality"

--- a/src/execution/crash-recovery.ts
+++ b/src/execution/crash-recovery.ts
@@ -45,8 +45,17 @@ export interface CrashRecoveryContext {
   getTotalStories?: () => number;
   getStoriesCompleted?: () => number;
   emitError?: (reason: string) => void;
-  /** Called during graceful shutdown before process.exit — use to close ACP sessions etc. */
-  onShutdown?: () => Promise<void>;
+  /**
+   * Shared abort controller (Issue 5). Signal handler calls `.abort()` on the
+   * first fatal signal so in-flight agent.run and onShutdown awaits can bail.
+   */
+  abortController?: AbortController;
+  /**
+   * Called during graceful shutdown before process.exit — use to close ACP
+   * sessions etc. Receives the abort signal so long-running awaits can short
+   * circuit.
+   */
+  onShutdown?: (abortSignal?: AbortSignal) => Promise<void>;
 }
 
 // Stores the active cleanup function so a second installCrashHandlers() call

--- a/src/execution/crash-signals.ts
+++ b/src/execution/crash-signals.ts
@@ -1,5 +1,19 @@
 /**
  * Crash detection — Signal and exception handlers
+ *
+ * Idempotency contract (fix for v0.63.0-canary.8 Issue 5):
+ *   The first fatal signal/exception wins. Subsequent signals log once and
+ *   no-op until the process exits. Without this, a cascading SIGINT → SIGTERM
+ *   → SIGHUP sequence (common when Ctrl+C is hit in a terminal that then
+ *   hangs the child) would run the full shutdown path once per signal,
+ *   writing duplicate `run.complete` events, killing PIDs repeatedly, and
+ *   racing against in-flight ACP retry loops that spawn new processes mid
+ *   shutdown.
+ *
+ * AbortController contract:
+ *   On first signal the handler aborts `ctx.abortController` (if present) so
+ *   long-running awaits in onShutdown/agent.run can bail instead of spawning
+ *   new work during teardown.
  */
 
 import { getSafeLogger } from "../logger";
@@ -15,8 +29,18 @@ export interface SignalHandlerContext extends RunCompleteContext {
   pidRegistry?: PidRegistry;
   featureDir?: string;
   emitError?: (reason: string) => void;
-  /** Called during graceful shutdown (signal/exception) before process.exit — use to close ACP sessions etc. */
-  onShutdown?: () => Promise<void>;
+  /**
+   * Shared abort controller. The signal handler calls `.abort()` on the first
+   * fatal signal; consumers (onShutdown, in-flight agent.run) can observe
+   * `.signal.aborted` to stop issuing new work. Caller owns creation.
+   */
+  abortController?: AbortController;
+  /**
+   * Called during graceful shutdown (signal/exception) before process.exit —
+   * use to close ACP sessions, flush buffers, etc. The abort signal is passed
+   * through so long-running awaits can short-circuit.
+   */
+  onShutdown?: (abortSignal?: AbortSignal) => Promise<void>;
 }
 
 /**
@@ -32,21 +56,41 @@ function getSignalNumber(signal: NodeJS.Signals): number {
 }
 
 /**
- * Create signal handler
+ * Create signal handler.
+ *
+ * Returns a per-install handler that is idempotent: once a shutdown path has
+ * started, subsequent signals log and no-op.
  */
-function createSignalHandler(ctx: SignalHandlerContext): (signal: NodeJS.Signals) => Promise<void> {
+function createSignalHandler(
+  ctx: SignalHandlerContext,
+  state: { shuttingDown: boolean },
+): (signal: NodeJS.Signals) => Promise<void> {
   return async (signal: NodeJS.Signals) => {
+    const logger = getSafeLogger();
+
+    if (state.shuttingDown) {
+      logger?.warn("crash-recovery", `${signal} ignored — shutdown already in progress`, { signal });
+      return;
+    }
+    state.shuttingDown = true;
+
     const hardDeadline = setTimeout(() => {
       process.exit(128 + getSignalNumber(signal));
     }, 10_000);
     if (hardDeadline.unref) hardDeadline.unref();
 
-    const logger = getSafeLogger();
     logger?.error("crash-recovery", `Received ${signal}, shutting down...`, { signal });
+
+    // Abort in-flight awaits so onShutdown / agent.run can bail fast.
+    ctx.abortController?.abort();
+
+    // Freeze the PID registry so retry paths cannot register new processes
+    // during teardown.
+    ctx.pidRegistry?.freeze?.();
 
     // Close ACP sessions gracefully first (spawns are tracked by pidRegistry)
     if (ctx.onShutdown) {
-      await ctx.onShutdown().catch(() => {});
+      await ctx.onShutdown(ctx.abortController?.signal).catch(() => {});
     }
 
     // Kill any remaining processes (including hung session-close spawns)
@@ -66,23 +110,37 @@ function createSignalHandler(ctx: SignalHandlerContext): (signal: NodeJS.Signals
 }
 
 /**
- * Create uncaught exception handler
+ * Create uncaught exception handler.
+ *
+ * Shares the idempotency flag with signal handlers so an uncaughtException
+ * that follows (or precedes) a signal does not re-run the shutdown path.
  */
-function createUncaughtExceptionHandler(ctx: SignalHandlerContext): (error: Error) => Promise<void> {
+function createUncaughtExceptionHandler(
+  ctx: SignalHandlerContext,
+  state: { shuttingDown: boolean },
+): (error: Error) => Promise<void> {
   return async (error: Error) => {
     process.stderr.write(`\n[nax crash] Uncaught exception: ${error.message}\n${error.stack ?? ""}\n`);
     const logger = getSafeLogger();
+
+    if (state.shuttingDown) {
+      logger?.warn("crash-recovery", "Uncaught exception during shutdown — ignored", { error: error.message });
+      return;
+    }
+    state.shuttingDown = true;
+
     logger?.error("crash-recovery", "Uncaught exception", {
       error: error.message,
       stack: error.stack,
     });
 
-    // Close ACP sessions gracefully first (spawns are tracked by pidRegistry)
+    ctx.abortController?.abort();
+    ctx.pidRegistry?.freeze?.();
+
     if (ctx.onShutdown) {
-      await ctx.onShutdown().catch(() => {});
+      await ctx.onShutdown(ctx.abortController?.signal).catch(() => {});
     }
 
-    // Kill any remaining processes (including hung session-close spawns)
     if (ctx.pidRegistry) {
       await ctx.pidRegistry.killAll();
     }
@@ -102,24 +160,37 @@ function createUncaughtExceptionHandler(ctx: SignalHandlerContext): (error: Erro
 }
 
 /**
- * Create unhandled promise rejection handler
+ * Create unhandled promise rejection handler.
+ *
+ * Shares the idempotency flag with signal handlers.
  */
-function createUnhandledRejectionHandler(ctx: SignalHandlerContext): (reason: unknown) => Promise<void> {
+function createUnhandledRejectionHandler(
+  ctx: SignalHandlerContext,
+  state: { shuttingDown: boolean },
+): (reason: unknown) => Promise<void> {
   return async (reason: unknown) => {
     const error = reason instanceof Error ? reason : new Error(String(reason));
     process.stderr.write(`\n[nax crash] Unhandled rejection: ${error.message}\n${error.stack ?? ""}\n`);
     const logger = getSafeLogger();
+
+    if (state.shuttingDown) {
+      logger?.warn("crash-recovery", "Unhandled rejection during shutdown — ignored", { error: error.message });
+      return;
+    }
+    state.shuttingDown = true;
+
     logger?.error("crash-recovery", "Unhandled promise rejection", {
       error: error.message,
       stack: error.stack,
     });
 
-    // Close ACP sessions gracefully first (spawns are tracked by pidRegistry)
+    ctx.abortController?.abort();
+    ctx.pidRegistry?.freeze?.();
+
     if (ctx.onShutdown) {
-      await ctx.onShutdown().catch(() => {});
+      await ctx.onShutdown(ctx.abortController?.signal).catch(() => {});
     }
 
-    // Kill any remaining processes (including hung session-close spawns)
     if (ctx.pidRegistry) {
       await ctx.pidRegistry.killAll();
     }
@@ -139,14 +210,20 @@ function createUnhandledRejectionHandler(ctx: SignalHandlerContext): (reason: un
 }
 
 /**
- * Install signal and exception handlers, return cleanup function
+ * Install signal and exception handlers, return cleanup function.
+ *
+ * All fatal handlers share a single `shuttingDown` flag: the first one to
+ * fire runs the full teardown path, subsequent ones log and no-op. This
+ * prevents duplicate `run.complete` events and race-registered PIDs when a
+ * cascade of signals (SIGINT → SIGTERM → SIGHUP) arrives during shutdown.
  */
 export function installSignalHandlers(ctx: SignalHandlerContext): () => void {
   const logger = getSafeLogger();
+  const state = { shuttingDown: false };
 
-  const signalHandler = createSignalHandler(ctx);
-  const uncaughtExceptionHandler = createUncaughtExceptionHandler(ctx);
-  const unhandledRejectionHandler = createUnhandledRejectionHandler(ctx);
+  const signalHandler = createSignalHandler(ctx, state);
+  const uncaughtExceptionHandler = createUncaughtExceptionHandler(ctx, state);
+  const unhandledRejectionHandler = createUnhandledRejectionHandler(ctx, state);
 
   const sigtermHandler = () => signalHandler("SIGTERM");
   const sigintHandler = () => signalHandler("SIGINT");

--- a/src/execution/executor-types.ts
+++ b/src/execution/executor-types.ts
@@ -44,6 +44,11 @@ export interface SequentialExecutionContext {
   agentGetFn?: AgentGetFn;
   /** PID registry for crash recovery — register child PIDs so they can be killed on SIGTERM. */
   pidRegistry?: PidRegistry;
+  /**
+   * Shutdown abort signal (Issue 5 fix). Fires on first fatal signal; threaded
+   * into PipelineContext.abortSignal → AgentRunOptions.abortSignal.
+   */
+  abortSignal?: AbortSignal;
   /** Max parallel sessions: undefined=sequential, 0=auto-detect, N>0=cap at N */
   parallelCount?: number;
 }

--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -176,6 +176,7 @@ export async function runIteration(
     interaction: ctx.interactionChain ?? undefined,
     agentGetFn: ctx.agentGetFn,
     pidRegistry: ctx.pidRegistry,
+    abortSignal: ctx.abortSignal,
     sessionManager: ctx.sessionManager,
     agentManager: ctx.agentManager,
     accumulatedAttemptCost: accumulatedAttemptCost > 0 ? accumulatedAttemptCost : undefined,

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -113,6 +113,13 @@ export interface RunSetupResult {
     failed: number;
   };
   interactionChain: InteractionChain | null;
+  /**
+   * Shutdown controller (fix for v0.63.0-canary.8 Issue 5).
+   * Aborted by the crash/signal handler on first fatal signal. Threaded into
+   * AgentRunOptions.abortSignal so in-flight adapter retry loops can bail
+   * instead of spawning new work during teardown.
+   */
+  shutdownController: AbortController;
 }
 
 /**
@@ -160,6 +167,11 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
   const pidRegistry = new PidRegistry(workdir);
   const sessionManager = new SessionManager();
 
+  // Shutdown controller — fires on first fatal signal. Threaded into
+  // AgentRunOptions.abortSignal so the ACP adapter's retry loop stops
+  // spawning fresh acpx processes during teardown (Issue 5).
+  const shutdownController = new AbortController();
+
   // Cleanup stale PIDs from previous crashed runs
   await pidRegistry.cleanupStale();
 
@@ -170,6 +182,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     getIterations,
     jsonlFilePath: logFilePath,
     pidRegistry,
+    abortController: shutdownController,
     // BUG-017: Pass context for run.complete event on SIGTERM
     runId: options.runId,
     feature: options.feature,
@@ -333,6 +346,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
       prd,
       storyCounts: counts,
       interactionChain,
+      shutdownController,
     };
   } catch (error) {
     // Release lock before re-throwing so the directory isn't permanently locked

--- a/src/execution/pid-registry.ts
+++ b/src/execution/pid-registry.ts
@@ -47,6 +47,7 @@ export class PidRegistry {
   private readonly pidsFilePath: string;
   private readonly pids: Set<number> = new Set();
   private readonly platform: NodeJS.Platform;
+  private frozen = false;
 
   /**
    * Create a new PID registry for the given workdir.
@@ -61,14 +62,41 @@ export class PidRegistry {
   }
 
   /**
+   * Mark the registry frozen. After freeze, `register()` is a no-op that logs
+   * a warning, and `killAll()` still works on already-registered PIDs. Called
+   * by signal handlers at shutdown so in-flight retry paths cannot register
+   * newly-spawned processes that would then outlive the process.
+   *
+   * Idempotent.
+   */
+  freeze(): void {
+    if (this.frozen) return;
+    this.frozen = true;
+    getSafeLogger()?.debug("pid-registry", "Registry frozen — new registrations blocked");
+  }
+
+  /** Whether the registry currently rejects new registrations. */
+  isFrozen(): boolean {
+    return this.frozen;
+  }
+
+  /**
    * Register a spawned process PID.
    *
    * Adds the PID to the in-memory set and writes to .nax-pids file.
+   *
+   * When the registry is frozen (see `freeze()`), the PID is NOT recorded and
+   * a warning is logged. Callers spawning during shutdown should not register
+   * their children; let the OS reap them once the process exits.
    *
    * @param pid - Process ID to register
    */
   async register(pid: number): Promise<void> {
     const logger = getSafeLogger();
+    if (this.frozen) {
+      logger?.warn("pid-registry", `Registration blocked (registry frozen) PID ${pid}`, { pid });
+      return;
+    }
     this.pids.add(pid);
 
     const entry: PidEntry = {

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -49,6 +49,8 @@ export interface RunnerExecutionOptions {
   agentGetFn?: AgentGetFn;
   /** PID registry for crash recovery — passed to agent.run() to register child processes. */
   pidRegistry?: PidRegistry;
+  /** Shutdown abort signal (Issue 5). Threaded into pipeline ctx for agent.run cancellation. */
+  abortSignal?: AbortSignal;
   /** Interaction chain for cost/pre-merge triggers during sequential execution. */
   interactionChain?: InteractionChain | null;
   /** Run-level SessionManager shared across story iterations. */
@@ -163,6 +165,7 @@ export async function runExecutionPhase(
       parallelCount: options.parallel,
       agentGetFn: options.agentGetFn,
       pidRegistry: options.pidRegistry,
+      abortSignal: options.abortSignal,
       interactionChain: options.interactionChain,
       agentManager: options.agentManager,
       batchPlan,

--- a/src/execution/runner-setup.ts
+++ b/src/execution/runner-setup.ts
@@ -50,6 +50,7 @@ export interface RunnerSetupResult {
   storyCounts: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["storyCounts"];
   interactionChain: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["interactionChain"];
   prd: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["prd"];
+  shutdownController: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["shutdownController"];
 }
 
 /**

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -149,8 +149,15 @@ export async function run(options: RunOptions): Promise<RunResult> {
     getTotalStories: () => (prd ? countStories(prd).total : 0),
   });
 
-  const { statusWriter, pidRegistry, sessionManager, cleanupCrashHandlers, pluginRegistry, interactionChain } =
-    setupResult;
+  const {
+    statusWriter,
+    pidRegistry,
+    sessionManager,
+    cleanupCrashHandlers,
+    pluginRegistry,
+    interactionChain,
+    shutdownController,
+  } = setupResult;
   prd = setupResult.prd;
 
   try {
@@ -177,6 +184,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
         parallel,
         agentGetFn,
         pidRegistry,
+        abortSignal: shutdownController.signal,
         interactionChain,
         sessionManager,
         agentManager,

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -209,6 +209,7 @@ export async function executeUnified(
                 featureDir: ctx.featureDir,
                 agentGetFn: ctx.agentGetFn,
                 pidRegistry: ctx.pidRegistry,
+                abortSignal: ctx.abortSignal,
               },
               eventEmitter: ctx.eventEmitter,
               agentGetFn: ctx.agentGetFn,

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -186,6 +186,7 @@ export const executionStage: PipelineStage = {
       ? ctx.agentManager.runWithFallback({
           runOptions: baseRunOptions,
           bundle: ctx.contextBundle,
+          signal: ctx.abortSignal,
           executeHop: async (agentName, bundle, failure) => {
             const hopAgent = (ctx.agentGetFn ?? _executionDeps.getAgent)(agentName);
             if (!hopAgent) {

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -170,6 +170,7 @@ export const executionStage: PipelineStage = {
       projectDir: ctx.projectDir,
       maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
       pidRegistry: ctx.pidRegistry,
+      abortSignal: ctx.abortSignal,
       featureName: ctx.prd.feature,
       storyId: ctx.story.id,
       sessionRole: "implementer",

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -109,6 +109,12 @@ export interface PipelineContext {
   agentGetFn?: AgentGetFn;
   /** PID registry for crash recovery — passed through to agent.run() for child process registration. */
   pidRegistry?: PidRegistry;
+  /**
+   * Shutdown abort signal (Issue 5 fix).
+   * Fires on first fatal signal. Threaded into AgentRunOptions.abortSignal so
+   * in-flight adapter retry loops can stop spawning new work during teardown.
+   */
+  abortSignal?: AbortSignal;
   /** Interaction chain (optional, for human-in-the-loop triggers) */
   interaction?: InteractionChain;
   /** Constitution result (set by constitutionStage) */

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -71,6 +71,8 @@ export interface ThreeSessionTddOptions {
   interactionChain?: InteractionChain | null;
   /** Absolute path to repo root — forwarded to agent.run() for prompt audit fast path */
   projectDir?: string;
+  /** Shutdown abort signal (Issue 5) — forwarded to each agent.run call */
+  abortSignal?: AbortSignal;
 }
 
 /**
@@ -96,6 +98,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     _recursionDepth = 0,
     interactionChain,
     projectDir,
+    abortSignal,
   } = options;
   const logger = getLogger();
 
@@ -204,6 +207,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
       featureContextMarkdown,
       testWriterBundle,
       getTddSessionBinding?.("test-writer"),
+      abortSignal,
     );
     sessions.push(session1);
     await recordTddSessionOutcome?.(session1);
@@ -325,6 +329,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     featureContextMarkdown,
     implementerBundle,
     getTddSessionBinding?.("implementer"),
+    abortSignal,
   );
   sessions.push(session2);
   await recordTddSessionOutcome?.(session2);
@@ -380,6 +385,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     featureContextMarkdown,
     verifierBundle,
     getTddSessionBinding?.("verifier"),
+    abortSignal,
   );
   sessions.push(session3);
   await recordTddSessionOutcome?.(session3);
@@ -662,5 +668,6 @@ export async function runThreeSessionTddFromCtx(
     lite: opts.lite ?? false,
     interactionChain: ctx.interaction,
     projectDir: ctx.projectDir,
+    abortSignal: ctx.abortSignal,
   });
 }

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -136,6 +136,7 @@ export async function runTddSession(
   featureContextMarkdown?: string,
   contextBundle?: import("../context/engine").ContextBundle,
   sessionBinding?: TddSessionBinding,
+  abortSignal?: AbortSignal,
 ): Promise<TddSessionResult> {
   const startTime = Date.now();
 
@@ -237,6 +238,7 @@ export async function runTddSession(
         })
       : undefined,
     interactionBridge,
+    abortSignal,
   });
 
   // #541: bind ACP protocolIds to the pre-created session descriptor so the

--- a/test/unit/agents/acp/adapter-abort.test.ts
+++ b/test/unit/agents/acp/adapter-abort.test.ts
@@ -1,0 +1,63 @@
+/**
+ * AcpAgentAdapter.run() — abortSignal behaviour (Issue 5 fix).
+ *
+ * When options.abortSignal is already aborted, run() must NOT spawn a client
+ * at all — return early with fail-aborted. This prevents the adapter's retry
+ * loop from registering new processes during shutdown.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { AcpAgentAdapter, _acpAdapterDeps } from "../../../../src/agents/acp/adapter";
+import { makeClient, makeRunOptions, makeSession } from "./adapter.test";
+
+describe("AcpAgentAdapter.run() — abortSignal", () => {
+  const origCreateClient = _acpAdapterDeps.createClient;
+  const origSleep = _acpAdapterDeps.sleep;
+
+  beforeEach(() => {
+    _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
+  });
+
+  afterEach(() => {
+    _acpAdapterDeps.createClient = origCreateClient;
+    _acpAdapterDeps.sleep = origSleep;
+    mock.restore();
+  });
+
+  test("pre-aborted signal short-circuits before createClient is called", async () => {
+    let createClientCalls = 0;
+    const session = makeSession();
+    _acpAdapterDeps.createClient = mock((_cmd: string) => {
+      createClientCalls += 1;
+      return makeClient(session);
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await new AcpAgentAdapter("claude").run(
+      makeRunOptions({ abortSignal: controller.signal }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(130);
+    expect(result.adapterFailure?.outcome).toBe("fail-aborted");
+    expect(result.adapterFailure?.category).toBe("availability");
+    expect(result.adapterFailure?.retriable).toBe(false);
+    // Crucial: no client was ever spawned.
+    expect(createClientCalls).toBe(0);
+  });
+
+  test("un-aborted signal is transparent — run proceeds normally", async () => {
+    const session = makeSession();
+    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
+
+    const controller = new AbortController();
+    const result = await new AcpAgentAdapter("claude").run(
+      makeRunOptions({ abortSignal: controller.signal }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.adapterFailure).toBeUndefined();
+  });
+});

--- a/test/unit/agents/manager-abort.test.ts
+++ b/test/unit/agents/manager-abort.test.ts
@@ -1,0 +1,125 @@
+/**
+ * AgentManager.runWithFallback — AbortSignal plumbing (#585 Path B).
+ *
+ * Verifies that when a request carries an `AbortSignal`, rate-limit backoff
+ * settles within a few ms instead of the full exponential wait, and that the
+ * outcome reflects the aborted state rather than continuing to retry.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { AgentManager, _agentManagerDeps } from "../../../src/agents/manager";
+import type { AgentRegistry } from "../../../src/agents/registry";
+import { DEFAULT_CONFIG } from "../../../src/config/defaults";
+import type { AgentResult } from "../../../src/agents/types";
+
+const rateLimitFailure = {
+  category: "availability" as const,
+  outcome: "fail-rate-limit" as const,
+  retriable: true,
+  message: "429",
+};
+
+const mockBundle = {} as import("../../../src/context/engine").ContextBundle;
+
+function makeConfigNoFallback() {
+  // No fallback chain — forces the rate-limit-backoff branch rather than a swap.
+  return {
+    ...DEFAULT_CONFIG,
+    agent: {
+      ...DEFAULT_CONFIG.agent,
+      fallback: { enabled: false, map: {}, maxHopsPerStory: 0, onQualityFailure: false, rebuildContext: false },
+    },
+  } as never;
+}
+
+function makeRateLimitedRegistry() {
+  return {
+    getAgent: () => ({
+      run: mock(
+        async (): Promise<AgentResult> => ({
+          success: false,
+          exitCode: 1,
+          output: "",
+          rateLimited: true,
+          durationMs: 0,
+          estimatedCost: 0,
+          adapterFailure: rateLimitFailure,
+        }),
+      ),
+    }),
+  } as unknown as AgentRegistry;
+}
+
+describe("AgentManager.runWithFallback — abort signal (#585)", () => {
+  const origSleep = _agentManagerDeps.sleep;
+  afterEach(() => {
+    _agentManagerDeps.sleep = origSleep;
+  });
+
+  test("pre-aborted signal stops backoff immediately (no sleep issued)", async () => {
+    const sleepCalls: Array<{ ms: number; aborted: boolean }> = [];
+    _agentManagerDeps.sleep = async (ms, signal) => {
+      sleepCalls.push({ ms, aborted: Boolean(signal?.aborted) });
+    };
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const m = new AgentManager(makeConfigNoFallback(), makeRateLimitedRegistry());
+    const outcome = await m.runWithFallback({
+      runOptions: { storyId: "s1" } as never,
+      bundle: mockBundle,
+      signal: controller.signal,
+    });
+
+    // The adapter ran once and returned the rate-limit failure.
+    // Backoff sleep must NOT have been issued because the signal was already aborted.
+    expect(outcome.result.success).toBe(false);
+    expect(sleepCalls).toHaveLength(0);
+  });
+
+  test("signal forwarded to sleep — backoff races against it", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    _agentManagerDeps.sleep = async (_ms, signal) => {
+      receivedSignal = signal;
+    };
+
+    const controller = new AbortController();
+    const m = new AgentManager(makeConfigNoFallback(), makeRateLimitedRegistry());
+    await m.runWithFallback({
+      runOptions: { storyId: "s1" } as never,
+      bundle: mockBundle,
+      signal: controller.signal,
+    });
+
+    expect(receivedSignal).toBe(controller.signal);
+  });
+
+  test("abort during backoff returns without further retries", async () => {
+    // Simulate a sleep that "wakes up" to find the signal aborted.
+    _agentManagerDeps.sleep = async (_ms, signal) => {
+      if (signal && !signal.aborted) {
+        // pretend the signal aborted while we were sleeping
+        (signal as unknown as { _testAbort?: () => void })._testAbort?.();
+      }
+    };
+
+    const controller = new AbortController();
+    // Abort after a microtask so the first hop runs, then the signal is aborted
+    // before the backoff loop checks again.
+    queueMicrotask(() => controller.abort());
+
+    const m = new AgentManager(makeConfigNoFallback(), makeRateLimitedRegistry());
+    const startHops = performance.now();
+    const outcome = await m.runWithFallback({
+      runOptions: { storyId: "s1" } as never,
+      bundle: mockBundle,
+      signal: controller.signal,
+    });
+    const elapsed = performance.now() - startHops;
+
+    // Settled quickly, did not loop through all 3 backoff attempts.
+    expect(elapsed).toBeLessThan(500);
+    expect(outcome.result.adapterFailure?.outcome).toBe("fail-rate-limit");
+  });
+});

--- a/test/unit/execution/crash-signals-idempotency.test.ts
+++ b/test/unit/execution/crash-signals-idempotency.test.ts
@@ -1,0 +1,152 @@
+/**
+ * crash-signals — idempotency + AbortController (Issue 5 fix).
+ *
+ * Ensures that once a shutdown path has started, subsequent fatal signals
+ * log and no-op. Also verifies that `abortController` is aborted on first
+ * signal and `onShutdown` receives the signal.
+ *
+ * Signals are not fired via `process.kill` (that would kill the test
+ * runner). Instead we invoke the listener directly — same code path, no
+ * process exit because we mock `process.exit`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  type SignalHandlerContext,
+  installSignalHandlers,
+} from "../../../src/execution/crash-signals";
+import type { StatusWriter } from "../../../src/execution/status-writer";
+
+const noopStatusWriter = {
+  setRunStatus: () => {},
+  update: async () => {},
+} as unknown as StatusWriter;
+
+/** Invoke every SIGTERM listener registered on `process`. */
+async function fireSignal(signal: NodeJS.Signals): Promise<void> {
+  const listeners = process.listeners(signal) as Array<() => Promise<void> | void>;
+  for (const fn of listeners) {
+    await fn();
+  }
+}
+
+describe("crash-signals idempotency", () => {
+  let cleanup: (() => void) | undefined;
+  let originalExit: typeof process.exit;
+  let exitCalls: number[] = [];
+
+  beforeEach(() => {
+    originalExit = process.exit;
+    exitCalls = [];
+    // Prevent the real process.exit from killing the test runner.
+    (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number) => {
+      exitCalls.push(code ?? 0);
+      // biome-ignore lint/correctness/noPrecisionLoss: no-op in tests
+      return undefined as never;
+    }) as typeof process.exit;
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    process.exit = originalExit;
+  });
+
+  test("second signal after shutdown has started is ignored (no duplicate onShutdown/killAll)", async () => {
+    const onShutdown = mock(async () => {});
+    const killAll = mock(async () => {});
+    const abortController = new AbortController();
+
+    const ctx: SignalHandlerContext = {
+      statusWriter: noopStatusWriter,
+      getTotalCost: () => 0,
+      getIterations: () => 0,
+      onShutdown,
+      pidRegistry: {
+        killAll,
+        register: async () => {},
+        unregister: async () => {},
+        cleanupStale: async () => {},
+        freeze: () => {},
+        isFrozen: () => false,
+        getPids: () => [],
+      } as never,
+      abortController,
+    };
+
+    cleanup = installSignalHandlers(ctx);
+
+    // First SIGINT fires the full path.
+    await fireSignal("SIGINT");
+
+    expect(onShutdown).toHaveBeenCalledTimes(1);
+    expect(killAll).toHaveBeenCalledTimes(1);
+    expect(abortController.signal.aborted).toBe(true);
+
+    // Second fatal signal must NOT re-run onShutdown / killAll.
+    await fireSignal("SIGTERM");
+
+    expect(onShutdown).toHaveBeenCalledTimes(1);
+    expect(killAll).toHaveBeenCalledTimes(1);
+  });
+
+  test("first signal aborts the shared AbortController", async () => {
+    const abortController = new AbortController();
+    const ctx: SignalHandlerContext = {
+      statusWriter: noopStatusWriter,
+      getTotalCost: () => 0,
+      getIterations: () => 0,
+      abortController,
+    };
+
+    cleanup = installSignalHandlers(ctx);
+
+    expect(abortController.signal.aborted).toBe(false);
+    await fireSignal("SIGINT");
+    expect(abortController.signal.aborted).toBe(true);
+  });
+
+  test("onShutdown receives the abort signal so it can short-circuit long awaits", async () => {
+    let received: AbortSignal | undefined;
+    const abortController = new AbortController();
+
+    const ctx: SignalHandlerContext = {
+      statusWriter: noopStatusWriter,
+      getTotalCost: () => 0,
+      getIterations: () => 0,
+      abortController,
+      onShutdown: async (signal) => {
+        received = signal;
+      },
+    };
+
+    cleanup = installSignalHandlers(ctx);
+    await fireSignal("SIGINT");
+
+    expect(received).toBeDefined();
+    expect(received?.aborted).toBe(true);
+  });
+
+  test("pidRegistry.freeze() is called on first signal", async () => {
+    const freeze = mock(() => {});
+    const ctx: SignalHandlerContext = {
+      statusWriter: noopStatusWriter,
+      getTotalCost: () => 0,
+      getIterations: () => 0,
+      pidRegistry: {
+        freeze,
+        killAll: async () => {},
+        register: async () => {},
+        unregister: async () => {},
+        cleanupStale: async () => {},
+        isFrozen: () => false,
+        getPids: () => [],
+      } as never,
+    };
+
+    cleanup = installSignalHandlers(ctx);
+    await fireSignal("SIGINT");
+
+    expect(freeze).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/execution/pid-registry-freeze.test.ts
+++ b/test/unit/execution/pid-registry-freeze.test.ts
@@ -1,0 +1,61 @@
+/**
+ * PidRegistry.freeze() — Issue 5 fix
+ *
+ * Once the registry is frozen (at shutdown), register() must become a no-op
+ * so late-spawning retry paths cannot add PIDs that would outlive the process.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { PidRegistry } from "../../../src/execution/pid-registry";
+
+describe("PidRegistry.freeze()", () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = `/tmp/nax-pid-freeze-test-${randomUUID()}`;
+    mkdirSync(workdir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(workdir)) rmSync(workdir, { recursive: true });
+  });
+
+  test("register() before freeze() records the PID", async () => {
+    const reg = new PidRegistry(workdir);
+    await reg.register(1111);
+    expect(reg.getPids()).toEqual([1111]);
+  });
+
+  test("register() after freeze() is a no-op — PID is not recorded", async () => {
+    const reg = new PidRegistry(workdir);
+    reg.freeze();
+    await reg.register(2222);
+    expect(reg.getPids()).toEqual([]);
+  });
+
+  test("isFrozen() reports state", () => {
+    const reg = new PidRegistry(workdir);
+    expect(reg.isFrozen()).toBe(false);
+    reg.freeze();
+    expect(reg.isFrozen()).toBe(true);
+  });
+
+  test("freeze() is idempotent — second call is harmless", () => {
+    const reg = new PidRegistry(workdir);
+    reg.freeze();
+    reg.freeze();
+    expect(reg.isFrozen()).toBe(true);
+  });
+
+  test("PIDs registered before freeze survive — killAll can still target them", async () => {
+    const reg = new PidRegistry(workdir);
+    await reg.register(3333);
+    reg.freeze();
+    expect(reg.getPids()).toEqual([3333]);
+    // After freeze, new registration blocked but existing state preserved.
+    await reg.register(4444);
+    expect(reg.getPids()).toEqual([3333]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **#593** and **#585** (Path B) — two facets of the same underlying problem: nax had no coordinated shutdown signal, so Ctrl+C cascaded into duplicate `run.complete` events, orphan processes, and ~14s rate-limit backoff hangs.

### What Ctrl+C does now

- **One** `run.complete` event per run (was 5× under signal cascade).
- In-flight adapter retries short-circuit with `fail-aborted` — no new acpx processes spawn during teardown.
- Rate-limit backoff settles in <1s instead of the full exponential wait.
- PID registry rejects late registrations so orphan processes can't slip through `killAll()`.

## Implementation — three compounding fixes

### 1. Signal handler idempotency (#593)
`createSignalHandler` now shares a `shuttingDown` flag across all fatal handlers (SIGTERM / SIGINT / SIGHUP, uncaughtException, unhandledRejection). First fatal signal wins; subsequent signals log once and no-op. 10 s hard-deadline remains.

### 2. AbortController plumbing (#593 + #585 Path B)
`SignalHandlerContext` gains an optional `abortController`; signal handler calls `.abort()` on first signal. Plumbed through:

```
shutdownController (run-setup)
  ↓
PipelineContext.abortSignal
  ↓
AgentRunOptions.abortSignal ──► ACP adapter retry loop (Issue 5)
AgentRunRequest.signal    ──► AgentManager.runWithFallback rate-limit sleep (#585)
```

- ACP adapter's `while(true)` retry loop checks `abortSignal.aborted` before spawning a fresh acpx client or entering session-error retry. Returns `fail-aborted` (new `AdapterFailure.outcome` in the `availability` category).
- `AgentManager.runWithFallback` forwards `signal` to `_agentManagerDeps.sleep` (already cancellable since #586). Pre-abort skips sleep entirely; abort mid-sleep returns fast.

### 3. PID registry race (#593)
`PidRegistry.freeze()` flips a flag that turns `register()` into a warn-and-skip no-op. Called by the signal handler immediately after `.abort()` so late-spawning retry paths cannot register new PIDs that would outlive teardown.

### 4. Safety guard (#593)
`AgentManager.shouldSwap` short-circuits on `fail-aborted` — aborted runs must not trigger fallback swaps (would spawn work on another agent during shutdown).

## Closes / Fixes

- Closes **#585** — Path B (AbortSignal through `runWithFallback`) shipped here. Path A already shipped in #586.
- Fixes **#593** — SIGINT crash cascade / duplicate run.complete / retry during shutdown

## Related issues (not in this PR)

Also found during the same v0.63.0-canary.8 dogfood run. Separately tracked:

- #589 — misleading `Session closed by closeStory, priorState: CREATED` log (TDD bookkeeping)
- #590 — TDD metrics missing `tokens` field
- #591 — session descriptor `protocolIds` null when run interrupted
- #592 — no fallback to codex after claude 401 (parseAgentError classifier gap)

See `docs/findings/2026-04-20-v0.63.0-canary.8-run-issues.md` for the full diagnostic.

## Test plan

- [x] 14 new unit tests pass:
  - `test/unit/execution/pid-registry-freeze.test.ts` (5)
  - `test/unit/execution/crash-signals-idempotency.test.ts` (4)
  - `test/unit/agents/acp/adapter-abort.test.ts` (2)
  - `test/unit/agents/manager-abort.test.ts` (3) — pre-abort skips sleep; signal forwarded to sleep; abort mid-sleep returns fast
- [x] Core unit suite: **1507 pass / 0 fail** across 148 files (`bun test test/unit/agents/ test/unit/execution/ test/unit/pipeline/`)
- [x] Typecheck clean (`bun run typecheck`)
- [x] Biome lint clean (`bun run lint`)

## Commits

1. `a43e9e96` — signal handler idempotency + AbortController plumbing (Issue 5 / #593)
2. `6f51a175` — AbortSignal through runWithFallback (#585 Path B)

## Files changed

| File | Change |
|:-----|:-------|
| `src/execution/crash-signals.ts` | Idempotency flag, abort on first signal, freeze pidRegistry, onShutdown(abortSignal) |
| `src/execution/crash-recovery.ts` | `CrashRecoveryContext.abortController?`, `onShutdown(abortSignal?)` |
| `src/execution/pid-registry.ts` | `freeze()`, `isFrozen()`, `register()` no-op when frozen |
| `src/execution/lifecycle/run-setup.ts` | Creates `shutdownController`, wires into handlers + returns it |
| `src/execution/{runner,runner-setup,runner-execution,unified-executor,iteration-runner,executor-types}.ts` | Threads `abortSignal` through the run lifecycle |
| `src/pipeline/types.ts` | `PipelineContext.abortSignal?: AbortSignal` |
| `src/pipeline/stages/execution.ts` | Forwards `abortSignal` to `agent.run()` and `runWithFallback({ signal })` |
| `src/tdd/orchestrator.ts`, `session-runner.ts` | Forwards `abortSignal` to each TDD `agent.run()` |
| `src/agents/types.ts` | `AgentRunOptions.abortSignal?: AbortSignal` |
| `src/agents/manager-types.ts` | `AgentRunRequest.signal?: AbortSignal` |
| `src/agents/manager.ts` | `runWithFallback` forwards signal to sleep; short-circuits on abort; `shouldSwap` short-circuits on `fail-aborted` |
| `src/agents/acp/adapter.ts` | Early-return with `fail-aborted` when `abortSignal.aborted`; retry loop checks signal |
| `src/context/engine/types.ts` | Adds `"fail-aborted"` to `AdapterFailure.outcome` |
| `docs/findings/2026-04-20-v0.63.0-canary.8-run-issues.md` | Diagnostic report (origin of this PR + sibling issues) |