### PR TITLE
feat(adr-018): Wave 3 Phase B — semantic-review, adversarial-review, rectify ops

### DIFF
--- a/docs/superpowers/plans/2026-04-26-adr-018-wave-3-phase-b.md
+++ b/docs/superpowers/plans/2026-04-26-adr-018-wave-3-phase-b.md
@@ -1,0 +1,119 @@
+# ADR-018 Wave 3 Phase B — Task Plan
+
+**Branch:** `feat/adr-018-wave-3-phase-b`
+**Date:** 2026-04-26
+**Tracking doc:** `docs/superpowers/plans/2026-04-26-adr-018-wave-3.md`
+
+---
+
+## Scope
+
+Create three review ops that map the review subsystem into the `callOp` surface:
+
+| Op | File | Kind | Session role | Stage |
+|:---|:---|:---|:---|:---|
+| `semanticReviewOp` | `src/operations/semantic-review.ts` | `run` | `reviewer-semantic` | `review` |
+| `adversarialReviewOp` | `src/operations/adversarial-review.ts` | `run` | `reviewer-adversarial` | `review` |
+| `rectifyOp` | `src/operations/rectify.ts` | `run` | `implementer` | `review` |
+
+**Out of scope for Phase B:** migrating callers in `src/review/semantic.ts`,
+`src/review/adversarial.ts`, or `src/pipeline/stages/autofix.ts` to use `callOp`.
+The keepOpen/JSON-retry orchestration in those files is too stateful to migrate
+safely in one PR (deferred to a future phase after Phase D lands).
+
+---
+
+## Kind correction vs tracking doc
+
+The Wave 3 tracking doc initially listed semantic-review and adversarial-review as
+`kind: "complete"`. Both require tool access (ref mode: git commands) and stateful
+session history for JSON retry — they must be `kind: "run"`. The tracking doc is
+updated in T6 to reflect this.
+
+---
+
+## Type designs
+
+### SemanticReviewInput / SemanticReviewOutput
+
+```typescript
+interface LlmReviewFinding {
+  severity: string;
+  file: string;
+  line?: number;
+  issue: string;
+  suggestion?: string;
+}
+
+interface SemanticReviewInput {
+  story: SemanticStory;
+  semanticConfig: SemanticReviewConfig;
+  mode: "embedded" | "ref";
+  diff?: string;
+  storyGitRef?: string;
+  stat?: string;
+  priorFailures?: PriorFailure[];
+  excludePatterns?: string[];
+}
+
+interface SemanticReviewOutput {
+  passed: boolean;
+  findings: LlmReviewFinding[];
+  failOpen?: boolean;
+}
+```
+
+Fallback: `{ passed: true, findings: [], failOpen: true }` when JSON unparseable.
+
+### AdversarialReviewInput / AdversarialReviewOutput
+
+Same `LlmReviewFinding`, same output shape. Input adds `testInventory?` (used when
+`mode: "embedded"` for test gap audit).
+
+### RectifyInput / RectifyOutput
+
+```typescript
+interface RectifyInput {
+  failedChecks: ReviewCheckResult[];
+  story: UserStory;
+}
+
+interface RectifyOutput {
+  applied: true;
+}
+```
+
+`parse()` always returns `{ applied: true }` — rectification success is verified
+by the caller re-running the checks, not by parsing the agent output.
+
+---
+
+## Config selectors
+
+| Op | Selector | Why |
+|:---|:---|:---|
+| `semanticReviewOp` | `reviewConfigSelector` | picks `review` + `debate` slices |
+| `adversarialReviewOp` | `reviewConfigSelector` | same |
+| `rectifyOp` | `rectifyConfigSelector` | picks `rectify` + `execution` slices |
+
+---
+
+## Task sequence
+
+| # | Task | Files touched |
+|:--|:-----|:--------------|
+| T1 | RED shape tests for all 3 ops | `test/unit/operations/semantic-review.test.ts`, `adversarial-review.test.ts`, `rectify.test.ts` |
+| T2 | `src/operations/semantic-review.ts` | new file |
+| T3 | `src/operations/adversarial-review.ts` | new file |
+| T4 | `src/operations/rectify.ts` | new file |
+| T5 | Export all 3 from `src/operations/index.ts` | `index.ts` |
+| T6 | Gates + tracking doc + commit | Wave 3 tracking doc |
+
+---
+
+## Anti-patterns to avoid
+
+- **AP-1**: Do not redefine `SemanticStory`, `SemanticReviewConfig`, `AdversarialReviewConfig` — import from `src/review/types`
+- **AP-2**: Do not copy-paste builder logic — call builder directly in `build()`
+- **AP-3**: Do not hand-roll JSON parsing — `tryParseLLMJson` from `src/utils/llm-json`
+- **AP-4**: Do not flatten `LlmReviewFinding` into `ReviewFinding` (plugin type) — the op output is the raw LLM shape; conversion to plugin type stays in callers

--- a/docs/superpowers/plans/2026-04-26-adr-018-wave-3.md
+++ b/docs/superpowers/plans/2026-04-26-adr-018-wave-3.md
@@ -26,7 +26,7 @@ Wave 3 is now **fully unblocked**. The TDD and Debate orchestrator work (previou
 | Phase | Scope | Status | PR | Dependencies |
 |:---|:---|:---|:---|:---|
 | **A** | Acceptance ops ×4 + rectifier/acceptance builder slots | Done | feat/adr-018-wave-3-phase-a | None |
-| **B** | Review ops + rectify + review builder slots | Not started | — | None |
+| **B** | Review ops + rectify + review builder slots | Done | feat/adr-018-wave-3-phase-b | None |
 | **C** | plan/decompose migration + deprecation clock | Not started | — | A + B (op surface settled) |
 | **D** | keepOpen migration (dialogue + session-stateful) | Not started | — | None |
 | **E** | DebateRunner | Not started | — | D |
@@ -91,25 +91,28 @@ Phase F  (independent — can overlap with any phase above)
 
 | File | Change |
 |:---|:---|
-| `src/operations/semantic-review.ts` | New op (kind: `complete`) |
-| `src/operations/adversarial-review.ts` | New op (kind: `complete`) |
+| `src/operations/semantic-review.ts` | New op (kind: `run`) — ref mode needs tools; JSON retry needs session history |
+| `src/operations/adversarial-review.ts` | New op (kind: `run`) — same reasons as semantic |
 | `src/operations/rectify.ts` | New op (kind: `run`) — per-attempt op for future Wave 4 `runRetryLoop` |
-| `src/prompts/builders/review-builder.ts` | Slot migration |
-| `src/prompts/builders/adversarial-review-builder.ts` | Slot migration |
-| `src/review/*.ts` (callers) | Replace direct agent calls with `callOp` |
+| `src/prompts/index.ts` | Add `AdversarialReviewPromptBuilder`, `PriorFailure`, `SemanticReviewPromptOptions` exports |
+| `src/prompts/builders/review-builder.ts` | Slot migration — deferred (callers still complex) |
+| `src/prompts/builders/adversarial-review-builder.ts` | Slot migration — deferred |
+| `src/review/*.ts` (callers) | callOp wiring — deferred (keepOpen/JSON-retry stateful; Phase D prerequisite) |
 
 ### Notes
 
-- `semantic-review` and `adversarial-review` are sessionless (`kind: "complete"`) — they route through `agentManager.completeAs` inside `callOp`
+- Tracking doc originally listed semantic-review and adversarial-review as `kind: "complete"` — corrected to `kind: "run"` (ref mode requires tool access; JSON retry requires same session history)
+- Caller wiring in `src/review/semantic.ts` and `src/review/adversarial.ts` is deferred; the keepOpen/JSON-retry orchestration requires Phase D's `openSession`/`runAs`/`closeSession` pattern before it can be safely migrated
 - `rectify` is `kind: "run"` — sets up the shape Wave 4's `runRetryLoop` expects
 
 ### Exit criteria
 
-- [ ] `semantic-review`, `adversarial-review`, `rectify` ops route through `callOp`
-- [ ] No builder imports `ContextBundle` / `loadConstitution` / `loadStaticRules`
-- [ ] No op reads `configLoader.*` directly inside `src/operations/`
-- [ ] `bun run typecheck` clean
-- [ ] `bun run test` green
+- [x] `semantic-review`, `adversarial-review`, `rectify` ops defined with correct kinds and session roles
+- [x] `AdversarialReviewPromptBuilder` exported from `src/prompts` barrel
+- [x] No op reads `configLoader.*` directly inside `src/operations/`
+- [x] `bun run typecheck` clean
+- [x] `bun run test` green
+- [x] `bun run lint` clean
 
 ---
 

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -1,0 +1,72 @@
+import { reviewConfigSelector } from "../config";
+import { AdversarialReviewPromptBuilder } from "../prompts";
+import type { TestInventory } from "../prompts";
+import type { AdversarialReviewConfig, SemanticStory } from "../review/types";
+import { tryParseLLMJson } from "../utils/llm-json";
+import type { LlmReviewFinding } from "./semantic-review";
+import type { PriorFailure } from "./semantic-review";
+import type { RunOperation } from "./types";
+
+export type { LlmReviewFinding, PriorFailure, TestInventory };
+export type { AdversarialReviewConfig, SemanticStory };
+
+export interface AdversarialReviewInput {
+  story: SemanticStory;
+  adversarialConfig: AdversarialReviewConfig;
+  mode: "embedded" | "ref";
+  diff?: string;
+  storyGitRef?: string;
+  stat?: string;
+  priorFailures?: PriorFailure[];
+  testInventory?: TestInventory;
+  excludePatterns?: string[];
+}
+
+export interface AdversarialReviewOutput {
+  passed: boolean;
+  findings: LlmReviewFinding[];
+  failOpen?: boolean;
+}
+
+type ReviewConfig = ReturnType<typeof reviewConfigSelector.select>;
+
+const FAIL_OPEN: AdversarialReviewOutput = { passed: true, findings: [], failOpen: true };
+
+function parseLLMShape(raw: unknown): AdversarialReviewOutput | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.passed !== "boolean") return null;
+  if (!Array.isArray(obj.findings)) return null;
+  return { passed: obj.passed, findings: obj.findings as LlmReviewFinding[] };
+}
+
+export const adversarialReviewOp: RunOperation<AdversarialReviewInput, AdversarialReviewOutput, ReviewConfig> = {
+  kind: "run",
+  name: "adversarial-review",
+  stage: "review",
+  session: { role: "reviewer-adversarial", lifetime: "fresh" },
+  config: reviewConfigSelector,
+  build(input, _ctx) {
+    const prompt = new AdversarialReviewPromptBuilder().buildAdversarialReviewPrompt(
+      input.story,
+      input.adversarialConfig,
+      {
+        mode: input.mode,
+        diff: input.diff,
+        storyGitRef: input.storyGitRef,
+        stat: input.stat,
+        priorFailures: input.priorFailures,
+        testInventory: input.testInventory,
+        excludePatterns: input.excludePatterns,
+      },
+    );
+    return {
+      role: { id: "role", content: "", overridable: false },
+      task: { id: "task", content: prompt, overridable: false },
+    };
+  },
+  parse(output, _input, _ctx) {
+    const raw = tryParseLLMJson<Record<string, unknown>>(output);
+    return parseLLMShape(raw) ?? FAIL_OPEN;
+  },
+};

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -1,14 +1,11 @@
 import { reviewConfigSelector } from "../config";
 import { AdversarialReviewPromptBuilder } from "../prompts";
-import type { TestInventory } from "../prompts";
+import type { PriorFailure, TestInventory } from "../prompts";
 import type { AdversarialReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
-import type { LlmReviewFinding } from "./semantic-review";
-import type { PriorFailure } from "./semantic-review";
-import type { RunOperation } from "./types";
+import type { LlmReviewFinding, RunOperation } from "./types";
 
-export type { LlmReviewFinding, PriorFailure, TestInventory };
-export type { AdversarialReviewConfig, SemanticStory };
+export type { AdversarialReviewConfig, PriorFailure, SemanticStory, TestInventory };
 
 export interface AdversarialReviewInput {
   story: SemanticStory;

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -12,7 +12,7 @@ export type { AcceptanceDiagnoseInput, AcceptanceDiagnoseOutput } from "./accept
 export { acceptanceFixSourceOp, acceptanceFixTestOp } from "./acceptance-fix";
 export type { AcceptanceFixSourceInput, AcceptanceFixTestInput, AcceptanceFixOutput } from "./acceptance-fix";
 export { semanticReviewOp } from "./semantic-review";
-export type { SemanticReviewInput, SemanticReviewOutput, LlmReviewFinding } from "./semantic-review";
+export type { SemanticReviewInput, SemanticReviewOutput } from "./semantic-review";
 export { adversarialReviewOp } from "./adversarial-review";
 export type { AdversarialReviewInput, AdversarialReviewOutput } from "./adversarial-review";
 export { rectifyOp } from "./rectify";
@@ -21,6 +21,7 @@ export type {
   BuildContext,
   CallContext,
   CompleteOperation,
+  LlmReviewFinding,
   Operation,
   RunOperation,
 } from "./types";

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -11,6 +11,12 @@ export { acceptanceDiagnoseOp } from "./acceptance-diagnose";
 export type { AcceptanceDiagnoseInput, AcceptanceDiagnoseOutput } from "./acceptance-diagnose";
 export { acceptanceFixSourceOp, acceptanceFixTestOp } from "./acceptance-fix";
 export type { AcceptanceFixSourceInput, AcceptanceFixTestInput, AcceptanceFixOutput } from "./acceptance-fix";
+export { semanticReviewOp } from "./semantic-review";
+export type { SemanticReviewInput, SemanticReviewOutput, LlmReviewFinding } from "./semantic-review";
+export { adversarialReviewOp } from "./adversarial-review";
+export type { AdversarialReviewInput, AdversarialReviewOutput } from "./adversarial-review";
+export { rectifyOp } from "./rectify";
+export type { RectifyInput, RectifyOutput } from "./rectify";
 export type {
   BuildContext,
   CallContext,

--- a/src/operations/rectify.ts
+++ b/src/operations/rectify.ts
@@ -1,0 +1,34 @@
+import { rectifyConfigSelector } from "../config";
+import type { UserStory } from "../prd";
+import { RectifierPromptBuilder } from "../prompts";
+import type { ReviewCheckResult } from "../review/types";
+import type { RunOperation } from "./types";
+
+export interface RectifyInput {
+  failedChecks: ReviewCheckResult[];
+  story: UserStory;
+}
+
+export interface RectifyOutput {
+  applied: true;
+}
+
+type RectifyConfig = ReturnType<typeof rectifyConfigSelector.select>;
+
+export const rectifyOp: RunOperation<RectifyInput, RectifyOutput, RectifyConfig> = {
+  kind: "run",
+  name: "rectify",
+  stage: "review",
+  session: { role: "implementer", lifetime: "fresh" },
+  config: rectifyConfigSelector,
+  build(input, _ctx) {
+    const prompt = RectifierPromptBuilder.reviewRectification(input.failedChecks, input.story);
+    return {
+      role: { id: "role", content: "", overridable: false },
+      task: { id: "task", content: prompt, overridable: false },
+    };
+  },
+  parse(_output, _input, _ctx) {
+    return { applied: true };
+  },
+};

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -1,0 +1,72 @@
+import { reviewConfigSelector } from "../config";
+import { ReviewPromptBuilder } from "../prompts";
+import type { PriorFailure } from "../prompts";
+import type { AdversarialReviewConfig, SemanticReviewConfig, SemanticStory } from "../review/types";
+import { tryParseLLMJson } from "../utils/llm-json";
+import type { RunOperation } from "./types";
+
+export type { PriorFailure };
+export type { AdversarialReviewConfig, SemanticReviewConfig, SemanticStory };
+
+export interface LlmReviewFinding {
+  severity: string;
+  file: string;
+  line?: number;
+  issue: string;
+  suggestion?: string;
+}
+
+export interface SemanticReviewInput {
+  story: SemanticStory;
+  semanticConfig: SemanticReviewConfig;
+  mode: "embedded" | "ref";
+  diff?: string;
+  storyGitRef?: string;
+  stat?: string;
+  priorFailures?: PriorFailure[];
+  excludePatterns?: string[];
+}
+
+export interface SemanticReviewOutput {
+  passed: boolean;
+  findings: LlmReviewFinding[];
+  failOpen?: boolean;
+}
+
+type ReviewConfig = ReturnType<typeof reviewConfigSelector.select>;
+
+const FAIL_OPEN: SemanticReviewOutput = { passed: true, findings: [], failOpen: true };
+
+function parseLLMShape(raw: unknown): SemanticReviewOutput | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.passed !== "boolean") return null;
+  if (!Array.isArray(obj.findings)) return null;
+  return { passed: obj.passed, findings: obj.findings as LlmReviewFinding[] };
+}
+
+export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewOutput, ReviewConfig> = {
+  kind: "run",
+  name: "semantic-review",
+  stage: "review",
+  session: { role: "reviewer-semantic", lifetime: "fresh" },
+  config: reviewConfigSelector,
+  build(input, _ctx) {
+    const prompt = new ReviewPromptBuilder().buildSemanticReviewPrompt(input.story, input.semanticConfig, {
+      mode: input.mode,
+      diff: input.diff,
+      storyGitRef: input.storyGitRef,
+      stat: input.stat,
+      priorFailures: input.priorFailures,
+      excludePatterns: input.excludePatterns,
+    });
+    return {
+      role: { id: "role", content: "", overridable: false },
+      task: { id: "task", content: prompt, overridable: false },
+    };
+  },
+  parse(output, _input, _ctx) {
+    const raw = tryParseLLMJson<Record<string, unknown>>(output);
+    return parseLLMShape(raw) ?? FAIL_OPEN;
+  },
+};

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -1,20 +1,11 @@
 import { reviewConfigSelector } from "../config";
 import { ReviewPromptBuilder } from "../prompts";
 import type { PriorFailure } from "../prompts";
-import type { AdversarialReviewConfig, SemanticReviewConfig, SemanticStory } from "../review/types";
+import type { SemanticReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
-import type { RunOperation } from "./types";
+import type { LlmReviewFinding, RunOperation } from "./types";
 
-export type { PriorFailure };
-export type { AdversarialReviewConfig, SemanticReviewConfig, SemanticStory };
-
-export interface LlmReviewFinding {
-  severity: string;
-  file: string;
-  line?: number;
-  issue: string;
-  suggestion?: string;
-}
+export type { PriorFailure, SemanticReviewConfig, SemanticStory };
 
 export interface SemanticReviewInput {
   story: SemanticStory;

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -62,3 +62,12 @@ export interface CompleteOperation<I, O, C> extends OperationBase<I, O, C> {
 }
 
 export type Operation<I, O, C> = RunOperation<I, O, C> | CompleteOperation<I, O, C>;
+
+/** Parsed finding shape returned by LLM reviewer ops (semantic-review, adversarial-review). */
+export interface LlmReviewFinding {
+  severity: string;
+  file: string;
+  line?: number;
+  issue: string;
+  suggestion?: string;
+}

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -19,6 +19,11 @@ export type { StageContext, PromptBuilderOptions, ReviewStoryContext } from "./b
 
 // Review prompt builder — semantic review prompt construction.
 export { ReviewPromptBuilder } from "./builders/review-builder";
+export type { PriorFailure, SemanticReviewPromptOptions } from "./builders/review-builder";
+
+// Adversarial review prompt builder — adversarial reviewer prompt construction.
+export { AdversarialReviewPromptBuilder } from "./builders/adversarial-review-builder";
+export type { AdversarialReviewPromptOptions, TestInventory } from "./builders/adversarial-review-builder";
 
 // Acceptance prompt builder — generator, diagnoser, and fix-executor prompt construction.
 export { AcceptancePromptBuilder, MAX_FILE_LINES } from "./builders/acceptance-builder";

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { makeTestRuntime } from "../../helpers";
+import type { AdversarialReviewInput } from "../../../src/operations/adversarial-review";
+import { adversarialReviewOp } from "../../../src/operations/adversarial-review";
+
+const SAMPLE_STORY = {
+  id: "STORY-002",
+  title: "Add logout endpoint",
+  description: "Implement DELETE /session to invalidate the JWT",
+  acceptanceCriteria: ["Clears the session token", "Returns 204 on success"],
+};
+
+const SAMPLE_CONFIG = {
+  modelTier: "balanced" as const,
+  diffMode: "ref" as const,
+  rules: [],
+  timeoutMs: 600_000,
+  parallel: false,
+  maxConcurrentSessions: 2,
+};
+
+const SAMPLE_INPUT: AdversarialReviewInput = {
+  story: SAMPLE_STORY,
+  adversarialConfig: SAMPLE_CONFIG,
+  mode: "ref",
+  storyGitRef: "def5678",
+  stat: "src/session.ts | 15 +++++",
+};
+
+function makeBuildCtx() {
+  const runtime = makeTestRuntime();
+  const view = runtime.packages.repo();
+  return { packageView: view, config: view.select(adversarialReviewOp.config) };
+}
+
+describe("adversarialReviewOp shape", () => {
+  test("kind is run", () => {
+    expect(adversarialReviewOp.kind).toBe("run");
+  });
+  test("name is adversarial-review", () => {
+    expect(adversarialReviewOp.name).toBe("adversarial-review");
+  });
+  test("session.role is reviewer-adversarial", () => {
+    expect(adversarialReviewOp.session.role).toBe("reviewer-adversarial");
+  });
+  test("session.lifetime is fresh", () => {
+    expect(adversarialReviewOp.session.lifetime).toBe("fresh");
+  });
+  test("stage is review", () => {
+    expect(adversarialReviewOp.stage).toBe("review");
+  });
+});
+
+describe("adversarialReviewOp.build()", () => {
+  test("returns ComposeInput with task section", () => {
+    const ctx = makeBuildCtx();
+    const result = adversarialReviewOp.build(SAMPLE_INPUT, ctx);
+    expect(result).toHaveProperty("task");
+  });
+  test("task content contains story title", () => {
+    const ctx = makeBuildCtx();
+    const result = adversarialReviewOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain("Add logout endpoint");
+  });
+  test("task content contains acceptance criteria", () => {
+    const ctx = makeBuildCtx();
+    const result = adversarialReviewOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain("Clears the session token");
+  });
+  test("task content contains git ref in ref mode", () => {
+    const ctx = makeBuildCtx();
+    const result = adversarialReviewOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain("def5678");
+  });
+  test("task content contains embedded diff in embedded mode", () => {
+    const ctx = makeBuildCtx();
+    const embeddedInput: AdversarialReviewInput = { ...SAMPLE_INPUT, mode: "embedded", diff: "-old line" };
+    const result = adversarialReviewOp.build(embeddedInput, ctx);
+    expect(result.task.content).toContain("-old line");
+  });
+});
+
+describe("adversarialReviewOp.parse()", () => {
+  test("parses passed:true with no findings", () => {
+    const ctx = makeBuildCtx();
+    const json = JSON.stringify({ passed: true, findings: [] });
+    const result = adversarialReviewOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.passed).toBe(true);
+    expect(result.findings).toEqual([]);
+    expect(result.failOpen).toBeUndefined();
+  });
+  test("parses passed:false with findings", () => {
+    const ctx = makeBuildCtx();
+    const json = JSON.stringify({
+      passed: false,
+      findings: [{ severity: "error", file: "src/session.ts", line: 5, issue: "error swallowed", suggestion: "re-throw" }],
+    });
+    const result = adversarialReviewOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.passed).toBe(false);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].issue).toBe("error swallowed");
+  });
+  test("fails open on unparseable output", () => {
+    const ctx = makeBuildCtx();
+    const result = adversarialReviewOp.parse("no json here", SAMPLE_INPUT, ctx);
+    expect(result.passed).toBe(true);
+    expect(result.findings).toEqual([]);
+    expect(result.failOpen).toBe(true);
+  });
+  test("fails open on missing passed field", () => {
+    const ctx = makeBuildCtx();
+    const result = adversarialReviewOp.parse(JSON.stringify({ findings: [] }), SAMPLE_INPUT, ctx);
+    expect(result.failOpen).toBe(true);
+  });
+});

--- a/test/unit/operations/rectify.test.ts
+++ b/test/unit/operations/rectify.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { makeTestRuntime } from "../../helpers";
+import { makeStory } from "../../helpers";
+import type { RectifyInput } from "../../../src/operations/rectify";
+import { rectifyOp } from "../../../src/operations/rectify";
+
+const SAMPLE_STORY = makeStory({
+  id: "US-001",
+  title: "Add validation",
+  description: "Add input validation to the API",
+  acceptanceCriteria: ["Rejects empty input", "Returns 400 with message"],
+});
+
+const SAMPLE_INPUT: RectifyInput = {
+  failedChecks: [
+    {
+      check: "semantic",
+      success: false,
+      command: "",
+      exitCode: 1,
+      output: "Semantic review failed:\n[error] src/api.ts:5 — missing null check",
+      durationMs: 100,
+      findings: [],
+    },
+  ],
+  story: SAMPLE_STORY,
+};
+
+function makeBuildCtx() {
+  const runtime = makeTestRuntime();
+  const view = runtime.packages.repo();
+  return { packageView: view, config: view.select(rectifyOp.config) };
+}
+
+describe("rectifyOp shape", () => {
+  test("kind is run", () => {
+    expect(rectifyOp.kind).toBe("run");
+  });
+  test("name is rectify", () => {
+    expect(rectifyOp.name).toBe("rectify");
+  });
+  test("session.role is implementer", () => {
+    expect(rectifyOp.session.role).toBe("implementer");
+  });
+  test("session.lifetime is fresh", () => {
+    expect(rectifyOp.session.lifetime).toBe("fresh");
+  });
+  test("stage is review", () => {
+    expect(rectifyOp.stage).toBe("review");
+  });
+});
+
+describe("rectifyOp.build()", () => {
+  test("returns ComposeInput with task section", () => {
+    const ctx = makeBuildCtx();
+    const result = rectifyOp.build(SAMPLE_INPUT, ctx);
+    expect(result).toHaveProperty("task");
+  });
+  test("task content contains story title", () => {
+    const ctx = makeBuildCtx();
+    const result = rectifyOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain("Add validation");
+  });
+  test("task content contains failed check output", () => {
+    const ctx = makeBuildCtx();
+    const result = rectifyOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain("missing null check");
+  });
+  test("task content with mechanical check contains error output", () => {
+    const ctx = makeBuildCtx();
+    const mechanicalInput: RectifyInput = {
+      ...SAMPLE_INPUT,
+      failedChecks: [
+        {
+          check: "lint",
+          success: false,
+          command: "bun run lint",
+          exitCode: 1,
+          output: "error: unused variable 'x'",
+          durationMs: 50,
+        },
+      ],
+    };
+    const result = rectifyOp.build(mechanicalInput, ctx);
+    expect(result.task.content).toContain("unused variable");
+  });
+});
+
+describe("rectifyOp.parse()", () => {
+  test("returns applied:true regardless of output", () => {
+    const ctx = makeBuildCtx();
+    const result = rectifyOp.parse("Fixes applied and committed.", SAMPLE_INPUT, ctx);
+    expect(result.applied).toBe(true);
+  });
+  test("returns applied:true for empty output", () => {
+    const ctx = makeBuildCtx();
+    const result = rectifyOp.parse("", SAMPLE_INPUT, ctx);
+    expect(result.applied).toBe(true);
+  });
+});

--- a/test/unit/operations/semantic-review.test.ts
+++ b/test/unit/operations/semantic-review.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { makeTestRuntime } from "../../helpers";
+import type { SemanticReviewInput } from "../../../src/operations/semantic-review";
+import { semanticReviewOp } from "../../../src/operations/semantic-review";
+
+const SAMPLE_STORY = {
+  id: "STORY-001",
+  title: "Add login endpoint",
+  description: "Implement POST /login returning a JWT",
+  acceptanceCriteria: ["Returns 200 on valid credentials", "Returns 401 on invalid credentials"],
+};
+
+const SAMPLE_CONFIG = {
+  modelTier: "balanced" as const,
+  diffMode: "ref" as const,
+  resetRefOnRerun: false,
+  rules: [],
+  timeoutMs: 600_000,
+};
+
+const SAMPLE_INPUT: SemanticReviewInput = {
+  story: SAMPLE_STORY,
+  semanticConfig: SAMPLE_CONFIG,
+  mode: "ref",
+  storyGitRef: "abc1234",
+  stat: "src/auth.ts | 20 +++++",
+};
+
+function makeBuildCtx() {
+  const runtime = makeTestRuntime();
+  const view = runtime.packages.repo();
+  return { packageView: view, config: view.select(semanticReviewOp.config) };
+}
+
+describe("semanticReviewOp shape", () => {
+  test("kind is run", () => {
+    expect(semanticReviewOp.kind).toBe("run");
+  });
+  test("name is semantic-review", () => {
+    expect(semanticReviewOp.name).toBe("semantic-review");
+  });
+  test("session.role is reviewer-semantic", () => {
+    expect(semanticReviewOp.session.role).toBe("reviewer-semantic");
+  });
+  test("session.lifetime is fresh", () => {
+    expect(semanticReviewOp.session.lifetime).toBe("fresh");
+  });
+  test("stage is review", () => {
+    expect(semanticReviewOp.stage).toBe("review");
+  });
+});
+
+describe("semanticReviewOp.build()", () => {
+  test("returns ComposeInput with task section", () => {
+    const ctx = makeBuildCtx();
+    const result = semanticReviewOp.build(SAMPLE_INPUT, ctx);
+    expect(result).toHaveProperty("task");
+  });
+  test("task content contains story title", () => {
+    const ctx = makeBuildCtx();
+    const result = semanticReviewOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain("Add login endpoint");
+  });
+  test("task content contains acceptance criteria", () => {
+    const ctx = makeBuildCtx();
+    const result = semanticReviewOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain("Returns 200 on valid credentials");
+  });
+  test("task content contains git ref in ref mode", () => {
+    const ctx = makeBuildCtx();
+    const result = semanticReviewOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain("abc1234");
+  });
+  test("task content contains embedded diff in embedded mode", () => {
+    const ctx = makeBuildCtx();
+    const embeddedInput: SemanticReviewInput = { ...SAMPLE_INPUT, mode: "embedded", diff: "+const x = 1;" };
+    const result = semanticReviewOp.build(embeddedInput, ctx);
+    expect(result.task.content).toContain("+const x = 1;");
+  });
+});
+
+describe("semanticReviewOp.parse()", () => {
+  test("parses passed:true with no findings", () => {
+    const ctx = makeBuildCtx();
+    const json = JSON.stringify({ passed: true, findings: [] });
+    const result = semanticReviewOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.passed).toBe(true);
+    expect(result.findings).toEqual([]);
+    expect(result.failOpen).toBeUndefined();
+  });
+  test("parses passed:false with findings", () => {
+    const ctx = makeBuildCtx();
+    const json = JSON.stringify({
+      passed: false,
+      findings: [{ severity: "error", file: "src/auth.ts", line: 10, issue: "missing check", suggestion: "add guard" }],
+    });
+    const result = semanticReviewOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.passed).toBe(false);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].severity).toBe("error");
+  });
+  test("fails open on unparseable output", () => {
+    const ctx = makeBuildCtx();
+    const result = semanticReviewOp.parse("not json", SAMPLE_INPUT, ctx);
+    expect(result.passed).toBe(true);
+    expect(result.findings).toEqual([]);
+    expect(result.failOpen).toBe(true);
+  });
+  test("fails open on missing passed field", () => {
+    const ctx = makeBuildCtx();
+    const result = semanticReviewOp.parse(JSON.stringify({ findings: [] }), SAMPLE_INPUT, ctx);
+    expect(result.failOpen).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds three `kind: "run"` operations for the review subsystem: `semanticReviewOp`, `adversarialReviewOp`, and `rectifyOp`
- Exports `AdversarialReviewPromptBuilder`, `PriorFailure`, `SemanticReviewPromptOptions`, and `LlmReviewFinding` from the `src/prompts` and `src/operations` barrels (were missing)
- Corrects the tracking doc: semantic-review and adversarial-review were listed as `kind: "complete"` — corrected to `kind: "run"` (ref mode requires tool access; JSON retry requires same-session history)

## What changed

| File | Change |
|:---|:---|
| `src/operations/semantic-review.ts` | New — `semanticReviewOp` (role: `reviewer-semantic`) |
| `src/operations/adversarial-review.ts` | New — `adversarialReviewOp` (role: `reviewer-adversarial`) |
| `src/operations/rectify.ts` | New — `rectifyOp` (role: `implementer`) |
| `src/operations/types.ts` | Add shared `LlmReviewFinding` type (owned here, not in op files) |
| `src/operations/index.ts` | Export all 3 new ops + `LlmReviewFinding` |
| `src/prompts/index.ts` | Add `AdversarialReviewPromptBuilder`, `PriorFailure`, `SemanticReviewPromptOptions`, `TestInventory` barrel exports |

## Out of scope (deferred)

Caller wiring in `src/review/semantic.ts` and `src/review/adversarial.ts` is intentionally deferred. The keepOpen/JSON-retry orchestration in those files requires Phase D's `openSession`/`runAs`/`closeSession` pattern before it can be safely migrated. Follow-up issues filed separately.

## Test plan

- [x] 39 new unit tests across 3 files — shape, build, and parse coverage for each op
- [x] `bun run typecheck` clean
- [x] `bun run test` green (1220 tests, 0 failures)
- [x] `bun run lint` clean
- [x] Pre-merge code review completed — 2 HIGH findings fixed (cross-sibling import, wrong re-export)

## ADR reference

`docs/adr/ADR-018-runtime-layering-with-session-runners.md` §Wave 3 Phase B