### PR TITLE
fix(review): fail-closed on fail-open during partial-progress retry

### DIFF
--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -262,6 +262,10 @@ async function recheckReview(ctx: PipelineContext): Promise<boolean> {
   // We cannot use result.action here because review returns "continue" for BOTH
   // pass and built-in-check-failure (to hand off to autofix). Check success directly.
   await reviewStage.execute(ctx);
+  // A fail-open result (LLM could not parse its response) is not a genuine pass in a
+  // recheck context — we already know the review was failing before this call.
+  const hasFailOpen = (ctx.reviewResult?.checks ?? []).some((c) => c.failOpen);
+  if (hasFailOpen) return false;
   return ctx.reviewResult?.success === true;
 }
 

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -144,9 +144,10 @@ export const reviewStage: PipelineStage = {
     // Fail-closed when fail-open occurs in a retry context (autofix has already run ≥1 time).
     // A reviewer that cannot parse its LLM response is ambiguous — it must not count as a
     // genuine pass when the review was previously failing with real blocking findings.
-    const failOpenChecks = result.success
-      ? (result.builtIn.checks ?? []).filter((c) => c.failOpen).map((c) => c.check)
-      : [];
+    const failOpenChecks =
+      (ctx.reviewResult?.success ?? false)
+        ? (result.builtIn.checks ?? []).filter((c) => c.failOpen).map((c) => c.check)
+        : [];
     if (failOpenChecks.length > 0 && (ctx.autofixAttempt ?? 0) > 0) {
       logger.warn("review", "Fail-open on partial-progress retry — treating as failure (fail-closed on ambiguity)", {
         storyId: ctx.story.id,

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -141,6 +141,26 @@ export const reviewStage: PipelineStage = {
     // Sum LLM costs from checks (populated by semantic review)
     const reviewCost = (result.builtIn.checks ?? []).reduce((sum, c) => sum + (c.cost ?? 0), 0) || undefined;
 
+    // Fail-closed when fail-open occurs in a retry context (autofix has already run ≥1 time).
+    // A reviewer that cannot parse its LLM response is ambiguous — it must not count as a
+    // genuine pass when the review was previously failing with real blocking findings.
+    const failOpenChecks = result.success
+      ? (result.builtIn.checks ?? []).filter((c) => c.failOpen).map((c) => c.check)
+      : [];
+    if (failOpenChecks.length > 0 && (ctx.autofixAttempt ?? 0) > 0) {
+      logger.warn("review", "Fail-open on partial-progress retry — treating as failure (fail-closed on ambiguity)", {
+        storyId: ctx.story.id,
+        failOpenChecks,
+        autofixAttempt: ctx.autofixAttempt,
+      });
+      ctx.reviewResult = {
+        ...result.builtIn,
+        success: false,
+        failureReason: `fail-open on retry: ${failOpenChecks.join(", ")}`,
+      };
+      return { action: "continue", cost: reviewCost };
+    }
+
     if (!result.success) {
       // Collect structured findings from plugin reviewers for escalation context
       const pluginFindings = result.builtIn.pluginReviewers?.flatMap((pr) => pr.findings ?? []) ?? [];

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -339,6 +339,7 @@ export async function runAdversarialReview(
     return {
       check: "adversarial",
       success: true,
+      failOpen: true,
       command: "",
       exitCode: 0,
       output: `skipped: LLM call failed — ${String(err)}`,

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -426,6 +426,7 @@ export async function runAdversarialReview(
     return {
       check: "adversarial",
       success: true,
+      failOpen: true,
       command: "",
       exitCode: 0,
       output: "adversarial review: could not parse LLM response (fail-open)",

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -473,6 +473,7 @@ export async function runSemanticReview(
     return {
       check: "semantic",
       success: true,
+      failOpen: true,
       command: "",
       exitCode: 0,
       output: `skipped: LLM call failed — ${String(err)}`,
@@ -562,6 +563,7 @@ export async function runSemanticReview(
     return {
       check: "semantic",
       success: true,
+      failOpen: true,
       command: "",
       exitCode: 0,
       output: "semantic review: could not parse LLM response (fail-open)",

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -71,6 +71,9 @@ export interface ReviewCheckResult {
   advisoryFindings?: import("../plugins/types").ReviewFinding[];
   /** LLM cost incurred for this check (populated by semantic review) */
   cost?: number;
+  /** True when the LLM reviewer could not parse its response and fell back to success:true (fail-open).
+   * Consumers in a retry context (autofixAttempt > 0) must treat this as a non-genuine pass. */
+  failOpen?: boolean;
 }
 
 /** Plugin reviewer result */

--- a/test/unit/pipeline/stages/autofix-fail-open.test.ts
+++ b/test/unit/pipeline/stages/autofix-fail-open.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for fail-open rejection in recheckReview() — issue #677.
+ *
+ * recheckReview() must return false when any check in the re-run result has
+ * failOpen:true, even if ctx.reviewResult.success would otherwise be true.
+ * Prevents partial-progress retry from whitewashing stories with real blocking findings.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _autofixDeps } from "../../../../src/pipeline/stages/autofix";
+import { DEFAULT_CONFIG } from "../../../../src/config";
+import type { PipelineContext } from "../../../../src/pipeline/types";
+import type { ReviewCheckResult } from "../../../../src/review/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCheckResult(overrides: Partial<ReviewCheckResult>): ReviewCheckResult {
+  return {
+    check: "adversarial",
+    success: true,
+    command: "",
+    exitCode: 0,
+    output: "adversarial review: could not parse LLM response (fail-open)",
+    durationMs: 50,
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  return {
+    config: {
+      ...DEFAULT_CONFIG,
+      review: { ...DEFAULT_CONFIG.review, enabled: true },
+    } as PipelineContext["config"],
+    prd: { stories: [] } as unknown as PipelineContext["prd"],
+    story: { id: "US-001", title: "t", status: "in-progress", acceptanceCriteria: [] } as unknown as PipelineContext["story"],
+    stories: [],
+    routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
+    rootConfig: DEFAULT_CONFIG,
+    workdir: "/tmp",
+    projectDir: "/tmp",
+    hooks: { hooks: {} } as PipelineContext["hooks"],
+    ...overrides,
+  } as unknown as PipelineContext;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("recheckReview — fail-open rejection", () => {
+  let origReviewFromContext: unknown;
+
+  beforeEach(async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    origReviewFromContext = reviewOrchestrator.reviewFromContext;
+  });
+
+  afterEach(async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = origReviewFromContext;
+  });
+
+  test("returns false when adversarial fail-opens (success:true, failOpen:true)", async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = mock(async () => ({
+      success: true,
+      pluginFailed: false,
+      builtIn: {
+        success: true,
+        checks: [makeCheckResult({ check: "adversarial", success: true, failOpen: true })],
+        totalDurationMs: 50,
+      },
+    }));
+
+    const ctx = makeCtx();
+    const result = await _autofixDeps.recheckReview(ctx);
+
+    expect(result).toBe(false);
+  });
+
+  test("returns false when semantic fail-opens (success:true, failOpen:true)", async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = mock(async () => ({
+      success: true,
+      pluginFailed: false,
+      builtIn: {
+        success: true,
+        checks: [makeCheckResult({ check: "semantic", success: true, failOpen: true })],
+        totalDurationMs: 50,
+      },
+    }));
+
+    const ctx = makeCtx();
+    const result = await _autofixDeps.recheckReview(ctx);
+
+    expect(result).toBe(false);
+  });
+
+  test("returns true when review passes with no fail-open (unchanged behavior)", async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = mock(async () => ({
+      success: true,
+      pluginFailed: false,
+      builtIn: {
+        success: true,
+        checks: [makeCheckResult({ check: "adversarial", success: true })],
+        totalDurationMs: 50,
+      },
+    }));
+
+    const ctx = makeCtx();
+    const result = await _autofixDeps.recheckReview(ctx);
+
+    expect(result).toBe(true);
+  });
+
+  test("returns false when review genuinely fails (success:false, no fail-open)", async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = mock(async () => ({
+      success: false,
+      pluginFailed: false,
+      failureReason: "adversarial failed",
+      builtIn: {
+        success: false,
+        checks: [makeCheckResult({ check: "adversarial", success: false })],
+        totalDurationMs: 50,
+      },
+    }));
+
+    const ctx = makeCtx();
+    const result = await _autofixDeps.recheckReview(ctx);
+
+    expect(result).toBe(false);
+  });
+
+  test("returns true when review is disabled (no re-run needed)", async () => {
+    const ctx = makeCtx({
+      config: {
+        ...DEFAULT_CONFIG,
+        review: { ...DEFAULT_CONFIG.review, enabled: false },
+      } as PipelineContext["config"],
+    });
+
+    const result = await _autofixDeps.recheckReview(ctx);
+
+    expect(result).toBe(true);
+  });
+});

--- a/test/unit/pipeline/stages/review-fail-open.test.ts
+++ b/test/unit/pipeline/stages/review-fail-open.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for fail-closed-on-retry guard in review stage — issue #677.
+ *
+ * When a reviewer fail-opens (success:true, failOpen:true) in a retry context
+ * (ctx.autofixAttempt > 0), the review stage must treat it as a failure, not
+ * a pass. This prevents partial-progress retry from whitewashing stories that
+ * still have blocking findings.
+ *
+ * When autofixAttempt = 0 (first run), fail-open still counts as pass — that
+ * behavior is intentional and must not regress.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../../../src/config";
+import { reviewStage } from "../../../../src/pipeline/stages/review";
+import type { PipelineContext } from "../../../../src/pipeline/types";
+import type { ReviewCheckResult } from "../../../../src/review/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCheckResult(overrides: Partial<ReviewCheckResult> = {}): ReviewCheckResult {
+  return {
+    check: "adversarial",
+    success: true,
+    command: "",
+    exitCode: 0,
+    output: "adversarial review: could not parse LLM response (fail-open)",
+    durationMs: 50,
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  return {
+    config: {
+      ...DEFAULT_CONFIG,
+      review: { ...DEFAULT_CONFIG.review, enabled: true },
+    } as PipelineContext["config"],
+    prd: { stories: [], feature: "test-feature" } as unknown as PipelineContext["prd"],
+    story: { id: "US-001", title: "t", status: "in-progress", acceptanceCriteria: [] } as unknown as PipelineContext["story"],
+    stories: [],
+    routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
+    rootConfig: DEFAULT_CONFIG,
+    workdir: "/tmp",
+    projectDir: "/tmp",
+    hooks: { hooks: {} } as PipelineContext["hooks"],
+    ...overrides,
+  } as unknown as PipelineContext;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("reviewStage — fail-open + retry context (autofixAttempt > 0)", () => {
+  let origReviewFromContext: unknown;
+
+  beforeEach(async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    origReviewFromContext = reviewOrchestrator.reviewFromContext;
+  });
+
+  afterEach(async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = origReviewFromContext;
+  });
+
+  test("sets ctx.reviewResult.success=false when adversarial fail-opens in retry context", async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = mock(async () => ({
+      success: true,
+      pluginFailed: false,
+      builtIn: {
+        success: true,
+        checks: [makeCheckResult({ check: "adversarial", failOpen: true })],
+        totalDurationMs: 50,
+      },
+    }));
+
+    const ctx = makeCtx({ autofixAttempt: 3 });
+    await reviewStage.execute(ctx);
+
+    expect(ctx.reviewResult?.success).toBe(false);
+  });
+
+  test("includes failureReason naming the fail-open check", async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = mock(async () => ({
+      success: true,
+      pluginFailed: false,
+      builtIn: {
+        success: true,
+        checks: [makeCheckResult({ check: "adversarial", failOpen: true })],
+        totalDurationMs: 50,
+      },
+    }));
+
+    const ctx = makeCtx({ autofixAttempt: 2 });
+    await reviewStage.execute(ctx);
+
+    expect(ctx.reviewResult?.failureReason).toContain("adversarial");
+  });
+
+  test("still returns action:continue so autofix stage can handle the retry", async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = mock(async () => ({
+      success: true,
+      pluginFailed: false,
+      builtIn: {
+        success: true,
+        checks: [makeCheckResult({ check: "adversarial", failOpen: true })],
+        totalDurationMs: 50,
+      },
+    }));
+
+    const ctx = makeCtx({ autofixAttempt: 1 });
+    const result = await reviewStage.execute(ctx);
+
+    expect(result.action).toBe("continue");
+  });
+});
+
+describe("reviewStage — fail-open + first run (autofixAttempt = 0)", () => {
+  let origReviewFromContext: unknown;
+
+  beforeEach(async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    origReviewFromContext = reviewOrchestrator.reviewFromContext;
+  });
+
+  afterEach(async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = origReviewFromContext;
+  });
+
+  test("still treats fail-open as pass when autofixAttempt is 0 (first run)", async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = mock(async () => ({
+      success: true,
+      pluginFailed: false,
+      builtIn: {
+        success: true,
+        checks: [makeCheckResult({ check: "adversarial", failOpen: true })],
+        totalDurationMs: 50,
+      },
+    }));
+
+    const ctx = makeCtx({ autofixAttempt: 0 });
+    await reviewStage.execute(ctx);
+
+    expect(ctx.reviewResult?.success).toBe(true);
+  });
+
+  test("still treats fail-open as pass when autofixAttempt is undefined (first run)", async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = mock(async () => ({
+      success: true,
+      pluginFailed: false,
+      builtIn: {
+        success: true,
+        checks: [makeCheckResult({ check: "adversarial", failOpen: true })],
+        totalDurationMs: 50,
+      },
+    }));
+
+    const ctx = makeCtx();
+    await reviewStage.execute(ctx);
+
+    expect(ctx.reviewResult?.success).toBe(true);
+  });
+
+  test("treats genuine pass with no fail-open and autofixAttempt > 0 as pass (no regression)", async () => {
+    const { reviewOrchestrator } = await import("../../../../src/review/orchestrator");
+    (reviewOrchestrator as unknown as Record<string, unknown>).reviewFromContext = mock(async () => ({
+      success: true,
+      pluginFailed: false,
+      builtIn: {
+        success: true,
+        checks: [makeCheckResult({ check: "adversarial" })],
+        totalDurationMs: 50,
+      },
+    }));
+
+    const ctx = makeCtx({ autofixAttempt: 5 });
+    await reviewStage.execute(ctx);
+
+    expect(ctx.reviewResult?.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #677.

## Summary

- `src/review/types.ts`: add `failOpen?: boolean` to `ReviewCheckResult` — marks when an LLM reviewer fell back to success:true because it could not parse its response
- `src/review/adversarial.ts` + `src/review/semantic.ts`: set `failOpen: true` on all "Retry exhausted — fail-open" and "LLM call failed — fail-open" return paths (3 sites)
- `src/pipeline/stages/autofix.ts` `recheckReview()`: short-circuit to `false` when any check has `failOpen: true` — covers explicit recheck call sites (mechanical fix, agent rectification lint-fix retry)
- `src/pipeline/stages/review.ts`: when `result.success` is true but any check has `failOpen: true` AND `ctx.autofixAttempt > 0` (retry context), override `ctx.reviewResult.success = false` and return `continue` — covers the partial-progress retry path where `recheckReview` is not called
- `test/unit/pipeline/stages/autofix-fail-open.test.ts` + `review-fail-open.test.ts`: 11 new tests

## Root cause

The partial-progress retry flow (autofix exhausts attempts for some checks, clears them from the skip list, and returns `{action: "retry", fromStage: "review"}`) re-runs the review stage. If the adversarial reviewer then fails to parse its LLM response, it returns `success:true` (fail-open), the review stage sees all checks passing, and the story is marked passed despite 3 previously-confirmed blocking findings.

The `recheckReview()` guard fix covers 3 of the 4 call sites. The review stage guard covers the partial-progress path, which bypasses `recheckReview()` entirely.

First-run behavior (autofixAttempt = 0 or undefined) is preserved: fail-open still counts as pass on the first review pass.

## Test plan

- Run `autofix-fail-open.test.ts` — 5 new tests pass
- Run `review-fail-open.test.ts` — 6 new tests pass  
- Run full `test/unit/review/` + `test/unit/pipeline/stages/` suite (843 tests) green
