### PR TITLE
docs: ADR-022 (fix strategy + cycle) and implementation plans for ADR-021/022

### DIFF
--- a/docs/adr/ADR-022-fix-strategy-and-cycle.md
+++ b/docs/adr/ADR-022-fix-strategy-and-cycle.md
@@ -1,0 +1,372 @@
+# ADR-022: Fix Strategy and Cycle Orchestration
+
+**Status:** Proposed
+**Date:** 2026-05-02
+**Author:** William Khoo, Claude
+**Builds on:** ADR-021 (Finding Type SSOT)
+**Related:** ADR-006 (Acceptance Retry Loop Restructure — superseded in part by phase 4 of this ADR)
+
+---
+
+## Context
+
+Three subsystems each implement their own diagnose-fix-validate loop:
+
+| Subsystem | Loop entry point | Carry-forward mechanism |
+|:---|:---|:---|
+| Acceptance | [`runAcceptanceLoop`](../../src/execution/lifecycle/acceptance-loop.ts) → [`applyFix`](../../src/execution/lifecycle/acceptance-fix.ts#L153) | `previousFailure: string` blob ([acceptance-loop.ts:299](../../src/execution/lifecycle/acceptance-loop.ts#L299)) |
+| Autofix (lint / typecheck / adversarial) | [`runAgentRectification`](../../src/pipeline/stages/autofix-agent.ts#L89) calls [`runRetryLoop`](../../src/verification/shared-rectification-loop.ts) | per-attempt prompt rebuild via `RectifierPromptBuilder` |
+| Test rectification | [`rectify.ts`](../../src/pipeline/stages/rectify.ts#L38) calls `runRectificationLoop` | inline in rectification loop |
+
+Adversarial review additionally maintains a `priorFindingsBlock` in its prompt builder, asking the reviewer to verdict each prior finding before scanning for new ones — but this is not invoked by acceptance or autofix.
+
+ADR-021 introduces a unified `Finding` type. This ADR introduces unified orchestration: a `FixStrategy` abstraction declarable per finding source, a `runFixCycle` that drives strategies through an iteration history, and a shared `buildPriorIterationsBlock` prompt helper that all rectifier-class prompts can consume.
+
+A separate critical review (2026-05-02) of an earlier draft surfaced eleven design decisions that this ADR makes explicit:
+
+1. **`runRetryLoop` overlap** — `runFixCycle` does not replace it; it sits above it.
+2. **Cycle granularity** — per-subsystem cycles, multi-source within subsystem.
+3. **Validator coupling** — what validator runs, and when, in a co-run iteration.
+4. **Validator failure semantics** — retry once, then terminal.
+5. **Verdict overload** — acceptance's `verdict` is more than routing; it drives fast-paths that produce no findings.
+6. **`stubRegenCount` cycle-wide state** — not representable as a strategy-level `bailWhen`.
+7. **Co-run validation order** — validate after each strategy or once at iteration end.
+8. **`Iteration` records multiple `FixApplied` per validation** — strategy invocations are not 1:1 with iterations.
+9. **`classifyOutcome` cross-source algorithm** — per-source bucket, then aggregate.
+10. **Strategy is a value not a class** — constructed at the cycle entry point, captures closure context.
+11. **`co-run-parallel` removed** — reserved but unused; YAGNI.
+
+## Decision
+
+### 1. Three-layer nesting: cycle → strategy group → retry loop
+
+`runFixCycle` does not replace `runRetryLoop`. The layers compose:
+
+```
+runFixCycle<F>(cycle, ctx)
+  per iteration:
+    1. select matching strategies (appliesTo)
+    2. exclusive strategy wins; else co-run group runs sequentially
+    3. for each strategy in group:
+         strategy.fixOp invoked via callOp
+           (strategy.fixOp may internally use runRetryLoop for same-session JSON-parse retries — that is opaque to the cycle)
+    4. validate ONCE at end of iteration (see §4)
+    5. classify outcome, push Iteration, repeat
+```
+
+`runRetryLoop` continues to handle:
+- Same-session retry on transient parse failures
+- Progressive prompt urgency (rethink-at-attempt, urgency-at-attempt)
+- Per-attempt session lifecycle
+
+`runFixCycle` adds, on top:
+- Multi-strategy iteration with co-run discipline
+- Validator deduplication per iteration
+- Outcome classification (resolved / partial / regressed / unchanged)
+- Cross-iteration history for prompt carry-forward
+
+### 1b. Cycle granularity — per-subsystem, multi-source within subsystem
+
+A cycle is **scoped to a subsystem** (the unit that owns its validator), not to a single finding source. Within that subsystem, the cycle holds strategies for every source that can flow through the same validator.
+
+| Cycle | Strategies | Why grouped |
+|:---|:---|:---|
+| **Autofix** (review checks) | `lint`, `typecheck`, `adversarial`, `plugin`, `test-writer`, `implementer` | All re-validated by the same `recheckReview` pass; cross-source drift (e.g. lint fix introduces typecheck error) is naturally handled because the next iteration sees the new finding and the matching strategy picks it up |
+| **Acceptance** | `acceptance-source-fix`, `acceptance-test-fix` | Single-source by nature; both validated by re-running the acceptance test suite |
+| **Test rectification** (if/when migrated) | `tdd-verifier` | Validated by re-running the test command |
+
+This mirrors current code: `runAgentRectification` already receives a mixed-source `failedChecks` array (lint + typecheck + adversarial together) and dispatches the implementer once for everything. Phase 7's autofix migration preserves that behaviour by composing all those strategies in one `FixCycle`.
+
+**Consequence:** strategies must use discriminating `appliesTo` selectors (by `source`, `category`, or `fixTarget`) to avoid collisions when two strategies could match the same finding. Reviewer discipline; not enforced by the type system.
+
+### 2. Iteration shape — multiple fixes per validation
+
+```typescript
+interface Iteration<F extends Finding = Finding> {
+  iterationNum: number;                 // 1-indexed
+  findingsBefore: F[];
+  fixesApplied: FixApplied[];           // ≥1 — one per strategy that ran in this iteration
+  findingsAfter: F[];
+  outcome: IterationOutcome;
+  startedAt: string;
+  finishedAt: string;
+}
+
+interface FixApplied {
+  strategyName: string;
+  op: string;                           // operation name from RunOperation.name
+  targetFiles: string[];
+  summary: string;                      // first ~500 chars of agent response or stdout
+  costUsd?: number;
+}
+
+type IterationOutcome =
+  | "resolved"                          // findingsAfter is empty
+  | "partial"                           // findingsAfter is a strict subset of findingsBefore
+  | "regressed"                         // findingsAfter contains new findings not in findingsBefore
+  | "unchanged"                         // findingsAfter equals findingsBefore (same files+rules+lines)
+  | "regressed-different-source";       // before had source A, after has source B
+```
+
+`fixesApplied: FixApplied[]` (plural) accommodates current behaviour where one diagnose-fix iteration runs `acceptanceFixSourceOp` then `acceptanceFixTestOp` (verdict=both), and where autofix runs test-writer then implementer.
+
+**`classifyOutcome` algorithm — per-source bucket, then aggregate.** Mixed cross-source comparisons (e.g. `before: [lintA, lintB]`, `after: [lintA, typecheckC]`) are not meaningful at the unified level — severity comparisons across sources don't share a vocabulary. Algorithm:
+
+```typescript
+function classifyOutcome(before: Finding[], after: Finding[]): IterationOutcome {
+  const sources = new Set([...before, ...after].map((f) => f.source));
+  const perSource = [...sources].map((source) =>
+    classifySingleSource(
+      before.filter((f) => f.source === source),
+      after.filter((f) => f.source === source),
+    ),
+  );
+  // Aggregate:
+  if (perSource.every((o) => o === "resolved")) return "resolved";
+  if (perSource.some((o) => o === "regressed")) return "regressed";
+  if (perSource.some((o) => o === "regressed-different-source")) return "regressed-different-source";
+  if (perSource.every((o) => o === "unchanged")) return "unchanged";
+  return "partial";
+}
+```
+
+`classifySingleSource` uses `findingKey` from ADR-021 to compute set difference within one source. The `regressed-different-source` outcome surfaces when a fix introduces findings of a source that wasn't present before.
+
+### 3. FixStrategy declares routing + co-run discipline
+
+```typescript
+interface FixStrategy<F extends Finding, I, O, C> {
+  name: string;
+  appliesTo: (finding: F) => boolean;
+  appliesToVerdict?: (verdict: string) => boolean;   // optional fallback when findings is empty (see §5)
+  fixOp: Operation<I, O, C>;
+  buildInput: (findings: F[], priorIterations: Iteration<F>[], ctx: FixCycleContext) => I;
+  bailWhen?: (priorIterations: Iteration<F>[]) => string | null;
+  maxAttempts: number;
+  coRun?: "exclusive" | "co-run-sequential";
+}
+```
+
+**Strategy selection per iteration:**
+- Filter `cycle.strategies` by `appliesTo` against current findings.
+- If any matching strategy is `"exclusive"` (default), it runs alone — highest precedence.
+- Otherwise all matching `"co-run-sequential"` strategies run in declaration order.
+
+**`co-run-parallel` was considered and removed (YAGNI).** The only conceivable use case (parallel disjoint-file lint fixes) doesn't justify the file-locking discipline required, and LLM latency dominates IO so wall-clock improvement is negligible. Re-introduce only if a concrete use case arrives.
+
+**Acceptance:** source-fix and test-fix are both `"co-run-sequential"`. When the diagnosis emits both source-targeted and test-targeted findings, both run in one iteration.
+**Autofix:** test-writer and implementer are both `"co-run-sequential"`. Test-writer naturally drops out in subsequent iterations once test-targeted findings are resolved — its `appliesTo` selector returns false, no special "runOnce" modifier needed (selector-based dropout).
+**Lint, typecheck:** `"exclusive"` per source within the autofix cycle.
+
+**`FixStrategy` is a value, not a class.** Each cycle entry point constructs its strategies inline, capturing closure variables (testOutput, diagnosis reasoning, verdict, packageDir) needed by `buildInput`. This avoids forcing every strategy to thread context through a generic `extras` field. Strategies are not registered globally or discovered at runtime — they live where they're used.
+
+**`appliesTo` discipline.** Selectors must be discriminating (by `source`, `category`, `fixTarget`, or file pattern), never `() => true`. A non-discriminating selector silently preempts every other strategy when paired with `"exclusive"`. Reviewer responsibility; no type-system enforcement.
+
+### 4. Validator lives on the cycle, not the strategy
+
+The earlier draft attached `validate` to the strategy. The review found this breaks down for mixed acceptance source+test (both strategies share the same validator: re-run acceptance tests) and for autofix (test-writer and implementer can have different validators).
+
+Resolution: **validator lives on the cycle, scoped per finding-source-group.**
+
+```typescript
+interface FixCycle<F extends Finding> {
+  findings: F[];
+  iterations: Iteration<F>[];
+  strategies: FixStrategy<F, any, any, any>[];
+  validate: (ctx: FixCycleContext) => Promise<F[]>;     // SINGLE validator for the cycle
+  config: FixCycleConfig;
+}
+
+interface FixCycleConfig {
+  maxAttemptsTotal: number;        // default 10
+  validatorRetries: number;        // default 1 — see §4 retry-once-then-terminal
+}
+```
+
+The validator runs **once per iteration**, after all co-run strategies have completed. No per-strategy validation.
+
+Why: in practice, the validator is a property of the failure source (acceptance test suite, lint runner, semantic review), not of the fix lane. Source-fix and test-fix in acceptance both validate by re-running the acceptance test suite. Autofix's test-writer and implementer both validate by re-running the merged review checks. Forcing per-strategy validators creates phantom flexibility that doesn't match how rectification actually works.
+
+**Tradeoff accepted:** if source-fix breaks something that test-fix would otherwise have noticed, validation only catches it at end of iteration. This matches today's acceptance behaviour ([applyFix:190-211](../../src/execution/lifecycle/acceptance-fix.ts#L190) calls both ops then the outer loop re-tests once). For autofix, test-writer's one-shot completes before implementer's loop starts, so cascading errors from test-writer surface in the implementer's first prompt — same as today.
+
+**Validator failure semantics — retry once, then terminal.** When `validate(ctx)` throws (LSP server crash, file lock, network blip), the cycle:
+
+1. Retries the validator immediately (default `validatorRetries: 1`).
+2. If the retry also throws, exits with `reason: "validator-error"`.
+3. The throw is logged with `storyId` and the original error chained via `cause`.
+
+Treating any validator throw as immediately terminal would make one flaky lint runner kill the cycle. Treating throws as "no findings = resolved" would silently suppress regressions — far worse. Retry-once-then-terminal is the pragmatic middle: tolerates transient glitches without papering over real validator breakage.
+
+### 5. Verdict is preserved as a hypothesis tag, not derived
+
+The review found `DiagnosisResult.verdict` is triple-overloaded:
+1. Routing (which fix ops to call) — addressable via per-finding `fixTarget`.
+2. **Heuristic fast-paths** that produce `verdict` *without* findings:
+   - `strategy === "implement-only"` → verdict `"source_bug"`, no findings
+   - `semanticVerdicts.every(v => v.passed)` → verdict `"test_bug"`, no findings
+   - `isTestLevelFailure(failedACs, totalACs)` → verdict `"test_bug"`, no findings
+3. Signaling (logged + accumulated in prompt context).
+
+A pure "derive verdict from findings" model breaks #2. Resolution: **`verdict` stays on `DiagnosisResult` as a hypothesis tag.** It can exist without findings and is consumed by the cycle as a *strategy selector hint*:
+
+```typescript
+interface DiagnosisResult {
+  verdict: "source_bug" | "test_bug" | "both";    // preserved
+  reasoning: string;
+  confidence: number;
+  findings: Finding[];                              // may be empty for fast-path verdicts
+}
+```
+
+The cycle uses verdict to **bias strategy selection** when findings are absent:
+
+```typescript
+strategies: [
+  {
+    name: "acceptance-source-fix",
+    appliesTo: (f) => f.fixTarget === "source",
+    // when findings is empty, fall through to verdict-based selection
+    appliesToVerdict: (v) => v === "source_bug" || v === "both",
+    ...
+  },
+  {
+    name: "acceptance-test-fix",
+    appliesTo: (f) => f.fixTarget === "test",
+    appliesToVerdict: (v) => v === "test_bug" || v === "both",
+    ...
+  },
+]
+```
+
+`appliesToVerdict` is an optional fallback selector consulted only when `findings.length === 0`. For non-acceptance strategies (lint, semantic, adversarial), it stays unset.
+
+This preserves all three uses of verdict and keeps fast-paths cheap.
+
+### 6. Stub regen stays as a prelude, not a strategy
+
+`stubRegenCount` ([acceptance-loop.ts:110-238](../../src/execution/lifecycle/acceptance-loop.ts#L110)) caps stub-test regenerations at 2 *before* the diagnosis loop starts. The review found this is cycle-wide state that strategy-level `bailWhen` cannot express.
+
+Resolution: **stub regen remains a prelude phase outside the cycle.** The cycle only runs after stubs are exhausted (or never present). Reasoning:
+- Stub regen is fundamentally different — full regeneration of the test file, not surgical fix.
+- Its cap is orthogonal to fix attempt counts.
+- The current code path is correct; we don't need to force it into the cycle just for symmetry.
+
+The cycle is only entered when there's a real test file to fix. The stub-regen counter and its cap stay where they are. `runFixCycle` is invoked by `runAcceptanceLoop` after the stub-guard check passes.
+
+### 7. Dual budget — preserved from autofix
+
+| Budget | Lives on | Default | Bail reason |
+|:---|:---|:---|:---|
+| Per-strategy attempt cap | `FixStrategy.maxAttempts` | acceptance: 3, lint: 5, semantic: 2 | `"max-attempts-per-strategy"` |
+| Cycle-wide total cap | `FixCycleConfig.maxAttemptsTotal` | 10 | `"max-attempts-total"` |
+
+Mirrors `quality.autofix.{maxAttempts, maxTotalAttempts}` ([autofix-agent.ts:96-120](../../src/pipeline/stages/autofix-agent.ts#L96)). Per-strategy attempts are counted from `iterations.flatMap(i => i.fixesApplied).filter(f => f.strategyName === X).length`.
+
+### 8. Shared `buildPriorIterationsBlock` prompt helper
+
+Verdict-first table consumed by all rectifier-class prompts:
+
+```
+## Prior Iterations — verdict required before new analysis
+
+| # | Strategies run                                | Files touched                  | Outcome    | Findings before → after   |
+|---|-----------------------------------------------|--------------------------------|------------|---------------------------|
+| 1 | acceptance-test-fix                           | .nax-acceptance.test.ts        | unchanged  | 1 [stdout-capture] → 1 [stdout-capture] |
+| 2 | acceptance-test-fix                           | .nax-acceptance.test.ts        | unchanged  | 1 [stdout-capture] → 1 [stdout-capture] |
+
+When outcome is "unchanged", the prior hypothesis is FALSIFIED — the change did
+not affect what was tested. Choose a different category before producing a new
+verdict. Do NOT repeat fixes listed above.
+```
+
+Replaces:
+- `buildPriorFindingsBlock` ([adversarial-review-builder.ts:202](../../src/prompts/builders/adversarial-review-builder.ts#L202))
+- `buildAttemptContextBlock` ([review-builder.ts:186](../../src/prompts/builders/review-builder.ts#L186))
+- The freeform `previousFailure` accumulator in [acceptance-loop.ts:299](../../src/execution/lifecycle/acceptance-loop.ts#L299)
+
+## Phased implementation
+
+| Phase | Scope | Risk |
+|:---|:---|:---|
+| **1. Cycle types** | new `src/findings/cycle-types.ts` — `Iteration`, `IterationOutcome`, `FixApplied`, `FixStrategy`, `FixCycleContext`, `FixCycleConfig`, `FixCycleResult` | zero |
+| **2. `runFixCycle` + `classifyOutcome`** | new `src/findings/cycle.ts` + tests under `test/unit/findings/` | low — pure logic, all bail paths covered by tests |
+| **3. `buildPriorIterationsBlock`** | new `src/prompts/builders/prior-iterations.ts` + tests | zero |
+| **4. Acceptance migration** | replace `applyFix` with `runFixCycle` invocation; preserve verdict fast-paths via `appliesToVerdict`. Behind `acceptance.fix.cycleV2` flag. | medium — bench against `nax-dogfood/fixtures/hello-lint` audit fixtures with both modes |
+| **5. Adversarial migration** | adversarial review already structured; replace `AdversarialFindingsCache` carry-forward with `Iteration[]` via shared `buildPriorIterationsBlock` | low |
+| **6. Semantic migration** | replace `PriorFailure[]` with `Iteration[]` | low |
+| **7. Autofix migration** | replace `runAgentRectification`'s hand-rolled split-and-route with `runFixCycle` driving two strategies (test-writer, implementer). Behind `quality.autofix.cycleV2` flag, shadow mode for two releases | medium — autofix on hot path |
+| **8. Cleanup** | delete legacy carry-forward types, remove feature flags | zero |
+
+Phase 4 ships the dogfood regression fix.
+
+## Test plan
+
+- Phase 2: cycle unit tests cover all bail paths (no-strategy, per-strategy cap, total cap, validator-error, bailWhen) and outcome classification (resolved, partial, regressed, unchanged, regressed-different-source).
+- Phase 3: `buildPriorIterationsBlock` snapshot tests (empty, single, multi-iteration, `unchanged` outcome rendering).
+- Phase 4: dogfood `hello-lint` audit shows attempt 2's diagnose prompt contains the verdict-first table; the model selects a different strategy than attempt 1.
+- Phase 5–6: existing review integration tests pass.
+- Phase 7: shadow-mode telemetry shows old + new autofix paths agree on routing for ≥95% of test fixtures over two releases before flag flip.
+
+## Consequences
+
+### Positive
+
+- Acceptance gains the verdict-first carry-forward that adversarial already has. Falsified-hypothesis detection ships with phase 4 (the dogfood regression).
+- Three loop implementations collapse to one (`runFixCycle`), with `runRetryLoop` preserved as the inner per-op retry primitive.
+- `Iteration<F>` history is queryable across all subsystems — a single "what fixes ran on this story" view becomes possible.
+- Prompt builder duplication eliminated (`buildPriorFindingsBlock` + `buildAttemptContextBlock` + acceptance accumulator → one helper).
+
+### Negative
+
+- Phase 4 introduces a feature-flagged parallel implementation; there are two acceptance fix loops in the codebase for one release.
+- Phase 7's shadow mode requires telemetry plumbing that doesn't exist today — adds two release cycles before legacy autofix can be removed.
+
+### Neutral
+
+- The verdict field on `DiagnosisResult` is preserved indefinitely. It's small, well-defined, and the alternative (deriving from empty findings via heuristics-as-data) is more complex.
+
+## Telemetry
+
+Standardised iteration log shape — every cycle emits this on iteration completion so dashboards and post-mortem audits work uniformly across subsystems:
+
+```typescript
+logger.info("findings.cycle", "iteration completed", {
+  storyId,                                  // first key, per project conventions
+  packageDir,                               // for monorepo correlation
+  cycleName: "acceptance" | "autofix" | …,  // matches the subsystem owning the cycle
+  iterationNum,
+  strategiesRan: ["acceptance-test-fix"],   // FixApplied[].strategyName
+  outcome: "unchanged",
+  findingsBefore: 1,
+  findingsAfter: 1,
+  costUsd: 0.012,
+});
+```
+
+Bail events emit `"cycle exited"` with the same shape plus `reason` and (when applicable) `exhaustedStrategy` / `bailDetail`. Validator-retry events emit `"validator retry"` with the original error chained via `cause`.
+
+## Audit logging
+
+Cycle iteration history stays **ephemeral by default** — `Iteration<F>[]` lives in memory in the cycle's owning context, used for prompt carry-forward via `buildPriorIterationsBlock` and discarded at end of run.
+
+Forensic post-mortem persistence (writing iteration history to `.nax/cycle-history/<cycleId>.jsonl` for after-the-fact debugging) is deferred to the broader audit redesign tracked in [docs/findings/2026-04-30-context-curator-design.md](../findings/2026-04-30-context-curator-design.md). The shape is already well-defined here; the persistence policy and storage location belong with the broader audit work.
+
+## Out of scope
+
+These are deliberately not addressed by this ADR:
+
+- **Plugin-supplied fix strategies.** Plugin reviewers (`IReviewPlugin`) emit `Finding[]` per ADR-021 phase 2 but cannot supply their own `FixStrategy`. The plugin contract stays check-only. If plugin-driven fixes become a concrete need, they get their own ADR with a contract extension.
+- **Hook integration.** The cycle does not fire its own hook events (`cycle:iteration-start`, etc.). Existing hooks remain at the run-lifecycle layer. Add only if a concrete observer/plugin needs them.
+- **Co-run-parallel.** Removed from the design (see §3). Re-add if a concrete use case arrives.
+- **Cross-package cycle composition.** A cycle is scoped to one package; cross-package finding aggregation is a consumer concern (see ADR-021 §3).
+- **Persistence beyond logging.** No on-disk iteration history in V1 (see Audit section above).
+
+## References
+
+- [src/verification/shared-rectification-loop.ts](../../src/verification/shared-rectification-loop.ts) — `runRetryLoop` (preserved as the inner primitive)
+- [src/execution/lifecycle/acceptance-fix.ts:78-116](../../src/execution/lifecycle/acceptance-fix.ts#L78) — verdict fast-paths (preserved via `appliesToVerdict`)
+- [src/execution/lifecycle/acceptance-loop.ts:110-238](../../src/execution/lifecycle/acceptance-loop.ts#L110) — `stubRegenCount` (preserved as prelude)
+- [src/pipeline/stages/autofix-agent.ts:96-120](../../src/pipeline/stages/autofix-agent.ts#L96) — dual-budget pattern (mirrored in `FixCycleConfig`)
+- [src/prompts/builders/adversarial-review-builder.ts:202](../../src/prompts/builders/adversarial-review-builder.ts#L202) — `buildPriorFindingsBlock` (replaced by `buildPriorIterationsBlock`)
+- ADR-021 — Finding Type SSOT (companion ADR; types prerequisite for this one)
+- ADR-006 — Acceptance Retry Loop Restructure (introduced `previousFailure: string`; superseded in part by phase 4)

--- a/docs/adr/ADR-022-fix-strategy-and-cycle.md
+++ b/docs/adr/ADR-022-fix-strategy-and-cycle.md
@@ -77,6 +77,8 @@ A cycle is **scoped to a subsystem** (the unit that owns its validator), not to 
 
 This mirrors current code: `runAgentRectification` already receives a mixed-source `failedChecks` array (lint + typecheck + adversarial together) and dispatches the implementer once for everything. Phase 7's autofix migration preserves that behaviour by composing all those strategies in one `FixCycle`.
 
+**Implementation note — six sources, two fix ops:** The table names six logical sources for autofix, but in phase 7 these are implemented as only **two strategies**: `autofix-implementer` (handles all `fixTarget === "source"` findings: lint, typecheck, adversarial, plugin) and `autofix-test-writer` (handles `fixTarget === "test"` findings). This matches current behaviour — the implementer already receives all source findings in one prompt; splitting into four per-source strategies would add ops without benefit. The six-source framing describes what *flows through* the cycle, not how many fix ops are needed. If per-source routing becomes necessary in the future (e.g. a specialised lint fixer), a new strategy with a tighter `appliesTo(f) => f.source === "lint"` selector can be added without changing `runFixCycle`.
+
 **Consequence:** strategies must use discriminating `appliesTo` selectors (by `source`, `category`, or `fixTarget`) to avoid collisions when two strategies could match the same finding. Reviewer discipline; not enforced by the type system.
 
 ### 2. Iteration shape — multiple fixes per validation

--- a/docs/findings/2026-04-30-context-curator-design.md
+++ b/docs/findings/2026-04-30-context-curator-design.md
@@ -337,6 +337,94 @@ Captured here so a future operator hitting the same fork can see the analysis wi
 
 ---
 
+## Step 5 — ADR-022 fix-cycle iteration audit (cross-reference)
+
+ADR-022 ("Fix Strategy and Cycle Orchestration", 2026-05-02) introduces a `runFixCycle<F>` that drives diagnose-fix-validate iterations across acceptance, autofix, semantic, and adversarial subsystems. Its "Audit logging" section deliberately **defers cycle-history persistence to this curator redesign** — iteration history is ephemeral by default (in-memory in `PipelineContext`), used only for prompt carry-forward via `buildPriorIterationsBlock`.
+
+When this curator redesign lands, cycle iterations should map onto the same `observations.jsonl` schema. Concrete sketch:
+
+### Mapping `Iteration<F>` → observations
+
+The schema's existing `kind: "rectify-cycle"` (Layer A, line 106) is the right slot — but it predates ADR-022 and was intended to capture only autofix's `runRetryLoop` attempts. Generalise it to cover all cycle iterations:
+
+```typescript
+// Replace existing "rectify-cycle" kind with three more specific events:
+kind:
+  | "fix-cycle.iteration"     // one Iteration<F> completed (cycle iteration boundary)
+  | "fix-cycle.exit"          // cycle terminated (resolved or bailed)
+  | "fix-cycle.validator-retry" // validator threw, cycle retried
+  // … existing kinds preserved
+```
+
+Per-event payloads, mapped from `Iteration<F>` and `FixCycleResult<F>`:
+
+```typescript
+// fix-cycle.iteration
+payload: {
+  cycleName: string;             // "acceptance" | "autofix" | "semantic" | …
+  iterationNum: number;
+  strategiesRan: string[];       // FixApplied[].strategyName
+  outcome: "resolved" | "partial" | "regressed" | "unchanged" | "regressed-different-source";
+  findingsBefore: number;
+  findingsAfter: number;
+  costUsd: number;
+  // optional: top-N finding categories for cross-iteration trend analysis
+  beforeCategories?: string[];
+  afterCategories?: string[];
+}
+
+// fix-cycle.exit
+payload: {
+  cycleName: string;
+  resolved: boolean;
+  reason?: "no-strategy-matches" | "max-attempts-per-strategy" | "max-attempts-total" | "bailed-by-strategy" | "validator-error";
+  bailDetail?: string;
+  exhaustedStrategy?: string;
+  totalIterations: number;
+  totalCostUsd: number;
+}
+
+// fix-cycle.validator-retry
+payload: {
+  cycleName: string;
+  iterationNum: number;
+  attempt: number;               // 0 = first try, 1 = retry
+  errorClass: string;            // err.constructor.name
+  errorMessage: string;
+}
+```
+
+### Why this matters for the curator
+
+Cycle iterations expose patterns the curator wants to surface:
+
+| Curator heuristic | jq query against observations.jsonl |
+|:---|:---|
+| "Story always falsifies its hypothesis (unchanged outcome ≥2 in a row)" → diagnose prompt is wrong | `select(.kind=="fix-cycle.iteration" and .payload.outcome=="unchanged") \| group_by(.storyId)` |
+| "Same strategy hits its per-strategy cap repeatedly" → strategy logic is broken | `select(.kind=="fix-cycle.exit" and .payload.reason=="max-attempts-per-strategy") \| group_by(.payload.exhaustedStrategy)` |
+| "Validator retries cluster on same error class" → validator infra is flaky | `select(.kind=="fix-cycle.validator-retry") \| group_by(.payload.errorClass)` |
+| "Cycle resolves quickly for some stories, never for others" → cross-story baseline anomaly | `select(.kind=="fix-cycle.exit") \| {storyId, resolved, totalIterations}` |
+
+### Telemetry symmetry
+
+ADR-022 §13 already mandates a logger contract for cycle iterations:
+
+```typescript
+logger.info("findings.cycle", "iteration completed", { storyId, packageDir, cycleName, iterationNum, strategiesRan, outcome, findingsBefore, findingsAfter, costUsd });
+```
+
+The `observations.jsonl` shape above is a strict superset — once unified-auditor work (Step 4 in this design) lands, the logger emit and the audit emit can share one dispatch path. Until then, a thin auditor reads logger entries and writes observations rows; same pattern as today's `PromptAuditor`.
+
+### Implementation timing
+
+This is **not a curator-v0 dependency**. ADR-022 phase 4 (acceptance migration) ships first and only requires the in-memory `Iteration<F>[]` carry-forward. Cycle-history audit persistence can wait until:
+
+1. ADR-022 phases 4–7 have shipped — real cycle data exists to mine
+2. Curator v0 is validated against existing auditors — proves the heuristics-from-observations workflow works
+3. Either Step 4's unified-auditor refactor lands, OR a new `cycleAuditor` is added analogous to `reviewAuditor` (R1 from Step 4 risk register may be re-evaluated by then)
+
+Document this here so a future operator landing the audit work sees the cycle-history requirement without re-deriving it from ADR-022.
+
 ## Open questions / next steps
 
 1. **Decide the v0 cut.** Ship the 2 remaining logger emits (pull-tool, acceptance) now, or ship a partial curator first?
@@ -346,6 +434,7 @@ Captured here so a future operator hitting the same fork can see the analysis wi
 5. **Plugin entry point.** `IPostRunAction` is the documented hook. Confirm it gets enough context (run artifacts path, config, logger) to do the walk.
 6. **Apply UX.** Interactive CLI (`nax curator apply`) vs. plain editing the proposals file — pick one before building.
 7. **Verify `dispatchEvents` contract** (R5 from Step 4) — only if the unified-auditor design is revisited.
+8. **Cycle-history audit timing** (Step 5). Ride along with curator v0, defer to v1, or wait for cycle data accumulation? Tied to ADR-022 phase 4+ shipping.
 
 ## References
 

--- a/docs/specs/2026-05-02-adr-021-implementation-plan.md
+++ b/docs/specs/2026-05-02-adr-021-implementation-plan.md
@@ -1,0 +1,690 @@
+# ADR-021 Implementation Plan — Phases 2–9
+
+**Date:** 2026-05-02
+**Status:** Pre-implementation — settles per-phase scope before PR work begins
+**Scope:** Detailed plan for migrating each producer to emit `Finding[]` per ADR-021
+**ADRs:** [ADR-021](../adr/ADR-021-findings-and-fix-strategy-ssot.md) (this plan); [ADR-022](../adr/ADR-022-fix-strategy-and-cycle.md) (companion)
+**Tracking:** [#867](https://github.com/nathapp-io/nax/issues/867)
+**Phase 1 PR:** [#868](https://github.com/nathapp-io/nax/pull/868)
+
+---
+
+## 1. Overview
+
+Phase 1 (the wire-format types) shipped on PR #868. This plan covers phases 2–9 — the producer migrations and final cleanup.
+
+**Migration model: fold-per-producer.** Each phase is a single PR that migrates one producer AND its direct consumers in lock-step. No additive-emission interval; no `Finding[]` arrays floating unused.
+
+**Order (lowest risk first):**
+
+| Phase | Producer | Risk | Flag? |
+|:---|:---|:---|:---|
+| 2 | Plugin reviewer adapter | low | none |
+| 3 | Lint (Biome JSON, ESLint JSON, text) | medium | none |
+| 4 | Typecheck (tsc) | medium | none |
+| 5 | TDD verifier / AC parser | low | none |
+| 6 | Adversarial review | high | none (rename absorbed by `normalizeSeverity`) |
+| 7 | Semantic review | high | none |
+| 8 | Acceptance diagnose | medium-high | `acceptance.fix.findingsV2` (default off, soak 1 release) |
+| 9 | Cleanup | zero | n/a |
+
+Phases 2–7 are unblocked from each other. Phase 8 depends on phase 5 (AC sentinel reuse). Phase 9 requires all preceding phases done plus ADR-022 consumer migrations done.
+
+## 2. Cross-phase concerns
+
+### 2.1 Severity rename strategy (`"warn"` → `"warning"`)
+
+**Producer side (3 prompt schemas to edit):**
+- [src/prompts/builders/adversarial-review-builder.ts:206](../../src/prompts/builders/adversarial-review-builder.ts#L206) — `OUTPUT_SCHEMA` block
+- Same file, severity guide text describing `"warn"` semantics
+- [src/prompts/builders/review-builder.ts](../../src/prompts/builders/review-builder.ts) — `SEMANTIC_OUTPUT_SCHEMA` block
+
+**Read side (already handled — no change needed):**
+- [src/review/adversarial-helpers.ts:56-62](../../src/review/adversarial-helpers.ts#L56) `normalizeSeverity()` — `"warn"` → `"warning"`
+- [src/review/semantic-helpers.ts:55](../../src/review/semantic-helpers.ts#L55) — same
+- [src/review/dialogue.ts](../../src/review/dialogue.ts) — same
+
+The `normalizeSeverity` adapters already accept legacy `"warn"` and emit `"warning"`. Rename in prompt schema is forward-only — LLMs producing legacy `"warn"` continue to parse correctly via the adapter. No flag required; the rename is safe across all releases.
+
+Lands during phases 6 (adversarial) and 7 (semantic), in the same PR as the producer migration.
+
+### 2.2 File path normalisation
+
+Per ADR-021 §3, every `Finding.file` is **relative to nax's workdir**. Each producer adapter does the rebasing at its boundary:
+
+| Producer | Native format | Rebase rule |
+|:---|:---|:---|
+| Biome JSON | `cwd`-relative | `path.relative(workdir, path.resolve(cwd, file))` |
+| `tsc --pretty=false` | absolute | `path.relative(workdir, file)` |
+| `LlmReviewFinding` | LLM-emitted | already workdir-relative per prompt instruction; no rebase needed; validate at parse |
+| `ReviewFinding` (plugin) | workdir-relative | direct (already conformant) |
+| `acceptanceDiagnoseOp` | LLM-emitted | already workdir-relative per prompt instruction |
+
+Helper to add in phase 2 (used by every adapter from phase 3 onward):
+
+```typescript
+// src/findings/path-utils.ts
+export function rebaseToWorkdir(rawPath: string, cwd: string, workdir: string): string {
+  if (rawPath.startsWith("/")) return path.relative(workdir, rawPath);
+  return path.relative(workdir, path.resolve(cwd, rawPath));
+}
+```
+
+### 2.3 Audit trail for soak phases
+
+Phase 8 ships behind a flag with shadow-mode comparison. The audit format:
+
+```typescript
+// .nax/findings-shadow/<storyId>/<timestamp>.json
+{
+  "phase": "acceptance.fix.findingsV2",
+  "legacyResult": { testIssues: string[], sourceIssues: string[], verdict: ... },
+  "newResult":    { findings: Finding[], verdict: ... },
+  "divergence":   { /* field-by-field diff */ }
+}
+```
+
+Audit lives under `.nax/findings-shadow/` so it's gitignored alongside other run artefacts. Disable via `acceptance.fix.findingsAuditEnabled: false` after one release of green soak.
+
+### 2.4 Test data plumbing
+
+Each phase that touches LLM ops needs fixture updates:
+
+- `test/fixtures/llm-output/` if it exists, else create.
+- Each phase's PR includes both the legacy LLM output (still accepted by the adapter) and a sample new-shape output asserting parse correctness.
+
+### 2.5 Helper imports
+
+All phases import from the existing barrel:
+
+```typescript
+import type { Finding, FindingSeverity, FindingSource, FixTarget } from "src/findings";
+import { compareSeverity, findingKey, SEVERITY_ORDER } from "src/findings";
+```
+
+No internal-path imports per [.claude/rules/project-conventions.md](../../.claude/rules/project-conventions.md).
+
+---
+
+## 3. Phase 2 — Plugin reviewer adapter
+
+**Goal:** Internal nax converts `ReviewFinding[]` (plugin contract) → `Finding[]` at the IReviewPlugin call site. Plugin contract stays stable.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| `src/findings/path-utils.ts` (new) | Add `rebaseToWorkdir()` helper (used by phases 3+) |
+| `src/findings/adapters/plugin.ts` (new) | `pluginToFinding(rf: ReviewFinding, workdir: string): Finding` |
+| `src/findings/index.ts` | Re-export `pluginToFinding`, `rebaseToWorkdir` |
+| [src/review/orchestrator.ts:378-420](../../src/review/orchestrator.ts#L378) | Convert plugin output via `pluginToFinding()`; store as `Finding[]` internally |
+| [src/review/types.ts:98](../../src/review/types.ts#L98) | `PluginReviewerResult.findings?` becomes `Finding[]` (was `ReviewFinding[]`) |
+| `src/pipeline/stages/review.ts` | Update audit serialiser to emit `Finding[]` shape |
+| `test/integration/review/review-plugin-integration.test.ts:74-140` | Assert plugin findings convert correctly |
+
+### Adapter shape
+
+```typescript
+// src/findings/adapters/plugin.ts
+export function pluginToFinding(rf: ReviewFinding, workdir: string): Finding {
+  return {
+    source: "plugin",
+    tool: rf.source,            // plugin's tool name (semgrep, eslint, snyk, ...)
+    severity: rf.severity,      // "critical" | "error" | "warning" | "info" | "low" — already aligned
+    category: rf.category ?? "general",
+    rule: rf.ruleId,
+    file: rf.file,              // plugin contract is workdir-relative — no rebasing
+    line: rf.line,
+    column: rf.column,
+    endLine: rf.endLine,
+    endColumn: rf.endColumn,
+    message: rf.message,
+    meta: rf.url ? { url: rf.url } : undefined,
+  };
+}
+```
+
+### Tests
+
+- New: `test/unit/findings/adapters/plugin.test.ts` — round-trip conversion, optional fields, severity passthrough.
+- Update: `review-plugin-integration.test.ts` — assert `pluginCalled` still works AND `result.pluginReviewers[*].findings` is now `Finding[]`.
+
+### Validation gate
+
+- `bun run typecheck` passes
+- `bun run test test/unit/findings/ test/integration/review/` passes
+- `bun run build` succeeds
+- Hand-run: plugin reviewer fixture from existing tests; verify audit output is valid JSON
+
+### Rollback
+
+`git revert` of the PR. Plugin contract was never exposed — no external consumers.
+
+### PR commit message template
+
+```
+feat(findings): plugin reviewer adapter (ADR-021 phase 2)
+
+Convert ReviewFinding -> Finding at the IReviewPlugin call site.
+Plugin contract unchanged.
+
+Refs: #867
+```
+
+---
+
+## 4. Phase 3 — Lint
+
+**Goal:** Lint output (Biome JSON, ESLint JSON, text) emits `Finding[]`. Scope-split routing reads `Finding[]`.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| `src/findings/adapters/lint.ts` (new) | `lintDiagnosticToFinding(d: LintDiagnostic, workdir, cwd, tool): Finding` |
+| `src/findings/index.ts` | Re-export `lintDiagnosticToFinding` |
+| [src/review/lint-parsing/parse.ts:14-23](../../src/review/lint-parsing/parse.ts#L14) | `parseLintOutput()` returns `LintParseResult` extended with `findings: Finding[]` |
+| [src/pipeline/stages/autofix-scope-split.ts:82-130](../../src/pipeline/stages/autofix-scope-split.ts#L82) | `splitByOutputParsing()` for lint reads `Finding[]` and partitions by `fixTarget` |
+| `src/review/lint-parsing/strategies/{eslint,biome,text}.ts` | Each strategy emits `Finding[]` directly |
+| New: `test/unit/findings/adapters/lint.test.ts` | Per-strategy conversion tests |
+
+### Adapter shape
+
+```typescript
+// src/findings/adapters/lint.ts
+export function lintDiagnosticToFinding(
+  d: LintDiagnostic,
+  workdir: string,
+  cwd: string,
+  tool: "biome" | "eslint" | "text"
+): Finding {
+  return {
+    source: "lint",
+    tool,
+    severity: d.severity,
+    category: d.category ?? "lint",
+    rule: d.ruleId,
+    file: rebaseToWorkdir(d.file, cwd, workdir),
+    line: d.line,
+    column: d.column,
+    endLine: d.endLine,
+    endColumn: d.endColumn,
+    message: d.message,
+    suggestion: d.fix ?? undefined,
+    fixTarget: undefined, // derived by cycle layer from file vs testFilePatterns
+  };
+}
+```
+
+### `splitByOutputParsing` rewrite
+
+Old behaviour: parse output → bucket diagnostics by file path against `testFilePatterns` → rebuild `ReviewCheckResult` per scope.
+
+New behaviour: parse output → `Finding[]` → partition by `(fixTarget ?? deriveFixTarget(finding.file, testFilePatterns))` → group into `{testFindings, sourceFindings}: Finding[][]`.
+
+```typescript
+function splitFindingsByFixTarget(
+  findings: Finding[],
+  testFilePatterns: TestFilePattern[]
+): { testFindings: Finding[]; sourceFindings: Finding[] } {
+  const test: Finding[] = [];
+  const source: Finding[] = [];
+  for (const f of findings) {
+    const target = f.fixTarget ?? (f.file && isTestFile(f.file, testFilePatterns) ? "test" : "source");
+    (target === "test" ? test : source).push(f);
+  }
+  return { testFindings: test, sourceFindings: source };
+}
+```
+
+### Tests
+
+- Per strategy: parse fixture → assert `Finding[]` shape (file paths workdir-relative, severity normalised, rule preserved).
+- `splitByOutputParsing` partitioning: mixed source+test findings → both buckets non-empty; all-source → testFindings empty; all-test → sourceFindings empty.
+- Existing autofix integration tests pass without modification (return shape preserved at the `ReviewCheckResult` boundary; `findings: Finding[]` is the only internal change).
+
+### Validation gate
+
+- `bun run typecheck` passes
+- All lint-parsing unit tests pass
+- All autofix integration tests pass
+- Hand-run: real Biome lint failure on a fixture; verify scope-split correctness
+
+### Risk mitigation
+
+The scope-split routing is hot — every lint failure goes through it. Mitigation:
+- Unit tests cover all three lint strategies (Biome, ESLint, text).
+- Integration test in `test/integration/autofix/` exercising end-to-end: lint failure → scope-split → implementer / test-writer routing.
+
+### Rollback
+
+`git revert`. The internal `findings: Finding[]` field is the only addition; old `output: string` remains for backward compatibility during this phase.
+
+---
+
+## 5. Phase 4 — Typecheck
+
+**Goal:** tsc output emits `Finding[]`. Same shape change as lint.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| `src/findings/adapters/typecheck.ts` (new) | `tscDiagnosticToFinding(d: TypecheckDiagnostic, workdir): Finding` |
+| `src/findings/index.ts` | Re-export `tscDiagnosticToFinding` |
+| [src/review/typecheck-parsing/parse.ts:12-24](../../src/review/typecheck-parsing/parse.ts#L12) | `parseTypecheckOutput()` returns `TypecheckParseResult` extended with `findings: Finding[]` |
+| [src/pipeline/stages/autofix-scope-split.ts:132-150](../../src/pipeline/stages/autofix-scope-split.ts#L132) | `splitByTypecheckOutputParsing()` reads `Finding[]` |
+| `src/review/typecheck-parsing/strategies/tsc.ts` | Emits `Finding[]` |
+| New: `test/unit/findings/adapters/typecheck.test.ts` | Conversion tests |
+
+### Adapter shape
+
+```typescript
+// src/findings/adapters/typecheck.ts
+export function tscDiagnosticToFinding(d: TypecheckDiagnostic, workdir: string): Finding {
+  return {
+    source: "typecheck",
+    tool: "tsc",
+    severity: "error",  // tsc errors are always blocking
+    category: "type-error",
+    rule: `TS${d.code}`,
+    file: path.relative(workdir, d.file), // tsc emits absolute paths
+    line: d.line,
+    column: d.column,
+    message: d.message,
+    fixTarget: undefined,
+  };
+}
+```
+
+### Tests
+
+- `tscDiagnosticToFinding`: absolute path → workdir-relative; `TS2304` rule preserved; severity always "error".
+- `splitByTypecheckOutputParsing` partitions correctly.
+
+### Validation gate
+
+Same as phase 3.
+
+### Rollback
+
+`git revert`.
+
+---
+
+## 6. Phase 5 — TDD verifier / AC parser
+
+**Goal:** Test runner output (AC parsing) emits `Finding[]`. AC sentinels (`AC-HOOK`, `AC-ERROR`) become first-class findings.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| `src/findings/adapters/test-runner.ts` (new) | `acFailureToFinding(failedAcId, testFile, output): Finding` and `acSentinelToFinding(sentinel, output): Finding` |
+| [src/test-runners/ac-parser.ts](../../src/test-runners/ac-parser.ts) | `parseAcResults()` extended to emit `Finding[]` alongside legacy AC-id strings |
+| [src/pipeline/stages/acceptance.ts](../../src/pipeline/stages/acceptance.ts) | Where `"AC-ERROR"` is pushed: build a `Finding` instead and add to a parallel `findings: Finding[]` field on `ctx.acceptanceFailures` |
+| `src/pipeline/types.ts` | `AcceptanceFailures` interface adds `findings: Finding[]` |
+| New: `test/unit/findings/adapters/test-runner.test.ts` | Sentinel + failure conversion |
+
+### Sentinel mapping
+
+| Sentinel | New Finding |
+|:---|:---|
+| `AC-N` (a real AC failed) | `{ source: "test-runner", category: "assertion-failure", rule: "AC-N", message: <test output excerpt>, fixTarget: "source", file: <test-file>, line: <test-line if parseable> }` |
+| `AC-HOOK` (lifecycle timeout) | `{ source: "test-runner", category: "hook-failure", message: "beforeAll/afterAll hook timed out", fixTarget: "test" }` |
+| `AC-ERROR` (runner crashed) | `{ source: "test-runner", category: "test-runner-error", severity: "critical", message: "Test runner crashed before test bodies ran", fixTarget: "test" }` |
+
+### Tests
+
+- Each sentinel → correct `Finding` shape and `category`.
+- Real AC failure → `rule: "AC-N"` correctly extracted.
+
+### Validation gate
+
+- All acceptance unit tests pass.
+- Hand-run: dogfood `nax-dogfood/fixtures/hello-lint`; verify `ctx.acceptanceFailures.findings` matches `failedACs` 1:1 plus any sentinels.
+
+### Rollback
+
+`git revert`. Both legacy `failedACs: string[]` and new `findings: Finding[]` coexist during this phase.
+
+---
+
+## 7. Phase 6 — Adversarial review
+
+**Goal:** Adversarial review emits `Finding[]`. Carry-forward cache uses `Finding[]`. Severity rename in OUTPUT_SCHEMA prompt block.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| `src/findings/adapters/llm-review.ts` (new) | `llmReviewFindingToFinding(lf: LlmReviewFinding, source, workdir): Finding` |
+| `src/findings/index.ts` | Re-export adapter |
+| [src/operations/adversarial-review.ts:67-105](../../src/operations/adversarial-review.ts#L67) | `parse()` returns `Finding[]` (was `LlmReviewFinding[]`) |
+| [src/operations/adversarial-review.ts:28](../../src/operations/adversarial-review.ts#L28) | `priorAdversarialFindings?: AdversarialFindingsCache` — cache shape upgraded to `{ round: number; findings: Finding[] }` |
+| [src/review/types.ts:171-182](../../src/review/types.ts#L171) | `AdversarialFindingsCache.findings: Finding[]` |
+| [src/prompts/builders/adversarial-review-builder.ts:202-225](../../src/prompts/builders/adversarial-review-builder.ts#L202) | `buildPriorFindingsBlock()` reads `Finding[]` |
+| [src/prompts/builders/adversarial-review-builder.ts:206](../../src/prompts/builders/adversarial-review-builder.ts#L206) | `OUTPUT_SCHEMA` rename `"warn"` → `"warning"` |
+| Same file, severity guide text | rename `"warn"` → `"warning"` |
+| `src/review/runner.ts`, `src/review/orchestrator.ts`, `src/review/adversarial.ts`, `src/pipeline/types.ts` | Update import sites and field types where `AdversarialFindingsCache` flows |
+| New: `test/unit/findings/adapters/llm-review.test.ts` | Conversion tests including legacy `"warn"` parse path |
+| Update: existing adversarial review unit/integration tests | Assert `Finding[]` shape |
+
+### Adapter shape
+
+```typescript
+// src/findings/adapters/llm-review.ts
+export function llmReviewFindingToFinding(
+  lf: LlmReviewFinding,
+  source: "semantic-review" | "adversarial-review",
+  workdir: string  // used to validate file is workdir-relative
+): Finding {
+  const meta: Record<string, unknown> = {};
+  if (lf.verifiedBy) meta.verifiedBy = lf.verifiedBy;
+  return {
+    source,
+    severity: normalizeSeverity(lf.severity), // "warn" → "warning" already handled
+    category: lf.category ?? (source === "semantic-review" ? "ac-coverage" : "general"),
+    rule: lf.acId,                            // semantic uses AC ID; adversarial leaves undefined
+    file: lf.file,
+    line: lf.line,
+    message: lf.issue,
+    suggestion: lf.suggestion,
+    fixTarget: source === "adversarial-review" && lf.category === "test-gap" ? "test" : undefined,
+    meta: Object.keys(meta).length > 0 ? meta : undefined,
+  };
+}
+```
+
+### Severity rename impact (verified count)
+
+[Per Explore report:](#critical-review-items) 25 `"warn"` literal occurrences. The non-prompt sites are all already `normalizeSeverity()`-handled — no behaviour change. Only the 3 prompt-builder sites (2 in adversarial-review-builder, 1 in review-builder) actively change.
+
+### Tests
+
+- `llmReviewFindingToFinding`: legacy `"warn"` input → `"warning"` output.
+- New shape `{severity: "warning"}` → preserved.
+- `verifiedBy` lands in `meta.verifiedBy`.
+- `acId` lands in `rule` for semantic, `undefined` for adversarial.
+- Adversarial `category: "test-gap"` → `fixTarget: "test"`.
+- Carry-forward: round 2 prompt contains the verdict-first table from round 1's findings.
+
+### Validation gate
+
+- `bun run typecheck` passes
+- All adversarial unit + integration tests pass
+- Hand-run: trigger adversarial review on a fixture; observe round-2 prompt contains `Prior Adversarial Findings` block populated from `Finding[]`.
+
+### Risk mitigation
+
+This is the highest-risk phase pre-acceptance. Mitigations:
+- The `normalizeSeverity` adapter handles legacy `"warn"` outputs — even if an LLM produces old-shape findings, parsing succeeds.
+- 25-site severity-literal audit confirmed no test asserts on `"warn"` directly.
+- Existing integration tests for adversarial cache carry-forward stay green.
+
+### Rollback
+
+`git revert`. Cache shape change is contained to one cache type; no on-disk persistence (cache lives in `PipelineContext`).
+
+---
+
+## 8. Phase 7 — Semantic review
+
+**Goal:** Semantic review emits `Finding[]`. Persisted `SemanticVerdict` uses `Finding[]`. `verifiedBy` evidence preserved via `meta`.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| [src/operations/semantic-review.ts:70-104](../../src/operations/semantic-review.ts#L70) | `parse()` returns `Finding[]` |
+| [src/prompts/builders/review-builder.ts](../../src/prompts/builders/review-builder.ts) `SEMANTIC_OUTPUT_SCHEMA` | Severity rename `"warn"` → `"warning"` |
+| [src/prompts/builders/review-builder.ts:186-211](../../src/prompts/builders/review-builder.ts#L186) | `buildAttemptContextBlock()` reads `Finding[]` |
+| [src/acceptance/types.ts:139-150](../../src/acceptance/types.ts#L139) | `SemanticVerdict.findings: Finding[]` (was `ReviewFinding[]`) |
+| [src/acceptance/semantic-verdict.ts:48-90](../../src/acceptance/semantic-verdict.ts#L48) | `persistSemanticVerdict()` and `loadSemanticVerdicts()` work with `Finding[]` shape (compatible per explore report — `Finding` is a superset of `ReviewFinding`) |
+| [src/review/semantic-evidence.ts](../../src/review/semantic-evidence.ts) | `substantiateSemanticEvidence()` operates on `Finding[]`; downgrade-to-unverifiable preserved |
+| Update: `test/unit/acceptance/semantic-verdict.test.ts` | Round-trip persist/load with `Finding[]` |
+
+### Persistence compatibility
+
+Existing semantic-verdict JSON files on disk look like:
+
+```json
+{
+  "storyId": "US-001",
+  "passed": false,
+  "findings": [{ "ruleId": "AC-2", "severity": "error", "file": "src/foo.ts", "line": 10, "message": "..." }]
+}
+```
+
+After phase 7, they look like:
+
+```json
+{
+  "storyId": "US-001",
+  "passed": false,
+  "findings": [{ "source": "semantic-review", "rule": "AC-2", "severity": "error", "file": "src/foo.ts", "line": 10, "message": "...", "category": "ac-coverage" }]
+}
+```
+
+**Backward-compat loader**: `loadSemanticVerdicts()` detects legacy shape (no `source` field on findings) and applies the `pluginToFinding`-equivalent migration in-memory. Forward writes use the new shape only. Stale-file readback works for one release.
+
+### Tests
+
+- `loadSemanticVerdicts()` accepts both legacy and new shapes.
+- `persistSemanticVerdict()` writes new shape only.
+- Round-trip: persist → load → equal `Finding[]`.
+- `substantiateSemanticEvidence()`: unverified `severity: "error"` → `severity: "unverifiable"` (existing behaviour preserved).
+
+### Validation gate
+
+- `bun run typecheck` passes
+- All semantic-related unit tests pass
+- Integration test: write legacy-shape semantic verdict to disk, load via new code, verify migration
+
+### Rollback
+
+`git revert`. The backward-compat loader stays — no need to revert disk format.
+
+---
+
+## 9. Phase 8 — Acceptance diagnose
+
+**Goal:** Acceptance diagnose op emits structured `findings: Finding[]` with `fixTarget` per item. Behind feature flag for soak.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| `src/findings/adapters/acceptance-diagnose.ts` (new) | `acceptanceLegacyToFindings({testIssues, sourceIssues}): Finding[]` for fallback parsing |
+| [src/operations/acceptance-diagnose.ts:30-68](../../src/operations/acceptance-diagnose.ts#L30) | `parse()` returns `findings: Finding[]`; legacy `string[]` shape parsed via fallback adapter |
+| [src/prompts/builders/acceptance-builder.ts:171-195](../../src/prompts/builders/acceptance-builder.ts#L171) | New OUTPUT_SCHEMA when flag enabled — asks LLM for structured `findings: Finding[]` |
+| [src/acceptance/types.ts:153-165](../../src/acceptance/types.ts#L153) | `DiagnosisResult.findings: Finding[]` (additive); `testIssues`/`sourceIssues` deprecated but preserved |
+| [src/execution/lifecycle/acceptance-fix.ts:129-180](../../src/execution/lifecycle/acceptance-fix.ts#L129) | `applyFix()` reads `findings: Finding[]` filtered by `fixTarget` (verdict still routes when findings empty — preserves fast-paths per ADR-022) |
+| [src/config/schemas.ts](../../src/config/schemas.ts) | New schema field `acceptance.fix.findingsV2: boolean` (default `false`) |
+| [src/config/selectors.ts](../../src/config/selectors.ts) | Expose flag to op via `acceptanceConfigSelector` |
+| New: `test/unit/findings/adapters/acceptance-diagnose.test.ts` | Legacy shape → `Finding[]` migration |
+| New: `test/integration/acceptance/findings-v2.test.ts` | End-to-end flag on/off both work |
+
+### Prompt schema diff
+
+Legacy:
+
+```json
+{
+  "verdict": "...",
+  "reasoning": "...",
+  "confidence": 0.0-1.0,
+  "testIssues": ["...", "..."],
+  "sourceIssues": ["...", "..."]
+}
+```
+
+New (when flag enabled):
+
+```json
+{
+  "verdict": "...",
+  "reasoning": "...",
+  "confidence": 0.0-1.0,
+  "findings": [
+    {
+      "fixTarget": "source" | "test",
+      "category": "stdout-capture" | "ac-mismatch" | "framework-misuse" | "missing-impl" | "import-path" | "hook-failure" | "test-runner-error" | "stub-test" | "other",
+      "file": "src/greeting.ts",
+      "line": 12,
+      "message": "...",
+      "suggestion": "..."
+    }
+  ]
+}
+```
+
+### Fallback parser
+
+When LLM emits the legacy shape (or partial), `parse()` calls `acceptanceLegacyToFindings()`:
+
+```typescript
+function acceptanceLegacyToFindings(
+  testIssues: string[] | undefined,
+  sourceIssues: string[] | undefined
+): Finding[] {
+  const findings: Finding[] = [];
+  for (const msg of testIssues ?? []) {
+    findings.push({
+      source: "acceptance-diagnose",
+      severity: "error",
+      category: "legacy",
+      message: msg,
+      fixTarget: "test",
+    });
+  }
+  for (const msg of sourceIssues ?? []) {
+    findings.push({
+      source: "acceptance-diagnose",
+      severity: "error",
+      category: "legacy",
+      message: msg,
+      fixTarget: "source",
+    });
+  }
+  return findings;
+}
+```
+
+### Shadow audit
+
+When flag is enabled, the op writes a comparison artefact under `.nax/findings-shadow/<storyId>/<timestamp>.json` showing legacy vs new parse output (per §2.3). One release of green soak before flipping default.
+
+### Verdict fast-path preservation
+
+The diagnose fast-paths in [acceptance-fix.ts:78-116](../../src/execution/lifecycle/acceptance-fix.ts#L78) (`implement-only`, `semanticVerdicts.every(passed)`, `isTestLevelFailure`) produce `verdict` without invoking the LLM. They emit `findings: []` and `applyFix` falls through to verdict-based routing. ADR-022 phase 4 will formalise this as `appliesToVerdict` on FixStrategy. For phase 8 we just preserve current behaviour — `applyFix` checks `findings.length > 0` first, falls back to verdict.
+
+### Tests
+
+- `acceptanceLegacyToFindings()`: empty arrays → empty findings; mixed → correct `fixTarget` partition.
+- Flag off: prompt asks for legacy schema; parse returns legacy shape; behaviour unchanged.
+- Flag on, LLM returns new shape: parsed correctly.
+- Flag on, LLM returns legacy shape: fallback parser invoked; same result.
+- Fast-path verdicts (`implement-only`, etc.): findings empty, verdict drives routing.
+- AC-HOOK / AC-ERROR sentinels appear as `Finding` entries (depends on phase 5).
+
+### Validation gate
+
+- `bun run typecheck` passes
+- All acceptance unit + integration tests pass
+- Dogfood `nax-dogfood/fixtures/hello-lint` with flag on: verify diagnose prompt audit contains structured findings; verify `applyFix` routes correctly.
+- Shadow audit: one release of green soak before flag flip.
+
+### Risk mitigation
+
+- Feature flag default off — zero behavioural change in production.
+- Legacy fallback parser handles all old LLM outputs.
+- Verdict fast-paths preserved verbatim.
+- Shadow comparison artefact catches divergence in CI dogfood.
+
+### Rollback
+
+Flag flip back to off. No code revert needed.
+
+### Flag flip plan
+
+Two PRs after phase 8 lands:
+1. After 1 release green soak: change default to `true`.
+2. After 1 more release: delete the flag and the legacy parser; old fallback adapter goes to ADR-022 phase 4 cleanup.
+
+---
+
+## 10. Phase 9 — Cleanup
+
+**Goal:** Delete legacy types now that no consumers reference them.
+
+### Prerequisites
+
+- All ADR-021 phases 2–8 merged
+- All ADR-022 consumer migrations merged (cycle, prior-iterations builder, acceptance migration)
+- `acceptance.fix.findingsV2` flag flipped to default `true` and stable for one release
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| [src/operations/types.ts:171-191](../../src/operations/types.ts#L171) | Delete `LlmReviewFinding` interface |
+| [src/operations/types.ts:204-210](../../src/operations/types.ts#L204) | Update `parseLlmReviewShape()` signature to return `Finding` |
+| [src/review/types.ts:171-182](../../src/review/types.ts#L171) | Delete `AdversarialFindingsCache` shape; replace with `type AdversarialFindingsCache = { round: number; findings: Finding[] }` (or fold into `Iteration` per ADR-022) |
+| [src/acceptance/types.ts:153-165](../../src/acceptance/types.ts#L153) | Delete `DiagnosisResult.testIssues / sourceIssues` fields |
+| [src/operations/index.ts](../../src/operations/index.ts) | Remove `LlmReviewFinding` export |
+| Various consumer files | Update import statements; remove fallback adapters; remove `acceptance.fix.findingsV2` flag plumbing |
+| [src/prompts/builders/acceptance-builder.ts](../../src/prompts/builders/acceptance-builder.ts) | Remove legacy OUTPUT_SCHEMA branch |
+| `test/**/*.test.ts` | Delete tests asserting on legacy field shapes |
+
+### Validation gate
+
+- `bun run typecheck` passes (all references resolve to `Finding` / `Finding[]`)
+- Full test suite passes
+- `git grep "LlmReviewFinding\|testIssues\|sourceIssues" -- 'src/'` returns nothing
+- Build artefact size unchanged or smaller
+
+### Rollback
+
+`git revert`. Cleanup is purely deletion + import cleanup — no semantic change.
+
+---
+
+## 11. Cross-cutting checklist
+
+Before merging each PR:
+
+- [ ] `bun run typecheck` passes
+- [ ] `bun run lint` passes
+- [ ] Pre-commit hooks pass (process.cwd, adapter-wrap, dispatch-context)
+- [ ] All new code has `storyId` as first key in logger calls (per [.claude/rules/project-conventions.md](../../.claude/rules/project-conventions.md))
+- [ ] No `process.cwd()` outside CLI entry points
+- [ ] File path SSOT: `Finding.file` workdir-relative everywhere
+- [ ] Severity normalised via `normalizeSeverity()` at parse boundary
+- [ ] No internal-path imports — barrel only
+- [ ] PR refs `#867`
+- [ ] Adapter has unit tests under `test/unit/findings/adapters/`
+
+## 12. Tracking
+
+| Phase | PR | Status | Notes |
+|:---|:---|:---|:---|
+| 1 | #868 | open | Wire-format types + helpers |
+| 2 | tbd | not started | Plugin adapter |
+| 3 | tbd | not started | Lint |
+| 4 | tbd | not started | Typecheck |
+| 5 | tbd | not started | TDD verifier / AC parser |
+| 6 | tbd | not started | Adversarial + severity rename |
+| 7 | tbd | not started | Semantic + persistence migration |
+| 8 | tbd | not started | Acceptance diagnose (flagged) |
+| 9 | tbd | not started | Cleanup (gated on ADR-022) |
+
+## 13. References
+
+- [ADR-021](../adr/ADR-021-findings-and-fix-strategy-ssot.md) — Finding type SSOT (this plan implements its phase 2+)
+- [ADR-022](../adr/ADR-022-fix-strategy-and-cycle.md) — Fix Strategy + Cycle Orchestration (companion; phases 4 onward of ADR-022 consume `Finding[]` from this plan)
+- [Issue #867](https://github.com/nathapp-io/nax/issues/867) — umbrella tracker
+- Phase-1 PR [#868](https://github.com/nathapp-io/nax/pull/868) — wire-format types
+- [src/findings/](../../src/findings/) — types module
+- [.claude/rules/monorepo-awareness.md](../../.claude/rules/monorepo-awareness.md) — workdir / packageDir conventions
+- [.claude/rules/forbidden-patterns.md](../../.claude/rules/forbidden-patterns.md) — Prompt builder convention

--- a/docs/specs/2026-05-02-adr-021-implementation-plan.md
+++ b/docs/specs/2026-05-02-adr-021-implementation-plan.md
@@ -42,7 +42,8 @@ Phases 2–7 are unblocked from each other. Phase 8 depends on phase 5 (AC senti
 **Read side (already handled — no change needed):**
 - [src/review/adversarial-helpers.ts:56-62](../../src/review/adversarial-helpers.ts#L56) `normalizeSeverity()` — `"warn"` → `"warning"`
 - [src/review/semantic-helpers.ts:55](../../src/review/semantic-helpers.ts#L55) — same
-- [src/review/dialogue.ts](../../src/review/dialogue.ts) — same
+
+> **Note:** `src/review/dialogue.ts` does NOT define or import `normalizeSeverity` — it is not part of the read-side adapter chain. Dialogue results are parsed via `adversarial-helpers.ts` upstream before they reach dialogue.ts.
 
 The `normalizeSeverity` adapters already accept legacy `"warn"` and emit `"warning"`. Rename in prompt schema is forward-only — LLMs producing legacy `"warn"` continue to parse correctly via the adapter. No flag required; the rename is safe across all releases.
 
@@ -129,11 +130,11 @@ No internal-path imports per [.claude/rules/project-conventions.md](../../.claud
 export function pluginToFinding(rf: ReviewFinding, workdir: string): Finding {
   return {
     source: "plugin",
-    tool: rf.source,            // plugin's tool name (semgrep, eslint, snyk, ...)
-    severity: rf.severity,      // "critical" | "error" | "warning" | "info" | "low" — already aligned
+    tool: rf.source ?? "plugin", // rf.source is optional (ReviewFinding.source?: string) — default "plugin"
+    severity: rf.severity,       // "critical" | "error" | "warning" | "info" | "low" — already aligned
     category: rf.category ?? "general",
     rule: rf.ruleId,
-    file: rf.file,              // plugin contract is workdir-relative — no rebasing
+    file: rf.file,               // plugin contract is workdir-relative — no rebasing
     line: rf.line,
     column: rf.column,
     endLine: rf.endLine,
@@ -361,7 +362,7 @@ Same as phase 3.
 | `src/findings/adapters/llm-review.ts` (new) | `llmReviewFindingToFinding(lf: LlmReviewFinding, source, workdir): Finding` |
 | `src/findings/index.ts` | Re-export adapter |
 | [src/operations/adversarial-review.ts:67-105](../../src/operations/adversarial-review.ts#L67) | `parse()` returns `Finding[]` (was `LlmReviewFinding[]`) |
-| [src/operations/adversarial-review.ts:28](../../src/operations/adversarial-review.ts#L28) | `priorAdversarialFindings?: AdversarialFindingsCache` — cache shape upgraded to `{ round: number; findings: Finding[] }` |
+| [src/operations/adversarial-review.ts:28](../../src/operations/adversarial-review.ts#L28) | `priorAdversarialFindings?: AdversarialFindingsCache` — cache shape upgraded to `{ round: number; findings: Finding[] }` (**not** `acceptance-diagnose.ts` — that is phase 8) |
 | [src/review/types.ts:171-182](../../src/review/types.ts#L171) | `AdversarialFindingsCache.findings: Finding[]` |
 | [src/prompts/builders/adversarial-review-builder.ts:202-225](../../src/prompts/builders/adversarial-review-builder.ts#L202) | `buildPriorFindingsBlock()` reads `Finding[]` |
 | [src/prompts/builders/adversarial-review-builder.ts:206](../../src/prompts/builders/adversarial-review-builder.ts#L206) | `OUTPUT_SCHEMA` rename `"warn"` → `"warning"` |
@@ -385,7 +386,7 @@ export function llmReviewFindingToFinding(
     source,
     severity: normalizeSeverity(lf.severity), // "warn" → "warning" already handled
     category: lf.category ?? (source === "semantic-review" ? "ac-coverage" : "general"),
-    rule: lf.acId,                            // semantic uses AC ID; adversarial leaves undefined
+    rule: lf.acId,    // semantic uses AC ID; adversarial: acId is always undefined — Finding.rule is optional
     file: lf.file,
     line: lf.line,
     message: lf.issue,
@@ -443,6 +444,10 @@ This is the highest-risk phase pre-acceptance. Mitigations:
 | [src/acceptance/semantic-verdict.ts:48-90](../../src/acceptance/semantic-verdict.ts#L48) | `persistSemanticVerdict()` and `loadSemanticVerdicts()` work with `Finding[]` shape (compatible per explore report — `Finding` is a superset of `ReviewFinding`) |
 | [src/review/semantic-evidence.ts](../../src/review/semantic-evidence.ts) | `substantiateSemanticEvidence()` operates on `Finding[]`; downgrade-to-unverifiable preserved |
 | Update: `test/unit/acceptance/semantic-verdict.test.ts` | Round-trip persist/load with `Finding[]` |
+
+### Import-path note
+
+`src/acceptance/types.ts:149` imports `ReviewFinding` from `../plugins/types` (not `../plugins/extensions`). Both export a `ReviewFinding` interface with the same fields. The backward-compat loader in `loadSemanticVerdicts()` treats them identically — legacy detection uses the absence of a `source` field, which neither import path adds. No path consolidation required in this phase; the two definitions are field-compatible.
 
 ### Persistence compatibility
 
@@ -629,11 +634,11 @@ Two PRs after phase 8 lands:
 | File | Change |
 |:---|:---|
 | [src/operations/types.ts:171-191](../../src/operations/types.ts#L171) | Delete `LlmReviewFinding` interface |
-| [src/operations/types.ts:204-210](../../src/operations/types.ts#L204) | Update `parseLlmReviewShape()` signature to return `Finding` |
-| [src/review/types.ts:171-182](../../src/review/types.ts#L171) | Delete `AdversarialFindingsCache` shape; replace with `type AdversarialFindingsCache = { round: number; findings: Finding[] }` (or fold into `Iteration` per ADR-022) |
+| [src/operations/types.ts:204-210](../../src/operations/types.ts#L204) | Delete `parseLlmReviewShape()` — by phase 9 it has no callers (phases 6+7 adapters handle conversion directly). Do NOT "update its return type"; just delete the function. |
+| [src/review/types.ts:171-182](../../src/review/types.ts#L171) | Delete `AdversarialFindingsCache` entirely — ADR-022 phase 5 has already migrated all carry-forward to `Iteration<Finding>[]`. Do NOT keep a thin alias; ADR-022 phase 8 is the authority for this deletion and may land after this phase. Co-ordinate so only one PR deletes the type. |
 | [src/acceptance/types.ts:153-165](../../src/acceptance/types.ts#L153) | Delete `DiagnosisResult.testIssues / sourceIssues` fields |
 | [src/operations/index.ts](../../src/operations/index.ts) | Remove `LlmReviewFinding` export |
-| Various consumer files | Update import statements; remove fallback adapters; remove `acceptance.fix.findingsV2` flag plumbing |
+| Various consumer files | Update import statements; remove fallback adapters; remove `acceptance.fix.findingsV2` flag plumbing. **Do NOT delete `acceptance.fix.cycleV2`** — that flag is owned by ADR-022 phase 8. |
 | [src/prompts/builders/acceptance-builder.ts](../../src/prompts/builders/acceptance-builder.ts) | Remove legacy OUTPUT_SCHEMA branch |
 | `test/**/*.test.ts` | Delete tests asserting on legacy field shapes |
 
@@ -641,7 +646,8 @@ Two PRs after phase 8 lands:
 
 - `bun run typecheck` passes (all references resolve to `Finding` / `Finding[]`)
 - Full test suite passes
-- `git grep "LlmReviewFinding\|testIssues\|sourceIssues" -- 'src/'` returns nothing
+- `git grep "LlmReviewFinding\|testIssues\|sourceIssues\|parseLlmReviewShape\|acceptanceLegacyToFindings\|findingsV2" -- 'src/'` returns nothing
+- For full cleanup coverage also run: `git grep "previousFailure\|AdversarialFindingsCache\|PriorFailure\|buildPriorFindingsBlock\|buildAttemptContextBlock\|cycleV2" -- 'src/'` per ADR-022 phase 8 gate
 - Build artefact size unchanged or smaller
 
 ### Rollback

--- a/docs/specs/2026-05-02-adr-022-implementation-plan.md
+++ b/docs/specs/2026-05-02-adr-022-implementation-plan.md
@@ -24,6 +24,8 @@ ADR-022 introduces unified fix orchestration on top of ADR-021's `Finding` wire 
 | 7 | Autofix migration (lint + typecheck + adversarial + plugin + test-writer/implementer) | medium-high | `quality.autofix.cycleV2` (shadow mode 2 releases) |
 | 8 | Cleanup (delete legacy carry-forward types; remove flags) | zero | n/a |
 
+**Hard prerequisite:** ADR-021 phase 1 (`src/findings/types.ts` + `src/findings/index.ts`) must be merged (PR #868) before any phase of this plan begins. Every phase imports from `src/findings` — if the barrel doesn't exist, `bun run typecheck` will fail immediately.
+
 **Migration model:** each phase is a single PR. Phases 1–3 are foundational and unblocked by anything outside ADR-022 phase 1. Phases 4–7 each consume `Finding[]` produced by the corresponding ADR-021 producer phase — see §2.4 for the cross-ADR sequencing.
 
 ## 2. Cross-phase concerns
@@ -102,8 +104,8 @@ No internal-path imports. Per [.claude/rules/project-conventions.md](../../.clau
 
 | File | Change |
 |:---|:---|
-| `src/findings/cycle-types.ts` (new) | All cycle/strategy types |
-| `src/findings/index.ts` | Re-export new types |
+| `src/findings/cycle-types.ts` (new) | All cycle/strategy types including `FixCycle<F>` |
+| `src/findings/index.ts` | Re-export new types (`Iteration`, `FixApplied`, `FixStrategy`, `FixCycle`, `FixCycleContext`, `FixCycleConfig`, `FixCycleResult`, `FixCycleBailReason`, `IterationOutcome`) |
 
 ### Type exports
 
@@ -175,6 +177,18 @@ export interface FixCycleResult<F extends Finding = Finding> {
   iterations: Iteration<F>[];
   findings: F[];
 }
+
+/** Input shape for runFixCycle — callers construct this and pass it. */
+export interface FixCycle<F extends Finding = Finding> {
+  name: string;                                          // for telemetry: "acceptance", "autofix", …
+  findings: F[];
+  iterations: Iteration<F>[];
+  strategies: FixStrategy<F, any, any, any>[];
+  validate: (ctx: FixCycleContext) => Promise<F[]>;
+  config: FixCycleConfig;
+  /** Optional verdict for fast-path strategies when findings is empty. */
+  verdict?: string;
+}
 ```
 
 ### Tests
@@ -228,21 +242,11 @@ import { getSafeLogger } from "../logger";
 import { callOp } from "../operations";
 import { findingKey } from "./types";
 import { classifyOutcome } from "./outcome";
+// FixCycle is defined in cycle-types.ts and re-exported from the barrel — import from there, not redefined here
 import type {
-  FixApplied, FixCycleConfig, FixCycleContext, FixCycleResult, FixStrategy, Iteration,
+  FixApplied, FixCycle, FixCycleConfig, FixCycleContext, FixCycleResult, FixStrategy, Iteration,
 } from "./cycle-types";
 import type { Finding } from "./types";
-
-export interface FixCycle<F extends Finding = Finding> {
-  name: string;                                          // for telemetry: "acceptance", "autofix", …
-  findings: F[];
-  iterations: Iteration<F>[];
-  strategies: FixStrategy<F, any, any, any>[];
-  validate: (ctx: FixCycleContext) => Promise<F[]>;
-  config: FixCycleConfig;
-  /** Optional verdict for fast-path strategies when findings is empty. */
-  verdict?: string;
-}
 
 export async function runFixCycle<F extends Finding = Finding>(
   cycle: FixCycle<F>,
@@ -487,8 +491,8 @@ function aggregateOutcomes(per: IterationOutcome[]): IterationOutcome {
 
 ```typescript
 // src/prompts/builders/prior-iterations.ts
-import type { Finding } from "../../findings/types";
-import type { Iteration } from "../../findings/cycle-types";
+// Use the barrel — never internal-path imports (project-conventions.md)
+import type { Finding, Iteration } from "../../findings";
 
 const FALSIFIED_LINE =
   'When outcome is "unchanged", the prior hypothesis is FALSIFIED — the change did\n' +
@@ -673,6 +677,10 @@ The diagnosis prompt builder now receives `priorIterations: Iteration<Finding>[]
 
 The fast-paths in [acceptance-fix.ts:78-116](../../src/execution/lifecycle/acceptance-fix.ts#L78) (`implement-only`, `semanticVerdicts.every(passed)`, `isTestLevelFailure`) **stay where they are** — they produce `DiagnosisResult` with `findings: []` and `verdict: "..."`. The cycle's `appliesToVerdict` selector picks up the right strategy.
 
+### Flag interaction: `cycleV2` vs `findingsV2`
+
+`cycleV2: true` with `findingsV2: false` is a **supported degraded mode**. When `findingsV2` is off the LLM still returns the old `testIssues/sourceIssues` schema; `applyFixV2` calls `acceptanceLegacyToFindings(diagnosis)` as fallback (since `diagnosis.findings` will be `undefined`). The cycle runs correctly on the resulting `Finding[]`. No config-schema validation is needed to enforce ordering between the two flags — the fallback path handles the gap transparently.
+
 ### Flag-gated implementation
 
 ```typescript
@@ -774,7 +782,7 @@ The prompt builder change is one line — `buildPriorFindingsBlock(...)` becomes
 ### Risk mitigation
 
 - No prompt schema change (the table format is the only change to prompt content; prompt instructions unaffected).
-- `AdversarialFindingsCache` stays in `src/review/types.ts` as a deprecated alias for one release before phase 8 deletes it.
+- `AdversarialFindingsCache` stays in `src/review/types.ts` as a **deprecated alias** (`type AdversarialFindingsCache = { round: number; findings: Finding[] }`) for one release before phase 8 deletes it. ADR-021 phase 9 must NOT independently delete or replace this type — phase 8 of this plan is the sole authority. Co-ordinate PRs so phase 8 lands first if both land in the same release window.
 
 ### Rollback
 
@@ -837,7 +845,11 @@ Same as phase 5, scoped to semantic review.
 
 ### Strategy set
 
-Six strategies in the autofix cycle:
+ADR-022 §1b lists six logical finding sources for the autofix cycle (lint, typecheck, adversarial, plugin, test-writer, implementer). In the implementation, these map to **two strategies** — not six — because the existing `runAgentRectification` already dispatches all source-targeted findings (lint, typecheck, adversarial, plugin) to a single implementer agent, and test-targeted findings to a single test-writer agent. The discriminant is `fixTarget`, not source. Adding per-source strategies would require splitting a single agent invocation into 4+ separate ops with no benefit — the implementer already receives all source findings in one prompt.
+
+The six-source framing in ADR-022 §1b describes logical groupings (what findings flow through the cycle), not distinct fix ops. This two-strategy set is the correct implementation.
+
+Two strategies in the autofix cycle:
 
 ```typescript
 const strategies: FixStrategy<Finding, any, any, any>[] = [
@@ -924,6 +936,8 @@ When flag is on:
 
 CI dogfood validates ≥95% routing agreement before flag flip. Two release cycles of soak.
 
+> **Gitignore:** `.nax/cycle-shadow/` must be covered by the `.nax/` gitignore pattern (same as `.nax/findings-shadow/` from ADR-021 phase 8). Verify the project `.gitignore` covers both before the phase 7 PR lands.
+
 ### Tests
 
 - Flag off: legacy path runs; existing autofix tests pass.
@@ -986,19 +1000,21 @@ Refs: #867
 |:---|:---|
 | [src/execution/lifecycle/acceptance-loop.ts](../../src/execution/lifecycle/acceptance-loop.ts) | Delete `previousFailure: string` accumulator and all writes |
 | [src/execution/lifecycle/acceptance-fix.ts](../../src/execution/lifecycle/acceptance-fix.ts) | Delete `applyFixLegacy`; rename `applyFixV2` → `applyFix` |
+| [src/operations/acceptance-diagnose.ts](../../src/operations/acceptance-diagnose.ts) | Remove `previousFailure?: string` from `AcceptanceDiagnoseInput` — the field becomes dead once `acceptance-loop.ts` stops passing it |
 | [src/review/types.ts:171-182](../../src/review/types.ts#L171) | Delete `AdversarialFindingsCache` (already migrated to `Iteration<Finding>[]`) |
-| [src/prompts/builders/adversarial-review-builder.ts:202-225](../../src/prompts/builders/adversarial-review-builder.ts#L202) | Delete `buildPriorFindingsBlock` (callers now use `buildPriorIterationsBlock`) |
+| [src/prompts/builders/adversarial-review-builder.ts:202-225](../../src/prompts/builders/adversarial-review-builder.ts#L202) | Delete `buildPriorFindingsBlock` — already replaced by one-line delegation in phase 5; now fully unused. Also remove the delegation shim added in phase 5. |
 | [src/prompts/builders/review-builder.ts:65-68,186-211](../../src/prompts/builders/review-builder.ts#L65) | Delete `PriorFailure` and `buildAttemptContextBlock` |
 | [src/pipeline/stages/autofix-agent.ts](../../src/pipeline/stages/autofix-agent.ts), [autofix.ts](../../src/pipeline/stages/autofix.ts) | Delete legacy `runAgentRectification`; rename V2 to canonical |
-| [src/config/schemas.ts](../../src/config/schemas.ts) | Delete `acceptance.fix.cycleV2` and `quality.autofix.cycleV2` fields |
+| [src/config/schemas.ts](../../src/config/schemas.ts) | Delete `acceptance.fix.cycleV2` and `quality.autofix.cycleV2` fields. **This is the sole authority for these deletions** — ADR-021 phase 9 must not delete them. |
 | Various tests | Delete tests asserting on legacy field shapes / flag-off behaviour |
 
 ### Validation gate
 
 - `bun run typecheck` passes
 - Full test suite passes
-- `git grep "previousFailure\|AdversarialFindingsCache\|PriorFailure\|buildPriorFindingsBlock\|buildAttemptContextBlock\|cycleV2" -- 'src/'` returns nothing
-- Feature flag config schema no longer mentions the deprecated flags
+- `git grep "previousFailure\|AdversarialFindingsCache\|PriorFailure\|buildPriorFindingsBlock\|buildAttemptContextBlock\|cycleV2\|AcceptanceDiagnoseInput" -- 'src/'` returns nothing (or only valid non-deprecated usages of `AcceptanceDiagnoseInput`)
+- Feature flag config schema no longer mentions `cycleV2` fields
+- For full end-to-end coverage, also run the ADR-021 phase 9 gate: `git grep "LlmReviewFinding\|testIssues\|sourceIssues\|parseLlmReviewShape\|acceptanceLegacyToFindings\|findingsV2" -- 'src/'` returns nothing
 
 ### Rollback
 

--- a/docs/specs/2026-05-02-adr-022-implementation-plan.md
+++ b/docs/specs/2026-05-02-adr-022-implementation-plan.md
@@ -1,0 +1,1047 @@
+# ADR-022 Implementation Plan — Phases 1–8
+
+**Date:** 2026-05-02
+**Status:** Pre-implementation — settles per-phase scope before PR work begins
+**Scope:** Detailed plan for `runFixCycle` + `FixStrategy` + `buildPriorIterationsBlock` and per-subsystem migrations
+**ADRs:** [ADR-022](../adr/ADR-022-fix-strategy-and-cycle.md) (this plan); [ADR-021](../adr/ADR-021-findings-and-fix-strategy-ssot.md) (companion — wire format)
+**Companion plan:** [docs/specs/2026-05-02-adr-021-implementation-plan.md](./2026-05-02-adr-021-implementation-plan.md)
+**Tracking:** [#867](https://github.com/nathapp-io/nax/issues/867)
+
+---
+
+## 1. Overview
+
+ADR-022 introduces unified fix orchestration on top of ADR-021's `Finding` wire format. Eight phases:
+
+| Phase | Goal | Risk | Flag |
+|:---|:---|:---|:---|
+| 1 | Cycle types in `src/findings/cycle-types.ts` | zero | none |
+| 2 | `runFixCycle` + `classifyOutcome` in `src/findings/cycle.ts` | low | none |
+| 3 | `buildPriorIterationsBlock` shared prompt helper | zero | none |
+| 4 | Acceptance migration (ships dogfood regression fix) | medium | `acceptance.fix.cycleV2` |
+| 5 | Adversarial migration | low | none |
+| 6 | Semantic migration | low | none |
+| 7 | Autofix migration (lint + typecheck + adversarial + plugin + test-writer/implementer) | medium-high | `quality.autofix.cycleV2` (shadow mode 2 releases) |
+| 8 | Cleanup (delete legacy carry-forward types; remove flags) | zero | n/a |
+
+**Migration model:** each phase is a single PR. Phases 1–3 are foundational and unblocked by anything outside ADR-022 phase 1. Phases 4–7 each consume `Finding[]` produced by the corresponding ADR-021 producer phase — see §2.4 for the cross-ADR sequencing.
+
+## 2. Cross-phase concerns
+
+### 2.1 ADR-021 / ADR-022 phase ordering
+
+Each ADR-022 consumer migration depends on the corresponding ADR-021 producer migration:
+
+| ADR-022 phase | Consumes Finding[] from | Blocked by |
+|:---|:---|:---|
+| Phase 4 — acceptance | acceptance-diagnose op | ADR-021 phase 8 (acceptance prompt schema) |
+| Phase 5 — adversarial | adversarial-review op | ADR-021 phase 6 (adversarial migration) |
+| Phase 6 — semantic | semantic-review op | ADR-021 phase 7 (semantic migration) |
+| Phase 7 — autofix | lint, typecheck, plugin, tdd-verifier ops | ADR-021 phases 2–5 |
+
+Phases 1–3 of ADR-022 only depend on ADR-021 phase 1 (already shipped on PR #868). They can land in parallel with any ADR-021 producer migration.
+
+### 2.2 Feature flag policy
+
+| Flag | Phase | Lifecycle |
+|:---|:---|:---|
+| `acceptance.fix.cycleV2` | 4 | Default off → flip default after 1 release green soak → delete in phase 8 |
+| `quality.autofix.cycleV2` | 7 | Default off + shadow mode → flip default after 2 release green soak → delete in phase 8 |
+
+Shadow mode for autofix runs **both** legacy `runAgentRectification` and new `runFixCycle` for the same input, compares routing decisions, and writes a divergence report to `.nax/cycle-shadow/<storyId>/<timestamp>.json` per ADR-022 "Audit logging" section. CI dogfood validates ≥95% routing agreement before flag flip.
+
+### 2.3 Telemetry contract
+
+Per ADR-022's "Telemetry" section — every cycle iteration emits:
+
+```typescript
+logger.info("findings.cycle", "iteration completed", {
+  storyId,                                // first key
+  packageDir,
+  cycleName: "acceptance" | "autofix" | "semantic" | …,
+  iterationNum,
+  strategiesRan: string[],
+  outcome: IterationOutcome,
+  findingsBefore: number,
+  findingsAfter: number,
+  costUsd: number,
+});
+```
+
+Bail events emit `"findings.cycle", "cycle exited"` with `reason` and (when applicable) `exhaustedStrategy` / `bailDetail`. Validator-retry events emit `"findings.cycle", "validator retry"` with the original error chained via `cause`.
+
+This shape is **mandatory** at every cycle exit point in phases 4–7. Tests verify the log entries appear.
+
+### 2.4 Helper imports
+
+All phases import from the existing barrel:
+
+```typescript
+import type { Finding, FindingSeverity, FindingSource, FixTarget } from "src/findings";
+import { compareSeverity, findingKey } from "src/findings";
+// added in phase 1:
+import type {
+  Iteration, IterationOutcome, FixApplied,
+  FixStrategy, FixCycleContext, FixCycleConfig, FixCycleResult, FixCycleBailReason,
+} from "src/findings";
+// added in phase 2:
+import { runFixCycle, classifyOutcome } from "src/findings";
+// added in phase 3:
+import { buildPriorIterationsBlock } from "src/prompts";
+```
+
+No internal-path imports. Per [.claude/rules/project-conventions.md](../../.claude/rules/project-conventions.md).
+
+---
+
+## 3. Phase 1 — Cycle types
+
+**Goal:** Add orchestration types (`Iteration`, `FixStrategy`, `FixCycleContext`, `FixCycleConfig`, `FixCycleResult`, `FixCycleBailReason`) without behaviour. Mirrors ADR-021 phase 1 in style.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| `src/findings/cycle-types.ts` (new) | All cycle/strategy types |
+| `src/findings/index.ts` | Re-export new types |
+
+### Type exports
+
+```typescript
+// src/findings/cycle-types.ts
+
+import type { CallContext, Operation } from "../operations/types";
+import type { Finding } from "./types";
+
+export type IterationOutcome =
+  | "resolved"
+  | "partial"
+  | "regressed"
+  | "unchanged"
+  | "regressed-different-source";
+
+export interface FixApplied {
+  strategyName: string;
+  op: string;
+  targetFiles: string[];
+  summary: string;             // first ~500 chars of agent response or stdout
+  costUsd?: number;
+}
+
+export interface Iteration<F extends Finding = Finding> {
+  iterationNum: number;        // 1-indexed
+  findingsBefore: F[];
+  fixesApplied: FixApplied[];
+  findingsAfter: F[];
+  outcome: IterationOutcome;
+  startedAt: string;           // ISO timestamps for forensic logs
+  finishedAt: string;
+}
+
+export interface FixCycleContext {
+  callCtx: CallContext;
+  workdir: string;
+}
+
+export interface FixStrategy<F extends Finding = Finding, I = unknown, O = unknown, C = unknown> {
+  name: string;
+  appliesTo: (finding: F) => boolean;
+  /** Optional fallback selector consulted only when findings.length === 0. */
+  appliesToVerdict?: (verdict: string) => boolean;
+  fixOp: Operation<I, O, C>;
+  buildInput: (findings: F[], priorIterations: Iteration<F>[], ctx: FixCycleContext) => I;
+  bailWhen?: (priorIterations: Iteration<F>[]) => string | null;
+  maxAttempts: number;
+  coRun?: "exclusive" | "co-run-sequential";   // default: "exclusive"
+}
+
+export interface FixCycleConfig {
+  maxAttemptsTotal: number;    // default 10
+  validatorRetries: number;    // default 1 — retry-once-then-terminal (ADR-022 §4)
+}
+
+export type FixCycleBailReason =
+  | "no-strategy-matches"
+  | "max-attempts-per-strategy"
+  | "max-attempts-total"
+  | "bailed-by-strategy"
+  | "validator-error";
+
+export interface FixCycleResult<F extends Finding = Finding> {
+  resolved: boolean;
+  reason?: FixCycleBailReason;
+  bailDetail?: string;
+  exhaustedStrategy?: string;
+  iterations: Iteration<F>[];
+  findings: F[];
+}
+```
+
+### Tests
+
+None — types only, no behaviour. Phase 2 unit tests will exercise these via the cycle implementation.
+
+### Validation gate
+
+- `bun run typecheck` passes
+- Pre-commit hooks pass (process-cwd, adapter-wrap, dispatch-context)
+
+### Rollback
+
+`git revert`. New file in a new namespace; no consumers.
+
+### PR commit message template
+
+```
+feat(findings): cycle and strategy types (ADR-022 phase 1)
+
+Add Iteration, FixApplied, FixStrategy, FixCycleConfig, FixCycleResult,
+FixCycleBailReason in src/findings/cycle-types.ts. Types only — no
+behaviour, no consumers in this PR. Phase 2 brings runFixCycle and
+classifyOutcome.
+
+Refs: #867
+```
+
+---
+
+## 4. Phase 2 — `runFixCycle` and `classifyOutcome`
+
+**Goal:** Implement the cycle loop and outcome classifier. Pure logic; thoroughly unit-tested.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| `src/findings/cycle.ts` (new) | `runFixCycle<F>(cycle, ctx)` — main loop |
+| `src/findings/outcome.ts` (new) | `classifyOutcome(before, after)` + `classifySingleSource` helper |
+| `src/findings/index.ts` | Re-export `runFixCycle`, `classifyOutcome` |
+| `test/unit/findings/cycle.test.ts` (new) | All bail paths, all outcomes, co-run discipline |
+| `test/unit/findings/outcome.test.ts` (new) | Per-source bucket + aggregate algorithm |
+
+### `runFixCycle` skeleton
+
+```typescript
+// src/findings/cycle.ts
+import { errorMessage } from "../utils/errors";
+import { getSafeLogger } from "../logger";
+import { callOp } from "../operations";
+import { findingKey } from "./types";
+import { classifyOutcome } from "./outcome";
+import type {
+  FixApplied, FixCycleConfig, FixCycleContext, FixCycleResult, FixStrategy, Iteration,
+} from "./cycle-types";
+import type { Finding } from "./types";
+
+export interface FixCycle<F extends Finding = Finding> {
+  name: string;                                          // for telemetry: "acceptance", "autofix", …
+  findings: F[];
+  iterations: Iteration<F>[];
+  strategies: FixStrategy<F, any, any, any>[];
+  validate: (ctx: FixCycleContext) => Promise<F[]>;
+  config: FixCycleConfig;
+  /** Optional verdict for fast-path strategies when findings is empty. */
+  verdict?: string;
+}
+
+export async function runFixCycle<F extends Finding = Finding>(
+  cycle: FixCycle<F>,
+  ctx: FixCycleContext,
+): Promise<FixCycleResult<F>> {
+  const logger = getSafeLogger();
+  const storyId = ctx.callCtx.storyId ?? "unknown";
+
+  while (true) {
+    // 1. Resolved?
+    if (cycle.findings.length === 0 && !cycle.verdict) {
+      return { resolved: true, iterations: cycle.iterations, findings: [] };
+    }
+
+    // 2. Total budget
+    if (cycle.iterations.length >= cycle.config.maxAttemptsTotal) {
+      logger?.warn("findings.cycle", "cycle exited", {
+        storyId, cycleName: cycle.name, reason: "max-attempts-total",
+        totalIterations: cycle.iterations.length, maxAttemptsTotal: cycle.config.maxAttemptsTotal,
+      });
+      return { resolved: false, reason: "max-attempts-total", iterations: cycle.iterations, findings: cycle.findings };
+    }
+
+    // 3. Strategy selection
+    const matching = selectStrategies(cycle);
+    if (matching.length === 0) {
+      logger?.warn("findings.cycle", "cycle exited", {
+        storyId, cycleName: cycle.name, reason: "no-strategy-matches",
+      });
+      return { resolved: false, reason: "no-strategy-matches", iterations: cycle.iterations, findings: cycle.findings };
+    }
+
+    // 4. Per-strategy bail / attempt-cap checks
+    for (const strategy of matching) {
+      const used = cycle.iterations
+        .flatMap((i) => i.fixesApplied)
+        .filter((f) => f.strategyName === strategy.name).length;
+      if (used >= strategy.maxAttempts) {
+        return {
+          resolved: false, reason: "max-attempts-per-strategy",
+          exhaustedStrategy: strategy.name, iterations: cycle.iterations, findings: cycle.findings,
+        };
+      }
+      const bail = strategy.bailWhen?.(cycle.iterations);
+      if (bail) {
+        return {
+          resolved: false, reason: "bailed-by-strategy", bailDetail: bail,
+          iterations: cycle.iterations, findings: cycle.findings,
+        };
+      }
+    }
+
+    // 5. Run strategies (sequential per coRun discipline)
+    const startedAt = new Date().toISOString();
+    const findingsBefore = cycle.findings;
+    const fixesApplied: FixApplied[] = [];
+
+    for (const strategy of matching) {
+      const input = strategy.buildInput(cycle.findings, cycle.iterations, ctx);
+      const output = await callOp(ctx.callCtx, strategy.fixOp, input as any);
+      fixesApplied.push({
+        strategyName: strategy.name,
+        op: strategy.fixOp.name,
+        targetFiles: extractTargetFiles(output),
+        summary: extractSummary(output),
+        costUsd: extractCost(output),
+      });
+    }
+
+    // 6. Validate (with retry)
+    const findingsAfter = await validateWithRetry(cycle.validate, ctx, cycle.config.validatorRetries, storyId, cycle.name);
+    if (findingsAfter === null) {
+      return { resolved: false, reason: "validator-error", iterations: cycle.iterations, findings: cycle.findings };
+    }
+
+    // 7. Classify and push iteration
+    const outcome = classifyOutcome(findingsBefore, findingsAfter);
+    const iteration: Iteration<F> = {
+      iterationNum: cycle.iterations.length + 1,
+      findingsBefore, fixesApplied, findingsAfter, outcome,
+      startedAt, finishedAt: new Date().toISOString(),
+    };
+    cycle.iterations.push(iteration);
+    cycle.findings = findingsAfter;
+    cycle.verdict = undefined; // verdict is consumed once; subsequent iterations rely on findings
+
+    logger?.info("findings.cycle", "iteration completed", {
+      storyId, cycleName: cycle.name,
+      iterationNum: iteration.iterationNum,
+      strategiesRan: fixesApplied.map((f) => f.strategyName),
+      outcome,
+      findingsBefore: findingsBefore.length, findingsAfter: findingsAfter.length,
+      costUsd: fixesApplied.reduce((sum, f) => sum + (f.costUsd ?? 0), 0),
+    });
+  }
+}
+
+function selectStrategies<F extends Finding>(cycle: FixCycle<F>): FixStrategy<F, any, any, any>[] {
+  const all = cycle.strategies;
+  const matchByFinding = (s: FixStrategy<F, any, any, any>) =>
+    cycle.findings.some(s.appliesTo);
+  const matchByVerdict = (s: FixStrategy<F, any, any, any>) =>
+    cycle.verdict !== undefined && s.appliesToVerdict?.(cycle.verdict);
+
+  const matching = cycle.findings.length === 0 && cycle.verdict
+    ? all.filter(matchByVerdict)
+    : all.filter(matchByFinding);
+
+  if (matching.length === 0) return [];
+
+  const exclusive = matching.find((s) => (s.coRun ?? "exclusive") === "exclusive");
+  if (exclusive) return [exclusive];
+  return matching.filter((s) => s.coRun === "co-run-sequential");
+}
+
+async function validateWithRetry<F extends Finding>(
+  validate: (ctx: FixCycleContext) => Promise<F[]>,
+  ctx: FixCycleContext,
+  retries: number,
+  storyId: string,
+  cycleName: string,
+): Promise<F[] | null> {
+  const logger = getSafeLogger();
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await validate(ctx);
+    } catch (err) {
+      logger?.warn("findings.cycle", "validator retry", {
+        storyId, cycleName, attempt, error: errorMessage(err), cause: err,
+      });
+      if (attempt === retries) return null;
+    }
+  }
+  return null;
+}
+
+// extractTargetFiles / extractSummary / extractCost — operation-output-specific helpers;
+// their shape depends on the fixOp's Output type. Implemented as duck-typing readers.
+```
+
+### `classifyOutcome` skeleton
+
+```typescript
+// src/findings/outcome.ts
+import { findingKey } from "./types";
+import type { Finding } from "./types";
+import type { IterationOutcome } from "./cycle-types";
+
+export function classifyOutcome(before: Finding[], after: Finding[]): IterationOutcome {
+  if (after.length === 0) return "resolved";
+
+  const sources = new Set([...before, ...after].map((f) => f.source));
+  const perSource: IterationOutcome[] = [];
+  for (const source of sources) {
+    perSource.push(
+      classifySingleSource(
+        before.filter((f) => f.source === source),
+        after.filter((f) => f.source === source),
+      ),
+    );
+  }
+  return aggregateOutcomes(perSource);
+}
+
+function classifySingleSource(before: Finding[], after: Finding[]): IterationOutcome {
+  const beforeKeys = new Set(before.map(findingKey));
+  const afterKeys = new Set(after.map(findingKey));
+  if (afterKeys.size === 0) return "resolved";
+  const sameSet = beforeKeys.size === afterKeys.size && [...beforeKeys].every((k) => afterKeys.has(k));
+  if (sameSet) return "unchanged";
+  const newOnes = [...afterKeys].some((k) => !beforeKeys.has(k));
+  if (newOnes) return "regressed";
+  return "partial";
+}
+
+function aggregateOutcomes(per: IterationOutcome[]): IterationOutcome {
+  if (per.every((o) => o === "resolved")) return "resolved";
+  if (per.some((o) => o === "regressed-different-source")) return "regressed-different-source";
+  if (per.some((o) => o === "regressed")) return "regressed";
+  if (per.every((o) => o === "unchanged")) return "unchanged";
+  return "partial";
+}
+```
+
+`regressed-different-source` is detected at the cycle level when the after-set introduces sources that weren't in before — handled in `classifyOutcome` (not shown above for brevity; tracked in phase 2 implementation).
+
+### Tests
+
+`test/unit/findings/cycle.test.ts`:
+
+- Empty findings + no verdict → resolved
+- Single strategy, single attempt, validator returns `[]` → resolved
+- Per-strategy cap exceeded → reason `max-attempts-per-strategy`, `exhaustedStrategy` set
+- Cycle-wide cap exceeded → reason `max-attempts-total`
+- No strategy matches → reason `no-strategy-matches`
+- `bailWhen` returns string → reason `bailed-by-strategy`, `bailDetail` set
+- Validator throws once → retried; second attempt succeeds → continues
+- Validator throws twice → reason `validator-error`
+- Mixed-target findings → both strategies co-run; one iteration; both `FixApplied` recorded
+- Empty findings + verdict → `appliesToVerdict` selects strategy
+- Telemetry: log entry per iteration; bail event with reason; validator retry event
+
+`test/unit/findings/outcome.test.ts`:
+
+- All resolved → `resolved`
+- Same set → `unchanged`
+- Strict subset → `partial`
+- New finding appears → `regressed`
+- Cross-source regression → `regressed-different-source`
+- Mixed sources, mixed outcomes → aggregated correctly
+
+### Validation gate
+
+- `bun run typecheck` passes
+- `bun test test/unit/findings/` passes (target: 100% line coverage on cycle.ts and outcome.ts)
+- `bun run lint` passes
+
+### Risk mitigation
+
+- All bail paths covered by tests before any consumer migrates.
+- `findingKey` reused from ADR-021 phase 1 (already shipped) — no new equality logic.
+
+### Rollback
+
+`git revert`. Pure additions; no consumer changes yet.
+
+---
+
+## 5. Phase 3 — `buildPriorIterationsBlock`
+
+**Goal:** Single shared helper that renders an `Iteration<F>[]` history as a verdict-first markdown table for prompt builders.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| `src/prompts/builders/prior-iterations.ts` (new) | `buildPriorIterationsBlock<F>(iterations: Iteration<F>[]): string` |
+| `src/prompts/index.ts` | Re-export |
+| `test/unit/prompts/prior-iterations.test.ts` (new) | Snapshot tests for empty / single / multi-iteration / `unchanged` |
+
+### Skeleton
+
+```typescript
+// src/prompts/builders/prior-iterations.ts
+import type { Finding } from "../../findings/types";
+import type { Iteration } from "../../findings/cycle-types";
+
+const FALSIFIED_LINE =
+  'When outcome is "unchanged", the prior hypothesis is FALSIFIED — the change did\n' +
+  "not affect what was tested. Choose a different category before producing a new\n" +
+  "verdict. Do NOT repeat fixes listed above.\n";
+
+export function buildPriorIterationsBlock<F extends Finding = Finding>(
+  iterations: Iteration<F>[],
+): string {
+  if (iterations.length === 0) return "";
+
+  const rows = iterations.map((it) => {
+    const strategies = it.fixesApplied.map((f) => f.strategyName).join(", ");
+    const files = uniq(it.fixesApplied.flatMap((f) => f.targetFiles)).join(", ");
+    const summary = summariseFindings(it.findingsBefore, it.findingsAfter);
+    return `| ${it.iterationNum} | ${strategies} | ${files} | ${it.outcome} | ${summary} |`;
+  });
+
+  const hasUnchanged = iterations.some((i) => i.outcome === "unchanged");
+
+  return [
+    "## Prior Iterations — verdict required before new analysis",
+    "",
+    "| # | Strategies run | Files touched | Outcome | Findings before → after |",
+    "|---|----------------|---------------|---------|------------------------|",
+    ...rows,
+    "",
+    hasUnchanged ? FALSIFIED_LINE : "",
+  ].filter(Boolean).join("\n");
+}
+
+function summariseFindings(before: Finding[], after: Finding[]): string {
+  const fmt = (f: Finding[]) => {
+    if (f.length === 0) return "0";
+    const cats = uniq(f.map((x) => x.category));
+    const head = cats.slice(0, 3).map((c) => `[${c}]`).join(" ");
+    const more = cats.length > 3 ? ` +${cats.length - 3} more` : "";
+    return `${f.length} ${head}${more}`;
+  };
+  return `${fmt(before)} → ${fmt(after)}`;
+}
+
+function uniq<T>(arr: T[]): T[] {
+  return [...new Set(arr)];
+}
+```
+
+### Tests
+
+- Empty iterations → `""`
+- One iteration, outcome=`partial` → table with 1 row, no falsified line
+- One iteration, outcome=`unchanged` → table with 1 row, falsified line present
+- Three iterations → all rows in chronological order
+- Multi-file `targetFiles` → comma-joined; deduped
+- More than 3 categories in summary → first 3 + "+N more"
+
+### Validation gate
+
+- `bun run typecheck` passes
+- `bun test test/unit/prompts/prior-iterations.test.ts` passes
+- Snapshot stable across two runs
+
+### Rollback
+
+`git revert`. Helper has no consumers yet.
+
+---
+
+## 6. Phase 4 — Acceptance migration
+
+**Goal:** Replace `applyFix` (acceptance) with `runFixCycle`. Ships the dogfood regression fix. Behind feature flag.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| [src/execution/lifecycle/acceptance-fix.ts:153](../../src/execution/lifecycle/acceptance-fix.ts#L153) | `applyFix` becomes a thin adapter — constructs strategies, builds `FixCycle`, invokes `runFixCycle`. Behind `acceptance.fix.cycleV2` flag |
+| [src/execution/lifecycle/acceptance-loop.ts:299](../../src/execution/lifecycle/acceptance-loop.ts#L299) | Replace `previousFailure: string` accumulator with `Iteration<Finding>[]` carry-forward |
+| [src/operations/acceptance-fix.ts](../../src/operations/acceptance-fix.ts) | Fix ops gain `priorIterations: Iteration<Finding>[]` input field |
+| [src/prompts/builders/acceptance-builder.ts:171-195](../../src/prompts/builders/acceptance-builder.ts#L171) | `buildDiagnosisPromptTemplate` consumes `priorIterations` via `buildPriorIterationsBlock` |
+| [src/prompts/builders/acceptance-builder.ts:364-378](../../src/prompts/builders/acceptance-builder.ts#L364) | `buildTestFixPrompt` / `buildSourceFixPrompt` consume `priorIterations` |
+| [src/config/schemas.ts](../../src/config/schemas.ts) | Add `acceptance.fix.cycleV2: z.boolean().default(false)` |
+| [src/config/selectors.ts](../../src/config/selectors.ts) | Expose flag through `acceptanceConfigSelector` |
+| `test/integration/acceptance/cycle-v2.test.ts` (new) | Flag on/off behaviour parity |
+
+### Strategy declaration
+
+```typescript
+// inside applyFix() / runAcceptanceLoop() entry
+function buildAcceptanceStrategies(
+  ctx: AcceptanceLoopContext,
+  failures: { failedACs: string[]; testOutput: string },
+  testFileContent: string,
+  acceptanceTestPath: string,
+): FixStrategy<Finding, any, any, any>[] {
+  return [
+    {
+      name: "acceptance-source-fix",
+      appliesTo: (f) => f.fixTarget === "source",
+      appliesToVerdict: (v) => v === "source_bug" || v === "both",
+      fixOp: acceptanceFixSourceOp,
+      buildInput: (findings, priorIterations, ctx) => ({
+        testOutput: failures.testOutput,
+        diagnosisReasoning: ctx.diagnosis?.reasoning ?? "",
+        acceptanceTestPath,
+        testFileContent,
+        priorIterations,
+      }),
+      maxAttempts: 3,
+      coRun: "co-run-sequential",
+    },
+    {
+      name: "acceptance-test-fix",
+      appliesTo: (f) => f.fixTarget === "test",
+      appliesToVerdict: (v) => v === "test_bug" || v === "both",
+      fixOp: acceptanceFixTestOp,
+      buildInput: (findings, priorIterations, ctx) => ({
+        testOutput: failures.testOutput,
+        diagnosisReasoning: ctx.diagnosis?.reasoning ?? "",
+        failedACs: failures.failedACs,
+        acceptanceTestPath,
+        testFileContent,
+        priorIterations,
+      }),
+      maxAttempts: 3,
+      coRun: "co-run-sequential",
+    },
+  ];
+}
+```
+
+The strategies are constructed inline at the call site to capture closure context (`failures`, `testFileContent`, `acceptanceTestPath`) — per ADR-022 §3 "FixStrategy is a value, not a class."
+
+### Cycle entry point
+
+```typescript
+async function applyFixV2(opts: ApplyFixOptions): Promise<ApplyFixResult> {
+  const { ctx, failures, diagnosis, priorIterations } = opts;
+  const findings = diagnosis.findings ?? acceptanceLegacyToFindings(diagnosis); // §6 fallback
+
+  const strategies = buildAcceptanceStrategies(ctx, failures, testFileContent, acceptanceTestPath);
+  const cycle: FixCycle<Finding> = {
+    name: "acceptance",
+    findings,
+    iterations: priorIterations ?? [],
+    strategies,
+    validate: async (cycleCtx) => {
+      // Re-run acceptance test stage; convert failures back to Finding[]
+      const result = await acceptanceStage.execute(buildPipelineContext(ctx));
+      return convertAcceptanceFailuresToFindings(result);
+    },
+    config: { maxAttemptsTotal: ctx.config.acceptance.maxRetries, validatorRetries: 1 },
+    verdict: diagnosis.verdict,
+  };
+
+  const result = await runFixCycle(cycle, fixCallCtx(ctx));
+  // Persist iterations into outer loop's priorIterations accumulator (replaces previousFailure: string)
+  ctx.priorIterations = result.iterations;
+  return { cost: 0 };
+}
+```
+
+### Outer loop changes
+
+[acceptance-loop.ts:299](../../src/execution/lifecycle/acceptance-loop.ts#L299) currently:
+
+```typescript
+previousFailure += `\n---\nAttempt ${acceptanceRetries}/${maxRetries}: verdict=${diagnosis.verdict}, …`;
+```
+
+Replaced with:
+
+```typescript
+// priorIterations is accumulated by applyFix's runFixCycle invocation
+// and threaded to the next iteration's diagnosis call
+const priorIterations = ctx.priorIterations ?? [];
+```
+
+The diagnosis prompt builder now receives `priorIterations: Iteration<Finding>[]` instead of `previousFailure: string`.
+
+### Verdict fast-paths preserved
+
+The fast-paths in [acceptance-fix.ts:78-116](../../src/execution/lifecycle/acceptance-fix.ts#L78) (`implement-only`, `semanticVerdicts.every(passed)`, `isTestLevelFailure`) **stay where they are** — they produce `DiagnosisResult` with `findings: []` and `verdict: "..."`. The cycle's `appliesToVerdict` selector picks up the right strategy.
+
+### Flag-gated implementation
+
+```typescript
+async function applyFix(opts: ApplyFixOptions): Promise<ApplyFixResult> {
+  if (opts.ctx.config.acceptance.fix?.cycleV2 === true) {
+    return applyFixV2(opts);
+  }
+  return applyFixLegacy(opts); // existing implementation, untouched
+}
+```
+
+### Tests
+
+`test/integration/acceptance/cycle-v2.test.ts`:
+
+- Flag off: legacy `applyFix` runs unchanged; existing tests pass
+- Flag on, verdict=source_bug + findings: source-fix strategy runs; one iteration; validator re-runs; outcome classified
+- Flag on, verdict=both + mixed findings: both strategies co-run in one iteration; validator runs once at end
+- Flag on, fast-path verdict (no findings): `appliesToVerdict` selects strategy
+- Flag on, two iterations with identical post-fix findings: outcome=`unchanged`; falsified line in next prompt
+- Diagnosis prompt contains `## Prior Iterations` table when `priorIterations.length > 0`
+- Telemetry: `findings.cycle` log entry per iteration with correct fields
+
+### Validation gate
+
+- `bun run typecheck` passes
+- All existing acceptance tests pass with flag default off
+- New cycle tests pass with flag on
+- Dogfood `nax-dogfood/fixtures/hello-lint`:
+  - Flag off: existing failure mode reproduces (sanity check)
+  - Flag on: attempt 2's diagnose prompt contains the verdict-first table from attempt 1; the LLM picks a different strategy (no longer the `2>&1` bogus fix)
+
+### Risk mitigation
+
+- Flag defaults off; production unaffected.
+- Legacy `applyFix` stays in the codebase during phase 4; no behaviour change with flag off.
+- Shadow-mode comparison: when flag is on, write `.nax/cycle-shadow/<storyId>/<timestamp>.json` showing both legacy and v2 routing decisions for offline diff.
+
+### Rollback
+
+Flag back to off — no code revert needed. After 1 release of green soak: change default to `true`. After 1 more release: phase 8 deletes the flag and the legacy path.
+
+### PR commit message template
+
+```
+feat(acceptance): runFixCycle migration (ADR-022 phase 4)
+
+Replace applyFix's hand-rolled diagnose-fix-validate flow with
+runFixCycle driven by [acceptance-source-fix, acceptance-test-fix]
+strategies. Ships the dogfood regression fix — verdict-first
+prior-iterations table appears in the diagnose prompt when prior
+attempts produced unchanged output.
+
+Behind acceptance.fix.cycleV2 flag, default off.
+
+Refs: #867
+```
+
+---
+
+## 7. Phase 5 — Adversarial migration
+
+**Goal:** Replace `AdversarialFindingsCache` carry-forward with `Iteration<Finding>[]`. `buildPriorFindingsBlock` delegates to `buildPriorIterationsBlock`.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| [src/operations/adversarial-review.ts:28](../../src/operations/adversarial-review.ts#L28) | `priorAdversarialFindings?: AdversarialFindingsCache` → `priorIterations?: Iteration<Finding>[]` |
+| [src/prompts/builders/adversarial-review-builder.ts:202-225](../../src/prompts/builders/adversarial-review-builder.ts#L202) | `buildPriorFindingsBlock(round, findings)` → `buildPriorIterationsBlock(iterations)` (one-line delegation) |
+| [src/review/types.ts:171-182](../../src/review/types.ts#L171) | `AdversarialFindingsCache` deprecated; carry-forward becomes `Iteration<Finding>[]` directly |
+| [src/review/runner.ts](../../src/review/runner.ts), [src/review/orchestrator.ts](../../src/review/orchestrator.ts), [src/review/adversarial.ts](../../src/review/adversarial.ts), [src/pipeline/types.ts](../../src/pipeline/types.ts) | Update references from `AdversarialFindingsCache` to `Iteration<Finding>[]` |
+| `test/unit/operations/adversarial-review.test.ts` | Round-2 prompt assertion: contains prior-iterations block built from previous round |
+
+### Migration shape
+
+Adversarial review historically stored only the most recent round's findings. With cycles, a single review iteration is a full `Iteration<Finding>` record (findings before, fix applied, findings after, outcome). The carry-forward becomes:
+
+```typescript
+// before:
+priorAdversarialFindings?: AdversarialFindingsCache;  // { round, findings[] }
+// after:
+priorIterations?: Iteration<Finding>[];               // full history
+```
+
+The prompt builder change is one line — `buildPriorFindingsBlock(...)` becomes `buildPriorIterationsBlock(priorIterations ?? [])`. Callers update.
+
+### Tests
+
+- Round 1 → no prior block in prompt
+- Round 2 → prompt contains prior-iterations table from round 1
+- Round 3 with outcome=`unchanged` from round 2 → falsified line present
+
+### Validation gate
+
+- All adversarial unit + integration tests pass
+- Hand-run: trigger adversarial review on a fixture; observe round 2 prompt structure
+
+### Risk mitigation
+
+- No prompt schema change (the table format is the only change to prompt content; prompt instructions unaffected).
+- `AdversarialFindingsCache` stays in `src/review/types.ts` as a deprecated alias for one release before phase 8 deletes it.
+
+### Rollback
+
+`git revert`. Cache lives in memory only — no persistence to migrate.
+
+---
+
+## 8. Phase 6 — Semantic migration
+
+**Goal:** Replace `PriorFailure[]` with `Iteration<Finding>[]`. `buildAttemptContextBlock` delegates to `buildPriorIterationsBlock`.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| [src/operations/semantic-review.ts](../../src/operations/semantic-review.ts) | Accept `priorIterations?: Iteration<Finding>[]` input |
+| [src/prompts/builders/review-builder.ts:65-68](../../src/prompts/builders/review-builder.ts#L65) | `PriorFailure` interface deprecated; replaced by `Iteration<Finding>` |
+| [src/prompts/builders/review-builder.ts:186-211](../../src/prompts/builders/review-builder.ts#L186) | `buildAttemptContextBlock` delegates to `buildPriorIterationsBlock` |
+| [src/review/runner.ts](../../src/review/runner.ts) | Update semantic carry-forward path |
+| `test/unit/operations/semantic-review.test.ts` | Round-2 prompt assertion |
+
+### Migration shape
+
+Same pattern as phase 5. `PriorFailure[]` (stage + tier only) was a thin reproduction of attempt context; `Iteration[]` is strictly richer. Migration is mechanical.
+
+### Tests
+
+Same as phase 5, scoped to semantic review.
+
+### Validation gate
+
+- All semantic unit + integration tests pass
+- Round 2 prompt contains prior-iterations table
+
+### Risk mitigation
+
+`PriorFailure` is barely used (only carries `stage` and `modelTier`); migration loses no information.
+
+### Rollback
+
+`git revert`.
+
+---
+
+## 9. Phase 7 — Autofix migration
+
+**Goal:** Replace `runAgentRectification`'s hand-rolled split-and-route with `runFixCycle` driving multiple strategies. Behind `quality.autofix.cycleV2` flag with shadow-mode comparison.
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| [src/pipeline/stages/autofix-agent.ts:89](../../src/pipeline/stages/autofix-agent.ts#L89) | `runAgentRectification` becomes a wrapper that constructs strategies and invokes `runFixCycle` |
+| [src/pipeline/stages/autofix.ts](../../src/pipeline/stages/autofix.ts) | Same wrapper change |
+| [src/pipeline/stages/autofix-scope-split.ts:158](../../src/pipeline/stages/autofix-scope-split.ts#L158) | `splitFindingsByScope` becomes purely a partition helper used by strategy `appliesTo` |
+| [src/config/schemas.ts](../../src/config/schemas.ts) | Add `quality.autofix.cycleV2: z.boolean().default(false)` |
+| [src/config/selectors.ts](../../src/config/selectors.ts) | Expose flag |
+| `test/unit/pipeline/stages/autofix-cycle.test.ts` (new) | Cycle-driven autofix tests |
+| `test/integration/autofix/cycle-shadow.test.ts` (new) | Shadow-mode divergence detection |
+
+### Strategy set
+
+Six strategies in the autofix cycle:
+
+```typescript
+const strategies: FixStrategy<Finding, any, any, any>[] = [
+  // Source-targeted findings → implementer
+  {
+    name: "autofix-implementer",
+    appliesTo: (f) => f.fixTarget === "source",
+    fixOp: implementerRectifyOp,         // wraps existing runRetryLoop
+    buildInput: (findings, prior, ctx) => ({
+      findings, priorIterations: prior, /* …implementer-specific context… */
+    }),
+    maxAttempts: 5,
+    coRun: "co-run-sequential",
+  },
+  // Test-targeted findings → test-writer
+  {
+    name: "autofix-test-writer",
+    appliesTo: (f) => f.fixTarget === "test",
+    fixOp: testWriterRectifyOp,          // wraps existing one-shot
+    buildInput: (findings, prior, ctx) => ({
+      findings, priorIterations: prior, /* … */
+    }),
+    maxAttempts: 1,                      // one-shot per cycle entry — natural dropout
+    coRun: "co-run-sequential",
+  },
+];
+```
+
+The "test-writer one-shot" pattern is preserved by `maxAttempts: 1` AND selector-based dropout: once test-writer fixes test findings, the validator returns no `fixTarget === "test"` findings, so test-writer's `appliesTo` returns false in subsequent iterations. No special "runOnce" modifier needed.
+
+### Cycle entry
+
+```typescript
+async function runAgentRectificationV2(ctx: PipelineContext, ...): Promise<...> {
+  const failedChecks = collectFailedChecks(ctx);
+  const findings = failedChecks.flatMap((c) => c.findings ?? []);  // already Finding[] post-ADR-021
+
+  const strategies = buildAutofixStrategies(ctx, ...);
+  const cycle: FixCycle<Finding> = {
+    name: "autofix",
+    findings,
+    iterations: ctx.autofixPriorIterations ?? [],
+    strategies,
+    validate: async (cycleCtx) => {
+      const review = await _autofixDeps.recheckReview(ctx);
+      return review.findings ?? [];
+    },
+    config: {
+      maxAttemptsTotal: ctx.config.quality.autofix?.maxTotalAttempts ?? 10,
+      validatorRetries: 1,
+    },
+  };
+
+  const result = await runFixCycle(cycle, fixCallCtx(ctx));
+  ctx.autofixPriorIterations = result.iterations;
+  return { succeeded: result.resolved, cost: aggregateCost(result.iterations) };
+}
+```
+
+### Shadow-mode comparison
+
+When flag is on:
+
+1. Run `runAgentRectificationV2` (new cycle path).
+2. **Also** run `runAgentRectificationLegacy` against the same input (read-only — no actual fixes; just record what strategies would have been chosen).
+3. Write `.nax/cycle-shadow/<storyId>/<timestamp>.json`:
+
+```json
+{
+  "phase": "quality.autofix.cycleV2",
+  "input": { "findings": [...], "failedChecks": [...] },
+  "legacyRouting": {
+    "testWriterChecks": ["adversarial"],
+    "implementerChecks": ["lint", "typecheck"]
+  },
+  "v2Routing": {
+    "iteration1": { "strategiesRan": ["autofix-test-writer"], "outcome": "partial" },
+    "iteration2": { "strategiesRan": ["autofix-implementer"], "outcome": "resolved" }
+  },
+  "agreement": "true | false",
+  "divergenceDetail": "..."
+}
+```
+
+CI dogfood validates ≥95% routing agreement before flag flip. Two release cycles of soak.
+
+### Tests
+
+- Flag off: legacy path runs; existing autofix tests pass.
+- Flag on, single test-writer run: cycle exits after 1 iteration with outcome=`resolved` (or `partial`).
+- Flag on, mixed findings: both strategies co-run in iteration 1; implementer iterates further if validator still returns findings.
+- Cross-source drift: lint fix introduces typecheck error → next iteration's `Finding[]` contains typecheck finding → implementer strategy applies again with the new finding.
+- Shadow comparison: divergence report written when v2 routing differs from legacy.
+
+### Validation gate
+
+- `bun run typecheck` passes
+- All autofix unit + integration tests pass with flag off
+- Cycle tests pass with flag on
+- Shadow-mode integration test produces valid divergence reports for fixtures
+- Two release cycles of dogfood ≥95% routing agreement before flag flip
+
+### Risk mitigation
+
+- Flag default off; production unaffected.
+- Shadow mode catches divergence in CI before users see it.
+- Two release soak (longer than acceptance phase 4) because autofix is on the hot path for every story.
+
+### Rollback
+
+Flag back to off. After 2 releases green: change default to `true`. After 1 more: phase 8 deletes flag and legacy path.
+
+### PR commit message template
+
+```
+feat(autofix): runFixCycle migration (ADR-022 phase 7)
+
+Replace runAgentRectification's hand-rolled split-and-route with
+runFixCycle driven by [autofix-implementer, autofix-test-writer]
+strategies (and any other source strategies that flow through the
+same review-check validator).
+
+Behind quality.autofix.cycleV2 flag, default off.
+Shadow-mode comparison writes divergence reports to
+.nax/cycle-shadow/ for two-release soak before flag flip.
+
+Refs: #867
+```
+
+---
+
+## 10. Phase 8 — Cleanup
+
+**Goal:** Delete legacy carry-forward types and feature flags. All consumers now on the cycle.
+
+### Prerequisites
+
+- All ADR-022 phases 1–7 merged
+- All ADR-021 producer migrations merged
+- `acceptance.fix.cycleV2` flipped to default `true` and stable for 1 release
+- `quality.autofix.cycleV2` flipped to default `true` and stable for 2 releases
+
+### Files modified
+
+| File | Change |
+|:---|:---|
+| [src/execution/lifecycle/acceptance-loop.ts](../../src/execution/lifecycle/acceptance-loop.ts) | Delete `previousFailure: string` accumulator and all writes |
+| [src/execution/lifecycle/acceptance-fix.ts](../../src/execution/lifecycle/acceptance-fix.ts) | Delete `applyFixLegacy`; rename `applyFixV2` → `applyFix` |
+| [src/review/types.ts:171-182](../../src/review/types.ts#L171) | Delete `AdversarialFindingsCache` (already migrated to `Iteration<Finding>[]`) |
+| [src/prompts/builders/adversarial-review-builder.ts:202-225](../../src/prompts/builders/adversarial-review-builder.ts#L202) | Delete `buildPriorFindingsBlock` (callers now use `buildPriorIterationsBlock`) |
+| [src/prompts/builders/review-builder.ts:65-68,186-211](../../src/prompts/builders/review-builder.ts#L65) | Delete `PriorFailure` and `buildAttemptContextBlock` |
+| [src/pipeline/stages/autofix-agent.ts](../../src/pipeline/stages/autofix-agent.ts), [autofix.ts](../../src/pipeline/stages/autofix.ts) | Delete legacy `runAgentRectification`; rename V2 to canonical |
+| [src/config/schemas.ts](../../src/config/schemas.ts) | Delete `acceptance.fix.cycleV2` and `quality.autofix.cycleV2` fields |
+| Various tests | Delete tests asserting on legacy field shapes / flag-off behaviour |
+
+### Validation gate
+
+- `bun run typecheck` passes
+- Full test suite passes
+- `git grep "previousFailure\|AdversarialFindingsCache\|PriorFailure\|buildPriorFindingsBlock\|buildAttemptContextBlock\|cycleV2" -- 'src/'` returns nothing
+- Feature flag config schema no longer mentions the deprecated flags
+
+### Rollback
+
+`git revert`. Cleanup is purely deletion + import cleanup — no semantic change.
+
+---
+
+## 11. Cross-cutting checklist
+
+Before merging each PR:
+
+- [ ] `bun run typecheck` passes
+- [ ] `bun run lint` (Biome) passes
+- [ ] Pre-commit hooks pass (process-cwd, adapter-wrap, dispatch-context)
+- [ ] All new logger calls have `storyId` as first key in data object
+- [ ] No `process.cwd()` outside CLI entry points
+- [ ] No internal-path imports — barrel only
+- [ ] `findingKey` (from ADR-021 phase 1) is the only finding-equality function used
+- [ ] PR refs `#867`
+- [ ] Telemetry contract (§2.3) emitted at every iteration completion + bail event
+- [ ] Phase 4 / Phase 7: feature flag works in both states; legacy path unchanged when flag off
+
+## 12. Tracking
+
+| Phase | PR | Status | Notes |
+|:---|:---|:---|:---|
+| 1 — Cycle types | tbd | not started | ~120 line addition |
+| 2 — `runFixCycle` + `classifyOutcome` | tbd | not started | ~250 lines + tests |
+| 3 — `buildPriorIterationsBlock` | tbd | not started | ~50 lines + tests |
+| 4 — Acceptance migration (flagged) | tbd | not started | ships dogfood regression fix |
+| 5 — Adversarial migration | tbd | not started | mostly mechanical |
+| 6 — Semantic migration | tbd | not started | mostly mechanical |
+| 7 — Autofix migration (flagged + shadow) | tbd | not started | hot path; longest soak |
+| 8 — Cleanup | tbd | not started | gated on all flags flipped |
+
+## 13. References
+
+- [ADR-021](../adr/ADR-021-findings-and-fix-strategy-ssot.md) — Finding type SSOT (companion ADR)
+- [ADR-022](../adr/ADR-022-fix-strategy-and-cycle.md) — this plan's source ADR
+- [ADR-021 implementation plan](./2026-05-02-adr-021-implementation-plan.md) — companion plan
+- [Issue #867](https://github.com/nathapp-io/nax/issues/867) — umbrella tracker
+- ADR-021 phase-1 PR [#868](https://github.com/nathapp-io/nax/pull/868) — wire-format types
+- [src/findings/](../../src/findings/) — types module (extends with cycle-types in phase 1)
+- [src/verification/shared-rectification-loop.ts](../../src/verification/shared-rectification-loop.ts) — `runRetryLoop` (preserved as inner primitive)
+- [docs/findings/2026-04-30-context-curator-design.md](../findings/2026-04-30-context-curator-design.md) — referenced for cycle-history audit (deferred)
+- [.claude/rules/project-conventions.md](../../.claude/rules/project-conventions.md) — logger/storyId, barrel imports


### PR DESCRIPTION
## Summary

- **`docs/adr/ADR-022-fix-strategy-and-cycle.md`** — new companion ADR to ADR-021 covering the full fix-cycle orchestration layer: `FixStrategy` interface (with `appliesToVerdict`, `coRun` discipline), `runFixCycle` skeleton, `classifyOutcome` (per-source-bucket then aggregate), `buildPriorIterationsBlock`, validator retry-once-then-terminal semantics, dual budget (per-strategy `maxAttempts` + cycle-wide `maxAttemptsTotal`), telemetry contract, feature flags (`acceptance.fix.cycleV2`, `quality.autofix.cycleV2`), and 8-phase migration plan.
- **`docs/specs/2026-05-02-adr-021-implementation-plan.md`** — per-phase execution plan for ADR-021 phases 2–9 (plugin → lint → typecheck → tdd-verifier → adversarial → semantic → acceptance → cleanup) with adapter code shapes, test gates, risk/rollback, and cross-phase helpers (`rebaseToWorkdir`, severity rename strategy).
- **`docs/specs/2026-05-02-adr-022-implementation-plan.md`** — per-phase execution plan for ADR-022 phases 1–8 (cycle types → `runFixCycle` → `buildPriorIterationsBlock` → acceptance migration → adversarial → semantic → autofix with shadow mode → cleanup) including full skeletons for `runFixCycle` and `classifyOutcome`.
- **`docs/findings/2026-04-30-context-curator-design.md`** — adds §Step 5 cross-referencing ADR-022 fix-cycle audit: `Iteration<F>` → `observations.jsonl` schema, new observation kinds (`fix-cycle.iteration`, `fix-cycle.exit`, `fix-cycle.validator-retry`), curator jq heuristics, and open question #8.

This PR is **docs-only** (no source changes). It closes the design phase and unblocks implementation PRs for both ADRs.

## Test plan

- [ ] All four files render correctly in GitHub (no broken links in cross-references between ADR-021 and ADR-022)
- [ ] Phase tables in both implementation plans are consistent with the phasing described in their respective ADRs
- [ ] Verify ADR-022 §3 `FixStrategy` interface matches the interface described in the ADR-021 plan phase descriptions that reference it
- [ ] Confirm `docs/findings/2026-04-30-context-curator-design.md` Step 5 telemetry kinds align with ADR-022 §13 logger contract

Refs #867.