### PR TITLE
Docs/adr 014 016 docs

### DIFF
--- a/docs/adr/ADR-014-runscope-and-middleware.md
+++ b/docs/adr/ADR-014-runscope-and-middleware.md
@@ -1,6 +1,6 @@
 # ADR-014: RunScope, Agent Middleware, and Orphan Consolidation
 
-**Status:** Proposed
+**Status:** Reject
 **Date:** 2026-04-23
 **Author:** William Khoo, Claude
 **Extends:** ADR-013 (SessionManager → AgentManager Hierarchy); ADR-012 (AgentManager Ownership); ADR-011 (SessionManager Ownership)

--- a/docs/adr/ADR-014-runscope-and-middleware.md
+++ b/docs/adr/ADR-014-runscope-and-middleware.md
@@ -132,9 +132,346 @@ Every `createAgentManager(config)` call outside this factory becomes a compile e
 
 ---
 
-### 2. Agent middleware chain
+### 2. Permission resolution and agent middleware
 
-Wraps every `IAgent` returned by `scope.getAgent()` and every agent used inside a `sessionManager.runInSession()`. Intercepts `run()` and `complete()`.
+Permissions flow through **three** layers today: a stage-driven **resolver** produces canonical policy; a per-transport **transport translator** renders canonical into the transport's wire format; the **adapter** applies the wire format. `scope.invoke()` owns the resolver call; the adapter owns its transport translator (which lives inside the adapter's folder). The middleware chain is purely observational — permission resolution happens pre-chain.
+
+An **agent-level translator layer** is intentionally **not** introduced in Phase 2. Today the only transport is ACP, and acpx passes tool-allowlist entries through to each hosted agent unchanged — per-agent tool-name translation (e.g. `"Read"` → `"read_file"` for a hypothetical non-Claude agent) is not something nax needs to own. If a future agent genuinely requires vocabulary adjustment nax must apply, the agent translator slots **between** canonical and transport as Layer 2′ with zero call-site churn: transport translators would then consume the agent-native policy instead of canonical directly.
+
+#### 2.1 Three-layer model
+
+```
+Config + stage (declarative — op.requires.permissions)
+       │
+       ▼ Layer 1 — RESOLVER (adapter-agnostic, agent-agnostic, transport-agnostic)
+       │   src/config/permissions.ts :: resolvePermissions()
+       │
+ResolvedPermissions (canonical — StandardTool vocabulary)
+       │
+       ▼ Layer 2 — TRANSPORT TRANSLATOR (transport-specific)
+       │   src/agents/acp/permissions.ts :: toAcpWire()
+       │   wrapped as `acpTranslator: IPermissionTranslator<AcpWirePolicy>`
+       │   registered in scope.services.translatorRegistry keyed by "acp"
+       │   adapter resolves via registry (middleman) — does not import directly
+       │
+AcpWirePolicy (ACP wire format — { permissionMode, allowedToolsArg })
+       │
+       ▼ Layer 3 — ADAPTER APPLICATION (transport I/O)
+       │   src/agents/acp/adapter.ts
+       │
+createSession({ permissionMode, … }) + acpxArgs.push("--allowed-tools", …)
+```
+
+Responsibilities:
+
+| Layer | Knows about | Does not know about |
+|:---|:---|:---|
+| Resolver | Config schema, pipeline stages | Transports, wire formats, agents |
+| Transport translator | Canonical policy, this transport's wire format | Pipeline stages, config schema |
+| Adapter | Wire format of its transport, session/process plumbing | Policy semantics, wire-token decisions |
+
+**Why no agent translator today:** ACP is the only transport, and acpx is agent-agnostic at the permission level — it forwards `permissionMode` and `--allowed-tools` entries without rewriting them. Every agent that runs under acpx consumes the same tokens. An agent translator would be a pass-through today, shipping ceremony for no benefit. When/if a future agent requires nax-side vocabulary adjustment, Layer 2′ slots in cleanly; transport translators re-target from consuming canonical to consuming agent-native. YAGNI applied to the "we might need it" speculation.
+
+**Future Layer 2′ (agent translator) — for reference, not Phase 2:**
+
+```
+                                 (future, only when a real agent demands it)
+ResolvedPermissions ─► Layer 2′ AGENT TRANSLATOR ─► AgentPermissionPolicy ─► Layer 2 TRANSPORT TRANSLATOR ─► Wire
+                       src/runtime/permissions/
+                       translators/<agent>.ts
+                       resolved via IPermissionTranslatorRegistry
+```
+
+At that point, `AgentPermissionPolicy` would mirror canonical's shape (profile, allowedTools with agent-native tool names, warnings for agent-capability downgrades). The transport translator's input type changes from `ResolvedPermissions` to `AgentPermissionPolicy`; the transport signature is otherwise stable.
+
+#### 2.2 Canonical `ResolvedPermissions`
+
+`src/config/permissions.ts` is amended. The existing type is replaced to remove adapter-specific fields.
+
+```typescript
+// src/config/permissions.ts
+export interface ResolvedPermissions {
+  readonly profile: PermissionProfile;
+  /** Scoped-profile patterns; undefined when profile ≠ "scoped". */
+  readonly allowedTools?: readonly ToolAllowPattern[];
+}
+
+/**
+ * Permission profile — single source of truth for auto-approve behavior.
+ *
+ *   "unrestricted" — blanket auto-approve; no user prompts for any action.
+ *   "auto"         — agent decides via its own policy/judgment (newer Claude Code
+ *                    ships a built-in auto-approve mode narrower than "unrestricted"
+ *                    but broader than "safe"). Transport translator emits the
+ *                    agent's native auto token.
+ *   "safe"         — auto-approve read-only operations; prompt on writes / shell / network.
+ *                    This is the default.
+ *   "none"         — prompt for every action.
+ *   "scoped"       — per-tool allowlist from `allowedTools`; actions matching the
+ *                    allowlist are auto-approved, everything else prompts.
+ *
+ * Permissiveness ordering (for static profiles): unrestricted > auto > safe > none.
+ * "scoped" is orthogonal — permissiveness depends on the allowlist.
+ */
+export type PermissionProfile =
+  | "unrestricted"
+  | "auto"
+  | "safe"
+  | "none"
+  | "scoped";
+
+export interface ToolAllowPattern {
+  readonly tool: StandardTool;
+  readonly paths?: readonly string[];     // globs for Read/Write/Edit
+  readonly commands?: readonly string[];  // globs for Bash
+}
+
+export type StandardTool =
+  | "Read"
+  | "Write"
+  | "Edit"
+  | "Bash"
+  | "Network"
+  | "Notebook";
+```
+
+**Dropped from the current type:**
+
+- `mode: "approve-all" | "approve-reads" | "default"` — ACP-specific vocabulary; moves inside the ACP adapter's folder (§2.5).
+- `skipPermissions: boolean` — dead (was the removed CLI adapter's `--dangerously-skip-permissions` flag).
+
+**Unchanged:** `resolvePermissions(config, stage): ResolvedPermissions` remains the single entry point. Phase 2 implementation of `resolveScopedPermissions()` populates `allowedTools`; until then it returns `undefined` and #374 delivers the stage-by-stage body.
+
+#### 2.3 `scope.invoke()` pre-chain resolution
+
+Resolution happens once, before the middleware chain fires, at the top of `scope.invoke()`:
+
+```typescript
+// src/runtime/scope.ts — scope.invoke() internal flow
+async invoke<I, O, C>(op, input, opts) {
+  // ... validate, resolve agent name, slice config ...
+
+  // Canonical policy — agent-agnostic, transport-agnostic.
+  const canonical = resolvePermissions(packageView.config, op.requires.permissions);
+
+  // Thread into agent-call options. Adapter consumes it via its transport translator;
+  // middleware observes it for audit/logging.
+  const agentCallOptions = {
+    ...baseOptions,
+    permissions: canonical,
+  };
+
+  // ... build OperationContext, invoke middleware-wrapped agent with agentCallOptions ...
+}
+```
+
+Neither the adapter nor any middleware calls `resolvePermissions()` at runtime. Single resolution per agent call. The adapter's transport translator (§2.5) consumes `canonical` and produces wire format.
+
+#### 2.4 `AgentRunOptions.permissions` and `.scope` shape
+
+```typescript
+// src/agents/types.ts — AgentRunOptions amended
+export interface AgentRunOptions {
+  // ... existing fields ...
+
+  readonly permissions: ResolvedPermissions;  // canonical; adapter calls its transport translator on this
+  readonly scope: RunScope;                   // scope reference — gives adapter access to services.translatorRegistry
+
+  // REMOVED:
+  // dangerouslySkipPermissions?: boolean;   (dead — CLI adapter removed)
+  // pipelineStage?: PipelineStage;          (no longer needed — pre-resolution handles it)
+}
+```
+
+`CompleteOptions` gets both `permissions` and `scope` fields on the same terms. `config` stays on both (still needed by audit/cost middleware, but **not** for permission derivation anywhere).
+
+The options carry the canonical `ResolvedPermissions` directly. When Layer 2′ (agent translator) is added later, this widens to a union or nested shape — the change is local to `scope.invoke()` and the transport translator signature.
+
+**Why thread `scope` through options** rather than have the adapter reach for a global: adapter calls happen inside middleware-wrapped paths; the wrapping middleware is the only thing that knows the active scope for this call. Threading via options keeps the adapter a pure function of its inputs — no singletons, no async-local storage — which matches the observer-only middleware invariant (§2.8) and keeps tests isolated (each `makeTestScope()` instance is self-contained).
+
+#### 2.5 ACP transport translator
+
+The ACP wire format lives **inside the ACP adapter folder**. No module outside `src/agents/acp/` treats ACP wire types as first-class — they surface only at the generic parameter of the registry's `get<AcpWirePolicy>()` call at the adapter boundary (§2.7). A pure function `toAcpWire()` bridges canonical `ResolvedPermissions` to the ACP wire tokens that `createSession()` and acpx expect.
+
+```typescript
+// src/agents/acp/permissions.ts (NEW — inside the adapter's folder)
+import type { ResolvedPermissions, ToolAllowPattern } from "../../config/permissions";
+
+// ACP wire tokens — exclusively scoped to this module
+export type AcpPermissionMode =
+  | "approve-all"
+  | "approve-auto"
+  | "approve-reads"
+  | "default";
+
+export interface AcpWirePolicy {
+  readonly permissionMode: AcpPermissionMode;
+  readonly allowedToolsArg?: readonly string[];   // pre-formatted strings for acpx --allowed-tools
+  /**
+   * Reserved for #374 (scoped tool allowlists) and for future transport-capability validation.
+   * Phase 2 leaves this undefined — `toAcpWire()` does not emit warnings today because every
+   * canonical profile maps cleanly to an ACP mode. Populated when validation in #374 encounters
+   * an allowlist pattern the wire cannot express.
+   */
+  readonly warnings?: readonly string[];
+}
+
+export function toAcpWire(resolved: ResolvedPermissions): AcpWirePolicy {
+  // Map canonical profile → ACP permissionMode.
+  // "scoped" uses "approve-reads" as the ceiling; the allowlist (below) carries the
+  // per-tool grants that acpx forwards to the underlying agent.
+  const permissionMode: AcpPermissionMode =
+    resolved.profile === "unrestricted" ? "approve-all"   :
+    resolved.profile === "auto"         ? "approve-auto"  :
+    resolved.profile === "safe"         ? "approve-reads" :
+    resolved.profile === "scoped"       ? "approve-reads" :
+                                          "default"; // "none"
+
+  const allowedToolsArg = resolved.allowedTools?.map(formatAsAcpAllowlistEntry);
+
+  return { permissionMode, allowedToolsArg };
+}
+
+function formatAsAcpAllowlistEntry(p: ToolAllowPattern): string {
+  // acpx passes the allowlist string through to the underlying agent, which enforces it.
+  // Tool names are in StandardTool vocabulary; acpx handles agent-specific name mapping today.
+  // Format: "Tool" or "Tool(glob1,glob2,...)"
+  if (p.paths && p.paths.length > 0)       return `${p.tool}(${p.paths.join(",")})`;
+  if (p.commands && p.commands.length > 0) return `${p.tool}(${p.commands.join(",")})`;
+  return p.tool;
+}
+```
+
+**What this buys us:**
+
+- ACP wire vocabulary (`approve-all`, `approve-reads`, etc.) never appears outside `src/agents/acp/`.
+- A future direct-API transport would live in `src/agents/<transport>/permissions.ts` with its own `toXxxWire()` function. Canonical stays stable.
+- `toAcpWire()` is a pure function — unit-testable without spawning a process. All ACP mode decisions live in one ~25-line function.
+- When Layer 2′ (agent translator) is added later, `toAcpWire()` re-targets from `ResolvedPermissions` to `AgentPermissionPolicy` — a one-line signature change inside this file.
+
+#### 2.6 Translator registry — middleman pattern
+
+The adapter does **not** import `toAcpWire` directly. Instead a `IPermissionTranslator` interface wraps the wire function, the registry holds it, and the adapter resolves through the registry. The registry is a scope-level service.
+
+**Why a registry when only one transport exists today:**
+
+- **Test injection.** Tests can supply a fake translator without stubbing the adapter or monkey-patching `toAcpWire`.
+- **Plugin extension seam.** Plugin API v2 (future ADR) can register additional translators or override the default without touching the ACP adapter's code.
+- **Extension for future transports.** Direct-API Claude, HTTP bridges, or any other transport add a new registry entry; the adapter wiring pattern stays identical.
+- **Keeps the adapter ignorant of *how* the translation is resolved.** Adapter calls `registry.get("acp")`; what that returns is the registry's concern.
+
+One entry today. Not speculative per-agent stubs — a deliberate middleman so the shape is stable when the second entry arrives.
+
+```typescript
+// src/runtime/permissions/translator.ts
+export interface IPermissionTranslator<W = unknown> {
+  readonly transport: string;                          // "acp" today; future: "claude-api" | ...
+  translate(resolved: ResolvedPermissions): W;         // W is the transport's wire type
+}
+
+export interface IPermissionTranslatorRegistry {
+  /** Returns the translator for a transport; throws NaxError PERMISSION_TRANSLATOR_MISSING on miss. */
+  get<W = unknown>(transport: string): IPermissionTranslator<W>;
+  /** Returns the translator or null — for composite chaining. */
+  tryGet<W = unknown>(transport: string): IPermissionTranslator<W> | null;
+}
+
+// src/runtime/permissions/registries/static.ts — Phase 2 default
+export class StaticTranslatorRegistry implements IPermissionTranslatorRegistry {
+  constructor(private readonly map: ReadonlyMap<string, IPermissionTranslator<unknown>>) {}
+  tryGet<W>(transport: string) {
+    // Runtime cast — the generic parameter is asserted by the caller. See "Generic type erasure"
+    // commentary in §2.7: the registry stores IPermissionTranslator<unknown>; the caller at the
+    // adapter boundary specifies the concrete wire type (e.g. AcpWirePolicy) in the type argument.
+    return (this.map.get(transport) ?? null) as IPermissionTranslator<W> | null;
+  }
+  get<W>(transport: string) {
+    const t = this.tryGet<W>(transport);
+    if (t) return t;
+    throw new NaxError(
+      `No permission translator registered for transport "${transport}"`,
+      "PERMISSION_TRANSLATOR_MISSING",
+      { transport },
+    );
+  }
+}
+```
+
+**Each transport contributes its translator** inside its own folder:
+
+```typescript
+// src/agents/acp/permissions.ts — appended to existing file
+import type { IPermissionTranslator } from "../../runtime/permissions/translator";
+
+export const acpTranslator: IPermissionTranslator<AcpWirePolicy> = {
+  transport: "acp",
+  translate: toAcpWire,     // the pure function defined above
+};
+```
+
+**Scope construction registers the Phase 2 set:**
+
+```typescript
+// src/runtime/scope-factory.ts — inside forRun()
+import { acpTranslator } from "../agents/acp/permissions";
+
+const translatorRegistry: IPermissionTranslatorRegistry = new StaticTranslatorRegistry(
+  new Map<string, IPermissionTranslator<unknown>>([
+    ["acp", acpTranslator],
+  ])
+);
+
+const scope: RunScope = {
+  // ...
+  services: {
+    costAggregator,
+    promptAuditor,
+    permissionResolver: resolvePermissions,
+    translatorRegistry,                     // NEW
+    logger,
+  },
+  // ...
+};
+```
+
+**Future variants** (deferred to plugin API v2 ADR, same pattern):
+
+- `AgentDescriptorTranslatorRegistry` — reads translators from `AgentDescriptor` entries when plugins contribute agents with custom transports.
+- `CompositeTranslatorRegistry` — chains multiple registries (plugins first, then built-ins).
+
+All three implementations satisfy the same `IPermissionTranslatorRegistry` interface. Adapter code is unaware which registry type backs it.
+
+#### 2.7 ACP adapter application
+
+The adapter resolves the translator from the registry and applies its output. Zero permission-semantics logic, zero direct translator imports.
+
+```typescript
+// src/agents/acp/adapter.ts — inside run()
+// No import of toAcpWire. Registry is the only seam.
+
+const translator = options.scope.services.translatorRegistry.get<AcpWirePolicy>("acp");
+const wire = translator.translate(options.permissions);
+
+const session = await client.createSession({
+  agentName: options.agentName,
+  permissionMode: wire.permissionMode,
+  sessionName,
+});
+if (wire.allowedToolsArg) {
+  acpxArgs.push("--allowed-tools", wire.allowedToolsArg.join(","));
+}
+if (wire.warnings) {
+  for (const w of wire.warnings) {
+    getSafeLogger()?.warn("acp-adapter", w, { agentName: options.agentName });
+  }
+}
+```
+
+Existing ACP adapter sites that call `resolvePermissions()` — [adapter.ts:593](../../src/agents/acp/adapter.ts#L593), [adapter.ts:847](../../src/agents/acp/adapter.ts#L847), [adapter.ts:1036](../../src/agents/acp/adapter.ts#L1036) — all delete. They become the ~8 lines above.
+
+#### 2.8 Agent middleware chain — observers only
+
+After pre-chain resolution, the middleware chain is pure observation. No middleware reads or derives permissions; `options.permissions` is present for audit/logging inspection only.
 
 ```typescript
 // src/runtime/agent-middleware.ts
@@ -146,7 +483,7 @@ export interface AgentMiddleware {
 
 export interface MiddlewareContext {
   readonly prompt: string;
-  readonly options: RunOptions | CompleteOptions;
+  readonly options: AgentRunOptions | CompleteOptions;  // includes .permissions (canonical) and .scope
   readonly agentName: string;
   readonly scope: RunScope;
   readonly stage?: PipelineStage;
@@ -160,18 +497,19 @@ export interface MiddlewareContext {
 
 | Middleware | Concern | Semantics |
 |:---|:---|:---|
-| `permissions` | Resolve permission mode from stage + config, apply to options | **Observer** — reads stage, enriches options; does not mutate prompt |
-| `audit` | Capture prompt + response via `IPromptAuditor` | Observer — emits `PromptAuditEntry` on success and on error |
-| `cost` | Emit `CostEvent` to `ICostAggregator` tagged with `{ agentName, stage, storyId, packageDir }` | Observer — emits on success only; partial/errored calls emit a separate `CostErrorEvent` |
-| `cancellation` | Thread `signal` into adapter call; translate `AbortError` to `NaxError CANCELLED` | Pass-through with error translation |
-| `logging` | Structured JSONL per `project-conventions.md`, `storyId` first | Observer |
+| `audit` | Capture prompt + response via `IPromptAuditor`; record `options.permissions.profile` | Observer — emits `PromptAuditEntry` on success, `PromptAuditErrorEntry` on error |
+| `cost` | Emit `CostEvent` to `ICostAggregator`, tagged with `{ agentName, stage, storyId, packageDir }` | Observer — `CostEvent` on success, `CostErrorEvent` on error |
+| `cancellation` | Thread `signal` into adapter call; translate `AbortError` to `NaxError CANCELLED` | Pass-through with error translation; does not observe prompt/response |
+| `logging` | Structured JSONL per `project-conventions.md`, `storyId` first, includes canonical `profile` | Observer |
+
+Note: no `permissions` entry — permission resolution is pre-chain (§2.3), not a middleware concern.
 
 **Middleware invariants:**
 
-- **Middleware are observers, not transformers** (Phase 1 constraint). No middleware mutates the prompt or response for the next middleware in the chain. This keeps ordering irrelevant in Phase 1 — middleware can be registered in any order and produce equivalent behavior.
-- **On error:** every middleware must be resilient to the call throwing. `audit` emits an error entry, `cost` emits a `CostErrorEvent`, `cancellation` translates the error. No middleware may swallow the thrown error.
+- **Middleware are observers, not transformers** (Phase 1 constraint). No middleware mutates the prompt, response, or options for the next middleware in the chain. Order-independence is preserved.
+- **On error:** every middleware is resilient to the call throwing. `audit` emits an error entry, `cost` emits a `CostErrorEvent`, `cancellation` translates the error. No middleware may swallow the thrown error.
 - **Frozen at scope construction.** The chain is registered once in `IRunScopeFactory.forRun()` and immutable for the scope lifetime. No per-call reordering, no per-op opt-out.
-- **Future extension:** if a later middleware needs to transform (e.g. inject system prompt, rewrite options), the invariant tightens to a declared order. Deferred until a concrete case exists.
+- **Future extension:** if a later middleware needs to transform (e.g. inject system prompt, rewrite options), the invariant tightens to a declared order at that point, with the concrete case as justification. The `permissions` case is handled pre-chain and does not justify loosening this invariant.
 
 ---
 
@@ -318,13 +656,24 @@ RunScope (per run / plan / ephemeral)
   ├─ services:
   │    ├─ costAggregator                         // NEW
   │    ├─ promptAuditor                          // NEW
-  │    ├─ permissionResolver
+  │    ├─ permissionResolver: resolvePermissions
+  │    ├─ translatorRegistry                     // NEW — IPermissionTranslatorRegistry
   │    └─ logger
   ├─ getAgent(name) → IAgent                     // middleware-wrapped
+  ├─ invoke<I,O,C>(op, input, opts) → O          // pre-chain resolves permissions, §2.3
   └─ close() → Promise<void>
 
-Agent middleware chain (observers only, order-independent)
-  permissions / audit / cost / cancellation / logging → rawAgent
+Permission flow (pre-chain, §2.1–§2.7)
+  scope.invoke() → resolvePermissions() → options.permissions (canonical)
+                                            │
+                                            ▼ adapter reads via registry
+  options.scope.services.translatorRegistry.get<AcpWirePolicy>("acp")
+                                            │
+                                            ▼ translate
+  toAcpWire(canonical) → AcpWirePolicy → createSession + acpx args
+
+Agent middleware chain (observers only, order-independent, no permissions entry)
+  audit / cost / cancellation / logging → rawAgent
 
 IAgent (ADR-013, unchanged)
   ├─ run(prompt, opts): Promise<AgentResult>
@@ -379,10 +728,25 @@ Three phases, each independently shippable. Each phase preserves all ADR-011/012
   3. Runner constructs and closes scope cleanly; `close()` idempotency verified by test.
 - **Risk:** Low. Purely additive. The one behavior change (SessionManager's `getAgent` callback) is constructor-level and invisible to call sites.
 
-### Phase 2 — Agent middleware chain + orphan consolidation
+### Phase 2 — Permission resolution, middleware chain, orphan consolidation
 
-- Implement `AgentMiddleware` interface and canonical middleware (permissions, audit, cost, cancellation, logging) as independent observers.
+**Permission resolution (§2.1–§2.7):**
+
+- Amend `src/config/permissions.ts` — canonical `ResolvedPermissions` as `{ profile, allowedTools? }`. `PermissionProfile` widens to `"unrestricted" | "auto" | "safe" | "none" | "scoped"`. Drops legacy `mode` and `skipPermissions`.
+- Add `AgentRunOptions.permissions: ResolvedPermissions` and `AgentRunOptions.scope: RunScope`; same on `CompleteOptions`.
+- Implement `scope.invoke()` pre-chain resolution — calls `resolvePermissions()` once, stuffs `options.permissions`.
+- Add `src/agents/acp/permissions.ts` — `AcpPermissionMode`, `AcpWirePolicy`, `toAcpWire()`, `acpTranslator`. ACP wire vocabulary scoped to this module.
+- Add `src/runtime/permissions/translator.ts` (interfaces) and `src/runtime/permissions/registries/static.ts` (`StaticTranslatorRegistry`).
+- Wire `scope.services.translatorRegistry` in `IRunScopeFactory.forRun()` with single entry `"acp" → acpTranslator`.
+- Shrink ACP adapter permission handling to registry-resolved translator call. Delete `resolvePermissions()` calls at [adapter.ts:593](../../src/agents/acp/adapter.ts#L593), [adapter.ts:847](../../src/agents/acp/adapter.ts#L847), [adapter.ts:1036](../../src/agents/acp/adapter.ts#L1036).
+
+**Middleware chain (§2.8):**
+
+- Implement `AgentMiddleware` interface and canonical middleware (audit, cost, cancellation, logging) as independent observers. **No `permissions` middleware** — it was pre-chain work above.
 - `scope.getAgent()` returns middleware-wrapped agent.
+
+**Orphan consolidation:**
+
 - Migrate orphan call sites in order of lowest blast radius:
   1. `routing/router.ts` — use `scope.getAgent(defaultAgent).complete()`
   2. `acceptance/refinement.ts`, `acceptance/generator.ts`
@@ -391,8 +755,14 @@ Three phases, each independently shippable. Each phase preserves all ADR-011/012
   5. `review/semantic.ts`
   6. `cli/plan.ts` — uses `forPlan()` factory
 - **Delete `createAgentManager` from public barrel.** Move to `src/runtime/internal/`.
-- **Exit criteria:** Zero `createAgentManager` imports outside `src/runtime/`. #523 verifiable: a 401 on routing activates the same fallback chain as execution.
-- **Risk:** Medium. Mechanical migrations touch many files; each site's behavior change is small and individually reviewable.
+
+**Exit criteria:**
+
+- Zero `createAgentManager` imports outside `src/runtime/`. #523 verifiable: a 401 on routing activates the same fallback chain as execution.
+- Zero `resolvePermissions()` calls inside `src/agents/acp/adapter.ts`.
+- No ACP wire-token literals (`"approve-all"`, etc.) outside `src/agents/acp/`.
+
+**Risk:** Medium. Mechanical migrations touch many files; each site's behavior change is small and individually reviewable.
 
 ### Phase 3 — Drain aggregator and auditor into metrics/disk
 
@@ -422,7 +792,27 @@ Three phases, each independently shippable. Each phase preserves all ADR-011/012
 
 ### D. Middleware as transformers from day one
 
-**Rejected.** Transformers (middleware that can rewrite prompt/response for the next middleware) introduce load-bearing ordering semantics: permissions-then-audit captures the permission-mutated prompt; audit-then-permissions captures caller intent. Phase 1 ships observers only — all middleware read `MiddlewareContext` and emit side effects without affecting the chain. If a future middleware needs to transform, the invariant tightens to a declared order at that point, with the concrete case as justification.
+**Rejected.** Transformers (middleware that can rewrite prompt/response for the next middleware) introduce load-bearing ordering semantics. Phase 1 ships observers only — all middleware read `MiddlewareContext` and emit side effects without affecting the chain. If a future middleware needs to transform, the invariant tightens to a declared order at that point, with the concrete case as justification.
+
+### E. Permissions as middleware
+
+**Rejected.** Early drafts listed `permissions` as a middleware entry. The middleware interface (observer-only, `readonly ctx`, args-less `next()`) cannot actually rewrite agent-call options — so a `permissions` middleware would either have to mutate (breaking the observer invariant) or do nothing useful. Resolution happens **pre-chain** inside `scope.invoke()` (§2.3), stuffs `options.permissions` with canonical policy, and the observer chain runs unchanged. The `permissions` entry disappears from the middleware table (§2.8).
+
+### F. Adapter-side `resolvePermissions()` calls (current code path)
+
+**Rejected.** Today's ACP adapter calls `resolvePermissions()` three times inside `run()`/`complete()`/`plan()` — duplicative with caller-side resolution. Single resolution in `scope.invoke()` puts canonical on options so middleware + audit can observe policy decisions without re-resolving, and adapters become pure consumers of pre-resolved state.
+
+### G. Adapter imports `toAcpWire` directly (no registry)
+
+**Rejected.** Loses the test-injection seam and forces each future transport to replicate its own ad-hoc wiring. The `IPermissionTranslatorRegistry` middleman (§2.6) is minor ceremony now (one entry) and pays off the moment a second transport or a plugin override appears.
+
+### H. Per-agent translator layer in Phase 2
+
+**Rejected as speculative.** Early drafts proposed per-agent translators (`translateToClaude`, `translateToGemini`, etc.) under ACP. Today acpx passes allowlist entries through unchanged — an agent translator would be a pass-through for every entry. Layer 2′ (§2.1 future reference) slots in cleanly when a real agent demands vocabulary adjustment; shipping the layer now would add ceremony without benefit.
+
+### I. ACP wire tokens in shared runtime types
+
+**Rejected.** Early drafts exported `AcpPermissionMode` from `src/runtime/permissions/`. Wire tokens are transport-specific and belong inside the transport's folder. `AcpPermissionMode`, `AcpWirePolicy`, and `toAcpWire()` all live inside `src/agents/acp/`. The registry stores `IPermissionTranslator<unknown>`; the adapter asserts the concrete wire type via the generic parameter at the call site.
 
 ---
 

--- a/docs/adr/ADR-014-runscope-and-operation-standardization.md
+++ b/docs/adr/ADR-014-runscope-and-operation-standardization.md
@@ -1,6 +1,6 @@
 # ADR-014: RunScope Composition, Operation Standardization, and Prompt Middleware
 
-**Status:** Proposed
+**Status:** Reject
 **Date:** 2026-04-23
 **Author:** William Khoo, Claude
 **Extends:** ADR-013 (SessionManager → AgentManager Hierarchy); ADR-012 (AgentManager Ownership); ADR-011 (SessionManager Ownership); ADR-010 (Context Engine)

--- a/docs/adr/ADR-015-operation-contract.md
+++ b/docs/adr/ADR-015-operation-contract.md
@@ -64,6 +64,8 @@ export interface Operation<I, O, C = NaxConfig> {
 
 export interface OperationRequires<C> {
   readonly session: boolean;                 // if true, scope provides ISession in ctx
+  readonly sessionRole?: SessionRole;        // required iff session === true; default role (runner may override via InvokeOptions.sessionRole)
+  readonly sessionLifetime?: "fresh" | "warm"; // default "fresh"; "warm" = keepOpen:true per ADR-008 matrix
   readonly scope: "package" | "cross-package" | "repo";
   readonly permissions: PipelineStage;       // drives resolvePermissions()
   readonly config: ConfigSelector<C>;        // narrows NaxConfig → C
@@ -121,6 +123,9 @@ export interface InvokeOptions {
   readonly agentName?: string;              // override default agent (used by DebateSessionRunner)
   readonly signal?: AbortSignal;            // override scope-level signal
   readonly logger?: Logger;                 // override scope-level logger (used for per-proposer attribution)
+  readonly sessionRole?: SessionRole;       // override op's declared role (e.g. runner stamps "debate-hybrid" / "plan-i")
+  readonly discriminator?: string | number; // N-sibling disambiguator (debater index, proposal slot)
+  readonly sessionHandle?: string;          // full ACP wire handle override — matches existing AgentRunOptions.sessionHandle escape hatch
 }
 ```
 
@@ -131,7 +136,11 @@ What `scope.invoke()` does, per call:
 3. Slice config: `ctx.config = resolveSlice(op.requires.config, scope.config)`.
    > **Forward-reference:** after ADR-016 introduces `PackageView`, slicing is applied to `ctx.package.config` (per-package-merged) instead of `scope.config` (root). Behavior is identical for single-package repos; polyglot monorepos gain per-package override support automatically.
 4. Resolve permissions: `resolvePermissions(ctx.config, op.requires.permissions)` and set on the `IAgent` options for downstream calls.
-5. If `op.requires.session`, create/reuse session via `scope.sessionManager`; otherwise `ctx.session = undefined`.
+5. If `op.requires.session`, thread session identity onto `AgentRunOptions` via `{ featureName, storyId, sessionRole: opts.sessionRole ?? op.sessionRole, discriminator: opts.discriminator, keepOpen: op.requires.sessionLifetime === "warm" }`. `scope.invoke()` does **not** mint sessionIds — the two-level ID model is preserved intact:
+   - **SessionManager owns `descriptor.id` = `sess-<uuid>`** — the nax-internal state machine key. Minted by SessionManager, opaque to callers; used as the first argument to `runInSession()` (ADR-013).
+   - **Adapter owns `descriptor.handle` = `nax-<hash8>-<feature>-<storyId>-<role>[-<discriminator>]`** — the ACP wire name, derived by `computeAcpHandle()` in [src/agents/acp/adapter.ts:175-193](src/agents/acp/adapter.ts#L175-L193) from the `AgentRunOptions` fields above. Deterministic: same role + storyId + feature + workdir → same handle → adapter's `loadSession` resumes automatically. This is how rectification's "reuse the implementer session" already works today ([src/verification/rectification-loop.ts:167](src/verification/rectification-loop.ts#L167)) and it survives unchanged.
+
+   Ephemerality for reviewer "fresh-per-round" (ADR-008) is expressed via `keepOpen: false` on the relevant call, not via a separate flag — closing the session makes the next deterministic-handle derivation hit a fresh ACP session. If `op.requires.session` is false, `ctx.session = undefined`.
 6. Build pre-scoped logger: `opts.logger ?? scope.services.logger.child({ storyId, packageDir, op: op.name })`.
 7. Thread `opts.signal ?? scope.signal` through as `ctx.signal`.
 8. Call `op.execute(ctx, input)`.
@@ -159,7 +168,7 @@ Compose via a thin composite operation that calls `scope.invoke()` on its parts.
 | `review/` semantic + adversarial | `semanticReview`, `adversarialReview`, `review` (composite, optional) | N/A (session-less) |
 | `tdd/` writer + implementer + verifier | `writeTest`, `implement`, `verify` | `ThreeSessionRunner` invokes each in its session |
 | `acceptance/` generate + refine + diagnose + fix | `generateAcceptance`, `refineAcceptance`, `diagnoseAcceptance`, `fixAcceptance` | `fixAcceptance` may use `SingleSessionRunner` |
-| `debate/` one-shot + stateful + plan | `debateProposer`, `debateResolve` (+ synthesis/judge variants) | `DebateSessionRunner` orchestrates proposers + resolver |
+| `debate/` one-shot + stateful + hybrid | `proposeCandidate`, `rebutCandidate`, `reviewDialogue`, `rankCandidates` | `DebateSessionRunner` (three internal modes) — used by both plan and review stages |
 | `routing/` keyword + LLM + plugin-chain | One `classifyRoute` op; strategies are internal | N/A |
 | `verification/` rectification-loop | `rectify` is an operation (one attempt); the loop is **control-flow** | N/A |
 | Adapter `.plan()` | `plan` operation | N/A (wraps `agent.run()` internally) |
@@ -200,7 +209,9 @@ Three properties this preserves:
 
 ### 2. `ISessionRunner` implementations
 
-Topology unit from ADR-013. Implementations invoke operations via `scope.invoke()`; they do not invoke `IAgent` directly.
+`ISessionRunner` is the abstraction for **session topologies** — how many sessions a logical unit of work opens, how they are sequenced, when they stay warm, when they close. It is not TDD-specific, and `SingleSessionRunner` is not the canonical form. Each concrete runner captures a distinct topology that may be reused across stages.
+
+Runners invoke operations via `scope.invoke()`; they do not invoke `IAgent` directly. **Topology is the runner's concern; content is the op's.** The same op composes into different runners when the topology differs; the same runner orchestrates different ops when the stage differs (e.g. `DebateSessionRunner` orchestrates plan-specific ops in the plan stage and review-specific ops in the review stage).
 
 ```typescript
 // src/sessions/runners/types.ts (ADR-013, re-referenced)
@@ -250,39 +261,93 @@ export class ThreeSessionRunner implements ISessionRunner<TddInput, TddResult> {
 
 #### 2.3 `DebateSessionRunner`
 
-N proposer sessions in parallel + 1 resolver session. Per-proposer isolation via `InvokeOptions.agentName`, `signal`, `logger` overrides — no `RunScope` fork.
+The third topology: N debater sessions (± a reviewer-dialogue session) across M rounds. Used by **both the plan stage and the review stage** — same runner, different ops plugged in.
+
+Reflects three internal modes already present in today's [src/debate/session.ts:24-174](src/debate/session.ts#L24-L174). The runner absorbs the mode dispatch:
+
+| Mode | Topology | Current file | Used by |
+|:---|:---|:---|:---|
+| `one-shot` | N × `complete()`, no sessions | [src/debate/session-one-shot.ts](src/debate/session-one-shot.ts) | panel review with `sessionMode: "one-shot"` |
+| `stateful` | N debater sessions, kept warm across proposal → critique rounds | [src/debate/session-stateful.ts](src/debate/session-stateful.ts) | panel review with `sessionMode: "stateful"` |
+| `hybrid` | N stateful debaters + reviewer-dialogue session across proposal + rebuttal rounds | [src/debate/session-hybrid.ts](src/debate/session-hybrid.ts) | plan stage; review with hybrid mode |
+
+**Decomposition — debate is ops inside a topology runner.** The runner owns *topology* (how many sessions, keep-open boundaries, round sequencing, abort isolation). The ops own *content* (prompt building, response parsing, validation). Four ops cover all three modes:
+
+| Op | What it does | Used in mode(s) |
+|:---|:---|:---|
+| `proposeCandidate` | One debater's proposal (plan draft or review verdict) | all three |
+| `rebutCandidate` | Debater refines under critique | stateful, hybrid |
+| `reviewDialogue` | Reviewer critiques / synthesizes across rounds | hybrid |
+| `rankCandidates` | Pick winner from the N debaters | all three |
+
+The same `proposeCandidate` op runs whether the stage is `plan` or `review` — the builder and config slice differ, but the contract is identical. That is the point of making debate ops-based.
 
 ```typescript
-export class DebateSessionRunner implements ISessionRunner<DebateInput, DebateResult> {
-  async run(scope: RunScope, input: DebateInput, opts: RunnerOptions): Promise<DebateResult> {
-    const results = await Promise.allSettled(
-      input.debaters.map((debater) => {
-        const proposerSignal = linkAbortSignals(opts.signal);
-        const proposerLogger = scope.services.logger.child({
-          storyId: opts.storyId,
-          debater: debater.agent,
-        });
-        return scope.invoke(debateProposer, { debater, prompt: input.prompt }, {
+export class DebateSessionRunner<I, O> implements ISessionRunner<DebateInput<I>, DebateResult<O>> {
+  async run(scope: RunScope, input: DebateInput<I>, opts: RunnerOptions): Promise<DebateResult<O>> {
+    switch (input.mode) {
+      case "one-shot": return this.runOneShot(scope, input, opts);
+      case "stateful": return this.runStateful(scope, input, opts);
+      case "hybrid":   return this.runHybrid(scope, input, opts);
+    }
+  }
+
+  private async runOneShot(scope, input, opts) {
+    const proposals = await Promise.allSettled(
+      input.debaters.map((debater, i) =>
+        scope.invoke(input.proposeOp, { debater, prompt: input.prompt }, {
           ...opts,
           agentName: debater.agent,
-          signal: proposerSignal,
-          logger: proposerLogger,
-        });
-      }),
+          sessionRole: `debate-${opts.stage}`,        // e.g. "debate-plan", "debate-review"
+          discriminator: i,
+          signal: linkAbortSignals(opts.signal),
+          logger: scope.services.logger.child({ storyId: opts.storyId, debater: debater.agent }),
+        }),
+      ),
     );
-
-    const successful = results.filter(isFulfilled).map((p) => p.value);
-    return scope.invoke(debateResolve, { proposals: successful, resolver: input.resolver }, opts);
+    return scope.invoke(input.rankOp, { proposals: proposals.filter(isFulfilled).map(p => p.value) }, opts);
   }
+
+  private async runStateful(scope, input, opts)  { /* proposals kept warm across critique round */ }
+  private async runHybrid(scope, input, opts)    { /* proposals + reviewDialogue interleaved across rounds */ }
 }
 ```
 
-Key points:
+Key properties:
 
-- Each proposer's middleware envelope fires independently → N audit entries, N cost events, each tagged with the proposer's `agentName`.
-- One proposer's timeout/error doesn't kill siblings (`Promise.allSettled` + per-proposer `AbortController`).
-- The runner does **not** construct an `AgentManager`, does **not** build prompts, does **not** resolve permissions. All that is inside `scope.invoke()`.
-- `src/debate/session-helpers.ts` shrinks drastically: proposal resolution logic collapses to `DebateSessionRunner.run()`; `_debateSessionDeps.createManager` and the orphan `createAgentManager` import delete (already removed by ADR-014 Phase 2).
+- Each debater's middleware envelope fires independently → N audit entries, N cost events, each tagged with `agentName` + `sessionRole`. A 401 on debater 0 is visibly distinct from a 401 on debater 2.
+- One debater's timeout/error does not kill siblings (`Promise.allSettled` + per-debater `AbortController`).
+- Per-debater sessionId is derived by `computeAcpHandle` from `{ sessionRole, discriminator }` — so `debate-review-0`, `debate-review-1`, `debate-hybrid-0`, `plan-0` all emerge from the same derivation rule. No inline string construction.
+- The runner does **not** construct an `AgentManager`, does **not** build prompts, does **not** resolve permissions — all of that is inside `scope.invoke()`.
+- `src/debate/session-helpers.ts` collapses: mode-specific topology logic moves into the runner; `_debateSessionDeps.createManager` and the orphan `createAgentManager` import are already removed by ADR-014 Phase 2. Files under `src/debate/` become thin strategy methods on the runner (or move to `src/sessions/runners/debate/*`).
+
+#### 2.4 What this ADR does NOT change
+
+The session primitives from ADR-007/008/011/013 are preserved intact. `ISessionRunner` is a topology abstraction *over* them, not a replacement:
+
+| Primitive | Owner | Preserved as-is |
+|:---|:---|:---|
+| `sess-<uuid>` descriptor ID | SessionManager | Yes — `runInSession(id, ...)` signature unchanged |
+| `nax-<hash8>-<feature>-<storyId>-<role>` wire handle | `computeAcpHandle()` in adapter | Yes — still the single place that builds the name |
+| `keepSessionOpen` per-role policy (ADR-008 matrix) | Caller of `agent.run()` | Yes — ops pass `keepOpen` on `AgentRunOptions` |
+| `sweepFeatureSessions` at story completion | SessionManager | Yes — still the single cleanup point |
+| `AgentRunOptions.sessionHandle` override | Adapter | Yes — exposed through `InvokeOptions.sessionHandle` for dialogue-style per-generation names |
+| Implementer session continuity across rectification | `computeAcpHandle` determinism | Yes — same role → same handle → automatic resume |
+| Fresh sessionId per reviewer round | `keepOpen: false` + deterministic handle | Yes — next round's `loadSession` creates fresh ACP session |
+
+What changes is the *path* by which operations reach these primitives: via `scope.invoke()` threading `AgentRunOptions` from `op.requires` + `InvokeOptions`, instead of each subsystem assembling the request by hand.
+
+**SessionRole latent bug fix.** Debate roles today (`debate-review-0`, `debate-hybrid-1`, `debate-hybrid-fallback`) bypass the `SessionRole` union at [src/session/types.ts:56-70](src/session/types.ts#L56-L70) and are constructed inline as strings ([src/debate/session-stateful.ts:160](src/debate/session-stateful.ts#L160), [src/debate/session-hybrid.ts:169](src/debate/session-hybrid.ts#L169)). Phase 2 of this ADR extends the union:
+
+```typescript
+export type SessionRole =
+  | /* existing 14 fixed roles */
+  | `debate-${string}`
+  | `debate-${string}-fallback`
+  | `plan-${number}`;
+```
+
+Runners generate these via `{ sessionRole, discriminator }` passed through `InvokeOptions` — no more inline string building at call sites.
 
 ---
 
@@ -434,6 +499,10 @@ is control-flow. It lives in `src/control/`. It imports `RunScope` and `Operatio
 
 #### 4.1 `plan` operation
 
+Two shapes, selected by the plan stage based on `config.debate.stages.plan.enabled`:
+
+**Shape A — simple `plan` op (debate disabled):** single `agent.run()` call.
+
 ```typescript
 // src/operations/plan.ts
 export const plan: Operation<PlanInput, PlanResult, PlanConfig> = {
@@ -455,6 +524,27 @@ export const plan: Operation<PlanInput, PlanResult, PlanConfig> = {
   },
 };
 ```
+
+**Shape B — debated plan (debate enabled):** plan stage invokes `DebateSessionRunner` with plan-specific ops. The stage module picks the shape; both paths produce a `PlanResult`:
+
+```typescript
+// src/pipeline/stages/plan.ts (sketch)
+async function planStage(scope, story, opts) {
+  if (scope.config.debate.stages.plan.enabled) {
+    return new DebateSessionRunner().run(scope, {
+      mode: scope.config.debate.stages.plan.mode,  // "one-shot" | "stateful" | "hybrid"
+      debaters: scope.config.debate.stages.plan.debaters,
+      proposeOp: planProposeCandidate,             // plan-specific builder
+      rebutOp:   planRebutCandidate,
+      rankOp:    planRankCandidates,
+      input: planInput,
+    }, opts);
+  }
+  return scope.invoke(plan, planInput, opts);
+}
+```
+
+Note: `proposeCandidate`, `rebutCandidate`, `rankCandidates` are the same ops used by the review stage's debated path (§2.3) — differing only in the builder and config slice passed to the op instance. Today's `plan-<i>` wire roles (ADR-008) fall out of the runner passing `sessionRole: "plan"` + `discriminator: i` through `InvokeOptions`.
 
 #### 4.2 `decompose` operation
 
@@ -504,10 +594,18 @@ Operation<I, O, C> (semantic unit)
   ├─ requires: { session, scope, permissions, config }
   └─ execute(ctx, input)
 
-ISessionRunner<I, O> (topology, ADR-013)
-  ├─ SingleSessionRunner
-  ├─ ThreeSessionRunner                       // tdd
-  └─ DebateSessionRunner                      // debate — no RunScope fork
+ISessionRunner<I, O> (topology, ADR-013 — reused across stages)
+  ├─ SingleSessionRunner                      // implementer, rectifier, diagnose, source-fix
+  ├─ ThreeSessionRunner                       // tdd (writer → implementer → verifier)
+  └─ DebateSessionRunner                      // plan AND review stages
+     ├─ mode: "one-shot"                      // N × complete(), no sessions
+     ├─ mode: "stateful"                      // N debater sessions across rounds
+     └─ mode: "hybrid"                        // N stateful debaters + reviewer-dialogue
+
+Session primitives (ADR-007/008/011/013 — preserved)
+  ├─ SessionManager.runInSession(sess-<uuid>, ...)       // unchanged
+  ├─ computeAcpHandle(workdir, feature, storyId, role)   // unchanged — still in adapter
+  └─ keepSessionOpen per-role matrix                     // unchanged
 
 Control-flow (src/control/, non-operations)
   ├─ escalation                               // tier decisions
@@ -567,7 +665,7 @@ Four phases. Phase 1 and Phase 2 are independent; Phase 3 and Phase 4 depend on 
   2. `generateAcceptance`, `refineAcceptance`, `diagnoseAcceptance`, `fixAcceptance`
   3. `semanticReview`, `adversarialReview` (and optional `review` composite)
   4. `writeTest`, `implement`, `verify` (TDD — behind `ThreeSessionRunner`)
-  5. `debateProposer`, `debateResolve` (behind `DebateSessionRunner`)
+  5. `proposeCandidate`, `rebutCandidate`, `reviewDialogue`, `rankCandidates` — the debate ops. Simultaneously extend `SessionRole` union to admit `debate-*` / `plan-<n>` forms (§2.3). Ship `DebateSessionRunner` with all three modes; switch plan stage and review stage to use it.
   6. `rectify`
 - Each migration ships independently and uses the middleware envelope from ADR-014.
 - **Exit criteria:** All subsystems invoke through `scope.invoke()`. No stage constructs ad-hoc prompt-permission-session ceremony.
@@ -619,7 +717,15 @@ Four phases. Phase 1 and Phase 2 are independent; Phase 3 and Phase 4 depend on 
 
 **Rejected** (ADR-014 §C already rejected `child()` generally). Per-proposer isolation is a per-call concern (own signal, own logger), not a scope-level concern. `InvokeOptions.{agentName, signal, logger}` covers it. Introducing child scopes re-raises all the lifecycle questions (who closes what, does child inherit or own) for no gain.
 
-### F. `ConfigSelector<C>` is lambda-only (no keyof-array sugar)
+### F. Separate `StatefulDebateRunner` / `OneShotDebateRunner` / `HybridDebateRunner`
+
+**Rejected.** The three modes differ in topology details (keep-open policy, round count, whether a reviewer-dialogue participates) but share debater vocabulary, per-debater abort isolation, and ranking. A mode parameter on one runner matches how today's [src/debate/session.ts](src/debate/session.ts) already dispatches; splitting into three runners triples the surface without simplifying any call site. The stages still have to choose a mode — choosing it on the runner input vs choosing which runner class to instantiate is the same decision, and input-choice keeps `ISessionRunner` a small enumerable set.
+
+### G. Mint sessionIds inside `scope.invoke()`
+
+**Rejected.** There are already two sessionIds in the stack (`sess-<uuid>` owned by SessionManager; ACP wire handle owned by adapter's `computeAcpHandle`) and both have correct owners per ADR-007/008/011/013. Moving mint logic into `scope.invoke()` would duplicate one of them or conflict with deterministic handle derivation (which is what makes rectification's automatic session-resume work). `scope.invoke()` threads `AgentRunOptions`; SessionManager and the adapter do what they already do.
+
+### H. `ConfigSelector<C>` is lambda-only (no keyof-array sugar)
 
 **Rejected.** 95% of operations want to pick top-level keys. Writing `(c) => ({ review: c.review })` for every op is noise. Keyof-array covers the common case; lambda covers reshape. Both are type-checked.
 

--- a/docs/adr/ADR-015-operation-contract.md
+++ b/docs/adr/ADR-015-operation-contract.md
@@ -1,6 +1,6 @@
 # ADR-015: Operation Contract, SessionRunners, and Control-Flow Layer
 
-**Status:** Proposed
+**Status:** Reject
 **Date:** 2026-04-23
 **Author:** William Khoo, Claude
 **Extends:** ADR-014 (RunScope & Middleware); ADR-013 (SessionManager → AgentManager Hierarchy); ADR-012 (AgentManager Ownership)

--- a/docs/adr/ADR-016-prompt-composition-and-packageview.md
+++ b/docs/adr/ADR-016-prompt-composition-and-packageview.md
@@ -1,6 +1,6 @@
 # ADR-016: Prompt Composition (Immutable Sections) and PackageView
 
-**Status:** Proposed
+**Status:** Reject
 **Date:** 2026-04-23
 **Author:** William Khoo, Claude
 **Extends:** ADR-015 (Operation Contract); ADR-014 (RunScope & Middleware); ADR-010 (Context Engine)

--- a/docs/adr/ADR-017-incremental-consolidation.md
+++ b/docs/adr/ADR-017-incremental-consolidation.md
@@ -1,0 +1,701 @@
+# ADR-017: Incremental Consolidation — NaxRuntime, Adapter Shrink, Prompt Composition Helper, Unified Retry
+
+**Status:** Reviewing
+**Date:** 2026-04-24
+**Author:** William Khoo, Claude
+**Supersedes:** ADR-014 (RunScope and Middleware), ADR-015 (Operation Contract), ADR-016 (Prompt Composition and PackageView)
+**Extends:** ADR-011 (SessionManager Ownership), ADR-012 (AgentManager Ownership), ADR-013 (SessionManager → AgentManager Hierarchy), ADR-009 (Test-File Pattern SSOT), ADR-008 (Session Lifecycle)
+**Related:** #523 (fallback state divergence across orphan AgentManagers), #533–#536 (monorepo awareness violations)
+
+---
+
+## Context
+
+ADR-014/015/016 identified four real problems: orphan `AgentManager` instances, `.plan()`/`.decompose()` on the adapter, retry-loop input divergence, and hand-wired prompt composition. Each of those problems is real and verified in the code. The proposed solutions in that trio — `RunScope`, agent middleware, `Operation<I, O, C>`, `ISessionRunner`, `src/control/`, prompt middleware, `PackageRegistry` — collectively introduce 24+ new types across three new directories, defer the plugin extension surface three times, and sequence awkwardly across three interdependent ADRs.
+
+A codebase review turned up six facts that reshape the solution space:
+
+1. **`PromptSection` + `SectionAccumulator` already exist.** [src/prompts/core/types.ts:19](../../src/prompts/core/types.ts#L19) defines `PromptSection`; [src/prompts/core/section-accumulator.ts](../../src/prompts/core/section-accumulator.ts) composes in insertion order; [src/prompts/core/universal-sections.ts](../../src/prompts/core/universal-sections.ts) exports `universalConstitutionSection()` and `universalContextSection()`. Prompt composition is partially abstracted; the gap is that builders hand-wire which sections to include.
+
+2. **A shared rectification driver already exists.** [src/verification/shared-rectification-loop.ts](../../src/verification/shared-rectification-loop.ts) is consumed by five callers; the divergence is in the input shape each caller passes, not in the driver.
+
+3. **Orphan `AgentManager` count is 7, not 8.** `src/review/semantic.ts:35` listed in ADR-014 §Problem 1 does not call `createAgentManager`. The actual sites are `routing/router.ts:271`, `cli/plan.ts:61`, `debate/session-helpers.ts:83`, `verification/rectification-loop.ts:129`, `acceptance/refinement.ts:25`, `acceptance/generator.ts:75`, plus the canonical `execution/runner.ts:117`.
+
+4. **`IAgent` does not exist.** [src/agents/types.ts](../../src/agents/types.ts) exposes `AgentAdapter` (transport); [src/agents/manager-types.ts](../../src/agents/manager-types.ts) exposes `IAgentManager` (fallback aggregator). Three different `getAgent()` methods already exist on the registry, the manager, and wrapper utilities.
+
+5. **A plugin system with 7 extension types already exists.** [src/plugins/types.ts](../../src/plugins/types.ts): `optimizer`, `router`, `agent`, `reviewer`, `context-provider`, `reporter`, `post-run-action`. New extension concerns should join this list, not spawn a parallel registration surface.
+
+6. **`process.cwd()` violations extend well beyond the 4 tracked issues.** Grep surfaces ≥5 additional sites in `debate/session.ts:44`, `acp/adapter.ts:884,895`, `precheck/index.ts:239`, `commands/common.ts:82,85,98`, plus hardcoded test patterns in `context/greenfield.ts:21-27`.
+
+The common thread: **the codebase already contains the abstractions the ADR trio proposes to introduce**, in partial form. The right refactor extends existing abstractions rather than replacing them.
+
+---
+
+## Decision
+
+Five self-contained refactors, shipped in sequence. Each closes a named pain point with existing code. No new top-level directory outside `src/runtime/`. No middleware chain. No `Operation<I, O, C>` contract. No `ISessionRunner`.
+
+1. **`NaxRuntime`** — single lifecycle container owning `AgentManager`, `SessionManager`, `CostTracker`, logger, signal. Threaded via existing `PipelineContext`. Replaces the 7 orphan `createAgentManager` call sites.
+
+2. **Cross-cutting work in `AgentManager.runAs()`** — `resolvePermissions()`, cost tagging, audit, error wrapping become one method-local envelope in the manager. The ACP adapter's three `resolvePermissions()` calls collapse to zero.
+
+3. **`.plan()` / `.decompose()` leave the adapter as plain functions** — `runPlan(runtime, input)` and `runDecompose(runtime, input)` replace the adapter methods. Adapter surface drops to 2 methods permanently.
+
+4. **`composeSections()` helper + typed `PromptSection` slots** — one helper function assembles sections in canonical order. Builders produce slot-specific sections (role, task, examples, output-format); the helper materializes context, constitution, static rules, monorepo hints, previous attempts. No middleware chain.
+
+5. **Unified `RetryInput<TFailure, TResult>` shape** — five callers of `runSharedRectificationLoop` migrate to one input shape. Progressive composition (previous attempts feeding the next prompt) is a callback parameter, not a prompt-middleware concern.
+
+Three cross-cutting enforcements land alongside:
+
+6. **CI lint rule — `process.cwd()` outside CLI entry points is an error.** Enforces the existing rule in `.claude/rules/monorepo-awareness.md`; closes #533–#536 plus the additional sites.
+
+7. **`SessionRole` tightens to a template-literal union** admitting `debate-${string}`, `plan-${number}` — retires ad-hoc string construction in `src/debate/`.
+
+8. **Plugin extension points extend by 1** — `IPromptSectionProvider` as an 8th plugin type. Plugins contribute sections for named slots; no operation-registration API, no middleware registration API.
+
+---
+
+### 1. `NaxRuntime` — single lifecycle container
+
+```typescript
+// src/runtime/index.ts (new, ~80 lines)
+export interface NaxRuntime {
+  readonly config: NaxConfig;
+  readonly workdir: string;
+  readonly projectDir: string;
+  readonly agentManager: IAgentManager;
+  readonly sessionManager: ISessionManager;
+  readonly costTracker: CostTracker;
+  readonly promptAuditor: IPromptAuditor;
+  readonly packages: PackageRegistry;
+  readonly logger: Logger;
+  readonly signal: AbortSignal;
+  close(): Promise<void>;
+}
+
+export function createRuntime(
+  config: NaxConfig,
+  workdir: string,
+  opts?: CreateRuntimeOptions,
+): NaxRuntime;
+```
+
+**Contract:**
+
+- `createRuntime()` is the only public constructor for `AgentManager` and `SessionManager`. `createAgentManager` leaves the public barrel (`src/agents/index.ts:29`) and moves to `src/runtime/internal/agent-manager-factory.ts`.
+- `close()` is idempotent and cascades: `signal.abort()` → `sessionManager.sweepAll()` → `promptAuditor.flush()` → `costTracker.drain()` → `agentManager.dispose()`. Order is explicit, not left to a service-drain loop.
+- `signal` is a scope-internal `AbortController`; `opts.parentSignal` (e.g. CLI SIGINT) is linked in via `AbortSignal.any()`.
+- `config` is frozen at construction. Configuration changes require a new runtime — there is no hot reload.
+- `NaxRuntime` is threaded through existing `PipelineContext`. No new `ctx.scope` field; use `ctx.runtime`.
+
+**Explicit non-goals compared to ADR-014's `RunScope`:**
+
+- **No `getAgent(name)` method.** Callers use `runtime.agentManager.runAs(agentName, request)` or `runtime.agentManager.completeAs(agentName, prompt, opts)` — today's shape.
+- **No `invoke(op, input, opts)` method.** Call sites are plain function calls; see §3.
+- **No `services` sub-object.** Five fields at the top level (`costTracker`, `promptAuditor`, `packages`, `logger`, plus managers) — flat, readable.
+- **No `child()` or nested runtime.** Per-call isolation (debate proposers, rectification attempts) is already expressed via per-call `signal`, `logger` overrides on `AgentRunOptions`.
+
+**Orphan consolidation — mechanical migration:**
+
+| Site | Today | After |
+|:---|:---|:---|
+| [src/routing/router.ts:271](../../src/routing/router.ts#L271) | `createManager: createAgentManager` | `_deps.runtime` threaded from caller |
+| [src/cli/plan.ts:61](../../src/cli/plan.ts#L61) | `createManager: createAgentManager` | `const runtime = createRuntime(config, workdir)` in the CLI entry point |
+| [src/debate/session-helpers.ts:83](../../src/debate/session-helpers.ts#L83) | `createManager: createAgentManager` | `_debateSessionDeps.runtime` |
+| [src/verification/rectification-loop.ts:129](../../src/verification/rectification-loop.ts#L129) | `createManager: createAgentManager` | `_rectificationDeps.runtime` |
+| [src/acceptance/refinement.ts:25](../../src/acceptance/refinement.ts#L25) | `createManager: (config) => createAgentManager(config)` | `_refinementDeps.runtime` |
+| [src/acceptance/generator.ts:75](../../src/acceptance/generator.ts#L75) | `createManager: (config) => createAgentManager(config)` | `_generatorDeps.runtime` |
+| [src/execution/runner.ts:117](../../src/execution/runner.ts#L117) | `const agentManager = createAgentManager(config)` | `const runtime = createRuntime(config, workdir)` |
+
+**Why this works for #523:** one `AgentManager` per run, so routing's 401 falls into the same fallback chain execution uses. Cost events from rectification and debate proposers roll into one `CostTracker`. No new middleware required.
+
+**Existing `_deps` pattern preserved.** The codebase's DI convention ([src/pipeline/stages/rectify.ts:126](../../src/pipeline/stages/rectify.ts#L126), `_unifiedExecutorDeps`, etc.) continues — the single change is that each `createManager` field becomes `runtime`.
+
+---
+
+### 2. `AgentManager.runAs()` becomes the cross-cutting envelope
+
+**Problem:** the ACP adapter calls `resolvePermissions()` three times — [adapter.ts:593,847,1036](../../src/agents/acp/adapter.ts#L593). Every orphan call site tags costs and logs differently. Prompt audit is inconsistent across session-less calls.
+
+**Fix:** one place where cross-cutting work happens — `AgentManager.runAs()` and its sibling `completeAs()`:
+
+```typescript
+// src/agents/manager.ts — amend existing runAs()
+async runAs(agentName: string, request: AgentRunRequest): Promise<AgentResult> {
+  const permissions = resolvePermissions(request.runOptions.config, request.runOptions.pipelineStage);
+  const logger = this._logger.child({
+    storyId: request.runOptions.storyId,
+    stage: request.runOptions.pipelineStage,
+    agent: agentName,
+  });
+  const started = Date.now();
+
+  try {
+    const result = await this._dispatch(agentName, {
+      ...request,
+      runOptions: {
+        ...request.runOptions,
+        resolvedPermissions: permissions,  // adapter reads this, no longer resolves itself
+      },
+    });
+
+    this._costTracker.record({
+      agentName,
+      stage: request.runOptions.pipelineStage,
+      storyId: request.runOptions.storyId,
+      tokens: result.tokenUsage,
+      costUsd: result.estimatedCost,
+      durationMs: Date.now() - started,
+    });
+    this._promptAuditor.record({ /* prompt hash, response hash, etc. */ });
+
+    return result;
+  } catch (err) {
+    this._costTracker.recordError({
+      agentName,
+      stage: request.runOptions.pipelineStage,
+      errorCode: extractErrorCode(err),
+      durationMs: Date.now() - started,
+    });
+    this._promptAuditor.recordError({ /* ... */ });
+    throw wrapNaxError(err, { stage: request.runOptions.pipelineStage, agentName });
+  }
+}
+```
+
+**Adapter simplification:** the three `resolvePermissions()` calls at [adapter.ts:593,847,1036](../../src/agents/acp/adapter.ts#L593) delete. The adapter reads `request.runOptions.resolvedPermissions` (pre-resolved by the manager). `AgentRunOptions.resolvedPermissions?: ResolvedPermissions` is added; `AgentRunOptions.pipelineStage` stays (still used for audit/log correlation).
+
+**ACP wire mapping stays where it already is.** Today, `resolvePermissions()` returns `{ mode: "approve-all" | "approve-reads" | "default", skipPermissions, allowedTools? }` — ACP's wire shape. Future second-transport integration adds a `toWirePolicy(resolved): W` method to the `AgentAdapter` interface; no registry needed until there is more than one transport. (Rejected Alternatives §B.)
+
+**Why no middleware chain:**
+
+- Method-local ordering is readable and testable. A three-line try-catch with cost-on-success and cost-on-error is easier to reason about than a middleware chain with observer-only invariants.
+- No chain ordering questions. No per-middleware resilience rules. No "transformer vs observer" tax.
+- Testing: `_agentManagerDeps.costTracker = mockTracker` via existing DI.
+- Extension: budget enforcement, rate limiting, etc. add as method branches or as subscribers to `CostTracker` / `PromptAuditor`. Nobody has asked for mid-call interception.
+
+---
+
+### 3. `.plan()` / `.decompose()` off the adapter — plain functions
+
+**Problem:** [src/agents/types.ts:322,325](../../src/agents/types.ts#L322) — `AgentAdapter.plan()` and `.decompose()` are prompt-composition-plus-one-call. Every new agent implements 4 methods. Prompt-building is pinned to the adapter layer, violating the Prompt Builder Convention.
+
+**Fix:** pull them out as plain functions that live with their callers:
+
+```typescript
+// src/pipeline/plan/run-plan.ts (new)
+export async function runPlan(runtime: NaxRuntime, input: PlanInput): Promise<PlanResult> {
+  const prompt = composeSections({
+    role: planBuilder.role(input),
+    task: planBuilder.task(input),
+    context: input.context,
+    constitution: input.constitution,
+    packageView: runtime.packages.get(input.packageDir),
+    outputFormat: planBuilder.outputFormat(),
+  });
+
+  const result = await runtime.agentManager.runAs(input.agentName, {
+    runOptions: {
+      prompt: join(prompt),
+      workdir: input.packageDir,
+      pipelineStage: "plan",
+      mode: "plan",
+      config: runtime.config,
+      storyId: input.storyId,
+      sessionRole: "plan",
+      keepOpen: false,
+    },
+  });
+
+  return planBuilder.parse(result.output);
+}
+
+// src/pipeline/decompose/run-decompose.ts (new)
+export async function runDecompose(runtime: NaxRuntime, input: DecomposeInput): Promise<DecomposeResult> {
+  const prompt = composeSections({
+    role: decomposeBuilder.role(input),
+    task: decomposeBuilder.task(input),
+    constitution: input.constitution,
+    outputFormat: decomposeBuilder.outputFormat(),
+    packageView: runtime.packages.repo(),
+  });
+
+  const response = await runtime.agentManager.completeAs(input.agentName, join(prompt), {
+    jsonMode: true,
+    pipelineStage: "complete",
+    config: runtime.config,
+  });
+
+  return decomposeBuilder.parse(response);
+}
+```
+
+**Migration:**
+
+1. Copy `adapter.plan()` body into `runPlan()`; replace `this.run(...)` with `runtime.agentManager.runAs(...)`.
+2. Copy `adapter.decompose()` body into `runDecompose()`; replace `this.complete(...)` with `runtime.agentManager.completeAs(...)`.
+3. Update `nax plan` CLI ([src/cli/plan.ts](../../src/cli/plan.ts)) to call `runPlan(runtime, input)`.
+4. Update decompose callers ([src/commands/decompose.ts](../../src/commands/decompose.ts), batch routing, etc.) to call `runDecompose(runtime, input)`.
+5. Delete `AgentAdapter.plan()` and `AgentAdapter.decompose()` from [src/agents/types.ts:322,325](../../src/agents/types.ts#L322).
+6. Delete `IAgentManager.planAs()` and `IAgentManager.decomposeAs()` from [src/agents/manager-types.ts](../../src/agents/manager-types.ts).
+7. Update `IAgentManager.plan()` and `.decompose()` to throw a deprecation `NaxError` with a one-release window, then delete.
+
+**Final adapter surface:** `run(options)` and `complete(prompt, options)` — 2 methods, permanently. Same outcome as ADR-015 §4 without `Operation<I, O, C>`.
+
+**Why no `Operation<I, O, C>`:** the declarative contract's only concrete benefit is plugin operation registration. Plugins contribute to the existing 7 types (`agent`, `reviewer`, `context-provider`, etc.) — they've never asked for a "new operation" primitive. When they do, wrap the function shape then; don't ship the type gymnastics preemptively.
+
+---
+
+### 4. `composeSections()` helper + typed `PromptSection` slots
+
+**Problem:** builders today each hand-wire which of (constitution, context, static rules, role, task, examples, output format) to include. [rectifier-builder.ts](../../src/prompts/builders/rectifier-builder.ts) is 720 lines partly because of this drift. Progressive composition (previous attempts feeding the next prompt) has no primitive.
+
+**Fix:** keep `PromptSection` as it is today; add one helper function:
+
+```typescript
+// src/prompts/core/types.ts — extend existing type
+export interface PromptSection {
+  readonly id: string;
+  readonly content: string;
+  readonly overridable: boolean;
+  readonly slot: SectionSlot;  // NEW — canonical position
+}
+
+export type SectionSlot =
+  | "constitution"
+  | "role"
+  | "context"
+  | "static-rules"
+  | "monorepo-hints"
+  | "task"
+  | "previous-attempts"
+  | "examples"
+  | "output-format"
+  | "extension";  // plugin-contributed sections
+
+// Canonical slot order — the single source of truth for section ordering.
+export const SLOT_ORDER: readonly SectionSlot[] = [
+  "constitution", "role", "context", "static-rules", "monorepo-hints",
+  "task", "previous-attempts", "examples", "output-format", "extension",
+];
+
+// src/prompts/compose.ts (new, ~100 lines)
+export interface ComposeInput {
+  readonly role: PromptSection;
+  readonly task: PromptSection;
+  readonly context?: ContextBundle;
+  readonly constitution?: string;
+  readonly staticRules?: readonly StaticRule[];
+  readonly previousAttempts?: readonly RetryAttempt<unknown>[];
+  readonly examples?: PromptSection;
+  readonly outputFormat?: PromptSection;
+  readonly packageView: PackageView;
+  readonly extensions?: readonly PromptSection[];  // from IPromptSectionProvider plugins
+}
+
+export function composeSections(input: ComposeInput): readonly PromptSection[] {
+  const sections: PromptSection[] = [];
+  if (input.constitution) sections.push(universalConstitutionSection(input.constitution));
+  sections.push(input.role);
+  if (input.context)       sections.push(universalContextSection(renderContext(input.context)));
+  if (input.staticRules?.length) sections.push(renderStaticRulesSection(input.staticRules));
+  sections.push(packageHintsSection(input.packageView));
+  sections.push(input.task);
+  if (input.previousAttempts?.length) sections.push(previousAttemptsSection(input.previousAttempts));
+  if (input.examples)     sections.push(input.examples);
+  if (input.outputFormat) sections.push(input.outputFormat);
+  if (input.extensions?.length) sections.push(...input.extensions);
+
+  return sortBySlot(sections, SLOT_ORDER);
+}
+
+export function join(sections: readonly PromptSection[]): string {
+  return sections.filter((s) => s.content.length > 0).map((s) => s.content).join(SECTION_SEP);
+}
+```
+
+**Builder simplification:** each builder exposes slot-specific methods (`role(input) → PromptSection`, `task(input) → PromptSection`, etc.) and leaves composition to `composeSections()`. The rectifier builder drops from 720 lines to ~200.
+
+**Progressive composition:** `RetryInput.previousAttempts` (§5) flows through `ComposeInput.previousAttempts` — materialized by `previousAttemptsSection()`. No middleware required.
+
+**CI-enforced forbidden imports inside `src/prompts/builders/**`:**
+
+| Forbidden | Module | Why |
+|:---|:---|:---|
+| `ContextBundle`, `IContextEngine` | `src/context` | Context enters via `ComposeInput.context` only |
+| `loadConstitution`, `Constitution` | `src/constitution` | Constitution enters via `ComposeInput.constitution` only |
+| `loadStaticRules` | `src/rules` | Static rules enter via `ComposeInput.staticRules` only |
+| `process.cwd`, `detectLanguage`, `resolveTestFilePatterns` | globals / detectors | Monorepo data enters via `ComposeInput.packageView` only |
+
+Violations are CI errors, not warnings.
+
+**Why no middleware chain:**
+
+- `composeSections()` is a total function: inputs → ordered sections. No ordering registry, no "who owns what" conflict errors at runtime.
+- Plugin contributions enter through one typed input (`ComposeInput.extensions`). See §6 below.
+- Section ordering is a `const readonly` array — the single source of truth, greppable.
+- Testing: builders test with fixed `ComposeInput`; `composeSections()` tests order. No middleware chain fixtures.
+
+---
+
+### 5. Unified `RetryInput<TFailure, TResult>` for the rectification driver
+
+**Problem:** [shared-rectification-loop.ts](../../src/verification/shared-rectification-loop.ts) already exists as a shared driver. The divergence is in what each caller hands in — `buildPrompt`, `canContinue`, per-stage state shapes.
+
+**Fix:** standardize the input; keep the driver.
+
+```typescript
+// src/verification/shared-rectification-loop.ts — amend existing exports
+export interface RetryInput<TFailure, TResult> {
+  readonly stage: PipelineStage;
+  readonly storyId: string;
+  readonly packageDir: string;
+  readonly maxAttempts: number;
+  readonly failure: TFailure;
+  readonly previousAttempts: ReadonlyArray<RetryAttempt<TResult>>;
+  readonly buildPrompt: (failure: TFailure, previous: readonly RetryAttempt<TResult>[]) => string;
+  readonly execute: (prompt: string) => Promise<TResult>;
+  readonly verify: (result: TResult) => Promise<VerifyOutcome<TFailure>>;
+}
+
+export interface RetryAttempt<TResult> {
+  readonly result: TResult;
+  readonly verification: VerifyOutcome<unknown>;
+  readonly ts: number;
+}
+
+export type VerifyOutcome<TFailure> =
+  | { readonly success: true }
+  | { readonly success: false; readonly reason: string; readonly remaining?: TFailure };
+
+export interface RetryOutcome<TResult> {
+  readonly outcome: "fixed" | "exhausted";
+  readonly attempts: readonly RetryAttempt<TResult>[];
+  readonly finalResult?: TResult;
+}
+
+export async function runRetryLoop<TFailure, TResult>(
+  input: RetryInput<TFailure, TResult>,
+): Promise<RetryOutcome<TResult>>;
+```
+
+**Migration — the 5 callers:**
+
+| Caller | Today | After |
+|:---|:---|:---|
+| [src/verification/rectification-loop.ts:136](../../src/verification/rectification-loop.ts#L136) | `runRectificationLoop(...)` wraps shared driver w/ escalation | `runRetryLoop<TestFailure, RectifyResult>({...})` + escalation remains in caller |
+| [src/tdd/rectification-gate.ts:199](../../src/tdd/rectification-gate.ts#L199) | local `runRectificationLoop` wrapper | deletes; calls `runRetryLoop` directly |
+| [src/pipeline/stages/autofix.ts:34](../../src/pipeline/stages/autofix.ts#L34) | direct import | `runRetryLoop<ReviewFindings, AutofixResult>({...})` |
+| [src/pipeline/stages/rectify.ts:72](../../src/pipeline/stages/rectify.ts#L72) | uses `runRectificationLoopFromCtx` | calls `runRetryLoop` directly; `runRectificationLoopFromCtx` retires |
+| [src/execution/lifecycle/run-regression.ts:277](../../src/execution/lifecycle/run-regression.ts#L277) | direct import | `runRetryLoop<RegressionFailure, RegressionResult>({...})` |
+
+**Progressive composition:** the `buildPrompt(failure, previous)` callback is the single place where "previous attempts" are rendered into the next prompt. Callers use `composeSections({ ..., previousAttempts: previous })` inside `buildPrompt`. No separate mechanism.
+
+**Escalation stays where it is.** `src/execution/escalation/` is unchanged; it runs between stage retries (outside the retry loop), not inside. The layering is:
+
+```
+Stage invocation (e.g. src/pipeline/stages/implement.ts)
+  │
+  ├─ on failure → runRetryLoop (same tier, N attempts via buildPrompt+execute+verify)
+  │               returns { outcome: "fixed" | "exhausted" }
+  │
+  └─ on "exhausted" → escalation module decides next-tier action
+                       escalation mutates story.modelTier; runner re-invokes stage
+```
+
+No `src/control/` directory. Escalation and retry live where they are today; only their I/O shapes normalize.
+
+---
+
+### 6. Plugin extension: `IPromptSectionProvider`
+
+**Problem:** when a plugin wants to inject a "security warning" section or a "compliance header," today it must fork the builder. No extension seam.
+
+**Fix:** add one plugin type — the 8th in the existing plugin system:
+
+```typescript
+// src/plugins/extensions.ts — extend existing file
+export interface IPromptSectionProvider {
+  readonly slot: "extension";  // plugins always contribute to the "extension" slot
+  readonly stages: readonly PipelineStage[];  // when to apply
+  provide(ctx: SectionProvideContext): Promise<readonly PromptSection[]>;
+}
+
+export interface SectionProvideContext {
+  readonly stage: PipelineStage;
+  readonly story?: UserStory;
+  readonly packageView: PackageView;
+  readonly runtime: NaxRuntime;  // read-only access for inspection
+}
+```
+
+**Plugin registration:** existing [src/plugins/types.ts:PluginType](../../src/plugins/types.ts) union gains `"prompt-section"`. The plugin loader ([src/plugins/loader.ts](../../src/plugins/loader.ts)) instantiates providers; `composeSections()` consumes them via `ComposeInput.extensions`.
+
+**Why this is enough:**
+
+- Section slot is fixed at `"extension"` — plugins cannot replace `role`, `task`, etc. No ordering wars with built-in sections.
+- Plugins with cross-cutting needs beyond prompts use the existing `IReporter`, `IContextProvider`, `IReviewPlugin`, or `IPostRunAction`. Nothing new required for observability, reporting, or review.
+- Full plugin API v2 (operation registration, middleware registration, etc.) is **not deferred** — it is explicitly **rejected** as speculative. If a concrete plugin use case surfaces that cannot be served by the 8 extension points, add a 9th. Don't pre-build a versioning system.
+
+---
+
+### 7. CI lint rules
+
+Two lint rules enforced at `bun run lint`:
+
+**Rule A — `process.cwd()` outside CLI entry points is an error.**
+
+- Permitted paths: `src/cli/**`, `src/commands/**`, `src/config/loader.ts` (bootstrap default).
+- Banned everywhere else, including `src/debate/session.ts:44`, `src/agents/acp/adapter.ts:884,895`, `src/precheck/index.ts:239`.
+- Fix in each site: require `workdir: string` as a parameter. Thread from `NaxRuntime.workdir` or `ctx.packageDir`.
+
+**Rule B — prompt builders' forbidden imports.**
+
+- `src/prompts/builders/**` may not import `ContextBundle`, `IContextEngine`, `loadConstitution`, `loadStaticRules`, `detectLanguage`, `resolveTestFilePatterns`, `process.cwd`, `Bun.cwd`.
+- Fix: add the field to `ComposeInput`; consume through the helper only.
+
+---
+
+### 8. `SessionRole` tightens
+
+```typescript
+// src/session/types.ts — amend existing union
+export type SessionRole =
+  | "main" | "test-writer" | "implementer" | "verifier"
+  | "plan" | "decompose" | "acceptance-gen" | "refine" | "fix-gen"
+  | "auto" | "diagnose" | "source-fix"
+  | "reviewer-semantic" | "reviewer-adversarial"
+  // Dynamic roles — admitted via template literals
+  | `debate-${string}`          // debate-proposal-0, debate-critique-1, debate-fallback
+  | `plan-${number}`;           // plan-0, plan-1, ...
+```
+
+And tighten `AgentRunOptions.sessionRole?: string` to `AgentRunOptions.sessionRole?: SessionRole`. Debate files ([session-one-shot.ts:85,159,209](../../src/debate/session-one-shot.ts#L85), [session-plan.ts:102](../../src/debate/session-plan.ts#L102), [session-helpers.ts:329,374](../../src/debate/session-helpers.ts#L329)) continue to construct strings inline — but now they're type-checked against the union. Introduce `deriveSessionRole()` helpers where the inline construction is noisy (e.g. `deriveDebateRole({ kind: "proposal", index: i })`).
+
+---
+
+### 9. `PackageRegistry` (thin)
+
+`NaxRuntime.packages` is a minimal cache:
+
+```typescript
+// src/runtime/packages.ts (new, ~60 lines)
+export interface PackageRegistry {
+  all(): readonly PackageView[];
+  get(packageDir: string): PackageView;
+  repo(): PackageView;  // fallback for cross-package operations
+}
+
+export interface PackageView {
+  readonly packageDir: string;
+  readonly relativeFromRoot: string;
+  readonly config: NaxConfig;                          // merged with .nax/mono/<pkg>/config.json
+  readonly testPatterns: ResolvedTestPatterns;
+  readonly language: DetectedLanguage;
+  readonly framework: TestFramework | null;
+}
+```
+
+Backed by existing detectors (`discoverWorkspacePackages`, `findPackageDir`, `detectLanguage`, `detectTestFramework`, `resolveTestFilePatterns`). Cache valid for the runtime's lifetime (config is frozen).
+
+`PackageView` threaded into `ComposeInput`; that closes #533 (`ctx.package.testPatterns.testDirs`), #534 (`ctx.package.testPatterns.globs`), #535 (`ctx.packageDir` required, no fallback), #536 (`ctx.package.language` enum).
+
+---
+
+## Architecture After ADR-017
+
+```
+NaxRuntime (per run / plan / standalone CLI invocation)
+  ├─ config, workdir, projectDir, signal
+  ├─ agentManager: IAgentManager        // ADR-012, ADR-013 — unchanged public interface;
+  │                                     //  runAs()/completeAs() gain internal envelope (permissions, cost, audit, error)
+  ├─ sessionManager: ISessionManager    // ADR-011 — unchanged
+  ├─ costTracker: CostTracker           // NEW — one per runtime
+  ├─ promptAuditor: IPromptAuditor      // NEW — flushes on close()
+  ├─ packages: PackageRegistry          // NEW — cached per-package views
+  └─ logger: Logger
+
+Prompt composition
+  ├─ Builders own slot-specific sections: role, task, examples, output-format
+  └─ composeSections(input) → readonly PromptSection[]
+       ├─ Materializes: constitution, context, static rules, monorepo hints, previous attempts
+       └─ Integrates: plugin-contributed "extension" slot sections
+
+Retry loop
+  └─ runRetryLoop<TFailure, TResult>(RetryInput) → RetryOutcome
+       ├─ buildPrompt(failure, previous) — caller-provided, uses composeSections
+       ├─ execute(prompt)                — caller-provided, typically runtime.agentManager.runAs
+       └─ verify(result)                 — caller-provided, stage-specific
+
+Escalation (unchanged location)
+  └─ src/execution/escalation/ — runs between stage retries, not inside retry loop
+
+Adapter surface
+  ├─ AgentAdapter.run(options)
+  └─ AgentAdapter.complete(prompt, options)
+     // .plan() and .decompose() REMOVED — now runPlan()/runDecompose() functions
+
+Plugin extensions (8 types)
+  ├─ optimizer, router, agent, reviewer, context-provider, reporter, post-run-action
+  └─ prompt-section  // NEW — contributes sections to ComposeInput.extensions
+```
+
+---
+
+## Consequences
+
+### Positive
+
+| Win | Mechanism |
+|:---|:---|
+| **#523 closes** | One `AgentManager` per run via `NaxRuntime`. Fallback, cost, audit uniform across routing → execution → rectification → debate. |
+| **Adapter surface shrinks permanently** | `run` + `complete`. New agents implement 2 methods. `.plan()` / `.decompose()` cannot leak back. |
+| **Cross-cutting uniform** | Permissions, cost, audit, error wrapping happen once in `AgentManager.runAs()`. The ACP adapter's three `resolvePermissions()` calls delete. |
+| **Prompt composition uniform** | `composeSections()` is the single assembly point. Constitution/context/static-rules injection consolidates. Rectifier builder drops from 720 → ~200 lines. |
+| **Monorepo violations close structurally** | `PackageView` threaded into `ComposeInput`. CI lint catches `process.cwd()` leaks. #533–#536 plus ≥5 additional sites fixed in one pass. |
+| **Retry inputs unify** | Five callers of `runSharedRectificationLoop` migrate to one `RetryInput` shape. Progressive composition is a callback parameter, not a new abstraction. |
+| **Plugin seam extends** | One new extension type (`prompt-section`) joins the existing 7. No plugin API v2 needed. |
+| **Zero new concept surface beyond needs** | ~5 new types (`NaxRuntime`, `CostTracker`, `RetryInput`, `RetryAttempt`, `ComposeInput`) vs ADR-014/015/016's ~24. |
+
+### Negative / Tradeoffs
+
+| Cost | Mitigation |
+|:---|:---|
+| `NaxRuntime` owns 5+ services — admission criteria informal | Explicitly documented: scope-bound lifecycle + used by ≥2 subsystems. Revisit if the field count exceeds ~8. |
+| Method-local envelope in `AgentManager.runAs()` — extension requires amending the method | Acceptable today. Cross-cutting extensions (budget, rate-limiting) add as internal method branches. Third parties extend via subscribers on `CostTracker` / `PromptAuditor`. |
+| No declarative `Operation` contract for plugins | Plugins extend via the existing 7 types (+ `prompt-section`). Contribute `AgentAdapter` implementations for new agents, `IReviewPlugin` for new reviewers, `IContextProvider` for context, `IPromptSectionProvider` for prompt sections. |
+| `SectionSlot` enum constrains ordering | Canonical — same slot model every builder uses. Non-canonical ordering cases require amending `SLOT_ORDER` + review. |
+| Migration spans 5 phases | Each phase is ~1–2 days of work, independently shippable, no inter-phase breakage. Total ~1200 LOC vs ~3000 LOC for ADR-014/015/016. |
+
+---
+
+## Migration Plan
+
+Five phases, each independently shippable and revertible.
+
+### Phase 1 — `NaxRuntime` + orphan consolidation
+
+- Introduce `src/runtime/index.ts` (`NaxRuntime` interface + `createRuntime` factory).
+- Introduce `CostTracker`, `PromptAuditor`, `PackageRegistry` as plain classes in `src/runtime/`.
+- Move `createAgentManager` from `src/agents/index.ts:29` to `src/runtime/internal/agent-manager-factory.ts`.
+- Migrate 7 orphan call sites: `_deps.createManager` fields → `_deps.runtime`.
+- Runner constructs runtime in `runSetupPhase()`, closes in `runCompletionPhase()`.
+- Thread `ctx.runtime: NaxRuntime` through `PipelineContext`.
+- **Exit criteria:** zero `createAgentManager` imports outside `src/runtime/`. `#523` reproducer: 401 on routing hits the same fallback chain as execution.
+- **Risk:** Low. Purely additive.
+
+### Phase 2 — `AgentManager.runAs()` envelope + adapter simplification
+
+- Amend `AgentManager.runAs()` / `completeAs()` to resolve permissions, tag cost, emit audit, wrap errors.
+- Add `AgentRunOptions.resolvedPermissions?: ResolvedPermissions`.
+- Delete the three `resolvePermissions()` calls in [src/agents/acp/adapter.ts:593,847,1036](../../src/agents/acp/adapter.ts#L593). Adapter reads `request.runOptions.resolvedPermissions`.
+- **Exit criteria:** zero `resolvePermissions()` calls inside `src/agents/acp/adapter.ts`. `CostTracker.snapshot()` reflects all agent calls including nested (rectification, debate proposers).
+- **Risk:** Low. Internal to the manager and adapter.
+
+### Phase 3 — `.plan()` / `.decompose()` → functions
+
+- Create `src/pipeline/plan/run-plan.ts` and `src/pipeline/decompose/run-decompose.ts`.
+- Migrate `nax plan` CLI and decompose callers.
+- Delete `AgentAdapter.plan()`, `AgentAdapter.decompose()`, `IAgentManager.planAs()`, `IAgentManager.decomposeAs()`.
+- Update adapter-boundary integration test to enforce 2-method surface.
+- **Exit criteria:** `AgentAdapter` has only `run` and `complete`. `nax plan` works end-to-end against existing fixtures.
+- **Risk:** Medium. Touches `nax plan` CLI; behavior parity required.
+
+### Phase 4 — `composeSections()` + builder migration
+
+- Introduce `src/prompts/compose.ts` (`ComposeInput`, `composeSections`, `join`, slot helpers).
+- Add `SectionSlot` + `SLOT_ORDER` to `src/prompts/core/types.ts`.
+- Migrate builders in impact-first order:
+  1. `rectifier-builder.ts` (biggest payoff — 720 → ~200 lines)
+  2. `review-builder.ts`, `adversarial-review-builder.ts`
+  3. `tdd-builder.ts`
+  4. `acceptance-builder.ts`
+  5. `debate-builder.ts`
+  6. `plan-builder.ts`, `decompose-builder.ts` (integrate with Phase 3's `runPlan`/`runDecompose`)
+  7. `one-shot-builder.ts`
+- Add CI lint rule for forbidden imports in `src/prompts/builders/**`.
+- **Exit criteria:** all builders produce slot-specific sections; no builder imports `ContextBundle`, `loadConstitution`, `loadStaticRules`.
+- **Risk:** Medium. Broad touch; each builder is independent.
+
+### Phase 5 — `RetryInput` unification + monorepo lint
+
+- Amend `runSharedRectificationLoop` to accept `RetryInput<TFailure, TResult>`; migrate 5 callers.
+- Delete per-caller wrappers (`runRectificationLoopFromCtx`, TDD's local `runRectificationLoop`).
+- Add CI lint rule for `process.cwd()` outside permitted paths.
+- Fix all flagged sites (≥5 beyond #533–#536): `src/debate/session.ts:44`, `src/agents/acp/adapter.ts:884,895`, `src/precheck/index.ts:239`, `src/commands/common.ts:82,85,98`.
+- Tighten `SessionRole` template-literal union; update debate files.
+- Add `IPromptSectionProvider` plugin type; loader wiring.
+- **Exit criteria:** one retry-loop input shape. Zero `process.cwd()` outside CLI. `SessionRole` admits debate/plan forms by type.
+- **Risk:** Low–Medium. Mechanical migrations; each site is small.
+
+**Rollback plan:** every phase is independently revertible. Phases 1–3 leave the adapter surface backwards-compatible during the window (deprecation path). Phases 4–5 touch production prompts; each builder PR lands independently so rollback is per-builder.
+
+---
+
+## Rejected Alternatives
+
+### A. Introduce `RunScope` + agent middleware chain + `Operation<I, O, C>` + `ISessionRunner` + `src/control/` + prompt middleware
+
+**Rejected — see ADR-014/015/016 for the full proposal; see this ADR's §Context for the review.** Summary: ~24 new types, three new directories, plugin API deferred three times, three interlocking ADRs with sequencing fragility. The pain points it addresses are real, but the codebase already contains partial forms (`PromptSection`, `shared-rectification-loop`, 7-type plugin system) that reach the same outcome with ~5 new types instead of 24.
+
+### B. Introduce `IPermissionTranslator` + `IPermissionTranslatorRegistry`
+
+**Rejected.** With ACP as the only transport today, the registry middleman buys test-injection and a plugin seam for translators that nobody is asking for. The adapter's wire mapping lives inside the adapter's own folder (where it already is). When a second transport arrives, add a `toWirePolicy(resolved)` method to `AgentAdapter`; the registry is one small refactor away if plugin-contributed translators materialize — but shipping it preemptively adds ceremony.
+
+### C. Prompt middleware chain with `PromptMiddleware.apply(sections) → sections`
+
+**Rejected.** Functional transformers over `readonly PromptSection[]` are elegant but the ownership registry, conflict errors at runtime, and phase-ordering invariants add operational complexity without concrete payoff. `composeSections()` as a total function is readable, testable, and extensible via one typed input (`extensions: readonly PromptSection[]`). Plugin contributions enter through `IPromptSectionProvider`.
+
+### D. Agent middleware chain with `AgentMiddleware.run(ctx, next)`
+
+**Rejected.** Method-local cross-cutting work in `AgentManager.runAs()` solves the same problems (uniform permissions, cost, audit) without a chain. Observer-vs-transformer invariants, per-middleware resilience rules, and chain ordering are complexity the codebase does not need. If a plugin needs mid-call interception one day, the manager method accepts an extension callback — one hook point, not a chain.
+
+### E. `ISessionRunner` abstraction over stages
+
+**Rejected.** Today's pipeline stages *are* the session-topology unit. `implement` stage opens one session; TDD is three related stages; debate is a multi-session loop in [src/debate/session.ts](../../src/debate/session.ts). Wrapping them in an `ISessionRunner` hierarchy and introducing `SingleSessionRunner` (a one-liner over `scope.invoke`) adds indirection for no gain. The multi-session cases (TDD, debate) stay where they are and keep their direct control over session choreography.
+
+### F. `Operation<I, O, C>` declarative contract
+
+**Rejected.** The contract's only concrete benefit is plugin operation registration — which is deferred three times across ADR-014/015/016 anyway. Plugins extend via the existing 7 types (+ the new `prompt-section`). Functions with parameters express the same semantics as `requires` + `execute` with less ceremony and less type gymnastics (no `ConfigSelector<C>`, no `OperationContext<C>` god context, no `scope.invoke()` envelope).
+
+### G. `src/control/` directory for escalation + retry + iteration
+
+**Rejected.** The layering already exists implicitly: `runner-execution.ts` iterates stages; `shared-rectification-loop` runs attempts within a stage; `src/execution/escalation/` decides between stages. Moving them into `src/control/` and adding an `IAgent`-import lint rule is pure taxonomy. Keep them where they live; fix the input shapes (Phase 5); done.
+
+### H. Plugin API v2 with operation registration
+
+**Rejected.** The 7 existing plugin types cover: custom agents (`agent`), reviewers (`reviewer`), context providers (`context-provider`), reporters (`reporter`), routers (`router`), optimizers (`optimizer`), post-run actions (`post-run-action`). One addition (`prompt-section`) covers prompt extensions. No concrete plugin need sits outside this set today. Build plugin API v2 when a third-party plugin author surfaces a use case that cannot fit — not speculatively.
+
+### I. `IAgent` as a new type distinct from `AgentAdapter`
+
+**Rejected.** `AgentAdapter` + `IAgentManager` already cover the space. Callers use `runtime.agentManager.runAs(name, request)`. Introducing a third agent-like type (`IAgent`) to sit between them creates three `getAgent()` methods with three return types — readability trap. Keep two types; don't add a third.
+
+### J. `scope.invoke(op, input, opts)` envelope
+
+**Rejected.** The envelope's nine internal steps (validate, resolve agent, slice config, resolve permissions, thread session identity, build logger, thread signal, execute, wrap errors) collapse into the body of `runPlan`, `runDecompose`, and similar plain functions. Each function's body is three to eight lines because the cross-cutting work already happens inside `AgentManager.runAs()`. A single envelope method forces every call site into the same mold; plain functions let each operation express its actual shape.
+
+---
+
+## Open Questions
+
+1. **`PromptSection.overridable` field.** Today's type has it; the new `SectionSlot` does not replace it. Keep as-is; no migration needed. Disk overrides remain a separate concern from slot composition.
+
+2. **Token budget enforcement.** Adding a per-run token budget that hard-aborts mid-rectification is trivial once `CostTracker` exposes a `currentTotal()` method. Not in scope for this ADR; `runRetryLoop`'s `verify` callback can return `{ success: false, reason: "budget-exhausted" }` when the caller detects budget overflow. No new abstraction required.
+
+3. **Session resume across runtime restarts.** A crashed run's `NaxRuntime` is gone; its persisted session descriptors can be reattached on next startup via `SessionManager.resume(descriptors)`. Exact contract inherits ADR-008's open question — unchanged by this ADR.
+
+4. **CostTracker + PromptAuditor disk schema.** `.nax/audit/<runId>.jsonl` and `.nax/cost/<runId>.jsonl` formats. Specified in Phase 2 implementation; not a blocker for ADR approval.
+
+5. **Plugin API versioning.** Explicitly deferred to "when a concrete use case surfaces." Not a 4th open question — a rejection (§H).
+
+---
+
+## References
+
+- **Superseded:** ADR-014 (RunScope and Middleware), ADR-015 (Operation Contract), ADR-016 (Prompt Composition and PackageView)
+- **Preserved invariants from:** ADR-008 (session lifecycle), ADR-011 (SessionManager ownership), ADR-012 (AgentManager ownership), ADR-013 (SessionManager → AgentManager hierarchy), ADR-009 (test-file pattern SSOT)
+- `docs/architecture/ARCHITECTURE.md` — subsystem index
+- `docs/architecture/agent-adapters.md` — adapter protocol (amended to 2-method surface in Phase 3)
+- `.claude/rules/forbidden-patterns.md` — Prompt Builder Convention (tightened by Phase 4)
+- `.claude/rules/monorepo-awareness.md` — rules made structural by Phase 5
+- Issues: [#523](https://github.com/nathapp-io/nax/issues/523) (fallback state divergence), [#533](https://github.com/nathapp-io/nax/issues/533)–[#536](https://github.com/nathapp-io/nax/issues/536) (monorepo violations)

--- a/docs/reviews/adr-014-016-split-review.md
+++ b/docs/reviews/adr-014-016-split-review.md
@@ -1,0 +1,320 @@
+# Review: ADR-014 / ADR-015 / ADR-016 split
+
+**Reviewer:** Claude (revised pass)
+**Date:** 2026-04-23
+**Subjects:**
+- `docs/adr/ADR-014-runscope-and-middleware.md`
+- `docs/adr/ADR-015-operation-contract.md`
+- `docs/adr/ADR-016-prompt-composition-and-packageview.md`
+
+---
+
+## TL;DR
+
+The split is a **strict improvement** over the monolithic ADR it replaces. Dependency chain (014 → 015 → 016) is clean, forward-references are honest, and several additions (`src/control/` directory, `CostErrorEvent`, functional prompt transformers, rejection of `child()` scope) are genuinely better than my original draft.
+
+**But the split should not ship as-is.** There are three architectural decisions still hiding as prose, plus eight smaller gaps. Without resolving them in the ADR text, migration Phase 1 will hit them mid-implementation and force rework.
+
+Severity legend:
+- **Blocker** — design decision not yet made; cannot implement from the current text.
+- **Gap** — decision made but plumbing incomplete; mechanical fix.
+- **Minor** — wording / framing; cosmetic.
+
+---
+
+## Blockers — must resolve before implementation
+
+### B1 — Agent middleware interface can't do what `permissions` claims
+
+**Where:** ADR-014 §2.
+
+**What the docs say:**
+
+```typescript
+run?(ctx: MiddlewareContext, next: () => Promise<AgentResult>): Promise<AgentResult>;
+```
+
+- `ctx` is `readonly`.
+- `next()` takes no arguments.
+
+Canonical middleware table row:
+> `permissions` | Resolve permission mode from stage + config, **apply to options** | Observer — reads stage, **enriches options**; does not mutate prompt
+
+**The problem:** there is no mechanism in the interface by which the `permissions` middleware can actually "apply to options" or "enrich options". The options cannot be mutated (readonly ctx), cannot be transformed and forwarded (args-less next), and aren't re-read from any side channel.
+
+**Three resolutions, each with consequences:**
+
+| # | Resolution | Consequence |
+|:---|:---|:---|
+| A | `next` accepts an `options` parameter; middleware transforms and passes forward | Middleware **are** transformers; "observer-only" invariant (order-independence) is false |
+| B | `permissions` isn't middleware — it's a pre-step before the chain that mutates `ctx.options` via a mutable field | Honest observer invariant; introduces a pre-chain layer |
+| C | Middleware writes resolved permissions to a scope service; adapter consults it by other means | New service; weakens "middleware is the interception layer" story |
+
+**Why this is a blocker:** the "observer-only" invariant in ADR-014 §2 is load-bearing — it's what justifies order-independence and frozen chain. If resolution (A) is picked, that invariant is false and Phase 2 ordering must be specified. If (B) or (C), the architecture diagram changes.
+
+**Recommended direction:** lean toward (A) — `next(options?)` signature — because real middleware (audit, cost) will eventually need to observe the *final* options the adapter sees, not the caller's unresolved options. Declare canonical order at that point.
+
+**Fix location:** ADR-014 §2 interface definition + invariant bullet.
+
+---
+
+### B2 — `OperationContext` should be a discriminated union
+
+**Where:** ADR-015 §1; ADR-016 §2.2.
+
+**What the docs say:**
+
+```typescript
+// ADR-015 §1
+readonly packageDir: string;  // "required for package-scoped ops"
+
+// ADR-016 §2.2 (amended)
+readonly packageDir: string;  // REQUIRED — no fallback
+readonly package: PackageView;
+readonly packages?: readonly PackageView[];  // cross-package ops
+```
+
+**The problem:** three invalid states are representable:
+
+1. `repo`-scoped op accesses `ctx.package` — compiles, wrong at runtime.
+2. `cross-package` op accesses `ctx.package` (singular) — compiles, wrong.
+3. `package`-scoped op accesses `ctx.packages` (plural) — compiles, wrong.
+
+**Concrete example from the ADR:** `decompose` in ADR-015 §4.2 declares `scope: "repo"` but its `execute()` reads `ctx.packageDir`:
+
+```typescript
+async execute(ctx, input) {
+  const prompt = await ctx.scope.promptComposer.compose(decomposeBuilder, input, {
+    stage: "decompose",
+    packageDir: ctx.packageDir,   // ← what packageDir does a repo-scoped op get?
+  });
+}
+```
+
+**Why this is a blocker:** the ADRs lean on type-level enforcement elsewhere ("lint-detectable", "CI errors", "structurally impossible"). Leaving `OperationContext` unenforced here contradicts the thesis.
+
+**Recommended shape:**
+
+```typescript
+type OperationContext<C> =
+  | { scope: "package";       packageDir: string; package: PackageView;         ... }
+  | { scope: "cross-package"; packages: readonly PackageView[];                  ... }
+  | { scope: "repo";          repoRoot: string;                                  ... };
+```
+
+With that shape, `decompose` cannot accidentally reach `ctx.package` — it has to decide explicitly.
+
+**Fix location:** ADR-015 §1 `OperationContext` definition; ADR-016 §2.2 amendment.
+
+---
+
+### B3 — Session creation ownership changed silently from ADR-013
+
+**Where:** ADR-015 §1.2 step 5; ADR-015 §2.
+
+**What ADR-013 established:**
+- `SingleSessionRunner` implements `ISessionRunner` → `sessionManager.runInSession()` × 1
+- `ThreeSessionRunner` → `sessionManager.runInSession()` × 3
+- `runInSession(sessionId, agentManager, request)` — caller supplies `sessionId`
+
+**What ADR-015 says:**
+
+> Step 5 of `scope.invoke()`: If `op.requires.session`, **create/reuse session** via `scope.sessionManager`; otherwise `ctx.session = undefined`.
+
+**The problem:** two unresolved questions emerge:
+
+1. **Where does `sessionId` come from inside `scope.invoke()`?** ADR-013's `runInSession` requires one. ADR-015 doesn't say whether `scope.invoke()` mints it, reads it from `InvokeOptions`, or something else.
+2. **"Create or reuse" — which?** The word choice is ambiguous and the answer matters:
+   - **Rectification loop** (ADR-015 §3.1) calls `scope.invoke(rectify, ...)` N times. N sessions or 1 reused?
+   - **TDD** (`ThreeSessionRunner`) calls `scope.invoke()` three times with three different ops. Three sessions (ADR-013's intent) or something else?
+
+**Why this is a blocker:** descriptor persistence, crash recovery, and resume semantics all depend on sessionId. Implementation cannot proceed without this decision.
+
+**Secondary implication:** ADR-015 makes `ISessionRunner` thinner than ADR-013 — session creation moves from runner to `scope.invoke()`. That architectural shift is real but unstated.
+
+**Recommended direction:**
+- `scope.invoke()` mints sessionId as `${runId}-${op.name}-${counter}` (default) OR reads from a new `InvokeOptions.sessionRole?: string` override for disambiguation.
+- Each `scope.invoke()` call with `requires.session: true` creates a new session by default. Reuse (e.g. debate continuation) is opt-in via `InvokeOptions.sessionId?`.
+- `ISessionRunner` becomes a sequencer, not a session creator. ADR-015 §2 should say so explicitly.
+
+**Fix location:** ADR-015 §1.2 (step 5), ADR-015 §2 (ISessionRunner role), ADR-015 §1 (`InvokeOptions` type).
+
+---
+
+## Gaps — mechanical, but need specifying
+
+### G1 — `rectify` doesn't thread `previousAttempts` into `PromptBuildContext`
+
+**Where:** ADR-015 §3.1; ADR-016 §1.5.
+
+**Mismatch:**
+- `RectifyInput.previousAttempts: RectifyAttempt[]` (ADR-015)
+- `PromptBuildContext.previousAttempts?: readonly PromptSection[]` (ADR-016)
+
+**Missing piece:** conversion from `RectifyAttempt` → `PromptSection`, and the call site in `rectify.execute()` that threads it.
+
+**Fix:**
+
+```typescript
+// ADR-015 §3.1 — update sample
+const prompt = await ctx.scope.promptComposer.compose(rectifierBuilder, input, {
+  stage: ctx.stage,
+  storyId: ctx.storyId,
+  packageDir: ctx.packageDir,
+  previousAttempts: input.previousAttempts.map(renderAttemptAsSection),
+});
+```
+
+Name `renderAttemptAsSection` (or equivalent) explicitly; reference from ADR-016 §1.5.
+
+---
+
+### G2 — Permissions resolution — single owner
+
+**Where:** ADR-014 §2 canonical middleware table; ADR-015 §1.2 step 4.
+
+**Downstream of B1.** Once B1 picks a resolution, remove the duplicate description. If (A) is chosen: ADR-015 step 4 describes the permissions middleware's work; the step is kept but reframed as "threads `op.requires.permissions` into `MiddlewareContext.stage`; the `permissions` middleware resolves and transforms options." If (B) or (C): step 4 stays as the owner; middleware bullet is rewritten.
+
+---
+
+### G3 — `rectify` loop uses direct `scope.invoke()`, not `SingleSessionRunner`
+
+**Where:** ADR-015 §2.1 (rule) vs §3.1 (implementation).
+
+**Mismatch:**
+- §2.1: "`SingleSessionRunner` (and its siblings) wraps operations with `requires.session: true`."
+- §3.1: `runRectificationLoop` calls `scope.invoke(rectify, ...)` directly — no `SingleSessionRunner` wrapping.
+
+**Either** the rule needs an exception for control-flow layers, **or** the loop should wrap rectify in `SingleSessionRunner`. Pick one.
+
+**Recommended direction:** exception — control-flow layers invoke ops directly because they're outside `src/operations/`. Runners exist for stage/plugin callers who want a standardized "op + session topology" bundle.
+
+---
+
+### G4 — Two paths to a wrapped agent
+
+**Where:** ADR-014 §Architecture.
+
+**What exists:**
+- `scope.agentManager.runAs(name, ...)` — middleware-wrapped (per the Architecture note)
+- `scope.getAgent(name).run(prompt, ...)` — middleware-wrapped (per §1)
+
+**Missing:** rationale for two surfaces. Is `scope.agentManager.runAs` a legacy/compat shim that disappears after ADR-015 migrations? Is `getAgent()` for new code only? Is one preferred over the other?
+
+**Recommended:** add a one-paragraph "migration path" note in ADR-014 saying `scope.agentManager.runAs` is the bridge for unmigrated stages; new code and operations use `scope.getAgent()` or `scope.invoke()`.
+
+---
+
+### G5 — `budget-truncate` owner-rule exception not explicit
+
+**Where:** ADR-016 §1.3.
+
+**Ownership rule** (§1.3): each `SectionId` has exactly one owner; duplicate emission → `PROMPT_SECTION_CONFLICT`.
+
+**Canonical middleware row:** `budget-truncate` "may modify any section's content" (no id).
+
+**Missing:** the content-modification exception isn't named in the ownership rule itself. Add a bullet: "Finalize-phase middleware may modify section content without changing ownership; at most one finalize-phase content modifier is permitted per chain."
+
+---
+
+### G6 — `PromptBuildContext.previousAttempts` visible to builders
+
+**Where:** ADR-016 §1.2, §1.5.
+
+**Issue:** `PromptBuildContext` exposes `previousAttempts` to **both** builders and middleware. Builders are expected not to render it (middleware owns `previous-attempts` section). But nothing type-prevents a builder from emitting a `previous-attempts` section, which would `PROMPT_SECTION_CONFLICT` at runtime.
+
+**Options:**
+1. Split: `BuilderBuildContext` vs `MiddlewareBuildContext`, builders get the narrower view.
+2. Keep single type; document that `previousAttempts` is middleware-only input. Accept runtime-only enforcement.
+
+**Recommended:** option (2) for simplicity — the runtime error is actionable and split types add a category without a concrete cost justification today.
+
+---
+
+### G7 — Routing file touched twice across ADR-014 P2 and ADR-015 P2
+
+**Where:** ADR-014 Phase 2 step 1; ADR-015 Phase 2 step 1.
+
+**What happens:**
+- ADR-014 P2: `router.ts` converts to `scope.getAgent(defaultAgent).complete(...)`.
+- ADR-015 P2: `router.ts` converts again to `scope.invoke(classifyRoute, input, opts)`.
+
+**Options:**
+1. Skip router in ADR-014 P2; let ADR-015 P2 do the whole migration in one step. Cost: orphan `createAgentManager` in routing survives until ADR-015 lands.
+2. Keep both migrations; accept double-touch. Benefit: #523 closes fully at end of ADR-014 regardless of ADR-015 timing.
+
+**Recommended:** option (2). #523 is high-value and ADR-015 could slip; better to close it in ADR-014 and accept the second touch.
+
+---
+
+### G8 — `plan` operation's `config.planner` may not exist in current schema
+
+**Where:** ADR-015 §4.1.
+
+```typescript
+config: (c) => ({ debate: c.debate, planner: c.planner }),
+```
+
+Needs actual schema inspection. If `planner` is a placeholder, rename to an actual config key (e.g. `c.plan` if that exists) or note it as a future field to add.
+
+---
+
+## Minor — wording / framing
+
+### M1 — Observer vs transformer framing
+
+Downstream of B1. After B1 is resolved, add a one-sentence callout in ADR-016 §1.3 distinguishing prompt middleware (functional transformers, by design) from agent middleware (whatever B1 settles on).
+
+### M2 — `IAgentManager` interface `runAs`/`completeAs` naming vs ADR-013
+
+ADR-013's listed interface shows `run(request)` / `complete(prompt, options)`. ADR-014 and ADR-015 reference `runAs(name, ...)` / `completeAs(name, prompt, ...)`. Likely ADR-013's listing was abbreviated and the real API has the `*As` variants. Verify against `src/agents/manager.ts`; if mismatch is real, update ADR-013's listing.
+
+### M3 — `RunOptions.mode`
+
+ADR-015 §4.1 uses `{ mode: "plan" }` on `agent.run()`. Either `RunOptions.mode` pre-exists (confirm in `src/agents/types.ts`) or needs one-line mention that it's added. Pre-exists is likely; just verify.
+
+---
+
+## What's right and should survive
+
+| Thing | Why it matters |
+|:---|:---|
+| Split dependency chain 014 → 015 → 016 | Each lands independently; Phase 1 of each is shippable without the next ADR |
+| Forward-reference discipline | Interim notes (e.g. rectify uses legacy builder until ADR-016 Phase 1) prevent blocked-on-future-ADR churn |
+| `src/control/` as a first-class directory with lint rule | Operation-vs-loop boundary becomes structural, not aspirational |
+| `CostErrorEvent` + `PromptAuditErrorEntry` as separate types | Avoids "model is required but sometimes absent" type problem |
+| Functional transformers (readonly in/out) for prompt middleware | Matches project immutability style; deterministic composition |
+| Rejected `child()` scope | Per-call `signal`/`logger`/`agentName` overrides cover debate + rectification without lifecycle questions |
+| `makeTestScope()` in Phase 1 | Tests have a landing pad from day one |
+| Section ownership model | Duplicate emission is an actionable runtime error, not a silent overwrite |
+| Rejected Anthropic `cache_control` as motivation | Honest acknowledgement that cache hit rate is low in practice; sections justified by progressive composition instead |
+| `ConfigSelector` keyof-array sugar | 95% case stops being a lambda |
+
+---
+
+## Revised recommendation
+
+**Don't start Phase 1 of ADR-014 until B1 is resolved.** Without a decision on middleware interface semantics, Phase 2 will rebuild the chain once implementation reveals the gap.
+
+**Don't start Phase 1 of ADR-015 until B2 and B3 are resolved.** The `OperationContext` shape and session-creation ownership are both on the critical path for operation migrations.
+
+**Sequence:**
+
+1. Resolve B1, B2, B3 in the ADR text. One-PR-per-blocker or batch — either works.
+2. Apply G1–G8 as a single cleanup PR on the ADRs.
+3. M1–M3 fold into step 2.
+4. Start Phase 1 of ADR-014.
+
+**Original three findings:** still valid. Now understood as downstream of the three blockers rather than independent issues. Don't fix G1–G3 in isolation — fix after blocker resolution so the framing is right.
+
+---
+
+## Discussion order for walking through
+
+When walking these one-by-one, I'd suggest the following order (not doc order — decision-value order):
+
+1. **B1** — makes or breaks the middleware model. Highest leverage.
+2. **B3** — session lifecycle decision that ripples through rectification, TDD, debate, resume.
+3. **B2** — type-safety fix; small decision, big correctness win.
+4. **G1–G8** — mechanical once blockers settle.
+5. **M1–M3** — cosmetic.


### PR DESCRIPTION
This pull request updates the status of three architectural decision records (ADRs) to "Reject" and includes a comprehensive rewrite and extension of ADR-015 to clarify the session runner model and debate operation structure. The changes standardize how session topologies and debate operations are composed and clarify the preservation of session primitives. Additionally, several rejected alternatives and clarifications are documented.

**Key changes:**

### ADR Status Updates

* Updated the status of `ADR-014`, `ADR-015`, and `ADR-016` from "Proposed" to "Reject", indicating these architectural proposals will not be adopted. [[1]](diffhunk://#diff-fe8b47a22a88fd5f92561cbf999d92b2de32144767acd7fec9acf7a461759087L3-R3) [[2]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cL3-R3) [[3]](diffhunk://#diff-86a39bb0b5271010380dadf6144335c0a0756068403877dae074de85e364396eL3-R3)

### Debate Operations and Session Runner Model

* Rewrote the debate session runner section to clarify that a single `DebateSessionRunner` class supports three internal modes (`one-shot`, `stateful`, `hybrid`) and is reused across both plan and review stages, instead of splitting into separate runner classes. The runner now orchestrates debate operations (`proposeCandidate`, `rebutCandidate`, `reviewDialogue`, `rankCandidates`) with clear separation between topology and operation content. [[1]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cL253-R350) [[2]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cL162-R171) [[3]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cL507-R608)

* Documented that session primitives (e.g., session IDs, ACP wire handles, session open/close policies) remain unchanged and are preserved as-is, with the runner and `scope.invoke()` now responsible for threading required options and roles. The `SessionRole` union is extended to cover debate-specific dynamic roles, fixing previous inline string construction bugs. [[1]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cL253-R350) [[2]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cL507-R608)

### Operation Contract and Control Flow

* Clarified the contract for operations and session runners, including how session identity and roles are threaded through `scope.invoke()` using `InvokeOptions` and `OperationRequires`, and how debated plan stages are composed using the runner and debate ops. [[1]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cR126-R128) [[2]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cL134-R143) [[3]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cR502-R505) [[4]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cR528-R548)

### Rejected Alternatives and Clarifications

* Added explicit rejections for several alternatives, including splitting debate runners by mode, minting session IDs inside `scope.invoke()`, and restricting `ConfigSelector` to lambda-only. These clarifications help document the rationale for the chosen architecture.

### Documentation and Table Updates

* Updated tables and diagrams to reflect the new session runner model and operation structure, making it clear how each runner and operation fits into the overall architecture for plan, review, and debate stages. [[1]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cL203-R214) [[2]](diffhunk://#diff-22fac17bdb5d1faf41699730fb3f51d80a77d58017483af35e6cec97dfd1073cL570-R668)

These changes collectively clarify the architecture for session runners, debate operations, and session management, while documenting the rejection of certain design paths and ensuring consistency in ADR status.