### PR TITLE
[codex] Validate semantic review evidence against files

### DIFF
--- a/src/review/semantic-evidence.ts
+++ b/src/review/semantic-evidence.ts
@@ -1,0 +1,68 @@
+import { getSafeLogger } from "../logger";
+import { validateModulePath } from "../utils/path-security";
+import type { LLMFinding } from "./semantic-helpers";
+import type { SemanticReviewConfig } from "./types";
+
+const OBSERVED_PREVIEW_CHARS = 160;
+
+export async function substantiateSemanticEvidence(
+  findings: LLMFinding[],
+  diffMode: SemanticReviewConfig["diffMode"],
+  workdir: string,
+  storyId: string,
+): Promise<LLMFinding[]> {
+  if (diffMode !== "ref") return findings;
+  return Promise.all(findings.map((finding) => substantiateFinding(finding, workdir, storyId)));
+}
+
+async function substantiateFinding(finding: LLMFinding, workdir: string, storyId: string): Promise<LLMFinding> {
+  if (finding.severity !== "error") return finding;
+
+  const observed = finding.verifiedBy?.observed?.trim();
+  if (!observed) return finding;
+
+  const file = finding.verifiedBy?.file?.trim() || finding.file;
+  const contents = await readSafeFile(workdir, file);
+  if (contents !== null && normalizedIncludes(contents, observed)) return finding;
+
+  getSafeLogger()?.warn("review", "Downgraded unsubstantiated semantic error finding", {
+    storyId,
+    file,
+    line: finding.verifiedBy?.line ?? finding.line,
+    observed: observed.slice(0, OBSERVED_PREVIEW_CHARS),
+  });
+
+  return { ...finding, severity: "unverifiable" };
+}
+
+async function readSafeFile(workdir: string, file: string): Promise<string | null> {
+  const validated = validateModulePath(file, [workdir]);
+  if (!validated.valid || !validated.absolutePath) return null;
+
+  try {
+    return await Bun.file(validated.absolutePath).text();
+  } catch {
+    return null;
+  }
+}
+
+function normalizedIncludes(contents: string, observed: string): boolean {
+  const normalizedObserved = normalizeEvidenceText(observed);
+  return normalizedObserved.length > 0 && normalizeEvidenceText(contents).includes(normalizedObserved);
+}
+
+function normalizeEvidenceText(text: string): string {
+  return stripWrappingQuotes(text).replace(/\s+/g, " ").trim();
+}
+
+function stripWrappingQuotes(text: string): string {
+  let trimmed = text.trim();
+  while (trimmed.length >= 2 && isMatchingWrapper(trimmed[0], trimmed[trimmed.length - 1])) {
+    trimmed = trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function isMatchingWrapper(first: string | undefined, last: string | undefined): boolean {
+  return (first === "`" && last === "`") || (first === `"` && last === `"`) || (first === "'" && last === "'");
+}

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -26,6 +26,7 @@ import type { NaxIgnoreIndex } from "../utils/path-filters";
 import { DIFF_CAP_BYTES, collectDiff, collectDiffStat, resolveEffectiveRef, truncateDiff } from "./diff-utils";
 import { writeReviewAudit } from "./review-audit";
 import { runSemanticDebate } from "./semantic-debate";
+import { substantiateSemanticEvidence } from "./semantic-evidence";
 import {
   type LLMFinding,
   type LLMResponse,
@@ -466,7 +467,12 @@ export async function runSemanticReview(
     parsed = legacyParsed;
   }
 
-  const sanitizedFindings = sanitizeRefModeFindings(parsed.findings, diffMode);
+  const sanitizedFindings = await substantiateSemanticEvidence(
+    sanitizeRefModeFindings(parsed.findings, diffMode),
+    diffMode,
+    workdir,
+    story.id,
+  );
   const sanitizedParsed: LLMResponse = { ...parsed, findings: sanitizedFindings };
 
   // Split findings by blocking threshold

--- a/test/unit/review/semantic-unverifiable.test.ts
+++ b/test/unit/review/semantic-unverifiable.test.ts
@@ -9,12 +9,15 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { AgentResult } from "../../../src/agents/types";
 import { _diffUtilsDeps } from "../../../src/review/diff-utils";
 import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
 import type { SemanticStory } from "../../../src/review/semantic";
 import type { SemanticReviewConfig } from "../../../src/review/types";
 import { makeMockAgentManager } from "../../helpers";
+import { withTempDir } from "../../helpers/temp";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -260,7 +263,7 @@ describe("unverifiable finding handling", () => {
     expect(result.advisoryFindings?.[0].message).toContain("Cannot verify from diff alone");
   });
 
-  test("ref mode preserves verified error findings as blocking", async () => {
+  test("ref mode preserves verified error findings when observed evidence exists on disk", async () => {
     const response = JSON.stringify({
       passed: false,
       findings: [
@@ -274,23 +277,66 @@ describe("unverifiable finding handling", () => {
             command: "sed -n '1,80p' src/foo.ts",
             file: "src/foo.ts",
             line: 5,
-            observed: "Function body is empty.",
+            observed: "export function foo() {}",
           },
         },
       ],
     });
     const agentManager = makeAgentManager(response);
-    const result = await runSemanticReview(
-      "/tmp/repo",
-      "abc123",
-      STORY,
-      { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
-      agentManager,
-    );
+    const result = await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "export function foo() {}\n");
+      return runSemanticReview(
+        workdir,
+        "abc123",
+        STORY,
+        { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+        agentManager,
+      );
+    });
 
     expect(result.success).toBe(false);
     expect(result.findings?.length).toBe(1);
     expect(result.findings?.[0].message).toBe("AC not implemented");
+  });
+
+  test("ref mode downgrades fabricated verifiedBy evidence to unverifiable", async () => {
+    const response = JSON.stringify({
+      passed: false,
+      findings: [
+        {
+          severity: "error",
+          file: "src/foo.ts",
+          line: 5,
+          issue: "AC not implemented",
+          suggestion: "Replace the bogus Set comparison.",
+          verifiedBy: {
+            command: "sed -n '1,80p' src/foo.ts",
+            file: "src/foo.ts",
+            line: 5,
+            observed: "new Set(array.sort().join('|'))",
+          },
+        },
+      ],
+    });
+    const agentManager = makeAgentManager(response);
+    const result = await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "const storedLinkStr = links.sort().join('|');\n");
+      return runSemanticReview(
+        workdir,
+        "abc123",
+        STORY,
+        { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+        agentManager,
+      );
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.findings).toBeUndefined();
+    expect(result.advisoryFindings?.length).toBe(1);
+    expect(result.advisoryFindings?.[0].severity).toBe("info");
+    expect(result.advisoryFindings?.[0].message).toBe("AC not implemented");
   });
 });
 


### PR DESCRIPTION
## Summary

- Add deterministic post-parse validation for semantic review `verifiedBy.observed` evidence in ref mode.
- Downgrade unsubstantiated semantic `error` findings to `unverifiable` so fabricated evidence does not block autofix.
- Cover both real on-disk evidence and fabricated evidence with focused semantic review tests.

## Root Cause

Semantic review prompts required `verifiedBy` evidence for blocking errors, but the implementation only checked that the evidence fields were non-empty. A reviewer could hallucinate a current-code fact, place it in `verifiedBy.observed`, and still produce a blocking `error` finding.

## Validation

- `bun test test/unit/review/semantic-unverifiable.test.ts --timeout=30000`
- `bun run lint`
- `bun run typecheck`
- pre-commit hooks: typecheck, lint, process.cwd check, adapter wrap check, dispatch context check

Closes #796