### PR TITLE
fix(autofix): route adversarial test-gap findings to test-writer (#829)

### DIFF
--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -61,8 +61,14 @@ function splitByStructuredFindings(
     return { testFindings: null, sourceFindings: null };
   }
 
-  const testFs = check.findings.filter((f) => isTestFile(f.file ?? "", testFilePatterns));
-  const sourceFs = check.findings.filter((f) => !isTestFile(f.file ?? "", testFilePatterns));
+  // Issue #829: adversarial `test-gap` findings flag a source-file unit that lacks
+  // a test, so `file` points at the source. The remediation is to create a test
+  // file — implementer scope cannot satisfy that. Route by category for `test-gap`.
+  const isTestScoped = (file: string | undefined, category: string | undefined): boolean =>
+    category === "test-gap" || isTestFile(file ?? "", testFilePatterns);
+
+  const testFs = check.findings.filter((f) => isTestScoped(f.file, f.category));
+  const sourceFs = check.findings.filter((f) => !isTestScoped(f.file, f.category));
 
   const toCheck = (findings: typeof testFs): ReviewCheckResult | null => {
     if (findings.length === 0) return null;

--- a/test/unit/pipeline/stages/autofix-adversarial.test.ts
+++ b/test/unit/pipeline/stages/autofix-adversarial.test.ts
@@ -282,6 +282,53 @@ describe("splitFindingsByScope — structured findings path", () => {
     const { sourceFindings } = splitFindingsByScope(check);
     expect(sourceFindings!.exitCode).toBe(check.exitCode);
   });
+
+  // Issue #829 — `test-gap` findings flag a source-file unit that lacks a test;
+  // the remediation belongs in test-writer scope, not implementer.
+  test("test-gap on source file → routes to testFindings, not sourceFindings", () => {
+    const finding = makeFinding("apps/api/src/rag/rag.service.ts", { category: "test-gap" });
+    const check = makeAdversarialCheck([finding]);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings).not.toBeNull();
+    expect(testFindings!.findings).toHaveLength(1);
+    expect(sourceFindings).toBeNull();
+  });
+
+  test("non-test-gap on source file still routes to sourceFindings", () => {
+    const finding = makeFinding("src/foo.ts", { category: "abandonment" });
+    const check = makeAdversarialCheck([finding]);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings).toBeNull();
+    expect(sourceFindings).not.toBeNull();
+    expect(sourceFindings!.findings).toHaveLength(1);
+  });
+
+  test("mixed test-gap + non-test-gap on source files → split correctly", () => {
+    const findings = [
+      makeFinding("src/foo.ts", { category: "abandonment" }),
+      makeFinding("src/foo.ts", { category: "test-gap" }),
+      makeFinding("src/bar.test.ts", { category: "convention" }),
+    ];
+    const check = makeAdversarialCheck(findings);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(sourceFindings!.findings!.map((f) => f.category)).toEqual(["abandonment"]);
+    expect(testFindings!.findings!.map((f) => f.category)).toEqual(["test-gap", "convention"]);
+  });
+
+  test("test-gap with undefined file routes to testFindings", () => {
+    const finding: ReviewFinding = {
+      ruleId: "r",
+      severity: "error",
+      file: undefined as any,
+      line: 1,
+      message: "m",
+      category: "test-gap",
+    };
+    const check = makeAdversarialCheck([finding]);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings).not.toBeNull();
+    expect(sourceFindings).toBeNull();
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #829.

## Summary

- The adversarial reviewer's `test-gap` category flags new exported source-file units that lack tests, so `finding.file` correctly points at the source. The triage in `splitByStructuredFindings` routed by file alone, sending those findings to the implementer — whose scope forbids creating test files. Result: implementer emits `UNRESOLVED` across rounds and the gap is never filled.
- This PR adds category-aware routing: `category === "test-gap"` is treated as test-writer-scoped regardless of file path. All other categories continue to route by `isTestFile(f.file)`, preserving existing behaviour.

## Changes

- [src/pipeline/stages/autofix-adversarial.ts](src/pipeline/stages/autofix-adversarial.ts) — extend `splitByStructuredFindings` with an `isTestScoped(file, category)` predicate.
- [test/unit/pipeline/stages/autofix-adversarial.test.ts](test/unit/pipeline/stages/autofix-adversarial.test.ts) — 4 new unit tests covering test-gap on source, non-test-gap on source unchanged, mixed split, test-gap with undefined file.

## Test plan

- [x] Targeted unit suite: 47/47 pass via `timeout 30 bun test test/unit/pipeline/stages/autofix-adversarial.test.ts --timeout=5000`
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — no new errors
- [ ] Verify on a real run that adversarial test-gap findings now reach the test-writer session and get fixed
