### PR TITLE
refactor(config): migrate rectification-gate to RectificationGateConfig selector

### DIFF
--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -9,8 +9,6 @@
 import type { IAgentManager } from "../agents";
 import type { ModelTier, NaxConfig } from "../config";
 import { type rectificationGateConfigSelector, resolveModelForAgent } from "../config";
-
-type RectificationGateConfig = ReturnType<typeof rectificationGateConfigSelector.select>;
 import type { getLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
@@ -28,6 +26,8 @@ import {
 import { buildFailureRecords } from "../verification/failure-records";
 import { cleanupProcessTree } from "./cleanup";
 import { verifyImplementerIsolation } from "./isolation";
+
+type RectificationGateConfig = ReturnType<typeof rectificationGateConfigSelector.select>;
 
 /** Failure snapshot for the TDD rectification gate retry loop. */
 interface TddRectificationFailure {
@@ -80,7 +80,7 @@ async function getStoryChangedFiles(workdir: string, fromRef: string): Promise<R
  */
 export async function runFullSuiteGate(
   story: UserStory,
-  config: NaxConfig,
+  config: RectificationGateConfig,
   workdir: string,
   agentManager: IAgentManager,
   implementerTier: ModelTier,
@@ -219,14 +219,14 @@ export async function runFullSuiteGate(
 /** Run the rectification retry loop when full suite gate detects regressions. */
 async function runRectificationLoop(
   story: UserStory,
-  config: NaxConfig,
+  config: RectificationGateConfig,
   workdir: string,
   agentManager: IAgentManager,
   implementerTier: ModelTier,
   lite: boolean,
   logger: ReturnType<typeof getLogger>,
   testSummary: ReturnType<typeof _parseTestOutput>,
-  rectificationConfig: NonNullable<NaxConfig["execution"]["rectification"]>,
+  rectificationConfig: NonNullable<RectificationGateConfig["execution"]["rectification"]>,
   testCmd: string,
   fullSuiteTimeout: number,
   testOutput: string,
@@ -292,7 +292,9 @@ async function runRectificationLoop(
           ),
           timeoutSeconds: config.execution.sessionTimeoutSeconds,
           pipelineStage: "rectification",
-          config,
+          // Cast required: AgentRunOptions.config expects NaxConfig, but only the picked
+          // subset of keys is actually used by the adapter (permissions, models, agent).
+          config: config as unknown as NaxConfig,
           projectDir,
           maxInteractionTurns: config.agent?.maxInteractionTurns,
           featureName,


### PR DESCRIPTION
## Summary

- Replaces `config: NaxConfig` with `config: RectificationGateConfig` on `runFullSuiteGate` and `runRectificationLoop`
- Updates the `rectificationConfig` type annotation for consistency (`NaxConfig["execution"]` → `RectificationGateConfig["execution"]`)
- Adds a cast at the `agentManager.run()` boundary with an explanatory comment (the only site that hard-requires `NaxConfig` per `AgentRunOptions`)

`RectificationGateConfig` was introduced in the base branch (Wave 5 commit) as `rectificationGateConfigSelector = pickSelector("rectification-gate", "execution", "models", "agent", "quality", "review")`. This PR wires it up to the actual function signatures.

Part of #745.

## Why this cast is safe

`AgentRunOptions.config: NaxConfig` is required by the adapter for `resolvePermissions()` (reads `execution.permissionProfile`) and model resolution (reads `models`). Both keys are in the picked set, so the cast holds at runtime. The comment at the cast site documents this explicitly.

## Test plan

- [ ] `bun run typecheck` — clean (enforced by pre-commit hook)
- [ ] `bun run lint` — clean (enforced by pre-commit hook)
- [ ] `timeout 60 bun test test/unit/tdd/ --timeout=10000` — 24 pass, 0 fail
- [ ] `timeout 30 bun test test/unit/quality/ --timeout=10000` — 21 pass, 0 fail