### PR TITLE
feat(findings): lint adapter (ADR-021 phase 3)

### DIFF
--- a/src/findings/adapters/index.ts
+++ b/src/findings/adapters/index.ts
@@ -1,1 +1,2 @@
+export { lintDiagnosticToFinding } from "./lint";
 export { pluginToFinding } from "./plugin";

--- a/src/findings/adapters/lint.ts
+++ b/src/findings/adapters/lint.ts
@@ -5,7 +5,6 @@ import type { Finding } from "../types";
 export function lintDiagnosticToFinding(
   d: LintDiagnostic,
   workdir: string,
-  cwd: string,
   tool: "biome" | "eslint" | "text",
 ): Finding {
   return {
@@ -14,7 +13,7 @@ export function lintDiagnosticToFinding(
     severity: d.severity ?? "warning",
     category: "lint",
     rule: d.ruleId,
-    file: rebaseToWorkdir(d.file, cwd, workdir),
+    file: rebaseToWorkdir(d.file, workdir, workdir),
     line: d.line,
     column: d.column,
     message: d.message,

--- a/src/findings/adapters/lint.ts
+++ b/src/findings/adapters/lint.ts
@@ -1,0 +1,22 @@
+import type { LintDiagnostic } from "../../review/lint-parsing/types";
+import { rebaseToWorkdir } from "../path-utils";
+import type { Finding } from "../types";
+
+export function lintDiagnosticToFinding(
+  d: LintDiagnostic,
+  workdir: string,
+  cwd: string,
+  tool: "biome" | "eslint" | "text",
+): Finding {
+  return {
+    source: "lint",
+    tool,
+    severity: d.severity ?? "warning",
+    category: "lint",
+    rule: d.ruleId,
+    file: rebaseToWorkdir(d.file, cwd, workdir),
+    line: d.line,
+    column: d.column,
+    message: d.message,
+  };
+}

--- a/src/findings/index.ts
+++ b/src/findings/index.ts
@@ -22,5 +22,5 @@ export type {
 
 export { SEVERITY_ORDER, compareSeverity, findingKey } from "./types";
 
-export { pluginToFinding } from "./adapters";
+export { lintDiagnosticToFinding, pluginToFinding } from "./adapters";
 export { rebaseToWorkdir } from "./path-utils";

--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -153,6 +153,8 @@ export async function runAgentRectification(
         stageTestFilePatterns,
         lintOutputFormat,
         typecheckOutputFormat,
+        ctx.workdir,
+        ctx.workdir,
       );
       // null/null means the check has no classifiable findings — leave implementerChecks unchanged.
       if (testFindings || sourceFindings) {

--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -153,8 +153,7 @@ export async function runAgentRectification(
         stageTestFilePatterns,
         lintOutputFormat,
         typecheckOutputFormat,
-        ctx.workdir,
-        ctx.workdir,
+        { workdir: ctx.workdir, cwd: ctx.workdir },
       );
       // null/null means the check has no classifiable findings — leave implementerChecks unchanged.
       if (testFindings || sourceFindings) {

--- a/src/pipeline/stages/autofix-agent.ts
+++ b/src/pipeline/stages/autofix-agent.ts
@@ -153,7 +153,7 @@ export async function runAgentRectification(
         stageTestFilePatterns,
         lintOutputFormat,
         typecheckOutputFormat,
-        { workdir: ctx.workdir, cwd: ctx.workdir },
+        { workdir: ctx.workdir },
       );
       // null/null means the check has no classifiable findings — leave implementerChecks unchanged.
       if (testFindings || sourceFindings) {

--- a/src/pipeline/stages/autofix-scope-split.ts
+++ b/src/pipeline/stages/autofix-scope-split.ts
@@ -132,7 +132,7 @@ function splitByOutputParsing(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
   format: LintOutputFormat = "auto",
-  lintOpts?: { workdir: string; cwd: string },
+  lintOpts?: { workdir: string },
 ): { testFindings: ReviewCheckResult | null; sourceFindings: ReviewCheckResult | null } {
   const parsed = parseLintOutput(check.output, format, lintOpts);
   if (!parsed) {
@@ -197,7 +197,7 @@ export function splitFindingsByScope(
   testFilePatterns?: readonly string[],
   lintOutputFormat: LintOutputFormat = "auto",
   typecheckOutputFormat: TypecheckOutputFormat = "auto",
-  lintOpts?: { workdir: string; cwd: string },
+  lintOpts?: { workdir: string },
 ): {
   testFindings: ReviewCheckResult | null;
   sourceFindings: ReviewCheckResult | null;

--- a/src/pipeline/stages/autofix-scope-split.ts
+++ b/src/pipeline/stages/autofix-scope-split.ts
@@ -119,9 +119,11 @@ function splitFindingsByFixTarget(
   const testDiagnostics: LintDiagnostic[] = [];
   const sourceDiagnostics: LintDiagnostic[] = [];
   for (let i = 0; i < findings.length; i++) {
+    const diagnostic = diagnostics[i];
+    if (!diagnostic) continue; // invariant: findings and diagnostics are co-produced by parseLintOutput
     const f = findings[i];
     const target = f.fixTarget ?? deriveFixTarget(f.file, testFilePatterns);
-    (target === "test" ? testDiagnostics : sourceDiagnostics).push(diagnostics[i]);
+    (target === "test" ? testDiagnostics : sourceDiagnostics).push(diagnostic);
   }
   return { testDiagnostics, sourceDiagnostics };
 }

--- a/src/pipeline/stages/autofix-scope-split.ts
+++ b/src/pipeline/stages/autofix-scope-split.ts
@@ -1,3 +1,4 @@
+import type { Finding } from "../../findings";
 import {
   type LintDiagnostic,
   type LintOutputFormat,
@@ -106,12 +107,33 @@ function splitByStructuredFindings(
   return { testFindings: toCheck(testFs), sourceFindings: toCheck(sourceFs) };
 }
 
+function deriveFixTarget(file: string | undefined, testFilePatterns: readonly string[] | undefined): "test" | "source" {
+  return file && isTestFile(file, testFilePatterns) ? "test" : "source";
+}
+
+function splitFindingsByFixTarget(
+  findings: readonly Finding[],
+  diagnostics: readonly LintDiagnostic[],
+  testFilePatterns: readonly string[] | undefined,
+): { testDiagnostics: LintDiagnostic[]; sourceDiagnostics: LintDiagnostic[] } {
+  const testDiagnostics: LintDiagnostic[] = [];
+  const sourceDiagnostics: LintDiagnostic[] = [];
+  for (let i = 0; i < findings.length; i++) {
+    const f = findings[i];
+    const target = f.fixTarget ?? deriveFixTarget(f.file, testFilePatterns);
+    (target === "test" ? testDiagnostics : sourceDiagnostics).push(diagnostics[i]);
+  }
+  return { testDiagnostics, sourceDiagnostics };
+}
+
 function splitByOutputParsing(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
   format: LintOutputFormat = "auto",
+  workdir?: string,
+  cwd?: string,
 ): { testFindings: ReviewCheckResult | null; sourceFindings: ReviewCheckResult | null } {
-  const parsed = parseLintOutput(check.output, format);
+  const parsed = parseLintOutput(check.output, format, workdir && cwd ? { workdir, cwd } : undefined);
   if (!parsed) {
     // Cannot classify by file -- conservative fallback: route to implementer if output is non-empty
     if (check.output.trim()) {
@@ -120,8 +142,19 @@ function splitByOutputParsing(
     return { testFindings: null, sourceFindings: null };
   }
 
-  const testDiagnostics = parsed.diagnostics.filter((d) => isTestFile(d.file, testFilePatterns));
-  const sourceDiagnostics = parsed.diagnostics.filter((d) => !isTestFile(d.file, testFilePatterns));
+  let testDiagnostics: LintDiagnostic[];
+  let sourceDiagnostics: LintDiagnostic[];
+
+  if (parsed.findings) {
+    ({ testDiagnostics, sourceDiagnostics } = splitFindingsByFixTarget(
+      parsed.findings,
+      parsed.diagnostics,
+      testFilePatterns,
+    ));
+  } else {
+    testDiagnostics = parsed.diagnostics.filter((d) => isTestFile(d.file, testFilePatterns));
+    sourceDiagnostics = parsed.diagnostics.filter((d) => !isTestFile(d.file, testFilePatterns));
+  }
 
   return {
     testFindings: buildScopedLintCheck(check, testDiagnostics),
@@ -154,12 +187,18 @@ function splitByTypecheckOutputParsing(
 /**
  * Split a check result into test-file vs source-file buckets for scope-aware routing.
  * Returns null for each bucket when there are no findings for that scope.
+ *
+ * Pass workdir and cwd (directory where lint ran) to enable Finding-based partitioning
+ * for lint checks (ADR-021 phase 3). Both must be provided together; omitting either
+ * falls back to the diagnostic file-path approach.
  */
 export function splitFindingsByScope(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
   lintOutputFormat: LintOutputFormat = "auto",
   typecheckOutputFormat: TypecheckOutputFormat = "auto",
+  workdir?: string,
+  cwd?: string,
 ): {
   testFindings: ReviewCheckResult | null;
   sourceFindings: ReviewCheckResult | null;
@@ -168,7 +207,7 @@ export function splitFindingsByScope(
     return splitByStructuredFindings(check, testFilePatterns);
   }
   if (check.check === "lint") {
-    return splitByOutputParsing(check, testFilePatterns, lintOutputFormat);
+    return splitByOutputParsing(check, testFilePatterns, lintOutputFormat, workdir, cwd);
   }
   if (check.check === "typecheck") {
     return splitByTypecheckOutputParsing(check, testFilePatterns, typecheckOutputFormat);

--- a/src/pipeline/stages/autofix-scope-split.ts
+++ b/src/pipeline/stages/autofix-scope-split.ts
@@ -132,10 +132,9 @@ function splitByOutputParsing(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
   format: LintOutputFormat = "auto",
-  workdir?: string,
-  cwd?: string,
+  lintOpts?: { workdir: string; cwd: string },
 ): { testFindings: ReviewCheckResult | null; sourceFindings: ReviewCheckResult | null } {
-  const parsed = parseLintOutput(check.output, format, workdir && cwd ? { workdir, cwd } : undefined);
+  const parsed = parseLintOutput(check.output, format, lintOpts);
   if (!parsed) {
     // Cannot classify by file -- conservative fallback: route to implementer if output is non-empty
     if (check.output.trim()) {
@@ -190,17 +189,15 @@ function splitByTypecheckOutputParsing(
  * Split a check result into test-file vs source-file buckets for scope-aware routing.
  * Returns null for each bucket when there are no findings for that scope.
  *
- * Pass workdir and cwd (directory where lint ran) to enable Finding-based partitioning
- * for lint checks (ADR-021 phase 3). Both must be provided together; omitting either
- * falls back to the diagnostic file-path approach.
+ * Pass lintOpts to enable Finding-based partitioning for lint checks (ADR-021 phase 3).
+ * Omitting it falls back to the diagnostic file-path approach.
  */
 export function splitFindingsByScope(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
   lintOutputFormat: LintOutputFormat = "auto",
   typecheckOutputFormat: TypecheckOutputFormat = "auto",
-  workdir?: string,
-  cwd?: string,
+  lintOpts?: { workdir: string; cwd: string },
 ): {
   testFindings: ReviewCheckResult | null;
   sourceFindings: ReviewCheckResult | null;
@@ -209,7 +206,7 @@ export function splitFindingsByScope(
     return splitByStructuredFindings(check, testFilePatterns);
   }
   if (check.check === "lint") {
-    return splitByOutputParsing(check, testFilePatterns, lintOutputFormat, workdir, cwd);
+    return splitByOutputParsing(check, testFilePatterns, lintOutputFormat, lintOpts);
   }
   if (check.check === "typecheck") {
     return splitByTypecheckOutputParsing(check, testFilePatterns, typecheckOutputFormat);

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -153,7 +153,7 @@ export const autofixStage: PipelineStage = {
             testFilePatterns,
             lintOutputFormat,
             typecheckOutputFormat,
-            { workdir: ctx.workdir, cwd: ctx.workdir },
+            { workdir: ctx.workdir },
           );
           return testFindings !== null && sourceFindings === null;
         })

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -153,8 +153,7 @@ export const autofixStage: PipelineStage = {
             testFilePatterns,
             lintOutputFormat,
             typecheckOutputFormat,
-            ctx.workdir,
-            ctx.workdir,
+            { workdir: ctx.workdir, cwd: ctx.workdir },
           );
           return testFindings !== null && sourceFindings === null;
         })

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -153,6 +153,8 @@ export const autofixStage: PipelineStage = {
             testFilePatterns,
             lintOutputFormat,
             typecheckOutputFormat,
+            ctx.workdir,
+            ctx.workdir,
           );
           return testFindings !== null && sourceFindings === null;
         })

--- a/src/review/lint-parsing/parse.ts
+++ b/src/review/lint-parsing/parse.ts
@@ -21,16 +21,15 @@ function toolForFormat(format: LintParserFormat): "biome" | "eslint" | "text" {
 export function parseLintOutput(
   output: string,
   format: LintOutputFormat = "auto",
-  opts?: { workdir?: string; cwd?: string },
+  opts?: { workdir: string; cwd: string },
 ): LintParseResult | null {
   if (!output.trim()) return null;
-  const { workdir, cwd } = opts ?? {};
   for (const strategy of strategiesFor(format)) {
     const parsed = strategy.parse(output);
     if (parsed && parsed.diagnostics.length > 0) {
-      if (workdir && cwd) {
+      if (opts) {
         const tool = toolForFormat(parsed.format);
-        const findings = parsed.diagnostics.map((d) => lintDiagnosticToFinding(d, workdir, cwd, tool));
+        const findings = parsed.diagnostics.map((d) => lintDiagnosticToFinding(d, opts.workdir, opts.cwd, tool));
         return { ...parsed, findings };
       }
       return parsed;

--- a/src/review/lint-parsing/parse.ts
+++ b/src/review/lint-parsing/parse.ts
@@ -21,7 +21,7 @@ function toolForFormat(format: LintParserFormat): "biome" | "eslint" | "text" {
 export function parseLintOutput(
   output: string,
   format: LintOutputFormat = "auto",
-  opts?: { workdir: string; cwd: string },
+  opts?: { workdir: string },
 ): LintParseResult | null {
   if (!output.trim()) return null;
   for (const strategy of strategiesFor(format)) {
@@ -29,7 +29,7 @@ export function parseLintOutput(
     if (parsed && parsed.diagnostics.length > 0) {
       if (opts) {
         const tool = toolForFormat(parsed.format);
-        const findings = parsed.diagnostics.map((d) => lintDiagnosticToFinding(d, opts.workdir, opts.cwd, tool));
+        const findings = parsed.diagnostics.map((d) => lintDiagnosticToFinding(d, opts.workdir, tool));
         return { ...parsed, findings };
       }
       return parsed;

--- a/src/review/lint-parsing/parse.ts
+++ b/src/review/lint-parsing/parse.ts
@@ -1,7 +1,8 @@
+import { lintDiagnosticToFinding } from "../../findings";
 import { biomeJsonStrategy } from "./strategies/biome-json";
 import { eslintJsonStrategy } from "./strategies/eslint-json";
 import { textBlockStrategy } from "./strategies/text-block";
-import type { LintDiagnostic, LintOutputFormat, LintParseResult, LintParseStrategy } from "./types";
+import type { LintDiagnostic, LintOutputFormat, LintParseResult, LintParseStrategy, LintParserFormat } from "./types";
 
 function strategiesFor(format: LintOutputFormat): ReadonlyArray<LintParseStrategy> {
   if (format === "eslint-json") return [eslintJsonStrategy];
@@ -11,11 +12,27 @@ function strategiesFor(format: LintOutputFormat): ReadonlyArray<LintParseStrateg
   return [eslintJsonStrategy, biomeJsonStrategy, textBlockStrategy];
 }
 
-export function parseLintOutput(output: string, format: LintOutputFormat = "auto"): LintParseResult | null {
+function toolForFormat(format: LintParserFormat): "biome" | "eslint" | "text" {
+  if (format === "biome-json") return "biome";
+  if (format === "eslint-json") return "eslint";
+  return "text";
+}
+
+export function parseLintOutput(
+  output: string,
+  format: LintOutputFormat = "auto",
+  opts?: { workdir?: string; cwd?: string },
+): LintParseResult | null {
   if (!output.trim()) return null;
+  const { workdir, cwd } = opts ?? {};
   for (const strategy of strategiesFor(format)) {
     const parsed = strategy.parse(output);
     if (parsed && parsed.diagnostics.length > 0) {
+      if (workdir && cwd) {
+        const tool = toolForFormat(parsed.format);
+        const findings = parsed.diagnostics.map((d) => lintDiagnosticToFinding(d, workdir, cwd, tool));
+        return { ...parsed, findings };
+      }
       return parsed;
     }
   }

--- a/src/review/lint-parsing/types.ts
+++ b/src/review/lint-parsing/types.ts
@@ -1,3 +1,5 @@
+import type { Finding } from "../../findings";
+
 export type LintOutputFormat = "auto" | "eslint-json" | "biome-json" | "text" | "none";
 
 export type LintParserFormat = "eslint-json" | "biome-json" | "text-block";
@@ -15,6 +17,8 @@ export interface LintDiagnostic {
 export interface LintParseResult {
   diagnostics: LintDiagnostic[];
   format: LintParserFormat;
+  /** Structured findings (ADR-021 phase 3). Populated when workdir/cwd are provided to parseLintOutput(). */
+  findings?: Finding[];
 }
 
 export interface LintParseStrategy {

--- a/test/unit/findings/adapters/lint.test.ts
+++ b/test/unit/findings/adapters/lint.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { lintDiagnosticToFinding } from "../../../../src/findings";
+import type { LintDiagnostic } from "../../../../src/review/lint-parsing/types";
+
+const WORKDIR = "/repo";
+const CWD = "/repo";
+
+const baseDiagnostic: LintDiagnostic = {
+  file: "src/foo.ts",
+  line: 10,
+  column: 5,
+  severity: "error",
+  ruleId: "lint/suspicious/noDoubleEquals",
+  message: "Use === instead of ==",
+  raw: "src/foo.ts:10:5 error lint/suspicious/noDoubleEquals Use === instead of ==",
+};
+
+describe("lintDiagnosticToFinding", () => {
+  test("maps required fields — biome tool", () => {
+    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, CWD, "biome");
+
+    expect(finding.source).toBe("lint");
+    expect(finding.tool).toBe("biome");
+    expect(finding.severity).toBe("error");
+    expect(finding.category).toBe("lint");
+    expect(finding.rule).toBe("lint/suspicious/noDoubleEquals");
+    expect(finding.file).toBe("src/foo.ts");
+    expect(finding.line).toBe(10);
+    expect(finding.column).toBe(5);
+    expect(finding.message).toBe("Use === instead of ==");
+  });
+
+  test("maps eslint tool", () => {
+    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, CWD, "eslint");
+    expect(finding.tool).toBe("eslint");
+    expect(finding.source).toBe("lint");
+  });
+
+  test("maps text tool", () => {
+    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, CWD, "text");
+    expect(finding.tool).toBe("text");
+  });
+
+  test("defaults severity to 'warning' when diagnostic severity is undefined", () => {
+    const d: LintDiagnostic = { ...baseDiagnostic, severity: undefined };
+    const finding = lintDiagnosticToFinding(d, WORKDIR, CWD, "biome");
+    expect(finding.severity).toBe("warning");
+  });
+
+  test.each([
+    ["error" as const],
+    ["warning" as const],
+    ["info" as const],
+  ])("passes through severity '%s'", (severity) => {
+    const d: LintDiagnostic = { ...baseDiagnostic, severity };
+    const finding = lintDiagnosticToFinding(d, WORKDIR, CWD, "biome");
+    expect(finding.severity).toBe(severity);
+  });
+
+  test("omits column when absent", () => {
+    const d: LintDiagnostic = { ...baseDiagnostic, column: undefined };
+    const finding = lintDiagnosticToFinding(d, WORKDIR, CWD, "biome");
+    expect(finding.column).toBeUndefined();
+  });
+
+  test("omits ruleId / rule when absent", () => {
+    const d: LintDiagnostic = { ...baseDiagnostic, ruleId: undefined };
+    const finding = lintDiagnosticToFinding(d, WORKDIR, CWD, "biome");
+    expect(finding.rule).toBeUndefined();
+  });
+
+  test("rebases cwd-relative file path to workdir-relative", () => {
+    const d: LintDiagnostic = { ...baseDiagnostic, file: "src/nested/bar.ts" };
+    const finding = lintDiagnosticToFinding(d, "/repo", "/repo", "biome");
+    expect(finding.file).toBe("src/nested/bar.ts");
+  });
+
+  test("rebases absolute file path to workdir-relative", () => {
+    const d: LintDiagnostic = { ...baseDiagnostic, file: "/repo/src/absolute.ts" };
+    const finding = lintDiagnosticToFinding(d, "/repo", "/repo", "biome");
+    expect(finding.file).toBe("src/absolute.ts");
+  });
+
+  test("rebases file when cwd differs from workdir", () => {
+    // lint ran in /repo/packages/lib, workdir is /repo
+    const d: LintDiagnostic = { ...baseDiagnostic, file: "src/util.ts" };
+    const finding = lintDiagnosticToFinding(d, "/repo", "/repo/packages/lib", "biome");
+    expect(finding.file).toBe("packages/lib/src/util.ts");
+  });
+
+  test("fixTarget is always undefined — derived by cycle layer", () => {
+    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, CWD, "biome");
+    expect(finding.fixTarget).toBeUndefined();
+  });
+
+  test("suggestion is always undefined — LintDiagnostic has no fix field", () => {
+    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, CWD, "biome");
+    expect(finding.suggestion).toBeUndefined();
+  });
+});

--- a/test/unit/findings/adapters/lint.test.ts
+++ b/test/unit/findings/adapters/lint.test.ts
@@ -3,7 +3,6 @@ import { lintDiagnosticToFinding } from "../../../../src/findings";
 import type { LintDiagnostic } from "../../../../src/review/lint-parsing";
 
 const WORKDIR = "/repo";
-const CWD = "/repo";
 
 const baseDiagnostic: LintDiagnostic = {
   file: "src/foo.ts",
@@ -17,7 +16,7 @@ const baseDiagnostic: LintDiagnostic = {
 
 describe("lintDiagnosticToFinding", () => {
   test("maps required fields — biome tool", () => {
-    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, CWD, "biome");
+    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, "biome");
 
     expect(finding.source).toBe("lint");
     expect(finding.tool).toBe("biome");
@@ -31,19 +30,19 @@ describe("lintDiagnosticToFinding", () => {
   });
 
   test("maps eslint tool", () => {
-    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, CWD, "eslint");
+    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, "eslint");
     expect(finding.tool).toBe("eslint");
     expect(finding.source).toBe("lint");
   });
 
   test("maps text tool", () => {
-    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, CWD, "text");
+    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, "text");
     expect(finding.tool).toBe("text");
   });
 
   test("defaults severity to 'warning' when diagnostic severity is undefined", () => {
     const d: LintDiagnostic = { ...baseDiagnostic, severity: undefined };
-    const finding = lintDiagnosticToFinding(d, WORKDIR, CWD, "biome");
+    const finding = lintDiagnosticToFinding(d, WORKDIR, "biome");
     expect(finding.severity).toBe("warning");
   });
 
@@ -53,48 +52,41 @@ describe("lintDiagnosticToFinding", () => {
     ["info" as const],
   ])("passes through severity '%s'", (severity) => {
     const d: LintDiagnostic = { ...baseDiagnostic, severity };
-    const finding = lintDiagnosticToFinding(d, WORKDIR, CWD, "biome");
+    const finding = lintDiagnosticToFinding(d, WORKDIR, "biome");
     expect(finding.severity).toBe(severity);
   });
 
   test("omits column when absent", () => {
     const d: LintDiagnostic = { ...baseDiagnostic, column: undefined };
-    const finding = lintDiagnosticToFinding(d, WORKDIR, CWD, "biome");
+    const finding = lintDiagnosticToFinding(d, WORKDIR, "biome");
     expect(finding.column).toBeUndefined();
   });
 
   test("omits ruleId / rule when absent", () => {
     const d: LintDiagnostic = { ...baseDiagnostic, ruleId: undefined };
-    const finding = lintDiagnosticToFinding(d, WORKDIR, CWD, "biome");
+    const finding = lintDiagnosticToFinding(d, WORKDIR, "biome");
     expect(finding.rule).toBeUndefined();
   });
 
-  test("rebases cwd-relative file path to workdir-relative", () => {
+  test("preserves workdir-relative file path unchanged", () => {
     const d: LintDiagnostic = { ...baseDiagnostic, file: "src/nested/bar.ts" };
-    const finding = lintDiagnosticToFinding(d, "/repo", "/repo", "biome");
+    const finding = lintDiagnosticToFinding(d, "/repo", "biome");
     expect(finding.file).toBe("src/nested/bar.ts");
   });
 
   test("rebases absolute file path to workdir-relative", () => {
     const d: LintDiagnostic = { ...baseDiagnostic, file: "/repo/src/absolute.ts" };
-    const finding = lintDiagnosticToFinding(d, "/repo", "/repo", "biome");
+    const finding = lintDiagnosticToFinding(d, "/repo", "biome");
     expect(finding.file).toBe("src/absolute.ts");
   });
 
-  test("rebases file when cwd differs from workdir", () => {
-    // lint ran in /repo/packages/lib, workdir is /repo
-    const d: LintDiagnostic = { ...baseDiagnostic, file: "src/util.ts" };
-    const finding = lintDiagnosticToFinding(d, "/repo", "/repo/packages/lib", "biome");
-    expect(finding.file).toBe("packages/lib/src/util.ts");
-  });
-
   test("fixTarget is always undefined — derived by cycle layer", () => {
-    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, CWD, "biome");
+    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, "biome");
     expect(finding.fixTarget).toBeUndefined();
   });
 
   test("suggestion is always undefined — LintDiagnostic has no fix field", () => {
-    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, CWD, "biome");
+    const finding = lintDiagnosticToFinding(baseDiagnostic, WORKDIR, "biome");
     expect(finding.suggestion).toBeUndefined();
   });
 });

--- a/test/unit/findings/adapters/lint.test.ts
+++ b/test/unit/findings/adapters/lint.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { lintDiagnosticToFinding } from "../../../../src/findings";
-import type { LintDiagnostic } from "../../../../src/review/lint-parsing/types";
+import type { LintDiagnostic } from "../../../../src/review/lint-parsing";
 
 const WORKDIR = "/repo";
 const CWD = "/repo";


### PR DESCRIPTION
## Summary

- Adds `lintDiagnosticToFinding(d, workdir, cwd, tool): Finding` adapter in `src/findings/adapters/lint.ts`
- Extends `LintParseResult` with optional `findings?: Finding[]` field
- Updates `parseLintOutput()` to accept optional `{ workdir, cwd }` and populate structured `Finding[]` via the adapter
- Updates `splitByOutputParsing()` (scope-split routing) to partition via `Finding.fixTarget` when findings are available, with diagnostic file-path fallback for backward compatibility
- Threads `ctx.workdir` through `splitFindingsByScope()` → `splitByOutputParsing()` in both `autofix.ts` and `autofix-agent.ts`
- 14 new unit tests in `test/unit/findings/adapters/lint.test.ts` covering all three lint tools, severity defaulting, path rebasing, and fixTarget/suggestion absence

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test test/unit/findings/adapters/lint.test.ts` — 14 tests pass
- [x] `bun test test/unit/findings/ test/unit/pipeline/stages/` — 501 tests pass
- [x] `bun test test/unit/review/ test/integration/review/ test/integration/autofix/` — 458 tests pass
- [x] `bun run test` — full suite passes (1205 pass, 0 fail)

Refs: #867