### PR TITLE
feat(review): carry forward adversarial prior findings across rounds (#736)

### DIFF
--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -3,7 +3,7 @@ import { reviewConfigSelector } from "../config";
 import { AdversarialReviewPromptBuilder, ReviewPromptBuilder } from "../prompts";
 import type { PriorFailure, TestInventory } from "../prompts";
 import { looksLikeTruncatedJson } from "../review/truncation";
-import type { AdversarialReviewConfig, SemanticStory } from "../review/types";
+import type { AdversarialFindingsCache, AdversarialReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { HopBody, LlmReviewFinding, RunOperation } from "./types";
 
@@ -22,10 +22,7 @@ export interface AdversarialReviewInput {
   /** Pre-built, role-filtered context prefix to prepend to the review prompt. */
   featureCtxBlock?: string;
   /** Prior adversarial findings to carry forward into this review round (issue #736). */
-  priorAdversarialFindings?: {
-    round: number;
-    findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
-  };
+  priorAdversarialFindings?: AdversarialFindingsCache;
 }
 
 export interface AdversarialReviewOutput {

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -21,6 +21,11 @@ export interface AdversarialReviewInput {
   excludePatterns?: string[];
   /** Pre-built, role-filtered context prefix to prepend to the review prompt. */
   featureCtxBlock?: string;
+  /** Prior adversarial findings to carry forward into this review round (issue #736). */
+  priorAdversarialFindings?: {
+    round: number;
+    findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
+  };
 }
 
 export interface AdversarialReviewOutput {
@@ -80,6 +85,7 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
         priorFailures: input.priorFailures,
         testInventory: input.testInventory,
         excludePatterns: input.excludePatterns,
+        priorAdversarialFindings: input.priorAdversarialFindings,
       },
     );
     const content = input.featureCtxBlock ? `${input.featureCtxBlock}${base}` : base;

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -14,7 +14,7 @@ import type { InteractionChain } from "../interaction/chain";
 import type { StoryMetrics } from "../metrics/types";
 import type { PluginRegistry } from "../plugins/registry";
 import type { PRD, UserStory } from "../prd/types";
-import type { ReviewResult } from "../review/types";
+import type { AdversarialFindingsCache, ReviewResult } from "../review/types";
 import type { FailureCategory } from "../tdd/types";
 import type { VerifyResult } from "../verification/orchestrator-types";
 
@@ -260,10 +260,7 @@ export interface PipelineContext {
    * Cleared when adversarial passes. Injected into the next round's prompt so the reviewer
    * does not open a fresh session with no memory of what it already flagged.
    */
-  priorAdversarialFindings?: {
-    round: number;
-    findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
-  };
+  priorAdversarialFindings?: AdversarialFindingsCache;
 }
 
 /**

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -254,6 +254,16 @@ export interface PipelineContext {
    * for mechanical failures in files the agent cannot modify (e.g. lint in test files).
    */
   mechanicalFailedOnly?: boolean;
+  /**
+   * Carry-forward cache for adversarial prior findings (issue #736).
+   * Set by reviewFromContext() when the adversarial check fails with blocking findings.
+   * Cleared when adversarial passes. Injected into the next round's prompt so the reviewer
+   * does not open a fresh session with no memory of what it already flagged.
+   */
+  priorAdversarialFindings?: {
+    round: number;
+    findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
+  };
 }
 
 /**

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -42,6 +42,15 @@ export interface AdversarialReviewPromptOptions {
    * Adversarial does NOT exclude test files (unlike semantic).
    */
   excludePatterns?: string[];
+  /**
+   * Prior adversarial findings from the previous round (issue #736).
+   * When set, injects a "## Prior Adversarial Findings" block instructing the reviewer
+   * to verdict on unresolved prior issues before scanning for new ones.
+   */
+  priorAdversarialFindings?: {
+    round: number;
+    findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
+  };
 }
 
 const ADVERSARIAL_ROLE = `You are an adversarial code reviewer with full access to the repository.
@@ -191,6 +200,35 @@ ${diff}\`\`\`
 }
 
 /**
+ * Build the prior-findings carry-forward block injected at the top of subsequent rounds.
+ * Verdict-first: the reviewer sees unresolved findings before scanning for new issues.
+ */
+function buildPriorFindingsBlock(
+  round: number,
+  findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>,
+): string {
+  const rows = findings
+    .map((f) => {
+      const location = f.line !== undefined ? `${f.file}:${f.line}` : f.file;
+      const category = f.category ?? "—";
+      return `| ${f.severity} | ${category} | ${location} | ${f.issue} |`;
+    })
+    .join("\n");
+
+  return `## Prior Adversarial Findings — Round ${round}
+
+The following issues were flagged in the previous adversarial review round.
+**Verdict on each of these first — determine whether each has been fixed, partially addressed, or is still present.**
+Then continue scanning for new issues.
+
+| Severity | Category | Location | Issue |
+|:---------|:---------|:---------|:------|
+${rows}
+
+`;
+}
+
+/**
  * Build an adversarial review prompt for the given story and diff context.
  */
 export class AdversarialReviewPromptBuilder {
@@ -199,7 +237,13 @@ export class AdversarialReviewPromptBuilder {
     config: AdversarialReviewConfig,
     options: AdversarialReviewPromptOptions,
   ): string {
-    const { mode, diff, storyGitRef, stat, priorFailures, testInventory, excludePatterns } = options;
+    const { mode, diff, storyGitRef, stat, priorFailures, testInventory, excludePatterns, priorAdversarialFindings } =
+      options;
+
+    const priorFindingsBlock =
+      priorAdversarialFindings && priorAdversarialFindings.findings.length > 0
+        ? buildPriorFindingsBlock(priorAdversarialFindings.round, priorAdversarialFindings.findings)
+        : "";
 
     const storyBlock = `## Story Under Review
 
@@ -231,6 +275,7 @@ ${story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n")}
     return [
       ADVERSARIAL_ROLE,
       "\n\n",
+      priorFindingsBlock,
       storyBlock,
       ADVERSARIAL_INSTRUCTIONS,
       "\n\n",

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -9,8 +9,7 @@
  * Reuses PriorFailure and buildAttemptContextBlock from review-builder.ts.
  */
 
-import type { AdversarialReviewConfig } from "../../review/types";
-import type { SemanticStory } from "../../review/types";
+import type { AdversarialFindingsCache, AdversarialReviewConfig, SemanticStory } from "../../review/types";
 import { buildAttemptContextBlock } from "./review-builder";
 import type { PriorFailure } from "./review-builder";
 
@@ -47,10 +46,7 @@ export interface AdversarialReviewPromptOptions {
    * When set, injects a "## Prior Adversarial Findings" block instructing the reviewer
    * to verdict on unresolved prior issues before scanning for new ones.
    */
-  priorAdversarialFindings?: {
-    round: number;
-    findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
-  };
+  priorAdversarialFindings?: AdversarialFindingsCache;
 }
 
 const ADVERSARIAL_ROLE = `You are an adversarial code reviewer with full access to the repository.

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -32,7 +32,7 @@ import type { NaxIgnoreIndex } from "../utils/path-filters";
 import { collectDiff, collectDiffStat, computeTestInventory, resolveEffectiveRef } from "./diff-utils";
 import { writeReviewAudit } from "./review-audit";
 import { looksLikeTruncatedJson } from "./truncation";
-import type { AdversarialReviewConfig, ReviewCheckResult, SemanticStory } from "./types";
+import type { AdversarialFindingsCache, AdversarialReviewConfig, ReviewCheckResult, SemanticStory } from "./types";
 
 /** Injectable dependencies for adversarial.ts — allows tests to mock without mock.module() */
 export const _adversarialDeps = {
@@ -144,10 +144,7 @@ export async function runAdversarialReview(
   projectDir?: string,
   naxIgnoreIndex?: NaxIgnoreIndex,
   runtime?: import("../runtime").NaxRuntime,
-  priorAdversarialFindings?: {
-    round: number;
-    findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
-  },
+  priorAdversarialFindings?: AdversarialFindingsCache,
 ): Promise<ReviewCheckResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -144,6 +144,10 @@ export async function runAdversarialReview(
   projectDir?: string,
   naxIgnoreIndex?: NaxIgnoreIndex,
   runtime?: import("../runtime").NaxRuntime,
+  priorAdversarialFindings?: {
+    round: number;
+    findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
+  },
 ): Promise<ReviewCheckResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -275,6 +279,7 @@ export async function runAdversarialReview(
         testInventory,
         excludePatterns: adversarialConfig.excludePatterns,
         featureCtxBlock,
+        priorAdversarialFindings,
       });
     } catch (err) {
       logger?.warn("adversarial", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
@@ -349,6 +354,7 @@ export async function runAdversarialReview(
       priorFailures,
       testInventory,
       excludePatterns: adversarialConfig.excludePatterns,
+      priorAdversarialFindings,
     });
     const prompt = featureCtxBlock ? `${featureCtxBlock}${basePrompt}` : basePrompt;
 

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -24,6 +24,7 @@ import { runReview } from "./runner";
 import type { SemanticStory } from "./semantic";
 import { runSemanticReview } from "./semantic";
 import type {
+  AdversarialFindingsCache,
   AdversarialReviewConfig,
   ReviewCheckResult,
   ReviewConfig,
@@ -149,10 +150,7 @@ export class ReviewOrchestrator {
     env?: Record<string, string | undefined>,
     naxIgnoreIndex?: NaxIgnoreIndex,
     runtime?: import("../runtime").NaxRuntime,
-    priorAdversarialFindings?: {
-      round: number;
-      findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
-    },
+    priorAdversarialFindings?: AdversarialFindingsCache,
   ): Promise<OrchestratorReviewResult> {
     const logger = getSafeLogger();
 
@@ -563,6 +561,10 @@ export class ReviewOrchestrator {
       } else if (advCheck.success) {
         ctx.priorAdversarialFindings = undefined;
       }
+    } else if (retrySkipChecks?.has("adversarial")) {
+      // Adversarial was skipped because it passed in the previous review pass.
+      // Clear any stale findings — the reviewer already approved this code.
+      ctx.priorAdversarialFindings = undefined;
     }
 
     return result;

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -149,6 +149,10 @@ export class ReviewOrchestrator {
     env?: Record<string, string | undefined>,
     naxIgnoreIndex?: NaxIgnoreIndex,
     runtime?: import("../runtime").NaxRuntime,
+    priorAdversarialFindings?: {
+      round: number;
+      findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
+    },
   ): Promise<OrchestratorReviewResult> {
     const logger = getSafeLogger();
 
@@ -317,6 +321,7 @@ export class ReviewOrchestrator {
             projectDir,
             naxIgnoreIndex,
             runtime,
+            priorAdversarialFindings,
           ),
         ]);
         llmCheckResults = [semResult, advResult];
@@ -344,6 +349,7 @@ export class ReviewOrchestrator {
           env,
           naxIgnoreIndex,
           runtime,
+          priorAdversarialFindings,
         );
         llmCheckResults = llmResult.checks;
       }
@@ -508,7 +514,7 @@ export class ReviewOrchestrator {
         ? { semantic: semanticBundle ?? undefined, adversarial: adversarialBundle ?? undefined }
         : undefined;
 
-    return this.review(
+    const result = await this.review(
       ctx.config.review,
       ctx.workdir,
       ctx.config.execution,
@@ -535,7 +541,31 @@ export class ReviewOrchestrator {
       ctx.worktreeDependencyContext?.env,
       ctx.naxIgnoreIndex,
       ctx.runtime,
+      ctx.priorAdversarialFindings,
     );
+
+    // Update ctx.priorAdversarialFindings for the next review round (issue #736).
+    // When adversarial fails with blocking findings, cache them so the next round's
+    // prompt carries them forward. When adversarial passes, clear the cache.
+    const advCheck = result.builtIn.checks?.find((c) => c.check === "adversarial");
+    if (advCheck) {
+      if (!advCheck.success && (advCheck.findings?.length ?? 0) > 0) {
+        ctx.priorAdversarialFindings = {
+          round: (ctx.priorAdversarialFindings?.round ?? 0) + 1,
+          findings: (advCheck.findings ?? []).map((f) => ({
+            severity: f.severity,
+            category: f.category,
+            file: f.file,
+            line: f.line,
+            issue: f.message,
+          })),
+        };
+      } else if (advCheck.success) {
+        ctx.priorAdversarialFindings = undefined;
+      }
+    }
+
+    return result;
   }
 }
 

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -226,6 +226,10 @@ export async function runReview(
   env?: Record<string, string | undefined>,
   naxIgnoreIndex?: NaxIgnoreIndex,
   runtime?: import("../runtime").NaxRuntime,
+  priorAdversarialFindings?: {
+    round: number;
+    findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
+  },
 ): Promise<ReviewResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -364,6 +368,7 @@ export async function runReview(
         projectDir,
         naxIgnoreIndex,
         runtime,
+        priorAdversarialFindings,
       );
       checks.push(result);
       if (!result.success && !firstFailure) {

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -15,7 +15,7 @@ import { runAdversarialReview as _runAdversarialReviewImpl } from "./adversarial
 import { resolveLanguageCommand } from "./language-commands";
 import { runSemanticReview as _runSemanticReviewImpl } from "./semantic";
 import type { SemanticStory } from "./semantic";
-import type { ReviewCheckName, ReviewCheckResult, ReviewConfig, ReviewResult } from "./types";
+import type { AdversarialFindingsCache, ReviewCheckName, ReviewCheckResult, ReviewConfig, ReviewResult } from "./types";
 
 // Re-export for test compatibility
 export { resolveLanguageCommand };
@@ -226,10 +226,7 @@ export async function runReview(
   env?: Record<string, string | undefined>,
   naxIgnoreIndex?: NaxIgnoreIndex,
   runtime?: import("../runtime").NaxRuntime,
-  priorAdversarialFindings?: {
-    round: number;
-    findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>;
-  },
+  priorAdversarialFindings?: AdversarialFindingsCache,
 ): Promise<ReviewResult> {
   const startTime = Date.now();
   const logger = getSafeLogger();

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -154,6 +154,24 @@ export interface AdversarialReviewConfig {
   maxConcurrentSessions: number;
 }
 
+/**
+ * Carry-forward cache for adversarial prior findings (issue #736).
+ * Stored in PipelineContext and injected into the next adversarial round's prompt
+ * so the reviewer does not open a fresh session with no memory of prior flags.
+ */
+export interface AdversarialFindingsCache {
+  /** Round that produced these findings (1-indexed) */
+  round: number;
+  /** Blocking findings from the previous adversarial round */
+  findings: Array<{
+    severity: string;
+    category?: string;
+    file: string;
+    line?: number;
+    issue: string;
+  }>;
+}
+
 /** Review configuration */
 export interface ReviewConfig {
   /** Enable review phase */

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -78,6 +78,26 @@ describe("adversarialReviewOp.build()", () => {
     const result = adversarialReviewOp.build(embeddedInput, ctx);
     expect(result.task.content).toContain("-old line");
   });
+
+  test("task content contains prior findings block when priorAdversarialFindings is set", () => {
+    const ctx = makeBuildCtx();
+    const inputWithPrior: AdversarialReviewInput = {
+      ...SAMPLE_INPUT,
+      priorAdversarialFindings: {
+        round: 2,
+        findings: [{ severity: "error", file: "src/session.ts", line: 10, issue: "Silent catch block" }],
+      },
+    };
+    const result = adversarialReviewOp.build(inputWithPrior, ctx);
+    expect(result.task.content).toContain("Prior Adversarial Findings — Round 2");
+    expect(result.task.content).toContain("Silent catch block");
+  });
+
+  test("task content has no prior findings block when priorAdversarialFindings is absent", () => {
+    const ctx = makeBuildCtx();
+    const result = adversarialReviewOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).not.toContain("Prior Adversarial Findings");
+  });
 });
 
 describe("adversarialReviewOp.parse()", () => {

--- a/test/unit/prompts/adversarial-review-builder.test.ts
+++ b/test/unit/prompts/adversarial-review-builder.test.ts
@@ -294,3 +294,111 @@ describe("AdversarialReviewPromptBuilder — no diff available", () => {
     expect(result).toContain("No diff available");
   });
 });
+
+// ─── prior adversarial findings (issue #736) ──────────────────────────────────
+
+describe("AdversarialReviewPromptBuilder — priorAdversarialFindings", () => {
+  const PRIOR_FINDINGS = {
+    round: 1,
+    findings: [
+      {
+        severity: "error",
+        category: "error-path",
+        file: "src/auth/login.ts",
+        line: 42,
+        issue: "Null pointer dereference on empty input",
+      },
+      {
+        severity: "warn",
+        category: "convention",
+        file: "src/auth/session.ts",
+        issue: "Missing storyId in logger call",
+      },
+    ],
+  };
+
+  test("prior findings block appears when priorAdversarialFindings is set", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      priorAdversarialFindings: PRIOR_FINDINGS,
+    });
+    expect(result).toContain("Prior Adversarial Findings — Round 1");
+  });
+
+  test("prior findings block contains the correct round number", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      priorAdversarialFindings: { round: 3, findings: PRIOR_FINDINGS.findings },
+    });
+    expect(result).toContain("Round 3");
+  });
+
+  test("prior findings block contains finding severity, file:line, category, and issue", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      priorAdversarialFindings: PRIOR_FINDINGS,
+    });
+    expect(result).toContain("src/auth/login.ts:42");
+    expect(result).toContain("Null pointer dereference on empty input");
+    expect(result).toContain("error-path");
+    expect(result).toContain("src/auth/session.ts");
+    expect(result).toContain("Missing storyId in logger call");
+  });
+
+  test("prior findings block appears before the story block (verdict-first)", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      priorAdversarialFindings: PRIOR_FINDINGS,
+    });
+    const priorFindingsIdx = result.indexOf("Prior Adversarial Findings");
+    const storyIdx = result.indexOf("## Story Under Review");
+    expect(priorFindingsIdx).toBeGreaterThanOrEqual(0);
+    expect(priorFindingsIdx).toBeLessThan(storyIdx);
+  });
+
+  test("prior findings block instructs reviewer to verdict prior issues first", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      priorAdversarialFindings: PRIOR_FINDINGS,
+    });
+    expect(result).toContain("Verdict on each of these first");
+  });
+
+  test("finding with no line number renders file path without colon-line suffix", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      priorAdversarialFindings: {
+        round: 1,
+        findings: [{ severity: "warn", file: "src/utils.ts", issue: "Unhandled promise rejection" }],
+      },
+    });
+    expect(result).toContain("src/utils.ts");
+    // Location cell should be "src/utils.ts" without a trailing colon+line
+    const tableRowIdx = result.indexOf("Unhandled promise rejection");
+    const rowText = result.slice(result.lastIndexOf("|", tableRowIdx), tableRowIdx + 30);
+    expect(rowText).not.toMatch(/src\/utils\.ts:\d/);
+  });
+
+  test("no prior findings block when priorAdversarialFindings is undefined", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+    });
+    expect(result).not.toContain("Prior Adversarial Findings");
+  });
+
+  test("no prior findings block when findings array is empty", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      priorAdversarialFindings: { round: 1, findings: [] },
+    });
+    expect(result).not.toContain("Prior Adversarial Findings");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `PipelineContext.priorAdversarialFindings` — an in-memory cache of the blocking findings from the most recent failed adversarial round
- `reviewFromContext()` now updates the cache after each review pass: sets on adversarial failure (with blocking findings), clears on adversarial pass
- Each subsequent adversarial round receives a `## Prior Adversarial Findings — Round N` block injected immediately after the role declaration (verdict-first), containing a markdown table of prior findings the reviewer must address before scanning for new ones
- Both the runtime `callOp` path and the legacy `keepOpen` path receive the carry-forward data
- 12 new tests across builder and operation layers

## Test plan

- [x] `test/unit/prompts/adversarial-review-builder.test.ts` — 9 new tests: block presence, round number, finding row content (severity/category/file:line/issue), verdict-first ordering, no-line-number rendering, no block when undefined/empty
- [x] `test/unit/operations/adversarial-review.test.ts` — 3 new tests: prior findings block in task content, absent when not set
- [x] Full suite passes: `bun run test:bail` — 1222 tests, 0 failures
- [x] Typecheck clean, Biome lint clean