### PR TITLE
feat(adr-020): Wave 3 — VerifyContext + verify/recover hooks + acceptanceGenerateOp disk recovery

### DIFF
--- a/.claude/rules/forbidden-patterns.md
+++ b/.claude/rules/forbidden-patterns.md
@@ -26,6 +26,7 @@ These patterns are **banned** from the nax codebase. Violations must be caught d
 | Resolving permissions outside `SessionManager.openSession` / `AgentManager.completeAs` | Pass `pipelineStage` upward; resource opener resolves once | ADR-019 §3 |
 | `wrapAdapterAsManager` (production or test imports from `src/agents/utils`) | `createRuntime(config, workdir).agentManager` for production; `fakeAgentManager(adapter)` for tests | ADR-020 §D3 — privatized; all dispatch must flow through the middleware chain |
 | `fakeAgentManager` in `src/` production code | `createRuntime(config, workdir).agentManager` | Test-only helper (see Test-Only Helpers below) |
+| Manual disk-recovery ladder in pipeline stages after `callOp` (reading disk to recover null/empty parse output — Tier-1/2/3 patterns) | Declare `verify`/`recover` on the op | Recovery logic belongs with the op (one place to maintain), not duplicated in every stage that calls it. ADR-020 §D4. |
 
 ## Prompt Builder Convention
 

--- a/scripts/check-dispatch-context.sh
+++ b/scripts/check-dispatch-context.sh
@@ -5,17 +5,18 @@ set -euo pipefail
 
 bun x tsc --project tsconfig.dispatch-context.json --noEmit
 
-MATCHES=$(grep -rnE "agentManager\\?[[:space:]]*:[[:space:]]*(import\\(.+\\)\\.)?IAgentManager" src/ --include="*.ts" | while IFS= read -r line; do
-  case "$line" in
-    src/runtime/index.ts:*) ;;
-    src/execution/runner-setup.ts:*) ;;
-    src/execution/lifecycle/run-setup.ts:*) ;;
-    src/execution/parallel-coordinator.ts:*) ;;
-    src/review/runner.ts:*) ;;
-    src/review/orchestrator.ts:*) ;;
-    *) echo "$line" ;;
-  esac
-done || true)
+# grep -v chains to exclude known-allowlisted files.
+# Uses portable grep -v instead of a case statement inside $() to avoid
+# a bash 3.2 (macOS default) syntax error with empty case arms in multi-line
+# command substitutions.
+MATCHES=$(grep -rnE "agentManager\?[[:space:]]*:[[:space:]]*(import\(.+\)\.)?IAgentManager" src/ --include="*.ts" \
+  | grep -v "^src/runtime/index\.ts:" \
+  | grep -v "^src/execution/runner-setup\.ts:" \
+  | grep -v "^src/execution/lifecycle/run-setup\.ts:" \
+  | grep -v "^src/execution/parallel-coordinator\.ts:" \
+  | grep -v "^src/review/runner\.ts:" \
+  | grep -v "^src/review/orchestrator\.ts:" \
+  || true)
 
 if [ -n "$MATCHES" ]; then
   echo "ERROR: optional agentManager found in dispatch-time source:"

--- a/src/acceptance/generator.ts
+++ b/src/acceptance/generator.ts
@@ -11,6 +11,7 @@ import { getLogger } from "../logger";
 import type { UserStory } from "../prd/types";
 import { AcceptancePromptBuilder } from "../prompts/builders/acceptance-builder";
 import { extractTestCode, generateSkeletonTests } from "./generator-helpers";
+import { hasLikelyTestContent } from "./heuristics";
 import {
   acceptanceTestFilename as defaultAcceptanceTestFilename,
   resolveAcceptanceTestFile as defaultResolveAcceptanceTestFile,
@@ -62,15 +63,6 @@ export const _generatorPRDDeps = {
     await Bun.write(path, content);
   },
 };
-
-function hasLikelyTestContent(content: string): boolean {
-  return (
-    /\b(?:describe|test|it|expect)\s*\(/.test(content) ||
-    /func\s+Test\w+\s*\(/.test(content) ||
-    /def\s+test_\w+/.test(content) ||
-    /#\[test\]/.test(content)
-  );
-}
 
 export const acceptanceTestFilename = defaultAcceptanceTestFilename;
 export const resolveAcceptanceTestFile = defaultResolveAcceptanceTestFile;

--- a/src/acceptance/heuristics.ts
+++ b/src/acceptance/heuristics.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared heuristics for detecting test file content.
+ *
+ * Single source of truth consolidated from acceptance-setup stage and
+ * acceptance/generator.ts. See ADR-020 Wave 3 Step 3.
+ */
+
+/** Returns true when content looks like a test file (language-agnostic). */
+export function hasLikelyTestContent(content: string): boolean {
+  return (
+    /\b(?:describe|test|it|expect)\s*\(/.test(content) ||
+    /func\s+Test\w+\s*\(/.test(content) ||
+    /def\s+test_\w+/.test(content) ||
+    /#\[test\]/.test(content)
+  );
+}
+
+/**
+ * Returns true when content appears to be a skeleton stub test (placeholder
+ * assertions only, no real test logic). Mirrors isStubTestFile in
+ * src/execution/lifecycle/acceptance-helpers.ts — both must stay aligned.
+ */
+export function isStubTestContent(content: string): boolean {
+  if (!/expect\s*\(\s*true\s*\)\s*\.\s*toBe\s*\(\s*(?:false|true)\s*\)/.test(content)) return false;
+  return !/expect\s*\(\s*(?!(?:true|false)\b)[^\s)]/.test(content);
+}

--- a/src/execution/lifecycle/acceptance-helpers.ts
+++ b/src/execution/lifecycle/acceptance-helpers.ts
@@ -7,6 +7,7 @@
  */
 
 import path from "node:path";
+import { isStubTestContent } from "../../acceptance/heuristics";
 import { getSafeLogger } from "../../logger";
 import type { PipelineContext } from "../../pipeline/types";
 import type { PRD } from "../../prd/types";
@@ -15,12 +16,9 @@ import type { AcceptanceLoopResult } from "./acceptance-loop";
 
 // ─── Stub detection ─────────────────────────────────────────────────────────
 
+/** @alias isStubTestContent — preserved for callers within this subsystem. */
 export function isStubTestFile(content: string): boolean {
-  // Must have a placeholder assertion to be a candidate stub
-  if (!/expect\s*\(\s*true\s*\)\s*\.\s*toBe\s*\(\s*(?:false|true)\s*\)/.test(content)) return false;
-  // Not a stub if real (non-boolean) assertions exist — e.g. expect(result).toBe(3).
-  // [^\s)] anchors to a real non-whitespace arg; \b prevents matching truthy/falsy-prefixed names.
-  return !/expect\s*\(\s*(?!(?:true|false)\b)[^\s)]/.test(content);
+  return isStubTestContent(content);
 }
 
 // ─── Test-level failure detection ───────────────────────────────────────────

--- a/src/operations/acceptance-generate.ts
+++ b/src/operations/acceptance-generate.ts
@@ -1,4 +1,5 @@
 import { extractTestCode } from "../acceptance/generator";
+import { hasLikelyTestContent, isStubTestContent } from "../acceptance/heuristics";
 import { acceptanceConfigSelector } from "../config";
 import { AcceptancePromptBuilder } from "../prompts";
 import type { CompleteOperation } from "./types";
@@ -44,5 +45,26 @@ export const acceptanceGenerateOp: CompleteOperation<
   },
   parse(output, _input, _ctx) {
     return { testCode: extractTestCode(output) };
+  },
+  async verify(parsed, input, ctx) {
+    // Stdout had real test code → accept as-is.
+    if (parsed.testCode !== null) return parsed;
+
+    // ACP agents write the test file as a tool-call side effect and return a
+    // conversational summary. Check whether the agent wrote a valid file.
+    const diskContent = await ctx.readFile(input.targetTestFilePath);
+    if (diskContent === null) return null;
+
+    // Tier 1: agent embedded a fenced code block inside the file.
+    const extracted = extractTestCode(diskContent);
+    if (extracted && !isStubTestContent(extracted)) return { testCode: extracted };
+
+    // Tier 2: disk content looks like real test source.
+    if (hasLikelyTestContent(diskContent) && !isStubTestContent(diskContent)) {
+      return { testCode: diskContent };
+    }
+
+    // Tier 3 (skeleton fallback) is a stage-level policy decision — not op concern.
+    return null;
   },
 };

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -5,7 +5,7 @@ import { NaxError } from "../errors";
 import type { UserStory } from "../prd";
 import { composeSections, join } from "../prompts/compose";
 import { buildHopCallback } from "./build-hop-callback";
-import type { CallContext, CompleteOperation, Operation, RunOperation } from "./types";
+import type { BuildContext, CallContext, CompleteOperation, Operation, RunOperation, VerifyContext } from "./types";
 
 function normalizeSelector<C>(s: ConfigSelector<C> | readonly (keyof NaxConfig)[], opName: string): ConfigSelector<C> {
   if (Array.isArray(s)) {
@@ -68,7 +68,8 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       workdir: ctx.packageDir,
       featureName: ctx.featureName,
     });
-    return op.parse(raw.output, input, buildCtx);
+    const parsedComplete = op.parse(raw.output, input, buildCtx);
+    return runPostParse(op, parsedComplete, input, buildCtx);
   }
 
   // kind:"run" — ADR-019 §5: route through runWithFallback + buildHopCallback.
@@ -145,5 +146,57 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       agentName: dispatchAgent,
     });
   }
-  return op.parse(rawOutput, input, buildCtx);
+  const parsedRun = op.parse(rawOutput, input, buildCtx);
+  return runPostParse(op, parsedRun, input, buildCtx);
+}
+
+async function runPostParse<I, O, C>(
+  op: Operation<I, O, C>,
+  parsed: O,
+  input: I,
+  buildCtx: BuildContext<C>,
+): Promise<O> {
+  if (!op.verify && !op.recover) return parsed;
+
+  const verifyCtx: VerifyContext<C> = {
+    packageView: buildCtx.packageView,
+    config: buildCtx.config,
+    readFile: async (p) => {
+      try {
+        return await Bun.file(p).text();
+      } catch {
+        return null;
+      }
+    },
+    fileExists: async (p) => Bun.file(p).exists(),
+  };
+
+  let final: O | null = parsed;
+
+  if (op.verify) {
+    final = await op.verify(parsed, input, verifyCtx);
+  }
+
+  if (final === null && op.recover) {
+    final = await op.recover(input, verifyCtx);
+  }
+
+  return (final ?? parsed) as O;
+}
+
+/**
+ * Exported for unit testing only — exercises runPostParse without a full callOp setup.
+ * Accepts a structural subtype of Operation (only verify/recover needed) and casts
+ * internally. Safe because runPostParse only reads verify and recover from op.
+ */
+export async function _runPostParseForTest<I, O, C>(
+  op: {
+    readonly verify?: (parsed: O, input: I, ctx: VerifyContext<C>) => Promise<O | null>;
+    readonly recover?: (input: I, ctx: VerifyContext<C>) => Promise<O | null>;
+  },
+  parsed: O,
+  input: I,
+  buildCtx: BuildContext<C>,
+): Promise<O> {
+  return runPostParse(op as unknown as Operation<I, O, C>, parsed, input, buildCtx);
 }

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,4 +1,4 @@
-export { callOp } from "./call";
+export { callOp, _runPostParseForTest } from "./call";
 export { planOp } from "./plan";
 export type { PlanOpInput } from "./plan";
 export { decomposeOp } from "./decompose";
@@ -32,6 +32,7 @@ export type {
   LlmReviewFinding,
   Operation,
   RunOperation,
+  VerifyContext,
 } from "./types";
 export { writeTddTestOp } from "./write-test";
 export type { TddRunOp } from "./write-test";

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -55,6 +55,35 @@ interface OperationBase<I, O, C> {
    * Migration Anti-Patterns AP-3.
    */
   readonly parse: (output: string, input: I, ctx: BuildContext<C>) => O;
+  /**
+   * Optional. Validate parsed output against on-disk artifacts. Returning
+   * non-null wins; returning null means "parsed output insufficient — fall
+   * through to recover (if defined) or return the original parsed value".
+   *
+   * Use when the agent's contract is "stdout has the answer, but disk has
+   * the canonical artifact" (e.g. ACP test-writer: stdout is conversational,
+   * disk has the test file). See ADR-020 §D4.
+   */
+  readonly verify?: (parsed: O, input: I, ctx: VerifyContext<C>) => Promise<O | null>;
+  /**
+   * Optional. Recover output from on-disk artifacts when parse + verify
+   * both produced "no useful result." Last resort before the caller sees
+   * the null/empty value. See ADR-020 §D4.
+   */
+  readonly recover?: (input: I, ctx: VerifyContext<C>) => Promise<O | null>;
+}
+
+/**
+ * Read-only context for verify/recover hooks. Mirrors BuildContext<C>'s narrow
+ * surface plus filesystem reads. No agent calls, no writes, no runtime
+ * mutation — both hooks operate on disk artifacts the agent may have
+ * produced as side effects.
+ *
+ * @see docs/adr/ADR-020-dispatch-boundary-ssot.md §D4
+ */
+export interface VerifyContext<C> extends BuildContext<C> {
+  readonly readFile: (path: string) => Promise<string | null>;
+  readonly fileExists: (path: string) => Promise<boolean>;
 }
 
 /**

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -21,7 +21,7 @@
  */
 
 import path from "node:path";
-import { buildAcceptanceRunCommand, extractTestCode, generateSkeletonTests } from "../../acceptance/generator";
+import { buildAcceptanceRunCommand, generateSkeletonTests } from "../../acceptance/generator";
 import { groupStoriesByPackage } from "../../acceptance/test-path";
 import type { AcceptanceCriterion, RefinedCriterion } from "../../acceptance/types";
 import type { AgentAdapter } from "../../agents/types";
@@ -32,24 +32,10 @@ import { getSafeLogger } from "../../logger";
 import { acceptanceGenerateOp } from "../../operations/acceptance-generate";
 import { acceptanceRefineOp } from "../../operations/acceptance-refine";
 import { callOp as _callOp } from "../../operations/call";
-import { errorMessage } from "../../utils/errors";
 import { autoCommitIfDirty as _autoCommitIfDirty } from "../../utils/git";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 // ─── Local helpers ──────────────────────────────────────────────────────────
-
-/**
- * Returns true when the content looks like a test file.
- * Mirrors the check in generator.ts without creating a circular import.
- */
-function hasLikelyTestContent(content: string): boolean {
-  return (
-    /\b(?:describe|test|it|expect)\s*\(/.test(content) ||
-    /func\s+Test\w+\s*\(/.test(content) ||
-    /def\s+test_\w+/.test(content) ||
-    /#\[test\]/.test(content)
-  );
-}
 
 /**
  * Metadata stored alongside the acceptance test file.
@@ -347,96 +333,28 @@ export const acceptanceSetupStage: PipelineStage = {
           groupStoryId,
         )) as { testCode: string | null };
 
-        let testCode = genResult.testCode;
-        if (!testCode) {
-          // ACP agents write the file via tool calls and return only a conversational
-          // summary, so extractTestCode(rawOutput) returns null. Before falling back
-          // to a skeleton, attempt 3-tier recovery from the on-disk file:
-          //
-          //   Tier 1 — extractTestCode(existing): agent embedded a fenced code block
-          //            inside the file → use the extracted block as testCode.
-          //   Tier 2 — hasLikelyTestContent(existing): file looks like test source
-          //            (describe/test/expect calls) → backup to .llm-recovery.bak
-          //            and preserve the full file.
-          //   Tier 3 — file exists but is unrecognised → backup + log error + fall
-          //            through to skeleton.
-          const backupPath = `${testPath}.llm-recovery.bak`;
-          if (await _acceptanceSetupDeps.fileExists(testPath)) {
-            try {
-              const existing = await _acceptanceSetupDeps.readFile(testPath);
-
-              // Tier 1: re-parse the on-disk file for a fenced code block.
-              const extracted = extractTestCode(existing);
-              if (extracted) {
-                testCode = extracted;
-                getSafeLogger()?.info(
-                  "acceptance-setup",
-                  "Agent wrote fenced code block to disk — using extracted code",
-                  { storyId: groupStoryId, testPath },
-                );
-              } else if (existing.trim().length > 0 && hasLikelyTestContent(existing)) {
-                // Tier 2: file looks like a test file — backup and preserve as-is.
-                let backupCreated = false;
-                try {
-                  await _acceptanceSetupDeps.writeFile(backupPath, existing);
-                  backupCreated = true;
-                } catch (backupErr) {
-                  getSafeLogger()?.warn(
-                    "acceptance-setup",
-                    "Failed to create .llm-recovery.bak — preserving agent file anyway",
-                    { storyId: groupStoryId, testPath, backupPath, error: errorMessage(backupErr) },
-                  );
-                }
-                testCode = existing;
-                getSafeLogger()?.info(
-                  "acceptance-setup",
-                  "Agent wrote acceptance test directly — preserving file with backup",
-                  { storyId: groupStoryId, testPath, backupPath, backupCreated },
-                );
-              } else {
-                // Tier 3: file exists but is not recognisable test code — backup + skeleton.
-                if (existing.trim().length > 0) {
-                  try {
-                    await _acceptanceSetupDeps.writeFile(backupPath, existing);
-                  } catch (backupErr) {
-                    getSafeLogger()?.warn(
-                      "acceptance-setup",
-                      "Failed to create .llm-recovery.bak for unrecognised file",
-                      { storyId: groupStoryId, testPath, backupPath, error: errorMessage(backupErr) },
-                    );
-                  }
-                }
-                getSafeLogger()?.error(
-                  "acceptance-setup",
-                  "Agent-written file not recognised as test code — falling back to skeleton",
-                  { storyId: groupStoryId, testPath, backupPath, fileSize: existing.length },
-                );
-              }
-            } catch (err) {
-              getSafeLogger()?.warn(
-                "acceptance-setup",
-                "Failed to read agent-written file — falling back to skeleton",
-                { storyId: groupStoryId, testPath, error: errorMessage(err) },
-              );
-            }
-          }
-
-          if (!testCode) {
-            const skeletonCriteria: AcceptanceCriterion[] = groupRefined.map((c, i) => ({
-              id: `AC-${i + 1}`,
-              text: c.refined,
-              lineNumber: i + 1,
-            }));
-            testCode = generateSkeletonTests(
-              featureName,
-              skeletonCriteria,
-              ctx.config.acceptance.testFramework,
-              language,
-            );
-          }
-        }
+        // verify+recover already ran inside callOp (ADR-020 Wave 3).
+        const testCode = genResult.testCode;
         if (testCode) {
           await _acceptanceSetupDeps.writeFile(testPath, testCode);
+        } else {
+          // Stage decision: op exhausted recovery — fall back to skeleton.
+          const skeletonCriteria: AcceptanceCriterion[] = groupRefined.map((c, i) => ({
+            id: `AC-${i + 1}`,
+            text: c.refined,
+            lineNumber: i + 1,
+          }));
+          const skeletonCode = generateSkeletonTests(
+            featureName,
+            skeletonCriteria,
+            ctx.config.acceptance.testFramework,
+            language,
+          );
+          await _acceptanceSetupDeps.writeFile(testPath, skeletonCode);
+          getSafeLogger()?.warn("acceptance-setup", "agent did not produce test content; using skeleton", {
+            storyId: groupStoryId,
+            testPath,
+          });
         }
       }
 

--- a/src/tdd/session-op.ts
+++ b/src/tdd/session-op.ts
@@ -1,3 +1,10 @@
+/**
+ * TDD ops are minimal role tags consumed by runTddSession (src/tdd/session-runner.ts),
+ * not full Operation<I, O, C> shapes. See ADR-020 Wave 3 §Step 5 — verify/recover
+ * hooks live on Operation, so TDD's session-side recovery (when needed) belongs
+ * in the orchestrator, not here. Migration to true callOp ops is deferred per
+ * ADR-018 §5.3 amendment.
+ */
 import type { AgentAdapter } from "../agents";
 import type { ModelTier, NaxConfig } from "../config";
 import type { ContextBundle } from "../context/engine";

--- a/test/integration/acceptance/agent-file-recovery.test.ts
+++ b/test/integration/acceptance/agent-file-recovery.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Integration test: verify hook recovers agent-written test files (ADR-020 Wave 3 / bug #774)
+ *
+ * ACP agents write the test file as a tool-call side effect and return a
+ * conversational summary. The verify hook on acceptanceGenerateOp detects this
+ * pattern and recovers the file content so the caller receives real testCode
+ * instead of null (which would trigger the skeleton fallback in acceptance-setup).
+ *
+ * Test coverage:
+ *   1. Agent writes real test file + returns conversational stdout → verify recovers it
+ *   2. Agent writes stub test file + returns conversational stdout → verify returns null
+ *   3. Agent returns conversational stdout, no file written → verify returns null
+ */
+
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { acceptanceGenerateOp, callOp } from "../../../src/operations";
+import type { AcceptanceGenerateInput, CallContext } from "../../../src/operations";
+import { makeMockAgentManager, makeTestRuntime } from "../../helpers";
+import { withTempDir } from "../../helpers/temp";
+
+const REAL_TEST_CODE = `import { describe, test, expect } from "bun:test";
+describe("test-feature - Acceptance Tests", () => {
+  test("AC-1: do X", () => {
+    expect(1 + 1).toBe(2);
+  });
+});
+`;
+
+const STUB_TEST_CODE = `import { describe, test, expect } from "bun:test";
+describe("test-feature - Acceptance Tests", () => {
+  test("AC-1: do X", () => {
+    expect(true).toBe(false);
+  });
+});
+`;
+
+const CONVERSATIONAL_OUTPUT =
+  "I have written the acceptance tests to the target file. The tests cover all specified ACs.";
+
+describe("acceptanceGenerateOp.verify — agent-file recovery (bug #774)", () => {
+  test("agent writes real test file to disk + returns conversational stdout — verify recovers file", async () => {
+    await withTempDir(async (dir) => {
+      const testFilePath = join(dir, "test-feature.nax-acceptance.test.ts");
+
+      const agentManager = makeMockAgentManager({
+        completeAsFn: async () => {
+          await Bun.write(testFilePath, REAL_TEST_CODE);
+          return { output: CONVERSATIONAL_OUTPUT, costUsd: 0, source: "exact" as const };
+        },
+      });
+      const runtime = makeTestRuntime({ agentManager, workdir: dir });
+      const ctx: CallContext = {
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: dir,
+        agentName: "claude",
+        storyId: "US-001",
+        featureName: "test-feature",
+      };
+      const input: AcceptanceGenerateInput = {
+        featureName: "test-feature",
+        criteriaList: "AC-1: do X",
+        frameworkOverrideLine: "",
+        targetTestFilePath: testFilePath,
+      };
+
+      const result = await callOp(ctx, acceptanceGenerateOp, input);
+
+      expect(result.testCode).not.toBeNull();
+      expect(result.testCode).toContain("describe");
+      expect(result.testCode).not.toContain("expect(true).toBe(false)");
+    });
+  });
+
+  test("agent writes stub test file to disk + returns conversational stdout — verify returns null", async () => {
+    await withTempDir(async (dir) => {
+      const testFilePath = join(dir, "test-feature.nax-acceptance.test.ts");
+
+      const agentManager = makeMockAgentManager({
+        completeAsFn: async () => {
+          await Bun.write(testFilePath, STUB_TEST_CODE);
+          return { output: CONVERSATIONAL_OUTPUT, costUsd: 0, source: "exact" as const };
+        },
+      });
+      const runtime = makeTestRuntime({ agentManager, workdir: dir });
+      const ctx: CallContext = {
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: dir,
+        agentName: "claude",
+        storyId: "US-001",
+        featureName: "test-feature",
+      };
+      const input: AcceptanceGenerateInput = {
+        featureName: "test-feature",
+        criteriaList: "AC-1: do X",
+        frameworkOverrideLine: "",
+        targetTestFilePath: testFilePath,
+      };
+
+      const result = await callOp(ctx, acceptanceGenerateOp, input);
+
+      expect(result.testCode).toBeNull();
+    });
+  });
+
+  test("agent returns conversational stdout with no file written — verify returns null", async () => {
+    await withTempDir(async (dir) => {
+      const testFilePath = join(dir, "test-feature.nax-acceptance.test.ts");
+
+      const agentManager = makeMockAgentManager({
+        completeAsFn: async () => ({ output: CONVERSATIONAL_OUTPUT, costUsd: 0, source: "exact" as const }),
+      });
+      const runtime = makeTestRuntime({ agentManager, workdir: dir });
+      const ctx: CallContext = {
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: dir,
+        agentName: "claude",
+        storyId: "US-001",
+        featureName: "test-feature",
+      };
+      const input: AcceptanceGenerateInput = {
+        featureName: "test-feature",
+        criteriaList: "AC-1: do X",
+        frameworkOverrideLine: "",
+        targetTestFilePath: testFilePath,
+      };
+
+      const result = await callOp(ctx, acceptanceGenerateOp, input);
+
+      expect(result.testCode).toBeNull();
+    });
+  });
+});

--- a/test/unit/operations/acceptance-generate.test.ts
+++ b/test/unit/operations/acceptance-generate.test.ts
@@ -138,9 +138,19 @@ describe("acceptanceGenerateOp.verify()", () => {
     expect(result).toBeNull();
   });
 
-  test("returns null when disk content is stub-shaped", async () => {
+  test("returns null when disk content is stub-shaped (raw, no fence)", async () => {
     const stubCode = "describe('x', () => { test('y', () => expect(true).toBe(false)); });";
     const ctx = makeVerifyCtx({ readFile: async () => stubCode });
+    const result = await acceptanceGenerateOp.verify!({ testCode: null }, SAMPLE_INPUT, ctx);
+    expect(result).toBeNull();
+  });
+
+  test("Tier 1: returns null when fenced block contains stub-shaped code (stub guard)", async () => {
+    // extractTestCode extracts the content inside the fence — but since it's
+    // stub-shaped the Tier-1 guard (!isStubTestContent) must reject it.
+    const fencedStub =
+      "```typescript\ndescribe('x', () => { test('y', () => expect(true).toBe(false)); });\n```";
+    const ctx = makeVerifyCtx({ readFile: async () => fencedStub });
     const result = await acceptanceGenerateOp.verify!({ testCode: null }, SAMPLE_INPUT, ctx);
     expect(result).toBeNull();
   });

--- a/test/unit/operations/acceptance-generate.test.ts
+++ b/test/unit/operations/acceptance-generate.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { makeTestRuntime } from "../../helpers";
-import type { AcceptanceGenerateInput } from "../../../src/operations/acceptance-generate";
+import { join } from "node:path";
 import { acceptanceGenerateOp } from "../../../src/operations/acceptance-generate";
+import type { AcceptanceGenerateInput } from "../../../src/operations/acceptance-generate";
+import type { VerifyContext } from "../../../src/operations/types";
+import { makeTestRuntime } from "../../helpers";
+import { withTempDir } from "../../helpers/temp";
 
 const SAMPLE_INPUT: AcceptanceGenerateInput = {
   featureName: "my-feature",
@@ -14,6 +17,20 @@ function makeBuildCtx() {
   const runtime = makeTestRuntime();
   const view = runtime.packages.repo();
   return { packageView: view, config: view.select(acceptanceGenerateOp.config) };
+}
+
+function makeVerifyCtx(overrides: {
+  readFile?: (path: string) => Promise<string | null>;
+  fileExists?: (path: string) => Promise<boolean>;
+} = {}): VerifyContext<ReturnType<typeof acceptanceGenerateOp.config.select>> {
+  const runtime = makeTestRuntime();
+  const view = runtime.packages.repo();
+  return {
+    packageView: view,
+    config: view.select(acceptanceGenerateOp.config),
+    readFile: overrides.readFile ?? (async () => null),
+    fileExists: overrides.fileExists ?? (async () => false),
+  };
 }
 
 describe("acceptanceGenerateOp shape", () => {
@@ -66,5 +83,71 @@ describe("acceptanceGenerateOp.parse()", () => {
     const output = "```\nimport { describe } from 'bun:test';\ndescribe('feature', () => {});\n```";
     const result = acceptanceGenerateOp.parse(output, SAMPLE_INPUT, ctx);
     expect(result.testCode).toContain("import");
+  });
+});
+
+describe("acceptanceGenerateOp.verify()", () => {
+  test("returns parsed unchanged when testCode is non-null (stdout had real code)", async () => {
+    const ctx = makeVerifyCtx();
+    const parsed = { testCode: "describe('x', () => {})" };
+    const result = await acceptanceGenerateOp.verify!(parsed, SAMPLE_INPUT, ctx);
+    expect(result).toEqual(parsed);
+  });
+
+  test("reads disk file when parsed.testCode is null", async () => {
+    await withTempDir(async (dir) => {
+      const testPath = join(dir, "acceptance.test.ts");
+      const diskCode = "```typescript\ndescribe('x', () => { test('y', () => expect(1).toBe(1)); });\n```";
+      await Bun.write(testPath, diskCode);
+
+      const input = { ...SAMPLE_INPUT, targetTestFilePath: testPath };
+      const ctx = makeVerifyCtx({
+        readFile: async (p) => {
+          const f = Bun.file(p);
+          return (await f.exists()) ? await f.text() : null;
+        },
+      });
+
+      const result = await acceptanceGenerateOp.verify!({ testCode: null }, input, ctx);
+      expect(result?.testCode).toContain("describe");
+    });
+  });
+
+  test("Tier 2: returns disk content when it looks like test source (no fenced block)", async () => {
+    await withTempDir(async (dir) => {
+      const testPath = join(dir, "acceptance.test.ts");
+      const diskCode = "import { describe, test, expect } from 'bun:test';\ndescribe('x', () => { test('y', () => expect(1).toBe(1)); });";
+      await Bun.write(testPath, diskCode);
+
+      const input = { ...SAMPLE_INPUT, targetTestFilePath: testPath };
+      const ctx = makeVerifyCtx({
+        readFile: async (p) => {
+          const f = Bun.file(p);
+          return (await f.exists()) ? await f.text() : null;
+        },
+      });
+
+      const result = await acceptanceGenerateOp.verify!({ testCode: null }, input, ctx);
+      expect(result?.testCode).toBe(diskCode);
+    });
+  });
+
+  test("returns null when disk file is missing", async () => {
+    const ctx = makeVerifyCtx({ readFile: async () => null });
+    const result = await acceptanceGenerateOp.verify!({ testCode: null }, SAMPLE_INPUT, ctx);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when disk content is stub-shaped", async () => {
+    const stubCode = "describe('x', () => { test('y', () => expect(true).toBe(false)); });";
+    const ctx = makeVerifyCtx({ readFile: async () => stubCode });
+    const result = await acceptanceGenerateOp.verify!({ testCode: null }, SAMPLE_INPUT, ctx);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when disk content has no test markers", async () => {
+    const ctx = makeVerifyCtx({ readFile: async () => "just some random text" });
+    const result = await acceptanceGenerateOp.verify!({ testCode: null }, SAMPLE_INPUT, ctx);
+    expect(result).toBeNull();
   });
 });

--- a/test/unit/operations/verify-recover.test.ts
+++ b/test/unit/operations/verify-recover.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { _runPostParseForTest } from "../../../src/operations/call";
+import type { BuildContext, VerifyContext } from "../../../src/operations/types";
+import { withTempDir } from "../../helpers/temp";
+
+// Minimal build context — verify/recover hooks under test don't use packageView/config.
+const FAKE_CTX = {
+  packageView: null,
+  config: null,
+} as unknown as BuildContext<unknown>;
+
+describe("runPostParse — no hooks", () => {
+  test("op without verify or recover returns parse output unchanged", async () => {
+    const result = await _runPostParseForTest({}, "from-parse", "input", FAKE_CTX);
+    expect(result).toBe("from-parse");
+  });
+});
+
+describe("runPostParse — verify hook", () => {
+  test("op.verify returning non-null wins over parsed value", async () => {
+    const op = {
+      verify: async (_parsed: string) => "from-verify" as string | null,
+    };
+    const result = await _runPostParseForTest(op, "from-parse", "input", FAKE_CTX);
+    expect(result).toBe("from-verify");
+  });
+
+  test("op.verify returning null falls through to recover", async () => {
+    const op = {
+      verify: async () => null as string | null,
+      recover: async () => "from-recover" as string | null,
+    };
+    const result = await _runPostParseForTest(op, "from-parse", "input", FAKE_CTX);
+    expect(result).toBe("from-recover");
+  });
+
+  test("both verify and recover null → final ?? parsed returns original parsed", async () => {
+    const op = {
+      verify: async () => null as string | null,
+      recover: async () => null as string | null,
+    };
+    const result = await _runPostParseForTest(op, "from-parse", "input", FAKE_CTX);
+    expect(result).toBe("from-parse");
+  });
+
+  test("recover not called when verify returns non-null", async () => {
+    let recoverCalled = false;
+    const op = {
+      verify: async () => "from-verify" as string | null,
+      recover: async () => {
+        recoverCalled = true;
+        return "from-recover" as string | null;
+      },
+    };
+    const result = await _runPostParseForTest(op, "from-parse", "input", FAKE_CTX);
+    expect(result).toBe("from-verify");
+    expect(recoverCalled).toBe(false);
+  });
+});
+
+describe("runPostParse — VerifyContext filesystem helpers", () => {
+  test("VerifyContext.readFile reads existing file and returns null for missing file", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = join(dir, "artifact.txt");
+      await Bun.write(filePath, "artifact content");
+
+      let capturedCtx: VerifyContext<unknown> | null = null;
+      const op = {
+        verify: async (
+          _parsed: string,
+          _input: unknown,
+          ctx: VerifyContext<unknown>,
+        ): Promise<string | null> => {
+          capturedCtx = ctx;
+          return null;
+        },
+      };
+
+      await _runPostParseForTest(op, "ignored", "input", FAKE_CTX);
+
+      const content = await capturedCtx!.readFile(filePath);
+      expect(content).toBe("artifact content");
+
+      const missing = await capturedCtx!.readFile(join(dir, "nonexistent.txt"));
+      expect(missing).toBeNull();
+    });
+  });
+
+  test("VerifyContext.fileExists returns true for existing and false for missing", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = join(dir, "artifact.txt");
+      await Bun.write(filePath, "content");
+
+      let capturedCtx: VerifyContext<unknown> | null = null;
+      const op = {
+        verify: async (
+          _parsed: string,
+          _input: unknown,
+          ctx: VerifyContext<unknown>,
+        ): Promise<string | null> => {
+          capturedCtx = ctx;
+          return null;
+        },
+      };
+
+      await _runPostParseForTest(op, "ignored", "input", FAKE_CTX);
+
+      expect(await capturedCtx!.fileExists(filePath)).toBe(true);
+      expect(await capturedCtx!.fileExists(join(dir, "nonexistent.txt"))).toBe(false);
+    });
+  });
+});

--- a/test/unit/pipeline/stages/acceptance-setup-agent-file.test.ts
+++ b/test/unit/pipeline/stages/acceptance-setup-agent-file.test.ts
@@ -1,15 +1,16 @@
 /**
- * acceptance-setup: ACP agent-written file preservation (3-tier recovery)
+ * acceptance-setup: ACP agent-written file handling (ADR-020 Wave 3)
  *
- * When the ACP agent writes the acceptance test file directly via tool calls,
- * `extractTestCode(rawOutput)` returns null (conversational summary). The
- * skeleton fallback performs 3-tier recovery on the on-disk file:
+ * Since ADR-020 Wave 3 the 3-tier disk-recovery ladder no longer lives in the
+ * stage.  Recovery (Tier-1/2) is now performed by acceptanceGenerateOp.verify
+ * inside callOp.  The stage only sees the result:
  *
- *   Tier 1 — extractTestCode(existing) non-null: re-extract code from the file
- *             and use it as testCode (common for files with import{} or describe()).
- *   Tier 2 — hasLikelyTestContent(existing): file looks like tests but extraction
- *             found no code block → backup to .llm-recovery.bak + preserve full file.
- *   Tier 3 — file exists but no test keywords → backup + fall to skeleton.
+ *   testCode non-null  → write it directly, no backup.
+ *   testCode null      → op exhausted all recovery → write skeleton, no backup.
+ *
+ * The old "tier 2 backup" and "tier 3 backup" paths are intentionally absent
+ * from the stage; they are tested in
+ * test/unit/operations/acceptance-generate.test.ts (verify hook coverage).
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -54,8 +55,7 @@ function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
   };
 }
 
-// Tier 1 fixture: has `import {` — extractTestCode matches the importMatch pattern
-// and returns the full content as testCode (non-null → tier 1 fires).
+// Real acceptance test content (has import + describe → extractTestCode matches).
 const REAL_ACCEPTANCE_TEST = `import { describe, test, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -74,9 +74,7 @@ describe("test-feature - Acceptance Tests", () => {
 });
 `;
 
-// Tier 2 fixture: bare test() calls with no import{} and no describe() wrapper —
-// extractTestCode returns null (no importMatch, no describeMatch, no fence) but
-// hasLikelyTestContent returns true (has `test(`). Triggers backup + full-file preserve.
+// Bare test content recovered by verify Tier-2 (has test() calls, no import{}/describe()).
 const BARE_TIER2_TEST = `test("AC-1: const name declared", () => {
   expect(true).toBe(true); // real assertion placeholder
 });
@@ -86,8 +84,7 @@ test("AC-2: tests pass", () => {
 });
 `;
 
-// Tier 3 fixture: conversational text — extractTestCode returns null and
-// hasLikelyTestContent returns false. Triggers backup + skeleton fallback.
+// Non-test conversational output — verify hook returns null for this.
 const NON_TEST_CONTENT =
   "The acceptance tests have been written. Please verify that the implementation satisfies all the criteria.";
 
@@ -103,18 +100,13 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Shared mock builder for the "ACP agent wrote to disk, callOp returned null" path.
-// fileExists call-order contract:
-//   call 1 — fingerprint backup guard (shouldGenerate=true path); returns false so
-//             no pre-generation backup/delete fires for the test path.
-//   call 2 — 3-tier recovery guard inside the skeleton fallback; returns true so
-//             the recovery logic reads the agent-written file.
-// If a new fileExists(testPath) call is added upstream, update callCount accordingly.
+// Helper: wire deps so callOp returns the given testCode for acceptance-generate.
+// No disk-reading needed — recovery now lives inside callOp/verify (ADR-020 Wave 3).
 // ---------------------------------------------------------------------------
 
-function makeNullCallOpDeps(
+function makeCallOpDeps(
   writtenFiles: Array<{ path: string; content: string }>,
-  agentFileContent: string,
+  testCodeResult: string | null,
 ) {
   _acceptanceSetupDeps.readMeta = async () => null;
   _acceptanceSetupDeps.callOp = async (_ctx, _packageDir, op, input) => {
@@ -122,16 +114,11 @@ function makeNullCallOpDeps(
       const { criteria, storyId } = input as { criteria: string[]; storyId: string };
       return criteria.map((c: string) => ({ original: c, refined: c, testable: true, storyId }));
     }
-    if (op.name === "acceptance-generate") return { testCode: null };
+    if (op.name === "acceptance-generate") return { testCode: testCodeResult };
     throw new Error(`unexpected op: ${op.name}`);
   };
-  let callCount = 0;
-  _acceptanceSetupDeps.fileExists = async (p) => {
-    if (!p.endsWith(".nax-acceptance.test.ts")) return false;
-    callCount++;
-    return callCount > 1;
-  };
-  _acceptanceSetupDeps.readFile = async () => agentFileContent;
+  // fileExists used only by fingerprint pre-backup guard (returns false → no pre-gen backup).
+  _acceptanceSetupDeps.fileExists = async () => false;
   _acceptanceSetupDeps.writeFile = async (p, c) => {
     writtenFiles.push({ path: p, content: c });
   };
@@ -141,83 +128,65 @@ function makeNullCallOpDeps(
 }
 
 // ---------------------------------------------------------------------------
-// ACP agent-written file: 3-tier recovery
+// ACP agent-written file handling (ADR-020 Wave 3)
 // ---------------------------------------------------------------------------
 
-describe("acceptance-setup: ACP agent-written file preservation", () => {
-  test("tier 1 — extractTestCode finds code in agent file (import match); file written back, no backup", async () => {
+describe("acceptance-setup: ACP agent-written file handling (ADR-020 Wave 3)", () => {
+  test("callOp returns real test code (verify extracted it); written directly, no backup", async () => {
     const writtenFiles: Array<{ path: string; content: string }> = [];
-    makeNullCallOpDeps(writtenFiles, REAL_ACCEPTANCE_TEST);
+    // Simulate: verify hook extracted code from agent-written file and returned it via callOp.
+    makeCallOpDeps(writtenFiles, REAL_ACCEPTANCE_TEST);
 
     await acceptanceSetupStage.execute(makeCtx());
 
-    // Tier 1: extractTestCode(REAL_ACCEPTANCE_TEST) is non-null (matches import{...} pattern).
-    // testCode is set to the extracted content, which equals REAL_ACCEPTANCE_TEST trimmed.
-    // The file IS written back with the real content.
     const testFileWrites = writtenFiles.filter((f) => f.path.endsWith(".nax-acceptance.test.ts"));
     expect(testFileWrites).toHaveLength(1);
-    expect(testFileWrites[0]!.content).toContain("const name");
+    // Content is the real acceptance test, not a skeleton placeholder.
+    expect(testFileWrites[0]!.content).toContain("const name\\s*=");
+    expect(testFileWrites[0]!.content).not.toContain("expect(true).toBe(false)");
 
-    // No .llm-recovery.bak created at tier 1
+    // No .llm-recovery.bak — backup is not done at stage level.
     const backupWrites = writtenFiles.filter((f) => f.path.endsWith(".llm-recovery.bak"));
     expect(backupWrites).toHaveLength(0);
   });
 
-  test("tier 2 — bare test file (no import/describe); backup created, full content preserved", async () => {
+  test("callOp returns bare test file (verify tier-2 recovery); written directly, no backup", async () => {
     const writtenFiles: Array<{ path: string; content: string }> = [];
-    makeNullCallOpDeps(writtenFiles, BARE_TIER2_TEST);
+    // Simulate: verify hook found bare test content (Tier-2) and returned it via callOp.
+    makeCallOpDeps(writtenFiles, BARE_TIER2_TEST);
 
     await acceptanceSetupStage.execute(makeCtx());
-
-    // Tier 2: extractTestCode(BARE_TIER2_TEST) returns null (no import{}, no describe()),
-    // but hasLikelyTestContent returns true (has `test(`).
-    // A .llm-recovery.bak backup is written first, then the full file is preserved.
-    const backupWrites = writtenFiles.filter((f) => f.path.endsWith(".llm-recovery.bak"));
-    expect(backupWrites).toHaveLength(1);
-    expect(backupWrites[0]!.content).toBe(BARE_TIER2_TEST);
 
     const testFileWrites = writtenFiles.filter((f) => f.path.endsWith(".nax-acceptance.test.ts"));
     expect(testFileWrites).toHaveLength(1);
     expect(testFileWrites[0]!.content).toBe(BARE_TIER2_TEST);
+
+    // No backup at stage level — backup was stage-side behavior removed in ADR-020 Wave 3.
+    const backupWrites = writtenFiles.filter((f) => f.path.endsWith(".llm-recovery.bak"));
+    expect(backupWrites).toHaveLength(0);
   });
 
-  test("tier 3 — non-test content; backup created, skeleton written", async () => {
+  test("callOp returns null (verify exhausted, non-test content); skeleton written, no backup", async () => {
     const writtenFiles: Array<{ path: string; content: string }> = [];
-    makeNullCallOpDeps(writtenFiles, NON_TEST_CONTENT);
+    // Simulate: verify hook found non-test content and returned null → callOp returns null.
+    makeCallOpDeps(writtenFiles, null);
+    // readFile would return NON_TEST_CONTENT but stage no longer reads disk after callOp.
+    void NON_TEST_CONTENT;
 
     await acceptanceSetupStage.execute(makeCtx());
-
-    // Tier 3: extractTestCode returns null, hasLikelyTestContent returns false.
-    // A .llm-recovery.bak backup is created, then the skeleton is written.
-    const backupWrites = writtenFiles.filter((f) => f.path.endsWith(".llm-recovery.bak"));
-    expect(backupWrites).toHaveLength(1);
-    expect(backupWrites[0]!.content).toBe(NON_TEST_CONTENT);
 
     const testFileWrites = writtenFiles.filter((f) => f.path.endsWith(".nax-acceptance.test.ts"));
     expect(testFileWrites).toHaveLength(1);
     expect(testFileWrites[0]!.content).toContain("expect(true).toBe(false)");
+
+    // No backup at stage level.
+    const backupWrites = writtenFiles.filter((f) => f.path.endsWith(".llm-recovery.bak"));
+    expect(backupWrites).toHaveLength(0);
   });
 
-  test("no file — file does not exist after callOp; skeleton written, no backup", async () => {
+  test("callOp returns null (file never written by agent); skeleton written, no backup", async () => {
     const writtenFiles: Array<{ path: string; content: string }> = [];
-
-    _acceptanceSetupDeps.readMeta = async () => null;
-    _acceptanceSetupDeps.callOp = async (_ctx, _packageDir, op, input) => {
-      if (op.name === "acceptance-refine") {
-        const { criteria, storyId } = input as { criteria: string[]; storyId: string };
-        return criteria.map((c: string) => ({ original: c, refined: c, testable: true, storyId }));
-      }
-      if (op.name === "acceptance-generate") return { testCode: null };
-      throw new Error(`unexpected op: ${op.name}`);
-    };
-    // Agent did not write the file — fileExists always returns false
-    _acceptanceSetupDeps.fileExists = async () => false;
-    _acceptanceSetupDeps.writeFile = async (p, c) => {
-      writtenFiles.push({ path: p, content: c });
-    };
-    _acceptanceSetupDeps.writeMeta = async () => {};
-    _acceptanceSetupDeps.autoCommitIfDirty = async () => {};
-    _acceptanceSetupDeps.runTest = async () => ({ exitCode: 1, output: "1 fail" });
+    makeCallOpDeps(writtenFiles, null);
 
     await acceptanceSetupStage.execute(makeCtx());
 
@@ -253,8 +222,7 @@ describe("acceptance-setup: ACP agent-written file preservation", () => {
 
     // testCode is set from callOp — written as-is, no skeleton substitution
     const testContentWrites = writtenContents.filter((c) => c.includes("describe(") || c.includes("test("));
-    expect(testContentWrites.some((c) => c.includes("const name"))).toBe(true);
+    expect(testContentWrites.some((c) => c.includes("const name\\s*="))).toBe(true);
     expect(testContentWrites.every((c) => !c.includes("expect(true).toBe(false)"))).toBe(true);
   });
 });
-


### PR DESCRIPTION
## Summary

- Extends `Operation<I,O,C>` with optional `verify` and `recover` hooks (ADR-020 Wave 3 §Step 1–2): `VerifyContext<C>` provides read-only filesystem access (`readFile`/`fileExists`) to ops that need to inspect side-effect artifacts after parse
- `callOp` now runs `runPostParse` after `parse` for both `kind:"complete"` and `kind:"run"` ops — `verify` can return a corrected output or null, `recover` runs if `verify` returns null
- `acceptanceGenerateOp` gains a `verify` hook implementing the 3-tier ACP disk-recovery ladder (bug #774): Tier-1 extracts fenced code from agent-written file (with stub guard), Tier-2 accepts raw test source, Tier-3 defers skeleton fallback to the stage
- `src/acceptance/heuristics.ts` introduced as SSOT for `hasLikelyTestContent` and `isStubTestContent`, consolidating 3 prior copies
- `acceptance-setup.ts` stage simplified: the old Tier-1/2/3 disk-recovery ladder is removed; stage now uses `genResult.testCode` directly and falls back to skeleton when null — no per-stage backups
- Tier-1 stub guard fix: `extractTestCode()` has a broad `describeMatch` fallback that can return stub content; adding `!isStubTestContent(extracted)` to the Tier-1 check prevents the stub from being passed through

## Test plan

- [ ] `test/unit/operations/verify-recover.test.ts` — 7 tests covering `runPostParse` logic (verify returns non-null / null / recover fallback / both absent)
- [ ] `test/unit/operations/acceptance-generate.test.ts` — 17 tests covering shape, build, parse, and all verify branches (Tier-1 real, Tier-1 stub-in-fence guard, Tier-2 raw source, missing file, stub content, no markers)
- [ ] `test/integration/acceptance/agent-file-recovery.test.ts` — 3 integration tests calling `callOp` directly with a mock `completeAs` that writes files to disk + returns conversational stdout (spec-required regression for bug #774)
- [ ] `test/unit/pipeline/stages/acceptance-setup-agent-file.test.ts` — updated to match new no-ladder architecture; confirms testCode written directly and no stage-level backups
- [ ] Full suite: `bun run test` — all pass