### PR TITLE
fix(review): severity-aware JSON-retry cap so blocking findings are never dropped

### DIFF
--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -1,5 +1,6 @@
 import type { TurnResult } from "../agents/types";
 import { reviewConfigSelector } from "../config";
+import { getSafeLogger } from "../logger";
 import { AdversarialReviewPromptBuilder, ReviewPromptBuilder } from "../prompts";
 import type { PriorFailure, TestInventory } from "../prompts";
 import { looksLikeTruncatedJson } from "../review/truncation";
@@ -24,6 +25,8 @@ export interface AdversarialReviewInput {
   featureCtxBlock?: string;
   /** Prior adversarial findings to carry forward into this review round (issue #736). */
   priorAdversarialFindings?: AdversarialFindingsCache;
+  /** Severity threshold from review config — drives the JSON-retry condensation prompt. */
+  blockingThreshold?: "error" | "warning" | "info";
 }
 
 export interface AdversarialReviewOutput extends LlmReviewOutput {
@@ -45,7 +48,16 @@ const adversarialReviewHopBody: HopBody<AdversarialReviewInput> = async (initial
   const parsed = tryParseLLMJson<Record<string, unknown>>(first.output);
   if (!isTruncated && parsed && parseLlmReviewShape(parsed)) return first;
 
-  const retryPrompt = isTruncated ? ReviewPromptBuilder.jsonRetryCondensed() : ReviewPromptBuilder.jsonRetry();
+  const retryPrompt = isTruncated
+    ? ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold: ctx.input.blockingThreshold })
+    : ReviewPromptBuilder.jsonRetry();
+  if (isTruncated) {
+    getSafeLogger()?.warn("adversarial", "JSON parse retry — original response truncated", {
+      storyId: ctx.input.story.id,
+      originalByteSize: first.output.length,
+      blockingThreshold: ctx.input.blockingThreshold ?? "error",
+    });
+  }
   const retry: TurnResult = await ctx.send(retryPrompt);
   return {
     ...retry,

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -1,5 +1,6 @@
 import type { TurnResult } from "../agents/types";
 import { reviewConfigSelector } from "../config";
+import { getSafeLogger } from "../logger";
 import { ReviewPromptBuilder } from "../prompts";
 import type { PriorFailure } from "../prompts";
 import { looksLikeTruncatedJson } from "../review/truncation";
@@ -21,6 +22,8 @@ export interface SemanticReviewInput {
   excludePatterns?: string[];
   /** Pre-built, role-filtered context prefix to prepend to the review prompt. */
   featureCtxBlock?: string;
+  /** Severity threshold from review config — drives the JSON-retry condensation prompt. */
+  blockingThreshold?: "error" | "warning" | "info";
 }
 
 export interface SemanticReviewOutput extends LlmReviewOutput {
@@ -48,7 +51,16 @@ const semanticReviewHopBody: HopBody<SemanticReviewInput> = async (initialPrompt
   const parsed = tryParseLLMJson<Record<string, unknown>>(first.output);
   if (!isTruncated && parsed && parseLlmReviewShape(parsed)) return first;
 
-  const retryPrompt = isTruncated ? ReviewPromptBuilder.jsonRetryCondensed() : ReviewPromptBuilder.jsonRetry();
+  const retryPrompt = isTruncated
+    ? ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold: ctx.input.blockingThreshold })
+    : ReviewPromptBuilder.jsonRetry();
+  if (isTruncated) {
+    getSafeLogger()?.warn("semantic", "JSON parse retry — original response truncated", {
+      storyId: ctx.input.story.id,
+      originalByteSize: first.output.length,
+      blockingThreshold: ctx.input.blockingThreshold ?? "error",
+    });
+  }
   const retry: TurnResult = await ctx.send(retryPrompt);
   return {
     ...retry,

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -145,10 +145,34 @@ ${SEMANTIC_OUTPUT_SCHEMA}`;
   /**
    * Follow-up prompt when the previous response was truncated mid-JSON.
    * Asking the same question again produces the same long output; instead
-   * ask for a condensed summary capped at maxFindings to fit within limits.
+   * ask for a severity-aware condensed summary so blocking findings are
+   * never dropped — only advisory (below-threshold) findings are capped.
+   *
+   * - `blockingThreshold` matches the project review config; findings at or
+   *   above it must be reported in full.
+   * - `advisoryCap` bounds findings strictly below the threshold (default 3).
    */
-  static jsonRetryCondensed(maxFindings = 3): string {
-    return `Your previous response was truncated and could not be parsed as valid JSON.\nRespond with a condensed summary: at most ${maxFindings} findings, highest severity first.\nOutput ONLY a complete, valid JSON object. It must start with { and end with }.\nSchema: {"passed": boolean, "findings": [{"severity": string, "category": string, "file": string, "line": number, "issue": string, "suggestion": string}]}`;
+  static jsonRetryCondensed(opts?: {
+    blockingThreshold?: "error" | "warning" | "info";
+    advisoryCap?: number;
+  }): string {
+    const threshold = opts?.blockingThreshold ?? "error";
+    const advisoryCap = opts?.advisoryCap ?? 3;
+    const blockingList =
+      threshold === "error"
+        ? '"error"'
+        : threshold === "warning"
+          ? '"error" and "warning"'
+          : '"error", "warning", and "info"';
+    const blockingClause =
+      threshold === "info"
+        ? "Include ALL findings — do not drop any by severity."
+        : `Include ALL findings with severity ${blockingList} (these are blocking — do not drop them).`;
+    const advisoryClause =
+      threshold === "info"
+        ? "If your response would still exceed limits, prioritize the highest-severity findings first."
+        : `Below that, include at most ${advisoryCap} additional findings (highest severity first).`;
+    return `Your previous response was truncated and could not be parsed as valid JSON.\nRespond with a condensed summary:\n- ${blockingClause}\n- ${advisoryClause}\nOutput ONLY a complete, valid JSON object. It must start with { and end with }.\nSchema: {"passed": boolean, "findings": [{"severity": string, "category": string, "file": string, "line": number, "issue": string, "suggestion": string}]}`;
   }
 }
 

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -197,6 +197,7 @@ export async function runAdversarialReview(
         excludePatterns: adversarialConfig.excludePatterns,
         featureCtxBlock,
         priorAdversarialFindings,
+        blockingThreshold,
       });
     } catch (err) {
       logger?.warn("adversarial", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
@@ -368,7 +369,16 @@ export async function runAdversarialReview(
     const isTruncated = looksLikeTruncatedJson(rawResponse);
     if (isTruncated || !parseAdversarialResponse(rawResponse)) {
       retryAttempted = true;
-      const retryPrompt = isTruncated ? ReviewPromptBuilder.jsonRetryCondensed() : ReviewPromptBuilder.jsonRetry();
+      const retryPrompt = isTruncated
+        ? ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold })
+        : ReviewPromptBuilder.jsonRetry();
+      if (isTruncated) {
+        logger?.warn("adversarial", "JSON parse retry — original response truncated", {
+          storyId: story.id,
+          originalByteSize: rawResponse.length,
+          blockingThreshold: blockingThreshold ?? "error",
+        });
+      }
       logger?.info("adversarial", "JSON parse failed, retrying (1/1)", {
         storyId: story.id,
         rawHead: rawResponse.slice(0, 200),

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -238,6 +238,7 @@ export async function runSemanticReview(
         priorFailures,
         excludePatterns,
         featureCtxBlock,
+        blockingThreshold,
       });
     } catch (err) {
       logger?.warn("semantic", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
@@ -392,7 +393,16 @@ export async function runSemanticReview(
     const isTruncated = looksLikeTruncatedJson(rawResponse);
     if (isTruncated || !parseLLMResponse(rawResponse)) {
       retryAttempted = true;
-      const retryPrompt = isTruncated ? ReviewPromptBuilder.jsonRetryCondensed() : ReviewPromptBuilder.jsonRetry();
+      const retryPrompt = isTruncated
+        ? ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold })
+        : ReviewPromptBuilder.jsonRetry();
+      if (isTruncated) {
+        logger?.warn("semantic", "JSON parse retry — original response truncated", {
+          storyId: story.id,
+          originalByteSize: rawResponse.length,
+          blockingThreshold: blockingThreshold ?? "error",
+        });
+      }
       logger?.info("semantic", "JSON parse failed, retrying (1/1)", {
         storyId: story.id,
         rawHead: rawResponse.slice(0, 200),

--- a/test/unit/prompts/review-builder.test.ts
+++ b/test/unit/prompts/review-builder.test.ts
@@ -124,3 +124,36 @@ describe("ReviewPromptBuilder.buildSemanticReviewPrompt()", () => {
     });
   });
 });
+
+describe("ReviewPromptBuilder.jsonRetryCondensed()", () => {
+  test("default threshold (error) — uncaps error severity, caps below at 3", () => {
+    const result = ReviewPromptBuilder.jsonRetryCondensed();
+    expect(result).toContain("Include ALL findings with severity \"error\"");
+    expect(result).toContain("at most 3 additional findings");
+    expect(result).toContain("Output ONLY a complete, valid JSON object");
+  });
+
+  test("threshold=warning — uncaps error AND warning, caps below at advisoryCap", () => {
+    const result = ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold: "warning" });
+    expect(result).toContain('Include ALL findings with severity "error" and "warning"');
+    expect(result).toContain("at most 3 additional findings");
+  });
+
+  test("threshold=info — no severity-based truncation", () => {
+    const result = ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold: "info" });
+    expect(result).toContain("Include ALL findings — do not drop any by severity.");
+    expect(result).not.toContain("at most 3 additional findings");
+    expect(result).toContain("prioritize the highest-severity findings first");
+  });
+
+  test("custom advisoryCap is honored", () => {
+    const result = ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold: "error", advisoryCap: 5 });
+    expect(result).toContain("at most 5 additional findings");
+  });
+
+  test("blocking findings are never capped — only below-threshold count is bounded", () => {
+    const result = ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold: "error", advisoryCap: 0 });
+    expect(result).toContain("Include ALL findings with severity \"error\"");
+    expect(result).toContain("at most 0 additional findings");
+  });
+});

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -469,14 +469,15 @@ describe("runAdversarialReview — truncation-detected condensed retry", () => {
     expect(retryPrompt).not.toContain("truncated");
   });
 
-  test("condensed retry prompt caps findings — prompt mentions a number limit", async () => {
+  test("condensed retry prompt caps below-threshold findings but never blocking ones", async () => {
     const agentManager = makeMultiCallAgentManager([AT_CAP_UNPARSEABLE, PASSING_RESPONSE]);
 
     await runAdversarialReview("/tmp/wd", "abc123", STORY, ADVERSARIAL_CONFIG, agentManager);
 
     const calls = (agentManager.getAgent("claude").run as ReturnType<typeof mock>).mock.calls;
     const retryPrompt = (calls[1][0] as Record<string, unknown>).prompt as string;
-    expect(retryPrompt).toMatch(/\d+ finding/);
+    expect(retryPrompt).toMatch(/Include ALL findings with severity/);
+    expect(retryPrompt).toMatch(/at most \d+ additional findings/);
   });
 
   test("succeeds when condensed retry returns valid JSON after cap-length truncation", async () => {

--- a/test/unit/review/semantic-retry-truncation.test.ts
+++ b/test/unit/review/semantic-retry-truncation.test.ts
@@ -214,14 +214,15 @@ describe("runSemanticReview — truncation-detected condensed retry", () => {
     expect(retryPrompt).not.toContain("truncated");
   });
 
-  test("condensed retry prompt caps findings — prompt mentions a number limit", async () => {
+  test("condensed retry prompt caps below-threshold findings but never blocking ones", async () => {
     const agentManager = makeMultiCallAgentManager([AT_CAP_UNPARSEABLE, PASSING_LLM_RESPONSE]);
 
     await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager);
 
     const calls = (agentManager.getAgent("claude").run as ReturnType<typeof mock>).mock.calls;
     const retryPrompt = (calls[1][0] as Record<string, unknown>).prompt as string;
-    expect(retryPrompt).toMatch(/\d+ finding/);
+    expect(retryPrompt).toMatch(/Include ALL findings with severity/);
+    expect(retryPrompt).toMatch(/at most \d+ additional findings/);
   });
 
   test("fires retry when response is at cap even before attempting parse", async () => {


### PR DESCRIPTION
## Summary

- Fix `jsonRetryCondensed()` so the truncated-response retry prompt is severity-aware: findings at or above `blockingThreshold` are uncapped; only below-threshold (advisory) findings are bounded (default `advisoryCap = 3`).
- Thread `blockingThreshold` through both dispatch paths — the legacy `keepOpen` retry sites in `src/review/{semantic,adversarial}.ts` and the runtime `callOp` hopBodies in `src/operations/{semantic,adversarial}-review.ts`.
- Emit `logger.warn("review", "JSON parse retry — original response truncated", { storyId, originalByteSize, blockingThreshold })` on every truncated retry so we can measure how often this fires in production.

## Why

The previous `jsonRetryCondensed(maxFindings = 3)` capped *all* findings at 3 on truncation, regardless of severity. A reviewer that produced 8 findings on the first response lost 5 of them, and the implementer had no signal that the result was a partial summary. Across multiple adversarial rounds (issue #736) this manifests as the "moving goalposts" symptom: each round surfaces 3 different findings of the original 8, and the implementer never converges. Tracked in the 2026-04-29 findings doc, §"Bug 3 — Track 3-PR A".

The cap is meant to prevent runaway responses on truncation — that purpose is preserved for *advisory* findings, but blocking findings (those at or above the project's configured `blockingThreshold`) are never dropped.

## Behaviour change

| `blockingThreshold` | Forwarded uncapped | Capped at `advisoryCap` |
|:---|:---|:---|
| `error` (default) | severity = error | warning, info |
| `warning` | severity in {error, warning} | info |
| `info` | all severities (no severity-based truncation) | n/a — LLM is told to prioritize worst-first if it still must truncate |

The new warn log gives us telemetry to scope #736 PR 3.1 (prior-findings carry-forward) — if truncation rarely fires, the goalpost-moving symptom is mostly carry-forward, not the silent cap.

## Out of scope

- Issue #736 PR 3.1 (prior-findings carry-forward) remains unstarted; hooks for it (`AdversarialFindingsCache`, `priorAdversarialFindings` plumbing) are already pre-wired in the codebase.
- `truncated: true` output flag on the parsed response (so the rectifier prompt can acknowledge "you may be seeing a partial result") — deferred to PR B with carry-forward.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — clean.
- [x] `timeout 90 bun test test/unit/prompts/ test/unit/operations/ test/unit/review/ test/integration/review/ --timeout=10000` — 1086 pass / 0 fail.
- [x] `bun run test:bail` — full suite (1233 unit + integration + 13 UI) all pass.
- [x] New unit tests in `test/unit/prompts/review-builder.test.ts` cover all three threshold permutations + custom `advisoryCap`.
- [x] Updated `test/unit/review/{adversarial-retry,semantic-retry-truncation}.test.ts` to assert the new severity-aware prompt shape.