### PR TITLE
fix(execution): thread agentManager into pre-run, parallel, and plan pipelines

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -196,6 +196,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
     const resolvedPerm = resolvePermissions(config, "plan");
     // Safe: debateEnabled guard confirms config.debate.stages.plan is defined
     const planStageConfig = config?.debate?.stages.plan as import("../debate").DebateStageConfig;
+    const debateAgentManager = _planDeps.createManager(config);
     const debateSession = _planDeps.createDebateSession({
       storyId: options.feature,
       stage: "plan",
@@ -204,6 +205,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
       workdir,
       featureName: options.feature,
       timeoutSeconds,
+      agentManager: debateAgentManager,
     });
     logger?.info("plan", "Starting debate planning session", {
       debaters: planStageConfig.debaters?.map((d) => d.agent),
@@ -646,6 +648,7 @@ export async function planDecomposeCommand(
         workdir,
         featureName: options.feature,
         timeoutSeconds,
+        agentManager,
       });
       const debateResult = await debateSession.run(prompt);
       if (debateResult.outcome !== "failed" && debateResult.output) {

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -146,6 +146,7 @@ export async function executeUnified(
         routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
         hooks: ctx.hooks,
         agentGetFn: ctx.agentGetFn,
+        agentManager: ctx.agentManager,
       };
       await runPipeline(preRunPipeline, preRunCtx, ctx.eventEmitter);
     }
@@ -243,6 +244,7 @@ export async function executeUnified(
                 hooks: ctx.hooks,
                 featureDir: ctx.featureDir,
                 agentGetFn: ctx.agentGetFn,
+                agentManager: ctx.agentManager,
                 pidRegistry: ctx.pidRegistry,
                 abortSignal: ctx.abortSignal,
               },


### PR DESCRIPTION
Closes #645

## Summary

- Thread `ctx.agentManager` into the pre-run `preRunCtx` and the parallel-batch `pipelineContext` in [`src/execution/unified-executor.ts`](https://github.com/nathapp-io/nax/blob/main/src/execution/unified-executor.ts). Both paths previously omitted it, causing `acceptance-setup` → `refineAcceptanceCriteria` / `generateFromPRD` to repeatedly fall through to `createManager(config)` and spawn a fresh `AgentManager` on every call — losing per-run unavailability and fallback-hop state.
- Thread `agentManager` into the two `DebateSession` constructions in [`src/cli/plan.ts`](https://github.com/nathapp-io/nax/blob/main/src/cli/plan.ts) (plan + decompose) for consistency with semantic review. One-shot scope, no behaviour change, but removes the internal fallback-createManager path.

## Root cause

Per-story pipeline contexts (`iteration-runner.ts`, `acceptance-loop.ts`, `rectification-loop.ts`, `autofix.ts`) already thread `agentManager` correctly. Only the pre-run and parallel-batch construction sites in `unified-executor.ts` missed it. The warning logs in `src/acceptance/refinement.ts` and `src/acceptance/generator.ts` had been firing in every run that hit acceptance-setup.

## Diff scope

```
src/cli/plan.ts                    | 3 +++
src/execution/unified-executor.ts  | 2 ++
```

Two commits:
- `1b775d9f` fix(execution): thread agentManager into pre-run and parallel-batch pipeline contexts
- `db367ac2` fix(plan): thread agentManager into plan and decompose DebateSession

## Test plan

- [x] typecheck — clean
- [x] lint (Biome) — clean
- [x] unified-executor unit suite — 58 pass
- [x] acceptance unit suite — 373 pass
- [x] parallel-batch unit suite — 22 pass
- [x] cli/plan unit suite — 170 pass
- [x] debate unit suite — 239 pass
- [ ] Re-run the koda acceptance flow end-to-end and confirm the "No agentManager threaded" warnings no longer appear