### PR TITLE
chore: release v0.64.0-canary.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.64.0-canary.3",
+  "version": "0.64.0-canary.4",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What
Release v0.64.0-canary.4 — incorporates 4 new commits from main.

## Why
Canary release keeping pace with main development.

## How
- Pulled latest main (4 new commits)
- Version bump: `0.64.0-canary.3` → `0.64.0-canary.4`

## Testing
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes

## Notes
Canary. Stable release to follow once validated.
