### PR TITLE
feat(agents): ADR-013 Phase 1 — formalise IAgentManager.run/complete/getAgent + wire SessionManager

### DIFF
--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -25,4 +25,4 @@ export type {
   AgentManagerEventName,
   AgentRunRequest,
 } from "./manager-types";
-export { resolveDefaultAgent } from "./utils";
+export { resolveDefaultAgent, wrapAdapterAsManager } from "./utils";

--- a/src/agents/manager-types.ts
+++ b/src/agents/manager-types.ts
@@ -5,7 +5,7 @@
 
 import type { ContextBundle } from "../context/engine";
 import type { AdapterFailure } from "../context/engine/types";
-import type { AgentResult, AgentRunOptions, CompleteOptions, CompleteResult } from "./types";
+import type { AgentAdapter, AgentResult, AgentRunOptions, CompleteOptions, CompleteResult } from "./types";
 
 export interface AgentFallbackRecord {
   storyId?: string;
@@ -120,4 +120,29 @@ export interface IAgentManager {
    * Swaps on availability failures when agent.fallback.enabled.
    */
   completeWithFallback(prompt: string, options: CompleteOptions): Promise<AgentCompleteOutcome>;
+
+  // ─── ADR-013 Phase 1: uniform call surface ───────────────────────────────
+
+  /**
+   * Long-running session call with automatic agent-swap fallback.
+   * Delegates to runWithFallback and surfaces AgentFallbackRecord[] via
+   * result.agentFallbacks. This is the method SessionManager.runInSession
+   * and ISessionRunner implementations call — never adapter.run() directly.
+   */
+  run(request: AgentRunRequest): Promise<AgentResult>;
+
+  /**
+   * One-shot LLM call with cross-agent fallback.
+   * Delegates to completeWithFallback. Callers that need the full fallback
+   * record list should use completeWithFallback directly.
+   */
+  complete(prompt: string, options: CompleteOptions): Promise<CompleteResult>;
+
+  /**
+   * Resolve a specific adapter by name.
+   * Returns undefined when no registry is set or the name is not registered.
+   * Internal use by subsystems that need to call adapter-level operations
+   * (e.g. deriveSessionName, closeSession) without bypassing AgentManager.
+   */
+  getAgent(name: string): AgentAdapter | undefined;
 }

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -344,6 +344,23 @@ export class AgentManager implements IAgentManager {
     }
   }
 
+  async run(request: AgentRunRequest): Promise<import("./types").AgentResult> {
+    const outcome = await this.runWithFallback(request);
+    return { ...outcome.result, agentFallbacks: outcome.fallbacks };
+  }
+
+  async complete(
+    prompt: string,
+    options: import("./types").CompleteOptions,
+  ): Promise<import("./types").CompleteResult> {
+    const outcome = await this.completeWithFallback(prompt, options);
+    return outcome.result;
+  }
+
+  getAgent(name: string): import("./types").AgentAdapter | undefined {
+    return this._registry?.getAgent(name);
+  }
+
   /** @internal — test helper */
   _emit(
     event: AgentManagerEventName,

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -74,6 +74,12 @@ export interface AgentResult {
    * See: docs/specs/SPEC-session-manager-integration.md Gap 2.
    */
   adapterFailure?: AdapterFailure;
+  /**
+   * Agent swap records when AgentManager executed a cross-agent fallback
+   * (ADR-013 Phase 1). Populated by IAgentManager.run(); empty array on success
+   * with no swaps. Undefined when the result does not go through AgentManager.
+   */
+  agentFallbacks?: import("./manager-types").AgentFallbackRecord[];
 }
 
 /**

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -1,4 +1,6 @@
 import type { NaxConfig } from "../config";
+import type { IAgentManager } from "./manager-types";
+import type { AgentAdapter } from "./types";
 
 const FALLBACK_DEFAULT_AGENT = "claude";
 
@@ -6,4 +8,36 @@ export function resolveDefaultAgent(config: NaxConfig): string {
   const fromAgent = config.agent?.default;
   if (typeof fromAgent === "string" && fromAgent.length > 0) return fromAgent;
   return FALLBACK_DEFAULT_AGENT;
+}
+
+/**
+ * Wrap a single AgentAdapter as a minimal IAgentManager with no fallback logic.
+ * Used by session runners when no AgentManager is available (test / bootstrap
+ * paths) so SessionManager.runInSession always receives an IAgentManager.
+ * ADR-013 Phase 1.
+ */
+export function wrapAdapterAsManager(adapter: AgentAdapter): IAgentManager {
+  const mgr: IAgentManager = {
+    getDefault: () => adapter.name,
+    isUnavailable: () => false,
+    markUnavailable: () => {},
+    reset: () => {},
+    validateCredentials: async () => {},
+    resolveFallbackChain: () => [],
+    shouldSwap: () => false,
+    nextCandidate: () => null,
+    runWithFallback: async (req) => ({ result: await adapter.run(req.runOptions), fallbacks: [] }),
+    completeWithFallback: async (prompt, opts) => ({
+      result: await adapter.complete(prompt, opts),
+      fallbacks: [],
+    }),
+    run: async (req) => {
+      const outcome = await mgr.runWithFallback(req);
+      return { ...outcome.result, agentFallbacks: outcome.fallbacks };
+    },
+    complete: async (prompt, opts) => adapter.complete(prompt, opts),
+    getAgent: () => adapter,
+    events: { on: () => {} },
+  };
+  return mgr;
 }

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -14,15 +14,16 @@
 import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import type { AgentResult, AgentRunOptions } from "../agents/types";
+import type { AgentRunRequest, IAgentManager } from "../agents/manager-types";
+import type { AgentResult } from "../agents/types";
 import { NaxError } from "../errors";
 import { getLogger } from "../logger";
 import type {
   CreateSessionOptions,
   ISessionManager,
   ProtocolIds,
-  SessionAgentRunner,
   SessionDescriptor,
+  SessionRunOptions,
   SessionState,
   TransitionOptions,
 } from "./types";
@@ -332,7 +333,17 @@ export class SessionManager implements ISessionManager {
    *   3. RUNNING → COMPLETED on success, RUNNING → FAILED on failure. If the
    *      runner threw, we transition to FAILED and re-throw.
    */
-  async runInSession(id: string, runner: SessionAgentRunner, options: AgentRunOptions): Promise<AgentResult> {
+  /**
+   * ADR-013 Phase 1: accepts IAgentManager + AgentRunRequest instead of the
+   * raw SessionAgentRunner function. Calls agentManager.run(injectedRequest)
+   * after injecting the onSessionEstablished callback for eager handle binding.
+   */
+  async runInSession(
+    id: string,
+    agentManager: IAgentManager,
+    request: AgentRunRequest,
+    _options?: SessionRunOptions,
+  ): Promise<AgentResult> {
     const pre = this._sessions.get(id);
     if (!pre) {
       throw new NaxError(`Session "${id}" not found in registry`, "SESSION_NOT_FOUND", {
@@ -350,44 +361,41 @@ export class SessionManager implements ISessionManager {
     // session-established and result-returned, the descriptor already
     // carries the correlation needed to resume. The caller's own callback
     // (if any) is chained afterwards so both fire.
-    const callerCallback = options.onSessionEstablished;
-    const injectedOptions: AgentRunOptions = {
-      ...options,
-      onSessionEstablished: (protocolIds, sessionName) => {
-        try {
-          this.bindHandle(id, sessionName, protocolIds);
-        } catch (err) {
-          getLogger().warn("session", "bindHandle via onSessionEstablished failed", {
-            sessionId: id,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-        callerCallback?.(protocolIds, sessionName);
+    const callerCallback = request.runOptions.onSessionEstablished;
+    const injectedRequest: AgentRunRequest = {
+      ...request,
+      runOptions: {
+        ...request.runOptions,
+        onSessionEstablished: (protocolIds, sessionName) => {
+          try {
+            this.bindHandle(id, sessionName, protocolIds);
+          } catch (err) {
+            getLogger().warn("session", "bindHandle via onSessionEstablished failed", {
+              sessionId: id,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+          callerCallback?.(protocolIds, sessionName);
+        },
       },
     };
 
     let result: AgentResult;
     try {
-      result = await runner(injectedOptions);
+      result = await agentManager.run(injectedRequest);
     } catch (err) {
-      // Runner threw — mark session failed, then propagate.
       if (this._sessions.get(id)?.state === "RUNNING") {
         this.transition(id, "FAILED");
       }
       throw err;
     }
 
-    // Bind protocolIds eagerly when the runner reported them. The handle is
-    // the caller-known session name (stored on the descriptor by whoever
-    // created it), or the runner's own derived name if it updated the
-    // descriptor itself. We use the current descriptor's handle as the fallback.
     if (result.protocolIds) {
       const current = this._sessions.get(id);
       const handle = current?.handle;
       if (handle) {
         this.bindHandle(id, handle, result.protocolIds);
       } else {
-        // No handle yet — persist the ids only.
         const updated: SessionDescriptor = {
           ...(current as SessionDescriptor),
           protocolIds: result.protocolIds,

--- a/src/session/runners/single-session-runner.ts
+++ b/src/session/runners/single-session-runner.ts
@@ -11,8 +11,8 @@
  */
 
 import type { AgentAdapter } from "../../agents";
-import { getAgent } from "../../agents";
-import type { AgentFallbackRecord, AgentRunOutcome } from "../../agents/manager-types";
+import { getAgent, wrapAdapterAsManager } from "../../agents";
+import type { AgentRunRequest, IAgentManager } from "../../agents/manager-types";
 import type { AgentResult, AgentRunOptions } from "../../agents/types";
 import { resolveModelForAgent } from "../../config";
 import type { NaxConfig } from "../../config";
@@ -23,7 +23,7 @@ import { getLogger } from "../../logger";
 import type { UserStory } from "../../prd";
 import { RectifierPromptBuilder } from "../../prompts";
 import type { ISessionRunner, SessionRunnerContext, StoryRunOutcome } from "../session-runner";
-import type { SessionAgentRunner, SessionDescriptor } from "../types";
+import type { SessionDescriptor } from "../types";
 
 /**
  * Additional per-story context that SingleSessionRunner needs beyond the
@@ -93,134 +93,138 @@ export class SingleSessionRunner implements ISessionRunner {
     const logger = getLogger();
     const sessionDescriptor = sessionManager && sessionId ? (sessionManager.get(sessionId) ?? undefined) : undefined;
 
-    // Primary-hop context-tool runtime (recreated per swap hop below).
-    const primaryContextToolRuntime = bundle
-      ? _singleSessionRunnerDeps.createContextToolRuntime({
-          bundle,
-          story,
-          config,
-          repoRoot: workdir,
-          runCounter: contextToolRunCounter,
-        })
-      : undefined;
-
     const primaryOptions: AgentRunOptions = {
       ...runOptions,
       contextPullTools: bundle?.pullTools,
-      contextToolRuntime: primaryContextToolRuntime,
+      contextToolRuntime: bundle
+        ? _singleSessionRunnerDeps.createContextToolRuntime({
+            bundle,
+            story,
+            config,
+            repoRoot: workdir,
+            runCounter: contextToolRunCounter,
+          })
+        : undefined,
       ...(sessionDescriptor && { session: sessionDescriptor }),
     };
 
-    // Swap tracking — populated by runWithFallback's closure when the manager path is used.
-    let fallbacks: AgentFallbackRecord[] = [];
+    // finalBundle/finalPrompt track the last hop's bundle + prompt via side effects
+    // inside executeHop. IAgentManager.run() returns only AgentResult, so these
+    // values cannot be carried on the return value — they are captured by the
+    // executeHop closure instead and reflected on StoryRunOutcome after the run.
+    // Invariant: executeHop always updates both before returning, so these always
+    // match the last-executed hop. If no hop ran (no agentManager / no swap),
+    // they retain the primary-agent values.
     let finalBundle: ContextBundle | undefined = bundle;
     let finalPrompt: string | undefined = runOptions.prompt;
 
-    const runFn: SessionAgentRunner = agentManager
-      ? async (opts) => {
-          const outcome: AgentRunOutcome = await agentManager.runWithFallback({
-            runOptions: opts,
-            bundle,
-            signal: opts.abortSignal,
-            executeHop: async (agentName, hopBundle, failure) => {
-              const hopAgent = (agentGetFn ?? _singleSessionRunnerDeps.getAgent)(agentName) ?? undefined;
-              if (!hopAgent) {
-                return {
-                  result: {
-                    success: false,
-                    exitCode: 1,
-                    output: `Agent "${agentName}" not found`,
-                    rateLimited: false,
-                    durationMs: 0,
-                    estimatedCost: 0,
-                  } satisfies AgentResult,
-                  bundle: hopBundle,
-                  prompt: opts.prompt,
-                };
-              }
-
-              let workingBundle = hopBundle;
-              let prompt: string = opts.prompt;
-
-              // On swap, rebuild bundle for the new agent and rewrite the prompt with the handoff preamble.
-              if (failure && hopBundle) {
-                workingBundle = _singleSessionRunnerDeps.rebuildForAgent(hopBundle, agentName, failure, story.id);
-                if (projectDir && featureName && workingBundle.manifest.rebuildInfo) {
-                  try {
-                    await _singleSessionRunnerDeps.writeRebuildManifest(projectDir, featureName, story.id, {
-                      requestId: workingBundle.manifest.requestId,
-                      stage: "execution",
-                      priorAgentId: workingBundle.manifest.rebuildInfo.priorAgentId,
-                      newAgentId: workingBundle.manifest.rebuildInfo.newAgentId,
-                      failureCategory: workingBundle.manifest.rebuildInfo.failureCategory,
-                      failureOutcome: workingBundle.manifest.rebuildInfo.failureOutcome,
-                      priorChunkIds: workingBundle.manifest.rebuildInfo.priorChunkIds,
-                      newChunkIds: workingBundle.manifest.rebuildInfo.newChunkIds,
-                      chunkIdMap: workingBundle.manifest.rebuildInfo.chunkIdMap,
-                      createdAt: new Date().toISOString(),
-                    });
-                  } catch (err) {
-                    logger.warn("execution", "Failed to write rebuild manifest", {
-                      storyId: story.id,
-                      error: String(err),
-                    });
-                  }
-                }
-                prompt = RectifierPromptBuilder.swapHandoff(opts.prompt, workingBundle.pushMarkdown);
-              }
-
-              // Handoff the session descriptor to the new agent so adapter correlates with the right record.
-              const session: SessionDescriptor | undefined =
-                failure && sessionManager && sessionId
-                  ? sessionManager.handoff?.(sessionId, agentName, failure.outcome)
-                  : sessionDescriptor;
-
-              const hopResult = await hopAgent.run({
-                ...opts,
-                prompt,
-                modelDef: resolveModelForAgent(config.models, agentName, effectiveTier, defaultAgent),
-                contextPullTools: workingBundle?.pullTools,
-                contextToolRuntime: workingBundle
-                  ? _singleSessionRunnerDeps.createContextToolRuntime({
-                      bundle: workingBundle,
-                      story,
-                      config,
-                      repoRoot: workdir,
-                      runCounter: contextToolRunCounter,
-                    })
-                  : undefined,
-                ...(session && { session }),
-              });
-
-              // Per-hop bindHandle — runInSession will do the final bind, but intermediate
-              // hops update the descriptor with the hop's protocolIds too so resumes land correctly.
-              if (hopResult.protocolIds && sessionManager && sessionId) {
-                const desc = sessionManager.get(sessionId);
-                if (desc) {
-                  sessionManager.bindHandle(sessionId, hopAgent.deriveSessionName(desc), hopResult.protocolIds);
-                }
-              }
-
-              return { result: hopResult, bundle: workingBundle, prompt };
-            },
-          });
-          fallbacks = outcome.fallbacks;
-          finalBundle = outcome.finalBundle ?? finalBundle;
-          finalPrompt = outcome.finalPrompt ?? finalPrompt;
-          return outcome.result;
-        }
-      : async (opts) => {
-          return agent.run(opts);
+    // executeHop: drives per-hop bundle rebuild + swap-handoff prompt rewrite.
+    // Called by AgentManager.runWithFallback for every hop (primary + fallback).
+    const executeHop: AgentRunRequest["executeHop"] = async (agentName, hopBundle, failure) => {
+      const hopAgent = (agentGetFn ?? _singleSessionRunnerDeps.getAgent)(agentName) ?? undefined;
+      if (!hopAgent) {
+        return {
+          result: {
+            success: false,
+            exitCode: 1,
+            output: `Agent "${agentName}" not found`,
+            rateLimited: false,
+            durationMs: 0,
+            estimatedCost: 0,
+          } satisfies AgentResult,
+          bundle: hopBundle,
+          prompt: primaryOptions.prompt,
         };
+      }
 
-    // When sessionManager + sessionId are both present, go through the per-session
-    // lifecycle primitive for full bookkeeping. Otherwise fall back to a direct
-    // runner call — tests and bootstrap paths that don't use SessionManager can
-    // still execute without a descriptor.
+      let workingBundle = hopBundle;
+      let prompt: string = primaryOptions.prompt;
+
+      if (failure && hopBundle) {
+        workingBundle = _singleSessionRunnerDeps.rebuildForAgent(hopBundle, agentName, failure, story.id);
+        if (projectDir && featureName && workingBundle.manifest.rebuildInfo) {
+          try {
+            await _singleSessionRunnerDeps.writeRebuildManifest(projectDir, featureName, story.id, {
+              requestId: workingBundle.manifest.requestId,
+              stage: "execution",
+              priorAgentId: workingBundle.manifest.rebuildInfo.priorAgentId,
+              newAgentId: workingBundle.manifest.rebuildInfo.newAgentId,
+              failureCategory: workingBundle.manifest.rebuildInfo.failureCategory,
+              failureOutcome: workingBundle.manifest.rebuildInfo.failureOutcome,
+              priorChunkIds: workingBundle.manifest.rebuildInfo.priorChunkIds,
+              newChunkIds: workingBundle.manifest.rebuildInfo.newChunkIds,
+              chunkIdMap: workingBundle.manifest.rebuildInfo.chunkIdMap,
+              createdAt: new Date().toISOString(),
+            });
+          } catch (err) {
+            logger.warn("execution", "Failed to write rebuild manifest", {
+              storyId: story.id,
+              error: String(err),
+            });
+          }
+        }
+        prompt = RectifierPromptBuilder.swapHandoff(primaryOptions.prompt, workingBundle.pushMarkdown);
+      }
+
+      const session: SessionDescriptor | undefined =
+        failure && sessionManager && sessionId
+          ? sessionManager.handoff?.(sessionId, agentName, failure.outcome)
+          : sessionDescriptor;
+
+      const hopResult = await hopAgent.run({
+        ...primaryOptions,
+        prompt,
+        modelDef: resolveModelForAgent(config.models, agentName, effectiveTier, defaultAgent),
+        contextPullTools: workingBundle?.pullTools,
+        contextToolRuntime: workingBundle
+          ? _singleSessionRunnerDeps.createContextToolRuntime({
+              bundle: workingBundle,
+              story,
+              config,
+              repoRoot: workdir,
+              runCounter: contextToolRunCounter,
+            })
+          : undefined,
+        ...(session && { session }),
+      });
+
+      // Per-hop bindHandle so intermediate swaps update the descriptor before
+      // runInSession's final bind; resumes land on the right ACP record.
+      if (hopResult.protocolIds && sessionManager && sessionId) {
+        const desc = sessionManager.get(sessionId);
+        if (desc) {
+          sessionManager.bindHandle(sessionId, hopAgent.deriveSessionName(desc), hopResult.protocolIds);
+        }
+      }
+
+      // Track final bundle/prompt via side effect — agentManager.run() only
+      // returns AgentResult so we capture these in the closure instead.
+      finalBundle = workingBundle ?? finalBundle;
+      finalPrompt = prompt;
+      return { result: hopResult, bundle: workingBundle, prompt };
+    };
+
+    // ADR-013 Phase 1: agentManager is passed directly to runInSession.
+    // When agentManager is absent (test / bootstrap paths), wrap the agent
+    // adapter so runInSession always receives an IAgentManager.
+    const effectiveManager: IAgentManager = agentManager ?? wrapAdapterAsManager(agent);
+
+    // Always pass executeHop so any IAgentManager implementation (real or wrapped)
+    // has access to the hop rebuild + handoff logic if it chooses to invoke it.
+    // wrapAdapterAsManager ignores executeHop safely (no fallback logic).
+    const request: AgentRunRequest = {
+      runOptions: primaryOptions,
+      bundle,
+      signal: primaryOptions.abortSignal,
+      executeHop,
+    };
+
+    // Route through runInSession for lifecycle bookkeeping when a descriptor is
+    // present; otherwise call run() directly (test / bootstrap paths).
     const result =
       sessionManager && sessionId
-        ? await sessionManager.runInSession(sessionId, runFn, primaryOptions)
-        : await runFn(primaryOptions);
+        ? await sessionManager.runInSession(sessionId, effectiveManager, request)
+        : await effectiveManager.run(request);
 
     return {
       success: result.success,
@@ -238,7 +242,7 @@ export class SingleSessionRunner implements ISessionRunner {
             }),
           }
         : undefined,
-      fallbacks,
+      fallbacks: result.agentFallbacks ?? [],
       finalBundle,
       finalPrompt,
       adapterFailure: result.adapterFailure,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -175,6 +175,13 @@ export type SessionAgentRunner = (
   options: import("../agents/types").AgentRunOptions,
 ) => Promise<import("../agents/types").AgentResult>;
 
+/**
+ * Options for SessionManager.runInSession (ADR-013 Phase 1).
+ * Reserved for Phase 2 retry limits and abort signal overrides. Currently unused.
+ */
+// biome-ignore lint/complexity/noBannedTypes: reserved empty interface for Phase 2 extensions
+export type SessionRunOptions = {};
+
 /** Interface the SessionManager implements */
 export interface ISessionManager {
   /** Create a new session descriptor */
@@ -208,8 +215,9 @@ export interface ISessionManager {
   resume(storyId: string, role: SessionRole): SessionDescriptor | null;
   /**
    * Run an agent within a tracked session — the per-session lifecycle primitive.
+   * (ADR-013 Phase 1: signature changed from SessionAgentRunner to IAgentManager.)
    *
-   * Owns: CREATED→RUNNING transition before the runner, handle/protocolIds
+   * Owns: CREATED→RUNNING transition before agentManager.run(), handle/protocolIds
    * binding from the result, and RUNNING→COMPLETED/FAILED transition after.
    * Callers don't need to touch transition/bindHandle for sessions that go
    * through this path.
@@ -224,8 +232,9 @@ export interface ISessionManager {
    */
   runInSession(
     id: string,
-    runner: SessionAgentRunner,
-    options: import("../agents/types").AgentRunOptions,
+    agentManager: import("../agents/manager-types").IAgentManager,
+    request: import("../agents/manager-types").AgentRunRequest,
+    options?: SessionRunOptions,
   ): Promise<import("../agents/types").AgentResult>;
   /**
    * Force-close all non-terminal sessions for a story (Phase 3).

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -5,7 +5,7 @@
  */
 
 import type { AgentAdapter } from "../agents";
-import { resolveDefaultAgent } from "../agents";
+import { resolveDefaultAgent, wrapAdapterAsManager } from "../agents";
 import type { ModelTier, NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config";
 import { resolvePermissions } from "../config/permissions";
@@ -111,10 +111,14 @@ export async function rollbackToRef(workdir: string, ref: string): Promise<void>
 /**
  * Binding used to tie a TDD session's ACP protocolIds back to a pre-created
  * session descriptor so the audit trail includes recordId/sessionId (#541).
+ * ADR-013 Phase 1: agentManager added so runTddSession can go through
+ * IAgentManager.run() → runWithFallback instead of adapter.run() directly.
  */
 export interface TddSessionBinding {
   sessionManager: ISessionManager;
   sessionId: string;
+  /** When provided, routes the session through IAgentManager.run() for fallback support. */
+  agentManager?: import("../agents/manager-types").IAgentManager;
 }
 
 /** Run a single TDD session */
@@ -243,13 +247,17 @@ export async function runTddSession(
   // Run the agent. When a sessionBinding is provided, route through
   // SessionManager.runInSession so state transitions (CREATED → RUNNING →
   // COMPLETED/FAILED) and bindHandle happen automatically (#541, #589).
+  // ADR-013 Phase 1: runInSession now takes IAgentManager. Use the binding's
+  // agentManager when present; otherwise wrap adapter for a no-fallback path.
   // Absent binding path stays compatible with tests that skip SessionManager.
+  const effectiveManager: import("../agents/manager-types").IAgentManager =
+    sessionBinding?.agentManager ?? wrapAdapterAsManager(agent);
+
   const result = sessionBinding
-    ? await sessionBinding.sessionManager.runInSession(
-        sessionBinding.sessionId,
-        (opts) => agent.run(opts),
-        agentRunOptions,
-      )
+    ? await sessionBinding.sessionManager.runInSession(sessionBinding.sessionId, effectiveManager, {
+        runOptions: agentRunOptions,
+        signal: agentRunOptions.abortSignal,
+      })
     : await agent.run(agentRunOptions);
 
   // When binding is present, runInSession already persisted protocolIds

--- a/test/helpers/mock-agent-manager.ts
+++ b/test/helpers/mock-agent-manager.ts
@@ -1,4 +1,14 @@
+import type { AgentAdapter } from "../../src/agents";
 import type { IAgentManager } from "../../src/agents";
+
+const DEFAULT_RESULT = {
+  success: true,
+  exitCode: 0,
+  output: "",
+  rateLimited: false,
+  durationMs: 0,
+  estimatedCost: 0,
+};
 
 export function createMockAgentManager(defaultAgent = "claude"): IAgentManager {
   return {
@@ -10,17 +20,14 @@ export function createMockAgentManager(defaultAgent = "claude"): IAgentManager {
     resolveFallbackChain: () => [],
     shouldSwap: () => false,
     nextCandidate: () => null,
-    runWithFallback: async (_req) => ({
-      result: {
-        success: true,
-        exitCode: 0,
-        output: "",
-        rateLimited: false,
-        durationMs: 0,
-        estimatedCost: 0,
-      },
+    runWithFallback: async (_req) => ({ result: DEFAULT_RESULT, fallbacks: [] }),
+    completeWithFallback: async (_prompt, _opts) => ({
+      result: { output: "", costUsd: 0, source: "fallback" as const },
       fallbacks: [],
     }),
+    run: async (_req) => ({ ...DEFAULT_RESULT, agentFallbacks: [] }),
+    complete: async (_prompt, _opts) => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    getAgent: (_name: string): AgentAdapter | undefined => undefined,
     events: { on: () => {} },
   };
 }

--- a/test/unit/agents/manager-iface-run.test.ts
+++ b/test/unit/agents/manager-iface-run.test.ts
@@ -1,0 +1,180 @@
+/**
+ * IAgentManager.run() / complete() / getAgent() — Phase 1 (ADR-013).
+ *
+ * run() and complete() are thin delegates over runWithFallback /
+ * completeWithFallback. They exist so SessionManager.runInSession and
+ * other callers receive a uniform IAgentManager surface without holding
+ * references to the internal fallback methods.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { AgentManager, _agentManagerDeps } from "../../../src/agents/manager";
+import type { AgentRunRequest } from "../../../src/agents/manager-types";
+import type { AgentAdapter } from "../../../src/agents/types";
+import type { NaxConfig } from "../../../src/config";
+import { DEFAULT_CONFIG } from "../../../src/config/defaults";
+
+function makeConfig(fallbackEnabled = false): NaxConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    agent: {
+      ...DEFAULT_CONFIG.agent,
+      default: "claude",
+      fallback: {
+        enabled: fallbackEnabled,
+        map: { claude: ["codex"] },
+        maxHopsPerStory: 2,
+        onQualityFailure: false,
+        rebuildContext: true,
+      },
+    },
+  } as NaxConfig;
+}
+
+function makeAdapter(name: string, success = true): AgentAdapter {
+  return {
+    name,
+    displayName: name,
+    binary: name,
+    capabilities: { supportedTiers: ["fast"], maxContextTokens: 100000, features: new Set() },
+    run: mock(async () => ({
+      success,
+      exitCode: success ? 0 : 1,
+      output: success ? "ok" : "",
+      rateLimited: false,
+      durationMs: 10,
+      estimatedCost: 0.001,
+    })),
+    complete: mock(async () => ({ output: "complete-out", costUsd: 0.001, source: "cache" as const })),
+    closeSession: async () => {},
+    closePhysicalSession: async () => {},
+    deriveSessionName: () => `nax-test-${name}`,
+    isInstalled: async () => true,
+    buildCommand: () => [],
+    plan: async () => ({ success: true, spec: "" }),
+    decompose: async () => ({ success: true, stories: [] }),
+  } as unknown as AgentAdapter;
+}
+
+function makeRegistry(adapters: AgentAdapter[]) {
+  const map = new Map(adapters.map((a) => [a.name, a]));
+  return { getAgent: (name: string) => map.get(name) };
+}
+
+describe("IAgentManager.run()", () => {
+  test("delegates to runWithFallback and returns AgentResult", async () => {
+    const adapter = makeAdapter("claude");
+    const mgr = new AgentManager(makeConfig(), makeRegistry([adapter]) as never);
+
+    const request: AgentRunRequest = {
+      runOptions: {
+        prompt: "test",
+        workdir: "/tmp",
+        modelTier: "fast",
+        modelDef: { provider: "anthropic", model: "m", env: {} },
+        timeoutSeconds: 30,
+        config: makeConfig(),
+      },
+    };
+
+    const result = await mgr.run(request);
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("ok");
+  });
+
+  test("copies fallback records into result.agentFallbacks on success", async () => {
+    const adapter = makeAdapter("claude");
+    const mgr = new AgentManager(makeConfig(), makeRegistry([adapter]) as never);
+
+    const result = await mgr.run({
+      runOptions: {
+        prompt: "test",
+        workdir: "/tmp",
+        modelTier: "fast",
+        modelDef: { provider: "anthropic", model: "m", env: {} },
+        timeoutSeconds: 30,
+        config: makeConfig(),
+      },
+    });
+
+    // No fallback needed — empty array
+    expect(result.agentFallbacks).toEqual([]);
+  });
+});
+
+describe("IAgentManager.run() — agent swap", () => {
+  let origSleep: typeof _agentManagerDeps.sleep;
+  beforeEach(() => { origSleep = _agentManagerDeps.sleep; });
+  afterEach(() => { _agentManagerDeps.sleep = origSleep; });
+
+  test("result.agentFallbacks has hop records when agent swap occurred", async () => {
+    const claudeAdapter = makeAdapter("claude", false);
+    const codexAdapter = makeAdapter("codex", true);
+
+    (claudeAdapter.run as ReturnType<typeof mock>).mockImplementation(async () => ({
+      success: false,
+      exitCode: 1,
+      output: "",
+      rateLimited: false,
+      durationMs: 10,
+      estimatedCost: 0,
+      adapterFailure: { category: "availability", outcome: "fail-auth", retriable: false, message: "" },
+    }));
+
+    const mgr = new AgentManager(makeConfig(true), makeRegistry([claudeAdapter, codexAdapter]) as never);
+    _agentManagerDeps.sleep = mock(async () => {});
+
+    const result = await mgr.run({
+      runOptions: {
+        prompt: "test",
+        workdir: "/tmp",
+        modelTier: "fast",
+        modelDef: { provider: "anthropic", model: "m", env: {} },
+        timeoutSeconds: 30,
+        config: makeConfig(true),
+      },
+      bundle: {} as never,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.agentFallbacks).toHaveLength(1);
+    expect(result.agentFallbacks?.[0]?.priorAgent).toBe("claude");
+    expect(result.agentFallbacks?.[0]?.newAgent).toBe("codex");
+  });
+});
+
+describe("IAgentManager.complete()", () => {
+  test("delegates to completeWithFallback and returns CompleteResult", async () => {
+    const adapter = makeAdapter("claude");
+    const mgr = new AgentManager(makeConfig(), makeRegistry([adapter]) as never);
+
+    const result = await mgr.complete("hello", {
+      model: "claude-haiku",
+      config: makeConfig(),
+      workdir: "/tmp",
+    });
+
+    expect(result.output).toBe("complete-out");
+  });
+});
+
+describe("IAgentManager.getAgent()", () => {
+  test("returns the adapter for a known agent name", () => {
+    const adapter = makeAdapter("claude");
+    const mgr = new AgentManager(makeConfig(), makeRegistry([adapter]) as never);
+
+    expect(mgr.getAgent("claude")).toBe(adapter);
+  });
+
+  test("returns undefined for an unknown agent name", () => {
+    const mgr = new AgentManager(makeConfig(), makeRegistry([]) as never);
+
+    expect(mgr.getAgent("nonexistent")).toBeUndefined();
+  });
+
+  test("returns undefined when no registry is set", () => {
+    const mgr = new AgentManager(makeConfig());
+    expect(mgr.getAgent("claude")).toBeUndefined();
+  });
+});

--- a/test/unit/pipeline/stages/execution-agent-swap-metrics.test.ts
+++ b/test/unit/pipeline/stages/execution-agent-swap-metrics.test.ts
@@ -73,7 +73,7 @@ function makeBundle(): ContextBundle {
 }
 
 function makeAgentManager(outcome: Partial<AgentRunOutcome> = {}): IAgentManager {
-  return {
+  const mgr: IAgentManager = {
     getDefault: () => "claude",
     isUnavailable: () => false,
     markUnavailable: () => {},
@@ -84,15 +84,9 @@ function makeAgentManager(outcome: Partial<AgentRunOutcome> = {}): IAgentManager
     shouldSwap: () => false,
     nextCandidate: () => null,
     runWithFallback: async (req: AgentRunRequest): Promise<AgentRunOutcome> => {
-      // Simulate executing hop with the executeHop callback if provided
       if (req.executeHop) {
         const { result, bundle, prompt } = await req.executeHop("claude", req.bundle, undefined);
-        return {
-          result,
-          fallbacks: outcome.fallbacks ?? [],
-          finalBundle: bundle,
-          finalPrompt: prompt,
-        };
+        return { result, fallbacks: outcome.fallbacks ?? [], finalBundle: bundle, finalPrompt: prompt };
       }
       return {
         result: { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 },
@@ -103,7 +97,14 @@ function makeAgentManager(outcome: Partial<AgentRunOutcome> = {}): IAgentManager
       };
     },
     completeWithFallback: async () => ({ result: { output: "", costUsd: 0, source: "fallback" as const }, fallbacks: [] }),
+    run: async (req) => {
+      const o = await mgr.runWithFallback(req);
+      return { ...o.result, agentFallbacks: o.fallbacks };
+    },
+    complete: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    getAgent: () => undefined,
   };
+  return mgr;
 }
 
 function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
@@ -318,45 +319,26 @@ describe("execution stage — AC-41 fallback observability", () => {
     _singleSessionRunnerDeps.rebuildForAgent = () => rebuildBundle;
 
     // Manager delegates to executeHop for a swap hop (failure is set)
-    const manager: IAgentManager = {
-      getDefault: () => "claude",
-      isUnavailable: () => false,
-      markUnavailable: () => {},
-      reset: () => {},
-      validateCredentials: async () => {},
-      events: { on: () => {} },
-      resolveFallbackChain: () => [],
-      shouldSwap: () => false,
-      nextCandidate: () => null,
-      runWithFallback: async (req: AgentRunRequest): Promise<AgentRunOutcome> => {
-        // Simulate: primary fails, then executeHop is called with a failure
-        if (req.executeHop) {
-          const failure = { category: "availability" as const, outcome: "fail-quota" as const, message: "quota", retriable: false };
-          const { result, bundle, prompt } = await req.executeHop("codex", req.bundle, failure);
-          return {
-            result,
-            fallbacks: [
-              {
-                storyId: "US-001",
-                priorAgent: "claude",
-                newAgent: "codex",
-                outcome: "fail-quota",
-                category: "availability",
-                hop: 1,
-                timestamp: new Date().toISOString(),
-                costUsd: 0,
-              },
-            ],
-            finalBundle: bundle,
-            finalPrompt: prompt,
-          };
-        }
-        return {
-          result: { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 },
-          fallbacks: [],
-        };
+    const swapFallbacks = [
+      {
+        storyId: "US-001",
+        priorAgent: "claude",
+        newAgent: "codex",
+        outcome: "fail-quota" as const,
+        category: "availability" as const,
+        hop: 1,
+        timestamp: new Date().toISOString(),
+        costUsd: 0,
       },
-      completeWithFallback: async () => ({ result: { output: "", costUsd: 0, source: "fallback" as const }, fallbacks: [] }),
+    ];
+    const manager = makeAgentManager({ fallbacks: swapFallbacks });
+    manager.runWithFallback = async (req: AgentRunRequest): Promise<AgentRunOutcome> => {
+      if (req.executeHop) {
+        const failure = { category: "availability" as const, outcome: "fail-quota" as const, message: "quota", retriable: false };
+        const { result, bundle, prompt } = await req.executeHop("codex", req.bundle, failure);
+        return { result, fallbacks: swapFallbacks, finalBundle: bundle, finalPrompt: prompt };
+      }
+      return { result: { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 }, fallbacks: [] };
     };
 
     _executionDeps.getAgent = (agentId: string) =>

--- a/test/unit/pipeline/stages/execution-manager-wiring.test.ts
+++ b/test/unit/pipeline/stages/execution-manager-wiring.test.ts
@@ -71,6 +71,12 @@ describe("execution stage — uses agentManager.runWithFallback", () => {
         return { result, fallbacks: [], finalBundle: b, finalPrompt: prompt };
       }),
       completeWithFallback: async () => ({ result: { output: "", costUsd: 0, source: "fallback" as const }, fallbacks: [] }),
+      run: async (request) => {
+        const outcome = await manager.runWithFallback(request);
+        return { ...outcome.result, agentFallbacks: outcome.fallbacks };
+      },
+      complete: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+      getAgent: () => undefined,
     };
 
     const successAdapter: AgentAdapter = {

--- a/test/unit/session/manager-early-protocol-ids.test.ts
+++ b/test/unit/session/manager-early-protocol-ids.test.ts
@@ -10,7 +10,9 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import type { AgentRunRequest } from "../../../src/agents/manager-types";
 import type { AgentResult, AgentRunOptions } from "../../../src/agents/types";
+import type { IAgentManager } from "../../../src/agents";
 import type { NaxConfig } from "../../../src/config";
 import { SessionManager } from "../../../src/session/manager";
 
@@ -25,7 +27,7 @@ function makeOptions(): AgentRunOptions {
   };
 }
 
-function makeResult(): AgentResult {
+function makeBaseResult(): AgentResult {
   return {
     success: true,
     exitCode: 0,
@@ -36,36 +38,54 @@ function makeResult(): AgentResult {
   };
 }
 
+function makeAgentManager(runFn: (req: AgentRunRequest) => Promise<AgentResult>): IAgentManager {
+  return {
+    getDefault: () => "claude",
+    isUnavailable: () => false,
+    markUnavailable: () => {},
+    reset: () => {},
+    validateCredentials: async () => {},
+    resolveFallbackChain: () => [],
+    shouldSwap: () => false,
+    nextCandidate: () => null,
+    runWithFallback: async (req) => ({ result: await runFn(req), fallbacks: [] }),
+    completeWithFallback: async () => ({
+      result: { output: "", costUsd: 0, source: "fallback" as const },
+      fallbacks: [],
+    }),
+    run: runFn,
+    complete: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    getAgent: () => undefined,
+    events: { on: () => {} },
+  };
+}
+
+function makeRequest(extraOpts?: Partial<AgentRunOptions>): AgentRunRequest {
+  return { runOptions: { ...makeOptions(), ...extraOpts } };
+}
+
 describe("SessionManager.runInSession — onSessionEstablished (#591)", () => {
   test("fires onSessionEstablished and binds handle + protocolIds before runner returns", async () => {
     const mgr = new SessionManager();
     const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
 
-    // Descriptor starts with null protocolIds.
     expect(mgr.get(d.id)?.protocolIds).toEqual({ recordId: null, sessionId: null });
     expect(mgr.get(d.id)?.handle).toBeUndefined();
 
-    // State before the runner returns — captured inside the runner via
-    // the callback, which fires BEFORE completing.
     type Observed = { protocolIds: unknown; handle: unknown };
     let observedDuringRun: Observed | null = null;
 
-    await mgr.runInSession(
-      d.id,
-      async (opts) => {
-        // Simulate adapter firing the callback after ensureAcpSession succeeds.
-        opts.onSessionEstablished?.({ recordId: "rec-early", sessionId: "sess-early" }, "nax-early-handle");
-        // Capture descriptor state from before the runner returns.
-        observedDuringRun = {
-          protocolIds: mgr.get(d.id)?.protocolIds,
-          handle: mgr.get(d.id)?.handle,
-        };
-        return makeResult();
-      },
-      makeOptions(),
-    );
+    const agentMgr = makeAgentManager(async (req) => {
+      req.runOptions.onSessionEstablished?.({ recordId: "rec-early", sessionId: "sess-early" }, "nax-early-handle");
+      observedDuringRun = {
+        protocolIds: mgr.get(d.id)?.protocolIds,
+        handle: mgr.get(d.id)?.handle,
+      };
+      return makeBaseResult();
+    });
 
-    // Eager binding during the runner — this is the whole point of #591.
+    await mgr.runInSession(d.id, agentMgr, makeRequest());
+
     if (!observedDuringRun) throw new Error("runner never observed descriptor state");
     const captured: Observed = observedDuringRun;
     expect(captured.protocolIds).toEqual({ recordId: "rec-early", sessionId: "sess-early" });
@@ -77,24 +97,20 @@ describe("SessionManager.runInSession — onSessionEstablished (#591)", () => {
     const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
 
     let caught: unknown;
+    const agentMgr = makeAgentManager(async (req) => {
+      req.runOptions.onSessionEstablished?.({ recordId: "rec-crash", sessionId: "sess-crash" }, "nax-crash-handle");
+      throw new Error("runner crashed mid-flight");
+    });
+
     try {
-      await mgr.runInSession(
-        d.id,
-        async (opts) => {
-          opts.onSessionEstablished?.({ recordId: "rec-crash", sessionId: "sess-crash" }, "nax-crash-handle");
-          throw new Error("runner crashed mid-flight");
-        },
-        makeOptions(),
-      );
+      await mgr.runInSession(d.id, agentMgr, makeRequest());
     } catch (e) {
       caught = e;
     }
 
     expect(caught).toBeDefined();
-    // #591 guarantee: protocolIds were persisted before the throw.
     expect(mgr.get(d.id)?.protocolIds).toEqual({ recordId: "rec-crash", sessionId: "sess-crash" });
     expect(mgr.get(d.id)?.handle).toBe("nax-crash-handle");
-    // State still transitions to FAILED.
     expect(mgr.get(d.id)?.state).toBe("FAILED");
   });
 
@@ -107,19 +123,15 @@ describe("SessionManager.runInSession — onSessionEstablished (#591)", () => {
       callerCalls.push({ ids, name });
     };
 
-    await mgr.runInSession(
-      d.id,
-      async (opts) => {
-        opts.onSessionEstablished?.({ recordId: "rec-1", sessionId: "sess-1" }, "nax-chain");
-        return makeResult();
-      },
-      { ...makeOptions(), onSessionEstablished: callerCallback },
-    );
+    const agentMgr = makeAgentManager(async (req) => {
+      req.runOptions.onSessionEstablished?.({ recordId: "rec-1", sessionId: "sess-1" }, "nax-chain");
+      return makeBaseResult();
+    });
 
-    // Manager bound the handle...
+    await mgr.runInSession(d.id, agentMgr, makeRequest({ onSessionEstablished: callerCallback }));
+
     expect(mgr.get(d.id)?.handle).toBe("nax-chain");
     expect(mgr.get(d.id)?.protocolIds).toEqual({ recordId: "rec-1", sessionId: "sess-1" });
-    // ...AND the caller's own callback still fired.
     expect(callerCalls).toHaveLength(1);
     expect(callerCalls[0]).toEqual({
       ids: { recordId: "rec-1", sessionId: "sess-1" },
@@ -131,17 +143,14 @@ describe("SessionManager.runInSession — onSessionEstablished (#591)", () => {
     const mgr = new SessionManager();
     const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x", handle: "pre-existing" });
 
-    // Runner returns protocolIds only in the final result — like the
-    // pre-#591 adapter path. runInSession's post-run bindHandle should
-    // still fire.
-    await mgr.runInSession(
-      d.id,
-      async () => ({ ...makeResult(), protocolIds: { recordId: "rec-late", sessionId: "sess-late" } }),
-      makeOptions(),
-    );
+    const agentMgr = makeAgentManager(async () => ({
+      ...makeBaseResult(),
+      protocolIds: { recordId: "rec-late", sessionId: "sess-late" },
+    }));
+
+    await mgr.runInSession(d.id, agentMgr, makeRequest());
 
     expect(mgr.get(d.id)?.protocolIds).toEqual({ recordId: "rec-late", sessionId: "sess-late" });
-    // handle was pre-existing so bindHandle at the end uses it.
     expect(mgr.get(d.id)?.handle).toBe("pre-existing");
   });
 });

--- a/test/unit/session/manager-run-in-session.test.ts
+++ b/test/unit/session/manager-run-in-session.test.ts
@@ -1,27 +1,35 @@
 /**
  * SessionManager.runInSession — per-session lifecycle primitive.
  *
+ * ADR-013 Phase 1: signature changed from (id, SessionAgentRunner, AgentRunOptions)
+ * to (id, IAgentManager, AgentRunRequest, SessionRunOptions?).
+ *
  * Contract:
- *   - transitions CREATED → RUNNING before the runner fires (idempotent —
+ *   - transitions CREATED → RUNNING before agentManager.run() fires (idempotent —
  *     RESUMING state is left alone)
- *   - binds protocolIds from the runner's return value
+ *   - binds protocolIds from the result
  *   - transitions RUNNING → COMPLETED on success, RUNNING → FAILED on failure
  *   - on thrown error: marks session FAILED, re-raises
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { SessionManager } from "../../../src/session/manager";
-import type { AgentResult, AgentRunOptions } from "../../../src/agents/types";
+import type { IAgentManager } from "../../../src/agents/manager-types";
+import type { AgentRunRequest } from "../../../src/agents/manager-types";
+import type { AgentResult } from "../../../src/agents/types";
 import type { NaxConfig } from "../../../src/config";
 
-function makeOptions(): AgentRunOptions {
+function makeRequest(overrides: Partial<AgentRunRequest> = {}): AgentRunRequest {
   return {
-    prompt: "test",
-    workdir: "/tmp/x",
-    modelTier: "fast",
-    modelDef: { provider: "anthropic", model: "claude-haiku", env: {} },
-    timeoutSeconds: 30,
-    config: {} as NaxConfig,
+    runOptions: {
+      prompt: "test",
+      workdir: "/tmp/x",
+      modelTier: "fast",
+      modelDef: { provider: "anthropic", model: "claude-haiku", env: {} },
+      timeoutSeconds: 30,
+      config: {} as NaxConfig,
+    },
+    ...overrides,
   };
 }
 
@@ -37,36 +45,54 @@ function makeResult(overrides: Partial<AgentResult> = {}): AgentResult {
   };
 }
 
-describe("SessionManager.runInSession", () => {
+function makeAgentManager(result: AgentResult | (() => Promise<AgentResult>)): IAgentManager {
+  const runFn = typeof result === "function" ? result : async () => result;
+  return {
+    getDefault: () => "claude",
+    isUnavailable: () => false,
+    markUnavailable: () => {},
+    reset: () => {},
+    validateCredentials: async () => {},
+    resolveFallbackChain: () => [],
+    shouldSwap: () => false,
+    nextCandidate: () => null,
+    runWithFallback: async (_req) => ({ result: await runFn(), fallbacks: [] }),
+    completeWithFallback: async () => ({ result: { output: "", costUsd: 0, source: "fallback" as const }, fallbacks: [] }),
+    run: mock(runFn),
+    complete: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    getAgent: () => undefined,
+    events: { on: () => {} },
+  };
+}
+
+describe("SessionManager.runInSession — ADR-013 Phase 1", () => {
   test("transitions CREATED → RUNNING → COMPLETED on success", async () => {
     const mgr = new SessionManager();
     const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x", handle: "nax-test" });
 
     const observed: string[] = [];
-    const result = await mgr.runInSession(
-      d.id,
-      async () => {
-        observed.push(mgr.get(d.id)?.state ?? "?");
-        return makeResult();
-      },
-      makeOptions(),
-    );
+    const agentMgr = makeAgentManager(async () => {
+      observed.push(mgr.get(d.id)?.state ?? "?");
+      return makeResult();
+    });
+
+    const result = await mgr.runInSession(d.id, agentMgr, makeRequest());
 
     expect(observed).toEqual(["RUNNING"]);
     expect(mgr.get(d.id)?.state).toBe("COMPLETED");
     expect(result.success).toBe(true);
   });
 
-  test("transitions to FAILED when runner returns success=false", async () => {
+  test("transitions to FAILED when agentManager.run() returns success=false", async () => {
     const mgr = new SessionManager();
     const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x", handle: "nax-test" });
 
-    await mgr.runInSession(d.id, async () => makeResult({ success: false }), makeOptions());
+    await mgr.runInSession(d.id, makeAgentManager(makeResult({ success: false })), makeRequest());
 
     expect(mgr.get(d.id)?.state).toBe("FAILED");
   });
 
-  test("transitions to FAILED and re-throws when runner throws", async () => {
+  test("transitions to FAILED and re-throws when agentManager.run() throws", async () => {
     const mgr = new SessionManager();
     const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x", handle: "nax-test" });
 
@@ -75,10 +101,8 @@ describe("SessionManager.runInSession", () => {
     try {
       await mgr.runInSession(
         d.id,
-        async () => {
-          throw err;
-        },
-        makeOptions(),
+        makeAgentManager(async () => { throw err; }),
+        makeRequest(),
       );
     } catch (e) {
       caught = e;
@@ -88,14 +112,14 @@ describe("SessionManager.runInSession", () => {
     expect(mgr.get(d.id)?.state).toBe("FAILED");
   });
 
-  test("binds protocolIds from runner result onto the descriptor", async () => {
+  test("binds protocolIds from agentManager.run() result onto the descriptor", async () => {
     const mgr = new SessionManager();
     const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x", handle: "nax-test" });
 
     await mgr.runInSession(
       d.id,
-      async () => makeResult({ protocolIds: { recordId: "rec-1", sessionId: "sess-1" } }),
-      makeOptions(),
+      makeAgentManager(makeResult({ protocolIds: { recordId: "rec-1", sessionId: "sess-1" } })),
+      makeRequest(),
     );
 
     expect(mgr.get(d.id)?.protocolIds).toEqual({ recordId: "rec-1", sessionId: "sess-1" });
@@ -106,7 +130,7 @@ describe("SessionManager.runInSession", () => {
 
     let caught: unknown;
     try {
-      await mgr.runInSession("sess-nonexistent", async () => makeResult(), makeOptions());
+      await mgr.runInSession("sess-nonexistent", makeAgentManager(makeResult()), makeRequest());
     } catch (e) {
       caught = e;
     }
@@ -116,21 +140,14 @@ describe("SessionManager.runInSession", () => {
   });
 
   test("leaves non-CREATED sessions alone (does not force RUNNING)", async () => {
-    // RESUMING-state sessions should not be force-transitioned through RUNNING.
-    // Only CREATED → RUNNING is automatic.
     const mgr = new SessionManager();
     const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x", handle: "nax-test" });
     mgr.transition(d.id, "RUNNING");
     mgr.transition(d.id, "PAUSED");
     mgr.transition(d.id, "RESUMING");
-    // RESUMING is not CREATED — runInSession should not try to re-enter RUNNING
-    // via the auto-transition logic. The runner still executes and the final
-    // transition happens if the session is RUNNING by end of run — which it
-    // won't be here. So the session state won't advance to COMPLETED.
 
-    const result = await mgr.runInSession(d.id, async () => makeResult(), makeOptions());
+    const result = await mgr.runInSession(d.id, makeAgentManager(makeResult()), makeRequest());
     expect(result.success).toBe(true);
-    // State should still be RESUMING — auto-transition only fires from CREATED.
     expect(mgr.get(d.id)?.state).toBe("RESUMING");
   });
 
@@ -140,13 +157,54 @@ describe("SessionManager.runInSession", () => {
 
     const result = await mgr.runInSession(
       d.id,
-      async () =>
-        makeResult({
-          tokenUsage: { inputTokens: 100, outputTokens: 50, cache_read_input_tokens: 10 },
-        }),
-      makeOptions(),
+      makeAgentManager(makeResult({
+        tokenUsage: { inputTokens: 100, outputTokens: 50, cache_read_input_tokens: 10 },
+      })),
+      makeRequest(),
     );
 
     expect(result.tokenUsage).toEqual({ inputTokens: 100, outputTokens: 50, cache_read_input_tokens: 10 });
+  });
+
+  test("injects onSessionEstablished into request.runOptions and fires caller callback", async () => {
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x", handle: "nax-test" });
+
+    let callerFired = false;
+    let bindHandleFired = false;
+
+    const origBind = mgr.bindHandle.bind(mgr);
+    mgr.bindHandle = mock((...args: Parameters<typeof mgr.bindHandle>) => {
+      bindHandleFired = true;
+      return origBind(...args);
+    });
+
+    const agentMgr: IAgentManager = {
+      ...makeAgentManager(makeResult()),
+      run: mock(async (req) => {
+        // Fire onSessionEstablished as if adapter established a session
+        req.runOptions.onSessionEstablished?.({ recordId: "r1", sessionId: "s1" }, "nax-test");
+        return makeResult();
+      }),
+    };
+
+    await mgr.runInSession(
+      d.id,
+      agentMgr,
+      makeRequest({
+        runOptions: {
+          prompt: "test",
+          workdir: "/tmp/x",
+          modelTier: "fast",
+          modelDef: { provider: "anthropic", model: "m", env: {} },
+          timeoutSeconds: 30,
+          config: {} as NaxConfig,
+          onSessionEstablished: () => { callerFired = true; },
+        },
+      }),
+    );
+
+    expect(callerFired).toBe(true);
+    expect(bindHandleFired).toBe(true);
   });
 });

--- a/test/unit/tdd/session-runner-bindhandle.test.ts
+++ b/test/unit/tdd/session-runner-bindhandle.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AgentRunRequest, IAgentManager } from "../../../src/agents/manager-types";
 import type { AgentResult, AgentRunOptions } from "../../../src/agents/types";
 import type { NaxConfig } from "../../../src/config";
 import type { UserStory } from "../../../src/prd";
@@ -87,12 +88,11 @@ function makeSessionManager() {
     descriptor.state = to as SessionDescriptor["state"];
     return descriptor;
   });
-  // Phase 2: stub runInSession that delegates to the runner and applies bindHandle
-  // the same way the real implementation does. Required so runTddSession's
-  // sessionBinding path works against the test mock.
-  const runInSession = mock(async (id: string, runner: (opts: unknown) => Promise<AgentResult>, opts: unknown) => {
+  // Stub runInSession that delegates to agentManager.run() and applies bindHandle
+  // the same way the real implementation does (ADR-013 Phase 1 signature).
+  const runInSession = mock(async (id: string, agentMgr: IAgentManager, request: AgentRunRequest) => {
     transition(id, "RUNNING");
-    const result = await runner(opts);
+    const result = await agentMgr.run(request);
     if (result.protocolIds && descriptor.handle) {
       bindHandle(id, descriptor.handle, result.protocolIds);
     }


### PR DESCRIPTION
## Summary

- **`IAgentManager`** gains `run()`, `complete()`, `getAgent()` — callers now hold a single typed handle without reaching into `runWithFallback`/`completeWithFallback` directly
- **`AgentManager`** implements the three methods; `run()` delegates to `runWithFallback` and surfaces fallback hop records via `result.agentFallbacks`
- **`SessionManager.runInSession`** signature changes from `SessionAgentRunner` to `(id, agentManager: IAgentManager, request: AgentRunRequest)` — injects `onSessionEstablished` into `request.runOptions` for eager handle binding (#591 preserved)
- **`SingleSessionRunner`** refactored to use `effectiveManager.run(request)` + always passes `executeHop` (wrap path ignores it safely); `finalBundle`/`finalPrompt` are tracked via closure side effects with documented invariant
- **`wrapAdapterAsManager`** extracted to `src/agents/utils.ts` barrel export; `run()` delegates to `runWithFallback` to eliminate duplication; unnecessary `as CompleteResult` casts removed
- **`TddSessionBinding`** gains optional `agentManager` field; `runTddSession` uses `wrapAdapterAsManager` fallback

## Test plan

- [ ] `test/unit/agents/manager-iface-run.test.ts` — new tests covering `IAgentManager.run()`, `complete()`, `getAgent()`, fallback hop record propagation
- [ ] `test/unit/session/manager-run-in-session.test.ts` — updated to new `(id, agentManager, request)` signature
- [ ] `test/unit/session/manager-early-protocol-ids.test.ts` — updated to use `IAgentManager` wrapper pattern
- [ ] `test/unit/tdd/session-runner-bindhandle.test.ts` — `runInSession` mock updated to ADR-013 Phase 1 signature
- [ ] `test/unit/pipeline/stages/execution-manager-wiring.test.ts` — mock manager gains `run/complete/getAgent`
- [ ] `test/helpers/mock-agent-manager.ts` — gains `run/complete/getAgent` methods
- [ ] Full suite: `bun run test` — 6449 pass, 5 fail (all pre-existing, down from 7 on main)