### PR TITLE
fix(ci): correct matrix indentation — all CI failing since #650

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       fail-fast: true
-        matrix:
+      matrix:
         check: [typecheck, lint, check:test-mocks]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Root cause

Commit 9d6cb8f (`chore(ci): add check:test-mocks to CI pipeline #650`) introduced a 2-space over-indent on `matrix:`, making it a child node of `fail-fast:` in YAML:

```yaml
# broken (current main)
strategy:
  fail-fast: true
    matrix:          # ← 6 spaces — parsed as child of fail-fast
      check: [...]

# fixed
strategy:
  fail-fast: true
  matrix:            # ← 4 spaces — sibling of fail-fast
    check: [...]
```

GitHub's workflow parser rejects the file entirely, so **0 jobs run** and every push/PR to main since #650 shows red CI with no job output.

## Fix

One-line indentation correction. Also keeps the intended `check:test-mocks` matrix entry from #650.

## Test plan

- [ ] After merge, verify the next push to main triggers `checks (typecheck)`, `checks (lint)`, `checks (check:test-mocks)`, and `test` jobs