### PR TITLE
refactor(review): convert runSemanticReview to options bag (#577)

### DIFF
--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -300,23 +300,23 @@ export class ReviewOrchestrator {
 
         logger?.debug("review", "Running semantic + adversarial in parallel", { storyId });
         const [semResult, advResult] = await Promise.all([
-          _orchestratorDeps.runSemanticReview(
+          _orchestratorDeps.runSemanticReview({
             workdir,
             storyGitRef,
-            semanticStory,
-            semanticCfg,
+            story: semanticStory,
+            semanticConfig: semanticCfg,
             agentManager,
             naxConfig,
             featureName,
             resolverSession,
             priorFailures,
-            reviewConfig.blockingThreshold,
+            blockingThreshold: reviewConfig.blockingThreshold,
             featureContextMarkdown,
-            contextBundles?.semantic,
+            contextBundle: contextBundles?.semantic,
             projectDir,
             naxIgnoreIndex,
             runtime,
-          ),
+          }),
           _orchestratorDeps.runAdversarialReview(
             workdir,
             storyGitRef,

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -305,23 +305,23 @@ export async function runReview(
         // excludePatterns omitted — runSemanticReview derives via resolveReviewExcludePatterns (ADR-009)
       };
       const runSemantic = _reviewSemanticDeps.runSemanticReview;
-      const result = await runSemantic(
+      const result = await runSemantic({
         workdir,
         storyGitRef,
-        semanticStory,
-        semanticCfg,
+        story: semanticStory,
+        semanticConfig: semanticCfg,
         agentManager,
         naxConfig,
         featureName,
         resolverSession,
         priorFailures,
-        config.blockingThreshold,
+        blockingThreshold: config.blockingThreshold,
         featureContextMarkdown,
-        contextBundles?.semantic,
+        contextBundle: contextBundles?.semantic,
         projectDir,
         naxIgnoreIndex,
         runtime,
-      );
+      });
       checks.push(result);
       if (!result.success && !firstFailure) {
         firstFailure = `${checkName} failed`;

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -44,26 +44,45 @@ export const _semanticDeps = {
   callOp: _callOp,
 };
 
+export interface RunSemanticReviewOptions {
+  workdir: string;
+  storyGitRef: string | undefined;
+  story: SemanticStory;
+  semanticConfig: SemanticReviewConfig;
+  agentManager: IAgentManager | undefined;
+  naxConfig?: NaxConfig;
+  featureName?: string;
+  resolverSession?: import("./dialogue").ReviewerSession;
+  priorFailures?: Array<{ stage: string; modelTier: string }>;
+  blockingThreshold?: "error" | "warning" | "info";
+  featureContextMarkdown?: string;
+  contextBundle?: import("../context/engine").ContextBundle;
+  projectDir?: string;
+  naxIgnoreIndex?: NaxIgnoreIndex;
+  runtime?: import("../runtime").NaxRuntime;
+}
+
 /**
  * Run a semantic review using an LLM against the story diff.
  */
-export async function runSemanticReview(
-  workdir: string,
-  storyGitRef: string | undefined,
-  story: SemanticStory,
-  semanticConfig: SemanticReviewConfig,
-  agentManager: IAgentManager | undefined,
-  naxConfig?: NaxConfig,
-  featureName?: string,
-  resolverSession?: import("./dialogue").ReviewerSession,
-  priorFailures?: Array<{ stage: string; modelTier: string }>,
-  blockingThreshold?: "error" | "warning" | "info",
-  featureContextMarkdown?: string,
-  contextBundle?: import("../context/engine").ContextBundle,
-  projectDir?: string,
-  naxIgnoreIndex?: NaxIgnoreIndex,
-  runtime?: import("../runtime").NaxRuntime,
-): Promise<ReviewCheckResult> {
+export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise<ReviewCheckResult> {
+  const {
+    workdir,
+    storyGitRef,
+    story,
+    semanticConfig,
+    agentManager,
+    naxConfig,
+    featureName,
+    resolverSession,
+    priorFailures,
+    blockingThreshold,
+    featureContextMarkdown,
+    contextBundle,
+    projectDir,
+    naxIgnoreIndex,
+    runtime,
+  } = opts;
   const startTime = Date.now();
   const logger = getSafeLogger();
 

--- a/test/helpers/runtime.ts
+++ b/test/helpers/runtime.ts
@@ -30,7 +30,7 @@ export function makeTestRuntime(opts?: TestRuntimeOptions): NaxRuntime {
  *   runWithFallbackFn: async (req) => ({ result: { ... }, fallbacks: [], bundle: req.bundle }),
  * });
  * const runtime = makeMockRuntime({ agentManager });
- * await runSemanticReview(workdir, ref, story, cfg, agentManager, ..., runtime);
+ * await runSemanticReview({ workdir, storyGitRef: ref, story, semanticConfig: cfg, agentManager, runtime });
  * ```
  *
  * - `agentManager` defaults to `makeMockAgentManager()` (no overrides) — supply

--- a/test/unit/review/orchestrator.test.ts
+++ b/test/unit/review/orchestrator.test.ts
@@ -474,8 +474,8 @@ describe("ReviewOrchestrator — retrySkipChecks in parallel LLM dispatch (#136)
 
   test("defaults semantic diffMode to ref in parallel path when semantic config is omitted", async () => {
     let observedDiffMode: unknown;
-    _orchestratorDeps.runSemanticReview = mock(async (...args: Parameters<typeof _orchestratorDeps.runSemanticReview>) => {
-      observedDiffMode = args[3].diffMode;
+    _orchestratorDeps.runSemanticReview = mock(async (opts: Parameters<typeof _orchestratorDeps.runSemanticReview>[0]) => {
+      observedDiffMode = opts.semanticConfig?.diffMode;
       return makePassedCheck("semantic");
     });
     const orchestrator = new ReviewOrchestrator();

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -502,21 +502,11 @@ describe("runReview — semantic check integration (AC-9)", () => {
     );
 
     expect(_semanticDeps.runSemanticReview).toHaveBeenCalledWith(
-      "/tmp/fake-workdir",
-      "abc1234",
-      expect.objectContaining({ id: "US-001", title: "My story", acceptanceCriteria: ["AC1"] }),
-      expect.any(Object),
-      mockResolver,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined, // blockingThreshold
-      undefined, // featureContextMarkdown
-      undefined, // contextBundles?.semantic (v2)
-      undefined, // projectDir
-      undefined, // naxIgnoreIndex
-      undefined, // runtime
+      expect.objectContaining({
+        workdir: "/tmp/fake-workdir",
+        storyGitRef: "abc1234",
+        story: expect.objectContaining({ id: "US-001" }),
+      }),
     );
   });
 
@@ -541,21 +531,12 @@ describe("runReview — semantic check integration (AC-9)", () => {
     await runReview(configWithSemantic, "/tmp/fake-workdir");
 
     expect(_semanticDeps.runSemanticReview).toHaveBeenCalledWith(
-      "/tmp/fake-workdir",
-      undefined,
-      expect.any(Object),
-      { modelTier: "powerful", rules: ["no stubs"], timeoutMs: 600_000, excludePatterns: [":!test/"], diffMode: "embedded", resetRefOnRerun: false },
-      undefined, // agentManager (was formerly ModelResolver factory)
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined, // blockingThreshold
-      undefined, // featureContextMarkdown
-      undefined, // contextBundles?.semantic (v2)
-      undefined, // projectDir
-      undefined, // naxIgnoreIndex
-      undefined, // runtime
+      expect.objectContaining({
+        workdir: "/tmp/fake-workdir",
+        storyGitRef: undefined,
+        story: expect.any(Object),
+        semanticConfig: { modelTier: "powerful", rules: ["no stubs"], timeoutMs: 600_000, excludePatterns: [":!test/"], diffMode: "embedded", resetRefOnRerun: false },
+      }),
     );
   });
 });

--- a/test/unit/review/semantic-agent-session.test.ts
+++ b/test/unit/review/semantic-agent-session.test.ts
@@ -104,69 +104,43 @@ function makeRuntime(agentManager: IAgentManager) {
 }
 
 async function callRunSemanticReview(agentManager: IAgentManager): Promise<import("../../../src/review/types").ReviewCheckResult> {
-  return runSemanticReview(
-    "/tmp/wd",
-    "abc123",
-    STORY,
-    DEFAULT_SEMANTIC_CONFIG,
+  return runSemanticReview({
+    workdir: "/tmp/wd",
+    storyGitRef: "abc123",
+    story: STORY,
+    semanticConfig: DEFAULT_SEMANTIC_CONFIG,
     agentManager,
-    undefined, // naxConfig
-    undefined, // featureName
-    undefined, // resolverSession
-    undefined, // priorFailures
-    undefined, // blockingThreshold
-    undefined, // featureContextMarkdown
-    undefined, // contextBundle
-    undefined, // projectDir
-    undefined, // naxIgnoreIndex
-    makeRuntime(agentManager),
-  );
+    runtime: makeRuntime(agentManager),
+  });
 }
 
 async function callRunSemanticReviewWithFeature(
   agentManager: IAgentManager,
   featureName?: string,
 ): Promise<import("../../../src/review/types").ReviewCheckResult> {
-  return runSemanticReview(
-    "/tmp/wd",
-    "abc123",
-    STORY,
-    DEFAULT_SEMANTIC_CONFIG,
+  return runSemanticReview({
+    workdir: "/tmp/wd",
+    storyGitRef: "abc123",
+    story: STORY,
+    semanticConfig: DEFAULT_SEMANTIC_CONFIG,
     agentManager,
-    undefined, // naxConfig
-    featureName, // featureName
-    undefined, // resolverSession
-    undefined, // priorFailures
-    undefined, // blockingThreshold
-    undefined, // featureContextMarkdown
-    undefined, // contextBundle
-    undefined, // projectDir
-    undefined, // naxIgnoreIndex
-    makeRuntime(agentManager),
-  );
+    featureName,
+    runtime: makeRuntime(agentManager),
+  });
 }
 
 async function callSemanticReviewWithRef(
   storyGitRef: string | undefined,
   agentManager: IAgentManager | undefined,
 ): Promise<import("../../../src/review/types").ReviewCheckResult> {
-  return runSemanticReview(
-    "/tmp/wd",
+  return runSemanticReview({
+    workdir: "/tmp/wd",
     storyGitRef,
-    STORY,
-    DEFAULT_SEMANTIC_CONFIG,
+    story: STORY,
+    semanticConfig: DEFAULT_SEMANTIC_CONFIG,
     agentManager,
-    undefined, // naxConfig
-    undefined, // featureName
-    undefined, // resolverSession
-    undefined, // priorFailures
-    undefined, // blockingThreshold
-    undefined, // featureContextMarkdown
-    undefined, // contextBundle
-    undefined, // projectDir
-    undefined, // naxIgnoreIndex
-    agentManager ? makeRuntime(agentManager) : undefined,
-  );
+    runtime: agentManager ? makeRuntime(agentManager) : undefined,
+  });
 }
 
 function makeSpawnMock(stdout: string, exitCode = 0) {
@@ -274,7 +248,12 @@ describe("runSemanticReview — BUG-114 storyGitRef fallback (merge-base)", () =
     _diffUtilsDeps.isGitRefValid = mock(async () => false);
     _diffUtilsDeps.getMergeBase = mock(async () => undefined);
 
-    const result = await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, undefined);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: undefined,
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+    });
 
     expect(result.success).toBe(true);
     expect(result.output).toContain("skipped: no git ref");
@@ -285,7 +264,12 @@ describe("runSemanticReview — BUG-114 storyGitRef fallback (merge-base)", () =
     _diffUtilsDeps.isGitRefValid = mock(async () => false);
     _diffUtilsDeps.getMergeBase = mock(async () => undefined);
 
-    const result = await runSemanticReview("/tmp/wd", "bad-sha", STORY, DEFAULT_SEMANTIC_CONFIG, undefined);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "bad-sha",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+    });
 
     expect(result.success).toBe(true);
     expect(result.output).toContain("skipped: no git ref");
@@ -380,23 +364,15 @@ describe("runSemanticReview — uses agent.run() instead of agent.complete() (US
     const agentManager = makeRunAgentManager(PASSING_LLM_RESPONSE);
     const storyWithDifferentId: SemanticStory = { ...STORY, id: "US-999" };
 
-    await runSemanticReview(
-      "/tmp/wd",
-      "abc123",
-      storyWithDifferentId,
-      DEFAULT_SEMANTIC_CONFIG,
+    await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: storyWithDifferentId,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, // naxConfig
-      "feat", // featureName
-      undefined, // resolverSession
-      undefined, // priorFailures
-      undefined, // blockingThreshold
-      undefined, // featureContextMarkdown
-      undefined, // contextBundle
-      undefined, // projectDir
-      undefined, // naxIgnoreIndex
-      makeRuntime(agentManager),
-    );
+      featureName: "feat",
+      runtime: makeRuntime(agentManager),
+    });
 
     expect(agentManager.runWithFallback).toHaveBeenCalled();
     const req = (agentManager.runWithFallback as ReturnType<typeof mock>).mock.calls[0][0] as { runOptions: Record<string, unknown> };

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -264,15 +264,15 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     const agentManager = makeAgentManager(PROPOSAL_PASS);
     const runtime = makeMockRuntime({ agentManager });
 
-    await runSemanticReview(
-      WORKDIR,
-      STORY_GIT_REF,
-      STORY,
-      SEMANTIC_CONFIG,
+    await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: SEMANTIC_CONFIG,
       agentManager,
-      DEBATE_REVIEW_ENABLED_CONFIG,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-    );
+      naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+      runtime,
+    });
 
     expect(_semanticDeps.createDebateRunner).toHaveBeenCalled();
   });
@@ -284,15 +284,15 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     const agentManager = makeAgentManager(PROPOSAL_PASS);
     const runtime = makeMockRuntime({ agentManager });
 
-    await runSemanticReview(
-      WORKDIR,
-      STORY_GIT_REF,
-      STORY,
-      SEMANTIC_CONFIG,
+    await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: SEMANTIC_CONFIG,
       agentManager,
-      DEBATE_REVIEW_ENABLED_CONFIG,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-    );
+      naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+      runtime,
+    });
 
     expect(runMock).toHaveBeenCalledTimes(1);
     const [promptArg] = runMock.mock.calls[0];
@@ -307,15 +307,15 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     const agentManager = makeAgentManager(PROPOSAL_PASS);
     const runtime = makeMockRuntime({ agentManager });
 
-    await runSemanticReview(
-      WORKDIR,
-      STORY_GIT_REF,
-      STORY,
-      SEMANTIC_CONFIG,
+    await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: SEMANTIC_CONFIG,
       agentManager,
-      DEBATE_REVIEW_ENABLED_CONFIG,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-    );
+      naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+      runtime,
+    });
 
     expect(agentManager.complete as ReturnType<typeof mock>).not.toHaveBeenCalled();
   });
@@ -329,15 +329,15 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     const agentManager = makeAgentManager(PROPOSAL_PASS);
     const runtime = makeMockRuntime({ agentManager });
 
-    await runSemanticReview(
-      WORKDIR,
-      STORY_GIT_REF,
-      STORY,
-      SEMANTIC_CONFIG,
+    await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: SEMANTIC_CONFIG,
       agentManager,
-      { debate: { enabled: false, agents: 0, stages: {} as never } } as NaxConfig,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-    );
+      naxConfig: { debate: { enabled: false, agents: 0, stages: {} as never } } as NaxConfig,
+      runtime,
+    });
 
     expect(agentManager.runWithFallback as ReturnType<typeof mock>).toHaveBeenCalledTimes(1);
     expect(createDebateMock).not.toHaveBeenCalled();
@@ -352,14 +352,14 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       run: mock(async () => DEBATE_MAJORITY_PASS_RESULT),
     }));
 
-    const result = await runSemanticReview(
-      WORKDIR,
-      STORY_GIT_REF,
-      STORY,
-      SEMANTIC_CONFIG,
-      () => makeMockAgent(PROPOSAL_PASS),
-      DEBATE_REVIEW_ENABLED_CONFIG,
-    );
+    const result = await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: SEMANTIC_CONFIG,
+      agentManager: () => makeMockAgent(PROPOSAL_PASS),
+      naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+    });
 
     expect(result.success).toBe(true);
   });
@@ -369,14 +369,14 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       run: mock(async () => DEBATE_MAJORITY_FAIL_RESULT),
     }));
 
-    const result = await runSemanticReview(
-      WORKDIR,
-      STORY_GIT_REF,
-      STORY,
-      SEMANTIC_CONFIG,
-      () => makeMockAgent(PROPOSAL_PASS),
-      DEBATE_REVIEW_ENABLED_CONFIG,
-    );
+    const result = await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: SEMANTIC_CONFIG,
+      agentManager: () => makeMockAgent(PROPOSAL_PASS),
+      naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+    });
 
     expect(result.success).toBe(false);
   });
@@ -390,14 +390,14 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       run: mock(async () => DEBATE_MAJORITY_FAIL_RESULT),
     }));
 
-    const result = await runSemanticReview(
-      WORKDIR,
-      STORY_GIT_REF,
-      STORY,
-      SEMANTIC_CONFIG,
-      () => makeMockAgent(PROPOSAL_PASS),
-      DEBATE_REVIEW_ENABLED_CONFIG,
-    );
+    const result = await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: SEMANTIC_CONFIG,
+      agentManager: () => makeMockAgent(PROPOSAL_PASS),
+      naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+    });
 
     expect(result.findings).toBeDefined();
     expect((result.findings ?? []).length).toBeGreaterThan(0);
@@ -412,14 +412,14 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       run: mock(async () => DEBATE_DUPLICATE_FINDINGS_RESULT),
     }));
 
-    const result = await runSemanticReview(
-      WORKDIR,
-      STORY_GIT_REF,
-      STORY,
-      SEMANTIC_CONFIG,
-      () => makeMockAgent(PROPOSAL_PASS),
-      DEBATE_REVIEW_ENABLED_CONFIG,
-    );
+    const result = await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: SEMANTIC_CONFIG,
+      agentManager: () => makeMockAgent(PROPOSAL_PASS),
+      naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+    });
 
     expect(result.findings).toBeDefined();
     // Both debaters report semantic.ts:10, but it should appear only once
@@ -434,14 +434,14 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       run: mock(async () => DEBATE_DUPLICATE_FINDINGS_RESULT),
     }));
 
-    const result = await runSemanticReview(
-      WORKDIR,
-      STORY_GIT_REF,
-      STORY,
-      SEMANTIC_CONFIG,
-      () => makeMockAgent(PROPOSAL_PASS),
-      DEBATE_REVIEW_ENABLED_CONFIG,
-    );
+    const result = await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: SEMANTIC_CONFIG,
+      agentManager: () => makeMockAgent(PROPOSAL_PASS),
+      naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+    });
 
     // PROPOSAL_FAIL_A has error finding (blocking), PROPOSAL_FAIL_B adds a warn finding (advisory at default threshold)
     const blockingFiles = (result.findings ?? []).map((f) => f.file);

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -69,23 +69,14 @@ function makeRuntime(agentManager: ReturnType<typeof makeAgentManager>) {
 
 async function callRunSemanticReview(llmResponse: string, overrides?: Partial<import("../../../src/review/types").ReviewCheckResult>): Promise<import("../../../src/review/types").ReviewCheckResult> {
   const agentManager = makeAgentManager(llmResponse);
-  return runSemanticReview(
-    "/tmp/wd",
-    "abc123",
-    STORY,
-    CFG,
+  return runSemanticReview({
+    workdir: "/tmp/wd",
+    storyGitRef: "abc123",
+    story: STORY,
+    semanticConfig: CFG,
     agentManager,
-    undefined, // naxConfig
-    undefined, // featureName
-    undefined, // resolverSession
-    undefined, // priorFailures
-    undefined, // blockingThreshold
-    undefined, // featureContextMarkdown
-    undefined, // contextBundle
-    undefined, // projectDir
-    undefined, // naxIgnoreIndex
-    makeRuntime(agentManager),
-  );
+    runtime: makeRuntime(agentManager),
+  });
 }
 
 function makeSpawnMock(stdout = "diff output", exitCode = 0) {
@@ -282,7 +273,12 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
   test("result.findings is empty or absent when storyGitRef is missing (skipped)", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("", 0);
 
-    const result = await runSemanticReview("/tmp/wd", undefined, STORY, CFG, undefined);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: undefined,
+      story: STORY,
+      semanticConfig: CFG,
+    });
 
     expect(!result.findings || result.findings.length === 0).toBe(true);
   });

--- a/test/unit/review/semantic-parsing.test.ts
+++ b/test/unit/review/semantic-parsing.test.ts
@@ -122,23 +122,14 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
   async function callRunSemanticReview(response: string) {
     const agentManager = makeAgentManager(response);
     const runtime = makeMockRuntime({ agentManager });
-    return runSemanticReview(
-      "/tmp/wd",
-      "abc123",
-      STORY,
-      CONFIG,
+    return runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: CONFIG,
       agentManager,
-      undefined, // naxConfig
-      undefined, // featureName
-      undefined, // resolverSession
-      undefined, // priorFailures
-      undefined, // blockingThreshold
-      undefined, // featureContextMarkdown
-      undefined, // contextBundle
-      undefined, // projectDir
-      undefined, // naxIgnoreIndex
       runtime,
-    );
+    });
   }
 
   // Failure mode 2: preamble + fenced JSON (production log pattern)

--- a/test/unit/review/semantic-prompt-response.test.ts
+++ b/test/unit/review/semantic-prompt-response.test.ts
@@ -134,9 +134,14 @@ describe("runSemanticReview — LLM prompt construction", () => {
         fallbacks: [],
       };
     });
-    await runSemanticReview("/tmp/wd", "abc123", story, config, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story,
+      semanticConfig: config,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     return capturedPrompt;
   }
 
@@ -225,63 +230,98 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
   test("returns success=false when LLM returns passed=false", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager(FAILING_LLM_RESPONSE);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.success).toBe(false);
   });
 
   test("output contains finding's file", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager(FAILING_LLM_RESPONSE);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.output).toContain("src/review/semantic.ts");
   });
 
   test("output contains finding's line number", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager(FAILING_LLM_RESPONSE);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.output).toContain("42");
   });
 
   test("output contains finding's severity", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager(FAILING_LLM_RESPONSE);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.output).toContain("error");
   });
 
   test("output contains finding's issue description", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager(FAILING_LLM_RESPONSE);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.output).toContain("Function is a stub");
   });
 
   test("output contains finding's suggestion", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager(FAILING_LLM_RESPONSE);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.output).toContain("Implement the function");
   });
 
   test("returns success=true when LLM returns passed=true with empty findings", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.success).toBe(true);
   });
 
@@ -295,9 +335,14 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
     });
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager(multiFindings);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.output).toContain("src/a.ts");
     expect(result.output).toContain("Issue A");
     expect(result.output).toContain("src/b.ts");
@@ -331,36 +376,56 @@ describe("runSemanticReview — fail-open on invalid JSON", () => {
   test("returns success=true when LLM returns invalid JSON", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager("this is not json at all }{");
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.success).toBe(true);
   });
 
   test("returns success=true when LLM returns empty string", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager("");
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.success).toBe(true);
   });
 
   test("returns success=true when LLM returns JSON missing 'passed' field", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager(JSON.stringify({ findings: [] }));
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.success).toBe(true);
   });
 
   test("result check is 'semantic' on invalid JSON", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const agentManager = makeAgentManager("not json");
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.check).toBe("semantic");
   });
 });
@@ -392,9 +457,14 @@ describe("runSemanticReview — fail-closed on truncated JSON with passed:false 
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const truncatedResponse = '```json\n{"passed": false, "findings": [{"severity": "error", "file": "test.ts", "line": 1, "issue": "Test file is 78';
     const agentManager = makeAgentManager(truncatedResponse);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.success).toBe(false);
   });
 
@@ -402,9 +472,14 @@ describe("runSemanticReview — fail-closed on truncated JSON with passed:false 
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const truncatedResponse = '{"passed": false, "findings": [{"severity": "error"';
     const agentManager = makeAgentManager(truncatedResponse);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.output).toContain("truncated");
     expect(result.output).toContain("passed:false");
   });
@@ -413,9 +488,14 @@ describe("runSemanticReview — fail-closed on truncated JSON with passed:false 
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const truncatedResponse = '{"passed": true, "findings": [';
     const agentManager = makeAgentManager(truncatedResponse);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.success).toBe(true);
   });
 });
@@ -447,9 +527,14 @@ describe("runSemanticReview — markdown fence stripping (BUG-090)", () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const fencedResponse = "```json\n" + JSON.stringify({ passed: true, findings: [] }) + "\n```";
     const agentManager = makeAgentManager(fencedResponse);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.success).toBe(true);
     expect(result.output).not.toContain("could not parse");
   });
@@ -458,9 +543,14 @@ describe("runSemanticReview — markdown fence stripping (BUG-090)", () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const fencedResponse = "```\n" + JSON.stringify({ passed: true, findings: [] }) + "\n```";
     const agentManager = makeAgentManager(fencedResponse);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.success).toBe(true);
     expect(result.output).not.toContain("could not parse");
   });
@@ -473,9 +563,14 @@ describe("runSemanticReview — markdown fence stripping (BUG-090)", () => {
     };
     const fencedResponse = "```json\n" + JSON.stringify(payload) + "\n```";
     const agentManager = makeAgentManager(fencedResponse);
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, makeMockRuntime({ agentManager }),
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime: makeMockRuntime({ agentManager }),
+    });
     expect(result.success).toBe(false);
   });
 });

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -147,16 +147,14 @@ describe("runSemanticReview — JSON retry outcomes", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    const result = await runSemanticReview(
-      "/tmp/wd",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined,
-      undefined, undefined, undefined, undefined,
-      undefined, runtime,
-    );
+      runtime,
+    });
 
     expect(result.success).toBe(true);
     expect(result.output).toContain("Semantic review passed");
@@ -171,16 +169,14 @@ describe("runSemanticReview — JSON retry outcomes", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    const result = await runSemanticReview(
-      "/tmp/wd",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined,
-      undefined, undefined, undefined, undefined,
-      undefined, runtime,
-    );
+      runtime,
+    });
 
     expect(result.success).toBe(true);
     expect(result.failOpen).toBe(true);
@@ -196,16 +192,14 @@ describe("runSemanticReview — JSON retry outcomes", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    const result = await runSemanticReview(
-      "/tmp/wd",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined,
-      undefined, undefined, undefined, undefined,
-      undefined, runtime,
-    );
+      runtime,
+    });
 
     expect(result.success).toBe(false);
     expect(result.output).toContain("passed:false");
@@ -219,16 +213,14 @@ describe("runSemanticReview — JSON retry outcomes", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    const result = await runSemanticReview(
-      "/tmp/wd",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined,
-      undefined, undefined, undefined, undefined,
-      undefined, runtime,
-    );
+      runtime,
+    });
 
     expect(result.success).toBe(false);
     expect(result.findings).toHaveLength(1);
@@ -240,16 +232,14 @@ describe("runSemanticReview — JSON retry outcomes", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    const result = await runSemanticReview(
-      "/tmp/wd",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined,
-      undefined, undefined, undefined, undefined,
-      undefined, runtime,
-    );
+      runtime,
+    });
 
     expect(result.success).toBe(true);
     expect(result.failOpen).toBe(true);
@@ -278,16 +268,14 @@ describe("runSemanticReview — logging", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    await runSemanticReview(
-      "/tmp/wd",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined,
-      undefined, undefined, undefined, undefined,
-      undefined, runtime,
-    );
+      runtime,
+    });
 
     const successLog = logger.infoCalls.find((c) => c.message.includes("Semantic review passed"));
     expect(successLog).toBeDefined();
@@ -302,16 +290,14 @@ describe("runSemanticReview — logging", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    await runSemanticReview(
-      "/tmp/wd",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined,
-      undefined, undefined, undefined, undefined,
-      undefined, runtime,
-    );
+      runtime,
+    });
 
     const exhaustLog = logger.warnCalls.find((c) => c.message.includes("Retry exhausted"));
     expect(exhaustLog).toBeDefined();
@@ -326,16 +312,14 @@ describe("runSemanticReview — logging", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    await runSemanticReview(
-      "/tmp/wd",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined,
-      undefined, undefined, undefined, undefined,
-      undefined, runtime,
-    );
+      runtime,
+    });
 
     const truncatedLog = logger.warnCalls.find((c) => c.message.includes("truncated JSON"));
     expect(truncatedLog).toBeDefined();
@@ -350,16 +334,14 @@ describe("runSemanticReview — logging", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    await runSemanticReview(
-      "/tmp/wd",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined,
-      undefined, undefined, undefined, undefined,
-      undefined, runtime,
-    );
+      runtime,
+    });
 
     const retryLog = logger.warnCalls.find((c) => c.message.includes("Retry exhausted"));
     expect(retryLog).toBeUndefined();

--- a/test/unit/review/semantic-signature-diff.test.ts
+++ b/test/unit/review/semantic-signature-diff.test.ts
@@ -154,7 +154,14 @@ describe("runSemanticReview — missing storyGitRef", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    const result = await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: undefined,
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime,
+    });
 
     expect(result.success).toBe(true);
   });
@@ -164,7 +171,14 @@ describe("runSemanticReview — missing storyGitRef", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    const result = await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: undefined,
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime,
+    });
 
     expect(result.output).toContain("skipped: no git ref");
   });
@@ -174,7 +188,14 @@ describe("runSemanticReview — missing storyGitRef", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    const result = await runSemanticReview("/tmp/wd", "", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime,
+    });
 
     expect(result.success).toBe(true);
   });
@@ -184,7 +205,14 @@ describe("runSemanticReview — missing storyGitRef", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    const result = await runSemanticReview("/tmp/wd", "", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime,
+    });
 
     expect(result.output).toContain("skipped: no git ref");
   });
@@ -193,7 +221,12 @@ describe("runSemanticReview — missing storyGitRef", () => {
     const spawnMock = makeSpawnMock("", 0);
     _diffUtilsDeps.spawn = spawnMock;
 
-    await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, undefined);
+    await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: undefined,
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+    });
 
     expect(spawnMock).not.toHaveBeenCalled();
   });
@@ -201,7 +234,12 @@ describe("runSemanticReview — missing storyGitRef", () => {
   test("result.check is 'semantic' when storyGitRef is undefined", async () => {
     _diffUtilsDeps.spawn = makeSpawnMock("", 0);
 
-    const result = await runSemanticReview("/tmp/wd", undefined, STORY, DEFAULT_SEMANTIC_CONFIG, undefined);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: undefined,
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+    });
 
     expect(result.check).toBe("semantic");
   });
@@ -236,7 +274,14 @@ describe("runSemanticReview — git diff invocation", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime,
+    });
 
     expect(spawnMock).toHaveBeenCalled();
     const allCalls = (spawnMock as ReturnType<typeof mock>).mock.calls;
@@ -259,7 +304,14 @@ describe("runSemanticReview — git diff invocation", () => {
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
 
-    await runSemanticReview("/my/project", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    await runSemanticReview({
+      workdir: "/my/project",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime,
+    });
 
     const call = (spawnMock as ReturnType<typeof mock>).mock.calls[0];
     const spawnOpts = call[0] as { cwd: string };
@@ -302,7 +354,14 @@ describe("runSemanticReview — diff truncation", () => {
       };
     });
 
-    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime,
+    });
 
     expect(_diffUtilsDeps.spawn).toHaveBeenCalled();
   });
@@ -318,7 +377,14 @@ describe("runSemanticReview — diff truncation", () => {
       fallbacks: [],
     }));
 
-    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime,
+    });
 
     expect(_diffUtilsDeps.spawn).toHaveBeenCalled();
   });
@@ -334,7 +400,14 @@ describe("runSemanticReview — diff truncation", () => {
       fallbacks: [],
     }));
 
-    await runSemanticReview("/tmp/wd", "abc123", STORY, DEFAULT_SEMANTIC_CONFIG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
+      agentManager,
+      runtime,
+    });
 
     expect(_diffUtilsDeps.spawn).toHaveBeenCalled();
   });

--- a/test/unit/review/semantic-threshold.test.ts
+++ b/test/unit/review/semantic-threshold.test.ts
@@ -137,7 +137,14 @@ describe("runSemanticReview — blockingThreshold defaults to 'error'", () => {
   test("warning finding goes to advisoryFindings, not findings, by default", async () => {
     const agentManager = makeAgentManager(WARNING_ONLY_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, BASE_CFG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: BASE_CFG,
+      agentManager,
+      runtime,
+    });
 
     expect(result.success).toBe(true);
     expect(!result.findings || result.findings.length === 0).toBe(true);
@@ -153,7 +160,14 @@ describe("runSemanticReview — blockingThreshold defaults to 'error'", () => {
     });
     const agentManager = makeAgentManager(errorOnly);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, BASE_CFG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: BASE_CFG,
+      agentManager,
+      runtime,
+    });
 
     expect(result.success).toBe(false);
     expect(result.findings).toBeDefined();
@@ -163,7 +177,14 @@ describe("runSemanticReview — blockingThreshold defaults to 'error'", () => {
   test("mixed: error goes to findings, warning to advisoryFindings by default", async () => {
     const agentManager = makeAgentManager(MIXED_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, BASE_CFG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: BASE_CFG,
+      agentManager,
+      runtime,
+    });
 
     expect(result.success).toBe(false);
     expect(result.findings!.length).toBe(1);
@@ -175,7 +196,14 @@ describe("runSemanticReview — blockingThreshold defaults to 'error'", () => {
   test("info finding goes to advisoryFindings by default", async () => {
     const agentManager = makeAgentManager(INFO_ONLY_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview("/tmp/wd", "abc123", STORY, BASE_CFG, agentManager, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime);
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: BASE_CFG,
+      agentManager,
+      runtime,
+    });
 
     expect(result.success).toBe(true);
     expect(!result.findings || result.findings.length === 0).toBe(true);
@@ -191,10 +219,15 @@ describe("runSemanticReview — blockingThreshold: 'warning'", () => {
   test("warning finding blocks when threshold is 'warning'", async () => {
     const agentManager = makeAgentManager(WARNING_ONLY_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview(
-      "/tmp/wd", "abc123", STORY, BASE_CFG, agentManager,
-      undefined, undefined, undefined, undefined, "warning", undefined, undefined, undefined, undefined, runtime,
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: BASE_CFG,
+      agentManager,
+      blockingThreshold: "warning",
+      runtime,
+    });
 
     expect(result.success).toBe(false);
     expect(result.findings!.length).toBe(1);
@@ -204,10 +237,15 @@ describe("runSemanticReview — blockingThreshold: 'warning'", () => {
   test("info finding remains advisory when threshold is 'warning'", async () => {
     const agentManager = makeAgentManager(INFO_ONLY_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview(
-      "/tmp/wd", "abc123", STORY, BASE_CFG, agentManager,
-      undefined, undefined, undefined, undefined, "warning", undefined, undefined, undefined, undefined, runtime,
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: BASE_CFG,
+      agentManager,
+      blockingThreshold: "warning",
+      runtime,
+    });
 
     expect(result.success).toBe(true);
     expect(!result.findings || result.findings.length === 0).toBe(true);
@@ -217,10 +255,15 @@ describe("runSemanticReview — blockingThreshold: 'warning'", () => {
   test("both error and warning block when threshold is 'warning'", async () => {
     const agentManager = makeAgentManager(MIXED_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview(
-      "/tmp/wd", "abc123", STORY, BASE_CFG, agentManager,
-      undefined, undefined, undefined, undefined, "warning", undefined, undefined, undefined, undefined, runtime,
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: BASE_CFG,
+      agentManager,
+      blockingThreshold: "warning",
+      runtime,
+    });
 
     expect(result.success).toBe(false);
     expect(result.findings!.length).toBe(2);
@@ -236,10 +279,15 @@ describe("runSemanticReview — blockingThreshold: 'info'", () => {
   test("info finding blocks when threshold is 'info'", async () => {
     const agentManager = makeAgentManager(INFO_ONLY_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview(
-      "/tmp/wd", "abc123", STORY, BASE_CFG, agentManager,
-      undefined, undefined, undefined, undefined, "info", undefined, undefined, undefined, undefined, runtime,
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: BASE_CFG,
+      agentManager,
+      blockingThreshold: "info",
+      runtime,
+    });
 
     expect(result.success).toBe(false);
     expect(result.findings!.length).toBe(1);
@@ -255,10 +303,15 @@ describe("runSemanticReview — advisoryFindings absent when no advisory finding
   test("advisoryFindings is undefined when all findings block", async () => {
     const agentManager = makeAgentManager(MIXED_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview(
-      "/tmp/wd", "abc123", STORY, BASE_CFG, agentManager,
-      undefined, undefined, undefined, undefined, "warning", undefined, undefined, undefined, undefined, runtime,
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: BASE_CFG,
+      agentManager,
+      blockingThreshold: "warning",
+      runtime,
+    });
 
     // Both findings are blocking at "warning" threshold
     expect(result.advisoryFindings).toBeUndefined();
@@ -267,10 +320,14 @@ describe("runSemanticReview — advisoryFindings absent when no advisory finding
   test("advisoryFindings is undefined when passed=true with no findings", async () => {
     const agentManager = makeAgentManager(JSON.stringify({ passed: true, findings: [] }));
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview(
-      "/tmp/wd", "abc123", STORY, BASE_CFG, agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-    );
+    const result = await runSemanticReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: BASE_CFG,
+      agentManager,
+      runtime,
+    });
 
     expect(result.advisoryFindings).toBeUndefined();
   });

--- a/test/unit/review/semantic-unverifiable.test.ts
+++ b/test/unit/review/semantic-unverifiable.test.ts
@@ -131,14 +131,14 @@ describe("unverifiable finding handling", () => {
     });
     const agentManager = makeAgentManager(response);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview(
-      "/tmp/repo",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    const result = await runSemanticReview({
+      workdir: "/tmp/repo",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-    );
+      runtime,
+    });
 
     expect(result.success).toBe(true);
     expect(result.output).toContain("advisory");
@@ -166,14 +166,14 @@ describe("unverifiable finding handling", () => {
     });
     const agentManager = makeAgentManager(response);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview(
-      "/tmp/repo",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    const result = await runSemanticReview({
+      workdir: "/tmp/repo",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-    );
+      runtime,
+    });
 
     expect(result.success).toBe(false);
     // Only the blocking finding should be in the output
@@ -199,14 +199,14 @@ describe("unverifiable finding handling", () => {
     });
     const agentManager = makeAgentManager(response);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview(
-      "/tmp/repo",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    const result = await runSemanticReview({
+      workdir: "/tmp/repo",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-    );
+      runtime,
+    });
 
     // With default 'error' threshold, info findings are advisory — not blocking
     expect(result.success).toBe(true);
@@ -230,14 +230,14 @@ describe("unverifiable finding handling", () => {
     });
     const agentManager = makeAgentManager(response);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview(
-      "/tmp/repo",
-      "abc123",
-      STORY,
-      { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+    const result = await runSemanticReview({
+      workdir: "/tmp/repo",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
       agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-    );
+      runtime,
+    });
 
     expect(result.success).toBe(true);
     expect(result.findings).toBeUndefined();
@@ -260,14 +260,14 @@ describe("unverifiable finding handling", () => {
     });
     const agentManager = makeAgentManager(response);
     const runtime = makeMockRuntime({ agentManager });
-    const result = await runSemanticReview(
-      "/tmp/repo",
-      "abc123",
-      STORY,
-      { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+    const result = await runSemanticReview({
+      workdir: "/tmp/repo",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
       agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-    );
+      runtime,
+    });
 
     expect(result.success).toBe(true);
     expect(result.findings).toBeUndefined();
@@ -298,14 +298,14 @@ describe("unverifiable finding handling", () => {
     const result = await withTempDir(async (workdir) => {
       mkdirSync(join(workdir, "src"), { recursive: true });
       writeFileSync(join(workdir, "src/foo.ts"), "export function foo() {}\n");
-      return runSemanticReview(
+      return runSemanticReview({
         workdir,
-        "abc123",
-        STORY,
-        { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+        storyGitRef: "abc123",
+        story: STORY,
+        semanticConfig: { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
         agentManager,
-        undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-      );
+        runtime,
+      });
     });
 
     expect(result.success).toBe(false);
@@ -337,14 +337,14 @@ describe("unverifiable finding handling", () => {
     const result = await withTempDir(async (workdir) => {
       mkdirSync(join(workdir, "src"), { recursive: true });
       writeFileSync(join(workdir, "src/foo.ts"), "const storedLinkStr = links.sort().join('|');\n");
-      return runSemanticReview(
+      return runSemanticReview({
         workdir,
-        "abc123",
-        STORY,
-        { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+        storyGitRef: "abc123",
+        story: STORY,
+        semanticConfig: { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
         agentManager,
-        undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-      );
+        runtime,
+      });
     });
 
     expect(result.success).toBe(true);
@@ -364,14 +364,14 @@ describe("semantic prompt includes tool-access instructions", () => {
       fallbacks: [],
     }));
 
-    await runSemanticReview(
-      "/tmp/repo",
-      "abc123",
-      STORY,
-      DEFAULT_SEMANTIC_CONFIG,
+    await runSemanticReview({
+      workdir: "/tmp/repo",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: DEFAULT_SEMANTIC_CONFIG,
       agentManager,
-      undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, runtime,
-    );
+      runtime,
+    });
 
     expect(_diffUtilsDeps.spawn).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Convert `runSemanticReview` from 15 positional parameters to a single `RunSemanticReviewOptions` object. This is Phase 1 of the options-bag refactor for the review path functions.

## Changes

- **`src/review/semantic.ts`**: Added `RunSemanticReviewOptions` interface and converted function signature
- **`src/review/runner.ts`**: Updated call site to use options bag
- **`src/review/orchestrator.ts`**: Updated parallel-path call site to use options bag
- **Tests**: Updated 10 test files (75+ call sites) to use new options-bag style, dropping `undefined` placeholders
- **`test/helpers/runtime.ts`**: Updated docstring example

## Validation

- `bun run typecheck` ✅
- `bun run lint` ✅  
- `bun test test/unit/review/semantic --timeout=10000` ✅ 132 tests
- `bun test test/unit/review/orchestrator.test.ts --timeout=10000` ✅ 21 tests
- `bun test test/unit/review/runner.test.ts --timeout=10000` ✅ 27 tests

## Notes

- No behaviour change — pure signature refactor
- Field names match the prior parameter names (mechanical conversion)
- `_reconcileDeps.runReview` boundary intentionally unchanged (Phase 3 scope)
- Phases 2–4 will follow in subsequent PRs

Closes part of #577.