### PR TITLE
fix: dogfood session expiry, logging gaps, and prompt-audit fixes

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -91,6 +91,8 @@ export interface AcpSessionResponse {
   exactCostUsd?: number;
   /** True if acpx signalled the error is retryable (e.g. QUEUE_DISCONNECTED_BEFORE_COMPLETION). */
   retryable?: boolean;
+  /** acpx exit code — present only on error responses (exitCode !== 0). */
+  exitCode?: number;
 }
 
 export interface AcpSession {
@@ -349,6 +351,7 @@ export class AcpSessionHandleImpl implements SessionHandle {
   readonly _resumed: boolean;
   readonly _timeoutSeconds: number;
   readonly _modelDef: ModelDef;
+  readonly _permissionMode: string;
 
   constructor(opts: {
     id: string;
@@ -360,6 +363,7 @@ export class AcpSessionHandleImpl implements SessionHandle {
     resumed: boolean;
     timeoutSeconds: number;
     modelDef: ModelDef;
+    permissionMode: string;
   }) {
     this.id = opts.id;
     this.agentName = opts.agentName;
@@ -370,6 +374,7 @@ export class AcpSessionHandleImpl implements SessionHandle {
     this._resumed = opts.resumed;
     this._timeoutSeconds = opts.timeoutSeconds;
     this._modelDef = opts.modelDef;
+    this._permissionMode = opts.permissionMode;
   }
 }
 
@@ -810,6 +815,7 @@ export class AcpAgentAdapter implements AgentAdapter {
         resumed: ensured.resumed,
         timeoutSeconds,
         modelDef,
+        permissionMode: resolvedPermissions.mode,
       });
     } catch (error) {
       if (session) {
@@ -822,7 +828,11 @@ export class AcpAgentAdapter implements AgentAdapter {
 
   async sendTurn(handle: SessionHandle, prompt: string, opts: SendTurnOpts): Promise<TurnResult> {
     const impl = handle as AcpSessionHandleImpl;
-    const { _session: session, _sessionName: sessionName, _timeoutSeconds: timeoutSeconds, _modelDef: modelDef } = impl;
+    const { _sessionName: sessionName, _timeoutSeconds: timeoutSeconds, _modelDef: modelDef } = impl;
+    // biome-ignore lint/style/useConst: mutated in NO_SESSION recovery block
+    let session = impl._session;
+    // biome-ignore lint/style/useConst: mutated in NO_SESSION recovery block
+    let sessionRecreated = false;
     const { interactionHandler, signal } = opts;
     const MAX_TURNS = opts.maxTurns ?? 10;
 
@@ -860,6 +870,25 @@ export class AcpAgentAdapter implements AgentAdapter {
 
       lastResponse = turnResult.response;
       if (!lastResponse) break;
+
+      // NO_SESSION recovery: acpx session expired server-side (exit code 4).
+      // Re-establish and retry this turn once — don't count the dead attempt.
+      if (lastResponse.exitCode === 4 && !sessionRecreated) {
+        sessionRecreated = true;
+        getSafeLogger()?.info("acp-adapter", "NO_SESSION detected — re-establishing session", { sessionName });
+        try {
+          const ensured = await ensureAcpSession(impl._client, impl._sessionName, impl.agentName, impl._permissionMode);
+          session = ensured.session;
+          turnCount--;
+          continue;
+        } catch (err) {
+          getSafeLogger()?.warn("acp-adapter", "Session re-establishment failed after NO_SESSION", {
+            sessionName,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          // Fall through to error throw at end of loop
+        }
+      }
 
       if (lastResponse.cumulative_token_usage) {
         totalTokenUsage = addTokenUsage(totalTokenUsage, this._mapper.toInternal(lastResponse.cumulative_token_usage));

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -346,7 +346,14 @@ export class AcpSessionHandleImpl implements SessionHandle {
 
   // ACP-internal fields — opaque to callers above the adapter boundary.
   readonly _client: AcpClient;
-  /** Mutable — updated on NO_SESSION recovery so closeSession targets the live session. */
+  /**
+   * Mutable. Holds the live acpx session pointer. Re-assigned by `sendTurn` on
+   * NO_SESSION (exit code 4) recovery so a subsequent `closeSession` targets the
+   * recreated server-side session, not the dead one. The handle's identity
+   * (`id`, `_sessionName`) is preserved across recovery — SessionManager's
+   * descriptor sees no lifecycle event. See `sendTurn` NO_SESSION block for the
+   * ADR-019 boundary rationale (transport-level reconnect, not lifecycle).
+   */
   _session: AcpSession;
   readonly _sessionName: string;
   readonly _resumed: boolean;
@@ -871,6 +878,17 @@ export class AcpAgentAdapter implements AgentAdapter {
 
       // NO_SESSION recovery: acpx session expired server-side (exit code 4).
       // Re-establish and retry this turn once — don't count the dead attempt.
+      //
+      // ADR-019 boundary note: ADR-019 §2 makes SessionManager the owner of session
+      // lifecycle (open/close, descriptor state, turn count). This recovery
+      // intentionally does NOT involve SessionManager — it is a transport-level
+      // reconnect of the underlying acpx session, analogous to a TCP reconnect under
+      // an HTTP keep-alive. The SessionManager-facing identity (`handle.id`,
+      // `_sessionName`) is unchanged; descriptor state stays `RUNNING`; only the
+      // opaque `_session` pointer is swapped. If future recovery work needs to
+      // reset descriptor state or invalidate turn count, that belongs in
+      // SessionManager.runInSession (catch a typed RetryableSessionError from the
+      // adapter and call `openSession` again at the orchestrator layer).
       if (lastResponse.exitCode === 4 && !sessionRecreated) {
         sessionRecreated = true;
         getSafeLogger()?.info("acp-adapter", "NO_SESSION detected — re-establishing session", { sessionName });

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -346,7 +346,8 @@ export class AcpSessionHandleImpl implements SessionHandle {
 
   // ACP-internal fields — opaque to callers above the adapter boundary.
   readonly _client: AcpClient;
-  readonly _session: AcpSession;
+  /** Mutable — updated on NO_SESSION recovery so closeSession targets the live session. */
+  _session: AcpSession;
   readonly _sessionName: string;
   readonly _resumed: boolean;
   readonly _timeoutSeconds: number;
@@ -829,7 +830,6 @@ export class AcpAgentAdapter implements AgentAdapter {
   async sendTurn(handle: SessionHandle, prompt: string, opts: SendTurnOpts): Promise<TurnResult> {
     const impl = handle as AcpSessionHandleImpl;
     const { _sessionName: sessionName, _timeoutSeconds: timeoutSeconds, _modelDef: modelDef } = impl;
-    let session = impl._session;
     let sessionRecreated = false;
     const { interactionHandler, signal } = opts;
     const MAX_TURNS = opts.maxTurns ?? 10;
@@ -855,7 +855,7 @@ export class AcpAgentAdapter implements AgentAdapter {
       turnCount++;
       getSafeLogger()?.debug("acp-adapter", `Session turn ${turnCount}/${MAX_TURNS}`, { sessionName });
 
-      const turnResult = await runSessionPrompt(session, currentPrompt, timeoutSeconds * 1000, signal);
+      const turnResult = await runSessionPrompt(impl._session, currentPrompt, timeoutSeconds * 1000, signal);
 
       if (turnResult.timedOut) {
         timedOut = true;
@@ -876,7 +876,7 @@ export class AcpAgentAdapter implements AgentAdapter {
         getSafeLogger()?.info("acp-adapter", "NO_SESSION detected — re-establishing session", { sessionName });
         try {
           const ensured = await ensureAcpSession(impl._client, impl._sessionName, impl.agentName, impl._permissionMode);
-          session = ensured.session;
+          impl._session = ensured.session;
           turnCount--;
           continue;
         } catch (err) {

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -829,9 +829,7 @@ export class AcpAgentAdapter implements AgentAdapter {
   async sendTurn(handle: SessionHandle, prompt: string, opts: SendTurnOpts): Promise<TurnResult> {
     const impl = handle as AcpSessionHandleImpl;
     const { _sessionName: sessionName, _timeoutSeconds: timeoutSeconds, _modelDef: modelDef } = impl;
-    // biome-ignore lint/style/useConst: mutated in NO_SESSION recovery block
     let session = impl._session;
-    // biome-ignore lint/style/useConst: mutated in NO_SESSION recovery block
     let sessionRecreated = false;
     const { interactionHandler, signal } = opts;
     const MAX_TURNS = opts.maxTurns ?? 10;

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -230,6 +230,7 @@ export class SpawnAcpSession implements AcpSession {
           messages: [{ role: "assistant", content: errorContent }],
           stopReason: "error",
           retryable: parsedOnError.retryable,
+          exitCode,
         };
       }
 

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -308,18 +308,25 @@ export const acceptanceSetupStage: PipelineStage = {
           ? `\n[FRAMEWORK OVERRIDE: Use ${ctx.config.acceptance.testFramework} as the test framework regardless of what you detect.]`
           : "";
 
-        const genResult = (await _acceptanceSetupDeps.callOp(ctx, packageDir, acceptanceGenerateOp, {
-          featureName: featureName ?? "",
-          criteriaList,
-          frameworkOverrideLine,
-          targetTestFilePath: testPath,
-          ...("implementationContext" in ctx && ctx.implementationContext
-            ? { implementationContext: ctx.implementationContext as Array<{ path: string; content: string }> }
-            : {}),
-          ...("previousFailure" in ctx && ctx.previousFailure
-            ? { previousFailure: ctx.previousFailure as string }
-            : {}),
-        })) as { testCode: string | null };
+        const groupStoryId = group.stories[0]?.id;
+        const genResult = (await _acceptanceSetupDeps.callOp(
+          ctx,
+          packageDir,
+          acceptanceGenerateOp,
+          {
+            featureName: featureName ?? "",
+            criteriaList,
+            frameworkOverrideLine,
+            targetTestFilePath: testPath,
+            ...("implementationContext" in ctx && ctx.implementationContext
+              ? { implementationContext: ctx.implementationContext as Array<{ path: string; content: string }> }
+              : {}),
+            ...("previousFailure" in ctx && ctx.previousFailure
+              ? { previousFailure: ctx.previousFailure as string }
+              : {}),
+          },
+          groupStoryId,
+        )) as { testCode: string | null };
 
         let testCode = genResult.testCode;
         if (!testCode) {

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -114,15 +114,9 @@ export class PromptAuditor implements IPromptAuditor {
   private readonly _jsonlPath: string;
   private readonly _featureDir: string;
 
-  constructor(
-    private readonly _runId: string,
-    /** Base audit directory (e.g. <workdir>/.nax/prompt-audit). */
-    private readonly _flushDir: string,
-    /** Feature name — used as a subdirectory so each feature has its own folder. */
-    private readonly _featureName: string,
-  ) {
-    this._featureDir = join(_flushDir, _featureName);
-    this._jsonlPath = join(this._featureDir, `${_runId}.jsonl`);
+  constructor(runId: string, flushDir: string, featureName: string) {
+    this._featureDir = join(flushDir, featureName);
+    this._jsonlPath = join(this._featureDir, `${runId}.jsonl`);
   }
 
   record(entry: PromptAuditEntry): void {

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -1,5 +1,12 @@
-import { mkdirSync } from "node:fs";
+// Bun-native carve-out: appendFile + mkdir.
+// Bun has no append API on Bun.write / FileSink (writer truncates), so node:fs/promises
+// is the pragmatic choice for incremental JSONL persistence. Top-level import avoids
+// per-call dynamic-import cost. See .claude/rules/forbidden-patterns.md (appendFile
+// is not in the banned list; documented carve-out from the broader Bun-native rule).
+import { appendFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import { getSafeLogger } from "../logger";
+import { errorMessage } from "../utils/errors";
 
 export interface PromptAuditEntry {
   readonly ts: number;
@@ -59,10 +66,7 @@ export function createNoOpPromptAuditor(): IPromptAuditor {
 /** Injectable deps — swap in tests to avoid real disk I/O. */
 export const _promptAuditorDeps = {
   write: (path: string, data: string): Promise<number> => Bun.write(path, data),
-  appendLine: async (path: string, data: string): Promise<void> => {
-    const { appendFile } = await import("node:fs/promises");
-    await appendFile(path, data, "utf8");
-  },
+  appendLine: (path: string, data: string): Promise<void> => appendFile(path, data, "utf8"),
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -130,16 +134,19 @@ export class PromptAuditor implements IPromptAuditor {
   private _enqueue(entry: PromptAuditEntry | PromptAuditErrorEntry): void {
     this._queue = this._queue
       .then(() => this._writeEntry(entry))
-      .catch(() => {
-        // Swallow write errors to keep the queue healthy for subsequent entries.
-        // Individual entry failures (disk full, permission denied) must not break
-        // the chain — later entries should still attempt to persist.
+      .catch((err) => {
+        // Per-entry failures (disk full, permission denied) must not break the chain.
+        // Surface the failure so silent audit gaps are diagnosable.
+        getSafeLogger()?.warn("audit", "prompt-audit write failed", {
+          path: this._jsonlPath,
+          error: errorMessage(err),
+        });
       });
   }
 
   private async _writeEntry(entry: PromptAuditEntry | PromptAuditErrorEntry): Promise<void> {
     if (!this._dirCreated) {
-      mkdirSync(this._featureDir, { recursive: true });
+      await mkdir(this._featureDir, { recursive: true });
       this._dirCreated = true;
     }
     await _promptAuditorDeps.appendLine(this._jsonlPath, `${JSON.stringify(entry)}\n`);

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -128,7 +128,13 @@ export class PromptAuditor implements IPromptAuditor {
   }
 
   private _enqueue(entry: PromptAuditEntry | PromptAuditErrorEntry): void {
-    this._queue = this._queue.then(() => this._writeEntry(entry)).catch(() => this._writeEntry(entry));
+    this._queue = this._queue
+      .then(() => this._writeEntry(entry))
+      .catch(() => {
+        // Swallow write errors to keep the queue healthy for subsequent entries.
+        // Individual entry failures (disk full, permission denied) must not break
+        // the chain — later entries should still attempt to persist.
+      });
   }
 
   private async _writeEntry(entry: PromptAuditEntry | PromptAuditErrorEntry): Promise<void> {

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -56,14 +56,27 @@ export function createNoOpPromptAuditor(): IPromptAuditor {
   };
 }
 
-/** Injectable deps — swap `write` in tests to avoid real disk I/O. */
+/** Injectable deps — swap in tests to avoid real disk I/O. */
 export const _promptAuditorDeps = {
   write: (path: string, data: string): Promise<number> => Bun.write(path, data),
+  appendLine: async (path: string, data: string): Promise<void> => {
+    const { appendFile } = await import("node:fs/promises");
+    await appendFile(path, data, "utf8");
+  },
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Human-readable txt content builder
 // ─────────────────────────────────────────────────────────────────────────────
+
+function deriveTxtFilename(entry: PromptAuditEntry): string {
+  if (entry.sessionName) {
+    return `${entry.ts}-${entry.sessionName}.txt`;
+  }
+  const parts: string[] = [String(entry.ts), entry.callType ?? "call", entry.stage ?? "unknown"];
+  if (entry.storyId) parts.push(entry.storyId);
+  return `${parts.join("-")}.txt`;
+}
 
 function buildTxtContent(entry: PromptAuditEntry): string {
   const ts = new Date(entry.ts).toISOString();
@@ -96,9 +109,10 @@ function buildTxtContent(entry: PromptAuditEntry): string {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export class PromptAuditor implements IPromptAuditor {
-  private readonly _entries: (PromptAuditEntry | PromptAuditErrorEntry)[] = [];
-  private _draining = false;
-  private readonly _inFlightEntries: (PromptAuditEntry | PromptAuditErrorEntry)[] = [];
+  private _queue: Promise<void> = Promise.resolve();
+  private _dirCreated = false;
+  private readonly _jsonlPath: string;
+  private readonly _featureDir: string;
 
   constructor(
     private readonly _runId: string,
@@ -106,62 +120,37 @@ export class PromptAuditor implements IPromptAuditor {
     private readonly _flushDir: string,
     /** Feature name — used as a subdirectory so each feature has its own folder. */
     private readonly _featureName: string,
-  ) {}
+  ) {
+    this._featureDir = join(_flushDir, _featureName);
+    this._jsonlPath = join(this._featureDir, `${_runId}.jsonl`);
+  }
 
   record(entry: PromptAuditEntry): void {
-    if (this._draining) {
-      this._inFlightEntries.push(entry);
-      return;
-    }
-    this._entries.push(entry);
+    this._enqueue(entry);
   }
 
   recordError(entry: PromptAuditErrorEntry): void {
-    if (this._draining) {
-      this._inFlightEntries.push(entry);
-      return;
+    this._enqueue(entry);
+  }
+
+  private _enqueue(entry: PromptAuditEntry | PromptAuditErrorEntry): void {
+    this._queue = this._queue.then(() => this._writeEntry(entry)).catch(() => this._writeEntry(entry));
+  }
+
+  private async _writeEntry(entry: PromptAuditEntry | PromptAuditErrorEntry): Promise<void> {
+    if (!this._dirCreated) {
+      mkdirSync(this._featureDir, { recursive: true });
+      this._dirCreated = true;
     }
-    this._entries.push(entry);
+    await _promptAuditorDeps.appendLine(this._jsonlPath, `${JSON.stringify(entry)}\n`);
+
+    if (!("prompt" in entry) || !("response" in entry)) return;
+    const auditEntry = entry as PromptAuditEntry;
+    const filename = deriveTxtFilename(auditEntry);
+    await _promptAuditorDeps.write(join(this._featureDir, filename), buildTxtContent(auditEntry));
   }
 
   async flush(): Promise<void> {
-    this._draining = true;
-    try {
-      const entries = this._entries.splice(0);
-      if (entries.length === 0) return;
-
-      const featureDir = join(this._flushDir, this._featureName);
-      mkdirSync(featureDir, { recursive: true });
-
-      // ── JSONL (machine-readable) ───────────────────────────────────────────
-      const jsonlPath = join(featureDir, `${this._runId}.jsonl`);
-      await _promptAuditorDeps.write(jsonlPath, `${entries.map((e) => JSON.stringify(e)).join("\n")}\n`);
-
-      // ── Per-entry .txt (human-readable) ───────────────────────────────────
-      // Only PromptAuditEntry has prompt+response; error entries go to JSONL only.
-      for (const entry of entries) {
-        if (!("prompt" in entry) || !("response" in entry)) continue;
-        const auditEntry = entry as PromptAuditEntry;
-        if (!auditEntry.sessionName) continue;
-        const filename = `${auditEntry.ts}-${auditEntry.sessionName}.txt`;
-        await _promptAuditorDeps.write(join(featureDir, filename), buildTxtContent(auditEntry));
-      }
-
-      // Flush any entries that arrived during the async writes.
-      const lateEntries = this._inFlightEntries.splice(0);
-      if (lateEntries.length > 0) {
-        const allEntries = [...entries, ...lateEntries];
-        await _promptAuditorDeps.write(jsonlPath, `${allEntries.map((e) => JSON.stringify(e)).join("\n")}\n`);
-        for (const entry of lateEntries) {
-          if (!("prompt" in entry) || !("response" in entry)) continue;
-          const auditEntry = entry as PromptAuditEntry;
-          if (!auditEntry.sessionName) continue;
-          const filename = `${auditEntry.ts}-${auditEntry.sessionName}.txt`;
-          await _promptAuditorDeps.write(join(featureDir, filename), buildTxtContent(auditEntry));
-        }
-      }
-    } finally {
-      this._draining = false;
-    }
+    await this._queue;
   }
 }

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -507,6 +507,15 @@ export class SessionManager implements ISessionManager {
       );
     }
 
+    const terminalDesc = this._findByName(handle.id);
+    if (terminalDesc && (terminalDesc.state === "COMPLETED" || terminalDesc.state === "FAILED")) {
+      throw new NaxError(
+        `Session "${handle.id}" is in terminal state ${terminalDesc.state} — call openSession first to resume`,
+        "SESSION_TERMINAL_STATE",
+        { stage: "session", sessionName: handle.id, state: terminalDesc.state },
+      );
+    }
+
     const adapter = this._getAdapter(handle.agentName);
     if (!adapter) {
       throw new NaxError(

--- a/test/integration/runtime/runtime-middleware.test.ts
+++ b/test/integration/runtime/runtime-middleware.test.ts
@@ -35,12 +35,11 @@ describe("Wave 2 exit criteria", () => {
 
   test("EC-3: PromptAuditor.flush() writes to .nax/prompt-audit/<feature>/<runId>.jsonl on close()", async () => {
     await withTempDir(async (dir) => {
-      const paths: string[] = [];
-      const orig = _promptAuditorDeps.write;
-      _promptAuditorDeps.write = async (p, _d) => {
-        paths.push(p);
-        return 0;
-      };
+      const appendedPaths: string[] = [];
+      const origAppend = _promptAuditorDeps.appendLine;
+      const origWrite = _promptAuditorDeps.write;
+      _promptAuditorDeps.appendLine = async (p, _d) => { appendedPaths.push(p); };
+      _promptAuditorDeps.write = async (_p, _d) => 0;
 
       try {
         const rt = createRuntime(auditEnabledConfig, dir, { featureName: "my-feature" });
@@ -55,12 +54,13 @@ describe("Wave 2 exit criteria", () => {
         });
         await rt.close();
 
-        // JSONL goes to .nax/prompt-audit/<feature>/<runId>.jsonl
-        expect(paths[0]).toBe(
+        // JSONL goes to .nax/prompt-audit/<feature>/<runId>.jsonl (written via appendLine)
+        expect(appendedPaths[0]).toBe(
           join(dir, ".nax", "prompt-audit", "my-feature", `${rt.runId}.jsonl`),
         );
       } finally {
-        _promptAuditorDeps.write = orig;
+        _promptAuditorDeps.appendLine = origAppend;
+        _promptAuditorDeps.write = origWrite;
       }
     });
   });

--- a/test/unit/agents/acp/adapter-phase-a.test.ts
+++ b/test/unit/agents/acp/adapter-phase-a.test.ts
@@ -481,6 +481,62 @@ describe("sendTurn()", () => {
     const drift = Math.abs(result.exactCostUsd! - result.estimatedCostUsd) / result.estimatedCostUsd;
     expect(drift).toBeLessThan(0.5);
   });
+
+  test("re-establishes session and retries once on NO_SESSION (exitCode 4)", async () => {
+    let sessionCreateCount = 0;
+    let promptCallCount = 0;
+
+    const deadPromptFn = async () => {
+      promptCallCount++;
+      return { messages: [{ role: "assistant", content: "NO_SESSION" }], stopReason: "error", exitCode: 4 };
+    };
+    const livePromptFn = async () => {
+      promptCallCount++;
+      return { messages: [{ role: "assistant", content: "Fixed output" }], stopReason: "end_turn" };
+    };
+
+    let isFirstSession = true;
+    const createSessionFn = async (_opts: any) => {
+      sessionCreateCount++;
+      const fn = isFirstSession ? deadPromptFn : livePromptFn;
+      isFirstSession = false;
+      return makeSession({ promptFn: fn });
+    };
+    const loadSessionFn = async (_name: string, _agent: string, _perm: string) => {
+      sessionCreateCount++;
+      const fn = isFirstSession ? deadPromptFn : livePromptFn;
+      isFirstSession = false;
+      return makeSession({ promptFn: fn });
+    };
+
+    const handle = await openHandle(makeSession({ promptFn: deadPromptFn }), { createSessionFn, loadSessionFn });
+
+    const result = await adapter.sendTurn(handle, "do the work", {
+      interactionHandler: { onInteraction: async () => null },
+    });
+
+    expect(result.output).toBe("Fixed output");
+    expect(promptCallCount).toBe(2);
+  });
+
+  test("throws on error when NO_SESSION occurs twice (no infinite retry)", async () => {
+    const alwaysDeadPromptFn = async () => ({
+      messages: [{ role: "assistant", content: "NO_SESSION" }],
+      stopReason: "error",
+      exitCode: 4,
+    });
+
+    const handle = await openHandle(makeSession({ promptFn: alwaysDeadPromptFn }), {
+      createSessionFn: async () => makeSession({ promptFn: alwaysDeadPromptFn }),
+      loadSessionFn: async () => makeSession({ promptFn: alwaysDeadPromptFn }),
+    });
+
+    await expect(
+      adapter.sendTurn(handle, "do the work", {
+        interactionHandler: { onInteraction: async () => null },
+      }),
+    ).rejects.toThrow();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/pipeline/stages/acceptance-setup-strategy.test.ts
+++ b/test/unit/pipeline/stages/acceptance-setup-strategy.test.ts
@@ -213,6 +213,28 @@ describe("acceptance-setup: testFramework appears in generate callOp input", () 
     expect(capturedFrameworkOverrideLine).toBe("");
   });
 
+  test("acceptanceGenerateOp callOp receives storyId from first group story", async () => {
+    wireBasicDeps();
+    let capturedGenerateStoryId: string | undefined = "not-set";
+
+    _acceptanceSetupDeps.callOp = async (_ctx, _packageDir, op, input, storyId) => {
+      if (op.name === "acceptance-refine") {
+        const { criteria, storyId: sid } = input as { criteria: string[]; storyId: string };
+        return criteria.map((c: string) => ({ original: c, refined: c, testable: true, storyId: sid }));
+      }
+      if (op.name === "acceptance-generate") {
+        capturedGenerateStoryId = storyId;
+        return { testCode: 'import { test } from "bun:test"; test("AC-1", () => {})' };
+      }
+      throw new Error(`unexpected op: ${op.name}`);
+    };
+
+    const ctx = makeCtx();
+    await acceptanceSetupStage.execute(ctx);
+
+    expect(capturedGenerateStoryId).toBe("US-001");
+  });
+
   test("stage runs without error when both testStrategy and testFramework are set", async () => {
     wireBasicDeps();
     _acceptanceSetupDeps.callOp = makeDefaultCallOp();

--- a/test/unit/runtime/prompt-auditor.test.ts
+++ b/test/unit/runtime/prompt-auditor.test.ts
@@ -127,6 +127,60 @@ describe("PromptAuditor", () => {
     });
   });
 
+  describe("deriveTxtFilename fallback (no sessionName)", () => {
+    test("uses <ts>-<callType>-<stage>-<storyId>.txt when all fields present", async () => {
+      await withTempDir(async (dir) => {
+        const paths: string[] = [];
+        const origWrite = _promptAuditorDeps.write;
+        const origAppend = _promptAuditorDeps.appendLine;
+        _promptAuditorDeps.write = async (p: string) => { paths.push(p); return 0; };
+        _promptAuditorDeps.appendLine = async () => {};
+        const aud = new PromptAuditor("r-001", join(dir, "audit"), FEATURE);
+        aud.record(makeEntry({ ts: 1777301912062, callType: "complete", stage: "acceptance", storyId: "US-001" }));
+        await aud.flush();
+        expect(paths).toHaveLength(1);
+        expect(paths[0]).toEndWith("1777301912062-complete-acceptance-US-001.txt");
+        _promptAuditorDeps.write = origWrite;
+        _promptAuditorDeps.appendLine = origAppend;
+      });
+    });
+
+    test("omits storyId segment when storyId absent", async () => {
+      await withTempDir(async (dir) => {
+        const paths: string[] = [];
+        const origWrite = _promptAuditorDeps.write;
+        const origAppend = _promptAuditorDeps.appendLine;
+        _promptAuditorDeps.write = async (p: string) => { paths.push(p); return 0; };
+        _promptAuditorDeps.appendLine = async () => {};
+        const aud = new PromptAuditor("r-001", join(dir, "audit"), FEATURE);
+        aud.record(makeEntry({ ts: 1777301880073, callType: "complete", stage: "acceptance" }));
+        await aud.flush();
+        expect(paths).toHaveLength(1);
+        expect(paths[0]).toEndWith("1777301880073-complete-acceptance.txt");
+        _promptAuditorDeps.write = origWrite;
+        _promptAuditorDeps.appendLine = origAppend;
+      });
+    });
+
+    test("writes txt even when response is empty (e.g. crashed regen)", async () => {
+      await withTempDir(async (dir) => {
+        const writes: Array<[string, string]> = [];
+        const origWrite = _promptAuditorDeps.write;
+        const origAppend = _promptAuditorDeps.appendLine;
+        _promptAuditorDeps.write = async (p: string, d: string) => { writes.push([p, String(d)]); return 0; };
+        _promptAuditorDeps.appendLine = async () => {};
+        const aud = new PromptAuditor("r-001", join(dir, "audit"), FEATURE);
+        aud.record(makeEntry({ ts: 1777302229409, callType: "complete", stage: "acceptance", prompt: "Generate tests", response: "" }));
+        await aud.flush();
+        expect(writes).toHaveLength(1);
+        expect(writes[0][0]).toEndWith("1777302229409-complete-acceptance.txt");
+        expect(writes[0][1]).toContain("Generate tests");
+        _promptAuditorDeps.write = origWrite;
+        _promptAuditorDeps.appendLine = origAppend;
+      });
+    });
+  });
+
   test("recordError() entries appear in JSONL but produce no txt file", async () => {
     await withTempDir(async (dir) => {
       const appends: string[] = [];

--- a/test/unit/runtime/prompt-auditor.test.ts
+++ b/test/unit/runtime/prompt-auditor.test.ts
@@ -27,8 +27,8 @@ describe("PromptAuditor", () => {
       _promptAuditorDeps.appendLine = async (_p: string, d: string) => { appendedLines.push(d); };
       const aud = new PromptAuditor("r-001", flushDir, FEATURE);
       aud.record(makeEntry({ prompt: "immediate" }));
-      // wait for microtask queue to process the enqueued write
-      await new Promise((r) => setTimeout(r, 0));
+      // Drain the queue deterministically — flush() awaits the chain head.
+      await aud.flush();
       expect(appendedLines.length).toBeGreaterThan(0);
       expect(appendedLines[0]).toContain('"immediate"');
       _promptAuditorDeps.appendLine = orig;

--- a/test/unit/runtime/prompt-auditor.test.ts
+++ b/test/unit/runtime/prompt-auditor.test.ts
@@ -133,7 +133,7 @@ describe("PromptAuditor", () => {
       const paths: string[] = [];
       const origAppend = _promptAuditorDeps.appendLine;
       const origWrite = _promptAuditorDeps.write;
-      _promptAuditorDeps.appendLine = async (p: string, d: string) => { appends.push(d); };
+      _promptAuditorDeps.appendLine = async (_p: string, d: string) => { appends.push(d); };
       _promptAuditorDeps.write = async (p: string) => { paths.push(p); return 0; };
       const aud = new PromptAuditor("r-001", join(dir, "audit"), FEATURE);
       aud.recordError({ ts: Date.now(), runId: "r-001", agentName: "claude", errorCode: "TIMEOUT", durationMs: 50 });

--- a/test/unit/runtime/prompt-auditor.test.ts
+++ b/test/unit/runtime/prompt-auditor.test.ts
@@ -19,48 +19,70 @@ function makeEntry(overrides: Partial<PromptAuditEntry> = {}): PromptAuditEntry 
 }
 
 describe("PromptAuditor", () => {
+  test("record() persists entry to JSONL immediately without waiting for flush()", async () => {
+    await withTempDir(async (dir) => {
+      const flushDir = join(dir, "audit");
+      const appendedLines: string[] = [];
+      const orig = _promptAuditorDeps.appendLine;
+      _promptAuditorDeps.appendLine = async (_p: string, d: string) => { appendedLines.push(d); };
+      const aud = new PromptAuditor("r-001", flushDir, FEATURE);
+      aud.record(makeEntry({ prompt: "immediate" }));
+      // wait for microtask queue to process the enqueued write
+      await new Promise((r) => setTimeout(r, 0));
+      expect(appendedLines.length).toBeGreaterThan(0);
+      expect(appendedLines[0]).toContain('"immediate"');
+      _promptAuditorDeps.appendLine = orig;
+    });
+  });
+
   test("flush() does nothing when no entries", async () => {
     const writes: string[] = [];
-    const orig = _promptAuditorDeps.write;
+    const appends: string[] = [];
+    const origWrite = _promptAuditorDeps.write;
+    const origAppend = _promptAuditorDeps.appendLine;
     _promptAuditorDeps.write = async (p) => { writes.push(p); return 0; };
+    _promptAuditorDeps.appendLine = async (p) => { appends.push(p); };
     const aud = new PromptAuditor("r-001", "/tmp/audit", FEATURE);
     await aud.flush();
     expect(writes).toHaveLength(0);
-    _promptAuditorDeps.write = orig;
+    expect(appends).toHaveLength(0);
+    _promptAuditorDeps.write = origWrite;
+    _promptAuditorDeps.appendLine = origAppend;
   });
 
   test("flush() writes one JSONL line per entry in insertion order", async () => {
     await withTempDir(async (dir) => {
       const flushDir = join(dir, "audit");
-      // Entries without sessionName produce no txt files — only one JSONL write
-      let capturedJsonl = "";
+      const appendedData: string[] = [];
+      const origAppend = _promptAuditorDeps.appendLine;
+      _promptAuditorDeps.appendLine = async (_p: string, d: string) => { appendedData.push(d); };
       const orig = _promptAuditorDeps.write;
-      _promptAuditorDeps.write = async (p, d) => {
-        if (p.endsWith(".jsonl")) capturedJsonl = String(d);
-        return 0;
-      };
+      _promptAuditorDeps.write = async () => 0;
       const aud = new PromptAuditor("r-test", flushDir, FEATURE);
       aud.record(makeEntry({ prompt: "first" }));
       aud.record(makeEntry({ prompt: "second" }));
       await aud.flush();
-      const lines = capturedJsonl.trim().split("\n");
-      expect(lines).toHaveLength(2);
-      expect(JSON.parse(lines[0]).prompt).toBe("first");
-      expect(JSON.parse(lines[1]).prompt).toBe("second");
+      expect(appendedData).toHaveLength(2);
+      expect(JSON.parse(appendedData[0].trim()).prompt).toBe("first");
+      expect(JSON.parse(appendedData[1].trim()).prompt).toBe("second");
+      _promptAuditorDeps.appendLine = origAppend;
       _promptAuditorDeps.write = orig;
     });
   });
 
-  test("flush() writes JSONL to <flushDir>/<featureName>/<runId>.jsonl", async () => {
+  test("flush() appends JSONL to <flushDir>/<featureName>/<runId>.jsonl", async () => {
     await withTempDir(async (dir) => {
       const flushDir = join(dir, "audit");
       let capturedPath = "";
+      const origAppend = _promptAuditorDeps.appendLine;
+      _promptAuditorDeps.appendLine = async (p: string) => { capturedPath = p; };
       const orig = _promptAuditorDeps.write;
-      _promptAuditorDeps.write = async (p, _d) => { capturedPath = p; return 0; };
+      _promptAuditorDeps.write = async () => 0;
       const aud = new PromptAuditor("my-run", flushDir, FEATURE);
       aud.record(makeEntry());
       await aud.flush();
       expect(capturedPath).toBe(join(flushDir, FEATURE, "my-run.jsonl"));
+      _promptAuditorDeps.appendLine = origAppend;
       _promptAuditorDeps.write = orig;
     });
   });
@@ -68,16 +90,18 @@ describe("PromptAuditor", () => {
   test("flush() writes <ts>-<sessionName>.txt alongside JSONL for entries with sessionName", async () => {
     await withTempDir(async (dir) => {
       const flushDir = join(dir, "audit");
-      const paths: string[] = [];
-      const orig = _promptAuditorDeps.write;
-      _promptAuditorDeps.write = async (p, _d) => { paths.push(p); return 0; };
+      const txtPaths: string[] = [];
+      const origWrite = _promptAuditorDeps.write;
+      const origAppend = _promptAuditorDeps.appendLine;
+      _promptAuditorDeps.write = async (p: string) => { txtPaths.push(p); return 0; };
+      _promptAuditorDeps.appendLine = async () => {};
       const aud = new PromptAuditor("my-run", flushDir, FEATURE);
       aud.record(makeEntry({ ts: 1234567890000, sessionName: "nax-abc12345-my-feature-us-000-run" }));
       await aud.flush();
-      expect(paths).toHaveLength(2);
-      expect(paths[0]).toBe(join(flushDir, FEATURE, "my-run.jsonl"));
-      expect(paths[1]).toBe(join(flushDir, FEATURE, "1234567890000-nax-abc12345-my-feature-us-000-run.txt"));
-      _promptAuditorDeps.write = orig;
+      expect(txtPaths).toHaveLength(1);
+      expect(txtPaths[0]).toBe(join(flushDir, FEATURE, "1234567890000-nax-abc12345-my-feature-us-000-run.txt"));
+      _promptAuditorDeps.write = origWrite;
+      _promptAuditorDeps.appendLine = origAppend;
     });
   });
 
@@ -86,10 +110,12 @@ describe("PromptAuditor", () => {
       const flushDir = join(dir, "audit");
       let txtContent = "";
       const orig = _promptAuditorDeps.write;
+      const origAppend = _promptAuditorDeps.appendLine;
       _promptAuditorDeps.write = async (p, d) => {
         if (p.endsWith(".txt")) txtContent = String(d);
         return 0;
       };
+      _promptAuditorDeps.appendLine = async () => {};
       const aud = new PromptAuditor("my-run", flushDir, FEATURE);
       aud.record(makeEntry({ sessionName: "nax-abc-my-feature-us-000-run", prompt: "hello", response: "world" }));
       await aud.flush();
@@ -97,74 +123,27 @@ describe("PromptAuditor", () => {
       expect(txtContent).toContain("=== RESPONSE ===");
       expect(txtContent).toContain("world");
       _promptAuditorDeps.write = orig;
+      _promptAuditorDeps.appendLine = origAppend;
     });
   });
 
   test("recordError() entries appear in JSONL but produce no txt file", async () => {
     await withTempDir(async (dir) => {
+      const appends: string[] = [];
       const paths: string[] = [];
-      let captured = "";
-      const orig = _promptAuditorDeps.write;
-      _promptAuditorDeps.write = async (p, d) => { paths.push(p); captured = String(d); return 0; };
+      const origAppend = _promptAuditorDeps.appendLine;
+      const origWrite = _promptAuditorDeps.write;
+      _promptAuditorDeps.appendLine = async (p: string, d: string) => { appends.push(d); };
+      _promptAuditorDeps.write = async (p: string) => { paths.push(p); return 0; };
       const aud = new PromptAuditor("r-001", join(dir, "audit"), FEATURE);
       aud.recordError({ ts: Date.now(), runId: "r-001", agentName: "claude", errorCode: "TIMEOUT", durationMs: 50 });
       await aud.flush();
-      expect(paths).toHaveLength(1);
-      expect(paths[0]).toEndWith(".jsonl");
-      const parsed = JSON.parse(captured.trim());
+      expect(paths).toHaveLength(0);
+      expect(appends).toHaveLength(1);
+      const parsed = JSON.parse(appends[0].trim());
       expect(parsed.errorCode).toBe("TIMEOUT");
-      _promptAuditorDeps.write = orig;
-    });
-  });
-
-  test("flush() captures entries recorded during async write (in-flight buffer)", async () => {
-    await withTempDir(async (dir) => {
-      const flushDir = join(dir, "audit");
-      const written: string[] = [];
-      let resolveWrite!: (n: number) => void;
-      const writePromise = new Promise<number>((r) => { resolveWrite = r; });
-      const orig = _promptAuditorDeps.write;
-      _promptAuditorDeps.write = async (_p, d) => { written.push(String(d)); return writePromise; };
-      const aud = new PromptAuditor("r-test", flushDir, FEATURE);
-      aud.record(makeEntry({ ts: 1000, prompt: "first" }));
-
-      const flushTask = aud.flush();
-      aud.record(makeEntry({ ts: 2000, prompt: "second" }));
-      resolveWrite(0);
-      await flushTask;
-
-      // entries without sessionName → only JSONL writes (2 total: initial + merged)
-      const jsonlWrites = written.filter((_, i) => i === 0 || i === 1);
-      const allLines = jsonlWrites[1].trim().split("\n").filter(Boolean);
-      expect(allLines).toHaveLength(2);
-      expect(JSON.parse(allLines[0]).prompt).toBe("first");
-      expect(JSON.parse(allLines[1]).prompt).toBe("second");
-      _promptAuditorDeps.write = orig;
-    });
-  });
-
-  test("flush() captures error entries recorded during async write", async () => {
-    await withTempDir(async (dir) => {
-      const flushDir = join(dir, "audit");
-      const written: string[] = [];
-      let resolveWrite!: (n: number) => void;
-      const writePromise = new Promise<number>((r) => { resolveWrite = r; });
-      const orig = _promptAuditorDeps.write;
-      _promptAuditorDeps.write = async (_p, d) => { written.push(String(d)); return writePromise; };
-      const aud = new PromptAuditor("r-test", flushDir, FEATURE);
-      aud.record(makeEntry({ ts: 1000, prompt: "first" }));
-
-      const flushTask = aud.flush();
-      aud.recordError({ ts: 2000, runId: "r-test", agentName: "claude", errorCode: "TIMEOUT", durationMs: 50 });
-      resolveWrite(0);
-      await flushTask;
-
-      // initial entry has no sessionName → JSONL only; error also JSONL only
-      // written[1] is the merged JSONL re-write
-      const allLines = written[1].trim().split("\n").filter(Boolean);
-      expect(allLines).toHaveLength(2);
-      expect(JSON.parse(allLines[1]).errorCode).toBe("TIMEOUT");
-      _promptAuditorDeps.write = orig;
+      _promptAuditorDeps.appendLine = origAppend;
+      _promptAuditorDeps.write = origWrite;
     });
   });
 });

--- a/test/unit/session/manager-phase-b-prompt.test.ts
+++ b/test/unit/session/manager-phase-b-prompt.test.ts
@@ -113,6 +113,22 @@ describe("sendPrompt()", () => {
     });
   });
 
+  test("throws SESSION_TERMINAL_STATE when session is COMPLETED (closed without re-open)", async () => {
+    const adapter = makeAgentAdapter({
+      openSession: mock(async (name: string) => ({ id: name, agentName: "claude" }) as SessionHandle),
+      sendTurn: mock(async () => MOCK_TURN),
+      closeSession: mock(async () => {}),
+    });
+    const sm = new SessionManager({ getAdapter: () => adapter });
+    const handle = await sm.openSession("nax-terminal-test", makeOpenRequest());
+    await sm.sendPrompt(handle, "first prompt");
+    await sm.closeSession(handle);
+
+    await expect(sm.sendPrompt(handle, "after close")).rejects.toMatchObject({
+      code: "SESSION_TERMINAL_STATE",
+    });
+  });
+
   test("forwards maxTurns to adapter.sendTurn", async () => {
     let capturedMaxTurns: number | undefined;
     const adapter = makeAgentAdapter({

--- a/test/unit/session/manager-phase-b-session.test.ts
+++ b/test/unit/session/manager-phase-b-session.test.ts
@@ -229,7 +229,7 @@ describe("closeSession()", () => {
     expect(sm.descriptor(name)?.state).toBe("COMPLETED");
   });
 
-  test("clears busy flag so a post-close sendPrompt does not throw SESSION_BUSY", async () => {
+  test("clears busy flag so a post-close sendPrompt throws SESSION_TERMINAL_STATE, not SESSION_BUSY", async () => {
     let resolveFirst!: () => void;
     let callCount = 0;
     const MOCK_TURN = {
@@ -258,8 +258,10 @@ describe("closeSession()", () => {
     resolveFirst();
     await firstTurn;
 
-    // Busy guard cleared — second sendPrompt must not throw SESSION_BUSY
-    const second = await sm.sendPrompt(handle, "second");
-    expect(second.output).toBe("hello world");
+    // Busy guard cleared (no SESSION_BUSY) — SESSION_TERMINAL_STATE fires instead,
+    // confirming the session is COMPLETED and must be re-opened before reuse.
+    await expect(sm.sendPrompt(handle, "second")).rejects.toMatchObject({
+      code: "SESSION_TERMINAL_STATE",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Issue A:** ACP adapter recovers from NO_SESSION (exit code 4) by re-establishing the session before retry, instead of replaying to a dead handle. Session manager guards `sendPrompt` against COMPLETED/FAILED state without re-open.
- **Issue B/E:** Thread `storyId` to `acceptanceGenerateOp` callOp so middleware logs and prompt-audit JSONL include story correlation.
- **Issue C:** Remove `sessionName` gate in prompt auditor — all entries now get txt files using a `deriveTxtFilename` fallback (`<ts>-<callType>-<stage>[-<storyId>].txt`).
- **Issue D:** Replace in-memory `_entries[]` buffer with a write-queue (`_queue: Promise<void>`) for crash-safe, per-entry persistence. JSONL is appendable and `tail -f`-able during runs.
- **Review fixes:** Make `_session` mutable on handle so `closeSession` targets the recovered session; swallow `_enqueue` errors instead of retrying to prevent double-writes and broken chains.

Findings: `docs/findings/2026-04-27-dogfood-session-expiry-and-logging-issues.md`

## Test plan

- [x] `test/unit/agents/acp/adapter-phase-a.test.ts` — NO_SESSION recovery + double-NO_SESSION throw
- [x] `test/unit/session/manager-phase-b-prompt.test.ts` — SESSION_TERMINAL_STATE guard
- [x] `test/unit/pipeline/stages/acceptance-setup-strategy.test.ts` — storyId threading to generate op
- [x] `test/unit/runtime/prompt-auditor.test.ts` — write-queue immediacy, sessionName-less txt filenames, empty-response txt
- [x] `test/integration/runtime/runtime-middleware.test.ts` — updated for appendLine-based JSONL path
- [ ] Full suite (`bun run test`) passes
- [ ] Typecheck (`bun run typecheck`) clean
- [ ] Lint (`bun run lint`) clean