### PR TITLE
feat(findings): semantic migration — Iteration[] replaces PriorFailure[] (ADR-022 phase 6)

### DIFF
--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -1,16 +1,16 @@
 import type { TurnResult } from "../agents/types";
 import { reviewConfigSelector } from "../config";
 import type { ReviewConfig } from "../config/selectors";
+import type { Iteration } from "../findings";
 import { getSafeLogger } from "../logger";
 import { ReviewPromptBuilder } from "../prompts";
-import type { PriorFailure } from "../prompts";
 import { looksLikeTruncatedJson } from "../review/truncation";
 import type { SemanticReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { HopBody, LlmReviewFinding, LlmReviewOutput, RunOperation } from "./types";
 import { parseLlmReviewShape } from "./types";
 
-export type { PriorFailure, SemanticReviewConfig, SemanticStory };
+export type { SemanticReviewConfig, SemanticStory };
 
 export interface SemanticReviewInput {
   story: SemanticStory;
@@ -19,7 +19,7 @@ export interface SemanticReviewInput {
   diff?: string;
   storyGitRef?: string;
   stat?: string;
-  priorFailures?: PriorFailure[];
+  priorSemanticIterations?: Iteration[];
   excludePatterns?: string[];
   /** Pre-built, role-filtered context prefix to prepend to the review prompt. */
   featureCtxBlock?: string;
@@ -85,7 +85,7 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
       diff: input.diff,
       storyGitRef: input.storyGitRef,
       stat: input.stat,
-      priorFailures: input.priorFailures,
+      priorSemanticIterations: input.priorSemanticIterations,
       excludePatterns: input.excludePatterns,
     });
     const content = input.featureCtxBlock ? `${input.featureCtxBlock}${base}` : base;

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -244,6 +244,11 @@ export interface PipelineContext extends DispatchContext {
    * buildPriorIterationsBlock so the reviewer sees prior-round findings verdict-first.
    */
   priorAdversarialIterations?: Iteration[];
+  /**
+   * Carry-forward iteration history for semantic review rounds (ADR-022 phase 6).
+   * Mirrors priorAdversarialIterations: appended on failure, cleared on pass.
+   */
+  priorSemanticIterations?: Iteration[];
 }
 
 /**

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -9,8 +9,10 @@
  * src/prompts, so importing semantic.ts here would form a cycle.
  */
 
+import type { Iteration } from "../../findings";
 import type { SemanticReviewConfig, SemanticStory } from "../../review/types";
 import { wrapJsonPrompt } from "../../utils/llm-json";
+import { buildPriorIterationsBlock } from "./prior-iterations-builder";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -61,7 +63,7 @@ If all ACs are correctly implemented, respond with { "passed": true, "findings":
 
 // ─── Options ──────────────────────────────────────────────────────────────────
 
-/** Prior failure entry for attempt context */
+/** Prior failure entry used by the adversarial attempt context block. */
 export interface PriorFailure {
   stage: string;
   modelTier: string;
@@ -77,8 +79,8 @@ export interface SemanticReviewPromptOptions {
   storyGitRef?: string;
   /** Git diff --stat output (used when mode = "ref") */
   stat?: string;
-  /** Prior failure context for attempt awareness */
-  priorFailures?: PriorFailure[];
+  /** Prior semantic review iterations for carry-forward context (ADR-022 phase 6). */
+  priorSemanticIterations?: Iteration[];
   /** Exclude patterns for the self-serve diff command (mode = "ref") */
   excludePatterns?: string[];
 }
@@ -105,7 +107,7 @@ export class ReviewPromptBuilder {
       semanticConfig.rules.length > 0
         ? `\n## Additional Review Rules\n${semanticConfig.rules.map((r, i) => `${i + 1}. ${r}`).join("\n")}\n`
         : "";
-    const attemptContextBlock = buildAttemptContextBlock(options.priorFailures);
+    const priorIterationsBlock = buildPriorIterationsBlock(options.priorSemanticIterations ?? []);
 
     let diffSection: string;
     if (options.mode === "ref") {
@@ -123,7 +125,7 @@ ${story.description}
 
 ### Acceptance Criteria
 ${acList}
-${customRulesBlock}${attemptContextBlock}${diffSection}
+${customRulesBlock}${priorIterationsBlock}${diffSection}
 ${SEMANTIC_INSTRUCTIONS}
 ${SEMANTIC_OUTPUT_SCHEMA}`;
 

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -240,12 +240,14 @@ export class ReviewOrchestrator {
         featureName,
         resolverSession,
         priorFailures,
+        priorSemanticIterations,
         featureContextMarkdown,
         contextBundles,
         projectDir,
         env,
         naxIgnoreIndex,
         runtime,
+        priorAdversarialIterations,
       });
     } else {
       // Split checks into ordered mechanical + LLM groups.

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -145,6 +145,7 @@ export interface OrchestratorReviewOptions {
   featureName?: string;
   resolverSession?: import("./dialogue").ReviewerSession;
   priorFailures?: Array<{ stage: string; modelTier: string }>;
+  priorSemanticIterations?: Iteration[];
   featureContextMarkdown?: string;
   contextBundles?: { semantic?: ContextBundle; adversarial?: ContextBundle };
   projectDir?: string;
@@ -173,6 +174,7 @@ export class ReviewOrchestrator {
       featureName,
       resolverSession,
       priorFailures,
+      priorSemanticIterations,
       featureContextMarkdown,
       contextBundles,
       projectDir,
@@ -337,7 +339,7 @@ export class ReviewOrchestrator {
             naxConfig,
             featureName,
             resolverSession,
-            priorFailures,
+            priorSemanticIterations,
             blockingThreshold: reviewConfig.blockingThreshold,
             featureContextMarkdown,
             contextBundle: contextBundles?.semantic,
@@ -382,6 +384,7 @@ export class ReviewOrchestrator {
           featureName,
           resolverSession,
           priorFailures,
+          priorSemanticIterations,
           featureContextMarkdown,
           contextBundles,
           projectDir,
@@ -575,6 +578,7 @@ export class ReviewOrchestrator {
       featureName: ctx.prd.feature,
       resolverSession,
       priorFailures: ctx.story.priorFailures,
+      priorSemanticIterations: ctx.priorSemanticIterations,
       featureContextMarkdown: ctx.featureContextMarkdown,
       contextBundles,
       projectDir: ctx.projectDir,
@@ -616,6 +620,33 @@ export class ReviewOrchestrator {
       // Adversarial was skipped because it passed in the previous review pass.
       // Clear any stale iteration history — the reviewer already approved this code.
       ctx.priorAdversarialIterations = undefined;
+    }
+
+    // Update ctx.priorSemanticIterations for the next review round (ADR-022 phase 6).
+    // Mirrors the adversarial carry-forward pattern: append on failure, clear on pass.
+    // fixesApplied is always [] — semantic fixes run in the implementation session.
+    const semCheck = result.builtIn.checks?.find((c) => c.check === "semantic");
+    if (semCheck) {
+      if (!semCheck.success && !semCheck.skipped) {
+        const prior = ctx.priorSemanticIterations ?? [];
+        const findingsBefore = prior.length > 0 ? (prior[prior.length - 1].findingsAfter ?? []) : [];
+        const findingsAfter = semCheck.findings ?? [];
+        const now = new Date().toISOString();
+        const newIteration: Iteration = {
+          iterationNum: prior.length + 1,
+          findingsBefore,
+          fixesApplied: [],
+          findingsAfter,
+          outcome: classifyOutcome(findingsBefore, findingsAfter),
+          startedAt: now,
+          finishedAt: now,
+        };
+        ctx.priorSemanticIterations = [...prior, newIteration];
+      } else if (semCheck.success && !semCheck.skipped) {
+        ctx.priorSemanticIterations = undefined;
+      }
+    } else if (retrySkipChecks?.has("semantic")) {
+      ctx.priorSemanticIterations = undefined;
     }
 
     return result;

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -35,6 +35,7 @@ export interface RunReviewOptions {
   featureName?: string;
   resolverSession?: import("./dialogue").ReviewerSession;
   priorFailures?: Array<{ stage: string; modelTier: string }>;
+  priorSemanticIterations?: Iteration[];
   featureContextMarkdown?: string;
   contextBundles?: {
     semantic?: import("../context/engine").ContextBundle;
@@ -245,6 +246,7 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
     featureName,
     resolverSession,
     priorFailures,
+    priorSemanticIterations,
     featureContextMarkdown,
     contextBundles,
     projectDir,
@@ -339,7 +341,7 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
         naxConfig,
         featureName,
         resolverSession,
-        priorFailures,
+        priorSemanticIterations,
         blockingThreshold: config.blockingThreshold,
         featureContextMarkdown,
         contextBundle: contextBundles?.semantic,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -16,6 +16,7 @@ import { filterContextByRole } from "../context";
 import { DebateRunner } from "../debate";
 import type { DebateRunnerOptions } from "../debate";
 import { NaxError } from "../errors";
+import type { Iteration } from "../findings";
 import { getSafeLogger } from "../logger";
 import { callOp as _callOp } from "../operations/call";
 import { semanticReviewOp } from "../operations/semantic-review";
@@ -85,7 +86,7 @@ export interface RunSemanticReviewOptions {
   naxConfig?: ReviewConfig;
   featureName?: string;
   resolverSession?: import("./dialogue").ReviewerSession;
-  priorSemanticIterations?: import("../findings").Iteration[];
+  priorSemanticIterations?: Iteration[];
   blockingThreshold?: "error" | "warning" | "info";
   featureContextMarkdown?: string;
   contextBundle?: import("../context/engine").ContextBundle;

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -85,7 +85,7 @@ export interface RunSemanticReviewOptions {
   naxConfig?: ReviewConfig;
   featureName?: string;
   resolverSession?: import("./dialogue").ReviewerSession;
-  priorFailures?: Array<{ stage: string; modelTier: string }>;
+  priorSemanticIterations?: import("../findings").Iteration[];
   blockingThreshold?: "error" | "warning" | "info";
   featureContextMarkdown?: string;
   contextBundle?: import("../context/engine").ContextBundle;
@@ -107,7 +107,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     naxConfig,
     featureName,
     resolverSession,
-    priorFailures,
+    priorSemanticIterations,
     blockingThreshold,
     featureContextMarkdown,
     contextBundle,
@@ -236,7 +236,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     diff,
     storyGitRef: effectiveRef,
     stat,
-    priorFailures,
+    priorSemanticIterations,
     excludePatterns: semanticConfig.excludePatterns,
   });
   const prompt = featureCtxBlock ? `${featureCtxBlock}${basePrompt}` : basePrompt;
@@ -315,7 +315,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       diff,
       storyGitRef: effectiveRef,
       stat,
-      priorFailures,
+      priorSemanticIterations,
       excludePatterns,
       featureCtxBlock,
       blockingThreshold,

--- a/test/unit/operations/semantic-review.test.ts
+++ b/test/unit/operations/semantic-review.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { Iteration } from "../../../src/findings";
 import { makeTestRuntime } from "../../helpers";
 import type { SemanticReviewInput } from "../../../src/operations/semantic-review";
 import { semanticReviewOp } from "../../../src/operations/semantic-review";
@@ -76,6 +77,37 @@ describe("semanticReviewOp.build()", () => {
     const embeddedInput: SemanticReviewInput = { ...SAMPLE_INPUT, mode: "embedded", diff: "+const x = 1;" };
     const result = semanticReviewOp.build(embeddedInput, ctx);
     expect(result.task.content).toContain("+const x = 1;");
+  });
+});
+
+describe("semanticReviewOp.build() — priorSemanticIterations", () => {
+  test("includes prior iterations block when priorSemanticIterations has entries", () => {
+    const ctx = makeBuildCtx();
+    const iteration: Iteration = {
+      iterationNum: 1,
+      findingsBefore: [],
+      fixesApplied: [],
+      findingsAfter: [
+        { source: "semantic-review", message: "handler not wired", severity: "error", category: "ac-coverage" },
+      ],
+      outcome: "partial",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:01.000Z",
+    };
+    const inputWithIterations: SemanticReviewInput = {
+      ...SAMPLE_INPUT,
+      priorSemanticIterations: [iteration],
+    };
+    const result = semanticReviewOp.build(inputWithIterations, ctx);
+    expect(result.task.content).toContain("## Prior Iterations — verdict required before new analysis");
+    expect(result.task.content).toContain("| 1 |");
+    expect(result.task.content).toContain("partial");
+  });
+
+  test("omits prior iterations block when priorSemanticIterations is undefined", () => {
+    const ctx = makeBuildCtx();
+    const result = semanticReviewOp.build(SAMPLE_INPUT, ctx);
+    expect(result.task.content).not.toContain("## Prior Iterations");
   });
 });
 

--- a/test/unit/prompts/review-builder.test.ts
+++ b/test/unit/prompts/review-builder.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import type { Iteration } from "../../../src/findings";
 import { ReviewPromptBuilder } from "../../../src/prompts";
 import type { SemanticReviewConfig, SemanticStory } from "../../../src/review/types";
 
@@ -131,6 +132,48 @@ describe("ReviewPromptBuilder.buildSemanticReviewPrompt()", () => {
       expect(result).toMatch(/observed.*(verbatim|copy-pasted|exact)/i);
       expect(result).toContain("not a description");
     });
+  });
+});
+
+describe("ReviewPromptBuilder.buildSemanticReviewPrompt() — priorSemanticIterations", () => {
+  const builder = new ReviewPromptBuilder();
+
+  test("omits prior iterations block when priorSemanticIterations is undefined", () => {
+    const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
+    expect(result).not.toContain("## Prior Iterations");
+  });
+
+  test("omits prior iterations block when priorSemanticIterations is empty array", () => {
+    const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, {
+      mode: "embedded",
+      diff: DIFF,
+      priorSemanticIterations: [],
+    });
+    expect(result).not.toContain("## Prior Iterations");
+  });
+
+  test("includes prior iterations table when priorSemanticIterations has entries", () => {
+    const iteration: Iteration = {
+      iterationNum: 1,
+      findingsBefore: [],
+      fixesApplied: [],
+      findingsAfter: [
+        { source: "semantic-review", message: "AC 2 not wired", severity: "error", category: "ac-coverage" },
+      ],
+      outcome: "partial",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:01.000Z",
+    };
+    const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, {
+      mode: "embedded",
+      diff: DIFF,
+      priorSemanticIterations: [iteration],
+    });
+    expect(result).toContain("## Prior Iterations — verdict required before new analysis");
+    expect(result).toContain("| 1 |");
+    expect(result).toContain("partial");
+    expect(result).toContain("0 →");
+    expect(result).toContain("1 [ac-coverage]");
   });
 });
 


### PR DESCRIPTION
## Summary

- Replaces `PriorFailure[]` / `buildAttemptContextBlock` in the **semantic** review prompt with `Iteration[]` / `buildPriorIterationsBlock` — the same verdict-first table introduced for adversarial in phase 5
- Adds `priorSemanticIterations` carry-forward tracking in `reviewFromContext()` (mirrors the adversarial pattern: append on failure, clear on pass)
- Threads `priorSemanticIterations` through `runner.ts → orchestrator.ts → semantic.ts → semanticReviewOp`
- Adds `priorSemanticIterations?: Iteration[]` to `PipelineContext`
- `PriorFailure` and `buildAttemptContextBlock` are **kept** — adversarial still uses them for escalation-attempt context

## Test Plan

- [ ] `bun run test` — all phases pass (1234 tests, 0 fail)
- [ ] `bun run lint` — no issues
- [ ] `bun run typecheck` — clean
- [ ] New tests in `review-builder.test.ts`: omit block when empty, include table when entries present
- [ ] New tests in `semantic-review.test.ts`: `priorSemanticIterations` threaded through op build