### PR TITLE
refactor(agents): standardize CompleteResult cost fields to match TurnResult

### DIFF
--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -207,33 +207,25 @@ export class AcpAgentAdapter implements AgentAdapter {
           throw new CompleteError("complete() returned empty output");
         }
 
-        if (response.exactCostUsd !== undefined) {
+        const tokenUsage = response.cumulative_token_usage
+          ? this._mapper.toInternal(response.cumulative_token_usage)
+          : { inputTokens: 0, outputTokens: 0 };
+        const estimatedCostUsd =
+          tokenUsage.inputTokens > 0 ? estimateCostFromTokenUsage(tokenUsage, _options.modelDef.model) : 0;
+        const exactCostUsd = response.exactCostUsd;
+
+        if (exactCostUsd !== undefined) {
           getSafeLogger()?.info("acp-adapter", "complete() cost", {
-            costUsd: response.exactCostUsd,
+            costUsd: exactCostUsd,
             model: _options.modelDef.model,
           });
-          return {
-            output: unwrapped,
-            costUsd: response.exactCostUsd,
-            source: "exact",
-          };
-        }
-
-        if (response.cumulative_token_usage) {
-          return {
-            output: unwrapped,
-            costUsd: estimateCostFromTokenUsage(
-              this._mapper.toInternal(response.cumulative_token_usage),
-              _options.modelDef.model,
-            ),
-            source: "estimated",
-          };
         }
 
         return {
           output: unwrapped,
-          costUsd: 0,
-          source: "fallback",
+          tokenUsage,
+          estimatedCostUsd,
+          exactCostUsd,
         };
       } finally {
         if (session) {
@@ -255,8 +247,8 @@ export class AcpAgentAdapter implements AgentAdapter {
       if (parsed.type === "auth") {
         return {
           output: error.message,
-          costUsd: 0,
-          source: "fallback",
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          estimatedCostUsd: 0,
           adapterFailure: {
             category: "availability",
             outcome: "fail-auth",
@@ -268,8 +260,8 @@ export class AcpAgentAdapter implements AgentAdapter {
       if (parsed.type === "rate-limit") {
         return {
           output: error.message,
-          costUsd: 0,
-          source: "fallback",
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          estimatedCostUsd: 0,
           adapterFailure: {
             category: "availability",
             outcome: "fail-rate-limit",
@@ -282,8 +274,8 @@ export class AcpAgentAdapter implements AgentAdapter {
       if (parsed.type === "model-not-available") {
         return {
           output: error.message,
-          costUsd: 0,
-          source: "fallback",
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          estimatedCostUsd: 0,
           adapterFailure: {
             category: "quality",
             outcome: "fail-adapter-error",

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -379,7 +379,7 @@ export class AgentManager implements IAgentManager {
         if (!adapter) {
           _finalStatus = "error";
           return {
-            result: { output: "", costUsd: 0, source: "fallback" },
+            result: { output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 },
             fallbacks,
           };
         }
@@ -397,8 +397,8 @@ export class AgentManager implements IAgentManager {
         } catch (err) {
           result = {
             output: "",
-            costUsd: 0,
-            source: "fallback",
+            tokenUsage: { inputTokens: 0, outputTokens: 0 },
+            estimatedCostUsd: 0,
             adapterFailure: {
               category: "quality",
               outcome: "fail-unknown",
@@ -408,7 +408,7 @@ export class AgentManager implements IAgentManager {
           };
         }
 
-        _totalCostUsd += result.costUsd ?? 0;
+        _totalCostUsd += result.estimatedCostUsd;
 
         if (!result.adapterFailure) {
           _finalStatus = "ok";
@@ -439,7 +439,7 @@ export class AgentManager implements IAgentManager {
           outcome: result.adapterFailure.outcome,
           category: result.adapterFailure.category,
           timestamp: new Date().toISOString(),
-          costUsd: result.costUsd ?? 0,
+          costUsd: result.estimatedCostUsd,
         };
         fallbacks.push(hop);
         this._emitter.emit("onSwapAttempt", hop);
@@ -606,7 +606,9 @@ export class AgentManager implements IAgentManager {
         featureName: options.featureName,
         workdir: options.workdir,
         resolvedPermissions,
-        exactCostUsd: outcome.result.source === "exact" ? outcome.result.costUsd : undefined,
+        tokenUsage: outcome.result.tokenUsage,
+        estimatedCostUsd: outcome.result.estimatedCostUsd,
+        exactCostUsd: outcome.result.exactCostUsd,
         durationMs: Date.now() - start,
         timestamp: Date.now(),
       };

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -286,10 +286,12 @@ export type ResolvedCompleteOptions = CompleteOptions & { resolvedPermissions: R
 export interface CompleteResult {
   /** Raw text output from the completion call */
   output: string;
-  /** Cost for this completion call in USD */
-  costUsd: number;
-  /** How costUsd was derived */
-  source: "exact" | "estimated" | "fallback";
+  /** Accumulated token usage for this completion call. */
+  tokenUsage: TokenUsage;
+  /** Estimated cost from token usage × pricing rates (always present). */
+  estimatedCostUsd: number;
+  /** Exact cost reported by wire protocol (when available). */
+  exactCostUsd?: number;
   /** Set when complete() failed due to an availability error — consumed by completeWithFallback. */
   adapterFailure?: AdapterFailure;
 }

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -324,7 +324,7 @@ export async function resolveOutcome(
       });
       return {
         outcome: "passed",
-        resolverCostUsd: resolverResult.costUsd,
+        resolverCostUsd: resolverResult.exactCostUsd ?? resolverResult.estimatedCostUsd,
         output: resolverResult.output,
       };
     }
@@ -369,7 +369,7 @@ export async function resolveOutcome(
     });
     return {
       outcome: "passed",
-      resolverCostUsd: resolverResult.costUsd,
+      resolverCostUsd: resolverResult.exactCostUsd ?? resolverResult.estimatedCostUsd,
       output: resolverResult.output,
     };
   }

--- a/src/runtime/dispatch-events.ts
+++ b/src/runtime/dispatch-events.ts
@@ -24,6 +24,7 @@ export interface DispatchEventBase {
   readonly projectDir?: string;
   readonly resolvedPermissions: ResolvedPermissions;
   readonly tokenUsage?: TokenUsage;
+  readonly estimatedCostUsd?: number;
   readonly exactCostUsd?: number;
   readonly durationMs: number;
   readonly timestamp: number;

--- a/src/runtime/middleware/cost.ts
+++ b/src/runtime/middleware/cost.ts
@@ -5,10 +5,10 @@ export function attachCostSubscriber(bus: IDispatchEventBus, aggregator: ICostAg
   const offDispatch = bus.onDispatch((event: DispatchEvent) => {
     const tu = event.tokenUsage;
     const exactCostUsd = event.exactCostUsd;
+    const estimatedCostUsd = event.estimatedCostUsd ?? exactCostUsd ?? 0;
 
-    if (!tu && exactCostUsd == null) return;
+    if (!tu && exactCostUsd == null && estimatedCostUsd === 0) return;
 
-    const estimatedCostUsd = exactCostUsd ?? 0;
     const costUsd = exactCostUsd ?? estimatedCostUsd;
     const confidence: "exact" | "estimated" = exactCostUsd != null ? "exact" : "estimated";
 

--- a/test/helpers/mock-agent-adapter.ts
+++ b/test/helpers/mock-agent-adapter.ts
@@ -3,8 +3,8 @@ import type { AgentAdapter, CompleteResult, SessionHandle, TurnResult } from "..
 
 const DEFAULT_COMPLETE_RESULT: CompleteResult = {
   output: "",
-  costUsd: 0,
-  source: "fallback" as const,
+  tokenUsage: { inputTokens: 0, outputTokens: 0 },
+  estimatedCostUsd: 0,
 };
 
 const DEFAULT_SESSION_HANDLE: SessionHandle = {
@@ -15,6 +15,7 @@ const DEFAULT_SESSION_HANDLE: SessionHandle = {
 const DEFAULT_TURN_RESULT: TurnResult = {
   output: "",
   tokenUsage: { inputTokens: 0, outputTokens: 0 },
+  estimatedCostUsd: 0,
   internalRoundTrips: 1,
 };
 

--- a/test/helpers/mock-agent-manager.ts
+++ b/test/helpers/mock-agent-manager.ts
@@ -16,8 +16,8 @@ const DEFAULT_RESULT = {
 
 const DEFAULT_COMPLETE_RESULT: CompleteResult = {
   output: "",
-  costUsd: 0,
-  source: "primary" as const,
+  tokenUsage: { inputTokens: 0, outputTokens: 0 },
+  estimatedCostUsd: 0,
 };
 
 export interface MockAgentManagerOptions {
@@ -39,7 +39,7 @@ export interface MockAgentManagerOptions {
  * Example:
  * ```ts
  * const manager = makeMockAgentManager({
- *   completeFn: async (_, __, opts) => ({ output: "stubbed", costUsd: 0, source: "primary" }),
+ *   completeFn: async (_, __, opts) => ({ output: "stubbed", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
  * });
  * ```
  */
@@ -58,7 +58,7 @@ export function makeMockAgentManager(opts: MockAgentManagerOptions = {}): IAgent
 
   const completeFn = opts.completeFn
     ? mock((prompt: string, completeOpts?: CompleteOptions) => opts.completeFn!("claude", prompt, completeOpts))
-    : mock(() => Promise.resolve({ output: "", costUsd: 0, source: "primary" as const }));
+    : mock(() => Promise.resolve({ output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 } satisfies CompleteResult));
 
   return {
     getDefault: () => opts.getDefaultAgent ?? "claude",
@@ -92,7 +92,7 @@ export function makeMockAgentManager(opts: MockAgentManagerOptions = {}): IAgent
       ? mock((name: string, prompt: string, completeOpts?: CompleteOptions) => opts.completeAsFn!(name, prompt, completeOpts))
       : opts.completeFn
         ? mock((name: string, prompt: string, completeOpts?: CompleteOptions) => opts.completeFn!(name, prompt, completeOpts))
-        : mock((name: string, _p: string, _o?: CompleteOptions) => Promise.resolve({ output: `output from ${name}`, costUsd: 0, source: "primary" as const })),
+        : mock((name: string, _p: string, _o?: CompleteOptions) => Promise.resolve({ output: `output from ${name}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 } satisfies CompleteResult)),
     runAsSession: opts.runAsSessionFn
       ? mock((agentName: string, handle: SessionHandle, prompt: string, sessionOpts: RunAsSessionOpts) =>
           opts.runAsSessionFn!(agentName, handle, prompt, sessionOpts),
@@ -101,6 +101,7 @@ export function makeMockAgentManager(opts: MockAgentManagerOptions = {}): IAgent
           Promise.resolve({
             output: "",
             tokenUsage: { inputTokens: 0, outputTokens: 0 },
+            estimatedCostUsd: 0,
             internalRoundTrips: 0,
           } satisfies TurnResult),
         ),

--- a/test/integration/acceptance/agent-file-recovery.test.ts
+++ b/test/integration/acceptance/agent-file-recovery.test.ts
@@ -46,7 +46,7 @@ describe("acceptanceGenerateOp.verify — agent-file recovery (bug #774)", () =>
       const agentManager = makeMockAgentManager({
         completeAsFn: async () => {
           await Bun.write(testFilePath, REAL_TEST_CODE);
-          return { output: CONVERSATIONAL_OUTPUT, costUsd: 0, source: "exact" as const };
+          return { output: CONVERSATIONAL_OUTPUT, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         },
       });
       const runtime = makeTestRuntime({ agentManager, workdir: dir });
@@ -80,7 +80,7 @@ describe("acceptanceGenerateOp.verify — agent-file recovery (bug #774)", () =>
       const agentManager = makeMockAgentManager({
         completeAsFn: async () => {
           await Bun.write(testFilePath, STUB_TEST_CODE);
-          return { output: CONVERSATIONAL_OUTPUT, costUsd: 0, source: "exact" as const };
+          return { output: CONVERSATIONAL_OUTPUT, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         },
       });
       const runtime = makeTestRuntime({ agentManager, workdir: dir });
@@ -110,7 +110,7 @@ describe("acceptanceGenerateOp.verify — agent-file recovery (bug #774)", () =>
       const testFilePath = join(dir, "test-feature.nax-acceptance.test.ts");
 
       const agentManager = makeMockAgentManager({
-        completeAsFn: async () => ({ output: CONVERSATIONAL_OUTPUT, costUsd: 0, source: "exact" as const }),
+        completeAsFn: async () => ({ output: CONVERSATIONAL_OUTPUT, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
       });
       const runtime = makeTestRuntime({ agentManager, workdir: dir });
       const ctx: CallContext = {

--- a/test/integration/execution/status-file-integration.test.ts
+++ b/test/integration/execution/status-file-integration.test.ts
@@ -62,7 +62,7 @@ class MockAgentAdapter implements AgentAdapter {
     return { stories: [] };
   }
   async complete(_prompt: string): Promise<import("../../../src/agents/types").CompleteResult> {
-    return { output: "", costUsd: 0, source: "exact" };
+    return { output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
   }
 }
 

--- a/test/integration/pipeline/reporter-lifecycle-basic.test.ts
+++ b/test/integration/pipeline/reporter-lifecycle-basic.test.ts
@@ -45,7 +45,7 @@ class MockAgentAdapter implements AgentAdapter {
     return { success: true, exitCode: 0, output: "", durationMs: 10, estimatedCostUsd: 0 };
   }
   async complete(_prompt: string): Promise<import("../../../src/agents/types").CompleteResult> {
-    return { output: "", costUsd: 0, source: "exact" };
+    return { output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
   }
 }
 

--- a/test/integration/pipeline/reporter-lifecycle-resilience.test.ts
+++ b/test/integration/pipeline/reporter-lifecycle-resilience.test.ts
@@ -45,7 +45,7 @@ class MockAgentAdapter implements AgentAdapter {
     return { success: true, exitCode: 0, output: "", durationMs: 10, estimatedCostUsd: 0 };
   }
   async complete(_prompt: string): Promise<import("../../../src/agents/types").CompleteResult> {
-    return { output: "", costUsd: 0, source: "exact" };
+    return { output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
   }
 }
 

--- a/test/integration/tdd/_tdd-test-helpers.ts
+++ b/test/integration/tdd/_tdd-test-helpers.ts
@@ -52,7 +52,7 @@ export function createMockAgent(results: Partial<AgentResult>[]): AgentAdapter {
     },
     isInstalled: async () => true,
     buildCommand: () => ["mock"],
-    complete: mock(async () => ({ output: "", costUsd: 0, source: "fallback" as const })),
+    complete: mock(async () => ({ output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 })),
     plan: mock(async () => ({ specContent: "" })),
     decompose: mock(async () => ({ stories: [] })),
     closePhysicalSession: mock(async () => {}),

--- a/test/unit/agents/manager-complete.test.ts
+++ b/test/unit/agents/manager-complete.test.ts
@@ -36,8 +36,7 @@ function makeRegistry(
       return {
         complete: mock(async () => ({
           output: r.output,
-          costUsd: 0.01,
-          source: "exact" as const,
+          tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0.01, exactCostUsd: 0.01,
           adapterFailure: r.failure,
         })),
       };
@@ -52,7 +51,7 @@ describe("AgentManager PID lifecycle — configureRuntime", () => {
       getAgent: () => ({
         complete: mock(async (_prompt: string, opts: CompleteOptions) => {
           capturedOptions = opts;
-          return { output: "ok", costUsd: 0, source: "exact" as const };
+          return { output: "ok", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         }),
       }),
     } as unknown as AgentRegistry;
@@ -87,7 +86,7 @@ describe("AgentManager PID lifecycle — configureRuntime", () => {
       getAgent: () => ({
         complete: mock(async (_prompt: string, opts: CompleteOptions) => {
           capturedOptions = opts;
-          return { output: "ok", costUsd: 0, source: "exact" as const };
+          return { output: "ok", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         }),
       }),
     } as unknown as AgentRegistry;
@@ -148,7 +147,7 @@ describe("AgentManager.completeAs — promptRetries flows from config, not optio
       getAgent: () => ({
         complete: mock(async (_prompt: string, opts: CompleteOptions) => {
           capturedOptions = opts;
-          return { output: "ok", costUsd: 0, source: "exact" as const };
+          return { output: "ok", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         }),
       }),
     } as unknown as AgentRegistry;

--- a/test/unit/agents/manager-credentials.test.ts
+++ b/test/unit/agents/manager-credentials.test.ts
@@ -20,7 +20,7 @@ function stubAdapter(name: string, hasCreds: boolean): AgentAdapter {
     buildCommand: () => [],
     plan: async () => ({ spec: "", cost: 0 }) as never,
     decompose: async () => ({ stories: [] }) as never,
-    complete: async () => ({ output: "", costUsd: 0, source: "estimated" as const }),
+    complete: async () => ({ output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
     closePhysicalSession: async () => {},
     closeSession: async () => {},
   });

--- a/test/unit/agents/manager.test.ts
+++ b/test/unit/agents/manager.test.ts
@@ -228,7 +228,7 @@ describe("AgentManager — middleware envelope", () => {
     let calledCompleteAs = false;
     (manager as unknown as { completeAs: typeof manager.completeAs }).completeAs = async (_name, _prompt, _opts) => {
       calledCompleteAs = true;
-      return { output: "", costUsd: 0, source: "fallback" as const };
+      return { output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     };
     try { await manager.complete("prompt", {} as never); } catch {}
     expect(calledCompleteAs).toBe(true);

--- a/test/unit/cli/plan-debate.test.ts
+++ b/test/unit/cli/plan-debate.test.ts
@@ -235,7 +235,7 @@ describe("planCommand — debate integration (US-004)", () => {
     _planDeps.createRuntime = mock(() =>
       makeMockPlanManager(
         undefined,
-        async (_name: string, _prompt: string, _opts: any) => ({ output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const }),
+        async (_name: string, _prompt: string, _opts: any) => ({ output: JSON.stringify(SAMPLE_PRD), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
       ),
     );
     _planDeps.createDebateRunner = origCreateDebateSession;
@@ -316,7 +316,7 @@ describe("planCommand — debate integration (US-004)", () => {
     _planDeps.createRuntime = mock(() =>
       makeMockPlanManager(
         undefined,
-        async (_name: string, _prompt: string, _opts: any) => { adapterComplete(); return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const }; },
+        async (_name: string, _prompt: string, _opts: any) => { adapterComplete(); return { output: JSON.stringify(SAMPLE_PRD), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }; },
       ),
     );
 
@@ -354,7 +354,7 @@ describe("planCommand — debate integration (US-004)", () => {
     _planDeps.createRuntime = mock(() =>
       makeMockPlanManager(undefined, async (_name, _prompt, _opts) => {
         completeCalls.push("called");
-        return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
+        return { output: JSON.stringify(SAMPLE_PRD), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
     );
     _planDeps.existsSync = mock(() => true);
@@ -380,7 +380,7 @@ describe("planCommand — debate integration (US-004)", () => {
     _planDeps.createRuntime = mock(() =>
       makeMockPlanManager(undefined, async (_name, _prompt, _opts) => {
         completeCalls.push("called");
-        return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
+        return { output: JSON.stringify(SAMPLE_PRD), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
     );
     _planDeps.existsSync = mock(() => true);
@@ -406,7 +406,7 @@ describe("planCommand — debate integration (US-004)", () => {
     _planDeps.createRuntime = mock(() =>
       makeMockPlanManager(undefined, async (_name, _prompt, _opts) => {
         completeCalls.push("called");
-        return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
+        return { output: JSON.stringify(SAMPLE_PRD), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
     );
     _planDeps.existsSync = mock(() => true);

--- a/test/unit/cli/plan-decompose-ac-repair.test.ts
+++ b/test/unit/cli/plan-decompose-ac-repair.test.ts
@@ -26,9 +26,9 @@ function makeMockDecomposeManager(
     completeAsFn: decomposeFn
       ? async (name: string, _prompt: string, opts?: any) => {
           const result = await decomposeFn(name, opts ?? {});
-          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(result.stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         }
-      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
+      : async () => ({ output: JSON.stringify([]), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
   });
 }
 
@@ -280,7 +280,7 @@ describe("planDecomposeCommand — AC overflow repair loop (issue #227)", () => 
           const stories = callCount === 1
             ? [makeOversizedSubStory("US-001-A", 6)]
             : [makeValidSubStory("US-001-A"), makeValidSubStory("US-001-B")];
-          return { output: JSON.stringify(stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         },
       }),
     ) as unknown as typeof _planDeps.createRuntime;

--- a/test/unit/cli/plan-decompose-ac13-14.test.ts
+++ b/test/unit/cli/plan-decompose-ac13-14.test.ts
@@ -20,9 +20,9 @@ function makeMockDecomposeManager(
     completeAsFn: decomposeFn
       ? async (name: string, _prompt: string, opts?: any) => {
           const result = await decomposeFn(name, opts ?? {});
-          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(result.stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         }
-      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
+      : async () => ({ output: JSON.stringify([]), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
   });
 }
 

--- a/test/unit/cli/plan-decompose-adapter.test.ts
+++ b/test/unit/cli/plan-decompose-adapter.test.ts
@@ -27,9 +27,9 @@ function makeMockDecomposeManager(
     completeAsFn: decomposeFn
       ? async (name: string, _prompt: string, opts?: any) => {
           const result = await decomposeFn(name, opts ?? {});
-          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(result.stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         }
-      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
+      : async () => ({ output: JSON.stringify([]), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
   });
 }
 

--- a/test/unit/cli/plan-decompose-debate.test.ts
+++ b/test/unit/cli/plan-decompose-debate.test.ts
@@ -28,9 +28,9 @@ function makeMockDecomposeManager(
     completeAsFn: decomposeFn
       ? async (name: string, _prompt: string, opts?: any) => {
           const result = await decomposeFn(name, opts ?? {});
-          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(result.stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         }
-      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
+      : async () => ({ output: JSON.stringify([]), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
   });
 }
 
@@ -277,7 +277,7 @@ describe("planDecomposeCommand — debate integration (US-004)", () => {
       makeMockAgentManager({
         completeAsFn: async () => {
           completeCalls.push(1);
-          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         },
       }),
     );
@@ -327,7 +327,7 @@ describe("planDecomposeCommand — debate integration (US-004)", () => {
       makeMockAgentManager({
         completeAsFn: async () => {
           completeCalls.push(1);
-          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         },
       }),
     );
@@ -392,7 +392,7 @@ describe("planDecomposeCommand — debate integration (US-004)", () => {
       makeMockAgentManager({
         completeAsFn: async () => {
           completeCalls.push(1);
-          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         },
       }),
     );
@@ -418,7 +418,7 @@ describe("planDecomposeCommand — debate integration (US-004)", () => {
       makeMockAgentManager({
         completeAsFn: async () => {
           completeCalls.push(1);
-          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(makeDecomposeAdapterResult().stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         },
       }),
     );

--- a/test/unit/cli/plan-decompose-guards.test.ts
+++ b/test/unit/cli/plan-decompose-guards.test.ts
@@ -138,7 +138,7 @@ describe("planDecomposeCommand — guards (AC-1 to AC-8)", () => {
       makeMockAgentManager({
         completeAsFn: async (_name: string, prompt: string) => {
           capturedCompleteArgs.push(prompt);
-          return { output: JSON.stringify(stories.map(toDecomposedStory)), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(stories.map(toDecomposedStory)), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         },
       }),
     );
@@ -267,7 +267,7 @@ describe("planDecomposeCommand — guards (AC-1 to AC-8)", () => {
       makeMockAgentManager({
         completeAsFn: async (_name: string, _prompt: string, opts?: any) => {
           capturedDecomposeOpts.push(opts ?? {});
-          return { output: JSON.stringify([makeSubStory("US-001-A"), makeSubStory("US-001-B")].map(toDecomposedStory)), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify([makeSubStory("US-001-A"), makeSubStory("US-001-B")].map(toDecomposedStory)), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         },
       }),
     );

--- a/test/unit/cli/plan-decompose-mapper.test.ts
+++ b/test/unit/cli/plan-decompose-mapper.test.ts
@@ -23,9 +23,9 @@ function makeMockDecomposeManager(
     completeAsFn: decomposeFn
       ? async (name: string, _prompt: string, opts?: any) => {
           const result = await decomposeFn(name, opts ?? {});
-          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(result.stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         }
-      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
+      : async () => ({ output: JSON.stringify([]), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
   });
 }
 

--- a/test/unit/cli/plan-decompose-regression.test.ts
+++ b/test/unit/cli/plan-decompose-regression.test.ts
@@ -23,9 +23,9 @@ function makeMockDecomposeManager(
     completeAsFn: decomposeFn
       ? async (name: string, _prompt: string, opts?: any) => {
           const result = await decomposeFn(name, opts ?? {});
-          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(result.stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         }
-      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
+      : async () => ({ output: JSON.stringify([]), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
   });
 }
 
@@ -169,7 +169,7 @@ describe("planDecomposeCommand — fenced JSON parsing regression", () => {
     setupBaseDeps(tmpDir, prd, capturedWrites);
     _planDeps.createRuntime = mock(() =>
       makeMockAgentManager({
-        completeAsFn: async () => ({ output: fencedJson, costUsd: 0, source: "exact" as const }),
+        completeAsFn: async () => ({ output: fencedJson, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
       }),
     );
 
@@ -186,7 +186,7 @@ describe("planDecomposeCommand — fenced JSON parsing regression", () => {
     setupBaseDeps(tmpDir, prd, capturedWrites);
     _planDeps.createRuntime = mock(() =>
       makeMockAgentManager({
-        completeAsFn: async () => ({ output: fencedJson, costUsd: 0, source: "exact" as const }),
+        completeAsFn: async () => ({ output: fencedJson, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
       }),
     );
 
@@ -203,7 +203,7 @@ describe("planDecomposeCommand — fenced JSON parsing regression", () => {
     setupBaseDeps(tmpDir, prd, capturedWrites);
     _planDeps.createRuntime = mock(() =>
       makeMockAgentManager({
-        completeAsFn: async () => ({ output: fencedJson, costUsd: 0, source: "exact" as const }),
+        completeAsFn: async () => ({ output: fencedJson, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
       }),
     );
 

--- a/test/unit/cli/plan-decompose-writeback.test.ts
+++ b/test/unit/cli/plan-decompose-writeback.test.ts
@@ -20,9 +20,9 @@ function makeMockDecomposeManager(
     completeAsFn: decomposeFn
       ? async (name: string, _prompt: string, opts?: any) => {
           const result = await decomposeFn(name, opts ?? {});
-          return { output: JSON.stringify(result.stories), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(result.stories), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         }
-      : async () => ({ output: JSON.stringify([]), costUsd: 0, source: "exact" as const }),
+      : async () => ({ output: JSON.stringify([]), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
   });
 }
 

--- a/test/unit/cli/plan-monorepo.test.ts
+++ b/test/unit/cli/plan-monorepo.test.ts
@@ -105,7 +105,7 @@ describe("planCommand — MW-007 monorepo awareness", () => {
     _planDeps.createRuntime = mock(() =>
       makeMockPlanManager(async (_name: string, prompt: string, _opts: any) => {
         capturedPrompts.push(prompt);
-        return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
+        return { output: JSON.stringify(SAMPLE_PRD), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
     );
   });
@@ -268,7 +268,7 @@ describe("planCommand — per-package tech stack in prompt", () => {
     _planDeps.createRuntime = mock(() =>
       makeMockPlanManager(async (_name: string, prompt: string, _opts: any) => {
         capturedPrompts.push(prompt);
-        return { output: JSON.stringify(minimalPrd), costUsd: 0, source: "exact" as const };
+        return { output: JSON.stringify(minimalPrd), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
     );
   });

--- a/test/unit/cli/plan.test.ts
+++ b/test/unit/cli/plan.test.ts
@@ -122,7 +122,7 @@ describe("planCommand", () => {
       return makeMockAgentManager({
         completeAsFn: async (_name: string, prompt: string, _opts?: any) => {
           if (prompt) capturedPlanArgs.push(prompt);
-          return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(SAMPLE_PRD), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         },
       });
     });
@@ -186,7 +186,7 @@ describe("planCommand", () => {
       makeMockAgentManager({
         completeAsFn: async (name: string, _prompt: string, _opts?: any) => {
           receivedAgentName = name;
-          return { output: JSON.stringify(SAMPLE_PRD), costUsd: 0, source: "exact" as const };
+          return { output: JSON.stringify(SAMPLE_PRD), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
         },
       }),
     );
@@ -286,7 +286,7 @@ describe("planCommand", () => {
   test("AC-4: throws on invalid JSON response from adapter", async () => {
     _planDeps.createRuntime = mock((_cfg: any) =>
       makeMockAgentManager({
-        completeAsFn: async () => ({ output: "not valid json {{", costUsd: 0, source: "exact" as const }),
+        completeAsFn: async () => ({ output: "not valid json {{", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
       }),
     );
 
@@ -308,8 +308,7 @@ describe("planCommand", () => {
       makeMockAgentManager({
         completeAsFn: async () => ({
           output: JSON.stringify(prdWithoutProject),
-          costUsd: 0,
-          source: "exact" as const,
+          tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0,
         }),
       }),
     );
@@ -334,8 +333,7 @@ describe("planCommand", () => {
       makeMockAgentManager({
         completeAsFn: async () => ({
           output: JSON.stringify(badPrd),
-          costUsd: 0,
-          source: "exact" as const,
+          tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0,
         }),
       }),
     );
@@ -395,8 +393,7 @@ describe("planCommand", () => {
       makeMockAgentManager({
         completeAsFn: async () => ({
           output: JSON.stringify(prdWithBadStatuses),
-          costUsd: 0,
-          source: "exact" as const,
+          tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0,
         }),
       }),
     );

--- a/test/unit/debate/resolvers.test.ts
+++ b/test/unit/debate/resolvers.test.ts
@@ -182,7 +182,7 @@ describe("synthesisResolver()", () => {
     let callCount = 0;
     const agentManager = makeMockAgentManager({ completeAsFn: async () => {
       callCount++;
-      return { output: "synthesis output", costUsd: 0, source: "fallback" };
+      return { output: "synthesis output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     await synthesisResolver(["proposal 1", "proposal 2", "proposal 3"], [], {
@@ -198,7 +198,7 @@ describe("synthesisResolver()", () => {
     let capturedPrompt = "";
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, prompt) => {
       capturedPrompt = prompt;
-      return { output: "synthesis output", costUsd: 0, source: "fallback" };
+      return { output: "synthesis output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     await synthesisResolver(
@@ -216,7 +216,7 @@ describe("synthesisResolver()", () => {
     let capturedPrompt = "";
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, prompt) => {
       capturedPrompt = prompt;
-      return { output: "synthesis output", costUsd: 0, source: "fallback" };
+      return { output: "synthesis output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     await synthesisResolver(["proposal 1"], ["critique X", "critique Y"], {
@@ -230,7 +230,7 @@ describe("synthesisResolver()", () => {
   });
 
   test("returns output and cost metadata from agentManager.completeAs()", async () => {
-    const agentManager = makeMockAgentManager({ completeAsFn: async () => ({ output: "the synthesis result", costUsd: 0, source: "fallback" }) });
+    const agentManager = makeMockAgentManager({ completeAsFn: async () => ({ output: "the synthesis result", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }) });
 
     const result = await synthesisResolver(["prop 1", "prop 2"], [], {
       agentManager,
@@ -239,12 +239,12 @@ describe("synthesisResolver()", () => {
     });
 
     expect(result.output).toBe("the synthesis result");
-    expect(result.costUsd).toBe(0);
-    expect(result.source).toBe("fallback");
+    expect(result.estimatedCostUsd).toBe(0);
+    expect(result.exactCostUsd).toBeUndefined();
   });
 
   test("works when critiques array is empty", async () => {
-    const agentManager = makeMockAgentManager({ completeAsFn: async () => ({ output: "synthesis without critiques", costUsd: 0, source: "fallback" }) });
+    const agentManager = makeMockAgentManager({ completeAsFn: async () => ({ output: "synthesis without critiques", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }) });
 
     const result = await synthesisResolver(["p1", "p2"], [], {
       agentManager,
@@ -253,12 +253,12 @@ describe("synthesisResolver()", () => {
     });
 
     expect(result.output).toBe("synthesis without critiques");
-    expect(result.costUsd).toBe(0);
-    expect(result.source).toBe("fallback");
+    expect(result.estimatedCostUsd).toBe(0);
+    expect(result.exactCostUsd).toBeUndefined();
   });
 
   test("preserves exact cost metadata from agentManager.completeAs()", async () => {
-    const agentManager = makeMockAgentManager({ completeAsFn: async () => ({ output: "exact synthesis", costUsd: 0.42, source: "exact" }) });
+    const agentManager = makeMockAgentManager({ completeAsFn: async () => ({ output: "exact synthesis", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0.42, exactCostUsd: 0.42 }) });
 
     const result = await synthesisResolver(["p1", "p2"], ["c1"], {
       agentManager,
@@ -267,15 +267,15 @@ describe("synthesisResolver()", () => {
     });
 
     expect(result.output).toBe("exact synthesis");
-    expect(result.costUsd).toBeCloseTo(0.42, 6);
-    expect(result.source).toBe("exact");
+    expect(result.estimatedCostUsd).toBeCloseTo(0.42, 6);
+    expect(result.exactCostUsd).toBeCloseTo(0.42, 6);
   });
 
   test("forwards complete options to agentManager.completeAs()", async () => {
     let capturedOptions: CompleteOptions | undefined;
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, _prompt, opts) => {
       capturedOptions = opts;
-      return { output: "exact synthesis", costUsd: 0.42, source: "exact" };
+      return { output: "exact synthesis", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0.42, exactCostUsd: 0.42 };
     } });
 
     const completeOptions = {
@@ -304,7 +304,7 @@ describe("judgeResolver()", () => {
 
     const agentManager = makeMockAgentManager({ completeAsFn: async (name, _prompt, _opts) => {
       usedAgentName = name;
-      return { output: "judge output", costUsd: 0, source: "fallback" };
+      return { output: "judge output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     const resolverConfig: ResolverConfig = {
@@ -325,7 +325,7 @@ describe("judgeResolver()", () => {
 
     const agentManager = makeMockAgentManager({ completeAsFn: async () => {
       callCount++;
-      return { output: "judge output", costUsd: 0, source: "fallback" };
+      return { output: "judge output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     await judgeResolver(["p1", "p2"], ["c1"], { type: "custom", agent: "judge" }, {
@@ -341,7 +341,7 @@ describe("judgeResolver()", () => {
 
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, prompt) => {
       capturedPrompt = prompt;
-      return { output: "judge output", costUsd: 0, source: "fallback" };
+      return { output: "judge output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     await judgeResolver(
@@ -360,7 +360,7 @@ describe("judgeResolver()", () => {
 
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, prompt) => {
       capturedPrompt = prompt;
-      return { output: "judge output", costUsd: 0, source: "fallback" };
+      return { output: "judge output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     await judgeResolver(
@@ -375,7 +375,7 @@ describe("judgeResolver()", () => {
   });
 
   test("returns output and cost metadata from agentManager.completeAs()", async () => {
-    const agentManager = makeMockAgentManager({ completeAsFn: async () => ({ output: "final judge verdict", costUsd: 0, source: "fallback" }) });
+    const agentManager = makeMockAgentManager({ completeAsFn: async () => ({ output: "final judge verdict", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }) });
 
     const result = await judgeResolver(["p1"], [], { type: "custom", agent: "judge" }, {
       agentManager,
@@ -383,12 +383,12 @@ describe("judgeResolver()", () => {
     });
 
     expect(result.output).toBe("final judge verdict");
-    expect(result.costUsd).toBe(0);
-    expect(result.source).toBe("fallback");
+    expect(result.estimatedCostUsd).toBe(0);
+    expect(result.exactCostUsd).toBeUndefined();
   });
 
   test("preserves exact cost metadata from judge agentManager.completeAs()", async () => {
-    const agentManager = makeMockAgentManager({ completeAsFn: async () => ({ output: "judge verdict", costUsd: 0.55, source: "exact" }) });
+    const agentManager = makeMockAgentManager({ completeAsFn: async () => ({ output: "judge verdict", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0.55, exactCostUsd: 0.55 }) });
 
     const result = await judgeResolver(["p1"], ["c1"], { type: "custom", agent: "judge" }, {
       agentManager,
@@ -396,8 +396,8 @@ describe("judgeResolver()", () => {
     });
 
     expect(result.output).toBe("judge verdict");
-    expect(result.costUsd).toBeCloseTo(0.55, 6);
-    expect(result.source).toBe("exact");
+    expect(result.estimatedCostUsd).toBeCloseTo(0.55, 6);
+    expect(result.exactCostUsd).toBeCloseTo(0.55, 6);
   });
 
   test("uses defaultAgentName when resolver.agent is not specified", async () => {
@@ -405,7 +405,7 @@ describe("judgeResolver()", () => {
 
     const agentManager = makeMockAgentManager({ completeAsFn: async (name, _prompt, _opts) => {
       usedAgentName = name;
-      return { output: "judge output", costUsd: 0, source: "fallback" };
+      return { output: "judge output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     const resolverConfig: ResolverConfig = {
@@ -427,7 +427,7 @@ describe("judgeResolver()", () => {
 
     const agentManager = makeMockAgentManager({ completeAsFn: async () => {
       wasCalled = true;
-      return { output: "fallback judge output", costUsd: 0, source: "fallback" };
+      return { output: "fallback judge output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     const resolverConfig: ResolverConfig = {
@@ -450,7 +450,7 @@ describe("judgeResolver()", () => {
     let capturedOptions: CompleteOptions | undefined;
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, _prompt, opts) => {
       capturedOptions = opts;
-      return { output: "judge verdict", costUsd: 0.55, source: "exact" };
+      return { output: "judge verdict", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0.55, exactCostUsd: 0.55 };
     } });
 
     const completeOptions = {
@@ -477,7 +477,7 @@ describe("synthesisResolver() — persona-aware proposal labels (P2)", () => {
     let capturedPrompt = "";
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, prompt) => {
       capturedPrompt = prompt;
-      return { output: "synthesis", costUsd: 0, source: "fallback" };
+      return { output: "synthesis", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     const debaters: Debater[] = [
@@ -504,7 +504,7 @@ describe("synthesisResolver() — persona-aware proposal labels (P2)", () => {
     let capturedPrompt = "";
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, prompt) => {
       capturedPrompt = prompt;
-      return { output: "synthesis", costUsd: 0, source: "fallback" };
+      return { output: "synthesis", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     const debaters: Debater[] = [
@@ -528,7 +528,7 @@ describe("synthesisResolver() — persona-aware proposal labels (P2)", () => {
     let capturedPrompt = "";
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, prompt) => {
       capturedPrompt = prompt;
-      return { output: "synthesis", costUsd: 0, source: "fallback" };
+      return { output: "synthesis", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     await synthesisResolver(["proposal A", "proposal B"], [], {
@@ -545,7 +545,7 @@ describe("synthesisResolver() — persona-aware proposal labels (P2)", () => {
     let capturedPrompt = "";
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, prompt) => {
       capturedPrompt = prompt;
-      return { output: "synthesis", costUsd: 0, source: "fallback" };
+      return { output: "synthesis", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     const debaters: Debater[] = [
@@ -570,7 +570,7 @@ describe("judgeResolver() — persona-aware proposal labels (P2)", () => {
     let capturedPrompt = "";
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, prompt) => {
       capturedPrompt = prompt;
-      return { output: "synthesis output", costUsd: 0, source: "fallback" };
+      return { output: "synthesis output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     const debaters: Debater[] = [
@@ -592,7 +592,7 @@ describe("judgeResolver() — persona-aware proposal labels (P2)", () => {
     let capturedPrompt = "";
     const agentManager = makeMockAgentManager({ completeAsFn: async (_name, prompt) => {
       capturedPrompt = prompt;
-      return { output: "verdict", costUsd: 0, source: "fallback" };
+      return { output: "verdict", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     } });
 
     await judgeResolver(["p1", "p2"], [], { type: "custom", agent: "judge" }, {

--- a/test/unit/debate/runner-agent-resolution.test.ts
+++ b/test/unit/debate/runner-agent-resolution.test.ts
@@ -101,7 +101,7 @@ describe("DebateRunner.run() — agent resolution", () => {
     const agentManager = makeMockAgentManager({
       completeAsFn: async (agentName, _prompt, _opts) => {
         completeCalls.push({ agent: agentName });
-        return { output: `{"passed": true}`, costUsd: 0, source: "fallback" as const };
+        return { output: `{"passed": true}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -134,7 +134,7 @@ describe("DebateRunner.run() — agent resolution", () => {
     const agentManager = makeMockAgentManager({
       completeAsFn: async (_name, prompt) => {
         receivedPrompts.push(prompt);
-        return { output: `{"passed": true}`, costUsd: 0, source: "fallback" as const };
+        return { output: `{"passed": true}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -165,7 +165,7 @@ describe("DebateRunner.run() — parallel execution", () => {
       completeAsFn: async (name) => {
         startTimes.push(Date.now());
         await new Promise<void>((resolve) => resolvers.push(resolve));
-        return { output: `output from ${name}`, costUsd: 0, source: "fallback" as const };
+        return { output: `output from ${name}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -193,7 +193,7 @@ describe("DebateRunner.run() — parallel execution", () => {
     const agentManager = makeMockAgentManager({
       completeAsFn: async (name) => {
         if (name === "failing") throw new Error("agent error");
-        return { output: `{"passed": true}`, costUsd: 0, source: "fallback" as const };
+        return { output: `{"passed": true}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -222,7 +222,7 @@ describe("DebateRunner.run() — unavailable agent handling", () => {
       unavailableAgents: new Set(["missing-agent"]),
       completeAsFn: async (name) => {
         completeCalls.push(name);
-        return { output: `{"passed": true}`, costUsd: 0, source: "fallback" as const };
+        return { output: `{"passed": true}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -283,7 +283,7 @@ describe("DebateRunner.run() — unavailable agent handling", () => {
       unavailableAgents: new Set(["null-agent"]),
       completeAsFn: async (name) => {
         completeCalls.push(name);
-        return { output: `{"passed": true}`, costUsd: 0, source: "fallback" as const };
+        return { output: `{"passed": true}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -309,7 +309,7 @@ describe("DebateRunner.run() — single-agent fallback", () => {
   test("returns the one successful proposal when only 1 debater succeeds", async () => {
     const agentManager = makeMockAgentManager({
       unavailableAgents: new Set(["missing-1", "missing-2"]),
-      completeAsFn: async () => ({ output: "the single successful proposal", costUsd: 0, source: "fallback" as const }),
+      completeAsFn: async () => ({ output: "the single successful proposal", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
     });
 
     const runner = new DebateRunner({

--- a/test/unit/debate/runner-events.test.ts
+++ b/test/unit/debate/runner-events.test.ts
@@ -212,7 +212,7 @@ describe("DebateRunner.run() — JSONL log events", () => {
     const agentManager = makeMockAgentManager({
       completeAsFn: async (agentName, _prompt, opts) => {
         completeCalls.push({ agent: agentName, model: opts?.model });
-        return { output: `output from ${agentName}`, costUsd: 0, source: "fallback" as const };
+        return { output: `output from ${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 

--- a/test/unit/debate/runner-mode-routing.test.ts
+++ b/test/unit/debate/runner-mode-routing.test.ts
@@ -90,7 +90,7 @@ afterEach(() => {
 describe("DebateRunner.run() mode routing — AC1: panel + one-shot", () => {
   test("with mode 'panel' and sessionMode 'one-shot', calls runOneShot", async () => {
     const agentManager = makeMockAgentManager({
-      completeAsFn: async (_name, _p, _o) => ({ output: `{"passed": true}`, costUsd: 0, source: "fallback" as const }),
+      completeAsFn: async (_name, _p, _o) => ({ output: `{"passed": true}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
     });
 
     const runner = new DebateRunner({
@@ -149,7 +149,7 @@ describe("DebateRunner.run() mode routing — AC3: mode undefined defaults to pa
     delete (stageConfig as any).mode;
 
     const agentManager = makeMockAgentManager({
-      completeAsFn: async (_name, _p, _o) => ({ output: `{"passed": true}`, costUsd: 0, source: "fallback" as const }),
+      completeAsFn: async (_name, _p, _o) => ({ output: `{"passed": true}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
     });
 
     const runner = new DebateRunner({
@@ -200,7 +200,7 @@ describe("DebateRunner.run() mode routing — AC4: hybrid + stateful", () => {
 describe("DebateRunner.run() mode routing — AC5: hybrid + one-shot with fallback", () => {
   test("with mode 'hybrid' and sessionMode 'one-shot', calls runOneShot and logs warning", async () => {
     const agentManager = makeMockAgentManager({
-      completeAsFn: async (_name, _p, _o) => ({ output: `{"passed": true}`, costUsd: 0, source: "fallback" as const }),
+      completeAsFn: async (_name, _p, _o) => ({ output: `{"passed": true}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
     });
 
     const runner = new DebateRunner({
@@ -236,7 +236,7 @@ describe("DebateRunner.run() mode routing — AC6: hybrid + undefined sessionMod
     delete (stageConfig as any).sessionMode;
 
     const agentManager = makeMockAgentManager({
-      completeAsFn: async (_name, _p, _o) => ({ output: `{"passed": true}`, costUsd: 0, source: "fallback" as const }),
+      completeAsFn: async (_name, _p, _o) => ({ output: `{"passed": true}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
     });
 
     const runner = new DebateRunner({

--- a/test/unit/debate/runner-one-shot-roles.test.ts
+++ b/test/unit/debate/runner-one-shot-roles.test.ts
@@ -24,7 +24,7 @@ function makeCallCtx(
   completeAsFn?: (agentName: string, prompt: string, opts?: CompleteOptions) => Promise<CompleteResult>,
 ): CallContext {
   const agentManager = makeMockAgentManager({
-    completeAsFn: completeAsFn ?? (async () => ({ output: '{"passed":true}', costUsd: 0, source: "fallback" as const })),
+    completeAsFn: completeAsFn ?? (async () => ({ output: '{"passed":true}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 })),
   });
   return {
     runtime: {
@@ -66,7 +66,7 @@ describe("DebateRunner.runPanelOneShot() proposal invocations", () => {
     const runner = new DebateRunner({
       ctx: makeCallCtx("US-ROLE", async (agentName, _prompt, _opts) => {
         agentCalls.push(agentName);
-        return { output: '{"passed":true}', costUsd: 0, source: "fallback" as const };
+        return { output: '{"passed":true}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
       stage: "review",
       stageConfig: makeStageConfig(),
@@ -87,7 +87,7 @@ describe("DebateRunner.runPanelOneShot() proposal invocations", () => {
     const runner = new DebateRunner({
       ctx: makeCallCtx("US-ROLE", async (_agentName, _prompt, _opts) => {
         callCount.total++;
-        return { output: '{"passed":true}', costUsd: 0, source: "fallback" as const };
+        return { output: '{"passed":true}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
       stage: "review",
       stageConfig: makeStageConfig({
@@ -114,7 +114,7 @@ describe("DebateRunner.runPanelOneShot() — persona injection in proposal round
     const runner = new DebateRunner({
       ctx: makeCallCtx("US-P1", async (_agentName, prompt) => {
         capturedPrompts.push(prompt);
-        return { output: '{"passed":true}', costUsd: 0, source: "fallback" as const };
+        return { output: '{"passed":true}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
       stage: "review",
       stageConfig: makeStageConfig({
@@ -151,7 +151,7 @@ describe("DebateRunner.runPanelOneShot() — persona injection in proposal round
     const runner = new DebateRunner({
       ctx: makeCallCtx("US-P1-NO-PERSONA", async (_agentName, prompt) => {
         capturedPrompts.push(prompt);
-        return { output: '{"passed":true}', costUsd: 0, source: "fallback" as const };
+        return { output: '{"passed":true}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
       stage: "review",
       stageConfig: makeStageConfig({
@@ -179,7 +179,7 @@ describe("DebateRunner.runPanelOneShot() — persona injection in proposal round
     const runner = new DebateRunner({
       ctx: makeCallCtx("US-P1-TASK", async (_agentName, prompt) => {
         capturedPrompts.push(prompt);
-        return { output: '{"passed":true}', costUsd: 0, source: "fallback" as const };
+        return { output: '{"passed":true}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
       stage: "review",
       stageConfig: makeStageConfig({
@@ -210,7 +210,7 @@ describe("DebateRunner.runPanelOneShot() — labeledProposals persona label (P3)
         if (opts?.sessionRole === "synthesis") {
           capturedSynthesisPrompt = prompt;
         }
-        return { output: "proposal output", costUsd: 0, source: "fallback" as const };
+        return { output: "proposal output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
       stage: "plan",
       stageConfig: makeStageConfig({
@@ -244,7 +244,7 @@ describe("DebateRunner.runPanelOneShot() — labeledProposals persona label (P3)
         if (opts?.sessionRole === "synthesis") {
           capturedSynthesisPrompt = prompt;
         }
-        return { output: "proposal output", costUsd: 0, source: "fallback" as const };
+        return { output: "proposal output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
       stage: "plan",
       stageConfig: makeStageConfig({

--- a/test/unit/debate/runner-plan.test.ts
+++ b/test/unit/debate/runner-plan.test.ts
@@ -509,7 +509,7 @@ describe("DebateRunner.runPlan()", () => {
     const agentManager = makeMockAgentManager({
       completeFn: async (_agentName, prompt) => {
         capturedSynthesisPrompt = prompt;
-        return { output: '{"userStories":[]}', costUsd: 0, source: "fallback" as const };
+        return { output: '{"userStories":[]}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -558,7 +558,7 @@ describe("DebateRunner.runPlan()", () => {
     const agentManager = makeMockAgentManager({
       completeFn: async (_agentName, prompt) => {
         capturedSynthesisPrompt = prompt;
-        return { output: '{"userStories":[]}', costUsd: 0, source: "fallback" as const };
+        return { output: '{"userStories":[]}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 

--- a/test/unit/debate/runner-rounds-and-cost.test.ts
+++ b/test/unit/debate/runner-rounds-and-cost.test.ts
@@ -70,7 +70,7 @@ describe("DebateRunner.run() — critique rounds (rounds === 2)", () => {
     const agentManager = makeMockAgentManager({
       completeAsFn: async (name) => {
         callCounts[name] = (callCounts[name] ?? 0) + 1;
-        return { output: `proposal from ${name}`, costUsd: 0, source: "fallback" as const };
+        return { output: `proposal from ${name}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -99,7 +99,7 @@ describe("DebateRunner.run() — critique rounds (rounds === 2)", () => {
       completeAsFn: async (name, prompt) => {
         if (!promptsByAgent[name]) promptsByAgent[name] = [];
         promptsByAgent[name].push(prompt);
-        return { output: `proposal from ${name}`, costUsd: 0, source: "fallback" as const };
+        return { output: `proposal from ${name}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -129,7 +129,7 @@ describe("DebateRunner.run() — critique rounds (rounds === 2)", () => {
       completeAsFn: async (name, prompt) => {
         if (!promptsByAgent[name]) promptsByAgent[name] = [];
         promptsByAgent[name].push(prompt);
-        return { output: `proposal from ${name}`, costUsd: 0, source: "fallback" as const };
+        return { output: `proposal from ${name}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -159,7 +159,7 @@ describe("DebateRunner.run() — critique rounds (rounds === 2)", () => {
       completeAsFn: async (name, prompt) => {
         if (!promptsByAgent[name]) promptsByAgent[name] = [];
         promptsByAgent[name].push(prompt);
-        return { output: `proposal from ${name}`, costUsd: 0, source: "fallback" as const };
+        return { output: `proposal from ${name}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -191,7 +191,7 @@ describe("DebateRunner.run() — no critique round (rounds === 1)", () => {
     const agentManager = makeMockAgentManager({
       completeAsFn: async (name) => {
         callCounts[name] = (callCounts[name] ?? 0) + 1;
-        return { output: `{"passed": true}`, costUsd: 0, source: "fallback" as const };
+        return { output: `{"passed": true}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -218,7 +218,7 @@ describe("DebateRunner.run() — no critique round (rounds === 1)", () => {
 describe("DebateRunner.run() — cost tracking", () => {
   test("DebateResult has totalCostUsd field", async () => {
     const agentManager = makeMockAgentManager({
-      completeAsFn: async (name, _p, _o) => ({ output: `output from ${name}`, costUsd: 0.1, source: "fallback" as const }),
+      completeAsFn: async (name, _p, _o) => ({ output: `output from ${name}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0.1 }),
     });
 
     const runner = new DebateRunner({
@@ -241,7 +241,7 @@ describe("DebateRunner.run() — cost tracking", () => {
 describe("DebateRunner.run() — proposals structure", () => {
   test("DebateResult.proposals contains one entry per successful debater", async () => {
     const agentManager = makeMockAgentManager({
-      completeAsFn: async (name) => ({ output: `output from ${name}`, costUsd: 0, source: "fallback" as const }),
+      completeAsFn: async (name) => ({ output: `output from ${name}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
     });
 
     const runner = new DebateRunner({
@@ -264,7 +264,7 @@ describe("DebateRunner.run() — proposals structure", () => {
 
   test("each proposal entry contains debater identity (agent name)", async () => {
     const agentManager = makeMockAgentManager({
-      completeAsFn: async (name) => ({ output: `output from ${name}`, costUsd: 0, source: "fallback" as const }),
+      completeAsFn: async (name) => ({ output: `output from ${name}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
     });
 
     const runner = new DebateRunner({
@@ -289,7 +289,7 @@ describe("DebateRunner.run() — proposals structure", () => {
 
   test("each proposal entry contains the output from completeAs()", async () => {
     const agentManager = makeMockAgentManager({
-      completeAsFn: async (name) => ({ output: `output from ${name}`, costUsd: 0, source: "fallback" as const }),
+      completeAsFn: async (name) => ({ output: `output from ${name}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
     });
 
     const runner = new DebateRunner({
@@ -316,7 +316,7 @@ describe("DebateRunner.run() — proposals structure", () => {
 
   test("DebateResult includes storyId, stage, and resolverType", async () => {
     const agentManager = makeMockAgentManager({
-      completeAsFn: async () => ({ output: `{"passed": true}`, costUsd: 0, source: "fallback" as const }),
+      completeAsFn: async () => ({ output: `{"passed": true}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
     });
 
     const runner = new DebateRunner({

--- a/test/unit/debate/runner-stateful.test.ts
+++ b/test/unit/debate/runner-stateful.test.ts
@@ -165,7 +165,7 @@ describe("DebateRunner.run() — stateful mode", () => {
       },
       completeAsFn: async (name) => {
         completeAsCalls.push(name);
-        return { output: "complete-output", costUsd: 0, source: "primary" as const };
+        return { output: "complete-output", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
 
@@ -406,7 +406,7 @@ describe("runStateful() — resolveOutcome receives workdir and featureName (US-
       }),
       completeFn: async (_agentName: string, _prompt: string, opts?: CompleteOptions) => {
         completeCalls.push({ opts });
-        return { output: "synthesis resolved", costUsd: 0.01, source: "exact" as const };
+        return { output: "synthesis resolved", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0.01, exactCostUsd: 0.01 };
       },
     });
 
@@ -449,7 +449,7 @@ describe("DebateRunner.run() — one-shot mode unchanged", () => {
       },
       completeFn: async () => {
         completeCount += 1;
-        return { output: '{"passed": true}', costUsd: 0.1, source: "exact" as const };
+        return { output: '{"passed": true}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0.1, exactCostUsd: 0.1 };
       },
     });
 

--- a/test/unit/debate/runner.test.ts
+++ b/test/unit/debate/runner.test.ts
@@ -9,7 +9,7 @@ import { makeMockAgentManager, makeSessionManager } from "../../helpers";
 
 function makeCallCtx(overrides: Partial<CallContext> = {}): CallContext {
   const agentManager = makeMockAgentManager({
-    completeFn: async (_name: string, _p: string, _o: unknown) => ({ output: '{"passed":true}', costUsd: 0, source: "primary" as const }),
+    completeFn: async (_name: string, _p: string, _o: unknown) => ({ output: '{"passed":true}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
   });
   return {
     runtime: {
@@ -82,7 +82,7 @@ describe("DebateRunner — one-shot panel mode", () => {
       completeAsFn: async (name: string, _p: string, _o: unknown) => {
         callCount++;
         if (callCount === 2) throw new Error("second debater failed");
-        return { output: '{"passed":true}', costUsd: 0, source: "primary" as const };
+        return { output: '{"passed":true}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
     const ctx = makeCallCtx({
@@ -123,7 +123,7 @@ describe("DebateRunner — one-shot panel mode", () => {
     const agentManager = makeMockAgentManager({
       completeAsFn: async (name: string, _p: string, _o: unknown) => {
         calls.push(name);
-        return { output: '{"passed":true}', costUsd: 0, source: "primary" as const };
+        return { output: '{"passed":true}', tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });
     const stageConfig = makeStageConfig({

--- a/test/unit/interaction/auto-plugin-adapter.test.ts
+++ b/test/unit/interaction/auto-plugin-adapter.test.ts
@@ -38,7 +38,7 @@ function makeAgentManager(
 ): { mgr: IAgentManager; completeMock: ReturnType<typeof mock> } {
   const completeMock = mock(
     completeImpl ??
-      (async () => ({ output: JSON.stringify({ action: "approve", confidence: 0.9, reasoning: "ok" }), costUsd: 0, source: "mock" as const })),
+      (async () => ({ output: JSON.stringify({ action: "approve", confidence: 0.9, reasoning: "ok" }), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 })),
   );
   return {
     mgr: {
@@ -101,7 +101,7 @@ describe("auto.ts does not spawn claude CLI directly", () => {
     const plugin = new AutoInteractionPlugin();
     await plugin.init({ confidenceThreshold: 0.7 });
 
-    const { mgr } = makeAgentManager(async () => ({ output: approveJson(), costUsd: 0, source: "mock" }));
+    const { mgr } = makeAgentManager(async () => ({ output: approveJson(), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     const originalSpawn = Bun.spawn;
@@ -130,7 +130,7 @@ describe("agentManager.complete() is called with correct arguments", () => {
   });
 
   test("agentManager.complete() is called exactly once per decide() invocation", async () => {
-    const { mgr, completeMock } = makeAgentManager(async () => ({ output: approveJson(), costUsd: 0, source: "mock" }));
+    const { mgr, completeMock } = makeAgentManager(async () => ({ output: approveJson(), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     await plugin.decide(makeRequest("req-once"));
@@ -139,7 +139,7 @@ describe("agentManager.complete() is called with correct arguments", () => {
   });
 
   test("agentManager.complete() receives a non-empty prompt string", async () => {
-    const { mgr, completeMock } = makeAgentManager(async () => ({ output: approveJson(), costUsd: 0, source: "mock" }));
+    const { mgr, completeMock } = makeAgentManager(async () => ({ output: approveJson(), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     await plugin.decide(makeRequest("req-prompt", { summary: "Is this safe?" }));
@@ -150,7 +150,7 @@ describe("agentManager.complete() is called with correct arguments", () => {
   });
 
   test("agentManager.complete() prompt contains the request summary", async () => {
-    const { mgr, completeMock } = makeAgentManager(async () => ({ output: approveJson(), costUsd: 0, source: "mock" }));
+    const { mgr, completeMock } = makeAgentManager(async () => ({ output: approveJson(), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     const summary = "Should we merge this story?";
@@ -161,7 +161,7 @@ describe("agentManager.complete() is called with correct arguments", () => {
   });
 
   test("agentManager.complete() receives jsonMode: true option", async () => {
-    const { mgr, completeMock } = makeAgentManager(async () => ({ output: approveJson(), costUsd: 0, source: "mock" }));
+    const { mgr, completeMock } = makeAgentManager(async () => ({ output: approveJson(), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     await plugin.decide(makeRequest("req-json-mode"));
@@ -184,7 +184,7 @@ describe("agentManager.complete() is called with correct arguments", () => {
       } as any,
     });
 
-    const { mgr, completeMock } = makeAgentManager(async () => ({ output: approveJson(), costUsd: 0, source: "mock" }));
+    const { mgr, completeMock } = makeAgentManager(async () => ({ output: approveJson(), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     await pluginWithModel.decide(makeRequest("req-model"));
@@ -214,7 +214,7 @@ describe("agentManager dependency injection via _deps.agentManager", () => {
     let completeCalled = false;
     const { mgr } = makeAgentManager(async () => {
       completeCalled = true;
-      return { output: approveJson(0.9), costUsd: 0, source: "mock" };
+      return { output: approveJson(0.9), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     });
     (_deps as Record<string, unknown>).agentManager = mgr;
 
@@ -237,7 +237,7 @@ describe("auto-response behaviour is preserved after adapter migration", () => {
   });
 
   test("agentManager returns approve JSON → response.action is approve", async () => {
-    const { mgr } = makeAgentManager(async () => ({ output: approveJson(0.9), costUsd: 0, source: "mock" }));
+    const { mgr } = makeAgentManager(async () => ({ output: approveJson(0.9), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     const response = await plugin.decide(makeRequest("req-approve"));
@@ -249,7 +249,7 @@ describe("auto-response behaviour is preserved after adapter migration", () => {
   });
 
   test("agentManager returns reject JSON → response.action is reject", async () => {
-    const { mgr } = makeAgentManager(async () => ({ output: rejectJson(0.85), costUsd: 0, source: "mock" }));
+    const { mgr } = makeAgentManager(async () => ({ output: rejectJson(0.85), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     const response = await plugin.decide(makeRequest("req-reject"));
@@ -258,7 +258,7 @@ describe("auto-response behaviour is preserved after adapter migration", () => {
   });
 
   test("agentManager returns choose JSON with value → value is propagated", async () => {
-    const { mgr } = makeAgentManager(async () => ({ output: chooseJson("option-b"), costUsd: 0, source: "mock" }));
+    const { mgr } = makeAgentManager(async () => ({ output: chooseJson("option-b"), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     const response = await plugin.decide(
@@ -276,7 +276,7 @@ describe("auto-response behaviour is preserved after adapter migration", () => {
   });
 
   test("confidence below threshold → returns undefined (escalates)", async () => {
-    const { mgr } = makeAgentManager(async () => ({ output: approveJson(0.5), costUsd: 0, source: "mock" }));
+    const { mgr } = makeAgentManager(async () => ({ output: approveJson(0.5), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     const response = await plugin.decide(makeRequest("req-low-conf"));
@@ -288,7 +288,7 @@ describe("auto-response behaviour is preserved after adapter migration", () => {
     const pluginAtThreshold = new AutoInteractionPlugin();
     await pluginAtThreshold.init({ confidenceThreshold: 0.8 });
 
-    const { mgr } = makeAgentManager(async () => ({ output: approveJson(0.8), costUsd: 0, source: "mock" }));
+    const { mgr } = makeAgentManager(async () => ({ output: approveJson(0.8), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     const response = await pluginAtThreshold.decide(makeRequest("req-at-threshold"));
@@ -301,7 +301,7 @@ describe("auto-response behaviour is preserved after adapter migration", () => {
     let completeCalled = false;
     const { mgr } = makeAgentManager(async () => {
       completeCalled = true;
-      return { output: approveJson(), costUsd: 0, source: "mock" };
+      return { output: approveJson(), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     });
     (_deps as Record<string, unknown>).agentManager = mgr;
 
@@ -327,7 +327,7 @@ describe("auto-response behaviour is preserved after adapter migration", () => {
   });
 
   test("agentManager.complete() returns malformed JSON → returns undefined (escalates)", async () => {
-    const { mgr } = makeAgentManager(async () => ({ output: "not valid json {{{", costUsd: 0, source: "mock" }));
+    const { mgr } = makeAgentManager(async () => ({ output: "not valid json {{{", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     const response = await plugin.decide(makeRequest("req-bad-json"));
@@ -337,7 +337,7 @@ describe("auto-response behaviour is preserved after adapter migration", () => {
 
   test("agentManager.complete() returns JSON with missing fields → returns undefined", async () => {
     const { mgr } = makeAgentManager(async () =>
-      ({ output: JSON.stringify({ action: "approve" }), costUsd: 0, source: "mock" }), // missing confidence and reasoning
+      ({ output: JSON.stringify({ action: "approve" }), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }), // missing confidence and reasoning
     );
     (_deps as Record<string, unknown>).agentManager = mgr;
 
@@ -348,7 +348,7 @@ describe("auto-response behaviour is preserved after adapter migration", () => {
 
   test("respondedAt is set to a recent timestamp", async () => {
     const before = Date.now();
-    const { mgr } = makeAgentManager(async () => ({ output: approveJson(), costUsd: 0, source: "mock" }));
+    const { mgr } = makeAgentManager(async () => ({ output: approveJson(), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     const response = await plugin.decide(makeRequest("req-timestamp"));
@@ -374,7 +374,7 @@ describe("agentManager.complete() response parsing handles markdown-wrapped JSON
 
   test("markdown-wrapped JSON is unwrapped and parsed correctly", async () => {
     const wrappedJson = "```json\n" + approveJson(0.95) + "\n```";
-    const { mgr } = makeAgentManager(async () => ({ output: wrappedJson, costUsd: 0, source: "mock" }));
+    const { mgr } = makeAgentManager(async () => ({ output: wrappedJson, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     const response = await plugin.decide(makeRequest("req-markdown"));
@@ -383,7 +383,7 @@ describe("agentManager.complete() response parsing handles markdown-wrapped JSON
   });
 
   test("plain JSON without markdown fences is parsed correctly", async () => {
-    const { mgr } = makeAgentManager(async () => ({ output: approveJson(0.88), costUsd: 0, source: "mock" }));
+    const { mgr } = makeAgentManager(async () => ({ output: approveJson(0.88), tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }));
     (_deps as Record<string, unknown>).agentManager = mgr;
 
     const response = await plugin.decide(makeRequest("req-plain-json"));

--- a/test/unit/operations/call.test.ts
+++ b/test/unit/operations/call.test.ts
@@ -59,7 +59,7 @@ const invalidTimedRunEchoOp: RunOperation<{ text: string }, string, Pick<typeof 
 
 describe("callOp — kind:complete", () => {
   test("calls agentManager.completeAs with composed prompt", async () => {
-    const completeResult: CompleteResult = { output: "echoed", costUsd: 0, source: "exact" };
+    const completeResult: CompleteResult = { output: "echoed", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     const agentManager = makeMockAgentManager({ completeAsFn: async () => completeResult });
     const runtime = makeTestRuntime({ agentManager });
 
@@ -77,7 +77,7 @@ describe("callOp — kind:complete", () => {
   });
 
   test("passes op timeoutMs to completeAs", async () => {
-    const completeResult: CompleteResult = { output: "echoed", costUsd: 0, source: "exact" };
+    const completeResult: CompleteResult = { output: "echoed", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     const agentManager = makeMockAgentManager({ completeAsFn: async () => completeResult });
     const runtime = makeTestRuntime({ agentManager });
 
@@ -99,7 +99,7 @@ describe("callOp — kind:complete", () => {
   });
 
   test("throws CALL_OP_INVALID_TIMEOUT on non-positive timeoutMs", async () => {
-    const completeResult: CompleteResult = { output: "echoed", costUsd: 0, source: "exact" };
+    const completeResult: CompleteResult = { output: "echoed", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     const agentManager = makeMockAgentManager({ completeAsFn: async () => completeResult });
     const runtime = makeTestRuntime({ agentManager });
 
@@ -296,7 +296,7 @@ describe("callOp — kind:run (ADR-019 §5)", () => {
 // back to "balanced is hardcoded".
 describe("callOp — op.model resolver (issue #725)", () => {
   test("CompleteOperation: literal model is forwarded to completeAs.model", async () => {
-    const completeResult: CompleteResult = { output: "ok", costUsd: 0, source: "exact" };
+    const completeResult: CompleteResult = { output: "ok", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     const agentManager = makeMockAgentManager({ completeAsFn: async () => completeResult });
     const runtime = makeTestRuntime({ agentManager });
 
@@ -323,7 +323,7 @@ describe("callOp — op.model resolver (issue #725)", () => {
   });
 
   test("CompleteOperation: resolver function is invoked with input and resolves to ConfiguredModel", async () => {
-    const completeResult: CompleteResult = { output: "ok", costUsd: 0, source: "exact" };
+    const completeResult: CompleteResult = { output: "ok", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
     const agentManager = makeMockAgentManager({ completeAsFn: async () => completeResult });
     const runtime = makeTestRuntime({ agentManager });
 

--- a/test/unit/pipeline/stages/execution-agent-swap-metrics.test.ts
+++ b/test/unit/pipeline/stages/execution-agent-swap-metrics.test.ts
@@ -83,12 +83,12 @@ function makeAgentManager(outcome: Partial<AgentRunOutcome> = {}): IAgentManager
         ...outcome,
       };
     },
-    completeWithFallback: async () => ({ result: { output: "", costUsd: 0, source: "fallback" as const }, fallbacks: [] }),
+    completeWithFallback: async () => ({ result: { output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }, fallbacks: [] }),
     run: async (req) => {
       const o = await mgr.runWithFallback(req);
       return { ...o.result, agentFallbacks: o.fallbacks };
     },
-    complete: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    complete: async () => ({ output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
     getAgent: () => undefined,
   };
   return mgr;

--- a/test/unit/pipeline/stages/execution-manager-wiring.test.ts
+++ b/test/unit/pipeline/stages/execution-manager-wiring.test.ts
@@ -76,12 +76,12 @@ describe("execution stage — uses agentManager.runWithFallback", () => {
         const result = { success: true, exitCode: 0, output: "done", rateLimited: false, durationMs: 100, estimatedCostUsd: 0.01 };
         return { result, fallbacks: [], finalBundle: request.bundle, finalPrompt: request.runOptions.prompt };
       }),
-      completeWithFallback: async () => ({ result: { output: "", costUsd: 0, source: "fallback" as const }, fallbacks: [] }),
+      completeWithFallback: async () => ({ result: { output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }, fallbacks: [] }),
       run: async (request: import("../../../../src/agents/manager-types").AgentRunRequest) => {
         const outcome = await manager.runWithFallback(request);
         return { ...outcome.result, agentFallbacks: outcome.fallbacks };
       },
-      complete: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+      complete: async () => ({ output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
       getAgent: () => undefined,
     } as unknown as IAgentManager;
 

--- a/test/unit/review/dialogue-debate.test.ts
+++ b/test/unit/review/dialogue-debate.test.ts
@@ -90,7 +90,7 @@ function makeAgentManager(runAsSessionFn: RunAsSessionFnType): IAgentManager {
   return makeMockAgentManager({
     getDefaultAgent: "claude",
     runAsSessionFn,
-    completeFn: async () => ({ output: "", costUsd: 0, source: "mock" as const }),
+    completeFn: async () => ({ output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
   });
 }
 

--- a/test/unit/review/dialogue-re-review.test.ts
+++ b/test/unit/review/dialogue-re-review.test.ts
@@ -116,7 +116,7 @@ function makeAgentManager(runAsSessionFn?: RunAsSessionFnType): IAgentManager {
     runAsSessionFn: async (agentName: string, handle: SessionHandle, prompt: string, opts?: RunAsSessionOpts) => {
       return await effectiveFn(agentName, handle, prompt, opts);
     },
-    completeFn: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    completeFn: async () => ({ output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
   });
 }
 

--- a/test/unit/review/dialogue.test.ts
+++ b/test/unit/review/dialogue.test.ts
@@ -96,7 +96,7 @@ function makeAgentManager(runAsSessionFn?: RunAsSessionFnType): IAgentManager {
   return makeMockAgentManager({
     getDefaultAgent: "claude",
     runAsSessionFn: effectiveFn,
-    completeFn: async () => ({ output: "", costUsd: 0, source: "fallback" as const }),
+    completeFn: async () => ({ output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
   });
 }
 

--- a/test/unit/tdd/orchestrator-totals.test.ts
+++ b/test/unit/tdd/orchestrator-totals.test.ts
@@ -55,7 +55,7 @@ function agentReturning(tokens: Array<AgentResult["tokenUsage"] | undefined>) {
     },
     isInstalled: mock(async () => true),
     buildCommand: mock(() => [] as string[]),
-    complete: mock(async () => ({ output: "", costUsd: 0, source: "fallback" as const })),
+    complete: mock(async () => ({ output: "", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 })),
     plan: mock(async () => ({ specContent: "" })),
     decompose: mock(async () => ({ stories: [] })),
     closePhysicalSession: mock(async () => {}),

--- a/test/unit/verification/rectification-loop-debate.test.ts
+++ b/test/unit/verification/rectification-loop-debate.test.ts
@@ -139,7 +139,7 @@ describe("runRectificationLoop — debate enabled", () => {
       }),
       completeFn: mock(async () => {
         completeCalls++;
-        return { output: "The root cause is a missing null check.", costUsd: 0, source: "primary" as const };
+        return { output: "The root cause is a missing null check.", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       }),
     });
 
@@ -176,7 +176,7 @@ describe("runRectificationLoop — debate enabled", () => {
         }
         return { success: true, exitCode: 0, output: "done", rateLimited: false, durationMs: 10, estimatedCostUsd: 0, agentFallbacks: [] };
       }),
-      completeFn: mock(async () => ({ output: diagnosisOutput, costUsd: 0, source: "primary" as const })),
+      completeFn: mock(async () => ({ output: diagnosisOutput, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 })),
     });
 
     _rectificationDeps.agentManager = mockManager as any;


### PR DESCRIPTION
## Summary

- Replaces the ad-hoc `costUsd`/`source` pair on `CompleteResult` with the same three-field cost shape `TurnResult` already uses: `tokenUsage`, `estimatedCostUsd`, `exactCostUsd?`
- `complete()` in the ACP adapter now unconditionally computes both cost fields before returning (same pattern as `sendTurn`), instead of branching into three differently-shaped returns
- Adds `estimatedCostUsd?` to `DispatchEventBase` so complete dispatch events carry the token-derived estimate through to the cost middleware
- Fixes a silent bug in `cost.ts` middleware: `estimatedCostUsd = exactCostUsd ?? 0` was zeroing token-based estimates when no exact wire cost was present — now reads `event.estimatedCostUsd` directly

## Files changed

- `src/agents/types.ts` — `CompleteResult` interface
- `src/agents/acp/adapter.ts` — `complete()` return shape
- `src/agents/manager.ts` — `completeWithFallback` + `completeAs` dispatch event
- `src/debate/session-helpers.ts` — resolver cost reads
- `src/runtime/dispatch-events.ts` — `DispatchEventBase.estimatedCostUsd`
- `src/runtime/middleware/cost.ts` — cost subscriber fix
- 38 test files — mock shapes + `resolvers.test.ts` assertions

## Test plan

- [ ] `bun run typecheck` — clean (verified pre-commit)
- [ ] `bun run lint` — clean (verified pre-commit)
- [ ] `bun run test` on the affected unit suites: `agents/manager*`, `debate/resolvers`, `debate/runner*`, `operations/call`
- [ ] Confirm cost middleware records non-zero `estimatedCostUsd` for token-only complete() calls (no `exactCostUsd` on wire)