### PR TITLE
feat(findings): ADR-022 phases 1-3 — cycle types, runFixCycle, buildPriorIterationsBlock

### DIFF
--- a/src/findings/cycle-types.ts
+++ b/src/findings/cycle-types.ts
@@ -1,0 +1,165 @@
+/**
+ * ADR-022 Phase 1 — Fix Strategy and Cycle orchestration types.
+ *
+ * These types sit above runRetryLoop and model the outer iteration history:
+ * which strategies ran, what findings looked like before/after, and how to
+ * classify progress across multiple fix attempts.
+ *
+ * Only types live here; behaviour is in cycle.ts (ADR-022 Phase 2).
+ */
+
+import type { Operation } from "../operations/types";
+import type { Finding } from "./types";
+
+// ─── Iteration record ────────────────────────────────────────────────────────
+
+export type IterationOutcome =
+  | "resolved" // findingsAfter is empty
+  | "partial" // findingsAfter is a strict subset of findingsBefore
+  | "regressed" // findingsAfter contains new findings not in findingsBefore (same source)
+  | "unchanged" // findingsAfter equals findingsBefore (same files+rules+lines)
+  | "regressed-different-source"; // before had source A, after has source B
+
+export interface FixApplied {
+  strategyName: string;
+  /** Operation name from RunOperation.name / CompleteOperation.name. */
+  op: string;
+  targetFiles: string[];
+  /** First ~500 chars of agent response or stdout. Empty when unavailable. */
+  summary: string;
+  costUsd?: number;
+}
+
+export interface Iteration<F extends Finding = Finding> {
+  /** 1-indexed. */
+  iterationNum: number;
+  findingsBefore: F[];
+  /** At least one entry per iteration — one per strategy that ran. */
+  fixesApplied: FixApplied[];
+  findingsAfter: F[];
+  outcome: IterationOutcome;
+  startedAt: string; // ISO-8601
+  finishedAt: string; // ISO-8601
+}
+
+// ─── Cycle result ────────────────────────────────────────────────────────────
+
+export type FixCycleExitReason =
+  | "resolved"
+  | "no-strategy"
+  | "max-attempts-total"
+  | "max-attempts-per-strategy"
+  | "validator-error"
+  | "bail-when";
+
+export interface FixCycleResult<F extends Finding = Finding> {
+  iterations: Iteration<F>[];
+  finalFindings: F[];
+  exitReason: FixCycleExitReason;
+  /** Strategy name that hit its maxAttempts cap. Set when exitReason is "max-attempts-per-strategy". */
+  exhaustedStrategy?: string;
+  /** Human-readable detail from strategy.bailWhen(). Set when exitReason is "bail-when". */
+  bailDetail?: string;
+}
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+/**
+ * Context passed to validate and buildInput. Structural superset of CallContext
+ * with storyId made required (parallel logging discipline). Satisfies CallContext
+ * so runFixCycle can pass it directly to callOp.
+ */
+export type FixCycleContext = import("../operations/types").CallContext & {
+  readonly storyId: string;
+};
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+export interface FixCycleConfig {
+  /** Hard cap on total fix invocations across all strategies. Default: 10. */
+  maxAttemptsTotal: number;
+  /** How many times to retry the validator on throw before terminal exit. Default: 1. */
+  validatorRetries: number;
+}
+
+// ─── Strategy ────────────────────────────────────────────────────────────────
+
+export interface FixStrategy<
+  F extends Finding,
+  I,
+  O,
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous strategies share a cycle; C is opaque at the cycle layer
+  C = any,
+> {
+  name: string;
+
+  /**
+   * Returns true for findings this strategy should fix. Must be discriminating
+   * (by source, category, fixTarget, or file pattern) — never `() => true`.
+   */
+  appliesTo: (finding: F) => boolean;
+
+  /**
+   * Optional fallback selector consulted only when findings.length === 0 (e.g.
+   * acceptance fast-path verdicts that produce no structured findings). When
+   * unset, the strategy is skipped in empty-findings iterations.
+   */
+  appliesToVerdict?: (verdict: string) => boolean;
+
+  fixOp: Operation<I, O, C>;
+
+  /**
+   * Build the input for fixOp. Captures closure context (diagnosis, verdict,
+   * test output, packageDir) — do not thread extras through FixCycleContext.
+   *
+   * `findings` is pre-filtered to only the findings where appliesTo returned
+   * true. For empty-findings iterations (appliesToVerdict path), it is [].
+   */
+  buildInput: (findings: F[], priorIterations: Iteration<F>[], ctx: FixCycleContext) => I;
+
+  /**
+   * Optional: extract targetFiles and summary from the op output for FixApplied
+   * record-keeping. When absent, targetFiles defaults to [] and summary to "".
+   */
+  extractApplied?: (output: O, input: I) => { targetFiles?: string[]; summary?: string };
+
+  /**
+   * Optional bail predicate called before each iteration. Return a non-null
+   * string reason to exit with exitReason "bail-when". Returning null continues.
+   */
+  bailWhen?: (priorIterations: Iteration<F>[]) => string | null;
+
+  /** Per-strategy attempt cap. Counted via fixesApplied[].strategyName. */
+  maxAttempts: number;
+
+  /**
+   * Co-run discipline. Default (undefined or "exclusive") means this strategy
+   * runs alone — all other matching strategies are skipped for this iteration.
+   * "co-run-sequential" means run alongside other co-run-sequential strategies
+   * in declaration order.
+   */
+  coRun?: "exclusive" | "co-run-sequential";
+}
+
+// ─── Cycle ───────────────────────────────────────────────────────────────────
+
+export interface FixCycle<F extends Finding> {
+  /** Mutable: updated to findingsAfter at the end of each iteration. */
+  findings: F[];
+  /** Mutable: pushed to at the end of each iteration. */
+  iterations: Iteration<F>[];
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous strategy array; I/O types are coherent per-strategy
+  strategies: FixStrategy<F, any, any, any>[];
+  /**
+   * Single validator for the cycle. Runs once per iteration, after all co-run
+   * strategies complete. On throw, retried config.validatorRetries times before
+   * exiting with "validator-error".
+   */
+  validate: (ctx: FixCycleContext) => Promise<F[]>;
+  config: FixCycleConfig;
+  /**
+   * Optional verdict string used to bias strategy selection when findings is
+   * empty. Passed to strategy.appliesToVerdict when findings.length === 0.
+   */
+  verdict?: string;
+}

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -1,0 +1,306 @@
+/**
+ * ADR-022 Phase 2 — runFixCycle and classifyOutcome.
+ *
+ * Sits above runRetryLoop: adds multi-strategy iteration, validator
+ * deduplication, outcome classification, and cross-iteration history.
+ *
+ * scope: repo-scoped (cycle drives per-subsystem strategies; strategies
+ * capture packageDir via closure in buildInput)
+ */
+
+import { getSafeLogger } from "../logger";
+import { callOp as _callOp } from "../operations/call";
+import type { Operation } from "../operations/types";
+import { errorMessage } from "../utils/errors";
+import type {
+  FixApplied,
+  FixCycle,
+  FixCycleContext,
+  FixCycleResult,
+  FixStrategy,
+  Iteration,
+  IterationOutcome,
+} from "./cycle-types";
+import type { Finding } from "./types";
+import { findingKey } from "./types";
+
+// ─── Injectable deps (for testing) ───────────────────────────────────────────
+
+export type CallOpFn = <I, O, C>(ctx: FixCycleContext, op: Operation<I, O, C>, input: I) => Promise<O>;
+
+export const _cycleDeps = {
+  callOp: _callOp as unknown as CallOpFn,
+  now: () => new Date().toISOString(),
+};
+
+// ─── classifyOutcome ─────────────────────────────────────────────────────────
+
+/**
+ * Classify the outcome of a single iteration for one finding source.
+ * Uses findingKey for stable identity.
+ */
+function classifySingleSource<F extends Finding>(before: F[], after: F[]): IterationOutcome {
+  const beforeKeys = new Set(before.map(findingKey));
+  const afterKeys = new Set(after.map(findingKey));
+
+  if (afterKeys.size === 0 && beforeKeys.size === 0) return "resolved";
+  if (afterKeys.size === 0) return "resolved";
+
+  // Check for new findings (regression)
+  const hasNew = [...afterKeys].some((k) => !beforeKeys.has(k));
+  const hasResolved = [...beforeKeys].some((k) => !afterKeys.has(k));
+
+  if (hasNew && !hasResolved) return "regressed";
+  if (!hasNew && !hasResolved) return "unchanged";
+  if (hasNew && hasResolved) return "regressed"; // new ones appeared even if some resolved
+  return "partial"; // hasResolved && !hasNew
+}
+
+/**
+ * Classify an iteration outcome by computing per-source outcomes then
+ * aggregating. Mixed cross-source comparisons are avoided: e.g. if before has
+ * [lintA] and after has [typecheckC], that surfaces as "regressed-different-source"
+ * because the lint source resolved but a new source appeared.
+ */
+export function classifyOutcome<F extends Finding>(before: F[], after: F[]): IterationOutcome {
+  if (before.length === 0 && after.length === 0) return "resolved";
+
+  const beforeSources = new Set(before.map((f) => f.source));
+  const afterSources = new Set(after.map((f) => f.source));
+
+  // Detect new sources appearing that weren't in before
+  const newSources = [...afterSources].filter((s) => !beforeSources.has(s));
+  if (newSources.length > 0) return "regressed-different-source";
+
+  // Compute per-source outcomes for sources that existed before
+  const sources = [...beforeSources];
+  const perSource = sources.map((source) =>
+    classifySingleSource(
+      before.filter((f) => f.source === source),
+      after.filter((f) => f.source === source),
+    ),
+  );
+
+  if (perSource.every((o) => o === "resolved")) return "resolved";
+  if (perSource.some((o) => o === "regressed")) return "regressed";
+  if (perSource.every((o) => o === "unchanged")) return "unchanged";
+  return "partial";
+}
+
+// ─── Strategy selection ───────────────────────────────────────────────────────
+
+function selectActiveStrategies<F extends Finding>(
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous strategy array; I/O types are opaque to the cycle
+  strategies: FixStrategy<F, any, any, any>[],
+  findings: F[],
+  verdict: string | undefined,
+  // biome-ignore lint/suspicious/noExplicitAny: see above
+): FixStrategy<F, any, any, any>[] {
+  if (findings.length > 0) {
+    return strategies.filter((s) => findings.some((f) => s.appliesTo(f)));
+  }
+  if (verdict !== undefined) {
+    return strategies.filter((s) => s.appliesToVerdict?.(verdict) ?? false);
+  }
+  return [];
+}
+
+function selectExecutionGroup<F extends Finding>(
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous strategy array; I/O types are opaque to the cycle
+  active: FixStrategy<F, any, any, any>[],
+  // biome-ignore lint/suspicious/noExplicitAny: see above
+): FixStrategy<F, any, any, any>[] {
+  const exclusive = active.find((s) => !s.coRun || s.coRun === "exclusive");
+  if (exclusive) return [exclusive];
+  return active.filter((s) => s.coRun === "co-run-sequential");
+}
+
+// ─── Attempt counting ────────────────────────────────────────────────────────
+
+function countStrategyAttempts<F extends Finding>(iterations: Iteration<F>[], strategyName: string): number {
+  return iterations.reduce(
+    (sum, iter) => sum + iter.fixesApplied.filter((fa) => fa.strategyName === strategyName).length,
+    0,
+  );
+}
+
+function countTotalAttempts<F extends Finding>(iterations: Iteration<F>[]): number {
+  return iterations.reduce((sum, iter) => sum + iter.fixesApplied.length, 0);
+}
+
+// ─── runFixCycle ─────────────────────────────────────────────────────────────
+
+/**
+ * Drive a fix cycle: select strategies, apply fixes, validate, classify outcome,
+ * repeat until resolved or a budget/bail condition fires.
+ *
+ * The cycle object is mutated: `findings` and `iterations` are updated in place
+ * so the caller can inspect partial progress if the run is interrupted.
+ */
+export async function runFixCycle<F extends Finding>(
+  cycle: FixCycle<F>,
+  ctx: FixCycleContext,
+  cycleName: string,
+  _deps: { callOp?: CallOpFn; now?: () => string } = {},
+): Promise<FixCycleResult<F>> {
+  const logger = getSafeLogger();
+  const doCallOp = _deps.callOp ?? _cycleDeps.callOp;
+  const now = _deps.now ?? _cycleDeps.now;
+
+  const storyId = ctx.storyId;
+  const packageDir = ctx.packageDir;
+
+  for (;;) {
+    // ── Select active strategies ──────────────────────────────────────────────
+    const active = selectActiveStrategies(cycle.strategies, cycle.findings, cycle.verdict);
+    if (active.length === 0) {
+      logger?.info("findings.cycle", "cycle exited — no matching strategy", {
+        storyId,
+        packageDir,
+        cycleName,
+        reason: "no-strategy",
+        findingsCount: cycle.findings.length,
+      });
+      return { iterations: cycle.iterations, finalFindings: cycle.findings, exitReason: "no-strategy" };
+    }
+
+    // ── Per-strategy attempt cap ──────────────────────────────────────────────
+    for (const strategy of active) {
+      const attempts = countStrategyAttempts(cycle.iterations, strategy.name);
+      if (attempts >= strategy.maxAttempts) {
+        logger?.info("findings.cycle", "cycle exited — strategy attempt cap reached", {
+          storyId,
+          packageDir,
+          cycleName,
+          reason: "max-attempts-per-strategy",
+          exhaustedStrategy: strategy.name,
+          attempts,
+          maxAttempts: strategy.maxAttempts,
+        });
+        return {
+          iterations: cycle.iterations,
+          finalFindings: cycle.findings,
+          exitReason: "max-attempts-per-strategy",
+          exhaustedStrategy: strategy.name,
+        };
+      }
+    }
+
+    // ── Total attempt cap ─────────────────────────────────────────────────────
+    const totalAttempts = countTotalAttempts(cycle.iterations);
+    if (totalAttempts >= cycle.config.maxAttemptsTotal) {
+      logger?.info("findings.cycle", "cycle exited — total attempt cap reached", {
+        storyId,
+        packageDir,
+        cycleName,
+        reason: "max-attempts-total",
+        totalAttempts,
+        maxAttemptsTotal: cycle.config.maxAttemptsTotal,
+      });
+      return { iterations: cycle.iterations, finalFindings: cycle.findings, exitReason: "max-attempts-total" };
+    }
+
+    // ── bailWhen predicates ───────────────────────────────────────────────────
+    for (const strategy of active) {
+      const bailReason = strategy.bailWhen?.(cycle.iterations) ?? null;
+      if (bailReason !== null) {
+        logger?.info("findings.cycle", "cycle exited — bail predicate fired", {
+          storyId,
+          packageDir,
+          cycleName,
+          reason: "bail-when",
+          strategyName: strategy.name,
+          bailDetail: bailReason,
+        });
+        return {
+          iterations: cycle.iterations,
+          finalFindings: cycle.findings,
+          exitReason: "bail-when",
+          bailDetail: bailReason,
+        };
+      }
+    }
+
+    // ── Execute strategies ────────────────────────────────────────────────────
+    const group = selectExecutionGroup(active);
+    const startedAt = now();
+    const findingsBefore = [...cycle.findings];
+    const fixesApplied: FixApplied[] = [];
+
+    for (const strategy of group) {
+      const relevantFindings = findingsBefore.filter((f) => strategy.appliesTo(f));
+      const input = strategy.buildInput(relevantFindings, cycle.iterations, ctx);
+      const output = await doCallOp(ctx, strategy.fixOp, input);
+      const extracted = strategy.extractApplied?.(output, input) ?? {};
+      fixesApplied.push({
+        strategyName: strategy.name,
+        op: strategy.fixOp.name,
+        targetFiles: extracted.targetFiles ?? [],
+        summary: extracted.summary ?? "",
+      });
+    }
+
+    // ── Validate ──────────────────────────────────────────────────────────────
+    let findingsAfter: F[];
+    let validatorAttempt = 0;
+    for (;;) {
+      try {
+        findingsAfter = await cycle.validate(ctx);
+        break;
+      } catch (err) {
+        if (validatorAttempt >= cycle.config.validatorRetries) {
+          logger?.error("findings.cycle", "cycle exited — validator error", {
+            storyId,
+            packageDir,
+            cycleName,
+            reason: "validator-error",
+            error: errorMessage(err),
+          });
+          return { iterations: cycle.iterations, finalFindings: cycle.findings, exitReason: "validator-error" };
+        }
+        logger?.warn("findings.cycle", "validator retry", {
+          storyId,
+          packageDir,
+          cycleName,
+          attempt: validatorAttempt + 1,
+          error: errorMessage(err),
+        });
+        validatorAttempt++;
+      }
+    }
+
+    // ── Classify and record ───────────────────────────────────────────────────
+    const outcome = classifyOutcome(findingsBefore, findingsAfter);
+    const finishedAt = now();
+    const iterationNum = cycle.iterations.length + 1;
+    const iteration: Iteration<F> = {
+      iterationNum,
+      findingsBefore,
+      fixesApplied,
+      findingsAfter,
+      outcome,
+      startedAt,
+      finishedAt,
+    };
+
+    cycle.iterations.push(iteration);
+    cycle.findings = findingsAfter;
+
+    const costUsd = fixesApplied.reduce((sum, fa) => sum + (fa.costUsd ?? 0), 0);
+    logger?.info("findings.cycle", "iteration completed", {
+      storyId,
+      packageDir,
+      cycleName,
+      iterationNum,
+      strategiesRan: fixesApplied.map((fa) => fa.strategyName),
+      outcome,
+      findingsBefore: findingsBefore.length,
+      findingsAfter: findingsAfter.length,
+      ...(costUsd > 0 ? { costUsd } : {}),
+    });
+
+    if (outcome === "resolved") {
+      return { iterations: cycle.iterations, finalFindings: [], exitReason: "resolved" };
+    }
+  }
+}

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -64,6 +64,8 @@ function classifySingleSource<F extends Finding>(before: F[], after: F[]): Itera
  */
 export function classifyOutcome<F extends Finding>(before: F[], after: F[]): IterationOutcome {
   if (before.length === 0 && after.length === 0) return "resolved";
+  // No prior findings — any new finding is a plain regression, not a source-switch.
+  if (before.length === 0) return "regressed";
 
   const beforeSources = new Set(before.map((f) => f.source));
   const afterSources = new Set(after.map((f) => f.source));

--- a/src/findings/index.ts
+++ b/src/findings/index.ts
@@ -1,16 +1,14 @@
 /**
- * src/findings — unified Finding wire format.
+ * src/findings — unified Finding wire format (ADR-021) and cycle orchestration
+ * types + runtime (ADR-022).
  *
- * ADR-021 phase 1: types only, no behaviour. Producers migrate to emit
- * Finding[] in subsequent phases.
+ * ADR-021: Finding wire format — types, severity ordering, stable identity key,
+ * and per-producer adapter converters.
  *
- * Phase 2: plugin reviewer adapter. Converts ReviewFinding → Finding at the
- * IReviewPlugin call site. Plugin contract (ReviewFinding) unchanged.
+ * ADR-022 Phase 1: cycle orchestration types — Iteration, FixApplied,
+ * FixStrategy, FixCycle, FixCycleResult, FixCycleContext, FixCycleConfig.
  *
- * Orchestration (Iteration, FixApplied, FixStrategy, runFixCycle, …) lives
- * in ADR-022 and will arrive in a separate file (e.g. cycle-types.ts) once
- * that ADR's phase 1 PR begins. Consumers should import only the wire-format
- * types from here for now.
+ * ADR-022 Phase 2: runFixCycle and classifyOutcome behaviour.
  */
 
 export type {
@@ -32,3 +30,17 @@ export {
   tscDiagnosticToFinding,
 } from "./adapters";
 export { rebaseToWorkdir } from "./path-utils";
+
+export type {
+  FixApplied,
+  FixCycle,
+  FixCycleConfig,
+  FixCycleContext,
+  FixCycleExitReason,
+  FixCycleResult,
+  FixStrategy,
+  Iteration,
+  IterationOutcome,
+} from "./cycle-types";
+
+export { classifyOutcome, runFixCycle, _cycleDeps } from "./cycle";

--- a/src/prompts/builders/prior-iterations-builder.ts
+++ b/src/prompts/builders/prior-iterations-builder.ts
@@ -10,8 +10,8 @@
  * so the model can avoid repeating falsified hypotheses.
  */
 
-import type { Iteration } from "../../findings/cycle-types";
-import type { Finding } from "../../findings/types";
+import type { Iteration } from "../../findings";
+import type { Finding } from "../../findings";
 
 /**
  * Build the prior iterations block for inclusion in a rectifier prompt.

--- a/src/prompts/builders/prior-iterations-builder.ts
+++ b/src/prompts/builders/prior-iterations-builder.ts
@@ -1,0 +1,91 @@
+/**
+ * ADR-022 Phase 3 — buildPriorIterationsBlock.
+ *
+ * Verdict-first table that replaces the three legacy carry-forward blocks:
+ *   - buildPriorFindingsBlock (adversarial-review-builder.ts)
+ *   - buildAttemptContextBlock (review-builder.ts)
+ *   - previousFailure accumulator (acceptance-loop.ts)
+ *
+ * Consumed by all rectifier-class prompts to carry iteration history forward
+ * so the model can avoid repeating falsified hypotheses.
+ */
+
+import type { Iteration } from "../../findings/cycle-types";
+import type { Finding } from "../../findings/types";
+
+/**
+ * Build the prior iterations block for inclusion in a rectifier prompt.
+ *
+ * Returns an empty string when there are no prior iterations so callers can
+ * unconditionally include it without an "## Prior Iterations" section
+ * appearing on the first attempt.
+ *
+ * Format (ADR-022 §8):
+ *
+ * ```
+ * ## Prior Iterations — verdict required before new analysis
+ * | # | Strategies run | Files touched | Outcome | Findings before → after |
+ * ...
+ * When outcome is "unchanged"...
+ * ```
+ */
+export function buildPriorIterationsBlock<F extends Finding>(iterations: Iteration<F>[]): string {
+  if (iterations.length === 0) return "";
+
+  const rows = iterations.map((iter) => {
+    const strategies = iter.fixesApplied.map((fa) => fa.strategyName).join(", ") || "-";
+    const files = iter.fixesApplied.flatMap((fa) => fa.targetFiles).join(", ") || "-";
+    const outcome = iter.outcome;
+    const findingSummary = formatFindingSummary(iter.findingsBefore, iter.findingsAfter);
+    return `| ${iter.iterationNum} | ${strategies} | ${files} | ${outcome} | ${findingSummary} |`;
+  });
+
+  const header = "| # | Strategies run | Files touched | Outcome | Findings before → after |";
+  const separator = "|---|----------------|---------------|---------|--------------------------|";
+  const table = [header, separator, ...rows].join("\n");
+
+  const hasUnchanged = iterations.some((i) => i.outcome === "unchanged");
+  const unchangedNote = hasUnchanged
+    ? `\nWhen outcome is "unchanged", the prior hypothesis is FALSIFIED — the change did not affect what was tested. Choose a different category before producing a new verdict. Do NOT repeat fixes listed above.`
+    : "";
+
+  return `## Prior Iterations — verdict required before new analysis\n\n${table}${unchangedNote}\n\n`;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Format the "Findings before → after" cell content.
+ *
+ * Shows count and top category per direction. When both sides are empty, shows
+ * "resolved". Groups findings by category and shows the most frequent category
+ * in brackets (e.g. "2 [stdout-capture]").
+ */
+function formatFindingSummary<F extends Finding>(before: F[], after: F[]): string {
+  const beforeStr = before.length === 0 ? "0" : formatFindingCount(before);
+  const afterStr = after.length === 0 ? "0" : formatFindingCount(after);
+  return `${beforeStr} → ${afterStr}`;
+}
+
+function formatFindingCount<F extends Finding>(findings: F[]): string {
+  const count = findings.length;
+  const topCategory = mostFrequentCategory(findings);
+  return topCategory !== null ? `${count} [${topCategory}]` : `${count}`;
+}
+
+function mostFrequentCategory<F extends Finding>(findings: F[]): string | null {
+  if (findings.length === 0) return null;
+  const freq = new Map<string, number>();
+  for (const f of findings) {
+    freq.set(f.category, (freq.get(f.category) ?? 0) + 1);
+  }
+  let top: string | null = null;
+  let topCount = 0;
+  for (const [cat, cnt] of freq) {
+    if (cnt > topCount) {
+      topCount = cnt;
+      top = cat;
+    }
+  }
+  return top;
+}

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -53,6 +53,9 @@ export type { PlanningPromptParts, PackageSummary } from "./builders/plan-builde
 export type { PromptRole, PromptSection, PromptOptions, SectionSlot } from "./core/types";
 export { SLOT_ORDER } from "./core/types";
 
+// Prior iterations prompt block — ADR-022 §8; replaces legacy carry-forward blocks.
+export { buildPriorIterationsBlock } from "./builders/prior-iterations-builder";
+
 // Wave 1 composition utilities — slot-ordered assembly and serialisation.
 export { composeSections, join } from "./compose";
 export type { ComposeInput } from "./compose";

--- a/test/unit/findings/cycle.test.ts
+++ b/test/unit/findings/cycle.test.ts
@@ -3,7 +3,7 @@ import type { CallOpFn } from "../../../src/findings/cycle";
 import { classifyOutcome, runFixCycle } from "../../../src/findings/cycle";
 import type { FixCycle, FixCycleContext, FixStrategy, Iteration } from "../../../src/findings";
 import type { Finding } from "../../../src/findings";
-import { makeNaxConfig } from "../../helpers";
+import { makeMockAgentManager, makeNaxConfig } from "../../helpers";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -24,7 +24,7 @@ function makeCtx(): FixCycleContext {
   return {
     runtime: {
       configLoader: { current: () => config },
-      agentManager: { getDefault: () => "claude" } as FixCycleContext["runtime"]["agentManager"],
+      agentManager: makeMockAgentManager(),
       sessionManager: {} as FixCycleContext["runtime"]["sessionManager"],
       packages: { resolve: () => ({ select: () => config }) } as unknown as FixCycleContext["runtime"]["packages"],
       projectDir: "/tmp/test",

--- a/test/unit/findings/cycle.test.ts
+++ b/test/unit/findings/cycle.test.ts
@@ -1,0 +1,452 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { CallOpFn } from "../../../src/findings/cycle";
+import { classifyOutcome, runFixCycle } from "../../../src/findings/cycle";
+import type { FixCycle, FixCycleContext, FixStrategy, Iteration } from "../../../src/findings/cycle-types";
+import type { Finding } from "../../../src/findings/types";
+import { makeNaxConfig } from "../../helpers";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeFinding(overrides: Partial<Finding> & Pick<Finding, "source" | "message">): Finding {
+  return {
+    severity: "error",
+    category: "test",
+    ...overrides,
+  };
+}
+
+const lintA = makeFinding({ source: "lint", message: "unused var", file: "src/a.ts", line: 1 });
+const lintB = makeFinding({ source: "lint", message: "missing semicolon", file: "src/b.ts", line: 5 });
+const typecheckC = makeFinding({ source: "typecheck", message: "TS2304: Cannot find name", file: "src/c.ts", line: 3 });
+
+function makeCtx(): FixCycleContext {
+  const config = makeNaxConfig();
+  return {
+    runtime: {
+      configLoader: { current: () => config },
+      agentManager: { getDefault: () => "claude" } as FixCycleContext["runtime"]["agentManager"],
+      sessionManager: {} as FixCycleContext["runtime"]["sessionManager"],
+      packages: { resolve: () => ({ select: () => config }) } as unknown as FixCycleContext["runtime"]["packages"],
+      projectDir: "/tmp/test",
+    } as unknown as FixCycleContext["runtime"],
+    packageView: { select: () => config } as unknown as FixCycleContext["packageView"],
+    packageDir: "/tmp/test",
+    storyId: "story-1",
+    agentName: "claude",
+  };
+}
+
+const noopOp = {
+  name: "noop-op",
+  kind: "complete" as const,
+  stage: "verify" as const,
+  config: [],
+  build: () => "",
+  parse: () => null,
+  jsonMode: false,
+} as unknown as FixStrategy<Finding, unknown, unknown>["fixOp"];
+
+function makeStrategy(
+  overrides: Partial<FixStrategy<Finding, unknown, unknown>> & Pick<FixStrategy<Finding, unknown, unknown>, "name">,
+): FixStrategy<Finding, unknown, unknown> {
+  return {
+    appliesTo: () => true,
+    fixOp: noopOp,
+    buildInput: () => ({}),
+    maxAttempts: 3,
+    coRun: "co-run-sequential",
+    ...overrides,
+  };
+}
+
+function makeCycle(
+  findings: Finding[],
+  strategies: FixStrategy<Finding, unknown, unknown>[],
+  validateFn: (ctx: FixCycleContext) => Promise<Finding[]>,
+  overrides?: Partial<FixCycle<Finding>>,
+): FixCycle<Finding> {
+  return {
+    findings,
+    iterations: [],
+    strategies,
+    validate: validateFn,
+    config: { maxAttemptsTotal: 10, validatorRetries: 1 },
+    ...overrides,
+  };
+}
+
+// callOp mock that returns a fixed output without calling real ops
+function makeCallOpMock(returnValue: unknown = {}): ReturnType<typeof mock> {
+  return mock(async () => returnValue);
+}
+
+beforeEach(() => {
+  // reset per-test state; individual tests inject _deps inline
+});
+
+// ─── classifyOutcome ──────────────────────────────────────────────────────────
+
+describe("classifyOutcome", () => {
+  test("resolved — both empty", () => {
+    expect(classifyOutcome([], [])).toBe("resolved");
+  });
+
+  test("resolved — before non-empty, after empty", () => {
+    expect(classifyOutcome([lintA], [])).toBe("resolved");
+  });
+
+  test("unchanged — same finding key", () => {
+    expect(classifyOutcome([lintA], [lintA])).toBe("unchanged");
+  });
+
+  test("partial — one resolved, one remains", () => {
+    const before = [lintA, lintB];
+    const after = [lintA];
+    expect(classifyOutcome(before, after)).toBe("partial");
+  });
+
+  test("regressed — new finding appears in same source", () => {
+    const before = [lintA];
+    const after = [lintA, lintB];
+    expect(classifyOutcome(before, after)).toBe("regressed");
+  });
+
+  test("regressed — all before resolved but new same-source finding appeared", () => {
+    const before = [lintA];
+    const after = [lintB]; // lintA resolved but lintB appeared (same source)
+    expect(classifyOutcome(before, after)).toBe("regressed");
+  });
+
+  test("regressed-different-source — source disappears, new source appears", () => {
+    const before = [lintA];
+    const after = [typecheckC];
+    expect(classifyOutcome(before, after)).toBe("regressed-different-source");
+  });
+
+  test("regressed-different-source — before has lint, after has lint + typecheck", () => {
+    const before = [lintA];
+    const after = [lintA, typecheckC];
+    expect(classifyOutcome(before, after)).toBe("regressed-different-source");
+  });
+});
+
+// ─── runFixCycle — bail: no-strategy ──────────────────────────────────────────
+
+describe("runFixCycle — bail: no-strategy", () => {
+  test("exits immediately when no strategies match and findings is empty", async () => {
+    const strategy = makeStrategy({
+      name: "lint-fix",
+      appliesTo: (f) => f.source === "lint",
+    });
+    const cycle = makeCycle([], [strategy], async () => []);
+    const ctx = makeCtx();
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, ctx, "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("no-strategy");
+    expect(result.iterations).toHaveLength(0);
+    expect(callOpMock).not.toHaveBeenCalled();
+  });
+
+  test("exits when findings present but no strategy appliesTo them", async () => {
+    const strategy = makeStrategy({
+      name: "typecheck-fix",
+      appliesTo: (f) => f.source === "typecheck",
+    });
+    const cycle = makeCycle([lintA], [strategy], async () => []);
+    const ctx = makeCtx();
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, ctx, "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("no-strategy");
+  });
+
+  test("uses appliesToVerdict fallback when findings is empty and verdict matches", async () => {
+    let validated = false;
+    const strategy = makeStrategy({
+      name: "source-fix",
+      appliesTo: () => false,
+      appliesToVerdict: (v) => v === "source_bug",
+    });
+    const cycle = makeCycle(
+      [],
+      [strategy],
+      async () => {
+        validated = true;
+        return [];
+      },
+      { verdict: "source_bug" },
+    );
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("resolved");
+    expect(callOpMock).toHaveBeenCalledTimes(1);
+    expect(validated).toBe(true);
+  });
+});
+
+// ─── runFixCycle — bail: max-attempts-per-strategy ───────────────────────────
+
+describe("runFixCycle — bail: max-attempts-per-strategy", () => {
+  test("exits when strategy has hit its maxAttempts cap", async () => {
+    const strategy = makeStrategy({ name: "lint-fix", maxAttempts: 2 });
+
+    const priorIterations: Iteration<Finding>[] = [
+      {
+        iterationNum: 1,
+        findingsBefore: [lintA],
+        fixesApplied: [{ strategyName: "lint-fix", op: "noop-op", targetFiles: [], summary: "" }],
+        findingsAfter: [lintA],
+        outcome: "unchanged",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        finishedAt: "2026-01-01T00:00:01.000Z",
+      },
+      {
+        iterationNum: 2,
+        findingsBefore: [lintA],
+        fixesApplied: [{ strategyName: "lint-fix", op: "noop-op", targetFiles: [], summary: "" }],
+        findingsAfter: [lintA],
+        outcome: "unchanged",
+        startedAt: "2026-01-01T00:00:02.000Z",
+        finishedAt: "2026-01-01T00:00:03.000Z",
+      },
+    ];
+
+    const cycle = makeCycle([lintA], [strategy], async () => []);
+    cycle.iterations.push(...priorIterations);
+
+    const callOpMock = makeCallOpMock();
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("max-attempts-per-strategy");
+    expect(result.exhaustedStrategy).toBe("lint-fix");
+    expect(callOpMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── runFixCycle — bail: max-attempts-total ───────────────────────────────────
+
+describe("runFixCycle — bail: max-attempts-total", () => {
+  test("exits when total fix invocations across all strategies exceeds cap", async () => {
+    const strategyA = makeStrategy({ name: "fix-a", maxAttempts: 99 });
+    const strategyB = makeStrategy({ name: "fix-b", maxAttempts: 99 });
+
+    // 5 invocations each = 10 total = maxAttemptsTotal
+    const priorIterations: Iteration<Finding>[] = Array.from({ length: 5 }, (_, i) => ({
+      iterationNum: i + 1,
+      findingsBefore: [lintA],
+      fixesApplied: [
+        { strategyName: "fix-a", op: "noop-op", targetFiles: [], summary: "" },
+        { strategyName: "fix-b", op: "noop-op", targetFiles: [], summary: "" },
+      ],
+      findingsAfter: [lintA],
+      outcome: "unchanged" as const,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:01.000Z",
+    }));
+
+    const cycle = makeCycle([lintA], [strategyA, strategyB], async () => [], {
+      config: { maxAttemptsTotal: 10, validatorRetries: 1 },
+    });
+    cycle.iterations.push(...priorIterations);
+
+    const callOpMock = makeCallOpMock();
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("max-attempts-total");
+    expect(callOpMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── runFixCycle — bail: bail-when ────────────────────────────────────────────
+
+describe("runFixCycle — bail: bail-when", () => {
+  test("exits when strategy bailWhen predicate fires", async () => {
+    const strategy = makeStrategy({
+      name: "lint-fix",
+      bailWhen: (iters) => (iters.length > 0 && iters[iters.length - 1].outcome === "unchanged" ? "unchanged twice" : null),
+    });
+
+    const priorIter: Iteration<Finding> = {
+      iterationNum: 1,
+      findingsBefore: [lintA],
+      fixesApplied: [{ strategyName: "lint-fix", op: "noop-op", targetFiles: [], summary: "" }],
+      findingsAfter: [lintA],
+      outcome: "unchanged",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:01.000Z",
+    };
+
+    const cycle = makeCycle([lintA], [strategy], async () => []);
+    cycle.iterations.push(priorIter);
+
+    const callOpMock = makeCallOpMock();
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("bail-when");
+    expect(result.bailDetail).toBe("unchanged twice");
+    expect(callOpMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── runFixCycle — bail: validator-error ─────────────────────────────────────
+
+describe("runFixCycle — bail: validator-error", () => {
+  test("exits after exhausting validatorRetries", async () => {
+    let validateCallCount = 0;
+    const strategy = makeStrategy({ name: "lint-fix" });
+    const cycle = makeCycle([lintA], [strategy], async () => {
+      validateCallCount++;
+      throw new Error("validator crashed");
+    });
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("validator-error");
+    // validatorRetries=1: first attempt + 1 retry = 2 calls
+    expect(validateCallCount).toBe(2);
+    // callOp was called (fix ran) but iterations not committed (validator failed)
+    expect(callOpMock).toHaveBeenCalledTimes(1);
+    expect(cycle.iterations).toHaveLength(0);
+  });
+
+  test("recovers when first validator call throws but retry succeeds", async () => {
+    let validateCallCount = 0;
+    const strategy = makeStrategy({ name: "lint-fix" });
+    const cycle = makeCycle([lintA], [strategy], async () => {
+      validateCallCount++;
+      if (validateCallCount === 1) throw new Error("transient error");
+      return []; // second attempt succeeds
+    });
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("resolved");
+    expect(validateCallCount).toBe(2);
+    expect(cycle.iterations).toHaveLength(1);
+    expect(cycle.iterations[0].outcome).toBe("resolved");
+  });
+});
+
+// ─── runFixCycle — success paths ──────────────────────────────────────────────
+
+describe("runFixCycle — success paths", () => {
+  test("resolves after one iteration when validator returns empty", async () => {
+    const strategy = makeStrategy({ name: "lint-fix" });
+    const cycle = makeCycle([lintA], [strategy], async () => []);
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("resolved");
+    expect(result.finalFindings).toHaveLength(0);
+    expect(result.iterations).toHaveLength(1);
+    expect(result.iterations[0].outcome).toBe("resolved");
+    expect(result.iterations[0].iterationNum).toBe(1);
+    expect(callOpMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("records FixApplied with extractApplied output", async () => {
+    const strategy = makeStrategy({
+      name: "lint-fix",
+      extractApplied: () => ({ targetFiles: ["src/a.ts"], summary: "fixed unused var" }),
+    });
+    const cycle = makeCycle([lintA], [strategy], async () => []);
+    const callOpMock = makeCallOpMock({ output: "done" });
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("resolved");
+    expect(result.iterations[0].fixesApplied[0].targetFiles).toEqual(["src/a.ts"]);
+    expect(result.iterations[0].fixesApplied[0].summary).toBe("fixed unused var");
+  });
+
+  test("exclusive strategy wins over co-run peers", async () => {
+    const called: string[] = [];
+    const exclusiveStrategy = makeStrategy({
+      name: "exclusive-fix",
+      coRun: "exclusive",
+    });
+    const coRunStrategy = makeStrategy({
+      name: "co-run-fix",
+      coRun: "co-run-sequential",
+    });
+
+    const callOpMock = mock(async (_ctx: unknown, op: { name: string }) => {
+      called.push(op.name);
+      return {};
+    });
+
+    const cycle = makeCycle([lintA], [exclusiveStrategy, coRunStrategy], async () => []);
+    await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(called).toHaveLength(1);
+    expect(called[0]).toBe("noop-op");
+    expect(cycle.iterations[0].fixesApplied[0].strategyName).toBe("exclusive-fix");
+  });
+
+  test("co-run strategies both execute in order", async () => {
+    const called: string[] = [];
+
+    const strategyA = makeStrategy({
+      name: "fix-a",
+      fixOp: { ...noopOp, name: "op-a" } as typeof noopOp,
+      coRun: "co-run-sequential",
+    });
+    const strategyB = makeStrategy({
+      name: "fix-b",
+      fixOp: { ...noopOp, name: "op-b" } as typeof noopOp,
+      coRun: "co-run-sequential",
+    });
+
+    const callOpMock = mock(async (_ctx: unknown, op: { name: string }) => {
+      called.push(op.name);
+      return {};
+    });
+
+    const cycle = makeCycle([lintA], [strategyA, strategyB], async () => []);
+    await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(called).toEqual(["op-a", "op-b"]);
+  });
+
+  test("iterates until resolved", async () => {
+    let validateCall = 0;
+    const strategy = makeStrategy({ name: "lint-fix" });
+    // First two validations return a finding, third returns empty
+    const cycle = makeCycle([lintA], [strategy], async () => {
+      validateCall++;
+      if (validateCall < 3) return [lintA];
+      return [];
+    });
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("resolved");
+    expect(result.iterations).toHaveLength(3);
+    expect(result.iterations[0].outcome).toBe("unchanged");
+    expect(result.iterations[1].outcome).toBe("unchanged");
+    expect(result.iterations[2].outcome).toBe("resolved");
+    expect(callOpMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/test/unit/findings/cycle.test.ts
+++ b/test/unit/findings/cycle.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { CallOpFn } from "../../../src/findings/cycle";
 import { classifyOutcome, runFixCycle } from "../../../src/findings/cycle";
-import type { FixCycle, FixCycleContext, FixStrategy, Iteration } from "../../../src/findings/cycle-types";
-import type { Finding } from "../../../src/findings/types";
+import type { FixCycle, FixCycleContext, FixStrategy, Iteration } from "../../../src/findings";
+import type { Finding } from "../../../src/findings";
 import { makeNaxConfig } from "../../helpers";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -103,6 +103,10 @@ describe("classifyOutcome", () => {
     const before = [lintA, lintB];
     const after = [lintA];
     expect(classifyOutcome(before, after)).toBe("partial");
+  });
+
+  test("regressed — before empty, after has new findings (not regressed-different-source)", () => {
+    expect(classifyOutcome([], [lintA])).toBe("regressed");
   });
 
   test("regressed — new finding appears in same source", () => {

--- a/test/unit/prompts/builders/prior-iterations-builder.test.ts
+++ b/test/unit/prompts/builders/prior-iterations-builder.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from "bun:test";
+import { buildPriorIterationsBlock } from "../../../../src/prompts/builders/prior-iterations-builder";
+import type { Iteration } from "../../../../src/findings/cycle-types";
+import type { Finding } from "../../../../src/findings/types";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeFinding(overrides: Partial<Finding> & Pick<Finding, "source" | "message">): Finding {
+  return {
+    severity: "error",
+    category: overrides.category ?? "stdout-capture",
+    ...overrides,
+  };
+}
+
+function makeIteration(overrides: Partial<Iteration<Finding>> & Pick<Iteration<Finding>, "iterationNum" | "outcome">): Iteration<Finding> {
+  return {
+    findingsBefore: [],
+    fixesApplied: [],
+    findingsAfter: [],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    finishedAt: "2026-01-01T00:00:01.000Z",
+    ...overrides,
+  };
+}
+
+const acceptanceTestFix = {
+  strategyName: "acceptance-test-fix",
+  op: "acceptance-fix-test-op",
+  targetFiles: [".nax-acceptance.test.ts"],
+  summary: "adjusted stdout capture assertion",
+};
+
+// ─── Empty input ──────────────────────────────────────────────────────────────
+
+describe("buildPriorIterationsBlock — empty", () => {
+  test("returns empty string for empty iterations array", () => {
+    expect(buildPriorIterationsBlock([])).toBe("");
+  });
+});
+
+// ─── Single iteration — resolved ─────────────────────────────────────────────
+
+describe("buildPriorIterationsBlock — single resolved iteration", () => {
+  test("renders table with resolved outcome", () => {
+    const finding = makeFinding({ source: "acceptance-diagnose", message: "wrong stream" });
+    const iter = makeIteration({
+      iterationNum: 1,
+      outcome: "resolved",
+      findingsBefore: [finding],
+      findingsAfter: [],
+      fixesApplied: [acceptanceTestFix],
+    });
+
+    const output = buildPriorIterationsBlock([iter]);
+
+    expect(output).toContain("## Prior Iterations — verdict required before new analysis");
+    expect(output).toContain("| # | Strategies run | Files touched | Outcome | Findings before → after |");
+    expect(output).toContain("| 1 | acceptance-test-fix | .nax-acceptance.test.ts | resolved |");
+    expect(output).toContain("1 [stdout-capture] → 0");
+  });
+
+  test("does NOT include unchanged note when no unchanged iterations", () => {
+    const iter = makeIteration({
+      iterationNum: 1,
+      outcome: "resolved",
+      findingsBefore: [makeFinding({ source: "acceptance-diagnose", message: "x" })],
+      findingsAfter: [],
+      fixesApplied: [acceptanceTestFix],
+    });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).not.toContain("FALSIFIED");
+  });
+});
+
+// ─── Single iteration — unchanged ────────────────────────────────────────────
+
+describe("buildPriorIterationsBlock — unchanged outcome", () => {
+  test("includes falsified-hypothesis note when outcome is unchanged", () => {
+    const finding = makeFinding({ source: "acceptance-diagnose", message: "wrong stream", category: "stdout-capture" });
+    const iter = makeIteration({
+      iterationNum: 1,
+      outcome: "unchanged",
+      findingsBefore: [finding],
+      findingsAfter: [finding],
+      fixesApplied: [acceptanceTestFix],
+    });
+
+    const output = buildPriorIterationsBlock([iter]);
+
+    expect(output).toContain("unchanged");
+    expect(output).toContain('outcome is "unchanged", the prior hypothesis is FALSIFIED');
+    expect(output).toContain("Do NOT repeat fixes listed above.");
+  });
+
+  test("finding summary shows same count before and after for unchanged", () => {
+    const finding = makeFinding({ source: "acceptance-diagnose", message: "wrong stream", category: "stdout-capture" });
+    const iter = makeIteration({
+      iterationNum: 1,
+      outcome: "unchanged",
+      findingsBefore: [finding],
+      findingsAfter: [finding],
+      fixesApplied: [acceptanceTestFix],
+    });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain("1 [stdout-capture] → 1 [stdout-capture]");
+  });
+});
+
+// ─── Multiple iterations ──────────────────────────────────────────────────────
+
+describe("buildPriorIterationsBlock — multiple iterations", () => {
+  test("renders all iteration rows in order", () => {
+    const finding = makeFinding({ source: "acceptance-diagnose", message: "x", category: "stdout-capture" });
+    const iter1 = makeIteration({
+      iterationNum: 1,
+      outcome: "unchanged",
+      findingsBefore: [finding],
+      findingsAfter: [finding],
+      fixesApplied: [acceptanceTestFix],
+    });
+    const iter2 = makeIteration({
+      iterationNum: 2,
+      outcome: "resolved",
+      findingsBefore: [finding],
+      findingsAfter: [],
+      fixesApplied: [{ ...acceptanceTestFix, summary: "second attempt" }],
+    });
+
+    const output = buildPriorIterationsBlock([iter1, iter2]);
+
+    expect(output).toContain("| 1 |");
+    expect(output).toContain("| 2 |");
+    // unchanged note present because iter1 was unchanged
+    expect(output).toContain("FALSIFIED");
+  });
+
+  test("co-run strategies are joined with comma in Strategies run column", () => {
+    const sourceFix = { strategyName: "acceptance-source-fix", op: "op-a", targetFiles: ["src/foo.ts"], summary: "" };
+    const testFix = { strategyName: "acceptance-test-fix", op: "op-b", targetFiles: [".nax-acceptance.test.ts"], summary: "" };
+    const iter = makeIteration({
+      iterationNum: 1,
+      outcome: "partial",
+      findingsBefore: [makeFinding({ source: "acceptance-diagnose", message: "x" })],
+      findingsAfter: [],
+      fixesApplied: [sourceFix, testFix],
+    });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain("acceptance-source-fix, acceptance-test-fix");
+    expect(output).toContain("src/foo.ts, .nax-acceptance.test.ts");
+  });
+
+  test("no-files iteration shows dash in Files touched column", () => {
+    const iter = makeIteration({
+      iterationNum: 1,
+      outcome: "unchanged",
+      findingsBefore: [makeFinding({ source: "acceptance-diagnose", message: "x" })],
+      findingsAfter: [makeFinding({ source: "acceptance-diagnose", message: "x" })],
+      fixesApplied: [{ strategyName: "lint-fix", op: "lint-op", targetFiles: [], summary: "" }],
+    });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain("| 1 | lint-fix | - |");
+  });
+
+  test("most-frequent category shown when findings have mixed categories", () => {
+    const f1 = makeFinding({ source: "lint", message: "a", category: "unused-var" });
+    const f2 = makeFinding({ source: "lint", message: "b", category: "unused-var" });
+    const f3 = makeFinding({ source: "lint", message: "c", category: "missing-semi" });
+    const iter = makeIteration({
+      iterationNum: 1,
+      outcome: "partial",
+      findingsBefore: [f1, f2, f3],
+      findingsAfter: [f3],
+      fixesApplied: [{ strategyName: "lint-fix", op: "lint-op", targetFiles: ["src/a.ts"], summary: "" }],
+    });
+
+    const output = buildPriorIterationsBlock([iter]);
+    // 3 before, top category "unused-var" (2 occurrences)
+    expect(output).toContain("3 [unused-var]");
+    // 1 after, category "missing-semi"
+    expect(output).toContain("1 [missing-semi]");
+  });
+});

--- a/test/unit/prompts/builders/prior-iterations-builder.test.ts
+++ b/test/unit/prompts/builders/prior-iterations-builder.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import type { Iteration, Finding } from "../../../../src/findings";
 import { buildPriorIterationsBlock } from "../../../../src/prompts/builders/prior-iterations-builder";
-import type { Iteration } from "../../../../src/findings/cycle-types";
-import type { Finding } from "../../../../src/findings/types";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **Phase 1** — `src/findings/cycle-types.ts`: ADR-022 type vocabulary (`Iteration<F>`, `FixApplied`, `IterationOutcome`, `FixCycleExitReason`, `FixCycleContext`, `FixCycleConfig`, `FixStrategy<F,I,O,C>`, `FixCycle<F>`, `FixCycleResult<F>`) exported from the `src/findings` barrel
- **Phase 2** — `src/findings/cycle.ts`: `classifyOutcome` (per-source bucket algorithm → aggregate) and `runFixCycle` (multi-strategy iteration loop with co-run/exclusive discipline, per-strategy + total attempt caps, `bailWhen` predicates, validator retry-once-then-terminal) — 22 unit tests
- **Phase 3** — `src/prompts/builders/prior-iterations-builder.ts`: `buildPriorIterationsBlock` verdict-first markdown table replacing three legacy carry-forward blocks — 9 unit tests

## Test Plan

- [ ] `bun run test` passes (1234+ tests, 0 failures)
- [ ] `classifyOutcome` covers all 5 outcomes + empty-before guard (`[], nonEmpty` → `"regressed"`, not `"regressed-different-source"`)
- [ ] `runFixCycle` bail paths: no-strategy, per-strategy cap, total cap, bail-when, validator-error with retry/recovery
- [ ] `buildPriorIterationsBlock`: empty → `""`, resolved/unchanged rows, co-run strategy joining, falsified-hypothesis note on unchanged, most-frequent category display