### PR TITLE
fix(session): eager protocolIds binding via onSessionEstablished (Phase 3, closes #591)

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -648,6 +648,21 @@ export class AcpAgentAdapter implements AgentAdapter {
       sessionId: (session as { id?: string }).id ?? null,
     };
 
+    // #591: fire the established-callback NOW (before any prompt) so the
+    // SessionManager can persist protocolIds eagerly. If the run is
+    // interrupted before return, the on-disk descriptor still carries the
+    // correlation needed to resume.
+    if (options.onSessionEstablished) {
+      try {
+        options.onSessionEstablished(protocolIds, sessionName);
+      } catch (err) {
+        getSafeLogger()?.warn("acp-adapter", "onSessionEstablished callback threw — continuing", {
+          sessionName,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
     let lastResponse: AcpSessionResponse | null = null;
     let timedOut = false;
     // Tracks whether the run completed successfully — used by finally to decide

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -155,6 +155,29 @@ export interface AgentRunOptions {
    * Optional for backward compat — adapters that ignore it stay functional.
    */
   abortSignal?: AbortSignal;
+  /**
+   * Fires once the agent has established its physical session and the
+   * adapter has captured its protocol identifiers — before any prompt has
+   * been sent (#591).
+   *
+   * Rationale: historically `protocolIds` were only reported back via the
+   * final `AgentResult`. If the run was interrupted (SIGINT, crash,
+   * first-turn failure) before return, the descriptor froze with
+   * `NULL_PROTOCOL_IDS` and became un-resumable. This callback lets
+   * `SessionManager.runInSession` bind the handle eagerly so the on-disk
+   * descriptor captures `recordId`/`sessionId` as soon as they exist.
+   *
+   * Fired at most once per `run()` invocation. Adapters that do not know
+   * their protocol ids ahead of the prompt can omit the call; the
+   * `AgentResult.protocolIds` path still works as a fallback.
+   *
+   * Synchronous — the callback must not block the run loop. Implementations
+   * that need async work should fire-and-forget.
+   */
+  onSessionEstablished?: (
+    protocolIds: { recordId: string | null; sessionId: string | null },
+    sessionName: string,
+  ) => void;
 }
 
 /**

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -345,9 +345,30 @@ export class SessionManager implements ISessionManager {
       this.transition(id, "RUNNING");
     }
 
+    // #591: inject onSessionEstablished so the adapter can bind protocolIds
+    // eagerly — before any prompt runs. If the run is interrupted between
+    // session-established and result-returned, the descriptor already
+    // carries the correlation needed to resume. The caller's own callback
+    // (if any) is chained afterwards so both fire.
+    const callerCallback = options.onSessionEstablished;
+    const injectedOptions: AgentRunOptions = {
+      ...options,
+      onSessionEstablished: (protocolIds, sessionName) => {
+        try {
+          this.bindHandle(id, sessionName, protocolIds);
+        } catch (err) {
+          getLogger().warn("session", "bindHandle via onSessionEstablished failed", {
+            sessionId: id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+        callerCallback?.(protocolIds, sessionName);
+      },
+    };
+
     let result: AgentResult;
     try {
-      result = await runner(options);
+      result = await runner(injectedOptions);
     } catch (err) {
       // Runner threw — mark session failed, then propagate.
       if (this._sessions.get(id)?.state === "RUNNING") {

--- a/test/unit/agents/acp/adapter-session-established.test.ts
+++ b/test/unit/agents/acp/adapter-session-established.test.ts
@@ -1,0 +1,91 @@
+/**
+ * AcpAgentAdapter.run() — onSessionEstablished callback (#591).
+ *
+ * Contract: the adapter must fire `options.onSessionEstablished(protocolIds,
+ * sessionName)` once, after `ensureAcpSession` succeeds and BEFORE the first
+ * prompt is sent. This gives SessionManager.runInSession a chance to bind
+ * protocolIds eagerly so an interrupted run still leaves a resumable
+ * descriptor on disk.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { AcpAgentAdapter, _acpAdapterDeps } from "../../../../src/agents/acp/adapter";
+import { makeClient, makeRunOptions, makeSession } from "./adapter.test";
+
+describe("AcpAgentAdapter.run() — onSessionEstablished (#591)", () => {
+  const origCreateClient = _acpAdapterDeps.createClient;
+  const origSleep = _acpAdapterDeps.sleep;
+
+  beforeEach(() => {
+    _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
+  });
+
+  afterEach(() => {
+    _acpAdapterDeps.createClient = origCreateClient;
+    _acpAdapterDeps.sleep = origSleep;
+    mock.restore();
+  });
+
+  test("fires callback before the prompt is sent", async () => {
+    const observed: Array<{ stage: string; protocolIds?: unknown; sessionName?: string }> = [];
+
+    const session = makeSession({
+      promptFn: async (_text: string) => {
+        observed.push({ stage: "prompt" });
+        return {
+          messages: [{ role: "assistant", content: "done" }],
+          stopReason: "end_turn",
+          cumulative_token_usage: { input_tokens: 1, output_tokens: 1 },
+        };
+      },
+    });
+    // Assign ACP protocol ids on the mock session so the adapter reports them.
+    (session as unknown as { recordId: string; id: string }).recordId = "rec-123";
+    (session as unknown as { recordId: string; id: string }).id = "acp-456";
+
+    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
+
+    await new AcpAgentAdapter("claude").run(
+      makeRunOptions({
+        onSessionEstablished: (protocolIds, sessionName) => {
+          observed.push({ stage: "established", protocolIds, sessionName });
+        },
+      }),
+    );
+
+    // Must fire exactly once, and must be ordered BEFORE the prompt.
+    const establishedIdx = observed.findIndex((o) => o.stage === "established");
+    const promptIdx = observed.findIndex((o) => o.stage === "prompt");
+    expect(establishedIdx).toBeGreaterThanOrEqual(0);
+    expect(promptIdx).toBeGreaterThanOrEqual(0);
+    expect(establishedIdx).toBeLessThan(promptIdx);
+
+    // Protocol ids reported match the mock session.
+    expect(observed[establishedIdx]?.protocolIds).toEqual({ recordId: "rec-123", sessionId: "acp-456" });
+    // Session name is well-formed (nax-<hash>-...).
+    expect(observed[establishedIdx]?.sessionName).toMatch(/^nax-/);
+  });
+
+  test("callback throw is swallowed — run completes normally", async () => {
+    const session = makeSession();
+    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
+
+    const result = await new AcpAgentAdapter("claude").run(
+      makeRunOptions({
+        onSessionEstablished: () => {
+          throw new Error("callback boom");
+        },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test("callback is optional — run works without it", async () => {
+    const session = makeSession();
+    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
+
+    const result = await new AcpAgentAdapter("claude").run(makeRunOptions());
+    expect(result.success).toBe(true);
+  });
+});

--- a/test/unit/session/manager-early-protocol-ids.test.ts
+++ b/test/unit/session/manager-early-protocol-ids.test.ts
@@ -1,0 +1,147 @@
+/**
+ * SessionManager.runInSession — eager protocolId binding via
+ * onSessionEstablished (#591).
+ *
+ * Invariant: if the runner fires the onSessionEstablished callback before
+ * completing (e.g. right after the physical session is opened), the
+ * descriptor must carry the protocolIds BEFORE the runner returns. If the
+ * run is then interrupted (SIGINT, crash, first-turn failure), the on-disk
+ * descriptor still has the correlation needed to resume.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { AgentResult, AgentRunOptions } from "../../../src/agents/types";
+import type { NaxConfig } from "../../../src/config";
+import { SessionManager } from "../../../src/session/manager";
+
+function makeOptions(): AgentRunOptions {
+  return {
+    prompt: "test",
+    workdir: "/tmp/x",
+    modelTier: "fast",
+    modelDef: { provider: "anthropic", model: "claude-haiku", env: {} },
+    timeoutSeconds: 30,
+    config: {} as NaxConfig,
+  };
+}
+
+function makeResult(): AgentResult {
+  return {
+    success: true,
+    exitCode: 0,
+    output: "ok",
+    rateLimited: false,
+    durationMs: 100,
+    estimatedCost: 0.01,
+  };
+}
+
+describe("SessionManager.runInSession — onSessionEstablished (#591)", () => {
+  test("fires onSessionEstablished and binds handle + protocolIds before runner returns", async () => {
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+
+    // Descriptor starts with null protocolIds.
+    expect(mgr.get(d.id)?.protocolIds).toEqual({ recordId: null, sessionId: null });
+    expect(mgr.get(d.id)?.handle).toBeUndefined();
+
+    // State before the runner returns — captured inside the runner via
+    // the callback, which fires BEFORE completing.
+    type Observed = { protocolIds: unknown; handle: unknown };
+    let observedDuringRun: Observed | null = null;
+
+    await mgr.runInSession(
+      d.id,
+      async (opts) => {
+        // Simulate adapter firing the callback after ensureAcpSession succeeds.
+        opts.onSessionEstablished?.({ recordId: "rec-early", sessionId: "sess-early" }, "nax-early-handle");
+        // Capture descriptor state from before the runner returns.
+        observedDuringRun = {
+          protocolIds: mgr.get(d.id)?.protocolIds,
+          handle: mgr.get(d.id)?.handle,
+        };
+        return makeResult();
+      },
+      makeOptions(),
+    );
+
+    // Eager binding during the runner — this is the whole point of #591.
+    if (!observedDuringRun) throw new Error("runner never observed descriptor state");
+    const captured: Observed = observedDuringRun;
+    expect(captured.protocolIds).toEqual({ recordId: "rec-early", sessionId: "sess-early" });
+    expect(captured.handle).toBe("nax-early-handle");
+  });
+
+  test("descriptor retains protocolIds even if the runner throws after onSessionEstablished fires", async () => {
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+
+    let caught: unknown;
+    try {
+      await mgr.runInSession(
+        d.id,
+        async (opts) => {
+          opts.onSessionEstablished?.({ recordId: "rec-crash", sessionId: "sess-crash" }, "nax-crash-handle");
+          throw new Error("runner crashed mid-flight");
+        },
+        makeOptions(),
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeDefined();
+    // #591 guarantee: protocolIds were persisted before the throw.
+    expect(mgr.get(d.id)?.protocolIds).toEqual({ recordId: "rec-crash", sessionId: "sess-crash" });
+    expect(mgr.get(d.id)?.handle).toBe("nax-crash-handle");
+    // State still transitions to FAILED.
+    expect(mgr.get(d.id)?.state).toBe("FAILED");
+  });
+
+  test("chains caller-provided onSessionEstablished after the manager's own", async () => {
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+
+    const callerCalls: Array<{ ids: unknown; name: string }> = [];
+    const callerCallback = (ids: unknown, name: string) => {
+      callerCalls.push({ ids, name });
+    };
+
+    await mgr.runInSession(
+      d.id,
+      async (opts) => {
+        opts.onSessionEstablished?.({ recordId: "rec-1", sessionId: "sess-1" }, "nax-chain");
+        return makeResult();
+      },
+      { ...makeOptions(), onSessionEstablished: callerCallback },
+    );
+
+    // Manager bound the handle...
+    expect(mgr.get(d.id)?.handle).toBe("nax-chain");
+    expect(mgr.get(d.id)?.protocolIds).toEqual({ recordId: "rec-1", sessionId: "sess-1" });
+    // ...AND the caller's own callback still fired.
+    expect(callerCalls).toHaveLength(1);
+    expect(callerCalls[0]).toEqual({
+      ids: { recordId: "rec-1", sessionId: "sess-1" },
+      name: "nax-chain",
+    });
+  });
+
+  test("no-op when the runner never fires the callback (legacy adapter path)", async () => {
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x", handle: "pre-existing" });
+
+    // Runner returns protocolIds only in the final result — like the
+    // pre-#591 adapter path. runInSession's post-run bindHandle should
+    // still fire.
+    await mgr.runInSession(
+      d.id,
+      async () => ({ ...makeResult(), protocolIds: { recordId: "rec-late", sessionId: "sess-late" } }),
+      makeOptions(),
+    );
+
+    expect(mgr.get(d.id)?.protocolIds).toEqual({ recordId: "rec-late", sessionId: "sess-late" });
+    // handle was pre-existing so bindHandle at the end uses it.
+    expect(mgr.get(d.id)?.handle).toBe("pre-existing");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of the session-runner refactor — closes the last of the four divergence bugs.

Before this PR, `protocolIds` were only reported via the final `AgentResult`. If a run was interrupted (SIGINT, crash, first-turn acpx failure) between *physical session established* and *adapter returns*, the on-disk descriptor froze at:

```json
{ "protocolIds": { "recordId": null, "sessionId": null } }
```

No way to resume — the next invocation would start a fresh ACP session and lose context.

## Fix

Three small, localised changes:

1. **New optional field** `onSessionEstablished(protocolIds, sessionName)` on `AgentRunOptions`. Fires once, after `ensureAcpSession` captures the ids and BEFORE any prompt.

2. **ACP adapter** invokes the callback right after protocol ids are captured ([`src/agents/acp/adapter.ts`](src/agents/acp/adapter.ts)). Thrown errors swallowed so a callback bug can't break the run.

3. **`SessionManager.runInSession`** injects its own callback that calls `bindHandle(id, sessionName, protocolIds)` eagerly, then chains the caller's own callback (if any).

## Why this shape

- Zero caller burden. Because every session in both paths (single-session + TDD) now goes through `SessionManager.runInSession` (after Phase 1 + Phase 2), neither `SingleSessionRunner` nor `ThreeSessionRunner` needs to know the callback exists. The manager wires it automatically.
- Back-compat. Pre-Phase-3 adapters (CLI, mocks) that don't fire the callback still work — the existing post-run `bindHandle` path in `runInSession` remains as fallback.
- Localised. Adapter change is 6 lines. Manager change is ~15 lines. No new types or modules.

## Test plan

- [x] 4 new tests: `test/unit/session/manager-early-protocol-ids.test.ts` — callback fires during run; protocolIds persisted before runner returns; survives runner throw; chains caller callback; no-op for legacy adapters.
- [x] 3 new tests: `test/unit/agents/acp/adapter-session-established.test.ts` — adapter fires callback BEFORE prompt; callback errors swallowed; optional.
- [x] Full `bun run test` (all three phases) green in ~12s
- [x] Typecheck + biome lint clean

## Resolves

- **#591** — session descriptor `protocolIds` null when run interrupted before adapter returns.

## Session-runner refactor series complete

This is the last of three PRs consolidating the per-session bookkeeping layer:

| Phase | PR | Fixes |
|:---|:---|:---|
| 1 — foundation | #596 | ISessionRunner + SingleSessionRunner + SessionManager.runInSession |
| 2 — TDD migration | #597 | #589 (state transitions), #590 (token propagation) |
| 3 — early binding | **this PR** | #591 (eager protocolIds) |

All four v0.63.0-canary.8 TDD-session bugs (#589, #590, #591, plus the already-fixed #541) now flow through one primitive. Adding the next cross-cutting concern only needs one edit.