### PR TITLE
fix(tdd): pass keepOpen in rectification-gate to preserve ACP session context across retries

### DIFF
--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -255,6 +255,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
   // Full-Suite Gate (v0.11 Rectification)
   // Pass initialRef so the gate can use git-diff to suppress pre-existing failures
   // in files the story never touched (BUG-TC-001).
+  const implementerBinding = getTddSessionBinding?.("implementer");
   const { passed: fullSuiteGatePassed, cost: fullSuiteGateCost } = await runFullSuiteGate(
     story,
     config,
@@ -266,6 +267,8 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     featureName,
     projectDir,
     initialRef,
+    implementerBinding?.sessionManager,
+    implementerBinding?.sessionId,
   );
 
   // Session 3: Verifier

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -14,6 +14,7 @@ import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
 import type { FailureRecord } from "../prompts";
 import { resolveQualityTestCommands } from "../quality/command-resolver";
+import { formatSessionName } from "../session/naming";
 import { autoCommitIfDirty, captureGitRef } from "../utils/git";
 import {
   type RectificationState,
@@ -86,6 +87,8 @@ export async function runFullSuiteGate(
   featureName?: string,
   projectDir?: string,
   storyFromRef?: string,
+  sessionManager?: import("../session").ISessionManager,
+  sessionId?: string,
 ): Promise<{ passed: boolean; cost: number }> {
   const rectificationEnabled = config.execution.rectification?.enabled ?? false;
   if (!rectificationEnabled) return { passed: false, cost: 0 };
@@ -172,6 +175,8 @@ export async function runFullSuiteGate(
         fullSuiteResult.output,
         featureName,
         projectDir,
+        sessionManager,
+        sessionId,
       );
     }
 
@@ -225,6 +230,8 @@ async function runRectificationLoop(
   testOutput: string,
   featureName?: string,
   projectDir?: string,
+  sessionManager?: import("../session").ISessionManager,
+  sessionId?: string,
 ): Promise<{ passed: boolean; cost: number }> {
   logger.warn("tdd", "Full suite gate detected regressions", {
     storyId: story.id,
@@ -233,6 +240,14 @@ async function runRectificationLoop(
   });
 
   let gateCostAccum = 0;
+  let currentAttempt = 0;
+
+  const rectificationSessionName = formatSessionName({
+    workdir,
+    featureName,
+    storyId: story.id,
+    role: "implementer",
+  });
 
   const initialFailure: TddRectificationFailure = {
     testSummary,
@@ -258,6 +273,8 @@ async function runRectificationLoop(
         .build();
     },
     execute: async (prompt) => {
+      currentAttempt++;
+      const isLastAttempt = currentAttempt >= rectificationConfig.maxRetries;
       const rectifyBeforeRef = (await captureGitRef(workdir)) ?? "HEAD";
       const defaultAgent = agentManager.getDefault();
       const rectifyResult = await agentManager.run({
@@ -279,8 +296,19 @@ async function runRectificationLoop(
           featureName,
           storyId: story.id,
           sessionRole: "implementer",
+          keepOpen: !isLastAttempt,
         },
       });
+
+      // G5: bind updated protocolIds after each rectification attempt so the session descriptor
+      // reflects the session that actually ran (may change after internal session retries).
+      if (sessionManager && sessionId && rectifyResult.protocolIds) {
+        try {
+          sessionManager.bindHandle(sessionId, rectificationSessionName, rectifyResult.protocolIds);
+        } catch {
+          // Session may not exist in manager (e.g. v2 context disabled) — ignore.
+        }
+      }
 
       if (!rectifyResult.success && rectifyResult.pid) {
         await cleanupProcessTree(rectifyResult.pid);

--- a/test/unit/tdd/rectification-gate-session.test.ts
+++ b/test/unit/tdd/rectification-gate-session.test.ts
@@ -178,7 +178,7 @@ describe("rectification session reuse", () => {
     expect(sessionRoles[1]).toBe(sessionRoles[2]);
   });
 
-  test("rectification calls do not set keepOpen (caller-managed per ADR-019)", async () => {
+  test("rectification calls set keepOpen except on last attempt", async () => {
     const story = makeStory();
     const config = makeConfig(2);
     const agent = makeAgent();
@@ -207,10 +207,10 @@ describe("rectification session reuse", () => {
     } as any);
 
     expect(agent.calls.length).toBe(2);
-    // Session management is caller-managed (ADR-019) — keepOpen is not set by runRetryLoop
-    for (const call of agent.calls) {
-      expect(call.keepOpen).not.toBeDefined();
-    }
+    // Non-last attempts keep the session open so retries share context.
+    // Last attempt closes the session.
+    expect(agent.calls[0]?.keepOpen).toBe(true);
+    expect(agent.calls[1]?.keepOpen).toBe(false);
   });
 
   test("all attempts use the same sessionRole even without featureName", async () => {


### PR DESCRIPTION
## Summary

Fixes #740 — `src/tdd/rectification-gate.ts` was not passing `keepOpen` in its `agentManager.run()` call inside the rectification retry loop. Every retry opened a fresh ACP session and lost the prior attempt's conversational context.

## Changes

- **`src/tdd/rectification-gate.ts`:**
  - Added optional `sessionManager` and `sessionId` parameters (inline type imports, backward-compatible)
  - Added `keepOpen: !isLastAttempt` in the `execute` callback so non-final retries preserve ACP session context
  - Added `formatSessionName` + `bindHandle` call (G5 pattern) to bind protocolIds to the session descriptor after each attempt

- **`src/tdd/orchestrator.ts`:**
  - Passed implementer session binding (`sessionManager` + `sessionId`) from `getTddSessionBinding?.("implementer")` into `runFullSuiteGate`

- **`test/unit/tdd/rectification-gate-session.test.ts`:**
  - Updated outdated test that expected `keepOpen` to be undefined; now asserts `keepOpen: true` on non-last attempts and `keepOpen: false` on the last attempt

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run build` ✅
- Full test suite: **8023 pass, 0 fail** ✅

## Related

- Issue: #740
- Pattern parity: `src/verification/rectification-loop.ts`, `src/pipeline/stages/autofix.ts`