### PR TITLE
fix(acp): track complete() PIDs and force-terminate sessions on Ctrl+C

### DIFF
--- a/.claude/rules/forbidden-patterns.md
+++ b/.claude/rules/forbidden-patterns.md
@@ -26,6 +26,7 @@ These patterns are **banned** from the nax codebase. Violations must be caught d
 | Resolving permissions outside `SessionManager.openSession` / `AgentManager.completeAs` | Pass `pipelineStage` upward; resource opener resolves once | ADR-019 §3 |
 | `wrapAdapterAsManager` (production or test imports from `src/agents/utils`) | `createRuntime(config, workdir).agentManager` for production; `fakeAgentManager(adapter)` for tests | ADR-020 §D3 — privatized; all dispatch must flow through the middleware chain |
 | `fakeAgentManager` in `src/` production code | `createRuntime(config, workdir).agentManager` | Test-only helper (see Test-Only Helpers below) |
+| Passing `undefined` (or omitting) `onPidSpawned` when constructing an ACP client / opening a session / building `AgentRunOptions` / `CompleteOptions` | Forward the runtime's callback: `onPidSpawned: ctx.runtime.onPidSpawned` (ops via `callOp`) or `(pid) => pidRegistry.register(pid)` (pipeline stages with direct registry access) | Untracked acpx subprocesses orphan past run teardown — Ctrl+C leaves zombie acpx + agent server processes. Issue #792, commit `e65e78b9`. |
 
 ## Prompt Builder Convention
 

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -177,11 +177,16 @@ export class AcpAgentAdapter implements AgentAdapter {
       const cmdStr = `acpx --model ${model} ${agentName}`;
       const timeoutSeconds = Math.ceil(timeoutMs / 1000);
       const promptRetries = _options?.config?.agent?.acp?.promptRetries;
-      const client = _acpAdapterDeps.createClient(cmdStr, workdir, timeoutSeconds, undefined, promptRetries);
+      const client = _acpAdapterDeps.createClient(
+        cmdStr,
+        workdir,
+        timeoutSeconds,
+        _options?.onPidSpawned,
+        promptRetries,
+      );
       await client.start();
 
       let session: import("./adapter-session-types").AcpSession | null = null;
-      let hadError = false;
       try {
         const completeSessionName =
           _options?.sessionName ??
@@ -247,12 +252,13 @@ export class AcpAgentAdapter implements AgentAdapter {
           costUsd: 0,
           source: "fallback",
         };
-      } catch (err) {
-        hadError = true;
-        throw err;
       } finally {
         if (session) {
-          await session.close({ forceTerminate: hadError }).catch(() => {});
+          // Always force-terminate on the complete-path: each complete() opens its
+          // own session and never reuses it, so the queue-owner has no work to amortize.
+          // Graceful close leaves the queue-owner alive until TTL — long enough to be
+          // orphaned if the user quits nax (or hits Ctrl+C) before the TTL elapses.
+          await session.close({ forceTerminate: true }).catch(() => {});
         }
         await client.close().catch(() => {});
       }

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -259,6 +259,13 @@ export interface CompleteOptions {
    * Defaults to "complete" when not provided.
    */
   pipelineStage?: import("../config/permissions").PipelineStage;
+  /**
+   * PID registration callback for crash-recovery bookkeeping. Mirrors the run-path
+   * `OpenSessionOpts.onPidSpawned`. Without this, complete-path acpx invocations
+   * (plan, decompose, classify-route, acceptance-generate, debate-*) leak their
+   * PIDs past PidRegistry — `Ctrl+C` mid-call leaves orphan acpx subprocesses.
+   */
+  onPidSpawned?: (pid: number) => void;
 }
 
 /**

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -184,6 +184,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     sessionManager,
     agentManager: options.agentManager,
     featureName: options.feature,
+    onPidSpawned: (pid: number) => pidRegistry.register(pid),
   });
 
   // Cleanup stale PIDs from previous crashed runs

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -67,6 +67,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       storyId: ctx.storyId,
       workdir: ctx.packageDir,
       featureName: ctx.featureName,
+      onPidSpawned: ctx.runtime.onPidSpawned,
     });
     return op.parse(raw.output, input, buildCtx);
   }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -69,6 +69,14 @@ export interface NaxRuntime {
   readonly packages: PackageRegistry;
   readonly logger: Logger;
   readonly signal: AbortSignal;
+  /**
+   * Optional PID registration callback used by complete-path adapter calls
+   * (plan, decompose, classify-route, acceptance-generate, debate-*) so any
+   * acpx subprocess they spawn lands on the run's PidRegistry. Without it
+   * Ctrl+C mid-call leaves orphan acpx subprocesses (and their queue-owner
+   * children) past run teardown.
+   */
+  readonly onPidSpawned?: (pid: number) => void;
   close(): Promise<void>;
 }
 
@@ -84,6 +92,13 @@ export interface CreateRuntimeOptions {
    * promptAuditor is provided.
    */
   featureName?: string;
+  /**
+   * PID registration callback. Threaded into complete-path adapter calls via
+   * `callOp` so plan/decompose/etc. acpx invocations are tracked by the run's
+   * PidRegistry. Run-path callers (execution stage, cli/plan) wire their own
+   * callback directly into `AgentRunOptions` and do not depend on this field.
+   */
+  onPidSpawned?: (pid: number) => void;
 }
 
 export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateRuntimeOptions): NaxRuntime {
@@ -169,6 +184,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     get signal() {
       return controller.signal;
     },
+    onPidSpawned: opts?.onPidSpawned,
     async close() {
       if (closed) return;
       closed = true;

--- a/test/unit/agents/acp/adapter.test.ts
+++ b/test/unit/agents/acp/adapter.test.ts
@@ -29,7 +29,7 @@ export interface AcpSessionResponse {
 
 export interface MockAcpSession {
   prompt(text: string): Promise<AcpSessionResponse>;
-  close(): Promise<void>;
+  close(opts?: { forceTerminate?: boolean }): Promise<void>;
   cancelActivePrompt(): Promise<void>;
 }
 
@@ -47,7 +47,7 @@ export interface MockAcpClient {
 
 export function makeSession(overrides: {
   promptFn?: (text: string) => Promise<AcpSessionResponse>;
-  closeFn?: () => Promise<void>;
+  closeFn?: (opts?: { forceTerminate?: boolean }) => Promise<void>;
   cancelFn?: () => Promise<void>;
 } = {}): MockAcpSession {
   return {
@@ -261,6 +261,50 @@ describe("complete()", () => {
     await expect(
       new AcpAgentAdapter("claude").complete("Unknown fail", { workdir: ACP_WORKDIR }),
     ).rejects.toThrow(/unexpected internal error/);
+  });
+
+  // SIGINT-orphan fix — see docs/findings/2026-04-29-sigint-cleanup-rectification-and-adversarial-loops.md
+  test("forwards onPidSpawned from CompleteOptions to createClient", async () => {
+    let capturedOnPidSpawned: ((pid: number) => void) | undefined;
+    const session = makeSession();
+    _acpAdapterDeps.createClient = mock(
+      (_cmd: string, _cwd: string, _timeout?: number, onPidSpawned?: (pid: number) => void) => {
+        capturedOnPidSpawned = onPidSpawned;
+        return makeClient(session) as unknown as ReturnType<typeof _acpAdapterDeps.createClient>;
+      },
+    );
+
+    const tracker = mock((_pid: number) => {});
+    await new AcpAgentAdapter("claude").complete("track-me", {
+      workdir: ACP_WORKDIR,
+      onPidSpawned: tracker,
+    });
+    expect(capturedOnPidSpawned).toBe(tracker);
+  });
+
+  test("force-terminates the session on successful completion (kills queue-owner)", async () => {
+    let capturedCloseOpts: { forceTerminate?: boolean } | undefined;
+    const session = makeSession({
+      closeFn: async (opts) => { capturedCloseOpts = opts; },
+    });
+    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
+
+    await new AcpAgentAdapter("claude").complete("hello", { workdir: ACP_WORKDIR });
+    expect(capturedCloseOpts?.forceTerminate).toBe(true);
+  });
+
+  test("force-terminates the session on error path as well", async () => {
+    let capturedCloseOpts: { forceTerminate?: boolean } | undefined;
+    const session = makeSession({
+      promptFn: async (_: string) => ({ messages: [], stopReason: "error" }),
+      closeFn: async (opts) => { capturedCloseOpts = opts; },
+    });
+    _acpAdapterDeps.createClient = mock((_cmd: string) => makeClient(session));
+
+    await expect(
+      new AcpAgentAdapter("claude").complete("fail", { workdir: ACP_WORKDIR }),
+    ).rejects.toBeInstanceOf(CompleteError);
+    expect(capturedCloseOpts?.forceTerminate).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes orphan acpx + agent-server processes after Ctrl+C on `nax plan` (and any other complete-path op: decompose, classify-route, acceptance-generate, debate-*).

Two root causes, both at the complete-path adapter boundary:

- **A.** `adapter.complete()` constructed the ACP client with `onPidSpawned: undefined`, so spawned acpx PIDs never landed on the run's `PidRegistry`. The run-path (`openSession`) already forwarded the callback — only `complete()` was dropping it.
- **B.** `complete()` closed its session gracefully, leaving the acpx queue-owner alive until its TTL. Since each `complete()` opens a fresh session and never reuses it, there is no work to amortize — the queue-owner just sits orphaned long enough to outlive a Ctrl+C.

### Wiring chain

`createRuntime` now accepts `onPidSpawned`; `run-setup.ts` wires it from the run's `PidRegistry`; `callOp` forwards `ctx.runtime.onPidSpawned` into `CompleteOptions`; the adapter forwards it into `createClient`.

### Anti-pattern rule

Added a single row to `.claude/rules/forbidden-patterns.md` so this regression can't return silently — drops or omissions of `onPidSpawned` at the adapter boundary are now a flagged forbidden pattern.

### Out of scope

Cleanup of long-lived queue-owners spawned by background ops (separate Bug 1c) is tracked in #792. That track requires acpx-side investigation of queue-owner lifecycle and is independent of this fix.

## Test plan

- [x] New unit tests in `test/unit/agents/acp/adapter.test.ts`:
  - forwards `onPidSpawned` from `CompleteOptions` to `createClient`
  - force-terminates the session on success path (kills queue-owner)
  - force-terminates the session on error path
- [ ] Manual: `nax plan` then Ctrl+C — verify no orphan `acpx` / `codex-acp` / `opencode-ai` processes remain (`pgrep -af acpx`).
- [ ] Manual: full `nax run` — verify implementer / test-writer / acceptance-generation flows still terminate cleanly (no regression on the run-path).