### PR TITLE
chore: release v0.64.0-canary.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.63.1",
+  "version": "0.64.0-canary.1",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What
Release v0.64.0-canary.1 — promotes latest main with updated version.

## Why
Canary release to validate pending changes before stable promotion.

## How
- Version bump: `0.63.1` → `0.64.0-canary.1`
- Full pre-commit validation passed

## Testing
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes

## Notes
Canary. Stable release to follow once validated.
