### PR TITLE
chore(ci): enforce inline-test-mocks rule in CI (closes #615)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
     timeout-minutes: 5
     strategy:
       fail-fast: true
-      matrix:
-        check: [typecheck, lint]
+        matrix:
+        check: [typecheck, lint, check:test-mocks]
     steps:
       - uses: actions/checkout@v4
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "check-test-overlap": "bun run scripts/check-test-overlap.ts",
     "check-dead-tests": "bun run scripts/check-dead-tests.ts",
     "check:test-sizes": "bun run scripts/check-test-sizes.ts",
+    "check:test-mocks": "bun scripts/check-inline-test-mocks.ts --strict",
     "prepublishOnly": "bun run build",
     "test:full": "FULL=1 NAX_PRECHECK=1 bun test test/ --timeout=60000"
   },


### PR DESCRIPTION
## Summary

Implements Issue #615 — adds `--strict` mode enforcement for inline test mock rule in CI.

## Changes

1. **package.json**: Added `check:test-mocks` script:
   ```json
   "check:test-mocks": "bun scripts/check-inline-test-mocks.ts --strict"
   ```

2. **ci.yml**: Added `check:test-mocks` to the checks matrix alongside `typecheck` and `lint`

## Verification

- `bun run check:test-mocks`: **0 violations**
- `bun run typecheck`: clean
- `bun run lint`: clean

## Issue

Closes #615