### PR TITLE
chore: release v0.64.0-canary.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.64.0-canary.4",
+  "version": "0.64.0-canary.5",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What
Release v0.64.0-canary.5 — incorporates 3 new commits from main.

## Why
Canary release keeping pace with main development.

## How
- Pulled latest main (3 new commits)
- Version bump: `0.64.0-canary.4` → `0.64.0-canary.5`

## Testing
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes

## Notes
Canary. Stable release to follow once validated.
