### PR TITLE
[codex] Fix review failureReason logging

### DIFF
--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -113,6 +113,18 @@ function buildReviewSummary(checks: ReviewCheckResult[]): ReviewResult["reviewSu
   return summary;
 }
 
+function formatFailureReason(check: ReviewCheckResult): string {
+  return check.check === "semantic" || check.check === "adversarial"
+    ? `${check.check} failed`
+    : `${check.check} failed (exit code ${check.exitCode})`;
+}
+
+function buildFailureReason(checks: ReviewCheckResult[]): string | undefined {
+  const failedChecks = checks.filter((check) => !check.success);
+  if (failedChecks.length === 0) return undefined;
+  return failedChecks.map(formatFailureReason).join(", ");
+}
+
 export class ReviewOrchestrator {
   /** Run built-in checks + plugin reviewers. Returns unified result. */
   async review(
@@ -333,12 +345,7 @@ export class ReviewOrchestrator {
       const allChecks = [...mechanicalResult.checks, ...llmCheckResults];
       const mechanicalPassed = mechanicalResult.success;
       const llmPassed = llmCheckResults.every((c) => c.success);
-      const firstFailure = allChecks.find((c) => !c.success);
-      const failureReason = firstFailure
-        ? firstFailure.check === "semantic" || firstFailure.check === "adversarial"
-          ? `${firstFailure.check} failed`
-          : `${firstFailure.check} failed (exit code ${firstFailure.exitCode})`
-        : undefined;
+      const failureReason = buildFailureReason(allChecks);
 
       // Build per-reviewer finding summary from LLM check results
       const reviewSummary = buildReviewSummary(llmCheckResults);

--- a/test/unit/review/orchestrator.test.ts
+++ b/test/unit/review/orchestrator.test.ts
@@ -338,6 +338,10 @@ function makePassedCheck(check: "semantic" | "adversarial"): ReviewCheckResult {
   return { check, success: true, command: "", exitCode: 0, output: "", durationMs: 50 };
 }
 
+function makeFailedCheck(check: "semantic" | "adversarial"): ReviewCheckResult {
+  return { check, success: false, command: "", exitCode: 1, output: `${check} failed`, durationMs: 50 };
+}
+
 describe("ReviewOrchestrator — retrySkipChecks in parallel LLM dispatch (#136)", () => {
   beforeEach(() => {
     _runnerDeps.getUncommittedFiles = mock(async () => []);
@@ -457,5 +461,21 @@ describe("ReviewOrchestrator — retrySkipChecks in parallel LLM dispatch (#136)
 
     expect(_orchestratorDeps.runSemanticReview).toHaveBeenCalledTimes(1);
     expect(_orchestratorDeps.runAdversarialReview).toHaveBeenCalledTimes(1);
+  });
+
+  test("aggregates failureReason across multiple failing LLM reviewers", async () => {
+    _orchestratorDeps.runSemanticReview = mock(async () => makeFailedCheck("semantic"));
+    _orchestratorDeps.runAdversarialReview = mock(async () => makeFailedCheck("adversarial"));
+    const orchestrator = new ReviewOrchestrator();
+
+    const result = await orchestrator.review(
+      makeParallelConfig(),
+      "/tmp/workdir",
+      minimalExecConfig,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.failureReason).toBe("semantic failed, adversarial failed");
+    expect(result.builtIn.failureReason).toBe("semantic failed, adversarial failed");
   });
 });


### PR DESCRIPTION
## What changed
- aggregate `ReviewOrchestrator` built-in `failureReason` across all failing checks instead of reporting only the first one
- add a regression test covering multiple failing LLM reviewers in the parallel review path

Close #680 

## Why
The review hand-off log was misleading when multiple checks failed together. Because the orchestrator picked only the first failed check, concurrent failures like lint plus adversarial review were logged as a single lint failure.

## Impact
Run triage now keeps the full failure context in the hand-off reason string, which improves observability without changing autofix behavior.

## Root cause
`src/review/orchestrator.ts` built `failureReason` from `allChecks.find(...)`, which dropped every failure after the first mechanical or LLM check.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun run test`