### PR TITLE
[codex] Restore prompt audit filename consistency

### DIFF
--- a/docs/findings/2026-04-28-prompt-audit-dispatch-boundary.md
+++ b/docs/findings/2026-04-28-prompt-audit-dispatch-boundary.md
@@ -1,0 +1,65 @@
+# Prompt audit dispatch boundary regression
+
+**Date:** 2026-04-28
+**Reporter:** williamkhoo
+**Observed in:** `/home/williamkhoo/Desktop/projects/nathapp/nax-dogfood/fixtures/hello-lint/.nax/prompt-audit/hello-lint`
+**Reference convention:** `logs/prompt-audit/memory-phase4-graph-code-intelligence/`
+
+## Summary
+
+Prompt audit file names drifted after ADR-018 / ADR-019 moved audit recording into the runtime middleware chain. A single logical run prompt could be recorded twice:
+
+- once by the outer `AgentManager.runAs()` middleware envelope, without session identity
+- once by the inner `AgentManager.runAsSession()` dispatch, with the real session identity
+
+This produced mixed audit names in the same feature folder, for example:
+
+```text
+1777359039605-nax-07a92405-hello-lint-us-001-implementer.txt
+1777359039822-run-run-US-001.txt
+1777358910568-complete-acceptance-US-001.txt
+```
+
+The historical convention was consistent and session-oriented:
+
+```text
+1777211627107-nax-b37155e8-memory-phase4-graph-code-intelligence-us-000-implementer-run-t01.txt
+1777219140491-nax-b37155e8-memory-phase4-graph-code-intelligence-us-001-reviewer-semantic-review-t01.txt
+1777211320978-nax-52d67808-memory-phase4-graph-code-intelligence-us-001-refine-complete.txt
+1777211412033-nax-b37155e8-memory-phase4-graph-code-intelligence-acceptance-gen-complete.txt
+```
+
+## Root Cause
+
+The outer/inner runtime shape is intentional:
+
+- `runAs()` / `runWithFallback()` owns fallback policy and the logical run envelope.
+- `runAsSession()` owns the concrete session turn and calls `SessionManager.sendPrompt()`.
+
+The design bug was making prompt audit a generic middleware side effect at both layers. For `executeHop` runs, the same prompt crosses both middleware boundaries, but only the inner boundary is the actual agent dispatch. The outer boundary lacks session handle, turn number, and protocol correlation, so it can only derive fallback-style names such as `run-run-US-001`.
+
+One-shot `complete` calls have a different shape: they do not go through `runAsSession()`, so their prompt audit still needs to happen at `completeAs()`. The missing piece was preserving enough complete-call metadata in `MiddlewareContext` to derive the same session-style filename convention.
+
+## Fix Applied
+
+The short-term fix restores the prior operator-facing convention while keeping ADR-018 / ADR-019 layering:
+
+1. `auditMiddleware` skips outer `run` audit entries when `ctx.request.executeHop` is present and no `sessionHandle` exists. The inner `runAsSession()` audit entry remains the source of truth.
+2. `completeAs()` threads `CompleteOptions` into `MiddlewareContext` so complete calls can derive session-style audit names from `workdir`, `featureName`, `storyId`, and `sessionRole`.
+3. `callOp()` now forwards `featureName` for `complete` operations, matching the metadata already passed for `run` operations.
+4. `PromptAuditor` writes legacy-style suffixes for session-named entries:
+   - `run` entries: `<epoch>-<sessionName>-<stage>-tNN.txt`
+   - `complete` entries: `<epoch>-<sessionName>-complete.txt`
+
+## Long-Term Recommendation
+
+Prompt audit should eventually stop inferring dispatch intent from generic middleware context. A more durable design is:
+
+- keep middleware for operation telemetry, cost, cancellation, fallback events, and logs
+- emit prompt audit from explicit concrete dispatch boundaries:
+  - `SessionManager.sendPrompt()` / `runAsSession()` for session turns
+  - `completeAs()` or the adapter complete boundary for one-shot completions
+- use a typed `PromptDispatchAuditEvent` that already contains `sessionName`, `callType`, `stage`, `turn`, `featureName`, `storyId`, and protocol IDs
+
+That would make duplicate prompt audit structurally impossible instead of relying on an `executeHop` guard.
+

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -489,6 +489,7 @@ export class AgentManager implements IAgentManager {
       agentName,
       kind: "complete",
       request: null,
+      completeOptions: augmented,
       prompt,
       config: this._config,
       signal: options.signal,

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -66,6 +66,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       pipelineStage: op.stage,
       storyId: ctx.storyId,
       workdir: ctx.packageDir,
+      featureName: ctx.featureName,
     });
     return op.parse(raw.output, input, buildCtx);
   }

--- a/src/runtime/agent-middleware.ts
+++ b/src/runtime/agent-middleware.ts
@@ -1,4 +1,5 @@
 import type { AgentRunRequest } from "../agents/manager-types";
+import type { CompleteOptions } from "../agents/types";
 import type { NaxConfig } from "../config";
 import type { ResolvedPermissions } from "../config/permissions";
 
@@ -7,6 +8,7 @@ export interface MiddlewareContext {
   readonly agentName: string;
   readonly kind: "run" | "complete" | "plan";
   readonly request: AgentRunRequest | null;
+  readonly completeOptions?: CompleteOptions;
   readonly prompt: string | null;
   readonly config: NaxConfig;
   readonly signal?: AbortSignal;

--- a/src/runtime/middleware/audit.ts
+++ b/src/runtime/middleware/audit.ts
@@ -2,23 +2,40 @@ import type { AgentResult } from "../../agents/types";
 import { NaxError } from "../../errors";
 import type { AgentMiddleware, MiddlewareContext } from "../agent-middleware";
 import type { IPromptAuditor, PromptAuditEntry, PromptAuditErrorEntry } from "../prompt-auditor";
+import { formatSessionName } from "../session-name";
 
 function extractOutput(result: unknown): string {
   if (!result || typeof result !== "object") return "";
   return ((result as Record<string, unknown>).output as string | undefined) ?? "";
 }
 
+function sessionNameFromCompleteOptions(ctx: MiddlewareContext): string | undefined {
+  const opts = ctx.completeOptions;
+  if (!opts) return undefined;
+  if (opts.sessionName) return opts.sessionName;
+  if (!opts.workdir || !opts.featureName) return undefined;
+  return formatSessionName({
+    workdir: opts.workdir,
+    featureName: opts.featureName,
+    storyId: opts.storyId,
+    role: opts.sessionRole,
+    pipelineStage: opts.pipelineStage,
+  });
+}
+
 export function auditMiddleware(auditor: IPromptAuditor, runId: string): AgentMiddleware {
   return {
     name: "audit",
     async after(ctx: MiddlewareContext, result: unknown, durationMs: number): Promise<void> {
+      if (ctx.kind === "run" && ctx.sessionHandle === undefined && ctx.request?.executeHop) return;
+
       const runOpts = ctx.request?.runOptions;
       const prompt = ctx.prompt ?? runOpts?.prompt;
       if (!prompt) return;
 
       const agentResult = (result ?? {}) as Partial<AgentResult>;
       const { protocolIds } = agentResult;
-      const sessionName = ctx.sessionHandle?.id;
+      const sessionName = ctx.sessionHandle?.id ?? sessionNameFromCompleteOptions(ctx);
       const internalRoundTrips =
         result && typeof result === "object" && "internalRoundTrips" in result
           ? (result as { internalRoundTrips: number }).internalRoundTrips
@@ -35,9 +52,9 @@ export function auditMiddleware(auditor: IPromptAuditor, runId: string): AgentMi
         response: extractOutput(result),
         durationMs,
         callType: ctx.kind,
-        workdir: runOpts?.workdir,
+        workdir: runOpts?.workdir ?? ctx.completeOptions?.workdir,
         projectDir: runOpts?.projectDir,
-        featureName: runOpts?.featureName,
+        featureName: runOpts?.featureName ?? ctx.completeOptions?.featureName,
         ...(sessionName !== undefined && { sessionName }),
         ...(protocolIds?.recordId !== undefined && { recordId: protocolIds.recordId }),
         ...(protocolIds?.sessionId !== undefined && { sessionId: protocolIds.sessionId }),

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -75,11 +75,21 @@ export const _promptAuditorDeps = {
 
 function deriveTxtFilename(entry: PromptAuditEntry): string {
   if (entry.sessionName) {
-    return `${entry.ts}-${entry.sessionName}.txt`;
+    const suffix = deriveAuditSuffix(entry);
+    return `${entry.ts}-${entry.sessionName}${suffix ? `-${suffix}` : ""}.txt`;
   }
   const parts: string[] = [String(entry.ts), entry.callType ?? "call", entry.stage ?? "unknown"];
   if (entry.storyId) parts.push(entry.storyId);
   return `${parts.join("-")}.txt`;
+}
+
+function deriveAuditSuffix(entry: PromptAuditEntry): string | undefined {
+  if (entry.callType === "run" && entry.turn !== undefined) {
+    const stage = entry.stage ?? "run";
+    return `${stage}-t${String(entry.turn).padStart(2, "0")}`;
+  }
+  if (entry.callType === "complete") return "complete";
+  return entry.stage ?? entry.callType;
 }
 
 function buildTxtContent(entry: PromptAuditEntry): string {

--- a/test/unit/runtime/middleware/audit.test.ts
+++ b/test/unit/runtime/middleware/audit.test.ts
@@ -52,6 +52,53 @@ describe("auditMiddleware", () => {
     expect(recorded[0].featureName).toBe("feat-x");
   });
 
+  test("after() records session-style name for complete calls with feature context", async () => {
+    const recorded: PromptAuditEntry[] = [];
+    const aud = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };
+    const mw = auditMiddleware(aud, "r-001");
+    const ctx: MiddlewareContext = {
+      runId: "r-001", agentName: "claude", kind: "complete",
+      request: null,
+      completeOptions: {
+        config: DEFAULT_CONFIG,
+        workdir: "/tmp/w",
+        featureName: "Feat X",
+        storyId: "US-001",
+        sessionRole: "refine",
+        pipelineStage: "acceptance",
+      },
+      prompt: "hello",
+      config: DEFAULT_CONFIG,
+      resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+      storyId: "US-001", stage: "acceptance",
+    };
+    await mw.after!(ctx, { output: "ok" }, 100);
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].sessionName).toStartWith("nax-");
+    expect(recorded[0].sessionName).toEndWith("-feat-x-us-001-refine");
+    expect(recorded[0].featureName).toBe("Feat X");
+    expect(recorded[0].workdir).toBe("/tmp/w");
+  });
+
+  test("after() skips outer runAs audit when executeHop handles session audit", async () => {
+    const recorded: PromptAuditEntry[] = [];
+    const aud = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };
+    const mw = auditMiddleware(aud, "r-001");
+    const ctx: MiddlewareContext = {
+      runId: "r-001", agentName: "claude", kind: "run",
+      request: {
+        runOptions: { prompt: "hello", workdir: "/tmp/w", projectDir: "/tmp/p", featureName: "feat-x" } as never,
+        executeHop: async () => ({ result: {} as never, bundle: undefined }),
+      },
+      prompt: "hello",
+      config: DEFAULT_CONFIG,
+      resolvedPermissions: { mode: "approve-reads", skipPermissions: false },
+      storyId: "s-1", stage: "run",
+    };
+    await mw.after!(ctx, { output: "ok" }, 100);
+    expect(recorded).toHaveLength(0);
+  });
+
   test("after() records ACP session correlation from MiddlewareContext.sessionHandle", async () => {
     const recorded: PromptAuditEntry[] = [];
     const aud = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };

--- a/test/unit/runtime/prompt-auditor.test.ts
+++ b/test/unit/runtime/prompt-auditor.test.ts
@@ -87,7 +87,7 @@ describe("PromptAuditor", () => {
     });
   });
 
-  test("flush() writes <ts>-<sessionName>.txt alongside JSONL for entries with sessionName", async () => {
+  test("flush() writes legacy session-style run filename alongside JSONL for entries with sessionName", async () => {
     await withTempDir(async (dir) => {
       const flushDir = join(dir, "audit");
       const txtPaths: string[] = [];
@@ -96,10 +96,43 @@ describe("PromptAuditor", () => {
       _promptAuditorDeps.write = async (p: string) => { txtPaths.push(p); return 0; };
       _promptAuditorDeps.appendLine = async () => {};
       const aud = new PromptAuditor("my-run", flushDir, FEATURE);
-      aud.record(makeEntry({ ts: 1234567890000, sessionName: "nax-abc12345-my-feature-us-000-run" }));
+      aud.record(makeEntry({
+        ts: 1234567890000,
+        callType: "run",
+        stage: "run",
+        sessionName: "nax-abc12345-my-feature-us-000-implementer",
+        turn: 1,
+      }));
       await aud.flush();
       expect(txtPaths).toHaveLength(1);
-      expect(txtPaths[0]).toBe(join(flushDir, FEATURE, "1234567890000-nax-abc12345-my-feature-us-000-run.txt"));
+      expect(txtPaths[0]).toBe(
+        join(flushDir, FEATURE, "1234567890000-nax-abc12345-my-feature-us-000-implementer-run-t01.txt"),
+      );
+      _promptAuditorDeps.write = origWrite;
+      _promptAuditorDeps.appendLine = origAppend;
+    });
+  });
+
+  test("flush() writes legacy session-style complete filename for complete entries", async () => {
+    await withTempDir(async (dir) => {
+      const flushDir = join(dir, "audit");
+      const txtPaths: string[] = [];
+      const origWrite = _promptAuditorDeps.write;
+      const origAppend = _promptAuditorDeps.appendLine;
+      _promptAuditorDeps.write = async (p: string) => { txtPaths.push(p); return 0; };
+      _promptAuditorDeps.appendLine = async () => {};
+      const aud = new PromptAuditor("my-run", flushDir, FEATURE);
+      aud.record(makeEntry({
+        ts: 1234567890000,
+        callType: "complete",
+        stage: "acceptance",
+        sessionName: "nax-abc12345-my-feature-us-000-refine",
+      }));
+      await aud.flush();
+      expect(txtPaths).toHaveLength(1);
+      expect(txtPaths[0]).toBe(
+        join(flushDir, FEATURE, "1234567890000-nax-abc12345-my-feature-us-000-refine-complete.txt"),
+      );
       _promptAuditorDeps.write = origWrite;
       _promptAuditorDeps.appendLine = origAppend;
     });


### PR DESCRIPTION
## Summary

Restores the pre-ADR-018/019 prompt-audit filename convention and documents the dispatch-boundary regression.

- Skip outer `runAs()` prompt-audit writes when `executeHop` delegates to the session-backed inner dispatch.
- Preserve complete-call metadata in middleware so one-shot `complete` audit entries can derive session-style names.
- Forward `featureName` through `callOp()` complete calls.
- Restore legacy text filename suffixes: `run-tNN` for session turns and `complete` for complete calls.
- Add a finding note at `docs/findings/2026-04-28-prompt-audit-dispatch-boundary.md`.

## Root Cause

After ADR-018/019 moved audit into runtime middleware, `executeHop` run prompts crossed two middleware boundaries: the outer logical run envelope and the inner concrete session dispatch. Both wrote prompt audit entries, but only the inner dispatch had session identity and turn metadata. That created duplicate and inconsistent files such as `run-run-US-001.txt` alongside session-style names.

## Validation

- `bun test test/unit/runtime/prompt-auditor.test.ts test/unit/runtime/middleware/audit.test.ts --timeout=30000`
- `bun run typecheck`
- `bun run lint`
- pre-commit hook: typecheck, lint, `scripts/check-process-cwd.sh`
