### PR TITLE
fix: guard keepOpen behind legacy-fallback runtime check (ADR-019 Phase D Finding 2)

### DIFF
--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -13,6 +13,7 @@
 import type { IAgentManager } from "../../agents";
 import { resolveModelForAgent } from "../../config";
 import { getLogger } from "../../logger";
+import { buildHopCallback } from "../../operations/build-hop-callback";
 import type { UserStory } from "../../prd";
 import { RectifierPromptBuilder } from "../../prompts";
 import type { ReviewCheckResult } from "../../review/types";
@@ -148,23 +149,49 @@ export async function runTestWriterRectification(
   }
   const modelTier = ctx.rootConfig.tdd?.sessionTiers?.testWriter ?? "balanced";
   const modelDef = resolveModelForAgent(ctx.rootConfig.models, defaultAgent, modelTier, defaultAgent);
+  const runOptions = {
+    prompt: twPrompt,
+    workdir: ctx.workdir,
+    modelTier,
+    modelDef,
+    timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
+    pipelineStage: "rectification" as const,
+    config: ctx.config,
+    projectDir: ctx.projectDir,
+    maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
+    featureName: ctx.prd.feature,
+    storyId: ctx.story.id,
+    sessionRole: "test-writer" as const,
+  };
   try {
+    if (ctx.runtime) {
+      // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback.
+      // Each call opens a fresh session; keepOpen is not used in the runtime path.
+      const executeHop = buildHopCallback(
+        {
+          sessionManager: ctx.runtime.sessionManager,
+          agentManager: ctx.runtime.agentManager,
+          story,
+          config: ctx.config,
+          projectDir: ctx.projectDir,
+          featureName: ctx.prd.feature ?? "",
+          workdir: ctx.workdir,
+          effectiveTier: modelTier,
+          defaultAgent,
+          pipelineStage: "rectification",
+        },
+        ctx.sessionId,
+        runOptions,
+      );
+      const outcome = await agentManager.runWithFallback(
+        { runOptions, signal: ctx.runtime.signal, executeHop },
+        defaultAgent,
+      );
+      return outcome.result.estimatedCost ?? 0;
+    }
+    // Legacy keepOpen path — used when no runtime is available (standalone callers).
     const twResult = await agentManager.run({
-      runOptions: {
-        prompt: twPrompt,
-        workdir: ctx.workdir,
-        modelTier,
-        modelDef,
-        timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
-        pipelineStage: "rectification",
-        config: ctx.config,
-        projectDir: ctx.projectDir,
-        maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
-        featureName: ctx.prd.feature,
-        storyId: ctx.story.id,
-        sessionRole: "test-writer",
-        keepOpen,
-      },
+      runOptions: { ...runOptions, keepOpen },
     });
     return twResult.estimatedCost ?? 0;
   } catch {

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -21,6 +21,7 @@
 
 import { resolveModelForAgent } from "../../config";
 import { getLogger } from "../../logger";
+import { buildHopCallback } from "../../operations/build-hop-callback";
 import type { UserStory } from "../../prd";
 import { RectifierPromptBuilder } from "../../prompts";
 import { runQualityCommand } from "../../quality";
@@ -539,26 +540,55 @@ async function runAgentRectification(
         defaultAgent,
       );
       const isLastAttempt = currentAttempt >= maxAttempts;
+      const runOptions = {
+        prompt,
+        workdir: ctx.workdir,
+        modelTier,
+        modelDef,
+        timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
+        pipelineStage: "rectification" as const,
+        config: ctx.config,
+        projectDir: ctx.projectDir,
+        maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
+        featureName: ctx.prd.feature,
+        storyId: ctx.story.id,
+        sessionRole: "implementer" as const,
+      };
       let result: import("../../agents").AgentResult;
       try {
-        result = await agentManager.run({
-          runOptions: {
-            prompt,
-            workdir: ctx.workdir,
-            modelTier,
-            modelDef,
-            timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
-            pipelineStage: "rectification",
-            config: ctx.config,
-            projectDir: ctx.projectDir,
-            maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
-            featureName: ctx.prd.feature,
-            storyId: ctx.story.id,
-            sessionRole: "implementer",
-            keepOpen: !isLastAttempt,
-          },
-        });
-        sessionConfirmedOpen = true;
+        if (ctx.runtime) {
+          // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback.
+          // Each attempt opens a fresh session (openSession → runAsSession → closeSession).
+          // No cross-attempt session continuity; session lifecycle managed by buildHopCallback.
+          const executeHop = buildHopCallback(
+            {
+              sessionManager: ctx.runtime.sessionManager,
+              agentManager: ctx.runtime.agentManager,
+              story: ctx.story,
+              config: ctx.config,
+              projectDir: ctx.projectDir,
+              featureName: ctx.prd.feature ?? "",
+              workdir: ctx.workdir,
+              effectiveTier: modelTier,
+              defaultAgent,
+              pipelineStage: "rectification",
+            },
+            ctx.sessionId,
+            runOptions,
+          );
+          const outcome = await agentManager.runWithFallback(
+            { runOptions, signal: ctx.runtime.signal, executeHop },
+            defaultAgent,
+          );
+          result = outcome.result;
+          sessionConfirmedOpen = false;
+        } else {
+          // Legacy keepOpen path — used when no runtime is available (standalone callers).
+          result = await agentManager.run({
+            runOptions: { ...runOptions, keepOpen: !isLastAttempt },
+          });
+          sessionConfirmedOpen = true;
+        }
       } catch (err) {
         sessionConfirmedOpen = false; // Session state unknown — next attempt uses full prompt
         throw err;

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -10,6 +10,7 @@ import type { IAgentManager } from "../agents";
 import type { ModelTier, NaxConfig } from "../config";
 import { type rectificationGateConfigSelector, resolveModelForAgent } from "../config";
 import type { getLogger } from "../logger";
+import { buildHopCallback } from "../operations/build-hop-callback";
 import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
 import type { FailureRecord } from "../prompts";
@@ -91,6 +92,7 @@ export async function runFullSuiteGate(
   storyFromRef?: string,
   sessionManager?: import("../session").ISessionManager,
   sessionId?: string,
+  runtime?: import("../runtime").NaxRuntime,
 ): Promise<{ passed: boolean; cost: number }> {
   const rectificationEnabled = config.execution.rectification?.enabled ?? false;
   if (!rectificationEnabled) return { passed: false, cost: 0 };
@@ -179,6 +181,7 @@ export async function runFullSuiteGate(
         projectDir,
         sessionManager,
         sessionId,
+        runtime,
       );
     }
 
@@ -234,6 +237,7 @@ async function runRectificationLoop(
   projectDir?: string,
   sessionManager?: import("../session").ISessionManager,
   sessionId?: string,
+  runtime?: import("../runtime").NaxRuntime,
 ): Promise<{ passed: boolean; cost: number }> {
   logger.warn("tdd", "Full suite gate detected regressions", {
     storyId: story.id,
@@ -278,30 +282,60 @@ async function runRectificationLoop(
       const isLastAttempt = currentAttempt >= rectificationConfig.maxRetries;
       const rectifyBeforeRef = (await captureGitRef(workdir)) ?? "HEAD";
       const defaultAgent = agentManager.getDefault();
-      const rectifyResult = await agentManager.run({
-        runOptions: {
-          prompt,
-          workdir,
-          modelTier: implementerTier,
-          modelDef: resolveModelForAgent(
-            config.models,
-            story.routing?.agent ?? defaultAgent,
-            implementerTier,
+
+      const runOptions = {
+        prompt,
+        workdir,
+        modelTier: implementerTier,
+        modelDef: resolveModelForAgent(
+          config.models,
+          story.routing?.agent ?? defaultAgent,
+          implementerTier,
+          defaultAgent,
+        ),
+        timeoutSeconds: config.execution.sessionTimeoutSeconds,
+        pipelineStage: "rectification" as const,
+        // Cast required: AgentRunOptions.config expects NaxConfig, but only the picked
+        // subset of keys is actually used by the adapter (permissions, models, agent).
+        config: config as unknown as NaxConfig,
+        projectDir,
+        maxInteractionTurns: config.agent?.maxInteractionTurns,
+        featureName,
+        storyId: story.id,
+        sessionRole: "implementer" as const,
+      };
+
+      let rectifyResult: import("../agents").AgentResult;
+      if (runtime) {
+        // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback.
+        // Each attempt opens a fresh session; keepOpen is not used in the runtime path.
+        const executeHop = buildHopCallback(
+          {
+            sessionManager: runtime.sessionManager,
+            agentManager: runtime.agentManager,
+            story,
+            config: config as unknown as NaxConfig,
+            projectDir,
+            featureName: featureName ?? "",
+            workdir,
+            effectiveTier: implementerTier,
             defaultAgent,
-          ),
-          timeoutSeconds: config.execution.sessionTimeoutSeconds,
-          pipelineStage: "rectification",
-          // Cast required: AgentRunOptions.config expects NaxConfig, but only the picked
-          // subset of keys is actually used by the adapter (permissions, models, agent).
-          config: config as unknown as NaxConfig,
-          projectDir,
-          maxInteractionTurns: config.agent?.maxInteractionTurns,
-          featureName,
-          storyId: story.id,
-          sessionRole: "implementer",
-          keepOpen: !isLastAttempt,
-        },
-      });
+            pipelineStage: "rectification",
+          },
+          sessionId,
+          runOptions,
+        );
+        const outcome = await agentManager.runWithFallback(
+          { runOptions, signal: runtime.signal, executeHop },
+          defaultAgent,
+        );
+        rectifyResult = outcome.result;
+      } else {
+        // Legacy keepOpen path — used when no runtime is available (standalone callers).
+        rectifyResult = await agentManager.run({
+          runOptions: { ...runOptions, keepOpen: !isLastAttempt },
+        });
+      }
 
       // G5: bind updated protocolIds after each rectification attempt so the session descriptor
       // reflects the session that actually ran (may change after internal session retries).

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -205,9 +205,10 @@ export async function runTddSession(
   logger.info("tdd", `-> Session: ${role}`, { role, storyId: story.id, lite });
 
   // When rectification is enabled, keep the implementer session open after it finishes.
-  // The rectification gate uses the same session name and will resume it directly — so
-  // the implementer retains full context of what it built.
-  // The session sweep (or the last rectification attempt) handles final cleanup.
+  // Legacy path: the rectification gate resumes the same session directly, preserving context.
+  // ADR-019 runtime path: each rectification hop opens a fresh session via buildHopCallback;
+  // keepOpen=true causes session-run-hop to skip closeSession so the sweep handles cleanup.
+  // This flag lives in runOptions and is meaningful regardless of execution path (ADR-019 Phase D).
   const keepOpen = role === "implementer" && (config.execution.rectification?.enabled ?? false);
 
   const agentRunOptions = {

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -14,6 +14,7 @@ import { resolveModelForAgent } from "../config";
 import type { DebateStageConfig, Debater } from "../debate/types";
 import { escalateTier as _escalateTier } from "../execution/escalation/escalation";
 import { getSafeLogger } from "../logger";
+import { buildHopCallback } from "../operations/build-hop-callback";
 import type { PipelineContext } from "../pipeline/types";
 import type { UserStory } from "../prd";
 import { getExpectedFiles } from "../prd";
@@ -73,6 +74,12 @@ export interface RectificationLoopOptions {
    * Required alongside sessionManager for bindHandle to work.
    */
   sessionId?: string;
+  /**
+   * NaxRuntime (ADR-019 Phase D). When present, each rectification attempt dispatches
+   * via buildHopCallback → runWithFallback (fresh session per hop). keepOpen is only
+   * used in the legacy path when runtime is absent.
+   */
+  runtime?: import("../runtime").NaxRuntime;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -168,6 +175,7 @@ export async function runRectificationLoop(
     testScopedTemplate,
     sessionManager,
     sessionId,
+    runtime,
   } = opts;
   const logger = getSafeLogger();
   const agentManager = opts.agentManager ?? _rectificationDeps.agentManager;
@@ -279,23 +287,52 @@ export async function runRectificationLoop(
 
       const isLastAttempt = currentAttempt >= rectificationConfig.maxRetries;
 
-      const agentResult = await agentManager.run({
-        runOptions: {
-          prompt,
-          workdir,
-          modelTier,
-          modelDef,
-          timeoutSeconds: config.execution.sessionTimeoutSeconds,
-          pipelineStage: "rectification",
-          config,
-          projectDir,
-          maxInteractionTurns: config.agent?.maxInteractionTurns,
-          featureName,
-          storyId: story.id,
-          sessionRole: "implementer",
-          keepOpen: !isLastAttempt,
-        },
-      });
+      const runOptions = {
+        prompt,
+        workdir,
+        modelTier,
+        modelDef,
+        timeoutSeconds: config.execution.sessionTimeoutSeconds,
+        pipelineStage: "rectification" as const,
+        config,
+        projectDir,
+        maxInteractionTurns: config.agent?.maxInteractionTurns,
+        featureName,
+        storyId: story.id,
+        sessionRole: "implementer" as const,
+      };
+
+      let agentResult: import("../agents").AgentResult;
+      if (runtime) {
+        // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback.
+        // Each attempt opens a fresh session; keepOpen is not used in the runtime path.
+        const executeHop = buildHopCallback(
+          {
+            sessionManager: runtime.sessionManager,
+            agentManager: runtime.agentManager,
+            story,
+            config,
+            projectDir,
+            featureName: featureName ?? "",
+            workdir,
+            effectiveTier: modelTier,
+            defaultAgent,
+            pipelineStage: "rectification",
+          },
+          sessionId,
+          runOptions,
+        );
+        const outcome = await agentManager.runWithFallback(
+          { runOptions, signal: runtime.signal, executeHop },
+          defaultAgent,
+        );
+        agentResult = outcome.result;
+      } else {
+        // Legacy keepOpen path — used when no runtime is available (standalone callers).
+        agentResult = await agentManager.run({
+          runOptions: { ...runOptions, keepOpen: !isLastAttempt },
+        });
+      }
 
       costAccum += agentResult.estimatedCost ?? 0;
 


### PR DESCRIPTION
## Summary

Guards `keepOpen`/`closePhysicalSession` behind the `if (runtime) { ADR-019 path } else { legacy keepOpen }` pattern in the 5 remaining files identified in **Finding 2** of `docs/findings/2026-04-27-adr-018-019-runtime-layering-review-synthesis.md`.

The reference pattern was already present in `src/review/semantic.ts` and `src/review/adversarial.ts`. This PR brings the remaining callers into conformance.

## Files Changed

| File | Change |
|---|---|
| `src/tdd/session-runner.ts` | `keepOpen` is a `runOptions` field (session lifecycle hint), not an adapter subprocess signal — set correctly regardless of execution path. Comment updated to describe both legacy and ADR-019 runtime paths. |
| `src/pipeline/stages/autofix-adversarial.ts` | `runTestWriterRectification` branches on `ctx.runtime` — ADR-019 path uses `buildHopCallback → runWithFallback` (fresh session per call); legacy `keepOpen` only in `else` branch. |
| `src/pipeline/stages/autofix.ts` | `runAgentRectification` execute handler branches on `ctx.runtime`; `sessionConfirmedOpen=false` in runtime path (fresh session per attempt, no continuation prompt reuse). |
| `src/verification/rectification-loop.ts` | Added `runtime?: NaxRuntime` to `RectificationLoopOptions`; execute handler uses `buildHopCallback` path when runtime present, legacy `keepOpen` path otherwise. |
| `src/tdd/rectification-gate.ts` | Added `runtime?` param to `runFullSuiteGate` and private `runRectificationLoop`; threaded through the call; same `if/else` guard. |

## Pattern Applied

```typescript
if (runtime) {
  // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback (fresh session per hop)
  const executeHop = buildHopCallback(ctx, sessionId, runOptions);
  const outcome = await agentManager.runWithFallback({ runOptions, signal: runtime.signal, executeHop }, defaultAgent);
  result = outcome.result;
} else {
  // Legacy keepOpen path — used when no runtime is available (standalone callers)
  result = await agentManager.run({ runOptions: { ...runOptions, keepOpen: !isLastAttempt } });
}
```

## Testing

- All 4 `session-runner-keep-open` tests pass
- All 24 `test/unit/tdd/` tests pass
- Typecheck: ✅ (exit 0)
- Lint: ✅ (exit 0)
- Pre-commit hooks (typecheck + biome + process.cwd check): ✅ all passed