### PR TITLE
[codex] Fix TDD verifier role boundary

### DIFF
--- a/docs/specs/2026-05-03-adr-022-phase7-post-verification.md
+++ b/docs/specs/2026-05-03-adr-022-phase7-post-verification.md
@@ -1,0 +1,110 @@
+# ADR-022 Phase 7 Post-Verification — TDD Verifier Boundary
+
+**Date:** 2026-05-03
+**Status:** Companion verification note for in-progress ADR-022 phase 7
+**Scope:** `quality.autofix.cycleV2` migration, specifically `tdd-verifier` findings and verdict handling
+**Parent plan:** [2026-05-02-adr-022-implementation-plan.md §9](./2026-05-02-adr-022-implementation-plan.md#9-phase-7--autofix-migration)
+
+---
+
+## 1. Background
+
+During phase 7 migration, the TDD verifier prompt/audit surfaced semantic-review-style critical findings:
+
+- Missing Prisma schema models
+- Acceptance criteria not met
+- Hash comparison correctness issues
+- Broad role-enforcement and code-quality concerns
+
+The same run log reported:
+
+- `Isolation maintained with warnings`
+- `Three-session TDD complete`
+- `success: true`
+- `verdictAvailable: false`
+
+This mismatch exposed a role-boundary bug: the verifier was being prompted and categorized like a semantic reviewer while the orchestrator log still treated the role as TDD isolation/integrity verification.
+
+## 2. Root Cause
+
+Two issues caused the overlap:
+
+1. **Prompt role drift**
+
+   The verifier prompt asked the agent to verify acceptance criteria, broad code quality, and implementation correctness. Those responsibilities belong to semantic/adversarial review, not the third TDD session.
+
+2. **Context leak**
+
+   `runTddSessionOp()` set `includeContext = false` for the verifier, but still passed `constitution` and v2 `ContextBundle` through to `runTddSession()`. This allowed the verifier to receive broad feature/constitution context even though the role was intended to be narrow.
+
+## 3. Correct Verifier Scope
+
+For ADR-022 phase 7, `tdd-verifier` findings must be limited to TDD integrity:
+
+- story-scoped tests fail
+- implementer loosened, deleted, or bypassed test assertions
+- implementer made illegitimate test-file modifications
+- isolation or handoff integrity failed
+
+The verifier must not be a blocking source for:
+
+- acceptance criteria completeness
+- implementation architecture
+- general code quality
+- security concerns unless they are directly expressed as test tampering or scoped-test failure
+
+Those findings belong to semantic/adversarial review producers and their phase 7 autofix strategy routing.
+
+## 4. Phase 7 Migration Checks
+
+Before merging phase 7, verify these invariants:
+
+- `tdd-verifier` strategy selectors only match TDD integrity findings.
+- `tdd-verifier` does not route AC/quality advisory fields into blocking autofix findings.
+- `approved: false` verifier verdicts block only when tests fail or test modifications are illegitimate.
+- AC/quality fields in `.nax-verifier-verdict.json` are treated as advisory or ignored for TDD failure categorization.
+- Verifier prompt inputs exclude `constitution`, legacy feature context, and v2 push/pull context.
+- Verifier may write `.nax-verifier-verdict.json`; it must not apply source/test fixes.
+- Shadow-mode reports distinguish `tdd-verifier` integrity findings from semantic/adversarial findings.
+
+## 5. Recommended Tests
+
+Add or keep regression coverage for:
+
+- verifier prompt input boundary: no `constitution`, no legacy feature context, no v2 `ContextBundle`
+- verifier prompt wording: TDD handoff integrity, not semantic acceptance review
+- verdict categorization:
+  - failing tests -> `tests-failing`
+  - illegitimate test modifications -> `verifier-rejected`
+  - AC not met only -> advisory success
+  - poor quality only -> advisory success
+- phase 7 strategy routing:
+  - `tdd-verifier` integrity finding routes to verifier/autofix handling
+  - semantic AC finding routes through semantic/adversarial autofix handling, not verifier
+
+## 6. Post-Migration Audit
+
+After phase 7 lands, inspect prompt audit and cycle shadow output for at least one three-session TDD story:
+
+- prompt audit file matching `*-verifier-run-*.txt`
+- `.nax-verifier-verdict.json` before cleanup, when available
+- `.nax/cycle-shadow/<storyId>/<timestamp>.json`
+- TDD logs around `Isolation maintained`, `Verifier verdict`, and `Three-session TDD complete`
+
+Expected outcome:
+
+- verifier prompt is narrow and does not include constitution or broad feature context
+- verifier verdict cannot reject solely on semantic AC/quality findings
+- cycle shadow uses fresh validator findings and does not replay stale verifier output
+- semantic/adversarial findings remain the source of broad correctness and quality fixes
+
+## 7. Rollback Guidance
+
+If phase 7 produces verifier/semantic overlap again:
+
+1. Keep `quality.autofix.cycleV2` default off.
+2. Preserve legacy autofix behavior.
+3. Compare shadow reports for `tdd-verifier` versus semantic/adversarial routing.
+4. Fix the finding-source mapping before enabling the flag.
+
+Do not widen verifier context or restore AC/quality blocking in verdict categorization as a rollback shortcut.

--- a/src/prompts/sections/isolation.ts
+++ b/src/prompts/sections/isolation.ts
@@ -72,7 +72,7 @@ export function buildIsolationSection(
   }
 
   if (role === "verifier") {
-    return `${header}\n\nisolation scope: Read-only inspection. Review all test results, implementation code, and acceptance criteria compliance. You MAY write a verdict file (.nax-verifier-verdict.json) and apply legitimate fixes if needed.${footer}`;
+    return `${header}\n\nisolation scope: Read-only TDD integrity inspection. Review story-scoped test results and test-file modifications. Do NOT apply source or test fixes. You MAY write only the verdict file (.nax-verifier-verdict.json).${footer}`;
   }
 
   if (role === "single-session") {

--- a/src/prompts/sections/role-task.ts
+++ b/src/prompts/sections/role-task.ts
@@ -131,17 +131,18 @@ Instructions:
   if (role === "verifier") {
     return `# Role: Verifier
 
-Your task: Review and verify the implementation against acceptance criteria.
+Your task: verify the TDD handoff integrity for this story.
 
-Context: You are the final session in a multi-session workflow. A test-writer created tests, and an implementer wrote the code. The orchestrator has already run the full test suite and confirmed it passes before handing off to you.
+Context: You are the final session in a multi-session workflow. A test-writer created tests, and an implementer wrote the code. The orchestrator has already attempted the full-suite gate before handing off to you; it may have passed, failed, or exhausted rectification.
 
 Instructions:
 - Run ONLY the story's scoped test files — do NOT run the full test suite (the orchestrator already handled that)
-- Check that implementation meets all acceptance criteria from the story
-- Inspect code quality, error handling, and edge cases
+- Confirm the story-scoped tests pass
+- Check whether the implementer modified test files after the test-writer phase
 - Verify any test modifications (if any) are legitimate fixes, not shortcuts
+- Do NOT perform semantic acceptance review; semantic/adversarial review stages own acceptance criteria and broad code-quality findings
 - Write a detailed verdict with reasoning
-- Goal: verify story-scoped tests pass, provide comprehensive code review and quality assurance`;
+- Goal: verify story-scoped tests pass and test integrity was preserved`;
   }
 
   if (role === "single-session") {

--- a/src/prompts/sections/verdict.ts
+++ b/src/prompts/sections/verdict.ts
@@ -17,16 +17,13 @@ After completing your verification, you **MUST** write a verdict file at the **p
 **File:** \`.nax-verifier-verdict.json\`
 
 Set \`approved: true\` when ALL of these conditions are met:
-- All story-scoped tests pass (the orchestrator already confirmed the full suite passes — you only need to verify the story's own tests)
-- Implementation is clean and follows conventions
-- All acceptance criteria met
+- All story-scoped tests pass (the orchestrator already attempted the full-suite gate — you only need to verify the story's own tests)
 - Any test modifications by implementer are legitimate fixes
 
 Set \`approved: false\` when ANY of these conditions are true:
 - Tests are failing and you cannot fix them
 - The implementer loosened test assertions to mask bugs
-- Critical acceptance criteria are not met
-- Code quality is poor (security issues, severe bugs, etc.)
+- The implementer made illegitimate test changes
 
 **JSON schema** (fill in all fields with real values):
 
@@ -37,8 +34,9 @@ Set \`approved: false\` when ANY of these conditions are true:
 **Field notes:**
 - \`quality.rating\` must be one of: \`"good"\`, \`"acceptable"\`, \`"poor"\`
 - \`testModifications.files\` — list any test files the implementer changed
-- \`fixes\` — list any fixes you applied yourself during this verification session
+- \`acceptanceCriteria\` and \`quality\` are advisory in this TDD verifier verdict; do not use them to reject semantic correctness
+- \`fixes\` — keep this empty; the verifier must not apply code or test fixes
 - \`reasoning\` — brief summary of your overall assessment
 
-When done, commit any fixes with message: "fix: verify and adjust ${story.title}"`;
+When done, do not commit code changes. Only write the verdict file.`;
 }

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -296,7 +296,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     const categorization = categorizeVerdict(verdict, verdict.tests.allPassing);
 
     if (categorization.success) {
-      logger.info("tdd", "[OK] Verifier verdict: approved", {
+      logger.info("tdd", "[OK] Verifier verdict: accepted", {
         storyId: story.id,
         verdictApproved: verdict.approved,
         testsAllPassing: verdict.tests.allPassing,

--- a/src/tdd/session-op.ts
+++ b/src/tdd/session-op.ts
@@ -100,6 +100,8 @@ export async function runTddSessionOp(
     ? buildInteractionBridge(interactionChain, { featureName, storyId: story.id, stage: "execution" })
     : undefined;
 
+  const verifierLimitedContext = role === "verifier";
+
   return runTddSession(
     role,
     agent,
@@ -112,12 +114,12 @@ export async function runTddSessionOp(
     includeContext ? contextMarkdown : undefined,
     lite,
     skipIsolation,
-    constitution,
+    verifierLimitedContext ? undefined : constitution,
     featureName,
     interactionBridge,
     projectDir,
     includeContext ? featureContextMarkdown : undefined,
-    contextBundle,
+    verifierLimitedContext ? undefined : contextBundle,
     sessionBinding,
     abortSignal,
   );

--- a/src/tdd/verdict.ts
+++ b/src/tdd/verdict.ts
@@ -88,9 +88,8 @@ export interface VerdictCategorization {
  * - verdict.approved = true → success
  * - Not approved, illegitimate test mods → verifier-rejected
  * - Not approved, tests failing → tests-failing
- * - Not approved, criteria not met → verifier-rejected
- * - Not approved, poor quality → verifier-rejected
- * - Not approved, other → verifier-rejected (catch-all)
+ * - Not approved for semantic AC/quality concerns only → success (advisory; semantic review owns these)
+ * - Not approved, other → success (advisory; verifier only blocks TDD integrity failures)
  * - null verdict, testsPass=true → success
  * - null verdict, testsPass=false → tests-failing
  */
@@ -127,26 +126,5 @@ export function categorizeVerdict(verdict: VerifierVerdict | null, testsPass: bo
     };
   }
 
-  if (!verdict.acceptanceCriteria.allMet) {
-    const unmet = verdict.acceptanceCriteria.criteria.filter((c) => !c.met).map((c) => c.criterion);
-    return {
-      success: false,
-      failureCategory: "verifier-rejected",
-      reviewReason: `Acceptance criteria not met: ${unmet.join("; ")}`,
-    };
-  }
-
-  if (verdict.quality.rating === "poor") {
-    return {
-      success: false,
-      failureCategory: "verifier-rejected",
-      reviewReason: `Poor code quality: ${verdict.quality.issues.join("; ")}`,
-    };
-  }
-
-  return {
-    success: false,
-    failureCategory: "verifier-rejected",
-    reviewReason: verdict.reasoning || "Verifier rejected without specific reason",
-  };
+  return { success: true };
 }

--- a/test/integration/tdd/tdd-orchestrator-verdict.test.ts
+++ b/test/integration/tdd/tdd-orchestrator-verdict.test.ts
@@ -245,7 +245,7 @@ describe("runThreeSessionTdd — T9: verdict integration", () => {
     expect(result.reviewReason).toContain("illegitimate test modifications");
   });
 
-  test("verdict approved=false + criteria not met → failureCategory='verifier-rejected'", async () => {
+  test("verdict approved=false + criteria not met only → advisory success", async () => {
     await writeVerdictToDir({ approved: false, failReason: "criteria-not-met" });
     mockGitAndTestForT9({});
 
@@ -264,9 +264,33 @@ describe("runThreeSessionTdd — T9: verdict integration", () => {
       modelTier: "balanced",
     });
 
-    expect(result.success).toBe(false);
-    expect(result.failureCategory).toBe("verifier-rejected");
-    expect(result.reviewReason).toContain("Must work");
+    expect(result.success).toBe(true);
+    expect(result.failureCategory).toBeUndefined();
+    expect(result.reviewReason).toBeUndefined();
+  });
+
+  test("verdict approved=false + poor quality only → advisory success", async () => {
+    await writeVerdictToDir({ approved: false, failReason: "poor-quality" });
+    mockGitAndTestForT9({});
+
+    const agent = createMockAgent([
+      { success: true, estimatedCostUsd: 0.01 },
+      { success: true, estimatedCostUsd: 0.02 },
+      { success: true, estimatedCostUsd: 0.01 },
+    ]);
+
+    const result = await runThreeSessionTdd({
+      agent,
+      agentManager: fakeAgentManager(agent),
+      story,
+      config: DEFAULT_CONFIG,
+      workdir: tmpDir,
+      modelTier: "balanced",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.failureCategory).toBeUndefined();
+    expect(result.reviewReason).toBeUndefined();
   });
 
   test("no verdict file → fallback: post-TDD test check is run on session failures", async () => {

--- a/test/unit/prompts/sections/role-task.test.ts
+++ b/test/unit/prompts/sections/role-task.test.ts
@@ -83,6 +83,19 @@ describe("buildRoleTaskSection — verifier role", () => {
     const result = buildRoleTaskSection("verifier");
     expect(result).not.toContain("Write tests first");
   });
+
+  test("keeps semantic acceptance review out of verifier role", () => {
+    const result = buildRoleTaskSection("verifier");
+    expect(result).toContain("TDD handoff integrity");
+    expect(result).toContain("Do NOT perform semantic acceptance review");
+  });
+
+  test("does not claim the full-suite gate already passed", () => {
+    const result = buildRoleTaskSection("verifier");
+    expect(result).toContain("attempted the full-suite gate");
+    expect(result).toContain("may have passed, failed, or exhausted rectification");
+    expect(result).not.toContain("confirmed it passes");
+  });
 });
 
 describe("buildRoleTaskSection — single-session role", () => {

--- a/test/unit/prompts/sections/sections.test.ts
+++ b/test/unit/prompts/sections/sections.test.ts
@@ -159,9 +159,9 @@ describe("buildVerdictSection", () => {
     expect(result).toContain('"poor"');
   });
 
-  test("includes commit instruction referencing the story title", () => {
+  test("instructs verifier not to commit code changes", () => {
     const result = buildVerdictSection(STORY);
-    expect(result).toContain(STORY.title);
+    expect(result).toContain("do not commit code changes");
   });
 
   test("is pure — same story returns same output", () => {

--- a/test/unit/prompts/sections/verdict.test.ts
+++ b/test/unit/prompts/sections/verdict.test.ts
@@ -50,4 +50,10 @@ describe("buildVerdictSection", () => {
     expect(result).toContain("Set `approved: true`");
     expect(result).toContain("Set `approved: false`");
   });
+
+  test("marks acceptance criteria and quality fields advisory", () => {
+    const result = buildVerdictSection(mockStory);
+    expect(result).toContain("advisory");
+    expect(result).toContain("do not use them to reject semantic correctness");
+  });
 });

--- a/test/unit/tdd/session-op.test.ts
+++ b/test/unit/tdd/session-op.test.ts
@@ -53,4 +53,39 @@ describe("runTddSessionOp", () => {
     expect(result.role).toBe("test-writer");
     expect(typeof result.success).toBe("boolean");
   });
+
+  test("limits verifier prompt inputs to TDD integrity context", async () => {
+    const config = makeNaxConfig({
+      quality: { commands: { test: "bun test" } },
+      tdd: { rollbackOnFailure: false },
+    });
+    const contextBundle = {
+      pushMarkdown: "## Broad Feature Context\nSemantic details",
+      pullTools: [{ name: "query_feature_context", description: "feature search" }],
+      digest: "digest",
+    };
+    const buildPrompt = _sessionRunnerDeps.buildPrompt as ReturnType<typeof mock>;
+
+    const result = await runTddSessionOp(
+      verifyTddOp,
+      {
+        agent: makeAgentAdapter(),
+        agentManager: fakeAgentManager(makeAgentAdapter()),
+        story: makeStory(),
+        config,
+        workdir: "/tmp/fake",
+        modelTier: "balanced" as const,
+        constitution: "constitution.md content",
+        featureContextMarkdown: "legacy feature context",
+        contextMarkdown: "legacy run context",
+      },
+      "HEAD",
+      contextBundle as never,
+    );
+
+    expect(result.role).toBe("verifier");
+    expect(buildPrompt.mock.calls[0]?.[4]).toBeUndefined(); // contextMarkdown
+    expect(buildPrompt.mock.calls[0]?.[6]).toBeUndefined(); // constitution
+    expect(buildPrompt.mock.calls[0]?.[7]).toBeUndefined(); // feature context / v2 pushMarkdown
+  });
 });

--- a/test/unit/verification/tdd-verdict.test.ts
+++ b/test/unit/verification/tdd-verdict.test.ts
@@ -440,9 +440,9 @@ describe("categorizeVerdict", () => {
     expect(result.reviewReason).toContain("3 failure(s)");
   });
 
-  // --- acceptance criteria not met ---
+  // --- advisory acceptance criteria / quality ---
 
-  test("acceptance criteria not met → verifier-rejected", () => {
+  test("acceptance criteria not met only → advisory success", () => {
     const verdict = makeVerdict({
       approved: false,
       tests: { allPassing: true, passCount: 10, failCount: 0 },
@@ -455,14 +455,12 @@ describe("categorizeVerdict", () => {
       },
     });
     const result = categorizeVerdict(verdict, true);
-    expect(result.success).toBe(false);
-    expect(result.failureCategory).toBe("verifier-rejected");
-    expect(result.reviewReason).toContain("Must validate input");
+    expect(result.success).toBe(true);
+    expect(result.failureCategory).toBeUndefined();
+    expect(result.reviewReason).toBeUndefined();
   });
 
-  // --- poor quality ---
-
-  test("poor quality → verifier-rejected", () => {
+  test("poor quality only → advisory success", () => {
     const verdict = makeVerdict({
       approved: false,
       tests: { allPassing: true, passCount: 10, failCount: 0 },
@@ -476,10 +474,9 @@ describe("categorizeVerdict", () => {
       },
     });
     const result = categorizeVerdict(verdict, true);
-    expect(result.success).toBe(false);
-    expect(result.failureCategory).toBe("verifier-rejected");
-    expect(result.reviewReason).toContain("SQL injection vulnerability");
-    expect(result.reviewReason).toContain("No error handling");
+    expect(result.success).toBe(true);
+    expect(result.failureCategory).toBeUndefined();
+    expect(result.reviewReason).toBeUndefined();
   });
 
   test("acceptable quality → does not trigger poor-quality rejection", () => {
@@ -497,14 +494,13 @@ describe("categorizeVerdict", () => {
       reasoning: "Overall acceptable but not approved for other reason",
     });
     const result = categorizeVerdict(verdict, true);
-    // Falls to catch-all
-    expect(result.success).toBe(false);
-    expect(result.failureCategory).toBe("verifier-rejected");
+    expect(result.success).toBe(true);
+    expect(result.failureCategory).toBeUndefined();
   });
 
-  // --- catch-all: not approved without specific categorizable reason ---
+  // --- catch-all: not approved without TDD integrity failure ---
 
-  test("not approved with no specific categorizable reason → verifier-rejected (catch-all)", () => {
+  test("not approved with no TDD integrity failure → advisory success", () => {
     const verdict = makeVerdict({
       approved: false,
       tests: { allPassing: true, passCount: 10, failCount: 0 },
@@ -514,9 +510,9 @@ describe("categorizeVerdict", () => {
       reasoning: "Something else is wrong.",
     });
     const result = categorizeVerdict(verdict, true);
-    expect(result.success).toBe(false);
-    expect(result.failureCategory).toBe("verifier-rejected");
-    expect(result.reviewReason).toContain("Something else is wrong.");
+    expect(result.success).toBe(true);
+    expect(result.failureCategory).toBeUndefined();
+    expect(result.reviewReason).toBeUndefined();
   });
 
   // --- null verdict fallback ---
@@ -552,7 +548,7 @@ describe("categorizeVerdict", () => {
     expect(result.reviewReason).toContain("illegitimate test modifications");
   });
 
-  test("failing tests take priority over acceptance criteria", () => {
+  test("failing tests still block when acceptance criteria are also unmet", () => {
     const verdict = makeVerdict({
       approved: false,
       tests: { allPassing: false, passCount: 1, failCount: 2 },
@@ -571,7 +567,7 @@ describe("categorizeVerdict", () => {
     expect(result.failureCategory).toBe("tests-failing");
   });
 
-  test("acceptance criteria not met takes priority over poor quality", () => {
+  test("acceptance criteria plus poor quality without TDD integrity failure → advisory success", () => {
     const verdict = makeVerdict({
       approved: false,
       tests: { allPassing: true, passCount: 10, failCount: 0 },
@@ -588,7 +584,8 @@ describe("categorizeVerdict", () => {
       quality: { rating: "poor", issues: ["Very bad"] },
     });
     const result = categorizeVerdict(verdict, true);
-    expect(result.failureCategory).toBe("verifier-rejected");
-    expect(result.reviewReason).toContain("Criterion A");
+    expect(result.success).toBe(true);
+    expect(result.failureCategory).toBeUndefined();
+    expect(result.reviewReason).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #885.

This narrows the three-session TDD verifier back to TDD handoff integrity instead of overlapping with semantic/adversarial review.

## Root Cause

The verifier had drifted in two ways:

- verifier prompt text asked for acceptance criteria and broad code-quality review
- verdict categorization treated AC/quality rejection as blocking TDD failure
- `runTddSessionOp()` disabled legacy context for verifier but still passed `constitution` and the v2 `ContextBundle`

That let verifier prompts receive broad context and return semantic-review-style critical findings even when the TDD isolation check itself was maintained.

## Changes

- Strip `constitution` and v2 context from verifier session prompt inputs.
- Reword verifier role/isolation/verdict instructions around TDD integrity.
- Treat AC/quality verdict fields as advisory for TDD categorization.
- Keep blocking verifier outcomes for failing scoped tests and illegitimate test modifications.
- Change verifier success log wording from `approved` to `accepted`.
- Add ADR-022 phase 7 post-verification checklist for `tdd-verifier` boundaries.
- Clarify that the full-suite gate was attempted before verifier; it may have passed, failed, or exhausted rectification.

## Validation

- `bun test test/unit/tdd/session-op.test.ts --timeout=30000`
- `bun test test/unit/prompts/sections/role-task.test.ts test/unit/prompts/sections/verdict.test.ts test/unit/prompts/sections/sections.test.ts --timeout=30000`
- `bun test test/integration/tdd/tdd-orchestrator-verdict.test.ts --timeout=30000`
- `bun run typecheck`
- `bun run lint`
- pre-commit checks: typecheck, lint, process.cwd, adapter wrap, dispatch context

## Follow-up

Created #886 to decide whether full-suite rectification exhaustion should stop before verifier or continue with explicit gate status.