### PR TITLE
[codex] Fix rectifier fallback for unmapped failures

### DIFF
--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -24,6 +24,7 @@ import {
   shouldRetryRectification as _shouldRetryRectification,
   runSharedRectificationLoop,
 } from "../verification";
+import { buildFailureRecords } from "../verification/failure-records";
 import { cleanupProcessTree } from "./cleanup";
 import { verifyImplementerIsolation } from "./isolation";
 
@@ -156,6 +157,7 @@ export async function runFullSuiteGate(
         rectificationConfig,
         effectiveTestCmd,
         fullSuiteTimeout,
+        fullSuiteResult.output,
         featureName,
         projectDir,
       );
@@ -208,6 +210,7 @@ async function runRectificationLoop(
   rectificationConfig: NonNullable<NaxConfig["execution"]["rectification"]>,
   testCmd: string,
   fullSuiteTimeout: number,
+  testOutput: string,
   featureName?: string,
   projectDir?: string,
 ): Promise<{ passed: boolean; cost: number }> {
@@ -236,6 +239,7 @@ async function runRectificationLoop(
     isolationPassed: true,
   };
   let gateCostAccum = 0;
+  let currentTestOutput = testOutput;
 
   const fixed = await runSharedRectificationLoop({
     stage: "tdd",
@@ -257,12 +261,7 @@ async function runRectificationLoop(
     canContinue: (state) =>
       state.isolationPassed && _rectificationGateDeps.shouldRetryRectification(state, rectificationConfig),
     buildPrompt: async () => {
-      const failureRecords: FailureRecord[] = testSummary.failures.map((f) => ({
-        test: f.testName,
-        file: f.file,
-        message: f.error,
-        output: f.stackTrace.length > 0 ? f.stackTrace.join("\n") : undefined,
-      }));
+      const failureRecords: FailureRecord[] = buildFailureRecords(testSummary, currentTestOutput);
       return RectifierPromptBuilder.for("tdd-suite-failure")
         .story(story)
         .priorFailures(failureRecords)
@@ -359,6 +358,7 @@ async function runRectificationLoop(
 
       if (retryFullSuite.output) {
         const newTestSummary = _rectificationGateDeps.parseTestOutput(retryFullSuite.output);
+        currentTestOutput = retryFullSuite.output;
         state.currentFailures = newTestSummary.failed;
         testSummary.failures = newTestSummary.failures;
         testSummary.failed = newTestSummary.failed;

--- a/src/verification/failure-records.ts
+++ b/src/verification/failure-records.ts
@@ -1,0 +1,38 @@
+import type { FailureRecord } from "../prompts";
+import type { TestSummary } from "./types";
+
+const UNMAPPED_FAILURE_OUTPUT_MAX_LINES = 200;
+const UNMAPPED_FAILURE_OUTPUT_MAX_CHARS = 8_000;
+
+function truncateUnmappedFailureOutput(output: string): string {
+  const tailLines = output.split("\n").slice(-UNMAPPED_FAILURE_OUTPUT_MAX_LINES).join("\n");
+  if (tailLines.length <= UNMAPPED_FAILURE_OUTPUT_MAX_CHARS) {
+    return tailLines;
+  }
+
+  return `... (truncated)\n${tailLines.slice(-UNMAPPED_FAILURE_OUTPUT_MAX_CHARS)}`;
+}
+
+export function buildFailureRecords(testSummary: TestSummary, rawOutput?: string): FailureRecord[] {
+  if (testSummary.failures.length > 0) {
+    return testSummary.failures.map((failure) => ({
+      test: failure.testName,
+      file: failure.file,
+      message: failure.error,
+      output: failure.stackTrace.length > 0 ? failure.stackTrace.join("\n") : undefined,
+    }));
+  }
+
+  if (testSummary.failed === 0) {
+    return [];
+  }
+
+  return [
+    {
+      test: `Unmapped test failures (${testSummary.failed} detected)`,
+      message:
+        "Structured test failure parsing returned no failure records. Diagnose the regression from the raw test output.",
+      output: rawOutput?.trim() ? truncateUnmappedFailureOutput(rawOutput.trim()) : undefined,
+    },
+  ];
+}

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -22,6 +22,7 @@ import type { UserStory } from "../prd";
 import { getExpectedFiles } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
 import type { FailureRecord } from "../prompts";
+import { buildFailureRecords } from "./failure-records";
 import { parseTestOutput } from "./parser";
 import { formatFailureSummary } from "./parser";
 import { type RectificationState, shouldRetryRectification } from "./rectification";
@@ -154,6 +155,7 @@ export async function runRectificationLoop(
   const agentManager = opts.agentManager ?? _rectificationDeps.createManager(config);
   const rectificationConfig = config.execution.rectification;
   const testSummary = parseTestOutput(testOutput);
+  let currentTestOutput = testOutput;
   const label = promptPrefix ? "regression rectification" : "rectification";
 
   const rectificationState: RectificationState = {
@@ -219,12 +221,7 @@ export async function runRectificationLoop(
         }
       }
 
-      const failureRecords: FailureRecord[] = testSummary.failures.map((f) => ({
-        test: f.testName,
-        file: f.file,
-        message: f.error,
-        output: f.stackTrace.length > 0 ? f.stackTrace.join("\n") : undefined,
-      }));
+      const failureRecords: FailureRecord[] = buildFailureRecords(testSummary, currentTestOutput);
       let rectificationPrompt = await RectifierPromptBuilder.for("verify-failure")
         .story(story)
         .priorFailures(failureRecords)
@@ -327,6 +324,7 @@ export async function runRectificationLoop(
 
       if (retryVerification.output) {
         const newTestSummary = parseTestOutput(retryVerification.output);
+        currentTestOutput = retryVerification.output;
         state.currentFailures = newTestSummary.failed;
         state.lastExitCode = retryVerification.status === "SUCCESS" ? 0 : 1;
         testSummary.failures = newTestSummary.failures;

--- a/test/unit/tdd/rectification-gate-session.test.ts
+++ b/test/unit/tdd/rectification-gate-session.test.ts
@@ -244,4 +244,53 @@ describe("rectification session reuse", () => {
     expect(role1).toBeDefined();
     expect(role1).toBe(role2);
   });
+
+  test("includes raw test output in the TDD rectification prompt when failures are unmapped", async () => {
+    const story = makeStory({ id: "US-UNMAPPED" });
+    const config = makeConfig(1);
+    const agent = makeAgent();
+    const unmappedOutput = `
+test/example.test.ts:
+✓ passing test [0.5ms]
+✗ compile failure 1 [1.2ms]
+✗ compile failure 2 [1.3ms]
+
+src/foo.ts:12:8 - error TS2304: Cannot find name 'missingSymbol'
+
+3 passed, 2 failed [1.7ms]
+    `.trim();
+
+    mockSuiteResults = [
+      { success: false, exitCode: 1, output: unmappedOutput },
+      { success: false, exitCode: 1, output: unmappedOutput },
+    ];
+
+    _rectificationGateDeps.parseTestOutput = mock((_output: string) => ({
+      failed: 2,
+      passed: 3,
+      failures: [],
+    })) as any;
+
+    const agentManager = makeMockAgentManager({
+      getDefaultAgent: "claude",
+      getAgentFn: (_name: string) => agent as any,
+      runFn: async (_agentName: string, opts: AgentRunOptions) => {
+        agent.calls.push(opts);
+        const result = await agent.run(opts);
+        return { success: result.success, exitCode: result.exitCode, output: result.output, rateLimited: result.rateLimited, durationMs: result.durationMs, estimatedCost: result.estimatedCost, agentFallbacks: [] };
+      },
+    });
+
+    await runFullSuiteGate(story, config, "/tmp/fake-workdir", agentManager, "balanced", true, {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    } as any, "my-feature");
+
+    expect(agent.calls.length).toBe(1);
+    expect(agent.calls[0]?.prompt).toContain("Unmapped test failures (2 detected)");
+    expect(agent.calls[0]?.prompt).toContain("Structured test failure parsing returned no failure records");
+    expect(agent.calls[0]?.prompt).toContain("Cannot find name 'missingSymbol'");
+  });
 });

--- a/test/unit/verification/failure-records.test.ts
+++ b/test/unit/verification/failure-records.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { buildFailureRecords } from "../../../src/verification/failure-records";
+
+describe("buildFailureRecords", () => {
+  test("maps structured failures without fallback text", () => {
+    const result = buildFailureRecords({
+      passed: 0,
+      failed: 1,
+      failures: [
+        {
+          file: "test/unit/example.test.ts",
+          testName: "handles retries",
+          error: "Expected true to be false",
+          stackTrace: ["at test/unit/example.test.ts:12:3"],
+        },
+      ],
+    });
+
+    expect(result).toEqual([
+      {
+        file: "test/unit/example.test.ts",
+        test: "handles retries",
+        message: "Expected true to be false",
+        output: "at test/unit/example.test.ts:12:3",
+      },
+    ]);
+  });
+
+  test("falls back to a raw-output failure record when parsing found no structured failures", () => {
+    const result = buildFailureRecords(
+      {
+        passed: 0,
+        failed: 2,
+        failures: [],
+      },
+      "src/foo.ts:1:1 - error TS2304: Cannot find name 'missingSymbol'",
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.test).toBe("Unmapped test failures (2 detected)");
+    expect(result[0]?.message).toContain("Structured test failure parsing returned no failure records");
+    expect(result[0]?.output).toContain("Cannot find name 'missingSymbol'");
+  });
+});

--- a/test/unit/verification/rectification-loop.test.ts
+++ b/test/unit/verification/rectification-loop.test.ts
@@ -227,6 +227,59 @@ describe("runRectificationLoop — session context params", () => {
     expect(result.succeeded).toBe(false);
   });
 
+  test("includes raw test output in the rectification prompt when failed tests are unmapped", async () => {
+    const capturedPrompts: string[] = [];
+    const unmappedOutput = `
+test/example.test.ts:
+✓ passing test [0.5ms]
+✗ compile failure 1 [1.2ms]
+✗ compile failure 2 [1.3ms]
+
+src/foo.ts:12:8 - error TS2304: Cannot find name 'missingSymbol'
+
+3 passed, 2 failed [1.7ms]
+    `.trim();
+
+    _rectificationDeps.createManager = mock((_config: NaxConfig) =>
+      makeMockAgentManager({
+        runFn: mock(async (_agentName: string, opts: AgentRunOptions) => {
+          capturedPrompts.push(opts.prompt);
+          return { success: false, exitCode: 1, output: "failed", rateLimited: false, durationMs: 10, estimatedCost: 0, agentFallbacks: [] };
+        }),
+      }),
+    );
+
+    _rectificationDeps.runVerification = mock(async () => ({
+      success: false,
+      output: unmappedOutput,
+      status: "TEST_FAILURE" as const,
+      countsTowardEscalation: true,
+    }));
+
+    await runRectificationLoop({
+      config: makeConfig({
+        execution: {
+          sessionTimeoutSeconds: 120,
+          rectification: {
+            maxRetries: 1,
+            abortOnRegression: true,
+          },
+          permissionProfile: "cautious",
+        },
+      } as unknown as Partial<NaxConfig>),
+      workdir: "/tmp/test",
+      story: makeStory({ id: "TS-UNMAPPED" }),
+      testCommand: "bun test",
+      timeoutSeconds: 30,
+      testOutput: unmappedOutput,
+    });
+
+    expect(capturedPrompts).toHaveLength(1);
+    expect(capturedPrompts[0]).toContain("Unmapped test failures (2 detected)");
+    expect(capturedPrompts[0]).toContain("Structured test failure parsing returned no failure records");
+    expect(capturedPrompts[0]).toContain("Cannot find name 'missingSymbol'");
+  });
+
   test("passes config into fallback _rectificationDeps.createManager when agentGetFn is omitted", async () => {
     const config = makeConfig({
       agent: {


### PR DESCRIPTION
## What changed
- add a shared `buildFailureRecords()` helper that falls back to a bounded raw test-output snippet when parsing reports failed tests but no structured `failures[]`
- use that helper in both the verification rectification loop and the TDD full-suite rectification gate
- keep the latest retry output in both loops so later rectification attempts use current failure context instead of stale output
- add regression tests for the helper and for both prompt-building call sites

## Why
When test output parsing counted failures but could not extract structured failure records, the rectifier prompt omitted the entire prior-failures section. That caused balanced-tier rectification attempts to run without test names, file paths, or raw errors.

## Impact
Rectification prompts now include concrete failure context even for compile/import-error style outputs that the parser cannot structure yet. This avoids blind retry attempts and improves recovery quality without changing the escalation policy.

## Root cause
Both rectification paths built prompt failures from `testSummary.failures.map(...)` only. In the `failed > 0 && failures.length === 0` case, that produced an empty prompt section and no actionable regression context.

## Validation
- `bun test test/unit/verification/failure-records.test.ts test/unit/verification/rectification-loop.test.ts test/unit/tdd/rectification-gate-session.test.ts --timeout=30000`
- `bun run typecheck`
- `bun run lint`
- `bun run test`