### PR TITLE
feat(acp): agent.acp.promptRetries — acpx --prompt-retries opt-in passthrough

### DIFF
--- a/docs/architecture/agent-adapters.md
+++ b/docs/architecture/agent-adapters.md
@@ -205,6 +205,20 @@ The ACP adapter uses tiered retry logic for session errors, configurable via `ex
 
 The adapter detects retryable errors via the `retryable?: boolean` flag in the ACP response. Error logs include the first 500 chars of output for diagnostics.
 
+### Layered Retry Semantics (acpx 0.4.0+)
+
+nax has three independent retry layers, each targeting a different failure class:
+
+| Layer | Config | Triggers on | Behaviour |
+|:------|:-------|:------------|:----------|
+| `agent.acp.promptRetries` (acpx) | `agent.acp.promptRetries` (default `0`) | Transient ACP-layer errors before side effects | acpx retries the same prompt with exponential backoff; JSON output stays stable; skipped if side effects already occurred |
+| Rectification loop (nax) | `execution.rectificationMaxAttempts` | Review or test failures after a complete turn | New prompt synthesised from failure details |
+| Tier escalation (nax) | `execution.escalation.*` | Repeated rectification failures | Bumps model tier (fast → balanced → powerful) |
+
+**Key rule:** `promptRetries` is the cheapest layer — it fires inside acpx before nax even sees the result. Set it to `2` for transient-rate-limit tolerance without overlapping the escalation logic. The failure classes are disjoint: prompt-level transients vs. quality failures vs. repeated quality failures.
+
+`promptRetries` is ACP-only (`agent.acp` sub-key); the CLI adapter (`protocol: "cli"`) has no equivalent.
+
 ### Async Decompose Prompts
 
 `src/agents/shared/decompose-prompt.ts`:

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -136,8 +136,14 @@ export const _acpAdapterDeps = {
    * Default: spawn-based client (shells out to acpx CLI).
    * Override in tests via: _acpAdapterDeps.createClient = mock(...)
    */
-  createClient(cmdStr: string, cwd?: string, timeoutSeconds?: number, onPidSpawned?: (pid: number) => void): AcpClient {
-    return createSpawnAcpClient(cmdStr, cwd, timeoutSeconds, onPidSpawned);
+  createClient(
+    cmdStr: string,
+    cwd?: string,
+    timeoutSeconds?: number,
+    onPidSpawned?: (pid: number) => void,
+    promptRetries?: number,
+  ): AcpClient {
+    return createSpawnAcpClient(cmdStr, cwd, timeoutSeconds, onPidSpawned, promptRetries);
   },
 };
 
@@ -749,6 +755,7 @@ export class AcpAgentAdapter implements AgentAdapter {
       resolvedPermissions,
       modelDef: options.modelDef,
       timeoutSeconds: options.timeoutSeconds,
+      promptRetries: options.config?.agent?.acp?.promptRetries,
       onSessionEstablished: options.onSessionEstablished,
       onPidSpawned: options.onPidSpawned,
       signal: options.abortSignal,
@@ -898,7 +905,8 @@ export class AcpAgentAdapter implements AgentAdapter {
       const model = await resolveModel(agentName);
       const cmdStr = `acpx --model ${model} ${agentName}`;
       const timeoutSeconds = Math.ceil(timeoutMs / 1000);
-      const client = _acpAdapterDeps.createClient(cmdStr, workdir, timeoutSeconds);
+      const promptRetries = _options?.config?.agent?.acp?.promptRetries;
+      const client = _acpAdapterDeps.createClient(cmdStr, workdir, timeoutSeconds, undefined, promptRetries);
       await client.start();
 
       let session: AcpSession | null = null;
@@ -1138,14 +1146,22 @@ export class AcpAgentAdapter implements AgentAdapter {
   async openSession(name: string, opts: OpenSessionOpts): Promise<SessionHandle> {
     // opts.resume is a hint — the ACP adapter always attempts loadSession first
     // via ensureAcpSession, so it is inherently self-resuming regardless of this flag.
-    const { agentName, workdir, resolvedPermissions, modelDef, timeoutSeconds, onSessionEstablished, onPidSpawned } =
-      opts;
+    const {
+      agentName,
+      workdir,
+      resolvedPermissions,
+      modelDef,
+      timeoutSeconds,
+      promptRetries,
+      onSessionEstablished,
+      onPidSpawned,
+    } = opts;
     const { signal } = opts;
 
     throwIfAborted(signal, "Run aborted — shutdown in progress");
 
     const cmdStr = `acpx --model ${modelDef.model} ${agentName}`;
-    const client = _acpAdapterDeps.createClient(cmdStr, workdir, timeoutSeconds, onPidSpawned);
+    const client = _acpAdapterDeps.createClient(cmdStr, workdir, timeoutSeconds, onPidSpawned, promptRetries);
     let session: AcpSession | undefined;
 
     try {

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -93,6 +93,7 @@ export class SpawnAcpSession implements AcpSession {
   private readonly cwd: string;
   private readonly model: string;
   private readonly timeoutSeconds: number;
+  private readonly promptRetries: number;
   private readonly permissionMode: string;
   private readonly env: Record<string, string | undefined>;
   private readonly onPidSpawned?: (pid: number) => void;
@@ -108,6 +109,7 @@ export class SpawnAcpSession implements AcpSession {
     cwd: string;
     model: string;
     timeoutSeconds: number;
+    promptRetries: number;
     permissionMode: string;
     env: Record<string, string | undefined>;
     onPidSpawned?: (pid: number) => void;
@@ -119,6 +121,7 @@ export class SpawnAcpSession implements AcpSession {
     this.cwd = opts.cwd;
     this.model = opts.model;
     this.timeoutSeconds = opts.timeoutSeconds;
+    this.promptRetries = opts.promptRetries;
     this.permissionMode = opts.permissionMode;
     this.env = opts.env;
     this.onPidSpawned = opts.onPidSpawned;
@@ -138,6 +141,7 @@ export class SpawnAcpSession implements AcpSession {
       this.model,
       "--timeout",
       String(this.timeoutSeconds),
+      ...(this.promptRetries > 0 ? ["--prompt-retries", String(this.promptRetries)] : []),
       this.agentName,
       "prompt",
       "-s",
@@ -368,10 +372,17 @@ export class SpawnAcpClient implements AcpClient {
   private readonly model: string;
   private readonly cwd: string;
   private readonly timeoutSeconds: number;
+  private readonly promptRetries: number;
   private readonly env: Record<string, string | undefined>;
   private readonly onPidSpawned?: (pid: number) => void;
 
-  constructor(cmdStr: string, cwd?: string, timeoutSeconds?: number, onPidSpawned?: (pid: number) => void) {
+  constructor(
+    cmdStr: string,
+    cwd?: string,
+    timeoutSeconds?: number,
+    onPidSpawned?: (pid: number) => void,
+    promptRetries?: number,
+  ) {
     // Parse: "acpx --model <model> <agentName>"
     const parts = cmdStr.split(/\s+/);
     const modelIdx = parts.indexOf("--model");
@@ -383,6 +394,7 @@ export class SpawnAcpClient implements AcpClient {
     }
     this.cwd = cwd || process.cwd();
     this.timeoutSeconds = timeoutSeconds || 1800;
+    this.promptRetries = promptRetries ?? 0;
     this.env = buildAllowedEnv();
     this.onPidSpawned = onPidSpawned;
   }
@@ -440,6 +452,7 @@ export class SpawnAcpClient implements AcpClient {
       cwd: this.cwd,
       model: this.model,
       timeoutSeconds: this.timeoutSeconds,
+      promptRetries: this.promptRetries,
       permissionMode: opts.permissionMode,
       env: this.env,
       onPidSpawned: this.onPidSpawned,
@@ -465,6 +478,7 @@ export class SpawnAcpClient implements AcpClient {
       cwd: this.cwd,
       model: this.model,
       timeoutSeconds: this.timeoutSeconds,
+      promptRetries: this.promptRetries,
       permissionMode,
       env: this.env,
       onPidSpawned: this.onPidSpawned,
@@ -504,6 +518,7 @@ export function createSpawnAcpClient(
   cwd?: string,
   timeoutSeconds?: number,
   onPidSpawned?: (pid: number) => void,
+  promptRetries?: number,
 ): AcpClient {
-  return new SpawnAcpClient(cmdStr, cwd, timeoutSeconds, onPidSpawned);
+  return new SpawnAcpClient(cmdStr, cwd, timeoutSeconds, onPidSpawned, promptRetries);
 }

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -293,6 +293,8 @@ export interface OpenSessionOpts {
   modelDef: ModelDef;
   /** ACP: maximum session duration in seconds. */
   timeoutSeconds: number;
+  /** ACP: acpx --prompt-retries value (default 0 — opt-in). */
+  promptRetries?: number;
   /** Fired once the session is physically established, before the first prompt. */
   onSessionEstablished?: (protocolIds: ProtocolIds, sessionName: string) => void;
   /** PID registration callback for crash-recovery bookkeeping. */

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -692,6 +692,12 @@ export interface AgentFallbackConfig {
   rebuildContext?: boolean;
 }
 
+/** ACP-specific agent configuration */
+export interface AgentAcpConfig {
+  /** Retries for transient prompt failures via acpx --prompt-retries (default: 0 — opt-in) */
+  promptRetries?: number;
+}
+
 /** Agent protocol configuration (ACP-003) */
 export interface AgentConfig {
   /** Protocol to use for agent communication (always 'acp') */
@@ -704,4 +710,6 @@ export interface AgentConfig {
   promptAudit?: PromptAuditConfig;
   /** Agent fallback configuration */
   fallback?: AgentFallbackConfig;
+  /** ACP-specific settings */
+  acp?: AgentAcpConfig;
 }

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -717,6 +717,10 @@ const AgentFallbackConfigSchema = z.object({
   rebuildContext: z.boolean().default(true),
 });
 
+const AgentAcpConfigSchema = z.object({
+  promptRetries: z.number().int().min(0).max(5).default(0),
+});
+
 const AgentConfigSchema = z.object({
   protocol: z.literal("acp").default("acp"),
   default: z.string().trim().min(1, "agent.default must be non-empty").default("claude"),
@@ -729,6 +733,7 @@ const AgentConfigSchema = z.object({
     onQualityFailure: false,
     rebuildContext: true,
   }),
+  acp: AgentAcpConfigSchema.default({ promptRetries: 0 }),
 });
 
 const PrecheckConfigSchema = z.object({
@@ -1091,6 +1096,7 @@ export const NaxConfigSchema = z
       maxInteractionTurns: 20,
       promptAudit: { enabled: false },
       fallback: { enabled: false, map: {}, maxHopsPerStory: 2, onQualityFailure: false, rebuildContext: true },
+      acp: { promptRetries: 0 },
     }),
     precheck: PrecheckConfigSchema.optional().default({
       storySizeGate: {

--- a/test/unit/agents/acp/spawn-client.test.ts
+++ b/test/unit/agents/acp/spawn-client.test.ts
@@ -340,3 +340,50 @@ describe("SpawnAcpClient — loadSession (SEC-3)", () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// --prompt-retries flag passthrough
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("SpawnAcpClient — --prompt-retries flag passthrough", () => {
+  withDepsRestore(_spawnClientDeps, ["spawn"]);
+
+  function capturePromptCmd(promptRetries?: number): {
+    capturedCmd: () => string[];
+    client: SpawnAcpClient;
+  } {
+    let captured: string[] = [];
+    _spawnClientDeps.spawn = (cmd, _opts) => {
+      captured = [...cmd];
+      return makeSpawnResult(0, JSON.stringify({ result: "ok" }));
+    };
+    const client = new SpawnAcpClient("acpx --model claude-sonnet-4-5 claude", "/tmp", 30, undefined, promptRetries);
+    return { capturedCmd: () => captured, client };
+  }
+
+  test("prompt cmd includes --prompt-retries when promptRetries > 0", async () => {
+    const { capturedCmd, client } = capturePromptCmd(2);
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    expect(session).not.toBeNull();
+    await session!.prompt("hello");
+    expect(capturedCmd()).toContain("--prompt-retries");
+    const idx = capturedCmd().indexOf("--prompt-retries");
+    expect(capturedCmd()[idx + 1]).toBe("2");
+  });
+
+  test("prompt cmd omits --prompt-retries when promptRetries is 0 (default)", async () => {
+    const { capturedCmd, client } = capturePromptCmd(0);
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    expect(session).not.toBeNull();
+    await session!.prompt("hello");
+    expect(capturedCmd()).not.toContain("--prompt-retries");
+  });
+
+  test("prompt cmd omits --prompt-retries when promptRetries is unset", async () => {
+    const { capturedCmd, client } = capturePromptCmd(undefined);
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    expect(session).not.toBeNull();
+    await session!.prompt("hello");
+    expect(capturedCmd()).not.toContain("--prompt-retries");
+  });
+});

--- a/test/unit/config/agent-schema.test.ts
+++ b/test/unit/config/agent-schema.test.ts
@@ -47,4 +47,21 @@ describe("AgentConfigSchema", () => {
       NaxConfigSchema.parse({ agent: { fallback: { maxHopsPerStory: 11 } } }),
     ).toThrow();
   });
+
+  test("agent.acp.promptRetries defaults to 0", () => {
+    const result = NaxConfigSchema.parse({});
+    expect(result.agent?.acp?.promptRetries).toBe(0);
+  });
+
+  test("agent.acp.promptRetries accepts values 0–5", () => {
+    for (const n of [0, 1, 3, 5]) {
+      const result = NaxConfigSchema.parse({ agent: { acp: { promptRetries: n } } });
+      expect(result.agent?.acp?.promptRetries).toBe(n);
+    }
+  });
+
+  test("agent.acp.promptRetries rejects values out of range", () => {
+    expect(() => NaxConfigSchema.parse({ agent: { acp: { promptRetries: -1 } } })).toThrow();
+    expect(() => NaxConfigSchema.parse({ agent: { acp: { promptRetries: 6 } } })).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

Implements the `acpx-prompt-retries` finding (closes #715).

acpx 0.4.0 added `--prompt-retries`: retries transient ACP-layer errors with exponential backoff, preserving JSON output stability and skipping replay after side effects have occurred. Without this, a momentary rate-limit or 5xx causes nax to enter the full rectification → escalation chain unnecessarily.

## Changes

- `AgentAcpConfig` interface + `AgentAcpConfigSchema` (`promptRetries: int, min 0, max 5, default 0`)
- `SpawnAcpSession.prompt()` appends `--prompt-retries N` when value > 0; omits when 0
- `SpawnAcpClient` stores and propagates `promptRetries` to both `createSession` and `loadSession` paths
- `_acpAdapterDeps.createClient` extended with optional `promptRetries` param
- Plumbed through `run()` path (`AgentRunOptions.config → openSession opts`) and `complete()` path (`_options.config.agent.acp.promptRetries`)
- `closePhysicalSession` intentionally unchanged — no retries on close
- Layered retry table added to `docs/architecture/agent-adapters.md`

## Test plan

- [ ] `bun test test/unit/agents/acp/spawn-client.test.ts` — 3 new tests: flag present when > 0, absent when 0, absent when unset
- [ ] `bun test test/unit/config/agent-schema.test.ts` — 3 new tests: default is 0, accepts 0–5, rejects out-of-range
- [ ] Full suite green: `bun run test`
- [ ] Manual: set `agent.acp.promptRetries: 2` in `.nax/config.json` and verify `--prompt-retries 2` appears in acpx `prompt` invocation logs