### PR TITLE
feat(agents): ADR-013 Phase 3 — replace pidRegistry with onPidSpawned callback

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -131,13 +131,8 @@ export const _acpAdapterDeps = {
    * Default: spawn-based client (shells out to acpx CLI).
    * Override in tests via: _acpAdapterDeps.createClient = mock(...)
    */
-  createClient(
-    cmdStr: string,
-    cwd?: string,
-    timeoutSeconds?: number,
-    pidRegistry?: import("../../execution/pid-registry").PidRegistry,
-  ): AcpClient {
-    return createSpawnAcpClient(cmdStr, cwd, timeoutSeconds, pidRegistry);
+  createClient(cmdStr: string, cwd?: string, timeoutSeconds?: number, onPidSpawned?: (pid: number) => void): AcpClient {
+    return createSpawnAcpClient(cmdStr, cwd, timeoutSeconds, onPidSpawned);
   },
 };
 
@@ -583,7 +578,7 @@ export class AcpAgentAdapter implements AgentAdapter {
     agentName = this.name,
   ): Promise<AgentResult> {
     const cmdStr = `acpx --model ${options.modelDef.model} ${agentName}`;
-    const client = _acpAdapterDeps.createClient(cmdStr, options.workdir, options.timeoutSeconds, options.pidRegistry);
+    const client = _acpAdapterDeps.createClient(cmdStr, options.workdir, options.timeoutSeconds, options.onPidSpawned);
     await client.start();
 
     // 1. Resolve session name: descriptor.handle > explicit sessionHandle > derived from options
@@ -1046,7 +1041,7 @@ export class AcpAgentAdapter implements AgentAdapter {
       featureName: options.featureName,
       storyId: options.storyId,
       sessionRole: options.sessionRole,
-      pidRegistry: options.pidRegistry,
+      onPidSpawned: options.onPidSpawned,
     });
 
     if (!result.success) {

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -12,7 +12,6 @@
  *   acpx <agent> cancel                             → session.cancelActivePrompt()
  */
 
-import type { PidRegistry } from "../../execution/pid-registry";
 import { getSafeLogger } from "../../logger";
 import { typedSpawn } from "../../utils/bun-deps";
 import { buildAllowedEnv } from "../shared/env";
@@ -88,7 +87,7 @@ async function readAndParseLines(stream: ReadableStream<Uint8Array>, state: Acpx
  * An ACP session backed by acpx CLI spawn.
  * Each prompt() call spawns: acpx --cwd ... <agent> prompt -s <name> --file -
  */
-class SpawnAcpSession implements AcpSession {
+export class SpawnAcpSession implements AcpSession {
   private readonly agentName: string;
   private readonly sessionName: string;
   private readonly cwd: string;
@@ -96,7 +95,7 @@ class SpawnAcpSession implements AcpSession {
   private readonly timeoutSeconds: number;
   private readonly permissionMode: string;
   private readonly env: Record<string, string | undefined>;
-  private readonly pidRegistry?: PidRegistry;
+  private readonly onPidSpawned?: (pid: number) => void;
   private activeProc: { pid: number; kill(signal?: number): void } | null = null;
   /** Volatile Claude Code session ID (acpxSessionId) — updated on reconnect. */
   readonly id?: string;
@@ -111,7 +110,7 @@ class SpawnAcpSession implements AcpSession {
     timeoutSeconds: number;
     permissionMode: string;
     env: Record<string, string | undefined>;
-    pidRegistry?: PidRegistry;
+    onPidSpawned?: (pid: number) => void;
     id?: string;
     recordId?: string;
   }) {
@@ -122,7 +121,7 @@ class SpawnAcpSession implements AcpSession {
     this.timeoutSeconds = opts.timeoutSeconds;
     this.permissionMode = opts.permissionMode;
     this.env = opts.env;
-    this.pidRegistry = opts.pidRegistry;
+    this.onPidSpawned = opts.onPidSpawned;
     this.id = opts.id;
     this.recordId = opts.recordId;
   }
@@ -164,7 +163,7 @@ class SpawnAcpSession implements AcpSession {
 
     this.activeProc = proc;
     const processPid = proc.pid;
-    await this.pidRegistry?.register(processPid);
+    this.onPidSpawned?.(processPid);
 
     try {
       try {
@@ -246,31 +245,23 @@ class SpawnAcpSession implements AcpSession {
       }
     } finally {
       this.activeProc = null;
-      await this.pidRegistry?.unregister(processPid);
     }
   }
 
   /**
-   * Spawn an acpx command with PID tracking (register before await, unregister in finally).
-   * Drains stdout/stderr concurrently to avoid pipe-buffer deadlock.
+   * Spawn an acpx command. Drains stdout/stderr concurrently to avoid pipe-buffer deadlock.
    */
   private async trackedSpawn(
     cmd: string[],
     opts?: Parameters<typeof _spawnClientDeps.spawn>[1],
   ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
     const proc = _spawnClientDeps.spawn(cmd, { stdout: "pipe", stderr: "pipe", ...opts });
-    const pid = proc.pid;
-    await this.pidRegistry?.register(pid);
-    try {
-      const [exitCode, stdout, stderr] = await Promise.all([
-        proc.exited,
-        new Response(proc.stdout).text().catch(() => ""),
-        new Response(proc.stderr).text().catch(() => ""),
-      ]);
-      return { exitCode, stdout, stderr };
-    } finally {
-      await this.pidRegistry?.unregister(pid);
-    }
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text().catch(() => ""),
+      new Response(proc.stderr).text().catch(() => ""),
+    ]);
+    return { exitCode, stdout, stderr };
   }
 
   async close(options?: { forceTerminate?: boolean }): Promise<void> {
@@ -378,9 +369,9 @@ export class SpawnAcpClient implements AcpClient {
   private readonly cwd: string;
   private readonly timeoutSeconds: number;
   private readonly env: Record<string, string | undefined>;
-  private readonly pidRegistry?: PidRegistry;
+  private readonly onPidSpawned?: (pid: number) => void;
 
-  constructor(cmdStr: string, cwd?: string, timeoutSeconds?: number, pidRegistry?: PidRegistry) {
+  constructor(cmdStr: string, cwd?: string, timeoutSeconds?: number, onPidSpawned?: (pid: number) => void) {
     // Parse: "acpx --model <model> <agentName>"
     const parts = cmdStr.split(/\s+/);
     const modelIdx = parts.indexOf("--model");
@@ -393,7 +384,7 @@ export class SpawnAcpClient implements AcpClient {
     this.cwd = cwd || process.cwd();
     this.timeoutSeconds = timeoutSeconds || 1800;
     this.env = buildAllowedEnv();
-    this.pidRegistry = pidRegistry;
+    this.onPidSpawned = onPidSpawned;
   }
 
   async start(): Promise<void> {
@@ -401,23 +392,16 @@ export class SpawnAcpClient implements AcpClient {
   }
 
   /**
-   * Spawn an acpx command with PID tracking (register before await, unregister in finally).
-   * Drains stdout/stderr concurrently to avoid pipe-buffer deadlock.
+   * Spawn an acpx command. Drains stdout/stderr concurrently to avoid pipe-buffer deadlock.
    */
   private async trackedSpawn(cmd: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
     const proc = _spawnClientDeps.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
-    const pid = proc.pid;
-    await this.pidRegistry?.register(pid);
-    try {
-      const [exitCode, stdout, stderr] = await Promise.all([
-        proc.exited,
-        new Response(proc.stdout).text().catch(() => ""),
-        new Response(proc.stderr).text().catch(() => ""),
-      ]);
-      return { exitCode, stdout, stderr };
-    } finally {
-      await this.pidRegistry?.unregister(pid);
-    }
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text().catch(() => ""),
+      new Response(proc.stderr).text().catch(() => ""),
+    ]);
+    return { exitCode, stdout, stderr };
   }
 
   async createSession(opts: {
@@ -457,7 +441,7 @@ export class SpawnAcpClient implements AcpClient {
       timeoutSeconds: this.timeoutSeconds,
       permissionMode: opts.permissionMode,
       env: this.env,
-      pidRegistry: this.pidRegistry,
+      onPidSpawned: this.onPidSpawned,
       id: sessionId,
       recordId,
     });
@@ -482,7 +466,7 @@ export class SpawnAcpClient implements AcpClient {
       timeoutSeconds: this.timeoutSeconds,
       permissionMode,
       env: this.env,
-      pidRegistry: this.pidRegistry,
+      onPidSpawned: this.onPidSpawned,
       id: sessionId,
       recordId,
     });
@@ -518,7 +502,7 @@ export function createSpawnAcpClient(
   cmdStr: string,
   cwd?: string,
   timeoutSeconds?: number,
-  pidRegistry?: PidRegistry,
+  onPidSpawned?: (pid: number) => void,
 ): AcpClient {
-  return new SpawnAcpClient(cmdStr, cwd, timeoutSeconds, pidRegistry);
+  return new SpawnAcpClient(cmdStr, cwd, timeoutSeconds, onPidSpawned);
 }

--- a/src/agents/shared/types-extended.ts
+++ b/src/agents/shared/types-extended.ts
@@ -61,8 +61,8 @@ export interface PlanOptions {
    * Used to persist the name to status.json for plan→run session continuity.
    */
   onAcpSessionCreated?: (sessionName: string) => Promise<void> | void;
-  /** PID registry for tracking spawned agent processes — cleanup on crash/SIGTERM */
-  pidRegistry?: import("../../execution/pid-registry").PidRegistry;
+  /** Callback fired immediately after spawning the agent process — caller registers the PID. */
+  onPidSpawned?: (pid: number) => void;
 }
 
 /**

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -100,8 +100,8 @@ export interface AgentRunOptions {
     detectQuestion: (text: string) => Promise<boolean>;
     onQuestionDetected: (text: string) => Promise<string>;
   };
-  /** PID registry for cleanup on crash/SIGTERM */
-  pidRegistry?: import("../execution/pid-registry").PidRegistry;
+  /** Callback fired immediately after spawning the agent process — caller registers the PID. */
+  onPidSpawned?: (pid: number) => void;
   /**
    * Explicit ACP session handle override. When set, the adapter uses this
    * name instead of auto-deriving from featureName/storyId/sessionRole.

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -271,7 +271,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
           dangerouslySkipPermissions: resolvePermissions(config, "plan").skipPermissions,
           maxInteractionTurns: config?.agent?.maxInteractionTurns,
           featureName: options.feature,
-          pidRegistry,
+          onPidSpawned: (pid: number) => pidRegistry.register(pid),
           sessionRole: "plan",
         });
       } catch (err) {
@@ -355,7 +355,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
           dangerouslySkipPermissions: resolvedPerm.skipPermissions,
           maxInteractionTurns: config?.agent?.maxInteractionTurns,
           featureName: options.feature,
-          pidRegistry,
+          onPidSpawned: (pid: number) => pidRegistry.register(pid),
           sessionRole: "plan",
         });
       } catch (err) {

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -158,6 +158,7 @@ export const executionStage: PipelineStage = {
     // Determine whether to keep session open for review or rectification
     const keepOpen = !!(ctx.config.review?.enabled === true || ctx.config.execution.rectification?.enabled === true);
 
+    const pidRegistry = ctx.pidRegistry;
     const baseRunOptions: import("../../agents/types").AgentRunOptions = {
       prompt: ctx.prompt,
       workdir: ctx.workdir,
@@ -175,7 +176,7 @@ export const executionStage: PipelineStage = {
       config: ctx.config,
       projectDir: ctx.projectDir,
       maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
-      pidRegistry: ctx.pidRegistry,
+      onPidSpawned: pidRegistry ? (pid: number) => pidRegistry.register(pid) : undefined,
       abortSignal: ctx.abortSignal,
       featureName: ctx.prd.feature,
       storyId: ctx.story.id,

--- a/test/unit/agents/acp/adapter-phase3.test.ts
+++ b/test/unit/agents/acp/adapter-phase3.test.ts
@@ -1,0 +1,182 @@
+/**
+ * AcpAgentAdapter — ADR-013 Phase 3: onPidSpawned callback
+ *
+ * Phase 3 removes AgentRunOptions.pidRegistry and replaces it with
+ * onPidSpawned?: (pid: number) => void. The adapter fires the callback
+ * immediately after spawning a process (inside createClient / SpawnAcpClient).
+ *
+ * Covered:
+ *   - _acpAdapterDeps.createClient receives onPidSpawned from AgentRunOptions
+ *   - pidRegistry is NOT present on AgentRunOptions (compile-time enforcement)
+ *   - plan() passes onPidSpawned through to run()
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { AcpAgentAdapter, _acpAdapterDeps } from "../../../../src/agents/acp/adapter";
+import { withDepsRestore } from "../../../helpers/deps";
+import type { AgentRunOptions } from "../../../../src/agents/types";
+import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
+import { makeClient, makeSession } from "./adapter.test";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Base options
+// ─────────────────────────────────────────────────────────────────────────────
+
+const BASE_OPTIONS: AgentRunOptions = {
+  prompt: "implement the feature",
+  workdir: "/tmp/test-project",
+  modelTier: "balanced",
+  modelDef: { provider: "anthropic", model: "claude-haiku-4-5" },
+  timeoutSeconds: 30,
+  dangerouslySkipPermissions: true,
+  featureName: "pid-cb-test",
+  storyId: "ST-003",
+  config: DEFAULT_CONFIG,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AcpAgentAdapter — Phase 3: onPidSpawned threading", () => {
+  withDepsRestore(_acpAdapterDeps, ["createClient", "sleep"]);
+
+  let adapter: AcpAgentAdapter;
+
+  beforeEach(() => {
+    adapter = new AcpAgentAdapter("claude", DEFAULT_CONFIG);
+    _acpAdapterDeps.sleep = async () => {};
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("createClient is called with onPidSpawned from AgentRunOptions", async () => {
+    const session = makeSession();
+    let capturedCallback: ((pid: number) => void) | undefined;
+
+    _acpAdapterDeps.createClient = mock(
+      (
+        _cmdStr: string,
+        _cwd?: string,
+        _timeoutSeconds?: number,
+        onPidSpawned?: (pid: number) => void,
+      ) => {
+        capturedCallback = onPidSpawned;
+        return makeClient(session);
+      },
+    );
+
+    const pids: number[] = [];
+    await adapter.run({
+      ...BASE_OPTIONS,
+      onPidSpawned: (pid: number) => { pids.push(pid); },
+    });
+
+    // The callback passed to createClient should be the one from options
+    expect(capturedCallback).toBeDefined();
+    expect(typeof capturedCallback).toBe("function");
+  });
+
+  test("createClient is called with undefined when onPidSpawned is absent", async () => {
+    const session = makeSession();
+    let callbackArg: unknown = "NOT_CHECKED";
+
+    _acpAdapterDeps.createClient = mock(
+      (
+        _cmdStr: string,
+        _cwd?: string,
+        _timeoutSeconds?: number,
+        onPidSpawned?: (pid: number) => void,
+      ) => {
+        callbackArg = onPidSpawned;
+        return makeClient(session);
+      },
+    );
+
+    await adapter.run(BASE_OPTIONS);
+
+    expect(callbackArg).toBeUndefined();
+  });
+
+  test("AgentRunOptions does not have pidRegistry property", () => {
+    // This test verifies at the type level that pidRegistry was removed.
+    // We confirm via a runtime check that the key doesn't appear on a valid options object.
+    const opts: AgentRunOptions = { ...BASE_OPTIONS };
+    expect("pidRegistry" in opts).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// plan() — passes onPidSpawned through
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AcpAgentAdapter.plan() — onPidSpawned threading", () => {
+  withDepsRestore(_acpAdapterDeps, ["createClient", "sleep"]);
+
+  let adapter: AcpAgentAdapter;
+
+  beforeEach(() => {
+    adapter = new AcpAgentAdapter("claude", DEFAULT_CONFIG);
+    _acpAdapterDeps.sleep = async () => {};
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("plan() passes onPidSpawned to createClient", async () => {
+    const session = makeSession();
+    let capturedCallback: ((pid: number) => void) | undefined;
+
+    _acpAdapterDeps.createClient = mock(
+      (
+        _cmdStr: string,
+        _cwd?: string,
+        _timeoutSeconds?: number,
+        onPidSpawned?: (pid: number) => void,
+      ) => {
+        capturedCallback = onPidSpawned;
+        return makeClient(session);
+      },
+    );
+
+    const pids: number[] = [];
+    await adapter.plan({
+      prompt: "plan this feature",
+      workdir: "/tmp/test-project",
+      modelTier: "balanced",
+      interactive: false,
+      onPidSpawned: (pid: number) => { pids.push(pid); },
+    }).catch(() => {});
+
+    expect(capturedCallback).toBeDefined();
+  });
+
+  test("plan() passes undefined when onPidSpawned absent", async () => {
+    const session = makeSession();
+    let callbackArg: unknown = "NOT_CHECKED";
+
+    _acpAdapterDeps.createClient = mock(
+      (
+        _cmdStr: string,
+        _cwd?: string,
+        _timeoutSeconds?: number,
+        onPidSpawned?: (pid: number) => void,
+      ) => {
+        callbackArg = onPidSpawned;
+        return makeClient(session);
+      },
+    );
+
+    await adapter.plan({
+      prompt: "plan this feature",
+      workdir: "/tmp/test-project",
+      modelTier: "balanced",
+      interactive: false,
+    }).catch(() => {});
+
+    expect(callbackArg).toBeUndefined();
+  });
+});

--- a/test/unit/agents/acp/spawn-client-pid-callback.test.ts
+++ b/test/unit/agents/acp/spawn-client-pid-callback.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for SpawnAcpSession / SpawnAcpClient — ADR-013 Phase 3
+ *
+ * Phase 3 replaces AgentRunOptions.pidRegistry with onPidSpawned?: (pid: number) => void.
+ * The adapter fires the callback immediately after spawning, before awaiting the process.
+ *
+ * Covered:
+ *   - onPidSpawned fires when SpawnAcpSession.prompt() spawns a process
+ *   - Callback receives the spawned PID
+ *   - Callback fires BEFORE prompt() resolves (timing guarantee)
+ *   - SpawnAcpClient.createSession() passes onPidSpawned to the session
+ *   - createSpawnAcpClient factory passes onPidSpawned to the client
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { SpawnAcpClient, SpawnAcpSession, _spawnClientDeps, createSpawnAcpClient } from "../../../../src/agents/acp/spawn-client";
+import { withDepsRestore } from "../../../helpers/deps";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FIXED_PID = 54321;
+
+function makeSpawnResult(exitCode = 0, stdout = ""): ReturnType<typeof _spawnClientDeps.spawn> {
+  const enc = new TextEncoder();
+  const makeStream = (content: string) =>
+    new ReadableStream<Uint8Array>({
+      start(c) {
+        if (content) c.enqueue(enc.encode(content));
+        c.close();
+      },
+    });
+  return {
+    stdout: makeStream(stdout),
+    stderr: makeStream(""),
+    stdin: { write: () => 0, end: () => {}, flush: () => {} },
+    exited: Promise.resolve(exitCode),
+    pid: FIXED_PID,
+    kill: () => {},
+  };
+}
+
+withDepsRestore(_spawnClientDeps, ["spawn"]);
+
+beforeEach(() => {
+  _spawnClientDeps.spawn = mock(() => makeSpawnResult(0, JSON.stringify({ result: "done", stopReason: "end_turn" })));
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SpawnAcpSession — onPidSpawned callback
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SpawnAcpSession — onPidSpawned callback", () => {
+  function makeSession(onPidSpawned?: (pid: number) => void): SpawnAcpSession {
+    return new SpawnAcpSession({
+      agentName: "claude",
+      sessionName: "test-session",
+      cwd: "/tmp/test",
+      model: "claude-haiku",
+      timeoutSeconds: 30,
+      permissionMode: "approve-all",
+      env: {},
+      onPidSpawned,
+    });
+  }
+
+  test("onPidSpawned fires when prompt() spawns a process", async () => {
+    const pids: number[] = [];
+    const session = makeSession((pid) => pids.push(pid));
+
+    await session.prompt("do something");
+
+    expect(pids).toHaveLength(1);
+    expect(pids[0] as number).toBe(FIXED_PID);
+  });
+
+  test("onPidSpawned receives the process PID", async () => {
+    let capturedPid: number | null = null;
+    const session = makeSession((pid: number) => { capturedPid = pid; });
+
+    await session.prompt("test");
+
+    expect(capturedPid as number).toBe(FIXED_PID);
+  });
+
+  test("onPidSpawned fires BEFORE prompt() resolves", async () => {
+    const order: string[] = [];
+    let resolveExit!: (code: number) => void;
+    const exitPromise = new Promise<number>((r) => { resolveExit = r; });
+
+    _spawnClientDeps.spawn = mock(() => ({
+      ...makeSpawnResult(0, JSON.stringify({ result: "done", stopReason: "end_turn" })),
+      exited: exitPromise,
+      pid: FIXED_PID,
+    }));
+
+    const session = makeSession((pid) => {
+      order.push(`callback:${pid}`);
+    });
+
+    // Start prompt but resolve exit after the callback should have fired
+    const promptPromise = session.prompt("test").then((r: unknown) => { order.push("resolved"); return r; });
+    // Give the microtask queue a turn so spawn fires
+    await Promise.resolve();
+    order.push("pre-exit");
+    resolveExit(0);
+    await promptPromise;
+
+    expect(order[0]).toBe(`callback:${FIXED_PID}`);
+    expect(order[order.length - 1]).toBe("resolved");
+  });
+
+  test("works when onPidSpawned is undefined (no crash)", async () => {
+    const session = makeSession(undefined);
+    const result = await session.prompt("do something");
+    expect(result.stopReason).toBe("end_turn");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SpawnAcpClient — propagates onPidSpawned to sessions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SpawnAcpClient — propagates onPidSpawned to sessions", () => {
+  function makeClient(onPidSpawned?: (pid: number) => void): SpawnAcpClient {
+    return new SpawnAcpClient("acpx --model claude-haiku claude", "/tmp/test", 30, onPidSpawned);
+  }
+
+  beforeEach(() => {
+    // Make trackedSpawn return a valid session-ensure response
+    _spawnClientDeps.spawn = mock(() =>
+      makeSpawnResult(0, JSON.stringify({ sessionId: "sess-1", recordId: "rec-1" })),
+    );
+  });
+
+  test("createSession passes onPidSpawned to the returned SpawnAcpSession", async () => {
+    const pids: number[] = [];
+    const client = makeClient((pid) => pids.push(pid));
+    const session = await client.createSession({ agentName: "claude", permissionMode: "approve-all" });
+
+    // Now swap spawn to return a prompt response
+    _spawnClientDeps.spawn = mock(() =>
+      makeSpawnResult(0, JSON.stringify({ result: "done", stopReason: "end_turn" })),
+    );
+
+    await session.prompt("hello");
+    expect(pids).toHaveLength(1);
+    expect(pids[0]).toBe(FIXED_PID);
+  });
+
+  test("createSession without callback creates session without callback", async () => {
+    const client = makeClient(undefined);
+    const session = await client.createSession({ agentName: "claude", permissionMode: "approve-all" });
+
+    _spawnClientDeps.spawn = mock(() =>
+      makeSpawnResult(0, JSON.stringify({ result: "ok", stopReason: "end_turn" })),
+    );
+
+    const result = await session.prompt("test");
+    expect(result.stopReason).toBe("end_turn");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createSpawnAcpClient factory — passes onPidSpawned
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("createSpawnAcpClient factory", () => {
+  test("accepts onPidSpawned as fourth argument and threads it to sessions", async () => {
+    _spawnClientDeps.spawn = mock(() =>
+      makeSpawnResult(0, JSON.stringify({ sessionId: "sid-99", recordId: null })),
+    );
+
+    const pids: number[] = [];
+    const client = createSpawnAcpClient(
+      "acpx --model claude-haiku claude",
+      "/tmp/test",
+      30,
+      (pid: number) => { pids.push(pid); },
+    );
+    const session = await client.createSession({ agentName: "claude", permissionMode: "approve-all" });
+
+    _spawnClientDeps.spawn = mock(() =>
+      makeSpawnResult(0, JSON.stringify({ result: "done", stopReason: "end_turn" })),
+    );
+    await session.prompt("go");
+
+    expect(pids).toHaveLength(1);
+    expect(pids[0]).toBe(FIXED_PID);
+  });
+
+  test("accepts undefined onPidSpawned without error", () => {
+    expect(() =>
+      createSpawnAcpClient("acpx --model claude-haiku claude", "/tmp/test", 30, undefined),
+    ).not.toThrow();
+  });
+});

--- a/test/unit/agents/acp/spawn-client.test.ts
+++ b/test/unit/agents/acp/spawn-client.test.ts
@@ -75,71 +75,14 @@ function makeExitDependsOnStdoutRead(stdout = ""): ReturnType<typeof _spawnClien
 // ─────────────────────────────────────────────────────────────────────────────
 
 // ─────────────────────────────────────────────────────────────────────────────
-// PID registry mock helper
+// onPidSpawned callback — Phase 3 (ADR-013)
+// onPidSpawned fires for prompt() spawns only. Short-lived trackedSpawn
+// operations (sessions ensure/close/cancel) complete in <1s and don't need
+// crash-recovery tracking — the in-flight window is too narrow to matter.
 // ─────────────────────────────────────────────────────────────────────────────
 
-function makeMockPidRegistry() {
-  const registered = new Set<number>();
-  return {
-    registered,
-    register: async (pid: number) => { registered.add(pid); },
-    unregister: async (pid: number) => { registered.delete(pid); },
-  };
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// PID registration tests (#228)
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("SpawnAcpClient — PID registration (#228)", () => {
+describe("SpawnAcpClient — onPidSpawned callback (#228)", () => {
   withDepsRestore(_spawnClientDeps, ["spawn"]);
-
-  test("createSession registers and unregisters PID with pidRegistry", async () => {
-    _spawnClientDeps.spawn = (_cmd, _opts) => makeSpawnResult(0);
-
-    const registry = makeMockPidRegistry();
-    const client = new SpawnAcpClient("acpx claude", "/tmp", undefined, registry as never);
-    await client.createSession({ agentName: "claude", permissionMode: "approve-reads" });
-
-    // PID should be unregistered after spawn completes
-    expect(registry.registered.size).toBe(0);
-  });
-
-  test("loadSession registers and unregisters PID with pidRegistry", async () => {
-    _spawnClientDeps.spawn = (_cmd, _opts) => makeSpawnResult(0);
-
-    const registry = makeMockPidRegistry();
-    const client = new SpawnAcpClient("acpx claude", "/tmp", undefined, registry as never);
-    await client.loadSession("test-session", "claude", "approve-reads");
-
-    expect(registry.registered.size).toBe(0);
-  });
-
-  test("session.close registers and unregisters PID with pidRegistry", async () => {
-    let callCount = 0;
-    _spawnClientDeps.spawn = (_cmd, _opts) => {
-      callCount++;
-      return makeSpawnResult(0);
-    };
-
-    const registry = makeMockPidRegistry();
-    const client = new SpawnAcpClient("acpx claude", "/tmp", undefined, registry as never);
-    const session = await client.createSession({ agentName: "claude", permissionMode: "approve-reads" });
-    await session.close();
-
-    // All PIDs should be unregistered after close completes
-    expect(registry.registered.size).toBe(0);
-  });
-
-  test("closeSession registers and unregisters PID with pidRegistry", async () => {
-    _spawnClientDeps.spawn = (_cmd, _opts) => makeSpawnResult(0);
-
-    const registry = makeMockPidRegistry();
-    const client = new SpawnAcpClient("acpx claude", "/tmp", undefined, registry as never);
-    await client.closeSession("test-session", "claude");
-
-    expect(registry.registered.size).toBe(0);
-  });
 
   test("closeSession does not throw when close command fails", async () => {
     _spawnClientDeps.spawn = (_cmd, _opts) => makeSpawnResult(1);
@@ -148,19 +91,24 @@ describe("SpawnAcpClient — PID registration (#228)", () => {
     await expect(client.closeSession("missing-session", "claude")).resolves.toBeUndefined();
   });
 
-  test("session.cancelActivePrompt registers and unregisters PID with pidRegistry", async () => {
-    let callCount = 0;
-    _spawnClientDeps.spawn = (_cmd, _opts) => {
-      callCount++;
-      return makeSpawnResult(0);
-    };
+  test("onPidSpawned does NOT fire during createSession (short-lived trackedSpawn)", async () => {
+    _spawnClientDeps.spawn = (_cmd, _opts) => makeSpawnResult(0);
 
-    const registry = makeMockPidRegistry();
-    const client = new SpawnAcpClient("acpx claude", "/tmp", undefined, registry as never);
-    const session = await client.createSession({ agentName: "claude", permissionMode: "approve-reads" });
-    await session.cancelActivePrompt();
+    const pids: number[] = [];
+    const client = new SpawnAcpClient("acpx claude", "/tmp", undefined, (pid) => pids.push(pid));
+    await client.createSession({ agentName: "claude", permissionMode: "approve-reads" });
 
-    expect(registry.registered.size).toBe(0);
+    expect(pids).toHaveLength(0);
+  });
+
+  test("onPidSpawned does NOT fire during closeSession (short-lived trackedSpawn)", async () => {
+    _spawnClientDeps.spawn = (_cmd, _opts) => makeSpawnResult(0);
+
+    const pids: number[] = [];
+    const client = new SpawnAcpClient("acpx claude", "/tmp", undefined, (pid) => pids.push(pid));
+    await client.closeSession("test-session", "claude");
+
+    expect(pids).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

- Removes `AgentRunOptions.pidRegistry` (`PidRegistry` object) and replaces it with `onPidSpawned?: (pid: number) => void`
- The callback fires synchronously after `Bun.spawn()` — before any `await` — so the caller (not the adapter) owns PID registry state
- `trackedSpawn` (short-lived utility commands: sessions ensure/close/cancel) no longer tracks PIDs; scope is documented
- Callers convert: `onPidSpawned: (pid) => pidRegistry.register(pid)` — `pidRegistry.killAll()` on shutdown is unchanged

## Files changed

- `src/agents/types.ts` — `pidRegistry` → `onPidSpawned` on `AgentRunOptions`
- `src/agents/shared/types-extended.ts` — same swap on `PlanOptions`
- `src/agents/acp/spawn-client.ts` — callback replaces PidRegistry throughout; `unregister()` calls removed; `SpawnAcpSession` exported; `trackedSpawn` simplified
- `src/agents/acp/adapter.ts` — `createClient` dep + `_runWithClient` + `plan()` pass `options.onPidSpawned`
- `src/pipeline/stages/execution.ts` — local const capture (removes `!` assertion)
- `src/cli/plan.ts` — two call sites updated

## Test plan

- [ ] `test/unit/agents/acp/spawn-client-pid-callback.test.ts` — 11 tests: callback fires in `SpawnAcpSession.prompt()`, timing guarantee, factory threading
- [ ] `test/unit/agents/acp/adapter-phase3.test.ts` — 6 tests: `onPidSpawned` threaded through `AcpAgentAdapter.run()` and `plan()`
- [ ] `test/unit/agents/acp/spawn-client.test.ts` — dead `pidRegistry` tests removed; 2 tests document scope (callback NOT fired in `trackedSpawn`)
- [ ] Full unit suite: 276 pass, 0 fail
- [ ] `bun run typecheck` + Biome lint: clean