### PR TITLE
feat(session): ADR-013 Phase 2 — move session-error retry to SessionManager + fix Gap A

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -127,13 +127,6 @@ export const _acpAdapterDeps = {
   sleep,
 
   /**
-   * Whether to retry when a session error (stopReason=error) is detected.
-   * Default: true (production retry safety net).
-   * Tests override to false to prevent mock callIndex drift from retries.
-   */
-  shouldRetrySessionError: true,
-
-  /**
    * Create an ACP client for the given command string.
    * Default: spawn-based client (shells out to acpx CLI).
    * Override in tests via: _acpAdapterDeps.createClient = mock(...)
@@ -450,10 +443,6 @@ export class AcpAgentAdapter implements AgentAdapter {
 
   async run(options: AgentRunOptions): Promise<AgentResult> {
     const startTime = Date.now();
-    const config = options.config;
-    const SESSION_ERROR_MAX_RETRIES = config?.execution?.sessionErrorMaxRetries ?? 1;
-    const SESSION_ERROR_RETRYABLE_MAX_RETRIES = config?.execution?.sessionErrorRetryableMaxRetries ?? 3;
-    let sessionErrorRetries = 0;
 
     getSafeLogger()?.debug("acp-adapter", `Starting run for ${this.name}`, {
       model: options.modelDef.model,
@@ -463,138 +452,81 @@ export class AcpAgentAdapter implements AgentAdapter {
       sessionRole: options.sessionRole,
     });
 
-    while (true) {
-      // Fix for v0.63.0-canary.8 Issue 5: honour the shutdown abort signal
-      // BEFORE issuing any new work. Without this, hitting Ctrl+C while the
-      // adapter is in its session-error retry path would spawn a fresh acpx
-      // session during shutdown, register a new PID, and race with teardown.
-      if (options.abortSignal?.aborted) {
-        getSafeLogger()?.warn("acp-adapter", `Run aborted for ${this.name} (shutdown in progress)`, {
-          storyId: options.storyId,
-          featureName: options.featureName,
+    // Honour the shutdown abort signal before issuing any new work.
+    // Without this, hitting Ctrl+C could spawn a fresh acpx session during
+    // shutdown and race with teardown.
+    if (options.abortSignal?.aborted) {
+      getSafeLogger()?.warn("acp-adapter", `Run aborted for ${this.name} (shutdown in progress)`, {
+        storyId: options.storyId,
+        featureName: options.featureName,
+      });
+      return {
+        success: false,
+        exitCode: 130,
+        output: "Run aborted — shutdown in progress",
+        rateLimited: false,
+        durationMs: Date.now() - startTime,
+        estimatedCost: 0,
+        adapterFailure: {
+          category: "availability",
+          outcome: "fail-aborted",
+          retriable: false,
+          message: "Run aborted — shutdown in progress",
+        },
+      };
+    }
+
+    try {
+      const result = await this._runWithClient(options, startTime, this.name);
+
+      if (!result.success) {
+        getSafeLogger()?.warn("acp-adapter", `Run failed for ${this.name}`, {
+          exitCode: result.exitCode,
+          ...(result.output ? { output: result.output.slice(0, 500) } : {}),
         });
-        return {
-          success: false,
-          exitCode: 130,
-          output: "Run aborted — shutdown in progress",
-          rateLimited: false,
-          durationMs: Date.now() - startTime,
-          estimatedCost: 0,
-          adapterFailure: {
-            category: "availability",
-            outcome: "fail-aborted",
-            retriable: false,
-            message: "Run aborted — shutdown in progress",
-          },
-        };
-      }
-      try {
-        const result = await this._runWithClient(options, startTime, this.name);
 
-        if (!result.success) {
-          getSafeLogger()?.warn("acp-adapter", `Run failed for ${this.name}`, {
-            exitCode: result.exitCode,
-            ...(result.output ? { output: result.output.slice(0, 500) } : {}),
-          });
-
-          // Session error retry: use a fresh session. Retryable errors (e.g. queue owner
-          // disconnect) get more attempts than non-retryable ones (stale/locked session).
-          // Default (test mode): disabled — retries would advance mock callIndex and break tests.
-          const maxSessionRetries = result.sessionErrorRetryable
-            ? SESSION_ERROR_RETRYABLE_MAX_RETRIES
-            : SESSION_ERROR_MAX_RETRIES;
-          if (
-            result.sessionError &&
-            _acpAdapterDeps.shouldRetrySessionError &&
-            sessionErrorRetries < maxSessionRetries &&
-            !options.abortSignal?.aborted
-          ) {
-            sessionErrorRetries += 1;
-            getSafeLogger()?.warn("acp-adapter", "Session error — retrying with fresh session", {
-              storyId: options.storyId,
-              featureName: options.featureName,
-              retryable: result.sessionErrorRetryable,
-              attempt: sessionErrorRetries,
-              maxAttempts: maxSessionRetries,
-            });
-            continue;
-          }
-
-          const parsed = _fallbackDeps.parseAgentError(result.output ?? "");
-          if (parsed.type === "auth") {
-            return {
-              success: false,
-              exitCode: result.exitCode ?? 1,
-              output: result.output ?? "",
-              rateLimited: false,
-              durationMs: Date.now() - startTime,
-              estimatedCost: result.estimatedCost ?? 0,
-              adapterFailure: {
-                category: "availability",
-                outcome: "fail-auth",
-                retriable: false,
-                message: (result.output ?? "").slice(0, 500),
-              },
-            };
-          }
-          if (parsed.type === "rate-limit") {
-            return {
-              success: false,
-              exitCode: result.exitCode ?? 1,
-              output: result.output ?? "",
-              rateLimited: true,
-              durationMs: Date.now() - startTime,
-              estimatedCost: result.estimatedCost ?? 0,
-              adapterFailure: {
-                category: "availability",
-                outcome: "fail-rate-limit",
-                retriable: true,
-                message: (result.output ?? "").slice(0, 500),
-                ...(parsed.retryAfterSeconds !== undefined && { retryAfterSeconds: parsed.retryAfterSeconds }),
-              },
-            };
-          }
-        }
-
-        return { ...result, sessionRetries: sessionErrorRetries };
-      } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err));
-        const parsed = _fallbackDeps.parseAgentError(error.message);
-
+        const parsed = _fallbackDeps.parseAgentError(result.output ?? "");
         if (parsed.type === "auth") {
           return {
             success: false,
-            exitCode: 1,
-            output: error.message,
+            exitCode: result.exitCode ?? 1,
+            output: result.output ?? "",
             rateLimited: false,
             durationMs: Date.now() - startTime,
-            estimatedCost: 0,
+            estimatedCost: result.estimatedCost ?? 0,
             adapterFailure: {
               category: "availability",
               outcome: "fail-auth",
               retriable: false,
-              message: error.message.slice(0, 500),
+              message: (result.output ?? "").slice(0, 500),
             },
           };
         }
         if (parsed.type === "rate-limit") {
           return {
             success: false,
-            exitCode: 1,
-            output: error.message,
+            exitCode: result.exitCode ?? 1,
+            output: result.output ?? "",
             rateLimited: true,
             durationMs: Date.now() - startTime,
-            estimatedCost: 0,
+            estimatedCost: result.estimatedCost ?? 0,
             adapterFailure: {
               category: "availability",
               outcome: "fail-rate-limit",
               retriable: true,
-              message: error.message.slice(0, 500),
+              message: (result.output ?? "").slice(0, 500),
               ...(parsed.retryAfterSeconds !== undefined && { retryAfterSeconds: parsed.retryAfterSeconds }),
             },
           };
         }
-        // Unknown error — return as failure result
+      }
+
+      return result;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      const parsed = _fallbackDeps.parseAgentError(error.message);
+
+      if (parsed.type === "auth") {
         return {
           success: false,
           exitCode: 1,
@@ -603,13 +535,45 @@ export class AcpAgentAdapter implements AgentAdapter {
           durationMs: Date.now() - startTime,
           estimatedCost: 0,
           adapterFailure: {
-            category: "quality",
-            outcome: "fail-unknown",
+            category: "availability",
+            outcome: "fail-auth",
             retriable: false,
             message: error.message.slice(0, 500),
           },
         };
       }
+      if (parsed.type === "rate-limit") {
+        return {
+          success: false,
+          exitCode: 1,
+          output: error.message,
+          rateLimited: true,
+          durationMs: Date.now() - startTime,
+          estimatedCost: 0,
+          adapterFailure: {
+            category: "availability",
+            outcome: "fail-rate-limit",
+            retriable: true,
+            message: error.message.slice(0, 500),
+            ...(parsed.retryAfterSeconds !== undefined && { retryAfterSeconds: parsed.retryAfterSeconds }),
+          },
+        };
+      }
+      // Unknown error — return as failure result
+      return {
+        success: false,
+        exitCode: 1,
+        output: error.message,
+        rateLimited: false,
+        durationMs: Date.now() - startTime,
+        estimatedCost: 0,
+        adapterFailure: {
+          category: "quality",
+          outcome: "fail-unknown",
+          retriable: false,
+          message: error.message.slice(0, 500),
+        },
+      };
     }
   }
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -61,11 +61,6 @@ export interface AgentResult {
     sessionId: string | null;
   };
   /**
-   * Number of session-level retries (broken connection, QUEUE_DISCONNECTED).
-   * Populated by the adapter; 0 when the first attempt succeeded.
-   */
-  sessionRetries?: number;
-  /**
    * Structured failure classification (Phase 2 plumbing — additive, callers may ignore).
    * Populated on all non-success return paths. Undefined on success.
    *

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -371,6 +371,7 @@ export class SessionManager implements ISessionManager {
             this.bindHandle(id, sessionName, protocolIds);
           } catch (err) {
             getLogger().warn("session", "bindHandle via onSessionEstablished failed", {
+              storyId: this._sessions.get(id)?.storyId,
               sessionId: id,
               error: err instanceof Error ? err.message : String(err),
             });
@@ -380,14 +381,40 @@ export class SessionManager implements ISessionManager {
       },
     };
 
+    const config = request.runOptions.config;
+    const maxRetriable = config?.execution?.sessionErrorRetryableMaxRetries ?? 3;
+    const maxNonRetriable = config?.execution?.sessionErrorMaxRetries ?? 1;
+    let sessionRetries = 0;
+
     let result: AgentResult;
-    try {
-      result = await agentManager.run(injectedRequest);
-    } catch (err) {
-      if (this._sessions.get(id)?.state === "RUNNING") {
-        this.transition(id, "FAILED");
+    // Session-transport retry loop: retries only on fail-adapter-error.
+    // Auth/rate-limit failures surface immediately so AgentManager's fallback
+    // and backoff logic fires without a SessionManager-level retry doubling up.
+    while (true) {
+      try {
+        result = await agentManager.run(injectedRequest);
+      } catch (err) {
+        if (this._sessions.get(id)?.state === "RUNNING") {
+          this.transition(id, "FAILED");
+        }
+        throw err;
       }
-      throw err;
+
+      if (result.adapterFailure?.outcome === "fail-adapter-error") {
+        const max = result.adapterFailure.retriable ? maxRetriable : maxNonRetriable;
+        if (sessionRetries < max && !request.signal?.aborted) {
+          sessionRetries++;
+          getLogger().warn("session", "Session transport error — retrying with fresh session", {
+            sessionId: id,
+            storyId: this._sessions.get(id)?.storyId,
+            retriable: result.adapterFailure.retriable,
+            attempt: sessionRetries,
+            maxAttempts: max,
+          });
+          continue;
+        }
+      }
+      break;
     }
 
     if (result.protocolIds) {
@@ -403,6 +430,17 @@ export class SessionManager implements ISessionManager {
         };
         this._sessions.set(id, updated);
         this._persistDescriptor(updated);
+      }
+    }
+
+    // Gap A: reconcile descriptor.agent after an agent swap in AgentManager.
+    // agentFallbacks.at(-1).newAgent is the final agent used; handoff() updates
+    // the descriptor so crash recovery and metrics see the correct agent name.
+    const finalAgent = result.agentFallbacks?.at(-1)?.newAgent;
+    if (finalAgent) {
+      const current = this._sessions.get(id);
+      if (current && finalAgent !== current.agent) {
+        this.handoff(id, finalAgent, "post-run-reconcile");
       }
     }
 

--- a/test/integration/agents/acp/tdd-flow-cost.test.ts
+++ b/test/integration/agents/acp/tdd-flow-cost.test.ts
@@ -169,7 +169,6 @@ function mockGitSpawn(diffFileSequences: string[][] = []) {
 
 beforeEach(() => {
   _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
-  _acpAdapterDeps.shouldRetrySessionError = false;
 });
 
 afterEach(() => {

--- a/test/integration/agents/acp/tdd-flow-isolation.test.ts
+++ b/test/integration/agents/acp/tdd-flow-isolation.test.ts
@@ -170,7 +170,6 @@ function mockGitSpawn(diffFileSequences: string[][] = []) {
 
 beforeEach(() => {
   _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
-  _acpAdapterDeps.shouldRetrySessionError = false;
 });
 
 afterEach(() => {

--- a/test/integration/agents/acp/tdd-flow-rectification.test.ts
+++ b/test/integration/agents/acp/tdd-flow-rectification.test.ts
@@ -109,7 +109,6 @@ withDepsRestore(_executorDeps, ["spawn"]);
 
 beforeEach(() => {
   _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
-  _acpAdapterDeps.shouldRetrySessionError = false;
 });
 
 afterEach(() => {

--- a/test/integration/agents/acp/tdd-flow-sessions.test.ts
+++ b/test/integration/agents/acp/tdd-flow-sessions.test.ts
@@ -171,7 +171,6 @@ function mockGitSpawn(diffFileSequences: string[][] = []) {
 
 beforeEach(() => {
   _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
-  _acpAdapterDeps.shouldRetrySessionError = false;
 });
 
 afterEach(() => {

--- a/test/unit/agents/acp/adapter-failure.test.ts
+++ b/test/unit/agents/acp/adapter-failure.test.ts
@@ -23,12 +23,11 @@ import { makeClient, makeRunOptions, makeSession } from "./adapter.test";
 describe("AcpAgentAdapter — adapterFailure taxonomy", () => {
   let adapter: AcpAgentAdapter;
 
-  withDepsRestore(_acpAdapterDeps, ["createClient", "sleep", "shouldRetrySessionError"]);
+  withDepsRestore(_acpAdapterDeps, ["createClient", "sleep"]);
 
   beforeEach(() => {
     adapter = new AcpAgentAdapter("claude");
     _acpAdapterDeps.sleep = async () => {};
-    _acpAdapterDeps.shouldRetrySessionError = false;
   });
 
   afterEach(() => {

--- a/test/unit/agents/acp/adapter-phase1.test.ts
+++ b/test/unit/agents/acp/adapter-phase1.test.ts
@@ -3,8 +3,10 @@
  *
  * Covers:
  * - protocolIds (recordId + sessionId) surfaced on AgentResult
- * - sessionRetries counter on AgentResult
  * - deriveSessionName() produces correct ACP session handle from SessionDescriptor
+ *
+ * Note: sessionRetries removed in ADR-013 Phase 2 — retry loop moved to
+ * SessionManager.runInSession; adapter now executes once per call.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -28,7 +30,7 @@ const BASE_OPTIONS: AgentRunOptions = {
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Phase 1 plumbing — protocolIds + sessionRetries on AgentResult
+// Phase 1 plumbing — protocolIds on AgentResult
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("AcpAgentAdapter — Phase 1: protocolIds surfaced on AgentResult", () => {
@@ -67,13 +69,7 @@ describe("AcpAgentAdapter — Phase 1: protocolIds surfaced on AgentResult", () 
     expect(result.protocolIds?.recordId).toBeNull();
   });
 
-  test("sessionRetries is 0 on a successful run with no retries", async () => {
-    const session = makeSession();
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
-    const result = await adapter.run(BASE_OPTIONS);
-    expect(result.sessionRetries).toBe(0);
-  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/session/manager-session-retry.test.ts
+++ b/test/unit/session/manager-session-retry.test.ts
@@ -1,0 +1,423 @@
+/**
+ * SessionManager.runInSession — session-transport retry (ADR-013 Phase 2).
+ *
+ * Phase 2 moves the session-error retry loop from AcpAgentAdapter into
+ * SessionManager.runInSession. The adapter now executes once, classifies the
+ * result, and returns. SessionManager owns the retry decision.
+ *
+ * Covered:
+ *   - fail-adapter-error retriable: true  → retries up to sessionErrorRetryableMaxRetries
+ *   - fail-adapter-error retriable: false → retries up to sessionErrorMaxRetries (non-retriable)
+ *   - fail-auth                           → no retry, surfaces immediately
+ *   - fail-rate-limit                     → no retry at session level
+ *   - abort signal                        → no retry when signal is aborted
+ *   - Gap A: handoff() called when agentFallbacks shows agent swap
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { SessionManager, _sessionManagerDeps } from "../../../src/session/manager";
+import type { IAgentManager, AgentRunRequest } from "../../../src/agents/manager-types";
+import type { AgentResult } from "../../../src/agents/types";
+import type { NaxConfig } from "../../../src/config";
+import type { AdapterFailure } from "../../../src/context/engine";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeConfig(overrides: Partial<NaxConfig["execution"]> = {}): NaxConfig {
+  return {
+    execution: {
+      sessionTimeoutSeconds: 30,
+      verificationTimeoutSeconds: 60,
+      sessionErrorMaxRetries: 1,
+      sessionErrorRetryableMaxRetries: 3,
+      ...overrides,
+    },
+  } as unknown as NaxConfig;
+}
+
+function makeRequest(config = makeConfig()): AgentRunRequest {
+  return {
+    runOptions: {
+      prompt: "test",
+      workdir: "/tmp/x",
+      modelTier: "fast",
+      modelDef: { provider: "anthropic", model: "claude-haiku", env: {} },
+      timeoutSeconds: 30,
+      config,
+    },
+  };
+}
+
+function makeResult(overrides: Partial<AgentResult> = {}): AgentResult {
+  return {
+    success: true,
+    exitCode: 0,
+    output: "ok",
+    rateLimited: false,
+    durationMs: 100,
+    estimatedCost: 0.01,
+    ...overrides,
+  };
+}
+
+function makeFailure(outcome: AdapterFailure["outcome"], retriable: boolean): AdapterFailure {
+  return { category: "availability", outcome, retriable, message: "" };
+}
+
+/** Build a mock IAgentManager that returns results in sequence from the queue. */
+function makeSequencedManager(queue: AgentResult[]): IAgentManager {
+  let callIndex = 0;
+  const runFn = mock(async () => {
+    const result = queue[callIndex] ?? queue[queue.length - 1];
+    callIndex++;
+    return result;
+  });
+  return {
+    getDefault: () => "claude",
+    isUnavailable: () => false,
+    markUnavailable: () => {},
+    reset: () => {},
+    validateCredentials: async () => {},
+    resolveFallbackChain: () => [],
+    shouldSwap: () => false,
+    nextCandidate: () => null,
+    runWithFallback: async () => ({ result: makeResult(), fallbacks: [] }),
+    completeWithFallback: async () => ({ result: { output: "", costUsd: 0, source: "fallback" as const }, fallbacks: [] }),
+    run: runFn,
+    complete: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    getAgent: () => undefined,
+    events: { on: () => {} },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Saved deps for restoration
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origNow: typeof _sessionManagerDeps.now;
+beforeEach(() => { origNow = _sessionManagerDeps.now; });
+afterEach(() => { _sessionManagerDeps.now = origNow; });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Retry on fail-adapter-error retriable: true
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SessionManager.runInSession — retry on fail-adapter-error", () => {
+  test("retries up to sessionErrorRetryableMaxRetries on retriable transport errors", async () => {
+    // Default: sessionErrorRetryableMaxRetries = 3 → 3 retries after the first attempt
+    const failResult = makeResult({
+      success: false,
+      exitCode: 1,
+      output: "",
+      adapterFailure: makeFailure("fail-adapter-error", true),
+    });
+    const successResult = makeResult({ success: true });
+
+    // Fail 3 times, succeed on 4th attempt (attempt index 3 = 4th call)
+    const queue = [failResult, failResult, failResult, successResult];
+    const manager = makeSequencedManager(queue);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    const result = await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect(result.success).toBe(true);
+    expect((manager.run as ReturnType<typeof mock>).mock.calls.length).toBe(4);
+  });
+
+  test("stops retrying after sessionErrorRetryableMaxRetries exhausted", async () => {
+    // sessionErrorRetryableMaxRetries = 3 → max 3 retries → 4 total attempts
+    const failResult = makeResult({
+      success: false,
+      exitCode: 1,
+      adapterFailure: makeFailure("fail-adapter-error", true),
+    });
+
+    // All attempts fail
+    const manager = makeSequencedManager([failResult, failResult, failResult, failResult]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    const result = await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect(result.success).toBe(false);
+    expect(result.adapterFailure?.outcome).toBe("fail-adapter-error");
+    expect((manager.run as ReturnType<typeof mock>).mock.calls.length).toBe(4); // 1 + 3 retries
+  });
+
+  test("succeeds immediately if first attempt succeeds (no retries fired)", async () => {
+    const manager = makeSequencedManager([makeResult({ success: true })]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect((manager.run as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  });
+
+  test("respects custom sessionErrorRetryableMaxRetries from config", async () => {
+    // Override to 1 retry only
+    const config = makeConfig({ sessionErrorRetryableMaxRetries: 1 });
+    const failResult = makeResult({
+      success: false,
+      exitCode: 1,
+      adapterFailure: makeFailure("fail-adapter-error", true),
+    });
+
+    const manager = makeSequencedManager([failResult, failResult, failResult]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    await mgr.runInSession(d.id, manager, makeRequest(config));
+
+    expect((manager.run as ReturnType<typeof mock>).mock.calls.length).toBe(2); // 1 + 1 retry
+  });
+
+  test("session stays RUNNING across all retry attempts (no intermediate FAILED)", async () => {
+    const failResult = makeResult({
+      success: false,
+      exitCode: 1,
+      adapterFailure: makeFailure("fail-adapter-error", true),
+    });
+    const successResult = makeResult({ success: true });
+
+    const states: string[] = [];
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+
+    let callIndex = 0;
+    const queue = [failResult, failResult, successResult];
+    const manager: IAgentManager = {
+      ...makeSequencedManager(queue),
+      run: mock(async () => {
+        states.push(mgr.get(d.id)?.state ?? "?");
+        const result = queue[callIndex] ?? queue[queue.length - 1];
+        callIndex++;
+        return result;
+      }),
+    };
+
+    await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect(states.every((s) => s === "RUNNING")).toBe(true);
+    expect(mgr.get(d.id)?.state).toBe("COMPLETED");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Non-retriable transport errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SessionManager.runInSession — non-retriable transport errors", () => {
+  test("retries once on fail-adapter-error retriable: false (sessionErrorMaxRetries = 1)", async () => {
+    const failResult = makeResult({
+      success: false,
+      exitCode: 1,
+      adapterFailure: makeFailure("fail-adapter-error", false),
+    });
+    const successResult = makeResult({ success: true });
+
+    const manager = makeSequencedManager([failResult, successResult]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    const result = await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect(result.success).toBe(true);
+    expect((manager.run as ReturnType<typeof mock>).mock.calls.length).toBe(2);
+  });
+
+  test("stops after sessionErrorMaxRetries exhausted for non-retriable", async () => {
+    // sessionErrorMaxRetries = 1 → 1 retry → 2 total attempts
+    const failResult = makeResult({
+      success: false,
+      exitCode: 1,
+      adapterFailure: makeFailure("fail-adapter-error", false),
+    });
+
+    const manager = makeSequencedManager([failResult, failResult, failResult]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect((manager.run as ReturnType<typeof mock>).mock.calls.length).toBe(2); // 1 + 1 retry
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// No retry for auth / rate-limit failures
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SessionManager.runInSession — no retry for auth/rate-limit", () => {
+  test("does not retry on fail-auth — surfaces immediately to AgentManager", async () => {
+    const authResult = makeResult({
+      success: false,
+      exitCode: 1,
+      adapterFailure: makeFailure("fail-auth", false),
+    });
+
+    const manager = makeSequencedManager([authResult, makeResult({ success: true })]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    const result = await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect(result.adapterFailure?.outcome).toBe("fail-auth");
+    expect((manager.run as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  });
+
+  test("does not retry on fail-rate-limit — surfaces immediately to AgentManager", async () => {
+    const rateLimitResult = makeResult({
+      success: false,
+      exitCode: 1,
+      rateLimited: true,
+      adapterFailure: makeFailure("fail-rate-limit", true),
+    });
+
+    const manager = makeSequencedManager([rateLimitResult, makeResult({ success: true })]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    const result = await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect(result.adapterFailure?.outcome).toBe("fail-rate-limit");
+    expect((manager.run as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  });
+
+  test("does not retry on fail-aborted", async () => {
+    const abortedResult = makeResult({
+      success: false,
+      exitCode: 130,
+      adapterFailure: makeFailure("fail-aborted", false),
+    });
+
+    const manager = makeSequencedManager([abortedResult, makeResult({ success: true })]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    const result = await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect(result.adapterFailure?.outcome).toBe("fail-aborted");
+    expect((manager.run as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Abort signal cancels retries
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SessionManager.runInSession — abort signal", () => {
+  test("does not retry when abort signal is already aborted", async () => {
+    const failResult = makeResult({
+      success: false,
+      exitCode: 1,
+      adapterFailure: makeFailure("fail-adapter-error", true),
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const manager = makeSequencedManager([failResult, makeResult({ success: true })]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    const request: AgentRunRequest = { ...makeRequest(), signal: controller.signal };
+    await mgr.runInSession(d.id, manager, request);
+
+    // Should not retry when signal already aborted
+    expect((manager.run as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gap A: descriptor.agent updated after swap (handoff called)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SessionManager.runInSession — Gap A: handoff after agent swap", () => {
+  test("calls handoff() when agentFallbacks shows a swap occurred", async () => {
+    const result = makeResult({
+      agentFallbacks: [
+        {
+          storyId: "US-001",
+          priorAgent: "claude",
+          newAgent: "codex",
+          outcome: "fail-auth" as const,
+          category: "availability" as const,
+          hop: 1,
+          timestamp: new Date().toISOString(),
+          costUsd: 0,
+        },
+      ],
+    });
+
+    const manager = makeSequencedManager([result]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect(mgr.get(d.id)?.agent).toBe("codex");
+  });
+
+  test("does not call handoff() when no fallbacks occurred", async () => {
+    const result = makeResult({ agentFallbacks: [] });
+
+    const manager = makeSequencedManager([result]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect(mgr.get(d.id)?.agent).toBe("claude");
+  });
+
+  test("uses the LAST hop's newAgent when multiple swaps occurred", async () => {
+    const result = makeResult({
+      agentFallbacks: [
+        {
+          storyId: "US-001",
+          priorAgent: "claude",
+          newAgent: "codex",
+          outcome: "fail-auth" as const,
+          category: "availability" as const,
+          hop: 1,
+          timestamp: new Date().toISOString(),
+          costUsd: 0,
+        },
+        {
+          storyId: "US-001",
+          priorAgent: "codex",
+          newAgent: "gemini",
+          outcome: "fail-rate-limit" as const,
+          category: "availability" as const,
+          hop: 2,
+          timestamp: new Date().toISOString(),
+          costUsd: 0,
+        },
+      ],
+    });
+
+    const manager = makeSequencedManager([result]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect(mgr.get(d.id)?.agent).toBe("gemini");
+  });
+
+  test("does not call handoff() when agentFallbacks is undefined", async () => {
+    const result = makeResult(); // agentFallbacks not set
+
+    const manager = makeSequencedManager([result]);
+
+    const mgr = new SessionManager();
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x" });
+    await mgr.runInSession(d.id, manager, makeRequest());
+
+    expect(mgr.get(d.id)?.agent).toBe("claude");
+  });
+});


### PR DESCRIPTION
## Summary

- **Retry ownership moved**: Session-transport retry loop removed from `AcpAgentAdapter.run()` and implemented in `SessionManager.runInSession()`. The adapter now executes once per call, classifies the result, and returns. SessionManager owns the retry decision.
- **Gap A fixed**: After `agentManager.run()` returns, `runInSession` reads `agentFallbacks.at(-1)?.newAgent` and calls `handoff()` to update `descriptor.agent` when an agent swap occurred during the run.
- **`AgentResult.sessionRetries` removed**: The field was set by the adapter's internal loop (now gone). Downstream metrics should use `agentFallbacks` for per-hop data.

## Changes

| File | Change |
|:-----|:-------|
| `src/session/manager.ts` | `runInSession`: adds retry loop (only on `fail-adapter-error`), respects abort signal, Gap A handoff, storyId added to log call |
| `src/agents/acp/adapter.ts` | Removes `shouldRetrySessionError`, `SESSION_ERROR_MAX_RETRIES`, `SESSION_ERROR_RETRYABLE_MAX_RETRIES`, retry counter, and `while(true)` loop |
| `src/agents/types.ts` | Removes `sessionRetries` from `AgentResult` |
| `test/unit/session/manager-session-retry.test.ts` | NEW — 15 tests: retry limits, no-retry for auth/rate-limit/aborted, abort signal, Gap A handoff, state stability |
| `test/unit/agents/acp/adapter-phase1.test.ts` | Removes `sessionRetries` test (field gone) |
| `test/unit/agents/acp/adapter-failure.test.ts` | Removes `shouldRetrySessionError = false` from `beforeEach` |
| `test/integration/agents/acp/tdd-flow-*.test.ts` (4 files) | Removes `shouldRetrySessionError = false` from `beforeEach` |

## Retry layer ownership after Phase 2

| Layer | Concern | Owner |
|:------|:--------|:------|
| Session-transport retry | fail-adapter-error — broken socket, QUEUE_DISCONNECTED | SessionManager |
| Availability fallback + backoff | Auth/rate-limit — new agent, exponential delay | AgentManager (unchanged) |
| Payload-shape retry | JSON parse fail — re-ask same agent | Caller (unchanged) |

## Test plan

- [x] typecheck passes
- [x] lint passes
- [x] manager-session-retry.test.ts — 15 pass
- [x] test/unit/session/ — 121 pass
- [x] test/unit/agents/acp/ — 266 pass
- [x] test/integration/agents/acp/ — 21 pass
- [x] test/unit/ — 6468 pass, 0 fail