### PR TITLE
feat(autofix): add scope-aware typecheck parsing and routing

### DIFF
--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -194,6 +194,11 @@ export interface QualityConfig {
     /** Parsing mode: auto-detect (default), specific parser, or disabled fallback. */
     format?: "auto" | "eslint-json" | "biome-json" | "text" | "none";
   };
+  /** Typecheck output parsing preferences for scope-aware rectification splitting. */
+  typecheckOutput?: {
+    /** Parsing mode: auto-detect (default), specific parser, or disabled fallback. */
+    format?: "auto" | "tsc" | "text" | "none";
+  };
   /** Auto-fix configuration (Phase 2) */
   autofix?: {
     /** Whether to auto-fix lint/format errors before escalating (default: true) */

--- a/src/config/schemas-execution.ts
+++ b/src/config/schemas-execution.ts
@@ -141,6 +141,11 @@ export const QualityConfigSchema = z.object({
       format: z.enum(["auto", "eslint-json", "biome-json", "text", "none"]).default("auto"),
     })
     .default({ format: "auto" }),
+  typecheckOutput: z
+    .object({
+      format: z.enum(["auto", "tsc", "text", "none"]).default("auto"),
+    })
+    .default({ format: "auto" }),
   autofix: z
     .object({
       enabled: z.boolean().default(true),

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -118,6 +118,9 @@ export const NaxConfigSchema = z
       lintOutput: {
         format: "auto",
       },
+      typecheckOutput: {
+        format: "auto",
+      },
       autofix: {
         enabled: true,
         maxAttempts: 3,

--- a/src/pipeline/stages/autofix-adversarial.ts
+++ b/src/pipeline/stages/autofix-adversarial.ts
@@ -23,6 +23,12 @@ import {
   formatDiagnosticsOutput,
   parseLintOutput,
 } from "../../review/lint-parsing";
+import {
+  type TypecheckDiagnostic,
+  type TypecheckOutputFormat,
+  formatTypecheckDiagnosticsOutput,
+  parseTypecheckOutput,
+} from "../../review/typecheck-parsing";
 import type { ReviewCheckResult } from "../../review/types";
 import { isTestFile } from "../../test-runners";
 import type { PipelineContext } from "../types";
@@ -45,6 +51,15 @@ function buildScopedLintCheck(
   return { ...check, output };
 }
 
+function buildScopedTypecheckCheck(
+  check: ReviewCheckResult,
+  diagnostics: readonly TypecheckDiagnostic[],
+): ReviewCheckResult | null {
+  const output = formatTypecheckDiagnosticsOutput(diagnostics);
+  if (!output) return null;
+  return { ...check, output };
+}
+
 /**
  * Best-effort block/diagnostic filter for lint output.
  * Returns null when no diagnostics map to target files.
@@ -58,6 +73,30 @@ export function filterLintOutputToFiles(
   if (!parsed) return null;
   const filtered = parsed.diagnostics.filter((d) => targetFiles.has(d.file));
   return formatDiagnosticsOutput(filtered);
+}
+
+/**
+ * Extract unique file paths from typecheck output by running parser strategies.
+ */
+export function extractFilesFromTypecheckOutput(output: string, format: TypecheckOutputFormat = "auto"): string[] {
+  const parsed = parseTypecheckOutput(output, format);
+  if (!parsed) return [];
+  return Array.from(new Set(parsed.diagnostics.map((d) => d.file)));
+}
+
+/**
+ * Best-effort block/diagnostic filter for typecheck output.
+ * Returns null when no diagnostics map to target files.
+ */
+export function filterTypecheckOutputToFiles(
+  output: string,
+  targetFiles: ReadonlySet<string>,
+  format: TypecheckOutputFormat = "text",
+): string | null {
+  const parsed = parseTypecheckOutput(output, format);
+  if (!parsed) return null;
+  const filtered = parsed.diagnostics.filter((d) => targetFiles.has(d.file));
+  return formatTypecheckDiagnosticsOutput(filtered);
 }
 
 function splitByStructuredFindings(
@@ -110,6 +149,28 @@ function splitByOutputParsing(
   };
 }
 
+function splitByTypecheckOutputParsing(
+  check: ReviewCheckResult,
+  testFilePatterns?: readonly string[],
+  format: TypecheckOutputFormat = "auto",
+): { testFindings: ReviewCheckResult | null; sourceFindings: ReviewCheckResult | null } {
+  const parsed = parseTypecheckOutput(check.output, format);
+  if (!parsed) {
+    if (check.output.trim()) {
+      return { testFindings: null, sourceFindings: check };
+    }
+    return { testFindings: null, sourceFindings: null };
+  }
+
+  const testDiagnostics = parsed.diagnostics.filter((d) => isTestFile(d.file, testFilePatterns));
+  const sourceDiagnostics = parsed.diagnostics.filter((d) => !isTestFile(d.file, testFilePatterns));
+
+  return {
+    testFindings: buildScopedTypecheckCheck(check, testDiagnostics),
+    sourceFindings: buildScopedTypecheckCheck(check, sourceDiagnostics),
+  };
+}
+
 /**
  * Split a check result into test-file vs source-file buckets for scope-aware routing.
  * Returns null for each bucket when there are no findings for that scope.
@@ -126,6 +187,7 @@ export function splitFindingsByScope(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
   lintOutputFormat: LintOutputFormat = "auto",
+  typecheckOutputFormat: TypecheckOutputFormat = "auto",
 ): {
   testFindings: ReviewCheckResult | null;
   sourceFindings: ReviewCheckResult | null;
@@ -135,6 +197,9 @@ export function splitFindingsByScope(
   }
   if (check.check === "lint") {
     return splitByOutputParsing(check, testFilePatterns, lintOutputFormat);
+  }
+  if (check.check === "typecheck") {
+    return splitByTypecheckOutputParsing(check, testFilePatterns, typecheckOutputFormat);
   }
   return { testFindings: null, sourceFindings: null };
 }

--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -145,9 +145,15 @@ export async function runAgentRectification(
       ? ctx.rootConfig.execution.smartTestRunner?.testFilePatterns
       : undefined;
   const lintOutputFormat = ctx.config.quality.lintOutput?.format ?? "auto";
+  const typecheckOutputFormat = ctx.config.quality.typecheckOutput?.format ?? "auto";
   for (const check of failedChecks) {
-    if (check.check === "adversarial" || check.check === "lint") {
-      const { testFindings, sourceFindings } = splitFindingsByScope(check, stageTestFilePatterns, lintOutputFormat);
+    if (check.check === "adversarial" || check.check === "lint" || check.check === "typecheck") {
+      const { testFindings, sourceFindings } = splitFindingsByScope(
+        check,
+        stageTestFilePatterns,
+        lintOutputFormat,
+        typecheckOutputFormat,
+      );
       // null/null means the check has no classifiable findings — leave implementerChecks unchanged.
       if (testFindings || sourceFindings) {
         if (testFindings) testWriterChecks = [...testWriterChecks, testFindings];

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -141,12 +141,18 @@ export const autofixStage: PipelineStage = {
         ? ctx.rootConfig.execution.smartTestRunner?.testFilePatterns
         : undefined;
     const lintOutputFormat = ctx.config.quality.lintOutput?.format ?? "auto";
+    const typecheckOutputFormat = ctx.config.quality.typecheckOutput?.format ?? "auto";
     if (ctx.routing.testStrategy === "no-test") {
       const failedChecks = (reviewResult.checks ?? []).filter((c) => !c.success);
       if (
         failedChecks.length > 0 &&
         failedChecks.every((c) => {
-          const { testFindings, sourceFindings } = splitFindingsByScope(c, testFilePatterns, lintOutputFormat);
+          const { testFindings, sourceFindings } = splitFindingsByScope(
+            c,
+            testFilePatterns,
+            lintOutputFormat,
+            typecheckOutputFormat,
+          );
           return testFindings !== null && sourceFindings === null;
         })
       ) {

--- a/src/review/typecheck-parsing/index.ts
+++ b/src/review/typecheck-parsing/index.ts
@@ -1,0 +1,7 @@
+export type {
+  TypecheckDiagnostic,
+  TypecheckOutputFormat,
+  TypecheckParseResult,
+  TypecheckParseStrategy,
+} from "./types";
+export { formatTypecheckDiagnosticsOutput, parseTypecheckOutput } from "./parse";

--- a/src/review/typecheck-parsing/parse.ts
+++ b/src/review/typecheck-parsing/parse.ts
@@ -1,0 +1,34 @@
+import { typecheckTextBlockStrategy } from "./strategies/text-block";
+import { tscStrategy } from "./strategies/tsc";
+import type { TypecheckDiagnostic, TypecheckOutputFormat, TypecheckParseResult, TypecheckParseStrategy } from "./types";
+
+function strategiesFor(format: TypecheckOutputFormat): ReadonlyArray<TypecheckParseStrategy> {
+  if (format === "tsc") return [tscStrategy];
+  if (format === "text") return [typecheckTextBlockStrategy];
+  if (format === "none") return [];
+  return [tscStrategy, typecheckTextBlockStrategy];
+}
+
+export function parseTypecheckOutput(
+  output: string,
+  format: TypecheckOutputFormat = "auto",
+): TypecheckParseResult | null {
+  if (!output.trim()) return null;
+  for (const strategy of strategiesFor(format)) {
+    const parsed = strategy.parse(output);
+    if (parsed && parsed.diagnostics.length > 0) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+export function formatTypecheckDiagnosticsOutput(diagnostics: readonly TypecheckDiagnostic[]): string | null {
+  if (diagnostics.length === 0) return null;
+  return (
+    diagnostics
+      .map((d) => d.raw)
+      .join("\n\n")
+      .trim() || null
+  );
+}

--- a/src/review/typecheck-parsing/strategies/text-block.ts
+++ b/src/review/typecheck-parsing/strategies/text-block.ts
@@ -1,0 +1,93 @@
+import type { TypecheckDiagnostic, TypecheckParseResult, TypecheckParseStrategy } from "../types";
+
+const SOURCE_EXT_RE = /\.(ts|tsx|js|jsx|mjs|cjs|mts|cts|vue|svelte|go|py|rs|rb|java|cs|cpp|c|h|swift|kt)$/;
+const PATH_RE = /^[ \t]*((?:\/[\w./-]+|\.\.?\/[\w./-]+|[\w][\w-]*(?:\/[\w./-]+)+))(?::\d+)?(?::\d+)?(?:\s|:|$)/;
+const LOCATION_RE = /:(\d+)(?::(\d+))?/;
+const SUMMARY_LINE_RE = /^(Found \d+ .+|Checked \d+ .+|[\d\s]+errors?\b.*|[\d\s]+problems?\b.*)$/i;
+
+interface TextBlock {
+  file: string;
+  text: string;
+}
+
+function parseLocation(text: string): { line?: number; column?: number } {
+  const match = LOCATION_RE.exec(text);
+  if (!match) return {};
+  const line = Number.parseInt(match[1], 10);
+  if (Number.isNaN(line)) return {};
+  const parsedColumn = match[2] ? Number.parseInt(match[2], 10) : undefined;
+  const column = parsedColumn !== undefined && !Number.isNaN(parsedColumn) ? parsedColumn : undefined;
+  return { line, column };
+}
+
+function stripTrailingSummaryLines(lines: string[]): string[] {
+  const next = [...lines];
+  while (next.length > 0) {
+    const last = next[next.length - 1]?.trim() ?? "";
+    if (!last) {
+      next.pop();
+      continue;
+    }
+    if (!SUMMARY_LINE_RE.test(last)) {
+      break;
+    }
+    next.pop();
+  }
+  return next;
+}
+
+function pushBlock(blocks: TextBlock[], current: { file: string; lines: string[] } | null): void {
+  if (!current) return;
+  const cleaned = stripTrailingSummaryLines(current.lines);
+  const text = cleaned.join("\n").trimEnd();
+  if (!text.trim()) return;
+  blocks.push({ file: current.file, text });
+}
+
+function collectBlocks(output: string): TextBlock[] {
+  const lines = output.split(/\r?\n/);
+  const blocks: TextBlock[] = [];
+  let current: { file: string; lines: string[] } | null = null;
+
+  for (const line of lines) {
+    const pathMatch = PATH_RE.exec(line);
+    const candidate = pathMatch?.[1] ?? "";
+    const hasSupportedPath = candidate.length > 0 && SOURCE_EXT_RE.test(candidate);
+    if (hasSupportedPath) {
+      pushBlock(blocks, current);
+      current = { file: candidate, lines: [line] };
+      continue;
+    }
+    if (current) {
+      current.lines.push(line);
+    }
+  }
+
+  pushBlock(blocks, current);
+  return blocks;
+}
+
+export function parseTypecheckTextBlocks(output: string): TypecheckParseResult | null {
+  if (!output.trim()) return null;
+  const blocks = collectBlocks(output);
+  if (blocks.length === 0) return null;
+
+  const diagnostics: TypecheckDiagnostic[] = blocks.map((block) => {
+    const firstLine = block.text.split(/\r?\n/, 1)[0] ?? block.text;
+    const { line, column } = parseLocation(firstLine);
+    return {
+      file: block.file,
+      line,
+      column,
+      message: firstLine.trim(),
+      raw: block.text,
+    };
+  });
+
+  return { diagnostics, format: "text-block" };
+}
+
+export const typecheckTextBlockStrategy: TypecheckParseStrategy = {
+  name: "text-block",
+  parse: parseTypecheckTextBlocks,
+};

--- a/src/review/typecheck-parsing/strategies/tsc.ts
+++ b/src/review/typecheck-parsing/strategies/tsc.ts
@@ -1,0 +1,99 @@
+import type { TypecheckDiagnostic, TypecheckParseResult, TypecheckParseStrategy } from "../types";
+
+const TSC_COMPACT_RE = /^(?<file>.+?)\((?<line>\d+),(?<column>\d+)\):\s+error\s+TS(?<code>\d+):\s+(?<message>.+)$/;
+const TSC_PRETTY_RE = /^(?<file>.+):(?<line>\d+):(?<column>\d+)\s+-\s+error\s+TS(?<code>\d+):\s+(?<message>.+)$/;
+const SUMMARY_LINE_RE = /^Found \d+ errors? in \d+ files?\.$/i;
+
+interface HeaderMatch {
+  file: string;
+  line: number;
+  column: number;
+  code: string;
+  message: string;
+}
+
+function parseHeader(line: string): HeaderMatch | null {
+  const compact = TSC_COMPACT_RE.exec(line);
+  if (compact?.groups) {
+    return {
+      file: compact.groups.file,
+      line: Number.parseInt(compact.groups.line, 10),
+      column: Number.parseInt(compact.groups.column, 10),
+      code: compact.groups.code,
+      message: compact.groups.message.trim(),
+    };
+  }
+
+  const pretty = TSC_PRETTY_RE.exec(line);
+  if (pretty?.groups) {
+    return {
+      file: pretty.groups.file,
+      line: Number.parseInt(pretty.groups.line, 10),
+      column: Number.parseInt(pretty.groups.column, 10),
+      code: pretty.groups.code,
+      message: pretty.groups.message.trim(),
+    };
+  }
+
+  return null;
+}
+
+function isSummaryLine(line: string): boolean {
+  return SUMMARY_LINE_RE.test(line.trim());
+}
+
+export function parseTscOutput(output: string): TypecheckParseResult | null {
+  if (!output.trim()) return null;
+
+  const lines = output.split(/\r?\n/);
+  const diagnostics: TypecheckDiagnostic[] = [];
+  let current: (TypecheckDiagnostic & { lines: string[] }) | null = null;
+
+  const flush = (): void => {
+    if (!current) return;
+    while (current.lines.length > 0 && isSummaryLine(current.lines[current.lines.length - 1] ?? "")) {
+      current.lines.pop();
+    }
+    current.raw = current.lines.join("\n").trimEnd();
+    if (current.raw.trim()) {
+      diagnostics.push({
+        file: current.file,
+        line: current.line,
+        column: current.column,
+        code: current.code,
+        message: current.message,
+        raw: current.raw,
+      });
+    }
+    current = null;
+  };
+
+  for (const line of lines) {
+    const header = parseHeader(line);
+    if (header) {
+      flush();
+      current = {
+        file: header.file,
+        line: header.line,
+        column: header.column,
+        code: header.code,
+        message: header.message,
+        raw: line,
+        lines: [line],
+      };
+      continue;
+    }
+    if (current) {
+      current.lines.push(line);
+    }
+  }
+
+  flush();
+  if (diagnostics.length === 0) return null;
+  return { diagnostics, format: "tsc" };
+}
+
+export const tscStrategy: TypecheckParseStrategy = {
+  name: "tsc",
+  parse: parseTscOutput,
+};

--- a/src/review/typecheck-parsing/types.ts
+++ b/src/review/typecheck-parsing/types.ts
@@ -1,0 +1,22 @@
+export type TypecheckOutputFormat = "auto" | "tsc" | "text" | "none";
+
+export type TypecheckParserFormat = "tsc" | "text-block";
+
+export interface TypecheckDiagnostic {
+  file: string;
+  line?: number;
+  column?: number;
+  code?: string;
+  message: string;
+  raw: string;
+}
+
+export interface TypecheckParseResult {
+  diagnostics: TypecheckDiagnostic[];
+  format: TypecheckParserFormat;
+}
+
+export interface TypecheckParseStrategy {
+  readonly name: TypecheckParserFormat;
+  parse(output: string): TypecheckParseResult | null;
+}

--- a/test/unit/config/quality-commands-schema.test.ts
+++ b/test/unit/config/quality-commands-schema.test.ts
@@ -140,3 +140,20 @@ describe("quality.lintOutput schema", () => {
     expect(parsed.quality.lintOutput?.format).toBe("eslint-json");
   });
 });
+
+describe("quality.typecheckOutput schema", () => {
+  test("defaults typecheckOutput.format to auto", () => {
+    const parsed = NaxConfigSchema.parse({});
+    expect(parsed.quality.typecheckOutput?.format).toBe("auto");
+  });
+
+  test("preserves explicit typecheckOutput.format", () => {
+    const parsed = NaxConfigSchema.parse({
+      quality: {
+        ...DEFAULT_CONFIG.quality,
+        typecheckOutput: { format: "tsc" },
+      },
+    });
+    expect(parsed.quality.typecheckOutput?.format).toBe("tsc");
+  });
+});

--- a/test/unit/pipeline/stages/autofix-adversarial.test.ts
+++ b/test/unit/pipeline/stages/autofix-adversarial.test.ts
@@ -12,7 +12,9 @@
 import { describe, expect, mock, test, afterEach } from "bun:test";
 import {
   extractFilesFromLintOutput,
+  extractFilesFromTypecheckOutput,
   filterLintOutputToFiles,
+  filterTypecheckOutputToFiles,
   splitFindingsByScope,
   runTestWriterRectification,
 } from "../../../../src/pipeline/stages/autofix-adversarial";
@@ -58,6 +60,17 @@ function makeLintCheck(output: string): ReviewCheckResult {
     check: "lint",
     success: false,
     command: "biome",
+    exitCode: 1,
+    output,
+    durationMs: 10,
+  };
+}
+
+function makeTypecheckCheck(output: string): ReviewCheckResult {
+  return {
+    check: "typecheck",
+    success: false,
+    command: "tsc --noEmit",
     exitCode: 1,
     output,
     durationMs: 10,
@@ -199,18 +212,52 @@ test/unit/service.test.ts:5:1 lint/error message
   });
 });
 
+describe("extractFilesFromTypecheckOutput", () => {
+  test("empty string → empty array", () => {
+    expect(extractFilesFromTypecheckOutput("")).toEqual([]);
+  });
+
+  test("unparseable output → empty array", () => {
+    const output = "Typecheck failed\nPlease fix errors";
+    expect(extractFilesFromTypecheckOutput(output)).toEqual([]);
+  });
+
+  test("tsc compact output extracts source + test files", () => {
+    const output = `
+src/service.ts(10,3): error TS2322: Type 'string' is not assignable to type 'number'.
+test/unit/service.test.ts(5,1): error TS2304: Cannot find name 'expect'.
+`.trim();
+    expect(extractFilesFromTypecheckOutput(output)).toEqual(["src/service.ts", "test/unit/service.test.ts"]);
+  });
+
+  test("tsc pretty output extracts file path", () => {
+    const output = `
+src/service.ts:10:3 - error TS2322: Type 'A' is not assignable to type 'B'.
+
+10 const x: B = value;
+         ~
+`.trim();
+    expect(extractFilesFromTypecheckOutput(output)).toEqual(["src/service.ts"]);
+  });
+
+  test("tsc pretty output extracts Windows drive-letter paths", () => {
+    const output = "C:\\repo\\src\\service.ts:10:3 - error TS2322: Type 'A' is not assignable to type 'B'.";
+    expect(extractFilesFromTypecheckOutput(output)).toEqual(["C:\\repo\\src\\service.ts"]);
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // splitFindingsByScope — structured findings path (adversarial checks)
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("splitFindingsByScope — structured findings path", () => {
-  test("non-LLM check (typecheck) → both buckets null", () => {
+  test("non-routable check (build) → both buckets null", () => {
     const check: ReviewCheckResult = {
-      check: "typecheck",
+      check: "build",
       success: false,
-      command: "tsc",
+      command: "bun run build",
       exitCode: 1,
-      output: "type error",
+      output: "build failed",
       durationMs: 10,
     };
     const { testFindings, sourceFindings } = splitFindingsByScope(check);
@@ -507,6 +554,69 @@ src/service.test.ts:5:1 lint/style/noNonNullAssertion
   });
 });
 
+describe("splitFindingsByScope — typecheck output path", () => {
+  test("typecheck check with empty output → both buckets null", () => {
+    const check = makeTypecheckCheck("");
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings).toBeNull();
+    expect(sourceFindings).toBeNull();
+  });
+
+  test("typecheck check with unparseable output → conservative: sourceFindings non-null, testFindings null", () => {
+    const check = makeTypecheckCheck("Typecheck failed with unknown format");
+    const { testFindings, sourceFindings } = splitFindingsByScope(check);
+    expect(testFindings).toBeNull();
+    expect(sourceFindings).not.toBeNull();
+  });
+
+  test("all test-file diagnostics → testFindings non-null, sourceFindings null", () => {
+    const output = `
+src/service.test.ts(5,1): error TS2304: Cannot find name 'expect'.
+test/unit/foo.test.ts(2,1): error TS2552: Cannot find name 'describe'.
+`.trim();
+    const check = makeTypecheckCheck(output);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check, undefined, "auto", "tsc");
+    expect(testFindings).not.toBeNull();
+    expect(sourceFindings).toBeNull();
+  });
+
+  test("all source diagnostics → sourceFindings non-null, testFindings null", () => {
+    const output = `
+src/service.ts(10,3): error TS2322: Type 'string' is not assignable to type 'number'.
+src/core.ts(1,1): error TS2304: Cannot find name 'foo'.
+`.trim();
+    const check = makeTypecheckCheck(output);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check, undefined, "auto", "tsc");
+    expect(testFindings).toBeNull();
+    expect(sourceFindings).not.toBeNull();
+  });
+
+  test("mixed test/source diagnostics split into distinct outputs", () => {
+    const output = `
+src/service.ts(10,3): error TS2322: Type 'string' is not assignable to type 'number'.
+src/service.test.ts(5,1): error TS2304: Cannot find name 'expect'.
+`.trim();
+    const check = makeTypecheckCheck(output);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check, undefined, "auto", "tsc");
+    expect(testFindings?.output).toContain("src/service.test.ts(5,1)");
+    expect(testFindings?.output).not.toContain("src/service.ts(10,3)");
+    expect(sourceFindings?.output).toContain("src/service.ts(10,3)");
+    expect(sourceFindings?.output).not.toContain("src/service.test.ts(5,1)");
+  });
+
+  test("typecheck parser can be disabled with format none", () => {
+    const output = `
+src/service.ts(10,3): error TS2322: Type 'string' is not assignable to type 'number'.
+src/service.test.ts(5,1): error TS2304: Cannot find name 'expect'.
+`.trim();
+    const check = makeTypecheckCheck(output);
+    const { testFindings, sourceFindings } = splitFindingsByScope(check, undefined, "auto", "none");
+    expect(testFindings).toBeNull();
+    expect(sourceFindings).not.toBeNull();
+    expect(sourceFindings?.output).toBe(output);
+  });
+});
+
 describe("filterLintOutputToFiles", () => {
   test("filters block output to target file blocks only", () => {
     const output = `
@@ -543,6 +653,28 @@ src/service.test.ts:5:1 lint/style/noNonNullAssertion
   test("returns null when target files are absent", () => {
     const output = "src/service.ts:10:3 lint/style/useConst";
     const filtered = filterLintOutputToFiles(output, new Set(["src/other.ts"]));
+    expect(filtered).toBeNull();
+  });
+});
+
+describe("filterTypecheckOutputToFiles", () => {
+  test("filters tsc blocks to target file only", () => {
+    const output = `
+src/service.ts(10,3): error TS2322: Type 'string' is not assignable to type 'number'.
+
+src/service.test.ts(5,1): error TS2304: Cannot find name 'expect'.
+Found 2 errors in 2 files.
+`.trim();
+    const filtered = filterTypecheckOutputToFiles(output, new Set(["src/service.test.ts"]), "tsc");
+    expect(filtered).not.toBeNull();
+    expect(filtered).toContain("src/service.test.ts(5,1)");
+    expect(filtered).not.toContain("src/service.ts(10,3)");
+    expect(filtered).not.toContain("Found 2 errors in 2 files.");
+  });
+
+  test("returns null when target files are absent", () => {
+    const output = "src/service.ts(10,3): error TS2322: Type 'string' is not assignable to type 'number'.";
+    const filtered = filterTypecheckOutputToFiles(output, new Set(["src/other.ts"]), "tsc");
     expect(filtered).toBeNull();
   });
 });


### PR DESCRIPTION
Summary:
- Implements issue #858 by adding structural typecheck parsing and scope-aware routing for test-writer vs implementer sessions.

What changed:
- Added parser module: src/review/typecheck-parsing/
  - tsc strategy for compact and pretty output forms
  - text-block fallback strategy
  - parse strategy selector and output formatter
- Extended splitFindingsByScope in src/pipeline/stages/autofix-adversarial.ts to route typecheck checks by file scope.
- Added exported helpers:
  - extractFilesFromTypecheckOutput
  - filterTypecheckOutputToFiles
- Added config support:
  - quality.typecheckOutput.format with values auto, tsc, text, none
  - wired through runtime types and schemas
- Threaded format config through autofix callsites:
  - src/pipeline/stages/autofix.ts
  - src/pipeline/stages/autofix-agent.ts
- Added and updated tests for parser behavior, routing behavior, and config schema defaults.

Code review notes:
- Found and fixed one portability issue before merge: Windows drive-letter paths in tsc pretty output were misparsed by a non-greedy regex.
- Added regression test to lock this behavior.

Verification:
- bun test test/unit/pipeline/stages/autofix-adversarial.test.ts test/unit/config/quality-commands-schema.test.ts --timeout=30000
- bun run typecheck
- bun run lint