### PR TITLE
fix(adr-019): route callOp kind:"run" through runWithFallback + buildHopCallback

### DIFF
--- a/docs/findings/2026-04-27-adr-018-019-runtime-layering-review-synthesis.md
+++ b/docs/findings/2026-04-27-adr-018-019-runtime-layering-review-synthesis.md
@@ -1,0 +1,212 @@
+# Review (Synthesis): ADR-018 Runtime Layering + ADR-019 Session Ownership Exit Criteria
+
+**Date:** 2026-04-27
+**Project under test:** `@nathapp/nax`
+**Scope:** [docs/adr/ADR-018-runtime-layering-with-session-runners.md](../adr/ADR-018-runtime-layering-with-session-runners.md), [docs/adr/ADR-019-adapter-primitives-and-session-ownership.md](../adr/ADR-019-adapter-primitives-and-session-ownership.md)
+**Related issues:** #688, #689, #690, #691, #692, #693, #706
+**Prior review:** [2026-04-27-adr-018-019-runtime-layering-review.md](./2026-04-27-adr-018-019-runtime-layering-review.md)
+**Status:** Implementation is test-green (`bun run typecheck`/`lint`/`test` all pass). Several exit criteria are **not** met.
+
+This document confirms the prior agent's four findings, and adds **five** further mismatches between the live code, ADR-018 §Wave 2/3, and ADR-019 §5.
+
+---
+
+## Confirmed prior findings
+
+The previous reviewer's evidence pointers were verified line-for-line. Summary, with my corroboration:
+
+| # | Finding | Severity | Verified? |
+|:--|:--|:--|:--|
+| 1 | `callOp()` for `kind:"run"` calls [`sessionManager.runInSession`](../../src/session/manager.ts#L552-L597) directly instead of `agentManager.runWithFallback` + `buildHopCallback` (ADR-019 §5) | **High** | ✔ — see [src/operations/call.ts:38-58](../../src/operations/call.ts#L38-L58); ADR-019 sketch is at [ADR-019 §5 lines 442-471](../adr/ADR-019-adapter-primitives-and-session-ownership.md#L442-L471) |
+| 2 | `keepOpen:` / `sessionHandle:` retirement still has live call paths in `src/review/`, `src/verification/`, `src/tdd/`, `src/pipeline/stages/autofix.ts` | **High** | ✔ — [src/review/semantic.ts:548,586](../../src/review/semantic.ts#L548), [src/review/adversarial.ts:318,359](../../src/review/adversarial.ts#L318), [src/verification/rectification-loop.ts:296](../../src/verification/rectification-loop.ts#L296), [src/tdd/rectification-gate.ts:303](../../src/tdd/rectification-gate.ts#L303), [src/tdd/session-runner.ts:211](../../src/tdd/session-runner.ts#L211), [src/pipeline/stages/autofix.ts:558](../../src/pipeline/stages/autofix.ts#L558), [src/pipeline/stages/autofix-adversarial.ts:138](../../src/pipeline/stages/autofix-adversarial.ts#L138). Tracking-doc claim "Zero `keepOpen: true` / `sessionHandle:` usages in `src/`" at [phase-e plan line 1887](../superpowers/plans/2026-04-26-adr-018-wave-3-phase-e.md#L1887) is incorrect. |
+| 3 | `buildHopCallback()` flattens every `runAsSession` failure into `availability/fail-adapter-error`, dropping `SessionFailureError` typed-failure routing | **Medium** | ✔ — compare [src/operations/build-hop-callback.ts:163-181](../../src/operations/build-hop-callback.ts#L163-L181) (always emits `availability/fail-adapter-error`) with [src/runtime/session-run-hop.ts:67-82](../../src/runtime/session-run-hop.ts#L67-L82) (preserves `SessionFailureError.adapterFailure` and rate-limit detection) |
+| 4 | Semantic-review debate uses unsafe placeholder `sessionManager` and `signal` while [src/debate/types.ts:11,14](../../src/debate/types.ts#L11) still admits `sessionMode:"stateful"` and `mode:"hybrid"` for the review stage | **Medium** | ✔ — see synthetic runtime in [src/review/semantic.ts:316,331](../../src/review/semantic.ts#L316-L331). No runtime guard rejects stateful/hybrid review. |
+
+The ADR-018 / ADR-019 picture below is the prior review with these four points incorporated; the additions in §New findings are mine.
+
+---
+
+## New findings
+
+### Finding 5 — `callOp` run-path bypasses the Wave-2 middleware chain
+
+**Severity:** High
+
+**Summary**
+
+ADR-018 §3 and Gap-5 (Resolution G) make the middleware chain (`audit`, `cost`, `cancellation`, `logging`) the structural backbone for observability:
+
+> **Session-internal calls covered by construction** — ADR-013 Phase 5 locked down direct adapter calls; everything flows through `IAgentManager`. `SessionManager.runInSession(id, manager, req)` therefore passes through the same middleware chain.
+> — [docs/adr/ADR-018-gap-review.md:303-306](../adr/ADR-018-gap-review.md#L303-L306)
+
+This is no longer true for `kind:"run"` ops dispatched through `callOp`.
+
+**Evidence**
+
+- Middleware is wired into the `AgentManager` only — see [src/runtime/index.ts:83-107](../../src/runtime/index.ts#L83-L107). The chain is passed to `createAgentManager`, never to `sessionManager`.
+- `callOp` for `kind:"run"` calls `sessionManager.runInSession(name, prompt, opts)` (the **Phase B prompt form**, [src/session/manager.ts:558-595](../../src/session/manager.ts#L558-L595)).
+- That overload calls `sessionManager.sendPrompt(handle, prompt, …)` → `adapter.sendTurn(...)` directly. Grep `src/session/manager.ts` for `middleware` — zero hits.
+- Compare with `agentManager.runAsSession(...)` in [src/agents/manager.ts:440-472](../../src/agents/manager.ts#L440-L472), where `runBefore` / `runAfter` / `runOnError` are explicitly invoked around the dispatch.
+
+**Why it matters**
+
+Every `kind:"run"` op currently shipped — `acceptance-fix`, `acceptance-fix-tests`, `acceptance-diagnose`, `semantic-review` (run-form callers), `adversarial-review` (run-form callers), `rectify` — silently misses:
+
+- **Audit** — no entry written to `.nax/audit/<runId>.jsonl` for these calls. Wave-2 exit criterion "PromptAuditor flushes to `.nax/audit/<runId>.jsonl` on `runtime.close()`" still flushes, but the run-op records never enter the buffer in the first place.
+- **Cost** — `CostAggregator.snapshot()` will not reflect these calls. Wave-2 exit criterion "CostAggregator.snapshot() reflects all calls including nested and session-internal calls" is **false** for callOp run-path ops.
+- **Budget enforcement** — the budget middleware (Wave 2 §6 OQ resolution) cannot abort these calls.
+- **Cancellation guard** — the `cancellation` middleware that checks `signal.aborted` before terminal dispatch is skipped.
+- **Logging** — structured per-call log entries are skipped.
+
+This couples to Finding 1: even fixing `callOp` to use `runWithFallback` + `buildHopCallback` is not enough on its own — `buildHopCallback` itself uses `agentManager.runAsSession` ([src/operations/build-hop-callback.ts:155](../../src/operations/build-hop-callback.ts#L155)), which DOES traverse the middleware chain. So fixing Finding 1 transitively fixes Finding 5. They are the same root cause: `callOp` route divergence from ADR-019 §5.
+
+**Recommended follow-up**
+
+Roll into the Finding 1 remediation. After `callOp` routes through `runWithFallback` + `buildHopCallback`, add a regression test that asserts:
+
+1. `auditMiddleware` writes one entry per `kind:"run"` `callOp` call.
+2. `costAggregator.snapshot()` totals match the sum of all `callOp(... kind:"run" ...)` results.
+
+Without these, the middleware chain can silently drift again.
+
+---
+
+### Finding 6 — `noFallback` flag on `RunOperation` is dead at runtime
+
+**Severity:** Medium
+
+**Summary**
+
+[src/operations/types.ts:54](../../src/operations/types.ts#L54) declares `readonly noFallback?: boolean` on `RunOperation<I,O,C>`. ADR-018 §5.3 ("TDD orchestrator") explicitly relies on this flag:
+
+> TDD ops set `noFallback: true` when invoking `callOp` (via `sessionOverride` or a dedicated field on input) so `SingleSessionRunner` wraps the adapter without fallback. Preserves today's `fallbacks: []` invariant at the type level.
+
+**Evidence**
+
+- The flag is declared but never read by `callOp` — `rtk grep -n "noFallback" src/operations/call.ts` returns nothing.
+- Today the question is moot: `callOp` calls `runInSession` directly, so no fallback can occur regardless. But once Finding 1 is fixed, the flag must be honored — otherwise TDD ops migrated through `callOp` would silently start participating in cross-agent fallback, regressing the established `fallbacks: []` invariant.
+
+**Why it matters**
+
+This is a latent regression: it is harmless today only because Finding 1 makes the fallback path unreachable from `callOp`. As soon as Finding 1 is corrected, TDD ops will gain unintended fallback behavior unless `callOp` branches on `op.noFallback`.
+
+**Recommended follow-up**
+
+Bundle with the Finding 1 fix: when `callOp` constructs the `runWithFallback` request, branch on `op.noFallback` to either pass the AgentManager or wrap the adapter with `wrapAdapterAsManager(...)` (mirroring ADR-018 §5.2's sketch). Add a test that confirms `noFallback:true` ops produce zero fallback hops even when an availability failure is injected on the primary agent.
+
+---
+
+### Finding 7 — `AgentAdapter` surface still exceeds the ADR-019 Phase D goal
+
+**Severity:** Low
+
+**Summary**
+
+ADR-019 Phase D ([issue #706](https://github.com/nathapp-io/nax/issues/706)) and the issue's exit criteria say the adapter surface becomes `{ openSession, sendTurn, closeSession, complete, plan, decompose }`, with `plan`/`decompose` removed in Wave 3.5. After Wave 3.5 the steady-state target should be **four** methods.
+
+In [src/agents/types.ts:365-442](../../src/agents/types.ts#L365-L442) the live shape carries:
+
+- `openSession`, `sendTurn`, `closeSession(handle)` — new (good)
+- `complete` — kept (good)
+- `closePhysicalSession(handle, workdir, options?)` — old form, marked "replaced by closeSession" but still present
+- `deriveSessionName(descriptor)` — used by pipeline stages to derive ACP names (peer to `SessionManager.nameFor`)
+- optional `runInteractive` (TUI PTY mode) — orthogonal, fine
+
+**Why it matters**
+
+Two callers of `closePhysicalSession` remain (semantic.ts and adversarial.ts) — the same call sites flagged in Finding 2. `deriveSessionName` is invoked from a handful of pipeline stages and duplicates `SessionManager.nameFor`. Until both are excised, the adapter surface still publishes session-naming and session-closing concerns that ADR-019 says belong on `SessionManager`.
+
+**Recommended follow-up**
+
+After Finding 2 is resolved (review subsystem migrated to caller-managed `openSession + runAsSession + closeSession`), `closePhysicalSession` becomes deletable. `deriveSessionName` deletion is a separate small refactor — convert callers to `SessionManager.nameFor`.
+
+---
+
+### Finding 8 — ADR-019 "zero cross-imports" exit criterion is not strictly met
+
+**Severity:** Low
+
+**Summary**
+
+[Issue #706](https://github.com/nathapp-io/nax/issues/706) lists "AgentManager and SessionManager have zero cross-imports (peer relationship)" as an exit criterion.
+
+The runtime `src/agents/manager.ts` and `src/session/manager.ts` files are clean of each other. But the surrounding modules in each tree do cross:
+
+- [src/agents/types.ts:13](../../src/agents/types.ts#L13) — `import type { ProtocolIds, SessionDescriptor } from "../session/types"` (load-bearing in `AgentRunOptions`)
+- [src/agents/acp/adapter.ts:22](../../src/agents/acp/adapter.ts#L22) — `import type { ProtocolIds } from "../../session/types"`
+- [src/agents/utils.ts:5](../../src/agents/utils.ts#L5) — `import { formatSessionName } from "../session/naming"` (value import)
+- [src/session/manager.ts:13-14](../../src/session/manager.ts#L13-L14) — `import { NO_OP_INTERACTION_HANDLER } from "../agents"` and `import type { AgentAdapter, AgentResult, SessionHandle, TurnResult } from "..."`
+
+**Why it matters**
+
+The interpretation of "cross-imports" is the deciding factor. If "module-tree" is the unit, the exit criterion is met (manager-to-manager is clean). If "subsystem barrel" is the unit, it is not — `agents/utils.ts` imports a session **value** (`formatSessionName`) and `session/manager.ts` imports an `agents` value (`NO_OP_INTERACTION_HANDLER`). The pure-type imports of `ProtocolIds` / `SessionDescriptor` from `session/types` into `agents/types` are also a structural coupling: any change to `SessionDescriptor` ripples into the `AgentRunOptions` type contract.
+
+**Recommended follow-up**
+
+Either (a) move the small set of shared types (`SessionDescriptor`, `ProtocolIds`, `SessionHandle`, `TurnResult`) into a neutral package — e.g. `src/agents-session/` or `src/runtime/protocol-types.ts` — so neither tree depends on the other, or (b) narrow the wording in the issue's exit criterion to "no value-level cross-import in the manager call paths" and document the type-only links as expected.
+
+---
+
+### Finding 9 — `_deps.createManager` survives outside `src/runtime/`
+
+**Severity:** Low
+
+**Summary**
+
+ADR-018 Wave 3.5 exit criterion ([issue #691](https://github.com/nathapp-io/nax/issues/691)) says:
+
+> Zero `_deps.createManager` references outside `src/runtime/`
+
+Live code:
+
+- [src/cli/plan.ts:64](../../src/cli/plan.ts#L64) — `createManager: createAgentManager` inside `_planDeps`, used at lines 201, 248, 304, 590.
+
+**Why it matters**
+
+`src/cli/plan.ts` is a CLI entry point and a legitimate place to construct a manager directly today; the code itself is reasonable. The literal exit-criterion claim is what is incorrect. Either the CLI path warrants an explicit carve-out in the exit criterion, or `nax plan` should be migrated to construct via `createRuntime()` like the runner does.
+
+**Recommended follow-up**
+
+Pick one of:
+
+1. Migrate `src/cli/plan.ts` to construct a runtime via `createRuntime()` (consistent with the rest of the CLI surface that no longer constructs managers).
+2. Update the wording in the Wave-3.5 exit criterion to "outside `src/runtime/` and `src/cli/`" and document the carve-out.
+
+---
+
+## Overall exit-criteria assessment (synthesis)
+
+### Met
+
+- Wave 3.5 adapter `plan` / `decompose` deletion landed (no `planAs` / `decomposeAs` in `src/`)
+- `DebateRunner` exists; old `DebateSession` entrypoint is gone; `runner-stateful.ts` / `runner-hybrid.ts` / `runner-plan.ts` use the new `openSession + runAsSession + closeSession` lifecycle
+- `dialogue.ts` migration to caller-managed sessions is complete
+- Wave 4 retry-loop unification (`RetryInput<TFailure,TResult>`) shipped
+- Wave 5 `process.cwd()` audit complete — no non-CLI/non-`config/loader.ts` usages
+- Wave 5 `SessionRole` template-literal tightening shipped (`debate-${string}`, `plan-hybrid-${number}`)
+- `ISessionRunner` and `SingleSessionRunner` deletion complete (Phase C)
+- `bun run typecheck`, `bun run lint`, `bun run test` all green
+
+### Not fully met
+
+- **Finding 1 (ADR-019 §5):** `callOp` run-path does not use `runWithFallback` + `buildHopCallback`. Architectural target unmet.
+- **Finding 5 (Wave 2 §3 + Gap-5 G):** Middleware chain bypassed for `kind:"run"` ops dispatched via `callOp`. CostAggregator and PromptAuditor are not "all-call complete" as the Wave-2 exit criterion claims.
+- **Finding 2 (Phase D / phase-e plan):** `keepOpen:` / `sessionHandle:` migration incomplete. Tracking-doc claim is wrong.
+- **Finding 3 (regression risk in fallback policy):** `buildHopCallback` flattens typed failures — fallback policy will misclassify under load.
+- **Finding 4 (review-debate config surface):** `sessionMode: "stateful"` / `mode: "hybrid"` accepted by the config surface but unsafe in the review-stage debate path.
+- **Finding 6 (latent regression):** `op.noFallback` declared but unread; will silently regress TDD invariant once Finding 1 is fixed.
+- **Finding 7 (Phase D adapter surface):** `closePhysicalSession` and `deriveSessionName` outlive their replacements.
+- **Finding 8 (#706 exit criterion):** "Zero cross-imports" between AgentManager and SessionManager is met at the manager level but not at the subsystem level (type-only and small value imports remain).
+- **Finding 9 (Wave 3.5 exit criterion):** `_deps.createManager` survives in `src/cli/plan.ts`.
+
+---
+
+## Suggested next steps
+
+1. **Triage Findings 1+5+6 as one work item.** They are the same root cause (callOp run-path divergence from ADR-019 §5) with three observable symptoms: bypassed middleware, missing fallback, and dead `noFallback`. Fixing `callOp` to use `runWithFallback` + `buildHopCallback` resolves all three simultaneously. Add structural tests so the boundary cannot drift again.
+2. **Decide on Finding 2.** Either complete the migration of the five remaining `keepOpen` / `sessionHandle` call sites in `src/review/`, `src/verification/`, `src/tdd/`, `src/pipeline/stages/autofix.ts`, or amend the Wave-3 phase-e tracking doc to remove the "zero usages" claim. Right now code and docs disagree.
+3. **Fix Finding 3 in `buildHopCallback`.** Mirror `session-run-hop.ts`'s `SessionFailureError` handling so typed failures (rate-limit, availability, etc.) survive into the swap-policy decision.
+4. **Decide Finding 4.** Either restrict review-stage debate at config validation time to `oneshot` / `panel`, or thread a real `sessionManager` + `signal` through the semantic-review debate path. The current synthetic-runtime placeholder is unsafe under hybrid/stateful review.
+5. **Cleanup pass.** Findings 7, 8, 9 are individually small but together they make the "we shipped ADR-018+019" story honest. Either land the deletions or update the exit-criteria wording to match what shipped.
+
+The implementation as a whole is in good shape — the bones are correct (DebateRunner, retry-loop unification, SingleSessionRunner deletion, Wave-5 lint guards) — but several exit criteria are claimed-met when they are not, and Findings 1+5+6 are real architectural debt that gates the soundness of the runtime model going forward.

--- a/docs/findings/2026-04-27-adr-018-019-runtime-layering-review.md
+++ b/docs/findings/2026-04-27-adr-018-019-runtime-layering-review.md
@@ -1,0 +1,197 @@
+# Review: ADR-018 Runtime Layering + ADR-019 Session Ownership Exit Criteria
+
+**Date:** 2026-04-27
+**Project under test:** `@nathapp/nax`
+**Scope:** `docs/adr/ADR-018-runtime-layering-with-session-runners.md`, `docs/adr/ADR-019-adapter-primitives-and-session-ownership.md`
+**Related issues:** #688, #689, #690, #691, #692, #693, #706
+**Status:** Reviewed — implementation is test-green, but exit criteria are only partially met
+
+`bun run typecheck`, `bun run lint`, and the full `bun run test` suite passed during this review. The findings below are therefore not "red test" failures; they are implementation-vs-ADR / implementation-vs-exit-criteria mismatches.
+
+---
+
+## Finding 1 — `callOp()` run-ops do not follow the ADR-019 ownership boundary
+
+### Severity
+
+High
+
+### Summary
+
+The shipped `callOp()` implementation for `kind: "run"` does not construct `buildHopCallback()` and does not route through `agentManager.runWithFallback(...)`. Instead, it calls `sessionManager.runInSession(...)` directly.
+
+That differs from the accepted ADR-019 design, which states that:
+
+- `callOp` should build `buildHopCallback`
+- `runWithFallback` should remain the fallback-chain owner
+- the callback should own rebuild + open + handoff + dispatch per hop
+
+### Evidence
+
+Current implementation:
+
+- [src/operations/call.ts:38-58](../../src/operations/call.ts#L38-L58)
+
+ADR-019 target:
+
+- [docs/adr/ADR-019-adapter-primitives-and-session-ownership.md:474-478](../adr/ADR-019-adapter-primitives-and-session-ownership.md#L474-L478)
+
+Wave 3 tracking claim:
+
+- [docs/superpowers/plans/2026-04-26-adr-018-wave-3.md:277-279](../superpowers/plans/2026-04-26-adr-018-wave-3.md#L277-L279)
+
+### Why it matters
+
+This means the run-ops introduced by ADR-018 Wave 3 do not inherit the documented fallback/context-rebuild path "by construction". The architecture described in ADR-019 is not what `callOp()` currently does.
+
+### Recommended follow-up
+
+Refactor `callOp()` run-paths to:
+
+1. Build the prompt
+2. Construct `buildHopCallback(...)`
+3. Call `agentManager.runWithFallback({ ..., executeHop })`
+4. Parse the final `AgentResult.output`
+
+That brings the implementation back in line with ADR-019 and the Wave 3 exit-criteria wording.
+
+---
+
+## Finding 2 — `keepOpen` / `sessionHandle` retirement is incomplete
+
+### Severity
+
+High
+
+### Summary
+
+The tracking docs mark "zero `keepOpen: true` / `sessionHandle:` usages in `src/`" as completed, but the repository still contains several live `keepOpen` call paths.
+
+### Evidence
+
+Exit criteria marked complete:
+
+- [docs/superpowers/plans/2026-04-26-adr-018-wave-3.md:198-205](../superpowers/plans/2026-04-26-adr-018-wave-3.md#L198-L205)
+- [docs/superpowers/plans/2026-04-26-adr-018-wave-3-phase-e.md:1887-1899](../superpowers/plans/2026-04-26-adr-018-wave-3-phase-e.md#L1887-L1899)
+
+Remaining code paths:
+
+- [src/review/semantic.ts:545-604](../../src/review/semantic.ts#L545-L604)
+- [src/review/adversarial.ts:315-377](../../src/review/adversarial.ts#L315-L377)
+- [src/verification/rectification-loop.ts:286-306](../../src/verification/rectification-loop.ts#L286-L306)
+- [src/tdd/rectification-gate.ts:290-302](../../src/tdd/rectification-gate.ts#L290-L302)
+- [src/pipeline/stages/autofix.ts:541-575](../../src/pipeline/stages/autofix.ts#L541-L575)
+
+### Why it matters
+
+The caller-managed-session migration is real in `review/dialogue.ts` and the debate runner paths, but it is not complete across the broader runtime/review/rectification surface. The implementation and the recorded exit state have drifted.
+
+### Recommended follow-up
+
+Either:
+
+1. Finish the migration for the remaining `keepOpen` flows, or
+2. Narrow the written exit criteria so they only claim what actually landed
+
+Right now the code and the completion docs disagree.
+
+---
+
+## Finding 3 — `buildHopCallback()` weakens failure classification
+
+### Severity
+
+Medium
+
+### Summary
+
+`buildHopCallback()` converts any `runAsSession()` error into a generic `availability / fail-adapter-error` result. The older hop path preserved typed session failures such as rate-limit outcomes via `SessionFailureError`.
+
+### Evidence
+
+Current callback behavior:
+
+- [src/operations/build-hop-callback.ts:154-183](../../src/operations/build-hop-callback.ts#L154-L183)
+
+Existing richer mapping:
+
+- [src/runtime/session-run-hop.ts:67-82](../../src/runtime/session-run-hop.ts#L67-L82)
+
+Typed failure surface:
+
+- [src/agents/types.ts:271-281](../../src/agents/types.ts#L271-L281)
+
+### Why it matters
+
+If a typed session failure gets flattened into generic availability failure, fallback policy can make the wrong decision:
+
+- swap when it should back off
+- swap when shutdown/abort semantics should stop work
+- lose rate-limit classification
+
+This is subtle, because tests can still stay green while the fallback behavior changes under load.
+
+### Recommended follow-up
+
+Make `buildHopCallback()` mirror the `SessionFailureError` handling already used in `session-run-hop.ts` instead of reclassifying all errors as generic availability failures.
+
+---
+
+## Finding 4 — review-stage debate is only safely wired for one-shot mode
+
+### Severity
+
+Medium
+
+### Summary
+
+The semantic-review debate path constructs a synthetic runtime object with `sessionManager` and `signal` filled using unsafe placeholders. That is fine for one-shot debate, but review-stage debate config still permits `sessionMode: "stateful"` and `mode: "hybrid"`.
+
+### Evidence
+
+Synthetic runtime in semantic-review debate path:
+
+- [src/review/semantic.ts:320-362](../../src/review/semantic.ts#L320-L362)
+
+Debate config surface still permits stateful/hybrid review debate:
+
+- [src/debate/types.ts:45-62](../../src/debate/types.ts#L45-L62)
+
+### Why it matters
+
+If review debate is configured to use stateful or hybrid mode, the current review path is not obviously backed by a real session manager/runtime. The config surface is broader than the safely wired implementation.
+
+### Recommended follow-up
+
+Either:
+
+1. Restrict review debate to one-shot/panel in config validation, or
+2. Thread a real runtime/session manager through the semantic-review debate path
+
+Without that, the implementation contract is underspecified.
+
+---
+
+## Overall Exit-Criteria Assessment
+
+### Met
+
+- Wave 3.5 adapter method deletion appears landed
+- DebateRunner exists and the old `DebateSession` entrypoint is gone
+- Retry-loop unification for Wave 4 is present
+- `bun run typecheck`, `bun run lint`, and full tests are green
+
+### Not fully met
+
+- The ADR-019 `callOp -> runWithFallback -> buildHopCallback` run-op architecture is not what the code currently does
+- The "zero `keepOpen` / `sessionHandle` usages in `src/`" claim is false
+- Some completion docs overstate what actually landed
+
+---
+
+## Suggested Next Steps
+
+1. Decide whether the source of truth is the current code or the ADR/tracking docs.
+2. If the ADR is still the target, treat Finding 1 and Finding 2 as follow-up implementation work before declaring the rollout complete.
+3. If the current code is the intended end state, update the ADR/tracking docs to remove the stronger claims.
+4. Add a structural test around `callOp()` run-path behavior so this boundary cannot silently drift again.

--- a/docs/specs/2026-04-27-callop-runpath-realignment.md
+++ b/docs/specs/2026-04-27-callop-runpath-realignment.md
@@ -1,0 +1,220 @@
+# Design Note: `callOp` Run-Path Realignment with ADR-019
+
+**Date:** 2026-04-27
+**Status:** Pre-implementation — settles open questions before PR work begins
+**Scope:** Resolves Findings 1–9 from [docs/findings/2026-04-27-adr-018-019-runtime-layering-review-synthesis.md](../findings/2026-04-27-adr-018-019-runtime-layering-review-synthesis.md)
+**ADRs:** [ADR-018](../adr/ADR-018-runtime-layering-with-session-runners.md), [ADR-019](../adr/ADR-019-adapter-primitives-and-session-ownership.md)
+**Issues touched:** #688, #689, #690, #691, #692, #693, #706
+
+---
+
+## 1. Problem statement
+
+`callOp()` for `kind:"run"` operations currently calls `sessionManager.runInSession(name, prompt, opts)` directly ([src/operations/call.ts:48](../../src/operations/call.ts#L48)). This diverges from ADR-019 §5, which specifies the path `callOp → agentManager.runWithFallback({ executeHop }) → buildHopCallback`. Three observable consequences flow from this single divergence:
+
+- **No cross-agent fallback** — `runInSession` does not iterate the fallback chain. Every `kind:"run"` op silently runs single-agent.
+- **Middleware bypassed** — the chain (`audit`, `cost`, `cancellation`, `logging`) is wired into `AgentManager` only ([src/runtime/index.ts:83-107](../../src/runtime/index.ts#L83-L107)). `runInSession`'s prompt overload calls `sessionManager.sendPrompt → adapter.sendTurn` directly with zero hops through `AgentManager`. CostAggregator and PromptAuditor never see these calls.
+- **`noFallback` flag is dead** — declared on [RunOperation](../../src/operations/types.ts#L54), never read.
+
+Secondarily, `buildHopCallback` itself flattens every error into `availability/fail-adapter-error` instead of preserving the `SessionFailureError`-bearing classification that `session-run-hop.ts` produces today. Once `callOp` routes through `buildHopCallback`, this regression becomes user-visible.
+
+This design note settles the open architectural questions and locks down the scope of the three follow-up PRs.
+
+---
+
+## 2. Decisions
+
+### 2.1 Cross-agent fallback semantics
+
+**Decision:** Cross-agent fallback stays for review and rectification flows. ACP sessions are not shared across agents (each agent gets a fresh session under its own adapter) — but the *user-facing* "if Claude rate-limits, retry on Codex" behavior is preserved.
+
+**Rationale:** Two independent levels:
+
+- *Within one hop* — multi-turn behavior (e.g. semantic-review's same-session JSON parse retry) needs the agent's conversation state and is therefore single-agent by construction.
+- *Between hops* — `runWithFallback` swaps agents when one hop returns availability failure. The next agent gets a fresh session and a context bundle rebuilt for it via `ContextEngine.rebuildForAgent`.
+
+These levels compose. The mistake in the synthesis review's first draft was conflating them and proposing to drop fallback for review. Walked back here.
+
+### 2.2 Multi-prompt orchestration shape
+
+**Decision:** Multi-prompt logic lives inside the hop callback, parameterized per operation. `RunOperation` optionally declares a `hopBody` that performs N prompts within a single hop's session. Default behavior (single prompt) is unchanged.
+
+**New surface:**
+
+```typescript
+// src/operations/types.ts
+export interface RunOperation<I, O, C> extends OperationBase<I, O, C> {
+  readonly kind: "run";
+  readonly session: { readonly role: SessionRole; readonly lifetime: "fresh" | "warm" };
+  readonly noFallback?: boolean;
+  /**
+   * Optional multi-prompt body executed within a single hop's session.
+   * When omitted, the default body is "send one prompt and return".
+   * The body owns retry-in-session logic (e.g. JSON parse retries).
+   * It does NOT own openSession / closeSession — that's the caller's job.
+   */
+  readonly hopBody?: (
+    handle: SessionHandle,
+    initialPrompt: string,
+    ctx: HopBodyContext<I>,
+  ) => Promise<TurnResult>;
+}
+```
+
+**Per-op orchestration today:**
+
+| Op | Hop body |
+|:---|:---|
+| `acceptance-fix`, `acceptance-fix-tests`, `acceptance-diagnose` | default (single prompt) |
+| `semantic-review`, `adversarial-review` | `runAsSession(initialPrompt)` → if JSON parse fails or output looks truncated, `runAsSession(retryPrompt)` in same handle → return |
+| `rectify` | default (single prompt). Attempt loop stays *outside* `callOp` — each attempt is one `callOp` invocation. |
+| TDD `write-test` / `implement` / `verify` | default, with `noFallback: true` |
+
+**Why this factoring wins:**
+
+- The rebuild + open + close + handoff scaffolding stays in `buildHopCallback` — one place.
+- Only the body varies per op. Review ops can collapse the keepOpen pattern from semantic.ts/adversarial.ts directly into the op definition. No more raw `agentManager.run({ keepOpen: true })` call sites.
+- Cross-agent fallback works automatically. If the hop returns `adapterFailure`, `runWithFallback` swaps; the new agent's hop runs the hop body fresh.
+
+**Why not "each attempt is its own session, rectification owns the loop":** rectification *could* live inside the hop body (intra-hop attempt loop, all attempts in one session). We'll keep the attempt loop external for PR 1, because:
+
+- It matches today's behavior — agent sees prior edits via the working tree, not via session memory.
+- It keeps the hop body shape simple (single multi-prompt pattern, no nested attempt loops).
+- The fresh-session-per-attempt cost is small (open is cheap; rebuild only fires on agent swap).
+
+If a follow-up shows session continuity matters for rectification quality, the hop body shape supports moving the loop in later — backwards compatible.
+
+### 2.3 `noFallback` flag
+
+**Decision:** Keep `noFallback` as a flag on `RunOperation`. `callOp` branches on it.
+
+```typescript
+// src/operations/call.ts (kind:"run" branch)
+const manager = op.noFallback
+  ? wrapAdapterAsManager(ctx.runtime.agentManager.getAgent(ctx.agentName))
+  : ctx.runtime.agentManager;
+const outcome = await manager.runWithFallback({ executeHop, ... });
+```
+
+This matches the ADR-018 §5.2 sketch for what `SingleSessionRunner.run()` was supposed to do. TDD ops set `noFallback: true` to preserve their `fallbacks: []` invariant.
+
+### 2.4 `runInSession` removal from `callOp` path
+
+**Decision:** `callOp` no longer calls `runInSession`. The Phase B prompt-form overload of `runInSession` ([src/session/manager.ts:558-595](../../src/session/manager.ts#L558-L595)) is left in place for legacy callers but expected to have near-zero usage after PR 1. A grep audit at the end of PR 1 will determine whether to delete the overload or keep it as a thin convenience.
+
+The hop callback uses the three Phase-B primitives directly:
+
+```
+sessionManager.openSession(name, opts)        // Phase B primitive
+agentManager.runAsSession(handle, prompt)     // fires middleware
+sessionManager.closeSession(handle)           // Phase B primitive
+```
+
+This is what ADR-019 §5 specifies; getting middleware coverage and fallback iteration "by construction" is the win.
+
+### 2.5 Test strategy
+
+**Decision:** Two new tests land with PR 1.
+
+1. **Middleware-coverage integration test** at `test/integration/operations/middleware-coverage.test.ts`. For each `kind:"run"` op in the registry, dispatch via `callOp` against a runtime where `auditMiddleware` and `costMiddleware` are observable. Assert exactly one audit entry and one cost entry per call. Asserts both Findings 1 and 5 cannot recur.
+
+2. **`buildHopCallback` failure-classification unit test** at `test/unit/operations/build-hop-callback-failures.test.ts`. Inject `SessionFailureError(adapterFailure: { outcome: "fail-rate-limit" })` from a stubbed `runAsSession`. Assert the returned `result.adapterFailure.outcome === "fail-rate-limit"` and `result.rateLimited === true`. Inject a non-`SessionFailureError` exception. Assert it still produces `availability/fail-adapter-error` (current generic branch). Asserts Finding 3 cannot recur.
+
+Skipping lint rules — they give noisier failure messages than tests for this kind of structural invariant.
+
+---
+
+## 3. Implementation shape
+
+### 3.1 New / changed surface
+
+| File | Change |
+|:---|:---|
+| `src/operations/types.ts` | Add optional `hopBody` field on `RunOperation`. Define `HopBodyContext<I>`. |
+| `src/operations/build-hop-callback.ts` | Mirror `session-run-hop.ts` failure handling: catch `SessionFailureError` and surface `adapterFailure`. Default hop body sends single prompt; if `op.hopBody` is supplied, invoke it instead. |
+| `src/operations/call.ts` | `kind:"run"` branch: build `executeHop` via `buildHopCallback(ctx, op, input, prompt)`, dispatch through `agentManager.runWithFallback({ executeHop, ... })`. Branch on `op.noFallback`. Remove direct `sessionManager.runInSession` call. |
+| `src/operations/semantic-review.ts` | Add `hopBody` performing the JSON-retry-in-same-session logic currently in [src/review/semantic.ts:541-604](../../src/review/semantic.ts#L541-L604). |
+| `src/operations/adversarial-review.ts` | Same shape as semantic. |
+| `src/review/semantic.ts`, `src/review/adversarial.ts` | Replace direct `agentManager.run({ keepOpen })` calls with `callOp(...)`. Drop `closePhysicalSession` calls (handled by `closeSession(handle)` in the callback). |
+| TDD ops (`src/operations/write-test.ts`, `implement.ts`, `verify.ts`) | Set `noFallback: true`. |
+| `test/integration/operations/middleware-coverage.test.ts` | New (per §2.5). |
+| `test/unit/operations/build-hop-callback-failures.test.ts` | New (per §2.5). |
+
+### 3.2 What does not change
+
+- `runWithFallback` itself — no changes. The chain iteration, rate-limit retry, and signal-aware backoff stay as-is.
+- `agentManager.runAsSession` — no changes. Already fires middleware correctly.
+- `SessionManager.openSession` / `closeSession` / `sendPrompt` — no changes.
+- TDD orchestrator (`runThreeSessionTdd`) — no changes; the three sub-ops simply gain `noFallback: true`.
+- `dialogue.ts`, `debate/runner-stateful.ts`, `debate/runner-hybrid.ts` — already on the new shape, untouched.
+
+### 3.3 Wave-2 invariant restoration
+
+After PR 1:
+
+- "CostAggregator.snapshot() reflects all calls including nested and session-internal calls" — true by construction. Every dispatch goes through `agentManager.runAsSession` or `agentManager.completeAs`, both of which fire the middleware chain.
+- "PromptAuditor flushes to `.nax/audit/<runId>.jsonl`" — true; audit middleware sees every call.
+- The Wave-2 phase-completion docs no longer overstate.
+
+---
+
+## 4. PR sequencing
+
+```
+PR 1: Foundation (Findings 1 + 3 + 5 + 6)
+  - Fix buildHopCallback failure classification (Finding 3)
+  - Add hopBody field to RunOperation (§2.2)
+  - Refactor callOp run-path to use runWithFallback + buildHopCallback (Findings 1, 5)
+  - Branch on noFallback (Finding 6)
+  - Add middleware-coverage and failure-classification tests (§2.5)
+  - Migrate semantic-review and adversarial-review ops to use hopBody
+  - Set noFallback:true on TDD ops
+  - Grep runInSession; delete prompt-form overload if unused
+
+PR 2: keepOpen retirement (Finding 2)
+  - Migrate src/review/semantic.ts and adversarial.ts to call callOp(...) instead of agentManager.run({ keepOpen })
+  - Migrate src/verification/rectification-loop.ts (decide intra-hop vs external attempt loop — see §2.2)
+  - Migrate src/tdd/rectification-gate.ts and src/tdd/session-runner.ts
+  - Migrate src/pipeline/stages/autofix.ts and autofix-adversarial.ts
+  - Update phase-e tracking doc to reflect what actually shipped
+  - Optional: delete keepOpen field from AgentRunOptions if no callers remain
+
+PR 3: Cleanup (Findings 4 + 7 + 8 + 9)
+  - Restrict review-stage debate config to oneshot/panel, OR thread real runtime (Finding 4)
+  - Delete adapter.closePhysicalSession and deriveSessionName (Finding 7)
+  - Decide cross-imports posture (Finding 8) — neutralize types or amend exit criterion
+  - Migrate src/cli/plan.ts off _deps.createManager OR amend Wave-3.5 exit criterion (Finding 9)
+```
+
+PR 1 is the one that matters. PR 2 follows naturally once PR 1 lands. PR 3 is a paperwork-vs-code call best made after PR 2.
+
+---
+
+## 5. Risks
+
+- **Behavior change risk (low–medium):** PR 1 enables fallback for review and rectification flows that today silently run single-agent. Users on a single-agent setup see no change. Users with a multi-agent fallback chain may see Codex/Gemini fire on review failures where they previously did not. Document in CHANGELOG.
+- **Test-suite duration risk (low):** middleware-coverage integration test runs every `kind:"run"` op; mocked dispatch should keep this under one second. Confirm during implementation.
+- **Hop body API risk (low):** introducing `hopBody` is a small interface change. Default behavior preserves today's single-prompt shape, so unaware ops keep working. The only ops that need to opt in for PR 1 are the two review ops.
+- **`runInSession` removal risk (low):** prompt-form overload may have non-callOp callers in tests. Grep before delete; replace with explicit `openSession + sendPrompt + closeSession` if any. Tracked-session form (the `SessionRunClient` overload) is independent and stays.
+- **Audit/cost backfill (cosmetic):** historical `.nax/audit/<runId>.jsonl` and `.nax/cost/<runId>.jsonl` files written before PR 1 will be missing entries for `kind:"run"` callOp ops. Note this in CHANGELOG; no migration needed.
+
+---
+
+## 6. Out of scope
+
+- Reorganizing `SessionDescriptor` / `ProtocolIds` / `SessionHandle` into a neutral types package to satisfy the strict reading of "zero cross-imports" (Finding 8). Punt to PR 3 or beyond.
+- Reworking the rectification attempt loop into intra-hop iteration (§2.2 keeps it external for PR 1; revisit if quality data shows session continuity matters).
+- Deleting `keepOpen` from `AgentRunOptions` itself. Optional cleanup at the end of PR 2; not required for the migration to be complete.
+- Migrating `nax plan` CLI to construct via `createRuntime()`. Tracked under Finding 9.
+
+---
+
+## 7. Decisions log
+
+| # | Question | Decision | Rationale |
+|:--|:---|:---|:---|
+| 1 | Drop fallback for review/rectification? | No — fallback stays at hop boundary | ACP sessions are per-agent, but cross-agent retry on availability failure is a user-facing feature worth preserving |
+| 2 | How to model multi-prompt-per-session? | Per-op `hopBody` field on `RunOperation` | Single factoring covers review's JSON retry, rectification's optional intra-hop loop, and stays default-compatible for single-prompt ops |
+| 3 | Keep `noFallback` flag? | Yes; `callOp` branches on it | Mirrors ADR-018 §5.2; TDD ops opt in |
+| 4 | Structural test choice | Middleware-coverage integration test + buildHopCallback failure-classification unit test | Catches the exact drift modes Findings 1, 3, 5 represent |
+| 5 | `runInSession` on `callOp` path? | Removed; `callOp` uses `openSession` / `runAsSession` / `closeSession` directly via `buildHopCallback` | Matches ADR-019 §5 specification verbatim |

--- a/src/agents/manager-types.ts
+++ b/src/agents/manager-types.ts
@@ -69,6 +69,14 @@ export interface AgentRunRequest {
     failure: AdapterFailure | undefined,
     resolvedRunOptions: AgentRunOptions,
   ) => Promise<{ result: AgentResult; bundle: ContextBundle | undefined; prompt?: string }>;
+  /**
+   * When true, runWithFallback dispatches at most one hop on the primary agent
+   * and never iterates the fallback chain. Used by ops that must preserve the
+   * `fallbacks: []` invariant (TDD test-writer / implementer / verifier per
+   * ADR-018 §5.2). Middleware still fires; rate-limit retry on the same agent
+   * still applies.
+   */
+  noFallback?: boolean;
 }
 
 /** Options for AgentManager.runAsSession — caller-managed session (Phase C). */
@@ -132,7 +140,7 @@ export interface IAgentManager {
    * Implements exponential backoff for rate-limit errors when no swap candidate
    * is available (up to 3 attempts). Emits onSwapAttempt / onSwapExhausted events.
    */
-  runWithFallback(request: AgentRunRequest): Promise<AgentRunOutcome>;
+  runWithFallback(request: AgentRunRequest, primaryAgentOverride?: string): Promise<AgentRunOutcome>;
 
   /**
    * One-shot completion with cross-agent fallback.

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -221,6 +221,13 @@ export class AgentManager implements IAgentManager {
 
       const bundleForSwapCheck = updatedBundle ?? request.bundle;
 
+      // Op-level opt-out (TDD ops per ADR-018 §5.2). Returns the primary-agent
+      // result without entering the swap branch. Rate-limit backoff inside
+      // shouldSwap is also skipped — single-agent ops should fail fast.
+      if (request.noFallback) {
+        return { result, fallbacks, finalBundle: updatedBundle, finalPrompt, finalAgent: currentAgent };
+      }
+
       if (!this.shouldSwap(result.adapterFailure, hopsSoFar, !!bundleForSwapCheck)) {
         // Preserve legacy rate-limit backoff when no swap candidates are available.
         // #585 Path B: race the sleep against the shutdown signal — an abort during

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -1,9 +1,11 @@
+import type { TurnResult } from "../agents/types";
 import { reviewConfigSelector } from "../config";
-import { AdversarialReviewPromptBuilder } from "../prompts";
+import { AdversarialReviewPromptBuilder, ReviewPromptBuilder } from "../prompts";
 import type { PriorFailure, TestInventory } from "../prompts";
+import { looksLikeTruncatedJson } from "../review/truncation";
 import type { AdversarialReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
-import type { LlmReviewFinding, RunOperation } from "./types";
+import type { HopBody, LlmReviewFinding, RunOperation } from "./types";
 
 export type { AdversarialReviewConfig, PriorFailure, SemanticStory, TestInventory };
 
@@ -37,12 +39,31 @@ function parseLLMShape(raw: unknown): AdversarialReviewOutput | null {
   return { passed: obj.passed, findings: obj.findings as LlmReviewFinding[] };
 }
 
+/** Same-session JSON-parse retry. See semantic-review.ts for rationale. */
+const adversarialReviewHopBody: HopBody<AdversarialReviewInput> = async (initialPrompt, ctx) => {
+  const first = await ctx.send(initialPrompt);
+  const isTruncated = looksLikeTruncatedJson(first.output);
+  const parsed = tryParseLLMJson<Record<string, unknown>>(first.output);
+  if (!isTruncated && parsed && parseLLMShape(parsed)) return first;
+
+  const retryPrompt = isTruncated ? ReviewPromptBuilder.jsonRetryCondensed() : ReviewPromptBuilder.jsonRetry();
+  const retry: TurnResult = await ctx.send(retryPrompt);
+  return {
+    ...retry,
+    cost: {
+      ...(retry.cost ?? { total: 0, source: "fallback" as const }),
+      total: (first.cost?.total ?? 0) + (retry.cost?.total ?? 0),
+    },
+  };
+};
+
 export const adversarialReviewOp: RunOperation<AdversarialReviewInput, AdversarialReviewOutput, ReviewConfig> = {
   kind: "run",
   name: "adversarial-review",
   stage: "review",
   session: { role: "reviewer-adversarial", lifetime: "fresh" },
   config: reviewConfigSelector,
+  hopBody: adversarialReviewHopBody,
   build(input, _ctx) {
     const prompt = new AdversarialReviewPromptBuilder().buildAdversarialReviewPrompt(
       input.story,

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AgentRunRequest, IAgentManager } from "../agents/manager-types";
+import { SessionFailureError } from "../agents/types";
 import type { AgentResult, AgentRunOptions, TurnResult } from "../agents/types";
 import { resolveModelForAgent } from "../config";
 import type { NaxConfig } from "../config";
@@ -40,6 +41,18 @@ export interface BuildHopCallbackContext {
   defaultAgent: string;
   contextToolRunCounter?: RunCallCounter;
   pipelineStage?: import("../config/permissions").PipelineStage;
+  /**
+   * Optional intra-hop multi-prompt body. When set, the callback invokes
+   * `hopBody(initialPrompt, { send })` instead of issuing a single
+   * `runAsSession` call. The `send` closure dispatches one turn against the
+   * current handle. Used by review ops for same-session JSON-parse retry.
+   */
+  hopBody?: <I = unknown>(
+    initialPrompt: string,
+    bodyCtx: { send: (prompt: string) => Promise<TurnResult>; input: I },
+  ) => Promise<TurnResult>;
+  /** Input value forwarded to `hopBody` via its `ctx.input`. */
+  hopBodyInput?: unknown;
 }
 
 function turnResultToAgentResult(r: TurnResult): AgentResult {
@@ -71,6 +84,8 @@ export function buildHopCallback(
     defaultAgent,
     contextToolRunCounter,
     pipelineStage,
+    hopBody,
+    hopBodyInput,
   } = ctx;
 
   const stage = pipelineStage ?? "run";
@@ -152,28 +167,42 @@ export function buildHopCallback(
     });
 
     try {
-      const turnResult = await agentManager.runAsSession(agentName, handle, prompt, {
-        storyId: story.id,
-        pipelineStage: stage,
-        signal: resolvedRunOptions.abortSignal,
-        contextPullTools,
-        contextToolRuntime,
-      });
+      // Bound `send` closure: each call dispatches one turn through AgentManager
+      // (so middleware fires) against the current hop's handle. Reused by both
+      // the default single-prompt path and any caller-supplied hopBody.
+      const send = (turnPrompt: string): Promise<TurnResult> =>
+        agentManager.runAsSession(agentName, handle, turnPrompt, {
+          storyId: story.id,
+          pipelineStage: stage,
+          signal: resolvedRunOptions.abortSignal,
+          contextPullTools,
+          contextToolRuntime,
+        });
+
+      const turnResult = hopBody ? await hopBody(prompt, { send, input: hopBodyInput }) : await send(prompt);
       return { result: turnResultToAgentResult(turnResult), bundle: workingBundle, prompt };
     } catch (err) {
+      // Preserve typed adapter failure on SessionFailureError so runWithFallback's
+      // swap policy sees the real outcome (rate-limit, auth, quota) instead of
+      // a generic "fail-adapter-error" reclassification. Mirrors session-run-hop.ts.
+      const sessionFailure = err instanceof SessionFailureError ? err.adapterFailure : undefined;
+      const errMessage = err instanceof Error ? err.message : String(err);
       return {
         result: {
           success: false,
           exitCode: 1,
-          output: `Agent "${agentName}" failed: ${String(err)}`,
-          rateLimited: false,
+          // Always prefix with agent name so downstream logs can attribute the
+          // failure even when the underlying error message doesn't carry it
+          // (e.g. bare `new Error("timeout")`).
+          output: `Agent "${agentName}" failed: ${errMessage}`,
+          rateLimited: sessionFailure?.outcome === "fail-rate-limit",
           durationMs: 0,
           estimatedCost: 0,
-          adapterFailure: {
+          adapterFailure: sessionFailure ?? {
             category: "availability",
             outcome: "fail-adapter-error",
             retriable: false,
-            message: String(err).slice(0, 500),
+            message: errMessage.slice(0, 500),
           },
         },
         bundle: workingBundle,

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -1,14 +1,44 @@
-import { pickSelector, resolveModelForAgent } from "../config";
-import type { ConfigSelector, NaxConfig } from "../config";
+import type { TurnResult } from "../agents/types";
+import { pickSelector, resolveConfiguredModel } from "../config";
+import type { ConfigSelector, ConfiguredModel, NaxConfig } from "../config";
 import { NaxError } from "../errors";
+import type { UserStory } from "../prd";
 import { composeSections, join } from "../prompts/compose";
-import type { CallContext, CompleteOperation, Operation } from "./types";
+import { buildHopCallback } from "./build-hop-callback";
+import type { CallContext, CompleteOperation, Operation, RunOperation } from "./types";
 
 function normalizeSelector<C>(s: ConfigSelector<C> | readonly (keyof NaxConfig)[], opName: string): ConfigSelector<C> {
   if (Array.isArray(s)) {
     return pickSelector(`anonymous:${opName}`, ...(s as readonly (keyof NaxConfig)[])) as unknown as ConfigSelector<C>;
   }
   return s as ConfigSelector<C>;
+}
+
+/**
+ * Synthesize a minimal UserStory for callOp use cases that don't carry a real
+ * one (CLI ad-hoc calls, debate runners, simple op invocations). Only the `id`
+ * field is read by buildHopCallback's active code paths when no context bundle
+ * is provided — the other fields are zero-value placeholders.
+ *
+ * Uses `satisfies` (not `as`) so any future required field on UserStory breaks
+ * compile here, forcing an explicit decision rather than silently producing an
+ * empty default. If a downstream provider starts reading e.g. `acceptanceCriteria`
+ * for these stub stories, that's a bug — the synthesis path shouldn't run for
+ * any op that consumes story data beyond `id`.
+ */
+function synthesizeStory(storyId: string | undefined): UserStory {
+  return {
+    id: storyId ?? "",
+    title: "",
+    description: "",
+    acceptanceCriteria: [],
+    tags: [],
+    dependencies: [],
+    status: "pending",
+    passes: false,
+    escalations: [],
+    attempts: 0,
+  } satisfies UserStory;
 }
 
 export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, input: I): Promise<O> {
@@ -18,14 +48,19 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
   const sections = composeSections(op.build(input, buildCtx));
   const prompt = join(sections);
 
+  const config = ctx.runtime.configLoader.current();
+  const defaultAgent = ctx.runtime.agentManager.getDefault();
+  const opModel: ConfiguredModel = (op as { model?: ConfiguredModel }).model ?? "balanced";
+  // resolved.agent honors `{ agent, model }` pin (cross-agent overrides);
+  // resolved.modelTier is undefined when an explicit non-tier model is pinned.
+  const resolved = resolveConfiguredModel(config.models, ctx.agentName, opModel, defaultAgent);
+  const dispatchAgent = resolved.agent;
+  const effectiveTier = resolved.modelTier ?? "balanced";
+
   if (op.kind === "complete") {
     const completeOp = op as CompleteOperation<I, O, C>;
-    const config = ctx.runtime.configLoader.current();
-    const defaultAgent = ctx.runtime.agentManager.getDefault();
-    const tier = completeOp.modelTier ?? "balanced";
-    const modelDef = resolveModelForAgent(config.models, ctx.agentName, tier, defaultAgent);
-    const raw = await ctx.runtime.agentManager.completeAs(ctx.agentName, prompt, {
-      model: modelDef.model,
+    const raw = await ctx.runtime.agentManager.completeAs(dispatchAgent, prompt, {
+      model: resolved.modelDef.model,
       config,
       jsonMode: completeOp.jsonMode ?? false,
       pipelineStage: op.stage,
@@ -35,34 +70,77 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
     return op.parse(raw.output, input, buildCtx);
   }
 
-  const config = ctx.runtime.configLoader.current();
-  const defaultAgent = ctx.runtime.agentManager.getDefault();
-  const sessionName = ctx.runtime.sessionManager.nameFor({
+  // kind:"run" — ADR-019 §5: route through runWithFallback + buildHopCallback.
+  // This restores cross-agent fallback (Finding 1), wires the hop through
+  // AgentManager.runAsSession so middleware fires (Finding 5), and lets
+  // op.noFallback short-circuit the swap branch (Finding 6).
+  const runOp = op as RunOperation<I, O, C>;
+  const story = ctx.story ?? synthesizeStory(ctx.storyId);
+  const sessionRole = ctx.sessionOverride?.role ?? runOp.session.role;
+  const runOptions = {
+    prompt,
     workdir: ctx.packageDir,
-    storyId: ctx.storyId,
-    featureName: ctx.featureName,
-    role: op.session.role,
-    pipelineStage: op.stage,
-  });
-
-  const turnResult = await ctx.runtime.sessionManager.runInSession(sessionName, prompt, {
-    agentName: ctx.agentName,
-    role: op.session.role,
-    workdir: ctx.packageDir,
-    pipelineStage: op.stage,
-    signal: ctx.runtime.signal,
-    modelDef: resolveModelForAgent(config.models, ctx.agentName, "balanced", defaultAgent),
+    modelTier: effectiveTier,
+    modelDef: resolved.modelDef,
     timeoutSeconds: config.execution.sessionTimeoutSeconds,
-    storyId: ctx.storyId,
+    pipelineStage: op.stage,
+    config,
+    sessionRole,
     featureName: ctx.featureName,
-  });
+    storyId: ctx.storyId,
+  };
 
-  const rawOutput = turnResult.output;
+  // Always dispatch through the real AgentManager so middleware (audit, cost,
+  // cancellation, logging) fires uniformly. `noFallback: true` short-circuits
+  // the swap branch in runWithFallback (manager.ts) — single-agent semantics
+  // without losing the middleware envelope. dispatchAgent roots the chain at
+  // the resolved agent, which may differ from ctx.agentName when op.model
+  // pins a specific `{ agent, model }`.
+  //
+  // The hopBody / hopBodyInput cast bridges the per-op generic `HopBody<I>`
+  // to BuildHopCallbackContext's `hopBody` (parameterized over `unknown`).
+  // Safe because the same `input` value flows into both `hopBodyInput` and
+  // the body's `ctx.input` — the cast only re-types the parameter.
+  const executeHop = buildHopCallback(
+    {
+      sessionManager: ctx.runtime.sessionManager,
+      agentManager: ctx.runtime.agentManager,
+      story,
+      config,
+      projectDir: ctx.runtime.projectDir,
+      featureName: ctx.featureName ?? "",
+      workdir: ctx.packageDir,
+      effectiveTier,
+      defaultAgent,
+      pipelineStage: op.stage,
+      ...(runOp.hopBody && {
+        hopBody: ((initialPrompt: string, bodyCtx: { send: (p: string) => Promise<TurnResult>; input: unknown }) =>
+          runOp.hopBody?.(initialPrompt, { send: bodyCtx.send, input: bodyCtx.input as I })) as NonNullable<
+          import("./build-hop-callback").BuildHopCallbackContext["hopBody"]
+        >,
+        hopBodyInput: input,
+      }),
+    },
+    undefined, // sessionId — callOp doesn't carry pipeline-level session descriptors
+    runOptions,
+  );
+
+  const outcome = await ctx.runtime.agentManager.runWithFallback(
+    {
+      runOptions,
+      signal: ctx.runtime.signal,
+      executeHop,
+      noFallback: runOp.noFallback,
+    },
+    dispatchAgent,
+  );
+
+  const rawOutput = outcome.result.output;
   if (!rawOutput) {
     throw new NaxError(`callOp[${op.name}]: agent returned no output`, "CALL_OP_NO_OUTPUT", {
       stage: op.stage,
       storyId: ctx.storyId,
-      agentName: ctx.agentName,
+      agentName: dispatchAgent,
     });
   }
   return op.parse(rawOutput, input, buildCtx);

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -1,9 +1,11 @@
+import type { TurnResult } from "../agents/types";
 import { reviewConfigSelector } from "../config";
 import { ReviewPromptBuilder } from "../prompts";
 import type { PriorFailure } from "../prompts";
+import { looksLikeTruncatedJson } from "../review/truncation";
 import type { SemanticReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
-import type { LlmReviewFinding, RunOperation } from "./types";
+import type { HopBody, LlmReviewFinding, RunOperation } from "./types";
 
 export type { PriorFailure, SemanticReviewConfig, SemanticStory };
 
@@ -36,12 +38,36 @@ function parseLLMShape(raw: unknown): SemanticReviewOutput | null {
   return { passed: obj.passed, findings: obj.findings as LlmReviewFinding[] };
 }
 
+/**
+ * Same-session JSON-parse retry. Sends the initial prompt; if the response is
+ * unparseable or truncated, sends a retry prompt in the same handle so the
+ * agent has full conversation history. Single retry; further failures fall
+ * through to the parse() FAIL_OPEN path.
+ */
+const semanticReviewHopBody: HopBody<SemanticReviewInput> = async (initialPrompt, ctx) => {
+  const first = await ctx.send(initialPrompt);
+  const isTruncated = looksLikeTruncatedJson(first.output);
+  const parsed = tryParseLLMJson<Record<string, unknown>>(first.output);
+  if (!isTruncated && parsed && parseLLMShape(parsed)) return first;
+
+  const retryPrompt = isTruncated ? ReviewPromptBuilder.jsonRetryCondensed() : ReviewPromptBuilder.jsonRetry();
+  const retry: TurnResult = await ctx.send(retryPrompt);
+  return {
+    ...retry,
+    cost: {
+      ...(retry.cost ?? { total: 0, source: "fallback" as const }),
+      total: (first.cost?.total ?? 0) + (retry.cost?.total ?? 0),
+    },
+  };
+};
+
 export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewOutput, ReviewConfig> = {
   kind: "run",
   name: "semantic-review",
   stage: "review",
   session: { role: "reviewer-semantic", lifetime: "fresh" },
   config: reviewConfigSelector,
+  hopBody: semanticReviewHopBody,
   build(input, _ctx) {
     const prompt = new ReviewPromptBuilder().buildSemanticReviewPrompt(input.story, input.semanticConfig, {
       mode: input.mode,

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -1,4 +1,5 @@
-import type { ConfigSelector, ModelTier } from "../config";
+import type { TurnResult } from "../agents/types";
+import type { ConfigSelector, ConfiguredModel } from "../config";
 import type { NaxConfig } from "../config";
 import type { PipelineStage } from "../config/permissions";
 import type { ComposeInput } from "../prompts/compose";
@@ -21,6 +22,13 @@ export interface CallContext {
     readonly role?: SessionRole;
     readonly discriminator?: string | number;
   };
+  /**
+   * Optional full UserStory passed to buildHopCallback for cross-agent fallback
+   * bundle rebuilds. When absent (e.g. ad-hoc CLI calls), callOp synthesizes a
+   * minimal stub from `storyId` — sufficient for `kind:"run"` ops that don't
+   * carry a context bundle. Bundle-aware ops should pass the real story.
+   */
+  readonly story?: import("../prd").UserStory;
 }
 
 interface OperationBase<I, O, C> {
@@ -43,22 +51,64 @@ interface OperationBase<I, O, C> {
   readonly parse: (output: string, input: I, ctx: BuildContext<C>) => O;
 }
 
+/**
+ * Context passed to a per-op `hopBody`. Exposes a bound `send(prompt)` closure
+ * that dispatches one turn against the active hop's session via
+ * `agentManager.runAsSession` (which fires the Wave-2 middleware chain). Ops
+ * never see the SessionHandle or the AgentManager directly — those stay inside
+ * `buildHopCallback`.
+ */
+export interface HopBodyContext<I> {
+  readonly send: (prompt: string) => Promise<TurnResult>;
+  readonly input: I;
+}
+
+/**
+ * Optional multi-prompt body executed within a single hop's session.
+ * When omitted, the default body is "send the initial prompt and return".
+ * The body owns same-session retry logic (e.g. JSON parse retries in review ops).
+ * It does NOT own openSession / closeSession / fallback iteration — those are
+ * `buildHopCallback`'s job.
+ */
+export type HopBody<I> = (initialPrompt: string, ctx: HopBodyContext<I>) => Promise<TurnResult>;
+
 export interface RunOperation<I, O, C> extends OperationBase<I, O, C> {
   readonly kind: "run";
   /** Reserved for future model-tier override; not yet consumed by callOp (Wave 3). */
   readonly mode?: string;
+  /**
+   * Model selection for this op. Accepts either a tier label
+   * ("fast" | "balanced" | "powerful") or an explicit `{ agent, model }`
+   * pin (for cross-agent or shorthand-aliased model overrides). Resolved via
+   * `resolveConfiguredModel` in callOp. Defaults to "balanced" when omitted.
+   */
+  readonly model?: ConfiguredModel;
   readonly session: {
     readonly role: SessionRole;
     readonly lifetime: "fresh" | "warm";
   };
+  /**
+   * When true, callOp wraps the adapter as a fallback-less manager so the op
+   * runs single-agent. Used by TDD ops to preserve the established
+   * `fallbacks: []` invariant. ADR-018 §5.2.
+   */
   readonly noFallback?: boolean;
+  /**
+   * Optional intra-hop multi-prompt body. See HopBody / HopBodyContext.
+   * Used by review ops to perform a same-session JSON-parse retry.
+   */
+  readonly hopBody?: HopBody<I>;
 }
 
 export interface CompleteOperation<I, O, C> extends OperationBase<I, O, C> {
   readonly kind: "complete";
   readonly jsonMode?: boolean;
-  /** Model tier to use for this call. Defaults to "balanced" when omitted. */
-  readonly modelTier?: ModelTier;
+  /**
+   * Model selection for this call. Accepts a tier label or an explicit
+   * `{ agent, model }` pin. Resolved via `resolveConfiguredModel` in callOp.
+   * Defaults to "balanced" when omitted.
+   */
+  readonly model?: ConfiguredModel;
 }
 
 export type Operation<I, O, C> = RunOperation<I, O, C> | CompleteOperation<I, O, C>;

--- a/test/integration/operations/middleware-coverage.test.ts
+++ b/test/integration/operations/middleware-coverage.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Middleware coverage for callOp `kind:"run"` dispatch (Findings 1 + 5).
+ *
+ * Asserts that `kind:"run"` operations dispatched via callOp flow through the
+ * AgentManager middleware chain (audit, cost, cancellation, logging). Before
+ * the ADR-019 §5 realignment, the run-path called `sessionManager.runInSession`
+ * directly and bypassed the chain — `kind:"run"` calls never reached
+ * CostAggregator or PromptAuditor. This test guards that boundary so it cannot
+ * drift again silently.
+ *
+ * `kind:"complete"` middleware coverage is verified elsewhere (audit/cost
+ * unit tests in test/unit/runtime/middleware/).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { AgentManager } from "../../../src/agents/manager";
+import type { SessionHandle, TurnResult } from "../../../src/agents/types";
+import { DEFAULT_CONFIG, pickSelector } from "../../../src/config";
+import { callOp } from "../../../src/operations/call";
+import type { RunOperation } from "../../../src/operations/types";
+import { MiddlewareChain } from "../../../src/runtime/agent-middleware";
+import type { AgentMiddleware, MiddlewareContext } from "../../../src/runtime/agent-middleware";
+import { makeNaxConfig, makeSessionManager, makeTestRuntime } from "../../helpers";
+
+const sel = pickSelector("mw-coverage", "routing");
+
+const runOp: RunOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+  kind: "run",
+  name: "mw-coverage-run",
+  stage: "run",
+  config: sel,
+  session: { role: "implementer", lifetime: "fresh" },
+  build: (input) => ({
+    role: { id: "role", content: "", overridable: false },
+    task: { id: "task", content: input.text, overridable: false },
+  }),
+  parse: (output) => output.trim(),
+};
+
+interface RecordedCall {
+  agentName: string;
+  kind: MiddlewareContext["kind"];
+  promptIncludes?: string;
+}
+
+function makeRecorder(): { mw: AgentMiddleware; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const mw: AgentMiddleware = {
+    name: "test-recorder",
+    after(ctx: MiddlewareContext, _result: unknown, _durationMs: number): void {
+      calls.push({
+        agentName: ctx.agentName,
+        kind: ctx.kind,
+        promptIncludes: ctx.prompt?.slice(0, 200),
+      });
+    },
+  };
+  return { mw, calls };
+}
+
+const noFallbackOp: RunOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+  ...runOp,
+  name: "mw-coverage-no-fallback",
+  noFallback: true,
+};
+
+describe("callOp middleware coverage (ADR-018 Wave 2 + ADR-019 §5)", () => {
+  test("kind:run dispatches through middleware chain via runAsSession", async () => {
+    const config = makeNaxConfig();
+    const realManager = new AgentManager(config);
+    const { mw, calls } = makeRecorder();
+
+    const sessionManager = makeSessionManager({
+      openSession: mock(async () => ({ id: "test-handle", agentName: "claude" }) as SessionHandle),
+      sendPrompt: mock(async (_handle: SessionHandle, prompt: string): Promise<TurnResult> => ({
+        output: `runOp says: ${prompt}`,
+        tokenUsage: { inputTokens: 10, outputTokens: 5 },
+        internalRoundTrips: 1,
+        cost: { total: 0.001 },
+      })),
+    });
+
+    // makeTestRuntime → createRuntime calls configureRuntime() on the manager,
+    // which overwrites sendPrompt with sessionManager.sendPrompt. Our recorded
+    // middleware survives because configureRuntime only overrides middleware
+    // when the new opts pass it explicitly — the default chain is the runtime
+    // chain. We re-apply our recorder middleware AFTER createRuntime so it
+    // wins.
+    const runtime = makeTestRuntime({ agentManager: realManager, sessionManager });
+    realManager.configureRuntime({ middleware: MiddlewareChain.from([mw]) });
+
+    await callOp(
+      {
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-001",
+      },
+      runOp,
+      { text: "hello-from-run-op" },
+    );
+
+    // Pre-fix: zero entries (middleware bypassed). Post-fix: exactly one entry.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.kind).toBe("run");
+    expect(calls[0]?.agentName).toBe("claude");
+    expect(calls[0]?.promptIncludes).toContain("hello-from-run-op");
+  });
+
+  test("kind:run with noFallback:true ALSO fires middleware (C1 regression)", async () => {
+    // Regression for review-Finding C1: an earlier draft routed noFallback ops
+    // through wrapAdapterAsManager, whose runWithFallback ignored executeHop
+    // and bypassed the middleware chain. Confirm the fixed path goes through
+    // the real AgentManager so middleware fires regardless of noFallback.
+    const config = makeNaxConfig();
+    const realManager = new AgentManager(config);
+    const { mw, calls } = makeRecorder();
+
+    const sessionManager = makeSessionManager({
+      openSession: mock(async () => ({ id: "test-handle", agentName: "claude" }) as SessionHandle),
+      sendPrompt: mock(async (_handle: SessionHandle, prompt: string): Promise<TurnResult> => ({
+        output: `noFallback says: ${prompt}`,
+        tokenUsage: { inputTokens: 5, outputTokens: 5 },
+        internalRoundTrips: 1,
+        cost: { total: 0.0005 },
+      })),
+    });
+    const runtime = makeTestRuntime({ agentManager: realManager, sessionManager });
+    realManager.configureRuntime({ middleware: MiddlewareChain.from([mw]) });
+
+    await callOp(
+      {
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-002",
+      },
+      noFallbackOp,
+      { text: "no-fallback-prompt" },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.kind).toBe("run");
+    expect(calls[0]?.promptIncludes).toContain("no-fallback-prompt");
+  });
+});

--- a/test/unit/operations/build-hop-callback.test.ts
+++ b/test/unit/operations/build-hop-callback.test.ts
@@ -3,6 +3,7 @@ import { buildHopCallback, _buildHopCallbackDeps } from "../../../src/operations
 import type { BuildHopCallbackContext } from "../../../src/operations/build-hop-callback";
 import { makeNaxConfig, makeSessionManager, makeStory } from "../../helpers";
 import type { IAgentManager } from "../../../src/agents/manager-types";
+import { SessionFailureError } from "../../../src/agents/types";
 import type { AgentRunOptions, SessionHandle, TurnResult } from "../../../src/agents/types";
 import type { AdapterFailure, ContextBundle } from "../../../src/context/engine";
 
@@ -178,6 +179,120 @@ describe("buildHopCallback — runAsSession throws", () => {
     expect(hop.result.success).toBe(false);
     expect(hop.result.exitCode).toBe(1);
     expect(hop.result.output).toContain("session error");
+  });
+});
+
+describe("buildHopCallback — failure classification (Finding 3)", () => {
+  test("preserves SessionFailureError adapterFailure with rate-limit outcome", async () => {
+    const failure: AdapterFailure = {
+      outcome: "fail-rate-limit",
+      category: "availability",
+      message: "rate limited by upstream",
+      retriable: true,
+    };
+    const agentManager = makeAgentManagerStub(() =>
+      Promise.reject(new SessionFailureError("rate limit", failure)),
+    );
+    const sessionManager = makeSessionManager();
+    const ctx = makeCtx({ agentManager, sessionManager });
+    const baseOptions = makeBaseOptions("p", ctx.config);
+    const cb = buildHopCallback(ctx, SESSION_ID, baseOptions);
+
+    const hop = await cb("claude", undefined, undefined, baseOptions);
+
+    expect(sessionManager.closeSession).toHaveBeenCalledTimes(1);
+    expect(hop.result.success).toBe(false);
+    expect(hop.result.rateLimited).toBe(true);
+    expect(hop.result.adapterFailure?.outcome).toBe("fail-rate-limit");
+    expect(hop.result.adapterFailure?.category).toBe("availability");
+  });
+
+  test("preserves SessionFailureError adapterFailure with auth-error outcome", async () => {
+    const failure: AdapterFailure = {
+      outcome: "fail-auth",
+      category: "availability",
+      message: "missing credentials",
+      retriable: false,
+    };
+    const agentManager = makeAgentManagerStub(() =>
+      Promise.reject(new SessionFailureError("auth fail", failure)),
+    );
+    const ctx = makeCtx({ agentManager });
+    const baseOptions = makeBaseOptions("p", ctx.config);
+    const cb = buildHopCallback(ctx, SESSION_ID, baseOptions);
+
+    const hop = await cb("claude", undefined, undefined, baseOptions);
+
+    expect(hop.result.success).toBe(false);
+    expect(hop.result.rateLimited).toBe(false);
+    expect(hop.result.adapterFailure?.outcome).toBe("fail-auth");
+    expect(hop.result.adapterFailure?.message).toBe("missing credentials");
+  });
+
+  test("falls back to generic availability/fail-adapter-error for non-typed errors", async () => {
+    const agentManager = makeAgentManagerStub(() => Promise.reject(new Error("plain network error")));
+    const ctx = makeCtx({ agentManager });
+    const baseOptions = makeBaseOptions("p", ctx.config);
+    const cb = buildHopCallback(ctx, SESSION_ID, baseOptions);
+
+    const hop = await cb("claude", undefined, undefined, baseOptions);
+
+    expect(hop.result.success).toBe(false);
+    expect(hop.result.rateLimited).toBe(false);
+    expect(hop.result.adapterFailure?.outcome).toBe("fail-adapter-error");
+    expect(hop.result.adapterFailure?.category).toBe("availability");
+    expect(hop.result.output).toContain("plain network error");
+  });
+});
+
+describe("buildHopCallback — hopBody (multi-prompt within one hop)", () => {
+  test("invokes hopBody with bound send closure; runs initial prompt followed by retry", async () => {
+    const turn1 = makeStubTurnResult("first-output");
+    const turn2 = makeStubTurnResult("second-output");
+    let runAsCount = 0;
+    const agentManager = makeAgentManagerStub(() => {
+      runAsCount++;
+      return Promise.resolve(runAsCount === 1 ? turn1 : turn2);
+    });
+    const sessionManager = makeSessionManager();
+    const observed: string[] = [];
+
+    const ctx = makeCtx({
+      agentManager,
+      sessionManager,
+      hopBody: async (initial, body) => {
+        observed.push(initial);
+        const a = await body.send(initial);
+        observed.push(`after-first:${a.output}`);
+        return body.send("retry-prompt");
+      },
+      hopBodyInput: { foo: "bar" },
+    });
+    const baseOptions = makeBaseOptions("initial-prompt", ctx.config);
+    const cb = buildHopCallback(ctx, SESSION_ID, baseOptions);
+
+    const hop = await cb("claude", undefined, undefined, baseOptions);
+
+    expect(observed).toEqual(["initial-prompt", "after-first:first-output"]);
+    expect(runAsCount).toBe(2);
+    expect(hop.result.success).toBe(true);
+    expect(hop.result.output).toBe("second-output");
+    // openSession + closeSession still called exactly once across both prompts
+    expect(sessionManager.openSession).toHaveBeenCalledTimes(1);
+    expect(sessionManager.closeSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("default body (no hopBody) sends initial prompt once", async () => {
+    const agentManager = makeAgentManagerStub();
+    const ctx = makeCtx({ agentManager });
+    const baseOptions = makeBaseOptions("only-prompt", ctx.config);
+    const cb = buildHopCallback(ctx, SESSION_ID, baseOptions);
+
+    await cb("claude", undefined, undefined, baseOptions);
+
+    expect(agentManager.runAsSession).toHaveBeenCalledTimes(1);
+    const promptArg = (agentManager.runAsSession as ReturnType<typeof mock>).mock.calls[0]?.[2] as string;
+    expect(promptArg).toBe("only-prompt");
   });
 });
 

--- a/test/unit/operations/call.test.ts
+++ b/test/unit/operations/call.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, mock } from "bun:test";
 import { callOp } from "../../../src/operations/call";
 import type { CompleteOperation, RunOperation } from "../../../src/operations/types";
 import { pickSelector } from "../../../src/config";
-import { makeTestRuntime, makeMockAgentManager, makeSessionManager } from "../../helpers";
+import { makeMockAgentManager, makeSessionManager, makeTestRuntime } from "../../helpers";
 import { DEFAULT_CONFIG } from "../../../src/config";
 import type { CompleteResult } from "../../../src/agents/types";
 
@@ -53,17 +53,15 @@ describe("callOp — kind:complete", () => {
   });
 });
 
-describe("callOp — kind:run", () => {
-  test("calls sessionManager.runInSession (phase-B form) with session name and ctx.agentName", async () => {
-    const runInSessionMock = mock(async () => ({
-      output: "ran pinned",
-      tokenUsage: { inputTokens: 0, outputTokens: 0 },
-      internalRoundTrips: 0,
-    }));
-    // Object.assign mutates the base mock and overrides runInSession without
-    // hitting the overloaded-type incompatibility at the Partial<ISessionManager> boundary.
-    const sessionManager = Object.assign(makeSessionManager(), { runInSession: runInSessionMock });
-    const agentManager = makeMockAgentManager();
+describe("callOp — kind:run (ADR-019 §5)", () => {
+  test("dispatches via agentManager.runWithFallback with executeHop callback", async () => {
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (_req) => ({
+        result: { success: true, exitCode: 0, output: "ran via fallback", rateLimited: false, durationMs: 1, estimatedCost: 0, agentFallbacks: [] },
+        fallbacks: [],
+      }),
+    });
+    const sessionManager = makeSessionManager();
     const runtime = makeTestRuntime({ agentManager, sessionManager });
 
     const result = await callOp(
@@ -78,20 +76,60 @@ describe("callOp — kind:run", () => {
       { text: "hello world" },
     );
 
-    expect(runInSessionMock).toHaveBeenCalledTimes(1);
-    expect(runInSessionMock).toHaveBeenCalledWith(
-      "nax-00000000",
-      expect.any(String),
-      expect.objectContaining({ agentName: "opencode" }),
-    );
-    expect(result).toBe("ran pinned");
+    expect(agentManager.runWithFallback).toHaveBeenCalledTimes(1);
+    const reqArg = (agentManager.runWithFallback as ReturnType<typeof mock>).mock.calls[0]?.[0] as { executeHop?: unknown; runOptions: { storyId?: string } };
+    expect(reqArg.executeHop).toBeTypeOf("function");
+    expect(reqArg.runOptions.storyId).toBe("US-001");
+    expect(result).toBe("ran via fallback");
   });
 
-  test("throws CALL_OP_NO_OUTPUT when session returns no output", async () => {
-    // Default makeSessionManager() stub returns output: "" — the empty string
-    // triggers callOp's no-output guard.
+  test("noFallback ops still dispatch via real runWithFallback with noFallback:true flag", async () => {
+    // Post-C1 fix: noFallback no longer routes through wrapAdapterAsManager.
+    // It calls the real agentManager.runWithFallback with `noFallback: true`,
+    // which short-circuits the swap branch (manager.ts) but preserves the
+    // middleware envelope. This test pins the dispatch path.
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => ({
+        result: { success: true, exitCode: 0, output: "single-agent output", rateLimited: false, durationMs: 1, estimatedCost: 0, agentFallbacks: [] },
+        fallbacks: [],
+        // Surface req fields for assertion via the mock's call records below.
+        ...({ _req: req } as Record<string, unknown>),
+      }),
+    });
     const sessionManager = makeSessionManager();
-    const agentManager = makeMockAgentManager();
+    const runtime = makeTestRuntime({ agentManager, sessionManager });
+
+    const noFallbackOp: RunOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      ...runEchoOp,
+      noFallback: true,
+    };
+
+    const result = await callOp(
+      {
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-001",
+      },
+      noFallbackOp,
+      { text: "hello" },
+    );
+
+    expect(agentManager.runWithFallback).toHaveBeenCalledTimes(1);
+    const reqArg = (agentManager.runWithFallback as ReturnType<typeof mock>).mock.calls[0]?.[0] as { noFallback?: boolean };
+    expect(reqArg.noFallback).toBe(true);
+    expect(result).toBe("single-agent output");
+  });
+
+  test("throws CALL_OP_NO_OUTPUT when run returns no output", async () => {
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (_req) => ({
+        result: { success: false, exitCode: 1, output: "", rateLimited: false, durationMs: 1, estimatedCost: 0, agentFallbacks: [] },
+        fallbacks: [],
+      }),
+    });
+    const sessionManager = makeSessionManager();
     const runtime = makeTestRuntime({ agentManager, sessionManager });
 
     let thrown: Error | null = null;


### PR DESCRIPTION
## Summary

PR 1 of a 3-PR series realigning callOp's run-path with ADR-019 §5. Closes review Findings 1, 3, 5, 6 from [docs/findings/2026-04-27-adr-018-019-runtime-layering-review-synthesis.md](docs/findings/2026-04-27-adr-018-019-runtime-layering-review-synthesis.md). Full design rationale in [docs/specs/2026-04-27-callop-runpath-realignment.md](docs/specs/2026-04-27-callop-runpath-realignment.md).

**Problem.** `callOp` for `kind:"run"` called `sessionManager.runInSession` directly. Three consequences from one routing divergence:
- **Finding 1** — cross-agent fallback was bypassed; `runInSession` doesn't iterate the chain.
- **Finding 5** — the Wave-2 middleware envelope (audit, cost, cancellation, logging) was bypassed; middleware lives on `AgentManager.runAsSession`.
- **Finding 6** — the `noFallback` flag on `RunOperation` was declared but never read.
- **Finding 3** — `buildHopCallback` flattened all errors into generic `availability/fail-adapter-error`, losing typed `SessionFailureError` classifications (rate-limit, auth, quota).

**Fix.** Per ADR-019 §5, `callOp` now constructs `buildHopCallback` and dispatches via `agentManager.runWithFallback({ executeHop, noFallback }, dispatchAgent)`. The hop callback owns rebuild + open + send + close per hop, using `agentManager.runAsSession` internally so middleware fires. `noFallback: true` short-circuits the swap branch without losing the envelope.

## Notable additions

- **`hopBody?: HopBody<I>` on `RunOperation`** — optional intra-hop multi-prompt body. Semantic + adversarial review ops migrate their same-session JSON-parse retry into a `hopBody`, replacing the previous `agentManager.run({ keepOpen: true })` approach. The retry now runs on the same session as the initial prompt with no special-cased session lifecycle.
- **`model?: ConfiguredModel` on `RunOperation` / `CompleteOperation`** — replaces the old `modelTier?: ModelTier`. Accepts a tier label *or* a `{ agent, model }` pin for cross-agent overrides. Resolved via `resolveConfiguredModel`. Fixes a latent bug where `ctx.agentName` was used to resolve the model but never used to root the fallback chain.
- **Typed failure preservation** — `buildHopCallback` now catches `SessionFailureError` and surfaces its `adapterFailure` so swap policy sees real outcomes instead of generic reclassifications.

## Out of scope (deferred to follow-up PRs)

- **Finding 2** — `keepOpen:` retirement across review/rectification/autofix call sites. PR 2 in the sequence.
- **Finding 4** — review-stage debate config validation (one-shot only). PR 3.
- **Findings 7–9** — adapter surface stragglers, cross-import audit, `_deps.createManager` carve-out. PR 3.
- **TDD ops via callOp** — TDD still routes via `runTddSessionOp` → `runTddSession` → `wrapAdapterAsManager(agent).run(...)`. The `noFallback` infrastructure is in place for when TDD migrates.

## Behavior changes worth flagging

- Review and rectification ops now participate in cross-agent fallback. Single-agent setups see no change. Multi-agent fallback chains will now fire on review/rectification availability failures where they previously did not.
- Audit and cost middleware now record entries for every `kind:"run"` callOp dispatch. Pre-PR, those entries were missing; users reading historical `.nax/audit/` or `.nax/cost/` JSONL files should treat the gap as known.

## Code review

A self-review via the `code-reviewer` agent found one critical issue (the original noFallback path used `wrapAdapterAsManager`, which silently bypasses `executeHop` — defeating the PR's purpose for that path) plus several lower-severity issues. All were fixed before commit; the fix added a new regression test (`kind:run with noFallback:true ALSO fires middleware`) so the boundary can't drift again.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (490 files, 0 fixes)
- [x] `bun run test:bail` — all 3 phases passed (unit + integration + UI)
- [x] Scoped: `bun test test/unit/operations/ test/integration/operations/` — 130 pass, 0 fail
- [x] New regression tests added: failure classification (3), hopBody (2), noFallback middleware coverage (1), runWithFallback dispatch (2)
- [ ] Soak in canary release before promoting to stable; watch for fallback-iteration regressions in review/rectification flows