### PR TITLE
fix: stabilize telegram callback handling and add debug logs

### DIFF
--- a/src/interaction/plugins/telegram.ts
+++ b/src/interaction/plugins/telegram.ts
@@ -6,10 +6,12 @@
  */
 
 import { z } from "zod";
+import { getSafeLogger } from "../../logger";
 import type { InteractionPlugin, InteractionRequest, InteractionResponse } from "../types";
 
 /** Telegram message length limit (4096 max, keep buffer) */
 const MAX_MESSAGE_CHARS = 4000;
+const CALLBACK_API_TIMEOUT_MS = 4000;
 
 /** Zod schema for validating telegram plugin config */
 const TelegramConfigSchema = z.object({
@@ -40,12 +42,20 @@ interface TelegramUpdate {
  */
 export class TelegramInteractionPlugin implements InteractionPlugin {
   name = "telegram";
+  private readonly logger = getSafeLogger();
   private botToken: string | null = null;
   private chatId: string | null = null;
   private pendingMessages = new Map<string, number[]>(); // requestId -> messageId[]
   private lastUpdateId = 0;
   private backoffMs = 1000; // Exponential backoff for getUpdates (starts at 1s)
   private readonly maxBackoffMs = 30000; // Max 30 seconds between retries
+
+  private static readonly INTERACTIVE_REQUEST_TYPES = new Set<InteractionRequest["type"]>([
+    "confirm",
+    "choose",
+    "input",
+    "review",
+  ]);
 
   async init(config: Record<string, unknown>): Promise<void> {
     const cfg = TelegramConfigSchema.parse(config);
@@ -108,8 +118,10 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
         sentIds.push(data.result.message_id);
       }
 
-      // Store ALL message IDs so we can match user replies to any of them
-      this.pendingMessages.set(request.id, sentIds);
+      // Store sent message IDs only for interactive requests that can receive a reply/callback.
+      if (TelegramInteractionPlugin.INTERACTIVE_REQUEST_TYPES.has(request.type)) {
+        this.pendingMessages.set(request.id, sentIds);
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       throw new Error(`Failed to send Telegram message: ${msg}`);
@@ -127,17 +139,40 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
       const updates = await this.getUpdates();
 
       for (const update of updates) {
+        if (update.callback_query) {
+          // Always acknowledge callback queries to prevent Telegram client spinner loops
+          // when users tap stale/mismatched inline buttons.
+          void this.answerCallbackQuery(update.callback_query.id);
+        }
+
         const response = this.parseUpdate(requestId, update);
         if (response) {
-          // Answer callback query if present
           if (update.callback_query) {
-            await this.answerCallbackQuery(update.callback_query.id);
+            this.logger?.debug("interaction", "Telegram callback matched", {
+              requestId,
+              updateId: update.update_id,
+              action: response.action,
+              value: response.value,
+            });
           }
+
+          if (update.callback_query?.message?.message_id !== undefined) {
+            void this.clearInlineKeyboard(update.callback_query.message.message_id);
+          }
+
           // Clean up tracking entry before returning to avoid accumulating stale entries
           this.pendingMessages.delete(requestId);
           // Reset backoff on successful response
           this.backoffMs = 1000;
           return response;
+        }
+
+        if (update.callback_query) {
+          this.logger?.debug("interaction", "Telegram callback ignored (stale/mismatched)", {
+            requestId,
+            updateId: update.update_id,
+            callbackData: update.callback_query.data,
+          });
         }
       }
 
@@ -429,15 +464,50 @@ export class TelegramInteractionPlugin implements InteractionPlugin {
     if (!this.botToken) return;
 
     try {
-      await fetch(`https://api.telegram.org/bot${this.botToken}/answerCallbackQuery`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          callback_query_id: callbackQueryId,
-        }),
-      });
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), CALLBACK_API_TIMEOUT_MS);
+      try {
+        await fetch(`https://api.telegram.org/bot${this.botToken}/answerCallbackQuery`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            callback_query_id: callbackQueryId,
+          }),
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timer);
+      }
     } catch {
       // Non-critical - fire-and-forget, no logging needed
+    }
+  }
+
+  /**
+   * Clear inline keyboard on a handled message so stale callbacks cannot be tapped repeatedly.
+   */
+  private async clearInlineKeyboard(messageId: number): Promise<void> {
+    if (!this.botToken || !this.chatId) return;
+
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), CALLBACK_API_TIMEOUT_MS);
+      try {
+        await fetch(`https://api.telegram.org/bot${this.botToken}/editMessageReplyMarkup`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            chat_id: this.chatId,
+            message_id: messageId,
+            reply_markup: { inline_keyboard: [] },
+          }),
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch {
+      // Non-critical cleanup: response already captured.
     }
   }
 

--- a/test/unit/interaction/interaction-plugins.test.ts
+++ b/test/unit/interaction/interaction-plugins.test.ts
@@ -365,6 +365,149 @@ describe("TelegramInteractionPlugin - send() and poll()", () => {
     expect(response.action).toBe("choose");
     expect(response.value).toBe("option-b");
   });
+
+  test("receive() acknowledges callback queries even when requestId does not match", async () => {
+    const answeredCallbackIds: string[] = [];
+    let resolveOtherAck: (() => void) | null = null;
+    let resolveCurrentAck: (() => void) | null = null;
+    const otherAcked = new Promise<void>((resolve) => {
+      resolveOtherAck = resolve;
+    });
+    const currentAcked = new Promise<void>((resolve) => {
+      resolveCurrentAck = resolve;
+    });
+
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = url.toString();
+
+      if (urlStr.includes("sendMessage")) {
+        return new Response(
+          JSON.stringify({ ok: true, result: { message_id: 12, chat: { id: 99999 } } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (urlStr.includes("getUpdates")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            result: [
+              {
+                update_id: 3,
+                callback_query: {
+                  id: "cq-other",
+                  data: "other-request:approve",
+                  message: { message_id: 12, chat: { id: 99999 } },
+                },
+              },
+              {
+                update_id: 4,
+                callback_query: {
+                  id: "cq-current",
+                  data: "tg-match-1:approve",
+                  message: { message_id: 12, chat: { id: 99999 } },
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (urlStr.includes("answerCallbackQuery")) {
+        const body = JSON.parse((init?.body as string) ?? "{}") as { callback_query_id?: string };
+        if (body.callback_query_id === "cq-other") {
+          answeredCallbackIds.push(body.callback_query_id);
+          resolveOtherAck?.();
+        }
+        if (body.callback_query_id === "cq-current") {
+          answeredCallbackIds.push(body.callback_query_id);
+          resolveCurrentAck?.();
+        }
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+
+      if (urlStr.includes("editMessageReplyMarkup")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
+
+    await plugin.send(makeConfirmRequest("tg-match-1"));
+    const response = await plugin.receive("tg-match-1", 5000);
+    await Promise.all([otherAcked, currentAcked]);
+
+    expect(response.action).toBe("approve");
+    expect(answeredCallbackIds).toContain("cq-other");
+    expect(answeredCallbackIds).toContain("cq-current");
+  });
+
+  test("receive() clears inline keyboard on successful callback response", async () => {
+    const replyMarkupBodies: Array<Record<string, unknown>> = [];
+    let resolveMarkupClear: (() => void) | null = null;
+    const markupCleared = new Promise<void>((resolve) => {
+      resolveMarkupClear = resolve;
+    });
+
+    globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+      const urlStr = url.toString();
+
+      if (urlStr.includes("sendMessage")) {
+        return new Response(
+          JSON.stringify({ ok: true, result: { message_id: 13, chat: { id: 99999 } } }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (urlStr.includes("getUpdates")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            result: [
+              {
+                update_id: 5,
+                callback_query: {
+                  id: "cq-clear",
+                  data: "tg-clear-1:approve",
+                  message: { message_id: 13, chat: { id: 99999 } },
+                },
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (urlStr.includes("answerCallbackQuery")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+
+      if (urlStr.includes("editMessageReplyMarkup")) {
+        const body = JSON.parse((init?.body as string) ?? "{}") as Record<string, unknown>;
+        replyMarkupBodies.push(body);
+        resolveMarkupClear?.();
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+
+      return new Response("not found", { status: 404 });
+    }) as typeof fetch;
+
+    const plugin = new TelegramInteractionPlugin();
+    await plugin.init({ botToken: "bot-abc123", chatId: "99999" });
+
+    await plugin.send(makeConfirmRequest("tg-clear-1"));
+    const response = await plugin.receive("tg-clear-1", 5000);
+    await markupCleared;
+
+    expect(response.action).toBe("approve");
+    expect(replyMarkupBodies).toHaveLength(1);
+    expect(replyMarkupBodies[0].message_id).toBe(13);
+    expect((replyMarkupBodies[0].reply_markup as { inline_keyboard: unknown[] }).inline_keyboard).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- acknowledge all Telegram callback queries (including stale/mismatched) to avoid spinner loops
- clear inline keyboard after successful callback handling to prevent repeated stale taps
- make callback-ack and keyboard-clear calls non-blocking with short timeouts
- add debug logs for matched vs ignored callbacks
- add regression tests for callback acknowledgement and keyboard clear behavior

## Validation
- timeout 60 bun test test/unit/interaction/interaction-plugins.test.ts --timeout=5000
- timeout 60 bun test test/unit/interaction/telegram-timeout.test.ts --timeout=5000
