### PR TITLE
fix(metrics): firstPassSuccess=true after autofix/fail-open; storyMetrics missing regression-gate stories (#679)

### DIFF
--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -8,6 +8,7 @@
  * - Update final status
  */
 
+import { resolveDefaultAgent } from "../../agents";
 import type { IAgentManager } from "../../agents";
 import type { NaxConfig } from "../../config";
 import { fireHook } from "../../hooks/runner";
@@ -197,6 +198,41 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
             },
             workdir,
           );
+        }
+      }
+
+      // Back-fill storyMetrics for stories rectified by the regression gate (issue #679).
+      // Stories that completed in a prior run-resume or earlier execution batch may not have an
+      // entry in allStoryMetrics — the aggregator only sees stories that entered the normal
+      // execution loop in this run. Injecting synthetic "rectification" entries here ensures
+      // their cost and outcome are visible in run.complete analytics and saved metrics.
+      const regressionStoryCosts = regressionResult.storyCosts ?? {};
+      if (Object.keys(regressionStoryCosts).length > 0) {
+        const existingStoryIds = new Set(allStoryMetrics.map((m) => m.storyId));
+        const rectCompletedAt = new Date().toISOString();
+        const defaultAgent = options.agentManager?.getDefault() ?? resolveDefaultAgent(config);
+        for (const [storyId, storyCost] of Object.entries(regressionStoryCosts)) {
+          if (!existingStoryIds.has(storyId)) {
+            const regrStory = prd.userStories.find((s) => s.id === storyId);
+            allStoryMetrics.push({
+              storyId,
+              complexity: regrStory?.routing?.complexity ?? "medium",
+              modelTier: "balanced",
+              modelUsed: defaultAgent,
+              attempts: 1,
+              finalTier: "balanced",
+              success: regressionResult.success,
+              cost: storyCost,
+              durationMs: 0,
+              firstPassSuccess: false,
+              startedAt: rectCompletedAt,
+              completedAt: rectCompletedAt,
+              source: "rectification" as const,
+              rectificationCost: storyCost,
+              fullSuiteGatePassed: false,
+              runtimeCrashes: 0,
+            });
+          }
         }
       }
     }

--- a/src/execution/lifecycle/run-regression.ts
+++ b/src/execution/lifecycle/run-regression.ts
@@ -43,6 +43,12 @@ export interface DeferredRegressionResult {
   passedTests: number;
   rectificationAttempts: number;
   affectedStories: string[];
+  /**
+   * Accumulated rectification agent cost per affected story ID (issue #679).
+   * Populated when at least one story was rectified. Empty for early-pass/disabled/timeout returns.
+   * Optional for backward-compatibility with existing mocks and snapshots.
+   */
+  storyCosts?: Record<string, number>;
 }
 
 /**
@@ -96,6 +102,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       passedTests: 0,
       rectificationAttempts: 0,
       affectedStories: [],
+      storyCosts: {},
     };
   }
 
@@ -108,6 +115,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       passedTests: 0,
       rectificationAttempts: 0,
       affectedStories: [],
+      storyCosts: {},
     };
   }
 
@@ -143,6 +151,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       passedTests: 0,
       rectificationAttempts: 0,
       affectedStories: [],
+      storyCosts: {},
     };
   }
 
@@ -163,6 +172,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       passedTests: fullSuiteResult.passCount ?? 0,
       rectificationAttempts: 0,
       affectedStories: [],
+      storyCosts: {},
     };
   }
 
@@ -176,6 +186,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       passedTests: 0,
       rectificationAttempts: 0,
       affectedStories: [],
+      storyCosts: {},
     };
   }
 
@@ -188,6 +199,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       passedTests: fullSuiteResult.passCount ?? 0,
       rectificationAttempts: 0,
       affectedStories: [],
+      storyCosts: {},
     };
   }
 
@@ -210,6 +222,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       passedTests: 0,
       rectificationAttempts: 0,
       affectedStories: [],
+      storyCosts: {},
     };
   }
 
@@ -259,6 +272,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       passedTests: testSummary.passed,
       rectificationAttempts: 0,
       affectedStories: Array.from(affectedStories),
+      storyCosts: {},
     };
   }
 
@@ -267,6 +281,8 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
   let storiesRectified = 0;
   let currentTestOutput = fullSuiteResult.output;
   const affectedStoriesList = Array.from(affectedStoriesObjs.values());
+  // Accumulated rectification cost per story — populated below for metrics back-fill (issue #679).
+  const storyCostAccum: Record<string, number> = {};
 
   for (const story of affectedStoriesList) {
     for (let attempt = 0; attempt < maxRectificationAttempts; attempt++) {
@@ -274,7 +290,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
 
       logger?.info("regression", `Rectifying story ${story.id} (attempt ${attempt + 1}/${maxRectificationAttempts})`);
 
-      const fixed = await _regressionDeps.runRectificationLoop({
+      const rectResult = await _regressionDeps.runRectificationLoop({
         config,
         workdir,
         story,
@@ -286,7 +302,10 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
         featureName: prd.feature,
       });
 
-      if (fixed) {
+      // Accumulate cost regardless of whether the attempt succeeded (issue #679).
+      storyCostAccum[story.id] = (storyCostAccum[story.id] ?? 0) + rectResult.cost;
+
+      if (rectResult.succeeded) {
         storiesRectified++;
         logger?.info("regression", `Story ${story.id} rectified successfully`);
 
@@ -314,6 +333,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
             passedTests: midResult.passCount ?? 0,
             rectificationAttempts,
             affectedStories: Array.from(affectedStories),
+            storyCosts: storyCostAccum,
           };
         }
 
@@ -350,5 +370,6 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
     passedTests: retryResult.passCount ?? 0,
     rectificationAttempts,
     affectedStories: Array.from(affectedStories),
+    storyCosts: storyCostAccum,
   };
 }

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -104,8 +104,20 @@ export async function collectStoryMetrics(ctx: PipelineContext, storyStartTime: 
   // Determine final tier (from last escalation or initial routing)
   const finalTier = escalationCount > 0 ? story.escalations[escalationCount - 1].toTier : routing.modelTier;
 
-  // First pass success = succeeded with no prior failures and no escalations (BUG-067)
-  const firstPassSuccess = agentResult?.success === true && escalationCount === 0 && priorFailureCount === 0;
+  // autofixAttempt > 0 means the autofix stage ran at least once (review found blocking issues that
+  // triggered an agent-autofix cycle). rectifyAttempt > 0 means the rectify stage ran at least once
+  // (verify stage failed and triggered rectification). Both disqualify first-pass success (issue #679).
+  const autofixAttemptCount = ctx.autofixAttempt ?? 0;
+  const rectifyAttemptCount = ctx.rectifyAttempt ?? 0;
+
+  // First pass success = succeeded with no tier escalation, no cross-tier failures,
+  // and no autofix or rectify repair cycles (BUG-067 / issue #679)
+  const firstPassSuccess =
+    agentResult?.success === true &&
+    escalationCount === 0 &&
+    priorFailureCount === 0 &&
+    autofixAttemptCount === 0 &&
+    rectifyAttemptCount === 0;
 
   // Extract model name and agent from config
   const agentUsed = routing.agent ?? ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config);

--- a/test/unit/execution/lifecycle/run-regression.test.ts
+++ b/test/unit/execution/lifecycle/run-regression.test.ts
@@ -7,6 +7,7 @@
  * - First story partial fix, second story fixes rest → early exit after second story
  * - No story fixes anything → falls through to final re-run
  * - currentTestOutput is forwarded to each story's rectification (not stale initial output)
+ * - storyCosts is populated with per-story agent cost from rectification (issue #679)
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -100,7 +101,7 @@ describe("runDeferredRegression — initial suite passes", () => {
       verifyCallCount.n++;
       return makePassResult();
     });
-    _regressionDeps.runRectificationLoop = mock(async () => false);
+    _regressionDeps.runRectificationLoop = mock(async () => ({ succeeded: false, cost: 0 }));
     _regressionDeps.parseTestOutput = mock(() => ({ passed: 150, failed: 0, failures: [] }));
     const result = await runDeferredRegression(makeOptions(["US-001", "US-002"]));
 
@@ -108,6 +109,8 @@ describe("runDeferredRegression — initial suite passes", () => {
     expect(result.rectificationAttempts).toBe(0);
     // Only the initial suite run — no mid-loop or final re-run
     expect(verifyCallCount.n).toBe(1);
+    // No rectification ran, so no costs
+    expect(result.storyCosts).toEqual({});
   });
 });
 
@@ -136,7 +139,7 @@ describe("runDeferredRegression — early exit after first story", () => {
     const rectifiedStories: string[] = [];
     _regressionDeps.runRectificationLoop = mock(async (opts) => {
       rectifiedStories.push(opts.story.id);
-      return true; // fixed on first attempt
+      return { succeeded: true, cost: 0.5 }; // fixed on first attempt
     });
 
     const result = await runDeferredRegression(makeOptions(["US-001", "US-002", "US-003"]));
@@ -148,6 +151,8 @@ describe("runDeferredRegression — early exit after first story", () => {
     // verify called twice: initial + mid-loop after US-001 (no final re-run)
     expect(verifyCalls).toHaveLength(2);
     expect(result.rectificationAttempts).toBe(1);
+    // Cost is tracked for the story that ran
+    expect(result.storyCosts).toEqual({ "US-001": 0.5 });
   });
 });
 
@@ -175,7 +180,7 @@ describe("runDeferredRegression — early exit after second story", () => {
     const rectifiedStories: string[] = [];
     _regressionDeps.runRectificationLoop = mock(async (opts) => {
       rectifiedStories.push(opts.story.id);
-      return true; // each story claims it fixed things
+      return { succeeded: true, cost: 0.3 }; // each story claims it fixed things
     });
 
     const result = await runDeferredRegression(makeOptions(["US-001", "US-002", "US-003"]));
@@ -207,7 +212,7 @@ describe("runDeferredRegression — no story fixes anything", () => {
       failed: 92,
       failures: [],
     }));
-    _regressionDeps.runRectificationLoop = mock(async () => false); // never fixed
+    _regressionDeps.runRectificationLoop = mock(async () => ({ succeeded: false, cost: 0 })); // never fixed
 
     const result = await runDeferredRegression(makeOptions(["US-001", "US-002"]));
 
@@ -243,7 +248,7 @@ describe("runDeferredRegression — test output context forwarding", () => {
     }));
     _regressionDeps.runRectificationLoop = mock(async (opts) => {
       capturedOutputs.push(opts.testOutput);
-      return true;
+      return { succeeded: true, cost: 0.1 };
     });
 
     await runDeferredRegression(makeOptions(["US-001", "US-002"]));
@@ -274,5 +279,69 @@ describe("runDeferredRegression — disabled mode", () => {
 
     expect(result.success).toBe(true);
     expect(_regressionDeps.runVerification).not.toHaveBeenCalled();
+    expect(result.storyCosts).toEqual({});
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// storyCosts accumulation — issue #679
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("runDeferredRegression — storyCosts tracking (issue #679)", () => {
+  test("accumulates cost per story across rectification attempts", async () => {
+    let verifyCallIndex = 0;
+    _regressionDeps.runVerification = mock(async () => {
+      const i = verifyCallIndex++;
+      if (i === 0) return makeVerifyResult(); // initial: fail
+      return makePassResult(); // mid-loop after first story: pass
+    });
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 5, failures: [] }));
+    _regressionDeps.runRectificationLoop = mock(async () => ({ succeeded: true, cost: 1.2559 }));
+
+    const result = await runDeferredRegression(makeOptions(["US-001"]));
+
+    expect(result.success).toBe(true);
+    expect(result.storyCosts["US-001"]).toBeCloseTo(1.2559);
+  });
+
+  test("accumulates cost for multiple attempts on the same story when no early exit fires", async () => {
+    // US-001 fails to fix in attempt 1, retries (maxRectificationAttempts = 2)
+    // Then the final re-run passes
+    let rectifyCallIndex = 0;
+    _regressionDeps.runVerification = mock(async () => makeVerifyResult());
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    _regressionDeps.runRectificationLoop = mock(async () => {
+      rectifyCallIndex++;
+      // Never claim succeeded so there's no mid-loop verify call and we fall through
+      return { succeeded: false, cost: 0.75 };
+    });
+
+    const result = await runDeferredRegression(makeOptions(["US-001"]));
+
+    // 2 attempts × $0.75 each — cost accumulated even when failed
+    expect(result.storyCosts["US-001"]).toBeCloseTo(1.5);
+    expect(rectifyCallIndex).toBe(2); // maxRectificationAttempts = 2
+  });
+
+  test("tracks cost for each affected story independently", async () => {
+    let verifyCallIndex = 0;
+    _regressionDeps.runVerification = mock(async () => {
+      const i = verifyCallIndex++;
+      if (i === 0) return makeVerifyResult(); // initial: fail
+      if (i === 1) return makeVerifyResult(); // mid after US-001: still fail
+      return makePassResult(); // mid after US-002: pass
+    });
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    let storyIdx = 0;
+    _regressionDeps.runRectificationLoop = mock(async () => {
+      storyIdx++;
+      return { succeeded: true, cost: storyIdx === 1 ? 0.4 : 0.6 };
+    });
+
+    const result = await runDeferredRegression(makeOptions(["US-001", "US-002"]));
+
+    expect(result.success).toBe(true);
+    expect(result.storyCosts["US-001"]).toBeCloseTo(0.4);
+    expect(result.storyCosts["US-002"]).toBeCloseTo(0.6);
   });
 });

--- a/test/unit/metrics/tracker-escalation.test.ts
+++ b/test/unit/metrics/tracker-escalation.test.ts
@@ -454,3 +454,71 @@ describe("handleTierEscalation — priorFailures records attempt data for cross-
     },
   );
 });
+
+// ---------------------------------------------------------------------------
+// firstPassSuccess — must be false when autofix or rectify ran (issue #679)
+//
+// Bug: collectStoryMetrics only checked escalationCount and priorFailureCount.
+// A story that went through 3 autofix attempts + fail-open still had
+// attempts:1, escalationCount:0, priorFailureCount:0 → firstPassSuccess:true.
+//
+// Fix: also gate on ctx.autofixAttempt > 0 and ctx.rectifyAttempt > 0.
+// ---------------------------------------------------------------------------
+
+describe("collectStoryMetrics — firstPassSuccess is false when autofix or rectify ran (issue #679)", () => {
+  test.each([
+    {
+      name: "firstPassSuccess is false when autofixAttempt > 0 (autofix cycle ran)",
+      autofixAttempt: 3,
+      rectifyAttempt: 0,
+      expectedFirstPassSuccess: false,
+    },
+    {
+      name: "firstPassSuccess is false when rectifyAttempt > 0 (rectify stage ran)",
+      autofixAttempt: 0,
+      rectifyAttempt: 1,
+      expectedFirstPassSuccess: false,
+    },
+    {
+      name: "firstPassSuccess is false when both autofixAttempt and rectifyAttempt > 0",
+      autofixAttempt: 2,
+      rectifyAttempt: 2,
+      expectedFirstPassSuccess: false,
+    },
+    {
+      name: "firstPassSuccess is true when no cycles ran and no escalation (clean first pass)",
+      autofixAttempt: 0,
+      rectifyAttempt: 0,
+      expectedFirstPassSuccess: true,
+    },
+    {
+      name: "firstPassSuccess is false when autofixAttempt is 1 (single autofix run)",
+      autofixAttempt: 1,
+      rectifyAttempt: 0,
+      expectedFirstPassSuccess: false,
+    },
+  ])(
+    "$name",
+    async ({ autofixAttempt, rectifyAttempt, expectedFirstPassSuccess }) => {
+      const story = makeStory({
+        attempts: 1,
+        escalations: [],
+        priorFailures: [],
+      });
+      const ctx = makeCtx(story, {
+        autofixAttempt,
+        rectifyAttempt,
+        agentResult: {
+          success: true,
+          exitCode: 0,
+          output: "",
+          rateLimited: false,
+          estimatedCost: 0.05,
+          durationMs: 3000,
+        },
+      });
+      const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
+      expect(metrics.firstPassSuccess).toBe(expectedFirstPassSuccess);
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Fixes two metric accuracy bugs reported in #679.

---

### Bug 1 — `firstPassSuccess: true` after autofix / fail-open cycles

**Root cause:** `collectStoryMetrics` in `src/metrics/tracker.ts` gated `firstPassSuccess` on tier-escalation signals only (`escalationCount`, `priorFailureCount`). It was blind to `ctx.autofixAttempt` and `ctx.rectifyAttempt`, which are incremented by the autofix and rectification pipeline stages respectively. A story that cycled through 3 autofix rounds with no tier change was still reported as `firstPassSuccess: true`.

**Fix:** Both counters must be `0` for `firstPassSuccess` to be `true`:

```typescript
const autofixAttemptCount = ctx.autofixAttempt ?? 0;
const rectifyAttemptCount = ctx.rectifyAttempt ?? 0;
const firstPassSuccess =
  agentResult?.success === true &&
  escalationCount === 0 &&
  priorFailureCount === 0 &&
  autofixAttemptCount === 0 &&
  rectifyAttemptCount === 0;
```

---

### Bug 2 — Story missing from `storyMetrics[]` after regression gate

**Root cause:** Stories completed in a prior run-resume (e.g. `US-001` already `"passed"` at run start) are skipped by the main execution loop, so `allStoryMetrics` is never populated for them. If `runDeferredRegression` later rectifies such a story, its cost and outcome are invisible in `run.complete` telemetry.

Additionally, `runRectificationLoop` returns `{ succeeded: boolean; cost: number }` but the result was used as a truthy boolean (`if (fixed)`), making the mid-loop re-verify always fire (benign but type-incorrect).

**Fix:**
1. Added optional `storyCosts?: Record<string, number>` to `DeferredRegressionResult` — accumulated per-story across all `runRectificationLoop` calls inside `runDeferredRegression`.
2. Fixed the `const fixed = await ...` type bug → `const rectResult = await ...; if (rectResult.succeeded)`.
3. `handleRunCompletion` back-fills `allStoryMetrics` with `source: "rectification"` entries for any story ID present in `storyCosts` that has no existing entry.

---

### Files changed

| File | Change |
|:-----|:-------|
| `src/metrics/tracker.ts` | Add `autofixAttempt`/`rectifyAttempt` to `firstPassSuccess` guard |
| `src/execution/lifecycle/run-regression.ts` | Add `storyCosts` to result; fix type bug; accumulate per-story costs |
| `src/execution/lifecycle/run-completion.ts` | Back-fill metrics for regression-gate stories |
| `test/unit/metrics/tracker-escalation.test.ts` | 5 new `firstPassSuccess` cases covering autofix/rectify counters |
| `test/unit/execution/lifecycle/run-regression.test.ts` | Fix mock return types; 3 new `storyCosts` tracking tests |

---

### Test plan

- ✅ `bun run typecheck` — clean
- ✅ `bun run test` — **6606 unit + 1175 integration + 11 ui, 0 failures**
- ✅ Pre-commit hook (typecheck + Biome lint) — clean

Closes #679