### PR TITLE
fix: thread runtime into execution-layer PipelineContext literals (Issues 3+4)

### DIFF
--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -182,6 +182,7 @@ export async function runIteration(
     agentManager: ctx.agentManager,
     pluginProviderCache: ctx.pluginProviderCache,
     accumulatedAttemptCost: accumulatedAttemptCost > 0 ? accumulatedAttemptCost : undefined,
+    runtime: ctx.runtime,
   };
 
   ctx.statusWriter.setPrd(prd);

--- a/src/execution/lifecycle/acceptance-loop.ts
+++ b/src/execution/lifecycle/acceptance-loop.ts
@@ -144,6 +144,7 @@ export async function runAcceptanceLoop(ctx: AcceptanceLoopContext): Promise<Acc
       agentGetFn: ctx.agentGetFn,
       agentManager: ctx.agentManager,
       acceptanceTestPaths: ctx.acceptanceTestPaths,
+      runtime: ctx.runtime,
     };
 
     const { acceptanceStage } = await import("../../pipeline/stages/acceptance");

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -552,12 +552,20 @@ export async function executeUnified(
         postRunPipeline,
         {
           config: ctx.config,
+          rootConfig: ctx.config,
           prd,
           workdir: ctx.workdir,
+          projectDir: ctx.workdir,
           featureDir: ctx.featureDir,
           story: prd.userStories[0],
+          stories: prd.userStories,
+          routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
+          hooks: ctx.hooks,
+          agentGetFn: ctx.agentGetFn,
+          agentManager: ctx.agentManager,
+          runtime: ctx.runtime,
           acceptanceTestPaths: preRunCtx?.acceptanceTestPaths,
-        } as unknown as PipelineContext,
+        } satisfies PipelineContext,
         ctx.eventEmitter,
       );
     }

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -342,6 +342,11 @@ export async function runAdversarialReview(
     }
     parsed = { passed: opResult.passed, findings: opResult.findings as AdversarialLLMFinding[] };
   } else {
+    // @deprecated Legacy keepOpen path — runtime is always present under executeUnified().
+    // TODO(ADR-019): Remove this branch once all callers thread runtime (tracked in dogfood findings 2026-04-27).
+    logger?.warn("adversarial", "LLM call via legacy agentManager.run — runtime not threaded, middleware skipped", {
+      storyId: story.id,
+    });
     // Legacy keepOpen path — used when no runtime is available (standalone callers).
     const basePrompt = new AdversarialReviewPromptBuilder().buildAdversarialReviewPrompt(story, adversarialConfig, {
       mode: diffMode,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -596,6 +596,11 @@ export async function runSemanticReview(
     }
     parsed = { passed: opResult.passed, findings: opResult.findings as LLMFinding[] };
   } else {
+    // @deprecated Legacy keepOpen path — runtime is always present under executeUnified().
+    // TODO(ADR-019): Remove this branch once all callers thread runtime (tracked in dogfood findings 2026-04-27).
+    logger?.warn("semantic", "LLM call via legacy agentManager.run — runtime not threaded, middleware skipped", {
+      storyId: story.id,
+    });
     // Legacy keepOpen path — used when no runtime is available (standalone callers).
     const reviewerSessionName = formatSessionName({
       workdir,


### PR DESCRIPTION
## Summary

Fixes the two highest-impact dogfood issues from `docs/findings/2026-04-27-post-adr-018-019-dogfood-issues.md`. Both are the same class of wiring gap: `PipelineContext` literals in the execution layer were not updated when ADR-018 introduced `ctx.runtime`.

- **Issue 3** — semantic + adversarial reviewers took the `agentManager.run` legacy path because `runtime` was missing from the per-story `pipelineContext` in `iteration-runner.ts`. Review middleware (audit, cost, cancellation) was silently bypassed on every review hop.
- **Issue 4** — `CALL_OP_NO_RUNTIME` crash from `acceptance-setup` on first runs and after AC edits, because `acceptanceContext` in `acceptance-loop.ts` was also missing `runtime`.
- **Latent (same class)** — `postRunPipeline` context in `unified-executor.ts` used `as unknown as PipelineContext` to hide missing fields; same crash pending for any `callOp`-using stage added to `postRunPipeline`.

## Changes

| File | Change |
|---|---|
| `src/execution/iteration-runner.ts` | Add `runtime: ctx.runtime` to per-story `pipelineContext` |
| `src/execution/lifecycle/acceptance-loop.ts` | Add `runtime: ctx.runtime` to `acceptanceContext` |
| `src/execution/unified-executor.ts` | Fully populate `postRunPipeline` context (runtime, agentManager, rootConfig, projectDir, stories, routing, hooks); replace `as unknown as PipelineContext` with `satisfies PipelineContext` |
| `src/review/semantic.ts` | Mark legacy `else` branch `@deprecated`, add `warn` log + `TODO(ADR-019)` removal marker |
| `src/review/adversarial.ts` | Same deprecation treatment as semantic |

Issues 1 (audit dir mismatch) and 2 (doubled cache path for test patterns) are documented in the findings file and deferred to separate PRs per the suggested breakdown.

## Test plan

- [ ] `bun run typecheck` — clean (no `as unknown` cast hiding missing fields)
- [ ] `timeout 60 bun test test/unit/review/ --timeout=10000` — 402 pass, 0 fail
- [ ] `timeout 60 bun test test/unit/execution/ --timeout=10000` — 617 pass, 0 fail
- [ ] Dogfood re-run on `nax-dogfood/fixtures/hello-lint` — semantic + adversarial should log `LLM call complete` (runtime path) instead of `(legacy)`, and acceptance-setup should no longer throw `CALL_OP_NO_RUNTIME`