### PR TITLE
feat(findings): introduce Finding wire-format type (ADR-021 phase 1)

### DIFF
--- a/docs/adr/ADR-021-findings-and-fix-strategy-ssot.md
+++ b/docs/adr/ADR-021-findings-and-fix-strategy-ssot.md
@@ -1,0 +1,200 @@
+# ADR-021: Finding Type SSOT
+
+**Status:** Proposed
+**Date:** 2026-05-02
+**Author:** William Khoo, Claude
+**Supersedes:** —
+**Related:** ADR-022 (Fix Strategy + Cycle Orchestration — companion ADR built on this type)
+
+---
+
+## Context
+
+Five subsystems each carry their own "thing that's wrong" type:
+
+| Subsystem | Type | Defined at |
+|:---|:---|:---|
+| Plugin reviewers | `ReviewFinding` | [src/plugins/extensions.ts:20](../../src/plugins/extensions.ts#L20) |
+| LLM reviewers (semantic, adversarial) | `LlmReviewFinding` | [src/operations/types.ts:171](../../src/operations/types.ts#L171) |
+| Adversarial review carry-forward | `AdversarialFindingsCache.findings[]` | [src/review/types.ts:171](../../src/review/types.ts#L171) |
+| Semantic review verdict | `SemanticVerdict.findings: ReviewFinding[]` | [src/acceptance/types.ts:139](../../src/acceptance/types.ts#L139) |
+| Acceptance diagnosis | `DiagnosisResult.{testIssues, sourceIssues}: string[]` | [src/acceptance/types.ts:153](../../src/acceptance/types.ts#L153) |
+
+The shapes are siblings — same fields with different names — and the unstructured `string[]` in acceptance carries no category, no file/line, no fixTarget. This blocks structured prior-attempt history (the falsified-hypothesis pattern that adversarial review already uses) and prevents cross-stage finding aggregation.
+
+ADR-021's scope is **types only**. The orchestration questions (cycle, strategies, validator coupling, verdict fast-paths) are deliberately deferred to ADR-022 because they require design decisions that can be made independently of the wire format.
+
+## Decision
+
+### 1. Single `Finding` type
+
+```typescript
+type FindingSource =
+  | "lint"
+  | "typecheck"
+  | "test-runner"
+  | "semantic-review"
+  | "adversarial-review"
+  | "acceptance-diagnose"
+  | "tdd-verifier"
+  | "plugin";
+
+type FindingSeverity = "critical" | "error" | "warning" | "info" | "low" | "unverifiable";
+
+type FixTarget = "source" | "test";
+
+type DiagnosisCategory =
+  | "stdout-capture"
+  | "ac-mismatch"
+  | "framework-misuse"
+  | "missing-impl"
+  | "import-path"
+  | "hook-failure"          // AC-HOOK sentinel — beforeAll / afterAll timeout
+  | "test-runner-error"     // AC-ERROR sentinel — runner crashed before test bodies ran
+  | "stub-test"             // detected stub via isStubTestFile heuristic
+  | "other";
+
+interface Finding {
+  source: FindingSource;
+  tool?: string;                       // "biome" | "tsc" | "semgrep" | …
+  severity: FindingSeverity;
+  category: string;                    // free-form; per-source enum documented at producer
+  rule?: string;                       // biome rule id, TS code, AC id, etc.
+  file?: string;                       // ALWAYS repoRoot-relative — see §3
+  line?: number; column?: number; endLine?: number; endColumn?: number;
+  message: string;
+  suggestion?: string;
+  confidence?: number;                 // LLM producers only
+  fixTarget?: "source" | "test";       // optional; consumers derive from file when unset
+  meta?: Record<string, unknown>;      // producer-specific extras
+}
+```
+
+### 2. Severity standardises on `"warning"`
+
+Adversarial review's prompt schema currently emits `"warn"`. Migration is one schema change in [adversarial-review-builder.ts:128](../../src/prompts/builders/adversarial-review-builder.ts#L128). The read path is already covered by `normalizeSeverity()` adapters in [src/review/semantic-helpers.ts:55](../../src/review/semantic-helpers.ts#L55), [src/review/adversarial-helpers.ts](../../src/review/adversarial-helpers.ts), and [src/review/dialogue.ts](../../src/review/dialogue.ts) which already accept `"warn"` and emit `"warning"`. The downgrade-to-unverifiable path in [src/review/semantic-evidence.ts:101](../../src/review/semantic-evidence.ts#L101) is unaffected.
+
+`"unverifiable"` is preserved (adversarial-only today). `"low"` is preserved for plugin compatibility.
+
+### 3. File path SSOT — repoRoot-relative
+
+Every `Finding.file` is **relative to the repo root** (the directory containing `.nax/`). Not workdir-relative, not packageDir-relative, not absolute.
+
+Rationale:
+- The autofix routing layer in [splitFindingsByScope](../../src/pipeline/stages/autofix-scope-split.ts#L158) and [isTestFile](../../src/test-runners/) already operates on repoRoot-relative paths.
+- Cross-package finding aggregation (the long-term goal) requires a single repo-anchored coordinate system.
+- Tools that natively emit workdir-relative paths (biome, tsc, plugin reviewers) get one rebasing step at their adapter boundary — not scattered across consumers.
+
+Producer adapters are responsible for normalisation:
+
+| Producer | Native format | Adapter rebases to |
+|:---|:---|:---|
+| Biome JSON output | `cwd`-relative | `path.relative(repoRoot, resolve(cwd, file))` |
+| `tsc` `--pretty=false` | absolute | `path.relative(repoRoot, file)` |
+| `LlmReviewFinding` | LLM-emitted, often packageDir-relative | adapter resolves against story's `packageDir`, then rebases |
+| `ReviewFinding` (plugin) | workdir-relative per contract | `path.relative(repoRoot, resolve(workdir, file))` |
+| Acceptance diagnose | LLM-emitted; new prompt schema instructs repoRoot-relative explicitly | direct |
+
+The plugin contract (`ReviewFinding.file: workdir-relative`) is unchanged — only the internal `Finding` representation is normalised. Plugin authors are unaffected.
+
+### 4. Absorption table — existing types map cleanly
+
+| Source field | Target | Adapter rule |
+|:---|:---|:---|
+| `LlmReviewFinding.issue` | `Finding.message` | rename |
+| `LlmReviewFinding.acId` | `Finding.rule` | rename (semantic only) |
+| `LlmReviewFinding.verifiedBy` | `Finding.meta.verifiedBy` | demote |
+| `LlmReviewFinding.severity: "warn"` | `Finding.severity: "warning"` | rename via `normalizeSeverity` (already exists) |
+| `AdversarialFindingsCache.findings[].issue` | `Finding.message` | rename |
+| `AdversarialFindingsCache.findings[].severity: "warn"` | `Finding.severity: "warning"` | rename |
+| `ReviewFinding.ruleId` | `Finding.rule` | rename |
+| `ReviewFinding.source` (tool name) | `Finding.tool` | rename; top-level `source` becomes `"plugin"` |
+| `ReviewFinding.url` | `Finding.meta.url` | demote |
+| `DiagnosisResult.testIssues: string[]` | `Finding[]` with `fixTarget: "test"` | LLM prompt schema change (see §6) |
+| `DiagnosisResult.sourceIssues: string[]` | `Finding[]` with `fixTarget: "source"` | LLM prompt schema change |
+
+### 5. Acceptance sentinels become first-class findings
+
+`AC-HOOK` and `AC-ERROR` sentinels in [acceptance-loop.ts:90](../../src/execution/lifecycle/acceptance-loop.ts#L90) are currently special-cased in `failedACs: string[]`. They become `Finding[]` entries:
+
+```typescript
+{ source: "acceptance-diagnose", category: "hook-failure", severity: "error", message: "beforeAll timed out (8000ms)", file: <test-file>, fixTarget: "test" }
+{ source: "acceptance-diagnose", category: "test-runner-error", severity: "critical", message: "Bun test runner crashed before test bodies ran", fixTarget: "test" }
+```
+
+The orchestration layer (ADR-022) decides how to route these — that's deferred. Phase 2 of this ADR only requires producers to emit them as findings.
+
+### 6. Acceptance diagnose prompt schema change
+
+`acceptanceDiagnoseOp` ([src/operations/acceptance-diagnose.ts](../../src/operations/acceptance-diagnose.ts)) currently asks the LLM for `testIssues: string[]` and `sourceIssues: string[]`. The new schema asks for `findings: Finding[]` with `fixTarget` per item:
+
+```json
+{
+  "verdict": "source_bug" | "test_bug" | "both",
+  "reasoning": "...",
+  "confidence": 0.0–1.0,
+  "findings": [
+    {
+      "fixTarget": "source" | "test",
+      "category": "stdout-capture" | "ac-mismatch" | …,
+      "file": "src/greeting.ts",
+      "line": 12,
+      "message": "...",
+      "suggestion": "..."
+    }
+  ]
+}
+```
+
+The legacy `testIssues` / `sourceIssues` fields stay parseable for one release as a fallback (parser checks `findings` first; if absent, wraps each string as `Finding{ category: "legacy", message: <string> }` with `fixTarget` from which array it came from). `verdict` stays in the schema — see ADR-022 for why (fast-paths can produce a verdict without findings).
+
+Schema change ships behind `acceptance.fix.findingsV2` config flag, default off, for one release. Bench against `nax-dogfood/fixtures/hello-lint` audit fixtures with both modes.
+
+## Phased implementation
+
+| Phase | Files | Scope | Risk |
+|:---|:---|:---|:---|
+| **1. Types** | new `src/findings/{types,index}.ts` | `Finding`, enums, no consumers | zero |
+| **2. Producer adapters — mechanical** | `src/quality/lint-output-parser.ts`, typecheck parser | Emit `Finding[]` alongside existing return shape (additive, non-breaking) | low |
+| **3. Producer adapters — LLM** | `src/operations/{semantic-review,adversarial-review,acceptance-diagnose}.ts` | Same — additive emission | medium (acceptance prompt schema, behind flag) |
+| **4. Severity rename** | adversarial prompt schema | One-line rename in OUTPUT_SCHEMA block | low |
+| **5. File-path normalisation** | each producer adapter | `path.relative(repoRoot, …)` at the boundary | low |
+| **6. Cleanup** | delete `LlmReviewFinding`, `AdversarialFindingsCache`, `DiagnosisResult.{testIssues,sourceIssues}` | After ADR-022's consumers migrate | zero |
+
+Phases 1–5 ship without ADR-022. Phase 6 is gated on ADR-022 phase completion.
+
+## Consequences
+
+### Positive
+
+- Producers emit a single shape; cross-stage aggregation becomes trivial.
+- Acceptance sentinels (`AC-HOOK`, `AC-ERROR`) become structured — orchestration in ADR-022 can route them like any other finding.
+- The severity rename (`"warn"` → `"warning"`) is much smaller than initially estimated thanks to existing `normalizeSeverity` adapters.
+- File-path SSOT decision unblocks cross-package finding aggregation (issue-level reporting, dashboards).
+
+### Negative
+
+- Producers each gain a thin adapter at their boundary. ~6 adapters total, ~30 lines each.
+- The acceptance diagnose prompt schema change requires a soak period and a feature flag.
+
+### Neutral
+
+- Plugin contract (`ReviewFinding`) is preserved as-is. Internal normalisation happens at the adapter boundary.
+
+## What this ADR explicitly does not decide
+
+- How findings are consumed by fix orchestration (cycle / strategies / validator coupling) — see ADR-022.
+- Whether `verdict` stays on `DiagnosisResult` or is derived — see ADR-022.
+- How prior attempts are carried forward in prompts (`buildPriorIterationsBlock`) — see ADR-022.
+- How `stubRegenCount` and acceptance fast-paths integrate with strategies — see ADR-022.
+
+This split lets the type migration ship and bake while orchestration design iterates.
+
+## References
+
+- [src/plugins/extensions.ts:20](../../src/plugins/extensions.ts#L20) — `ReviewFinding` (plugin contract; preserved as-is)
+- [src/operations/types.ts:171](../../src/operations/types.ts#L171) — `LlmReviewFinding` (deprecated by phase 6)
+- [src/review/types.ts:171](../../src/review/types.ts#L171) — `AdversarialFindingsCache` (deprecated by phase 6)
+- [src/acceptance/types.ts:153](../../src/acceptance/types.ts#L153) — `DiagnosisResult` (legacy fields deprecated by phase 6)
+- [src/review/semantic-helpers.ts:55](../../src/review/semantic-helpers.ts#L55) — `normalizeSeverity` (read-path adapter for severity rename)
+- ADR-022 — Fix Strategy + Cycle Orchestration (companion ADR)

--- a/docs/adr/ADR-021-findings-and-fix-strategy-ssot.md
+++ b/docs/adr/ADR-021-findings-and-fix-strategy-ssot.md
@@ -76,26 +76,26 @@ Adversarial review's prompt schema currently emits `"warn"`. Migration is one sc
 
 `"unverifiable"` is preserved (adversarial-only today). `"low"` is preserved for plugin compatibility.
 
-### 3. File path SSOT — repoRoot-relative
+### 3. File path SSOT — relative to nax's workdir
 
-Every `Finding.file` is **relative to the repo root** (the directory containing `.nax/`). Not workdir-relative, not packageDir-relative, not absolute.
+Every `Finding.file` is **relative to nax's workdir** — the directory where `.nax/` lives and where nax is invoked. In single-package projects this is the project root; in monorepos with per-package nax invocations this is the package directory (`packageDir`).
 
 Rationale:
-- The autofix routing layer in [splitFindingsByScope](../../src/pipeline/stages/autofix-scope-split.ts#L158) and [isTestFile](../../src/test-runners/) already operates on repoRoot-relative paths.
-- Cross-package finding aggregation (the long-term goal) requires a single repo-anchored coordinate system.
-- Tools that natively emit workdir-relative paths (biome, tsc, plugin reviewers) get one rebasing step at their adapter boundary — not scattered across consumers.
+- Matches the convention already used across nax for test-file pattern resolution, story workdirs, and review artifact paths (see [.claude/rules/monorepo-awareness.md](../../.claude/rules/monorepo-awareness.md)).
+- The autofix routing layer in [splitFindingsByScope](../../src/pipeline/stages/autofix-scope-split.ts#L158) and [isTestFile](../../src/test-runners/) already operates on workdir-relative paths.
+- Plugin contract (`ReviewFinding.file: workdir-relative`) uses the same convention — no rebasing needed at the boundary.
 
 Producer adapters are responsible for normalisation:
 
 | Producer | Native format | Adapter rebases to |
 |:---|:---|:---|
-| Biome JSON output | `cwd`-relative | `path.relative(repoRoot, resolve(cwd, file))` |
-| `tsc` `--pretty=false` | absolute | `path.relative(repoRoot, file)` |
-| `LlmReviewFinding` | LLM-emitted, often packageDir-relative | adapter resolves against story's `packageDir`, then rebases |
-| `ReviewFinding` (plugin) | workdir-relative per contract | `path.relative(repoRoot, resolve(workdir, file))` |
-| Acceptance diagnose | LLM-emitted; new prompt schema instructs repoRoot-relative explicitly | direct |
+| Biome JSON output | `cwd`-relative | `path.relative(workdir, resolve(cwd, file))` |
+| `tsc` `--pretty=false` | absolute | `path.relative(workdir, file)` |
+| `LlmReviewFinding` | LLM-emitted | adapter resolves against the active workdir |
+| `ReviewFinding` (plugin) | workdir-relative per contract | direct (no rebasing) |
+| Acceptance diagnose | LLM-emitted; new prompt schema instructs workdir-relative | direct |
 
-The plugin contract (`ReviewFinding.file: workdir-relative`) is unchanged — only the internal `Finding` representation is normalised. Plugin authors are unaffected.
+**Cross-package aggregation** — when a future consumer needs to aggregate findings across multiple monorepo packages (e.g. an "all open findings on this branch" view), it must thread workdir context per finding-batch externally. `Finding.file` alone is ambiguous in that case. This is a consumer concern, deliberately not solved at the type layer.
 
 ### 4. Absorption table — existing types map cleanly
 
@@ -152,16 +152,23 @@ Schema change ships behind `acceptance.fix.findingsV2` config flag, default off,
 
 ## Phased implementation
 
-| Phase | Files | Scope | Risk |
-|:---|:---|:---|:---|
-| **1. Types** | new `src/findings/{types,index}.ts` | `Finding`, enums, no consumers | zero |
-| **2. Producer adapters — mechanical** | `src/quality/lint-output-parser.ts`, typecheck parser | Emit `Finding[]` alongside existing return shape (additive, non-breaking) | low |
-| **3. Producer adapters — LLM** | `src/operations/{semantic-review,adversarial-review,acceptance-diagnose}.ts` | Same — additive emission | medium (acceptance prompt schema, behind flag) |
-| **4. Severity rename** | adversarial prompt schema | One-line rename in OUTPUT_SCHEMA block | low |
-| **5. File-path normalisation** | each producer adapter | `path.relative(repoRoot, …)` at the boundary | low |
-| **6. Cleanup** | delete `LlmReviewFinding`, `AdversarialFindingsCache`, `DiagnosisResult.{testIssues,sourceIssues}` | After ADR-022's consumers migrate | zero |
+Each phase after phase 1 is a **fold-per-producer** PR — the producer's adapter migration AND its direct consumers ship together. This avoids the "additive emission of unread `Finding[]`" interval that an earlier draft proposed and ensures every PR is a complete, reviewable unit.
 
-Phases 1–5 ship without ADR-022. Phase 6 is gated on ADR-022 phase completion.
+| Phase | Producer | Direct consumer(s) updated in same PR | Notes |
+|:---|:---|:---|:---|
+| **1. Types** | — | — | This PR. `src/findings/{types,index}.ts`. Zero consumers. |
+| **2. Plugin adapter** | `IReviewPlugin` boundary | `failedChecks` aggregator in autofix; review-result audit serialiser | Plugin contract (`ReviewFinding`) unchanged. Internal nax converts to `Finding` at the IReviewPlugin call site. |
+| **3. Lint** | Biome JSON parser | `splitFindingsByScope` lint branch; lint output rendering | Replaces raw output parsing. Mechanical, deterministic. |
+| **4. Typecheck** | tsc `--pretty=false` parser | `splitFindingsByScope` typecheck branch | Same shape change as lint. |
+| **5. TDD verifier** | TDD verifier output parser | Verifier verdict consumer | Small. User confirmed scope (item 7 in design discussion). |
+| **6. Adversarial** | `acceptanceDiagnoseOp` and the adversarial review op | `buildPriorFindingsBlock` reads `Finding[]`; `AdversarialFindingsCache.findings[]` becomes `Finding[]` | Severity rename `"warn"` → `"warning"` in OUTPUT_SCHEMA block lands here. Read-path `normalizeSeverity` adapters in `semantic-helpers.ts`/`adversarial-helpers.ts`/`dialogue.ts` already handle the rename. |
+| **7. Semantic** | semantic review op | `buildAttemptContextBlock`, `SemanticVerdict.findings`, semantic evidence verifier | `verifiedBy` → `meta.verifiedBy`; AC ID → `rule`. |
+| **8. Acceptance diagnose** | `acceptanceDiagnoseOp` prompt schema | `applyFix` consumes `findings: Finding[]` (with `fixTarget` per item) instead of `testIssues`/`sourceIssues`. AC-HOOK / AC-ERROR sentinels emitted as findings (§5). | Behind `acceptance.fix.findingsV2` flag, default off. Bench against `nax-dogfood/fixtures/hello-lint`. Largest behaviour change in the ADR; lands last to benefit from prior phases' patterns. |
+| **9. Cleanup** | — | delete `LlmReviewFinding`, `AdversarialFindingsCache`, `DiagnosisResult.{testIssues,sourceIssues}`, scaffolding adapters | Zero risk. |
+
+Phases 2–7 are unblocked by ADR-022. Phase 8 (acceptance) and the ADR-022 cycle can land in either order — they're independent. Phase 9 (cleanup) requires phase 8 done plus all ADR-022 consumer migrations done.
+
+**What ADR-022 owns** (orchestration, not data): cycle types (`Iteration`, `FixApplied`, `FixStrategy`), `runFixCycle`, `classifyOutcome`, the shared `buildPriorIterationsBlock` helper that replaces `buildPriorFindingsBlock` + `buildAttemptContextBlock` + acceptance's `previousFailure` accumulator. ADR-022 operates on `Finding[]` which already exists everywhere by the time it lands.
 
 ## Consequences
 

--- a/src/findings/index.ts
+++ b/src/findings/index.ts
@@ -16,3 +16,5 @@ export type {
   FindingSource,
   FixTarget,
 } from "./types";
+
+export { SEVERITY_ORDER, compareSeverity, findingKey } from "./types";

--- a/src/findings/index.ts
+++ b/src/findings/index.ts
@@ -1,0 +1,18 @@
+/**
+ * src/findings — unified Finding wire format.
+ *
+ * ADR-021 phase 1: types only, no behaviour. Producers migrate to emit
+ * Finding[] in subsequent phases.
+ *
+ * Orchestration (Iteration, FixApplied, FixStrategy, runFixCycle, …) lives
+ * in ADR-022 and will arrive in a separate file (e.g. cycle-types.ts) once
+ * that ADR's phase 1 PR begins. Consumers should import only the wire-format
+ * types from here for now.
+ */
+
+export type {
+  Finding,
+  FindingSeverity,
+  FindingSource,
+  FixTarget,
+} from "./types";

--- a/src/findings/types.ts
+++ b/src/findings/types.ts
@@ -110,18 +110,28 @@ export interface Finding {
   rule?: string;
 
   /**
-   * Path to the offending file, ALWAYS relative to the repo root (the
-   * directory containing `.nax/`). Producers normalise at their adapter
-   * boundary. See ADR-021 §3.
+   * Path to the offending file, ALWAYS relative to nax's workdir — the
+   * directory where `.nax/` lives and where nax is invoked. In single-package
+   * projects this is the project root; in monorepos with per-package nax
+   * invocations this is the package directory (`packageDir`). Matches the
+   * convention already used across nax for test-pattern resolution and
+   * review artifact paths (see `.claude/rules/monorepo-awareness.md`).
    *
-   * Optional — a finding may be repo-global (e.g. "package.json missing
-   * required script"). Plugin contract (ReviewFinding.file: workdir-relative)
-   * is preserved at the plugin boundary; only the internal Finding shape
-   * is normalised.
+   * Optional — a finding may be workdir-global (e.g. "package.json missing
+   * required script"). Plugin contract (`ReviewFinding.file: workdir-relative`)
+   * is preserved as-is; this field uses the same convention internally.
+   *
+   * Cross-package aggregation across multiple monorepo packages is the
+   * consumer's concern — they must thread workdir context per finding-batch.
    */
   file?: string;
   line?: number;
   column?: number;
+  /**
+   * Range end — 1-indexed, end-INCLUSIVE. Matches biome and tsc native
+   * output. For LSP-style consumers (0-indexed, end-exclusive), convert at
+   * the boundary.
+   */
   endLine?: number;
   endColumn?: number;
 
@@ -152,8 +162,69 @@ export interface Finding {
    * Producer-specific extras — semantic review's verifiedBy evidence,
    * raw tool output, AC text, TS span, etc.
    *
-   * Avoid putting load-bearing data here that downstream consumers must read.
-   * Prefer promoting frequently-used fields to first-class properties.
+   * **Read-only by convention** — this is for human inspection, debug
+   * dumps, and forensic logs. Consumers must NOT branch on `meta` fields
+   * for load-bearing logic; doing so couples consumers to producer
+   * internals and turns `meta` into an unenforced contract. When a meta
+   * field is being read by ≥2 consumers, promote it to a first-class
+   * property in a follow-up. The shape is `Record<string, unknown>` to
+   * make this discipline explicit at the type level — there's no
+   * compile-time help here, so reviewers must enforce it.
    */
   meta?: Record<string, unknown>;
+}
+
+// ─── Severity ordering ───────────────────────────────────────────────────────
+
+/**
+ * Total ordering on severities for threshold comparisons. Higher number =
+ * more severe. Consumers that need to filter by `blockingThreshold` should
+ * import this constant rather than hand-rolling order tables.
+ *
+ * Order rationale:
+ *   - critical (5)     hard production breakage; halts everything
+ *   - error    (4)     definite bug; matches `blockingThreshold: "error"`
+ *   - warning  (3)     fragile / incomplete; matches `blockingThreshold: "warning"`
+ *   - info     (2)     advisory; matches `blockingThreshold: "info"`
+ *   - low      (1)     plugin-compat; below info but still actionable
+ *   - unverifiable (0) suspect but unconfirmed; orthogonal to severity but
+ *                      placed lowest so threshold comparisons treat it as
+ *                      strictly advisory
+ */
+export const SEVERITY_ORDER: Readonly<Record<FindingSeverity, number>> = Object.freeze({
+  critical: 5,
+  error: 4,
+  warning: 3,
+  info: 2,
+  low: 1,
+  unverifiable: 0,
+});
+
+/**
+ * Compare two severities. Returns negative if a < b, zero if a === b,
+ * positive if a > b — same shape as `Array.prototype.sort` comparator.
+ */
+export function compareSeverity(a: FindingSeverity, b: FindingSeverity): number {
+  return SEVERITY_ORDER[a] - SEVERITY_ORDER[b];
+}
+
+// ─── Stable identity ─────────────────────────────────────────────────────────
+
+/**
+ * Stable string identity for a Finding — used by ADR-022's `classifyOutcome`
+ * to detect whether two iterations produced equivalent finding sets ("did
+ * the fix change anything?"). Also usable for deduplication and persistence.
+ *
+ * Key composition: `(source, file, line, rule, message)` JSON-serialised.
+ * Including `message` makes the key strict — LLM rephrasing of the same
+ * underlying issue produces a different key. This is the safe direction:
+ * over-counting "different findings" is fine because it conservatively
+ * classifies the iteration as "changed" rather than "unchanged"; the
+ * falsified-hypothesis detection only fires on truly identical output,
+ * which validator-emitted (deterministic tool) findings reliably produce.
+ *
+ * JSON.stringify is used to handle pipe-character collisions in messages.
+ */
+export function findingKey(f: Finding): string {
+  return JSON.stringify([f.source, f.file ?? null, f.line ?? null, f.rule ?? null, f.message]);
 }

--- a/src/findings/types.ts
+++ b/src/findings/types.ts
@@ -1,0 +1,159 @@
+/**
+ * Finding — structured representation of "something is wrong"
+ * shared across lint, typecheck, semantic review, adversarial review,
+ * acceptance diagnosis, and TDD verifier outputs.
+ *
+ * Designed as a strict superset of:
+ *   - src/plugins/extensions.ts ReviewFinding   (mechanical / plugin findings)
+ *   - src/operations/types.ts   LlmReviewFinding (LLM reviewer ops)
+ *   - src/acceptance/types.ts   DiagnosisResult.testIssues / sourceIssues (string-typed today)
+ *
+ * Producers convert to Finding[] at the boundary; the wire format is uniform
+ * regardless of subsystem. See ADR-021 §3 for the file-path SSOT decision and
+ * §4 for the field-by-field absorption table.
+ *
+ * This file holds ONLY the wire-format types (ADR-021 phase 1). Orchestration
+ * types (Iteration, FixApplied, FixStrategy, FixCycleResult, …) belong to
+ * ADR-022 and ship in a separate file when that ADR's phase 1 is implemented.
+ */
+
+/**
+ * Producer category. Sub-tools (e.g. "biome" under "lint") go in `tool`.
+ *
+ * Includes acceptance sentinels (AC-HOOK / AC-ERROR) — see ADR-021 §5. They
+ * are emitted by the acceptance-diagnose source with `category: "hook-failure"`
+ * or `"test-runner-error"`.
+ *
+ * "plugin" is reserved for IReviewPlugin output where the actual producer
+ * is identified by `tool`.
+ */
+export type FindingSource =
+  | "lint"
+  | "typecheck"
+  | "test-runner"
+  | "semantic-review"
+  | "adversarial-review"
+  | "acceptance-diagnose"
+  | "tdd-verifier"
+  | "plugin";
+
+/**
+ * Severity scale. Standardised on "warning" (not "warn") to align with
+ * ReviewFinding. Adversarial review currently emits "warn" — its OUTPUT_SCHEMA
+ * prompt block must rename when migrated (read-path normalizeSeverity adapters
+ * already exist; see ADR-021 §2).
+ *
+ * "unverifiable" (adversarial-only today) means "suspect but unconfirmed".
+ * "low" preserved for plugin compatibility.
+ */
+export type FindingSeverity = "critical" | "error" | "warning" | "info" | "low" | "unverifiable";
+
+/**
+ * Where a fix lands. Drives strategy selection in ADR-022's cycle layer.
+ *
+ * `fixTarget` reflects where the fix LANDS, not what produced the finding.
+ * A lint or typecheck finding on `foo.test.ts` has fixTarget="test" because
+ * the fix edits the test file. A semantic-review finding always lands in
+ * source code (tests are gospel for semantic). An adversarial test-gap
+ * finding is "test" — the fix adds a missing test file.
+ *
+ * Mechanical producers (lint, typecheck) typically leave this unset; the
+ * cycle layer derives it from the file path against the project's test-file
+ * patterns (resolveTestFilePatterns). LLM producers should tag explicitly
+ * when the file alone doesn't disambiguate.
+ */
+export type FixTarget = "source" | "test";
+
+/**
+ * Free-form category convention per source. Not a closed enum — each producer
+ * documents its own vocabulary. Listed below for the acceptance-diagnose
+ * source as a reference (other sources follow ReviewFinding's `category`
+ * convention or their own LLM-prompted enum).
+ *
+ * Acceptance-diagnose categories (ADR-021 §1):
+ *   - "stdout-capture"      — wrong stream captured (e.g. bun test → stderr)
+ *   - "ac-mismatch"         — assertion shape doesn't match AC text
+ *   - "framework-misuse"    — wrong assertion API for the framework
+ *   - "missing-impl"        — source code missing required behaviour
+ *   - "import-path"         — wrong relative path / module resolution
+ *   - "hook-failure"        — beforeAll / afterAll timeout (AC-HOOK sentinel)
+ *   - "test-runner-error"   — runner crashed before test bodies (AC-ERROR sentinel)
+ *   - "stub-test"           — detected stub via isStubTestFile heuristic
+ *   - "other"
+ *
+ * Adversarial categories (existing): "input" | "error-path" | "abandonment" |
+ * "test-gap" | "convention" | "assumption".
+ */
+export interface Finding {
+  /** Producer of this finding. */
+  source: FindingSource;
+
+  /**
+   * Tool sub-source — e.g. "biome" / "tsc" / "semgrep".
+   * Required when source is "lint", "typecheck", or "plugin".
+   */
+  tool?: string;
+
+  severity: FindingSeverity;
+
+  /**
+   * Free-form category. Each source documents its own enum (see top-of-file
+   * comment for acceptance-diagnose; ReviewFinding.category for plugins).
+   */
+  category: string;
+
+  /**
+   * Rule identifier — biome rule id, TS error code (TS2304), AC id (AC-2),
+   * or any stable handle the producer can attach. Optional because some
+   * findings (free-form LLM observations) genuinely have no rule.
+   */
+  rule?: string;
+
+  /**
+   * Path to the offending file, ALWAYS relative to the repo root (the
+   * directory containing `.nax/`). Producers normalise at their adapter
+   * boundary. See ADR-021 §3.
+   *
+   * Optional — a finding may be repo-global (e.g. "package.json missing
+   * required script"). Plugin contract (ReviewFinding.file: workdir-relative)
+   * is preserved at the plugin boundary; only the internal Finding shape
+   * is normalised.
+   */
+  file?: string;
+  line?: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+
+  /** Human-readable description of the issue. */
+  message: string;
+
+  /** Concrete fix or mitigation, when the producer can suggest one. */
+  suggestion?: string;
+
+  /**
+   * LLM producers only: 0..1 confidence in the finding. Mechanical producers
+   * (lint, typecheck) omit this — their findings are deterministic.
+   */
+  confidence?: number;
+
+  /**
+   * Where the fix lands. Set explicitly by LLM producers (acceptance-diagnose
+   * tags via its prompt; adversarial test-gap is always "test"). Mechanical
+   * producers (lint, typecheck) typically leave this unset — the cycle layer
+   * derives it from the file path against the project's test-file patterns.
+   *
+   * When unset and `file` is also unset, consumers treat the finding as
+   * source-targeted by default.
+   */
+  fixTarget?: FixTarget;
+
+  /**
+   * Producer-specific extras — semantic review's verifiedBy evidence,
+   * raw tool output, AC text, TS span, etc.
+   *
+   * Avoid putting load-bearing data here that downstream consumers must read.
+   * Prefer promoting frequently-used fields to first-class properties.
+   */
+  meta?: Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary

Introduces a single `Finding` type as the wire format for all "something is wrong" producers (lint, typecheck, semantic review, adversarial review, acceptance diagnose, TDD verifier, plugin reviewers). **Types only — no behaviour, no consumers in this PR.** Subsequent PRs (ADR-021 phases 2–5) migrate producers to emit `Finding[]` additively.

Companion ADR-022 covers cycle / strategy orchestration and ships separately.

## What this PR does

- Adds `src/findings/types.ts` — `Finding`, `FindingSource`, `FindingSeverity`, `FixTarget`
- Adds `src/findings/index.ts` — barrel re-exports
- Adds `docs/adr/ADR-021-findings-and-fix-strategy-ssot.md` — design rationale, absorption table, phased plan

## What this PR does NOT do

- No orchestration changes — see ADR-022 (companion, not in this PR) for cycle / strategy / runFixCycle design
- No producer migration — that's phases 2–5 of ADR-021
- No consumer changes — existing types (`LlmReviewFinding`, `AdversarialFindingsCache`, `DiagnosisResult.{testIssues,sourceIssues}`) stay in place until ADR-021 phase 6
- No prompt-builder changes — `RectifierPromptBuilder`, `buildPriorFindingsBlock`, `buildAttemptContextBlock` are unaffected

## Key design decisions (full rationale in ADR-021)

1. **Severity standardises on `"warning"`** — adversarial currently emits `"warn"`. Read-path `normalizeSeverity` adapters in [`src/review/{semantic-helpers,adversarial-helpers,dialogue}.ts`](src/review) already accept `"warn"` and emit `"warning"`. Only adversarial's prompt schema needs updating in a later phase.
2. **`Finding.file` is repoRoot-relative** — producers normalise at adapter boundary. Plugin contract (`ReviewFinding.file: workdir-relative`) preserved; internal normalisation only.
3. **Acceptance sentinels become first-class findings** — `AC-HOOK` / `AC-ERROR` map to `category: "hook-failure" | "test-runner-error"` per ADR-021 §5.
4. **`fixTarget: "source" | "test"`** — binary per finding; "both" emerges naturally from a mixed `Finding[]`. Mechanical producers may leave unset (cycle layer derives from file path against `resolveTestFilePatterns`).

## Risk

Zero. Types are exported from a new `src/findings/` namespace with no current consumers. `bun run typecheck`, `bun run lint`, and pre-commit gates all pass. Reverting is one commit.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` (Biome) passes
- [x] Pre-commit hooks pass (process.cwd, adapter-wrap, dispatch-context)
- [x] No production code touched — full suite behaviourally unchanged

## Review guide

The entire diff is 377 lines (177 code + 254 ADR). Suggested path:

1. Read [`docs/adr/ADR-021-findings-and-fix-strategy-ssot.md`](docs/adr/ADR-021-findings-and-fix-strategy-ssot.md) — design doc explains every field choice
2. Read [`src/findings/types.ts`](src/findings/types.ts) against the ADR's §4 absorption table
3. Verify isolation: `git grep "src/findings" -- 'src/'` should return only the new files

The two non-trivial choices to flag concerns on: file-path SSOT (§3) and severity rename (§2).

## Refs

- ADR-021 (this PR): types only
- ADR-022 (held — companion ADR): cycle + strategy orchestration, ships separately
- Issue #867: tracking umbrella