### PR TITLE
[codex] Align cost events with prompt dispatch

### DIFF
--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -63,6 +63,7 @@ function turnResultToAgentResult(r: TurnResult): AgentResult {
     rateLimited: false,
     durationMs: 0,
     estimatedCostUsd: r.estimatedCostUsd ?? 0,
+    exactCostUsd: r.exactCostUsd,
     tokenUsage: r.tokenUsage,
   };
 }

--- a/src/runtime/middleware/cost.ts
+++ b/src/runtime/middleware/cost.ts
@@ -19,9 +19,11 @@ function extractTokens(
 function extractCosts(result: unknown): { estimatedCostUsd: number; exactCostUsd?: number } | null {
   if (!result || typeof result !== "object") return null;
   const r = result as Record<string, unknown>;
+  const hasEstimatedCost = "estimatedCostUsd" in r;
+  const hasCost = "costUsd" in r;
   const estimatedCostUsd = (r.estimatedCostUsd as number | undefined) ?? (r.costUsd as number | undefined) ?? 0;
   const exactCostUsd = r.exactCostUsd as number | undefined;
-  if (estimatedCostUsd === 0 && exactCostUsd == null) return null;
+  if (!hasEstimatedCost && !hasCost && exactCostUsd == null) return null;
   return { estimatedCostUsd, exactCostUsd };
 }
 
@@ -29,6 +31,8 @@ export function costMiddleware(aggregator: ICostAggregator, runId: string): Agen
   return {
     name: "cost",
     async after(ctx: MiddlewareContext, result: unknown, durationMs: number): Promise<void> {
+      if (ctx.kind === "run" && ctx.sessionHandle === undefined && ctx.request?.executeHop) return;
+
       const tokens = extractTokens(result);
       const costs = extractCosts(result);
       if (!tokens && !costs) return;

--- a/test/unit/operations/build-hop-callback.test.ts
+++ b/test/unit/operations/build-hop-callback.test.ts
@@ -37,6 +37,7 @@ function makeStubTurnResult(output = "agent output"): TurnResult {
     tokenUsage: { inputTokens: 10, outputTokens: 20 },
     internalRoundTrips: 1,
     estimatedCostUsd: 0.001 ,
+    exactCostUsd: 0.002,
   };
 }
 
@@ -120,6 +121,7 @@ describe("buildHopCallback — primary hop (no failure)", () => {
     expect(hop.result.success).toBe(true);
     expect(hop.result.output).toBe("hello from agent");
     expect(hop.result.estimatedCostUsd).toBe(0.001);
+    expect(hop.result.exactCostUsd).toBe(0.002);
     expect(hop.result.tokenUsage).toEqual(turnResult.tokenUsage);
   });
 });

--- a/test/unit/runtime/middleware/cost.test.ts
+++ b/test/unit/runtime/middleware/cost.test.ts
@@ -50,6 +50,35 @@ describe("costMiddleware", () => {
     expect(recorded[0].durationMs).toBe(150);
   });
 
+  test("after() records explicit zero-cost complete calls", async () => {
+    const recorded: CostEvent[] = [];
+    const agg = { ...createNoOpCostAggregator(), record: (e: CostEvent) => recorded.push(e) };
+    const mw = costMiddleware(agg, "r-001");
+    const result = { output: "", costUsd: 0, source: "fallback" };
+    await mw.after!(makeCtx(), result, 150);
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].costUsd).toBe(0);
+    expect(recorded[0].estimatedCostUsd).toBe(0);
+    expect(recorded[0].confidence).toBe("estimated");
+  });
+
+  test("after() skips outer runAs cost when executeHop handles session cost", async () => {
+    const recorded: CostEvent[] = [];
+    const agg = { ...createNoOpCostAggregator(), record: (e: CostEvent) => recorded.push(e) };
+    const mw = costMiddleware(agg, "r-001");
+    const ctx: MiddlewareContext = {
+      ...makeCtx(),
+      request: {
+        runOptions: { prompt: "hello" } as never,
+        executeHop: async () => ({ result: {} as never, bundle: undefined }),
+      },
+      prompt: "hello",
+    };
+    const result = { success: true, estimatedCostUsd: 0.005, tokenUsage: { inputTokens: 1, outputTokens: 1 } };
+    await mw.after!(ctx, result, 100);
+    expect(recorded).toHaveLength(0);
+  });
+
   test("after() records exactCostUsd and confidence=exact when present", async () => {
     const recorded: CostEvent[] = [];
     const agg = { ...createNoOpCostAggregator(), record: (e: CostEvent) => recorded.push(e) };


### PR DESCRIPTION
## Summary

Aligns cost aggregation with the same concrete-dispatch boundary used by prompt audit.

- Skip outer `runAs()` cost events when `executeHop` delegates to the inner session dispatch.
- Preserve `exactCostUsd` when `buildHopCallback` wraps a `TurnResult` as an `AgentResult`.
- Record explicit zero-cost complete results so cost call counts can line up with prompt-audit dispatch counts.

## Root Cause

A dogfood run showed prompt-audit had 11 entries while cost had 10. One complete call returned an explicit zero cost and was skipped because `costMiddleware` treated `costUsd: 0` as absent cost data.

The same run also showed duplicate cost lines for the implementer dispatch. The inner session event had exact wire cost, while the outer `runAs()` envelope re-recorded the same dispatch using estimated cost because `exactCostUsd` was dropped during `TurnResult` -> `AgentResult` conversion.

## Validation

- `bun test test/unit/runtime/middleware/cost.test.ts test/unit/runtime/middleware/audit.test.ts test/unit/operations/build-hop-callback.test.ts --timeout=30000`
- `bun run typecheck`
- `bun run lint`
- pre-commit hook: typecheck, lint, `scripts/check-process-cwd.sh`
