### PR TITLE
fix(acp): handle acpx 0.6.1 strict --model validation errors

### DIFF
--- a/docs/findings/acpx-strict-model-error.md
+++ b/docs/findings/acpx-strict-model-error.md
@@ -1,0 +1,62 @@
+# acpx 0.6.1 — Strict `--model` Validation: Error Mapping & Early Check
+
+**Parent:** [2026-04-26-acpx-0.6.x-adapter-opportunities.md](./2026-04-26-acpx-0.6.x-adapter-opportunities.md)
+**Priority:** High (defensive)
+**Effort:** S
+
+## What changed in acpx
+
+From the 0.6.1 changelog:
+
+> CLI/models: fail clearly when `--model` targets a non-Claude ACP agent that does not advertise ACP model support, and reject model ids outside an adapter's advertised `availableModels` instead of silently falling back to the adapter default.
+
+Before 0.6.1: an unknown model id silently fell back to the adapter default. After 0.6.1: acpx errors out.
+
+## Why we care
+
+[src/agents/acp/spawn-client.ts:137-138](../../src/agents/acp/spawn-client.ts#L137-L138) always passes `--model <model>` to the `prompt` subcommand. The model string comes from `resolveModelForAgent(config.models, agentName, tier, defaultAgent)`. Mis-resolution that previously "worked" (silent fallback) will now hard-fail.
+
+Risks:
+
+- A user adds a new tier mapping with a typoed model id → every prompt fails until they spot it.
+- Adapter-specific model lists drift from our static config — Codex adds/removes models faster than our config catches up.
+- The failure surfaces as a generic acpx exit-code-1 with stderr; today our `parse-agent-error.ts` may not classify it cleanly, leading to confused escalation/rectification.
+
+## Proposed change
+
+### A. Error classification
+
+Update [src/agents/acp/parse-agent-error.ts](../../src/agents/acp/parse-agent-error.ts) to recognise the strict-model rejection pattern (exact strings TBD — capture from a deliberate misuse run against acpx 0.6.1) and map it to a dedicated error code:
+
+- New code: `ACP_MODEL_NOT_AVAILABLE` (or align with whatever acpx surfaces).
+- Mark as **non-retryable** — a tier escalation will not help if the configured model literally does not exist.
+- Surface a remediation hint pointing at the agent's `availableModels` (acpx exposes this — confirm via `acpx <agent> --help` or `acpx <agent> models`).
+
+### B. Early validation — DEFERRED
+
+Add a fast pre-flight check in the model-resolution layer (likely [src/agents/shared/model-resolution.ts](../../src/agents/shared/model-resolution.ts) — verify path) so we fail before spawning:
+
+- At config load (or first adapter use), ask acpx for each agent's `availableModels` once and cache.
+- If `resolveModelForAgent()` returns a model id not in that set, throw `NaxError("MODEL_NOT_AVAILABLE", { agent, model, available })`.
+- If acpx itself does not yet expose a programmatic models query, defer this to a follow-up and rely solely on (A).
+
+**Deferred 2026-04-26**: acpx does not yet expose a stable programmatic `availableModels` query outside of `session/new` response data. Implementing (B) would require a one-shot session just to probe the model list. Deferred until acpx exposes a lighter-weight models query (e.g. `acpx <agent> models`). Part (A) is implemented and provides sufficient coverage for the 0.6.1 regression risk.
+
+### C. Tests
+
+- Unit: `parse-agent-error.ts` recognises the new error string → returns `{ code: ACP_MODEL_NOT_AVAILABLE, retryable: false }`.
+- Integration (real acpx): pass a known-bad model id, assert clean error surface.
+- Optional: snapshot `acpx <agent> models` output if such a command exists.
+
+## Open questions
+
+- What is the exact stderr text acpx 0.6.1 emits? Need to capture verbatim before writing the regex.
+- Does acpx expose a non-JSONRPC way to query `availableModels` per agent? If yes, (B) is cheap; if no, defer.
+- Should we degrade gracefully (warn + send anyway) for non-Claude agents whose model lists may be stale, or fail hard? Lean fail-hard — silent fallback is exactly what acpx removed.
+
+## Acceptance criteria
+
+- [ ] `parse-agent-error.ts` returns a stable `code` for the strict-model error.
+- [ ] Unit test covering the parser branch.
+- [ ] If feasible, early validation throws `NaxError` before spawning acpx.
+- [ ] Docs: short note in [docs/architecture/agent-adapters.md](../../docs/architecture/agent-adapters.md) about the 0.6.1 behaviour change.

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -642,6 +642,22 @@ export class AcpAgentAdapter implements AgentAdapter {
             },
           };
         }
+        if (parsed.type === "model-not-available") {
+          return {
+            success: false,
+            exitCode: result.exitCode ?? 1,
+            output: result.output ?? "",
+            rateLimited: false,
+            durationMs: Date.now() - startTime,
+            estimatedCost: result.estimatedCost ?? 0,
+            adapterFailure: {
+              category: "quality",
+              outcome: "fail-adapter-error",
+              retriable: false,
+              message: (result.output ?? "").slice(0, 500),
+            },
+          };
+        }
       }
 
       return result;
@@ -679,6 +695,22 @@ export class AcpAgentAdapter implements AgentAdapter {
             retriable: true,
             message: error.message.slice(0, 500),
             ...(parsed.retryAfterSeconds !== undefined && { retryAfterSeconds: parsed.retryAfterSeconds }),
+          },
+        };
+      }
+      if (parsed.type === "model-not-available") {
+        return {
+          success: false,
+          exitCode: 1,
+          output: error.message,
+          rateLimited: false,
+          durationMs: Date.now() - startTime,
+          estimatedCost: 0,
+          adapterFailure: {
+            category: "quality",
+            outcome: "fail-adapter-error",
+            retriable: false,
+            message: error.message.slice(0, 500),
           },
         };
       }
@@ -979,6 +1011,19 @@ export class AcpAgentAdapter implements AgentAdapter {
             retriable: true,
             message: error.message.slice(0, 500),
             ...(parsed.retryAfterSeconds !== undefined && { retryAfterSeconds: parsed.retryAfterSeconds }),
+          },
+        };
+      }
+      if (parsed.type === "model-not-available") {
+        return {
+          output: error.message,
+          costUsd: 0,
+          source: "fallback",
+          adapterFailure: {
+            category: "quality",
+            outcome: "fail-adapter-error",
+            retriable: false,
+            message: error.message.slice(0, 500),
           },
         };
       }

--- a/src/agents/acp/parse-agent-error.ts
+++ b/src/agents/acp/parse-agent-error.ts
@@ -44,6 +44,13 @@ export function parseAgentError(stderr: string): AgentError {
   const fromKeyValue = classifyFromCodeTokens(extractKeyValueCodes(stderr));
   if (fromKeyValue) return fromKeyValue;
 
+  // 3. acpx 0.6.1: flat-string model-not-available (Claude Code path).
+  //    Claude accepts unknown models at session/new but rejects at prompt time
+  //    via a plain error string with no machine-readable code — only this
+  //    specific acpx-controlled message can be matched.
+  const flatModel = classifyModelErrorMessage(stderr);
+  if (flatModel) return flatModel;
+
   return { type: "unknown" };
 }
 
@@ -57,6 +64,12 @@ function classifyJsonPayload(payload: Record<string, unknown>): AgentError | nul
 
   const nested = classifyNestedAnthropicError(payload);
   if (nested) return nested;
+
+  // acpx 0.6.1: model-not-available from JSON-RPC error envelope.
+  // The error.message is checked for stable acpx strings before the generic
+  // code-token path, which would only see the too-broad "RUNTIME" acpxCode.
+  const jsonRpcModel = classifyJsonRpcModelError(payload);
+  if (jsonRpcModel) return jsonRpcModel;
 
   const structured = classifyFromCodeTokens(extractJsonCodeTokens(payload), payload);
   if (structured) return structured;
@@ -177,6 +190,47 @@ function parseJsonObject(stderr: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Detect model-not-available from a JSON-RPC error envelope.
+ *
+ * acpx 0.6.1 throws RequestedModelUnsupportedError (src/acp/model-support.ts)
+ * which is serialised to a JSON-RPC -32603 with these stable message prefixes:
+ *   "Cannot apply --model \"...\": the ACP agent did not advertise that model."
+ *   "Cannot apply --model \"...\": the ACP agent did not advertise model support."
+ * The acpxCode is "RUNTIME" (too generic) so we check the message instead.
+ */
+function classifyJsonRpcModelError(payload: Record<string, unknown>): AgentError | null {
+  const errObj = payload.error;
+  if (!errObj || typeof errObj !== "object") return null;
+  const message = (errObj as Record<string, unknown>).message;
+  if (typeof message !== "string") return null;
+  return classifyModelErrorMessage(message);
+}
+
+/**
+ * Shared check for acpx model-support.ts and Claude Code error strings.
+ *
+ * Used both by the JSON-RPC envelope path (checking error.message) and the
+ * flat-string path (checking the raw input directly).
+ *
+ * Pattern 1 — acpx src/acp/model-support.ts (assertRequestedModelSupported):
+ *   stable prefixes from two throw sites in that file.
+ * Pattern 2 — Claude Code prompt rejection: no machine-readable codes;
+ *   two co-occurring substrings narrow the match to avoid false positives.
+ */
+function classifyModelErrorMessage(message: string): AgentError | null {
+  // acpx src/acp/model-support.ts (assertRequestedModelSupported) — stable prefixes.
+  if (message.startsWith("Cannot apply --model") || message.startsWith("Cannot replay saved model")) {
+    return { type: "model-not-available" };
+  }
+  // Claude Code prompt rejection — no machine-readable code; two co-occurring
+  // substrings narrow the match to avoid false positives.
+  if (message.includes("There's an issue with the selected model") && message.includes("Run --model")) {
+    return { type: "model-not-available" };
+  }
+  return null;
 }
 
 function classifyDirectType(payload: Record<string, unknown>): AgentError | null {

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -429,7 +429,8 @@ export class SpawnAcpClient implements AcpClient {
     const { exitCode, stdout, stderr } = await this.trackedSpawn(cmd);
 
     if (exitCode !== 0) {
-      throw new Error(`[acp-adapter] Failed to create session: ${stderr || `exit code ${exitCode}`}`);
+      // Use stdout first — acpx puts the JSON-RPC error there when --format json is set.
+      throw new Error(`[acp-adapter] Failed to create session: ${stdout || stderr || `exit code ${exitCode}`}`);
     }
 
     const { sessionId, recordId } = parseSessionIds(stdout);

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -360,7 +360,7 @@ export interface TurnResult {
  */
 export interface AgentError {
   /** Error type classification */
-  type: "rate-limit" | "auth" | "timeout" | "crash" | "unknown";
+  type: "rate-limit" | "auth" | "timeout" | "crash" | "unknown" | "model-not-available";
   /** Optional retry delay in seconds (for rate-limit errors) */
   retryAfterSeconds?: number;
 }

--- a/test/unit/agents/acp/parse-agent-error.test.ts
+++ b/test/unit/agents/acp/parse-agent-error.test.ts
@@ -123,4 +123,67 @@ describe("parseAgentError", () => {
       expect(parseAgentError("Internal error: Failed to authenticate. API Error: 401").type).toBe("unknown");
     });
   });
+
+  // acpx 0.6.1 strict --model validation (two signal paths)
+  describe("model-not-available errors", () => {
+    // Codex-style: acpx rejects the model at sessions ensure time and emits a
+    // JSON-RPC error on stdout. After the spawn-client fix, the error message
+    // embeds that JSON. Message prefix is stable — from acpx model-support.ts.
+    test("detects model-not-available from embedded JSON-RPC error (Codex ensure path)", () => {
+      const stdout =
+        '[acp-adapter] Failed to create session: {"jsonrpc":"2.0","id":null,"error":{"code":-32603,' +
+        '"message":"Cannot apply --model \\"bad-model-xyz\\": the ACP agent did not advertise that model.' +
+        ' Available models: gpt-5.5/low, gpt-5.5/medium.","data":{"acpxCode":"RUNTIME","origin":"cli","sessionId":"unknown"}}}';
+      const result = parseAgentError(stdout);
+      expect(result.type).toBe("model-not-available");
+    });
+
+    test("detects model-not-available for the advertise-model-support variant (Codex no ACP models)", () => {
+      const stdout =
+        '[acp-adapter] Failed to create session: {"jsonrpc":"2.0","id":null,"error":{"code":-32603,' +
+        '"message":"Cannot apply --model \\"sonnet\\": the ACP agent did not advertise model support.",' +
+        '"data":{"acpxCode":"RUNTIME","origin":"cli","sessionId":"unknown"}}}';
+      const result = parseAgentError(stdout);
+      expect(result.type).toBe("model-not-available");
+    });
+
+    // Claude-style: Claude Code accepts the model at session/new but rejects it
+    // when the prompt is sent. The error arrives as a flat string (no JSON).
+    test("detects model-not-available from Claude Code flat error string", () => {
+      const errorMsg =
+        "Internal error: There's an issue with the selected model (bad-model-xyz)." +
+        " It may not exist or you may not have access to it. Run --model to pick a different model.";
+      const result = parseAgentError(errorMsg);
+      expect(result.type).toBe("model-not-available");
+    });
+
+    test("detects model-not-available for the replay-saved-model variant", () => {
+      const result = parseAgentError(
+        'Cannot replay saved model "claude-sonnet-4-5": the ACP agent did not advertise that model.',
+      );
+      expect(result.type).toBe("model-not-available");
+    });
+
+    test("model-not-available has no retryAfterSeconds", () => {
+      const result = parseAgentError(
+        'Cannot apply --model "x": the ACP agent did not advertise that model. Available models: none advertised.',
+      );
+      expect(result.type).toBe("model-not-available");
+      expect((result as { retryAfterSeconds?: number }).retryAfterSeconds).toBeUndefined();
+    });
+
+    test("does not classify generic RUNTIME acpxCode as model-not-available", () => {
+      // RUNTIME is used for many errors — must not classify without the message prefix.
+      const result = parseAgentError(
+        '{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Some other runtime error",' +
+          '"data":{"acpxCode":"RUNTIME","origin":"cli"}}}',
+      );
+      expect(result.type).toBe("unknown");
+    });
+
+    test("does not classify invalid_request_error Anthropic envelope as model-not-available", () => {
+      const result = parseAgentError('boom {"type":"error","error":{"type":"invalid_request_error"}}');
+      expect(result.type).toBe("unknown");
+    });
+  });
 });


### PR DESCRIPTION
Closes #713

## Summary

- acpx 0.6.1 strict `--model` validation now errors (instead of silently falling back) when an unknown model id is passed. This PR ensures nax classifies these failures cleanly.
- `createSession` was dropping the Codex model-rejection error because it only read `stderr`; acpx writes JSON-RPC errors to `stdout` when `--format json` is active.
- Two new message-pattern classifiers added to `parse-agent-error.ts` for the Codex (JSON-RPC envelope) and Claude Code (flat string) paths.
- `model-not-available` errors map to `adapterFailure { category: "quality", outcome: "fail-adapter-error", retriable: false }` — no tier escalation, no fallback chain.

## Changes

| File | Change |
|---|---|
| `src/agents/types.ts` | Add `"model-not-available"` to `AgentError.type` |
| `src/agents/acp/parse-agent-error.ts` | `classifyJsonRpcModelError` (envelope path) + `classifyModelErrorMessage` (shared, covers both paths) |
| `src/agents/acp/spawn-client.ts` | `createSession` prefers `stdout` over `stderr` in thrown error |
| `src/agents/acp/adapter.ts` | `model-not-available` handling in `run()` success-check, `run()` catch, and `complete()` catch |
| `test/unit/agents/acp/parse-agent-error.test.ts` | 6 new test cases (Codex path × 2, replay-model variant, Claude path, non-retryable assertion, false-positive guards × 2) |
| `docs/findings/acpx-strict-model-error.md` | Mark plan item B (early validation) as deferred |

## Test plan

- [ ] `timeout 30 bun test test/unit/agents/acp/parse-agent-error.test.ts --timeout=5000` — 28 pass, 0 fail
- [ ] `timeout 60 bun test test/unit/agents/acp/ --timeout=5000` — 306 pass, 0 fail
- [ ] `bun run typecheck` — no errors
- [ ] `bun run lint` — no errors
- [ ] Manual smoke: `acpx --format json --model bad-model codex sessions ensure` → classified as `model-not-available`, logged as `fail-adapter-error`, no escalation