### PR TITLE
fix: smart-runner coercion/logging and rectification prompt continuity

### DIFF
--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -270,6 +270,10 @@ function collectFailedChecks(ctx: PipelineContext): ReviewCheckResult[] {
   return (ctx.reviewResult?.checks ?? []).filter((c) => !c.success);
 }
 
+function getCheckSignature(checks: ReviewCheckResult[]): string {
+  return [...new Set(checks.map((check) => check.check))].sort().join("|");
+}
+
 function buildAutofixEscalationPreamble(
   attempt: number,
   maxAttempts: number,
@@ -398,6 +402,8 @@ async function runAgentRectification(
   const loopState = {
     attempt: 0,
     failedChecks: implementerChecks,
+    checkSignature: getCheckSignature(implementerChecks),
+    checkSignatureChanged: false,
     /** Number of consecutive no-op turns (zero file changes) so far this cycle. */
     consecutiveNoOps: 0,
     /** True when the previous turn produced no file changes and the reprompt should fire. */
@@ -456,6 +462,13 @@ async function runAgentRectification(
       const isSessionContinuation = attempt > 1 && sessionConfirmedOpen;
 
       if (isSessionContinuation) {
+        // If failing check categories changed since the previous attempt, this is the
+        // first attempt for a new failure class (e.g. semantic -> adversarial). Reset
+        // to first-attempt framing instead of continuation wording.
+        if (state.checkSignatureChanged) {
+          const attemptsRemaining = Math.max(1, maxAttempts - attempt + 1);
+          return RectifierPromptBuilder.firstAttemptDelta(state.failedChecks, attemptsRemaining);
+        }
         // Apply the same capping as buildProgressivePromptPreamble so the last attempt
         // always triggers urgency even when urgencyAtAttempt > maxAttempts.
         return RectifierPromptBuilder.continuation(
@@ -660,7 +673,12 @@ async function runAgentRectification(
       }
 
       if (updatedFailed.length > 0) {
-        state.failedChecks.splice(0, state.failedChecks.length, ...collectFailedChecks(ctx));
+        const updatedCheckSignature = getCheckSignature(updatedFailed);
+        state.checkSignatureChanged = updatedCheckSignature !== state.checkSignature;
+        state.checkSignature = updatedCheckSignature;
+        state.failedChecks.splice(0, state.failedChecks.length, ...updatedFailed);
+      } else {
+        state.checkSignatureChanged = false;
       }
       return false;
     },

--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -35,7 +35,7 @@ const DEFAULT_SMART_RUNNER_CONFIG: SmartTestRunnerConfig = {
 function coerceSmartTestRunner(val: boolean | SmartTestRunnerConfig | undefined): SmartTestRunnerConfig {
   if (val === undefined || val === true) return DEFAULT_SMART_RUNNER_CONFIG;
   if (val === false) return { ...DEFAULT_SMART_RUNNER_CONFIG, enabled: false };
-  return val;
+  return { ...DEFAULT_SMART_RUNNER_CONFIG, ...val };
 }
 
 /**
@@ -102,6 +102,10 @@ export const verifyStage: PipelineStage = {
           command: effectiveCommand,
         });
       }
+    } else if (!smartRunnerConfig.enabled) {
+      logger.info("verify", "[smart-runner] Disabled by config", {
+        storyId: ctx.story.id,
+      });
     } else if (smartRunnerConfig.enabled) {
       // Resolve test file patterns via ADR-009 SSOT — language-agnostic, config-driven,
       // per-package override-aware. ctx.projectDir is the repo root; story.workdir is the
@@ -175,16 +179,20 @@ export const verifyStage: PipelineStage = {
     // US-003: If we are falling back to the full suite AND mode is deferred, skip this stage
     // because the deferred regression gate will handle the full suite at run-end.
     if (isFullSuite && regressionMode === "deferred") {
-      logger.info("verify", "[smart-runner] No mapped tests — deferring full suite to run-end (mode: deferred)", {
-        storyId: ctx.story.id,
-      });
+      const message =
+        !isMonorepoOrchestrator && !smartRunnerConfig.enabled
+          ? "[smart-runner] Disabled by config — deferring full suite to run-end (mode: deferred)"
+          : "[smart-runner] No mapped tests — deferring full suite to run-end (mode: deferred)";
+      logger.info("verify", message, { storyId: ctx.story.id });
       return { action: "continue" };
     }
 
     if (isFullSuite) {
-      logger.info("verify", "[smart-runner] No mapped tests — falling back to full suite", {
-        storyId: ctx.story.id,
-      });
+      const message =
+        !isMonorepoOrchestrator && !smartRunnerConfig.enabled
+          ? "[smart-runner] Disabled by config — running full suite"
+          : "[smart-runner] No mapped tests — falling back to full suite";
+      logger.info("verify", message, { storyId: ctx.story.id });
     }
 
     // BUG-044: Log the effective command for observability

--- a/test/integration/agents/acp/tdd-flow-rectification.test.ts
+++ b/test/integration/agents/acp/tdd-flow-rectification.test.ts
@@ -16,7 +16,7 @@ import { DEFAULT_CONFIG } from "../../../../src/config";
 import type { NaxConfig } from "../../../../src/config";
 import type { UserStory } from "../../../../src/prd";
 import { _isolationDeps } from "../../../../src/tdd/isolation";
-import { runFullSuiteGate } from "../../../../src/tdd/rectification-gate";
+import { _rectificationGateDeps, runFullSuiteGate } from "../../../../src/tdd/rectification-gate";
 import { _sessionRunnerDeps } from "../../../../src/tdd/session-runner";
 import { _gitDeps } from "../../../../src/utils/git";
 import { _executorDeps } from "../../../../src/verification/executor";
@@ -103,6 +103,7 @@ const story: UserStory = {
 // ─────────────────────────────────────────────────────────────────────────────
 
 withDepsRestore(_acpAdapterDeps, ["createClient", "sleep"]);
+withDepsRestore(_rectificationGateDeps, ["executeWithTimeout", "resolveTestCommands"]);
 withDepsRestore(_gitDeps, ["spawn"]);
 withDepsRestore(_sessionRunnerDeps, ["autoCommitIfDirty", "spawn"]);
 withDepsRestore(_isolationDeps, ["spawn"]);
@@ -210,43 +211,32 @@ describe("runFullSuiteGate with AcpAgentAdapter", () => {
       return makeClient(session);
     });
 
-    let testRunCount = 0;
-
-    _executorDeps.spawn = mock((cmd: string[], spawnOpts?: unknown) => {
-      if (cmd[0] === "git" && cmd[1] === "rev-parse") {
+    _rectificationGateDeps.resolveTestCommands = mock(async () => ({
+      rawTestCommand: "bun test",
+      testCommand: "bun test",
+      testScopedTemplate: undefined,
+      isMonorepoOrchestrator: false,
+      scopeFileThreshold: 10,
+    }));
+    let runCount = 0;
+    _rectificationGateDeps.executeWithTimeout = mock(async (_cmd: string) => {
+      runCount++;
+      if (runCount === 1) {
         return {
-          exited: Promise.resolve(0),
-          stdout: new Response("abc123\n").body,
-          stderr: new Response("").body,
+          success: false,
+          timeout: false,
+          exitCode: 1,
+          output: "test/feature.test.ts:\n✘ should work [1.0ms]\n(fail) suite > should work [1.0ms]\nError: boom\n",
+          countsTowardEscalation: true,
         };
       }
-      if (cmd[0] === "git" && cmd[1] === "diff") {
-        return {
-          exited: Promise.resolve(0),
-          stdout: new Response("src/feature.ts\n").body,
-          stderr: new Response("").body,
-        };
-      }
-      if (cmd[0] === "git" && cmd[1] === "status") {
-        return {
-          exited: Promise.resolve(0),
-          stdout: new Response("nothing to commit\n").body,
-          stderr: new Response("").body,
-        };
-      }
-      if ((cmd[0] === "/bin/sh" || cmd[0] === "/bin/bash") && cmd[1] === "-c") {
-        testRunCount++;
-        const failed = testRunCount === 1;
-        const failedOutput = "test/feature.test.ts:\n✘ should work [1.0ms]\n";
-        const passedOutput = "test/feature.test.ts:\n✓ should work [1.0ms]\n";
-        return {
-          pid: 9999,
-          exited: Promise.resolve(failed ? 1 : 0),
-          stdout: new Response(failed ? failedOutput : passedOutput).body,
-          stderr: new Response("").body,
-        };
-      }
-      return { exited: Promise.resolve(0), stdout: new Response("").body, stderr: new Response("").body };
+      return {
+        success: true,
+        timeout: false,
+        exitCode: 0,
+        output: "test/feature.test.ts:\n✓ should work [1.0ms]\n",
+        countsTowardEscalation: true,
+      };
     });
 
     const adapter = new AcpAgentAdapter("claude");
@@ -271,34 +261,20 @@ describe("runFullSuiteGate with AcpAgentAdapter", () => {
       return makeClient(session);
     });
 
-    let testRunCount = 0;
-
-    _executorDeps.spawn = mock((cmd: string[], spawnOpts?: unknown) => {
-      if (cmd[0] === "git" && cmd[1] === "rev-parse") {
-        return {
-          exited: Promise.resolve(0),
-          stdout: new Response("abc123\n").body,
-          stderr: new Response("").body,
-        };
-      }
-      if (cmd[0] === "git" && (cmd[1] === "diff" || cmd[1] === "status")) {
-        return {
-          exited: Promise.resolve(0),
-          stdout: new Response("src/feature.ts\n").body,
-          stderr: new Response("").body,
-        };
-      }
-      if ((cmd[0] === "/bin/sh" || cmd[0] === "/bin/bash") && cmd[1] === "-c") {
-        testRunCount++;
-        return {
-          pid: 9999,
-          exited: Promise.resolve(1),
-          stdout: new Response("test/feature.test.ts:\n✘ should work [1.0ms]\n").body,
-          stderr: new Response("").body,
-        };
-      }
-      return { exited: Promise.resolve(0), stdout: new Response("").body, stderr: new Response("").body };
-    });
+    _rectificationGateDeps.resolveTestCommands = mock(async () => ({
+      rawTestCommand: "bun test",
+      testCommand: "bun test",
+      testScopedTemplate: undefined,
+      isMonorepoOrchestrator: false,
+      scopeFileThreshold: 10,
+    }));
+    _rectificationGateDeps.executeWithTimeout = mock(async (_cmd: string) => ({
+      success: false,
+      timeout: false,
+      exitCode: 1,
+      output: "test/feature.test.ts:\n✘ should work [1.0ms]\n(fail) suite > should work [1.0ms]\nError: boom\n",
+      countsTowardEscalation: true,
+    }));
 
     const adapter = new AcpAgentAdapter("claude");
     const result = await runFullSuiteGate(

--- a/test/unit/pipeline/stages/autofix-budget-prompts.test.ts
+++ b/test/unit/pipeline/stages/autofix-budget-prompts.test.ts
@@ -336,4 +336,46 @@ describe("autofixStage — #412 prompt selection", () => {
     expect(prompts[1]).toContain("Your previous fix attempt did not resolve all issues");
     expect(prompts[1]).not.toContain("Review failed after your implementation");
   });
+
+  test("resets to first-attempt framing when failed check type changes between attempts", async () => {
+    const prompts: string[] = [];
+    const mockRun = mock(async (opts: Record<string, unknown>) => {
+      prompts.push(opts.prompt as string);
+      return { success: false, estimatedCost: 0 };
+    });
+    const agentManager = makeMockAgentManager(mockRun);
+    const saved = { recheckReview: _autofixDeps.recheckReview };
+    let recheckCount = 0;
+
+    const ctx = makeCtx({
+      agentManager,
+      reviewResult: makeFailedReviewResult([{ check: "semantic", output: "AC mismatch" }]),
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          commands: { test: "bun test" },
+          autofix: { enabled: true, maxAttempts: 2 },
+        },
+        autoMode: { ...DEFAULT_CONFIG.autoMode, defaultAgent: "claude" },
+      } as any,
+    });
+
+    _autofixDeps.recheckReview = async () => {
+      recheckCount++;
+      if (recheckCount === 1) {
+        ctx.reviewResult = makeFailedReviewResult([{ check: "adversarial", output: "Security gap" }]);
+      }
+      return false;
+    };
+
+    await autofixStage.execute(ctx);
+
+    _autofixDeps.recheckReview = saved.recheckReview;
+
+    expect(prompts).toHaveLength(2);
+    expect(prompts[0]).toContain("Review failed after your implementation");
+    expect(prompts[1]).toContain("Review failed after your implementation");
+    expect(prompts[1]).not.toContain("Your previous fix attempt did not resolve all issues");
+  });
 });

--- a/test/unit/pipeline/verify-smart-runner.test.ts
+++ b/test/unit/pipeline/verify-smart-runner.test.ts
@@ -341,6 +341,22 @@ describe("Verify Stage --- Smart Runner Integration", () => {
       const callArgs = mockRegression.mock.calls[0][0] as { command: string };
       expect(callArgs.command).toBe("bun test test/");
     });
+
+    test("treats object config without enabled flag as enabled", async () => {
+      mockGetChangedTestFiles.mockImplementation(async () => ["/test/workdir/src/foo/bar.spec.ts"]);
+      mockRegression.mockImplementation(async () => ({ success: true, status: "SUCCESS" as const }));
+
+      const ctx = makeContext({
+        smartTestRunner: {
+          fallback: "import-grep",
+          testFilePatterns: ["**/*.spec.ts"],
+        } as any,
+      });
+      await verifyStage.execute(ctx);
+
+      expect(mockGetChangedTestFiles).toHaveBeenCalledTimes(1);
+      expect(mockRegression).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("AC4: logs the mode used", () => {


### PR DESCRIPTION
## What

Fixes verify/autofix behavior and test coverage in three areas:

- Smart runner config coercion now merges defaults for object config, so partial objects (for example only `testFilePatterns`) do not silently disable smart-runner.
- Verify logging now distinguishes disabled smart-runner from genuine “no mapped tests” outcomes.
- Autofix prompt selection now resets to first-attempt framing when failed check types change between retries (prevents semantic→adversarial continuation pollution).
- Stabilizes ACP rectification integration tests by mocking rectification gate execution flow deterministically while still exercising AcpAgentAdapter run paths.

## Why

This addresses confusing/incorrect behavior observed in real runs:

- Smart-runner could be unintentionally disabled by partial config and emit misleading logs.
- Rectification prompts could carry over “previous attempt” framing across different reviewer failure categories.
- ACP rectification integration tests were flaky due to command-output coupling.

Closes #658

## How

- Updated `coerceSmartTestRunner()` in verify stage to merge with defaults.
- Added explicit disabled-mode verify logs and disabled-specific deferred/full-suite messages.
- Added failed-check signature tracking in autofix rectification loop; when signature changes, use `firstAttemptDelta()` instead of continuation prompt.
- Updated ACP rectification integration tests to mock `_rectificationGateDeps.resolveTestCommands` and `_rectificationGateDeps.executeWithTimeout` with deterministic sequences.

## Testing

- [x] Tests added/updated
- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

Targeted tests run:

- `bun test test/unit/pipeline/verify-smart-runner.test.ts test/unit/pipeline/stages/verify.test.ts test/unit/pipeline/stages/autofix-budget-prompts.test.ts test/integration/agents/acp/tdd-flow-rectification.test.ts`

## Notes

Lint and typecheck are enforced by pre-commit in this repo and passed during commit. Full-suite `bun test` was not run in this branch; targeted suites covering changed behavior passed.
