### PR TITLE
fix(tdd): BUG-TC-002 — full-suite gate path mismatch always suppresses regressions + Jest parser fixes

### DIFF
--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -41,7 +41,7 @@ export const _rectificationGateDeps = {
  */
 async function getStoryChangedFiles(workdir: string, fromRef: string): Promise<ReadonlySet<string>> {
   const result = await _rectificationGateDeps.executeWithTimeout(
-    `git diff --name-only ${fromRef} HEAD`,
+    `git diff --name-only --relative ${fromRef} HEAD`,
     15,
     undefined,
     { cwd: workdir },
@@ -119,10 +119,12 @@ export async function runFullSuiteGate(
       const wasFiltered = filteredFailures.length < testSummary.failures.length;
 
       if (wasFiltered && filteredFailures.length === 0) {
+        const uniqueSuppressedFiles = [...new Set(testSummary.failures.map((f) => f.file))];
         logger.info("tdd", "Full suite gate: all failures are pre-existing — accepting as pass", {
           storyId: story.id,
-          suppressedCount: testSummary.failures.length,
-          suppressedFiles: testSummary.failures.map((f) => f.file),
+          suppressedFileCount: uniqueSuppressedFiles.length,
+          suppressedTestCount: testSummary.failures.length,
+          suppressedFiles: uniqueSuppressedFiles,
         });
         return { passed: true, cost: 0 };
       }

--- a/src/test-runners/parser.ts
+++ b/src/test-runners/parser.ts
@@ -209,7 +209,18 @@ function parseJestOutput(output: string): TestSummary {
     }
   }
 
-  return { passed, failed, failures };
+  // Jest output repeats FAIL <file> headers in multiple sections (run-summary and
+  // per-file detail), sometimes with different path forms (e.g. "src/foo.spec.ts"
+  // vs "foo.spec.ts"). Deduplicate by testName to prevent inflated failure counts.
+  const seen = new Set<string>();
+  const dedupedFailures = failures.filter((f) => {
+    const key = f.testName;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  return { passed, failed, failures: dedupedFailures };
 }
 
 /**


### PR DESCRIPTION
Closes #665

## Summary

- **Bug 1 (critical):** `--relative` flag added to `git diff` in `getStoryChangedFiles` — git was returning repo-root-relative paths that never matched workdir-relative paths from the test parser, causing the gate to always return `passed:true` and miss story regressions
- **Bug 2 (medium):** Deduplicate `FailureRecord` entries in `parseJestOutput` by `testName` — Jest output repeats `FAIL <file>` headers with different path forms in multiple sections, inflating failure counts 2x
- **Bug 3 (low):** Split `suppressedCount` into `suppressedFileCount` (unique files) and `suppressedTestCount` (test cases) for accurate logging

## Changes

| File | Change |
|------|--------|
| `src/tdd/rectification-gate.ts` | Add `--relative` to `git diff` command; split `suppressedCount` into file/test counts |
| `src/test-runners/parser.ts` | Deduplicate failures by `testName` in `parseJestOutput` |

## Test plan

- [ ] Typecheck passes (`bun run typecheck`) ✅
- [ ] `test/unit/tdd/rectification-gate-session.test.ts` passes ✅
- [ ] `test/unit/utils/test-output-parser.test.ts` passes ✅
- [ ] `test/unit/test-runners/` all 115 tests pass ✅
- [ ] Verify on a monorepo run: pre-existing failures in untouched files are suppressed, but failures in story-touched files still trigger rectification