### PR TITLE
fix(agents): parseAgentError recognises embedded Anthropic error envelope (closes #592)

### DIFF
--- a/src/agents/acp/parse-agent-error.ts
+++ b/src/agents/acp/parse-agent-error.ts
@@ -4,24 +4,37 @@ import type { AgentError } from "../types";
  * Parse structured adapter error output to identify agent error type.
  *
  * Classification intentionally uses machine-readable signals only:
- * - JSON fields (type/status/statusCode/code/acpxCode/detailCode)
+ * - Root JSON object fields (type/status/statusCode/code/acpxCode/detailCode)
+ * - Nested Anthropic-style error shape: `{"type":"error","error":{"type":"authentication_error"}}`
+ * - Embedded JSON objects within a larger free-text message (acpx wraps vendor
+ *   errors in a human-readable prefix — #592)
  * - bracketed code suffixes (e.g. "[ACPX_RATE_LIMIT/TOO_MANY_REQUESTS]")
  * - explicit key=value codes (e.g. "statusCode=429")
  *
- * Free-text phrase inference is intentionally not supported.
+ * Free-text phrase inference is intentionally not supported — we only match
+ * structured signals, even when they are nested inside a larger string.
  */
 export function parseAgentError(stderr: string): AgentError {
   if (!stderr) {
     return { type: "unknown" };
   }
 
+  // 1. Try parsing the whole string as a JSON object.
   const parsedJson = parseJsonObject(stderr);
   if (parsedJson) {
-    const direct = classifyDirectType(parsedJson);
-    if (direct) return direct;
+    const classified = classifyJsonPayload(parsedJson);
+    if (classified) return classified;
+  }
 
-    const structured = classifyFromCodeTokens(extractJsonCodeTokens(parsedJson), parsedJson);
-    if (structured) return structured;
+  // 2. If the whole string isn't JSON, look for embedded JSON objects (#592).
+  //    Acpx wraps vendor errors like:
+  //      `Internal error: Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error",...}}`
+  //    The embedded object is the authoritative classifier.
+  if (!parsedJson) {
+    for (const embedded of extractEmbeddedJsonObjects(stderr)) {
+      const classified = classifyJsonPayload(embedded);
+      if (classified) return classified;
+    }
   }
 
   const bracketed = extractBracketedCodes(stderr);
@@ -32,6 +45,126 @@ export function parseAgentError(stderr: string): AgentError {
   if (fromKeyValue) return fromKeyValue;
 
   return { type: "unknown" };
+}
+
+/**
+ * Apply all JSON-payload classifiers in order. Shared by the root-JSON
+ * path and the embedded-JSON path (#592).
+ */
+function classifyJsonPayload(payload: Record<string, unknown>): AgentError | null {
+  const direct = classifyDirectType(payload);
+  if (direct) return direct;
+
+  const nested = classifyNestedAnthropicError(payload);
+  if (nested) return nested;
+
+  const structured = classifyFromCodeTokens(extractJsonCodeTokens(payload), payload);
+  if (structured) return structured;
+
+  return null;
+}
+
+/**
+ * Match the Anthropic-style error envelope where the outer `type` is "error"
+ * and the inner `error.type` carries the specific classification (#592):
+ *
+ *   {"type":"error","error":{"type":"authentication_error","message":"..."}}
+ *   {"type":"error","error":{"type":"rate_limit_error","message":"..."}}
+ *
+ * Returns null when the envelope doesn't match — falls through to other
+ * classifiers.
+ */
+function classifyNestedAnthropicError(payload: Record<string, unknown>): AgentError | null {
+  if (payload.type !== "error") return null;
+  const inner = payload.error;
+  if (!inner || typeof inner !== "object") return null;
+  const innerType = (inner as Record<string, unknown>).type;
+  if (typeof innerType !== "string") return null;
+
+  switch (innerType) {
+    case "authentication_error":
+    case "permission_error":
+    case "invalid_api_key_error":
+      return { type: "auth" };
+    case "rate_limit_error":
+    case "overloaded_error": {
+      const retryAfterSeconds = toNumber(
+        (inner as Record<string, unknown>).retryAfterSeconds ??
+          (inner as Record<string, unknown>).retry_after_seconds ??
+          payload.retryAfterSeconds ??
+          payload.retry_after_seconds,
+      );
+      return retryAfterSeconds !== undefined ? { type: "rate-limit", retryAfterSeconds } : { type: "rate-limit" };
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Scan a free-text message for embedded JSON objects (#592).
+ *
+ * Uses a balanced-brace walk rather than a naive regex so nested objects
+ * parse correctly. Returns objects only — top-level arrays and primitives
+ * are skipped since the classifier only looks at objects.
+ *
+ * Caps the number of extracted candidates to keep pathological inputs from
+ * becoming a performance issue.
+ */
+const MAX_EMBEDDED_CANDIDATES = 8;
+function extractEmbeddedJsonObjects(text: string): Record<string, unknown>[] {
+  const objects: Record<string, unknown>[] = [];
+  let i = 0;
+  while (i < text.length && objects.length < MAX_EMBEDDED_CANDIDATES) {
+    const open = text.indexOf("{", i);
+    if (open === -1) break;
+    const close = findMatchingBrace(text, open);
+    if (close === -1) break;
+    const candidate = text.slice(open, close + 1);
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        objects.push(parsed as Record<string, unknown>);
+      }
+    } catch {
+      // Not valid JSON — advance past the opening brace and keep scanning.
+    }
+    i = close + 1;
+  }
+  return objects;
+}
+
+/**
+ * Find the index of the `}` that closes the `{` at `openIdx`.
+ * Honours string literals so braces inside JSON strings don't mislead the
+ * scanner. Returns -1 if no match is found (unbalanced input).
+ */
+function findMatchingBrace(text: string, openIdx: number): number {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = openIdx; i < text.length; i++) {
+    const ch = text[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && inString) {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
 }
 
 function parseJsonObject(stderr: string): Record<string, unknown> | null {

--- a/test/unit/agents/acp/parse-agent-error.test.ts
+++ b/test/unit/agents/acp/parse-agent-error.test.ts
@@ -54,4 +54,73 @@ describe("parseAgentError", () => {
     expect(parseAgentError("").type).toBe("unknown");
     expect(parseAgentError("something went wrong").type).toBe("unknown");
   });
+
+  // #592: acpx wraps vendor errors in a human-readable prefix. The embedded
+  // JSON envelope must still classify cleanly so AgentManager.shouldSwap fires.
+  describe("#592 — embedded Anthropic error envelope", () => {
+    test("detects auth from embedded Anthropic authentication_error envelope", () => {
+      const stderr =
+        'Internal error: Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"login fail: Please carry the API secret key in the \'Authorization\' field of the request header"},"request_id":"0634d680c8f2e70e15e50e20bebaf407"}';
+      const result = parseAgentError(stderr);
+      expect(result.type).toBe("auth");
+    });
+
+    test("detects rate-limit from embedded Anthropic rate_limit_error envelope", () => {
+      const stderr =
+        'Internal error: Too many requests. API Error: 429 {"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}';
+      const result = parseAgentError(stderr);
+      expect(result.type).toBe("rate-limit");
+    });
+
+    test("detects rate-limit with retryAfterSeconds from inner envelope", () => {
+      const stderr =
+        'throttled {"type":"error","error":{"type":"rate_limit_error","retryAfterSeconds":42}}';
+      const result = parseAgentError(stderr);
+      expect(result.type).toBe("rate-limit");
+      expect(result.retryAfterSeconds).toBe(42);
+    });
+
+    test("detects auth from permission_error variant", () => {
+      const stderr = 'boom {"type":"error","error":{"type":"permission_error"}}';
+      expect(parseAgentError(stderr).type).toBe("auth");
+    });
+
+    test("detects auth from invalid_api_key_error variant", () => {
+      const stderr = 'boom {"type":"error","error":{"type":"invalid_api_key_error"}}';
+      expect(parseAgentError(stderr).type).toBe("auth");
+    });
+
+    test("detects rate-limit from overloaded_error variant", () => {
+      const stderr = 'boom {"type":"error","error":{"type":"overloaded_error"}}';
+      expect(parseAgentError(stderr).type).toBe("rate-limit");
+    });
+
+    test("root JSON Anthropic envelope also classifies (not just embedded)", () => {
+      const root = '{"type":"error","error":{"type":"authentication_error"}}';
+      expect(parseAgentError(root).type).toBe("auth");
+    });
+
+    test("unrelated inner error type leaves classification unknown", () => {
+      const stderr = 'boom {"type":"error","error":{"type":"invalid_request_error"}}';
+      // Not one of the known auth/rate-limit variants.
+      expect(parseAgentError(stderr).type).toBe("unknown");
+    });
+
+    test("nested JSON with braces inside a string literal is parsed correctly", () => {
+      const stderr =
+        'prefix {"type":"error","error":{"type":"authentication_error","message":"please set `{authHeader}` properly"}} suffix';
+      expect(parseAgentError(stderr).type).toBe("auth");
+    });
+
+    test("does not misclassify when embedded JSON is unrelated", () => {
+      const stderr = 'log: {"user":"alice","event":"login"}';
+      expect(parseAgentError(stderr).type).toBe("unknown");
+    });
+
+    test("still returns unknown when no embedded JSON exists", () => {
+      // Free-text-only — no structured signal anywhere. Must stay unknown
+      // (no free-text phrase inference).
+      expect(parseAgentError("Internal error: Failed to authenticate. API Error: 401").type).toBe("unknown");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes the last issue from the v0.63.0-canary.8 dogfood diagnostic.

acpx wraps vendor errors in a human-readable prefix:

```
Internal error: Failed to authenticate. API Error: 401
{"type":"error","error":{"type":"authentication_error","message":"..."}}
```

Before this PR the whole string failed `JSON.parse`, bracketed / key-value regexes didn't match (`"API Error: 401"` has no colon/equals structure the regex requires), and `parseAgentError` returned `{ type: "unknown" }`. The adapter then classified the failure as `category: "quality"` / `outcome: "fail-adapter-error"`. `AgentManager.shouldSwap` returns `false` on quality without `onQualityFailure`, so the configured `claude → codex` fallback never fired. Users silently got tier escalation on the same failing agent.

## Fix — two narrow additions, no free-text inference

1. **Nested Anthropic envelope recognition.** When `payload.type === "error"` and `payload.error.type` is a known variant:

   | Inner `error.type` | Classifier |
   |:---|:---|
   | `authentication_error` / `permission_error` / `invalid_api_key_error` | `auth` |
   | `rate_limit_error` / `overloaded_error` | `rate-limit` |

   `retryAfterSeconds` is pulled from either the inner `error` object or the outer payload if present.

2. **Embedded JSON extraction.** When the whole string isn't JSON, scan for embedded JSON objects using a balanced-brace walk that honours string literals (so `"{authHeader}"` inside a JSON message doesn't confuse the scanner). Each candidate is run through the same classifier pipeline as a root-level JSON payload. Capped at 8 candidates per message.

No free-text phrase inference was added — the module's existing design decision (`Free-text phrase inference is intentionally not supported`) is preserved.

## Tests — 11 new in `parse-agent-error.test.ts`

- [x] canonical #592 401 scenario
- [x] 429 rate-limit variant (with and without `retryAfterSeconds`)
- [x] `permission_error`, `invalid_api_key_error`, `overloaded_error` variants
- [x] root-level Anthropic envelope (not just embedded)
- [x] unrelated inner error types (`invalid_request_error`) stay `unknown`
- [x] braces inside JSON string literals parse correctly
- [x] unrelated embedded JSON (e.g. log events) doesn't false-positive
- [x] pure free-text with no JSON still returns `unknown` (no phrase inference)

## Downstream effect

With this fix:
1. `parseAgentError("Internal error: ... API Error: 401 {...authentication_error...}")` returns `{ type: "auth" }`
2. ACP adapter returns `adapterFailure: { category: "availability", outcome: "fail-auth", retriable: false }`
3. `AgentManager.shouldSwap` sees `category === "availability"` → `true`
4. `nextCandidate("claude", 0)` returns `"codex"` from the fallback map
5. Swap fires; the run continues on codex

## Diagnostic series closed

This is the fifth and final issue from the `docs/findings/2026-04-20-v0.63.0-canary.8-run-issues.md` report:

| Issue | PR | Status |
|:---|:---|:---|
| #589 TDD state transitions | #597 | merged |
| #590 TDD token propagation | #597 | merged |
| #591 early protocolIds | #598 | merged |
| #593 SIGINT cascade | #594 | merged |
| #592 auth classifier | **this PR** | ready |