### PR TITLE
fix(tdd): remove unsound file-modification filter from full-suite gate

### DIFF
--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -253,9 +253,10 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     };
   }
 
-  // Full-Suite Gate (v0.11 Rectification)
-  // Pass initialRef so the gate can use git-diff to suppress pre-existing failures
-  // in files the story never touched (BUG-TC-001).
+  // Full-Suite Gate (v0.11 Rectification).
+  // Baseline must be green entering the run; the gate treats any post-implementer
+  // failure as story-caused (the file-modification filter from BUG-TC-001 was
+  // removed — see rectification-gate.ts header for the rationale).
   const implementerBinding = getTddSessionBinding?.("implementer");
   const { cost: fullSuiteGateCost, fullSuiteGatePassed } = await runFullSuiteGate(
     story,
@@ -267,7 +268,6 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     logger,
     featureName,
     projectDir,
-    initialRef,
     implementerBinding?.sessionManager,
     implementerBinding?.sessionId,
   );

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -13,12 +13,10 @@ import { type rectificationGateConfigSelector, resolveModelForAgent } from "../c
 import type { getLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
-import type { FailureRecord } from "../prompts";
 import { resolveQualityTestCommands } from "../quality/command-resolver";
 import { formatSessionName } from "../session/naming";
 import { autoCommitIfDirty, captureGitRef } from "../utils/git";
 import {
-  type RectificationState,
   executeWithTimeout as _executeWithTimeout,
   parseTestOutput as _parseTestOutput,
   shouldRetryRectification as _shouldRetryRectification,
@@ -59,31 +57,15 @@ export const _rectificationGateDeps = {
 };
 
 /**
- * Return the set of files changed since `fromRef` via `git diff --name-only`.
- * Used to infer which failures the story is responsible for (BUG-TC-001).
- */
-async function getStoryChangedFiles(workdir: string, fromRef: string): Promise<ReadonlySet<string>> {
-  const result = await _rectificationGateDeps.executeWithTimeout(
-    `git diff --name-only --relative ${fromRef} HEAD`,
-    15,
-    undefined,
-    { cwd: workdir },
-  );
-  if (!result.output) return new Set();
-  return new Set(
-    result.output
-      .split("\n")
-      .map((l) => l.trim())
-      .filter(Boolean),
-  );
-}
-
-/**
  * Run full test suite gate before verifier session (v0.11 Rectification).
  *
- * @param storyFromRef - git ref captured before the story started (initialRef).
- *   When provided, failures in test files the story never touched are suppressed
- *   to prevent pre-existing failures from consuming rectification attempts (BUG-TC-001).
+ * Pre-condition: the baseline test suite is green at the start of the run.
+ * Any failure observed here is treated as story-caused and routed to the
+ * rectification loop. The previous file-modification-based filter (BUG-TC-001 /
+ * PR #656) silently suppressed real regressions whenever a story changed source
+ * code that broke a sibling spec it didn't author (e.g. editing rag.service.ts
+ * breaking rag.service.spec.ts), so it has been removed. The deferred regression
+ * gate in execution/lifecycle/run-regression.ts is the run-level safety net.
  */
 export async function runFullSuiteGate(
   story: UserStory,
@@ -95,7 +77,6 @@ export async function runFullSuiteGate(
   logger: ReturnType<typeof getLogger>,
   featureName?: string,
   projectDir?: string,
-  storyFromRef?: string,
   sessionManager?: import("../session").ISessionManager,
   sessionId?: string,
   runtime?: import("../runtime").NaxRuntime,
@@ -142,43 +123,6 @@ export async function runFullSuiteGate(
         return { passed: true, cost: 0, fullSuiteGatePassed: false };
       }
 
-      // Filter out failures in files the story never touched (pre-existing pollution).
-      // Uses git diff since storyFromRef to identify story-owned files.
-      let filteredFailures = testSummary.failures;
-      if (storyFromRef) {
-        const storyFiles = await getStoryChangedFiles(workdir, storyFromRef);
-        if (storyFiles.size > 0) {
-          filteredFailures = testSummary.failures.filter((f) => storyFiles.has(f.file));
-        }
-      }
-      const wasFiltered = filteredFailures.length < testSummary.failures.length;
-
-      if (wasFiltered && filteredFailures.length === 0) {
-        const uniqueSuppressedFiles = [...new Set(testSummary.failures.map((f) => f.file))];
-        logger.info("tdd", "Full suite gate: all failures are pre-existing — accepting as pass", {
-          storyId: story.id,
-          suppressedFileCount: uniqueSuppressedFiles.length,
-          suppressedTestCount: testSummary.failures.length,
-          suppressedFiles: uniqueSuppressedFiles,
-        });
-        return { passed: true, cost: 0, fullSuiteGatePassed: true };
-      }
-
-      if (wasFiltered) {
-        logger.info("tdd", "Full suite gate: suppressed pre-existing failures", {
-          storyId: story.id,
-          total: testSummary.failures.length,
-          suppressed: testSummary.failures.length - filteredFailures.length,
-          remaining: filteredFailures.length,
-        });
-      }
-
-      // Preserve the original failed count when no structured failures were available to filter
-      const filteredSummary = {
-        ...testSummary,
-        failures: filteredFailures,
-        failed: wasFiltered ? filteredFailures.length : testSummary.failed,
-      };
       return await runRectificationLoop(
         story,
         config,
@@ -187,7 +131,7 @@ export async function runFullSuiteGate(
         implementerTier,
         lite,
         logger,
-        filteredSummary,
+        testSummary,
         rectificationConfig,
         effectiveTestCmd,
         fullSuiteTimeout,


### PR DESCRIPTION
## Summary

The TDD full-suite rectification gate filtered failures by *"did the story modify the test file?"* (introduced in #656 to replace the original pre-run baseline approach, then path-fixed in #665). The heuristic is fundamentally unsound: stories typically change source files (e.g. `rag.service.ts`), and the corresponding sibling specs (`rag.service.spec.ts`) live in different files the story never touches. Those genuine regressions were silently classified as "pre-existing" and the gate returned `passed`.

Observed in koda `US-001` (`memory-phase4-graph-code-intelligence`, 2026-04-30T03-17-55.jsonl): the implementer rewrote 258 lines of `apps/api/src/rag/rag.service.ts` and changed `rag.controller.ts`; the gate suppressed 10 failures across `src/rag/rag.service.spec.ts` and `test/e2e/api-endpoint/endpoint.e2e.spec.ts` as "pre-existing". Baseline was confirmed green before the run, so those were real regressions caused by the story.

## Why removal, not replacement

- File-modification ≠ test ownership. There is no cheap heuristic that distinguishes "failure caused by source change in this story" from "failure that was already there" without re-running the suite at the baseline ref.
- PR #656 chose the heuristic only to keep `testRunCount` mocks working — not because it was the correct design.
- The deferred regression gate in [`src/execution/lifecycle/run-regression.ts`](src/execution/lifecycle/run-regression.ts) already runs the full suite once after all stories complete and attributes regressions back to stories — it is the correct run-level safety net.
- Under the green-baseline contract (which we already operate under), any failure observed by the per-story gate is by definition story-caused.

## Changes

- Delete `getStoryChangedFiles` and the entire suppression block in [`src/tdd/rectification-gate.ts`](src/tdd/rectification-gate.ts).
- Drop the `storyFromRef` parameter from `runFullSuiteGate`; stop passing `initialRef` from [`src/tdd/orchestrator.ts`](src/tdd/orchestrator.ts) (`initialRef` is still captured for rollback).
- Remove two now-unused imports (`FailureRecord`, `RectificationState`) the linter flagged in the modified file.
- Update header comment on `runFullSuiteGate` to record the green-baseline contract and point at the deferred regression gate as the run-level safety net.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run test` scoped to `test/unit/tdd/` — 24/24 pass
- [x] Scoped runs across `test/integration/tdd/`, `test/integration/agents/acp/tdd-flow-rectification.test.ts`, `test/unit/metrics/tracker-full-suite-gate.test.ts`, `test/unit/tdd/rectification-gate-session.test.ts` — 77/77 pass
- [ ] dogfood on a koda story whose implementer modifies a source file with a sibling spec — verify the gate now routes the failure to the rectification loop instead of returning `passed: true`

## Refs

- Replaces the heuristic introduced in #656
- Follow-up to the path-mismatch fix in #665 (the path-mismatch fix made the filter actually fire — which then exposed this design-level issue)
