### PR TITLE
refactor(tdd): ThreeSessionRunner + runInSession for TDD path (Phase 2, closes #589 #590)

### DIFF
--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -14,7 +14,7 @@ import { buildInteractionBridge } from "../../interaction/bridge-builder";
 import { checkMergeConflict, checkStoryAmbiguity, isTriggerEnabled } from "../../interaction/triggers";
 import { getLogger } from "../../logger";
 import { SingleSessionRunner } from "../../session/runners/single-session-runner";
-import { runThreeSessionTddFromCtx } from "../../tdd";
+import { ThreeSessionRunner } from "../../tdd/three-session-runner";
 import { autoCommitIfDirty, detectMergeConflict } from "../../utils/git";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 import { isAmbiguousOutput, routeTddFailure } from "./execution-helpers";
@@ -51,33 +51,54 @@ export const executionStage: PipelineStage = {
         lite: isLiteMode,
       });
 
-      const tddResult = await runThreeSessionTddFromCtx(ctx, { agent, dryRun: false, lite: isLiteMode });
+      // Phase 2 refactor: dispatch through ThreeSessionRunner. Per-role
+      // SessionManager.runInSession inside runTddSession now handles state
+      // transitions (#589) and tokenUsage propagation (#590) automatically.
+      const tddRunner = new ThreeSessionRunner();
+      const outcome = await tddRunner.run({
+        pipelineContext: ctx,
+        agent,
+        dryRun: false,
+        lite: isLiteMode,
+        // Base fields — ThreeSessionRunner reads pipelineContext for everything else.
+        sessionId: ctx.sessionId,
+        sessionManager: ctx.sessionManager,
+        defaultAgent,
+        runOptions: {
+          prompt: ctx.prompt ?? "",
+          workdir: ctx.workdir,
+          modelTier: ctx.routing.modelTier,
+          modelDef: resolveModelForAgent(
+            ctx.rootConfig.models,
+            ctx.routing.agent ?? defaultAgent,
+            ctx.routing.modelTier,
+            defaultAgent,
+          ),
+          timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
+          dangerouslySkipPermissions: resolvePermissions(ctx.config, "run").skipPermissions,
+          pipelineStage: "run",
+          config: ctx.config,
+        },
+      });
 
-      ctx.agentResult = {
-        success: tddResult.success,
-        estimatedCost: tddResult.totalCost,
-        rateLimited: false,
-        output: "",
-        exitCode: tddResult.success ? 0 : 1,
-        durationMs: 0, // TDD result doesn't track total duration
-      };
+      ctx.agentResult = outcome.primaryResult;
 
       // Propagate full-suite gate result so verify stage can skip redundant run (BUG-054)
-      if (tddResult.fullSuiteGatePassed) {
+      if (outcome.fullSuiteGatePassed) {
         ctx.fullSuiteGatePassed = true;
       }
 
-      if (!tddResult.success) {
+      if (!outcome.success) {
         // Store failure category in context for runner to use at max-attempts decision
-        ctx.tddFailureCategory = tddResult.failureCategory;
+        ctx.tddFailureCategory = outcome.failureCategory;
 
         // Log and notify when human review is needed
-        if (tddResult.needsHumanReview) {
+        if (outcome.needsHumanReview) {
           logger.warn("execution", "Human review needed", {
             storyId: ctx.story.id,
-            reason: tddResult.reviewReason,
-            lite: tddResult.lite,
-            failureCategory: tddResult.failureCategory,
+            reason: outcome.reviewReason,
+            lite: outcome.lite,
+            failureCategory: outcome.failureCategory,
           });
           // Send notification via interaction chain (Telegram in headless mode)
           if (ctx.interaction) {
@@ -89,7 +110,7 @@ export const executionStage: PipelineStage = {
                 storyId: ctx.story.id,
                 stage: "execution",
                 summary: `⚠️ Human review needed: ${ctx.story.id}`,
-                detail: `Story: ${ctx.story.title}\nReason: ${tddResult.reviewReason ?? "No reason provided"}\nCategory: ${tddResult.failureCategory ?? "unknown"}`,
+                detail: `Story: ${ctx.story.title}\nReason: ${outcome.reviewReason ?? "No reason provided"}\nCategory: ${outcome.failureCategory ?? "unknown"}`,
                 fallback: "continue",
                 createdAt: Date.now(),
               });
@@ -104,11 +125,11 @@ export const executionStage: PipelineStage = {
           // Pause for human review instead of auto-escalating (#3 bench-04 finding)
           return {
             action: "pause",
-            reason: tddResult.reviewReason || `Human review needed: ${tddResult.failureCategory ?? "unknown"}`,
+            reason: outcome.reviewReason || `Human review needed: ${outcome.failureCategory ?? "unknown"}`,
           };
         }
 
-        return routeTddFailure(tddResult.failureCategory, isLiteMode, ctx, tddResult.reviewReason);
+        return routeTddFailure(outcome.failureCategory, isLiteMode, ctx, outcome.reviewReason);
       }
 
       return { action: "continue" };

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -76,6 +76,34 @@ export interface ThreeSessionTddOptions {
 }
 
 /**
+ * Sum TokenUsage values across TDD session results (#590).
+ * Returns undefined when no session reported usage — mirrors the adapter
+ * contract so `metrics.tracker` can emit a tokens block only when real data exists.
+ */
+function sumTddTokenUsage(sessions: TddSessionResult[]): import("../agents/cost").TokenUsage | undefined {
+  const usages = sessions.map((s) => s.tokenUsage).filter((u): u is import("../agents/cost").TokenUsage => !!u);
+  if (usages.length === 0) return undefined;
+  const total = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+  };
+  for (const u of usages) {
+    total.inputTokens += u.inputTokens ?? 0;
+    total.outputTokens += u.outputTokens ?? 0;
+    total.cache_read_input_tokens += u.cache_read_input_tokens ?? 0;
+    total.cache_creation_input_tokens += u.cache_creation_input_tokens ?? 0;
+  }
+  return {
+    inputTokens: total.inputTokens,
+    outputTokens: total.outputTokens,
+    ...(total.cache_read_input_tokens > 0 && { cache_read_input_tokens: total.cache_read_input_tokens }),
+    ...(total.cache_creation_input_tokens > 0 && { cache_creation_input_tokens: total.cache_creation_input_tokens }),
+  };
+}
+
+/**
  * Run the full three-session TDD pipeline for a user story.
  */
 export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promise<ThreeSessionTddResult> {
@@ -459,6 +487,10 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
   }
 
   const totalCost = sessions.reduce((sum, s) => sum + s.estimatedCost, 0) + fullSuiteGateCost;
+  const totalDurationMs = sessions.reduce((sum, s) => sum + s.durationMs, 0);
+  // #590: sum tokenUsage across all sessions so metrics.tracker emits a tokens block
+  // for TDD runs the same way single-session runs do.
+  const totalTokenUsage = sumTddTokenUsage(sessions);
 
   logger.info("tdd", allSuccessful ? "[OK] Three-session TDD complete" : "[WARN] Three-session TDD needs review", {
     storyId: story.id,
@@ -494,6 +526,8 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     ...(finalFailureCategory !== undefined ? { failureCategory: finalFailureCategory } : {}),
     verdict,
     totalCost,
+    totalDurationMs,
+    ...(totalTokenUsage && { totalTokenUsage }),
     lite,
     fullSuiteGatePassed,
   };

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -207,8 +207,7 @@ export async function runTddSession(
   // The session sweep (or the last rectification attempt) handles final cleanup.
   const keepOpen = role === "implementer" && (config.execution.rectification?.enabled ?? false);
 
-  // Run the agent
-  const result = await agent.run({
+  const agentRunOptions = {
     prompt,
     workdir,
     modelTier,
@@ -220,7 +219,7 @@ export async function runTddSession(
     ),
     timeoutSeconds: config.execution.sessionTimeoutSeconds,
     dangerouslySkipPermissions: resolvePermissions(config, "run").skipPermissions,
-    pipelineStage: "run",
+    pipelineStage: "run" as const,
     config,
     projectDir,
     maxInteractionTurns: config.agent?.maxInteractionTurns,
@@ -239,14 +238,27 @@ export async function runTddSession(
       : undefined,
     interactionBridge,
     abortSignal,
-  });
+  };
 
-  // #541: bind ACP protocolIds to the pre-created session descriptor so the
-  // audit trail can correlate storyId → sess-<uuid> → recordId for TDD roles.
-  // Mirrors the pattern used in src/pipeline/stages/execution.ts:208.
+  // Run the agent. When a sessionBinding is provided, route through
+  // SessionManager.runInSession so state transitions (CREATED → RUNNING →
+  // COMPLETED/FAILED) and bindHandle happen automatically (#541, #589).
+  // Absent binding path stays compatible with tests that skip SessionManager.
+  const result = sessionBinding
+    ? await sessionBinding.sessionManager.runInSession(
+        sessionBinding.sessionId,
+        (opts) => agent.run(opts),
+        agentRunOptions,
+      )
+    : await agent.run(agentRunOptions);
+
+  // When binding is present, runInSession already persisted protocolIds
+  // using the descriptor's handle. If the descriptor had no handle (race on
+  // first use), re-bind now with the agent's derived session name so later
+  // resume logic can find the ACP record.
   if (sessionBinding && result.protocolIds) {
     const descriptor = sessionBinding.sessionManager.get(sessionBinding.sessionId);
-    if (descriptor) {
+    if (descriptor && !descriptor.handle) {
       sessionBinding.sessionManager.bindHandle(
         sessionBinding.sessionId,
         agent.deriveSessionName(descriptor),
@@ -340,6 +352,7 @@ export async function runTddSession(
     filesChanged,
     durationMs,
     estimatedCost: result.estimatedCost,
+    tokenUsage: result.tokenUsage,
     outputTail: result.output.slice(-500),
   };
 }

--- a/src/tdd/three-session-runner.ts
+++ b/src/tdd/three-session-runner.ts
@@ -1,0 +1,96 @@
+/**
+ * ThreeSessionRunner — ISessionRunner implementation for TDD (three-session
+ * test-writer → implementer → verifier). Thin adapter over
+ * runThreeSessionTddFromCtx, returning the generic StoryRunOutcome that
+ * execution.ts consumes the same way it consumes SingleSessionRunner output.
+ *
+ * Every TDD session now goes through SessionManager.runInSession (via
+ * runTddSession's sessionBinding path), so state transitions (#589) and
+ * tokenUsage propagation (#590) happen automatically for each of the three
+ * roles — no per-role plumbing needed.
+ */
+
+import type { AgentAdapter } from "../agents";
+import type { AgentResult } from "../agents/types";
+import type { PipelineContext } from "../pipeline/types";
+import type { ISessionRunner, SessionRunnerContext, StoryRunOutcome } from "../session/session-runner";
+import { runThreeSessionTddFromCtx } from "./orchestrator";
+import type { FailureCategory, ThreeSessionTddResult } from "./types";
+
+export interface ThreeSessionRunnerContext extends SessionRunnerContext {
+  /** Full PipelineContext — the TDD orchestrator assembles per-role context bundles from it. */
+  pipelineContext: PipelineContext;
+  /** Primary agent adapter — used across all three roles. */
+  agent: AgentAdapter;
+  /** Dry-run mode skips actual agent invocations. */
+  dryRun?: boolean;
+  /** Lite mode skips test-writer isolation. */
+  lite?: boolean;
+}
+
+/**
+ * Extended StoryRunOutcome for TDD — surfaces fields that the pipeline needs
+ * for branch decisions (human review, failure category, full-suite gate,
+ * lite flag). SingleSessionRunner doesn't produce these, so they live on
+ * the subtype rather than the generic interface.
+ */
+export interface ThreeSessionStoryRunOutcome extends StoryRunOutcome {
+  needsHumanReview: boolean;
+  reviewReason?: string;
+  failureCategory?: FailureCategory;
+  fullSuiteGatePassed?: boolean;
+  lite: boolean;
+}
+
+export class ThreeSessionRunner implements ISessionRunner {
+  readonly name = "three-session-tdd";
+
+  async run(context: ThreeSessionRunnerContext): Promise<ThreeSessionStoryRunOutcome> {
+    const { pipelineContext, agent, dryRun = false, lite = false } = context;
+
+    const tddResult: ThreeSessionTddResult = await runThreeSessionTddFromCtx(pipelineContext, {
+      agent,
+      dryRun,
+      lite,
+    });
+
+    // Synthesize a primaryResult so downstream pipeline stages (auto-commit,
+    // merge-conflict detection, escalation) can treat the TDD outcome like
+    // a single AgentResult. Output and stderr are left empty — TDD decisions
+    // flow through tddResult fields (needsHumanReview, failureCategory).
+    const primaryResult: AgentResult = {
+      success: tddResult.success,
+      estimatedCost: tddResult.totalCost,
+      rateLimited: false,
+      output: "",
+      exitCode: tddResult.success ? 0 : 1,
+      durationMs: tddResult.totalDurationMs ?? 0,
+      ...(tddResult.totalTokenUsage && { tokenUsage: tddResult.totalTokenUsage }),
+    };
+
+    return {
+      success: tddResult.success,
+      primaryResult,
+      totalCost: tddResult.totalCost,
+      totalTokenUsage: tddResult.totalTokenUsage
+        ? {
+            inputTokens: tddResult.totalTokenUsage.inputTokens,
+            outputTokens: tddResult.totalTokenUsage.outputTokens,
+            ...(tddResult.totalTokenUsage.cache_read_input_tokens !== undefined && {
+              cache_read_input_tokens: tddResult.totalTokenUsage.cache_read_input_tokens,
+            }),
+            ...(tddResult.totalTokenUsage.cache_creation_input_tokens !== undefined && {
+              cache_creation_input_tokens: tddResult.totalTokenUsage.cache_creation_input_tokens,
+            }),
+          }
+        : undefined,
+      // TDD does not go through cross-agent fallback.
+      fallbacks: [],
+      needsHumanReview: tddResult.needsHumanReview,
+      reviewReason: tddResult.reviewReason,
+      failureCategory: tddResult.failureCategory,
+      fullSuiteGatePassed: tddResult.fullSuiteGatePassed,
+      lite: tddResult.lite,
+    };
+  }
+}

--- a/src/tdd/types.ts
+++ b/src/tdd/types.ts
@@ -41,6 +41,12 @@ export interface TddSessionResult {
   isolation?: IsolationCheck;
   /** Cost of this session (USD) */
   estimatedCost: number;
+  /**
+   * Token usage for this session (fixes #590).
+   * Undefined when the adapter did not report usage (e.g. pre-first-turn
+   * failure, or a mock adapter in tests).
+   */
+  tokenUsage?: import("../agents/cost").TokenUsage;
   /** Files changed by this session (from git diff) */
   filesChanged: string[];
   /** Duration of this session in milliseconds */
@@ -73,6 +79,10 @@ export interface ThreeSessionTddResult {
   reviewReason?: string;
   /** Total cost of all sessions (USD) */
   totalCost: number;
+  /** Total token usage summed across all sessions (fixes #590). Undefined when no session reported usage. */
+  totalTokenUsage?: import("../agents/cost").TokenUsage;
+  /** Total wall-clock duration of all sessions in milliseconds (sum of session durationMs). */
+  totalDurationMs?: number;
   /** Whether lite mode was used (skips test-writer/implementer isolation) */
   lite: boolean;
   /** Category of failure (if success is false) */

--- a/test/unit/tdd/orchestrator-totals.test.ts
+++ b/test/unit/tdd/orchestrator-totals.test.ts
@@ -1,0 +1,145 @@
+/**
+ * runThreeSessionTdd — totalTokenUsage + totalDurationMs aggregation (#590).
+ *
+ * Each TDD session reports its own tokenUsage/durationMs; the orchestrator
+ * now sums them so the metrics tracker can emit a tokens block for TDD runs
+ * the same way it does for single-session runs.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AgentResult, AgentRunOptions } from "../../../src/agents/types";
+import type { NaxConfig } from "../../../src/config";
+import type { UserStory } from "../../../src/prd";
+import { runThreeSessionTdd } from "../../../src/tdd/orchestrator";
+import { _sessionRunnerDeps } from "../../../src/tdd/session-runner";
+
+function makeStory(): UserStory {
+  return {
+    id: "US-001",
+    title: "Impl",
+    description: "desc",
+    acceptanceCriteria: ["AC-1"],
+    status: "pending",
+    attempts: 0,
+    priorFailures: [],
+  } as unknown as UserStory;
+}
+
+function makeConfig(): NaxConfig {
+  return {
+    models: {
+      claude: {
+        fast: { model: "fast" },
+        balanced: { model: "balanced" },
+        powerful: { model: "powerful" },
+      },
+    },
+    autoMode: { defaultAgent: "claude" },
+    execution: { rectification: { enabled: false }, sessionTimeoutSeconds: 300 },
+    quality: { commands: { test: "bun test" } },
+    tdd: { testWriterAllowedPaths: [], rollbackOnFailure: false },
+  } as unknown as NaxConfig;
+}
+
+function agentReturning(tokens: Array<AgentResult["tokenUsage"] | undefined>) {
+  let call = 0;
+  return {
+    run: mock(
+      async (_opts: AgentRunOptions): Promise<AgentResult> => {
+        const tokenUsage = tokens[call++];
+        return {
+          success: true,
+          exitCode: 0,
+          output: "ok",
+          rateLimited: false,
+          durationMs: 50,
+          estimatedCost: 0.01,
+          ...(tokenUsage ? { tokenUsage } : {}),
+        };
+      },
+    ),
+    isInstalled: mock(async () => true),
+    complete: mock(async () => ""),
+    buildCommand: mock(() => []),
+    deriveSessionName: mock(() => "nax-test"),
+  };
+}
+
+let origDeps: Record<string, unknown>;
+beforeEach(() => {
+  origDeps = {
+    autoCommitIfDirty: _sessionRunnerDeps.autoCommitIfDirty,
+    getChangedFiles: _sessionRunnerDeps.getChangedFiles,
+    verifyTestWriterIsolation: _sessionRunnerDeps.verifyTestWriterIsolation,
+    verifyImplementerIsolation: _sessionRunnerDeps.verifyImplementerIsolation,
+    captureGitRef: _sessionRunnerDeps.captureGitRef,
+    cleanupProcessTree: _sessionRunnerDeps.cleanupProcessTree,
+    buildPrompt: _sessionRunnerDeps.buildPrompt,
+  };
+  _sessionRunnerDeps.autoCommitIfDirty = mock(async () => {});
+  // test-writer needs filesChanged containing a test file for the orchestrator to proceed
+  _sessionRunnerDeps.getChangedFiles = mock(async () => ["test/foo.test.ts"]);
+  _sessionRunnerDeps.verifyTestWriterIsolation = mock(async () => ({ passed: true, violations: [] }));
+  _sessionRunnerDeps.verifyImplementerIsolation = mock(async () => ({ passed: true, violations: [] }));
+  _sessionRunnerDeps.captureGitRef = mock(async () => "ref");
+  _sessionRunnerDeps.cleanupProcessTree = mock(async () => {});
+  _sessionRunnerDeps.buildPrompt = mock(async () => "prompt");
+});
+afterEach(() => {
+  Object.assign(_sessionRunnerDeps, origDeps);
+});
+
+describe("runThreeSessionTdd — token + duration aggregation", () => {
+  test("sums tokenUsage from all three sessions", async () => {
+    const agent = agentReturning([
+      { inputTokens: 100, outputTokens: 50 }, // test-writer
+      { inputTokens: 200, outputTokens: 100, cache_read_input_tokens: 10 }, // implementer
+      { inputTokens: 50, outputTokens: 25 }, // verifier
+    ]);
+
+    const result = await runThreeSessionTdd({
+      agent: agent as never,
+      story: makeStory(),
+      config: makeConfig(),
+      workdir: "/tmp/fake",
+      modelTier: "balanced",
+    });
+
+    expect(result.totalTokenUsage).toEqual({
+      inputTokens: 350,
+      outputTokens: 175,
+      cache_read_input_tokens: 10,
+    });
+  });
+
+  test("totalTokenUsage undefined when no session reports usage", async () => {
+    const agent = agentReturning([undefined, undefined, undefined]);
+
+    const result = await runThreeSessionTdd({
+      agent: agent as never,
+      story: makeStory(),
+      config: makeConfig(),
+      workdir: "/tmp/fake",
+      modelTier: "balanced",
+    });
+
+    expect(result.totalTokenUsage).toBeUndefined();
+  });
+
+  test("totalDurationMs sums session durations", async () => {
+    const agent = agentReturning([undefined, undefined, undefined]);
+
+    const result = await runThreeSessionTdd({
+      agent: agent as never,
+      story: makeStory(),
+      config: makeConfig(),
+      workdir: "/tmp/fake",
+      modelTier: "balanced",
+    });
+
+    // Each session is timed by the orchestrator (startTime → Date.now()),
+    // so the exact value is non-deterministic, but must be a sum ≥ 0.
+    expect(typeof result.totalDurationMs).toBe("number");
+    expect(result.totalDurationMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/test/unit/tdd/session-runner-bindhandle.test.ts
+++ b/test/unit/tdd/session-runner-bindhandle.test.ts
@@ -83,8 +83,24 @@ function makeSessionManager() {
     },
   );
   const get = mock((id: string) => (id === "sess-test" ? descriptor : undefined));
+  const transition = mock((_id: string, to: string) => {
+    descriptor.state = to as SessionDescriptor["state"];
+    return descriptor;
+  });
+  // Phase 2: stub runInSession that delegates to the runner and applies bindHandle
+  // the same way the real implementation does. Required so runTddSession's
+  // sessionBinding path works against the test mock.
+  const runInSession = mock(async (id: string, runner: (opts: unknown) => Promise<AgentResult>, opts: unknown) => {
+    transition(id, "RUNNING");
+    const result = await runner(opts);
+    if (result.protocolIds && descriptor.handle) {
+      bindHandle(id, descriptor.handle, result.protocolIds);
+    }
+    transition(id, result.success ? "COMPLETED" : "FAILED");
+    return result;
+  });
   return {
-    manager: { get, bindHandle } as unknown as ISessionManager,
+    manager: { get, bindHandle, transition, runInSession } as unknown as ISessionManager,
     bindHandle,
     descriptor,
   };

--- a/test/unit/tdd/session-runner-tokens.test.ts
+++ b/test/unit/tdd/session-runner-tokens.test.ts
@@ -1,0 +1,184 @@
+/**
+ * runTddSession — token usage propagation (#590) and state transitions (#589).
+ *
+ * Phase 2: TDD sessions now route through SessionManager.runInSession so:
+ *   - tokenUsage from AgentResult is returned on TddSessionResult.tokenUsage
+ *   - descriptor state advances CREATED → RUNNING → COMPLETED automatically
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AgentResult, AgentRunOptions } from "../../../src/agents/types";
+import type { NaxConfig } from "../../../src/config";
+import type { UserStory } from "../../../src/prd";
+import { SessionManager } from "../../../src/session/manager";
+import { _sessionRunnerDeps, runTddSession } from "../../../src/tdd/session-runner";
+
+function makeStory(): UserStory {
+  return {
+    id: "US-001",
+    title: "Impl story",
+    description: "Do the thing",
+    acceptanceCriteria: ["AC-1"],
+    status: "pending",
+  } as unknown as UserStory;
+}
+
+function makeConfig(): NaxConfig {
+  return {
+    models: {
+      claude: {
+        fast: { model: "fast-model" },
+        balanced: { model: "balanced-model" },
+        powerful: { model: "powerful-model" },
+      },
+    },
+    autoMode: { defaultAgent: "claude" },
+    execution: { rectification: { enabled: false }, sessionTimeoutSeconds: 300, dangerouslySkipPermissions: true },
+    quality: { commands: { test: "bun test" } },
+    tdd: { testWriterAllowedPaths: [] },
+  } as unknown as NaxConfig;
+}
+
+function makeAgent(result: Partial<AgentResult>) {
+  return {
+    run: mock(
+      async (_opts: AgentRunOptions): Promise<AgentResult> => ({
+        success: true,
+        exitCode: 0,
+        output: "done",
+        rateLimited: false,
+        durationMs: 100,
+        estimatedCost: 0.05,
+        ...result,
+      }),
+    ),
+    isInstalled: mock(async () => true),
+    complete: mock(async () => ""),
+    buildCommand: mock(() => []),
+    deriveSessionName: mock(() => "nax-abc12345-feat-US-001-implementer"),
+  };
+}
+
+let origDeps: Record<string, unknown>;
+
+beforeEach(() => {
+  origDeps = {
+    autoCommitIfDirty: _sessionRunnerDeps.autoCommitIfDirty,
+    getChangedFiles: _sessionRunnerDeps.getChangedFiles,
+    verifyImplementerIsolation: _sessionRunnerDeps.verifyImplementerIsolation,
+    verifyTestWriterIsolation: _sessionRunnerDeps.verifyTestWriterIsolation,
+    captureGitRef: _sessionRunnerDeps.captureGitRef,
+    cleanupProcessTree: _sessionRunnerDeps.cleanupProcessTree,
+    buildPrompt: _sessionRunnerDeps.buildPrompt,
+  };
+  _sessionRunnerDeps.autoCommitIfDirty = mock(async () => {});
+  _sessionRunnerDeps.getChangedFiles = mock(async () => []);
+  _sessionRunnerDeps.verifyImplementerIsolation = mock(async () => ({ passed: true, violations: [] }));
+  _sessionRunnerDeps.verifyTestWriterIsolation = mock(async () => ({ passed: true, violations: [] }));
+  _sessionRunnerDeps.captureGitRef = mock(async () => "abc");
+  _sessionRunnerDeps.cleanupProcessTree = mock(async () => {});
+  _sessionRunnerDeps.buildPrompt = mock(async () => "mock prompt");
+});
+
+afterEach(() => {
+  Object.assign(_sessionRunnerDeps, origDeps);
+});
+
+describe("runTddSession — tokenUsage (#590)", () => {
+  test("propagates tokenUsage from AgentResult to TddSessionResult", async () => {
+    const agent = makeAgent({
+      tokenUsage: { inputTokens: 1000, outputTokens: 200, cache_read_input_tokens: 500 },
+    });
+
+    const outcome = await runTddSession(
+      "implementer",
+      agent as never,
+      makeStory(),
+      makeConfig(),
+      "/tmp/fake",
+      "balanced",
+      "HEAD",
+    );
+
+    expect(outcome.tokenUsage).toEqual({
+      inputTokens: 1000,
+      outputTokens: 200,
+      cache_read_input_tokens: 500,
+    });
+  });
+
+  test("tokenUsage is undefined when the agent reports none", async () => {
+    const agent = makeAgent({}); // no tokenUsage field
+
+    const outcome = await runTddSession(
+      "verifier",
+      agent as never,
+      makeStory(),
+      makeConfig(),
+      "/tmp/fake",
+      "balanced",
+      "HEAD",
+    );
+
+    expect(outcome.tokenUsage).toBeUndefined();
+  });
+});
+
+describe("runTddSession — state transitions via runInSession (#589)", () => {
+  test("advances descriptor CREATED → RUNNING → COMPLETED on success", async () => {
+    const mgr = new SessionManager();
+    const descriptor = mgr.create({ role: "implementer", agent: "claude", workdir: "/tmp/fake", handle: "nax-test" });
+    expect(mgr.get(descriptor.id)?.state).toBe("CREATED");
+
+    const agent = makeAgent({});
+    await runTddSession(
+      "implementer",
+      agent as never,
+      makeStory(),
+      makeConfig(),
+      "/tmp/fake",
+      "balanced",
+      "HEAD",
+      undefined, // contextMarkdown
+      false, // lite
+      false, // skipIsolation
+      undefined, // constitution
+      "feat", // featureName
+      undefined, // interactionBridge
+      undefined, // projectDir
+      undefined, // featureContextMarkdown
+      undefined, // contextBundle
+      { sessionManager: mgr, sessionId: descriptor.id },
+    );
+
+    expect(mgr.get(descriptor.id)?.state).toBe("COMPLETED");
+  });
+
+  test("advances descriptor to FAILED when agent returns success=false", async () => {
+    const mgr = new SessionManager();
+    const descriptor = mgr.create({ role: "implementer", agent: "claude", workdir: "/tmp/fake", handle: "nax-test" });
+
+    const agent = makeAgent({ success: false, exitCode: 1 });
+    await runTddSession(
+      "implementer",
+      agent as never,
+      makeStory(),
+      makeConfig(),
+      "/tmp/fake",
+      "balanced",
+      "HEAD",
+      undefined,
+      false,
+      false,
+      undefined,
+      "feat",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { sessionManager: mgr, sessionId: descriptor.id },
+    );
+
+    expect(mgr.get(descriptor.id)?.state).toBe("FAILED");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the session-runner refactor (follows #596). TDD now uses the same lifecycle primitive as single-session, closing two bugs by construction:

- **#589** — "Session closed by closeStory, priorState: CREATED" log. Every TDD role now goes through `SessionManager.runInSession`, so descriptors actually transition `CREATED → RUNNING → COMPLETED/FAILED`. `closeStory` now logs `priorState: COMPLETED` (or `FAILED`) for terminal sessions.
- **#590** — TDD metrics missing `tokens` field. `tokenUsage` now flows from `AgentResult` → `TddSessionResult.tokenUsage` → `ThreeSessionTddResult.totalTokenUsage` → `ctx.agentResult.tokenUsage` → `metrics.tracker`. `totalDurationMs` is also summed (was hardcoded `0`).

## What changed

| File | Change |
|:---|:---|
| `src/tdd/session-runner.ts` | `agent.run()` call wrapped in `sessionBinding.sessionManager.runInSession(...)` when binding is provided. `tokenUsage` propagated to the returned `TddSessionResult`. |
| `src/tdd/orchestrator.ts` | `sumTddTokenUsage` helper. `ThreeSessionTddResult` now carries `totalTokenUsage` + `totalDurationMs`. |
| `src/tdd/three-session-runner.ts` (new) | `ISessionRunner` impl for TDD. Thin adapter over `runThreeSessionTddFromCtx`; returns a `StoryRunOutcome` with the full-suite-gate / failure-category / review-flag fields the TDD branch of `execution.ts` needs. |
| `src/tdd/types.ts` | `TddSessionResult.tokenUsage`, `ThreeSessionTddResult.totalTokenUsage` / `totalDurationMs`. |
| `src/pipeline/stages/execution.ts` | TDD branch dispatches via `new ThreeSessionRunner().run(...)`. `ctx.agentResult` is now `outcome.primaryResult` which includes real `tokenUsage` + `durationMs`. |

## Cross-cutting concerns consolidated

The whole point of Phase 1 + Phase 2 is to stop duplicating this logic across two paths. After this PR, adding a new cross-cutting feature (e.g. audit events, pre-run hooks) only needs to land in one place — `SessionManager.runInSession`.

| Concern | Single-session (Phase 1) | TDD (Phase 2) |
|:---|:---|:---|
| State transitions (CREATED → RUNNING → COMPLETED/FAILED) | ✅ `runInSession` | ✅ `runInSession` |
| `bindHandle` with `protocolIds` | ✅ `runInSession` + executeHop | ✅ `runInSession` + post-hoc for handle-less sessions |
| `tokenUsage` propagation | ✅ `StoryRunOutcome.totalTokenUsage` | ✅ `StoryRunOutcome.totalTokenUsage` |
| `abortSignal` plumbing | ✅ via `AgentRunOptions` | ✅ via `AgentRunOptions` |

## Test plan

- [x] 4 new tests: `test/unit/tdd/session-runner-tokens.test.ts` — token propagation + state transitions
- [x] 3 new tests: `test/unit/tdd/orchestrator-totals.test.ts` — sum across sessions, undefined when no usage, duration sum
- [x] Updated `test/unit/tdd/session-runner-bindhandle.test.ts` mock to include `runInSession` stub (#541 tests still green)
- [x] Full `bun run test` (all three phases) green
- [x] Typecheck + biome lint clean

## Phase 3 (not this PR)

**#591** — session descriptor `protocolIds` null when run interrupted. Will add `onSessionEstablished` callback on `AgentRunOptions` so the adapter can bind protocol ids right after `ensureAcpSession`, before any prompt runs. Small, localized change.