### PR TITLE
chore: release v0.63.0-canary.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.63.0-canary.12",
+  "version": "0.63.0-canary.13",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release canary.13 — mainly test-pattern sweeps and CI refinements from recent merges.