### PR TITLE
docs: findings on adversarial review, rectification, and implementer prompt gaps

### DIFF
--- a/docs/findings/2026-04-27-implementer-prompt-bloat-and-burial.md
+++ b/docs/findings/2026-04-27-implementer-prompt-bloat-and-burial.md
@@ -1,0 +1,417 @@
+# Gap 3: Implementer prompt buries the story under rules bloat
+
+**Date:** 2026-04-27
+**Project under test:** [koda](https://github.com/nathapp-io/koda) — feature branch `feat/memory-phase4-graph-code-intelligence`
+**Run date:** 2026-04-26 13:48:36 UTC
+**Affected stories:** US-000, US-001, US-006 (likely all stories — pattern is structural)
+**Source spec:** [SPEC-004 (koda repo)](https://github.com/nathapp-io/koda/blob/feat/memory-phase4-graph-code-intelligence/docs/specs/SPEC-004-memory-phase4-graph-code-intelligence.md) — also linked at section level below
+**Status:** Planned — Framing A locked; B follow-up gated on A telemetry; C deferred
+**Related:** [2026-04-27-implementer-review-rectification-gaps.md](./2026-04-27-implementer-review-rectification-gaps.md) (Gaps 1+2 — post-implementation rectification flow). Gap 3 is independent: it affects the **implementer prompt at story start**, not rectification.
+
+> **Evidence sources:** Findings cite (a) locally-captured nax audit logs (`logs/prompt-audit/`, gitignored — load-bearing excerpts inlined as code blocks) and (b) the public [koda repo](https://github.com/nathapp-io/koda) on the `feat/memory-phase4-graph-code-intelligence` branch. All koda links resolve on GitHub.
+
+---
+
+## Symptom
+
+The implementer prompt at story start is dominated by generic rules/conventions, with the actual story description buried in the middle. Three concrete prompts confirm the pattern:
+
+| Prompt (timestamp, story, strategy) | Total lines | Rules + constitution | Story context | Ratio |
+|:---|:---|:---|:---|:---|
+| 13:54 — US-000 implementer-run-t01 (`tdd-simple`) | ~330 | ~270 | ~20 | 93% / 6% |
+| 13:59 — US-006 implementer-run-t01 (`tdd-simple`) | ~343 | ~280 | ~20 | **93% / 6%** |
+| 15:04 — US-001 implementer-run-t01 (`three-session-tdd-lite`) | ~415 | ~330 | ~25 | **89% / 6%** |
+
+In all three, the story description and acceptance criteria — the actual goal — are ~6% of the prompt and sit at position 5 of 8 sections, after ~300 lines of generic guidance.
+
+**US-001 prompt structure** (verbatim section ordering captured from the local prompt audit):
+
+```
+Position  Section                                          Lines
+1         CONSTITUTION (nax + Koda — wrapped in            64
+            <!-- USER-SUPPLIED DATA --> tags)
+2         Role: Implementer (Lite)                         14
+3         Project Context — api.md + common.md +           250
+            project-conventions.md (full content with
+            ### file headers + ## section headers)
+4         Prior Stage Summary + Session History            15
+5         Story Context (title + description + 11 ACs,     25
+            wrapped in <!-- USER-SUPPLIED DATA --> tags)
+6         Isolation Rules                                  5
+7         Hermetic Test Requirement                        3
+8         Conventions + Security                           12
+                                                          ───
+                                                          ~415
+```
+
+---
+
+## Five sub-issues, all interrelated
+
+### (a) `contextFiles` in prd.json is dead data
+
+The schema default for `config.context.fileInjection` is `"disabled"` ([schemas.ts:638](../../src/config/schemas.ts#L638)). The injection logic in [builder.ts:213-215](../../src/context/builder.ts#L213-L215) bails when the value isn't `"keyword"`. The koda project's [.nax/config.json](https://github.com/nathapp-io/koda/blob/feat/memory-phase4-graph-code-intelligence/.nax/config.json) confirms `fileInjection: "disabled"`.
+
+**Result:** explicit `contextFiles` in prd.json — author intent telling the agent "these are the existing files you'll modify" — never appear in the prompt.
+
+Concrete examples from [memory-phase4 prd.json](https://github.com/nathapp-io/koda/blob/feat/memory-phase4-graph-code-intelligence/.nax/features/memory-phase4-graph-code-intelligence/prd.json):
+
+| Story | `contextFiles` in prd.json | Appears in prompt? |
+|:---|:---|:---|
+| US-000 | `apps/api/prisma/schema.prisma` | ❌ No |
+| US-001 | `apps/api/src/rag/rag.controller.ts`, `rag.service.ts`, `import-graphify.dto.ts`, `schema.prisma`, `outbox-fan-out-registry.ts` | ❌ No |
+| US-002 | (5 files) | ❌ No |
+| US-006 | **(none — field absent)** | n/a |
+
+US-001 specifies 5 highly relevant files; the agent gets none of them and has to grep-discover the existing rag controller from scratch. US-006 has no `contextFiles` at all, compounding the problem.
+
+### (b) Story is in the worst attention position
+
+Current section order (US-001 implementer-run):
+
+| Position | Section | Lines (approx) |
+|:---|:---|:---|
+| 1 | Constitution (nax + Koda) | 64 |
+| 2 | Role description | 14 |
+| 3 | Project rules dump (api.md + common.md + project-conventions.md) | 250 |
+| 4 | Prior stage summary + session history | 15 |
+| **5** | **Story context (title, description, ACs)** | **25** |
+| 6 | Isolation rules | 5 |
+| 7 | Hermetic test requirement | 3 |
+| 8 | Conventions + security | 12 |
+
+Primacy/recency research is unambiguous: information at the start and end of long context is better attended to than information in the middle. The story is in the **worst possible position** — buried under the largest section, ~330 lines from the top, ~80 lines from the bottom.
+
+### (c) Rule bloat is generic, not story-relevant
+
+Current behavior: the entire `.nax/rules/<app>.md` for the story's app gets injected verbatim. For US-001 (Incremental Graph Diff — Prisma + role enforcement + RAG):
+
+| Rule section | Lines | Relevance to US-001 |
+|:---|:---|:---|
+| Auth / role enforcement | ~10 | ✅ Relevant (AC 10) |
+| Prisma patterns | ~15 | ✅ Relevant (Prisma reads/writes) |
+| Soft-delete | ~5 | ✅ Relevant (Project model) |
+| Pagination anti-patterns | **28** | ❌ Irrelevant (no pagination in this story) |
+| i18n separation | ~15 | ❌ Irrelevant (no UI strings) |
+| OpenAPI generation flow | ~10 | ❌ Irrelevant (no contract change) |
+| Testing anti-patterns (Jest DI cleanup) | **16** | ⚠️ Only relevant when writing Jest tests |
+| Web app context files | ~5 | ❌ Irrelevant (api-only story) |
+
+About **50% of the api.md content is generic anti-pattern guidance** that has nothing to do with this specific story but is injected anyway. Other rule files (`.nax/rules/`) total 353 lines across 5 files; even after per-app filtering, only sections matching the story tags are useful.
+
+### (d) Rendering bug: tdd-simple loses section headers
+
+Comparison of how api.md content appears across roles:
+
+| Role | api.md rendering |
+|:---|:---|
+| Implementer (Lite) (three-session-tdd-lite, US-001) | Full content with `### api.md` header and `## Section` subheadings preserved |
+| TDD-Simple (US-006) | Bullet content appears (lines 93-152) **without** the `### api.md` header or parent `## Section` headings |
+
+The bullets are recognizable as `## Implementation Anti-Patterns`, `## Pagination Anti-Patterns`, `## Testing Anti-Patterns` from api.md, but the headers are missing. The agent sees a flat bullet list with no hierarchical context. This is orthogonal to the design issues but worth fixing in whatever PR touches the rendering path.
+
+### (e) Planner drops spec design content; ACs alone are insufficient
+
+This is the largest single contributor to "story context vague" — sharper than the earlier "description quality" framing. The spec author writes a rich design subsection per story (interfaces, algorithms, motivation); the planner collapses each into a one-sentence summary.
+
+#### Spec vs PRD comparison
+
+The source spec is [SPEC-004 in the koda repo](https://github.com/nathapp-io/koda/blob/feat/memory-phase4-graph-code-intelligence/docs/specs/SPEC-004-memory-phase4-graph-code-intelligence.md). Its §1 (Incremental Graph Diff) ships:
+
+```typescript
+// Verbatim excerpt from SPEC-004 §1
+class IncrementalGraphDiffService {
+  constructor(
+    private graphStore: GraphStoreService,
+    private rag: RagService,
+  ) {}
+
+  async diffAndApply(
+    projectId: string,
+    newNodes: GraphifyNodeDto[],
+    newLinks: GraphifyLinkDto[],
+  ): Promise<DiffResult>
+
+  async getStoredGraph(projectId: string): Promise<StoredGraph>
+}
+
+interface StoredGraph {
+  nodeMap: Map<string, GraphifyNodeDto>;
+  linkMap: Map<string, GraphifyLinkDto[]>;
+}
+
+interface DiffResult {
+  added: number;
+  updated: number;
+  removed: number;
+  indexed: number;
+  durationMs: number;
+}
+```
+
+Plus a problem statement (`importGraphify()` does `deleteAllBySourceType('code')` then re-indexes all — O(n) memory load), a 5-step diff algorithm, and a content-regeneration policy ("only regenerate adjacency text when label/type/source_file/links changed").
+
+What landed in [prd.json US-001](https://github.com/nathapp-io/koda/blob/feat/memory-phase4-graph-code-intelligence/.nax/features/memory-phase4-graph-code-intelligence/prd.json):
+
+```json
+{
+  "id": "US-001",
+  "title": "Incremental Graph Diff — Replace Full Re-Import",
+  "description": "Replace full graphify re-import with incremental diff-and-apply against durable graph tables, while preserving existing import API behavior and project isolation.",
+  "acceptanceCriteria": [ ... 11 ACs ... ]
+}
+```
+
+One-sentence description. Class signature, interfaces, algorithm, motivation — all dropped. US-006 has the same pattern: SPEC-004 §6 ships full `CanonicalStateService` interface + `CanonicalSnapshotQuery` + `CanonicalSnapshot` schema; PRD description is one sentence.
+
+#### Why the planner drops design content
+
+Two contributing causes, both fixable in the same PR:
+
+**1. Initial planner prompt has zero description guidance.**
+
+In [plan-builder.ts:153](../../src/prompts/builders/plan-builder.ts#L153):
+
+```typescript
+"description": "string — detailed description of the story",
+```
+
+Compare with the ~30 lines of `AC_QUALITY_RULES` + bad/good examples + format templates ([test-strategy.ts:93-128](../../src/config/test-strategy.ts#L93-L128)). LLMs default to summarization when given no other guidance — and that's exactly what they do for descriptions.
+
+**2. Debate synthesis prompt anchors ACs but not descriptions.**
+
+When debate is enabled, the synthesis resolver merges debater outputs using rules in [runner-plan.ts:224-225](../../src/debate/runner-plan.ts#L224-L225):
+
+```
+## Synthesis Rules — Acceptance Criteria
+The spec above is the authoritative source for acceptance criteria.
+- Each story's acceptanceCriteria array MUST contain only criteria
+  explicitly stated or directly implied by the spec.
+- Preserve the spec's AC wording. ...
+```
+
+**Spec-anchor for ACs only.** Descriptions and design content have no anchor → resolver picks the lowest-common-denominator restatement from the debaters' proposals. Debate doesn't *cause* the gap (single-agent path has it too), but it slightly amplifies it via the convergence dynamic.
+
+This explains the asymmetry observed in PRD output:
+- ACs: 10 in spec → 11 in PRD (preserved + 1 inferred). Spec-anchor working.
+- Design sections: 30+ lines in spec → 1 sentence in PRD. No anchor → collapsed.
+
+#### Are ACs doing the heavy lifting?
+
+**For "what to test", yes. For "what to implement", partially.**
+
+US-001's 11 ACs comprehensively cover behavior:
+
+- Class methods (#1, #6 — `diffAndApply`, `importGraphify`)
+- Data sources (#2 — Prisma not LanceDB)
+- Input/output behavior (#3, #4, #5 — exact counts, deletion semantics, skip-unchanged)
+- Performance bounds (#8 — under 2s for 510 nodes)
+- Return shape (#7, #9 — `indexed`, `durationMs`)
+- Authorization (#10), project scoping (#11)
+
+What ACs DON'T carry that the spec design provides:
+
+| Spec content | In ACs? | Implementer impact if missing |
+|:---|:---|:---|
+| Class signature: `IncrementalGraphDiffService(graphStore, rag)` | ❌ Implied | Implementer invents constructor — may pick wrong dependencies |
+| Interface shapes: `StoredGraph`, `DiffResult` | ⚠️ Partial | Implementer reverse-engineers full type from ACs |
+| 5-step diff algorithm | ❌ Behaviorally implied | Implementer re-derives; may pick less efficient ordering |
+| Equality semantics ("changed when label/type/source_file/links changed") | ⚠️ AC #5 says "skip unchanged" but doesn't define "changed" | Implementer picks own equality; may diverge from spec author intent |
+| Motivation ("full re-import unscalable, O(n) memory load") | ❌ Absent | No "why" → judgment calls during implementation lack anchor |
+
+US-006 is starker: the spec ships the full `CanonicalSnapshot` interface (tickets/recentEvents/activeDecisions arrays with their own fields). The 6 ACs verify pieces (`retrievedAt`, filtered `tickets[]`) but never declare the overall return shape. The implementer must assemble the type from 6 separate ACs.
+
+**Conclusion:** ACs are necessary but not sufficient. The spec's design sections carry implementation-level structure (signatures, interfaces, algorithms) and motivation. Today both are dropped.
+
+---
+
+## Three possible framings
+
+### Framing A — Minimal: fix what's broken
+
+Four small changes:
+
+1. **Honor `contextFiles` always, path-only.** Treat explicit `contextFiles` in prd.json as separate from auto-detection — always inject the listed paths regardless of `fileInjection` mode. Standardize on path-only output (drop the current `<10KB inline / >10KB path-only` policy from [builder.ts:210-292](../../src/context/builder.ts#L210-L292)). The agent uses Read on demand; eager inlining is just pre-fetching that wastes tokens, becomes stale once the agent edits the file, and bloats prompts replayed every turn. Keyword auto-detection remains gated by `fileInjection: "keyword"`.
+
+2. **Reorder the prompt.** Move `Story Context` to position 1 (right after a 1-line role description). Rules and constitution follow. Restate goal at the bottom (sandwich pattern — ~25 extra lines for both primacy and recency benefit).
+
+3. **Fix the rendering bug.** Ensure `### api.md` and parent section headers are preserved in tdd-simple's prompt rendering, matching three-session-tdd-lite's output.
+
+4. **Description quality rules — two-place fix.** Carry spec design content into PRD descriptions:
+
+   - **Initial planner prompt** ([plan-builder.ts](../../src/prompts/builders/plan-builder.ts)): add `DESCRIPTION_QUALITY_RULES` constant similar to existing `AC_QUALITY_RULES`. Format guidance + one strong bad/good example showing verbatim spec-section embedding.
+   - **Synthesis prompt** ([runner-plan.ts:224-225](../../src/debate/runner-plan.ts#L224-L225)): extend the existing spec-anchor block to cover descriptions (parallel to the existing AC anchor). Without this, debate synthesis still drops design content even after the initial-prompt fix lands.
+
+   Rule wording (draft):
+
+   ```
+   When the spec contains a design subsection corresponding to this story
+   (e.g. `### N. <Topic>` under `## Design`), the description MUST include
+   that subsection's interface declarations, algorithms, and design notes
+   verbatim. Do not paraphrase. Format:
+
+   **Goal** — 1 sentence: what this story changes
+   **Motivation** — 1 sentence from spec's Motivation section: why this matters
+   **Approach** — verbatim from spec's design subsection
+   **Scope** — In: ... Out: ...
+   **Interface** — verbatim TypeScript signatures from the spec
+   ```
+
+**Scope:** ~265 LOC total across:
+- `src/context/builder.ts` (path-only contextFiles, ~80 LOC removed/changed)
+- Prompt assembly path (reorder + rendering bug fix, ~80 LOC)
+- `src/config/test-strategy.ts` (`DESCRIPTION_QUALITY_RULES` constant + example, ~50 LOC)
+- `src/prompts/builders/plan-builder.ts` (inject the new rules, ~10 LOC)
+- `src/debate/runner-plan.ts` (extend synthesis spec-anchor, ~20 LOC)
+- Tests + snapshots (~50 LOC)
+
+**Risk:** Low — fixes are localized; description quality may need a follow-up if the LLM still paraphrases despite strong examples (escalation path: mechanical spec-section extractor as PR (b), ~150 extra LOC).
+
+**Doesn't address:** rule bloat (still 250+ lines of generic guidance per prompt). That's deferred to Framing B.
+
+### Framing B — Medium: A + per-section relevance filtering, plus vocabulary plumbing
+
+Everything in A, plus three coupled changes — **all required for B to actually work**:
+
+1. **Section-level tagging in rules files.** Each `## Section` in `.nax/rules/*.md` gets an optional HTML comment after the heading: `<!-- nax-tags: [auth, security] -->`. Untagged sections inject by default (backward-compatible).
+
+2. **Vocabulary extraction at plan time.** A new `extractRuleTagVocabulary(naxDir)` step scans `.nax/rules/*.md`, collects the union of `nax-tags`, returns the canonical set. **Rule-derived, not pre-declared** — the vocabulary is whatever the rule authors put in their files.
+
+3. **Vocabulary surfaced to planner.** When `nax plan` or `nax run --plan` invokes the planner LLM, the prompt includes the vocabulary as the controlled tag list:
+
+   ```
+   ## Allowed Story Tags
+
+   Tag each story with one or more of these concerns:
+     auth, security, prisma, pagination, i18n, openapi, testing, ...
+
+   Pick tags describing what coding concerns the story raises.
+   Feature-area tags (e.g. "memory", "graph") may also appear in tags[]
+   but rule matching uses the controlled list above.
+   ```
+
+   `prd.json` schema treats unknown tags as a warning (not error) for backward compatibility — existing prd.json files don't break.
+
+**Why this is required:** today's prd.json story tags are feature-area descriptors (`["feature", "api", "graph", "rag"]`); rule sections would be tagged with concern descriptors (`auth`, `prisma`, `pagination`). The intersection is empty without a unified vocabulary. Shipping B without closing this gap means rule matching falls back to inject-everything (no benefit) or matches nothing (worse).
+
+**Monorepo handling:** existing infrastructure already filters rules by package via file-level `paths:` frontmatter ([static-rules.ts:188-213](../../src/context/engine/providers/static-rules.ts#L188-L213)) and overlays per-package rules from `.nax/mono/<pkg>/`. Section-level filtering layers on top without modification — sections inherit their parent file's `paths:` scope automatically. Vocabulary stays **global** (single union across all rule files); per-package vocabularies would force planner context-switching per story without measurable benefit.
+
+**Scope:** ~325 LOC + content migration (~5 rule files tagged with section frontmatter):
+
+| Sub-task | LOC |
+|:---|:---|
+| Section frontmatter parser (HTML comment after `##` headings) | ~60 |
+| Vocabulary extractor | ~30 |
+| Planner prompt vocabulary injection | ~20 |
+| prd.json schema unknown-tag warning | ~15 |
+| Rule-section filter on injection | ~50 |
+| Tests + snapshots | ~150 |
+
+**Effect on US-001:** rules drop from ~250 lines to ~80 lines per prompt.
+
+**Risk:** Medium — introduces a tagging convention; needs documented format. Tagging discipline becomes a maintenance concern (someone has to keep rule tags accurate as rules evolve).
+
+### Framing C — Structural: on-demand rules via tools
+
+Eagerly inject only:
+- 1-line role description
+- Story context + acceptance criteria + `contextFiles` paths
+- Always-on safety rules (5–10 lines: no remote push, no exfiltration, etc.)
+- **Rule index** (the same vocabulary extracted in B, rendered as "for `auth` concerns, see api.md#Auth; for `prisma`, see api.md#Prisma; …")
+
+Everything else (`.nax/rules/`, constitution, conventions) becomes a tool the agent can grep/read on demand.
+
+**Scope:** ~800 LOC, UX shift across all agent roles (not just implementer). **Builds on B's vocabulary work** — the rule index is the same tag→section mapping B uses for filtering, just rendered differently.
+
+**Risk:** High — agents may not consult rules without explicit prompting; rule violations may go up before they go down. The "agent fetches rules on demand" failure mode is real and unmeasured.
+
+**Pays off when:** rule library grows past 500+ lines per app, or when stories vary widely in rule relevance.
+
+#### B vs C — why B first
+
+| Concern | B (eager filtered) | C (on-demand index) |
+|:---|:---|:---|
+| Prompt size after fix | ~80 lines of rules | ~10 lines (index only) |
+| Agent might skip consulting rules | Won't happen — rules are visible | Real risk, hard to detect in audit logs |
+| Validation in audit logs | Easy — see exactly which sections shipped | Hard — see only that the agent had the option |
+| Reusability of vocabulary work | High — same tags drive C later | High — built on B's foundation |
+| Risk if model behavior is wrong | Easy rollback (flip filter to inject-all) | Hard rollback (re-train/re-prompt the agent) |
+
+**B is a stepping stone to C, not a competitor.** The vocabulary plumbing in B is 80% of C's work. Doing B first lets us measure whether eager-filtered rules are sufficient before committing to the larger UX shift. If they are, C is unnecessary. If they aren't, C is one config flip away (`rules.injectMode: "filter" | "index"`).
+
+---
+
+## Recommendation
+
+**Land Framing A first** as a single coherent PR (or 2-3 small PRs). Measure on the next real feature run, then decide on B based on data.
+
+A's success criteria (measurable in audit logs):
+- `contextFiles` count actually appearing in the prompt > 0 for stories that declare them
+- Story Context appears in position 1, not position 5
+- PRD descriptions for SPEC-004-style stories include verbatim interface declarations from the spec
+- US-001's implementer reads fewer files via Read tool (because they're listed up front)
+
+If after A:
+- Rules are still the dominant prompt bloat (likely yes, ~70% rules-to-story even after A) → land **B**
+- Rule volume grows past ~500 lines per app or stories vary widely in rule relevance → flip B to **C** using the same vocabulary
+
+---
+
+## Resolved design decisions
+
+1. **`contextFiles` honoring policy.** ✅ Honor always, separate from `fileInjection` mode. Author intent (explicit list in prd.json) is a stronger signal than keyword scanning. `fileInjection: "keyword"` continues to gate only auto-detection.
+
+2. **Inline vs path-only.** ✅ Standardize on **path-only** with optional author-supplied annotations (e.g. `contextFilesAnnotations: { "path": "purpose" }` in prd.json). Drop the current `<10KB inline / >10KB path-only` policy entirely. Rationale: same disease as Gap 3 itself (prompt bloat); inlined files become stale on first edit; agent has Read for on-demand fetch.
+
+3. **Story-first reordering — sandwich, not full reorder.** ✅ Story (top) → rules/constitution → Story restated (bottom). ~25 extra lines per prompt; doubles the agent's "what's the goal" signal via primacy AND recency. Worth the cost.
+
+4. **`contextFiles` size budget.** ✅ Path-only output makes this moot — paths are ~50 bytes each, no content cap needed. Keep the existing `MAX_FILES = 5` cap as a sanity guard against runaway prd.json content.
+
+5. **Rendering bug fix scope.** Pending root-cause investigation in implementation. Suspect: tdd-simple's role template path drops a header rendering call. Easy to confirm by diffing the rendered output of both roles against the same input. ~30 LOC fix once root-caused.
+
+6. **Should US-006's prd.json get `contextFiles`?** ✅ Yes, but that's a content fix in the user's project — not nax's responsibility. Flag as a usage hint in `nax plan` output: "Story US-006 has no contextFiles. Consider adding 2-5 to anchor the implementer faster."
+
+7. **Description quality fix path.** ✅ Path (a) — prompt-only rules in **both** the initial planner prompt and the synthesis prompt. Strong concrete bad/good example carries most of the weight. Path (b) — mechanical spec-section extractor — held as a follow-up if (a) doesn't stick.
+
+8. **Tag vocabulary scope (for Framing B).** ✅ Single global tag list (rule-derived). Per-package vocabulary would force planner context-switching per story without measurable benefit. Existing path-frontmatter on rule files already handles "this rule only applies in apps/api".
+
+9. **Vocabulary source of truth (for Framing B).** ✅ Rule-derived (extracted from `.nax/rules/*.md` section frontmatter at plan-time). Pre-declared `tag-vocabulary.yaml` rejected — rules are the consumer, so deriving from them keeps the system self-consistent.
+
+---
+
+## Files to investigate before implementation
+
+| File | Why |
+|:---|:---|
+| [`src/context/builder.ts`](../../src/context/builder.ts) | Owns the `fileInjection` gate (lines 213-215) and the `<10KB inline` policy (lines 210, 280-292). Needs split between explicit-contextFiles (always honor, path-only) and auto-detection (`fileInjection: "keyword"`). |
+| Prompt assembly for implementer role | Owns section ordering. Identify it across `tdd-simple` / `three-session-tdd` / `three-session-tdd-lite` paths — root-cause the rendering-bug delta in (d) here. |
+| [`src/prompts/sections/role-task.ts`](../../src/prompts/sections/role-task.ts) | Role description rendering — possibly where the missing-header bug originates. |
+| [`src/prompts/builders/plan-builder.ts:153`](../../src/prompts/builders/plan-builder.ts#L153) | Description field guidance lives here — needs `DESCRIPTION_QUALITY_RULES` injection. |
+| [`src/debate/runner-plan.ts:224-225`](../../src/debate/runner-plan.ts#L224-L225) | Synthesis spec-anchor block — extend to cover descriptions in addition to ACs. |
+| [`src/config/test-strategy.ts`](../../src/config/test-strategy.ts) | Where `AC_QUALITY_RULES` lives. Add `DESCRIPTION_QUALITY_RULES` here for symmetry. |
+| `.nax/rules/*.md` parser | If we go to B, need section-tag parser. Today's [canonical-loader.ts](../../src/context/rules/canonical-loader.ts) parses file-level frontmatter only. |
+
+---
+
+## Execution status
+
+- [x] Spec finalized
+- [x] Framing chosen (A first, B follow-up gated on A telemetry, C deferred)
+- [x] Open questions resolved (9/9)
+- [ ] PR(s) drafted
+
+### PR sequencing
+
+| PR | Scope | LOC | Standalone? |
+|:---|:---|:---|:---|
+| 1 | Honor `contextFiles` always, path-only, with annotations support | ~80 | Yes |
+| 2 | Sandwich-pattern prompt reorder | ~50 | Yes |
+| 3 | Fix tdd-simple header rendering bug | ~30 | Yes (after root-cause) |
+| 4 | Description quality rules — planner prompt + synthesis prompt | ~115 | Yes (orthogonal to 1-3) |
+| **A total** | | **~275 LOC** | |
+| 5 (gated on A telemetry) | Section-tag vocabulary + planner prompt + filtering (Framing B) | ~325 + content migration | After A measurement |
+| 6 (gated on B telemetry) | On-demand rule index (Framing C) | ~800 | After B measurement |
+
+PRs 1-4 can land in parallel — they touch independent files. PR 4 specifically depends on `AC_QUALITY_RULES`'s style as a pattern but has no code dependency on the others.
+
+Execution deferred until PR drafting begins.

--- a/docs/findings/2026-04-27-implementer-review-rectification-gaps.md
+++ b/docs/findings/2026-04-27-implementer-review-rectification-gaps.md
@@ -1,0 +1,463 @@
+# Gaps: Implementer ↔ Rectification ↔ Semantic + Adversarial Review
+
+**Date:** 2026-04-27
+**Project under test:** [koda](https://github.com/nathapp-io/koda) — feature branch `feat/memory-phase4-graph-code-intelligence`
+**Run date:** 2026-04-26 13:48:36 UTC
+**Affected stories:** US-001, US-006
+**Status:** Planned — pending sign-off; execution deferred
+
+Two independent gaps observed in the same nax run on koda. Each section below is self-contained and has a phased PR plan. Implementations should be separate PRs in the order listed at the end of the doc.
+
+> **Evidence sources:** Findings cite locally-captured nax audit logs (`logs/prompt-audit/`, `logs/review-audit/`, gitignored). Load-bearing excerpts are inlined as code blocks below so claims are verifiable without local log access.
+
+---
+
+## Gap 1 — Adversarial review keeps moving the goalposts
+
+### Symptom
+
+For US-006, the adversarial reviewer ran 5+ rounds. Each round surfaced a *different* set of "blocking" findings. The implementer fixed the previous round's findings, but had no way to tell whether the next round's NEW findings were:
+
+1. Genuine regressions introduced by the fix
+2. Issues the reviewer could have raised the first time but didn't
+3. The reviewer simply re-framing the same complaint at a different file/line
+
+Concrete trace summary:
+
+| Round | Timestamp (UTC) | Findings |
+|:------|:----------|:---------|
+| 1 | 14:22 | 3 errors: dead-code abandonment, missing input validation, e2e test gap |
+| 2 | 14:40 | 8 findings (2 errors): auth bypass, NaN guard, redundant if/else, test cleanup, … (none from round 1) |
+| 3 | 14:52 | 6 findings: redundant if/else **flagged again** as `error`, test gap re-framed |
+
+Verbatim excerpts from the audit logs (`logs/review-audit/.../us-006-reviewer-adversarial.json`):
+
+**Round 1 (14:22):**
+```
+[error][abandonment] apps/api/src/state/canonical-state.service.ts:27 —
+  CanonicalStateService.getSnapshot is a public @Injectable() method but
+  the service is never exposed via a controller or middleware. No consumer
+  can reach it — the feature is entirely dead code.
+[error][input] apps/api/src/state/canonical-state.service.ts:27 —
+  getSnapshot accepts SnapshotQuery without validating projectId is non-empty.
+[error][test-gap] test/e2e/api-endpoint/endpoint.e2e.spec.ts:1 —
+  No e2e tests exist for this feature. AC#5 (unauthorized projectId) is untested.
+```
+
+**Round 2 (14:40):**
+```
+[error][error-path] apps/api/src/state/state.controller.ts:91 —
+  Auth bypass: when actor is undefined (unauthenticated), checkProjectMembership
+  is never called, making the endpoint publicly accessible.
+[warn][error-path] apps/api/src/state/state.controller.ts:104 —
+  parseInt(timeWindowMinutes, 10) has no NaN guard.
+[error][test-gap] apps/api/test/e2e/state/canonical-state.e2e.spec.ts:10 —
+  E2E test creates a NestJS TestingModule inside beforeEach without cleanup.
+[warn][abandonment] apps/api/src/state/state.controller.ts:34 —
+  The if/else branches for actorType !== 'agent' and else are literally identical code.
+... (4 more findings)
+```
+
+**Round 3 (14:52):**
+```
+[error][error-path] apps/api/src/state/state.controller.ts:34 —
+  The if (actorType !== 'agent') branch and the else branch contain identical logic.
+  This is dead code. The if branch adds no unique behavior...
+[warn][test-gap] apps/api/test/e2e/state/canonical-state.e2e.spec.ts:26 —
+  E2E test only covers the 404 path. AC2-5 are never exercised at e2e level.
+... (4 more findings)
+```
+
+Round 1's flagged issues are not addressed in round 2's verdict — the reviewer moved on. Round 3 re-flags the redundant-branches issue (round 2 also flagged it as `warn`; round 3 escalates to `error`). The loop never converges; eventually rectification budget is exhausted and the story escalates.
+
+### Root cause
+
+[`src/review/adversarial.ts:269-318, 377`](../../src/review/adversarial.ts#L269-L377)
+
+- Each adversarial review opens a **fresh ACP session** and **explicitly closes it** at the end of the call.
+- Session name is deterministic (`reviewer-adversarial`), but `closePhysicalSession` is called on every exit path → the next cycle starts cold.
+- The next round's prompt is built from scratch with no reference to prior findings.
+- **The implementer side, by contrast, has a structured memory mechanism**: `RectifierPromptBuilder.priorFailures(failures)` carries failure context forward as a prompt block ([rectifier-builder.ts:80-84](../../src/prompts/builders/rectifier-builder.ts#L80-L84)). The implementer also runs cold sessions across cycles, but it gets memory via prompt input, not session continuity. The adversarial reviewer has neither.
+
+### Design tension
+
+Two competing goods:
+
+- **Fresh eyes** — a new session re-reads the diff cold and is willing to flag things prior rounds missed. Good when prior rounds were too lenient.
+- **Continuity** — a session with memory can verify "issue A is now fixed" rather than treat every round as a new audit. Good when the implementer is making real progress.
+
+Pure kept-session trades fresh eyes for memory. Pure fresh-session trades memory for fresh eyes. The recommended approach grafts memory onto fresh eyes via structured prompt input — same pattern the implementer already uses.
+
+### Recommendation: fresh session + structured prior-findings carry-forward
+
+Each round's prompt gets a `## PRIOR ADVERSARIAL FINDINGS — Round N-1` block:
+
+```
+## PRIOR ADVERSARIAL FINDINGS — Round N-1
+[error][error-path] state.controller.ts:91 — Auth bypass when actor undefined
+[error][test-gap]   canonical-state.e2e.spec.ts:1 — Missing e2e for AC#5
+
+## Verdict required FIRST
+For each prior finding, check whether it has been addressed.
+Only after that, raise NEW blocking findings.
+Do not re-flag a fixed finding with new wording at the same severity.
+A NEW finding blocks only if it could not have been raised in round N-1
+(i.e. the issue was introduced by the rectification, or is genuinely
+distinct from prior findings).
+```
+
+### Why this over keep-session-open
+
+| Concern | Kept session | Fresh + structured |
+|:---|:---|:---|
+| **Cost** | Replays full diff + findings + responses on every turn. By round 4–5 of a complex story: 100K+ tokens per call (~3–5× higher cost). | Fresh diff each round + compact prior-findings block. Stays under 30K consistently. |
+| **Anchoring bias** | LLMs have well-documented commitment effects — a session that already issued a verdict tends to defend it rather than revise. Defeats the "fresh eyes" benefit. | Fresh session with explicit memory separates "what's there" from "what did I say before". |
+| **Symmetry with implementer** | Implementer doesn't keep sessions across rectification cycles — it carries `priorFailures[]` as a structured prompt block. | Mirrors that pattern. One mechanism, two sides. |
+| **Multi-turn dialogue** | Possible, but adversarial is one-shot by design ([adversarial.ts:10](../../src/review/adversarial.ts#L10)) — dialogue lives in the semantic-review path's `ReviewerSession`. | Same — no loss. |
+
+### Phasing — three PRs, only the first is mandatory
+
+| PR | Scope | LOC | Land if… |
+|:---|:---|:---|:---|
+| 1 | Cache findings in orchestrator; render prior-findings block in next prompt; verdict-first instruction in builder | ~80 | **Always — this is the actual fix** |
+| 2 | Add `priorVerdict[]` field to response JSON; log "implementer fixed N/M prior findings" convergence signal; feed verdict back into next implementer rectification prompt | ~60 | If PR 1 deployed but observability/loop-closure desired |
+| 3 | Convergence-stall heuristic (escalate when reviewer thrashes — zero new errors AND zero verified fixes for N rounds) | ~40 | Only if PR 1+2 still let runs diverge |
+
+**Recommended sequence**: land PR 1 alone, run it on the next real feature, inspect audit logs, then decide PR 2/3 from data.
+
+### PR 1 — what actually changes
+
+**Three small additions, no response-shape change.**
+
+1. `AdversarialReviewPromptBuilder.priorFindings(findings, roundNumber)` — new builder method that renders the compact block shown above. When called with empty/undefined findings, renders nothing (first round behaves identically to today). The `roundNumber` is interpolated into the block header (`## PRIOR ADVERSARIAL FINDINGS — Round 2` etc.) for audit-log readability.
+
+2. `runAdversarialReview(...)` accepts `priorFindings?: ReviewFinding[]` and `priorRoundNumber?: number`, forwards both to the builder. Signature change is additive; existing callers that don't pass the parameters behave as before.
+
+3. Orchestrator caches per-story state on the `ReviewOrchestrator` instance:
+
+   ```typescript
+   private adversarialState = new Map<string, {
+     lastFindings: ReviewFinding[];
+     roundNumber: number;
+   }>();
+   ```
+
+   - **Scope:** keyed by `storyId`, lives on the orchestrator instance (lifecycle = one run). Cleared per-story when the story enters review for the first time, **not** on every adversarial call (otherwise cache is wiped before it's read).
+   - **Initialization:** entry is created on the first adversarial call for a story with `{ lastFindings: [], roundNumber: 1 }`.
+   - **Update rule:** after each `runAdversarialReview` returns, replace `lastFindings` with the just-returned findings (last-call-wins) and increment `roundNumber`.
+   - **Clear rule:** on story success/escalation/failure (any terminal exit from the review→rectify loop), delete the entry. Prevents leaks if the orchestrator is reused for a follow-up run.
+   - **Parallel execution:** keys are per-story, so concurrent stories don't collide. The `Map` is single-threaded JS; no locking needed.
+
+**The reviewer answers the verdict question naturally inside its existing findings text.** PR 2 is what adds the structured `priorVerdict[]` field — but that's a follow-up, not required to fix the goalpost-moving symptom.
+
+### PR 1 — files touched
+
+- [`src/prompts/builders/adversarial-review-builder.ts`](../../src/prompts/builders/adversarial-review-builder.ts) — new `priorFindings()` builder method + verdict-first task instruction
+- [`src/review/adversarial.ts`](../../src/review/adversarial.ts) — accept and forward `priorFindings` parameter
+- [`src/review/orchestrator.ts`](../../src/review/orchestrator.ts) — cache last round's findings, thread to next call
+- `test/unit/review/adversarial-prior-findings.test.ts` — new test asserting block renders correctly and is suppressed when empty
+- Existing snapshot tests — update to cover the new prompt section
+
+### Risks and edge cases
+
+| Risk | Mitigation |
+|:---|:---|
+| Reviewer ignores the prior-findings block (model doesn't follow instruction) | Goalpost-moving symptom returns. Detectable in audit logs immediately — would trigger PR 3's stall heuristic. Acceptable for PR 1. |
+| Prior-findings list grows unboundedly across rounds | Carry only the **most recent round's** findings, not full history. Enforced by last-call-wins cache (replace, don't append). |
+| What counts as a "round"? Cycles can re-enter through autofix → verify → review | A "round" = each call to `runAdversarialReview` for a given `storyId`. Cache key is `storyId`. Origin of the cycle (autofix vs fresh review) doesn't matter — the reviewer sees its own immediate prior verdict. |
+| Cache leaks across stories in parallel execution | Cache keyed by `storyId` — parallel stories are isolated. `Map` is single-threaded JS, no locking needed. |
+| Cache key collisions across feature/run boundaries | Cache lives on the `ReviewOrchestrator` instance, scoped to one run. Cleared on story terminal exit. No cross-run leakage. |
+| Orchestrator instance reuse between runs (e.g., a long-lived nax server) | Explicit clear-rule on story terminal exit (success/escalation/failure) prevents stale entries surviving into a new run. |
+
+### Resolved design decisions
+
+1. **Cache location.** ✅ In-memory `Map` on the `ReviewOrchestrator` instance, keyed by `storyId`, lifecycle = one run with explicit clear-on-story-terminal-exit. Persistence to `sessionScratchDir` rejected — adversarial findings have no post-run value, and persistence invites cache-staleness bugs.
+
+2. **Implementer-side feedback loop.** ✅ In-scope as **PR 2**, gated on PR 1 landing first. PR 2 adds the structured `priorVerdict[]` response field, then threads `"reviewer says you fixed X but missed Y"` into the next implementer rectification prompt via [`RectifierPromptBuilder.regressionFailure(...)`](../../src/prompts/builders/rectifier-builder.ts) (the consolidated method introduced by Gap 2's PR 2). Coupling note: Gap 1 PR 2 depends on Gap 2 PR 2 having landed, so the rectifier method exists to extend.
+
+3. **Semantic review parity.** ✅ Out of scope for PR 1. Adversarial only. Reasons:
+   - Reported symptom was specifically adversarial (US-006 goalpost-moving)
+   - Semantic has `ReviewerSession` dialogue mode ([dialogue.ts](../../src/review/dialogue.ts)) — different memory mechanism (kept session, debate-style)
+   - Will revisit if semantic shows the same pattern. Tracked as a follow-up, not a blocker.
+
+4. **Round numbering in the prompt.** ✅ Numeric. The cache holds `{ lastFindings, roundNumber }`; the block header reads `## PRIOR ADVERSARIAL FINDINGS — Round 2` (or 3, 4…). Audit-log readability outweighs the trivial cost of incrementing a counter.
+
+### Alternatives considered
+
+- **Keep session open across cycles** — simplest plumbing change, but cost-prohibitive for 4–6 round cycles and prone to anchoring bias. Rejected for the reasons in the comparison table above.
+- **Reviewer drives implementer in same session** — pairs reviewer turn-by-turn with implementer. Couples the two roles tightly, blocks parallel-execution paths, and is closer to debate-mode (which already exists for semantic). Out of scope for this fix.
+- **Reviewer reads its own audit JSON files** — uses `logs/review-audit/` as the carry-forward mechanism. Couples prompt logic to file-system layout; audit logs are observability, not control flow. Rejected.
+- **Persist findings in session scratch** — same as the recommended approach but with persistence. Adds an indirection (the reviewer would need a "read prior findings" tool call). No clear advantage. Rejected.
+
+### Execution status
+
+- [ ] Spec finalized and approved (this doc)
+- [ ] PR 1 — fresh session + structured carry-forward (mandatory)
+- [ ] PR 2 — structured `priorVerdict[]` + implementer feedback loop (optional, after PR 1 telemetry)
+- [ ] PR 3 — convergence-stall escalation (optional, only if needed)
+
+Execution deferred until spec sign-off.
+
+---
+
+## Gap 2 — Rectification prompt doesn't demand full-suite green
+
+### Symptom
+
+US-001 implementer rectification ran multiple times. Two consecutive prompts (15:24 and 15:39 UTC, same `implementer` session resumed) illustrate the failure mode.
+
+**Prompt 1 (15:24):** 12 unit-test failures, all in one file:
+
+```
+# PRIOR FAILURES
+
+## Failure 1 — IncrementalGraphDiffService › AC-8: DiffResult shape › returns
+  a DiffResult with added, removed, indexed, and durationMs fields
+File: src/rag/incremental-graph-diff.service.spec.ts
+Message: expect(received).rejects.toThrow()
+
+## Failure 2 — IncrementalGraphDiffService › AC-9: stored graph loaded from
+  GraphNode + GraphLink Prisma tables › queries GraphNode and GraphLink tables
+File: src/rag/incremental-graph-diff.service.spec.ts
+Message: expect(received).rejects.toThrow()
+
+... (10 more failures, ALL in src/rag/incremental-graph-diff.service.spec.ts)
+
+# TEST COMMAND
+
+`bun run test`
+
+# Rectification Required
+
+Your changes caused test regressions. Fix these without breaking existing logic.
+
+## Instructions
+1. Review the failures above carefully.
+2. Identify the root cause of each failure.
+3. Fix the implementation WITHOUT loosening test assertions.
+4. Run the test command shown above to verify your fixes.
+5. Ensure ALL tests pass before completing.
+```
+
+**Prompt 2 (15:39, 14 minutes later, same session):** 1 NEW failure in a *different* spec file for an *unrelated* story:
+
+```
+# PRIOR FAILURES
+
+## Failure 1 — API Integration Tests › Knowledge Base — Graphify Import (US-003)
+  › POST /kb/import/graphify — 200 when links field is absent (links is optional)
+File: test/e2e/api-endpoint/endpoint.e2e.spec.ts
+Message: expect(received).toBe(expected) // Object.is equality
+
+# TEST COMMAND
+
+`bun run test`
+
+# Rectification Required
+... (same instructions as prompt 1)
+```
+
+Pattern: implementer fixed the 12 unit tests, ran a scoped subset to confirm green, declared done. The system's `checkResult` then ran the full suite, caught the cross-story e2e regression in US-003's endpoint, and kicked off a fresh rectification cycle (prompt 2). **One avoidable cycle per regression** — if the implementer had run `bun run test` (full suite) themselves before declaring done, they'd have caught the regression in cycle 1.
+
+### Where the gap actually lives
+
+The system already runs the full suite at every rectification iteration's `checkResult()` ([rectification-loop.ts:312-326](../../src/verification/rectification-loop.ts#L312-L326)). Cross-story regressions are not undetected — they're detected one cycle later than they could be.
+
+The gap is purely **the agent's self-verification within its session**: the prompt's "Ensure ALL tests pass" is ambiguous, and the agent treats it as "all the failures listed in this prompt" rather than "every test in the repo". So they run `bun test <failing-files>`, see green, hand off — and the system catches the regressions on the next pass.
+
+### Test-execution architecture (so the wording doesn't fight it)
+
+| Surface | Tests run | Smart runner involved? |
+|:---|:---|:---|
+| Per-story verify (single-session: `tdd-simple`, `test-after`) | Scoped via `testScopedTemplate` when smart runner maps; full suite otherwise | Yes |
+| Per-story verify (deferred mode + would-fall-back-to-full) | **Skipped** — defers to run-end gate | Yes (decides skip) |
+| Three-session TDD full-suite gate (between session 2 and 3) | Full suite | No |
+| Per-story rectification `checkResult()` (any trigger) | Full `testCommand` | No |
+| Run-end deferred regression gate | Full suite | No |
+
+The smart runner is upstream of rectification only — by the time the rectification prompt is built, `testCommand` is always the full-suite command. So the wording fix doesn't need any branching on strategy or `testScopedTemplate`.
+
+### Root cause
+
+Two issues, both in [`src/prompts/builders/rectifier-builder.ts`](../../src/prompts/builders/rectifier-builder.ts).
+
+**(a) Trigger taxonomy is half-dead.** The `RectifierTrigger` union has four values:
+
+| Trigger | Used via `.for(...)`? | Notes |
+|:---|:---|:---|
+| `tdd-test-failure` | **no** | TDD red phase has its own prompts in `TddPromptBuilder` |
+| `tdd-suite-failure` | yes ([rectification-gate.ts:269](../../src/tdd/rectification-gate.ts#L269)) | Three-session TDD's full-suite gate |
+| `verify-failure` | yes ([rectification-loop.ts:238](../../src/verification/rectification-loop.ts#L238)) | Per-story verify failure + deferred regression |
+| `review-findings` | **no** | Review findings flow through `RectifierPromptBuilder.reviewRectification()` (a separate static method) |
+
+Two of four are dead. Of the two live ones, the task strings are nearly identical — they describe the same situation from the implementer's perspective ("tests are broken after your implementation, fix them and confirm full suite green").
+
+**(b) Task wording is ambiguous about what "ALL" means.** All four task constants share these lines:
+
+```
+4. Run the test command shown above to verify your fixes.
+5. Ensure ALL tests pass before completing.
+```
+
+"Verify your fixes" reinforces the scoped-run interpretation. "ALL tests" is read as "all the failures listed", not "every test in the repo".
+
+### Phase 5 history (why dead code exists)
+
+[`docs/specs/prompt-builder-phase5.md`](../specs/prompt-builder-phase5.md) defines the migration that created `RectifierPromptBuilder`. Phase 5 planned to wire all four triggers:
+
+| Trigger | Phase 5 plan | Today |
+|:---|:---|:---|
+| `tdd-test-failure` | `src/tdd/session-runner.ts` | **Never wired** — session-runner doesn't build a rectification prompt; the implementer session continues in-place after test-writer ([session-runner.ts:207-211](../../src/tdd/session-runner.ts#L207-L211)) |
+| `tdd-suite-failure` | `src/tdd/rectification-gate.ts:210` | Wired ✓ |
+| `verify-failure` | `src/verification/rectification-loop.ts:241` | Wired ✓ |
+| `review-findings` | `verification/rectification-loop.ts` (with `.findings(...)`) | **Never wired** — review findings flow through `RectifierPromptBuilder.reviewRectification()`, a separate static method with semantic/adversarial/mechanical/combined sub-paths |
+
+Phase 5's risk-1 mitigation ("keep four distinct trigger task constants — preserves the original prompt verbatim") was correct at migration time. That mitigation is no longer load-bearing: the historical TDD prompts the constants were preserving have since converged in wording, and the two unwired triggers represent flows that don't exist (tdd-test-failure: never had a fresh-prompt callsite; review-findings: superseded by `reviewRectification()`).
+
+So consolidating now reclaims a parking spot, not erasing intent.
+
+### Proposed approach — three-PR sequence
+
+Land as three small, independent PRs rather than one big change:
+
+#### PR 1 — Dead-code removal (low risk, atomic, reviewable in 2 minutes)
+
+Delete unused trigger values and their plumbing. **No behavior change. No production callsite touched.**
+
+Files modified:
+
+- [`src/prompts/builders/rectifier-builder.ts`](../../src/prompts/builders/rectifier-builder.ts):
+  - Remove `"tdd-test-failure"` and `"review-findings"` from the `RectifierTrigger` union ([:46-49](../../src/prompts/builders/rectifier-builder.ts#L46-L49))
+  - Remove `TDD_TEST_FAILURE_TASK` constant ([:655-670](../../src/prompts/builders/rectifier-builder.ts#L655-L670)) and `REVIEW_FINDINGS_TASK` constant ([:706+](../../src/prompts/builders/rectifier-builder.ts#L706))
+  - Remove their switch arms in `rectifierTaskFor()` ([:642-652](../../src/prompts/builders/rectifier-builder.ts#L642-L652))
+
+- [`test/unit/prompts/rectifier-builder.test.ts`](../../test/unit/prompts/rectifier-builder.test.ts):
+  - Remove ~12 test cases that reference the dead trigger values (lines 79, 82, 93, 107, 124, 139, 149, 174, 185, 229, 240, 251 — verify exhaustive list before deleting)
+  - The remaining tests for `"tdd-suite-failure"` and `"verify-failure"` cover the live paths
+
+Net: ~80 LOC removed across 2 files. No source callsites touched.
+
+#### PR 2 — Consolidate + sharpen wording (the main Gap 2 fix)
+
+After PR 1, the trigger union has only 2 values left and they describe the same situation. Replace `RectifierPromptBuilder.for(trigger).…build()` with a single static method, matching the existing pattern of sibling methods (`reviewRectification`, `testWriterRectification`, `firstAttemptDelta`):
+
+```typescript
+RectifierPromptBuilder.regressionFailure({
+  story,
+  failures,        // FailureRecord[] — formerly priorFailures()
+  testCommand,
+  conventions,     // boolean (default true)
+  isolation,       // "strict" | "lite" | undefined
+  constitution,    // string | undefined
+  context,         // string | undefined
+  promptPrefix,    // string | undefined — for diagnosis prefix from debate stage
+})
+```
+
+Returns the assembled prompt string directly. Both call sites switch to the new shape:
+
+- [`src/verification/rectification-loop.ts:238`](../../src/verification/rectification-loop.ts#L238)
+- [`src/tdd/rectification-gate.ts:269`](../../src/tdd/rectification-gate.ts#L269)
+
+Delete (PR 1 pruned the dead trigger values; PR 2 finishes the job):
+- The remaining `RectifierTrigger` union and its `for(trigger)` constructor (now down to 2 values)
+- `TDD_SUITE_FAILURE_TASK` and `VERIFY_FAILURE_TASK` constants (collapsed into the new method's body)
+- The `rectifierTaskFor(trigger)` switch
+- All chained instance methods on the builder used only by the trigger flow:
+  - `constitution(c)`, `context(md)`, `story(s)`, `priorFailures(failures)`, `findings(fs)`, `testCommand(cmd)`, `isolation(mode)`, `conventions()`, `task()`, `build()`
+  - The internal `SectionAccumulator` / `acc` field
+  - The private `s(...)` section-tagging helper
+- These instance methods are unique to the `for(trigger)` flow. **The other static methods on the builder remain untouched**: `firstAttemptDelta`, `continuation`, `noOpReprompt`, `reviewRectification`, `semanticRectification`, `adversarialRectification`, `mechanicalRectification`, `combinedLlmRectification`, `testWriterRectification`, `escalated`, `formatCheckErrors`. PR 2 removes only the trigger/builder/chain pattern, not the shared static helpers.
+
+Single task string body, embedded in `regressionFailure()`:
+
+```
+# Rectification Required
+
+Tests are failing. Fix the source so all tests pass — not just the ones listed.
+
+## Instructions
+
+1. Review the failures above and identify the root cause of each.
+2. Fix the source code WITHOUT loosening test assertions or removing tests.
+3. After your fix, run the FULL repo test suite — the EXACT command below:
+
+   `<testCommand>`
+
+   The verifier will replay this same command. If you only run the failing
+   tests in isolation, you may have introduced cross-story regressions you
+   won't see. There is no benefit to skipping this — the verifier WILL catch
+   anything you miss, and you'll just be back here in another cycle.
+
+4. Do not declare done until step 3 shows 0 failures.
+
+**IMPORTANT:**
+- Do NOT modify test files unless there is a legitimate bug in the test itself.
+- Do NOT loosen assertions to mask implementation bugs.
+- Focus on fixing the source code to meet the test requirements.
+```
+
+Notes:
+- No branching on `testScopedTemplate` — smart runner is orthogonal to rectification ([see architecture table above](#test-execution-architecture-so-the-wording-doesnt-fight-it)).
+- The "verifier will replay this command" framing makes skipping it strictly worse than running it (no behavior change, just clearer incentive).
+- One canonical wording covers both `tdd-suite-failure` and `verify-failure` semantics, since they're the same situation.
+
+#### PR 3 (optional) — Spec annotation
+
+Update [`docs/specs/prompt-builder-phase5.md`](../specs/prompt-builder-phase5.md) to reflect what actually shipped:
+
+- Annotate the `tdd-test-failure` and `review-findings` callsites as "planned but never wired"
+- Add a footnote pointing at PR 1 + PR 2
+
+Optional and can land anytime. Purpose: prevent future readers from concluding the migration was incomplete and re-introducing the dead values.
+
+### Scope estimate
+
+| PR | LOC delta | Files | Risk | Standalone? |
+|:---|:---|:---|:---|:---|
+| 1 — dead-code removal | ~80 removed | 2 | Very low | Yes |
+| 2 — consolidate + wording | ~120 net | ~5 (builder + 2 callsites + tests) | Low–medium | Yes (after PR 1) |
+| 3 — spec annotation | ~10 | 1 | None | Yes (any time) |
+
+### Resolved design decisions
+
+1. **Stricter "do not modify test files" wording.** ✅ Skip — the new `regressionFailure()` method uses the unified wording shown above, with the standard "do not loosen assertions" rule. The stricter test-writer-style wording from the dead `tdd-test-failure` constant has no live caller; the current TDD design is implementer-session-continues-in-place ([session-runner.ts:207-211](../../src/tdd/session-runner.ts#L207-L211)). If a future caller emerges that needs the stricter wording, add it as an opt-in field on the options object then.
+
+2. **Loop-level full-suite enforcement.** ✅ Skip — prompt-only. The system already validates with the full suite at every rectification iteration's `checkResult()` ([rectification-loop.ts:312-326](../../src/verification/rectification-loop.ts#L312-L326)). In-session enforcement (e.g., parsing agent output for evidence of a full-suite invocation) adds complexity without protecting against anything new.
+
+3. **Pre-merge validation.** ✅ Required as part of PR 2's review process: capture before/after rendered prompts using a real `testCommand` from a recent run, attach to PR description, confirm token impact is small (~+10 lines net) and the `<testCommand>` interpolation renders correctly. Also run one full feature end-to-end with the new prompt to confirm no regression in implementer behavior.
+
+### Execution status
+
+- [ ] Spec finalized and approved (this doc)
+- [ ] PR 1 — dead-code removal
+- [ ] PR 2 — consolidate + sharpen wording
+- [ ] PR 3 — spec annotation (optional)
+
+Execution deferred until spec sign-off.
+
+---
+
+## Order of work
+
+The two gaps are largely independent — except that **Gap 1 PR 2 depends on Gap 2 PR 2** (the implementer-feedback verdict block lives in `RectifierPromptBuilder.regressionFailure(...)`, which is created by Gap 2 PR 2).
+
+### Recommended sequence
+
+| Order | PR | Why this slot |
+|:---|:---|:---|
+| 1 | **Gap 2 PR 1** — dead-code removal | Smallest, lowest risk, atomic. Unblocks reviewers' mental model of the builder. |
+| 2 | **Gap 2 PR 2** — consolidate + sharpen wording | Validates the regression-detection wording on a real run before stacking more changes. |
+| 3 | **Gap 1 PR 1** — fresh session + structured carry-forward | The actual goalpost-moving fix. Independent of Gap 2 PR 2 for PR 1's own scope. |
+| 4 | **Gap 1 PR 2** *(optional)* — `priorVerdict[]` + implementer feedback loop | Depends on both Gap 2 PR 2 (rectifier method) and Gap 1 PR 1 (cache + carry-forward). Land only after PR 1 telemetry shows it's worthwhile. |
+| 5 | **Gap 2 PR 3** *(optional)* — spec annotation | Anytime; documentation hygiene. |
+| 6 | **Gap 1 PR 3** *(optional)* — convergence-stall escalation | Only if Gap 1 PR 1+2 still let runs diverge. |
+
+### Why this order
+
+- **Land cleanups first.** Gap 2 PR 1 is mechanical and reduces surface area for everything that follows.
+- **Validate wording before architectural change.** Gap 2 PR 2 changes a prompt the agent reads on every rectification cycle — get it on a real run before piling on Gap 1's changes.
+- **Gap 1 PR 1 is the load-bearing change.** It's the actual fix for the goalpost-moving bug. Land it once Gap 2 has stabilized so the new prompt and the new builder method aren't both in flight at once.
+- **Defer optional PRs until data exists.** PRs 4–6 are gated on observability from the prior PRs. Don't pre-build them.
+
+Each PR carries its own tests, snapshot updates, and audit-log expectations.


### PR DESCRIPTION
## Summary

Two findings docs documenting three gaps observed in a koda run on 2026-04-26. Each gap has a phased PR plan; this PR adds the findings only — implementation is deferred per each doc's execution-status section.

- **Gap 1** — Adversarial reviewer moves goalposts across cycles ([rectification-gaps.md](docs/findings/2026-04-27-implementer-review-rectification-gaps.md))
- **Gap 2** — Rectification prompt doesn't demand full-suite green ([rectification-gaps.md](docs/findings/2026-04-27-implementer-review-rectification-gaps.md))
- **Gap 3** — Implementer prompt buries the story under rules bloat ([prompt-bloat.md](docs/findings/2026-04-27-implementer-prompt-bloat-and-burial.md))

## Why this is doc-only

Each gap has resolved design decisions, scope estimates, and PR sequencing. Implementation lives in follow-up PRs tracked by GitHub issues. Splitting docs from implementation lets reviewers steer the design before code is written.

## Implementation order

Tracked in the issues, **not in the docs** — the docs describe the design; the issues track sequencing and progress.

| Order | Issue | Gap | Why this slot |
|:---|:---|:---|:---|
| 1 | #737 | Gap 2 (rectification) | Safest first PR (pure dead-code deletion); unblocks #736's PR 2 dependency |
| 2 | #738 | Gap 3 (prompt bloat) | Broadest impact across all stories; Framing A (4 PRs) before B/C decision gate |
| 3 | #736 | Gap 1 (adversarial) | Highest behavior-change risk; ship last so audit-log changes are attributable |

Each issue's body has the sub-PR checklist + telemetry gates. Cross-dependency: #736 PR 3.2 needs #737 PR 1.2 (handled naturally by the order).

## Evidence portability

Findings cite a koda run that used local audit logs (`logs/prompt-audit/`, `logs/review-audit/`, gitignored). Load-bearing excerpts are inlined as code blocks so claims are verifiable without local log access. Koda content links to the public [koda repo](https://github.com/nathapp-io/koda) on `feat/memory-phase4-graph-code-intelligence`.

## Test plan

- [ ] Doc renders correctly on GitHub (tables, code blocks, links resolve)
- [ ] All in-repo links (`src/...`, `docs/...`) resolve
- [ ] All koda links (`https://github.com/nathapp-io/koda/...`) resolve
- [ ] No machine-local paths (`/home/...`) remain