### PR TITLE
fix(review): preserve error findings when verifiedBy file is unreadable outside workdir

### DIFF
--- a/src/review/semantic-evidence.ts
+++ b/src/review/semantic-evidence.ts
@@ -1,3 +1,4 @@
+import { isAbsolute } from "node:path";
 import { getSafeLogger } from "../logger";
 import { validateModulePath } from "../utils/path-security";
 import type { LLMFinding } from "./semantic-helpers";
@@ -40,7 +41,12 @@ async function substantiateFinding(finding: LLMFinding, workdir: string, storyId
 
   const file = finding.verifiedBy?.file?.trim() || finding.file;
   const contents = await readSafeFile(workdir, file);
-  if (contents !== null && normalizedIncludes(contents, observed)) return finding;
+
+  // File genuinely unreadable on this machine — cannot verify or refute.
+  // Preserve the finding rather than silently demoting a real AC violation.
+  if (contents === null) return finding;
+
+  if (normalizedIncludes(contents, observed)) return finding;
 
   _evidenceDeps.getLogger()?.warn("review", "Downgraded unsubstantiated semantic error finding", {
     storyId,
@@ -56,13 +62,26 @@ async function substantiateFinding(finding: LLMFinding, workdir: string, storyId
 
 async function readSafeFile(workdir: string, file: string): Promise<string | null> {
   const validated = validateModulePath(file, [workdir]);
-  if (!validated.valid || !validated.absolutePath) return null;
-
-  try {
-    return await Bun.file(validated.absolutePath).text();
-  } catch {
-    return null;
+  if (validated.valid && validated.absolutePath) {
+    try {
+      return await Bun.file(validated.absolutePath).text();
+    } catch {
+      return null;
+    }
   }
+
+  // Absolute path outside workdir — the LLM ran its tool against a different
+  // machine or repo root. Attempt a direct read so we can still verify the
+  // evidence rather than skipping substantiation entirely.
+  if (isAbsolute(file)) {
+    try {
+      return await Bun.file(file).text();
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
 }
 
 function normalizedIncludes(contents: string, observed: string): boolean {

--- a/test/unit/review/semantic-evidence.test.ts
+++ b/test/unit/review/semantic-evidence.test.ts
@@ -124,7 +124,7 @@ describe("substantiateSemanticEvidence — ref mode", () => {
         issue: "hasContentChanged() ignores outgoing links",
         verifiedBy: {
           command: "Read src/foo.ts",
-          file: "apps/api/src/rag/rag.service.ts",
+          file: "src/foo.ts",
           line: 109,
           observed: "hasContentChanged only compares label, type, source_file — storedLinkMap captured on line 814",
         },
@@ -138,7 +138,7 @@ describe("substantiateSemanticEvidence — ref mode", () => {
       expect(downgradeCall?.stage).toBe("review");
       expect(downgradeCall?.data?.event).toBe("review.semantic.finding.downgraded");
       expect(downgradeCall?.data?.storyId).toBe(STORY_ID);
-      expect(downgradeCall?.data?.file).toBe("apps/api/src/rag/rag.service.ts");
+      expect(downgradeCall?.data?.file).toBe("src/foo.ts");
       expect(downgradeCall?.data?.line).toBe(109);
       expect(downgradeCall?.data?.issue).toBe("hasContentChanged() ignores outgoing links");
       expect(typeof downgradeCall?.data?.observed).toBe("string");
@@ -156,6 +156,71 @@ describe("substantiateSemanticEvidence — ref mode", () => {
       const result = await substantiateSemanticEvidence(findings, "ref", workdir, STORY_ID);
 
       expect(result.map((f) => f.severity)).toEqual(["warn", "info", "unverifiable"]);
+      expect(logger.calls.find((c) => c.message.includes("Downgraded"))).toBeUndefined();
+    });
+  });
+
+  test("preserves error finding when absolute verifiedBy.file does not exist on this machine", async () => {
+    await withTempDir(async (workdir) => {
+      // Simulates the real case: LLM ran its grep on a Mac against an absolute
+      // path that doesn't exist in the current environment (CI, Linux, different
+      // repo location). The file is unreadable, so we preserve rather than demote.
+      const finding = makeFinding({
+        verifiedBy: {
+          command: "grep -n 'deleteAllBySourceType' /Users/williamkhoo/repos/koda/apps/api/src/rag/rag.service.ts",
+          file: "/Users/williamkhoo/repos/koda/apps/api/src/rag/rag.service.ts",
+          line: 723,
+          observed: "const cleared = await this.deleteAllBySourceType(projectId, 'code');",
+        },
+      });
+
+      const result = await substantiateSemanticEvidence([finding], "ref", workdir, STORY_ID);
+
+      expect(result[0].severity).toBe("error");
+      expect(logger.calls.find((c) => c.message.includes("Downgraded"))).toBeUndefined();
+    });
+  });
+
+  test("downgrades error finding when absolute verifiedBy.file exists but snippet is absent", async () => {
+    await withTempDir(async (workdir) => {
+      // Write a real file at a known absolute path (temp dir) so the direct read
+      // succeeds, then verify that a non-matching observed still downgrades.
+      const absFile = join(workdir, "abs-target.ts");
+      writeFileSync(absFile, "export function realCode() { return 42; }\n");
+
+      const finding = makeFinding({
+        verifiedBy: {
+          command: `cat ${absFile}`,
+          file: absFile,
+          line: 1,
+          observed: "this snippet does not appear in the file at all",
+        },
+      });
+
+      const result = await substantiateSemanticEvidence([finding], "ref", workdir, STORY_ID);
+
+      expect(result[0].severity).toBe("unverifiable");
+      expect(logger.calls.find((c) => c.message.includes("Downgraded"))).toBeDefined();
+    });
+  });
+
+  test("preserves error finding when absolute verifiedBy.file exists and snippet matches", async () => {
+    await withTempDir(async (workdir) => {
+      const absFile = join(workdir, "abs-target.ts");
+      writeFileSync(absFile, "const cleared = await this.deleteAllBySourceType(projectId, 'code');\n");
+
+      const finding = makeFinding({
+        verifiedBy: {
+          command: `grep -n deleteAllBySourceType ${absFile}`,
+          file: absFile,
+          line: 1,
+          observed: "const cleared = await this.deleteAllBySourceType(projectId, 'code');",
+        },
+      });
+
+      const result = await substantiateSemanticEvidence([finding], "ref", workdir, STORY_ID);
+
+      expect(result[0].severity).toBe("error");
       expect(logger.calls.find((c) => c.message.includes("Downgraded"))).toBeUndefined();
     });
   });


### PR DESCRIPTION
Closes #880

## Summary

- `readSafeFile` called `validateModulePath(file, [workdir])` which rejects absolute paths outside the workdir, returning `null`
- The caller treated `null` (file unreadable) identically to "snippet not found" — both downgraded the finding to `unverifiable`
- When the LLM provides valid absolute paths from its tool calls (normal behaviour), real AC violations were silently demoted

## Fix

When `validateModulePath` rejects an absolute path, attempt a direct `Bun.file(file).text()` read:

- File exists + snippet matches → preserved as `error`
- File exists + snippet absent → downgraded to `unverifiable` (genuine hallucination)
- File doesn't exist on this machine → `null` → preserved as `error` (cannot refute)

## Test plan

- [ ] New test: absolute path not on this machine → finding stays `error`, no downgrade log
- [ ] New test: absolute path exists, snippet absent → downgraded to `unverifiable`
- [ ] New test: absolute path exists, snippet matches → preserved as `error`
- [ ] All 10 `semantic-evidence.test.ts` tests pass