### PR TITLE
[codex] Add runtime review auditor

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -68,7 +68,7 @@ Deep reference for each subsystem — consult when working on a specific module.
 - **§33 Error Classes** — `NaxError` + 5 derived error classes
 - **§34 Session Manager** (ADR-011 + ADR-019) — `SessionManager` owns full session lifecycle: `openSession` / `sendPrompt` / `closeSession` / `runInSession` / `nameFor` / `handoff`, 7-state machine, scratch dir, runtime helpers (`failAndClose`)
 - **§35 Agent Manager** (ADR-012 + ADR-019) — `AgentManager` is a peer of `SessionManager`. Three entry points: `completeAs` (sessionless), `runAsSession` (caller-managed handle), `runWithFallback` (chain iteration via `executeHop` callback)
-- **§36 NaxRuntime** (ADR-018) — Single lifecycle container per run: `agentManager`, `sessionManager`, `configLoader`, `costAggregator`, `promptAuditor`, `packages`, `logger`, `signal`. Frozen middleware chain (audit → cost → cancellation → logging) wraps every `runAs` / `completeAs` call.
+- **§36 NaxRuntime** (ADR-018) — Single lifecycle container per run: `agentManager`, `sessionManager`, `configLoader`, `costAggregator`, `promptAuditor`, `reviewAuditor`, `packages`, `logger`, `signal`. Frozen middleware chain (audit → cost → cancellation → logging) wraps every `runAs` / `completeAs` call.
 - **§37 Operations & `callOp`** (ADR-018) — `Operation<I, O, C>` typed spec under `src/operations/`. `callOp(ctx, op, input)` slices config via `packageView.select`, composes prompts via `composeSections`, dispatches `kind:"complete"` to `completeAs` and `kind:"run"` to `runWithFallback` with `buildHopCallback`.
 
 ---
@@ -109,7 +109,7 @@ Deep reference for each subsystem — consult when working on a specific module.
 | Context Engine v2 | Stage-aware context assembly | `ContextOrchestrator.assemble(request)` → `ContextBundle` |
 | Session Manager | Session lifecycle + state machine | `sessionManager.openSession() / sendPrompt() / closeSession() / runInSession() / handoff()` |
 | Agent Manager | Agent default + availability fallback | `agentManager.getDefault() / completeAs() / runAsSession() / runWithFallback()` |
-| NaxRuntime | Single lifecycle container per run | `createRuntime(config, workdir)` → `{ agentManager, sessionManager, configLoader, costAggregator, promptAuditor, … }` |
+| NaxRuntime | Single lifecycle container per run | `createRuntime(config, workdir)` → `{ agentManager, sessionManager, configLoader, costAggregator, promptAuditor, reviewAuditor, … }` |
 | Operation | Typed semantic envelope for LLM work | `Operation<I, O, C>` + `callOp(ctx, op, input)` |
 
 ---

--- a/docs/architecture/subsystems.md
+++ b/docs/architecture/subsystems.md
@@ -536,9 +536,10 @@ Two-phase approach when review fails:
 ### Review Audit Trail
 
 `src/review/review-audit.ts`:
-- Fire-and-forget JSON audit writer for semantic and adversarial reviewer output
+- Runtime-owned JSON audit writer for semantic and adversarial reviewer decisions
 - Directory: `.nax/review-audit/<featureName>/<epochMs>-<sessionName>.json`
-- Tracks parse success, `looksLikeFail` heuristic, and structured result
+- Captures sessionName/sessionId/recordId from reviewer dispatch events
+- Tracks parse success, `looksLikeFail`, fail-open, threshold, and structured result
 - Errors warn but never throw — audit failures cannot interrupt a run
 
 ### Diff Utilities (SSOT)
@@ -1049,6 +1050,7 @@ export interface NaxRuntime {
   readonly sessionManager: ISessionManager;  // Layer 2 — session lifecycle primitive
   readonly costAggregator: ICostAggregator;  // middleware-owned sink; drains on close
   readonly promptAuditor: IPromptAuditor;    // middleware-owned sink; flushes on close
+  readonly reviewAuditor: IReviewAuditor;    // review decision audit; flushes on close
   readonly packages: PackageRegistry;        // root-equiv view when no workdir
   readonly logger: Logger;
   readonly signal: AbortSignal;              // scope-internal AbortController
@@ -1074,8 +1076,9 @@ export interface NaxRuntime {
 ### close() ordering
 
 `close()` is idempotent and drains in this order:
-`signal.abort()` → flush `promptAuditor` → drain `costAggregator`. Errors are
-swallowed and logged (drain must not block run completion).
+`signal.abort()` → flush `promptAuditor` / `reviewAuditor` → drain
+`costAggregator`. Errors are swallowed and logged (drain must not block run
+completion).
 
 ### Why a runtime container?
 

--- a/docs/guides/semantic-review.md
+++ b/docs/guides/semantic-review.md
@@ -238,7 +238,7 @@ When `mechanicalFailedOnly` is `false` or `undefined`, normal escalation behavio
 
 ## Review Audit Trail
 
-Every semantic and adversarial review writes a JSON audit file to `.nax/review-audit/` so operators can inspect exactly what each reviewer decided, regardless of pass/fail.
+When `review.audit.enabled` is true, every semantic and adversarial review writes a JSON audit file to `.nax/review-audit/` so operators can inspect exactly what each reviewer decided, regardless of pass/fail.
 
 ### Directory Layout
 
@@ -258,15 +258,20 @@ Every semantic and adversarial review writes a JSON audit file to `.nax/review-a
 | `featureName` | Feature name (determines subfolder) |
 | `reviewer` | `"semantic"` or `"adversarial"` |
 | `sessionName` | ACP session name — correlates with prompt-audit entries |
+| `sessionId` | ACP volatile session ID, when the reviewer session opened |
+| `recordId` | ACP stable record ID, when the reviewer session opened |
 | `parsed` | `true` if the LLM response parsed into valid review JSON |
 | `looksLikeFail` | (only when `parsed: false`) Whether the raw response contained `"passed":false` |
+| `failOpen` | Whether nax treated the reviewer failure as fail-open |
+| `passed` | Final review decision after threshold handling |
+| `blockingThreshold` | Severity threshold used for blocking vs advisory findings |
 | `result` | Structured `{ passed, findings }` or `null` when parse failed |
 
 ### Behavior
 
-- **Fire-and-forget** — errors warn via the logger but never throw, so an audit failure cannot interrupt a run
-- **Best-effort** — uses `_reviewAuditDeps` injectable deps for testability
-- **Automatic** — no configuration needed; audit files are written whenever semantic or adversarial review runs
+- **Runtime-owned** — `NaxRuntime.reviewAuditor` captures reviewer session metadata and flushes on runtime close
+- **Best-effort** — errors warn via the logger but never throw, so an audit failure cannot interrupt a run
+- **Config gated** — audit files are written whenever semantic or adversarial review runs and `review.audit.enabled` is true
 
 ---
 

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -174,6 +174,9 @@ export function buildHopCallback(
       const send = (turnPrompt: string): Promise<TurnResult> =>
         agentManager.runAsSession(agentName, handle, turnPrompt, {
           storyId: story.id,
+          featureName,
+          workdir,
+          projectDir,
           pipelineStage: stage,
           signal: resolvedRunOptions.abortSignal,
           contextPullTools,

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -38,6 +38,36 @@ export const _adversarialDeps = {
   callOp: _callOp,
 };
 
+function recordAdversarialAudit(opts: {
+  runtime?: import("../runtime").NaxRuntime;
+  workdir: string;
+  projectDir?: string;
+  storyId: string;
+  featureName?: string;
+  parsed: boolean;
+  looksLikeFail?: boolean;
+  failOpen?: boolean;
+  passed?: boolean;
+  blockingThreshold?: "error" | "warning" | "info";
+  result: { passed: boolean; findings: unknown[] } | null;
+  advisoryFindings?: unknown[];
+}): void {
+  opts.runtime?.reviewAuditor.recordDecision({
+    reviewer: "adversarial",
+    workdir: opts.workdir,
+    projectDir: opts.projectDir,
+    storyId: opts.storyId,
+    featureName: opts.featureName,
+    parsed: opts.parsed,
+    looksLikeFail: opts.looksLikeFail,
+    failOpen: opts.failOpen,
+    passed: opts.passed,
+    blockingThreshold: opts.blockingThreshold,
+    result: opts.result,
+    advisoryFindings: opts.advisoryFindings,
+  });
+}
+
 export interface RunAdversarialReviewOptions {
   workdir: string;
   storyGitRef: string | undefined;
@@ -221,6 +251,19 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     });
   } catch (err) {
     logger?.warn("adversarial", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
+    recordAdversarialAudit({
+      runtime,
+      workdir,
+      projectDir,
+      storyId: story.id,
+      featureName,
+      parsed: false,
+      looksLikeFail: false,
+      failOpen: true,
+      passed: true,
+      blockingThreshold,
+      result: null,
+    });
     return {
       check: "adversarial",
       success: true,
@@ -233,18 +276,19 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   }
   if (opResult.failOpen) {
     logger?.warn("adversarial", "Retry exhausted — fail-open", { storyId: story.id });
-    if (naxConfig?.review?.audit?.enabled) {
-      void _adversarialDeps.writeReviewAudit({
-        reviewer: "adversarial",
-        sessionName: "",
-        workdir,
-        storyId: story.id,
-        featureName,
-        parsed: false,
-        looksLikeFail: false,
-        result: null,
-      });
-    }
+    recordAdversarialAudit({
+      runtime,
+      workdir,
+      projectDir,
+      storyId: story.id,
+      featureName,
+      parsed: false,
+      looksLikeFail: false,
+      failOpen: true,
+      passed: true,
+      blockingThreshold,
+      result: null,
+    });
     return {
       check: "adversarial",
       success: true,
@@ -259,18 +303,19 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     logger?.warn("adversarial", "LLM returned truncated JSON with passed:false — treating as failure", {
       storyId: story.id,
     });
-    if (naxConfig?.review?.audit?.enabled) {
-      void _adversarialDeps.writeReviewAudit({
-        reviewer: "adversarial",
-        sessionName: "",
-        workdir,
-        storyId: story.id,
-        featureName,
-        parsed: false,
-        looksLikeFail: true,
-        result: null,
-      });
-    }
+    recordAdversarialAudit({
+      runtime,
+      workdir,
+      projectDir,
+      storyId: story.id,
+      featureName,
+      parsed: false,
+      looksLikeFail: true,
+      failOpen: false,
+      passed: false,
+      blockingThreshold,
+      result: null,
+    });
     return {
       check: "adversarial",
       success: false,
@@ -325,6 +370,19 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
         issue: f.issue,
       })),
     });
+    recordAdversarialAudit({
+      runtime,
+      workdir,
+      projectDir,
+      storyId: story.id,
+      featureName,
+      parsed: true,
+      failOpen: false,
+      passed: false,
+      blockingThreshold: threshold,
+      result: { passed: false, findings: parsed.findings },
+      advisoryFindings,
+    });
     return {
       check: "adversarial",
       success: false,
@@ -345,6 +403,19 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       storyId: story.id,
       durationMs,
     });
+    recordAdversarialAudit({
+      runtime,
+      workdir,
+      projectDir,
+      storyId: story.id,
+      featureName,
+      parsed: true,
+      failOpen: false,
+      passed: true,
+      blockingThreshold: threshold,
+      result: { passed: true, findings: parsed.findings },
+      advisoryFindings,
+    });
     return {
       check: "adversarial",
       success: true,
@@ -361,6 +432,19 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   if (parsed.passed) {
     logger?.info("review", "Adversarial review passed", { storyId: story.id, durationMs });
   }
+  recordAdversarialAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId: story.id,
+    featureName,
+    parsed: true,
+    failOpen: false,
+    passed: parsed.passed,
+    blockingThreshold: threshold,
+    result: { passed: parsed.passed, findings: parsed.findings },
+    advisoryFindings,
+  });
   return {
     check: "adversarial",
     success: parsed.passed,

--- a/src/review/review-audit.ts
+++ b/src/review/review-audit.ts
@@ -18,12 +18,22 @@ import { getSafeLogger } from "../logger";
 import { findNaxProjectRoot } from "../utils/nax-project-root";
 
 export interface ReviewAuditEntry {
+  /** Runtime run ID for correlation with prompt/cost audit. */
+  runId?: string;
   /** Reviewer type. */
   reviewer: "semantic" | "adversarial";
   /** ACP session name — used as part of the filename for correlation with prompt-audit. */
   sessionName: string;
+  /** ACP volatile session ID. */
+  sessionId?: string | null;
+  /** ACP stable record ID. */
+  recordId?: string | null;
   /** Working directory — used to resolve the audit dir when projectDir is absent. */
   workdir: string;
+  /** Project root, when known. */
+  projectDir?: string;
+  /** Agent that produced the reviewed response. */
+  agentName?: string;
   /** Story ID for metadata. */
   storyId?: string;
   /** Feature name — determines the subfolder under review-audit/. */
@@ -35,8 +45,40 @@ export interface ReviewAuditEntry {
   parsed: boolean;
   /** When parsed is false, whether the raw response contained "passed":false. */
   looksLikeFail?: boolean;
+  /** Whether the final review result failed open. */
+  failOpen?: boolean;
+  /** Final review pass/fail after review-domain threshold handling. */
+  passed?: boolean;
+  /** Blocking threshold used to classify findings. */
+  blockingThreshold?: "error" | "warning" | "info";
   /** The structured reviewer result. null when parsed is false. */
   result: { passed: boolean; findings: unknown[] } | null;
+  /** Findings retained as advisory after threshold handling. */
+  advisoryFindings?: unknown[];
+}
+
+export interface ReviewAuditDispatch {
+  runId: string;
+  reviewer: "semantic" | "adversarial";
+  sessionName: string;
+  sessionId?: string | null;
+  recordId?: string | null;
+  workdir?: string;
+  projectDir?: string;
+  agentName?: string;
+  storyId?: string;
+  featureName?: string;
+}
+
+export type ReviewAuditDecision = Omit<ReviewAuditEntry, "sessionName" | "workdir"> & {
+  sessionName?: string;
+  workdir?: string;
+};
+
+export interface IReviewAuditor {
+  recordDispatch(entry: ReviewAuditDispatch): void;
+  recordDecision(entry: ReviewAuditDecision): void;
+  flush(): Promise<void>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -56,6 +98,105 @@ export const _reviewAuditDeps = {
   findNaxProjectRoot,
 };
 
+function auditKey(reviewer: "semantic" | "adversarial", storyId: string | undefined): string {
+  return `${reviewer}:${storyId ?? "_feature"}`;
+}
+
+function fallbackSessionName(entry: ReviewAuditDecision): string {
+  return `review-${entry.reviewer}-${entry.storyId ?? "unknown"}`;
+}
+
+function toPersistedEntry(entry: ReviewAuditEntry, epochMs: number): string {
+  return JSON.stringify(
+    {
+      timestamp: new Date(epochMs).toISOString(),
+      runId: entry.runId ?? null,
+      storyId: entry.storyId ?? null,
+      featureName: entry.featureName ?? null,
+      reviewer: entry.reviewer,
+      sessionName: entry.sessionName,
+      sessionId: entry.sessionId ?? null,
+      recordId: entry.recordId ?? null,
+      agentName: entry.agentName ?? null,
+      parsed: entry.parsed,
+      ...(entry.parsed ? {} : { looksLikeFail: entry.looksLikeFail ?? false }),
+      failOpen: entry.failOpen ?? false,
+      passed: entry.passed ?? entry.result?.passed ?? null,
+      blockingThreshold: entry.blockingThreshold ?? null,
+      result: entry.result,
+      advisoryFindings: entry.advisoryFindings ?? null,
+    },
+    null,
+    2,
+  );
+}
+
+async function persistReviewAudit(entry: ReviewAuditEntry): Promise<void> {
+  const projectRoot = entry.projectDir ?? (await _reviewAuditDeps.findNaxProjectRoot(entry.workdir));
+  const resolvedDir = join(projectRoot, ".nax", "review-audit", entry.featureName ?? "_unknown");
+
+  await _reviewAuditDeps.mkdir(resolvedDir);
+
+  const epochMs = _reviewAuditDeps.now();
+  const filename = `${epochMs}-${entry.sessionName}.json`;
+  await _reviewAuditDeps.writeFile(join(resolvedDir, filename), toPersistedEntry(entry, epochMs));
+}
+
+export function createNoOpReviewAuditor(): IReviewAuditor {
+  return {
+    recordDispatch() {},
+    recordDecision() {},
+    async flush() {},
+  };
+}
+
+export class ReviewAuditor implements IReviewAuditor {
+  private _queue: Promise<void> = Promise.resolve();
+  private readonly _dispatches = new Map<string, ReviewAuditDispatch>();
+
+  constructor(
+    private readonly _runId: string,
+    private readonly _workdir: string,
+  ) {}
+
+  recordDispatch(entry: ReviewAuditDispatch): void {
+    this._dispatches.set(auditKey(entry.reviewer, entry.storyId), entry);
+  }
+
+  recordDecision(entry: ReviewAuditDecision): void {
+    const key = auditKey(entry.reviewer, entry.storyId);
+    const dispatch = this._dispatches.get(key);
+    this._dispatches.delete(key);
+    const merged: ReviewAuditEntry = {
+      ...entry,
+      runId: entry.runId ?? dispatch?.runId ?? this._runId,
+      sessionName: entry.sessionName ?? dispatch?.sessionName ?? fallbackSessionName(entry),
+      sessionId: entry.sessionId ?? dispatch?.sessionId ?? null,
+      recordId: entry.recordId ?? dispatch?.recordId ?? null,
+      workdir: entry.workdir ?? dispatch?.workdir ?? this._workdir,
+      projectDir: entry.projectDir ?? dispatch?.projectDir,
+      agentName: entry.agentName ?? dispatch?.agentName,
+      storyId: entry.storyId ?? dispatch?.storyId,
+      featureName: entry.featureName ?? dispatch?.featureName,
+    };
+
+    this._queue = this._queue
+      .then(() => persistReviewAudit(merged))
+      .catch((err) => {
+        getSafeLogger()?.warn("review-audit", "Failed to write review audit file", {
+          error: String(err),
+          sessionName: merged.sessionName,
+          storyId: merged.storyId,
+          reviewer: merged.reviewer,
+        });
+      });
+  }
+
+  async flush(): Promise<void> {
+    await this._queue;
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Public API
 // ─────────────────────────────────────────────────────────────────────────────
@@ -66,30 +207,7 @@ export const _reviewAuditDeps = {
  */
 export async function writeReviewAudit(entry: ReviewAuditEntry): Promise<void> {
   try {
-    const projectRoot = await _reviewAuditDeps.findNaxProjectRoot(entry.workdir);
-    const resolvedDir = join(projectRoot, ".nax", "review-audit", entry.featureName ?? "_unknown");
-
-    await _reviewAuditDeps.mkdir(resolvedDir);
-
-    const epochMs = _reviewAuditDeps.now();
-    const filename = `${epochMs}-${entry.sessionName}.json`;
-
-    const content = JSON.stringify(
-      {
-        timestamp: new Date(epochMs).toISOString(),
-        storyId: entry.storyId ?? null,
-        featureName: entry.featureName ?? null,
-        reviewer: entry.reviewer,
-        sessionName: entry.sessionName,
-        parsed: entry.parsed,
-        ...(entry.parsed ? {} : { looksLikeFail: entry.looksLikeFail ?? false }),
-        result: entry.result,
-      },
-      null,
-      2,
-    );
-
-    await _reviewAuditDeps.writeFile(join(resolvedDir, filename), content);
+    await persistReviewAudit(entry);
   } catch (err) {
     getSafeLogger()?.warn("review-audit", "Failed to write review audit file", {
       error: String(err),

--- a/src/review/semantic-debate.ts
+++ b/src/review/semantic-debate.ts
@@ -23,6 +23,31 @@ import {
 import type { SemanticReviewConfig } from "./types";
 import type { ReviewCheckResult, SemanticStory } from "./types";
 
+function recordSemanticDebateAudit(opts: {
+  runtime: import("../runtime").NaxRuntime;
+  workdir: string;
+  storyId: string;
+  featureName?: string;
+  parsed: boolean;
+  passed: boolean;
+  blockingThreshold?: "error" | "warning" | "info";
+  result: { passed: boolean; findings: unknown[] } | null;
+  advisoryFindings?: unknown[];
+}): void {
+  opts.runtime.reviewAuditor.recordDecision({
+    reviewer: "semantic",
+    workdir: opts.workdir,
+    storyId: opts.storyId,
+    featureName: opts.featureName,
+    parsed: opts.parsed,
+    failOpen: false,
+    passed: opts.passed,
+    blockingThreshold: opts.blockingThreshold,
+    result: opts.result,
+    advisoryFindings: opts.advisoryFindings,
+  });
+}
+
 export interface SemanticDebateOptions {
   naxConfig: NaxConfig | undefined;
   runtime: import("../runtime").NaxRuntime | undefined;
@@ -140,6 +165,16 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
             storyId: story.id,
             durationMs,
           });
+          recordSemanticDebateAudit({
+            runtime: debateRuntime,
+            workdir,
+            storyId: story.id,
+            featureName,
+            parsed: true,
+            passed: false,
+            blockingThreshold,
+            result: { passed: false, findings },
+          });
           return {
             check: "semantic",
             success: false,
@@ -155,6 +190,16 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
           ? "Semantic review passed (debate+dialogue)"
           : "Semantic review passed (debate+dialogue, all findings non-blocking)";
         logger?.info("review", label, { storyId: story.id, durationMs });
+        recordSemanticDebateAudit({
+          runtime: debateRuntime,
+          workdir,
+          storyId: story.id,
+          featureName,
+          parsed: true,
+          passed: true,
+          blockingThreshold,
+          result: { passed: true, findings },
+        });
         return {
           check: "semantic",
           success: true,
@@ -206,6 +251,17 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
           storyId: story.id,
           durationMs,
         });
+        recordSemanticDebateAudit({
+          runtime: debateRuntime,
+          workdir,
+          storyId: story.id,
+          featureName,
+          parsed: true,
+          passed: false,
+          blockingThreshold: debateThreshold,
+          result: { passed: false, findings: debateFindings },
+          advisoryFindings: debateAdvisory,
+        });
         return {
           check: "semantic",
           success: false,
@@ -223,6 +279,17 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
         storyId: story.id,
         durationMs,
       });
+      recordSemanticDebateAudit({
+        runtime: debateRuntime,
+        workdir,
+        storyId: story.id,
+        featureName,
+        parsed: true,
+        passed: true,
+        blockingThreshold: debateThreshold,
+        result: { passed: true, findings: debateFindings },
+        advisoryFindings: debateAdvisory,
+      });
       return {
         check: "semantic",
         success: true,
@@ -235,6 +302,17 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
       };
     }
     logger?.info("review", "Semantic review passed (debate)", { storyId: story.id, durationMs });
+    recordSemanticDebateAudit({
+      runtime: debateRuntime,
+      workdir,
+      storyId: story.id,
+      featureName,
+      parsed: true,
+      passed: true,
+      blockingThreshold: debateThreshold,
+      result: { passed: true, findings: debateFindings },
+      advisoryFindings: debateAdvisory,
+    });
     return {
       check: "semantic",
       success: true,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -44,6 +44,36 @@ export const _semanticDeps = {
   callOp: _callOp,
 };
 
+function recordSemanticAudit(opts: {
+  runtime?: import("../runtime").NaxRuntime;
+  workdir: string;
+  projectDir?: string;
+  storyId: string;
+  featureName?: string;
+  parsed: boolean;
+  looksLikeFail?: boolean;
+  failOpen?: boolean;
+  passed?: boolean;
+  blockingThreshold?: "error" | "warning" | "info";
+  result: { passed: boolean; findings: unknown[] } | null;
+  advisoryFindings?: unknown[];
+}): void {
+  opts.runtime?.reviewAuditor.recordDecision({
+    reviewer: "semantic",
+    workdir: opts.workdir,
+    projectDir: opts.projectDir,
+    storyId: opts.storyId,
+    featureName: opts.featureName,
+    parsed: opts.parsed,
+    looksLikeFail: opts.looksLikeFail,
+    failOpen: opts.failOpen,
+    passed: opts.passed,
+    blockingThreshold: opts.blockingThreshold,
+    result: opts.result,
+    advisoryFindings: opts.advisoryFindings,
+  });
+}
+
 export interface RunSemanticReviewOptions {
   workdir: string;
   storyGitRef: string | undefined;
@@ -264,6 +294,19 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     });
   } catch (err) {
     logger?.warn("semantic", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });
+    recordSemanticAudit({
+      runtime,
+      workdir,
+      projectDir,
+      storyId: story.id,
+      featureName,
+      parsed: false,
+      looksLikeFail: false,
+      failOpen: true,
+      passed: true,
+      blockingThreshold,
+      result: null,
+    });
     return {
       check: "semantic",
       success: true,
@@ -276,18 +319,19 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
   }
   if (opResult.failOpen) {
     logger?.warn("semantic", "Retry exhausted — fail-open", { storyId: story.id });
-    if (naxConfig?.review?.audit?.enabled) {
-      void _semanticDeps.writeReviewAudit({
-        reviewer: "semantic",
-        sessionName: "",
-        workdir,
-        storyId: story.id,
-        featureName,
-        parsed: false,
-        looksLikeFail: false,
-        result: null,
-      });
-    }
+    recordSemanticAudit({
+      runtime,
+      workdir,
+      projectDir,
+      storyId: story.id,
+      featureName,
+      parsed: false,
+      looksLikeFail: false,
+      failOpen: true,
+      passed: true,
+      blockingThreshold,
+      result: null,
+    });
     return {
       check: "semantic",
       success: true,
@@ -302,18 +346,19 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     logger?.warn("semantic", "LLM returned truncated JSON with passed:false — treating as failure", {
       storyId: story.id,
     });
-    if (naxConfig?.review?.audit?.enabled) {
-      void _semanticDeps.writeReviewAudit({
-        reviewer: "semantic",
-        sessionName: "",
-        workdir,
-        storyId: story.id,
-        featureName,
-        parsed: false,
-        looksLikeFail: true,
-        result: null,
-      });
-    }
+    recordSemanticAudit({
+      runtime,
+      workdir,
+      projectDir,
+      storyId: story.id,
+      featureName,
+      parsed: false,
+      looksLikeFail: true,
+      failOpen: false,
+      passed: false,
+      blockingThreshold,
+      result: null,
+    });
     return {
       check: "semantic",
       success: false,
@@ -367,6 +412,19 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       })),
     });
     const output = `Semantic review failed:\n\n${formatFindings(blockingFindings)}`;
+    recordSemanticAudit({
+      runtime,
+      workdir,
+      projectDir,
+      storyId: story.id,
+      featureName,
+      parsed: true,
+      failOpen: false,
+      passed: false,
+      blockingThreshold: threshold,
+      result: { passed: false, findings: sanitizedParsed.findings },
+      advisoryFindings,
+    });
     return {
       check: "semantic",
       success: false,
@@ -387,6 +445,19 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       storyId: story.id,
       durationMs,
     });
+    recordSemanticAudit({
+      runtime,
+      workdir,
+      projectDir,
+      storyId: story.id,
+      featureName,
+      parsed: true,
+      failOpen: false,
+      passed: true,
+      blockingThreshold: threshold,
+      result: { passed: true, findings: sanitizedParsed.findings },
+      advisoryFindings,
+    });
     return {
       check: "semantic",
       success: true,
@@ -403,6 +474,19 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
   if (sanitizedParsed.passed) {
     logger?.info("review", "Semantic review passed", { storyId: story.id, durationMs });
   }
+  recordSemanticAudit({
+    runtime,
+    workdir,
+    projectDir,
+    storyId: story.id,
+    featureName,
+    parsed: true,
+    failOpen: false,
+    passed: sanitizedParsed.passed,
+    blockingThreshold: threshold,
+    result: { passed: sanitizedParsed.passed, findings: sanitizedParsed.findings },
+    advisoryFindings,
+  });
   return {
     check: "semantic",
     success: sanitizedParsed.passed,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -11,6 +11,13 @@ export type {
   PromptAuditEntry,
   PromptAuditErrorEntry,
 } from "./prompt-auditor";
+export { createNoOpReviewAuditor, ReviewAuditor, _reviewAuditDeps } from "../review/review-audit";
+export type {
+  IReviewAuditor,
+  ReviewAuditDecision,
+  ReviewAuditDispatch,
+  ReviewAuditEntry,
+} from "../review/review-audit";
 export type { PackageView, PackageRegistry } from "./packages";
 export { createPackageRegistry } from "./packages";
 export type { DispatchContext } from "./dispatch-context";
@@ -37,6 +44,8 @@ import { NaxError } from "../errors";
 import { PidRegistry } from "../execution/pid-registry";
 import { getLogger } from "../logger";
 import type { Logger } from "../logger";
+import { ReviewAuditor, createNoOpReviewAuditor } from "../review/review-audit";
+import type { IReviewAuditor } from "../review/review-audit";
 import type { ISessionManager } from "../session";
 import { SessionManager } from "../session";
 import { MiddlewareChain } from "./agent-middleware";
@@ -49,6 +58,7 @@ import {
   attachAuditSubscriber,
   attachCostSubscriber,
   attachLoggingSubscriber,
+  attachReviewAuditSubscriber,
   cancellationMiddleware,
 } from "./middleware";
 import { createPackageRegistry } from "./packages";
@@ -66,6 +76,7 @@ export interface NaxRuntime {
   readonly sessionManager: ISessionManager;
   readonly costAggregator: ICostAggregator;
   readonly promptAuditor: IPromptAuditor;
+  readonly reviewAuditor: IReviewAuditor;
   readonly dispatchEvents: IDispatchEventBus;
   readonly packages: PackageRegistry;
   readonly pidRegistry: PidRegistry;
@@ -80,6 +91,7 @@ export interface CreateRuntimeOptions {
   agentManager?: IAgentManager;
   costAggregator?: ICostAggregator;
   promptAuditor?: IPromptAuditor;
+  reviewAuditor?: IReviewAuditor;
   /**
    * Feature name — used as a subdirectory under the audit dir so each feature
    * has its own folder. Required when promptAudit.enabled is true and no custom
@@ -125,6 +137,10 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     promptAuditor = createNoOpPromptAuditor();
   }
 
+  const reviewAuditor =
+    opts?.reviewAuditor ??
+    (config.review?.audit?.enabled ? new ReviewAuditor(runId, workdir) : createNoOpReviewAuditor());
+
   const defaultAgent = config.agent?.default ?? "claude";
   const pidRegistry = opts?.pidRegistry ?? new PidRegistry(workdir);
 
@@ -160,6 +176,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
   const offLogging = attachLoggingSubscriber(dispatchEvents, runId);
   const offCost = attachCostSubscriber(dispatchEvents, costAggregator, runId);
   const offAudit = attachAuditSubscriber(dispatchEvents, promptAuditor, runId);
+  const offReviewAudit = attachReviewAuditSubscriber(dispatchEvents, reviewAuditor, runId);
 
   const packages = createPackageRegistry(configLoader, workdir);
   const logger = getLogger();
@@ -175,6 +192,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     sessionManager,
     costAggregator,
     promptAuditor,
+    reviewAuditor,
     dispatchEvents,
     packages,
     pidRegistry,
@@ -189,7 +207,8 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
       offLogging();
       offCost();
       offAudit();
-      const results = await Promise.allSettled([promptAuditor.flush(), costAggregator.drain()]);
+      offReviewAudit();
+      const results = await Promise.allSettled([promptAuditor.flush(), reviewAuditor.flush(), costAggregator.drain()]);
       for (const r of results) {
         if (r.status === "rejected") {
           logger.warn("runtime", "close() flush/drain error", { error: String(r.reason) });
@@ -202,3 +221,4 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
 // Suppress unused import warnings — these are re-exported above for the barrel.
 void createNoOpCostAggregator;
 void createNoOpPromptAuditor;
+void createNoOpReviewAuditor;

--- a/src/runtime/middleware/index.ts
+++ b/src/runtime/middleware/index.ts
@@ -2,3 +2,4 @@ export { cancellationMiddleware } from "./cancellation";
 export { attachLoggingSubscriber } from "./logging";
 export { attachCostSubscriber } from "./cost";
 export { attachAuditSubscriber } from "./audit";
+export { attachReviewAuditSubscriber } from "./review-audit";

--- a/src/runtime/middleware/review-audit.ts
+++ b/src/runtime/middleware/review-audit.ts
@@ -1,0 +1,33 @@
+import type { IReviewAuditor } from "../../review/review-audit";
+import type { DispatchEvent, IDispatchEventBus } from "../dispatch-events";
+
+function reviewerFromRole(role: string): "semantic" | "adversarial" | null {
+  if (role === "reviewer-semantic") return "semantic";
+  if (role === "reviewer-adversarial") return "adversarial";
+  return null;
+}
+
+export function attachReviewAuditSubscriber(
+  bus: IDispatchEventBus,
+  auditor: IReviewAuditor,
+  runId: string,
+): () => void {
+  return bus.onDispatch((event: DispatchEvent) => {
+    if (event.kind !== "session-turn") return;
+    const reviewer = reviewerFromRole(event.sessionRole);
+    if (!reviewer) return;
+
+    auditor.recordDispatch({
+      runId,
+      reviewer,
+      sessionName: event.sessionName,
+      sessionId: event.protocolIds.sessionId ?? null,
+      recordId: event.protocolIds.recordId ?? null,
+      workdir: event.workdir,
+      projectDir: event.projectDir,
+      agentName: event.agentName,
+      storyId: event.storyId,
+      featureName: event.featureName,
+    });
+  });
+}

--- a/test/helpers/runtime.ts
+++ b/test/helpers/runtime.ts
@@ -2,6 +2,7 @@ import type { IAgentManager } from "../../src/agents";
 import { DEFAULT_CONFIG } from "../../src/config";
 import type { NaxConfig } from "../../src/config";
 import { createRuntime, type CreateRuntimeOptions, type NaxRuntime } from "../../src/runtime";
+import type { IReviewAuditor } from "../../src/runtime";
 import type { ISessionManager } from "../../src/session/types";
 import { makeMockAgentManager } from "./mock-agent-manager";
 import { makeSessionManager } from "./mock-session-manager";
@@ -47,6 +48,7 @@ export function makeTestRuntime(opts?: TestRuntimeOptions): NaxRuntime {
 export interface MockRuntimeOptions {
   agentManager?: IAgentManager;
   sessionManager?: ISessionManager;
+  reviewAuditor?: IReviewAuditor;
   config?: NaxConfig;
   workdir?: string;
 }
@@ -55,6 +57,7 @@ export function makeMockRuntime(opts: MockRuntimeOptions = {}): NaxRuntime {
   return createRuntime(opts.config ?? DEFAULT_CONFIG, opts.workdir ?? "/tmp/test", {
     agentManager: opts.agentManager ?? makeMockAgentManager(),
     sessionManager: opts.sessionManager ?? makeSessionManager(),
+    reviewAuditor: opts.reviewAuditor,
     featureName: "_test",
   });
 }

--- a/test/unit/review/adversarial-metadata-audit.test.ts
+++ b/test/unit/review/adversarial-metadata-audit.test.ts
@@ -289,7 +289,7 @@ describe("runAdversarialReview — cost propagation", () => {
 });
 
 // ---------------------------------------------------------------------------
-// review.audit gate — writeReviewAudit only called when audit.enabled === true
+// review.audit gate — ReviewAuditor records final decisions
 // ---------------------------------------------------------------------------
 
 describe("runAdversarialReview — review audit gate", () => {
@@ -300,22 +300,28 @@ describe("runAdversarialReview — review audit gate", () => {
 
   afterEach(restoreAllDeps);
 
-  test("audit disabled (default) — writeReviewAudit not called on success", async () => {
+  test("audit disabled (default) — injected ReviewAuditor records success decisions", async () => {
     const auditCalls: unknown[] = [];
-    _adversarialDeps.writeReviewAudit = mock(async (entry) => { auditCalls.push(entry); });
     const agentManager = makeAgentManager(PASSING_RESPONSE);
-    const runtime = makeMockRuntime({ agentManager });
+    const runtime = makeMockRuntime({
+      agentManager,
+      reviewAuditor: { recordDispatch() {}, recordDecision: (entry) => auditCalls.push(entry), async flush() {} },
+    });
 
     await runAdversarialReview({ workdir: "/tmp/wd", storyGitRef: "abc123", story: STORY, adversarialConfig: ADVERSARIAL_CONFIG, agentManager, runtime });
 
-    expect(auditCalls).toHaveLength(0);
+    expect(auditCalls).toHaveLength(1);
+    expect((auditCalls[0] as any).parsed).toBe(true);
+    expect((auditCalls[0] as any).passed).toBe(true);
   });
 
-  test.skip("audit enabled — writeReviewAudit called with parsed:true on success (BUG: ADR-019 migration incomplete — src/ should write audit on all paths per docs/guides/semantic-review.md)", async () => {
+  test("audit enabled — ReviewAuditor records parsed:true on success", async () => {
     const auditCalls: unknown[] = [];
-    _adversarialDeps.writeReviewAudit = mock(async (entry) => { auditCalls.push(entry); });
     const agentManager = makeAgentManager(PASSING_RESPONSE);
-    const runtime = makeMockRuntime({ agentManager });
+    const runtime = makeMockRuntime({
+      agentManager,
+      reviewAuditor: { recordDispatch() {}, recordDecision: (entry) => auditCalls.push(entry), async flush() {} },
+    });
     const naxConfig = { review: { audit: { enabled: true } } } as any;
 
     await runAdversarialReview({ workdir: "/tmp/wd", storyGitRef: "abc123", story: STORY, adversarialConfig: ADVERSARIAL_CONFIG, agentManager, naxConfig, runtime });
@@ -323,13 +329,16 @@ describe("runAdversarialReview — review audit gate", () => {
     expect(auditCalls).toHaveLength(1);
     expect((auditCalls[0] as any).parsed).toBe(true);
     expect((auditCalls[0] as any).reviewer).toBe("adversarial");
+    expect((auditCalls[0] as any).result.passed).toBe(true);
   });
 
-  test("audit enabled — writeReviewAudit called with parsed:false on parse failure", async () => {
+  test("audit enabled — ReviewAuditor records parsed:false on parse failure", async () => {
     const auditCalls: unknown[] = [];
-    _adversarialDeps.writeReviewAudit = mock(async (entry) => { auditCalls.push(entry); });
     const agentManager = makeAgentManager("not json at all");
-    const runtime = makeMockRuntime({ agentManager });
+    const runtime = makeMockRuntime({
+      agentManager,
+      reviewAuditor: { recordDispatch() {}, recordDecision: (entry) => auditCalls.push(entry), async flush() {} },
+    });
     const naxConfig = { review: { audit: { enabled: true } } } as any;
 
     await runAdversarialReview({ workdir: "/tmp/wd", storyGitRef: "abc123", story: STORY, adversarialConfig: ADVERSARIAL_CONFIG, agentManager, naxConfig, runtime });

--- a/test/unit/review/review-audit.test.ts
+++ b/test/unit/review/review-audit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach } from "bun:test";
-import { writeReviewAudit, _reviewAuditDeps } from "../../../src/review/review-audit";
+import { ReviewAuditor, writeReviewAudit, _reviewAuditDeps } from "../../../src/review/review-audit";
 import type { ReviewAuditEntry } from "../../../src/review/review-audit";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -121,7 +121,23 @@ describe("writeReviewAudit", () => {
     expect(content.reviewer).toBe("semantic");
     expect(content.storyId).toBe("US-002");
     expect(content.featureName).toBe("my-feature");
+    expect(content.sessionId).toBeNull();
+    expect(content.recordId).toBeNull();
     expect(content.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("content includes ACP correlation fields when provided", async () => {
+    const { deps, written } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+
+    await writeReviewAudit(makeEntry({ runId: "run-1", sessionId: "sid-1", recordId: "rid-1", agentName: "claude" }));
+    Object.assign(_reviewAuditDeps, saved);
+
+    const content = JSON.parse(written[0].content);
+    expect(content.runId).toBe("run-1");
+    expect(content.sessionId).toBe("sid-1");
+    expect(content.recordId).toBe("rid-1");
+    expect(content.agentName).toBe("claude");
   });
 
   test("falls back to _unknown subfolder when featureName is absent", async () => {
@@ -151,5 +167,117 @@ describe("writeReviewAudit", () => {
 
     await writeReviewAudit(makeEntry());
     Object.assign(_reviewAuditDeps, saved);
+  });
+});
+
+describe("ReviewAuditor", () => {
+  let saved: typeof _reviewAuditDeps;
+
+  beforeEach(() => {
+    saved = { ..._reviewAuditDeps };
+  });
+
+  test("merges review dispatch metadata into final decision audit", async () => {
+    const { deps, written } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+    const auditor = new ReviewAuditor("run-1", "/tmp/workdir");
+
+    auditor.recordDispatch({
+      runId: "run-1",
+      reviewer: "semantic",
+      sessionName: "nax-reviewer-semantic",
+      sessionId: "sid-1",
+      recordId: "rid-1",
+      workdir: "/tmp/workdir",
+      projectDir: "/tmp/project",
+      agentName: "claude",
+      storyId: "US-001",
+      featureName: "my-feature",
+    });
+    auditor.recordDecision({
+      reviewer: "semantic",
+      storyId: "US-001",
+      parsed: true,
+      passed: true,
+      blockingThreshold: "error",
+      result: { passed: true, findings: [] },
+    });
+    await auditor.flush();
+    Object.assign(_reviewAuditDeps, saved);
+
+    const content = JSON.parse(written[0].content);
+    expect(written[0].path).toContain(".nax/review-audit/my-feature");
+    expect(content.sessionName).toBe("nax-reviewer-semantic");
+    expect(content.sessionId).toBe("sid-1");
+    expect(content.recordId).toBe("rid-1");
+    expect(content.agentName).toBe("claude");
+    expect(content.passed).toBe(true);
+    expect(content.blockingThreshold).toBe("error");
+  });
+
+  test("writes decision with fallback session name when dispatch metadata is absent", async () => {
+    const { deps, written } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+    const auditor = new ReviewAuditor("run-1", "/tmp/workdir");
+
+    auditor.recordDecision({
+      reviewer: "adversarial",
+      storyId: "US-404",
+      parsed: false,
+      looksLikeFail: false,
+      failOpen: true,
+      passed: true,
+      result: null,
+    });
+    await auditor.flush();
+    Object.assign(_reviewAuditDeps, saved);
+
+    const content = JSON.parse(written[0].content);
+    expect(content.sessionName).toBe("review-adversarial-US-404");
+    expect(content.sessionId).toBeNull();
+    expect(content.recordId).toBeNull();
+    expect(content.failOpen).toBe(true);
+  });
+
+  test("does not reuse dispatch metadata after a decision is recorded", async () => {
+    const { deps, written } = makeDeps();
+    Object.assign(_reviewAuditDeps, deps);
+    const auditor = new ReviewAuditor("run-1", "/tmp/workdir");
+
+    auditor.recordDispatch({
+      runId: "run-1",
+      reviewer: "semantic",
+      sessionName: "nax-old-review",
+      sessionId: "sid-old",
+      recordId: "rid-old",
+      storyId: "US-001",
+      featureName: "my-feature",
+    });
+    auditor.recordDecision({
+      reviewer: "semantic",
+      storyId: "US-001",
+      parsed: true,
+      passed: true,
+      result: { passed: true, findings: [] },
+    });
+    auditor.recordDecision({
+      reviewer: "semantic",
+      storyId: "US-001",
+      parsed: false,
+      looksLikeFail: false,
+      failOpen: true,
+      passed: true,
+      result: null,
+    });
+    await auditor.flush();
+    Object.assign(_reviewAuditDeps, saved);
+
+    const first = JSON.parse(written[0].content);
+    const second = JSON.parse(written[1].content);
+    expect(first.sessionName).toBe("nax-old-review");
+    expect(first.sessionId).toBe("sid-old");
+    expect(second.sessionName).toBe("review-semantic-US-001");
+    expect(second.sessionId).toBeNull();
+    expect(second.recordId).toBeNull();
   });
 });

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -364,6 +364,36 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     expect(result.success).toBe(true);
   });
 
+  test("records review audit decision for semantic debate result", async () => {
+    const auditCalls: unknown[] = [];
+    _semanticDeps.createDebateRunner = mock(() => ({
+      run: mock(async () => DEBATE_MAJORITY_FAIL_RESULT),
+    }));
+
+    const agentManager = makeAgentManager(PROPOSAL_PASS);
+    const runtime = makeMockRuntime({
+      agentManager,
+      reviewAuditor: { recordDispatch() {}, recordDecision: (entry) => auditCalls.push(entry), async flush() {} },
+    });
+
+    const result = await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: SEMANTIC_CONFIG,
+      agentManager,
+      naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+      runtime,
+    });
+
+    expect(result.success).toBe(false);
+    expect(auditCalls).toHaveLength(1);
+    expect((auditCalls[0] as any).reviewer).toBe("semantic");
+    expect((auditCalls[0] as any).parsed).toBe(true);
+    expect((auditCalls[0] as any).passed).toBe(false);
+    expect((auditCalls[0] as any).result.findings).toHaveLength(1);
+  });
+
   test("AC4: success=false when majority (2 of 3) proposals have passed=false", async () => {
     _semanticDeps.createDebateRunner = mock(() => ({
       run: mock(async () => DEBATE_MAJORITY_FAIL_RESULT),

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -144,8 +144,12 @@ describe("runSemanticReview — JSON retry outcomes", () => {
       passed: true,
       findings: [],
     }));
+    const auditCalls: unknown[] = [];
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
-    const runtime = makeMockRuntime({ agentManager });
+    const runtime = makeMockRuntime({
+      agentManager,
+      reviewAuditor: { recordDispatch() {}, recordDecision: (entry) => auditCalls.push(entry), async flush() {} },
+    });
 
     const result = await runSemanticReview({
       workdir: "/tmp/wd",
@@ -158,6 +162,10 @@ describe("runSemanticReview — JSON retry outcomes", () => {
 
     expect(result.success).toBe(true);
     expect(result.output).toContain("Semantic review passed");
+    expect(auditCalls).toHaveLength(1);
+    expect((auditCalls[0] as any).reviewer).toBe("semantic");
+    expect((auditCalls[0] as any).parsed).toBe(true);
+    expect((auditCalls[0] as any).passed).toBe(true);
   });
 
   test("returns fail-open when callOp returns failOpen", async () => {

--- a/test/unit/runtime/middleware/review-audit.test.ts
+++ b/test/unit/runtime/middleware/review-audit.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import type { ReviewAuditDispatch } from "../../../../src/review/review-audit";
+import { DispatchEventBus } from "../../../../src/runtime/dispatch-events";
+import type { SessionTurnDispatchEvent } from "../../../../src/runtime/dispatch-events";
+import { attachReviewAuditSubscriber } from "../../../../src/runtime/middleware/review-audit";
+
+const PERMS = { mode: "approve-reads" as const, skipPermissions: false };
+
+function makeSessionTurnEvent(overrides: Partial<SessionTurnDispatchEvent> = {}): SessionTurnDispatchEvent {
+  return {
+    kind: "session-turn",
+    sessionName: "nax-abc-feat-s1-reviewer-semantic",
+    sessionRole: "reviewer-semantic",
+    prompt: "Review this",
+    response: JSON.stringify({ passed: true, findings: [] }),
+    agentName: "claude",
+    stage: "review",
+    storyId: "US-001",
+    featureName: "feat",
+    workdir: "/tmp/w",
+    projectDir: "/tmp/p",
+    resolvedPermissions: PERMS,
+    turn: 1,
+    protocolIds: { sessionId: "sid-1", recordId: "rid-1" },
+    origin: "runAsSession",
+    durationMs: 150,
+    timestamp: 1000,
+    ...overrides,
+  };
+}
+
+describe("attachReviewAuditSubscriber", () => {
+  test("captures semantic reviewer session metadata", () => {
+    const recorded: ReviewAuditDispatch[] = [];
+    const bus = new DispatchEventBus();
+    attachReviewAuditSubscriber(
+      bus,
+      { recordDispatch: (e) => recorded.push(e), recordDecision() {}, async flush() {} },
+      "run-1",
+    );
+
+    bus.emitDispatch(makeSessionTurnEvent());
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].reviewer).toBe("semantic");
+    expect(recorded[0].sessionName).toBe("nax-abc-feat-s1-reviewer-semantic");
+    expect(recorded[0].sessionId).toBe("sid-1");
+    expect(recorded[0].recordId).toBe("rid-1");
+    expect(recorded[0].storyId).toBe("US-001");
+    expect(recorded[0].featureName).toBe("feat");
+  });
+
+  test("captures adversarial reviewer session metadata", () => {
+    const recorded: ReviewAuditDispatch[] = [];
+    const bus = new DispatchEventBus();
+    attachReviewAuditSubscriber(
+      bus,
+      { recordDispatch: (e) => recorded.push(e), recordDecision() {}, async flush() {} },
+      "run-1",
+    );
+
+    bus.emitDispatch(
+      makeSessionTurnEvent({
+        sessionName: "nax-abc-feat-s1-reviewer-adversarial",
+        sessionRole: "reviewer-adversarial",
+      }),
+    );
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].reviewer).toBe("adversarial");
+  });
+
+  test("ignores non-review session roles", () => {
+    const recorded: ReviewAuditDispatch[] = [];
+    const bus = new DispatchEventBus();
+    attachReviewAuditSubscriber(
+      bus,
+      { recordDispatch: (e) => recorded.push(e), recordDecision() {}, async flush() {} },
+      "run-1",
+    );
+
+    bus.emitDispatch(makeSessionTurnEvent({ sessionRole: "implementer" }));
+
+    expect(recorded).toHaveLength(0);
+  });
+});

--- a/test/unit/runtime/runtime.test.ts
+++ b/test/unit/runtime/runtime.test.ts
@@ -12,6 +12,7 @@ describe("createRuntime", () => {
     expect(rt.packages).toBeDefined();
     expect(rt.costAggregator).toBeDefined();
     expect(rt.promptAuditor).toBeDefined();
+    expect(rt.reviewAuditor).toBeDefined();
     expect(rt.signal).toBeDefined();
     expect(rt.pidRegistry).toBeDefined();
   });
@@ -94,6 +95,33 @@ describe("createRuntime", () => {
     const config = makeNaxConfig({ agent: { promptAudit: { enabled: true, dir: "/custom/audit" } } });
     const rt = createRuntime(config, "/tmp/test", { featureName: "my-feature" });
     expect(rt.promptAuditor).toBeDefined();
+  });
+
+  test("reviewAuditor exists and is silent when review.audit.enabled is false", () => {
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test");
+    expect(() =>
+      rt.reviewAuditor.recordDecision({
+        reviewer: "semantic",
+        storyId: "US-001",
+        parsed: true,
+        passed: true,
+        result: { passed: true, findings: [] },
+      }),
+    ).not.toThrow();
+  });
+
+  test("reviewAuditor is real when review.audit.enabled is true", () => {
+    const config = makeNaxConfig({ review: { audit: { enabled: true } } });
+    const rt = createRuntime(config, "/tmp/test", { featureName: "my-feature" });
+    expect(() =>
+      rt.reviewAuditor.recordDecision({
+        reviewer: "adversarial",
+        storyId: "US-001",
+        parsed: true,
+        passed: true,
+        result: { passed: true, findings: [] },
+      }),
+    ).not.toThrow();
   });
 
   test("close() resolves when flush() throws", async () => {
@@ -181,6 +209,20 @@ describe("createRuntime", () => {
     const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test", { promptAuditor, costAggregator });
     await rt.close();
     expect(flushCalled).toBe(true);
+  });
+
+  test("close() flushes reviewAuditor", async () => {
+    let reviewFlushCalled = false;
+    const reviewAuditor = {
+      recordDispatch() {},
+      recordDecision() {},
+      async flush() { reviewFlushCalled = true; },
+    };
+    const rt = createRuntime(DEFAULT_CONFIG, "/tmp/test", { reviewAuditor });
+
+    await rt.close();
+
+    expect(reviewFlushCalled).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements runtime-owned review audit recording for semantic, adversarial, and semantic-debate review decisions.

- Adds a `ReviewAuditor` alongside `promptAuditor`, gated by `review.audit.enabled`.
- Captures ACP dispatch metadata from review session turns, including `sessionName`, `sessionId`, and `recordId`.
- Records review audit files for both passing and failing decisions, including fail-open, advisory, and blocking outcomes.
- Adds middleware, runtime wiring, focused unit coverage, and documentation updates.

Fixes #839.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun test test/unit/review/review-audit.test.ts test/unit/review/semantic-debate.test.ts --timeout=30000`
- `bun test test/unit/review --timeout=30000`
- `bun test test/unit/runtime/runtime.test.ts test/unit/runtime/middleware/review-audit.test.ts --timeout=30000`
- pre-commit hook: typecheck, lint, process.cwd check, adapter wrap check, dispatch context check