### PR TITLE
feat(adr-018): Wave 2 — middleware chain + real aggregators + permissions pre-chain

### DIFF
--- a/docs/specs/adr-018-wave-3-followups.md
+++ b/docs/specs/adr-018-wave-3-followups.md
@@ -1,0 +1,199 @@
+# ADR-018 Wave 3 Follow-ups — Session Ownership + Middleware Context Alignment
+
+**Status:** Proposed
+**Owner:** TBD
+**Predecessor:** ADR-018 Wave 2 (PR-697)
+**Filed:** 2026-04-25
+**Origin:** PR-697 review questions Q2 and Q3 — surfaced while landing Finding 5 (lost ACP audit metadata).
+
+---
+
+## Problem 1 — Adapter still owns session lifecycle
+
+### Current state
+
+The ACP adapter (`src/agents/acp/adapter.ts`) owns:
+
+| Concern | Location |
+|:---|:---|
+| Session-name derivation | `computeAcpHandle()` / `buildSessionName()` |
+| Multi-turn loop + `turnCount` | inline `let turnCount = 0` in `run()` |
+| `ensureAcpSession()` / `closeAcpSession()` | adapter lifecycle |
+| `sessionResumed` detection | derived inside `run()` |
+
+Wave 2's Finding 5 fix (commit `68a67816`) had to plumb three of those values
+(`sessionName`, `turn`, `resumed`) back up through `AgentResult.sessionMetadata`
+so the audit middleware could record them. That plumbing exists only because
+`SessionManager` does not own session lifecycle today.
+
+### Target state (per ADR-018 §3.1)
+
+```
+SessionManager (owns: name, lifecycle, turn count, resumed flag)
+  └─ AgentManager.runAs(req, sessionManager)
+       └─ middleware chain (audit reads from sessionManager.snapshot())
+            └─ adapter.sendTurn(handle, prompt)   ← primitive only
+```
+
+`AgentResult.sessionMetadata` goes away. `SessionManager` exposes a snapshot
+that the audit middleware reads directly. Adapters expose lower-level
+primitives (`openHandle`, `sendTurn`, `closeHandle`); `SessionManager`
+orchestrates the multi-turn loop.
+
+### Why this matters
+
+- **Ownership clarity.** Today the same concern is partially in the adapter,
+  partially in `SessionManager`, partially threaded through `AgentResult`.
+  One place wins.
+- **Audit completeness.** When the adapter throws mid-turn, audit never sees
+  `protocolIds` or `sessionMetadata` — they live in `AgentResult` which was
+  never returned. With `SessionManager` owning state, the snapshot is always
+  available to `onError`.
+- **Multi-adapter parity.** A future non-ACP adapter would otherwise need to
+  re-implement session naming + turn counting. The primitives + orchestrator
+  split removes that duplication.
+
+### Migration
+
+1. **Phase A — extract primitives.** Add `openHandle`/`sendTurn`/`closeHandle`
+   to `AgentAdapter`. ACP adapter implements them by extracting code from
+   `run()`. CLI adapter no-ops or wraps the existing single-call shape.
+2. **Phase B — SessionManager orchestrates.** `SessionManager.runInSession`
+   takes ownership of the turn loop. Updates a `SessionSnapshot`
+   (`{ handle, turn, resumed, protocolIds }`) at each transition.
+3. **Phase C — middleware reads from SessionManager.** `MiddlewareContext`
+   gains `sessionSnapshot: () => SessionSnapshot | null`. Audit middleware
+   replaces its `result.sessionMetadata`/`result.protocolIds` reads with the
+   snapshot accessor.
+4. **Phase D — remove `AgentResult.sessionMetadata`** and the adapter's
+   internal turn counter. ACP adapter `run()` becomes a thin wrapper or
+   deletes entirely (replaced by `SessionManager.runInSession`).
+
+### Estimated cost
+
+- Phase A: ~3 days. Mostly mechanical extraction.
+- Phase B: ~5 days. Touches `SessionManager`, snapshot persistence, and the
+  ACP retry loop's interaction-bridge handling.
+- Phase C–D: ~2 days. Mostly delete.
+
+Total: ~2 weeks. Should be its own PR sequence, not bundled with feature work.
+
+---
+
+## Problem 2 — `MiddlewareContext` shape diverges from ADR-018 §3.1
+
+### Current state
+
+```typescript
+// src/runtime/agent-middleware.ts (current)
+export interface MiddlewareContext {
+  readonly runId: string;
+  readonly agentName: string;
+  readonly kind: "run" | "complete" | "plan";
+  readonly request: AgentRunRequest | null;   // null for complete
+  readonly prompt: string | null;              // null for run/plan
+  readonly config: NaxConfig;
+  readonly signal?: AbortSignal;
+  readonly resolvedPermissions: ResolvedPermissions;
+  readonly storyId?: string;
+  readonly stage?: string;
+}
+```
+
+The two correlated fields `request` and `prompt` are split — for `run`/`plan`
+the prompt lives at `request.runOptions.prompt`; for `complete` it lives at
+`ctx.prompt`. Reading "the prompt" requires kind-awareness at every call site.
+
+The PR-697 review surfaced this when Finding 5 had to extract `workdir` /
+`projectDir` / `featureName` from `ctx.request?.runOptions` — workable, but
+the discriminator on `kind` was not used to narrow types automatically.
+
+### Target state (per ADR-018 §3.1)
+
+```typescript
+type MiddlewareContext = RunMiddlewareContext | CompleteMiddlewareContext;
+
+interface MiddlewareContextBase {
+  readonly runId: string;
+  readonly agentName: string;
+  readonly resolvedPermissions: ResolvedPermissions;
+  readonly storyId?: string;
+  readonly stage?: PipelineStage;
+  readonly signal?: AbortSignal;
+}
+
+interface RunMiddlewareContext extends MiddlewareContextBase {
+  readonly kind: "run" | "plan";
+  readonly options: AgentRunOptions;
+  /** Prompt actually sent to the final hop (after fallback transformation). */
+  readonly finalPrompt?: string;
+}
+
+interface CompleteMiddlewareContext extends MiddlewareContextBase {
+  readonly kind: "complete";
+  readonly options: CompleteOptions;
+  readonly prompt: string;
+}
+```
+
+`audit.ts` becomes:
+
+```typescript
+async after(ctx, result, durationMs) {
+  const prompt = ctx.kind === "complete" ? ctx.prompt : (ctx.finalPrompt ?? ctx.options.prompt);
+  if (!prompt) return;
+  const entry: PromptAuditEntry = {
+    // ...
+    workdir: ctx.options.workdir,                                        // typed
+    featureName: ctx.options.featureName,                                // typed
+    projectDir: ctx.kind !== "complete" ? ctx.options.projectDir : undefined,
+    // ...
+  };
+}
+```
+
+No casts. TypeScript narrows via `kind`.
+
+### Why not done in Wave 2
+
+The current shape is functionally equivalent (`AgentRunRequest.runOptions` is
+already strongly typed). The unsafe-looking casts in `audit.ts` were defensive
+coding, not a structural typing requirement, and were removed in the same
+commit that filed this follow-up. The remaining benefit is ergonomic /
+consistency-with-ADR, not correctness.
+
+### Scope
+
+| File | Change |
+|:---|:---|
+| `src/runtime/agent-middleware.ts` | Redefine `MiddlewareContext` as discriminated union |
+| `src/agents/manager.ts` | Update 3 ctx constructions (`runAs`, `completeAs`, `hopCtx`) |
+| `src/runtime/middleware/audit.ts` | Replace `request.runOptions` reads with `options` |
+| `src/runtime/middleware/cost.ts` | Minor — uses shared base fields only |
+| `src/runtime/middleware/logging.ts` | Minor — uses shared base fields only |
+| `src/runtime/middleware/cancellation.ts` | Minor — uses `signal` |
+| `test/unit/runtime/agent-middleware.test.ts` | Update `makeCtx` helper |
+| `test/unit/runtime/middleware/audit.test.ts` | Update ctx fixtures |
+| `test/unit/agents/manager.test.ts` | Update middleware spy setup |
+
+Estimated cost: ~1 day. Single PR, mostly mechanical.
+
+### Optional: also remove `ctx.config`
+
+ADR-018 §3 specifies `AgentManager` reads its own `this._config` rather than
+threading it through `runOptions.config`. The current `MiddlewareContext.config`
+field is unused by any middleware (`audit`, `cost`, `logging`, `cancellation`
+all access `ctx.runId`/`ctx.agentName`/`ctx.stage` instead). Worth removing in
+the same PR for shape consistency.
+
+---
+
+## Sequencing
+
+These two follow-ups are independent. Recommended order:
+
+1. **Problem 2 first** (small, isolated, ADR-aligning). Lands as a single PR.
+2. **Problem 1 second** (multi-week refactor). Can be split into the four
+   phases above as separate PRs.
+
+Tracking issues: TBD (file when picking up).

--- a/docs/specs/cost-token-mapper-decoupling.md
+++ b/docs/specs/cost-token-mapper-decoupling.md
@@ -1,0 +1,457 @@
+# Cost / Token Mapper Decoupling Refactor
+
+**Status:** Draft (rev 2)
+**Date:** 2026-04-25
+**Owner:** Nax Dev
+**Related:** [ADR-018](../adr/ADR-018-runtime-layering-with-session-runners.md), [cost-ssot.md](./cost-ssot.md)
+
+## Revision history
+
+| Rev | Date | Change |
+|:--|:--|:--|
+| 1 | 2026-04-25 | Initial draft — wire-format decoupling via `ITokenUsageMapper`. Treated `exactCostUsd` split as out of scope. |
+| 2 | 2026-04-25 | **Store both exact and estimated cost.** `AgentResult.estimatedCost` → `estimatedCostUsd` (always present) + new `exactCostUsd?` (when wire reports it). `CostEvent` carries both. Cost-calc ownership decision recorded explicitly: cost module owns the function; adapter owns the call; middleware observes; aggregator stores. Drift detection enabled. |
+
+---
+
+## 1. Problem
+
+The cost SSOT (`estimateCostFromTokenUsage`) **operates on the ACP wire shape** (`SessionTokenUsage`, snake_case). This is a leak: a shared, adapter-agnostic cost utility carries protocol-specific naming. Concrete symptoms today:
+
+| # | Site | Issue |
+|:--|:--|:--|
+| 1 | [src/agents/cost/calculate.ts:128](../../src/agents/cost/calculate.ts#L128) | `estimateCostFromTokenUsage(usage: SessionTokenUsage, model)` — wire format inside the shared cost SSOT |
+| 2 | [src/agents/cost/types.ts:40](../../src/agents/cost/types.ts#L40) | `SessionTokenUsage` (an ACP wire contract) lives in the shared `cost/` module |
+| 3 | [src/agents/acp/cost.ts](../../src/agents/acp/cost.ts) | Vestigial 9-line re-export "kept for zero-breakage backward compatibility" |
+| 4 | [src/agents/acp/adapter.ts:86-91](../../src/agents/acp/adapter.ts#L86-L91) | Inline duplicate of `cumulative_token_usage` shape — drift hazard against `SessionTokenUsage` |
+| 5 | [src/agents/acp/adapter.ts:657-662](../../src/agents/acp/adapter.ts#L657-L662) | Working accumulator (`totalTokenUsage`) holds wire snake_case |
+| 6 | [src/agents/acp/adapter.ts:774](../../src/agents/acp/adapter.ts#L774), [:913](../../src/agents/acp/adapter.ts#L913) | Two separate call sites pass wire shape to cost calc |
+| 7 | [src/agents/acp/adapter.ts:777-789](../../src/agents/acp/adapter.ts#L777-L789) | Inline anonymous wire→internal mapping when constructing `AgentResult.tokenUsage` |
+
+If/when a second adapter (Codex, Aider) lands with its own wire shape, every fix above gets duplicated. The cost module would need to grow per-adapter overloads. That's the dependency direction inverted.
+
+## 2. Principle — single boundary, owned contract
+
+**One mapper boundary.** Wire format is converted to internal `TokenUsage` exactly once, at the seam between the external library and our adapter wrapper. Above that boundary, only internal types exist.
+
+**Consumer owns the abstraction.** The cost module (consumer) defines the mapper contract. Adapters (producers) implement it. This is Dependency Inversion: high-level modules don't depend on low-level modules; both depend on abstractions owned by the high-level module.
+
+**Single Responsibility on each piece.** The mapper converts wire → internal. The accumulator (`addTokenUsage`) does arithmetic. The cost calc does pricing. The middleware records. The aggregator stores. None of these overlap.
+
+**Both exact and estimated cost are first-class.** When acpx reports an exact cost (`usage_update.cost.amount`), we store it alongside our token-based estimate. Storing both enables drift detection (pricing-rate staleness signal), forward-compat (graceful degradation if exact stops being reported), and unambiguous confidence semantics (`confidence` is derived from "is `exactCostUsd` present?" instead of being a label that can lie).
+
+**Cost-calc ownership: cost module owns the function; adapter owns the call.** `estimateCostFromTokenUsage` is a pure function in `src/agents/cost/calculate.ts`. The adapter calls it once per run and writes the result to `AgentResult.estimatedCostUsd`. Middleware observes; it never computes. Rationale: cost numbers have non-observability consumers (fallback-hop accounting in [metrics/types.ts:92](../../src/metrics/types.ts#L92), budget gates, tests-driving-adapters-directly) that read `AgentResult` without a middleware chain in scope. Producer-side computation is the only correct location.
+
+## 3. Architecture — layered relationships
+
+### 3.1 Top-down layer responsibilities
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Layer 1 — CostAggregator        src/runtime/cost-aggregator.ts          │
+│   Sink. Stores CostEvent / CostErrorEvent.                              │
+│   Provides snapshot(), byAgent(), byStage(), byStory(), drain().        │
+│   Owns: aggregation, query, flush-to-StoryMetrics on runtime close.     │
+│   Stores both estimatedCostUsd and exactCostUsd from each event so      │
+│   reports / audits can show drift, totals, or either number alone.      │
+│   Knows: nothing about wire formats. Operates on CostEvent only.        │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Layer 2 — Cost Middleware       src/runtime/middleware/cost.ts          │
+│   Observer in AgentManager.runAs() chain. Stateless. Never computes.    │
+│   Reads:  AgentResult.tokenUsage, .estimatedCostUsd, .exactCostUsd?     │
+│   Emits:  CostEvent {                                                   │
+│             tokens, runId, agentName, stage, storyId, model,            │
+│             estimatedCostUsd,                                           │
+│             exactCostUsd?,                                              │
+│             costUsd:    exactCostUsd ?? estimatedCostUsd,  // canonical │
+│             confidence: exactCostUsd != null ? "exact" : "estimated",   │
+│             durationMs,                                                 │
+│           } → ICostAggregator.record()                                  │
+│   Owns: record-on-success / record-error-on-throw.                      │
+│   Knows: TokenUsage (camelCase) only. Never sees wire format.           │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Layer 3 — AgentManager          src/agents/manager.ts                   │
+│   Wraps adapter call with permission pre-resolve + middleware chain.    │
+│   Pass-through for tokens/cost. Defined by ADR-018.                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Layer 4 — Agent Adapter         src/agents/acp/adapter.ts (our code)    │
+│   Implements the AgentAdapter contract.                                 │
+│   Owns: protocol orchestration (start, session, prompt, close) +        │
+│         the call to the cost SSOT.                                      │
+│   Returns: AgentResult {                                                │
+│              tokenUsage:        TokenUsage,                             │
+│              estimatedCostUsd:  number,        // always — from tokens  │
+│              exactCostUsd?:     number,        // when wire reports it  │
+│            }                                                            │
+│   ─────────────────────────────────────────────────                     │
+│   Internally uses:                                                      │
+│     - ITokenUsageMapper<SessionTokenUsage> (Layer 6)                    │
+│     - addTokenUsage() (Layer 5)                                         │
+│     - estimateCostFromTokenUsage(TokenUsage, model) (Layer 5)           │
+│   Wire format crosses the boundary exactly once: mapper.toInternal()    │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Layer 5 — Cost Module           src/agents/cost/                        │
+│   Owns abstractions and pure functions over internal TokenUsage:        │
+│     - ITokenUsageMapper<Wire>      (token-mapper.ts)  ← contract        │
+│     - addTokenUsage(a, b)          (calculate.ts)     ← arithmetic      │
+│     - estimateCostFromTokenUsage   (calculate.ts)     ← pricing         │
+│   Knows: nothing about any specific wire format.                        │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Layer 6 — Mapper Implementation  src/agents/acp/token-mapper.ts         │
+│   Concrete adapter per protocol.                                        │
+│     class AcpTokenUsageMapper implements ITokenUsageMapper<…>           │
+│   The ONLY place SessionTokenUsage flows into TokenUsage.               │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Layer 7 — Wire Types            src/agents/acp/wire-types.ts            │
+│   SessionTokenUsage (snake_case). Mirrors acpx contract.                │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Layer 8 — External (acpx)                                               │
+│   We do not edit. Emits cumulative_token_usage (snake_case) and         │
+│   usage_update.cost.amount.                                             │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Data flow on a single run
+
+```
+acpx                                          ← external; wire format
+   │  emits cumulative_token_usage : SessionTokenUsage
+   ▼
+parser.ts                                     ← captures wire shape (Layer 7)
+   │  state.tokenUsage : SessionTokenUsage
+   ▼
+adapter.run() loop:
+   │
+   │  for each session response:
+   │    wire  = response.cumulative_token_usage         // Layer 7
+   │    delta = mapper.toInternal(wire)                 // Layer 6 ── boundary crossed once
+   │    totalTokens = addTokenUsage(totalTokens, delta) // Layer 5 ── internal arithmetic
+   │    if (response.exactCostUsd != null)
+   │      totalExactCostUsd = (totalExactCostUsd ?? 0) + response.exactCostUsd
+   │
+   │  on completion:
+   │    estimatedCostUsd = estimateCostFromTokenUsage(totalTokens, model)  // Layer 5 ── always
+   │    exactCostUsd     = totalExactCostUsd                                // undefined if wire never reported
+   │
+   │  return AgentResult {
+   │    tokenUsage:       totalTokens,         // TokenUsage (camelCase)
+   │    estimatedCostUsd,                      // always present
+   │    exactCostUsd,                          // optional
+   │  }
+   ▼
+AgentManager.runAs() → middleware chain         ← Layer 3
+   │
+   ▼
+Cost Middleware                                 ← Layer 2
+   │  reads result.tokenUsage, .estimatedCostUsd, .exactCostUsd
+   │  emits CostEvent {
+   │    tokens, runId, agentName, model, stage, storyId, packageDir,
+   │    estimatedCostUsd,
+   │    exactCostUsd?,
+   │    costUsd:    exactCostUsd ?? estimatedCostUsd,   // canonical for budget/totals
+   │    confidence: exactCostUsd != null ? "exact" : "estimated",
+   │    durationMs,
+   │  }
+   ▼
+CostAggregator.record()                         ← Layer 1
+   │  retains both estimatedCostUsd and exactCostUsd
+   │  on runtime.close() → drain() → StoryMetrics (both numbers preserved)
+   ▼
+.nax/metrics.json
+```
+
+### 3.3 Boundary inventory after refactor
+
+| Boundary | Direction | Type | Where |
+|:--|:--|:--|:--|
+| External → Adapter | acpx → parser | `SessionTokenUsage` (wire) | `parser.ts`, `spawn-client.ts` |
+| Adapter → Mapper | wire → internal | `SessionTokenUsage → TokenUsage` | `AcpTokenUsageMapper.toInternal()` |
+| Mapper → Adapter accumulator | internal | `TokenUsage` | `addTokenUsage(a, b)` |
+| Adapter → Cost calc | internal | `TokenUsage` | `estimateCostFromTokenUsage(TokenUsage, model)` |
+| Adapter → Manager | internal | `AgentResult.tokenUsage : TokenUsage` | `AgentResult` |
+| Manager → Middleware | internal | `AgentResult` | middleware chain |
+| Middleware → Aggregator | event | `CostEvent` | `CostAggregator.record()` |
+| Aggregator → Metrics | aggregate | `RunMetrics.totalTokens / StoryMetrics.tokens` | `runtime.close() → drain()` |
+
+The wire format appears in exactly two layers: external (Layer 8) and the wire-types file + parser (Layer 7). Above Layer 6 (mapper) it never appears.
+
+## 4. Code shape
+
+### 4.1 Cost module — owns the contract
+
+```ts
+// src/agents/cost/token-mapper.ts (new)
+import type { TokenUsage } from "./types";
+
+/**
+ * Generic mapper from an external wire format to internal canonical TokenUsage.
+ * Each adapter package provides a concrete implementation parameterised by its
+ * own wire type. The cost module never imports any specific Wire.
+ */
+export interface ITokenUsageMapper<Wire> {
+  toInternal(wire: Wire): TokenUsage;
+}
+```
+
+```ts
+// src/agents/cost/calculate.ts (modified)
+import type { TokenUsage } from "./types";
+import { MODEL_PRICING } from "./pricing";
+
+/** Sum two internal TokenUsage values. Pure. */
+export function addTokenUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
+  return {
+    inputTokens: a.inputTokens + b.inputTokens,
+    outputTokens: a.outputTokens + b.outputTokens,
+    cacheReadInputTokens: (a.cacheReadInputTokens ?? 0) + (b.cacheReadInputTokens ?? 0),
+    cacheCreationInputTokens: (a.cacheCreationInputTokens ?? 0) + (b.cacheCreationInputTokens ?? 0),
+  };
+}
+
+/** Pricing function — takes internal TokenUsage; no wire-format awareness. */
+export function estimateCostFromTokenUsage(usage: TokenUsage, model: string): number {
+  const pricing = MODEL_PRICING[model];
+  if (!pricing) {
+    const fallbackInputRate = 3 / 1_000_000;
+    const fallbackOutputRate = 15 / 1_000_000;
+    return (
+      usage.inputTokens * fallbackInputRate +
+      usage.outputTokens * fallbackOutputRate +
+      (usage.cacheReadInputTokens ?? 0) * (0.5 / 1_000_000) +
+      (usage.cacheCreationInputTokens ?? 0) * (2 / 1_000_000)
+    );
+  }
+  const inputRate = pricing.input / 1_000_000;
+  const outputRate = pricing.output / 1_000_000;
+  const cacheReadRate = (pricing.cacheRead ?? pricing.input * 0.1) / 1_000_000;
+  const cacheCreationRate = (pricing.cacheCreation ?? pricing.input * 0.33) / 1_000_000;
+  return (
+    usage.inputTokens * inputRate +
+    usage.outputTokens * outputRate +
+    (usage.cacheReadInputTokens ?? 0) * cacheReadRate +
+    (usage.cacheCreationInputTokens ?? 0) * cacheCreationRate
+  );
+}
+```
+
+### 4.2 ACP adapter — owns its wire types and concrete mapper
+
+```ts
+// src/agents/acp/wire-types.ts (new — moved from cost/types.ts)
+/**
+ * Token usage from an ACP session's cumulative_token_usage field.
+ * Snake_case: matches the acpx wire format. Never escapes the acp/ folder
+ * except through AcpTokenUsageMapper.toInternal().
+ */
+export interface SessionTokenUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+}
+```
+
+```ts
+// src/agents/acp/token-mapper.ts (new)
+import type { ITokenUsageMapper, TokenUsage } from "../cost";
+import type { SessionTokenUsage } from "./wire-types";
+
+export class AcpTokenUsageMapper implements ITokenUsageMapper<SessionTokenUsage> {
+  toInternal(wire: SessionTokenUsage): TokenUsage {
+    return {
+      inputTokens: wire.input_tokens ?? 0,
+      outputTokens: wire.output_tokens ?? 0,
+      cacheReadInputTokens: wire.cache_read_input_tokens,
+      cacheCreationInputTokens: wire.cache_creation_input_tokens,
+    };
+  }
+}
+
+export const defaultAcpTokenUsageMapper = new AcpTokenUsageMapper();
+```
+
+### 4.3 Adapter usage — wire crosses the boundary exactly once
+
+```ts
+// src/agents/acp/adapter.ts (simplified)
+import { addTokenUsage, estimateCostFromTokenUsage } from "../cost";
+import type { TokenUsage } from "../cost";
+import type { SessionTokenUsage } from "./wire-types";
+import { defaultAcpTokenUsageMapper } from "./token-mapper";
+
+export class AcpAgentAdapter implements AgentAdapter {
+  constructor(
+    name: string,
+    naxConfig: NaxConfig,
+    private readonly mapper: ITokenUsageMapper<SessionTokenUsage> = defaultAcpTokenUsageMapper,
+  ) { /* ... */ }
+
+  async run(options: AgentRunOptions): Promise<AgentResult> {
+    let totalTokens: TokenUsage = { inputTokens: 0, outputTokens: 0 };
+    let totalExactCostUsd: number | undefined;
+
+    // Per response loop:
+    if (lastResponse.cumulative_token_usage) {
+      totalTokens = addTokenUsage(
+        totalTokens,
+        this.mapper.toInternal(lastResponse.cumulative_token_usage),  // ← only boundary crossing
+      );
+    }
+    if (lastResponse.exactCostUsd) {
+      totalExactCostUsd = (totalExactCostUsd ?? 0) + lastResponse.exactCostUsd;
+    }
+
+    // On completion — compute both numbers, never collapse them:
+    const estimatedCostUsd = estimateCostFromTokenUsage(
+      totalTokens,
+      options.modelDef.model,
+    );
+    const exactCostUsd = totalExactCostUsd; // undefined if wire never reported
+
+    return {
+      /* ...result, */
+      tokenUsage: totalTokens,
+      estimatedCostUsd,   // always present
+      exactCostUsd,       // optional
+    };
+  }
+}
+```
+
+After this, no wire-format identifier (`input_tokens`, `cache_read_input_tokens`, etc.) appears anywhere in the adapter file outside the `cumulative_token_usage` field shape (which is required to match acpx). The accumulator, cost call, and `AgentResult` mapping all operate on `TokenUsage`. Both cost numbers are independent — neither is computed from the other; both are stored.
+
+### 4.4 Cost middleware — observes both, never computes
+
+```ts
+// src/runtime/middleware/cost.ts (revised)
+async after(ctx, result, durationMs) {
+  if (!result?.tokenUsage && result?.estimatedCostUsd === 0 && result?.exactCostUsd == null) {
+    return; // nothing to record
+  }
+  const estimatedCostUsd = result.estimatedCostUsd ?? 0;
+  const exactCostUsd     = result.exactCostUsd;
+  const costUsd          = exactCostUsd ?? estimatedCostUsd;
+  const confidence: "exact" | "estimated" = exactCostUsd != null ? "exact" : "estimated";
+
+  aggregator.record({
+    ts: Date.now(),
+    runId, agentName: ctx.agentName, model: result.model ?? "unknown",
+    stage: ctx.stage, storyId: ctx.storyId, packageDir: ctx.packageDir,
+    tokens: { /* ...mapped from result.tokenUsage */ },
+    estimatedCostUsd,
+    exactCostUsd,
+    costUsd,
+    confidence,
+    durationMs,
+  });
+}
+```
+
+The middleware never calls `estimateCostFromTokenUsage`. It reads two scalars off `AgentResult` and forwards them. Pure observation.
+
+## 5. Refactor steps (low-risk first)
+
+### Phase A — wire-format decoupling (mapper)
+
+| # | Step | Type | Touches |
+|:--|:--|:--|:--|
+| A1 | Create `src/agents/acp/wire-types.ts`; move `SessionTokenUsage` from `cost/types.ts` to here | Move | new file + `cost/types.ts` + `cost/index.ts` |
+| A2a | Create `src/agents/cost/token-mapper.ts` with `ITokenUsageMapper<Wire>`; export from `cost/index.ts` | Add | new file + `cost/index.ts` |
+| A2b | Add `addTokenUsage(a, b)` to `cost/calculate.ts`; export from `cost/index.ts` | Add | `cost/calculate.ts` + `cost/index.ts` |
+| A2c | Create `src/agents/acp/token-mapper.ts` with `AcpTokenUsageMapper` + `defaultAcpTokenUsageMapper`; export from `acp/index.ts`. Add unit tests. | Add | new file + `acp/index.ts` + new test |
+| A3 | Refactor `estimateCostFromTokenUsage(usage: TokenUsage, model)`. Update all call sites. Update [test/unit/agents/acp/cost.test.ts](../../test/unit/agents/acp/cost.test.ts) (currently uses wire shape). | Breaking | `cost/calculate.ts` + tests |
+| A4 | Refactor [src/agents/acp/adapter.ts](../../src/agents/acp/adapter.ts): inject mapper, accumulate via `addTokenUsage`, drop inline duplicate `cumulative_token_usage` interface (replace with `SessionTokenUsage` import), remove inline wire→internal mapping at result-construction site. Update tests if needed. | Breaking | `acp/adapter.ts` + adapter tests |
+| A5 | Delete [src/agents/acp/cost.ts](../../src/agents/acp/cost.ts) (vestigial re-export). Update any consumers. | Delete | `acp/cost.ts` + grep-found consumers |
+
+A1, A2a–A2c are pure additions and independently mergeable. A3 + A4 are breaking and ship together (one commit) so tests stay green. A5 ships after.
+
+### Phase B — split exact + estimated cost (preserve both)
+
+| # | Step | Type | Touches |
+|:--|:--|:--|:--|
+| B1 | Rename `AgentResult.estimatedCost` → `estimatedCostUsd`; add `exactCostUsd?: number`. Update [src/agents/types.ts](../../src/agents/types.ts) and every `AgentResult` consumer (grep). | Breaking rename | `agents/types.ts` + ~20 call sites |
+| B2 | Refactor [src/agents/acp/adapter.ts](../../src/agents/acp/adapter.ts) to populate both: `estimatedCostUsd` always, `exactCostUsd` from accumulated `totalExactCostUsd`. Remove the today's `?? estimateCost(...)` collapse. | Breaking | `acp/adapter.ts` |
+| B3 | Update `CostEvent` interface ([src/runtime/cost-aggregator.ts](../../src/runtime/cost-aggregator.ts)): add `estimatedCostUsd`, `exactCostUsd?`, `confidence`. Keep `costUsd` as canonical (= `exactCostUsd ?? estimatedCostUsd`). | Breaking | `cost-aggregator.ts` |
+| B4 | Update [src/runtime/middleware/cost.ts](../../src/runtime/middleware/cost.ts): read both numbers off `AgentResult`, emit both into `CostEvent`. No calculation. | Breaking | `middleware/cost.ts` + tests |
+| B5 | Update fallback-hop accounting ([src/agents/manager.ts](../../src/agents/manager.ts), `AgentFallbackHop.costUsd` source) to read `result.estimatedCostUsd` (the canonical comparable number across hops). | Mechanical | `manager.ts` + `metrics/types.ts` reader |
+| B6 | Update `StoryMetrics` / `RunMetrics` if they should carry both numbers (decision: yes, add `tokenCostUsd` mirror of `estimatedCostUsd` and `exactCostUsd?`). Optional in this phase; the aggregator already retains both for query. | Additive | `metrics/types.ts` |
+| B7 | Update tests: replace `expect(result.estimatedCost).toBe(...)` with `expect(result.estimatedCostUsd)` / add coverage for `exactCostUsd` populated when wire reports it; one test asserting both are present and independent. | Test | wide |
+
+### Phase C — verification
+
+| # | Step | Type |
+|:--|:--|:--|
+| C1 | `bun run typecheck` clean. `bun run lint` clean. | Verify |
+| C2 | `bun run test` all green. | Verify |
+| C3 | Grep audit: `grep -rn 'input_tokens\|output_tokens\|cache_read_input_tokens\|cache_creation_input_tokens' src/` returns only `acp/wire-types.ts`, `acp/parser.ts`, `acp/spawn-client.ts`, and inside `AcpTokenUsageMapper.toInternal()`. | Verify |
+| C4 | Grep audit: `grep -rn 'estimatedCost[^U]' src/` returns zero hits (the field is fully renamed to `estimatedCostUsd`). | Verify |
+| C5 | Drift smoke test: with mocked acpx that reports both wire tokens AND `usage_update`, assert `AgentResult.exactCostUsd != null && estimatedCostUsd != null && |exactCostUsd - estimatedCostUsd| / estimatedCostUsd < 0.5` (i.e. they're in the same order of magnitude — pricing rates are not catastrophically wrong). | Verify |
+
+**Recommended PR layout:** Phase A as one PR (mapper decoupling, no behaviour change to cost numbers). Phase B as a second PR (cost field split, behaviour change: both numbers stored). Phase C runs against the merged result.
+
+## 6. Risk & mitigation
+
+| Risk | Likelihood | Mitigation |
+|:--|:--|:--|
+| `estimateCostFromTokenUsage` signature change breaks downstream callers | High (it has callers) | Find all call sites with grep; convert each via the mapper or directly to camelCase; tests catch missed sites |
+| Existing tests pass `SessionTokenUsage`-shaped literals to the cost function | Certain | [test/unit/agents/acp/cost.test.ts](../../test/unit/agents/acp/cost.test.ts) is the main hit; rewrite to camelCase. Add new tests for `AcpTokenUsageMapper` |
+| `acp/cost.ts` removal breaks an external consumer (e.g. test imports it) | Medium | Grep before deletion; keep a single-line deprecation if needed and remove in a follow-up; current users redirect to `../cost` directly |
+| Mapper DI added to `AcpAgentAdapter` constructor breaks existing instantiations | Low — default param | Default to `defaultAcpTokenUsageMapper`; only tests that want a custom mapper opt in |
+| Future Codex adapter needs a different `Wire` type but the same mapper interface | None — that's the goal | `class CodexTokenUsageMapper implements ITokenUsageMapper<CodexWire>` lands as a sibling; no changes to `cost/` |
+| `estimatedCost` → `estimatedCostUsd` rename misses a call site, silently uses `undefined` | Medium | TS strict null checks catch it at typecheck; phase-B PR forces every consumer through the type system |
+| Fallback-hop cost accounting changes meaning (was the `?? estimate` collapsed value, now strictly estimated) | Low | Document in B5: `AgentFallbackHop.costUsd` becomes "estimated cost of the failed attempt"; this is more precise (exact varies per call type and isn't always reported), not less |
+| Drift between `exact` and `estimated` is large (signals pricing-table staleness) | Possible | C5 smoke test catches catastrophic drift; periodic alerting can be added later by reading aggregator snapshot |
+
+## 7. What this deliberately does NOT change
+
+- **Producer-side cost ownership.** Cost is computed in the adapter and lands on `AgentResult`. Non-middleware consumers (fallback-hop cost accounting in `AgentManager.runWithFallback`, [src/metrics/types.ts:92](../../src/metrics/types.ts#L92), and tests driving adapters directly) continue to read it without a middleware chain in scope. Only the *field shape* changes (split into `estimatedCostUsd` + `exactCostUsd?`) and the cost function's *input type* changes (wire → internal).
+- **`CostEvent.tokens` shape (`{ input, output, cacheRead?, cacheWrite? }`).** Aggregator's own contract, intentionally distinct from `TokenUsage` (the field names are shorter / more event-friendly). Different layer, different contract — fine.
+- **`metrics/types.ts` `TokenUsage` class with `toJSON()`.** It's a duplicate shape of `cost/TokenUsage` but exists for `metrics.json` zero-omit serialization. Out of scope for this refactor; tracked separately.
+- **External `acpx` library.** Out of our control. Wire format is what it is.
+
+## 8. Acceptance criteria
+
+### Phase A — wire-format decoupling
+
+| AC | Verifies |
+|:--|:--|
+| AC-A1 | `src/agents/cost/` contains zero references to `input_tokens`, `output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens` (grep) |
+| AC-A2 | `src/agents/cost/token-mapper.ts` exists; exports `ITokenUsageMapper<Wire>` |
+| AC-A3 | `src/agents/cost/calculate.ts` exports `addTokenUsage(a, b): TokenUsage` and `estimateCostFromTokenUsage(usage: TokenUsage, model): number` |
+| AC-A4 | `src/agents/acp/wire-types.ts` exists; declares `SessionTokenUsage` |
+| AC-A5 | `src/agents/acp/token-mapper.ts` exports `AcpTokenUsageMapper implements ITokenUsageMapper<SessionTokenUsage>` and `defaultAcpTokenUsageMapper` |
+| AC-A6 | `src/agents/acp/cost.ts` deleted |
+| AC-A7 | `src/agents/acp/adapter.ts` references no inline duplicate of `cumulative_token_usage` shape (uses `SessionTokenUsage` from `./wire-types`) |
+| AC-A8 | `src/agents/acp/adapter.ts` accumulates `TokenUsage` (not `SessionTokenUsage`) and calls `estimateCostFromTokenUsage(TokenUsage, model)` exactly via internal type |
+| AC-A9 | Unit tests for `AcpTokenUsageMapper` cover: full snake_case → camelCase mapping, undefined cache fields → undefined, zero values preserved |
+| AC-A10 | Snake_case identifiers `input_tokens` / `output_tokens` / `cache_read_input_tokens` / `cache_creation_input_tokens` appear in `src/` only in: `acp/wire-types.ts`, `acp/parser.ts`, `acp/spawn-client.ts`, and inside `AcpTokenUsageMapper.toInternal()` |
+
+### Phase B — split exact + estimated cost
+
+| AC | Verifies |
+|:--|:--|
+| AC-B1 | `AgentResult.estimatedCost` no longer exists; replaced by `estimatedCostUsd: number` (always present) and `exactCostUsd?: number` (optional). Grep for the old name returns zero hits. |
+| AC-B2 | `AcpAgentAdapter.run()` populates **both** numbers when wire reports `usage_update.cost.amount`: `estimatedCostUsd` from `estimateCostFromTokenUsage(tokens, model)` and `exactCostUsd` from accumulated wire-reported exact cost. Neither is computed from the other. |
+| AC-B3 | When wire does NOT report exact cost, `AgentResult.exactCostUsd === undefined` and `estimatedCostUsd > 0`. The adapter never collapses the absence into a fallback estimate at the field level. |
+| AC-B4 | `CostEvent` interface includes: `estimatedCostUsd: number`, `exactCostUsd?: number`, `costUsd: number` (= `exactCostUsd ?? estimatedCostUsd`), `confidence: "exact" \| "estimated"` (= `exactCostUsd != null ? "exact" : "estimated"`). |
+| AC-B5 | `costMiddleware.after()` performs no cost calculation — it reads the two scalars from `AgentResult` and forwards them into `CostEvent`. Inspecting the source: no call to `estimateCostFromTokenUsage`. |
+| AC-B6 | `AgentFallbackHop.costUsd` is sourced from `AgentResult.estimatedCostUsd` (documented as "estimated cost of the failed attempt"). |
+| AC-B7 | Integration test: with mock adapter populating both fields, `CostAggregator.snapshot()` retains both `totalEstimatedCostUsd` and `totalExactCostUsd` as separate, queryable totals. |
+| AC-B8 | Drift smoke test (Phase C, AC-C5): same-run estimated and exact differ by less than 50% (catches order-of-magnitude pricing errors). |
+
+### Phase C — verification
+
+| AC | Verifies |
+|:--|:--|
+| AC-C1 | `bun run typecheck` passes; full `bun run test` suite green. |
+| AC-C2 | Grep audit confirms wire-format identifiers are quarantined (AC-A10 above). |
+| AC-C3 | Grep audit: zero hits for `\.estimatedCost[^U]` in `src/` (rename complete). |
+| AC-C4 | Drift smoke test passes (AC-B8 above). |
+
+## 9. Future extensions enabled
+
+- **Codex adapter** — adds `CodexTokenUsageMapper implements ITokenUsageMapper<CodexWire>`. Cost module untouched.
+- **Pricing strategy injection** — `estimateCostFromTokenUsage` could accept a pricing-strategy parameter (e.g. negotiated rates, dry-run discounts) without any awareness of wire formats.
+- **Drift alerting** — periodic check on aggregator snapshot: if `Σ exactCostUsd / Σ estimatedCostUsd` strays past a threshold, surface a warning. Trivially implementable once both numbers land.
+- **Confidence-aware budget gates** — budget enforcement could be stricter on `exact` (hard cap) and softer on `estimated` (warning). Requires both numbers separately, which this refactor guarantees.
+- **Test-only mappers** — DI lets unit tests inject deterministic mappers (e.g. echo-back for property tests).

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -631,12 +631,12 @@ export class AcpAgentAdapter implements AgentAdapter {
       cache_creation_input_tokens: 0,
     };
     let totalExactCostUsd: number | undefined;
+    let turnCount = 0;
 
     try {
       // 5. Multi-turn loop
       const hasContextTools = Boolean(options.contextToolRuntime && (options.contextPullTools?.length ?? 0) > 0);
       let currentPrompt = buildContextToolPreamble(options);
-      let turnCount = 0;
       const MAX_TURNS = options.interactionBridge || hasContextTools ? (options.maxInteractionTurns ?? 10) : 1;
 
       while (turnCount < MAX_TURNS) {
@@ -816,6 +816,7 @@ export class AcpAgentAdapter implements AgentAdapter {
       tokenUsage,
       protocolIds,
       adapterFailure,
+      sessionMetadata: { sessionName, turn: turnCount, resumed: sessionResumed },
     };
   }
 

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -780,10 +780,10 @@ export class AcpAgentAdapter implements AgentAdapter {
             inputTokens: totalTokenUsage.input_tokens,
             outputTokens: totalTokenUsage.output_tokens,
             ...(totalTokenUsage.cache_read_input_tokens > 0 && {
-              cache_read_input_tokens: totalTokenUsage.cache_read_input_tokens,
+              cacheReadInputTokens: totalTokenUsage.cache_read_input_tokens,
             }),
             ...(totalTokenUsage.cache_creation_input_tokens > 0 && {
-              cache_creation_input_tokens: totalTokenUsage.cache_creation_input_tokens,
+              cacheCreationInputTokens: totalTokenUsage.cache_creation_input_tokens,
             }),
           }
         : undefined;

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -12,13 +12,11 @@
  */
 
 import { createHash } from "node:crypto";
-import { resolvePermissions } from "../../config/permissions";
 import { getSafeLogger } from "../../logger";
 import { sleep, which } from "../../utils/bun-deps";
 import { parseDecomposeOutput } from "../shared/decompose";
 import { buildDecomposePromptAsync } from "../shared/decompose-prompt";
 import { parseAgentError } from "./parse-agent-error";
-import { writePromptAudit } from "./prompt-audit";
 import { createSpawnAcpClient } from "./spawn-client";
 
 import type { AdapterFailure } from "../../context/engine";
@@ -589,9 +587,9 @@ export class AcpAgentAdapter implements AgentAdapter {
       options.sessionHandle ??
       computeAcpHandle(options.workdir, options.featureName, options.storyId, options.sessionRole);
 
-    // 2. Resolve permission mode from config via single source of truth.
-    const resolvedPerm = resolvePermissions(options.config, options.pipelineStage ?? "run");
-    const permissionMode = resolvedPerm.mode;
+    // 2. Read pre-resolved permission mode from AgentManager (passed via options.resolvedPermissions).
+    const permissionMode =
+      options.resolvedPermissions?.mode ?? (options.dangerouslySkipPermissions ? "approve-all" : "approve-reads");
     getSafeLogger()?.info("acp-adapter", "Permission mode resolved", {
       permission: permissionMode,
       stage: options.pipelineStage ?? "run",
@@ -645,26 +643,6 @@ export class AcpAgentAdapter implements AgentAdapter {
       while (turnCount < MAX_TURNS) {
         turnCount++;
         getSafeLogger()?.debug("acp-adapter", `Session turn ${turnCount}/${MAX_TURNS}`, { sessionName });
-
-        // Audit: fire-and-forget prompt write — never blocks or throws
-        const _runAuditConfig = options.config;
-        if (_runAuditConfig?.agent?.promptAudit?.enabled) {
-          void writePromptAudit({
-            prompt: currentPrompt,
-            sessionName,
-            recordId: session.recordId,
-            sessionId: session.id,
-            workdir: options.workdir,
-            projectDir: options.projectDir,
-            auditDir: _runAuditConfig.agent.promptAudit.dir,
-            storyId: options.storyId,
-            featureName: options.featureName,
-            pipelineStage: options.pipelineStage ?? "run",
-            callType: "run",
-            turn: turnCount,
-            resumed: sessionResumed,
-          });
-        }
 
         const turnResult = await runSessionPrompt(session, currentPrompt, options.timeoutSeconds * 1000);
 
@@ -844,7 +822,8 @@ export class AcpAgentAdapter implements AgentAdapter {
 
   async complete(prompt: string, _options?: CompleteOptions): Promise<CompleteResult> {
     const timeoutMs = _options?.timeoutMs ?? 120_000;
-    const permissionMode = resolvePermissions(_options?.config, "complete").mode;
+    const permissionMode =
+      _options?.resolvedPermissions?.mode ?? (_options?.dangerouslySkipPermissions ? "approve-all" : "approve-reads");
     const workdir = _options?.workdir;
     const config = _options?.config;
 
@@ -883,24 +862,6 @@ export class AcpAgentAdapter implements AgentAdapter {
           _options?.sessionName ??
           computeAcpHandle(workdir ?? process.cwd(), _options?.featureName, _options?.storyId, _options?.sessionRole);
         session = await client.createSession({ agentName, permissionMode, sessionName: completeSessionName });
-
-        // Audit: fire-and-forget prompt write — never blocks or throws
-        const _completeAuditConfig = config ?? this.naxConfig;
-        if (_completeAuditConfig?.agent?.promptAudit?.enabled) {
-          void writePromptAudit({
-            prompt,
-            sessionName: completeSessionName,
-            recordId: session.recordId,
-            sessionId: session.id,
-            workdir: workdir ?? process.cwd(),
-            auditDir: _completeAuditConfig.agent.promptAudit.dir,
-            storyId: _options?.storyId,
-            featureName: _options?.featureName,
-            pipelineStage: _options?.pipelineStage ?? "complete",
-            callType: "complete",
-            resumed: false,
-          });
-        }
 
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         const timeoutPromise = new Promise<never>((_, reject) => {
@@ -1033,7 +994,7 @@ export class AcpAgentAdapter implements AgentAdapter {
       modelTier: options.modelTier ?? "balanced",
       modelDef,
       timeoutSeconds,
-      dangerouslySkipPermissions: resolvePermissions(this.naxConfig, "plan").skipPermissions,
+      resolvedPermissions: options.resolvedPermissions,
       pipelineStage: "plan",
       config: this.naxConfig,
       interactionBridge: options.interactionBridge,

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -588,8 +588,7 @@ export class AcpAgentAdapter implements AgentAdapter {
       computeAcpHandle(options.workdir, options.featureName, options.storyId, options.sessionRole);
 
     // 2. Read pre-resolved permission mode from AgentManager (passed via options.resolvedPermissions).
-    const permissionMode =
-      options.resolvedPermissions?.mode ?? (options.dangerouslySkipPermissions ? "approve-all" : "approve-reads");
+    const permissionMode = options.resolvedPermissions?.mode ?? "approve-reads";
     getSafeLogger()?.info("acp-adapter", "Permission mode resolved", {
       permission: permissionMode,
       stage: options.pipelineStage ?? "run",
@@ -822,8 +821,7 @@ export class AcpAgentAdapter implements AgentAdapter {
 
   async complete(prompt: string, _options?: CompleteOptions): Promise<CompleteResult> {
     const timeoutMs = _options?.timeoutMs ?? 120_000;
-    const permissionMode =
-      _options?.resolvedPermissions?.mode ?? (_options?.dangerouslySkipPermissions ? "approve-all" : "approve-reads");
+    const permissionMode = _options?.resolvedPermissions?.mode ?? "approve-reads";
     const workdir = _options?.workdir;
     const config = _options?.config;
 

--- a/src/agents/cost/types.ts
+++ b/src/agents/cost/types.ts
@@ -16,8 +16,8 @@ export interface ModelCostRates {
 export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;
-  cache_read_input_tokens?: number;
-  cache_creation_input_tokens?: number;
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens?: number;
 }
 
 /** Cost estimate with confidence indicator */

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -1,6 +1,14 @@
 import type { NaxConfig } from "../config";
+// Leaf import to avoid barrel cycle (same as in manager.ts):
+// src/runtime/index.ts → internal/agent-manager-factory → agents/factory → agents/manager → runtime/index.ts
+import type { MiddlewareChain } from "../runtime/agent-middleware";
 import { AgentManager } from "./manager";
 import type { IAgentManager } from "./manager-types";
+
+export interface CreateAgentManagerOpts {
+  middleware?: MiddlewareChain;
+  runId?: string;
+}
 
 /**
  * Single construction point for AgentManager. Called only via
@@ -8,6 +16,6 @@ import type { IAgentManager } from "./manager-types";
  * (CLI entry point). Mid-run code must receive IAgentManager via context/DI —
  * never call this factory directly. See docs/specs/SPEC-agent-manager-lifetime.md §2.1.
  */
-export function createAgentManager(config: NaxConfig): IAgentManager {
-  return new AgentManager(config);
+export function createAgentManager(config: NaxConfig, opts?: CreateAgentManagerOpts): IAgentManager {
+  return new AgentManager(config, undefined, opts);
 }

--- a/src/agents/manager-types.ts
+++ b/src/agents/manager-types.ts
@@ -35,6 +35,8 @@ export interface AgentRunOutcome {
   finalBundle?: ContextBundle;
   /** The prompt used by the final (successful or last failed) hop. */
   finalPrompt?: string;
+  /** The agent that actually executed the final hop (may differ from the initial agent after a swap). */
+  finalAgent?: string;
 }
 
 export interface AgentCompleteOutcome {

--- a/src/agents/manager-types.ts
+++ b/src/agents/manager-types.ts
@@ -74,6 +74,7 @@ export interface AgentRunRequest {
     agentName: string,
     bundle: ContextBundle | undefined,
     failure: AdapterFailure | undefined,
+    resolvedRunOptions: AgentRunOptions,
   ) => Promise<{ result: AgentResult; bundle: ContextBundle | undefined; prompt?: string }>;
 }
 

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -214,7 +214,8 @@ export class AgentManager implements IAgentManager {
         }
       }
 
-      if (result.success) return { result, fallbacks, finalBundle: updatedBundle, finalPrompt };
+      if (result.success)
+        return { result, fallbacks, finalBundle: updatedBundle, finalPrompt, finalAgent: currentAgent };
 
       const bundleForSwapCheck = updatedBundle ?? request.bundle;
 
@@ -227,7 +228,7 @@ export class AgentManager implements IAgentManager {
             logger?.info("agent-manager", "Rate-limited backoff aborted — shutdown in progress", {
               storyId: request.runOptions.storyId,
             });
-            return { result, fallbacks, finalBundle: updatedBundle, finalPrompt };
+            return { result, fallbacks, finalBundle: updatedBundle, finalPrompt, finalAgent: currentAgent };
           }
           rateLimitRetry += 1;
           const backoffMs = 2 ** rateLimitRetry * 1000;
@@ -238,14 +239,14 @@ export class AgentManager implements IAgentManager {
           });
           await _agentManagerDeps.sleep(backoffMs, request.signal);
           if (request.signal?.aborted) {
-            return { result, fallbacks, finalBundle: updatedBundle, finalPrompt };
+            return { result, fallbacks, finalBundle: updatedBundle, finalPrompt, finalAgent: currentAgent };
           }
           continue;
         }
         if (hopsSoFar > 0) {
           this._emitter.emit("onSwapExhausted", { storyId: request.runOptions.storyId, hops: hopsSoFar });
         }
-        return { result, fallbacks, finalBundle: updatedBundle, finalPrompt };
+        return { result, fallbacks, finalBundle: updatedBundle, finalPrompt, finalAgent: currentAgent };
       }
 
       const adapterFailure = result.adapterFailure ?? {
@@ -263,7 +264,7 @@ export class AgentManager implements IAgentManager {
       const next = this.nextCandidate(primaryAgent, hopsSoFar);
       if (!next) {
         this._emitter.emit("onSwapExhausted", { storyId: request.runOptions.storyId, hops: hopsSoFar });
-        return { result, fallbacks, finalBundle: updatedBundle, finalPrompt };
+        return { result, fallbacks, finalBundle: updatedBundle, finalPrompt, finalAgent: currentAgent };
       }
       hopsSoFar += 1;
       // Reset per-agent rate-limit counter so the new agent gets its own backoff budget.
@@ -414,7 +415,14 @@ export class AgentManager implements IAgentManager {
       }
       const outcome = await this.runWithFallback(augmented, agentName);
       const result = { ...outcome.result, agentFallbacks: outcome.fallbacks };
-      await this._middleware.runAfter(ctx, result, Date.now() - start);
+      // Update context to reflect the actual final hop's agent and prompt so that
+      // cost/audit middleware attributes the result to the agent that produced it,
+      // not the initial agent that may have been swapped out by the fallback chain.
+      const hopCtx: MiddlewareContext =
+        outcome.finalAgent !== undefined || outcome.finalPrompt !== undefined
+          ? { ...ctx, agentName: outcome.finalAgent ?? agentName, prompt: outcome.finalPrompt ?? ctx.prompt }
+          : ctx;
+      await this._middleware.runAfter(hopCtx, result, Date.now() - start);
       return result;
     } catch (err) {
       await this._middleware.runOnError(ctx, err, Date.now() - start);

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -7,9 +7,14 @@
 
 import { EventEmitter } from "node:events";
 import type { NaxConfig } from "../config";
+import { resolvePermissions } from "../config/permissions";
 import type { AdapterFailure } from "../context/engine";
 import { NaxError } from "../errors";
 import { getSafeLogger } from "../logger";
+// Leaf import to avoid barrel cycle:
+// src/runtime/index.ts → internal/agent-manager-factory → agents/factory → agents/manager → runtime/index.ts
+import { MiddlewareChain } from "../runtime/agent-middleware";
+import type { MiddlewareContext } from "../runtime/agent-middleware";
 import { cancellableDelay } from "../utils/bun-deps";
 import type {
   AgentCompleteOutcome,
@@ -54,12 +59,20 @@ export class AgentManager implements IAgentManager {
   private readonly _prunedFallback = new Set<string>();
   private readonly _emitter = new EventEmitter();
   private readonly _logger: LoggerLike;
+  private readonly _middleware: MiddlewareChain;
+  private readonly _runId: string;
   readonly events: AgentManagerEvents;
 
-  constructor(config: NaxConfig, registry?: AgentRegistry, opts?: { logger?: LoggerLike }) {
+  constructor(
+    config: NaxConfig,
+    registry?: AgentRegistry,
+    opts?: { logger?: LoggerLike; middleware?: MiddlewareChain; runId?: string },
+  ) {
     this._config = config;
     this._registry = registry;
     this._logger = opts?.logger ?? getSafeLogger() ?? { warn: () => {}, info: () => {} };
+    this._middleware = opts?.middleware ?? MiddlewareChain.empty();
+    this._runId = opts?.runId ?? crypto.randomUUID();
     this.events = {
       on: (event, listener) => {
         this._emitter.on(event as AgentManagerEventName, listener as (...args: unknown[]) => void);
@@ -357,17 +370,12 @@ export class AgentManager implements IAgentManager {
     }
   }
 
-  async run(request: AgentRunRequest): Promise<import("./types").AgentResult> {
-    const outcome = await this.runWithFallback(request);
-    return { ...outcome.result, agentFallbacks: outcome.fallbacks };
+  async run(request: AgentRunRequest): Promise<AgentResult> {
+    return this.runAs(this.getDefault(), request);
   }
 
-  async complete(
-    prompt: string,
-    options: import("./types").CompleteOptions,
-  ): Promise<import("./types").CompleteResult> {
-    const outcome = await this.completeWithFallback(prompt, options);
-    return outcome.result;
+  async complete(prompt: string, options: CompleteOptions): Promise<CompleteResult> {
+    return this.completeAs(this.getDefault(), prompt, options);
   }
 
   getAgent(name: string): import("./types").AgentAdapter | undefined {
@@ -375,13 +383,72 @@ export class AgentManager implements IAgentManager {
   }
 
   async runAs(agentName: string, request: AgentRunRequest): Promise<AgentResult> {
-    const outcome = await this.runWithFallback(request, agentName);
-    return { ...outcome.result, agentFallbacks: outcome.fallbacks };
+    const resolvedPermissions = resolvePermissions(
+      (request.runOptions.config as NaxConfig | undefined) ?? this._config,
+      request.runOptions.pipelineStage ?? "run",
+    );
+    const augmented: AgentRunRequest = {
+      ...request,
+      runOptions: { ...request.runOptions, resolvedPermissions },
+    };
+    const ctx: MiddlewareContext = {
+      runId: this._runId,
+      agentName,
+      kind: "run",
+      request: augmented,
+      prompt: null,
+      config: this._config,
+      signal: request.signal ?? request.runOptions.abortSignal,
+      resolvedPermissions,
+      storyId: request.runOptions.storyId,
+      stage: request.runOptions.pipelineStage,
+    };
+    const start = Date.now();
+    await this._middleware.runBefore(ctx);
+    try {
+      if (!request.executeHop && !this._resolveRegistry().getAgent(agentName)) {
+        throw new NaxError(`Agent "${agentName}" not found in registry`, "AGENT_NOT_FOUND", {
+          stage: "run",
+          agentName,
+        });
+      }
+      const outcome = await this.runWithFallback(augmented, agentName);
+      const result = { ...outcome.result, agentFallbacks: outcome.fallbacks };
+      await this._middleware.runAfter(ctx, result, Date.now() - start);
+      return result;
+    } catch (err) {
+      await this._middleware.runOnError(ctx, err, Date.now() - start);
+      throw err;
+    }
   }
 
   async completeAs(agentName: string, prompt: string, options: CompleteOptions): Promise<CompleteResult> {
-    const outcome = await this.completeWithFallback(prompt, options, agentName);
-    return outcome.result;
+    const resolvedPermissions = resolvePermissions(
+      (options.config as NaxConfig | undefined) ?? this._config,
+      options.pipelineStage ?? "complete",
+    );
+    const augmented: CompleteOptions = { ...options, resolvedPermissions };
+    const ctx: MiddlewareContext = {
+      runId: this._runId,
+      agentName,
+      kind: "complete",
+      request: null,
+      prompt,
+      config: this._config,
+      resolvedPermissions,
+      storyId: options.storyId,
+      stage: options.pipelineStage,
+    };
+    const start = Date.now();
+    await this._middleware.runBefore(ctx);
+    try {
+      const outcome = await this.completeWithFallback(prompt, augmented, agentName);
+      await this._middleware.runAfter(ctx, outcome.result, Date.now() - start);
+      return outcome.result;
+    } catch (err) {
+      await this._middleware.runOnError(ctx, err, Date.now() - start);
+      throw err;
+    }
   }
 
   async plan(options: PlanOptions): Promise<PlanResult> {
@@ -389,9 +456,11 @@ export class AgentManager implements IAgentManager {
   }
 
   async planAs(agentName: string, options: PlanOptions): Promise<PlanResult> {
+    const resolvedPermissions = resolvePermissions((options.config as NaxConfig | undefined) ?? this._config, "plan");
+    const augmented: PlanOptions = { ...options, resolvedPermissions };
     const adapter = this._resolveRegistry().getAgent(agentName);
     if (!adapter) return { specContent: `Agent "${agentName}" not found` };
-    return adapter.plan(options);
+    return adapter.plan(augmented);
   }
 
   async decompose(options: DecomposeOptions): Promise<DecomposeResult> {

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -173,7 +173,7 @@ export class AgentManager implements IAgentManager {
       let updatedBundle = currentBundle;
 
       if (request.executeHop) {
-        const hopOut = await request.executeHop(currentAgent, currentBundle, currentFailure);
+        const hopOut = await request.executeHop(currentAgent, currentBundle, currentFailure, request.runOptions);
         result = hopOut.result;
         updatedBundle = hopOut.bundle ?? currentBundle;
         finalPrompt = hopOut.prompt ?? finalPrompt;

--- a/src/agents/shared/types-extended.ts
+++ b/src/agents/shared/types-extended.ts
@@ -5,6 +5,7 @@
  * Separated from core types to keep each file under 400 lines.
  */
 
+import type { ResolvedPermissions } from "../../config/permissions";
 import type { ModelDef, ModelTier, NaxConfig } from "../../config/schema";
 
 /**
@@ -54,6 +55,8 @@ export interface PlanOptions {
   timeoutSeconds?: number;
   /** Whether to skip permission prompts (maps to permissionMode in ACP) */
   dangerouslySkipPermissions?: boolean;
+  /** Pre-resolved permissions from AgentManager.planAs() — adapter reads this instead of calling resolvePermissions(). */
+  resolvedPermissions?: ResolvedPermissions;
   /** Max interaction turns when interactionBridge is active (default: 10) */
   maxInteractionTurns?: number;
   /**

--- a/src/agents/shared/types-extended.ts
+++ b/src/agents/shared/types-extended.ts
@@ -53,8 +53,6 @@ export interface PlanOptions {
   sessionRole?: string;
   /** Timeout in seconds — inherited from config.execution.sessionTimeoutSeconds */
   timeoutSeconds?: number;
-  /** Whether to skip permission prompts (maps to permissionMode in ACP) */
-  dangerouslySkipPermissions?: boolean;
   /** Pre-resolved permissions from AgentManager.planAs() — adapter reads this instead of calling resolvePermissions(). */
   resolvedPermissions?: ResolvedPermissions;
   /** Max interaction turns when interactionBridge is active (default: 10) */

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -94,8 +94,6 @@ export interface AgentRunOptions {
   timeoutSeconds: number;
   /** Environment variables to pass */
   env?: Record<string, string>;
-  /** Use --dangerously-skip-permissions flag (default: true) */
-  dangerouslySkipPermissions?: boolean;
   /** Pre-resolved permissions from AgentManager — adapter reads this instead of calling resolvePermissions(). */
   resolvedPermissions?: ResolvedPermissions;
   /** Interaction bridge for mid-session human interaction (ACP) */
@@ -206,8 +204,6 @@ export interface CompleteOptions {
   jsonMode?: boolean;
   /** Override the model (adds --model flag) */
   model?: string;
-  /** Whether to skip permission prompts (maps to permissionMode in ACP) */
-  dangerouslySkipPermissions?: boolean;
   /** Pre-resolved permissions from AgentManager — adapter reads this instead of calling resolvePermissions(). */
   resolvedPermissions?: ResolvedPermissions;
   /**

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type { NaxConfig } from "../config";
+import type { ResolvedPermissions } from "../config/permissions";
 import type { ModelDef, ModelTier } from "../config/schema";
 import type { AdapterFailure, ToolDescriptor } from "../context/engine";
 import type { SessionDescriptor } from "../session/types";
@@ -95,6 +96,8 @@ export interface AgentRunOptions {
   env?: Record<string, string>;
   /** Use --dangerously-skip-permissions flag (default: true) */
   dangerouslySkipPermissions?: boolean;
+  /** Pre-resolved permissions from AgentManager — adapter reads this instead of calling resolvePermissions(). */
+  resolvedPermissions?: ResolvedPermissions;
   /** Interaction bridge for mid-session human interaction (ACP) */
   interactionBridge?: {
     detectQuestion: (text: string) => Promise<boolean>;
@@ -205,6 +208,8 @@ export interface CompleteOptions {
   model?: string;
   /** Whether to skip permission prompts (maps to permissionMode in ACP) */
   dangerouslySkipPermissions?: boolean;
+  /** Pre-resolved permissions from AgentManager — adapter reads this instead of calling resolvePermissions(). */
+  resolvedPermissions?: ResolvedPermissions;
   /**
    * Working directory for the completion call.
    * Used by ACP adapter to set --cwd on the spawned acpx session.

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -76,6 +76,18 @@ export interface AgentResult {
    * with no swaps. Undefined when the result does not go through AgentManager.
    */
   agentFallbacks?: import("./manager-types").AgentFallbackRecord[];
+  /**
+   * ACP session correlation metadata for audit/debug.
+   * Populated by the ACP adapter on every run(); absent for CLI adapter results.
+   */
+  sessionMetadata?: {
+    /** Derived ACP session handle (stable across reconnects). */
+    sessionName?: string;
+    /** Number of interaction turns executed. */
+    turn?: number;
+    /** Whether the run resumed a previously open session. */
+    resumed?: boolean;
+  };
 }
 
 /**

--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -69,7 +69,6 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "execution.contextProviderTokenBudget": "Token budget for plugin context providers",
   "execution.lintCommand": "Lint command override (null=disabled, undefined=auto-detect)",
   "execution.typecheckCommand": "Typecheck command override (null=disabled, undefined=auto-detect)",
-  "execution.dangerouslySkipPermissions": "Skip permissions for agent (use with caution)",
   "execution.rectification": "Rectification loop settings (retry failed tests)",
   "execution.rectification.enabled": "Enable rectification loop",
   "execution.rectification.maxRetries": "Max retry attempts per story",

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -194,7 +194,6 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
       packageDetails,
       config?.project,
     );
-    const resolvedPerm = resolvePermissions(config, "plan");
     // Safe: debateEnabled guard confirms config.debate.stages.plan is defined
     const planStageConfig = config?.debate?.stages.plan as import("../debate").DebateStageConfig;
     const debateAgentManager = _planDeps.createManager(config);
@@ -218,7 +217,6 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
       feature: options.feature,
       outputDir: outputDir,
       timeoutSeconds,
-      dangerouslySkipPermissions: resolvedPerm.skipPermissions,
       maxInteractionTurns: config?.agent?.maxInteractionTurns,
       specContent,
     });
@@ -268,7 +266,6 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
           config,
           modelTier: resolvedPlanModel.modelTier,
           modelDef: resolvedPlanModel.modelDef,
-          dangerouslySkipPermissions: resolvePermissions(config, "plan").skipPermissions,
           maxInteractionTurns: config?.agent?.maxInteractionTurns,
           featureName: options.feature,
           onPidSpawned: (pid: number) => pidRegistry.register(pid),
@@ -352,7 +349,6 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
           config,
           modelTier: resolvedPlanModel.modelTier,
           modelDef: resolvedPlanModel.modelDef,
-          dangerouslySkipPermissions: resolvedPerm.skipPermissions,
           maxInteractionTurns: config?.agent?.maxInteractionTurns,
           featureName: options.feature,
           onPidSpawned: (pid: number) => pidRegistry.register(pid),

--- a/src/config/permissions.ts
+++ b/src/config/permissions.ts
@@ -34,12 +34,9 @@ export interface ResolvedPermissions {
 /**
  * Resolve permissions for a given pipeline stage.
  * Single source of truth — all adapters call this.
- *
- * Precedence: permissionProfile > dangerouslySkipPermissions boolean > safe default.
  */
 export function resolvePermissions(config: NaxConfig | undefined, _stage: PipelineStage): ResolvedPermissions {
-  const profile: PermissionProfile =
-    config?.execution?.permissionProfile ?? (config?.execution?.dangerouslySkipPermissions ? "unrestricted" : "safe");
+  const profile: PermissionProfile = config?.execution?.permissionProfile ?? "unrestricted";
 
   switch (profile) {
     case "unrestricted":

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -133,10 +133,8 @@ export interface ExecutionConfig {
   lintCommand?: string | null;
   /** Typecheck command override (null = disabled, undefined = auto-detect from package.json) */
   typecheckCommand?: string | null;
-  /** Use --dangerously-skip-permissions flag for agent (default: true for backward compat, SEC-1 fix) */
-  dangerouslySkipPermissions?: boolean;
-  /** Permission profile — takes precedence over dangerouslySkipPermissions (Phase 1) */
-  permissionProfile?: "unrestricted" | "safe" | "scoped"; // default: "unrestricted"
+  /** Permission profile for the agent (default: "unrestricted") */
+  permissionProfile?: "unrestricted" | "safe" | "scoped";
   /** Per-stage permission overrides — only read when permissionProfile = "scoped" (Phase 2) */
   permissions?: Record<
     string,

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -148,9 +148,6 @@ const ExecutionConfigSchema = z.object({
     .default(2000),
   lintCommand: z.string().nullable().optional(),
   typecheckCommand: z.string().nullable().optional(),
-  // DEPRECATED — use permissionProfile instead. Kept for backward compat.
-  dangerouslySkipPermissions: z.boolean().default(true),
-  // NEW — takes precedence over dangerouslySkipPermissions
   permissionProfile: z.enum(["unrestricted", "safe", "scoped"]).default("unrestricted"),
   // Phase 2: per-stage permission overrides (only read when profile = "scoped")
   permissions: z
@@ -913,7 +910,6 @@ export const NaxConfigSchema = z
         maxRectificationAttempts: 3,
       },
       contextProviderTokenBudget: 2000,
-      dangerouslySkipPermissions: true,
       permissionProfile: "unrestricted",
       smartTestRunner: true,
       worktreeDependencies: {

--- a/src/debate/session-plan.ts
+++ b/src/debate/session-plan.ts
@@ -41,7 +41,6 @@ export async function runPlan(
     feature: string;
     outputDir: string;
     timeoutSeconds?: number;
-    dangerouslySkipPermissions?: boolean;
     maxInteractionTurns?: number;
     /** Original spec content — anchors synthesis to prevent AC hallucination. */
     specContent?: string;
@@ -98,7 +97,6 @@ export async function runPlan(
         config: ctx.config,
         modelTier,
         modelDef,
-        dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
         maxInteractionTurns: opts.maxInteractionTurns,
         featureName: opts.feature,
         storyId: ctx.storyId,

--- a/src/debate/session-stateful.ts
+++ b/src/debate/session-stateful.ts
@@ -8,7 +8,6 @@
 import type { IAgentManager } from "../agents";
 import type { ModelDef, ModelTier } from "../config";
 import type { NaxConfig } from "../config";
-import { resolvePermissions } from "../config/permissions";
 import { DebatePromptBuilder } from "../prompts";
 import { allSettledBounded } from "./concurrency";
 import { buildDebaterLabel, resolvePersonas } from "./personas";
@@ -59,7 +58,6 @@ export async function runStatefulTurn(
       modelTier,
       modelDef,
       timeoutSeconds: ctx.timeoutSeconds,
-      dangerouslySkipPermissions: resolvePermissions(ctx.config, pipelineStage).skipPermissions,
       pipelineStage,
       config: ctx.config,
       featureName: ctx.featureName,
@@ -101,7 +99,6 @@ export async function closeStatefulSession(
       modelTier,
       modelDef,
       timeoutSeconds: ctx.timeoutSeconds,
-      dangerouslySkipPermissions: resolvePermissions(ctx.config, pipelineStage).skipPermissions,
       pipelineStage,
       config: ctx.config,
       featureName: ctx.featureName,

--- a/src/debate/session.ts
+++ b/src/debate/session.ts
@@ -152,7 +152,6 @@ export class DebateSession {
       feature: string;
       outputDir: string;
       timeoutSeconds?: number;
-      dangerouslySkipPermissions?: boolean;
       maxInteractionTurns?: number;
       /** Original spec content — anchors synthesis to prevent AC hallucination. */
       specContent?: string;

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -166,16 +166,10 @@ export async function collectStoryMetrics(ctx: PipelineContext, storyStartTime: 
     runtimeCrashes: ctx.storyRuntimeCrashes ?? 0,
     tokens: agentResult?.tokenUsage
       ? new TokenUsage({
-          input_tokens:
-            ((agentResult.tokenUsage as unknown as Record<string, unknown>).input_tokens as number) ??
-            ((agentResult.tokenUsage as unknown as Record<string, unknown>).inputTokens as number),
-          output_tokens:
-            ((agentResult.tokenUsage as unknown as Record<string, unknown>).output_tokens as number) ??
-            ((agentResult.tokenUsage as unknown as Record<string, unknown>).outputTokens as number),
-          cache_read_input_tokens: (agentResult.tokenUsage as unknown as Record<string, unknown>)
-            .cache_read_input_tokens as number | undefined,
-          cache_creation_input_tokens: (agentResult.tokenUsage as unknown as Record<string, unknown>)
-            .cache_creation_input_tokens as number | undefined,
+          inputTokens: agentResult.tokenUsage.inputTokens,
+          outputTokens: agentResult.tokenUsage.outputTokens,
+          cacheReadInputTokens: agentResult.tokenUsage.cacheReadInputTokens,
+          cacheCreationInputTokens: agentResult.tokenUsage.cacheCreationInputTokens,
         })
       : undefined,
     ...(ctx.verifyResult?.scopeTestFallback !== undefined && {
@@ -287,10 +281,10 @@ export async function saveRunMetrics(workdir: string, runMetrics: RunMetrics): P
 
   for (const story of runMetrics.stories) {
     if (story.tokens) {
-      totalInputTokens += story.tokens.input_tokens;
-      totalOutputTokens += story.tokens.output_tokens;
-      totalCacheReadInputTokens += story.tokens.cache_read_input_tokens ?? 0;
-      totalCacheCreationInputTokens += story.tokens.cache_creation_input_tokens ?? 0;
+      totalInputTokens += story.tokens.inputTokens;
+      totalOutputTokens += story.tokens.outputTokens;
+      totalCacheReadInputTokens += story.tokens.cacheReadInputTokens ?? 0;
+      totalCacheCreationInputTokens += story.tokens.cacheCreationInputTokens ?? 0;
     }
   }
 
@@ -300,10 +294,10 @@ export async function saveRunMetrics(workdir: string, runMetrics: RunMetrics): P
 
   if (hasTokenData) {
     runMetrics.totalTokens = new TokenUsage({
-      input_tokens: totalInputTokens,
-      output_tokens: totalOutputTokens,
-      cache_read_input_tokens: totalCacheReadInputTokens,
-      cache_creation_input_tokens: totalCacheCreationInputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
+      cacheReadInputTokens: totalCacheReadInputTokens,
+      cacheCreationInputTokens: totalCacheCreationInputTokens,
     });
   }
 

--- a/src/metrics/types.ts
+++ b/src/metrics/types.ts
@@ -9,44 +9,44 @@
  */
 export interface TokenUsage {
   /** Number of input tokens consumed */
-  input_tokens: number;
+  inputTokens: number;
   /** Number of output tokens generated */
-  output_tokens: number;
+  outputTokens: number;
   /** Number of input tokens read from cache (optional, omitted when 0) */
-  cache_read_input_tokens?: number;
+  cacheReadInputTokens?: number;
   /** Number of input tokens used for cache creation (optional, omitted when 0) */
-  cache_creation_input_tokens?: number;
+  cacheCreationInputTokens?: number;
 }
 
 // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: TokenUsage must be both an interface (for type checking) and a class (for runtime construction with toJSON)
 export class TokenUsage {
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_input_tokens?: number;
-  cache_creation_input_tokens?: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens?: number;
 
   constructor(data: {
-    input_tokens: number;
-    output_tokens: number;
-    cache_read_input_tokens?: number;
-    cache_creation_input_tokens?: number;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadInputTokens?: number;
+    cacheCreationInputTokens?: number;
   }) {
-    this.input_tokens = data.input_tokens;
-    this.output_tokens = data.output_tokens;
-    this.cache_read_input_tokens = data.cache_read_input_tokens;
-    this.cache_creation_input_tokens = data.cache_creation_input_tokens;
+    this.inputTokens = data.inputTokens;
+    this.outputTokens = data.outputTokens;
+    this.cacheReadInputTokens = data.cacheReadInputTokens;
+    this.cacheCreationInputTokens = data.cacheCreationInputTokens;
   }
 
   toJSON(): Record<string, unknown> {
     const result: Record<string, unknown> = {
-      input_tokens: this.input_tokens,
-      output_tokens: this.output_tokens,
+      inputTokens: this.inputTokens,
+      outputTokens: this.outputTokens,
     };
-    if (this.cache_read_input_tokens !== 0) {
-      result.cache_read_input_tokens = this.cache_read_input_tokens;
+    if (this.cacheReadInputTokens !== 0) {
+      result.cacheReadInputTokens = this.cacheReadInputTokens;
     }
-    if (this.cache_creation_input_tokens !== 0) {
-      result.cache_creation_input_tokens = this.cache_creation_input_tokens;
+    if (this.cacheCreationInputTokens !== 0) {
+      result.cacheCreationInputTokens = this.cacheCreationInputTokens;
     }
     return result;
   }

--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -12,7 +12,6 @@
 
 import type { IAgentManager } from "../../agents";
 import { resolveModelForAgent } from "../../config";
-import { resolvePermissions } from "../../config/permissions";
 import { getLogger } from "../../logger";
 import type { UserStory } from "../../prd";
 import { RectifierPromptBuilder } from "../../prompts";
@@ -157,7 +156,6 @@ export async function runTestWriterRectification(
         modelTier,
         modelDef,
         timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
-        dangerouslySkipPermissions: resolvePermissions(ctx.config, "rectification").skipPermissions,
         pipelineStage: "rectification",
         config: ctx.config,
         projectDir: ctx.projectDir,

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -21,7 +21,6 @@
 
 import { computeAcpHandle } from "../../agents/acp/adapter";
 import { resolveModelForAgent } from "../../config";
-import { resolvePermissions } from "../../config/permissions";
 import { getLogger } from "../../logger";
 import type { UserStory } from "../../prd";
 import { RectifierPromptBuilder } from "../../prompts";
@@ -520,7 +519,6 @@ async function runAgentRectification(
             modelTier,
             modelDef,
             timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
-            dangerouslySkipPermissions: resolvePermissions(ctx.config, "rectification").skipPermissions,
             pipelineStage: "rectification",
             config: ctx.config,
             projectDir: ctx.projectDir,

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -9,7 +9,6 @@
 import { validateAgentForTier } from "../../agents";
 import type { AgentAdapter } from "../../agents/types";
 import { resolveModelForAgent } from "../../config";
-import { resolvePermissions } from "../../config/permissions";
 import { failAndClose } from "../../execution/session-manager-runtime";
 import { buildInteractionBridge } from "../../interaction/bridge-builder";
 import { checkMergeConflict, checkStoryAmbiguity, isTriggerEnabled } from "../../interaction/triggers";
@@ -76,7 +75,6 @@ export const executionStage: PipelineStage = {
             defaultAgent,
           ),
           timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
-          dangerouslySkipPermissions: resolvePermissions(ctx.config, "run").skipPermissions,
           pipelineStage: "run",
           config: ctx.config,
         },
@@ -172,7 +170,6 @@ export const executionStage: PipelineStage = {
         defaultAgent,
       ),
       timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
-      dangerouslySkipPermissions: resolvePermissions(ctx.config, "run").skipPermissions,
       pipelineStage: "run",
       config: ctx.config,
       projectDir: ctx.projectDir,

--- a/src/runtime/agent-middleware.ts
+++ b/src/runtime/agent-middleware.ts
@@ -1,0 +1,47 @@
+import type { AgentRunRequest } from "../agents/manager-types";
+import type { NaxConfig } from "../config";
+import type { ResolvedPermissions } from "../config/permissions";
+
+export interface MiddlewareContext {
+  readonly runId: string;
+  readonly agentName: string;
+  readonly kind: "run" | "complete" | "plan";
+  readonly request: AgentRunRequest | null;
+  readonly prompt: string | null;
+  readonly config: NaxConfig;
+  readonly signal?: AbortSignal;
+  readonly resolvedPermissions: ResolvedPermissions;
+  readonly storyId?: string;
+  readonly stage?: string;
+}
+
+export interface AgentMiddleware {
+  readonly name: string;
+  before?(ctx: MiddlewareContext): void | Promise<void>;
+  after?(ctx: MiddlewareContext, result: unknown, durationMs: number): void | Promise<void>;
+  onError?(ctx: MiddlewareContext, err: unknown, durationMs: number): void | Promise<void>;
+}
+
+export class MiddlewareChain {
+  private constructor(private readonly _chain: readonly AgentMiddleware[]) {}
+
+  static empty(): MiddlewareChain {
+    return new MiddlewareChain([]);
+  }
+
+  static from(chain: readonly AgentMiddleware[]): MiddlewareChain {
+    return new MiddlewareChain([...chain]);
+  }
+
+  async runBefore(ctx: MiddlewareContext): Promise<void> {
+    for (const mw of this._chain) await mw.before?.(ctx);
+  }
+
+  async runAfter(ctx: MiddlewareContext, result: unknown, durationMs: number): Promise<void> {
+    for (const mw of this._chain) await mw.after?.(ctx, result, durationMs);
+  }
+
+  async runOnError(ctx: MiddlewareContext, err: unknown, durationMs: number): Promise<void> {
+    for (const mw of this._chain) await mw.onError?.(ctx, err, durationMs);
+  }
+}

--- a/src/runtime/cost-aggregator.ts
+++ b/src/runtime/cost-aggregator.ts
@@ -67,3 +67,80 @@ export function createNoOpCostAggregator(): ICostAggregator {
     async drain() {},
   };
 }
+
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+/** Injectable deps — swap `write` in tests to avoid real disk I/O. */
+export const _costAggDeps = {
+  write: (path: string, data: string): Promise<number> => Bun.write(path, data),
+};
+
+function emptySnap(): CostSnapshot {
+  return { totalCostUsd: 0, totalInputTokens: 0, totalOutputTokens: 0, callCount: 0, errorCount: 0 };
+}
+
+function accumulate(snap: CostSnapshot, e: CostEvent): CostSnapshot {
+  return {
+    totalCostUsd: snap.totalCostUsd + e.costUsd,
+    totalInputTokens: snap.totalInputTokens + e.tokens.input,
+    totalOutputTokens: snap.totalOutputTokens + e.tokens.output,
+    callCount: snap.callCount + 1,
+    errorCount: snap.errorCount,
+  };
+}
+
+export class CostAggregator implements ICostAggregator {
+  private readonly _events: CostEvent[] = [];
+  private readonly _errors: CostErrorEvent[] = [];
+
+  constructor(
+    private readonly _runId: string,
+    private readonly _drainDir: string,
+  ) {}
+
+  record(event: CostEvent): void {
+    this._events.push(event);
+  }
+
+  recordError(event: CostErrorEvent): void {
+    this._errors.push(event);
+  }
+
+  snapshot(): CostSnapshot {
+    return this._events.reduce(accumulate, { ...emptySnap(), errorCount: this._errors.length });
+  }
+
+  byAgent(): Record<string, CostSnapshot> {
+    const m: Record<string, CostSnapshot> = {};
+    for (const e of this._events) m[e.agentName] = accumulate(m[e.agentName] ?? emptySnap(), e);
+    return m;
+  }
+
+  byStage(): Record<string, CostSnapshot> {
+    const m: Record<string, CostSnapshot> = {};
+    for (const e of this._events) {
+      const k = e.stage ?? "unknown";
+      m[k] = accumulate(m[k] ?? emptySnap(), e);
+    }
+    return m;
+  }
+
+  byStory(): Record<string, CostSnapshot> {
+    const m: Record<string, CostSnapshot> = {};
+    for (const e of this._events) {
+      const k = e.storyId ?? "unknown";
+      m[k] = accumulate(m[k] ?? emptySnap(), e);
+    }
+    return m;
+  }
+
+  async drain(): Promise<void> {
+    if (this._events.length === 0 && this._errors.length === 0) return;
+    mkdirSync(this._drainDir, { recursive: true });
+    const path = join(this._drainDir, `${this._runId}.jsonl`);
+    const sorted = [...this._events, ...this._errors].sort((a, b) => a.ts - b.ts);
+    const content = `${sorted.map((e) => JSON.stringify(e)).join("\n")}\n`;
+    await _costAggDeps.write(path, content);
+  }
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -70,9 +70,12 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
   const configLoader = createConfigLoader(config);
 
   const costDir = join(workdir, ".nax", "cost");
-  const auditDir = join(workdir, ".nax", "audit");
   const costAggregator = opts?.costAggregator ?? new CostAggregator(runId, costDir);
-  const promptAuditor = opts?.promptAuditor ?? new PromptAuditor(runId, auditDir);
+
+  const auditEnabled = config.agent?.promptAudit?.enabled ?? false;
+  const auditDir = config.agent?.promptAudit?.dir ?? join(workdir, ".nax", "audit");
+  const promptAuditor =
+    opts?.promptAuditor ?? (auditEnabled ? new PromptAuditor(runId, auditDir) : createNoOpPromptAuditor());
 
   const middleware = MiddlewareChain.from([
     cancellationMiddleware(),

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,11 +1,11 @@
-export { createNoOpCostAggregator } from "./cost-aggregator";
+export { createNoOpCostAggregator, CostAggregator, _costAggDeps } from "./cost-aggregator";
 export type {
   ICostAggregator,
   CostEvent,
   CostErrorEvent,
   CostSnapshot,
 } from "./cost-aggregator";
-export { createNoOpPromptAuditor } from "./prompt-auditor";
+export { createNoOpPromptAuditor, PromptAuditor, _promptAuditorDeps } from "./prompt-auditor";
 export type {
   IPromptAuditor,
   PromptAuditEntry,
@@ -13,8 +13,12 @@ export type {
 } from "./prompt-auditor";
 export type { PackageView, PackageRegistry } from "./packages";
 export { createPackageRegistry } from "./packages";
+export type { AgentMiddleware, MiddlewareContext } from "./agent-middleware";
+export { MiddlewareChain } from "./agent-middleware";
 
+import { join } from "node:path";
 import type { IAgentManager } from "../agents";
+import type { CreateAgentManagerOpts } from "../agents/factory";
 import type { NaxConfig } from "../config";
 import { createConfigLoader } from "../config";
 import type { ConfigLoader } from "../config";
@@ -22,15 +26,18 @@ import { getLogger } from "../logger";
 import type { Logger } from "../logger";
 import type { ISessionManager } from "../session";
 import { SessionManager } from "../session";
-import { createNoOpCostAggregator } from "./cost-aggregator";
+import { MiddlewareChain } from "./agent-middleware";
+import { CostAggregator, createNoOpCostAggregator } from "./cost-aggregator";
 import type { ICostAggregator } from "./cost-aggregator";
 import { createAgentManager } from "./internal/agent-manager-factory";
+import { auditMiddleware, cancellationMiddleware, costMiddleware, loggingMiddleware } from "./middleware";
 import { createPackageRegistry } from "./packages";
 import type { PackageRegistry } from "./packages";
-import { createNoOpPromptAuditor } from "./prompt-auditor";
+import { PromptAuditor, createNoOpPromptAuditor } from "./prompt-auditor";
 import type { IPromptAuditor } from "./prompt-auditor";
 
 export interface NaxRuntime {
+  readonly runId: string;
   readonly configLoader: ConfigLoader;
   readonly workdir: string;
   readonly projectDir: string;
@@ -53,22 +60,37 @@ export interface CreateRuntimeOptions {
 }
 
 export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateRuntimeOptions): NaxRuntime {
+  const runId = crypto.randomUUID();
+
   const controller = new AbortController();
   if (opts?.parentSignal) {
     opts.parentSignal.addEventListener("abort", () => controller.abort(opts.parentSignal?.reason), { once: true });
   }
 
   const configLoader = createConfigLoader(config);
-  const agentManager = opts?.agentManager ?? createAgentManager(config);
+
+  const costDir = join(workdir, ".nax", "cost");
+  const auditDir = join(workdir, ".nax", "audit");
+  const costAggregator = opts?.costAggregator ?? new CostAggregator(runId, costDir);
+  const promptAuditor = opts?.promptAuditor ?? new PromptAuditor(runId, auditDir);
+
+  const middleware = MiddlewareChain.from([
+    cancellationMiddleware(),
+    loggingMiddleware(),
+    costMiddleware(costAggregator, runId),
+    auditMiddleware(promptAuditor, runId),
+  ]);
+  const agentManagerOpts: CreateAgentManagerOpts = { middleware, runId };
+  const agentManager = opts?.agentManager ?? createAgentManager(config, agentManagerOpts);
+
   const sessionManager = opts?.sessionManager ?? new SessionManager();
-  const costAggregator = opts?.costAggregator ?? createNoOpCostAggregator();
-  const promptAuditor = opts?.promptAuditor ?? createNoOpPromptAuditor();
   const packages = createPackageRegistry(configLoader, workdir);
   const logger = getLogger();
 
   let closed = false;
 
   return {
+    runId,
     configLoader,
     workdir,
     projectDir: workdir, // Wave 1: equal to workdir; Wave 3 will separate worktree paths
@@ -90,3 +112,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     },
   };
 }
+
+// Suppress unused import warnings — these are re-exported above for the barrel.
+void createNoOpCostAggregator;
+void createNoOpPromptAuditor;

--- a/src/runtime/internal/agent-manager-factory.ts
+++ b/src/runtime/internal/agent-manager-factory.ts
@@ -1,7 +1,8 @@
 import type { IAgentManager } from "../../agents";
 import { createAgentManager as createAgentManagerFromFactory } from "../../agents/factory";
+import type { CreateAgentManagerOpts } from "../../agents/factory";
 import type { NaxConfig } from "../../config";
 
-export function createAgentManager(config: NaxConfig): IAgentManager {
-  return createAgentManagerFromFactory(config);
+export function createAgentManager(config: NaxConfig, opts?: CreateAgentManagerOpts): IAgentManager {
+  return createAgentManagerFromFactory(config, opts);
 }

--- a/src/runtime/middleware/audit.ts
+++ b/src/runtime/middleware/audit.ts
@@ -1,3 +1,4 @@
+import type { AgentResult } from "../../agents/types";
 import { NaxError } from "../../errors";
 import type { AgentMiddleware, MiddlewareContext } from "../agent-middleware";
 import type { IPromptAuditor, PromptAuditEntry, PromptAuditErrorEntry } from "../prompt-auditor";
@@ -11,18 +12,12 @@ export function auditMiddleware(auditor: IPromptAuditor, runId: string): AgentMi
   return {
     name: "audit",
     async after(ctx: MiddlewareContext, result: unknown, durationMs: number): Promise<void> {
-      const runOpts = ctx.request?.runOptions as Record<string, unknown> | undefined;
-      const prompt = ctx.prompt ?? (runOpts?.prompt as string | undefined);
+      const runOpts = ctx.request?.runOptions;
+      const prompt = ctx.prompt ?? runOpts?.prompt;
       if (!prompt) return;
 
-      // Extract ACP session correlation from AgentResult if present.
-      const agentResult = result as Record<string, unknown> | null | undefined;
-      const protocolIds = agentResult?.protocolIds as
-        | { recordId?: string | null; sessionId?: string | null }
-        | undefined;
-      const sessionMeta = agentResult?.sessionMetadata as
-        | { sessionName?: string; turn?: number; resumed?: boolean }
-        | undefined;
+      const agentResult = (result ?? {}) as Partial<AgentResult>;
+      const { protocolIds, sessionMetadata } = agentResult;
 
       const entry: PromptAuditEntry = {
         ts: Date.now(),
@@ -35,18 +30,21 @@ export function auditMiddleware(auditor: IPromptAuditor, runId: string): AgentMi
         response: extractOutput(result),
         durationMs,
         callType: ctx.kind,
-        workdir: runOpts?.workdir as string | undefined,
-        projectDir: runOpts?.projectDir as string | undefined,
-        featureName: runOpts?.featureName as string | undefined,
-        ...(sessionMeta?.sessionName !== undefined && { sessionName: sessionMeta.sessionName }),
+        workdir: runOpts?.workdir,
+        projectDir: runOpts?.projectDir,
+        featureName: runOpts?.featureName,
+        ...(sessionMetadata?.sessionName !== undefined && { sessionName: sessionMetadata.sessionName }),
         ...(protocolIds?.recordId !== undefined && { recordId: protocolIds.recordId }),
         ...(protocolIds?.sessionId !== undefined && { sessionId: protocolIds.sessionId }),
-        ...(sessionMeta?.turn !== undefined && { turn: sessionMeta.turn }),
-        ...(sessionMeta?.resumed !== undefined && { resumed: sessionMeta.resumed }),
+        ...(sessionMetadata?.turn !== undefined && { turn: sessionMetadata.turn }),
+        ...(sessionMetadata?.resumed !== undefined && { resumed: sessionMetadata.resumed }),
       };
       auditor.record(entry);
     },
     async onError(ctx: MiddlewareContext, err: unknown, durationMs: number): Promise<void> {
+      const runOpts = ctx.request?.runOptions;
+      const prompt = ctx.prompt ?? runOpts?.prompt;
+      const errorMessage = err instanceof Error ? err.message : typeof err === "string" ? err : undefined;
       const entry: PromptAuditErrorEntry = {
         ts: Date.now(),
         runId,
@@ -55,6 +53,13 @@ export function auditMiddleware(auditor: IPromptAuditor, runId: string): AgentMi
         storyId: ctx.storyId,
         errorCode: err instanceof NaxError ? err.code : "UNKNOWN",
         durationMs,
+        callType: ctx.kind,
+        permissionProfile: ctx.resolvedPermissions.mode,
+        ...(errorMessage !== undefined && { errorMessage }),
+        ...(prompt !== undefined && { prompt }),
+        ...(runOpts?.workdir !== undefined && { workdir: runOpts.workdir }),
+        ...(runOpts?.projectDir !== undefined && { projectDir: runOpts.projectDir }),
+        ...(runOpts?.featureName !== undefined && { featureName: runOpts.featureName }),
       };
       auditor.recordError(entry);
     },

--- a/src/runtime/middleware/audit.ts
+++ b/src/runtime/middleware/audit.ts
@@ -11,9 +11,19 @@ export function auditMiddleware(auditor: IPromptAuditor, runId: string): AgentMi
   return {
     name: "audit",
     async after(ctx: MiddlewareContext, result: unknown, durationMs: number): Promise<void> {
-      const prompt =
-        ctx.prompt ?? ((ctx.request?.runOptions as Record<string, unknown> | undefined)?.prompt as string | undefined);
+      const runOpts = ctx.request?.runOptions as Record<string, unknown> | undefined;
+      const prompt = ctx.prompt ?? (runOpts?.prompt as string | undefined);
       if (!prompt) return;
+
+      // Extract ACP session correlation from AgentResult if present.
+      const agentResult = result as Record<string, unknown> | null | undefined;
+      const protocolIds = agentResult?.protocolIds as
+        | { recordId?: string | null; sessionId?: string | null }
+        | undefined;
+      const sessionMeta = agentResult?.sessionMetadata as
+        | { sessionName?: string; turn?: number; resumed?: boolean }
+        | undefined;
+
       const entry: PromptAuditEntry = {
         ts: Date.now(),
         runId,
@@ -24,6 +34,15 @@ export function auditMiddleware(auditor: IPromptAuditor, runId: string): AgentMi
         prompt,
         response: extractOutput(result),
         durationMs,
+        callType: ctx.kind,
+        workdir: runOpts?.workdir as string | undefined,
+        projectDir: runOpts?.projectDir as string | undefined,
+        featureName: runOpts?.featureName as string | undefined,
+        ...(sessionMeta?.sessionName !== undefined && { sessionName: sessionMeta.sessionName }),
+        ...(protocolIds?.recordId !== undefined && { recordId: protocolIds.recordId }),
+        ...(protocolIds?.sessionId !== undefined && { sessionId: protocolIds.sessionId }),
+        ...(sessionMeta?.turn !== undefined && { turn: sessionMeta.turn }),
+        ...(sessionMeta?.resumed !== undefined && { resumed: sessionMeta.resumed }),
       };
       auditor.record(entry);
     },

--- a/src/runtime/middleware/audit.ts
+++ b/src/runtime/middleware/audit.ts
@@ -1,0 +1,43 @@
+import { NaxError } from "../../errors";
+import type { AgentMiddleware, MiddlewareContext } from "../agent-middleware";
+import type { IPromptAuditor, PromptAuditEntry, PromptAuditErrorEntry } from "../prompt-auditor";
+
+function extractOutput(result: unknown): string {
+  if (!result || typeof result !== "object") return "";
+  return ((result as Record<string, unknown>).output as string | undefined) ?? "";
+}
+
+export function auditMiddleware(auditor: IPromptAuditor, runId: string): AgentMiddleware {
+  return {
+    name: "audit",
+    async after(ctx: MiddlewareContext, result: unknown, durationMs: number): Promise<void> {
+      const prompt =
+        ctx.prompt ?? ((ctx.request?.runOptions as Record<string, unknown> | undefined)?.prompt as string | undefined);
+      if (!prompt) return;
+      const entry: PromptAuditEntry = {
+        ts: Date.now(),
+        runId,
+        agentName: ctx.agentName,
+        stage: ctx.stage,
+        storyId: ctx.storyId,
+        permissionProfile: ctx.resolvedPermissions.mode,
+        prompt,
+        response: extractOutput(result),
+        durationMs,
+      };
+      auditor.record(entry);
+    },
+    async onError(ctx: MiddlewareContext, err: unknown, durationMs: number): Promise<void> {
+      const entry: PromptAuditErrorEntry = {
+        ts: Date.now(),
+        runId,
+        agentName: ctx.agentName,
+        stage: ctx.stage,
+        storyId: ctx.storyId,
+        errorCode: err instanceof NaxError ? err.code : "UNKNOWN",
+        durationMs,
+      };
+      auditor.recordError(entry);
+    },
+  };
+}

--- a/src/runtime/middleware/cancellation.ts
+++ b/src/runtime/middleware/cancellation.ts
@@ -1,0 +1,16 @@
+import { NaxError } from "../../errors";
+import type { AgentMiddleware, MiddlewareContext } from "../agent-middleware";
+
+export function cancellationMiddleware(): AgentMiddleware {
+  return {
+    name: "cancellation",
+    async before(ctx: MiddlewareContext): Promise<void> {
+      if (ctx.signal?.aborted) {
+        throw new NaxError("Agent call cancelled before start", "AGENT_CANCELLED", {
+          stage: ctx.stage ?? "run",
+          agentName: ctx.agentName,
+        });
+      }
+    },
+  };
+}

--- a/src/runtime/middleware/cost.ts
+++ b/src/runtime/middleware/cost.ts
@@ -9,8 +9,8 @@ function extractTokens(
   const tu = (result as Record<string, unknown>).tokenUsage as Record<string, number> | undefined;
   if (!tu) return null;
   return {
-    input: tu.input_tokens ?? 0,
-    output: tu.output_tokens ?? 0,
+    input: tu.inputTokens ?? 0,
+    output: tu.outputTokens ?? 0,
     cacheRead: tu.cache_read_input_tokens,
     cacheWrite: tu.cache_creation_input_tokens,
   };
@@ -27,7 +27,8 @@ export function costMiddleware(aggregator: ICostAggregator, runId: string): Agen
     name: "cost",
     async after(ctx: MiddlewareContext, result: unknown, durationMs: number): Promise<void> {
       const tokens = extractTokens(result);
-      if (!tokens) return;
+      const costUsd = extractCostUsd(result);
+      if (!tokens && costUsd === 0) return;
       const event: CostEvent = {
         ts: Date.now(),
         runId,
@@ -35,8 +36,8 @@ export function costMiddleware(aggregator: ICostAggregator, runId: string): Agen
         model: ((result as Record<string, unknown>).model as string | undefined) ?? "unknown",
         stage: ctx.stage,
         storyId: ctx.storyId,
-        tokens,
-        costUsd: extractCostUsd(result),
+        tokens: tokens ?? { input: 0, output: 0 },
+        costUsd,
         durationMs,
       };
       aggregator.record(event);

--- a/src/runtime/middleware/cost.ts
+++ b/src/runtime/middleware/cost.ts
@@ -1,0 +1,57 @@
+import { NaxError } from "../../errors";
+import type { AgentMiddleware, MiddlewareContext } from "../agent-middleware";
+import type { CostErrorEvent, CostEvent, ICostAggregator } from "../cost-aggregator";
+
+function extractTokens(
+  result: unknown,
+): { input: number; output: number; cacheRead?: number; cacheWrite?: number } | null {
+  if (!result || typeof result !== "object") return null;
+  const tu = (result as Record<string, unknown>).tokenUsage as Record<string, number> | undefined;
+  if (!tu) return null;
+  return {
+    input: tu.input_tokens ?? 0,
+    output: tu.output_tokens ?? 0,
+    cacheRead: tu.cache_read_input_tokens,
+    cacheWrite: tu.cache_creation_input_tokens,
+  };
+}
+
+function extractCostUsd(result: unknown): number {
+  if (!result || typeof result !== "object") return 0;
+  const r = result as Record<string, unknown>;
+  return (r.estimatedCost as number | undefined) ?? (r.costUsd as number | undefined) ?? 0;
+}
+
+export function costMiddleware(aggregator: ICostAggregator, runId: string): AgentMiddleware {
+  return {
+    name: "cost",
+    async after(ctx: MiddlewareContext, result: unknown, durationMs: number): Promise<void> {
+      const tokens = extractTokens(result);
+      if (!tokens) return;
+      const event: CostEvent = {
+        ts: Date.now(),
+        runId,
+        agentName: ctx.agentName,
+        model: ((result as Record<string, unknown>).model as string | undefined) ?? "unknown",
+        stage: ctx.stage,
+        storyId: ctx.storyId,
+        tokens,
+        costUsd: extractCostUsd(result),
+        durationMs,
+      };
+      aggregator.record(event);
+    },
+    async onError(ctx: MiddlewareContext, err: unknown, durationMs: number): Promise<void> {
+      const event: CostErrorEvent = {
+        ts: Date.now(),
+        runId,
+        agentName: ctx.agentName,
+        stage: ctx.stage,
+        storyId: ctx.storyId,
+        errorCode: err instanceof NaxError ? err.code : "UNKNOWN",
+        durationMs,
+      };
+      aggregator.recordError(event);
+    },
+  };
+}

--- a/src/runtime/middleware/cost.ts
+++ b/src/runtime/middleware/cost.ts
@@ -11,8 +11,8 @@ function extractTokens(
   return {
     input: tu.inputTokens ?? 0,
     output: tu.outputTokens ?? 0,
-    cacheRead: tu.cache_read_input_tokens,
-    cacheWrite: tu.cache_creation_input_tokens,
+    cacheRead: tu.cacheReadInputTokens,
+    cacheWrite: tu.cacheCreationInputTokens,
   };
 }
 

--- a/src/runtime/middleware/index.ts
+++ b/src/runtime/middleware/index.ts
@@ -1,0 +1,4 @@
+export { cancellationMiddleware } from "./cancellation";
+export { loggingMiddleware } from "./logging";
+export { costMiddleware } from "./cost";
+export { auditMiddleware } from "./audit";

--- a/src/runtime/middleware/logging.ts
+++ b/src/runtime/middleware/logging.ts
@@ -1,0 +1,38 @@
+import { getSafeLogger } from "../../logger";
+import type { AgentMiddleware, MiddlewareContext } from "../agent-middleware";
+
+export function loggingMiddleware(): AgentMiddleware {
+  return {
+    name: "logging",
+    async before(ctx: MiddlewareContext): Promise<void> {
+      getSafeLogger()?.info("middleware", "Agent call start", {
+        storyId: ctx.storyId,
+        runId: ctx.runId,
+        agentName: ctx.agentName,
+        kind: ctx.kind,
+        stage: ctx.stage,
+      });
+    },
+    async after(ctx: MiddlewareContext, _result: unknown, durationMs: number): Promise<void> {
+      getSafeLogger()?.info("middleware", "Agent call complete", {
+        storyId: ctx.storyId,
+        runId: ctx.runId,
+        agentName: ctx.agentName,
+        kind: ctx.kind,
+        stage: ctx.stage,
+        durationMs,
+      });
+    },
+    async onError(ctx: MiddlewareContext, err: unknown, durationMs: number): Promise<void> {
+      getSafeLogger()?.warn("middleware", "Agent call failed", {
+        storyId: ctx.storyId,
+        runId: ctx.runId,
+        agentName: ctx.agentName,
+        kind: ctx.kind,
+        stage: ctx.stage,
+        durationMs,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    },
+  };
+}

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -33,3 +33,36 @@ export function createNoOpPromptAuditor(): IPromptAuditor {
     async flush() {},
   };
 }
+
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+/** Injectable deps — swap `write` in tests to avoid real disk I/O. */
+export const _promptAuditorDeps = {
+  write: (path: string, data: string): Promise<number> => Bun.write(path, data),
+};
+
+export class PromptAuditor implements IPromptAuditor {
+  private readonly _entries: (PromptAuditEntry | PromptAuditErrorEntry)[] = [];
+
+  constructor(
+    private readonly _runId: string,
+    private readonly _flushDir: string,
+  ) {}
+
+  record(entry: PromptAuditEntry): void {
+    this._entries.push(entry);
+  }
+
+  recordError(entry: PromptAuditErrorEntry): void {
+    this._entries.push(entry);
+  }
+
+  async flush(): Promise<void> {
+    if (this._entries.length === 0) return;
+    mkdirSync(this._flushDir, { recursive: true });
+    const path = join(this._flushDir, `${this._runId}.jsonl`);
+    const content = `${this._entries.map((e) => JSON.stringify(e)).join("\n")}\n`;
+    await _promptAuditorDeps.write(path, content);
+  }
+}

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -8,6 +8,17 @@ export interface PromptAuditEntry {
   readonly prompt: string;
   readonly response: string;
   readonly durationMs: number;
+  /** Type of call: "run" | "complete" | "plan". */
+  readonly callType?: string;
+  readonly workdir?: string;
+  readonly projectDir?: string;
+  readonly featureName?: string;
+  /** ACP-specific session correlation fields. */
+  readonly sessionName?: string;
+  readonly recordId?: string | null;
+  readonly sessionId?: string | null;
+  readonly turn?: number;
+  readonly resumed?: boolean;
 }
 
 export interface PromptAuditErrorEntry {

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -28,7 +28,16 @@ export interface PromptAuditErrorEntry {
   readonly stage?: string;
   readonly storyId?: string;
   readonly errorCode: string;
+  readonly errorMessage?: string;
   readonly durationMs: number;
+  /** Type of call that errored: "run" | "complete" | "plan". */
+  readonly callType?: string;
+  /** Prompt that was being attempted when the error occurred — captured from ctx. */
+  readonly prompt?: string;
+  readonly workdir?: string;
+  readonly projectDir?: string;
+  readonly featureName?: string;
+  readonly permissionProfile?: string;
 }
 
 export interface IPromptAuditor {

--- a/src/session/runners/single-session-runner.ts
+++ b/src/session/runners/single-session-runner.ts
@@ -259,8 +259,13 @@ export class SingleSessionRunner implements ISessionRunner {
 
     // executeHop: thin wrapper that delegates to executeHopFn and captures the
     // last hop's bundle/prompt for StoryRunOutcome. Called by runWithFallback.
-    const executeHop: AgentRunRequest["executeHop"] = async (agentName, hopBundle, failure) => {
-      const hop = await executeHopFn(hopParams, agentName, hopBundle, failure);
+    const executeHop: AgentRunRequest["executeHop"] = async (agentName, hopBundle, failure, resolvedRunOptions) => {
+      const hop = await executeHopFn(
+        { ...hopParams, primaryOptions: resolvedRunOptions },
+        agentName,
+        hopBundle,
+        failure,
+      );
       finalBundle = hop.bundle ?? finalBundle;
       finalPrompt = hop.prompt;
       return hop;

--- a/src/session/runners/single-session-runner.ts
+++ b/src/session/runners/single-session-runner.ts
@@ -301,11 +301,11 @@ export class SingleSessionRunner implements ISessionRunner {
         ? {
             inputTokens: result.tokenUsage.inputTokens ?? 0,
             outputTokens: result.tokenUsage.outputTokens ?? 0,
-            ...(result.tokenUsage.cache_read_input_tokens !== undefined && {
-              cache_read_input_tokens: result.tokenUsage.cache_read_input_tokens,
+            ...(result.tokenUsage.cacheReadInputTokens !== undefined && {
+              cacheReadInputTokens: result.tokenUsage.cacheReadInputTokens,
             }),
-            ...(result.tokenUsage.cache_creation_input_tokens !== undefined && {
-              cache_creation_input_tokens: result.tokenUsage.cache_creation_input_tokens,
+            ...(result.tokenUsage.cacheCreationInputTokens !== undefined && {
+              cacheCreationInputTokens: result.tokenUsage.cacheCreationInputTokens,
             }),
           }
         : undefined,

--- a/src/session/session-runner.ts
+++ b/src/session/session-runner.ts
@@ -67,8 +67,8 @@ export interface StoryRunOutcome {
   totalTokenUsage?: {
     inputTokens: number;
     outputTokens: number;
-    cache_read_input_tokens?: number;
-    cache_creation_input_tokens?: number;
+    cacheReadInputTokens?: number;
+    cacheCreationInputTokens?: number;
   };
   /** Agent swap history when the runner delegates to AgentManager. Empty for direct-adapter runners. */
   fallbacks: AgentFallbackRecord[];

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -86,20 +86,20 @@ function sumTddTokenUsage(sessions: TddSessionResult[]): import("../agents/cost"
   const total = {
     inputTokens: 0,
     outputTokens: 0,
-    cache_read_input_tokens: 0,
-    cache_creation_input_tokens: 0,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
   };
   for (const u of usages) {
     total.inputTokens += u.inputTokens ?? 0;
     total.outputTokens += u.outputTokens ?? 0;
-    total.cache_read_input_tokens += u.cache_read_input_tokens ?? 0;
-    total.cache_creation_input_tokens += u.cache_creation_input_tokens ?? 0;
+    total.cacheReadInputTokens += u.cacheReadInputTokens ?? 0;
+    total.cacheCreationInputTokens += u.cacheCreationInputTokens ?? 0;
   }
   return {
     inputTokens: total.inputTokens,
     outputTokens: total.outputTokens,
-    ...(total.cache_read_input_tokens > 0 && { cache_read_input_tokens: total.cache_read_input_tokens }),
-    ...(total.cache_creation_input_tokens > 0 && { cache_creation_input_tokens: total.cache_creation_input_tokens }),
+    ...(total.cacheReadInputTokens > 0 && { cacheReadInputTokens: total.cacheReadInputTokens }),
+    ...(total.cacheCreationInputTokens > 0 && { cacheCreationInputTokens: total.cacheCreationInputTokens }),
   };
 }
 

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -10,7 +10,6 @@ import type { IAgentManager } from "../agents";
 import { computeAcpHandle } from "../agents/acp/adapter";
 import type { ModelTier, NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config";
-import { resolvePermissions } from "../config/permissions";
 import type { getLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
@@ -287,7 +286,6 @@ async function runRectificationLoop(
             defaultAgent,
           ),
           timeoutSeconds: config.execution.sessionTimeoutSeconds,
-          dangerouslySkipPermissions: resolvePermissions(config, "rectification").skipPermissions,
           pipelineStage: "rectification",
           config,
           projectDir,

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -8,7 +8,6 @@ import type { AgentAdapter } from "../agents";
 import { resolveDefaultAgent, wrapAdapterAsManager } from "../agents";
 import type { ModelTier, NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config";
-import { resolvePermissions } from "../config/permissions";
 import { createContextToolRuntime } from "../context/engine";
 import type { InteractionBridge } from "../interaction/bridge-builder";
 import { getLogger } from "../logger";
@@ -222,7 +221,6 @@ export async function runTddSession(
       resolveDefaultAgent(config),
     ),
     timeoutSeconds: config.execution.sessionTimeoutSeconds,
-    dangerouslySkipPermissions: resolvePermissions(config, "run").skipPermissions,
     pipelineStage: "run" as const,
     config,
     projectDir,

--- a/src/tdd/three-session-runner.ts
+++ b/src/tdd/three-session-runner.ts
@@ -76,11 +76,11 @@ export class ThreeSessionRunner implements ISessionRunner {
         ? {
             inputTokens: tddResult.totalTokenUsage.inputTokens,
             outputTokens: tddResult.totalTokenUsage.outputTokens,
-            ...(tddResult.totalTokenUsage.cache_read_input_tokens !== undefined && {
-              cache_read_input_tokens: tddResult.totalTokenUsage.cache_read_input_tokens,
+            ...(tddResult.totalTokenUsage.cacheReadInputTokens !== undefined && {
+              cacheReadInputTokens: tddResult.totalTokenUsage.cacheReadInputTokens,
             }),
-            ...(tddResult.totalTokenUsage.cache_creation_input_tokens !== undefined && {
-              cache_creation_input_tokens: tddResult.totalTokenUsage.cache_creation_input_tokens,
+            ...(tddResult.totalTokenUsage.cacheCreationInputTokens !== undefined && {
+              cacheCreationInputTokens: tddResult.totalTokenUsage.cacheCreationInputTokens,
             }),
           }
         : undefined,

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -12,7 +12,6 @@ import { computeAcpHandle } from "../agents/acp/adapter";
 import { estimateCostByDuration } from "../agents/cost";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config";
-import { resolvePermissions } from "../config/permissions";
 import type { DebateStageConfig, Debater } from "../debate/types";
 import { escalateTier as _escalateTier } from "../execution/escalation/escalation";
 import { getSafeLogger } from "../logger";
@@ -268,7 +267,6 @@ export async function runRectificationLoop(
           modelTier,
           modelDef,
           timeoutSeconds: config.execution.sessionTimeoutSeconds,
-          dangerouslySkipPermissions: resolvePermissions(config, "rectification").skipPermissions,
           pipelineStage: "rectification",
           config,
           projectDir,
@@ -443,7 +441,6 @@ export async function runRectificationLoop(
           modelTier: escalatedTier,
           modelDef: escalatedModelDef,
           timeoutSeconds: config.execution.sessionTimeoutSeconds,
-          dangerouslySkipPermissions: resolvePermissions(config, "rectification").skipPermissions,
           pipelineStage: "rectification",
           config,
           projectDir,

--- a/test/integration/runtime/runtime-middleware.test.ts
+++ b/test/integration/runtime/runtime-middleware.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect } from "bun:test";
+import { join } from "node:path";
+import { createRuntime } from "../../../src/runtime";
+import { _promptAuditorDeps } from "../../../src/runtime/prompt-auditor";
+import { _costAggDeps } from "../../../src/runtime/cost-aggregator";
+import { DEFAULT_CONFIG } from "../../../src/config";
+import { makeMockAgentManager, makeTestRuntime } from "../../helpers";
+import { withTempDir } from "../../helpers/temp";
+
+describe("Wave 2 exit criteria", () => {
+  test("EC-1: createRuntime() produces a NaxRuntime with a UUID runId", () => {
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/ec1");
+    expect(rt.runId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test("EC-2: CostAggregator.snapshot() reflects recorded events", () => {
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/ec2");
+    expect(rt.costAggregator.snapshot().callCount).toBe(0);
+    rt.costAggregator.record({
+      ts: Date.now(),
+      runId: rt.runId,
+      agentName: "claude",
+      model: "claude-sonnet-4-6",
+      tokens: { input: 200, output: 100 },
+      costUsd: 0.01,
+      durationMs: 300,
+    });
+    expect(rt.costAggregator.snapshot().callCount).toBe(1);
+    expect(rt.costAggregator.snapshot().totalInputTokens).toBe(200);
+  });
+
+  test("EC-3: PromptAuditor.flush() writes to .nax/audit/<runId>.jsonl on close()", async () => {
+    await withTempDir(async (dir) => {
+      let flushedPath = "";
+      const orig = _promptAuditorDeps.write;
+      _promptAuditorDeps.write = async (p, _d) => {
+        flushedPath = p;
+        return 0;
+      };
+
+      try {
+        const rt = createRuntime(DEFAULT_CONFIG, dir);
+        rt.promptAuditor.record({
+          ts: Date.now(),
+          runId: rt.runId,
+          agentName: "claude",
+          permissionProfile: "approve-reads",
+          prompt: "test",
+          response: "ok",
+          durationMs: 50,
+        });
+        await rt.close();
+
+        expect(flushedPath).toBe(
+          join(dir, ".nax", "audit", `${rt.runId}.jsonl`),
+        );
+      } finally {
+        _promptAuditorDeps.write = orig;
+      }
+    });
+  });
+
+  test("EC-4: CostAggregator.drain() writes to .nax/cost/<runId>.jsonl on close()", async () => {
+    await withTempDir(async (dir) => {
+      let drainedPath = "";
+      const orig = _costAggDeps.write;
+      _costAggDeps.write = async (p, _d) => {
+        drainedPath = p;
+        return 0;
+      };
+
+      try {
+        const rt = createRuntime(DEFAULT_CONFIG, dir);
+        rt.costAggregator.record({
+          ts: Date.now(),
+          runId: rt.runId,
+          agentName: "claude",
+          model: "m",
+          tokens: { input: 10, output: 5 },
+          costUsd: 0.001,
+          durationMs: 100,
+        });
+        await rt.close();
+
+        expect(drainedPath).toBe(
+          join(dir, ".nax", "cost", `${rt.runId}.jsonl`),
+        );
+      } finally {
+        _costAggDeps.write = orig;
+      }
+    });
+  });
+
+  test("EC-5: makeTestRuntime() creates runtime with overrideable agentManager", () => {
+    const mockMgr = makeMockAgentManager();
+    const rt = makeTestRuntime({ agentManager: mockMgr });
+    expect(rt.agentManager).toBe(mockMgr);
+    expect(rt.runId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  test("EC-6: close() is idempotent — flush/drain called only once", async () => {
+    await withTempDir(async (dir) => {
+      let flushCount = 0;
+      let drainCount = 0;
+      const origFlush = _promptAuditorDeps.write;
+      const origDrain = _costAggDeps.write;
+      _promptAuditorDeps.write = async () => {
+        flushCount++;
+        return 0;
+      };
+      _costAggDeps.write = async () => {
+        drainCount++;
+        return 0;
+      };
+
+      try {
+        const rt = createRuntime(DEFAULT_CONFIG, dir);
+        rt.promptAuditor.record({
+          ts: Date.now(),
+          runId: rt.runId,
+          agentName: "a",
+          permissionProfile: "approve-reads",
+          prompt: "p",
+          response: "r",
+          durationMs: 1,
+        });
+        rt.costAggregator.record({
+          ts: Date.now(),
+          runId: rt.runId,
+          agentName: "a",
+          model: "m",
+          tokens: { input: 1, output: 1 },
+          costUsd: 0,
+          durationMs: 1,
+        });
+
+        await rt.close();
+        await rt.close(); // second close — should be idempotent
+
+        expect(flushCount).toBe(1);
+        expect(drainCount).toBe(1);
+      } finally {
+        _promptAuditorDeps.write = origFlush;
+        _costAggDeps.write = origDrain;
+      }
+    });
+  });
+});

--- a/test/integration/runtime/runtime-middleware.test.ts
+++ b/test/integration/runtime/runtime-middleware.test.ts
@@ -4,8 +4,10 @@ import { createRuntime } from "../../../src/runtime";
 import { _promptAuditorDeps } from "../../../src/runtime/prompt-auditor";
 import { _costAggDeps } from "../../../src/runtime/cost-aggregator";
 import { DEFAULT_CONFIG } from "../../../src/config";
-import { makeMockAgentManager, makeTestRuntime } from "../../helpers";
+import { makeNaxConfig, makeMockAgentManager, makeTestRuntime } from "../../helpers";
 import { withTempDir } from "../../helpers/temp";
+
+const auditEnabledConfig = makeNaxConfig({ agent: { promptAudit: { enabled: true } } });
 
 describe("Wave 2 exit criteria", () => {
   test("EC-1: createRuntime() produces a NaxRuntime with a UUID runId", () => {
@@ -41,7 +43,7 @@ describe("Wave 2 exit criteria", () => {
       };
 
       try {
-        const rt = createRuntime(DEFAULT_CONFIG, dir);
+        const rt = createRuntime(auditEnabledConfig, dir);
         rt.promptAuditor.record({
           ts: Date.now(),
           runId: rt.runId,
@@ -116,7 +118,7 @@ describe("Wave 2 exit criteria", () => {
       };
 
       try {
-        const rt = createRuntime(DEFAULT_CONFIG, dir);
+        const rt = createRuntime(auditEnabledConfig, dir);
         rt.promptAuditor.record({
           ts: Date.now(),
           runId: rt.runId,

--- a/test/unit/agents/acp/adapter-run.test.ts
+++ b/test/unit/agents/acp/adapter-run.test.ts
@@ -377,8 +377,8 @@ describe("run() — tokenUsage", () => {
     expect(result.tokenUsage).toBeDefined();
     expect(result.tokenUsage?.inputTokens).toBe(1000);
     expect(result.tokenUsage?.outputTokens).toBe(500);
-    expect((result.tokenUsage as Record<string, unknown>)["cache_read_input_tokens"]).toBe(100);
-    expect((result.tokenUsage as Record<string, unknown>)["cache_creation_input_tokens"]).toBe(50);
+    expect(result.tokenUsage?.cacheReadInputTokens).toBe(100);
+    expect(result.tokenUsage?.cacheCreationInputTokens).toBe(50);
   });
 
   test("omits cache fields from tokenUsage when both are 0", async () => {
@@ -401,8 +401,8 @@ describe("run() — tokenUsage", () => {
     expect(result.tokenUsage).toBeDefined();
     expect(result.tokenUsage?.inputTokens).toBe(1000);
     expect(result.tokenUsage?.outputTokens).toBe(500);
-    expect(Object.prototype.hasOwnProperty.call(result.tokenUsage, "cache_read_input_tokens")).toBe(false);
-    expect(Object.prototype.hasOwnProperty.call(result.tokenUsage, "cache_creation_input_tokens")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(result.tokenUsage, "cacheReadInputTokens")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(result.tokenUsage, "cacheCreationInputTokens")).toBe(false);
   });
 
   test("returns undefined tokenUsage when cumulative_token_usage is absent", async () => {
@@ -449,7 +449,7 @@ describe("run() — tokenUsage", () => {
     expect(turnCount).toBe(3);
     expect(result.tokenUsage?.inputTokens).toBe(300);
     expect(result.tokenUsage?.outputTokens).toBe(150);
-    expect((result.tokenUsage as Record<string, unknown>)["cache_read_input_tokens"]).toBe(30);
-    expect((result.tokenUsage as Record<string, unknown>)["cache_creation_input_tokens"]).toBe(15);
+    expect(result.tokenUsage?.cacheReadInputTokens).toBe(30);
+    expect(result.tokenUsage?.cacheCreationInputTokens).toBe(15);
   });
 });

--- a/test/unit/agents/acp/adapter-run.test.ts
+++ b/test/unit/agents/acp/adapter-run.test.ts
@@ -83,7 +83,7 @@ describe("run() — session flow", () => {
     expect(closeCalled).toBe(true);
   });
 
-  test("uses approve-all permission mode when permissionProfile is unrestricted", async () => {
+  test("uses approve-all permission mode when resolvedPermissions.mode is approve-all", async () => {
     let capturedMode = "";
     const session = makeSession();
     const client = makeClient(session, {
@@ -96,7 +96,7 @@ describe("run() — session flow", () => {
 
     await new AcpAgentAdapter("claude").run(
       makeRunOptions({
-        config: { execution: { permissionProfile: "unrestricted" } } as import("../../../../src/config").NaxConfig,
+        resolvedPermissions: { mode: "approve-all", skipPermissions: true },
       }),
     );
     expect(capturedMode).toBe("approve-all");

--- a/test/unit/agents/acp/adapter-session.test.ts
+++ b/test/unit/agents/acp/adapter-session.test.ts
@@ -241,7 +241,7 @@ describe("AcpAgentAdapter — session mode (run)", () => {
   // ─────────────────────────────────────────────────────────────────────────
 
   describe("permission mode", () => {
-    test("approve-all when permissionProfile is unrestricted", async () => {
+    test("approve-all when resolvedPermissions.mode is approve-all", async () => {
       let capturedMode = "";
       const session = makeSession();
       _acpAdapterDeps.createClient = mock((_cmd: string) =>
@@ -251,12 +251,12 @@ describe("AcpAgentAdapter — session mode (run)", () => {
       );
       await adapter.run({
         ...BASE_OPTIONS,
-        config: { execution: { permissionProfile: "unrestricted" } } as import("../../../../src/config").NaxConfig,
+        resolvedPermissions: { mode: "approve-all", skipPermissions: true },
       });
       expect(capturedMode).toBe("approve-all");
     });
 
-    test("approve-reads when permissionProfile is safe", async () => {
+    test("approve-reads when resolvedPermissions.mode is approve-reads", async () => {
       let capturedMode = "";
       const session = makeSession();
       _acpAdapterDeps.createClient = mock((_cmd: string) =>
@@ -266,7 +266,7 @@ describe("AcpAgentAdapter — session mode (run)", () => {
       );
       await adapter.run({
         ...BASE_OPTIONS,
-        config: { ...DEFAULT_CONFIG, execution: { ...DEFAULT_CONFIG.execution, permissionProfile: "safe" } } as import("../../../../src/config").NaxConfig,
+        resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
       });
       expect(capturedMode).toBe("approve-reads");
     });

--- a/test/unit/agents/manager.test.ts
+++ b/test/unit/agents/manager.test.ts
@@ -3,6 +3,7 @@ import { AgentManager } from "../../../src/agents/manager";
 import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import type { NaxConfig } from "../../../src/config";
 import { NaxConfigSchema } from "../../../src/config/schemas";
+import { MiddlewareChain, type AgentMiddleware, type MiddlewareContext } from "../../../src/runtime/agent-middleware";
 
 function makeManager(fallback: Record<string, unknown> = {}) {
   return new AgentManager({
@@ -180,5 +181,68 @@ describe("AgentManager.nextCandidate (Phase 4)", () => {
     const m = makeManager({ map: { claude: ["codex"] } });
     m.markUnavailable("codex", availFailure);
     expect(m.nextCandidate("claude", 0)).toBeNull();
+  });
+});
+
+describe("AgentManager — middleware envelope", () => {
+  function makeMiddlewareManager(mw?: AgentMiddleware): AgentManager {
+    return new AgentManager(DEFAULT_CONFIG, undefined, {
+      middleware: mw ? MiddlewareChain.from([mw]) : MiddlewareChain.empty(),
+      runId: "r-test",
+    });
+  }
+
+  test("run() delegates to runAs(getDefault(), request)", async () => {
+    const manager = makeMiddlewareManager();
+    let calledRunAs = false;
+    (manager as unknown as { runAs: typeof manager.runAs }).runAs = async (_name, _req) => {
+      calledRunAs = true;
+      return { success: false, exitCode: 1, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 };
+    };
+    try { await manager.run({ runOptions: { prompt: "test" } as never }); } catch {}
+    expect(calledRunAs).toBe(true);
+  });
+
+  test("complete() delegates to completeAs(getDefault(), prompt, options)", async () => {
+    const manager = makeMiddlewareManager();
+    let calledCompleteAs = false;
+    (manager as unknown as { completeAs: typeof manager.completeAs }).completeAs = async (_name, _prompt, _opts) => {
+      calledCompleteAs = true;
+      return { output: "", costUsd: 0, source: "fallback" as const };
+    };
+    try { await manager.complete("prompt", {} as never); } catch {}
+    expect(calledCompleteAs).toBe(true);
+  });
+
+  test("middleware before() is called before the adapter", async () => {
+    const calls: string[] = [];
+    const mw: AgentMiddleware = { name: "spy", before: async () => { calls.push("before"); } };
+    const manager = makeMiddlewareManager(mw);
+    try { await manager.runAs("claude", { runOptions: { prompt: "test", workdir: "/tmp" } as never }); } catch {}
+    expect(calls).toContain("before");
+  });
+
+  test("runAs() injects resolvedPermissions into request.runOptions", async () => {
+    let capturedPerms: Record<string, unknown> | undefined;
+    const mw: AgentMiddleware = {
+      name: "spy",
+      before: async (ctx: MiddlewareContext) => {
+        capturedPerms = ctx.resolvedPermissions as unknown as Record<string, unknown>;
+      },
+    };
+    const manager = makeMiddlewareManager(mw);
+    try { await manager.runAs("claude", { runOptions: { prompt: "test", workdir: "/tmp" } as never }); } catch {}
+    expect(capturedPerms).toBeDefined();
+    expect(typeof capturedPerms!["mode"]).toBe("string");
+  });
+
+  test("middleware onError() is called when adapter throws", async () => {
+    const errors: unknown[] = [];
+    const mw: AgentMiddleware = { name: "spy", onError: async (_ctx, err) => { errors.push(err); } };
+    const manager = makeMiddlewareManager(mw);
+    await expect(
+      manager.runAs("nonexistent-agent-xyz", { runOptions: { prompt: "test" } as never })
+    ).rejects.toThrow();
+    expect(errors.length).toBeGreaterThan(0);
   });
 });

--- a/test/unit/agents/manager.test.ts
+++ b/test/unit/agents/manager.test.ts
@@ -245,4 +245,51 @@ describe("AgentManager — middleware envelope", () => {
     ).rejects.toThrow();
     expect(errors.length).toBeGreaterThan(0);
   });
+
+  test("after() context reflects fallback agent name and prompt after agent swap", async () => {
+    const afterCalls: MiddlewareContext[] = [];
+    const mw: AgentMiddleware = {
+      name: "spy",
+      after: async (ctx) => { afterCalls.push(ctx); },
+    };
+    const config = NaxConfigSchema.parse({
+      agent: {
+        default: "claude",
+        fallback: { enabled: true, map: { claude: ["codex"] }, maxHopsPerStory: 2, onQualityFailure: false, rebuildContext: true },
+      },
+    }) as NaxConfig;
+    const manager = new AgentManager(config, undefined, {
+      middleware: MiddlewareChain.from([mw]),
+      runId: "r-fallback-test",
+    });
+
+    let callCount = 0;
+    await manager.runAs("claude", {
+      runOptions: { prompt: "original-prompt", workdir: "/tmp", modelTier: "fast", modelDef: { provider: "anthropic", model: "m", env: {} }, timeoutSeconds: 10, config } as never,
+      executeHop: async (_agentName, _bundle, _failure) => {
+        callCount += 1;
+        if (callCount === 1) {
+          // Primary hop — claude fails with availability failure; return a bundle so shouldSwap allows the swap
+          return {
+            result: {
+              success: false, exitCode: 1, output: "unavailable", rateLimited: false, durationMs: 10, estimatedCost: 0,
+              adapterFailure: { category: "availability" as const, outcome: "fail-auth" as const, retriable: false, message: "" },
+            },
+            bundle: { files: [] } as never,
+            prompt: "original-prompt",
+          };
+        }
+        // Fallback hop — codex succeeds
+        return {
+          result: { success: true, exitCode: 0, output: "fallback-done", rateLimited: false, durationMs: 20, estimatedCost: 0.001 },
+          bundle: undefined,
+          prompt: "swap-handoff-prompt",
+        };
+      },
+    });
+
+    expect(afterCalls).toHaveLength(1);
+    expect(afterCalls[0].agentName).toBe("codex");
+    expect(afterCalls[0].prompt).toBe("swap-handoff-prompt");
+  });
 });

--- a/test/unit/config/permissions.test.ts
+++ b/test/unit/config/permissions.test.ts
@@ -3,10 +3,9 @@
  *
  * Covers:
  * - resolvePermissions() for all 3 profiles × representative stages
- * - Backward compat: dangerouslySkipPermissions: true → same as permissionProfile: "unrestricted"
- * - Precedence: permissionProfile overrides dangerouslySkipPermissions
+ * - Default behaviour when no config / no permissionProfile is provided
  * - "scoped" profile returns safe defaults (Phase 2 stub)
- * - No local fallbacks remain in src/ (grep check)
+ * - No dangerouslySkipPermissions references remain in src/ (grep check)
  */
 
 import { describe, expect, test } from "bun:test";
@@ -30,7 +29,6 @@ function makeConfig(overrides: Partial<NaxConfig["execution"]> = {}): NaxConfig 
       regressionGate: { enabled: false, timeoutSeconds: 60, acceptOnTimeout: true, mode: "disabled", maxRectificationAttempts: 1 },
       contextProviderTokenBudget: 2000,
       verificationTimeoutSeconds: 300,
-      dangerouslySkipPermissions: false,
       ...overrides,
     },
   } as NaxConfig;
@@ -81,89 +79,31 @@ describe("resolvePermissions — scoped profile (Phase 2 stub)", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Backward compat: dangerouslySkipPermissions boolean
+// Default behaviour (no permissionProfile set)
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("resolvePermissions — backward compat (dangerouslySkipPermissions boolean)", () => {
-  test("dangerouslySkipPermissions: true → same as permissionProfile: unrestricted", () => {
-    const legacyConfig = makeConfig({ dangerouslySkipPermissions: true });
-    const profileConfig = makeConfig({ permissionProfile: "unrestricted" });
-
-    const legacyResult = resolvePermissions(legacyConfig, "run");
-    const profileResult = resolvePermissions(profileConfig, "run");
-
-    expect(legacyResult.mode).toBe(profileResult.mode);
-    expect(legacyResult.skipPermissions).toBe(profileResult.skipPermissions);
-    expect(legacyResult.mode).toBe("approve-all");
-    expect(legacyResult.skipPermissions).toBe(true);
-  });
-
-  test("dangerouslySkipPermissions: false → safe mode (approve-reads)", () => {
-    const config = makeConfig({ dangerouslySkipPermissions: false });
-    const result = resolvePermissions(config, "run");
-    expect(result.mode).toBe("approve-reads");
-    expect(result.skipPermissions).toBe(false);
-  });
-
-  test("no config → safe defaults", () => {
-    const result = resolvePermissions(undefined, "run");
-    expect(result.mode).toBe("approve-reads");
-    expect(result.skipPermissions).toBe(false);
-  });
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Precedence: permissionProfile overrides dangerouslySkipPermissions
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("resolvePermissions — precedence", () => {
-  test("permissionProfile=safe overrides dangerouslySkipPermissions=true", () => {
-    const config = makeConfig({
-      permissionProfile: "safe",
-      dangerouslySkipPermissions: true, // would be "unrestricted" without profile
-    });
-    const result = resolvePermissions(config, "run");
-    expect(result.mode).toBe("approve-reads");
-    expect(result.skipPermissions).toBe(false);
-  });
-
-  test("permissionProfile=unrestricted overrides dangerouslySkipPermissions=false", () => {
-    const config = makeConfig({
-      permissionProfile: "unrestricted",
-      dangerouslySkipPermissions: false, // would be "safe" without profile
-    });
+describe("resolvePermissions — default behaviour", () => {
+  test("no permissionProfile → unrestricted (approve-all)", () => {
+    const config = makeConfig();
     const result = resolvePermissions(config, "run");
     expect(result.mode).toBe("approve-all");
     expect(result.skipPermissions).toBe(true);
   });
 
-  test("permissionProfile=scoped overrides dangerouslySkipPermissions=true → still safe", () => {
-    const config = makeConfig({
-      permissionProfile: "scoped",
-      dangerouslySkipPermissions: true,
-    });
-    const result = resolvePermissions(config, "run");
-    // Phase 2 stub always returns safe defaults
-    expect(result.mode).toBe("approve-reads");
-    expect(result.skipPermissions).toBe(false);
+  test("no config → unrestricted (approve-all)", () => {
+    const result = resolvePermissions(undefined, "run");
+    expect(result.mode).toBe("approve-all");
+    expect(result.skipPermissions).toBe(true);
   });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Grep verify: no local permission fallbacks remain in src/
+// Grep verify: dangerouslySkipPermissions fully removed from src/
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("resolvePermissions — no local fallbacks in src/", () => {
-  test("no ?? true fallback for dangerouslySkipPermissions in src/", async () => {
-    const result = Bun.spawnSync(["grep", "-rn", "dangerouslySkipPermissions.*?? true", "src/"], {
-      cwd: new URL("../../../", import.meta.url).pathname,
-    });
-    const matches = result.stdout.toString().trim();
-    expect(matches).toBe("");
-  });
-
-  test("no ?? false fallback for dangerouslySkipPermissions in src/", async () => {
-    const result = Bun.spawnSync(["grep", "-rn", "dangerouslySkipPermissions.*?? false", "src/"], {
+describe("resolvePermissions — dangerouslySkipPermissions absent from src/", () => {
+  test("no dangerouslySkipPermissions references remain in src/", async () => {
+    const result = Bun.spawnSync(["grep", "-rn", "dangerouslySkipPermissions", "src/"], {
       cwd: new URL("../../../", import.meta.url).pathname,
     });
     const matches = result.stdout.toString().trim();

--- a/test/unit/metrics/save-run-metrics.test.ts
+++ b/test/unit/metrics/save-run-metrics.test.ts
@@ -2,9 +2,9 @@
  * saveRunMetrics / loadRunMetrics — US-003: Aggregate totalTokens
  *
  * AC-1: saveRunMetrics() computes totalTokens by iterating over runMetrics.stories
- * AC-2: totalTokens.input_tokens equals sum of all story.tokens.input_tokens
- * AC-3: totalTokens.cache_read_input_tokens equals sum (undefined → 0)
- * AC-4: totalTokens.cache_creation_input_tokens equals sum (undefined → 0)
+ * AC-2: totalTokens.inputTokens equals sum of all story.tokens.inputTokens
+ * AC-3: totalTokens.cacheReadInputTokens equals sum (undefined → 0)
+ * AC-4: totalTokens.cacheCreationInputTokens equals sum (undefined → 0)
  * AC-5: When no stories have tokens data, totalTokens is absent from written output
  * AC-6: loadRunMetrics() handles existing metrics.json without totalTokens field
  */
@@ -43,7 +43,7 @@ afterEach(async () => {
 });
 
 describe("saveRunMetrics - totalTokens aggregation", () => {
-  test("AC-1 & AC-2: computes totalTokens.input_tokens as sum of story tokens", async () => {
+  test("AC-1 & AC-2: computes totalTokens.inputTokens as sum of story tokens", async () => {
     const story1: StoryMetrics = {
       storyId: "US-001",
       complexity: "medium",
@@ -57,7 +57,7 @@ describe("saveRunMetrics - totalTokens aggregation", () => {
       firstPassSuccess: true,
       startedAt: new Date().toISOString(),
       completedAt: new Date().toISOString(),
-      tokens: new TokenUsage({ input_tokens: 1000, output_tokens: 500 }),
+      tokens: new TokenUsage({ inputTokens: 1000, outputTokens: 500 }),
     };
 
     const story2: StoryMetrics = {
@@ -73,7 +73,7 @@ describe("saveRunMetrics - totalTokens aggregation", () => {
       firstPassSuccess: true,
       startedAt: new Date().toISOString(),
       completedAt: new Date().toISOString(),
-      tokens: new TokenUsage({ input_tokens: 2000, output_tokens: 800 }),
+      tokens: new TokenUsage({ inputTokens: 2000, outputTokens: 800 }),
     };
 
     const runMetrics: RunMetrics = {
@@ -94,11 +94,11 @@ describe("saveRunMetrics - totalTokens aggregation", () => {
     const saved = await readMetricsFile();
     expect(saved).toHaveLength(1);
     expect(saved[0].totalTokens).toBeDefined();
-    expect(saved[0].totalTokens?.input_tokens).toBe(3000);
-    expect(saved[0].totalTokens?.output_tokens).toBe(1300);
+    expect(saved[0].totalTokens?.inputTokens).toBe(3000);
+    expect(saved[0].totalTokens?.outputTokens).toBe(1300);
   });
 
-  test("AC-3: totalTokens.cache_read_input_tokens sums undefined as 0", async () => {
+  test("AC-3: totalTokens.cacheReadInputTokens sums undefined as 0", async () => {
     const story1: StoryMetrics = {
       storyId: "US-001",
       complexity: "medium",
@@ -113,9 +113,9 @@ describe("saveRunMetrics - totalTokens aggregation", () => {
       startedAt: new Date().toISOString(),
       completedAt: new Date().toISOString(),
       tokens: new TokenUsage({
-        input_tokens: 1000,
-        output_tokens: 500,
-        cache_read_input_tokens: 100,
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadInputTokens: 100,
       }),
     };
 
@@ -133,9 +133,9 @@ describe("saveRunMetrics - totalTokens aggregation", () => {
       startedAt: new Date().toISOString(),
       completedAt: new Date().toISOString(),
       tokens: new TokenUsage({
-        input_tokens: 2000,
-        output_tokens: 800,
-        cache_creation_input_tokens: 50,
+        inputTokens: 2000,
+        outputTokens: 800,
+        cacheCreationInputTokens: 50,
       }),
     };
 
@@ -157,8 +157,8 @@ describe("saveRunMetrics - totalTokens aggregation", () => {
     const saved = await readMetricsFile();
     expect(saved).toHaveLength(1);
     expect(saved[0].totalTokens).toBeDefined();
-    expect(saved[0].totalTokens?.cache_read_input_tokens).toBe(100);
-    expect(saved[0].totalTokens?.cache_creation_input_tokens).toBe(50);
+    expect(saved[0].totalTokens?.cacheReadInputTokens).toBe(100);
+    expect(saved[0].totalTokens?.cacheCreationInputTokens).toBe(50);
   });
 
   test("AC-5: when no stories have tokens data, totalTokens is absent", async () => {
@@ -175,7 +175,7 @@ describe("saveRunMetrics - totalTokens aggregation", () => {
       firstPassSuccess: true,
       startedAt: new Date().toISOString(),
       completedAt: new Date().toISOString(),
-      tokens: new TokenUsage({ input_tokens: 0, output_tokens: 0 }),
+      tokens: new TokenUsage({ inputTokens: 0, outputTokens: 0 }),
     };
 
     const story2: StoryMetrics = {

--- a/test/unit/metrics/tracker.test.ts
+++ b/test/unit/metrics/tracker.test.ts
@@ -248,8 +248,8 @@ describe("collectStoryMetrics - tokenUsage field", () => {
     const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.tokens).toBeDefined();
-    expect(metrics.tokens?.input_tokens).toBe(1000);
-    expect(metrics.tokens?.output_tokens).toBe(500);
+    expect(metrics.tokens?.inputTokens).toBe(1000);
+    expect(metrics.tokens?.outputTokens).toBe(500);
   });
 
   test("sets storyMetrics.tokens with cache fields when present in tokenUsage", async () => {
@@ -265,18 +265,18 @@ describe("collectStoryMetrics - tokenUsage field", () => {
       tokenUsage: {
         inputTokens: 1000,
         outputTokens: 500,
-        cache_read_input_tokens: 100,
-        cache_creation_input_tokens: 50,
-      } as unknown as { inputTokens: number; outputTokens: number },
+        cacheReadInputTokens: 100,
+        cacheCreationInputTokens: 50,
+      },
     };
 
     const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
 
     expect(metrics.tokens).toBeDefined();
-    expect(metrics.tokens?.input_tokens).toBe(1000);
-    expect(metrics.tokens?.output_tokens).toBe(500);
-    expect(metrics.tokens?.cache_read_input_tokens).toBe(100);
-    expect(metrics.tokens?.cache_creation_input_tokens).toBe(50);
+    expect(metrics.tokens?.inputTokens).toBe(1000);
+    expect(metrics.tokens?.outputTokens).toBe(500);
+    expect(metrics.tokens?.cacheReadInputTokens).toBe(100);
+    expect(metrics.tokens?.cacheCreationInputTokens).toBe(50);
   });
 
   test("storyMetrics.tokens is undefined when ctx.agentResult.tokenUsage is undefined", async () => {

--- a/test/unit/metrics/types.test.ts
+++ b/test/unit/metrics/types.test.ts
@@ -1,7 +1,7 @@
 /**
  * TokenUsage and Metrics Extensions — US-001
  *
- * AC-1: TokenUsage interface with input_tokens, output_tokens, cache_read_input_tokens?, cache_creation_input_tokens?
+ * AC-1: TokenUsage class with inputTokens, outputTokens, cacheReadInputTokens?, cacheCreationInputTokens?
  * AC-2: StoryMetrics has optional tokens?: TokenUsage
  * AC-3: RunMetrics has optional totalTokens?: TokenUsage
  * AC-4: TokenUsage re-exported from src/metrics/index.ts barrel
@@ -9,63 +9,45 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import type { RunMetrics, StoryMetrics, TokenUsage } from "../../../src/metrics/types";
+import { TokenUsage } from "../../../src/metrics/types";
+import type { RunMetrics, StoryMetrics } from "../../../src/metrics/types";
 
 // ---------------------------------------------------------------------------
-// AC-1: TokenUsage interface structure
+// AC-1: TokenUsage class structure
 // ---------------------------------------------------------------------------
 
-describe("TokenUsage interface", () => {
-  test("has required input_tokens and output_tokens fields", () => {
-    const usage: TokenUsage = {
-      input_tokens: 1000,
-      output_tokens: 500,
-    };
+describe("TokenUsage class", () => {
+  test("has required inputTokens and outputTokens fields", () => {
+    const usage = new TokenUsage({ inputTokens: 1000, outputTokens: 500 });
 
-    expect(usage.input_tokens).toBe(1000);
-    expect(usage.output_tokens).toBe(500);
+    expect(usage.inputTokens).toBe(1000);
+    expect(usage.outputTokens).toBe(500);
   });
 
-  test("has optional cache_read_input_tokens field", () => {
-    const usage: TokenUsage = {
-      input_tokens: 1000,
-      output_tokens: 500,
-      cache_read_input_tokens: 300,
-    };
+  test("has optional cacheReadInputTokens field", () => {
+    const usage = new TokenUsage({ inputTokens: 1000, outputTokens: 500, cacheReadInputTokens: 300 });
 
-    expect(usage.cache_read_input_tokens).toBe(300);
+    expect(usage.cacheReadInputTokens).toBe(300);
   });
 
-  test("has optional cache_creation_input_tokens field", () => {
-    const usage: TokenUsage = {
-      input_tokens: 1000,
-      output_tokens: 500,
-      cache_creation_input_tokens: 150,
-    };
+  test("has optional cacheCreationInputTokens field", () => {
+    const usage = new TokenUsage({ inputTokens: 1000, outputTokens: 500, cacheCreationInputTokens: 150 });
 
-    expect(usage.cache_creation_input_tokens).toBe(150);
+    expect(usage.cacheCreationInputTokens).toBe(150);
   });
 
   test("cache fields are optional and may be omitted", () => {
-    const usage: TokenUsage = {
-      input_tokens: 1000,
-      output_tokens: 500,
-    };
+    const usage = new TokenUsage({ inputTokens: 1000, outputTokens: 500 });
 
-    expect(usage.cache_read_input_tokens).toBeUndefined();
-    expect(usage.cache_creation_input_tokens).toBeUndefined();
+    expect(usage.cacheReadInputTokens).toBeUndefined();
+    expect(usage.cacheCreationInputTokens).toBeUndefined();
   });
 
   test("cache fields can be set to numbers including 0", () => {
-    const usage: TokenUsage = {
-      input_tokens: 1000,
-      output_tokens: 500,
-      cache_read_input_tokens: 0,
-      cache_creation_input_tokens: 0,
-    };
+    const usage = new TokenUsage({ inputTokens: 1000, outputTokens: 500, cacheReadInputTokens: 0, cacheCreationInputTokens: 0 });
 
-    expect(usage.cache_read_input_tokens).toBe(0);
-    expect(usage.cache_creation_input_tokens).toBe(0);
+    expect(usage.cacheReadInputTokens).toBe(0);
+    expect(usage.cacheCreationInputTokens).toBe(0);
   });
 });
 
@@ -107,17 +89,13 @@ describe("StoryMetrics - tokens field", () => {
       firstPassSuccess: true,
       startedAt: new Date().toISOString(),
       completedAt: new Date().toISOString(),
-      tokens: {
-        input_tokens: 2000,
-        output_tokens: 1000,
-        cache_read_input_tokens: 500,
-      },
+      tokens: new TokenUsage({ inputTokens: 2000, outputTokens: 1000, cacheReadInputTokens: 500 }),
     };
 
     expect(metrics.tokens).toBeDefined();
-    expect(metrics.tokens?.input_tokens).toBe(2000);
-    expect(metrics.tokens?.output_tokens).toBe(1000);
-    expect(metrics.tokens?.cache_read_input_tokens).toBe(500);
+    expect(metrics.tokens?.inputTokens).toBe(2000);
+    expect(metrics.tokens?.outputTokens).toBe(1000);
+    expect(metrics.tokens?.cacheReadInputTokens).toBe(500);
   });
 });
 
@@ -155,16 +133,12 @@ describe("RunMetrics - totalTokens field", () => {
       storiesFailed: 1,
       totalDurationMs: 30000,
       stories: [],
-      totalTokens: {
-        input_tokens: 5000,
-        output_tokens: 2500,
-        cache_creation_input_tokens: 1000,
-      },
+      totalTokens: new TokenUsage({ inputTokens: 5000, outputTokens: 2500, cacheCreationInputTokens: 1000 }),
     };
 
     expect(metrics.totalTokens).toBeDefined();
-    expect(metrics.totalTokens?.input_tokens).toBe(5000);
-    expect(metrics.totalTokens?.output_tokens).toBe(2500);
-    expect(metrics.totalTokens?.cache_creation_input_tokens).toBe(1000);
+    expect(metrics.totalTokens?.inputTokens).toBe(5000);
+    expect(metrics.totalTokens?.outputTokens).toBe(2500);
+    expect(metrics.totalTokens?.cacheCreationInputTokens).toBe(1000);
   });
 });

--- a/test/unit/pipeline/stages/execution-agent-swap-metrics.test.ts
+++ b/test/unit/pipeline/stages/execution-agent-swap-metrics.test.ts
@@ -72,7 +72,7 @@ function makeAgentManager(outcome: Partial<AgentRunOutcome> = {}): IAgentManager
     nextCandidate: () => null,
     runWithFallback: async (req: AgentRunRequest): Promise<AgentRunOutcome> => {
       if (req.executeHop) {
-        const { result, bundle, prompt } = await req.executeHop("claude", req.bundle, undefined);
+        const { result, bundle, prompt } = await req.executeHop("claude", req.bundle, undefined, req.runOptions);
         return { result, fallbacks: outcome.fallbacks ?? [], finalBundle: bundle, finalPrompt: prompt };
       }
       return {
@@ -322,7 +322,7 @@ describe("execution stage — AC-41 fallback observability", () => {
     manager.runWithFallback = async (req: AgentRunRequest): Promise<AgentRunOutcome> => {
       if (req.executeHop) {
         const failure = { category: "availability" as const, outcome: "fail-quota" as const, message: "quota", retriable: false };
-        const { result, bundle, prompt } = await req.executeHop("codex", req.bundle, failure);
+        const { result, bundle, prompt } = await req.executeHop("codex", req.bundle, failure, req.runOptions);
         return { result, fallbacks: swapFallbacks, finalBundle: bundle, finalPrompt: prompt };
       }
       return { result: { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 0, estimatedCost: 0 }, fallbacks: [] };

--- a/test/unit/pipeline/stages/execution-manager-wiring.test.ts
+++ b/test/unit/pipeline/stages/execution-manager-wiring.test.ts
@@ -67,7 +67,7 @@ describe("execution stage — uses agentManager.runWithFallback", () => {
       nextCandidate: () => null,
       runWithFallback: mock(async (request) => {
         runWithFallbackCalled = true;
-        const { result, bundle: b, prompt } = await request.executeHop!("claude", request.bundle, undefined);
+        const { result, bundle: b, prompt } = await request.executeHop!("claude", request.bundle, undefined, request.runOptions);
         return { result, fallbacks: [], finalBundle: b, finalPrompt: prompt };
       }),
       completeWithFallback: async () => ({ result: { output: "", costUsd: 0, source: "fallback" as const }, fallbacks: [] }),

--- a/test/unit/runtime/agent-middleware.test.ts
+++ b/test/unit/runtime/agent-middleware.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from "bun:test";
+import { MiddlewareChain, type AgentMiddleware, type MiddlewareContext } from "../../../src/runtime/agent-middleware";
+import { DEFAULT_CONFIG } from "../../../src/config";
+
+function makeCtx(overrides: Partial<MiddlewareContext> = {}): MiddlewareContext {
+  return {
+    runId: "r-001",
+    agentName: "claude",
+    kind: "run",
+    request: null,
+    prompt: null,
+    config: DEFAULT_CONFIG,
+    resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+    ...overrides,
+  };
+}
+
+describe("MiddlewareChain", () => {
+  test("empty() — runBefore is a no-op", async () => {
+    await expect(MiddlewareChain.empty().runBefore(makeCtx())).resolves.toBeUndefined();
+  });
+
+  test("calls before hooks in order", async () => {
+    const calls: string[] = [];
+    const a: AgentMiddleware = { name: "a", before: async () => { calls.push("a"); } };
+    const b: AgentMiddleware = { name: "b", before: async () => { calls.push("b"); } };
+    await MiddlewareChain.from([a, b]).runBefore(makeCtx());
+    expect(calls).toEqual(["a", "b"]);
+  });
+
+  test("calls after hooks in order with result + durationMs", async () => {
+    const calls: Array<[string, unknown, number]> = [];
+    const a: AgentMiddleware = { name: "a", after: async (_, r, d) => { calls.push(["a", r, d]); } };
+    const b: AgentMiddleware = { name: "b", after: async (_, r, d) => { calls.push(["b", r, d]); } };
+    await MiddlewareChain.from([a, b]).runAfter(makeCtx(), { success: true }, 42);
+    expect(calls).toEqual([["a", { success: true }, 42], ["b", { success: true }, 42]]);
+  });
+
+  test("calls onError hooks in order with err + durationMs", async () => {
+    const calls: string[] = [];
+    const err = new Error("boom");
+    const a: AgentMiddleware = { name: "a", onError: async (_, e) => { calls.push(String(e)); } };
+    await MiddlewareChain.from([a]).runOnError(makeCtx(), err, 10);
+    expect(calls).toEqual(["Error: boom"]);
+  });
+
+  test("skips middleware with no hook for the phase", async () => {
+    const mw: AgentMiddleware = { name: "noop" };
+    await expect(MiddlewareChain.from([mw]).runBefore(makeCtx())).resolves.toBeUndefined();
+    await expect(MiddlewareChain.from([mw]).runAfter(makeCtx(), null, 0)).resolves.toBeUndefined();
+    await expect(MiddlewareChain.from([mw]).runOnError(makeCtx(), new Error(), 0)).resolves.toBeUndefined();
+  });
+
+  test("passes MiddlewareContext through to each hook", async () => {
+    const seen: string[] = [];
+    const mw: AgentMiddleware = { name: "spy", before: async (ctx) => { seen.push(ctx.agentName); } };
+    await MiddlewareChain.from([mw]).runBefore(makeCtx({ agentName: "codex" }));
+    expect(seen).toEqual(["codex"]);
+  });
+});

--- a/test/unit/runtime/cost-aggregator.test.ts
+++ b/test/unit/runtime/cost-aggregator.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect } from "bun:test";
+import { CostAggregator, _costAggDeps, type CostEvent } from "../../../src/runtime/cost-aggregator";
+import { withTempDir } from "../../helpers/temp";
+import { join } from "node:path";
+
+function makeEvent(overrides: Partial<CostEvent> = {}): CostEvent {
+  return {
+    ts: Date.now(),
+    runId: "r-001",
+    agentName: "claude",
+    model: "claude-sonnet-4-6",
+    tokens: { input: 100, output: 50 },
+    costUsd: 0.001,
+    durationMs: 500,
+    ...overrides,
+  };
+}
+
+describe("CostAggregator", () => {
+  test("snapshot() returns zero totals when no events recorded", () => {
+    const agg = new CostAggregator("r-001", "/tmp/drain");
+    const snap = agg.snapshot();
+    expect(snap.callCount).toBe(0);
+    expect(snap.totalCostUsd).toBe(0);
+    expect(snap.errorCount).toBe(0);
+  });
+
+  test("snapshot() accumulates recorded events", () => {
+    const agg = new CostAggregator("r-001", "/tmp/drain");
+    agg.record(makeEvent({ costUsd: 0.001, tokens: { input: 100, output: 50 } }));
+    agg.record(makeEvent({ costUsd: 0.002, tokens: { input: 200, output: 80 } }));
+    const snap = agg.snapshot();
+    expect(snap.callCount).toBe(2);
+    expect(snap.totalCostUsd).toBeCloseTo(0.003);
+    expect(snap.totalInputTokens).toBe(300);
+    expect(snap.totalOutputTokens).toBe(130);
+  });
+
+  test("snapshot() counts errors separately", () => {
+    const agg = new CostAggregator("r-001", "/tmp/drain");
+    agg.record(makeEvent());
+    agg.recordError({ ts: Date.now(), runId: "r-001", agentName: "claude", errorCode: "TIMEOUT", durationMs: 100 });
+    const snap = agg.snapshot();
+    expect(snap.callCount).toBe(1);
+    expect(snap.errorCount).toBe(1);
+  });
+
+  test("byAgent() groups events by agentName", () => {
+    const agg = new CostAggregator("r-001", "/tmp/drain");
+    agg.record(makeEvent({ agentName: "claude", costUsd: 0.001 }));
+    agg.record(makeEvent({ agentName: "claude", costUsd: 0.002 }));
+    agg.record(makeEvent({ agentName: "codex", costUsd: 0.005 }));
+    const by = agg.byAgent();
+    expect(by["claude"].callCount).toBe(2);
+    expect(by["claude"].totalCostUsd).toBeCloseTo(0.003);
+    expect(by["codex"].callCount).toBe(1);
+    expect(by["codex"].totalCostUsd).toBeCloseTo(0.005);
+  });
+
+  test("byStage() groups events by stage", () => {
+    const agg = new CostAggregator("r-001", "/tmp/drain");
+    agg.record(makeEvent({ stage: "run", costUsd: 0.01 }));
+    agg.record(makeEvent({ stage: "verify", costUsd: 0.02 }));
+    agg.record(makeEvent({ stage: undefined }));
+    const by = agg.byStage();
+    expect(by["run"].callCount).toBe(1);
+    expect(by["verify"].callCount).toBe(1);
+    expect(by["unknown"].callCount).toBe(1);
+  });
+
+  test("byStory() groups events by storyId", () => {
+    const agg = new CostAggregator("r-001", "/tmp/drain");
+    agg.record(makeEvent({ storyId: "s-1", costUsd: 0.01 }));
+    agg.record(makeEvent({ storyId: "s-1", costUsd: 0.02 }));
+    agg.record(makeEvent({ storyId: "s-2", costUsd: 0.05 }));
+    const by = agg.byStory();
+    expect(by["s-1"].callCount).toBe(2);
+    expect(by["s-2"].callCount).toBe(1);
+  });
+
+  test("drain() does nothing when no events", async () => {
+    const writes: string[] = [];
+    const origWrite = _costAggDeps.write;
+    _costAggDeps.write = async (p) => { writes.push(p); return 0; };
+    const agg = new CostAggregator("r-001", "/tmp/drain");
+    await agg.drain();
+    expect(writes).toHaveLength(0);
+    _costAggDeps.write = origWrite;
+  });
+
+  test("drain() writes JSONL file with all events sorted by ts", async () => {
+    await withTempDir(async (dir) => {
+      const drainDir = join(dir, "cost");
+      let captured = "";
+      const origWrite = _costAggDeps.write;
+      _costAggDeps.write = async (_p, data) => { captured = String(data); return 0; };
+      const agg = new CostAggregator("r-test", drainDir);
+      agg.record(makeEvent({ ts: 2000 }));
+      agg.record(makeEvent({ ts: 1000 }));
+      await agg.drain();
+      const lines = captured.trim().split("\n");
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]).ts).toBe(1000);
+      expect(JSON.parse(lines[1]).ts).toBe(2000);
+      _costAggDeps.write = origWrite;
+    });
+  });
+
+  test("drain() writes to <drainDir>/<runId>.jsonl", async () => {
+    await withTempDir(async (dir) => {
+      const drainDir = join(dir, "cost");
+      let capturedPath = "";
+      const origWrite = _costAggDeps.write;
+      _costAggDeps.write = async (p, _d) => { capturedPath = p; return 0; };
+      const agg = new CostAggregator("my-run-id", drainDir);
+      agg.record(makeEvent());
+      await agg.drain();
+      expect(capturedPath).toBe(join(drainDir, "my-run-id.jsonl"));
+      _costAggDeps.write = origWrite;
+    });
+  });
+});

--- a/test/unit/runtime/middleware/audit.test.ts
+++ b/test/unit/runtime/middleware/audit.test.ts
@@ -1,7 +1,12 @@
 import { describe, test, expect } from "bun:test";
 import { auditMiddleware } from "../../../../src/runtime/middleware/audit";
-import { createNoOpPromptAuditor, type PromptAuditEntry } from "../../../../src/runtime/prompt-auditor";
+import {
+  createNoOpPromptAuditor,
+  type PromptAuditEntry,
+  type PromptAuditErrorEntry,
+} from "../../../../src/runtime/prompt-auditor";
 import { DEFAULT_CONFIG } from "../../../../src/config";
+import { NaxError } from "../../../../src/errors";
 import type { MiddlewareContext } from "../../../../src/runtime/agent-middleware";
 
 function makeCtx(kind: "run" | "complete" = "complete"): MiddlewareContext {
@@ -91,5 +96,47 @@ describe("auditMiddleware", () => {
     expect(errors).toHaveLength(1);
     expect((errors[0] as Record<string, unknown>).agentName).toBe("claude");
     expect((errors[0] as Record<string, unknown>).durationMs).toBe(80);
+  });
+
+  test("onError() captures prompt, callType, workdir, featureName, and NaxError code", async () => {
+    const errors: PromptAuditErrorEntry[] = [];
+    const aud = { ...createNoOpPromptAuditor(), recordError: (e: PromptAuditErrorEntry) => errors.push(e) };
+    const mw = auditMiddleware(aud, "r-001");
+    const ctx: MiddlewareContext = {
+      runId: "r-001",
+      agentName: "claude",
+      kind: "run",
+      request: {
+        runOptions: { prompt: "implement feature", workdir: "/tmp/w", projectDir: "/tmp/p", featureName: "feat-x" } as never,
+      },
+      prompt: null,
+      config: DEFAULT_CONFIG,
+      resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+      storyId: "s-1",
+      stage: "run",
+    };
+    const err = new NaxError("session lost", "SESSION_ERROR", { stage: "run" });
+    await mw.onError!(ctx, err, 42);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].callType).toBe("run");
+    expect(errors[0].prompt).toBe("implement feature");
+    expect(errors[0].workdir).toBe("/tmp/w");
+    expect(errors[0].projectDir).toBe("/tmp/p");
+    expect(errors[0].featureName).toBe("feat-x");
+    expect(errors[0].permissionProfile).toBe("approve-reads");
+    expect(errors[0].errorCode).toBe("SESSION_ERROR");
+    expect(errors[0].errorMessage).toBe("session lost");
+  });
+
+  test("onError() captures prompt for complete-kind calls from ctx.prompt", async () => {
+    const errors: PromptAuditErrorEntry[] = [];
+    const aud = { ...createNoOpPromptAuditor(), recordError: (e: PromptAuditErrorEntry) => errors.push(e) };
+    const mw = auditMiddleware(aud, "r-001");
+    await mw.onError!(makeCtx("complete"), new Error("boom"), 10);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].callType).toBe("complete");
+    expect(errors[0].prompt).toBe("Do the thing");
+    expect(errors[0].errorCode).toBe("UNKNOWN");
+    expect(errors[0].errorMessage).toBe("boom");
   });
 });

--- a/test/unit/runtime/middleware/audit.test.ts
+++ b/test/unit/runtime/middleware/audit.test.ts
@@ -27,6 +27,52 @@ describe("auditMiddleware", () => {
     expect(recorded[0].durationMs).toBe(150);
   });
 
+  test("after() records callType, workdir, featureName from runOptions", async () => {
+    const recorded: PromptAuditEntry[] = [];
+    const aud = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };
+    const mw = auditMiddleware(aud, "r-001");
+    const ctx: MiddlewareContext = {
+      runId: "r-001", agentName: "claude", kind: "run",
+      request: { runOptions: { prompt: "hello", workdir: "/tmp/w", projectDir: "/tmp/p", featureName: "feat-x" } as never },
+      prompt: null,
+      config: DEFAULT_CONFIG,
+      resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+      storyId: "s-1", stage: "run",
+    };
+    await mw.after!(ctx, { output: "ok" }, 100);
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].callType).toBe("run");
+    expect(recorded[0].workdir).toBe("/tmp/w");
+    expect(recorded[0].projectDir).toBe("/tmp/p");
+    expect(recorded[0].featureName).toBe("feat-x");
+  });
+
+  test("after() records ACP session correlation from AgentResult", async () => {
+    const recorded: PromptAuditEntry[] = [];
+    const aud = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };
+    const mw = auditMiddleware(aud, "r-001");
+    const ctx: MiddlewareContext = {
+      runId: "r-001", agentName: "claude", kind: "run",
+      request: { runOptions: { prompt: "p", workdir: "/tmp" } as never },
+      prompt: null,
+      config: DEFAULT_CONFIG,
+      resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+      storyId: "s-1", stage: "run",
+    };
+    const result = {
+      success: true, output: "done",
+      protocolIds: { recordId: "rec-1", sessionId: "sess-1" },
+      sessionMetadata: { sessionName: "nax-abc-feat-x", turn: 3, resumed: true },
+    };
+    await mw.after!(ctx, result, 200);
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].sessionName).toBe("nax-abc-feat-x");
+    expect(recorded[0].recordId).toBe("rec-1");
+    expect(recorded[0].sessionId).toBe("sess-1");
+    expect(recorded[0].turn).toBe(3);
+    expect(recorded[0].resumed).toBe(true);
+  });
+
   test("after() is a no-op when prompt and request are both null", async () => {
     const recorded: PromptAuditEntry[] = [];
     const aud = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };

--- a/test/unit/runtime/middleware/audit.test.ts
+++ b/test/unit/runtime/middleware/audit.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "bun:test";
+import { auditMiddleware } from "../../../../src/runtime/middleware/audit";
+import { createNoOpPromptAuditor, type PromptAuditEntry } from "../../../../src/runtime/prompt-auditor";
+import { DEFAULT_CONFIG } from "../../../../src/config";
+import type { MiddlewareContext } from "../../../../src/runtime/agent-middleware";
+
+function makeCtx(kind: "run" | "complete" = "complete"): MiddlewareContext {
+  return {
+    runId: "r-001", agentName: "claude", kind,
+    request: null, prompt: kind === "complete" ? "Do the thing" : null,
+    config: DEFAULT_CONFIG,
+    resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+    storyId: "s-1", stage: "run",
+  };
+}
+
+describe("auditMiddleware", () => {
+  test("after() records PromptAuditEntry for complete calls", async () => {
+    const recorded: PromptAuditEntry[] = [];
+    const aud = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };
+    const mw = auditMiddleware(aud, "r-001");
+    await mw.after!(makeCtx("complete"), { output: "Done" }, 150);
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].prompt).toBe("Do the thing");
+    expect(recorded[0].response).toBe("Done");
+    expect(recorded[0].permissionProfile).toBe("approve-reads");
+    expect(recorded[0].durationMs).toBe(150);
+  });
+
+  test("after() is a no-op when prompt and request are both null", async () => {
+    const recorded: PromptAuditEntry[] = [];
+    const aud = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };
+    const mw = auditMiddleware(aud, "r-001");
+    const ctx = makeCtx("run");
+    // request is null and prompt is null — no audit data
+    await mw.after!(ctx, { output: "" }, 10);
+    expect(recorded).toHaveLength(0);
+  });
+
+  test("onError() records PromptAuditErrorEntry", async () => {
+    const errors: unknown[] = [];
+    const aud = { ...createNoOpPromptAuditor(), recordError: (e: unknown) => errors.push(e) };
+    const mw = auditMiddleware(aud, "r-001");
+    await mw.onError!(makeCtx(), new Error("fail"), 80);
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Record<string, unknown>).agentName).toBe("claude");
+    expect((errors[0] as Record<string, unknown>).durationMs).toBe(80);
+  });
+});

--- a/test/unit/runtime/middleware/cancellation.test.ts
+++ b/test/unit/runtime/middleware/cancellation.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from "bun:test";
+import { cancellationMiddleware } from "../../../../src/runtime/middleware/cancellation";
+import { DEFAULT_CONFIG } from "../../../../src/config";
+import type { MiddlewareContext } from "../../../../src/runtime/agent-middleware";
+
+function makeCtx(aborted = false): MiddlewareContext {
+  const ctrl = new AbortController();
+  if (aborted) ctrl.abort();
+  return {
+    runId: "r-001", agentName: "claude", kind: "run",
+    request: null, prompt: null, config: DEFAULT_CONFIG,
+    signal: ctrl.signal,
+    resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+  };
+}
+
+describe("cancellationMiddleware", () => {
+  test("before() passes through when signal is not aborted", async () => {
+    const mw = cancellationMiddleware();
+    await expect(mw.before!(makeCtx(false))).resolves.toBeUndefined();
+  });
+
+  test("before() throws NaxError when signal is already aborted", async () => {
+    const mw = cancellationMiddleware();
+    await expect(mw.before!(makeCtx(true))).rejects.toThrow("Agent call cancelled");
+  });
+
+  test("before() passes through when signal is undefined", async () => {
+    const mw = cancellationMiddleware();
+    const ctx: MiddlewareContext = {
+      runId: "r-001", agentName: "claude", kind: "run",
+      request: null, prompt: null, config: DEFAULT_CONFIG,
+      resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+    };
+    await expect(mw.before!(ctx)).resolves.toBeUndefined();
+  });
+});

--- a/test/unit/runtime/middleware/cost.test.ts
+++ b/test/unit/runtime/middleware/cost.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from "bun:test";
+import { costMiddleware } from "../../../../src/runtime/middleware/cost";
+import { createNoOpCostAggregator, type CostEvent } from "../../../../src/runtime/cost-aggregator";
+import { DEFAULT_CONFIG } from "../../../../src/config";
+import type { MiddlewareContext } from "../../../../src/runtime/agent-middleware";
+
+function makeCtx(): MiddlewareContext {
+  return {
+    runId: "r-001", agentName: "claude", kind: "run",
+    request: null, prompt: null, config: DEFAULT_CONFIG,
+    resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+    storyId: "s-1", stage: "run",
+  };
+}
+
+describe("costMiddleware", () => {
+  test("after() records CostEvent when result has tokenUsage", async () => {
+    const recorded: CostEvent[] = [];
+    const agg = { ...createNoOpCostAggregator(), record: (e: CostEvent) => recorded.push(e) };
+    const mw = costMiddleware(agg, "r-001");
+    const result = {
+      success: true, estimatedCost: 0.005,
+      tokenUsage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 10, cache_creation_input_tokens: 5 },
+    };
+    await mw.after!(makeCtx(), result, 200);
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].costUsd).toBe(0.005);
+    expect(recorded[0].tokens.input).toBe(100);
+    expect(recorded[0].tokens.cacheRead).toBe(10);
+    expect(recorded[0].durationMs).toBe(200);
+    expect(recorded[0].storyId).toBe("s-1");
+    expect(recorded[0].stage).toBe("run");
+  });
+
+  test("after() is a no-op when result has no tokenUsage", async () => {
+    const recorded: CostEvent[] = [];
+    const agg = { ...createNoOpCostAggregator(), record: (e: CostEvent) => recorded.push(e) };
+    const mw = costMiddleware(agg, "r-001");
+    await mw.after!(makeCtx(), { success: true }, 100);
+    expect(recorded).toHaveLength(0);
+  });
+
+  test("onError() records CostErrorEvent", async () => {
+    const errors: unknown[] = [];
+    const agg = { ...createNoOpCostAggregator(), recordError: (e: unknown) => errors.push(e) };
+    const mw = costMiddleware(agg, "r-001");
+    await mw.onError!(makeCtx(), new Error("boom"), 50);
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Record<string, unknown>).durationMs).toBe(50);
+    expect((errors[0] as Record<string, unknown>).agentName).toBe("claude");
+  });
+});

--- a/test/unit/runtime/middleware/cost.test.ts
+++ b/test/unit/runtime/middleware/cost.test.ts
@@ -20,7 +20,7 @@ describe("costMiddleware", () => {
     const mw = costMiddleware(agg, "r-001");
     const result = {
       success: true, estimatedCost: 0.005,
-      tokenUsage: { inputTokens: 100, outputTokens: 50, cache_read_input_tokens: 10, cache_creation_input_tokens: 5 },
+      tokenUsage: { inputTokens: 100, outputTokens: 50, cacheReadInputTokens: 10, cacheCreationInputTokens: 5 },
     };
     await mw.after!(makeCtx(), result, 200);
     expect(recorded).toHaveLength(1);

--- a/test/unit/runtime/middleware/cost.test.ts
+++ b/test/unit/runtime/middleware/cost.test.ts
@@ -14,25 +14,40 @@ function makeCtx(): MiddlewareContext {
 }
 
 describe("costMiddleware", () => {
-  test("after() records CostEvent when result has tokenUsage", async () => {
+  test("after() records CostEvent with correct camelCase token fields", async () => {
     const recorded: CostEvent[] = [];
     const agg = { ...createNoOpCostAggregator(), record: (e: CostEvent) => recorded.push(e) };
     const mw = costMiddleware(agg, "r-001");
     const result = {
       success: true, estimatedCost: 0.005,
-      tokenUsage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 10, cache_creation_input_tokens: 5 },
+      tokenUsage: { inputTokens: 100, outputTokens: 50, cache_read_input_tokens: 10, cache_creation_input_tokens: 5 },
     };
     await mw.after!(makeCtx(), result, 200);
     expect(recorded).toHaveLength(1);
     expect(recorded[0].costUsd).toBe(0.005);
     expect(recorded[0].tokens.input).toBe(100);
+    expect(recorded[0].tokens.output).toBe(50);
     expect(recorded[0].tokens.cacheRead).toBe(10);
+    expect(recorded[0].tokens.cacheWrite).toBe(5);
     expect(recorded[0].durationMs).toBe(200);
     expect(recorded[0].storyId).toBe("s-1");
     expect(recorded[0].stage).toBe("run");
   });
 
-  test("after() is a no-op when result has no tokenUsage", async () => {
+  test("after() records CostEvent for complete calls with costUsd but no tokenUsage", async () => {
+    const recorded: CostEvent[] = [];
+    const agg = { ...createNoOpCostAggregator(), record: (e: CostEvent) => recorded.push(e) };
+    const mw = costMiddleware(agg, "r-001");
+    const result = { output: "done", costUsd: 0.002, source: "exact" };
+    await mw.after!(makeCtx(), result, 150);
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].costUsd).toBe(0.002);
+    expect(recorded[0].tokens.input).toBe(0);
+    expect(recorded[0].tokens.output).toBe(0);
+    expect(recorded[0].durationMs).toBe(150);
+  });
+
+  test("after() is a no-op when result has no tokenUsage and no costUsd", async () => {
     const recorded: CostEvent[] = [];
     const agg = { ...createNoOpCostAggregator(), record: (e: CostEvent) => recorded.push(e) };
     const mw = costMiddleware(agg, "r-001");

--- a/test/unit/runtime/prompt-auditor.test.ts
+++ b/test/unit/runtime/prompt-auditor.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from "bun:test";
+import { PromptAuditor, _promptAuditorDeps, type PromptAuditEntry } from "../../../src/runtime/prompt-auditor";
+import { withTempDir } from "../../helpers/temp";
+import { join } from "node:path";
+
+function makeEntry(overrides: Partial<PromptAuditEntry> = {}): PromptAuditEntry {
+  return {
+    ts: Date.now(),
+    runId: "r-001",
+    agentName: "claude",
+    permissionProfile: "approve-reads",
+    prompt: "Do the thing",
+    response: "Done",
+    durationMs: 100,
+    ...overrides,
+  };
+}
+
+describe("PromptAuditor", () => {
+  test("flush() does nothing when no entries", async () => {
+    const writes: string[] = [];
+    const orig = _promptAuditorDeps.write;
+    _promptAuditorDeps.write = async (p) => { writes.push(p); return 0; };
+    const aud = new PromptAuditor("r-001", "/tmp/audit");
+    await aud.flush();
+    expect(writes).toHaveLength(0);
+    _promptAuditorDeps.write = orig;
+  });
+
+  test("flush() writes one JSONL line per entry in insertion order", async () => {
+    await withTempDir(async (dir) => {
+      const flushDir = join(dir, "audit");
+      let captured = "";
+      const orig = _promptAuditorDeps.write;
+      _promptAuditorDeps.write = async (_p, d) => { captured = String(d); return 0; };
+      const aud = new PromptAuditor("r-test", flushDir);
+      aud.record(makeEntry({ prompt: "first" }));
+      aud.record(makeEntry({ prompt: "second" }));
+      await aud.flush();
+      const lines = captured.trim().split("\n");
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]).prompt).toBe("first");
+      expect(JSON.parse(lines[1]).prompt).toBe("second");
+      _promptAuditorDeps.write = orig;
+    });
+  });
+
+  test("flush() writes to <flushDir>/<runId>.jsonl", async () => {
+    await withTempDir(async (dir) => {
+      const flushDir = join(dir, "audit");
+      let capturedPath = "";
+      const orig = _promptAuditorDeps.write;
+      _promptAuditorDeps.write = async (p, _d) => { capturedPath = p; return 0; };
+      const aud = new PromptAuditor("my-run", flushDir);
+      aud.record(makeEntry());
+      await aud.flush();
+      expect(capturedPath).toBe(join(flushDir, "my-run.jsonl"));
+      _promptAuditorDeps.write = orig;
+    });
+  });
+
+  test("recordError() entries appear in flush output", async () => {
+    await withTempDir(async (dir) => {
+      let captured = "";
+      const orig = _promptAuditorDeps.write;
+      _promptAuditorDeps.write = async (_p, d) => { captured = String(d); return 0; };
+      const aud = new PromptAuditor("r-001", join(dir, "audit"));
+      aud.recordError({ ts: Date.now(), runId: "r-001", agentName: "claude", errorCode: "TIMEOUT", durationMs: 50 });
+      await aud.flush();
+      const parsed = JSON.parse(captured.trim());
+      expect(parsed.errorCode).toBe("TIMEOUT");
+      _promptAuditorDeps.write = orig;
+    });
+  });
+});

--- a/test/unit/runtime/runtime.test.ts
+++ b/test/unit/runtime/runtime.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { createRuntime } from "../../../src/runtime";
 import { DEFAULT_CONFIG } from "../../../src/config";
-import { makeTestRuntime } from "../../helpers";
+import { makeNaxConfig, makeTestRuntime } from "../../helpers";
 
 describe("createRuntime", () => {
   test("runtime has required fields", () => {
@@ -65,19 +65,34 @@ describe("createRuntime", () => {
     expect(rt.costAggregator.snapshot().callCount).toBe(1);
   });
 
-  test("production PromptAuditor accumulates entries", () => {
+  test("promptAuditor is no-op when agent.promptAudit.enabled is false (default)", () => {
     const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test");
+    // No-op auditor.record() does nothing — snapshot stays empty
+    rt.promptAuditor.record({
+      ts: Date.now(), runId: "x", agentName: "claude",
+      permissionProfile: "approve-reads", prompt: "p", response: "r", durationMs: 50,
+    });
+    // No throw — no-op is silent
+  });
+
+  test("promptAuditor is real PromptAuditor when agent.promptAudit.enabled is true", () => {
+    const config = makeNaxConfig({ agent: { promptAudit: { enabled: true } } });
+    const rt = createRuntime(config, "/tmp/test");
+    // Real auditor.record() doesn't throw either, but snapshot() on cost aggregator
+    // confirms the runtime is operational — the key contract is that record() doesn't
+    // silently discard entries (tested via flush in EC-3 integration test).
     expect(() =>
       rt.promptAuditor.record({
-        ts: Date.now(),
-        runId: "x",
-        agentName: "claude",
-        permissionProfile: "approve-reads",
-        prompt: "p",
-        response: "r",
-        durationMs: 50,
+        ts: Date.now(), runId: "x", agentName: "claude",
+        permissionProfile: "approve-reads", prompt: "p", response: "r", durationMs: 50,
       }),
     ).not.toThrow();
+  });
+
+  test("promptAuditor uses configured dir when agent.promptAudit.dir is set", () => {
+    const config = makeNaxConfig({ agent: { promptAudit: { enabled: true, dir: "/custom/audit" } } });
+    const rt = createRuntime(config, "/tmp/test");
+    expect(rt.promptAuditor).toBeDefined();
   });
 });
 

--- a/test/unit/runtime/runtime.test.ts
+++ b/test/unit/runtime/runtime.test.ts
@@ -45,6 +45,40 @@ describe("createRuntime", () => {
     parent.abort();
     expect(rt.signal.aborted).toBe(true);
   });
+
+  test("runtime has runId field", () => {
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test");
+    expect(rt.runId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  test("production CostAggregator is wired (not no-op)", () => {
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test");
+    rt.costAggregator.record({
+      ts: Date.now(),
+      runId: "x",
+      agentName: "claude",
+      model: "m",
+      tokens: { input: 10, output: 5 },
+      costUsd: 0.001,
+      durationMs: 100,
+    });
+    expect(rt.costAggregator.snapshot().callCount).toBe(1);
+  });
+
+  test("production PromptAuditor accumulates entries", () => {
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test");
+    expect(() =>
+      rt.promptAuditor.record({
+        ts: Date.now(),
+        runId: "x",
+        agentName: "claude",
+        permissionProfile: "approve-reads",
+        prompt: "p",
+        response: "r",
+        durationMs: 50,
+      }),
+    ).not.toThrow();
+  });
 });
 
 describe("makeTestRuntime", () => {
@@ -58,5 +92,10 @@ describe("makeTestRuntime", () => {
   test("accepts config override", () => {
     const rt = makeTestRuntime({ workdir: "/tmp/custom" });
     expect(rt.workdir).toBe("/tmp/custom");
+  });
+
+  test("makeTestRuntime produces runtime with runId", () => {
+    const rt = makeTestRuntime();
+    expect(rt.runId).toMatch(/^[0-9a-f-]{36}$/);
   });
 });

--- a/test/unit/session/manager-run-in-session.test.ts
+++ b/test/unit/session/manager-run-in-session.test.ts
@@ -151,13 +151,13 @@ describe("SessionManager.runInSession — ADR-013 Phase 1", () => {
       d.id,
       makeAgentManager(
         makeResult({
-          tokenUsage: { inputTokens: 100, outputTokens: 50, cache_read_input_tokens: 10 },
+          tokenUsage: { inputTokens: 100, outputTokens: 50, cacheReadInputTokens: 10 },
         }),
       ),
       makeRequest(),
     );
 
-    expect(result.tokenUsage).toEqual({ inputTokens: 100, outputTokens: 50, cache_read_input_tokens: 10 });
+    expect(result.tokenUsage).toEqual({ inputTokens: 100, outputTokens: 50, cacheReadInputTokens: 10 });
   });
 
   test("injects onSessionEstablished into request.runOptions and fires caller callback", async () => {

--- a/test/unit/tdd/orchestrator-totals.test.ts
+++ b/test/unit/tdd/orchestrator-totals.test.ts
@@ -93,7 +93,7 @@ describe("runThreeSessionTdd — token + duration aggregation", () => {
   test("sums tokenUsage from all three sessions", async () => {
     const agent = agentReturning([
       { inputTokens: 100, outputTokens: 50 }, // test-writer
-      { inputTokens: 200, outputTokens: 100, cache_read_input_tokens: 10 }, // implementer
+      { inputTokens: 200, outputTokens: 100, cacheReadInputTokens: 10 }, // implementer
       { inputTokens: 50, outputTokens: 25 }, // verifier
     ]);
 
@@ -108,7 +108,7 @@ describe("runThreeSessionTdd — token + duration aggregation", () => {
     expect(result.totalTokenUsage).toEqual({
       inputTokens: 350,
       outputTokens: 175,
-      cache_read_input_tokens: 10,
+      cacheReadInputTokens: 10,
     });
   });
 

--- a/test/unit/tdd/session-runner-tokens.test.ts
+++ b/test/unit/tdd/session-runner-tokens.test.ts
@@ -87,7 +87,7 @@ afterEach(() => {
 describe("runTddSession — tokenUsage (#590)", () => {
   test("propagates tokenUsage from AgentResult to TddSessionResult", async () => {
     const agent = makeAgent({
-      tokenUsage: { inputTokens: 1000, outputTokens: 200, cache_read_input_tokens: 500 },
+      tokenUsage: { inputTokens: 1000, outputTokens: 200, cacheReadInputTokens: 500 },
     });
 
     const outcome = await runTddSession(
@@ -103,7 +103,7 @@ describe("runTddSession — tokenUsage (#590)", () => {
     expect(outcome.tokenUsage).toEqual({
       inputTokens: 1000,
       outputTokens: 200,
-      cache_read_input_tokens: 500,
+      cacheReadInputTokens: 500,
     });
   });
 


### PR DESCRIPTION
## Summary

Implements ADR-018 Wave 2: wires a 4-middleware observer chain into `AgentManager`, ships real in-memory `CostAggregator` and `PromptAuditor` that flush to `.nax/cost/` and `.nax/audit/` on runtime close, and eliminates all `resolvePermissions()` calls from ACP adapter internals by pre-resolving in the manager layer.

### What changed

- **`src/runtime/agent-middleware.ts`** (new) — `MiddlewareContext`, `AgentMiddleware` interface, `MiddlewareChain` class (frozen, ordered, sequential)
- **`src/runtime/cost-aggregator.ts`** — real `CostAggregator` class with in-memory accumulation, `byAgent()`/`byStage()`/`byStory()` grouping, and JSONL drain sorted by `ts`; injectable `_costAggDeps.write`
- **`src/runtime/prompt-auditor.ts`** — real `PromptAuditor` class with in-memory buffer, insertion-order JSONL flush; injectable `_promptAuditorDeps.write`
- **`src/runtime/middleware/`** (new) — 4 observer middlewares: `cancellationMiddleware` (AbortSignal guard), `loggingMiddleware` (structured JSONL), `costMiddleware` (→ `ICostAggregator.record`), `auditMiddleware` (→ `IPromptAuditor.record`)
- **`src/agents/types.ts`** + **`src/agents/shared/types-extended.ts`** — `resolvedPermissions?: ResolvedPermissions` added to `AgentRunOptions`, `CompleteOptions`, `PlanOptions`
- **`src/agents/manager.ts`** — constructor accepts `{ middleware, runId }`; `run()`/`complete()` delegate to `runAs()`/`completeAs()`; full middleware envelope (before → adapter → after/onError) + permission pre-chain in all three dispatch paths
- **`src/agents/factory.ts`** — `CreateAgentManagerOpts` interface, threads opts to constructor
- **`src/runtime/index.ts`** — `NaxRuntime.runId` field; `createRuntime()` generates UUID runId, instantiates real aggregators, composes 4-middleware chain, calls `flush()`/`drain()` in `close()`; barrel exports updated
- **`src/agents/acp/adapter.ts`** — removed 3× `resolvePermissions()` + 2× `writePromptAudit` blocks; reads `options.resolvedPermissions` instead

### Architecture note

`AgentManager` imports `MiddlewareChain` from the leaf file `src/runtime/agent-middleware` (not the `src/runtime` barrel) to avoid the circular import chain: `runtime/index → internal/agent-manager-factory → agents/factory → agents/manager → runtime/index`.

## Exit criteria verified

- `grep -c "resolvePermissions" src/agents/acp/adapter.ts` → `0`
- `CostAggregator.snapshot()` accumulates across recorded events
- `PromptAuditor.flush()` writes `.nax/audit/<runId>.jsonl` on `runtime.close()`
- `CostAggregator.drain()` writes `.nax/cost/<runId>.jsonl` on `runtime.close()`
- `close()` is idempotent — flush/drain called exactly once

## Test plan

- [ ] `bun run typecheck` — 0 errors
- [ ] `bun run test` — full suite green (1181 pass, 0 fail)
- [ ] `test/unit/runtime/agent-middleware.test.ts` — 6 tests
- [ ] `test/unit/runtime/cost-aggregator.test.ts` — 9 tests
- [ ] `test/unit/runtime/prompt-auditor.test.ts` — 4 tests
- [ ] `test/unit/runtime/middleware/` — 9 tests across 3 files
- [ ] `test/unit/agents/manager.test.ts` — 5 new middleware envelope tests
- [ ] `test/unit/runtime/runtime.test.ts` — 4 new tests (runId, real aggregators)
- [ ] `test/integration/runtime-middleware.test.ts` — 6 EC tests