### PR TITLE
feat(findings): typecheck adapter (ADR-021 phase 4)

### DIFF
--- a/src/findings/adapters/index.ts
+++ b/src/findings/adapters/index.ts
@@ -1,2 +1,3 @@
 export { lintDiagnosticToFinding } from "./lint";
 export { pluginToFinding } from "./plugin";
+export { tscDiagnosticToFinding } from "./typecheck";

--- a/src/findings/adapters/typecheck.ts
+++ b/src/findings/adapters/typecheck.ts
@@ -1,0 +1,17 @@
+import type { TypecheckDiagnostic } from "../../review/typecheck-parsing/types";
+import { rebaseToWorkdir } from "../path-utils";
+import type { Finding } from "../types";
+
+export function tscDiagnosticToFinding(d: TypecheckDiagnostic, workdir: string): Finding {
+  return {
+    source: "typecheck",
+    tool: "tsc",
+    severity: "error",
+    category: "type-error",
+    rule: d.code ? `TS${d.code}` : undefined,
+    file: rebaseToWorkdir(d.file, workdir, workdir),
+    line: d.line,
+    column: d.column,
+    message: d.message,
+  };
+}

--- a/src/findings/index.ts
+++ b/src/findings/index.ts
@@ -22,5 +22,5 @@ export type {
 
 export { SEVERITY_ORDER, compareSeverity, findingKey } from "./types";
 
-export { lintDiagnosticToFinding, pluginToFinding } from "./adapters";
+export { lintDiagnosticToFinding, pluginToFinding, tscDiagnosticToFinding } from "./adapters";
 export { rebaseToWorkdir } from "./path-utils";

--- a/src/pipeline/stages/autofix-scope-split.ts
+++ b/src/pipeline/stages/autofix-scope-split.ts
@@ -111,16 +111,16 @@ function deriveFixTarget(file: string | undefined, testFilePatterns: readonly st
   return file && isTestFile(file, testFilePatterns) ? "test" : "source";
 }
 
-function splitFindingsByFixTarget(
+function splitFindingsByFixTarget<D>(
   findings: readonly Finding[],
-  diagnostics: readonly LintDiagnostic[],
+  diagnostics: readonly D[],
   testFilePatterns: readonly string[] | undefined,
-): { testDiagnostics: LintDiagnostic[]; sourceDiagnostics: LintDiagnostic[] } {
-  const testDiagnostics: LintDiagnostic[] = [];
-  const sourceDiagnostics: LintDiagnostic[] = [];
+): { testDiagnostics: D[]; sourceDiagnostics: D[] } {
+  const testDiagnostics: D[] = [];
+  const sourceDiagnostics: D[] = [];
   for (let i = 0; i < findings.length; i++) {
     const diagnostic = diagnostics[i];
-    if (!diagnostic) continue; // invariant: findings and diagnostics are co-produced by parseLintOutput
+    if (!diagnostic) continue; // invariant: findings and diagnostics are co-produced by the parser
     const f = findings[i];
     const target = f.fixTarget ?? deriveFixTarget(f.file, testFilePatterns);
     (target === "test" ? testDiagnostics : sourceDiagnostics).push(diagnostic);
@@ -132,9 +132,9 @@ function splitByOutputParsing(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
   format: LintOutputFormat = "auto",
-  lintOpts?: { workdir: string },
+  opts?: { workdir: string },
 ): { testFindings: ReviewCheckResult | null; sourceFindings: ReviewCheckResult | null } {
-  const parsed = parseLintOutput(check.output, format, lintOpts);
+  const parsed = parseLintOutput(check.output, format, opts);
   if (!parsed) {
     // Cannot classify by file -- conservative fallback: route to implementer if output is non-empty
     if (check.output.trim()) {
@@ -167,8 +167,9 @@ function splitByTypecheckOutputParsing(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
   format: TypecheckOutputFormat = "auto",
+  opts?: { workdir: string },
 ): { testFindings: ReviewCheckResult | null; sourceFindings: ReviewCheckResult | null } {
-  const parsed = parseTypecheckOutput(check.output, format);
+  const parsed = parseTypecheckOutput(check.output, format, opts);
   if (!parsed) {
     if (check.output.trim()) {
       return { testFindings: null, sourceFindings: check };
@@ -176,8 +177,19 @@ function splitByTypecheckOutputParsing(
     return { testFindings: null, sourceFindings: null };
   }
 
-  const testDiagnostics = parsed.diagnostics.filter((d) => isTestFile(d.file, testFilePatterns));
-  const sourceDiagnostics = parsed.diagnostics.filter((d) => !isTestFile(d.file, testFilePatterns));
+  let testDiagnostics: TypecheckDiagnostic[];
+  let sourceDiagnostics: TypecheckDiagnostic[];
+
+  if (parsed.findings) {
+    ({ testDiagnostics, sourceDiagnostics } = splitFindingsByFixTarget(
+      parsed.findings,
+      parsed.diagnostics,
+      testFilePatterns,
+    ));
+  } else {
+    testDiagnostics = parsed.diagnostics.filter((d) => isTestFile(d.file, testFilePatterns));
+    sourceDiagnostics = parsed.diagnostics.filter((d) => !isTestFile(d.file, testFilePatterns));
+  }
 
   return {
     testFindings: buildScopedTypecheckCheck(check, testDiagnostics),
@@ -189,15 +201,15 @@ function splitByTypecheckOutputParsing(
  * Split a check result into test-file vs source-file buckets for scope-aware routing.
  * Returns null for each bucket when there are no findings for that scope.
  *
- * Pass lintOpts to enable Finding-based partitioning for lint checks (ADR-021 phase 3).
- * Omitting it falls back to the diagnostic file-path approach.
+ * Pass opts to enable Finding-based partitioning for lint and typecheck checks (ADR-021 phase 3/4).
+ * Omitting opts falls back to the diagnostic file-path approach.
  */
 export function splitFindingsByScope(
   check: ReviewCheckResult,
   testFilePatterns?: readonly string[],
   lintOutputFormat: LintOutputFormat = "auto",
   typecheckOutputFormat: TypecheckOutputFormat = "auto",
-  lintOpts?: { workdir: string },
+  opts?: { workdir: string },
 ): {
   testFindings: ReviewCheckResult | null;
   sourceFindings: ReviewCheckResult | null;
@@ -206,10 +218,10 @@ export function splitFindingsByScope(
     return splitByStructuredFindings(check, testFilePatterns);
   }
   if (check.check === "lint") {
-    return splitByOutputParsing(check, testFilePatterns, lintOutputFormat, lintOpts);
+    return splitByOutputParsing(check, testFilePatterns, lintOutputFormat, opts);
   }
   if (check.check === "typecheck") {
-    return splitByTypecheckOutputParsing(check, testFilePatterns, typecheckOutputFormat);
+    return splitByTypecheckOutputParsing(check, testFilePatterns, typecheckOutputFormat, opts);
   }
   return { testFindings: null, sourceFindings: null };
 }

--- a/src/pipeline/stages/autofix-scope-split.ts
+++ b/src/pipeline/stages/autofix-scope-split.ts
@@ -1,3 +1,4 @@
+import { NaxError } from "../../errors";
 import type { Finding } from "../../findings";
 import {
   type LintDiagnostic,
@@ -120,7 +121,18 @@ function splitFindingsByFixTarget<D>(
   const sourceDiagnostics: D[] = [];
   for (let i = 0; i < findings.length; i++) {
     const diagnostic = diagnostics[i];
-    if (!diagnostic) continue; // invariant: findings and diagnostics are co-produced by the parser
+    if (!diagnostic) {
+      throw new NaxError(
+        `findings and diagnostics arrays are not co-produced: length mismatch at index ${i}`,
+        "INVARIANT_VIOLATION",
+        {
+          stage: "autofix-scope-split",
+          index: i,
+          findingsCount: findings.length,
+          diagnosticsCount: diagnostics.length,
+        },
+      );
+    }
     const f = findings[i];
     const target = f.fixTarget ?? deriveFixTarget(f.file, testFilePatterns);
     (target === "test" ? testDiagnostics : sourceDiagnostics).push(diagnostic);

--- a/src/review/typecheck-parsing/parse.ts
+++ b/src/review/typecheck-parsing/parse.ts
@@ -1,3 +1,4 @@
+import { tscDiagnosticToFinding } from "../../findings";
 import { typecheckTextBlockStrategy } from "./strategies/text-block";
 import { tscStrategy } from "./strategies/tsc";
 import type { TypecheckDiagnostic, TypecheckOutputFormat, TypecheckParseResult, TypecheckParseStrategy } from "./types";
@@ -12,11 +13,16 @@ function strategiesFor(format: TypecheckOutputFormat): ReadonlyArray<TypecheckPa
 export function parseTypecheckOutput(
   output: string,
   format: TypecheckOutputFormat = "auto",
+  opts?: { workdir: string },
 ): TypecheckParseResult | null {
   if (!output.trim()) return null;
   for (const strategy of strategiesFor(format)) {
     const parsed = strategy.parse(output);
     if (parsed && parsed.diagnostics.length > 0) {
+      if (opts) {
+        const findings = parsed.diagnostics.map((d) => tscDiagnosticToFinding(d, opts.workdir));
+        return { ...parsed, findings };
+      }
       return parsed;
     }
   }

--- a/src/review/typecheck-parsing/types.ts
+++ b/src/review/typecheck-parsing/types.ts
@@ -1,3 +1,5 @@
+import type { Finding } from "../../findings";
+
 export type TypecheckOutputFormat = "auto" | "tsc" | "text" | "none";
 
 export type TypecheckParserFormat = "tsc" | "text-block";
@@ -14,6 +16,8 @@ export interface TypecheckDiagnostic {
 export interface TypecheckParseResult {
   diagnostics: TypecheckDiagnostic[];
   format: TypecheckParserFormat;
+  /** Structured findings (ADR-021 phase 4). Populated when workdir is provided to parseTypecheckOutput(). */
+  findings?: Finding[];
 }
 
 export interface TypecheckParseStrategy {

--- a/test/unit/findings/adapters/typecheck.test.ts
+++ b/test/unit/findings/adapters/typecheck.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { tscDiagnosticToFinding } from "../../../../src/findings";
+import type { TypecheckDiagnostic } from "../../../../src/review/typecheck-parsing";
+
+const WORKDIR = "/repo";
+
+const baseDiagnostic: TypecheckDiagnostic = {
+  file: "src/foo.ts",
+  line: 42,
+  column: 10,
+  code: "2304",
+  message: "Cannot find name 'Foo'.",
+  raw: "src/foo.ts(42,10): error TS2304: Cannot find name 'Foo'.",
+};
+
+describe("tscDiagnosticToFinding", () => {
+  test("maps required fields", () => {
+    const finding = tscDiagnosticToFinding(baseDiagnostic, WORKDIR);
+
+    expect(finding.source).toBe("typecheck");
+    expect(finding.tool).toBe("tsc");
+    expect(finding.severity).toBe("error");
+    expect(finding.category).toBe("type-error");
+    expect(finding.rule).toBe("TS2304");
+    expect(finding.file).toBe("src/foo.ts");
+    expect(finding.line).toBe(42);
+    expect(finding.column).toBe(10);
+    expect(finding.message).toBe("Cannot find name 'Foo'.");
+  });
+
+  test("severity is always 'error'", () => {
+    const finding = tscDiagnosticToFinding(baseDiagnostic, WORKDIR);
+    expect(finding.severity).toBe("error");
+  });
+
+  test("formats code as TS-prefixed rule", () => {
+    const finding = tscDiagnosticToFinding(baseDiagnostic, WORKDIR);
+    expect(finding.rule).toBe("TS2304");
+  });
+
+  test("omits rule when code is undefined", () => {
+    const d: TypecheckDiagnostic = { ...baseDiagnostic, code: undefined };
+    const finding = tscDiagnosticToFinding(d, WORKDIR);
+    expect(finding.rule).toBeUndefined();
+  });
+
+  test("omits column when absent", () => {
+    const d: TypecheckDiagnostic = { ...baseDiagnostic, column: undefined };
+    const finding = tscDiagnosticToFinding(d, WORKDIR);
+    expect(finding.column).toBeUndefined();
+  });
+
+  test("omits line when absent", () => {
+    const d: TypecheckDiagnostic = { ...baseDiagnostic, line: undefined };
+    const finding = tscDiagnosticToFinding(d, WORKDIR);
+    expect(finding.line).toBeUndefined();
+  });
+
+  test("preserves workdir-relative file path unchanged", () => {
+    const d: TypecheckDiagnostic = { ...baseDiagnostic, file: "src/nested/bar.ts" };
+    const finding = tscDiagnosticToFinding(d, "/repo");
+    expect(finding.file).toBe("src/nested/bar.ts");
+  });
+
+  test("rebases absolute file path to workdir-relative", () => {
+    const d: TypecheckDiagnostic = { ...baseDiagnostic, file: "/repo/src/absolute.ts" };
+    const finding = tscDiagnosticToFinding(d, "/repo");
+    expect(finding.file).toBe("src/absolute.ts");
+  });
+
+  test("fixTarget is always undefined — derived by cycle layer", () => {
+    const finding = tscDiagnosticToFinding(baseDiagnostic, WORKDIR);
+    expect(finding.fixTarget).toBeUndefined();
+  });
+
+  test("suggestion is always undefined — TypecheckDiagnostic has no fix field", () => {
+    const finding = tscDiagnosticToFinding(baseDiagnostic, WORKDIR);
+    expect(finding.suggestion).toBeUndefined();
+  });
+});

--- a/test/unit/findings/adapters/typecheck.test.ts
+++ b/test/unit/findings/adapters/typecheck.test.ts
@@ -28,16 +28,6 @@ describe("tscDiagnosticToFinding", () => {
     expect(finding.message).toBe("Cannot find name 'Foo'.");
   });
 
-  test("severity is always 'error'", () => {
-    const finding = tscDiagnosticToFinding(baseDiagnostic, WORKDIR);
-    expect(finding.severity).toBe("error");
-  });
-
-  test("formats code as TS-prefixed rule", () => {
-    const finding = tscDiagnosticToFinding(baseDiagnostic, WORKDIR);
-    expect(finding.rule).toBe("TS2304");
-  });
-
   test("omits rule when code is undefined", () => {
     const d: TypecheckDiagnostic = { ...baseDiagnostic, code: undefined };
     const finding = tscDiagnosticToFinding(d, WORKDIR);


### PR DESCRIPTION
## Summary

- Adds `tscDiagnosticToFinding(d, workdir): Finding` adapter in `src/findings/adapters/typecheck.ts` — converts `TypecheckDiagnostic` to the `Finding` wire format with `severity: "error"` always and `rule: \`TS\${code}\`` when `code` is present
- Extends `TypecheckParseResult` with `findings?: Finding[]`, populated when `opts.workdir` is provided to `parseTypecheckOutput()` (same pattern as phase 3 lint adapter)
- Makes `splitFindingsByFixTarget` generic (`<D>`) so it handles both `LintDiagnostic` and `TypecheckDiagnostic` without duplication
- Threads `opts?: { workdir: string }` through `splitByTypecheckOutputParsing` → `splitFindingsByScope`; renames `lintOpts` → `opts` since the same workdir applies to both lint and typecheck
- 10 unit tests in `test/unit/findings/adapters/typecheck.test.ts` covering field mappings, severity invariant, TS-prefixed rule format, path rebasing (absolute → relative), and missing optional fields

## Test plan

- [ ] `timeout 30 bun test test/unit/findings/adapters/typecheck.test.ts --timeout=10000` — 10/10 pass
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `bun run test` — all phases pass (1234 unit/integration + 13 UI, 0 failures)