### PR TITLE
fix(verification): use final failure snapshot for escalation prompt instead of initial failures

### DIFF
--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -756,10 +756,10 @@ async function runAgentRectification(
     },
   }).catch((error: unknown) => {
     if (error instanceof Error && error.message === "AUTOFIX_AGENT_NOT_FOUND") {
-      return { outcome: "exhausted", attempts: 0 } as const;
+      return { outcome: "exhausted", attempts: 0, finalFailure: initialFailure } as const;
     }
     if (error instanceof Error && error.message === "AUTOFIX_UNRESOLVED") {
-      return { outcome: "exhausted", attempts: 0 } as const;
+      return { outcome: "exhausted", attempts: 0, finalFailure: initialFailure } as const;
     }
     throw error;
   });

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -414,10 +414,11 @@ export async function runRectificationLoop(
 
   // Escalation logic — runs only when exhausted and conditions permit
   if (outcome.outcome === "exhausted") {
+    const finalFailure = outcome.finalFailure;
     const shouldEscalate =
       rectificationConfig.escalateOnExhaustion !== false &&
       config.autoMode?.escalation?.enabled === true &&
-      initialFailure.testSummary.failed > 0;
+      finalFailure.testSummary.failed > 0;
 
     if (shouldEscalate) {
       const complexity = story.routing?.complexity ?? "medium";
@@ -440,7 +441,7 @@ export async function runRectificationLoop(
             escalationManager.getDefault(),
           );
           let escalationPrompt = RectifierPromptBuilder.escalated(
-            initialFailure.testSummary.failures,
+            finalFailure.testSummary.failures,
             story,
             outcome.attempts,
             currentTier,

--- a/src/verification/shared-rectification-loop.ts
+++ b/src/verification/shared-rectification-loop.ts
@@ -24,9 +24,9 @@ export type VerifyOutcome<TFailure> =
  * Outcome from runRetryLoop() — either fixed (with the result that passed verify)
  * or exhausted (all maxAttempts consumed without a passing verify).
  */
-export type RetryOutcome<TResult> =
+export type RetryOutcome<TFailure, TResult> =
   | { readonly outcome: "fixed"; readonly result: TResult; readonly attempts: number }
-  | { readonly outcome: "exhausted"; readonly attempts: number }
+  | { readonly outcome: "exhausted"; readonly attempts: number; readonly finalFailure: TFailure }
   | { readonly outcome: "aborted"; readonly attempts: number };
 
 /**
@@ -124,7 +124,7 @@ export function buildProgressivePromptPreamble(opts: ProgressivePromptPreambleOp
  */
 export async function runRetryLoop<TFailure, TResult>(
   input: RetryInput<TFailure, TResult>,
-): Promise<RetryOutcome<TResult>> {
+): Promise<RetryOutcome<TFailure, TResult>> {
   let currentFailure = input.failure;
   const previous: RetryAttempt<TResult>[] = [...input.previousAttempts];
 
@@ -144,5 +144,5 @@ export async function runRetryLoop<TFailure, TResult>(
     }
   }
 
-  return { outcome: "exhausted", attempts: input.maxAttempts };
+  return { outcome: "exhausted", attempts: input.maxAttempts, finalFailure: currentFailure };
 }

--- a/test/unit/verification/retry-loop.test.ts
+++ b/test/unit/verification/retry-loop.test.ts
@@ -38,7 +38,7 @@ describe("runRetryLoop", () => {
     }
   });
 
-  test("returns exhausted outcome when verify never passes", async () => {
+  test("returns exhausted outcome with finalFailure when verify never passes", async () => {
     const input = makeInput({
       maxAttempts: 2,
       verify: async (_result) => ({ passed: false, newFailure: { message: "still failing" } }),
@@ -47,6 +47,7 @@ describe("runRetryLoop", () => {
     expect(outcome.outcome).toBe("exhausted");
     if (outcome.outcome === "exhausted") {
       expect(outcome.attempts).toBe(2);
+      expect(outcome.finalFailure).toEqual({ message: "still failing" });
     }
   });
 


### PR DESCRIPTION
## Summary

Fixes #741 — When `runRetryLoop` exhausts all retries and escalation is triggered, `rectification-loop.ts` was building the escalation prompt from `initialFailure.testSummary.failures` rather than the latest failure snapshot. If retries reduced or changed the failing test set, the escalated agent was asked to fix the wrong failures.

## Changes

- **`src/verification/shared-rectification-loop.ts`:**
  - Extended `RetryOutcome` from `RetryOutcome<TResult>` to `RetryOutcome<TFailure, TResult>`
  - Added `finalFailure: TFailure` to the exhausted outcome case
  - Returns `currentFailure` (the last updated failure snapshot) on exhaustion

- **`src/verification/rectification-loop.ts`:**
  - Escalation prompt now uses `outcome.finalFailure.testSummary.failures` instead of `initialFailure.testSummary.failures`
  - Escalation gate condition also uses `outcome.finalFailure.testSummary.failed > 0`

- **`src/pipeline/stages/autofix.ts`:**
  - Updated manual `{ outcome: "exhausted" }` returns in `.catch()` blocks to include `finalFailure: initialFailure` for type compatibility

- **`test/unit/verification/retry-loop.test.ts`:**
  - Updated exhausted outcome test to assert `finalFailure` equals the last `newFailure` returned by verify

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run build` ✅
- Full test suite: **8023 pass, 0 fail** ✅

## Related

- Issue: #741
- Design: Option 1 from issue — extend `RetryOutcome` to carry final failure snapshot