### PR TITLE
chore: release v0.63.0-canary.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.63.0-canary.8",
+  "version": "0.63.0-canary.9",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Release v0.63.0-canary.9 — bump package.json + tag for canary release.

## Why

Routine canary release per weekly cadence.

## How

- Branched from `main` at `ee8a67bf`
- Bumped `package.json` version from `0.63.0-canary.8` → `0.63.0-canary.9`
- Committed as `chore: release v0.63.0-canary.9`
- Auto-generated tag `v0.63.0-canary.9` pushed separately via CI

## Testing

- [ ] CI passes on this PR
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes

## Notes

- No code changes — version bump only.
- Release workflow (`release.yml`) publishes to npm OIDC upon tag push.
