### PR TITLE
feat(rectifier-builder): categorized + prioritized prompt sections

### DIFF
--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -14,7 +14,7 @@
 
 import type { RectificationConfig } from "../../config";
 import type { UserStory } from "../../prd";
-import type { ReviewCheckResult } from "../../review/types";
+import type { ReviewCheckName, ReviewCheckResult } from "../../review/types";
 import { formatFailureSummary } from "../../verification/parser";
 import type { TestFailure } from "../../verification/types";
 import { priorFailuresSection, universalConstitutionSection, universalContextSection } from "../core";
@@ -40,6 +40,121 @@ export type { FailureRecord, ReviewFinding };
  */
 export type RectifierTrigger = "tdd-test-failure" | "tdd-suite-failure" | "verify-failure" | "review-findings";
 
+type RectificationPriority = "compile-build" | "lint" | "behavior" | "semantic" | "architectural";
+
+interface PriorityBucket {
+  priority: number;
+  heading: string;
+  guidance: string;
+}
+
+const PRIORITY_BUCKETS: Readonly<Record<RectificationPriority, PriorityBucket>> = {
+  "compile-build": {
+    priority: 1,
+    heading: "Compile/build",
+    guidance: "Must fix first. Fixes here may resolve later items automatically.",
+  },
+  lint: {
+    priority: 2,
+    heading: "Lint/style",
+    guidance: "Fix after compile errors. Often automated.",
+  },
+  behavior: {
+    priority: 3,
+    heading: "Behavior",
+    guidance: "Fix after compile passes. Indicates implementation does not match assertion.",
+  },
+  semantic: {
+    priority: 4,
+    heading: "Semantic",
+    guidance: "Story-alignment concerns. Re-read the story before editing.",
+  },
+  architectural: {
+    priority: 5,
+    heading: "Architectural",
+    guidance: "Lowest priority. Fix only after all above pass.",
+  },
+};
+
+const PRIORITY_ORDER: Readonly<RectificationPriority[]> = [
+  "compile-build",
+  "lint",
+  "behavior",
+  "semantic",
+  "architectural",
+];
+
+function priorityForCheck(checkName: ReviewCheckName): RectificationPriority {
+  switch (checkName) {
+    case "typecheck":
+    case "build":
+      return "compile-build";
+    case "lint":
+      return "lint";
+    case "test":
+      return "behavior";
+    case "semantic":
+      return "semantic";
+    case "adversarial":
+      return "architectural";
+    default:
+      return assertNever(checkName);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled review check category: ${String(value)}`);
+}
+
+function renderCheckBlock(check: ReviewCheckResult): string {
+  const parts: string[] = [];
+  parts.push(`### ${check.check} (exit ${check.exitCode})\n`);
+  const truncated = check.output.length > 4000;
+  const output = truncated
+    ? `${check.output.slice(0, 4000)}\n... (truncated — ${check.output.length} chars total)`
+    : check.output;
+  parts.push(`\`\`\`\n${output}\n\`\`\`\n`);
+
+  if (check.findings?.length) {
+    parts.push("Structured findings:\n");
+    for (const f of check.findings) {
+      parts.push(`- [${f.severity}] ${f.file}:${f.line} — ${f.message}\n`);
+    }
+  }
+
+  return parts.join("\n");
+}
+
+function renderPrioritizedFailures(failedChecks: Readonly<ReviewCheckResult[]>): string {
+  const grouped: Readonly<Record<RectificationPriority, Readonly<ReviewCheckResult[]>>> = {
+    "compile-build": failedChecks.filter((check) => priorityForCheck(check.check) === "compile-build"),
+    lint: failedChecks.filter((check) => priorityForCheck(check.check) === "lint"),
+    behavior: failedChecks.filter((check) => priorityForCheck(check.check) === "behavior"),
+    semantic: failedChecks.filter((check) => priorityForCheck(check.check) === "semantic"),
+    architectural: failedChecks.filter((check) => priorityForCheck(check.check) === "architectural"),
+  };
+
+  const sections: string[] = [
+    "**Order matters: fix Priority 1 first; later priorities may need redo if earlier ones change the code.**\n",
+  ];
+
+  for (const priority of PRIORITY_ORDER) {
+    const checks = grouped[priority];
+    if (checks.length === 0) {
+      continue;
+    }
+
+    const bucket = PRIORITY_BUCKETS[priority];
+    sections.push(`## Priority ${bucket.priority} — ${bucket.heading}\n`);
+    sections.push(`${bucket.guidance}\n`);
+    for (const check of checks) {
+      sections.push(renderCheckBlock(check));
+    }
+  }
+
+  return sections.join("\n");
+}
+
 // biome-ignore lint/complexity/noStaticOnlyClass: Static-method namespace for prompt builders (ADR-018)
 export class RectifierPromptBuilder {
   /**
@@ -58,23 +173,10 @@ export class RectifierPromptBuilder {
       `Review failed after your implementation. Fix the following issues (${attemptWord} available before escalation):\n`,
     );
 
-    for (const check of failedChecks) {
-      parts.push(`### ${check.check} (exit ${check.exitCode})\n`);
-      const truncated = check.output.length > 4000;
-      const output = truncated
-        ? `${check.output.slice(0, 4000)}\n... (truncated — ${check.output.length} chars total)`
-        : check.output;
-      parts.push(`\`\`\`\n${output}\n\`\`\`\n`);
-      if (check.findings?.length) {
-        parts.push("Structured findings:\n");
-        for (const f of check.findings) {
-          parts.push(`- [${f.severity}] ${f.file}:${f.line} — ${f.message}\n`);
-        }
-      }
-    }
+    parts.push(renderPrioritizedFailures(failedChecks));
 
     parts.push(
-      "\nFix ALL issues listed. After fixing, re-run the failing check(s) to verify they pass before committing. Do NOT change test files or test behavior. Commit your changes when all checks pass.",
+      "\nFix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior. Commit your changes when all checks pass.",
     );
     parts.push(CONTRADICTION_ESCAPE_HATCH);
 
@@ -98,20 +200,7 @@ export class RectifierPromptBuilder {
 
     parts.push("Your previous fix attempt did not resolve all issues. Here are the remaining failures:\n");
 
-    for (const check of failedChecks) {
-      parts.push(`### ${check.check} (exit ${check.exitCode})\n`);
-      const truncated = check.output.length > 4000;
-      const output = truncated
-        ? `${check.output.slice(0, 4000)}\n... (truncated — ${check.output.length} chars total)`
-        : check.output;
-      parts.push(`\`\`\`\n${output}\n\`\`\`\n`);
-      if (check.findings?.length) {
-        parts.push("Structured findings:\n");
-        for (const f of check.findings) {
-          parts.push(`- [${f.severity}] ${f.file}:${f.line} — ${f.message}\n`);
-        }
-      }
-    }
+    parts.push(renderPrioritizedFailures(failedChecks));
 
     if (attempt >= rethinkAtAttempt) {
       parts.push(

--- a/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
@@ -167,3 +167,261 @@ Tests are failing. Fix the source so all tests pass — not just the ones listed
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements."
 `;
+
+exports[`RectifierPromptBuilder.firstAttemptDelta single-category: renders only the matching priority bucket 1`] = `
+"Review failed after your implementation. Fix the following issues (3 attempts available before escalation):
+
+**Order matters: fix Priority 1 first; later priorities may need redo if earlier ones change the code.**
+
+## Priority 2 — Lint/style
+
+Fix after compile errors. Often automated.
+
+### lint (exit 1)
+
+\`\`\`
+lint output
+\`\`\`
+
+
+Fix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior. Commit your changes when all checks pass.
+
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+`;
+
+exports[`RectifierPromptBuilder.firstAttemptDelta two-categories: renders in fixed priority order, not input order 1`] = `
+"Review failed after your implementation. Fix the following issues (3 attempts available before escalation):
+
+**Order matters: fix Priority 1 first; later priorities may need redo if earlier ones change the code.**
+
+## Priority 1 — Compile/build
+
+Must fix first. Fixes here may resolve later items automatically.
+
+### typecheck (exit 1)
+
+\`\`\`
+typecheck output
+\`\`\`
+
+## Priority 4 — Semantic
+
+Story-alignment concerns. Re-read the story before editing.
+
+### semantic (exit 1)
+
+\`\`\`
+semantic output
+\`\`\`
+
+
+Fix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior. Commit your changes when all checks pass.
+
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+`;
+
+exports[`RectifierPromptBuilder.firstAttemptDelta all-categories: renders all five buckets with expected grouping 1`] = `
+"Review failed after your implementation. Fix the following issues (3 attempts available before escalation):
+
+**Order matters: fix Priority 1 first; later priorities may need redo if earlier ones change the code.**
+
+## Priority 1 — Compile/build
+
+Must fix first. Fixes here may resolve later items automatically.
+
+### build (exit 2)
+
+\`\`\`
+build output
+\`\`\`
+
+### typecheck (exit 1)
+
+\`\`\`
+typecheck output
+\`\`\`
+
+## Priority 2 — Lint/style
+
+Fix after compile errors. Often automated.
+
+### lint (exit 1)
+
+\`\`\`
+lint output
+\`\`\`
+
+## Priority 3 — Behavior
+
+Fix after compile passes. Indicates implementation does not match assertion.
+
+### test (exit 1)
+
+\`\`\`
+test output
+\`\`\`
+
+## Priority 4 — Semantic
+
+Story-alignment concerns. Re-read the story before editing.
+
+### semantic (exit 1)
+
+\`\`\`
+semantic output
+\`\`\`
+
+Structured findings:
+
+- [error] src/foo.ts:42 — Implementation does not satisfy AC#3
+
+## Priority 5 — Architectural
+
+Lowest priority. Fix only after all above pass.
+
+### adversarial (exit 1)
+
+\`\`\`
+adversarial output
+\`\`\`
+
+
+Fix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior. Commit your changes when all checks pass.
+
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+`;
+
+exports[`RectifierPromptBuilder.continuation single-category: renders only the matching priority bucket 1`] = `
+"Your previous fix attempt did not resolve all issues. Here are the remaining failures:
+
+**Order matters: fix Priority 1 first; later priorities may need redo if earlier ones change the code.**
+
+## Priority 2 — Lint/style
+
+Fix after compile errors. Often automated.
+
+### lint (exit 1)
+
+\`\`\`
+lint output
+\`\`\`
+
+
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+`;
+
+exports[`RectifierPromptBuilder.continuation two-categories: renders in fixed priority order, not input order 1`] = `
+"Your previous fix attempt did not resolve all issues. Here are the remaining failures:
+
+**Order matters: fix Priority 1 first; later priorities may need redo if earlier ones change the code.**
+
+## Priority 1 — Compile/build
+
+Must fix first. Fixes here may resolve later items automatically.
+
+### typecheck (exit 1)
+
+\`\`\`
+typecheck output
+\`\`\`
+
+## Priority 4 — Semantic
+
+Story-alignment concerns. Re-read the story before editing.
+
+### semantic (exit 1)
+
+\`\`\`
+semantic output
+\`\`\`
+
+
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+`;
+
+exports[`RectifierPromptBuilder.continuation all-categories: renders all five buckets with expected grouping 1`] = `
+"Your previous fix attempt did not resolve all issues. Here are the remaining failures:
+
+**Order matters: fix Priority 1 first; later priorities may need redo if earlier ones change the code.**
+
+## Priority 1 — Compile/build
+
+Must fix first. Fixes here may resolve later items automatically.
+
+### build (exit 2)
+
+\`\`\`
+build output
+\`\`\`
+
+### typecheck (exit 1)
+
+\`\`\`
+typecheck output
+\`\`\`
+
+## Priority 2 — Lint/style
+
+Fix after compile errors. Often automated.
+
+### lint (exit 1)
+
+\`\`\`
+lint output
+\`\`\`
+
+## Priority 3 — Behavior
+
+Fix after compile passes. Indicates implementation does not match assertion.
+
+### test (exit 1)
+
+\`\`\`
+test output
+\`\`\`
+
+## Priority 4 — Semantic
+
+Story-alignment concerns. Re-read the story before editing.
+
+### semantic (exit 1)
+
+\`\`\`
+semantic output
+\`\`\`
+
+Structured findings:
+
+- [error] src/foo.ts:42 — Implementation does not satisfy AC#3
+
+## Priority 5 — Architectural
+
+Lowest priority. Fix only after all above pass.
+
+### adversarial (exit 1)
+
+\`\`\`
+adversarial output
+\`\`\`
+
+
+**Rethink your approach.** The same strategy has failed multiple times. Consider a fundamentally different fix.
+
+
+**URGENT: This is your final attempt.** If you cannot fix all issues, emit \`UNRESOLVED: <reason>\` to escalate.
+
+
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+`;

--- a/test/unit/prompts/builders/rectifier-builder.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder.test.ts
@@ -136,14 +136,14 @@ describe("RectifierPromptBuilder.firstAttemptDelta", () => {
     expect(prompt).toContain("UNRESOLVED:");
   });
 
-  test("instructs agent to fix ALL issues, verify, and commit", () => {
+  test("instructs agent to fix in priority order, verify, and commit", () => {
     const prompt = RectifierPromptBuilder.firstAttemptDelta(
       [makeCheck("lint", "error")],
       2,
     );
 
-    expect(prompt).toContain("Fix ALL issues listed");
-    expect(prompt).toContain("re-run the failing check(s) to verify they pass before committing");
+    expect(prompt).toContain("Fix in priority order");
+    expect(prompt).toContain("re-run the failing check(s) at that level to verify they pass before moving on");
     expect(prompt).toContain("Commit your changes when all checks pass");
   });
 

--- a/test/unit/prompts/rectifier-builder.test.ts
+++ b/test/unit/prompts/rectifier-builder.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, test } from "bun:test";
 import { makeStory } from "../../helpers";
 import { RectifierPromptBuilder } from "../../../src/prompts";
 import type { FailureRecord } from "../../../src/prompts";
+import type { ReviewCheckResult } from "../../../src/review/types";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -224,5 +225,148 @@ describe("RectifierPromptBuilder.noOpReprompt", () => {
     const atLimit = RectifierPromptBuilder.noOpReprompt([FAILED_CHECK], 1, 1);
     expect(beforeLimit).not.toContain("WARNING");
     expect(atLimit).toContain("WARNING");
+  });
+});
+
+// ─── firstAttemptDelta / continuation priority-bucket rendering ───────────────
+
+const makeReviewCheck = (
+  check: ReviewCheckResult["check"],
+  overrides: Partial<ReviewCheckResult> = {},
+): ReviewCheckResult => {
+  return {
+    check,
+    success: false,
+    command: `${check} command`,
+    exitCode: 1,
+    output: `${check} output`,
+    durationMs: 10,
+    ...overrides,
+  };
+};
+
+describe("RectifierPromptBuilder.firstAttemptDelta", () => {
+  test("single-category: renders only the matching priority bucket", () => {
+    const result = RectifierPromptBuilder.firstAttemptDelta([makeReviewCheck("lint")], 3);
+
+    expect(result).toContain("Order matters: fix Priority 1 first");
+    expect(result).toContain("## Priority 2 — Lint/style");
+    expect(result).not.toContain("## Priority 1 — Compile/build");
+    expect(result).not.toContain("## Priority 3 — Behavior");
+    expect(result).not.toContain("## Priority 4 — Semantic");
+    expect(result).not.toContain("## Priority 5 — Architectural");
+    expect(result).toMatchSnapshot();
+  });
+
+  test("two-categories: renders in fixed priority order, not input order", () => {
+    const result = RectifierPromptBuilder.firstAttemptDelta(
+      [makeReviewCheck("semantic"), makeReviewCheck("typecheck")],
+      3,
+    );
+
+    expect(result).toContain("## Priority 1 — Compile/build");
+    expect(result).toContain("## Priority 4 — Semantic");
+    expect(result.indexOf("## Priority 1 — Compile/build")).toBeLessThan(result.indexOf("## Priority 4 — Semantic"));
+    expect(result).toMatchSnapshot();
+  });
+
+  test("all-categories: renders all five buckets with expected grouping", () => {
+    const result = RectifierPromptBuilder.firstAttemptDelta(
+      [
+        makeReviewCheck("adversarial"),
+        makeReviewCheck("build", { exitCode: 2 }),
+        makeReviewCheck("semantic", {
+          findings: [
+            {
+              ruleId: "semantic-ac3",
+              severity: "error",
+              file: "src/foo.ts",
+              line: 42,
+              message: "Implementation does not satisfy AC#3",
+            },
+          ],
+        }),
+        makeReviewCheck("test"),
+        makeReviewCheck("lint"),
+        makeReviewCheck("typecheck"),
+      ],
+      3,
+    );
+
+    expect(result).toContain("## Priority 1 — Compile/build");
+    expect(result).toContain("### typecheck (exit 1)");
+    expect(result).toContain("### build (exit 2)");
+    expect(result).toContain("## Priority 2 — Lint/style");
+    expect(result).toContain("## Priority 3 — Behavior");
+    expect(result).toContain("## Priority 4 — Semantic");
+    expect(result).toContain("## Priority 5 — Architectural");
+    expect(result).toContain("Structured findings:");
+    expect(result).toMatchSnapshot();
+  });
+});
+
+describe("RectifierPromptBuilder.continuation", () => {
+  test("single-category: renders only the matching priority bucket", () => {
+    const result = RectifierPromptBuilder.continuation([makeReviewCheck("lint")], 1, 2, 3);
+
+    expect(result).toContain("Order matters: fix Priority 1 first");
+    expect(result).toContain("## Priority 2 — Lint/style");
+    expect(result).not.toContain("## Priority 1 — Compile/build");
+    expect(result).not.toContain("## Priority 3 — Behavior");
+    expect(result).not.toContain("## Priority 4 — Semantic");
+    expect(result).not.toContain("## Priority 5 — Architectural");
+    expect(result).toMatchSnapshot();
+  });
+
+  test("two-categories: renders in fixed priority order, not input order", () => {
+    const result = RectifierPromptBuilder.continuation(
+      [makeReviewCheck("semantic"), makeReviewCheck("typecheck")],
+      1,
+      2,
+      3,
+    );
+
+    expect(result).toContain("## Priority 1 — Compile/build");
+    expect(result).toContain("## Priority 4 — Semantic");
+    expect(result.indexOf("## Priority 1 — Compile/build")).toBeLessThan(result.indexOf("## Priority 4 — Semantic"));
+    expect(result).toMatchSnapshot();
+  });
+
+  test("all-categories: renders all five buckets with expected grouping", () => {
+    const result = RectifierPromptBuilder.continuation(
+      [
+        makeReviewCheck("adversarial"),
+        makeReviewCheck("build", { exitCode: 2 }),
+        makeReviewCheck("semantic", {
+          findings: [
+            {
+              ruleId: "semantic-ac3",
+              severity: "error",
+              file: "src/foo.ts",
+              line: 42,
+              message: "Implementation does not satisfy AC#3",
+            },
+          ],
+        }),
+        makeReviewCheck("test"),
+        makeReviewCheck("lint"),
+        makeReviewCheck("typecheck"),
+      ],
+      3,
+      2,
+      3,
+    );
+
+    expect(result).toContain("## Priority 1 — Compile/build");
+    expect(result).toContain("### typecheck (exit 1)");
+    expect(result).toContain("### build (exit 2)");
+    expect(result).toContain("## Priority 2 — Lint/style");
+    expect(result).toContain("## Priority 3 — Behavior");
+    expect(result).toContain("## Priority 4 — Semantic");
+    expect(result).toContain("## Priority 5 — Architectural");
+    expect(result).toContain("Structured findings:");
+    expect(result).toContain("Rethink your approach");
+    expect(result).toContain("URGENT: This is your final attempt");
+    expect(result).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary
- implement prioritized rectification rendering in RectifierPromptBuilder for both firstAttemptDelta() and continuation()
- group failed checks into five ordered buckets: compile/build, lint, behavior, semantic, architectural
- render only non-empty buckets with per-bucket guidance and top-level priority preamble
- keep per-check output formatting (exit code, truncation, structured findings) and continuation escalation messaging
- add prompt tests/snapshots for single-category, two-category, and all-category scenarios
- update one legacy first-attempt expectation in builder tests to match new priority-order wording

## Validation
- bun run lint
- bun run typecheck
- bun run test

## Scope
- src/prompts/builders/rectifier-builder.ts
- test/unit/prompts/rectifier-builder.test.ts
- test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
- test/unit/prompts/builders/rectifier-builder.test.ts

Closes #816
