### PR TITLE
feat(interaction): phase 2 — migrate triggers.ts to InteractionConfig

### DIFF
--- a/src/interaction/index.ts
+++ b/src/interaction/index.ts
@@ -55,7 +55,7 @@ export {
   checkStoryAmbiguity,
   checkReviewGate,
 } from "./triggers";
-export type { TriggerContext } from "./triggers";
+export type { TriggerContext, InteractionConfig } from "./triggers";
 
 // Initialization
 export { initInteractionChain } from "./init";

--- a/src/interaction/triggers.ts
+++ b/src/interaction/triggers.ts
@@ -9,6 +9,8 @@ import type { InteractionChain } from "./chain";
 import type { InteractionFallback, InteractionRequest, InteractionResponse, TriggerName } from "./types";
 import { TRIGGER_METADATA } from "./types";
 
+export type InteractionConfig = Pick<NaxConfig, "interaction">;
+
 /** Trigger context data for template substitution */
 export interface TriggerContext {
   featureName: string;
@@ -25,7 +27,7 @@ export interface TriggerContext {
 /**
  * Check if a trigger is enabled in config
  */
-export function isTriggerEnabled(trigger: TriggerName, config: NaxConfig): boolean {
+export function isTriggerEnabled(trigger: TriggerName, config: InteractionConfig): boolean {
   const triggerConfig = config.interaction?.triggers?.[trigger];
   if (triggerConfig === undefined) return false;
   if (typeof triggerConfig === "boolean") return triggerConfig;
@@ -37,7 +39,7 @@ export function isTriggerEnabled(trigger: TriggerName, config: NaxConfig): boole
  */
 export function getTriggerConfig(
   trigger: TriggerName,
-  config: NaxConfig,
+  config: InteractionConfig,
 ): { fallback: InteractionFallback; timeout: number } {
   const metadata = TRIGGER_METADATA[trigger];
   const triggerConfig = config.interaction?.triggers?.[trigger];
@@ -80,7 +82,7 @@ function substituteTemplate(template: string, context: TriggerContext): string {
 export function createTriggerRequest(
   trigger: TriggerName,
   context: TriggerContext,
-  config: NaxConfig,
+  config: InteractionConfig,
 ): InteractionRequest {
   const metadata = TRIGGER_METADATA[trigger];
   const { fallback, timeout } = getTriggerConfig(trigger, config);
@@ -111,7 +113,7 @@ export function createTriggerRequest(
 export async function executeTrigger(
   trigger: TriggerName,
   context: TriggerContext,
-  config: NaxConfig,
+  config: InteractionConfig,
   chain: InteractionChain,
 ): Promise<InteractionResponse> {
   const request = createTriggerRequest(trigger, context, config);
@@ -124,7 +126,7 @@ export async function executeTrigger(
  */
 export async function checkSecurityReview(
   context: TriggerContext,
-  config: NaxConfig,
+  config: InteractionConfig,
   chain: InteractionChain,
 ): Promise<boolean> {
   if (!isTriggerEnabled("security-review", config)) return true;
@@ -138,7 +140,7 @@ export async function checkSecurityReview(
  */
 export async function checkCostExceeded(
   context: TriggerContext,
-  config: NaxConfig,
+  config: InteractionConfig,
   chain: InteractionChain,
 ): Promise<boolean> {
   if (!isTriggerEnabled("cost-exceeded", config)) return true;
@@ -152,7 +154,7 @@ export async function checkCostExceeded(
  */
 export async function checkMergeConflict(
   context: TriggerContext,
-  config: NaxConfig,
+  config: InteractionConfig,
   chain: InteractionChain,
 ): Promise<boolean> {
   if (!isTriggerEnabled("merge-conflict", config)) return true;
@@ -166,7 +168,7 @@ export async function checkMergeConflict(
  */
 export async function checkCostWarning(
   context: TriggerContext,
-  config: NaxConfig,
+  config: InteractionConfig,
   chain: InteractionChain,
 ): Promise<"continue" | "escalate"> {
   if (!isTriggerEnabled("cost-warning", config)) return "continue";
@@ -180,7 +182,7 @@ export async function checkCostWarning(
  */
 export async function checkMaxRetries(
   context: TriggerContext,
-  config: NaxConfig,
+  config: InteractionConfig,
   chain: InteractionChain,
 ): Promise<"continue" | "skip"> {
   if (!isTriggerEnabled("max-retries", config)) return "continue";
@@ -194,7 +196,7 @@ export async function checkMaxRetries(
  */
 export async function checkPreMerge(
   context: TriggerContext,
-  config: NaxConfig,
+  config: InteractionConfig,
   chain: InteractionChain,
 ): Promise<boolean> {
   if (!isTriggerEnabled("pre-merge", config)) return true;
@@ -208,7 +210,7 @@ export async function checkPreMerge(
  */
 export async function checkStoryAmbiguity(
   context: TriggerContext,
-  config: NaxConfig,
+  config: InteractionConfig,
   chain: InteractionChain,
 ): Promise<boolean> {
   if (!isTriggerEnabled("story-ambiguity", config)) return true;
@@ -222,7 +224,7 @@ export async function checkStoryAmbiguity(
  */
 export async function checkReviewGate(
   context: TriggerContext,
-  config: NaxConfig,
+  config: InteractionConfig,
   chain: InteractionChain,
 ): Promise<boolean> {
   if (!isTriggerEnabled("review-gate", config)) return true;

--- a/test/unit/interaction/triggers-narrowed.test.ts
+++ b/test/unit/interaction/triggers-narrowed.test.ts
@@ -1,0 +1,220 @@
+import { describe, test, expect } from "bun:test";
+import type { NaxConfig } from "../../../src/config";
+import type { InteractionChain } from "../../../src/interaction/chain";
+import type { TriggerName } from "../../../src/interaction/types";
+import {
+  isTriggerEnabled,
+  getTriggerConfig,
+  createTriggerRequest,
+  executeTrigger,
+  checkSecurityReview,
+  checkCostExceeded,
+  checkMergeConflict,
+  checkCostWarning,
+  checkMaxRetries,
+  checkPreMerge,
+  checkStoryAmbiguity,
+  checkReviewGate,
+  type TriggerContext,
+} from "../../../src/interaction/triggers";
+
+const makeSlicedConfig = (triggers: Partial<Record<TriggerName, unknown>>, defaults: Record<string, unknown> = {}): NaxConfig =>
+  ({ interaction: { triggers: triggers as Record<string, unknown>, defaults } } as NaxConfig);
+
+const mockChain = {
+  prompt: async () => ({ action: "approve" } as const),
+  applyFallback: (_r: unknown, _f: string) => "approve" as const,
+} as unknown as InteractionChain;
+
+describe("triggers — narrowed config (Pick<NaxConfig, 'interaction'>)", () => {
+  describe("isTriggerEnabled", () => {
+    test("returns false when trigger not configured", () => {
+      const config = makeSlicedConfig({});
+      expect(isTriggerEnabled("security-review", config)).toBe(false);
+    });
+
+    test("returns boolean true when trigger is true", () => {
+      const config = makeSlicedConfig({ "security-review": true });
+      expect(isTriggerEnabled("security-review", config)).toBe(true);
+    });
+
+    test("returns enabled from object config", () => {
+      const config = makeSlicedConfig({ "security-review": { enabled: true } });
+      expect(isTriggerEnabled("security-review", config)).toBe(true);
+    });
+
+    test("returns false when enabled is false", () => {
+      const config = makeSlicedConfig({ "security-review": { enabled: false } });
+      expect(isTriggerEnabled("security-review", config)).toBe(false);
+    });
+  });
+
+  describe("getTriggerConfig", () => {
+    test("returns metadata defaultFallback when trigger not configured", () => {
+      const config = makeSlicedConfig({}, { timeout: 30000, fallback: "approve" });
+      const result = getTriggerConfig("security-review", config);
+      expect(result.timeout).toBe(30000);
+      expect(result.fallback).toBe("abort");
+    });
+
+    test("overrides defaults with trigger config", () => {
+      const config = makeSlicedConfig(
+        { "security-review": { timeout: 60000, fallback: "escalate" } },
+        { timeout: 30000, fallback: "approve" },
+      );
+      const result = getTriggerConfig("security-review", config);
+      expect(result.timeout).toBe(60000);
+      expect(result.fallback).toBe("escalate");
+    });
+  });
+
+  describe("createTriggerRequest", () => {
+    test("creates request with correct id prefix", () => {
+      const config = makeSlicedConfig({});
+      const context: TriggerContext = { featureName: "my-feature" };
+      const request = createTriggerRequest("security-review", context, config);
+      expect(request.id.startsWith("trigger-security-review-")).toBe(true);
+      expect(request.type).toBe("confirm");
+    });
+
+    test("uses metadata defaultFallback when trigger not configured", () => {
+      const config = makeSlicedConfig({}, { timeout: 60000, fallback: "escalate" });
+      const context: TriggerContext = { featureName: "my-feature" };
+      const request = createTriggerRequest("security-review", context, config);
+      expect(request.timeout).toBe(60000);
+      expect(request.fallback).toBe("abort");
+    });
+  });
+
+  describe("executeTrigger", () => {
+    test("calls chain.prompt with constructed request", async () => {
+      const config = makeSlicedConfig({});
+      const context: TriggerContext = { featureName: "my-feature" };
+      let called = false;
+      const chain = {
+        prompt: async (req: unknown) => {
+          called = true;
+          expect((req as { id: string }).id.startsWith("trigger-")).toBe(true);
+          return { action: "approve" } as const;
+        },
+        applyFallback: (_r: unknown, _f: string) => "approve" as const,
+      } as unknown as InteractionChain;
+
+      const response = await executeTrigger("security-review", context, config, chain);
+      expect(called).toBe(true);
+      expect(response.action).toBe("approve");
+    });
+  });
+
+  describe("checkSecurityReview", () => {
+    test("returns true when trigger disabled", async () => {
+      const config = makeSlicedConfig({ "security-review": false });
+      const result = await checkSecurityReview({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+
+    test("returns true when no trigger configured", async () => {
+      const config = makeSlicedConfig({});
+      const result = await checkSecurityReview({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("checkCostExceeded", () => {
+    test("returns true when trigger disabled", async () => {
+      const config = makeSlicedConfig({ "cost-exceeded": false });
+      const result = await checkCostExceeded({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+
+    test("returns true when no trigger configured", async () => {
+      const config = makeSlicedConfig({});
+      const result = await checkCostExceeded({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("checkMergeConflict", () => {
+    test("returns true when trigger disabled", async () => {
+      const config = makeSlicedConfig({ "merge-conflict": false });
+      const result = await checkMergeConflict({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+
+    test("returns true when no trigger configured", async () => {
+      const config = makeSlicedConfig({});
+      const result = await checkMergeConflict({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("checkCostWarning", () => {
+    test("returns continue when trigger disabled", async () => {
+      const config = makeSlicedConfig({ "cost-warning": false });
+      const result = await checkCostWarning({ featureName: "f" }, config, mockChain);
+      expect(result).toBe("continue");
+    });
+
+    test("returns continue when no trigger configured", async () => {
+      const config = makeSlicedConfig({});
+      const result = await checkCostWarning({ featureName: "f" }, config, mockChain);
+      expect(result).toBe("continue");
+    });
+  });
+
+  describe("checkMaxRetries", () => {
+    test("returns continue when trigger disabled", async () => {
+      const config = makeSlicedConfig({ "max-retries": false });
+      const result = await checkMaxRetries({ featureName: "f" }, config, mockChain);
+      expect(result).toBe("continue");
+    });
+
+    test("returns continue when no trigger configured", async () => {
+      const config = makeSlicedConfig({});
+      const result = await checkMaxRetries({ featureName: "f" }, config, mockChain);
+      expect(result).toBe("continue");
+    });
+  });
+
+  describe("checkPreMerge", () => {
+    test("returns true when trigger disabled", async () => {
+      const config = makeSlicedConfig({ "pre-merge": false });
+      const result = await checkPreMerge({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+
+    test("returns true when no trigger configured", async () => {
+      const config = makeSlicedConfig({});
+      const result = await checkPreMerge({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("checkStoryAmbiguity", () => {
+    test("returns true when trigger disabled", async () => {
+      const config = makeSlicedConfig({ "story-ambiguity": false });
+      const result = await checkStoryAmbiguity({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+
+    test("returns true when no trigger configured", async () => {
+      const config = makeSlicedConfig({});
+      const result = await checkStoryAmbiguity({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("checkReviewGate", () => {
+    test("returns true when trigger disabled", async () => {
+      const config = makeSlicedConfig({ "review-gate": false });
+      const result = await checkReviewGate({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+
+    test("returns true when no trigger configured", async () => {
+      const config = makeSlicedConfig({});
+      const result = await checkReviewGate({ featureName: "f" }, config, mockChain);
+      expect(result).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Migrate 11 functions in `src/interaction/triggers.ts` from `config: NaxConfig` to `config: InteractionConfig` (Pick<NaxConfig, 'interaction'>)
- Add `test/unit/interaction/triggers-narrowed.test.ts` — 25 stripped-config tests covering all 11 functions

## Acceptance (per plan § Phase 2)
- [x] All 11 functions migrated
- [x] Stripped-config tests pass (25/25)
- [x] Existing tests pass (1193 pass, 40 skip, 0 fail)
- [x] `grep -n "config: NaxConfig" src/interaction/triggers.ts` returns 0
- `bun run typecheck` ✅ clean
- `bun run lint` ✅ clean

## Notes
- `initInteractionChain` in `init.ts` retains `NaxConfig` — per plan § Out of Scope (initialization layer)
- Only `triggers.ts` functions are in scope for phase 2

## References
- Issue: #745
- Plan: `docs/findings/2026-04-30-issue-745-config-selector-migration-plan.md § Phase 2`