### PR TITLE
[codex] Route ambiguous full-suite failures to deferred regression

### DIFF
--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -256,7 +256,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
   // Pass initialRef so the gate can use git-diff to suppress pre-existing failures
   // in files the story never touched (BUG-TC-001).
   const implementerBinding = getTddSessionBinding?.("implementer");
-  const { passed: fullSuiteGatePassed, cost: fullSuiteGateCost } = await runFullSuiteGate(
+  const { cost: fullSuiteGateCost, fullSuiteGatePassed } = await runFullSuiteGate(
     story,
     config,
     workdir,

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -44,6 +44,12 @@ interface TddRectificationAttemptResult {
   isolationPassed: boolean;
 }
 
+interface FullSuiteGateResult {
+  passed: boolean;
+  cost: number;
+  fullSuiteGatePassed: boolean;
+}
+
 /** Injectable deps for testability — avoids mock.module() contamination */
 export const _rectificationGateDeps = {
   executeWithTimeout: _executeWithTimeout,
@@ -93,9 +99,9 @@ export async function runFullSuiteGate(
   sessionManager?: import("../session").ISessionManager,
   sessionId?: string,
   runtime?: import("../runtime").NaxRuntime,
-): Promise<{ passed: boolean; cost: number }> {
+): Promise<FullSuiteGateResult> {
   const rectificationEnabled = config.execution.rectification?.enabled ?? false;
-  if (!rectificationEnabled) return { passed: false, cost: 0 };
+  if (!rectificationEnabled) return { passed: false, cost: 0, fullSuiteGatePassed: false };
 
   const rectificationConfig = config.execution.rectification;
   const fullSuiteTimeout = rectificationConfig.fullSuiteTimeoutSeconds;
@@ -125,12 +131,21 @@ export async function runFullSuiteGate(
     const testSummary = _rectificationGateDeps.parseTestOutput(fullSuiteResult.output);
 
     if (testSummary.failed > 0) {
+      if (testSummary.failures.length === 0) {
+        logger.warn("tdd", "Full suite gate found unattributable failures — deferring to run-level regression", {
+          storyId: story.id,
+          failedTests: testSummary.failed,
+          passedTests: testSummary.passed,
+          outputLength: fullSuiteResult.output.length,
+          outputTail: fullSuiteResult.output.slice(-200),
+        });
+        return { passed: true, cost: 0, fullSuiteGatePassed: false };
+      }
+
       // Filter out failures in files the story never touched (pre-existing pollution).
       // Uses git diff since storyFromRef to identify story-owned files.
-      // Only applies when structured failures are available — if failures[] is empty
-      // (parser limitation / count-only output), fall through to rectification unchanged.
       let filteredFailures = testSummary.failures;
-      if (storyFromRef && testSummary.failures.length > 0) {
+      if (storyFromRef) {
         const storyFiles = await getStoryChangedFiles(workdir, storyFromRef);
         if (storyFiles.size > 0) {
           filteredFailures = testSummary.failures.filter((f) => storyFiles.has(f.file));
@@ -146,7 +161,7 @@ export async function runFullSuiteGate(
           suppressedTestCount: testSummary.failures.length,
           suppressedFiles: uniqueSuppressedFiles,
         });
-        return { passed: true, cost: 0 };
+        return { passed: true, cost: 0, fullSuiteGatePassed: true };
       }
 
       if (wasFiltered) {
@@ -196,7 +211,7 @@ export async function runFullSuiteGate(
         exitCode: fullSuiteResult.exitCode,
         passedTests: testSummary.passed,
       });
-      return { passed: true, cost: 0 };
+      return { passed: true, cost: 0, fullSuiteGatePassed: true };
     }
 
     // No tests passed AND no tests failed — output is likely truncated/crashed
@@ -206,17 +221,17 @@ export async function runFullSuiteGate(
       outputLength: fullSuiteResult.output.length,
       outputTail: fullSuiteResult.output.slice(-200),
     });
-    return { passed: false, cost: 0 };
+    return { passed: false, cost: 0, fullSuiteGatePassed: false };
   }
   if (fullSuitePassed) {
     logger.info("tdd", "Full suite gate passed", { storyId: story.id });
-    return { passed: true, cost: 0 };
+    return { passed: true, cost: 0, fullSuiteGatePassed: true };
   }
   logger.warn("tdd", "Full suite gate execution failed (no output)", {
     storyId: story.id,
     exitCode: fullSuiteResult.exitCode,
   });
-  return { passed: false, cost: 0 };
+  return { passed: false, cost: 0, fullSuiteGatePassed: false };
 }
 
 /** Run the rectification retry loop when full suite gate detects regressions. */
@@ -238,7 +253,7 @@ async function runRectificationLoop(
   sessionManager?: import("../session").ISessionManager,
   sessionId?: string,
   runtime?: import("../runtime").NaxRuntime,
-): Promise<{ passed: boolean; cost: number }> {
+): Promise<FullSuiteGateResult> {
   logger.warn("tdd", "Full suite gate detected regressions", {
     storyId: story.id,
     failedTests: testSummary.failed,
@@ -419,12 +434,12 @@ async function runRectificationLoop(
   const fixed = outcome.outcome === "fixed";
 
   if (fixed) {
-    return { passed: true, cost: gateCostAccum };
+    return { passed: true, cost: gateCostAccum, fullSuiteGatePassed: true };
   }
 
   logger.warn("tdd", "[WARN] Full suite gate failed after rectification exhausted", {
     storyId: story.id,
     attempts: outcome.attempts,
   });
-  return { passed: false, cost: gateCostAccum };
+  return { passed: false, cost: gateCostAccum, fullSuiteGatePassed: false };
 }

--- a/test/unit/execution/lifecycle/run-regression.test.ts
+++ b/test/unit/execution/lifecycle/run-regression.test.ts
@@ -155,6 +155,43 @@ describe("runDeferredRegression — early exit after first story", () => {
     // Cost is tracked for the story that ran
     expect(result.storyCosts).toEqual({ "US-001": 0.5 });
   });
+
+  test("count-only failures are treated as unmapped and still trigger deferred rectification", async () => {
+    const verifyCalls: string[] = [];
+
+    _regressionDeps.runVerification = mock(async () => {
+      const call = verifyCalls.length;
+      verifyCalls.push(`call-${call}`);
+      if (call === 0) {
+        return makeVerifyResult({
+          output: "3 passed, 2 failed [1.7ms]\nsrc/foo.ts:12:8 - error TS2304: Cannot find name 'missingSymbol'",
+          passCount: 3,
+          failCount: 2,
+        });
+      }
+      return makePassResult(151);
+    });
+
+    _regressionDeps.parseTestOutput = mock(() => ({
+      passed: 3,
+      failed: 2,
+      failures: [],
+    }));
+
+    const rectifiedStories: string[] = [];
+    _regressionDeps.runRectificationLoop = mock(async (opts) => {
+      rectifiedStories.push(opts.story.id);
+      return { succeeded: true, cost: 0.4, durationMs: 120 };
+    });
+
+    const result = await runDeferredRegression(makeOptions(["US-001", "US-002"]));
+
+    expect(result.success).toBe(true);
+    expect(result.affectedStories).toEqual(["US-001", "US-002"]);
+    expect(rectifiedStories).toEqual(["US-001"]);
+    expect(result.rectificationAttempts).toBe(1);
+    expect(verifyCalls).toHaveLength(2);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/tdd/rectification-gate-session.test.ts
+++ b/test/unit/tdd/rectification-gate-session.test.ts
@@ -247,10 +247,11 @@ describe("rectification session reuse", () => {
     expect(role1).toBe(role2);
   });
 
-  test("includes raw test output in the TDD rectification prompt when failures are unmapped", async () => {
+  test("defers unattributable failures to run-level regression instead of rectifying", async () => {
     const story = makeStory({ id: "US-UNMAPPED" });
     const config = makeConfig(1);
     const agent = makeAgent();
+    const warn = mock(() => {});
     const unmappedOutput = `
 test/example.test.ts:
 ✓ passing test [0.5ms]
@@ -283,16 +284,16 @@ src/foo.ts:12:8 - error TS2304: Cannot find name 'missingSymbol'
       },
     });
 
-    await runFullSuiteGate(story, config, "/tmp/fake-workdir", agentManager, "balanced", true, {
+    const result = await runFullSuiteGate(story, config, "/tmp/fake-workdir", agentManager, "balanced", true, {
       info: () => {},
-      warn: () => {},
+      warn,
       error: () => {},
       debug: () => {},
     } as any, "my-feature");
 
-    expect(agent.calls.length).toBe(1);
-    expect(agent.calls[0]?.prompt).toContain("Unmapped test failures (2 detected)");
-    expect(agent.calls[0]?.prompt).toContain("Structured test failure parsing returned no failure records");
-    expect(agent.calls[0]?.prompt).toContain("Cannot find name 'missingSymbol'");
+    expect(result.passed).toBe(true);
+    expect(result.fullSuiteGatePassed).toBe(false);
+    expect(agent.calls.length).toBe(0);
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- route ambiguous full-suite failures in the TDD gate to deferred regression instead of immediate rectification
- keep `fullSuiteGatePassed` false for deferred ambiguity so run-end smart-skip does not suppress deferred regression
- add targeted tests for both the TDD gate and deferred regression count-only path

## Root Cause
The TDD full-suite gate treated `failed > 0` with `failures: []` as a rectification case. That sent the implementer into retries for failures that could not be attributed to the story. If we had simply passed the gate, the existing `fullSuiteGatePassed` flag could also have caused run-end deferred regression to be skipped.

## Impact
This keeps per-story TDD runs from burning rectification attempts on unattributable failures while preserving the deferred regression gate as the run-level backstop.

## Validation
- `bun test test/unit/execution/lifecycle/run-regression.test.ts test/unit/execution/lifecycle-completion.test.ts test/unit/tdd/rectification-gate-session.test.ts --timeout=30000`
- `bun test test/unit/tdd/rectification-gate-session.test.ts test/unit/execution/lifecycle-completion.test.ts test/integration/agents/acp/tdd-flow-rectification.test.ts --timeout=30000`
- `bun run typecheck`
- `bun run lint`