### PR TITLE
fix(prompt-audit): propagate recordId and harden JSONL reliability

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -541,7 +541,10 @@ export class AgentManager implements IAgentManager {
         durationMs: Date.now() - start,
         timestamp: Date.now(),
         turn: result.internalRoundTrips ?? 1,
-        protocolIds: { sessionId: handle.protocolIds?.sessionId ?? null },
+        protocolIds: {
+          sessionId: handle.protocolIds?.sessionId ?? null,
+          recordId: handle.protocolIds?.recordId ?? null,
+        },
         origin: "runAsSession",
       };
       this._dispatchEvents.emitDispatch(event);

--- a/src/runtime/dispatch-events.ts
+++ b/src/runtime/dispatch-events.ts
@@ -32,7 +32,7 @@ export interface DispatchEventBase {
 export interface SessionTurnDispatchEvent extends DispatchEventBase {
   readonly kind: "session-turn";
   readonly turn: number;
-  readonly protocolIds: { sessionId?: string | null; turnId?: string };
+  readonly protocolIds: { sessionId?: string | null; recordId?: string | null; turnId?: string };
   /** Diagnostic only — never branch subscriber logic on this. */
   readonly origin: "runAsSession" | "runTrackedSession";
 }

--- a/src/runtime/middleware/audit.ts
+++ b/src/runtime/middleware/audit.ts
@@ -20,6 +20,7 @@ export function attachAuditSubscriber(bus: IDispatchEventBus, auditor: IPromptAu
       sessionName: event.sessionName,
       ...(event.kind === "session-turn" && {
         sessionId: event.protocolIds.sessionId ?? null,
+        recordId: event.protocolIds.recordId ?? null,
         turn: event.turn,
       }),
     };

--- a/src/runtime/prompt-auditor.ts
+++ b/src/runtime/prompt-auditor.ts
@@ -1,9 +1,28 @@
-// Bun-native carve-out: appendFile + mkdir.
-// Bun has no append API on Bun.write / FileSink (writer truncates), so node:fs/promises
-// is the pragmatic choice for incremental JSONL persistence. Top-level import avoids
-// per-call dynamic-import cost. See .claude/rules/forbidden-patterns.md (appendFile
-// is not in the banned list; documented carve-out from the broader Bun-native rule).
-import { appendFile, mkdir } from "node:fs/promises";
+// Bun-native carve-out: appendFileSync + mkdir.
+// Bun has no append API on Bun.write / FileSink (writer truncates), so node:fs is
+// the pragmatic choice for incremental JSONL persistence.
+//
+// Why appendFileSync (not appendFile)? Under sustained load we observed
+// JSONL entries silently dropping while their sibling `.txt` files (written
+// via Bun.write) landed on disk — see the 2026-04-29 dogfood run where the
+// run-log heartbeat also silenced for 9 minutes during the same window
+// (`docs/findings/...`). The async `appendFile` from `node:fs/promises`
+// goes through Bun's libuv-style queue; under event-loop pressure or a
+// transient FS stall the promise can resolve without the bytes hitting
+// disk. The sync variant goes straight to a `write(2)` syscall, removing
+// that buffering hop. The `_queue` Promise chain still serializes calls,
+// so the sync hit blocks only the auditor's own microtask — not the rest
+// of the run. Audit lines are tiny (a few KB), so the cost is microseconds.
+//
+// Same pattern is used elsewhere in the repo for reliability-critical
+// append paths: `src/execution/crash-heartbeat.ts:45` and
+// `src/execution/lifecycle/precheck-runner.ts:67`.
+//
+// Top-level import avoids per-call dynamic-import cost. See
+// `.claude/rules/forbidden-patterns.md` (appendFileSync is not banned;
+// documented carve-out from the broader Bun-native rule).
+import { appendFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { getSafeLogger } from "../logger";
 import { errorMessage } from "../utils/errors";
@@ -66,8 +85,29 @@ export function createNoOpPromptAuditor(): IPromptAuditor {
 /** Injectable deps — swap in tests to avoid real disk I/O. */
 export const _promptAuditorDeps = {
   write: (path: string, data: string): Promise<number> => Bun.write(path, data),
-  appendLine: (path: string, data: string): Promise<void> => appendFile(path, data, "utf8"),
+  // Sync append: see file header for rationale (silent-drop bug under load
+  // with async appendFile). Returns Promise<void> to keep the call-site
+  // signature symmetric with `write` — callers `await` it.
+  appendLine: async (path: string, data: string): Promise<void> => {
+    appendFileSync(path, data, "utf8");
+  },
 };
+
+/**
+ * Tag a write failure with the phase that produced it ("jsonl" vs "txt") so
+ * the catch handler in `_enqueue` can include it in the warning. Preserves
+ * the original error as `cause` so OS-level errno fields (code/errno/syscall)
+ * remain accessible for diagnostics.
+ */
+function tagAuditError(err: unknown, phase: "jsonl" | "txt"): Error {
+  const wrapped = new Error(`prompt-audit ${phase} write failed: ${errorMessage(err)}`) as Error & {
+    _auditPhase: "jsonl" | "txt";
+    cause: unknown;
+  };
+  wrapped._auditPhase = phase;
+  wrapped.cause = err;
+  return wrapped;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Human-readable txt content builder
@@ -145,26 +185,58 @@ export class PromptAuditor implements IPromptAuditor {
     this._queue = this._queue
       .then(() => this._writeEntry(entry))
       .catch((err) => {
-        // Per-entry failures (disk full, permission denied) must not break the chain.
-        // Surface the failure so silent audit gaps are diagnosable.
+        // Per-entry failures (disk full, permission denied, transient FS stall)
+        // must not break the chain. Log enough context to correlate the dropped
+        // entry with the rest of the run's artifacts:
+        //   - phase tells us whether the JSONL append or the .txt write failed
+        //     (if .txt succeeded we'll find an orphan file with the same `ts`)
+        //   - errno/code/syscall surface the OS-level cause (EACCES, ENOSPC, …)
+        //   - entry identity (ts/storyId/sessionName/callType/agentName/stage)
+        //     lets an operator find the corresponding .txt sidecar by `ts`
+        // See file header for the silent-drop incident this guard exists for.
+        const phase = (err as { _auditPhase?: "jsonl" | "txt" })._auditPhase;
+        const cause = (err as { cause?: unknown }).cause ?? err;
+        const sysErr = cause as NodeJS.ErrnoException;
         getSafeLogger()?.warn("audit", "prompt-audit write failed", {
           path: this._jsonlPath,
-          error: errorMessage(err),
+          phase: phase ?? "unknown",
+          error: errorMessage(cause),
+          code: sysErr?.code,
+          errno: sysErr?.errno,
+          syscall: sysErr?.syscall,
+          ts: entry.ts,
+          storyId: entry.storyId,
+          sessionName: "sessionName" in entry ? entry.sessionName : undefined,
+          callType: entry.callType,
+          agentName: entry.agentName,
+          stage: entry.stage,
         });
       });
   }
 
   private async _writeEntry(entry: PromptAuditEntry | PromptAuditErrorEntry): Promise<void> {
     if (!this._dirCreated) {
-      await mkdir(this._featureDir, { recursive: true });
+      try {
+        await mkdir(this._featureDir, { recursive: true });
+      } catch (err) {
+        throw tagAuditError(err, "jsonl");
+      }
       this._dirCreated = true;
     }
-    await _promptAuditorDeps.appendLine(this._jsonlPath, `${JSON.stringify(entry)}\n`);
+    try {
+      await _promptAuditorDeps.appendLine(this._jsonlPath, `${JSON.stringify(entry)}\n`);
+    } catch (err) {
+      throw tagAuditError(err, "jsonl");
+    }
 
     if (!("prompt" in entry) || !("response" in entry)) return;
     const auditEntry = entry as PromptAuditEntry;
     const filename = deriveTxtFilename(auditEntry);
-    await _promptAuditorDeps.write(join(this._featureDir, filename), buildTxtContent(auditEntry));
+    try {
+      await _promptAuditorDeps.write(join(this._featureDir, filename), buildTxtContent(auditEntry));
+    } catch (err) {
+      throw tagAuditError(err, "txt");
+    }
   }
 
   async flush(): Promise<void> {

--- a/src/session/manager-run.ts
+++ b/src/session/manager-run.ts
@@ -178,7 +178,10 @@ export async function runTrackedSession(
     workdir: pre.workdir,
     resolvedPermissions,
     turn: (result as { internalRoundTrips?: number }).internalRoundTrips ?? 0,
-    protocolIds: { sessionId: result.protocolIds?.sessionId ?? null },
+    protocolIds: {
+      sessionId: result.protocolIds?.sessionId ?? null,
+      recordId: result.protocolIds?.recordId ?? null,
+    },
     origin: "runTrackedSession",
     tokenUsage: result.tokenUsage,
     exactCostUsd: result.exactCostUsd,

--- a/test/unit/agents/manager-dispatch-emission.test.ts
+++ b/test/unit/agents/manager-dispatch-emission.test.ts
@@ -60,6 +60,14 @@ function makeHandle(agentName = "claude", id = "nax-test-handle"): SessionHandle
   return { id, agentName };
 }
 
+function makeHandleWithIds(
+  agentName = "claude",
+  id = "nax-test-handle",
+  protocolIds?: { sessionId: string | null; recordId: string | null },
+): SessionHandle {
+  return { id, agentName, ...(protocolIds && { protocolIds }) };
+}
+
 // ─── runAsSession ────────────────────────────────────────────────────────────
 
 describe("runAsSession — dispatch emission", () => {
@@ -89,6 +97,29 @@ describe("runAsSession — dispatch emission", () => {
     expect(received[0]?.featureName).toBe("my-feat");
     expect(received[0]?.workdir).toBe("/tmp/repo");
     expect(received[0]?.prompt).toBe("test-prompt");
+  });
+
+  test("forwards handle.protocolIds.recordId into session-turn event", async () => {
+    const bus = new DispatchEventBus();
+    const manager = new AgentManager(DEFAULT_CONFIG, undefined, {
+      sendPrompt: mock(async () => makeTurnResult("hello")),
+      dispatchEvents: bus,
+    });
+
+    const received: SessionTurnDispatchEvent[] = [];
+    bus.onDispatch((e) => {
+      if (e.kind === "session-turn") received.push(e);
+    });
+
+    const handle = makeHandleWithIds("claude", "nax-test-handle", {
+      sessionId: "sess-abc",
+      recordId: "rec-xyz",
+    });
+    await manager.runAsSession("claude", handle, "p", { pipelineStage: "run", storyId: "US-001" });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.protocolIds.sessionId).toBe("sess-abc");
+    expect(received[0]?.protocolIds.recordId).toBe("rec-xyz");
   });
 
   test("emits DispatchErrorEvent on sendPrompt throw, then re-throws", async () => {

--- a/test/unit/runtime/middleware/audit.test.ts
+++ b/test/unit/runtime/middleware/audit.test.ts
@@ -25,7 +25,7 @@ function makeSessionTurnEvent(overrides: Partial<SessionTurnDispatchEvent> = {})
     projectDir: "/tmp/p",
     resolvedPermissions: PERMS,
     turn: 2,
-    protocolIds: { sessionId: "sess-1" },
+    protocolIds: { sessionId: "sess-1", recordId: "rec-1" },
     origin: "runAsSession",
     durationMs: 150,
     timestamp: 1000,
@@ -84,6 +84,7 @@ describe("attachAuditSubscriber", () => {
     expect(recorded[0].callType).toBe("run");
     expect(recorded[0].sessionName).toBe("nax-abc-feat-s1-main");
     expect(recorded[0].sessionId).toBe("sess-1");
+    expect(recorded[0].recordId).toBe("rec-1");
     expect(recorded[0].turn).toBe(2);
     expect(recorded[0].permissionProfile).toBe("approve-reads");
     expect(recorded[0].durationMs).toBe(150);
@@ -110,6 +111,19 @@ describe("attachAuditSubscriber", () => {
     expect(recorded[0].sessionName).toBe("nax-abc-feat-s1-plan");
     expect(recorded[0].turn).toBeUndefined();
     expect(recorded[0].sessionId).toBeUndefined();
+    expect(recorded[0].recordId).toBeUndefined();
+  });
+
+  test("session-turn dispatch with missing recordId records null", () => {
+    const recorded: PromptAuditEntry[] = [];
+    const auditor = { ...createNoOpPromptAuditor(), record: (e: PromptAuditEntry) => recorded.push(e) };
+    const bus = new DispatchEventBus();
+    attachAuditSubscriber(bus, auditor, "r-001");
+
+    bus.emitDispatch(makeSessionTurnEvent({ protocolIds: { sessionId: "sess-x" } }));
+
+    expect(recorded[0].sessionId).toBe("sess-x");
+    expect(recorded[0].recordId).toBeNull();
   });
 
   test("records PromptAuditErrorEntry on dispatch error", () => {

--- a/test/unit/runtime/prompt-auditor.test.ts
+++ b/test/unit/runtime/prompt-auditor.test.ts
@@ -214,6 +214,52 @@ describe("PromptAuditor", () => {
     });
   });
 
+  test("write failure does not break the queue — subsequent entries still write", async () => {
+    await withTempDir(async (dir) => {
+      const appends: string[] = [];
+      const origAppend = _promptAuditorDeps.appendLine;
+      let calls = 0;
+      _promptAuditorDeps.appendLine = async (_p: string, d: string) => {
+        calls++;
+        if (calls === 1) {
+          const err = new Error("disk full") as NodeJS.ErrnoException;
+          err.code = "ENOSPC";
+          err.errno = -28;
+          err.syscall = "write";
+          throw err;
+        }
+        appends.push(d);
+      };
+      const aud = new PromptAuditor("r-001", join(dir, "audit"), FEATURE);
+      aud.record(makeEntry({ ts: 1, prompt: "first (will fail)" }));
+      aud.record(makeEntry({ ts: 2, prompt: "second (should succeed)" }));
+      await aud.flush();
+      expect(appends).toHaveLength(1);
+      expect(appends[0]).toContain("second");
+      _promptAuditorDeps.appendLine = origAppend;
+    });
+  });
+
+  test("txt-phase failure does not block JSONL — JSONL line is still persisted", async () => {
+    await withTempDir(async (dir) => {
+      const appends: string[] = [];
+      const origAppend = _promptAuditorDeps.appendLine;
+      const origWrite = _promptAuditorDeps.write;
+      _promptAuditorDeps.appendLine = async (_p: string, d: string) => { appends.push(d); };
+      _promptAuditorDeps.write = async () => {
+        throw new Error("txt write failed");
+      };
+      const aud = new PromptAuditor("r-001", join(dir, "audit"), FEATURE);
+      aud.record(makeEntry({ ts: 100, prompt: "txt-fail" }));
+      await aud.flush();
+      // JSONL was appended before txt write was attempted.
+      expect(appends).toHaveLength(1);
+      expect(appends[0]).toContain("txt-fail");
+      _promptAuditorDeps.appendLine = origAppend;
+      _promptAuditorDeps.write = origWrite;
+    });
+  });
+
   test("recordError() entries appear in JSONL but produce no txt file", async () => {
     await withTempDir(async (dir) => {
       const appends: string[] = [];


### PR DESCRIPTION
## Summary

Two prompt-audit fidelity bugs surfaced in the v0.64.0-canary.8 dogfood run (`hello-lint` fixture):

1. **`recordId` never reached the audit `.txt`** — `SessionTurnDispatchEvent.protocolIds` only carried `sessionId`; `recordId` was dropped at the dispatch boundary even though the session descriptor and `ProtocolIds` both had it.
2. **JSONL had 8 entries; `.txt` had 13** with identical `RunId` — async `appendFile` was silently dropping entries during a transient FS stall (cross-referenced run log shows 8 missing heartbeats over the same 9-minute window).

## What changed

**recordId propagation** — extend `SessionTurnDispatchEvent.protocolIds` with `recordId`; populate at both emit sites (`SessionManager.runTrackedSession`, `AgentManager.runAsSession`); forward through `attachAuditSubscriber` into `PromptAuditEntry` (the field already existed, was unreached).

**JSONL silent-drop fix** — swap the auditor's `appendLine` from async `appendFile` (`node:fs/promises`) to sync `appendFileSync` (`node:fs`). The `_queue` Promise chain still serializes calls so only the auditor's microtask blocks. Same precedent already in the codebase: `crash-heartbeat.ts:45` and `precheck-runner.ts:67` use sync append for reliability-critical paths. File header comment explains the silent-drop incident and rationale.

**Diagnostic hardening** — `_writeEntry` now tags failures with `phase: "jsonl" | "txt"` via a small `tagAuditError` helper that preserves the original error as `cause`. The `_enqueue` catch handler logs `phase`, errno fields (`code` / `errno` / `syscall`), and entry identity (`ts` / `storyId` / `sessionName` / `callType` / `agentName` / `stage`) — a future orphan `.txt` can now be correlated by `ts` and the OS-level cause surfaces in the run log.

## Risk / impact (sync `appendFileSync`)

- **Per-call cost:** microseconds for KB-sized writes; the queue already serializes so no event-loop fanout to block. No measurable run-time impact for typical audit volumes (<200 entries / run).
- **Crash safety:** equal or better than `appendFile` — sync write returns only after `write(2)` is in OS cache; previously the async promise could resolve before bytes were committed.
- **No API/format changes:** JSONL on-disk format is identical; `.txt` filename and content unchanged; `_promptAuditorDeps.appendLine` keeps `Promise<void>` signature so existing test mocks still work.
- **Considered alternatives:** `Bun.write` read-modify-write (rejected — O(n²) IO and worse crash truncation); per-entry JSON sidecars (rejected — bigger refactor than the bug warrants).

## Test plan

- [x] Runtime suites green (`test/unit/runtime`, `test/integration/runtime`) — 129 pass
- [x] Agents + audit-naming green (`manager-dispatch-emission`, `audit-naming`) — 11 pass
- [x] `prompt-auditor` suite green — 13 pass (2 new cases: ENOSPC errno doesn't break the queue, txt-phase failure still persists JSONL)
- [x] Pre-commit hooks (typecheck, biome, process.cwd, adapter-wrap, dispatch-context) all green
- [ ] Verify on next dogfood run that `.txt` and JSONL counts match and `RecordId:` line appears in run-turn `.txt` files