### PR TITLE
docs: document Context Engine v2, SessionManager, AgentManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,14 +183,14 @@ nax communicates with all coding agents via [ACP](https://github.com/openclaw/ac
 
 | Agent | Binary | Notes |
 |:------|:-------|:------|
-| Claude Code | `claude` | Default. Set `autoMode.defaultAgent: "claude"` |
-| OpenCode | `opencode` | Set `autoMode.defaultAgent: "opencode"` |
-| Codex | `codex` | Set `autoMode.defaultAgent: "codex"` |
-| Gemini CLI | `gemini` | Set `autoMode.defaultAgent: "gemini"` |
-| Aider | `aider` | Set `autoMode.defaultAgent: "aider"` |
+| Claude Code | `claude` | Default. Set `agent.default: "claude"` |
+| OpenCode | `opencode` | Set `agent.default: "opencode"` |
+| Codex | `codex` | Set `agent.default: "codex"` |
+| Gemini CLI | `gemini` | Set `agent.default: "gemini"` |
+| Aider | `aider` | Set `agent.default: "aider"` |
 | Any ACP-compatible | — | See [acpx agent docs](https://github.com/openclaw/acpx#agents) |
 
-See [Agents Guide](docs/guides/agents.md).
+See [Agents Guide](docs/guides/agents.md) and the [Context Engine Guide](docs/guides/context-engine.md) for agent-portable context configuration.
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -56,7 +56,7 @@ Deep reference for each subsystem — consult when working on a specific module.
 - **§21 Verification & Test Runners** — Orchestrator, strategies (scoped/regression/acceptance), smart runner, rectification, test-runners module (framework detection, output parsing SSOT)
 - **§22 Routing & Classification** — `classifyComplexity()`, `determineTestStrategy()`, pluggable strategies
 - **§23 Plugin System** — Plugin interface, 7 extension points, lifecycle
-- **§24 Context & Constitution** — Token-budgeted context, auto-detect, 7 agent generators, constitution
+- **§24 Context Engine & Constitution** — Context Engine v2 (ADR-010): `ContextOrchestrator`, providers, scoring/dedup/packing, push/pull model, `rebuildForAgent`; legacy v1 builder; per-agent generators; constitution
 - **§25 Review & Quality** — Review orchestrator, semantic review, adversarial review, diff utilities, quality runner, test command resolver
 - **§26 Interaction & Human-in-the-Loop** — Interaction chain, 8 triggers, bridge, plugins
 - **§27 Hooks & Lifecycle** — 11 hook events, `HookDef`, `HookContext`
@@ -66,6 +66,8 @@ Deep reference for each subsystem — consult when working on a specific module.
 - **§31 Queue Management** — PAUSE/ABORT/SKIP mid-run control
 - **§32 TUI (Terminal UI)** — React/Ink terminal UI, components, hooks
 - **§33 Error Classes** — `NaxError` + 5 derived error classes
+- **§34 Session Manager** (ADR-011) — `SessionManager`, 7-state machine, scratch dir, `handoff`, orphan detection, runtime helpers (`failAndClose`)
+- **§35 Agent Manager** (ADR-012 + ADR-013) — `AgentManager`, three retry layers, availability fallback, `runWithFallback`, `resolveDefaultAgent`, SessionManager hierarchy
 
 ---
 
@@ -102,7 +104,10 @@ Deep reference for each subsystem — consult when working on a specific module.
 | Injectable sleep | Test performance | `_moduleDeps.sleep = Bun.sleep` → spy in tests |
 | PidRegistry | Subprocess lifecycle | Register on spawn, unregister on exit, `killAll()` on crash |
 | Permission resolver | Agent permissions | `resolvePermissions(config, stage)` → `{ mode, skipPermissions }` |
+| Context Engine v2 | Stage-aware context assembly | `ContextOrchestrator.assemble(request)` → `ContextBundle` |
+| Session Manager | Session lifecycle + state machine | `ctx.sessionManager.create() / transition() / handoff()` |
+| Agent Manager | Agent default + availability fallback | `ctx.agentManager.getDefault() / runWithFallback()` |
 
 ---
 
-*Created: 2026-03-10. Last updated: 2026-04-12. Maintained by nax-dev.*
+*Created: 2026-03-10. Last updated: 2026-04-22. Maintained by nax-dev.*

--- a/docs/architecture/subsystems.md
+++ b/docs/architecture/subsystems.md
@@ -394,19 +394,69 @@ loadPlugins() → plugin.setup(config, logger)
 
 ---
 
-## §24 Context & Constitution System
+## §24 Context Engine & Constitution System
 
-### Context Builder
+### Context Engine v2 (`src/context/engine/`)
 
-`src/context/builder.ts`:
-- Token-budgeted context assembly for agent prompts
-- Priority-based element selection (story context > dependencies > project context)
+Stage-aware, session-aware, pluggable context assembly. Single point of context
+assembly for all pipeline stages. Spec: `SPEC-context-engine-v2.md`;
+decision record: ADR-010.
 
-### Auto-Detection
+**Entry point:** `ContextOrchestrator.assemble(ContextRequest)` →
+`ContextBundle { pushMarkdown, pullTools, digest, manifest, chunks }`.
 
-`src/context/auto-detect.ts`:
-- Scans git, detects language, frameworks, test files
-- Populates `BuiltContext` with relevant code/docs
+**Pipeline (9 steps):**
+
+1. Filter providers for this stage (`stageConfig.providerIds`).
+2. Parallel `fetch()` with 5-second timeout per provider.
+3. Score chunks (role × freshness × kind weights).
+4. Deduplicate (character-level trigram Jaccard ≥ 0.9).
+5. Role-filter (drop chunks whose audience tag mismatches `request.role`).
+6. Min-score filter (`config.context.v2.minScore`).
+7. Greedy pack (floor items first, then fill budget ceiling).
+8. Render push markdown (scope-ordered: project → feature → story → session → retrieved).
+9. Build digest (≤250 tokens, deterministic — threaded into the next stage's `priorStageDigest`).
+
+**Provider contract — `IContextProvider`:** duck-typed, three fields —
+`id: string`, `kind: ChunkKind`, `fetch(request): Promise<ContextProviderResult>`.
+No base class; validated structurally at load time.
+
+**Built-in providers (`src/context/engine/providers/`):**
+
+| Provider | Source | Scope |
+|:---------|:-------|:------|
+| `StaticRulesProvider` | `.nax/rules/` — canonical, agent-agnostic markdown | `repo-scoped` |
+| `FeatureContextProvider` | `context.md` — feature working memory | `repo-scoped` |
+| `SessionScratchProvider` | per-session scratch dir | `package-scoped` |
+| `GitHistoryProvider` | git log diffs — recent changes | `package-scoped` |
+| `CodeNeighborProvider` | import graph — co-changed files | `package-scoped` / `cross-package` |
+| `TestCoverageProvider` | coverage metrics | `package-scoped` |
+| Plugin providers | npm packages or project-relative paths | operator-registered |
+
+**Hybrid push/pull model.** Push markdown is pre-injected on every stage. Pull
+tools (`query_neighbor`, `query_feature_context`) are agent-callable mid-session,
+opt-in per stage via `config.context.v2.pull`, capped by
+`maxCallsPerSession`.
+
+**Availability fallback (ADR-010 D5).** On agent-availability failure,
+`ContextOrchestrator.rebuildForAgent(prior, { newAgentId, failure })` re-renders
+the existing bundle under the new agent's profile without re-fetching providers
+and injects a synthetic failure-note chunk. Called by `AgentManager` during
+swap (see §35).
+
+**Auditability.** Every bundle emits a `ContextManifest` recording exactly which
+chunks were included, excluded, and why. Persisted per story for post-hoc review.
+
+**Barrel:** `src/context/engine/index.ts` exports `ContextOrchestrator`,
+`IContextProvider`, all built-in providers, types (`ContextRequest`,
+`ContextBundle`, `ContextChunk`, `RawChunk`, `ContextManifest`), and utilities
+(`scoreChunks`, `dedupeChunks`, `packChunks`, `renderChunks`, `buildDigest`).
+
+### Context v1 (Legacy)
+
+`src/context/builder.ts` + `src/context/auto-detect.ts` remain for
+backwards compatibility and fall-through when v2 is disabled. New code must use
+the v2 engine; v1 is no longer the recommended entry point.
 
 ### Context Generators
 
@@ -421,6 +471,9 @@ loadPlugins() → plugin.setup(config, logger)
 | OpenCode | `opencode.ts` | Agent config |
 | Aider | `aider.ts` | `.aider.conf` |
 | Windsurf | `windsurf.ts` | Agent config |
+
+Generators remain agent-facing shims over the canonical `.nax/rules/` store
+consumed by `StaticRulesProvider`.
 
 ### Constitution
 
@@ -748,3 +801,177 @@ DebateSession.run()
 | `StoryLimitExceededError` | Too many stories for current plan |
 | `AllAgentsUnavailableError` | All configured agents failed or missing |
 | `LockAcquisitionError` | Another nax instance holds the lock |
+
+---
+
+## §34 Session Manager
+
+`src/session/manager.ts` — `SessionManager` class implementing `ISessionManager`.
+Decision record: ADR-011 (extraction) + ADR-013 (hierarchy with AgentManager).
+Spec: `SPEC-session-manager-integration.md`.
+
+Owns session *lifecycle*. The adapter keeps the *physical* session (acpx
+process, protocol calls). Policy from ADR-008 is preserved but re-expressed as
+state-machine transitions instead of a `keepSessionOpen: boolean`.
+
+### Ownership boundary
+
+```
+SessionManager                               AcpAgentAdapter
+─────────────────────────────────            ─────────────────────────
+Owns:                                        Owns:
+  - Stable session ID (sess-<uuid>)            - acpx process lifecycle
+  - State machine (7 states)                   - loadSession / createSession
+  - Scratch directory                          - sendPrompt / multi-turn loop
+  - index.json (sidecar replacement)           - token / cost tracking
+  - Close / resume / handoff decisions         - prompt audit
+  - Orphan detection (state-based)             - protocol-level retry on
+  - Agent-agnostic session naming                QUEUE_DISCONNECTED (AC-79)
+  - Prompt audit (per #523)
+```
+
+### State machine
+
+```
+CREATED → RUNNING → { PAUSED | COMPLETED | FAILED | CLOSING }
+PAUSED   → { RESUMING | FAILED }
+RESUMING → { RUNNING | FAILED }
+CLOSING  → { COMPLETED | FAILED }
+```
+
+Transitions are validated by `SESSION_TRANSITIONS`. `COMPLETED` and `FAILED` are
+terminal.
+
+### Key methods
+
+- `create(options)` → `SessionDescriptor` (stable `sess-<uuid>`).
+- `get(sessionId)` / `listActive()` → descriptor lookup; `listActive()` excludes
+  terminal states.
+- `transition(sessionId, toState)` → state-machine guard.
+- `handoff(id, newAgent)` → updates `descriptor.agent` while preserving `id`,
+  `handle`, and `scratchDir` (availability fallback; AC-42 cross-agent scratch
+  neutralization).
+- `scratchDir(sessionId)` → persistent per-session scratch path consumed by
+  `SessionScratchProvider` (§24).
+
+### Runtime helpers (not on the manager)
+
+`src/execution/session-manager-runtime.ts`:
+
+- `closeStorySessions` / `closeAllRunSessions` — orchestration.
+- `failAndClose(sm, sessionId, agentGetFn)` — atomic `→ FAILED` transition +
+  `closePhysicalSession(handle, workdir, { force: true })` (AC-83). Required
+  because `listActive()` excludes terminal sessions; teardown would otherwise
+  miss a failed session's handle.
+
+### Persistence & portability
+
+- `index.json` replaces the protocol-specific `acp-sessions.json` sidecar.
+- `descriptor.json` and `context-manifest-*.json` store paths **relative to
+  `projectDir`**; loaders rehydrate to absolute paths for runtime use.
+- One `SessionManager` per run, threaded through `PipelineContext`. Sessions do
+  not persist across runs; `index.json` is rewritten at run start.
+
+### Barrel
+
+`src/session/index.ts` exports `SessionManager`, `ISessionManager`,
+`SessionDescriptor`, `SessionState`, `SESSION_TRANSITIONS`, and
+`CreateSessionOptions`.
+
+---
+
+## §35 Agent Manager
+
+`src/agents/manager.ts` — `AgentManager` class implementing `IAgentManager`.
+Decision record: ADR-012 (extraction) + ADR-013 (SessionManager hierarchy).
+Spec: `SPEC-agent-manager-integration.md`.
+
+Owns agent *policy*: default resolution, availability fallback, unavailable-agent
+tracking. The adapter keeps the *physical* agent call. ContextOrchestrator keeps
+`rebuildForAgent()` as a utility the manager invokes.
+
+### Three retry layers — only one is owned here
+
+| Layer | Owner | Scope |
+|:------|:------|:------|
+| **Availability retry** (auth / 429 / service-down → swap agent) | **AgentManager** | Cross-agent policy |
+| **Transport retry** (broken socket, `QUEUE_DISCONNECTED`, stale session) | Adapter (`sessionErrorRetryable` loop) | Protocol-level, same agent |
+| **Payload-shape retry** (JSON parse fail → re-ask LLM) | Caller (`src/review/semantic.ts`, `adversarial.ts`) | Output validation, same agent |
+
+Conflating these was the root of the T16.3 silent-fallback regression. Reviewers
+must preserve this boundary — availability swaps never fire on payload-shape
+failures.
+
+### Ownership boundary
+
+```
+AgentManager                                  AcpAgentAdapter
+─────────────────────────────────             ─────────────────────────
+Owns:                                         Owns:
+  - Default agent resolution                    - acpx process lifecycle
+  - Fallback chain (flat or keyed map)          - sendPrompt / multi-turn loop
+  - Per-run unavailable-agent tracking          - token / cost tracking
+  - shouldSwap(failure) decision                - RunResult { adapterFailure }
+  - nextCandidate(current, failure)             - Transport-level retry
+  - runWithFallback / completeWithFallback
+  - Swap event emission
+  - Calls ContextOrchestrator.rebuildForAgent
+  - Calls SessionManager.handoff on swap
+```
+
+### Key methods
+
+- `getDefault()` → reads `config.agent.default` (replaces 79-site
+  `config.autoMode.defaultAgent` access).
+- `runAs(name, request)` / `runWithFallback(request)` → delegate to adapter;
+  on availability failure, consult `nextCandidate`, rebuild context, hand off
+  session, retry.
+- `completeAs(name, prompt, opts?)` / `completeWithFallback(...)` — one-shot
+  variant.
+- `planAs()` / `decomposeAs()` — delegators for the specialized calls.
+- `shouldSwap(failure)` / `nextCandidate(agentName, failure)` /
+  `isUnavailable(agent)` — fallback policy primitives.
+
+### Canonical resolution helper
+
+`resolveDefaultAgent(config)` in `src/agents/index.ts` is the standalone-module
+form for code that does not carry a `ctx`. In pipeline stages, prefer
+`ctx.agentManager?.getDefault() ?? "claude"`. **Never** read
+`config.autoMode.defaultAgent` directly — that key was removed in ADR-012
+Phase 6 and is rejected at config-load time.
+
+### Swap flow
+
+1. Adapter returns `RunResult { adapterFailure: { category, outcome, retriable, message } }`
+   (adapters no longer throw `AllAgentsUnavailableError`).
+2. Manager calls `shouldSwap(failure)`; if false, returns original result.
+3. Manager calls `nextCandidate(current, failure)` → next agent name or `null`.
+4. Manager calls `ContextOrchestrator.rebuildForAgent(bundle, { newAgentId, failure })`
+   to re-render under the new profile (no provider re-fetch).
+5. Manager calls `SessionManager.handoff(sessionId, newAgent)` so the descriptor
+   reflects the swap (ADR-013 Gap A).
+6. Manager emits `onSwapAttempt` event (consumed by reporters / TUI / audit).
+7. Manager invokes `runAs(newAgent, request)` and loops until terminal or
+   `maxHopsPerStory` exhausted.
+
+### Hierarchy with SessionManager (ADR-013)
+
+SessionManager orchestrates AgentManager, not the other way around.
+Execution-layer code receives `ISessionRunner` from the SessionManager; the
+runner holds a reference to AgentManager and calls `runInSession()` which
+internally dispatches through `AgentManager.runWithFallback`. This keeps all
+retry decisions in one place and prevents direct `adapter.run()` calls from
+bypassing the fallback chain (ADR-013 Problem 4).
+
+### Configuration
+
+See `docs/guides/configuration.md` → *Agent Configuration* for the canonical
+`config.agent` shape. Legacy keys (`autoMode.defaultAgent`,
+`autoMode.fallbackOrder`, `context.v2.fallback`) are rejected at load time with
+a migration hint (`NaxError code: CONFIG_LEGACY_AGENT_KEYS`).
+
+### Barrel
+
+`src/agents/index.ts` exports `AgentManager`, `IAgentManager`,
+`resolveDefaultAgent`, `AgentRunRequest`, `AgentRunOutcome`,
+`AgentCompleteOutcome`, and `AgentManagerEvents`.

--- a/docs/architecture/subsystems.md
+++ b/docs/architecture/subsystems.md
@@ -400,7 +400,7 @@ loadPlugins() → plugin.setup(config, logger)
 
 Stage-aware, session-aware, pluggable context assembly. Single point of context
 assembly for all pipeline stages. Spec: `SPEC-context-engine-v2.md`;
-decision record: ADR-010.
+decision record: ADR-010. **User guide:** [docs/guides/context-engine.md](../guides/context-engine.md).
 
 **Entry point:** `ContextOrchestrator.assemble(ContextRequest)` →
 `ContextBundle { pushMarkdown, pullTools, digest, manifest, chunks }`.

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -91,7 +91,7 @@ Why this matters for agent configuration:
 - **Force-terminate is explicit.** A terminally failed session transitions to `FAILED` and is closed atomically via `failAndClose()`. This guarantees AC-83 fires on availability-category exhaustion — previously the adapter's `finally` block could silently swallow the intent.
 - **Resume is deterministic.** Orphan detection walks `index.json` for non-terminal sessions older than TTL, replacing the old mtime heuristic. Crash-resume picks up with the same `sess-<uuid>` the original run would have used.
 
-See [Architecture — §34 Session Manager](../architecture/subsystems.md) and [§35 Agent Manager](../architecture/subsystems.md) for the full ownership boundary and state machine.
+See [Architecture — §34 Session Manager](../architecture/subsystems.md) and [§35 Agent Manager](../architecture/subsystems.md) for the full ownership boundary and state machine. For configuring what context the agent sees at each stage (and how to plug in RAG / graph providers), see the [Context Engine Guide](context-engine.md).
 
 ---
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -27,23 +27,71 @@ nax connects to agents via [acpx](https://github.com/openclaw/acpx). All agents 
 
 > **Known issue — `acpx` ≤ 0.3.1:** The `--model` flag is not supported. Model selection via `execution.model` or per-package `model` overrides has no effect. As a temporary workaround, use the [nathapp-io/acpx](https://github.com/nathapp-io/acpx) fork which adds `--model` support. Upstream fix is tracked in [openclaw/acpx#49](https://github.com/openclaw/acpx/issues/49).
 
-**Configuring the default agent:**
+**Configuring the default agent and fallback chain (ADR-012):**
 
 ```json
 {
-  "autoMode": {
-    "defaultAgent": "claude",
-    "fallbackOrder": ["claude", "opencode", "codex", "gemini"]
+  "agent": {
+    "protocol": "acp",
+    "default": "claude",
+    "fallback": {
+      "enabled": true,
+      "map": {
+        "claude": ["codex", "opencode"],
+        "codex": ["claude"]
+      },
+      "maxHopsPerStory": 2,
+      "rebuildContext": true,
+      "onQualityFailure": false
+    }
   }
 }
 ```
 
+> Legacy keys (`autoMode.defaultAgent`, `autoMode.fallbackOrder`, `context.v2.fallback`) were removed in ADR-012 Phase 6. Loading a config with them throws `NaxError CONFIG_LEGACY_AGENT_KEYS` with a per-key migration hint. See [Configuration — Agent Configuration](configuration.md#agent-configuration) for the full schema.
+
 **Selecting an agent at runtime:**
 
 ```bash
-# Run with a specific agent
+# Run with a specific agent (overrides agent.default for the invocation)
 nax run -f my-feature --agent opencode
 ```
+
+---
+
+### How fallback works
+
+nax has three independent retry layers. Only one of them swaps the agent; the other two stay on the same agent. Conflating them causes silent regressions (the T16.3 bug), so it's worth understanding the split.
+
+| Layer | Trigger | Owner | Swaps agent? |
+|:------|:--------|:------|:-------------|
+| **Availability** | Auth (401), rate-limit (429), service down | `AgentManager` | Yes — walks `agent.fallback.map` |
+| **Transport** | Broken socket, `QUEUE_DISCONNECTED`, stale session | `AcpAgentAdapter` | No — same agent, new protocol session |
+| **Payload** | JSON parse / schema mismatch on LLM reply | Caller (e.g. semantic / adversarial review) | No — same agent, re-ask |
+
+When the availability layer fires:
+
+1. Adapter returns a `RunResult` with `adapterFailure: { category: "auth" | "rate_limit" | ... }` — it no longer throws `AllAgentsUnavailableError`.
+2. `AgentManager.shouldSwap(failure)` decides whether this failure is swappable.
+3. `AgentManager.nextCandidate(current, failure)` walks `agent.fallback.map[current]`.
+4. `ContextOrchestrator.rebuildForAgent(bundle, { newAgentId, failure })` re-renders the existing context bundle under the new agent's profile without re-fetching providers (ADR-010 D5).
+5. `SessionManager.handoff(sessionId, newAgent)` updates the session descriptor so the stable `sess-<uuid>` persists across the swap (ADR-013 Gap A).
+6. An `onSwapAttempt` event is emitted for reporters / TUI / audit consumers.
+7. The manager retries until terminal or `maxHopsPerStory` is exhausted.
+
+**Availability fallback ≠ tier escalation.** Tier escalation (`fast` → `balanced` → `powerful`) fires when the *same* agent repeatedly fails the verification gate on *content* — it runs the next attempt at a stronger model. Availability fallback fires when the agent itself cannot be reached. The two can stack: an exhausted escalation can still swap agents if the terminal failure was availability-category.
+
+### Session handoff and the SessionManager
+
+Every story's internal sessions (plan → test-writer → implementer → verifier → reviewer → rectifier) carry a stable `sess-<uuid>` owned by `SessionManager` (ADR-011). The adapter only owns the *physical* acpx session.
+
+Why this matters for agent configuration:
+
+- **Scratch survives swaps.** `SessionScratchProvider` (Context Engine v2) writes to `SessionManager.scratchDir(sessionId)`. When the manager hands off to a new agent on availability swap, the scratch dir is preserved and cross-agent neutralized (AC-42) so observations from the old agent are still available to the new one.
+- **Force-terminate is explicit.** A terminally failed session transitions to `FAILED` and is closed atomically via `failAndClose()`. This guarantees AC-83 fires on availability-category exhaustion — previously the adapter's `finally` block could silently swallow the intent.
+- **Resume is deterministic.** Orphan detection walks `index.json` for non-terminal sessions older than TTL, replacing the old mtime heuristic. Crash-resume picks up with the same `sess-<uuid>` the original run would have used.
+
+See [Architecture — §34 Session Manager](../architecture/subsystems.md) and [§35 Agent Manager](../architecture/subsystems.md) for the full ownership boundary and state machine.
 
 ---
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -39,6 +39,49 @@ Config is layered — project overrides global:
 }
 ```
 
+### Agent Configuration
+
+<a name="agent-configuration"></a>
+
+The `agent` block is the canonical source of truth for agent selection and availability fallback (ADR-012). It consolidates three legacy configs (`autoMode.defaultAgent`, `autoMode.fallbackOrder`, `context.v2.fallback`) into a single shape.
+
+```json
+{
+  "agent": {
+    "protocol": "acp",
+    "default": "claude",
+    "maxInteractionTurns": 20,
+    "fallback": {
+      "enabled": true,
+      "map": {
+        "claude": ["codex", "opencode"],
+        "codex": ["claude"]
+      },
+      "maxHopsPerStory": 2,
+      "rebuildContext": true,
+      "onQualityFailure": false
+    }
+  }
+}
+```
+
+| Key | Default | Description |
+|:----|:--------|:------------|
+| `agent.protocol` | `"acp"` | Transport protocol. Only `"acp"` is supported. |
+| `agent.default` | `"claude"` | Primary agent. Read via `resolveDefaultAgent(config)` / `ctx.agentManager.getDefault()`. |
+| `agent.maxInteractionTurns` | `20` | Max turns per agent session. |
+| `agent.fallback.enabled` | `false` | Master switch for availability fallback (auth / rate-limit / service-down). |
+| `agent.fallback.map` | `{}` | Keyed map — `{ primary: [next, ...] }`. Walked by `AgentManager.nextCandidate()`. |
+| `agent.fallback.maxHopsPerStory` | `2` | Swap ceiling per story. Prevents runaway swap loops. |
+| `agent.fallback.rebuildContext` | `true` | Call `ContextOrchestrator.rebuildForAgent()` on swap so the new agent sees a re-rendered bundle. |
+| `agent.fallback.onQualityFailure` | `false` | Also swap on review / verify reject, not just availability. Use with care — often masks real regressions. |
+
+**Scope — what this controls.** Only the *availability* retry layer (auth / 429 / service down). Transport retries (broken socket, stale session) stay on the same agent inside the adapter. Payload-shape retries (JSON parse fail) stay on the same agent inside the caller. See [Agents — How fallback works](agents.md#how-fallback-works) for the full three-layer split.
+
+**Legacy keys are rejected, not stripped.** `autoMode.defaultAgent`, `autoMode.fallbackOrder`, and `context.v2.fallback` were removed in ADR-012 Phase 6. Loading a config with them throws `NaxError code: CONFIG_LEGACY_AGENT_KEYS` with a migration hint. This is intentional — silently stripping would mask the migration.
+
+---
+
 ### Shell Operators in Commands
 
 Review commands (`lint`, `typecheck`) are executed directly via `Bun.spawn` — **not** through a shell. This means shell operators like `&&`, `||`, `;`, and `|` are passed as literal arguments and will not work as expected.

--- a/docs/guides/context-engine.md
+++ b/docs/guides/context-engine.md
@@ -259,6 +259,92 @@ The loader validates the shape structurally (duck-typed — no import from nax i
 
 **Determinism.** If your provider is non-deterministic (network call, LLM summary), set `deterministic: false` on it. Users who set `context.v2.deterministic: true` in their config will have it excluded — this is how you opt out of reproducibility-sensitive runs.
 
+#### Scoping a provider to specific stages
+
+A common question is "how do I run my provider only on `tdd-test-writer`?" or "only on `review-semantic`?" There's no config-level toggle for this today — the stage-to-provider mapping is hardcoded in `STAGE_CONTEXT_MAP` ([src/context/engine/stage-config.ts](../../src/context/engine/stage-config.ts)) and `context.v2.stages.*` only overrides `budgetTokens`. Tracked in [#662](https://github.com/nathapp-io/nax/issues/662).
+
+Three patterns work today:
+
+**Pattern A — chunk `role` tags (audience filter).** Every pipeline stage has a fixed *role* and the orchestrator drops chunks whose `role` doesn't match. This is the right tool when you want a provider to serve one audience (e.g. reviewers).
+
+| Role | Stages that consume it |
+|:-----|:-----------------------|
+| `implementer` | `execution`, `context`, `tdd-implementer`, `verify`, `rectify`, `autofix`, `acceptance`, `plan`, `single-session`, `tdd-simple`, `no-test`, `batch`, `route` |
+| `tdd` | `tdd-test-writer`, `tdd-verifier` |
+| `reviewer` | `review`, `review-semantic`, `review-adversarial`, `review-dialogue`, `debate` |
+| `all` | matches every stage |
+
+```typescript
+// Appears only in reviewer-role stages:
+{ id: "my:design-decisions", role: ["reviewer"], content: "...", /* ... */ }
+
+// Appears only in tdd-role stages:
+{ id: "my:acceptance-invariants", role: ["tdd"], content: "...", /* ... */ }
+
+// Multi-role — matches if ANY tag aligns with the stage role:
+{ id: "my:cross-cutting", role: ["reviewer", "tdd"], content: "...", /* ... */ }
+```
+
+**Pattern B — switch on `request.stage` inside `fetch()`.** Use this when you need finer granularity than `role` (e.g. `tdd-test-writer` but not `tdd-verifier`):
+
+```typescript
+export const provider: IContextProvider = {
+  id: "my-provider",
+  kind: "rag",
+  fetch: async (request) => {
+    if (request.stage === "tdd-test-writer") {
+      return {
+        chunks: [{
+          id: "my:acceptance-fixtures",
+          kind: "rag",
+          scope: "retrieved",
+          role: ["tdd"],
+          content: await loadAcceptanceFixtures(request.touchedFiles),
+          tokens: 400,
+          rawScore: 0.9,
+        }],
+        pullTools: [],
+      };
+    }
+    if (request.stage === "review-semantic") {
+      return {
+        chunks: [{
+          id: "my:design-rationale",
+          kind: "rag",
+          scope: "retrieved",
+          role: ["reviewer"],
+          content: await loadDesignRationale(request.featureId),
+          tokens: 300,
+          rawScore: 0.85,
+        }],
+        pullTools: [],
+      };
+    }
+    return { chunks: [], pullTools: [] };  // no-op on other stages
+  },
+};
+```
+
+**Pattern C — combine A + B.** Use chunk `role` for coarse audience scoping and `request.stage` inside `fetch()` for fine per-stage variation (e.g. different framings for `tdd-test-writer` vs. `tdd-implementer`, both `tdd`-role).
+
+#### The catch — getting your plugin to fire at all
+
+Plugin providers load and register with the orchestrator, but the orchestrator then filters by each stage's `providerIds`. None of the built-in stages include plugin IDs today, so a freshly registered plugin **runs on zero stages** until someone adds its ID to `STAGE_CONTEXT_MAP`.
+
+**Until [#662](https://github.com/nathapp-io/nax/issues/662) lands**, the only way to wire a plugin into a stage is a source edit:
+
+```typescript
+// src/context/engine/stage-config.ts
+"tdd-test-writer": {
+  role: "tdd",
+  budgetTokens: 8_000,
+  providerIds: [...PHASE_3_TDD_TEST_WRITER, "my-symbol-graph"],  // <-- add plugin ID
+  pullToolNames: ["query_neighbor"],
+},
+```
+
+Unknown IDs in a stage's `providerIds` throw `CONTEXT_UNKNOWN_PROVIDER_IDS` at assembly time, so typos surface immediately.
+
 ---
 
 ### 7. Debug & audit — the manifest

--- a/docs/guides/context-engine.md
+++ b/docs/guides/context-engine.md
@@ -1,0 +1,388 @@
+---
+title: Context Engine
+description: Seed, configure, extend, and debug the Context Engine v2
+---
+
+## Context Engine
+
+The Context Engine assembles everything your coding agent "knows" at each pipeline stage — canonical rules, feature notes, prior session observations, recent git changes, co-changed files, and any custom RAG / graph / KB sources you plug in. It replaces the old "one big `context.md` dump" model with stage-aware, session-aware, budgeted assembly.
+
+This guide covers **how to use it**. For the design rationale, see [ADR-010](../adr/ADR-010-context-engine.md) and [Architecture §24](../architecture/subsystems.md).
+
+---
+
+### When to use it
+
+Turn the engine on when any of the following are true:
+
+- You're running multi-story pipelines and want prior-story observations to carry forward.
+- Your project has rules / conventions that Claude-specific files (`CLAUDE.md`, `.claude/rules/`) can't express portably across agents (Codex, OpenCode, Gemini, etc.).
+- You want to plug in a RAG index, symbol graph, or internal KB as a context source.
+- You want to audit exactly what went into each agent prompt after the fact.
+
+You can skip it if you're running single-story, single-agent, small-repo flows — the legacy v1 path (`context.md` inlined at prompt build) still works.
+
+---
+
+### 1. Enable it
+
+The engine is **off by default**. Opt in per-project:
+
+```json
+// .nax/config.json
+{
+  "context": {
+    "v2": {
+      "enabled": true
+    }
+  }
+}
+```
+
+That's the minimum. With just `enabled: true`, you get the five built-in providers active on every pipeline stage that has a default provider set (execution, tdd-*, rectify, review, review-semantic, etc.).
+
+Verify it's on:
+
+```bash
+nax run -f my-feature --dry-run
+# Look for "[context] assemble ok" lines in the log
+# Or inspect the manifest (§6 below)
+```
+
+---
+
+### 2. Seed feature context (`context.md`)
+
+The single highest-leverage file. Read by `FeatureContextProvider` on every stage.
+
+**Path:** `<repoRoot>/.nax/features/<featureId>/context.md`
+
+**Format:** plain Markdown. Append entries as you go — order matters (newer entries outrank older ones once the staleness detector kicks in).
+
+```markdown
+## Design decision — 2026-04-18
+
+Chose Postgres over Dynamo for multi-tenant isolation. Partition key must
+include `tenant_id` in every new table.
+
+## Known constraint
+
+RDS hard-caps at 1000 concurrent connections. Avoid N+1 in reviews — use
+the batch endpoint `/v2/reviews/batch`.
+
+## Deprecated
+
+`/v1/*` endpoints deprecated 2026-01-15. All new routes land under `/v2/`.
+```
+
+**Staleness.** Entries past `staleness.maxStoryAge` completed stories (default 10) get their score multiplied by `staleness.scoreMultiplier` (default 0.4) so fresh context beats old context for the same budget slot. Entries are never auto-deleted — you edit the file to remove them.
+
+**Pull tool.** Reviewers and rectifiers can call `query_feature_context` mid-session to re-query this file with an optional keyword filter. See §5.
+
+---
+
+### 3. Replace `CLAUDE.md` / `.claude/rules/` with canonical rules
+
+Agent-specific files (`CLAUDE.md`, `.claude/rules/`, `.cursorrules`) are not portable. When availability fallback swaps Claude → Codex, the new agent never reads them.
+
+The engine reads from a canonical, agent-agnostic store instead:
+
+**Path:** `<repoRoot>/.nax/rules/*.md`
+
+Any `.md` file in that directory is picked up by `StaticRulesProvider` on every stage. Structure by concern:
+
+```
+.nax/rules/
+  project-conventions.md
+  error-handling.md
+  testing-commands.md
+  forbidden-patterns.md
+```
+
+**Legacy fallback.** While you migrate, keep reading the old files:
+
+```json
+{
+  "context": {
+    "v2": {
+      "rules": {
+        "allowLegacyClaudeMd": true,
+        "budgetTokens": 8192
+      }
+    }
+  }
+}
+```
+
+With `allowLegacyClaudeMd: true`, `StaticRulesProvider` falls back to `CLAUDE.md` + `.claude/rules/` when `.nax/rules/` is empty. Default is `false` — once you've migrated, drop the flag to avoid drift.
+
+---
+
+### 4. Configure per-stage budgets
+
+Every pipeline stage has a default token budget and a default provider list (see `src/context/engine/stage-config.ts`). Override per-stage in your config:
+
+```json
+{
+  "context": {
+    "v2": {
+      "stages": {
+        "execution":        { "budgetTokens": 15000 },
+        "tdd-test-writer":  { "budgetTokens": 10000 },
+        "review":           { "budgetTokens": 6000 }
+      }
+    }
+  }
+}
+```
+
+Bigger budget = more context, higher token cost. Smaller = tighter prompts, cheaper but more prone to pull-tool fetches (§5).
+
+Common starting points:
+
+| Stage | Default | Raise when |
+|:------|:--------|:-----------|
+| `execution` | 12,000 | Stories touch ≥3 files or cross-package boundaries |
+| `tdd-test-writer` | 8,000 | Tests need broad domain context (acceptance specs, invariants) |
+| `review` | 6,000 | Diffs are typically large; reviewers miss cross-cutting concerns |
+| `rectify` | 8,000 | Rectification fails with "didn't know about X" verdicts |
+
+---
+
+### 5. Enable pull tools (on-demand context)
+
+Pull tools let the agent fetch context *mid-session* instead of everything being pre-injected. Two built-ins:
+
+- **`query_neighbor(filePath)`** — fetch import-graph neighbours for a file. Useful for implementers and rectifiers.
+- **`query_feature_context(keyword?)`** — fetch feature context with optional keyword filter. Useful for reviewers.
+
+Pull tools are off by default. Enable them:
+
+```json
+{
+  "context": {
+    "v2": {
+      "pull": {
+        "enabled": true,
+        "allowedTools": [],
+        "maxCallsPerSession": 5,
+        "maxCallsPerRun": 50
+      }
+    }
+  }
+}
+```
+
+| Key | Default | Notes |
+|:----|:--------|:------|
+| `pull.enabled` | `false` | Master switch |
+| `pull.allowedTools` | `[]` | Empty = allow all stage-configured tools; set `["query_neighbor"]` to restrict |
+| `pull.maxCallsPerSession` | `5` | Per agent session ceiling |
+| `pull.maxCallsPerRun` | `50` | Per-run ceiling (shared across all sessions) |
+
+Exhausted budgets throw `PULL_TOOL_BUDGET_EXHAUSTED`; the agent recovers gracefully and finishes with whatever it already has.
+
+Which stages get which tools is defined in `stage-config.ts` (`pullToolNames` per stage). You can't currently add a pull tool to an arbitrary stage from config alone — that's a code change.
+
+---
+
+### 6. Add a plugin provider (RAG / graph / KB)
+
+This is the extension point for operator-specific context: an embeddings index, a symbol graph, your internal wiki, a domain-model summariser.
+
+**Register in config:**
+
+```json
+{
+  "context": {
+    "v2": {
+      "pluginProviders": [
+        {
+          "module": "@mycompany/nax-rag",
+          "config": { "indexUrl": "https://rag.internal", "topK": 5 },
+          "enabled": true
+        },
+        {
+          "module": "./plugins/my-symbol-graph.ts",
+          "enabled": true
+        }
+      ]
+    }
+  }
+}
+```
+
+`module` accepts npm package names or project-relative paths (`./` / `../`). Absolute paths are rejected. Relative paths that try to escape the project root are rejected.
+
+**Minimum viable provider:**
+
+```typescript
+// plugins/my-symbol-graph.ts
+import type { IContextProvider, ContextRequest, ContextProviderResult } from "nax/context";
+
+export const provider: IContextProvider = {
+  id: "my-symbol-graph",
+  kind: "graph",
+  fetch: async (request: ContextRequest): Promise<ContextProviderResult> => {
+    const files = request.changedFiles ?? [];
+    const related = await querySymbolGraph(files);
+
+    return {
+      chunks: related.map((r, i) => ({
+        id: `my-symbol-graph:${r.symbol}`,
+        kind: "graph",
+        scope: "retrieved",
+        role: ["all"],             // or ["implementer"], ["reviewer"], etc.
+        content: `### ${r.symbol}\n${r.summary}\n`,
+        tokens: estimateTokens(r.summary),
+        rawScore: r.relevance,     // 0..1
+      })),
+      pullTools: [],               // advanced — usually empty
+    };
+  },
+};
+```
+
+**Optional lifecycle hooks:**
+
+```typescript
+export const provider = {
+  id: "my-symbol-graph",
+  kind: "graph",
+  async init(config: Record<string, unknown>) { /* open DB, warm cache */ },
+  async fetch(request) { /* ... */ },
+  async dispose() { /* close DB */ },
+};
+```
+
+The loader validates the shape structurally (duck-typed — no import from nax internals required). Providers that fail to load log a warning and are skipped — the pipeline never blocks on a broken plugin.
+
+**Determinism.** If your provider is non-deterministic (network call, LLM summary), set `deterministic: false` on it. Users who set `context.v2.deterministic: true` in their config will have it excluded — this is how you opt out of reproducibility-sensitive runs.
+
+---
+
+### 7. Debug & audit — the manifest
+
+Every bundle the engine assembles writes a manifest to disk. This is how you answer "why did the agent see X but not Y?"
+
+**Path:**
+
+```
+<projectDir>/.nax/features/<featureId>/stories/<storyId>/context-manifest-<stage>.json
+```
+
+**What's in it:**
+
+- `includedChunks` — what made it into the prompt, with score and byte-offset
+- `excludedChunks` — with reason: `below-min-score` / `budget` / `dedupe` / `role-filter` / `stale`
+- `providerResults` — per-provider status (`ok` / `empty` / `failed` / `timeout`) + duration
+- `chunkSummaries` — first 300 chars of each chunk (so you can read the manifest without cross-referencing the bundle)
+- `rebuildInfo` — when a swap happened, records prior/new agent IDs and which chunks were re-rendered
+
+Typical debugging workflow:
+
+```bash
+# Inspect what went into the execution stage for story US-003
+cat .nax/features/my-feature/stories/US-003/context-manifest-execution.json | jq '.'
+
+# "Why isn't my .nax/rules/testing.md showing up?"
+jq '.excludedChunks[] | select(.id | contains("testing"))' \
+  .nax/features/my-feature/stories/US-003/context-manifest-execution.json
+
+# "Did my plugin provider run?"
+jq '.providerResults[] | select(.id == "my-symbol-graph")' \
+  .nax/features/my-feature/stories/US-003/context-manifest-execution.json
+```
+
+Verbose logging:
+
+```bash
+NAX_DEBUG_CONTEXT=1 nax run -f my-feature
+```
+
+---
+
+### 8. Monorepo tuning
+
+In a monorepo, context scope matters. By default, per-package providers only scan the story's package — which is usually what you want.
+
+```json
+{
+  "context": {
+    "v2": {
+      "providers": {
+        "historyScope": "package",
+        "neighborScope": "package",
+        "crossPackageDepth": 1
+      }
+    }
+  }
+}
+```
+
+| Key | Default | Effect |
+|:----|:--------|:-------|
+| `providers.historyScope` | `"package"` | `git log` runs in `packageDir` only. Set `"repo"` for full-repo history when stories commonly touch root-level files. |
+| `providers.neighborScope` | `"package"` | Import graph scans only within `packageDir`. Set `"repo"` when packages tightly share imports. |
+| `providers.crossPackageDepth` | `1` | How many package boundaries the neighbor provider may cross. `0` disables cross-package scans. |
+
+Per-package overrides live in `.nax/mono/<packageDir>/config.json` — use them when one package needs a different budget or scope than the repo default.
+
+---
+
+### 9. What happens when it's off
+
+If `context.v2.enabled: false` (default), the pipeline falls back to v1:
+
+- `featureContextMarkdown()` reads `context.md` directly and inlines it.
+- No providers, no manifests, no pull tools, no session scratch.
+- Agent-specific files (`CLAUDE.md`) are the only rules path.
+- Everything goes into every stage's prompt — no budgets, no scoring.
+
+Migration approach:
+
+1. Leave `enabled: false`, author `.nax/rules/*.md` + `.nax/features/<id>/context.md`.
+2. Flip `enabled: true` on a throwaway feature branch.
+3. Inspect `context-manifest-*.json` after a run; confirm the chunks you expect are included.
+4. Flip on in main config.
+
+---
+
+### 10. Full config reference
+
+Every `context.v2.*` key:
+
+| Key | Type | Default | Effect |
+|:----|:-----|:--------|:-------|
+| `enabled` | bool | `false` | Master switch |
+| `minScore` | 0–1 | `0.1` | Drop chunks below this relevance score |
+| `deterministic` | bool | `false` | When `true`, exclude providers that declare `deterministic: false` |
+| `pull.enabled` | bool | `false` | Allow mid-session pull tool calls |
+| `pull.allowedTools` | `string[]` | `[]` | Allowlist (empty = all stage-configured tools) |
+| `pull.maxCallsPerSession` | int | `5` | Per agent session |
+| `pull.maxCallsPerRun` | int | `50` | Per entire nax run |
+| `rules.allowLegacyClaudeMd` | bool | `false` | Fall back to `CLAUDE.md` / `.claude/rules/` when `.nax/rules/` is empty |
+| `rules.budgetTokens` | int | `8192` | Token ceiling for canonical rules |
+| `pluginProviders` | `PluginConfig[]` | `[]` | External providers (RAG / graph / KB) |
+| `stages.<name>.budgetTokens` | int | per-stage | Override token budget for a specific stage |
+| `session.retentionDays` | int | `7` | Days to keep completed session scratch before purging |
+| `session.archiveOnFeatureArchive` | bool | `true` | Archive instead of delete on feature completion |
+| `staleness.enabled` | bool | `true` | Detect and downweight old context.md entries |
+| `staleness.maxStoryAge` | int | `10` | Entries older than N completed stories are stale |
+| `staleness.scoreMultiplier` | 0–1 | `0.4` | Score multiplier applied to stale chunks |
+| `providers.historyScope` | `"package" \| "repo"` | `"package"` | Git log scope |
+| `providers.neighborScope` | `"package" \| "repo"` | `"package"` | Neighbor scan scope |
+| `providers.crossPackageDepth` | int | `1` | Cross-package neighbor traversal depth |
+
+---
+
+### References
+
+- [ADR-010 — Context Engine](../adr/ADR-010-context-engine.md) — decisions D1–D8
+- [Architecture §24 — Context Engine & Constitution](../architecture/subsystems.md) — internals
+- `src/config/schemas.ts` — canonical config schema (`ContextV2ConfigSchema`)
+- `src/context/engine/stage-config.ts` — default providers + budgets per stage
+- `src/context/engine/providers/plugin-loader.ts` — plugin validation rules
+- [Agents guide](agents.md) — how agent fallback interacts with context rebuild
+
+[Back to README](../../README.md)


### PR DESCRIPTION
## Summary

Architecture docs were lagging the ADR-010/011/012/013 implementations. `subsystems.md §24` still described the v1 context builder, there were no subsystem sections for `SessionManager` or `AgentManager`, and the agent guides still referenced legacy config keys (`autoMode.defaultAgent`, `autoMode.fallbackOrder`, `context.v2.fallback`) that are now rejected at config-load time.

- **subsystems.md** — rewrite §24 to cover Context Engine v2 (orchestrator, providers, scoring/dedup/packing, push/pull, `rebuildForAgent`); keep v1 legacy and generators/constitution subsections. Add §34 SessionManager (7-state machine, `handoff`, runtime helpers, persistence) and §35 AgentManager (three retry layers, `runWithFallback`, SessionManager hierarchy, canonical resolution helper).
- **ARCHITECTURE.md** — update index entries for §24/§34/§35 and extend the quick-ref card.
- **guides/agents.md** — replace legacy `autoMode.*` config with the canonical `config.agent` shape. Add "How fallback works" (three retry layers) and SessionManager handoff notes.
- **guides/configuration.md** — add an Agent Configuration section documenting every `config.agent.*` field and scoping each retry layer.

Deferred (out of scope for this PR, called out in the audit):
- Publishing `.claude/rules/adapter-wiring.md` to `docs/guides/`.
- A v1 → v2 context migration guide.

## Test plan

- [ ] Render `docs/architecture/subsystems.md` — verify §24 / §34 / §35 render cleanly and cross-link to ADR-010/011/012/013.
- [ ] Render `docs/architecture/ARCHITECTURE.md` — verify new index entries and quick-ref rows.
- [ ] Render `docs/guides/agents.md` + `docs/guides/configuration.md` — verify anchor `#agent-configuration` resolves from `agents.md`, and all code blocks are valid JSON.
- [ ] `git grep -n "autoMode\.defaultAgent\|autoMode\.fallbackOrder\|context\.v2\.fallback" docs/` should return no user-facing guidance (ADRs still reference them in historical context, which is expected).