### PR TITLE
fix(operations): resolve timeout per operation config

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -49,6 +49,7 @@ export {
   decomposeConfigSelector,
   rectifyConfigSelector,
   acceptanceConfigSelector,
+  acceptanceFixConfigSelector,
   tddConfigSelector,
   debateConfigSelector,
   routingConfigSelector,

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -13,9 +13,10 @@ import type { NaxConfig } from "./types";
 
 export const reviewConfigSelector = pickSelector("review", "review", "debate");
 export const planConfigSelector = pickSelector("plan", "plan", "debate");
-export const decomposeConfigSelector = pickSelector("decompose", "agent");
+export const decomposeConfigSelector = pickSelector("decompose", "plan", "agent");
 export const rectifyConfigSelector = pickSelector("rectify", "execution");
 export const acceptanceConfigSelector = pickSelector("acceptance", "acceptance");
+export const acceptanceFixConfigSelector = pickSelector("acceptance-fix", "acceptance", "execution");
 export const tddConfigSelector = pickSelector("tdd", "tdd", "execution");
 export const debateConfigSelector = pickSelector("debate", "debate");
 export const routingConfigSelector = pickSelector("routing", "routing");

--- a/src/operations/acceptance-diagnose.ts
+++ b/src/operations/acceptance-diagnose.ts
@@ -32,6 +32,7 @@ export const acceptanceDiagnoseOp: RunOperation<AcceptanceDiagnoseInput, Accepta
   stage: "acceptance",
   session: { role: "diagnose", lifetime: "fresh" },
   config: acceptanceConfigSelector,
+  timeoutMs: (_input, ctx) => ctx.config.acceptance.timeoutMs,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildDiagnosisPrompt({
       testOutput: input.testOutput,

--- a/src/operations/acceptance-fix.ts
+++ b/src/operations/acceptance-fix.ts
@@ -1,4 +1,4 @@
-import { acceptanceConfigSelector } from "../config";
+import { acceptanceFixConfigSelector } from "../config";
 import { AcceptancePromptBuilder } from "../prompts";
 import type { RunOperation } from "./types";
 
@@ -22,14 +22,15 @@ export interface AcceptanceFixOutput {
   applied: true;
 }
 
-type AcceptanceConfig = ReturnType<typeof acceptanceConfigSelector.select>;
+type AcceptanceFixConfig = ReturnType<typeof acceptanceFixConfigSelector.select>;
 
-export const acceptanceFixSourceOp: RunOperation<AcceptanceFixSourceInput, AcceptanceFixOutput, AcceptanceConfig> = {
+export const acceptanceFixSourceOp: RunOperation<AcceptanceFixSourceInput, AcceptanceFixOutput, AcceptanceFixConfig> = {
   kind: "run",
   name: "acceptance-fix-source",
   stage: "acceptance",
   session: { role: "source-fix", lifetime: "fresh" },
-  config: acceptanceConfigSelector,
+  config: acceptanceFixConfigSelector,
+  timeoutMs: (_input, ctx) => ctx.config.execution.sessionTimeoutSeconds * 1000,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildSourceFixPrompt({
       testOutput: input.testOutput,
@@ -47,12 +48,13 @@ export const acceptanceFixSourceOp: RunOperation<AcceptanceFixSourceInput, Accep
   },
 };
 
-export const acceptanceFixTestOp: RunOperation<AcceptanceFixTestInput, AcceptanceFixOutput, AcceptanceConfig> = {
+export const acceptanceFixTestOp: RunOperation<AcceptanceFixTestInput, AcceptanceFixOutput, AcceptanceFixConfig> = {
   kind: "run",
   name: "acceptance-fix-test",
   stage: "acceptance",
   session: { role: "test-fix", lifetime: "fresh" },
-  config: acceptanceConfigSelector,
+  config: acceptanceFixConfigSelector,
+  timeoutMs: (_input, ctx) => ctx.config.execution.sessionTimeoutSeconds * 1000,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildTestFixPrompt({
       testOutput: input.testOutput,

--- a/src/operations/acceptance-generate.ts
+++ b/src/operations/acceptance-generate.ts
@@ -29,6 +29,7 @@ export const acceptanceGenerateOp: CompleteOperation<
   stage: "acceptance",
   jsonMode: false,
   config: acceptanceConfigSelector,
+  timeoutMs: (_input, ctx) => ctx.config.acceptance.timeoutMs,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildGeneratorFromPRDPrompt({
       featureName: input.featureName,

--- a/src/operations/acceptance-refine.ts
+++ b/src/operations/acceptance-refine.ts
@@ -20,6 +20,7 @@ export const acceptanceRefineOp: CompleteOperation<AcceptanceRefineInput, Accept
   stage: "acceptance",
   jsonMode: true,
   config: acceptanceConfigSelector,
+  timeoutMs: (_input, ctx) => ctx.config.acceptance.timeoutMs,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildRefinementPrompt(input.criteria, input.codebaseContext);
     return {

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -71,6 +71,7 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
   stage: "review",
   session: { role: "reviewer-adversarial", lifetime: "fresh" },
   config: reviewConfigSelector,
+  timeoutMs: (input) => input.adversarialConfig.timeoutMs,
   hopBody: adversarialReviewHopBody,
   build(input, _ctx) {
     const base = new AdversarialReviewPromptBuilder().buildAdversarialReviewPrompt(

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -152,7 +152,7 @@ export function buildHopCallback(
       pipelineStage: stage,
     });
     const modelDef = resolveModelForAgent(config.models, agentName, effectiveTier, defaultAgent);
-    const timeoutSeconds = config.execution.sessionTimeoutSeconds;
+    const timeoutSeconds = resolvedRunOptions.timeoutSeconds ?? config.execution.sessionTimeoutSeconds;
 
     // openSession errors propagate naturally — no handle, no closeSession needed
     const handle = await sessionManager.openSession(sessionName, {

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -14,6 +14,18 @@ function normalizeSelector<C>(s: ConfigSelector<C> | readonly (keyof NaxConfig)[
   return s as ConfigSelector<C>;
 }
 
+function resolveTimeoutMs<I, O, C>(op: Operation<I, O, C>, input: I, buildCtx: BuildContext<C>): number | undefined {
+  const timeoutMs = op.timeoutMs?.(input, buildCtx);
+  if (timeoutMs === undefined) return undefined;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new NaxError(`callOp[${op.name}]: invalid timeoutMs (${String(timeoutMs)})`, "CALL_OP_INVALID_TIMEOUT", {
+      stage: op.stage,
+      timeoutMs,
+    });
+  }
+  return timeoutMs;
+}
+
 /**
  * Synthesize a minimal UserStory for callOp use cases that don't carry a real
  * one (CLI ad-hoc calls, debate runners, simple op invocations). Only the `id`
@@ -47,6 +59,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
   const buildCtx = { packageView: ctx.packageView, config: slicedConfig };
   const sections = composeSections(op.build(input, buildCtx));
   const prompt = join(sections);
+  const timeoutMs = resolveTimeoutMs(op, input, buildCtx);
 
   const config = ctx.runtime.configLoader.current();
   const defaultAgent = ctx.runtime.agentManager.getDefault();
@@ -67,6 +80,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       storyId: ctx.storyId,
       workdir: ctx.packageDir,
       featureName: ctx.featureName,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       onPidSpawned: ctx.runtime.onPidSpawned,
     });
     const parsedComplete = op.parse(raw.output, input, buildCtx);
@@ -85,7 +99,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
     workdir: ctx.packageDir,
     modelTier: effectiveTier,
     modelDef: resolved.modelDef,
-    timeoutSeconds: config.execution.sessionTimeoutSeconds,
+    timeoutSeconds: timeoutMs !== undefined ? Math.ceil(timeoutMs / 1000) : config.execution.sessionTimeoutSeconds,
     pipelineStage: op.stage,
     config,
     sessionRole,

--- a/src/operations/decompose.ts
+++ b/src/operations/decompose.ts
@@ -23,6 +23,7 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
   stage: "plan",
   jsonMode: false,
   config: decomposeConfigSelector,
+  timeoutMs: (_input, ctx) => (ctx.config.plan.decomposeTimeoutSeconds ?? ctx.config.plan.timeoutSeconds ?? 600) * 1000,
   build(input, _ctx) {
     const prompt = buildDecomposePromptSync({
       specContent: input.specContent,

--- a/src/operations/plan.ts
+++ b/src/operations/plan.ts
@@ -24,6 +24,7 @@ export const planOp: CompleteOperation<PlanOpInput, PRD, PlanConfig> = {
   stage: "plan",
   jsonMode: false,
   config: planConfigSelector,
+  timeoutMs: (_input, ctx) => (ctx.config.plan.timeoutSeconds ?? 600) * 1000,
   build(input, _ctx) {
     const { taskContext, outputFormat } = new PlanPromptBuilder().build(
       input.specContent,

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -74,6 +74,7 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
   stage: "review",
   session: { role: "reviewer-semantic", lifetime: "fresh" },
   config: reviewConfigSelector,
+  timeoutMs: (input) => input.semanticConfig.timeoutMs,
   hopBody: semanticReviewHopBody,
   build(input, _ctx) {
     const base = new ReviewPromptBuilder().buildSemanticReviewPrompt(input.story, input.semanticConfig, {

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -56,6 +56,12 @@ interface OperationBase<I, O, C> {
    */
   readonly parse: (output: string, input: I, ctx: BuildContext<C>) => O;
   /**
+   * Optional operation-specific timeout resolver in milliseconds.
+   * callOp uses this as the single timeout source and converts to seconds
+   * only at runOptions boundaries for run-kind operations.
+   */
+  readonly timeoutMs?: (input: I, ctx: BuildContext<C>) => number | undefined;
+  /**
    * Optional. Validate parsed output against on-disk artifacts. Returning
    * non-null wins; returning null means "parsed output insufficient — fall
    * through to recover (if defined) or return the original parsed value".

--- a/test/unit/operations/acceptance-fix.test.ts
+++ b/test/unit/operations/acceptance-fix.test.ts
@@ -44,6 +44,11 @@ describe("acceptanceFixSourceOp shape", () => {
   test("stage is acceptance", () => {
     expect(acceptanceFixSourceOp.stage).toBe("acceptance");
   });
+  test("timeoutMs resolves from execution.sessionTimeoutSeconds", () => {
+    const ctx = makeSourceCtx();
+    const timeoutMs = acceptanceFixSourceOp.timeoutMs?.(SOURCE_INPUT, ctx);
+    expect(timeoutMs).toBe((ctx.config.execution.sessionTimeoutSeconds ?? 0) * 1000);
+  });
 });
 
 describe("acceptanceFixSourceOp.build()", () => {
@@ -92,6 +97,11 @@ describe("acceptanceFixTestOp shape", () => {
   });
   test("stage is acceptance", () => {
     expect(acceptanceFixTestOp.stage).toBe("acceptance");
+  });
+  test("timeoutMs resolves from execution.sessionTimeoutSeconds", () => {
+    const ctx = makeTestCtx();
+    const timeoutMs = acceptanceFixTestOp.timeoutMs?.(TEST_INPUT, ctx);
+    expect(timeoutMs).toBe((ctx.config.execution.sessionTimeoutSeconds ?? 0) * 1000);
   });
 });
 

--- a/test/unit/operations/call.test.ts
+++ b/test/unit/operations/call.test.ts
@@ -20,6 +20,12 @@ const echoOp: CompleteOperation<{ text: string }, string, Pick<typeof DEFAULT_CO
   parse: (output) => output.trim(),
 };
 
+const timedEchoOp: CompleteOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+  ...echoOp,
+  name: "timed-echo-test",
+  timeoutMs: () => 123_000,
+};
+
 const runEchoOp: RunOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
   kind: "run",
   name: "run-echo-test",
@@ -31,6 +37,24 @@ const runEchoOp: RunOperation<{ text: string }, string, Pick<typeof DEFAULT_CONF
     task: { id: "task", content: input.text, overridable: false },
   }),
   parse: (output) => output.trim(),
+};
+
+const timedRunEchoOp: RunOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+  ...runEchoOp,
+  name: "timed-run-echo-test",
+  timeoutMs: () => 123_000,
+};
+
+const invalidTimedEchoOp: CompleteOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+  ...echoOp,
+  name: "invalid-timed-echo-test",
+  timeoutMs: () => 0,
+};
+
+const invalidTimedRunEchoOp: RunOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+  ...runEchoOp,
+  name: "invalid-timed-run-echo-test",
+  timeoutMs: () => Number.NaN,
 };
 
 describe("callOp — kind:complete", () => {
@@ -50,6 +74,47 @@ describe("callOp — kind:complete", () => {
 
     expect(agentManager.completeAs).toHaveBeenCalledTimes(1);
     expect(result).toBe("echoed");
+  });
+
+  test("passes op timeoutMs to completeAs", async () => {
+    const completeResult: CompleteResult = { output: "echoed", costUsd: 0, source: "exact" };
+    const agentManager = makeMockAgentManager({ completeAsFn: async () => completeResult });
+    const runtime = makeTestRuntime({ agentManager });
+
+    await callOp(
+      {
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+      },
+      timedEchoOp,
+      { text: "hello world" },
+    );
+
+    const completeArgs = (agentManager.completeAs as ReturnType<typeof mock>).mock.calls[0]?.[2] as
+      | { timeoutMs?: number }
+      | undefined;
+    expect(completeArgs?.timeoutMs).toBe(123_000);
+  });
+
+  test("throws CALL_OP_INVALID_TIMEOUT on non-positive timeoutMs", async () => {
+    const completeResult: CompleteResult = { output: "echoed", costUsd: 0, source: "exact" };
+    const agentManager = makeMockAgentManager({ completeAsFn: async () => completeResult });
+    const runtime = makeTestRuntime({ agentManager });
+
+    await expect(
+      callOp(
+        {
+          runtime,
+          packageView: runtime.packages.repo(),
+          packageDir: "/tmp",
+          agentName: "claude",
+        },
+        invalidTimedEchoOp,
+        { text: "hello world" },
+      ),
+    ).rejects.toThrow("invalid timeoutMs");
   });
 });
 
@@ -151,5 +216,74 @@ describe("callOp — kind:run (ADR-019 §5)", () => {
 
     expect(thrown).not.toBeNull();
     expect(thrown?.message).toContain("agent returned no output");
+  });
+
+  test("uses op timeoutMs for run timeoutSeconds", async () => {
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (_req) => ({
+        result: {
+          success: true,
+          exitCode: 0,
+          output: "ran via fallback",
+          rateLimited: false,
+          durationMs: 1,
+          estimatedCostUsd: 0,
+          agentFallbacks: [],
+        },
+        fallbacks: [],
+      }),
+    });
+    const sessionManager = makeSessionManager();
+    const runtime = makeTestRuntime({ agentManager, sessionManager });
+
+    await callOp(
+      {
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "opencode",
+        storyId: "US-001",
+      },
+      timedRunEchoOp,
+      { text: "hello world" },
+    );
+
+    const reqArg = (agentManager.runWithFallback as ReturnType<typeof mock>).mock.calls[0]?.[0] as
+      | { runOptions?: { timeoutSeconds?: number } }
+      | undefined;
+    expect(reqArg?.runOptions?.timeoutSeconds).toBe(123);
+  });
+
+  test("throws CALL_OP_INVALID_TIMEOUT on non-finite run timeoutMs", async () => {
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (_req) => ({
+        result: {
+          success: true,
+          exitCode: 0,
+          output: "ran via fallback",
+          rateLimited: false,
+          durationMs: 1,
+          estimatedCostUsd: 0,
+          agentFallbacks: [],
+        },
+        fallbacks: [],
+      }),
+    });
+    const sessionManager = makeSessionManager();
+    const runtime = makeTestRuntime({ agentManager, sessionManager });
+
+    await expect(
+      callOp(
+        {
+          runtime,
+          packageView: runtime.packages.repo(),
+          packageDir: "/tmp",
+          agentName: "opencode",
+          storyId: "US-001",
+        },
+        invalidTimedRunEchoOp,
+        { text: "hello world" },
+      ),
+    ).rejects.toThrow("invalid timeoutMs");
   });
 });

--- a/test/unit/operations/timeout-resolvers.test.ts
+++ b/test/unit/operations/timeout-resolvers.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { makeTestRuntime } from "../../helpers";
+import { adversarialReviewOp } from "../../../src/operations/adversarial-review";
+import { decomposeOp } from "../../../src/operations/decompose";
+import { planOp } from "../../../src/operations/plan";
+import { semanticReviewOp } from "../../../src/operations/semantic-review";
+
+describe("operation timeout resolvers", () => {
+  test("planOp timeoutMs resolves from plan.timeoutSeconds", () => {
+    const runtime = makeTestRuntime();
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(planOp.config) };
+    const timeoutMs = planOp.timeoutMs?.(
+      {
+        specContent: "spec",
+        codebaseContext: "",
+        featureName: "feature",
+        branchName: "feature-branch",
+      },
+      ctx,
+    );
+    expect(timeoutMs).toBe((ctx.config.plan.timeoutSeconds ?? 600) * 1000);
+  });
+
+  test("decomposeOp timeoutMs prefers plan.decomposeTimeoutSeconds", () => {
+    const runtime = makeTestRuntime();
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(decomposeOp.config) };
+    const timeoutMs = decomposeOp.timeoutMs?.(
+      {
+        specContent: "spec",
+        codebaseContext: "",
+      },
+      ctx,
+    );
+    expect(timeoutMs).toBe((ctx.config.plan.decomposeTimeoutSeconds ?? ctx.config.plan.timeoutSeconds ?? 600) * 1000);
+  });
+
+  test("semanticReviewOp timeoutMs resolves from semanticConfig.timeoutMs input", () => {
+    const runtime = makeTestRuntime();
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(semanticReviewOp.config) };
+    const timeoutMs = semanticReviewOp.timeoutMs?.(
+      {
+        story: {
+          id: "US-001",
+          title: "title",
+          description: "desc",
+          acceptanceCriteria: ["AC-1"],
+        },
+        semanticConfig: {
+          modelTier: "balanced",
+          diffMode: "ref",
+          resetRefOnRerun: false,
+          rules: [],
+          timeoutMs: 321_000,
+        },
+        mode: "ref",
+      },
+      ctx,
+    );
+    expect(timeoutMs).toBe(321_000);
+  });
+
+  test("adversarialReviewOp timeoutMs resolves from adversarialConfig.timeoutMs input", () => {
+    const runtime = makeTestRuntime();
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(adversarialReviewOp.config) };
+    const timeoutMs = adversarialReviewOp.timeoutMs?.(
+      {
+        story: {
+          id: "US-002",
+          title: "title",
+          description: "desc",
+          acceptanceCriteria: ["AC-1"],
+        },
+        adversarialConfig: {
+          modelTier: "balanced",
+          diffMode: "ref",
+          rules: [],
+          timeoutMs: 654_000,
+          parallel: false,
+          maxConcurrentSessions: 2,
+        },
+        mode: "ref",
+      },
+      ctx,
+    );
+    expect(timeoutMs).toBe(654_000);
+  });
+});


### PR DESCRIPTION
Closes #788

## Summary
- Add operation-owned `timeoutMs` resolver to the operation contract (`OperationBase`)
- Update `callOp` to resolve timeout from the operation itself, then:
  - pass `timeoutMs` to complete-kind calls
  - convert to `timeoutSeconds` for run-kind calls
- Add validation in `callOp`: reject invalid timeout values (`<= 0` or non-finite)
- Update `buildHopCallback` to honor caller-provided `resolvedRunOptions.timeoutSeconds`
- Add explicit timeout resolvers for:
  - acceptance refine/generate/diagnose ops
  - acceptance fix ops (explicitly from `execution.sessionTimeoutSeconds` via dedicated selector)
  - plan/decompose ops
  - semantic/adversarial review ops
- Add `acceptanceFixConfigSelector` for clear timeout policy ownership in acceptance fix ops

## Tests
- `bun run typecheck`
- `bun test test/unit/operations/call.test.ts test/unit/operations/timeout-resolvers.test.ts --timeout=30000`
- `bun test test/unit/operations/acceptance-fix.test.ts --timeout=30000`
- `bun test test/unit/operations/ --timeout=30000`

## Notes
- This keeps timeout policy out of stage-based branching in `callOp`.
- Acceptance fix operations intentionally use `execution.sessionTimeoutSeconds`, while other acceptance ops use `acceptance.timeoutMs`.