### PR TITLE
[codex] support per-stage extra context providers

### DIFF
--- a/docs/guides/context-engine.md
+++ b/docs/guides/context-engine.md
@@ -327,23 +327,24 @@ export const provider: IContextProvider = {
 
 **Pattern C — combine A + B.** Use chunk `role` for coarse audience scoping and `request.stage` inside `fetch()` for fine per-stage variation (e.g. different framings for `tdd-test-writer` vs. `tdd-implementer`, both `tdd`-role).
 
-#### The catch — getting your plugin to fire at all
+#### Wire the plugin to specific stages
 
-Plugin providers load and register with the orchestrator, but the orchestrator then filters by each stage's `providerIds`. None of the built-in stages include plugin IDs today, so a freshly registered plugin **runs on zero stages** until someone adds its ID to `STAGE_CONTEXT_MAP`.
+Plugin providers register globally, but they only run on stages that opt into their provider ID. Use `stages.<name>.extraProviderIds` for that:
 
-**Until [#662](https://github.com/nathapp-io/nax/issues/662) lands**, the only way to wire a plugin into a stage is a source edit:
-
-```typescript
-// src/context/engine/stage-config.ts
-"tdd-test-writer": {
-  role: "tdd",
-  budgetTokens: 8_000,
-  providerIds: [...PHASE_3_TDD_TEST_WRITER, "my-symbol-graph"],  // <-- add plugin ID
-  pullToolNames: ["query_neighbor"],
-},
+```json
+{
+  "context": {
+    "v2": {
+      "stages": {
+        "tdd-test-writer": { "extraProviderIds": ["my-symbol-graph"] },
+        "review-semantic": { "extraProviderIds": ["my-symbol-graph"] }
+      }
+    }
+  }
+}
 ```
 
-Unknown IDs in a stage's `providerIds` throw `CONTEXT_UNKNOWN_PROVIDER_IDS` at assembly time, so typos surface immediately.
+This is additive: built-in `providerIds` from `stage-config.ts` still run, and your plugin gets appended to that stage's allowlist. Unknown IDs in either the built-in list or `extraProviderIds` throw `CONTEXT_UNKNOWN_PROVIDER_IDS` at assembly time, so typos surface immediately.
 
 ---
 

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -453,7 +453,7 @@ export interface ContextV2Config {
    * Set via per-package config (<repoRoot>/.nax/mono/<packageDir>/config.json).
    * Keys are stage names; value overrides the default stage budgetTokens.
    */
-  stages: Record<string, { budgetTokens?: number }>;
+  stages: Record<string, { budgetTokens?: number; extraProviderIds?: string[] }>;
   /**
    * Determinism mode (AC-24).
    * When true, providers declaring `deterministic: false` are excluded from assembly.

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -509,6 +509,11 @@ const ContextPluginProviderConfigSchema = z.object({
   enabled: z.boolean().default(true),
 });
 
+const ContextV2StageOverrideSchema = z.object({
+  budgetTokens: z.number().int().positive().optional(),
+  extraProviderIds: z.array(z.string().min(1)).default([]),
+});
+
 // Context Engine config (Phase 6: selective on; operators opt in per project)
 export const ContextV2ConfigSchema = z
   .object({
@@ -542,7 +547,7 @@ export const ContextV2ConfigSchema = z
      *
      * Example: { "execution": { "budgetTokens": 15000 } }
      */
-    stages: z.record(z.string().min(1), z.object({ budgetTokens: z.number().int().positive().optional() })).default({}),
+    stages: z.record(z.string().min(1), ContextV2StageOverrideSchema).default({}),
     /**
      * Determinism mode (AC-24).
      * When true, providers that declare `deterministic: false` are excluded from assembly.

--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -72,6 +72,8 @@ export const _orchestratorDeps = {
   uuid: () => randomUUID(),
 };
 
+type ProviderActivationSource = NonNullable<NonNullable<ContextManifest["providerResults"]>[number]["source"]>;
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Provider fetch timeout
 // ─────────────────────────────────────────────────────────────────────────────
@@ -120,6 +122,18 @@ function toContextChunk(packed: PackedChunk): ContextChunk {
 /** Stamp providerId onto a raw chunk from the provider. */
 function enrichRaw(chunk: RawChunk, providerId: string): RawChunk {
   return { ...chunk, providerId };
+}
+
+function buildProviderSourceMap(
+  stageProviderIds: string[],
+  extraProviderIds: string[],
+): Map<string, ProviderActivationSource> {
+  const sourceMap = new Map<string, ProviderActivationSource>();
+  for (const id of stageProviderIds) sourceMap.set(id, "stage-config");
+  for (const id of extraProviderIds) {
+    if (!sourceMap.has(id)) sourceMap.set(id, "extra");
+  }
+  return sourceMap;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -228,10 +242,15 @@ export class ContextOrchestrator {
 
     // Step 1: filter providers to those applicable for this stage.
     // request.providerIds (test-only override) takes precedence; otherwise stageConfig.providerIds.
-    const allowedIds = request.providerIds ?? stageConfig.providerIds;
+    const providerSourceMap =
+      request.providerIds === undefined
+        ? buildProviderSourceMap(stageConfig.providerIds, request.extraProviderIds ?? [])
+        : new Map<string, ProviderActivationSource>();
+    const allowedIds = request.providerIds ?? [...providerSourceMap.keys()];
+    const allowedIdSet = new Set(allowedIds);
     // AC-24: determinism mode — skip providers that declare deterministic: false.
     const activeProviders = this.providers.filter(
-      (p) => allowedIds.includes(p.id) && !(request.deterministic === true && p.deterministic === false),
+      (p) => allowedIdSet.has(p.id) && !(request.deterministic === true && p.deterministic === false),
     );
 
     // AC-16: detect providerIds configured by the user that matched no registered provider.
@@ -240,12 +259,13 @@ export class ContextOrchestrator {
     // tests can assert "unknown ID filters to empty" semantics without registering stubs.
     if (request.providerIds === undefined) {
       const registeredIds = new Set(this.providers.map((p) => p.id));
-      const unknownProviderIds = stageConfig.providerIds.filter((id) => !registeredIds.has(id));
+      const unknownProviderIds = [...providerSourceMap.keys()].filter((id) => !registeredIds.has(id));
       if (unknownProviderIds.length > 0) {
         logger.error("context-v2", "Unknown provider IDs in stage config", {
           storyId: request.storyId,
           stage: request.stage,
           unknownProviderIds,
+          extraProviderIds: request.extraProviderIds ?? [],
           availableProviderIds: [...registeredIds].sort(),
         });
         throw new NaxError(
@@ -254,6 +274,8 @@ export class ContextOrchestrator {
           {
             stage: "context-v2",
             storyId: request.storyId,
+            requestStage: request.stage,
+            unknownProviderIds,
           },
         );
       }
@@ -276,6 +298,7 @@ export class ContextOrchestrator {
             providerStatus: {
               providerId: provider.id,
               status,
+              source: providerSourceMap.get(provider.id),
               chunkCount: result.chunks.length,
               durationMs,
               tokensProduced,
@@ -296,6 +319,7 @@ export class ContextOrchestrator {
             providerStatus: {
               providerId: provider.id,
               status,
+              source: providerSourceMap.get(provider.id),
               chunkCount: 0,
               durationMs,
               tokensProduced: 0,
@@ -330,6 +354,7 @@ export class ContextOrchestrator {
       providerResults.push({
         providerId: "plan-digest",
         status: "ok",
+        source: undefined,
         chunkCount: 1,
         durationMs: 0,
         tokensProduced: tokens,

--- a/src/context/engine/stage-assembler.ts
+++ b/src/context/engine/stage-assembler.ts
@@ -178,6 +178,7 @@ export async function assembleForStage(
     // do not re-join story.workdir here or the path will be doubled in monorepo mode.
     const targetAgentId = ctx.routing.agent ?? ctx.agentManager?.getDefault() ?? "claude";
 
+    const stageOverrides = ctx.config.context?.v2?.stages?.[stage];
     const request: ContextRequest = {
       storyId: ctx.story.id,
       featureId: ctx.prd.feature,
@@ -187,7 +188,8 @@ export async function assembleForStage(
       role: stageConfig.role,
       // AC-59: per-package stage budget — reads from ctx.config which is already the
       // merged config (root + <repoRoot>/.nax/mono/<packageDir>/config.json overlay).
-      budgetTokens: ctx.config.context?.v2?.stages?.[stage]?.budgetTokens ?? stageConfig.budgetTokens,
+      budgetTokens: stageOverrides?.budgetTokens ?? stageConfig.budgetTokens,
+      extraProviderIds: stageOverrides?.extraProviderIds ?? [],
       touchedFiles: options.touchedFiles ?? getContextFiles(ctx.story),
       storyScratchDirs,
       priorStageDigest: options.priorStageDigest ?? ctx.contextBundle?.digest,

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -196,6 +196,11 @@ export interface ContextManifest {
     providerId: string;
     /** "ok" = returned ≥1 chunk; "empty" = succeeded but returned no chunks; "failed" = threw; "timeout" = timed out */
     status: "ok" | "empty" | "failed" | "timeout";
+    /**
+     * How this provider was activated for the stage.
+     * Omitted for synthetic entries such as "plan-digest".
+     */
+    source?: "stage-config" | "extra";
     chunkCount: number;
     durationMs: number;
     /** Total tokens across all chunks returned by this provider */
@@ -367,6 +372,11 @@ export interface ContextRequest {
   priorStageDigest?: string;
   /** Restrict fetch to only these provider IDs (optional, for testing). */
   providerIds?: string[];
+  /**
+   * Additional provider IDs configured for this stage via context.v2.stages.
+   * Merged additively with the built-in stage allowlist.
+   */
+  extraProviderIds?: string[];
   /**
    * Minimum score threshold for noise filtering.
    * Chunks whose adjusted score falls below this are excluded from packing.

--- a/test/unit/context/engine/orchestrator-extra-provider-ids.test.ts
+++ b/test/unit/context/engine/orchestrator-extra-provider-ids.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { ContextOrchestrator, _orchestratorDeps } from "../../../../src/context/engine/orchestrator";
+import type { ContextProviderResult, ContextRequest, IContextProvider } from "../../../../src/context/engine/types";
+
+const BASE_REQUEST: ContextRequest = {
+  storyId: "US-001",
+  featureId: "test-feature",
+  repoRoot: "/repo",
+  packageDir: "/repo",
+  stage: "review",
+  role: "reviewer",
+  budgetTokens: 6_000,
+  extraProviderIds: [],
+};
+
+beforeEach(() => {
+  _orchestratorDeps.uuid = () => "00000000-0000-4000-8000-000000000001";
+  _orchestratorDeps.now = () => Date.now();
+});
+
+function makeProvider(id: string, fetch: () => Promise<ContextProviderResult>): IContextProvider {
+  return {
+    id,
+    kind: "feature",
+    fetch: async () => fetch(),
+  };
+}
+
+function makeChunk(providerId: string): ContextProviderResult {
+  return {
+    chunks: [
+      {
+        id: `${providerId}:chunk-1`,
+        kind: "feature",
+        scope: "feature",
+        role: ["reviewer"],
+        content: `content from ${providerId}`,
+        tokens: 40,
+        rawScore: 1,
+      },
+    ],
+    pullTools: [],
+  };
+}
+
+describe("ContextOrchestrator — issue #662 extraProviderIds", () => {
+  test("runs extra providers only on opted-in stages and records manifest source", async () => {
+    let pluginFetches = 0;
+    const orchestrator = new ContextOrchestrator([
+      makeProvider("static-rules", async () => ({ chunks: [], pullTools: [] })),
+      makeProvider("feature-context", async () => ({ chunks: [], pullTools: [] })),
+      makeProvider("my-symbol-graph", async () => {
+        pluginFetches += 1;
+        return makeChunk("my-symbol-graph");
+      }),
+    ]);
+
+    const withExtra = await orchestrator.assemble({
+      ...BASE_REQUEST,
+      stage: "review-semantic",
+      extraProviderIds: ["my-symbol-graph"],
+    });
+    const withoutExtra = await orchestrator.assemble({
+      ...BASE_REQUEST,
+      stage: "review",
+      extraProviderIds: [],
+    });
+
+    expect(pluginFetches).toBe(1);
+    expect(withExtra.manifest.providerResults?.find((p) => p.providerId === "my-symbol-graph")).toMatchObject({
+      providerId: "my-symbol-graph",
+      source: "extra",
+      status: "ok",
+    });
+    expect(withExtra.manifest.providerResults?.find((p) => p.providerId === "static-rules")).toMatchObject({
+      providerId: "static-rules",
+      source: "stage-config",
+    });
+    expect(withoutExtra.manifest.providerResults?.some((p) => p.providerId === "my-symbol-graph")).toBe(false);
+  });
+
+  test("throws CONTEXT_UNKNOWN_PROVIDER_IDS for unknown extraProviderIds with stage context", async () => {
+    const orchestrator = new ContextOrchestrator([
+      makeProvider("static-rules", async () => ({ chunks: [], pullTools: [] })),
+      makeProvider("feature-context", async () => ({ chunks: [], pullTools: [] })),
+    ]);
+
+    await expect(
+      orchestrator.assemble({
+        ...BASE_REQUEST,
+        extraProviderIds: ["missing-provider"],
+      }),
+    ).rejects.toMatchObject({
+      code: "CONTEXT_UNKNOWN_PROVIDER_IDS",
+      context: {
+        requestStage: "review",
+        unknownProviderIds: ["missing-provider"],
+      },
+    });
+  });
+});

--- a/test/unit/context/engine/stage-assembler-extra-provider-ids.test.ts
+++ b/test/unit/context/engine/stage-assembler-extra-provider-ids.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ContextV2ConfigSchema } from "../../../../src/config/schemas";
+import { _stageAssemblerDeps, assembleForStage } from "../../../../src/context/engine/stage-assembler";
+import type { ContextBundle, ContextRequest } from "../../../../src/context/engine/types";
+import type { PipelineContext } from "../../../../src/pipeline/types";
+
+function makeCtx(extraProviderIds?: string[]): PipelineContext {
+  return {
+    config: {
+      context: {
+        v2: {
+          enabled: true,
+          minScore: 0.1,
+          deterministic: false,
+          pluginProviders: [],
+          pull: { enabled: false, allowedTools: [], maxCallsPerSession: 5 },
+          stages: extraProviderIds ? { review: { extraProviderIds } } : {},
+        },
+      },
+      autoMode: { defaultAgent: "claude" },
+    },
+    rootConfig: { autoMode: { defaultAgent: "claude" } },
+    prd: { feature: "test-feature", userStories: [] },
+    story: { id: "US-001" },
+    stories: [],
+    routing: {},
+    projectDir: undefined,
+    workdir: "/repo",
+    hooks: {},
+  } as unknown as PipelineContext;
+}
+
+function makeMockOrchestrator() {
+  const captured: { request: ContextRequest | null } = { request: null };
+  return {
+    captured,
+    orchestrator: {
+      assemble: async (request: ContextRequest): Promise<ContextBundle> => {
+        captured.request = request;
+        return {
+          pushMarkdown: "",
+          digest: "digest",
+          manifest: {
+            requestId: "req-1",
+            stage: request.stage,
+            totalBudgetTokens: request.budgetTokens,
+            usedTokens: 0,
+            includedChunks: [],
+            excludedChunks: [],
+            floorItems: [],
+            digestTokens: 0,
+            buildMs: 0,
+          },
+          packedChunks: [],
+        } as unknown as ContextBundle;
+      },
+    },
+  };
+}
+
+describe("assembleForStage — issue #662 extraProviderIds", () => {
+  let origReaddir: typeof _stageAssemblerDeps.readdir;
+  let origReadDescriptor: typeof _stageAssemblerDeps.readDescriptor;
+  let origCreateOrchestrator: typeof _stageAssemblerDeps.createOrchestrator;
+
+  beforeEach(() => {
+    origReaddir = _stageAssemblerDeps.readdir;
+    origReadDescriptor = _stageAssemblerDeps.readDescriptor;
+    origCreateOrchestrator = _stageAssemblerDeps.createOrchestrator;
+    _stageAssemblerDeps.readdir = async () => {
+      throw new Error("ENOENT");
+    };
+    _stageAssemblerDeps.readDescriptor = async () => null;
+  });
+
+  afterEach(() => {
+    _stageAssemblerDeps.readdir = origReaddir;
+    _stageAssemblerDeps.readDescriptor = origReadDescriptor;
+    _stageAssemblerDeps.createOrchestrator = origCreateOrchestrator;
+  });
+
+  test("passes configured extraProviderIds into the ContextRequest", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    await assembleForStage(makeCtx(["my-symbol-graph", "team-rag"]), "review");
+
+    expect(mock.captured.request?.extraProviderIds).toEqual(["my-symbol-graph", "team-rag"]);
+  });
+
+  test("defaults extraProviderIds to an empty array when the stage has no override", async () => {
+    const mock = makeMockOrchestrator();
+    _stageAssemblerDeps.createOrchestrator = () =>
+      mock.orchestrator as ReturnType<typeof _stageAssemblerDeps.createOrchestrator>;
+
+    await assembleForStage(makeCtx(), "review");
+
+    expect(mock.captured.request?.extraProviderIds).toEqual([]);
+  });
+
+  test("schema accepts extraProviderIds and defaults it to [] per stage", () => {
+    const parsed = ContextV2ConfigSchema.parse({
+      stages: {
+        review: { extraProviderIds: ["my-symbol-graph"] },
+        verify: {},
+      },
+    });
+
+    expect(parsed.stages.review?.extraProviderIds).toEqual(["my-symbol-graph"]);
+    expect(parsed.stages.verify?.extraProviderIds).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Adds config-driven `context.v2.stages.<stage>.extraProviderIds` so plugin context providers can be opted into specific stages without editing `STAGE_CONTEXT_MAP`.

## What changed
- added `extraProviderIds` to the Context Engine v2 stage override schema and runtime types
- threaded stage-level extra provider IDs through `assembleForStage()` into `ContextRequest`
- updated the orchestrator to merge built-in stage provider IDs with configured extras
- preserved unknown-provider validation for both built-in and extra IDs
- recorded manifest provider provenance with `source: "stage-config" | "extra"`
- updated the context engine guide to document the config-driven wiring path
- added regression tests for schema parsing, request propagation, provider activation, and unknown extra-ID failures

## Why
Plugin providers could load successfully but still never execute because stage provider allowlists were hardcoded. This change makes the documented plugin provider configuration actually usable without a source fork.

## Validation
- `bun test test/unit/context/engine/orchestrator-extra-provider-ids.test.ts test/unit/context/engine/stage-assembler-extra-provider-ids.test.ts test/unit/context/engine/orchestrator-unknown-providers.test.ts --timeout=30000`
- `bun run typecheck`
- `bun run lint`

## Review
Manual code review of this branch found no blocking issues. Residual risk is limited to the new behavior being covered by focused unit/regression tests rather than a full runner-level integration test.