### PR TITLE
refactor(adr-018): Wave 3 Phase D — keepOpen migration to ADR-019 caller-managed sessions

### DIFF
--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -30,6 +30,8 @@ export interface SuccessfulProposal {
   /** Cost for this complete() call in USD. */
   cost: number;
   roleKey?: string;
+  /** Caller-managed session handle for stateful turns (ADR-019 §4). */
+  handle?: import("../agents/types").SessionHandle;
 }
 
 export interface ResolveOutcome {
@@ -72,6 +74,8 @@ export interface DebateSessionOptions {
   timeoutSeconds?: number;
   /** AgentManager threaded from the pipeline stage — ensures unavailability state survives across debate calls. */
   agentManager?: IAgentManager;
+  /** Session manager for caller-managed session lifecycle (ADR-019 §4). */
+  sessionManager?: import("../session/types").ISessionManager;
   /** Optional ReviewerSession for debate+dialogue mode (US-001/US-002) */
   reviewerSession?: import("../review/dialogue").ReviewerSession;
   /** Outer resolver context (without labeledProposals) — sub-modules complete it */

--- a/src/debate/session-hybrid.ts
+++ b/src/debate/session-hybrid.ts
@@ -2,8 +2,6 @@
  * session-hybrid.ts
  *
  * runHybrid() implementation for hybrid-mode debate sessions.
- * Proposal round runs all debaters in parallel via allSettledBounded.
- * The rebuttal loop is implemented in US-004-B.
  */
 
 import type { IAgentManager } from "../agents";
@@ -18,9 +16,12 @@ import {
   type SuccessfulProposal,
   _debateSessionDeps,
   buildFailedResult,
+  modelTierFromDebater,
+  pipelineStageForDebate,
+  resolveModelDefForDebater,
   resolveOutcome,
 } from "./session-helpers";
-import { closeStatefulSession, runStatefulTurn } from "./session-stateful";
+import { runStatefulTurn } from "./session-stateful";
 import type { DebateResult, DebateStageConfig, Rebuttal } from "./types";
 
 /** Result of the rebuttal loop — rebuttals collected + accumulated cost. */
@@ -38,20 +39,15 @@ export interface HybridCtx {
   readonly featureName: string;
   readonly timeoutSeconds: number;
   readonly agentManager?: IAgentManager;
+  readonly sessionManager?: import("../session/types").ISessionManager;
   readonly reviewerSession?: import("../review/dialogue").ReviewerSession;
   readonly resolverContextInput?: ResolverContextInput;
 }
 
 /**
- * Run the sequential rebuttal loop across all debaters for N rounds,
- * then close all sessions in a finally block.
- *
- * SSOT for hybrid-mode rebuttal logic — called by runHybrid() and runPlan().
- *
- * @param ctx                - Session context (must include workdir/featureName/timeoutSeconds)
- * @param proposals          - Successful proposals with adapter references
- * @param builder            - Prompt builder (constructed by caller with successful debaters)
- * @param sessionRolePrefix  - Prefix for session roles (e.g. "debate-hybrid", "plan-hybrid")
+ * Run the sequential rebuttal loop across all debaters for N rounds.
+ * Uses proposal.handle when present (hybrid mode); opens fresh sessions otherwise (plan-mode).
+ * Closes only internally-opened handles in finally.
  */
 export async function runRebuttalLoop(
   ctx: HybridCtx,
@@ -69,6 +65,40 @@ export async function runRebuttalLoop(
   }
 
   const proposalList = proposals.map((s) => ({ debater: s.debater, output: s.output }));
+  const sessionManager = ctx.sessionManager;
+
+  // Resolve effective handles — use caller-supplied handles when present (hybrid mode),
+  // open fresh sessions otherwise (plan-mode rebuttals where proposals came from planAs).
+  const internalHandles: Array<import("../agents/types").SessionHandle | null> = [];
+  for (let i = 0; i < proposals.length; i++) {
+    const proposal = proposals[i];
+    const sessionRole = `${sessionRolePrefix}-${i}`;
+    if (proposal.handle) {
+      internalHandles.push(null); // Caller owns this handle; we do not close it
+    } else if (sessionManager) {
+      const modelTier = modelTierFromDebater(proposal.debater);
+      const modelDef = resolveModelDefForDebater(proposal.debater, modelTier, ctx.config);
+      const name = sessionManager.nameFor({
+        workdir: ctx.workdir,
+        featureName: ctx.featureName,
+        storyId: ctx.storyId,
+        role: sessionRole,
+      });
+      const handle = await sessionManager.openSession(name, {
+        agentName: proposal.agentName,
+        role: sessionRole,
+        workdir: ctx.workdir,
+        pipelineStage: pipelineStageForDebate(ctx.stage),
+        modelDef,
+        timeoutSeconds: ctx.timeoutSeconds,
+        featureName: ctx.featureName,
+        storyId: ctx.storyId,
+      });
+      internalHandles.push(handle);
+    } else {
+      internalHandles.push(null);
+    }
+  }
 
   try {
     for (let round = 1; round <= config.rounds; round++) {
@@ -76,7 +106,8 @@ export async function runRebuttalLoop(
 
       for (let debaterIdx = 0; debaterIdx < proposals.length; debaterIdx++) {
         const proposal = proposals[debaterIdx];
-        const sessionRole = `${sessionRolePrefix}-${debaterIdx}`;
+        const effectiveHandle = proposal.handle ?? internalHandles[debaterIdx];
+        if (!effectiveHandle) continue;
 
         logger?.info("debate:rebuttal-start", "debate:rebuttal-start", {
           storyId: ctx.storyId,
@@ -87,16 +118,11 @@ export async function runRebuttalLoop(
         const rebuttalPrompt = builder.buildRebuttalPrompt(debaterIdx, proposalList, priorRebuttals);
 
         try {
-          const turnResult = await runStatefulTurn(
-            ctx,
-            agentManager,
-            proposal.agentName,
-            proposal.debater,
-            rebuttalPrompt,
-            sessionRole,
-            true,
-          );
-          costUsd += turnResult.cost;
+          const turnResult = await agentManager.runAsSession(proposal.agentName, effectiveHandle, rebuttalPrompt, {
+            storyId: ctx.storyId,
+            pipelineStage: pipelineStageForDebate(ctx.stage),
+          });
+          costUsd += turnResult.cost?.total ?? 0;
           rebuttals.push({ debater: proposal.debater, round, output: turnResult.output });
         } catch (err) {
           logger?.warn("debate", "debate:rebuttal-failed", {
@@ -109,20 +135,14 @@ export async function runRebuttalLoop(
       }
     }
   } finally {
-    for (let debaterIdx = 0; debaterIdx < proposals.length; debaterIdx++) {
-      const proposal = proposals[debaterIdx];
-      const sessionRole = `${sessionRolePrefix}-${debaterIdx}`;
-      try {
-        const closeCost = await closeStatefulSession(
-          ctx,
-          agentManager,
-          proposal.agentName,
-          proposal.debater,
-          sessionRole,
-        );
-        costUsd += closeCost;
-      } catch {
-        // Ignore close errors
+    // Close only internally-opened handles (caller-supplied handles are closed by the caller)
+    for (const handle of internalHandles) {
+      if (handle && sessionManager) {
+        try {
+          await sessionManager.closeSession(handle);
+        } catch {
+          // Ignore close errors
+        }
       }
     }
   }
@@ -130,17 +150,6 @@ export async function runRebuttalLoop(
   return { rebuttals, costUsd };
 }
 
-/**
- * Run a hybrid-mode debate session.
- *
- * Proposal phase: all debaters run in parallel via allSettledBounded with
- * sessionRole 'debate-hybrid-{debaterIndex}' and keepOpen: true.
- * If fewer than 2 proposals succeed, returns the single-agent fallback result.
- * Rebuttal loop delegates to runRebuttalLoop() (SSOT).
- *
- * @param ctx    - Hybrid session context
- * @param prompt - The debate prompt
- */
 export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateResult> {
   const logger = _debateSessionDeps.getSafeLogger();
   const config = ctx.stageConfig;
@@ -148,13 +157,13 @@ export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateR
   const rawDebaters = config.debaters ?? [];
   const debaters = resolvePersonas(rawDebaters, personaStage, config.autoPersona ?? false);
   let totalCostUsd = 0;
+  const sessionManager = ctx.sessionManager;
 
   const agentManager = ctx.agentManager ?? _debateSessionDeps.agentManager;
   if (!agentManager) {
     return buildFailedResult(ctx.storyId, ctx.stage, config, 0);
   }
 
-  // Resolve agents via shared helper — skip unavailable
   const resolved: ResolvedDebater[] = [];
   for (const debater of debaters) {
     if (!agentManager.getAgent(debater.agent)) {
@@ -164,140 +173,187 @@ export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateR
     resolved.push({ debater, agentName: debater.agent });
   }
 
-  // Proposal round — bounded parallel, sessionRole 'debate-hybrid-{debaterIndex}'
   const debate = ctx.config?.debate;
   const concurrencyLimit = debate?.maxConcurrentDebaters ?? 2;
 
-  const proposalSettled = await allSettledBounded(
-    resolved.map(
-      ({ debater, agentName }, debaterIdx) =>
-        () =>
-          runStatefulTurn(ctx, agentManager, agentName, debater, prompt, `debate-hybrid-${debaterIdx}`, true),
-    ),
-    concurrencyLimit,
-  );
+  // Pre-open one session per resolved debater
+  const openHandles: Array<import("../agents/types").SessionHandle | null> = [];
 
-  const successfulProposals: SuccessfulProposal[] = proposalSettled
-    .filter((r): r is PromiseFulfilledResult<SuccessfulProposal> => r.status === "fulfilled")
-    .map((r) => r.value);
-
-  for (const r of proposalSettled) {
-    if (r.status === "fulfilled") {
-      totalCostUsd += r.value.cost;
-    }
-  }
-
-  // Fewer than 2 succeeded — single-agent fallback for resiliency
-  if (successfulProposals.length < 2) {
-    if (successfulProposals.length === 1) {
-      const solo = successfulProposals[0];
-      logger?.warn("debate", "debate:fallback", {
-        storyId: ctx.storyId,
-        stage: ctx.stage,
-        reason: "only 1 debater succeeded",
-      });
-      return {
-        storyId: ctx.storyId,
-        stage: ctx.stage,
-        outcome: "passed",
-        rounds: 1,
-        debaters: [solo.debater.agent],
-        resolverType: config.resolver.type,
-        proposals: [{ debater: solo.debater, output: solo.output }],
-        totalCostUsd,
-      };
+  try {
+    for (let i = 0; i < resolved.length; i++) {
+      const { debater, agentName } = resolved[i];
+      const sessionRole = `debate-hybrid-${i}`;
+      if (sessionManager) {
+        const modelTier = modelTierFromDebater(debater);
+        const modelDef = resolveModelDefForDebater(debater, modelTier, ctx.config);
+        const name = sessionManager.nameFor({
+          workdir: ctx.workdir,
+          featureName: ctx.featureName,
+          storyId: ctx.storyId,
+          role: sessionRole,
+        });
+        const handle = await sessionManager.openSession(name, {
+          agentName,
+          role: sessionRole,
+          workdir: ctx.workdir,
+          pipelineStage: pipelineStageForDebate(ctx.stage),
+          modelDef,
+          timeoutSeconds: ctx.timeoutSeconds,
+          featureName: ctx.featureName,
+          storyId: ctx.storyId,
+        });
+        openHandles.push(handle);
+      } else {
+        openHandles.push(null);
+      }
     }
 
-    // 0 succeeded — retry with first resolved agent
-    if (resolved.length > 0) {
-      const { agentName: fallbackAgentName, debater: fallbackDebater } = resolved[0];
-      logger?.warn("debate", "debate:fallback", {
-        storyId: ctx.storyId,
-        stage: ctx.stage,
-        reason: "all debaters failed — retrying with first adapter",
-      });
-      try {
-        const fallbackResult = await runStatefulTurn(
-          ctx,
-          agentManager,
-          fallbackAgentName,
-          fallbackDebater,
-          prompt,
-          "debate-hybrid-fallback",
-          false,
-        );
-        totalCostUsd += fallbackResult.cost;
+    const proposalSettled = await allSettledBounded(
+      resolved.map(({ debater, agentName }, debaterIdx) => () => {
+        const handle = openHandles[debaterIdx];
+        if (!handle) {
+          return Promise.reject(new Error(`No session handle for hybrid debater ${debaterIdx}`));
+        }
+        return runStatefulTurn(ctx, agentManager, agentName, debater, prompt, handle);
+      }),
+      concurrencyLimit,
+    );
+
+    const successfulProposals: SuccessfulProposal[] = proposalSettled
+      .filter((r): r is PromiseFulfilledResult<SuccessfulProposal> => r.status === "fulfilled")
+      .map((r) => r.value);
+
+    for (const r of proposalSettled) {
+      if (r.status === "fulfilled") {
+        totalCostUsd += r.value.cost;
+      }
+    }
+
+    // Fewer than 2 succeeded — single-agent fallback
+    if (successfulProposals.length < 2) {
+      if (successfulProposals.length === 1) {
+        const solo = successfulProposals[0];
+        logger?.warn("debate", "debate:fallback", {
+          storyId: ctx.storyId,
+          stage: ctx.stage,
+          reason: "only 1 debater succeeded",
+        });
         return {
           storyId: ctx.storyId,
           stage: ctx.stage,
           outcome: "passed",
           rounds: 1,
-          debaters: [fallbackDebater.agent],
+          debaters: [solo.debater.agent],
           resolverType: config.resolver.type,
-          proposals: [{ debater: fallbackDebater, output: fallbackResult.output }],
+          proposals: [{ debater: solo.debater, output: solo.output }],
           totalCostUsd,
         };
-      } catch {
-        // Retry also failed — fall through to failed result
       }
+
+      // 0 succeeded — retry with first resolved agent (use existing open handle)
+      if (resolved.length > 0) {
+        const { agentName: fallbackAgentName, debater: fallbackDebater } = resolved[0];
+        const fallbackHandle = openHandles[0];
+        logger?.warn("debate", "debate:fallback", {
+          storyId: ctx.storyId,
+          stage: ctx.stage,
+          reason: "all debaters failed — retrying with first adapter",
+        });
+        try {
+          if (fallbackHandle) {
+            const fallbackResult = await runStatefulTurn(
+              ctx,
+              agentManager,
+              fallbackAgentName,
+              fallbackDebater,
+              prompt,
+              fallbackHandle,
+            );
+            totalCostUsd += fallbackResult.cost;
+            return {
+              storyId: ctx.storyId,
+              stage: ctx.stage,
+              outcome: "passed",
+              rounds: 1,
+              debaters: [fallbackDebater.agent],
+              resolverType: config.resolver.type,
+              proposals: [{ debater: fallbackDebater, output: fallbackResult.output }],
+              totalCostUsd,
+            };
+          }
+        } catch {
+          // Retry also failed — fall through to failed result
+        }
+      }
+
+      return buildFailedResult(ctx.storyId, ctx.stage, config, totalCostUsd);
     }
 
-    return buildFailedResult(ctx.storyId, ctx.stage, config, totalCostUsd);
-  }
+    const proposalOutputs = successfulProposals.map((s) => s.output);
+    const proposalList = successfulProposals.map((s) => ({ debater: s.debater, output: s.output }));
 
-  // Collect proposal outputs ready for resolve()
-  const proposalOutputs = successfulProposals.map((s) => s.output);
-  const proposalList = successfulProposals.map((s) => ({ debater: s.debater, output: s.output }));
+    // Rebuttal loop — successfulProposals carry handles, so runRebuttalLoop uses them directly
+    const rebuttalBuilder = new DebatePromptBuilder(
+      { taskContext: prompt, outputFormat: "", stage: ctx.stage },
+      { debaters: successfulProposals.map((s) => s.debater), sessionMode: "stateful" },
+    );
+    const { rebuttals, costUsd: rebuttalCost } = await runRebuttalLoop(
+      ctx,
+      successfulProposals,
+      rebuttalBuilder,
+      "debate-hybrid",
+    );
+    totalCostUsd += rebuttalCost;
 
-  // Rebuttal loop + session cleanup — delegated to SSOT
-  const rebuttalBuilder = new DebatePromptBuilder(
-    { taskContext: prompt, outputFormat: "", stage: ctx.stage },
-    { debaters: successfulProposals.map((s) => s.debater), sessionMode: "stateful" },
-  );
-  const { rebuttals, costUsd: rebuttalCost } = await runRebuttalLoop(
-    ctx,
-    successfulProposals,
-    rebuttalBuilder,
-    "debate-hybrid",
-  );
-  totalCostUsd += rebuttalCost;
+    const critiqueOutputs = rebuttals.map((r) => r.output);
 
-  const critiqueOutputs = rebuttals.map((r) => r.output);
+    const fullResolverContext = ctx.resolverContextInput
+      ? {
+          ...ctx.resolverContextInput,
+          labeledProposals: successfulProposals.map((s) => ({
+            debater: buildDebaterLabel(s.debater),
+            output: s.output,
+          })),
+        }
+      : undefined;
+    const resolveResult: ResolveOutcome = await resolveOutcome(
+      proposalOutputs,
+      critiqueOutputs,
+      ctx.stageConfig,
+      ctx.config,
+      ctx.storyId,
+      ctx.timeoutSeconds * 1000,
+      ctx.workdir,
+      ctx.featureName,
+      ctx.reviewerSession,
+      fullResolverContext,
+      /* promptSuffix */ undefined,
+      successfulProposals.map((s) => s.debater),
+      agentManager,
+    );
+    totalCostUsd += resolveResult.resolverCostUsd;
 
-  const fullResolverContext = ctx.resolverContextInput
-    ? {
-        ...ctx.resolverContextInput,
-        labeledProposals: successfulProposals.map((s) => ({ debater: buildDebaterLabel(s.debater), output: s.output })),
+    return {
+      storyId: ctx.storyId,
+      stage: ctx.stage,
+      outcome: "passed",
+      rounds: config.rounds,
+      debaters: successfulProposals.map((s) => s.debater.agent),
+      resolverType: config.resolver.type,
+      proposals: proposalList,
+      rebuttals,
+      totalCostUsd,
+    };
+  } finally {
+    // Close all pre-opened handles
+    for (const handle of openHandles) {
+      if (handle && sessionManager) {
+        try {
+          await sessionManager.closeSession(handle);
+        } catch {
+          // Ignore close errors
+        }
       }
-    : undefined;
-  const resolveResult: ResolveOutcome = await resolveOutcome(
-    proposalOutputs,
-    critiqueOutputs,
-    ctx.stageConfig,
-    ctx.config,
-    ctx.storyId,
-    ctx.timeoutSeconds * 1000,
-    ctx.workdir,
-    ctx.featureName,
-    ctx.reviewerSession,
-    fullResolverContext,
-    /* promptSuffix */ undefined,
-    successfulProposals.map((s) => s.debater),
-    agentManager,
-  );
-  totalCostUsd += resolveResult.resolverCostUsd;
-
-  return {
-    storyId: ctx.storyId,
-    stage: ctx.stage,
-    // In hybrid mode, 2+ proposals succeeded — the debate ran successfully.
-    // Resolver provides cost; pass/fail is determined by proposal success.
-    outcome: "passed",
-    rounds: config.rounds,
-    debaters: successfulProposals.map((s) => s.debater.agent),
-    resolverType: config.resolver.type,
-    proposals: proposalList,
-    rebuttals,
-    totalCostUsd,
-  };
+    }
+  }
 }

--- a/src/debate/session-plan.ts
+++ b/src/debate/session-plan.ts
@@ -30,6 +30,7 @@ interface PlanCtx {
   readonly stageConfig: DebateStageConfig;
   readonly config: NaxConfig;
   readonly agentManager?: IAgentManager;
+  readonly sessionManager?: import("../session/types").ISessionManager;
 }
 
 export async function runPlan(
@@ -188,6 +189,7 @@ export async function runPlan(
       workdir: opts.workdir,
       featureName: opts.feature,
       timeoutSeconds: opts.timeoutSeconds ?? 600,
+      sessionManager: ctx.sessionManager,
     };
     const rebuttalBuilder = new DebatePromptBuilder(
       { taskContext, outputFormat: "", stage: "plan" },

--- a/src/debate/session-stateful.ts
+++ b/src/debate/session-stateful.ts
@@ -1,12 +1,11 @@
 /**
  * session-stateful.ts
  *
- * Extracted runStateful(), runStatefulTurn(), and closeStatefulSession()
- * implementations for DebateSession.
+ * Extracted runStateful(), runStatefulTurn() implementations for DebateSession.
  */
 
 import type { IAgentManager } from "../agents";
-import type { ModelDef, ModelTier } from "../config";
+import type { ModelDef } from "../config";
 import type { NaxConfig } from "../config";
 import { DebatePromptBuilder } from "../prompts";
 import { allSettledBounded } from "./concurrency";
@@ -34,6 +33,7 @@ interface StatefulCtx {
   readonly featureName: string;
   readonly timeoutSeconds: number;
   readonly agentManager?: IAgentManager;
+  readonly sessionManager?: import("../session/types").ISessionManager;
   readonly reviewerSession?: import("../review/dialogue").ReviewerSession;
   readonly resolverContextInput?: ResolverContextInput;
 }
@@ -44,72 +44,22 @@ export async function runStatefulTurn(
   agentName: string,
   debater: Debater,
   prompt: string,
-  roleKey: string,
-  keepOpen: boolean,
+  handle: import("../agents/types").SessionHandle,
 ): Promise<SuccessfulProposal> {
-  const modelTier = modelTierFromDebater(debater);
-  const modelDef: ModelDef = resolveModelDefForDebater(debater, modelTier, ctx.config);
   const pipelineStage = pipelineStageForDebate(ctx.stage);
 
-  const runResult = await agentManager.runAs(agentName, {
-    runOptions: {
-      prompt,
-      workdir: ctx.workdir,
-      modelTier,
-      modelDef,
-      timeoutSeconds: ctx.timeoutSeconds,
-      pipelineStage,
-      config: ctx.config,
-      featureName: ctx.featureName,
-      storyId: ctx.storyId,
-      sessionRole: roleKey,
-      maxInteractionTurns: ctx.config?.agent?.maxInteractionTurns,
-      keepOpen,
-    },
+  const turnResult = await agentManager.runAsSession(agentName, handle, prompt, {
+    storyId: ctx.storyId,
+    pipelineStage,
   });
-
-  if (!runResult.success) {
-    throw new Error(runResult.output || `Stateful debate turn failed for ${debater.agent}`);
-  }
 
   return {
     debater,
     agentName,
-    output: runResult.output,
-    cost: runResult.estimatedCost,
-    roleKey,
+    output: turnResult.output,
+    cost: turnResult.cost?.total ?? 0,
+    handle,
   };
-}
-
-export async function closeStatefulSession(
-  ctx: StatefulCtx,
-  agentManager: IAgentManager,
-  agentName: string,
-  debater: Debater,
-  roleKey: string,
-): Promise<number> {
-  const modelTier: ModelTier = modelTierFromDebater(debater);
-  const modelDef: ModelDef = resolveModelDefForDebater(debater, modelTier, ctx.config);
-  const pipelineStage = pipelineStageForDebate(ctx.stage);
-
-  const runResult = await agentManager.runAs(agentName, {
-    runOptions: {
-      prompt: "Close this debate session.",
-      workdir: ctx.workdir,
-      modelTier,
-      modelDef,
-      timeoutSeconds: ctx.timeoutSeconds,
-      pipelineStage,
-      config: ctx.config,
-      featureName: ctx.featureName,
-      storyId: ctx.storyId,
-      sessionRole: roleKey,
-      maxInteractionTurns: ctx.config?.agent?.maxInteractionTurns,
-      keepOpen: false,
-    },
-  });
-
-  return runResult.success ? runResult.estimatedCost : 0;
 }
 
 export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<DebateResult> {
@@ -124,7 +74,6 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
     return buildFailedResult(ctx.storyId, ctx.stage, config, 0);
   }
 
-  // Resolve agents — skip unavailable
   const resolved: ResolvedDebater[] = [];
   for (const debater of debaters) {
     if (!agentManager.getAgent(debater.agent)) {
@@ -140,87 +89,84 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
     debaters: resolved.map((r) => r.debater.agent),
   });
 
-  // Proposal round — bounded parallel
   const debate = ctx.config?.debate;
   const concurrencyLimit = debate?.maxConcurrentDebaters ?? 2;
   const proposalBuilder = new DebatePromptBuilder(
     { taskContext: prompt, outputFormat: "", stage: ctx.stage },
     { debaters: resolved.map((r) => r.debater), sessionMode: "stateful" },
   );
-  const proposalSettled = await allSettledBounded(
-    resolved.map(
-      ({ debater, agentName }, debaterIdx) =>
-        () =>
-          runStatefulTurn(
-            ctx,
-            agentManager,
-            agentName,
-            debater,
-            proposalBuilder.buildProposalPrompt(debaterIdx),
-            `debate-${ctx.stage}-${debaterIdx}`,
-            config.rounds > 1,
-          ),
-    ),
-    concurrencyLimit,
-  );
 
-  const successfulProposals: SuccessfulProposal[] = proposalSettled
-    .filter((r): r is PromiseFulfilledResult<SuccessfulProposal> => r.status === "fulfilled")
-    .map((r) => r.value);
+  // Pre-open one session per resolved debater
+  const openHandles: Array<import("../agents/types").SessionHandle | null> = [];
+  const sessionManager = ctx.sessionManager;
 
-  for (const r of proposalSettled) {
-    if (r.status === "fulfilled") {
-      totalCostUsd += r.value.cost;
-    }
-  }
-
-  // Fewer than 2 succeeded — single-agent fallback for resiliency.
-  if (successfulProposals.length < 2) {
-    if (successfulProposals.length === 1) {
-      const solo = successfulProposals[0];
-      if (config.rounds > 1 && solo.roleKey) {
-        totalCostUsd += await closeStatefulSession(ctx, agentManager, solo.agentName, solo.debater, solo.roleKey);
+  try {
+    for (let i = 0; i < resolved.length; i++) {
+      const { debater, agentName } = resolved[i];
+      const roleKey = `debate-${ctx.stage}-${i}`;
+      if (sessionManager) {
+        const modelTier = modelTierFromDebater(debater);
+        const modelDef: ModelDef = resolveModelDefForDebater(debater, modelTier, ctx.config);
+        const name = sessionManager.nameFor({
+          workdir: ctx.workdir,
+          featureName: ctx.featureName,
+          storyId: ctx.storyId,
+          role: roleKey,
+        });
+        const handle = await sessionManager.openSession(name, {
+          agentName,
+          role: roleKey,
+          workdir: ctx.workdir,
+          pipelineStage: pipelineStageForDebate(ctx.stage),
+          modelDef,
+          timeoutSeconds: ctx.timeoutSeconds,
+          featureName: ctx.featureName,
+          storyId: ctx.storyId,
+        });
+        openHandles.push(handle);
+      } else {
+        openHandles.push(null);
       }
-      logger?.warn("debate", "debate:fallback", {
-        storyId: ctx.storyId,
-        stage: ctx.stage,
-        reason: "only 1 debater succeeded",
-      });
-      logger?.info("debate", "debate:result", {
-        storyId: ctx.storyId,
-        stage: ctx.stage,
-        outcome: "passed",
-      });
-      return {
-        storyId: ctx.storyId,
-        stage: ctx.stage,
-        outcome: "passed",
-        rounds: 1,
-        debaters: [solo.debater.agent],
-        resolverType: config.resolver.type,
-        proposals: [{ debater: solo.debater, output: solo.output }],
-        totalCostUsd,
-      };
     }
 
-    if (resolved.length > 0) {
-      const { agentName: fallbackAgentName, debater: fallbackDebater } = resolved[0];
-      logger?.warn("debate", "debate:fallback", {
-        storyId: ctx.storyId,
-        stage: ctx.stage,
-        reason: "all debaters failed — retrying with first adapter",
-      });
-      try {
-        const fallbackResult = await runStatefulTurn(
+    // Proposal round
+    const proposalSettled = await allSettledBounded(
+      resolved.map(({ debater, agentName }, debaterIdx) => () => {
+        const handle = openHandles[debaterIdx];
+        if (!handle) {
+          return Promise.reject(new Error(`No session handle for debater ${debaterIdx}`));
+        }
+        return runStatefulTurn(
           ctx,
           agentManager,
-          fallbackAgentName,
-          fallbackDebater,
-          prompt,
-          `debate-${ctx.stage}-fallback`,
-          false,
+          agentName,
+          debater,
+          proposalBuilder.buildProposalPrompt(debaterIdx),
+          handle,
         );
-        totalCostUsd += fallbackResult.cost;
+      }),
+      concurrencyLimit,
+    );
+
+    const successfulProposals: SuccessfulProposal[] = proposalSettled
+      .filter((r): r is PromiseFulfilledResult<SuccessfulProposal> => r.status === "fulfilled")
+      .map((r) => r.value);
+
+    for (const r of proposalSettled) {
+      if (r.status === "fulfilled") {
+        totalCostUsd += r.value.cost;
+      }
+    }
+
+    // Fewer than 2 succeeded — single-agent fallback
+    if (successfulProposals.length < 2) {
+      if (successfulProposals.length === 1) {
+        const solo = successfulProposals[0];
+        logger?.warn("debate", "debate:fallback", {
+          storyId: ctx.storyId,
+          stage: ctx.stage,
+          reason: "only 1 debater succeeded",
+        });
         logger?.info("debate", "debate:result", {
           storyId: ctx.storyId,
           stage: ctx.stage,
@@ -231,113 +177,165 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
           stage: ctx.stage,
           outcome: "passed",
           rounds: 1,
-          debaters: [fallbackDebater.agent],
+          debaters: [solo.debater.agent],
           resolverType: config.resolver.type,
-          proposals: [{ debater: fallbackDebater, output: fallbackResult.output }],
+          proposals: [{ debater: solo.debater, output: solo.output }],
           totalCostUsd,
         };
-      } catch {
-        // Retry also failed — fall through to failed result.
       }
+
+      // 0 succeeded — retry with first adapter (uses existing open handle)
+      if (resolved.length > 0) {
+        const { agentName: fallbackAgentName, debater: fallbackDebater } = resolved[0];
+        const fallbackHandle = openHandles[0];
+        logger?.warn("debate", "debate:fallback", {
+          storyId: ctx.storyId,
+          stage: ctx.stage,
+          reason: "all debaters failed — retrying with first adapter",
+        });
+        try {
+          if (fallbackHandle) {
+            const fallbackResult = await runStatefulTurn(
+              ctx,
+              agentManager,
+              fallbackAgentName,
+              fallbackDebater,
+              prompt,
+              fallbackHandle,
+            );
+            totalCostUsd += fallbackResult.cost;
+            logger?.info("debate", "debate:result", {
+              storyId: ctx.storyId,
+              stage: ctx.stage,
+              outcome: "passed",
+            });
+            return {
+              storyId: ctx.storyId,
+              stage: ctx.stage,
+              outcome: "passed",
+              rounds: 1,
+              debaters: [fallbackDebater.agent],
+              resolverType: config.resolver.type,
+              proposals: [{ debater: fallbackDebater, output: fallbackResult.output }],
+              totalCostUsd,
+            };
+          }
+        } catch {
+          // Retry also failed — fall through to failed result.
+        }
+      }
+
+      logger?.warn("debate", "debate:fallback", {
+        storyId: ctx.storyId,
+        stage: ctx.stage,
+        reason: "fewer than 2 proposal rounds succeeded",
+      });
+      return buildFailedResult(ctx.storyId, ctx.stage, config, totalCostUsd);
     }
 
-    logger?.warn("debate", "debate:fallback", {
-      storyId: ctx.storyId,
-      stage: ctx.stage,
-      reason: "fewer than 2 proposal rounds succeeded",
-    });
-    return buildFailedResult(ctx.storyId, ctx.stage, config, totalCostUsd);
-  }
+    for (let i = 0; i < successfulProposals.length; i++) {
+      const s = successfulProposals[i];
+      logger?.info("debate", "debate:proposal", {
+        storyId: ctx.storyId,
+        stage: ctx.stage,
+        debaterIndex: i,
+        agent: s.debater.agent,
+      });
+    }
 
-  for (let i = 0; i < successfulProposals.length; i++) {
-    const s = successfulProposals[i];
-    logger?.info("debate", "debate:proposal", {
-      storyId: ctx.storyId,
-      stage: ctx.stage,
-      debaterIndex: i,
-      agent: s.debater.agent,
-    });
-  }
-
-  // Critique round (when rounds > 1)
-  // In stateful mode, send only OTHER debaters' proposals — session retains own history.
-  let critiqueOutputs: string[] = [];
-  if (config.rounds > 1) {
-    const proposals = successfulProposals.map((s) => ({ debater: s.debater, output: s.output }));
-    const critiqueBuilder = new DebatePromptBuilder(
-      { taskContext: prompt, outputFormat: "", stage: ctx.stage },
-      { debaters: proposals.map((p) => p.debater), sessionMode: ctx.stageConfig.sessionMode ?? "one-shot" },
-    );
-    const critiqueSettled = await allSettledBounded(
-      successfulProposals.map(
-        (proposal, successfulIdx) => () =>
-          runStatefulTurn(
+    // Critique round (when rounds > 1)
+    let critiqueOutputs: string[] = [];
+    if (config.rounds > 1) {
+      const proposals = successfulProposals.map((s) => ({ debater: s.debater, output: s.output }));
+      const critiqueBuilder = new DebatePromptBuilder(
+        { taskContext: prompt, outputFormat: "", stage: ctx.stage },
+        { debaters: proposals.map((p) => p.debater), sessionMode: ctx.stageConfig.sessionMode ?? "one-shot" },
+      );
+      const critiqueSettled = await allSettledBounded(
+        successfulProposals.map((proposal, successfulIdx) => () => {
+          if (!proposal.handle) {
+            return Promise.reject(new Error("No handle on successful proposal for critique round"));
+          }
+          return runStatefulTurn(
             ctx,
             agentManager,
             proposal.agentName,
             proposal.debater,
             critiqueBuilder.buildCritiquePrompt(successfulIdx, proposals),
-            proposal.roleKey ?? `debate-${ctx.stage}-${successfulIdx}`,
-            false,
-          ),
-      ),
-      concurrencyLimit,
-    );
+            proposal.handle,
+          );
+        }),
+        concurrencyLimit,
+      );
 
-    for (const r of critiqueSettled) {
-      if (r.status === "fulfilled") {
-        totalCostUsd += r.value.cost;
+      for (const r of critiqueSettled) {
+        if (r.status === "fulfilled") {
+          totalCostUsd += r.value.cost;
+        }
       }
+
+      critiqueOutputs = critiqueSettled
+        .filter((r): r is PromiseFulfilledResult<SuccessfulProposal> => r.status === "fulfilled")
+        .map((r) => r.value.output);
     }
 
-    critiqueOutputs = critiqueSettled
-      .filter((r): r is PromiseFulfilledResult<SuccessfulProposal> => r.status === "fulfilled")
-      .map((r) => r.value.output);
-  }
+    // Resolve outcome
+    const proposalOutputs = successfulProposals.map((s) => s.output);
+    const fullResolverContext = ctx.resolverContextInput
+      ? {
+          ...ctx.resolverContextInput,
+          labeledProposals: successfulProposals.map((s) => ({
+            debater: buildDebaterLabel(s.debater),
+            output: s.output,
+          })),
+        }
+      : undefined;
+    const outcome: ResolveOutcome = await resolveOutcome(
+      proposalOutputs,
+      critiqueOutputs,
+      ctx.stageConfig,
+      ctx.config,
+      ctx.storyId,
+      ctx.timeoutSeconds * 1000,
+      ctx.workdir,
+      ctx.featureName,
+      ctx.reviewerSession,
+      fullResolverContext,
+      /* promptSuffix */ undefined,
+      successfulProposals.map((s) => s.debater),
+      agentManager,
+    );
+    totalCostUsd += outcome.resolverCostUsd;
 
-  // Resolve outcome
-  const proposalOutputs = successfulProposals.map((s) => s.output);
-  const fullResolverContext = ctx.resolverContextInput
-    ? {
-        ...ctx.resolverContextInput,
-        labeledProposals: successfulProposals.map((s) => ({ debater: buildDebaterLabel(s.debater), output: s.output })),
+    const proposals = successfulProposals.map((s) => ({
+      debater: s.debater,
+      output: s.output,
+    }));
+
+    logger?.info("debate", "debate:result", {
+      storyId: ctx.storyId,
+      stage: ctx.stage,
+      outcome: outcome.outcome,
+    });
+    return {
+      storyId: ctx.storyId,
+      stage: ctx.stage,
+      outcome: outcome.outcome,
+      rounds: config.rounds,
+      debaters: successfulProposals.map((s) => s.debater.agent),
+      resolverType: config.resolver.type,
+      proposals,
+      totalCostUsd,
+    };
+  } finally {
+    for (const handle of openHandles) {
+      if (handle && sessionManager) {
+        try {
+          await sessionManager.closeSession(handle);
+        } catch {
+          // Ignore close errors
+        }
       }
-    : undefined;
-  const outcome: ResolveOutcome = await resolveOutcome(
-    proposalOutputs,
-    critiqueOutputs,
-    ctx.stageConfig,
-    ctx.config,
-    ctx.storyId,
-    ctx.timeoutSeconds * 1000,
-    ctx.workdir,
-    ctx.featureName,
-    ctx.reviewerSession,
-    fullResolverContext,
-    /* promptSuffix */ undefined,
-    successfulProposals.map((s) => s.debater),
-    agentManager,
-  );
-  totalCostUsd += outcome.resolverCostUsd;
-
-  const proposals = successfulProposals.map((s) => ({
-    debater: s.debater,
-    output: s.output,
-  }));
-
-  logger?.info("debate", "debate:result", {
-    storyId: ctx.storyId,
-    stage: ctx.stage,
-    outcome: outcome.outcome,
-  });
-  return {
-    storyId: ctx.storyId,
-    stage: ctx.stage,
-    outcome: outcome.outcome,
-    rounds: config.rounds,
-    debaters: successfulProposals.map((s) => s.debater.agent),
-    resolverType: config.resolver.type,
-    proposals,
-    totalCostUsd,
-  };
+    }
+  }
 }

--- a/src/debate/session.ts
+++ b/src/debate/session.ts
@@ -30,6 +30,7 @@ export class DebateSession {
   private readonly featureName: string;
   private readonly timeoutSeconds: number;
   private readonly agentManager: IAgentManager | undefined;
+  private readonly sessionManager: import("./session-helpers").DebateSessionOptions["sessionManager"];
   private readonly reviewerSession: import("./session-helpers").DebateSessionOptions["reviewerSession"];
   private readonly resolverContextInput: import("./session-helpers").DebateSessionOptions["resolverContextInput"];
   private get timeoutMs(): number {
@@ -45,6 +46,7 @@ export class DebateSession {
     this.featureName = opts.featureName ?? opts.stage;
     this.timeoutSeconds = opts.timeoutSeconds ?? opts.stageConfig.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
     this.agentManager = opts.agentManager;
+    this.sessionManager = opts.sessionManager;
     this.reviewerSession = opts.reviewerSession;
     this.resolverContextInput = opts.resolverContextInput;
   }
@@ -66,6 +68,7 @@ export class DebateSession {
             featureName: this.featureName,
             timeoutSeconds: this.timeoutSeconds,
             agentManager: this.agentManager,
+            sessionManager: this.sessionManager,
             reviewerSession: this.reviewerSession,
             resolverContextInput: this.resolverContextInput,
           },
@@ -109,6 +112,7 @@ export class DebateSession {
           featureName: this.featureName,
           timeoutSeconds: this.timeoutSeconds,
           agentManager: this.agentManager,
+          sessionManager: this.sessionManager,
           reviewerSession: this.reviewerSession,
           resolverContextInput: this.resolverContextInput,
         },
@@ -164,6 +168,7 @@ export class DebateSession {
         stageConfig: this.stageConfig,
         config: this.config,
         agentManager: this.agentManager,
+        sessionManager: this.sessionManager,
       },
       taskContext,
       outputFormat,

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -71,9 +71,10 @@ export const reviewStage: PipelineStage = {
     }
 
     // AC2: When dialogue is enabled and no session exists (first run), create one
-    if (dialogueEnabled && !ctx.reviewerSession && ctx.agentManager) {
+    if (dialogueEnabled && !ctx.reviewerSession && ctx.agentManager && ctx.sessionManager) {
       ctx.reviewerSession = _reviewDeps.createReviewerSession(
         ctx.agentManager,
+        ctx.sessionManager,
         ctx.story.id,
         ctx.workdir,
         ctx.prd.feature ?? "",

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -1,18 +1,20 @@
 /**
  * Reviewer-Implementer Dialogue
  *
- * Maintains a persistent reviewer session via agent.run() with keepOpen: true.
- * The reviewer holds full conversation context across multiple review() calls.
+ * Maintains a persistent reviewer session via the ADR-019 caller-managed pattern:
+ * sessionManager.openSession → agentManager.runAsSession × N → sessionManager.closeSession.
  */
 
 import type { SemanticVerdict } from "../acceptance/types";
 import type { IAgentManager } from "../agents";
+import type { SessionHandle } from "../agents/types";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config/schema-types";
 import type { DebateResolverContext } from "../debate/types";
 import { NaxError } from "../errors";
 import type { ReviewFinding } from "../plugins/types";
 import { DebatePromptBuilder } from "../prompts";
+import type { ISessionManager } from "../session/types";
 import { parseLLMJson, tryParseLLMJson } from "../utils/llm-json";
 import type { SemanticStory } from "./semantic";
 import type { DiffContext, SemanticReviewConfig } from "./types";
@@ -211,6 +213,7 @@ function parseReviewResponse(output: string): ReviewDialogueResult {
  */
 export function createReviewerSession(
   agentManager: IAgentManager,
+  sessionManager: ISessionManager,
   storyId: string,
   workdir: string,
   featureName: string,
@@ -225,17 +228,12 @@ export function createReviewerSession(
   // reReviewDebate() requires a prior resolveDebate() to avoid using findings
   // from a non-debate review() call as the delta baseline.
   let lastWasDebateResolve = false;
-  /**
-   * Tracks session lifecycle for compaction-triggered resets.
-   * - generation: incremented each time history overflow causes a session reset.
-   * - pendingCompactionContext: when non-null, the next agent.run() call must
-   *   inject this compacted context as initial context and use a new sessionHandle
-   *   to start a fresh session (satisfying AC4 session destruction + recreation).
-   */
-  const sessionState = {
-    generation: 1,
-    pendingCompactionContext: null as string | null,
-  };
+  // Caller-managed session handle — opened lazily on first call, reused on subsequent
+  // calls. Closed and nulled after compaction (new session opened on next call).
+  let _handle: SessionHandle | null = null;
+  // When compaction occurs, the summary is stored here so the next agent call
+  // prepends it as initial context for the fresh session.
+  let pendingCompactionContext: string | null = null;
   // Shared builder instance — review-specific methods are self-contained and don't use stageContext/options.
   const promptBuilder = new DebatePromptBuilder(
     { taskContext: "", outputFormat: "", stage: "review" },
@@ -252,27 +250,30 @@ export function createReviewerSession(
     return { modelTier, modelDef, timeoutSeconds };
   }
 
-  /**
-   * Builds the effective prompt and sessionHandle for an agent.run() call.
-   *
-   * When a compaction reset occurred (pendingCompactionContext is set), the
-   * compacted context is prepended to the prompt so the fresh session receives
-   * the full prior conversation summary as initial context (AC4).
-   * sessionHandle is set to a generation-scoped name so the adapter creates
-   * a new session rather than reusing the previous one.
-   */
-  function buildEffectiveRunArgs(prompt: string): { effectivePrompt: string; sessionHandle: string | undefined } {
-    if (sessionState.pendingCompactionContext !== null) {
-      const context = sessionState.pendingCompactionContext;
-      sessionState.pendingCompactionContext = null;
-      return {
-        effectivePrompt: `${context}\n\n---\n\n${prompt}`,
-        sessionHandle: `nax-reviewer-${storyId}-gen${sessionState.generation}`,
-      };
+  function buildEffectivePrompt(prompt: string): string {
+    if (pendingCompactionContext !== null) {
+      const context = pendingCompactionContext;
+      pendingCompactionContext = null;
+      return `${context}\n\n---\n\n${prompt}`;
     }
-    const sessionHandle =
-      sessionState.generation > 1 ? `nax-reviewer-${storyId}-gen${sessionState.generation}` : undefined;
-    return { effectivePrompt: prompt, sessionHandle };
+    return prompt;
+  }
+
+  async function getOrOpenHandle(semanticConfig: SemanticReviewConfig): Promise<SessionHandle> {
+    if (_handle !== null) return _handle;
+    const { modelDef, timeoutSeconds } = resolveRunParams(semanticConfig);
+    const sessionName = sessionManager.nameFor({ workdir, featureName, storyId, role: "reviewer" });
+    _handle = await sessionManager.openSession(sessionName, {
+      agentName: agentManager.getDefault(),
+      role: "reviewer",
+      workdir,
+      pipelineStage: "review",
+      modelDef,
+      timeoutSeconds,
+      featureName,
+      storyId,
+    });
+    return _handle;
   }
 
   return {
@@ -296,31 +297,18 @@ export function createReviewerSession(
       }
 
       const prompt = promptBuilder.buildReviewPrompt(diff, story);
-      const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(semanticConfig);
-      const { effectivePrompt, sessionHandle } = buildEffectiveRunArgs(prompt);
-
-      const result = await agentManager.run({
-        runOptions: {
-          prompt: effectivePrompt,
-          workdir,
-          modelTier,
-          modelDef,
-          timeoutSeconds,
-          sessionRole: "reviewer",
-          keepOpen: true,
-          pipelineStage: "review",
-          config: _config,
-          storyId,
-          featureName,
-          sessionHandle,
-        },
+      const effectivePrompt = buildEffectivePrompt(prompt);
+      const handle = await getOrOpenHandle(semanticConfig);
+      const turnResult = await agentManager.runAsSession(agentManager.getDefault(), handle, effectivePrompt, {
+        storyId,
+        pipelineStage: "review",
       });
 
       history.push({ role: "implementer", content: prompt });
-      history.push({ role: "reviewer", content: result.output });
+      history.push({ role: "reviewer", content: turnResult.output });
 
-      const parsed = parseReviewResponse(result.output);
-      const reviewResult: ReviewDialogueResult = { ...parsed, cost: result.estimatedCost ?? 0 };
+      const parsed = parseReviewResponse(turnResult.output);
+      const reviewResult: ReviewDialogueResult = { ...parsed, cost: turnResult.cost?.total ?? 0 };
       lastCheckResult = reviewResult;
       lastStory = story;
       lastSemanticConfig = semanticConfig;
@@ -344,45 +332,29 @@ export function createReviewerSession(
 
       const previousFindings = lastCheckResult.checkResult.findings;
       const prompt = promptBuilder.buildReReviewPrompt(updatedDiff, previousFindings);
-      const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(lastSemanticConfig);
-      const { effectivePrompt, sessionHandle } = buildEffectiveRunArgs(prompt);
-
-      const result = await agentManager.run({
-        runOptions: {
-          prompt: effectivePrompt,
-          workdir,
-          modelTier,
-          modelDef,
-          timeoutSeconds,
-          sessionRole: "reviewer",
-          keepOpen: true,
-          pipelineStage: "review",
-          config: _config,
-          storyId,
-          featureName,
-          sessionHandle,
-        },
+      const effectivePrompt = buildEffectivePrompt(prompt);
+      const handle = await getOrOpenHandle(lastSemanticConfig);
+      const turnResult = await agentManager.runAsSession(agentManager.getDefault(), handle, effectivePrompt, {
+        storyId,
+        pipelineStage: "review",
       });
 
       history.push({ role: "implementer", content: prompt });
-      history.push({ role: "reviewer", content: result.output });
+      history.push({ role: "reviewer", content: turnResult.output });
 
-      const parsed = parseReviewResponse(result.output);
-      const deltaSummary = extractDeltaSummary(result.output, previousFindings, parsed.checkResult.findings);
-      const dialogueResult: ReviewDialogueResult = { ...parsed, deltaSummary, cost: result.estimatedCost ?? 0 };
+      const parsed = parseReviewResponse(turnResult.output);
+      const deltaSummary = extractDeltaSummary(turnResult.output, previousFindings, parsed.checkResult.findings);
+      const dialogueResult: ReviewDialogueResult = { ...parsed, deltaSummary, cost: turnResult.cost?.total ?? 0 };
       lastCheckResult = dialogueResult;
 
       const maxMessages = _config.review?.dialogue?.maxDialogueMessages ?? 20;
       if (history.length > maxMessages) {
-        // AC4: destroy the current session and prepare a fresh one.
-        // compactHistory() returns the summary string; store it so the next
-        // agent.run() call injects it as initial context for the new session.
-        // Incrementing sessionState.generation causes buildEffectiveRunArgs()
-        // to use a new sessionHandle, which forces the adapter to create a
-        // fresh session rather than resuming the previous one.
         const compactedSummary = compactHistory(history);
-        sessionState.generation++;
-        sessionState.pendingCompactionContext = compactedSummary;
+        pendingCompactionContext = compactedSummary;
+        if (_handle !== null) {
+          await sessionManager.closeSession(_handle);
+          _handle = null;
+        }
       }
 
       return dialogueResult;
@@ -406,30 +378,17 @@ export function createReviewerSession(
           timeoutMs: 60_000,
           excludePatterns: [],
         } as SemanticReviewConfig);
-      const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(effectiveSemanticConfig);
-      const { effectivePrompt, sessionHandle } = buildEffectiveRunArgs(question);
-
-      const result = await agentManager.run({
-        runOptions: {
-          prompt: effectivePrompt,
-          workdir,
-          modelTier,
-          modelDef,
-          timeoutSeconds,
-          sessionRole: "reviewer",
-          keepOpen: true,
-          pipelineStage: "review",
-          config: _config,
-          storyId,
-          featureName,
-          sessionHandle,
-        },
+      const effectivePrompt = buildEffectivePrompt(question);
+      const handle = await getOrOpenHandle(effectiveSemanticConfig);
+      const turnResult = await agentManager.runAsSession(agentManager.getDefault(), handle, effectivePrompt, {
+        storyId,
+        pipelineStage: "review",
       });
 
       history.push({ role: "implementer", content: question });
-      history.push({ role: "reviewer", content: result.output });
+      history.push({ role: "reviewer", content: turnResult.output });
 
-      return result.output;
+      return turnResult.output;
     },
     async resolveDebate(
       proposals: Array<{ debater: string; output: string }>,
@@ -448,31 +407,18 @@ export function createReviewerSession(
       }
 
       const prompt = promptBuilder.buildResolverPrompt(proposals, critiques, diffContext, story, resolverContext);
-      const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(semanticConfig);
-      const { effectivePrompt, sessionHandle } = buildEffectiveRunArgs(prompt);
-
-      const result = await agentManager.run({
-        runOptions: {
-          prompt: effectivePrompt,
-          workdir,
-          modelTier,
-          modelDef,
-          timeoutSeconds,
-          sessionRole: "reviewer",
-          keepOpen: true,
-          pipelineStage: "review",
-          config: _config,
-          storyId,
-          featureName,
-          sessionHandle,
-        },
+      const effectivePrompt = buildEffectivePrompt(prompt);
+      const handle = await getOrOpenHandle(semanticConfig);
+      const turnResult = await agentManager.runAsSession(agentManager.getDefault(), handle, effectivePrompt, {
+        storyId,
+        pipelineStage: "review",
       });
 
       history.push({ role: "implementer", content: prompt });
-      history.push({ role: "reviewer", content: result.output });
+      history.push({ role: "reviewer", content: turnResult.output });
 
-      const parsed = parseReviewResponse(result.output);
-      const reviewResult: ReviewDialogueResult = { ...parsed, cost: result.estimatedCost ?? 0 };
+      const parsed = parseReviewResponse(turnResult.output);
+      const reviewResult: ReviewDialogueResult = { ...parsed, cost: turnResult.cost?.total ?? 0 };
       lastCheckResult = reviewResult;
       lastStory = story;
       lastSemanticConfig = semanticConfig;
@@ -508,39 +454,29 @@ export function createReviewerSession(
         previousFindings,
         resolverContext,
       );
-      const { modelTier, modelDef, timeoutSeconds } = resolveRunParams(lastSemanticConfig);
-      const { effectivePrompt, sessionHandle } = buildEffectiveRunArgs(prompt);
-
-      const result = await agentManager.run({
-        runOptions: {
-          prompt: effectivePrompt,
-          workdir,
-          modelTier,
-          modelDef,
-          timeoutSeconds,
-          sessionRole: "reviewer",
-          keepOpen: true,
-          pipelineStage: "review",
-          config: _config,
-          storyId,
-          featureName,
-          sessionHandle,
-        },
+      const effectivePrompt = buildEffectivePrompt(prompt);
+      const handle = await getOrOpenHandle(lastSemanticConfig);
+      const turnResult = await agentManager.runAsSession(agentManager.getDefault(), handle, effectivePrompt, {
+        storyId,
+        pipelineStage: "review",
       });
 
       history.push({ role: "implementer", content: prompt });
-      history.push({ role: "reviewer", content: result.output });
+      history.push({ role: "reviewer", content: turnResult.output });
 
-      const parsed = parseReviewResponse(result.output);
-      const deltaSummary = extractDeltaSummary(result.output, previousFindings, parsed.checkResult.findings);
-      const dialogueResult: ReviewDialogueResult = { ...parsed, deltaSummary, cost: result.estimatedCost ?? 0 };
+      const parsed = parseReviewResponse(turnResult.output);
+      const deltaSummary = extractDeltaSummary(turnResult.output, previousFindings, parsed.checkResult.findings);
+      const dialogueResult: ReviewDialogueResult = { ...parsed, deltaSummary, cost: turnResult.cost?.total ?? 0 };
       lastCheckResult = dialogueResult;
 
       const maxMessages = _config.review?.dialogue?.maxDialogueMessages ?? 20;
       if (history.length > maxMessages) {
         const compactedSummary = compactHistory(history);
-        sessionState.generation++;
-        sessionState.pendingCompactionContext = compactedSummary;
+        pendingCompactionContext = compactedSummary;
+        if (_handle !== null) {
+          await sessionManager.closeSession(_handle);
+          _handle = null;
+        }
       }
 
       return dialogueResult;
@@ -564,6 +500,10 @@ export function createReviewerSession(
     async destroy(): Promise<void> {
       if (!active) return;
       active = false;
+      if (_handle !== null) {
+        await sessionManager.closeSession(_handle);
+        _handle = null;
+      }
       history.length = 0;
     },
   };

--- a/test/unit/debate/session-hybrid-rebuttal.test.ts
+++ b/test/unit/debate/session-hybrid-rebuttal.test.ts
@@ -1,44 +1,18 @@
 /**
- * Tests for US-004-B: runHybrid() sequential rebuttal loop, session cleanup,
- * and result assembly.
- *
- * Covers ACs 1-10 for the rebuttal loop extension to runHybrid().
- * Proposal-phase behaviour is covered in session-hybrid.test.ts.
+ * Tests for runHybrid() sequential rebuttal loop, session cleanup, and result assembly.
+ * Covers ACs 1-10 for the rebuttal loop (ADR-019 §4 session pattern).
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { DebateSession, _debateSessionDeps } from "../../../src/debate/session";
-import type { IAgentManager } from "../../../src/agents";
-import type { AgentRunOptions, CompleteOptions, CompleteResult } from "../../../src/agents/types";
+import { _debateSessionDeps } from "../../../src/debate/session";
+import type { HybridCtx } from "../../../src/debate/session-hybrid";
 import type { DebateStageConfig } from "../../../src/debate/types";
-import { makeMockAgentManager } from "../../helpers";
-
-// ─── Constants ────────────────────────────────────────────────────────────────
-
-const CLOSE_SESSION_PROMPT = "Close this debate session.";
+import { makeMockAgentManager, makeSessionManager } from "../../helpers";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function isRebuttalPrompt(prompt: string): boolean {
   return prompt.includes("## Your Task") && prompt.includes("You are debater");
-}
-
-function isClosePrompt(prompt: string): boolean {
-  return prompt === CLOSE_SESSION_PROMPT;
-}
-
-function makeMockManager(
-  options: {
-    runFn?: (agentName: string, opts: AgentRunOptions) => Promise<{ success: boolean; exitCode: number; output: string; rateLimited: boolean; durationMs: number; estimatedCost: number; agentFallbacks: any[] }>;
-    completeFn?: (agentName: string, prompt: string, opts?: CompleteOptions) => Promise<CompleteResult>;
-    unavailableAgents?: Set<string>;
-  } = {},
-): IAgentManager {
-  return makeMockAgentManager({
-    runFn: options.runFn,
-    completeFn: options.completeFn,
-    unavailableAgents: options.unavailableAgents,
-  });
 }
 
 function makeHybridStageConfig(overrides: Partial<DebateStageConfig> = {}): DebateStageConfig {
@@ -53,6 +27,31 @@ function makeHybridStageConfig(overrides: Partial<DebateStageConfig> = {}): Deba
       { agent: "claude", model: "fast" },
       { agent: "opencode", model: "fast" },
     ],
+    ...overrides,
+  };
+}
+
+function makeHybridCtx(overrides: Partial<HybridCtx> = {}): HybridCtx {
+  return {
+    storyId: "US-test",
+    stage: "run",
+    stageConfig: makeHybridStageConfig(),
+    config: {} as any,
+    workdir: "/tmp/work",
+    featureName: "feat",
+    timeoutSeconds: 60,
+    agentManager: makeMockAgentManager({
+      runAsSessionFn: async (agentName, _handle, prompt) => ({
+        output: isRebuttalPrompt(prompt) ? `rebuttal-${agentName}` : `proposal-${agentName}`,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        internalRoundTrips: 0,
+      }),
+    }),
+    sessionManager: makeSessionManager({
+      openSession: mock(async (name: string) => ({ id: name, agentName: "claude" })),
+      closeSession: mock(async () => {}),
+      nameFor: mock((req) => req.role ?? ""),
+    }),
     ...overrides,
   };
 }
@@ -77,103 +76,51 @@ afterEach(() => {
 // ─── AC1: 2 debaters, rounds=1 → exactly 2 sequential rebuttal calls ─────────
 
 describe("runHybrid() — sequential rebuttal call count with 2 debaters (AC1)", () => {
-  test("with 2 debaters and rounds=1, rebuttal runStatefulTurn is called exactly 2 times", async () => {
-    const rebuttalCalls: AgentRunOptions[] = [];
-
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName, opts) => {
-          if (isRebuttalPrompt(opts.prompt ?? "")) {
-            rebuttalCalls.push(opts);
-          }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `output-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
+  test("with 2 debaters and rounds=1, rebuttal runAsSession is called exactly 2 times", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const rebuttalCalls: string[] = [];
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (agentName, _handle, prompt) => {
+          if (isRebuttalPrompt(prompt)) rebuttalCalls.push(agentName);
+          return { output: `output-${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
         },
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac1-count",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 1 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
-
+    await runHybrid(ctx, "test prompt");
     expect(rebuttalCalls).toHaveLength(2);
   });
 
   test("with 2 debaters and rounds=1, rebuttal calls happen in sequential debater order (0 then 1)", async () => {
-    const rebuttalRoles: string[] = [];
-
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName, opts) => {
-          if (isRebuttalPrompt(opts.prompt ?? "")) {
-            rebuttalRoles.push(opts.sessionRole ?? "");
-          }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `output-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const rebuttalOrder: string[] = [];
+    const ctx = makeHybridCtx({
+      sessionManager: makeSessionManager({
+        openSession: mock(async (name: string) => ({ id: name, agentName: "claude" })),
+        closeSession: mock(async () => {}),
+        nameFor: mock((req) => req.role ?? ""),
+      }),
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (agentName, handle, prompt) => {
+          if (isRebuttalPrompt(prompt)) rebuttalOrder.push(handle.id);
+          return { output: `output-${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
         },
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac1-order",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 1 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
-
-    expect(rebuttalRoles).toHaveLength(2);
-    expect(rebuttalRoles[0]).toBe("debate-hybrid-0");
-    expect(rebuttalRoles[1]).toBe("debate-hybrid-1");
+    await runHybrid(ctx, "test prompt");
+    expect(rebuttalOrder).toHaveLength(2);
+    expect(rebuttalOrder[0]).toBe("debate-hybrid-0");
+    expect(rebuttalOrder[1]).toBe("debate-hybrid-1");
   });
 });
 
 // ─── AC2: 3 debaters, rounds=2 → exactly 6 rebuttal calls ────────────────────
 
 describe("runHybrid() — rebuttal call count with 3 debaters and 2 rounds (AC2)", () => {
-  test("with 3 debaters and rounds=2, rebuttal runStatefulTurn is called exactly 6 times", async () => {
-    const rebuttalCalls: AgentRunOptions[] = [];
-
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName, opts) => {
-          if (isRebuttalPrompt(opts.prompt ?? "")) {
-            rebuttalCalls.push(opts);
-          }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `output-${agentName}-${rebuttalCalls.length}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
-        },
-    });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac2",
-      stage: "run",
+  test("with 3 debaters and rounds=2, rebuttal runAsSession is called exactly 6 times", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const rebuttalCalls: string[] = [];
+    const ctx = makeHybridCtx({
       stageConfig: makeHybridStageConfig({
         rounds: 2,
         debaters: [
@@ -182,13 +129,14 @@ describe("runHybrid() — rebuttal call count with 3 debaters and 2 rounds (AC2)
           { agent: "gemini", model: "fast" },
         ],
       }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (agentName, _handle, prompt) => {
+          if (isRebuttalPrompt(prompt)) rebuttalCalls.push(agentName);
+          return { output: `output-${agentName}-${rebuttalCalls.length}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
+        },
+      }),
     });
-
-    await session.run("test prompt");
-
+    await runHybrid(ctx, "test prompt");
     expect(rebuttalCalls).toHaveLength(6);
   });
 });
@@ -197,36 +145,17 @@ describe("runHybrid() — rebuttal call count with 3 debaters and 2 rounds (AC2)
 
 describe("runHybrid() — rebuttal prompts include proposal outputs (AC3)", () => {
   test("each rebuttal turn prompt contains all successful proposal outputs", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
     const rebuttalPrompts: string[] = [];
-
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName, opts) => {
-          if (isRebuttalPrompt(opts.prompt ?? "")) {
-            rebuttalPrompts.push(opts.prompt ?? "");
-          }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-output-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (agentName, _handle, prompt) => {
+          if (isRebuttalPrompt(prompt)) rebuttalPrompts.push(prompt);
+          return { output: `proposal-output-${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
         },
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac3",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 1 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
-
+    await runHybrid(ctx, "test prompt");
     expect(rebuttalPrompts).toHaveLength(2);
     for (const prompt of rebuttalPrompts) {
       expect(prompt).toContain("proposal-output-claude");
@@ -239,54 +168,27 @@ describe("runHybrid() — rebuttal prompts include proposal outputs (AC3)", () =
 
 describe("runHybrid() — round 2 rebuttal prompts include round 1 outputs (AC4)", () => {
   test("round 2 rebuttal prompts contain all round 1 rebuttal outputs in previous-rebuttals section", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
     let roundTracker = 0;
     const round1RebuttalOutputs: string[] = [];
     const round2Prompts: string[] = [];
 
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName, opts) => {
-          const prompt = opts.prompt ?? "";
+    const ctx = makeHybridCtx({
+      stageConfig: makeHybridStageConfig({ rounds: 2 }),
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (agentName, _handle, prompt) => {
           if (isRebuttalPrompt(prompt)) {
             roundTracker++;
             const output = `rebuttal-${agentName}-round-${roundTracker <= 2 ? 1 : 2}`;
-            if (roundTracker <= 2) {
-              round1RebuttalOutputs.push(output);
-            } else {
-              round2Prompts.push(prompt);
-            }
-            return {
-              success: true,
-              exitCode: 0,
-              output,
-              rateLimited: false,
-              durationMs: 1,
-              estimatedCost: 0.01,
-              agentFallbacks: [],
-            };
+            if (roundTracker <= 2) round1RebuttalOutputs.push(output);
+            else round2Prompts.push(prompt);
+            return { output, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
           }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
+          return { output: `proposal-${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
         },
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac4",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 2 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
-
+    await runHybrid(ctx, "test prompt");
     expect(round2Prompts).toHaveLength(2);
     for (const prompt of round2Prompts) {
       for (const r1output of round1RebuttalOutputs) {
@@ -300,11 +202,10 @@ describe("runHybrid() — round 2 rebuttal prompts include round 1 outputs (AC4)
 
 describe("runHybrid() — failed rebuttal turn is skipped with warning (AC5)", () => {
   test("when one rebuttal turn throws, a warning is logged and the loop continues", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
     const warnMessages: string[] = [];
     const mockLogger = {
-      warn: (_stage: string, msg: string) => {
-        warnMessages.push(msg);
-      },
+      warn: (_stage: string, msg: string) => { warnMessages.push(msg); },
       info: () => {},
       debug: () => {},
       error: () => {},
@@ -312,297 +213,131 @@ describe("runHybrid() — failed rebuttal turn is skipped with warning (AC5)", (
     _debateSessionDeps.getSafeLogger = mock(() => mockLogger) as unknown as typeof _debateSessionDeps.getSafeLogger;
 
     let rebuttalCallCount = 0;
-
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName, opts) => {
-          const prompt = opts.prompt ?? "";
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (agentName, _handle, prompt) => {
           if (isRebuttalPrompt(prompt)) {
             rebuttalCallCount++;
-            if (agentName === "claude") {
-              throw new Error("rebuttal failed for claude");
-            }
+            if (agentName === "claude") throw new Error("rebuttal failed for claude");
           }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `output-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
+          return { output: `output-${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
         },
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac5",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 1 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    const result = await session.run("test prompt");
-
-    // The loop must continue even when claude's rebuttal fails
+    const result = await runHybrid(ctx, "test prompt");
     expect(rebuttalCallCount).toBe(2);
-    // A warning must be emitted for the failed turn
     expect(warnMessages.some((m) => m.includes("rebuttal") || m.includes("failed") || m.includes("debate"))).toBe(true);
-    // Overall run should still succeed
     expect(result.outcome).not.toBe("failed");
   });
 });
 
-// ─── AC6: rebuttal calls use same sessionRole as proposal and keepOpen:true
+// ─── AC6: rebuttal calls use same handle as proposal ─────────────────────────
 
-describe("runHybrid() — rebuttal calls use correct sessionRole and keepOpen (AC6)", () => {
-  test("every rebuttal runStatefulTurn call uses the same sessionRole as the proposal round for that debater", async () => {
-    const rebuttalCalls: AgentRunOptions[] = [];
+describe("runHybrid() — rebuttal calls use same handle as proposal (AC6)", () => {
+  test("each rebuttal runAsSession call uses the same handle as the proposal for that debater", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const handleCallCount: Record<string, number> = {};
 
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName, opts) => {
-          if (isRebuttalPrompt(opts.prompt ?? "")) {
-            rebuttalCalls.push(opts);
-          }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `output-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (_agentName, handle, _prompt) => {
+          handleCallCount[handle.id] = (handleCallCount[handle.id] ?? 0) + 1;
+          return { output: "output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
         },
+      }),
     });
+    await runHybrid(ctx, "test prompt");
 
-    const session = new DebateSession({
-      storyId: "US-004-B-ac6-role",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 1 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
-
-    expect(rebuttalCalls).toHaveLength(2);
-    const roles = rebuttalCalls.map((c) => c.sessionRole);
-    expect(roles).toContain("debate-hybrid-0");
-    expect(roles).toContain("debate-hybrid-1");
-  });
-
-  test("every rebuttal runStatefulTurn call has keepOpen: true", async () => {
-    const rebuttalCalls: AgentRunOptions[] = [];
-
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName, opts) => {
-          if (isRebuttalPrompt(opts.prompt ?? "")) {
-            rebuttalCalls.push(opts);
-          }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `output-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
-        },
-    });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac6-ksopen",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 1 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
-
-    expect(rebuttalCalls).toHaveLength(2);
-    for (const call of rebuttalCalls) {
-      expect(call.keepOpen).toBe(true);
+    // Each handle should have been used for both proposal (1) and rebuttal (1) = 2 calls
+    for (const count of Object.values(handleCallCount)) {
+      expect(count).toBe(2);
     }
   });
 });
 
-// ─── AC7: closeStatefulSession called once per debater after normal completion
+// ─── AC7: sessionManager.closeSession called once per debater ────────────────
 
-describe("runHybrid() — closeStatefulSession called after normal rebuttal loop (AC7)", () => {
-  test("after the rebuttal loop completes normally, closeStatefulSession is called once per opened debater session", async () => {
-    const closeCalls: AgentRunOptions[] = [];
-
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName, opts) => {
-          if (isClosePrompt(opts.prompt ?? "")) {
-            closeCalls.push(opts);
-          }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `output-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
-        },
+describe("runHybrid() — sessionManager.closeSession called after normal rebuttal loop (AC7)", () => {
+  test("after the rebuttal loop completes normally, closeSession is called once per opened debater session", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const closedHandleIds: string[] = [];
+    const ctx = makeHybridCtx({
+      sessionManager: makeSessionManager({
+        openSession: mock(async (name: string) => ({ id: name, agentName: "claude" })),
+        closeSession: mock(async (handle) => { closedHandleIds.push(handle.id); }),
+        nameFor: mock((req) => req.role ?? ""),
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac7",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 1 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
-
-    // One closeStatefulSession call per debater (2 debaters)
-    expect(closeCalls).toHaveLength(2);
-    const roles = closeCalls.map((c) => c.sessionRole);
-    expect(roles).toContain("debate-hybrid-0");
-    expect(roles).toContain("debate-hybrid-1");
+    await runHybrid(ctx, "test prompt");
+    expect(closedHandleIds).toHaveLength(2);
+    expect(closedHandleIds).toContain("debate-hybrid-0");
+    expect(closedHandleIds).toContain("debate-hybrid-1");
   });
 });
 
-// ─── AC8: closeStatefulSession called even when all rebuttal turns fail ───────
+// ─── AC8: closeSession called even when all rebuttal turns fail ───────────────
 
-describe("runHybrid() — closeStatefulSession called when rebuttal turns fail (AC8)", () => {
-  test("when all rebuttal turns fail, closeStatefulSession is still called for all opened sessions", async () => {
-    const closeCalls: AgentRunOptions[] = [];
-
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName, opts) => {
-          const prompt = opts.prompt ?? "";
-          if (isClosePrompt(prompt)) {
-            closeCalls.push(opts);
-            return {
-              success: true,
-              exitCode: 0,
-              output: "",
-              rateLimited: false,
-              durationMs: 1,
-              estimatedCost: 0,
-              agentFallbacks: [],
-            };
-          }
-          if (isRebuttalPrompt(prompt)) {
-            throw new Error(`rebuttal failed for ${agentName}`);
-          }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
+describe("runHybrid() — closeSession called when rebuttal turns fail (AC8)", () => {
+  test("when all rebuttal turns fail, closeSession is still called for all opened sessions", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const closedHandleIds: string[] = [];
+    const ctx = makeHybridCtx({
+      sessionManager: makeSessionManager({
+        openSession: mock(async (name: string) => ({ id: name, agentName: "claude" })),
+        closeSession: mock(async (handle) => { closedHandleIds.push(handle.id); }),
+        nameFor: mock((req) => req.role ?? ""),
+      }),
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (_agentName, _handle, prompt) => {
+          if (isRebuttalPrompt(prompt)) throw new Error("rebuttal failed");
+          return { output: "proposal", tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
         },
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac8",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 1 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
-
-    // Even though all rebuttal turns failed, close must still be called for each debater
-    expect(closeCalls).toHaveLength(2);
+    await runHybrid(ctx, "test prompt");
+    expect(closedHandleIds).toHaveLength(2);
   });
 });
 
 // ─── AC9: per-turn rebuttal costs summed into totalCostUsd ───────────────────
 
 describe("runHybrid() — rebuttal costs accumulated in totalCostUsd (AC9)", () => {
-  test("per-turn rebuttal costs are summed and reflected in totalCostUsd on the returned DebateResult", async () => {
-    // Proposal cost: 2 × 0.10 = 0.20
-    // Rebuttal cost: 2 × 0.05 = 0.10
-    // Total expected: at least 0.30
-
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (_agentName, opts) => {
-          const prompt = opts.prompt ?? "";
-          if (isClosePrompt(prompt)) {
-            return { success: true, exitCode: 0, output: "", rateLimited: false, durationMs: 1, estimatedCost: 0, agentFallbacks: [] };
-          }
+  test("per-turn rebuttal costs are summed and reflected in totalCostUsd", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (_agentName, _handle, prompt) => {
           const cost = isRebuttalPrompt(prompt) ? 0.05 : 0.1;
-          return {
-            success: true,
-            exitCode: 0,
-            output: `output-${_agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: cost,
-            agentFallbacks: [],
-          };
+          return { output: "output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0, cost: { total: cost } };
         },
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac9",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 1 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    const result = await session.run("test prompt");
-
+    const result = await runHybrid(ctx, "test prompt");
     // 2 proposals × 0.10 + 2 rebuttals × 0.05 = 0.30
     expect(result.totalCostUsd).toBeGreaterThanOrEqual(0.29);
   });
 });
 
-// ─── AC10: DebateResult.rebuttals populated; debate:rebuttal-start emitted ───
+// ─── AC10: DebateResult.rebuttals populated ───────────────────────────────────
 
 describe("runHybrid() — DebateResult.rebuttals populated and debug event emitted (AC10)", () => {
-  test("DebateResult.rebuttals contains one entry per successful rebuttal with correct debaterIndex, round, and output", async () => {
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName, opts) => ({
-          success: true,
-          exitCode: 0,
-          output: isRebuttalPrompt(opts.prompt ?? "") ? `rebuttal-output-${agentName}` : `proposal-${agentName}`,
-          rateLimited: false,
-          durationMs: 1,
-          estimatedCost: 0.01,
-          agentFallbacks: [],
+  test("DebateResult.rebuttals contains one entry per successful rebuttal", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (agentName, _handle, prompt) => ({
+          output: isRebuttalPrompt(prompt) ? `rebuttal-output-${agentName}` : `proposal-${agentName}`,
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          internalRoundTrips: 0,
         }),
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac10-rebuttals",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 1 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    const result = await session.run("test prompt");
-
+    const result = await runHybrid(ctx, "test prompt");
     expect(result.rebuttals).toBeDefined();
     expect(result.rebuttals).toHaveLength(2);
-
     const outputs = (result.rebuttals ?? []).map((r) => r.output);
     expect(outputs).toContain("rebuttal-output-claude");
     expect(outputs).toContain("rebuttal-output-opencode");
-
     for (const rebuttal of result.rebuttals ?? []) {
       expect(rebuttal.round).toBe(1);
       expect(typeof rebuttal.debater).toBe("object");
@@ -610,45 +345,21 @@ describe("runHybrid() — DebateResult.rebuttals populated and debug event emitt
   });
 
   test("debate:rebuttal-start info event is emitted before each rebuttal turn", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
     const infoEvents: Array<{ stage: string; event: string; data?: unknown }> = [];
     const mockLogger = {
       warn: () => {},
-      info: (stage: string, event: string, data?: unknown) => {
-        infoEvents.push({ stage, event, data });
-      },
+      info: (stage: string, event: string, data?: unknown) => { infoEvents.push({ stage, event, data }); },
       debug: () => {},
       error: () => {},
     };
     _debateSessionDeps.getSafeLogger = mock(() => mockLogger) as unknown as typeof _debateSessionDeps.getSafeLogger;
 
-    _debateSessionDeps.agentManager = makeMockManager({
-        runFn: async (agentName) => ({
-          success: true,
-          exitCode: 0,
-          output: `output-${agentName}`,
-          rateLimited: false,
-          durationMs: 1,
-          estimatedCost: 0.01,
-          agentFallbacks: [],
-        }),
-    });
-
-    const session = new DebateSession({
-      storyId: "US-004-B-ac10-event",
-      stage: "run",
-      stageConfig: makeHybridStageConfig({ rounds: 1 }),
-      workdir: "/tmp/work",
-      featureName: "feat",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
+    const ctx = makeHybridCtx();
+    await runHybrid(ctx, "test prompt");
 
     const rebuttalStartEvents = infoEvents.filter((e) => e.stage === "debate:rebuttal-start");
-    // One debate:rebuttal-start event per rebuttal turn (2 debaters × 1 round = 2)
     expect(rebuttalStartEvents).toHaveLength(2);
-
-    // Each event must carry round and debaterIndex
     for (const evt of rebuttalStartEvents) {
       expect((evt.data as Record<string, unknown>)?.round).toBeDefined();
       expect((evt.data as Record<string, unknown>)?.debaterIndex).toBeDefined();

--- a/test/unit/debate/session-hybrid.test.ts
+++ b/test/unit/debate/session-hybrid.test.ts
@@ -1,9 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { DebateSession, _debateSessionDeps } from "../../../src/debate/session";
-import type { AgentRunRequest } from "../../../src/agents";
-import type { AgentRunOptions, CompleteOptions, CompleteResult } from "../../../src/agents/types";
+import { _debateSessionDeps } from "../../../src/debate/session";
+import type { HybridCtx } from "../../../src/debate/session-hybrid";
 import type { DebateStageConfig } from "../../../src/debate/types";
-import { makeMockAgentManager } from "../../helpers";
+import { makeMockAgentManager, makeSessionManager } from "../../helpers";
 
 function makeHybridStageConfig(overrides: Partial<DebateStageConfig> = {}): DebateStageConfig {
   return {
@@ -21,7 +20,29 @@ function makeHybridStageConfig(overrides: Partial<DebateStageConfig> = {}): Deba
   };
 }
 
-// ─── Setup / Teardown ─────────────────────────────────────────────────────────
+function makeHybridCtx(overrides: Partial<HybridCtx> = {}): HybridCtx {
+  return {
+    storyId: "US-test",
+    stage: "run",
+    stageConfig: makeHybridStageConfig(),
+    config: {} as any,
+    workdir: "/tmp/work",
+    featureName: "feat-hybrid",
+    timeoutSeconds: 60,
+    agentManager: makeMockAgentManager({
+      runAsSessionFn: async (agentName) => ({
+        output: `proposal-${agentName}`,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        internalRoundTrips: 0,
+      }),
+    }),
+    sessionManager: makeSessionManager({
+      openSession: mock(async (name: string) => ({ id: name, agentName: "claude" })),
+      closeSession: mock(async () => {}),
+    }),
+    ...overrides,
+  };
+}
 
 let origAgentManager: typeof _debateSessionDeps.agentManager;
 let origGetSafeLogger: typeof _debateSessionDeps.getSafeLogger;
@@ -38,66 +59,28 @@ afterEach(() => {
   mock.restore();
 });
 
-// ─── AC1: sessionRole is 'debate-hybrid-{debaterIndex}' (0-based) ────────────
+// ─── AC1: sessionRole is 'debate-hybrid-{debaterIndex}' ──────────────────────
 
-describe("runHybrid() — sessionRole for proposal calls (AC1)", () => {
-  test("debater 0 gets sessionRole 'debate-hybrid-0' and debater 1 gets 'debate-hybrid-1'", async () => {
-    const runCalls: AgentRunOptions[] = [];
-
-    _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (agentName, opts) => {
-          runCalls.push(opts);
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
-        },
+describe("runHybrid() — handle IDs correspond to sessionRole (AC1)", () => {
+  test("debater 0 gets handle 'debate-hybrid-0' and debater 1 gets 'debate-hybrid-1'", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const openedNames: string[] = [];
+    const ctx = makeHybridCtx({
+      sessionManager: makeSessionManager({
+        openSession: mock(async (name: string) => { openedNames.push(name); return { id: name, agentName: "claude" }; }),
+        closeSession: mock(async () => {}),
+        nameFor: mock((req) => req.role ?? ""),
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-A-role",
-      stage: "run",
-      stageConfig: makeHybridStageConfig(),
-      workdir: "/tmp/work",
-      featureName: "feat-hybrid",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
-
-    const proposalCalls = runCalls.filter((c) => c.prompt === "test prompt");
-    expect(proposalCalls.length).toBe(2);
-    const roles = proposalCalls.map((c) => c.sessionRole).sort();
-    expect(roles).toContain("debate-hybrid-0");
-    expect(roles).toContain("debate-hybrid-1");
+    await runHybrid(ctx, "test prompt");
+    expect(openedNames).toContain("debate-hybrid-0");
+    expect(openedNames).toContain("debate-hybrid-1");
   });
 
   test("sessionRole index matches debater position in the debaters array (3 debaters)", async () => {
-    const runCalls: AgentRunOptions[] = [];
-
-    _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (agentName, opts) => {
-          runCalls.push(opts);
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
-        },
-    });
-
-    const session = new DebateSession({
-      storyId: "US-004-A-role-3",
-      stage: "run",
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const openedNames: string[] = [];
+    const ctx = makeHybridCtx({
       stageConfig: makeHybridStageConfig({
         debaters: [
           { agent: "claude", model: "fast" },
@@ -105,86 +88,32 @@ describe("runHybrid() — sessionRole for proposal calls (AC1)", () => {
           { agent: "gemini", model: "fast" },
         ],
       }),
-      workdir: "/tmp/work",
-      featureName: "feat-hybrid",
-      timeoutSeconds: 60,
+      sessionManager: makeSessionManager({
+        openSession: mock(async (name: string) => { openedNames.push(name); return { id: name, agentName: "claude" }; }),
+        closeSession: mock(async () => {}),
+        nameFor: mock((req) => req.role ?? ""),
+      }),
     });
-
-    await session.run("test prompt");
-
-    const proposalCalls = runCalls.filter((c) => c.prompt === "test prompt");
-    expect(proposalCalls.length).toBe(3);
-    const roles = proposalCalls.map((c) => c.sessionRole).sort();
-    expect(roles).toContain("debate-hybrid-0");
-    expect(roles).toContain("debate-hybrid-1");
-    expect(roles).toContain("debate-hybrid-2");
+    await runHybrid(ctx, "test prompt");
+    expect(openedNames).toContain("debate-hybrid-0");
+    expect(openedNames).toContain("debate-hybrid-1");
+    expect(openedNames).toContain("debate-hybrid-2");
   });
 });
 
-// ─── AC3: every proposal call uses keepOpen: true ─────────────────────
-
-describe("runHybrid() — keepOpen for proposal calls (AC3)", () => {
-  test("all proposal run() calls have keepOpen: true", async () => {
-    const runCalls: AgentRunOptions[] = [];
-
-    _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (agentName, opts) => {
-          runCalls.push(opts);
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
-        },
-    });
-
-    const session = new DebateSession({
-      storyId: "US-004-A-ksopen",
-      stage: "run",
-      stageConfig: makeHybridStageConfig(),
-      workdir: "/tmp/work",
-      featureName: "feat-hybrid",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
-
-    const proposalCalls = runCalls.filter((c) => c.prompt === "test prompt");
-    expect(proposalCalls.length).toBeGreaterThanOrEqual(2);
-    for (const call of proposalCalls) {
-      expect(call.keepOpen).toBe(true);
-    }
-  });
-});
-
-// ─── AC2: parallel via allSettledBounded respecting maxConcurrentDebaters ────
+// ─── AC2: parallel via allSettledBounded ─────────────────────────────────────
 
 describe("runHybrid() — parallel proposals via allSettledBounded (AC2)", () => {
   test("all debaters are invoked in the proposal round", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
     const invoked: string[] = [];
-
-    _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (agentName) => {
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (agentName) => {
           invoked.push(agentName);
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
+          return { output: `proposal-${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
         },
-    });
-
-    const session = new DebateSession({
-      storyId: "US-004-A-parallel",
-      stage: "run",
+      }),
       stageConfig: makeHybridStageConfig({
         debaters: [
           { agent: "claude", model: "fast" },
@@ -192,50 +121,61 @@ describe("runHybrid() — parallel proposals via allSettledBounded (AC2)", () =>
           { agent: "gemini", model: "fast" },
         ],
       }),
-      workdir: "/tmp/work",
-      featureName: "feat-hybrid",
-      timeoutSeconds: 60,
     });
-
-    await session.run("test prompt");
-
+    await runHybrid(ctx, "test prompt");
     expect(invoked).toContain("claude");
     expect(invoked).toContain("opencode");
     expect(invoked).toContain("gemini");
   });
 
   test("maxConcurrentDebaters: 1 still runs all proposals (sequentially)", async () => {
-    const runCalls: AgentRunOptions[] = [];
-
-    _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (agentName, opts) => {
-          runCalls.push(opts);
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
-        },
-    });
-
-    const session = new DebateSession({
-      storyId: "US-004-A-concurrency",
-      stage: "run",
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const proposalInvoked: string[] = [];
+    const ctx = makeHybridCtx({
       config: { debate: { maxConcurrentDebaters: 1 } } as any,
-      stageConfig: makeHybridStageConfig(),
-      workdir: "/tmp/work",
-      featureName: "feat-hybrid",
-      timeoutSeconds: 60,
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (agentName, _handle, prompt) => {
+          // Only count proposal calls (not rebuttals)
+          if (!prompt.includes("## Your Task")) proposalInvoked.push(agentName);
+          return { output: `proposal-${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
+        },
+      }),
+    });
+    await runHybrid(ctx, "test prompt");
+    expect(proposalInvoked.length).toBe(2);
+  });
+});
+
+// ─── AC3: pre-opened sessions per debater ────────────────────────────────────
+
+describe("runHybrid() — pre-opened sessions per debater (AC3)", () => {
+  test("opens one session per debater before proposal round", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const openCalls: string[] = [];
+    const runAsSessionCalls: number[] = [];
+    const closeCalls: number[] = [];
+
+    const ctx = makeHybridCtx({
+      sessionManager: makeSessionManager({
+        openSession: mock(async (name: string) => { openCalls.push(name); return { id: "h-" + openCalls.length, agentName: "claude" }; }),
+        closeSession: mock(async () => { closeCalls.push(1); }),
+        nameFor: mock((req) => req.role ?? ""),
+      }),
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async () => {
+          runAsSessionCalls.push(1);
+          return { output: "proposal", tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
+        },
+      }),
     });
 
-    await session.run("test prompt");
+    await runHybrid(ctx, "prompt");
 
-    expect(runCalls.filter((c) => c.prompt === "test prompt").length).toBe(2);
+    // 2 debaters → 2 open, 2 close
+    expect(openCalls.length).toBe(2);
+    expect(closeCalls.length).toBe(2);
+    // runAsSession is called for both proposals AND rebuttals (rounds=1 → 2+2=4 total)
+    expect(runAsSessionCalls.length).toBeGreaterThanOrEqual(2);
   });
 });
 
@@ -243,42 +183,16 @@ describe("runHybrid() — parallel proposals via allSettledBounded (AC2)", () =>
 
 describe("runHybrid() — single-agent fallback when fewer than 2 proposals succeed (AC4)", () => {
   test("returns outcome=passed with single debater when exactly 1 proposal succeeds", async () => {
-    _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (agentName) => {
-          if (agentName === "opencode") {
-            return {
-              success: false,
-              exitCode: 1,
-              output: "failed",
-              rateLimited: false,
-              durationMs: 1,
-              estimatedCost: 0,
-              agentFallbacks: [],
-            };
-          }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.01,
-            agentFallbacks: [],
-          };
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (agentName) => {
+          if (agentName === "opencode") throw new Error("opencode failed");
+          return { output: `proposal-${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
         },
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-A-fallback-1",
-      stage: "run",
-      stageConfig: makeHybridStageConfig(),
-      workdir: "/tmp/work",
-      featureName: "feat-hybrid",
-      timeoutSeconds: 60,
-    });
-
-    const result = await session.run("test prompt");
-
+    const result = await runHybrid(ctx, "test prompt");
     expect(result.outcome).toBe("passed");
     expect(result.debaters).toEqual(["claude"]);
     expect(result.rounds).toBe(1);
@@ -287,29 +201,13 @@ describe("runHybrid() — single-agent fallback when fewer than 2 proposals succ
   });
 
   test("returns outcome=failed when 0 proposals succeed and fallback retry also fails", async () => {
-    _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async () => ({
-          success: false,
-          exitCode: 1,
-          output: "error",
-          rateLimited: false,
-          durationMs: 1,
-          estimatedCost: 0,
-          agentFallbacks: [],
-        }),
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async () => { throw new Error("all failed"); },
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-A-fallback-0",
-      stage: "run",
-      stageConfig: makeHybridStageConfig(),
-      workdir: "/tmp/work",
-      featureName: "feat-hybrid",
-      timeoutSeconds: 60,
-    });
-
-    const result = await session.run("test prompt");
-
+    const result = await runHybrid(ctx, "test prompt");
     expect(result.outcome).toBe("failed");
     expect(result.debaters).toEqual([]);
   });
@@ -319,29 +217,17 @@ describe("runHybrid() — single-agent fallback when fewer than 2 proposals succ
 
 describe("runHybrid() — successful proposal outputs collected (AC5)", () => {
   test("both proposal outputs appear in result.proposals when 2 proposals succeed", async () => {
-    _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (agentName) => ({
-          success: true,
-          exitCode: 0,
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async (agentName) => ({
           output: `proposal-from-${agentName}`,
-          rateLimited: false,
-          durationMs: 1,
-          estimatedCost: 0.01,
-          agentFallbacks: [],
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          internalRoundTrips: 0,
         }),
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-A-proposals",
-      stage: "run",
-      stageConfig: makeHybridStageConfig(),
-      workdir: "/tmp/work",
-      featureName: "feat-hybrid",
-      timeoutSeconds: 60,
-    });
-
-    const result = await session.run("test prompt");
-
+    const result = await runHybrid(ctx, "test prompt");
     expect(result.proposals).toHaveLength(2);
     const outputs = result.proposals.map((p) => p.output);
     expect(outputs).toContain("proposal-from-claude");
@@ -349,60 +235,43 @@ describe("runHybrid() — successful proposal outputs collected (AC5)", () => {
   });
 });
 
-// ─── AC6: adapters resolved via _debateSessionDeps.createManager ──────────────────
+// ─── AC6: adapters resolved via getAgent ─────────────────────────────────────
 
-describe("runHybrid() — adapter resolution via shared helper (AC6)", () => {
+describe("runHybrid() — adapter resolution via getAgent (AC6)", () => {
   test("manager.getAgent is called for each debater to resolve adapters", async () => {
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
     const agentCalls: string[] = [];
-
-    _debateSessionDeps.agentManager = makeMockAgentManager({
-      getAgentFn: (name: string) => {
-        agentCalls.push(name);
-        return {} as any;
-      },
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
+        getAgentFn: (name: string) => {
+          agentCalls.push(name);
+          return {} as any;
+        },
+        runAsSessionFn: async (agentName) => ({
+          output: `proposal-${agentName}`,
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          internalRoundTrips: 0,
+        }),
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-A-dep-calls",
-      stage: "run",
-      stageConfig: makeHybridStageConfig(),
-      workdir: "/tmp/work",
-      featureName: "feat-hybrid",
-      timeoutSeconds: 60,
-    });
-
-    await session.run("test prompt");
-
+    await runHybrid(ctx, "test prompt");
     expect(agentCalls).toContain("claude");
     expect(agentCalls).toContain("opencode");
   });
 
   test("debater is skipped when manager.getAgent returns undefined — triggers single-agent fallback", async () => {
-    _debateSessionDeps.agentManager = makeMockAgentManager({
+    const { runHybrid } = await import("../../../src/debate/session-hybrid");
+    const ctx = makeHybridCtx({
+      agentManager: makeMockAgentManager({
         unavailableAgents: new Set(["opencode"]),
-        runFn: async (agentName) => ({
-          success: true,
-          exitCode: 0,
+        runAsSessionFn: async (agentName) => ({
           output: `proposal-${agentName}`,
-          rateLimited: false,
-          durationMs: 1,
-          estimatedCost: 0.01,
-          agentFallbacks: [],
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          internalRoundTrips: 0,
         }),
+      }),
     });
-
-    const session = new DebateSession({
-      storyId: "US-004-A-helper-skip",
-      stage: "run",
-      stageConfig: makeHybridStageConfig(),
-      workdir: "/tmp/work",
-      featureName: "feat-hybrid",
-      timeoutSeconds: 60,
-    });
-
-    const result = await session.run("test prompt");
-
-    // Only 1 adapter resolved → falls back to single-agent
+    const result = await runHybrid(ctx, "test prompt");
     expect(result.outcome).toBe("passed");
     expect(result.debaters).toEqual(["claude"]);
   });

--- a/test/unit/debate/session-plan.test.ts
+++ b/test/unit/debate/session-plan.test.ts
@@ -4,7 +4,7 @@ import { DebateSession, _debateSessionDeps } from "../../../src/debate/session";
 import type { AgentRunRequest } from "../../../src/agents";
 import type { AgentRunOptions, CompleteOptions, CompleteResult, PlanOptions, PlanResult } from "../../../src/agents/types";
 import type { DebateStageConfig } from "../../../src/debate/types";
-import { makeMockAgentManager } from "../../helpers";
+import { makeMockAgentManager, makeSessionManager } from "../../helpers";
 
 async function waitForStartedPlans(
   startedOrder: number[],
@@ -113,24 +113,25 @@ describe("DebateSession.runPlan()", () => {
   });
 
   test("runs hybrid rebuttal loop when mode=hybrid and sessionMode=stateful", async () => {
-    const runCalls: Array<{ prompt: string; sessionRole?: string; keepOpen?: boolean }> = [];
+    const rebuttalCalls: Array<{ prompt: string; handleId: string }> = [];
+    const closedHandleIds: string[] = [];
+
+    const mockSM = makeSessionManager({
+      openSession: mock(async (name: string) => ({ id: name, agentName: "opencode" })),
+      closeSession: mock(async (handle) => { closedHandleIds.push(handle.id); }),
+      nameFor: mock((req) => req.role ?? ""),
+    });
 
     _debateSessionDeps.agentManager = makeMockAgentManager({
       planFn: async () => ({ specContent: "ok" }),
-      runFn: async (_agentName, options) => {
-        runCalls.push({
-          prompt: options.prompt ?? "",
-          sessionRole: options.sessionRole,
-          keepOpen: options.keepOpen,
-        });
+      runAsSessionFn: async (_agentName, handle, prompt) => {
+        if (prompt.includes("You are debater") && prompt.includes("## Your Task")) {
+          rebuttalCalls.push({ prompt, handleId: handle.id });
+        }
         return {
-          success: true,
-          exitCode: 0,
-          output: `run-output-${options.sessionRole}`,
-          rateLimited: false,
-          durationMs: 1,
-          estimatedCost: 0.05,
-          agentFallbacks: [],
+          output: `run-output-${handle.id}`,
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          internalRoundTrips: 0,
         };
       },
     });
@@ -146,6 +147,7 @@ describe("DebateSession.runPlan()", () => {
         rounds: 1,
       }),
       config: { ...TEST_CONFIG, debate: { enabled: true, agents: 2, maxConcurrentDebaters: 2 } } as unknown as NaxConfig,
+      sessionManager: mockSM,
     });
 
     const result = await session.runPlan("task context", "output format", {
@@ -154,17 +156,13 @@ describe("DebateSession.runPlan()", () => {
       outputDir: "/tmp/out",
     });
 
-    // Rebuttal calls should use manager.runAs() with plan-hybrid-{idx} session roles
-    const rebuttalCalls = runCalls.filter(
-      (c) => c.prompt.includes("You are debater") && c.prompt.includes("## Your Task"),
-    );
+    // Rebuttal calls should use runAsSession with plan-hybrid-{idx} handle IDs
     expect(rebuttalCalls).toHaveLength(2);
-    expect(rebuttalCalls[0]?.sessionRole).toBe("plan-hybrid-0");
-    expect(rebuttalCalls[1]?.sessionRole).toBe("plan-hybrid-1");
+    expect(rebuttalCalls[0]?.handleId).toBe("plan-hybrid-0");
+    expect(rebuttalCalls[1]?.handleId).toBe("plan-hybrid-1");
 
-    // Session close calls
-    const closeCalls = runCalls.filter((c) => c.prompt === "Close this debate session.");
-    expect(closeCalls).toHaveLength(2);
+    // Session close calls via sessionManager.closeSession
+    expect(closedHandleIds).toHaveLength(2);
 
     // Result should include rebuttals and correct round count
     expect(result.rebuttals).toBeDefined();

--- a/test/unit/debate/session-stateful.test.ts
+++ b/test/unit/debate/session-stateful.test.ts
@@ -6,6 +6,17 @@ import type { DebateStageConfig } from "../../../src/debate/types";
 import { computeAcpHandle } from "../../../src/agents/acp/adapter";
 import { makeMockAgentManager } from "../../helpers";
 
+test("SuccessfulProposal type carries optional handle field (compile-time check)", () => {
+  const proposal: import("../../../src/debate/session-helpers").SuccessfulProposal = {
+    debater: { agent: "claude", model: "fast" },
+    agentName: "claude",
+    output: "test",
+    cost: 0,
+    handle: { id: "sess-001", agentName: "claude" },
+  };
+  expect(proposal.handle?.id).toBe("sess-001");
+});
+
 function makeStageConfig(overrides: Partial<DebateStageConfig> = {}): DebateStageConfig {
   return {
     enabled: true,

--- a/test/unit/debate/session-stateful.test.ts
+++ b/test/unit/debate/session-stateful.test.ts
@@ -1,10 +1,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { DebateSession, _debateSessionDeps } from "../../../src/debate/session";
-import type { AgentRunRequest } from "../../../src/agents";
-import type { AgentRunOptions, CompleteOptions, CompleteResult } from "../../../src/agents/types";
+import type { CompleteOptions } from "../../../src/agents/types";
 import type { DebateStageConfig } from "../../../src/debate/types";
 import { computeAcpHandle } from "../../../src/agents/acp/adapter";
-import { makeMockAgentManager } from "../../helpers";
+import { makeMockAgentManager, makeSessionManager } from "../../helpers";
 
 test("SuccessfulProposal type carries optional handle field (compile-time check)", () => {
   const proposal: import("../../../src/debate/session-helpers").SuccessfulProposal = {
@@ -42,23 +41,20 @@ afterEach(() => {
   mock.restore();
 });
 
-describe("DebateSession.run() — stateful mode uses adapter.run SSOT", () => {
-  test("proposal round calls adapter.run for each debater with stable sessionRole", async () => {
-    const runCalls: AgentRunOptions[] = [];
+describe("DebateSession.run() — stateful mode uses runAsSession SSOT", () => {
+  test("proposal round calls runAsSession for each debater", async () => {
+    const runAsSessionCalls: Array<{ agentName: string; prompt: string; handleId: string }> = [];
+
+    const mockSM = makeSessionManager({
+      openSession: mock(async (name: string) => ({ id: name, agentName: "claude" })),
+      closeSession: mock(async () => {}),
+    });
 
     _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (agentName, opts) => {
-          runCalls.push(opts);
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.1,
-            agentFallbacks: [],
-          };
-        },
+      runAsSessionFn: async (agentName, handle, prompt) => {
+        runAsSessionCalls.push({ agentName, prompt, handleId: handle.id });
+        return { output: `proposal-${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
+      },
     });
 
     const session = new DebateSession({
@@ -68,74 +64,31 @@ describe("DebateSession.run() — stateful mode uses adapter.run SSOT", () => {
       workdir: "/tmp/work",
       featureName: "feat-a",
       timeoutSeconds: 120,
+      sessionManager: mockSM,
     });
 
     await session.run("test prompt");
 
-    expect(runCalls.length).toBe(2);
-    expect(runCalls[0].sessionRole).toBe("debate-plan-0");
-    expect(runCalls[1].sessionRole).toBe("debate-plan-1");
-    expect(runCalls[0].storyId).toBe("US-003");
-    expect(runCalls[0].featureName).toBe("feat-a");
-    expect(runCalls[0].workdir).toBe("/tmp/work");
-    expect(runCalls[0].keepOpen).toBe(false);
-    expect(runCalls[0].modelDef.model).not.toBe("fast");
-    expect(runCalls[1].modelDef.model).not.toBe("balanced");
+    expect(runAsSessionCalls.length).toBe(2);
+    expect(runAsSessionCalls[0].agentName).toBe("claude");
+    expect(runAsSessionCalls[1].agentName).toBe("opencode");
   });
 
-  test("uses explicit non-tier debater model override for modelDef", async () => {
-    const runCalls: AgentRunOptions[] = [];
+  test("rounds > 1: critique runs on same session handle as proposal", async () => {
+    const handleCallMap: Record<string, string[]> = {};
+    const closedHandles: string[] = [];
 
-    _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (agentName, opts) => {
-          runCalls.push(opts);
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.1,
-            agentFallbacks: [],
-          };
-        },
+    const mockSM = makeSessionManager({
+      openSession: mock(async (name: string) => ({ id: name, agentName: "claude" })),
+      closeSession: mock(async (handle) => { closedHandles.push(handle.id); }),
     });
 
-    const session = new DebateSession({
-      storyId: "US-003b",
-      stage: "plan",
-      stageConfig: makeStageConfig({
-        rounds: 1,
-        debaters: [
-          { agent: "claude", model: "claude-sonnet-4-5-20250514" },
-          { agent: "opencode", model: "balanced" },
-        ],
-      }),
-      workdir: "/tmp/work",
-      featureName: "feat-a",
-    });
-
-    await session.run("test prompt");
-
-    expect(runCalls[0].modelDef.model).toBe("claude-sonnet-4-5-20250514");
-  });
-
-  test("rounds > 1 keeps proposal session open and reuses same role in critique", async () => {
-    const runCalls: AgentRunOptions[] = [];
-
     _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (agentName, opts) => {
-          runCalls.push(opts);
-          return {
-            success: true,
-            exitCode: 0,
-            output: opts.prompt.includes("Critique") ? `critique-${agentName}` : `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.1,
-            agentFallbacks: [],
-          };
-        },
+      runAsSessionFn: async (_agentName, handle, prompt) => {
+        handleCallMap[handle.id] = handleCallMap[handle.id] ?? [];
+        handleCallMap[handle.id].push(prompt.includes("reviewing proposals") ? "critique" : "proposal");
+        return { output: "ok", tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
+      },
     });
 
     const session = new DebateSession({
@@ -145,57 +98,28 @@ describe("DebateSession.run() — stateful mode uses adapter.run SSOT", () => {
       workdir: "/tmp/work",
       featureName: "feat-b",
       timeoutSeconds: 120,
+      sessionManager: mockSM,
     });
 
     await session.run("review prompt");
 
-    expect(runCalls.length).toBe(4);
-    expect(runCalls[0].keepOpen).toBe(true);
-    expect(runCalls[1].keepOpen).toBe(true);
-    expect(runCalls[2].keepOpen).toBe(false);
-    expect(runCalls[3].keepOpen).toBe(false);
-    expect(runCalls[2].sessionRole).toBe("debate-review-0");
-    expect(runCalls[3].sessionRole).toBe("debate-review-1");
+    for (const calls of Object.values(handleCallMap)) {
+      expect(calls).toContain("proposal");
+      expect(calls).toContain("critique");
+    }
+    expect(closedHandles.length).toBe(2);
   });
 
   test("falls back to single-agent passed when only one proposal run succeeds", async () => {
-    const runCalls: AgentRunOptions[] = [];
-
+    const mockSM = makeSessionManager({
+      openSession: mock(async (name: string) => ({ id: name, agentName: name.includes("opencode") ? "opencode" : "claude" })),
+      closeSession: mock(async () => {}),
+    });
     _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (agentName, opts) => {
-          runCalls.push(opts);
-          if (opts.prompt === "Close this debate session.") {
-            return {
-              success: true,
-              exitCode: 0,
-              output: "closed",
-              rateLimited: false,
-              durationMs: 1,
-              estimatedCost: 0.05,
-              agentFallbacks: [],
-            };
-          }
-          if (agentName === "opencode") {
-            return {
-              success: false,
-              exitCode: 1,
-              output: "failed",
-              rateLimited: false,
-              durationMs: 1,
-              estimatedCost: 0,
-              agentFallbacks: [],
-            };
-          }
-          return {
-            success: true,
-            exitCode: 0,
-            output: `proposal-${agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.1,
-            agentFallbacks: [],
-          };
-        },
+      runAsSessionFn: async (agentName, _handle, _prompt) => {
+        if (agentName === "opencode") throw new Error("opencode failed");
+        return { output: `proposal-${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
+      },
     });
 
     const session = new DebateSession({
@@ -204,35 +128,34 @@ describe("DebateSession.run() — stateful mode uses adapter.run SSOT", () => {
       stageConfig: makeStageConfig({ rounds: 2 }),
       workdir: "/tmp/work",
       featureName: "feat-c",
+      sessionManager: mockSM,
     });
 
     const result = await session.run("review prompt");
     expect(result.outcome).toBe("passed");
     expect(result.debaters).toEqual(["claude"]);
-    expect(runCalls.some((c) => c.prompt === "Close this debate session." && c.keepOpen === false)).toBe(true);
   });
 });
-
-// ─── AC4: call site passes ctx.workdir and ctx.featureName to resolveOutcome ──
 
 describe("runStateful() — resolveOutcome receives workdir and featureName (US-004 AC4)", () => {
   test("synthesis resolver receives sessionName built from ctx.workdir and ctx.featureName", async () => {
     const completeCalls: { opts?: CompleteOptions }[] = [];
 
+    const mockSM = makeSessionManager({
+      openSession: mock(async (name: string) => ({ id: name, agentName: "claude" })),
+      closeSession: mock(async () => {}),
+    });
+
     _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (_agentName, _opts) => ({
-          success: true,
-          exitCode: 0,
-          output: '{"passed": true}',
-          rateLimited: false,
-          durationMs: 1,
-          estimatedCost: 0.05,
-          agentFallbacks: [],
-        }),
-        completeFn: async (_agentName: string, _prompt: string, opts?: CompleteOptions) => {
-          completeCalls.push({ opts });
-          return { output: "synthesis resolved", costUsd: 0.01, source: "exact" as const };
-        },
+      runAsSessionFn: async () => ({
+        output: '{"passed": true}',
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        internalRoundTrips: 0,
+      }),
+      completeFn: async (_agentName: string, _prompt: string, opts?: CompleteOptions) => {
+        completeCalls.push({ opts });
+        return { output: "synthesis resolved", costUsd: 0.01, source: "exact" as const };
+      },
     });
 
     const workdir = "/tmp/stateful-work";
@@ -246,11 +169,11 @@ describe("runStateful() — resolveOutcome receives workdir and featureName (US-
       workdir,
       featureName,
       timeoutSeconds: 60,
+      sessionManager: mockSM,
     });
 
     await session.run("review prompt");
 
-    // The synthesis resolver's complete() should have been called with the synthesis sessionName.
     const synthesisCall = completeCalls.find((c) => c.opts !== undefined);
     expect(synthesisCall).toBeDefined();
     const expectedSessionName = computeAcpHandle(workdir, featureName, storyId, "synthesis");
@@ -259,27 +182,19 @@ describe("runStateful() — resolveOutcome receives workdir and featureName (US-
 });
 
 describe("DebateSession.run() — one-shot mode unchanged", () => {
-  test("one-shot does not use adapter.run for proposal path", async () => {
-    let runCount = 0;
+  test("one-shot does not use runAsSession for proposal path", async () => {
+    let runAsSessionCount = 0;
     let completeCount = 0;
 
     _debateSessionDeps.agentManager = makeMockAgentManager({
-        runFn: async (_agentName, _opts) => {
-          runCount += 1;
-          return {
-            success: true,
-            exitCode: 0,
-            output: `run-${_agentName}`,
-            rateLimited: false,
-            durationMs: 1,
-            estimatedCost: 0.1,
-            agentFallbacks: [],
-          };
-        },
-        completeFn: async () => {
-          completeCount += 1;
-          return { output: '{"passed": true}', costUsd: 0.1, source: "exact" };
-        },
+      runAsSessionFn: async () => {
+        runAsSessionCount += 1;
+        return { output: "run-session", tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
+      },
+      completeFn: async () => {
+        completeCount += 1;
+        return { output: '{"passed": true}', costUsd: 0.1, source: "exact" };
+      },
     });
 
     const session = new DebateSession({
@@ -292,7 +207,7 @@ describe("DebateSession.run() — one-shot mode unchanged", () => {
 
     await session.run("plan prompt");
 
-    expect(runCount).toBe(0);
+    expect(runAsSessionCount).toBe(0);
     expect(completeCount).toBeGreaterThan(0);
   });
 });

--- a/test/unit/pipeline/stages/review-debate-dialogue.test.ts
+++ b/test/unit/pipeline/stages/review-debate-dialogue.test.ts
@@ -14,7 +14,7 @@ import { _reviewDeps, reviewStage } from "../../../../src/pipeline/stages/review
 import type { PipelineContext } from "../../../../src/pipeline/types";
 import type { ReviewerSession } from "../../../../src/review/dialogue";
 import type { PRD, UserStory } from "../../../../src/prd";
-import { makeMockAgentManager, makeNaxConfig } from "../../../helpers";
+import { makeMockAgentManager, makeNaxConfig, makeSessionManager } from "../../../helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Saved originals — restored in afterEach
@@ -141,6 +141,7 @@ function makeCtx(config: ReturnType<typeof makeNaxConfig>, overrides: Partial<Pi
     workdir: "/tmp/test",
     hooks: {} as PipelineContext["hooks"],
     agentManager: mockAgentManager,
+    sessionManager: makeSessionManager(),
     ...overrides,
   } as unknown as PipelineContext;
 }

--- a/test/unit/pipeline/stages/review-dialogue.test.ts
+++ b/test/unit/pipeline/stages/review-dialogue.test.ts
@@ -12,7 +12,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { _reviewDeps, reviewStage } from "../../../../src/pipeline/stages/review";
 import type { PipelineContext } from "../../../../src/pipeline/types";
-import { makeMockAgentManager, makeSparseNaxConfig, makeStory } from "../../../helpers";
+import { makeMockAgentManager, makeSessionManager, makeSparseNaxConfig, makeStory } from "../../../helpers";
 import type { ReviewerSession } from "../../../../src/review/dialogue";
 import type { PRD, UserStory } from "../../../../src/prd";
 
@@ -77,6 +77,7 @@ function makeCtx(config: NaxConfig, overrides: Partial<PipelineContext> = {}): P
     workdir: "/tmp/test",
     hooks: {} as PipelineContext["hooks"],
     agentManager: mockAgentManager,
+    sessionManager: makeSessionManager(),
     ...overrides,
   } as unknown as PipelineContext;
 }

--- a/test/unit/review/dialogue-debate.test.ts
+++ b/test/unit/review/dialogue-debate.test.ts
@@ -19,11 +19,12 @@ import { describe, expect, mock, test } from "bun:test";
 import { createReviewerSession } from "../../../src/review/dialogue";
 import type { DebateResolverContext } from "../../../src/debate/types";
 import type { IAgentManager } from "../../../src/agents/manager-types";
-import type { AgentRunOptions, AgentResult } from "../../../src/agents/types";
+import type { RunAsSessionOpts } from "../../../src/agents/manager-types";
+import type { SessionHandle, TurnResult } from "../../../src/agents/types";
 import type { SemanticStory } from "../../../src/review/semantic";
 import type { SemanticReviewConfig } from "../../../src/review/types";
 import { NaxError } from "../../../src/errors";
-import { makeMockAgentManager } from "../../helpers";
+import { makeMockAgentManager, makeSessionManager } from "../../helpers";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -38,6 +39,8 @@ const STORY: SemanticStory = {
 
 const SEMANTIC_CONFIG: SemanticReviewConfig = {
   modelTier: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
   rules: [],
   timeoutMs: 60_000,
   excludePatterns: [],
@@ -71,26 +74,21 @@ const REREVIEW_RESPONSE = JSON.stringify({
   deltaSummary: "ac-gap is now resolved",
 });
 
-type RunFn = (opts: AgentRunOptions) => Promise<AgentResult>;
+type RunAsSessionFnType = (agentName: string, handle: SessionHandle, prompt: string, opts: RunAsSessionOpts) => Promise<TurnResult>;
 
-function makeRunFn(response: string, cost = 0.001): RunFn {
-  return mock(async (_opts: AgentRunOptions): Promise<AgentResult> => ({
+function makeRunFn(response: string, cost = 0.001): RunAsSessionFnType {
+  return mock(async (_agentName: string, _handle: SessionHandle, _prompt: string, _opts: RunAsSessionOpts): Promise<TurnResult> => ({
     output: response,
-    exitCode: 0,
-    success: true,
-    rateLimited: false,
-    durationMs: 100,
-    estimatedCost: cost,
+    tokenUsage: { inputTokens: 0, outputTokens: 0 },
+    cost: { total: cost },
+    internalRoundTrips: 0,
   }));
 }
 
-function makeAgentManager(runFn: RunFn): IAgentManager {
+function makeAgentManager(runAsSessionFn: RunAsSessionFnType): IAgentManager {
   return makeMockAgentManager({
     getDefaultAgent: "claude",
-    runFn: async (_agentName: string, opts: unknown) => {
-      const result = await runFn(opts as AgentRunOptions);
-      return { ...result, agentFallbacks: [] };
-    },
+    runAsSessionFn,
     completeFn: async () => ({ output: "", costUsd: 0, source: "mock" as const }),
   });
 }
@@ -107,21 +105,23 @@ const MOCK_CONFIG = {
 // ---------------------------------------------------------------------------
 
 describe("ReviewerSession.resolveDebate()", () => {
-  test("calls agent.run() with keepOpen: true and sessionRole: reviewer", async () => {
-    const runFn = makeRunFn(PASSING_RESPONSE);
-    const session = createReviewerSession(makeAgentManager(runFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+  test("calls agentManager.runAsSession() with pipelineStage: review (ADR-019)", async () => {
+    let capturedOpts: RunAsSessionOpts | undefined;
+    const runFn = mock(async (_agentName: string, _handle: SessionHandle, _prompt: string, opts: RunAsSessionOpts): Promise<TurnResult> => {
+      capturedOpts = opts;
+      return { output: PASSING_RESPONSE, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
+    });
+    const session = createReviewerSession(makeAgentManager(runFn), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
 
     expect(runFn).toHaveBeenCalledTimes(1);
-    const opts = (runFn as ReturnType<typeof mock>).mock.calls[0][0] as AgentRunOptions;
-    expect(opts.keepOpen).toBe(true);
-    expect(opts.sessionRole).toBe("reviewer");
-    expect(opts.pipelineStage).toBe("review");
+    expect(capturedOpts?.pipelineStage).toBe("review");
+    await session.destroy();
   });
 
   test("parses JSON response into ReviewDialogueResult (passing)", async () => {
-    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const result = await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
 
@@ -130,7 +130,7 @@ describe("ReviewerSession.resolveDebate()", () => {
   });
 
   test("parses JSON response into ReviewDialogueResult (failing with findings)", async () => {
-    const session = createReviewerSession(makeAgentManager(makeRunFn(FAILING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(makeRunFn(FAILING_RESPONSE)), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const result = await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
 
@@ -141,14 +141,14 @@ describe("ReviewerSession.resolveDebate()", () => {
   });
 
   test("captures LLM cost", async () => {
-    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE, 0.005)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE, 0.005)), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const result = await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
     expect(result.cost).toBe(0.005);
   });
 
   test("appends exactly 2 history entries (implementer prompt + reviewer response)", async () => {
-    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
 
@@ -158,7 +158,7 @@ describe("ReviewerSession.resolveDebate()", () => {
   });
 
   test("stores lastCheckResult so getVerdict() works", async () => {
-    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
     // getVerdict() should not throw
@@ -168,7 +168,7 @@ describe("ReviewerSession.resolveDebate()", () => {
   });
 
   test("throws REVIEWER_SESSION_DESTROYED when session is inactive", async () => {
-    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     await session.destroy();
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
 
@@ -183,49 +183,53 @@ describe("ReviewerSession.resolveDebate()", () => {
 describe("resolveDebate() prompt framing by resolver type", () => {
   test("synthesis: prompt contains 'synthes'", async () => {
     const runFn = makeRunFn(PASSING_RESPONSE);
-    const session = createReviewerSession(makeAgentManager(runFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(runFn), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
 
-    const opts = (runFn as ReturnType<typeof mock>).mock.calls[0][0] as AgentRunOptions;
-    expect(opts.prompt.toLowerCase()).toContain("synthes");
+    const prompt = (runFn as ReturnType<typeof mock>).mock.calls[0][2] as string;
+    expect(prompt.toLowerCase()).toContain("synthes");
+    await session.destroy();
   });
 
   test("custom: prompt contains 'judge'", async () => {
     const runFn = makeRunFn(PASSING_RESPONSE);
-    const session = createReviewerSession(makeAgentManager(runFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(runFn), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "custom" };
     await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
 
-    const opts = (runFn as ReturnType<typeof mock>).mock.calls[0][0] as AgentRunOptions;
-    expect(opts.prompt.toLowerCase()).toContain("judge");
+    const prompt = (runFn as ReturnType<typeof mock>).mock.calls[0][2] as string;
+    expect(prompt.toLowerCase()).toContain("judge");
+    await session.destroy();
   });
 
   test("majority-fail-closed: prompt contains vote tally", async () => {
     const runFn = makeRunFn(PASSING_RESPONSE);
-    const session = createReviewerSession(makeAgentManager(runFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(runFn), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = {
       resolverType: "majority-fail-closed",
       majorityVote: { passed: false, passCount: 1, failCount: 1 },
     };
     await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
 
-    const opts = (runFn as ReturnType<typeof mock>).mock.calls[0][0] as AgentRunOptions;
-    expect(opts.prompt).toContain("1 passed");
-    expect(opts.prompt).toContain("1 failed");
+    const prompt = (runFn as ReturnType<typeof mock>).mock.calls[0][2] as string;
+    expect(prompt).toContain("1 passed");
+    expect(prompt).toContain("1 failed");
+    await session.destroy();
   });
 
   test("majority-fail-open: prompt contains vote tally", async () => {
     const runFn = makeRunFn(PASSING_RESPONSE);
-    const session = createReviewerSession(makeAgentManager(runFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(runFn), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = {
       resolverType: "majority-fail-open",
       majorityVote: { passed: true, passCount: 2, failCount: 0 },
     };
     await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
 
-    const opts = (runFn as ReturnType<typeof mock>).mock.calls[0][0] as AgentRunOptions;
-    expect(opts.prompt).toContain("2 passed");
+    const prompt = (runFn as ReturnType<typeof mock>).mock.calls[0][2] as string;
+    expect(prompt).toContain("2 passed");
+    await session.destroy();
   });
 });
 
@@ -235,7 +239,7 @@ describe("resolveDebate() prompt framing by resolver type", () => {
 
 describe("ReviewerSession.reReviewDebate()", () => {
   test("throws NO_REVIEW_RESULT when called before any resolveDebate()", async () => {
-    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
 
     await expect(session.reReviewDebate(PROPOSALS, CRITIQUES, DIFF, ctx)).rejects.toBeInstanceOf(NaxError);
@@ -244,7 +248,7 @@ describe("ReviewerSession.reReviewDebate()", () => {
   test("throws NO_REVIEW_RESULT when called after review() but not resolveDebate() (prevents wrong delta baseline)", async () => {
     // review() sets lastCheckResult/lastSemanticConfig but lastWasDebateResolve stays false —
     // reReviewDebate() must not accept non-debate findings as the delta baseline.
-    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     await session.review(DIFF, STORY, SEMANTIC_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
 
@@ -252,7 +256,7 @@ describe("ReviewerSession.reReviewDebate()", () => {
   });
 
   test("throws REVIEWER_SESSION_DESTROYED when session is inactive", async () => {
-    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(makeRunFn(PASSING_RESPONSE)), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     await session.destroy();
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
 
@@ -262,12 +266,12 @@ describe("ReviewerSession.reReviewDebate()", () => {
   test("references previous findings in prompt", async () => {
     // Second call returns passing
     let callCount = 0;
-    const multiRunFn: RunFn = mock(async (_opts: AgentRunOptions): Promise<AgentResult> => {
+    const multiRunFn: RunAsSessionFnType = mock(async (_agentName: string, _handle: SessionHandle, _prompt: string, _opts: RunAsSessionOpts): Promise<TurnResult> => {
       callCount++;
-      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, exitCode: 0, success: true, rateLimited: false, durationMs: 100, estimatedCost: 0.001 };
+      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
     });
 
-    const session = createReviewerSession(makeAgentManager(multiRunFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(multiRunFn), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
 
     // First: resolveDebate with failing result
@@ -275,18 +279,18 @@ describe("ReviewerSession.reReviewDebate()", () => {
     // Second: reReviewDebate — prompt should reference "ac-gap"
     await session.reReviewDebate(PROPOSALS, CRITIQUES, DIFF, ctx);
 
-    const secondCallOpts = (multiRunFn as ReturnType<typeof mock>).mock.calls[1][0] as AgentRunOptions;
-    expect(secondCallOpts.prompt).toContain("ac-gap");
+    const secondCallPrompt = (multiRunFn as ReturnType<typeof mock>).mock.calls[1][2] as string;
+    expect(secondCallPrompt).toContain("ac-gap");
   });
 
   test("returns ReviewDialogueResult with deltaSummary", async () => {
     let callCount = 0;
-    const multiRunFn: RunFn = mock(async (_opts: AgentRunOptions): Promise<AgentResult> => {
+    const multiRunFn: RunAsSessionFnType = mock(async (_agentName: string, _handle: SessionHandle, _prompt: string, _opts: RunAsSessionOpts): Promise<TurnResult> => {
       callCount++;
-      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, exitCode: 0, success: true, rateLimited: false, durationMs: 100, estimatedCost: 0.001 };
+      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
     });
 
-    const session = createReviewerSession(makeAgentManager(multiRunFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(multiRunFn), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
 
     await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
@@ -299,12 +303,12 @@ describe("ReviewerSession.reReviewDebate()", () => {
 
   test("appends 2 more history entries", async () => {
     let callCount = 0;
-    const multiRunFn: RunFn = mock(async (_opts: AgentRunOptions): Promise<AgentResult> => {
+    const multiRunFn: RunAsSessionFnType = mock(async (_agentName: string, _handle: SessionHandle, _prompt: string, _opts: RunAsSessionOpts): Promise<TurnResult> => {
       callCount++;
-      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, exitCode: 0, success: true, rateLimited: false, durationMs: 100, estimatedCost: 0.001 };
+      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
     });
 
-    const session = createReviewerSession(makeAgentManager(multiRunFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(multiRunFn), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
 
     await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
@@ -320,12 +324,12 @@ describe("ReviewerSession.reReviewDebate()", () => {
     } as unknown as import("../../../src/config").NaxConfig;
 
     let callCount = 0;
-    const multiRunFn: RunFn = mock(async (_opts: AgentRunOptions): Promise<AgentResult> => {
+    const multiRunFn: RunAsSessionFnType = mock(async (_agentName: string, _handle: SessionHandle, _prompt: string, _opts: RunAsSessionOpts): Promise<TurnResult> => {
       callCount++;
-      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, exitCode: 0, success: true, rateLimited: false, durationMs: 100, estimatedCost: 0.001 };
+      return { output: callCount === 1 ? FAILING_RESPONSE : REREVIEW_RESPONSE, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
     });
 
-    const session = createReviewerSession(makeAgentManager(multiRunFn), "story-1", "/workdir", "feature", smallMaxConfig);
+    const session = createReviewerSession(makeAgentManager(multiRunFn), makeSessionManager(), "story-1", "/workdir", "feature", smallMaxConfig);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
 
     await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);
@@ -345,19 +349,16 @@ describe("ReviewerSession.reReviewDebate()", () => {
 describe("clarify() after resolveDebate()", () => {
   test("can clarify after resolveDebate without error", async () => {
     let callCount = 0;
-    const multiRunFn: RunFn = mock(async (_opts: AgentRunOptions): Promise<AgentResult> => {
+    const multiRunFn: RunAsSessionFnType = mock(async (_agentName: string, _handle: SessionHandle, _prompt: string, _opts: RunAsSessionOpts): Promise<TurnResult> => {
       callCount++;
       return {
         output: callCount === 1 ? PASSING_RESPONSE : "The finding means X needs to be implemented.",
-        exitCode: 0,
-        success: true,
-        rateLimited: false,
-        durationMs: 100,
-        estimatedCost: 0.001,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        internalRoundTrips: 0,
       };
     });
 
-    const session = createReviewerSession(makeAgentManager(multiRunFn), "story-1", "/workdir", "feature", MOCK_CONFIG);
+    const session = createReviewerSession(makeAgentManager(multiRunFn), makeSessionManager(), "story-1", "/workdir", "feature", MOCK_CONFIG);
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
 
     await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, SEMANTIC_CONFIG, ctx);

--- a/test/unit/review/dialogue-re-review.test.ts
+++ b/test/unit/review/dialogue-re-review.test.ts
@@ -14,15 +14,16 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { NaxConfigSchema } from "../../../src/config/schemas";
+import type { NaxConfig } from "../../../src/config";
 import type { IAgentManager } from "../../../src/agents/manager-types";
+import type { RunAsSessionOpts } from "../../../src/agents/manager-types";
+import type { SessionHandle, TurnResult } from "../../../src/agents/types";
 import { createReviewerSession } from "../../../src/review/dialogue";
-import type { DialogueMessage, ReviewDialogueResult, ReviewerSession } from "../../../src/review/dialogue";
-import type { AgentRunOptions, AgentResult } from "../../../src/agents/types";
+import type { ReviewerSession } from "../../../src/review/dialogue";
 import type { SemanticReviewConfig } from "../../../src/review/types";
 import type { SemanticStory } from "../../../src/review/semantic";
-import type { SemanticVerdict } from "../../../src/acceptance/types";
 import { NaxError } from "../../../src/errors";
-import { makeMockAgentManager } from "../../helpers";
+import { makeMockAgentManager, makeSessionManager } from "../../helpers";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,6 +42,8 @@ const STORY: SemanticStory = {
 
 const SEMANTIC_CONFIG: SemanticReviewConfig = {
   modelTier: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
   rules: [],
   timeoutMs: 60_000,
   excludePatterns: [":!test/", ":!*.test.ts"],
@@ -98,31 +101,27 @@ const RE_REVIEW_RESPONSE = JSON.stringify({
 
 const CLARIFY_RESPONSE = "AC-1 requires that reReview() calls agent.run() with keepOpen: true and includes the previous findings in the prompt.";
 
-type RunFn = (opts: AgentRunOptions) => Promise<AgentResult>;
+type RunAsSessionFnType = (agentName: string, handle: SessionHandle, prompt: string, opts?: RunAsSessionOpts) => Promise<TurnResult>;
 
-function makeAgentManager(runFn?: RunFn): IAgentManager {
-  const defaultRunFn = mock(async () => ({
-    success: true,
-    exitCode: 0,
+function makeAgentManager(runAsSessionFn?: RunAsSessionFnType): IAgentManager {
+  const defaultFn = mock(async (_agentName: string, _handle: SessionHandle, _prompt: string): Promise<TurnResult> => ({
     output: INITIAL_PASSING_RESPONSE,
-    rateLimited: false,
-    durationMs: 10,
-    estimatedCost: 0.001,
+    tokenUsage: { inputTokens: 0, outputTokens: 0 },
+    internalRoundTrips: 0,
   }));
-  const effectiveRunFn = runFn ?? defaultRunFn;
+  const effectiveFn = runAsSessionFn ?? defaultFn;
 
   return makeMockAgentManager({
     getDefaultAgent: "claude",
-    runFn: async (_agentName: string, opts: unknown) => {
-      const result = await effectiveRunFn(opts as AgentRunOptions);
-      return { ...result, agentFallbacks: [] };
+    runAsSessionFn: async (agentName: string, handle: SessionHandle, prompt: string, opts?: RunAsSessionOpts) => {
+      return await effectiveFn(agentName, handle, prompt, opts);
     },
     completeFn: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
   });
 }
 
 function makeConfig() {
-  return NaxConfigSchema.parse({}) as ReturnType<typeof NaxConfigSchema.parse>;
+  return NaxConfigSchema.parse({}) as unknown as NaxConfig;
 }
 
 /**
@@ -131,20 +130,13 @@ function makeConfig() {
  */
 async function makeSessionWithReview(runSequence: string[]): Promise<ReviewerSession> {
   let callIndex = 0;
-  const runFn: RunFn = async () => {
+  const runFn: RunAsSessionFnType = async () => {
     const output = runSequence[callIndex] ?? INITIAL_PASSING_RESPONSE;
     callIndex++;
-    return {
-      success: true,
-      exitCode: 0,
-      output,
-      rateLimited: false,
-      durationMs: 10,
-      estimatedCost: 0.001,
-    };
+    return { output, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
   };
   const agentManager = makeAgentManager(runFn);
-  const session = createReviewerSession(agentManager, "US-002", "/work", "my-feature", makeConfig());
+  const session = createReviewerSession(agentManager, makeSessionManager(), "US-002", "/work", "my-feature", makeConfig());
   await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
   return session;
 }
@@ -153,32 +145,29 @@ async function makeSessionWithReview(runSequence: string[]): Promise<ReviewerSes
 // AC1 — reReview() sends follow-up referencing previous findings by AC identifier
 // ---------------------------------------------------------------------------
 
-describe("ReviewerSession.reReview() — agent.run() call parameters", () => {
-  let capturedOpts: AgentRunOptions | undefined;
+describe("ReviewerSession.reReview() — agentManager.runAsSession() call parameters (ADR-019)", () => {
+  let capturedPrompt: string | undefined;
+  let capturedOpts: RunAsSessionOpts | undefined;
   let session: ReviewerSession;
 
   beforeEach(async () => {
+    capturedPrompt = undefined;
     capturedOpts = undefined;
     let callIndex = 0;
     const responses = [INITIAL_FAILING_RESPONSE, RE_REVIEW_RESPONSE];
-    const runFn: RunFn = async (opts) => {
+    const runFn: RunAsSessionFnType = async (_agentName, _handle, prompt, opts) => {
+      capturedPrompt = prompt;
       capturedOpts = opts;
       const output = responses[callIndex] ?? INITIAL_PASSING_RESPONSE;
       callIndex++;
-      return {
-        success: true,
-        exitCode: 0,
-        output,
-        rateLimited: false,
-        durationMs: 10,
-        estimatedCost: 0.001,
-      };
+      return { output, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
     };
     const agentManager = makeAgentManager(runFn);
-    session = createReviewerSession(agentManager, "US-002", "/work", "my-feature", makeConfig());
+    session = createReviewerSession(agentManager, makeSessionManager(), "US-002", "/work", "my-feature", makeConfig());
     // perform initial review so checkResult is populated
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
-    // reset captured opts so we only capture reReview's call
+    // reset captured values so we only capture reReview's call
+    capturedPrompt = undefined;
     capturedOpts = undefined;
   });
 
@@ -187,34 +176,24 @@ describe("ReviewerSession.reReview() — agent.run() call parameters", () => {
     mock.restore();
   });
 
-  test("calls agent.run() with keepOpen: true", async () => {
-    await session.reReview(UPDATED_DIFF);
-    expect(capturedOpts?.keepOpen).toBe(true);
-  });
-
-  test("calls agent.run() with sessionRole: 'reviewer'", async () => {
-    await session.reReview(UPDATED_DIFF);
-    expect(capturedOpts?.sessionRole).toBe("reviewer");
-  });
-
-  test("calls agent.run() with pipelineStage: 'review'", async () => {
+  test("calls agentManager.runAsSession() with pipelineStage: 'review'", async () => {
     await session.reReview(UPDATED_DIFF);
     expect(capturedOpts?.pipelineStage).toBe("review");
   });
 
   test("prompt contains the updated diff", async () => {
     await session.reReview(UPDATED_DIFF);
-    expect(capturedOpts?.prompt).toContain(UPDATED_DIFF);
+    expect(capturedPrompt).toContain(UPDATED_DIFF);
   });
 
   test("prompt references previous finding by ruleId (AC-1-not-satisfied)", async () => {
     await session.reReview(UPDATED_DIFF);
-    expect(capturedOpts?.prompt).toContain("AC-1-not-satisfied");
+    expect(capturedPrompt).toContain("AC-1-not-satisfied");
   });
 
   test("prompt references second previous finding by ruleId (AC-2-not-satisfied)", async () => {
     await session.reReview(UPDATED_DIFF);
-    expect(capturedOpts?.prompt).toContain("AC-2-not-satisfied");
+    expect(capturedPrompt).toContain("AC-2-not-satisfied");
   });
 });
 
@@ -325,19 +304,19 @@ describe("ReviewerSession.reReview() — session compaction", () => {
    * We perform 2 reviews (4 entries) then 1 reReview — total would be 6, exceeding 5.
    */
 
-  function makeSmallDialogueConfig() {
-    const base = NaxConfigSchema.parse({}) as ReturnType<typeof NaxConfigSchema.parse>;
+  function makeSmallDialogueConfig(): NaxConfig {
+    const base = NaxConfigSchema.parse({}) as unknown as { review: Record<string, unknown> };
     return NaxConfigSchema.parse({
       ...base,
       review: {
-        ...(base as unknown as { review: Record<string, unknown> }).review,
+        ...base.review,
         dialogue: {
           enabled: true,
           maxClarificationsPerAttempt: 2,
           maxDialogueMessages: 5,
         },
       },
-    });
+    }) as unknown as NaxConfig;
   }
 
   test("session remains active after compaction", async () => {
@@ -348,16 +327,13 @@ describe("ReviewerSession.reReview() — session compaction", () => {
       INITIAL_FAILING_RESPONSE, // review #2
       RE_REVIEW_RESPONSE,       // reReview #1 — triggers compaction (would be 6th entry)
     ];
-    const runFn: RunFn = async () => ({
-      success: true,
-      exitCode: 0,
+    const runFn: RunAsSessionFnType = async () => ({
       output: responses[callIndex++] ?? INITIAL_PASSING_RESPONSE,
-      rateLimited: false,
-      durationMs: 10,
-      estimatedCost: 0.001,
+      tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      internalRoundTrips: 0,
     });
     const agentManager = makeAgentManager(runFn);
-    const session = createReviewerSession(agentManager, "US-002", "/work", "my-feature", config);
+    const session = createReviewerSession(agentManager, makeSessionManager(), "US-002", "/work", "my-feature", config);
 
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
@@ -376,16 +352,13 @@ describe("ReviewerSession.reReview() — session compaction", () => {
       INITIAL_FAILING_RESPONSE,
       RE_REVIEW_RESPONSE,
     ];
-    const runFn: RunFn = async () => ({
-      success: true,
-      exitCode: 0,
+    const runFn: RunAsSessionFnType = async () => ({
       output: responses[callIndex++] ?? INITIAL_PASSING_RESPONSE,
-      rateLimited: false,
-      durationMs: 10,
-      estimatedCost: 0.001,
+      tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      internalRoundTrips: 0,
     });
     const agentManager = makeAgentManager(runFn);
-    const session = createReviewerSession(agentManager, "US-002", "/work", "my-feature", config);
+    const session = createReviewerSession(agentManager, makeSessionManager(), "US-002", "/work", "my-feature", config);
 
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
@@ -401,30 +374,27 @@ describe("ReviewerSession.reReview() — session compaction", () => {
 // AC5 — clarify() sends question as follow-up and returns raw response string
 // ---------------------------------------------------------------------------
 
-describe("ReviewerSession.clarify() — agent.run() call and return value", () => {
-  let capturedOpts: AgentRunOptions | undefined;
+describe("ReviewerSession.clarify() — agentManager.runAsSession() call and return value (ADR-019)", () => {
+  let capturedPrompt: string | undefined;
+  let capturedOpts: RunAsSessionOpts | undefined;
   let session: ReviewerSession;
 
   beforeEach(async () => {
+    capturedPrompt = undefined;
     capturedOpts = undefined;
     let callIndex = 0;
     const responses = [INITIAL_FAILING_RESPONSE, CLARIFY_RESPONSE];
-    const runFn: RunFn = async (opts) => {
+    const runFn: RunAsSessionFnType = async (_agentName, _handle, prompt, opts) => {
+      capturedPrompt = prompt;
       capturedOpts = opts;
       const output = responses[callIndex] ?? "";
       callIndex++;
-      return {
-        success: true,
-        exitCode: 0,
-        output,
-        rateLimited: false,
-        durationMs: 10,
-        estimatedCost: 0.001,
-      };
+      return { output, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
     };
     const agentManager = makeAgentManager(runFn);
-    session = createReviewerSession(agentManager, "US-002", "/work", "my-feature", makeConfig());
+    session = createReviewerSession(agentManager, makeSessionManager(), "US-002", "/work", "my-feature", makeConfig());
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
+    capturedPrompt = undefined;
     capturedOpts = undefined;
   });
 
@@ -443,20 +413,15 @@ describe("ReviewerSession.clarify() — agent.run() call and return value", () =
     expect(result).toBe(CLARIFY_RESPONSE);
   });
 
-  test("calls agent.run() with keepOpen: true", async () => {
+  test("calls agentManager.runAsSession() with pipelineStage: 'review'", async () => {
     await session.clarify("What does AC-1 require exactly?");
-    expect(capturedOpts?.keepOpen).toBe(true);
-  });
-
-  test("calls agent.run() with sessionRole: 'reviewer'", async () => {
-    await session.clarify("What does AC-1 require exactly?");
-    expect(capturedOpts?.sessionRole).toBe("reviewer");
+    expect(capturedOpts?.pipelineStage).toBe("review");
   });
 
   test("prompt contains the clarification question", async () => {
     const question = "What does AC-1 require exactly?";
     await session.clarify(question);
-    expect(capturedOpts?.prompt).toContain(question);
+    expect(capturedPrompt).toContain(question);
   });
 });
 
@@ -593,13 +558,13 @@ describe("ReviewerSession.getVerdict() — SemanticVerdict fields", () => {
 describe("ReviewerSession.getVerdict() — NO_REVIEW_RESULT guard", () => {
   test("throws NaxError when called before any review()", () => {
     const agentManager = makeAgentManager();
-    const session = createReviewerSession(agentManager, "US-002", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agentManager, makeSessionManager(), "US-002", "/work", "my-feature", makeConfig());
     expect(() => session.getVerdict()).toThrow(NaxError);
   });
 
   test("throws NaxError with code 'NO_REVIEW_RESULT' when called before any review()", () => {
     const agentManager = makeAgentManager();
-    const session = createReviewerSession(agentManager, "US-002", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agentManager, makeSessionManager(), "US-002", "/work", "my-feature", makeConfig());
     let caught: unknown;
     try {
       session.getVerdict();
@@ -612,7 +577,7 @@ describe("ReviewerSession.getVerdict() — NO_REVIEW_RESULT guard", () => {
 
   test("does not throw after a successful review()", async () => {
     const agentManager = makeAgentManager();
-    const session = createReviewerSession(agentManager, "US-002", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agentManager, makeSessionManager(), "US-002", "/work", "my-feature", makeConfig());
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(() => session.getVerdict()).not.toThrow();
     await session.destroy();

--- a/test/unit/review/dialogue.test.ts
+++ b/test/unit/review/dialogue.test.ts
@@ -16,15 +16,17 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { ReviewDialogueConfigSchema } from "../../../src/config/schemas";
 import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import { NaxConfigSchema } from "../../../src/config/schemas";
+import type { NaxConfig } from "../../../src/config";
 import type { IAgentManager } from "../../../src/agents/manager-types";
+import type { RunAsSessionOpts } from "../../../src/agents/manager-types";
 import { createReviewerSession } from "../../../src/review/dialogue";
-import type { DialogueMessage, ReviewDialogueResult, ReviewerSession } from "../../../src/review/dialogue";
+import type { ReviewerSession } from "../../../src/review/dialogue";
 import type { ReviewConfig } from "../../../src/review/types";
-import type { AgentRunOptions, AgentResult } from "../../../src/agents/types";
+import type { SessionHandle, TurnResult } from "../../../src/agents/types";
 import type { SemanticReviewConfig } from "../../../src/review/types";
 import type { SemanticStory } from "../../../src/review/semantic";
 import { NaxError } from "../../../src/errors";
-import { makeMockAgentManager } from "../../helpers";
+import { makeMockAgentManager, makeSessionManager } from "../../helpers";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -42,6 +44,8 @@ const STORY: SemanticStory = {
 
 const SEMANTIC_CONFIG: SemanticReviewConfig = {
   modelTier: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
   rules: [],
   timeoutMs: 60_000,
   excludePatterns: [":!test/", ":!*.test.ts"],
@@ -78,31 +82,26 @@ const FAILING_RUN_RESPONSE = JSON.stringify({
   },
 });
 
-type RunFn = (opts: AgentRunOptions) => Promise<AgentResult>;
+type RunAsSessionFnType = (agentName: string, handle: SessionHandle, prompt: string, opts: RunAsSessionOpts) => Promise<TurnResult>;
 
-function makeAgentManager(runFn?: RunFn): IAgentManager {
-  const defaultRunFn = mock(async () => ({
-    success: true,
-    exitCode: 0,
+function makeAgentManager(runAsSessionFn?: RunAsSessionFnType): IAgentManager {
+  const defaultFn: RunAsSessionFnType = async () => ({
     output: PASSING_RUN_RESPONSE,
-    rateLimited: false,
-    durationMs: 10,
-    estimatedCost: 0.001,
-  }));
-  const effectiveRunFn = runFn ?? defaultRunFn;
+    tokenUsage: { inputTokens: 0, outputTokens: 0 },
+    cost: { total: 0.001 },
+    internalRoundTrips: 0,
+  });
+  const effectiveFn = runAsSessionFn ?? defaultFn;
 
   return makeMockAgentManager({
     getDefaultAgent: "claude",
-    runFn: async (_agentName: string, opts: unknown) => {
-      const result = await effectiveRunFn(opts as AgentRunOptions);
-      return { ...result, agentFallbacks: [] };
-    },
+    runAsSessionFn: effectiveFn,
     completeFn: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
   });
 }
 
-function makeConfig() {
-  return NaxConfigSchema.parse({}) as ReturnType<typeof NaxConfigSchema.parse>;
+function makeConfig(): NaxConfig {
+  return NaxConfigSchema.parse({}) as unknown as NaxConfig;
 }
 
 // ---------------------------------------------------------------------------
@@ -286,57 +285,53 @@ describe("ReviewConfig — dialogue field type compatibility", () => {
 describe("createReviewerSession — initial state", () => {
   test("returns a ReviewerSession object", () => {
     const agentManager = makeAgentManager();
-    const session = createReviewerSession(agentManager, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agentManager, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     expect(session).toBeDefined();
   });
 
   test("session.active is true after creation", () => {
     const agentManager = makeAgentManager();
-    const session = createReviewerSession(agentManager, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agentManager, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     expect(session.active).toBe(true);
   });
 
   test("session.history is empty after creation", () => {
     const agentManager = makeAgentManager();
-    const session = createReviewerSession(agentManager, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agentManager, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     expect(session.history.length).toBe(0);
   });
 
   test("session exposes review() method", () => {
     const agentManager = makeAgentManager();
-    const session = createReviewerSession(agentManager, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agentManager, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     expect(typeof session.review).toBe("function");
   });
 
   test("session exposes destroy() method", () => {
     const agentManager = makeAgentManager();
-    const session = createReviewerSession(agentManager, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agentManager, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     expect(typeof session.destroy).toBe("function");
   });
 });
 
 // ---------------------------------------------------------------------------
-// AC5 — review() calls agent.run() with sessionRole='reviewer', keepOpen=true, pipelineStage='review'
+// AC5 — review() calls agentManager.runAsSession() with pipelineStage='review' (ADR-019)
 // ---------------------------------------------------------------------------
 
-describe("ReviewerSession.review() — agent.run() call parameters", () => {
-  let capturedOpts: AgentRunOptions | undefined;
+describe("ReviewerSession.review() — agentManager.runAsSession() call parameters (ADR-019)", () => {
+  let capturedPrompt: string | undefined;
+  let capturedOpts: RunAsSessionOpts | undefined;
   let session: ReviewerSession;
 
   beforeEach(() => {
+    capturedPrompt = undefined;
     capturedOpts = undefined;
-    const runFn: RunFn = async (opts) => {
+    const runAsSessionFn: RunAsSessionFnType = async (_agentName, _handle, prompt, opts) => {
+      capturedPrompt = prompt;
       capturedOpts = opts;
-      return {
-        success: true,
-        exitCode: 0,
-        output: PASSING_RUN_RESPONSE,
-        rateLimited: false,
-        durationMs: 10,
-        estimatedCost: 0.001,
-      };
+      return { output: PASSING_RUN_RESPONSE, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
     };
-    session = createReviewerSession(makeAgentManager(runFn), "US-001", "/work", "my-feature", makeConfig());
+    session = createReviewerSession(makeAgentManager(runAsSessionFn), makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
   });
 
   afterEach(async () => {
@@ -344,50 +339,36 @@ describe("ReviewerSession.review() — agent.run() call parameters", () => {
     mock.restore();
   });
 
-  test("calls agent.run() exactly once per review() call", async () => {
-    const runMock = mock(async (_opts: AgentRunOptions): Promise<AgentResult> => ({
-      success: true,
-      exitCode: 0,
-      output: PASSING_RUN_RESPONSE,
-      rateLimited: false,
-      durationMs: 10,
-      estimatedCost: 0.001,
-    }));
-    const agentManager = makeAgentManager(runMock as RunFn);
-    const s = createReviewerSession(agentManager, "US-001", "/work", "my-feature", makeConfig());
+  test("calls agentManager.runAsSession() exactly once per review() call", async () => {
+    let callCount = 0;
+    const countingFn: RunAsSessionFnType = async () => {
+      callCount++;
+      return { output: PASSING_RUN_RESPONSE, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
+    };
+    const s = createReviewerSession(makeAgentManager(countingFn), makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await s.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
-    expect((runMock as ReturnType<typeof mock>).mock.calls.length).toBe(1);
+    expect(callCount).toBe(1);
     await s.destroy();
   });
 
-  test("passes sessionRole: 'reviewer' to agent.run()", async () => {
-    await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
-    expect(capturedOpts?.sessionRole).toBe("reviewer");
-  });
-
-  test("passes keepOpen: true to agent.run()", async () => {
-    await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
-    expect(capturedOpts?.keepOpen).toBe(true);
-  });
-
-  test("passes pipelineStage: 'review' to agent.run()", async () => {
+  test("passes pipelineStage: 'review' to agentManager.runAsSession()", async () => {
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(capturedOpts?.pipelineStage).toBe("review");
   });
 
-  test("prompt passed to agent.run() contains the diff", async () => {
+  test("prompt passed to agentManager.runAsSession() contains the diff", async () => {
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
-    expect(capturedOpts?.prompt).toContain(SAMPLE_DIFF);
+    expect(capturedPrompt).toContain(SAMPLE_DIFF);
   });
 
-  test("prompt passed to agent.run() contains the story id", async () => {
+  test("prompt passed to agentManager.runAsSession() contains the story id", async () => {
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
-    expect(capturedOpts?.prompt).toContain(STORY.id);
+    expect(capturedPrompt).toContain(STORY.id);
   });
 
-  test("prompt passed to agent.run() contains at least one acceptance criterion", async () => {
+  test("prompt passed to agentManager.runAsSession() contains at least one acceptance criterion", async () => {
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
-    expect(capturedOpts?.prompt).toContain(STORY.acceptanceCriteria[0]);
+    expect(capturedPrompt).toContain(STORY.acceptanceCriteria[0]);
   });
 });
 
@@ -398,7 +379,7 @@ describe("ReviewerSession.review() — agent.run() call parameters", () => {
 describe("ReviewerSession.review() — result parsing", () => {
   test("returns ReviewDialogueResult with checkResult.success === true for passing response", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     const result = await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(result.checkResult.success).toBe(true);
     await session.destroy();
@@ -406,7 +387,7 @@ describe("ReviewerSession.review() — result parsing", () => {
 
   test("returns ReviewDialogueResult with checkResult.findings as array for passing response", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     const result = await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(Array.isArray(result.checkResult.findings)).toBe(true);
     expect(result.checkResult.findings.length).toBe(0);
@@ -415,37 +396,31 @@ describe("ReviewerSession.review() — result parsing", () => {
 
   test("returns ReviewDialogueResult with findingReasoning as Map for passing response", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     const result = await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(result.findingReasoning instanceof Map).toBe(true);
     await session.destroy();
   });
 
   test("parses failing response: checkResult.success === false", async () => {
-    const runFn: RunFn = async () => ({
-      success: true,
-      exitCode: 0,
+    const runAsSessionFn: RunAsSessionFnType = async () => ({
       output: FAILING_RUN_RESPONSE,
-      rateLimited: false,
-      durationMs: 10,
-      estimatedCost: 0.001,
+      tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      internalRoundTrips: 0,
     });
-    const session = createReviewerSession(makeAgentManager(runFn), "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(makeAgentManager(runAsSessionFn), makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     const result = await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(result.checkResult.success).toBe(false);
     await session.destroy();
   });
 
   test("parses failing response: checkResult.findings contains expected finding", async () => {
-    const runFn: RunFn = async () => ({
-      success: true,
-      exitCode: 0,
+    const runAsSessionFn: RunAsSessionFnType = async () => ({
       output: FAILING_RUN_RESPONSE,
-      rateLimited: false,
-      durationMs: 10,
-      estimatedCost: 0.001,
+      tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      internalRoundTrips: 0,
     });
-    const session = createReviewerSession(makeAgentManager(runFn), "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(makeAgentManager(runAsSessionFn), makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     const result = await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(result.checkResult.findings.length).toBe(1);
     expect(result.checkResult.findings[0]?.ruleId).toBe("missing-ac-coverage");
@@ -453,15 +428,12 @@ describe("ReviewerSession.review() — result parsing", () => {
   });
 
   test("parses failing response: findingReasoning Map contains entry for finding id", async () => {
-    const runFn: RunFn = async () => ({
-      success: true,
-      exitCode: 0,
+    const runAsSessionFn: RunAsSessionFnType = async () => ({
       output: FAILING_RUN_RESPONSE,
-      rateLimited: false,
-      durationMs: 10,
-      estimatedCost: 0.001,
+      tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      internalRoundTrips: 0,
     });
-    const session = createReviewerSession(makeAgentManager(runFn), "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(makeAgentManager(runAsSessionFn), makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     const result = await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(result.findingReasoning.has("missing-ac-coverage")).toBe(true);
     expect(result.findingReasoning.get("missing-ac-coverage")).toContain("acceptance criteria");
@@ -469,15 +441,12 @@ describe("ReviewerSession.review() — result parsing", () => {
   });
 
   test("findingReasoning Map size matches number of reasoning entries in response", async () => {
-    const runFn: RunFn = async () => ({
-      success: true,
-      exitCode: 0,
+    const runAsSessionFn: RunAsSessionFnType = async () => ({
       output: FAILING_RUN_RESPONSE,
-      rateLimited: false,
-      durationMs: 10,
-      estimatedCost: 0.001,
+      tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      internalRoundTrips: 0,
     });
-    const session = createReviewerSession(makeAgentManager(runFn), "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(makeAgentManager(runAsSessionFn), makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     const result = await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(result.findingReasoning.size).toBe(1);
     await session.destroy();
@@ -491,7 +460,7 @@ describe("ReviewerSession.review() — result parsing", () => {
 describe("ReviewerSession.review() — history entries", () => {
   test("appends exactly two entries to history per review() call", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(session.history.length).toBe(2);
     await session.destroy();
@@ -499,7 +468,7 @@ describe("ReviewerSession.review() — history entries", () => {
 
   test("first history entry has role 'implementer'", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(session.history[0]?.role).toBe("implementer");
     await session.destroy();
@@ -507,7 +476,7 @@ describe("ReviewerSession.review() — history entries", () => {
 
   test("second history entry has role 'reviewer'", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(session.history[1]?.role).toBe("reviewer");
     await session.destroy();
@@ -515,7 +484,7 @@ describe("ReviewerSession.review() — history entries", () => {
 
   test("implementer history entry content contains the diff", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(session.history[0]?.content).toContain(SAMPLE_DIFF);
     await session.destroy();
@@ -523,7 +492,7 @@ describe("ReviewerSession.review() — history entries", () => {
 
   test("reviewer history entry content contains the agent response", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(session.history[1]?.content).toBeTruthy();
     await session.destroy();
@@ -531,7 +500,7 @@ describe("ReviewerSession.review() — history entries", () => {
 
   test("second review() call appends two more entries (total 4)", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(session.history.length).toBe(4);
@@ -540,7 +509,7 @@ describe("ReviewerSession.review() — history entries", () => {
 
   test("history entries are DialogueMessage shaped (role + content)", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     for (const msg of session.history) {
       expect(typeof msg.role).toBe("string");
@@ -557,14 +526,14 @@ describe("ReviewerSession.review() — history entries", () => {
 describe("ReviewerSession.destroy() — deactivation and guard", () => {
   test("destroy() sets session.active to false", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.destroy();
     expect(session.active).toBe(false);
   });
 
   test("destroy() clears history to empty array", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(session.history.length).toBe(2);
     await session.destroy();
@@ -573,14 +542,14 @@ describe("ReviewerSession.destroy() — deactivation and guard", () => {
 
   test("review() after destroy() throws NaxError", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.destroy();
     await expect(session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG)).rejects.toBeInstanceOf(NaxError);
   });
 
   test("review() after destroy() throws NaxError with code REVIEWER_SESSION_DESTROYED", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.destroy();
     let caught: unknown;
     try {
@@ -594,8 +563,56 @@ describe("ReviewerSession.destroy() — deactivation and guard", () => {
 
   test("destroy() is idempotent — calling twice does not throw", async () => {
     const agent = makeAgentManager();
-    const session = createReviewerSession(agent, "US-001", "/work", "my-feature", makeConfig());
+    const session = createReviewerSession(agent, makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     await session.destroy();
     await expect(session.destroy()).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADR-019 — caller-managed session lifecycle via ISessionManager
+// ---------------------------------------------------------------------------
+
+describe("ReviewerSession — ADR-019 caller-managed session lifecycle", () => {
+  test("openSession is called once on first review() call", async () => {
+    let openCount = 0;
+    const sm = makeSessionManager({
+      openSession: async (name) => {
+        openCount++;
+        return { id: name, agentName: "claude" };
+      },
+    });
+    const session = createReviewerSession(makeAgentManager(), sm, "US-001", "/work", "my-feature", makeConfig());
+    await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
+    expect(openCount).toBe(1);
+    await session.destroy();
+  });
+
+  test("openSession is called only once across multiple review() calls (handle reused)", async () => {
+    let openCount = 0;
+    const sm = makeSessionManager({
+      openSession: async (name) => {
+        openCount++;
+        return { id: name, agentName: "claude" };
+      },
+    });
+    const session = createReviewerSession(makeAgentManager(), sm, "US-001", "/work", "my-feature", makeConfig());
+    await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
+    await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
+    expect(openCount).toBe(1);
+    await session.destroy();
+  });
+
+  test("closeSession is called on destroy()", async () => {
+    let closedCount = 0;
+    const sm = makeSessionManager({
+      closeSession: async () => {
+        closedCount++;
+      },
+    });
+    const session = createReviewerSession(makeAgentManager(), sm, "US-001", "/work", "my-feature", makeConfig());
+    await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
+    await session.destroy();
+    expect(closedCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- Migrates all `keepOpen: true` + `sessionHandle: string` patterns in `src/review/dialogue.ts` and debate session files to the ADR-019 caller-managed session pattern (`sessionManager.openSession` → `agentManager.runAsSession` × N → `sessionManager.closeSession`)
- Introduces lazy handle pattern in `ReviewerSession`: `_handle` opened on first call via `getOrOpenHandle`, reused across turns, closed and nulled after compaction or on `destroy()`
- Compaction now closes the active session handle and sets `pendingCompactionContext` so the next `getOrOpenHandle` opens a fresh session with the summarised context prepended
- Threads `ISessionManager` through `DebateSession`, `session-stateful`, `session-hybrid`, and `session-plan` as required
- Updates all affected test files to use `RunAsSessionFnType`/`TurnResult` instead of `RunFn`/`AgentResult`, and wires `makeSessionManager()` into every `createReviewerSession` call and pipeline-stage `makeCtx` factory

## Files changed (14)

**Source (6):**
- `src/review/dialogue.ts` — core Phase D migration; new `getOrOpenHandle`, `buildEffectivePrompt`, `destroy()` lifecycle
- `src/debate/session-stateful.ts` — `runAsSession` migration
- `src/debate/session-hybrid.ts` — `runRebuttalLoop`/`resolveRebuttal` migration
- `src/debate/session-plan.ts` — `sessionManager` threading
- `src/debate/session-helpers.ts` — `SuccessfulProposal` gets `handle` field
- `src/pipeline/stages/review.ts` — guard + `sessionManager` arg wired

**Tests (8):**
- `test/unit/review/dialogue.test.ts`
- `test/unit/review/dialogue-debate.test.ts`
- `test/unit/review/dialogue-re-review.test.ts`
- `test/unit/debate/session-stateful.test.ts`
- `test/unit/debate/session-hybrid.test.ts`
- `test/unit/debate/session-hybrid-rebuttal.test.ts`
- `test/unit/pipeline/stages/review-dialogue.test.ts`
- `test/unit/pipeline/stages/review-debate-dialogue.test.ts`

## Test plan

- [x] `bun run test` — 6809 unit + 1220 integration + 13 UI tests, 0 failures
- [x] Pre-commit hook (typecheck + biome lint) passes on all commits
- [x] Targeted suite `test/unit/review/` — 402/402 pass