### PR TITLE
fix(prompts): improve rectifier no-op and mechanical fix guidance

### DIFF
--- a/src/prompts/builders/rectifier-builder-helpers.ts
+++ b/src/prompts/builders/rectifier-builder-helpers.ts
@@ -125,5 +125,5 @@ ${errors}
 
 Fix ALL errors listed above. Do NOT change test files or test behavior.
 Do NOT add new features — only fix the quality check errors.
-Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
+After fixing, re-run the failing check(s) to verify they pass, then commit your changes.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
 }

--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -73,7 +73,9 @@ export class RectifierPromptBuilder {
       }
     }
 
-    parts.push("\nFix ALL issues listed. Do NOT change test files or test behavior. Commit your fixes when done.");
+    parts.push(
+      "\nFix ALL issues listed. After fixing, re-run the failing check(s) to verify they pass before committing. Do NOT change test files or test behavior. Commit your changes when all checks pass.",
+    );
     parts.push(CONTRADICTION_ESCAPE_HATCH);
 
     return parts.join("\n");
@@ -174,10 +176,12 @@ Commit your fixes when done.${scopeConstraint}`;
     const parts: string[] = [];
 
     parts.push(
-      "**Your previous turn produced no file changes.**\n\n" +
+      "**Your previous turn produced no committed file changes.**\n\n" +
         "You must take one of these two actions:\n" +
-        "1. **Edit source files** to address the review findings listed below, OR\n" +
-        "2. **Emit `UNRESOLVED: <reason>`** if the findings are contradictory or cannot be fixed\n\n",
+        "1. **Edit project files** (source code, `package.json`, `tsconfig.json`, config files, etc.) to address the review findings listed below, then **commit** the changes, OR\n" +
+        "2. **Emit `UNRESOLVED: <reason>`** if the findings are contradictory or cannot be fixed\n\n" +
+        "**Important:** Running `bun install` / `npm install` alone does not count — if a package is missing, add it to `package.json` AND commit. Staged-but-uncommitted changes also do not count.\n\n" +
+        "After editing, re-run the failing check(s) to verify they pass, then commit.\n\n",
     );
 
     if (noOpCount >= maxNoOpReprompts) {

--- a/test/unit/prompts/builders/rectifier-builder.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder.test.ts
@@ -136,14 +136,15 @@ describe("RectifierPromptBuilder.firstAttemptDelta", () => {
     expect(prompt).toContain("UNRESOLVED:");
   });
 
-  test("instructs agent to fix ALL issues and commit", () => {
+  test("instructs agent to fix ALL issues, verify, and commit", () => {
     const prompt = RectifierPromptBuilder.firstAttemptDelta(
       [makeCheck("lint", "error")],
       2,
     );
 
     expect(prompt).toContain("Fix ALL issues listed");
-    expect(prompt).toContain("Commit your fixes when done");
+    expect(prompt).toContain("re-run the failing check(s) to verify they pass before committing");
+    expect(prompt).toContain("Commit your changes when all checks pass");
   });
 
   test("does NOT include story title or acceptance criteria sections", () => {


### PR DESCRIPTION
## Summary

- `noOpReprompt`: "Edit source files" → "Edit project files" (package.json, tsconfig.json, etc.); clarifies that `bun install` alone or staged-but-uncommitted changes don't count; adds verify-then-commit instruction
- `firstAttemptDelta` + `mechanicalRectification`: add explicit instruction to re-run the failing check after fixing to verify it passes before committing

## Context

Discovered in `v0.64.0-canary.8` dogfood run — typecheck error `Cannot find type definition file for 'bun-types'` drained 3 rectification attempts:
1. Agent ran `bun install` (no tracked changes) → no-op reprompt: "Edit source files"
2. Agent staged `package.json` without committing → no-op again
3. Third attempt consumed, budget exhausted

Two root causes:
1. Mechanical fix prompts never told the agent to verify the fix actually passes before committing
2. `noOpReprompt` said "Edit source files" which actively misled the agent when the real fix was a dependency change

This PR fixes the prompt layer. The detection layer (distinguishing staged vs. install-only vs. true no-op at the `captureGitRef` level) is tracked separately in #808.

## Test plan

- [ ] `noOpReprompt` contains "no committed file changes", package.json guidance, and verify instruction
- [ ] `firstAttemptDelta` contains verify-before-commit instruction
- [ ] `mechanicalRectification` contains verify-before-commit instruction
- [ ] All tests pass: `bun run test`