### PR TITLE
refactor(debate): phase 4a — narrow debate runner config to selector slice

### DIFF
--- a/src/config/selectors.ts
+++ b/src/config/selectors.ts
@@ -21,7 +21,7 @@ export const acceptanceFixConfigSelector = pickSelector("acceptance-fix", "accep
 // acceptance generator take more time to generate the test code, so we use a separate config selector to use execution.sessionTimeoutSeconds instead of acceptance.timeoutMs
 export const acceptanceGenConfigSelector = pickSelector("acceptance-gen", "acceptance", "execution");
 export const tddConfigSelector = pickSelector("tdd", "tdd", "execution", "quality", "agent", "models");
-export const debateConfigSelector = pickSelector("debate", "debate", "models");
+export const debateConfigSelector = pickSelector("debate", "debate", "models", "agent");
 export const routingConfigSelector = pickSelector("routing", "routing", "autoMode", "tdd");
 
 export const verifyConfigSelector = reshapeSelector("verify", (c: NaxConfig) => ({

--- a/src/debate/runner-hybrid.ts
+++ b/src/debate/runner-hybrid.ts
@@ -4,8 +4,9 @@
  * runHybrid() implementation for DebateRunner.
  */
 
+import { resolveDefaultAgent } from "../agents";
 import type { IAgentManager } from "../agents";
-import type { NaxConfig } from "../config";
+import type { ConfiguredModel, NaxConfig } from "../config";
 import { DebatePromptBuilder } from "../prompts";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import type { SessionRole } from "../runtime/session-role";
@@ -36,7 +37,7 @@ export interface HybridCtx extends DispatchContext {
   readonly storyId: string;
   readonly stage: string;
   readonly stageConfig: DebateStageConfig;
-  readonly config: NaxConfig;
+  readonly config: Pick<NaxConfig, "debate" | "models" | "agent">;
   readonly workdir: string;
   readonly featureName: string;
   readonly timeoutSeconds: number;
@@ -77,7 +78,13 @@ export async function runRebuttalLoop(
       internalHandles.push(null); // Caller owns this handle; we do not close it
     } else if (sessionManager) {
       const modelTier = modelTierFromDebater(proposal.debater);
-      const modelDef = resolveModelDefForDebater(proposal.debater, modelTier, ctx.config);
+      const model: ConfiguredModel = { agent: proposal.debater.agent, model: proposal.debater.model ?? modelTier };
+      const modelDef = resolveModelDefForDebater(
+        proposal.debater,
+        model,
+        ctx.config.models,
+        resolveDefaultAgent(ctx.config),
+      );
       const name = sessionManager.nameFor({
         workdir: ctx.workdir,
         featureName: ctx.featureName,
@@ -186,7 +193,8 @@ export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateR
       const sessionRole = `debate-hybrid-${i}` as SessionRole;
       if (sessionManager) {
         const modelTier = modelTierFromDebater(debater);
-        const modelDef = resolveModelDefForDebater(debater, modelTier, ctx.config);
+        const model: ConfiguredModel = { agent: debater.agent, model: debater.model ?? modelTier };
+        const modelDef = resolveModelDefForDebater(debater, model, ctx.config.models, resolveDefaultAgent(ctx.config));
         const name = sessionManager.nameFor({
           workdir: ctx.workdir,
           featureName: ctx.featureName,
@@ -322,7 +330,8 @@ export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateR
       proposalOutputs,
       critiqueOutputs,
       ctx.stageConfig,
-      ctx.config,
+      // resolveOutcome's CompleteOptions.config stays NaxConfig per Phase 3 §3.3
+      ctx.config as NaxConfig,
       ctx.storyId,
       ctx.timeoutSeconds * 1000,
       ctx.workdir,

--- a/src/debate/runner-plan.ts
+++ b/src/debate/runner-plan.ts
@@ -5,9 +5,9 @@
  */
 
 import { join } from "node:path";
+import { resolveDefaultAgent } from "../agents";
 import type { IAgentManager } from "../agents";
-import type { NaxConfig } from "../config";
-import type { ModelDef } from "../config";
+import type { ConfiguredModel, ModelDef, NaxConfig } from "../config";
 import { NaxError } from "../errors";
 import { DebatePromptBuilder } from "../prompts";
 import type { DispatchContext } from "../runtime/dispatch-context";
@@ -30,7 +30,7 @@ interface PlanCtx extends DispatchContext {
   readonly storyId: string;
   readonly stage: string;
   readonly stageConfig: DebateStageConfig;
-  readonly config: NaxConfig;
+  readonly config: Pick<NaxConfig, "debate" | "models" | "agent">;
 }
 
 export async function runPlan(
@@ -88,7 +88,13 @@ export async function runPlan(
       const debaterPrompt = `${proposalBuilder.buildProposalPrompt(i)}\n\nWrite the PRD JSON directly to this file path: ${tempOutputPath}\nDo NOT output the JSON to the conversation. Write the file, then reply with a brief confirmation.`;
 
       const modelTier = modelTierFromDebater(rd);
-      const modelDef: ModelDef = resolveModelDefForDebater(rd, modelTier, ctx.config);
+      const model: ConfiguredModel = { agent: rd.agent, model: rd.model ?? modelTier };
+      const modelDef: ModelDef = resolveModelDefForDebater(
+        rd,
+        model,
+        ctx.config.models,
+        resolveDefaultAgent(ctx.config),
+      );
 
       const sessionManager = ctx.sessionManager;
       if (!sessionManager) {
@@ -229,7 +235,8 @@ export async function runPlan(
     proposalOutputs,
     critiqueOutputs,
     ctx.stageConfig,
-    ctx.config,
+    // resolveOutcome's CompleteOptions.config stays NaxConfig per Phase 3 §3.3
+    ctx.config as NaxConfig,
     ctx.storyId,
     resolverTimeoutMs,
     opts.workdir,

--- a/src/debate/runner-stateful.ts
+++ b/src/debate/runner-stateful.ts
@@ -4,9 +4,9 @@
  * runStateful(), runStatefulTurn() implementations for DebateRunner.
  */
 
+import { resolveDefaultAgent } from "../agents";
 import type { IAgentManager } from "../agents";
-import type { ModelDef } from "../config";
-import type { NaxConfig } from "../config";
+import type { ConfiguredModel, ModelDef, NaxConfig } from "../config";
 import { DebatePromptBuilder } from "../prompts";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import type { SessionRole } from "../runtime/session-role";
@@ -30,7 +30,7 @@ interface StatefulCtx extends DispatchContext {
   readonly storyId: string;
   readonly stage: string;
   readonly stageConfig: DebateStageConfig;
-  readonly config: NaxConfig;
+  readonly config: Pick<NaxConfig, "debate" | "models" | "agent">;
   readonly workdir: string;
   readonly featureName: string;
   readonly timeoutSeconds: number;
@@ -106,7 +106,13 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
       const roleKey = `debate-${ctx.stage}-${i}` as SessionRole;
       if (sessionManager) {
         const modelTier = modelTierFromDebater(debater);
-        const modelDef: ModelDef = resolveModelDefForDebater(debater, modelTier, ctx.config);
+        const model: ConfiguredModel = { agent: debater.agent, model: debater.model ?? modelTier };
+        const modelDef: ModelDef = resolveModelDefForDebater(
+          debater,
+          model,
+          ctx.config.models,
+          resolveDefaultAgent(ctx.config),
+        );
         const name = sessionManager.nameFor({
           workdir: ctx.workdir,
           featureName: ctx.featureName,
@@ -295,7 +301,8 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
       proposalOutputs,
       critiqueOutputs,
       ctx.stageConfig,
-      ctx.config,
+      // resolveOutcome's CompleteOptions.config stays NaxConfig per Phase 3 §3.3
+      ctx.config as NaxConfig,
       ctx.storyId,
       ctx.timeoutSeconds * 1000,
       ctx.workdir,

--- a/src/debate/runner.ts
+++ b/src/debate/runner.ts
@@ -40,7 +40,7 @@ export class DebateRunner {
   private readonly ctx: CallContext;
   private readonly stage: string;
   private readonly stageConfig: DebateStageConfig;
-  private readonly config: NaxConfig;
+  private readonly config: Pick<NaxConfig, "debate" | "models" | "agent">;
   private readonly workdir: string;
   private readonly featureName: string;
   private readonly timeoutSeconds: number;
@@ -245,7 +245,8 @@ export class DebateRunner {
       proposalOutputs,
       critiqueOutputs,
       this.stageConfig,
-      this.config,
+      // resolveOutcome's CompleteOptions.config stays NaxConfig per Phase 3 §3.3
+      this.config as NaxConfig,
       this.ctx.storyId ?? "",
       this.timeoutSeconds * 1000,
       this.workdir,

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -1,9 +1,10 @@
 import { resolveDefaultAgent } from "../agents";
 import type { IAgentManager } from "../agents";
 import type { CompleteOptions, CompleteResult } from "../agents/types";
-import type { ModelTier, NaxConfig, ResolvedConfiguredModel } from "../config";
+import type { ConfiguredModel, ModelTier, NaxConfig, ResolvedConfiguredModel } from "../config";
 import { DEFAULT_CONFIG, resolveConfiguredModel, resolveModelForAgent } from "../config";
 import type { PipelineStage } from "../config/permissions";
+import type { ModelsConfig } from "../config/schema-types";
 import type { ModelDef } from "../config/schema-types";
 import { getSafeLogger } from "../logger";
 import type { DispatchContext } from "../runtime/dispatch-context";
@@ -153,31 +154,23 @@ export function pipelineStageForDebate(stage: string): PipelineStage {
   }
 }
 
-export function resolveModelDefForDebater(debater: Debater, tier: ModelTier, config: NaxConfig): ModelDef {
-  const configModels = config?.models ?? DEFAULT_CONFIG.models;
-  // Use optional chaining throughout: config may be partially-constructed in tests.
-  const configDefaultAgent = resolveDefaultAgent(config ?? DEFAULT_CONFIG);
-
+export function resolveModelDefForDebater(
+  debater: Debater,
+  model: ConfiguredModel,
+  modelsConfig: ModelsConfig,
+  defaultAgent: string,
+): ModelDef {
   try {
-    return resolveConfiguredModel(
-      configModels,
-      debater.agent,
-      { agent: debater.agent, model: debater.model ?? tier },
-      configDefaultAgent,
-    ).modelDef;
+    return resolveConfiguredModel(modelsConfig, debater.agent, model, defaultAgent).modelDef;
   } catch {
     // Fall through to secondary fallback strategies.
   }
 
   try {
-    return resolveConfiguredModel(
-      DEFAULT_CONFIG.models,
-      debater.agent,
-      { agent: debater.agent, model: debater.model ?? tier },
-      resolveDefaultAgent(DEFAULT_CONFIG),
-    ).modelDef;
+    return resolveConfiguredModel(DEFAULT_CONFIG.models, debater.agent, model, resolveDefaultAgent(DEFAULT_CONFIG))
+      .modelDef;
   } catch {
-    return resolveModelForAgent(configModels, debater.agent, "fast", configDefaultAgent);
+    return resolveModelForAgent(modelsConfig, debater.agent, "fast", defaultAgent);
   }
 }
 

--- a/test/unit/config/selectors.test.ts
+++ b/test/unit/config/selectors.test.ts
@@ -73,11 +73,12 @@ describe("ConfigSelector — Phase 1 selectors", () => {
   });
 
   describe("widened selectors", () => {
-    test("debateConfigSelector now includes models", () => {
+    test("debateConfigSelector now includes models and agent", () => {
       const slice = debateConfigSelector.select(DEFAULT_CONFIG);
       expect(slice).toHaveProperty("debate");
       expect(slice).toHaveProperty("models");
-      expect(Object.keys(slice).sort()).toEqual(["debate", "models"]);
+      expect(slice).toHaveProperty("agent");
+      expect(Object.keys(slice).sort()).toEqual(["agent", "debate", "models"]);
     });
 
     test("reviewConfigSelector now includes models and execution", () => {
@@ -141,6 +142,7 @@ describe("ConfigSelector — Phase 1 selectors", () => {
       const slice = debateConfigSelector.select(DEFAULT_CONFIG);
       expect(slice.debate).toEqual(DEFAULT_CONFIG.debate);
       expect(slice.models).toEqual(DEFAULT_CONFIG.models);
+      expect(slice.agent).toEqual(DEFAULT_CONFIG.agent);
     });
 
     test("reviewConfigSelector preserves values", () => {


### PR DESCRIPTION
## Summary

- Widens `debateConfigSelector` to include `"agent"` key (Phase 1 gap fix — `resolveDefaultAgent` needs `config.agent`)
- Refactors `resolveModelDefForDebater` to accept `model: ConfiguredModel`, `modelsConfig: ModelsConfig`, `defaultAgent: string` instead of `tier: ModelTier, config: NaxConfig` — model selection type is now explicit at the call site
- Narrows `DebateRunner.config`, `StatefulCtx.config`, `HybridCtx.config`, `PlanCtx.config` from `NaxConfig` to `Pick<NaxConfig, "debate" | "models" | "agent">`
- Applies `as NaxConfig` boundary cast at all four `resolveOutcome` call sites (`CompleteOptions.config` stays `NaxConfig` per Phase 3 §3.3)

Closes part of #745 (Phase 4a — debate runners).

## Test Plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `timeout 60 bun test test/unit/debate/ --timeout=5000` — 271/271 pass
- [x] `bun run test` — full suite passes