### PR TITLE
feat(runtime): close() should use Promise.allSettled for flush + drain

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -128,8 +128,12 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
       if (closed) return;
       closed = true;
       controller.abort();
-      await promptAuditor.flush();
-      await costAggregator.drain();
+      const results = await Promise.allSettled([promptAuditor.flush(), costAggregator.drain()]);
+      for (const r of results) {
+        if (r.status === "rejected") {
+          logger.warn("runtime", "close() flush/drain error", { error: String(r.reason) });
+        }
+      }
     },
   };
 }

--- a/test/unit/runtime/runtime.test.ts
+++ b/test/unit/runtime/runtime.test.ts
@@ -94,6 +94,93 @@ describe("createRuntime", () => {
     const rt = createRuntime(config, "/tmp/test");
     expect(rt.promptAuditor).toBeDefined();
   });
+
+  test("close() resolves when flush() throws", async () => {
+    const flushError = new Error("flush failed");
+    const promptAuditor = {
+      record() {},
+      recordError() {},
+      async flush() { throw flushError; },
+    };
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test", { promptAuditor });
+    await expect(rt.close()).resolves.toBeUndefined();
+  });
+
+  test("close() resolves when drain() throws", async () => {
+    const drainError = new Error("drain failed");
+    const costAggregator = {
+      record() {},
+      recordError() {},
+      snapshot() { return { totalCostUsd: 0, totalInputTokens: 0, totalOutputTokens: 0, callCount: 0, errorCount: 0 }; },
+      byAgent() { return {}; },
+      byStage() { return {}; },
+      byStory() { return {}; },
+      async drain() { throw drainError; },
+    };
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test", { costAggregator });
+    await expect(rt.close()).resolves.toBeUndefined();
+  });
+
+  test("close() resolves when both flush() and drain() throw", async () => {
+    const promptAuditor = {
+      record() {},
+      recordError() {},
+      async flush() { throw new Error("flush failed"); },
+    };
+    const costAggregator = {
+      record() {},
+      recordError() {},
+      snapshot() { return { totalCostUsd: 0, totalInputTokens: 0, totalOutputTokens: 0, callCount: 0, errorCount: 0 }; },
+      byAgent() { return {}; },
+      byStage() { return {}; },
+      byStory() { return {}; },
+      async drain() { throw new Error("drain failed"); },
+    };
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test", { promptAuditor, costAggregator });
+    await expect(rt.close()).resolves.toBeUndefined();
+  });
+
+  test("close() calls drain() even when flush() throws", async () => {
+    let drainCalled = false;
+    const promptAuditor = {
+      record() {},
+      recordError() {},
+      async flush() { throw new Error("flush failed"); },
+    };
+    const costAggregator = {
+      record() {},
+      recordError() {},
+      snapshot() { return { totalCostUsd: 0, totalInputTokens: 0, totalOutputTokens: 0, callCount: 0, errorCount: 0 }; },
+      byAgent() { return {}; },
+      byStage() { return {}; },
+      byStory() { return {}; },
+      async drain() { drainCalled = true; },
+    };
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test", { promptAuditor, costAggregator });
+    await rt.close();
+    expect(drainCalled).toBe(true);
+  });
+
+  test("close() calls flush() even when drain() throws", async () => {
+    let flushCalled = false;
+    const promptAuditor = {
+      record() {},
+      recordError() {},
+      async flush() { flushCalled = true; },
+    };
+    const costAggregator = {
+      record() {},
+      recordError() {},
+      snapshot() { return { totalCostUsd: 0, totalInputTokens: 0, totalOutputTokens: 0, callCount: 0, errorCount: 0 }; },
+      byAgent() { return {}; },
+      byStage() { return {}; },
+      byStory() { return {}; },
+      async drain() { throw new Error("drain failed"); },
+    };
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test", { promptAuditor, costAggregator });
+    await rt.close();
+    expect(flushCalled).toBe(true);
+  });
 });
 
 describe("makeTestRuntime", () => {


### PR DESCRIPTION
## Summary
- Fixes #698
- Changes `NaxRuntime.close()` to run `promptAuditor.flush()` and `costAggregator.drain()` concurrently via `Promise.allSettled`
- If one operation fails, the other still completes; rejections are logged via `logger.warn()`
- Adds 5 unit tests covering failure isolation for both operations

## Test Plan
- [x] `bun test ./test/unit/runtime/runtime.test.ts` — 19 pass, 0 fail
- [x] `bun run test` — full suite: 8,028 pass, 0 fail
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean