### PR TITLE
fix(prompts): use resolved test patterns in adversarial/debate review prompts

### DIFF
--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -55,6 +55,11 @@ export interface ResolverContext {
   storyGitRef?: string;
   /** Git diff --stat summary (ref mode) */
   stat?: string;
+  /**
+   * Ref-mode production diff excludes derived from resolveTestFilePatterns().
+   * Used to avoid hardcoded language-specific test file patterns in debate prompts.
+   */
+  productionExcludePatterns?: readonly string[];
   story: { id: string; title: string; acceptanceCriteria: string[] };
   semanticConfig: import("../review/types").SemanticReviewConfig;
   labeledProposals: Array<{ debater: string; output: string }>;
@@ -227,7 +232,12 @@ export async function resolveOutcome(
       // Build diffContext from resolverContext — discriminated on diffMode.
       const diffContext: import("../review/types").DiffContext =
         resolverContext.diffMode === "ref"
-          ? { mode: "ref", storyGitRef: resolverContext.storyGitRef ?? "", stat: resolverContext.stat }
+          ? {
+              mode: "ref",
+              storyGitRef: resolverContext.storyGitRef ?? "",
+              stat: resolverContext.stat,
+              productionExcludePatterns: resolverContext.productionExcludePatterns,
+            }
           : { mode: "embedded", diff: resolverContext.diff ?? "" };
 
       let dialogueResult: import("../review/dialogue").ReviewDialogueResult;

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -21,7 +21,9 @@ export interface AdversarialReviewInput {
   stat?: string;
   priorFailures?: PriorFailure[];
   testInventory?: TestInventory;
+  testGlobs?: readonly string[];
   excludePatterns?: string[];
+  refExcludePatterns?: readonly string[];
   /** Pre-built, role-filtered context prefix to prepend to the review prompt. */
   featureCtxBlock?: string;
   /** Prior adversarial findings to carry forward into this review round (issue #736). */
@@ -86,6 +88,8 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
         priorFailures: input.priorFailures,
         testInventory: input.testInventory,
         excludePatterns: input.excludePatterns,
+        testGlobs: input.testGlobs,
+        refExcludePatterns: input.refExcludePatterns,
         priorAdversarialFindings: input.priorAdversarialFindings,
       },
     );

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -149,9 +149,11 @@ function buildAdversarialRefDiffSection(
   testGlobs: readonly string[] = [],
   refExcludePatterns: readonly string[] = [],
 ): string {
-  const merged = [...new Set([...excludePatterns, ":!.nax/", ":!.nax-pids"])];
+  const merged = [...new Set([...excludePatterns, ":!.nax/", ":!**/.nax/", ":!.nax-pids", ":!**/.nax-pids"])];
   const excludeArgs = merged.map((p) => `'${p}'`).join(" ");
-  const productionExcludes = [...new Set([...refExcludePatterns, ":!.nax/", ":!.nax-pids"])];
+  const productionExcludes = [
+    ...new Set([...refExcludePatterns, ":!.nax/", ":!**/.nax/", ":!.nax-pids", ":!**/.nax-pids"]),
+  ];
   const productionExcludeArgs = productionExcludes.map((p) => `'${p}'`).join(" ");
   const statBlock = stat ? `## Changed Files Summary\n\n\`\`\`\n${stat}\n\`\`\`\n\n` : "";
   const testPatternGuide =

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -35,12 +35,19 @@ export interface AdversarialReviewPromptOptions {
   priorFailures?: PriorFailure[];
   /** Used when mode === "embedded": pre-computed test file audit */
   testInventory?: TestInventory;
+  /** Project test file globs resolved by resolveTestFilePatterns(). */
+  testGlobs?: readonly string[];
   /**
    * Pathspec exclusions for mode === "ref" git commands shown in prompt.
    * Always merged with ':!.nax/' and ':!.nax-pids'.
    * Adversarial does NOT exclude test files (unlike semantic).
    */
   excludePatterns?: string[];
+  /**
+   * Production-diff excludes derived from resolveReviewExcludePatterns().
+   * Used for test-audit instructions in ref mode.
+   */
+  refExcludePatterns?: readonly string[];
   /**
    * Prior adversarial findings from the previous round (issue #736).
    * When set, injects a "## Prior Adversarial Findings" block instructing the reviewer
@@ -83,7 +90,7 @@ What did the implementer accept but not actually use?
 
 ### 4. Test Audit Gap
 What new exported units lack corresponding test files?
-- New \`src/foo/bar.ts\` with exports but no \`test/**/bar.test.ts\`
+- New source modules with exports but no matching test file
 - New public functions that only appear in implementation, not in tests
 - Acceptance criteria that touch a code path with no test coverage
 
@@ -135,10 +142,22 @@ Severity guide:
  * Instructs the reviewer to self-serve the full diff (including tests) via git commands.
  * Always excludes .nax/ and .nax-pids metadata paths; test files are included.
  */
-function buildAdversarialRefDiffSection(storyGitRef: string, stat?: string, excludePatterns: string[] = []): string {
+function buildAdversarialRefDiffSection(
+  storyGitRef: string,
+  stat?: string,
+  excludePatterns: string[] = [],
+  testGlobs: readonly string[] = [],
+  refExcludePatterns: readonly string[] = [],
+): string {
   const merged = [...new Set([...excludePatterns, ":!.nax/", ":!.nax-pids"])];
   const excludeArgs = merged.map((p) => `'${p}'`).join(" ");
+  const productionExcludes = [...new Set([...refExcludePatterns, ":!.nax/", ":!.nax-pids"])];
+  const productionExcludeArgs = productionExcludes.map((p) => `'${p}'`).join(" ");
   const statBlock = stat ? `## Changed Files Summary\n\n\`\`\`\n${stat}\n\`\`\`\n\n` : "";
+  const testPatternGuide =
+    testGlobs.length > 0
+      ? testGlobs.map((glob) => `\`${glob}\``).join(", ")
+      : "the resolved project test-file patterns";
 
   return `${statBlock}## Diff Access
 
@@ -164,8 +183,10 @@ cat path/to/file.ts
 
 **Test audit workflow:**
 1. Run: \`git diff --name-only --diff-filter=A ${storyGitRef}..HEAD -- . ${excludeArgs}\`
-2. For each new \`src/**.ts\` file, check whether a matching \`test/**/**.test.ts\` was also added.
+2. For each new source file, check whether a matching test file was added (patterns: ${testPatternGuide}).
 3. If a new exported module has no test file, flag it as \`"test-gap"\`.
+4. To focus only on production deltas while auditing test coverage, run:
+  \`git diff --unified=3 ${storyGitRef}..HEAD -- . ${productionExcludeArgs}\`
 
 `;
 }
@@ -233,8 +254,18 @@ export class AdversarialReviewPromptBuilder {
     config: AdversarialReviewConfig,
     options: AdversarialReviewPromptOptions,
   ): string {
-    const { mode, diff, storyGitRef, stat, priorFailures, testInventory, excludePatterns, priorAdversarialFindings } =
-      options;
+    const {
+      mode,
+      diff,
+      storyGitRef,
+      stat,
+      priorFailures,
+      testInventory,
+      excludePatterns,
+      testGlobs,
+      refExcludePatterns,
+      priorAdversarialFindings,
+    } = options;
 
     const priorFindingsBlock =
       priorAdversarialFindings && priorAdversarialFindings.findings.length > 0
@@ -261,7 +292,13 @@ ${story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n")}
 
     let diffBlock: string;
     if (mode === "ref" && storyGitRef) {
-      diffBlock = buildAdversarialRefDiffSection(storyGitRef, stat, excludePatterns ?? []);
+      diffBlock = buildAdversarialRefDiffSection(
+        storyGitRef,
+        stat,
+        excludePatterns ?? [],
+        testGlobs ?? [],
+        refExcludePatterns ?? [],
+      );
     } else if (mode === "embedded" && diff) {
       diffBlock = buildAdversarialEmbeddedDiffSection(diff, testInventory);
     } else {

--- a/src/prompts/builders/debate-builder.ts
+++ b/src/prompts/builders/debate-builder.ts
@@ -417,6 +417,8 @@ function buildDebateDiffSection(ctx: DiffContext): string {
     // ref mode: reviewer self-serves the full diff via tools
     const stat = ctx.stat ?? "(no stat available)";
     const ref = ctx.storyGitRef;
+    const excludes = [...new Set([...(ctx.productionExcludePatterns ?? []), ":!.nax/", ":!.nax-pids"])];
+    const excludeArgs = excludes.map((p) => `'${p}'`).join(" ");
     return [
       "## Changed Files",
       "```",
@@ -427,7 +429,7 @@ function buildDebateDiffSection(ctx: DiffContext): string {
       "",
       "To inspect the implementation:",
       `- Full diff: \`git diff --unified=3 ${ref}..HEAD\``,
-      `- Production diff: \`git diff --unified=3 ${ref}..HEAD -- . ':!test/' ':!tests/' ':!*.test.ts' ':!*.spec.ts' ':!.nax/' ':!.nax-pids'\``,
+      `- Production diff: \`git diff --unified=3 ${ref}..HEAD -- . ${excludeArgs}\``,
       `- Commit history: \`git log --oneline ${ref}..HEAD\``,
       "",
       "Use these commands to inspect the code. Do NOT rely solely on the file list above.",

--- a/src/prompts/builders/debate-builder.ts
+++ b/src/prompts/builders/debate-builder.ts
@@ -417,7 +417,9 @@ function buildDebateDiffSection(ctx: DiffContext): string {
     // ref mode: reviewer self-serves the full diff via tools
     const stat = ctx.stat ?? "(no stat available)";
     const ref = ctx.storyGitRef;
-    const excludes = [...new Set([...(ctx.productionExcludePatterns ?? []), ":!.nax/", ":!.nax-pids"])];
+    const excludes = [
+      ...new Set([...(ctx.productionExcludePatterns ?? []), ":!.nax/", ":!**/.nax/", ":!.nax-pids", ":!**/.nax-pids"]),
+    ];
     const excludeArgs = excludes.map((p) => `'${p}'`).join(" ");
     return [
       "## Changed Files",

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -13,13 +13,16 @@
  *   - Findings carry a `category` field (input, error-path, abandonment, etc.).
  */
 
+import { relative, sep } from "node:path";
 import type { IAgentManager } from "../agents";
+import { DEFAULT_CONFIG, reviewConfigSelector } from "../config";
 import type { ReviewConfig } from "../config/selectors";
 import { filterContextByRole } from "../context";
 import { NaxError } from "../errors";
 import { getSafeLogger } from "../logger";
 import { adversarialReviewOp } from "../operations/adversarial-review";
 import { callOp as _callOp } from "../operations/call";
+import { resolveReviewExcludePatterns, resolveTestFilePatterns } from "../test-runners";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
 import {
   type AdversarialLLMFinding,
@@ -152,6 +155,23 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
 
   let diff: string | undefined;
   let testInventory: import("./diff-utils").TestInventory | undefined;
+  const effectiveConfig = naxConfig ?? reviewConfigSelector.select(DEFAULT_CONFIG);
+  const packageDirRelative =
+    projectDir && workdir !== projectDir
+      ? (() => {
+          const rel = relative(projectDir, workdir);
+          if (rel === ".." || rel.startsWith(`..${sep}`)) return undefined;
+          return rel && rel !== "." ? rel : undefined;
+        })()
+      : undefined;
+  const resolvedTestPatterns = await resolveTestFilePatterns(
+    effectiveConfig,
+    projectDir ?? workdir,
+    packageDirRelative,
+  );
+  const effectiveRefExcludePatterns = [
+    ...resolveReviewExcludePatterns(adversarialConfig.excludePatterns, resolvedTestPatterns),
+  ];
 
   if (diffMode === "embedded") {
     // Adversarial embedded mode: excludes .nax/ metadata but sees test files (unlike semantic).
@@ -245,9 +265,11 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       priorFailures,
       testInventory,
       excludePatterns: adversarialConfig.excludePatterns,
+      testGlobs: resolvedTestPatterns.globs,
       featureCtxBlock,
       priorAdversarialFindings,
       blockingThreshold,
+      refExcludePatterns: effectiveRefExcludePatterns,
     });
   } catch (err) {
     logger?.warn("adversarial", "LLM call failed — fail-open", { storyId: story.id, cause: String(err) });

--- a/src/review/semantic-debate.ts
+++ b/src/review/semantic-debate.ts
@@ -62,6 +62,7 @@ export interface SemanticDebateOptions {
   effectiveRef: string;
   startTime: number;
   prompt: string;
+  productionExcludePatterns: readonly string[];
   blockingThreshold: "error" | "warning" | "info" | undefined;
   createDebateRunner: (opts: DebateRunnerOptions) => DebateRunner;
 }
@@ -82,6 +83,7 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
     effectiveRef,
     startTime,
     prompt,
+    productionExcludePatterns,
     blockingThreshold,
     createDebateRunner,
   } = opts;
@@ -129,7 +131,7 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
     resolverContextInput: resolverSession
       ? {
           diffMode,
-          ...(diffMode === "ref" ? { storyGitRef: effectiveRef, stat } : { diff }),
+          ...(diffMode === "ref" ? { storyGitRef: effectiveRef, stat, productionExcludePatterns } : { diff }),
           story: { id: story.id, title: story.title, acceptanceCriteria: story.acceptanceCriteria },
           semanticConfig,
           resolverType: reviewStageConfig.resolver.type,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -7,6 +7,7 @@
  * is handled by lint/typecheck, not semantic review.
  */
 
+import { relative, sep } from "node:path";
 import type { IAgentManager } from "../agents";
 import { DEFAULT_CONFIG, reviewConfigSelector } from "../config";
 import type { NaxConfig } from "../config";
@@ -154,7 +155,19 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
 
   // ADR-009: resolve effective exclude patterns from config (falls back to DEFAULT_TEST_FILE_PATTERNS
   // when semanticConfig.excludePatterns is undefined — no behaviour change for default config).
-  const resolved = await resolveTestFilePatterns(naxConfig ?? reviewConfigSelector.select(DEFAULT_CONFIG), workdir);
+  const packageDirRelative =
+    projectDir && workdir !== projectDir
+      ? (() => {
+          const rel = relative(projectDir, workdir);
+          if (rel === ".." || rel.startsWith(`..${sep}`)) return undefined;
+          return rel && rel !== "." ? rel : undefined;
+        })()
+      : undefined;
+  const resolved = await resolveTestFilePatterns(
+    naxConfig ?? reviewConfigSelector.select(DEFAULT_CONFIG),
+    projectDir ?? workdir,
+    packageDirRelative,
+  );
   const excludePatterns = [...resolveReviewExcludePatterns(semanticConfig.excludePatterns, resolved)];
 
   let diff: string | undefined;
@@ -259,6 +272,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       effectiveRef,
       startTime,
       prompt,
+      productionExcludePatterns: excludePatterns,
       blockingThreshold,
       createDebateRunner: _semanticDeps.createDebateRunner,
     });

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -14,7 +14,17 @@ export type ReviewCheckName = "typecheck" | "lint" | "test" | "build" | "semanti
  */
 export type DiffContext =
   | { mode: "embedded"; diff: string; storyGitRef?: never; stat?: never }
-  | { mode: "ref"; storyGitRef: string; stat?: string; diff?: never };
+  | {
+      mode: "ref";
+      storyGitRef: string;
+      stat?: string;
+      diff?: never;
+      /**
+       * Production-diff exclude pathspec derived from resolveTestFilePatterns() +
+       * resolveReviewExcludePatterns(). Used by debate resolver prompts.
+       */
+      productionExcludePatterns?: readonly string[];
+    };
 
 /** Story fields required for semantic review */
 export interface SemanticStory {

--- a/test/unit/debate/prompt-builder.test.ts
+++ b/test/unit/debate/prompt-builder.test.ts
@@ -492,6 +492,46 @@ describe("buildResolverPrompt()", () => {
     expect(prompt).toContain(DIFF);
   });
 
+  test("ref mode production diff uses provided exclusion pathspec", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const builder = makeBuilder();
+    const prompt = builder.buildResolverPrompt(
+      LABELED_PROPOSALS,
+      CRITIQUES_STRINGS,
+      {
+        mode: "ref" as const,
+        storyGitRef: "abc123",
+        stat: "1 file changed",
+        productionExcludePatterns: [":!*_test.go", ":!tests/test_*.py"],
+      },
+      REVIEW_STORY,
+      ctx,
+    );
+
+    expect(prompt).toContain(":!*_test.go");
+    expect(prompt).toContain(":!tests/test_*.py");
+  });
+
+  test("ref mode production diff omits hardcoded TypeScript exclusion literals", () => {
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const builder = makeBuilder();
+    const prompt = builder.buildResolverPrompt(
+      LABELED_PROPOSALS,
+      CRITIQUES_STRINGS,
+      {
+        mode: "ref" as const,
+        storyGitRef: "abc123",
+        stat: "1 file changed",
+        productionExcludePatterns: [":!*_test.go"],
+      },
+      REVIEW_STORY,
+      ctx,
+    );
+
+    expect(prompt).not.toContain(":!*.test.ts");
+    expect(prompt).not.toContain(":!*.spec.ts");
+  });
+
   test("includes acceptance criteria", () => {
     const ctx: DebateResolverContext = { resolverType: "synthesis" };
     const builder = makeBuilder();

--- a/test/unit/prompts/adversarial-review-builder.test.ts
+++ b/test/unit/prompts/adversarial-review-builder.test.ts
@@ -113,6 +113,31 @@ describe("AdversarialReviewPromptBuilder — ref mode", () => {
 
     expect(result).not.toContain("Changed Files Summary");
   });
+
+  test("ref mode uses resolver-provided test patterns in test-audit workflow", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      testGlobs: ["**/*_test.go", "tests/test_*.py"],
+      refExcludePatterns: [":!*_test.go", ":!tests/test_*.py"],
+    });
+
+    expect(result).toContain("**/*_test.go");
+    expect(result).toContain("tests/test_*.py");
+    expect(result).toContain(":!*_test.go");
+  });
+
+  test("ref mode does not include hardcoded TypeScript test layout literals", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      testGlobs: ["**/*_test.go"],
+      refExcludePatterns: [":!*_test.go"],
+    });
+
+    expect(result).not.toContain("src/**.ts");
+    expect(result).not.toContain("test/**/**.test.ts");
+  });
 });
 
 // ─── embedded mode ────────────────────────────────────────────────────────────

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -227,6 +227,41 @@ describe("runAdversarialReview — JSON retry outcomes", () => {
     expect(result.findings![0].ruleId).toBe("adversarial");
   });
 
+  test("passes resolver-derived testGlobs and refExcludePatterns to callOp input", async () => {
+    const callOpMock = mock(async () => ({
+      passed: true,
+      findings: [],
+    }));
+    _adversarialDeps.callOp = callOpMock;
+
+    const agentManager = makeAgentManager(PASSING_RESPONSE);
+    const runtime = makeMockRuntime({ agentManager });
+
+    await runAdversarialReview({
+      workdir: "/tmp/wd",
+      storyGitRef: "abc123",
+      story: STORY,
+      adversarialConfig: { ...ADVERSARIAL_CONFIG, excludePatterns: undefined },
+      agentManager,
+      runtime,
+    });
+
+    expect(callOpMock).toHaveBeenCalledTimes(1);
+    const input = (callOpMock.mock.calls[0] as unknown[])[2] as {
+      testGlobs?: readonly string[];
+      refExcludePatterns?: readonly string[];
+    };
+
+    expect((input.testGlobs ?? []).length).toBeGreaterThan(0);
+    expect((input.testGlobs ?? []).some((glob) => glob.includes(".test.ts"))).toBe(true);
+
+    expect((input.refExcludePatterns ?? []).length).toBeGreaterThan(0);
+    expect(input.refExcludePatterns).toContain(":!*.test.ts");
+    expect(input.refExcludePatterns).toContain(":!*.spec.ts");
+    expect(input.refExcludePatterns).toContain(":!.nax/");
+    expect(input.refExcludePatterns).toContain(":!.nax-pids");
+  });
+
   test("returns fail-open when callOp throws", async () => {
     _adversarialDeps.callOp = mock(async () => { throw new Error("LLM call failed"); });
     const agentManager = makeAgentManager(PASSING_RESPONSE);

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -277,6 +277,42 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     expect(_semanticDeps.createDebateRunner).toHaveBeenCalled();
   });
 
+  test("ref mode + resolverSession threads productionExcludePatterns into resolverContextInput", async () => {
+    const runMock = mock(async () => DEBATE_MAJORITY_PASS_RESULT);
+    const createDebateRunnerMock = mock(() => ({ run: runMock }));
+    _semanticDeps.createDebateRunner = createDebateRunnerMock as unknown as typeof _semanticDeps.createDebateRunner;
+
+    const agentManager = makeAgentManager(PROPOSAL_PASS);
+    const runtime = makeMockRuntime({ agentManager });
+    const resolverSession = { history: [] } as unknown as import("../../../src/review/dialogue").ReviewerSession;
+
+    await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: { ...SEMANTIC_CONFIG, diffMode: "ref", excludePatterns: undefined },
+      agentManager,
+      naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+      runtime,
+      resolverSession,
+    });
+
+    expect(createDebateRunnerMock).toHaveBeenCalledTimes(1);
+    const [opts] = createDebateRunnerMock.mock.calls[0] as [
+      {
+        resolverContextInput?: {
+          productionExcludePatterns?: readonly string[];
+        };
+      },
+    ];
+    const excludes = opts.resolverContextInput?.productionExcludePatterns ?? [];
+    expect(excludes.length).toBeGreaterThan(0);
+    expect(excludes).toContain(":!test/");
+    expect(excludes).toContain(":!*.test.ts");
+    expect(excludes).toContain(":!.nax/");
+    expect(excludes).toContain(":!.nax-pids");
+  });
+
   test("AC3: DebateSession.run() is called with the semantic review prompt", async () => {
     const runMock = mock(async (_prompt: string) => DEBATE_MAJORITY_PASS_RESULT);
     _semanticDeps.createDebateRunner = mock(() => ({ run: runMock })) as unknown as typeof _semanticDeps.createDebateRunner;


### PR DESCRIPTION
## Summary
- remove hardcoded TypeScript test pattern guidance from adversarial and debate prompt builders
- thread resolver-derived test pattern data through review/debate plumbing
- make ref-mode debate production diff command use dynamic excludes instead of TS literals
- add wiring-level unit tests for semantic debate and adversarial callOp propagation

## Implementation details
- extend debate/ref diff context with productionExcludePatterns
- propagate ref excludes through semantic -> semantic-debate -> session-helpers -> debate prompt builder
- resolve test patterns in adversarial review and pass testGlobs + refExcludePatterns into adversarial prompt op
- harden package-dir relative-path derivation for resolver calls to avoid out-of-repo .. segments

## Validation
- bun run lint
- bun run typecheck
- bun run test
- targeted tests:
  - test/unit/prompts/adversarial-review-builder.test.ts
  - test/unit/debate/prompt-builder.test.ts
  - test/unit/review/semantic-debate.test.ts
  - test/unit/review/adversarial-retry.test.ts

Closes #813