### PR TITLE
fix(rectification): hold implementer session open across attempts (ADR-008)

### DIFF
--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -5,10 +5,9 @@
  * Imports _autofixDeps from autofix.ts (safe — autofix.ts lazily imports this module).
  */
 
+import type { SessionHandle } from "../../agents/types";
 import { resolveModelForAgent } from "../../config";
 import { getLogger } from "../../logger";
-import { buildHopCallback } from "../../operations/build-hop-callback";
-import type { UserStory } from "../../prd";
 import { RectifierPromptBuilder } from "../../prompts";
 import type { ReviewCheckResult } from "../../review/types";
 import { formatSessionName } from "../../session/naming";
@@ -188,9 +187,11 @@ export async function runAgentRectification(
   // (e.g. UNRESOLVED signal, lint-only fix), passed LLM checks are skipped.
   let autofixBeforeRef: string | undefined;
 
-  // Session continuity: the implementer session is open only on the very first autofix call
-  // (consumed === 0). On subsequent cycles (after a review retry), the previous loop's last
-  // execute used keepOpen: false, so the session was closed before we re-enter.
+  // ADR-008 §6 / ADR-018 §7 Pattern B: hold the implementer session open across
+  // all attempts in this rectification cycle so the agent retains conversation
+  // history between attempts. consumed === 0 means execution.ts is the upstream
+  // owner; openSession is idempotent on a live handle (session/manager.ts:354)
+  // so we attach to the existing session when present, otherwise open fresh.
   const implementerSession = formatSessionName({
     workdir: ctx.workdir,
     featureName: ctx.prd.feature,
@@ -216,6 +217,11 @@ export async function runAgentRectification(
   let currentAttempt = 0;
   let currentConsecutiveNoOps = 0;
   let currentCheckSignatureChanged = false;
+
+  // Held-open implementer session for the duration of the loop. Opened lazily
+  // on first execute() to avoid paying openSession cost when the agent fails
+  // before any attempt runs (e.g. validation errors). Closed in finally below.
+  let heldHandle: SessionHandle | undefined;
 
   const outcome = await runRetryLoop<AutofixFailure, AutofixAttemptResult>({
     stage: "rectification",
@@ -321,31 +327,52 @@ export async function runAgentRectification(
       let result: import("../../agents").AgentResult;
       try {
         if (ctx.runtime) {
-          // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback.
-          // Each attempt opens a fresh session (openSession → runAsSession → closeSession).
-          // No cross-attempt session continuity; session lifecycle managed by buildHopCallback.
-          const executeHop = buildHopCallback(
-            {
-              sessionManager: ctx.runtime.sessionManager,
-              agentManager: ctx.runtime.agentManager,
-              story: ctx.story,
-              config: ctx.config,
-              projectDir: ctx.projectDir,
-              featureName: ctx.prd.feature ?? "",
+          // ADR-008 §6 / ADR-018 §7 Pattern B: open the implementer session
+          // once and reuse across attempts so conversation history persists.
+          // openSession is idempotent on a live handle (session/manager.ts:354)
+          // so the first attempt of cycle 0 attaches to the execution-stage
+          // session when one is still open, otherwise opens fresh.
+          if (!heldHandle) {
+            heldHandle = await ctx.runtime.sessionManager.openSession(implementerSession, {
+              agentName: defaultAgent,
+              role: "implementer",
               workdir: ctx.workdir,
-              effectiveTier: modelTier,
-              defaultAgent,
               pipelineStage: "rectification",
-            },
-            ctx.sessionId,
-            runOptions,
-          );
-          const outcome = await agentManager.runWithFallback(
-            { runOptions, signal: ctx.runtime.signal, executeHop },
-            defaultAgent,
-          );
-          result = outcome.result;
-          sessionConfirmedOpen = false;
+              modelDef,
+              timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
+              featureName: ctx.prd.feature,
+              storyId: ctx.story.id,
+              signal: ctx.runtime.signal,
+              onPidSpawned: ctx.runtime.onPidSpawned,
+            });
+          }
+          // ADR-020 single-emission invariant: each runAsSession emits one
+          // session-turn event, regardless of handle reuse across attempts.
+          const turn = await agentManager.runAsSession(defaultAgent, heldHandle, prompt, {
+            storyId: ctx.story.id,
+            featureName: ctx.prd.feature,
+            workdir: ctx.workdir,
+            projectDir: ctx.projectDir,
+            pipelineStage: "rectification",
+            sessionRole: "implementer",
+            signal: ctx.runtime.signal,
+            maxTurns: ctx.config.agent?.maxInteractionTurns,
+          });
+          // Synthesize AgentResult so the downstream UNRESOLVED/CLARIFY/no-op
+          // detection paths keep working unchanged. runAsSession throws on
+          // failure, so a returned TurnResult always means success=true.
+          result = {
+            success: true,
+            exitCode: 0,
+            output: turn.output,
+            rateLimited: false,
+            durationMs: 0,
+            estimatedCostUsd: turn.estimatedCostUsd,
+            ...(turn.exactCostUsd !== undefined && { exactCostUsd: turn.exactCostUsd }),
+            ...(turn.tokenUsage && { tokenUsage: turn.tokenUsage }),
+            ...(heldHandle.protocolIds && { protocolIds: heldHandle.protocolIds }),
+          };
+          sessionConfirmedOpen = true;
         } else {
           // Legacy keepOpen path — used when no runtime is available (standalone callers).
           result = await agentManager.run({
@@ -354,7 +381,14 @@ export async function runAgentRectification(
           sessionConfirmedOpen = true;
         }
       } catch (err) {
-        sessionConfirmedOpen = false; // Session state unknown — next attempt uses full prompt
+        sessionConfirmedOpen = false;
+        // Discard the held handle so the next attempt reopens — the previous
+        // session may be in a terminal/cancelled state after the throw.
+        if (heldHandle && ctx.runtime) {
+          const stale = heldHandle;
+          heldHandle = undefined;
+          await ctx.runtime.sessionManager.closeSession(stale).catch(() => {});
+        }
         throw err;
       }
 
@@ -548,15 +582,26 @@ export async function runAgentRectification(
         newFailure: initialFailure,
       };
     },
-  }).catch((error: unknown) => {
-    if (error instanceof Error && error.message === "AUTOFIX_AGENT_NOT_FOUND") {
-      return { outcome: "exhausted", attempts: 0, finalFailure: initialFailure } as const;
-    }
-    if (error instanceof Error && error.message === "AUTOFIX_UNRESOLVED") {
-      return { outcome: "exhausted", attempts: 0, finalFailure: initialFailure } as const;
-    }
-    throw error;
-  });
+  })
+    .catch((error: unknown) => {
+      if (error instanceof Error && error.message === "AUTOFIX_AGENT_NOT_FOUND") {
+        return { outcome: "exhausted", attempts: 0, finalFailure: initialFailure } as const;
+      }
+      if (error instanceof Error && error.message === "AUTOFIX_UNRESOLVED") {
+        return { outcome: "exhausted", attempts: 0, finalFailure: initialFailure } as const;
+      }
+      throw error;
+    })
+    .finally(async () => {
+      // ADR-008 §6: close the held implementer session at loop exit (success,
+      // exhaustion, or unhandled error). Best-effort — failures here must not
+      // mask the loop outcome.
+      if (heldHandle && ctx.runtime) {
+        const stale = heldHandle;
+        heldHandle = undefined;
+        await ctx.runtime.sessionManager.closeSession(stale).catch(() => {});
+      }
+    });
 
   const succeeded = outcome.outcome === "fixed";
   return { succeeded, cost: autofixCostAccum, unresolvedReason };

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -7,10 +7,10 @@
  */
 
 import type { IAgentManager } from "../agents";
+import type { SessionHandle } from "../agents/types";
 import type { ModelTier, NaxConfig } from "../config";
 import { type rectificationGateConfigSelector, resolveModelForAgent } from "../config";
 import type { getLogger } from "../logger";
-import { buildHopCallback } from "../operations/build-hop-callback";
 import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
 import type { FailureRecord } from "../prompts";
@@ -270,6 +270,12 @@ async function runRectificationLoop(
     role: "implementer",
   });
 
+  // ADR-008 §6 / ADR-018 §7 Pattern B: hold the implementer session open across
+  // all attempts in this rectification cycle so the agent retains conversation
+  // history between attempts. Opened lazily on first execute(), closed in the
+  // .finally() at loop exit.
+  let heldHandle: SessionHandle | undefined;
+
   const initialFailure: TddRectificationFailure = {
     testSummary,
     testOutput,
@@ -322,29 +328,55 @@ async function runRectificationLoop(
 
       let rectifyResult: import("../agents").AgentResult;
       if (runtime) {
-        // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback.
-        // Each attempt opens a fresh session; keepOpen is not used in the runtime path.
-        const executeHop = buildHopCallback(
-          {
-            sessionManager: runtime.sessionManager,
-            agentManager: runtime.agentManager,
-            story,
-            config: config as unknown as NaxConfig,
-            projectDir,
-            featureName: featureName ?? "",
+        // ADR-008 §6 / ADR-018 §7 Pattern B: open the implementer session once
+        // and reuse across attempts. openSession is idempotent (session/manager.ts:354)
+        // so we attach to any session opened upstream by execution.ts when one
+        // is still alive.
+        if (!heldHandle) {
+          heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
+            agentName: defaultAgent,
+            role: "implementer",
             workdir,
-            effectiveTier: implementerTier,
-            defaultAgent,
             pipelineStage: "rectification",
-          },
-          sessionId,
-          runOptions,
-        );
-        const outcome = await agentManager.runWithFallback(
-          { runOptions, signal: runtime.signal, executeHop },
-          defaultAgent,
-        );
-        rectifyResult = outcome.result;
+            modelDef: runOptions.modelDef,
+            timeoutSeconds: config.execution.sessionTimeoutSeconds,
+            featureName,
+            storyId: story.id,
+            signal: runtime.signal,
+            onPidSpawned: runtime.onPidSpawned,
+          });
+        }
+        // ADR-020 single-emission invariant: each runAsSession emits one
+        // session-turn event for audit/cost subscribers, regardless of handle
+        // reuse across attempts.
+        try {
+          const turn = await agentManager.runAsSession(defaultAgent, heldHandle, prompt, {
+            storyId: story.id,
+            featureName,
+            workdir,
+            projectDir,
+            pipelineStage: "rectification",
+            sessionRole: "implementer",
+            signal: runtime.signal,
+            maxTurns: config.agent?.maxInteractionTurns,
+          });
+          rectifyResult = {
+            success: true,
+            exitCode: 0,
+            output: turn.output,
+            rateLimited: false,
+            durationMs: 0,
+            estimatedCostUsd: turn.estimatedCostUsd,
+            ...(turn.exactCostUsd !== undefined && { exactCostUsd: turn.exactCostUsd }),
+            ...(turn.tokenUsage && { tokenUsage: turn.tokenUsage }),
+            ...(heldHandle.protocolIds && { protocolIds: heldHandle.protocolIds }),
+          };
+        } catch (err) {
+          const stale = heldHandle;
+          heldHandle = undefined;
+          await runtime.sessionManager.closeSession(stale).catch(() => {});
+          throw err;
+        }
       } else {
         // Legacy keepOpen path — used when no runtime is available (standalone callers).
         rectifyResult = await agentManager.run({
@@ -429,6 +461,13 @@ async function runRectificationLoop(
         },
       };
     },
+  }).finally(async () => {
+    // ADR-008 §6: close the held implementer session at loop exit. Best-effort.
+    if (heldHandle && runtime) {
+      const stale = heldHandle;
+      heldHandle = undefined;
+      await runtime.sessionManager.closeSession(stale).catch(() => {});
+    }
   });
 
   const fixed = outcome.outcome === "fixed";

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -9,12 +9,12 @@
 
 import type { IAgentManager } from "../agents";
 import { estimateCostByDuration } from "../agents/cost";
+import type { SessionHandle } from "../agents/types";
 import type { NaxConfig } from "../config";
 import { resolveModelForAgent } from "../config";
 import type { DebateStageConfig, Debater } from "../debate/types";
 import { escalateTier as _escalateTier } from "../execution/escalation/escalation";
 import { getSafeLogger } from "../logger";
-import { buildHopCallback } from "../operations/build-hop-callback";
 import type { PipelineContext } from "../pipeline/types";
 import type { UserStory } from "../prd";
 import { getExpectedFiles } from "../prd";
@@ -199,6 +199,12 @@ export async function runRectificationLoop(
   let costAccum = 0;
   let currentAttempt = 0;
 
+  // ADR-008 §6 / ADR-018 §7 Pattern B: hold the implementer session open across
+  // all attempts in this rectification cycle so the agent retains conversation
+  // history between attempts. Opened lazily on first execute(), closed in the
+  // .finally() at loop exit.
+  let heldHandle: SessionHandle | undefined;
+
   // Initial failure snapshot for the retry loop
   const initialFailure: RectificationFailure = {
     testOutput,
@@ -304,29 +310,57 @@ export async function runRectificationLoop(
 
       let agentResult: import("../agents").AgentResult;
       if (runtime) {
-        // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback.
-        // Each attempt opens a fresh session; keepOpen is not used in the runtime path.
-        const executeHop = buildHopCallback(
-          {
-            sessionManager: runtime.sessionManager,
-            agentManager: runtime.agentManager,
-            story,
-            config,
-            projectDir,
-            featureName: featureName ?? "",
+        // ADR-008 §6 / ADR-018 §7 Pattern B: open the implementer session
+        // once and reuse across attempts. openSession is idempotent on a live
+        // handle (session/manager.ts:354) so we attach to any session opened
+        // upstream by execution.ts when one is still alive.
+        if (!heldHandle) {
+          heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
+            agentName: defaultAgent,
+            role: "implementer",
             workdir,
-            effectiveTier: modelTier,
-            defaultAgent,
             pipelineStage: "rectification",
-          },
-          sessionId,
-          runOptions,
-        );
-        const outcome = await agentManager.runWithFallback(
-          { runOptions, signal: runtime.signal, executeHop },
-          defaultAgent,
-        );
-        agentResult = outcome.result;
+            modelDef,
+            timeoutSeconds: config.execution.sessionTimeoutSeconds,
+            featureName,
+            storyId: story.id,
+            signal: runtime.signal,
+            onPidSpawned: runtime.onPidSpawned,
+          });
+        }
+        // ADR-020 single-emission invariant: each runAsSession emits one
+        // session-turn event for audit/cost subscribers, regardless of handle
+        // reuse across attempts.
+        try {
+          const turn = await agentManager.runAsSession(defaultAgent, heldHandle, prompt, {
+            storyId: story.id,
+            featureName,
+            workdir,
+            projectDir,
+            pipelineStage: "rectification",
+            sessionRole: "implementer",
+            signal: runtime.signal,
+            maxTurns: config.agent?.maxInteractionTurns,
+          });
+          agentResult = {
+            success: true,
+            exitCode: 0,
+            output: turn.output,
+            rateLimited: false,
+            durationMs: 0,
+            estimatedCostUsd: turn.estimatedCostUsd,
+            ...(turn.exactCostUsd !== undefined && { exactCostUsd: turn.exactCostUsd }),
+            ...(turn.tokenUsage && { tokenUsage: turn.tokenUsage }),
+            ...(heldHandle.protocolIds && { protocolIds: heldHandle.protocolIds }),
+          };
+        } catch (err) {
+          // Discard the held handle on error — the previous session may be in
+          // a terminal/cancelled state. Next attempt will reopen.
+          const stale = heldHandle;
+          heldHandle = undefined;
+          await runtime.sessionManager.closeSession(stale).catch(() => {});
+          throw err;
+        }
       } else {
         // Legacy keepOpen path — used when no runtime is available (standalone callers).
         agentResult = await agentManager.run({
@@ -445,6 +479,15 @@ export async function runRectificationLoop(
         },
       };
     },
+  }).finally(async () => {
+    // ADR-008 §6: close the held implementer session at loop exit. Best-effort —
+    // failures here must not mask the loop outcome. Tier escalation below opens
+    // a fresh session via runAs, so we close before that branch fires.
+    if (heldHandle && runtime) {
+      const stale = heldHandle;
+      heldHandle = undefined;
+      await runtime.sessionManager.closeSession(stale).catch(() => {});
+    }
   });
 
   const succeeded = outcome.outcome === "fixed";


### PR DESCRIPTION
## Summary

Restores ADR-008 §6's implementer-session-continuity invariant in the three rectification sites by migrating them from ADR-018 Pattern A (single-prompt-per-hop, fresh session per attempt) to **Pattern B (keep-open multi-prompt)** — the path that ADR-018 §7 line 1098 explicitly names rectification loops as a canonical example for.

### Root cause

`autofix-agent.ts`, `verification/rectification-loop.ts`, and `tdd/rectification-gate.ts` each dispatched per-attempt via `runWithFallback` + `buildHopCallback`. `buildHopCallback` does `openSession → runAsSession → closeSession` in a try/finally — closing unconditionally on every executeHop call. Result: every rectification attempt got a fresh protocol session with no conversation history, breaking the ADR-008 invariant that the implementer session persists from execution → autofix → verification rectification → TDD rectification within one tier.

This made the lean `firstAttemptDelta` prompt (autofix-agent.ts:253) unsound: it gates on \`consumed === 0 && sessionConfirmedOpen\` and assumes the agent has execution-stage context. With fresh-per-attempt sessions, that assumption was false, so attempt 1 received a context-free delta and either no-op'd or terminated immediately (the `SESSION_TERMINAL_STATE` 0ms failure observed in koda's 2026-04-28 dogfood run).

### Fix

For each of the three sites, on the runtime path:
1. **Open once** at first execute() via `sessionManager.openSession(implementerSessionName, {...})`. Idempotent on a live handle (session/manager.ts:354), so it attaches to any execution-stage session still alive.
2. **Dispatch each attempt** via `agentManager.runAsSession(agent, handle, prompt, opts)` — the middleware-aware multi-prompt primitive (ADR-019 §6).
3. **Close once** in `.finally()` at loop exit (success / exhaustion / error). On per-attempt error, discard the handle so the next attempt reopens.

Legacy `keepOpen` path is retained for non-runtime callers (test/standalone).

### ADR alignment

- **ADR-008 §6**: implementer continuity restored.
- **ADR-018 §7 Pattern B**: explicitly names rectification loops as a canonical Pattern B use case (line 1098). This PR implements that.
- **ADR-019 §5.5/§5.6/§7.4**: keep-open multi-prompt is a first-class supported dispatch shape. `runAsSession` is the prescribed primitive for the multi-prompt-against-held-handle case.
- **ADR-020 single-emission invariant**: `runAsSession` emits exactly one `session-turn` DispatchEvent per call, so audit/cost/cancellation subscribers fire correctly across N attempts on one descriptor.

No ADR amendment required.

### Side effect: removes covert tier escalation

Pattern A wired `runWithFallback` with no `noFallback` flag, theoretically permitting cross-agent swap mid-rectification. Per ADR-008 §6, tier escalation must start a fresh session; mid-loop swap with retained conversation history was a covert violation. Pattern B doesn't go through `runWithFallback`'s swap logic, so this is removed by construction. Explicit tier escalation paths (e.g. `rectification-loop.ts:494-509`) are preserved as a separate post-exhaustion branch.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (auto-fixed one Biome formatting issue)
- [x] All pre-commit guards pass: process.cwd guard, adapter-wrap guard, dispatch-context guard
- [x] `bun run test:bail` — full suite passes (1233 unit, full integration + UI)
- [x] Targeted suites: `autofix-session-wiring.test.ts`, `rectification-loop.test.ts`, `rectification-gate-session.test.ts`, plus all autofix-* and rectification-* tests (161/161 pass)
- [ ] Manual dogfood on a feature with autofix retry to confirm the lean delta prompt now lands on a warm session

## Out of scope

- Bug 2b (semantic reviewer hallucinating `new Set(...)` defect) — independent of session lifecycle, separate fix track.
- Bug 3 (adversarial loop oscillation, #736) — separate fix track.