### PR TITLE
feat: gate llm review checks behind mechanical pass

### DIFF
--- a/src/config/schemas-review.ts
+++ b/src/config/schemas-review.ts
@@ -71,6 +71,7 @@ export const AdversarialReviewConfigSchema = z.object({
 
 export const ReviewConfigSchema = z.object({
   enabled: z.boolean(),
+  gateLLMChecksOnMechanicalPass: z.boolean().default(true),
   checks: z.array(z.enum(["typecheck", "lint", "test", "build", "semantic", "adversarial"])),
   commands: z.object({
     typecheck: z.string().optional(),

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -183,6 +183,7 @@ export const NaxConfigSchema = z
     }),
     review: ReviewConfigSchema.default({
       enabled: true,
+      gateLLMChecksOnMechanicalPass: true,
       checks: ["typecheck", "lint"],
       commands: {},
       pluginMode: "per-story",

--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -9,6 +9,7 @@ import type { SessionHandle } from "../../agents/types";
 import { resolveModelForAgent } from "../../config";
 import { getLogger } from "../../logger";
 import { RectifierPromptBuilder } from "../../prompts";
+import { LLM_REVIEW_CHECKS } from "../../review";
 import type { ReviewCheckResult } from "../../review/types";
 import { formatSessionName } from "../../session/naming";
 import { buildProgressivePromptPreamble, runRetryLoop } from "../../verification/shared-rectification-loop";
@@ -44,19 +45,6 @@ const UNRESOLVED_REGEX = /^UNRESOLVED:\s*(.+)$/ms;
  * changes after the stronger directive, the second no-op counts as a real attempt.
  */
 const MAX_CONSECUTIVE_NOOP_REPROMPTS = 1;
-
-/**
- * Review checks whose verdict depends on LLM judgment of the diff.
- *
- * On a no-op turn (HEAD did not advance) the diff is unchanged, so re-running
- * these checks against the same input would yield the same result — and incur
- * fresh LLM cost (~$0.01–0.10 + ~10–30s per call). The autofix verify path uses
- * this to skip recheck when ALL failing checks are LLM-driven. Mechanical
- * checks (typecheck/lint/test/build) are NOT in this set because their verdicts
- * CAN flip without a new commit (cache invalidation, transient diagnostics,
- * post-stage state propagation).
- */
-const LLM_REVIEW_CHECKS = new Set<ReviewCheckResult["check"]>(["semantic", "adversarial"]);
 
 function collectFailedChecks(ctx: PipelineContext): ReviewCheckResult[] {
   return (ctx.reviewResult?.checks ?? []).filter((c) => !c.success);
@@ -518,7 +506,9 @@ export async function runAgentRectification(
           attemptsRemaining: maxAttempts - currentAttempt,
         });
         // Skip LLM checks that already passed — they'll return the same result on the unchanged diff.
-        const passedChecks = (ctx.reviewResult?.checks ?? []).filter((c) => c.success).map((c) => c.check);
+        const passedChecks = (ctx.reviewResult?.checks ?? [])
+          .filter((c) => c.success && !c.skipped)
+          .map((c) => c.check);
         if (passedChecks.length > 0) {
           ctx.retrySkipChecks = new Set(passedChecks);
           logger.debug("autofix", "No source changes — skipping already-passed checks on recheck", {

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -113,7 +113,9 @@ export const autofixStage: PipelineStage = {
       if (recheckPassed) {
         // #136: Skip checks that already passed — mechanical fix only touched lint/format.
         // Semantic/debate review doesn't need to re-run after a lint-only fix.
-        const passedChecks = (ctx.reviewResult?.checks ?? []).filter((c) => c.success).map((c) => c.check);
+        const passedChecks = (ctx.reviewResult?.checks ?? [])
+          .filter((c) => c.success && !c.skipped)
+          .map((c) => c.check);
         if (passedChecks.length > 0) {
           ctx.retrySkipChecks = new Set(passedChecks);
           logger.debug("autofix", "Skipping already-passed checks on retry", {
@@ -189,7 +191,7 @@ export const autofixStage: PipelineStage = {
       // #136: Skip checks that already passed — only re-run checks that originally failed.
       // Agent rectification fixes mechanical issues (lint/typecheck); passing checks like
       // semantic (~45s) don't need to re-run unless they were the failing check.
-      const passedChecks = (ctx.reviewResult?.checks ?? []).filter((c) => c.success).map((c) => c.check);
+      const passedChecks = (ctx.reviewResult?.checks ?? []).filter((c) => c.success && !c.skipped).map((c) => c.check);
       if (passedChecks.length > 0) {
         ctx.retrySkipChecks = new Set(passedChecks);
         logger.debug("autofix", "Skipping already-passed checks on retry", {

--- a/src/review/categorization.ts
+++ b/src/review/categorization.ts
@@ -1,0 +1,16 @@
+import type { ReviewCheckName } from "./types";
+
+export const ORDERED_MECHANICAL_REVIEW_CHECKS: ReadonlyArray<ReviewCheckName> = ["typecheck", "build", "lint", "test"];
+
+export const ORDERED_LLM_REVIEW_CHECKS: ReadonlyArray<ReviewCheckName> = ["semantic", "adversarial"];
+
+export const MECHANICAL_REVIEW_CHECKS = new Set<ReviewCheckName>(ORDERED_MECHANICAL_REVIEW_CHECKS);
+export const LLM_REVIEW_CHECKS = new Set<ReviewCheckName>(ORDERED_LLM_REVIEW_CHECKS);
+
+export function isLlmReviewCheck(check: ReviewCheckName): boolean {
+  return LLM_REVIEW_CHECKS.has(check);
+}
+
+export function isMechanicalReviewCheck(check: ReviewCheckName): boolean {
+  return MECHANICAL_REVIEW_CHECKS.has(check);
+}

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from "./adversarial";
+export * from "./categorization";
 export * from "./diff-utils";
 export * from "./types";
 export * from "./runner";

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -20,6 +20,7 @@ import type { PluginRegistry } from "../plugins";
 import { errorMessage } from "../utils/errors";
 import { type NaxIgnoreIndex, filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
 import { runAdversarialReview } from "./adversarial";
+import { ORDERED_LLM_REVIEW_CHECKS, ORDERED_MECHANICAL_REVIEW_CHECKS } from "./categorization";
 import { runReview } from "./runner";
 import type { SemanticStory } from "./semantic";
 import { runSemanticReview } from "./semantic";
@@ -217,14 +218,12 @@ export class ReviewOrchestrator {
         runtime,
       );
     } else {
-      // Always split: mechanical checks first, then LLM checks independently.
-      // This prevents mechanical failures (e.g. lint in a test file the agent cannot touch)
-      // from blocking semantic/adversarial review — and signals to autofix that the code
-      // is functionally correct when LLM checks pass despite mechanical failures.
-      const mechanicalCheckNames = reviewConfig.checks.filter((c) => c !== "semantic" && c !== "adversarial");
-      const llmCheckNames = reviewConfig.checks.filter(
-        (c): c is "semantic" | "adversarial" => c === "semantic" || c === "adversarial",
+      // Split checks into ordered mechanical + LLM groups.
+      const mechanicalCheckNames = ORDERED_MECHANICAL_REVIEW_CHECKS.filter((check) =>
+        reviewConfig.checks.includes(check),
       );
+      const llmCheckNames = ORDERED_LLM_REVIEW_CHECKS.filter((check) => reviewConfig.checks.includes(check));
+      const gateLLMChecksOnMechanicalPass = reviewConfig.gateLLMChecksOnMechanicalPass ?? true;
 
       // Step 1: Run mechanical checks (fail-fast preserved within mechanical)
       const mechanicalConfig = { ...reviewConfig, checks: mechanicalCheckNames };
@@ -258,7 +257,21 @@ export class ReviewOrchestrator {
       const llmStart = Date.now();
       let llmCheckResults: ReviewCheckResult[];
 
-      if (activeLlmCheckNames.length === 0) {
+      if (gateLLMChecksOnMechanicalPass && !mechanicalResult.success && llmCheckNames.length > 0) {
+        logger?.debug("review", "Gating LLM checks due to mechanical failure", {
+          storyId,
+          gatedChecks: llmCheckNames,
+        });
+        llmCheckResults = llmCheckNames.map((check) => ({
+          check,
+          success: true,
+          skipped: true,
+          command: "gated",
+          exitCode: 0,
+          output: "Skipped: gated until all mechanical checks pass",
+          durationMs: 0,
+        }));
+      } else if (activeLlmCheckNames.length === 0) {
         // All LLM checks already passed — skip Step 2 entirely.
         logger?.debug("review", "Skipping LLM checks (all already passed in previous review pass)", { storyId });
         llmCheckResults = [];
@@ -354,11 +367,12 @@ export class ReviewOrchestrator {
 
       const allChecks = [...mechanicalResult.checks, ...llmCheckResults];
       const mechanicalPassed = mechanicalResult.success;
-      const llmPassed = llmCheckResults.every((c) => c.success);
+      const ranLlmChecks = llmCheckResults.filter((c) => !c.skipped);
+      const llmPassed = ranLlmChecks.every((c) => c.success);
       const failureReason = buildFailureReason(allChecks);
 
       // Build per-reviewer finding summary from LLM check results
-      const reviewSummary = buildReviewSummary(llmCheckResults);
+      const reviewSummary = buildReviewSummary(ranLlmChecks);
 
       builtIn = {
         success: mechanicalPassed && llmPassed,
@@ -369,10 +383,10 @@ export class ReviewOrchestrator {
       };
 
       // Write unified verdict file (fire-and-forget) when LLM checks ran
-      if (llmCheckResults.length > 0 && storyId) {
+      if (ranLlmChecks.length > 0 && storyId) {
         const threshold = reviewConfig.blockingThreshold ?? "error";
         const verdictReviewers: Record<string, { blocking: number; advisory: number; passed: boolean }> = {};
-        const semCheck = llmCheckResults.find((c) => c.check === "semantic");
+        const semCheck = ranLlmChecks.find((c) => c.check === "semantic");
         if (semCheck) {
           verdictReviewers.semantic = {
             blocking: semCheck.findings?.length ?? 0,
@@ -380,7 +394,7 @@ export class ReviewOrchestrator {
             passed: semCheck.success,
           };
         }
-        const advCheck = llmCheckResults.find((c) => c.check === "adversarial");
+        const advCheck = ranLlmChecks.find((c) => c.check === "adversarial");
         if (advCheck) {
           verdictReviewers.adversarial = {
             blocking: advCheck.findings?.length ?? 0,
@@ -398,7 +412,7 @@ export class ReviewOrchestrator {
       }
 
       // Signal to autofix that code is functionally correct (LLM passed) despite mechanical failure
-      mechanicalFailedOnly = !mechanicalPassed && llmPassed;
+      mechanicalFailedOnly = ranLlmChecks.length > 0 ? !mechanicalPassed && llmPassed : undefined;
     }
 
     if (!builtIn.success) {
@@ -558,7 +572,7 @@ export class ReviewOrchestrator {
             issue: f.message,
           })),
         };
-      } else if (advCheck.success) {
+      } else if (advCheck.success && !advCheck.skipped) {
         ctx.priorAdversarialFindings = undefined;
       }
     } else if (retrySkipChecks?.has("adversarial")) {

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -57,6 +57,8 @@ export interface ReviewCheckResult {
   check: ReviewCheckName;
   /** Pass or fail */
   success: boolean;
+  /** True when this check was intentionally not run (for example, gated by mechanical failures). */
+  skipped?: boolean;
   /** Command that was run */
   command: string;
   /** Exit code */
@@ -176,6 +178,11 @@ export interface AdversarialFindingsCache {
 export interface ReviewConfig {
   /** Enable review phase */
   enabled: boolean;
+  /**
+   * When true (default), semantic/adversarial checks run only after all enabled
+   * mechanical checks pass.
+   */
+  gateLLMChecksOnMechanicalPass?: boolean;
   /** List of checks to run */
   checks: ReviewCheckName[];
   /** Custom commands per check */

--- a/test/unit/config/semantic-review.test.ts
+++ b/test/unit/config/semantic-review.test.ts
@@ -131,6 +131,35 @@ describe("ReviewConfig semantic field", () => {
     const result = NaxConfigSchema.safeParse(config);
     expect(result.success).toBe(true);
   });
+
+  test("gateLLMChecksOnMechanicalPass defaults to true", () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      review: {
+        ...DEFAULT_CONFIG.review,
+      },
+    };
+    const result = NaxConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.review.gateLLMChecksOnMechanicalPass).toBe(true);
+    }
+  });
+
+  test("gateLLMChecksOnMechanicalPass accepts false override", () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      review: {
+        ...DEFAULT_CONFIG.review,
+        gateLLMChecksOnMechanicalPass: false,
+      },
+    };
+    const result = NaxConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.review.gateLLMChecksOnMechanicalPass).toBe(false);
+    }
+  });
 });
 
 describe("ReviewConfigSchema semantic validation", () => {

--- a/test/unit/pipeline/stages/autofix-core.test.ts
+++ b/test/unit/pipeline/stages/autofix-core.test.ts
@@ -104,6 +104,53 @@ describe("autofixStage", () => {
     if (result.action === "retry") expect(result.fromStage).toBe("review");
   });
 
+  test("recheck pass: skipped checks are not added to retrySkipChecks", async () => {
+    const saved = { ..._autofixDeps };
+    _autofixDeps.runQualityCommand = async () => ({
+      commandName: "lintFix",
+      command: "",
+      success: true,
+      exitCode: 0,
+      output: "",
+      durationMs: 0,
+      timedOut: false,
+    });
+    _autofixDeps.recheckReview = async (mockCtx: PipelineContext) => {
+      mockCtx.reviewResult = {
+        success: true,
+        checks: [
+          {
+            check: "typecheck",
+            success: true,
+            command: "tsc --noEmit",
+            exitCode: 0,
+            output: "",
+            durationMs: 10,
+          },
+          {
+            check: "semantic",
+            success: true,
+            skipped: true,
+            command: "gated",
+            exitCode: 0,
+            output: "skipped",
+            durationMs: 0,
+          },
+        ],
+      } as any;
+      return true;
+    };
+
+    const ctx = makeCtx({ reviewResult: makeFailedReviewResult([{ check: "lint" }]) });
+    const result = await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(result.action).toBe("retry");
+    expect(ctx.retrySkipChecks?.has("typecheck")).toBe(true);
+    expect(ctx.retrySkipChecks?.has("semantic")).toBe(false);
+  });
+
   test("escalates when recheck still fails and agent rectification also fails", async () => {
     const saved = { ..._autofixDeps };
     _autofixDeps.runQualityCommand = async () => ({ commandName: "lintFix", command: "", success: false, exitCode: 1, output: "lint error", durationMs: 0, timedOut: false });

--- a/test/unit/review/orchestrator.test.ts
+++ b/test/unit/review/orchestrator.test.ts
@@ -29,13 +29,17 @@ withDepsRestore(_orchestratorDeps, ["spawn", "runSemanticReview", "runAdversaria
 withDepsRestore(_reviewSemanticDeps, ["runSemanticReview"]);
 withDepsRestore(_reviewAdversarialDeps, ["runAdversarialReview"]);
 
-function makeReviewConfig(pluginMode?: "per-story" | "deferred"): ReviewConfig {
+function makeReviewConfig(
+  pluginMode?: "per-story" | "deferred",
+  gateLLMChecksOnMechanicalPass = true,
+): ReviewConfig {
   // pluginMode is added by DR-001 — cast until the type is updated
   return {
     enabled: true,
     checks: [],
     commands: {},
     pluginMode,
+    gateLLMChecksOnMechanicalPass,
   } as unknown as ReviewConfig;
 }
 
@@ -203,12 +207,16 @@ function makeSemanticCheckResult(passed: boolean): ReviewCheckResult {
   };
 }
 
-function makeConfigWithSemantic(mechanicalChecks: string[] = ["lint"]): ReviewConfig {
+function makeConfigWithSemantic(
+  mechanicalChecks: string[] = ["lint"],
+  gateLLMChecksOnMechanicalPass = true,
+): ReviewConfig {
   return {
     enabled: true,
     checks: [...mechanicalChecks, "semantic"],
     commands: { lint: "biome check" },
     pluginMode: "deferred",
+    gateLLMChecksOnMechanicalPass,
   } as unknown as ReviewConfig;
 }
 
@@ -219,50 +227,59 @@ describe("ReviewOrchestrator — mechanical / LLM isolation (#405)", () => {
     _reviewAdversarialDeps.runAdversarialReview = mock(async () => makeSemanticCheckResult(true));
   });
 
-  test("semantic review runs even when mechanical check fails", async () => {
-    // Simulate lint failure via dirty tree (forces runner to fail before running checks)
-    // Then override runner so lint actually fails
-    _runnerDeps.getUncommittedFiles = mock(async () => []);
-    // No lint command configured so it will be skipped — use a failing typecheck instead
-    const config: ReviewConfig = {
-      enabled: true,
-      checks: ["semantic"],
-      commands: {},
-      pluginMode: "deferred",
-    } as unknown as ReviewConfig;
-
-    // With no mechanical checks, semantic should still run
+  test("mechanical failure gates semantic check by default and marks it skipped", async () => {
+    _runnerDeps.getUncommittedFiles = mock(async () => ["src/changed.ts"]);
     const orchestrator = new ReviewOrchestrator();
-    const result = await orchestrator.review(config, "/tmp/workdir", minimalExecConfig);
 
-    expect(_reviewSemanticDeps.runSemanticReview).toHaveBeenCalledTimes(1);
-    expect(result.success).toBe(true);
+    const result = await orchestrator.review(
+      makeConfigWithSemantic(["lint"], true),
+      "/tmp/workdir",
+      minimalExecConfig,
+    );
+
+    expect(_reviewSemanticDeps.runSemanticReview).not.toHaveBeenCalled();
+    const semanticCheck = result.builtIn.checks.find((c) => c.check === "semantic");
+    expect(semanticCheck).toBeDefined();
+    expect(semanticCheck?.skipped).toBe(true);
+    expect(semanticCheck?.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 
-  test("mechanicalFailedOnly is true when mechanical fails but semantic passes", async () => {
-    // Dirty tree on the first call (mechanical run) → mechanical fails.
-    // Clean on the second call (LLM run) → LLM proceeds and runs semantic.
+  test("gate disabled runs semantic check even when mechanical fails", async () => {
     let callCount = 0;
     _runnerDeps.getUncommittedFiles = mock(async () => {
-      callCount++;
+      callCount += 1;
       return callCount === 1 ? ["src/changed.ts"] : [];
     });
     const orchestrator = new ReviewOrchestrator();
 
     const result = await orchestrator.review(
-      makeConfigWithSemantic(["lint"]),
+      makeConfigWithSemantic(["lint"], false),
       "/tmp/workdir",
       minimalExecConfig,
     );
 
-    // Mechanical failed (dirty tree), semantic mocked to pass
-    expect(result.success).toBe(false);
-    expect(result.mechanicalFailedOnly).toBe(true);
-    // Semantic should have been attempted despite mechanical failure
     expect(_reviewSemanticDeps.runSemanticReview).toHaveBeenCalledTimes(1);
+    const semanticCheck = result.builtIn.checks.find((c) => c.check === "semantic");
+    expect(semanticCheck?.skipped).toBeUndefined();
+    expect(result.mechanicalFailedOnly).toBe(true);
+    expect(result.success).toBe(false);
   });
 
-  test("mechanicalFailedOnly is false when semantic also fails", async () => {
+  test("mechanicalFailedOnly is undefined when semantic is gated", async () => {
+    _runnerDeps.getUncommittedFiles = mock(async () => ["src/changed.ts"]);
+    const orchestrator = new ReviewOrchestrator();
+
+    const result = await orchestrator.review(
+      makeConfigWithSemantic(["lint"], true),
+      "/tmp/workdir",
+      minimalExecConfig,
+    );
+
+    expect(result.mechanicalFailedOnly).toBeUndefined();
+  });
+
+  test("mechanicalFailedOnly is false when gate disabled and semantic fails", async () => {
     // Same call-counter trick: dirty for mechanical, clean for LLM so semantic actually runs.
     let callCount = 0;
     _runnerDeps.getUncommittedFiles = mock(async () => {
@@ -273,7 +290,7 @@ describe("ReviewOrchestrator — mechanical / LLM isolation (#405)", () => {
     const orchestrator = new ReviewOrchestrator();
 
     const result = await orchestrator.review(
-      makeConfigWithSemantic(["lint"]),
+      makeConfigWithSemantic(["lint"], false),
       "/tmp/workdir",
       minimalExecConfig,
     );
@@ -313,6 +330,21 @@ describe("ReviewOrchestrator — mechanical / LLM isolation (#405)", () => {
     const checkNames = result.builtIn.checks.map((c) => c.check);
     expect(checkNames).toContain("semantic");
     expect(result.success).toBe(true);
+  });
+
+  test("mechanical pass runs semantic check normally when gate enabled", async () => {
+    _runnerDeps.getUncommittedFiles = mock(async () => []);
+    const orchestrator = new ReviewOrchestrator();
+
+    const result = await orchestrator.review(
+      makeConfigWithSemantic([], true),
+      "/tmp/workdir",
+      minimalExecConfig,
+    );
+
+    expect(_reviewSemanticDeps.runSemanticReview).toHaveBeenCalledTimes(1);
+    const semanticCheck = result.builtIn.checks.find((c) => c.check === "semantic");
+    expect(semanticCheck?.skipped).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- add shared review check categorization for mechanical and LLM checks
- gate LLM review checks when mechanical checks fail (default enabled)
- mark gated LLM checks as skipped and exclude skipped checks from retry skip propagation
- add config support for `review.gateLLMChecksOnMechanicalPass` with default `true`
- update orchestrator/autofix behavior and unit tests for gating and skip semantics

## Verification
- bun run lint
- bun run typecheck
- bun run test
