### PR TITLE
feat(findings): ADR-021 phase 8 — acceptance diagnose findingsV2 wire format

### DIFF
--- a/src/acceptance/types.ts
+++ b/src/acceptance/types.ts
@@ -158,9 +158,11 @@ export interface DiagnosisResult {
   reasoning: string;
   /** Confidence score between 0 and 1 */
   confidence: number;
-  /** Issues found in the test (optional) */
+  /** Structured findings from the LLM (ADR-021 phase 8 findingsV2 mode). When present, supersedes testIssues/sourceIssues. */
+  findings?: Finding[];
+  /** Issues found in the test (optional, legacy — superseded by findings in findingsV2 mode) */
   testIssues?: string[];
-  /** Issues found in the source code (optional) */
+  /** Issues found in the source code (optional, legacy — superseded by findings in findingsV2 mode) */
   sourceIssues?: string[];
   /** LLM cost incurred for the diagnosis agent session */
   cost?: number;

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -288,6 +288,8 @@ export interface AcceptanceFixConfig {
   strategy: "diagnose-first" | "implement-only";
   /** @deprecated Ignored — outer loop controls retries via acceptance.maxRetries. Kept for backward compat. */
   maxRetries: number;
+  /** ADR-021 phase 8: emit findings[] in diagnose prompt instead of testIssues/sourceIssues. Default off. */
+  findingsV2: boolean;
 }
 
 /** Acceptance validation config */

--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -20,6 +20,8 @@ const AcceptanceFixConfigSchema = z.object({
   fixModel: ConfiguredModelSchema.default("balanced"),
   strategy: z.enum(["diagnose-first", "implement-only"]).default("diagnose-first"),
   maxRetries: z.number().int().nonnegative().default(2),
+  /** ADR-021 phase 8: emit findings: Finding[] in diagnose prompt instead of testIssues/sourceIssues. Default off for one release. */
+  findingsV2: z.boolean().default(false),
 });
 
 export const AcceptanceConfigSchema = z.object({
@@ -40,6 +42,7 @@ export const AcceptanceConfigSchema = z.object({
     fixModel: "balanced",
     strategy: "diagnose-first",
     maxRetries: 2,
+    findingsV2: false,
   }),
   suggestedTestPath: z.string().min(1).optional(),
   hardening: z

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -238,6 +238,7 @@ export const NaxConfigSchema = z
         fixModel: "balanced",
         strategy: "diagnose-first",
         maxRetries: 2,
+        findingsV2: false,
       },
       hardening: { enabled: true },
     }),

--- a/src/execution/lifecycle/acceptance-fix.ts
+++ b/src/execution/lifecycle/acceptance-fix.ts
@@ -14,6 +14,7 @@ import { loadSourceFilesForDiagnosis } from "../../acceptance/fix-diagnosis";
 import { resolveAcceptanceFeatureTestPath } from "../../acceptance/test-path";
 import type { DiagnosisResult, SemanticVerdict } from "../../acceptance/types";
 import { NaxError } from "../../errors";
+import type { FixTarget } from "../../findings";
 import { getSafeLogger } from "../../logger";
 import { acceptanceDiagnoseOp, acceptanceFixSourceOp, acceptanceFixTestOp } from "../../operations";
 import { callOp as _callOp } from "../../operations/call";
@@ -126,6 +127,28 @@ export async function resolveAcceptanceDiagnosis(opts: ResolveAcceptanceDiagnosi
   });
 }
 
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Build diagnosisReasoning string for a fix op.
+ *
+ * When structured findings are present, appends findings relevant to the
+ * given fixTarget so the fix agent has structured context. Falls back to
+ * plain reasoning when no findings match.
+ */
+function buildDiagnosisReasoning(diagnosis: DiagnosisResult, fixTarget: FixTarget): string {
+  if (!diagnosis.findings || diagnosis.findings.length === 0) {
+    return diagnosis.reasoning;
+  }
+  const relevant = diagnosis.findings.filter((f) => f.fixTarget === fixTarget);
+  if (relevant.length === 0) return diagnosis.reasoning;
+  const lines = relevant.map((f) => {
+    const loc = f.file ? ` [${f.file}${f.line != null ? `:${f.line}` : ""}]` : "";
+    return `- ${f.message}${loc}${f.suggestion ? ` → ${f.suggestion}` : ""}`;
+  });
+  return `${diagnosis.reasoning}\n\nFindings:\n${lines.join("\n")}`;
+}
+
 // ─── applyFix ───────────────────────────────────────────────────────────────
 
 export interface ApplyFixOptions {
@@ -187,11 +210,14 @@ export async function applyFix(opts: ApplyFixOptions): Promise<ApplyFixResult> {
 
   const callCtx = fixCallCtx(ctx);
 
+  const sourceDiagnosisReasoning = buildDiagnosisReasoning(diagnosis, "source");
+  const testDiagnosisReasoning = buildDiagnosisReasoning(diagnosis, "test");
+
   if (diagnosis.verdict === "source_bug" || diagnosis.verdict === "both") {
     logger?.info("acceptance.applyFix", "Applying source fix", { storyId, verdict: diagnosis.verdict });
     await _applyFixDeps.callOp(callCtx, acceptanceFixSourceOp, {
       testOutput: failures.testOutput,
-      diagnosisReasoning: diagnosis.reasoning,
+      diagnosisReasoning: sourceDiagnosisReasoning,
       acceptanceTestPath,
       testFileContent,
     });
@@ -202,7 +228,7 @@ export async function applyFix(opts: ApplyFixOptions): Promise<ApplyFixResult> {
     logger?.info("acceptance.applyFix", "Applying test fix", { storyId, verdict: diagnosis.verdict });
     await _applyFixDeps.callOp(callCtx, acceptanceFixTestOp, {
       testOutput: failures.testOutput,
-      diagnosisReasoning: diagnosis.reasoning,
+      diagnosisReasoning: testDiagnosisReasoning,
       failedACs: failures.failedACs,
       acceptanceTestPath,
       testFileContent,

--- a/src/operations/acceptance-diagnose.ts
+++ b/src/operations/acceptance-diagnose.ts
@@ -1,6 +1,7 @@
 import type { SemanticVerdict } from "../acceptance/types";
 import { acceptanceConfigSelector } from "../config";
 import type { AcceptanceConfig } from "../config/selectors";
+import type { Finding } from "../findings";
 import { AcceptancePromptBuilder } from "../prompts";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { RunOperation } from "./types";
@@ -17,6 +18,8 @@ export interface AcceptanceDiagnoseOutput {
   verdict: "source_bug" | "test_bug" | "both";
   reasoning: string;
   confidence: number;
+  /** findingsV2 mode: structured findings supersede testIssues/sourceIssues */
+  findings?: Finding[];
   testIssues?: string[];
   sourceIssues?: string[];
 }
@@ -34,13 +37,15 @@ export const acceptanceDiagnoseOp: RunOperation<AcceptanceDiagnoseInput, Accepta
   session: { role: "diagnose", lifetime: "fresh" },
   config: acceptanceConfigSelector,
   timeoutMs: (_input, ctx) => ctx.config.acceptance.timeoutMs,
-  build(input, _ctx) {
+  build(input, ctx) {
+    const findingsV2 = ctx.config.acceptance.fix?.findingsV2 ?? false;
     const prompt = new AcceptancePromptBuilder().buildDiagnosisPrompt({
       testOutput: input.testOutput,
       testFileContent: input.testFileContent,
       sourceFiles: input.sourceFiles,
       semanticVerdicts: input.semanticVerdicts,
       previousFailure: input.previousFailure,
+      findingsV2,
     });
     return {
       role: { id: "role", content: "", overridable: false },
@@ -55,10 +60,45 @@ export const acceptanceDiagnoseOp: RunOperation<AcceptanceDiagnoseInput, Accepta
       typeof raw.reasoning === "string" &&
       typeof raw.confidence === "number"
     ) {
-      return {
+      const base = {
         verdict: raw.verdict as AcceptanceDiagnoseOutput["verdict"],
         reasoning: raw.reasoning,
         confidence: raw.confidence,
+      };
+
+      // findingsV2 path: LLM emits findings[] directly
+      if (Array.isArray(raw.findings) && raw.findings.length > 0) {
+        return { ...base, findings: raw.findings as Finding[] };
+      }
+
+      // Legacy path: wrap testIssues/sourceIssues as Finding[] for uniform consumption
+      const legacyFindings: Finding[] = [];
+      if (Array.isArray(raw.testIssues)) {
+        for (const msg of raw.testIssues as string[]) {
+          legacyFindings.push({
+            source: "acceptance-diagnose",
+            severity: "error",
+            category: "legacy",
+            message: msg,
+            fixTarget: "test",
+          });
+        }
+      }
+      if (Array.isArray(raw.sourceIssues)) {
+        for (const msg of raw.sourceIssues as string[]) {
+          legacyFindings.push({
+            source: "acceptance-diagnose",
+            severity: "error",
+            category: "legacy",
+            message: msg,
+            fixTarget: "source",
+          });
+        }
+      }
+
+      return {
+        ...base,
+        findings: legacyFindings.length > 0 ? legacyFindings : undefined,
         testIssues: Array.isArray(raw.testIssues) ? (raw.testIssues as string[]) : undefined,
         sourceIssues: Array.isArray(raw.sourceIssues) ? (raw.sourceIssues as string[]) : undefined,
       };

--- a/src/operations/acceptance-diagnose.ts
+++ b/src/operations/acceptance-diagnose.ts
@@ -1,7 +1,7 @@
 import type { SemanticVerdict } from "../acceptance/types";
 import { acceptanceConfigSelector } from "../config";
 import type { AcceptanceConfig } from "../config/selectors";
-import type { Finding } from "../findings";
+import type { Finding, FindingSeverity, FixTarget } from "../findings";
 import { AcceptancePromptBuilder } from "../prompts";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { RunOperation } from "./types";
@@ -52,7 +52,8 @@ export const acceptanceDiagnoseOp: RunOperation<AcceptanceDiagnoseInput, Accepta
       task: { id: "task", content: prompt, overridable: false },
     };
   },
-  parse(output, _input, _ctx) {
+  parse(output, _input, ctx) {
+    const findingsV2 = ctx.config.acceptance.fix?.findingsV2 ?? false;
     const raw = tryParseLLMJson<Record<string, unknown>>(output);
     if (
       raw &&
@@ -66,9 +67,23 @@ export const acceptanceDiagnoseOp: RunOperation<AcceptanceDiagnoseInput, Accepta
         confidence: raw.confidence,
       };
 
-      // findingsV2 path: LLM emits findings[] directly
-      if (Array.isArray(raw.findings) && raw.findings.length > 0) {
-        return { ...base, findings: raw.findings as Finding[] };
+      // findingsV2 path: gated on config flag; inject source and validate shape
+      if (findingsV2 && Array.isArray(raw.findings) && raw.findings.length > 0) {
+        const findings = (raw.findings as Array<Record<string, unknown>>)
+          .filter((f) => typeof f.message === "string" && typeof f.category === "string")
+          .map(
+            (f): Finding => ({
+              source: "acceptance-diagnose",
+              severity: (typeof f.severity === "string" ? f.severity : "error") as FindingSeverity,
+              category: String(f.category),
+              message: String(f.message),
+              fixTarget: (f.fixTarget as FixTarget | undefined) ?? undefined,
+              file: typeof f.file === "string" ? f.file : undefined,
+              line: typeof f.line === "number" ? f.line : undefined,
+              suggestion: typeof f.suggestion === "string" ? f.suggestion : undefined,
+            }),
+          );
+        if (findings.length > 0) return { ...base, findings };
       }
 
       // Legacy path: wrap testIssues/sourceIssues as Finding[] for uniform consumption

--- a/src/prompts/builders/acceptance-builder.ts
+++ b/src/prompts/builders/acceptance-builder.ts
@@ -69,6 +69,8 @@ export interface DiagnosisPromptParams {
   /** Minimal shape — avoids importing SemanticVerdict across layers */
   semanticVerdicts?: Array<{ storyId: string; passed: boolean }>;
   previousFailure?: string;
+  /** ADR-021 phase 8: when true, emit findings[] instead of testIssues/sourceIssues */
+  findingsV2?: boolean;
 }
 
 export interface RefinementPromptOptions {
@@ -103,6 +105,8 @@ export interface DiagnosisTemplateParams {
   verdictSection: string;
   previousFailureSection: string;
   maxFileLines: number;
+  /** ADR-021 phase 8: when true, emit findings[] instead of testIssues/sourceIssues */
+  findingsV2?: boolean;
 }
 
 export interface SourceFixParams {
@@ -169,6 +173,30 @@ ${STEP3_SHARED_RULES}
 
   /** Template assembly for buildDiagnosisPrompt() — receives pre-processed strings. */
   buildDiagnosisPromptTemplate(p: DiagnosisTemplateParams): string {
+    const responseSchema = p.findingsV2
+      ? `{
+  "verdict": "source_bug" | "test_bug" | "both",
+  "reasoning": "Your analysis explaining why this is a source_bug, test_bug, or both",
+  "confidence": 0.0-1.0,
+  "findings": [
+    {
+      "fixTarget": "source" | "test",
+      "category": "stdout-capture" | "ac-mismatch" | "framework-misuse" | "missing-impl" | "import-path" | "hook-failure" | "test-runner-error" | "stub-test" | "other",
+      "file": "optional/path/relative/to/workdir.ts",
+      "line": 0,
+      "message": "Concrete description of the issue",
+      "suggestion": "Optional concrete fix suggestion"
+    }
+  ]
+}`
+      : `{
+  "verdict": "source_bug" | "test_bug" | "both",
+  "reasoning": "Your analysis explaining why this is a source_bug, test_bug, or both",
+  "confidence": 0.0-1.0,
+  "testIssues": ["Issue in test code if any"],
+  "sourceIssues": ["Issue in source code if any"]
+}`;
+
     return `You are a debugging expert. An acceptance test has failed.
 
 TASK: Diagnose whether the failure is due to a bug in the SOURCE CODE or a bug in the TEST CODE.
@@ -185,13 +213,7 @@ SOURCE FILES (auto-detected from imports, up to ${p.maxFileLines} lines each):
 ${p.sourceFilesSection}
 ${p.verdictSection}${p.previousFailureSection}
 Respond with ONLY a JSON object in this exact format (no markdown, no extra text):
-{
-  "verdict": "source_bug" | "test_bug" | "both",
-  "reasoning": "Your analysis explaining why this is a source_bug, test_bug, or both",
-  "confidence": 0.0-1.0,
-  "testIssues": ["Issue in test code if any"],
-  "sourceIssues": ["Issue in source code if any"]
-}`;
+${responseSchema}`;
   }
 
   /** Prompt for acceptanceFixSourceOp — instructs agent to fix source implementation. */
@@ -276,6 +298,7 @@ Respond with ONLY the fix description (no JSON, no markdown, just the descriptio
       verdictSection,
       previousFailureSection,
       maxFileLines: MAX_FILE_LINES,
+      findingsV2: p.findingsV2,
     });
   }
 

--- a/test/unit/config/acceptance-fix-config.test.ts
+++ b/test/unit/config/acceptance-fix-config.test.ts
@@ -17,6 +17,7 @@ describe("AcceptanceFixConfig type (US-001)", () => {
       fixModel: "balanced",
       strategy: "diagnose-first",
       maxRetries: 2,
+      findingsV2: false,
     };
     expect(fix.diagnoseModel).toBe("fast");
     expect(fix.fixModel).toBe("balanced");
@@ -30,6 +31,7 @@ describe("AcceptanceFixConfig type (US-001)", () => {
       fixModel: "balanced",
       strategy: "implement-only",
       maxRetries: 2,
+      findingsV2: false,
     };
     expect(fix.strategy).toBe("implement-only");
   });
@@ -42,6 +44,7 @@ describe("DEFAULT_CONFIG.acceptance.fix (US-001)", () => {
       fixModel: "balanced",
       strategy: "diagnose-first",
       maxRetries: 2,
+      findingsV2: false,
     });
   });
 

--- a/test/unit/operations/acceptance-diagnose.test.ts
+++ b/test/unit/operations/acceptance-diagnose.test.ts
@@ -159,6 +159,46 @@ describe("acceptanceDiagnoseOp findingsV2 mode", () => {
     expect(result.testIssues).toBeUndefined();
     expect(result.sourceIssues).toBeUndefined();
   });
+  test("parse() injects source:'acceptance-diagnose' into LLM findings (LLM does not emit source)", () => {
+    const ctx = makeBuildCtx({ findingsV2: true });
+    const json = JSON.stringify({
+      verdict: "test_bug",
+      reasoning: "bad import",
+      confidence: 0.9,
+      findings: [{ fixTarget: "test", category: "import-path", message: "wrong path" }],
+    });
+    const result = acceptanceDiagnoseOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.findings?.[0].source).toBe("acceptance-diagnose");
+  });
+  test("parse() drops findings items missing required message or category", () => {
+    const ctx = makeBuildCtx({ findingsV2: true });
+    const json = JSON.stringify({
+      verdict: "test_bug",
+      reasoning: "bad import",
+      confidence: 0.9,
+      findings: [
+        { fixTarget: "test", category: "import-path", message: "valid" },
+        { fixTarget: "test", message: "missing category" },
+        { fixTarget: "source", category: "missing-impl" },
+      ],
+    });
+    const result = acceptanceDiagnoseOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.findings?.length).toBe(1);
+    expect(result.findings?.[0].message).toBe("valid");
+  });
+  test("parse() ignores findings[] when findingsV2 is false (flag isolation)", () => {
+    const ctx = makeBuildCtx({ findingsV2: false });
+    const json = JSON.stringify({
+      verdict: "test_bug",
+      reasoning: "bad import",
+      confidence: 0.9,
+      // LLM hallucinated findings even though prompt asked for testIssues/sourceIssues
+      findings: [{ fixTarget: "test", category: "import-path", message: "wrong path" }],
+    });
+    const result = acceptanceDiagnoseOp.parse(json, SAMPLE_INPUT, ctx);
+    // Should NOT use the findingsV2 fast-path — fall through to legacy path
+    expect(result.findings).toBeUndefined();
+  });
   test("parse() falls back gracefully when findings[] is empty array", () => {
     const ctx = makeBuildCtx({ findingsV2: true });
     const json = JSON.stringify({

--- a/test/unit/operations/acceptance-diagnose.test.ts
+++ b/test/unit/operations/acceptance-diagnose.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { makeTestRuntime } from "../../helpers";
+import { makeNaxConfig, makeTestRuntime } from "../../helpers";
 import type { AcceptanceDiagnoseInput } from "../../../src/operations/acceptance-diagnose";
 import { acceptanceDiagnoseOp } from "../../../src/operations/acceptance-diagnose";
 
@@ -12,8 +12,13 @@ const SAMPLE_INPUT: AcceptanceDiagnoseInput = {
   ],
 };
 
-function makeBuildCtx() {
-  const runtime = makeTestRuntime();
+function makeBuildCtx(overrides?: { findingsV2?: boolean }) {
+  const config = makeNaxConfig(
+    overrides?.findingsV2 != null
+      ? { acceptance: { fix: { findingsV2: overrides.findingsV2 } } }
+      : {},
+  );
+  const runtime = makeTestRuntime({ config });
   const view = runtime.packages.repo();
   return { packageView: view, config: view.select(acceptanceDiagnoseOp.config) };
 }
@@ -98,5 +103,72 @@ describe("acceptanceDiagnoseOp.parse()", () => {
     const result = acceptanceDiagnoseOp.parse(json, SAMPLE_INPUT, ctx);
     expect(result.testIssues).toEqual(["wrong assertion"]);
     expect(result.sourceIssues).toEqual(["off by one"]);
+  });
+  test("wraps testIssues/sourceIssues as legacy findings when no findings[] present", () => {
+    const ctx = makeBuildCtx();
+    const json = JSON.stringify({
+      verdict: "both",
+      reasoning: "both sides",
+      confidence: 0.5,
+      testIssues: ["wrong assertion"],
+      sourceIssues: ["off by one"],
+    });
+    const result = acceptanceDiagnoseOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.findings).toBeDefined();
+    expect(result.findings?.length).toBe(2);
+    expect(result.findings?.[0]).toMatchObject({ fixTarget: "test", message: "wrong assertion", category: "legacy" });
+    expect(result.findings?.[1]).toMatchObject({ fixTarget: "source", message: "off by one", category: "legacy" });
+  });
+  test("findings is undefined when no testIssues/sourceIssues and no findings[] in response", () => {
+    const ctx = makeBuildCtx();
+    const json = JSON.stringify({ verdict: "source_bug", reasoning: "plain", confidence: 0.8 });
+    const result = acceptanceDiagnoseOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.findings).toBeUndefined();
+  });
+});
+
+describe("acceptanceDiagnoseOp findingsV2 mode", () => {
+  test("build() emits findings schema when findingsV2 is true", () => {
+    const ctx = makeBuildCtx({ findingsV2: true });
+    const result = acceptanceDiagnoseOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain('"findings"');
+    expect(result.task.content).toContain('"fixTarget"');
+    expect(result.task.content).not.toContain('"testIssues"');
+    expect(result.task.content).not.toContain('"sourceIssues"');
+  });
+  test("build() emits legacy schema when findingsV2 is false", () => {
+    const ctx = makeBuildCtx({ findingsV2: false });
+    const result = acceptanceDiagnoseOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).toContain('"testIssues"');
+    expect(result.task.content).toContain('"sourceIssues"');
+    expect(result.task.content).not.toContain('"fixTarget"');
+  });
+  test("parse() returns findings[] directly when LLM emits findings array", () => {
+    const ctx = makeBuildCtx({ findingsV2: true });
+    const json = JSON.stringify({
+      verdict: "test_bug",
+      reasoning: "test imports wrong",
+      confidence: 0.85,
+      findings: [
+        { fixTarget: "test", category: "import-path", message: "wrong relative path", file: "test/foo.test.ts", line: 3 },
+      ],
+    });
+    const result = acceptanceDiagnoseOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.findings?.length).toBe(1);
+    expect(result.findings?.[0]).toMatchObject({ fixTarget: "test", category: "import-path", message: "wrong relative path" });
+    expect(result.testIssues).toBeUndefined();
+    expect(result.sourceIssues).toBeUndefined();
+  });
+  test("parse() falls back gracefully when findings[] is empty array", () => {
+    const ctx = makeBuildCtx({ findingsV2: true });
+    const json = JSON.stringify({
+      verdict: "source_bug",
+      reasoning: "missing impl",
+      confidence: 0.9,
+      findings: [],
+    });
+    const result = acceptanceDiagnoseOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.verdict).toBe("source_bug");
+    expect(result.findings).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Adds `findingsV2: boolean` (default `false`) to `AcceptanceFixConfig` / Zod schema, gating the new wire format for one release
- `acceptanceDiagnoseOp` prompt now emits structured `findings[]` schema (with `fixTarget` per item) when flag is on; legacy `testIssues`/`sourceIssues` schema when off
- `parse()` always normalises both paths into `findings?: Finding[]` — legacy strings are wrapped as `category:"legacy"` findings so downstream consumers see a uniform shape regardless of flag
- `applyFix()` gains `buildDiagnosisReasoning()` helper that formats relevant findings (filtered by `fixTarget`) into the `diagnosisReasoning` string forwarded to fix ops

## Test plan

- [ ] 7 new unit tests: `findingsV2` prompt schema, structured parse, legacy wrapping, empty-findings fallback (`test/unit/operations/acceptance-diagnose.test.ts`)
- [ ] Updated `DEFAULT_CONFIG` snapshot test to include `findingsV2: false`
- [ ] All 6904 tests pass; lint clean; typecheck clean
- [ ] Enable `acceptance.fix.findingsV2: true` in a project config to exercise the structured path end-to-end