### PR TITLE
refactor(runtime): NaxRuntime owns PidRegistry; managers auto-attach lifecycle callbacks

### DIFF
--- a/docs/findings/2026-04-30-pid-lifecycle-runtime-ownership-plan.md
+++ b/docs/findings/2026-04-30-pid-lifecycle-runtime-ownership-plan.md
@@ -1,0 +1,297 @@
+# Plan — Move PID lifecycle into the runtime/managers, eliminate caller threading
+
+**Branch:** `fix/pid-registry-unregister-and-safer-kill` (already has commit `7e246103` — see "Prerequisite" below)
+**Hand-off:** intended for Sonnet to execute end-to-end
+**Estimated scope:** ~12 files modified, net diff likely smaller than the prerequisite commit (we delete more than we add)
+
+---
+
+## 1. Context (read this first — no prior conversation needed)
+
+### What just shipped (commit `7e246103`)
+
+The prerequisite commit reintroduces symmetric register/unregister to `PidRegistry` and hardens the kill path. It does so by adding an `onPidExited?: (pid: number) => void` callback alongside `onPidSpawned` and threading both through ~12 call sites. That commit is correct and stays — but the *shape* it preserves is fragile: every future caller must remember to pass both halves, or the registry leaks dead PIDs again.
+
+Read the commit message of `7e246103` for the failure history (ADR-013 Phase 3 introduced the imbalance; PR #793 amplified it; the worst-case symptom was Ctrl+C signaling unrelated process groups, which from the user's perspective looked like the Linux desktop session crashing). That context informs why we want a stronger guarantee here.
+
+### What this plan changes
+
+PID lifecycle is a **runtime-shared resource concern**, not a caller concern. The runtime already owns `agentManager` + `sessionManager` (per ADR-018). It should also own `PidRegistry`, and the two managers should attach lifecycle callbacks to adapter calls **transparently**. Callers stop threading the callbacks at all — the public-facing options types lose `onPidSpawned` and `onPidExited` entirely. The fields survive only at the adapter primitive boundary, where the wiring layer attaches them.
+
+This aligns with two existing rules the codebase already enforces:
+
+- **ADR-018 §2** — one runtime per run, single owner of shared run state.
+- **ADR-019 Rule 3 / `.claude/rules/adapter-wiring.md`** — adapter primitives (`openSession` / `sendTurn` / `closeSession` / `complete`) are wiring-layer-only. The wiring layer is the right place to attach lifecycle hooks.
+
+### Architecture target
+
+```
+                 NaxRuntime                                     ← owns pidRegistry
+                  │
+        ┌─────────┴─────────┐
+        ▼                   ▼
+  SessionManager       AgentManager                             ← receive pidRegistry at configureRuntime()
+   .openSession()        .completeAs()
+        │                   │
+        ▼                   ▼
+  adapter.openSession  adapter.complete                         ← managers attach onPidSpawned/onPidExited here
+  (with lifecycle      (with lifecycle
+   attached)            attached)
+
+  Callers (op, pipeline stage, cli/plan, rectification, autofix, ...)
+                                                                ← pass NOTHING. Lifecycle is invisible.
+```
+
+---
+
+## 2. Acceptance criteria
+
+The refactor is done when **all** of these hold:
+
+1. `runtime.pidRegistry` is the single instance per run, set up by `createRuntime()`. `runtime.onPidSpawned` and `runtime.onPidExited` are removed from the `NaxRuntime` interface.
+2. `SessionManager.openSession()` automatically passes `onPidSpawned` and `onPidExited` to `adapter.openSession()` when its configured `pidRegistry` is present. Callers do not pass them.
+3. `AgentManager.completeAs()` automatically passes `onPidSpawned` and `onPidExited` to `adapter.complete()` when its configured `pidRegistry` is present. Callers do not pass them.
+4. `AgentRunOptions`, `PlanOptions`, and `OpenSessionInternalOpts` no longer expose `onPidSpawned` / `onPidExited` fields. The fields remain on `OpenSessionOpts` and `CompleteOptions` (the two adapter primitive surfaces) where the wiring layer attaches them. See §3 Step 4 for the precise boundary.
+5. Every `onPidSpawned` / `onPidExited` reference outside the four allowed locations is deleted. Allowed locations after the refactor:
+   - `src/agents/types.ts` — interface declarations on `OpenSessionOpts` and `CompleteOptions` only
+   - `src/agents/manager.ts` — the attach inside `completeWithFallback`
+   - `src/agents/acp/**` — adapter primitives + spawn-client (where the adapter actually fires the callbacks)
+   - `src/session/manager.ts` — the attach inside `openSession`
+
+   Specifically, `src/runtime/` should have **zero** matches after the refactor — including `session-run-hop.ts` and `index.ts`.
+6. `cli/plan.ts` no longer constructs its own `PidRegistry` — it uses the runtime's. (Closes a related crash-handler-visibility gap: the cli/plan-owned registry was previously invisible to the run-level signal handlers.)
+7. `bun run typecheck` clean.
+8. `bun run lint` clean.
+9. Targeted unit suites pass: `bun test test/unit/runtime/ test/unit/agents/ test/unit/session/ test/unit/execution/ test/unit/operations/ test/unit/pipeline/ test/unit/cli/ test/unit/verification/ test/unit/tdd/ --timeout=10000`.
+10. Adapter-boundary integration test still passes: `bun test test/integration/cli/adapter-boundary.test.ts --timeout=10000`.
+11. The "I forgot to add `onPidExited:`" failure mode is **not reachable** from a caller — that is, there should be no callable API surface where a caller can pass `onPidSpawned` without `onPidExited` (other than directly constructing an adapter, which is already forbidden by the wiring-layer rule and enforced by `scripts/check-no-adapter-wrap.sh` + the adapter-boundary integration test).
+12. The kill-path safety hardening from `7e246103` (`pid <= 1` rejection, single-PID kill, `cleanupStale()` no-signal) is **untouched** — that's defense-in-depth in case anyone ever does construct an adapter directly.
+
+---
+
+## 3. Step-by-step
+
+### Step 0 — sanity check the starting state
+
+```bash
+git log --oneline -3
+# Expect: 7e246103 fix(pid-registry): restore unregister symmetry...
+
+bun run typecheck
+bun run lint
+# Both must be clean before you start. If they are not, stop and reconcile first.
+```
+
+### Step 1 — `NaxRuntime` owns `PidRegistry`
+
+**File:** `src/runtime/index.ts`
+
+- Add `import { PidRegistry } from "../execution/pid-registry";` (value import, not type-only — `createRuntime` may construct a default). Confirm no import cycle: `src/execution/pid-registry.ts` currently imports only from `node:fs`, `node:fs/promises`, and `../logger` — safe.
+- Add to the `NaxRuntime` interface (in this same file):
+  ```ts
+  readonly pidRegistry: PidRegistry;
+  ```
+  Make it required, not optional, so callers can rely on `runtime.pidRegistry` without nullable checks downstream.
+- **Remove** these fields from `NaxRuntime` (added by `7e246103`):
+  ```ts
+  readonly onPidSpawned?: (pid: number) => void;
+  readonly onPidExited?: (pid: number) => void;
+  ```
+- Add `pidRegistry?: PidRegistry` to `CreateRuntimeOptions` (still optional here — caller can supply a pre-built one for tests, but if absent `createRuntime` constructs one). **Remove** `onPidSpawned` and `onPidExited` from `CreateRuntimeOptions`.
+- Inside `createRuntime()`:
+  - `const pidRegistry = opts?.pidRegistry ?? new PidRegistry(workdir);`
+  - Store on the returned object: `pidRegistry,`
+  - Pass `pidRegistry` into the SessionManager and AgentManager `configureRuntime` opts at lines 154 and 169 (see Step 2 and Step 3).
+  - In the `createAgentManager(...)` else-branch at line 172, the registry needs to flow through too. `createAgentManager` is defined in `src/agents/factory.ts:25` (re-exported from `src/runtime/internal/agent-manager-factory.ts`). Either extend `CreateAgentManagerOpts` (in `src/agents/factory.ts`) to carry `pidRegistry?: PidRegistry`, or — simpler — call `agentManager.configureRuntime({ pidRegistry })` from `runtime/index.ts` immediately after the factory returns. Prefer the second: keeps the factory signature unchanged and matches the if-branch behavior.
+
+### Step 2 — `SessionManager` attaches the lifecycle
+
+**File:** `src/session/manager.ts`
+
+- `SessionManager` is declared at line 63. Add a private `_pidRegistry?: PidRegistry` field.
+- Extend `configureRuntime()` (line 85) opts to accept `pidRegistry?: PidRegistry`. The current opts shape is `{ getAdapter?, config?, dispatchEvents?, defaultAgent? }` — add `pidRegistry?` and store via `if (opts.pidRegistry) this._pidRegistry = opts.pidRegistry`.
+- The single `adapter.openSession` call is at line 379 (the only one in this file — line 563 is `this.openSession(...)` recursing into the public method). At line 379, **always** include both callbacks in the adapter call:
+  ```ts
+  onPidSpawned: this._pidRegistry ? (pid) => this._pidRegistry!.register(pid) : undefined,
+  onPidExited: this._pidRegistry ? (pid) => this._pidRegistry!.unregister(pid) : undefined,
+  ```
+  These overrides are unconditional — do not honor any caller-supplied values, because callers will no longer be able to supply them once the type changes (Step 5).
+- **Remove** `onPidSpawned` and `onPidExited` from `OpenSessionInternalOpts` in `src/session/types.ts` (added by `7e246103`).
+
+### Step 3 — `AgentManager` attaches the lifecycle for `complete()`
+
+**File:** `src/agents/manager.ts`
+
+- Add a private `_pidRegistry?: PidRegistry` field on `AgentManager` (class declared at line 64).
+- Extend `configureRuntime()` (line 105) opts to accept `pidRegistry?: PidRegistry`. The current opts shape is `{ middleware?, runId?, sendPrompt?, runHop?, dispatchEvents? }` — add `pidRegistry?` and store via `if (opts.pidRegistry) this._pidRegistry = opts.pidRegistry`.
+- The `complete()` call chain is:
+  ```
+  complete(prompt, options)         → completeAs(default, prompt, options)         (line 467)
+  completeAs(agentName, prompt, options) → completeWithFallback(prompt, augmented)  (line 571 → line 585)
+  completeWithFallback(prompt, options) → adapter.complete(prompt, options)         (line 356 → line 385)
+  ```
+  There is **exactly one** `adapter.complete` call site in this file: line 385, inside the `completeWithFallback` while-loop. **Attach the lifecycle there**, not in `completeAs`.
+- Replace the bare `result = await adapter.complete(prompt, options)` (line 385) with:
+  ```ts
+  const optionsWithLifecycle: CompleteOptions = this._pidRegistry
+    ? {
+        ...options,
+        onPidSpawned: (pid: number) => this._pidRegistry!.register(pid),
+        onPidExited: (pid: number) => this._pidRegistry!.unregister(pid),
+      }
+    : options;
+  result = await adapter.complete(prompt, optionsWithLifecycle);
+  ```
+- This is the *one* place in the codebase that should construct these callbacks for `complete()`. The same applies to `openSession()` in `SessionManager` (Step 2) for the run path. No other production code should reference `pidRegistry.register` / `.unregister` directly after this refactor.
+
+### Step 4 — Trim the public-facing options types
+
+The two callbacks should live **only** on the adapter primitive surfaces:
+- `OpenSessionOpts` (in `src/agents/types.ts`) — kept, because the adapter primitive consumes them.
+- `CompleteOptions` (in `src/agents/types.ts`) — **kept**, because `adapter.complete()` consumes them. But the `completeAs` flow attaches them inside the manager, so callers don't need to provide them. Mark them `@internal` in JSDoc and document that callers should not pass them — `AgentManager` overrides any caller-supplied values.
+
+**Remove** the fields from these higher-level shapes:
+
+| File | Type | Action |
+|:---|:---|:---|
+| `src/agents/types.ts` | `AgentRunOptions` | Remove `onPidSpawned` and `onPidExited`. |
+| `src/agents/shared/types-extended.ts` | `PlanOptions` | Remove `onPidSpawned` and `onPidExited`. |
+| `src/session/types.ts` | `OpenSessionInternalOpts` | Remove `onPidSpawned` and `onPidExited`. |
+
+Note `CompleteOptions` is retained because the manager-attach happens *during* the `completeAs` → `adapter.complete` boundary, and the field needs to survive that hand-off. Add a JSDoc note saying "set by `AgentManager.completeAs`; callers must not pass this — it will be overwritten." `OpenSessionOpts` likewise stays.
+
+### Step 5 — Delete the now-dead caller threading
+
+For each of these files, delete the `onPidSpawned: …` and `onPidExited: …` lines that I added in `7e246103`:
+
+| File | Lines to delete |
+|:---|:---|
+| `src/operations/call.ts` | The `onPidSpawned: ctx.runtime.onPidSpawned` and `onPidExited: ctx.runtime.onPidExited` from the `completeAs` call. |
+| `src/runtime/session-run-hop.ts` | `onPidSpawned: options.onPidSpawned` and `onPidExited: options.onPidExited`. |
+| `src/pipeline/stages/execution.ts` | Delete the `const pidRegistry = ctx.pidRegistry;` at line 160 (becomes unused) **and** the `onPidSpawned`/`onPidExited` registry-callback lines in `baseRunOptions`. |
+| `src/pipeline/stages/autofix-agent.ts` | The `onPidSpawned`/`onPidExited` lines in the `runtime.openSession` call. |
+| `src/verification/rectification-loop.ts` | Same. |
+| `src/tdd/rectification-gate.ts` | Same. |
+| `src/cli/plan.ts` | Three touches: **(a)** delete `onPidSpawned`/`onPidExited` lines in the `agentManager.runAs(...)` call (interactive plan path, around line 270 area). **(b)** delete the standalone `const pidRegistry = new PidRegistry(workdir);` at line 245. **(c)** replace `pidRegistry.killAll()` at line 283 with `rt.pidRegistry.killAll()`. The `auto` path (line 188 `callOp(...)`) does not need editing — `callOp` already routes through `agentManager.completeAs`, which will get the lifecycle attached automatically per Step 3. Detail in Step 6. |
+| `src/execution/lifecycle/run-setup.ts` | Multiple touches: **(a)** delete `const pidRegistry = new PidRegistry(workdir);` (line 170 — runtime constructs its own now). **(b)** Delete the `onPidSpawned`/`onPidExited` opts in the `createRuntime({ ... })` call (lines 187–188 — those keys are removed from `CreateRuntimeOptions` in Step 1). **(c)** Replace the `await pidRegistry.cleanupStale();` call (line 191) with `await runtime.pidRegistry.cleanupStale();`. **(d)** Replace the `pidRegistry,` reference inside the `installCrashHandlers({ ... })` call (line 199 area) with `pidRegistry: runtime.pidRegistry`. The construction order is already correct — `createRuntime` at line 182 runs before both `cleanupStale` and `installCrashHandlers`. |
+
+After this step, `grep -rn 'onPidSpawned\|onPidExited' src/` should return matches only in:
+- `src/agents/types.ts` (interface declarations on `OpenSessionOpts` and `CompleteOptions`)
+- `src/agents/manager.ts` (Step 3 attach-site)
+- `src/agents/acp/**` (adapter primitives + spawn-client where the adapter actually fires the callbacks)
+- `src/session/manager.ts` (Step 2 attach-site)
+
+If anything else lights up, you missed a deletion.
+
+### Step 6 — `cli/plan.ts` migration detail
+
+`cli/plan.ts` does NOT call `createRuntime` directly; it uses the helper `createPlanRuntime(config, workdir, options.feature)` from `src/cli/plan-runtime.ts` (called at lines 128, 175, 231 of plan.ts). The bare `pidRegistry` is constructed at line 245, *after* `createPlanRuntime`, and is currently invisible to crash-signal handlers.
+
+After Step 1, `createRuntime` constructs a default `PidRegistry(workdir)` whenever opts don't supply one. `createPlanRuntime` already routes through `createRuntime` (see `src/cli/plan-runtime.ts:34-41`) — its returned runtime will therefore automatically carry a `pidRegistry`. **No signature change to `createPlanRuntime` is required.**
+
+Migration steps:
+
+1. In `cli/plan.ts`, **delete line 245** (`const pidRegistry = new PidRegistry(workdir);`).
+
+2. Replace the cleanup call at line 283 (`await pidRegistry.killAll().catch(() => {})`) with `await rt.pidRegistry.killAll().catch(() => {})`. (Note: required field, no `?.` needed after Step 1.)
+
+3. Verify the unused import: remove `PidRegistry` from the imports at the top of `cli/plan.ts` if no other reference remains.
+
+4. Confirm there are no other `PidRegistry` constructors anywhere outside `src/runtime/` after the refactor: `grep -rn "new PidRegistry" src/` should match only `src/runtime/index.ts` and (untouched) `src/execution/pid-registry.ts` self-references and tests.
+
+5. **Other `createPlanRuntime` callers:** `src/cli/plan-decompose.ts:71` also calls `createPlanRuntime`. It does not currently construct a separate `PidRegistry` — and after Step 1 it will inherit one for free. Verify nothing else there needs changing.
+
+### Step 7 — Tests
+
+- **`test/unit/agents/acp/spawn-client-pid-callback.test.ts`** stays — it tests the adapter primitive, which still exposes the callbacks. No change needed.
+- **`test/unit/execution/pid-registry.test.ts`** stays — tests the registry directly. No change needed.
+- **Add `test/unit/session/manager-pid-lifecycle.test.ts`** with these cases (mirror the existing `test/unit/session/` naming convention; if the directory has a different convention, follow it):
+  - When `SessionManager` is configured with a `pidRegistry`, calling `openSession()` results in `adapter.openSession` receiving an `onPidSpawned` AND `onPidExited` that, when invoked, route to the registry's `register` / `unregister`. Use `makeAgentAdapter` from `test/helpers/`.
+  - When `SessionManager` has no `pidRegistry`, the adapter receives `undefined` for both callbacks (opt-out is allowed).
+  - The type system prevents passing `onPidSpawned` / `onPidExited` through `OpenSessionInternalOpts` (verify with a `// @ts-expect-error` assertion).
+- **Add complete-path lifecycle tests to `test/unit/agents/manager-complete.test.ts`** (existing file — extend it; do not create a separate `manager-pid-lifecycle.test.ts` for AgentManager, the convention is to group by manager method). Same three cases for `AgentManager` against `adapter.complete`.
+- **Update existing call-site tests** that previously asserted the caller passed callbacks. Most were testing object identity (`expect(opts.onPidSpawned).toBe(...)`); rewrite them to assert behavior — that the registry's `register` was called when the adapter fired the callback.
+- Use `test/helpers/` factories per `.claude/rules/test-helpers.md` — do not inline mocks.
+
+### Step 8 — Verify and commit
+
+```bash
+bun run typecheck
+bun run lint
+timeout 120 bun test test/unit/runtime/ test/unit/agents/ test/unit/session/ test/unit/execution/ test/unit/operations/ test/unit/pipeline/ test/unit/cli/ test/unit/verification/ test/unit/tdd/ --timeout=10000
+timeout 60 bun test test/integration/cli/adapter-boundary.test.ts --timeout=15000
+```
+
+All must be green. Then commit on the same branch:
+
+```
+refactor(runtime): runtime owns PidRegistry; managers attach lifecycle automatically
+
+Eliminates the entire class of "caller forgot to pass onPidExited" bugs by
+removing the caller-threading entirely. PidRegistry now lives on NaxRuntime;
+SessionManager.openSession and AgentManager.completeAs attach the
+register/unregister callbacks to adapter primitive calls automatically. The
+public-facing options types (AgentRunOptions, PlanOptions,
+OpenSessionInternalOpts) no longer expose onPidSpawned/onPidExited; the
+fields survive only at the adapter primitive boundary where the wiring
+layer attaches them.
+
+Aligns with ADR-018 (runtime owns shared run state) and ADR-019 (managers
+own dispatch + middleware; adapter primitives are wiring-layer-only).
+
+Side-effect: closes a related gap where cli/plan constructed its own
+PidRegistry that was invisible to crash-signal handlers.
+```
+
+---
+
+## 4. Things that are NOT in scope
+
+- Do not modify `src/execution/pid-registry.ts` — its safety hardening from `7e246103` is independent and final.
+- Do not modify `SpawnAcpSession.prompt()` finally-block — `notifyExit()` stays. The change is *who attaches the callback*, not *whether the adapter fires it*.
+- Do not touch `crash-signals.ts` — it already reads `pidRegistry` from its own `SignalHandlerContext`, which is wired separately in `run-setup.ts`. (Verify this still works after the run-setup migration in Step 6 — but no code change should be needed in `crash-signals.ts`.)
+
+---
+
+## 5. Watchpoints / known traps
+
+1. **Import cycle risk on `src/runtime/index.ts` ↔ `src/execution/pid-registry.ts`.** `runtime/` already imports from `agents/`, `session/`, `config/`. Adding `execution/pid-registry.ts` to the runtime should be safe (one-way), but verify with `bun run typecheck` — if it complains, fall back to a structural `IPidRegistry` interface declared in `src/runtime/pid-registry-types.ts`.
+
+2. **`AgentManager.completeAs` is called from many places, but none of them need to pass lifecycle callbacks.** After Step 5 the field is removed from `AgentRunOptions`/`PlanOptions` consumers; the type-system catches stragglers. `CompleteOptions` keeps the fields (adapter consumes them) but they're marked `@internal`/"set by manager".
+
+3. **There is exactly ONE `adapter.complete` call site in `agents/manager.ts`** — line 385, inside `completeWithFallback`'s while-loop. There is no separate retry-branch site. Verify with `grep -n "adapter\.complete" src/agents/manager.ts` (expect 1 match).
+
+4. **`cli/plan.ts` uses `createPlanRuntime`, not `createRuntime` directly.** See Step 6 — the wrapper helper needs to route the `pidRegistry` through to `createRuntime` so it lands on `rt.pidRegistry`.
+
+5. **Tests that assert "the caller passed `onPidSpawned`"** — those are testing the wrong thing under the new model. Rewrite them to assert behavior at the adapter boundary or at the registry, not at the options-object level.
+
+6. **`fakeAgentManager` test helper** (`test/helpers/fake-agent-manager.ts`) wraps a single adapter without going through the manager attach path. After this refactor, tests that use it to exercise complete-path behavior do *not* automatically get lifecycle attached. That's fine — those are unit tests of the adapter primitive, not the manager — but if any test relied on the registry being touched via `fakeAgentManager`, update it to use a real `AgentManager` (or pass `pidRegistry` directly via the test helper if you extend it).
+
+7. **Backward compat of `OpenSessionOpts.onPidSpawned`** — keep this exposed on the adapter primitive (`adapter.openSession`). Callers above the adapter boundary go through `SessionManager.openSession`, which has its own (different) options type without these fields. Don't conflate the two.
+
+8. **`AgentManager.configureRuntime` and `SessionManager.configureRuntime`** are both **idempotent merges** — they only assign fields that are present in the opts object. So passing `{ pidRegistry }` from `runtime/index.ts` won't clobber existing fields. Follow the existing `if (opts.X) this._X = opts.X` pattern.
+
+9. **`PipelineContext.pidRegistry` becomes dead** after Step 5 (the only production consumer was the deleted `const pidRegistry = ctx.pidRegistry;` at `src/pipeline/stages/execution.ts:160`). Cleanup chain — these are **recommended** for a clean refactor, but not strictly required for the bug fix:
+   - `src/pipeline/types.ts:114` — `pidRegistry?: PidRegistry` field
+   - `src/execution/runner-execution.ts:52` (declaration) and line 166 (propagation)
+   - `src/execution/executor-types.ts:50` — `pidRegistry?: PidRegistry` field
+   - `src/execution/unified-executor.ts:252` — `pidRegistry: ctx.pidRegistry,` propagation
+
+   Don't conflate with `SignalHandlerContext.pidRegistry` in `src/execution/crash-signals.ts` — that's a different type carrying the same registry, wired by `installCrashHandlers` in `run-setup.ts`. It stays. If you skip the cleanup, leave a `// TODO(post-refactor): unused — remove when no consumers` comment on each dead field; if you do the cleanup, make sure typecheck stays green and that no test reads `ctx.pidRegistry`.
+
+10. **The `crash-signals.ts` `ctx.pidRegistry` reads (lines 89/97-98/138/144-145/188/194-195)** are reading `SignalHandlerContext.pidRegistry`, not `PipelineContext.pidRegistry`. They continue to work as-is — `installCrashHandlers` is called from `run-setup.ts` and gets `runtime.pidRegistry` after Step 5(d). No change to `crash-signals.ts`.
+
+---
+
+## 6. Rollback plan
+
+If something goes wrong, the prerequisite commit `7e246103` is fully self-sufficient — the codebase is safe with that commit alone (kill path is hardened, lifecycle is symmetric). You can `git reset --hard 7e246103` and abandon this refactor without losing the bug fix. Only do this if you've verified the `7e246103` state is green first.
+
+---
+
+## 7. Done definition
+
+- All 12 acceptance criteria in §2 satisfied.
+- Two commits on the branch: `7e246103` (the prerequisite) + the new refactor commit from Step 8.
+- A grep-sweep proving §5: `grep -rn 'onPidSpawned\|onPidExited' src/` returns matches only in the four sanctioned locations listed in Step 5.
+- PR description references this plan file and explains both commits' roles (defense-in-depth + structural prevention).

--- a/src/agents/acp/adapter-lifecycle.ts
+++ b/src/agents/acp/adapter-lifecycle.ts
@@ -33,8 +33,9 @@ export const _acpAdapterDeps = {
     timeoutSeconds?: number,
     onPidSpawned?: (pid: number) => void,
     promptRetries?: number,
+    onPidExited?: (pid: number) => void,
   ): AcpClient {
-    return createSpawnAcpClient(cmdStr, cwd, timeoutSeconds, onPidSpawned, promptRetries);
+    return createSpawnAcpClient(cmdStr, cwd, timeoutSeconds, onPidSpawned, promptRetries, onPidExited);
   },
 };
 

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -183,6 +183,7 @@ export class AcpAgentAdapter implements AgentAdapter {
         timeoutSeconds,
         _options?.onPidSpawned,
         promptRetries,
+        _options?.onPidExited,
       );
       await client.start();
 
@@ -351,13 +352,21 @@ export class AcpAgentAdapter implements AgentAdapter {
       promptRetries,
       onSessionEstablished,
       onPidSpawned,
+      onPidExited,
     } = opts;
     const { signal } = opts;
 
     throwIfAborted(signal, "Run aborted — shutdown in progress");
 
     const cmdStr = `acpx --model ${modelDef.model} ${agentName}`;
-    const client = _acpAdapterDeps.createClient(cmdStr, workdir, timeoutSeconds, onPidSpawned, promptRetries);
+    const client = _acpAdapterDeps.createClient(
+      cmdStr,
+      workdir,
+      timeoutSeconds,
+      onPidSpawned,
+      promptRetries,
+      onPidExited,
+    );
     let session: import("./adapter-session-types").AcpSession | undefined;
 
     try {

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -97,6 +97,7 @@ export class SpawnAcpSession implements AcpSession {
   private readonly permissionMode: string;
   private readonly env: Record<string, string | undefined>;
   private readonly onPidSpawned?: (pid: number) => void;
+  private readonly onPidExited?: (pid: number) => void;
   private activeProc: { pid: number; kill(signal?: number): void } | null = null;
   /** Volatile Claude Code session ID (acpxSessionId) — updated on reconnect. */
   readonly id?: string;
@@ -113,6 +114,7 @@ export class SpawnAcpSession implements AcpSession {
     permissionMode: string;
     env: Record<string, string | undefined>;
     onPidSpawned?: (pid: number) => void;
+    onPidExited?: (pid: number) => void;
     id?: string;
     recordId?: string;
   }) {
@@ -125,6 +127,7 @@ export class SpawnAcpSession implements AcpSession {
     this.permissionMode = opts.permissionMode;
     this.env = opts.env;
     this.onPidSpawned = opts.onPidSpawned;
+    this.onPidExited = opts.onPidExited;
     this.id = opts.id;
     this.recordId = opts.recordId;
   }
@@ -168,6 +171,16 @@ export class SpawnAcpSession implements AcpSession {
     this.activeProc = proc;
     const processPid = proc.pid;
     this.onPidSpawned?.(processPid);
+    let exitNotified = false;
+    const notifyExit = (): void => {
+      if (exitNotified) return;
+      exitNotified = true;
+      try {
+        this.onPidExited?.(processPid);
+      } catch {
+        // unregister is best-effort — never let it surface from prompt()
+      }
+    };
 
     try {
       try {
@@ -250,6 +263,7 @@ export class SpawnAcpSession implements AcpSession {
       }
     } finally {
       this.activeProc = null;
+      notifyExit();
     }
   }
 
@@ -376,6 +390,7 @@ export class SpawnAcpClient implements AcpClient {
   private readonly promptRetries: number;
   private readonly env: Record<string, string | undefined>;
   private readonly onPidSpawned?: (pid: number) => void;
+  private readonly onPidExited?: (pid: number) => void;
 
   constructor(
     cmdStr: string,
@@ -383,6 +398,7 @@ export class SpawnAcpClient implements AcpClient {
     timeoutSeconds?: number,
     onPidSpawned?: (pid: number) => void,
     promptRetries?: number,
+    onPidExited?: (pid: number) => void,
   ) {
     // Parse: "acpx --model <model> <agentName>"
     const parts = cmdStr.split(/\s+/);
@@ -401,6 +417,7 @@ export class SpawnAcpClient implements AcpClient {
     this.promptRetries = promptRetries ?? 0;
     this.env = buildAllowedEnv();
     this.onPidSpawned = onPidSpawned;
+    this.onPidExited = onPidExited;
   }
 
   async start(): Promise<void> {
@@ -460,6 +477,7 @@ export class SpawnAcpClient implements AcpClient {
       permissionMode: opts.permissionMode,
       env: this.env,
       onPidSpawned: this.onPidSpawned,
+      onPidExited: this.onPidExited,
       id: sessionId,
       recordId,
     });
@@ -486,6 +504,7 @@ export class SpawnAcpClient implements AcpClient {
       permissionMode,
       env: this.env,
       onPidSpawned: this.onPidSpawned,
+      onPidExited: this.onPidExited,
       id: sessionId,
       recordId,
     });
@@ -523,6 +542,7 @@ export function createSpawnAcpClient(
   timeoutSeconds?: number,
   onPidSpawned?: (pid: number) => void,
   promptRetries?: number,
+  onPidExited?: (pid: number) => void,
 ): AcpClient {
-  return new SpawnAcpClient(cmdStr, cwd, timeoutSeconds, onPidSpawned, promptRetries);
+  return new SpawnAcpClient(cmdStr, cwd, timeoutSeconds, onPidSpawned, promptRetries, onPidExited);
 }

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -10,6 +10,7 @@ import type { NaxConfig } from "../config";
 import { resolvePermissions } from "../config/permissions";
 import type { AdapterFailure } from "../context/engine";
 import { NaxError } from "../errors";
+import type { PidRegistry } from "../execution/pid-registry";
 import { getSafeLogger } from "../logger";
 // Leaf import to avoid barrel cycle:
 // src/runtime/index.ts → internal/agent-manager-factory → agents/factory → agents/manager → runtime/index.ts
@@ -73,6 +74,7 @@ export class AgentManager implements IAgentManager {
   private _sendPrompt: SendPromptFn | undefined;
   private _runHop: SessionRunHopFn | undefined;
   private _dispatchEvents: IDispatchEventBus;
+  private _pidRegistry: PidRegistry | undefined;
   readonly events: AgentManagerEvents;
 
   constructor(
@@ -108,12 +110,14 @@ export class AgentManager implements IAgentManager {
     sendPrompt?: SendPromptFn;
     runHop?: SessionRunHopFn;
     dispatchEvents?: IDispatchEventBus;
+    pidRegistry?: PidRegistry;
   }): void {
     if (opts.middleware) this._middleware = opts.middleware;
     if (opts.runId) this._runId = opts.runId;
     if (opts.sendPrompt) this._sendPrompt = opts.sendPrompt;
     if (opts.runHop) this._runHop = opts.runHop;
     if (opts.dispatchEvents) this._dispatchEvents = opts.dispatchEvents;
+    if (opts.pidRegistry) this._pidRegistry = opts.pidRegistry;
   }
 
   getDefault(): string {
@@ -382,7 +386,14 @@ export class AgentManager implements IAgentManager {
 
         let result: CompleteResult;
         try {
-          result = await adapter.complete(prompt, options);
+          const optionsWithLifecycle: CompleteOptions = this._pidRegistry
+            ? {
+                ...options,
+                onPidSpawned: (pid: number) => this._pidRegistry?.register(pid),
+                onPidExited: (pid: number) => this._pidRegistry?.unregister(pid),
+              }
+            : options;
+          result = await adapter.complete(prompt, optionsWithLifecycle);
         } catch (err) {
           result = {
             output: "",

--- a/src/agents/shared/types-extended.ts
+++ b/src/agents/shared/types-extended.ts
@@ -64,6 +64,8 @@ export interface PlanOptions {
   onAcpSessionCreated?: (sessionName: string) => Promise<void> | void;
   /** Callback fired immediately after spawning the agent process — caller registers the PID. */
   onPidSpawned?: (pid: number) => void;
+  /** Callback fired when the spawned agent process exits — caller unregisters the PID. */
+  onPidExited?: (pid: number) => void;
 }
 
 /**

--- a/src/agents/shared/types-extended.ts
+++ b/src/agents/shared/types-extended.ts
@@ -62,10 +62,6 @@ export interface PlanOptions {
    * Used to persist the name to status.json for plan→run session continuity.
    */
   onAcpSessionCreated?: (sessionName: string) => Promise<void> | void;
-  /** Callback fired immediately after spawning the agent process — caller registers the PID. */
-  onPidSpawned?: (pid: number) => void;
-  /** Callback fired when the spawned agent process exits — caller unregisters the PID. */
-  onPidExited?: (pid: number) => void;
 }
 
 /**

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -108,6 +108,13 @@ export interface AgentRunOptions {
   /** Callback fired immediately after spawning the agent process — caller registers the PID. */
   onPidSpawned?: (pid: number) => void;
   /**
+   * Callback fired when a previously-spawned PID exits naturally (success or failure).
+   * Mirrors `onPidSpawned` to keep PidRegistry symmetric — without this, dead PIDs
+   * accumulate in the registry across a run and on Ctrl+C the kill path may signal
+   * recycled, unrelated processes (potentially their entire process groups).
+   */
+  onPidExited?: (pid: number) => void;
+  /**
    * Explicit ACP session handle override. When set, the adapter uses this
    * name instead of auto-deriving from featureName/storyId/sessionRole.
    * Use only when a non-standard session name is required (e.g. generation-scoped
@@ -266,6 +273,11 @@ export interface CompleteOptions {
    * PIDs past PidRegistry — `Ctrl+C` mid-call leaves orphan acpx subprocesses.
    */
   onPidSpawned?: (pid: number) => void;
+  /**
+   * Unregistration callback fired when a complete-path acpx subprocess exits.
+   * Required to keep PidRegistry from accumulating dead PIDs over the life of a run.
+   */
+  onPidExited?: (pid: number) => void;
 }
 
 /**
@@ -342,6 +354,11 @@ export interface OpenSessionOpts {
   onSessionEstablished?: (protocolIds: ProtocolIds, sessionName: string) => void;
   /** PID registration callback for crash-recovery bookkeeping. */
   onPidSpawned?: (pid: number) => void;
+  /**
+   * PID unregistration callback. Called when an acpx subprocess associated with this
+   * session exits naturally — keeps PidRegistry from accumulating dead PIDs.
+   */
+  onPidExited?: (pid: number) => void;
   /** Abort signal — if already aborted, openSession rejects immediately. */
   signal?: AbortSignal;
   /**

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -105,15 +105,6 @@ export interface AgentRunOptions {
     detectQuestion: (text: string) => Promise<boolean>;
     onQuestionDetected: (text: string) => Promise<string>;
   };
-  /** Callback fired immediately after spawning the agent process — caller registers the PID. */
-  onPidSpawned?: (pid: number) => void;
-  /**
-   * Callback fired when a previously-spawned PID exits naturally (success or failure).
-   * Mirrors `onPidSpawned` to keep PidRegistry symmetric — without this, dead PIDs
-   * accumulate in the registry across a run and on Ctrl+C the kill path may signal
-   * recycled, unrelated processes (potentially their entire process groups).
-   */
-  onPidExited?: (pid: number) => void;
   /**
    * Explicit ACP session handle override. When set, the adapter uses this
    * name instead of auto-deriving from featureName/storyId/sessionRole.
@@ -267,15 +258,13 @@ export interface CompleteOptions {
    */
   pipelineStage?: import("../config/permissions").PipelineStage;
   /**
-   * PID registration callback for crash-recovery bookkeeping. Mirrors the run-path
-   * `OpenSessionOpts.onPidSpawned`. Without this, complete-path acpx invocations
-   * (plan, decompose, classify-route, acceptance-generate, debate-*) leak their
-   * PIDs past PidRegistry — `Ctrl+C` mid-call leaves orphan acpx subprocesses.
+   * @internal Set by `AgentManager.completeAs`; callers must not pass this — it will be overwritten.
+   * PID registration callback attached by AgentManager when a PidRegistry is configured.
    */
   onPidSpawned?: (pid: number) => void;
   /**
-   * Unregistration callback fired when a complete-path acpx subprocess exits.
-   * Required to keep PidRegistry from accumulating dead PIDs over the life of a run.
+   * @internal Set by `AgentManager.completeAs`; callers must not pass this — it will be overwritten.
+   * PID unregistration callback attached by AgentManager when a PidRegistry is configured.
    */
   onPidExited?: (pid: number) => void;
 }

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -268,6 +268,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
             maxInteractionTurns: config?.agent?.maxInteractionTurns,
             featureName: options.feature,
             onPidSpawned: (pid: number) => pidRegistry.register(pid),
+            onPidExited: (pid: number) => pidRegistry.unregister(pid),
             sessionRole: "plan",
             pipelineStage: "plan",
           },

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -13,7 +13,6 @@ import { join } from "node:path";
 import { resolveDefaultAgent } from "../agents";
 import type { NaxConfig } from "../config";
 import { resolvePermissions } from "../config/permissions";
-import { PidRegistry } from "../execution/pid-registry";
 import { buildInteractionBridge } from "../interaction/bridge-builder";
 import { getLogger } from "../logger";
 import { callOp, planOp } from "../operations";
@@ -242,7 +241,6 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
         })
       : undefined;
     const interactionBridge = configuredBridge ?? _planDeps.createInteractionBridge();
-    const pidRegistry = new PidRegistry(workdir);
     const resolvedPerm = resolvePermissions(config, "plan");
     logger?.info("plan", "Starting interactive planning session", {
       agent: agentName,
@@ -267,8 +265,6 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
             modelDef: resolvedPlanModel.modelDef,
             maxInteractionTurns: config?.agent?.maxInteractionTurns,
             featureName: options.feature,
-            onPidSpawned: (pid: number) => pidRegistry.register(pid),
-            onPidExited: (pid: number) => pidRegistry.unregister(pid),
             sessionRole: "plan",
             pipelineStage: "plan",
           },
@@ -281,7 +277,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
         });
       }
     } finally {
-      await pidRegistry.killAll().catch(() => {});
+      await rt.pidRegistry.killAll().catch(() => {});
       if (interactionChain) await interactionChain.destroy().catch(() => {});
       await rt.close().catch(() => {});
       logger?.info("plan", "Interactive session ended", { durationMs: Date.now() - planStartTime });

--- a/src/execution/executor-types.ts
+++ b/src/execution/executor-types.ts
@@ -14,11 +14,9 @@ import type { AgentGetFn } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins";
 import type { PRD, UserStory } from "../prd/types";
 import type { DispatchContext } from "../runtime/dispatch-context";
-import type { ISessionManager } from "../session";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
 import type { StoryBatch } from "./batching";
 import type { DeferredReviewResult } from "./deferred-review";
-import type { PidRegistry } from "./pid-registry";
 import type { StatusWriter } from "./status-writer";
 
 export interface SequentialExecutionContext extends DispatchContext {
@@ -46,8 +44,6 @@ export interface SequentialExecutionContext extends DispatchContext {
   interactionChain?: InteractionChain | null;
   /** Protocol-aware agent resolver (ACP wiring). Falls back to standalone getAgent when absent. */
   agentGetFn?: AgentGetFn;
-  /** PID registry for crash recovery — register child PIDs so they can be killed on SIGTERM. */
-  pidRegistry?: PidRegistry;
   /** Max parallel sessions: undefined=sequential, 0=auto-detect, N>0=cap at N */
   parallelCount?: number;
   /** Run-scoped pre-resolved .naxignore index (refreshed when package set changes). */

--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -176,7 +176,6 @@ export async function runIteration(
     storyGitRef: storyGitRef ?? undefined,
     interaction: ctx.interactionChain ?? undefined,
     agentGetFn: ctx.agentGetFn,
-    pidRegistry: ctx.pidRegistry,
     abortSignal: ctx.abortSignal,
     sessionManager: ctx.sessionManager,
     agentManager: ctx.agentManager,

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -33,7 +33,6 @@ import { resolveTestFilePatterns } from "../../test-runners/resolver";
 import { NAX_BUILD_INFO, NAX_COMMIT, NAX_VERSION } from "../../version";
 import { installCrashHandlers } from "../crash-recovery";
 import { acquireLock, releaseLock } from "../helpers";
-import type { PidRegistry } from "../pid-registry";
 import { closeAllRunSessions } from "../session-manager-runtime";
 import { StatusWriter } from "../status-writer";
 
@@ -102,7 +101,6 @@ export interface RunSetupOptions {
 
 export interface RunSetupResult {
   statusWriter: StatusWriter;
-  pidRegistry: PidRegistry;
   sessionManager: SessionManager;
   cleanupCrashHandlers: () => void;
   pluginRegistry: PluginRegistry;
@@ -355,7 +353,6 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
 
     return {
       statusWriter,
-      pidRegistry: runtime.pidRegistry,
       sessionManager,
       cleanupCrashHandlers,
       pluginRegistry,

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -185,6 +185,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     agentManager: options.agentManager,
     featureName: options.feature,
     onPidSpawned: (pid: number) => pidRegistry.register(pid),
+    onPidExited: (pid: number) => pidRegistry.unregister(pid),
   });
 
   // Cleanup stale PIDs from previous crashed runs

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -33,7 +33,7 @@ import { resolveTestFilePatterns } from "../../test-runners/resolver";
 import { NAX_BUILD_INFO, NAX_COMMIT, NAX_VERSION } from "../../version";
 import { installCrashHandlers } from "../crash-recovery";
 import { acquireLock, releaseLock } from "../helpers";
-import { PidRegistry } from "../pid-registry";
+import type { PidRegistry } from "../pid-registry";
 import { closeAllRunSessions } from "../session-manager-runtime";
 import { StatusWriter } from "../status-writer";
 
@@ -166,8 +166,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     pid: process.pid,
   });
 
-  // ── PID registry for orphan process cleanup (BUG-002) ───────
-  const pidRegistry = new PidRegistry(workdir);
+  // ── PID registry constructed by createRuntime (BUG-002) ────────
   const sessionManager = new SessionManager();
 
   // Shutdown controller — fires on first fatal signal. Threaded into
@@ -184,12 +183,10 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     sessionManager,
     agentManager: options.agentManager,
     featureName: options.feature,
-    onPidSpawned: (pid: number) => pidRegistry.register(pid),
-    onPidExited: (pid: number) => pidRegistry.unregister(pid),
   });
 
   // Cleanup stale PIDs from previous crashed runs
-  await pidRegistry.cleanupStale();
+  await runtime.pidRegistry.cleanupStale();
 
   // Install crash handlers for signal recovery (US-007, BUG-1+MEM-1 fix: pass getters, cleanup in finally)
   const cleanupCrashHandlers = installCrashHandlers({
@@ -197,7 +194,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     getTotalCost,
     getIterations,
     jsonlFilePath: logFilePath,
-    pidRegistry,
+    pidRegistry: runtime.pidRegistry,
     abortController: shutdownController,
     // @design: BUG-017: Pass context for run.complete event on SIGTERM
     runId: options.runId,
@@ -358,7 +355,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
 
     return {
       statusWriter,
-      pidRegistry,
+      pidRegistry: runtime.pidRegistry,
       sessionManager,
       cleanupCrashHandlers,
       pluginRegistry,

--- a/src/execution/parallel-coordinator.ts
+++ b/src/execution/parallel-coordinator.ts
@@ -20,7 +20,6 @@ import { errorMessage } from "../utils/errors";
 import { WorktreeManager } from "../worktree/manager";
 import { MergeEngine, type StoryDependencies } from "../worktree/merge";
 import { executeParallelBatch } from "./parallel-worker";
-import type { PidRegistry } from "./pid-registry";
 import { groupStoriesByDependencies } from "./story-selector";
 
 /**
@@ -71,7 +70,6 @@ export async function executeParallel(
   parallel: number,
   eventEmitter?: PipelineEventEmitter,
   agentGetFn?: AgentGetFn,
-  pidRegistry?: PidRegistry,
   interactionChain?: InteractionChain | null,
   statusWriter?: PostRunStatusWriter,
   agentManager?: import("../agents").IAgentManager,
@@ -125,7 +123,6 @@ export async function executeParallel(
       plugins,
       storyStartTime: new Date().toISOString(),
       agentGetFn,
-      pidRegistry,
       interaction: interactionChain ?? undefined,
       // biome-ignore lint/style/noNonNullAssertion: executeParallel is exported but unused in production; callers always provide these fields
       agentManager: agentManager!,

--- a/src/execution/pid-registry.ts
+++ b/src/execution/pid-registry.ts
@@ -6,7 +6,16 @@
  * - Write .nax-pids file for persistence across crashes
  * - Support killAll() for crash signal handlers
  * - Support cleanupStale() for startup cleanup
- * - Use process groups (setsid) on Linux, direct kill on macOS
+ *
+ * Safety: signals are sent to a single PID, never to a process group. The previous
+ * Linux code path used `kill -TERM -<pid>` (negative pid = process group) under the
+ * assumption every spawned acpx was a session leader. That assumption fails for
+ * per-call acpx invocations (not setsid'd) and, combined with PID recycling between
+ * the existence check and the signal, could SIGTERM unrelated process groups —
+ * including the user's desktop session. Direct PID-only signaling avoids that
+ * blast radius. If a single descendant survives this signal, the OS reaps it when
+ * nax exits; orphan acpx queue-owners are addressed independently by
+ * `complete()` calling `session.close({ forceTerminate: true })`.
  */
 
 import { existsSync } from "node:fs";
@@ -46,19 +55,18 @@ export class PidRegistry {
   private readonly workdir: string;
   private readonly pidsFilePath: string;
   private readonly pids: Set<number> = new Set();
-  private readonly platform: NodeJS.Platform;
   private frozen = false;
 
   /**
    * Create a new PID registry for the given workdir.
    *
    * @param workdir - Working directory where .nax-pids will be stored
-   * @param platform - Optional platform override (for testing)
+   * @param _platform - Reserved for backward compatibility; signals are now
+   *   sent identically across platforms (single PID, not process group).
    */
-  constructor(workdir: string, platform?: NodeJS.Platform) {
+  constructor(workdir: string, _platform?: NodeJS.Platform) {
     this.workdir = workdir;
     this.pidsFilePath = `${workdir}/${PID_REGISTRY_FILE}`;
-    this.platform = platform ?? process.platform;
   }
 
   /**
@@ -143,10 +151,12 @@ export class PidRegistry {
    * Kill all registered processes.
    *
    * Called by crash signal handlers to cleanup spawned agent processes.
-   * Uses process groups (setsid) on Linux, direct kill on macOS.
+   * Signals each registered PID directly (single process, never a process group).
    *
-   * On Linux: kill -TERM -<pid> kills the entire process group
-   * On macOS: kill -TERM <pid> kills the process directly
+   * Process-group kill (`kill -TERM -<pid>`) is intentionally avoided: with PID
+   * recycling between the existence check and the signal, a recycled PID that
+   * happens to be a session leader would receive SIGTERM across its entire
+   * group — potentially including the user's desktop session.
    */
   async killAll(): Promise<void> {
     const logger = getSafeLogger();
@@ -177,8 +187,16 @@ export class PidRegistry {
   /**
    * Cleanup stale PIDs from previous runs.
    *
-   * Called at runner startup before lock acquisition.
-   * Reads .nax-pids file and kills any still-running processes.
+   * Called at runner startup before lock acquisition. Reads `.nax-pids` only to
+   * record what was left over for diagnostics, then truncates the file.
+   *
+   * IMPORTANT: this method does NOT signal any of the recorded PIDs. Stale PIDs
+   * from a previous run have almost certainly been recycled by the kernel, and
+   * signaling a recycled PID would target an unrelated process — most often
+   * something belonging to the user's desktop session. Orphan acpx processes
+   * from a prior crashed run are reaped by acpx's own queue-owner TTL and by
+   * `complete()` always closing its session with `forceTerminate: true`. The
+   * file is treated as a leak indicator, not a kill list.
    */
   async cleanupStale(): Promise<void> {
     const logger = getSafeLogger();
@@ -209,16 +227,15 @@ export class PidRegistry {
       }
 
       const stalePids = lines.map((entry) => entry.pid);
-      logger?.info("pid-registry", `Cleaning up ${stalePids.length} stale PIDs from previous run`, {
-        pids: stalePids,
-      });
+      logger?.info(
+        "pid-registry",
+        `Found ${stalePids.length} stale PID entries from previous run; clearing file without signaling (PIDs likely recycled)`,
+        { pids: stalePids },
+      );
 
-      const killPromises = stalePids.map((pid) => this.killPid(pid));
-      await Promise.allSettled(killPromises);
-
-      // Clear the registry file after cleanup
+      // Clear the registry file. Do NOT call killPid on these — see method docs.
       await Bun.write(this.pidsFilePath, "");
-      logger?.info("pid-registry", "Stale PIDs cleanup completed");
+      logger?.info("pid-registry", "Stale PIDs file cleared");
     } catch (err) {
       logger?.warn("pid-registry", "Failed to cleanup stale PIDs", {
         error: (err as Error).message,
@@ -229,16 +246,27 @@ export class PidRegistry {
   /**
    * Kill a single PID.
    *
-   * Uses process groups on Linux (kill -TERM -<pid>), direct kill on macOS (kill -TERM <pid>).
-   * Ignores ESRCH (process not found) errors.
+   * Signals the specific PID only — never a process group. Reject pid<=1 to
+   * make the bad-input case impossible (kill 0 = caller's group, kill 1 = init,
+   * kill -1 = "every process the caller can signal"). Ignores ESRCH (process
+   * not found) errors.
    *
    * @param pid - Process ID to kill
    */
   private async killPid(pid: number): Promise<void> {
     const logger = getSafeLogger();
 
+    if (!Number.isInteger(pid) || pid <= 1) {
+      logger?.warn("pid-registry", `Refusing to signal non-positive or reserved PID ${pid}`, { pid });
+      return;
+    }
+
     try {
-      // Check if process exists first
+      // Check if process exists first. Note: this is best-effort — there is an
+      // inherent TOCTOU between this check and the kill below. The pid<=1 guard
+      // and the explicit single-PID (non-group) signaling bound the worst case
+      // to "we signal a recycled, unrelated process" rather than "we slaughter
+      // an entire process group containing the user's desktop session."
       const checkProc = Bun.spawn(["kill", "-0", String(pid)], {
         stdout: "pipe",
         stderr: "pipe",
@@ -251,11 +279,9 @@ export class PidRegistry {
         return;
       }
 
-      // On Linux, use process groups (kill -TERM -<pid>)
-      // On macOS, use direct kill (kill -TERM <pid>)
-      const killArgs = this.platform === "linux" ? ["kill", "-TERM", `-${pid}`] : ["kill", "-TERM", String(pid)];
-
-      const killProc = Bun.spawn(killArgs, {
+      // Signal a single PID. Do NOT use `-${pid}` (process-group kill) —
+      // see class header for rationale.
+      const killProc = Bun.spawn(["kill", "-TERM", String(pid)], {
         stdout: "pipe",
         stderr: "pipe",
       });

--- a/src/execution/runner-execution.ts
+++ b/src/execution/runner-execution.ts
@@ -18,10 +18,8 @@ import { tryLlmBatchRoute } from "../routing";
 import { clearCache as clearLlmCache } from "../routing/strategies/llm";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import { SessionManager } from "../session";
-import type { ISessionManager } from "../session";
 import { precomputeBatchPlan } from "./batching";
 import { getAllReadyStories } from "./helpers";
-import type { PidRegistry } from "./pid-registry";
 
 /**
  * Options for the execution phase.
@@ -48,8 +46,6 @@ export interface RunnerExecutionOptions extends DispatchContext {
   parallel?: number;
   /** Protocol-aware agent resolver — bound from agentManager.getAgent in runner.ts */
   agentGetFn?: AgentGetFn;
-  /** PID registry for crash recovery — passed to agent.run() to register child processes. */
-  pidRegistry?: PidRegistry;
   /** Interaction chain for cost/pre-merge triggers during sequential execution. */
   interactionChain?: InteractionChain | null;
   /** Per-run plugin-provider cache (Finding 5 / issue #473). */
@@ -163,7 +159,6 @@ export async function runExecutionPhase(
       startTime: options.startTime,
       parallelCount: options.parallel,
       agentGetFn: options.agentGetFn,
-      pidRegistry: options.pidRegistry,
       abortSignal: options.abortSignal,
       interactionChain: options.interactionChain,
       agentManager: options.agentManager,

--- a/src/execution/runner-setup.ts
+++ b/src/execution/runner-setup.ts
@@ -43,7 +43,6 @@ export interface RunnerSetupOptions {
  */
 export interface RunnerSetupResult {
   statusWriter: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["statusWriter"];
-  pidRegistry: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["pidRegistry"];
   sessionManager: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["sessionManager"];
   cleanupCrashHandlers: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["cleanupCrashHandlers"];
   pluginRegistry: Awaited<ReturnType<typeof import("./lifecycle/run-setup").setupRun>>["pluginRegistry"];

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -145,7 +145,6 @@ export async function run(options: RunOptions): Promise<RunResult> {
 
   const {
     statusWriter,
-    pidRegistry,
     sessionManager,
     cleanupCrashHandlers,
     pluginRegistry,
@@ -180,7 +179,6 @@ export async function run(options: RunOptions): Promise<RunResult> {
         headless,
         parallel,
         agentGetFn,
-        pidRegistry,
         abortSignal: shutdownController.signal,
         interactionChain,
         sessionManager,

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -249,7 +249,6 @@ export async function executeUnified(
                 agentGetFn: ctx.agentGetFn,
                 agentManager: ctx.agentManager,
                 sessionManager: ctx.sessionManager,
-                pidRegistry: ctx.pidRegistry,
                 runtime: ctx.runtime,
                 abortSignal: ctx.abortSignal,
               },

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -82,6 +82,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       featureName: ctx.featureName,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       onPidSpawned: ctx.runtime.onPidSpawned,
+      onPidExited: ctx.runtime.onPidExited,
     });
     const parsedComplete = op.parse(raw.output, input, buildCtx);
     return runPostParse(op, parsedComplete, input, buildCtx);

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -81,8 +81,6 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       workdir: ctx.packageDir,
       featureName: ctx.featureName,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-      onPidSpawned: ctx.runtime.onPidSpawned,
-      onPidExited: ctx.runtime.onPidExited,
     });
     const parsedComplete = op.parse(raw.output, input, buildCtx);
     return runPostParse(op, parsedComplete, input, buildCtx);

--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -337,8 +337,6 @@ export async function runAgentRectification(
             featureName: ctx.prd.feature,
             storyId: ctx.story.id,
             signal: runtime.signal,
-            onPidSpawned: runtime.onPidSpawned,
-            onPidExited: runtime.onPidExited,
           });
         }
         // ADR-020 single-emission invariant: each runAsSession emits one

--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -338,6 +338,7 @@ export async function runAgentRectification(
             storyId: ctx.story.id,
             signal: runtime.signal,
             onPidSpawned: runtime.onPidSpawned,
+            onPidExited: runtime.onPidExited,
           });
         }
         // ADR-020 single-emission invariant: each runAsSession emits one

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -175,6 +175,7 @@ export const executionStage: PipelineStage = {
       projectDir: ctx.projectDir,
       maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
       onPidSpawned: pidRegistry ? (pid: number) => pidRegistry.register(pid) : undefined,
+      onPidExited: pidRegistry ? (pid: number) => pidRegistry.unregister(pid) : undefined,
       abortSignal: ctx.abortSignal,
       featureName: ctx.prd.feature,
       storyId: ctx.story.id,

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -157,7 +157,6 @@ export const executionStage: PipelineStage = {
     // Determine whether to keep session open for review or rectification
     const keepOpen = !!(ctx.config.review?.enabled === true || ctx.config.execution.rectification?.enabled === true);
 
-    const pidRegistry = ctx.pidRegistry;
     const baseRunOptions: import("../../agents/types").AgentRunOptions = {
       prompt: ctx.prompt,
       workdir: ctx.workdir,
@@ -174,8 +173,6 @@ export const executionStage: PipelineStage = {
       config: ctx.config,
       projectDir: ctx.projectDir,
       maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
-      onPidSpawned: pidRegistry ? (pid: number) => pidRegistry.register(pid) : undefined,
-      onPidExited: pidRegistry ? (pid: number) => pidRegistry.unregister(pid) : undefined,
       abortSignal: ctx.abortSignal,
       featureName: ctx.prd.feature,
       storyId: ctx.story.id,

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -8,7 +8,6 @@ import type { AgentResult } from "../agents/types";
 import type { NaxConfig } from "../config/schema";
 import type { ConstitutionResult } from "../constitution/types";
 import type { BuiltContext } from "../context/types";
-import type { PidRegistry } from "../execution/pid-registry";
 import type { HooksConfig } from "../hooks/types";
 import type { InteractionChain } from "../interaction/chain";
 import type { StoryMetrics } from "../metrics/types";
@@ -110,8 +109,6 @@ export interface PipelineContext extends DispatchContext {
    * falls back to standalone getAgent (CLI mode) when absent.
    */
   agentGetFn?: AgentGetFn;
-  /** PID registry for crash recovery — passed through to agent.run() for child process registration. */
-  pidRegistry?: PidRegistry;
   /** Interaction chain (optional, for human-in-the-loop triggers) */
   interaction?: InteractionChain;
   /** Constitution result (set by constitutionStage) */

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -148,13 +148,11 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     dispatchEvents,
   };
   if (opts?.agentManager instanceof AgentManager) {
-    opts.agentManager.configureRuntime(agentManagerOpts);
-    opts.agentManager.configureRuntime({ pidRegistry });
+    opts.agentManager.configureRuntime({ ...agentManagerOpts, pidRegistry });
     agentManager = opts.agentManager;
   } else {
     agentManager = opts?.agentManager ?? createAgentManager(config, agentManagerOpts);
   }
-  // Attach pidRegistry to the agentManager for the factory-created path.
   if (agentManager instanceof AgentManager) {
     agentManager.configureRuntime({ pidRegistry });
   }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -77,6 +77,13 @@ export interface NaxRuntime {
    * children) past run teardown.
    */
   readonly onPidSpawned?: (pid: number) => void;
+  /**
+   * PID unregistration callback paired with `onPidSpawned`. Adapters call this
+   * when a previously-registered acpx subprocess exits naturally so the run's
+   * PidRegistry does not accumulate dead PIDs (which on Ctrl+C would otherwise
+   * be re-killed against recycled, unrelated processes).
+   */
+  readonly onPidExited?: (pid: number) => void;
   close(): Promise<void>;
 }
 
@@ -99,6 +106,11 @@ export interface CreateRuntimeOptions {
    * callback directly into `AgentRunOptions` and do not depend on this field.
    */
   onPidSpawned?: (pid: number) => void;
+  /**
+   * PID unregistration callback paired with `onPidSpawned`. Threaded the same
+   * way; adapters call it when the registered acpx subprocess exits naturally.
+   */
+  onPidExited?: (pid: number) => void;
 }
 
 export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateRuntimeOptions): NaxRuntime {
@@ -185,6 +197,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
       return controller.signal;
     },
     onPidSpawned: opts?.onPidSpawned,
+    onPidExited: opts?.onPidExited,
     async close() {
       if (closed) return;
       closed = true;

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -34,6 +34,7 @@ import type { NaxConfig } from "../config";
 import { createConfigLoader } from "../config";
 import type { ConfigLoader } from "../config";
 import { NaxError } from "../errors";
+import { PidRegistry } from "../execution/pid-registry";
 import { getLogger } from "../logger";
 import type { Logger } from "../logger";
 import type { ISessionManager } from "../session";
@@ -67,23 +68,9 @@ export interface NaxRuntime {
   readonly promptAuditor: IPromptAuditor;
   readonly dispatchEvents: IDispatchEventBus;
   readonly packages: PackageRegistry;
+  readonly pidRegistry: PidRegistry;
   readonly logger: Logger;
   readonly signal: AbortSignal;
-  /**
-   * Optional PID registration callback used by complete-path adapter calls
-   * (plan, decompose, classify-route, acceptance-generate, debate-*) so any
-   * acpx subprocess they spawn lands on the run's PidRegistry. Without it
-   * Ctrl+C mid-call leaves orphan acpx subprocesses (and their queue-owner
-   * children) past run teardown.
-   */
-  readonly onPidSpawned?: (pid: number) => void;
-  /**
-   * PID unregistration callback paired with `onPidSpawned`. Adapters call this
-   * when a previously-registered acpx subprocess exits naturally so the run's
-   * PidRegistry does not accumulate dead PIDs (which on Ctrl+C would otherwise
-   * be re-killed against recycled, unrelated processes).
-   */
-  readonly onPidExited?: (pid: number) => void;
   close(): Promise<void>;
 }
 
@@ -100,17 +87,10 @@ export interface CreateRuntimeOptions {
    */
   featureName?: string;
   /**
-   * PID registration callback. Threaded into complete-path adapter calls via
-   * `callOp` so plan/decompose/etc. acpx invocations are tracked by the run's
-   * PidRegistry. Run-path callers (execution stage, cli/plan) wire their own
-   * callback directly into `AgentRunOptions` and do not depend on this field.
+   * Pre-built PidRegistry. When absent, createRuntime constructs a default
+   * PidRegistry(workdir). Supply one in tests to control lifecycle.
    */
-  onPidSpawned?: (pid: number) => void;
-  /**
-   * PID unregistration callback paired with `onPidSpawned`. Threaded the same
-   * way; adapters call it when the registered acpx subprocess exits naturally.
-   */
-  onPidExited?: (pid: number) => void;
+  pidRegistry?: PidRegistry;
 }
 
 export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateRuntimeOptions): NaxRuntime {
@@ -146,6 +126,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
   }
 
   const defaultAgent = config.agent?.default ?? "claude";
+  const pidRegistry = opts?.pidRegistry ?? new PidRegistry(workdir);
 
   let agentManager: IAgentManager | undefined;
   const middleware = MiddlewareChain.from([cancellationMiddleware()]);
@@ -156,6 +137,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
       getAdapter: (name) => agentManager?.getAgent(name),
       dispatchEvents,
       defaultAgent,
+      pidRegistry,
     });
   }
   const agentManagerOpts: CreateAgentManagerOpts = {
@@ -167,9 +149,14 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
   };
   if (opts?.agentManager instanceof AgentManager) {
     opts.agentManager.configureRuntime(agentManagerOpts);
+    opts.agentManager.configureRuntime({ pidRegistry });
     agentManager = opts.agentManager;
   } else {
     agentManager = opts?.agentManager ?? createAgentManager(config, agentManagerOpts);
+  }
+  // Attach pidRegistry to the agentManager for the factory-created path.
+  if (agentManager instanceof AgentManager) {
+    agentManager.configureRuntime({ pidRegistry });
   }
 
   const offLogging = attachLoggingSubscriber(dispatchEvents, runId);
@@ -192,12 +179,11 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     promptAuditor,
     dispatchEvents,
     packages,
+    pidRegistry,
     logger,
     get signal() {
       return controller.signal;
     },
-    onPidSpawned: opts?.onPidSpawned,
-    onPidExited: opts?.onPidExited,
     async close() {
       if (closed) return;
       closed = true;

--- a/src/runtime/session-run-hop.ts
+++ b/src/runtime/session-run-hop.ts
@@ -34,8 +34,6 @@ export function createSessionRunHop(sessionManager: ISessionManager): SessionRun
       featureName: options.featureName,
       storyId: options.storyId,
       signal: options.abortSignal,
-      onPidSpawned: options.onPidSpawned,
-      onPidExited: options.onPidExited,
       onSessionEstablished: options.onSessionEstablished,
     });
 

--- a/src/runtime/session-run-hop.ts
+++ b/src/runtime/session-run-hop.ts
@@ -35,6 +35,7 @@ export function createSessionRunHop(sessionManager: ISessionManager): SessionRun
       storyId: options.storyId,
       signal: options.abortSignal,
       onPidSpawned: options.onPidSpawned,
+      onPidExited: options.onPidExited,
       onSessionEstablished: options.onSessionEstablished,
     });
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -11,6 +11,7 @@ import type { AgentAdapter, AgentResult, SessionHandle, TurnResult } from "../ag
 import type { NaxConfig } from "../config";
 import { resolvePermissions } from "../config/permissions";
 import { NaxError } from "../errors";
+import type { PidRegistry } from "../execution/pid-registry";
 import { getLogger } from "../logger";
 import type { IDispatchEventBus } from "../runtime/dispatch-events";
 import { DispatchEventBus } from "../runtime/dispatch-events";
@@ -69,6 +70,7 @@ export class SessionManager implements ISessionManager {
   private _config: NaxConfig | undefined;
   private _dispatchEvents: IDispatchEventBus;
   private _defaultAgent: string;
+  private _pidRegistry: PidRegistry | undefined;
 
   constructor(opts?: {
     getAdapter?: (name: string) => AgentAdapter | undefined;
@@ -87,11 +89,13 @@ export class SessionManager implements ISessionManager {
     config?: NaxConfig;
     dispatchEvents?: IDispatchEventBus;
     defaultAgent?: string;
+    pidRegistry?: PidRegistry;
   }): void {
     if (opts.getAdapter) this._getAdapter = opts.getAdapter;
     if (opts.config) this._config = opts.config;
     if (opts.dispatchEvents) this._dispatchEvents = opts.dispatchEvents;
     if (opts.defaultAgent) this._defaultAgent = opts.defaultAgent;
+    if (opts.pidRegistry) this._pidRegistry = opts.pidRegistry;
   }
 
   /**
@@ -382,8 +386,8 @@ export class SessionManager implements ISessionManager {
       resolvedPermissions,
       modelDef: opts.modelDef,
       timeoutSeconds: opts.timeoutSeconds,
-      onPidSpawned: opts.onPidSpawned,
-      onPidExited: opts.onPidExited,
+      onPidSpawned: this._pidRegistry ? (pid) => this._pidRegistry?.register(pid) : undefined,
+      onPidExited: this._pidRegistry ? (pid) => this._pidRegistry?.unregister(pid) : undefined,
       onSessionEstablished: opts.onSessionEstablished,
       signal: opts.signal,
       resume,

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -383,6 +383,7 @@ export class SessionManager implements ISessionManager {
       modelDef: opts.modelDef,
       timeoutSeconds: opts.timeoutSeconds,
       onPidSpawned: opts.onPidSpawned,
+      onPidExited: opts.onPidExited,
       onSessionEstablished: opts.onSessionEstablished,
       signal: opts.signal,
       resume,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -179,10 +179,6 @@ export interface OpenSessionRequest {
   storyId?: string;
   /** Abort signal forwarded to the adapter. */
   signal?: AbortSignal;
-  /** PID registration callback forwarded to the adapter. */
-  onPidSpawned?: (pid: number) => void;
-  /** PID unregistration callback forwarded to the adapter — pairs with onPidSpawned. */
-  onPidExited?: (pid: number) => void;
   /** Eager protocol-id callback forwarded to the adapter. */
   onSessionEstablished?: (protocolIds: ProtocolIds, sessionName: string) => void;
 }

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -181,6 +181,8 @@ export interface OpenSessionRequest {
   signal?: AbortSignal;
   /** PID registration callback forwarded to the adapter. */
   onPidSpawned?: (pid: number) => void;
+  /** PID unregistration callback forwarded to the adapter — pairs with onPidSpawned. */
+  onPidExited?: (pid: number) => void;
   /** Eager protocol-id callback forwarded to the adapter. */
   onSessionEstablished?: (protocolIds: ProtocolIds, sessionName: string) => void;
 }

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -344,6 +344,7 @@ async function runRectificationLoop(
             storyId: story.id,
             signal: runtime.signal,
             onPidSpawned: runtime.onPidSpawned,
+            onPidExited: runtime.onPidExited,
           });
         }
         // ADR-020 single-emission invariant: each runAsSession emits one

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -343,8 +343,6 @@ async function runRectificationLoop(
             featureName,
             storyId: story.id,
             signal: runtime.signal,
-            onPidSpawned: runtime.onPidSpawned,
-            onPidExited: runtime.onPidExited,
           });
         }
         // ADR-020 single-emission invariant: each runAsSession emits one

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -326,6 +326,7 @@ export async function runRectificationLoop(
             storyId: story.id,
             signal: runtime.signal,
             onPidSpawned: runtime.onPidSpawned,
+            onPidExited: runtime.onPidExited,
           });
         }
         // ADR-020 single-emission invariant: each runAsSession emits one

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -325,8 +325,6 @@ export async function runRectificationLoop(
             featureName,
             storyId: story.id,
             signal: runtime.signal,
-            onPidSpawned: runtime.onPidSpawned,
-            onPidExited: runtime.onPidExited,
           });
         }
         // ADR-020 single-emission invariant: each runAsSession emits one

--- a/test/unit/agents/acp/spawn-client-pid-callback.test.ts
+++ b/test/unit/agents/acp/spawn-client-pid-callback.test.ts
@@ -63,6 +63,7 @@ describe("SpawnAcpSession — onPidSpawned callback", () => {
       cwd: "/tmp/test",
       model: "claude-haiku",
       timeoutSeconds: 30,
+      promptRetries: 0,
       permissionMode: "approve-all",
       env: {},
       onPidSpawned,
@@ -119,6 +120,76 @@ describe("SpawnAcpSession — onPidSpawned callback", () => {
     const session = makeSession(undefined);
     const result = await session.prompt("do something");
     expect(result.stopReason).toBe("end_turn");
+  });
+
+  test("onPidExited fires after prompt() resolves and pairs with onPidSpawned", async () => {
+    const events: string[] = [];
+    const session = new SpawnAcpSession({
+      agentName: "claude",
+      sessionName: "test-session",
+      cwd: "/tmp/test",
+      model: "claude-haiku",
+      timeoutSeconds: 30,
+      promptRetries: 0,
+      permissionMode: "approve-all",
+      env: {},
+      onPidSpawned: (pid) => events.push(`spawn:${pid}`),
+      onPidExited: (pid) => events.push(`exit:${pid}`),
+    });
+
+    await session.prompt("do something");
+
+    expect(events).toEqual([`spawn:${FIXED_PID}`, `exit:${FIXED_PID}`]);
+  });
+
+  test("onPidExited fires exactly once even when prompt() throws", async () => {
+    // Make the spawned proc fail with a non-zero exit
+    _spawnClientDeps.spawn = mock(() => ({
+      ...makeSpawnResult(1, ""),
+      pid: FIXED_PID,
+    }));
+
+    const exits: number[] = [];
+    const session = new SpawnAcpSession({
+      agentName: "claude",
+      sessionName: "test-session",
+      cwd: "/tmp/test",
+      model: "claude-haiku",
+      timeoutSeconds: 30,
+      promptRetries: 0,
+      permissionMode: "approve-all",
+      env: {},
+      onPidExited: (pid) => exits.push(pid),
+    });
+
+    // prompt() with non-zero exit returns an error response (doesn't throw),
+    // but we still expect the exit callback to fire exactly once.
+    await session.prompt("test");
+    expect(exits).toEqual([FIXED_PID]);
+  });
+
+  test("onPidExited tolerates a throwing callback without breaking prompt()", async () => {
+    let exitCalls = 0;
+    const session = new SpawnAcpSession({
+      agentName: "claude",
+      sessionName: "test-session",
+      cwd: "/tmp/test",
+      model: "claude-haiku",
+      timeoutSeconds: 30,
+      promptRetries: 0,
+      permissionMode: "approve-all",
+      env: {},
+      onPidExited: () => {
+        exitCalls++;
+        throw new Error("registry write failed");
+      },
+    });
+
+    // Even if onPidExited throws, prompt() must still resolve normally —
+    // unregistration is best-effort.
+    const result = await session.prompt("do something");
+    expect(result.stopReason).toBe("end_turn");
+    expect(exitCalls).toBe(1);
   });
 });
 

--- a/test/unit/agents/acp/spawn-client-pid-callback.test.ts
+++ b/test/unit/agents/acp/spawn-client-pid-callback.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for SpawnAcpSession / SpawnAcpClient — ADR-013 Phase 3
  *
- * Phase 3 replaces AgentRunOptions.pidRegistry with onPidSpawned?: (pid: number) => void.
- * The adapter fires the callback immediately after spawning, before awaiting the process.
+ * The adapter fires onPidSpawned immediately after spawning, before awaiting the process.
+ * Callbacks are injected by AgentManager/SessionManager from the runtime PidRegistry.
  *
  * Covered:
  *   - onPidSpawned fires when SpawnAcpSession.prompt() spawns a process

--- a/test/unit/agents/manager-complete.test.ts
+++ b/test/unit/agents/manager-complete.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 import { AgentManager } from "../../../src/agents/manager";
 import type { AgentRegistry } from "../../../src/agents/registry";
+import type { CompleteOptions } from "../../../src/agents/types";
+import { PidRegistry } from "../../../src/execution/pid-registry";
 import { makeNaxConfig } from "../../helpers";
 
 const availFailure = {
@@ -42,6 +44,61 @@ function makeRegistry(
     },
   } as unknown as AgentRegistry;
 }
+
+describe("AgentManager PID lifecycle — configureRuntime", () => {
+  test("attaches onPidSpawned and onPidExited to adapter.complete when pidRegistry is configured", async () => {
+    let capturedOptions: CompleteOptions | undefined;
+    const registry = {
+      getAgent: () => ({
+        complete: mock(async (_prompt: string, opts: CompleteOptions) => {
+          capturedOptions = opts;
+          return { output: "ok", costUsd: 0, source: "exact" as const };
+        }),
+      }),
+    } as unknown as AgentRegistry;
+
+    const m = new AgentManager(makeNaxConfig(), registry);
+    const pidRegistry = new PidRegistry("/tmp/test-pid-manager");
+    const registerSpy = mock((pid: number) => pidRegistry.register(pid));
+    const unregisterSpy = mock((pid: number) => pidRegistry.unregister(pid));
+    const patchedRegistry = {
+      ...pidRegistry,
+      register: registerSpy,
+      unregister: unregisterSpy,
+    } as unknown as PidRegistry;
+
+    m.configureRuntime({ pidRegistry: patchedRegistry });
+
+    await m.completeWithFallback("prompt", { config: makeNaxConfig() } as never);
+
+    expect(capturedOptions?.onPidSpawned).toBeDefined();
+    expect(capturedOptions?.onPidExited).toBeDefined();
+
+    capturedOptions?.onPidSpawned?.(99);
+    expect(registerSpy).toHaveBeenCalledWith(99);
+
+    capturedOptions?.onPidExited?.(99);
+    expect(unregisterSpy).toHaveBeenCalledWith(99);
+  });
+
+  test("does not attach lifecycle when no pidRegistry is configured", async () => {
+    let capturedOptions: CompleteOptions | undefined;
+    const registry = {
+      getAgent: () => ({
+        complete: mock(async (_prompt: string, opts: CompleteOptions) => {
+          capturedOptions = opts;
+          return { output: "ok", costUsd: 0, source: "exact" as const };
+        }),
+      }),
+    } as unknown as AgentRegistry;
+
+    const m = new AgentManager(makeNaxConfig(), registry);
+    await m.completeWithFallback("prompt", { config: makeNaxConfig() } as never);
+
+    expect(capturedOptions?.onPidSpawned).toBeUndefined();
+    expect(capturedOptions?.onPidExited).toBeUndefined();
+  });
+});
 
 describe("AgentManager.completeWithFallback (#567)", () => {
   test("returns output on success", async () => {

--- a/test/unit/execution/pid-registry.test.ts
+++ b/test/unit/execution/pid-registry.test.ts
@@ -130,25 +130,29 @@ describe("PidRegistry", () => {
     expect(registry.getPids()).toEqual([]);
   });
 
-  test("cleanupStale() reads and kills PIDs from previous run", async () => {
-    // Simulate a previous run that left PIDs in the file
+  test("cleanupStale() truncates the PID file without signaling recycled PIDs", async () => {
+    // Simulate a previous run that left PIDs in the file. We deliberately
+    // include `1` (init/systemd on Linux) — under the prior `kill -TERM -<pid>`
+    // path this would have sent SIGTERM to PGID 1 / "all processes", taking
+    // down the user's session. cleanupStale must NOT signal it; it must just
+    // record the leak and clear the file.
     const entry1 = JSON.stringify({
-      pid: 99999, // Non-existent PID
+      pid: 1, // Reserved — must never be signaled
       spawnedAt: new Date().toISOString(),
       workdir: TEST_WORKDIR,
     });
     const entry2 = JSON.stringify({
-      pid: 88888, // Non-existent PID
+      pid: 99999,
       spawnedAt: new Date().toISOString(),
       workdir: TEST_WORKDIR,
     });
     await Bun.write(PID_FILE, `${entry1}\n${entry2}\n`);
 
-    // Create new registry and cleanup stale PIDs
     const registry = new PidRegistry(TEST_WORKDIR);
     await registry.cleanupStale();
 
-    // Check file is cleared
+    // File is cleared, but no signaling occurred (verified by the absence of a
+    // delivered SIGTERM — implicit: this test process is still alive).
     const content = await Bun.file(PID_FILE).text();
     expect(content.trim()).toBe("");
   });
@@ -189,25 +193,31 @@ describe("PidRegistry", () => {
     expect(content.trim()).toBe("");
   });
 
-  test("platform-specific kill command: Linux uses process groups", async () => {
-    const registry = new PidRegistry(TEST_WORKDIR, "linux");
+  test("killAll() signals each PID directly, never as a process group", async () => {
+    // Single-PID signaling (no leading `-`) is the safety property. Both
+    // platforms now go through the same code path; the second constructor arg
+    // is preserved only for backward compat with prior call sites and is
+    // intentionally a no-op.
+    const linuxRegistry = new PidRegistry(TEST_WORKDIR, "linux");
+    await linuxRegistry.register(99999);
+    await linuxRegistry.killAll();
+    expect(linuxRegistry.getPids()).toEqual([]);
 
-    // Register a non-existent PID
-    await registry.register(99999);
-
-    // Should not throw (process doesn't exist, but kill command should be correct)
-    await registry.killAll();
-
-    expect(registry.getPids()).toEqual([]);
+    const darwinRegistry = new PidRegistry(TEST_WORKDIR, "darwin");
+    await darwinRegistry.register(99998);
+    await darwinRegistry.killAll();
+    expect(darwinRegistry.getPids()).toEqual([]);
   });
 
-  test("platform-specific kill command: macOS uses direct PID", async () => {
-    const registry = new PidRegistry(TEST_WORKDIR, "darwin");
+  test("killAll() refuses to signal pid <= 1 (kill 0 = caller's group, kill 1 = init, kill -1 = all)", async () => {
+    const registry = new PidRegistry(TEST_WORKDIR);
 
-    // Register a non-existent PID
-    await registry.register(99999);
-
-    // Should not throw (process doesn't exist, but kill command should be correct)
+    // These would have been catastrophic under the prior process-group code
+    // path. We assert they are silently dropped — and crucially, this test
+    // process surviving the call is itself the assertion.
+    await registry.register(0);
+    await registry.register(1);
+    await registry.register(-5);
     await registry.killAll();
 
     expect(registry.getPids()).toEqual([]);

--- a/test/unit/runtime/runtime.test.ts
+++ b/test/unit/runtime/runtime.test.ts
@@ -13,6 +13,7 @@ describe("createRuntime", () => {
     expect(rt.costAggregator).toBeDefined();
     expect(rt.promptAuditor).toBeDefined();
     expect(rt.signal).toBeDefined();
+    expect(rt.pidRegistry).toBeDefined();
   });
 
   test("packages.repo() returns root-equivalent view", () => {

--- a/test/unit/session/manager-pid-lifecycle.test.ts
+++ b/test/unit/session/manager-pid-lifecycle.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for SessionManager automatic PID lifecycle attachment.
+ * Verifies that configureRuntime({ pidRegistry }) causes openSession to
+ * attach onPidSpawned/onPidExited to the adapter automatically.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { PidRegistry } from "../../../src/execution/pid-registry";
+import { SessionManager, _sessionManagerDeps } from "../../../src/session/manager";
+import { makeAgentAdapter, makeNaxConfig } from "../../helpers";
+
+function makeRegistry(workdir = "/tmp/test-pid-session"): PidRegistry {
+  return new PidRegistry(workdir);
+}
+
+beforeEach(() => {
+  _sessionManagerDeps.writeDescriptor = async () => {};
+});
+
+describe("SessionManager PID lifecycle — configureRuntime", () => {
+  test("attaches onPidSpawned and onPidExited when pidRegistry is configured", async () => {
+    const adapter = makeAgentAdapter();
+    let capturedOnPidSpawned: ((pid: number) => void) | undefined;
+    let capturedOnPidExited: ((pid: number) => void) | undefined;
+
+    adapter.openSession = mock(async (_name, opts) => {
+      capturedOnPidSpawned = opts?.onPidSpawned;
+      capturedOnPidExited = opts?.onPidExited;
+      return { id: "mock-session", agentName: "mock" };
+    });
+
+    const registry = makeRegistry();
+    const registerSpy = mock((pid: number) => registry.register(pid));
+    const unregisterSpy = mock((pid: number) => registry.unregister(pid));
+    const patchedRegistry = {
+      ...registry,
+      register: registerSpy,
+      unregister: unregisterSpy,
+    } as unknown as PidRegistry;
+
+    const sm = new SessionManager({ getAdapter: () => adapter });
+    sm.configureRuntime({
+      config: makeNaxConfig(),
+      pidRegistry: patchedRegistry,
+    });
+
+    const modelDef = { model: "claude-3-5-sonnet-20241022", provider: "anthropic" } as never;
+    await sm.openSession("test-session", {
+      agentName: "mock",
+      workdir: "/tmp",
+      pipelineStage: "run",
+      modelDef,
+      timeoutSeconds: 30,
+      role: "main",
+      storyId: "s-001",
+      featureName: "test",
+    });
+
+    expect(capturedOnPidSpawned).toBeDefined();
+    expect(capturedOnPidExited).toBeDefined();
+
+    capturedOnPidSpawned!(42);
+    expect(registerSpy).toHaveBeenCalledWith(42);
+
+    capturedOnPidExited!(42);
+    expect(unregisterSpy).toHaveBeenCalledWith(42);
+  });
+
+  test("passes undefined callbacks when no pidRegistry is configured", async () => {
+    const adapter = makeAgentAdapter();
+    let capturedOnPidSpawned: unknown = "NOT_SET";
+    let capturedOnPidExited: unknown = "NOT_SET";
+
+    adapter.openSession = mock(async (_name, opts) => {
+      capturedOnPidSpawned = opts?.onPidSpawned;
+      capturedOnPidExited = opts?.onPidExited;
+      return { id: "mock-session", agentName: "mock" };
+    });
+
+    const sm = new SessionManager({ getAdapter: () => adapter });
+    sm.configureRuntime({ config: makeNaxConfig() });
+
+    const modelDef = { model: "claude-3-5-sonnet-20241022", provider: "anthropic" } as never;
+    await sm.openSession("test-session-no-pid", {
+      agentName: "mock",
+      workdir: "/tmp",
+      pipelineStage: "run",
+      modelDef,
+      timeoutSeconds: 30,
+      role: "main",
+      storyId: "s-002",
+      featureName: "test",
+    });
+
+    expect(capturedOnPidSpawned).toBeUndefined();
+    expect(capturedOnPidExited).toBeUndefined();
+  });
+
+});


### PR DESCRIPTION
## Summary

- **`NaxRuntime` is now the single owner of `PidRegistry`** — constructed once in `createRuntime()`, exposed as `runtime.pidRegistry`. No more caller-side threading of `onPidSpawned`/`onPidExited` through every pipeline stage and executor.
- **`SessionManager` auto-attaches** `onPidSpawned`/`onPidExited` to every `adapter.openSession` call when a `pidRegistry` is configured via `configureRuntime({ pidRegistry })`.
- **`AgentManager` auto-attaches** the same callbacks to the single `adapter.complete` call site in `completeWithFallback` when a `pidRegistry` is configured.
- Eliminates the previous bug class where a caller could pass `onPidSpawned` without `onPidExited` (or vice versa), leaving PIDs stuck in the registry forever.

## What changed

**New ownership model:**
- `createRuntime()` constructs `new PidRegistry(workdir)` (or accepts an injected one via `opts.pidRegistry` for tests)
- `sessionManager.configureRuntime({ pidRegistry })` and `agentManager.configureRuntime({ pidRegistry })` wire the callbacks at the primitive call sites
- All intermediate threading removed: pipeline stages, executors, ops, `session-run-hop.ts`

**Removed from call sites:** `onPidSpawned`/`onPidExited` props stripped from `PlanOptions`, `AgentRunOptions` (public surface), `OpenSessionInternalOpts`, `RunSetupResult`, `RunnerSetupResult`, `PipelineContext`, `ExecutorContext`, `RunExecutionContext`, `ParallelCoordinator`

**Tests added:**
- `test/unit/session/manager-pid-lifecycle.test.ts` — verifies `SessionManager` auto-attachment
- `test/unit/agents/manager-complete.test.ts` — verifies `AgentManager` auto-attachment (new describe block)
- `test/unit/runtime/runtime.test.ts` — added `expect(rt.pidRegistry).toBeDefined()`

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 1193 pass, 0 fail across 104 files
- [x] Grep confirms: `onPidSpawned` only in adapter primitives, `CompleteOptions`/`OpenSessionOpts` type definitions, `AgentManager.completeWithFallback`, `SessionManager.openSession`, and unit tests
- [x] `new PidRegistry` only in `src/runtime/index.ts` (single allowed construction site)