### PR TITLE
fix(autofix): test-writer rectification uses context-aware framing for lint vs adversarial

### DIFF
--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -219,37 +219,64 @@ export class RectifierPromptBuilder {
   }
 
   /**
-   * Prompt for the test-writer to fix test file issues flagged by adversarial review (#409).
+   * Prompt for the test-writer to fix test file issues routed from review (#409).
    *
-   * Sent when adversarial review found problems in test files that the implementer
-   * cannot fix (isolation constraint). The test-writer is allowed to modify test files.
+   * Sent when review found problems in test files that the implementer cannot fix
+   * (isolation constraint). Handles both adversarial-review findings and lint failures.
    */
   static testWriterRectification(testFileFindings: ReviewCheckResult[], story: UserStory): string {
     const scopeConstraint = story.workdir
       ? `\n\nIMPORTANT: Only modify test files within \`${story.workdir}/\`. Do NOT touch source files.`
       : "\n\nIMPORTANT: Only modify test files. Do NOT touch source implementation files.";
 
+    const checkTypes = new Set(testFileFindings.map((c) => c.check));
+    const isLintOnly = checkTypes.size === 1 && checkTypes.has("lint");
+    const hasAdversarial = checkTypes.has("adversarial");
+
+    const opener = isLintOnly
+      ? "You are fixing test file lint errors."
+      : hasAdversarial
+        ? "You are fixing test file issues flagged by an adversarial code reviewer."
+        : "You are fixing test file issues.";
+
+    const sectionLabel = isLintOnly
+      ? "lint"
+      : hasAdversarial && checkTypes.size === 1
+        ? "adversarial review"
+        : "review";
+
     const findingLines = testFileFindings
-      .flatMap((c) => c.findings ?? [])
-      .map((f) => `- [${f.severity}] ${f.file}:${f.line} — ${f.message}`)
+      .flatMap((c) => {
+        if (c.findings && c.findings.length > 0) {
+          return c.findings.map((f) => `- [${f.severity}] ${f.file}:${f.line} — ${f.message}`);
+        }
+        if (c.check === "lint" && c.output.trim()) {
+          return [c.output.trim()];
+        }
+        return [];
+      })
       .join("\n");
 
     const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
 
-    return `You are fixing test file issues flagged by an adversarial code reviewer.
+    const importantNote = isLintOnly
+      ? "**Important:** Fix the lint errors in the test files listed above. Do NOT modify source implementation files."
+      : `**Important:** These findings are in test files. Before making any changes:
+1. Read the flagged test files to verify each finding is a real issue
+2. Only fix findings that are genuinely incorrect or missing — do NOT remove tests
+3. Do NOT modify source implementation files`;
+
+    return `${opener}
 
 Story: ${story.title} (${story.id})
 
 ### Acceptance Criteria
 ${acList}
 
-### Test File Findings (adversarial review)
+### Test File Findings (${sectionLabel})
 ${findingLines}
 
-**Important:** These findings are in test files. Before making any changes:
-1. Read the flagged test files to verify each finding is a real issue
-2. Only fix findings that are genuinely incorrect or missing — do NOT remove tests
-3. Do NOT modify source implementation files
+${importantNote}
 
 Commit your fixes when done.${scopeConstraint}`;
   }

--- a/test/unit/prompts/builders/rectifier-builder.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder.test.ts
@@ -469,4 +469,58 @@ describe("RectifierPromptBuilder.testWriterRectification", () => {
     expect(prompt).toContain("test/unit/foo.test.ts");
     expect(prompt).toContain("test/unit/bar.test.ts");
   });
+
+  test("adversarial check: uses adversarial opener and section label", () => {
+    const checks = [makeTestFileCheck("test/unit/foo.test.ts", "finding")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory());
+
+    expect(prompt).toContain("You are fixing test file issues flagged by an adversarial code reviewer.");
+    expect(prompt).toContain("### Test File Findings (adversarial review)");
+    expect(prompt).toContain("do NOT remove tests");
+  });
+
+  test("lint-only check: uses lint opener and section label", () => {
+    const lintCheck: import("../../../../src/review/types").ReviewCheckResult = {
+      check: "lint",
+      success: false,
+      command: "bun run lint",
+      exitCode: 1,
+      output: "apps/api/test/unit/foo.test.ts:10:5 error — Unexpected console statement",
+      durationMs: 100,
+    };
+    const prompt = RectifierPromptBuilder.testWriterRectification([lintCheck], makeStory());
+
+    expect(prompt).toContain("You are fixing test file lint errors.");
+    expect(prompt).toContain("### Test File Findings (lint)");
+    expect(prompt).not.toContain("adversarial");
+  });
+
+  test("lint-only check: includes raw output in findings section", () => {
+    const lintCheck: import("../../../../src/review/types").ReviewCheckResult = {
+      check: "lint",
+      success: false,
+      command: "bun run lint",
+      exitCode: 1,
+      output: "foo.test.ts:5 error — some lint error",
+      durationMs: 100,
+    };
+    const prompt = RectifierPromptBuilder.testWriterRectification([lintCheck], makeStory());
+
+    expect(prompt).toContain("foo.test.ts:5 error — some lint error");
+  });
+
+  test("lint-only check: uses simplified important note without verify-findings step", () => {
+    const lintCheck: import("../../../../src/review/types").ReviewCheckResult = {
+      check: "lint",
+      success: false,
+      command: "bun run lint",
+      exitCode: 1,
+      output: "some lint output",
+      durationMs: 100,
+    };
+    const prompt = RectifierPromptBuilder.testWriterRectification([lintCheck], makeStory());
+
+    expect(prompt).toContain("Fix the lint errors");
+    expect(prompt).not.toContain("verify each finding is a real issue");
+  });
 });


### PR DESCRIPTION
## Summary

- `testWriterRectification()` hardcoded adversarial framing regardless of what check types triggered the session — when lint failed and adversarial review was gated, the agent received the wrong opener, an empty findings section, and a nonsensical "verify each finding" instruction
- Fix: inspect `check.check` types on the incoming findings and select opener, section label, findings body, and important note accordingly
- 4 new unit tests cover the lint-only path

## Root cause

`splitFindingsByScope` routes both `adversarial` and `lint` findings to the test-writer session, but `testWriterRectification()` had no awareness of which type it was handling:

| Field | Before (always) | After — lint-only |
|---|---|---|
| Opener | "adversarial code reviewer" | "You are fixing test file lint errors." |
| Section label | `(adversarial review)` | `(lint)` |
| Findings body | `findings[]` — **empty for lint** | `check.output` |
| Important note | "verify each finding is a real issue" | "Fix the lint errors listed above" |

## Test plan

- [ ] `bun run test` passes (40/40 in `rectifier-builder.test.ts`)
- [ ] Lint-only path: prompt opens with "You are fixing test file lint errors." and renders `check.output`
- [ ] Adversarial-only path: existing language unchanged
- [ ] `bun run typecheck` clean

Closes #848
Relates to #672