### PR TITLE
refactor(adr-018): Wave 3 Phase C — planOp/decomposeOp via callOp

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -12,13 +12,10 @@
  */
 
 import { createHash } from "node:crypto";
-import { DEFAULT_CONFIG } from "../../config";
+import { NaxError } from "../../errors";
 import { getSafeLogger } from "../../logger";
 import { sleep, which } from "../../utils/bun-deps";
-import { NO_OP_INTERACTION_HANDLER } from "../interaction-handler";
 import type { InteractionHandler } from "../interaction-handler";
-import { parseDecomposeOutput } from "../shared/decompose";
-import { buildDecomposePromptAsync } from "../shared/decompose-prompt";
 import { parseAgentError } from "./parse-agent-error";
 import { createSpawnAcpClient } from "./spawn-client";
 
@@ -536,10 +533,7 @@ export class AcpAgentAdapter implements AgentAdapter {
   readonly binary: string;
   readonly capabilities: AgentCapabilities;
 
-  constructor(
-    agentName: string,
-    private readonly naxConfig?: import("../../config").NaxConfig,
-  ) {
+  constructor(agentName: string, _naxConfig?: import("../../config").NaxConfig) {
     const entry = resolveRegistryEntry(agentName);
     this.name = agentName;
     this.displayName = entry.displayName;
@@ -731,107 +725,20 @@ export class AcpAgentAdapter implements AgentAdapter {
     }
   }
 
-  async plan(options: PlanOptions): Promise<PlanResult> {
-    // Resolve model: explicit > resolveModelForAgent(tier) > fallback
-    let modelDef = options.modelDef;
-    if (!modelDef && options.config?.models) {
-      const tier = options.modelTier ?? "balanced";
-      const config = options.config;
-      const { resolveModelForAgent } = await import("../../config/schema");
-      try {
-        const defaultAgent = config.agent?.default ?? "claude";
-        modelDef = resolveModelForAgent(config.models ?? {}, defaultAgent, tier, defaultAgent);
-      } catch {
-        // resolveModelForAgent can throw on malformed entries
-      }
-    }
-    modelDef ??= { provider: "anthropic", model: "claude-sonnet-4-5-20250514" };
-    // Timeout: from options, or config, or fallback to 600s
-    const timeoutSeconds =
-      options.timeoutSeconds ?? (options.config?.execution?.sessionTimeoutSeconds as number | undefined) ?? 600;
-
-    const resolvedPermissions = options.resolvedPermissions ?? {
-      mode: "approve-reads" as const,
-      skipPermissions: false,
-    };
-    const sessionName = computeAcpHandle(options.workdir, options.featureName, options.storyId, options.sessionRole);
-    const handle = await this.openSession(sessionName, {
-      agentName: this.name,
-      workdir: options.workdir,
-      resolvedPermissions,
-      modelDef,
-      timeoutSeconds,
-      onPidSpawned: options.onPidSpawned,
-    });
-
-    const bridge = options.interactionBridge;
-    const planInteractionHandler = bridge
-      ? {
-          onInteraction: async (req: import("../interaction-handler").AdapterInteraction) => {
-            if (req.kind === "question") {
-              const answer = await bridge.onQuestionDetected(req.text);
-              return { answer };
-            }
-            return null;
-          },
-        }
-      : NO_OP_INTERACTION_HANDLER;
-
-    let specContent: string;
-    let costUsd: number;
-    try {
-      const turnResult = await this.sendTurn(handle, options.prompt, {
-        interactionHandler: planInteractionHandler,
-        maxTurns: options.maxInteractionTurns ?? 1,
-      });
-      specContent = turnResult.output.trim();
-      costUsd = turnResult.cost?.total ?? 0;
-    } catch (err) {
-      throw new Error(`[acp-adapter] plan() failed: ${err instanceof Error ? err.message : String(err)}`, {
-        cause: err,
-      });
-    } finally {
-      await this.closeSession(handle).catch(() => {});
-    }
-
-    if (!specContent) {
-      throw new Error("[acp-adapter] plan() returned empty spec content");
-    }
-
-    return { specContent, costUsd };
+  async plan(_options: PlanOptions): Promise<PlanResult> {
+    throw new NaxError(
+      "AgentAdapter.plan() is deprecated. Use callOp(ctx, planOp, input) instead.",
+      "ADAPTER_METHOD_DEPRECATED",
+      { stage: "plan", migration: "src/operations/plan.ts" },
+    );
   }
 
-  async decompose(options: DecomposeOptions): Promise<DecomposeResult> {
-    const model = options.modelDef?.model;
-    const prompt = await buildDecomposePromptAsync(options);
-
-    let output: string;
-    try {
-      const completeResult = await this.complete(prompt, {
-        model,
-        jsonMode: true,
-        config: this.naxConfig ?? DEFAULT_CONFIG,
-        workdir: options.workdir,
-        featureName: options.featureName,
-        storyId: options.storyId,
-        sessionRole: options.sessionRole ?? "decompose",
-        timeoutMs:
-          (this.naxConfig?.plan?.decomposeTimeoutSeconds ?? this.naxConfig?.plan?.timeoutSeconds ?? 300) * 1_000,
-      });
-      output = completeResult.output;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      throw new Error(`[acp-adapter] decompose() failed: ${msg}`, { cause: err });
-    }
-
-    let stories: ReturnType<typeof parseDecomposeOutput>;
-    try {
-      stories = parseDecomposeOutput(output);
-    } catch (err) {
-      throw new Error(`[acp-adapter] decompose() failed to parse stories: ${(err as Error).message}`, { cause: err });
-    }
-
-    return { stories };
+  async decompose(_options: DecomposeOptions): Promise<DecomposeResult> {
+    throw new NaxError(
+      "AgentAdapter.decompose() is deprecated. Use callOp(ctx, decomposeOp, input) instead.",
+      "ADAPTER_METHOD_DEPRECATED",
+      { stage: "plan", migration: "src/operations/decompose.ts" },
+    );
   }
 
   async closePhysicalSession(handle: string, workdir: string, options?: { force?: boolean }): Promise<void> {

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -533,7 +533,7 @@ export class AcpAgentAdapter implements AgentAdapter {
   readonly binary: string;
   readonly capabilities: AgentCapabilities;
 
-  constructor(agentName: string, _naxConfig?: import("../../config").NaxConfig) {
+  constructor(agentName: string) {
     const entry = resolveRegistryEntry(agentName);
     this.name = agentName;
     this.displayName = entry.displayName;

--- a/src/agents/manager-types.ts
+++ b/src/agents/manager-types.ts
@@ -209,21 +209,27 @@ export interface IAgentManager {
   ): Promise<import("./types").TurnResult>;
 
   /**
-   * Plan mode — feature spec generation via default agent with fallback.
-   * Routes through the fallback chain; availability failures swap agents.
+   * @deprecated Use `callOp(ctx, planOp, input)` from `src/operations/plan.ts` instead.
+   * Throws `NaxError ADAPTER_METHOD_DEPRECATED` at runtime. Deleted in Wave 3.5.
    */
   plan(options: PlanOptions): Promise<PlanResult>;
 
-  /** Plan mode pinned to a specific agent (debate plan debaters). */
+  /**
+   * @deprecated Use `callOp(ctx, planOp, input)` from `src/operations/plan.ts` instead.
+   * Throws `NaxError ADAPTER_METHOD_DEPRECATED` at runtime. Deleted in Wave 3.5.
+   */
   planAs(agentName: string, options: PlanOptions): Promise<PlanResult>;
 
   /**
-   * Decompose mode — story splitting via default agent with fallback.
-   * Routes through the fallback chain; availability failures swap agents.
+   * @deprecated Use `callOp(ctx, decomposeOp, input)` from `src/operations/decompose.ts` instead.
+   * Throws `NaxError ADAPTER_METHOD_DEPRECATED` at runtime. Deleted in Wave 3.5.
    */
   decompose(options: DecomposeOptions): Promise<DecomposeResult>;
 
-  /** Decompose mode pinned to a specific agent. */
+  /**
+   * @deprecated Use `callOp(ctx, decomposeOp, input)` from `src/operations/decompose.ts` instead.
+   * Throws `NaxError ADAPTER_METHOD_DEPRECATED` at runtime. Deleted in Wave 3.5.
+   */
   decomposeAs(agentName: string, options: DecomposeOptions): Promise<DecomposeResult>;
 }
 

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -508,26 +508,36 @@ export class AgentManager implements IAgentManager {
     }
   }
 
-  async plan(options: PlanOptions): Promise<PlanResult> {
-    return this.planAs(this.getDefault(), options);
+  async plan(_options: PlanOptions): Promise<PlanResult> {
+    throw new NaxError(
+      "AgentManager.plan() is deprecated. Use callOp(ctx, planOp, input) instead.",
+      "ADAPTER_METHOD_DEPRECATED",
+      { stage: "plan", migration: "src/operations/plan.ts" },
+    );
   }
 
-  async planAs(agentName: string, options: PlanOptions): Promise<PlanResult> {
-    const resolvedPermissions = resolvePermissions((options.config as NaxConfig | undefined) ?? this._config, "plan");
-    const augmented: PlanOptions = { ...options, resolvedPermissions };
-    const adapter = this._resolveRegistry().getAgent(agentName);
-    if (!adapter) return { specContent: `Agent "${agentName}" not found` };
-    return adapter.plan(augmented);
+  async planAs(_agentName: string, _options: PlanOptions): Promise<PlanResult> {
+    throw new NaxError(
+      "AgentManager.planAs() is deprecated. Use callOp(ctx, planOp, input) instead.",
+      "ADAPTER_METHOD_DEPRECATED",
+      { stage: "plan", migration: "src/operations/plan.ts" },
+    );
   }
 
-  async decompose(options: DecomposeOptions): Promise<DecomposeResult> {
-    return this.decomposeAs(this.getDefault(), options);
+  async decompose(_options: DecomposeOptions): Promise<DecomposeResult> {
+    throw new NaxError(
+      "AgentManager.decompose() is deprecated. Use callOp(ctx, decomposeOp, input) instead.",
+      "ADAPTER_METHOD_DEPRECATED",
+      { stage: "plan", migration: "src/operations/decompose.ts" },
+    );
   }
 
-  async decomposeAs(agentName: string, options: DecomposeOptions): Promise<DecomposeResult> {
-    const adapter = this._resolveRegistry().getAgent(agentName);
-    if (!adapter) return { stories: [] };
-    return adapter.decompose(options);
+  async decomposeAs(_agentName: string, _options: DecomposeOptions): Promise<DecomposeResult> {
+    throw new NaxError(
+      "AgentManager.decomposeAs() is deprecated. Use callOp(ctx, decomposeOp, input) instead.",
+      "ADAPTER_METHOD_DEPRECATED",
+      { stage: "plan", migration: "src/operations/decompose.ts" },
+    );
   }
 
   private _resolveRegistry(): AgentRegistry {

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -68,7 +68,7 @@ export function createAgentRegistry(config: NaxConfig): AgentRegistry {
     if (_registryTestAdapters.has(name)) return _registryTestAdapters.get(name);
     if (!KNOWN_AGENT_NAMES.includes(name)) return undefined;
     if (!acpCache.has(name)) {
-      acpCache.set(name, new AcpAgentAdapter(name, config));
+      acpCache.set(name, new AcpAgentAdapter(name));
       logger?.debug("agents", `Created AcpAgentAdapter for ${name}`, { name });
     }
     return acpCache.get(name);
@@ -78,7 +78,7 @@ export function createAgentRegistry(config: NaxConfig): AgentRegistry {
     const testAdapters = Array.from(_registryTestAdapters.values());
     const acpAdapters = KNOWN_AGENT_NAMES.map((name) => {
       if (!acpCache.has(name)) {
-        acpCache.set(name, new AcpAgentAdapter(name, config));
+        acpCache.set(name, new AcpAgentAdapter(name));
       }
       return acpCache.get(name) as AcpAgentAdapter;
     });
@@ -93,7 +93,7 @@ export function createAgentRegistry(config: NaxConfig): AgentRegistry {
     const testAdapters = Array.from(_registryTestAdapters.values());
     const acpAdapters = KNOWN_AGENT_NAMES.map((name) => {
       if (!acpCache.has(name)) {
-        acpCache.set(name, new AcpAgentAdapter(name, config));
+        acpCache.set(name, new AcpAgentAdapter(name));
       }
       return acpCache.get(name) as AcpAgentAdapter;
     });

--- a/src/agents/shared/decompose-prompt.ts
+++ b/src/agents/shared/decompose-prompt.ts
@@ -99,6 +99,28 @@ ${TEST_STRATEGY_GUIDE}
 ${GROUPING_RULES}${acConstraint}`;
 }
 
+/** Narrowed input for synchronous decompose prompt building (used by decomposeOp). */
+export interface DecomposePromptInput {
+  specContent: string;
+  codebaseContext: string;
+  targetStory?: import("../../prd/types").UserStory;
+  siblings?: import("../../prd/types").UserStory[];
+  maxAcCount?: number | null;
+}
+
+/**
+ * Build a decompose prompt synchronously (used by decomposeOp.build()).
+ *
+ * Functionally identical to buildDecomposePromptAsync — all inner operations
+ * are synchronous (OneShotPromptBuilder.build() returns a string, no I/O).
+ */
+export function buildDecomposePromptSync(input: DecomposePromptInput): string {
+  if (input.targetStory) {
+    return buildPlanModePromptSync(input);
+  }
+  return buildSpecModePromptSync(input);
+}
+
 /**
  * Build a decompose prompt using OneShotPromptBuilder.
  *
@@ -109,6 +131,34 @@ export async function buildDecomposePromptAsync(options: DecomposeOptions): Prom
     return buildPlanModePrompt(options);
   }
   return buildSpecModePrompt(options);
+}
+
+function buildPlanModePromptSync(input: DecomposePromptInput): string {
+  // biome-ignore lint/style/noNonNullAssertion: guarded by caller (input.targetStory is defined)
+  const targetStory = input.targetStory!;
+  const siblings = input.siblings ?? [];
+  const instructions = buildPlanModeInstructions(targetStory.id, input.maxAcCount ?? null);
+
+  let builder = OneShotPromptBuilder.for("decomposer")
+    .instructions(instructions)
+    .inputData("Target Story", JSON.stringify(targetStory, null, 2))
+    .inputData("Codebase Context", input.codebaseContext);
+
+  if (siblings.length > 0) {
+    const siblingsSummary = siblings.map((s) => `- ${s.id}: ${s.title}`).join("\n");
+    builder = builder.inputData("Sibling Stories", siblingsSummary);
+  }
+
+  return builder.jsonSchema(DECOMPOSE_PLAN_SCHEMA).build();
+}
+
+function buildSpecModePromptSync(input: DecomposePromptInput): string {
+  return OneShotPromptBuilder.for("decomposer")
+    .instructions(SPEC_DECOMPOSE_INSTRUCTIONS)
+    .inputData("Codebase Context", input.codebaseContext)
+    .inputData("Feature Specification", input.specContent)
+    .jsonSchema(DECOMPOSE_SPEC_SCHEMA)
+    .build();
 }
 
 async function buildPlanModePrompt(options: DecomposeOptions): Promise<string> {

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -387,10 +387,16 @@ export interface AgentAdapter {
   /** Build the CLI command for a given run (for dry-run display). */
   buildCommand(options: AgentRunOptions): string[];
 
-  /** Run the agent in plan mode to generate a feature specification. */
+  /**
+   * @deprecated Use `callOp(ctx, planOp, input)` from `src/operations/plan.ts` instead.
+   * Implementations throw `NaxError ADAPTER_METHOD_DEPRECATED`. Deleted in Wave 3.5.
+   */
   plan(options: import("./shared/types-extended").PlanOptions): Promise<import("./shared/types-extended").PlanResult>;
 
-  /** Run the agent in decompose mode to break spec into classified stories. */
+  /**
+   * @deprecated Use `callOp(ctx, decomposeOp, input)` from `src/operations/decompose.ts` instead.
+   * Implementations throw `NaxError ADAPTER_METHOD_DEPRECATED`. Deleted in Wave 3.5.
+   */
   decompose(
     options: import("./shared/types-extended").DecomposeOptions,
   ): Promise<import("./shared/types-extended").DecomposeResult>;

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
 import { resolvePermissions } from "../config/permissions";
+import { NaxError } from "../errors";
 import { getLogger } from "../logger";
 import { formatSessionName } from "../session/naming";
 import { buildContextToolPreamble, buildRunInteractionHandler } from "./acp/adapter";
@@ -133,15 +134,33 @@ export function wrapAdapterAsManager(adapter: AgentAdapter): IAgentManager {
       warnMismatch("completeAs", agentName);
       return adapter.complete(prompt, opts);
     },
-    plan: async (opts) => adapter.plan(opts),
-    planAs: async (agentName, opts) => {
-      warnMismatch("planAs", agentName);
-      return adapter.plan(opts);
+    plan: async (_opts) => {
+      throw new NaxError(
+        "AgentManager.plan() is deprecated. Use callOp(ctx, planOp, input) instead.",
+        "ADAPTER_METHOD_DEPRECATED",
+        { stage: "plan", migration: "src/operations/plan.ts" },
+      );
     },
-    decompose: async (opts) => adapter.decompose(opts),
-    decomposeAs: async (agentName, opts) => {
-      warnMismatch("decomposeAs", agentName);
-      return adapter.decompose(opts);
+    planAs: async (_agentName, _opts) => {
+      throw new NaxError(
+        "AgentManager.planAs() is deprecated. Use callOp(ctx, planOp, input) instead.",
+        "ADAPTER_METHOD_DEPRECATED",
+        { stage: "plan", migration: "src/operations/plan.ts" },
+      );
+    },
+    decompose: async (_opts) => {
+      throw new NaxError(
+        "AgentManager.decompose() is deprecated. Use callOp(ctx, decomposeOp, input) instead.",
+        "ADAPTER_METHOD_DEPRECATED",
+        { stage: "plan", migration: "src/operations/decompose.ts" },
+      );
+    },
+    decomposeAs: async (_agentName, _opts) => {
+      throw new NaxError(
+        "AgentManager.decomposeAs() is deprecated. Use callOp(ctx, decomposeOp, input) instead.",
+        "ADAPTER_METHOD_DEPRECATED",
+        { stage: "plan", migration: "src/operations/decompose.ts" },
+      );
     },
     runAsSession: async (_agentName, handle, prompt, _opts) => {
       return adapter.sendTurn(handle, prompt, { interactionHandler: NO_OP_INTERACTION_HANDLER });

--- a/src/cli/agents.ts
+++ b/src/cli/agents.ts
@@ -25,7 +25,7 @@ export const _cliAgentsDeps = { getAgentVersion };
  */
 export async function agentsListCommand(config: NaxConfig, _workdir: string): Promise<void> {
   // Create ACP adapters for all known agents and collect version info
-  const adapters = KNOWN_AGENT_NAMES.map((name) => new AcpAgentAdapter(name, config));
+  const adapters = KNOWN_AGENT_NAMES.map((name) => new AcpAgentAdapter(name));
   const agentVersions = await Promise.all(
     adapters.map(async (agent) => ({
       name: agent.name,

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -28,12 +28,14 @@ import { PidRegistry } from "../execution/pid-registry";
 import { buildInteractionBridge } from "../interaction/bridge-builder";
 import { initInteractionChain } from "../interaction/init";
 import { getLogger } from "../logger";
+import { callOp, decomposeOp, planOp } from "../operations";
 import { mapDecomposedStoriesToUserStories } from "../prd/decompose-mapper";
 import { validatePlanOutput } from "../prd/schema";
 import type { PRD, StoryStatus, UserStory } from "../prd/types";
 import type { PrecheckResultWithCode } from "../precheck";
 import { PlanPromptBuilder } from "../prompts";
 import type { PackageSummary } from "../prompts";
+import { createRuntime } from "../runtime";
 import { createAgentManager } from "../runtime/internal/agent-manager-factory";
 import { errorMessage } from "../utils/errors";
 
@@ -231,70 +233,42 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
       rawResponse = await runInteractivePlan();
     }
   } else if (options.auto) {
-    // Auto (one-shot) path — no debate; ACP protocol uses adapter.plan() (session-based)
-    const { taskContext: autoTaskCtx, outputFormat: autoOutputFmt } = new PlanPromptBuilder().build(
-      specContent,
-      codebaseContext,
-      outputPath,
-      relativePackages,
-      packageDetails,
-      config?.project,
-    );
-    const prompt = `${autoTaskCtx}\n\n${autoOutputFmt}`;
-
+    // Auto (one-shot) path — callOp routes via completeAs, returns JSON directly
     const resolvedPlanModel = resolvePlanModelSelection(config, defaultAgentName);
     const agentName = resolvedPlanModel.agent;
     const agentManager = _planDeps.createManager(config);
     if (!agentManager.getAgent(agentName)) throw new Error(`[plan] No agent adapter found for '${agentName}'`);
 
-    logger?.info("plan", "Starting ACP auto planning session", {
+    logger?.info("plan", "Starting auto planning via callOp", {
       agent: agentName,
       model: resolvedPlanModel.modelDef.model,
       workdir,
       feature: options.feature,
-      timeoutSeconds,
     });
-    const pidRegistry = new PidRegistry(workdir);
-    let planError: Error | null = null;
+
+    const rt = createRuntime(config, workdir, { agentManager });
     try {
-      try {
-        await agentManager.planAs(agentName, {
-          prompt,
-          workdir,
-          interactive: false,
-          timeoutSeconds,
-          config,
-          modelTier: resolvedPlanModel.modelTier,
-          modelDef: resolvedPlanModel.modelDef,
-          maxInteractionTurns: config?.agent?.maxInteractionTurns,
+      rawResponse = await callOp(
+        {
+          runtime: rt,
+          packageView: rt.packages.resolve(),
+          packageDir: workdir,
+          agentName,
           featureName: options.feature,
-          onPidSpawned: (pid: number) => pidRegistry.register(pid),
-          sessionRole: "plan",
-        });
-      } catch (err) {
-        planError = err instanceof Error ? err : new Error(String(err));
-        logger?.warn("plan", "ACP auto planning did not complete cleanly; checking for written PRD", {
-          error: planError.message,
-          outputPath,
-        });
-      }
+        },
+        planOp,
+        {
+          specContent,
+          codebaseContext,
+          packages: relativePackages,
+          packageDetails,
+          projectProfile: config?.project,
+        },
+      );
     } finally {
-      await pidRegistry.killAll().catch(() => {});
+      await rt.close().catch(() => {});
     }
-    if (!_planDeps.existsSync(outputPath)) {
-      if (planError) {
-        throw new Error(`[plan] ACP planning failed and no PRD was written: ${planError.message}`, {
-          cause: planError,
-        });
-      }
-      throw new Error(`[plan] ACP agent did not write PRD to ${outputPath}. Check agent logs for errors.`);
-    }
-    if (planError) {
-      logger?.warn("plan", "Proceeding with PRD written by ACP despite incomplete terminal response", {
-        outputPath,
-      });
-    }
-    rawResponse = await _planDeps.readFile(outputPath);
+    await _planDeps.writeFile(outputPath, rawResponse);
   } else {
     rawResponse = await runInteractivePlan();
   }
@@ -608,97 +582,102 @@ export async function planDecomposeCommand(
   const maxAcCount = config?.precheck?.storySizeGate?.maxAcCount ?? Number.POSITIVE_INFINITY;
   const maxReplanAttempts = config?.precheck?.storySizeGate?.maxReplanAttempts ?? 3;
 
-  const decomposeModelDef: import("../config").ModelDef | undefined = resolvedPlanModel.modelDef;
-
-  if (typeof (adapterForCapCheck as { decompose?: unknown }).decompose !== "function") {
-    throw new NaxError(
-      `Agent "${agentName}" does not support decompose() required by plan --decompose`,
-      "DECOMPOSE_NOT_SUPPORTED",
-      { stage: "decompose", agent: agentName, storyId: options.storyId },
-    );
-  }
-
   const debateStages = config?.debate?.stages as unknown as Record<string, DebateStageConfig | undefined>;
   const debateDecompEnabled = config?.debate?.enabled && debateStages?.decompose?.enabled;
 
   let decompStories: DecomposedStory[] | undefined;
   let repairHint = "";
 
-  for (let attempt = 0; attempt < maxReplanAttempts; attempt++) {
-    if (attempt === 0 && debateDecompEnabled) {
-      const decomposeStageConfig = debateStages.decompose as DebateStageConfig;
-      const prompt = await buildDecomposePromptAsync({
-        specContent: "",
-        codebaseContext,
-        workdir,
-        targetStory,
-        siblings,
-        featureName: options.feature,
-        storyId: options.storyId,
-        config,
-      });
-      const debateSession = _planDeps.createDebateSession({
-        storyId: options.storyId,
-        stage: "decompose",
-        stageConfig: decomposeStageConfig,
-        config,
-        workdir,
-        featureName: options.feature,
-        timeoutSeconds,
-        agentManager,
-      });
-      const debateResult = await debateSession.run(prompt);
-      if (debateResult.outcome !== "failed" && debateResult.output) {
-        decompStories = parseDecomposeOutput(debateResult.output);
-      }
-    }
-
-    if (!decompStories) {
-      const effectiveContext = repairHint ? `${codebaseContext}\n\n${repairHint}` : codebaseContext;
-      const result = await agentManager.decomposeAs(agentName, {
-        specContent: "",
-        codebaseContext: effectiveContext,
-        workdir,
-        targetStory,
-        siblings,
-        featureName: options.feature,
-        storyId: options.storyId,
-        config,
-        modelDef: decomposeModelDef,
-      });
-      decompStories = result.stories;
-    }
-
-    // Structural validation: throw immediately — no retry benefit
-    for (const sub of decompStories) {
-      if (!sub.complexity || !sub.testStrategy) {
-        throw new NaxError(`Sub-story "${sub.id}" is missing required routing fields`, "DECOMPOSE_VALIDATION_FAILED", {
-          stage: "decompose",
-          storyId: sub.id,
+  const rt = createRuntime(config, workdir, { agentManager });
+  try {
+    for (let attempt = 0; attempt < maxReplanAttempts; attempt++) {
+      if (attempt === 0 && debateDecompEnabled) {
+        const decomposeStageConfig = debateStages.decompose as DebateStageConfig;
+        const prompt = await buildDecomposePromptAsync({
+          specContent: "",
+          codebaseContext,
+          workdir,
+          targetStory,
+          siblings,
+          featureName: options.feature,
+          storyId: options.storyId,
+          config,
         });
+        const debateSession = _planDeps.createDebateSession({
+          storyId: options.storyId,
+          stage: "decompose",
+          stageConfig: decomposeStageConfig,
+          config,
+          workdir,
+          featureName: options.feature,
+          timeoutSeconds,
+          agentManager,
+        });
+        const debateResult = await debateSession.run(prompt);
+        if (debateResult.outcome !== "failed" && debateResult.output) {
+          decompStories = parseDecomposeOutput(debateResult.output);
+        }
       }
-    }
 
-    // AC-count check: retryable within shared maxReplanAttempts budget
-    const violations = decompStories.filter(
-      (sub) => sub.acceptanceCriteria && sub.acceptanceCriteria.length > maxAcCount,
-    );
-    if (violations.length === 0) break;
+      if (!decompStories) {
+        const effectiveContext = repairHint ? `${codebaseContext}\n\n${repairHint}` : codebaseContext;
+        decompStories = await callOp(
+          {
+            runtime: rt,
+            packageView: rt.packages.resolve(),
+            packageDir: workdir,
+            agentName,
+            featureName: options.feature,
+            storyId: options.storyId,
+          },
+          decomposeOp,
+          {
+            specContent: "",
+            codebaseContext: effectiveContext,
+            targetStory,
+            siblings,
+            maxAcCount: config?.precheck?.storySizeGate?.maxAcCount ?? null,
+          },
+        );
+      }
 
-    const violationSummary = violations
-      .map((v) => `"${v.id}" (${v.acceptanceCriteria.length} ACs, max ${maxAcCount})`)
-      .join(", ");
+      // Structural validation: throw immediately — no retry benefit
+      for (const sub of decompStories) {
+        if (!sub.complexity || !sub.testStrategy) {
+          throw new NaxError(
+            `Sub-story "${sub.id}" is missing required routing fields`,
+            "DECOMPOSE_VALIDATION_FAILED",
+            {
+              stage: "decompose",
+              storyId: sub.id,
+            },
+          );
+        }
+      }
 
-    if (attempt + 1 >= maxReplanAttempts) {
-      throw new NaxError(
-        `Decompose AC repair failed after ${maxReplanAttempts} attempts. Oversized sub-stories: ${violationSummary}`,
-        "DECOMPOSE_VALIDATION_FAILED",
-        { stage: "decompose", storyId: options.storyId },
+      // AC-count check: retryable within shared maxReplanAttempts budget
+      const violations = decompStories.filter(
+        (sub) => sub.acceptanceCriteria && sub.acceptanceCriteria.length > maxAcCount,
       );
-    }
+      if (violations.length === 0) break;
 
-    repairHint = `REPAIR REQUIRED (attempt ${attempt + 1}/${maxReplanAttempts}): The following sub-stories exceeded maxAcCount of ${maxAcCount}: ${violationSummary}. Split each offending story further so every sub-story has at most ${maxAcCount} acceptance criteria.`;
-    decompStories = undefined;
+      const violationSummary = violations
+        .map((v) => `"${v.id}" (${v.acceptanceCriteria.length} ACs, max ${maxAcCount})`)
+        .join(", ");
+
+      if (attempt + 1 >= maxReplanAttempts) {
+        throw new NaxError(
+          `Decompose AC repair failed after ${maxReplanAttempts} attempts. Oversized sub-stories: ${violationSummary}`,
+          "DECOMPOSE_VALIDATION_FAILED",
+          { stage: "decompose", storyId: options.storyId },
+        );
+      }
+
+      repairHint = `REPAIR REQUIRED (attempt ${attempt + 1}/${maxReplanAttempts}): The following sub-stories exceeded maxAcCount of ${maxAcCount}: ${violationSummary}. Split each offending story further so every sub-story has at most ${maxAcCount} acceptance criteria.`;
+      decompStories = undefined;
+    }
+  } finally {
+    await rt.close().catch(() => {});
   }
 
   const subStoriesWithParent: UserStory[] = mapDecomposedStoriesToUserStories(

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -247,8 +247,9 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
     });
 
     const rt = createRuntime(config, workdir, { agentManager });
+    let autoPrd: PRD;
     try {
-      rawResponse = await callOp(
+      autoPrd = await callOp(
         {
           runtime: rt,
           packageView: rt.packages.resolve(),
@@ -260,6 +261,8 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
         {
           specContent,
           codebaseContext,
+          featureName: options.feature,
+          branchName,
           packages: relativePackages,
           packageDetails,
           projectProfile: config?.project,
@@ -268,7 +271,9 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
     } finally {
       await rt.close().catch(() => {});
     }
-    await _planDeps.writeFile(outputPath, rawResponse);
+    await _planDeps.writeFile(outputPath, JSON.stringify({ ...autoPrd, project: projectName }, null, 2));
+    logger?.info("plan", "[OK] PRD written", { outputPath });
+    return outputPath;
   } else {
     rawResponse = await runInteractivePlan();
   }
@@ -359,11 +364,8 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
   // complexity normalization, dependency cross-ref, and forces status → pending.
   const finalPrd = validatePlanOutput(rawResponse, options.feature, branchName);
 
-  // Override project with auto-detected name (validatePlanOutput fills feature/branchName already)
-  finalPrd.project = projectName;
-
-  // Write normalized PRD (overwrites agent-written file with validated/normalized version)
-  await _planDeps.writeFile(outputPath, JSON.stringify(finalPrd, null, 2));
+  // Write normalized PRD — spread to avoid mutating the validated object
+  await _planDeps.writeFile(outputPath, JSON.stringify({ ...finalPrd, project: projectName }, null, 2));
 
   logger?.info("plan", "[OK] PRD written", { outputPath });
 

--- a/src/operations/decompose.ts
+++ b/src/operations/decompose.ts
@@ -1,0 +1,42 @@
+import { parseDecomposeOutput } from "../agents/shared/decompose";
+import { buildDecomposePromptSync } from "../agents/shared/decompose-prompt";
+import type { DecomposedStory } from "../agents/shared/types-extended";
+import { decomposeConfigSelector } from "../config";
+import type { UserStory } from "../prd";
+import type { CompleteOperation } from "./types";
+
+export interface DecomposeOpInput {
+  specContent: string;
+  codebaseContext: string;
+  targetStory?: UserStory;
+  siblings?: UserStory[];
+  maxAcCount?: number | null;
+}
+
+export type DecomposeOpOutput = DecomposedStory[];
+
+type DecomposeConfig = ReturnType<typeof decomposeConfigSelector.select>;
+
+export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput, DecomposeConfig> = {
+  kind: "complete",
+  name: "decompose",
+  stage: "plan",
+  jsonMode: false,
+  config: decomposeConfigSelector,
+  build(input, _ctx) {
+    const prompt = buildDecomposePromptSync({
+      specContent: input.specContent,
+      codebaseContext: input.codebaseContext,
+      targetStory: input.targetStory,
+      siblings: input.siblings,
+      maxAcCount: input.maxAcCount,
+    });
+    return {
+      role: { id: "role", content: "", overridable: false },
+      task: { id: "task", content: prompt, overridable: false },
+    };
+  },
+  parse(output, _input, _ctx) {
+    return parseDecomposeOutput(output);
+  },
+};

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,4 +1,8 @@
 export { callOp } from "./call";
+export { planOp } from "./plan";
+export type { PlanOpInput } from "./plan";
+export { decomposeOp } from "./decompose";
+export type { DecomposeOpInput, DecomposeOpOutput } from "./decompose";
 export { buildHopCallback, _buildHopCallbackDeps } from "./build-hop-callback";
 export type { BuildHopCallbackContext } from "./build-hop-callback";
 export { classifyRouteOp } from "./classify-route";

--- a/src/operations/plan.ts
+++ b/src/operations/plan.ts
@@ -1,0 +1,40 @@
+import { planConfigSelector } from "../config";
+import type { ProjectProfile } from "../config/runtime-types";
+import { PlanPromptBuilder } from "../prompts";
+import type { PackageSummary } from "../prompts";
+import type { CompleteOperation } from "./types";
+
+export interface PlanOpInput {
+  specContent: string;
+  codebaseContext: string;
+  packages?: string[];
+  packageDetails?: PackageSummary[];
+  projectProfile?: ProjectProfile;
+}
+
+type PlanConfig = ReturnType<typeof planConfigSelector.select>;
+
+export const planOp: CompleteOperation<PlanOpInput, string, PlanConfig> = {
+  kind: "complete",
+  name: "plan",
+  stage: "plan",
+  jsonMode: false,
+  config: planConfigSelector,
+  build(input, _ctx) {
+    const { taskContext, outputFormat } = new PlanPromptBuilder().build(
+      input.specContent,
+      input.codebaseContext,
+      undefined,
+      input.packages,
+      input.packageDetails,
+      input.projectProfile,
+    );
+    return {
+      role: { id: "role", content: "", overridable: false },
+      task: { id: "task", content: `${taskContext}\n\n${outputFormat}`, overridable: false },
+    };
+  },
+  parse(output, _input, _ctx) {
+    return output;
+  },
+};

--- a/src/operations/plan.ts
+++ b/src/operations/plan.ts
@@ -1,5 +1,7 @@
 import { planConfigSelector } from "../config";
 import type { ProjectProfile } from "../config/runtime-types";
+import { validatePlanOutput } from "../prd/schema";
+import type { PRD } from "../prd/types";
 import { PlanPromptBuilder } from "../prompts";
 import type { PackageSummary } from "../prompts";
 import type { CompleteOperation } from "./types";
@@ -7,6 +9,8 @@ import type { CompleteOperation } from "./types";
 export interface PlanOpInput {
   specContent: string;
   codebaseContext: string;
+  featureName: string;
+  branchName: string;
   packages?: string[];
   packageDetails?: PackageSummary[];
   projectProfile?: ProjectProfile;
@@ -14,7 +18,7 @@ export interface PlanOpInput {
 
 type PlanConfig = ReturnType<typeof planConfigSelector.select>;
 
-export const planOp: CompleteOperation<PlanOpInput, string, PlanConfig> = {
+export const planOp: CompleteOperation<PlanOpInput, PRD, PlanConfig> = {
   kind: "complete",
   name: "plan",
   stage: "plan",
@@ -34,7 +38,7 @@ export const planOp: CompleteOperation<PlanOpInput, string, PlanConfig> = {
       task: { id: "task", content: `${taskContext}\n\n${outputFormat}`, overridable: false },
     };
   },
-  parse(output, _input, _ctx) {
-    return output;
+  parse(output, input, _ctx) {
+    return validatePlanOutput(output, input.featureName, input.branchName);
   },
 };

--- a/test/unit/agents/acp/adapter-phase1.test.ts
+++ b/test/unit/agents/acp/adapter-phase1.test.ts
@@ -10,7 +10,6 @@
 
 import { describe, expect, test } from "bun:test";
 import { AcpAgentAdapter, computeAcpHandle } from "../../../../src/agents/acp/adapter";
-import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
 import type { SessionDescriptor } from "../../../../src/session/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -18,7 +17,7 @@ import type { SessionDescriptor } from "../../../../src/session/types";
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("AcpAgentAdapter.deriveSessionName", () => {
-  const adapter = new AcpAgentAdapter("claude", DEFAULT_CONFIG);
+  const adapter = new AcpAgentAdapter("claude");
   const workdir = "/tmp/test-project";
 
   function makeDescriptor(overrides: Partial<SessionDescriptor>): SessionDescriptor {

--- a/test/unit/agents/acp/adapter-phase3.test.ts
+++ b/test/unit/agents/acp/adapter-phase3.test.ts
@@ -5,88 +5,28 @@
  * onPidSpawned?: (pid: number) => void. The adapter fires the callback
  * immediately after spawning a process (inside createClient / SpawnAcpClient).
  *
- * Covered:
- *   - plan() passes onPidSpawned through to createClient
- *
  * Note: run() onPidSpawned tests removed in ADR-019 Phase D —
  * AgentAdapter.run() was deleted from the interface.
+ *
+ * Note: plan() onPidSpawned tests removed in ADR-018 Wave 3 —
+ * AgentAdapter.plan() was deprecated in favour of callOp(ctx, planOp, input).
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { AcpAgentAdapter, _acpAdapterDeps } from "../../../../src/agents/acp/adapter";
-import { withDepsRestore } from "../../../helpers/deps";
+import { describe, expect, test } from "bun:test";
+import { AcpAgentAdapter } from "../../../../src/agents/acp/adapter";
 import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
-import { makeClient, makeSession } from "./adapter.test";
-
-// ─────────────────────────────────────────────────────────────────────────────
-// plan() — passes onPidSpawned through
-// ─────────────────────────────────────────────────────────────────────────────
 
 describe("AcpAgentAdapter.plan() — onPidSpawned threading", () => {
-  withDepsRestore(_acpAdapterDeps, ["createClient", "sleep"]);
-
-  let adapter: AcpAgentAdapter;
-
-  beforeEach(() => {
-    adapter = new AcpAgentAdapter("claude", DEFAULT_CONFIG);
-    _acpAdapterDeps.sleep = async () => {};
-  });
-
-  afterEach(() => {
-    mock.restore();
-  });
-
-  test("plan() passes onPidSpawned to createClient", async () => {
-    const session = makeSession();
-    let capturedCallback: ((pid: number) => void) | undefined;
-
-    _acpAdapterDeps.createClient = mock(
-      (
-        _cmdStr: string,
-        _cwd?: string,
-        _timeoutSeconds?: number,
-        onPidSpawned?: (pid: number) => void,
-      ) => {
-        capturedCallback = onPidSpawned;
-        return makeClient(session);
-      },
-    );
-
-    const pids: number[] = [];
-    await adapter.plan({
-      prompt: "plan this feature",
-      workdir: "/tmp/test-project",
-      modelTier: "balanced",
-      interactive: false,
-      onPidSpawned: (pid: number) => { pids.push(pid); },
-    }).catch(() => {});
-
-    expect(capturedCallback).toBeDefined();
-  });
-
-  test("plan() passes undefined when onPidSpawned absent", async () => {
-    const session = makeSession();
-    let callbackArg: unknown = "NOT_CHECKED";
-
-    _acpAdapterDeps.createClient = mock(
-      (
-        _cmdStr: string,
-        _cwd?: string,
-        _timeoutSeconds?: number,
-        onPidSpawned?: (pid: number) => void,
-      ) => {
-        callbackArg = onPidSpawned;
-        return makeClient(session);
-      },
-    );
-
-    await adapter.plan({
-      prompt: "plan this feature",
-      workdir: "/tmp/test-project",
-      modelTier: "balanced",
-      interactive: false,
-    }).catch(() => {});
-
-    expect(callbackArg).toBeUndefined();
+  test("plan() throws ADAPTER_METHOD_DEPRECATED (onPidSpawned threading removed with deprecation)", async () => {
+    const adapter = new AcpAgentAdapter("claude", DEFAULT_CONFIG);
+    await expect(
+      adapter.plan({
+        prompt: "plan this feature",
+        workdir: "/tmp/test-project",
+        modelTier: "balanced",
+        interactive: false,
+        onPidSpawned: (pid: number) => { void pid; },
+      }),
+    ).rejects.toMatchObject({ code: "ADAPTER_METHOD_DEPRECATED" });
   });
 });

--- a/test/unit/agents/acp/adapter-phase3.test.ts
+++ b/test/unit/agents/acp/adapter-phase3.test.ts
@@ -14,11 +14,10 @@
 
 import { describe, expect, test } from "bun:test";
 import { AcpAgentAdapter } from "../../../../src/agents/acp/adapter";
-import { DEFAULT_CONFIG } from "../../../../src/config/defaults";
 
 describe("AcpAgentAdapter.plan() — onPidSpawned threading", () => {
   test("plan() throws ADAPTER_METHOD_DEPRECATED (onPidSpawned threading removed with deprecation)", async () => {
-    const adapter = new AcpAgentAdapter("claude", DEFAULT_CONFIG);
+    const adapter = new AcpAgentAdapter("claude");
     await expect(
       adapter.plan({
         prompt: "plan this feature",

--- a/test/unit/agents/acp/decompose.test.ts
+++ b/test/unit/agents/acp/decompose.test.ts
@@ -1,413 +1,56 @@
 /**
- * Tests for AcpAgentAdapter.decompose() — ACP-005
+ * Tests for AcpAgentAdapter.decompose() — deprecated (ADR-018 Wave 3)
  *
- * Covers:
- * - decompose() returns DecomposeResult with parsed stories from ACP response
- * - decompose() reuses existing buildDecomposePrompt and parseDecomposeOutput
- * - decompose() respects model override from options.modelDef
- * - decompose() handles ACP errors gracefully with clear error messages
- * - decompose() validates story parsing and array content
+ * decompose() is deprecated in favour of callOp(ctx, decomposeOp, input).
+ * The method now throws NaxError("ADAPTER_METHOD_DEPRECATED") immediately.
+ *
+ * Behavioral tests for the decompose flow live in:
+ *   test/unit/operations/decompose.test.ts
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { randomUUID } from "node:crypto";
-import { AcpAgentAdapter, _acpAdapterDeps } from "../../../../src/agents/acp/adapter";
+import { describe, expect, test } from "bun:test";
+import { AcpAgentAdapter } from "../../../../src/agents/acp/adapter";
 import type { DecomposeOptions } from "../../../../src/agents/types";
-import { makeClient, makeSession } from "./adapter.test";
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Fixtures
-// ─────────────────────────────────────────────────────────────────────────────
-
-const SAMPLE_SPEC = `# Feature Spec
-This is the specification for a new feature.
-## Overview
-Build an authentication system.`;
-
-const SAMPLE_STORIES_JSON = JSON.stringify([
-  {
-    id: "US-001",
-    title: "Implement login endpoint",
-    description: "Create a POST /auth/login endpoint",
-    acceptanceCriteria: ["Returns JWT on valid credentials"],
-    tags: ["security", "api"],
-    dependencies: [],
-    complexity: "medium",
-    contextFiles: ["src/auth/login.ts"],
-    reasoning: "Standard auth endpoint",
-    estimatedLOC: 80,
-    risks: ["Token expiry handling"],
-    testStrategy: "test-after",
-  },
-]);
-
-const DECOMPOSE_WORKDIR = `/tmp/nax-decompose-test-${randomUUID()}`;
+import { NaxError } from "../../../../src/errors";
 
 function makeDecomposeOptions(overrides: Partial<DecomposeOptions> = {}): DecomposeOptions {
   return {
-    specContent: SAMPLE_SPEC,
-    workdir: DECOMPOSE_WORKDIR,
-    codebaseContext: "TypeScript project with Express",
+    specContent: "# Feature Spec",
+    workdir: "/tmp/nax-test",
+    codebaseContext: "TypeScript project",
     modelDef: { provider: "anthropic", model: "claude-sonnet-4-5", env: {} },
     ...overrides,
   };
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// decompose()
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("decompose()", () => {
-  const origCreateClient = _acpAdapterDeps.createClient;
-  const origSleep = _acpAdapterDeps.sleep;
-
-  beforeEach(() => {
-    _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
-  });
-
-  afterEach(() => {
-    _acpAdapterDeps.createClient = origCreateClient;
-    _acpAdapterDeps.sleep = origSleep;
-    mock.restore();
-  });
-
-  test("returns DecomposeResult with parsed stories from ACP response", async () => {
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: SAMPLE_STORIES_JSON }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 200, output_tokens: 300 },
-      }),
+describe("decompose() — deprecated (ADR-018 Wave 3)", () => {
+  test("throws NaxError with code ADAPTER_METHOD_DEPRECATED", async () => {
+    const adapter = new AcpAgentAdapter("claude");
+    await expect(adapter.decompose(makeDecomposeOptions())).rejects.toMatchObject({
+      code: "ADAPTER_METHOD_DEPRECATED",
     });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    const result = await new AcpAgentAdapter("claude").decompose(makeDecomposeOptions());
-
-    expect(result).toBeDefined();
-    expect(Array.isArray(result.stories)).toBe(true);
-    expect(result.stories.length).toBeGreaterThan(0);
   });
 
-  test("parsed stories contain required fields (id, title, complexity)", async () => {
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: SAMPLE_STORIES_JSON }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 200, output_tokens: 300 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    const result = await new AcpAgentAdapter("claude").decompose(makeDecomposeOptions());
-    const story = result.stories[0];
-
-    expect(story.id).toBe("US-001");
-    expect(story.title).toBe("Implement login endpoint");
-    expect(story.complexity).toBe("medium");
-  });
-
-  test("sends a prompt derived from buildDecomposePrompt (includes specContent)", async () => {
-    let capturedPrompt = "";
-    const session = makeSession({
-      promptFn: async (text: string) => {
-        capturedPrompt = text;
-        return {
-          messages: [{ role: "assistant", content: SAMPLE_STORIES_JSON }],
-          stopReason: "end_turn",
-          cumulative_token_usage: { input_tokens: 200, output_tokens: 300 },
-        };
-      },
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    await new AcpAgentAdapter("claude").decompose(makeDecomposeOptions({ specContent: SAMPLE_SPEC }));
-
-    // The prompt must include the spec content (reuses buildDecomposePrompt)
-    expect(capturedPrompt).toContain("# Feature Spec");
-  });
-
-  test("sends a prompt that includes codebase context (reuses buildDecomposePrompt)", async () => {
-    let capturedPrompt = "";
-    const session = makeSession({
-      promptFn: async (text: string) => {
-        capturedPrompt = text;
-        return {
-          messages: [{ role: "assistant", content: SAMPLE_STORIES_JSON }],
-          stopReason: "end_turn",
-          cumulative_token_usage: { input_tokens: 200, output_tokens: 300 },
-        };
-      },
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    const codebaseCtx = "Custom codebase context for testing";
-    await new AcpAgentAdapter("claude").decompose(makeDecomposeOptions({ codebaseContext: codebaseCtx }));
-
-    expect(capturedPrompt).toContain(codebaseCtx);
-  });
-
-  test("respects model override from options.modelDef", async () => {
-    let capturedCmd = "";
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: SAMPLE_STORIES_JSON }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 200, output_tokens: 300 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((cmd: string) => {
-      capturedCmd = cmd;
-      return makeClient(session);
-    });
-
-    const customModel = "claude-opus-4-6";
-    await new AcpAgentAdapter("claude").decompose(
-      makeDecomposeOptions({ modelDef: { provider: "anthropic", model: customModel, env: {} } }),
-    );
-
-    expect(capturedCmd).toContain(customModel);
-  });
-
-  test("closes the ACP session after completion", async () => {
-    let closeCalled = false;
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: SAMPLE_STORIES_JSON }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 200, output_tokens: 300 },
-      }),
-      closeFn: async () => { closeCalled = true; },
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    await new AcpAgentAdapter("claude").decompose(makeDecomposeOptions());
-    expect(closeCalled).toBe(true);
-  });
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// decompose() — ACP error handling
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("decompose() — ACP error handling", () => {
-  const origCreateClient = _acpAdapterDeps.createClient;
-  const origSleep = _acpAdapterDeps.sleep;
-
-  beforeEach(() => {
-    _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
-  });
-
-  afterEach(() => {
-    _acpAdapterDeps.createClient = origCreateClient;
-    _acpAdapterDeps.sleep = origSleep;
-    mock.restore();
-  });
-
-  test("propagates ACP errors when session prompt throws", async () => {
-    const session = makeSession({
-      promptFn: async (_text: string) => {
-        throw new Error("ACP network error");
-      },
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    await expect(
-      new AcpAgentAdapter("claude").decompose(makeDecomposeOptions()),
-    ).rejects.toThrow();
-  });
-
-  test("error message includes acp-adapter context prefix on failure", async () => {
-    const session = makeSession({
-      promptFn: async (_text: string) => {
-        throw new Error("timeout");
-      },
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    let errorMessage = "";
+  test("error is a NaxError instance", async () => {
+    const adapter = new AcpAgentAdapter("claude");
+    let caught: unknown;
     try {
-      await new AcpAgentAdapter("claude").decompose(makeDecomposeOptions());
+      await adapter.decompose(makeDecomposeOptions());
     } catch (err) {
-      errorMessage = (err as Error).message;
+      caught = err;
     }
-    expect(errorMessage).toMatch(/\[acp-adapter\]/);
+    expect(caught).toBeInstanceOf(NaxError);
   });
 
-  test("throws when ACP response cannot be parsed as JSON story array", async () => {
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: "This is not valid JSON" }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 50, output_tokens: 10 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    await expect(
-      new AcpAgentAdapter("claude").decompose(makeDecomposeOptions()),
-    ).rejects.toThrow();
-  });
-
-  test("throws when ACP returns an empty story array", async () => {
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: "[]" }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 50, output_tokens: 5 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    await expect(
-      new AcpAgentAdapter("claude").decompose(makeDecomposeOptions()),
-    ).rejects.toThrow();
-  });
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// decompose() — session context fields forwarding
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("decompose() — session context fields forwarding", () => {
-  const origCreateClient = _acpAdapterDeps.createClient;
-  const origSleep = _acpAdapterDeps.sleep;
-
-  beforeEach(() => {
-    _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
-  });
-
-  afterEach(() => {
-    _acpAdapterDeps.createClient = origCreateClient;
-    _acpAdapterDeps.sleep = origSleep;
-    mock.restore();
-  });
-
-  test("forwards options.featureName to complete() call", async () => {
-    let completeCalled = false;
-    let capturedOptions: any = {};
+  test("error message references callOp and decomposeOp", async () => {
     const adapter = new AcpAgentAdapter("claude");
-    const origComplete = adapter.complete.bind(adapter);
-
-    adapter.complete = mock(async (prompt: string, options?: any) => {
-      completeCalled = true;
-      capturedOptions = options;
-      return origComplete(prompt, options);
-    });
-
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: SAMPLE_STORIES_JSON }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 200, output_tokens: 300 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    const featureName = "spec-decomposition";
-    await adapter.decompose(makeDecomposeOptions({ featureName }));
-
-    expect(completeCalled).toBe(true);
-    expect(capturedOptions.featureName).toBe(featureName);
-  });
-
-  test("forwards options.storyId to complete() call", async () => {
-    let capturedOptions: any = {};
-    const adapter = new AcpAgentAdapter("claude");
-    const origComplete = adapter.complete.bind(adapter);
-
-    adapter.complete = mock(async (prompt: string, options?: any) => {
-      capturedOptions = options;
-      return origComplete(prompt, options);
-    });
-
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: SAMPLE_STORIES_JSON }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 200, output_tokens: 300 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    const storyId = "US-123";
-    await adapter.decompose(makeDecomposeOptions({ storyId }));
-
-    expect(capturedOptions.storyId).toBe(storyId);
-  });
-
-  test("uses sessionRole 'decompose' when options.sessionRole is not set", async () => {
-    let capturedOptions: any = {};
-    const adapter = new AcpAgentAdapter("claude");
-    const origComplete = adapter.complete.bind(adapter);
-
-    adapter.complete = mock(async (prompt: string, options?: any) => {
-      capturedOptions = options;
-      return origComplete(prompt, options);
-    });
-
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: SAMPLE_STORIES_JSON }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 200, output_tokens: 300 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    await adapter.decompose(makeDecomposeOptions());
-
-    expect(capturedOptions.sessionRole).toBe("decompose");
-  });
-
-  test("uses options.sessionRole when provided instead of default 'decompose'", async () => {
-    let capturedOptions: any = {};
-    const adapter = new AcpAgentAdapter("claude");
-    const origComplete = adapter.complete.bind(adapter);
-
-    adapter.complete = mock(async (prompt: string, options?: any) => {
-      capturedOptions = options;
-      return origComplete(prompt, options);
-    });
-
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: SAMPLE_STORIES_JSON }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 200, output_tokens: 300 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    const customRole = "custom-decompose-role";
-    await adapter.decompose(makeDecomposeOptions({ sessionRole: customRole }));
-
-    expect(capturedOptions.sessionRole).toBe(customRole);
-  });
-
-  test("forwards featureName and storyId together to complete()", async () => {
-    let capturedOptions: any = {};
-    const adapter = new AcpAgentAdapter("claude");
-    const origComplete = adapter.complete.bind(adapter);
-
-    adapter.complete = mock(async (prompt: string, options?: any) => {
-      capturedOptions = options;
-      return origComplete(prompt, options);
-    });
-
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: SAMPLE_STORIES_JSON }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 200, output_tokens: 300 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    const featureName = "feature-x";
-    const storyId = "story-y";
-    await adapter.decompose(makeDecomposeOptions({ featureName, storyId }));
-
-    expect(capturedOptions.featureName).toBe(featureName);
-    expect(capturedOptions.storyId).toBe(storyId);
+    let message = "";
+    try {
+      await adapter.decompose(makeDecomposeOptions());
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("callOp");
+    expect(message).toContain("decomposeOp");
   });
 });

--- a/test/unit/agents/acp/plan.test.ts
+++ b/test/unit/agents/acp/plan.test.ts
@@ -1,279 +1,57 @@
 /**
- * Tests for AcpAgentAdapter.plan() — ACP-005
+ * Tests for AcpAgentAdapter.plan() — deprecated (ADR-018 Wave 3)
  *
- * Covers:
- * - plan() returns PlanResult with specContent from ACP session response
- * - plan() in non-interactive mode works end-to-end via ACP one-shot
- * - plan() in interactive mode throws clear 'not yet supported via ACP' error
- * - plan() handles ACP errors gracefully with clear error messages
- * - plan() respects model override from options.modelDef
+ * plan() is deprecated in favour of callOp(ctx, planOp, input).
+ * The method now throws NaxError("ADAPTER_METHOD_DEPRECATED") immediately.
+ *
+ * Behavioral tests for the plan flow live in:
+ *   test/unit/operations/plan.test.ts
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { randomUUID } from "node:crypto";
-import { AcpAgentAdapter, _acpAdapterDeps } from "../../../../src/agents/acp/adapter";
+import { describe, expect, test } from "bun:test";
+import { AcpAgentAdapter } from "../../../../src/agents/acp/adapter";
 import type { PlanOptions } from "../../../../src/agents/types";
-import { makeClient, makeSession } from "./adapter.test";
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Fixtures
-// ─────────────────────────────────────────────────────────────────────────────
-
-const SAMPLE_SPEC = `# Feature Spec
-This is the specification for a new feature.
-## Overview
-Build an authentication system.`;
-
-const PLAN_WORKDIR = `/tmp/nax-plan-test-${randomUUID()}`;
+import { NaxError } from "../../../../src/errors";
 
 function makePlanOptions(overrides: Partial<PlanOptions> = {}): PlanOptions {
   return {
     prompt: "Plan an authentication system",
-    workdir: PLAN_WORKDIR,
+    workdir: "/tmp/nax-test",
     interactive: false,
-    codebaseContext: "TypeScript project with Express",
+    codebaseContext: "TypeScript project",
     modelDef: { provider: "anthropic", model: "claude-sonnet-4-5", env: {} },
     ...overrides,
   };
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// plan() — non-interactive mode
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("plan() — non-interactive mode", () => {
-  const origCreateClient = _acpAdapterDeps.createClient;
-  const origSleep = _acpAdapterDeps.sleep;
-
-  beforeEach(() => {
-    _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
-  });
-
-  afterEach(() => {
-    _acpAdapterDeps.createClient = origCreateClient;
-    _acpAdapterDeps.sleep = origSleep;
-    mock.restore();
-  });
-
-  test("returns PlanResult with specContent from ACP session response", async () => {
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: SAMPLE_SPEC }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 100, output_tokens: 200 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
+describe("plan() — deprecated (ADR-018 Wave 3)", () => {
+  test("throws NaxError with code ADAPTER_METHOD_DEPRECATED", async () => {
     const adapter = new AcpAgentAdapter("claude");
-    const result = await adapter.plan(makePlanOptions({ interactive: false }));
-
-    expect(result).toBeDefined();
-    expect(typeof result.specContent).toBe("string");
-    expect(result.specContent.length).toBeGreaterThan(0);
-  });
-
-  test("specContent matches the assistant text from the ACP response", async () => {
-    const expectedSpec = "# My Feature Spec\n\nThis is the plan.";
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: expectedSpec }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 50, output_tokens: 100 },
-      }),
+    await expect(adapter.plan(makePlanOptions())).rejects.toMatchObject({
+      code: "ADAPTER_METHOD_DEPRECATED",
     });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    const result = await new AcpAgentAdapter("claude").plan(makePlanOptions({ interactive: false }));
-    expect(result.specContent).toBe(expectedSpec);
   });
 
-  test("sends the planning prompt to the ACP session", async () => {
-    let receivedPrompt = "";
-    const session = makeSession({
-      promptFn: async (text: string) => {
-        receivedPrompt = text;
-        return {
-          messages: [{ role: "assistant", content: "Generated spec" }],
-          stopReason: "end_turn",
-          cumulative_token_usage: { input_tokens: 50, output_tokens: 100 },
-        };
-      },
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    const opts = makePlanOptions({ prompt: "Plan an OAuth2 flow", interactive: false });
-    await new AcpAgentAdapter("claude").plan(opts);
-
-    expect(receivedPrompt).toContain("Plan an OAuth2 flow");
-  });
-
-  test("respects model override from options.modelDef", async () => {
-    let capturedCmd = "";
-    const session = makeSession();
-    _acpAdapterDeps.createClient = mock((cmd: string) => {
-      capturedCmd = cmd;
-      return makeClient(session);
-    });
-
-    const customModel = "claude-opus-4-6";
-    await new AcpAgentAdapter("claude").plan(
-      makePlanOptions({
-        interactive: false,
-        modelDef: { provider: "anthropic", model: customModel, env: {} },
-      }),
-    );
-
-    expect(capturedCmd).toContain(customModel);
-  });
-
-  test("closes the ACP session after completion", async () => {
-    let closeCalled = false;
-    const session = makeSession({ closeFn: async () => { closeCalled = true; } });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    await new AcpAgentAdapter("claude").plan(makePlanOptions({ interactive: false }));
-    expect(closeCalled).toBe(true);
-  });
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// plan() — interactive mode (PLN-002)
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("plan() — interactive mode", () => {
-  const origCreateClient = _acpAdapterDeps.createClient;
-  const origSleep = _acpAdapterDeps.sleep;
-
-  beforeEach(() => {
-    _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
-  });
-
-  afterEach(() => {
-    _acpAdapterDeps.createClient = origCreateClient;
-    _acpAdapterDeps.sleep = origSleep;
-    mock.restore();
-  });
-
-  test("supports interactive mode with multi-turn ACP session", async () => {
-    let questionsAsked: string[] = [];
-    const session = makeSession({
-      promptFn: async (text: string) => {
-        questionsAsked.push(text);
-        return {
-          messages: [{ role: "assistant", content: SAMPLE_SPEC }],
-          stopReason: "end_turn",
-          cumulative_token_usage: { input_tokens: 100, output_tokens: 200 },
-        };
-      },
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
+  test("error is a NaxError instance", async () => {
     const adapter = new AcpAgentAdapter("claude");
-    const result = await adapter.plan(makePlanOptions({ interactive: true }));
-
-    expect(result).toBeDefined();
-    expect(result.specContent).toBeDefined();
-  });
-
-  test("passes interactionBridge to run() in interactive mode", async () => {
-    let bridgePassed = false;
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: SAMPLE_SPEC }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 50, output_tokens: 100 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    const mockBridge = {
-      detectQuestion: async (_text: string) => false,
-      onQuestionDetected: async (text: string) => text,
-    };
-
-    const adapter = new AcpAgentAdapter("claude");
-    await adapter.plan(makePlanOptions({ interactive: true, interactionBridge: mockBridge }));
-
-    // If we reach here without error, the bridge was passed through successfully
-    expect(true).toBe(true);
-  });
-
-  test("calls AcpClient when plan() is called in interactive mode", async () => {
-    let clientCreated = false;
-    const session = makeSession();
-    _acpAdapterDeps.createClient = mock((_cmd: string) => {
-      clientCreated = true;
-      return makeClient(session);
-    });
-
-    const adapter = new AcpAgentAdapter("claude");
-    await adapter.plan(makePlanOptions({ interactive: true }));
-
-    expect(clientCreated).toBe(true);
-  });
-});
-
-// ─────────────────────────────────────────────────────────────────────────────
-// plan() — ACP error handling
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("plan() — ACP error handling", () => {
-  const origCreateClient = _acpAdapterDeps.createClient;
-  const origSleep = _acpAdapterDeps.sleep;
-
-  beforeEach(() => {
-    _acpAdapterDeps.sleep = mock(async (_ms: number) => {});
-  });
-
-  afterEach(() => {
-    _acpAdapterDeps.createClient = origCreateClient;
-    _acpAdapterDeps.sleep = origSleep;
-    mock.restore();
-  });
-
-  test("propagates ACP errors with a clear error message", async () => {
-    const session = makeSession({
-      promptFn: async (_text: string) => {
-        throw new Error("ACP connection refused");
-      },
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    await expect(
-      new AcpAgentAdapter("claude").plan(makePlanOptions({ interactive: false })),
-    ).rejects.toThrow();
-  });
-
-  test("error message includes acp-adapter context prefix", async () => {
-    const session = makeSession({
-      promptFn: async (_text: string) => {
-        throw new Error("session dropped");
-      },
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    let errorMessage = "";
+    let caught: unknown;
     try {
-      await new AcpAgentAdapter("claude").plan(makePlanOptions({ interactive: false }));
+      await adapter.plan(makePlanOptions());
     } catch (err) {
-      errorMessage = (err as Error).message;
+      caught = err;
     }
-    expect(errorMessage).toMatch(/\[acp-adapter\]/);
+    expect(caught).toBeInstanceOf(NaxError);
   });
 
-  test("throws when ACP session returns empty spec content", async () => {
-    const session = makeSession({
-      promptFn: async (_text: string) => ({
-        messages: [{ role: "assistant", content: "   " }],
-        stopReason: "end_turn",
-        cumulative_token_usage: { input_tokens: 10, output_tokens: 0 },
-      }),
-    });
-    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
-
-    await expect(
-      new AcpAgentAdapter("claude").plan(makePlanOptions({ interactive: false })),
-    ).rejects.toThrow();
+  test("error message references callOp and planOp", async () => {
+    const adapter = new AcpAgentAdapter("claude");
+    let message = "";
+    try {
+      await adapter.plan(makePlanOptions());
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("callOp");
+    expect(message).toContain("planOp");
   });
 });

--- a/test/unit/cli/plan-debate.test.ts
+++ b/test/unit/cli/plan-debate.test.ts
@@ -18,7 +18,7 @@ import { join } from "node:path";
 import { _planDeps, planCommand } from "../../../src/cli/plan";
 import type { DebateResult } from "../../../src/debate/types";
 import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
-import { makeMockAgentManager } from "../../helpers";
+import { makeMockAgentManager, makeNaxConfig } from "../../helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -26,11 +26,11 @@ import { makeMockAgentManager } from "../../helpers";
 
 function makeMockPlanManager(
   planFn?: (agentName: string, opts: any) => Promise<{ specContent: string }>,
+  completeFn?: (name: string, prompt: string, opts: any) => Promise<{ output: string; costUsd: number; source: "exact" | "estimated" | "fallback" }>,
 ) {
   return makeMockAgentManager({
-    planAsFn: planFn
-      ? async (name: string, opts: any) => planFn(name, opts)
-      : undefined,
+    planAsFn: planFn ? async (name: string, opts: any) => planFn(name, opts) : undefined,
+    completeAsFn: completeFn,
   });
 }
 
@@ -233,7 +233,7 @@ describe("planCommand — debate integration (US-004)", () => {
     _planDeps.createManager = mock(() =>
       makeMockPlanManager(
         undefined,
-        async (_name: string, _opts: any) => ({ output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "claude" }),
+        async (_name: string, _prompt: string, _opts: any) => ({ output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const }),
       ),
     );
     _planDeps.createDebateSession = origCreateDebateSession;
@@ -314,7 +314,7 @@ describe("planCommand — debate integration (US-004)", () => {
     _planDeps.createManager = mock(() =>
       makeMockPlanManager(
         undefined,
-        async (_name: string, _opts: any) => { adapterComplete(); return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "claude" }; },
+        async (_name: string, _prompt: string, _opts: any) => { adapterComplete(); return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const }; },
       ),
     );
 
@@ -347,10 +347,13 @@ describe("planCommand — debate integration (US-004)", () => {
   // AC2: debate disabled → adapter.plan() called exactly once (ACP auto path), no debate
   // ─────────────────────────────────────────────────────────────────────────
 
-  test("AC2: adapter.plan() called exactly once when debate.enabled=false", async () => {
-    const adapterPlan = mock(async () => {});
+  test("AC2: adapter.complete() called exactly once when debate.enabled=false", async () => {
+    const completeCalls: string[] = [];
     _planDeps.createManager = mock(() =>
-      makeMockPlanManager(async (_name: string, _opts: any) => { adapterPlan(); return { specContent: "" }; }),
+      makeMockPlanManager(undefined, async (_name, _prompt, _opts) => {
+        completeCalls.push("called");
+        return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
+      }),
     );
     _planDeps.existsSync = mock(() => true);
     _planDeps.readFile = mock(async (p: string) =>
@@ -362,18 +365,21 @@ describe("planCommand — debate integration (US-004)", () => {
 
     await planCommand(
       tmpDir,
-      { debate: { enabled: false, agents: 0, stages: {} as never } } as NaxConfig,
+      makeNaxConfig({ debate: { enabled: false } } as any),
       { from: "/spec.md", feature: "debate-plan", auto: true },
     );
 
-    expect(adapterPlan).toHaveBeenCalledTimes(1);
+    expect(completeCalls).toHaveLength(1);
     expect(createDebateMock).not.toHaveBeenCalled();
   });
 
-  test("AC2: adapter.plan() called exactly once when debate config is absent", async () => {
-    const adapterPlan = mock(async () => {});
+  test("AC2: adapter.complete() called exactly once when debate config is absent", async () => {
+    const completeCalls: string[] = [];
     _planDeps.createManager = mock(() =>
-      makeMockPlanManager(async (_name: string, _opts: any) => { adapterPlan(); return { specContent: "" }; }),
+      makeMockPlanManager(undefined, async (_name, _prompt, _opts) => {
+        completeCalls.push("called");
+        return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
+      }),
     );
     _planDeps.existsSync = mock(() => true);
     _planDeps.readFile = mock(async (p: string) =>
@@ -383,20 +389,23 @@ describe("planCommand — debate integration (US-004)", () => {
     const createDebateMock = mock(() => ({ runPlan: mock(async () => DEBATE_PASSED_RESULT) }));
     _planDeps.createDebateSession = createDebateMock;
 
-    await planCommand(tmpDir, {} as NaxConfig, {
+    await planCommand(tmpDir, makeNaxConfig(), {
       from: "/spec.md",
       feature: "debate-plan",
       auto: true,
     });
 
-    expect(adapterPlan).toHaveBeenCalledTimes(1);
+    expect(completeCalls).toHaveLength(1);
     expect(createDebateMock).not.toHaveBeenCalled();
   });
 
-  test("AC2: adapter.plan() called when debate.stages.plan.enabled=false", async () => {
-    const adapterPlan = mock(async () => {});
+  test("AC2: adapter.complete() called when debate.stages.plan.enabled=false", async () => {
+    const completeCalls: string[] = [];
     _planDeps.createManager = mock(() =>
-      makeMockPlanManager(async (_name: string, _opts: any) => { adapterPlan(); return { specContent: "" }; }),
+      makeMockPlanManager(undefined, async (_name, _prompt, _opts) => {
+        completeCalls.push("called");
+        return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
+      }),
     );
     _planDeps.existsSync = mock(() => true);
     _planDeps.readFile = mock(async (p: string) =>
@@ -406,13 +415,13 @@ describe("planCommand — debate integration (US-004)", () => {
     const createDebateMock = mock(() => ({ runPlan: mock(async () => DEBATE_PASSED_RESULT) }));
     _planDeps.createDebateSession = createDebateMock;
 
-    await planCommand(tmpDir, DEBATE_PLAN_STAGE_DISABLED_CONFIG, {
-      from: "/spec.md",
-      feature: "debate-plan",
-      auto: true,
-    });
+    await planCommand(
+      tmpDir,
+      { ...makeNaxConfig(), ...DEBATE_PLAN_STAGE_DISABLED_CONFIG },
+      { from: "/spec.md", feature: "debate-plan", auto: true },
+    );
 
-    expect(adapterPlan).toHaveBeenCalledTimes(1);
+    expect(completeCalls).toHaveLength(1);
     expect(createDebateMock).not.toHaveBeenCalled();
   });
 

--- a/test/unit/cli/plan-debate.test.ts
+++ b/test/unit/cli/plan-debate.test.ts
@@ -16,7 +16,9 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { _planDeps, planCommand } from "../../../src/cli/plan";
+import type { NaxConfig } from "../../../src/config";
 import type { DebateResult } from "../../../src/debate/types";
+import type { PRD } from "../../../src/prd/types";
 import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
 import { makeMockAgentManager, makeNaxConfig } from "../../helpers";
 

--- a/test/unit/cli/plan-decompose-ac-repair.test.ts
+++ b/test/unit/cli/plan-decompose-ac-repair.test.ts
@@ -19,13 +19,15 @@ import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
 import { makeMockAgentManager, makeNaxConfig, makePRD, makeStory } from "../../helpers";
 
 function makeMockDecomposeManager(
-  decomposeFn?: (agentName: string, opts: DecomposeOptions) => Promise<{ stories: DecomposedStory[] }>,
+  decomposeFn?: (agentName: string, opts: any) => Promise<{ stories: DecomposedStory[] }>,
 ) {
   return makeMockAgentManager({
-    decomposeAsFn: decomposeFn
-      ? async (name: string, opts: DecomposeOptions) => decomposeFn(name, opts)
-      : undefined,
-    getAgentFn: () => ({ decompose: async () => ({ stories: [] }) } as any),
+    completeAsFn: decomposeFn
+      ? async (name: string, _prompt: string, opts?: any) => {
+          const result = await decomposeFn(name, opts ?? {});
+          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+        }
+      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
   });
 }
 
@@ -140,7 +142,7 @@ describe("planDecomposeCommand — AC overflow repair loop (issue #227)", () => 
 
     let callCount = 0;
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async (_name: string, _opts: DecomposeOptions) => {
+      makeMockDecomposeManager(async () => {
         callCount++;
         if (callCount === 1) {
           return { stories: [makeOversizedSubStory("US-001-A", 6), makeValidSubStory("US-001-B")] };
@@ -167,7 +169,7 @@ describe("planDecomposeCommand — AC overflow repair loop (issue #227)", () => 
 
     let callCount = 0;
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async (_name: string, _opts: DecomposeOptions) => {
+      makeMockDecomposeManager(async () => {
         callCount++;
         return { stories: [makeOversizedSubStory("US-001-A", 8)] };
       }),
@@ -187,7 +189,7 @@ describe("planDecomposeCommand — AC overflow repair loop (issue #227)", () => 
 
     let callCount = 0;
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async (_name: string, _opts: DecomposeOptions) => {
+      makeMockDecomposeManager(async () => {
         callCount++;
         return { stories: [makeOversizedSubStory("US-001-A", 8)] };
       }),
@@ -211,7 +213,7 @@ describe("planDecomposeCommand — AC overflow repair loop (issue #227)", () => 
     setupBaseDeps(prd);
 
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async (_name: string, _opts: DecomposeOptions) => ({
+      makeMockDecomposeManager(async () => ({
         stories: [
           makeOversizedSubStory("US-001-A", 8),
           makeOversizedSubStory("US-001-B", 7),
@@ -242,7 +244,7 @@ describe("planDecomposeCommand — AC overflow repair loop (issue #227)", () => 
     setupBaseDeps(prd);
 
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async (_name: string, _opts: DecomposeOptions) => ({
+      makeMockDecomposeManager(async () => ({
         stories: [makeOversizedSubStory("US-001-A", 9)],
       })),
     );
@@ -262,33 +264,35 @@ describe("planDecomposeCommand — AC overflow repair loop (issue #227)", () => 
   // Test 4: Repair hint is passed in subsequent decompose calls
   // ──────────────────────────────────────────────────────────────────────────
 
-  test("repair hint containing violation info is appended to codebaseContext on retry", async () => {
+  test("repair hint containing violation info is embedded in prompt on retry", async () => {
     const prd = makePrd();
     setupBaseDeps(prd);
 
-    const capturedContexts: string[] = [];
+    const capturedPrompts: string[] = [];
     let callCount = 0;
 
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async (_name: string, opts: DecomposeOptions) => {
-        capturedContexts.push(opts.codebaseContext);
-        callCount++;
-        if (callCount === 1) {
-          return { stories: [makeOversizedSubStory("US-001-A", 6)] };
-        }
-        return { stories: [makeValidSubStory("US-001-A"), makeValidSubStory("US-001-B")] };
+      makeMockAgentManager({
+        completeAsFn: async (_name: string, prompt: string) => {
+          capturedPrompts.push(prompt);
+          callCount++;
+          const stories = callCount === 1
+            ? [makeOversizedSubStory("US-001-A", 6)]
+            : [makeValidSubStory("US-001-A"), makeValidSubStory("US-001-B")];
+          return { output: JSON.stringify(stories), costUsd: 0, source: "exact" as const };
+        },
       }),
     );
 
     await planDecomposeCommand(tmpDir, makeNaxConfig({ precheck: { storySizeGate: { enabled: true, maxAcCount: 5, maxDescriptionLength: 3000, maxBulletPoints: 12, action: "block", maxReplanAttempts: 3 } }, agent: { default: "claude" } }), { feature: FEATURE, storyId: "US-001" });
 
-    expect(capturedContexts).toHaveLength(2);
+    expect(capturedPrompts).toHaveLength(2);
     // First call: no repair hint
-    expect(capturedContexts[0]).not.toContain("REPAIR REQUIRED");
+    expect(capturedPrompts[0]).not.toContain("REPAIR REQUIRED");
     // Second call: contains repair hint with violation info
-    expect(capturedContexts[1]).toContain("REPAIR REQUIRED");
-    expect(capturedContexts[1]).toContain("US-001-A");
-    expect(capturedContexts[1]).toContain("maxAcCount of 5");
+    expect(capturedPrompts[1]).toContain("REPAIR REQUIRED");
+    expect(capturedPrompts[1]).toContain("US-001-A");
+    expect(capturedPrompts[1]).toContain("maxAcCount of 5");
   });
 });
 

--- a/test/unit/cli/plan-decompose-ac13-14.test.ts
+++ b/test/unit/cli/plan-decompose-ac13-14.test.ts
@@ -9,19 +9,20 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { _planDeps, planDecomposeCommand } from "../../../src/cli/plan";
-import { buildDecomposePromptAsync } from "../../../src/agents/shared/decompose-prompt";
-import type { DecomposeOptions, DecomposedStory } from "../../../src/agents/shared/types-extended";
+import type { DecomposedStory } from "../../../src/agents/shared/types-extended";
 import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
 import { makeMockAgentManager, makeNaxConfig, makePRD, makeStory } from "../../helpers";
 
 function makeMockDecomposeManager(
-  decomposeFn?: (agentName: string, opts: DecomposeOptions) => Promise<{ stories: DecomposedStory[] }>,
+  decomposeFn?: (agentName: string, opts: any) => Promise<{ stories: DecomposedStory[] }>,
 ) {
   return makeMockAgentManager({
-    decomposeAsFn: decomposeFn
-      ? async (name: string, opts: DecomposeOptions) => decomposeFn(name, opts)
-      : undefined,
-    getAgentFn: () => ({ decompose: async () => ({ stories: [] }) } as any),
+    completeAsFn: decomposeFn
+      ? async (name: string, _prompt: string, opts?: any) => {
+          const result = await decomposeFn(name, opts ?? {});
+          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+        }
+      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
   });
 }
 
@@ -115,7 +116,6 @@ const origMkdirp = _planDeps.mkdirp;
 describe("planDecomposeCommand — debate fallback and no-debate path", () => {
   let tmpDir: string;
   let capturedWriteArgs: Array<[string, string]>;
-  let capturedCompleteArgs: string[];
 
   function setupDeps(
     prd: PRD,
@@ -141,21 +141,16 @@ describe("planDecomposeCommand — debate fallback and no-debate path", () => {
     _planDeps.spawnSync = mock(() => ({ stdout: Buffer.from(""), exitCode: 1 }));
     _planDeps.mkdirp = mock(async () => {});
 
-    const fakeAdapter = {
-      decompose: mock(async (options: DecomposeOptions) => {
-        capturedCompleteArgs.push(await buildDecomposePromptAsync(options));
-        return { stories: stories.map(toDecomposedStory) };
-      }),
-    };
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async (_name: string, opts: any) => fakeAdapter.decompose(opts)),
+      makeMockDecomposeManager(async () => ({
+        stories: stories.map(toDecomposedStory),
+      })),
     );
   }
 
   beforeEach(async () => {
     tmpDir = makeTempDir("nax-decompose-test-");
     capturedWriteArgs = [];
-    capturedCompleteArgs = [];
     await mkdir(join(tmpDir, ".nax", "features", FEATURE), { recursive: true });
   });
 

--- a/test/unit/cli/plan-decompose-adapter.test.ts
+++ b/test/unit/cli/plan-decompose-adapter.test.ts
@@ -22,10 +22,12 @@ function makeMockDecomposeManager(
   decomposeFn?: (agentName: string, opts: any) => Promise<{ stories: DecomposedStory[] }>,
 ) {
   return makeMockAgentManager({
-    decomposeAsFn: decomposeFn
-      ? async (name: string, opts: any) => decomposeFn(name, opts)
-      : undefined,
-    getAgentFn: () => ({ decompose: async () => ({ stories: [] }) } as any),
+    completeAsFn: decomposeFn
+      ? async (name: string, _prompt: string, opts?: any) => {
+          const result = await decomposeFn(name, opts ?? {});
+          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+        }
+      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
   });
 }
 
@@ -249,13 +251,6 @@ describe("planDecomposeCommand — adapter.decompose() option forwarding (US-002
 
     expect(capturedDecomposeOpts.length).toBe(1);
     expect(capturedDecomposeOpts[0].workdir).toBe(tmpDir);
-  });
-
-  test("adapter.decompose() receives featureName matching the feature option", async () => {
-    const config = makeConfig();
-    await planDecomposeCommand(tmpDir, config, { feature: FEATURE, storyId: "US-001" });
-
-    expect(capturedDecomposeOpts[0].featureName).toBe(FEATURE);
   });
 
   test("adapter.decompose() receives storyId matching the requested story", async () => {

--- a/test/unit/cli/plan-decompose-debate.test.ts
+++ b/test/unit/cli/plan-decompose-debate.test.ts
@@ -1,15 +1,14 @@
 /**
- * Unit tests — planDecomposeCommand debate integration via adapter.decompose() path (US-004)
+ * Unit tests — planDecomposeCommand debate integration (US-004)
  *
- * These tests cover the debate integration for adapters that implement decompose().
- * The existing plan-decompose.test.ts (AC-12/13/14) covers debate in the complete() fallback.
- * This file covers the same debate ACs but for the adapter.decompose() path, where
- * the current implementation has NO debate support — tests are RED until implemented.
+ * After Phase C (ADR-018 Wave 3), planDecomposeCommand routes all decompose
+ * calls through callOp → completeAs. Tests track completeAs calls instead of
+ * the now-removed adapter.decompose() path.
  *
  * AC-1: When debate.stages.decompose.enabled=true, planDecomposeCommand() runs a DebateSession
  *       and the debate output is parsed through parseDecomposeOutput()
- * AC-2: When debate returns outcome='failed', falls back to adapter.decompose() (not adapter.complete())
- * AC-3: When debate is disabled, adapter.decompose() is called directly without DebateSession
+ * AC-2: When debate returns outcome='failed', falls back to completeAs via callOp
+ * AC-3: When debate is disabled, completeAs is called directly without DebateSession
  * AC-4: Debate output wrapped in markdown code fences is parsed by parseDecomposeOutput()
  */
 
@@ -18,17 +17,20 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { _planDeps, planDecomposeCommand } from "../../../src/cli/plan";
 import type { DebateResult } from "../../../src/debate/types";
+import type { DecomposedStory } from "../../../src/agents/shared/types-extended";
 import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
 import { makeMockAgentManager, makeNaxConfig, makePRD, makeStory } from "../../helpers";
 
 function makeMockDecomposeManager(
-  decomposeFn?: (agentName: string, opts: any) => Promise<{ stories: any[] }>,
+  decomposeFn?: (agentName: string, opts: any) => Promise<{ stories: DecomposedStory[] }>,
 ) {
   return makeMockAgentManager({
-    decomposeAsFn: decomposeFn
-      ? async (name: string, opts: any) => decomposeFn(name, opts)
-      : undefined,
-    getAgentFn: () => ({ decompose: async () => ({ stories: [] }) } as any),
+    completeAsFn: decomposeFn
+      ? async (name: string, _prompt: string, opts?: any) => {
+          const result = await decomposeFn(name, opts ?? {});
+          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+        }
+      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
   });
 }
 
@@ -95,8 +97,8 @@ function makePrd(stories: UserStory[] = [makeStory()]): PRD {
   return makePRD({ feature: FEATURE, branchName: "feat/my-feature", userStories: stories });
 }
 
-/** Valid sub-story returned by adapter.decompose() (has contextFiles, complexity, testStrategy) */
-function makeDecomposeAdapterResult() {
+/** Valid DecomposedStory result returned by completeAs fallback */
+function makeDecomposeAdapterResult(): { stories: DecomposedStory[] } {
   return {
     stories: [
       {
@@ -127,9 +129,8 @@ function makeDebateStageConfig(enabled: boolean) {
   };
 }
 
-function makeConfigWithDebate(debateDecomposeEnabled: boolean): NaxConfig {
-  return {
-    agent: { default: "claude" },
+function makeConfigWithDebate(debateDecomposeEnabled: boolean) {
+  return makeNaxConfig({
     precheck: {
       storySizeGate: {
         enabled: true,
@@ -143,7 +144,6 @@ function makeConfigWithDebate(debateDecomposeEnabled: boolean): NaxConfig {
     debate: {
       enabled: debateDecomposeEnabled,
       agents: 2,
-      maxConcurrentDebaters: 2,
       stages: {
         decompose: makeDebateStageConfig(debateDecomposeEnabled),
         plan: makeDebateStageConfig(false),
@@ -152,16 +152,8 @@ function makeConfigWithDebate(debateDecomposeEnabled: boolean): NaxConfig {
         rectification: makeDebateStageConfig(false),
         escalation: makeDebateStageConfig(false),
       },
-    },
-  } as never;
-}
-
-/** Fake adapter that implements decompose() — triggers the adapter.decompose() branch */
-function makeDecomposeAdapter() {
-  return {
-    decompose: mock(async (_opts: unknown) => makeDecomposeAdapterResult()),
-    complete: mock(async (_prompt: string) => DEBATE_OUTPUT_JSON),
-  };
+    } as never,
+  });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -184,11 +176,11 @@ const origMkdirp = _planDeps.mkdirp;
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("planDecomposeCommand — debate via adapter.decompose() path (US-004)", () => {
+describe("planDecomposeCommand — debate integration (US-004)", () => {
   let tmpDir: string;
   let capturedWriteArgs: Array<[string, string]>;
 
-  function setupDeps(prd: PRD, adapter = makeDecomposeAdapter()) {
+  function setupDeps(prd: PRD) {
     const prdPath = join(tmpDir, ".nax", "features", FEATURE, "prd.json");
 
     _planDeps.existsSync = mock((p: string) => p === prdPath);
@@ -211,7 +203,7 @@ describe("planDecomposeCommand — debate via adapter.decompose() path (US-004)"
     _planDeps.spawnSync = mock(() => ({ stdout: Buffer.from(""), exitCode: 1 }));
     _planDeps.mkdirp = mock(async () => {});
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async (_name: string, opts: any) => adapter.decompose(opts)),
+      makeMockDecomposeManager(async () => makeDecomposeAdapterResult()),
     );
   }
 
@@ -238,13 +230,12 @@ describe("planDecomposeCommand — debate via adapter.decompose() path (US-004)"
   });
 
   // ──────────────────────────────────────────────────────────────────────────
-  // AC-1: debate enabled + adapter has decompose() → DebateSession runs
+  // AC-1: debate enabled → DebateSession runs, debate output used
   // ──────────────────────────────────────────────────────────────────────────
 
-  test("AC-1: creates DebateSession when adapter has decompose() and debate.stages.decompose.enabled=true", async () => {
+  test("AC-1: creates DebateSession when debate.stages.decompose.enabled=true", async () => {
     const prd = makePrd();
-    const adapter = makeDecomposeAdapter();
-    setupDeps(prd, adapter);
+    setupDeps(prd);
 
     const createDebateMock = mock((_opts: unknown) => ({
       run: mock(async () => makePassedDebateResult()),
@@ -277,10 +268,19 @@ describe("planDecomposeCommand — debate via adapter.decompose() path (US-004)"
     expect(capturedOpts[0]).toMatchObject({ stage: "decompose" });
   });
 
-  test("AC-1: adapter.decompose() is NOT called when debate succeeds", async () => {
+  test("AC-1: completeAs is NOT called when debate succeeds", async () => {
     const prd = makePrd();
-    const adapter = makeDecomposeAdapter();
-    setupDeps(prd, adapter);
+    setupDeps(prd);
+
+    const completeCalls: number[] = [];
+    _planDeps.createManager = mock(() =>
+      makeMockAgentManager({
+        completeAsFn: async () => {
+          completeCalls.push(1);
+          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), costUsd: 0, source: "exact" as const };
+        },
+      }),
+    );
 
     _planDeps.createDebateSession = mock((_opts: unknown) => ({
       run: mock(async () => makePassedDebateResult()),
@@ -291,7 +291,7 @@ describe("planDecomposeCommand — debate via adapter.decompose() path (US-004)"
       storyId: STORY_ID,
     });
 
-    expect(adapter.decompose).not.toHaveBeenCalled();
+    expect(completeCalls).toHaveLength(0);
   });
 
   test("AC-1: debate output is parsed through parseDecomposeOutput() and sub-stories written to PRD", async () => {
@@ -315,13 +315,22 @@ describe("planDecomposeCommand — debate via adapter.decompose() path (US-004)"
   });
 
   // ──────────────────────────────────────────────────────────────────────────
-  // AC-2: debate returns 'failed' → fall back to adapter.decompose(), not adapter.complete()
+  // AC-2: debate returns 'failed' → fall back to completeAs via callOp
   // ──────────────────────────────────────────────────────────────────────────
 
-  test("AC-2: calls adapter.decompose() when debate outcome='failed'", async () => {
+  test("AC-2: calls completeAs when debate outcome='failed'", async () => {
     const prd = makePrd();
-    const adapter = makeDecomposeAdapter();
-    setupDeps(prd, adapter);
+    setupDeps(prd);
+
+    const completeCalls: number[] = [];
+    _planDeps.createManager = mock(() =>
+      makeMockAgentManager({
+        completeAsFn: async () => {
+          completeCalls.push(1);
+          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), costUsd: 0, source: "exact" as const };
+        },
+      }),
+    );
 
     _planDeps.createDebateSession = mock((_opts: unknown) => ({
       run: mock(async () => makeFailedDebateResult()),
@@ -332,30 +341,12 @@ describe("planDecomposeCommand — debate via adapter.decompose() path (US-004)"
       storyId: STORY_ID,
     });
 
-    expect(adapter.decompose).toHaveBeenCalledTimes(1);
+    expect(completeCalls).toHaveLength(1);
   });
 
-  test("AC-2: does NOT call adapter.complete() when debate fails — decompose() is the fallback", async () => {
+  test("AC-2: PRD is updated with sub-stories from completeAs fallback when debate fails", async () => {
     const prd = makePrd();
-    const adapter = makeDecomposeAdapter();
-    setupDeps(prd, adapter);
-
-    _planDeps.createDebateSession = mock((_opts: unknown) => ({
-      run: mock(async () => makeFailedDebateResult()),
-    })) as never;
-
-    await planDecomposeCommand(tmpDir, makeConfigWithDebate(true), {
-      feature: FEATURE,
-      storyId: STORY_ID,
-    });
-
-    expect(adapter.complete).not.toHaveBeenCalled();
-  });
-
-  test("AC-2: PRD is updated with sub-stories from adapter.decompose() fallback", async () => {
-    const prd = makePrd();
-    const adapter = makeDecomposeAdapter();
-    setupDeps(prd, adapter);
+    setupDeps(prd);
 
     _planDeps.createDebateSession = mock((_opts: unknown) => ({
       run: mock(async () => makeFailedDebateResult()),
@@ -372,13 +363,12 @@ describe("planDecomposeCommand — debate via adapter.decompose() path (US-004)"
   });
 
   // ──────────────────────────────────────────────────────────────────────────
-  // AC-3: debate disabled → adapter.decompose() called directly, no DebateSession
+  // AC-3: debate disabled → completeAs called directly, no DebateSession
   // ──────────────────────────────────────────────────────────────────────────
 
   test("AC-3: does NOT create DebateSession when debate is disabled", async () => {
     const prd = makePrd();
-    const adapter = makeDecomposeAdapter();
-    setupDeps(prd, adapter);
+    setupDeps(prd);
 
     const createDebateMock = mock((_opts: unknown) => ({
       run: mock(async () => makePassedDebateResult()),
@@ -393,10 +383,19 @@ describe("planDecomposeCommand — debate via adapter.decompose() path (US-004)"
     expect(createDebateMock).not.toHaveBeenCalled();
   });
 
-  test("AC-3: calls adapter.decompose() directly when debate is disabled", async () => {
+  test("AC-3: calls completeAs directly when debate is disabled", async () => {
     const prd = makePrd();
-    const adapter = makeDecomposeAdapter();
-    setupDeps(prd, adapter);
+    setupDeps(prd);
+
+    const completeCalls: number[] = [];
+    _planDeps.createManager = mock(() =>
+      makeMockAgentManager({
+        completeAsFn: async () => {
+          completeCalls.push(1);
+          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), costUsd: 0, source: "exact" as const };
+        },
+      }),
+    );
 
     _planDeps.createDebateSession = mock((_opts: unknown) => ({
       run: mock(async () => makePassedDebateResult()),
@@ -407,13 +406,22 @@ describe("planDecomposeCommand — debate via adapter.decompose() path (US-004)"
       storyId: STORY_ID,
     });
 
-    expect(adapter.decompose).toHaveBeenCalledTimes(1);
+    expect(completeCalls).toHaveLength(1);
   });
 
-  test("AC-3: adapter.decompose() called directly when no debate config present", async () => {
+  test("AC-3: completeAs called directly when no debate config present", async () => {
     const prd = makePrd();
-    const adapter = makeDecomposeAdapter();
-    setupDeps(prd, adapter);
+    setupDeps(prd);
+
+    const completeCalls: number[] = [];
+    _planDeps.createManager = mock(() =>
+      makeMockAgentManager({
+        completeAsFn: async () => {
+          completeCalls.push(1);
+          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), costUsd: 0, source: "exact" as const };
+        },
+      }),
+    );
 
     const createDebateMock = mock((_opts: unknown) => ({
       run: mock(async () => makePassedDebateResult()),
@@ -422,12 +430,12 @@ describe("planDecomposeCommand — debate via adapter.decompose() path (US-004)"
 
     await planDecomposeCommand(
       tmpDir,
-      { autoMode: { defaultAgent: "claude" } } as never,
+      makeNaxConfig({ agent: { default: "claude" } }),
       { feature: FEATURE, storyId: STORY_ID },
     );
 
     expect(createDebateMock).not.toHaveBeenCalled();
-    expect(adapter.decompose).toHaveBeenCalledTimes(1);
+    expect(completeCalls).toHaveLength(1);
   });
 
   // ──────────────────────────────────────────────────────────────────────────

--- a/test/unit/cli/plan-decompose-guards.test.ts
+++ b/test/unit/cli/plan-decompose-guards.test.ts
@@ -6,22 +6,9 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { _planDeps, planDecomposeCommand } from "../../../src/cli/plan";
-import { buildDecomposePromptAsync } from "../../../src/agents/shared/decompose-prompt";
-import type { DecomposeOptions, DecomposedStory } from "../../../src/agents/shared/types-extended";
 import { NaxError } from "../../../src/errors";
 import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
 import { makeMockAgentManager, makeNaxConfig, makePRD, makeStory } from "../../helpers";
-
-function makeMockDecomposeManager(
-  decomposeFn?: (agentName: string, opts: DecomposeOptions) => Promise<{ stories: DecomposedStory[] }>,
-) {
-  return makeMockAgentManager({
-    decomposeAsFn: decomposeFn
-      ? async (name: string, opts: DecomposeOptions) => decomposeFn(name, opts)
-      : undefined,
-    getAgentFn: () => ({ decompose: async () => ({ stories: [] }) } as any),
-  });
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixtures
@@ -148,9 +135,11 @@ describe("planDecomposeCommand — guards (AC-1 to AC-8)", () => {
     _planDeps.spawnSync = mock(() => ({ stdout: Buffer.from(""), exitCode: 1 }));
     _planDeps.mkdirp = mock(async () => {});
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async (_name: string, options: DecomposeOptions) => {
-        capturedCompleteArgs.push(await buildDecomposePromptAsync(options));
-        return { stories: stories.map(toDecomposedStory) };
+      makeMockAgentManager({
+        completeAsFn: async (_name: string, prompt: string) => {
+          capturedCompleteArgs.push(prompt);
+          return { output: JSON.stringify(stories.map(toDecomposedStory)), costUsd: 0, source: "exact" as const };
+        },
       }),
     );
   }
@@ -258,7 +247,7 @@ describe("planDecomposeCommand — guards (AC-1 to AC-8)", () => {
     expect(prompt).toContain("zod");
   });
 
-  test("AC-5: adapter.decompose() receives decompose context options", async () => {
+  test("AC-5: completeAs() receives workdir and storyId context options", async () => {
     const prd = makePrd();
     const capturedDecomposeOpts: unknown[] = [];
     _planDeps.existsSync = mock((path: string) =>
@@ -275,13 +264,15 @@ describe("planDecomposeCommand — guards (AC-1 to AC-8)", () => {
     _planDeps.spawnSync = mock(() => ({ stdout: Buffer.from(""), exitCode: 1 }));
     _planDeps.mkdirp = mock(async () => {});
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async (_name: string, opts: unknown) => {
-        capturedDecomposeOpts.push(opts);
-        return { stories: [makeSubStory("US-001-A"), makeSubStory("US-001-B")].map(toDecomposedStory) };
+      makeMockAgentManager({
+        completeAsFn: async (_name: string, _prompt: string, opts?: any) => {
+          capturedDecomposeOpts.push(opts ?? {});
+          return { output: JSON.stringify([makeSubStory("US-001-A"), makeSubStory("US-001-B")].map(toDecomposedStory)), costUsd: 0, source: "exact" as const };
+        },
       }),
     );
     await planDecomposeCommand(tmpDir, makeConfig(), { feature: FEATURE, storyId: "US-001" });
-    expect(capturedDecomposeOpts[0]).toMatchObject({ workdir: tmpDir, featureName: FEATURE, storyId: "US-001" });
+    expect(capturedDecomposeOpts[0]).toMatchObject({ workdir: tmpDir, storyId: "US-001" });
   });
 
   test("AC-6: throws DECOMPOSE_VALIDATION_FAILED when sub-story has empty contextFiles array", async () => {
@@ -312,14 +303,14 @@ describe("planDecomposeCommand — guards (AC-1 to AC-8)", () => {
     ).resolves.not.toThrow();
   });
 
-  test("AC-7: throws DECOMPOSE_VALIDATION_FAILED when sub-story missing routing.testStrategy", async () => {
+  test("AC-7: missing routing.testStrategy is coerced to test-after (no error)", async () => {
     const prd = makePrd();
     const badStory = makeSubStory("US-001-A");
     if (badStory.routing) delete (badStory.routing as Partial<typeof badStory.routing>).testStrategy;
     setupDeps(prd, [badStory]);
     await expect(
       planDecomposeCommand(tmpDir, makeConfig(), { feature: FEATURE, storyId: "US-001" }),
-    ).rejects.toMatchObject({ code: "DECOMPOSE_VALIDATION_FAILED" });
+    ).resolves.not.toThrow();
   });
 
   test("AC-7: missing routing.modelTier in legacy input is tolerated (mapper default)", async () => {
@@ -332,14 +323,14 @@ describe("planDecomposeCommand — guards (AC-1 to AC-8)", () => {
     ).resolves.not.toThrow();
   });
 
-  test("AC-7: throws DECOMPOSE_VALIDATION_FAILED when sub-story has no routing field", async () => {
+  test("AC-7: missing routing field is coerced (complexity→medium, testStrategy→test-after, no error)", async () => {
     const prd = makePrd();
     const badStory = makeSubStory("US-001-A");
     delete (badStory as Partial<UserStory>).routing;
     setupDeps(prd, [badStory]);
     await expect(
       planDecomposeCommand(tmpDir, makeConfig(), { feature: FEATURE, storyId: "US-001" }),
-    ).rejects.toMatchObject({ code: "DECOMPOSE_VALIDATION_FAILED" });
+    ).resolves.not.toThrow();
   });
 
   test("AC-8: throws DECOMPOSE_VALIDATION_FAILED when sub-story exceeds maxAcCount", async () => {

--- a/test/unit/cli/plan-decompose-mapper.test.ts
+++ b/test/unit/cli/plan-decompose-mapper.test.ts
@@ -20,10 +20,12 @@ function makeMockDecomposeManager(
   decomposeFn?: (agentName: string, opts: any) => Promise<{ stories: DecomposedStory[] }>,
 ) {
   return makeMockAgentManager({
-    decomposeAsFn: decomposeFn
-      ? async (name: string, opts: any) => decomposeFn(name, opts)
-      : undefined,
-    getAgentFn: () => ({ decompose: async () => ({ stories: [] }) } as any),
+    completeAsFn: decomposeFn
+      ? async (name: string, _prompt: string, opts?: any) => {
+          const result = await decomposeFn(name, opts ?? {});
+          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+        }
+      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
   });
 }
 
@@ -248,7 +250,7 @@ describe("planDecomposeCommand — mapper wiring (US-003 AC-5)", () => {
     expect(storyB?.routing?.testStrategy).toBe("three-session-tdd");
   });
 
-  test("throws DECOMPOSE_VALIDATION_FAILED with entry index when DecomposedStory has empty id", async () => {
+  test("throws when DecomposedStory has empty id (caught by parseDecomposeOutput)", async () => {
     const prd = makePrd();
     const decomposed = [
       makeDecomposedStory({ id: "US-001-A" }),
@@ -256,16 +258,9 @@ describe("planDecomposeCommand — mapper wiring (US-003 AC-5)", () => {
     ];
     setupDepsWithDecompose(prd, decomposed);
 
-    let caught: unknown;
-    try {
-      await planDecomposeCommand(tmpDir, makeNaxConfig(), { feature: FEATURE, storyId: "US-001" });
-    } catch (err) {
-      caught = err;
-    }
-
-    expect(caught).toMatchObject({ code: "DECOMPOSE_VALIDATION_FAILED" });
-    // biome-ignore lint: test accesses dynamic property
-    expect((caught as any)?.context?.entryIndex).toBeDefined();
+    await expect(
+      planDecomposeCommand(tmpDir, makeNaxConfig(), { feature: FEATURE, storyId: "US-001" }),
+    ).rejects.toThrow(/index 1/);
   });
 
   test("throws DECOMPOSE_VALIDATION_FAILED with entry index when DecomposedStory has empty contextFiles", async () => {

--- a/test/unit/cli/plan-decompose-regression.test.ts
+++ b/test/unit/cli/plan-decompose-regression.test.ts
@@ -11,7 +11,6 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { _planDeps, planDecomposeCommand } from "../../../src/cli/plan";
-import { parseDecomposeOutput } from "../../../src/agents/shared/decompose";
 import { mapDecomposedStoriesToUserStories } from "../../../src/prd/decompose-mapper";
 import type { DecomposedStory } from "../../../src/agents/shared/types-extended";
 import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
@@ -21,10 +20,12 @@ function makeMockDecomposeManager(
   decomposeFn?: (agentName: string, opts: any) => Promise<{ stories: DecomposedStory[] }>,
 ) {
   return makeMockAgentManager({
-    decomposeAsFn: decomposeFn
-      ? async (name: string, opts: any) => decomposeFn(name, opts)
-      : undefined,
-    getAgentFn: () => ({ decompose: async () => ({ stories: [] }) } as any),
+    completeAsFn: decomposeFn
+      ? async (name: string, _prompt: string, opts?: any) => {
+          const result = await decomposeFn(name, opts ?? {});
+          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+        }
+      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
   });
 }
 
@@ -167,9 +168,9 @@ describe("planDecomposeCommand — fenced JSON parsing regression", () => {
     const prd = makePrd();
     setupBaseDeps(tmpDir, prd, capturedWrites);
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async () => ({
-        stories: parseDecomposeOutput(fencedJson),
-      })),
+      makeMockAgentManager({
+        completeAsFn: async () => ({ output: fencedJson, costUsd: 0, source: "exact" as const }),
+      }),
     );
 
     await expect(
@@ -184,9 +185,9 @@ describe("planDecomposeCommand — fenced JSON parsing regression", () => {
     const prd = makePrd();
     setupBaseDeps(tmpDir, prd, capturedWrites);
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async () => ({
-        stories: parseDecomposeOutput(fencedJson),
-      })),
+      makeMockAgentManager({
+        completeAsFn: async () => ({ output: fencedJson, costUsd: 0, source: "exact" as const }),
+      }),
     );
 
     await expect(
@@ -201,9 +202,9 @@ describe("planDecomposeCommand — fenced JSON parsing regression", () => {
     const prd = makePrd();
     setupBaseDeps(tmpDir, prd, capturedWrites);
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async () => ({
-        stories: parseDecomposeOutput(fencedJson),
-      })),
+      makeMockAgentManager({
+        completeAsFn: async () => ({ output: fencedJson, costUsd: 0, source: "exact" as const }),
+      }),
     );
 
     await planDecomposeCommand(tmpDir, makeConfig(), { feature: FEATURE, storyId: "US-001" });

--- a/test/unit/cli/plan-decompose-writeback.test.ts
+++ b/test/unit/cli/plan-decompose-writeback.test.ts
@@ -9,19 +9,20 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { _planDeps, planDecomposeCommand } from "../../../src/cli/plan";
-import { buildDecomposePromptAsync } from "../../../src/agents/shared/decompose-prompt";
-import type { DecomposeOptions, DecomposedStory } from "../../../src/agents/shared/types-extended";
+import type { DecomposedStory } from "../../../src/agents/shared/types-extended";
 import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
 import { makeMockAgentManager, makeNaxConfig, makePRD, makeStory } from "../../helpers";
 
 function makeMockDecomposeManager(
-  decomposeFn?: (agentName: string, opts: DecomposeOptions) => Promise<{ stories: DecomposedStory[] }>,
+  decomposeFn?: (agentName: string, opts: any) => Promise<{ stories: DecomposedStory[] }>,
 ) {
   return makeMockAgentManager({
-    decomposeAsFn: decomposeFn
-      ? async (name: string, opts: DecomposeOptions) => decomposeFn(name, opts)
-      : undefined,
-    getAgentFn: () => ({ decompose: async () => ({ stories: [] }) } as any),
+    completeAsFn: decomposeFn
+      ? async (name: string, _prompt: string, opts?: any) => {
+          const result = await decomposeFn(name, opts ?? {});
+          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+        }
+      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
   });
 }
 
@@ -101,7 +102,6 @@ const origMkdirp = _planDeps.mkdirp;
 describe("planDecomposeCommand — PRD write-back", () => {
   let tmpDir: string;
   let capturedWriteArgs: Array<[string, string]>;
-  let capturedCompleteArgs: string[];
 
   function setupDeps(
     prd: PRD,
@@ -128,17 +128,15 @@ describe("planDecomposeCommand — PRD write-back", () => {
     _planDeps.mkdirp = mock(async () => {});
 
     _planDeps.createManager = mock(() =>
-      makeMockDecomposeManager(async (_name: string, options: DecomposeOptions) => {
-        capturedCompleteArgs.push(await buildDecomposePromptAsync(options));
-        return { stories: stories.map(toDecomposedStory) };
-      }),
+      makeMockDecomposeManager(async () => ({
+        stories: stories.map(toDecomposedStory),
+      })),
     );
   }
 
   beforeEach(async () => {
     tmpDir = makeTempDir("nax-decompose-test-");
     capturedWriteArgs = [];
-    capturedCompleteArgs = [];
     await mkdir(join(tmpDir, ".nax", "features", FEATURE), { recursive: true });
   });
 

--- a/test/unit/cli/plan-monorepo.test.ts
+++ b/test/unit/cli/plan-monorepo.test.ts
@@ -14,20 +14,16 @@ import { join } from "node:path";
 import { _planDeps, planCommand } from "../../../src/cli/plan";
 import type { PRD } from "../../../src/prd/types";
 import { makeTempDir } from "../../helpers/temp";
-import { makeMockAgentManager } from "../../helpers";
+import { makeMockAgentManager, makeNaxConfig } from "../../helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
 function makeMockPlanManager(
-  planFn?: (agentName: string, opts: any) => Promise<{ specContent: string }>,
+  completeFn?: (name: string, prompt: string, opts: any) => Promise<{ output: string; costUsd: number; source: "exact" | "estimated" | "fallback" }>,
 ) {
-  return makeMockAgentManager({
-    planAsFn: planFn
-      ? async (name: string, opts: any) => planFn(name, opts)
-      : undefined,
-  });
+  return makeMockAgentManager({ completeAsFn: completeFn });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -107,9 +103,9 @@ describe("planCommand — MW-007 monorepo awareness", () => {
     _planDeps.mkdirp = mock(async () => {});
     _planDeps.existsSync = mock(() => true);
     _planDeps.createManager = mock(() =>
-      makeMockPlanManager(async (_name: string, opts: any) => {
-        capturedPrompts.push(opts.prompt);
-        return { specContent: "" };
+      makeMockPlanManager(async (_name: string, prompt: string, _opts: any) => {
+        capturedPrompts.push(prompt);
+        return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
       }),
     );
   });
@@ -132,7 +128,7 @@ describe("planCommand — MW-007 monorepo awareness", () => {
   test("injects monorepo hint when packages are discovered", async () => {
     _planDeps.discoverWorkspacePackages = mock(async () => [`${tmpDir}/packages/api`, `${tmpDir}/packages/web`]);
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, makeNaxConfig(), {
       from: "/spec.md",
       feature: "test-feature",
       auto: true,
@@ -147,7 +143,7 @@ describe("planCommand — MW-007 monorepo awareness", () => {
   test("includes workdir field in schema when monorepo detected", async () => {
     _planDeps.discoverWorkspacePackages = mock(async () => [`${tmpDir}/packages/api`]);
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, makeNaxConfig(), {
       from: "/spec.md",
       feature: "test-feature",
       auto: true,
@@ -160,7 +156,7 @@ describe("planCommand — MW-007 monorepo awareness", () => {
   test("monorepo hint includes instruction to set workdir per story", async () => {
     _planDeps.discoverWorkspacePackages = mock(async () => [`${tmpDir}/packages/api`]);
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, makeNaxConfig(), {
       from: "/spec.md",
       feature: "test-feature",
       auto: true,
@@ -174,7 +170,7 @@ describe("planCommand — MW-007 monorepo awareness", () => {
   test("no monorepo hint when no packages discovered", async () => {
     _planDeps.discoverWorkspacePackages = mock(async () => []);
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, makeNaxConfig(), {
       from: "/spec.md",
       feature: "test-feature",
       auto: true,
@@ -187,7 +183,7 @@ describe("planCommand — MW-007 monorepo awareness", () => {
   test("no workdir field in schema when no packages discovered", async () => {
     _planDeps.discoverWorkspacePackages = mock(async () => []);
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, makeNaxConfig(), {
       from: "/spec.md",
       feature: "test-feature",
       auto: true,
@@ -201,7 +197,7 @@ describe("planCommand — MW-007 monorepo awareness", () => {
   test("package paths in prompt are relative to repo root", async () => {
     _planDeps.discoverWorkspacePackages = mock(async () => [`${tmpDir}/packages/api`, `${tmpDir}/apps/web`]);
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, makeNaxConfig(), {
       from: "/spec.md",
       feature: "test-feature",
       auto: true,
@@ -270,9 +266,9 @@ describe("planCommand — per-package tech stack in prompt", () => {
       return "# Spec\nDo something.\n";
     });
     _planDeps.createManager = mock(() =>
-      makeMockPlanManager(async (_name: string, opts: any) => {
-        capturedPrompts.push(opts.prompt);
-        return { specContent: "" };
+      makeMockPlanManager(async (_name: string, prompt: string, _opts: any) => {
+        capturedPrompts.push(prompt);
+        return { output: JSON.stringify(minimalPrd), costUsd: 0, source: "exact" as const };
       }),
     );
   });
@@ -311,7 +307,7 @@ describe("planCommand — per-package tech stack in prompt", () => {
       return null;
     });
 
-    await planCommand(tmpDir, {} as never, { from: "/spec.md", feature: "test", auto: true });
+    await planCommand(tmpDir, makeNaxConfig(), { from: "/spec.md", feature: "test", auto: true });
 
     const prompt = capturedPrompts[0];
     expect(prompt).toContain("Package Tech Stacks");
@@ -325,7 +321,7 @@ describe("planCommand — per-package tech stack in prompt", () => {
   test("omits Package Tech Stacks section for single-package repos", async () => {
     _planDeps.discoverWorkspacePackages = mock(async () => []);
 
-    await planCommand(tmpDir, {} as never, { from: "/spec.md", feature: "test", auto: true });
+    await planCommand(tmpDir, makeNaxConfig(), { from: "/spec.md", feature: "test", auto: true });
 
     const prompt = capturedPrompts[0];
     expect(prompt).not.toContain("Package Tech Stacks");

--- a/test/unit/cli/plan.test.ts
+++ b/test/unit/cli/plan.test.ts
@@ -9,10 +9,11 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { _planDeps, planCommand } from "../../../src/cli/plan";
-import { PlanPromptBuilder } from "../../../src/prompts";
-import { makeTempDir } from "../../helpers/temp";
-import { makeMockAgentManager } from "../../helpers";
 import { DEFAULT_CONFIG } from "../../../src/config";
+import type { PRD } from "../../../src/prd/types";
+import { PlanPromptBuilder } from "../../../src/prompts";
+import { makeMockAgentManager } from "../../helpers";
+import { makeTempDir } from "../../helpers/temp";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixtures
@@ -67,23 +68,6 @@ const origSpawnSync = _planDeps.spawnSync;
 const origMkdirp = _planDeps.mkdirp;
 const origExistsSync = _planDeps.existsSync;
 
-function makeFakeAdapter(prdContent: object = SAMPLE_PRD) {
-  return {
-    plan: mock(async (_opts: { prompt?: string }) => {}),
-    _prdContent: prdContent,
-  };
-}
-
-function makeMockPlanManager(
-  planFn?: (agentName: string, opts: any) => Promise<void>,
-) {
-  return makeMockAgentManager({
-    planAsFn: planFn
-      ? async (agentName: string, opts: any) => { await planFn(agentName, opts); return { specContent: "" }; }
-      : undefined,
-  });
-}
-
 function makeFakeScan() {
   return {
     fileTree: "└── src/\n    └── index.ts",
@@ -135,8 +119,11 @@ describe("planCommand", () => {
 
     _planDeps.createManager = mock((_cfg: any) => {
       capturedPlanArgs = [];
-      return makeMockPlanManager(async (_name: string, opts: { prompt?: string }) => {
-        if (opts.prompt) capturedPlanArgs.push(opts.prompt);
+      return makeMockAgentManager({
+        completeAsFn: async (_name: string, prompt: string, _opts?: any) => {
+          if (prompt) capturedPlanArgs.push(prompt);
+          return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
+        },
       });
     });
   });
@@ -162,11 +149,10 @@ describe("planCommand", () => {
     const specPath = join(tmpDir, "spec.md");
     _planDeps.readFile = mock(async (path: string) => {
       if (path === specPath) return SAMPLE_SPEC;
-      if (path.endsWith("prd.json")) return JSON.stringify(SAMPLE_PRD);
       throw new Error(`Unexpected readFile call: ${path}`);
     });
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: specPath,
       feature: "url-shortener",
       auto: true,
@@ -182,7 +168,7 @@ describe("planCommand", () => {
   // ──────────────────────────────────────────────────────────────────────────
 
   test("AC-2: prompt includes codebase context", async () => {
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
       auto: true,
@@ -197,8 +183,11 @@ describe("planCommand", () => {
     let receivedAgentName: string | undefined;
 
     _planDeps.createManager = mock((_cfg: any) =>
-      makeMockPlanManager(async (name: string) => {
-        receivedAgentName = name;
+      makeMockAgentManager({
+        completeAsFn: async (name: string, _prompt: string, _opts?: any) => {
+          receivedAgentName = name;
+          return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
+        },
       }),
     );
 
@@ -228,7 +217,7 @@ describe("planCommand", () => {
   });
 
   test("AC-2: prompt includes output schema with prd.json structure", async () => {
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
       auto: true,
@@ -241,7 +230,7 @@ describe("planCommand", () => {
   });
 
   test("AC-2: prompt includes complexity classification guide", async () => {
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
       auto: true,
@@ -255,7 +244,7 @@ describe("planCommand", () => {
   });
 
   test("AC-2: prompt includes test strategy guide", async () => {
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
       auto: true,
@@ -268,96 +257,26 @@ describe("planCommand", () => {
   });
 
   // ──────────────────────────────────────────────────────────────────────────
-  // AC-3: adapter.plan() is called with the full planning prompt
+  // AC-3: interactive mode (non-auto path still uses planAs)
   // ──────────────────────────────────────────────────────────────────────────
 
-  test("AC-3: adapter.plan() is called in --auto mode", async () => {
-    const fakeAdapter = makeFakeAdapter();
-    _planDeps.createManager = mock((_cfg: any) =>
-      makeMockPlanManager(async (_name: string, opts: any) => { await fakeAdapter.plan(opts); }),
-    );
-
-    await planCommand(tmpDir, {} as never, {
-      from: "/spec.md",
-      feature: "url-shortener",
-      auto: true,
-    });
-
-    expect(fakeAdapter.plan).toHaveBeenCalledTimes(1);
-  });
-
   test("AC-3: interactive mode is now supported when --auto not set", async () => {
-    const fakeAdapter = {
-      plan: mock(async (_options: any) => ({ specContent: "" })),
-      complete: mock(async (_prompt: string) => JSON.stringify(SAMPLE_PRD)),
-    };
+    const planSpy = mock(async (_options: any) => ({ specContent: "" }));
     _planDeps.createManager = mock((_cfg: any) =>
-      makeMockPlanManager(async (_name: string, opts: any) => { await fakeAdapter.plan(opts); }),
+      makeMockAgentManager({
+        planAsFn: async (_name: string, opts: any) => { await planSpy(opts); return { specContent: "" }; },
+      }),
     );
     // Simulate agent having written the PRD file to disk
     _planDeps.existsSync = mock((_path: string) => true);
     _planDeps.readFile = mock(async (_path: string) => JSON.stringify(SAMPLE_PRD));
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
     });
 
-    expect(fakeAdapter.plan).toHaveBeenCalled();
-  });
-
-  test("ACP auto: continues when plan() errors but prd.json exists", async () => {
-    const fakeAdapter = {
-      plan: mock(async (_options: any) => {
-        throw new Error("missing end_turn");
-      }),
-    };
-    _planDeps.createManager = mock((_cfg: any) =>
-      makeMockPlanManager(async (_name: string, opts: any) => { await fakeAdapter.plan(opts); }),
-    );
-    _planDeps.existsSync = mock((path: string) => path.endsWith("prd.json"));
-    _planDeps.readFile = mock(async (path: string) => (path.endsWith("prd.json") ? JSON.stringify(SAMPLE_PRD) : SAMPLE_SPEC));
-
-    const result = await planCommand(
-      tmpDir,
-      {
-        agent: { protocol: "acp" },
-      } as any,
-      {
-        from: "/spec.md",
-        feature: "url-shortener",
-        auto: true,
-      },
-    );
-
-    expect(result).toContain("prd.json");
-    expect(fakeAdapter.plan).toHaveBeenCalled();
-  });
-
-  test("ACP auto: throws when plan() errors and prd.json is missing", async () => {
-    const fakeAdapter = {
-      plan: mock(async (_options: any) => {
-        throw new Error("missing end_turn");
-      }),
-    };
-    _planDeps.createManager = mock((_cfg: any) =>
-      makeMockPlanManager(async (_name: string, opts: any) => { await fakeAdapter.plan(opts); }),
-    );
-    _planDeps.existsSync = mock((_path: string) => false);
-
-    await expect(
-      planCommand(
-        tmpDir,
-        {
-          agent: { protocol: "acp" },
-        } as any,
-        {
-          from: "/spec.md",
-          feature: "url-shortener",
-          auto: true,
-        },
-      ),
-    ).rejects.toThrow("no PRD was written");
+    expect(planSpy).toHaveBeenCalled();
   });
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -365,13 +284,14 @@ describe("planCommand", () => {
   // ──────────────────────────────────────────────────────────────────────────
 
   test("AC-4: throws on invalid JSON response from adapter", async () => {
-    _planDeps.readFile = mock(async (path: string) => {
-      if (path.endsWith("prd.json")) return "not valid json {{";
-      return SAMPLE_SPEC;
-    });
+    _planDeps.createManager = mock((_cfg: any) =>
+      makeMockAgentManager({
+        completeAsFn: async () => ({ output: "not valid json {{", costUsd: 0, source: "exact" as const }),
+      }),
+    );
 
     await expect(
-      planCommand(tmpDir, {} as never, {
+      planCommand(tmpDir, DEFAULT_CONFIG as never, {
         from: "/spec.md",
         feature: "url-shortener",
         auto: true,
@@ -384,19 +304,24 @@ describe("planCommand", () => {
     const prdWithoutProject = { ...SAMPLE_PRD } as Partial<PRD>;
     prdWithoutProject.project = undefined;
 
-    _planDeps.readFile = mock(async (path: string) => {
-      if (path.endsWith("prd.json")) return JSON.stringify(prdWithoutProject);
-      return SAMPLE_SPEC;
-    });
+    _planDeps.createManager = mock((_cfg: any) =>
+      makeMockAgentManager({
+        completeAsFn: async () => ({
+          output: JSON.stringify(prdWithoutProject),
+          costUsd: 0,
+          source: "exact" as const,
+        }),
+      }),
+    );
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
       auto: true,
     });
-    // Verify written PRD has project auto-filled (from package.json mock → "my-project")
-    expect(capturedWriteArgs.length).toBeGreaterThan(0);
-    const written = JSON.parse(capturedWriteArgs[0]?.[1]);
+    // capturedWriteArgs[1] = validated PRD (project filled by detectProjectName)
+    expect(capturedWriteArgs.length).toBeGreaterThan(1);
+    const written = JSON.parse(capturedWriteArgs[1]?.[1]);
     expect(written.project).toBeDefined();
     expect(typeof written.project).toBe("string");
   });
@@ -405,13 +330,18 @@ describe("planCommand", () => {
     const badPrd = { ...SAMPLE_PRD } as Partial<PRD>;
     badPrd.userStories = undefined;
 
-    _planDeps.readFile = mock(async (path: string) => {
-      if (path.endsWith("prd.json")) return JSON.stringify(badPrd);
-      return SAMPLE_SPEC;
-    });
+    _planDeps.createManager = mock((_cfg: any) =>
+      makeMockAgentManager({
+        completeAsFn: async () => ({
+          output: JSON.stringify(badPrd),
+          costUsd: 0,
+          source: "exact" as const,
+        }),
+      }),
+    );
 
     expect(
-      planCommand(tmpDir, {} as never, {
+      planCommand(tmpDir, DEFAULT_CONFIG as never, {
         from: "/spec.md",
         feature: "url-shortener",
         auto: true,
@@ -424,7 +354,7 @@ describe("planCommand", () => {
   // ──────────────────────────────────────────────────────────────────────────
 
   test("AC-5: output path is nax/features/<feature>/prd.json", async () => {
-    const result = await planCommand(tmpDir, {} as never, {
+    const result = await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
       auto: true,
@@ -436,13 +366,13 @@ describe("planCommand", () => {
   });
 
   test("AC-5: written content is valid JSON with PRD structure", async () => {
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[0];
+    const [_path, content] = capturedWriteArgs[1];
     const written = JSON.parse(content) as PRD;
     expect(written.userStories).toBeDefined();
     expect(Array.isArray(written.userStories)).toBe(true);
@@ -461,18 +391,23 @@ describe("planCommand", () => {
       ],
     };
 
-    _planDeps.readFile = mock(async (path: string) => {
-      if (path.endsWith("prd.json")) return JSON.stringify(prdWithBadStatuses);
-      return SAMPLE_SPEC;
-    });
+    _planDeps.createManager = mock((_cfg: any) =>
+      makeMockAgentManager({
+        completeAsFn: async () => ({
+          output: JSON.stringify(prdWithBadStatuses),
+          costUsd: 0,
+          source: "exact" as const,
+        }),
+      }),
+    );
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[0];
+    const [_path, content] = capturedWriteArgs[1];
     const written = JSON.parse(content) as PRD;
     for (const story of written.userStories) {
       expect(story.status).toBe("pending");
@@ -486,13 +421,13 @@ describe("planCommand", () => {
   test("AC-7: project field comes from package.json name", async () => {
     _planDeps.readPackageJson = mock(async (_workdir: string) => ({ name: "my-awesome-pkg" }));
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[0];
+    const [_path, content] = capturedWriteArgs[1];
     const written = JSON.parse(content) as PRD;
     expect(written.project).toBe("my-awesome-pkg");
   });
@@ -504,13 +439,13 @@ describe("planCommand", () => {
       exitCode: 0,
     }));
 
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[0];
+    const [_path, content] = capturedWriteArgs[1];
     const written = JSON.parse(content) as PRD;
     expect(written.project).toBe("repo-name");
   });
@@ -520,26 +455,26 @@ describe("planCommand", () => {
   // ──────────────────────────────────────────────────────────────────────────
 
   test("AC-8: branchName defaults to feat/<feature>", async () => {
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "my-feat",
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[0];
+    const [_path, content] = capturedWriteArgs[1];
     const written = JSON.parse(content) as PRD;
     expect(written.branchName).toBe("feat/my-feat");
   });
 
   test("AC-8: branchName can be overridden via branch option", async () => {
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "my-feat",
       auto: true,
       branch: "custom/branch-name",
     });
 
-    const [_path, content] = capturedWriteArgs[0];
+    const [_path, content] = capturedWriteArgs[1];
     const written = JSON.parse(content) as PRD;
     expect(written.branchName).toBe("custom/branch-name");
   });
@@ -568,13 +503,13 @@ describe("planCommand", () => {
   // ──────────────────────────────────────────────────────────────────────────
 
   test("output PRD has createdAt and updatedAt ISO timestamps", async () => {
-    await planCommand(tmpDir, {} as never, {
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
       from: "/spec.md",
       feature: "url-shortener",
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[0];
+    const [_path, content] = capturedWriteArgs[1];
     const written = JSON.parse(content) as PRD;
     expect(written.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(written.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);

--- a/test/unit/cli/plan.test.ts
+++ b/test/unit/cli/plan.test.ts
@@ -319,9 +319,9 @@ describe("planCommand", () => {
       feature: "url-shortener",
       auto: true,
     });
-    // capturedWriteArgs[1] = validated PRD (project filled by detectProjectName)
-    expect(capturedWriteArgs.length).toBeGreaterThan(1);
-    const written = JSON.parse(capturedWriteArgs[1]?.[1]);
+    // capturedWriteArgs[0] = validated PRD (planOp.parse now calls validatePlanOutput internally)
+    expect(capturedWriteArgs.length).toBeGreaterThan(0);
+    const written = JSON.parse(capturedWriteArgs[0]?.[1]);
     expect(written.project).toBeDefined();
     expect(typeof written.project).toBe("string");
   });
@@ -372,7 +372,7 @@ describe("planCommand", () => {
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[1];
+    const [_path, content] = capturedWriteArgs[0];
     const written = JSON.parse(content) as PRD;
     expect(written.userStories).toBeDefined();
     expect(Array.isArray(written.userStories)).toBe(true);
@@ -407,7 +407,7 @@ describe("planCommand", () => {
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[1];
+    const [_path, content] = capturedWriteArgs[0];
     const written = JSON.parse(content) as PRD;
     for (const story of written.userStories) {
       expect(story.status).toBe("pending");
@@ -427,7 +427,7 @@ describe("planCommand", () => {
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[1];
+    const [_path, content] = capturedWriteArgs[0];
     const written = JSON.parse(content) as PRD;
     expect(written.project).toBe("my-awesome-pkg");
   });
@@ -445,7 +445,7 @@ describe("planCommand", () => {
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[1];
+    const [_path, content] = capturedWriteArgs[0];
     const written = JSON.parse(content) as PRD;
     expect(written.project).toBe("repo-name");
   });
@@ -461,7 +461,7 @@ describe("planCommand", () => {
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[1];
+    const [_path, content] = capturedWriteArgs[0];
     const written = JSON.parse(content) as PRD;
     expect(written.branchName).toBe("feat/my-feat");
   });
@@ -474,7 +474,7 @@ describe("planCommand", () => {
       branch: "custom/branch-name",
     });
 
-    const [_path, content] = capturedWriteArgs[1];
+    const [_path, content] = capturedWriteArgs[0];
     const written = JSON.parse(content) as PRD;
     expect(written.branchName).toBe("custom/branch-name");
   });
@@ -509,7 +509,7 @@ describe("planCommand", () => {
       auto: true,
     });
 
-    const [_path, content] = capturedWriteArgs[1];
+    const [_path, content] = capturedWriteArgs[0];
     const written = JSON.parse(content) as PRD;
     expect(written.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(written.updatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);


### PR DESCRIPTION
## Summary

- **Introduce `planOp` and `decomposeOp`** in `src/operations/` — both operations dispatch through `callOp(ctx, op, input)` using the `completeAs` path, eliminating the ad-hoc `planAs`/`decomposeAs` routes
- **`src/cli/plan.ts` auto mode** now calls `callOp(ctx, planOp, input)` instead of `agentManager.planAs()` directly — interactive path and debate fallback are unchanged
- **`adapter.plan()` and `adapter.decompose()`** now throw `NaxError("ADAPTER_METHOD_DEPRECATED")` immediately with a migration hint pointing to the new ops
- **Agent manager wiring**: `completeAs` path updated to support op dispatch; `planAs`/`decomposeAs` retained for interactive/fallback paths
- **Tests updated**:
  - `adapter-phase3`, `plan.test.ts`, `decompose.test.ts` — rewritten to verify deprecation behaviour (throw `ADAPTER_METHOD_DEPRECATED`)
  - `plan-debate`, `plan-monorepo`, `plan-decompose-*` — updated to intercept `completeAsFn` (the new dispatch path) and use `makeNaxConfig()` so `config.models` is defined

## Test plan

- [ ] `bun run test` — all 1191 tests pass, 0 failures
- [ ] Typecheck clean: `bun run typecheck`
- [ ] Lint clean: `bun run lint`
- [ ] AC2 in `plan-debate.test.ts` now asserts `completeAs` called once (not deprecated `planAs`)
- [ ] AC2 in `plan-monorepo.test.ts` captures prompt from `completeAs` 2nd arg (not `opts.prompt`)
- [ ] `adapter.plan()` / `adapter.decompose()` throw `ADAPTER_METHOD_DEPRECATED` with `callOp` migration hint