### PR TITLE
chore(adr-012): drop Phase 3 codemod AC (#584)

### DIFF
--- a/docs/adr/ADR-012-agent-manager-ownership.md
+++ b/docs/adr/ADR-012-agent-manager-ownership.md
@@ -229,7 +229,7 @@ AgentManager exposes `runWithFallback(request)` in this ADR. A parallel `complet
 - [ ] `grep -rn "context.v2.fallback" src/` outside `src/config/` returns 0 hits.
 - [ ] Each sub-PR passes the full test suite independently.
 - [ ] No behaviour change — manager is still a pass-through to legacy code paths.
-- [ ] Codemod artefact preserved in `scripts/codemods/agent-manager-migration.ts` for auditability.
+- [x] ~~Codemod artefact preserved in `scripts/codemods/agent-manager-migration.ts` for auditability.~~ Dropped: the migration was a one-time 46-site bulk rename; the git diff in #568 is the sufficient audit record. No reuse value.
 
 ### Phase 4 — Adapter cleanup *(requires #529 merged first)*
 

--- a/docs/reviews/ADR-012-implementation-review.md
+++ b/docs/reviews/ADR-012-implementation-review.md
@@ -59,7 +59,7 @@
 | Canonical accessors used | `agentManager.getDefault()` used at 12+ sites under `src/pipeline/stages/` and `src/review/`; `resolveDefaultAgent(config)` at 26 files including `src/routing/`, `src/tdd/`, `src/acceptance/`, `src/debate/`, `src/verification/`, `src/cli/`. | Pass | |
 | Full test suite green | Not run in review. | Not verified | |
 | No behaviour change | Historic. | N/A | |
-| Codemod artefact preserved in `scripts/codemods/agent-manager-migration.ts` | **Directory `scripts/codemods/` does not exist.** | Fail (minor) | Phase 3 plan called for this for auditability. Lost. |
+| Codemod artefact preserved in `scripts/codemods/agent-manager-migration.ts` | AC dropped in #584 — git diff in #568 is the audit record; script had no reuse value. | Resolved | |
 
 ### Findings
 
@@ -216,7 +216,7 @@ Recommended: delete `resetStoryState` + `clearUnavailableAgents` (one PR, ~30 li
 10. Replace the `{} as ContextBundle` sentinel in `src/agents/manager.ts:293` with an explicit `{ skipBundleCheck: true }` option to `shouldSwap`.
 11. Make rate-limit backoff cancellable (`Promise.race` vs. an `AbortSignal`) to comply with `.claude/rules/forbidden-patterns.md` on uncancellable `Bun.sleep`.
 12. If follow-up #577 / #578 exist for aggregates or credential-pre-flight surfacing, link them from the ADR's "Phase 5 follow-ups" section so the doc-vs-code drift is at least traceable.
-13. Recover the codemod artefact (Phase 3 AC) or remove the AC from the ADR. Either is fine; the discrepancy is what matters.
+13. ~~Recover the codemod artefact (Phase 3 AC) or remove the AC from the ADR.~~ Resolved in #584 — AC dropped from ADR.
 
 ---
 


### PR DESCRIPTION
## Summary

- Removes the codemod-artefact AC from ADR-012 Phase 3 checklist (was `[ ] Codemod artefact preserved in scripts/codemods/agent-manager-migration.ts`)
- Updates `docs/reviews/ADR-012-implementation-review.md` to mark recommendation #13 as resolved

## Rationale

The codemod was a one-time 46-site bulk rename with no reuse value. The git diff in #568 is the sufficient audit record. Recovering the script would add maintenance burden with zero benefit.

## Test plan

- [ ] Doc-only change — no code, no tests needed
- [ ] Typecheck and lint clean