### PR TITLE
refactor: post-merge follow-ups from #676-#680 review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.11"
+          bun-version: "1.3.13"
 
       - name: Cache bun dependencies
         uses: actions/cache@v5
@@ -61,7 +61,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.11"
+          bun-version: "1.3.13"
 
       - name: Cache bun dependencies
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,14 @@ jobs:
       matrix:
         check: [typecheck, lint, check:test-mocks]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.11"
 
       - name: Cache bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -57,14 +57,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.11"
 
       - name: Cache bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
     environment: npm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # full history for changelog extraction
 
@@ -30,7 +30,7 @@ jobs:
         with:
           bun-version: "1.3.11"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: "1.3.11"
+          bun-version: "1.3.13"
 
       - uses: actions/setup-node@v5
         with:

--- a/docker-compose.test-bail.yml
+++ b/docker-compose.test-bail.yml
@@ -1,10 +1,10 @@
 version: "3.9"
-# Mirrors GitHub Actions CI environment (ubuntu-latest + Bun 1.3.11, glibc).
+# Mirrors GitHub Actions CI environment (ubuntu-latest + Bun 1.3.13, glibc).
 # Usage: docker compose -f docker-compose.test-bail.yml run --rm ci-test-bail
 # Resources: 1 vCPU / 2GB RAM — stress test to surface flakiness early.
 services:
   ci-test-bail:
-    image: oven/bun:1.3.11
+    image: oven/bun:1.3.13
     working_dir: /app
     volumes:
       - .:/app

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,9 +1,9 @@
 version: "3.9"
-# Mirrors GitHub Actions CI environment (ubuntu-latest + Bun 1.3.11, glibc).
+# Mirrors GitHub Actions CI environment (ubuntu-latest + Bun 1.3.13, glibc).
 # Usage: docker compose -f docker-compose.test.yml run --rm ci-test
 services:
   ci-test:
-    image: oven/bun:1.3.11
+    image: oven/bun:1.3.13
     working_dir: /app
     volumes:
       - .:/app

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -201,18 +201,27 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
         }
       }
 
-      // Back-fill storyMetrics for stories rectified by the regression gate (issue #679).
-      // Stories that completed in a prior run-resume or earlier execution batch may not have an
-      // entry in allStoryMetrics — the aggregator only sees stories that entered the normal
-      // execution loop in this run. Injecting synthetic "rectification" entries here ensures
-      // their cost and outcome are visible in run.complete analytics and saved metrics.
+      // Back-fill or merge storyMetrics for stories rectified by the regression gate (issue #679).
+      // Two cases:
+      //   1. Story has no existing entry (prior run-resume or earlier execution batch): inject a
+      //      synthetic "rectification" entry so cost and outcome show up in run.complete analytics.
+      //   2. Story already has an entry (normal execution loop + regression-gate rectification in
+      //      the same run): fold the rectification cost + duration into the existing entry so the
+      //      regression-gate effort isn't silently dropped.
       const regressionStoryCosts = regressionResult.storyCosts ?? {};
+      const regressionStoryDurations = regressionResult.storyDurations ?? {};
+      const regressionStoryOutcomes = regressionResult.storyOutcomes ?? {};
       if (Object.keys(regressionStoryCosts).length > 0) {
-        const existingStoryIds = new Set(allStoryMetrics.map((m) => m.storyId));
+        const existingIndex = new Map(allStoryMetrics.map((m, i) => [m.storyId, i]));
         const rectCompletedAt = new Date().toISOString();
         const defaultAgent = options.agentManager?.getDefault() ?? resolveDefaultAgent(config);
         for (const [storyId, storyCost] of Object.entries(regressionStoryCosts)) {
-          if (!existingStoryIds.has(storyId)) {
+          const storyDuration = regressionStoryDurations[storyId] ?? 0;
+          // Per-story outcome; fall back to the overall regression result only when missing
+          // (e.g. older mocks emit storyCosts without storyOutcomes).
+          const storySuccess = regressionStoryOutcomes[storyId] ?? regressionResult.success;
+          const existingIdx = existingIndex.get(storyId);
+          if (existingIdx === undefined) {
             const regrStory = prd.userStories.find((s) => s.id === storyId);
             allStoryMetrics.push({
               storyId,
@@ -221,9 +230,9 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
               modelUsed: defaultAgent,
               attempts: 1,
               finalTier: "balanced",
-              success: regressionResult.success,
+              success: storySuccess,
               cost: storyCost,
-              durationMs: 0,
+              durationMs: storyDuration,
               firstPassSuccess: false,
               startedAt: rectCompletedAt,
               completedAt: rectCompletedAt,
@@ -232,6 +241,18 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
               fullSuiteGatePassed: false,
               runtimeCrashes: 0,
             });
+          } else {
+            const existing = allStoryMetrics[existingIdx];
+            allStoryMetrics[existingIdx] = {
+              ...existing,
+              cost: existing.cost + storyCost,
+              durationMs: existing.durationMs + storyDuration,
+              rectificationCost: (existing.rectificationCost ?? 0) + storyCost,
+              // A story that needed regression-gate rectification was not a clean first pass.
+              firstPassSuccess: false,
+              // Preserve the normal-loop success flag unless the regression attempt actually failed.
+              success: existing.success && storySuccess,
+            };
           }
         }
       }

--- a/src/execution/lifecycle/run-regression.ts
+++ b/src/execution/lifecycle/run-regression.ts
@@ -49,6 +49,18 @@ export interface DeferredRegressionResult {
    * Optional for backward-compatibility with existing mocks and snapshots.
    */
   storyCosts?: Record<string, number>;
+  /**
+   * Accumulated rectification wall-clock duration per affected story ID (ms).
+   * Same population rules as `storyCosts`.
+   */
+  storyDurations?: Record<string, number>;
+  /**
+   * Per-story rectification outcome: `true` when the story was successfully rectified
+   * (at least one attempt returned succeeded:true), `false` otherwise. Lets downstream
+   * metrics attribute success/failure to the right story instead of using the overall
+   * regression result as a blanket answer.
+   */
+  storyOutcomes?: Record<string, boolean>;
 }
 
 /**
@@ -103,6 +115,8 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       rectificationAttempts: 0,
       affectedStories: [],
       storyCosts: {},
+      storyDurations: {},
+      storyOutcomes: {},
     };
   }
 
@@ -116,6 +130,8 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       rectificationAttempts: 0,
       affectedStories: [],
       storyCosts: {},
+      storyDurations: {},
+      storyOutcomes: {},
     };
   }
 
@@ -152,6 +168,8 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       rectificationAttempts: 0,
       affectedStories: [],
       storyCosts: {},
+      storyDurations: {},
+      storyOutcomes: {},
     };
   }
 
@@ -173,6 +191,8 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       rectificationAttempts: 0,
       affectedStories: [],
       storyCosts: {},
+      storyDurations: {},
+      storyOutcomes: {},
     };
   }
 
@@ -187,6 +207,8 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       rectificationAttempts: 0,
       affectedStories: [],
       storyCosts: {},
+      storyDurations: {},
+      storyOutcomes: {},
     };
   }
 
@@ -200,6 +222,8 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       rectificationAttempts: 0,
       affectedStories: [],
       storyCosts: {},
+      storyDurations: {},
+      storyOutcomes: {},
     };
   }
 
@@ -223,6 +247,8 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       rectificationAttempts: 0,
       affectedStories: [],
       storyCosts: {},
+      storyDurations: {},
+      storyOutcomes: {},
     };
   }
 
@@ -273,6 +299,8 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
       rectificationAttempts: 0,
       affectedStories: Array.from(affectedStories),
       storyCosts: {},
+      storyDurations: {},
+      storyOutcomes: {},
     };
   }
 
@@ -281,8 +309,10 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
   let storiesRectified = 0;
   let currentTestOutput = fullSuiteResult.output;
   const affectedStoriesList = Array.from(affectedStoriesObjs.values());
-  // Accumulated rectification cost per story — populated below for metrics back-fill (issue #679).
+  // Accumulated rectification telemetry per story — populated below for metrics back-fill (issue #679).
   const storyCostAccum: Record<string, number> = {};
+  const storyDurationAccum: Record<string, number> = {};
+  const storyOutcomeAccum: Record<string, boolean> = {};
 
   for (const story of affectedStoriesList) {
     for (let attempt = 0; attempt < maxRectificationAttempts; attempt++) {
@@ -302,8 +332,13 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
         featureName: prd.feature,
       });
 
-      // Accumulate cost regardless of whether the attempt succeeded (issue #679).
+      // Accumulate telemetry regardless of whether the attempt succeeded (issue #679).
+      // Story outcome is latched true once any attempt succeeds; default false otherwise.
       storyCostAccum[story.id] = (storyCostAccum[story.id] ?? 0) + rectResult.cost;
+      storyDurationAccum[story.id] = (storyDurationAccum[story.id] ?? 0) + rectResult.durationMs;
+      if (!storyOutcomeAccum[story.id]) {
+        storyOutcomeAccum[story.id] = rectResult.succeeded;
+      }
 
       if (rectResult.succeeded) {
         storiesRectified++;
@@ -334,6 +369,8 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
             rectificationAttempts,
             affectedStories: Array.from(affectedStories),
             storyCosts: storyCostAccum,
+            storyDurations: storyDurationAccum,
+            storyOutcomes: storyOutcomeAccum,
           };
         }
 
@@ -371,5 +408,7 @@ export async function runDeferredRegression(options: DeferredRegressionOptions):
     rectificationAttempts,
     affectedStories: Array.from(affectedStories),
     storyCosts: storyCostAccum,
+    storyDurations: storyDurationAccum,
+    storyOutcomes: storyOutcomeAccum,
   };
 }

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -144,10 +144,14 @@ export const reviewStage: PipelineStage = {
     // Fail-closed when fail-open occurs in a retry context (autofix has already run ≥1 time).
     // A reviewer that cannot parse its LLM response is ambiguous — it must not count as a
     // genuine pass when the review was previously failing with real blocking findings.
-    const failOpenChecks =
-      (ctx.reviewResult?.success ?? false)
-        ? (result.builtIn.checks ?? []).filter((c) => c.failOpen).map((c) => c.check)
-        : [];
+    //
+    // Invariant: fail-open only lands here with result.builtIn.success === true, which
+    // implies every plugin/mechanical check already passed. There are therefore no
+    // pluginFindings or semanticFindings to gather (the `!result.success` branch below
+    // handles that case), so skipping straight to `continue` loses no information.
+    const failOpenChecks = result.builtIn.success
+      ? (result.builtIn.checks ?? []).filter((c) => c.failOpen).map((c) => c.check)
+      : [];
     if (failOpenChecks.length > 0 && (ctx.autofixAttempt ?? 0) > 0) {
       logger.warn("review", "Fail-open on partial-progress retry — treating as failure (fail-closed on ambiguity)", {
         storyId: ctx.story.id,

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -14,7 +14,7 @@
  */
 
 import type { IAgentManager } from "../agents";
-import { MAX_AGENT_OUTPUT_CHARS, computeAcpHandle } from "../agents/acp/adapter";
+import { computeAcpHandle } from "../agents/acp/adapter";
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config/schema-types";
@@ -29,6 +29,7 @@ import { tryParseLLMJson } from "../utils/llm-json";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
 import { collectDiff, collectDiffStat, computeTestInventory, resolveEffectiveRef } from "./diff-utils";
 import { writeReviewAudit } from "./review-audit";
+import { looksLikeTruncatedJson } from "./truncation";
 import type { AdversarialReviewConfig, ReviewCheckResult, SemanticStory } from "./types";
 
 /** Injectable dependencies for adversarial.ts — allows tests to mock without mock.module() */
@@ -71,19 +72,6 @@ function parseAdversarialResponse(raw: string): AdversarialLLMResponse | null {
   } catch {
     return null;
   }
-}
-
-/**
- * Returns true when the raw response was almost certainly truncated by the
- * ACP adapter's MAX_AGENT_OUTPUT_CHARS tail-truncation cap.
- *
- * The adapter keeps the LAST N chars (tail truncation), so a truncated response
- * ends at the cap boundary — not at a natural JSON close. Checking for a near-cap
- * length is more reliable than heuristics on the string content, since the tail
- * may start anywhere inside the JSON and may or may not end with `}`.
- */
-export function looksLikeTruncatedJson(raw: string): boolean {
-  return raw.trimEnd().length >= MAX_AGENT_OUTPUT_CHARS - 100;
 }
 
 /** Format findings into readable text output. */

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -23,9 +23,9 @@ import { ReviewPromptBuilder } from "../prompts";
 import { resolveReviewExcludePatterns, resolveTestFilePatterns } from "../test-runners";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
-import { looksLikeTruncatedJson } from "./adversarial";
 import { DIFF_CAP_BYTES, collectDiff, collectDiffStat, resolveEffectiveRef, truncateDiff } from "./diff-utils";
 import { writeReviewAudit } from "./review-audit";
+import { looksLikeTruncatedJson } from "./truncation";
 import type { ReviewCheckResult, SemanticReviewConfig, SemanticStory } from "./types";
 
 // Re-export so existing callers (`import type { SemanticStory } from "./semantic"`) keep working.

--- a/src/review/truncation.ts
+++ b/src/review/truncation.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared helpers for detecting ACP output-cap truncation in LLM reviewer responses.
+ *
+ * Both adversarial and semantic reviewers parse JSON responses from the agent. The ACP
+ * adapter tail-truncates output at MAX_AGENT_OUTPUT_CHARS, so a near-cap response is
+ * almost certainly corrupted mid-stream. Detecting this lets reviewers choose a condensed
+ * retry prompt (vs. a standard "return valid JSON" retry) to avoid re-triggering the cap.
+ */
+
+import { MAX_AGENT_OUTPUT_CHARS } from "../agents/acp/adapter";
+
+export { MAX_AGENT_OUTPUT_CHARS };
+
+/**
+ * Returns true when the raw response was almost certainly truncated by the
+ * ACP adapter's MAX_AGENT_OUTPUT_CHARS tail-truncation cap.
+ *
+ * The adapter keeps the LAST N chars (tail truncation), so a truncated response
+ * ends at the cap boundary — not at a natural JSON close. Checking for a near-cap
+ * length is more reliable than heuristics on the string content, since the tail
+ * may start anywhere inside the JSON and may or may not end with `}`.
+ */
+export function looksLikeTruncatedJson(raw: string): boolean {
+  return raw.trimEnd().length >= MAX_AGENT_OUTPUT_CHARS - 100;
+}

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -133,10 +133,14 @@ export const _rectificationDeps = {
   runDebate: _defaultRunDebate as typeof _defaultRunDebate,
 };
 
-/** Run the rectification retry loop. Returns whether all failures were fixed and the accumulated agent cost. */
+/**
+ * Run the rectification retry loop.
+ * Returns whether all failures were fixed, the accumulated agent cost, and total wall-clock duration.
+ */
 export async function runRectificationLoop(
   opts: RectificationLoopOptions,
-): Promise<{ succeeded: boolean; cost: number }> {
+): Promise<{ succeeded: boolean; cost: number; durationMs: number }> {
+  const loopStartMs = Date.now();
   const {
     config,
     workdir,
@@ -486,7 +490,7 @@ export async function runRectificationLoop(
     throw error;
   });
 
-  return { succeeded, cost: costAccum };
+  return { succeeded, cost: costAccum, durationMs: Date.now() - loopStartMs };
 }
 
 /**
@@ -496,7 +500,7 @@ export async function runRectificationLoop(
 export function runRectificationLoopFromCtx(
   ctx: PipelineContext,
   opts: { testCommand: string; testOutput: string; promptPrefix?: string; testScopedTemplate?: string },
-): Promise<{ succeeded: boolean; cost: number }> {
+): Promise<{ succeeded: boolean; cost: number; durationMs: number }> {
   return runRectificationLoop({
     config: ctx.config,
     workdir: ctx.workdir,

--- a/test/unit/execution/lifecycle/run-completion-backfill.test.ts
+++ b/test/unit/execution/lifecycle/run-completion-backfill.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for regression-gate storyMetrics back-fill + merge behavior in handleRunCompletion.
+ *
+ * Two code paths live in src/execution/lifecycle/run-completion.ts:
+ *   1. Back-fill: a story has no entry in allStoryMetrics (resume-run / prior batch) → inject
+ *      a synthetic "rectification" entry using per-story cost, duration, and outcome.
+ *   2. Merge:    a story already has an entry (normal execution loop + regression-gate
+ *      rectification in the same run) → fold the regression cost + duration into the existing
+ *      entry, mark firstPassSuccess:false, and preserve the normal-loop success unless the
+ *      regression attempt failed.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import type { NaxConfig } from "../../../../src/config";
+import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
+import {
+  type RunCompletionOptions,
+  _runCompletionDeps,
+  handleRunCompletion,
+} from "../../../../src/execution/lifecycle/run-completion";
+import type { DeferredRegressionResult } from "../../../../src/execution/lifecycle/run-regression";
+import type { StoryMetrics } from "../../../../src/metrics";
+import { pipelineEventBus } from "../../../../src/pipeline/event-bus";
+import type { PRD, UserStory } from "../../../../src/prd";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStory(id: string, status: UserStory["status"]): UserStory {
+  return {
+    id,
+    title: `Story ${id}`,
+    description: "Test story",
+    acceptanceCriteria: [],
+    tags: [],
+    dependencies: [],
+    status,
+    passes: status === "passed",
+    escalations: [],
+    attempts: 1,
+  };
+}
+
+function makePRD(ids: string[]): PRD {
+  return {
+    project: "test-project",
+    feature: "test-feature",
+    branchName: "test-branch",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    userStories: ids.map((id) => makeStory(id, "passed")),
+  };
+}
+
+function makeConfig(): NaxConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    execution: {
+      ...DEFAULT_CONFIG.execution,
+      regressionGate: {
+        enabled: true,
+        timeoutSeconds: 30,
+        acceptOnTimeout: true,
+        mode: "deferred",
+        maxRectificationAttempts: 2,
+      },
+    },
+    quality: {
+      ...DEFAULT_CONFIG.quality,
+      commands: { ...DEFAULT_CONFIG.quality.commands, test: "bun test" },
+    },
+  };
+}
+
+function makeStatusWriter() {
+  return {
+    setPrd: mock(() => {}),
+    setCurrentStory: mock(() => {}),
+    setRunStatus: mock(() => {}),
+    setPostRunPhase: mock(() => {}),
+    update: mock(async () => {}),
+    writeFeatureStatus: mock(async () => {}),
+  };
+}
+
+function makeStoryMetrics(overrides: Partial<StoryMetrics>): StoryMetrics {
+  return {
+    storyId: "US-001",
+    complexity: "simple",
+    modelTier: "balanced",
+    modelUsed: "claude-sonnet-4-5",
+    attempts: 1,
+    finalTier: "balanced",
+    success: true,
+    cost: 0.1,
+    durationMs: 1000,
+    firstPassSuccess: true,
+    startedAt: new Date().toISOString(),
+    completedAt: new Date().toISOString(),
+    fullSuiteGatePassed: undefined,
+    ...overrides,
+  };
+}
+
+const WORKDIR = `/tmp/nax-test-backfill-${randomUUID()}`;
+
+function makeOpts(config: NaxConfig, prd: PRD, metrics: StoryMetrics[]): RunCompletionOptions {
+  return {
+    runId: "run-001",
+    feature: "test-feature",
+    startedAt: new Date().toISOString(),
+    prd,
+    allStoryMetrics: metrics,
+    totalCost: 0,
+    storiesCompleted: metrics.length,
+    iterations: 1,
+    startTime: Date.now() - 1000,
+    workdir: WORKDIR,
+    statusWriter: makeStatusWriter() as unknown as RunCompletionOptions["statusWriter"],
+    config,
+  };
+}
+
+const origDeps = { ..._runCompletionDeps };
+
+afterEach(() => {
+  Object.assign(_runCompletionDeps, origDeps);
+  pipelineEventBus.clear();
+  mock.restore();
+});
+
+function mockRegression(regressionResult: DeferredRegressionResult) {
+  _runCompletionDeps.runDeferredRegression = mock(async (): Promise<DeferredRegressionResult> => regressionResult);
+}
+
+// ---------------------------------------------------------------------------
+// Back-fill (story not already in allStoryMetrics)
+// ---------------------------------------------------------------------------
+
+describe("handleRunCompletion — back-fill for stories missing from allStoryMetrics", () => {
+  test("injects a synthetic rectification entry with real per-story duration and outcome", async () => {
+    const prd = makePRD(["US-001"]);
+    const metrics: StoryMetrics[] = []; // no existing entry
+
+    mockRegression({
+      success: false, // overall regression still failing
+      failedTests: 2,
+      failedTestFiles: ["test/foo.test.ts"],
+      passedTests: 8,
+      rectificationAttempts: 1,
+      affectedStories: ["US-001"],
+      storyCosts: { "US-001": 0.42 },
+      storyDurations: { "US-001": 314 },
+      storyOutcomes: { "US-001": true }, // story itself succeeded, but suite still failing
+    });
+
+    await handleRunCompletion(makeOpts(makeConfig(), prd, metrics));
+
+    expect(metrics).toHaveLength(1);
+    const entry = metrics[0];
+    expect(entry.storyId).toBe("US-001");
+    expect(entry.source).toBe("rectification");
+    expect(entry.cost).toBeCloseTo(0.42);
+    expect(entry.durationMs).toBe(314);
+    expect(entry.rectificationCost).toBeCloseTo(0.42);
+    expect(entry.firstPassSuccess).toBe(false);
+    // Uses per-story outcome, NOT the overall regression success
+    expect(entry.success).toBe(true);
+  });
+
+  test("falls back to overall regression success when per-story outcome is absent", async () => {
+    const prd = makePRD(["US-001"]);
+    const metrics: StoryMetrics[] = [];
+
+    mockRegression({
+      success: false,
+      failedTests: 1,
+      failedTestFiles: [],
+      passedTests: 0,
+      rectificationAttempts: 1,
+      affectedStories: ["US-001"],
+      storyCosts: { "US-001": 0.1 },
+      // storyOutcomes intentionally omitted (older mock shape)
+    });
+
+    await handleRunCompletion(makeOpts(makeConfig(), prd, metrics));
+
+    expect(metrics[0].success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Merge (story already exists in allStoryMetrics)
+// ---------------------------------------------------------------------------
+
+describe("handleRunCompletion — merge regression cost into existing storyMetrics", () => {
+  test("folds rectification cost and duration into the normal-loop entry", async () => {
+    const prd = makePRD(["US-001"]);
+    const existing = makeStoryMetrics({
+      storyId: "US-001",
+      cost: 0.5,
+      durationMs: 2000,
+      rectificationCost: 0.05,
+      firstPassSuccess: true,
+      success: true,
+    });
+    const metrics: StoryMetrics[] = [existing];
+
+    mockRegression({
+      success: true,
+      failedTests: 0,
+      failedTestFiles: [],
+      passedTests: 5,
+      rectificationAttempts: 1,
+      affectedStories: ["US-001"],
+      storyCosts: { "US-001": 0.3 },
+      storyDurations: { "US-001": 500 },
+      storyOutcomes: { "US-001": true },
+    });
+
+    await handleRunCompletion(makeOpts(makeConfig(), prd, metrics));
+
+    expect(metrics).toHaveLength(1); // still one entry
+    const merged = metrics[0];
+    expect(merged.cost).toBeCloseTo(0.8); // 0.5 + 0.3
+    expect(merged.durationMs).toBe(2500); // 2000 + 500
+    expect(merged.rectificationCost).toBeCloseTo(0.35); // 0.05 + 0.3
+    // A story that went through regression-gate rectification is NOT a clean first pass
+    expect(merged.firstPassSuccess).toBe(false);
+    // Rectification succeeded — overall success preserved
+    expect(merged.success).toBe(true);
+  });
+
+  test("marks existing entry success=false when regression-gate rectification failed", async () => {
+    const prd = makePRD(["US-001"]);
+    const existing = makeStoryMetrics({ storyId: "US-001", success: true });
+    const metrics: StoryMetrics[] = [existing];
+
+    mockRegression({
+      success: false,
+      failedTests: 1,
+      failedTestFiles: [],
+      passedTests: 0,
+      rectificationAttempts: 2,
+      affectedStories: ["US-001"],
+      storyCosts: { "US-001": 0.2 },
+      storyDurations: { "US-001": 100 },
+      storyOutcomes: { "US-001": false },
+    });
+
+    await handleRunCompletion(makeOpts(makeConfig(), prd, metrics));
+
+    expect(metrics[0].success).toBe(false);
+    expect(metrics[0].firstPassSuccess).toBe(false);
+  });
+
+  test("initializes rectificationCost from 0 when the existing entry has no prior rectification", async () => {
+    const prd = makePRD(["US-001"]);
+    const existing = makeStoryMetrics({ storyId: "US-001", rectificationCost: undefined });
+    const metrics: StoryMetrics[] = [existing];
+
+    mockRegression({
+      success: true,
+      failedTests: 0,
+      failedTestFiles: [],
+      passedTests: 1,
+      rectificationAttempts: 1,
+      affectedStories: ["US-001"],
+      storyCosts: { "US-001": 0.25 },
+      storyDurations: { "US-001": 200 },
+      storyOutcomes: { "US-001": true },
+    });
+
+    await handleRunCompletion(makeOpts(makeConfig(), prd, metrics));
+
+    expect(metrics[0].rectificationCost).toBeCloseTo(0.25);
+  });
+});

--- a/test/unit/execution/lifecycle/run-completion-backfill.test.ts
+++ b/test/unit/execution/lifecycle/run-completion-backfill.test.ts
@@ -13,7 +13,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import type { NaxConfig } from "../../../../src/config";
-import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
 import {
   type RunCompletionOptions,
   _runCompletionDeps,
@@ -22,57 +21,38 @@ import {
 import type { DeferredRegressionResult } from "../../../../src/execution/lifecycle/run-regression";
 import type { StoryMetrics } from "../../../../src/metrics";
 import { pipelineEventBus } from "../../../../src/pipeline/event-bus";
-import type { PRD, UserStory } from "../../../../src/prd";
+import type { PRD } from "../../../../src/prd";
+import { makeNaxConfig, makePRD as makePRDHelper, makeStory } from "../../../helpers";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeStory(id: string, status: UserStory["status"]): UserStory {
-  return {
-    id,
-    title: `Story ${id}`,
-    description: "Test story",
-    acceptanceCriteria: [],
-    tags: [],
-    dependencies: [],
-    status,
-    passes: status === "passed",
-    escalations: [],
-    attempts: 1,
-  };
-}
-
 function makePRD(ids: string[]): PRD {
-  return {
+  return makePRDHelper({
     project: "test-project",
     feature: "test-feature",
     branchName: "test-branch",
-    createdAt: new Date().toISOString(),
-    updatedAt: new Date().toISOString(),
-    userStories: ids.map((id) => makeStory(id, "passed")),
-  };
+    userStories: ids.map((id) =>
+      makeStory({ id, title: `Story ${id}`, description: "Test story", status: "passed", passes: true, attempts: 1 }),
+    ),
+  });
 }
 
-function makeConfig(): NaxConfig {
-  return {
-    ...DEFAULT_CONFIG,
-    execution: {
-      ...DEFAULT_CONFIG.execution,
-      regressionGate: {
-        enabled: true,
-        timeoutSeconds: 30,
-        acceptOnTimeout: true,
-        mode: "deferred",
-        maxRectificationAttempts: 2,
-      },
+const REGRESSION_CONFIG: NaxConfig = makeNaxConfig({
+  execution: {
+    regressionGate: {
+      enabled: true,
+      timeoutSeconds: 30,
+      acceptOnTimeout: true,
+      mode: "deferred",
+      maxRectificationAttempts: 2,
     },
-    quality: {
-      ...DEFAULT_CONFIG.quality,
-      commands: { ...DEFAULT_CONFIG.quality.commands, test: "bun test" },
-    },
-  };
-}
+  },
+  quality: {
+    commands: { test: "bun test" },
+  },
+});
 
 function makeStatusWriter() {
   return {
@@ -156,7 +136,7 @@ describe("handleRunCompletion — back-fill for stories missing from allStoryMet
       storyOutcomes: { "US-001": true }, // story itself succeeded, but suite still failing
     });
 
-    await handleRunCompletion(makeOpts(makeConfig(), prd, metrics));
+    await handleRunCompletion(makeOpts(REGRESSION_CONFIG, prd, metrics));
 
     expect(metrics).toHaveLength(1);
     const entry = metrics[0];
@@ -185,7 +165,7 @@ describe("handleRunCompletion — back-fill for stories missing from allStoryMet
       // storyOutcomes intentionally omitted (older mock shape)
     });
 
-    await handleRunCompletion(makeOpts(makeConfig(), prd, metrics));
+    await handleRunCompletion(makeOpts(REGRESSION_CONFIG, prd, metrics));
 
     expect(metrics[0].success).toBe(false);
   });
@@ -220,7 +200,7 @@ describe("handleRunCompletion — merge regression cost into existing storyMetri
       storyOutcomes: { "US-001": true },
     });
 
-    await handleRunCompletion(makeOpts(makeConfig(), prd, metrics));
+    await handleRunCompletion(makeOpts(REGRESSION_CONFIG, prd, metrics));
 
     expect(metrics).toHaveLength(1); // still one entry
     const merged = metrics[0];
@@ -250,7 +230,7 @@ describe("handleRunCompletion — merge regression cost into existing storyMetri
       storyOutcomes: { "US-001": false },
     });
 
-    await handleRunCompletion(makeOpts(makeConfig(), prd, metrics));
+    await handleRunCompletion(makeOpts(REGRESSION_CONFIG, prd, metrics));
 
     expect(metrics[0].success).toBe(false);
     expect(metrics[0].firstPassSuccess).toBe(false);
@@ -273,7 +253,7 @@ describe("handleRunCompletion — merge regression cost into existing storyMetri
       storyOutcomes: { "US-001": true },
     });
 
-    await handleRunCompletion(makeOpts(makeConfig(), prd, metrics));
+    await handleRunCompletion(makeOpts(REGRESSION_CONFIG, prd, metrics));
 
     expect(metrics[0].rectificationCost).toBeCloseTo(0.25);
   });

--- a/test/unit/execution/lifecycle/run-regression.test.ts
+++ b/test/unit/execution/lifecycle/run-regression.test.ts
@@ -11,9 +11,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { NaxConfig } from "../../../../src/config";
 import { _regressionDeps, runDeferredRegression } from "../../../../src/execution/lifecycle/run-regression";
 import type { DeferredRegressionOptions } from "../../../../src/execution/lifecycle/run-regression";
-import type { NaxConfig } from "../../../../src/config";
 import type { PRD } from "../../../../src/prd";
 import type { VerificationResult } from "../../../../src/verification/types";
 
@@ -101,7 +101,7 @@ describe("runDeferredRegression — initial suite passes", () => {
       verifyCallCount.n++;
       return makePassResult();
     });
-    _regressionDeps.runRectificationLoop = mock(async () => ({ succeeded: false, cost: 0 }));
+    _regressionDeps.runRectificationLoop = mock(async () => ({ succeeded: false, cost: 0, durationMs: 0 }));
     _regressionDeps.parseTestOutput = mock(() => ({ passed: 150, failed: 0, failures: [] }));
     const result = await runDeferredRegression(makeOptions(["US-001", "US-002"]));
 
@@ -139,7 +139,7 @@ describe("runDeferredRegression — early exit after first story", () => {
     const rectifiedStories: string[] = [];
     _regressionDeps.runRectificationLoop = mock(async (opts) => {
       rectifiedStories.push(opts.story.id);
-      return { succeeded: true, cost: 0.5 }; // fixed on first attempt
+      return { succeeded: true, cost: 0.5, durationMs: 200 }; // fixed on first attempt
     });
 
     const result = await runDeferredRegression(makeOptions(["US-001", "US-002", "US-003"]));
@@ -167,9 +167,9 @@ describe("runDeferredRegression — early exit after second story", () => {
     _regressionDeps.runVerification = mock(async () => {
       const call = verifyCalls.length;
       verifyCalls.push(`call-${call}`);
-      if (call === 0) return makeVerifyResult();          // initial: fail
-      if (call === 1) return makeVerifyResult();          // mid-loop after US-001: still fail
-      return makePassResult(100);                          // mid-loop after US-002: pass → early exit
+      if (call === 0) return makeVerifyResult(); // initial: fail
+      if (call === 1) return makeVerifyResult(); // mid-loop after US-001: still fail
+      return makePassResult(100); // mid-loop after US-002: pass → early exit
     });
 
     _regressionDeps.parseTestOutput = mock(() => ({
@@ -180,7 +180,7 @@ describe("runDeferredRegression — early exit after second story", () => {
     const rectifiedStories: string[] = [];
     _regressionDeps.runRectificationLoop = mock(async (opts) => {
       rectifiedStories.push(opts.story.id);
-      return { succeeded: true, cost: 0.3 }; // each story claims it fixed things
+      return { succeeded: true, cost: 0.3, durationMs: 150 }; // each story claims it fixed things
     });
 
     const result = await runDeferredRegression(makeOptions(["US-001", "US-002", "US-003"]));
@@ -212,7 +212,7 @@ describe("runDeferredRegression — no story fixes anything", () => {
       failed: 92,
       failures: [],
     }));
-    _regressionDeps.runRectificationLoop = mock(async () => ({ succeeded: false, cost: 0 })); // never fixed
+    _regressionDeps.runRectificationLoop = mock(async () => ({ succeeded: false, cost: 0, durationMs: 0 })); // never fixed
 
     const result = await runDeferredRegression(makeOptions(["US-001", "US-002"]));
 
@@ -248,7 +248,7 @@ describe("runDeferredRegression — test output context forwarding", () => {
     }));
     _regressionDeps.runRectificationLoop = mock(async (opts) => {
       capturedOutputs.push(opts.testOutput);
-      return { succeeded: true, cost: 0.1 };
+      return { succeeded: true, cost: 0.1, durationMs: 75 };
     });
 
     await runDeferredRegression(makeOptions(["US-001", "US-002"]));
@@ -296,12 +296,12 @@ describe("runDeferredRegression — storyCosts tracking (issue #679)", () => {
       return makePassResult(); // mid-loop after first story: pass
     });
     _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 5, failures: [] }));
-    _regressionDeps.runRectificationLoop = mock(async () => ({ succeeded: true, cost: 1.2559 }));
+    _regressionDeps.runRectificationLoop = mock(async () => ({ succeeded: true, cost: 1.2559, durationMs: 500 }));
 
     const result = await runDeferredRegression(makeOptions(["US-001"]));
 
     expect(result.success).toBe(true);
-    expect(result.storyCosts["US-001"]).toBeCloseTo(1.2559);
+    expect(result.storyCosts?.["US-001"]).toBeCloseTo(1.2559);
   });
 
   test("accumulates cost for multiple attempts on the same story when no early exit fires", async () => {
@@ -313,13 +313,13 @@ describe("runDeferredRegression — storyCosts tracking (issue #679)", () => {
     _regressionDeps.runRectificationLoop = mock(async () => {
       rectifyCallIndex++;
       // Never claim succeeded so there's no mid-loop verify call and we fall through
-      return { succeeded: false, cost: 0.75 };
+      return { succeeded: false, cost: 0.75, durationMs: 120 };
     });
 
     const result = await runDeferredRegression(makeOptions(["US-001"]));
 
     // 2 attempts × $0.75 each — cost accumulated even when failed
-    expect(result.storyCosts["US-001"]).toBeCloseTo(1.5);
+    expect(result.storyCosts?.["US-001"]).toBeCloseTo(1.5);
     expect(rectifyCallIndex).toBe(2); // maxRectificationAttempts = 2
   });
 
@@ -335,13 +335,76 @@ describe("runDeferredRegression — storyCosts tracking (issue #679)", () => {
     let storyIdx = 0;
     _regressionDeps.runRectificationLoop = mock(async () => {
       storyIdx++;
-      return { succeeded: true, cost: storyIdx === 1 ? 0.4 : 0.6 };
+      return { succeeded: true, cost: storyIdx === 1 ? 0.4 : 0.6, durationMs: storyIdx === 1 ? 90 : 110 };
     });
 
     const result = await runDeferredRegression(makeOptions(["US-001", "US-002"]));
 
     expect(result.success).toBe(true);
-    expect(result.storyCosts["US-001"]).toBeCloseTo(0.4);
-    expect(result.storyCosts["US-002"]).toBeCloseTo(0.6);
+    expect(result.storyCosts?.["US-001"]).toBeCloseTo(0.4);
+    expect(result.storyCosts?.["US-002"]).toBeCloseTo(0.6);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// storyDurations + storyOutcomes — follow-up to #679
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("runDeferredRegression — storyDurations + storyOutcomes", () => {
+  test("accumulates wall-clock duration per story across rectification attempts", async () => {
+    _regressionDeps.runVerification = mock(async () => makeVerifyResult());
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    _regressionDeps.runRectificationLoop = mock(async () => ({
+      succeeded: false,
+      cost: 0.2,
+      durationMs: 175,
+    }));
+
+    const result = await runDeferredRegression(makeOptions(["US-001"]));
+
+    // 2 attempts × 175 ms
+    expect(result.storyDurations?.["US-001"]).toBe(350);
+  });
+
+  test("storyOutcomes reflects per-story rectification success rather than the overall result", async () => {
+    let verifyCallIndex = 0;
+    _regressionDeps.runVerification = mock(async () => {
+      const i = verifyCallIndex++;
+      if (i === 0) return makeVerifyResult(); // initial: fail
+      if (i === 1) return makeVerifyResult(); // mid after US-001: still fail
+      return makeVerifyResult(); // final re-run: still fail
+    });
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    let storyIdx = 0;
+    _regressionDeps.runRectificationLoop = mock(async () => {
+      storyIdx++;
+      // First story "succeeds" locally but the overall suite still fails; second story fails.
+      return storyIdx === 1
+        ? { succeeded: true, cost: 0.4, durationMs: 80 }
+        : { succeeded: false, cost: 0.5, durationMs: 120 };
+    });
+
+    const result = await runDeferredRegression(makeOptions(["US-001", "US-002"]));
+
+    expect(result.success).toBe(false); // overall still failing
+    expect(result.storyOutcomes?.["US-001"]).toBe(true);
+    expect(result.storyOutcomes?.["US-002"]).toBe(false);
+  });
+
+  test("storyOutcomes latches true once any attempt succeeds", async () => {
+    _regressionDeps.runVerification = mock(async () => makeVerifyResult());
+    _regressionDeps.parseTestOutput = mock(() => ({ passed: 0, failed: 3, failures: [] }));
+    let attempt = 0;
+    _regressionDeps.runRectificationLoop = mock(async () => {
+      attempt++;
+      // First attempt succeeds; early-exit triggers before second attempt.
+      return attempt === 1
+        ? { succeeded: true, cost: 0.3, durationMs: 100 }
+        : { succeeded: false, cost: 0.3, durationMs: 100 };
+    });
+
+    const result = await runDeferredRegression(makeOptions(["US-001"]));
+
+    expect(result.storyOutcomes?.["US-001"]).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Four non-blocking follow-ups surfaced during the code review of PRs #681-#685 (issues #676-#680). All four were recorded as *recommendations* in that review; bundling them here per request.

## Changes

### 1. Extract truncation utility (follow-up to #681 / #676)
- New [src/review/truncation.ts](../blob/refactor/post-review-followups-676-680/src/review/truncation.ts) housing `looksLikeTruncatedJson` + `MAX_AGENT_OUTPUT_CHARS`.
- `semantic.ts` no longer imports a helper from its sibling `adversarial.ts`; both files now depend on the shared module.

### 2. Document fail-open guard invariant (follow-up to #683 / #677)
- Added a multi-line comment at [src/pipeline/stages/review.ts:144](../blob/refactor/post-review-followups-676-680/src/pipeline/stages/review.ts#L144) explaining *why* skipping plugin/semantic finding-gathering in the fail-open-on-retry branch is safe.
- Simplified `(ctx.reviewResult?.success ?? false)` → `result.builtIn.success` (identical semantics since `ctx.reviewResult` was just assigned from `result.builtIn`).

### 3. Thread real per-story duration + outcome through regression gate (follow-up to #684 / #679)
- `runRectificationLoop()` now returns `{ succeeded, cost, durationMs }` (previously dropped duration).
- `DeferredRegressionResult` gains `storyDurations?: Record<string, number>` and `storyOutcomes?: Record<string, boolean>`.
- Back-fill in `run-completion.ts` now uses real values instead of `durationMs: 0` and the overall regression success flag.

### 4. Merge regression cost into existing storyMetrics entries (follow-up to #684 / #679)
- If a story ran in both the normal execution loop AND the regression gate in the same run, the regression cost/duration is now folded into the existing entry instead of being dropped.
- Merged entry: cost and duration summed, `rectificationCost` accumulated, `firstPassSuccess` forced to `false`, `success` preserved unless the regression attempt itself failed.

## Test Plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (454 files, no fixes)
- [x] Targeted tests green (217 tests):
  - `test/unit/execution/lifecycle/run-regression.test.ts` — extended with 3 new tests covering `storyDurations` + `storyOutcomes`
  - `test/unit/execution/lifecycle/run-completion-backfill.test.ts` — new file, 5 tests for back-fill + merge behavior
  - `test/unit/review/semantic-retry-truncation.test.ts` — unchanged, still green after import relocation
  - `test/unit/review/adversarial-retry.test.ts` — unchanged, still green
  - `test/unit/pipeline/stages/review-fail-open.test.ts` — unchanged, still green after simplification
  - `test/unit/verification/rectification-loop.test.ts` — unchanged
  - `test/unit/metrics/` — unchanged
- [ ] CI green on push

## Notes

No behavior change for the common path (single-run story execution without regression-gate rectification). The merge path is exercised only when a story is rectified by the regression gate after completing the normal loop — previously a silent telemetry drop, now visible in `storyMetrics`.