### PR TITLE
fix: thread AbortSignal into completeAs() for cancellation middleware

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -491,6 +491,7 @@ export class AgentManager implements IAgentManager {
       request: null,
       prompt,
       config: this._config,
+      signal: options.signal,
       resolvedPermissions,
       storyId: options.storyId,
       stage: options.pipelineStage,

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -239,6 +239,8 @@ export interface CompleteOptions {
   storyId?: string;
   /** Session role for disambiguation when the same story has multiple concurrent sessions */
   sessionRole?: string;
+  /** Abort signal for cancellation middleware support on complete() calls. */
+  signal?: AbortSignal;
   /**
    * Model tier hint for adapters that resolve model from config (e.g. ACP adapter).
    * When set alongside `config`, the adapter resolves the model from `config.models[modelTier]`

--- a/test/unit/agents/manager.test.ts
+++ b/test/unit/agents/manager.test.ts
@@ -312,4 +312,29 @@ describe("AgentManager — middleware envelope", () => {
     expect(afterCalls[0].agentName).toBe("codex");
     expect(afterCalls[0].prompt).toBe("swap-handoff-prompt");
   });
+
+  test("completeAs() threads signal into middleware context", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const mw: AgentMiddleware = {
+      name: "spy",
+      before: async (ctx: MiddlewareContext) => { capturedSignal = ctx.signal; },
+    };
+    const manager = makeMiddlewareManager(mw);
+    const controller = new AbortController();
+    try {
+      await manager.completeAs("claude", "prompt", { signal: controller.signal } as never);
+    } catch {}
+    expect(capturedSignal).toBe(controller.signal);
+  });
+
+  test("completeAs() middleware context has undefined signal when not provided", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const mw: AgentMiddleware = {
+      name: "spy",
+      before: async (ctx: MiddlewareContext) => { capturedSignal = ctx.signal; },
+    };
+    const manager = makeMiddlewareManager(mw);
+    try { await manager.completeAs("claude", "prompt", {} as never); } catch {}
+    expect(capturedSignal).toBeUndefined();
+  });
 });

--- a/test/unit/runtime/middleware/cancellation.test.ts
+++ b/test/unit/runtime/middleware/cancellation.test.ts
@@ -34,4 +34,17 @@ describe("cancellationMiddleware", () => {
     };
     await expect(mw.before!(ctx)).resolves.toBeUndefined();
   });
+
+  test("before() throws for kind='complete' with aborted signal", async () => {
+    const mw = cancellationMiddleware();
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const ctx: MiddlewareContext = {
+      runId: "r-001", agentName: "claude", kind: "complete",
+      request: null, prompt: "test", config: DEFAULT_CONFIG,
+      signal: ctrl.signal,
+      resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+    };
+    await expect(mw.before!(ctx)).rejects.toThrow("Agent call cancelled");
+  });
 });


### PR DESCRIPTION
## Summary

- Add `signal?: AbortSignal` to `CompleteOptions`
- Thread `options.signal` into `completeAs()` middleware context
- Cancellation middleware now fires for one-shot `complete()` calls (decompose, acceptance gen, router, debate proposers, rectification)

Closes #699.

## Changes

| File | Purpose |
|:-----|:--------|
| `src/agents/types.ts` | Add `signal` field to `CompleteOptions` |
| `src/agents/manager.ts` | Thread signal into `completeAs()` middleware context |
| `test/unit/agents/manager.test.ts` | 2 tests: signal threaded, undefined when absent |
| `test/unit/runtime/middleware/cancellation.test.ts` | 1 test: cancellation fires for `kind='complete'` |

## Verification

- 34 tests pass (manager + cancellation)
- Typecheck clean
- Lint clean