### PR TITLE
feat(findings): plugin reviewer adapter (ADR-021 phase 2)

### DIFF
--- a/src/findings/adapters/index.ts
+++ b/src/findings/adapters/index.ts
@@ -1,0 +1,1 @@
+export { pluginToFinding } from "./plugin";

--- a/src/findings/adapters/plugin.ts
+++ b/src/findings/adapters/plugin.ts
@@ -1,0 +1,25 @@
+import type { ReviewFinding } from "../../plugins/types";
+import type { Finding } from "../types";
+
+/**
+ * Convert a ReviewFinding from the IReviewPlugin contract to the canonical Finding wire format.
+ *
+ * Plugin contract (ReviewFinding) is workdir-relative — no path rebasing needed.
+ * workdir is accepted for API consistency with other adapters (phases 3+) but unused here.
+ */
+export function pluginToFinding(rf: ReviewFinding, _workdir: string): Finding {
+  return {
+    source: "plugin",
+    tool: rf.source ?? "plugin",
+    severity: rf.severity,
+    category: rf.category ?? "general",
+    rule: rf.ruleId,
+    file: rf.file,
+    line: rf.line,
+    column: rf.column,
+    endLine: rf.endLine,
+    endColumn: rf.endColumn,
+    message: rf.message,
+    meta: rf.url ? { url: rf.url } : undefined,
+  };
+}

--- a/src/findings/index.ts
+++ b/src/findings/index.ts
@@ -4,6 +4,9 @@
  * ADR-021 phase 1: types only, no behaviour. Producers migrate to emit
  * Finding[] in subsequent phases.
  *
+ * Phase 2: plugin reviewer adapter. Converts ReviewFinding → Finding at the
+ * IReviewPlugin call site. Plugin contract (ReviewFinding) unchanged.
+ *
  * Orchestration (Iteration, FixApplied, FixStrategy, runFixCycle, …) lives
  * in ADR-022 and will arrive in a separate file (e.g. cycle-types.ts) once
  * that ADR's phase 1 PR begins. Consumers should import only the wire-format
@@ -18,3 +21,6 @@ export type {
 } from "./types";
 
 export { SEVERITY_ORDER, compareSeverity, findingKey } from "./types";
+
+export { pluginToFinding } from "./adapters";
+export { rebaseToWorkdir } from "./path-utils";

--- a/src/findings/path-utils.ts
+++ b/src/findings/path-utils.ts
@@ -1,0 +1,14 @@
+import { relative, resolve } from "node:path";
+
+/**
+ * Rebase a raw path (absolute or cwd-relative) to nax's workdir-relative convention.
+ * Used by producer adapters (phases 3+) that receive paths in non-workdir-relative form.
+ *
+ * Per ADR-021 §3, every Finding.file must be relative to workdir.
+ */
+export function rebaseToWorkdir(rawPath: string, cwd: string, workdir: string): string {
+  if (rawPath.startsWith("/")) {
+    return relative(workdir, rawPath);
+  }
+  return relative(workdir, resolve(cwd, rawPath));
+}

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -168,15 +168,18 @@ export const reviewStage: PipelineStage = {
     }
 
     if (!result.success) {
-      // Collect structured findings from plugin reviewers for escalation context
-      const pluginFindings = result.builtIn.pluginReviewers?.flatMap((pr) => pr.findings ?? []) ?? [];
-      // Collect semantic findings from built-in checks (AC-1/AC-2/AC-3)
+      // Collect semantic findings from built-in checks (AC-1/AC-2/AC-3) for escalation context.
+      // Plugin findings (Finding[] per ADR-021 phase 2) are accessible via
+      // ctx.reviewResult.builtIn.pluginReviewers[*].findings — they use Finding.rule (not
+      // ReviewFinding.ruleId) so they cannot be merged into ctx.reviewFindings (ReviewFinding[])
+      // until context/elements.ts migrates to Finding[] in a later phase.
+      // Note: plugins only run when built-in checks pass (guard in orchestrator), so
+      // pluginFindings and semanticFindings are mutually exclusive in practice.
       const semanticFindings = (result.builtIn.checks ?? [])
         .filter((c) => c.check === "semantic" && !c.success && c.findings?.length)
         .flatMap((c) => c.findings ?? []);
-      const allFindings = [...pluginFindings, ...semanticFindings];
-      if (allFindings.length > 0) {
-        ctx.reviewFindings = allFindings;
+      if (semanticFindings.length > 0) {
+        ctx.reviewFindings = semanticFindings;
       }
 
       if (result.pluginFailed) {

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -14,6 +14,7 @@ import type { IAgentManager } from "../agents";
 import type { NaxConfig } from "../config";
 import { assembleForStage } from "../context/engine";
 import type { ContextBundle } from "../context/engine";
+import { pluginToFinding } from "../findings";
 import { getSafeLogger } from "../logger";
 import type { PipelineContext } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins";
@@ -491,7 +492,7 @@ export class ReviewOrchestrator {
               passed: result.passed,
               output: result.output,
               exitCode: result.exitCode,
-              findings: result.findings,
+              findings: result.findings?.map((rf) => pluginToFinding(rf, workdir)),
             });
             if (!result.passed) {
               builtIn.pluginReviewers = pluginResults;

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -104,8 +104,8 @@ export interface PluginReviewerResult {
   exitCode?: number;
   /** Error message if reviewer threw an exception */
   error?: string;
-  /** Structured findings from the reviewer (optional) */
-  findings?: import("../plugins/types").ReviewFinding[];
+  /** Structured findings from the reviewer (optional) — Finding[] per ADR-021 phase 2 */
+  findings?: import("../findings").Finding[];
 }
 
 /** Per-reviewer blocking/advisory finding counts for reviewSummary */

--- a/test/integration/review/review-plugin-integration.test.ts
+++ b/test/integration/review/review-plugin-integration.test.ts
@@ -138,6 +138,83 @@ describe("Review Stage - Plugin Integration", () => {
       expect(ctx.reviewResult?.success).toBe(false);
     });
 
+    test("plugin findings are converted to Finding[] (ADR-021 phase 2)", async () => {
+      const tempDir = makeTempDir("nax-review-plugin-");
+      await initGitRepo(tempDir);
+
+      const mockReviewer: IReviewPlugin = {
+        name: "security-scanner",
+        description: "Security scanner",
+        async check() {
+          return {
+            passed: false,
+            output: "Security issue found",
+            exitCode: 1,
+            findings: [
+              {
+                ruleId: "detect-non-literal-regexp",
+                severity: "error" as const,
+                file: "src/auth.ts",
+                line: 42,
+                column: 5,
+                message: "Potentially unsafe regex construction",
+                source: "semgrep",
+                category: "security",
+                url: "https://semgrep.dev/r/detect-non-literal-regexp",
+              },
+              {
+                ruleId: "no-dynamic-require",
+                severity: "critical" as const,
+                file: "src/loader.ts",
+                line: 7,
+                message: "Dynamic require is dangerous",
+              },
+            ],
+          };
+        },
+      };
+
+      const mockPlugin: NaxPlugin = {
+        name: "security-plugin",
+        version: "1.0.0",
+        provides: ["reviewer"],
+        extensions: { reviewer: mockReviewer },
+      };
+
+      const registry = new PluginRegistry([mockPlugin]);
+      const ctx = createMockContext(tempDir, registry);
+
+      await reviewStage.execute(ctx);
+
+      const pluginResult = ctx.reviewResult?.pluginReviewers?.[0];
+      expect(pluginResult).toBeDefined();
+      expect(pluginResult?.findings).toHaveLength(2);
+
+      // First finding: full field mapping with source, category, url
+      const f0 = pluginResult?.findings?.[0];
+      expect(f0?.source).toBe("plugin");
+      expect(f0?.tool).toBe("semgrep");
+      expect(f0?.severity).toBe("error");
+      expect(f0?.category).toBe("security");
+      expect(f0?.rule).toBe("detect-non-literal-regexp");
+      expect(f0?.file).toBe("src/auth.ts");
+      expect(f0?.line).toBe(42);
+      expect(f0?.column).toBe(5);
+      expect(f0?.message).toBe("Potentially unsafe regex construction");
+      expect(f0?.meta).toEqual({ url: "https://semgrep.dev/r/detect-non-literal-regexp" });
+
+      // Second finding: defaults (no source → tool "plugin", no category → "general", no url → no meta)
+      const f1 = pluginResult?.findings?.[1];
+      expect(f1?.source).toBe("plugin");
+      expect(f1?.tool).toBe("plugin");
+      expect(f1?.severity).toBe("critical");
+      expect(f1?.category).toBe("general");
+      expect(f1?.rule).toBe("no-dynamic-require");
+      expect(f1?.file).toBe("src/loader.ts");
+      expect(f1?.line).toBe(7);
+      expect(f1?.meta).toBeUndefined();
+    });
+
     test("no plugin reviewers registered - continues normally", async () => {
       const tempDir = makeTempDir("nax-review-plugin-");
       await initGitRepo(tempDir);

--- a/test/unit/findings/adapters/plugin.test.ts
+++ b/test/unit/findings/adapters/plugin.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import type { ReviewFinding } from "../../../../src/plugins/types";
+import { pluginToFinding } from "../../../../src/findings";
+
+const WORKDIR = "/repo";
+
+const baseReviewFinding: ReviewFinding = {
+  ruleId: "no-unused-vars",
+  severity: "error",
+  file: "src/foo.ts",
+  line: 10,
+  message: "Variable is unused",
+};
+
+describe("pluginToFinding", () => {
+  test("maps required fields", () => {
+    const finding = pluginToFinding(baseReviewFinding, WORKDIR);
+
+    expect(finding.source).toBe("plugin");
+    expect(finding.severity).toBe("error");
+    expect(finding.category).toBe("general");
+    expect(finding.rule).toBe("no-unused-vars");
+    expect(finding.file).toBe("src/foo.ts");
+    expect(finding.line).toBe(10);
+    expect(finding.message).toBe("Variable is unused");
+  });
+
+  test("defaults tool to 'plugin' when source is absent", () => {
+    const finding = pluginToFinding(baseReviewFinding, WORKDIR);
+    expect(finding.tool).toBe("plugin");
+  });
+
+  test("uses rf.source as tool when present", () => {
+    const rf: ReviewFinding = { ...baseReviewFinding, source: "semgrep" };
+    const finding = pluginToFinding(rf, WORKDIR);
+    expect(finding.tool).toBe("semgrep");
+  });
+
+  test("passes through all severity levels without change", () => {
+    const severities = ["critical", "error", "warning", "info", "low"] as const;
+    for (const severity of severities) {
+      const finding = pluginToFinding({ ...baseReviewFinding, severity }, WORKDIR);
+      expect(finding.severity).toBe(severity);
+    }
+  });
+
+  test("uses rf.category when present", () => {
+    const rf: ReviewFinding = { ...baseReviewFinding, category: "security" };
+    const finding = pluginToFinding(rf, WORKDIR);
+    expect(finding.category).toBe("security");
+  });
+
+  test("defaults category to 'general' when absent", () => {
+    const finding = pluginToFinding(baseReviewFinding, WORKDIR);
+    expect(finding.category).toBe("general");
+  });
+
+  test("passes through column, endLine, endColumn when present", () => {
+    const rf: ReviewFinding = { ...baseReviewFinding, column: 5, endLine: 12, endColumn: 8 };
+    const finding = pluginToFinding(rf, WORKDIR);
+    expect(finding.column).toBe(5);
+    expect(finding.endLine).toBe(12);
+    expect(finding.endColumn).toBe(8);
+  });
+
+  test("omits column, endLine, endColumn when absent", () => {
+    const finding = pluginToFinding(baseReviewFinding, WORKDIR);
+    expect(finding.column).toBeUndefined();
+    expect(finding.endLine).toBeUndefined();
+    expect(finding.endColumn).toBeUndefined();
+  });
+
+  test("stores url in meta when present", () => {
+    const rf: ReviewFinding = { ...baseReviewFinding, url: "https://eslint.org/rules/no-unused-vars" };
+    const finding = pluginToFinding(rf, WORKDIR);
+    expect(finding.meta).toEqual({ url: "https://eslint.org/rules/no-unused-vars" });
+  });
+
+  test("omits meta when url is absent", () => {
+    const finding = pluginToFinding(baseReviewFinding, WORKDIR);
+    expect(finding.meta).toBeUndefined();
+  });
+
+  test("workdir parameter is accepted but file path is not rebased (already workdir-relative)", () => {
+    const rf: ReviewFinding = { ...baseReviewFinding, file: "src/nested/bar.ts" };
+    const finding = pluginToFinding(rf, "/different/workdir");
+    expect(finding.file).toBe("src/nested/bar.ts");
+  });
+});


### PR DESCRIPTION
## Summary

- Converts `ReviewFinding[]` → `Finding[]` at the `IReviewPlugin` call site in `ReviewOrchestrator`. Plugin contract (`IReviewPlugin`, `ReviewCheckResult`, `ReviewFinding`) is unchanged.
- Adds `src/findings/adapters/plugin.ts` (`pluginToFinding`) and `src/findings/path-utils.ts` (`rebaseToWorkdir` — used by phases 3+), both re-exported from the `src/findings` barrel.
- Changes `PluginReviewerResult.findings?` from `ReviewFinding[]` to `Finding[]` in `src/review/types.ts`.
- Updates `src/pipeline/stages/review.ts` to keep `ctx.reviewFindings` (`ReviewFinding[]`) populated with only semantic findings; plugin findings (`Finding[]`) remain accessible via `ctx.reviewResult.builtIn.pluginReviewers[*].findings`. Plugin and semantic findings are mutually exclusive (orchestrator guards plugin execution behind built-in check success), so no data is lost.

## Design notes

- `ctx.reviewFindings` stays `ReviewFinding[]` until `context/elements.ts` and downstream consumers migrate to `Finding[]` (later phase — blocked on phases 6+7 migrating LLM review findings).
- `rebaseToWorkdir` is included in this PR per the spec (§2.2) as it is used by every adapter from phase 3 onward; it has no callers yet.

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes
- [ ] All pre-commit hooks pass
- [ ] `bun run test:bail` — 1234 tests pass, 0 fail
- [ ] `test/unit/findings/adapters/plugin.test.ts` — 11 new unit tests covering required fields, defaults, severity passthrough, optional fields, url→meta mapping
- [ ] `test/integration/review/review-plugin-integration.test.ts` — new test asserts `Finding[]` shape end-to-end (source, tool, rule, category, meta)

Refs: #867