### PR TITLE
fix(session): clear stale keepOpen handle when descriptor is terminal

### DIFF
--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -353,7 +353,14 @@ export class SessionManager implements ISessionManager {
   async openSession(name: string, opts: OpenSessionRequest): Promise<SessionHandle> {
     const liveHandle = this._liveHandles.get(name);
     if (liveHandle && liveHandle.agentName === opts.agentName) {
-      return liveHandle;
+      const liveDesc = this._findByName(name);
+      if (!liveDesc || (liveDesc.state !== "COMPLETED" && liveDesc.state !== "FAILED")) {
+        return liveHandle;
+      }
+      // Stale handle: keepOpen left it in _liveHandles but runTrackedSession
+      // already transitioned the descriptor to a terminal state. Remove the
+      // stale entry so the full open path runs and resets the descriptor.
+      this._liveHandles.delete(name);
     }
 
     const adapter = this._getAdapter(opts.agentName);

--- a/test/unit/session/manager-phase-b-session.test.ts
+++ b/test/unit/session/manager-phase-b-session.test.ts
@@ -192,6 +192,40 @@ describe("openSession()", () => {
     await sm.openSession(name, makeOpenRequest());
     expect(sm.descriptor(name)?.state).toBe("RUNNING");
   });
+
+  test("resets live-handle with terminal descriptor to RUNNING (keepOpen scenario)", async () => {
+    // Reproduces the bug where TDD session-runner sets keepOpen=true so
+    // session-run-hop skips closeSession (handle stays in _liveHandles) but
+    // runTrackedSession still transitions the descriptor to COMPLETED.
+    // A later openSession call on the same name must not return the stale handle.
+    let openCallCount = 0;
+    const adapter = makeAgentAdapter({
+      openSession: mock(async (name: string) => {
+        openCallCount++;
+        return { id: name, agentName: "claude" } as SessionHandle;
+      }),
+      closeSession: mock(async () => {}),
+    });
+    const sm = new SessionManager({ getAdapter: () => adapter });
+    const name = "nax-keepopen-stale-test";
+
+    // Open session — handle is now in _liveHandles, descriptor is RUNNING
+    await sm.openSession(name, makeOpenRequest());
+    expect(sm.descriptor(name)?.state).toBe("RUNNING");
+    expect(openCallCount).toBe(1);
+
+    // Simulate runTrackedSession completing without closeSession (keepOpen path):
+    // descriptor goes COMPLETED but handle stays in _liveHandles
+    const desc = sm.descriptor(name);
+    sm.transition(desc!.id, "COMPLETED");
+    expect(sm.descriptor(name)?.state).toBe("COMPLETED");
+
+    // openSession must NOT return the stale live handle; it must open fresh and
+    // reset the descriptor to RUNNING
+    await sm.openSession(name, makeOpenRequest());
+    expect(sm.descriptor(name)?.state).toBe("RUNNING");
+    expect(openCallCount).toBe(2);
+  });
 });
 
 // ─── closeSession() ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- After PR #795 (ADR-008 hold-open pattern), the TDD implementer session runs with `keepOpen=true`: `session-run-hop` skips `closeSession` (handle stays in `_liveHandles`) but `runTrackedSession` still transitions the descriptor to `COMPLETED`
- When autofix later called `openSession` for the same implementer session name, the early-return path at `manager.ts:354` returned the stale live handle without checking the descriptor state — `sendPrompt` then correctly rejected it with `SESSION_TERMINAL_STATE`, causing the autofix stage to throw
- Fix: before returning the live handle early in `openSession`, check if its descriptor is terminal; if so, remove the stale entry from `_liveHandles` and fall through to the full open path which correctly resets `COMPLETED → RUNNING`

## Test plan

- [ ] New unit test `"resets live-handle with terminal descriptor to RUNNING (keepOpen scenario)"` in `test/unit/session/manager-phase-b-session.test.ts` directly reproduces the race: open session → transition to COMPLETED without closing → re-open → assert descriptor is RUNNING and adapter `openSession` was called twice (not the early-return path)
- [ ] All existing session manager tests still pass (68 tests across 3 files)
- [ ] Regression: TDD run where tests pass on first attempt (no rectification) followed by a review failure that triggers autofix should no longer throw `SESSION_TERMINAL_STATE`