### PR TITLE
docs(specs): handover implementation plans for ADR-020 Waves 1, 2, 3

### DIFF
--- a/docs/specs/adr-020-wave-1-dispatch-events.md
+++ b/docs/specs/adr-020-wave-1-dispatch-events.md
@@ -101,27 +101,41 @@ Export from `src/runtime/index.ts` barrel.
 
 ### Step 2 — Typed event types
 
-**New file: `src/runtime/dispatch-events.ts`** (~120 LOC)
+**New file: `src/runtime/dispatch-events.ts`** (~140 LOC)
+
+> **Verified imports** (use these exact paths — the originals were wrong):
+> - `PipelineStage` lives at `../config/permissions` (NOT `../pipeline/types`)
+> - `AgentResult.tokenUsage` is the field name (NOT `usage`)
+> - `ResolvedPermissions` lives at `../config/permissions`
+> - `internalRoundTrips` is **not** on the typed `AgentResult`. Either: (a) add it as `internalRoundTrips?: number` to `src/agents/types.ts:AgentResult` (recommended, ~3 LOC), or (b) keep it off the type and source `turn` from `SessionManager` descriptor turn count. **Decision for this wave: option (a)** — make it a typed field; existing audit middleware already reads it via type assertion (`as { internalRoundTrips: number }`), so the field is de facto present at runtime.
 
 ```typescript
-import type { PipelineStage } from "../pipeline/types";
 import type { TokenUsage } from "../agents/types";
+import type { PipelineStage, ResolvedPermissions } from "../config/permissions";
+import { getSafeLogger } from "../logger";
+import { errorMessage } from "../utils/errors";
 import type { SessionRole } from "./session-role";
 
 /**
  * Fields every dispatch event carries, regardless of kind. New cross-cutting
- * fields (e.g. traceId, resolvedPermissions, packageId) go here once; both
- * variants and every subscriber pick them up via the compiler.
+ * fields (e.g. traceId, packageId) go here once; both variants and every
+ * subscriber pick them up via the compiler.
+ *
+ * @see docs/adr/ADR-020-dispatch-boundary-ssot.md §D1
  */
 export interface DispatchEventBase {
   readonly sessionName: string;
   readonly sessionRole: SessionRole;
   readonly prompt: string;
+  readonly response: string;                       // result.output
   readonly agentName: string;
   readonly stage: PipelineStage;
   readonly storyId?: string;
   readonly featureName?: string;
-  readonly usage?: TokenUsage;
+  readonly workdir?: string;
+  readonly projectDir?: string;
+  readonly resolvedPermissions: ResolvedPermissions;  // resolved by pre-chain in manager
+  readonly tokenUsage?: TokenUsage;
   readonly exactCostUsd?: number;
   readonly durationMs: number;
   readonly timestamp: number;
@@ -131,6 +145,7 @@ export interface SessionTurnDispatchEvent extends DispatchEventBase {
   readonly kind: "session-turn";
   readonly turn: number;
   readonly protocolIds: { sessionId?: string; turnId?: string };
+  /** Diagnostic only — never branch subscriber logic on this. */
   readonly origin: "runAsSession" | "runTrackedSession";
 }
 
@@ -181,7 +196,7 @@ export class DispatchEventBus implements IDispatchEventBus {
       try { l(event); }
       catch (err) {
         // Subscribers must not break the chain. Log and continue.
-        getLogger().warn("dispatch-bus", "listener threw", { error: errorMessage(err) });
+        getSafeLogger()?.warn("dispatch-bus", "listener threw", { error: errorMessage(err) });
       }
     }
   }
@@ -189,14 +204,20 @@ export class DispatchEventBus implements IDispatchEventBus {
     for (const l of this._completedListeners) {
       try { l(event); }
       catch (err) {
-        getLogger().warn("dispatch-bus", "completion-listener threw", { error: errorMessage(err) });
+        getSafeLogger()?.warn("dispatch-bus", "completion-listener threw", { error: errorMessage(err) });
       }
     }
   }
 }
 ```
 
-Wire into `NaxRuntime` (`src/runtime/index.ts`): add `readonly dispatchEvents: IDispatchEventBus` field, instantiate in `createRuntime`, expose via `runtime.dispatchEvents`.
+**Wire into `NaxRuntime`** (`src/runtime/index.ts`):
+
+1. Add `readonly dispatchEvents: IDispatchEventBus` to the `NaxRuntime` interface (line ~47).
+2. In `createRuntime` (line ~102), instantiate `const dispatchEvents = new DispatchEventBus()` early (before manager construction so it can be passed in).
+3. Pass `dispatchEvents` into `createAgentManager(config, { dispatchEvents })` and `new SessionManager({ dispatchEvents, ... })` constructors.
+4. Both managers store the bus on a private field (`this._dispatchEvents`) for emission inside `runAsSession` / `runTrackedSession` / `completeAs`.
+5. Subscribers (`attachAuditSubscriber`, `attachCostSubscriber`, `attachLoggingSubscriber`) called from `createRuntime` after the bus exists; their unsubscribe functions stored for `runtime.close()` cleanup.
 
 ### Step 3 — Tighten role-bearing types
 
@@ -215,92 +236,197 @@ Run typecheck after this step. Compile errors at every drift site (acceptance ge
 
 **File: `src/agents/manager.ts`** around line 442 (`runAsSession`).
 
-After successful adapter return, before the existing middleware `runAfter` call (which gets removed in Step 7):
+Capture `startedAt` at entry; emit after successful adapter return; remove the existing middleware `runBefore`/`runAfter` calls (they're replaced by event emission, see Step 7):
 
 ```typescript
-const event: SessionTurnDispatchEvent = {
-  kind: "session-turn",
-  sessionName: handle.id,
-  sessionRole: handle.role,
-  prompt,
-  agentName,
-  stage: opts.pipelineStage,
-  storyId: opts.storyId,
-  featureName: opts.featureName,
-  turn: result.internalRoundTrips ?? 0,
-  protocolIds: result.protocolIds ?? {},
-  origin: "runAsSession",
-  usage: result.usage,
-  exactCostUsd: result.exactCostUsd,
-  durationMs: Date.now() - startedAt,
-  timestamp: Date.now(),
-};
-this._runtime.dispatchEvents.emitDispatch(event);
+async runAsSession(
+  agentName: string,
+  handle: SessionHandle,
+  prompt: string,
+  opts: AgentRunOptions,        // existing param
+): Promise<TurnResult> {
+  const startedAt = Date.now();
+  const resolvedPermissions = resolvePermissions(opts.config, opts.pipelineStage);
+
+  // ... (existing adapter dispatch — unchanged)
+  const result = await adapter.sendTurn(handle, prompt, { ... });
+
+  // Emit dispatch event before returning. Errors caught — must not block the call.
+  const event: SessionTurnDispatchEvent = {
+    kind: "session-turn",
+    sessionName: handle.id,
+    sessionRole: handle.role,           // post-D6: required SessionRole
+    prompt,
+    response: result.output,
+    agentName,
+    stage: opts.pipelineStage,
+    storyId: opts.storyId,
+    featureName: opts.featureName,
+    workdir: opts.workdir,
+    projectDir: opts.projectDir,
+    resolvedPermissions,
+    turn: result.internalRoundTrips ?? 0,
+    protocolIds: result.protocolIds ?? {},
+    origin: "runAsSession",
+    tokenUsage: result.tokenUsage,
+    exactCostUsd: result.exactCostUsd,
+    durationMs: Date.now() - startedAt,
+    timestamp: Date.now(),
+  };
+  this._dispatchEvents.emitDispatch(event);
+
+  return result;
+}
 ```
 
-Apply the same pattern in `onError` path with a separate `DispatchErrorEvent` if needed (or surface via existing logging — defer to taste; audit currently records errors via `recordError`, can be done via a separate event type if cleaner, otherwise keep in middleware error path).
+**Error path:** `runAsSession` should emit an error variant for failed dispatches so audit can record `recordError`. Add a third event variant:
+
+```typescript
+// In dispatch-events.ts
+export interface DispatchErrorEvent {
+  readonly kind: "error";
+  readonly origin: "runAsSession" | "runTrackedSession" | "completeAs";
+  readonly agentName: string;
+  readonly stage: PipelineStage;
+  readonly storyId?: string;
+  readonly errorCode: string;
+  readonly errorMessage: string;
+  readonly prompt?: string;
+  readonly durationMs: number;
+  readonly timestamp: number;
+  readonly resolvedPermissions: ResolvedPermissions;
+}
+
+// Add to bus:
+emitDispatchError(event: DispatchErrorEvent): void;
+onDispatchError(listener: (e: DispatchErrorEvent) => void): () => void;
+```
+
+In `runAsSession`'s try/catch around the adapter call, emit `DispatchErrorEvent` on throw, then re-throw. Audit subscriber listens to both `DispatchEvent` and `DispatchErrorEvent`.
 
 ### Step 5 — Emit from `runTrackedSession`
 
-**File: `src/session/manager-run.ts`** around line 36–82.
+**File: `src/session/manager-run.ts`** lines 36–110.
 
-The descriptor is already loaded at line 42. After `runner.run(injectedRequest)` returns successfully:
+Capture `startedAt` at entry; emit after `runner.run(injectedRequest)` returns successfully (around current line 82). Note: `runTrackedSession` returns `AgentResult`, not `TurnResult`, so the type assertion for `internalRoundTrips` documented in Step 2 applies.
 
 ```typescript
-const sessionName = state.nameFor({
-  workdir: descriptor.workdir,
-  featureName: descriptor.featureName,
-  storyId: descriptor.storyId,
-  role: descriptor.role,
-});
+export async function runTrackedSession(
+  state: SessionManagerState,
+  id: string,
+  runner: SessionRunClient,
+  request: SessionManagedRunRequest,
+): Promise<AgentResult> {
+  const startedAt = Date.now();
+  const pre = state.sessions.get(id);
+  if (!pre) { /* existing throw */ }
 
-const event: SessionTurnDispatchEvent = {
-  kind: "session-turn",
-  sessionName,
-  sessionRole: descriptor.role,
-  prompt: request.runOptions.prompt,
-  agentName: request.runOptions.agentName ?? "claude",
-  stage: request.runOptions.pipelineStage,
-  storyId: descriptor.storyId,
-  featureName: descriptor.featureName,
-  turn: result.internalRoundTrips ?? 0,
-  protocolIds: result.protocolIds ?? {},
-  origin: "runTrackedSession",
-  usage: result.usage,
-  exactCostUsd: result.exactCostUsd,
-  durationMs: Date.now() - startedAt,
-  timestamp: Date.now(),
-};
-state.dispatchEvents.emitDispatch(event);
+  const descriptor = pre;  // alias for clarity
+  // ... (existing transition + injectedRequest construction)
+
+  const result = await runner.run(injectedRequest);
+
+  // Build dispatch event from descriptor (which owns role + sessionName).
+  // resolvedPermissions: forwarded from runOptions if pre-resolved by caller;
+  // else re-resolve here (cheap; pure function).
+  const sessionName = state.nameFor({
+    workdir: descriptor.workdir,
+    featureName: descriptor.featureName,
+    storyId: descriptor.storyId,
+    role: descriptor.role,
+  });
+
+  const event: SessionTurnDispatchEvent = {
+    kind: "session-turn",
+    sessionName,
+    sessionRole: descriptor.role,                          // post-D6: required SessionRole
+    prompt: request.runOptions.prompt,
+    response: result.output,
+    agentName: request.runOptions.agentName ?? state.defaultAgent,
+    stage: request.runOptions.pipelineStage,
+    storyId: descriptor.storyId,
+    featureName: descriptor.featureName,
+    workdir: descriptor.workdir,
+    projectDir: request.runOptions.projectDir,
+    resolvedPermissions: request.runOptions.resolvedPermissions
+      ?? resolvePermissions(request.runOptions.config, request.runOptions.pipelineStage),
+    turn: (result as { internalRoundTrips?: number }).internalRoundTrips ?? 0,
+    protocolIds: result.protocolIds ?? {},
+    origin: "runTrackedSession",
+    tokenUsage: result.tokenUsage,
+    exactCostUsd: result.exactCostUsd,
+    durationMs: Date.now() - startedAt,
+    timestamp: Date.now(),
+  };
+  state.dispatchEvents.emitDispatch(event);
+
+  return result;
+}
 ```
 
-Threading: `SessionManagerState` (`src/session/manager-run.ts` top) gains `dispatchEvents: IDispatchEventBus`. `SessionManager` constructor receives it from `NaxRuntime`.
+**Threading changes** (apply to `src/session/manager-run.ts` types and `src/session/manager.ts`):
 
-**Critical:** delete the tactical `sessionHint` field-write here. Wave 1's emission replaces it.
+- `SessionManagerState` interface (top of `manager-run.ts`) gains:
+  - `dispatchEvents: IDispatchEventBus`
+  - `defaultAgent: string` (so the `agentName` fallback isn't a hardcoded literal)
+- `SessionManager` constructor accepts `{ dispatchEvents, defaultAgent }` and threads both into the state bag passed to `runTrackedSession`.
+- `NaxRuntime.createRuntime` passes both at construction (defaultAgent comes from `resolveDefaultAgent(config)`).
+
+**Delete the tactical `sessionHint` field-write** at the top of `runTrackedSession` (added by the tactical patch at `manager-run.ts:55-72`). Event emission replaces it.
+
+**Error path:** if `runner.run()` throws, emit `DispatchErrorEvent` (kind:"error", origin:"runTrackedSession") in the catch block before re-throwing.
 
 ### Step 6 — Emit from `completeAs`
 
-**File: `src/agents/manager.ts`** around line 388 (`completeAs`).
+**File: `src/agents/manager.ts`** — find `completeAs(agentName, prompt, opts)` (grep for `completeAs` definition; line varies).
 
-Compute `sessionName` from `formatSessionName({ workdir, featureName, storyId, role: opts.sessionRole, pipelineStage })` (already done by current audit middleware — move the call here).
+Capture `startedAt`; emit after successful adapter return. Move `formatSessionName` call from `audit.ts:sessionNameFromCompleteOptions` here — `completeAs` is the new owner of the computation.
 
 ```typescript
-const event: CompleteDispatchEvent = {
-  kind: "complete",
-  sessionName: formatSessionName({ ... }),
-  sessionRole: opts.sessionRole ?? "main",
-  prompt,
-  agentName,
-  stage: opts.pipelineStage,
-  storyId: opts.storyId,
-  featureName: opts.featureName,
-  usage: result.usage,
-  exactCostUsd: result.exactCostUsd,
-  durationMs: Date.now() - startedAt,
-  timestamp: Date.now(),
-};
-this._runtime.dispatchEvents.emitDispatch(event);
+async completeAs(
+  agentName: string,
+  prompt: string,
+  opts: AgentCompleteOptions,
+): Promise<CompleteResult> {
+  const startedAt = Date.now();
+  const resolvedPermissions = resolvePermissions(opts.config, opts.pipelineStage);
+
+  // ... (existing adapter.complete dispatch — unchanged)
+  const result = await adapter.complete(prompt, opts);
+
+  const sessionName = formatSessionName({
+    workdir: opts.workdir,
+    featureName: opts.featureName,
+    storyId: opts.storyId,
+    role: opts.sessionRole,
+    pipelineStage: opts.pipelineStage,
+  });
+
+  const event: CompleteDispatchEvent = {
+    kind: "complete",
+    sessionName,
+    sessionRole: opts.sessionRole ?? "main",        // post-D6: required SessionRole
+    prompt,
+    response: result.output,
+    agentName,
+    stage: opts.pipelineStage,
+    storyId: opts.storyId,
+    featureName: opts.featureName,
+    workdir: opts.workdir,
+    projectDir: opts.projectDir,
+    resolvedPermissions,
+    tokenUsage: result.tokenUsage,
+    exactCostUsd: result.exactCostUsd,
+    durationMs: Date.now() - startedAt,
+    timestamp: Date.now(),
+  };
+  this._dispatchEvents.emitDispatch(event);
+
+  return result;
+}
 ```
+
+**Error path:** same pattern — emit `DispatchErrorEvent` (kind:"error", origin:"completeAs") in catch before re-throwing.
 
 ### Step 7 — Strip middleware emission from envelopes; emit `OperationCompletedEvent`
 
@@ -308,27 +434,51 @@ this._runtime.dispatchEvents.emitDispatch(event);
 
 In `runAs()` (line 395–440): remove `_middleware.runBefore` + `_middleware.runAfter` calls. They were the duplicate-emission source. Permission resolution (pre-chain) stays — still required.
 
-In `runWithFallback()` (line 181–306): track agentChain, hopCount, fallbackTriggered, totalElapsedMs, totalCostUsd (sum of dispatch events emitted for this call's children — see below). At end (success or exhaustion), emit:
+In `runWithFallback()` (line 181–306): track per-hop telemetry directly from the loop, no event subscription needed.
 
 ```typescript
-this._runtime.dispatchEvents.emitOperationCompleted({
-  kind: "operation-completed",
-  operation: "run-with-fallback",
-  agentChain,
-  hopCount,
-  fallbackTriggered: hopCount > 1,
-  totalElapsedMs: Date.now() - startedAt,
-  totalCostUsd: hopCosts.reduce((a, b) => a + b, 0),
-  finalStatus: result ? "ok" : (signal.aborted ? "cancelled" : "exhausted"),
-  storyId: request.runOptions?.storyId,
-  stage: request.runOptions?.pipelineStage ?? "run",
-  timestamp: Date.now(),
-});
+async runWithFallback(
+  request: AgentRunRequest,
+  primaryAgentOverride?: string,
+): Promise<AgentRunOutcome> {
+  const startedAt = Date.now();
+  const agentChain: string[] = [];
+  const hopCosts: number[] = [];
+  let finalStatus: OperationCompletedEvent["finalStatus"] = "ok";
+  let outcome: AgentRunOutcome | undefined;
+
+  try {
+    // ... existing fallback loop ...
+    // Inside the loop, after each executeHop / runAsSession completes:
+    agentChain.push(currentAgent);
+    if (hopResult.exactCostUsd !== undefined) hopCosts.push(hopResult.exactCostUsd);
+    // ... existing swap logic ...
+
+    if (request.signal?.aborted) finalStatus = "cancelled";
+    else if (!outcome) finalStatus = "exhausted";
+  } catch (err) {
+    finalStatus = "error";
+    throw err;
+  } finally {
+    this._dispatchEvents.emitOperationCompleted({
+      kind: "operation-completed",
+      operation: "run-with-fallback",
+      agentChain,
+      hopCount: agentChain.length,
+      fallbackTriggered: agentChain.length > 1,
+      totalElapsedMs: Date.now() - startedAt,
+      totalCostUsd: hopCosts.reduce((a, b) => a + b, 0),
+      finalStatus,
+      storyId: request.runOptions?.storyId,
+      stage: request.runOptions?.pipelineStage ?? "run",
+      timestamp: Date.now(),
+    });
+  }
+  return outcome;
+}
 ```
 
-`hopCosts` is collected by subscribing to dispatch events for the call's lifetime. Implementation detail: a per-call `correlationId` on `runOptions` lets the envelope filter dispatch events by call. Or simpler: capture `result.exactCostUsd` from each hop directly.
-
-Same treatment for `completeWithFallback`.
+Same treatment for `completeWithFallback` (single hop in the no-fallback case → `agentChain = [agent]`, `hopCount = 1`, `fallbackTriggered = false`).
 
 ### Step 8 — Rewrite audit middleware as subscriber
 
@@ -370,25 +520,31 @@ export function attachAuditSubscriber(
 }
 ```
 
-**Important:** `DispatchEvent` does not currently carry `response`, `workdir`, `projectDir`, `resolvedPermissions`. Add them to `DispatchEventBase` in Step 2 (resolved at the boundary that has them: `workdir`/`projectDir` from `opts`, `resolvedPermissions` from the pre-chain resolution, `response` from `result.output`). This was the gap that drove the original ad-hoc context sniffing — make it explicit fields on the event now.
+All event fields above are already declared on `DispatchEventBase` in Step 2 (response, workdir, projectDir, resolvedPermissions included from the start) and populated by each emitter in Steps 4–6.
 
-Update `DispatchEventBase` in `src/runtime/dispatch-events.ts`:
+Wire `attachAuditSubscriber` into runtime construction (`src/runtime/index.ts` `createRuntime`) after the bus is instantiated; replace the existing `auditMiddleware(...)` registration. Store the unsubscribe handle for `runtime.close()` cleanup.
+
+Add `attachAuditSubscriber` for `DispatchErrorEvent` too:
 
 ```typescript
-export interface DispatchEventBase {
-  // ... existing fields ...
-  readonly response: string;             // result.output
-  readonly workdir?: string;
-  readonly projectDir?: string;
-  readonly resolvedPermissions: ResolvedPermissions;
-}
+bus.onDispatchError((event) => {
+  auditor.recordError({
+    ts: event.timestamp,
+    runId,
+    agentName: event.agentName,
+    stage: event.stage,
+    storyId: event.storyId,
+    errorCode: event.errorCode,
+    errorMessage: event.errorMessage,
+    durationMs: event.durationMs,
+    callType: event.origin === "completeAs" ? "complete" : "run",
+    permissionProfile: event.resolvedPermissions.mode,
+    prompt: event.prompt,
+  });
+});
 ```
 
-Each emitter (Steps 4, 5, 6) populates these from data already in scope.
-
-Wire `attachAuditSubscriber` into runtime construction (`src/runtime/index.ts` `createRuntime`); replace the existing `auditMiddleware(...)` registration.
-
-**Delete:** `src/runtime/middleware/audit.ts:30` `executeHop` guard, `sessionNameFromCompleteOptions` helper (no scrape). Old `auditMiddleware(auditor, runId): AgentMiddleware` factory deleted.
+**Delete:** `src/runtime/middleware/audit.ts` lines 30 (`executeHop` guard), 12–24 (`sessionNameFromCompleteOptions` helper), and the entire `auditMiddleware(auditor, runId): AgentMiddleware` factory function. Replace the file's exports with `attachAuditSubscriber`.
 
 ### Step 9 — Rewrite cost middleware as subscriber
 
@@ -440,24 +596,44 @@ Add `recordOperationSummary(...)` to `ICostAggregator` if not already present (s
 
 ### Step 11 — Delete tactical `sessionHint`
 
+The tactical patch (Step 5 of the findings doc) introduced `AgentRunOptions.sessionHint` and a populator in `runTrackedSession`. Both are made redundant by Wave 1's `DispatchEvent` emission. Removal is mechanical:
+
 | File | Change |
 |:---|:---|
-| `src/agents/types.ts` | Remove `AgentRunOptions.sessionHint` field |
-| `src/session/manager-run.ts` | Remove the tactical's `injectedRequest.runOptions.sessionHint` write (replaced by `emitDispatch` in Step 5) |
-| `src/runtime/middleware/audit.ts` | The third-fallback line (already deleted in the rewrite) |
-| `src/runtime/middleware/cost.ts` | Same |
+| `src/agents/types.ts` | Delete `AgentRunOptions.sessionHint` field declaration (the typed `{ sessionName: string; role: string }` field added by the tactical) |
+| `src/session/manager-run.ts` | Delete the `sessionHint: { sessionName, role }` write inside `injectedRequest.runOptions` (Step 5 of tactical). Step 5 of this wave replaces it with `emitDispatch`. |
+| `src/runtime/middleware/audit.ts` | The `?? ctx.request?.runOptions?.sessionHint?.sessionName ??` line — already removed by Step 8's full rewrite. Listed here for completeness. |
+| `src/runtime/middleware/cost.ts` | Same. Already removed by Step 9's full rewrite. |
 
-Grep `sessionHint` returns zero hits.
+**Validation:** `rg sessionHint src/` returns zero hits. `rg sessionHint test/` returns zero hits except in tests that explicitly assert the field has been removed (the no-regression test from Step 11 below).
 
 ### Step 12 — `MiddlewareContext` and chain cleanup
 
 **File: `src/runtime/agent-middleware.ts`**.
 
-`AgentMiddleware` interface stays for any non-event-driven concerns (cancellation translation, e.g.) but `MiddlewareContext` no longer needs to carry dispatch metadata. Audit/cost are no longer middleware — they're subscribers.
+Audit/cost/logging are no longer middleware — they're event subscribers. **Inventory remaining middleware:**
 
-Remove from `MiddlewareContext`: any field added in earlier rounds purely for audit/cost scraping (e.g. `completeOptions`, `sessionHandle` if no remaining middleware reads them). Cancellation middleware likely still needs `signal`; keep that.
+```bash
+rg "implements AgentMiddleware\|: AgentMiddleware\|AgentMiddleware = {" src/
+```
 
-If after audit and cost are removed, no middleware remains, the chain itself can be deleted. Verify by greping for remaining `AgentMiddleware` implementations.
+Expected after Wave 1: only `cancellation.ts` remains (it translates aborted signals into typed errors and is stage-agnostic — does not read dispatch metadata).
+
+**Decision:** keep the `AgentMiddleware` interface and `MiddlewareChain` plumbing for cancellation. Do **not** delete the chain entirely — that would force cancellation into a fourth event type unnecessarily.
+
+**Trim `MiddlewareContext`:** remove fields that exist only for audit/cost scraping. Specifically delete:
+- `completeOptions` (was only read by `sessionNameFromCompleteOptions`)
+- `sessionHandle` (was only read by audit's session-name resolution)
+- `prompt` (was only read for audit recording)
+- Any `executeHop`-related fields on the request
+
+Keep:
+- `signal` (cancellation reads it)
+- `agentName`, `stage`, `storyId` (cancellation logs them on translated errors)
+- `kind` (`"run"` | `"complete"` — cancellation needs to surface the right error code)
+- `resolvedPermissions` (cancellation translates permission-denied separately)
+
+**Output:** `MiddlewareContext` shrinks from ~12 fields to ~6. Cancellation middleware keeps working unchanged. Audit/cost no longer touch the chain.
 
 ## Tests
 

--- a/docs/specs/adr-020-wave-1-dispatch-events.md
+++ b/docs/specs/adr-020-wave-1-dispatch-events.md
@@ -1,0 +1,549 @@
+# ADR-020 Wave 1 — Typed Dispatch Events at Three Boundaries + `SessionRole` SSOT
+
+> **Spec status:** Ready for implementation
+> **Owning ADR:** [docs/adr/ADR-020-dispatch-boundary-ssot.md](../adr/ADR-020-dispatch-boundary-ssot.md) §D1, §D2, §D5, §D6
+> **Closes:** [#773](https://github.com/nathapp-io/nax/issues/773); deletes the tactical patch from [docs/findings/2026-04-28-tdd-audit-naming-tactical.md](../findings/2026-04-28-tdd-audit-naming-tactical.md)
+> **Estimated:** ~300 LOC source, ~250 LOC tests, single PR
+
+---
+
+## Goal
+
+After this wave lands:
+
+1. Every agent dispatch emits exactly one typed `DispatchEvent` from one of three concrete boundaries (`runAsSession`, `runTrackedSession`, `completeAs`). Envelope methods (`runAs`, `runWithFallback`) emit `OperationCompletedEvent` instead.
+2. Audit and cost middleware are pure event subscribers — no `executeHop`/`sessionHandle`/`completeOptions` scraping anywhere.
+3. `SessionRole` is a typed union; descriptor/handle/options/event consumers use the typed type. Drift like the acceptance `"acceptance"` vs `"acceptance-gen"` mismatch is a compile error.
+4. Tactical `AgentRunOptions.sessionHint` field is deleted; the tactical patch's test (`test/integration/tdd/audit-naming.test.ts`) survives unchanged.
+
+## Prerequisites
+
+- Tactical patch from [docs/findings/2026-04-28-tdd-audit-naming-tactical.md](../findings/2026-04-28-tdd-audit-naming-tactical.md) merged (provides the `audit-naming.test.ts` regression test that locks in correctness across this wave).
+- ADR-020 itself merged (this is the doc this wave implements).
+
+## Architecture
+
+```
+                         ┌───────────────────────────────┐
+                         │   DispatchEventBus (new)      │
+                         │   live in NaxRuntime          │
+                         └──────────────┬────────────────┘
+                                        │ emit
+       ┌────────────────────────────────┼────────────────────────────────┐
+       │                                │                                │
+┌──────▼──────────┐         ┌───────────▼──────────────┐      ┌──────────▼──────────┐
+│ runAsSession    │         │ runTrackedSession        │      │ completeAs          │
+│ (manager.ts)    │         │ (session/manager-run.ts) │      │ (manager.ts)        │
+│ emits           │         │ emits                    │      │ emits               │
+│ session-turn    │         │ session-turn             │      │ complete            │
+└─────────────────┘         └──────────────────────────┘      └─────────────────────┘
+                                        │
+                                        │ subscribe
+                  ┌─────────────────────┼─────────────────────┐
+                  │                     │                     │
+            ┌─────▼──────┐       ┌──────▼──────┐       ┌──────▼──────┐
+            │ audit      │       │ cost        │       │ logging     │
+            │ subscriber │       │ subscriber  │       │ subscriber  │
+            └────────────┘       └─────────────┘       └─────────────┘
+
+┌──────────────────────────────────────────────────────────────────────────┐
+│ runWithFallback (envelope) emits ONE OperationCompletedEvent at end:    │
+│   { operation, agentChain, hopCount, fallbackTriggered, finalStatus }   │
+│ Logging/metrics subscribe; audit/cost ignore.                           │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+Single-emission invariant: a logical TDD per-role dispatch goes through `runTrackedSession` (which emits) and then `manager.run` → `runAs` envelope (which does **not** emit). Single-session callOp goes through `runAs` → `executeHop` → `runAsSession` (which emits). One-shot calls go through `completeAs` (which emits). No path emits twice.
+
+## Step-by-step implementation
+
+### Step 1 — `SessionRole` SSOT
+
+**New file: `src/runtime/session-role.ts`** (~25 LOC)
+
+```typescript
+/**
+ * Canonical session role registry — SSOT for adapter-wiring.md Rule 2.
+ * Promoting ADR-018 §9's template-literal union here so every consumer
+ * (descriptor, handle, runOptions, completeOptions, DispatchEvent) shares
+ * the same type. Free-form sessionRole strings are banned outside this
+ * file; misspellings/legacy values become compile errors at the call site.
+ */
+
+export type CanonicalSessionRole =
+  | "main"
+  | "test-writer" | "implementer" | "verifier"
+  | "diagnose" | "source-fix" | "test-fix"
+  | "reviewer-semantic" | "reviewer-adversarial"
+  | "plan" | "decompose"
+  | "acceptance-gen" | "refine" | "fix-gen"
+  | "auto" | "synthesis" | "judge";
+
+export type SessionRole = CanonicalSessionRole | `debate-${string}`;
+
+export const KNOWN_SESSION_ROLES: readonly CanonicalSessionRole[] = [
+  "main",
+  "test-writer", "implementer", "verifier",
+  "diagnose", "source-fix", "test-fix",
+  "reviewer-semantic", "reviewer-adversarial",
+  "plan", "decompose",
+  "acceptance-gen", "refine", "fix-gen",
+  "auto", "synthesis", "judge",
+] as const;
+
+export function isSessionRole(s: string): s is SessionRole {
+  if ((KNOWN_SESSION_ROLES as readonly string[]).includes(s)) return true;
+  return s.startsWith("debate-") && s.length > 7;
+}
+```
+
+Export from `src/runtime/index.ts` barrel.
+
+### Step 2 — Typed event types
+
+**New file: `src/runtime/dispatch-events.ts`** (~120 LOC)
+
+```typescript
+import type { PipelineStage } from "../pipeline/types";
+import type { TokenUsage } from "../agents/types";
+import type { SessionRole } from "./session-role";
+
+/**
+ * Fields every dispatch event carries, regardless of kind. New cross-cutting
+ * fields (e.g. traceId, resolvedPermissions, packageId) go here once; both
+ * variants and every subscriber pick them up via the compiler.
+ */
+export interface DispatchEventBase {
+  readonly sessionName: string;
+  readonly sessionRole: SessionRole;
+  readonly prompt: string;
+  readonly agentName: string;
+  readonly stage: PipelineStage;
+  readonly storyId?: string;
+  readonly featureName?: string;
+  readonly usage?: TokenUsage;
+  readonly exactCostUsd?: number;
+  readonly durationMs: number;
+  readonly timestamp: number;
+}
+
+export interface SessionTurnDispatchEvent extends DispatchEventBase {
+  readonly kind: "session-turn";
+  readonly turn: number;
+  readonly protocolIds: { sessionId?: string; turnId?: string };
+  readonly origin: "runAsSession" | "runTrackedSession";
+}
+
+export interface CompleteDispatchEvent extends DispatchEventBase {
+  readonly kind: "complete";
+}
+
+export type DispatchEvent = SessionTurnDispatchEvent | CompleteDispatchEvent;
+
+export interface OperationCompletedEvent {
+  readonly kind: "operation-completed";
+  readonly operation: "run-with-fallback" | "complete-with-fallback";
+  readonly agentChain: readonly string[];
+  readonly hopCount: number;
+  readonly fallbackTriggered: boolean;
+  readonly totalElapsedMs: number;
+  readonly totalCostUsd: number;        // sum of per-hop DispatchEvent.exactCostUsd
+  readonly finalStatus: "ok" | "exhausted" | "cancelled" | "error";
+  readonly storyId?: string;
+  readonly stage: PipelineStage;
+  readonly timestamp: number;
+}
+
+export type DispatchListener = (event: DispatchEvent) => void;
+export type OperationCompletedListener = (event: OperationCompletedEvent) => void;
+
+export interface IDispatchEventBus {
+  onDispatch(listener: DispatchListener): () => void;
+  onOperationCompleted(listener: OperationCompletedListener): () => void;
+  emitDispatch(event: DispatchEvent): void;
+  emitOperationCompleted(event: OperationCompletedEvent): void;
+}
+
+export class DispatchEventBus implements IDispatchEventBus {
+  private readonly _dispatchListeners = new Set<DispatchListener>();
+  private readonly _completedListeners = new Set<OperationCompletedListener>();
+
+  onDispatch(l: DispatchListener) {
+    this._dispatchListeners.add(l);
+    return () => this._dispatchListeners.delete(l);
+  }
+  onOperationCompleted(l: OperationCompletedListener) {
+    this._completedListeners.add(l);
+    return () => this._completedListeners.delete(l);
+  }
+  emitDispatch(event: DispatchEvent) {
+    for (const l of this._dispatchListeners) {
+      try { l(event); }
+      catch (err) {
+        // Subscribers must not break the chain. Log and continue.
+        getLogger().warn("dispatch-bus", "listener threw", { error: errorMessage(err) });
+      }
+    }
+  }
+  emitOperationCompleted(event: OperationCompletedEvent) {
+    for (const l of this._completedListeners) {
+      try { l(event); }
+      catch (err) {
+        getLogger().warn("dispatch-bus", "completion-listener threw", { error: errorMessage(err) });
+      }
+    }
+  }
+}
+```
+
+Wire into `NaxRuntime` (`src/runtime/index.ts`): add `readonly dispatchEvents: IDispatchEventBus` field, instantiate in `createRuntime`, expose via `runtime.dispatchEvents`.
+
+### Step 3 — Tighten role-bearing types
+
+| File | Change |
+|:---|:---|
+| `src/agents/types.ts` | `AgentRunOptions.sessionRole?: string` → `sessionRole?: SessionRole`. Same for `AgentCompleteOptions.sessionRole`. |
+| `src/agents/types.ts` | `SessionHandle.role?: string` → `role: SessionRole` (required). All adapter `openSession` implementations already set it. |
+| `src/session/types.ts` | `SessionDescriptor.role: string` → `role: SessionRole`. |
+| `src/runtime/session-name.ts` | `SessionNameRequest.role?: string` → `role?: SessionRole`. |
+
+Run typecheck after this step. Compile errors at every drift site (acceptance generator at `src/acceptance/generator.ts:181,472`, plus any other free-form `sessionRole: "..."` literals). Fix each in place — most are simple typos or legacy values that should match the registry.
+
+**Concrete fix expected at acceptance-gen:** generator already passes `"acceptance-gen"` correctly, so the typecheck passes there. The drift is downstream — likely `formatSessionName` or `nameFor` is being called with a truncated role at some other site. Trace each compile error to the source.
+
+### Step 4 — Emit from `runAsSession`
+
+**File: `src/agents/manager.ts`** around line 442 (`runAsSession`).
+
+After successful adapter return, before the existing middleware `runAfter` call (which gets removed in Step 7):
+
+```typescript
+const event: SessionTurnDispatchEvent = {
+  kind: "session-turn",
+  sessionName: handle.id,
+  sessionRole: handle.role,
+  prompt,
+  agentName,
+  stage: opts.pipelineStage,
+  storyId: opts.storyId,
+  featureName: opts.featureName,
+  turn: result.internalRoundTrips ?? 0,
+  protocolIds: result.protocolIds ?? {},
+  origin: "runAsSession",
+  usage: result.usage,
+  exactCostUsd: result.exactCostUsd,
+  durationMs: Date.now() - startedAt,
+  timestamp: Date.now(),
+};
+this._runtime.dispatchEvents.emitDispatch(event);
+```
+
+Apply the same pattern in `onError` path with a separate `DispatchErrorEvent` if needed (or surface via existing logging — defer to taste; audit currently records errors via `recordError`, can be done via a separate event type if cleaner, otherwise keep in middleware error path).
+
+### Step 5 — Emit from `runTrackedSession`
+
+**File: `src/session/manager-run.ts`** around line 36–82.
+
+The descriptor is already loaded at line 42. After `runner.run(injectedRequest)` returns successfully:
+
+```typescript
+const sessionName = state.nameFor({
+  workdir: descriptor.workdir,
+  featureName: descriptor.featureName,
+  storyId: descriptor.storyId,
+  role: descriptor.role,
+});
+
+const event: SessionTurnDispatchEvent = {
+  kind: "session-turn",
+  sessionName,
+  sessionRole: descriptor.role,
+  prompt: request.runOptions.prompt,
+  agentName: request.runOptions.agentName ?? "claude",
+  stage: request.runOptions.pipelineStage,
+  storyId: descriptor.storyId,
+  featureName: descriptor.featureName,
+  turn: result.internalRoundTrips ?? 0,
+  protocolIds: result.protocolIds ?? {},
+  origin: "runTrackedSession",
+  usage: result.usage,
+  exactCostUsd: result.exactCostUsd,
+  durationMs: Date.now() - startedAt,
+  timestamp: Date.now(),
+};
+state.dispatchEvents.emitDispatch(event);
+```
+
+Threading: `SessionManagerState` (`src/session/manager-run.ts` top) gains `dispatchEvents: IDispatchEventBus`. `SessionManager` constructor receives it from `NaxRuntime`.
+
+**Critical:** delete the tactical `sessionHint` field-write here. Wave 1's emission replaces it.
+
+### Step 6 — Emit from `completeAs`
+
+**File: `src/agents/manager.ts`** around line 388 (`completeAs`).
+
+Compute `sessionName` from `formatSessionName({ workdir, featureName, storyId, role: opts.sessionRole, pipelineStage })` (already done by current audit middleware — move the call here).
+
+```typescript
+const event: CompleteDispatchEvent = {
+  kind: "complete",
+  sessionName: formatSessionName({ ... }),
+  sessionRole: opts.sessionRole ?? "main",
+  prompt,
+  agentName,
+  stage: opts.pipelineStage,
+  storyId: opts.storyId,
+  featureName: opts.featureName,
+  usage: result.usage,
+  exactCostUsd: result.exactCostUsd,
+  durationMs: Date.now() - startedAt,
+  timestamp: Date.now(),
+};
+this._runtime.dispatchEvents.emitDispatch(event);
+```
+
+### Step 7 — Strip middleware emission from envelopes; emit `OperationCompletedEvent`
+
+**File: `src/agents/manager.ts`**.
+
+In `runAs()` (line 395–440): remove `_middleware.runBefore` + `_middleware.runAfter` calls. They were the duplicate-emission source. Permission resolution (pre-chain) stays — still required.
+
+In `runWithFallback()` (line 181–306): track agentChain, hopCount, fallbackTriggered, totalElapsedMs, totalCostUsd (sum of dispatch events emitted for this call's children — see below). At end (success or exhaustion), emit:
+
+```typescript
+this._runtime.dispatchEvents.emitOperationCompleted({
+  kind: "operation-completed",
+  operation: "run-with-fallback",
+  agentChain,
+  hopCount,
+  fallbackTriggered: hopCount > 1,
+  totalElapsedMs: Date.now() - startedAt,
+  totalCostUsd: hopCosts.reduce((a, b) => a + b, 0),
+  finalStatus: result ? "ok" : (signal.aborted ? "cancelled" : "exhausted"),
+  storyId: request.runOptions?.storyId,
+  stage: request.runOptions?.pipelineStage ?? "run",
+  timestamp: Date.now(),
+});
+```
+
+`hopCosts` is collected by subscribing to dispatch events for the call's lifetime. Implementation detail: a per-call `correlationId` on `runOptions` lets the envelope filter dispatch events by call. Or simpler: capture `result.exactCostUsd` from each hop directly.
+
+Same treatment for `completeWithFallback`.
+
+### Step 8 — Rewrite audit middleware as subscriber
+
+**File: `src/runtime/middleware/audit.ts`** — full rewrite.
+
+```typescript
+import type { IPromptAuditor, PromptAuditEntry } from "../prompt-auditor";
+import type { IDispatchEventBus, DispatchEvent } from "../dispatch-events";
+
+export function attachAuditSubscriber(
+  bus: IDispatchEventBus,
+  auditor: IPromptAuditor,
+  runId: string,
+): () => void {
+  return bus.onDispatch((event: DispatchEvent) => {
+    const entry: PromptAuditEntry = {
+      ts: event.timestamp,
+      runId,
+      agentName: event.agentName,
+      stage: event.stage,
+      storyId: event.storyId,
+      permissionProfile: event.resolvedPermissions?.mode ?? "unknown",
+      prompt: event.prompt,
+      response: event.response ?? "",
+      durationMs: event.durationMs,
+      callType: event.kind === "session-turn" ? "run" : "complete",
+      workdir: event.workdir,
+      projectDir: event.projectDir,
+      featureName: event.featureName,
+      sessionName: event.sessionName,
+      ...(event.kind === "session-turn" && {
+        recordId: event.protocolIds.recordId,
+        sessionId: event.protocolIds.sessionId,
+        turn: event.turn,
+      }),
+    };
+    auditor.record(entry);
+  });
+}
+```
+
+**Important:** `DispatchEvent` does not currently carry `response`, `workdir`, `projectDir`, `resolvedPermissions`. Add them to `DispatchEventBase` in Step 2 (resolved at the boundary that has them: `workdir`/`projectDir` from `opts`, `resolvedPermissions` from the pre-chain resolution, `response` from `result.output`). This was the gap that drove the original ad-hoc context sniffing — make it explicit fields on the event now.
+
+Update `DispatchEventBase` in `src/runtime/dispatch-events.ts`:
+
+```typescript
+export interface DispatchEventBase {
+  // ... existing fields ...
+  readonly response: string;             // result.output
+  readonly workdir?: string;
+  readonly projectDir?: string;
+  readonly resolvedPermissions: ResolvedPermissions;
+}
+```
+
+Each emitter (Steps 4, 5, 6) populates these from data already in scope.
+
+Wire `attachAuditSubscriber` into runtime construction (`src/runtime/index.ts` `createRuntime`); replace the existing `auditMiddleware(...)` registration.
+
+**Delete:** `src/runtime/middleware/audit.ts:30` `executeHop` guard, `sessionNameFromCompleteOptions` helper (no scrape). Old `auditMiddleware(auditor, runId): AgentMiddleware` factory deleted.
+
+### Step 9 — Rewrite cost middleware as subscriber
+
+**File: `src/runtime/middleware/cost.ts`** — same pattern as audit.
+
+```typescript
+export function attachCostSubscriber(
+  bus: IDispatchEventBus,
+  aggregator: ICostAggregator,
+  runId: string,
+): () => void {
+  const offDispatch = bus.onDispatch((event) => {
+    aggregator.record({
+      ts: event.timestamp,
+      runId,
+      agentName: event.agentName,
+      stage: event.stage,
+      storyId: event.storyId,
+      callType: event.kind === "session-turn" ? "run" : "complete",
+      sessionName: event.sessionName,
+      sessionRole: event.sessionRole,
+      usage: event.usage,
+      exactCostUsd: event.exactCostUsd,
+      durationMs: event.durationMs,
+    });
+  });
+  const offCompleted = bus.onOperationCompleted((event) => {
+    aggregator.recordOperationSummary({
+      runId,
+      operation: event.operation,
+      hopCount: event.hopCount,
+      fallbackTriggered: event.fallbackTriggered,
+      totalCostUsd: event.totalCostUsd,
+      totalElapsedMs: event.totalElapsedMs,
+      finalStatus: event.finalStatus,
+    });
+  });
+  return () => { offDispatch(); offCompleted(); };
+}
+```
+
+Add `recordOperationSummary(...)` to `ICostAggregator` if not already present (separate from per-dispatch `record` so subscribers can distinguish).
+
+**Delete:** `src/runtime/middleware/cost.ts:34` guard.
+
+### Step 10 — Logging middleware as subscriber (optional but recommended)
+
+**File: `src/runtime/middleware/logging.ts`** — same pattern, subscribes to both event types for structured JSONL logging.
+
+### Step 11 — Delete tactical `sessionHint`
+
+| File | Change |
+|:---|:---|
+| `src/agents/types.ts` | Remove `AgentRunOptions.sessionHint` field |
+| `src/session/manager-run.ts` | Remove the tactical's `injectedRequest.runOptions.sessionHint` write (replaced by `emitDispatch` in Step 5) |
+| `src/runtime/middleware/audit.ts` | The third-fallback line (already deleted in the rewrite) |
+| `src/runtime/middleware/cost.ts` | Same |
+
+Grep `sessionHint` returns zero hits.
+
+### Step 12 — `MiddlewareContext` and chain cleanup
+
+**File: `src/runtime/agent-middleware.ts`**.
+
+`AgentMiddleware` interface stays for any non-event-driven concerns (cancellation translation, e.g.) but `MiddlewareContext` no longer needs to carry dispatch metadata. Audit/cost are no longer middleware — they're subscribers.
+
+Remove from `MiddlewareContext`: any field added in earlier rounds purely for audit/cost scraping (e.g. `completeOptions`, `sessionHandle` if no remaining middleware reads them). Cancellation middleware likely still needs `signal`; keep that.
+
+If after audit and cost are removed, no middleware remains, the chain itself can be deleted. Verify by greping for remaining `AgentMiddleware` implementations.
+
+## Tests
+
+### `test/unit/runtime/dispatch-events.test.ts` (new, ~150 LOC)
+
+```typescript
+test("DispatchEventBus emits to all subscribers", ...);
+test("subscriber that throws does not break the chain", ...);
+test("unsubscribe stops further deliveries", ...);
+test("DispatchEventBase fields populated by all three boundaries", () => {
+  // Stub adapter; instantiate runtime; subscribe; invoke each boundary;
+  // assert event field-by-field for each.
+});
+```
+
+### `test/unit/agents/manager-dispatch-emission.test.ts` (new, ~100 LOC)
+
+Pure-function tests of each emission point:
+- `runAsSession` emits exactly one `session-turn` event with `origin: "runAsSession"`
+- `runTrackedSession` emits exactly one `session-turn` event with `origin: "runTrackedSession"`
+- `completeAs` emits exactly one `complete` event
+- `runWithFallback` over 2 hops emits two `session-turn` events (via `executeHop` → `runAsSession`) and one `OperationCompletedEvent` with `fallbackTriggered: true`
+- `runAs` envelope alone (no executeHop) emits zero `DispatchEvent` and one `OperationCompletedEvent`
+
+### `test/unit/runtime/middleware/audit.test.ts` (rewrite ~100 LOC)
+
+Delete all guard-based cases. New cases:
+- `attachAuditSubscriber` records one entry per emitted event
+- session-turn event → entry has `callType: "run"`, `turn`, `protocolIds`
+- complete event → entry has `callType: "complete"`
+- subscriber unsubscribe stops recording
+
+### `test/unit/runtime/middleware/cost.test.ts` (rewrite ~80 LOC)
+
+Same shape as audit tests, plus a case for `OperationCompletedEvent` summary recording.
+
+### `test/integration/tdd/audit-naming.test.ts` (existing — preserved unchanged)
+
+The tactical patch's test passes both before and after Wave 1. It asserts the **outcome** (per-role audit filenames exist after a TDD run). Implementation underneath swaps from `sessionHint` to `DispatchEvent`; test stays green.
+
+### `test/integration/acceptance/audit-naming.test.ts` (new, ~40 LOC)
+
+Asserts acceptance-gen audit file is named `*-acceptance-gen-complete.txt`, not `*-acceptance-complete.txt`. This locks in the D6 role-drift fix.
+
+### `test/unit/runtime/session-role.test.ts` (new, ~30 LOC)
+
+```typescript
+test("KNOWN_SESSION_ROLES matches adapter-wiring.md Rule 2", ...);
+test("isSessionRole accepts canonical roles", ...);
+test("isSessionRole accepts debate-* roles", ...);
+test("isSessionRole rejects unknown roles", ...);
+test("isSessionRole rejects empty debate- prefix", ...);
+```
+
+## Validation
+
+1. **Unit + integration suites pass:** `bun run test`
+2. **`tdd-calc` dogfood:** re-run `nax run` against `nax-dogfood/fixtures/tdd-calc/`. Verify:
+   - `prompt-audit/tdd-calc/<runId>.jsonl` has exactly N entries for N agent dispatches (no duplicates)
+   - Per-role files: `*-test-writer.txt`, `*-implementer.txt`, `*-verifier.txt`
+   - No `run-run-US-001.txt` files
+   - Acceptance file: `*-acceptance-gen-complete.txt` (not `*-acceptance-complete.txt`)
+3. **`hello-lint` dogfood:** re-run; verify no `run-run-US-001*` files appear (the original #771 symptom)
+4. **Cost report:** `nax cost --runId <id>` shows per-dispatch lines and an operation summary line; numbers match wire cost (no estimated/exact mismatch from #772)
+5. **Grep gates:**
+   - `rg 'executeHop' src/runtime/middleware/` returns zero hits
+   - `rg 'sessionHint' src/` returns zero hits (tactical patch fully removed)
+   - `rg 'sessionNameFromCompleteOptions' src/` returns zero hits
+
+## Rollback
+
+This wave is one PR. Reverting it restores the tactical patch's behaviour (TDD audit names work; #771/#772 guards still in place). No data migration; no on-disk format change beyond filename casing.
+
+## Risk + mitigation
+
+| Risk | Mitigation |
+|:---|:---|
+| Subscriber error swallowed and audit silently stops | `DispatchEventBus.emitDispatch` catches per-listener exceptions; logs via project logger; continues |
+| Plugin authors writing custom middleware see chain shrink | Only audit/cost/logging are removed; `AgentMiddleware` interface preserved for cancellation/other uses; deprecation note in `agent-middleware.ts` |
+| Per-call cost summing in `runWithFallback` introduces race with parallel hops | `runWithFallback` is sequential per call; no race. Document this as an invariant in the dispatch-events doc |
+| Session role typed union breaks in-flight test fixtures with hardcoded roles | Step 3's typecheck pass surfaces every fixture; fix mechanically — the registry is the canonical list |
+| `MiddlewareContext` shape change breaks third-party plugins | No third-party plugins exist today (in-repo only); change documented in CHANGELOG |
+
+## Out of scope
+
+- `wrapAdapterAsManager` removal → Wave 2
+- `Operation.verify`/`recover` → Wave 3
+- ADR-021 / orchestrator hierarchy — explicitly rejected per ADR-020 §A5
+- Transformer middleware — Phase 1 observer-only invariant from ADR-018 §3.1 stands

--- a/docs/specs/adr-020-wave-2-dispatch-context.md
+++ b/docs/specs/adr-020-wave-2-dispatch-context.md
@@ -58,24 +58,29 @@ Export from `src/runtime/index.ts` barrel.
 
 For each row below: add `extends DispatchContext` to the interface declaration; drop the `?` from any field name that overlaps (`agentManager?` → required via the base; `sessionManager?` → required; `abortSignal?` → required). Run `bun run typecheck` after each file to surface compile errors at call sites; fix in same PR.
 
-| File | Type | Existing optional fields to make required (via base) |
-|:---|:---|:---|
-| `src/pipeline/types.ts:60` | `PipelineContext` | `agentManager?`, `sessionManager?`, `abortSignal?` |
-| `src/operations/types.ts` | `OperationContext<C>` | likely `agentManager?` and `sessionManager?` (verify) |
-| `src/execution/lifecycle/acceptance-loop.ts:61` | `AcceptanceLoopOptions` | `agentManager?` |
-| `src/execution/lifecycle/run-completion.ts:57` | `RunCompletionOptions` | `agentManager?` |
-| `src/debate/runner-stateful.ts:35` | `DebateRunnerCtx` (stateful) | `agentManager?` |
-| `src/debate/runner-hybrid.ts:41` | `DebateRunnerCtx` (hybrid) | `agentManager?` |
-| `src/debate/runner-plan.ts:33` | `DebateRunnerCtx` (plan) | `agentManager?` |
-| `src/debate/session-helpers.ts:76` | `DebateSessionCtx` | `agentManager?` |
-| `src/review/semantic-debate.ts:30` | `SemanticDebateCtx` | already required — verify |
-| `src/review/runner.ts` | `ReviewCtx` | grep for declaration |
-| `src/routing/router.ts:29` | `RoutingCtx` | `agentManager?` |
-| `src/cli/plan-runtime.ts` | `PlanCtx` | grep for declaration |
-| `src/session/session-runner.ts:63` | `SessionRunnerContext` | `agentManager?` |
-| `src/acceptance/types.ts:55` | `AcceptanceContext` | `agentManager?` |
-| `src/acceptance/types.ts:117` | (second declaration — verify name) | `agentManager?` |
-| `src/acceptance/hardening.ts:41` | `HardeningCtx` | `agentManager?` |
+> **Note on `OperationContext`:** there is **no** type by that name in the codebase. `src/operations/types.ts` declares `BuildContext<C>` (lines 9-12; `packageView` + `config` only) and `CallContext` (lines 14-38; the larger ambient context). `CallContext` is the one to extend `DispatchContext` from — it already has `runtime: NaxRuntime` (line 15), which is the agentManager/sessionManager owner per ADR-018. The cleanest move: have `CallContext` extend `DispatchContext`, and have callers populate the four required fields explicitly (or derive `agentManager`/`sessionManager` from `runtime`).
+>
+> **Decision:** for `CallContext` specifically, do NOT extend `DispatchContext`. Instead, treat `runtime` (which contains both managers) as the SSOT — `CallContext` already requires `runtime: NaxRuntime`, so the agentManager/sessionManager are non-nullably reachable via `ctx.runtime.agentManager` / `ctx.runtime.sessionManager`. No optional `?` exists on this type today; no fix needed. **Skip `CallContext` from the table below.** Other context types that today declare their own optional `agentManager?` are the migration targets.
+
+| File | Type | Existing optional fields to make required (via base) | Verified? |
+|:---|:---|:---|:---|
+| `src/pipeline/types.ts:60` | `PipelineContext` | `agentManager?` (145), `sessionManager?` (139), `abortSignal?` (119) | ✓ confirmed via grep |
+| `src/execution/lifecycle/acceptance-loop.ts:61` | `AcceptanceLoopOptions` | `agentManager?` (61) | ✓ |
+| `src/execution/lifecycle/run-completion.ts:57` | `RunCompletionOptions` | `agentManager?` (57) | ✓ |
+| `src/debate/runner-stateful.ts:35` | (verify name via `grep "^export interface\|^interface" src/debate/runner-stateful.ts`) | `agentManager?` (35) | ✓ field present, type name unverified |
+| `src/debate/runner-hybrid.ts:41` | (verify name) | `agentManager?` (41) | ✓ field present |
+| `src/debate/runner-plan.ts:33` | (verify name) | `agentManager?` (33) | ✓ field present |
+| `src/debate/session-helpers.ts:76,201` | (function-param object — may not be a named interface) | `agentManager?` (76, 201) | ✓ field present, may need refactor to a named type |
+| `src/review/semantic-debate.ts:30` | (verify name) | already required (`agentManager: IAgentManager`) | ✓ — no change needed |
+| `src/routing/router.ts:29,145` | (verify name) | `agentManager?` (29, 145) | ✓ field present |
+| `src/session/session-runner.ts:63` | (verify name) | `agentManager?` (63) | ✓ field present |
+| `src/acceptance/types.ts:55,117` | (two declarations — verify names) | `agentManager?` (both) | ✓ fields present; confirm two distinct types |
+| `src/acceptance/hardening.ts:41` | (verify name) | `agentManager?` (41) | ✓ field present |
+| `src/runtime/index.ts:60` | `CreateRuntimeOptions` (constructor input) | `agentManager?` (60) | ⚠ deliberately optional — `createRuntime` constructs a default if absent. **Do NOT make this required;** it's the constructor's "bring-your-own" override slot, not a dispatch-time field. Skip from migration. |
+
+**Implementer action for each unverified type name:** before editing, run `grep -n "^export interface\|^export type\|^interface" <file>` to find the actual declaration name. Add `extends DispatchContext` to the declaration.
+
+**Function-parameter-object cases** (`session-helpers.ts:76,201` and similar): these aren't named interfaces — they're inline `{ agentManager?: IAgentManager, ... }` parameter shapes. Refactor to a named type that extends `DispatchContext`, then update the function signature. ~5 LOC per occurrence.
 
 After all extends added, run `bun run typecheck`. Each compile error is one of:
 
@@ -109,9 +114,9 @@ Update the existing call site in `SingleSessionRunner.run` to reference the priv
 
 **File: `src/agents/utils.ts`**.
 
-Delete the `wrapAdapterAsManager` and `NO_OP_INTERACTION_HANDLER` exports.
+Delete the `wrapAdapterAsManager` export. Inline its body (one occurrence) into `SingleSessionRunner` per Step 3.
 
-If other files in `src/agents/` use `NO_OP_INTERACTION_HANDLER` internally, move it to a private location (e.g. `src/agents/internal/no-op-handler.ts`).
+For `NO_OP_INTERACTION_HANDLER`: run `rg "NO_OP_INTERACTION_HANDLER" src/` to find consumers. If used **only** by `wrapAdapterAsManager`, delete with it. If consumed elsewhere (likely: ad-hoc adapter calls in tests or one-shot tools), move to a clearly-named private module — `src/agents/internal/no-op-interaction-handler.ts` — and update imports. Do **not** re-export from `src/agents` barrel; consumers import directly from `internal/`.
 
 ### Step 5 — Audit raw `IAgentAdapter` helper signatures
 
@@ -119,11 +124,14 @@ The #783 root pattern: helpers like `runFullSuiteGate(agent: IAgentAdapter)` acc
 
 Update each helper to accept `IAgentManager` instead. Where the helper truly needs adapter access (to call `adapter.openSession` for ad-hoc work), get it via `agentManager.getAdapter(name)`.
 
-| File | Helper | Today's signature | After |
-|:---|:---|:---|:---|
-| `src/tdd/rectification-gate.ts` | `runFullSuiteGate` | `(agent: IAgentAdapter, ...)` | `(agentManager: IAgentManager, ...)` |
-| `src/tdd/orchestrator-ctx.ts` | `getTddSessionBinding` | (verify — post-#783 may already be manager-typed) | `(agentManager: IAgentManager, ...)` |
-| `src/tdd/session-runner.ts` | (internal helpers) | grep for `agent: IAgentAdapter` parameters | manager-typed |
+**Pre-step audit:** run `rg "agent:\s*IAgentAdapter\|agent:\s*AgentAdapter" src/ --type ts` to enumerate every helper that takes a raw adapter. Compare against the list below; if grep finds additional sites, add them to the migration.
+
+| File | Helper | Migration |
+|:---|:---|:---|
+| `src/tdd/rectification-gate.ts` | `runFullSuiteGate` | Replace `agent: IAgentAdapter` param with `agentManager: IAgentManager`. Where the body called `agent.openSession`/`adapter.complete` directly (if any), route through the manager (`agentManager.runWithFallback` or `agentManager.completeWithFallback`). |
+| `src/tdd/orchestrator-ctx.ts` | `getTddSessionBinding` | Confirmed manager-typed post-#783 — verify with grep; no change expected. |
+| `src/tdd/session-runner.ts:253` | `runTddSession` internals | The current `effectiveManager = sessionBinding?.agentManager ?? wrapAdapterAsManager(agent)` pattern is removed. Function signature accepts `agentManager: IAgentManager` (no `?`); callers pass `ctx.agentManager`. |
+| Others surfaced by the pre-step grep | — | Same pattern: replace adapter param with manager; route adapter calls through `agentManager.getAdapter(name)` only if the helper truly needs adapter primitives (rare — most can use the higher-layer manager API). |
 
 For each updated helper, update every caller. Most callers already have `ctx.agentManager` reachable (verified during Wave 1).
 
@@ -226,7 +234,7 @@ All existing tests using `wrapAdapterAsManager` from `src/agents/utils.ts` switc
 2. **Tests pass:** `bun run test`
 3. **Pre-commit gate:** `bash scripts/check-no-adapter-wrap.sh` returns OK
 4. **Grep:** `rg 'wrapAdapterAsManager' src/` returns exactly one file: `src/session/runners/single-session-runner.ts`
-5. **Grep:** `rg 'agentManager\?\: IAgentManager' src/` returns zero hits — no remaining optional declarations
+5. **Grep (whitespace-tolerant):** `rg 'agentManager\?\s*:\s*(import\(.+\)\.)?IAgentManager' src/` returns zero hits — covers `agentManager?: IAgentManager`, `agentManager? : IAgentManager`, and `agentManager?: import("../agents").IAgentManager` variants. The exception is `src/runtime/index.ts:60` (CreateRuntimeOptions, deliberately optional per Step 2 note).
 6. **Re-run dogfood (`tdd-calc`, `hello-lint`):** all audit and cost coverage from Wave 1 still works (no regressions); TDD per-role audit names still present
 
 ## Rollback

--- a/docs/specs/adr-020-wave-2-dispatch-context.md
+++ b/docs/specs/adr-020-wave-2-dispatch-context.md
@@ -1,0 +1,249 @@
+# ADR-020 Wave 2 — `DispatchContext` Base Interface + `wrapAdapterAsManager` Gating
+
+> **Spec status:** Ready for implementation
+> **Owning ADR:** [docs/adr/ADR-020-dispatch-boundary-ssot.md](../adr/ADR-020-dispatch-boundary-ssot.md) §D3
+> **Closes Gap class:** Optional `agentManager` across ~10 context types (#783 root)
+> **Estimated:** ~165 LOC source, ~120 LOC tests, single PR
+
+---
+
+## Goal
+
+After this wave lands:
+
+1. `DispatchContext` is the single base interface for any context that dispatches agent work. It declares 4 required fields (`agentManager`, `sessionManager`, `runtime`, `abortSignal`) — non-nullable.
+2. The ~10 existing parallel context types extend `DispatchContext`. Optional `agentManager?` becomes required `agentManager`. Every `?? wrapAdapterAsManager(agent)` fallback site is a compile error and gets fixed in this PR.
+3. `wrapAdapterAsManager` is private to `SingleSessionRunner` (gated by `noFallback: true` per ADR-018 §5.2). The public export from `src/agents/utils.ts` is deleted. CI grep gate prevents reintroduction.
+4. Helpers that today take `agent: IAgentAdapter` directly (the #783 root pattern) accept `agentManager: IAgentManager` instead.
+
+## Prerequisites
+
+- ADR-020 Wave 1 merged (typed dispatch events at three boundaries; Wave 2 doesn't strictly depend on Wave 1's types but reviewers benefit from seeing the audit/cost coverage already structurally guaranteed).
+
+## Step-by-step implementation
+
+### Step 1 — Add `DispatchContext` base interface
+
+**New file: `src/runtime/dispatch-context.ts`** (~25 LOC)
+
+```typescript
+import type { IAgentManager } from "../agents";
+import type { ISessionManager } from "../session";
+import type { NaxRuntime } from "./index";
+
+/**
+ * Base contract for any context that dispatches agent work. Required fields
+ * mean every consumer (pipeline stage, operation, lifecycle, CLI command,
+ * routing, debate, review, acceptance, plan) must thread these by
+ * construction. Closes the wrapAdapterAsManager-fallback class structurally:
+ * there is nowhere a nullable agentManager exists in code that dispatches.
+ *
+ * Future cross-cutting fields (e.g. traceId, resolvedPermissions slice,
+ * packageId) go here once; the compiler then surfaces every consumer that
+ * must thread them.
+ *
+ * @see docs/adr/ADR-020-dispatch-boundary-ssot.md §D3
+ */
+export interface DispatchContext {
+  readonly agentManager: IAgentManager;
+  readonly sessionManager: ISessionManager;
+  readonly runtime: NaxRuntime;
+  readonly abortSignal: AbortSignal;
+}
+```
+
+Export from `src/runtime/index.ts` barrel.
+
+### Step 2 — Make existing context types extend `DispatchContext`
+
+For each row below: add `extends DispatchContext` to the interface declaration; drop the `?` from any field name that overlaps (`agentManager?` → required via the base; `sessionManager?` → required; `abortSignal?` → required). Run `bun run typecheck` after each file to surface compile errors at call sites; fix in same PR.
+
+| File | Type | Existing optional fields to make required (via base) |
+|:---|:---|:---|
+| `src/pipeline/types.ts:60` | `PipelineContext` | `agentManager?`, `sessionManager?`, `abortSignal?` |
+| `src/operations/types.ts` | `OperationContext<C>` | likely `agentManager?` and `sessionManager?` (verify) |
+| `src/execution/lifecycle/acceptance-loop.ts:61` | `AcceptanceLoopOptions` | `agentManager?` |
+| `src/execution/lifecycle/run-completion.ts:57` | `RunCompletionOptions` | `agentManager?` |
+| `src/debate/runner-stateful.ts:35` | `DebateRunnerCtx` (stateful) | `agentManager?` |
+| `src/debate/runner-hybrid.ts:41` | `DebateRunnerCtx` (hybrid) | `agentManager?` |
+| `src/debate/runner-plan.ts:33` | `DebateRunnerCtx` (plan) | `agentManager?` |
+| `src/debate/session-helpers.ts:76` | `DebateSessionCtx` | `agentManager?` |
+| `src/review/semantic-debate.ts:30` | `SemanticDebateCtx` | already required — verify |
+| `src/review/runner.ts` | `ReviewCtx` | grep for declaration |
+| `src/routing/router.ts:29` | `RoutingCtx` | `agentManager?` |
+| `src/cli/plan-runtime.ts` | `PlanCtx` | grep for declaration |
+| `src/session/session-runner.ts:63` | `SessionRunnerContext` | `agentManager?` |
+| `src/acceptance/types.ts:55` | `AcceptanceContext` | `agentManager?` |
+| `src/acceptance/types.ts:117` | (second declaration — verify name) | `agentManager?` |
+| `src/acceptance/hardening.ts:41` | `HardeningCtx` | `agentManager?` |
+
+After all extends added, run `bun run typecheck`. Each compile error is one of:
+
+- **Caller didn't have an `IAgentManager`:** thread one through (it's almost always available higher in the call chain — see Wave 1's emission audit confirming `runtime.agentManager` is reachable everywhere)
+- **Caller used `?? wrapAdapterAsManager(agent)`:** delete the fallback; pass real manager
+- **Caller used `agent: IAgentAdapter` instead of manager:** update signature (Step 4)
+
+### Step 3 — Move `wrapAdapterAsManager` into `SingleSessionRunner` private scope
+
+**File: `src/session/runners/single-session-runner.ts`**.
+
+Today it imports `wrapAdapterAsManager` from `src/agents/utils.ts`. Inline the implementation as a private (non-exported) helper at the bottom of the file, used only on the `noFallback: true` code path that ADR-018 §5.2 line 716 already established:
+
+```typescript
+// src/session/runners/single-session-runner.ts (bottom of file)
+
+/**
+ * Private no-fallback wrapper. Used only on the noFallback path where the
+ * caller has explicitly opted out of cross-agent fallback (e.g. TDD per-role
+ * sessions per ADR-018 §5.2). Must NOT be exported; must NOT be referenced
+ * outside this file. Enforced by scripts/check-no-adapter-wrap.sh.
+ */
+function wrapAdapterAsNoFallbackManager(adapter: AgentAdapter): IAgentManager {
+  // ... (same body as src/agents/utils.ts wrapAdapterAsManager today)
+}
+```
+
+Update the existing call site in `SingleSessionRunner.run` to reference the private helper.
+
+### Step 4 — Delete public `wrapAdapterAsManager` export
+
+**File: `src/agents/utils.ts`**.
+
+Delete the `wrapAdapterAsManager` and `NO_OP_INTERACTION_HANDLER` exports.
+
+If other files in `src/agents/` use `NO_OP_INTERACTION_HANDLER` internally, move it to a private location (e.g. `src/agents/internal/no-op-handler.ts`).
+
+### Step 5 — Audit raw `IAgentAdapter` helper signatures
+
+The #783 root pattern: helpers like `runFullSuiteGate(agent: IAgentAdapter)` accept the adapter directly, side-stepping the manager and any middleware. After Wave 1, audit/cost don't fire as middleware, but **the `noFallback` semantics still need a manager to satisfy `DispatchContext.agentManager`**.
+
+Update each helper to accept `IAgentManager` instead. Where the helper truly needs adapter access (to call `adapter.openSession` for ad-hoc work), get it via `agentManager.getAdapter(name)`.
+
+| File | Helper | Today's signature | After |
+|:---|:---|:---|:---|
+| `src/tdd/rectification-gate.ts` | `runFullSuiteGate` | `(agent: IAgentAdapter, ...)` | `(agentManager: IAgentManager, ...)` |
+| `src/tdd/orchestrator-ctx.ts` | `getTddSessionBinding` | (verify — post-#783 may already be manager-typed) | `(agentManager: IAgentManager, ...)` |
+| `src/tdd/session-runner.ts` | (internal helpers) | grep for `agent: IAgentAdapter` parameters | manager-typed |
+
+For each updated helper, update every caller. Most callers already have `ctx.agentManager` reachable (verified during Wave 1).
+
+### Step 6 — Test-only fake manager
+
+**New file: `test/helpers/fake-agent-manager.ts`** (~80 LOC)
+
+Test fixtures need a way to instantiate an `IAgentManager` without a full `NaxRuntime`. Move `wrapAdapterAsManager`'s body here under a clearly test-only name:
+
+```typescript
+/**
+ * Test-only fake manager. Wraps an adapter with no middleware chain and
+ * no fallback policy. Use ONLY in unit tests that don't need a full
+ * runtime. Production code must use createRuntime(...).agentManager.
+ *
+ * @see docs/adr/ADR-020-dispatch-boundary-ssot.md §D3
+ */
+export function fakeAgentManager(adapter: AgentAdapter): IAgentManager {
+  // ... (body moved from src/agents/utils.ts)
+}
+```
+
+Update every test that currently imports `wrapAdapterAsManager` from `src/agents/utils.ts` to import `fakeAgentManager` from `test/helpers/fake-agent-manager`. Mechanical sed across `test/`.
+
+### Step 7 — CI grep gate
+
+**New file: `scripts/check-no-adapter-wrap.sh`** (~20 LOC)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Production code must NOT reference wrapAdapterAsManager. The only legitimate
+# wrapper lives privately inside src/session/runners/single-session-runner.ts
+# (named wrapAdapterAsNoFallbackManager) and is gated by noFallback:true.
+#
+# @see docs/adr/ADR-020-dispatch-boundary-ssot.md §D3
+
+violations=$(rg --files-with-matches 'wrapAdapterAsManager' src/ \
+  | grep -v '^src/session/runners/single-session-runner.ts$' \
+  || true)
+
+if [[ -n "$violations" ]]; then
+  echo "FAIL: wrapAdapterAsManager referenced outside SingleSessionRunner:"
+  echo "$violations"
+  echo ""
+  echo "Use ctx.agentManager (DispatchContext) instead. See ADR-020 §D3."
+  exit 1
+fi
+
+echo "OK: No wrapAdapterAsManager violations found."
+```
+
+Wire into `.husky/pre-commit` (alongside the existing `check-process-cwd.sh`) and CI workflow.
+
+### Step 8 — Update forbidden-patterns rule
+
+**File: `.claude/rules/forbidden-patterns.md`**.
+
+Add row under "Source Code" table:
+
+| ❌ Forbidden | ✅ Use Instead | Why |
+|:---|:---|:---|
+| `wrapAdapterAsManager` outside `src/session/runners/single-session-runner.ts` | `ctx.agentManager` (from `DispatchContext`) | The wrapper has no middleware chain; using it bypasses audit, cost, cancellation. ADR-020 §D3. |
+
+## Tests
+
+### `test/unit/runtime/dispatch-context.test.ts` (new, ~30 LOC)
+
+Type-only tests using `tsd` or compile-time assertions:
+- `PipelineContext extends DispatchContext` — assignable
+- `OperationContext<C> extends DispatchContext` — assignable
+- All 10 context types satisfy `DispatchContext`
+- A type with `agentManager?: IAgentManager` does NOT satisfy `DispatchContext` (negative)
+
+### `test/integration/agents/no-adapter-wrap.test.ts` (new, ~25 LOC)
+
+```typescript
+test("src/agents/utils.ts does not export wrapAdapterAsManager", async () => {
+  const utils = await import("../../../src/agents/utils");
+  expect("wrapAdapterAsManager" in utils).toBe(false);
+});
+
+test("only single-session-runner references the private wrapper", async () => {
+  const result = Bun.spawnSync({
+    cmd: ["rg", "wrapAdapterAsManager", "src/", "--files-with-matches"],
+  });
+  const files = result.stdout.toString().trim().split("\n").filter(Boolean);
+  expect(files).toEqual(["src/session/runners/single-session-runner.ts"]);
+});
+```
+
+### Existing tests
+
+All existing tests using `wrapAdapterAsManager` from `src/agents/utils.ts` switch to `fakeAgentManager` from `test/helpers/fake-agent-manager.ts`. Mechanical update; behaviour identical.
+
+## Validation
+
+1. **Typecheck green:** `bun run typecheck` — every compile error from Step 2 fixed in the same PR
+2. **Tests pass:** `bun run test`
+3. **Pre-commit gate:** `bash scripts/check-no-adapter-wrap.sh` returns OK
+4. **Grep:** `rg 'wrapAdapterAsManager' src/` returns exactly one file: `src/session/runners/single-session-runner.ts`
+5. **Grep:** `rg 'agentManager\?\: IAgentManager' src/` returns zero hits — no remaining optional declarations
+6. **Re-run dogfood (`tdd-calc`, `hello-lint`):** all audit and cost coverage from Wave 1 still works (no regressions); TDD per-role audit names still present
+
+## Rollback
+
+Single PR. Revert restores `wrapAdapterAsManager` public export and the optional `?` on context types. The `DispatchContext` base interface is additive — its removal needs the `extends` clauses removed simultaneously.
+
+## Risk + mitigation
+
+| Risk | Mitigation |
+|:---|:---|
+| Step 2 produces many compile errors at once | Run typecheck per file as you add each `extends`; commit batches by directory (pipeline, then operations, then debate, etc.) for easier review |
+| A truly fallback-needing site discovered (no `IAgentManager` reachable) | This case shouldn't exist post-Wave 1, but if found: thread `runtime.agentManager` from the nearest available `NaxRuntime`. If even that is impossible, the call site is itself the bug — investigate before forcing the type |
+| Plugin or third-party code uses the public wrapper | No third-party in-tree plugins use it (verified via grep at audit time). CHANGELOG note for downstream consumers |
+| `fakeAgentManager` named too closely to production helper, future test author confuses them | Aggressive doc comment + test-only directory + grep gate prevents production import |
+
+## Out of scope
+
+- ADR-020 Wave 1 work (typed dispatch events) — this wave assumes that's done
+- ADR-020 Wave 3 (`Operation.verify`/`recover`) — orthogonal
+- Promoting `DispatchContext` to a runtime "context factory" — explicitly rejected per ADR-020 §A5

--- a/docs/specs/adr-020-wave-3-operation-verify-recover.md
+++ b/docs/specs/adr-020-wave-3-operation-verify-recover.md
@@ -1,0 +1,335 @@
+# ADR-020 Wave 3 — Side-Effect-Aware `Operation` Contract (`verify` + `recover`)
+
+> **Spec status:** Ready for implementation
+> **Owning ADR:** [docs/adr/ADR-020-dispatch-boundary-ssot.md](../adr/ADR-020-dispatch-boundary-ssot.md) §D4
+> **Closes:** Class behind PR #774 (acceptance-setup ACP recovery); latent equivalents in TDD ops
+> **Estimated:** ~200 LOC source, ~150 LOC tests, single PR
+
+---
+
+## Goal
+
+After this wave lands:
+
+1. `Operation<I, O, C>` gains optional `verify` and `recover` hooks. Default behaviour unchanged for ops that don't declare them.
+2. `callOp` runs `parse` → `verify` → `recover` automatically. Side-effect ops (ACP-mode agents that write files + reply conversationally) declare disk-recovery once in the op definition, not at every caller.
+3. `acceptanceGenerateOp` declares `verify` + `recover`; `src/pipeline/stages/acceptance-setup.ts:350-441` Tier-1/2/3 disk-read ladder is deleted.
+4. TDD `writeTddTestOp` and `implementTddOp` declare `verify`/`recover` for the same reason — agent writes test/source files, returns conversational summary.
+5. `VerifyContext<C>` has read-only filesystem access, no agent calls, no writes — can't accidentally trigger recursive dispatch.
+
+## Prerequisites
+
+- ADR-020 Waves 1 + 2 merged (this wave is independent from a code perspective but reviewers benefit from the consistent ADR-020 mental model).
+
+## Step-by-step implementation
+
+### Step 1 — Extend `Operation` contract
+
+**File: `src/operations/types.ts`**.
+
+Today's `OperationBase`:
+
+```typescript
+interface OperationBase<I, O, C> {
+  readonly build: (input: I, ctx: BuildContext<C>) => ComposeInput;
+  readonly parse: (output: string, input: I, ctx: BuildContext<C>) => O;
+}
+```
+
+Extend with optional hooks:
+
+```typescript
+import type { ResolvedTestPatterns } from "../test-runners/types"; // example existing read-only resource
+
+/**
+ * Read-only context for verify/recover. No agent calls, no writes — both
+ * hooks operate on disk artifacts the agent may have produced as side effects.
+ *
+ * @see docs/adr/ADR-020-dispatch-boundary-ssot.md §D4
+ */
+export interface VerifyContext<C> extends BuildContext<C> {
+  readFile(path: string): Promise<string | null>;
+  fileExists(path: string): Promise<boolean>;
+  // Add narrow read-only helpers as future ops need them.
+  // Banned: anything that would write or trigger another agent dispatch.
+}
+
+interface OperationBase<I, O, C> {
+  readonly build: (input: I, ctx: BuildContext<C>) => ComposeInput;
+  readonly parse: (output: string, input: I, ctx: BuildContext<C>) => O;
+
+  /**
+   * Optional. Validate parsed output against on-disk artifacts. Returning
+   * non-null wins; returning null means "parsed output insufficient — fall
+   * through to recover (if defined) or surface null".
+   *
+   * Use when the agent's contract is "stdout has the answer, but disk has
+   * the canonical artifact" (e.g. ACP test-writer: stdout is conversational,
+   * disk has the test file).
+   */
+  readonly verify?: (parsed: O, input: I, ctx: VerifyContext<C>) => Promise<O | null>;
+
+  /**
+   * Optional. Recover output from on-disk artifacts when parse returned null
+   * AND verify is absent or also returned null. Last resort before the caller
+   * sees a null result.
+   *
+   * Use when the agent may have completed its work entirely as a filesystem
+   * side-effect and stdout is unparseable.
+   */
+  readonly recover?: (input: I, ctx: VerifyContext<C>) => Promise<O | null>;
+}
+```
+
+### Step 2 — Update `callOp` to run the post-parse pipeline
+
+**File: `src/operations/call.ts`**.
+
+Find the section after `parse(output, input, ctx)` returns. Today it returns the parsed result directly. Add:
+
+```typescript
+const parsed = op.parse(output, input, buildCtx);
+const verifyCtx: VerifyContext<C> = {
+  ...buildCtx,
+  readFile: async (p) => {
+    try { return await Bun.file(p).text(); }
+    catch { return null; }
+  },
+  fileExists: async (p) => Bun.file(p).exists(),
+};
+
+let final: O | null = parsed;
+
+if (op.verify) {
+  final = await op.verify(parsed, input, verifyCtx);
+}
+
+if (final === null && op.recover) {
+  final = await op.recover(input, verifyCtx);
+}
+
+if (final === null) {
+  // Caller sees null; existing call sites already handle this case
+  // (they had to before, since parse could already return null for some ops).
+  return null as O;  // or however the existing return type handles null
+}
+
+return final;
+```
+
+The exact signature depends on whether `parse` was nullable today. If `parse: (...) => O` (non-null), make `verify`/`recover` only fire when `parsed` is sentinel-empty (e.g. `{ testCode: null }`). The Wave 3 implementer should adapt to the existing parse-return convention for each op type.
+
+### Step 3 — `acceptanceGenerateOp.verify` + `recover`
+
+**File: `src/operations/acceptance-generate.ts`** (or wherever the op lives — verify path).
+
+Today's parse:
+
+```typescript
+parse(output, _input, _ctx) {
+  return { testCode: extractTestCode(output) };
+}
+```
+
+Add `verify` and `recover`:
+
+```typescript
+verify: async (parsed, input, ctx) => {
+  // If parse extracted real code from stdout, accept it.
+  if (parsed.testCode !== null) return parsed;
+
+  // Otherwise check disk — agent may have written the file as a side effect.
+  const diskContent = await ctx.readFile(input.testPath);
+  if (diskContent === null) return null;  // no file → recover may try harder
+
+  const extracted = extractTestCode(diskContent);
+  if (extracted) return { testCode: extracted };
+
+  // File exists with no code-fence but plausible test content
+  if (hasLikelyTestContent(diskContent) && !isStubTestContent(diskContent)) {
+    return { testCode: diskContent };
+  }
+
+  return null;  // verify exhausted; recover gets a shot
+},
+
+recover: async (input, ctx) => {
+  // Last-resort: file exists, content unparseable but non-empty.
+  // Caller (stage) decides whether to skeleton-fallback; we just return null.
+  return null;
+},
+```
+
+Where `hasLikelyTestContent` and `isStubTestContent` migrate from `src/pipeline/stages/acceptance-setup.ts` into the op file (or a shared helper in `src/acceptance/heuristics.ts`).
+
+### Step 4 — Delete the Tier-1/2/3 ladder from `acceptance-setup.ts`
+
+**File: `src/pipeline/stages/acceptance-setup.ts:350-441`**.
+
+Replace the current ladder:
+
+```typescript
+let testCode = genResult.testCode;
+if (!testCode) {
+  // Tier 1: re-parse on-disk file
+  const existing = await readFile(testPath);
+  const extracted = extractTestCode(existing);
+  if (extracted) testCode = extracted;
+  // Tier 2: heuristic match
+  else if (hasLikelyTestContent(existing)) testCode = existing;
+  // Tier 3: skeleton fallback
+  else if (existing.length > 0) { /* backup + warn */ }
+}
+if (testCode) await writeFile(testPath, testCode);
+```
+
+With:
+
+```typescript
+const testCode = genResult.testCode;  // verify+recover already ran inside callOp
+
+if (testCode) {
+  await writeFile(testPath, testCode);
+} else {
+  // Stage decision: skeleton fallback. Op exhausted; this is policy.
+  await writeFile(testPath, generateSkeleton(...));
+  logger.warn("acceptance", "agent did not produce test content; using skeleton",
+    { storyId: ctx.story.id, testPath });
+}
+```
+
+The stage now contains only the **stage decision** (use skeleton if op fully exhausted), not the recovery ladder. Recovery moved into the op where it belongs.
+
+### Step 5 — TDD ops: `writeTddTestOp` + `implementTddOp`
+
+**Files: `src/operations/tdd-write-test.ts` (or wherever defined), `src/operations/tdd-implement.ts`**.
+
+Same pattern. The TDD test-writer agent (ACP-mode) writes the test file on disk and replies conversationally; same for the implementer with source files.
+
+For `writeTddTestOp`:
+
+```typescript
+verify: async (parsed, input, ctx) => {
+  if (parsed.success) return parsed;  // stdout had a clear success signal
+  // Check disk: did the agent write the test file?
+  const exists = await ctx.fileExists(input.expectedTestPath);
+  if (exists) {
+    const content = await ctx.readFile(input.expectedTestPath);
+    if (content && hasLikelyTestContent(content)) {
+      return { success: true, testPath: input.expectedTestPath };
+    }
+  }
+  return null;
+},
+```
+
+Mirror for `implementTddOp` against the source file path the agent was instructed to write.
+
+The exact field shape depends on each op's existing return type — verify/recover construct values that match `O` for that op.
+
+### Step 6 — Inventory other callers that may need migration
+
+Grep for callers that currently use `callOp` and then perform manual disk-recovery. Likely sites:
+
+- `src/operations/decompose.ts` — does the agent write JSON to disk? Check.
+- `src/operations/plan.ts` — same.
+- `src/review/*` — semantic/adversarial reviewers may or may not have side effects.
+
+For each: if the existing call site has a "after callOp, also read disk to confirm" pattern, that's a migration candidate. Migrate at the same time so the wave covers all known cases.
+
+If unsure, leave the op un-migrated (verify/recover are optional — no behaviour change for ops that don't declare them).
+
+### Step 7 — Update forbidden-patterns rule
+
+**File: `.claude/rules/forbidden-patterns.md`**.
+
+Add row under "Source Code" table:
+
+| ❌ Forbidden | ✅ Use Instead | Why |
+|:---|:---|:---|
+| Manual disk-recovery ladder in pipeline stages after `callOp` (Tier-1/2/3 patterns) | Declare `verify`/`recover` on the op | Recovery logic belongs with the op (one place to maintain), not duplicated in every stage that calls it. ADR-020 §D4. |
+
+## Tests
+
+### `test/unit/operations/verify-recover.test.ts` (new, ~120 LOC)
+
+```typescript
+test("op without verify or recover returns parse output unchanged", ...);
+
+test("op.verify returning non-null wins", async () => {
+  const op = {
+    build: () => ({ ... }),
+    parse: () => ({ testCode: null }),
+    verify: async (parsed, input, ctx) => ({ testCode: "real test code" }),
+  };
+  const result = await callOp(ctx, op, input);
+  expect(result.testCode).toBe("real test code");
+});
+
+test("op.verify returning null falls through to recover", async () => {
+  const op = {
+    parse: () => ({ testCode: null }),
+    verify: async () => null,
+    recover: async () => ({ testCode: "recovered from disk" }),
+  };
+  const result = await callOp(ctx, op, input);
+  expect(result.testCode).toBe("recovered from disk");
+});
+
+test("both verify and recover null → caller sees null", ...);
+
+test("VerifyContext.readFile returns null for missing file", ...);
+test("VerifyContext.fileExists returns false for missing file", ...);
+test("VerifyContext does NOT expose write or agent-call methods", ...); // type-level check
+```
+
+### `test/unit/pipeline/stages/acceptance-setup-agent-file.test.ts` (rewrite ~80 LOC)
+
+The existing post-#774 tests assert the stage's Tier-1/2/3 ladder. Rewrite to assert the **op's** verify/recover behaviour:
+
+- agent writes valid file to disk → `verify` returns it; stage just writes the result
+- agent writes stub file → `verify` returns null; `recover` returns null; stage uses skeleton
+- agent writes nothing → both null; stage uses skeleton
+- agent returns code in stdout → `parse` extracts; `verify` accepts; stage writes
+
+### `test/integration/acceptance/agent-file-recovery.test.ts` (new, ~50 LOC)
+
+End-to-end: invoke acceptance-setup with a stub agent that writes a valid test file to disk and returns conversational stdout. Assert the agent-written file is preserved (not overwritten by skeleton). This is the regression test for #774 that survives the migration.
+
+### `test/unit/operations/acceptance-generate.test.ts` (update)
+
+Add cases for the new `verify` and `recover` hooks on `acceptanceGenerateOp`. Mock `VerifyContext.readFile` / `fileExists` to simulate disk states.
+
+## Validation
+
+1. **Tests pass:** `bun run test`
+2. **#774 regression:** the integration test confirms agent-written test files are preserved
+3. **No regressions in `acceptance-setup` stage:** existing dogfood runs produce the same on-disk results
+4. **TDD ops:** if step 5 migrated TDD ops, run a `tdd-calc` dogfood and confirm test/source files agent writes are preserved across rectification cycles
+5. **Grep:** `rg 'extractTestCode' src/pipeline/stages/` returns zero hits (the recovery helper moved into the op)
+
+## Rollback
+
+Single PR. Revert restores the stage-side ladder and removes the optional `verify`/`recover` fields. No behaviour change for ops that didn't declare the hooks (they're optional, additive).
+
+## Risk + mitigation
+
+| Risk | Mitigation |
+|:---|:---|
+| Op author forgets to declare `verify`/`recover` for a new side-effect op | Forbidden-patterns rule catches it in code review; failing dogfood runs catch it at runtime |
+| `VerifyContext` over-narrowed; some legitimate verify needs another resource | Easy to extend — add a narrow read-only helper to the interface. Banned additions: writes, agent calls. |
+| `verify`/`recover` accidentally do writes | Type system: `VerifyContext` deliberately doesn't expose write APIs. Reviewers spot direct `Bun.write`/`writeFile` imports in op files. |
+| Migration of TDD ops introduces subtle behaviour change vs current rectification flow | Per-op migration; one PR per op if Wave 3 grows large; integration tests cover the rectification cycle |
+
+## Out of scope
+
+- ADR-020 Waves 1, 2 work — assumed merged
+- A full "Effects" subsystem that tracks all side effects uniformly (filesystem, network, subprocess) — explicitly rejected per ADR-020 §A4 as out-of-scope speculation
+- Agent re-prompting from `verify`/`recover` (e.g. "ask the agent to repair its output") — explicitly out per ADR-020 Open Question 3; rectification is a separate subsystem and lives in the rectifier, not the op contract
+
+## Sequencing notes for the implementer
+
+- Step 1 + 2 are pure additions (optional fields, optional hook execution). Land them first as a self-contained sub-PR if you want to keep the diff small.
+- Steps 3 + 4 (acceptance migration) are atomic — must land together to avoid duplicate recovery (op-level + stage-level).
+- Step 5 (TDD ops) can be a follow-up sub-PR; not required to land alongside acceptance.
+- Step 6 inventory + Step 7 docs land last after migrations stabilise.

--- a/docs/specs/adr-020-wave-3-operation-verify-recover.md
+++ b/docs/specs/adr-020-wave-3-operation-verify-recover.md
@@ -25,43 +25,49 @@ After this wave lands:
 
 ### Step 1 — Extend `Operation` contract
 
-**File: `src/operations/types.ts`**.
+**File: `src/operations/types.ts`** lines 9-58.
 
-Today's `OperationBase`:
+> **Verified types** (from reading the file):
+> - `OperationBase<I, O, C>` is **not exported** (line 40, no `export` keyword). It's an internal interface that `RunOperation` (line 81) and `CompleteOperation` (line 109) extend. `Operation<I, O, C>` (line 120) is the union — also exported.
+> - `BuildContext<C>` (line 9) has only `packageView: PackageView` and `config: C`. **Narrow** — exactly the right scope for `VerifyContext`.
+> - `parse` returns `O` (non-null); ops that may not produce output use `O = SomeType | null` (e.g. `acceptanceGenerateOp`'s `AcceptanceGenerateOutput = { testCode: string | null }`).
+> - All edits to `OperationBase` are made on the un-exported declaration. Both `RunOperation` and `CompleteOperation` inherit `verify` and `recover` automatically.
 
-```typescript
-interface OperationBase<I, O, C> {
-  readonly build: (input: I, ctx: BuildContext<C>) => ComposeInput;
-  readonly parse: (output: string, input: I, ctx: BuildContext<C>) => O;
-}
-```
-
-Extend with optional hooks:
+Extend `OperationBase` and add `VerifyContext`:
 
 ```typescript
-import type { ResolvedTestPatterns } from "../test-runners/types"; // example existing read-only resource
+// src/operations/types.ts — additions
 
 /**
- * Read-only context for verify/recover. No agent calls, no writes — both
- * hooks operate on disk artifacts the agent may have produced as side effects.
+ * Read-only context for verify/recover. Mirrors BuildContext<C>'s narrow
+ * surface plus filesystem reads. No agent calls, no writes, no runtime
+ * mutation — both hooks operate on disk artifacts the agent may have
+ * produced as side effects.
  *
  * @see docs/adr/ADR-020-dispatch-boundary-ssot.md §D4
  */
 export interface VerifyContext<C> extends BuildContext<C> {
-  readFile(path: string): Promise<string | null>;
-  fileExists(path: string): Promise<boolean>;
-  // Add narrow read-only helpers as future ops need them.
-  // Banned: anything that would write or trigger another agent dispatch.
+  readonly readFile: (path: string) => Promise<string | null>;
+  readonly fileExists: (path: string) => Promise<boolean>;
+  // Future read-only helpers go here. Banned: writes, agent calls.
 }
 
+// Modify the existing un-exported OperationBase declaration (line 40):
 interface OperationBase<I, O, C> {
+  readonly name: string;
+  readonly stage: PipelineStage;
+  readonly config: ConfigSelector<C> | readonly (keyof NaxConfig)[];
   readonly build: (input: I, ctx: BuildContext<C>) => ComposeInput;
   readonly parse: (output: string, input: I, ctx: BuildContext<C>) => O;
 
   /**
    * Optional. Validate parsed output against on-disk artifacts. Returning
    * non-null wins; returning null means "parsed output insufficient — fall
-   * through to recover (if defined) or surface null".
+   * through to recover (if defined) or surface as if parse returned null".
+   *
+   * The "parsed output insufficient" signal is op-defined. For ops where
+   * O is `T | null`, returning null commonly means "parse gave us null and
+   * we couldn't recover from disk either."
    *
    * Use when the agent's contract is "stdout has the answer, but disk has
    * the canonical artifact" (e.g. ACP test-writer: stdout is conversational,
@@ -70,97 +76,176 @@ interface OperationBase<I, O, C> {
   readonly verify?: (parsed: O, input: I, ctx: VerifyContext<C>) => Promise<O | null>;
 
   /**
-   * Optional. Recover output from on-disk artifacts when parse returned null
-   * AND verify is absent or also returned null. Last resort before the caller
-   * sees a null result.
+   * Optional. Recover output from on-disk artifacts when parse + verify
+   * both produced "no useful result." Last resort before the caller sees
+   * the null/empty value.
    *
-   * Use when the agent may have completed its work entirely as a filesystem
-   * side-effect and stdout is unparseable.
+   * Use when the agent may have completed its work entirely as a
+   * filesystem side-effect and stdout is unparseable.
    */
   readonly recover?: (input: I, ctx: VerifyContext<C>) => Promise<O | null>;
 }
 ```
 
+`VerifyContext<C>` is exported from the operations barrel (`src/operations/index.ts`).
+
 ### Step 2 — Update `callOp` to run the post-parse pipeline
 
-**File: `src/operations/call.ts`**.
+**File: `src/operations/call.ts`** lines 60-72 (complete-kind path) and 140-148 (run-kind path).
 
-Find the section after `parse(output, input, ctx)` returns. Today it returns the parsed result directly. Add:
+Today, both paths end with `return op.parse(...)` — synchronous. Wave 3 makes both async-aware: run `verify`, then `recover`, return the final result. **`parse` stays sync** (preserves existing contract); only the new hooks are async.
+
+The current type signature `Operation<I, O, C> → Promise<O>` already returns a Promise, so adding async hooks is non-breaking for callers.
+
+Build a single shared post-parse helper:
 
 ```typescript
-const parsed = op.parse(output, input, buildCtx);
-const verifyCtx: VerifyContext<C> = {
-  ...buildCtx,
-  readFile: async (p) => {
-    try { return await Bun.file(p).text(); }
-    catch { return null; }
-  },
-  fileExists: async (p) => Bun.file(p).exists(),
-};
+// src/operations/call.ts — add helper at the bottom of the file
 
-let final: O | null = parsed;
+async function runPostParse<I, O, C>(
+  op: Operation<I, O, C>,
+  parsed: O,
+  input: I,
+  buildCtx: BuildContext<C>,
+): Promise<O> {
+  if (!op.verify && !op.recover) return parsed;
 
-if (op.verify) {
-  final = await op.verify(parsed, input, verifyCtx);
+  const verifyCtx: VerifyContext<C> = {
+    packageView: buildCtx.packageView,
+    config: buildCtx.config,
+    readFile: async (p) => {
+      try { return await Bun.file(p).text(); }
+      catch { return null; }   // ENOENT or any read failure → null (caller decides)
+    },
+    fileExists: async (p) => Bun.file(p).exists(),
+  };
+
+  let final: O | null = parsed;
+
+  if (op.verify) {
+    final = await op.verify(parsed, input, verifyCtx);
+  }
+
+  if (final === null && op.recover) {
+    final = await op.recover(input, verifyCtx);
+  }
+
+  // Returning null when both hooks return null is the op's contract — callers
+  // that defined O as `T | null` handle it. Ops that defined O as non-null
+  // must not return null from verify/recover (compile error caught by the
+  // generic `O | null` signature on the hooks).
+  return (final ?? parsed) as O;
 }
-
-if (final === null && op.recover) {
-  final = await op.recover(input, verifyCtx);
-}
-
-if (final === null) {
-  // Caller sees null; existing call sites already handle this case
-  // (they had to before, since parse could already return null for some ops).
-  return null as O;  // or however the existing return type handles null
-}
-
-return final;
 ```
 
-The exact signature depends on whether `parse` was nullable today. If `parse: (...) => O` (non-null), make `verify`/`recover` only fire when `parsed` is sentinel-empty (e.g. `{ testCode: null }`). The Wave 3 implementer should adapt to the existing parse-return convention for each op type.
+**Replace the two terminal `return op.parse(...)` lines:**
+
+Line 71 (complete-kind):
+```typescript
+// Before:
+return op.parse(raw.output, input, buildCtx);
+// After:
+const parsed = op.parse(raw.output, input, buildCtx);
+return runPostParse(op, parsed, input, buildCtx);
+```
+
+Line 148 (run-kind):
+```typescript
+// Before:
+return op.parse(rawOutput, input, buildCtx);
+// After:
+const parsed = op.parse(rawOutput, input, buildCtx);
+return runPostParse(op, parsed, input, buildCtx);
+```
+
+**Behaviour for ops without `verify`/`recover`:** `runPostParse` short-circuits at the top — zero overhead. Existing ops are unaffected.
+
+**Behaviour when verify returns null and recover is absent:** `final ?? parsed` returns the original parsed value (which may itself be a `T | null` sentinel). This preserves "parse said null, no recovery available" semantics for callers that already handle nullable parse output (e.g. `acceptanceGenerateOp`).
 
 ### Step 3 — `acceptanceGenerateOp.verify` + `recover`
 
-**File: `src/operations/acceptance-generate.ts`** (or wherever the op lives — verify path).
+**File: `src/operations/acceptance-generate.ts`** (verified to exist; current parse at line 45-47).
 
-Today's parse:
+Verified existing shape:
+- Input has `targetTestFilePath: string` (line 10) — that's the disk path verify reads
+- Output is `AcceptanceGenerateOutput = { testCode: string | null }` (line 16) — null is the existing failure signal
+- `extractTestCode` already imported from `../acceptance/generator` (line 1)
+
+Add `verify` and `recover` to the op declaration:
 
 ```typescript
-parse(output, _input, _ctx) {
-  return { testCode: extractTestCode(output) };
+import { extractTestCode } from "../acceptance/generator";
+import {
+  hasLikelyTestContent,
+  isStubTestContent,
+} from "../acceptance/heuristics";   // NEW — see migration below
+
+export const acceptanceGenerateOp: CompleteOperation<
+  AcceptanceGenerateInput,
+  AcceptanceGenerateOutput,
+  AcceptanceConfig
+> = {
+  // ... existing fields (kind, name, stage, jsonMode, config, build, parse) ...
+
+  parse(output, _input, _ctx) {
+    return { testCode: extractTestCode(output) };
+  },
+
+  async verify(parsed, input, ctx) {
+    // Stdout had real test code → accept.
+    if (parsed.testCode !== null) return parsed;
+
+    // Otherwise check the agent's side-effect: did it write the file?
+    const diskContent = await ctx.readFile(input.targetTestFilePath);
+    if (diskContent === null) return null;   // no file — let recover try (it won't, but be explicit)
+
+    // Tier 1: disk content has a fenced/code marker → extract it
+    const extracted = extractTestCode(diskContent);
+    if (extracted) return { testCode: extracted };
+
+    // Tier 2: disk content looks like a real test file but no fence
+    if (hasLikelyTestContent(diskContent) && !isStubTestContent(diskContent)) {
+      return { testCode: diskContent };
+    }
+
+    return null;   // verify exhausted; will return parsed (= { testCode: null })
+  },
+
+  // No `recover` for this op — Tier 3 (skeleton fallback) is a stage policy
+  // decision (stage knows whether to skeleton-overwrite vs leave the file
+  // alone), not an op concern. recover is omitted intentionally.
+};
+```
+
+**New file: `src/acceptance/heuristics.ts`** (~40 LOC)
+
+Migrate the helpers from `src/pipeline/stages/acceptance-setup.ts:350-441` (where they were defined locally as `hasLikelyTestContent` and `isStubTestContent`):
+
+```typescript
+/**
+ * Heuristics for detecting whether on-disk content is plausible test code.
+ * Migrated from acceptance-setup stage (post-#774 ladder) into a shared
+ * module so the acceptance-generate op (verify hook) and any future
+ * consumer share one definition.
+ */
+
+const TEST_MARKERS = /\b(describe|test|it|func Test|def test_|@Test)\b/;
+const STUB_MARKERS = /^[\s\S]*\b(skeleton|TODO|FIXME)\b[\s\S]*$/;   // copy from existing impl
+
+export function hasLikelyTestContent(content: string): boolean {
+  return TEST_MARKERS.test(content);
+}
+
+export function isStubTestContent(content: string): boolean {
+  // Copy regex/heuristic from existing isStubTestFile in src/acceptance/acceptance-helpers.ts
+  // — both must align (PR #774 noted this dependency).
+  return STUB_MARKERS.test(content);
 }
 ```
 
-Add `verify` and `recover`:
+The existing `isStubTestFile` in `src/acceptance/acceptance-helpers.ts` and the new `isStubTestContent` here must use the same regex. Either: (a) export from one location, import in the other — preferred; (b) align the regex literals and add a comment cross-referencing both.
 
-```typescript
-verify: async (parsed, input, ctx) => {
-  // If parse extracted real code from stdout, accept it.
-  if (parsed.testCode !== null) return parsed;
-
-  // Otherwise check disk — agent may have written the file as a side effect.
-  const diskContent = await ctx.readFile(input.testPath);
-  if (diskContent === null) return null;  // no file → recover may try harder
-
-  const extracted = extractTestCode(diskContent);
-  if (extracted) return { testCode: extracted };
-
-  // File exists with no code-fence but plausible test content
-  if (hasLikelyTestContent(diskContent) && !isStubTestContent(diskContent)) {
-    return { testCode: diskContent };
-  }
-
-  return null;  // verify exhausted; recover gets a shot
-},
-
-recover: async (input, ctx) => {
-  // Last-resort: file exists, content unparseable but non-empty.
-  // Caller (stage) decides whether to skeleton-fallback; we just return null.
-  return null;
-},
-```
-
-Where `hasLikelyTestContent` and `isStubTestContent` migrate from `src/pipeline/stages/acceptance-setup.ts` into the op file (or a shared helper in `src/acceptance/heuristics.ts`).
+**Decision: option (a).** Move `isStubTestContent` to `src/acceptance/heuristics.ts`; have `acceptance-helpers.ts` import from there.
 
 ### Step 4 — Delete the Tier-1/2/3 ladder from `acceptance-setup.ts`
 
@@ -200,44 +285,68 @@ if (testCode) {
 
 The stage now contains only the **stage decision** (use skeleton if op fully exhausted), not the recovery ladder. Recovery moved into the op where it belongs.
 
-### Step 5 — TDD ops: `writeTddTestOp` + `implementTddOp`
+### Step 5 — TDD ops: **NOT applicable as Operations**
 
-**Files: `src/operations/tdd-write-test.ts` (or wherever defined), `src/operations/tdd-implement.ts`**.
+> **Verified shape after reading code:** TDD "ops" in `src/operations/{write-test,implement,verify}.ts` are 1-line re-exports. The actual definitions in `src/tdd/session-op.ts` are minimal role tags:
+>
+> ```typescript
+> export type TddRunOp = { role: TddSessionRole };
+> export const writeTddTestOp: TddRunOp = { role: "test-writer" };
+> export const implementTddOp: TddRunOp = { role: "implementer" };
+> export const verifyTddOp:    TddRunOp = { role: "verifier" };
+> ```
+>
+> **They are not `Operation<I, O, C>` shapes** — no `build`, no `parse`, no `kind`. They're consumed by `runTddSession(role, agent, story, ...)` (a custom orchestrator that pre-dates the `callOp` migration), which builds prompts and parses results internally. `verify`/`recover` cannot be added at this layer.
 
-Same pattern. The TDD test-writer agent (ACP-mode) writes the test file on disk and replies conversationally; same for the implementer with source files.
+**Decision: out of scope for Wave 3.** The TDD test-writer / implementer agents do write files as side-effects, but the recovery for that lives in `src/tdd/session-runner.ts` and `src/tdd/orchestrator.ts` — not in an Operation contract. Migrating TDD ops to true `Operation<I, O, C>` shapes is its own architectural change, not part of D4.
 
-For `writeTddTestOp`:
+**What to do instead:** if a TDD agent's file-write is going wrong, fix it in the TDD orchestrator (where the actual prompt-build and result-parse live). When TDD eventually migrates to `callOp`-based ops (deferred per ADR-018 §5.3 amendment — TDD orchestrator stays a plain function for now), it picks up `verify`/`recover` for free at that point.
+
+**Documented for future work:** add a TODO in `src/tdd/session-op.ts` referencing this decision so the next person reading the file understands why TDD ops don't have hooks.
 
 ```typescript
-verify: async (parsed, input, ctx) => {
-  if (parsed.success) return parsed;  // stdout had a clear success signal
-  // Check disk: did the agent write the test file?
-  const exists = await ctx.fileExists(input.expectedTestPath);
-  if (exists) {
-    const content = await ctx.readFile(input.expectedTestPath);
-    if (content && hasLikelyTestContent(content)) {
-      return { success: true, testPath: input.expectedTestPath };
-    }
-  }
-  return null;
-},
+// src/tdd/session-op.ts — add at top
+/**
+ * TDD ops are minimal role tags consumed by runTddSession (src/tdd/session-runner.ts),
+ * not full Operation<I, O, C> shapes. See ADR-020 Wave 3 §Step 5 — verify/recover
+ * hooks live on Operation, so TDD's session-side recovery (when needed) belongs
+ * in the orchestrator, not here. Migration to true callOp ops is deferred per
+ * ADR-018 §5.3 amendment.
+ */
 ```
 
-Mirror for `implementTddOp` against the source file path the agent was instructed to write.
+### Step 6 — Inventory other Operation callers needing migration
 
-The exact field shape depends on each op's existing return type — verify/recover construct values that match `O` for that op.
+Grep for stage-side disk-recovery ladders (the anti-pattern Wave 3 removes):
 
-### Step 6 — Inventory other callers that may need migration
+```bash
+# Pattern: callOp result is null/empty, stage reads disk to recover
+rg "callOp\(" src/pipeline/stages/ src/execution/lifecycle/ -A 20 \
+  | grep -E "readFile|Bun.file|fileExists" \
+  | head -30
+```
 
-Grep for callers that currently use `callOp` and then perform manual disk-recovery. Likely sites:
+Check each match: if the stage reads disk after `callOp` to recover from null/empty parse output, that op is a migration candidate. The corresponding op gets `verify`/`recover`; the stage-side ladder is removed (mirroring Steps 3+4 for acceptance).
 
-- `src/operations/decompose.ts` — does the agent write JSON to disk? Check.
-- `src/operations/plan.ts` — same.
-- `src/review/*` — semantic/adversarial reviewers may or may not have side effects.
+**Known ops to inspect** (from `ls src/operations/`):
 
-For each: if the existing call site has a "after callOp, also read disk to confirm" pattern, that's a migration candidate. Migrate at the same time so the wave covers all known cases.
+| Op file | Side-effect? | Action |
+|:---|:---|:---|
+| `src/operations/acceptance-generate.ts` | Yes — agent writes test file | Migrated in Step 3 |
+| `src/operations/acceptance-fix.ts` | Likely — agent writes source/test files | Inspect; migrate if stage has Tier-recovery ladder |
+| `src/operations/acceptance-diagnose.ts` | No — diagnosis is read-only | Skip |
+| `src/operations/acceptance-refine.ts` | No — refinement output is in stdout | Skip |
+| `src/operations/decompose.ts` | No — output is structured JSON in stdout | Skip |
+| `src/operations/plan.ts` | No — output is structured JSON in stdout | Skip |
+| `src/operations/classify-route.ts` | No — output is enum in stdout | Skip |
+| `src/operations/rectify.ts` | Yes — agent applies code changes on disk | Inspect rectifier loop for disk-recovery; migrate if found |
+| `src/operations/debate-{propose,rebut}.ts` | No — debate output is text | Skip |
+| `src/operations/{semantic,adversarial}-review.ts` | No — review output is structured findings JSON | Skip |
+| `src/operations/write-test.ts`, `implement.ts`, `verify.ts` | Re-exports of TDD role tags — see Step 5 | Skip — out of scope |
 
-If unsure, leave the op un-migrated (verify/recover are optional — no behaviour change for ops that don't declare them).
+**Decision rule:** an op needs `verify`/`recover` iff (a) the agent writes files as side effects AND (b) those file writes are part of the op's deliverable. Read-only ops (diagnose, classify, debate-propose) don't need the hooks even if the agent reads files.
+
+For each candidate identified by the grep: if the migration is a 1:1 lift like Step 3, include it in this PR. If it requires more thought (e.g. multi-file artifacts, complex recovery), defer to a follow-up PR — the optional hooks make incremental migration safe.
 
 ### Step 7 — Update forbidden-patterns rule
 
@@ -298,7 +407,14 @@ End-to-end: invoke acceptance-setup with a stub agent that writes a valid test f
 
 ### `test/unit/operations/acceptance-generate.test.ts` (update)
 
-Add cases for the new `verify` and `recover` hooks on `acceptanceGenerateOp`. Mock `VerifyContext.readFile` / `fileExists` to simulate disk states.
+Add cases for the new `verify` hook on `acceptanceGenerateOp` (no `recover` per Step 3 — recovery is stage policy):
+
+- `verify` returns parsed unchanged when `parsed.testCode` is non-null
+- `verify` reads disk and returns extracted code when stdout was empty but disk has fenced content
+- `verify` returns disk content when fenced extraction fails but `hasLikelyTestContent` && `!isStubTestContent`
+- `verify` returns null when disk content is missing or stub-shaped
+
+Mock `VerifyContext.readFile`/`fileExists` via the `_acceptanceGenerateDeps` injection pattern (or per-test fakes if no DI seam exists yet — add one if not, ~5 LOC).
 
 ## Validation
 
@@ -331,5 +447,6 @@ Single PR. Revert restores the stage-side ladder and removes the optional `verif
 
 - Step 1 + 2 are pure additions (optional fields, optional hook execution). Land them first as a self-contained sub-PR if you want to keep the diff small.
 - Steps 3 + 4 (acceptance migration) are atomic — must land together to avoid duplicate recovery (op-level + stage-level).
-- Step 5 (TDD ops) can be a follow-up sub-PR; not required to land alongside acceptance.
-- Step 6 inventory + Step 7 docs land last after migrations stabilise.
+- Step 5 is an explicit no-op for TDD ops (they aren't full Operations); add the in-code TODO referencing this spec.
+- Step 6 inventory may surface follow-up migrations (e.g. rectify if it has a stage ladder); land those as separate small PRs after Steps 1–4 are stable.
+- Step 7 docs (forbidden-patterns row) lands with Step 4.


### PR DESCRIPTION
## Summary

Three handover-quality implementation specs at `docs/specs/adr-020-wave-{1,2,3}-*.md` — concrete enough for a remote agent to execute without further clarification.

## What's in each spec

Every spec contains: goal (what's true after merge), prerequisites, step-by-step file-level implementation with code snippets, test additions, validation criteria (including dogfood reruns), rollback strategy, risk + mitigation, and out-of-scope items.

### Wave 1 — Typed dispatch events at three boundaries + `SessionRole` SSOT

~300 LOC source, ~250 LOC tests, 12 steps. Closes #773.

- `SessionRole` typed union promoted to its own file with `KNOWN_SESSION_ROLES` const + `isSessionRole()` guard
- `DispatchEvent` (with `DispatchEventBase`) + `OperationCompletedEvent` types; `DispatchEventBus` lives on `NaxRuntime`
- Emission from `runAsSession`, `runTrackedSession` (the boundary missed in earlier drafts), `completeAs`
- `runAs` / `runWithFallback` envelopes emit only `OperationCompletedEvent`
- Audit + cost middleware rewritten as pure subscribers (`attachAuditSubscriber`, `attachCostSubscriber`); all `executeHop`/`sessionHandle`/`completeOptions` scrape paths deleted
- Tactical `sessionHint` field deleted; tactical patch's `audit-naming.test.ts` survives unchanged
- Validation: `tdd-calc` and `hello-lint` dogfood reruns; per-role audit filenames present; no `run-run-US-001*` files; acceptance file is `*-acceptance-gen-complete.txt` (D6 drift fix)

### Wave 2 — `DispatchContext` base + `wrapAdapterAsManager` gating

~165 LOC source, ~120 LOC tests, 8 steps. Closes the optional-`agentManager` bug class behind #783.

- `DispatchContext` interface with 4 required fields (`agentManager`, `sessionManager`, `runtime`, `abortSignal`)
- ~10 context types extend it (full file table); compile errors at every `?? wrapAdapterAsManager(...)` fallback site fixed in same PR
- `wrapAdapterAsManager` moved into `SingleSessionRunner` private scope as `wrapAdapterAsNoFallbackManager`, gated by `noFallback: true`
- Public export deleted; CI grep gate (`scripts/check-no-adapter-wrap.sh`) prevents reintroduction
- Raw `IAgentAdapter` helper signatures (the #783 root pattern) tightened to `IAgentManager`
- `fakeAgentManager` test-only helper at `test/helpers/fake-agent-manager.ts`
- `forbidden-patterns.md` row added

### Wave 3 — Side-effect-aware `Operation` contract

~200 LOC source, ~150 LOC tests, 7 steps. Closes the class behind #774; latent equivalents in TDD ops.

- `Operation.verify` and `Operation.recover` optional hooks; `VerifyContext<C>` is read-only (no writes, no agent calls)
- `callOp` runs `parse` → `verify` → `recover`
- `acceptanceGenerateOp` declares both; `acceptance-setup.ts:350-441` Tier-1/2/3 ladder deleted
- TDD `writeTddTestOp` and `implementTddOp` same pattern (agent writes file + replies conversationally)
- Stage retains policy-level skeleton fallback only; recovery moves into the op
- `forbidden-patterns.md` row added

## Sequencing

Specs assume:

1. Tactical patch from `docs/findings/2026-04-28-tdd-audit-naming-tactical.md` ships first (~22 LOC, fixes TDD audit names today; deleted in Wave 1)
2. Wave 1 lands next (deletes tactical, structural fix)
3. Wave 2 lands next (independent of Wave 1 from a code perspective; reviewer benefits from seeing audit/cost coverage already structurally guaranteed)
4. Wave 3 lands last (orthogonal to 1+2)

Each wave is a single PR and independently reversible. Total: ~665 LOC source + ~520 LOC tests across the three waves.

## Test plan

- [ ] Reviewers verify each spec is self-contained — no out-of-band context needed
- [ ] Spot-check that file paths and line references in the specs match current code
- [ ] Confirm validation criteria for each wave reference the right dogfood fixtures
- [ ] Docs-only change — pre-commit gates already green