### PR TITLE
fix(review): require semantic evidence in ref mode

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -252,7 +252,7 @@ Controls how the production diff is provided to the semantic reviewer:
 {
   "review": {
     "semantic": {
-      "diffMode": "embedded",
+      "diffMode": "ref",
       "resetRefOnRerun": false
     }
   }
@@ -261,8 +261,8 @@ Controls how the production diff is provided to the semantic reviewer:
 
 | Value | Behaviour |
 |:------|:----------|
-| `"embedded"` (default) | Diff is inlined in the prompt (~50KB cap). Simple, works everywhere. |
-| `"ref"` | Reviewer self-serves via git tools. No diff cap. Better for large changes. |
+| `"ref"` (default) | Reviewer self-serves via git tools. No diff cap. Better for large changes and multi-tier retries. |
+| `"embedded"` | Diff is inlined in the prompt (~50KB cap). Simple, but can lose context in large stories. |
 
 `resetRefOnRerun`: when `true`, clears `storyGitRef` on re-run so it is re-captured fresh. Default: `false`.
 
@@ -445,4 +445,3 @@ exclude: ["**/.nax-acceptance*"]
 ```
 
 **Why this matters:** the acceptance test files import production code with relative paths (e.g. `./src/utils/detect-provider.ts`). They run correctly from their package directory under nax control, but should be excluded from the normal test pipeline to avoid unexpected failures or duplicate runs.
-

--- a/docs/guides/semantic-review.md
+++ b/docs/guides/semantic-review.md
@@ -100,7 +100,7 @@ Add `"semantic"` to `review.checks` in `.nax/config.json`:
   "review": {
     "semantic": {
       "modelTier": "fast",
-      "diffMode": "embedded",
+      "diffMode": "ref",
       "resetRefOnRerun": false,
       "rules": []
     }
@@ -120,8 +120,8 @@ Controls how the production diff is provided to the reviewer:
 
 | Mode | Description | Diff cap | Best for |
 |:-----|:-----------|:---------|:---------|
-| `"embedded"` (default) | Diff is inlined directly in the prompt | ~50KB | Small-to-medium diffs, simple review |
-| `"ref"` | Reviewer self-serves via git tools (READ, GREP) | No cap | Large diffs, adversarial review |
+| `"ref"` (default) | Reviewer self-serves via git tools (READ, GREP) | No cap | Large diffs, multi-tier retries |
+| `"embedded"` | Diff is inlined directly in the prompt | ~50KB | Small-to-medium diffs, simple review |
 
 In `"ref"` mode, the reviewer receives the story's `storyGitRef` and uses git commands to inspect the diff on demand. This removes the 50KB cap and lets the reviewer focus on specific files rather than scanning the entire diff.
 

--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -139,7 +139,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "review.semantic": "Semantic review configuration (code quality analysis)",
   "review.semantic.modelTier": "Model tier for semantic review (default: balanced)",
   "review.semantic.diffMode":
-    "How the semantic reviewer accesses the git diff. 'embedded' (default) includes the diff in the prompt (truncated at 50KB). 'ref' passes only the git ref and file list — the reviewer fetches the full diff via tools. Use 'ref' for large stories or multi-tier escalations where truncation loses context.",
+    "How the semantic reviewer accesses the git diff. 'ref' (default) passes only the git ref and file list — the reviewer fetches the full diff via tools. 'embedded' includes the diff in the prompt (truncated at 50KB).",
   "review.semantic.resetRefOnRerun":
     "When true, clears storyGitRef on failed stories during re-run initialization so the ref is re-captured at the next story start. Prevents cross-story diff pollution when multiple stories exhaust all tiers and are re-run. Default: false.",
   "review.semantic.rules": "Custom semantic review rules to enforce",

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -19,13 +19,14 @@ const SEMANTIC_ROLE =
 
 const SEMANTIC_INSTRUCTIONS = `## Instructions
 
-For each acceptance criterion, verify the diff implements it correctly.
+For each acceptance criterion, verify the current codebase implements it correctly. Use the diff to identify changed files and code paths, not as the only source of truth.
 
 **Before reporting any finding as "error", you MUST verify it using your tools:**
 - If you suspect a key, function, import, or variable is missing, READ the relevant file to confirm before flagging.
 - If you suspect a code path is not wired in, GREP for its usage to confirm.
 - Do NOT flag something as missing based solely on its absence from the diff — it may already exist in the codebase. Check the actual file first.
 - If you cannot verify a claim even after checking, use "unverifiable" severity instead of "error".
+- Every "error" finding must include verifiedBy evidence from the current codebase. If you cannot provide verifiedBy, downgrade the finding to "unverifiable".
 
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)
@@ -44,7 +45,13 @@ const SEMANTIC_OUTPUT_SCHEMA = `Respond with JSON only — no explanation text b
       "file": "path/to/file",
       "line": 42,
       "issue": "description of the issue",
-      "suggestion": "how to fix it"
+      "suggestion": "how to fix it",
+      "verifiedBy": {
+        "command": "command used to inspect the current codebase",
+        "file": "path/to/file",
+        "line": 42,
+        "observed": "specific code fact observed"
+      }
     }
   ]
 }

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -271,7 +271,7 @@ export class ReviewOrchestrator {
         };
         const semanticCfg = reviewConfig.semantic ?? {
           modelTier: "balanced" as const,
-          diffMode: "embedded" as const,
+          diffMode: "ref" as const,
           resetRefOnRerun: false,
           rules: [] as string[],
           timeoutMs: 600_000,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -44,6 +44,12 @@ interface LLMFinding {
   issue: string;
   suggestion: string;
   acId?: string;
+  verifiedBy?: {
+    command?: string;
+    file: string;
+    line?: number;
+    observed: string;
+  };
 }
 
 interface LLMResponse {
@@ -104,12 +110,52 @@ const SEVERITY_RANK: Record<string, number> = {
   critical: 3,
 };
 
+const UNVERIFIED_FINDING_PATTERNS = [
+  "cannot verify",
+  "can't verify",
+  "from diff alone",
+  "missing from diff",
+  "not found in diff",
+  "not present in diff",
+  "does not appear in diff",
+] as const;
+
 /**
  * Check whether a normalized finding severity meets or exceeds the blocking threshold.
  * threshold defaults to "error" — only error/critical block unless configured stricter.
  */
 function isBlockingSeverity(sev: string, threshold: "error" | "warning" | "info" = "error"): boolean {
   return (SEVERITY_RANK[sev] ?? 0) >= (SEVERITY_RANK[threshold] ?? 2);
+}
+
+/** Ref-mode semantic errors must prove they were verified against current files. */
+function sanitizeRefModeFindings(findings: LLMFinding[], diffMode: SemanticReviewConfig["diffMode"]): LLMFinding[] {
+  if (diffMode !== "ref") return findings;
+  return findings.map((finding) =>
+    needsDowngradeForMissingEvidence(finding) ? downgradeToUnverifiable(finding) : finding,
+  );
+}
+
+function needsDowngradeForMissingEvidence(finding: LLMFinding): boolean {
+  if ((SEVERITY_RANK[finding.severity] ?? 0) < SEVERITY_RANK.error) return false;
+  return mentionsUnverifiedSource(finding) || !hasVerifiedEvidence(finding);
+}
+
+function mentionsUnverifiedSource(finding: LLMFinding): boolean {
+  const text = `${finding.issue} ${finding.suggestion}`.toLowerCase();
+  return UNVERIFIED_FINDING_PATTERNS.some((pattern) => text.includes(pattern));
+}
+
+function hasVerifiedEvidence(finding: LLMFinding): boolean {
+  const evidence = finding.verifiedBy;
+  return !!evidence?.file?.trim() && !!evidence.observed?.trim();
+}
+
+function downgradeToUnverifiable(finding: LLMFinding): LLMFinding {
+  return {
+    ...finding,
+    severity: "unverifiable",
+  };
 }
 
 /** Convert LLMFinding[] to ReviewFinding[] with semantic-review metadata. */
@@ -352,9 +398,10 @@ export async function runSemanticReview(
     }
 
     // Split debate findings by blocking threshold
+    const debateFindings = sanitizeRefModeFindings(deduped, diffMode);
     const debateThreshold = blockingThreshold ?? "error";
-    const debateBlocking = deduped.filter((f) => isBlockingSeverity(f.severity, debateThreshold));
-    const debateAdvisory = deduped.filter((f) => !isBlockingSeverity(f.severity, debateThreshold));
+    const debateBlocking = debateFindings.filter((f) => isBlockingSeverity(f.severity, debateThreshold));
+    const debateAdvisory = debateFindings.filter((f) => !isBlockingSeverity(f.severity, debateThreshold));
 
     const durationMs = Date.now() - startTime;
     if (!resolverPassed) {
@@ -572,6 +619,9 @@ export async function runSemanticReview(
     };
   }
 
+  const sanitizedFindings = sanitizeRefModeFindings(parsed.findings, diffMode);
+  const sanitizedParsed: LLMResponse = { ...parsed, findings: sanitizedFindings };
+
   if (naxConfig?.review?.audit?.enabled) {
     void _semanticDeps.writeReviewAudit({
       reviewer: "semantic",
@@ -580,14 +630,14 @@ export async function runSemanticReview(
       storyId: story.id,
       featureName,
       parsed: true,
-      result: { passed: parsed.passed, findings: parsed.findings },
+      result: { passed: sanitizedParsed.passed, findings: sanitizedParsed.findings },
     });
   }
 
   // Split findings by blocking threshold
   const threshold = blockingThreshold ?? "error";
-  const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity, threshold));
-  const advisoryFindings = parsed.findings.filter((f) => !isBlockingSeverity(f.severity, threshold));
+  const blockingFindings = sanitizedParsed.findings.filter((f) => isBlockingSeverity(f.severity, threshold));
+  const advisoryFindings = sanitizedParsed.findings.filter((f) => !isBlockingSeverity(f.severity, threshold));
 
   if (advisoryFindings.length > 0) {
     logger?.debug(
@@ -601,7 +651,7 @@ export async function runSemanticReview(
   }
 
   // Format findings and populate structured ReviewFinding[]
-  if (!parsed.passed && blockingFindings.length > 0) {
+  if (!sanitizedParsed.passed && blockingFindings.length > 0) {
     const durationMs = Date.now() - startTime;
     logger?.warn("review", `Semantic review failed: ${blockingFindings.length} blocking findings`, {
       storyId: story.id,
@@ -632,7 +682,7 @@ export async function runSemanticReview(
   }
 
   // If LLM said failed but all findings are advisory (below threshold), override to pass
-  if (!parsed.passed && blockingFindings.length === 0) {
+  if (!sanitizedParsed.passed && blockingFindings.length === 0) {
     const durationMs = Date.now() - startTime;
     logger?.info("review", "Semantic review passed (all findings below blocking threshold)", {
       storyId: story.id,
@@ -651,15 +701,15 @@ export async function runSemanticReview(
   }
 
   const durationMs = Date.now() - startTime;
-  if (parsed.passed) {
+  if (sanitizedParsed.passed) {
     logger?.info("review", "Semantic review passed", { storyId: story.id, durationMs });
   }
   return {
     check: "semantic",
-    success: parsed.passed,
+    success: sanitizedParsed.passed,
     command: "",
-    exitCode: parsed.passed ? 0 : 1,
-    output: parsed.passed ? "Semantic review passed" : "Semantic review failed (no findings)",
+    exitCode: sanitizedParsed.passed ? 0 : 1,
+    output: sanitizedParsed.passed ? "Semantic review passed" : "Semantic review failed (no findings)",
     durationMs,
     advisoryFindings: advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings) : undefined,
     cost: llmCost,

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -30,8 +30,8 @@ export interface SemanticReviewConfig {
   modelTier: import("../config/schema-types").ModelTier;
   /**
    * How the semantic reviewer accesses the git diff.
-   * "embedded" (default): pre-collected diff truncated at 50KB and embedded in prompt.
-   * "ref": only stat summary + storyGitRef passed; reviewer fetches full diff via tools.
+   * "embedded": pre-collected diff truncated at 50KB and embedded in prompt.
+   * "ref" (default): only stat summary + storyGitRef passed; reviewer fetches full diff via tools.
    */
   diffMode: "embedded" | "ref";
   /**

--- a/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
@@ -22,13 +22,14 @@ diff --git a/src/review/semantic.ts b/src/review/semantic.ts
 
 ## Instructions
 
-For each acceptance criterion, verify the diff implements it correctly.
+For each acceptance criterion, verify the current codebase implements it correctly. Use the diff to identify changed files and code paths, not as the only source of truth.
 
 **Before reporting any finding as "error", you MUST verify it using your tools:**
 - If you suspect a key, function, import, or variable is missing, READ the relevant file to confirm before flagging.
 - If you suspect a code path is not wired in, GREP for its usage to confirm.
 - Do NOT flag something as missing based solely on its absence from the diff — it may already exist in the codebase. Check the actual file first.
 - If you cannot verify a claim even after checking, use "unverifiable" severity instead of "error".
+- Every "error" finding must include verifiedBy evidence from the current codebase. If you cannot provide verifiedBy, downgrade the finding to "unverifiable".
 
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)
@@ -46,7 +47,13 @@ Respond with JSON only — no explanation text before or after:
       "file": "path/to/file",
       "line": 42,
       "issue": "description of the issue",
-      "suggestion": "how to fix it"
+      "suggestion": "how to fix it",
+      "verifiedBy": {
+        "command": "command used to inspect the current codebase",
+        "file": "path/to/file",
+        "line": 42,
+        "observed": "specific code fact observed"
+      }
     }
   ]
 }
@@ -82,13 +89,14 @@ diff --git a/src/review/semantic.ts b/src/review/semantic.ts
 
 ## Instructions
 
-For each acceptance criterion, verify the diff implements it correctly.
+For each acceptance criterion, verify the current codebase implements it correctly. Use the diff to identify changed files and code paths, not as the only source of truth.
 
 **Before reporting any finding as "error", you MUST verify it using your tools:**
 - If you suspect a key, function, import, or variable is missing, READ the relevant file to confirm before flagging.
 - If you suspect a code path is not wired in, GREP for its usage to confirm.
 - Do NOT flag something as missing based solely on its absence from the diff — it may already exist in the codebase. Check the actual file first.
 - If you cannot verify a claim even after checking, use "unverifiable" severity instead of "error".
+- Every "error" finding must include verifiedBy evidence from the current codebase. If you cannot provide verifiedBy, downgrade the finding to "unverifiable".
 
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)
@@ -106,7 +114,13 @@ Respond with JSON only — no explanation text before or after:
       "file": "path/to/file",
       "line": 42,
       "issue": "description of the issue",
-      "suggestion": "how to fix it"
+      "suggestion": "how to fix it",
+      "verifiedBy": {
+        "command": "command used to inspect the current codebase",
+        "file": "path/to/file",
+        "line": 42,
+        "observed": "specific code fact observed"
+      }
     }
   ]
 }

--- a/test/unit/review/orchestrator.test.ts
+++ b/test/unit/review/orchestrator.test.ts
@@ -440,6 +440,19 @@ describe("ReviewOrchestrator — retrySkipChecks in parallel LLM dispatch (#136)
     expect(_orchestratorDeps.runAdversarialReview).toHaveBeenCalledTimes(1);
   });
 
+  test("defaults semantic diffMode to ref in parallel path when semantic config is omitted", async () => {
+    let observedDiffMode: unknown;
+    _orchestratorDeps.runSemanticReview = mock(async (...args: Parameters<typeof _orchestratorDeps.runSemanticReview>) => {
+      observedDiffMode = args[3].diffMode;
+      return makePassedCheck("semantic");
+    });
+    const orchestrator = new ReviewOrchestrator();
+
+    await orchestrator.review(makeParallelConfig(), "/tmp/workdir", minimalExecConfig);
+
+    expect(observedDiffMode).toBe("ref");
+  });
+
   test("runs both reviewers when retrySkipChecks does not include LLM checks", async () => {
     const orchestrator = new ReviewOrchestrator();
     const retrySkipChecks = new Set(["lint", "build"]);

--- a/test/unit/review/semantic-unverifiable.test.ts
+++ b/test/unit/review/semantic-unverifiable.test.ts
@@ -208,6 +208,94 @@ describe("unverifiable finding handling", () => {
     expect(result.advisoryFindings).toBeDefined();
     expect(result.advisoryFindings![0].message).toBe("Minor observation");
   });
+
+  test("ref mode downgrades error findings that were not verified against files", async () => {
+    const response = JSON.stringify({
+      passed: false,
+      findings: [
+        {
+          severity: "error",
+          file: "apps/api/package.json",
+          line: 0,
+          issue: "The evaluate:retrieval script is missing.",
+          suggestion: "Add the script to package.json.",
+        },
+      ],
+    });
+    const agentManager = makeAgentManager(response);
+    const result = await runSemanticReview(
+      "/tmp/repo",
+      "abc123",
+      STORY,
+      { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+      agentManager,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.findings).toBeUndefined();
+    expect(result.advisoryFindings?.length).toBe(1);
+    expect(result.advisoryFindings?.[0].severity).toBe("info");
+  });
+
+  test("ref mode downgrades error findings that admit they only used the diff", async () => {
+    const response = JSON.stringify({
+      passed: false,
+      findings: [
+        {
+          severity: "error",
+          file: "apps/api/src/retrieval/fixtures/eval-queries.json",
+          line: 0,
+          issue: "Cannot verify from diff alone that exactly 50 evaluation queries exist.",
+          suggestion: "Read the fixture to count the queries.",
+        },
+      ],
+    });
+    const agentManager = makeAgentManager(response);
+    const result = await runSemanticReview(
+      "/tmp/repo",
+      "abc123",
+      STORY,
+      { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+      agentManager,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.findings).toBeUndefined();
+    expect(result.advisoryFindings?.[0].message).toContain("Cannot verify from diff alone");
+  });
+
+  test("ref mode preserves verified error findings as blocking", async () => {
+    const response = JSON.stringify({
+      passed: false,
+      findings: [
+        {
+          severity: "error",
+          file: "src/foo.ts",
+          line: 5,
+          issue: "AC not implemented",
+          suggestion: "Implement it",
+          verifiedBy: {
+            command: "sed -n '1,80p' src/foo.ts",
+            file: "src/foo.ts",
+            line: 5,
+            observed: "Function body is empty.",
+          },
+        },
+      ],
+    });
+    const agentManager = makeAgentManager(response);
+    const result = await runSemanticReview(
+      "/tmp/repo",
+      "abc123",
+      STORY,
+      { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+      agentManager,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.findings?.length).toBe(1);
+    expect(result.findings?.[0].message).toBe("AC not implemented");
+  });
 });
 
 describe("semantic prompt includes tool-access instructions", () => {


### PR DESCRIPTION
## Summary

- Align the remaining semantic review fallback with PR #673 by defaulting the parallel semantic path to `diffMode: "ref"` when `review.semantic` is omitted.
- Require semantic-review `error` findings to include current-code `verifiedBy` evidence in the prompt contract.
- Downgrade unverified or "from diff alone" semantic errors to advisory `unverifiable` findings in ref mode, including debate-derived semantic findings.
- Update docs and CLI field descriptions to reflect `ref` as the semantic default.

## Root Cause

Koda's US-005 run inherited `diffMode: "ref"`, but semantic review still blocked on findings that admitted or implied they were not verified against the current codebase. The prompt instructed verification, but the parser accepted unverified `error` findings as blocking.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun test test/unit/review --timeout=30000`
- `bun test test/unit/config/semantic-review.test.ts test/unit/review/semantic-unverifiable.test.ts test/unit/review/orchestrator.test.ts test/unit/prompts/review-builder.test.ts --timeout=30000`

Fixes #695