### PR TITLE
fix(review): tighten semantic substantiator + emit structured downgrade event (#826)

### DIFF
--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -27,6 +27,7 @@ For each acceptance criterion, verify the current codebase implements it correct
 - Do NOT flag something as missing based solely on its absence from the diff — it may already exist in the codebase. Check the actual file first.
 - If you cannot verify a claim even after checking, use "unverifiable" severity instead of "error".
 - Every "error" finding must include verifiedBy evidence from the current codebase. If you cannot provide verifiedBy, downgrade the finding to "unverifiable".
+- The \`verifiedBy.observed\` field MUST be a **verbatim** 1-3 line code excerpt copy-pasted from the file — not a description. Paste the actual source lines (or a substring of them) that prove your claim. A description like "function X does not check Y" is not a verifiable observation; quote the lines that demonstrate the omission instead. If you cannot quote an exact excerpt that proves your point, downgrade the finding to "unverifiable".
 
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)
@@ -50,7 +51,7 @@ const SEMANTIC_OUTPUT_SCHEMA = `Respond with JSON only — no explanation text b
         "command": "command used to inspect the current codebase",
         "file": "path/to/file",
         "line": 42,
-        "observed": "specific code fact observed"
+        "observed": "verbatim 1-3 line code excerpt copy-pasted from the file (not a description)"
       }
     }
   ]

--- a/src/review/semantic-evidence.ts
+++ b/src/review/semantic-evidence.ts
@@ -4,6 +4,23 @@ import type { LLMFinding } from "./semantic-helpers";
 import type { SemanticReviewConfig } from "./types";
 
 const OBSERVED_PREVIEW_CHARS = 160;
+const ISSUE_PREVIEW_CHARS = 200;
+
+/**
+ * Stable telemetry marker for the substring-substantiation downgrade.
+ * Surfaced on every "Downgraded unsubstantiated semantic error finding" log
+ * line so audit / dashboards can measure how often this filter suppresses
+ * findings (#826).
+ */
+export const SEMANTIC_FINDING_DOWNGRADED_EVENT = "review.semantic.finding.downgraded";
+
+/**
+ * Injectable deps so tests can capture log calls without poking the logger
+ * singleton. Production code should never override this.
+ */
+export const _evidenceDeps = {
+  getLogger: getSafeLogger,
+};
 
 export async function substantiateSemanticEvidence(
   findings: LLMFinding[],
@@ -25,10 +42,12 @@ async function substantiateFinding(finding: LLMFinding, workdir: string, storyId
   const contents = await readSafeFile(workdir, file);
   if (contents !== null && normalizedIncludes(contents, observed)) return finding;
 
-  getSafeLogger()?.warn("review", "Downgraded unsubstantiated semantic error finding", {
+  _evidenceDeps.getLogger()?.warn("review", "Downgraded unsubstantiated semantic error finding", {
     storyId,
+    event: SEMANTIC_FINDING_DOWNGRADED_EVENT,
     file,
     line: finding.verifiedBy?.line ?? finding.line,
+    issue: finding.issue?.slice(0, ISSUE_PREVIEW_CHARS),
     observed: observed.slice(0, OBSERVED_PREVIEW_CHARS),
   });
 

--- a/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
@@ -30,6 +30,7 @@ For each acceptance criterion, verify the current codebase implements it correct
 - Do NOT flag something as missing based solely on its absence from the diff — it may already exist in the codebase. Check the actual file first.
 - If you cannot verify a claim even after checking, use "unverifiable" severity instead of "error".
 - Every "error" finding must include verifiedBy evidence from the current codebase. If you cannot provide verifiedBy, downgrade the finding to "unverifiable".
+- The \`verifiedBy.observed\` field MUST be a **verbatim** 1-3 line code excerpt copy-pasted from the file — not a description. Paste the actual source lines (or a substring of them) that prove your claim. A description like "function X does not check Y" is not a verifiable observation; quote the lines that demonstrate the omission instead. If you cannot quote an exact excerpt that proves your point, downgrade the finding to "unverifiable".
 
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)
@@ -52,7 +53,7 @@ Respond with JSON only — no explanation text before or after:
         "command": "command used to inspect the current codebase",
         "file": "path/to/file",
         "line": 42,
-        "observed": "specific code fact observed"
+        "observed": "verbatim 1-3 line code excerpt copy-pasted from the file (not a description)"
       }
     }
   ]
@@ -97,6 +98,7 @@ For each acceptance criterion, verify the current codebase implements it correct
 - Do NOT flag something as missing based solely on its absence from the diff — it may already exist in the codebase. Check the actual file first.
 - If you cannot verify a claim even after checking, use "unverifiable" severity instead of "error".
 - Every "error" finding must include verifiedBy evidence from the current codebase. If you cannot provide verifiedBy, downgrade the finding to "unverifiable".
+- The \`verifiedBy.observed\` field MUST be a **verbatim** 1-3 line code excerpt copy-pasted from the file — not a description. Paste the actual source lines (or a substring of them) that prove your claim. A description like "function X does not check Y" is not a verifiable observation; quote the lines that demonstrate the omission instead. If you cannot quote an exact excerpt that proves your point, downgrade the finding to "unverifiable".
 
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)
@@ -119,7 +121,7 @@ Respond with JSON only — no explanation text before or after:
         "command": "command used to inspect the current codebase",
         "file": "path/to/file",
         "line": 42,
-        "observed": "specific code fact observed"
+        "observed": "verbatim 1-3 line code excerpt copy-pasted from the file (not a description)"
       }
     }
   ]

--- a/test/unit/prompts/review-builder.test.ts
+++ b/test/unit/prompts/review-builder.test.ts
@@ -122,6 +122,15 @@ describe("ReviewPromptBuilder.buildSemanticReviewPrompt()", () => {
       const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toContain("Do NOT flag: style issues");
     });
+
+    // #826 — observed must be a verbatim excerpt, not a description, so the
+    // substring substantiator in semantic-evidence.ts can verify it on disk.
+    test("requires verifiedBy.observed to be a verbatim code excerpt", () => {
+      const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
+      expect(result).toContain("verbatim");
+      expect(result).toMatch(/observed.*(verbatim|copy-pasted|exact)/i);
+      expect(result).toContain("not a description");
+    });
   });
 });
 

--- a/test/unit/review/semantic-evidence.test.ts
+++ b/test/unit/review/semantic-evidence.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for substantiateSemanticEvidence (#826).
+ *
+ * Pinpoints the false-negative behaviour exposed by the
+ * memory-phase4-graph-code-intelligence US-001 run: a real AC violation was
+ * flagged but silently downgraded because the model phrased `verifiedBy.observed`
+ * as a description rather than a verbatim code excerpt.
+ *
+ * Tests cover:
+ * - Verbatim observed found on disk → preserved at severity "error"
+ * - Whitespace + quote normalization still works for verbatim excerpts
+ * - Prose-only observed (no substring match) → downgraded to "unverifiable"
+ * - Downgrade emits a structured event with a stable marker + issue snippet
+ *   so telemetry can correlate the suppression to the original finding
+ * - Non-error findings pass through unchanged
+ * - Embedded mode is a no-op (only ref mode substantiates)
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { _evidenceDeps, substantiateSemanticEvidence } from "../../../src/review/semantic-evidence";
+import type { LLMFinding } from "../../../src/review/semantic-helpers";
+import { makeLogger, type MockLogger } from "../../helpers/mock-logger";
+import { withTempDir } from "../../helpers/temp";
+
+const STORY_ID = "US-001";
+
+let logger: MockLogger;
+let origGetLogger: typeof _evidenceDeps.getLogger;
+
+beforeEach(() => {
+  logger = makeLogger();
+  origGetLogger = _evidenceDeps.getLogger;
+  _evidenceDeps.getLogger = () => logger as unknown as ReturnType<typeof _evidenceDeps.getLogger>;
+});
+
+afterEach(() => {
+  _evidenceDeps.getLogger = origGetLogger;
+});
+
+function makeFinding(overrides: Partial<LLMFinding> = {}): LLMFinding {
+  return {
+    severity: "error",
+    file: "src/foo.ts",
+    line: 5,
+    issue: "AC not implemented",
+    suggestion: "Implement it",
+    verifiedBy: {
+      command: "sed -n '1,80p' src/foo.ts",
+      file: "src/foo.ts",
+      line: 5,
+      observed: "export function foo() {}",
+    },
+    ...overrides,
+  };
+}
+
+describe("substantiateSemanticEvidence — ref mode", () => {
+  test("preserves error finding when verbatim observed appears in the file", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "export function foo() {}\n");
+
+      const result = await substantiateSemanticEvidence([makeFinding()], "ref", workdir, STORY_ID);
+
+      expect(result[0].severity).toBe("error");
+      expect(logger.calls.find((c) => c.message.includes("Downgraded"))).toBeUndefined();
+    });
+  });
+
+  test("preserves error finding when observed differs only by whitespace and wrapping quotes", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "const sum  =  a   +   b;\n");
+
+      const finding = makeFinding({
+        verifiedBy: {
+          command: "cat src/foo.ts",
+          file: "src/foo.ts",
+          line: 1,
+          observed: '"const sum = a + b;"',
+        },
+      });
+      const result = await substantiateSemanticEvidence([finding], "ref", workdir, STORY_ID);
+
+      expect(result[0].severity).toBe("error");
+    });
+  });
+
+  test("downgrades error finding when observed is prose, not a verbatim excerpt", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(
+        join(workdir, "src/foo.ts"),
+        "function hasContentChanged(a, b) { return a.label !== b.label; }\n",
+      );
+
+      const finding = makeFinding({
+        line: 1,
+        issue:
+          "hasContentChanged() does NOT check outgoing links, contradicting the AC requirement and its own docstring",
+        verifiedBy: {
+          command: "Read src/foo.ts",
+          file: "src/foo.ts",
+          line: 1,
+          observed:
+            "hasContentChanged only compares label, type, source_file — storedLinkMap is captured but hasContentChanged never receives or checks it.",
+        },
+      });
+      const result = await substantiateSemanticEvidence([finding], "ref", workdir, STORY_ID);
+
+      expect(result[0].severity).toBe("unverifiable");
+    });
+  });
+
+  test("downgrade emits a structured event with stable marker + finding issue snippet", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "function bar() {}\n");
+
+      const finding = makeFinding({
+        line: 109,
+        issue: "hasContentChanged() ignores outgoing links",
+        verifiedBy: {
+          command: "Read src/foo.ts",
+          file: "apps/api/src/rag/rag.service.ts",
+          line: 109,
+          observed: "hasContentChanged only compares label, type, source_file — storedLinkMap captured on line 814",
+        },
+      });
+
+      await substantiateSemanticEvidence([finding], "ref", workdir, STORY_ID);
+
+      const downgradeCall = logger.calls.find((c) => c.message === "Downgraded unsubstantiated semantic error finding");
+      expect(downgradeCall).toBeDefined();
+      expect(downgradeCall?.level).toBe("warn");
+      expect(downgradeCall?.stage).toBe("review");
+      expect(downgradeCall?.data?.event).toBe("review.semantic.finding.downgraded");
+      expect(downgradeCall?.data?.storyId).toBe(STORY_ID);
+      expect(downgradeCall?.data?.file).toBe("apps/api/src/rag/rag.service.ts");
+      expect(downgradeCall?.data?.line).toBe(109);
+      expect(downgradeCall?.data?.issue).toBe("hasContentChanged() ignores outgoing links");
+      expect(typeof downgradeCall?.data?.observed).toBe("string");
+    });
+  });
+
+  test("non-error severities pass through unchanged (no downgrade attempted)", async () => {
+    await withTempDir(async (workdir) => {
+      const findings: LLMFinding[] = [
+        makeFinding({ severity: "warn" }),
+        makeFinding({ severity: "info" }),
+        makeFinding({ severity: "unverifiable" }),
+      ];
+
+      const result = await substantiateSemanticEvidence(findings, "ref", workdir, STORY_ID);
+
+      expect(result.map((f) => f.severity)).toEqual(["warn", "info", "unverifiable"]);
+      expect(logger.calls.find((c) => c.message.includes("Downgraded"))).toBeUndefined();
+    });
+  });
+
+  test("missing or empty verifiedBy.observed leaves error finding unchanged", async () => {
+    await withTempDir(async (workdir) => {
+      const findings: LLMFinding[] = [
+        makeFinding({ verifiedBy: { command: "x", file: "src/foo.ts", line: 1, observed: "" } }),
+        makeFinding({ verifiedBy: undefined }),
+      ];
+
+      const result = await substantiateSemanticEvidence(findings, "ref", workdir, STORY_ID);
+
+      expect(result.every((f) => f.severity === "error")).toBe(true);
+      expect(logger.calls.find((c) => c.message.includes("Downgraded"))).toBeUndefined();
+    });
+  });
+});
+
+describe("substantiateSemanticEvidence — embedded mode", () => {
+  test("does not substantiate (passes findings through unchanged)", async () => {
+    await withTempDir(async (workdir) => {
+      const finding = makeFinding({
+        verifiedBy: {
+          command: "Read",
+          file: "src/foo.ts",
+          line: 1,
+          observed: "this prose would normally be downgraded",
+        },
+      });
+      const result = await substantiateSemanticEvidence([finding], "embedded", workdir, STORY_ID);
+
+      expect(result[0].severity).toBe("error");
+      expect(logger.calls).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #826.

## Summary
- Semantic review's substring-based substantiator silently downgraded real findings whose `verifiedBy.observed` was phrased as prose rather than a verbatim code excerpt. The memory-phase4-graph-code-intelligence US-001 run hit this — a correct AC-5 violation (`hasContentChanged()` ignores outgoing links) was identified by semantic review but downgraded to `unverifiable`, and only caught because adversarial review (which doesn't substantiate) backstopped it.
- **Prompt**: `verifiedBy.observed` is now explicitly required to be a verbatim 1-3 line code excerpt. Descriptions are stated to be unverifiable; schema example updated accordingly.
- **Substantiator**: emits a stable `event: review.semantic.finding.downgraded` marker plus a snippet of the finding's `issue` on every downgrade, so audit / telemetry can measure suppression rate.
- Logger injected via `_evidenceDeps` for testability.

Out of scope (follow-up): re-prompt fallback that asks the model for a verbatim quote before downgrading.

## Test plan
- [x] New unit tests in `test/unit/review/semantic-evidence.test.ts` — 7 cases (verbatim preservation, whitespace+quote normalization, prose downgrade, structured event payload, non-error pass-through, missing observed, embedded-mode no-op)
- [x] New prompt-contract test in `test/unit/prompts/review-builder.test.ts` + snapshot update
- [x] Targeted suite (`test/unit/review/` + `test/unit/prompts/`) — 900 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Pre-commit hooks (cwd, adapter-wrap, dispatch-context) — clean