### PR TITLE
feat(agents): ADR-013 Phase 6A — centralized AgentManager factory

### DIFF
--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -1,0 +1,12 @@
+import type { NaxConfig } from "../config";
+import { AgentManager } from "./manager";
+import type { IAgentManager } from "./manager-types";
+
+/**
+ * Single construction point for AgentManager. Pre-run phases and CLI entry
+ * points call this. Mid-run code must receive IAgentManager via context/DI —
+ * it must NOT call this factory. See docs/specs/SPEC-agent-manager-lifetime.md §2.1.
+ */
+export function createAgentManager(config: NaxConfig): IAgentManager {
+  return new AgentManager(config);
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -26,3 +26,4 @@ export type {
   AgentRunRequest,
 } from "./manager-types";
 export { resolveDefaultAgent, wrapAdapterAsManager } from "./utils";
+export { createAgentManager } from "./factory";

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -11,8 +11,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
-import { AgentManager, resolveDefaultAgent } from "../agents";
-import type { IAgentManager } from "../agents";
+import { createAgentManager, resolveDefaultAgent } from "../agents";
 import { parseDecomposeOutput } from "../agents/shared/decompose";
 import { buildDecomposePromptAsync } from "../agents/shared/decompose-prompt";
 import type { DecomposedStory } from "../agents/shared/types-extended";
@@ -59,7 +58,7 @@ export const _planDeps = {
   readFile: (path: string): Promise<string> => Bun.file(path).text(),
   writeFile: (path: string, content: string): Promise<void> => Bun.write(path, content).then(() => {}),
   scanCodebase: (workdir: string): Promise<CodebaseScan> => scanCodebase(workdir),
-  createManager: (cfg: NaxConfig): IAgentManager => new AgentManager(cfg),
+  createManager: createAgentManager,
   readPackageJson: (workdir: string): Promise<Record<string, unknown> | null> =>
     Bun.file(join(workdir, "package.json"))
       .json()

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -13,7 +13,7 @@
  * - runner-completion.ts: Acceptance loop, hooks, metrics
  */
 
-import { AgentManager } from "../agents";
+import { createAgentManager } from "../agents";
 import type { NaxConfig } from "../config";
 import type { LoadedHooksConfig } from "../hooks";
 import { fireHook } from "../hooks";
@@ -113,7 +113,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
   // biome-ignore lint/suspicious/noExplicitAny: Metrics array type varies
   const allStoryMetrics: any[] = [];
 
-  const agentManager = new AgentManager(config);
+  const agentManager = createAgentManager(config);
   const agentGetFn = agentManager.getAgent.bind(agentManager);
 
   // Declare prd before crash handler setup to avoid TDZ if SIGTERM arrives during setup

--- a/src/routing/router.ts
+++ b/src/routing/router.ts
@@ -6,7 +6,7 @@
  *   plugin routers > LLM fallback > keyword fallback
  */
 
-import { AgentManager } from "../agents";
+import { createAgentManager } from "../agents";
 import type { IAgentManager } from "../agents";
 import type { Complexity, ModelTier, NaxConfig, TddStrategy, TestStrategy } from "../config";
 import { getSafeLogger } from "../logger";
@@ -268,7 +268,7 @@ export function routeTask(
  * No-ops if routing.strategy is not "llm" or mode is "per-story" or stories is empty.
  */
 export const _tryLlmBatchRouteDeps = {
-  createManager: (config: NaxConfig): IAgentManager => new AgentManager(config),
+  createManager: createAgentManager,
 };
 
 export async function tryLlmBatchRoute(


### PR DESCRIPTION
## Summary

- Creates `src/agents/factory.ts` exporting `createAgentManager(config): IAgentManager` — the single construction point for `AgentManager`
- Exports `createAgentManager` from `src/agents/index.ts` barrel
- Migrates 3 pre-run/CLI sites to delegate to the factory instead of inlining `new AgentManager(config)`:
  - `src/execution/runner.ts:116` — SSOT per-run creation
  - `src/routing/router.ts:271` — pre-run classify phase
  - `src/cli/plan.ts:62` — CLI entry point

## Why

If the `AgentManager` constructor signature changes (e.g. takes a `SessionManager` or telemetry sink), all six inline factories would break simultaneously. One centralized factory means one edit. See `docs/specs/SPEC-agent-manager-lifetime.md` §2.2.

## Out of scope (follow-up PRs)

- **Phase 6B**: Thread `agentManager` as parameter into `verification/rectification-loop.ts` and `debate/session-helpers.ts` (mid-story sites — state-leak fix)
- **Phase 6C**: Audit and migrate `acceptance/refinement.ts` and `acceptance/generator.ts`
- **Phase 6D**: Extend `adapter-boundary.test.ts` with `new AgentManager(` scan + integration test for unavailability-state persistence

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `timeout 60 bun test test/unit/agents/ test/unit/cli/plan-decompose-adapter.test.ts` — 422 pass, 0 fail
- [x] `grep -rn "new AgentManager(" src/` — only `factory.ts` and the 4 Phase 6B/6C sites remain