### PR TITLE
fix(autofix): extend scope-splitting to lint checks (#669)

### DIFF
--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -1,9 +1,13 @@
 /**
- * Scope-aware adversarial rectification helpers (#409).
+ * Scope-aware rectification helpers (#409, #669).
  *
- * When adversarial review flags issues in test files, the implementer session
- * cannot fix them (isolation constraint). These helpers classify adversarial
- * findings by file scope and route test-file findings to a test-writer session.
+ * When review flags issues in test files, the implementer session cannot fix them
+ * (isolation constraint). These helpers classify findings by file scope and route
+ * test-file findings to a test-writer session.
+ *
+ * Handles two input shapes:
+ * - Adversarial checks: structured `findings[]` with explicit file paths
+ * - Lint checks: raw CLI `output` text -- file paths extracted via regex heuristics
  */
 
 import type { IAgentManager } from "../../agents";
@@ -16,22 +20,43 @@ import type { ReviewCheckResult } from "../../review/types";
 import { isTestFile } from "../../test-runners";
 import type { PipelineContext } from "../types";
 
+// Known source-file extensions for lint output path extraction.
+const SOURCE_EXT_RE = /\.(ts|tsx|js|jsx|mjs|cjs|go|py|rs|rb|java|cs|cpp|c|h|swift|kt)$/;
+
 /**
- * Split adversarial findings in a check result into test-file vs source-file buckets.
- * Returns null for each bucket when there are no findings for that scope.
- *
- * @param check            - The adversarial review check result to split.
- * @param testFilePatterns - Configured test file globs (ADR-009). When undefined, falls back to
- *   the broad language-agnostic regex (Phase 1 backward-compat path).
+ * Extract unique file paths from raw lint CLI output.
+ * Handles ESLint stylish, ESLint compact, and Biome stylish formats.
+ * Returns empty array when output is empty or no recognisable paths are found.
  */
-export function splitAdversarialFindingsByScope(
+export function extractFilesFromLintOutput(output: string): string[] {
+  if (!output.trim()) return [];
+
+  const files = new Set<string>();
+
+  // Matches file paths at the start of a line (stylish headers) and path:line or
+  // path:line:col patterns (compact format). Covers absolute and relative forms.
+  const PATH_RE = /^[ \t]*((?:\/[\w./-]+|\.\.?\/[\w./-]+|[\w][\w-]*(?:\/[\w./-]+)+))(?::\d+)?(?::\d+)?(?:\s|:|$)/gm;
+
+  let startIndex = 0;
+  while (startIndex <= output.length) {
+    PATH_RE.lastIndex = startIndex;
+    const m = PATH_RE.exec(output);
+    if (m === null) break;
+    const candidate = m[1];
+    if (SOURCE_EXT_RE.test(candidate)) {
+      files.add(candidate);
+    }
+    startIndex = m.index + 1;
+  }
+
+  return Array.from(files);
+}
+
+function splitByStructuredFindings(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
-): {
-  testFindings: ReviewCheckResult | null;
-  sourceFindings: ReviewCheckResult | null;
-} {
-  if (check.check !== "adversarial" || !check.findings?.length) {
+): { testFindings: ReviewCheckResult | null; sourceFindings: ReviewCheckResult | null } {
+  if (!check.findings?.length) {
     return { testFindings: null, sourceFindings: null };
   }
 
@@ -40,17 +65,67 @@ export function splitAdversarialFindingsByScope(
 
   const toCheck = (findings: typeof testFs): ReviewCheckResult | null => {
     if (findings.length === 0) return null;
-    // Preserve the raw tool output from the original check — it may contain structured
-    // diagnostics, stack traces, or indented blocks that the agent needs for accurate
-    // diagnosis. Only `findings` is scoped; output carries the full reviewer context.
+    // Preserve the raw tool output -- it may contain structured diagnostics or stack traces
+    // that the agent needs for accurate diagnosis. Only `findings` is scoped.
     return { ...check, findings };
   };
 
   return { testFindings: toCheck(testFs), sourceFindings: toCheck(sourceFs) };
 }
 
+function splitByOutputParsing(
+  check: ReviewCheckResult,
+  testFilePatterns?: readonly string[],
+): { testFindings: ReviewCheckResult | null; sourceFindings: ReviewCheckResult | null } {
+  const files = extractFilesFromLintOutput(check.output);
+
+  if (files.length === 0) {
+    // Cannot classify by file -- conservative fallback: route to implementer if output is non-empty
+    if (check.output.trim()) {
+      return { testFindings: null, sourceFindings: check };
+    }
+    return { testFindings: null, sourceFindings: null };
+  }
+
+  const hasTest = files.some((f) => isTestFile(f, testFilePatterns));
+  const hasSource = files.some((f) => !isTestFile(f, testFilePatterns));
+
+  return {
+    testFindings: hasTest ? check : null,
+    sourceFindings: hasSource ? check : null,
+  };
+}
+
 /**
- * Run a test-writer session to fix adversarial review findings scoped to test files (#409).
+ * Split a check result into test-file vs source-file buckets for scope-aware routing.
+ * Returns null for each bucket when there are no findings for that scope.
+ *
+ * - Adversarial checks: splits structured `findings[]` by file path classification.
+ * - Lint checks: extracts file paths from raw `output` text and classifies.
+ * - All other check types: returns null/null (not routable by scope).
+ *
+ * @param check            - The review check result to split.
+ * @param testFilePatterns - Configured test file globs (ADR-009). Omit to use the
+ *   broad language-agnostic regex (Phase 1 backward-compat path).
+ */
+export function splitFindingsByScope(
+  check: ReviewCheckResult,
+  testFilePatterns?: readonly string[],
+): {
+  testFindings: ReviewCheckResult | null;
+  sourceFindings: ReviewCheckResult | null;
+} {
+  if (check.check === "adversarial") {
+    return splitByStructuredFindings(check, testFilePatterns);
+  }
+  if (check.check === "lint") {
+    return splitByOutputParsing(check, testFilePatterns);
+  }
+  return { testFindings: null, sourceFindings: null };
+}
+
+/**
+ * Run a test-writer session to fix review findings scoped to test files (#409).
  * Returns the cost incurred, or 0 if the agent is unavailable.
  *
  * @param keepOpen - Whether to keep the ACP session open after this call so subsequent
@@ -65,11 +140,11 @@ export async function runTestWriterRectification(
 ): Promise<number> {
   const logger = getLogger();
   const twPrompt = RectifierPromptBuilder.testWriterRectification(testWriterChecks, story);
-  // Use the TDD test-writer tier from config — consistent with how the TDD orchestrator
+  // Use the TDD test-writer tier from config -- consistent with how the TDD orchestrator
   // selects the tier for the test-writer session (tdd.orchestrator.ts:150).
   const defaultAgent = agentManager.getDefault();
   if (!defaultAgent) {
-    logger.warn("autofix", "Test-writer rectification skipped — no default agent", { storyId: ctx.story.id });
+    logger.warn("autofix", "Test-writer rectification skipped -- no default agent", { storyId: ctx.story.id });
     return 0;
   }
   const modelTier = ctx.rootConfig.tdd?.sessionTiers?.testWriter ?? "balanced";
@@ -95,7 +170,7 @@ export async function runTestWriterRectification(
     });
     return twResult.estimatedCost ?? 0;
   } catch {
-    logger.warn("autofix", "Test-writer rectification failed — proceeding with implementer", {
+    logger.warn("autofix", "Test-writer rectification failed -- proceeding with implementer", {
       storyId: ctx.story.id,
     });
     return 0;

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -34,7 +34,7 @@ import {
 } from "../../verification/shared-rectification-loop";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
-import { runTestWriterRectification, splitAdversarialFindingsByScope } from "./autofix-adversarial";
+import { runTestWriterRectification, splitFindingsByScope } from "./autofix-adversarial";
 
 const CLARIFY_REGEX = /^CLARIFY:\s*(.+)$/ms;
 /** Matches the REVIEW-003 reviewer contradiction escape hatch emitted by the implementer. */
@@ -163,13 +163,12 @@ export const autofixStage: PipelineStage = {
       if (
         failedChecks.length > 0 &&
         failedChecks.every((c) => {
-          if (c.check !== "adversarial") return false;
-          const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(c, testFilePatterns);
+          const { testFindings, sourceFindings } = splitFindingsByScope(c, testFilePatterns);
           return testFindings !== null && sourceFindings === null;
         })
       ) {
         const skippedFindingCount = failedChecks.flatMap((c) => c.findings ?? []).length;
-        logger.warn("autofix", "Adversarial review found test-file issues — skipped (no-test strategy)", {
+        logger.warn("autofix", "Review found test-file issues only — skipped (no-test strategy)", {
           storyId: ctx.story.id,
           skippedFindingCount,
         });
@@ -344,9 +343,10 @@ async function runAgentRectification(
   }
   const { agentManager } = ctx;
 
-  // #409: Split adversarial findings by file scope.
+  // #409 #669: Split findings by file scope.
   // Test-file findings cannot be fixed by the implementer (isolation constraint) —
   // route them to a separate test-writer rectification call before the implementer loop.
+  // Handles both adversarial checks (structured findings[]) and lint checks (raw output).
   let implementerChecks = failedChecks;
   let testWriterChecks: ReviewCheckResult[] = [];
 
@@ -355,17 +355,19 @@ async function runAgentRectification(
       ? ctx.rootConfig.execution.smartTestRunner?.testFilePatterns
       : undefined;
   for (const check of failedChecks) {
-    if (check.check === "adversarial" && check.findings?.length) {
-      const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check, stageTestFilePatterns);
-      if (testFindings) testWriterChecks = [...testWriterChecks, testFindings];
-      if (sourceFindings) {
-        // Use reference equality (c === check) rather than type matching so that multiple
-        // adversarial entries don't all get replaced with the last iteration's sourceFindings.
-        implementerChecks = implementerChecks.map((c) => (c === check ? sourceFindings : c));
-      } else {
-        // All adversarial findings are in test files — remove only this check from implementer
-        // checks using reference equality so other adversarial entries (if present) are not dropped.
-        implementerChecks = implementerChecks.filter((c) => c !== check);
+    if (check.check === "adversarial" || check.check === "lint") {
+      const { testFindings, sourceFindings } = splitFindingsByScope(check, stageTestFilePatterns);
+      // null/null means the check has no classifiable findings — leave implementerChecks unchanged.
+      if (testFindings || sourceFindings) {
+        if (testFindings) testWriterChecks = [...testWriterChecks, testFindings];
+        if (sourceFindings) {
+          // Use reference equality (c === check) rather than type matching so that multiple
+          // entries don't all get replaced with the last iteration's sourceFindings.
+          implementerChecks = implementerChecks.map((c) => (c === check ? sourceFindings : c));
+        } else {
+          // All findings are in test files — remove only this check from implementer checks.
+          implementerChecks = implementerChecks.filter((c) => c !== check);
+        }
       }
     }
   }
@@ -376,24 +378,24 @@ async function runAgentRectification(
     if (ctx.routing.testStrategy === "no-test") {
       // STRAT-001: no-test stories must not modify test files — skip test-writer session.
       // The execute()-level early exit handles the common case; this guard is a safety net
-      // for mixed failures (adversarial test-file + other checks) that bypass the early exit.
+      // for mixed failures (test-file checks + other checks) that bypass the early exit.
       logger.warn("autofix", "Skipping test-writer rectification (no-test strategy)", {
         storyId: ctx.story.id,
-        skippedFindingCount: testWriterChecks.flatMap((c) => c.findings ?? []).length,
+        checks: testWriterChecks.map((c) => c.check),
       });
     } else {
-      logger.info("autofix", "Routing test-file adversarial findings to test-writer session", {
+      logger.info("autofix", "Routing test-file findings to test-writer session", {
         storyId: ctx.story.id,
-        findingCount: testWriterChecks.flatMap((c) => c.findings ?? []).length,
+        checks: testWriterChecks.map((c) => c.check),
       });
       autofixCostAccum += await _autofixDeps.runTestWriterRectification(ctx, testWriterChecks, ctx.story, agentManager);
     }
   }
 
-  // If all adversarial findings were test-file scoped and no other checks failed,
+  // If all findings were test-file scoped and no other checks failed,
   // skip the implementer loop — return for recheck after test-writer fixed the issues.
   if (implementerChecks.length === 0) {
-    logger.info("autofix", "All adversarial findings routed to test-writer — skipping implementer loop", {
+    logger.info("autofix", "All findings routed to test-writer — skipping implementer loop", {
       storyId: ctx.story.id,
     });
     return { succeeded: false, cost: autofixCostAccum };

--- a/test/unit/pipeline/stages/autofix-adversarial.test.ts
+++ b/test/unit/pipeline/stages/autofix-adversarial.test.ts
@@ -1,20 +1,21 @@
 /**
- * Tests for autofix-adversarial helpers (#409 post-review fixes)
+ * Tests for autofix-adversarial helpers (#409, #669)
  *
  * Covers:
- * - splitAdversarialFindingsByScope: test-file vs source-file bucket classification
- * - Edge cases: no findings, all test, all source, mixed, file:undefined, non-adversarial check
- * - Raw output preservation — scoped check retains original check.output
+ * - extractFilesFromLintOutput: ESLint stylish/compact + Biome format parsing
+ * - splitFindingsByScope (replaces splitAdversarialFindingsByScope):
+ *   - Structured findings path (adversarial checks)
+ *   - Output parsing path (lint checks)
  * - runTestWriterRectification: success, agent unavailable, agent throws
  */
 
 import { describe, expect, mock, test, afterEach } from "bun:test";
 import {
-  splitAdversarialFindingsByScope,
+  extractFilesFromLintOutput,
+  splitFindingsByScope,
   runTestWriterRectification,
 } from "../../../../src/pipeline/stages/autofix-adversarial";
 import { isTestFile } from "../../../../src/test-runners";
-import { _autofixDeps } from "../../../../src/pipeline/stages/autofix";
 import { DEFAULT_CONFIG } from "../../../../src/config";
 import type { ReviewCheckResult } from "../../../../src/review/types";
 import type { PipelineContext } from "../../../../src/pipeline/types";
@@ -50,6 +51,17 @@ function makeAdversarialCheck(
   };
 }
 
+function makeLintCheck(output: string): ReviewCheckResult {
+  return {
+    check: "lint",
+    success: false,
+    command: "biome",
+    exitCode: 1,
+    output,
+    durationMs: 10,
+  };
+}
+
 function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
   return {
     config: DEFAULT_CONFIG as any,
@@ -66,7 +78,7 @@ function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// TEST_FILE_PATTERN
+// isTestFile (sanity check)
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("isTestFile", () => {
@@ -95,28 +107,100 @@ describe("isTestFile", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// splitAdversarialFindingsByScope
+// extractFilesFromLintOutput
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("splitAdversarialFindingsByScope", () => {
-  test("non-adversarial check → both buckets null", () => {
+describe("extractFilesFromLintOutput", () => {
+  test("empty string → empty array", () => {
+    expect(extractFilesFromLintOutput("")).toEqual([]);
+  });
+
+  test("whitespace-only string → empty array", () => {
+    expect(extractFilesFromLintOutput("   \n  \n")).toEqual([]);
+  });
+
+  test("unparseable output (no file paths) → empty array", () => {
+    const output = "Lint failed\nSome warnings\nPlease fix the errors above\n";
+    expect(extractFilesFromLintOutput(output)).toEqual([]);
+  });
+
+  test("ESLint stylish format — file header line", () => {
+    const output = `
+src/foo.test.ts
+  1:5   error  Non-null assertion  @typescript-eslint/no-non-null-assertion
+`.trim();
+    const files = extractFilesFromLintOutput(output);
+    expect(files).toContain("src/foo.test.ts");
+  });
+
+  test("Biome stylish format — path:line:col prefix", () => {
+    const output = `
+src/entity-store.integration.spec.ts:232:26 lint/suspicious/noNonNullAssertion ━━━━━
+  ✖ Non-null assertion operator is forbidden.
+  232 │ const result = store.search(projectId, "foo")!;
+`.trim();
+    const files = extractFilesFromLintOutput(output);
+    expect(files).toContain("src/entity-store.integration.spec.ts");
+  });
+
+  test("ESLint compact format — path:line:col: severity", () => {
+    const output = "src/foo.test.ts:1:5: error  Non-null assertion  @typescript-eslint/no-non-null-assertion";
+    const files = extractFilesFromLintOutput(output);
+    expect(files).toContain("src/foo.test.ts");
+  });
+
+  test("multiple test files deduplicated", () => {
+    const output = `
+src/foo.test.ts:1:5 lint/error
+src/foo.test.ts:2:8 lint/error
+src/bar.spec.ts:10:3 lint/error
+`.trim();
+    const files = extractFilesFromLintOutput(output);
+    expect(files).toContain("src/foo.test.ts");
+    expect(files).toContain("src/bar.spec.ts");
+    // deduplicated — foo.test.ts appears only once
+    expect(files.filter((f) => f === "src/foo.test.ts")).toHaveLength(1);
+  });
+
+  test("mixed test and source files extracted", () => {
+    const output = `
+src/service.ts:10:3 lint/error message
+test/unit/service.test.ts:5:1 lint/error message
+`.trim();
+    const files = extractFilesFromLintOutput(output);
+    expect(files).toContain("src/service.ts");
+    expect(files).toContain("test/unit/service.test.ts");
+  });
+
+  test("absolute paths extracted", () => {
+    const output = "/home/user/project/src/foo.test.ts:5:3 lint/error message";
+    const files = extractFilesFromLintOutput(output);
+    expect(files).toContain("/home/user/project/src/foo.test.ts");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// splitFindingsByScope — structured findings path (adversarial checks)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("splitFindingsByScope — structured findings path", () => {
+  test("non-LLM check (typecheck) → both buckets null", () => {
     const check: ReviewCheckResult = {
-      check: "lint",
+      check: "typecheck",
       success: false,
-      command: "biome",
+      command: "tsc",
       exitCode: 1,
-      output: "lint error",
+      output: "type error",
       durationMs: 10,
-      findings: [makeFinding("src/foo.test.ts")],
     };
-    const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
     expect(testFindings).toBeNull();
     expect(sourceFindings).toBeNull();
   });
 
   test("adversarial check with no findings → both buckets null", () => {
     const check = makeAdversarialCheck([]);
-    const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
     expect(testFindings).toBeNull();
     expect(sourceFindings).toBeNull();
   });
@@ -130,7 +214,7 @@ describe("splitAdversarialFindingsByScope", () => {
       output: "output",
       durationMs: 10,
     };
-    const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
     expect(testFindings).toBeNull();
     expect(sourceFindings).toBeNull();
   });
@@ -138,7 +222,7 @@ describe("splitAdversarialFindingsByScope", () => {
   test("all test-file findings → testFindings non-null, sourceFindings null", () => {
     const findings = [makeFinding("src/auth.test.ts"), makeFinding("test/unit/foo.spec.ts")];
     const check = makeAdversarialCheck(findings);
-    const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
     expect(testFindings).not.toBeNull();
     expect(testFindings!.findings).toHaveLength(2);
     expect(sourceFindings).toBeNull();
@@ -147,7 +231,7 @@ describe("splitAdversarialFindingsByScope", () => {
   test("all source-file findings → sourceFindings non-null, testFindings null", () => {
     const findings = [makeFinding("src/auth.ts"), makeFinding("src/utils/helpers.ts")];
     const check = makeAdversarialCheck(findings);
-    const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
     expect(testFindings).toBeNull();
     expect(sourceFindings).not.toBeNull();
     expect(sourceFindings!.findings).toHaveLength(2);
@@ -161,7 +245,7 @@ describe("splitAdversarialFindingsByScope", () => {
       makeFinding("test/unit/auth.spec.ts"),
     ];
     const check = makeAdversarialCheck(findings);
-    const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
 
     expect(testFindings!.findings).toHaveLength(2);
     expect(testFindings!.findings!.map((f) => f.file)).toEqual(["src/auth.test.ts", "test/unit/auth.spec.ts"]);
@@ -172,7 +256,7 @@ describe("splitAdversarialFindingsByScope", () => {
   test("finding with file:undefined is treated as source-file (non-test)", () => {
     const finding: ReviewFinding = { ruleId: "r", severity: "error", file: undefined as any, line: 1, message: "m" };
     const check = makeAdversarialCheck([finding]);
-    const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
     expect(testFindings).toBeNull();
     expect(sourceFindings).not.toBeNull();
     expect(sourceFindings!.findings).toHaveLength(1);
@@ -182,7 +266,7 @@ describe("splitAdversarialFindingsByScope", () => {
     const rawOutput = "adversarial tool raw output with stack trace\n  at line 42\n  at line 100";
     const findings = [makeFinding("src/foo.ts"), makeFinding("src/foo.test.ts")];
     const check = makeAdversarialCheck(findings, rawOutput);
-    const { testFindings, sourceFindings } = splitAdversarialFindingsByScope(check);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
 
     expect(testFindings!.output).toBe(rawOutput);
     expect(sourceFindings!.output).toBe(rawOutput);
@@ -191,8 +275,77 @@ describe("splitAdversarialFindingsByScope", () => {
   test("scoped check exitCode is inherited from parent check", () => {
     const findings = [makeFinding("src/foo.ts")];
     const check = makeAdversarialCheck(findings);
-    const { sourceFindings } = splitAdversarialFindingsByScope(check);
+    const { sourceFindings } = splitFindingsByScope(check);
     expect(sourceFindings!.exitCode).toBe(check.exitCode);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// splitFindingsByScope — lint output parsing path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("splitFindingsByScope — lint output path", () => {
+  test("lint check with empty output → both buckets null", () => {
+    const check = makeLintCheck("");
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings).toBeNull();
+    expect(sourceFindings).toBeNull();
+  });
+
+  test("lint check with unparseable output → conservative: sourceFindings non-null, testFindings null", () => {
+    const check = makeLintCheck("Lint failed with unknown format\nPlease check your code");
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings).toBeNull();
+    expect(sourceFindings).not.toBeNull();
+  });
+
+  test("lint check with all test-file paths → testFindings non-null, sourceFindings null", () => {
+    const output = `
+src/entity-store.integration.spec.ts:232:26 lint/style/noNonNullAssertion
+src/entity-store.integration.spec.ts:247:18 lint/style/noNonNullAssertion
+test/unit/foo.test.ts:10:5 lint/style/noNonNullAssertion
+`.trim();
+    const check = makeLintCheck(output);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings).not.toBeNull();
+    expect(sourceFindings).toBeNull();
+  });
+
+  test("lint check with all source-file paths → sourceFindings non-null, testFindings null", () => {
+    const output = `
+src/service.ts:10:3 lint/style/useConst
+src/utils/helpers.ts:25:1 lint/style/useConst
+`.trim();
+    const check = makeLintCheck(output);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings).toBeNull();
+    expect(sourceFindings).not.toBeNull();
+  });
+
+  test("lint check with mixed paths → both buckets non-null", () => {
+    const output = `
+src/service.ts:10:3 lint/style/useConst
+src/service.test.ts:5:1 lint/style/noNonNullAssertion
+`.trim();
+    const check = makeLintCheck(output);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings).not.toBeNull();
+    expect(sourceFindings).not.toBeNull();
+  });
+
+  test("lint scoped checks carry the original full output (agent needs full context)", () => {
+    const output = "src/foo.test.ts:1:5 lint/style/noNonNullAssertion\n  ✖ Non-null assertion";
+    const check = makeLintCheck(output);
+    const { testFindings } = splitFindingsByScope(check);
+    expect(testFindings!.output).toBe(output);
+  });
+
+  test("lint check is not a structured-findings split — testFindings.findings is undefined", () => {
+    const output = "src/foo.test.ts:1:5 lint/style/noNonNullAssertion";
+    const check = makeLintCheck(output);
+    const { testFindings } = splitFindingsByScope(check);
+    expect(testFindings).not.toBeNull();
+    expect(testFindings!.findings).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `extractFilesFromLintOutput` — regex-based file path extraction from ESLint stylish/compact and Biome output formats
- Replaces `splitAdversarialFindingsByScope` with `splitFindingsByScope` — unified scope-splitter that handles both adversarial (structured `findings[]`) and lint (raw `output` text) checks
- Updates `autofix.ts` call sites: STRAT-001 early-exit guard and the main scope-routing loop now handle both adversarial and lint checks

**Root cause fixed (US-003 ISSUE-1):** Lint failures from test files (e.g. `@typescript-eslint/no-non-null-assertion` firing on `*.spec.ts`) previously routed to the implementer, which is constitutionally prohibited from modifying test files. This caused UNRESOLVED signals and unnecessary tier escalation. Test-only lint failures now route to the test-writer session.

**Fallback behaviour:** unparseable lint output conservatively routes to the implementer (not discarded). A `null/null` split (no classifiable findings) leaves `implementerChecks` unchanged.

## Test plan

- [x] New `describe("extractFilesFromLintOutput")` — ESLint stylish, Biome, compact, multi-file, absolute paths, empty/unparseable
- [x] New `describe("splitFindingsByScope — lint output path")` — all-test, all-source, mixed, empty, unparseable, output preservation
- [x] Existing adversarial tests updated to call `splitFindingsByScope` (same behaviour preserved)
- [x] `autofix-noop.test.ts` regression — null/null guard in routing loop prevents removing unclassifiable checks from `implementerChecks`
- [x] Full test suite green (5398 tests, 0 failures)
- [x] Typecheck + Biome lint clean