### PR TITLE
feat(config): phase 1 selectors for issue #745

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -56,6 +56,10 @@ export {
   routingConfigSelector,
   verifyConfigSelector,
   rectificationGateConfigSelector,
+  agentManagerConfigSelector,
+  interactionConfigSelector,
+  precheckConfigSelector,
+  qualityConfigSelector,
 } from "./selectors";
 export { createConfigLoader } from "./loader-runtime";
 export type { ConfigLoader } from "./loader-runtime";

--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -11,7 +11,7 @@
 import { pickSelector, reshapeSelector } from "./selector";
 import type { NaxConfig } from "./types";
 
-export const reviewConfigSelector = pickSelector("review", "review", "debate");
+export const reviewConfigSelector = pickSelector("review", "review", "debate", "models", "execution");
 export const planConfigSelector = pickSelector("plan", "plan", "debate");
 export const decomposeConfigSelector = pickSelector("decompose", "plan", "agent");
 export const rectifyConfigSelector = pickSelector("rectify", "execution");
@@ -20,9 +20,9 @@ export const acceptanceConfigSelector = pickSelector("acceptance", "acceptance")
 export const acceptanceFixConfigSelector = pickSelector("acceptance-fix", "acceptance", "execution");
 // acceptance generator take more time to generate the test code, so we use a separate config selector to use execution.sessionTimeoutSeconds instead of acceptance.timeoutMs
 export const acceptanceGenConfigSelector = pickSelector("acceptance-gen", "acceptance", "execution");
-export const tddConfigSelector = pickSelector("tdd", "tdd", "execution");
-export const debateConfigSelector = pickSelector("debate", "debate");
-export const routingConfigSelector = pickSelector("routing", "routing");
+export const tddConfigSelector = pickSelector("tdd", "tdd", "execution", "quality", "agent", "models");
+export const debateConfigSelector = pickSelector("debate", "debate", "models");
+export const routingConfigSelector = pickSelector("routing", "routing", "autoMode", "tdd");
 
 export const verifyConfigSelector = reshapeSelector("verify", (c: NaxConfig) => ({
   timeout: c.execution?.verificationTimeoutSeconds,
@@ -37,3 +37,16 @@ export const rectificationGateConfigSelector = pickSelector(
   "quality",
   "review",
 );
+
+export const agentManagerConfigSelector = pickSelector("agent-manager", "agent", "execution");
+export const interactionConfigSelector = pickSelector("interaction", "interaction");
+export const precheckConfigSelector = pickSelector(
+  "precheck",
+  "precheck",
+  "quality",
+  "execution",
+  "prompts",
+  "review",
+  "project",
+);
+export const qualityConfigSelector = pickSelector("quality", "quality", "execution");

--- a/test/unit/config/selectors.test.ts
+++ b/test/unit/config/selectors.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from "bun:test";
+import { DEFAULT_CONFIG } from "../../../src/config/defaults";
+import {
+  agentManagerConfigSelector,
+  interactionConfigSelector,
+  precheckConfigSelector,
+  qualityConfigSelector,
+  debateConfigSelector,
+  reviewConfigSelector,
+  tddConfigSelector,
+  routingConfigSelector,
+} from "../../../src/config/selectors";
+
+describe("ConfigSelector — Phase 1 selectors", () => {
+  describe("new selectors", () => {
+    test("agentManagerConfigSelector picks agent and execution", () => {
+      const slice = agentManagerConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice).toHaveProperty("agent");
+      expect(slice).toHaveProperty("execution");
+      expect(Object.keys(slice).sort()).toEqual(["agent", "execution"]);
+    });
+
+    test("agentManagerConfigSelector has correct name", () => {
+      expect(agentManagerConfigSelector.name).toBe("agent-manager");
+    });
+
+    test("interactionConfigSelector picks interaction", () => {
+      const slice = interactionConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice).toHaveProperty("interaction");
+      expect(Object.keys(slice)).toEqual(["interaction"]);
+    });
+
+    test("interactionConfigSelector has correct name", () => {
+      expect(interactionConfigSelector.name).toBe("interaction");
+    });
+
+    test("interactionConfigSelector preserves values", () => {
+      const slice = interactionConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice.interaction).toEqual(DEFAULT_CONFIG.interaction);
+    });
+
+    test("precheckConfigSelector picks all keys precheck/* uses", () => {
+      const slice = precheckConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice).toMatchObject({
+        precheck: expect.any(Object),
+        quality: expect.any(Object),
+        execution: expect.any(Object),
+      });
+      expect(Object.keys(slice).sort()).toEqual([
+        "execution",
+        "precheck",
+        "project",
+        "prompts",
+        "quality",
+        "review",
+      ]);
+    });
+
+    test("precheckConfigSelector has correct name", () => {
+      expect(precheckConfigSelector.name).toBe("precheck");
+    });
+
+    test("qualityConfigSelector picks quality and execution", () => {
+      const slice = qualityConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice).toHaveProperty("quality");
+      expect(slice).toHaveProperty("execution");
+      expect(Object.keys(slice).sort()).toEqual(["execution", "quality"]);
+    });
+
+    test("qualityConfigSelector has correct name", () => {
+      expect(qualityConfigSelector.name).toBe("quality");
+    });
+  });
+
+  describe("widened selectors", () => {
+    test("debateConfigSelector now includes models", () => {
+      const slice = debateConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice).toHaveProperty("debate");
+      expect(slice).toHaveProperty("models");
+      expect(Object.keys(slice).sort()).toEqual(["debate", "models"]);
+    });
+
+    test("reviewConfigSelector now includes models and execution", () => {
+      const slice = reviewConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice).toHaveProperty("review");
+      expect(slice).toHaveProperty("debate");
+      expect(slice).toHaveProperty("models");
+      expect(slice).toHaveProperty("execution");
+      expect(Object.keys(slice).sort()).toEqual([
+        "debate",
+        "execution",
+        "models",
+        "review",
+      ]);
+    });
+
+    test("tddConfigSelector now includes quality, agent, and models", () => {
+      const slice = tddConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice).toHaveProperty("tdd");
+      expect(slice).toHaveProperty("execution");
+      expect(slice).toHaveProperty("quality");
+      expect(slice).toHaveProperty("agent");
+      expect(slice).toHaveProperty("models");
+      expect(Object.keys(slice).sort()).toEqual([
+        "agent",
+        "execution",
+        "models",
+        "quality",
+        "tdd",
+      ]);
+    });
+
+    test("routingConfigSelector now includes autoMode and tdd", () => {
+      const slice = routingConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice).toHaveProperty("routing");
+      expect(slice).toHaveProperty("autoMode");
+      expect(slice).toHaveProperty("tdd");
+      expect(Object.keys(slice).sort()).toEqual([
+        "autoMode",
+        "routing",
+        "tdd",
+      ]);
+    });
+  });
+
+  describe("round-trip — sliced values match full config", () => {
+    test("agentManagerConfigSelector preserves values", () => {
+      const slice = agentManagerConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice.agent).toEqual(DEFAULT_CONFIG.agent);
+      expect(slice.execution).toEqual(DEFAULT_CONFIG.execution);
+    });
+
+    test("precheckConfigSelector preserves values", () => {
+      const slice = precheckConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice.quality).toEqual(DEFAULT_CONFIG.quality);
+      expect(slice.execution).toEqual(DEFAULT_CONFIG.execution);
+      expect(slice.review).toEqual(DEFAULT_CONFIG.review);
+    });
+
+    test("debateConfigSelector preserves values", () => {
+      const slice = debateConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice.debate).toEqual(DEFAULT_CONFIG.debate);
+      expect(slice.models).toEqual(DEFAULT_CONFIG.models);
+    });
+
+    test("reviewConfigSelector preserves values", () => {
+      const slice = reviewConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice.review).toEqual(DEFAULT_CONFIG.review);
+      expect(slice.models).toEqual(DEFAULT_CONFIG.models);
+      expect(slice.execution).toEqual(DEFAULT_CONFIG.execution);
+    });
+
+    test("tddConfigSelector preserves values", () => {
+      const slice = tddConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice.tdd).toEqual(DEFAULT_CONFIG.tdd);
+      expect(slice.quality).toEqual(DEFAULT_CONFIG.quality);
+      expect(slice.models).toEqual(DEFAULT_CONFIG.models);
+      expect(slice.agent).toEqual(DEFAULT_CONFIG.agent);
+    });
+
+    test("routingConfigSelector preserves values", () => {
+      const slice = routingConfigSelector.select(DEFAULT_CONFIG);
+      expect(slice.routing).toEqual(DEFAULT_CONFIG.routing);
+      expect(slice.autoMode).toEqual(DEFAULT_CONFIG.autoMode);
+      expect(slice.tdd).toEqual(DEFAULT_CONFIG.tdd);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 4 new selectors: `agentManagerConfigSelector`, `interactionConfigSelector`, `precheckConfigSelector`, `qualityConfigSelector`
- Widen 4 existing selectors: `debateConfigSelector` (+models), `reviewConfigSelector` (+models,+execution), `tddConfigSelector` (+quality,+agent,+models), `routingConfigSelector` (+autoMode,+tdd)
- `precheckConfigSelector` includes `project` key per Phase 5 requirements (fixes code review finding TYPE-1)

## Testing
- 19 selector unit tests pass
- Full suite: 1193 pass, 40 skip, 0 fail
- `bun run typecheck` clean
- `bun run lint` clean

## References
- Issue: #745
- Plan: `docs/findings/2026-04-30-issue-745-config-selector-migration-plan.md`