### PR TITLE
fix(review): add context-manifest to runtime exclusions and wire .naxignore

### DIFF
--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -253,6 +253,7 @@ export async function runReview(
     /nax\/features\/[^/]+\/progress\.txt$/,
     /nax\/features\/[^/]+\/acceptance-refined\.json$/,
     /nax\/features\/[^/]+\/stories\/[^/]+\/context-manifest-[^/]+\.json$/,
+    /nax\/features\/[^/]+\/stories\/[^/]+\/rebuild-manifest\.json$/,
     /\.nax-verifier-verdict\.json$/,
     /\.nax-pids$/,
     /\.nax-wt\//,
@@ -262,7 +263,8 @@ export async function runReview(
     (f) => !NAX_RUNTIME_PATTERNS.some((pattern) => pattern.test(f)),
   );
   // Apply .naxignore as a second, user-extensible layer on top of the built-in patterns.
-  const uncommittedFiles = naxIgnoreIndex ? naxIgnoreIndex.filter(afterRuntimeFilter) : afterRuntimeFilter;
+  // Pass workdir as packageDir so per-package .naxignore rules apply in monorepos.
+  const uncommittedFiles = naxIgnoreIndex ? naxIgnoreIndex.filter(afterRuntimeFilter, workdir) : afterRuntimeFilter;
   if (uncommittedFiles.length > 0) {
     const fileList = uncommittedFiles.join(", ");
     logger?.warn("review", `Uncommitted changes detected before review: ${fileList}`);

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -252,12 +252,17 @@ export async function runReview(
     /nax\/features\/[^/]+\/interactions\//,
     /nax\/features\/[^/]+\/progress\.txt$/,
     /nax\/features\/[^/]+\/acceptance-refined\.json$/,
+    /nax\/features\/[^/]+\/stories\/[^/]+\/context-manifest-[^/]+\.json$/,
     /\.nax-verifier-verdict\.json$/,
     /\.nax-pids$/,
     /\.nax-wt\//,
     /\.nax-acceptance[^/]*$/,
   ];
-  const uncommittedFiles = allUncommittedFiles.filter((f) => !NAX_RUNTIME_PATTERNS.some((pattern) => pattern.test(f)));
+  const afterRuntimeFilter = allUncommittedFiles.filter(
+    (f) => !NAX_RUNTIME_PATTERNS.some((pattern) => pattern.test(f)),
+  );
+  // Apply .naxignore as a second, user-extensible layer on top of the built-in patterns.
+  const uncommittedFiles = naxIgnoreIndex ? naxIgnoreIndex.filter(afterRuntimeFilter) : afterRuntimeFilter;
   if (uncommittedFiles.length > 0) {
     const fileList = uncommittedFiles.join(", ");
     logger?.warn("review", `Uncommitted changes detected before review: ${fileList}`);

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -172,6 +172,30 @@ describe("nax runtime file exclusions", () => {
     expect(result.success).toBe(true);
   });
 
+  test(".nax/features/*/stories/*/context-manifest-*.json is excluded from uncommitted check", async () => {
+    _deps.getUncommittedFiles = mock(async (_workdir: string) => [
+      ".nax/features/memory-guardrails/stories/US-001/context-manifest-review-semantic.json",
+    ]);
+    const result = await runReview(noChecksConfig, "/tmp/fake-workdir");
+    expect(result.success).toBe(true);
+  });
+
+  test("monorepo-prefixed context-manifest is excluded", async () => {
+    _deps.getUncommittedFiles = mock(async (_workdir: string) => [
+      "apps/backend/nax/features/memory-guardrails/stories/US-001/context-manifest-verify.json",
+    ]);
+    const result = await runReview(noChecksConfig, "/tmp/fake-workdir");
+    expect(result.success).toBe(true);
+  });
+
+  test(".nax/features/*/stories/*/rebuild-manifest.json is excluded from uncommitted check", async () => {
+    _deps.getUncommittedFiles = mock(async (_workdir: string) => [
+      ".nax/features/memory-guardrails/stories/US-001/rebuild-manifest.json",
+    ]);
+    const result = await runReview(noChecksConfig, "/tmp/fake-workdir");
+    expect(result.success).toBe(true);
+  });
+
   test("agent source files are still caught by uncommitted check", async () => {
     _deps.getUncommittedFiles = mock(async (_workdir: string) => [
       ".nax/status.json",


### PR DESCRIPTION
## Summary

- Adds `/nax/features/<id>/stories/<id>/context-manifest-<stage>.json` to `NAX_RUNTIME_PATTERNS` — files written by the context engine during review were missing from the exclusion list, causing false-positive uncommitted-changes failures that blocked the reviewer infinitely.
- Wires the already-threaded `naxIgnoreIndex` parameter into the uncommitted-files filter as a second, user-extensible layer — `.naxignore` entries (e.g. `.nax/`) now take effect here.
- Both rules apply as a union: a file is excluded if it matches either.

Fixes #647

## Test plan

- [ ] Run a review with context-manifest files present in `.nax/features/*/stories/*/` — review should proceed without false-positive uncommitted-changes failure
- [ ] Add `.nax/` to `.naxignore` in a test project — any `.nax/` path in uncommitted files should be excluded by the naxignore layer
- [ ] Verify existing runtime exclusions (runs/, plan/, prd.json, etc.) still filter correctly