### PR TITLE
feat: add opencode agent profile

### DIFF
--- a/src/context/engine/agent-profiles.ts
+++ b/src/context/engine/agent-profiles.ts
@@ -130,6 +130,17 @@ export const AGENT_PROFILES: Record<string, AgentProfile> = {
       toolSchemaDialect: "openai",
     },
   },
+  opencode: {
+    caps: {
+      maxContextTokens: 128_000,
+      preferredPromptTokens: 12_000,
+      supportsToolCalls: true,
+      supportsSystemPrompt: true,
+      supportsMarkdown: true,
+      systemPromptStyle: "markdown-sections",
+      toolSchemaDialect: "openai",
+    },
+  },
   local: {
     caps: {
       maxContextTokens: 32_000,


### PR DESCRIPTION
## Summary
- Register `opencode` as a model-agnostic agent shell in the Context Engine v2
- Configures 128k context window, OpenAI tool schema, and markdown rendering
- Resolves "Unknown agent id" warning when opencode is used as the default agent

## Details
opencode is a model-agnostic shell that can front any underlying LLM. Without a registered profile, the context engine was falling back to CONSERVATIVE_DEFAULT_PROFILE (8k token budget, no tool calls), which underutilized opencode's actual capabilities.

The 128k context window matches other mid-tier agent adapters like Cursor and Codex, making it a safe conservative choice that works across most modern models.

## Test plan
- [x] Pre-commit lint and typecheck pass
- Verify `agentId: "opencode"` no longer triggers "Unknown agent id" warning in logs