### PR TITLE
feat(session): persist descriptor and manifest paths relative to project root

### DIFF
--- a/docs/adr/ADR-011-session-manager-ownership.md
+++ b/docs/adr/ADR-011-session-manager-ownership.md
@@ -129,6 +129,7 @@ Instead of `failAndClose` doing inline close, have `closeStory()` include termin
 - **Two layers of cleanup.** A failed session is physically closed at the point of failure (`failAndClose`), AND run-completion teardown runs `closeAllRunSessions()`. The second is a no-op for already-FAILED sessions but must be correct under that assumption. Documented; tested.
 - **`keepSessionOpen` removal is a breaking change to `AgentRunOptions`.** Migration: old callers keep passing the flag during Phase 0 dual-write; it is ignored when a `session: SessionDescriptor` is present. Phase 5.5 removes the old parameter entirely. Captured in SPEC-session-manager-integration Interface Changes.
 - **State machine is enforceable but not enforced everywhere yet.** Only `CREATED → RUNNING` and implicit `RUNNING → COMPLETED` (via `closeStory`) are wired on main. The explicit `RUNNING → FAILED` transition is new in the H-1 fix. `PAUSED` / `RESUMING` are spec'd but not consumed by any call site yet (Phase 1+).
+- **Path serialization is now relative on disk.** Persisted `descriptor.json` and `context-manifest-*.json` path fields are stored relative to `projectDir` for cross-machine portability; loaders rehydrate them to absolute paths at read time for runtime use.
 
 ### Scope of Changes
 

--- a/src/context/engine/manifest-store.ts
+++ b/src/context/engine/manifest-store.ts
@@ -8,7 +8,7 @@
  */
 
 import { mkdir } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { ContextManifest } from "./types";
 
 export const _manifestStoreDeps = {
@@ -53,6 +53,30 @@ export function rebuildManifestPath(projectDir: string, featureId: string, story
   return join(contextStoryDir(projectDir, featureId, storyId), "rebuild-manifest.json");
 }
 
+function toStoredPath(projectDir: string, pathValue: string): string {
+  return isAbsolute(pathValue) ? relative(projectDir, pathValue) : pathValue;
+}
+
+function toAbsolutePath(projectDir: string, pathValue: string): string {
+  return isAbsolute(pathValue) ? pathValue : resolve(projectDir, pathValue);
+}
+
+function toStoredManifest(projectDir: string, manifest: ContextManifest): ContextManifest {
+  return {
+    ...manifest,
+    ...(manifest.repoRoot !== undefined && { repoRoot: toStoredPath(projectDir, manifest.repoRoot) }),
+    ...(manifest.packageDir !== undefined && { packageDir: toStoredPath(projectDir, manifest.packageDir) }),
+  };
+}
+
+function hydrateManifestPaths(projectDir: string, manifest: ContextManifest): ContextManifest {
+  return {
+    ...manifest,
+    ...(manifest.repoRoot !== undefined && { repoRoot: toAbsolutePath(projectDir, manifest.repoRoot) }),
+    ...(manifest.packageDir !== undefined && { packageDir: toAbsolutePath(projectDir, manifest.packageDir) }),
+  };
+}
+
 export async function writeContextManifest(
   projectDir: string,
   featureId: string,
@@ -62,7 +86,7 @@ export async function writeContextManifest(
 ): Promise<void> {
   const filePath = contextManifestPath(projectDir, featureId, storyId, stage);
   await _manifestStoreDeps.mkdirp(dirname(filePath));
-  await _manifestStoreDeps.writeFile(filePath, `${JSON.stringify(manifest, null, 2)}\n`);
+  await _manifestStoreDeps.writeFile(filePath, `${JSON.stringify(toStoredManifest(projectDir, manifest), null, 2)}\n`);
 }
 
 export interface RebuildManifestEntry {
@@ -136,11 +160,12 @@ export async function loadContextManifests(
       if (!(await _manifestStoreDeps.fileExists(fullPath))) continue;
       try {
         const raw = await _manifestStoreDeps.readFile(fullPath);
+        const parsed = JSON.parse(raw) as ContextManifest;
         results.push({
           featureId: feature,
           stage: stageFromFileName(fileName),
           path: fullPath,
-          manifest: JSON.parse(raw) as ContextManifest,
+          manifest: hydrateManifestPaths(projectDir, parsed),
         });
       } catch {
         // Skip malformed files so inspect stays best-effort.

--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -15,7 +15,7 @@
  */
 
 import { readdir } from "node:fs/promises";
-import { join } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import { NaxError } from "../../errors";
 import { getLogger } from "../../logger";
 import type { PipelineContext } from "../../pipeline/types";
@@ -54,6 +54,10 @@ export interface StageAssembleOptions {
 
 function dedupeScratchDirs(dirs: Array<string | undefined>): string[] {
   return [...new Set(dirs.filter((dir): dir is string => Boolean(dir)))];
+}
+
+function toAbsolutePath(projectDir: string, pathValue: string): string {
+  return isAbsolute(pathValue) ? pathValue : resolve(projectDir, pathValue);
 }
 
 /**
@@ -96,7 +100,7 @@ export async function discoverSessionScratchDirsOnDisk(
       const activity = parsed.lastActivityAt ? Date.parse(parsed.lastActivityAt) : Number.NaN;
       if (Number.isNaN(activity) || activity < cutoff) continue;
 
-      found.push(parsed.scratchDir);
+      found.push(toAbsolutePath(projectDir, parsed.scratchDir));
     } catch (err) {
       logger.debug("context-v2", "Skipped malformed session descriptor", {
         storyId,

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -13,7 +13,7 @@
 
 import { randomUUID } from "node:crypto";
 import { mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { isAbsolute, join, relative, sep } from "node:path";
 import type { AgentRunRequest, IAgentManager } from "../agents/manager-types";
 import type { AgentResult } from "../agents/types";
 import { NaxError } from "../errors";
@@ -55,12 +55,36 @@ export const _sessionManagerDeps = {
    * architecture review). Creates the scratch directory if it does not exist.
    * `handle` is omitted — it is process-bound and cannot be rehydrated.
    */
-  writeDescriptor: async (scratchDir: string, descriptor: SessionDescriptor): Promise<void> => {
+  writeDescriptor: async (scratchDir: string, descriptor: SessionDescriptor, projectDir?: string): Promise<void> => {
     await mkdir(scratchDir, { recursive: true });
     const { handle: _handle, ...persistable } = descriptor;
+    const derivedProjectDir = projectDir ?? resolveProjectDirFromScratchDir(scratchDir);
+    if (derivedProjectDir) {
+      persistable.workdir = toProjectRelativePath(derivedProjectDir, persistable.workdir);
+      if (persistable.scratchDir) {
+        persistable.scratchDir = toProjectRelativePath(derivedProjectDir, persistable.scratchDir);
+      }
+    }
     await Bun.write(join(scratchDir, "descriptor.json"), JSON.stringify(persistable, null, 2));
   },
 };
+
+function resolveProjectDirFromScratchDir(scratchDir: string): string | undefined {
+  const marker = `${sep}.nax${sep}features${sep}`;
+  const markerIdx = scratchDir.lastIndexOf(marker);
+  if (markerIdx > 0) return scratchDir.slice(0, markerIdx);
+
+  // Backstop: tolerate persisted forward-slash paths regardless of platform.
+  const posixIdx = scratchDir.lastIndexOf("/.nax/features/");
+  if (posixIdx > 0) return scratchDir.slice(0, posixIdx);
+
+  return undefined;
+}
+
+function toProjectRelativePath(projectDir: string, pathValue: string): string {
+  if (!isAbsolute(pathValue)) return pathValue;
+  return relative(projectDir, pathValue);
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // SessionManager
@@ -99,7 +123,8 @@ export class SessionManager implements ISessionManager {
    */
   private _persistDescriptor(descriptor: SessionDescriptor): void {
     if (!descriptor.scratchDir) return;
-    void _sessionManagerDeps.writeDescriptor(descriptor.scratchDir, descriptor).catch((err) => {
+    const projectDir = resolveProjectDirFromScratchDir(descriptor.scratchDir);
+    void _sessionManagerDeps.writeDescriptor(descriptor.scratchDir, descriptor, projectDir).catch((err) => {
       getLogger().warn("session", "Failed to re-persist session descriptor", {
         storyId: descriptor.storyId,
         sessionId: descriptor.id,
@@ -140,7 +165,8 @@ export class SessionManager implements ISessionManager {
     // disk discovery (Finding 2). Failures do not block session creation —
     // disk discovery is a best-effort supplement to the in-memory registry.
     if (scratchDir) {
-      void _sessionManagerDeps.writeDescriptor(scratchDir, descriptor).catch((err) => {
+      const projectDir = options.projectDir ?? resolveProjectDirFromScratchDir(scratchDir);
+      void _sessionManagerDeps.writeDescriptor(scratchDir, descriptor, projectDir).catch((err) => {
         getLogger().warn("session", "Failed to persist session descriptor", {
           storyId: options.storyId,
           sessionId: id,

--- a/test/unit/context/engine/manifest-store.test.ts
+++ b/test/unit/context/engine/manifest-store.test.ts
@@ -41,13 +41,57 @@ describe("manifest-store", () => {
       floorItems: [],
       digestTokens: 120,
       buildMs: 15,
+      repoRoot: "/repo",
+      packageDir: "/repo/apps/api",
     });
+
+    const persistedRaw = writes.get("/repo/.nax/features/feat-auth/stories/US-001/context-manifest-review-semantic.json");
+    const persisted = JSON.parse(persistedRaw ?? "{}") as { repoRoot?: string; packageDir?: string };
+    expect(persisted.repoRoot).toBe("");
+    expect(persisted.packageDir).toBe("apps/api");
 
     const manifests = await loadContextManifests("/repo", "US-001");
     expect(manifests).toHaveLength(1);
     expect(manifests[0]?.featureId).toBe("feat-auth");
     expect(manifests[0]?.stage).toBe("review-semantic");
     expect(manifests[0]?.manifest.includedChunks).toEqual(["chunk:1"]);
+    expect(manifests[0]?.manifest.repoRoot).toBe("/repo");
+    expect(manifests[0]?.manifest.packageDir).toBe("/repo/apps/api");
+  });
+
+  test("loadContextManifests preserves legacy absolute repoRoot/packageDir values", async () => {
+    const writes = new Map<string, string>();
+    const path = "/repo/.nax/features/feat-auth/stories/US-001/context-manifest-review-semantic.json";
+    writes.set(
+      path,
+      `${JSON.stringify(
+        {
+          requestId: "req-legacy",
+          stage: "review-semantic",
+          totalBudgetTokens: 8_000,
+          usedTokens: 1_200,
+          includedChunks: [],
+          excludedChunks: [],
+          floorItems: [],
+          digestTokens: 0,
+          buildMs: 10,
+          repoRoot: "/repo",
+          packageDir: "/repo/packages/web",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    _manifestStoreDeps.listFeatureDirs = async () => ["feat-auth"];
+    _manifestStoreDeps.listManifestFiles = async () => ["context-manifest-review-semantic.json"];
+    _manifestStoreDeps.fileExists = async (filePath) => writes.has(filePath);
+    _manifestStoreDeps.readFile = async (filePath) => writes.get(filePath) ?? "";
+
+    const manifests = await loadContextManifests("/repo", "US-001");
+    expect(manifests).toHaveLength(1);
+    expect(manifests[0]?.manifest.repoRoot).toBe("/repo");
+    expect(manifests[0]?.manifest.packageDir).toBe("/repo/packages/web");
   });
 
   test("writeRebuildManifest appends rebuild events into rebuild-manifest.json", async () => {

--- a/test/unit/context/engine/stage-assembler.test.ts
+++ b/test/unit/context/engine/stage-assembler.test.ts
@@ -76,6 +76,18 @@ describe("discoverSessionScratchDirsOnDisk — Finding 2", () => {
     expect(result).toContain(`${SESSIONS_ROOT}/sess-b`);
   });
 
+  test("resolves relative scratchDir from descriptor to absolute project path", async () => {
+    _stageAssemblerDeps.readdir = async () => ["sess-rel"];
+    _stageAssemblerDeps.readDescriptor = async () => ({
+      storyId: STORY,
+      scratchDir: ".nax/features/test-feature/sessions/sess-rel",
+      lastActivityAt: WITHIN_TTL_ISO,
+    });
+
+    const result = await discoverSessionScratchDirsOnDisk(PROJECT_DIR, FEATURE, STORY, TTL_4H);
+    expect(result).toEqual([`${SESSIONS_ROOT}/sess-rel`]);
+  });
+
   test("skips descriptors for a different story", async () => {
     _stageAssemblerDeps.readdir = async () => ["sess-mine", "sess-theirs"];
     _stageAssemblerDeps.readDescriptor = async (path: string) => {

--- a/test/unit/session/manager.test.ts
+++ b/test/unit/session/manager.test.ts
@@ -87,9 +87,9 @@ describe("SessionManager.create() — descriptor persistence", () => {
   });
 
   test("writes descriptor.json when scratchDir is resolved", async () => {
-    const writes: Array<{ scratchDir: string; descriptor: unknown }> = [];
-    _sessionManagerDeps.writeDescriptor = async (scratchDir, descriptor) => {
-      writes.push({ scratchDir, descriptor });
+    const writes: Array<{ scratchDir: string; descriptor: unknown; projectDir?: string }> = [];
+    _sessionManagerDeps.writeDescriptor = async (scratchDir, descriptor, projectDir) => {
+      writes.push({ scratchDir, descriptor, projectDir });
     };
 
     const mgr = new SessionManager();
@@ -113,6 +113,7 @@ describe("SessionManager.create() — descriptor persistence", () => {
     const persisted = writes[0]?.descriptor as { storyId?: string; role?: string };
     expect(persisted.storyId).toBe("US-001");
     expect(persisted.role).toBe("test-writer");
+    expect(writes[0]?.projectDir).toBe("/repo");
 
     _sessionManagerDeps.writeDescriptor = originalWriteDescriptor;
   });


### PR DESCRIPTION
## Summary
- persist session descriptor path fields (`workdir`, `scratchDir`) as paths relative to `projectDir` when writing `descriptor.json`
- resolve relative `scratchDir` values back to absolute paths during disk discovery in context stage assembly
- persist context manifest path fields (`repoRoot`, `packageDir`) as project-relative and hydrate them to absolute paths on load
- add compatibility coverage for legacy absolute manifests and new relative-path descriptors/manifests
- add ADR note in `ADR-011` documenting project-relative on-disk path serialization for portability

Close #530 

## Why
Issue #530 identified portability gaps when absolute paths are persisted in `.nax` artifacts. This change keeps runtime behavior absolute while making persisted artifacts portable across machines and repo relocations.

## Testing
- `bun run lint`
- `bun run typecheck`
- `bun test test/unit/session/manager.test.ts test/unit/context/engine/stage-assembler.test.ts test/unit/context/engine/manifest-store.test.ts --timeout=120000`
- `bun test test/unit/interaction/interaction-network-failures.test.ts test/unit/interaction/interaction-plugins.test.ts test/unit/pipeline/subscribers/registry.test.ts test/unit/pipeline/subscribers/events-writer.test.ts --timeout=120000`

I also ran `bun run test` multiple times. I observed intermittent unrelated failures in webhook/registry subscriber suites in this environment; targeted suites above pass and the touched-path tests are green.