### PR TITLE
chore(adr-019): foundation for legacy agentManager.run test migration

### DIFF
--- a/docs/findings/2026-04-29-legacy-agentmanager-run-cleanup.md
+++ b/docs/findings/2026-04-29-legacy-agentmanager-run-cleanup.md
@@ -1,0 +1,247 @@
+# Legacy `agentManager.run` cleanup — post ADR-018/019/020
+
+**Date:** 2026-04-29
+**Reporter:** williamkhoo
+**Related issue:** [#762](https://github.com/nathapp-io/nax/issues/762)
+**Related ADRs:**
+- [ADR-018 — Runtime layering with session runners](../adr/ADR-018-runtime-layering-with-session-runners.md)
+- [ADR-019 — Adapter primitives and session ownership](../adr/ADR-019-adapter-primitives-and-session-ownership.md)
+- [ADR-020 — Dispatch boundary SSOT](../adr/ADR-020-dispatch-boundary-ssot.md)
+- Predecessor finding: [2026-04-27 post ADR-018/019 dogfood](./2026-04-27-post-adr-018-019-dogfood-issues.md)
+
+---
+
+## TL;DR
+
+Issue #762 names two files (`semantic.ts`, `adversarial.ts`), but the same
+`if (runtime) { callOp/runWithFallback } else { legacy keepOpen agentManager.run }`
+pattern exists in **six source files** plus one unrelated interactive callsite.
+
+After PR #761 threaded `runtime` into every per-story `PipelineContext`,
+most of those `else` branches are dead under `executeUnified()`. **However**,
+a few callers still pass `runtime: undefined`, so blindly deleting the
+`else` block will silently regress those flows.
+
+This finding catalogs every legacy site, classifies it by readiness, and
+recommends a 3-PR cleanup sequence.
+
+---
+
+## Pattern under review
+
+The legacy pattern is:
+
+```ts
+if (runtime) {
+  // ADR-019 Pattern A — dispatch via callOp / runWithFallback + buildHopCallback
+  // Middleware (audit, cost, cancellation) fires uniformly.
+  ...
+} else {
+  // @deprecated Legacy keepOpen path
+  // TODO(ADR-019): Remove once all callers thread runtime.
+  logger?.warn(scope, "LLM call via legacy agentManager.run — middleware skipped", { storyId });
+  ...
+  const result = await agentManager.run({ runOptions: { ..., keepOpen: true } });
+  ...
+  void legacyCloser?.closePhysicalSession?.(sessionName, workdir);
+}
+```
+
+Per ADR-019 §1 + ADR-020 Wave 3, all dispatch must flow through:
+- **Layer 4 (preferred):** `callOp(ctx, op, input)`
+- **Layer 3:** `agentManager.completeAs` / `runAsSession` / `runWithFallback`
+- **Layer 2:** `sessionManager.openSession` + `runAsSession × N` + `closeSession`
+- **Layer 1 (wiring only):** `adapter.openSession` / `sendTurn` / `closeSession` / `complete`
+  (allowed only inside `src/agents/manager.ts`, `src/agents/utils.ts`, `src/session/manager.ts`)
+
+`agentManager.run({ runOptions: { ..., keepOpen: true } })` is a Layer-3
+escape hatch that:
+1. Skips most middleware (audit / cost / cancellation hooks fire from
+   `runAsSession`, not from `run`).
+2. Implicitly creates an ACP session inside the adapter, requiring callers
+   to manually `closePhysicalSession` later (visible as the `legacyCloser`
+   helper in semantic/adversarial).
+3. Bypasses fallback/handoff because it does not go through `buildHopCallback`.
+
+Removing it is the goal of ADR-019 Wave 3 follow-through.
+
+---
+
+## Inventory
+
+### Sites found
+
+```bash
+$ grep -rn "agentManager\.run\b\|agentManager\.runAs\b" src/ --include="*.ts" \
+    | grep -v "\.test\.ts\|runAsSession\|runWithFallback"
+```
+
+| # | File | Line | Function / context |
+|---|------|------|--------------------|
+| 1 | [src/review/semantic.ts](../../src/review/semantic.ts) | 309–478 | `runSemanticReview` legacy `else` branch |
+| 2 | [src/review/adversarial.ts](../../src/review/adversarial.ts) | 266–466 | `runAdversarialReview` legacy `else` branch |
+| 3 | [src/pipeline/stages/autofix-adversarial.ts](../../src/pipeline/stages/autofix-adversarial.ts) | 192–196 | `runTestWriterRectification` legacy `else` |
+| 4 | [src/pipeline/stages/autofix-agent.ts](../../src/pipeline/stages/autofix-agent.ts) | 329–385 | `runAgentRectification` legacy `else` |
+| 5 | [src/verification/rectification-loop.ts](../../src/verification/rectification-loop.ts) | 312–376 | `runRectificationLoop` legacy `else` |
+| 6 | [src/tdd/rectification-gate.ts](../../src/tdd/rectification-gate.ts) | 330–394 | `runRectificationLoop` (TDD full-suite gate) legacy `else` |
+| 7 | [src/cli/plan.ts](../../src/cli/plan.ts) | 259 | `agentManager.runAs(...)` interactive plan — different concern |
+
+---
+
+## Classification by readiness
+
+### Group A — Safe to delete now
+
+`runtime` is unconditionally threaded by all current callers. The `if (runtime)` guard can be replaced with a `NaxError` ("fail fast, not fail-open") so the dispatch boundary is enforced rather than silently downgraded.
+
+| # | File | Lines | Notes |
+|---|------|-------|-------|
+| 1 | `src/review/semantic.ts` | 309–478 | Issue #762 — already annotated `@deprecated` with `TODO(ADR-019)` |
+| 2 | `src/review/adversarial.ts` | 266–466 | Issue #762 — already annotated `@deprecated` with `TODO(ADR-019)` |
+| 3 | `src/pipeline/stages/autofix-adversarial.ts` | 192–196 | Takes `ctx: PipelineContext`; `ctx.runtime` always present after PR #761 |
+| 4 | `src/pipeline/stages/autofix-agent.ts` | 377–385 | Takes `ctx: PipelineContext`; `ctx.runtime` always present after PR #761 |
+
+**Verification of #3 and #4:** both functions accept `ctx: PipelineContext`. `executeUnified()` constructs every per-story context literal with `runtime: ctx.runtime` after PR #761:
+
+- [src/execution/iteration-runner.ts:185, 247](../../src/execution/iteration-runner.ts) ✅
+- [src/execution/unified-executor.ts:151, 253, 292, 575](../../src/execution/unified-executor.ts) ✅
+- [src/execution/lifecycle/acceptance-loop.ts:145](../../src/execution/lifecycle/acceptance-loop.ts) ✅
+- [src/execution/merge-conflict-rectify.ts:144](../../src/execution/merge-conflict-rectify.ts) ✅
+
+So Group A can be cleaned in one direct PR without further wiring work.
+
+**Cleanup template (per file):**
+
+```ts
+// Before
+if (runtime) {
+  // ADR-019 Pattern A...
+  ...
+} else {
+  // @deprecated Legacy keepOpen path
+  ...
+}
+
+// After
+if (!runtime) {
+  throw new NaxError(
+    "runtime required — legacy agentManager.run path removed (ADR-019 Wave 3)",
+    "DISPATCH_NO_RUNTIME",
+    { stage, storyId: story.id },
+  );
+}
+// ADR-019 Pattern A...
+...
+```
+
+---
+
+### Group B — Needs upstream wiring fix first
+
+Same legacy `else` branch, but **at least one production caller passes `runtime: undefined`**, so the legacy path is currently live. Removing it without first threading `runtime` will regress those flows.
+
+| # | File (legacy branch) | Caller missing `runtime` | Symptom if removed prematurely |
+|---|----------------------|--------------------------|-------------------------------|
+| 5 | `src/verification/rectification-loop.ts:312–376` | [src/pipeline/stages/rectify.ts:130](../../src/pipeline/stages/rectify.ts#L130) — `runRectificationLoop({...})` literal omits `runtime` | Every post-verify rectification crashes with `DISPATCH_NO_RUNTIME` |
+| 5 | (same) | [src/execution/lifecycle/run-regression.ts:323](../../src/execution/lifecycle/run-regression.ts#L323) — deferred regression gate omits `runtime` | Deferred regression rectification crashes |
+| 6 | `src/tdd/rectification-gate.ts:330–394` | [src/tdd/orchestrator.ts:260](../../src/tdd/orchestrator.ts#L260) — `runFullSuiteGate(...)` does not forward `runtime` | Every TDD full-suite gate regression rectification fires the legacy path; removal crashes the entire TDD path |
+
+`merge-conflict-rectify.ts:144` is OK — it already passes `runtime: options.runtime`.
+
+**Wiring fix shape:**
+- Add `runtime?: NaxRuntime` to `RectificationLoopOptions` (already done — see line 82 doc-comment) and **forward it** from the two production callers.
+- Add a `runtime` parameter (or thread via options) on `runFullSuiteGate` and forward from `tdd/orchestrator.ts:260`.
+
+After the wiring fix, apply the same `if (!runtime) throw NaxError` pattern as Group A.
+
+---
+
+### Group C — Out of scope (different concern)
+
+| # | File | Pattern | Why different |
+|---|------|---------|---------------|
+| 7 | [src/cli/plan.ts:259](../../src/cli/plan.ts#L259) | `agentManager.runAs(agentName, { runOptions: { ..., interactionBridge, ... } })` | This is the **interactive** plan path — TTY user co-drives the session via `interactionBridge`. Auto-mode plan already uses `callOp(planOp, ...)` at [line 188](../../src/cli/plan.ts#L188). Migrating the interactive variant requires either an `interactivePlanOp` or formally admitting the canonical Layer-3 manager API path; this is **not a "remove legacy" cleanup** — it is design work tracked separately. |
+
+---
+
+## Recommended PR sequence
+
+Three PRs, ordered by risk and to keep diffs reviewable:
+
+### PR-A — issue #762 literal scope
+
+- Files: `src/review/semantic.ts`, `src/review/adversarial.ts`
+- Action: drop the `else` legacy block; replace `if (runtime)` with `if (!runtime) throw NaxError`
+- Removes the per-stage `legacyCloser` / `formatSessionName(role: "reviewer-…")` / model-resolution helpers used only by the legacy path
+- AC mirrors issue #762:
+  - [ ] Both `else` legacy branches deleted
+  - [ ] `if (runtime)` guard replaced with `NaxError` (fail fast, not fail-open)
+  - [ ] All tests pass (`bun run test`)
+  - [ ] `bun run typecheck` clean
+  - [ ] `grep -r "agentManager\.run" src/review/` returns nothing
+
+### PR-B — sibling cleanup (no wiring change)
+
+- Files: `src/pipeline/stages/autofix-adversarial.ts`, `src/pipeline/stages/autofix-agent.ts`
+- Same diff shape as PR-A — collapse `if (ctx.runtime) { … } else { legacy }` to a fail-fast guard
+- Cheap, identical pattern, prevents drift on the same boundary
+
+### PR-C — wiring fix + cleanup (highest impact)
+
+- Wiring:
+  - Thread `runtime: ctx.runtime` from `src/pipeline/stages/rectify.ts:130` into the `runRectificationLoop({ … })` literal
+  - Thread `runtime` from `src/execution/lifecycle/run-regression.ts:323` (likely needs `DeferredRegressionOptions.runtime` field)
+  - Thread `runtime` from `src/tdd/orchestrator.ts:260` into `runFullSuiteGate(...)` (and through to inner `runRectificationLoop` at `src/tdd/rectification-gate.ts:182`)
+- Cleanup:
+  - Drop legacy `else` in `src/verification/rectification-loop.ts:312–376`
+  - Drop legacy `else` in `src/tdd/rectification-gate.ts:330–394`
+- Add a regression test that asserts `runtime` is forwarded into `runRectificationLoop` / `runFullSuiteGate`
+- Recommended split: do the wiring + cleanup in one PR per gate (rectify, regression, tdd) so each can be reverted independently if a downstream consumer surfaces
+
+---
+
+## Why fail-fast, not fail-open
+
+ADR-019 §3 + ADR-020 §D3 §D4 are clear: the dispatch boundary is the SSOT
+for middleware (audit, cost, cancellation). Silently downgrading to the
+legacy path:
+
+- Loses prompt-audit entries for the affected hops (issue #1 in the dogfood
+  finding)
+- Under-counts per-check cost (`ReviewCheckResult.cost` becomes 0)
+- Skips the cancellation middleware → orphan acpx subprocesses on Ctrl+C
+  (issue #792)
+- Bypasses fallback policy → no agent handoff if the primary fails
+
+A `NaxError` makes wiring gaps **loud** instead of silent — this is the
+same lesson the ADR-012 phase-6 legacy-key guard (`CONFIG_LEGACY_AGENT_KEYS`)
+encodes for config.
+
+---
+
+## Out-of-scope notes
+
+- **`src/cli/plan.ts:259`** — interactive planning. Not a fallback; needs design (interactivePlanOp or formal Layer-3 admission). File a separate issue if desired.
+- **`src/agents/manager.ts:463–469`** — `AgentManager.run()` and `AgentManager.complete()` themselves remain as Layer-3 primitives. They are not "legacy"; they are the manager API. Group A/B/C only delete the **callsites that bypass higher layers**, not the methods themselves. Whether to ultimately privatize `agentManager.run` (keep `runAs`/`runAsSession`/`runWithFallback` only) is a follow-up after Group C lands.
+
+---
+
+## Quick verification commands
+
+```bash
+# After PR-A
+grep -rn "agentManager\.run\b" src/review/ | grep -v "\.test\.ts"
+# expect: no matches
+
+# After PR-B
+grep -rn "agentManager\.run\b" src/pipeline/stages/ | grep -v "\.test\.ts"
+# expect: no matches
+
+# After PR-C
+grep -rn "agentManager\.run\b" src/verification/ src/tdd/ | grep -v "\.test\.ts"
+# expect: no matches
+
+# Final sweep — should leave only src/cli/plan.ts and intra-manager calls
+grep -rn "agentManager\.run\b\|agentManager\.runAs\b" src/ --include="*.ts" \
+  | grep -v "\.test\.ts\|runAsSession\|runWithFallback"
+```

--- a/docs/findings/2026-04-29-legacy-run-test-migration-playbook.md
+++ b/docs/findings/2026-04-29-legacy-run-test-migration-playbook.md
@@ -1,0 +1,344 @@
+# Playbook — migrate review/autofix tests to runtime path (ADR-019 Wave 3)
+
+**Date:** 2026-04-29
+**Predecessor:** [2026-04-29 legacy `agentManager.run` cleanup analysis](./2026-04-29-legacy-agentmanager-run-cleanup.md)
+**Goal:** migrate the seven test files listed below so each call into `runSemanticReview` / `runAdversarialReview` / `runAgentRectification` / `runTestWriterRectification` exercises the ADR-019 runtime/`callOp` dispatch path. After this playbook is done, the source-cleanup PR can drop the legacy `agentManager.run({ keepOpen: true })` fallback without breaking tests.
+
+This document is the **agent prompt source of truth**. It must stay self-contained so an opencode (or any other agent CLI) run with a cheap model can follow it end-to-end without other context.
+
+---
+
+## TL;DR for humans
+
+- Foundation PR (`chore/adr-019-test-migration-foundation`) introduces `makeMockRuntime` and migrates two reference test files. All tests stay green.
+- This playbook describes how a remote agent migrates the remaining 7 files.
+- After the migration PR lands, a small cleanup PR drops the legacy code path in `src/review/{semantic,adversarial}.ts` and `src/pipeline/stages/autofix-{agent,adversarial}.ts`.
+
+---
+
+## Context the agent needs
+
+`nax` is a Bun + TypeScript project. It runs tests via `bun test`. ADR-019 migrated review and autofix dispatch to flow through a `NaxRuntime` (`callOp` → `runWithFallback` → `buildHopCallback` → `openSession` + `runAsSession`). The legacy code path used `agentManager.run({ keepOpen: true })` — that path is being removed.
+
+Some tests still exercise the legacy path because they pass `agentManager` only and not `runtime`. This playbook adds a `runtime` parameter (or threads it through the test's `makeCtx` helper) so those tests run via the new path.
+
+A new helper `makeMockRuntime` (in `test/helpers/runtime.ts`) builds a NaxRuntime suitable for unit tests:
+
+```ts
+import { makeMockRuntime } from "../../helpers";
+
+const runtime = makeMockRuntime({ agentManager });   // wraps an existing agent-manager mock
+```
+
+`makeMockRuntime` accepts `{ agentManager?, sessionManager?, config?, workdir? }` and returns a real `NaxRuntime` built around the provided mocks via `createRuntime`. Always pass `agentManager` so the runtime's dispatch flows through the same mock the test set up.
+
+---
+
+## File list (the agent's whole job)
+
+These seven files have tests that currently fail when the legacy path is removed. Process them in any order. Two reference files have already been migrated and serve as patterns; do not edit them.
+
+### Reference migrations (DO NOT EDIT — copy patterns from these)
+
+- `test/unit/review/semantic-parsing.test.ts` — pattern **T2-review**: hoist `agentManager`, build `runtime`, pass at the last positional slot.
+- `test/unit/pipeline/stages/autofix-routing.test.ts` — pattern **T2-pipeline**: modify the file's `makeCtx()` helper to derive `runtime` from `overrides.agentManager`.
+
+### Files to migrate
+
+1. `test/unit/review/adversarial-pass-fail.test.ts` — apply T2-review.
+2. `test/unit/review/semantic-agent-session.test.ts` — apply T2-review.
+3. `test/unit/review/semantic-debate.test.ts` — apply T2-review.
+4. `test/unit/review/semantic-findings.test.ts` — apply T2-review.
+5. `test/unit/review/semantic-signature-diff.test.ts` — apply T2-review.
+6. `test/unit/pipeline/stages/autofix-adversarial.test.ts` — apply T2-pipeline.
+7. `test/unit/pipeline/stages/autofix-budget-prompts.test.ts` — apply T2-pipeline.
+
+For each file: target failures only. If a file's tests already pass against the source-cleanup branch, mark it done and move on.
+
+---
+
+## Decision rule
+
+For each file, look at how it calls `runSemanticReview`, `runAdversarialReview`, or any pipeline stage that goes through `runAgentRectification` / `runTestWriterRectification`:
+
+| Shape of test | Pattern |
+|:---|:---|
+| Direct call to `runSemanticReview(...)` / `runAdversarialReview(...)` with positional args | **T2-review** |
+| Test calls `autofixStage.execute(ctx)` or similar pipeline stage with a custom `makeCtx()` helper in the file | **T2-pipeline** |
+
+If both shapes exist in one file: apply T2-pipeline first (helper change covers most usages), then T2-review for any residual direct calls.
+
+---
+
+## Pattern T2-review — direct review-function calls
+
+### Step 1 — add the import
+
+In the test file's import block, add `makeMockRuntime`:
+
+```ts
+import { makeMockAgentManager, makeMockRuntime, /* ...existing helpers... */ } from "../../helpers";
+```
+
+### Step 2 — hoist `agentManager`, build runtime, pass it
+
+Replace each call to `runSemanticReview(... makeAgentManager(response))` with a call that passes both an `agentManager` and a `runtime`. Reference (from `semantic-parsing.test.ts`):
+
+```ts
+async function callRunSemanticReview(response: string) {
+  const agentManager = makeAgentManager(response);
+  const runtime = makeMockRuntime({ agentManager });
+  return runSemanticReview(
+    "/tmp/wd",
+    "abc123",
+    STORY,
+    CONFIG,
+    agentManager,
+    undefined, // naxConfig
+    undefined, // featureName
+    undefined, // resolverSession
+    undefined, // priorFailures
+    undefined, // blockingThreshold
+    undefined, // featureContextMarkdown
+    undefined, // contextBundle
+    undefined, // projectDir
+    undefined, // naxIgnoreIndex
+    runtime,
+  );
+}
+```
+
+The `runtime` parameter is the **15th positional argument** for `runSemanticReview` and the **15th positional argument** for `runAdversarialReview` (after `naxIgnoreIndex`, before `priorAdversarialFindings` for adversarial — check the actual signature in `src/review/{semantic,adversarial}.ts` if unclear).
+
+If the file already extracts `agentManager` into a variable, you only need to add the `runtime` line and pass it as the last arg.
+
+### Step 3 — verify
+
+Run: `timeout 30 bun test <file> --timeout=10000`
+
+If 0 fail: done. Commit. Move to next file.
+
+If still failing: see "If a file resists the pattern" below.
+
+---
+
+## Pattern T2-pipeline — pipeline-stage tests with `makeCtx()` helper
+
+### Step 1 — add the import
+
+```ts
+import { makeMockAgentManager, makeMockRuntime, /* ...existing helpers... */ } from "../../helpers";
+```
+
+### Step 2 — modify the file's `makeCtx()` helper
+
+Find the local `makeCtx(overrides: Partial<PipelineContext>)` function in the file (commonly near the top). Extract `agentManager` once and derive `runtime` from it. Reference (from `autofix-routing.test.ts`):
+
+```ts
+function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  // ADR-019: derive runtime from agentManager so callOp dispatch flows through
+  // the same mock the test set up. Override `runtime` explicitly when a test
+  // needs a different shape.
+  const agentManager = overrides.agentManager ?? makeMockAgentManager();
+  return {
+    // ...existing fields...
+    agentManager,
+    runtime: overrides.runtime ?? makeMockRuntime({ agentManager }),
+    ...overrides,
+  };
+}
+```
+
+The two key changes:
+- Hoist `agentManager` so the same instance can be reused.
+- Add `runtime: overrides.runtime ?? makeMockRuntime({ agentManager })`.
+
+If the file's `makeCtx` already uses `makeMockAgentManager()` inline, you can keep that call but assign the result to a `const agentManager =` first.
+
+### Step 3 — verify
+
+Run: `timeout 30 bun test <file> --timeout=10000`
+
+If 0 fail: done. Commit. Move to next file.
+
+If still failing: see "If a file resists the pattern" below.
+
+---
+
+## If a file resists the pattern
+
+Some failures need extra care. The fallback is:
+
+1. `git restore <file>` (revert your changes).
+2. Append to `quarantine.md` at repo root, with format:
+   ```
+   ## <file>
+   - Reason: <one-line summary of what didn't work>
+   - First failing test: <name>
+   - Last error line: <copy-paste>
+   ```
+3. Mark the file as `[~] <file>` in the progress tracker.
+4. Move to next file.
+
+A human will handle quarantined files after the batch.
+
+---
+
+## Workflow rules (the agent must follow)
+
+1. Make a working branch off `main` (or off the foundation PR's merge once it lands): `chore/adr-019-test-migration-batch`.
+2. Apply the source-cleanup commits *first* so legacy code is removed and the failing tests are visible (see "Bootstrap" below).
+3. Process the file list in order. One file at a time.
+4. For each file:
+   - Run `timeout 30 bun test <file> --timeout=10000`.
+   - If 0 fail: tick `[x]` in `migration-progress.md`, do NOT commit (no change), continue.
+   - If failing: apply T2-review or T2-pipeline per decision rule, re-run, then commit on success or quarantine on failure.
+5. After all files: run `bun run test` (full suite). Append result to `migration-progress.md`.
+6. **STOP. Do NOT push. Do NOT call `gh pr create`. A human reviews and pushes.**
+
+### Boundaries
+
+The agent must NEVER edit files outside:
+- The test file currently being migrated.
+- `migration-progress.md`
+- `quarantine.md`
+
+The agent must NEVER call:
+- `git push`
+- `gh pr create` / `gh pr edit`
+- Any network command except `bun install` (only if the install is missing — should not happen).
+
+### Verification commands
+
+| Purpose | Command |
+|:---|:---|
+| Test one file | `timeout 30 bun test <file> --timeout=10000` |
+| Typecheck | `bun run typecheck` |
+| Lint | `bun run lint` |
+| Full test suite | `bun run test` |
+
+If `bun run lint` fails with formatting errors after editing, run `bun run lint:fix` and commit the formatting changes.
+
+---
+
+## Bootstrap (run once before processing files)
+
+The agent is expected to start on a branch where the legacy code has been removed so failures are visible. Bootstrap commands:
+
+```bash
+# Foundation must already be merged into main (or available on the foundation branch).
+git fetch origin
+git checkout main
+git pull
+git checkout -b chore/adr-019-test-migration-batch
+
+# Apply the source-cleanup patches. These four files have one mechanical change:
+# replace the `if (runtime) { ... } else { legacy ... }` with `if (!runtime) throw NaxError; ...`
+# Pre-prepared patches live at scripts/adr-019-source-cleanup.patch — apply them:
+git apply scripts/adr-019-source-cleanup.patch
+
+# Sanity check: the bootstrap should leave the working tree dirty in 4 src/ files.
+git status -s | wc -l   # expect 4
+
+# Verify failures are visible
+timeout 60 bun test test/unit/review/adversarial-pass-fail.test.ts --timeout=10000
+# Expect ~13 fail with "DISPATCH_NO_RUNTIME"
+```
+
+If the patch does not apply cleanly, stop and write `quarantine.md` with the apply error.
+
+---
+
+## Progress tracker (the agent maintains this)
+
+Create `migration-progress.md` at repo root with this initial content:
+
+```markdown
+# ADR-019 test migration progress
+
+Started: <ISO timestamp>
+Branch: chore/adr-019-test-migration-batch
+
+## Files
+
+- [ ] test/unit/review/adversarial-pass-fail.test.ts  (T2-review)
+- [ ] test/unit/review/semantic-agent-session.test.ts (T2-review)
+- [ ] test/unit/review/semantic-debate.test.ts        (T2-review)
+- [ ] test/unit/review/semantic-findings.test.ts      (T2-review)
+- [ ] test/unit/review/semantic-signature-diff.test.ts (T2-review)
+- [ ] test/unit/pipeline/stages/autofix-adversarial.test.ts (T2-pipeline)
+- [ ] test/unit/pipeline/stages/autofix-budget-prompts.test.ts (T2-pipeline)
+
+## Final suite result
+(populated when done)
+```
+
+After each file: tick `[x]` for success, `[~]` for quarantine, leave `[ ]` if skipped.
+
+---
+
+## Agent Prompt
+
+Copy the section between the fences below and feed it to opencode.
+
+```
+You are migrating TypeScript test files in a Bun+TS project. The repo at the
+current working directory is `nax`. Your goal: migrate seven specific test
+files so they pass after the legacy `agentManager.run({ keepOpen: true })`
+code path is removed.
+
+Read this entire file BEFORE starting:
+docs/findings/2026-04-29-legacy-run-test-migration-playbook.md
+
+Specifically follow:
+1. The "Bootstrap" section to set up the working branch and apply patches.
+2. The "File list" section for the queue of files.
+3. The "Decision rule" + "Pattern T2-review" / "Pattern T2-pipeline" sections
+   for how to migrate each file.
+4. The "Workflow rules" section for invariants — DO NOT push, DO NOT open PRs,
+   DO NOT edit files outside the file currently being migrated +
+   migration-progress.md + quarantine.md.
+
+For each file in the queue:
+  1. Run: timeout 30 bun test <file> --timeout=10000
+  2. If exit 0: tick [x] in migration-progress.md, continue. Do NOT commit.
+  3. If failing:
+     a. Determine pattern (T2-review or T2-pipeline) using the Decision Rule.
+     b. Apply the pattern by editing the test file. Use the Reference
+        migrations as templates (semantic-parsing.test.ts and
+        autofix-routing.test.ts).
+     c. Re-run: timeout 30 bun test <file> --timeout=10000
+     d. If exit 0: git add the file + migration-progress.md, commit with
+        message "test: migrate <file> to runtime path (ADR-019 T2-review)" or
+        "T2-pipeline" as appropriate. Continue.
+     e. If still failing: git restore <file>, append to quarantine.md, tick
+        [~] in migration-progress.md, continue.
+
+After the last file:
+  - Run: bun run test
+  - Append the pass/fail counts to migration-progress.md.
+  - Run: bun run typecheck
+  - Run: bun run lint   (if it fails on formatting, run bun run lint:fix and
+    commit the formatting fix as a separate commit).
+  - Stop. Do NOT push. Do NOT open a PR. A human will review.
+
+NEVER use git push, gh, or any network command.
+NEVER edit src/ files.
+NEVER edit docs/ files.
+NEVER edit any test file other than the one currently being migrated.
+
+If you get stuck or hit anything ambiguous, write the situation to
+quarantine.md with full context and move on. Do not invent fixes.
+```
+
+---
+
+## Acceptance criteria for the migration PR
+
+- [ ] All seven listed test files migrated or quarantined.
+- [ ] `bun run test` passes (any quarantined files left as-is, with their tests still passing on legacy path).
+- [ ] `bun run typecheck` clean.
+- [ ] `bun run lint` clean.
+- [ ] `migration-progress.md` and `quarantine.md` checked in at repo root.
+- [ ] No edits outside `test/unit/**/*.test.ts`, `migration-progress.md`, `quarantine.md`.
+- [ ] No `git push` / no PR opened by the agent.

--- a/docs/findings/2026-04-29-opencode-invocation.md
+++ b/docs/findings/2026-04-29-opencode-invocation.md
@@ -1,0 +1,227 @@
+# Operator guide — running opencode against the ADR-019 test migration
+
+**Date:** 2026-04-29
+**Companion to:** [legacy-run-test-migration-playbook.md](./2026-04-29-legacy-run-test-migration-playbook.md)
+**Audience:** the human (you) running opencode on a remote machine, not the agent itself.
+
+The playbook is self-contained for the agent. This document covers the surrounding mechanics: how to launch opencode, what to verify before and after, and how to land the result.
+
+---
+
+## Prerequisites
+
+On the machine you'll run opencode on:
+
+- `bun` 1.3.7+ on PATH.
+- `git` configured with commit identity (the agent will run `git commit`).
+- `opencode` installed and configured with a cheap model (Haiku-class, DeepSeek, GPT-4o-mini, etc.). The exact model is your choice — anything that can call shell tools and read files reliably.
+- A clone of `nax` with the foundation PR merged to `main` (or with the foundation branch checked out).
+- Network access disabled or restricted (the agent should not need it; this is a defensive measure).
+
+---
+
+## Step 1 — verify the foundation is in place
+
+```bash
+cd /path/to/nax
+git fetch origin
+git checkout main
+git pull
+test -f test/helpers/runtime.ts && grep -q makeMockRuntime test/helpers/runtime.ts && echo "foundation present"
+test -f scripts/adr-019-source-cleanup.patch && echo "cleanup patch present"
+test -f docs/findings/2026-04-29-legacy-run-test-migration-playbook.md && echo "playbook present"
+```
+
+All three should print "present". If not, the foundation PR is not merged yet — stop and merge it first.
+
+---
+
+## Step 2 — sanity-check the patch applies cleanly
+
+```bash
+git apply --check scripts/adr-019-source-cleanup.patch && echo "patch OK"
+```
+
+If this fails, `main` has drifted from when the patch was generated. Stop and ask a human to regenerate the patch.
+
+---
+
+## Step 3 — launch opencode
+
+The agent prompt is the fenced block in the playbook's "Agent Prompt" section. Two ways to feed it:
+
+### Option A — single-shot run (preferred)
+
+```bash
+# Extract the prompt (works because the playbook puts it inside a single fence
+# in the "## Agent Prompt" section).
+prompt=$(awk '/^```$/{f=!f; next} f && /^You are migrating/,/^```$/{print}' \
+  docs/findings/2026-04-29-legacy-run-test-migration-playbook.md \
+  | sed '$d')
+
+opencode run "$prompt"
+```
+
+### Option B — interactive
+
+```bash
+opencode
+# In the REPL:
+> Read docs/findings/2026-04-29-legacy-run-test-migration-playbook.md and
+> follow the "Agent Prompt" section verbatim. Begin with the Bootstrap
+> section. Start now.
+```
+
+Recommended: Option A. Less drift from the prompt, no interactive turn-taking the cheap model can lose track of.
+
+### Model choice
+
+Configure in your `opencode.json` or via the `--model` flag if your build supports it. Suggestions:
+
+- `anthropic/claude-haiku-4-5-20251001` — cheapest Anthropic model that handles structured edits well.
+- `deepseek/deepseek-chat` — cheaper still, good at mechanical tasks.
+- `openai/gpt-4o-mini` — comparable.
+
+Avoid anything below the Haiku tier (e.g. Llama 3.1 8B); the playbook's two-pattern decision rule is simple but wrong choice → quarantine, and a sub-Haiku model quarantines too aggressively.
+
+---
+
+## Step 4 — supervise loosely
+
+The agent will:
+
+1. Create branch `chore/adr-019-test-migration-batch`.
+2. Apply the patch.
+3. Process 7 files one by one. Each successful migration is a separate commit.
+4. Maintain `migration-progress.md` and (if needed) `quarantine.md`.
+5. Stop when done. Will NOT push, will NOT open a PR.
+
+Expected wall time: 30–90 minutes depending on the model. You can leave it unattended.
+
+If the process stalls for more than 15 minutes on a single file, consider Ctrl+C — it's likely looping on a tricky migration. Restart from the same branch; the agent should pick up at the next unticked file in `migration-progress.md`.
+
+---
+
+## Step 5 — review the agent's work
+
+When the agent stops:
+
+```bash
+cd /path/to/nax
+git log main..chore/adr-019-test-migration-batch --oneline
+cat migration-progress.md
+test -f quarantine.md && cat quarantine.md
+git diff main..HEAD --stat
+```
+
+Sanity checks:
+
+- [ ] All commits touch only `test/unit/**/*.test.ts`, `migration-progress.md`, and `quarantine.md`.
+- [ ] No commits touch `src/`, `docs/`, `package.json`, or other non-test files.
+- [ ] No `git push` happened (`git log origin/main..HEAD` shows the unpushed commits).
+- [ ] `migration-progress.md`'s final suite result matches what the agent claims.
+
+Then run yourself:
+
+```bash
+bun run typecheck
+bun run lint
+bun run test
+```
+
+If `bun run test` is green: proceed to Step 6.
+If red: review `quarantine.md` and the failing files. Fix manually or re-launch opencode with a narrower scope ("retry only quarantined files").
+
+---
+
+## Step 6 — push and open the migration PR
+
+```bash
+git push -u origin chore/adr-019-test-migration-batch
+gh pr create \
+  --base main \
+  --title "test: migrate review/autofix tests to runtime path (ADR-019)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Migrates the seven test files that exercised the legacy `agentManager.run({ keepOpen: true })` path so they now flow through the ADR-019 runtime/`callOp` dispatch path. Unblocks the source-cleanup PR that drops the legacy fallback.
+
+Generated by opencode following docs/findings/2026-04-29-legacy-run-test-migration-playbook.md.
+
+## Files migrated
+
+See migration-progress.md for the per-file outcome.
+
+## Test plan
+
+- [x] bun run typecheck clean
+- [x] bun run lint clean
+- [x] bun run test green (full suite)
+- [x] Each migrated test file passes both with and without the source-cleanup patch applied
+
+## Follow-up
+
+After this PR merges, a small cleanup PR drops the legacy code path:
+- src/review/semantic.ts
+- src/review/adversarial.ts
+- src/pipeline/stages/autofix-agent.ts
+- src/pipeline/stages/autofix-adversarial.ts
+EOF
+)"
+```
+
+---
+
+## Step 7 — after the migration PR merges
+
+Land the source cleanup. The patch lives at `scripts/adr-019-source-cleanup.patch` (delete it as part of this PR; it has served its purpose).
+
+```bash
+git checkout main && git pull
+git checkout -b refactor/adr-019-source-cleanup
+git apply scripts/adr-019-source-cleanup.patch
+git rm scripts/adr-019-source-cleanup.patch docs/findings/2026-04-29-legacy-run-test-migration-playbook.md docs/findings/2026-04-29-opencode-invocation.md migration-progress.md
+test -f quarantine.md && git rm quarantine.md
+bun run typecheck && bun run lint && bun run test  # should all be green
+git add -A
+git commit -m "refactor: drop legacy agentManager.run keepOpen path (ADR-019 Wave 3, #762)"
+git push -u origin refactor/adr-019-source-cleanup
+gh pr create --base main --title "refactor: drop legacy agentManager.run path (ADR-019, #762)" --body "..."
+```
+
+This third PR is mechanical and should pass CI on the first try. Done.
+
+---
+
+## Troubleshooting
+
+### "patch OK" but the agent reports apply failure
+
+Likely a CRLF / line-ending issue if you're on Windows. Run:
+
+```bash
+git config --global core.autocrlf false
+git checkout chore/adr-019-test-migration-batch
+git apply --3way scripts/adr-019-source-cleanup.patch
+```
+
+### Agent edits files outside the allowed list
+
+Stop the agent. Reset:
+
+```bash
+git checkout chore/adr-019-test-migration-batch
+git reset --hard main
+git apply scripts/adr-019-source-cleanup.patch
+```
+
+Re-launch with a stronger constraint: prepend to the prompt: "If you ever feel inclined to edit a file outside test/unit/, write to quarantine.md instead and move on."
+
+### Agent gets every file wrong
+
+Either the model is too weak or the playbook is wrong for the codebase state. Check:
+- Is `main` actually at the foundation PR head? (`git log --oneline -3`)
+- Is `makeMockRuntime` actually exported? (`grep makeMockRuntime test/helpers/index.ts`)
+- Do the reference test files (`semantic-parsing.test.ts`, `autofix-routing.test.ts`) pass? (`bun test test/unit/review/semantic-parsing.test.ts`)
+
+If all three are green, the model is the issue. Switch to a stronger one (Sonnet-class) and re-run. The cost difference for ~7 files is small.

--- a/scripts/adr-019-source-cleanup.patch
+++ b/scripts/adr-019-source-cleanup.patch
@@ -1,0 +1,1108 @@
+diff --git a/src/pipeline/stages/autofix-adversarial.ts b/src/pipeline/stages/autofix-adversarial.ts
+index 6455eca1..9df9c7a3 100644
+--- a/src/pipeline/stages/autofix-adversarial.ts
++++ b/src/pipeline/stages/autofix-adversarial.ts
+@@ -12,6 +12,7 @@
+ 
+ import type { IAgentManager } from "../../agents";
+ import { resolveModelForAgent } from "../../config";
++import { NaxError } from "../../errors";
+ import { getLogger } from "../../logger";
+ import { buildHopCallback } from "../../operations/build-hop-callback";
+ import type { UserStory } from "../../prd";
+@@ -127,16 +128,12 @@ export function splitFindingsByScope(
+ /**
+  * Run a test-writer session to fix review findings scoped to test files (#409).
+  * Returns the cost incurred, or 0 if the agent is unavailable.
+- *
+- * @param keepOpen - Whether to keep the ACP session open after this call so subsequent
+- *   autofix cycles can resume it (default: true). Pass false only on the final call.
+  */
+ export async function runTestWriterRectification(
+   ctx: PipelineContext,
+   testWriterChecks: ReviewCheckResult[],
+   story: UserStory,
+   agentManager: IAgentManager,
+-  keepOpen = true,
+ ): Promise<number> {
+   const logger = getLogger();
+   const twPrompt = RectifierPromptBuilder.testWriterRectification(testWriterChecks, story);
+@@ -147,6 +144,13 @@ export async function runTestWriterRectification(
+     logger.warn("autofix", "Test-writer rectification skipped -- no default agent", { storyId: ctx.story.id });
+     return 0;
+   }
++  if (!ctx.runtime) {
++    throw new NaxError(
++      "runtime required — legacy agentManager.run path removed (ADR-019 Wave 3, issue #762)",
++      "DISPATCH_NO_RUNTIME",
++      { stage: "rectification", storyId: ctx.story.id },
++    );
++  }
+   const modelTier = ctx.rootConfig.tdd?.sessionTiers?.testWriter ?? "balanced";
+   const modelDef = resolveModelForAgent(ctx.rootConfig.models, defaultAgent, modelTier, defaultAgent);
+   const runOptions = {
+@@ -164,36 +168,29 @@ export async function runTestWriterRectification(
+     sessionRole: "test-writer" as const,
+   };
+   try {
+-    if (ctx.runtime) {
+-      // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback.
+-      // Each call opens a fresh session; keepOpen is not used in the runtime path.
+-      const executeHop = buildHopCallback(
+-        {
+-          sessionManager: ctx.runtime.sessionManager,
+-          agentManager: ctx.runtime.agentManager,
+-          story,
+-          config: ctx.config,
+-          projectDir: ctx.projectDir,
+-          featureName: ctx.prd.feature ?? "",
+-          workdir: ctx.workdir,
+-          effectiveTier: modelTier,
+-          defaultAgent,
+-          pipelineStage: "rectification",
+-        },
+-        ctx.sessionId,
+-        runOptions,
+-      );
+-      const outcome = await agentManager.runWithFallback(
+-        { runOptions, signal: ctx.runtime.signal, executeHop },
++    // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback.
++    // Each call opens a fresh session; middleware (audit, cost, cancellation) fires uniformly.
++    const executeHop = buildHopCallback(
++      {
++        sessionManager: ctx.runtime.sessionManager,
++        agentManager: ctx.runtime.agentManager,
++        story,
++        config: ctx.config,
++        projectDir: ctx.projectDir,
++        featureName: ctx.prd.feature ?? "",
++        workdir: ctx.workdir,
++        effectiveTier: modelTier,
+         defaultAgent,
+-      );
+-      return outcome.result.estimatedCostUsd ?? 0;
+-    }
+-    // Legacy keepOpen path — used when no runtime is available (standalone callers).
+-    const twResult = await agentManager.run({
+-      runOptions: { ...runOptions, keepOpen },
+-    });
+-    return twResult.estimatedCostUsd ?? 0;
++        pipelineStage: "rectification",
++      },
++      ctx.sessionId,
++      runOptions,
++    );
++    const outcome = await agentManager.runWithFallback(
++      { runOptions, signal: ctx.runtime.signal, executeHop },
++      defaultAgent,
++    );
++    return outcome.result.estimatedCostUsd ?? 0;
+   } catch {
+     logger.warn("autofix", "Test-writer rectification failed -- proceeding with implementer", {
+       storyId: ctx.story.id,
+diff --git a/src/pipeline/stages/autofix-agent.ts b/src/pipeline/stages/autofix-agent.ts
+index 3d4b350c..a915b6b9 100644
+--- a/src/pipeline/stages/autofix-agent.ts
++++ b/src/pipeline/stages/autofix-agent.ts
+@@ -7,6 +7,7 @@
+ 
+ import type { SessionHandle } from "../../agents/types";
+ import { resolveModelForAgent } from "../../config";
++import { NaxError } from "../../errors";
+ import { getLogger } from "../../logger";
+ import { RectifierPromptBuilder } from "../../prompts";
+ import type { ReviewCheckResult } from "../../review/types";
+@@ -121,7 +122,15 @@ export async function runAgentRectification(
+     logger.error("autofix", "Agent manager unavailable — cannot run agent rectification", { storyId: ctx.story.id });
+     return { succeeded: false, cost: 0 };
+   }
++  if (!ctx.runtime) {
++    throw new NaxError(
++      "runtime required — legacy agentManager.run path removed (ADR-019 Wave 3, issue #762)",
++      "DISPATCH_NO_RUNTIME",
++      { stage: "rectification", storyId: ctx.story.id },
++    );
++  }
+   const { agentManager } = ctx;
++  const { runtime } = ctx;
+ 
+   // #409 #669: Split findings by file scope.
+   // Test-file findings cannot be fixed by the implementer (isolation constraint) —
+@@ -309,85 +318,62 @@ export async function runAgentRectification(
+         modelTier,
+         defaultAgent,
+       );
+-      const isLastAttempt = currentAttempt >= maxAttempts;
+-      const runOptions = {
+-        prompt,
+-        workdir: ctx.workdir,
+-        modelTier,
+-        modelDef,
+-        timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
+-        pipelineStage: "rectification" as const,
+-        config: ctx.config,
+-        projectDir: ctx.projectDir,
+-        maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
+-        featureName: ctx.prd.feature,
+-        storyId: ctx.story.id,
+-        sessionRole: "implementer" as const,
+-      };
+       let result: import("../../agents").AgentResult;
+       try {
+-        if (ctx.runtime) {
+-          // ADR-008 §6 / ADR-018 §7 Pattern B: open the implementer session
+-          // once and reuse across attempts so conversation history persists.
+-          // openSession is idempotent on a live handle (session/manager.ts:354)
+-          // so the first attempt of cycle 0 attaches to the execution-stage
+-          // session when one is still open, otherwise opens fresh.
+-          if (!heldHandle) {
+-            heldHandle = await ctx.runtime.sessionManager.openSession(implementerSession, {
+-              agentName: defaultAgent,
+-              role: "implementer",
+-              workdir: ctx.workdir,
+-              pipelineStage: "rectification",
+-              modelDef,
+-              timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
+-              featureName: ctx.prd.feature,
+-              storyId: ctx.story.id,
+-              signal: ctx.runtime.signal,
+-              onPidSpawned: ctx.runtime.onPidSpawned,
+-            });
+-          }
+-          // ADR-020 single-emission invariant: each runAsSession emits one
+-          // session-turn event, regardless of handle reuse across attempts.
+-          const turn = await agentManager.runAsSession(defaultAgent, heldHandle, prompt, {
+-            storyId: ctx.story.id,
+-            featureName: ctx.prd.feature,
++        // ADR-008 §6 / ADR-018 §7 Pattern B: open the implementer session
++        // once and reuse across attempts so conversation history persists.
++        // openSession is idempotent on a live handle (session/manager.ts:354)
++        // so the first attempt of cycle 0 attaches to the execution-stage
++        // session when one is still open, otherwise opens fresh.
++        if (!heldHandle) {
++          heldHandle = await runtime.sessionManager.openSession(implementerSession, {
++            agentName: defaultAgent,
++            role: "implementer",
+             workdir: ctx.workdir,
+-            projectDir: ctx.projectDir,
+             pipelineStage: "rectification",
+-            sessionRole: "implementer",
+-            signal: ctx.runtime.signal,
+-            maxTurns: ctx.config.agent?.maxInteractionTurns,
+-          });
+-          // Synthesize AgentResult so the downstream UNRESOLVED/CLARIFY/no-op
+-          // detection paths keep working unchanged. runAsSession throws on
+-          // failure, so a returned TurnResult always means success=true.
+-          result = {
+-            success: true,
+-            exitCode: 0,
+-            output: turn.output,
+-            rateLimited: false,
+-            durationMs: 0,
+-            estimatedCostUsd: turn.estimatedCostUsd,
+-            ...(turn.exactCostUsd !== undefined && { exactCostUsd: turn.exactCostUsd }),
+-            ...(turn.tokenUsage && { tokenUsage: turn.tokenUsage }),
+-            ...(heldHandle.protocolIds && { protocolIds: heldHandle.protocolIds }),
+-          };
+-          sessionConfirmedOpen = true;
+-        } else {
+-          // Legacy keepOpen path — used when no runtime is available (standalone callers).
+-          result = await agentManager.run({
+-            runOptions: { ...runOptions, keepOpen: !isLastAttempt },
++            modelDef,
++            timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
++            featureName: ctx.prd.feature,
++            storyId: ctx.story.id,
++            signal: runtime.signal,
++            onPidSpawned: runtime.onPidSpawned,
+           });
+-          sessionConfirmedOpen = true;
+         }
++        // ADR-020 single-emission invariant: each runAsSession emits one
++        // session-turn event, regardless of handle reuse across attempts.
++        const turn = await agentManager.runAsSession(defaultAgent, heldHandle, prompt, {
++          storyId: ctx.story.id,
++          featureName: ctx.prd.feature,
++          workdir: ctx.workdir,
++          projectDir: ctx.projectDir,
++          pipelineStage: "rectification",
++          sessionRole: "implementer",
++          signal: runtime.signal,
++          maxTurns: ctx.config.agent?.maxInteractionTurns,
++        });
++        // Synthesize AgentResult so the downstream UNRESOLVED/CLARIFY/no-op
++        // detection paths keep working unchanged. runAsSession throws on
++        // failure, so a returned TurnResult always means success=true.
++        result = {
++          success: true,
++          exitCode: 0,
++          output: turn.output,
++          rateLimited: false,
++          durationMs: 0,
++          estimatedCostUsd: turn.estimatedCostUsd,
++          ...(turn.exactCostUsd !== undefined && { exactCostUsd: turn.exactCostUsd }),
++          ...(turn.tokenUsage && { tokenUsage: turn.tokenUsage }),
++          ...(heldHandle.protocolIds && { protocolIds: heldHandle.protocolIds }),
++        };
++        sessionConfirmedOpen = true;
+       } catch (err) {
+         sessionConfirmedOpen = false;
+         // Discard the held handle so the next attempt reopens — the previous
+         // session may be in a terminal/cancelled state after the throw.
+-        if (heldHandle && ctx.runtime) {
++        if (heldHandle) {
+           const stale = heldHandle;
+           heldHandle = undefined;
+-          await ctx.runtime.sessionManager.closeSession(stale).catch(() => {});
++          await runtime.sessionManager.closeSession(stale).catch(() => {});
+         }
+         throw err;
+       }
+@@ -596,10 +582,10 @@ export async function runAgentRectification(
+       // ADR-008 §6: close the held implementer session at loop exit (success,
+       // exhaustion, or unhandled error). Best-effort — failures here must not
+       // mask the loop outcome.
+-      if (heldHandle && ctx.runtime) {
++      if (heldHandle) {
+         const stale = heldHandle;
+         heldHandle = undefined;
+-        await ctx.runtime.sessionManager.closeSession(stale).catch(() => {});
++        await runtime.sessionManager.closeSession(stale).catch(() => {});
+       }
+     });
+ 
+diff --git a/src/review/adversarial.ts b/src/review/adversarial.ts
+index baeb535e..2991ebaf 100644
+--- a/src/review/adversarial.ts
++++ b/src/review/adversarial.ts
+@@ -14,30 +14,22 @@
+  */
+ 
+ import type { IAgentManager } from "../agents";
+-import { DEFAULT_CONFIG } from "../config";
+ import type { NaxConfig } from "../config";
+-import { resolveModelForAgent } from "../config/schema-types";
+ import { filterContextByRole } from "../context";
+-import { createContextToolRuntime } from "../context/engine";
++import { NaxError } from "../errors";
+ import { getSafeLogger } from "../logger";
+ import { adversarialReviewOp } from "../operations/adversarial-review";
+ import { callOp } from "../operations/call";
+-import type { UserStory } from "../prd";
+-import { AdversarialReviewPromptBuilder } from "../prompts/builders/adversarial-review-builder";
+-import { ReviewPromptBuilder } from "../prompts/builders/review-builder";
+-import { formatSessionName } from "../session/naming";
+ import type { NaxIgnoreIndex } from "../utils/path-filters";
+ import {
+   type AdversarialLLMFinding,
+   type AdversarialLLMResponse,
+   formatFindings,
+   isBlockingSeverity,
+-  parseAdversarialResponse,
+   toAdversarialReviewFindings,
+ } from "./adversarial-helpers";
+ import { collectDiff, collectDiffStat, computeTestInventory, resolveEffectiveRef } from "./diff-utils";
+ import { writeReviewAudit } from "./review-audit";
+-import { looksLikeTruncatedJson } from "./truncation";
+ import type { AdversarialFindingsCache, AdversarialReviewConfig, ReviewCheckResult, SemanticStory } from "./types";
+ 
+ /** Injectable dependencies for adversarial.ts — allows tests to mock without mock.module() */
+@@ -162,114 +154,36 @@ export async function runAdversarialReview(
+     if (filtered.trim()) featureCtxBlock = `${filtered}\n\n---\n\n`;
+   }
+ 
+-  // ADR-019 Pattern A: when a NaxRuntime is available, dispatch via callOp so the
+-  // hop routes through AgentManager.runWithFallback + buildHopCallback, firing the
+-  // middleware chain and managing session lifecycle explicitly. The adversarialReviewOp
+-  // hopBody handles the same-session JSON-parse retry.
+-  //
+-  // Falls back to the legacy keepOpen path when no runtime is available.
+-  let parsed: AdversarialLLMResponse | null;
++  // ADR-019 Pattern A: dispatch via callOp so the hop routes through
++  // AgentManager.runWithFallback + buildHopCallback, firing the middleware chain
++  // and managing session lifecycle explicitly. The adversarialReviewOp hopBody
++  // handles the same-session JSON-parse retry.
++  if (!runtime) {
++    throw new NaxError(
++      "runtime required — legacy agentManager.run path removed (ADR-019 Wave 3, issue #762)",
++      "DISPATCH_NO_RUNTIME",
++      { stage: "review-adversarial", storyId: story.id },
++    );
++  }
++
+   // NOTE: llmCost stays 0 on the runtime path — buildHopCallback charges cost via
+-  // costAggregator. ReviewCheckResult.cost will be 0 for pipeline-managed reviews.
+-  let llmCost = 0;
++  // costAggregator. ReviewCheckResult.cost is 0 for pipeline-managed reviews.
++  const llmCost = 0;
+ 
+-  if (runtime) {
+-    const callCtx = {
+-      runtime,
+-      packageView: runtime.packages.resolve(workdir),
+-      packageDir: workdir,
+-      agentName: agentManager.getDefault(),
+-      storyId: story.id,
+-      featureName,
+-      contextBundle,
+-    };
+-    let opResult: import("../operations/adversarial-review").AdversarialReviewOutput;
+-    try {
+-      opResult = await callOp(callCtx, adversarialReviewOp, {
+-        story,
+-        adversarialConfig,
+-        mode: diffMode,
+-        diff,
+-        storyGitRef: effectiveRef,
+-        stat,
+-        priorFailures,
+-        testInventory,
+-        excludePatterns: adversarialConfig.excludePatterns,
+-        featureCtxBlock,
+-        priorAdversarialFindings,
+-        blockingThreshold,
+-      });
+-    } catch (err) {
+-      logger?.warn("adversarial", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
+-      return {
+-        check: "adversarial",
+-        success: true,
+-        failOpen: true,
+-        command: "",
+-        exitCode: 0,
+-        output: `skipped: LLM call failed — ${String(err)}`,
+-        durationMs: Date.now() - startTime,
+-      };
+-    }
+-    if (opResult.failOpen) {
+-      logger?.warn("adversarial", "Retry exhausted — fail-open", { storyId: story.id });
+-      if (naxConfig?.review?.audit?.enabled) {
+-        void _adversarialDeps.writeReviewAudit({
+-          reviewer: "adversarial",
+-          sessionName: "",
+-          workdir,
+-          storyId: story.id,
+-          featureName,
+-          parsed: false,
+-          looksLikeFail: false,
+-          result: null,
+-        });
+-      }
+-      return {
+-        check: "adversarial",
+-        success: true,
+-        failOpen: true,
+-        command: "",
+-        exitCode: 0,
+-        output: "adversarial review: could not parse LLM response (fail-open)",
+-        durationMs: Date.now() - startTime,
+-      };
+-    }
+-    if (opResult.looksLikeFail) {
+-      logger?.warn("adversarial", "LLM returned truncated JSON with passed:false — treating as failure", {
+-        storyId: story.id,
+-      });
+-      if (naxConfig?.review?.audit?.enabled) {
+-        void _adversarialDeps.writeReviewAudit({
+-          reviewer: "adversarial",
+-          sessionName: "",
+-          workdir,
+-          storyId: story.id,
+-          featureName,
+-          parsed: false,
+-          looksLikeFail: true,
+-          result: null,
+-        });
+-      }
+-      return {
+-        check: "adversarial",
+-        success: false,
+-        command: "",
+-        exitCode: 1,
+-        output:
+-          "adversarial review: LLM response truncated but indicated failure (passed:false found in partial response)",
+-        durationMs: Date.now() - startTime,
+-      };
+-    }
+-    parsed = { passed: opResult.passed, findings: opResult.findings as AdversarialLLMFinding[] };
+-  } else {
+-    // @deprecated Legacy keepOpen path — runtime is always present under executeUnified().
+-    // TODO(ADR-019): Remove this branch once all callers thread runtime (tracked in dogfood findings 2026-04-27).
+-    logger?.warn("adversarial", "LLM call via legacy agentManager.run — runtime not threaded, middleware skipped", {
+-      storyId: story.id,
+-    });
+-    // Legacy keepOpen path — used when no runtime is available (standalone callers).
+-    const basePrompt = new AdversarialReviewPromptBuilder().buildAdversarialReviewPrompt(story, adversarialConfig, {
++  const callCtx = {
++    runtime,
++    packageView: runtime.packages.resolve(workdir),
++    packageDir: workdir,
++    agentName: agentManager.getDefault(),
++    storyId: story.id,
++    featureName,
++    contextBundle,
++  };
++  let opResult: import("../operations/adversarial-review").AdversarialReviewOutput;
++  try {
++    opResult = await callOp(callCtx, adversarialReviewOp, {
++      story,
++      adversarialConfig,
+       mode: diffMode,
+       diff,
+       storyGitRef: effectiveRef,
+@@ -277,193 +191,76 @@ export async function runAdversarialReview(
+       priorFailures,
+       testInventory,
+       excludePatterns: adversarialConfig.excludePatterns,
++      featureCtxBlock,
+       priorAdversarialFindings,
++      blockingThreshold,
+     });
+-    const prompt = featureCtxBlock ? `${featureCtxBlock}${basePrompt}` : basePrompt;
+-
+-    const defaultAgent = agentManager.getDefault();
+-    let resolvedModelDef = { provider: "anthropic", model: "claude-sonnet-4-5-20250514" };
+-    try {
+-      if (naxConfig?.models) {
+-        resolvedModelDef = resolveModelForAgent(
+-          naxConfig.models,
+-          defaultAgent,
+-          adversarialConfig.modelTier,
+-          defaultAgent,
+-        );
+-      }
+-    } catch {
+-      // Use default model if resolution fails
+-    }
+-
+-    const adversarialSessionName = formatSessionName({
+-      workdir,
+-      featureName,
+-      storyId: story.id,
+-      role: "reviewer-adversarial",
+-    });
+-    const contextToolStory: UserStory = {
+-      id: story.id,
+-      title: story.title,
+-      description: story.description,
+-      acceptanceCriteria: story.acceptanceCriteria,
+-      tags: [],
+-      dependencies: [],
+-      status: "in-progress",
+-      passes: false,
+-      escalations: [],
+-      attempts: 0,
++  } catch (err) {
++    logger?.warn("adversarial", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
++    return {
++      check: "adversarial",
++      success: true,
++      failOpen: true,
++      command: "",
++      exitCode: 0,
++      output: `skipped: LLM call failed — ${String(err)}`,
++      durationMs: Date.now() - startTime,
+     };
+-    const runOpts = {
+-      workdir,
+-      timeoutSeconds: adversarialConfig.timeoutMs ? Math.ceil(adversarialConfig.timeoutMs / 1000) : 600,
+-      modelTier: adversarialConfig.modelTier,
+-      modelDef: resolvedModelDef,
+-      pipelineStage: "review",
+-      config: naxConfig ?? DEFAULT_CONFIG,
+-      featureName,
+-      storyId: story.id,
+-      sessionRole: "reviewer-adversarial",
+-      contextPullTools: contextBundle?.pullTools,
+-      contextToolRuntime: contextBundle
+-        ? createContextToolRuntime({
+-            bundle: contextBundle,
+-            story: contextToolStory,
+-            config: naxConfig ?? DEFAULT_CONFIG,
+-            repoRoot: workdir,
+-          })
+-        : undefined,
+-    } as const;
+-
+-    const adapter = agentManager.getAgent(defaultAgent);
+-    const legacyCloser = adapter as
+-      | (import("../agents/types").AgentAdapter & {
+-          closePhysicalSession?: (handle: string, runWorkdir: string, options?: { force?: boolean }) => Promise<void>;
+-        })
+-      | undefined;
+-    let rawResponse: string;
+-    let retryAttempted = false;
+-    try {
+-      const runResult = await agentManager.run({ runOptions: { prompt, ...runOpts, keepOpen: true } });
+-      rawResponse = runResult.output;
+-      llmCost = runResult.estimatedCostUsd ?? 0;
+-      logger?.debug("adversarial", "LLM call complete (legacy)", {
+-        storyId: story.id,
+-        responseLen: rawResponse.length,
+-        estimatedCostUsd: llmCost,
+-      });
+-    } catch (err) {
+-      logger?.warn("adversarial", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
+-      void legacyCloser?.closePhysicalSession?.(adversarialSessionName, workdir);
+-      return {
+-        check: "adversarial",
+-        success: true,
+-        failOpen: true,
+-        command: "",
+-        exitCode: 0,
+-        output: `skipped: LLM call failed — ${String(err)}`,
+-        durationMs: Date.now() - startTime,
+-      };
+-    }
+-
+-    const isTruncated = looksLikeTruncatedJson(rawResponse);
+-    if (isTruncated || !parseAdversarialResponse(rawResponse)) {
+-      retryAttempted = true;
+-      const retryPrompt = isTruncated
+-        ? ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold })
+-        : ReviewPromptBuilder.jsonRetry();
+-      if (isTruncated) {
+-        logger?.warn("adversarial", "JSON parse retry — original response truncated", {
+-          storyId: story.id,
+-          originalByteSize: rawResponse.length,
+-          blockingThreshold: blockingThreshold ?? "error",
+-        });
+-      }
+-      logger?.info("adversarial", "JSON parse failed, retrying (1/1)", {
+-        storyId: story.id,
+-        rawHead: rawResponse.slice(0, 200),
+-        responseLen: rawResponse.length,
+-        isTruncated,
+-      });
+-      try {
+-        const retryResult = await agentManager.run({
+-          runOptions: { prompt: retryPrompt, ...runOpts, keepOpen: false },
+-        });
+-        rawResponse = retryResult.output;
+-        llmCost += retryResult.estimatedCostUsd ?? 0;
+-        if (parseAdversarialResponse(rawResponse)) {
+-          logger?.info("adversarial", "JSON retry succeeded", { storyId: story.id, responseLen: rawResponse.length });
+-        }
+-      } catch (err) {
+-        logger?.warn("adversarial", "JSON retry call failed", { storyId: story.id, cause: String(err) });
+-      }
+-    }
+-
+-    void legacyCloser?.closePhysicalSession?.(adversarialSessionName, workdir);
+-
+-    const legacyParsed = parseAdversarialResponse(rawResponse);
+-    if (!legacyParsed) {
+-      const looksLikeFail = /"passed"\s*:\s*false/.test(rawResponse);
+-      if (naxConfig?.review?.audit?.enabled) {
+-        void _adversarialDeps.writeReviewAudit({
+-          reviewer: "adversarial",
+-          sessionName: adversarialSessionName,
+-          workdir,
+-          storyId: story.id,
+-          featureName,
+-          parsed: false,
+-          looksLikeFail,
+-          result: null,
+-        });
+-      }
+-      if (looksLikeFail) {
+-        logger?.warn("adversarial", "LLM returned truncated JSON with passed:false — treating as failure", {
+-          storyId: story.id,
+-          retryAttempted,
+-          rawHead: rawResponse.slice(0, 200),
+-        });
+-        return {
+-          check: "adversarial",
+-          success: false,
+-          command: "",
+-          exitCode: 1,
+-          output:
+-            "adversarial review: LLM response truncated but indicated failure (passed:false found in partial response)",
+-          durationMs: Date.now() - startTime,
+-          cost: llmCost,
+-        };
+-      }
+-      logger?.warn("adversarial", "Retry exhausted — fail-open", {
++  }
++  if (opResult.failOpen) {
++    logger?.warn("adversarial", "Retry exhausted — fail-open", { storyId: story.id });
++    if (naxConfig?.review?.audit?.enabled) {
++      void _adversarialDeps.writeReviewAudit({
++        reviewer: "adversarial",
++        sessionName: "",
++        workdir,
+         storyId: story.id,
+-        retries: retryAttempted ? 1 : 0,
+-        rawHead: rawResponse.slice(0, 200),
+-        responseLen: rawResponse.length,
++        featureName,
++        parsed: false,
++        looksLikeFail: false,
++        result: null,
+       });
+-      return {
+-        check: "adversarial",
+-        success: true,
+-        failOpen: true,
+-        command: "",
+-        exitCode: 0,
+-        output: "adversarial review: could not parse LLM response (fail-open)",
+-        durationMs: Date.now() - startTime,
+-        cost: llmCost,
+-      };
+     }
+-    parsed = legacyParsed;
++    return {
++      check: "adversarial",
++      success: true,
++      failOpen: true,
++      command: "",
++      exitCode: 0,
++      output: "adversarial review: could not parse LLM response (fail-open)",
++      durationMs: Date.now() - startTime,
++    };
++  }
++  if (opResult.looksLikeFail) {
++    logger?.warn("adversarial", "LLM returned truncated JSON with passed:false — treating as failure", {
++      storyId: story.id,
++    });
+     if (naxConfig?.review?.audit?.enabled) {
+       void _adversarialDeps.writeReviewAudit({
+         reviewer: "adversarial",
+-        sessionName: adversarialSessionName,
++        sessionName: "",
+         workdir,
+         storyId: story.id,
+         featureName,
+-        parsed: true,
+-        looksLikeFail: false,
+-        result: legacyParsed,
++        parsed: false,
++        looksLikeFail: true,
++        result: null,
+       });
+     }
++    return {
++      check: "adversarial",
++      success: false,
++      command: "",
++      exitCode: 1,
++      output:
++        "adversarial review: LLM response truncated but indicated failure (passed:false found in partial response)",
++      durationMs: Date.now() - startTime,
++    };
+   }
++  const parsed: AdversarialLLMResponse = {
++    passed: opResult.passed,
++    findings: opResult.findings as AdversarialLLMFinding[],
++  };
+ 
+   const threshold = blockingThreshold ?? "error";
+   const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity, threshold));
+diff --git a/src/review/semantic.ts b/src/review/semantic.ts
+index 9b1c20ce..aef13e53 100644
+--- a/src/review/semantic.ts
++++ b/src/review/semantic.ts
+@@ -10,17 +10,14 @@
+ import type { IAgentManager } from "../agents";
+ import { DEFAULT_CONFIG } from "../config";
+ import type { NaxConfig } from "../config";
+-import { resolveModelForAgent } from "../config/schema-types";
+ import { filterContextByRole } from "../context";
+-import { createContextToolRuntime } from "../context/engine";
+ import { DebateRunner } from "../debate";
+ import type { DebateRunnerOptions } from "../debate";
++import { NaxError } from "../errors";
+ import { getSafeLogger } from "../logger";
+ import { callOp } from "../operations/call";
+ import { semanticReviewOp } from "../operations/semantic-review";
+-import type { UserStory } from "../prd";
+ import { ReviewPromptBuilder } from "../prompts";
+-import { formatSessionName } from "../session/naming";
+ import { resolveReviewExcludePatterns, resolveTestFilePatterns } from "../test-runners";
+ import type { NaxIgnoreIndex } from "../utils/path-filters";
+ import { DIFF_CAP_BYTES, collectDiff, collectDiffStat, resolveEffectiveRef, truncateDiff } from "./diff-utils";
+@@ -32,11 +29,9 @@ import {
+   type LLMResponse,
+   formatFindings,
+   isBlockingSeverity,
+-  parseLLMResponse,
+   sanitizeRefModeFindings,
+   toReviewFindings,
+ } from "./semantic-helpers";
+-import { looksLikeTruncatedJson } from "./truncation";
+ import type { ReviewCheckResult, SemanticReviewConfig, SemanticStory } from "./types";
+ 
+ // Re-export so existing callers (`import type { SemanticStory } from "./semantic"`) keep working.
+@@ -201,281 +196,110 @@ export async function runSemanticReview(
+     });
+   }
+ 
+-  // ADR-019 Pattern A: when a NaxRuntime is available, dispatch via callOp so the
+-  // hop routes through AgentManager.runWithFallback + buildHopCallback, firing the
+-  // middleware chain (audit, cost, cancellation) and managing session lifecycle
+-  // explicitly via openSession + runAsSession × N + closeSession. The semanticReviewOp
+-  // hopBody handles the same-session JSON-parse retry.
+-  //
+-  // Falls back to the legacy keepOpen path when no runtime is available (standalone
+-  // callers, tests that only pass agentManager).
+-  let parsed: LLMResponse | null;
++  // ADR-019 Pattern A: dispatch via callOp so the hop routes through
++  // AgentManager.runWithFallback + buildHopCallback, firing the middleware chain
++  // (audit, cost, cancellation) and managing session lifecycle explicitly via
++  // openSession + runAsSession × N + closeSession. The semanticReviewOp hopBody
++  // handles the same-session JSON-parse retry.
++  if (!runtime) {
++    throw new NaxError(
++      "runtime required — legacy agentManager.run path removed (ADR-019 Wave 3, issue #762)",
++      "DISPATCH_NO_RUNTIME",
++      { stage: "review-semantic", storyId: story.id },
++    );
++  }
++
+   // NOTE: llmCost stays 0 on the runtime path — buildHopCallback charges cost via
+-  // costAggregator directly. ReviewCheckResult.cost will be 0 for pipeline-managed
++  // costAggregator directly. ReviewCheckResult.cost is 0 for pipeline-managed
+   // reviews; per-stage cost roll-up is the trade-off for ADR-019 session-lifecycle
+   // ownership. Track in follow-up if per-check cost breakdown is needed.
+-  let llmCost = 0;
++  const llmCost = 0;
+ 
+-  if (runtime) {
+-    const callCtx = {
+-      runtime,
+-      packageView: runtime.packages.resolve(workdir),
+-      packageDir: workdir,
+-      agentName: agentManager.getDefault(),
+-      storyId: story.id,
+-      featureName,
+-      contextBundle,
++  const callCtx = {
++    runtime,
++    packageView: runtime.packages.resolve(workdir),
++    packageDir: workdir,
++    agentName: agentManager.getDefault(),
++    storyId: story.id,
++    featureName,
++    contextBundle,
++  };
++  let opResult: import("../operations/semantic-review").SemanticReviewOutput;
++  try {
++    opResult = await callOp(callCtx, semanticReviewOp, {
++      story,
++      semanticConfig,
++      mode: diffMode,
++      diff,
++      storyGitRef: effectiveRef,
++      stat,
++      priorFailures,
++      excludePatterns,
++      featureCtxBlock,
++      blockingThreshold,
++    });
++  } catch (err) {
++    logger?.warn("semantic", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
++    return {
++      check: "semantic",
++      success: true,
++      failOpen: true,
++      command: "",
++      exitCode: 0,
++      output: `skipped: LLM call failed — ${String(err)}`,
++      durationMs: Date.now() - startTime,
+     };
+-    let opResult: import("../operations/semantic-review").SemanticReviewOutput;
+-    try {
+-      opResult = await callOp(callCtx, semanticReviewOp, {
+-        story,
+-        semanticConfig,
+-        mode: diffMode,
+-        diff,
+-        storyGitRef: effectiveRef,
+-        stat,
+-        priorFailures,
+-        excludePatterns,
+-        featureCtxBlock,
+-        blockingThreshold,
+-      });
+-    } catch (err) {
+-      logger?.warn("semantic", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
+-      return {
+-        check: "semantic",
+-        success: true,
+-        failOpen: true,
+-        command: "",
+-        exitCode: 0,
+-        output: `skipped: LLM call failed — ${String(err)}`,
+-        durationMs: Date.now() - startTime,
+-      };
+-    }
+-    if (opResult.failOpen) {
+-      logger?.warn("semantic", "Retry exhausted — fail-open", { storyId: story.id });
+-      if (naxConfig?.review?.audit?.enabled) {
+-        void _semanticDeps.writeReviewAudit({
+-          reviewer: "semantic",
+-          sessionName: "",
+-          workdir,
+-          storyId: story.id,
+-          featureName,
+-          parsed: false,
+-          looksLikeFail: false,
+-          result: null,
+-        });
+-      }
+-      return {
+-        check: "semantic",
+-        success: true,
+-        failOpen: true,
+-        command: "",
+-        exitCode: 0,
+-        output: "semantic review: could not parse LLM response (fail-open)",
+-        durationMs: Date.now() - startTime,
+-      };
+-    }
+-    if (opResult.looksLikeFail) {
+-      logger?.warn("semantic", "LLM returned truncated JSON with passed:false — treating as failure", {
++  }
++  if (opResult.failOpen) {
++    logger?.warn("semantic", "Retry exhausted — fail-open", { storyId: story.id });
++    if (naxConfig?.review?.audit?.enabled) {
++      void _semanticDeps.writeReviewAudit({
++        reviewer: "semantic",
++        sessionName: "",
++        workdir,
+         storyId: story.id,
++        featureName,
++        parsed: false,
++        looksLikeFail: false,
++        result: null,
+       });
+-      if (naxConfig?.review?.audit?.enabled) {
+-        void _semanticDeps.writeReviewAudit({
+-          reviewer: "semantic",
+-          sessionName: "",
+-          workdir,
+-          storyId: story.id,
+-          featureName,
+-          parsed: false,
+-          looksLikeFail: true,
+-          result: null,
+-        });
+-      }
+-      return {
+-        check: "semantic",
+-        success: false,
+-        command: "",
+-        exitCode: 1,
+-        output:
+-          "semantic review: LLM response truncated but indicated failure (passed:false found in partial response)",
+-        durationMs: Date.now() - startTime,
+-      };
+     }
+-    parsed = { passed: opResult.passed, findings: opResult.findings as LLMFinding[] };
+-  } else {
+-    // @deprecated Legacy keepOpen path — runtime is always present under executeUnified().
+-    // TODO(ADR-019): Remove this branch once all callers thread runtime (tracked in dogfood findings 2026-04-27).
+-    logger?.warn("semantic", "LLM call via legacy agentManager.run — runtime not threaded, middleware skipped", {
+-      storyId: story.id,
+-    });
+-    // Legacy keepOpen path — used when no runtime is available (standalone callers).
+-    const reviewerSessionName = formatSessionName({
+-      workdir,
+-      featureName,
+-      storyId: story.id,
+-      role: "reviewer-semantic",
+-    });
+-    const contextToolStory: UserStory = {
+-      id: story.id,
+-      title: story.title,
+-      description: story.description,
+-      acceptanceCriteria: story.acceptanceCriteria,
+-      tags: [],
+-      dependencies: [],
+-      status: "in-progress",
+-      passes: false,
+-      escalations: [],
+-      attempts: 0,
++    return {
++      check: "semantic",
++      success: true,
++      failOpen: true,
++      command: "",
++      exitCode: 0,
++      output: "semantic review: could not parse LLM response (fail-open)",
++      durationMs: Date.now() - startTime,
+     };
+-    const defaultAgent = agentManager.getDefault();
+-    const adapter = agentManager.getAgent(defaultAgent);
+-    const legacyCloser = adapter as
+-      | (import("../agents/types").AgentAdapter & {
+-          closePhysicalSession?: (handle: string, runWorkdir: string, options?: { force?: boolean }) => Promise<void>;
+-        })
+-      | undefined;
+-    let resolvedModelDef = { provider: "anthropic", model: "claude-sonnet-4-5-20250514" };
+-    try {
+-      if (naxConfig?.models) {
+-        resolvedModelDef = resolveModelForAgent(naxConfig.models, defaultAgent, semanticConfig.modelTier, defaultAgent);
+-      }
+-    } catch {
+-      // Use default model if resolution fails
+-    }
+-
+-    const runOpts = {
+-      workdir,
+-      timeoutSeconds: semanticConfig.timeoutMs ? Math.ceil(semanticConfig.timeoutMs / 1000) : 3600,
+-      modelTier: semanticConfig.modelTier,
+-      modelDef: resolvedModelDef,
+-      pipelineStage: "review",
+-      config: naxConfig ?? DEFAULT_CONFIG,
+-      featureName,
++  }
++  if (opResult.looksLikeFail) {
++    logger?.warn("semantic", "LLM returned truncated JSON with passed:false — treating as failure", {
+       storyId: story.id,
+-      sessionRole: "reviewer-semantic",
+-      contextPullTools: contextBundle?.pullTools,
+-      contextToolRuntime: contextBundle
+-        ? createContextToolRuntime({
+-            bundle: contextBundle,
+-            story: contextToolStory,
+-            config: naxConfig ?? DEFAULT_CONFIG,
+-            repoRoot: workdir,
+-          })
+-        : undefined,
+-    } as const;
+-
+-    let rawResponse: string;
+-    let retryAttempted = false;
+-    try {
+-      const runResult = await agentManager.run({ runOptions: { prompt, ...runOpts, keepOpen: true } });
+-      rawResponse = runResult.output;
+-      llmCost = runResult.estimatedCostUsd ?? 0;
+-      logger?.debug("semantic", "LLM call complete (legacy)", {
+-        storyId: story.id,
+-        responseLen: rawResponse.length,
+-        estimatedCostUsd: llmCost,
+-      });
+-    } catch (err) {
+-      logger?.warn("semantic", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
+-      void legacyCloser?.closePhysicalSession?.(reviewerSessionName, workdir);
+-      return {
+-        check: "semantic",
+-        success: true,
+-        failOpen: true,
+-        command: "",
+-        exitCode: 0,
+-        output: `skipped: LLM call failed — ${String(err)}`,
+-        durationMs: Date.now() - startTime,
+-      };
+-    }
+-
+-    const isTruncated = looksLikeTruncatedJson(rawResponse);
+-    if (isTruncated || !parseLLMResponse(rawResponse)) {
+-      retryAttempted = true;
+-      const retryPrompt = isTruncated
+-        ? ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold })
+-        : ReviewPromptBuilder.jsonRetry();
+-      if (isTruncated) {
+-        logger?.warn("semantic", "JSON parse retry — original response truncated", {
+-          storyId: story.id,
+-          originalByteSize: rawResponse.length,
+-          blockingThreshold: blockingThreshold ?? "error",
+-        });
+-      }
+-      logger?.info("semantic", "JSON parse failed, retrying (1/1)", {
++    });
++    if (naxConfig?.review?.audit?.enabled) {
++      void _semanticDeps.writeReviewAudit({
++        reviewer: "semantic",
++        sessionName: "",
++        workdir,
+         storyId: story.id,
+-        rawHead: rawResponse.slice(0, 200),
+-        responseLen: rawResponse.length,
+-        isTruncated,
++        featureName,
++        parsed: false,
++        looksLikeFail: true,
++        result: null,
+       });
+-      try {
+-        const retryResult = await agentManager.run({
+-          runOptions: { prompt: retryPrompt, ...runOpts, keepOpen: false },
+-        });
+-        rawResponse = retryResult.output;
+-        llmCost += retryResult.estimatedCostUsd ?? 0;
+-        if (parseLLMResponse(rawResponse)) {
+-          logger?.info("semantic", "JSON retry succeeded", { storyId: story.id, responseLen: rawResponse.length });
+-        }
+-      } catch (err) {
+-        logger?.warn("semantic", "JSON retry call failed", { storyId: story.id, cause: String(err) });
+-      }
+     }
+-
+-    void legacyCloser?.closePhysicalSession?.(reviewerSessionName, workdir);
+-
+-    const legacyParsed = parseLLMResponse(rawResponse);
+-    if (!legacyParsed) {
+-      const looksLikeFail = /"passed"\s*:\s*false/.test(rawResponse);
+-      if (naxConfig?.review?.audit?.enabled) {
+-        void _semanticDeps.writeReviewAudit({
+-          reviewer: "semantic",
+-          sessionName: reviewerSessionName,
+-          workdir,
+-          storyId: story.id,
+-          featureName,
+-          parsed: false,
+-          looksLikeFail,
+-          result: null,
+-        });
+-      }
+-      if (looksLikeFail) {
+-        logger?.warn("semantic", "LLM returned truncated JSON with passed:false — treating as failure", {
+-          storyId: story.id,
+-          retryAttempted,
+-          rawHead: rawResponse.slice(0, 200),
+-        });
+-        return {
+-          check: "semantic",
+-          success: false,
+-          command: "",
+-          exitCode: 1,
+-          output:
+-            "semantic review: LLM response truncated but indicated failure (passed:false found in partial response)",
+-          durationMs: Date.now() - startTime,
+-          cost: llmCost,
+-        };
+-      }
+-      logger?.warn("semantic", "Retry exhausted — fail-open", {
+-        storyId: story.id,
+-        retries: retryAttempted ? 1 : 0,
+-        rawHead: rawResponse.slice(0, 200),
+-        responseLen: rawResponse.length,
+-      });
+-      return {
+-        check: "semantic",
+-        success: true,
+-        failOpen: true,
+-        command: "",
+-        exitCode: 0,
+-        output: "semantic review: could not parse LLM response (fail-open)",
+-        durationMs: Date.now() - startTime,
+-        cost: llmCost,
+-      };
+-    }
+-    parsed = legacyParsed;
++    return {
++      check: "semantic",
++      success: false,
++      command: "",
++      exitCode: 1,
++      output: "semantic review: LLM response truncated but indicated failure (passed:false found in partial response)",
++      durationMs: Date.now() - startTime,
++    };
+   }
++  const parsed: LLMResponse = { passed: opResult.passed, findings: opResult.findings as LLMFinding[] };
+ 
+   const sanitizedFindings = await substantiateSemanticEvidence(
+     sanitizeRefModeFindings(parsed.findings, diffMode),

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -13,5 +13,5 @@ export { createMockAgentManager, makeMockAgentManager } from "./mock-agent-manag
 export { makeLogger, type LogCall, type MockLogger } from "./mock-logger";
 export { makeNaxConfig, makeSparseNaxConfig } from "./mock-nax-config";
 export { makeSessionManager } from "./mock-session-manager";
-export { makeTestRuntime, type TestRuntimeOptions } from "./runtime";
+export { makeMockRuntime, makeTestRuntime, type MockRuntimeOptions, type TestRuntimeOptions } from "./runtime";
 export { makeInProgressStory, makePRD, makePendingStory, makeStory } from "./mock-story";

--- a/test/helpers/runtime.ts
+++ b/test/helpers/runtime.ts
@@ -1,6 +1,10 @@
+import type { IAgentManager } from "../../src/agents";
 import { DEFAULT_CONFIG } from "../../src/config";
 import type { NaxConfig } from "../../src/config";
 import { createRuntime, type CreateRuntimeOptions, type NaxRuntime } from "../../src/runtime";
+import type { ISessionManager } from "../../src/session/types";
+import { makeMockAgentManager } from "./mock-agent-manager";
+import { makeSessionManager } from "./mock-session-manager";
 
 export interface TestRuntimeOptions extends CreateRuntimeOptions {
   config?: NaxConfig;
@@ -11,5 +15,46 @@ export function makeTestRuntime(opts?: TestRuntimeOptions): NaxRuntime {
   return createRuntime(opts?.config ?? DEFAULT_CONFIG, opts?.workdir ?? "/tmp/test", {
     ...opts,
     featureName: opts?.featureName ?? "_test",
+  });
+}
+
+/**
+ * Build a NaxRuntime suitable for unit tests that exercise the ADR-019 callOp /
+ * runWithFallback / openSession+runAsSession dispatch path.
+ *
+ * Use this when migrating a legacy `agentManager.run()` test to the runtime path:
+ * pass the existing agent-manager mock so the runtime's dispatch flows through it.
+ *
+ * ```ts
+ * const agentManager = makeMockAgentManager({
+ *   runWithFallbackFn: async (req) => ({ result: { ... }, fallbacks: [], bundle: req.bundle }),
+ * });
+ * const runtime = makeMockRuntime({ agentManager });
+ * await runSemanticReview(workdir, ref, story, cfg, agentManager, ..., runtime);
+ * ```
+ *
+ * - `agentManager` defaults to `makeMockAgentManager()` (no overrides) — supply
+ *   one if your test asserts on dispatch behaviour.
+ * - `sessionManager` defaults to `makeSessionManager()` — override for tests that
+ *   assert on session lifecycle.
+ * - `workdir` defaults to `/tmp/test` (no real filesystem access — never used by
+ *   the test mocks themselves).
+ *
+ * Built on top of `createRuntime`, so the resulting object has every NaxRuntime
+ * field (`packages`, `costAggregator`, `promptAuditor`, `dispatchEvents`, etc.)
+ * with no-op or default-mocked implementations.
+ */
+export interface MockRuntimeOptions {
+  agentManager?: IAgentManager;
+  sessionManager?: ISessionManager;
+  config?: NaxConfig;
+  workdir?: string;
+}
+
+export function makeMockRuntime(opts: MockRuntimeOptions = {}): NaxRuntime {
+  return createRuntime(opts.config ?? DEFAULT_CONFIG, opts.workdir ?? "/tmp/test", {
+    agentManager: opts.agentManager ?? makeMockAgentManager(),
+    sessionManager: opts.sessionManager ?? makeSessionManager(),
+    featureName: "_test",
   });
 }

--- a/test/unit/pipeline/stages/autofix-routing.test.ts
+++ b/test/unit/pipeline/stages/autofix-routing.test.ts
@@ -13,7 +13,7 @@ import { RectifierPromptBuilder } from "../../../../src/prompts";
 import type { PipelineContext } from "../../../../src/pipeline/types";
 import { DEFAULT_CONFIG } from "../../../../src/config";
 import type { ReviewCheckResult } from "../../../../src/review/types";
-import { makeMockAgentManager as _makeMockAgentManager } from "../../../helpers";
+import { makeMockAgentManager as _makeMockAgentManager, makeMockRuntime } from "../../../helpers";
 
 function makeReviewResult(success: boolean) {
   return { success, checks: [], summary: "" } as any;
@@ -36,6 +36,10 @@ function makeMockAgentManager() {
 }
 
 function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  // ADR-019: derive runtime from agentManager so callOp dispatch flows through
+  // the same mock the test set up. Override `runtime` explicitly when a test
+  // needs a different shape.
+  const agentManager = overrides.agentManager ?? makeMockAgentManager();
   return {
     config: {
       ...DEFAULT_CONFIG,
@@ -57,7 +61,8 @@ function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
     workdir: "/tmp",
     projectDir: "/tmp",
     hooks: { hooks: {} } as any,
-    agentManager: makeMockAgentManager(),
+    agentManager,
+    runtime: overrides.runtime ?? makeMockRuntime({ agentManager }),
     ...overrides,
   };
 }

--- a/test/unit/review/semantic-parsing.test.ts
+++ b/test/unit/review/semantic-parsing.test.ts
@@ -14,7 +14,7 @@ import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
 import type { SemanticStory } from "../../../src/review/semantic";
 import type { SemanticReviewConfig } from "../../../src/review/types";
 import type { AgentResult } from "../../../src/agents/types";
-import { makeAgentAdapter, makeMockAgentManager } from "../../helpers";
+import { makeAgentAdapter, makeMockAgentManager, makeMockRuntime } from "../../helpers";
 
 // ---------------------------------------------------------------------------
 // Helpers (mirrors semantic.test.ts patterns)
@@ -115,6 +115,32 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
     _diffUtilsDeps.getMergeBase = origGetMergeBase;
   });
 
+  // ADR-019 migration helper: hoists agentManager so the runtime can wrap it,
+  // then calls runSemanticReview with both. Tests must dispatch through the
+  // runtime path (callOp → runWithFallback) so they keep working after the
+  // legacy agentManager.run() fallback is removed.
+  async function callRunSemanticReview(response: string) {
+    const agentManager = makeAgentManager(response);
+    const runtime = makeMockRuntime({ agentManager });
+    return runSemanticReview(
+      "/tmp/wd",
+      "abc123",
+      STORY,
+      CONFIG,
+      agentManager,
+      undefined, // naxConfig
+      undefined, // featureName
+      undefined, // resolverSession
+      undefined, // priorFailures
+      undefined, // blockingThreshold
+      undefined, // featureContextMarkdown
+      undefined, // contextBundle
+      undefined, // projectDir
+      undefined, // naxIgnoreIndex
+      runtime,
+    );
+  }
+
   // Failure mode 2: preamble + fenced JSON (production log pattern)
   test("parses passed=true from preamble + ```json fence", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
@@ -123,7 +149,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
       "```json\n" +
       JSON.stringify({ passed: true, findings: [] }) +
       "\n```";
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, makeAgentManager(response));
+    const result = await callRunSemanticReview(response);
     expect(result.success).toBe(true);
     expect(result.output).not.toContain("could not parse");
   });
@@ -136,7 +162,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
     };
     const response =
       "Let me check the implementation.\n```json\n" + JSON.stringify(payload) + "\n```";
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, makeAgentManager(response));
+    const result = await callRunSemanticReview(response);
     expect(result.success).toBe(false);
     expect(result.output).toContain("Semantic review failed");
   });
@@ -148,7 +174,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
       "```\n" +
       JSON.stringify({ passed: true, findings: [] }) +
       "\n```";
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, makeAgentManager(response));
+    const result = await callRunSemanticReview(response);
     expect(result.success).toBe(true);
     expect(result.output).not.toContain("could not parse");
   });
@@ -158,7 +184,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const response =
       'After analysis: {"passed":true,"findings":[]} All ACs are correctly implemented.';
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, makeAgentManager(response));
+    const result = await callRunSemanticReview(response);
     expect(result.success).toBe(true);
     expect(result.output).not.toContain("could not parse");
   });
@@ -170,7 +196,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
       findings: [{ severity: "error", file: "src/bar.ts", line: 5, issue: "stub", suggestion: "implement" }],
     };
     const response = "I found issues. " + JSON.stringify(payload) + " That concludes my review.";
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, makeAgentManager(response));
+    const result = await callRunSemanticReview(response);
     expect(result.success).toBe(false);
   });
 
@@ -178,7 +204,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
   test("parses JSON with trailing commas in fence", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const response = '```json\n{"passed":true,"findings":[],}\n```';
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, makeAgentManager(response));
+    const result = await callRunSemanticReview(response);
     expect(result.success).toBe(true);
     expect(result.output).not.toContain("could not parse");
   });
@@ -188,7 +214,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const response =
       "I'll verify each acceptance criterion by examining the actual files to ensure all i18n keys exist and are correctly wired.";
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, makeAgentManager(response));
+    const result = await callRunSemanticReview(response);
     expect(result.success).toBe(true);
     expect(result.output).toContain("fail-open");
   });
@@ -197,7 +223,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
   test("tier 1 still parses clean JSON directly", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const response = JSON.stringify({ passed: true, findings: [] });
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, CONFIG, makeAgentManager(response));
+    const result = await callRunSemanticReview(response);
     expect(result.success).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Foundation PR for the ADR-019 Wave 3 cleanup tracked in #762. Lays the groundwork for a remote agent (opencode + cheap model) to migrate the seven test files that still exercise the legacy `agentManager.run({ keepOpen: true })` dispatch path. Source code is **untouched** — the legacy fallback remains intact and the full unit suite stays at 6717 pass / 0 fail.

## What this adds

- **`makeMockRuntime`** in `test/helpers/runtime.ts` — wraps an existing agent-manager mock with a real `NaxRuntime` built via `createRuntime`, so tests can exercise the ADR-019 `callOp` / `runWithFallback` / `runAsSession` path.
- **Two reference migrations** that prove the pattern works on legacy AND post-cleanup code:
  - `test/unit/review/semantic-parsing.test.ts` — pattern T2-review
  - `test/unit/pipeline/stages/autofix-routing.test.ts` — pattern T2-pipeline
- **`scripts/adr-019-source-cleanup.patch`** — the source-level diff the migration agent applies during bootstrap so failing tests are visible.
- **Three docs**:
  - [`docs/findings/2026-04-29-legacy-agentmanager-run-cleanup.md`](docs/findings/2026-04-29-legacy-agentmanager-run-cleanup.md) — analysis of every legacy callsite, grouped by readiness.
  - [`docs/findings/2026-04-29-legacy-run-test-migration-playbook.md`](docs/findings/2026-04-29-legacy-run-test-migration-playbook.md) — self-contained agent playbook with decision rule, two patterns, the seven-file queue, and an "Agent Prompt" section to paste into opencode.
  - [`docs/findings/2026-04-29-opencode-invocation.md`](docs/findings/2026-04-29-opencode-invocation.md) — operator guide for launching opencode and shipping the follow-up PRs.

## Why split foundation + migration + cleanup

Sequential PRs keep CI green at every step:

1. **This PR** — adds helpers and reference migrations. No behaviour change. (you are here)
2. **Migration PR** — opencode follows the playbook, migrates the remaining seven test files. CI green.
3. **Source cleanup PR** — applies the patch, drops the legacy code path. Trivially small after migration lands.

Doing it in three steps means a cheap-model agent has a tight, mechanical loop with the test runner as the success oracle, and humans can audit the agent's work without CI ever going red.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test` — 6717 pass / 0 fail / 13 skip (unchanged from main)
- [x] Both reference test files pass with legacy code path active
- [x] Both reference test files pass with the source-cleanup patch applied (verified by stash + apply + run + restash)
- [x] `git apply --check scripts/adr-019-source-cleanup.patch` succeeds against this branch's tip

## Follow-up

After this lands, run opencode against the playbook to produce the migration PR. The operator guide walks through the full sequence end-to-end.

Ref: #762, ADR-018, ADR-019, ADR-020.