### PR TITLE
fix(acceptance): add acceptanceGenConfigSelector to change acceptance genarate timeout

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -49,6 +49,7 @@ export {
   decomposeConfigSelector,
   rectifyConfigSelector,
   acceptanceConfigSelector,
+  acceptanceGenConfigSelector,
   acceptanceFixConfigSelector,
   tddConfigSelector,
   debateConfigSelector,

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -16,7 +16,10 @@ export const planConfigSelector = pickSelector("plan", "plan", "debate");
 export const decomposeConfigSelector = pickSelector("decompose", "plan", "agent");
 export const rectifyConfigSelector = pickSelector("rectify", "execution");
 export const acceptanceConfigSelector = pickSelector("acceptance", "acceptance");
+// acceptance fix take more time to fix the code, so we use a separate config selector to use execution.sessionTimeoutSeconds instead of acceptance.timeoutMs
 export const acceptanceFixConfigSelector = pickSelector("acceptance-fix", "acceptance", "execution");
+// acceptance generator take more time to generate the test code, so we use a separate config selector to use execution.sessionTimeoutSeconds instead of acceptance.timeoutMs
+export const acceptanceGenConfigSelector = pickSelector("acceptance-gen", "acceptance", "execution");
 export const tddConfigSelector = pickSelector("tdd", "tdd", "execution");
 export const debateConfigSelector = pickSelector("debate", "debate");
 export const routingConfigSelector = pickSelector("routing", "routing");

--- a/src/operations/acceptance-generate.ts
+++ b/src/operations/acceptance-generate.ts
@@ -1,6 +1,6 @@
 import { extractTestCode } from "../acceptance/generator";
 import { hasLikelyTestContent, isStubTestContent } from "../acceptance/heuristics";
-import { acceptanceConfigSelector } from "../config";
+import { acceptanceGenConfigSelector } from "../config";
 import { AcceptancePromptBuilder } from "../prompts";
 import type { CompleteOperation } from "./types";
 
@@ -17,7 +17,7 @@ export interface AcceptanceGenerateOutput {
   testCode: string | null;
 }
 
-type AcceptanceConfig = ReturnType<typeof acceptanceConfigSelector.select>;
+type AcceptanceConfig = ReturnType<typeof acceptanceGenConfigSelector.select>;
 
 export const acceptanceGenerateOp: CompleteOperation<
   AcceptanceGenerateInput,
@@ -28,8 +28,8 @@ export const acceptanceGenerateOp: CompleteOperation<
   name: "acceptance-generate",
   stage: "acceptance",
   jsonMode: false,
-  config: acceptanceConfigSelector,
-  timeoutMs: (_input, ctx) => ctx.config.acceptance.timeoutMs,
+  config: acceptanceGenConfigSelector,
+  timeoutMs: (_input, ctx) => ctx.config.execution.sessionTimeoutSeconds * 1000,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildGeneratorFromPRDPrompt({
       featureName: input.featureName,


### PR DESCRIPTION


This pull request introduces a new configuration selector, `acceptanceGenConfigSelector`, specifically for the acceptance test code generation operation. This change ensures that acceptance test code generation uses a longer timeout (`execution.sessionTimeoutSeconds`) instead of the standard acceptance timeout, which is more appropriate given the operation's complexity. The changes also update the acceptance generation operation to use this new configuration.

**Configuration changes:**

* Added `acceptanceGenConfigSelector` to `src/config/selectors.ts` to provide a separate configuration for acceptance test code generation, using `execution.sessionTimeoutSeconds` for timeouts.
* Exported `acceptanceGenConfigSelector` in `src/config/index.ts`.

**Acceptance test generation operation updates:**

* Updated `src/operations/acceptance-generate.ts` to import and use `acceptanceGenConfigSelector` instead of `acceptanceConfigSelector`.
* Changed the `AcceptanceConfig` type to use the new selector.
* Modified the `acceptanceGenerateOp` operation to use `acceptanceGenConfigSelector` for configuration and to set the timeout based on `execution.sessionTimeoutSeconds`.
- [x] `bun run lint` passes
- [x] `bun test` passes
- [x] `bun run typecheck` passes
## Notes

<!-- Anything reviewers should know? Breaking changes? -->
