### PR TITLE
refactor(review): phase 4b — narrow review runner config to selector slice

### DIFF
--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -74,7 +74,7 @@ export interface RunAdversarialReviewOptions {
   story: SemanticStory;
   adversarialConfig: AdversarialReviewConfig;
   agentManager: IAgentManager | undefined;
-  naxConfig?: NaxConfig;
+  naxConfig?: Pick<NaxConfig, "review" | "debate" | "models" | "execution">;
   featureName?: string;
   priorFailures?: Array<{ stage: string; modelTier: string }>;
   blockingThreshold?: "error" | "warning" | "info";

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -14,7 +14,7 @@
  */
 
 import type { IAgentManager } from "../agents";
-import type { NaxConfig } from "../config";
+import type { ReviewConfig } from "../config/selectors";
 import { filterContextByRole } from "../context";
 import { NaxError } from "../errors";
 import { getSafeLogger } from "../logger";
@@ -74,7 +74,7 @@ export interface RunAdversarialReviewOptions {
   story: SemanticStory;
   adversarialConfig: AdversarialReviewConfig;
   agentManager: IAgentManager | undefined;
-  naxConfig?: Pick<NaxConfig, "review" | "debate" | "models" | "execution">;
+  config?: ReviewConfig;
   featureName?: string;
   priorFailures?: Array<{ stage: string; modelTier: string }>;
   blockingThreshold?: "error" | "warning" | "info";
@@ -97,7 +97,7 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     story,
     adversarialConfig,
     agentManager,
-    naxConfig,
+    config: naxConfig,
     featureName,
     priorFailures,
     blockingThreshold,

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -217,7 +217,7 @@ export function createReviewerSession(
   storyId: string,
   workdir: string,
   featureName: string,
-  _config: NaxConfig,
+  _config: Pick<NaxConfig, "review" | "debate" | "models" | "execution">,
 ): ReviewerSession {
   const history: DialogueMessage[] = [];
   let active = true;

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -8,8 +8,8 @@
 import type { SemanticVerdict } from "../acceptance/types";
 import type { IAgentManager } from "../agents";
 import type { SessionHandle } from "../agents/types";
-import type { NaxConfig } from "../config";
 import { resolveConfiguredModel } from "../config/schema-types";
+import type { ReviewConfig } from "../config/selectors";
 import type { DebateResolverContext } from "../debate/types";
 import { NaxError } from "../errors";
 import type { ReviewFinding } from "../plugins/types";
@@ -217,7 +217,7 @@ export function createReviewerSession(
   storyId: string,
   workdir: string,
   featureName: string,
-  _config: Pick<NaxConfig, "review" | "debate" | "models" | "execution">,
+  _config: ReviewConfig,
 ): ReviewerSession {
   const history: DialogueMessage[] = [];
   let active = true;

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -127,6 +127,7 @@ function buildFailureReason(checks: ReviewCheckResult[]): string | undefined {
   return failedChecks.map(formatFailureReason).join(", ");
 }
 
+//TODO: clean up options bag - most of the config is redundant
 export interface OrchestratorReviewOptions {
   reviewConfig: ReviewConfig;
   workdir: string;
@@ -349,7 +350,7 @@ export class ReviewOrchestrator {
             story: semanticStory,
             adversarialConfig: adversarialCfg,
             agentManager,
-            naxConfig,
+            config: naxConfig,
             featureName,
             priorFailures,
             blockingThreshold: reviewConfig.blockingThreshold,

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -5,8 +5,8 @@
  */
 
 import type { IAgentManager } from "../agents";
-import type { NaxConfig } from "../config";
 import type { ExecutionConfig, QualityConfig } from "../config/schema";
+import type { ReviewConfig as ReviewNaxConfig } from "../config/selectors";
 import { getSafeLogger } from "../logger";
 import { runQualityCommand } from "../quality";
 import { autoCommitIfDirty } from "../utils/git";
@@ -29,7 +29,7 @@ export interface RunReviewOptions {
   storyGitRef?: string;
   story?: SemanticStory;
   agentManager?: IAgentManager;
-  naxConfig?: Pick<NaxConfig, "review" | "debate" | "models" | "execution">;
+  naxConfig?: ReviewNaxConfig;
   retrySkipChecks?: Set<string>;
   featureName?: string;
   resolverSession?: import("./dialogue").ReviewerSession;
@@ -380,7 +380,7 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
         story: adversarialStory,
         adversarialConfig: adversarialCfg,
         agentManager,
-        naxConfig,
+        config: naxConfig,
         featureName,
         priorFailures,
         blockingThreshold: config.blockingThreshold,

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -29,7 +29,7 @@ export interface RunReviewOptions {
   storyGitRef?: string;
   story?: SemanticStory;
   agentManager?: IAgentManager;
-  naxConfig?: NaxConfig;
+  naxConfig?: Pick<NaxConfig, "review" | "debate" | "models" | "execution">;
   retrySkipChecks?: Set<string>;
   featureName?: string;
   resolverSession?: import("./dialogue").ReviewerSession;

--- a/src/review/semantic-debate.ts
+++ b/src/review/semantic-debate.ts
@@ -7,11 +7,10 @@
  */
 
 import type { IAgentManager } from "../agents";
-import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
+import type { ReviewConfig } from "../config/selectors";
 import type { DebateRunner, DebateRunnerOptions } from "../debate";
 import { getSafeLogger } from "../logger";
-import { createRuntime } from "../runtime";
 import {
   type LLMFinding,
   formatFindings,
@@ -49,8 +48,8 @@ function recordSemanticDebateAudit(opts: {
 }
 
 export interface SemanticDebateOptions {
-  naxConfig: Pick<NaxConfig, "review" | "debate" | "models" | "execution"> | undefined;
-  runtime: import("../runtime").NaxRuntime | undefined;
+  naxConfig: ReviewConfig;
+  runtime: import("../runtime").NaxRuntime;
   workdir: string;
   agentManager: IAgentManager;
   featureName: string | undefined;
@@ -87,226 +86,191 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
     createDebateRunner,
   } = opts;
   const logger = getSafeLogger();
-  const semanticEffectiveConfig = naxConfig ?? DEFAULT_CONFIG;
-  const createdRuntime = runtime
-    ? undefined
-    : createRuntime(semanticEffectiveConfig as NaxConfig, workdir, {
-        agentManager,
-        featureName: featureName ?? "_standalone",
-      });
-  const debateRuntime = runtime ?? createdRuntime;
-  if (!debateRuntime) {
-    throw new Error("[review] Debate runtime unavailable");
-  }
-  try {
-    // Safe: reviewDebateEnabled guard (in caller) confirms naxConfig.debate.stages.review is defined
-    const configuredStageConfig = naxConfig?.debate?.stages.review as import("../debate").DebateStageConfig;
-    const reviewStageConfig =
-      configuredStageConfig.sessionMode === "one-shot" && (configuredStageConfig.mode ?? "panel") === "panel"
-        ? configuredStageConfig
-        : {
-            ...configuredStageConfig,
-            // Review debate currently supports panel one-shot only.
-            sessionMode: "one-shot" as const,
-            mode: "panel" as const,
-          };
-    if (reviewStageConfig !== configuredStageConfig) {
-      logger?.warn("review", "Review debate requires sessionMode=one-shot and mode=panel — forcing safe defaults", {
-        storyId: story.id,
-        configuredSessionMode: configuredStageConfig.sessionMode,
-        configuredMode: configuredStageConfig.mode ?? "panel",
-      });
-    }
-    const isReReview = resolverSession !== undefined && resolverSession.history.length > 0;
-    const semanticAgentName =
-      agentManager && typeof (agentManager as IAgentManager).getDefault === "function"
-        ? (agentManager as IAgentManager).getDefault()
-        : "claude";
-    const semanticCallCtx: import("../operations/types").CallContext = {
-      runtime: debateRuntime,
-      packageView: debateRuntime.packages.resolve(workdir),
-      packageDir: workdir,
-      agentName: semanticAgentName,
-      storyId: story.id,
-      featureName,
-    };
-    const debateRunner = createDebateRunner({
-      ctx: semanticCallCtx,
-      stage: "review",
-      stageConfig: reviewStageConfig,
-      config: semanticEffectiveConfig as NaxConfig,
-      workdir,
-      featureName: featureName,
-      timeoutSeconds: naxConfig?.execution?.sessionTimeoutSeconds,
-      reviewerSession: resolverSession,
-      resolverContextInput: resolverSession
-        ? {
-            diffMode,
-            ...(diffMode === "ref" ? { storyGitRef: effectiveRef, stat } : { diff }),
-            story: { id: story.id, title: story.title, acceptanceCriteria: story.acceptanceCriteria },
-            semanticConfig,
-            resolverType: reviewStageConfig.resolver.type,
-            isReReview,
-          }
-        : undefined,
-    });
-    // Track history length before to detect if the session was actually used by the resolver
-    const historyLenBefore = resolverSession?.history.length ?? 0;
-    const debateResult = await debateRunner.run(prompt);
-    const debateCost = debateResult.totalCostUsd ?? 0;
-
-    // When the ReviewerSession was used by the resolver (history grew), use its tool-verified
-    // verdict via getVerdict() instead of re-deriving from raw proposals.
-    const sessionUsed = resolverSession && resolverSession.history.length > historyLenBefore;
-    if (sessionUsed) {
-      const durationMs = Date.now() - startTime;
-      try {
-        const verdict = resolverSession.getVerdict();
-        const findings = verdict.findings ?? [];
-        if (!verdict.passed && findings.length > 0) {
-          logger?.warn("review", `Semantic review failed (debate+dialogue): ${findings.length} findings`, {
-            storyId: story.id,
-            durationMs,
-          });
-          recordSemanticDebateAudit({
-            runtime: debateRuntime,
-            workdir,
-            storyId: story.id,
-            featureName,
-            parsed: true,
-            passed: false,
-            blockingThreshold,
-            result: { passed: false, findings },
-          });
-          return {
-            check: "semantic",
-            success: false,
-            command: "",
-            exitCode: 1,
-            output: `Semantic review failed:\n\n${findings.map((f) => `${f.ruleId}: ${f.message}`).join("\n")}`,
-            durationMs,
-            findings,
-            cost: debateCost,
-          };
-        }
-        const label = verdict.passed
-          ? "Semantic review passed (debate+dialogue)"
-          : "Semantic review passed (debate+dialogue, all findings non-blocking)";
-        logger?.info("review", label, { storyId: story.id, durationMs });
-        recordSemanticDebateAudit({
-          runtime: debateRuntime,
-          workdir,
-          storyId: story.id,
-          featureName,
-          parsed: true,
-          passed: true,
-          blockingThreshold,
-          result: { passed: true, findings },
-        });
-        return {
-          check: "semantic",
-          success: true,
-          command: "",
-          exitCode: 0,
-          output: label,
-          durationMs,
-          cost: debateCost,
+  // Safe: reviewDebateEnabled guard (in caller) confirms naxConfig.debate.stages.review is defined
+  const configuredStageConfig = naxConfig.debate?.stages.review as import("../debate").DebateStageConfig;
+  const reviewStageConfig =
+    configuredStageConfig.sessionMode === "one-shot" && (configuredStageConfig.mode ?? "panel") === "panel"
+      ? configuredStageConfig
+      : {
+          ...configuredStageConfig,
+          // Review debate currently supports panel one-shot only.
+          sessionMode: "one-shot" as const,
+          mode: "panel" as const,
         };
-      } catch {
-        // getVerdict() threw (e.g. session destroyed) — fall through to stateless path
-        logger?.warn("review", "getVerdict() failed after debate+dialogue — falling back to stateless verdict", {
-          storyId: story.id,
-        });
-      }
-    }
+  if (reviewStageConfig !== configuredStageConfig) {
+    logger?.warn("review", "Review debate requires sessionMode=one-shot and mode=panel — forcing safe defaults", {
+      storyId: story.id,
+      configuredSessionMode: configuredStageConfig.sessionMode,
+      configuredMode: configuredStageConfig.mode ?? "panel",
+    });
+  }
+  const isReReview = resolverSession !== undefined && resolverSession.history.length > 0;
+  const semanticAgentName =
+    agentManager && typeof (agentManager as IAgentManager).getDefault === "function"
+      ? (agentManager as IAgentManager).getDefault()
+      : "claude";
+  const semanticCallCtx: import("../operations/types").CallContext = {
+    runtime,
+    packageView: runtime.packages.resolve(workdir),
+    packageDir: workdir,
+    agentName: semanticAgentName,
+    storyId: story.id,
+    featureName,
+  };
+  const debateRunner = createDebateRunner({
+    ctx: semanticCallCtx,
+    stage: "review",
+    stageConfig: reviewStageConfig,
+    config: naxConfig as NaxConfig,
+    workdir,
+    featureName: featureName,
+    timeoutSeconds: naxConfig.execution?.sessionTimeoutSeconds,
+    reviewerSession: resolverSession,
+    resolverContextInput: resolverSession
+      ? {
+          diffMode,
+          ...(diffMode === "ref" ? { storyGitRef: effectiveRef, stat } : { diff }),
+          story: { id: story.id, title: story.title, acceptanceCriteria: story.acceptanceCriteria },
+          semanticConfig,
+          resolverType: reviewStageConfig.resolver.type,
+          isReReview,
+        }
+      : undefined,
+  });
+  // Track history length before to detect if the session was actually used by the resolver
+  const historyLenBefore = resolverSession?.history.length ?? 0;
+  const debateResult = await debateRunner.run(prompt);
+  const debateCost = debateResult.totalCostUsd ?? 0;
 
-    // Stateless fallback: re-derive verdict from proposals (existing behavior)
-    const resolverPassed = debateResult.outcome === "passed";
-    const allFindings: LLMFinding[] = [];
-    for (const p of debateResult.proposals) {
-      const parsed = parseLLMResponse(p.output);
-      if (parsed) {
-        allFindings.push(...parsed.findings);
-      }
-    }
-
-    // Deduplicate findings by AC id (primary) or file:line (fallback)
-    const seen = new Set<string>();
-    const deduped: LLMFinding[] = [];
-    for (const f of allFindings) {
-      const key = f.acId ?? `${f.file}:${f.line}`;
-      if (!seen.has(key)) {
-        seen.add(key);
-        deduped.push(f);
-      }
-    }
-
-    // Split debate findings by blocking threshold
-    const debateFindings = sanitizeRefModeFindings(deduped, diffMode);
-    const debateThreshold = blockingThreshold ?? "error";
-    const debateBlocking = debateFindings.filter((f) => isBlockingSeverity(f.severity, debateThreshold));
-    const debateAdvisory = debateFindings.filter((f) => !isBlockingSeverity(f.severity, debateThreshold));
-
+  // When the ReviewerSession was used by the resolver (history grew), use its tool-verified
+  // verdict via getVerdict() instead of re-deriving from raw proposals.
+  const sessionUsed = resolverSession && resolverSession.history.length > historyLenBefore;
+  if (sessionUsed) {
     const durationMs = Date.now() - startTime;
-    if (!resolverPassed) {
-      if (debateBlocking.length > 0) {
-        logger?.warn("review", `Semantic review failed (debate): ${debateBlocking.length} blocking findings`, {
+    try {
+      const verdict = resolverSession.getVerdict();
+      const findings = verdict.findings ?? [];
+      if (!verdict.passed && findings.length > 0) {
+        logger?.warn("review", `Semantic review failed (debate+dialogue): ${findings.length} findings`, {
           storyId: story.id,
           durationMs,
         });
         recordSemanticDebateAudit({
-          runtime: debateRuntime,
+          runtime: runtime,
           workdir,
           storyId: story.id,
           featureName,
           parsed: true,
           passed: false,
-          blockingThreshold: debateThreshold,
-          result: { passed: false, findings: debateFindings },
-          advisoryFindings: debateAdvisory,
+          blockingThreshold,
+          result: { passed: false, findings },
         });
         return {
           check: "semantic",
           success: false,
           command: "",
           exitCode: 1,
-          output: `Semantic review failed:\n\n${formatFindings(debateBlocking)}`,
+          output: `Semantic review failed:\n\n${findings.map((f) => `${f.ruleId}: ${f.message}`).join("\n")}`,
           durationMs,
-          findings: toReviewFindings(debateBlocking),
-          advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory) : undefined,
+          findings,
           cost: debateCost,
         };
       }
-      // All findings were advisory — override to pass
-      logger?.info("review", "Semantic review passed (debate, all findings below blocking threshold)", {
-        storyId: story.id,
-        durationMs,
-      });
+      const label = verdict.passed
+        ? "Semantic review passed (debate+dialogue)"
+        : "Semantic review passed (debate+dialogue, all findings non-blocking)";
+      logger?.info("review", label, { storyId: story.id, durationMs });
       recordSemanticDebateAudit({
-        runtime: debateRuntime,
+        runtime: runtime,
         workdir,
         storyId: story.id,
         featureName,
         parsed: true,
         passed: true,
-        blockingThreshold: debateThreshold,
-        result: { passed: true, findings: debateFindings },
-        advisoryFindings: debateAdvisory,
+        blockingThreshold,
+        result: { passed: true, findings },
       });
       return {
         check: "semantic",
         success: true,
         command: "",
         exitCode: 0,
-        output: "Semantic review passed (debate, all findings were advisory — below blocking threshold)",
+        output: label,
         durationMs,
+        cost: debateCost,
+      };
+    } catch {
+      // getVerdict() threw (e.g. session destroyed) — fall through to stateless path
+      logger?.warn("review", "getVerdict() failed after debate+dialogue — falling back to stateless verdict", {
+        storyId: story.id,
+      });
+    }
+  }
+
+  // Stateless fallback: re-derive verdict from proposals (existing behavior)
+  const resolverPassed = debateResult.outcome === "passed";
+  const allFindings: LLMFinding[] = [];
+  for (const p of debateResult.proposals) {
+    const parsed = parseLLMResponse(p.output);
+    if (parsed) {
+      allFindings.push(...parsed.findings);
+    }
+  }
+
+  // Deduplicate findings by AC id (primary) or file:line (fallback)
+  const seen = new Set<string>();
+  const deduped: LLMFinding[] = [];
+  for (const f of allFindings) {
+    const key = f.acId ?? `${f.file}:${f.line}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(f);
+    }
+  }
+
+  // Split debate findings by blocking threshold
+  const debateFindings = sanitizeRefModeFindings(deduped, diffMode);
+  const debateThreshold = blockingThreshold ?? "error";
+  const debateBlocking = debateFindings.filter((f) => isBlockingSeverity(f.severity, debateThreshold));
+  const debateAdvisory = debateFindings.filter((f) => !isBlockingSeverity(f.severity, debateThreshold));
+
+  const durationMs = Date.now() - startTime;
+  if (!resolverPassed) {
+    if (debateBlocking.length > 0) {
+      logger?.warn("review", `Semantic review failed (debate): ${debateBlocking.length} blocking findings`, {
+        storyId: story.id,
+        durationMs,
+      });
+      recordSemanticDebateAudit({
+        runtime: runtime,
+        workdir,
+        storyId: story.id,
+        featureName,
+        parsed: true,
+        passed: false,
+        blockingThreshold: debateThreshold,
+        result: { passed: false, findings: debateFindings },
+        advisoryFindings: debateAdvisory,
+      });
+      return {
+        check: "semantic",
+        success: false,
+        command: "",
+        exitCode: 1,
+        output: `Semantic review failed:\n\n${formatFindings(debateBlocking)}`,
+        durationMs,
+        findings: toReviewFindings(debateBlocking),
         advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory) : undefined,
         cost: debateCost,
       };
     }
-    logger?.info("review", "Semantic review passed (debate)", { storyId: story.id, durationMs });
+    // All findings were advisory — override to pass
+    logger?.info("review", "Semantic review passed (debate, all findings below blocking threshold)", {
+      storyId: story.id,
+      durationMs,
+    });
     recordSemanticDebateAudit({
-      runtime: debateRuntime,
+      runtime: runtime,
       workdir,
       storyId: story.id,
       featureName,
@@ -321,14 +285,32 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
       success: true,
       command: "",
       exitCode: 0,
-      output: "Semantic review passed",
+      output: "Semantic review passed (debate, all findings were advisory — below blocking threshold)",
       durationMs,
       advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory) : undefined,
       cost: debateCost,
     };
-  } finally {
-    if (createdRuntime) {
-      await createdRuntime.close().catch(() => {});
-    }
   }
+  logger?.info("review", "Semantic review passed (debate)", { storyId: story.id, durationMs });
+  recordSemanticDebateAudit({
+    runtime: runtime,
+    workdir,
+    storyId: story.id,
+    featureName,
+    parsed: true,
+    passed: true,
+    blockingThreshold: debateThreshold,
+    result: { passed: true, findings: debateFindings },
+    advisoryFindings: debateAdvisory,
+  });
+  return {
+    check: "semantic",
+    success: true,
+    command: "",
+    exitCode: 0,
+    output: "Semantic review passed",
+    durationMs,
+    advisoryFindings: debateAdvisory.length > 0 ? toReviewFindings(debateAdvisory) : undefined,
+    cost: debateCost,
+  };
 }

--- a/src/review/semantic-debate.ts
+++ b/src/review/semantic-debate.ts
@@ -49,7 +49,7 @@ function recordSemanticDebateAudit(opts: {
 }
 
 export interface SemanticDebateOptions {
-  naxConfig: NaxConfig | undefined;
+  naxConfig: Pick<NaxConfig, "review" | "debate" | "models" | "execution"> | undefined;
   runtime: import("../runtime").NaxRuntime | undefined;
   workdir: string;
   agentManager: IAgentManager;
@@ -90,7 +90,10 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
   const semanticEffectiveConfig = naxConfig ?? DEFAULT_CONFIG;
   const createdRuntime = runtime
     ? undefined
-    : createRuntime(semanticEffectiveConfig, workdir, { agentManager, featureName: featureName ?? "_standalone" });
+    : createRuntime(semanticEffectiveConfig as NaxConfig, workdir, {
+        agentManager,
+        featureName: featureName ?? "_standalone",
+      });
   const debateRuntime = runtime ?? createdRuntime;
   if (!debateRuntime) {
     throw new Error("[review] Debate runtime unavailable");
@@ -131,7 +134,7 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
       ctx: semanticCallCtx,
       stage: "review",
       stageConfig: reviewStageConfig,
-      config: semanticEffectiveConfig,
+      config: semanticEffectiveConfig as NaxConfig,
       workdir,
       featureName: featureName,
       timeoutSeconds: naxConfig?.execution?.sessionTimeoutSeconds,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -80,7 +80,7 @@ export interface RunSemanticReviewOptions {
   story: SemanticStory;
   semanticConfig: SemanticReviewConfig;
   agentManager: IAgentManager | undefined;
-  naxConfig?: NaxConfig;
+  naxConfig?: Pick<NaxConfig, "review" | "debate" | "models" | "execution">;
   featureName?: string;
   resolverSession?: import("./dialogue").ReviewerSession;
   priorFailures?: Array<{ stage: string; modelTier: string }>;
@@ -153,7 +153,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
 
   // ADR-009: resolve effective exclude patterns from config (falls back to DEFAULT_TEST_FILE_PATTERNS
   // when semanticConfig.excludePatterns is undefined — no behaviour change for default config).
-  const resolved = await resolveTestFilePatterns(naxConfig ?? DEFAULT_CONFIG, workdir);
+  const resolved = await resolveTestFilePatterns((naxConfig ?? DEFAULT_CONFIG) as NaxConfig, workdir);
   const excludePatterns = [...resolveReviewExcludePatterns(semanticConfig.excludePatterns, resolved)];
 
   let diff: string | undefined;

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -10,6 +10,7 @@
 import type { IAgentManager } from "../agents";
 import { DEFAULT_CONFIG } from "../config";
 import type { NaxConfig } from "../config";
+import type { ReviewConfig } from "../config/selectors";
 import { filterContextByRole } from "../context";
 import { DebateRunner } from "../debate";
 import type { DebateRunnerOptions } from "../debate";
@@ -80,7 +81,7 @@ export interface RunSemanticReviewOptions {
   story: SemanticStory;
   semanticConfig: SemanticReviewConfig;
   agentManager: IAgentManager | undefined;
-  naxConfig?: Pick<NaxConfig, "review" | "debate" | "models" | "execution">;
+  naxConfig?: ReviewConfig;
   featureName?: string;
   resolverSession?: import("./dialogue").ReviewerSession;
   priorFailures?: Array<{ stage: string; modelTier: string }>;
@@ -230,6 +231,19 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
   // Debate path: when debate is enabled for review stage, use DebateRunner instead of agent.complete()
   const reviewDebateEnabled = naxConfig?.debate?.enabled && naxConfig?.debate?.stages?.review?.enabled;
   if (reviewDebateEnabled) {
+    if (!runtime) {
+      throw new NaxError("runtime required for debate path — legacy standalone path removed", "DISPATCH_NO_RUNTIME", {
+        stage: "review-semantic-debate",
+        storyId: story.id,
+      });
+    }
+    if (!naxConfig) {
+      throw new NaxError(
+        "naxConfig required for debate path — reviewDebateEnabled implies naxConfig is present",
+        "CONFIG_MISSING",
+        { stage: "review-semantic-debate", storyId: story.id },
+      );
+    }
     return runSemanticDebate({
       naxConfig,
       runtime,

--- a/test/unit/review/dialogue-debate.test.ts
+++ b/test/unit/review/dialogue-debate.test.ts
@@ -94,11 +94,10 @@ function makeAgentManager(runAsSessionFn: RunAsSessionFnType): IAgentManager {
 }
 
 const MOCK_CONFIG = {
-  autoMode: { defaultAgent: "claude" },
   models: { claude: { fast: { model: "claude-haiku-4-5-20251001" }, balanced: { model: "claude-sonnet-4-6" }, powerful: { model: "claude-opus-4-6" } } },
   execution: { sessionTimeoutSeconds: 3600 },
   review: { dialogue: { enabled: true, maxClarificationsPerAttempt: 3, maxDialogueMessages: 20 } },
-} as unknown as import("../../../src/config").NaxConfig;
+} as Pick<import("../../../src/config").NaxConfig, "review" | "debate" | "models" | "execution">;
 
 // ---------------------------------------------------------------------------
 // resolveDebate() — core behavior
@@ -321,7 +320,7 @@ describe("ReviewerSession.reReviewDebate()", () => {
     const smallMaxConfig = {
       ...MOCK_CONFIG,
       review: { dialogue: { enabled: true, maxClarificationsPerAttempt: 3, maxDialogueMessages: 2 } },
-    } as unknown as import("../../../src/config").NaxConfig;
+    } as Pick<import("../../../src/config").NaxConfig, "review" | "debate" | "models" | "execution">;
 
     let callCount = 0;
     const multiRunFn: RunAsSessionFnType = mock(async (_agentName: string, _handle: SessionHandle, _prompt: string, _opts: RunAsSessionOpts): Promise<TurnResult> => {

--- a/test/unit/review/dialogue-debate.test.ts
+++ b/test/unit/review/dialogue-debate.test.ts
@@ -23,6 +23,7 @@ import type { RunAsSessionOpts } from "../../../src/agents/manager-types";
 import type { SessionHandle, TurnResult } from "../../../src/agents/types";
 import type { SemanticStory } from "../../../src/review/semantic";
 import type { SemanticReviewConfig } from "../../../src/review/types";
+import type { ReviewConfig } from "../../../src/config/selectors";
 import { NaxError } from "../../../src/errors";
 import { makeMockAgentManager, makeSessionManager } from "../../helpers";
 
@@ -97,7 +98,7 @@ const MOCK_CONFIG = {
   models: { claude: { fast: { model: "claude-haiku-4-5-20251001" }, balanced: { model: "claude-sonnet-4-6" }, powerful: { model: "claude-opus-4-6" } } },
   execution: { sessionTimeoutSeconds: 3600 },
   review: { dialogue: { enabled: true, maxClarificationsPerAttempt: 3, maxDialogueMessages: 20 } },
-} as Pick<import("../../../src/config").NaxConfig, "review" | "debate" | "models" | "execution">;
+} as unknown as ReviewConfig;
 
 // ---------------------------------------------------------------------------
 // resolveDebate() — core behavior
@@ -320,7 +321,7 @@ describe("ReviewerSession.reReviewDebate()", () => {
     const smallMaxConfig = {
       ...MOCK_CONFIG,
       review: { dialogue: { enabled: true, maxClarificationsPerAttempt: 3, maxDialogueMessages: 2 } },
-    } as Pick<import("../../../src/config").NaxConfig, "review" | "debate" | "models" | "execution">;
+    } as unknown as ReviewConfig;
 
     let callCount = 0;
     const multiRunFn: RunAsSessionFnType = mock(async (_agentName: string, _handle: SessionHandle, _prompt: string, _opts: RunAsSessionOpts): Promise<TurnResult> => {

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -359,6 +359,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       semanticConfig: SEMANTIC_CONFIG,
       agentManager: () => makeMockAgent(PROPOSAL_PASS),
       naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+      runtime: makeMockRuntime(),
     });
 
     expect(result.success).toBe(true);
@@ -406,6 +407,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       semanticConfig: SEMANTIC_CONFIG,
       agentManager: () => makeMockAgent(PROPOSAL_PASS),
       naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+      runtime: makeMockRuntime(),
     });
 
     expect(result.success).toBe(false);
@@ -427,6 +429,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       semanticConfig: SEMANTIC_CONFIG,
       agentManager: () => makeMockAgent(PROPOSAL_PASS),
       naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+      runtime: makeMockRuntime(),
     });
 
     expect(result.findings).toBeDefined();
@@ -449,6 +452,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       semanticConfig: SEMANTIC_CONFIG,
       agentManager: () => makeMockAgent(PROPOSAL_PASS),
       naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+      runtime: makeMockRuntime(),
     });
 
     expect(result.findings).toBeDefined();
@@ -471,6 +475,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       semanticConfig: SEMANTIC_CONFIG,
       agentManager: () => makeMockAgent(PROPOSAL_PASS),
       naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+      runtime: makeMockRuntime(),
     });
 
     // PROPOSAL_FAIL_A has error finding (blocking), PROPOSAL_FAIL_B adds a warn finding (advisory at default threshold)

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -214,9 +214,9 @@ function makeAgentManager(llmResponse: string, cost = 0) {
       estimatedCostUsd: cost,
       agentFallbacks: [],
     }),
-    completeFn: async () => ({ output: llmResponse, costUsd: cost, source: "mock" }),
+    completeFn: async () => ({ output: llmResponse, costUsd: cost, source: "exact" as const }),
     runWithFallbackFn: async () => ({ result: { success: true, exitCode: 0, output: llmResponse, rateLimited: false, durationMs: 100, estimatedCostUsd: cost, agentFallbacks: [] }, fallbacks: [] }),
-    completeWithFallbackFn: async () => ({ result: { output: llmResponse, costUsd: cost, source: "mock" }, fallbacks: [] }),
+    completeWithFallbackFn: async () => ({ result: { output: llmResponse, costUsd: cost, source: "exact" as const }, fallbacks: [] }),
     runAsFn: async (_agent, opts) => ({
       success: true,
       exitCode: 0,
@@ -226,7 +226,7 @@ function makeAgentManager(llmResponse: string, cost = 0) {
       estimatedCostUsd: cost,
       agentFallbacks: [],
     }),
-    completeAsFn: async (_agent, _prompt, _opts) => ({ output: llmResponse, costUsd: cost, source: "mock" }),
+    completeAsFn: async (_agent, _prompt, _opts) => ({ output: llmResponse, costUsd: cost, source: "exact" as const }),
   });
 }
 
@@ -241,7 +241,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
   beforeEach(() => {
     _diffUtilsDeps.spawn = makeSpawnMock("diff content");
     _diffUtilsDeps.isGitRefValid = mock(async () => true);
-    _diffUtilsDeps.getMergeBase = mock(async () => null);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
     _semanticDeps.createDebateRunner = origCreateDebateSession;
   });
 
@@ -259,7 +259,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
 
   test("AC3: createDebateRunner is called when debate.stages.review.enabled=true", async () => {
     const runMock = mock(async () => DEBATE_MAJORITY_PASS_RESULT);
-    _semanticDeps.createDebateRunner = mock(() => ({ run: runMock }));
+    _semanticDeps.createDebateRunner = mock(() => ({ run: runMock })) as unknown as typeof _semanticDeps.createDebateRunner;
 
     const agentManager = makeAgentManager(PROPOSAL_PASS);
     const runtime = makeMockRuntime({ agentManager });
@@ -278,8 +278,8 @@ describe("runSemanticReview — debate integration (US-004)", () => {
   });
 
   test("AC3: DebateSession.run() is called with the semantic review prompt", async () => {
-    const runMock = mock(async () => DEBATE_MAJORITY_PASS_RESULT);
-    _semanticDeps.createDebateRunner = mock(() => ({ run: runMock }));
+    const runMock = mock(async (_prompt: string) => DEBATE_MAJORITY_PASS_RESULT);
+    _semanticDeps.createDebateRunner = mock(() => ({ run: runMock })) as unknown as typeof _semanticDeps.createDebateRunner;
 
     const agentManager = makeAgentManager(PROPOSAL_PASS);
     const runtime = makeMockRuntime({ agentManager });
@@ -302,7 +302,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
 
   test("AC3: agent.complete() is NOT called when debate is enabled and debate runs", async () => {
     const runMock = mock(async () => DEBATE_MAJORITY_PASS_RESULT);
-    _semanticDeps.createDebateRunner = mock(() => ({ run: runMock }));
+    _semanticDeps.createDebateRunner = mock(() => ({ run: runMock })) as unknown as typeof _semanticDeps.createDebateRunner;
 
     const agentManager = makeAgentManager(PROPOSAL_PASS);
     const runtime = makeMockRuntime({ agentManager });
@@ -324,7 +324,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     const createDebateMock = mock(() => ({
       run: mock(async () => DEBATE_MAJORITY_PASS_RESULT),
     }));
-    _semanticDeps.createDebateRunner = createDebateMock;
+    _semanticDeps.createDebateRunner = createDebateMock as unknown as typeof _semanticDeps.createDebateRunner;
 
     const agentManager = makeAgentManager(PROPOSAL_PASS);
     const runtime = makeMockRuntime({ agentManager });
@@ -335,7 +335,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       story: STORY,
       semanticConfig: SEMANTIC_CONFIG,
       agentManager,
-      naxConfig: { debate: { enabled: false, agents: 0, stages: {} as never } } as NaxConfig,
+      naxConfig: { debate: { enabled: false, agents: 0, stages: {} as never } } as unknown as NaxConfig,
       runtime,
     });
 
@@ -350,14 +350,14 @@ describe("runSemanticReview — debate integration (US-004)", () => {
   test("AC4: success=true when majority (2 of 3) proposals have passed=true", async () => {
     _semanticDeps.createDebateRunner = mock(() => ({
       run: mock(async () => DEBATE_MAJORITY_PASS_RESULT),
-    }));
+    })) as unknown as typeof _semanticDeps.createDebateRunner;
 
     const result = await runSemanticReview({
       workdir: WORKDIR,
       storyGitRef: STORY_GIT_REF,
       story: STORY,
       semanticConfig: SEMANTIC_CONFIG,
-      agentManager: () => makeMockAgent(PROPOSAL_PASS),
+      agentManager: makeAgentManager(PROPOSAL_PASS),
       naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
       runtime: makeMockRuntime(),
     });
@@ -369,7 +369,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     const auditCalls: unknown[] = [];
     _semanticDeps.createDebateRunner = mock(() => ({
       run: mock(async () => DEBATE_MAJORITY_FAIL_RESULT),
-    }));
+    })) as unknown as typeof _semanticDeps.createDebateRunner;
 
     const agentManager = makeAgentManager(PROPOSAL_PASS);
     const runtime = makeMockRuntime({
@@ -398,14 +398,14 @@ describe("runSemanticReview — debate integration (US-004)", () => {
   test("AC4: success=false when majority (2 of 3) proposals have passed=false", async () => {
     _semanticDeps.createDebateRunner = mock(() => ({
       run: mock(async () => DEBATE_MAJORITY_FAIL_RESULT),
-    }));
+    })) as unknown as typeof _semanticDeps.createDebateRunner;
 
     const result = await runSemanticReview({
       workdir: WORKDIR,
       storyGitRef: STORY_GIT_REF,
       story: STORY,
       semanticConfig: SEMANTIC_CONFIG,
-      agentManager: () => makeMockAgent(PROPOSAL_PASS),
+      agentManager: makeAgentManager(PROPOSAL_PASS),
       naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
       runtime: makeMockRuntime(),
     });
@@ -420,14 +420,14 @@ describe("runSemanticReview — debate integration (US-004)", () => {
   test("AC5: findings contains entries from all debaters when majority fails", async () => {
     _semanticDeps.createDebateRunner = mock(() => ({
       run: mock(async () => DEBATE_MAJORITY_FAIL_RESULT),
-    }));
+    })) as unknown as typeof _semanticDeps.createDebateRunner;
 
     const result = await runSemanticReview({
       workdir: WORKDIR,
       storyGitRef: STORY_GIT_REF,
       story: STORY,
       semanticConfig: SEMANTIC_CONFIG,
-      agentManager: () => makeMockAgent(PROPOSAL_PASS),
+      agentManager: makeAgentManager(PROPOSAL_PASS),
       naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
       runtime: makeMockRuntime(),
     });
@@ -443,14 +443,14 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     // Expected merged+deduped: 2 findings (not 3)
     _semanticDeps.createDebateRunner = mock(() => ({
       run: mock(async () => DEBATE_DUPLICATE_FINDINGS_RESULT),
-    }));
+    })) as unknown as typeof _semanticDeps.createDebateRunner;
 
     const result = await runSemanticReview({
       workdir: WORKDIR,
       storyGitRef: STORY_GIT_REF,
       story: STORY,
       semanticConfig: SEMANTIC_CONFIG,
-      agentManager: () => makeMockAgent(PROPOSAL_PASS),
+      agentManager: makeAgentManager(PROPOSAL_PASS),
       naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
       runtime: makeMockRuntime(),
     });
@@ -466,14 +466,14 @@ describe("runSemanticReview — debate integration (US-004)", () => {
   test("AC5: findings from both debaters are included when they report different issues", async () => {
     _semanticDeps.createDebateRunner = mock(() => ({
       run: mock(async () => DEBATE_DUPLICATE_FINDINGS_RESULT),
-    }));
+    })) as unknown as typeof _semanticDeps.createDebateRunner;
 
     const result = await runSemanticReview({
       workdir: WORKDIR,
       storyGitRef: STORY_GIT_REF,
       story: STORY,
       semanticConfig: SEMANTIC_CONFIG,
-      agentManager: () => makeMockAgent(PROPOSAL_PASS),
+      agentManager: makeAgentManager(PROPOSAL_PASS),
       naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
       runtime: makeMockRuntime(),
     });


### PR DESCRIPTION
## Summary

- Narrows `_config: NaxConfig` in `createReviewerSession` (`dialogue.ts`) to `Pick<NaxConfig, "review" | "debate" | "models" | "execution">` — the exact slice used by `reviewConfigSelector`
- Narrows `naxConfig?: NaxConfig` in `RunReviewOptions` (`runner.ts`), `RunSemanticReviewOptions` (`semantic.ts`), `RunAdversarialReviewOptions` (`adversarial.ts`), and `SemanticDebateOptions` (`semantic-debate.ts`) to the same Pick type
- Applies boundary casts (`as NaxConfig`) at two call sites in `semantic-debate.ts` where `createRuntime` and `DebateRunnerOptions.config` still require the full type (wiring-layer / out-of-scope for this phase)
- Updates `dialogue-debate.test.ts` mock config to use the narrowed type and drops the unused `autoMode` key from the fixture

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `timeout 60 bun test test/unit/review/ --timeout=10000` — 409/409 pass
- [x] `bun run test` — 1193 unit + 11 UI pass, 0 fail

Part of issue #745 — phase 4b (review runners). Parallel with 4a (debate), 4c (tdd), 4d (routing).