### PR TITLE
refactor(adr-018): widen Operation.parse to (output, input, ctx); collapse ClassifyRouteOutput

### DIFF
--- a/docs/adr/ADR-018-runtime-layering-with-session-runners.md
+++ b/docs/adr/ADR-018-runtime-layering-with-session-runners.md
@@ -386,7 +386,7 @@ interface OperationBase<I, O, C> {
   readonly stage: PipelineStage;
   readonly config: ConfigSelector<C>;
   readonly build: (input: I, ctx: BuildContext<C>) => ComposeInput;
-  readonly parse: (output: string) => O;
+  readonly parse: (output: string, input: I, ctx: BuildContext<C>) => O;
 }
 
 export interface RunOperation<I, O, C> extends OperationBase<I, O, C> {
@@ -424,7 +424,9 @@ export interface CallContext {
 }
 ```
 
-**`parse` contract clarification:** for `kind:"complete"` ops, `parse(output)` is a pure text→domain transform (typical JSON-mode completion result). For `kind:"run"` ops that need session-close post-work (autoCommit, isolation verification, changed-file diff, PID cleanup), that work lives in the domain orchestrator that called `callOp` (for TDD: in `src/tdd/session-op.ts`'s shared helper), not inside `parse`. This keeps `parse` side-effect-free for the common case while accommodating the session-based ops that need session-close bookkeeping.
+**`parse` contract clarification:** `parse(output, input, ctx)` is a pure (side-effect-free) typed parser. It may consult `input` and `ctx` — specifically `ctx.packageView.config` for full-config lookups (e.g. validating a model tier against `config.models`) and `ctx.config` for the selector-sliced view — to perform domain-aware validation and derivation (e.g. computing a derived field from `input` properties before returning the typed output). It must remain free of I/O, agent calls, or runtime mutation. For `kind:"run"` ops that need session-close post-work (autoCommit, isolation verification, changed-file diff, PID cleanup), that work lives in the domain orchestrator that called `callOp` (for TDD: in `src/tdd/session-op.ts`'s shared helper), not inside `parse`.
+
+**Signature symmetry with `build`:** both `build(input, ctx)` and `parse(output, input, ctx)` receive `(payload, input, ctx)`. The original Wave-1 shape was `parse(output) => O`; it was widened post-Wave-1 (PR #705) after Wave 1's `classifyRoute` op required config-aware tier validation and `testStrategy` derivation that the one-argument shape could not support. The widening is purely additive — pre-existing one-argument parsers continue to compile because the new parameters are simply unread. See "Migration Anti-Patterns" → AP-3 for the historical context. Do **not** reintroduce a separate `validate(parsed, ctx)` hook (Open Question #1 remains closed); validation belongs inside `parse` so the type system enforces it.
 
 ### 4.2 `ConfigSelector<C>` — named, reusable, interface-based
 
@@ -605,7 +607,7 @@ export async function callOp<I, O, C>(
       storyId: ctx.storyId,
       packageDir: ctx.packageDir,
     });
-    return op.parse(raw);
+    return op.parse(raw, input, buildCtx);
   }
 
   // kind:"run" → Layer 3 (SingleSessionRunner) → Layer 2 (runInSession) → Layer 1 (runAs + middleware)
@@ -619,7 +621,7 @@ export async function callOp<I, O, C>(
     op,
     sessionOverride: ctx.sessionOverride,
   });
-  return op.parse(outcome.primaryResult.output);
+  return op.parse(outcome.primaryResult.output, input, buildCtx);
 }
 
 // Accepts a ConfigSelector OR the inline keyof-array sugar; returns a proper selector.
@@ -1283,7 +1285,9 @@ parse(output: string): ClassifyRouteOutput {
 
 **Why it matters:** the regex-strip + `JSON.parse` path is single-tier. It silently fails on responses with preamble text before a fence, on bare JSON embedded in narration, and on trailing-comma quirks from cheap models. `parseLLMJson` runs three extraction tiers and is the SSOT — codified in [`forbidden-patterns.md`](../../.claude/rules/forbidden-patterns.md).
 
-**Rule:** any `parse()` reading an LLM response goes through `parseLLMJson`. Validation (shape checks, value enums) happens after; extraction does not.
+**Rule:** any `parse()` reading an LLM response goes through `parseLLMJson`. Validation (shape checks, value enums, config-aware checks like tier validity, plus any derivation like `testStrategy`) happens **inside** `parse` after extraction — `parse` receives `(output, input, ctx)` for exactly this purpose (§4.1).
+
+**Subsequent fix (PR #705 — second-order issue from the Wave 1 retro):** the original Wave 1 `parse: (output) => O` signature had no access to config or input, so `classifyRouteOp` could not run the SSOT `validateRoutingDecision` (which needs `config.models` for tier validity and `input.title/description/tags` to derive `testStrategy`). The op consequently shipped with hand-rolled, weaker validation **and** with `ClassifyRouteOutput` defined as a near-duplicate of `RoutingDecision` minus `testStrategy`. The fix widened §4.1 `parse` to `(output, input, ctx)`, dropped `ClassifyRouteOutput`, and made the op emit `RoutingDecision` directly via `validateRoutingDecision`. Lesson: **a typed-output op whose validator depends on config or input is a signal that the framework signature itself is too narrow** — fix the framework, do not silently weaken the op's validation.
 
 ### AP-4. Cross-subsystem duplication disguised as locality
 

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -94,7 +94,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       storyId: ctx.storyId,
       workdir: ctx.packageDir,
     });
-    return op.parse(raw.output);
+    return op.parse(raw.output, input, buildCtx);
   }
 
   const runOp = op as RunOperation<I, O, C>;
@@ -117,5 +117,5 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       agentName: ctx.agentName,
     });
   }
-  return op.parse(rawOutput);
+  return op.parse(rawOutput, input, buildCtx);
 }

--- a/src/operations/classify-route.ts
+++ b/src/operations/classify-route.ts
@@ -1,23 +1,21 @@
-import type { Complexity, ModelTier } from "../config";
 import { routingConfigSelector } from "../config";
-import { NaxError } from "../errors";
 import type { UserStory } from "../prd";
-import { ROUTING_INSTRUCTIONS } from "../routing";
+import type { RoutingDecision } from "../routing";
+import { ROUTING_INSTRUCTIONS, validateRoutingDecision } from "../routing";
 import { parseLLMJson } from "../utils/llm-json";
 import type { BuildContext, CompleteOperation } from "./types";
 
 export interface ClassifyRouteInput extends Pick<UserStory, "title" | "description" | "acceptanceCriteria" | "tags"> {}
 
-export interface ClassifyRouteOutput {
-  complexity: Complexity;
-  modelTier: ModelTier;
-  reasoning: string;
-}
+/**
+ * The op outputs a full `RoutingDecision` — the same shape the legacy
+ * `classifyWithLlm` returns. There is no separate output type: the op IS a
+ * RoutingDecision producer. `parse` runs the SSOT validator
+ * `validateRoutingDecision` (config-aware tier check + `testStrategy` derivation).
+ */
+export type ClassifyRouteOutput = RoutingDecision;
 
 type RoutingConfig = ReturnType<typeof routingConfigSelector.select>;
-
-const VALID_COMPLEXITY = new Set<string>(["simple", "medium", "complex", "expert"]);
-const VALID_TIERS = new Set<string>(["fast", "balanced", "powerful"]);
 
 const CLASSIFY_ROLE = `You are a story classifier that assigns complexity and model tier to user stories.
 Respond with JSON only — no explanation text before or after.`;
@@ -42,19 +40,8 @@ export const classifyRouteOp: CompleteOperation<ClassifyRouteInput, ClassifyRout
       task: { id: "task", content: `${ROUTING_INSTRUCTIONS}\n\n## Story\n\n${storyBody}`, overridable: false },
     };
   },
-  parse(output: string): ClassifyRouteOutput {
+  parse(output: string, input: ClassifyRouteInput, ctx: BuildContext<RoutingConfig>): ClassifyRouteOutput {
     const raw = parseLLMJson<Record<string, unknown>>(output);
-    if (
-      !VALID_COMPLEXITY.has(raw.complexity as string) ||
-      !VALID_TIERS.has(raw.modelTier as string) ||
-      typeof raw.reasoning !== "string"
-    ) {
-      throw new NaxError(
-        `classify-route: invalid response — ${JSON.stringify(raw)}`,
-        "CLASSIFY_ROUTE_INVALID_RESPONSE",
-        { stage: "run", parsed: raw },
-      );
-    }
-    return raw as unknown as ClassifyRouteOutput;
+    return validateRoutingDecision(raw, ctx.packageView.config, input);
   },
 };

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -28,7 +28,19 @@ interface OperationBase<I, O, C> {
   readonly stage: PipelineStage;
   readonly config: ConfigSelector<C> | readonly (keyof NaxConfig)[];
   readonly build: (input: I, ctx: BuildContext<C>) => ComposeInput;
-  readonly parse: (output: string) => O;
+  /**
+   * Parse and validate the agent output into a typed domain value.
+   *
+   * Signature mirrors `build(input, ctx)` for symmetry — `parse` may consult
+   * `input` and `ctx` (specifically `ctx.packageView.config` for full-config
+   * lookups, `ctx.config` for the sliced view) to perform domain-aware
+   * validation and derivation. Must remain side-effect-free: no I/O, no
+   * agent calls, no runtime mutation.
+   *
+   * Widened from `(output) => O` post-Wave-1 (ADR-018 §4.1 amended) — see
+   * Migration Anti-Patterns AP-3.
+   */
+  readonly parse: (output: string, input: I, ctx: BuildContext<C>) => O;
 }
 
 export interface RunOperation<I, O, C> extends OperationBase<I, O, C> {

--- a/src/routing/index.ts
+++ b/src/routing/index.ts
@@ -4,6 +4,10 @@ export type { RoutingDecision, RoutingStrategy, RoutingContext } from "./router"
 // Shared prompt constants used by classifyRoute op and llm strategy
 export { ROUTING_INSTRUCTIONS } from "./strategies/llm";
 
+// Shared validator used by classifyRoute op and llm parsing — single SSOT for
+// LLM routing-decision validation (config-aware tier check + testStrategy derivation).
+export { validateRoutingDecision } from "./strategies/llm-parsing";
+
 // Main routing functions
 export {
   resolveRouting,

--- a/src/routing/strategies/llm-parsing.ts
+++ b/src/routing/strategies/llm-parsing.ts
@@ -14,12 +14,16 @@ import type { RoutingDecision } from "../router";
 /**
  * Validate a parsed routing object and return a clean RoutingDecision.
  *
+ * Signature is intentionally narrow — accepts the minimum fields required.
+ * This lets ops in `src/operations/` pass their input/ctx slices without
+ * widening the operation context type.
+ *
  * @throws Error if required fields are missing or values are invalid
  */
 export function validateRoutingDecision(
   parsed: Record<string, unknown>,
-  config: NaxConfig,
-  story?: UserStory,
+  config: Pick<NaxConfig, "models" | "tdd">,
+  story?: Pick<UserStory, "title" | "description" | "tags">,
 ): RoutingDecision {
   if (!parsed.complexity || !parsed.modelTier || !parsed.reasoning) {
     throw new Error(`Missing required fields in LLM response: ${JSON.stringify(parsed)}`);

--- a/test/unit/operations/classify-route.test.ts
+++ b/test/unit/operations/classify-route.test.ts
@@ -1,6 +1,21 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { routingConfigSelector } from "../../../src/config";
+import type { ClassifyRouteInput } from "../../../src/operations/classify-route";
 import { classifyRouteOp } from "../../../src/operations/classify-route";
 import { makeTestRuntime } from "../../helpers";
+
+const SAMPLE_INPUT: ClassifyRouteInput = {
+  title: "Add button",
+  description: "Add a red button",
+  acceptanceCriteria: ["Button exists"],
+  tags: [],
+};
+
+function makeBuildCtx() {
+  const runtime = makeTestRuntime();
+  const view = runtime.packages.repo();
+  return { packageView: view, config: view.select(routingConfigSelector) };
+}
 
 describe("classifyRouteOp shape", () => {
   test("kind is complete", () => {
@@ -16,27 +31,47 @@ describe("classifyRouteOp shape", () => {
 
 describe("classifyRouteOp.build()", () => {
   test("build returns role + task sections with content", () => {
-    const runtime = makeTestRuntime();
-    const view = runtime.packages.repo();
-    const ctx = { packageView: view, config: view.select(classifyRouteOp.config) };
-    const composeInput = classifyRouteOp.build(
-      { title: "Add button", description: "Add a red button", acceptanceCriteria: ["Button exists"], tags: [] },
-      ctx,
-    );
+    const ctx = makeBuildCtx();
+    const composeInput = classifyRouteOp.build(SAMPLE_INPUT, ctx);
     expect(composeInput.role.content.length).toBeGreaterThan(0);
     expect(composeInput.task.content.length).toBeGreaterThan(0);
   });
 });
 
 describe("classifyRouteOp.parse()", () => {
-  test("parses valid JSON decision", () => {
+  test("parses valid JSON decision and derives testStrategy", () => {
+    const ctx = makeBuildCtx();
     const raw = JSON.stringify({ complexity: "simple", modelTier: "fast", reasoning: "trivial" });
-    const result = classifyRouteOp.parse(raw);
-    expect(result.modelTier).toBe("fast");
+    const result = classifyRouteOp.parse(raw, SAMPLE_INPUT, ctx);
     expect(result.complexity).toBe("simple");
+    expect(result.modelTier).toBe("fast");
+    expect(result.reasoning).toBe("trivial");
+    // testStrategy is derived by validateRoutingDecision — verify presence rather than value,
+    // since the derivation depends on default config.tdd.strategy.
+    expect(typeof result.testStrategy).toBe("string");
+    expect(result.testStrategy.length).toBeGreaterThan(0);
   });
 
   test("throws on unparseable JSON", () => {
-    expect(() => classifyRouteOp.parse("not json")).toThrow();
+    const ctx = makeBuildCtx();
+    expect(() => classifyRouteOp.parse("not json", SAMPLE_INPUT, ctx)).toThrow();
+  });
+
+  test("throws on invalid complexity value", () => {
+    const ctx = makeBuildCtx();
+    const raw = JSON.stringify({ complexity: "trivial", modelTier: "fast", reasoning: "x" });
+    expect(() => classifyRouteOp.parse(raw, SAMPLE_INPUT, ctx)).toThrow(/Invalid complexity/);
+  });
+
+  test("throws on tier not in config.models", () => {
+    const ctx = makeBuildCtx();
+    const raw = JSON.stringify({ complexity: "simple", modelTier: "nonexistent-tier", reasoning: "x" });
+    expect(() => classifyRouteOp.parse(raw, SAMPLE_INPUT, ctx)).toThrow(/Invalid modelTier/);
+  });
+
+  test("throws on missing required fields", () => {
+    const ctx = makeBuildCtx();
+    const raw = JSON.stringify({ complexity: "simple" });
+    expect(() => classifyRouteOp.parse(raw, SAMPLE_INPUT, ctx)).toThrow(/Missing required fields/);
   });
 });


### PR DESCRIPTION
## Summary
Wave-1 followup: collapses `ClassifyRouteOutput` into `RoutingDecision`, runs the SSOT `validateRoutingDecision` from inside the op's parse, and widens the framework `Operation.parse` signature to make this possible. ADR-018 §4.1 / §4.3 amended; Migration Anti-Patterns AP-3 extended with the second-order lesson.

## Why
Wave 1's `parse: (output) => O` had no access to config or input. As a result `classifyRouteOp`:
- Could not validate `modelTier` against `config.models` (only against a hardcoded `["fast","balanced","powerful"]` set).
- Could not derive `testStrategy` (needs `config.tdd.strategy` + story title/description/tags).
- Defined `ClassifyRouteOutput` as a near-duplicate of `RoutingDecision` minus `testStrategy`.

The right fix is to widen the framework signature, not to silently weaken op validation.

## Framework change
- `src/operations/types.ts`: `parse: (output, input, ctx: BuildContext<C>) => O` — mirrors `build(input, ctx)`. Side-effect-free constraint preserved.
- `src/operations/call.ts`: both call sites now pass `(rawOutput, input, buildCtx)`.

## Op refactor
- `src/operations/classify-route.ts`:
  - Drops the `ClassifyRouteOutput` interface; the op now emits `RoutingDecision` directly.
  - `parse` calls `validateRoutingDecision(raw, ctx.packageView.config, input)` — config-aware tier validation + `testStrategy` derivation in one place.
  - `ClassifyRouteOutput` kept as a type alias of `RoutingDecision` for any external import compat (no separate shape).

## Supporting changes
- `src/routing/strategies/llm-parsing.ts`: `validateRoutingDecision` signature narrowed to `Pick<NaxConfig, \"models\" | \"tdd\">` + `Pick<UserStory, \"title\" | \"description\" | \"tags\">`. Existing callers (`parseRoutingResponse`, `parseBatchResponse`) pass full `NaxConfig` / `UserStory` and stay compatible by structural typing.
- `src/routing/index.ts`: re-export `validateRoutingDecision` via the barrel so ops can import from `\"../routing\"`.
- `test/unit/operations/classify-route.test.ts`: covers the new parse signature and four validation paths — valid response, unparseable JSON, invalid complexity, tier missing from `config.models`, missing required fields.

## ADR amendment
- §4.1 type: `parse: (output: string) => O` → `parse: (output: string, input: I, ctx: BuildContext<C>) => O`.
- §4.1 contract: rewritten to permit input/ctx consumption while keeping the side-effect-free invariant. Records that input-side `validate()` hook (Open Question 1) remains closed.
- §4.3: both `op.parse(raw)` examples updated.
- Migration Anti-Patterns AP-3: extended with the second-order finding from this PR — \"a typed-output op whose validator depends on config or input is a signal that the framework signature itself is too narrow.\"

## Compatibility
- Type-driven; the compiler caught every call site (only one op uses `parse` today).
- One-argument `parse` implementations would still compile because the new parameters are just unread — but the only such op in the tree (this one) is rewritten.
- No runtime behavior change for the legacy `classifyWithLlm` path; the op was Wave-1 proof-of-concept and is not yet wired into runtime call sites.

## Test plan
- [x] Typecheck clean (\`bun run typecheck\`).
- [x] Lint clean (\`bun run lint\`).
- [x] Targeted suites: operations + routing + config + runtime — 591/591 pass.
- [x] Pre-commit hook green (typecheck + biome).
- [ ] CI to confirm full suite stays green.
- [ ] Reviewer to verify ADR amendment wording around \"side-effect-free\" reads correctly and that the rejection of input-side validate() (Open Question 1) is cited correctly.