### PR TITLE
fix(adr-018): clean up Wave 1 classifyRoute migration

### DIFF
--- a/.claude/rules/forbidden-patterns.md
+++ b/.claude/rules/forbidden-patterns.md
@@ -18,6 +18,7 @@ These patterns are **banned** from the nax codebase. Violations must be caught d
 | Test files > 800 lines | Split by concern | Violates the hard limit in `docs/guides/testing-rules.md` / `docs/guides/testing-conventions.md` |
 | Prompt-building functions outside `src/prompts/builders/` | Add a method to the appropriate builder class | Orphan prompts scatter LLM instruction logic across subsystems, making them impossible to audit, test, or optimise centrally (see Prompt Builder Convention below) |
 | Inline test-file classification outside `src/test-runners/` | `resolveTestFilePatterns(config, workdir, packageDir)` SSOT | ADR-009 — nax is language-agnostic and monorepo-aware. Hardcoded `test/unit/`, `.test.ts`, `_test.go`, `\.spec\.` regexes fragment the truth and break under polyglot monorepos (see Test-File Classification Convention below) |
+| Hand-rolled LLM JSON extraction (`output.trim().replace(/\`\`\`json.../)`, bare `JSON.parse(output)`) | `parseLLMJson<T>(output)` from `src/utils/llm-json` | Single-tier parsing silently fails on fence-wrapped, preamble-padded, or trailing-comma responses. `parseLLMJson` runs three extraction tiers and is the SSOT for all LLM response parsing. |
 
 ## Prompt Builder Convention
 

--- a/docs/adr/ADR-018-runtime-layering-with-session-runners.md
+++ b/docs/adr/ADR-018-runtime-layering-with-session-runners.md
@@ -1221,6 +1221,114 @@ Five waves. Each independently shippable and revertible.
 
 ---
 
+## Migration Anti-Patterns — Lessons from Wave 1
+
+> Wave 1's `classifyRoute` op (Task 13) shipped with four migration defects fixed in #704. Future wave authors must avoid these patterns. They share one root cause: **migrations should mostly *reuse* existing primitives, not invent new ones.** When a new op file is mostly self-contained constants and types, that is a red flag — it almost certainly duplicates code from the call site it is supposed to replace.
+
+### AP-1. Redefining types that already exist in the schema SSOT
+
+**Symptom (Wave 1):**
+```typescript
+// src/operations/classify-route.ts — wrong
+export interface ClassifyRouteOutput {
+  complexity: "simple" | "medium" | "complex" | "expert";  // duplicates Complexity
+  modelTier: "fast" | "balanced" | "powerful";              // duplicates ModelTier
+  reasoning: string;
+}
+```
+
+**Fix:** import the canonical type.
+```typescript
+import type { Complexity, ModelTier } from "../config";
+export interface ClassifyRouteOutput {
+  complexity: Complexity;
+  modelTier: ModelTier;
+  reasoning: string;
+}
+```
+
+**Why it matters:** literal-union duplicates drift from `src/config/schema-types.ts`. When the schema gains a new tier, the op silently rejects valid responses.
+
+**Rule:** before declaring an op output type, grep `src/config/schema-types.ts` and `src/*/types.ts` for any union/interface whose values match. Reuse beats redefine.
+
+### AP-2. Copy-pasting prompt constants from the legacy call site
+
+**Symptom (Wave 1):** `ROUTING_INSTRUCTIONS` was a verbatim copy of the constant in `src/routing/strategies/llm.ts`.
+
+**Fix:** export the constant from the legacy module, re-export via the subsystem barrel, import in the op.
+
+**Why it matters:** the live call site (`classifyWithLlm`) and the op (`classifyRouteOp`) coexist during the deprecation window. Two copies of the same instruction string drift the moment one is tuned and the other is not — the op then classifies under different rules than the legacy path it claims to replicate.
+
+**Rule:** when the op is a 1:1 replacement for an existing function, every prompt constant the op uses must be imported from where the legacy function defines it. The `build()` method assembles — it does not redefine.
+
+### AP-3. Hand-rolled LLM JSON parsing instead of `parseLLMJson`
+
+**Symptom (Wave 1):**
+```typescript
+parse(output: string): ClassifyRouteOutput {
+  const trimmed = output.trim().replace(/^```json?\s*/i, "").replace(/\s*```$/, "");
+  const raw = JSON.parse(trimmed) as Record<string, unknown>;
+  // ...
+}
+```
+
+**Fix:**
+```typescript
+import { parseLLMJson } from "../utils/llm-json";
+parse(output: string): ClassifyRouteOutput {
+  const raw = parseLLMJson<Record<string, unknown>>(output);
+  // ...
+}
+```
+
+**Why it matters:** the regex-strip + `JSON.parse` path is single-tier. It silently fails on responses with preamble text before a fence, on bare JSON embedded in narration, and on trailing-comma quirks from cheap models. `parseLLMJson` runs three extraction tiers and is the SSOT — codified in [`forbidden-patterns.md`](../../.claude/rules/forbidden-patterns.md).
+
+**Rule:** any `parse()` reading an LLM response goes through `parseLLMJson`. Validation (shape checks, value enums) happens after; extraction does not.
+
+### AP-4. Cross-subsystem duplication disguised as locality
+
+This is the meta-pattern AP-1, AP-2, and AP-3 share. New op files in `src/operations/` look small and self-contained. That appearance is the trap: a 60-line op that defines its own types, prompt strings, and parsers is almost always duplicating code from its target subsystem (`src/routing/`, `src/review/`, `src/acceptance/`, etc.).
+
+**Heuristic:** an op file should be thin — mostly `build()` shape and `parse()` validation. If it has more than ~10 lines of module-level constants or type aliases, audit each one for an existing source.
+
+### Pre-task checklist (apply for every new op in Waves 2–3)
+
+Before writing the op file:
+
+```bash
+# 1. Find the legacy call site the op replaces (named in the wave plan).
+LEGACY=src/routing/strategies/llm.ts   # adjust per task
+
+# 2. Grep its constants — if any non-trivial string appears, it must be exported.
+grep -n "^const " "$LEGACY"
+
+# 3. Grep its types — if it uses Complexity/ModelTier/etc., import the same.
+grep -n "Complexity\|ModelTier\|TestStrategy\|RoutingDecision" "$LEGACY"
+
+# 4. Confirm the parser uses parseLLMJson.
+grep -n "parseLLMJson\|JSON\.parse" "$LEGACY" src/utils/llm-json.ts
+
+# 5. After implementation, verify zero verbatim copies.
+git diff main -- src/operations/<new-op>.ts \
+  | grep '^+' | grep -v '^+++' \
+  | while read line; do
+      grep -F "${line:1}" "$LEGACY" >/dev/null 2>&1 && echo "DUPLICATE: $line"
+    done
+```
+
+The fifth step turns "did you duplicate anything?" into a mechanical check. Commit the op only when it produces no output.
+
+### Wave-author obligation
+
+Each wave's PR description must include an **AP audit** section listing:
+- Which legacy module the op(s) replace
+- Which constants/types/utilities are imported (not redefined)
+- The output of step 5 above (must be empty)
+
+Reviewers should reject any new-op PR that omits the AP audit or shows duplicates.
+
+---
+
 ## Rejected Alternatives
 
 ### A. ADR-017's rejection of `ISessionRunner` (§E)

--- a/src/operations/classify-route.ts
+++ b/src/operations/classify-route.ts
@@ -1,13 +1,16 @@
+import type { Complexity, ModelTier } from "../config";
 import { routingConfigSelector } from "../config";
 import { NaxError } from "../errors";
 import type { UserStory } from "../prd";
+import { ROUTING_INSTRUCTIONS } from "../routing";
+import { parseLLMJson } from "../utils/llm-json";
 import type { BuildContext, CompleteOperation } from "./types";
 
 export interface ClassifyRouteInput extends Pick<UserStory, "title" | "description" | "acceptanceCriteria" | "tags"> {}
 
 export interface ClassifyRouteOutput {
-  complexity: "simple" | "medium" | "complex" | "expert";
-  modelTier: "fast" | "balanced" | "powerful";
+  complexity: Complexity;
+  modelTier: ModelTier;
   reasoning: string;
 }
 
@@ -18,20 +21,6 @@ const VALID_TIERS = new Set<string>(["fast", "balanced", "powerful"]);
 
 const CLASSIFY_ROLE = `You are a story classifier that assigns complexity and model tier to user stories.
 Respond with JSON only — no explanation text before or after.`;
-
-const ROUTING_INSTRUCTIONS = `Classify the user story's complexity and select the cheapest model tier that will succeed.
-
-## Complexity Levels
-- simple: Typos, config updates, boilerplate, barrel exports, re-exports. <30 min.
-- medium: Standard features, moderate logic, straightforward tests. 30-90 min.
-- complex: Multi-file refactors, new subsystems, integration work. >90 min.
-- expert: Security-critical, novel algorithms, complex architecture decisions.
-
-## Rules
-- Default to the CHEAPEST tier that will succeed.
-- Simple barrel exports, re-exports, or index files → always simple + fast.
-- Many files ≠ complex — copy-paste refactors across files are simple.
-- Pure refactoring/deletion with no new behavior → simple.`;
 
 export const classifyRouteOp: CompleteOperation<ClassifyRouteInput, ClassifyRouteOutput, RoutingConfig> = {
   kind: "complete",
@@ -54,11 +43,7 @@ export const classifyRouteOp: CompleteOperation<ClassifyRouteInput, ClassifyRout
     };
   },
   parse(output: string): ClassifyRouteOutput {
-    const trimmed = output
-      .trim()
-      .replace(/^```json?\s*/i, "")
-      .replace(/\s*```$/, "");
-    const raw = JSON.parse(trimmed) as Record<string, unknown>;
+    const raw = parseLLMJson<Record<string, unknown>>(output);
     if (
       !VALID_COMPLEXITY.has(raw.complexity as string) ||
       !VALID_TIERS.has(raw.modelTier as string) ||

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -1,6 +1,9 @@
 // Core types
 export type { RoutingDecision, RoutingStrategy, RoutingContext } from "./router";
 
+// Shared prompt constants used by classifyRoute op and llm strategy
+export { ROUTING_INSTRUCTIONS } from "./strategies/llm";
+
 // Main routing functions
 export {
   resolveRouting,

--- a/src/routing/strategies/llm.ts
+++ b/src/routing/strategies/llm.ts
@@ -23,7 +23,7 @@ export { validateRoutingDecision, stripCodeFences, parseRoutingResponse } from "
 
 // ─── Routing prompt constants ─────────────────────────────────────────────────
 
-const ROUTING_INSTRUCTIONS = `Classify the user story's complexity and select the cheapest model tier that will succeed.
+export const ROUTING_INSTRUCTIONS = `Classify the user story's complexity and select the cheapest model tier that will succeed.
 
 ## Complexity Levels
 - simple: Typos, config updates, boilerplate, barrel exports, re-exports. <30 min.


### PR DESCRIPTION
## Summary
- Addresses four issues left by ADR-018 Wave 1 Task 13 (`classifyRoute` op): inline type duplication, hand-rolled LLM JSON parsing, copy-pasted prompt constants, and a missing SSOT rule.
- Reuses existing primitives from `src/config`, `src/routing`, and `src/utils/llm-json` instead of redefining them in `src/operations/`.
- Adds a `forbidden-patterns.md` entry codifying `parseLLMJson` as the SSOT so future op migrations cannot regress.

## Issues Fixed
1. **`ClassifyRouteOutput`** redefined `Complexity` and `ModelTier` as inline literal unions — now imported from `src/config` (matches `schema-types.ts` SSOT).
2. **`ROUTING_INSTRUCTIONS`** was a verbatim copy of the same constant in `src/routing/strategies/llm.ts` — now exported from `llm.ts`, re-exported via the routing barrel, and imported in `classify-route.ts`.
3. **`parse()`** used `JSON.parse(output.trim().replace(/\`\`\`json.../))` (single-tier) — now uses `parseLLMJson<T>` from `src/utils/llm-json` (three-tier extraction handles fences, preamble, trailing commas).
4. **Cross-subsystem duplication** of `src/routing/strategies/` content — same root as #2.

## Files Changed
- `src/operations/classify-route.ts` — type fixes + `parseLLMJson` + import shared constant
- `src/routing/strategies/llm.ts` — export `ROUTING_INSTRUCTIONS`
- `src/routing/index.ts` — re-export `ROUTING_INSTRUCTIONS` via barrel
- `.claude/rules/forbidden-patterns.md` — new SSOT rule for `parseLLMJson`

## Test plan
- [x] Typecheck passes (\`bun run typecheck\`)
- [x] Operations unit suite passes (9/9) via \`timeout 30 bun run test:bail\`-style targeted run
- [x] Pre-commit hook clean (typecheck + biome)
- [ ] CI to confirm full suite stays green
- [ ] Reviewer to confirm \`ROUTING_INSTRUCTIONS\` barrel re-export does not introduce a circular dependency (verified locally — \`src/routing\` does not import from \`src/operations\`)