### PR TITLE
fix: prefer active feature in feature-resolver to avoid story-ID collisions

### DIFF
--- a/src/context/engine/providers/feature-context.ts
+++ b/src/context/engine/providers/feature-context.ts
@@ -79,7 +79,7 @@ export class FeatureContextProviderV2 implements IContextProvider {
 
     try {
       const v1 = _featureContextV2Deps.createV1Provider();
-      const result = await v1.getContext(this.story, request.repoRoot, this.config);
+      const result = await v1.getContext(this.story, request.repoRoot, this.config, request.featureId);
       if (!result) {
         return { chunks: [], pullTools: [] };
       }

--- a/src/context/feature-resolver.ts
+++ b/src/context/feature-resolver.ts
@@ -100,13 +100,60 @@ async function buildIndex(workdir: string): Promise<Map<string, string | null>> 
 }
 
 /**
+ * Check whether a specific feature's prd.json contains the given story.
+ * Returns the featureId when the story is present, otherwise null.
+ *
+ * This bypasses the global index and is used when the caller already knows
+ * which feature the story belongs to (e.g. `nax run -f <feature>`) — it
+ * avoids story-ID collisions across features that restart numbering at US-001.
+ */
+async function tryResolveFromActiveFeature(
+  story: UserStory,
+  workdir: string,
+  activeFeature: string,
+): Promise<string | null> {
+  const logger = getLogger();
+  const prdPath = `${workdir}/.nax/features/${activeFeature}/prd.json`;
+
+  try {
+    const raw = await _resolverDeps.readFile(prdPath);
+    const prd = JSON.parse(raw) as { userStories?: Array<{ id: string }> };
+    for (const entry of prd.userStories ?? []) {
+      if (entry.id === story.id) return activeFeature;
+    }
+    return null;
+  } catch (err) {
+    logger.debug("feature-resolver", "Active-feature PRD unreadable — falling back to index scan", {
+      storyId: story.id,
+      activeFeature,
+      error: errorMessage(err),
+    });
+    return null;
+  }
+}
+
+/**
  * Resolve which feature a story belongs to by scanning .nax/features/<id>/prd.json.
  * Returns the feature directory name (featureId) or null if the story is unattached.
  *
- * The first call per workdir builds a full index of all features in one pass.
- * Subsequent calls for any story in the same workdir are O(1) map lookups.
+ * When `activeFeature` is provided, the resolver first checks that feature's prd.json
+ * directly. This prevents story-ID collisions (US-001 in multiple features) from
+ * pointing at the wrong feature and is the common path for `nax run -f <feature>`.
+ *
+ * When the hint does not resolve (missing PRD, story not listed), falls back to the
+ * global index: the first call per workdir builds a full index of all features in
+ * one pass; subsequent calls for any story in the same workdir are O(1) map lookups.
  */
-export async function resolveFeatureId(story: UserStory, workdir: string): Promise<string | null> {
+export async function resolveFeatureId(
+  story: UserStory,
+  workdir: string,
+  activeFeature?: string,
+): Promise<string | null> {
+  if (activeFeature) {
+    const hinted = await tryResolveFromActiveFeature(story, workdir, activeFeature);
+    if (hinted) return hinted;
+  }
+
   // Return from completed index if available
   const existing = _index.get(workdir);
   if (existing) {

--- a/src/context/providers/feature-context.ts
+++ b/src/context/providers/feature-context.ts
@@ -45,13 +45,22 @@ export class FeatureContextProvider {
   /**
    * Fetch the feature context for the given story.
    * Returns null when: feature engine disabled, story unattached, no context.md.
+   *
+   * When `activeFeature` is provided (typically `ctx.prd.feature`), the resolver
+   * prefers that feature when the story ID matches. This avoids story-ID
+   * collisions across features that both number from US-001.
    */
-  async getContext(story: UserStory, workdir: string, config: NaxConfig): Promise<FeatureContextResult | null> {
+  async getContext(
+    story: UserStory,
+    workdir: string,
+    config: NaxConfig,
+    activeFeature?: string,
+  ): Promise<FeatureContextResult | null> {
     const logger = getLogger();
 
     if (!config.context?.featureEngine?.enabled) return null;
 
-    const featureId = await _featureContextDeps.resolveFeatureId(story, workdir);
+    const featureId = await _featureContextDeps.resolveFeatureId(story, workdir, activeFeature);
     if (!featureId) return null;
 
     const contextPath = `${workdir}/.nax/features/${featureId}/context.md`;

--- a/test/unit/context/feature-resolver.test.ts
+++ b/test/unit/context/feature-resolver.test.ts
@@ -131,6 +131,64 @@ describe("resolveFeatureId", () => {
     _resolverDeps.readFile = originalReadFile;
   });
 
+  test("prefers activeFeature hint over first alphabetical match when story ID collides", async () => {
+    // Reproduces issue #663: US-001 exists in multiple features; alphabetical first
+    // match would point to the wrong feature.
+    const firstDir = join(tempDir, ".nax", "features", "aaa-other-feature");
+    const activeDir = join(tempDir, ".nax", "features", "zzz-active-feature");
+    mkdirSync(firstDir, { recursive: true });
+    mkdirSync(activeDir, { recursive: true });
+    writeFileSync(join(firstDir, "prd.json"), makePrd(["US-001"]));
+    writeFileSync(join(activeDir, "prd.json"), makePrd(["US-001"]));
+
+    const story = makeStory("US-001");
+    const result = await resolveFeatureId(story, tempDir, "zzz-active-feature");
+    expect(result).toBe("zzz-active-feature");
+  });
+
+  test("activeFeature hint skips the global index scan", async () => {
+    const activeDir = join(tempDir, ".nax", "features", "active-feature");
+    mkdirSync(activeDir, { recursive: true });
+    writeFileSync(join(activeDir, "prd.json"), makePrd(["US-001"]));
+
+    let globCalls = 0;
+    const originalGlob = _resolverDeps.glob;
+    _resolverDeps.glob = ((pattern: string, opts: { cwd: string }) => {
+      globCalls++;
+      return originalGlob(pattern, opts);
+    }) as typeof _resolverDeps.glob;
+
+    const story = makeStory("US-001");
+    const result = await resolveFeatureId(story, tempDir, "active-feature");
+    expect(result).toBe("active-feature");
+    expect(globCalls).toBe(0);
+
+    _resolverDeps.glob = originalGlob;
+  });
+
+  test("falls back to index scan when activeFeature does not contain the story", async () => {
+    const activeDir = join(tempDir, ".nax", "features", "active-feature");
+    const otherDir = join(tempDir, ".nax", "features", "other-feature");
+    mkdirSync(activeDir, { recursive: true });
+    mkdirSync(otherDir, { recursive: true });
+    writeFileSync(join(activeDir, "prd.json"), makePrd(["US-999"]));
+    writeFileSync(join(otherDir, "prd.json"), makePrd(["US-001"]));
+
+    const story = makeStory("US-001");
+    const result = await resolveFeatureId(story, tempDir, "active-feature");
+    expect(result).toBe("other-feature");
+  });
+
+  test("falls back to index scan when activeFeature PRD does not exist", async () => {
+    const otherDir = join(tempDir, ".nax", "features", "other-feature");
+    mkdirSync(otherDir, { recursive: true });
+    writeFileSync(join(otherDir, "prd.json"), makePrd(["US-001"]));
+
+    const story = makeStory("US-001");
+    const result = await resolveFeatureId(story, tempDir, "nonexistent-feature");
+    expect(result).toBe("other-feature");
+  });
+
   test("clearFeatureResolverCache clears all cached results", async () => {
     const featDir = join(tempDir, ".nax", "features", "some-feature");
     mkdirSync(featDir, { recursive: true });


### PR DESCRIPTION
## Summary

- `resolveFeatureId` built a global `storyId → featureId` index and kept the first glob (alphabetical) match on collision. In real projects each feature numbers stories from `US-001`, so `nax run -f memory-phase1-canonical-episodic` resolved `US-001` to `agents-management-page` (first alphabetical), read a non-existent `context.md`, and silently injected no feature context.
- Thread an optional `activeFeature` hint from `ContextRequest.featureId` through `FeatureContextProviderV2` → `V1.getContext` → `resolveFeatureId`. When the hint's prd.json contains the story, return it directly without scanning. Falls back to the index scan on hint miss.

Fixes #663

## Test plan

- [x] New test: `prefers activeFeature hint over first alphabetical match when story ID collides`
- [x] New test: `activeFeature hint skips the global index scan`
- [x] New test: `falls back to index scan when activeFeature does not contain the story`
- [x] New test: `falls back to index scan when activeFeature PRD does not exist`
- [x] Existing tests in `feature-resolver.test.ts`, `feature-context.test.ts`, and v2 provider tests still pass
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [ ] Manual verification against the koda project reproducer where `memory-phase1-canonical-episodic/context.md` now injects