### PR TITLE
fix: prevent primary event batch overwrite in drain/flush (#700)

### DIFF
--- a/src/runtime/cost-aggregator.ts
+++ b/src/runtime/cost-aggregator.ts
@@ -112,6 +112,9 @@ function accumulate(snap: CostSnapshot, e: CostEvent): CostSnapshot {
 export class CostAggregator implements ICostAggregator {
   private readonly _events: CostEvent[] = [];
   private readonly _errors: CostErrorEvent[] = [];
+  private _draining = false;
+  private _inFlightEvents: CostEvent[] = [];
+  private _inFlightErrors: CostErrorEvent[] = [];
 
   constructor(
     private readonly _runId: string,
@@ -119,26 +122,41 @@ export class CostAggregator implements ICostAggregator {
   ) {}
 
   record(event: CostEvent): void {
+    if (this._draining) {
+      this._inFlightEvents.push(event);
+      return;
+    }
     this._events.push(event);
   }
 
   recordError(event: CostErrorEvent): void {
+    if (this._draining) {
+      this._inFlightErrors.push(event);
+      return;
+    }
     this._errors.push(event);
   }
 
   snapshot(): CostSnapshot {
-    return this._events.reduce(accumulate, { ...emptySnap(), errorCount: this._errors.length });
+    const allEvents = [...this._events, ...this._inFlightEvents];
+    const allErrors = [...this._errors, ...this._inFlightErrors];
+    return allEvents.reduce(accumulate, { ...emptySnap(), errorCount: allErrors.length });
   }
 
   byAgent(): Record<string, CostSnapshot> {
     const m: Record<string, CostSnapshot> = {};
     for (const e of this._events) m[e.agentName] = accumulate(m[e.agentName] ?? emptySnap(), e);
+    for (const e of this._inFlightEvents) m[e.agentName] = accumulate(m[e.agentName] ?? emptySnap(), e);
     return m;
   }
 
   byStage(): Record<string, CostSnapshot> {
     const m: Record<string, CostSnapshot> = {};
     for (const e of this._events) {
+      const k = e.stage ?? "unknown";
+      m[k] = accumulate(m[k] ?? emptySnap(), e);
+    }
+    for (const e of this._inFlightEvents) {
       const k = e.stage ?? "unknown";
       m[k] = accumulate(m[k] ?? emptySnap(), e);
     }
@@ -151,15 +169,47 @@ export class CostAggregator implements ICostAggregator {
       const k = e.storyId ?? "unknown";
       m[k] = accumulate(m[k] ?? emptySnap(), e);
     }
+    for (const e of this._inFlightEvents) {
+      const k = e.storyId ?? "unknown";
+      m[k] = accumulate(m[k] ?? emptySnap(), e);
+    }
     return m;
   }
 
   async drain(): Promise<void> {
-    if (this._events.length === 0 && this._errors.length === 0) return;
-    mkdirSync(this._drainDir, { recursive: true });
-    const path = join(this._drainDir, `${this._runId}.jsonl`);
-    const sorted = [...this._events, ...this._errors].sort((a, b) => a.ts - b.ts);
-    const content = `${sorted.map((e) => JSON.stringify(e)).join("\n")}\n`;
-    await _costAggDeps.write(path, content);
+    this._draining = true;
+    try {
+      const events = [...this._events];
+      const errors = [...this._errors];
+      this._events.length = 0;
+      this._errors.length = 0;
+
+      if (
+        events.length === 0 &&
+        errors.length === 0 &&
+        this._inFlightEvents.length === 0 &&
+        this._inFlightErrors.length === 0
+      )
+        return;
+
+      mkdirSync(this._drainDir, { recursive: true });
+      const path = join(this._drainDir, `${this._runId}.jsonl`);
+
+      const sorted = [...events, ...errors].sort((a, b) => a.ts - b.ts);
+      const content = `${sorted.map((e) => JSON.stringify(e)).join("\n")}\n`;
+      await _costAggDeps.write(path, content);
+
+      if (this._inFlightEvents.length > 0 || this._inFlightErrors.length > 0) {
+        const lateEvents = [...this._inFlightEvents];
+        const lateErrors = [...this._inFlightErrors];
+        this._inFlightEvents.length = 0;
+        this._inFlightErrors.length = 0;
+        const lateSorted = [...lateEvents, ...lateErrors].sort((a, b) => a.ts - b.ts);
+        const lateContent = `${lateSorted.map((e) => JSON.stringify(e)).join("\n")}\n`;
+        await _costAggDeps.write(path, lateContent);
+      }
+    } finally {
+      this._draining = false;
+    }
   }
 }

--- a/src/runtime/cost-aggregator.ts
+++ b/src/runtime/cost-aggregator.ts
@@ -113,8 +113,8 @@ export class CostAggregator implements ICostAggregator {
   private readonly _events: CostEvent[] = [];
   private readonly _errors: CostErrorEvent[] = [];
   private _draining = false;
-  private _inFlightEvents: CostEvent[] = [];
-  private _inFlightErrors: CostErrorEvent[] = [];
+  private readonly _inFlightEvents: CostEvent[] = [];
+  private readonly _inFlightErrors: CostErrorEvent[] = [];
 
   constructor(
     private readonly _runId: string,
@@ -179,34 +179,24 @@ export class CostAggregator implements ICostAggregator {
   async drain(): Promise<void> {
     this._draining = true;
     try {
-      const events = [...this._events];
-      const errors = [...this._errors];
-      this._events.length = 0;
-      this._errors.length = 0;
+      const events = this._events.splice(0);
+      const errors = this._errors.splice(0);
 
-      if (
-        events.length === 0 &&
-        errors.length === 0 &&
-        this._inFlightEvents.length === 0 &&
-        this._inFlightErrors.length === 0
-      )
-        return;
+      if (events.length === 0 && errors.length === 0) return;
 
       mkdirSync(this._drainDir, { recursive: true });
       const path = join(this._drainDir, `${this._runId}.jsonl`);
 
       const sorted = [...events, ...errors].sort((a, b) => a.ts - b.ts);
-      const content = `${sorted.map((e) => JSON.stringify(e)).join("\n")}\n`;
-      await _costAggDeps.write(path, content);
+      await _costAggDeps.write(path, `${sorted.map((e) => JSON.stringify(e)).join("\n")}\n`);
 
-      if (this._inFlightEvents.length > 0 || this._inFlightErrors.length > 0) {
-        const lateEvents = [...this._inFlightEvents];
-        const lateErrors = [...this._inFlightErrors];
-        this._inFlightEvents.length = 0;
-        this._inFlightErrors.length = 0;
-        const lateSorted = [...lateEvents, ...lateErrors].sort((a, b) => a.ts - b.ts);
-        const lateContent = `${lateSorted.map((e) => JSON.stringify(e)).join("\n")}\n`;
-        await _costAggDeps.write(path, lateContent);
+      // Flush any events that arrived during the async write.
+      // Re-write the complete merged file so the first batch is not lost.
+      const lateEvents = this._inFlightEvents.splice(0);
+      const lateErrors = this._inFlightErrors.splice(0);
+      if (lateEvents.length > 0 || lateErrors.length > 0) {
+        const allSorted = [...sorted, ...lateEvents, ...lateErrors].sort((a, b) => a.ts - b.ts);
+        await _costAggDeps.write(path, `${allSorted.map((e) => JSON.stringify(e)).join("\n")}\n`);
       }
     } finally {
       this._draining = false;

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -64,7 +64,7 @@ export const _promptAuditorDeps = {
 export class PromptAuditor implements IPromptAuditor {
   private readonly _entries: (PromptAuditEntry | PromptAuditErrorEntry)[] = [];
   private _draining = false;
-  private _inFlightEntries: (PromptAuditEntry | PromptAuditErrorEntry)[] = [];
+  private readonly _inFlightEntries: (PromptAuditEntry | PromptAuditErrorEntry)[] = [];
 
   constructor(
     private readonly _runId: string,
@@ -90,21 +90,20 @@ export class PromptAuditor implements IPromptAuditor {
   async flush(): Promise<void> {
     this._draining = true;
     try {
-      const entries = [...this._entries];
-      this._entries.length = 0;
+      const entries = this._entries.splice(0);
 
-      if (entries.length === 0 && this._inFlightEntries.length === 0) return;
+      if (entries.length === 0) return;
 
       mkdirSync(this._flushDir, { recursive: true });
       const path = join(this._flushDir, `${this._runId}.jsonl`);
-      const content = `${entries.map((e) => JSON.stringify(e)).join("\n")}\n`;
-      await _promptAuditorDeps.write(path, content);
+      await _promptAuditorDeps.write(path, `${entries.map((e) => JSON.stringify(e)).join("\n")}\n`);
 
-      if (this._inFlightEntries.length > 0) {
-        const lateEntries = [...this._inFlightEntries];
-        this._inFlightEntries.length = 0;
-        const lateContent = `${lateEntries.map((e) => JSON.stringify(e)).join("\n")}\n`;
-        await _promptAuditorDeps.write(path, lateContent);
+      // Flush any entries that arrived during the async write.
+      // Re-write the complete merged file so the first batch is not lost.
+      const lateEntries = this._inFlightEntries.splice(0);
+      if (lateEntries.length > 0) {
+        const allEntries = [...entries, ...lateEntries];
+        await _promptAuditorDeps.write(path, `${allEntries.map((e) => JSON.stringify(e)).join("\n")}\n`);
       }
     } finally {
       this._draining = false;

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -63,6 +63,8 @@ export const _promptAuditorDeps = {
 
 export class PromptAuditor implements IPromptAuditor {
   private readonly _entries: (PromptAuditEntry | PromptAuditErrorEntry)[] = [];
+  private _draining = false;
+  private _inFlightEntries: (PromptAuditEntry | PromptAuditErrorEntry)[] = [];
 
   constructor(
     private readonly _runId: string,
@@ -70,18 +72,42 @@ export class PromptAuditor implements IPromptAuditor {
   ) {}
 
   record(entry: PromptAuditEntry): void {
+    if (this._draining) {
+      this._inFlightEntries.push(entry);
+      return;
+    }
     this._entries.push(entry);
   }
 
   recordError(entry: PromptAuditErrorEntry): void {
+    if (this._draining) {
+      this._inFlightEntries.push(entry);
+      return;
+    }
     this._entries.push(entry);
   }
 
   async flush(): Promise<void> {
-    if (this._entries.length === 0) return;
-    mkdirSync(this._flushDir, { recursive: true });
-    const path = join(this._flushDir, `${this._runId}.jsonl`);
-    const content = `${this._entries.map((e) => JSON.stringify(e)).join("\n")}\n`;
-    await _promptAuditorDeps.write(path, content);
+    this._draining = true;
+    try {
+      const entries = [...this._entries];
+      this._entries.length = 0;
+
+      if (entries.length === 0 && this._inFlightEntries.length === 0) return;
+
+      mkdirSync(this._flushDir, { recursive: true });
+      const path = join(this._flushDir, `${this._runId}.jsonl`);
+      const content = `${entries.map((e) => JSON.stringify(e)).join("\n")}\n`;
+      await _promptAuditorDeps.write(path, content);
+
+      if (this._inFlightEntries.length > 0) {
+        const lateEntries = [...this._inFlightEntries];
+        this._inFlightEntries.length = 0;
+        const lateContent = `${lateEntries.map((e) => JSON.stringify(e)).join("\n")}\n`;
+        await _promptAuditorDeps.write(path, lateContent);
+      }
+    } finally {
+      this._draining = false;
+    }
   }
 }

--- a/test/unit/runtime/cost-aggregator.test.ts
+++ b/test/unit/runtime/cost-aggregator.test.ts
@@ -139,7 +139,8 @@ describe("CostAggregator", () => {
       await drainTask;
 
       expect(written).toHaveLength(2);
-      const allLines = written.join("").trim().split("\n").filter(Boolean);
+      // The second write is the complete merged file — both events must appear in it.
+      const allLines = written[1].trim().split("\n").filter(Boolean);
       expect(allLines).toHaveLength(2);
       expect(JSON.parse(allLines[0]).ts).toBe(1000);
       expect(JSON.parse(allLines[1]).ts).toBe(2000);
@@ -164,7 +165,9 @@ describe("CostAggregator", () => {
       await drainTask;
 
       expect(written).toHaveLength(2);
-      const allLines = written.join("").trim().split("\n").filter(Boolean);
+      // The second write is the complete merged file — all events must appear in it.
+      const allLines = written[1].trim().split("\n").filter(Boolean);
+      expect(allLines).toHaveLength(2);
       expect(JSON.parse(allLines[1]).errorCode).toBe("TIMEOUT");
       _costAggDeps.write = origWrite;
     });

--- a/test/unit/runtime/cost-aggregator.test.ts
+++ b/test/unit/runtime/cost-aggregator.test.ts
@@ -121,4 +121,75 @@ describe("CostAggregator", () => {
       _costAggDeps.write = origWrite;
     });
   });
+
+  test("drain() captures events recorded during async write (in-flight buffer)", async () => {
+    await withTempDir(async (dir) => {
+      const drainDir = join(dir, "cost");
+      const written: string[] = [];
+      let resolveWrite: () => void;
+      const writePromise = new Promise<number>((r) => { resolveWrite = r; });
+      const origWrite = _costAggDeps.write;
+      _costAggDeps.write = async (_p, d) => { written.push(String(d)); return writePromise; };
+      const agg = new CostAggregator("r-test", drainDir);
+      agg.record(makeEvent({ ts: 1000 }));
+
+      const drainTask = agg.drain();
+      agg.record(makeEvent({ ts: 2000 }));
+      resolveWrite!();
+      await drainTask;
+
+      expect(written).toHaveLength(2);
+      const allLines = written.join("").trim().split("\n").filter(Boolean);
+      expect(allLines).toHaveLength(2);
+      expect(JSON.parse(allLines[0]).ts).toBe(1000);
+      expect(JSON.parse(allLines[1]).ts).toBe(2000);
+      _costAggDeps.write = origWrite;
+    });
+  });
+
+  test("drain() captures error events recorded during async write", async () => {
+    await withTempDir(async (dir) => {
+      const drainDir = join(dir, "cost");
+      const written: string[] = [];
+      let resolveWrite: () => void;
+      const writePromise = new Promise<number>((r) => { resolveWrite = r; });
+      const origWrite = _costAggDeps.write;
+      _costAggDeps.write = async (_p, d) => { written.push(String(d)); return writePromise; };
+      const agg = new CostAggregator("r-test", drainDir);
+      agg.record(makeEvent({ ts: 1000 }));
+
+      const drainTask = agg.drain();
+      agg.recordError({ ts: 2000, runId: "r-test", agentName: "claude", errorCode: "TIMEOUT", durationMs: 100 });
+      resolveWrite!();
+      await drainTask;
+
+      expect(written).toHaveLength(2);
+      const allLines = written.join("").trim().split("\n").filter(Boolean);
+      expect(JSON.parse(allLines[1]).errorCode).toBe("TIMEOUT");
+      _costAggDeps.write = origWrite;
+    });
+  });
+
+  test("snapshot() includes in-flight events during drain", async () => {
+    await withTempDir(async (dir) => {
+      const drainDir = join(dir, "cost");
+      let resolveWrite: () => void;
+      const writePromise = new Promise<number>((r) => { resolveWrite = r; });
+      const origWrite = _costAggDeps.write;
+      _costAggDeps.write = async (_p, _d) => writePromise;
+      const agg = new CostAggregator("r-test", drainDir);
+      agg.record(makeEvent({ ts: 1000, costUsd: 0.01 }));
+
+      const drainTask = agg.drain();
+      agg.record(makeEvent({ ts: 2000, costUsd: 0.02 }));
+
+      const snap = agg.snapshot();
+      expect(snap.callCount).toBe(1);
+      expect(snap.totalCostUsd).toBeCloseTo(0.02);
+
+      resolveWrite!();
+      await drainTask;
+      _costAggDeps.write = origWrite;
+    });
+  });
 });

--- a/test/unit/runtime/prompt-auditor.test.ts
+++ b/test/unit/runtime/prompt-auditor.test.ts
@@ -72,4 +72,52 @@ describe("PromptAuditor", () => {
       _promptAuditorDeps.write = orig;
     });
   });
+
+  test("flush() captures entries recorded during async write (in-flight buffer)", async () => {
+    await withTempDir(async (dir) => {
+      const flushDir = join(dir, "audit");
+      const written: string[] = [];
+      let resolveWrite: () => void;
+      const writePromise = new Promise<number>((r) => { resolveWrite = r; });
+      const orig = _promptAuditorDeps.write;
+      _promptAuditorDeps.write = async (_p, d) => { written.push(String(d)); return writePromise; };
+      const aud = new PromptAuditor("r-test", flushDir);
+      aud.record(makeEntry({ ts: 1000, prompt: "first" }));
+
+      const flushTask = aud.flush();
+      aud.record(makeEntry({ ts: 2000, prompt: "second" }));
+      resolveWrite!();
+      await flushTask;
+
+      expect(written).toHaveLength(2);
+      const allLines = written.join("").trim().split("\n").filter(Boolean);
+      expect(allLines).toHaveLength(2);
+      expect(JSON.parse(allLines[0]).prompt).toBe("first");
+      expect(JSON.parse(allLines[1]).prompt).toBe("second");
+      _promptAuditorDeps.write = orig;
+    });
+  });
+
+  test("flush() captures error entries recorded during async write", async () => {
+    await withTempDir(async (dir) => {
+      const flushDir = join(dir, "audit");
+      const written: string[] = [];
+      let resolveWrite: () => void;
+      const writePromise = new Promise<number>((r) => { resolveWrite = r; });
+      const orig = _promptAuditorDeps.write;
+      _promptAuditorDeps.write = async (_p, d) => { written.push(String(d)); return writePromise; };
+      const aud = new PromptAuditor("r-test", flushDir);
+      aud.record(makeEntry({ ts: 1000, prompt: "first" }));
+
+      const flushTask = aud.flush();
+      aud.recordError({ ts: 2000, runId: "r-test", agentName: "claude", errorCode: "TIMEOUT", durationMs: 50 });
+      resolveWrite!();
+      await flushTask;
+
+      expect(written).toHaveLength(2);
+      const allLines = written.join("").trim().split("\n").filter(Boolean);
+      expect(JSON.parse(allLines[1]).errorCode).toBe("TIMEOUT");
+      _promptAuditorDeps.write = orig;
+    });
+  });
 });

--- a/test/unit/runtime/prompt-auditor.test.ts
+++ b/test/unit/runtime/prompt-auditor.test.ts
@@ -90,7 +90,8 @@ describe("PromptAuditor", () => {
       await flushTask;
 
       expect(written).toHaveLength(2);
-      const allLines = written.join("").trim().split("\n").filter(Boolean);
+      // The second write is the complete merged file — both entries must appear in it.
+      const allLines = written[1].trim().split("\n").filter(Boolean);
       expect(allLines).toHaveLength(2);
       expect(JSON.parse(allLines[0]).prompt).toBe("first");
       expect(JSON.parse(allLines[1]).prompt).toBe("second");
@@ -115,7 +116,9 @@ describe("PromptAuditor", () => {
       await flushTask;
 
       expect(written).toHaveLength(2);
-      const allLines = written.join("").trim().split("\n").filter(Boolean);
+      // The second write is the complete merged file — all entries must appear in it.
+      const allLines = written[1].trim().split("\n").filter(Boolean);
+      expect(allLines).toHaveLength(2);
       expect(JSON.parse(allLines[1]).errorCode).toBe("TIMEOUT");
       _promptAuditorDeps.write = orig;
     });


### PR DESCRIPTION
## Problem

Fixes #700.

The original in-flight buffer approach correctly captured events that arrived during an async `Bun.write()` call, but persisted them via a **second** `Bun.write()` on the same path. `Bun.write()` always **overwrites** — so the primary batch was silently discarded whenever any late event arrived during drain/flush.

## Root Cause

In both `CostAggregator.drain()` and `PromptAuditor.flush()`:
```ts
await _costAggDeps.write(path, content);      // primary batch written
// ...
await _costAggDeps.write(path, lateContent);  // OVERWRITES — primary batch gone
```

The test suite didn't catch this because the mock accumulated both `write` calls in an array and the assertions joined them (`written.join('')`), simulating append semantics that `Bun.write` doesn't have.

## Fix

After the first write resolves, collect the in-flight buffer and perform a single **merged re-write** (primary + late events, sorted by `ts`) so the file is always a complete record.

Additional improvements:
- Use `splice(0)` for atomic snapshot-and-clear instead of `[...arr]` + `length = 0`
- Add `readonly` to `_inFlightEvents` / `_inFlightErrors` / `_inFlightEntries` fields (consistency with existing `_events`/`_errors`)
- Fix test assertions to check `written[1]` (the final merged file content) rather than `written.join('')`, so the tests would have caught the overwrite bug

## Testing

All 67 existing unit tests pass. No new tests added — the existing in-flight tests now correctly validate the merged file content.