### PR TITLE
fix(review): condensed retry on truncated adversarial JSON response

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -42,7 +42,7 @@ import type { AgentRegistryEntry } from "./types";
 // Constants
 // ─────────────────────────────────────────────────────────────────────────────
 
-const MAX_AGENT_OUTPUT_CHARS = 5000;
+export const MAX_AGENT_OUTPUT_CHARS = 5000;
 const INTERACTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 min for human to respond
 const CONTEXT_TOOL_CALL_PATTERN = /<nax_tool_call\s+name="([^"]+)">\s*([\s\S]*?)\s*<\/nax_tool_call>/i;
 

--- a/src/agents/acp/index.ts
+++ b/src/agents/acp/index.ts
@@ -2,7 +2,7 @@
  * ACP Agent Adapter — barrel exports
  */
 
-export { AcpAgentAdapter, _acpAdapterDeps, _fallbackDeps } from "./adapter";
+export { AcpAgentAdapter, _acpAdapterDeps, _fallbackDeps, MAX_AGENT_OUTPUT_CHARS } from "./adapter";
 export { createSpawnAcpClient } from "./spawn-client";
 export { parseAgentError } from "./parse-agent-error";
 export { writePromptAudit, findNaxProjectRoot, _promptAuditDeps } from "./prompt-audit";

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -134,6 +134,15 @@ ${SEMANTIC_OUTPUT_SCHEMA}`;
       "The object must start with { and end with }."
     );
   }
+
+  /**
+   * Follow-up prompt when the previous response was truncated mid-JSON.
+   * Asking the same question again produces the same long output; instead
+   * ask for a condensed summary capped at maxFindings to fit within limits.
+   */
+  static jsonRetryCondensed(maxFindings = 3): string {
+    return `Your previous response was truncated and could not be parsed as valid JSON.\nRespond with a condensed summary: at most ${maxFindings} findings, highest severity first.\nOutput ONLY a complete, valid JSON object. It must start with { and end with }.\nSchema: {"passed": boolean, "findings": [{"severity": string, "category": string, "file": string, "line": number, "issue": string, "suggestion": string}]}`;
+  }
 }
 
 // ─── Private helpers ──────────────────────────────────────────────────────────

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -14,7 +14,7 @@
  */
 
 import type { IAgentManager } from "../agents";
-import { computeAcpHandle } from "../agents/acp/adapter";
+import { MAX_AGENT_OUTPUT_CHARS, computeAcpHandle } from "../agents/acp/adapter";
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config/schema-types";
@@ -71,6 +71,19 @@ function parseAdversarialResponse(raw: string): AdversarialLLMResponse | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Returns true when the raw response was almost certainly truncated by the
+ * ACP adapter's MAX_AGENT_OUTPUT_CHARS tail-truncation cap.
+ *
+ * The adapter keeps the LAST N chars (tail truncation), so a truncated response
+ * ends at the cap boundary — not at a natural JSON close. Checking for a near-cap
+ * length is more reliable than heuristics on the string content, since the tail
+ * may start anywhere inside the JSON and may or may not end with `}`.
+ */
+export function looksLikeTruncatedJson(raw: string): boolean {
+  return raw.trimEnd().length >= MAX_AGENT_OUTPUT_CHARS - 100;
 }
 
 /** Format findings into readable text output. */
@@ -333,18 +346,23 @@ export async function runAdversarialReview(
     };
   }
 
-  // Retry once when the response cannot be parsed — the session has full context so
-  // a short follow-up asking for valid JSON is sufficient.
-  if (!parseAdversarialResponse(rawResponse)) {
+  // Detect cap truncation before attempting parse — the ACP adapter tail-truncates
+  // output at MAX_AGENT_OUTPUT_CHARS, so a near-cap response is corrupted JSON and
+  // parsing it is pointless. Go straight to condensed retry in that case.
+  // For short unparseable responses (model misbehaved), use the standard retry.
+  const isTruncated = looksLikeTruncatedJson(rawResponse);
+  if (isTruncated || !parseAdversarialResponse(rawResponse)) {
     retryAttempted = true;
+    const retryPrompt = isTruncated ? ReviewPromptBuilder.jsonRetryCondensed() : ReviewPromptBuilder.jsonRetry();
     logger?.info("adversarial", "JSON parse failed, retrying (1/1)", {
       storyId: story.id,
       rawHead: rawResponse.slice(0, 200),
       responseLen: rawResponse.length,
+      isTruncated,
     });
     try {
       const retryResult = await agentManager.run({
-        runOptions: { prompt: ReviewPromptBuilder.jsonRetry(), ...runOpts, keepOpen: false },
+        runOptions: { prompt: retryPrompt, ...runOpts, keepOpen: false },
       });
       rawResponse = retryResult.output;
       llmCost += retryResult.estimatedCost ?? 0;

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -429,3 +429,94 @@ describe("runAdversarialReview — retry logging", () => {
     expect(exhaustLog?.data?.retries).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Truncation detection — condensed retry prompt
+// ---------------------------------------------------------------------------
+
+// The ACP adapter tail-truncates output at MAX_AGENT_OUTPUT_CHARS (5000 chars).
+// looksLikeTruncatedJson() fires when the response length is within 100 chars of
+// that cap, indicating the tail was cut off mid-stream.
+const AT_CAP_UNPARSEABLE = "x".repeat(4950); // 4950 chars — within 100 of 5000 cap, not valid JSON
+
+
+describe("runAdversarialReview — truncation-detected condensed retry", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("uses condensed retry prompt when response length is at the ACP output cap", async () => {
+    const agentManager = makeMultiCallAgentManager([AT_CAP_UNPARSEABLE, PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, agentManager);
+
+    const calls = (agentManager.getAgent("claude").run as ReturnType<typeof mock>).mock.calls;
+    const retryPrompt = (calls[1][0] as Record<string, unknown>).prompt as string;
+    expect(retryPrompt).toContain("truncated");
+  });
+
+  test("uses standard retry prompt when response is short unparseable text (not at cap)", async () => {
+    const nonJson = "here is my analysis: the code looks fine overall";
+    const agentManager = makeMultiCallAgentManager([nonJson, PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, agentManager);
+
+    const calls = (agentManager.getAgent("claude").run as ReturnType<typeof mock>).mock.calls;
+    const retryPrompt = (calls[1][0] as Record<string, unknown>).prompt as string;
+    expect(retryPrompt).not.toContain("truncated");
+  });
+
+  test("condensed retry prompt caps findings — prompt mentions a number limit", async () => {
+    const agentManager = makeMultiCallAgentManager([AT_CAP_UNPARSEABLE, PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, agentManager);
+
+    const calls = (agentManager.getAgent("claude").run as ReturnType<typeof mock>).mock.calls;
+    const retryPrompt = (calls[1][0] as Record<string, unknown>).prompt as string;
+    expect(retryPrompt).toMatch(/\d+ finding/);
+  });
+
+  test("succeeds when condensed retry returns valid JSON after cap-length truncation", async () => {
+    const condensedResponse = JSON.stringify({
+      passed: false,
+      findings: [{ severity: "error", category: "abandonment", file: "src/foo.ts", line: 1, issue: "missing impl", suggestion: "add it" }],
+    });
+    const agentManager = makeMultiCallAgentManager([AT_CAP_UNPARSEABLE, condensedResponse]);
+
+    const result = await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, agentManager);
+
+    expect(result.success).toBe(false);
+    expect(result.findings).toHaveLength(1);
+  });
+
+  test("logs isTruncated:true when response length is at the ACP output cap", async () => {
+    const logger = makeLogger();
+    const loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    const agentManager = makeMultiCallAgentManager([AT_CAP_UNPARSEABLE, PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, agentManager);
+
+    const parseFailLog = logger.infoCalls.find((c) => c.message.includes("JSON parse failed"));
+    expect(parseFailLog?.data?.isTruncated).toBe(true);
+
+    loggerSpy.mockRestore();
+  });
+
+  test("logs isTruncated:false when response is short unparseable text (not at cap)", async () => {
+    const logger = makeLogger();
+    const loggerSpy = spyOn(loggerModule, "getSafeLogger").mockReturnValue(logger as never);
+
+    const agentManager = makeMultiCallAgentManager(["not json text", PASSING_RESPONSE]);
+
+    await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, agentManager);
+
+    const parseFailLog = logger.infoCalls.find((c) => c.message.includes("JSON parse failed"));
+    expect(parseFailLog?.data?.isTruncated).toBe(false);
+
+    loggerSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes #675

## Summary

- Export `MAX_AGENT_OUTPUT_CHARS` from `src/agents/acp/adapter.ts` and re-export from the barrel
- Add `looksLikeTruncatedJson(raw)` — fires when response length is within 100 chars of the 5000-char ACP output cap (tail truncation)
- Add `ReviewPromptBuilder.jsonRetryCondensed(maxFindings = 3)` — retry prompt that explicitly caps output at 3 findings (highest severity first) to fit within limits
- Detect truncation **before** the parse attempt — skip the pointless parse on known-corrupted output and go straight to condensed retry; standard `jsonRetry()` preserved for short genuinely-unparseable responses

## Background

ISSUE-7 from US-003 run analysis: the ACP adapter tail-truncates all `run()` output at 5000 chars. When the adversarial reviewer produced a large findings JSON, the response was silently corrupted. The existing retry asked the model to reformat — it regenerated the same large output and truncated again. Both attempts failed to parse and fell back to fail-open, masking whether rectification had actually fixed the issues.

## Test plan

- [ ] `timeout 30 bun test test/unit/review/adversarial-retry.test.ts --timeout=5000` — all 21 tests pass (6 new tests cover truncation detection, condensed prompt selection, and `isTruncated` logging)
- [ ] `timeout 60 bun test test/unit/review/ test/unit/agents/ test/unit/prompts/ --timeout=10000` — 1289 pass, 0 fail