### PR TITLE
feat(agents): ADR-013 Phase 6B — thread agentManager into mid-story sites

### DIFF
--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -1,4 +1,4 @@
-import { AgentManager, resolveDefaultAgent } from "../agents";
+import { createAgentManager, resolveDefaultAgent } from "../agents";
 import type { IAgentManager } from "../agents";
 import { computeAcpHandle } from "../agents/acp/adapter";
 import type { CompleteOptions, CompleteResult } from "../agents/types";
@@ -70,6 +70,8 @@ export interface DebateSessionOptions {
   workdir?: string;
   featureName?: string;
   timeoutSeconds?: number;
+  /** AgentManager threaded from the pipeline stage — ensures unavailability state survives across debate calls. */
+  agentManager?: IAgentManager;
   /** Optional ReviewerSession for debate+dialogue mode (US-001/US-002) */
   reviewerSession?: import("../review/dialogue").ReviewerSession;
   /** Outer resolver context (without labeledProposals) — sub-modules complete it */
@@ -78,7 +80,7 @@ export interface DebateSessionOptions {
 
 /** Injectable deps for testability */
 export const _debateSessionDeps = {
-  createManager: (config: NaxConfig): IAgentManager => new AgentManager(config),
+  createManager: createAgentManager,
   getSafeLogger: getSafeLogger as () => ReturnType<typeof getSafeLogger>,
   readFile: (path: string): Promise<string> => Bun.file(path).text(),
 };
@@ -192,6 +194,7 @@ export async function resolveOutcome(
   resolverContext?: ResolverContext,
   promptSuffix?: string,
   debaters?: Debater[],
+  agentManager?: IAgentManager,
 ): Promise<ResolveOutcome> {
   const resolverConfig = stageConfig.resolver;
   const logger = _debateSessionDeps.getSafeLogger();
@@ -292,7 +295,7 @@ export async function resolveOutcome(
 
   if (resolverConfig.type === "synthesis") {
     const agentName = resolverConfig.agent ?? RESOLVER_FALLBACK_AGENT;
-    const manager = _debateSessionDeps.createManager(config ?? DEFAULT_CONFIG);
+    const manager = agentManager ?? _debateSessionDeps.createManager(config ?? DEFAULT_CONFIG);
     if (manager.getAgent(agentName) !== undefined) {
       const configModels = config?.models ?? DEFAULT_CONFIG.models;
       const configDefaultAgent = resolveDefaultAgent(config ?? DEFAULT_CONFIG);
@@ -339,7 +342,7 @@ export async function resolveOutcome(
 
   if (resolverConfig.type === "custom") {
     const agentName = resolverConfig.agent ?? RESOLVER_FALLBACK_AGENT;
-    const manager = _debateSessionDeps.createManager(config ?? DEFAULT_CONFIG);
+    const manager = agentManager ?? _debateSessionDeps.createManager(config ?? DEFAULT_CONFIG);
     const configModels = config?.models ?? DEFAULT_CONFIG.models;
     const configDefaultAgent = resolveDefaultAgent(config ?? DEFAULT_CONFIG);
     const judgeSessionName =

--- a/src/debate/session-hybrid.ts
+++ b/src/debate/session-hybrid.ts
@@ -37,6 +37,7 @@ export interface HybridCtx {
   readonly workdir: string;
   readonly featureName: string;
   readonly timeoutSeconds: number;
+  readonly agentManager?: IAgentManager;
   readonly reviewerSession?: import("../review/dialogue").ReviewerSession;
   readonly resolverContextInput?: ResolverContextInput;
 }
@@ -62,7 +63,7 @@ export async function runRebuttalLoop(
   const config = ctx.stageConfig;
   const rebuttals: Rebuttal[] = [];
   let costUsd = 0;
-  const agentManager: IAgentManager = _debateSessionDeps.createManager(ctx.config);
+  const agentManager: IAgentManager = ctx.agentManager ?? _debateSessionDeps.createManager(ctx.config);
 
   const proposalList = proposals.map((s) => ({ debater: s.debater, output: s.output }));
 
@@ -145,7 +146,7 @@ export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateR
   const debaters = resolvePersonas(rawDebaters, personaStage, config.autoPersona ?? false);
   let totalCostUsd = 0;
 
-  const agentManager: IAgentManager = _debateSessionDeps.createManager(ctx.config);
+  const agentManager: IAgentManager = ctx.agentManager ?? _debateSessionDeps.createManager(ctx.config);
 
   // Resolve agents via shared helper — skip unavailable
   const resolved: ResolvedDebater[] = [];
@@ -276,6 +277,7 @@ export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateR
     fullResolverContext,
     /* promptSuffix */ undefined,
     successfulProposals.map((s) => s.debater),
+    agentManager,
   );
   totalCostUsd += resolveResult.resolverCostUsd;
 

--- a/src/debate/session-one-shot.ts
+++ b/src/debate/session-one-shot.ts
@@ -31,6 +31,7 @@ interface OneShotCtx {
   readonly timeoutMs: number;
   readonly workdir?: string;
   readonly featureName?: string;
+  readonly agentManager?: IAgentManager;
   readonly reviewerSession?: import("../review/dialogue").ReviewerSession;
   readonly resolverContextInput?: ResolverContextInput;
 }
@@ -43,7 +44,7 @@ export async function runOneShot(ctx: OneShotCtx, prompt: string): Promise<Debat
   const debaters = resolvePersonas(rawDebaters, personaStage, config.autoPersona ?? false);
   let totalCostUsd = 0;
 
-  const agentManager: IAgentManager = _debateSessionDeps.createManager(ctx.config);
+  const agentManager: IAgentManager = ctx.agentManager ?? _debateSessionDeps.createManager(ctx.config);
 
   // Step 1: Resolve agents — skip unavailable
   const resolved: ResolvedDebater[] = [];
@@ -244,6 +245,7 @@ export async function runOneShot(ctx: OneShotCtx, prompt: string): Promise<Debat
     fullResolverContext,
     /* promptSuffix */ undefined,
     successful.map((p) => p.debater),
+    agentManager,
   );
   totalCostUsd += outcome.resolverCostUsd;
 

--- a/src/debate/session-plan.ts
+++ b/src/debate/session-plan.ts
@@ -29,6 +29,7 @@ interface PlanCtx {
   readonly stage: string;
   readonly stageConfig: DebateStageConfig;
   readonly config: NaxConfig;
+  readonly agentManager?: IAgentManager;
 }
 
 export async function runPlan(
@@ -53,7 +54,7 @@ export async function runPlan(
   // Mutable: plan debater costs accumulated below; hybrid rebuttal loop adds cost via adapter.run().
   let totalCostUsd = 0;
 
-  const agentManager: IAgentManager = _debateSessionDeps.createManager(ctx.config);
+  const agentManager: IAgentManager = ctx.agentManager ?? _debateSessionDeps.createManager(ctx.config);
 
   // Resolve agents — skip unavailable
   const resolved: ResolvedDebater[] = [];
@@ -220,6 +221,7 @@ export async function runPlan(
     /* resolverContext */ undefined,
     planSynthesisSuffix,
     successful.map((p) => p.debater),
+    agentManager,
   );
 
   // Winning output: synthesis/custom resolver returns a combined PRD — use it when available.

--- a/src/debate/session-stateful.ts
+++ b/src/debate/session-stateful.ts
@@ -34,6 +34,7 @@ interface StatefulCtx {
   readonly workdir: string;
   readonly featureName: string;
   readonly timeoutSeconds: number;
+  readonly agentManager?: IAgentManager;
   readonly reviewerSession?: import("../review/dialogue").ReviewerSession;
   readonly resolverContextInput?: ResolverContextInput;
 }
@@ -121,7 +122,7 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
   const rawDebaters = config.debaters ?? [];
   const debaters = resolvePersonas(rawDebaters, personaStage, config.autoPersona ?? false);
   let totalCostUsd = 0;
-  const agentManager = _debateSessionDeps.createManager(ctx.config);
+  const agentManager = ctx.agentManager ?? _debateSessionDeps.createManager(ctx.config);
 
   // Resolve agents — skip unavailable
   const resolved: ResolvedDebater[] = [];
@@ -315,6 +316,7 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
     fullResolverContext,
     /* promptSuffix */ undefined,
     successfulProposals.map((s) => s.debater),
+    agentManager,
   );
   totalCostUsd += outcome.resolverCostUsd;
 

--- a/src/debate/session.ts
+++ b/src/debate/session.ts
@@ -5,6 +5,7 @@
  * Delegates one-shot, stateful, and plan execution to focused sub-modules.
  */
 
+import type { IAgentManager } from "../agents";
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
 import { _debateSessionDeps } from "./session-helpers";
@@ -28,6 +29,7 @@ export class DebateSession {
   private readonly workdir: string;
   private readonly featureName: string;
   private readonly timeoutSeconds: number;
+  private readonly agentManager: IAgentManager | undefined;
   private readonly reviewerSession: import("./session-helpers").DebateSessionOptions["reviewerSession"];
   private readonly resolverContextInput: import("./session-helpers").DebateSessionOptions["resolverContextInput"];
   private get timeoutMs(): number {
@@ -42,6 +44,7 @@ export class DebateSession {
     this.workdir = opts.workdir ?? process.cwd();
     this.featureName = opts.featureName ?? opts.stage;
     this.timeoutSeconds = opts.timeoutSeconds ?? opts.stageConfig.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
+    this.agentManager = opts.agentManager;
     this.reviewerSession = opts.reviewerSession;
     this.resolverContextInput = opts.resolverContextInput;
   }
@@ -62,6 +65,7 @@ export class DebateSession {
             workdir: this.workdir,
             featureName: this.featureName,
             timeoutSeconds: this.timeoutSeconds,
+            agentManager: this.agentManager,
             reviewerSession: this.reviewerSession,
             resolverContextInput: this.resolverContextInput,
           },
@@ -85,6 +89,7 @@ export class DebateSession {
           timeoutMs: this.timeoutMs,
           workdir: this.workdir,
           featureName: this.featureName,
+          agentManager: this.agentManager,
           reviewerSession: this.reviewerSession,
           resolverContextInput: this.resolverContextInput,
         },
@@ -103,6 +108,7 @@ export class DebateSession {
           workdir: this.workdir,
           featureName: this.featureName,
           timeoutSeconds: this.timeoutSeconds,
+          agentManager: this.agentManager,
           reviewerSession: this.reviewerSession,
           resolverContextInput: this.resolverContextInput,
         },
@@ -119,6 +125,7 @@ export class DebateSession {
         timeoutMs: this.timeoutMs,
         workdir: this.workdir,
         featureName: this.featureName,
+        agentManager: this.agentManager,
         reviewerSession: this.reviewerSession,
         resolverContextInput: this.resolverContextInput,
       },
@@ -157,6 +164,7 @@ export class DebateSession {
         stage: this.stage,
         stageConfig: this.stageConfig,
         config: this.config,
+        agentManager: this.agentManager,
       },
       taskContext,
       outputFormat,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -266,6 +266,7 @@ export async function runSemanticReview(
       workdir,
       featureName: featureName,
       timeoutSeconds: naxConfig?.execution?.sessionTimeoutSeconds,
+      agentManager: agentManager ?? undefined,
       reviewerSession: resolverSession,
       resolverContextInput: resolverSession
         ? {

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -7,7 +7,7 @@
  * Used by: src/pipeline/stages/rectify.ts, src/execution/lifecycle/run-regression.ts
  */
 
-import { AgentManager } from "../agents";
+import { createAgentManager } from "../agents";
 import type { IAgentManager } from "../agents";
 import { computeAcpHandle } from "../agents/acp/adapter";
 import { estimateCostByDuration } from "../agents/cost";
@@ -69,10 +69,11 @@ async function _defaultRunDebate(
   stageConfig: DebateStageConfig,
   prompt: string,
   config: NaxConfig,
+  agentManager: IAgentManager,
 ): Promise<{ output: string | null; totalCostUsd: number }> {
   const logger = getSafeLogger();
   const debaters: Debater[] = stageConfig.debaters ?? [];
-  const manager = _rectificationDeps.createManager(config);
+  const manager = agentManager;
   const resolved: Array<{ debater: Debater; agentName: string }> = [];
 
   for (const debater of debaters) {
@@ -125,7 +126,7 @@ async function _defaultRunDebate(
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const _rectificationDeps = {
-  createManager: (config: NaxConfig): IAgentManager => new AgentManager(config),
+  createManager: createAgentManager,
   runVerification: _fullSuite as typeof _fullSuite,
   escalateTier: _escalateTier,
   runDebate: _defaultRunDebate as typeof _defaultRunDebate,
@@ -150,6 +151,7 @@ export async function runRectificationLoop(
     sessionId,
   } = opts;
   const logger = getSafeLogger();
+  const agentManager = opts.agentManager ?? _rectificationDeps.createManager(config);
   const rectificationConfig = config.execution.rectification;
   const testSummary = parseTestOutput(testOutput);
   const label = promptPrefix ? "regression rectification" : "rectification";
@@ -189,7 +191,13 @@ export async function runRectificationLoop(
         const failureSummary = formatFailureSummary(testSummary.failures);
         const diagnosisPrompt = `Analyze the following test failures and identify the root cause:\n\n${failureSummary}`;
         try {
-          const debateResult = await _rectificationDeps.runDebate(story.id, debateStageConfig, diagnosisPrompt, config);
+          const debateResult = await _rectificationDeps.runDebate(
+            story.id,
+            debateStageConfig,
+            diagnosisPrompt,
+            config,
+            agentManager,
+          );
           if (debateResult.totalCostUsd > 0 && story.routing) {
             story.routing.estimatedCost = (story.routing.estimatedCost ?? 0) + debateResult.totalCostUsd;
           }
@@ -233,7 +241,6 @@ export async function runRectificationLoop(
       return rectificationPrompt;
     },
     runAttempt: async (attempt, rectificationPrompt) => {
-      const agentManager = opts.agentManager ?? _rectificationDeps.createManager(config);
       const defaultAgent = agentManager.getDefault();
 
       const complexity = story.routing?.complexity ?? "medium";
@@ -395,7 +402,7 @@ export async function runRectificationLoop(
         return false;
       }
 
-      const escalationManager = opts.agentManager ?? _rectificationDeps.createManager(config);
+      const escalationManager = agentManager;
       const agentName = escalatedAgent ?? story.routing?.agent ?? escalationManager.getDefault();
 
       if (!escalationManager.getAgent(agentName)) {

--- a/test/helpers/mock-agent-manager.ts
+++ b/test/helpers/mock-agent-manager.ts
@@ -37,6 +37,12 @@ export function makeMockAgentManager(overrides: Partial<IAgentManager> = {}): IA
     run: async () => ({ ...DEFAULT_RESULT, agentFallbacks: [] }),
     complete: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
     getAgent: (_name: string): AgentAdapter | undefined => undefined,
+    runAs: async (_name: string, _req: unknown) => ({ ...DEFAULT_RESULT, agentFallbacks: [] }),
+    completeAs: async (_name: string, _prompt: string, _opts: unknown) => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    plan: async () => ({ specContent: "" }),
+    planAs: async (_name: string, _opts: unknown) => ({ specContent: "" }),
+    decompose: async () => ({ stories: [] }),
+    decomposeAs: async (_name: string, _opts: unknown) => ({ stories: [] }),
     events: { on: () => {} },
     ...overrides,
   } as IAgentManager;

--- a/test/unit/verification/rectification-loop-debate-cost.test.ts
+++ b/test/unit/verification/rectification-loop-debate-cost.test.ts
@@ -9,22 +9,28 @@
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import type { AgentRunOptions } from "../../../src/agents/types";
+import { makeMockAgentManager } from "../../helpers";
 import { _rectificationDeps, runRectificationLoop } from "../../../src/verification/rectification-loop";
 import {
   FAILING_TEST_OUTPUT,
-  makeAgent,
   makeConfig,
   makeStory,
 } from "./_rectification-debate-helpers";
 
+const SUCCESS_VERIFICATION = {
+  success: true,
+  status: "SUCCESS" as const,
+  output: "1 pass",
+  countsTowardEscalation: false,
+};
+
 describe("runRectificationLoop — debate cost included in story total", () => {
-  const origGetAgent = _rectificationDeps.getAgent;
+  const origCreateManager = _rectificationDeps.createManager;
   const origRunVerification = _rectificationDeps.runVerification;
   const origRunDebate = _rectificationDeps.runDebate;
 
   afterEach(() => {
-    _rectificationDeps.getAgent = origGetAgent;
+    _rectificationDeps.createManager = origCreateManager;
     _rectificationDeps.runVerification = origRunVerification;
     _rectificationDeps.runDebate = origRunDebate;
     mock.restore();
@@ -36,25 +42,14 @@ describe("runRectificationLoop — debate cost included in story total", () => {
   });
 
   test("debate cost is accumulated into story.routing.estimatedCost when totalCostUsd > 0", async () => {
-    const mockAgent = makeAgent({
-      run: mock(async (_opts: AgentRunOptions) => ({
-        success: true,
-        exitCode: 0,
-        output: "done",
-        rateLimited: false,
-        durationMs: 10,
-        estimatedCost: 0,
-      })),
-    });
-
-    _rectificationDeps.getAgent = mock(() => mockAgent as unknown as import("../../../src/agents/types").AgentAdapter);
-    _rectificationDeps.runVerification = mock(async () => ({ success: true, output: "1 pass" }));
+    _rectificationDeps.createManager = mock(() => makeMockAgentManager());
+    _rectificationDeps.runVerification = mock(async () => SUCCESS_VERIFICATION);
     _rectificationDeps.runDebate = mock(async () => ({
       output: "Root cause: incorrect state mutation.",
       totalCostUsd: 0.05,
     }));
 
-    const story = makeStory({ routing: { modelTier: "balanced", estimatedCost: 0.10 } });
+    const story = makeStory({ routing: { modelTier: "balanced", estimatedCost: 0.10 } as never });
 
     await runRectificationLoop({
       config: makeConfig(true),
@@ -69,25 +64,14 @@ describe("runRectificationLoop — debate cost included in story total", () => {
   });
 
   test("story.routing.estimatedCost is not modified when debate returns totalCostUsd === 0", async () => {
-    const mockAgent = makeAgent({
-      run: mock(async (_opts: AgentRunOptions) => ({
-        success: true,
-        exitCode: 0,
-        output: "done",
-        rateLimited: false,
-        durationMs: 10,
-        estimatedCost: 0,
-      })),
-    });
-
-    _rectificationDeps.getAgent = mock(() => mockAgent as unknown as import("../../../src/agents/types").AgentAdapter);
-    _rectificationDeps.runVerification = mock(async () => ({ success: true, output: "1 pass" }));
+    _rectificationDeps.createManager = mock(() => makeMockAgentManager());
+    _rectificationDeps.runVerification = mock(async () => SUCCESS_VERIFICATION);
     _rectificationDeps.runDebate = mock(async () => ({
       output: "Root cause analysis output.",
       totalCostUsd: 0,
     }));
 
-    const story = makeStory({ routing: { modelTier: "balanced", estimatedCost: 0.10 } });
+    const story = makeStory({ routing: { modelTier: "balanced", estimatedCost: 0.10 } as never });
 
     await runRectificationLoop({
       config: makeConfig(true),
@@ -102,19 +86,8 @@ describe("runRectificationLoop — debate cost included in story total", () => {
   });
 
   test("debate cost is tracked and loop completes without error when debate succeeds", async () => {
-    const mockAgent = makeAgent({
-      run: mock(async (_opts: AgentRunOptions) => ({
-        success: true,
-        exitCode: 0,
-        output: "done",
-        rateLimited: false,
-        durationMs: 10,
-        estimatedCost: 0.01,
-      })),
-    });
-
-    _rectificationDeps.getAgent = mock(() => mockAgent as unknown as import("../../../src/agents/types").AgentAdapter);
-    _rectificationDeps.runVerification = mock(async () => ({ success: true, output: "1 pass" }));
+    _rectificationDeps.createManager = mock(() => makeMockAgentManager());
+    _rectificationDeps.runVerification = mock(async () => SUCCESS_VERIFICATION);
     _rectificationDeps.runDebate = mock(async () => ({
       output: "Root cause: incorrect state mutation.",
       totalCostUsd: 0.03,

--- a/test/unit/verification/rectification-loop.test.ts
+++ b/test/unit/verification/rectification-loop.test.ts
@@ -330,7 +330,7 @@ describe("runRectificationLoop — session context params", () => {
     expect(capturedConfig).toBe(config);
   });
 
-  test("passes config into fallback _rectificationDeps.getAgent during escalation", async () => {
+  test("passes config into _rectificationDeps.createManager during escalation", async () => {
     const config = makeConfig({
       models: {
         claude: {
@@ -428,9 +428,8 @@ describe("runRectificationLoop — session context params", () => {
 
     expect(result.succeeded).toBe(false);
     expect(verifyCallCount).toBeGreaterThanOrEqual(1);
-    expect(capturedConfigs.length).toBeGreaterThanOrEqual(2);
+    expect(capturedConfigs.length).toBeGreaterThanOrEqual(1);
     expect(capturedConfigs[0]).toBe(config);
-    expect(capturedConfigs[1]).toBe(config);
   });
 
   test("storyId is always passed from story.id regardless of featureName", async () => {


### PR DESCRIPTION
## Summary

- **`rectification-loop.ts`**: hoist `agentManager` once at `runRectificationLoop` entry (instead of per-attempt/per-closure), thread into `_defaultRunDebate`, `runAttempt`, and `onExhausted` closures
- **`debate/session*.ts`**: add `agentManager?` to `DebateSessionOptions`, all ctx interfaces, and `resolveOutcome` signature; each sub-module uses `ctx.agentManager ?? createManager()` fallback so callers can pass a pipeline-stage manager without breaking standalone usage
- **`review/semantic.ts`**: pass `agentManager` when constructing `DebateSession`
- **`test/helpers/mock-agent-manager.ts`**: add `runAs`/`completeAs`/`planAs`/`decomposeAs` stubs to satisfy full `IAgentManager` interface
- **3 pre-existing test fixes**: stale `_rectificationDeps.getAgent` mocks replaced with `createManager` mocks; `>= 2` escalation assertion updated to `>= 1` after manager hoisting

## Why

ADR-013 "one AgentManager per run" — mid-story sites were silently discarding unavailability state (rate limits, auth failures) by constructing a fresh `AgentManager` on every attempt. Threading the pipeline-stage manager through preserves that state across debate rounds and rectification retries.

## Test plan

- [ ] `bun run test` — full suite green (1165 pass, 0 fail)
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] Targeted: `timeout 60 bun test test/unit/verification/rectification-loop*.test.ts --timeout=10000` — 16 pass