### PR TITLE
feat(agents): ADR-013 Phase 4 — confine AgentRegistry ownership to AgentManager

### DIFF
--- a/.claude/rules/adapter-wiring.md
+++ b/.claude/rules/adapter-wiring.md
@@ -79,11 +79,11 @@ Format: `nax-<hash8>-<feature>-<storyId>-<sessionRole>`
 | `"reviewer-semantic"` | `run()` | Semantic review session — initial call `keepOpen: true` (retry needs history); `agent.closeSession()` called on all exit paths (ADR-008: session closes by end of `runReview`) |
 | `"reviewer-adversarial"` | `run()` | Adversarial review session — initial call `keepOpen: true` (retry needs history); `agent.closeSession()` called on all exit paths (ADR-008: session closes by end of `runReview`) |
 
-## Rule 3: Agent Resolution — CRITICAL
+## Rule 3: Agent Resolution — CRITICAL (compiler-enforced since ADR-013 Phase 4)
 
-**Never use bare `getAgent()` when `config` (NaxConfig) is available.**
+**Never import from `src/agents/registry.ts` outside `src/agents/manager.ts`.**
 
-Bare `getAgent()` from `src/agents/registry.ts` always returns CLI adapters from `ALL_AGENTS[]`. It ignores `config.agent.protocol` entirely. When protocol is `"acp"`, this silently spawns a CLI session instead of an ACP session.
+`AgentRegistry` and `createAgentRegistry` are internal to `AgentManager` since Phase 4. The compiler prevents bypassing this boundary: `getAgent` and `createAgentRegistry` are not exported from `src/agents/index.ts`.
 
 ### Correct Patterns
 
@@ -96,16 +96,20 @@ const agent = (ctx.agentGetFn ?? _deps.getAgent)(defaultAgent);
 
 **In standalone modules** (outside pipeline, have `config: NaxConfig`):
 ```typescript
-import { createAgentRegistry } from "../agents/registry";
-const agent = createAgentRegistry(config).getAgent(agentName);
+import { AgentManager } from "../agents";
+const agent = new AgentManager(config).getAgent(agentName);
 ```
 
-### Forbidden Pattern
+### Forbidden Patterns
 
 ```typescript
-// ❌ WRONG — ignores config.agent.protocol, always returns CLI adapter
+// ❌ WRONG — bypasses AgentManager ownership (compiler error since Phase 4)
+import { createAgentRegistry } from "../agents/registry";
+const agent = createAgentRegistry(config).getAgent(agentName);
+
+// ❌ WRONG — stub that always returns undefined (removed from barrel in Phase 4)
 import { getAgent } from "../agents/registry";
-const agent = getAgent(agentName);  // even when config is in scope
+const agent = getAgent(agentName);
 ```
 
-The `_deps.getAgent` fallback in `?? _deps.getAgent` is acceptable ONLY as a test injection point. In production, `agentGetFn` is always set by `runner.ts`.
+The `_deps.getAgent` fallback in `ctx.agentGetFn ?? _deps.getAgent` defaults to `() => undefined` — it is a test injection point only. In production, `agentGetFn` is always set by `runner.ts`.

--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -6,8 +6,8 @@
  */
 
 import { join } from "node:path";
+import { AgentManager } from "../agents";
 import { resolveDefaultAgent } from "../agents";
-import { createAgentRegistry } from "../agents/registry";
 import type { AgentAdapter } from "../agents/types";
 import { resolveConfiguredModel } from "../config";
 import { getLogger } from "../logger";
@@ -85,7 +85,7 @@ export const _generatorPRDDeps = {
         config.acceptance?.model ?? "fast",
         resolveDefaultAgent(config),
       );
-      const adapter = createAgentRegistry(config).getAgent(resolvedModel.agent);
+      const adapter = new AgentManager(config).getAgent(resolvedModel.agent);
       if (!adapter) throw new Error(`Agent "${resolvedModel.agent}" not found`);
 
       return adapter.complete(...args);

--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -6,8 +6,7 @@
  */
 
 import type { AgentAdapter } from "../agents";
-import { resolveDefaultAgent } from "../agents";
-import { createAgentRegistry } from "../agents/registry";
+import { AgentManager, resolveDefaultAgent } from "../agents";
 import { resolveConfiguredModel } from "../config";
 import { getLogger } from "../logger";
 import { AcceptancePromptBuilder } from "../prompts";
@@ -34,7 +33,7 @@ export const _refineDeps = {
         config.acceptance?.model ?? "fast",
         resolveDefaultAgent(config),
       );
-      const adapter = createAgentRegistry(config).getAgent(resolvedModel.agent);
+      const adapter = new AgentManager(config).getAgent(resolvedModel.agent);
       if (!adapter) throw new Error(`Agent "${resolvedModel.agent}" not found`);
 
       return adapter.complete(...args);

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,6 +1,6 @@
 export type { AgentAdapter, AgentCapabilities, AgentResult, AgentRunOptions, CompleteOptions } from "./types";
 export { CompleteError } from "./types";
-export { getAllAgentNames, getAgent, getInstalledAgents, checkAgentHealth } from "./registry";
+export { getAllAgentNames, getInstalledAgents, checkAgentHealth, KNOWN_AGENT_NAMES } from "./registry";
 export type { ModelCostRates, TokenUsage, CostEstimate, TokenUsageWithConfidence, SessionTokenUsage } from "./cost";
 export {
   COST_RATES,

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -20,6 +20,7 @@ import type {
   AgentRunRequest,
   IAgentManager,
 } from "./manager-types";
+import { createAgentRegistry } from "./registry";
 import type { AgentRegistry } from "./registry";
 import type { AgentResult, CompleteOptions, CompleteResult } from "./types";
 
@@ -40,7 +41,7 @@ export const _agentManagerDeps = {
 
 export class AgentManager implements IAgentManager {
   private readonly _config: NaxConfig;
-  private readonly _registry: AgentRegistry | undefined;
+  private _registry: AgentRegistry | undefined;
   private readonly _unavailable = new Map<string, AdapterFailure>();
   private readonly _prunedFallback = new Set<string>();
   private readonly _emitter = new EventEmitter();
@@ -87,7 +88,7 @@ export class AgentManager implements IAgentManager {
       for (const to of tos) candidates.add(to);
     }
     for (const name of candidates) {
-      const adapter = this._registry?.getAgent(name);
+      const adapter = this._resolveRegistry().getAgent(name);
       if (!adapter || typeof adapter.hasCredentials !== "function") continue;
       const ok = await adapter.hasCredentials();
       if (ok) continue;
@@ -156,7 +157,7 @@ export class AgentManager implements IAgentManager {
         updatedBundle = hopOut.bundle ?? currentBundle;
         finalPrompt = hopOut.prompt ?? finalPrompt;
       } else {
-        const adapter = this._registry?.getAgent(currentAgent);
+        const adapter = this._resolveRegistry().getAgent(currentAgent);
         if (!adapter) {
           logger?.warn("agent-manager", "No adapter available", {
             storyId: request.runOptions.storyId,
@@ -281,7 +282,7 @@ export class AgentManager implements IAgentManager {
     let hopsSoFar = 0;
 
     while (true) {
-      const adapter = this._registry?.getAgent(currentAgent);
+      const adapter = this._resolveRegistry().getAgent(currentAgent);
       if (!adapter) {
         return {
           result: { output: "", costUsd: 0, source: "fallback" },
@@ -358,7 +359,12 @@ export class AgentManager implements IAgentManager {
   }
 
   getAgent(name: string): import("./types").AgentAdapter | undefined {
-    return this._registry?.getAgent(name);
+    return this._resolveRegistry().getAgent(name);
+  }
+
+  private _resolveRegistry(): AgentRegistry {
+    this._registry ??= createAgentRegistry(this._config);
+    return this._registry;
   }
 
   /** @internal — test helper */

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -28,11 +28,6 @@ export function getAllAgentNames(): string[] {
   return KNOWN_AGENT_NAMES;
 }
 
-/** Get a specific agent by name — returns undefined (use createAgentRegistry for production) */
-export function getAgent(_name: string): AgentAdapter | undefined {
-  return undefined;
-}
-
 /** Get all installed agents on this machine */
 export async function getInstalledAgents(): Promise<AgentAdapter[]> {
   return [];

--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -4,9 +4,8 @@
  * Lists available agents with their binary paths, versions, and health status.
  */
 
-import { resolveDefaultAgent } from "../agents";
+import { KNOWN_AGENT_NAMES, resolveDefaultAgent } from "../agents";
 import { AcpAgentAdapter } from "../agents/acp/adapter";
-import { KNOWN_AGENT_NAMES } from "../agents/registry";
 import { getAgentVersion } from "../agents/shared/version-detection";
 import type { NaxConfig } from "../config/schema";
 

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -11,8 +11,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
-import { resolveDefaultAgent } from "../agents";
-import { createAgentRegistry, getAgent } from "../agents/registry";
+import { AgentManager, resolveDefaultAgent } from "../agents";
 import { parseDecomposeOutput } from "../agents/shared/decompose";
 import { buildDecomposePromptAsync } from "../agents/shared/decompose-prompt";
 import type { DecomposedStory } from "../agents/shared/types-extended";
@@ -61,7 +60,7 @@ export const _planDeps = {
   writeFile: (path: string, content: string): Promise<void> => Bun.write(path, content).then(() => {}),
   scanCodebase: (workdir: string): Promise<CodebaseScan> => scanCodebase(workdir),
   getAgent: (name: string, cfg?: NaxConfig): AgentAdapter | undefined =>
-    cfg ? createAgentRegistry(cfg).getAgent(name) : getAgent(name),
+    cfg ? new AgentManager(cfg).getAgent(name) : undefined,
   readPackageJson: (workdir: string): Promise<Record<string, unknown> | null> =>
     Bun.file(join(workdir, "package.json"))
       .json()

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -1,6 +1,5 @@
-import { resolveDefaultAgent } from "../agents";
+import { AgentManager, resolveDefaultAgent } from "../agents";
 import { computeAcpHandle } from "../agents/acp/adapter";
-import { createAgentRegistry, getAgent } from "../agents/registry";
 import type { AgentAdapter, CompleteOptions, CompleteResult } from "../agents/types";
 import type { ModelTier, NaxConfig, ResolvedConfiguredModel } from "../config";
 import { DEFAULT_CONFIG, resolveConfiguredModel, resolveModelForAgent } from "../config";
@@ -78,14 +77,8 @@ export interface DebateSessionOptions {
 
 /** Injectable deps for testability */
 export const _debateSessionDeps = {
-  /**
-   * Resolve an agent adapter by name.
-   * When config is provided, uses createAgentRegistry(config) so that ACP agents
-   * are returned as AcpAgentAdapter (respecting agent.protocol).
-   * Falls back to bare getAgent() when config is absent (backward compat / tests).
-   */
   getAgent: (name: string, config?: NaxConfig): AgentAdapter | undefined =>
-    config ? createAgentRegistry(config).getAgent(name) : getAgent(name),
+    config ? new AgentManager(config).getAgent(name) : undefined,
   getSafeLogger: getSafeLogger as () => ReturnType<typeof getSafeLogger>,
   readFile: (path: string): Promise<string> => Bun.file(path).text(),
 };

--- a/src/execution/lifecycle/acceptance-fix.ts
+++ b/src/execution/lifecycle/acceptance-fix.ts
@@ -14,7 +14,7 @@ import { type DiagnoseOptions, diagnoseAcceptanceFailure } from "../../acceptanc
 import { executeSourceFix, executeTestFix } from "../../acceptance/fix-executor";
 import { resolveAcceptanceFeatureTestPath } from "../../acceptance/test-path";
 import type { DiagnosisResult, SemanticVerdict } from "../../acceptance/types";
-import { getAgent, resolveDefaultAgent } from "../../agents";
+import { resolveDefaultAgent } from "../../agents";
 import type { AgentAdapter } from "../../agents/types";
 import { resolveConfiguredModel } from "../../config";
 import { getSafeLogger } from "../../logger";
@@ -120,7 +120,7 @@ export interface ApplyFixResult {
 
 /** Injectable dependencies for applyFix — allows tests to mock executors. */
 export const _applyFixDeps = {
-  getAgent,
+  getAgent: (_name: string): AgentAdapter | undefined => undefined,
   executeSourceFix,
   executeTestFix,
 };

--- a/src/execution/lifecycle/acceptance-loop.ts
+++ b/src/execution/lifecycle/acceptance-loop.ts
@@ -12,7 +12,8 @@
 import { loadAcceptanceTestContent as loadAcceptanceTestContentModule } from "../../acceptance/content-loader";
 import { loadSemanticVerdicts } from "../../acceptance/semantic-verdict";
 import { findExistingAcceptanceTestPath as findExistingAcceptanceTestPathFromOptions } from "../../acceptance/test-path";
-import { getAgent, resolveDefaultAgent } from "../../agents";
+import { resolveDefaultAgent } from "../../agents";
+import type { AgentAdapter } from "../../agents/types";
 import type { NaxConfig } from "../../config";
 import { type LoadedHooksConfig, fireHook } from "../../hooks";
 import { getSafeLogger } from "../../logger";
@@ -81,7 +82,7 @@ export interface AcceptanceLoopResult {
 // buildResult — extracted to acceptance-helpers.ts (re-exported above)
 
 export const _acceptanceLoopDeps = {
-  getAgent,
+  getAgent: (_name: string): AgentAdapter | undefined => undefined,
   loadSemanticVerdicts,
 };
 

--- a/src/execution/lifecycle/run-initialization.ts
+++ b/src/execution/lifecycle/run-initialization.ts
@@ -9,7 +9,8 @@
  */
 
 import { join } from "node:path";
-import { getAgent, resolveDefaultAgent } from "../../agents";
+import { resolveDefaultAgent } from "../../agents";
+import type { AgentAdapter } from "../../agents/types";
 import type { NaxConfig } from "../../config";
 import { AgentNotFoundError, AgentNotInstalledError, StoryLimitExceededError } from "../../errors";
 import { getSafeLogger } from "../../logger";
@@ -26,7 +27,7 @@ import { hasCommitsForStory } from "../../utils/git";
  * hasCommitsForStory and runReview without mock.module().
  */
 export const _reconcileDeps = {
-  getAgent,
+  getAgent: (_name: string): AgentAdapter | undefined => undefined,
   hasCommitsForStory: (workdir: string, storyId: string) => hasCommitsForStory(workdir, storyId),
   runReview: (reviewConfig: ReviewConfig, workdir: string, executionConfig: NaxConfig["execution"]) =>
     runReview(reviewConfig, workdir, executionConfig),

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -45,7 +45,7 @@ export interface RunnerExecutionOptions {
   formatterMode: "quiet" | "normal" | "verbose" | "json";
   headless: boolean;
   parallel?: number;
-  /** Protocol-aware agent resolver — created once in runner.ts from createAgentRegistry(config) */
+  /** Protocol-aware agent resolver — bound from agentManager.getAgent in runner.ts */
   agentGetFn?: AgentGetFn;
   /** PID registry for crash recovery — passed to agent.run() to register child processes. */
   pidRegistry?: PidRegistry;

--- a/src/execution/runner-setup.ts
+++ b/src/execution/runner-setup.ts
@@ -32,7 +32,7 @@ export interface RunnerSetupOptions {
   getIterations: () => number;
   getStoriesCompleted: () => number;
   getTotalStories: () => number;
-  /** Protocol-aware agent resolver — created from createAgentRegistry(config) in runner.ts */
+  /** Protocol-aware agent resolver — bound from agentManager.getAgent in runner.ts */
   agentGetFn?: AgentGetFn;
   /** Per-run AgentManager (ADR-012). When provided, validateCredentials() is called during setup. */
   agentManager?: import("../agents").IAgentManager;

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -14,7 +14,6 @@
  */
 
 import { AgentManager } from "../agents";
-import { createAgentRegistry } from "../agents/registry";
 import type { NaxConfig } from "../config";
 import type { LoadedHooksConfig } from "../hooks";
 import { fireHook } from "../hooks";
@@ -114,10 +113,8 @@ export async function run(options: RunOptions): Promise<RunResult> {
   // biome-ignore lint/suspicious/noExplicitAny: Metrics array type varies
   const allStoryMetrics: any[] = [];
 
-  // Create protocol-aware agent registry (ACP wiring — ACP-003/registry-wiring)
-  const registry = createAgentRegistry(config);
-  const agentGetFn = registry.getAgent.bind(registry);
-  const agentManager = new AgentManager(config, registry);
+  const agentManager = new AgentManager(config);
+  const agentGetFn = agentManager.getAgent.bind(agentManager);
 
   // Declare prd before crash handler setup to avoid TDZ if SIGTERM arrives during setup
   // biome-ignore lint/suspicious/noExplicitAny: PRD type initialized during setup

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -24,7 +24,7 @@ import path from "node:path";
 import { buildAcceptanceRunCommand } from "../../acceptance/generator";
 import { groupStoriesByPackage } from "../../acceptance/test-path";
 import type { RefinedCriterion } from "../../acceptance/types";
-import { getAgent } from "../../agents/registry";
+import type { AgentAdapter } from "../../agents/types";
 import { type ModelDef, type ResolvedConfiguredModel, resolveConfiguredModel } from "../../config";
 import { getSafeLogger } from "../../logger";
 import { autoCommitIfDirty as _autoCommitIfDirty } from "../../utils/git";
@@ -68,7 +68,7 @@ export function computeACFingerprint(criteria: string[]): string {
  * @internal
  */
 export const _acceptanceSetupDeps = {
-  getAgent,
+  getAgent: (_name: string): AgentAdapter | undefined => undefined,
   fileExists: async (_path: string): Promise<boolean> => {
     const f = Bun.file(_path);
     return f.exists();

--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -6,7 +6,7 @@
  * findings by file scope and route test-file findings to a test-writer session.
  */
 
-import type { createAgentRegistry } from "../../agents/registry";
+import type { AgentAdapter } from "../../agents/types";
 import { resolveModelForAgent } from "../../config";
 import { resolvePermissions } from "../../config/permissions";
 import { getLogger } from "../../logger";
@@ -60,7 +60,7 @@ export async function runTestWriterRectification(
   ctx: PipelineContext,
   testWriterChecks: ReviewCheckResult[],
   story: UserStory,
-  agentGetFn: (name: string) => ReturnType<ReturnType<typeof createAgentRegistry>["getAgent"]>,
+  agentGetFn: (name: string) => AgentAdapter | undefined,
   keepOpen = true,
 ): Promise<number> {
   const logger = getLogger();

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -19,8 +19,8 @@
  * - `escalate`                 — max attempts exhausted or agent unavailable
  */
 
+import { AgentManager } from "../../agents";
 import { computeAcpHandle } from "../../agents/acp/adapter";
-import { createAgentRegistry } from "../../agents/registry";
 import { resolveModelForAgent } from "../../config";
 import type { NaxConfig } from "../../config";
 import { resolvePermissions } from "../../config/permissions";
@@ -701,7 +701,7 @@ async function runAgentRectification(
  */
 export const _autofixDeps = {
   /** Protocol-aware agent factory. Override in tests to inject a mock agent. */
-  getAgent: (name: string, config: NaxConfig) => createAgentRegistry(config).getAgent(name),
+  getAgent: (name: string, config: NaxConfig) => new AgentManager(config).getAgent(name),
   runQualityCommand,
   recheckReview,
   captureGitRef,
@@ -716,6 +716,6 @@ export const _autofixDeps = {
     ctx: PipelineContext,
     testWriterChecks: ReviewCheckResult[],
     story: UserStory,
-    agentGetFn: (name: string) => ReturnType<ReturnType<typeof createAgentRegistry>["getAgent"]>,
+    agentGetFn: (name: string) => import("../../agents/types").AgentAdapter | undefined,
   ): Promise<number> => runTestWriterRectification(ctx, testWriterChecks, story, agentGetFn),
 };

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -6,7 +6,8 @@
  * On availability failure, delegates swap policy to AgentManager.runWithFallback().
  */
 
-import { getAgent, validateAgentForTier } from "../../agents";
+import { validateAgentForTier } from "../../agents";
+import type { AgentAdapter } from "../../agents/types";
 import { resolveModelForAgent } from "../../config";
 import { resolvePermissions } from "../../config/permissions";
 import { failAndClose } from "../../execution/session-manager-runtime";
@@ -310,7 +311,7 @@ export const executionStage: PipelineStage = {
  * (`src/session/runners/single-session-runner.ts` → `_singleSessionRunnerDeps`).
  */
 export const _executionDeps = {
-  getAgent,
+  getAgent: (_name: string): AgentAdapter | undefined => undefined,
   validateAgentForTier,
   detectMergeConflict,
   checkMergeConflict,

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -11,7 +11,7 @@
  */
 
 // RE-ARCH: rewrite
-import { getAgent } from "../../agents";
+import type { AgentAdapter } from "../../agents/types";
 import { checkSecurityReview, isTriggerEnabled } from "../../interaction/triggers";
 import { getLogger } from "../../logger";
 import { createReviewerSession } from "../../review/dialogue";
@@ -33,7 +33,7 @@ export const reviewStage: PipelineStage = {
     // MW-010: workdir is already resolved to the package directory at context creation
 
     // Build agent resolver for dialogue session creation
-    const agentResolver = ctx.agentGetFn ?? getAgent;
+    const agentResolver = ctx.agentGetFn ?? ((_name: string): AgentAdapter | undefined => undefined);
     const agentName = ctx.agentManager?.getDefault() ?? "claude";
 
     // AC3: When dialogue is enabled (non-debate) and a session already exists (retry loop), use reReview()

--- a/src/routing/classify.ts
+++ b/src/routing/classify.ts
@@ -2,7 +2,7 @@
  * Pure classification functions — no agent registry or heavy deps.
  *
  * Extracted from router.ts so test files can import classifyComplexity /
- * determineTestStrategy without pulling in createAgentRegistry → AcpAgentAdapter,
+ * determineTestStrategy without pulling in AgentManager → AcpAgentAdapter,
  * which registers background handles and prevents Bun from exiting after tests.
  */
 

--- a/src/routing/router.ts
+++ b/src/routing/router.ts
@@ -6,8 +6,7 @@
  *   plugin routers > LLM fallback > keyword fallback
  */
 
-import { resolveDefaultAgent } from "../agents";
-import { createAgentRegistry } from "../agents/registry";
+import { AgentManager, resolveDefaultAgent } from "../agents";
 import type { AgentAdapter } from "../agents/types";
 import type { Complexity, ModelTier, NaxConfig, TddStrategy, TestStrategy } from "../config";
 import { resolveConfiguredModel } from "../config";
@@ -270,7 +269,7 @@ export function routeTask(
  * No-ops if routing.strategy is not "llm" or mode is "per-story" or stories is empty.
  */
 export const _tryLlmBatchRouteDeps = {
-  getAgent: (name: string, config: NaxConfig) => createAgentRegistry(config).getAgent(name),
+  getAgent: (name: string, config: NaxConfig) => new AgentManager(config).getAgent(name),
 };
 
 export async function tryLlmBatchRoute(

--- a/src/session/runners/single-session-runner.ts
+++ b/src/session/runners/single-session-runner.ts
@@ -11,7 +11,7 @@
  */
 
 import type { AgentAdapter } from "../../agents";
-import { getAgent, wrapAdapterAsManager } from "../../agents";
+import { wrapAdapterAsManager } from "../../agents";
 import type { AgentRunRequest, IAgentManager } from "../../agents/manager-types";
 import type { AgentResult, AgentRunOptions } from "../../agents/types";
 import { resolveModelForAgent } from "../../config";
@@ -64,7 +64,7 @@ export const _singleSessionRunnerDeps = {
     storyId?: string,
   ): ContextBundle => new ContextOrchestrator([]).rebuildForAgent(prior, { newAgentId, failure, storyId }),
   writeRebuildManifest,
-  getAgent,
+  getAgent: (_name: string): AgentAdapter | undefined => undefined,
   createContextToolRuntime,
 };
 

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -7,10 +7,9 @@
  * Used by: src/pipeline/stages/rectify.ts, src/execution/lifecycle/run-regression.ts
  */
 
-import { getAgent as _getAgent, resolveDefaultAgent } from "../agents";
+import { AgentManager, resolveDefaultAgent } from "../agents";
 import { computeAcpHandle } from "../agents/acp/adapter";
 import { estimateCostByDuration } from "../agents/cost";
-import { createAgentRegistry } from "../agents/registry";
 import type { AgentAdapter } from "../agents/types";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config";
@@ -126,8 +125,8 @@ async function _defaultRunDebate(
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const _rectificationDeps = {
-  getAgent: (name: string, config?: NaxConfig) =>
-    (config ? createAgentRegistry(config).getAgent(name) : _getAgent(name)) as AgentAdapter | undefined,
+  getAgent: (name: string, config?: NaxConfig): AgentAdapter | undefined =>
+    config ? new AgentManager(config).getAgent(name) : undefined,
   runVerification: _fullSuite as typeof _fullSuite,
   escalateTier: _escalateTier,
   runDebate: _defaultRunDebate as typeof _defaultRunDebate,

--- a/test/unit/agents/manager-iface-run.test.ts
+++ b/test/unit/agents/manager-iface-run.test.ts
@@ -173,8 +173,8 @@ describe("IAgentManager.getAgent()", () => {
     expect(mgr.getAgent("nonexistent")).toBeUndefined();
   });
 
-  test("returns undefined when no registry is set", () => {
+  test("lazily creates registry and returns adapter when no explicit registry is provided (Phase 4)", () => {
     const mgr = new AgentManager(makeConfig());
-    expect(mgr.getAgent("claude")).toBeUndefined();
+    expect(mgr.getAgent("claude")).not.toBeUndefined();
   });
 });

--- a/test/unit/agents/manager.test.ts
+++ b/test/unit/agents/manager.test.ts
@@ -78,8 +78,9 @@ describe("AgentManager — Phase 1 pass-through", () => {
     expect(manager.nextCandidate("claude", 0)).toBeNull();
   });
 
-  test("runWithFallback() with no registry returns failure result and empty fallbacks", async () => {
-    const manager = new AgentManager(DEFAULT_CONFIG);
+  test("runWithFallback() with stub registry returning undefined returns failure result and empty fallbacks", async () => {
+    const stubRegistry = { getAgent: () => undefined };
+    const manager = new AgentManager(DEFAULT_CONFIG, stubRegistry as never);
     const outcome = await manager.runWithFallback({
       runOptions: {
         prompt: "test",

--- a/test/unit/agents/phase4-registry-cleanup.test.ts
+++ b/test/unit/agents/phase4-registry-cleanup.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Phase 4 invariants — ADR-013 AgentRegistry ownership cleanup
+ *
+ * Acceptance criteria:
+ *   - AgentManager.getAgent() works without an explicit registry (lazy creation)
+ *   - src/agents barrel does NOT export getAgent (removed)
+ *   - src/agents barrel DOES export KNOWN_AGENT_NAMES
+ *   - createAgentRegistry is only used inside src/agents/manager.ts
+ *   - No src/ file outside src/agents/manager.ts imports from agents/registry
+ */
+
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { AgentManager } from "../../../src/agents/manager";
+import { DEFAULT_CONFIG } from "../../../src/config/defaults";
+
+const ROOT = join(import.meta.dir, "../../../");
+
+async function readSrc(rel: string): Promise<string> {
+  return Bun.file(join(ROOT, rel)).text();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Behavioral: AgentManager lazy registry
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AgentManager — lazy registry creation (Phase 4)", () => {
+  test("getAgent returns an adapter without an explicit registry", () => {
+    const manager = new AgentManager(DEFAULT_CONFIG);
+    const adapter = manager.getAgent("claude");
+    expect(adapter).not.toBeUndefined();
+  });
+
+  test("getAgent returns undefined for unknown agent names", () => {
+    const manager = new AgentManager(DEFAULT_CONFIG);
+    const adapter = manager.getAgent("unknown-agent-xyz");
+    expect(adapter).toBeUndefined();
+  });
+
+  test("getAgent returns the same adapter on repeated calls (cache)", () => {
+    const manager = new AgentManager(DEFAULT_CONFIG);
+    const first = manager.getAgent("claude");
+    const second = manager.getAgent("claude");
+    expect(first).toBe(second);
+  });
+
+  test("_registry is undefined before first getAgent() call and defined after", () => {
+    const manager = new AgentManager(DEFAULT_CONFIG);
+    // Access private field via type cast to verify laziness
+    const before = (manager as unknown as Record<string, unknown>)["_registry"];
+    expect(before).toBeUndefined();
+    manager.getAgent("claude");
+    const after = (manager as unknown as Record<string, unknown>)["_registry"];
+    expect(after).not.toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Barrel invariants
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("src/agents barrel — Phase 4 exports", () => {
+  test("barrel does NOT export getAgent", async () => {
+    const code = await readSrc("src/agents/index.ts");
+    // getAgent (the stub) must not be in the barrel export
+    expect(code).not.toMatch(/export\s+\{[^}]*\bgetAgent\b[^}]*\}\s+from/);
+  });
+
+  test("barrel DOES export KNOWN_AGENT_NAMES", async () => {
+    const code = await readSrc("src/agents/index.ts");
+    expect(code).toContain("KNOWN_AGENT_NAMES");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Source-wide invariants: no createAgentRegistry outside agents/manager.ts
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("createAgentRegistry confinement (Phase 4)", () => {
+  test("no src/ file outside src/agents/manager.ts imports createAgentRegistry", async () => {
+    const files: string[] = [];
+    for await (const f of new Bun.Glob("**/*.ts").scan({ cwd: join(ROOT, "src"), absolute: true })) {
+      files.push(f);
+    }
+    const violations: string[] = [];
+    for (const file of files) {
+      // Allow in agents/manager.ts (the one permitted import site) and
+      // agents/registry.ts (the definition site).
+      if (file.endsWith("agents/manager.ts") || file.endsWith("agents/registry.ts")) continue;
+      const content = await Bun.file(file).text();
+      if (content.includes("createAgentRegistry")) {
+        violations.push(file.replace(ROOT, ""));
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  test("no src/ file outside src/agents/manager.ts imports from agents/registry", async () => {
+    const files: string[] = [];
+    for await (const f of new Bun.Glob("**/*.ts").scan({ cwd: join(ROOT, "src"), absolute: true })) {
+      files.push(f);
+    }
+    const violations: string[] = [];
+    for (const file of files) {
+      if (file.endsWith("agents/manager.ts") || file.endsWith("agents/registry.ts")) continue;
+      const content = await Bun.file(file).text();
+      // Match value imports from agents/registry — type-only imports are fine
+      if (/import\s+(?!type\s*\{)[^;]+from\s+["'][^"']*agents\/registry["']/.test(content)) {
+        violations.push(file.replace(ROOT, ""));
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- `AgentManager` now lazily self-creates its `AgentRegistry` via `_resolveRegistry()` (`??=` operator) — no external caller needs to instantiate a registry
- Removed dead `getAgent` stub from `src/agents/registry.ts` and its barrel export; added `KNOWN_AGENT_NAMES` to the barrel instead
- Migrated all ~18 violation sites across pipeline stages, CLI, routing, debate, verification, and execution to use `new AgentManager(config).getAgent(name)` or `(_name) => undefined` DI-pattern stubs (for sites where `agentGetFn` is always set in production)
- Phase 4 invariant tests confirm: correct barrel exports, `createAgentRegistry` confined to `agents/manager.ts`, no value imports from `agents/registry` outside the permitted sites, and laziness (`_registry` is `undefined` before first `getAgent()` call)
- Updated `adapter-wiring.md` Rule 3 to document the compiler-enforced boundary

## Test plan

- [ ] `timeout 60 bun test test/unit/agents/ --timeout=10000` — 412 pass, 0 fail
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] Phase 4 invariant tests: `phase4-registry-cleanup.test.ts` — all 8 pass (including new laziness test)
- [ ] Full suite: `bun run test` — verify no regressions