### PR TITLE
fix(autofix): abort retry loop on adversarial fail-open; exclude from retrySkipChecks (#832)

### DIFF
--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -227,6 +227,10 @@ export async function runAgentRectification(
   let currentAttempt = 0;
   let currentConsecutiveNoOps = 0;
   let currentCheckSignatureChanged = false;
+  // Set true when recheckReview fails solely due to adversarial fail-open (timeout).
+  // shouldAbort (below) reads this flag and exits before the next attempt is built,
+  // preventing a wasted implementer call with stale initialFailure findings. Issue #832.
+  let failOpenAborted = false;
 
   // Held-open implementer session for the duration of the loop. Opened lazily
   // on first execute() to avoid paying openSession cost when the agent fails
@@ -240,6 +244,7 @@ export async function runAgentRectification(
     maxAttempts,
     failure: initialFailure,
     previousAttempts: [],
+    shouldAbort: () => failOpenAborted,
     buildPrompt: (failure, previous) => {
       currentAttempt = previous.length + 1;
       const lastResult = previous[previous.length - 1]?.result;
@@ -584,12 +589,27 @@ export async function runAgentRectification(
         };
       }
 
-      logger.warn("autofix", "Agent rectification exhausted", {
-        storyId: ctx.story.id,
-        attemptsUsed: currentAttempt,
-        globalBudgetUsed: consumed + currentAttempt,
-        maxTotalAttempts: maxTotal,
-      });
+      // recheckReview returned false but collectFailedChecks found nothing — this happens
+      // exclusively when adversarial timed out (fail-open): ctx.reviewResult.success=false
+      // but all checks carry success=true. Re-prompting with stale initialFailure would
+      // send the implementer already-fixed findings. Set failOpenAborted so shouldAbort
+      // exits before the next attempt is built. Issue #832.
+      const isFailOpenOnly = (ctx.reviewResult?.checks ?? []).some((c) => c.failOpen);
+      if (isFailOpenOnly) {
+        failOpenAborted = true;
+      }
+      logger.warn(
+        "autofix",
+        isFailOpenOnly
+          ? "Adversarial timed out during recheck (fail-open) — aborting retry to avoid stale re-prompt"
+          : "Agent rectification exhausted — no failed checks detected after recheck",
+        {
+          storyId: ctx.story.id,
+          attemptsUsed: currentAttempt,
+          globalBudgetUsed: consumed + currentAttempt,
+          maxTotalAttempts: maxTotal,
+        },
+      );
       return {
         passed: false,
         newFailure: initialFailure,

--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -244,7 +244,7 @@ export async function runAgentRectification(
     maxAttempts,
     failure: initialFailure,
     previousAttempts: [],
-    shouldAbort: () => failOpenAborted,
+    shouldAbort: (_failure, _attempt) => failOpenAborted,
     buildPrompt: (failure, previous) => {
       currentAttempt = previous.length + 1;
       const lastResult = previous[previous.length - 1]?.result;

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -209,7 +209,12 @@ export const autofixStage: PipelineStage = {
     // Zero-progress → escalate immediately (stuck rule: no point burning more budget).
     const maxTotal = ctx.config.quality.autofix?.maxTotalAttempts ?? 10;
     const totalUsed = ctx.autofixAttempt ?? 0;
-    const currentlyFailing = new Set((ctx.reviewResult?.checks ?? []).filter((c) => !c.success).map((c) => c.check));
+    // Treat fail-open checks as still-failing so they are not added to retrySkipChecks.
+    // An adversarial timeout is not a genuine pass — skipping it next cycle would let
+    // the story complete without a real adversarial review. Issue #832.
+    const currentlyFailing = new Set(
+      (ctx.reviewResult?.checks ?? []).filter((c) => !c.success || c.failOpen).map((c) => c.check),
+    );
     const nowPassing = [...failedCheckNames].filter((c) => !currentlyFailing.has(c));
 
     if (nowPassing.length > 0 && totalUsed < maxTotal) {

--- a/test/unit/pipeline/stages/autofix-fail-open.test.ts
+++ b/test/unit/pipeline/stages/autofix-fail-open.test.ts
@@ -7,10 +7,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { _autofixDeps } from "../../../../src/pipeline/stages/autofix";
+import { _autofixDeps, autofixStage } from "../../../../src/pipeline/stages/autofix";
 import { DEFAULT_CONFIG } from "../../../../src/config";
 import type { PipelineContext } from "../../../../src/pipeline/types";
 import type { ReviewCheckResult } from "../../../../src/review/types";
+import { makeMockAgentManager, makeSessionManager } from "../../../helpers";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -147,5 +148,154 @@ describe("recheckReview — fail-open rejection", () => {
     const result = await _autofixDeps.recheckReview(ctx);
 
     expect(result).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #832 Fix 1: verify callback sets failOpenAborted → shouldAbort exits
+// before the next buildPrompt, preventing a wasted implementer call with stale
+// findings.
+// ---------------------------------------------------------------------------
+
+describe("runAgentRectification — fail-open aborts retry loop (issue #832)", () => {
+  test("aborts loop before attempt 2 when recheck detects adversarial fail-open", async () => {
+    const { runAgentRectification } = await import("../../../../src/pipeline/stages/autofix-agent");
+
+    let runAsSessionCallCount = 0;
+    const agentManager = makeMockAgentManager({
+      runAsSessionFn: async () => {
+        runAsSessionCallCount++;
+        return {
+          output: "Fixed the issues",
+          estimatedCostUsd: 0.01,
+          tokenUsage: { inputTokens: 100, outputTokens: 200 },
+          internalRoundTrips: 0,
+        };
+      },
+    });
+
+    const sessionManager = makeSessionManager();
+
+    const savedCaptureGitRef = _autofixDeps.captureGitRef;
+    const savedRecheckReview = _autofixDeps.recheckReview;
+
+    // Both before/after return undefined → sourceFilesChanged=true, noOp=false,
+    // so recheckWorthwhile=true and recheckReview is invoked.
+    _autofixDeps.captureGitRef = async () => undefined as unknown as string;
+    _autofixDeps.recheckReview = async (mockCtx: PipelineContext) => {
+      // Simulate: adversarial timed out during recheck — success:true but failOpen:true
+      mockCtx.reviewResult = {
+        success: false,
+        checks: [
+          {
+            check: "adversarial",
+            success: true,
+            failOpen: true,
+            command: "",
+            exitCode: 0,
+            output: "fail-open",
+            durationMs: 0,
+          },
+        ],
+      } as unknown as PipelineContext["reviewResult"];
+      return false;
+    };
+
+    const ctx = makeCtx({
+      reviewResult: {
+        success: false,
+        checks: [
+          {
+            check: "adversarial",
+            success: false,
+            command: "",
+            exitCode: 1,
+            output: "adversarial finding",
+            durationMs: 0,
+          },
+        ],
+      } as unknown as PipelineContext["reviewResult"],
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          autofix: { enabled: true, maxAttempts: 3, maxTotalAttempts: 12 },
+        },
+      } as PipelineContext["config"],
+      agentManager,
+      runtime: {
+        sessionManager,
+        signal: new AbortController().signal,
+      } as unknown as PipelineContext["runtime"],
+    });
+
+    const result = await runAgentRectification(ctx, undefined, undefined, "/tmp");
+
+    _autofixDeps.captureGitRef = savedCaptureGitRef;
+    _autofixDeps.recheckReview = savedRecheckReview;
+
+    expect(result.succeeded).toBe(false);
+    // shouldAbort fires after attempt 1's verify — attempt 2 must not be built
+    expect(runAsSessionCallCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #832 Fix 2: currentlyFailing includes failOpen checks so adversarial
+// timeout is not added to retrySkipChecks on the partial-progress path.
+// ---------------------------------------------------------------------------
+
+describe("autofixStage — fail-open excluded from retrySkipChecks (issue #832)", () => {
+  test("adversarial fail-open is NOT added to retrySkipChecks when lint is cleared", async () => {
+    const saved = { ..._autofixDeps };
+
+    _autofixDeps.runAgentRectification = async (mockCtx: PipelineContext) => {
+      mockCtx.autofixAttempt = 1;
+      // Simulate: lint resolved but adversarial timed out (fail-open)
+      mockCtx.reviewResult = {
+        success: false,
+        checks: [
+          { check: "lint", success: true, command: "", exitCode: 0, output: "", durationMs: 0 },
+          {
+            check: "adversarial",
+            success: true,
+            failOpen: true,
+            command: "",
+            exitCode: 0,
+            output: "fail-open",
+            durationMs: 0,
+          },
+        ],
+      } as unknown as PipelineContext["reviewResult"];
+      return { succeeded: false, cost: 0 };
+    };
+
+    const ctx = makeCtx({
+      reviewResult: {
+        success: false,
+        checks: [
+          { check: "lint", success: false, command: "", exitCode: 1, output: "lint error", durationMs: 0 },
+          {
+            check: "adversarial",
+            success: false,
+            command: "",
+            exitCode: 1,
+            output: "adversarial finding",
+            durationMs: 0,
+          },
+        ],
+      } as unknown as PipelineContext["reviewResult"],
+    });
+
+    const result = await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    // lint was genuinely cleared → partial progress → retry
+    expect(result.action).toBe("retry");
+    // lint cleared for real → skip on next cycle
+    expect(ctx.retrySkipChecks?.has("lint")).toBe(true);
+    // adversarial timed out (failOpen) → must NOT be treated as passing
+    expect(ctx.retrySkipChecks?.has("adversarial")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **Fix 1 (`autofix-agent.ts`)**: When `recheckReview` returns `false` and `collectFailedChecks` returns `[]` (meaning every check carries `success:true` but at least one has `failOpen:true`), the verify callback now sets `failOpenAborted = true`. The `shouldAbort` callback reads this flag and exits the retry loop before the next `buildPrompt`, preventing a wasted implementer call with stale `initialFailure` findings.
- **Fix 2 (`autofix.ts`)**: The `currentlyFailing` filter on the partial-progress path now includes checks with `failOpen:true` (i.e., `!c.success || c.failOpen`). This prevents an adversarial timeout from being added to `retrySkipChecks` and silently skipped on the next review cycle.
- **Tests (`autofix-fail-open.test.ts`)**: Two new describe blocks verify both behaviors — the loop aborts after exactly one agent call, and `retrySkipChecks` does not contain the timed-out adversarial check.

## Root cause

When the adversarial reviewer times out, `review.ts` emits `{success: true, failOpen: true}` for that check. In a recheck context (after a prior agent attempt), `autofix-agent.ts:recheckReview` returns `false` because it explicitly rejects fail-open results. However, `collectFailedChecks` filters on `!c.success` — so a fail-open check (success:true) was invisible to it. The verify callback saw `updatedFailed = []`, fell through to the "exhausted" path, and returned `initialFailure` (stale findings from the start of the cycle). With `maxAttempts > 1`, the retry loop then called `buildPrompt` again with those stale findings, prompting the implementer about issues it had already fixed.

Separately, the partial-progress path in `autofix.ts` used the same `!c.success` filter for `currentlyFailing`. A timed-out adversarial check would appear in `nowPassing` and be added to `retrySkipChecks`, causing it to be silently skipped on the next review cycle — letting the story complete without any real adversarial review.

## Test plan

- [ ] `timeout 30 bun test test/unit/pipeline/stages/autofix-fail-open.test.ts --timeout=15000` — all 7 tests pass (5 existing + 2 new)
- [ ] `bun run test` — full suite passes (0 fail)
- [ ] Verify that a run log showing adversarial double-timeout no longer produces a 3rd implementer attempt with stale findings