### PR TITLE
fix: complete acceptance operation parity (PR2)

### DIFF
--- a/src/operations/acceptance-diagnose.ts
+++ b/src/operations/acceptance-diagnose.ts
@@ -1,6 +1,6 @@
+import type { SemanticVerdict } from "../acceptance/types";
 import { acceptanceConfigSelector } from "../config";
 import { AcceptancePromptBuilder } from "../prompts";
-import type { SemanticVerdict } from "../acceptance/types";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { RunOperation } from "./types";
 

--- a/src/operations/acceptance-diagnose.ts
+++ b/src/operations/acceptance-diagnose.ts
@@ -1,5 +1,6 @@
 import { acceptanceConfigSelector } from "../config";
 import { AcceptancePromptBuilder } from "../prompts";
+import type { SemanticVerdict } from "../acceptance/types";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { RunOperation } from "./types";
 
@@ -7,6 +8,7 @@ export interface AcceptanceDiagnoseInput {
   testOutput: string;
   testFileContent: string;
   sourceFiles: Array<{ path: string; content: string }>;
+  semanticVerdicts?: SemanticVerdict[];
   previousFailure?: string;
 }
 
@@ -38,6 +40,7 @@ export const acceptanceDiagnoseOp: RunOperation<AcceptanceDiagnoseInput, Accepta
       testOutput: input.testOutput,
       testFileContent: input.testFileContent,
       sourceFiles: input.sourceFiles,
+      semanticVerdicts: input.semanticVerdicts,
       previousFailure: input.previousFailure,
     });
     return {

--- a/src/operations/acceptance-refine.ts
+++ b/src/operations/acceptance-refine.ts
@@ -8,6 +8,10 @@ export interface AcceptanceRefineInput {
   criteria: string[];
   codebaseContext: string;
   storyId: string;
+  testStrategy?: "unit" | "component" | "cli" | "e2e" | "snapshot";
+  testFramework?: string;
+  storyTitle?: string;
+  storyDescription?: string;
 }
 
 export type AcceptanceRefineOutput = RefinedCriterion[];
@@ -22,7 +26,12 @@ export const acceptanceRefineOp: CompleteOperation<AcceptanceRefineInput, Accept
   config: acceptanceConfigSelector,
   timeoutMs: (_input, ctx) => ctx.config.acceptance.timeoutMs,
   build(input, _ctx) {
-    const prompt = new AcceptancePromptBuilder().buildRefinementPrompt(input.criteria, input.codebaseContext);
+    const prompt = new AcceptancePromptBuilder().buildRefinementPrompt(input.criteria, input.codebaseContext, {
+      testStrategy: input.testStrategy,
+      testFramework: input.testFramework,
+      storyTitle: input.storyTitle,
+      storyDescription: input.storyDescription,
+    });
     return {
       role: { id: "role", content: "", overridable: false },
       task: { id: "task", content: prompt, overridable: false },

--- a/src/pipeline/stages/acceptance-setup.ts
+++ b/src/pipeline/stages/acceptance-setup.ts
@@ -268,7 +268,15 @@ export const acceptanceSetupStage: PipelineStage = {
               ctx,
               ctx.workdir,
               acceptanceRefineOp,
-              { criteria: story.acceptanceCriteria, codebaseContext: "", storyId: story.id },
+              {
+                criteria: story.acceptanceCriteria,
+                codebaseContext: "",
+                storyId: story.id,
+                testStrategy: ctx.config.acceptance.testStrategy,
+                testFramework: ctx.config.acceptance.testFramework,
+                storyTitle: story.title,
+                storyDescription: story.description,
+              },
               story.id,
             ) as Promise<RefinedCriterion[]>
           )

--- a/test/unit/execution/lifecycle/acceptance-fix.test.ts
+++ b/test/unit/execution/lifecycle/acceptance-fix.test.ts
@@ -199,6 +199,29 @@ describe("resolveAcceptanceDiagnosis() — fast paths", () => {
     });
     expect(capturedInput?.previousFailure).toBe("PREVIOUS_MARKER");
   });
+
+  test("normal path passes semanticVerdicts to callOp input", async () => {
+    let capturedInput: any;
+    _applyFixDeps.callOp = async (_callCtx, _op, input) => {
+      capturedInput = input;
+      return { verdict: "source_bug", reasoning: "LLM diagnosis", confidence: 0.8 } as any;
+    };
+
+    const semanticVerdicts: SemanticVerdict[] = [
+      { storyId: "US-001", passed: false, timestamp: "2026-01-01T00:00:00Z", acCount: 2, findings: [] },
+    ];
+
+    await resolveAcceptanceDiagnosis({
+      ctx: makeAcceptanceCtx(true),
+      failures: { failedACs: ["AC-1"], testOutput: "fail" },
+      totalACs: 10,
+      strategy: "diagnose-first",
+      semanticVerdicts,
+      diagnosisOpts: makeDiagnosisOpts(),
+    });
+
+    expect(capturedInput?.semanticVerdicts).toEqual(semanticVerdicts);
+  });
 });
 
 // ─── applyFix() ─────────────────────────────────────────────────────────────

--- a/test/unit/operations/acceptance-diagnose.test.ts
+++ b/test/unit/operations/acceptance-diagnose.test.ts
@@ -7,6 +7,9 @@ const SAMPLE_INPUT: AcceptanceDiagnoseInput = {
   testOutput: "FAIL: expected 1 but got 2",
   testFileContent: "test('x', () => expect(fn()).toBe(1))",
   sourceFiles: [{ path: "src/fn.ts", content: "export function fn() { return 2; }" }],
+  semanticVerdicts: [
+    { storyId: "US-001", passed: true, timestamp: "2026-01-01T00:00:00Z", acCount: 2, findings: [] },
+  ],
 };
 
 function makeBuildCtx() {
@@ -48,6 +51,12 @@ describe("acceptanceDiagnoseOp.build()", () => {
     const ctx = makeBuildCtx();
     const result = acceptanceDiagnoseOp.build(SAMPLE_INPUT, ctx);
     expect(result.task.content).toContain("fn()");
+  });
+  test("task section includes semantic verdict hints when provided", () => {
+    const ctx = makeBuildCtx();
+    const result = acceptanceDiagnoseOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain("SEMANTIC VERDICTS");
+    expect(result.task.content).toContain("likely test bug");
   });
 });
 

--- a/test/unit/operations/acceptance-refine.test.ts
+++ b/test/unit/operations/acceptance-refine.test.ts
@@ -7,6 +7,10 @@ const SAMPLE_INPUT: AcceptanceRefineInput = {
   criteria: ["User can log in", "User can log out"],
   codebaseContext: "# Context\nRelevant files...",
   storyId: "US-001",
+  testStrategy: "component",
+  testFramework: "react-testing-library",
+  storyTitle: "Login flow",
+  storyDescription: "Allow users to authenticate with email and password",
 };
 
 function makeBuildCtx() {
@@ -40,6 +44,14 @@ describe("acceptanceRefineOp.build()", () => {
     const ctx = makeBuildCtx();
     const result = acceptanceRefineOp.build(SAMPLE_INPUT, ctx);
     expect(result.task.content).toContain("User can log in");
+  });
+  test("task section includes strategy/framework/story context", () => {
+    const ctx = makeBuildCtx();
+    const result = acceptanceRefineOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain("TEST STRATEGY: component");
+    expect(result.task.content).toContain("react-testing-library");
+    expect(result.task.content).toContain("Title: Login flow");
+    expect(result.task.content).toContain("Description: Allow users to authenticate");
   });
 });
 

--- a/test/unit/pipeline/stages/acceptance-setup-strategy.test.ts
+++ b/test/unit/pipeline/stages/acceptance-setup-strategy.test.ts
@@ -1,9 +1,9 @@
 /**
  * ACS-005: acceptance-setup stage — testStrategy / testFramework wiring
  *
- * testStrategy is now internalized inside the callOp implementation and not
- * visible in the mock input. Tests verify:
+ * Tests verify:
  *   - callOp is invoked when testStrategy is set (stage completes without error)
+ *   - testStrategy/testFramework/story context are forwarded to acceptance-refine op input
  *   - testFramework appears as frameworkOverrideLine in the generate callOp input
  */
 
@@ -152,6 +152,39 @@ describe("acceptance-setup: testStrategy config is consumed (callOp invoked)", (
     await acceptanceSetupStage.execute(ctx);
 
     expect(callOpCalled).toBe(true);
+  });
+
+  test("refine call receives strategy/framework/story context", async () => {
+    wireBasicDeps();
+    let capturedRefineInput:
+      | {
+          testStrategy?: string;
+          testFramework?: string;
+          storyTitle?: string;
+          storyDescription?: string;
+        }
+      | undefined;
+
+    _acceptanceSetupDeps.callOp = async (_ctx, _pkg, op, input) => {
+      if (op.name === "acceptance-refine") {
+        capturedRefineInput = input as typeof capturedRefineInput;
+        const { criteria, storyId } = input as { criteria: string[]; storyId: string };
+        return criteria.map((c: string) => ({ original: c, refined: c, testable: true, storyId }));
+      }
+      if (op.name === "acceptance-generate") {
+        return { testCode: 'import { test } from "bun:test"; test("AC-1", () => {})' };
+      }
+      throw new Error(`unexpected op: ${op.name}`);
+    };
+
+    const ctx = makeCtx({ testStrategy: "component", testFramework: "ink-testing-library" });
+    await acceptanceSetupStage.execute(ctx);
+
+    expect(capturedRefineInput).toBeDefined();
+    expect(capturedRefineInput?.testStrategy).toBe("component");
+    expect(capturedRefineInput?.testFramework).toBe("ink-testing-library");
+    expect(capturedRefineInput?.storyTitle).toBe("Story US-001");
+    expect(capturedRefineInput?.storyDescription).toBe("desc");
   });
 });
 


### PR DESCRIPTION
## Summary
- make acceptanceRefineOp consume strategy/framework/story context via config-selected input
- make acceptanceDiagnoseOp consume semanticVerdicts so diagnosis prompt receives semantic review context
- thread refine context from acceptance setup into op input
- add focused unit coverage for refine/diagnose prompt composition and lifecycle forwarding

## Why
PR1 fixed acceptance timeout selection. This PR2 completes the broader operation parity by ensuring acceptance ops use the same context inputs as legacy acceptance flow where applicable.

## Test Plan
- bun test test/unit/operations/acceptance-refine.test.ts test/unit/operations/acceptance-diagnose.test.ts test/unit/pipeline/stages/acceptance-setup-strategy.test.ts test/unit/execution/lifecycle/acceptance-fix.test.ts --timeout=30000
- bun run typecheck