### PR TITLE
chore: release v0.64.0-canary.9 (canary)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.64.0-canary.8",
+  "version": "0.64.0-canary.9",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.64.0-canary.9

Bumps version: 0.64.0-canary.8 → 0.64.0-canary.9

After merging, run:
```bash
git checkout main && git pull origin main
bun run release tag
```