### PR TITLE
feat(ops): wire per-call model resolver through callOp (#725)

### DIFF
--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -136,7 +136,10 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "review.commands.test": "Custom test command for review",
   "review.commands.build": "Custom build command for review",
   "review.semantic": "Semantic review configuration (code quality analysis)",
-  "review.semantic.modelTier": "Model tier for semantic review (default: balanced)",
+  "review.semantic.model":
+    'Model selector for semantic review. Accepts a tier string ("fast" | "balanced" | "powerful") or an explicit object like { agent: "codex", model: "gpt-5.4" }.',
+  "review.adversarial.model":
+    "Model selector for adversarial review. Accepts a tier string or an explicit { agent, model } pin.",
   "review.semantic.diffMode":
     "How the semantic reviewer accesses the git diff. 'ref' (default) passes only the git ref and file list — the reviewer fetches the full diff via tools. 'embedded' includes the diff in the prompt (truncated at 50KB).",
   "review.semantic.resetRefOnRerun":

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -11,7 +11,7 @@ import { getLogger } from "../logger";
 import { loadJsonFile } from "../utils/json-file";
 import { mergePackageConfig } from "./merge";
 import { deepMergeConfig } from "./merger";
-import { migrateLegacyTestPattern } from "./migrations";
+import { migrateLegacyReviewModelKey, migrateLegacyTestPattern } from "./migrations";
 import { MAX_DIRECTORY_DEPTH } from "./path-security";
 import { PROJECT_NAX_DIR, globalConfigDir } from "./paths";
 import { loadProfile, loadProfileEnv, resolveProfileName } from "./profile";
@@ -186,7 +186,9 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
   if (globalConfRaw) {
     const { profile: _gProfile, ...globalConfStripped } = globalConfRaw;
     const globalConf = applyBatchModeCompat(
-      applyRemovedStrategyCompat(migrateLegacyTestPattern(globalConfStripped, logger)),
+      applyRemovedStrategyCompat(
+        migrateLegacyReviewModelKey(migrateLegacyTestPattern(globalConfStripped, logger), logger),
+      ),
     );
     rawConfig = deepMergeConfig(rawConfig, globalConf);
   }
@@ -197,7 +199,9 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
     if (projConf) {
       const { profile: _pProfile, ...projConfStripped } = projConf;
       const resolvedProjConf = applyBatchModeCompat(
-        applyRemovedStrategyCompat(migrateLegacyTestPattern(projConfStripped, logger)),
+        applyRemovedStrategyCompat(
+          migrateLegacyReviewModelKey(migrateLegacyTestPattern(projConfStripped, logger), logger),
+        ),
       );
       rawConfig = deepMergeConfig(rawConfig, resolvedProjConf);
     }

--- a/src/config/migrations.ts
+++ b/src/config/migrations.ts
@@ -71,3 +71,61 @@ export function migrateLegacyTestPattern(raw: Record<string, unknown>, logger: L
 
   return { ...raw, execution: migratedExecution, context: migratedContext };
 }
+
+/**
+ * Alias the deprecated `review.semantic.modelTier` and `review.adversarial.modelTier`
+ * (string tier label) to `review.{semantic,adversarial}.model` (ConfiguredModel).
+ *
+ * Behaviour per block:
+ * - If `modelTier` is absent → no-op for that block.
+ * - If both `modelTier` and `model` are set → both are kept dropped except `model`
+ *   (canonical wins); we do NOT throw — `model` is a strict superset and the user
+ *   has already adopted the new key.
+ * - If only `modelTier` is present → alias: `model = modelTier`, drop `modelTier`.
+ *
+ * In all migrated cases the `modelTier` key is removed from the output to keep
+ * the deprecated field out of Zod-parsed config (Zod is in `.strip()` mode so it
+ * would silently drop, but we drop here to log + keep one place to maintain).
+ */
+export function migrateLegacyReviewModelKey(
+  raw: Record<string, unknown>,
+  logger: Logger | null,
+): Record<string, unknown> {
+  type Block = { modelTier?: unknown; model?: unknown; [k: string]: unknown };
+  type RawReview = { semantic?: Block; adversarial?: Block; [k: string]: unknown };
+
+  const review = raw.review as RawReview | undefined;
+  if (!review) return raw;
+
+  const semantic = migrateBlock(review.semantic, "review.semantic", logger);
+  const adversarial = migrateBlock(review.adversarial, "review.adversarial", logger);
+  if (semantic === review.semantic && adversarial === review.adversarial) return raw;
+
+  return {
+    ...raw,
+    review: {
+      ...review,
+      ...(semantic !== undefined ? { semantic } : {}),
+      ...(adversarial !== undefined ? { adversarial } : {}),
+    },
+  };
+
+  function migrateBlock(block: Block | undefined, path: string, log: Logger | null): Block | undefined {
+    if (!block || block.modelTier === undefined) return block;
+    const { modelTier, ...rest } = block;
+    if (block.model !== undefined) {
+      log?.warn(
+        "config",
+        `${path}.modelTier is deprecated and ignored — ${path}.model is set and wins. Remove ${path}.modelTier.`,
+        { legacyKey: `${path}.modelTier`, canonicalKey: `${path}.model` },
+      );
+      return rest;
+    }
+    log?.warn(
+      "config",
+      `${path}.modelTier is deprecated — migrate to ${path}.model (accepts the same tier string or a { agent, model } pin). Migration shim applied.`,
+      { legacyKey: `${path}.modelTier`, canonicalKey: `${path}.model`, value: modelTier },
+    );
+    return { ...rest, model: modelTier };
+  }
+}

--- a/src/config/schemas-review.ts
+++ b/src/config/schemas-review.ts
@@ -4,10 +4,16 @@
  */
 
 import { z } from "zod";
-import { ModelTierSchema } from "./schemas-model";
+import { ConfiguredModelSchema } from "./schemas-model";
 
 const SemanticReviewConfigSchema = z.object({
-  modelTier: ModelTierSchema.default("balanced"),
+  /**
+   * Model selector for semantic review. Tier label or `{ agent, model }` pin.
+   * Renamed from `modelTier` (schema-types ConfiguredModel widening). Legacy
+   * `modelTier` keys are migrated by `migrateLegacyReviewModelKey` in the
+   * config loader and rejected if both keys are present.
+   */
+  model: ConfiguredModelSchema.default("balanced"),
   /**
    * How the semantic reviewer accesses the git diff.
    * "embedded": pre-collected diff truncated at 50KB and embedded in prompt.
@@ -40,7 +46,11 @@ export const ReviewDialogueConfigSchema = z.object({
  * Destructive heuristics: finds what is missing or broken, not what is present.
  */
 export const AdversarialReviewConfigSchema = z.object({
-  modelTier: ModelTierSchema.default("balanced"),
+  /**
+   * Model selector for adversarial review. Tier label or `{ agent, model }` pin.
+   * See SemanticReviewConfigSchema.model for migration notes.
+   */
+  model: ConfiguredModelSchema.default("balanced"),
   /**
    * "ref" (default): reviewer self-serves the full diff via git tools — no 50KB cap,
    *   test files included. Instructs reviewer to run git diff commands.

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -190,7 +190,7 @@ export const NaxConfigSchema = z
       audit: { enabled: false },
       blockingThreshold: "error",
       semantic: {
-        modelTier: "balanced",
+        model: "balanced",
         diffMode: "ref",
         resetRefOnRerun: false,
         rules: [],

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -71,6 +71,8 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
   stage: "review",
   session: { role: "reviewer-adversarial", lifetime: "fresh" },
   config: reviewConfigSelector,
+  // Issue #725 — per-call tier from user-configured AdversarialReviewConfig.model.
+  model: (input) => input.adversarialConfig.model,
   timeoutMs: (input) => input.adversarialConfig.timeoutMs,
   hopBody: adversarialReviewHopBody,
   build(input, _ctx) {

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -14,6 +14,16 @@ function normalizeSelector<C>(s: ConfigSelector<C> | readonly (keyof NaxConfig)[
   return s as ConfigSelector<C>;
 }
 
+function resolveOpModel<I, O, C>(
+  op: Operation<I, O, C>,
+  input: I,
+  buildCtx: BuildContext<C>,
+): ConfiguredModel | undefined {
+  const m = (op as { model?: ConfiguredModel | ((i: I, ctx: BuildContext<C>) => ConfiguredModel | undefined) }).model;
+  if (typeof m === "function") return m(input, buildCtx);
+  return m;
+}
+
 function resolveTimeoutMs<I, O, C>(op: Operation<I, O, C>, input: I, buildCtx: BuildContext<C>): number | undefined {
   const timeoutMs = op.timeoutMs?.(input, buildCtx);
   if (timeoutMs === undefined) return undefined;
@@ -63,7 +73,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
 
   const config = ctx.runtime.configLoader.current();
   const defaultAgent = ctx.runtime.agentManager.getDefault();
-  const opModel: ConfiguredModel = (op as { model?: ConfiguredModel }).model ?? "balanced";
+  const opModel: ConfiguredModel = resolveOpModel(op, input, buildCtx) ?? "balanced";
   // resolved.agent honors `{ agent, model }` pin (cross-agent overrides);
   // resolved.modelTier is undefined when an explicit non-tier model is pinned.
   const resolved = resolveConfiguredModel(config.models, ctx.agentName, opModel, defaultAgent);

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -74,6 +74,10 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
   stage: "review",
   session: { role: "reviewer-semantic", lifetime: "fresh" },
   config: reviewConfigSelector,
+  // Issue #725 — per-call tier from user-configured SemanticReviewConfig.model.
+  // Without this resolver callOp would fall through to its "balanced" default and
+  // silently ignore the user's review.semantic.model setting.
+  model: (input) => input.semanticConfig.model,
   timeoutMs: (input) => input.semanticConfig.timeoutMs,
   hopBody: semanticReviewHopBody,
   build(input, _ctx) {

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -115,15 +115,18 @@ export type HopBody<I> = (initialPrompt: string, ctx: HopBodyContext<I>) => Prom
 
 export interface RunOperation<I, O, C> extends OperationBase<I, O, C> {
   readonly kind: "run";
-  /** Reserved for future model-tier override; not yet consumed by callOp (Wave 3). */
-  readonly mode?: string;
   /**
-   * Model selection for this op. Accepts either a tier label
-   * ("fast" | "balanced" | "powerful") or an explicit `{ agent, model }`
-   * pin (for cross-agent or shorthand-aliased model overrides). Resolved via
-   * `resolveConfiguredModel` in callOp. Defaults to "balanced" when omitted.
+   * Model selection for this op. Accepts either:
+   * - a `ConfiguredModel` literal (tier label like "fast"/"balanced"/"powerful"
+   *   or an explicit `{ agent, model }` pin), or
+   * - a resolver `(input, ctx) => ConfiguredModel | undefined` that derives the
+   *   selection from per-call input or per-package config (e.g. semantic /
+   *   adversarial review ops carry their tier on `input.semanticConfig.model`).
+   *
+   * A resolver returning `undefined` falls back to "balanced". Callop resolves
+   * the final selection via `resolveConfiguredModel`.
    */
-  readonly model?: ConfiguredModel;
+  readonly model?: OperationModel<I, C>;
   readonly session: {
     readonly role: SessionRole;
     readonly lifetime: "fresh" | "warm";
@@ -145,12 +148,22 @@ export interface CompleteOperation<I, O, C> extends OperationBase<I, O, C> {
   readonly kind: "complete";
   readonly jsonMode?: boolean;
   /**
-   * Model selection for this call. Accepts a tier label or an explicit
-   * `{ agent, model }` pin. Resolved via `resolveConfiguredModel` in callOp.
-   * Defaults to "balanced" when omitted.
+   * Model selection for this call. Accepts a `ConfiguredModel` literal or a
+   * resolver `(input, ctx) => ConfiguredModel | undefined`. Resolver returning
+   * `undefined` falls back to "balanced". Resolved via `resolveConfiguredModel`
+   * in callOp.
    */
-  readonly model?: ConfiguredModel;
+  readonly model?: OperationModel<I, C>;
 }
+
+/**
+ * Operation model selector — literal value or resolver function.
+ *
+ * Resolver form lets ops derive the selection from per-call input or per-package
+ * config (e.g. `(input) => input.semanticConfig.model`). Mirrors the shape of
+ * `OperationBase.timeoutMs` so per-op runtime customization is uniform.
+ */
+export type OperationModel<I, C> = ConfiguredModel | ((input: I, ctx: BuildContext<C>) => ConfiguredModel | undefined);
 
 export type Operation<I, O, C> = RunOperation<I, O, C> | CompleteOperation<I, O, C>;
 

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -128,7 +128,7 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   const diffMode = adversarialConfig.diffMode ?? "ref";
   logger?.info("review", "Running adversarial check", {
     storyId: story.id,
-    modelTier: adversarialConfig.modelTier,
+    model: adversarialConfig.model,
     diffMode,
   });
 
@@ -183,7 +183,7 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   if (!effectiveAgentManager) {
     logger?.warn("adversarial", "No agent available for adversarial review — skipping", {
       storyId: story.id,
-      modelTier: adversarialConfig.modelTier,
+      model: adversarialConfig.model,
     });
     return {
       check: "adversarial",

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -9,7 +9,7 @@ import type { SemanticVerdict } from "../acceptance/types";
 import type { IAgentManager } from "../agents";
 import type { SessionHandle } from "../agents/types";
 import type { NaxConfig } from "../config";
-import { resolveModelForAgent } from "../config/schema-types";
+import { resolveConfiguredModel } from "../config/schema-types";
 import type { DebateResolverContext } from "../debate/types";
 import { NaxError } from "../errors";
 import type { ReviewFinding } from "../plugins/types";
@@ -241,13 +241,13 @@ export function createReviewerSession(
   );
 
   function resolveRunParams(semanticConfig: SemanticReviewConfig) {
-    const modelTier = semanticConfig.modelTier;
     const defaultAgent = agentManager.getDefault();
-    const modelDef = resolveModelForAgent(_config.models, defaultAgent, modelTier, defaultAgent);
+    const resolved = resolveConfiguredModel(_config.models, defaultAgent, semanticConfig.model, defaultAgent);
+    const modelTier = resolved.modelTier ?? "balanced";
     const timeoutSeconds = semanticConfig.timeoutMs
       ? Math.ceil(semanticConfig.timeoutMs / 1000)
       : (_config.execution?.sessionTimeoutSeconds ?? 3600);
-    return { modelTier, modelDef, timeoutSeconds };
+    return { modelTier, modelDef: resolved.modelDef, timeoutSeconds };
   }
 
   function buildEffectivePrompt(prompt: string): string {
@@ -371,7 +371,7 @@ export function createReviewerSession(
       const effectiveSemanticConfig =
         lastSemanticConfig ??
         ({
-          modelTier: "balanced",
+          model: "balanced",
           diffMode: "embedded",
           resetRefOnRerun: false,
           rules: [],

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -314,7 +314,7 @@ export class ReviewOrchestrator {
           acceptanceCriteria: story?.acceptanceCriteria ?? [],
         };
         const semanticCfg = reviewConfig.semantic ?? {
-          modelTier: "balanced" as const,
+          model: "balanced" as const,
           diffMode: "ref" as const,
           resetRefOnRerun: false,
           rules: [] as string[],

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -321,7 +321,7 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
         acceptanceCriteria: story?.acceptanceCriteria ?? [],
       };
       const semanticCfg = config.semantic ?? {
-        modelTier: "balanced" as const,
+        model: "balanced" as const,
         diffMode: "ref" as const,
         resetRefOnRerun: false,
         rules: [] as string[],
@@ -365,7 +365,7 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
         acceptanceCriteria: story?.acceptanceCriteria ?? [],
       };
       const adversarialCfg = config.adversarial ?? {
-        modelTier: "balanced" as const,
+        model: "balanced" as const,
         diffMode: "ref" as const,
         rules: [] as string[],
         timeoutMs: 600_000,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -139,7 +139,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
   const diffMode = semanticConfig.diffMode ?? "ref";
   logger?.info("review", "Running semantic check", {
     storyId: story.id,
-    modelTier: semanticConfig.modelTier,
+    model: semanticConfig.model,
     diffMode,
     configProvided: !!naxConfig,
   });
@@ -191,7 +191,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
   if (!effectiveAgentManager) {
     logger?.warn("semantic", "No agent available for semantic review — skipping", {
       storyId: story.id,
-      modelTier: semanticConfig.modelTier,
+      model: semanticConfig.model,
     });
     return {
       check: "semantic",

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -26,8 +26,12 @@ export interface SemanticStory {
 
 /** Semantic review configuration */
 export interface SemanticReviewConfig {
-  /** Model tier for semantic review (default: 'balanced') */
-  modelTier: import("../config/schema-types").ModelTier;
+  /**
+   * Model selector for semantic review (default: 'balanced').
+   * Accepts a tier label ("fast" | "balanced" | "powerful") or an explicit
+   * `{ agent, model }` pin for cross-agent overrides.
+   */
+  model: import("../config/schema-types").ConfiguredModel;
   /**
    * How the semantic reviewer accesses the git diff.
    * "embedded": pre-collected diff truncated at 50KB and embedded in prompt.
@@ -133,8 +137,11 @@ export interface ReviewDialogueConfig {
 
 /** Adversarial review configuration (when 'adversarial' is in checks) */
 export interface AdversarialReviewConfig {
-  /** Model tier for adversarial review (default: 'balanced') */
-  modelTier: import("../config/schema-types").ModelTier;
+  /**
+   * Model selector for adversarial review (default: 'balanced').
+   * Accepts a tier label or an explicit `{ agent, model }` pin.
+   */
+  model: import("../config/schema-types").ConfiguredModel;
   /**
    * "ref" (default): reviewer self-serves the full diff via git tools — no 50KB cap,
    *   test files included.

--- a/test/unit/config/migrations.test.ts
+++ b/test/unit/config/migrations.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { migrateLegacyTestPattern } from "../../../src/config/migrations";
+import { migrateLegacyReviewModelKey, migrateLegacyTestPattern } from "../../../src/config/migrations";
 
 describe("migrateLegacyTestPattern", () => {
   test("no-op when testPattern absent", () => {
@@ -89,5 +89,84 @@ describe("migrateLegacyTestPattern", () => {
     expect(runner?.enabled).toBe(true);
     expect(runner?.fallback).toBe("import-grep");
     expect(runner?.testFilePatterns).toEqual(["**/*.test.ts"]);
+  });
+});
+
+// Issue #725 — review.semantic.modelTier and review.adversarial.modelTier
+// were renamed to review.{semantic,adversarial}.model with widened type
+// (ConfiguredModel). Existing user configs must keep loading; migration
+// runs before Zod parse so .strip() doesn't silently drop the legacy key.
+describe("migrateLegacyReviewModelKey", () => {
+  test("no-op when review block absent", () => {
+    const raw: Record<string, unknown> = { execution: {} };
+    const result = migrateLegacyReviewModelKey(raw, null);
+    expect(result).toBe(raw);
+  });
+
+  test("no-op when neither modelTier is set", () => {
+    const raw: Record<string, unknown> = {
+      review: { semantic: { rules: [] }, adversarial: { rules: [] } },
+    };
+    const result = migrateLegacyReviewModelKey(raw, null);
+    expect(result).toBe(raw);
+  });
+
+  test("aliases semantic.modelTier to semantic.model", () => {
+    const raw: Record<string, unknown> = {
+      review: { semantic: { modelTier: "powerful", rules: [] } },
+    };
+    const result = migrateLegacyReviewModelKey(raw, null);
+    const sem = (result.review as any)?.semantic;
+    expect(sem?.model).toBe("powerful");
+    expect(sem?.modelTier).toBeUndefined();
+    expect(sem?.rules).toEqual([]);
+  });
+
+  test("aliases adversarial.modelTier to adversarial.model", () => {
+    const raw: Record<string, unknown> = {
+      review: { adversarial: { modelTier: "fast", parallel: true } },
+    };
+    const result = migrateLegacyReviewModelKey(raw, null);
+    const adv = (result.review as any)?.adversarial;
+    expect(adv?.model).toBe("fast");
+    expect(adv?.modelTier).toBeUndefined();
+    expect(adv?.parallel).toBe(true);
+  });
+
+  test("when both modelTier and model present, model wins and modelTier is dropped", () => {
+    const raw: Record<string, unknown> = {
+      review: {
+        semantic: { modelTier: "fast", model: "powerful", rules: [] },
+      },
+    };
+    const result = migrateLegacyReviewModelKey(raw, null);
+    const sem = (result.review as any)?.semantic;
+    expect(sem?.model).toBe("powerful");
+    expect(sem?.modelTier).toBeUndefined();
+  });
+
+  test("does not mutate input", () => {
+    const raw: Record<string, unknown> = {
+      review: { semantic: { modelTier: "powerful", rules: [] } },
+    };
+    const original = structuredClone(raw);
+    migrateLegacyReviewModelKey(raw, null);
+    expect(raw).toEqual(original);
+  });
+
+  test("only one of {semantic, adversarial} migrating leaves the other untouched", () => {
+    const raw: Record<string, unknown> = {
+      review: {
+        semantic: { modelTier: "fast", rules: [] },
+        adversarial: { rules: [], model: "balanced" },
+      },
+    };
+    const result = migrateLegacyReviewModelKey(raw, null);
+    const sem = (result.review as any)?.semantic;
+    const adv = (result.review as any)?.adversarial;
+    expect(sem?.model).toBe("fast");
+    expect(sem?.modelTier).toBeUndefined();
+    expect(adv?.model).toBe("balanced");
+    expect(adv?.modelTier).toBeUndefined();
   });
 });

--- a/test/unit/config/semantic-review.test.ts
+++ b/test/unit/config/semantic-review.test.ts
@@ -47,22 +47,34 @@ describe("ReviewCheckName type", () => {
 });
 
 describe("SemanticReviewConfig", () => {
-  test("SemanticReviewConfig has modelTier field of type ModelTier", () => {
+  test("SemanticReviewConfig has model field of type ConfiguredModel (tier label)", () => {
     const config: SemanticReviewConfig = {
-      modelTier: "balanced",
+      model: "balanced",
       diffMode: "embedded",
       resetRefOnRerun: false,
       rules: [],
       timeoutMs: 600_000,
       excludePatterns: [],
     };
-    expect(config.modelTier).toBe("balanced");
-    expect(typeof config.modelTier).toBe("string");
+    expect(config.model).toBe("balanced");
+    expect(typeof config.model).toBe("string");
+  });
+
+  test("SemanticReviewConfig.model accepts an explicit { agent, model } pin", () => {
+    const config: SemanticReviewConfig = {
+      model: { agent: "codex", model: "gpt-5.4" },
+      diffMode: "embedded",
+      resetRefOnRerun: false,
+      rules: [],
+      timeoutMs: 600_000,
+      excludePatterns: [],
+    };
+    expect(config.model).toEqual({ agent: "codex", model: "gpt-5.4" });
   });
 
   test("SemanticReviewConfig has rules field of type string[]", () => {
     const config: SemanticReviewConfig = {
-      modelTier: "balanced",
+      model: "balanced",
       diffMode: "embedded",
       resetRefOnRerun: false,
       rules: ["rule1", "rule2"],
@@ -74,22 +86,18 @@ describe("SemanticReviewConfig", () => {
   });
 
   test("SemanticReviewConfig accepts all ModelTier values", () => {
-    const tiers: Array<"fast" | "balanced" | "powerful"> = [
-      "fast",
-      "balanced",
-      "powerful",
-    ];
+    const tiers: Array<"fast" | "balanced" | "powerful"> = ["fast", "balanced", "powerful"];
 
     tiers.forEach((tier) => {
       const config: SemanticReviewConfig = {
-        modelTier: tier,
+        model: tier,
         diffMode: "embedded",
         resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
         excludePatterns: [],
       };
-      expect(config.modelTier).toBe(tier);
+      expect(config.model).toBe(tier);
     });
   });
 });
@@ -101,7 +109,7 @@ describe("ReviewConfig semantic field", () => {
       review: {
         ...DEFAULT_CONFIG.review,
         semantic: {
-          modelTier: "balanced" as const,
+          model: "balanced" as const,
           rules: [],
         },
       },
@@ -110,7 +118,7 @@ describe("ReviewConfig semantic field", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.review.semantic).toEqual({
-        modelTier: "balanced",
+        model: "balanced",
         diffMode: "ref",
         resetRefOnRerun: false,
         rules: [],
@@ -163,13 +171,13 @@ describe("ReviewConfig semantic field", () => {
 });
 
 describe("ReviewConfigSchema semantic validation", () => {
-  test("semantic.modelTier defaults to 'balanced'", () => {
+  test("semantic.model defaults to 'balanced'", () => {
     const config = {
       ...DEFAULT_CONFIG,
       review: {
         ...DEFAULT_CONFIG.review,
         semantic: {
-          modelTier: "balanced",
+          model: "balanced",
           rules: [],
         },
       },
@@ -177,7 +185,7 @@ describe("ReviewConfigSchema semantic validation", () => {
     const result = NaxConfigSchema.safeParse(config);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.review.semantic?.modelTier).toBe("balanced");
+      expect(result.data.review.semantic?.model).toBe("balanced");
     }
   });
 
@@ -187,7 +195,7 @@ describe("ReviewConfigSchema semantic validation", () => {
       review: {
         ...DEFAULT_CONFIG.review,
         semantic: {
-          modelTier: "balanced",
+          model: "balanced",
           rules: [],
         },
       },
@@ -199,14 +207,14 @@ describe("ReviewConfigSchema semantic validation", () => {
     }
   });
 
-  test("semantic can omit modelTier and get default", () => {
+  test("semantic can omit model and get default", () => {
     const config = {
       ...DEFAULT_CONFIG,
       review: {
         ...DEFAULT_CONFIG.review,
         checks: ["semantic"],
         semantic: {
-          modelTier: "balanced",
+          model: "balanced",
           rules: [],
         },
       },
@@ -214,7 +222,7 @@ describe("ReviewConfigSchema semantic validation", () => {
     const result = NaxConfigSchema.safeParse(config);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.review.semantic?.modelTier).toBe("balanced");
+      expect(result.data.review.semantic?.model).toBe("balanced");
     }
   });
 
@@ -224,7 +232,7 @@ describe("ReviewConfigSchema semantic validation", () => {
       review: {
         ...DEFAULT_CONFIG.review,
         semantic: {
-          modelTier: "powerful",
+          model: "powerful",
           rules: ["no-mutations", "immutable-defaults"],
         },
       },
@@ -245,8 +253,8 @@ describe("DEFAULT_CONFIG.review.semantic", () => {
     expect(DEFAULT_CONFIG.review.semantic).toBeDefined();
   });
 
-  test("DEFAULT_CONFIG.review.semantic.modelTier equals 'balanced'", () => {
-    expect(DEFAULT_CONFIG.review.semantic?.modelTier).toBe("balanced");
+  test("DEFAULT_CONFIG.review.semantic.model equals 'balanced'", () => {
+    expect(DEFAULT_CONFIG.review.semantic?.model).toBe("balanced");
   });
 
   test("DEFAULT_CONFIG.review.semantic.rules equals empty array", () => {
@@ -255,7 +263,7 @@ describe("DEFAULT_CONFIG.review.semantic", () => {
 
   test("DEFAULT_CONFIG.review.semantic has correct defaults", () => {
     expect(DEFAULT_CONFIG.review.semantic).toEqual({
-      modelTier: "balanced",
+      model: "balanced",
       diffMode: "ref",
       resetRefOnRerun: false,
       rules: [],
@@ -280,7 +288,7 @@ describe("Semantic check in review.checks with semantic config", () => {
     if (result.success) {
       // After parsing, semantic should have defaults
       expect(result.data.review.semantic).toBeDefined();
-      expect(result.data.review.semantic?.modelTier).toBe("balanced");
+      expect(result.data.review.semantic?.model).toBe("balanced");
       expect(result.data.review.semantic?.rules).toEqual([]);
     }
   });

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -11,7 +11,7 @@ const SAMPLE_STORY = {
 };
 
 const SAMPLE_CONFIG = {
-  modelTier: "balanced" as const,
+  model: "balanced" as const,
   diffMode: "ref" as const,
   rules: [],
   timeoutMs: 600_000,

--- a/test/unit/operations/call.test.ts
+++ b/test/unit/operations/call.test.ts
@@ -287,3 +287,156 @@ describe("callOp — kind:run (ADR-019 §5)", () => {
     ).rejects.toThrow("invalid timeoutMs");
   });
 });
+
+// Issue #725 — RunOperation.model / CompleteOperation.model accept either a
+// literal ConfiguredModel or a resolver `(input, ctx) => ConfiguredModel`. The
+// resolver form is what unblocks per-call tier selection from input config
+// (e.g. semanticReviewOp reads `input.semanticConfig.model`). Without these
+// tests a future refactor could silently drop the resolver path and we'd be
+// back to "balanced is hardcoded".
+describe("callOp — op.model resolver (issue #725)", () => {
+  test("CompleteOperation: literal model is forwarded to completeAs.model", async () => {
+    const completeResult: CompleteResult = { output: "ok", costUsd: 0, source: "exact" };
+    const agentManager = makeMockAgentManager({ completeAsFn: async () => completeResult });
+    const runtime = makeTestRuntime({ agentManager });
+
+    const opWithLiteralModel: CompleteOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      ...echoOp,
+      name: "literal-model-op",
+      model: "fast",
+    };
+
+    await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude" },
+      opWithLiteralModel,
+      { text: "hi" },
+    );
+
+    const completeArgs = (agentManager.completeAs as ReturnType<typeof mock>).mock.calls[0]?.[2] as
+      | { model?: string }
+      | undefined;
+    // The fast tier of the default models config resolves to a real ModelDef.model — assert
+    // that something was passed (the exact id depends on DEFAULT_CONFIG.models, not on our
+    // resolver). What we want to pin is that the resolver fired and produced a definition.
+    expect(typeof completeArgs?.model).toBe("string");
+    expect(completeArgs?.model).not.toBe("");
+  });
+
+  test("CompleteOperation: resolver function is invoked with input and resolves to ConfiguredModel", async () => {
+    const completeResult: CompleteResult = { output: "ok", costUsd: 0, source: "exact" };
+    const agentManager = makeMockAgentManager({ completeAsFn: async () => completeResult });
+    const runtime = makeTestRuntime({ agentManager });
+
+    const resolverCalls: Array<{ text: string }> = [];
+    const opWithResolver: CompleteOperation<
+      { text: string; pickFast: boolean },
+      string,
+      Pick<typeof DEFAULT_CONFIG, "routing">
+    > = {
+      ...echoOp,
+      name: "resolver-model-op",
+      model: (input) => {
+        resolverCalls.push({ text: input.text });
+        return input.pickFast ? "fast" : "powerful";
+      },
+    };
+
+    await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude" },
+      opWithResolver,
+      { text: "case-1", pickFast: true },
+    );
+
+    expect(resolverCalls).toHaveLength(1);
+    expect(resolverCalls[0]).toEqual({ text: "case-1" });
+    // Sanity: the chosen tier flows downstream (agentManager.completeAs got *some* model id).
+    const completeArgs = (agentManager.completeAs as ReturnType<typeof mock>).mock.calls[0]?.[2] as
+      | { model?: string }
+      | undefined;
+    expect(typeof completeArgs?.model).toBe("string");
+  });
+
+  test("RunOperation: resolver returning undefined falls back to 'balanced'", async () => {
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (_req) => ({
+        result: {
+          success: true,
+          exitCode: 0,
+          output: "ran",
+          rateLimited: false,
+          durationMs: 1,
+          estimatedCostUsd: 0,
+          agentFallbacks: [],
+        },
+        fallbacks: [],
+      }),
+    });
+    const sessionManager = makeSessionManager();
+    const runtime = makeTestRuntime({ agentManager, sessionManager });
+
+    const opWithUndefinedResolver: RunOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      ...runEchoOp,
+      name: "undefined-resolver-op",
+      model: () => undefined,
+    };
+
+    await callOp(
+      {
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-001",
+      },
+      opWithUndefinedResolver,
+      { text: "hi" },
+    );
+
+    const reqArg = (agentManager.runWithFallback as ReturnType<typeof mock>).mock.calls[0]?.[0] as
+      | { runOptions?: { modelTier?: string } }
+      | undefined;
+    expect(reqArg?.runOptions?.modelTier).toBe("balanced");
+  });
+
+  test("RunOperation: resolver tier flows into runOptions.modelTier", async () => {
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (_req) => ({
+        result: {
+          success: true,
+          exitCode: 0,
+          output: "ran",
+          rateLimited: false,
+          durationMs: 1,
+          estimatedCostUsd: 0,
+          agentFallbacks: [],
+        },
+        fallbacks: [],
+      }),
+    });
+    const sessionManager = makeSessionManager();
+    const runtime = makeTestRuntime({ agentManager, sessionManager });
+
+    const opWithFastResolver: RunOperation<{ text: string }, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      ...runEchoOp,
+      name: "fast-resolver-op",
+      model: () => "fast",
+    };
+
+    await callOp(
+      {
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-001",
+      },
+      opWithFastResolver,
+      { text: "hi" },
+    );
+
+    const reqArg = (agentManager.runWithFallback as ReturnType<typeof mock>).mock.calls[0]?.[0] as
+      | { runOptions?: { modelTier?: string } }
+      | undefined;
+    expect(reqArg?.runOptions?.modelTier).toBe("fast");
+  });
+});

--- a/test/unit/operations/semantic-review.test.ts
+++ b/test/unit/operations/semantic-review.test.ts
@@ -11,7 +11,7 @@ const SAMPLE_STORY = {
 };
 
 const SAMPLE_CONFIG = {
-  modelTier: "balanced" as const,
+  model: "balanced" as const,
   diffMode: "ref" as const,
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/operations/timeout-resolvers.test.ts
+++ b/test/unit/operations/timeout-resolvers.test.ts
@@ -49,7 +49,7 @@ describe("operation timeout resolvers", () => {
           acceptanceCriteria: ["AC-1"],
         },
         semanticConfig: {
-          modelTier: "balanced",
+          model: "balanced",
           diffMode: "ref",
           resetRefOnRerun: false,
           rules: [],
@@ -75,7 +75,7 @@ describe("operation timeout resolvers", () => {
           acceptanceCriteria: ["AC-1"],
         },
         adversarialConfig: {
-          modelTier: "balanced",
+          model: "balanced",
           diffMode: "ref",
           rules: [],
           timeoutMs: 654_000,

--- a/test/unit/pipeline/stages/review-debate-dialogue.test.ts
+++ b/test/unit/pipeline/stages/review-debate-dialogue.test.ts
@@ -352,7 +352,7 @@ describe("regression — pure dialogue (no debate) path unchanged", () => {
     // Add semanticConfig so the session.review() path is triggered
     (ctx.config as unknown as Record<string, unknown>).review = {
       ...(ctx.config.review as object),
-      semantic: { modelTier: "balanced", rules: [], timeoutMs: 60000, excludePatterns: [] },
+      semantic: { model: "balanced", rules: [], timeoutMs: 60000, excludePatterns: [] },
     };
     // Provide a fake agent so the session path isn't skipped
     ctx.agentGetFn = mock(() => ({ complete: mock(async () => ({})) })) as unknown as typeof ctx.agentGetFn;

--- a/test/unit/prompts/adversarial-review-builder.test.ts
+++ b/test/unit/prompts/adversarial-review-builder.test.ts
@@ -26,7 +26,7 @@ const STORY: SemanticStory = {
 };
 
 const CONFIG: AdversarialReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "ref",
   rules: [],
   timeoutMs: 180_000,

--- a/test/unit/prompts/review-builder.test.ts
+++ b/test/unit/prompts/review-builder.test.ts
@@ -23,7 +23,7 @@ const STORY: SemanticStory = {
 };
 
 const CONFIG_NO_RULES: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/adversarial-metadata-audit.test.ts
+++ b/test/unit/review/adversarial-metadata-audit.test.ts
@@ -27,7 +27,7 @@ const STORY: SemanticStory = {
 };
 
 const ADVERSARIAL_CONFIG: AdversarialReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "ref",
   rules: [],
   timeoutMs: 180_000,

--- a/test/unit/review/adversarial-pass-fail.test.ts
+++ b/test/unit/review/adversarial-pass-fail.test.ts
@@ -27,7 +27,7 @@ const STORY: SemanticStory = {
 };
 
 const ADVERSARIAL_CONFIG: AdversarialReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "ref",
   rules: [],
   timeoutMs: 180_000,

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -25,7 +25,7 @@ const STORY: SemanticStory = {
 };
 
 const ADVERSARIAL_CONFIG: AdversarialReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "ref",
   rules: [],
   timeoutMs: 180_000,

--- a/test/unit/review/adversarial-threshold.test.ts
+++ b/test/unit/review/adversarial-threshold.test.ts
@@ -31,7 +31,7 @@ const STORY: SemanticStory = {
 };
 
 const BASE_CFG: AdversarialReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "ref",
   rules: [],
   timeoutMs: 180_000,

--- a/test/unit/review/dialogue-debate.test.ts
+++ b/test/unit/review/dialogue-debate.test.ts
@@ -38,7 +38,7 @@ const STORY: SemanticStory = {
 };
 
 const SEMANTIC_CONFIG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/dialogue-re-review.test.ts
+++ b/test/unit/review/dialogue-re-review.test.ts
@@ -41,7 +41,7 @@ const STORY: SemanticStory = {
 };
 
 const SEMANTIC_CONFIG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/dialogue.test.ts
+++ b/test/unit/review/dialogue.test.ts
@@ -43,7 +43,7 @@ const STORY: SemanticStory = {
 };
 
 const SEMANTIC_CONFIG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/semantic-agent-session.test.ts
+++ b/test/unit/review/semantic-agent-session.test.ts
@@ -28,7 +28,7 @@ const STORY: SemanticStory = {
 };
 
 const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -34,7 +34,7 @@ const STORY: SemanticStory = {
 };
 
 const SEMANTIC_CONFIG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -31,7 +31,7 @@ const STORY: SemanticStory = {
 };
 
 const CFG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/semantic-parsing.test.ts
+++ b/test/unit/review/semantic-parsing.test.ts
@@ -28,7 +28,7 @@ const STORY: SemanticStory = {
 };
 
 const CONFIG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/semantic-prompt-response.test.ts
+++ b/test/unit/review/semantic-prompt-response.test.ts
@@ -28,7 +28,7 @@ const STORY: SemanticStory = {
 };
 
 const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],
@@ -172,7 +172,7 @@ describe("runSemanticReview — LLM prompt construction", () => {
 
   test("prompt includes custom rules from semanticConfig.rules", async () => {
     const config: SemanticReviewConfig = {
-      modelTier: "balanced",
+      model: "balanced",
       diffMode: "embedded",
       resetRefOnRerun: false,
       timeoutMs: 60_000,

--- a/test/unit/review/semantic-retry-truncation.test.ts
+++ b/test/unit/review/semantic-retry-truncation.test.ts
@@ -25,7 +25,7 @@ const STORY: SemanticStory = {
 };
 
 const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -27,7 +27,7 @@ const STORY: SemanticStory = {
 };
 
 const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/semantic-signature-diff.test.ts
+++ b/test/unit/review/semantic-signature-diff.test.ts
@@ -27,7 +27,7 @@ const STORY: SemanticStory = {
 };
 
 const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/semantic-threshold.test.ts
+++ b/test/unit/review/semantic-threshold.test.ts
@@ -30,7 +30,7 @@ const STORY: SemanticStory = {
 };
 
 const BASE_CFG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],

--- a/test/unit/review/semantic-unverifiable.test.ts
+++ b/test/unit/review/semantic-unverifiable.test.ts
@@ -35,7 +35,7 @@ const STORY: SemanticStory = {
 };
 
 const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
-  modelTier: "balanced",
+  model: "balanced",
   diffMode: "embedded",
   resetRefOnRerun: false,
   rules: [],


### PR DESCRIPTION
## Summary

Fixes #725. After ADR-019 Phase D + #762 routed semantic and adversarial reviewers through `callOp`, the user-configured `review.semantic.modelTier` and `review.adversarial.modelTier` settings were silently ignored — `callOp` hardcoded `"balanced"` for every `kind:"run"` op.

- Widen `RunOperation.model` / `CompleteOperation.model` to accept either a literal `ConfiguredModel` or a resolver `(input, ctx) => ConfiguredModel | undefined` (same shape as `timeoutMs`). `callOp` invokes the resolver before `resolveConfiguredModel`.
- Rename reviewer config field `modelTier` → `model` and widen the type from `ModelTier` to `ConfiguredModel` so users can pin a cross-agent `{ agent, model }` selection.
- Pre-Zod migration shim (`migrateLegacyReviewModelKey`) aliases the legacy `modelTier` key with a warn; existing user configs keep loading.
- Drop the dead `RunOperation.mode` placeholder (Wave 3 reservation, never consumed).

## Mechanism

Pulled the resolver from the issue's option-1 mechanism (`modelTier` field on the op) because that's static and can't read per-call input. Resolver function form lets `semanticReviewOp` / `adversarialReviewOp` declare:

```ts
model: (input) => input.semanticConfig.model,
```

Wiring per the comment in [src/operations/call.ts](src/operations/call.ts#L66) and [src/operations/types.ts](src/operations/types.ts#L122-L131).

## Migration

- New: `review.semantic.model` / `review.adversarial.model` (`ConfiguredModel`).
- Deprecated: `review.semantic.modelTier` / `review.adversarial.modelTier` (still accepted, warned, dropped pre-parse).
- Behavioural rename — no semantic change for users on `"balanced"`.

## Test plan

- [x] tsc --noEmit clean
- [x] biome lint clean
- [x] Unit suites for operations / review / config — 1057 pass, 0 fail
- [x] Integration suites for pipeline / review — 145 pass, 1 skip, 0 fail
- [x] New tests in [test/unit/operations/call.test.ts](test/unit/operations/call.test.ts): literal model, resolver invocation, undefined→balanced fallback, tier flow into `runOptions.modelTier`
- [x] New tests in [test/unit/config/migrations.test.ts](test/unit/config/migrations.test.ts): legacy `modelTier` aliasing, both-keys-present (canonical wins), immutability
- [ ] Manual smoke: load a config with legacy `review.semantic.modelTier: "powerful"` and confirm warn fires + value migrates