### PR TITLE
feat(agents): ADR-013 Phase 6C — thread agentManager into acceptance sites

### DIFF
--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -6,7 +6,7 @@
  */
 
 import { join } from "node:path";
-import { AgentManager } from "../agents";
+import { createAgentManager } from "../agents";
 import type { IAgentManager } from "../agents";
 import type { NaxConfig } from "../config";
 import { getLogger } from "../logger";
@@ -72,7 +72,7 @@ function skeletonImportLine(testFramework?: string): string {
  * @internal
  */
 export const _generatorPRDDeps = {
-  createManager: (config: NaxConfig): IAgentManager => new AgentManager(config),
+  createManager: (config: NaxConfig): IAgentManager => createAgentManager(config),
   writeFile: async (path: string, content: string): Promise<void> => {
     await Bun.write(path, content);
   },

--- a/src/acceptance/hardening.ts
+++ b/src/acceptance/hardening.ts
@@ -6,6 +6,7 @@
  */
 
 import { resolveDefaultAgent } from "../agents";
+import type { IAgentManager } from "../agents";
 import type { AgentAdapter } from "../agents/types";
 import { type ModelDef, resolveConfiguredModel } from "../config";
 import type { NaxConfig } from "../config";
@@ -37,6 +38,7 @@ export interface HardeningContext {
   workdir: string;
   config: NaxConfig;
   agentGetFn?: (name: string) => AgentAdapter | undefined;
+  agentManager?: IAgentManager;
 }
 
 // ─── Injectable deps ────────────────────────────────────────────────────────
@@ -80,6 +82,7 @@ export async function runHardeningPass(ctx: HardeningContext): Promise<Hardening
         config: ctx.config,
         storyTitle: story.title,
         storyDescription: story.description,
+        agentManager: ctx.agentManager,
       });
       allRefined.push(...refineResult.criteria);
       result.costUsd += refineResult.costUsd;
@@ -121,6 +124,7 @@ export async function runHardeningPass(ctx: HardeningContext): Promise<Hardening
       config: ctx.config,
       language,
       targetTestFile: suggestedTestPath,
+      agentManager: ctx.agentManager,
     });
     result.costUsd += genResult.costUsd ?? 0;
 

--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -5,7 +5,7 @@
  * testable assertions using an LLM call via adapter.complete().
  */
 
-import { AgentManager } from "../agents";
+import { createAgentManager } from "../agents";
 import type { IAgentManager } from "../agents";
 import type { NaxConfig } from "../config";
 import { resolveConfiguredModel } from "../config";
@@ -22,7 +22,7 @@ import type { RefineResult, RefinedCriterion, RefinementContext } from "./types"
  * @internal
  */
 export const _refineDeps = {
-  createManager: (config: NaxConfig): IAgentManager => new AgentManager(config),
+  createManager: (config: NaxConfig): IAgentManager => createAgentManager(config),
 };
 
 /**

--- a/src/pipeline/stages/acceptance.ts
+++ b/src/pipeline/stages/acceptance.ts
@@ -243,6 +243,7 @@ export const acceptanceStage: PipelineStage = {
             workdir: ctx.workdir,
             config: ctx.config,
             agentGetFn: ctx.agentGetFn,
+            agentManager: ctx.agentManager,
           });
           logger.info("acceptance", "Hardening pass complete", {
             storyId: ctx.story.id,


### PR DESCRIPTION
## Summary

- `acceptance/refinement.ts` + `acceptance/generator.ts`: migrate `_deps.createManager` from `new AgentManager(config)` to `createAgentManager(config)` (canonical factory)
- `acceptance/hardening.ts`: add `agentManager?: IAgentManager` to `HardeningContext`; pass it through to `refine` and `generate` calls
- `pipeline/stages/acceptance.ts`: pass `ctx.agentManager` when calling `runHardeningPass`

After this PR, `new AgentManager()` in `src/` is confined to `src/agents/factory.ts` only — the final acceptance criteria from the SPEC.

## Test plan

- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `timeout 60 bun test test/unit/acceptance/refinement.test.ts test/unit/acceptance/generator-prd-result.test.ts test/unit/acceptance/hardening.test.ts` — 65 pass, 0 fail
- [ ] `grep -rn "new AgentManager" src/` → only `src/agents/factory.ts`