### PR TITLE
feat: add .naxignore filtering across changed-file pipelines

### DIFF
--- a/src/context/engine/providers/session-scratch.ts
+++ b/src/context/engine/providers/session-scratch.ts
@@ -18,7 +18,7 @@
 import { createHash } from "node:crypto";
 import type { ScratchEntry } from "../../../session/scratch-writer";
 import { scratchFilePath } from "../../../session/scratch-writer";
-import { filterNaxInternalPaths } from "../../../utils/path-filters";
+import { type NaxIgnoreMatcher, filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../../../utils/path-filters";
 import { neutralizeForAgent } from "../scratch-neutralizer";
 import type { ContextProviderResult, ContextRequest, IContextProvider, RawChunk } from "../types";
 
@@ -71,7 +71,11 @@ function parseJsonl(raw: string): ScratchEntry[] {
  * fields (outputTail) are passed through neutralizeForAgent() to strip
  * agent-specific tool-name references (AC-42).
  */
-function renderEntry(entry: ScratchEntry, targetAgentId?: string): string {
+function renderEntry(
+  entry: ScratchEntry,
+  targetAgentId?: string,
+  ignoreMatchers: readonly NaxIgnoreMatcher[] = [],
+): string {
   switch (entry.kind) {
     case "verify-result": {
       const status = entry.success ? "PASS" : `FAIL (${entry.failCount} failures)`;
@@ -86,7 +90,7 @@ function renderEntry(entry: ScratchEntry, targetAgentId?: string): string {
       return `**Rectify** attempt ${entry.attempt} at ${entry.timestamp}: ${entry.succeeded ? "succeeded" : "failed"}`;
     case "tdd-session": {
       // #542: drop .nax/ bookkeeping noise so the prompt only surfaces real code changes.
-      const userChanged = filterNaxInternalPaths(entry.filesChanged);
+      const userChanged = filterNaxInternalPaths(entry.filesChanged, ignoreMatchers);
       const changed = userChanged.length > 0 ? ` — changed: ${userChanged.join(", ")}` : "";
       const lines = [
         `**TDD ${entry.role}** at ${entry.timestamp}: ${entry.success ? "succeeded" : "failed"}${changed}`,
@@ -106,7 +110,11 @@ function renderEntry(entry: ScratchEntry, targetAgentId?: string): string {
  * Read a scratch dir and produce a RawChunk for its most recent entries.
  * Returns null when the dir has no scratch file or the file is empty.
  */
-async function readScratchDir(scratchDir: string, targetAgentId?: string): Promise<RawChunk | null> {
+async function readScratchDir(
+  scratchDir: string,
+  targetAgentId?: string,
+  ignoreMatchers: readonly NaxIgnoreMatcher[] = [],
+): Promise<RawChunk | null> {
   const filePath = scratchFilePath(scratchDir);
   if (!(await _sessionScratchDeps.fileExists(filePath))) return null;
 
@@ -116,7 +124,7 @@ async function readScratchDir(scratchDir: string, targetAgentId?: string): Promi
 
   // Take most recent N entries (tail of the JSONL)
   const entries = allEntries.slice(-MAX_ENTRIES_PER_DIR);
-  const content = entries.map((e) => renderEntry(e, targetAgentId)).join("\n\n");
+  const content = entries.map((e) => renderEntry(e, targetAgentId, ignoreMatchers)).join("\n\n");
 
   // Truncate content to the token ceiling so the reported token count
   // matches the actual content length. Without truncation the packing stage
@@ -156,9 +164,10 @@ export class SessionScratchProvider implements IContextProvider {
       return { chunks: [], pullTools: [] };
     }
 
+    const ignoreMatchers = await resolveNaxIgnorePatterns(request.repoRoot, request.packageDir);
     const chunks: RawChunk[] = [];
     for (const dir of dirs) {
-      const chunk = await readScratchDir(dir, request.agentId);
+      const chunk = await readScratchDir(dir, request.agentId, ignoreMatchers);
       if (chunk) chunks.push(chunk);
     }
 

--- a/src/execution/deferred-review.ts
+++ b/src/execution/deferred-review.ts
@@ -8,6 +8,7 @@
 import { spawn } from "bun";
 import type { PluginRegistry } from "../plugins";
 import type { ReviewConfig } from "../review/types";
+import { filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
 
 /** Injectable deps for testing */
 export const _deferredReviewDeps = { spawn };
@@ -72,7 +73,9 @@ export async function runDeferredReview(
     return undefined;
   }
 
-  const changedFiles = await getChangedFilesForDeferred(workdir, runStartRef);
+  const changedFilesRaw = await getChangedFilesForDeferred(workdir, runStartRef);
+  const ignoreMatchers = await resolveNaxIgnorePatterns(workdir);
+  const changedFiles = filterNaxInternalPaths(changedFilesRaw, ignoreMatchers);
 
   const reviewerResults: DeferredReviewResult["reviewerResults"] = [];
   let anyFailed = false;

--- a/src/execution/deferred-review.ts
+++ b/src/execution/deferred-review.ts
@@ -8,7 +8,7 @@
 import { spawn } from "bun";
 import type { PluginRegistry } from "../plugins";
 import type { ReviewConfig } from "../review/types";
-import { filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
+import { type NaxIgnoreIndex, filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
 
 /** Injectable deps for testing */
 export const _deferredReviewDeps = { spawn };
@@ -63,6 +63,7 @@ export async function runDeferredReview(
   reviewConfig: ReviewConfig,
   plugins: PluginRegistry,
   runStartRef: string,
+  naxIgnoreIndex?: NaxIgnoreIndex,
 ): Promise<DeferredReviewResult | undefined> {
   if (!reviewConfig || reviewConfig.pluginMode !== "deferred") {
     return undefined;
@@ -74,7 +75,7 @@ export async function runDeferredReview(
   }
 
   const changedFilesRaw = await getChangedFilesForDeferred(workdir, runStartRef);
-  const ignoreMatchers = await resolveNaxIgnorePatterns(workdir);
+  const ignoreMatchers = naxIgnoreIndex?.getMatchers() ?? (await resolveNaxIgnorePatterns(workdir));
   const changedFiles = filterNaxInternalPaths(changedFilesRaw, ignoreMatchers);
 
   const reviewerResults: DeferredReviewResult["reviewerResults"] = [];

--- a/src/execution/executor-types.ts
+++ b/src/execution/executor-types.ts
@@ -14,6 +14,7 @@ import type { AgentGetFn } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins";
 import type { PRD, UserStory } from "../prd/types";
 import type { ISessionManager } from "../session";
+import type { NaxIgnoreIndex } from "../utils/path-filters";
 import type { StoryBatch } from "./batching";
 import type { DeferredReviewResult } from "./deferred-review";
 import type { PidRegistry } from "./pid-registry";
@@ -51,6 +52,8 @@ export interface SequentialExecutionContext {
   abortSignal?: AbortSignal;
   /** Max parallel sessions: undefined=sequential, 0=auto-detect, N>0=cap at N */
   parallelCount?: number;
+  /** Run-scoped pre-resolved .naxignore index (refreshed when package set changes). */
+  naxIgnoreIndex?: NaxIgnoreIndex;
 }
 
 export interface SequentialExecutionResult {

--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -166,6 +166,7 @@ export async function runIteration(
     routing,
     projectDir: ctx.workdir,
     workdir: resolvedWorkdir,
+    naxIgnoreIndex: ctx.naxIgnoreIndex,
     worktreeDependencyContext: dependencyContext,
     prdPath: ctx.prdPath,
     featureDir: ctx.featureDir,

--- a/src/execution/lifecycle/acceptance-helpers.ts
+++ b/src/execution/lifecycle/acceptance-helpers.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 import { getSafeLogger } from "../../logger";
 import type { PipelineContext } from "../../pipeline/types";
 import type { PRD } from "../../prd/types";
+import { filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../../utils/path-filters";
 import type { AcceptanceLoopResult } from "./acceptance-loop";
 
 // ─── Stub detection ─────────────────────────────────────────────────────────
@@ -170,10 +171,17 @@ export async function regenerateAcceptanceTest(
   if (storyGitRef) {
     try {
       const diffOutput = await _regenerateDeps.spawnGitDiff(workdir, storyGitRef);
-      const changedFiles = diffOutput
+      const changedFilesRaw = diffOutput
         .split("\n")
         .map((f) => f.trim())
         .filter((f) => f.length > 0);
+      const repoRoot = acceptanceContext.projectDir ?? workdir;
+      const packageDir =
+        acceptanceContext.story.workdir && acceptanceContext.projectDir
+          ? path.join(acceptanceContext.projectDir, acceptanceContext.story.workdir)
+          : undefined;
+      const ignoreMatchers = await resolveNaxIgnorePatterns(repoRoot, packageDir);
+      const changedFiles = filterNaxInternalPaths(changedFilesRaw, ignoreMatchers);
 
       const MAX_BYTES = 50 * 1024;
       let totalBytes = 0;

--- a/src/execution/lifecycle/acceptance-helpers.ts
+++ b/src/execution/lifecycle/acceptance-helpers.ts
@@ -180,7 +180,9 @@ export async function regenerateAcceptanceTest(
         acceptanceContext.story.workdir && acceptanceContext.projectDir
           ? path.join(acceptanceContext.projectDir, acceptanceContext.story.workdir)
           : undefined;
-      const ignoreMatchers = await resolveNaxIgnorePatterns(repoRoot, packageDir);
+      const ignoreMatchers =
+        acceptanceContext.naxIgnoreIndex?.getMatchers(packageDir) ??
+        (await resolveNaxIgnorePatterns(repoRoot, packageDir));
       const changedFiles = filterNaxInternalPaths(changedFilesRaw, ignoreMatchers);
 
       const MAX_BYTES = 50 * 1024;

--- a/src/execution/lifecycle/acceptance-loop.ts
+++ b/src/execution/lifecycle/acceptance-loop.ts
@@ -21,6 +21,7 @@ import type { PipelineEventEmitter } from "../../pipeline/events";
 import type { AgentGetFn, PipelineContext } from "../../pipeline/types";
 import type { PluginRegistry } from "../../plugins";
 import type { PRD } from "../../prd/types";
+import type { NaxIgnoreIndex } from "../../utils/path-filters";
 import { hookCtx } from "../helpers";
 import type { StatusWriter } from "../status-writer";
 import { applyFix, resolveAcceptanceDiagnosis } from "./acceptance-fix";
@@ -57,6 +58,8 @@ export interface AcceptanceLoopContext {
   statusWriter: StatusWriter;
   /** Protocol-aware agent resolver — passed from registry at run start */
   agentGetFn?: AgentGetFn;
+  /** Pre-resolved .naxignore matcher cache shared across run stages */
+  naxIgnoreIndex?: NaxIgnoreIndex;
   /** Per-package acceptance test paths — used to load test content for fix routing */
   acceptanceTestPaths?: Array<{ testPath: string; packageDir: string }>;
 }
@@ -132,6 +135,7 @@ export async function runAcceptanceLoop(ctx: AcceptanceLoopContext): Promise<Acc
       },
       projectDir: ctx.workdir,
       workdir: ctx.workdir,
+      naxIgnoreIndex: ctx.naxIgnoreIndex,
       featureDir: ctx.featureDir,
       hooks: ctx.hooks,
       plugins: ctx.pluginRegistry,

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -15,6 +15,7 @@ import { wireReporters } from "../pipeline/subscribers/reporters";
 import type { PipelineContext } from "../pipeline/types";
 import { countStories, isComplete, isStalled, loadPRD } from "../prd";
 import type { PRD } from "../prd/types";
+import { buildNaxIgnoreIndex } from "../utils/path-filters";
 import { startHeartbeat } from "./crash-recovery";
 import { captureRunStartRef, runDeferredReview } from "./deferred-review";
 import type { DeferredReviewResult } from "./deferred-review";
@@ -59,6 +60,23 @@ export async function executeUnified(
   let deferredReview: DeferredReviewResult | undefined;
 
   const runStartRef = await captureRunStartRef(ctx.workdir);
+  let cachedNaxIgnoreKey: string | undefined;
+  const getRunNaxIgnoreIndex = async (currentPrd: PRD) => {
+    const packageDirs = [
+      ...new Set(
+        currentPrd.userStories
+          .map((s) => s.workdir)
+          .filter((w): w is string => typeof w === "string" && w.length > 0)
+          .map((w) => `${ctx.workdir}/${w}`),
+      ),
+    ].sort();
+    const cacheKey = packageDirs.join("|");
+    if (ctx.naxIgnoreIndex && cachedNaxIgnoreKey === cacheKey) return ctx.naxIgnoreIndex;
+    const nextIndex = await buildNaxIgnoreIndex(ctx.workdir, packageDirs);
+    cachedNaxIgnoreKey = cacheKey;
+    ctx.naxIgnoreIndex = nextIndex;
+    return nextIndex;
+  };
 
   pipelineEventBus.clear();
   // Wire subscribers — unsubscribe fns are NOT called here because run:completed
@@ -99,7 +117,14 @@ export async function executeUnified(
   try {
     if (isComplete(prd)) {
       logger?.info("execution", "All stories already complete — skipping pre-run pipeline");
-      deferredReview = await runDeferredReview(ctx.workdir, ctx.config.review, ctx.pluginRegistry, runStartRef);
+      const naxIgnoreIndex = await getRunNaxIgnoreIndex(prd);
+      deferredReview = await runDeferredReview(
+        ctx.workdir,
+        ctx.config.review,
+        ctx.pluginRegistry,
+        runStartRef,
+        naxIgnoreIndex,
+      );
       return buildResult("completed");
     }
 
@@ -107,12 +132,14 @@ export async function executeUnified(
     let preRunCtx: PipelineContext | undefined;
     if (ctx.config.acceptance?.enabled) {
       logger?.info("execution", "Running pre-run pipeline (acceptance test setup)");
+      const naxIgnoreIndex = await getRunNaxIgnoreIndex(prd);
       preRunCtx = {
         config: ctx.config,
         rootConfig: ctx.config,
         prd,
         projectDir: ctx.workdir,
         workdir: ctx.workdir,
+        naxIgnoreIndex,
         featureDir: ctx.featureDir,
         story: prd.userStories[0],
         stories: prd.userStories,
@@ -131,6 +158,7 @@ export async function executeUnified(
         prd = await loadPRD(ctx.prdPath);
         prdDirty = false;
       }
+      const naxIgnoreIndex = await getRunNaxIgnoreIndex(prd);
       const storyCounts = countStories(prd);
       logger?.debug("execution", "Loop iteration", {
         iteration: iterations,
@@ -151,7 +179,13 @@ export async function executeUnified(
           if (!shouldProceed) return buildResult("pre-merge-aborted");
         }
         logger?.debug("execution", "Running deferred review");
-        deferredReview = await runDeferredReview(ctx.workdir, ctx.config.review, ctx.pluginRegistry, runStartRef);
+        deferredReview = await runDeferredReview(
+          ctx.workdir,
+          ctx.config.review,
+          ctx.pluginRegistry,
+          runStartRef,
+          naxIgnoreIndex,
+        );
         logger?.debug("execution", "Deferred review done — returning completed");
         return buildResult("completed");
       }
@@ -205,6 +239,7 @@ export async function executeUnified(
                 rootConfig: ctx.config,
                 prd,
                 projectDir: ctx.workdir,
+                naxIgnoreIndex,
                 hooks: ctx.hooks,
                 featureDir: ctx.featureDir,
                 agentGetFn: ctx.agentGetFn,

--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -120,6 +120,7 @@ export const verifyStage: PipelineStage = {
         ctx.storyGitRef,
         ctx.story.workdir,
         [...resolvedPatterns.regex],
+        ctx.naxIgnoreIndex,
       );
       if (changedTestFiles.length > 0) {
         logger.info(
@@ -139,6 +140,7 @@ export const verifyStage: PipelineStage = {
           ctx.storyGitRef,
           ctx.story.workdir,
           [...resolvedPatterns.regex],
+          ctx.naxIgnoreIndex,
         );
 
         // Pass 1: path convention mapping — pass packagePrefix and testFilePatterns for language-agnostic suffix derivation.

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -92,6 +92,8 @@ export interface PipelineContext {
    * `projectDir` — never re-join `story.workdir` onto this value.
    */
   workdir: string;
+  /** Run-scoped pre-resolved .naxignore matcher index (repo-root + package-level). */
+  naxIgnoreIndex?: import("../utils/path-filters").NaxIgnoreIndex;
   /** Dependency-preparation context for worktree execution, if one was created. */
   worktreeDependencyContext?: import("../worktree/types").WorktreeDependencyContext;
   /** Absolute path to the prd.json file (used by routing stage to persist initial classification) */

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -28,6 +28,7 @@ import type { UserStory } from "../prd";
 import { AdversarialReviewPromptBuilder } from "../prompts/builders/adversarial-review-builder";
 import { ReviewPromptBuilder } from "../prompts/builders/review-builder";
 import { tryParseLLMJson } from "../utils/llm-json";
+import type { NaxIgnoreIndex } from "../utils/path-filters";
 import { collectDiff, collectDiffStat, computeTestInventory, resolveEffectiveRef } from "./diff-utils";
 import { writeReviewAudit } from "./review-audit";
 import type { AdversarialReviewConfig, ReviewCheckResult, SemanticStory } from "./types";
@@ -143,6 +144,7 @@ export async function runAdversarialReview(
   featureContextMarkdown?: string,
   contextBundle?: import("../context/engine").ContextBundle,
   projectDir?: string,
+  naxIgnoreIndex?: NaxIgnoreIndex,
 ): Promise<ReviewCheckResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -171,7 +173,9 @@ export async function runAdversarialReview(
   // Collect stat summary (used by both modes as a quick overview).
   // In ref mode: stat + ref passed to reviewer; reviewer self-serves the full diff via git tools.
   // In embedded mode: also collect full diff (no excludePatterns — adversarial sees test files).
-  const stat = await collectDiffStat(workdir, effectiveRef);
+  const repoRoot = projectDir ?? workdir;
+  const packageDir = workdir !== repoRoot ? workdir : undefined;
+  const stat = await collectDiffStat(workdir, effectiveRef, { naxIgnoreIndex, packageDir });
 
   if (!stat) {
     return {
@@ -189,7 +193,10 @@ export async function runAdversarialReview(
 
   if (diffMode === "embedded") {
     // Adversarial embedded mode: excludes .nax/ metadata but sees test files (unlike semantic).
-    diff = await collectDiff(workdir, effectiveRef, adversarialConfig.excludePatterns ?? []);
+    diff = await collectDiff(workdir, effectiveRef, adversarialConfig.excludePatterns ?? [], {
+      naxIgnoreIndex,
+      packageDir,
+    });
     if (!diff) {
       return {
         check: "adversarial",
@@ -204,7 +211,7 @@ export async function runAdversarialReview(
       (typeof naxConfig?.execution?.smartTestRunner === "object"
         ? naxConfig.execution.smartTestRunner?.testFilePatterns
         : undefined) ?? undefined;
-    testInventory = await computeTestInventory(workdir, effectiveRef, testFilePatterns);
+    testInventory = await computeTestInventory(workdir, effectiveRef, testFilePatterns, { naxIgnoreIndex, packageDir });
   }
 
   // Resolve agent

--- a/src/review/diff-utils.ts
+++ b/src/review/diff-utils.ts
@@ -9,12 +9,22 @@ import { spawn } from "bun";
 import { getSafeLogger } from "../logger";
 import { isTestFile } from "../test-runners";
 import { getMergeBase, isGitRefValid } from "../utils/git";
+import { filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
 
 /** Maximum diff size in bytes before truncation. 50KB keeps prompts within LLM context. */
 export const DIFF_CAP_BYTES = 51_200;
 
 /** nax metadata paths — always excluded from diffs (never production code). */
 export const ALWAYS_EXCLUDED = [":!.nax/", ":!.nax-pids"];
+
+async function resolveNaxIgnorePathspecExcludes(workdir: string): Promise<string[]> {
+  const matchers = await resolveNaxIgnorePatterns(workdir);
+  const pathspec = new Set<string>();
+  for (const matcher of matchers) {
+    pathspec.add(`:!${matcher.pattern}`);
+  }
+  return [...pathspec];
+}
 
 /** Injectable dependencies for diff-utils — avoids mock.module() in tests. */
 export const _diffUtilsDeps = {
@@ -34,7 +44,8 @@ export interface TestInventory {
  * Always excludes .nax/ and .nax-pids regardless of caller config.
  */
 export async function collectDiff(workdir: string, storyGitRef: string, excludePatterns: string[]): Promise<string> {
-  const merged = [...new Set([...excludePatterns, ...ALWAYS_EXCLUDED])];
+  const naxIgnoreExcludes = await resolveNaxIgnorePathspecExcludes(workdir);
+  const merged = [...new Set([...excludePatterns, ...naxIgnoreExcludes, ...ALWAYS_EXCLUDED])];
   const cmd = ["git", "diff", "--unified=3", `${storyGitRef}..HEAD`, "--", ".", ...merged];
   const proc = _diffUtilsDeps.spawn({
     cmd,
@@ -58,8 +69,10 @@ export async function collectDiff(workdir: string, storyGitRef: string, excludeP
  * always knows which files changed even if content is cut off.
  */
 export async function collectDiffStat(workdir: string, storyGitRef: string): Promise<string> {
+  const naxIgnoreExcludes = await resolveNaxIgnorePathspecExcludes(workdir);
+  const merged = [...new Set([...naxIgnoreExcludes, ...ALWAYS_EXCLUDED])];
   const proc = _diffUtilsDeps.spawn({
-    cmd: ["git", "diff", "--stat", `${storyGitRef}..HEAD`],
+    cmd: ["git", "diff", "--stat", `${storyGitRef}..HEAD`, "--", ".", ...merged],
     cwd: workdir,
     stdout: "pipe",
     stderr: "pipe",
@@ -189,9 +202,11 @@ export async function computeTestInventory(
   }
 
   const addedFiles = stdout.trim().split("\n").filter(Boolean);
+  const ignoreMatchers = await resolveNaxIgnorePatterns(workdir);
+  const visibleAddedFiles = filterNaxInternalPaths(addedFiles, ignoreMatchers);
 
-  const addedTestFiles = addedFiles.filter((f) => isTestFile(f, testFilePatterns));
-  const addedSourceFiles = addedFiles.filter((f) => !isTestFile(f, testFilePatterns));
+  const addedTestFiles = visibleAddedFiles.filter((f) => isTestFile(f, testFilePatterns));
+  const addedSourceFiles = visibleAddedFiles.filter((f) => !isTestFile(f, testFilePatterns));
 
   // For each added source file, check whether a matching test file was also added.
   // Match by basename: src/foo/bar.ts → looks for bar.test.ts, bar.spec.ts in addedFiles.

--- a/src/review/diff-utils.ts
+++ b/src/review/diff-utils.ts
@@ -9,7 +9,7 @@ import { spawn } from "bun";
 import { getSafeLogger } from "../logger";
 import { isTestFile } from "../test-runners";
 import { getMergeBase, isGitRefValid } from "../utils/git";
-import { filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
+import { type NaxIgnoreIndex, filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
 
 /** Maximum diff size in bytes before truncation. 50KB keeps prompts within LLM context. */
 export const DIFF_CAP_BYTES = 51_200;
@@ -17,12 +17,16 @@ export const DIFF_CAP_BYTES = 51_200;
 /** nax metadata paths — always excluded from diffs (never production code). */
 export const ALWAYS_EXCLUDED = [":!.nax/", ":!.nax-pids"];
 
-async function resolveNaxIgnorePathspecExcludes(workdir: string): Promise<string[]> {
-  const matchers = await resolveNaxIgnorePatterns(workdir);
+interface DiffIgnoreOptions {
+  naxIgnoreIndex?: NaxIgnoreIndex;
+  packageDir?: string;
+}
+
+async function resolveNaxIgnorePathspecExcludes(workdir: string, options?: DiffIgnoreOptions): Promise<string[]> {
+  if (options?.naxIgnoreIndex) return options.naxIgnoreIndex.toPathspecExcludes(options.packageDir);
+  const matchers = await resolveNaxIgnorePatterns(workdir, options?.packageDir);
   const pathspec = new Set<string>();
-  for (const matcher of matchers) {
-    pathspec.add(`:!${matcher.pattern}`);
-  }
+  for (const matcher of matchers) pathspec.add(`:!${matcher.pattern}`);
   return [...pathspec];
 }
 
@@ -43,8 +47,13 @@ export interface TestInventory {
  * excludePatterns: pathspec exclusions (e.g. test files for semantic). Pass [] for adversarial (sees all).
  * Always excludes .nax/ and .nax-pids regardless of caller config.
  */
-export async function collectDiff(workdir: string, storyGitRef: string, excludePatterns: string[]): Promise<string> {
-  const naxIgnoreExcludes = await resolveNaxIgnorePathspecExcludes(workdir);
+export async function collectDiff(
+  workdir: string,
+  storyGitRef: string,
+  excludePatterns: string[],
+  options?: DiffIgnoreOptions,
+): Promise<string> {
+  const naxIgnoreExcludes = await resolveNaxIgnorePathspecExcludes(workdir, options);
   const merged = [...new Set([...excludePatterns, ...naxIgnoreExcludes, ...ALWAYS_EXCLUDED])];
   const cmd = ["git", "diff", "--unified=3", `${storyGitRef}..HEAD`, "--", ".", ...merged];
   const proc = _diffUtilsDeps.spawn({
@@ -68,8 +77,12 @@ export async function collectDiff(workdir: string, storyGitRef: string, excludeP
  * Used as a preamble when the full diff is truncated so the reviewer
  * always knows which files changed even if content is cut off.
  */
-export async function collectDiffStat(workdir: string, storyGitRef: string): Promise<string> {
-  const naxIgnoreExcludes = await resolveNaxIgnorePathspecExcludes(workdir);
+export async function collectDiffStat(
+  workdir: string,
+  storyGitRef: string,
+  options?: DiffIgnoreOptions,
+): Promise<string> {
+  const naxIgnoreExcludes = await resolveNaxIgnorePathspecExcludes(workdir, options);
   const merged = [...new Set([...naxIgnoreExcludes, ...ALWAYS_EXCLUDED])];
   const proc = _diffUtilsDeps.spawn({
     cmd: ["git", "diff", "--stat", `${storyGitRef}..HEAD`, "--", ".", ...merged],
@@ -183,6 +196,7 @@ export async function computeTestInventory(
   workdir: string,
   storyGitRef: string,
   testFilePatterns?: readonly string[],
+  options?: DiffIgnoreOptions,
 ): Promise<TestInventory> {
   const proc = _diffUtilsDeps.spawn({
     cmd: ["git", "diff", "--name-only", "--diff-filter=A", `${storyGitRef}..HEAD`],
@@ -202,7 +216,9 @@ export async function computeTestInventory(
   }
 
   const addedFiles = stdout.trim().split("\n").filter(Boolean);
-  const ignoreMatchers = await resolveNaxIgnorePatterns(workdir);
+  const ignoreMatchers =
+    options?.naxIgnoreIndex?.getMatchers(options.packageDir) ??
+    (await resolveNaxIgnorePatterns(workdir, options?.packageDir));
   const visibleAddedFiles = filterNaxInternalPaths(addedFiles, ignoreMatchers);
 
   const addedTestFiles = visibleAddedFiles.filter((f) => isTestFile(f, testFilePatterns));

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -19,7 +19,7 @@ import { getSafeLogger } from "../logger";
 import type { PipelineContext } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins";
 import { errorMessage } from "../utils/errors";
-import { filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
+import { type NaxIgnoreIndex, filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
 import { runAdversarialReview } from "./adversarial";
 import { runReview } from "./runner";
 import type { SemanticStory } from "./semantic";
@@ -136,6 +136,7 @@ export class ReviewOrchestrator {
     contextBundles?: { semantic?: ContextBundle; adversarial?: ContextBundle },
     projectDir?: string,
     env?: Record<string, string | undefined>,
+    naxIgnoreIndex?: NaxIgnoreIndex,
   ): Promise<OrchestratorReviewResult> {
     const logger = getSafeLogger();
 
@@ -198,6 +199,7 @@ export class ReviewOrchestrator {
         contextBundles,
         projectDir,
         env,
+        naxIgnoreIndex,
       );
     } else {
       // Always split: mechanical checks first, then LLM checks independently.
@@ -229,6 +231,7 @@ export class ReviewOrchestrator {
         contextBundles,
         projectDir,
         env,
+        naxIgnoreIndex,
       );
 
       // Step 2: Run LLM checks regardless of mechanical result (fail-fast within LLM).
@@ -282,6 +285,7 @@ export class ReviewOrchestrator {
             featureContextMarkdown,
             contextBundles?.semantic,
             projectDir,
+            naxIgnoreIndex,
           ),
           _orchestratorDeps.runAdversarialReview(
             workdir,
@@ -296,6 +300,7 @@ export class ReviewOrchestrator {
             featureContextMarkdown,
             contextBundles?.adversarial,
             projectDir,
+            naxIgnoreIndex,
           ),
         ]);
         llmCheckResults = [semResult, advResult];
@@ -321,6 +326,7 @@ export class ReviewOrchestrator {
           contextBundles,
           undefined,
           env,
+          naxIgnoreIndex,
         );
         llmCheckResults = llmResult.checks;
       }
@@ -402,7 +408,8 @@ export class ReviewOrchestrator {
         const changedFiles = await getChangedFiles(workdir, baseRef);
         const repoRoot = projectDir ?? workdir;
         const packageDir = scopePrefix ? join(repoRoot, scopePrefix) : undefined;
-        const ignoreMatchers = await resolveNaxIgnorePatterns(repoRoot, packageDir);
+        const ignoreMatchers =
+          naxIgnoreIndex?.getMatchers(packageDir) ?? (await resolveNaxIgnorePatterns(repoRoot, packageDir));
         const visibleChangedFiles = filterNaxInternalPaths(changedFiles, ignoreMatchers);
         const scopedFiles = scopePrefix
           ? visibleChangedFiles.filter((f) => f === scopePrefix || f.startsWith(`${scopePrefix}/`))
@@ -518,6 +525,7 @@ export class ReviewOrchestrator {
       contextBundles,
       ctx.projectDir,
       ctx.worktreeDependencyContext?.env,
+      ctx.naxIgnoreIndex,
     );
   }
 }

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -8,6 +8,7 @@
  *   const result = await reviewOrchestrator.review(config, workdir, executionConfig, plugins);
  */
 
+import { join } from "node:path";
 import { spawn } from "bun";
 import type { AgentAdapter } from "../agents/types";
 import type { NaxConfig } from "../config";
@@ -18,6 +19,7 @@ import { getSafeLogger } from "../logger";
 import type { PipelineContext } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins";
 import { errorMessage } from "../utils/errors";
+import { filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
 import { runAdversarialReview } from "./adversarial";
 import { runReview } from "./runner";
 import type { SemanticStory } from "./semantic";
@@ -398,9 +400,13 @@ export class ReviewOrchestrator {
         // Use the story's start ref if available to capture auto-committed changes
         const baseRef = storyGitRef ?? executionConfig?.storyGitRef;
         const changedFiles = await getChangedFiles(workdir, baseRef);
+        const repoRoot = projectDir ?? workdir;
+        const packageDir = scopePrefix ? join(repoRoot, scopePrefix) : undefined;
+        const ignoreMatchers = await resolveNaxIgnorePatterns(repoRoot, packageDir);
+        const visibleChangedFiles = filterNaxInternalPaths(changedFiles, ignoreMatchers);
         const scopedFiles = scopePrefix
-          ? changedFiles.filter((f) => f === scopePrefix || f.startsWith(`${scopePrefix}/`))
-          : changedFiles;
+          ? visibleChangedFiles.filter((f) => f === scopePrefix || f.startsWith(`${scopePrefix}/`))
+          : visibleChangedFiles;
         const pluginResults: ReviewResult["pluginReviewers"] = [];
 
         for (const reviewer of reviewers) {

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -11,6 +11,7 @@ import type { ModelTier } from "../config/schema-types";
 import { getSafeLogger } from "../logger";
 import { runQualityCommand } from "../quality";
 import { autoCommitIfDirty } from "../utils/git";
+import type { NaxIgnoreIndex } from "../utils/path-filters";
 import { runAdversarialReview as _runAdversarialReviewImpl } from "./adversarial";
 import { resolveLanguageCommand } from "./language-commands";
 import { runSemanticReview as _runSemanticReviewImpl } from "./semantic";
@@ -224,6 +225,7 @@ export async function runReview(
   },
   projectDir?: string,
   env?: Record<string, string | undefined>,
+  naxIgnoreIndex?: NaxIgnoreIndex,
 ): Promise<ReviewResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -309,6 +311,7 @@ export async function runReview(
         featureContextMarkdown,
         contextBundles?.semantic,
         projectDir,
+        naxIgnoreIndex,
       );
       checks.push(result);
       if (!result.success && !firstFailure) {
@@ -351,6 +354,7 @@ export async function runReview(
         featureContextMarkdown,
         contextBundles?.adversarial,
         projectDir,
+        naxIgnoreIndex,
       );
       checks.push(result);
       if (!result.success && !firstFailure) {

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -24,6 +24,7 @@ import type { UserStory } from "../prd";
 import { ReviewPromptBuilder } from "../prompts";
 import { resolveReviewExcludePatterns, resolveTestFilePatterns } from "../test-runners";
 import { tryParseLLMJson } from "../utils/llm-json";
+import type { NaxIgnoreIndex } from "../utils/path-filters";
 import { DIFF_CAP_BYTES, collectDiff, collectDiffStat, resolveEffectiveRef, truncateDiff } from "./diff-utils";
 import { writeReviewAudit } from "./review-audit";
 import type { ReviewCheckResult, SemanticReviewConfig, SemanticStory } from "./types";
@@ -144,6 +145,7 @@ export async function runSemanticReview(
   featureContextMarkdown?: string,
   contextBundle?: import("../context/engine").ContextBundle,
   projectDir?: string,
+  naxIgnoreIndex?: NaxIgnoreIndex,
 ): Promise<ReviewCheckResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -179,7 +181,9 @@ export async function runSemanticReview(
   // Collect stat summary (used by both modes).
   // In embedded mode: also collect full diff, truncate if needed.
   // In ref mode: pass stat + ref to reviewer; reviewer self-serves the full diff via tools.
-  const stat = await collectDiffStat(workdir, effectiveRef);
+  const repoRoot = projectDir ?? workdir;
+  const packageDir = workdir !== repoRoot ? workdir : undefined;
+  const stat = await collectDiffStat(workdir, effectiveRef, { naxIgnoreIndex, packageDir });
 
   // ADR-009: resolve effective exclude patterns from config (falls back to DEFAULT_TEST_FILE_PATTERNS
   // when semanticConfig.excludePatterns is undefined — no behaviour change for default config).
@@ -188,7 +192,7 @@ export async function runSemanticReview(
 
   let diff: string | undefined;
   if (diffMode === "embedded") {
-    const rawDiff = await collectDiff(workdir, effectiveRef, excludePatterns);
+    const rawDiff = await collectDiff(workdir, effectiveRef, excludePatterns, { naxIgnoreIndex, packageDir });
     diff = truncateDiff(rawDiff, rawDiff.length > DIFF_CAP_BYTES ? stat : undefined);
     if (!diff) {
       return {

--- a/src/utils/path-filters.ts
+++ b/src/utils/path-filters.ts
@@ -39,6 +39,17 @@ export interface NaxIgnoreMatcher {
   readonly test: (repoRelativePath: string) => boolean;
 }
 
+export interface NaxIgnoreIndex {
+  /** Absolute repo-root path used to build this index. */
+  readonly repoRoot: string;
+  /** Return pre-resolved matchers for repo root or a known package directory. */
+  getMatchers(packageDir?: string): readonly NaxIgnoreMatcher[];
+  /** Filter changed paths using built-ins + pre-resolved matchers. */
+  filter(paths: readonly string[], packageDir?: string): string[];
+  /** Convert pre-resolved matchers into git pathspec exclusion args. */
+  toPathspecExcludes(packageDir?: string): string[];
+}
+
 export const _pathFilterDeps = {
   fileExists: async (path: string): Promise<boolean> => Bun.file(path).exists(),
   readFile: async (path: string): Promise<string> => Bun.file(path).text(),
@@ -127,6 +138,10 @@ async function readIgnorePatterns(filePath: string): Promise<string[]> {
   return parseIgnoreFile(raw);
 }
 
+function normalizeAbsolutePath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/\/+$/, "");
+}
+
 /**
  * Resolve `.naxignore` patterns for session-history changed-file filtering.
  *
@@ -151,6 +166,45 @@ export async function resolveNaxIgnorePatterns(repoRoot: string, packageDir?: st
     ...rootPatterns.map((p) => compileMatcher("root", p, packagePrefix)),
     ...packagePatterns.map((p) => compileMatcher("package", p, packagePrefix)),
   ];
+}
+
+/**
+ * Build a pre-resolved `.naxignore` index for a run.
+ *
+ * Single-package repos: resolve once for `repoRoot`.
+ * Monorepos: resolve once for `repoRoot` and each provided package dir.
+ */
+export async function buildNaxIgnoreIndex(
+  repoRoot: string,
+  packageDirs: readonly string[] = [],
+): Promise<NaxIgnoreIndex> {
+  const repoRootKey = normalizeAbsolutePath(repoRoot);
+  const uniquePackageDirs = [...new Set(packageDirs.map(normalizeAbsolutePath).filter((p) => p !== repoRootKey))];
+
+  const entries = new Map<string, readonly NaxIgnoreMatcher[]>();
+  entries.set(repoRootKey, await resolveNaxIgnorePatterns(repoRootKey));
+  for (const packageDir of uniquePackageDirs) {
+    entries.set(packageDir, await resolveNaxIgnorePatterns(repoRootKey, packageDir));
+  }
+
+  const getMatchers = (packageDir?: string): readonly NaxIgnoreMatcher[] => {
+    if (!packageDir) return entries.get(repoRootKey) ?? [];
+    const key = normalizeAbsolutePath(packageDir);
+    return entries.get(key) ?? entries.get(repoRootKey) ?? [];
+  };
+
+  return {
+    repoRoot: repoRootKey,
+    getMatchers,
+    filter: (paths: readonly string[], packageDir?: string): string[] =>
+      filterNaxInternalPaths(paths, getMatchers(packageDir)),
+    toPathspecExcludes: (packageDir?: string): string[] => {
+      const matchers = getMatchers(packageDir);
+      const excludes = new Set<string>();
+      for (const matcher of matchers ?? []) excludes.add(`:!${matcher.pattern}`);
+      return [...excludes];
+    },
+  };
 }
 
 /**

--- a/src/utils/path-filters.ts
+++ b/src/utils/path-filters.ts
@@ -9,6 +9,8 @@
  * See: #542
  */
 
+import { join, relative } from "node:path";
+
 /**
  * Package-manager lockfiles — high-churn machine-generated files that add no
  * signal to an agent reviewing "what did the previous session change?".
@@ -29,10 +31,126 @@ const LOCKFILE_BASENAMES = new Set<string>([
   "Gemfile.lock",
 ]);
 
+const NAX_IGNORE_FILENAME = ".naxignore";
+
+export interface NaxIgnoreMatcher {
+  readonly source: "root" | "package";
+  readonly pattern: string;
+  readonly test: (repoRelativePath: string) => boolean;
+}
+
+export const _pathFilterDeps = {
+  fileExists: async (path: string): Promise<boolean> => Bun.file(path).exists(),
+  readFile: async (path: string): Promise<string> => Bun.file(path).text(),
+};
+
 function basename(path: string): string {
   const stripped = path.startsWith("./") ? path.slice(2) : path;
   const idx = stripped.lastIndexOf("/");
   return idx === -1 ? stripped : stripped.slice(idx + 1);
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "").replace(/^\/+/, "");
+}
+
+function globToRegex(pattern: string): RegExp {
+  let regex = "";
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i];
+    if (c === "*") {
+      if (pattern[i + 1] === "*") {
+        const beforeSlash = i > 0 && pattern[i - 1] === "/";
+        const afterSlash = pattern[i + 2] === "/";
+        if (beforeSlash && afterSlash) {
+          regex = `${regex.slice(0, -1)}(?:.*\\/)?`;
+          i += 3;
+        } else if (afterSlash) {
+          regex += "(?:.*\\/)?";
+          i += 3;
+        } else {
+          regex += ".*";
+          i += 2;
+        }
+        continue;
+      }
+      regex += "[^/]*";
+      i++;
+      continue;
+    }
+    if (c === "?") {
+      regex += "[^/]";
+      i++;
+      continue;
+    }
+    if (".+^${}()|[]\\".includes(c)) {
+      regex += `\\${c}`;
+    } else {
+      regex += c;
+    }
+    i++;
+  }
+  return new RegExp(`(?:^|/)${regex}$`);
+}
+
+function parseIgnoreFile(raw: string): string[] {
+  const patterns: string[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const normalized = normalizePath(trimmed.endsWith("/") ? `${trimmed}**` : trimmed);
+    if (normalized) patterns.push(normalized);
+  }
+  return patterns;
+}
+
+function compileMatcher(source: "root" | "package", pattern: string, packagePrefix: string | null): NaxIgnoreMatcher {
+  const regex = globToRegex(pattern);
+  return {
+    source,
+    pattern,
+    test: (repoRelativePath: string): boolean => {
+      const normalized = normalizePath(repoRelativePath);
+      if (regex.test(normalized)) return true;
+      if (source === "root" && packagePrefix) {
+        return regex.test(`${packagePrefix}/${normalized}`);
+      }
+      return false;
+    },
+  };
+}
+
+async function readIgnorePatterns(filePath: string): Promise<string[]> {
+  if (!(await _pathFilterDeps.fileExists(filePath))) return [];
+  const raw = await _pathFilterDeps.readFile(filePath);
+  return parseIgnoreFile(raw);
+}
+
+/**
+ * Resolve `.naxignore` patterns for session-history changed-file filtering.
+ *
+ * Resolution order:
+ *   1. root `<repoRoot>/.naxignore`
+ *   2. package `<packageDir>/.naxignore` (when packageDir differs from repoRoot)
+ */
+export async function resolveNaxIgnorePatterns(repoRoot: string, packageDir?: string): Promise<NaxIgnoreMatcher[]> {
+  const normalizedRepoRoot = normalizePath(repoRoot);
+  const normalizedPackageDir = packageDir ? normalizePath(packageDir) : normalizedRepoRoot;
+  const packagePrefix =
+    normalizedPackageDir !== normalizedRepoRoot ? normalizePath(relative(repoRoot, packageDir ?? repoRoot)) : null;
+
+  const rootFile = join(repoRoot, NAX_IGNORE_FILENAME);
+  const packageFile = join(packageDir ?? repoRoot, NAX_IGNORE_FILENAME);
+
+  const rootPatterns = await readIgnorePatterns(rootFile);
+  const packagePatterns =
+    packageDir && packageDir !== repoRoot ? await readIgnorePatterns(packageFile) : ([] as string[]);
+
+  return [
+    ...rootPatterns.map((p) => compileMatcher("root", p, packagePrefix)),
+    ...packagePatterns.map((p) => compileMatcher("package", p, packagePrefix)),
+  ];
 }
 
 /**
@@ -58,6 +176,9 @@ export function isNaxInternalPath(path: string): boolean {
  * Filter a list of changed files, removing nax-internal bookkeeping entries.
  * Preserves order and does not mutate the input array.
  */
-export function filterNaxInternalPaths(paths: readonly string[]): string[] {
-  return paths.filter((p) => !isNaxInternalPath(p));
+export function filterNaxInternalPaths(
+  paths: readonly string[],
+  ignoreMatchers: readonly NaxIgnoreMatcher[] = [],
+): string[] {
+  return paths.filter((path) => !isNaxInternalPath(path) && !ignoreMatchers.some((matcher) => matcher.test(path)));
 }

--- a/src/verification/orchestrator-types.ts
+++ b/src/verification/orchestrator-types.ts
@@ -9,6 +9,7 @@
 
 import type { NaxConfig } from "../config";
 import type { SmartTestRunnerConfig } from "../config/types";
+import type { NaxIgnoreIndex } from "../utils/path-filters";
 
 // ---------------------------------------------------------------------------
 // Strategy enum
@@ -33,6 +34,7 @@ export interface VerifyContext {
   acceptOnTimeout?: boolean;
   acceptanceTestPath?: string;
   config?: NaxConfig;
+  naxIgnoreIndex?: NaxIgnoreIndex;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -13,7 +13,7 @@
 import { join } from "node:path";
 import { DEFAULT_SEPARATED_TEST_DIRS, DEFAULT_TEST_FILE_PATTERNS } from "../test-runners/conventions";
 import { gitWithTimeout } from "../utils/git";
-import { filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
+import { type NaxIgnoreIndex, filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
 
 /**
  * Bun API wrappers — defined before functions to avoid circular type inference.
@@ -282,6 +282,7 @@ export async function getChangedNonTestFiles(
   baseRef?: string,
   packagePrefix?: string,
   testFileRegex: RegExp[] = [],
+  naxIgnoreIndex?: NaxIgnoreIndex,
 ): Promise<string[]> {
   try {
     // FEAT-010: Use per-attempt baseRef for precise diff; fall back to HEAD~1 if not provided
@@ -292,7 +293,8 @@ export async function getChangedNonTestFiles(
 
     const lines = stdout.trim().split("\n").filter(Boolean);
     const packageDir = packagePrefix ? join(workdir, packagePrefix) : undefined;
-    const ignoreMatchers = await resolveNaxIgnorePatterns(workdir, packageDir);
+    const ignoreMatchers =
+      naxIgnoreIndex?.getMatchers(packageDir) ?? (await resolveNaxIgnorePatterns(workdir, packageDir));
 
     const scopedRaw = packagePrefix ? lines.filter((f) => f.startsWith(`${packagePrefix}/`)) : lines;
     const scoped = filterNaxInternalPaths(scopedRaw, ignoreMatchers);
@@ -328,6 +330,7 @@ export async function getChangedTestFiles(
   baseRef?: string,
   packagePrefix?: string,
   testFileRegex: RegExp[] = [],
+  naxIgnoreIndex?: NaxIgnoreIndex,
 ): Promise<string[]> {
   if (testFileRegex.length === 0) return [];
   try {
@@ -337,7 +340,8 @@ export async function getChangedTestFiles(
 
     const lines = stdout.trim().split("\n").filter(Boolean);
     const packageDir = packagePrefix ? join(repoRoot, packagePrefix) : undefined;
-    const ignoreMatchers = await resolveNaxIgnorePatterns(repoRoot, packageDir);
+    const ignoreMatchers =
+      naxIgnoreIndex?.getMatchers(packageDir) ?? (await resolveNaxIgnorePatterns(repoRoot, packageDir));
 
     // Scope to package directory — covers both co-located (src/) and separated (test/) layouts
     const scopedRaw = packagePrefix ? lines.filter((f) => f.startsWith(`${packagePrefix}/`)) : lines;

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -13,6 +13,7 @@
 import { join } from "node:path";
 import { DEFAULT_SEPARATED_TEST_DIRS, DEFAULT_TEST_FILE_PATTERNS } from "../test-runners/conventions";
 import { gitWithTimeout } from "../utils/git";
+import { filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
 
 /**
  * Bun API wrappers — defined before functions to avoid circular type inference.
@@ -290,8 +291,11 @@ export async function getChangedNonTestFiles(
     if (exitCode !== 0) return [];
 
     const lines = stdout.trim().split("\n").filter(Boolean);
+    const packageDir = packagePrefix ? join(workdir, packagePrefix) : undefined;
+    const ignoreMatchers = await resolveNaxIgnorePatterns(workdir, packageDir);
 
-    const scoped = packagePrefix ? lines.filter((f) => f.startsWith(`${packagePrefix}/`)) : lines;
+    const scopedRaw = packagePrefix ? lines.filter((f) => f.startsWith(`${packagePrefix}/`)) : lines;
+    const scoped = filterNaxInternalPaths(scopedRaw, ignoreMatchers);
     if (testFileRegex.length === 0) return scoped;
     return scoped.filter((f) => !testFileRegex.some((re) => re.test(f)));
   } catch {
@@ -332,9 +336,12 @@ export async function getChangedTestFiles(
     if (exitCode !== 0) return [];
 
     const lines = stdout.trim().split("\n").filter(Boolean);
+    const packageDir = packagePrefix ? join(repoRoot, packagePrefix) : undefined;
+    const ignoreMatchers = await resolveNaxIgnorePatterns(repoRoot, packageDir);
 
     // Scope to package directory — covers both co-located (src/) and separated (test/) layouts
-    const scoped = packagePrefix ? lines.filter((f) => f.startsWith(`${packagePrefix}/`)) : lines;
+    const scopedRaw = packagePrefix ? lines.filter((f) => f.startsWith(`${packagePrefix}/`)) : lines;
+    const scoped = filterNaxInternalPaths(scopedRaw, ignoreMatchers);
     return scoped.filter((f) => testFileRegex.some((re) => re.test(f))).map((f) => join(repoRoot, f));
   } catch {
     return [];

--- a/src/verification/strategies/scoped.ts
+++ b/src/verification/strategies/scoped.ts
@@ -74,6 +74,7 @@ export class ScopedStrategy implements IVerificationStrategy {
         ctx.storyGitRef,
         undefined,
         globsToTestRegex(smartCfg.testFilePatterns),
+        ctx.naxIgnoreIndex,
       );
       const threshold = ctx.config?.quality?.scopeTestThreshold ?? 10;
       const pass1Files = await _scopedDeps.mapSourceToTests(nonTestFiles, ctx.workdir);

--- a/test/unit/context/engine/providers/session-scratch.test.ts
+++ b/test/unit/context/engine/providers/session-scratch.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { SessionScratchProvider, _sessionScratchDeps } from "../../../../../src/context/engine/providers/session-scratch";
 import type { ContextRequest } from "../../../../../src/context/engine/types";
+import { _pathFilterDeps } from "../../../../../src/utils/path-filters";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixtures
@@ -56,15 +57,21 @@ const TDD_ENTRY = JSON.stringify({
 
 let origFileExists: typeof _sessionScratchDeps.fileExists;
 let origReadFile: typeof _sessionScratchDeps.readFile;
+let origPathFilterFileExists: typeof _pathFilterDeps.fileExists;
+let origPathFilterReadFile: typeof _pathFilterDeps.readFile;
 
 beforeEach(() => {
   origFileExists = _sessionScratchDeps.fileExists;
   origReadFile = _sessionScratchDeps.readFile;
+  origPathFilterFileExists = _pathFilterDeps.fileExists;
+  origPathFilterReadFile = _pathFilterDeps.readFile;
 });
 
 afterEach(() => {
   _sessionScratchDeps.fileExists = origFileExists;
   _sessionScratchDeps.readFile = origReadFile;
+  _pathFilterDeps.fileExists = origPathFilterFileExists;
+  _pathFilterDeps.readFile = origPathFilterReadFile;
 });
 
 function mockScratchFile(content: string) {
@@ -76,11 +83,20 @@ function mockNoFile() {
   _sessionScratchDeps.fileExists = async () => false;
 }
 
+function mockNoIgnoreFile() {
+  _pathFilterDeps.fileExists = async () => false;
+  _pathFilterDeps.readFile = async () => "";
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("SessionScratchProvider", () => {
+  beforeEach(() => {
+    mockNoIgnoreFile();
+  });
+
   test("id and kind are correct", () => {
     const provider = new SessionScratchProvider();
     expect(provider.id).toBe("session-scratch");
@@ -149,6 +165,32 @@ describe("SessionScratchProvider", () => {
     expect(result.chunks[0].content).toContain("TDD implementer");
     expect(result.chunks[0].content).toContain("src/index.ts");
     expect(result.chunks[0].content).toContain("edge-case handling");
+  });
+
+  test("applies .naxignore filters to TDD changed-file listing", async () => {
+    const ignoreFiles = new Map<string, string>([
+      ["/repo/.naxignore", "*.generated.ts\ncoverage/\n"],
+    ]);
+    _pathFilterDeps.fileExists = async (path) => ignoreFiles.has(path);
+    _pathFilterDeps.readFile = async (path) => ignoreFiles.get(path) ?? "";
+    const entry = JSON.stringify({
+      kind: "tdd-session",
+      timestamp: "2026-01-01T00:02:00.000Z",
+      storyId: "US-001",
+      stage: "tdd-implementer",
+      role: "implementer",
+      success: true,
+      filesChanged: ["src/index.ts", "src/types.generated.ts", "coverage/lcov.info"],
+      outputTail: "updated files",
+    });
+    mockScratchFile(`${entry}\n`);
+    const provider = new SessionScratchProvider();
+    const result = await provider.fetch(makeRequest({ storyScratchDirs: ["/sess/dir"] }));
+
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0].content).toContain("src/index.ts");
+    expect(result.chunks[0].content).not.toContain("src/types.generated.ts");
+    expect(result.chunks[0].content).not.toContain("coverage/lcov.info");
   });
 
   test("skips malformed JSONL lines without throwing", async () => {

--- a/test/unit/pipeline/verify-smart-runner.test.ts
+++ b/test/unit/pipeline/verify-smart-runner.test.ts
@@ -222,7 +222,13 @@ describe("Verify Stage --- Smart Runner Integration", () => {
       const ctx = makeContext({ smartTestRunner: true });
       await verifyStage.execute(ctx);
 
-      expect(mockGetChangedNonTestFiles).toHaveBeenCalledWith("/test/workdir", undefined, undefined, expect.any(Array));
+      expect(mockGetChangedNonTestFiles).toHaveBeenCalledWith(
+        "/test/workdir",
+        undefined,
+        undefined,
+        expect.any(Array),
+        undefined,
+      );
     });
 
     test("calls mapSourceToTests with changed files, workdir, and undefined packagePrefix for single-package story", async () => {

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -491,6 +491,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
       undefined, // featureContextMarkdown
       undefined, // contextBundles?.semantic (v2)
       undefined, // projectDir
+      undefined, // naxIgnoreIndex
     );
   });
 
@@ -528,6 +529,7 @@ describe("runReview — semantic check integration (AC-9)", () => {
       undefined, // featureContextMarkdown
       undefined, // contextBundles?.semantic (v2)
       undefined, // projectDir
+      undefined, // naxIgnoreIndex
     );
   });
 });

--- a/test/unit/utils/path-filters.test.ts
+++ b/test/unit/utils/path-filters.test.ts
@@ -1,7 +1,25 @@
-import { describe, expect, test } from "bun:test";
-import { filterNaxInternalPaths, isNaxInternalPath } from "../../../src/utils/path-filters";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  _pathFilterDeps,
+  filterNaxInternalPaths,
+  isNaxInternalPath,
+  resolveNaxIgnorePatterns,
+} from "../../../src/utils/path-filters";
 
 describe("path-filters (#542)", () => {
+  let origFileExists: typeof _pathFilterDeps.fileExists;
+  let origReadFile: typeof _pathFilterDeps.readFile;
+
+  beforeEach(() => {
+    origFileExists = _pathFilterDeps.fileExists;
+    origReadFile = _pathFilterDeps.readFile;
+  });
+
+  afterEach(() => {
+    _pathFilterDeps.fileExists = origFileExists;
+    _pathFilterDeps.readFile = origReadFile;
+  });
+
   describe("isNaxInternalPath", () => {
     test.each([
       [".nax/cache/test-patterns.json", true],
@@ -64,6 +82,63 @@ describe("path-filters (#542)", () => {
       const snapshot = [...input];
       filterNaxInternalPaths(input);
       expect(input).toEqual(snapshot);
+    });
+
+    test("drops files matching resolved .naxignore patterns", async () => {
+      const files = new Map<string, string>([
+        ["/repo/.naxignore", "*.generated.ts\ncoverage/\n"],
+      ]);
+      _pathFilterDeps.fileExists = async (path) => files.has(path);
+      _pathFilterDeps.readFile = async (path) => files.get(path) ?? "";
+
+      const matchers = await resolveNaxIgnorePatterns("/repo");
+      const input = ["src/app.ts", "src/types.generated.ts", "coverage/lcov.info"];
+      expect(filterNaxInternalPaths(input, matchers)).toEqual(["src/app.ts"]);
+    });
+  });
+
+  describe("resolveNaxIgnorePatterns (#550)", () => {
+    test("loads root patterns and ignores comments/blank lines", async () => {
+      const files = new Map<string, string>([
+        ["/repo/.naxignore", "# comment\n\n*.generated.ts\nlocales/en.json\n"],
+      ]);
+      _pathFilterDeps.fileExists = async (path) => files.has(path);
+      _pathFilterDeps.readFile = async (path) => files.get(path) ?? "";
+
+      const matchers = await resolveNaxIgnorePatterns("/repo");
+      expect(matchers).toHaveLength(2);
+      expect(matchers.every((m) => m.source === "root")).toBe(true);
+      expect(matchers.some((m) => m.test("src/foo.generated.ts"))).toBe(true);
+      expect(matchers.some((m) => m.test("locales/en.json"))).toBe(true);
+    });
+
+    test("merges root then package patterns for monorepo package", async () => {
+      const files = new Map<string, string>([
+        ["/repo/.naxignore", "*.generated.ts\n"],
+        ["/repo/packages/web/.naxignore", "dist/\nassets/tmp/**\n"],
+      ]);
+      _pathFilterDeps.fileExists = async (path) => files.has(path);
+      _pathFilterDeps.readFile = async (path) => files.get(path) ?? "";
+
+      const matchers = await resolveNaxIgnorePatterns("/repo", "/repo/packages/web");
+      expect(matchers).toHaveLength(3);
+      expect(matchers[0]?.source).toBe("root");
+      expect(matchers[1]?.source).toBe("package");
+      expect(matchers[2]?.source).toBe("package");
+      expect(matchers.some((m) => m.test("src/foo.generated.ts"))).toBe(true);
+      expect(matchers.some((m) => m.test("dist/index.js"))).toBe(true);
+    });
+
+    test("allows root patterns with package prefixes to match package-relative paths", async () => {
+      const files = new Map<string, string>([
+        ["/repo/.naxignore", "packages/web/locales/en.json\n"],
+      ]);
+      _pathFilterDeps.fileExists = async (path) => files.has(path);
+      _pathFilterDeps.readFile = async (path) => files.get(path) ?? "";
+
+      const matchers = await resolveNaxIgnorePatterns("/repo", "/repo/packages/web");
+      expect(matchers).toHaveLength(1);
+      expect(matchers[0]?.test("locales/en.json")).toBe(true);
     });
   });
 });

--- a/test/unit/utils/path-filters.test.ts
+++ b/test/unit/utils/path-filters.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   _pathFilterDeps,
+  buildNaxIgnoreIndex,
   filterNaxInternalPaths,
   isNaxInternalPath,
   resolveNaxIgnorePatterns,
@@ -139,6 +140,33 @@ describe("path-filters (#542)", () => {
       const matchers = await resolveNaxIgnorePatterns("/repo", "/repo/packages/web");
       expect(matchers).toHaveLength(1);
       expect(matchers[0]?.test("locales/en.json")).toBe(true);
+    });
+  });
+
+  describe("buildNaxIgnoreIndex", () => {
+    test("pre-resolves repo-root and package matchers", async () => {
+      const files = new Map<string, string>([
+        ["/repo/.naxignore", "*.generated.ts\n"],
+        ["/repo/packages/web/.naxignore", "dist/\n"],
+      ]);
+      _pathFilterDeps.fileExists = async (path) => files.has(path);
+      _pathFilterDeps.readFile = async (path) => files.get(path) ?? "";
+
+      const index = await buildNaxIgnoreIndex("/repo", ["/repo/packages/web"]);
+      expect(index.getMatchers()).toHaveLength(1);
+      expect(index.getMatchers("/repo/packages/web")).toHaveLength(2);
+      expect(index.filter(["src/foo.generated.ts", "src/main.ts"], "/repo/packages/web")).toEqual(["src/main.ts"]);
+      expect(index.filter(["dist/app.js", "src/main.ts"], "/repo/packages/web")).toEqual(["src/main.ts"]);
+    });
+
+    test("returns root matchers for unknown package dir", async () => {
+      const files = new Map<string, string>([["/repo/.naxignore", "*.generated.ts\n"]]);
+      _pathFilterDeps.fileExists = async (path) => files.has(path);
+      _pathFilterDeps.readFile = async (path) => files.get(path) ?? "";
+
+      const index = await buildNaxIgnoreIndex("/repo", []);
+      expect(index.filter(["src/foo.generated.ts", "src/main.ts"], "/repo/packages/unknown")).toEqual(["src/main.ts"]);
+      expect(index.toPathspecExcludes()).toEqual([":!*.generated.ts"]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add `.naxignore` resolution + matcher support in `path-filters`
- apply `.naxignore` filtering in Session History (`SessionScratchProvider`)
- extend `.naxignore` filtering to additional changed-file consumers:
  - acceptance regeneration implementation context
  - review diff/stat collection and review test-inventory inputs
  - plugin reviewer changed-file inputs (per-story + deferred)
  - smart-runner changed-file detection (non-test + test file discovery)
- keep built-in nax-internal exclusions (`.nax/`, lockfiles) as always-on filtering

## Tests
- `bun run typecheck`
- `bun run lint`
- `bun test test/unit/utils/path-filters.test.ts test/unit/context/engine/providers/session-scratch.test.ts test/unit/review/diff-utils.test.ts test/unit/review/orchestrator.test.ts test/unit/execution/deferred-review.test.ts test/unit/execution/lifecycle/acceptance-loop.test.ts test/unit/verification/smart-runner.test.ts --timeout=60000`

Closes #550