### PR TITLE
fix(review): default semantic diffMode to ref

### DIFF
--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -295,10 +295,10 @@ const SemanticReviewConfigSchema = z.object({
   modelTier: ModelTierSchema.default("balanced"),
   /**
    * How the semantic reviewer accesses the git diff.
-   * "embedded" (default): pre-collected diff truncated at 50KB and embedded in prompt.
-   * "ref": only stat summary + storyGitRef passed; reviewer fetches full diff via tools.
+   * "embedded": pre-collected diff truncated at 50KB and embedded in prompt.
+   * "ref" (default): only stat summary + storyGitRef passed; reviewer fetches full diff via tools.
    */
-  diffMode: z.enum(["embedded", "ref"]).default("embedded"),
+  diffMode: z.enum(["embedded", "ref"]).default("ref"),
   /**
    * When true, clears storyGitRef on failed stories during re-run initialization so
    * the ref is re-captured at the next story start. Prevents cross-story diff pollution
@@ -1003,7 +1003,7 @@ export const NaxConfigSchema = z
       blockingThreshold: "error",
       semantic: {
         modelTier: "balanced",
-        diffMode: "embedded",
+        diffMode: "ref",
         resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -296,7 +296,7 @@ export async function runReview(
       };
       const semanticCfg = config.semantic ?? {
         modelTier: "balanced" as const,
-        diffMode: "embedded" as const,
+        diffMode: "ref" as const,
         resetRefOnRerun: false,
         rules: [] as string[],
         timeoutMs: 600_000,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -165,7 +165,7 @@ export async function runSemanticReview(
     };
   }
 
-  const diffMode = semanticConfig.diffMode ?? "embedded";
+  const diffMode = semanticConfig.diffMode ?? "ref";
   logger?.info("review", "Running semantic check", {
     storyId: story.id,
     modelTier: semanticConfig.modelTier,

--- a/test/unit/config/semantic-review.test.ts
+++ b/test/unit/config/semantic-review.test.ts
@@ -111,7 +111,7 @@ describe("ReviewConfig semantic field", () => {
     if (result.success) {
       expect(result.data.review.semantic).toEqual({
         modelTier: "balanced",
-        diffMode: "embedded",
+        diffMode: "ref",
         resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
@@ -227,7 +227,7 @@ describe("DEFAULT_CONFIG.review.semantic", () => {
   test("DEFAULT_CONFIG.review.semantic has correct defaults", () => {
     expect(DEFAULT_CONFIG.review.semantic).toEqual({
       modelTier: "balanced",
-      diffMode: "embedded",
+      diffMode: "ref",
       resetRefOnRerun: false,
       rules: [],
       timeoutMs: 600_000,


### PR DESCRIPTION
## Summary

- Changes semantic review `diffMode` default from `"embedded"` to `"ref"` in 4 places: Zod schema, the `ReviewConfigSchema.default({...})` object, the `runReview` fallback literal, and the `runSemanticReview` fallback guard
- Ref mode passes `storyGitRef` + stat summary to the reviewer, which self-serves the full diff via `git diff` tool calls — no 50KB cap

## Background

Root cause from US-003 run analysis (ISSUE-2): `embedded` mode pre-collects and truncates the diff at 50KB. When a story escalates through tiers, the cumulative `storyGitRef..HEAD` diff grows large (balanced-tier implementation + powerful-tier incremental changes). The reviewer only sees the truncated fragment and reports false-positive "not found in diff" errors on code that was committed in earlier tier attempts.

Both modes use the same `storyGitRef` baseline — the difference is delivery only. `ref` mode has no size cap and is already the adversarial reviewer's default.

## Test plan

- [ ] `bun run test` — all tests pass (856 review + config tests, 0 fail)
- [ ] `test/unit/config/semantic-review.test.ts` — default snapshot updated to `"ref"`, all 17 pass
- [ ] Existing tests that explicitly set `diffMode: "embedded"` continue to cover the embedded code path (unchanged)