### PR TITLE
feat(findings): ADR-021 phase 6 — adversarial review Finding adapter

### DIFF
--- a/src/findings/adapters/index.ts
+++ b/src/findings/adapters/index.ts
@@ -1,4 +1,5 @@
 export { lintDiagnosticToFinding } from "./lint";
+export { llmReviewFindingToFinding } from "./llm-review";
 export { pluginToFinding } from "./plugin";
 export { acFailureToFinding, acSentinelToFinding } from "./test-runner";
 export { tscDiagnosticToFinding } from "./typecheck";

--- a/src/findings/adapters/llm-review.ts
+++ b/src/findings/adapters/llm-review.ts
@@ -1,0 +1,29 @@
+import type { LlmReviewFinding } from "../../operations/types";
+import { rebaseToWorkdir } from "../path-utils";
+import type { Finding, FindingSeverity } from "../types";
+
+function normalizeSeverity(sev: string): FindingSeverity {
+  if (sev === "warn") return "warning";
+  if (
+    sev === "critical" ||
+    sev === "error" ||
+    sev === "warning" ||
+    sev === "info" ||
+    sev === "low" ||
+    sev === "unverifiable"
+  )
+    return sev;
+  return "info";
+}
+
+export function llmReviewFindingToFinding(lf: LlmReviewFinding, workdir: string): Finding {
+  return {
+    source: "adversarial-review",
+    severity: normalizeSeverity(lf.severity),
+    category: lf.category ?? "",
+    file: rebaseToWorkdir(lf.file, workdir, workdir),
+    line: lf.line,
+    message: lf.issue,
+    suggestion: lf.suggestion,
+  };
+}

--- a/src/findings/index.ts
+++ b/src/findings/index.ts
@@ -26,6 +26,7 @@ export {
   acFailureToFinding,
   acSentinelToFinding,
   lintDiagnosticToFinding,
+  llmReviewFindingToFinding,
   pluginToFinding,
   tscDiagnosticToFinding,
 } from "./adapters";

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -9,6 +9,7 @@
  * Reuses PriorFailure and buildAttemptContextBlock from review-builder.ts.
  */
 
+import type { Finding } from "../../findings";
 import type { AdversarialFindingsCache, AdversarialReviewConfig, SemanticStory } from "../../review/types";
 import { buildAttemptContextBlock } from "./review-builder";
 import type { PriorFailure } from "./review-builder";
@@ -117,7 +118,7 @@ Respond with ONLY a JSON object — no preamble, no explanation outside the JSON
   "passed": true | false,
   "findings": [
     {
-      "severity": "error" | "warn" | "info" | "unverifiable",
+      "severity": "error" | "warning" | "info" | "unverifiable",
       "category": "input" | "error-path" | "abandonment" | "test-gap" | "convention" | "assumption",
       "file": "relative/path/to/file.ts",
       "line": 42,
@@ -130,11 +131,11 @@ Respond with ONLY a JSON object — no preamble, no explanation outside the JSON
 
 Severity guide:
 - \`"error"\`: confident this will cause real failure or regression
-- \`"warn"\`: fragile or incomplete but may ship without immediate breakage
+- \`"warning"\`: fragile or incomplete but may ship without immediate breakage
 - \`"info"\`: noteworthy but not actionable as a blocker
 - \`"unverifiable"\`: suspect problem but couldn't confirm from available artifacts
 
-\`passed\` must be \`false\` if any finding has severity \`"error"\` or \`"warn"\`.
+\`passed\` must be \`false\` if any finding has severity \`"error"\` or \`"warning"\`.
 \`passed\` may be \`true\` with findings if all findings are \`"info"\` or \`"unverifiable"\`.`;
 
 /**
@@ -222,15 +223,13 @@ ${diff}\`\`\`
  * Build the prior-findings carry-forward block injected at the top of subsequent rounds.
  * Verdict-first: the reviewer sees unresolved findings before scanning for new issues.
  */
-function buildPriorFindingsBlock(
-  round: number,
-  findings: Array<{ severity: string; category?: string; file: string; line?: number; issue: string }>,
-): string {
+function buildPriorFindingsBlock(round: number, findings: readonly Finding[]): string {
   const rows = findings
     .map((f) => {
-      const location = f.line !== undefined ? `${f.file}:${f.line}` : f.file;
-      const category = f.category ?? "—";
-      return `| ${f.severity} | ${category} | ${location} | ${f.issue} |`;
+      const filePath = f.file ?? "";
+      const location = f.line !== undefined ? `${filePath}:${f.line}` : filePath;
+      const category = f.category || "—";
+      return `| ${f.severity} | ${category} | ${location} | ${f.message} |`;
     })
     .join("\n");
 

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -593,11 +593,12 @@ export class ReviewOrchestrator {
         ctx.priorAdversarialFindings = {
           round: (ctx.priorAdversarialFindings?.round ?? 0) + 1,
           findings: (advCheck.findings ?? []).map((f) => ({
+            source: "adversarial-review" as const,
             severity: f.severity,
-            category: f.category,
+            category: f.category ?? "",
             file: f.file,
             line: f.line,
-            issue: f.message,
+            message: f.message,
           })),
         };
       } else if (advCheck.success && !advCheck.skipped) {

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -4,6 +4,8 @@
  * Post-implementation quality verification
  */
 
+import type { Finding } from "../findings";
+
 /** Review check name */
 export type ReviewCheckName = "typecheck" | "lint" | "test" | "build" | "semantic" | "adversarial";
 
@@ -182,13 +184,7 @@ export interface AdversarialFindingsCache {
   /** Round that produced these findings (1-indexed) */
   round: number;
   /** Blocking findings from the previous adversarial round */
-  findings: Array<{
-    severity: string;
-    category?: string;
-    file: string;
-    line?: number;
-    issue: string;
-  }>;
+  findings: Finding[];
 }
 
 /** Review configuration */

--- a/test/unit/findings/adapters/llm-review.test.ts
+++ b/test/unit/findings/adapters/llm-review.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { llmReviewFindingToFinding } from "../../../../src/findings";
+
+describe("llmReviewFindingToFinding", () => {
+  test("maps required fields", () => {
+    const f = llmReviewFindingToFinding({ severity: "error", file: "src/foo.ts", issue: "null dereference" }, "/repo");
+    expect(f.source).toBe("adversarial-review");
+    expect(f.severity).toBe("error");
+    expect(f.message).toBe("null dereference");
+    expect(f.file).toBe("src/foo.ts");
+    expect(f.category).toBe("");
+  });
+
+  test("maps optional fields when present", () => {
+    const f = llmReviewFindingToFinding(
+      {
+        severity: "warning",
+        file: "src/bar.ts",
+        issue: "incomplete error handling",
+        suggestion: "add catch block",
+        category: "error-path",
+        line: 42,
+      },
+      "/repo",
+    );
+    expect(f.line).toBe(42);
+    expect(f.suggestion).toBe("add catch block");
+    expect(f.category).toBe("error-path");
+    expect(f.severity).toBe("warning");
+  });
+
+  test("normalizes legacy 'warn' severity to 'warning'", () => {
+    const f = llmReviewFindingToFinding({ severity: "warn", file: "src/foo.ts", issue: "fragile pattern" }, "/repo");
+    expect(f.severity).toBe("warning");
+  });
+
+  test("passes through 'unverifiable' severity", () => {
+    const f = llmReviewFindingToFinding(
+      { severity: "unverifiable", file: "src/foo.ts", issue: "suspect pattern" },
+      "/repo",
+    );
+    expect(f.severity).toBe("unverifiable");
+  });
+
+  test("defaults unknown severity to 'info'", () => {
+    const f = llmReviewFindingToFinding({ severity: "unknown", file: "src/foo.ts", issue: "something" }, "/repo");
+    expect(f.severity).toBe("info");
+  });
+
+  test("rebases absolute path to workdir-relative", () => {
+    const f = llmReviewFindingToFinding({ severity: "error", file: "/repo/src/foo.ts", issue: "issue" }, "/repo");
+    expect(f.file).toBe("src/foo.ts");
+  });
+
+  test("passes through 'critical' severity", () => {
+    const f = llmReviewFindingToFinding({ severity: "critical", file: "src/foo.ts", issue: "crash" }, "/repo");
+    expect(f.severity).toBe("critical");
+  });
+});

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -85,7 +85,16 @@ describe("adversarialReviewOp.build()", () => {
       ...SAMPLE_INPUT,
       priorAdversarialFindings: {
         round: 2,
-        findings: [{ severity: "error", file: "src/session.ts", line: 10, issue: "Silent catch block" }],
+        findings: [
+            {
+              source: "adversarial-review",
+              severity: "error",
+              category: "error-path",
+              file: "src/session.ts",
+              line: 10,
+              message: "Silent catch block",
+            },
+          ],
       },
     };
     const result = adversarialReviewOp.build(inputWithPrior, ctx);

--- a/test/unit/prompts/adversarial-review-builder.test.ts
+++ b/test/unit/prompts/adversarial-review-builder.test.ts
@@ -270,7 +270,7 @@ describe("AdversarialReviewPromptBuilder — output schema", () => {
     });
 
     expect(result).toContain('"error"');
-    expect(result).toContain('"warn"');
+    expect(result).toContain('"warning"');
     expect(result).toContain('"info"');
     expect(result).toContain('"unverifiable"');
   });
@@ -327,17 +327,19 @@ describe("AdversarialReviewPromptBuilder — priorAdversarialFindings", () => {
     round: 1,
     findings: [
       {
-        severity: "error",
+        source: "adversarial-review" as const,
+        severity: "error" as const,
         category: "error-path",
         file: "src/auth/login.ts",
         line: 42,
-        issue: "Null pointer dereference on empty input",
+        message: "Null pointer dereference on empty input",
       },
       {
-        severity: "warn",
+        source: "adversarial-review" as const,
+        severity: "warning" as const,
         category: "convention",
         file: "src/auth/session.ts",
-        issue: "Missing storyId in logger call",
+        message: "Missing storyId in logger call",
       },
     ],
   };
@@ -400,7 +402,15 @@ describe("AdversarialReviewPromptBuilder — priorAdversarialFindings", () => {
       storyGitRef: STORY_GIT_REF,
       priorAdversarialFindings: {
         round: 1,
-        findings: [{ severity: "warn", file: "src/utils.ts", issue: "Unhandled promise rejection" }],
+        findings: [
+              {
+                source: "adversarial-review" as const,
+                severity: "warning" as const,
+                category: "",
+                file: "src/utils.ts",
+                message: "Unhandled promise rejection",
+              },
+            ],
       },
     });
     expect(result).toContain("src/utils.ts");


### PR DESCRIPTION
## Summary

- Adds `llmReviewFindingToFinding()` adapter in `src/findings/adapters/llm-review.ts` — converts raw `LlmReviewFinding` (from LLM JSON) to the unified `Finding` wire format, normalizing legacy `"warn"` → `"warning"` severity on the read path
- Upgrades `AdversarialFindingsCache.findings` from an inline object shape (`{ severity, category?, file, line?, issue }`) to `Finding[]`, completing the carry-forward cache migration
- Updates `orchestrator.ts` to map `ReviewFinding[]` → `Finding[]` when building the cache for the next review round
- Updates `buildPriorFindingsBlock()` in the adversarial review prompt builder to read `Finding[]` (`f.message`, optional `f.file`)
- Renames `"warn"` → `"warning"` in `OUTPUT_SCHEMA` so the LLM is prompted to emit the canonical severity; `normalizeSeverity` keeps the legacy read path for in-flight responses

## Test plan

- [ ] 7 new unit tests in `test/unit/findings/adapters/llm-review.test.ts` covering all severity normalizations (warn→warning, unverifiable, unknown→info, critical), path rebasing, optional fields, and missing category defaulting
- [ ] All 49 findings adapter tests pass
- [ ] Full suite: 6896 pass, 3 pre-existing flaky failures in acceptance lifecycle tests (verified pre-exist on main)