### PR TITLE
feat(findings): ADR-021 phase 7 — semantic review Finding migration

### DIFF
--- a/src/acceptance/semantic-verdict.ts
+++ b/src/acceptance/semantic-verdict.ts
@@ -7,6 +7,7 @@
  */
 
 import path from "node:path";
+import { reviewFindingToFinding } from "../findings";
 import { getLogger } from "../logger";
 import type { SemanticVerdict } from "./types";
 export type { SemanticVerdict } from "./types";
@@ -57,6 +58,23 @@ export async function persistSemanticVerdict(
 }
 
 /**
+ * Migrate a verdict that may have been persisted with the old ReviewFinding shape
+ * (pre-ADR-021-phase-7). Detection: a finding with `ruleId` but no `source` field
+ * is a legacy ReviewFinding — convert it via reviewFindingToFinding.
+ */
+function migrateSemanticVerdict(verdict: SemanticVerdict): SemanticVerdict {
+  if (!verdict.findings?.length) return verdict;
+  const first = verdict.findings[0] as unknown as Record<string, unknown>;
+  if ("source" in first) return verdict;
+  return {
+    ...verdict,
+    findings: (verdict.findings as unknown as Array<unknown>).map((f) =>
+      reviewFindingToFinding(f as Parameters<typeof reviewFindingToFinding>[0]),
+    ),
+  };
+}
+
+/**
  * Load all semantic verdicts from <featureDir>/semantic-verdicts/.
  *
  * Returns an empty array when the directory does not exist or is empty.
@@ -81,7 +99,8 @@ export async function loadSemanticVerdicts(featureDir: string): Promise<Semantic
     const filePath = path.join(dir, file);
     const content = await _semanticVerdictDeps.readFile(filePath);
     try {
-      results.push(JSON.parse(content) as SemanticVerdict);
+      const parsed = JSON.parse(content) as SemanticVerdict;
+      results.push(migrateSemanticVerdict(parsed));
     } catch {
       _semanticVerdictDeps.logDebug(`Skipping invalid JSON in semantic-verdicts/${file}`);
     }

--- a/src/acceptance/types.ts
+++ b/src/acceptance/types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { AcceptanceTestStrategy, ModelDef, ModelTier, NaxConfig } from "../config/schema";
+import type { Finding } from "../findings";
 import type { DispatchContext } from "../runtime/dispatch-context";
 
 /**
@@ -145,8 +146,8 @@ export interface SemanticVerdict {
   timestamp: string;
   /** Number of acceptance criteria in scope at review time */
   acCount: number;
-  /** Structured findings from the semantic check (empty when passed) */
-  findings: import("../plugins/types").ReviewFinding[];
+  /** Structured findings from the semantic check (empty when passed) — Finding[] per ADR-021 phase 7 */
+  findings: Finding[];
 }
 
 /** Diagnosis result from acceptance test failure analysis (US-001) */

--- a/src/findings/adapters/index.ts
+++ b/src/findings/adapters/index.ts
@@ -1,5 +1,6 @@
 export { lintDiagnosticToFinding } from "./lint";
 export { llmReviewFindingToFinding } from "./llm-review";
 export { pluginToFinding } from "./plugin";
+export { reviewFindingToFinding } from "./semantic-review";
 export { acFailureToFinding, acSentinelToFinding } from "./test-runner";
 export { tscDiagnosticToFinding } from "./typecheck";

--- a/src/findings/adapters/semantic-review.ts
+++ b/src/findings/adapters/semantic-review.ts
@@ -1,0 +1,18 @@
+import type { ReviewFinding } from "../../plugins/types";
+import type { Finding } from "../types";
+
+/** Convert a persisted ReviewFinding (semantic check) to the unified Finding wire format. */
+export function reviewFindingToFinding(f: ReviewFinding): Finding {
+  return {
+    source: "semantic-review",
+    severity: f.severity,
+    category: f.category ?? "",
+    rule: f.ruleId,
+    file: f.file,
+    line: f.line,
+    column: f.column,
+    endLine: f.endLine,
+    endColumn: f.endColumn,
+    message: f.message,
+  };
+}

--- a/src/findings/index.ts
+++ b/src/findings/index.ts
@@ -28,6 +28,7 @@ export {
   lintDiagnosticToFinding,
   llmReviewFindingToFinding,
   pluginToFinding,
+  reviewFindingToFinding,
   tscDiagnosticToFinding,
 } from "./adapters";
 export { rebaseToWorkdir } from "./path-utils";

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -13,6 +13,7 @@
 // RE-ARCH: rewrite
 import { checkSecurityReview, isTriggerEnabled } from "../../interaction/triggers";
 import { getLogger } from "../../logger";
+import type { ReviewFinding } from "../../plugins/types";
 import { createReviewerSession } from "../../review/dialogue";
 import { reviewOrchestrator } from "../../review/orchestrator";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
@@ -179,7 +180,16 @@ export const reviewStage: PipelineStage = {
         .filter((c) => c.check === "semantic" && !c.success && c.findings?.length)
         .flatMap((c) => c.findings ?? []);
       if (semanticFindings.length > 0) {
-        ctx.reviewFindings = semanticFindings;
+        // Downcast Finding[] → ReviewFinding[] for ctx.reviewFindings; migrates in a later phase once elements.ts adopts Finding[].
+        ctx.reviewFindings = semanticFindings.map((f) => ({
+          ruleId: f.rule ?? "semantic",
+          severity: (f.severity === "unverifiable" ? "info" : f.severity) as ReviewFinding["severity"],
+          file: f.file ?? "",
+          line: f.line ?? 0,
+          message: f.message,
+          source: f.source,
+          category: f.category,
+        }));
       }
 
       if (result.pluginFailed) {

--- a/src/prompts/builders/debate-builder.ts
+++ b/src/prompts/builders/debate-builder.ts
@@ -13,7 +13,7 @@
 
 import { PERSONA_FRAGMENTS } from "../../debate/personas";
 import type { DebateResolverContext, Debater, Proposal, Rebuttal } from "../../debate/types";
-import type { ReviewFinding } from "../../plugins/types";
+import type { Finding } from "../../findings";
 import type { DiffContext } from "../../review/types";
 import type { ComposeInput } from "../compose";
 
@@ -234,9 +234,11 @@ ${this.stageContext.outputFormat}`;
   }
 
   /** Re-review prompt — references previous findings and updated diff. */
-  buildReReviewPrompt(updatedDiff: string, previousFindings: ReviewFinding[]): string {
+  buildReReviewPrompt(updatedDiff: string, previousFindings: Finding[]): string {
     const findingsList =
-      previousFindings.length > 0 ? previousFindings.map((f) => `- ${f.ruleId}: ${f.message}`).join("\n") : "(none)";
+      previousFindings.length > 0
+        ? previousFindings.map((f) => `- ${f.rule ?? "semantic"}: ${f.message}`).join("\n")
+        : "(none)";
     return [
       "This is a follow-up re-review. Please review the updated diff below.",
       "",
@@ -292,12 +294,14 @@ ${this.stageContext.outputFormat}`;
     proposals: Array<{ debater: string; output: string }>,
     critiques: string[],
     diffContext: DiffContext,
-    previousFindings: ReviewFinding[],
+    previousFindings: Finding[],
     resolverContext: DebateResolverContext,
   ): string {
     const framing = this.buildResolverFraming(resolverContext);
     const findingsList =
-      previousFindings.length > 0 ? previousFindings.map((f) => `- ${f.ruleId}: ${f.message}`).join("\n") : "(none)";
+      previousFindings.length > 0
+        ? previousFindings.map((f) => `- ${f.rule ?? "semantic"}: ${f.message}`).join("\n")
+        : "(none)";
     const proposalsSection = this.buildLabeledProposalsSection(proposals);
     const critiquesSection = this.buildLabeledCritiquesSection(critiques);
     const diffSection = buildDebateDiffSection(diffContext);

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -42,7 +42,7 @@ const SEMANTIC_OUTPUT_SCHEMA = `Respond with JSON only — no explanation text b
   "passed": boolean,
   "findings": [
     {
-      "severity": "error" | "warn" | "info" | "unverifiable",
+      "severity": "error" | "warning" | "info" | "unverifiable",
       "file": "path/to/file",
       "line": 42,
       "issue": "description of the issue",

--- a/src/review/adversarial-helpers.ts
+++ b/src/review/adversarial-helpers.ts
@@ -5,7 +5,7 @@
  * to keep each file within the 600-line project limit.
  */
 
-import type { ReviewFinding } from "../plugins/types";
+import type { Finding, FindingSeverity } from "../findings";
 import { tryParseLLMJson } from "../utils/llm-json";
 import { SEVERITY_RANK } from "./severity";
 
@@ -53,11 +53,18 @@ export function formatFindings(findings: AdversarialLLMFinding[]): string {
     .join("\n");
 }
 
-/** Normalize LLM severity values to ReviewFinding severity union. */
-export function normalizeSeverity(sev: string): ReviewFinding["severity"] {
+/** Normalize LLM severity values to FindingSeverity. */
+export function normalizeSeverity(sev: string): FindingSeverity {
   if (sev === "warn") return "warning";
-  if (sev === "unverifiable") return "info";
-  if (sev === "critical" || sev === "error" || sev === "warning" || sev === "info" || sev === "low") return sev;
+  if (
+    sev === "critical" ||
+    sev === "error" ||
+    sev === "warning" ||
+    sev === "info" ||
+    sev === "low" ||
+    sev === "unverifiable"
+  )
+    return sev;
   return "info";
 }
 
@@ -69,15 +76,15 @@ export function isBlockingSeverity(sev: string, threshold: "error" | "warning" |
   return (SEVERITY_RANK[sev] ?? 0) >= (SEVERITY_RANK[threshold] ?? 2);
 }
 
-/** Convert AdversarialLLMFinding[] to ReviewFinding[] with adversarial-review metadata. */
-export function toAdversarialReviewFindings(findings: AdversarialLLMFinding[]): ReviewFinding[] {
+/** Convert AdversarialLLMFinding[] to Finding[] with adversarial-review source. */
+export function toAdversarialReviewFindings(findings: AdversarialLLMFinding[]): Finding[] {
   return findings.map((f) => ({
-    ruleId: "adversarial",
+    source: "adversarial-review",
     severity: normalizeSeverity(f.severity),
+    category: f.category,
     file: f.file,
     line: f.line,
     message: f.issue,
-    source: "adversarial-review",
-    category: f.category,
+    suggestion: f.suggestion,
   }));
 }

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -12,7 +12,7 @@ import { resolveConfiguredModel } from "../config/schema-types";
 import type { ReviewConfig } from "../config/selectors";
 import type { DebateResolverContext } from "../debate/types";
 import { NaxError } from "../errors";
-import type { ReviewFinding } from "../plugins/types";
+import type { Finding, FindingSeverity } from "../findings";
 import { DebatePromptBuilder } from "../prompts";
 import type { ISessionManager } from "../session/types";
 import { parseLLMJson, tryParseLLMJson } from "../utils/llm-json";
@@ -36,8 +36,8 @@ export interface ReviewDialogueResult {
   checkResult: {
     /** Whether all acceptance criteria passed */
     success: boolean;
-    /** Structured findings from the reviewer */
-    findings: ReviewFinding[];
+    /** Structured findings from the reviewer — Finding[] per ADR-021 phase 7 */
+    findings: Finding[];
   };
   /** Map from finding identifier to detailed reasoning string */
   findingReasoning: Map<string, string>;
@@ -105,32 +105,32 @@ export interface ReviewerSession {
   destroy(): Promise<void>;
 }
 
-function extractDeltaSummary(
-  rawOutput: string,
-  previousFindings: ReviewFinding[],
-  newFindings: ReviewFinding[],
-): string {
+function findingId(f: Finding): string {
+  return f.rule ?? `${f.file ?? ""}:${f.line ?? 0}:${f.message.slice(0, 40)}`;
+}
+
+function extractDeltaSummary(rawOutput: string, previousFindings: Finding[], newFindings: Finding[]): string {
   const parsed = tryParseLLMJson<Record<string, unknown>>(rawOutput);
   if (parsed && typeof parsed.deltaSummary === "string" && parsed.deltaSummary.length > 0) {
     return parsed.deltaSummary;
   }
 
-  const newIds = new Set(newFindings.map((f) => f.ruleId));
-  const prevIds = new Set(previousFindings.map((f) => f.ruleId));
+  const newIds = new Set(newFindings.map(findingId));
+  const prevIds = new Set(previousFindings.map(findingId));
 
-  const resolved = previousFindings.filter((f) => !newIds.has(f.ruleId));
-  const stillPresent = newFindings.filter((f) => prevIds.has(f.ruleId));
-  const added = newFindings.filter((f) => !prevIds.has(f.ruleId));
+  const resolved = previousFindings.filter((f) => !newIds.has(findingId(f)));
+  const stillPresent = newFindings.filter((f) => prevIds.has(findingId(f)));
+  const added = newFindings.filter((f) => !prevIds.has(findingId(f)));
 
   const parts: string[] = [];
   if (resolved.length > 0) {
-    parts.push(`Resolved: ${resolved.map((f) => f.ruleId).join(", ")}.`);
+    parts.push(`Resolved: ${resolved.map(findingId).join(", ")}.`);
   }
   if (stillPresent.length > 0) {
-    parts.push(`Still present: ${stillPresent.map((f) => f.ruleId).join(", ")}.`);
+    parts.push(`Still present: ${stillPresent.map(findingId).join(", ")}.`);
   }
   if (added.length > 0) {
-    parts.push(`New findings: ${added.map((f) => f.ruleId).join(", ")}.`);
+    parts.push(`New findings: ${added.map(findingId).join(", ")}.`);
   }
   if (parts.length === 0) {
     return previousFindings.length > 0 ? "All previous findings resolved." : "No changes from previous review.";
@@ -155,26 +155,30 @@ function compactHistory(history: DialogueMessage[]): string {
 }
 
 /**
- * Map a raw LLM finding object to a ReviewFinding.
+ * Map a raw LLM finding object to a Finding.
  * The dialogue reviewer LLM may return `issue`/`suggestion` (matching the semantic.ts prompt schema)
- * or may return `message`/`ruleId` directly. Both shapes are normalized here so that
- * ReviewFinding.ruleId and ReviewFinding.message are always populated.
+ * or may return `message` directly. Both shapes are normalized here.
  */
-function mapLLMFindingToReviewFinding(f: Record<string, unknown>): ReviewFinding {
+function mapLLMFindingToFinding(f: Record<string, unknown>): Finding {
   const rawSeverity = typeof f.severity === "string" ? f.severity : "info";
-  let severity: ReviewFinding["severity"] = "info";
+  let severity: FindingSeverity = "info";
   if (rawSeverity === "warn" || rawSeverity === "warning") severity = "warning";
-  else if (rawSeverity === "critical" || rawSeverity === "error" || rawSeverity === "low") severity = rawSeverity;
-  else if (rawSeverity === "unverifiable") severity = "info";
-  else if (rawSeverity === "info") severity = "info";
+  else if (
+    rawSeverity === "critical" ||
+    rawSeverity === "error" ||
+    rawSeverity === "low" ||
+    rawSeverity === "unverifiable"
+  )
+    severity = rawSeverity;
 
   return {
-    ruleId: typeof f.ruleId === "string" && f.ruleId ? f.ruleId : "semantic",
+    source: "semantic-review",
     severity,
+    category: "",
+    rule: typeof f.ruleId === "string" && f.ruleId ? f.ruleId : undefined,
     file: typeof f.file === "string" ? f.file : "",
     line: typeof f.line === "number" ? f.line : 0,
     message: typeof f.message === "string" && f.message ? f.message : typeof f.issue === "string" ? f.issue : "",
-    source: typeof f.source === "string" ? f.source : "semantic-review",
   };
 }
 
@@ -197,7 +201,7 @@ function parseReviewResponse(output: string): ReviewDialogueResult {
   }
   const success = Boolean(parsed.passed);
   const rawFindings = Array.isArray(parsed.findings) ? (parsed.findings as Record<string, unknown>[]) : [];
-  const findings: ReviewFinding[] = rawFindings.map((f) => mapLLMFindingToReviewFinding(f));
+  const findings: Finding[] = rawFindings.map((f) => mapLLMFindingToFinding(f));
   const reasoningObj =
     parsed.findingReasoning && typeof parsed.findingReasoning === "object"
       ? (parsed.findingReasoning as Record<string, string>)

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -592,14 +592,7 @@ export class ReviewOrchestrator {
       if (!advCheck.success && (advCheck.findings?.length ?? 0) > 0) {
         ctx.priorAdversarialFindings = {
           round: (ctx.priorAdversarialFindings?.round ?? 0) + 1,
-          findings: (advCheck.findings ?? []).map((f) => ({
-            source: "adversarial-review" as const,
-            severity: f.severity,
-            category: f.category ?? "",
-            file: f.file,
-            line: f.line,
-            message: f.message,
-          })),
+          findings: advCheck.findings ?? [],
         };
       } else if (advCheck.success && !advCheck.skipped) {
         ctx.priorAdversarialFindings = undefined;

--- a/src/review/semantic-debate.ts
+++ b/src/review/semantic-debate.ts
@@ -172,7 +172,7 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
           success: false,
           command: "",
           exitCode: 1,
-          output: `Semantic review failed:\n\n${findings.map((f) => `${f.ruleId}: ${f.message}`).join("\n")}`,
+          output: `Semantic review failed:\n\n${findings.map((f) => `${f.rule ?? "semantic"}: ${f.message}`).join("\n")}`,
           durationMs,
           findings,
           cost: debateCost,

--- a/src/review/semantic-helpers.ts
+++ b/src/review/semantic-helpers.ts
@@ -3,7 +3,7 @@
  * Extracted from semantic.ts to stay within the 600-line file limit.
  */
 
-import type { ReviewFinding } from "../plugins/types";
+import type { Finding, FindingSeverity } from "../findings";
 import { tryParseLLMJson } from "../utils/llm-json";
 import { SEVERITY_RANK } from "./severity";
 import type { SemanticReviewConfig } from "./types";
@@ -50,11 +50,18 @@ export function formatFindings(findings: LLMFinding[]): string {
     .join("\n");
 }
 
-/** Normalize LLM severity values to ReviewFinding severity union. */
-export function normalizeSeverity(sev: string): ReviewFinding["severity"] {
+/** Normalize LLM severity values to FindingSeverity. */
+export function normalizeSeverity(sev: string): FindingSeverity {
   if (sev === "warn") return "warning";
-  if (sev === "unverifiable") return "info";
-  if (sev === "critical" || sev === "error" || sev === "warning" || sev === "info" || sev === "low") return sev;
+  if (
+    sev === "critical" ||
+    sev === "error" ||
+    sev === "warning" ||
+    sev === "info" ||
+    sev === "low" ||
+    sev === "unverifiable"
+  )
+    return sev;
   return "info";
 }
 
@@ -105,14 +112,21 @@ function downgradeToUnverifiable(finding: LLMFinding): LLMFinding {
   };
 }
 
-/** Convert LLMFinding[] to ReviewFinding[] with semantic-review metadata. */
-export function toReviewFindings(findings: LLMFinding[]): ReviewFinding[] {
-  return findings.map((f) => ({
-    ruleId: "semantic",
+/** Convert a single LLMFinding to the unified Finding wire format. */
+export function llmFindingToFinding(f: LLMFinding): Finding {
+  return {
+    source: "semantic-review",
     severity: normalizeSeverity(f.severity),
+    category: "",
     file: f.file,
     line: f.line,
     message: f.issue,
-    source: "semantic-review",
-  }));
+    suggestion: f.suggestion ?? undefined,
+    meta: f.verifiedBy ? { verifiedBy: f.verifiedBy } : undefined,
+  };
+}
+
+/** Convert LLMFinding[] to Finding[] with semantic-review source. */
+export function toReviewFindings(findings: LLMFinding[]): Finding[] {
+  return findings.map(llmFindingToFinding);
 }

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -83,10 +83,10 @@ export interface ReviewCheckResult {
   output: string;
   /** Duration in milliseconds */
   durationMs: number;
-  /** Blocking findings — severity at or above blockingThreshold (populated by LLM reviewers) */
-  findings?: import("../plugins/types").ReviewFinding[];
-  /** Advisory findings — severity below blockingThreshold (populated by LLM reviewers) */
-  advisoryFindings?: import("../plugins/types").ReviewFinding[];
+  /** Blocking findings — severity at or above blockingThreshold (populated by LLM reviewers) — Finding[] per ADR-021 phase 7 */
+  findings?: Finding[];
+  /** Advisory findings — severity below blockingThreshold (populated by LLM reviewers) — Finding[] per ADR-021 phase 7 */
+  advisoryFindings?: Finding[];
   /** LLM cost incurred for this check (populated by semantic review) */
   cost?: number;
   /** True when the LLM reviewer could not parse its response and fell back to success:true (fail-open).

--- a/test/unit/debate/prompt-builder.test.ts
+++ b/test/unit/debate/prompt-builder.test.ts
@@ -366,7 +366,7 @@ describe("buildClosePrompt()", () => {
 // ─── Review-specific methods (Phase 4) ──────────────────────────────────────
 
 import type { DebateResolverContext } from "../../../src/debate/types";
-import type { ReviewFinding } from "../../../src/plugins/types";
+import type { Finding } from "../../../src/findings";
 import type { ReviewStoryContext } from "../../../src/prompts";
 
 const REVIEW_STORY: ReviewStoryContext = {
@@ -377,9 +377,11 @@ const REVIEW_STORY: ReviewStoryContext = {
 
 const DIFF = "diff --git a/src/foo.ts b/src/foo.ts\n+export function foo() {}";
 
-const FINDING: ReviewFinding = {
-  ruleId: "missing-ac",
+const FINDING: Finding = {
+  source: "semantic-review",
+  rule: "missing-ac",
   severity: "error",
+  category: "",
   file: "src/foo.ts",
   line: 1,
   message: "AC-1 not satisfied",

--- a/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
@@ -44,7 +44,7 @@ Respond with JSON only — no explanation text before or after:
   "passed": boolean,
   "findings": [
     {
-      "severity": "error" | "warn" | "info" | "unverifiable",
+      "severity": "error" | "warning" | "info" | "unverifiable",
       "file": "path/to/file",
       "line": 42,
       "issue": "description of the issue",
@@ -112,7 +112,7 @@ Respond with JSON only — no explanation text before or after:
   "passed": boolean,
   "findings": [
     {
-      "severity": "error" | "warn" | "info" | "unverifiable",
+      "severity": "error" | "warning" | "info" | "unverifiable",
       "file": "path/to/file",
       "line": 42,
       "issue": "description of the issue",

--- a/test/unit/review/adversarial-metadata-audit.test.ts
+++ b/test/unit/review/adversarial-metadata-audit.test.ts
@@ -148,7 +148,7 @@ describe("runAdversarialReview — finding category and metadata", () => {
     });
 
     expect(result.findings).toBeDefined();
-    expect(result.findings![0].ruleId).toBe("adversarial");
+    expect(result.findings![0].source).toBe("adversarial-review");
   });
 
   test("finding has source 'adversarial-review'", async () => {

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -224,7 +224,7 @@ describe("runAdversarialReview — JSON retry outcomes", () => {
 
     expect(result.success).toBe(false);
     expect(result.findings).toHaveLength(1);
-    expect(result.findings![0].ruleId).toBe("adversarial");
+    expect(result.findings![0].source).toBe("adversarial-review");
   });
 
   test("passes resolver-derived testGlobs and refExcludePatterns to callOp input", async () => {

--- a/test/unit/review/dialogue-debate.test.ts
+++ b/test/unit/review/dialogue-debate.test.ts
@@ -136,7 +136,7 @@ describe("ReviewerSession.resolveDebate()", () => {
 
     expect(result.checkResult.success).toBe(false);
     expect(result.checkResult.findings).toHaveLength(1);
-    expect(result.checkResult.findings[0].ruleId).toBe("ac-gap");
+    expect(result.checkResult.findings[0].rule).toBe("ac-gap");
     expect(result.findingReasoning.get("ac-gap")).toBe("The code does not satisfy AC-1");
   });
 

--- a/test/unit/review/dialogue-re-review.test.ts
+++ b/test/unit/review/dialogue-re-review.test.ts
@@ -528,7 +528,7 @@ describe("ReviewerSession.getVerdict() — SemanticVerdict fields", () => {
     const verdict = session.getVerdict();
     expect(Array.isArray(verdict.findings)).toBe(true);
     expect(verdict.findings.length).toBe(2);
-    expect(verdict.findings[0]?.ruleId).toBe("AC-1-not-satisfied");
+    expect(verdict.findings[0]?.rule).toBe("AC-1-not-satisfied");
     await session.destroy();
   });
 
@@ -546,7 +546,7 @@ describe("ReviewerSession.getVerdict() — SemanticVerdict fields", () => {
     // RE_REVIEW_RESPONSE has 1 finding (AC-2-not-satisfied only)
     expect(verdict.passed).toBe(false);
     expect(verdict.findings.length).toBe(1);
-    expect(verdict.findings[0]?.ruleId).toBe("AC-2-not-satisfied");
+    expect(verdict.findings[0]?.rule).toBe("AC-2-not-satisfied");
     await session.destroy();
   });
 });

--- a/test/unit/review/dialogue.test.ts
+++ b/test/unit/review/dialogue.test.ts
@@ -423,7 +423,7 @@ describe("ReviewerSession.review() — result parsing", () => {
     const session = createReviewerSession(makeAgentManager(runAsSessionFn), makeSessionManager(), "US-001", "/work", "my-feature", makeConfig());
     const result = await session.review(SAMPLE_DIFF, STORY, SEMANTIC_CONFIG);
     expect(result.checkResult.findings.length).toBe(1);
-    expect(result.checkResult.findings[0]?.ruleId).toBe("missing-ac-coverage");
+    expect(result.checkResult.findings[0]?.rule).toBe("missing-ac-coverage");
     await session.destroy();
   });
 

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -166,7 +166,8 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
     const result = await callRunSemanticReview(llmResponse);
 
     // info is advisory by default — check advisoryFindings
-    expect(result.advisoryFindings![0].ruleId).toBe("semantic");
+    expect(result.advisoryFindings![0].rule).toBeUndefined();
+    expect(result.advisoryFindings![0].source).toBe("semantic-review");
   });
 
   test("maps finding.file to ReviewFinding.file", async () => {

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -232,7 +232,7 @@ describe("runSemanticReview — JSON retry outcomes", () => {
 
     expect(result.success).toBe(false);
     expect(result.findings).toHaveLength(1);
-    expect(result.findings![0].ruleId).toBe("semantic");
+    expect(result.findings![0].source).toBe("semantic-review");
   });
 
   test("returns fail-open when callOp throws", async () => {

--- a/test/unit/review/semantic-unverifiable.test.ts
+++ b/test/unit/review/semantic-unverifiable.test.ts
@@ -242,7 +242,7 @@ describe("unverifiable finding handling", () => {
     expect(result.success).toBe(true);
     expect(result.findings).toBeUndefined();
     expect(result.advisoryFindings?.length).toBe(1);
-    expect(result.advisoryFindings?.[0].severity).toBe("info");
+    expect(result.advisoryFindings?.[0].severity).toBe("unverifiable");
   });
 
   test("ref mode downgrades error findings that admit they only used the diff", async () => {
@@ -350,7 +350,7 @@ describe("unverifiable finding handling", () => {
     expect(result.success).toBe(true);
     expect(result.findings).toBeUndefined();
     expect(result.advisoryFindings?.length).toBe(1);
-    expect(result.advisoryFindings?.[0].severity).toBe("info");
+    expect(result.advisoryFindings?.[0].severity).toBe("unverifiable");
     expect(result.advisoryFindings?.[0].message).toBe("AC not implemented");
   });
 });


### PR DESCRIPTION
## Summary

- Migrates `SemanticVerdict.findings` and `ReviewCheckResult.findings/advisoryFindings` from `ReviewFinding[]` to `Finding[]`, completing the semantic-review producer migration (ADR-021 phase 7)
- Adds `reviewFindingToFinding()` adapter + backward-compat `migrateSemanticVerdict()` loader that detects legacy on-disk shape and converts in-memory
- `normalizeSeverity` now preserves `"unverifiable"` (previously downgraded to `"info"` because `ReviewFinding` didn't support it); `SEMANTIC_OUTPUT_SCHEMA` renamed `"warn"` → `"warning"` to match `FindingSeverity`
- `ctx.reviewFindings` assignment in `review.ts` does a local downcast `Finding[] → ReviewFinding[]` (deferred; `elements.ts` migration is a later phase)

## Test plan

- [x] All unit tests pass (`bun run test` — 6897 pass, 13 skip, 0 fail)
- [x] Lint clean (`bun run lint`)
- [x] Typecheck clean (pre-commit hook)
- [x] Updated affected test assertions: `ruleId` → `rule`/`source`, severity `"info"` → `"unverifiable"` where intentional
- [x] Snapshot updates for `review-builder.test.ts` (`"warn"` → `"warning"`)
- [x] Backward-compat migration logic: detects legacy `ReviewFinding` on disk (has `ruleId`, no `source`) and converts in-memory without touching the file