### PR TITLE
feat(agents): phase 3 — migrate AgentManager to narrowed config

### DIFF
--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -1,4 +1,6 @@
 import type { NaxConfig } from "../config";
+
+type AgentManagerConfig = Pick<NaxConfig, "agent" | "execution">;
 // Leaf import to avoid barrel cycle (same as in manager.ts):
 // src/runtime/index.ts → internal/agent-manager-factory → agents/factory → agents/manager → runtime/index.ts
 import type { MiddlewareChain } from "../runtime/agent-middleware";
@@ -22,6 +24,6 @@ export interface CreateAgentManagerOpts {
  * (CLI entry point). Mid-run code must receive IAgentManager via context/DI —
  * never call this factory directly. See docs/specs/SPEC-agent-manager-lifetime.md §2.1.
  */
-export function createAgentManager(config: NaxConfig, opts?: CreateAgentManagerOpts): IAgentManager {
+export function createAgentManager(config: AgentManagerConfig, opts?: CreateAgentManagerOpts): IAgentManager {
   return new AgentManager(config, undefined, opts);
 }

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -41,6 +41,8 @@ import { createAgentRegistry } from "./registry";
 import type { AgentRegistry } from "./registry";
 import type { AgentResult, CompleteOptions, CompleteResult } from "./types";
 
+type AgentManagerConfig = Pick<NaxConfig, "agent" | "execution">;
+
 type LoggerLike = {
   warn: (scope: string, msg: string, data?: Record<string, unknown>) => void;
   info: (scope: string, msg: string, data?: Record<string, unknown>) => void;
@@ -63,7 +65,7 @@ export const _agentManagerDeps = {
 };
 
 export class AgentManager implements IAgentManager {
-  private readonly _config: NaxConfig;
+  private readonly _config: AgentManagerConfig;
   private _registry: AgentRegistry | undefined;
   private readonly _unavailable = new Map<string, AdapterFailure>();
   private readonly _prunedFallback = new Set<string>();
@@ -78,7 +80,7 @@ export class AgentManager implements IAgentManager {
   readonly events: AgentManagerEvents;
 
   constructor(
-    config: NaxConfig,
+    config: AgentManagerConfig,
     registry?: AgentRegistry,
     opts?: {
       logger?: LoggerLike;
@@ -484,8 +486,9 @@ export class AgentManager implements IAgentManager {
   }
 
   async runAs(agentName: string, request: AgentRunRequest): Promise<AgentResult> {
+    /** @design Per plan §3.3 Note: resolvePermissions needs full NaxConfig for permission resolution. this._config is Pick<agent|execution>. */
     const resolvedPermissions = resolvePermissions(
-      (request.runOptions.config as NaxConfig | undefined) ?? this._config,
+      (request.runOptions.config as NaxConfig | undefined) ?? (this._config as NaxConfig),
       request.runOptions.pipelineStage ?? "run",
     );
     const augmented: AgentRunRequest = {
@@ -529,7 +532,8 @@ export class AgentManager implements IAgentManager {
       );
     }
     const stage = opts.pipelineStage ?? "run";
-    const resolvedPermissions = resolvePermissions(this._config, stage);
+    /** @design Per plan §3.3 Note: resolvePermissions needs full NaxConfig. */
+    const resolvedPermissions = resolvePermissions(this._config as NaxConfig, stage);
     const sessionRole = handle.role ?? opts.sessionRole ?? "main";
     const start = Date.now();
     try {
@@ -581,7 +585,11 @@ export class AgentManager implements IAgentManager {
 
   async completeAs(agentName: string, prompt: string, options: CompleteOptions): Promise<CompleteResult> {
     const stage = options.pipelineStage ?? "complete";
-    const resolvedPermissions = resolvePermissions((options.config as NaxConfig | undefined) ?? this._config, stage);
+    /** @design Per plan §3.3 Note: resolvePermissions needs full NaxConfig for permission resolution. this._config is Pick<agent|execution>. */
+    const resolvedPermissions = resolvePermissions(
+      (options.config as NaxConfig | undefined) ?? (this._config as NaxConfig),
+      stage,
+    );
     const augmented: CompleteOptions = { ...options, resolvedPermissions };
     const sessionName =
       options.sessionName ??

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -57,7 +57,7 @@ export interface AgentRegistry {
  * lifetime of the registry. Test adapters registered in _registryTestAdapters
  * take precedence and are returned as-is without ACP wrapping.
  */
-export function createAgentRegistry(config: NaxConfig): AgentRegistry {
+export function createAgentRegistry(config: Pick<NaxConfig, "agent">): AgentRegistry {
   const logger = getLogger();
   const acpCache = new Map<string, AcpAgentAdapter>();
 

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -2,7 +2,7 @@ import type { NaxConfig } from "../config";
 
 const FALLBACK_DEFAULT_AGENT = "claude";
 
-export function resolveDefaultAgent(config: NaxConfig): string {
+export function resolveDefaultAgent(config: Pick<NaxConfig, "agent">): string {
   const fromAgent = config.agent?.default;
   if (typeof fromAgent === "string" && fromAgent.length > 0) return fromAgent;
   return FALLBACK_DEFAULT_AGENT;

--- a/src/runtime/agent-middleware.ts
+++ b/src/runtime/agent-middleware.ts
@@ -7,7 +7,7 @@ export interface MiddlewareContext {
   readonly agentName: string;
   readonly kind: "run" | "complete" | "plan";
   readonly request: AgentRunRequest | null;
-  readonly config: NaxConfig;
+  readonly config: Pick<NaxConfig, "agent" | "execution">;
   readonly signal?: AbortSignal;
   readonly resolvedPermissions: ResolvedPermissions;
   readonly storyId?: string;

--- a/src/runtime/internal/agent-manager-factory.ts
+++ b/src/runtime/internal/agent-manager-factory.ts
@@ -3,6 +3,8 @@ import { createAgentManager as createAgentManagerFromFactory } from "../../agent
 import type { CreateAgentManagerOpts } from "../../agents/factory";
 import type { NaxConfig } from "../../config";
 
-export function createAgentManager(config: NaxConfig, opts?: CreateAgentManagerOpts): IAgentManager {
+type AgentManagerConfig = Pick<NaxConfig, "agent" | "execution">;
+
+export function createAgentManager(config: AgentManagerConfig, opts?: CreateAgentManagerOpts): IAgentManager {
   return createAgentManagerFromFactory(config, opts);
 }

--- a/test/unit/agents/manager-narrowed.test.ts
+++ b/test/unit/agents/manager-narrowed.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import type { NaxConfig } from "../../../src/config";
+import { _registryTestAdapters } from "../../../src/agents/registry";
+import type { AgentAdapter } from "../../../src/agents/types";
+import { resolveDefaultAgent } from "../../../src/agents/utils";
+import { createAgentRegistry } from "../../../src/agents/registry";
+
+const makeSlicedConfig = (agent: Record<string, unknown> = {}, execution: Record<string, unknown> = {}): NaxConfig =>
+  ({ agent: agent as NaxConfig["agent"], execution: execution as NaxConfig["execution"] } as NaxConfig);
+
+describe("AgentManager — narrowed config (Pick<NaxConfig, 'agent' | 'execution'>)", () => {
+  describe("resolveDefaultAgent", () => {
+    test("returns default agent from config", () => {
+      const config = makeSlicedConfig({ default: "codex" });
+      expect(resolveDefaultAgent(config)).toBe("codex");
+    });
+
+    test("returns fallback when default is empty", () => {
+      const config = makeSlicedConfig({ default: "" });
+      expect(resolveDefaultAgent(config)).toBe("claude");
+    });
+
+    test("returns fallback when no agent config", () => {
+      const config = makeSlicedConfig({});
+      expect(resolveDefaultAgent(config)).toBe("claude");
+    });
+  });
+
+  describe("createAgentRegistry", () => {
+    let mockAdapter: AgentAdapter;
+
+    beforeEach(() => {
+      mockAdapter = {
+        name: "mock",
+        displayName: "Mock Agent",
+        protocol: "acp",
+        run: async () => ({ outputs: "", exitCode: 0 }),
+        complete: async () => ({ outputs: "", exitCode: 0 }),
+        isInstalled: async () => true,
+        healthCheck: async () => ({ healthy: true }),
+      };
+    });
+
+    afterEach(() => {
+      _registryTestAdapters.delete("mock");
+    });
+
+    test("creates registry with sliced config", () => {
+      const config = makeSlicedConfig({ default: "mock" });
+      const registry = createAgentRegistry(config);
+      expect(registry.protocol).toBe("acp");
+    });
+
+    test("creates registry with sliced config — safe with no agent.default", () => {
+      const config = makeSlicedConfig({}); // no default, no agent
+      const registry = createAgentRegistry(config);
+      expect(registry.protocol).toBe("acp");
+    });
+
+    test("test adapter takes precedence in registry", () => {
+      _registryTestAdapters.set("mock", mockAdapter);
+      const config = makeSlicedConfig({});
+      const registry = createAgentRegistry(config);
+      expect(registry.getAgent("mock")).toBe(mockAdapter);
+    });
+
+    test("returns undefined for unknown agent", () => {
+      const config = makeSlicedConfig({});
+      const registry = createAgentRegistry(config);
+      expect(registry.getAgent("nonexistent")).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Migrate `AgentManager._config` from `NaxConfig` to `Pick<NaxConfig, 'agent' | 'execution'>`
- Narrow `MiddlewareContext.config` to match
- Migrate `resolveDefaultAgent`, `createAgentRegistry`, `createAgentManager` factory signatures
- Add 7 stripped-config tests in `test/unit/agents/manager-narrowed.test.ts`
- Document 3 `resolvePermissions` casts with `/** @design */` comments (per plan §3.3 Note: `resolvePermissions` needs full NaxConfig)

## Acceptance (per plan § Phase 3)
- [x] `MiddlewareContext.config` narrowed
- [x] `AgentManager._config` narrowed
- [x] `resolveDefaultAgent`, `createAgentRegistry`, `createAgentManager` narrowed
- [x] Stripped-config tests pass (7/7)
- [x] All existing AgentManager tests pass (357 pass)
- `bun run typecheck` ✅ clean
- `bun run lint` ✅ clean

## Notes
- `AgentRunRequest.config` and `CompleteOptions.config` remain `NaxConfig | undefined` — per plan § Note (caller-owned, reads models/agent.acp.promptRetries/execution.permissionProfile)
- Only `cancellationMiddleware` is active post ADR-020 Wave 1 — safe to narrow

## References
- Issue: #745
- Plan: `docs/findings/2026-04-30-issue-745-config-selector-migration-plan.md § Phase 3`