### PR TITLE
fix(context): write project-root relative paths as dot

### DIFF
--- a/src/context/engine/manifest-store.ts
+++ b/src/context/engine/manifest-store.ts
@@ -54,7 +54,8 @@ export function rebuildManifestPath(projectDir: string, featureId: string, story
 }
 
 function toStoredPath(projectDir: string, pathValue: string): string {
-  return isAbsolute(pathValue) ? relative(projectDir, pathValue) : pathValue;
+  const relativePath = isAbsolute(pathValue) ? relative(projectDir, pathValue) : pathValue;
+  return relativePath === "" ? "." : relativePath;
 }
 
 function toAbsolutePath(projectDir: string, pathValue: string): string {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -82,8 +82,8 @@ function resolveProjectDirFromScratchDir(scratchDir: string): string | undefined
 }
 
 function toProjectRelativePath(projectDir: string, pathValue: string): string {
-  if (!isAbsolute(pathValue)) return pathValue;
-  return relative(projectDir, pathValue);
+  const relativePath = isAbsolute(pathValue) ? relative(projectDir, pathValue) : pathValue;
+  return relativePath === "" ? "." : relativePath;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/context/engine/manifest-store.test.ts
+++ b/test/unit/context/engine/manifest-store.test.ts
@@ -47,7 +47,7 @@ describe("manifest-store", () => {
 
     const persistedRaw = writes.get("/repo/.nax/features/feat-auth/stories/US-001/context-manifest-review-semantic.json");
     const persisted = JSON.parse(persistedRaw ?? "{}") as { repoRoot?: string; packageDir?: string };
-    expect(persisted.repoRoot).toBe("");
+    expect(persisted.repoRoot).toBe(".");
     expect(persisted.packageDir).toBe("apps/api");
 
     const manifests = await loadContextManifests("/repo", "US-001");
@@ -92,6 +92,41 @@ describe("manifest-store", () => {
     expect(manifests).toHaveLength(1);
     expect(manifests[0]?.manifest.repoRoot).toBe("/repo");
     expect(manifests[0]?.manifest.packageDir).toBe("/repo/packages/web");
+  });
+
+  test("loadContextManifests resolves explicit dot-relative root paths", async () => {
+    const writes = new Map<string, string>();
+    const path = "/repo/.nax/features/feat-auth/stories/US-001/context-manifest-review-semantic.json";
+    writes.set(
+      path,
+      `${JSON.stringify(
+        {
+          requestId: "req-dot",
+          stage: "review-semantic",
+          totalBudgetTokens: 8_000,
+          usedTokens: 1_200,
+          includedChunks: [],
+          excludedChunks: [],
+          floorItems: [],
+          digestTokens: 0,
+          buildMs: 10,
+          repoRoot: ".",
+          packageDir: ".",
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    _manifestStoreDeps.listFeatureDirs = async () => ["feat-auth"];
+    _manifestStoreDeps.listManifestFiles = async () => ["context-manifest-review-semantic.json"];
+    _manifestStoreDeps.fileExists = async (filePath) => writes.has(filePath);
+    _manifestStoreDeps.readFile = async (filePath) => writes.get(filePath) ?? "";
+
+    const manifests = await loadContextManifests("/repo", "US-001");
+    expect(manifests).toHaveLength(1);
+    expect(manifests[0]?.manifest.repoRoot).toBe("/repo");
+    expect(manifests[0]?.manifest.packageDir).toBe("/repo");
   });
 
   test("writeRebuildManifest appends rebuild events into rebuild-manifest.json", async () => {

--- a/test/unit/context/engine/stage-assembler.test.ts
+++ b/test/unit/context/engine/stage-assembler.test.ts
@@ -88,6 +88,18 @@ describe("discoverSessionScratchDirsOnDisk — Finding 2", () => {
     expect(result).toEqual([`${SESSIONS_ROOT}/sess-rel`]);
   });
 
+  test("resolves dot scratchDir from descriptor to project root", async () => {
+    _stageAssemblerDeps.readdir = async () => ["sess-dot"];
+    _stageAssemblerDeps.readDescriptor = async () => ({
+      storyId: STORY,
+      scratchDir: ".",
+      lastActivityAt: WITHIN_TTL_ISO,
+    });
+
+    const result = await discoverSessionScratchDirsOnDisk(PROJECT_DIR, FEATURE, STORY, TTL_4H);
+    expect(result).toEqual([PROJECT_DIR]);
+  });
+
   test("skips descriptors for a different story", async () => {
     _stageAssemblerDeps.readdir = async () => ["sess-mine", "sess-theirs"];
     _stageAssemblerDeps.readDescriptor = async (path: string) => {


### PR DESCRIPTION
## Summary
- persist project-root-relative paths as `"."` instead of empty string in context manifests
- keep loader behavior backward-compatible while explicitly resolving `"."` to absolute project root
- apply same root normalization (`"."`) for persisted session descriptor path fields
- add tests for dot-root hydration in manifests and scratch-dir resolution

## Why
After #635, persisted root-relative fields were written as empty string (`""`). That is technically valid but misleading for humans inspecting artifacts. Using `"."` keeps portability while making intent explicit.

## Testing
- `bun test test/unit/context/engine/manifest-store.test.ts test/unit/context/engine/stage-assembler.test.ts --timeout=120000`
- `bun run lint`
- pre-commit hooks: typecheck + lint passed during commit

Related: #530