### PR TITLE
feat(autofix): add configurable lint parse strategies for scope-aware routing

### DIFF
--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -189,6 +189,11 @@ export interface QualityConfig {
     /** Build command (e.g., "bun run build") */
     build?: string;
   };
+  /** Lint output parsing preferences for scope-aware rectification splitting. */
+  lintOutput?: {
+    /** Parsing mode: auto-detect (default), specific parser, or disabled fallback. */
+    format?: "auto" | "eslint-json" | "biome-json" | "text" | "none";
+  };
   /** Auto-fix configuration (Phase 2) */
   autofix?: {
     /** Whether to auto-fix lint/format errors before escalating (default: true) */

--- a/src/config/schemas-execution.ts
+++ b/src/config/schemas-execution.ts
@@ -136,6 +136,11 @@ export const QualityConfigSchema = z.object({
       build: z.string().optional(),
     })
     .default({}),
+  lintOutput: z
+    .object({
+      format: z.enum(["auto", "eslint-json", "biome-json", "text", "none"]).default("auto"),
+    })
+    .default({ format: "auto" }),
   autofix: z
     .object({
       enabled: z.boolean().default(true),

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -115,6 +115,9 @@ export const NaxConfigSchema = z
       requireTests: true,
       scopeTestThreshold: 10,
       commands: {},
+      lintOutput: {
+        format: "auto",
+      },
       autofix: {
         enabled: true,
         maxAttempts: 3,

--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -17,40 +17,47 @@ import { getLogger } from "../../logger";
 import { buildHopCallback } from "../../operations/build-hop-callback";
 import type { UserStory } from "../../prd";
 import { RectifierPromptBuilder } from "../../prompts";
+import {
+  type LintDiagnostic,
+  type LintOutputFormat,
+  formatDiagnosticsOutput,
+  parseLintOutput,
+} from "../../review/lint-parsing";
 import type { ReviewCheckResult } from "../../review/types";
 import { isTestFile } from "../../test-runners";
 import type { PipelineContext } from "../types";
 
-// Known source-file extensions for lint output path extraction.
-const SOURCE_EXT_RE = /\.(ts|tsx|js|jsx|mjs|cjs|go|py|rs|rb|java|cs|cpp|c|h|swift|kt)$/;
+/**
+ * Extract unique file paths from lint output by running the best-effort parser chain.
+ */
+export function extractFilesFromLintOutput(output: string, format: LintOutputFormat = "auto"): string[] {
+  const parsed = parseLintOutput(output, format);
+  if (!parsed) return [];
+  return Array.from(new Set(parsed.diagnostics.map((d) => d.file)));
+}
+
+function buildScopedLintCheck(
+  check: ReviewCheckResult,
+  diagnostics: readonly LintDiagnostic[],
+): ReviewCheckResult | null {
+  const output = formatDiagnosticsOutput(diagnostics);
+  if (!output) return null;
+  return { ...check, output };
+}
 
 /**
- * Extract unique file paths from raw lint CLI output.
- * Handles ESLint stylish, ESLint compact, and Biome stylish formats.
- * Returns empty array when output is empty or no recognisable paths are found.
+ * Best-effort block/diagnostic filter for lint output.
+ * Returns null when no diagnostics map to target files.
  */
-export function extractFilesFromLintOutput(output: string): string[] {
-  if (!output.trim()) return [];
-
-  const files = new Set<string>();
-
-  // Matches file paths at the start of a line (stylish headers) and path:line or
-  // path:line:col patterns (compact format). Covers absolute and relative forms.
-  const PATH_RE = /^[ \t]*((?:\/[\w./-]+|\.\.?\/[\w./-]+|[\w][\w-]*(?:\/[\w./-]+)+))(?::\d+)?(?::\d+)?(?:\s|:|$)/gm;
-
-  let startIndex = 0;
-  while (startIndex <= output.length) {
-    PATH_RE.lastIndex = startIndex;
-    const m = PATH_RE.exec(output);
-    if (m === null) break;
-    const candidate = m[1];
-    if (SOURCE_EXT_RE.test(candidate)) {
-      files.add(candidate);
-    }
-    startIndex = m.index + 1;
-  }
-
-  return Array.from(files);
+export function filterLintOutputToFiles(
+  output: string,
+  targetFiles: ReadonlySet<string>,
+  format: LintOutputFormat = "text",
+): string | null {
+  const parsed = parseLintOutput(output, format);
+  if (!parsed) return null;
+  const filtered = parsed.diagnostics.filter((d) => targetFiles.has(d.file));
+  return formatDiagnosticsOutput(filtered);
 }
 
 function splitByStructuredFindings(
@@ -83,10 +90,10 @@ function splitByStructuredFindings(
 function splitByOutputParsing(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
+  format: LintOutputFormat = "auto",
 ): { testFindings: ReviewCheckResult | null; sourceFindings: ReviewCheckResult | null } {
-  const files = extractFilesFromLintOutput(check.output);
-
-  if (files.length === 0) {
+  const parsed = parseLintOutput(check.output, format);
+  if (!parsed) {
     // Cannot classify by file -- conservative fallback: route to implementer if output is non-empty
     if (check.output.trim()) {
       return { testFindings: null, sourceFindings: check };
@@ -94,12 +101,12 @@ function splitByOutputParsing(
     return { testFindings: null, sourceFindings: null };
   }
 
-  const hasTest = files.some((f) => isTestFile(f, testFilePatterns));
-  const hasSource = files.some((f) => !isTestFile(f, testFilePatterns));
+  const testDiagnostics = parsed.diagnostics.filter((d) => isTestFile(d.file, testFilePatterns));
+  const sourceDiagnostics = parsed.diagnostics.filter((d) => !isTestFile(d.file, testFilePatterns));
 
   return {
-    testFindings: hasTest ? check : null,
-    sourceFindings: hasSource ? check : null,
+    testFindings: buildScopedLintCheck(check, testDiagnostics),
+    sourceFindings: buildScopedLintCheck(check, sourceDiagnostics),
   };
 }
 
@@ -118,6 +125,7 @@ function splitByOutputParsing(
 export function splitFindingsByScope(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
+  lintOutputFormat: LintOutputFormat = "auto",
 ): {
   testFindings: ReviewCheckResult | null;
   sourceFindings: ReviewCheckResult | null;
@@ -126,7 +134,7 @@ export function splitFindingsByScope(
     return splitByStructuredFindings(check, testFilePatterns);
   }
   if (check.check === "lint") {
-    return splitByOutputParsing(check, testFilePatterns);
+    return splitByOutputParsing(check, testFilePatterns, lintOutputFormat);
   }
   return { testFindings: null, sourceFindings: null };
 }

--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -144,9 +144,10 @@ export async function runAgentRectification(
     typeof ctx.rootConfig.execution?.smartTestRunner === "object"
       ? ctx.rootConfig.execution.smartTestRunner?.testFilePatterns
       : undefined;
+  const lintOutputFormat = ctx.config.quality.lintOutput?.format ?? "auto";
   for (const check of failedChecks) {
     if (check.check === "adversarial" || check.check === "lint") {
-      const { testFindings, sourceFindings } = splitFindingsByScope(check, stageTestFilePatterns);
+      const { testFindings, sourceFindings } = splitFindingsByScope(check, stageTestFilePatterns, lintOutputFormat);
       // null/null means the check has no classifiable findings — leave implementerChecks unchanged.
       if (testFindings || sourceFindings) {
         if (testFindings) testWriterChecks = [...testWriterChecks, testFindings];

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -140,12 +140,13 @@ export const autofixStage: PipelineStage = {
       typeof ctx.rootConfig.execution?.smartTestRunner === "object"
         ? ctx.rootConfig.execution.smartTestRunner?.testFilePatterns
         : undefined;
+    const lintOutputFormat = ctx.config.quality.lintOutput?.format ?? "auto";
     if (ctx.routing.testStrategy === "no-test") {
       const failedChecks = (reviewResult.checks ?? []).filter((c) => !c.success);
       if (
         failedChecks.length > 0 &&
         failedChecks.every((c) => {
-          const { testFindings, sourceFindings } = splitFindingsByScope(c, testFilePatterns);
+          const { testFindings, sourceFindings } = splitFindingsByScope(c, testFilePatterns, lintOutputFormat);
           return testFindings !== null && sourceFindings === null;
         })
       ) {

--- a/src/review/lint-parsing/index.ts
+++ b/src/review/lint-parsing/index.ts
@@ -1,0 +1,2 @@
+export type { LintDiagnostic, LintOutputFormat, LintParseResult, LintParseStrategy } from "./types";
+export { filterDiagnosticsByFiles, formatDiagnosticsOutput, parseLintOutput } from "./parse";

--- a/src/review/lint-parsing/parse.ts
+++ b/src/review/lint-parsing/parse.ts
@@ -1,0 +1,40 @@
+import { biomeJsonStrategy } from "./strategies/biome-json";
+import { eslintJsonStrategy } from "./strategies/eslint-json";
+import { textBlockStrategy } from "./strategies/text-block";
+import type { LintDiagnostic, LintOutputFormat, LintParseResult, LintParseStrategy } from "./types";
+
+function strategiesFor(format: LintOutputFormat): ReadonlyArray<LintParseStrategy> {
+  if (format === "eslint-json") return [eslintJsonStrategy];
+  if (format === "biome-json") return [biomeJsonStrategy];
+  if (format === "text") return [textBlockStrategy];
+  if (format === "none") return [];
+  return [eslintJsonStrategy, biomeJsonStrategy, textBlockStrategy];
+}
+
+export function parseLintOutput(output: string, format: LintOutputFormat = "auto"): LintParseResult | null {
+  if (!output.trim()) return null;
+  for (const strategy of strategiesFor(format)) {
+    const parsed = strategy.parse(output);
+    if (parsed && parsed.diagnostics.length > 0) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+export function filterDiagnosticsByFiles(
+  diagnostics: readonly LintDiagnostic[],
+  files: ReadonlySet<string>,
+): LintDiagnostic[] {
+  return diagnostics.filter((d) => files.has(d.file));
+}
+
+export function formatDiagnosticsOutput(diagnostics: readonly LintDiagnostic[]): string | null {
+  if (diagnostics.length === 0) return null;
+  return (
+    diagnostics
+      .map((d) => d.raw)
+      .join("\n\n")
+      .trim() || null
+  );
+}

--- a/src/review/lint-parsing/strategies/biome-json.ts
+++ b/src/review/lint-parsing/strategies/biome-json.ts
@@ -1,0 +1,97 @@
+import type { LintDiagnostic, LintParseResult, LintParseStrategy } from "../types";
+
+interface LocatedDiagnostic {
+  file: string;
+  line?: number;
+  column?: number;
+  message: string;
+  ruleId?: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function readString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readNumber(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function extractLocation(record: Record<string, unknown>): { file?: string; line?: number; column?: number } {
+  const directFile = readString(record, "path") ?? readString(record, "file");
+  if (directFile) {
+    return {
+      file: directFile,
+      line: readNumber(record, "line"),
+      column: readNumber(record, "column"),
+    };
+  }
+
+  const location = asRecord(record.location);
+  const span = asRecord(location?.span);
+  const file = readString(location ?? {}, "path") ?? readString(span ?? {}, "path") ?? readString(span ?? {}, "file");
+  if (!file) return {};
+
+  return {
+    file,
+    line: readNumber(span ?? {}, "line") ?? readNumber(location ?? {}, "line"),
+    column: readNumber(span ?? {}, "column") ?? readNumber(location ?? {}, "column"),
+  };
+}
+
+function collectDiagnostics(node: unknown, sink: LocatedDiagnostic[]): void {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectDiagnostics(item, sink);
+    }
+    return;
+  }
+  const record = asRecord(node);
+  if (!record) return;
+
+  const category = readString(record, "category");
+  const severity = readString(record, "severity");
+  const message = readString(record, "message") ?? readString(asRecord(record.description) ?? {}, "text");
+  const { file, line, column } = extractLocation(record);
+  if (file && message && (category?.startsWith("lint/") || severity !== undefined)) {
+    sink.push({ file, line, column, message, ruleId: category });
+  }
+
+  for (const value of Object.values(record)) {
+    collectDiagnostics(value, sink);
+  }
+}
+
+export function parseBiomeJson(output: string): LintParseResult | null {
+  if (!output.trim()) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    return null;
+  }
+
+  const found: LocatedDiagnostic[] = [];
+  collectDiagnostics(parsed, found);
+  if (found.length === 0) return null;
+
+  const diagnostics: LintDiagnostic[] = found.map((entry) => ({
+    file: entry.file,
+    line: entry.line,
+    column: entry.column,
+    ruleId: entry.ruleId,
+    message: entry.message,
+    raw: `${entry.file}:${entry.line ?? 0}:${entry.column ?? 0} ${entry.message}`,
+  }));
+  return { diagnostics, format: "biome-json" };
+}
+
+export const biomeJsonStrategy: LintParseStrategy = {
+  name: "biome-json",
+  parse: parseBiomeJson,
+};

--- a/src/review/lint-parsing/strategies/eslint-json.ts
+++ b/src/review/lint-parsing/strategies/eslint-json.ts
@@ -1,0 +1,74 @@
+import type { LintDiagnostic, LintParseResult, LintParseStrategy } from "../types";
+
+interface EslintMessage {
+  line?: number;
+  column?: number;
+  severity?: number;
+  ruleId?: string | null;
+  message?: string;
+}
+
+interface EslintResultEntry {
+  filePath?: string;
+  messages?: EslintMessage[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function getEntries(payload: unknown): EslintResultEntry[] {
+  if (Array.isArray(payload)) {
+    return payload as EslintResultEntry[];
+  }
+  const record = asRecord(payload);
+  const results = record?.results;
+  return Array.isArray(results) ? (results as EslintResultEntry[]) : [];
+}
+
+function mapSeverity(value: number | undefined): "error" | "warning" | "info" {
+  if (value === 2) return "error";
+  if (value === 1) return "warning";
+  return "info";
+}
+
+function toDiagnostic(file: string, message: EslintMessage): LintDiagnostic | null {
+  if (!message.message) return null;
+  return {
+    file,
+    line: typeof message.line === "number" ? message.line : undefined,
+    column: typeof message.column === "number" ? message.column : undefined,
+    severity: mapSeverity(message.severity),
+    ruleId: message.ruleId ?? undefined,
+    message: message.message,
+    raw: `${file}:${message.line ?? 0}:${message.column ?? 0} ${message.message}`,
+  };
+}
+
+export function parseEslintJson(output: string): LintParseResult | null {
+  if (!output.trim()) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    return null;
+  }
+
+  const entries = getEntries(parsed);
+  if (entries.length === 0) return null;
+
+  const diagnostics = entries.flatMap((entry) => {
+    const file = typeof entry.filePath === "string" ? entry.filePath : "";
+    if (!file || !Array.isArray(entry.messages)) return [];
+    return entry.messages.map((m) => toDiagnostic(file, m)).filter((d): d is LintDiagnostic => d !== null);
+  });
+
+  if (diagnostics.length === 0) return null;
+  return { diagnostics, format: "eslint-json" };
+}
+
+export const eslintJsonStrategy: LintParseStrategy = {
+  name: "eslint-json",
+  parse: parseEslintJson,
+};

--- a/src/review/lint-parsing/strategies/text-block.ts
+++ b/src/review/lint-parsing/strategies/text-block.ts
@@ -1,0 +1,93 @@
+import type { LintDiagnostic, LintParseResult, LintParseStrategy } from "../types";
+
+const SOURCE_EXT_RE = /\.(ts|tsx|js|jsx|mjs|cjs|go|py|rs|rb|java|cs|cpp|c|h|swift|kt)$/;
+const PATH_RE = /^[ \t]*((?:\/[\w./-]+|\.\.?\/[\w./-]+|[\w][\w-]*(?:\/[\w./-]+)+))(?::\d+)?(?::\d+)?(?:\s|:|$)/;
+const LOCATION_RE = /:(\d+)(?::(\d+))?/;
+const SUMMARY_LINE_RE = /^(Found \d+ .+|Checked \d+ .+|[\d\s]+problems?\b.+|[\d\s]+errors?\b.*)$/i;
+
+interface TextBlock {
+  file: string;
+  text: string;
+}
+
+function pushBlock(blocks: TextBlock[], current: { file: string; lines: string[] } | null): void {
+  if (!current) return;
+  const cleaned = stripTrailingSummaryLines(current.lines);
+  const text = cleaned.join("\n").trimEnd();
+  if (!text.trim()) return;
+  blocks.push({ file: current.file, text });
+}
+
+function parseLocation(text: string): { line?: number; column?: number } {
+  const match = LOCATION_RE.exec(text);
+  if (!match) return {};
+  const line = Number.parseInt(match[1], 10);
+  if (Number.isNaN(line)) return {};
+  const parsedColumn = match[2] ? Number.parseInt(match[2], 10) : undefined;
+  const column = parsedColumn !== undefined && !Number.isNaN(parsedColumn) ? parsedColumn : undefined;
+  return { line, column };
+}
+
+function stripTrailingSummaryLines(lines: string[]): string[] {
+  const next = [...lines];
+  while (next.length > 0) {
+    const last = next[next.length - 1]?.trim() ?? "";
+    if (!last) {
+      next.pop();
+      continue;
+    }
+    if (!SUMMARY_LINE_RE.test(last)) {
+      break;
+    }
+    next.pop();
+  }
+  return next;
+}
+
+function collectBlocks(output: string): TextBlock[] {
+  const lines = output.split(/\r?\n/);
+  const blocks: TextBlock[] = [];
+  let current: { file: string; lines: string[] } | null = null;
+
+  for (const line of lines) {
+    const pathMatch = PATH_RE.exec(line);
+    const candidate = pathMatch?.[1] ?? "";
+    const hasSupportedPath = candidate.length > 0 && SOURCE_EXT_RE.test(candidate);
+    if (hasSupportedPath) {
+      pushBlock(blocks, current);
+      current = { file: candidate, lines: [line] };
+      continue;
+    }
+    if (current) {
+      current.lines.push(line);
+    }
+  }
+
+  pushBlock(blocks, current);
+  return blocks;
+}
+
+export function parseTextBlocks(output: string): LintParseResult | null {
+  if (!output.trim()) return null;
+  const blocks = collectBlocks(output);
+  if (blocks.length === 0) return null;
+
+  const diagnostics: LintDiagnostic[] = blocks.map((block) => {
+    const firstLine = block.text.split(/\r?\n/, 1)[0] ?? block.text;
+    const { line, column } = parseLocation(firstLine);
+    return {
+      file: block.file,
+      line,
+      column,
+      message: firstLine.trim(),
+      raw: block.text,
+    };
+  });
+
+  return { diagnostics, format: "text-block" };
+}
+
+export const textBlockStrategy: LintParseStrategy = {
+  name: "text-block",
+  parse: parseTextBlocks,
+};

--- a/src/review/lint-parsing/types.ts
+++ b/src/review/lint-parsing/types.ts
@@ -1,0 +1,23 @@
+export type LintOutputFormat = "auto" | "eslint-json" | "biome-json" | "text" | "none";
+
+export type LintParserFormat = "eslint-json" | "biome-json" | "text-block";
+
+export interface LintDiagnostic {
+  file: string;
+  line?: number;
+  column?: number;
+  severity?: "error" | "warning" | "info";
+  ruleId?: string;
+  message: string;
+  raw: string;
+}
+
+export interface LintParseResult {
+  diagnostics: LintDiagnostic[];
+  format: LintParserFormat;
+}
+
+export interface LintParseStrategy {
+  readonly name: LintParserFormat;
+  parse(output: string): LintParseResult | null;
+}

--- a/test/unit/config/quality-commands-schema.test.ts
+++ b/test/unit/config/quality-commands-schema.test.ts
@@ -123,3 +123,20 @@ describe("review.commands schema — lintFix/formatFix not stripped by Zod", () 
     expect(result.review.commands.formatFix).toBe("bun run format --write");
   });
 });
+
+describe("quality.lintOutput schema", () => {
+  test("defaults lintOutput.format to auto", () => {
+    const parsed = NaxConfigSchema.parse({});
+    expect(parsed.quality.lintOutput?.format).toBe("auto");
+  });
+
+  test("preserves explicit lintOutput.format", () => {
+    const parsed = NaxConfigSchema.parse({
+      quality: {
+        ...DEFAULT_CONFIG.quality,
+        lintOutput: { format: "eslint-json" },
+      },
+    });
+    expect(parsed.quality.lintOutput?.format).toBe("eslint-json");
+  });
+});

--- a/test/unit/pipeline/stages/autofix-adversarial.test.ts
+++ b/test/unit/pipeline/stages/autofix-adversarial.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, mock, test, afterEach } from "bun:test";
 import {
   extractFilesFromLintOutput,
+  filterLintOutputToFiles,
   splitFindingsByScope,
   runTestWriterRectification,
 } from "../../../../src/pipeline/stages/autofix-adversarial";
@@ -180,6 +181,21 @@ test/unit/service.test.ts:5:1 lint/error message
     const output = "/home/user/project/src/foo.test.ts:5:3 lint/error message";
     const files = extractFilesFromLintOutput(output);
     expect(files).toContain("/home/user/project/src/foo.test.ts");
+  });
+
+  test("ESLint json output extracts file paths", () => {
+    const output = JSON.stringify([
+      {
+        filePath: "src/service.ts",
+        messages: [{ line: 10, column: 3, severity: 2, ruleId: "no-var", message: "Use const." }],
+      },
+      {
+        filePath: "src/service.test.ts",
+        messages: [{ line: 5, column: 1, severity: 2, ruleId: "no-var", message: "Use const in test." }],
+      },
+    ]);
+    const files = extractFilesFromLintOutput(output);
+    expect(files).toEqual(["src/service.ts", "src/service.test.ts"]);
   });
 });
 
@@ -382,9 +398,13 @@ src/service.test.ts:5:1 lint/style/noNonNullAssertion
     const { testFindings, sourceFindings } = splitFindingsByScope(check);
     expect(testFindings).not.toBeNull();
     expect(sourceFindings).not.toBeNull();
+    expect(testFindings?.output).toContain("src/service.test.ts:5:1");
+    expect(testFindings?.output).not.toContain("src/service.ts:10:3");
+    expect(sourceFindings?.output).toContain("src/service.ts:10:3");
+    expect(sourceFindings?.output).not.toContain("src/service.test.ts:5:1");
   });
 
-  test("lint scoped checks carry the original full output (agent needs full context)", () => {
+  test("lint scoped checks carry scoped output only", () => {
     const output = "src/foo.test.ts:1:5 lint/style/noNonNullAssertion\n  ✖ Non-null assertion";
     const check = makeLintCheck(output);
     const { testFindings } = splitFindingsByScope(check);
@@ -397,6 +417,133 @@ src/service.test.ts:5:1 lint/style/noNonNullAssertion
     const { testFindings } = splitFindingsByScope(check);
     expect(testFindings).not.toBeNull();
     expect(testFindings!.findings).toBeUndefined();
+  });
+
+  test("lint check with eslint json output splits test and source diagnostics", () => {
+    const output = JSON.stringify([
+      {
+        filePath: "src/service.ts",
+        messages: [{ line: 10, column: 3, severity: 2, ruleId: "no-var", message: "Use const." }],
+      },
+      {
+        filePath: "src/service.test.ts",
+        messages: [{ line: 5, column: 1, severity: 2, ruleId: "no-var", message: "Use const in test." }],
+      },
+    ]);
+    const check = makeLintCheck(output);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings?.output).toContain("src/service.test.ts");
+    expect(testFindings?.output).not.toContain("src/service.ts");
+    expect(sourceFindings?.output).toContain("src/service.ts");
+    expect(sourceFindings?.output).not.toContain("src/service.test.ts");
+  });
+
+  test("lint check with eslint json-with-metadata output splits correctly", () => {
+    const output = JSON.stringify({
+      results: [
+        {
+          filePath: "src/core.ts",
+          messages: [{ line: 1, column: 1, severity: 2, ruleId: "x", message: "core error" }],
+        },
+        {
+          filePath: "test/unit/core.test.ts",
+          messages: [{ line: 2, column: 1, severity: 2, ruleId: "x", message: "test error" }],
+        },
+      ],
+    });
+    const check = makeLintCheck(output);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings?.output).toContain("test/unit/core.test.ts");
+    expect(sourceFindings?.output).toContain("src/core.ts");
+  });
+
+  test("lint parsing can be disabled with format none", () => {
+    const output = `
+src/service.ts:10:3 lint/style/useConst
+src/service.test.ts:5:1 lint/style/noNonNullAssertion
+`.trim();
+    const check = makeLintCheck(output);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check, undefined, "none");
+    expect(testFindings).toBeNull();
+    expect(sourceFindings).not.toBeNull();
+    expect(sourceFindings?.output).toBe(output);
+  });
+
+  test("lint check with biome json output splits test and source diagnostics", () => {
+    const output = JSON.stringify({
+      diagnostics: [
+        {
+          category: "lint/style/useConst",
+          severity: "error",
+          message: "Use const.",
+          location: {
+            span: {
+              path: "src/service.ts",
+              line: 10,
+              column: 3,
+            },
+          },
+        },
+        {
+          category: "lint/suspicious/noNonNullAssertion",
+          severity: "error",
+          message: "Avoid non-null assertion.",
+          location: {
+            span: {
+              path: "test/unit/service.test.ts",
+              line: 5,
+              column: 1,
+            },
+          },
+        },
+      ],
+    });
+    const check = makeLintCheck(output);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check, undefined, "biome-json");
+    expect(testFindings?.output).toContain("test/unit/service.test.ts");
+    expect(testFindings?.output).not.toContain("src/service.ts");
+    expect(sourceFindings?.output).toContain("src/service.ts");
+    expect(sourceFindings?.output).not.toContain("test/unit/service.test.ts");
+  });
+});
+
+describe("filterLintOutputToFiles", () => {
+  test("filters block output to target file blocks only", () => {
+    const output = `
+src/service.ts:10:3 lint/style/useConst
+  ✖ Use const.
+
+src/service.test.ts:5:1 lint/style/noNonNullAssertion
+  ✖ avoid non-null assertion.
+
+Found 2 errors.
+`.trim();
+    const filtered = filterLintOutputToFiles(output, new Set(["src/service.test.ts"]));
+    expect(filtered).not.toBeNull();
+    expect(filtered).toContain("src/service.test.ts:5:1");
+    expect(filtered).not.toContain("src/service.ts:10:3");
+    expect(filtered).not.toContain("Found 2 errors.");
+  });
+
+  test("strips summary lines that appear before the next block", () => {
+    const output = `
+src/service.ts:10:3 lint/style/useConst
+  ✖ Use const.
+Found 1 error.
+
+src/service.test.ts:5:1 lint/style/noNonNullAssertion
+  ✖ avoid non-null assertion.
+`.trim();
+    const sourceOnly = filterLintOutputToFiles(output, new Set(["src/service.ts"]));
+    expect(sourceOnly).not.toBeNull();
+    expect(sourceOnly).toContain("src/service.ts:10:3");
+    expect(sourceOnly).not.toContain("Found 1 error.");
+  });
+
+  test("returns null when target files are absent", () => {
+    const output = "src/service.ts:10:3 lint/style/useConst";
+    const filtered = filterLintOutputToFiles(output, new Set(["src/other.ts"]));
+    expect(filtered).toBeNull();
   });
 });
 


### PR DESCRIPTION
Summary: Implements issue #672 with a structural lint parsing pipeline so scope splitting uses diagnostic-level data instead of file-presence heuristics.

Changes:
- Added lint parsing strategy module under src/review/lint-parsing
- Added parsers for ESLint JSON, Biome JSON, and text block output
- Added quality lint output format config with values auto, eslint-json, biome-json, text, none
- Updated lint branch of splitFindingsByScope to produce scoped outputs
- Exported filterLintOutputToFiles helper
- Wired lint output format through autofix and autofix-agent call sites
- Added unit tests for parser behavior, scoped splitting, summary stripping, and config schema.

Verification:
- bun test test/unit/pipeline/stages/autofix-adversarial.test.ts --timeout=30000
- bun test test/unit/config/quality-commands-schema.test.ts --timeout=30000
- bun run typecheck
- bun run lint