### PR TITLE
fix: preserve escalated retries and refresh ready-story batching

### DIFF
--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -42,6 +42,19 @@ function buildEscalationFailure(
   };
 }
 
+function buildEscalationRecord(
+  currentTier: string,
+  nextTier: string,
+  reason: string,
+): UserStory["escalations"][number] {
+  return {
+    fromTier: currentTier,
+    toTier: nextTier,
+    reason,
+    timestamp: new Date().toISOString(),
+  };
+}
+
 /**
  * Determine the outcome when max attempts are reached for an escalation.
  *
@@ -115,12 +128,14 @@ export async function preIterationTierCheck(
   const routingMode = config.routing.llm?.mode ?? "hybrid";
 
   if (escalationResult && config.autoMode.escalation.enabled) {
+    const escalatedTier = escalationResult.tier;
+
     logger?.warn("escalation", "Story exceeded tier budget, escalating", {
       storyId: story.id,
       attempts: story.attempts,
       tierAttempts: tierCfg.attempts,
       currentTier,
-      nextTier,
+      nextTier: escalatedTier,
     });
 
     // Update story routing in PRD and reset attempts for new tier
@@ -131,9 +146,25 @@ export async function preIterationTierCheck(
           ? {
               ...s,
               attempts: 0, // Reset attempts for new tier
+              escalations: [
+                ...(s.escalations || []),
+                buildEscalationRecord(
+                  currentTier,
+                  escalatedTier,
+                  `Exceeded tier budget for ${currentTier} (${story.attempts}/${tierCfg.attempts})`,
+                ),
+              ],
               routing: s.routing
-                ? { ...s.routing, modelTier: nextTier, ...(nextAgent !== undefined ? { agent: nextAgent } : {}) }
-                : { ...routing, modelTier: nextTier, ...(nextAgent !== undefined ? { agent: nextAgent } : {}) },
+                ? {
+                    ...s.routing,
+                    modelTier: escalatedTier,
+                    ...(nextAgent !== undefined ? { agent: nextAgent } : {}),
+                  }
+                : {
+                    ...routing,
+                    modelTier: escalatedTier,
+                    ...(nextAgent !== undefined ? { agent: nextAgent } : {}),
+                  },
             }
           : s,
       ) as PRD["userStories"],
@@ -282,6 +313,8 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
     return await handleMaxAttemptsReached(ctx, escalateFailureCategory);
   }
 
+  const escalatedTier = escalationResult.tier;
+
   // Can escalate — log and update stories
   for (const s of storiesToEscalate) {
     const currentTestStrategy = s.routing?.testStrategy ?? ctx.routing.testStrategy;
@@ -299,7 +332,7 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
     } else {
       logger?.warn("escalation", "Escalating story to next tier", {
         storyId: s.id,
-        nextTier,
+        nextTier: escalatedTier,
         retryAsLite: escalateRetryAsLite,
       });
     }
@@ -323,7 +356,7 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
       const baseRouting = s.routing ?? { ...ctx.routing };
       const updatedRouting = {
         ...baseRouting,
-        modelTier: shouldSwitchToTestAfter ? baseRouting.modelTier : nextTier,
+        modelTier: shouldSwitchToTestAfter ? baseRouting.modelTier : escalatedTier,
         ...(nextAgent !== undefined ? { agent: nextAgent } : {}),
         ...(escalateRetryAsLite ? { testStrategy: "three-session-tdd-lite" as const } : {}),
         ...(shouldSwitchToTestAfter ? { testStrategy: "test-after" as const } : {}),
@@ -331,8 +364,16 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
 
       // BUG-011: Reset attempt counter on tier escalation
       const currentStoryTier = s.routing?.modelTier ?? ctx.routing.modelTier;
-      const isChangingTier = currentStoryTier !== nextTier;
+      const isChangingTier = currentStoryTier !== escalatedTier;
       const shouldResetAttempts = isChangingTier || shouldSwitchToTestAfter;
+      const escalationRecord =
+        isChangingTier || shouldSwitchToTestAfter
+          ? buildEscalationRecord(
+              currentStoryTier,
+              shouldSwitchToTestAfter ? currentStoryTier : escalatedTier,
+              ctx.pipelineResult.reason ?? "Escalated to next retry path",
+            )
+          : undefined;
 
       // Build escalation failure (BUG-067: include cost for accumulatedAttemptCost in metrics)
       const escalationFailure = buildEscalationFailure(s, currentStoryTier, escalateReviewFindings, ctx.attemptCost);
@@ -340,6 +381,11 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
       return {
         ...s,
         attempts: shouldResetAttempts ? 0 : (s.attempts ?? 0) + 1,
+        ...(escalationRecord
+          ? {
+              escalations: [...(s.escalations || []), escalationRecord],
+            }
+          : {}),
         routing: updatedRouting,
         priorErrors: [...(s.priorErrors || []), errorMessage],
         // Cap at 3 entries — only the most recent failures are useful for the next tier.

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -16,6 +16,7 @@ import type { PipelineContext } from "../pipeline/types";
 import { countStories, isComplete, isStalled, loadPRD } from "../prd";
 import type { PRD } from "../prd/types";
 import { buildNaxIgnoreIndex } from "../utils/path-filters";
+import { precomputeBatchPlan } from "./batching";
 import { startHeartbeat } from "./crash-recovery";
 import { captureRunStartRef, runDeferredReview } from "./deferred-review";
 import type { DeferredReviewResult } from "./deferred-review";
@@ -54,7 +55,6 @@ export async function executeUnified(
   let storiesCompleted = 0;
   let totalCost = 0;
   let lastStoryId: string | null = null;
-  let currentBatchIndex = 0;
   const allStoryMetrics: StoryMetrics[] = [];
   let warningSent = false;
   let deferredReview: DeferredReviewResult | undefined;
@@ -457,13 +457,9 @@ export async function executeUnified(
       }
 
       // Sequential single-story dispatch
-      const selected = selectNextStories(prd, ctx.config, ctx.batchPlan, currentBatchIndex, lastStoryId, ctx.useBatch);
+      const currentBatchPlan = ctx.useBatch ? precomputeBatchPlan(getAllReadyStories(prd), 4) : ctx.batchPlan;
+      const selected = selectNextStories(prd, ctx.config, currentBatchPlan, 0, lastStoryId, ctx.useBatch);
       if (!selected) return buildResult("no-stories");
-      if (!selected.selection) {
-        currentBatchIndex = selected.nextBatchIndex;
-        continue;
-      }
-      currentBatchIndex = selected.nextBatchIndex;
       const { selection } = selected;
       if (!ctx.useBatch) lastStoryId = selection.story.id;
 

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -71,6 +71,22 @@ export async function savePRD(prd: PRD, path: string): Promise<void> {
   await saveJsonFile(path, prd, "prd");
 }
 
+function hasSatisfiedDependencies(story: UserStory, storyIds: Set<string>, completedIds: Set<string>): boolean {
+  return story.dependencies.every((dep) => !storyIds.has(dep) || completedIds.has(dep));
+}
+
+function isResumableCurrentStory(story: UserStory, maxRetries: number): boolean {
+  if (story.status === "failed") {
+    return (story.attempts ?? 0) <= maxRetries;
+  }
+
+  if (story.status !== "pending") {
+    return false;
+  }
+
+  return (story.attempts ?? 0) > 0 || (story.escalations?.length ?? 0) > 0 || (story.priorFailures?.length ?? 0) > 0;
+}
+
 /**
  * Get the next story to work on.
  *
@@ -85,23 +101,22 @@ export async function savePRD(prd: PRD, path: string): Promise<void> {
  * @param maxRetries - Max retry attempts per story before giving up (optional)
  */
 export function getNextStory(prd: PRD, currentStoryId?: string | null, maxRetries?: number): UserStory | null {
-  // Priority 1: Retry current story if failed but has attempts remaining
-  if (currentStoryId != null && maxRetries != null && maxRetries > 0) {
-    const currentStory = prd.userStories.find((s) => s.id === currentStoryId);
-    if (currentStory && currentStory.status === "failed" && (currentStory.attempts ?? 0) <= maxRetries) {
-      return currentStory;
-    }
-    // BUG-029: After tier escalation, story is set to "pending" (not "failed").
-    // Prioritize current story if it was escalated (pending + has prior attempts).
-    if (currentStory && currentStory.status === "pending" && (currentStory.attempts ?? 0) > 0) {
-      return currentStory;
-    }
-  }
-
   const storyIds = new Set(prd.userStories.map((s) => s.id));
   const completedIds = new Set(
     prd.userStories.filter((s) => s.passes || s.status === "passed" || s.status === "skipped").map((s) => s.id),
   );
+
+  // Priority 1: Retry current story if failed but has attempts remaining
+  if (currentStoryId != null && maxRetries != null && maxRetries > 0) {
+    const currentStory = prd.userStories.find((s) => s.id === currentStoryId);
+    if (
+      currentStory &&
+      isResumableCurrentStory(currentStory, maxRetries) &&
+      hasSatisfiedDependencies(currentStory, storyIds, completedIds)
+    ) {
+      return currentStory;
+    }
+  }
 
   return (
     prd.userStories.find(
@@ -113,8 +128,7 @@ export function getNextStory(prd: PRD, currentStoryId?: string | null, maxRetrie
         s.status !== "failed" &&
         s.status !== "paused" &&
         s.status !== "decomposed" &&
-        // A dep is fulfilled if it is not in this PRD (external/prior-phase) or it is completed.
-        s.dependencies.every((dep) => !storyIds.has(dep) || completedIds.has(dep)),
+        hasSatisfiedDependencies(s, storyIds, completedIds),
     ) ?? null
   );
 }

--- a/test/unit/execution/unified-executor-dispatch.test.ts
+++ b/test/unit/execution/unified-executor-dispatch.test.ts
@@ -12,6 +12,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { join } from "node:path";
+import { precomputeBatchPlan } from "../../../src/execution/batching";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Test fixture helpers
@@ -315,3 +316,74 @@ describe("AC-5 — story:started per-batch story via _deps injection", () => {
   });
 });
 
+describe("useBatch scheduling refresh", () => {
+  let deps: Record<string, unknown>;
+  let origRunIteration: unknown;
+
+  beforeEach(async () => {
+    const mod = await import("../../../src/execution/unified-executor");
+    deps = (mod as Record<string, unknown>)._unifiedExecutorDeps as Record<string, unknown>;
+    origRunIteration = deps.runIteration;
+  });
+
+  afterEach(() => {
+    if (deps) {
+      deps.runIteration = origRunIteration;
+    }
+    mock.restore();
+  });
+
+  test("recomputes the batch plan after a story completes so newly unblocked stories run next", async () => {
+    const us000 = {
+      ...makePendingStory("US-000"),
+      routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "simple" },
+    };
+    const us001 = {
+      ...makePendingStory("US-001"),
+      dependencies: ["US-000"],
+      routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "simple" },
+    };
+    const us006 = {
+      ...makePendingStory("US-006"),
+      routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "simple" },
+    };
+
+    const initialPrd = makePrd([us000, us001, us006]);
+    const staleBatchPlan = precomputeBatchPlan([us000, us006], 4);
+    const selectedStoryIds: string[] = [];
+
+    deps.runIteration = mock(async (_ctx: unknown, prdArg: typeof initialPrd, selection: { story: { id: string } }) => {
+      selectedStoryIds.push(selection.story.id);
+      const nextPrd = {
+        ...prdArg,
+        userStories: prdArg.userStories.map((story) =>
+          story.id === selection.story.id ? { ...story, status: "passed" as const, passes: true } : story,
+        ),
+      };
+      return {
+        prd: nextPrd,
+        storiesCompletedDelta: 1,
+        costDelta: 0,
+        prdDirty: false,
+      };
+    });
+
+    const { executeUnified } = await import("../../../src/execution/unified-executor");
+    const ctx = {
+      ...makeCtx(),
+      config: {
+        ...makeCtx().config,
+        execution: {
+          ...makeCtx().config.execution,
+          maxIterations: 2,
+        },
+      },
+      useBatch: true,
+      batchPlan: staleBatchPlan,
+    };
+
+    await executeUnified(ctx as never, initialPrd as never);
+
+    expect(selectedStoryIds).toEqual(["US-000", "US-001"]);
+  });
+});

--- a/test/unit/metrics/tracker-escalation.test.ts
+++ b/test/unit/metrics/tracker-escalation.test.ts
@@ -388,6 +388,18 @@ describe("handleTierEscalation — priorFailures records attempt data for cross-
         expect(updatedStory!.routing?.modelTier).toBe("balanced");
       },
     },
+    {
+      name: "escalated story records escalation history for retry prioritization",
+      checkKey: "escalations",
+      assertion: (updatedStory: any) => {
+        expect(updatedStory!.escalations).toBeDefined();
+        expect(updatedStory!.escalations.length).toBe(1);
+        expect(updatedStory!.escalations[0]).toMatchObject({
+          fromTier: "fast",
+          toTier: "balanced",
+        });
+      },
+    },
   ])(
     "$name",
     async ({ checkKey, assertion }) => {

--- a/test/unit/prd/prd-get-next-story.test.ts
+++ b/test/unit/prd/prd-get-next-story.test.ts
@@ -186,7 +186,7 @@ describe("getNextStory() — run order S1-I1 -> S1-I2 (retry) -> S2-I1", () => {
     expect(pick2?.id).toBe("US-002");
   });
 
-  test("BUG-029: prioritizes escalated story (pending + attempts > 0) over other pending stories", () => {
+  test("BUG-029: prioritizes escalated story when attempt counter still reflects prior work", () => {
     const prd = makePrd([makeStory("US-001"), makeStory("US-002"), makeStory("US-003")]);
     const maxRetries = 2;
 
@@ -198,6 +198,40 @@ describe("getNextStory() — run order S1-I1 -> S1-I2 (retry) -> S2-I1", () => {
     // getNextStory should prioritize US-001 (escalated, pending with attempts)
     const pick = getNextStory(prd, "US-001", maxRetries);
     expect(pick?.id).toBe("US-001");
+  });
+
+  test("BUG-029: prioritizes escalated story after tier bump resets attempts to 0", () => {
+    const prd = makePrd([makeStory("US-006"), makeStory("US-001")]);
+    const maxRetries = 2;
+
+    prd.userStories[0].status = "pending";
+    prd.userStories[0].attempts = 0;
+    prd.userStories[0].routing = {
+      complexity: "complex",
+      modelTier: "balanced",
+      testStrategy: "three-session-tdd",
+      reasoning: "Escalated after fast-tier failure",
+    };
+    prd.userStories[0].escalations = [
+      {
+        fromTier: "fast",
+        toTier: "balanced",
+        reason: "Autofix exhausted",
+        timestamp: new Date().toISOString(),
+      },
+    ];
+    prd.userStories[0].priorFailures = [
+      {
+        attempt: 1,
+        modelTier: "fast",
+        stage: "review",
+        summary: "Failed with tier fast, escalating to balanced",
+        timestamp: new Date().toISOString(),
+      },
+    ];
+
+    const pick = getNextStory(prd, "US-006", maxRetries);
+    expect(pick?.id).toBe("US-006");
   });
 
   test("BUG-029: does not reprioritize story with 0 attempts (fresh pending)", () => {


### PR DESCRIPTION
## Summary
- preserve retry priority after tier escalation even when the new tier resets attempts to 0
- rebuild the sequential batch plan from the current ready-story set so newly unblocked stories run in PRD order
- add regression coverage for both scheduler bugs

## Testing
- bun test test/unit/execution/unified-executor-dispatch.test.ts --timeout=30000
- bun test test/unit/prd/prd-get-next-story.test.ts test/unit/metrics/tracker-escalation.test.ts test/unit/execution/escalation/tier-escalation.test.ts --timeout=30000
- bun run typecheck

Closes #728
Closes #729