### PR TITLE
refactor(ops): unify parseLLMShape + add fence-wrapped JSON tests for review ops

### DIFF
--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -5,7 +5,8 @@ import type { PriorFailure, TestInventory } from "../prompts";
 import { looksLikeTruncatedJson } from "../review/truncation";
 import type { AdversarialFindingsCache, AdversarialReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
-import type { HopBody, LlmReviewFinding, RunOperation } from "./types";
+import type { HopBody, LlmReviewFinding, LlmReviewOutput, RunOperation } from "./types";
+import { parseLlmReviewShape } from "./types";
 
 export type { AdversarialReviewConfig, PriorFailure, SemanticStory, TestInventory };
 
@@ -25,10 +26,7 @@ export interface AdversarialReviewInput {
   priorAdversarialFindings?: AdversarialFindingsCache;
 }
 
-export interface AdversarialReviewOutput {
-  passed: boolean;
-  findings: LlmReviewFinding[];
-  failOpen?: boolean;
+export interface AdversarialReviewOutput extends LlmReviewOutput {
   /**
    * True when the raw output could not be parsed but contained `"passed": false`.
    * Callers should treat this as a hard failure rather than fail-open.
@@ -40,20 +38,12 @@ type ReviewConfig = ReturnType<typeof reviewConfigSelector.select>;
 
 const FAIL_OPEN: AdversarialReviewOutput = { passed: true, findings: [], failOpen: true };
 
-function parseLLMShape(raw: unknown): AdversarialReviewOutput | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const obj = raw as Record<string, unknown>;
-  if (typeof obj.passed !== "boolean") return null;
-  if (!Array.isArray(obj.findings)) return null;
-  return { passed: obj.passed, findings: obj.findings as LlmReviewFinding[] };
-}
-
 /** Same-session JSON-parse retry. See semantic-review.ts for rationale. */
 const adversarialReviewHopBody: HopBody<AdversarialReviewInput> = async (initialPrompt, ctx) => {
   const first = await ctx.send(initialPrompt);
   const isTruncated = looksLikeTruncatedJson(first.output);
   const parsed = tryParseLLMJson<Record<string, unknown>>(first.output);
-  if (!isTruncated && parsed && parseLLMShape(parsed)) return first;
+  if (!isTruncated && parsed && parseLlmReviewShape(parsed)) return first;
 
   const retryPrompt = isTruncated ? ReviewPromptBuilder.jsonRetryCondensed() : ReviewPromptBuilder.jsonRetry();
   const retry: TurnResult = await ctx.send(retryPrompt);
@@ -93,7 +83,7 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
   },
   parse(output, _input, _ctx) {
     const raw = tryParseLLMJson<Record<string, unknown>>(output);
-    const parsed = parseLLMShape(raw);
+    const parsed = parseLlmReviewShape(raw);
     if (parsed) return parsed;
     if (/"passed"\s*:\s*false/.test(output)) return { passed: false, findings: [], looksLikeFail: true };
     return FAIL_OPEN;

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -5,7 +5,8 @@ import type { PriorFailure } from "../prompts";
 import { looksLikeTruncatedJson } from "../review/truncation";
 import type { SemanticReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
-import type { HopBody, LlmReviewFinding, RunOperation } from "./types";
+import type { HopBody, LlmReviewFinding, LlmReviewOutput, RunOperation } from "./types";
+import { parseLlmReviewShape } from "./types";
 
 export type { PriorFailure, SemanticReviewConfig, SemanticStory };
 
@@ -22,10 +23,7 @@ export interface SemanticReviewInput {
   featureCtxBlock?: string;
 }
 
-export interface SemanticReviewOutput {
-  passed: boolean;
-  findings: LlmReviewFinding[];
-  failOpen?: boolean;
+export interface SemanticReviewOutput extends LlmReviewOutput {
   /**
    * True when the raw output could not be parsed but contained `"passed": false` —
    * the agent clearly intended a failure but the response was truncated/malformed.
@@ -38,14 +36,6 @@ type ReviewConfig = ReturnType<typeof reviewConfigSelector.select>;
 
 const FAIL_OPEN: SemanticReviewOutput = { passed: true, findings: [], failOpen: true };
 
-function parseLLMShape(raw: unknown): SemanticReviewOutput | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const obj = raw as Record<string, unknown>;
-  if (typeof obj.passed !== "boolean") return null;
-  if (!Array.isArray(obj.findings)) return null;
-  return { passed: obj.passed, findings: obj.findings as LlmReviewFinding[] };
-}
-
 /**
  * Same-session JSON-parse retry. Sends the initial prompt; if the response is
  * unparseable or truncated, sends a retry prompt in the same handle so the
@@ -56,7 +46,7 @@ const semanticReviewHopBody: HopBody<SemanticReviewInput> = async (initialPrompt
   const first = await ctx.send(initialPrompt);
   const isTruncated = looksLikeTruncatedJson(first.output);
   const parsed = tryParseLLMJson<Record<string, unknown>>(first.output);
-  if (!isTruncated && parsed && parseLLMShape(parsed)) return first;
+  if (!isTruncated && parsed && parseLlmReviewShape(parsed)) return first;
 
   const retryPrompt = isTruncated ? ReviewPromptBuilder.jsonRetryCondensed() : ReviewPromptBuilder.jsonRetry();
   const retry: TurnResult = await ctx.send(retryPrompt);
@@ -90,7 +80,7 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
   },
   parse(output, _input, _ctx) {
     const raw = tryParseLLMJson<Record<string, unknown>>(output);
-    const parsed = parseLLMShape(raw);
+    const parsed = parseLlmReviewShape(raw);
     if (parsed) return parsed;
     if (/"passed"\s*:\s*false/.test(output)) return { passed: false, findings: [], looksLikeFail: true };
     return FAIL_OPEN;

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -141,3 +141,22 @@ export interface LlmReviewFinding {
     observed: string;
   };
 }
+
+/** Shared LLM review output shape consumed by semantic-review and adversarial-review ops. */
+export interface LlmReviewOutput {
+  passed: boolean;
+  findings: LlmReviewFinding[];
+  failOpen?: boolean;
+}
+
+/**
+ * Parse and validate a raw object into the shared {@link LlmReviewOutput} shape.
+ * Returns `null` when the object does not match the expected contract.
+ */
+export function parseLlmReviewShape(raw: unknown): LlmReviewOutput | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.passed !== "boolean") return null;
+  if (!Array.isArray(obj.findings)) return null;
+  return { passed: obj.passed, findings: obj.findings as LlmReviewFinding[] };
+}

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -132,4 +132,11 @@ describe("adversarialReviewOp.parse()", () => {
     const result = adversarialReviewOp.parse(JSON.stringify({ findings: [] }), SAMPLE_INPUT, ctx);
     expect(result.failOpen).toBe(true);
   });
+  test("parses fence-wrapped JSON response", () => {
+    const ctx = makeBuildCtx();
+    const json = "```json\n" + JSON.stringify({ passed: true, findings: [] }) + "\n```";
+    const result = adversarialReviewOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.passed).toBe(true);
+    expect(result.failOpen).toBeUndefined();
+  });
 });

--- a/test/unit/operations/semantic-review.test.ts
+++ b/test/unit/operations/semantic-review.test.ts
@@ -111,4 +111,11 @@ describe("semanticReviewOp.parse()", () => {
     const result = semanticReviewOp.parse(JSON.stringify({ findings: [] }), SAMPLE_INPUT, ctx);
     expect(result.failOpen).toBe(true);
   });
+  test("parses fence-wrapped JSON response", () => {
+    const ctx = makeBuildCtx();
+    const json = "```json\n" + JSON.stringify({ passed: true, findings: [] }) + "\n```";
+    const result = semanticReviewOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.passed).toBe(true);
+    expect(result.failOpen).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Closes #724 and #726.

### #724 — Unify `parseLLMShape` across semantic-review and adversarial-review ops

Both ops defined an identical `parseLLMShape` function. This refactor extracts a shared `LlmReviewOutput` interface and `parseLlmReviewShape()` parser into `src/operations/types.ts`, removing the duplication.

- `SemanticReviewOutput` and `AdversarialReviewOutput` now extend `LlmReviewOutput`
- Removed duplicated `parseLLMShape` from both op files
- Both ops import the shared `parseLlmReviewShape`

### #726 — Add fence-wrapped JSON parse test coverage

The op-level tests previously covered plain JSON and plain non-JSON, but not the `` ```json ... ``` `` fence-wrapped case that is the most common real-world LLM misbehavior. Added one test per op.

## Verification

- `bun test test/unit/operations/semantic-review.test.ts test/unit/operations/adversarial-review.test.ts` — 32 pass, 0 fail
- `bun run typecheck` — clean
- `bun run lint` — clean