### PR TITLE
chore: release v0.63.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.63.0-canary.14",
+  "version": "0.63.0",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Promote canary v0.63.0-canary.14 to stable v0.63.0.

## Why

All canary.11→canary.14 changes are stable and tested. Release notes auto-generated from merged commits.

Closes #

## How

- Version bump: `package.json` 0.63.0-canary.14 → 0.63.0
- Tag: `v0.63.0`
- Release: GitHub Releases page

## Testing

- [ ] `bun test` passes on main
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes

## Notes

- Install: `npm install -g @nathapp/nax@latest`
- Post-release: run lobster pipeline to update Mac mini
