### PR TITLE
feat(findings): adversarial migration — Iteration[] replaces AdversarialFindingsCache (ADR-022 phase 5)

### DIFF
--- a/src/findings/cycle-types.ts
+++ b/src/findings/cycle-types.ts
@@ -34,7 +34,15 @@ export interface Iteration<F extends Finding = Finding> {
   /** 1-indexed. */
   iterationNum: number;
   findingsBefore: F[];
-  /** At least one entry per iteration — one per strategy that ran. */
+  /**
+   * Strategies that ran during this iteration. At least one entry when the
+   * iteration is produced by runFixCycle (one per strategy that ran).
+   *
+   * Exception: carry-forward iterations recorded by review orchestrators
+   * (e.g. adversarial) have fixesApplied: [] because the fix ran in the
+   * implementation session outside the FixCycle. The rendered table shows "-"
+   * in the "Strategies run" column for these rows.
+   */
   fixesApplied: FixApplied[];
   findingsAfter: F[];
   outcome: IterationOutcome;

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -1,11 +1,12 @@
 import type { TurnResult } from "../agents/types";
 import { reviewConfigSelector } from "../config";
 import type { ReviewConfig } from "../config/selectors";
+import type { Iteration } from "../findings";
 import { getSafeLogger } from "../logger";
 import { AdversarialReviewPromptBuilder, ReviewPromptBuilder } from "../prompts";
 import type { PriorFailure, TestInventory } from "../prompts";
 import { looksLikeTruncatedJson } from "../review/truncation";
-import type { AdversarialFindingsCache, AdversarialReviewConfig, SemanticStory } from "../review/types";
+import type { AdversarialReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { HopBody, LlmReviewFinding, LlmReviewOutput, RunOperation } from "./types";
 import { parseLlmReviewShape } from "./types";
@@ -26,8 +27,8 @@ export interface AdversarialReviewInput {
   refExcludePatterns?: readonly string[];
   /** Pre-built, role-filtered context prefix to prepend to the review prompt. */
   featureCtxBlock?: string;
-  /** Prior adversarial findings to carry forward into this review round (issue #736). */
-  priorAdversarialFindings?: AdversarialFindingsCache;
+  /** Prior adversarial review iterations to carry forward into this round (ADR-022 phase 5). */
+  priorAdversarialIterations?: Iteration[];
   /** Severity threshold from review config — drives the JSON-retry condensation prompt. */
   blockingThreshold?: "error" | "warning" | "info";
 }
@@ -90,7 +91,7 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
         excludePatterns: input.excludePatterns,
         testGlobs: input.testGlobs,
         refExcludePatterns: input.refExcludePatterns,
-        priorAdversarialFindings: input.priorAdversarialFindings,
+        priorAdversarialIterations: input.priorAdversarialIterations,
       },
     );
     const content = input.featureCtxBlock ? `${input.featureCtxBlock}${base}` : base;

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -9,12 +9,13 @@ import type { NaxConfig } from "../config/schema";
 import type { ConstitutionResult } from "../constitution/types";
 import type { BuiltContext } from "../context/types";
 import type { Finding } from "../findings";
+import type { Iteration } from "../findings";
 import type { HooksConfig } from "../hooks/types";
 import type { InteractionChain } from "../interaction/chain";
 import type { StoryMetrics } from "../metrics/types";
 import type { PluginRegistry } from "../plugins/registry";
 import type { PRD, UserStory } from "../prd/types";
-import type { AdversarialFindingsCache, ReviewResult } from "../review/types";
+import type { ReviewResult } from "../review/types";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import type { FailureCategory } from "../tdd/types";
 import type { VerifyResult } from "../verification/orchestrator-types";
@@ -237,12 +238,12 @@ export interface PipelineContext extends DispatchContext {
    */
   mechanicalFailedOnly?: boolean;
   /**
-   * Carry-forward cache for adversarial prior findings (issue #736).
-   * Set by reviewFromContext() when the adversarial check fails with blocking findings.
-   * Cleared when adversarial passes. Injected into the next round's prompt so the reviewer
-   * does not open a fresh session with no memory of what it already flagged.
+   * Carry-forward iteration history for adversarial review rounds (ADR-022 phase 5).
+   * Appended by reviewFromContext() when adversarial fails with blocking findings.
+   * Cleared when adversarial passes. Injected into the next round's prompt via
+   * buildPriorIterationsBlock so the reviewer sees prior-round findings verdict-first.
    */
-  priorAdversarialFindings?: AdversarialFindingsCache;
+  priorAdversarialIterations?: Iteration[];
 }
 
 /**

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -54,6 +54,13 @@ export interface AdversarialReviewPromptOptions {
    * Prior adversarial review iterations (ADR-022 phase 5).
    * When set, injects buildPriorIterationsBlock instructing the reviewer to verdict
    * on unresolved prior-round issues before scanning for new ones.
+   *
+   * Trade-off (accepted, ADR-022): the block shows aggregated finding counts per
+   * iteration rather than per-finding detail (severity, file:line, message). This
+   * is intentional — individual findings appear in the current diff, and the LLM
+   * re-derives them from the code. The count table keeps token cost bounded across
+   * many rounds without repeating the full finding list. fixesApplied may be []
+   * for adversarial carry-forward iterations (fix ran in the implementation session).
    */
   priorAdversarialIterations?: Iteration[];
 }

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -9,8 +9,9 @@
  * Reuses PriorFailure and buildAttemptContextBlock from review-builder.ts.
  */
 
-import type { Finding } from "../../findings";
-import type { AdversarialFindingsCache, AdversarialReviewConfig, SemanticStory } from "../../review/types";
+import type { Iteration } from "../../findings";
+import type { AdversarialReviewConfig, SemanticStory } from "../../review/types";
+import { buildPriorIterationsBlock } from "./prior-iterations-builder";
 import { buildAttemptContextBlock } from "./review-builder";
 import type { PriorFailure } from "./review-builder";
 
@@ -50,11 +51,11 @@ export interface AdversarialReviewPromptOptions {
    */
   refExcludePatterns?: readonly string[];
   /**
-   * Prior adversarial findings from the previous round (issue #736).
-   * When set, injects a "## Prior Adversarial Findings" block instructing the reviewer
-   * to verdict on unresolved prior issues before scanning for new ones.
+   * Prior adversarial review iterations (ADR-022 phase 5).
+   * When set, injects buildPriorIterationsBlock instructing the reviewer to verdict
+   * on unresolved prior-round issues before scanning for new ones.
    */
-  priorAdversarialFindings?: AdversarialFindingsCache;
+  priorAdversarialIterations?: Iteration[];
 }
 
 const ADVERSARIAL_ROLE = `You are an adversarial code reviewer with full access to the repository.
@@ -220,33 +221,6 @@ ${diff}\`\`\`
 }
 
 /**
- * Build the prior-findings carry-forward block injected at the top of subsequent rounds.
- * Verdict-first: the reviewer sees unresolved findings before scanning for new issues.
- */
-function buildPriorFindingsBlock(round: number, findings: readonly Finding[]): string {
-  const rows = findings
-    .map((f) => {
-      const filePath = f.file ?? "";
-      const location = f.line !== undefined ? `${filePath}:${f.line}` : filePath;
-      const category = f.category || "—";
-      return `| ${f.severity} | ${category} | ${location} | ${f.message} |`;
-    })
-    .join("\n");
-
-  return `## Prior Adversarial Findings — Round ${round}
-
-The following issues were flagged in the previous adversarial review round.
-**Verdict on each of these first — determine whether each has been fixed, partially addressed, or is still present.**
-Then continue scanning for new issues.
-
-| Severity | Category | Location | Issue |
-|:---------|:---------|:---------|:------|
-${rows}
-
-`;
-}
-
-/**
  * Build an adversarial review prompt for the given story and diff context.
  */
 export class AdversarialReviewPromptBuilder {
@@ -265,13 +239,10 @@ export class AdversarialReviewPromptBuilder {
       excludePatterns,
       testGlobs,
       refExcludePatterns,
-      priorAdversarialFindings,
+      priorAdversarialIterations,
     } = options;
 
-    const priorFindingsBlock =
-      priorAdversarialFindings && priorAdversarialFindings.findings.length > 0
-        ? buildPriorFindingsBlock(priorAdversarialFindings.round, priorAdversarialFindings.findings)
-        : "";
+    const priorFindingsBlock = buildPriorIterationsBlock(priorAdversarialIterations ?? []);
 
     const storyBlock = `## Story Under Review
 

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -19,6 +19,7 @@ import { DEFAULT_CONFIG, reviewConfigSelector } from "../config";
 import type { ReviewConfig } from "../config/selectors";
 import { filterContextByRole } from "../context";
 import { NaxError } from "../errors";
+import type { Iteration } from "../findings";
 import { getSafeLogger } from "../logger";
 import { adversarialReviewOp } from "../operations/adversarial-review";
 import { callOp as _callOp } from "../operations/call";
@@ -33,7 +34,7 @@ import {
 } from "./adversarial-helpers";
 import { collectDiff, collectDiffStat, computeTestInventory, resolveEffectiveRef } from "./diff-utils";
 import { writeReviewAudit } from "./review-audit";
-import type { AdversarialFindingsCache, AdversarialReviewConfig, ReviewCheckResult, SemanticStory } from "./types";
+import type { AdversarialReviewConfig, ReviewCheckResult, SemanticStory } from "./types";
 
 /** Injectable dependencies for adversarial.ts — allows tests to mock without mock.module() */
 export const _adversarialDeps = {
@@ -86,7 +87,7 @@ export interface RunAdversarialReviewOptions {
   projectDir?: string;
   naxIgnoreIndex?: NaxIgnoreIndex;
   runtime?: import("../runtime").NaxRuntime;
-  priorAdversarialFindings?: AdversarialFindingsCache;
+  priorAdversarialIterations?: Iteration[];
 }
 
 /**
@@ -109,7 +110,7 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     projectDir,
     naxIgnoreIndex,
     runtime,
-    priorAdversarialFindings,
+    priorAdversarialIterations,
   } = opts;
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -267,7 +268,7 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       excludePatterns: adversarialConfig.excludePatterns,
       testGlobs: resolvedTestPatterns.globs,
       featureCtxBlock,
-      priorAdversarialFindings,
+      priorAdversarialIterations,
       blockingThreshold,
       refExcludePatterns: effectiveRefExcludePatterns,
     });

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -585,12 +585,16 @@ export class ReviewOrchestrator {
     });
 
     // Update ctx.priorAdversarialIterations for the next review round (ADR-022 phase 5).
-    // When adversarial fails with blocking findings, append an Iteration so the next
-    // round's prompt carries them forward via buildPriorIterationsBlock (verdict-first).
+    // When adversarial fails, append an Iteration so the next round's prompt carries
+    // history forward via buildPriorIterationsBlock (verdict-first). This covers both
+    // structured-findings failures and looksLikeFail (truncated JSON / no findings array).
     // When adversarial passes, clear the history.
+    //
+    // fixesApplied is always [] here because adversarial fixes run in the implementation
+    // session outside this subsystem — there is no FixApplied op to record.
     const advCheck = result.builtIn.checks?.find((c) => c.check === "adversarial");
     if (advCheck) {
-      if (!advCheck.success && (advCheck.findings?.length ?? 0) > 0) {
+      if (!advCheck.success && !advCheck.skipped) {
         const prior = ctx.priorAdversarialIterations ?? [];
         const findingsBefore = prior.length > 0 ? (prior[prior.length - 1].findingsAfter ?? []) : [];
         const findingsAfter = advCheck.findings ?? [];

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -14,7 +14,8 @@ import type { IAgentManager } from "../agents";
 import type { NaxConfig } from "../config";
 import { assembleForStage } from "../context/engine";
 import type { ContextBundle } from "../context/engine";
-import { pluginToFinding } from "../findings";
+import { classifyOutcome, pluginToFinding } from "../findings";
+import type { Iteration } from "../findings";
 import { getSafeLogger } from "../logger";
 import type { PipelineContext } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins";
@@ -26,7 +27,6 @@ import { runReview } from "./runner";
 import type { SemanticStory } from "./semantic";
 import { runSemanticReview } from "./semantic";
 import type {
-  AdversarialFindingsCache,
   AdversarialReviewConfig,
   ReviewCheckResult,
   ReviewConfig,
@@ -151,7 +151,7 @@ export interface OrchestratorReviewOptions {
   env?: Record<string, string | undefined>;
   naxIgnoreIndex?: NaxIgnoreIndex;
   runtime?: import("../runtime").NaxRuntime;
-  priorAdversarialFindings?: AdversarialFindingsCache;
+  priorAdversarialIterations?: Iteration[];
 }
 
 export class ReviewOrchestrator {
@@ -179,7 +179,7 @@ export class ReviewOrchestrator {
       env,
       naxIgnoreIndex,
       runtime,
-      priorAdversarialFindings,
+      priorAdversarialIterations,
     } = opts;
     const logger = getSafeLogger();
 
@@ -360,7 +360,7 @@ export class ReviewOrchestrator {
             projectDir,
             naxIgnoreIndex,
             runtime,
-            priorAdversarialFindings,
+            priorAdversarialIterations,
           }),
         ]);
         llmCheckResults = [semResult, advResult];
@@ -388,7 +388,7 @@ export class ReviewOrchestrator {
           env,
           naxIgnoreIndex,
           runtime,
-          priorAdversarialFindings,
+          priorAdversarialIterations,
         });
         llmCheckResults = llmResult.checks;
       }
@@ -581,26 +581,37 @@ export class ReviewOrchestrator {
       env: ctx.worktreeDependencyContext?.env,
       naxIgnoreIndex: ctx.naxIgnoreIndex,
       runtime: ctx.runtime,
-      priorAdversarialFindings: ctx.priorAdversarialFindings,
+      priorAdversarialIterations: ctx.priorAdversarialIterations,
     });
 
-    // Update ctx.priorAdversarialFindings for the next review round (issue #736).
-    // When adversarial fails with blocking findings, cache them so the next round's
-    // prompt carries them forward. When adversarial passes, clear the cache.
+    // Update ctx.priorAdversarialIterations for the next review round (ADR-022 phase 5).
+    // When adversarial fails with blocking findings, append an Iteration so the next
+    // round's prompt carries them forward via buildPriorIterationsBlock (verdict-first).
+    // When adversarial passes, clear the history.
     const advCheck = result.builtIn.checks?.find((c) => c.check === "adversarial");
     if (advCheck) {
       if (!advCheck.success && (advCheck.findings?.length ?? 0) > 0) {
-        ctx.priorAdversarialFindings = {
-          round: (ctx.priorAdversarialFindings?.round ?? 0) + 1,
-          findings: advCheck.findings ?? [],
+        const prior = ctx.priorAdversarialIterations ?? [];
+        const findingsBefore = prior.length > 0 ? (prior[prior.length - 1].findingsAfter ?? []) : [];
+        const findingsAfter = advCheck.findings ?? [];
+        const now = new Date().toISOString();
+        const newIteration: Iteration = {
+          iterationNum: prior.length + 1,
+          findingsBefore,
+          fixesApplied: [],
+          findingsAfter,
+          outcome: classifyOutcome(findingsBefore, findingsAfter),
+          startedAt: now,
+          finishedAt: now,
         };
+        ctx.priorAdversarialIterations = [...prior, newIteration];
       } else if (advCheck.success && !advCheck.skipped) {
-        ctx.priorAdversarialFindings = undefined;
+        ctx.priorAdversarialIterations = undefined;
       }
     } else if (retrySkipChecks?.has("adversarial")) {
       // Adversarial was skipped because it passed in the previous review pass.
-      // Clear any stale findings — the reviewer already approved this code.
-      ctx.priorAdversarialFindings = undefined;
+      // Clear any stale iteration history — the reviewer already approved this code.
+      ctx.priorAdversarialIterations = undefined;
     }
 
     return result;

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -7,6 +7,7 @@
 import type { IAgentManager } from "../agents";
 import type { ExecutionConfig, QualityConfig } from "../config/schema";
 import type { ReviewConfig as ReviewNaxConfig } from "../config/selectors";
+import type { Iteration } from "../findings";
 import { getSafeLogger } from "../logger";
 import { runQualityCommand } from "../quality";
 import { autoCommitIfDirty } from "../utils/git";
@@ -15,7 +16,7 @@ import { runAdversarialReview as _runAdversarialReviewImpl } from "./adversarial
 import { resolveLanguageCommand } from "./language-commands";
 import { runSemanticReview as _runSemanticReviewImpl } from "./semantic";
 import type { SemanticStory } from "./semantic";
-import type { AdversarialFindingsCache, ReviewCheckName, ReviewCheckResult, ReviewConfig, ReviewResult } from "./types";
+import type { ReviewCheckName, ReviewCheckResult, ReviewConfig, ReviewResult } from "./types";
 
 // Re-export for test compatibility
 export { resolveLanguageCommand };
@@ -43,7 +44,7 @@ export interface RunReviewOptions {
   env?: Record<string, string | undefined>;
   naxIgnoreIndex?: NaxIgnoreIndex;
   runtime?: import("../runtime").NaxRuntime;
-  priorAdversarialFindings?: AdversarialFindingsCache;
+  priorAdversarialIterations?: Iteration[];
 }
 
 /**
@@ -250,7 +251,7 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
     env,
     naxIgnoreIndex,
     runtime,
-    priorAdversarialFindings,
+    priorAdversarialIterations,
   } = opts;
   const startTime = Date.now();
   const logger = getSafeLogger();
@@ -389,7 +390,7 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
         projectDir,
         naxIgnoreIndex,
         runtime,
-        priorAdversarialFindings,
+        priorAdversarialIterations,
       });
       checks.push(result);
       if (!result.success && !firstFailure) {

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -175,18 +175,6 @@ export interface AdversarialReviewConfig {
   maxConcurrentSessions: number;
 }
 
-/**
- * Carry-forward cache for adversarial prior findings (issue #736).
- * Stored in PipelineContext and injected into the next adversarial round's prompt
- * so the reviewer does not open a fresh session with no memory of prior flags.
- */
-export interface AdversarialFindingsCache {
-  /** Round that produced these findings (1-indexed) */
-  round: number;
-  /** Blocking findings from the previous adversarial round */
-  findings: Finding[];
-}
-
 /** Review configuration */
 export interface ReviewConfig {
   /** Enable review phase */

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -79,33 +79,41 @@ describe("adversarialReviewOp.build()", () => {
     expect(result.task.content).toContain("-old line");
   });
 
-  test("task content contains prior findings block when priorAdversarialFindings is set", () => {
+  test("task content contains prior iterations block when priorAdversarialIterations is set", () => {
     const ctx = makeBuildCtx();
     const inputWithPrior: AdversarialReviewInput = {
       ...SAMPLE_INPUT,
-      priorAdversarialFindings: {
-        round: 2,
-        findings: [
+      priorAdversarialIterations: [
+        {
+          iterationNum: 1,
+          findingsBefore: [],
+          fixesApplied: [{ strategyName: "source-fix", op: "source-fix", targetFiles: ["src/session.ts"], summary: "", costUsd: 0 }],
+          findingsAfter: [
             {
-              source: "adversarial-review",
-              severity: "error",
+              source: "adversarial-review" as const,
+              severity: "error" as const,
               category: "error-path",
               file: "src/session.ts",
               line: 10,
               message: "Silent catch block",
             },
           ],
-      },
+          outcome: "partial" as const,
+          startedAt: "2026-01-01T00:00:00.000Z",
+          finishedAt: "2026-01-01T00:01:00.000Z",
+        },
+      ],
     };
     const result = adversarialReviewOp.build(inputWithPrior, ctx);
-    expect(result.task.content).toContain("Prior Adversarial Findings — Round 2");
-    expect(result.task.content).toContain("Silent catch block");
+    expect(result.task.content).toContain("## Prior Iterations — verdict required before new analysis");
+    expect(result.task.content).toContain("source-fix");
+    expect(result.task.content).toContain("partial");
   });
 
-  test("task content has no prior findings block when priorAdversarialFindings is absent", () => {
+  test("task content has no prior iterations block when priorAdversarialIterations is absent", () => {
     const ctx = makeBuildCtx();
     const result = adversarialReviewOp.build(SAMPLE_INPUT, ctx);
-    expect(result.task.content).not.toContain("Prior Adversarial Findings");
+    expect(result.task.content).not.toContain("## Prior Iterations");
   });
 });
 

--- a/test/unit/prompts/adversarial-review-builder.test.ts
+++ b/test/unit/prompts/adversarial-review-builder.test.ts
@@ -230,9 +230,8 @@ describe("AdversarialReviewPromptBuilder — prior failures", () => {
       storyGitRef: STORY_GIT_REF,
       priorFailures: [
         {
-          attempt: 1,
-          tier: "fast",
-          findings: [{ severity: "error", description: "Missing null check" }],
+          stage: "review",
+          modelTier: "fast",
         },
       ],
     });
@@ -320,120 +319,115 @@ describe("AdversarialReviewPromptBuilder — no diff available", () => {
   });
 });
 
-// ─── prior adversarial findings (issue #736) ──────────────────────────────────
+// ─── prior adversarial iterations (ADR-022 phase 5) ──────────────────────────
 
-describe("AdversarialReviewPromptBuilder — priorAdversarialFindings", () => {
-  const PRIOR_FINDINGS = {
-    round: 1,
-    findings: [
-      {
-        source: "adversarial-review" as const,
-        severity: "error" as const,
-        category: "error-path",
-        file: "src/auth/login.ts",
-        line: 42,
-        message: "Null pointer dereference on empty input",
-      },
-      {
-        source: "adversarial-review" as const,
-        severity: "warning" as const,
-        category: "convention",
-        file: "src/auth/session.ts",
-        message: "Missing storyId in logger call",
-      },
-    ],
-  };
+describe("AdversarialReviewPromptBuilder — priorAdversarialIterations", () => {
+  const PRIOR_ITERATIONS = [
+    {
+      iterationNum: 1,
+      findingsBefore: [],
+      fixesApplied: [{ strategyName: "source-fix", op: "source-fix", targetFiles: ["src/auth/login.ts"], summary: "", costUsd: 0 }],
+      findingsAfter: [
+        {
+          source: "adversarial-review" as const,
+          severity: "error" as const,
+          category: "error-path",
+          file: "src/auth/login.ts",
+          line: 42,
+          message: "Null pointer dereference on empty input",
+        },
+        {
+          source: "adversarial-review" as const,
+          severity: "warning" as const,
+          category: "convention",
+          file: "src/auth/session.ts",
+          message: "Missing storyId in logger call",
+        },
+      ],
+      outcome: "partial" as const,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:01:00.000Z",
+    },
+  ];
 
-  test("prior findings block appears when priorAdversarialFindings is set", () => {
+  test("prior iterations block appears when priorAdversarialIterations is set", () => {
     const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
       mode: "ref",
       storyGitRef: STORY_GIT_REF,
-      priorAdversarialFindings: PRIOR_FINDINGS,
+      priorAdversarialIterations: PRIOR_ITERATIONS,
     });
-    expect(result).toContain("Prior Adversarial Findings — Round 1");
+    expect(result).toContain("## Prior Iterations — verdict required before new analysis");
   });
 
-  test("prior findings block contains the correct round number", () => {
+  test("prior iterations block contains the iteration number", () => {
     const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
       mode: "ref",
       storyGitRef: STORY_GIT_REF,
-      priorAdversarialFindings: { round: 3, findings: PRIOR_FINDINGS.findings },
+      priorAdversarialIterations: PRIOR_ITERATIONS,
     });
-    expect(result).toContain("Round 3");
+    expect(result).toContain("| 1 |");
   });
 
-  test("prior findings block contains finding severity, file:line, category, and issue", () => {
+  test("prior iterations block contains strategy name and outcome", () => {
     const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
       mode: "ref",
       storyGitRef: STORY_GIT_REF,
-      priorAdversarialFindings: PRIOR_FINDINGS,
+      priorAdversarialIterations: PRIOR_ITERATIONS,
     });
-    expect(result).toContain("src/auth/login.ts:42");
-    expect(result).toContain("Null pointer dereference on empty input");
-    expect(result).toContain("error-path");
-    expect(result).toContain("src/auth/session.ts");
-    expect(result).toContain("Missing storyId in logger call");
+    expect(result).toContain("source-fix");
+    expect(result).toContain("partial");
   });
 
-  test("prior findings block appears before the story block (verdict-first)", () => {
+  test("prior iterations block contains finding count summary", () => {
     const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
       mode: "ref",
       storyGitRef: STORY_GIT_REF,
-      priorAdversarialFindings: PRIOR_FINDINGS,
+      priorAdversarialIterations: PRIOR_ITERATIONS,
     });
-    const priorFindingsIdx = result.indexOf("Prior Adversarial Findings");
+    // findingsBefore is empty (0), findingsAfter has 2 findings
+    expect(result).toContain("0 →");
+    expect(result).toContain("2 [");
+  });
+
+  test("prior iterations block appears before the story block (verdict-first)", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      priorAdversarialIterations: PRIOR_ITERATIONS,
+    });
+    const priorIdx = result.indexOf("## Prior Iterations");
     const storyIdx = result.indexOf("## Story Under Review");
-    expect(priorFindingsIdx).toBeGreaterThanOrEqual(0);
-    expect(priorFindingsIdx).toBeLessThan(storyIdx);
+    expect(priorIdx).toBeGreaterThanOrEqual(0);
+    expect(priorIdx).toBeLessThan(storyIdx);
   });
 
-  test("prior findings block instructs reviewer to verdict prior issues first", () => {
-    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
-      mode: "ref",
-      storyGitRef: STORY_GIT_REF,
-      priorAdversarialFindings: PRIOR_FINDINGS,
-    });
-    expect(result).toContain("Verdict on each of these first");
-  });
-
-  test("finding with no line number renders file path without colon-line suffix", () => {
-    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
-      mode: "ref",
-      storyGitRef: STORY_GIT_REF,
-      priorAdversarialFindings: {
-        round: 1,
-        findings: [
-              {
-                source: "adversarial-review" as const,
-                severity: "warning" as const,
-                category: "",
-                file: "src/utils.ts",
-                message: "Unhandled promise rejection",
-              },
-            ],
-      },
-    });
-    expect(result).toContain("src/utils.ts");
-    // Location cell should be "src/utils.ts" without a trailing colon+line
-    const tableRowIdx = result.indexOf("Unhandled promise rejection");
-    const rowText = result.slice(result.lastIndexOf("|", tableRowIdx), tableRowIdx + 30);
-    expect(rowText).not.toMatch(/src\/utils\.ts:\d/);
-  });
-
-  test("no prior findings block when priorAdversarialFindings is undefined", () => {
+  test("no prior iterations block when priorAdversarialIterations is undefined", () => {
     const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
       mode: "ref",
       storyGitRef: STORY_GIT_REF,
     });
-    expect(result).not.toContain("Prior Adversarial Findings");
+    expect(result).not.toContain("## Prior Iterations");
   });
 
-  test("no prior findings block when findings array is empty", () => {
+  test("no prior iterations block when priorAdversarialIterations is empty array", () => {
     const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
       mode: "ref",
       storyGitRef: STORY_GIT_REF,
-      priorAdversarialFindings: { round: 1, findings: [] },
+      priorAdversarialIterations: [],
     });
-    expect(result).not.toContain("Prior Adversarial Findings");
+    expect(result).not.toContain("## Prior Iterations");
+  });
+
+  test("unchanged outcome note appears when an iteration outcome is unchanged", () => {
+    const unchangedIteration = {
+      ...PRIOR_ITERATIONS[0],
+      outcome: "unchanged" as const,
+    };
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      priorAdversarialIterations: [unchangedIteration],
+    });
+    expect(result).toContain("FALSIFIED");
   });
 });

--- a/test/unit/prompts/builders/prior-iterations-builder.test.ts
+++ b/test/unit/prompts/builders/prior-iterations-builder.test.ts
@@ -165,6 +165,21 @@ describe("buildPriorIterationsBlock — multiple iterations", () => {
     expect(output).toContain("| 1 | lint-fix | - |");
   });
 
+  test("empty fixesApplied (carry-forward iteration) shows dash in both strategy and files columns", () => {
+    // Adversarial carry-forward iterations have fixesApplied: [] because fixes run
+    // in the implementation session outside the FixCycle.
+    const iter = makeIteration({
+      iterationNum: 1,
+      outcome: "partial",
+      findingsBefore: [],
+      findingsAfter: [makeFinding({ source: "adversarial-review", message: "null dereference" })],
+      fixesApplied: [],
+    });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain("| 1 | - | - | partial |");
+  });
+
   test("most-frequent category shown when findings have mixed categories", () => {
     const f1 = makeFinding({ source: "lint", message: "a", category: "unused-var" });
     const f2 = makeFinding({ source: "lint", message: "b", category: "unused-var" });


### PR DESCRIPTION
## Summary

- Deletes `AdversarialFindingsCache { round: number; findings: Finding[] }` from `src/review/types.ts` — this legacy carry-forward type is superseded by ADR-022's `Iteration<Finding>[]`
- Replaces `priorAdversarialFindings?: AdversarialFindingsCache` with `priorAdversarialIterations?: Iteration[]` across `adversarial.ts`, `runner.ts`, `orchestrator.ts`, `operations/adversarial-review.ts`, and `pipeline/types.ts`
- Removes local `buildPriorFindingsBlock` from `adversarial-review-builder.ts`; the shared `buildPriorIterationsBlock` (introduced in phase 3) replaces it — producing the unified "Prior Iterations" verdict-first table instead of the old "Prior Adversarial Findings — Round N" table
- Orchestrator constructs `Iteration` records with `classifyOutcome()` — `findingsBefore` is derived from the prior round's `findingsAfter`, `fixesApplied` is empty (fixes run outside the adversarial subsystem), `outcome` reflects actual change
- Updates both test files (`adversarial-review-builder.test.ts`, `adversarial-review.test.ts`) to use `Iteration[]` fixtures and assert against the new table format

## Test Plan

- [x] `test/unit/prompts/adversarial-review-builder.test.ts` — 31 tests pass; rewrote the `priorAdversarialFindings` describe block as `priorAdversarialIterations` with new assertions for table header, iterationNum, strategy, outcome, finding counts, and empty-array guard
- [x] `test/unit/operations/adversarial-review.test.ts` — 17 tests pass; updated two tests to pass `priorAdversarialIterations` and assert against "Prior Iterations" header
- [x] Full suite: 1194 pass, 0 fail
- [x] Typecheck clean
- [x] Lint clean