### PR TITLE
fix(audit): thread ctx.agentManager into TDD dispatch path

### DIFF
--- a/src/tdd/orchestrator-ctx.ts
+++ b/src/tdd/orchestrator-ctx.ts
@@ -19,7 +19,7 @@ export async function runThreeSessionTddFromCtx(
     if (!ctx.sessionManager) return undefined;
     const id = sessionIdByRole.get(role);
     if (!id) return undefined;
-    return { sessionManager: ctx.sessionManager, sessionId: id };
+    return { sessionManager: ctx.sessionManager, sessionId: id, agentManager: ctx.agentManager };
   };
 
   // Defensive check: test fixtures may bypass Zod and omit `context.v2`.
@@ -168,5 +168,6 @@ export async function runThreeSessionTddFromCtx(
     interactionChain: ctx.interaction,
     projectDir: ctx.projectDir,
     abortSignal: ctx.abortSignal,
+    agentManager: ctx.agentManager,
   });
 }

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -37,6 +37,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     lite = false,
     _recursionDepth = 0,
     projectDir,
+    agentManager,
   } = options;
   const logger = getLogger();
 
@@ -260,7 +261,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     story,
     config,
     workdir,
-    wrapAdapterAsManager(agent),
+    agentManager ?? wrapAdapterAsManager(agent),
     implementerTier,
     lite,
     logger,

--- a/src/tdd/types.ts
+++ b/src/tdd/types.ts
@@ -112,6 +112,12 @@ export interface ThreeSessionTddOptions {
   projectDir?: string;
   /** Shutdown abort signal (Issue 5) — forwarded to each agent.run call */
   abortSignal?: AbortSignal;
+  /**
+   * Audit-wired AgentManager from the pipeline context. When provided, the rectification
+   * gate and TDD session runner use it instead of wrapAdapterAsManager(agent) so all
+   * agent calls flow through the middleware chain (audit, cost, cancellation).
+   */
+  agentManager?: import("../agents/manager-types").IAgentManager;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **TDD sessions** (`test-writer`, `implementer`, `verifier`) were silently absent from prompt-audit JSONL because `getTddSessionBinding` returned a binding without `agentManager`, causing `runTddSession` to fall back to `wrapAdapterAsManager(agent)` — a bare adapter wrapper with no middleware chain.
- **Rectification gate** (`runFullSuiteGate`) had the same gap: always used `wrapAdapterAsManager(agent)` even when `ctx.agentManager` was available, so any rectification hop also bypassed audit.

Closes #782. Structural fix tracked in #773.

## Changes

| File | Change |
|:-----|:-------|
| `src/tdd/orchestrator-ctx.ts` | `getTddSessionBinding` now includes `agentManager: ctx.agentManager` in the returned binding |
| `src/tdd/types.ts` | Added `agentManager?: IAgentManager` to `ThreeSessionTddOptions` |
| `src/tdd/orchestrator.ts` | `runFullSuiteGate` uses `agentManager ?? wrapAdapterAsManager(agent)` instead of always wrapping the raw adapter |

## Test plan

- [ ] Full suite passes: `bun run test`
- [ ] TDD integration tests pass: `timeout 60 bun test test/integration/tdd/ --timeout=20000`
- [ ] Typecheck clean: `bun run typecheck`
- [ ] Dogfood a TDD-strategy run and verify `test-writer`, `implementer`, `verifier` entries appear in `.nax/prompt-audit/<feature>/<runId>.jsonl`
- [ ] Trigger rectification (leave a failing test after implementer) and verify the rectification hop also appears in the audit JSONL