### PR TITLE
refactor: split autofix scope-routing and test-writer modules

### DIFF
--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -17,7 +17,7 @@ import { buildProgressivePromptPreamble, runRetryLoop } from "../../verification
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext } from "../types";
 import { _autofixDeps } from "./autofix";
-import { splitFindingsByScope } from "./autofix-adversarial";
+import { splitFindingsByScope } from "./autofix-scope-split";
 
 /** Failure snapshot for the autofix retry loop. */
 interface AutofixFailure {

--- a/src/pipeline/stages/autofix-scope-split.ts
+++ b/src/pipeline/stages/autofix-scope-split.ts
@@ -1,22 +1,3 @@
-/**
- * Scope-aware rectification helpers (#409, #669).
- *
- * When review flags issues in test files, the implementer session cannot fix them
- * (isolation constraint). These helpers classify findings by file scope and route
- * test-file findings to a test-writer session.
- *
- * Handles two input shapes:
- * - Adversarial checks: structured `findings[]` with explicit file paths
- * - Lint checks: raw CLI `output` text -- file paths extracted via regex heuristics
- */
-
-import type { IAgentManager } from "../../agents";
-import { resolveModelForAgent } from "../../config";
-import { NaxError } from "../../errors";
-import { getLogger } from "../../logger";
-import { buildHopCallback } from "../../operations/build-hop-callback";
-import type { UserStory } from "../../prd";
-import { RectifierPromptBuilder } from "../../prompts";
 import {
   type LintDiagnostic,
   type LintOutputFormat,
@@ -31,7 +12,6 @@ import {
 } from "../../review/typecheck-parsing";
 import type { ReviewCheckResult } from "../../review/types";
 import { isTestFile } from "../../test-runners";
-import type { PipelineContext } from "../types";
 
 /**
  * Extract unique file paths from lint output by running the best-effort parser chain.
@@ -174,14 +154,6 @@ function splitByTypecheckOutputParsing(
 /**
  * Split a check result into test-file vs source-file buckets for scope-aware routing.
  * Returns null for each bucket when there are no findings for that scope.
- *
- * - Adversarial checks: splits structured `findings[]` by file path classification.
- * - Lint checks: extracts file paths from raw `output` text and classifies.
- * - All other check types: returns null/null (not routable by scope).
- *
- * @param check            - The review check result to split.
- * @param testFilePatterns - Configured test file globs (ADR-009). Omit to use the
- *   broad language-agnostic regex (Phase 1 backward-compat path).
  */
 export function splitFindingsByScope(
   check: ReviewCheckResult,
@@ -202,78 +174,4 @@ export function splitFindingsByScope(
     return splitByTypecheckOutputParsing(check, testFilePatterns, typecheckOutputFormat);
   }
   return { testFindings: null, sourceFindings: null };
-}
-
-/**
- * Run a test-writer session to fix review findings scoped to test files (#409).
- * Returns the cost incurred, or 0 if the agent is unavailable.
- */
-export async function runTestWriterRectification(
-  ctx: PipelineContext,
-  testWriterChecks: ReviewCheckResult[],
-  story: UserStory,
-  agentManager: IAgentManager,
-): Promise<number> {
-  const logger = getLogger();
-  const twPrompt = RectifierPromptBuilder.testWriterRectification(testWriterChecks, story);
-  // Use the TDD test-writer tier from config -- consistent with how the TDD orchestrator
-  // selects the tier for the test-writer session (tdd.orchestrator.ts:150).
-  const defaultAgent = agentManager.getDefault();
-  if (!defaultAgent) {
-    logger.warn("autofix", "Test-writer rectification skipped -- no default agent", { storyId: ctx.story.id });
-    return 0;
-  }
-  if (!ctx.runtime) {
-    throw new NaxError(
-      "runtime required — legacy agentManager.run path removed (ADR-019 Wave 3, issue #762)",
-      "DISPATCH_NO_RUNTIME",
-      { stage: "rectification", storyId: ctx.story.id },
-    );
-  }
-  const modelTier = ctx.rootConfig.tdd?.sessionTiers?.testWriter ?? "balanced";
-  const modelDef = resolveModelForAgent(ctx.rootConfig.models, defaultAgent, modelTier, defaultAgent);
-  const runOptions = {
-    prompt: twPrompt,
-    workdir: ctx.workdir,
-    modelTier,
-    modelDef,
-    timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
-    pipelineStage: "rectification" as const,
-    config: ctx.config,
-    projectDir: ctx.projectDir,
-    maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
-    featureName: ctx.prd.feature,
-    storyId: ctx.story.id,
-    sessionRole: "test-writer" as const,
-  };
-  try {
-    // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback.
-    // Each call opens a fresh session; middleware (audit, cost, cancellation) fires uniformly.
-    const executeHop = buildHopCallback(
-      {
-        sessionManager: ctx.runtime.sessionManager,
-        agentManager: ctx.runtime.agentManager,
-        story,
-        config: ctx.config,
-        projectDir: ctx.projectDir,
-        featureName: ctx.prd.feature ?? "",
-        workdir: ctx.workdir,
-        effectiveTier: modelTier,
-        defaultAgent,
-        pipelineStage: "rectification",
-      },
-      ctx.sessionId,
-      runOptions,
-    );
-    const outcome = await agentManager.runWithFallback(
-      { runOptions, signal: ctx.runtime.signal, executeHop },
-      defaultAgent,
-    );
-    return outcome.result.estimatedCostUsd ?? 0;
-  } catch {
-    logger.warn("autofix", "Test-writer rectification failed -- proceeding with implementer", {
-      storyId: ctx.story.id,
-    });
-    return 0;
-  }
 }

--- a/src/pipeline/stages/autofix-test-writer.ts
+++ b/src/pipeline/stages/autofix-test-writer.ts
@@ -1,0 +1,83 @@
+import type { IAgentManager } from "../../agents";
+import { resolveModelForAgent } from "../../config";
+import { NaxError } from "../../errors";
+import { getLogger } from "../../logger";
+import { buildHopCallback } from "../../operations/build-hop-callback";
+import type { UserStory } from "../../prd";
+import { RectifierPromptBuilder } from "../../prompts";
+import type { ReviewCheckResult } from "../../review/types";
+import type { PipelineContext } from "../types";
+
+/**
+ * Run a test-writer session to fix review findings scoped to test files (#409).
+ * Returns the cost incurred, or 0 if the agent is unavailable.
+ */
+export async function runTestWriterRectification(
+  ctx: PipelineContext,
+  testWriterChecks: ReviewCheckResult[],
+  story: UserStory,
+  agentManager: IAgentManager,
+): Promise<number> {
+  const logger = getLogger();
+  const twPrompt = RectifierPromptBuilder.testWriterRectification(testWriterChecks, story);
+  // Use the TDD test-writer tier from config -- consistent with how the TDD orchestrator
+  // selects the tier for the test-writer session (tdd.orchestrator.ts:150).
+  const defaultAgent = agentManager.getDefault();
+  if (!defaultAgent) {
+    logger.warn("autofix", "Test-writer rectification skipped -- no default agent", { storyId: ctx.story.id });
+    return 0;
+  }
+  if (!ctx.runtime) {
+    throw new NaxError(
+      "runtime required — legacy agentManager.run path removed (ADR-019 Wave 3, issue #762)",
+      "DISPATCH_NO_RUNTIME",
+      { stage: "rectification", storyId: ctx.story.id },
+    );
+  }
+  const modelTier = ctx.rootConfig.tdd?.sessionTiers?.testWriter ?? "balanced";
+  const modelDef = resolveModelForAgent(ctx.rootConfig.models, defaultAgent, modelTier, defaultAgent);
+  const runOptions = {
+    prompt: twPrompt,
+    workdir: ctx.workdir,
+    modelTier,
+    modelDef,
+    timeoutSeconds: ctx.config.execution.sessionTimeoutSeconds,
+    pipelineStage: "rectification" as const,
+    config: ctx.config,
+    projectDir: ctx.projectDir,
+    maxInteractionTurns: ctx.config.agent?.maxInteractionTurns,
+    featureName: ctx.prd.feature,
+    storyId: ctx.story.id,
+    sessionRole: "test-writer" as const,
+  };
+  try {
+    // ADR-019 Pattern A: dispatch via buildHopCallback → runWithFallback.
+    // Each call opens a fresh session; middleware (audit, cost, cancellation) fires uniformly.
+    const executeHop = buildHopCallback(
+      {
+        sessionManager: ctx.runtime.sessionManager,
+        agentManager: ctx.runtime.agentManager,
+        story,
+        config: ctx.config,
+        projectDir: ctx.projectDir,
+        featureName: ctx.prd.feature ?? "",
+        workdir: ctx.workdir,
+        effectiveTier: modelTier,
+        defaultAgent,
+        pipelineStage: "rectification",
+      },
+      ctx.sessionId,
+      runOptions,
+    );
+    const outcome = await agentManager.runWithFallback(
+      { runOptions, signal: ctx.runtime.signal, executeHop },
+      defaultAgent,
+    );
+    return outcome.result.estimatedCostUsd ?? 0;
+  } catch {
+    logger.warn("autofix", "Test-writer rectification failed -- proceeding with implementer", {
+      storyId: ctx.story.id,
+    });
+    return 0;
+  }
+}

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -26,7 +26,8 @@ import type { ReviewCheckResult } from "../../review/types";
 import { captureGitRef } from "../../utils/git";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
-import { runTestWriterRectification, splitFindingsByScope } from "./autofix-adversarial";
+import { splitFindingsByScope } from "./autofix-scope-split";
+import { runTestWriterRectification } from "./autofix-test-writer";
 
 export const autofixStage: PipelineStage = {
   name: "autofix",

--- a/test/unit/pipeline/stages/autofix-adversarial.test.ts
+++ b/test/unit/pipeline/stages/autofix-adversarial.test.ts
@@ -16,8 +16,8 @@ import {
   filterLintOutputToFiles,
   filterTypecheckOutputToFiles,
   splitFindingsByScope,
-  runTestWriterRectification,
-} from "../../../../src/pipeline/stages/autofix-adversarial";
+} from "../../../../src/pipeline/stages/autofix-scope-split";
+import { runTestWriterRectification } from "../../../../src/pipeline/stages/autofix-test-writer";
 import { isTestFile } from "../../../../src/test-runners";
 import { DEFAULT_CONFIG } from "../../../../src/config";
 import type { ReviewCheckResult } from "../../../../src/review/types";


### PR DESCRIPTION
## Summary
- extract lint/adversarial scope-splitting helpers into `autofix-scope-split.ts`
- extract test-writer rectification into `autofix-test-writer.ts`
- keep `autofix-adversarial.ts` as a compatibility shim with re-exports
- migrate direct imports in `autofix.ts` and `autofix-agent.ts` to the new modules

## Why
Implements issue #859 to decouple unrelated concerns in `autofix-adversarial.ts` while preserving runtime behavior and external import compatibility.

## Validation
- bun test test/unit/pipeline/stages/autofix-adversarial.test.ts --timeout=30000
- bun test test/unit/pipeline/stages/autofix-routing.test.ts --timeout=30000
- bun run typecheck
- bun run lint
