### PR TITLE
fix(adr-018): Wave 5 — remove process.cwd() from non-CLI code, tighten SessionRole, add lint guard

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,4 +13,7 @@ bun run typecheck
 echo "[pre-commit] Running lint..."
 bun run lint
 
+echo "[pre-commit] Running process.cwd() check..."
+bun run check:process-cwd
+
 echo "[pre-commit] OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        check: [typecheck, lint, check:test-mocks]
+        check: [typecheck, lint, check:test-mocks, check:process-cwd]
     steps:
       - uses: actions/checkout@v5
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "check-dead-tests": "bun run scripts/check-dead-tests.ts",
     "check:test-sizes": "bun run scripts/check-test-sizes.ts",
     "check:test-mocks": "bun scripts/check-inline-test-mocks.ts --strict",
+    "check:process-cwd": "bash scripts/check-process-cwd.sh",
     "prepublishOnly": "bun run build",
     "test:full": "FULL=1 NAX_PRECHECK=1 bun test test/ --timeout=60000"
   },

--- a/scripts/check-process-cwd.sh
+++ b/scripts/check-process-cwd.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Check for process.cwd() outside permitted CLI entry points.
+# Permitted: src/cli/*.ts, src/commands/*.ts, src/config/loader.ts
+
+set -euo pipefail
+
+VIOLATIONS=$(grep -rn 'process\.cwd()' src/ \
+  --include='*.ts' \
+  --exclude-dir='node_modules' \
+  | grep -v '^src/cli/' \
+  | grep -v '^src/commands/' \
+  | grep -v '^src/config/loader.ts:' \
+  || true)
+
+if [ -n "$VIOLATIONS" ]; then
+  echo "ERROR: process.cwd() found outside permitted paths (src/cli/*, src/commands/*, src/config/loader.ts):"
+  echo "$VIOLATIONS"
+  exit 1
+fi
+
+echo "OK: No process.cwd() violations found."

--- a/scripts/check-process-cwd.sh
+++ b/scripts/check-process-cwd.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Check for process.cwd() outside permitted CLI entry points.
 # Permitted: src/cli/*.ts, src/commands/*.ts, src/config/loader.ts
+#
+# NOTE: This is a temporary grep-based lint guard. Once Biome supports custom
+# lint rules via its plugin system (roadmap), migrate this to a native Biome
+# rule for editor integration, structured diagnostics, and potential autofix.
+# See: https://biomejs.dev/internals/language-support/
 
 set -euo pipefail
 

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -131,7 +131,7 @@ export const _acpAdapterDeps = {
    */
   createClient(
     cmdStr: string,
-    cwd?: string,
+    cwd: string,
     timeoutSeconds?: number,
     onPidSpawned?: (pid: number) => void,
     promptRetries?: number,
@@ -564,6 +564,9 @@ export class AcpAgentAdapter implements AgentAdapter {
     const timeoutMs = _options?.timeoutMs ?? 120_000;
     const permissionMode = _options?.resolvedPermissions?.mode ?? "approve-reads";
     const workdir = _options?.workdir;
+    if (!workdir) {
+      throw new Error("[acp-adapter] complete() requires workdir in options");
+    }
     // Resolve model for a given agent name
     const resolveModel = async (agentName: string): Promise<string> => {
       let model = _options?.model;
@@ -598,7 +601,7 @@ export class AcpAgentAdapter implements AgentAdapter {
       try {
         const completeSessionName =
           _options?.sessionName ??
-          computeAcpHandle(workdir ?? process.cwd(), _options?.featureName, _options?.storyId, _options?.sessionRole);
+          computeAcpHandle(workdir, _options?.featureName, _options?.storyId, _options?.sessionRole);
         session = await client.createSession({ agentName, permissionMode, sessionName: completeSessionName });
 
         let timeoutId: ReturnType<typeof setTimeout> | undefined;

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -392,7 +392,10 @@ export class SpawnAcpClient implements AcpClient {
     if (!lastToken || lastToken.startsWith("-")) {
       throw new Error(`[acp-adapter] Could not parse agentName from cmdStr: "${cmdStr}"`);
     }
-    this.cwd = cwd || process.cwd();
+    if (!cwd) {
+      throw new Error("[acp-adapter] SpawnAcpClient requires cwd");
+    }
+    this.cwd = cwd;
     this.timeoutSeconds = timeoutSeconds || 1800;
     this.promptRetries = promptRetries ?? 0;
     this.env = buildAllowedEnv();
@@ -515,7 +518,7 @@ export class SpawnAcpClient implements AcpClient {
  */
 export function createSpawnAcpClient(
   cmdStr: string,
-  cwd?: string,
+  cwd: string,
   timeoutSeconds?: number,
   onPidSpawned?: (pid: number) => void,
   promptRetries?: number,

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -110,7 +110,7 @@ export interface AgentRunOptions {
   /** Story ID for ACP session naming and logging */
   storyId?: string;
   /** Session role for TDD isolation (e.g. "test-writer" | "implementer" | "verifier") */
-  sessionRole?: string;
+  sessionRole?: import("../session/types").SessionRole;
   /** Max turns in multi-turn interaction loop when interactionBridge is active (default: 10) */
   maxInteractionTurns?: number;
   /** Pipeline stage this run belongs to — used by resolvePermissions() (default: "run") */

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -86,7 +86,7 @@ export const _planDeps = {
   runPrecheck: async (
     config: NaxConfig,
     prd: PRD,
-    opts?: { workdir: string; silent?: boolean },
+    opts: { workdir: string; silent?: boolean },
   ): Promise<PrecheckResultWithCode> => {
     const { runPrecheck } = await import("../precheck");
     return runPrecheck(config, prd, opts);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -53,6 +53,7 @@ export {
   debateConfigSelector,
   routingConfigSelector,
   verifyConfigSelector,
+  rectificationGateConfigSelector,
 } from "./selectors";
 export { createConfigLoader } from "./loader-runtime";
 export type { ConfigLoader } from "./loader-runtime";

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -24,3 +24,12 @@ export const verifyConfigSelector = reshapeSelector("verify", (c: NaxConfig) => 
   timeout: c.execution?.verificationTimeoutSeconds,
   testCommand: c.quality?.commands?.test,
 }));
+
+export const rectificationGateConfigSelector = pickSelector(
+  "rectification-gate",
+  "execution",
+  "models",
+  "agent",
+  "quality",
+  "review",
+);

--- a/src/execution/story-context.ts
+++ b/src/execution/story-context.ts
@@ -75,6 +75,7 @@ export async function maybeGetContext(
   story: UserStory,
   config: NaxConfig,
   useContext: boolean,
+  workdir: string,
 ): Promise<string | undefined> {
   if (!useContext) {
     return undefined;
@@ -82,7 +83,7 @@ export async function maybeGetContext(
 
   const logger = getSafeLogger();
   logger?.debug("context", "Building context...");
-  const contextMarkdown = await buildStoryContext(prd, story, config);
+  const contextMarkdown = await buildStoryContext(prd, story, config, workdir);
   if (contextMarkdown) {
     logger?.debug("context", "Context built successfully");
   }
@@ -97,12 +98,17 @@ export async function maybeGetContext(
  * @param config - Ngent config
  * @returns Context markdown or undefined if no context available
  */
-export async function buildStoryContext(prd: PRD, story: UserStory, _config: NaxConfig): Promise<string | undefined> {
+export async function buildStoryContext(
+  prd: PRD,
+  story: UserStory,
+  _config: NaxConfig,
+  workdir: string,
+): Promise<string | undefined> {
   try {
     const storyContext: StoryContext = {
       prd,
       currentStoryId: story.id,
-      workdir: process.cwd(),
+      workdir,
       config: _config,
     };
 
@@ -154,13 +160,14 @@ export async function buildStoryContextFull(
   prd: PRD,
   story: UserStory,
   config: NaxConfig,
+  workdir: string,
   packageWorkdir?: string,
 ): Promise<{ markdown: string; builtContext: BuiltContext } | undefined> {
   try {
     const storyContext: StoryContext = {
       prd,
       currentStoryId: story.id,
-      workdir: process.cwd(),
+      workdir,
       config,
     };
 
@@ -211,7 +218,7 @@ export function buildStoryContextFullFromCtx(
   ctx: PipelineContext,
 ): Promise<{ markdown: string; builtContext: BuiltContext } | undefined> {
   const packageWorkdir = ctx.story.workdir ? ctx.workdir : undefined;
-  return buildStoryContextFull(ctx.prd, ctx.story, ctx.config, packageWorkdir);
+  return buildStoryContextFull(ctx.prd, ctx.story, ctx.config, ctx.workdir, packageWorkdir);
 }
 
 /**

--- a/src/precheck/index.ts
+++ b/src/precheck/index.ts
@@ -234,11 +234,11 @@ export async function runEnvironmentPrecheck(
 export async function runPrecheck(
   config: NaxConfig,
   prd: PRD,
-  options?: PrecheckOptions,
+  options: PrecheckOptions,
 ): Promise<PrecheckResultWithCode> {
-  const workdir = options?.workdir || process.cwd();
-  const format = options?.format || "human";
-  const silent = options?.silent ?? false;
+  const workdir = options.workdir;
+  const format = options.format || "human";
+  const silent = options.silent ?? false;
 
   const passed: Check[] = [];
   const blockers: Check[] = [];

--- a/src/quality/command-resolver.ts
+++ b/src/quality/command-resolver.ts
@@ -58,7 +58,7 @@ export const _commandResolverDeps = {
  * @param storyWorkdir - story.workdir — set for monorepo stories, undefined for single-package
  */
 export async function resolveQualityTestCommands(
-  config: NaxConfig,
+  config: Pick<NaxConfig, "review" | "quality">,
   workdir: string,
   storyWorkdir?: string,
 ): Promise<ResolvedTestCommands> {

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -8,7 +8,9 @@
 
 import type { IAgentManager } from "../agents";
 import type { ModelTier, NaxConfig } from "../config";
-import { resolveModelForAgent } from "../config";
+import { type rectificationGateConfigSelector, resolveModelForAgent } from "../config";
+
+type RectificationGateConfig = ReturnType<typeof rectificationGateConfigSelector.select>;
 import type { getLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";

--- a/src/tui/hooks/usePty.ts
+++ b/src/tui/hooks/usePty.ts
@@ -16,7 +16,7 @@ export interface PtySpawnOptions {
   /** Command arguments */
   args?: string[];
   /** Working directory */
-  cwd?: string;
+  cwd: string;
   /** Environment variables */
   env?: Record<string, string>;
   /** Terminal columns (default: 80) */
@@ -97,7 +97,7 @@ export function usePty(options: PtySpawnOptions | null): PtyState & { handle: Pt
     // BUN-001: Replaced node-pty with Bun.spawn (piped stdio).
     // TERM + FORCE_COLOR preserve Claude Code output formatting.
     const proc = Bun.spawn([command, ...(JSON.parse(argsJson) || [])], {
-      cwd: cwd || process.cwd(),
+      cwd,
       env: { ...process.env, ...JSON.parse(envJson), TERM: "xterm-256color", FORCE_COLOR: "1" },
       stdin: "pipe",
       stdout: "pipe",

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -42,7 +42,7 @@ export interface PtySpawnOptions {
   /** Command arguments */
   args?: string[];
   /** Working directory */
-  cwd?: string;
+  cwd: string;
   /** Environment variables */
   env?: Record<string, string>;
   /** Terminal columns (default: 80) */

--- a/test/unit/agents/acp/adapter.test.ts
+++ b/test/unit/agents/acp/adapter.test.ts
@@ -175,7 +175,7 @@ describe("complete()", () => {
     });
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
-    const result = await new AcpAgentAdapter("claude").complete("What is the answer?");
+    const result = await new AcpAgentAdapter("claude").complete("What is the answer?", { workdir: ACP_WORKDIR });
     expect(result.output).toBe("The answer is 42.");
   });
 
@@ -193,7 +193,7 @@ describe("complete()", () => {
     });
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
-    await new AcpAgentAdapter("claude").complete("Explain recursion");
+    await new AcpAgentAdapter("claude").complete("Explain recursion", { workdir: ACP_WORKDIR });
     expect(received).toBe("Explain recursion");
   });
 
@@ -203,7 +203,7 @@ describe("complete()", () => {
     });
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
-    await expect(new AcpAgentAdapter("claude").complete("Hello")).rejects.toBeInstanceOf(CompleteError);
+    await expect(new AcpAgentAdapter("claude").complete("Hello", { workdir: ACP_WORKDIR })).rejects.toBeInstanceOf(CompleteError);
   });
 
   test("throws CompleteError when assistant output is blank", async () => {
@@ -216,7 +216,7 @@ describe("complete()", () => {
     });
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
-    await expect(new AcpAgentAdapter("claude").complete("Hello")).rejects.toBeInstanceOf(CompleteError);
+    await expect(new AcpAgentAdapter("claude").complete("Hello", { workdir: ACP_WORKDIR })).rejects.toBeInstanceOf(CompleteError);
   });
 
   test("closes the session after one-shot completion", async () => {
@@ -224,7 +224,7 @@ describe("complete()", () => {
     const session = makeSession({ closeFn: async () => { closeCalled = true; } });
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
-    await new AcpAgentAdapter("claude").complete("Quick question");
+    await new AcpAgentAdapter("claude").complete("Quick question", { workdir: ACP_WORKDIR });
     expect(closeCalled).toBe(true);
   });
 
@@ -235,7 +235,7 @@ describe("complete()", () => {
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
     await expect(
-      new AcpAgentAdapter("claude").complete("Hang?", { timeoutMs: 50 }),
+      new AcpAgentAdapter("claude").complete("Hang?", { timeoutMs: 50, workdir: ACP_WORKDIR }),
     ).rejects.toThrow(/timed out/i);
   });
 
@@ -245,7 +245,7 @@ describe("complete()", () => {
     });
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
-    const result = await new AcpAgentAdapter("claude").complete("Rate limited");
+    const result = await new AcpAgentAdapter("claude").complete("Rate limited", { workdir: ACP_WORKDIR });
     expect(result.adapterFailure).toBeDefined();
     expect(result.adapterFailure?.outcome).toBe("fail-rate-limit");
     expect(result.adapterFailure?.category).toBe("availability");
@@ -259,7 +259,7 @@ describe("complete()", () => {
     _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
 
     await expect(
-      new AcpAgentAdapter("claude").complete("Unknown fail"),
+      new AcpAgentAdapter("claude").complete("Unknown fail", { workdir: ACP_WORKDIR }),
     ).rejects.toThrow(/unexpected internal error/);
   });
 });
@@ -294,7 +294,7 @@ describe("complete() — model resolution", () => {
       return client as unknown as ReturnType<typeof _acpAdapterDeps.createClient>;
     });
 
-    await new AcpAgentAdapter("claude").complete("test");
+    await new AcpAgentAdapter("claude").complete("test", { workdir: ACP_WORKDIR });
     expect(capturedCmd).toContain("--model default");
   });
 
@@ -306,7 +306,7 @@ describe("complete() — model resolution", () => {
       return client as unknown as ReturnType<typeof _acpAdapterDeps.createClient>;
     });
 
-    await new AcpAgentAdapter("claude").complete("test", { model: "claude-haiku-4-5" });
+    await new AcpAgentAdapter("claude").complete("test", { model: "claude-haiku-4-5", workdir: ACP_WORKDIR });
     expect(capturedCmd).toContain("--model claude-haiku-4-5");
   });
 
@@ -323,7 +323,7 @@ agent: { default: "claude" },
       models: { claude: { fast: "claude-haiku-4-5-20250514", balanced: "claude-sonnet-4-5-20250514" } },
     } as unknown as Parameters<AcpAgentAdapter["complete"]>[1]["config"];
 
-    await new AcpAgentAdapter("claude").complete("test", { modelTier: "fast", config: naxConfig });
+    await new AcpAgentAdapter("claude").complete("test", { modelTier: "fast", config: naxConfig, workdir: ACP_WORKDIR });
     expect(capturedCmd).toContain("--model claude-haiku-4-5-20250514");
   });
 
@@ -337,7 +337,7 @@ agent: { default: "claude" },
 
     const naxConfig = { agent: { default: "claude" }, models: {} } as unknown as Parameters<AcpAgentAdapter["complete"]>[1]["config"];
 
-    await new AcpAgentAdapter("claude").complete("test", { modelTier: "powerful", config: naxConfig });
+    await new AcpAgentAdapter("claude").complete("test", { modelTier: "powerful", config: naxConfig, workdir: ACP_WORKDIR });
     expect(capturedCmd).toContain("--model default");
   });
 });

--- a/test/unit/execution/story-context.test.ts
+++ b/test/unit/execution/story-context.test.ts
@@ -61,7 +61,7 @@ describe("buildStoryContextFull — package context loading (MW-003)", () => {
   test("returns result without package context when no packageWorkdir", async () => {
     const story = makeStory();
     const prd = makePrd(story);
-    const result = await buildStoryContextFull(prd, story, makeConfig());
+    const result = await buildStoryContextFull(prd, story, makeConfig(), tmpDir);
     // PRD context contains story elements — result is defined
     expect(result).not.toBeUndefined();
     expect(result?.markdown).not.toContain("---");
@@ -73,7 +73,7 @@ describe("buildStoryContextFull — package context loading (MW-003)", () => {
 
     const story = makeStory();
     const prd = makePrd(story);
-    const result = await buildStoryContextFull(prd, story, makeConfig(), tmpDir);
+    const result = await buildStoryContextFull(prd, story, makeConfig(), tmpDir, tmpDir);
 
     // Should include the package context.md content
     expect(result).not.toBeUndefined();
@@ -85,7 +85,7 @@ describe("buildStoryContextFull — package context loading (MW-003)", () => {
     // tmpDir has no nax/context.md
     const story = makeStory();
     const prd = makePrd(story);
-    const result = await buildStoryContextFull(prd, story, makeConfig(), tmpDir);
+    const result = await buildStoryContextFull(prd, story, makeConfig(), tmpDir, tmpDir);
     // PRD context still present, but no package section appended
     expect(result).not.toBeUndefined();
     expect(result?.markdown).not.toContain("---");
@@ -96,7 +96,7 @@ describe("buildStoryContextFull — package context loading (MW-003)", () => {
 
     const story = makeStory();
     const prd = makePrd(story);
-    const result = await buildStoryContextFull(prd, story, makeConfig(), tmpDir);
+    const result = await buildStoryContextFull(prd, story, makeConfig(), tmpDir, tmpDir);
 
     expect(result?.markdown).toContain("---");
     expect(result?.markdown).toContain("# Package Context");


### PR DESCRIPTION
Closes #693, closes #533, closes #534, closes #535, closes #536

## Summary
- Remove \+process.cwd()\+ fallback from core non-CLI modules; make \+workdir\+/\+cwd\+ required where it was previously optional.
- Tighten \+AgentRunOptions.sessionRole\+ from `string` to `SessionRole` type.
- Update unit tests to pass required `workdir` parameters.
- Add `scripts/check-process-cwd.sh` lint guard and integrate into CI + pre-commit hook.

## Verification
- `bun run typecheck` passes
- `bun run lint` passes
- `bun run test` passes (6832 unit + 1180 integration + 11 UI, 0 failures)
- `bun run build` passes
- `bun run check:process-cwd` passes