### PR TITLE
fix: PTY output batching and @design annotation cleanup (P3/P5)

### DIFF
--- a/src/agents/acp/adapter-output.ts
+++ b/src/agents/acp/adapter-output.ts
@@ -25,7 +25,7 @@ export function extractQuestion(output: string): string | null {
   const text = output.trim();
   if (!text) return null;
 
-  // BUG-097: Only check the last non-empty line for question marks.
+  // @design: BUG-097: Only check the last non-empty line for question marks.
   // Scanning all sentences caused false positives on code snippets mid-output
   // containing ?. (optional chaining), ?? (nullish coalescing), or ternary ?.
   const lines = text.split("\n").filter((l) => l.trim().length > 0);

--- a/src/agents/acp/interaction-bridge.ts
+++ b/src/agents/acp/interaction-bridge.ts
@@ -35,7 +35,7 @@ type BridgeEventHandler = (event: unknown) => void;
 const QUESTION_PATTERNS = [/\?\s*$/, /\bwhich\b/i, /\bshould i\b/i, /\bunclear\b/i, /\bplease clarify\b/i];
 
 function containsQuestionPattern(content: string): boolean {
-  // BUG-097: Only check the last non-empty line to avoid false positives
+  // @design: BUG-097: Only check the last non-empty line to avoid false positives
   // from code snippets containing ?. / ?? / ternary ? in the body.
   const lines = content.split("\n").filter((l) => l.trim().length > 0);
   const lastLine = lines.at(-1)?.trim() ?? "";

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -278,7 +278,7 @@ export const _tierEscalationDeps = {
 export async function handleTierEscalation(ctx: EscalationHandlerContext): Promise<EscalationHandlerResult> {
   const logger = getSafeLogger();
 
-  // BUG-070: Runtime crashes are transient — retry same tier, do NOT escalate
+  // @design: BUG-070: Runtime crashes are transient — retry same tier, do NOT escalate
   if (shouldRetrySameTier(ctx.verifyResult)) {
     logger?.warn("escalation", "Runtime crash detected — retrying same tier (transient, not a code issue)", {
       storyId: ctx.story.id,
@@ -362,7 +362,7 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
         ...(shouldSwitchToTestAfter ? { testStrategy: "test-after" as const } : {}),
       };
 
-      // BUG-011: Reset attempt counter on tier escalation
+      // @design: BUG-011: Reset attempt counter on tier escalation
       const currentStoryTier = s.routing?.modelTier ?? ctx.routing.modelTier;
       const isChangingTier = currentStoryTier !== escalatedTier;
       const shouldResetAttempts = isChangingTier || shouldSwitchToTestAfter;

--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -84,7 +84,7 @@ export async function runIteration(
     effectiveWorkdir = worktreePath;
   }
 
-  // BUG-114: Persist storyGitRef in prd.json so it survives crashes and restarts.
+  // @design: BUG-114: Persist storyGitRef in prd.json so it survives crashes and restarts.
   // On the first attempt we capture HEAD and save it. On resume we reuse the stored
   // ref (after validating it still exists in git history), so semantic review always
   // diffs from the true start of this story regardless of how many times nax restarted.
@@ -100,7 +100,7 @@ export async function runIteration(
     }
   }
 
-  // BUG-067: Accumulate cost from all prior failed attempts (stored in priorFailures by handleTierEscalation)
+  // @design: BUG-067: Accumulate cost from all prior failed attempts (stored in priorFailures by handleTierEscalation)
   const accumulatedAttemptCost = (story.priorFailures || []).reduce((sum, f) => sum + (f.cost || 0), 0);
 
   // PKG-003: Resolve per-package effective config once per story (not per-stage)

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -91,7 +91,7 @@ export interface RunSetupOptions {
   formatterMode: "quiet" | "normal" | "verbose" | "json";
   getTotalCost: () => number;
   getIterations: () => number;
-  // BUG-017: Additional getters for run.complete event on SIGTERM
+  // @design: BUG-017: Additional getters for run.complete event on SIGTERM
   getStoriesCompleted: () => number;
   getTotalStories: () => number;
   /** Protocol-aware agent resolver — passed from runner.ts registry */
@@ -197,7 +197,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     jsonlFilePath: logFilePath,
     pidRegistry,
     abortController: shutdownController,
-    // BUG-017: Pass context for run.complete event on SIGTERM
+    // @design: BUG-017: Pass context for run.complete event on SIGTERM
     runId: options.runId,
     feature: options.feature,
     featureDir: options.featureDir,

--- a/src/execution/lock.ts
+++ b/src/execution/lock.ts
@@ -45,7 +45,7 @@ export async function acquireLock(workdir: string): Promise<boolean> {
   const lockFile = Bun.file(lockPath);
 
   try {
-    // BUG-2 fix: First check for stale lock before attempting atomic create
+    // @design: BUG-2 fix: First check for stale lock before attempting atomic create
     const exists = await lockFile.exists();
     if (exists) {
       // Read lock data

--- a/src/execution/merge-conflict-rectify.ts
+++ b/src/execution/merge-conflict-rectify.ts
@@ -103,7 +103,7 @@ export async function rectifyConflictedStory(options: RectifyConflictedStoryOpti
     await worktreeManager.create(workdir, storyId);
     const worktreePath = path.join(workdir, ".nax-wt", storyId);
 
-    // BUG-122: Close stale ACP session from the original failed run before re-running.
+    // @design: BUG-122: Close stale ACP session from the original failed run before re-running.
     // computeAcpHandle hashes the workdir path — same worktree path = same session name.
     // The old Claude process may still be registered in acpx, causing prompt() to exit
     // with code 4 immediately. Close it explicitly so ensureAcpSession creates fresh.

--- a/src/execution/pipeline-result-handler.ts
+++ b/src/execution/pipeline-result-handler.ts
@@ -123,7 +123,7 @@ export async function handlePipelineSuccess(
       storyDurationMs: ctx.storyStartTime ? now - ctx.storyStartTime : undefined,
     });
 
-    // BUG-074: story:completed event is already emitted by completion stage
+    // @design: BUG-074: story:completed event is already emitted by completion stage
     // (src/pipeline/stages/completion.ts). Do NOT emit again here — it causes
     // duplicate hook messages (on-story-complete fires twice per story).
   }

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -130,7 +130,7 @@ export async function runExecutionPhase(
   // PERF-1: Precompute batch plan once from ready stories
   const readyStories = getAllReadyStories(prd);
 
-  // BUG-068: debug log to diagnose unexpected storyCount in batch routing
+  // @design: BUG-068: debug log to diagnose unexpected storyCount in batch routing
   logger?.debug("routing", "Ready stories for batch routing", {
     readyCount: readyStories.length,
     readyIds: readyStories.map((s) => s.id),

--- a/src/execution/runner-setup.ts
+++ b/src/execution/runner-setup.ts
@@ -81,7 +81,7 @@ export async function runSetupPhase(options: RunnerSetupOptions): Promise<Runner
     formatterMode: options.formatterMode ?? "normal",
     getTotalCost: options.getTotalCost,
     getIterations: options.getIterations,
-    // BUG-017: Pass getters for run.complete event on SIGTERM
+    // @design: BUG-017: Pass getters for run.complete event on SIGTERM
     getStoriesCompleted: options.getStoriesCompleted,
     getTotalStories: options.getTotalStories,
     agentGetFn: options.agentGetFn,

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -138,7 +138,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
     formatterMode,
     getTotalCost: () => totalCost,
     getIterations: () => iterations,
-    // BUG-017: Pass getters for run.complete event on SIGTERM
+    // @design: BUG-017: Pass getters for run.complete event on SIGTERM
     getStoriesCompleted: () => storiesCompleted,
     getTotalStories: () => (prd ? countStories(prd).total : 0),
   });

--- a/src/execution/status-writer.ts
+++ b/src/execution/status-writer.ts
@@ -66,7 +66,7 @@ export class StatusWriter {
   private _runStatus: RunStateSnapshot["runStatus"] = "running";
   private _prd: PRD | null = null;
   private _currentStory: RunStateSnapshot["currentStory"] = null;
-  private _consecutiveWriteFailures = 0; // BUG-2: Track consecutive write failures
+  private _consecutiveWriteFailures = 0; // @design: BUG-2: Track consecutive write failures
   private _postRun: PostRunStatus | null = null;
 
   /**

--- a/src/interaction/bridge-builder.ts
+++ b/src/interaction/bridge-builder.ts
@@ -23,7 +23,7 @@ export interface BridgeContext {
   stage: InteractionStage;
 }
 
-// BUG-097: Use /\?\s*$/ instead of /\?/ to avoid false positives on code (?., ??, ternary)
+// @design: BUG-097: Use /\?\s*$/ instead of /\?/ to avoid false positives on code (?., ??, ternary)
 const QUESTION_PATTERNS = [/\?\s*$/, /\bwhich\b/i, /\bshould i\b/i, /\bunclear\b/i, /\bplease clarify\b/i];
 
 /** Default interaction timeout when config value is not available (2 minutes) */

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -96,7 +96,7 @@ export async function collectStoryMetrics(ctx: PipelineContext, storyStartTime: 
   const agentResult = ctx.agentResult;
 
   // Calculate attempts (initial + escalations)
-  // BUG-067: priorFailures captures cross-tier attempts that story.escalations never records
+  // @design: BUG-067: priorFailures captures cross-tier attempts that story.escalations never records
   const escalationCount = story.escalations?.length || 0;
   const priorFailureCount = story.priorFailures?.length || 0;
   const attempts = priorFailureCount + Math.max(1, story.attempts || 1);

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -507,7 +507,7 @@ export const acceptanceSetupStage: PipelineStage = {
       return { action: "continue" };
     }
 
-    // BUG-084: Use testFramework-aware single-file command (not quality.commands.test which runs full suite)
+    // @design: BUG-084: Use testFramework-aware single-file command (not quality.commands.test which runs full suite)
     // Run RED gate for each per-package test file from its package directory.
     // Use per-package testFramework/commandOverride resolved above.
     let redFailCount = 0;

--- a/src/pipeline/stages/acceptance.ts
+++ b/src/pipeline/stages/acceptance.ts
@@ -155,7 +155,7 @@ export const acceptanceStage: PipelineStage = {
         continue;
       }
 
-      // BUG-083/BUG-084: Run ONLY the acceptance test file, not the full project test suite.
+      // @design: BUG-083/BUG-084: Run ONLY the acceptance test file, not the full project test suite.
       // Resolution order: per-package commandOverride → per-package testFramework → bun test fallback.
       // In monorepo mode, testFramework and commandOverride come from the per-package config
       // resolved by acceptance-setup. In fallback (single-package) mode they fall back to ctx.config.

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -250,7 +250,7 @@ export const executionStage: PipelineStage = {
       }));
     }
 
-    // BUG-058: Auto-commit if agent left uncommitted changes (single-session/test-after)
+    // @design: BUG-058: Auto-commit if agent left uncommitted changes (single-session/test-after)
     await autoCommitIfDirty(ctx.workdir, "execution", "single-session", ctx.story.id);
 
     // merge-conflict trigger: detect CONFLICT markers in agent output

--- a/src/pipeline/stages/routing.ts
+++ b/src/pipeline/stages/routing.ts
@@ -34,7 +34,7 @@ export const routingStage: PipelineStage = {
     // Classify story via resolveRouting() (plugin routers > LLM > keyword)
     const decision = await _routingDeps.resolveRouting(ctx.story, ctx.config, ctx.plugins, ctx.agentManager);
 
-    // BUG-032: Only preserve a previously-stored modelTier when it represents an escalation
+    // @design: BUG-032: Only preserve a previously-stored modelTier when it represents an escalation
     // (i.e., a higher tier than what routing freshly derives). This prevents stale tiers
     // from sticking when complexity changes between runs, while still honoring explicit
     // escalations set by handleTierEscalation.
@@ -59,7 +59,7 @@ export const routingStage: PipelineStage = {
       await _routingDeps.savePRD(ctx.prd, ctx.prdPath);
     }
 
-    // BUG-010: Greenfield detection — force test-after if no test files exist
+    // @design: BUG-010: Greenfield detection — force test-after if no test files exist
     // MW-011: Scan story.workdir for monorepo, not repo root
     // STRAT-001: no-test is exempt from greenfield override
     const greenfieldDetectionEnabled = ctx.config.tdd.greenfieldDetection ?? true;

--- a/src/pipeline/stages/verify.ts
+++ b/src/pipeline/stages/verify.ts
@@ -195,7 +195,7 @@ export const verifyStage: PipelineStage = {
       logger.info("verify", message, { storyId: ctx.story.id });
     }
 
-    // BUG-044: Log the effective command for observability
+    // @design: BUG-044: Log the effective command for observability
     logger.info("verify", isFullSuite ? "Running full suite" : "Running scoped tests", {
       storyId: ctx.story.id,
       command: effectiveCommand,
@@ -260,7 +260,7 @@ export const verifyStage: PipelineStage = {
 
     // HARD FAILURE: Tests must pass for story to be marked complete
     if (!result.success) {
-      // BUG-019: Distinguish timeout from actual test failures
+      // @design: BUG-019: Distinguish timeout from actual test failures
       if (result.status === "TIMEOUT") {
         const timeout = ctx.config.execution.verificationTimeoutSeconds;
         logger.error(
@@ -280,7 +280,7 @@ export const verifyStage: PipelineStage = {
       }
 
       // Log tail of output at debug level for context (ENH-001)
-      // BUG-037: Use .slice(-20) to show failures, not prechecks
+      // @design: BUG-037: Use .slice(-20) to show failures, not prechecks
       if (result.status !== "TIMEOUT") {
         logTestOutput(logger, "verify", result.output, { storyId: ctx.story.id });
       }

--- a/src/prd/index.ts
+++ b/src/prd/index.ts
@@ -41,8 +41,8 @@ export async function loadPRD(path: string): Promise<PRD> {
 
   const prd: PRD = await Bun.file(path).json();
 
-  // BUG-21: Normalize story fields to prevent null/undefined arithmetic issues
-  // BUG-004: Auto-default optional PRD fields in-memory (tags, status, acceptanceCriteria, storyPoints)
+  // @design: BUG-21: Normalize story fields to prevent null/undefined arithmetic issues
+  // @design: BUG-004: Auto-default optional PRD fields in-memory (tags, status, acceptanceCriteria, storyPoints)
   for (const story of prd.userStories) {
     story.attempts = story.attempts ?? 0;
     story.priorErrors = story.priorErrors ?? [];

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -69,7 +69,7 @@ export async function runAdversarialReview(
   const startTime = Date.now();
   const logger = getSafeLogger();
 
-  // BUG-114: Resolve effective git ref via shared fallback chain (diff-utils.ts).
+  // @design: BUG-114: Resolve effective git ref via shared fallback chain (diff-utils.ts).
   const effectiveRef = await resolveEffectiveRef(workdir, storyGitRef, story.id);
 
   if (!effectiveRef) {

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -233,7 +233,7 @@ export async function runReview(
   const checks: ReviewCheckResult[] = [];
   let firstFailure: string | undefined;
 
-  // BUG-074: Auto-commit any dirty files the agent left (e.g. bun.lock / package.json
+  // @design: BUG-074: Auto-commit any dirty files the agent left (e.g. bun.lock / package.json
   // after `bun add`) before the uncommitted-changes check. Mirrors BUG-058/063.
   await autoCommitIfDirty(workdir, "review", "agent", storyId ?? "review");
 

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -76,7 +76,7 @@ export async function runSemanticReview(
     });
   }
 
-  // BUG-114: Resolve effective git ref via shared fallback chain (diff-utils.ts).
+  // @design: BUG-114: Resolve effective git ref via shared fallback chain (diff-utils.ts).
   const effectiveRef = await resolveEffectiveRef(workdir, storyGitRef, story.id);
 
   if (!effectiveRef) {

--- a/src/routing/classify.ts
+++ b/src/routing/classify.ts
@@ -125,7 +125,7 @@ export function determineTestStrategy(
   if (tddStrategy === "off") return "test-after";
 
   // auto mode: apply heuristics
-  // BUG-031: exclude description — only use stable, immutable story fields
+  // @design: BUG-031: exclude description — only use stable, immutable story fields
   const text = [title, ...(tags ?? [])].join(" ").toLowerCase();
 
   const isSecurityCritical = SECURITY_KEYWORDS.some((kw) => text.includes(kw));

--- a/src/routing/strategies/llm-parsing.ts
+++ b/src/routing/strategies/llm-parsing.ts
@@ -40,7 +40,7 @@ export function validateRoutingDecision(
     throw new Error(`Invalid modelTier: ${modelTier} (not found in any agent's tier map)`);
   }
 
-  // BUG-045: Derive testStrategy from determineTestStrategy() — single source of truth.
+  // @design: BUG-045: Derive testStrategy from determineTestStrategy() — single source of truth.
   const tddStrategy: TddStrategy = config.tdd?.strategy ?? "auto";
   const testStrategy = determineTestStrategy(
     parsed.complexity as Complexity,

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -99,7 +99,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
   const shouldRollbackOnFailure = config.tdd.rollbackOnFailure ?? true;
 
   // Session 1: Test Writer
-  // BUG-018 / #410: Skip on retry (tests already exist) or review-stage escalation
+  // @design: BUG-018 / #410: Skip on retry (tests already exist) or review-stage escalation
   // (tests already passed). stage="review" is set by buildEscalationFailure when
   // reviewFindings are present (covers both review and autofix exhaustion).
   const hasReviewEscalation = (story.priorFailures ?? []).some((f) => f.stage === "review");
@@ -150,7 +150,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     };
   }
 
-  // BUG-20 Fix: Verify test-writer created test files (isTestFile is language-agnostic).
+  // @design: BUG-20 Fix: Verify test-writer created test files (isTestFile is language-agnostic).
   // ADR-009: pass user-configured testFilePatterns; undefined → broad regex fallback.
   const _tddTestFilePatterns =
     typeof config.execution?.smartTestRunner === "object" && config.execution.smartTestRunner !== null
@@ -159,7 +159,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
   const testFilesCreated = session1 ? session1.filesChanged.filter((f) => isTestFile(f, _tddTestFilePatterns)) : [];
 
   if (!isRetry && testFilesCreated.length === 0) {
-    // BUG-012 Fix: Before declaring greenfield, check if test files already exist in the repo.
+    // @design: BUG-012 Fix: Before declaring greenfield, check if test files already exist in the repo.
     // The test-writer may have produced 0 new files because tests were pre-written and committed
     // separately (e.g. during dogfooding or manual setup). If tests already exist, skip
     // test-writer phase and proceed directly to the implementer.

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -200,7 +200,7 @@ export async function runFullSuiteGate(
       );
     }
 
-    // BUG-059: Non-zero exit with 0 parsed failures could mean:
+    // @design: BUG-059: Non-zero exit with 0 parsed failures could mean:
     // (a) Environmental noise (linter warning) — safe to pass
     // (b) Bun crashed/OOM mid-run — truncated output, parser found nothing
     // Distinguish by checking if any tests were actually detected in the output.

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -279,7 +279,7 @@ export async function runTddSession(
     }
   }
 
-  // BUG-21 Fix: Clean up orphaned child processes if agent failed
+  // @design: BUG-21 Fix: Clean up orphaned child processes if agent failed
   if (!result.success && result.pid) {
     await _sessionRunnerDeps.cleanupProcessTree(result.pid);
   }
@@ -301,7 +301,7 @@ export async function runTddSession(
     });
   }
 
-  // BUG-058: Auto-commit if agent left uncommitted changes
+  // @design: BUG-058: Auto-commit if agent left uncommitted changes
   await _sessionRunnerDeps.autoCommitIfDirty(workdir, "tdd", role, story.id);
 
   // Check isolation based on role and skipIsolation flag.

--- a/src/tui/hooks/usePty.ts
+++ b/src/tui/hooks/usePty.ts
@@ -52,6 +52,14 @@ const MAX_PTY_BUFFER_LINES = 500;
 const MAX_LINE_LENGTH = 10_000;
 
 /**
+ * Interval in ms at which accumulated stdout lines are flushed into React state.
+ *
+ * Batching reduces GC pressure from O(500) spread+slice on every chunk when
+ * the agent produces rapid output. 100ms gives ~10 renders/s — imperceptible lag.
+ */
+const PTY_FLUSH_INTERVAL_MS = 100;
+
+/**
  * Hook for managing PTY lifecycle.
  *
  * Spawns a PTY process, buffers output, and provides a handle for input/resize/kill.
@@ -83,7 +91,7 @@ export function usePty(options: PtySpawnOptions | null): PtyState & { handle: Pt
   const [handle, setHandle] = useState<PtyHandle | null>(null);
 
   // Spawn PTY process
-  // BUG-2: Destructure options to prevent infinite respawn loop due to object identity
+  // @design: BUG-2: Destructure options to prevent infinite respawn loop due to object identity
   const command = options?.command;
   const argsJson = JSON.stringify(options?.args);
   const cwd = options?.cwd;
@@ -106,7 +114,30 @@ export function usePty(options: PtySpawnOptions | null): PtyState & { handle: Pt
 
     setState((prev) => ({ ...prev, isRunning: true }));
 
-    // Stream stdout line-by-line into state buffer.
+    // Accumulate stdout lines here; the flush loop drains them into React state in batches.
+    const pendingLines: string[] = [];
+
+    // Self-scheduling flush loop — batches state updates to avoid O(500) spread+slice per chunk.
+    // @design: setTimeout (not setInterval) so the handle can be cancelled mid-flight via clearTimeout.
+    let cancelled = false;
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleFlush = () => {
+      flushTimer = setTimeout(() => {
+        if (cancelled) return;
+        if (pendingLines.length > 0) {
+          const batch = pendingLines.splice(0);
+          setState((prev) => {
+            const newLines = [...prev.outputLines, ...batch];
+            const trimmed = newLines.length > MAX_PTY_BUFFER_LINES ? newLines.slice(-MAX_PTY_BUFFER_LINES) : newLines;
+            return { ...prev, outputLines: trimmed };
+          });
+        }
+        scheduleFlush();
+      }, PTY_FLUSH_INTERVAL_MS);
+    };
+    scheduleFlush();
+
+    // Stream stdout line-by-line into pendingLines; the flush loop drains to state.
     // void is explicit: proc.kill() closes stdout, which terminates the for-await loop.
     void (async () => {
       let currentLine = "";
@@ -120,14 +151,9 @@ export function usePty(options: PtySpawnOptions | null): PtyState & { handle: Pt
         }
 
         if (lines.length > 0) {
-          const truncatedLines = lines.map((line) =>
-            line.length > MAX_LINE_LENGTH ? `${line.slice(0, MAX_LINE_LENGTH)}…` : line,
+          pendingLines.push(
+            ...lines.map((line) => (line.length > MAX_LINE_LENGTH ? `${line.slice(0, MAX_LINE_LENGTH)}…` : line)),
           );
-          setState((prev) => {
-            const newLines = [...prev.outputLines, ...truncatedLines];
-            const trimmed = newLines.length > MAX_PTY_BUFFER_LINES ? newLines.slice(-MAX_PTY_BUFFER_LINES) : newLines;
-            return { ...prev, outputLines: trimmed };
-          });
         }
       }
     })().catch(() => {});
@@ -138,7 +164,7 @@ export function usePty(options: PtySpawnOptions | null): PtyState & { handle: Pt
         setState((prev) => ({ ...prev, isRunning: false, exitCode: code ?? undefined }));
       })
       .catch(() => {
-        // BUG-22: Guard against setState throws (e.g. on unmount)
+        // @design: BUG-22: Guard against setState throws (e.g. on unmount)
         setState((prev) => ({ ...prev, isRunning: false }));
       });
 
@@ -158,8 +184,10 @@ export function usePty(options: PtySpawnOptions | null): PtyState & { handle: Pt
 
     setHandle(ptyHandle);
 
-    // Cleanup on unmount
+    // Cleanup on unmount — cancel flush loop then kill process
     return () => {
+      cancelled = true;
+      if (flushTimer !== null) clearTimeout(flushTimer);
       proc.kill();
     };
   }, [command, argsJson, cwd, envJson]);

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -299,7 +299,7 @@ export async function getChangedNonTestFiles(
   try {
     // FEAT-010: Use per-attempt baseRef for precise diff; fall back to HEAD~1 if not provided
     const ref = baseRef ?? "HEAD~1";
-    // BUG-039: Use gitWithTimeout to prevent orphan processes on hang
+    // @design: BUG-039: Use gitWithTimeout to prevent orphan processes on hang
     const { stdout, exitCode } = await gitWithTimeout(["diff", "--name-only", ref], workdir);
     if (exitCode !== 0) return [];
 


### PR DESCRIPTION
## Summary

- **PERF-2** (`usePty.ts`): Replaces per-chunk `setState` with a batched flush loop. Stdout lines accumulate in a local array; a self-scheduling `setTimeout` drains them into React state every 100ms (`PTY_FLUSH_INTERVAL_MS`). The timer handle is cancelled via `clearTimeout` in cleanup — satisfying the project's "setTimeout is permitted when cancellable via clearTimeout" exception. Reduces O(500) spread+slice allocations on every chunk to ~10 renders/second.
- **ENH-1** (41 sites, 30 files): Converts all `// BUG-N:` inline annotations to `// @design: BUG-N:`. Signals these are historical design decisions, not open unresolvable tickets. Mechanical find-and-replace, no logic changes.

**Not included — BUG-1** (stack path stripping in `crash-signals.ts`): Requires `process.cwd()` which the pre-commit guard forbids outside `src/cli/` and `src/config/loader.ts`. Proper fix is to thread `workdir` through `SignalHandlerContext` from the CLI entry point — tracked separately.

## Test plan

- [ ] `bun run typecheck` — passes
- [ ] `bun run lint` — passes
- [ ] `bun run test` — 1222 pass, 0 fail
- [ ] Verify TUI still renders PTY output (slight ~100ms delay is imperceptible)
- [ ] Confirm no `// BUG-` comments remain in `src/` (`grep -r "// BUG-" src/` → 0 results)