### PR TITLE
[codex] Fix ADR-021 and ADR-022 review gaps

### DIFF
--- a/src/context/elements.ts
+++ b/src/context/elements.ts
@@ -103,11 +103,12 @@ export function formatPriorFailures(failures: StructuredFailure[]): string {
       parts.push("\n**Review Findings (fix these issues):**");
       for (const finding of failure.reviewFindings) {
         const source = finding.source ? ` (${finding.source})` : "";
-        parts.push(`\n- **[${finding.severity}]** \`${finding.file}:${finding.line}\`${source}`);
-        parts.push(`  **Rule:** ${finding.ruleId}`);
+        const loc = finding.file ? `${finding.file}:${finding.line ?? 0}` : "global";
+        parts.push(`\n- **[${finding.severity}]** \`${loc}\`${source}`);
+        parts.push(`  **Rule:** ${finding.rule ?? finding.category}`);
         parts.push(`  **Issue:** ${finding.message}`);
-        if (finding.url) {
-          parts.push(`  **Docs:** ${finding.url}`);
+        if (typeof finding.meta?.url === "string") {
+          parts.push(`  **Docs:** ${finding.meta.url}`);
         }
       }
     }

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -8,6 +8,7 @@
  */
 
 import type { NaxConfig } from "../../config";
+import type { Finding } from "../../findings";
 import { type LoadedHooksConfig, fireHook } from "../../hooks";
 import { getSafeLogger } from "../../logger";
 import type { PRD, StructuredFailure, UserStory } from "../../prd";
@@ -24,7 +25,7 @@ import { handleMaxAttemptsReached, handleNoTierAvailable } from "./tier-outcome"
 function buildEscalationFailure(
   story: UserStory,
   currentTier: string,
-  reviewFindings?: import("../../plugins/types").ReviewFinding[],
+  reviewFindings?: Finding[],
   cost?: number,
 ): StructuredFailure {
   // AC-3: Use stage='review' when there are semantic review findings
@@ -225,7 +226,7 @@ export interface EscalationHandlerContext {
     context: {
       retryAsLite?: boolean;
       tddFailureCategory?: FailureCategory;
-      reviewFindings?: import("../../plugins/types").ReviewFinding[];
+      reviewFindings?: Finding[];
     };
   };
   config: NaxConfig;

--- a/src/execution/lifecycle/acceptance-loop.ts
+++ b/src/execution/lifecycle/acceptance-loop.ts
@@ -25,6 +25,7 @@ import type { PipelineEventEmitter } from "../../pipeline/events";
 import type { AgentGetFn, PipelineContext } from "../../pipeline/types";
 import type { PluginRegistry } from "../../plugins";
 import type { PRD } from "../../prd/types";
+import { buildPriorIterationsBlock } from "../../prompts";
 
 import type { DispatchContext } from "../../runtime/dispatch-context";
 import type { NaxIgnoreIndex } from "../../utils/path-filters";
@@ -117,6 +118,26 @@ function convertFailuresToFindings(failedACs: string[], testOutput: string): Fin
   });
 }
 
+function findingsForDiagnosis(failedACs: string[], testOutput: string, diagnosis: DiagnosisResult): Finding[] {
+  if (diagnosis.findings && diagnosis.findings.length > 0) return diagnosis.findings;
+
+  const findings = convertFailuresToFindings(failedACs, testOutput);
+  const isTestRunnerSentinel = (f: Finding): boolean =>
+    f.category === "hook-failure" || f.category === "test-runner-error";
+  if (diagnosis.verdict === "source_bug") {
+    return findings.map((f) => (isTestRunnerSentinel(f) ? f : { ...f, fixTarget: "source" }));
+  }
+  if (diagnosis.verdict === "test_bug") return findings.map((f) => ({ ...f, fixTarget: "test" }));
+  return findings.flatMap((f) =>
+    isTestRunnerSentinel(f)
+      ? [f]
+      : [
+          { ...f, fixTarget: "source" as const },
+          { ...f, fixTarget: "test" as const },
+        ],
+  );
+}
+
 function buildFixCycleCtx(
   ctx: AcceptanceLoopContext,
   runtime: NonNullable<AcceptanceLoopContext["runtime"]>,
@@ -204,7 +225,7 @@ export async function runAcceptanceFixCycle(
   const cycleCtx = buildFixCycleCtx(ctx, runtime, storyId);
 
   const cycle: FixCycle<Finding> = {
-    findings: convertFailuresToFindings(initialFailures.failedACs, initialFailures.testOutput),
+    findings: findingsForDiagnosis(initialFailures.failedACs, initialFailures.testOutput, diagnosis),
     iterations: [],
     strategies: [
       {
@@ -212,9 +233,10 @@ export async function runAcceptanceFixCycle(
         appliesTo: (f) => f.fixTarget === "source",
         appliesToVerdict: (v) => v === "source_bug" || v === "both",
         fixOp: acceptanceFixSourceOp,
-        buildInput: (_findings, _priorIterations, _ctx) => ({
+        buildInput: (_findings, priorIterations, _ctx) => ({
           testOutput: currentTestOutput,
           diagnosisReasoning: diagnosis.reasoning,
+          priorIterationsBlock: buildPriorIterationsBlock(priorIterations),
           acceptanceTestPath,
           testFileContent,
         }),
@@ -226,9 +248,10 @@ export async function runAcceptanceFixCycle(
         appliesTo: (f) => f.fixTarget === "test",
         appliesToVerdict: (v) => v === "test_bug" || v === "both",
         fixOp: acceptanceFixTestOp,
-        buildInput: (_findings, _priorIterations, _ctx) => ({
+        buildInput: (_findings, priorIterations, _ctx) => ({
           testOutput: currentTestOutput,
           diagnosisReasoning: diagnosis.reasoning,
+          priorIterationsBlock: buildPriorIterationsBlock(priorIterations),
           failedACs: currentFailedACs,
           acceptanceTestPath,
           testFileContent,
@@ -242,7 +265,7 @@ export async function runAcceptanceFixCycle(
       if (result.passed) return [];
       currentTestOutput = result.testOutput;
       currentFailedACs = result.failedACs;
-      return convertFailuresToFindings(result.failedACs, result.testOutput);
+      return findingsForDiagnosis(result.failedACs, result.testOutput, diagnosis);
     },
     config: {
       maxAttemptsTotal: ctx.config.acceptance.maxRetries,

--- a/src/findings/adapters/semantic-review.ts
+++ b/src/findings/adapters/semantic-review.ts
@@ -14,5 +14,6 @@ export function reviewFindingToFinding(f: ReviewFinding): Finding {
     endLine: f.endLine,
     endColumn: f.endColumn,
     message: f.message,
+    fixTarget: "source",
   };
 }

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -154,6 +154,10 @@ export async function runFixCycle<F extends Finding>(
   let totalCostUsd = 0;
 
   for (;;) {
+    if (cycle.findings.length === 0 && cycle.verdict === undefined) {
+      return { iterations: cycle.iterations, finalFindings: [], exitReason: "resolved", costUsd: totalCostUsd };
+    }
+
     // ── Select active strategies ──────────────────────────────────────────────
     const active = selectActiveStrategies(cycle.strategies, cycle.findings, cycle.verdict);
     if (active.length === 0) {

--- a/src/operations/acceptance-fix.ts
+++ b/src/operations/acceptance-fix.ts
@@ -6,6 +6,7 @@ import type { RunOperation } from "./types";
 export interface AcceptanceFixSourceInput {
   testOutput: string;
   diagnosisReasoning?: string;
+  priorIterationsBlock?: string;
   acceptanceTestPath: string;
   testFileContent?: string;
 }
@@ -13,6 +14,7 @@ export interface AcceptanceFixSourceInput {
 export interface AcceptanceFixTestInput {
   testOutput: string;
   diagnosisReasoning?: string;
+  priorIterationsBlock?: string;
   failedACs: string[];
   acceptanceTestPath: string;
   testFileContent?: string;
@@ -33,6 +35,7 @@ export const acceptanceFixSourceOp: RunOperation<AcceptanceFixSourceInput, Accep
     const prompt = new AcceptancePromptBuilder().buildSourceFixPrompt({
       testOutput: input.testOutput,
       diagnosisReasoning: input.diagnosisReasoning,
+      priorIterationsBlock: input.priorIterationsBlock,
       acceptanceTestPath: input.acceptanceTestPath,
       testFileContent: input.testFileContent,
     });
@@ -57,6 +60,7 @@ export const acceptanceFixTestOp: RunOperation<AcceptanceFixTestInput, Acceptanc
     const prompt = new AcceptancePromptBuilder().buildTestFixPrompt({
       testOutput: input.testOutput,
       diagnosisReasoning: input.diagnosisReasoning,
+      priorIterationsBlock: input.priorIterationsBlock,
       failedACs: input.failedACs,
       acceptanceTestPath: input.acceptanceTestPath,
       testFileContent: input.testFileContent ?? "",

--- a/src/pipeline/stages/review.ts
+++ b/src/pipeline/stages/review.ts
@@ -13,7 +13,6 @@
 // RE-ARCH: rewrite
 import { checkSecurityReview, isTriggerEnabled } from "../../interaction/triggers";
 import { getLogger } from "../../logger";
-import type { ReviewFinding } from "../../plugins/types";
 import { createReviewerSession } from "../../review/dialogue";
 import { reviewOrchestrator } from "../../review/orchestrator";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
@@ -169,27 +168,12 @@ export const reviewStage: PipelineStage = {
     }
 
     if (!result.success) {
-      // Collect semantic findings from built-in checks (AC-1/AC-2/AC-3) for escalation context.
-      // Plugin findings (Finding[] per ADR-021 phase 2) are accessible via
-      // ctx.reviewResult.builtIn.pluginReviewers[*].findings — they use Finding.rule (not
-      // ReviewFinding.ruleId) so they cannot be merged into ctx.reviewFindings (ReviewFinding[])
-      // until context/elements.ts migrates to Finding[] in a later phase.
-      // Note: plugins only run when built-in checks pass (guard in orchestrator), so
-      // pluginFindings and semanticFindings are mutually exclusive in practice.
+      // Collect semantic findings from built-in checks for escalation context.
       const semanticFindings = (result.builtIn.checks ?? [])
         .filter((c) => c.check === "semantic" && !c.success && c.findings?.length)
         .flatMap((c) => c.findings ?? []);
       if (semanticFindings.length > 0) {
-        // Downcast Finding[] → ReviewFinding[] for ctx.reviewFindings; migrates in a later phase once elements.ts adopts Finding[].
-        ctx.reviewFindings = semanticFindings.map((f) => ({
-          ruleId: f.rule ?? "semantic",
-          severity: (f.severity === "unverifiable" ? "info" : f.severity) as ReviewFinding["severity"],
-          file: f.file ?? "",
-          line: f.line ?? 0,
-          message: f.message,
-          source: f.source,
-          category: f.category,
-        }));
+        ctx.reviewFindings = semanticFindings;
       }
 
       if (result.pluginFailed) {

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -207,8 +207,8 @@ export interface PipelineContext extends DispatchContext {
   fullSuiteGatePassed?: boolean;
   /** Number of runtime crashes (RUNTIME_CRASH verify status) encountered for this story (BUG-070) */
   storyRuntimeCrashes?: number;
-  /** Structured review findings from plugin reviewers — passed to escalation for retry context */
-  reviewFindings?: import("../plugins/types").ReviewFinding[];
+  /** Structured review findings — passed to escalation for retry context */
+  reviewFindings?: import("../findings").Finding[];
   /** Active reviewer-implementer dialogue session (set by reviewStage when dialogue.enabled) */
   reviewerSession?: import("../review/dialogue").ReviewerSession;
   /** Accumulated cost across all prior escalation attempts (BUG-067) */

--- a/src/prd/types.ts
+++ b/src/prd/types.ts
@@ -47,8 +47,8 @@ export interface StructuredFailure {
   summary: string;
   /** Parsed test failures (if applicable) */
   testFailures?: TestFailureContext[];
-  /** Structured review findings from plugin reviewers (e.g., semgrep, eslint) */
-  reviewFindings?: import("../plugins/types").ReviewFinding[];
+  /** Structured review findings from nax review producers. */
+  reviewFindings?: import("../findings").Finding[];
   /** Estimated cost of this attempt (BUG-067: accumulated across escalations) */
   cost?: number;
   /** ISO timestamp when failure was recorded */

--- a/src/prompts/builders/acceptance-builder.ts
+++ b/src/prompts/builders/acceptance-builder.ts
@@ -105,6 +105,7 @@ export interface DiagnosisTemplateParams {
 export interface SourceFixParams {
   testOutput: string;
   diagnosisReasoning?: string;
+  priorIterationsBlock?: string;
   acceptanceTestPath: string;
   testFileContent?: string;
 }
@@ -112,6 +113,7 @@ export interface SourceFixParams {
 export interface TestFixParams {
   testOutput: string;
   diagnosisReasoning?: string;
+  priorIterationsBlock?: string;
   failedACs: string[];
   acceptanceTestPath: string;
   testFileContent: string;
@@ -201,6 +203,7 @@ ${responseSchema}`;
   buildSourceFixPrompt(p: SourceFixParams): string {
     let prompt = `ACCEPTANCE TEST FAILURE:\n${p.testOutput}\n\n`;
     if (p.diagnosisReasoning) prompt += `DIAGNOSIS:\n${p.diagnosisReasoning}\n\n`;
+    if (p.priorIterationsBlock) prompt += p.priorIterationsBlock;
     prompt += `ACCEPTANCE TEST FILE: ${p.acceptanceTestPath}\n\n`;
     if (p.testFileContent && p.testFileContent.length > 0) {
       prompt += `\`\`\`typescript\n${p.testFileContent}\n\`\`\`\n\n`;
@@ -365,6 +368,7 @@ Assert about HTTP responses, status codes, and API endpoint output.${framework}
     prompt += `FAILING ACS: ${p.failedACs.join(", ")}\n\n`;
     prompt += `TEST OUTPUT:\n${p.testOutput}\n\n`;
     if (p.diagnosisReasoning) prompt += `DIAGNOSIS:\n${p.diagnosisReasoning}\n\n`;
+    if (p.priorIterationsBlock) prompt += p.priorIterationsBlock;
     prompt += `ACCEPTANCE TEST FILE: ${p.acceptanceTestPath}\n\n`;
     prompt += `\`\`\`typescript\n${p.testFileContent}\n\`\`\`\n\n`;
     prompt += "Fix ONLY the failing test assertions for the ACs listed above. ";

--- a/src/review/adversarial-helpers.ts
+++ b/src/review/adversarial-helpers.ts
@@ -86,5 +86,6 @@ export function toAdversarialReviewFindings(findings: AdversarialLLMFinding[]): 
     line: f.line,
     message: f.issue,
     suggestion: f.suggestion,
+    fixTarget: f.category === "test-gap" ? "test" : undefined,
   }));
 }

--- a/src/review/semantic-helpers.ts
+++ b/src/review/semantic-helpers.ts
@@ -122,6 +122,7 @@ export function llmFindingToFinding(f: LLMFinding): Finding {
     line: f.line,
     message: f.issue,
     suggestion: f.suggestion ?? undefined,
+    fixTarget: "source",
     meta: f.verifiedBy ? { verifiedBy: f.verifiedBy } : undefined,
   };
 }

--- a/test/unit/context/prior-failures.test.ts
+++ b/test/unit/context/prior-failures.test.ts
@@ -175,6 +175,36 @@ describe("formatPriorFailures", () => {
     // Should not crash or include undefined stack
     expect(formatted).not.toContain("undefined");
   });
+
+  test("should format review findings using Finding wire format", () => {
+    const failure: StructuredFailure = {
+      attempt: 1,
+      modelTier: "balanced",
+      stage: "review",
+      summary: "Review failed",
+      reviewFindings: [
+        {
+          source: "semantic-review",
+          severity: "error",
+          category: "semantic",
+          rule: "semantic-ac",
+          file: "src/foo.ts",
+          line: 12,
+          message: "AC not satisfied",
+          meta: { url: "https://example.com/rule" },
+        },
+      ],
+      timestamp: new Date().toISOString(),
+    };
+
+    const formatted = formatPriorFailures([failure]);
+
+    expect(formatted).toContain("**Review Findings (fix these issues):**");
+    expect(formatted).toContain("`src/foo.ts:12` (semantic-review)");
+    expect(formatted).toContain("**Rule:** semantic-ac");
+    expect(formatted).toContain("**Issue:** AC not satisfied");
+    expect(formatted).toContain("**Docs:** https://example.com/rule");
+  });
 });
 
 describe("createPriorFailuresContext", () => {

--- a/test/unit/execution/lifecycle/acceptance-loop-cycle.test.ts
+++ b/test/unit/execution/lifecycle/acceptance-loop-cycle.test.ts
@@ -82,6 +82,41 @@ function makeDiagnosis(verdict: DiagnosisResult["verdict"] = "source_bug"): Diag
   return { verdict, reasoning: "test reasoning", confidence: 0.9 };
 }
 
+function makeIteration(): import("../../../../src/findings").Iteration<Finding> {
+  return {
+    iterationNum: 1,
+    findingsBefore: [
+      {
+        source: "test-runner",
+        severity: "error",
+        category: "assertion-failure",
+        message: "AC-1 failed",
+        fixTarget: "test",
+      },
+    ],
+    fixesApplied: [
+      {
+        strategyName: "acceptance-test-fix",
+        op: "acceptance-fix-test",
+        targetFiles: ["/tmp/test.ts"],
+        summary: "updated import",
+      },
+    ],
+    findingsAfter: [
+      {
+        source: "test-runner",
+        severity: "error",
+        category: "assertion-failure",
+        message: "AC-1 failed",
+        fixTarget: "test",
+      },
+    ],
+    outcome: "unchanged",
+    startedAt: "2026-05-03T00:00:00.000Z",
+    finishedAt: "2026-05-03T00:00:01.000Z",
+  };
+}
+
 const resolvedCycleResult: FixCycleResult<Finding> = {
   iterations: [],
   finalFindings: [],
@@ -249,6 +284,76 @@ describe("runAcceptanceFixCycle", () => {
     expect(capturedCycle?.findings[0].fixTarget).toBe("source");
   });
 
+  test("cycle.findings are retargeted to test when diagnosis verdict is test_bug", async () => {
+    let capturedCycle: FixCycle<Finding> | undefined;
+    _acceptanceFixCycleDeps.runFixCycle = mock(async (cycle) => {
+      capturedCycle = cycle;
+      return resolvedCycleResult;
+    }) as typeof _acceptanceFixCycleDeps.runFixCycle;
+
+    await runAcceptanceFixCycle(
+      makeCtx(),
+      makePrd(),
+      { failedACs: ["AC-1"], testOutput: "test output" },
+      makeDiagnosis("test_bug"),
+      "",
+      "",
+    );
+
+    expect(capturedCycle?.findings).toHaveLength(1);
+    expect(capturedCycle?.findings[0].fixTarget).toBe("test");
+  });
+
+  test("cycle.findings duplicate source and test targets when diagnosis verdict is both", async () => {
+    let capturedCycle: FixCycle<Finding> | undefined;
+    _acceptanceFixCycleDeps.runFixCycle = mock(async (cycle) => {
+      capturedCycle = cycle;
+      return resolvedCycleResult;
+    }) as typeof _acceptanceFixCycleDeps.runFixCycle;
+
+    await runAcceptanceFixCycle(
+      makeCtx(),
+      makePrd(),
+      { failedACs: ["AC-1"], testOutput: "test output" },
+      makeDiagnosis("both"),
+      "",
+      "",
+    );
+
+    expect(capturedCycle?.findings.map((f) => f.fixTarget).sort()).toEqual(["source", "test"]);
+  });
+
+  test("diagnosis findings are used directly when available", async () => {
+    let capturedCycle: FixCycle<Finding> | undefined;
+    _acceptanceFixCycleDeps.runFixCycle = mock(async (cycle) => {
+      capturedCycle = cycle;
+      return resolvedCycleResult;
+    }) as typeof _acceptanceFixCycleDeps.runFixCycle;
+
+    const diagnosis: DiagnosisResult = {
+      ...makeDiagnosis("test_bug"),
+      findings: [
+        {
+          source: "acceptance-diagnose",
+          severity: "error",
+          category: "import-path",
+          message: "wrong test import",
+          fixTarget: "test",
+        },
+      ],
+    };
+    await runAcceptanceFixCycle(
+      makeCtx(),
+      makePrd(),
+      { failedACs: ["AC-1"], testOutput: "test output" },
+      diagnosis,
+      "",
+      "",
+    );
+
+    expect(capturedCycle?.findings).toEqual(diagnosis.findings);
+  });
+
   test("AC-HOOK sentinel converted via acSentinelToFinding", async () => {
     let capturedCycle: FixCycle<Finding> | undefined;
     _acceptanceFixCycleDeps.runFixCycle = mock(async (cycle) => {
@@ -357,6 +462,27 @@ describe("strategy buildInput closures", () => {
     expect(input.testFileContent).toBe("test-content");
   });
 
+  test("source-fix buildInput includes prior iterations block", async () => {
+    let capturedCycle: FixCycle<Finding> | undefined;
+    _acceptanceFixCycleDeps.runFixCycle = mock(async (cycle) => {
+      capturedCycle = cycle;
+      return resolvedCycleResult;
+    }) as typeof _acceptanceFixCycleDeps.runFixCycle;
+
+    await runAcceptanceFixCycle(
+      makeCtx(),
+      makePrd(),
+      { failedACs: ["AC-1"], testOutput: "initial output" },
+      makeDiagnosis(),
+      "test-content",
+      "/path/to/test.ts",
+    );
+
+    const input = capturedCycle!.strategies[0].buildInput([], [makeIteration()], {} as never) as Record<string, unknown>;
+    expect(input.priorIterationsBlock).toContain("## Prior Iterations");
+    expect(input.priorIterationsBlock).toContain("acceptance-test-fix");
+  });
+
   test("test-fix buildInput reflects currentFailedACs at call time", async () => {
     let capturedCycle: FixCycle<Finding> | undefined;
     _acceptanceFixCycleDeps.runFixCycle = mock(async (cycle) => {
@@ -392,6 +518,20 @@ describe("strategy buildInput closures", () => {
     const inputEmpty = testStrategy.buildInput([], [], {} as never) as Record<string, unknown>;
     expect(inputEmpty.testOutput).toBe("");
     expect(inputEmpty.failedACs).toEqual([]);
+  });
+
+  test("test-fix buildInput includes prior iterations block", async () => {
+    let capturedCycle: FixCycle<Finding> | undefined;
+    _acceptanceFixCycleDeps.runFixCycle = mock(async (cycle) => {
+      capturedCycle = cycle;
+      return resolvedCycleResult;
+    }) as typeof _acceptanceFixCycleDeps.runFixCycle;
+
+    await runAcceptanceFixCycle(makeCtx(), makePrd(), { failedACs: ["AC-1"], testOutput: "" }, makeDiagnosis("test_bug"), "", "");
+
+    const input = capturedCycle!.strategies[1].buildInput([], [makeIteration()], {} as never) as Record<string, unknown>;
+    expect(input.priorIterationsBlock).toContain("## Prior Iterations");
+    expect(input.priorIterationsBlock).toContain("unchanged");
   });
 });
 

--- a/test/unit/findings/cycle.test.ts
+++ b/test/unit/findings/cycle.test.ts
@@ -137,7 +137,7 @@ describe("classifyOutcome", () => {
 // ─── runFixCycle — bail: no-strategy ──────────────────────────────────────────
 
 describe("runFixCycle — bail: no-strategy", () => {
-  test("exits immediately when no strategies match and findings is empty", async () => {
+  test("resolves immediately when findings is empty and no verdict is pending", async () => {
     const strategy = makeStrategy({
       name: "lint-fix",
       appliesTo: (f) => f.source === "lint",
@@ -149,7 +149,7 @@ describe("runFixCycle — bail: no-strategy", () => {
     const result = await runFixCycle(cycle, ctx, "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
 callOp: callOpMock as unknown as CallOpFn});
 
-    expect(result.exitReason).toBe("no-strategy");
+    expect(result.exitReason).toBe("resolved");
     expect(result.iterations).toHaveLength(0);
     expect(callOpMock).not.toHaveBeenCalled();
   });

--- a/test/unit/pipeline/stages/autofix-cycle.test.ts
+++ b/test/unit/pipeline/stages/autofix-cycle.test.ts
@@ -4,6 +4,7 @@ import { _cycleDeps } from "../../../../src/findings";
 import { _autofixDeps } from "../../../../src/pipeline/stages/autofix";
 import { runAgentRectificationV2 } from "../../../../src/pipeline/stages/autofix-cycle";
 import type { PipelineContext } from "../../../../src/pipeline/types";
+import { toAdversarialReviewFindings } from "../../../../src/review/adversarial-helpers";
 import type { ReviewCheckResult } from "../../../../src/review/types";
 import { makeMockAgentManager, makeMockRuntime } from "../../../helpers";
 
@@ -144,6 +145,44 @@ describe("runAgentRectificationV2", () => {
     await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
 
     expect(capturedOps).toContain("autofix-test-writer");
+  });
+
+  test("test-writer strategy fires for real adversarial test-gap adapter output", async () => {
+    const capturedOps: string[] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any): Promise<any> => {
+      capturedOps.push(op.name as string);
+      return { applied: true };
+    });
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
+      return true;
+    });
+
+    const ctx = makeCtx();
+    ctx.reviewResult = {
+      success: false,
+      checks: [
+        {
+          ...failedCheck("adversarial", "test gap found"),
+          findings: toAdversarialReviewFindings([
+            {
+              severity: "error",
+              category: "test-gap",
+              file: "src/foo.ts",
+              line: 1,
+              issue: "missing behavioral test",
+              suggestion: "add coverage",
+            },
+          ]),
+        },
+      ],
+    } as unknown as PipelineContext["reviewResult"];
+
+    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    expect(capturedOps).toContain("autofix-test-writer");
+    expect(capturedOps).not.toContain("autofix-implementer");
   });
 
   test("buildInput for second iteration uses fresh post-recheck checks", async () => {

--- a/test/unit/pipeline/stages/review.test.ts
+++ b/test/unit/pipeline/stages/review.test.ts
@@ -11,6 +11,7 @@
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../../../src/config";
+import type { Finding } from "../../../../src/findings";
 import { InteractionChain } from "../../../../src/interaction/chain";
 import type { InteractionPlugin, InteractionResponse } from "../../../../src/interaction/types";
 import { _reviewDeps, reviewStage } from "../../../../src/pipeline/stages/review";
@@ -253,14 +254,15 @@ describe("reviewStage — semantic findings wired into ctx.reviewFindings (US-00
   // AC-1: ctx.reviewFindings is populated when semantic check fails with findings
 
   test("populates ctx.reviewFindings when semantic check returns success=false with findings", async () => {
-    const semanticFindings: ReviewFinding[] = [
+    const semanticFindings: Finding[] = [
       {
-        ruleId: "semantic",
+        source: "semantic-review",
+        rule: "semantic",
         severity: "error",
+        category: "semantic",
         file: "src/review/runner.ts",
         line: 42,
         message: "Missing wiring",
-        source: "semantic-review",
       },
     ];
 
@@ -298,23 +300,25 @@ describe("reviewStage — semantic findings wired into ctx.reviewFindings (US-00
   });
 
   // AC-2: correct field mapping verified at stage level
-  test("ctx.reviewFindings contains findings with source='semantic-review' and ruleId='semantic'", async () => {
-    const semanticFindings: ReviewFinding[] = [
+  test("ctx.reviewFindings contains findings with source='semantic-review' and rule='semantic'", async () => {
+    const semanticFindings: Finding[] = [
       {
-        ruleId: "semantic",
+        source: "semantic-review",
+        rule: "semantic",
         severity: "error",
+        category: "semantic",
         file: "src/foo.ts",
         line: 10,
         message: "Stub left in code",
-        source: "semantic-review",
       },
       {
-        ruleId: "semantic",
+        source: "semantic-review",
+        rule: "semantic",
         severity: "warning",
+        category: "semantic",
         file: "src/bar.ts",
         line: 25,
         message: "TODO not addressed",
-        source: "semantic-review",
       },
     ];
 
@@ -341,7 +345,7 @@ describe("reviewStage — semantic findings wired into ctx.reviewFindings (US-00
     expect(ctx.reviewFindings).toHaveLength(2);
     for (const f of ctx.reviewFindings!) {
       expect(f.source).toBe("semantic-review");
-      expect(f.ruleId).toBe("semantic");
+      expect(f.rule).toBe("semantic");
     }
     expect(ctx.reviewFindings![0].file).toBe("src/foo.ts");
     expect(ctx.reviewFindings![0].line).toBe(10);
@@ -349,10 +353,18 @@ describe("reviewStage — semantic findings wired into ctx.reviewFindings (US-00
     reviewOrchestrator.review = original;
   });
 
-  // AC-3: findings structured for priorFailures context (source/ruleId match context renderer expectations)
+  // AC-3: findings structured for priorFailures context (source/rule match context renderer expectations)
   test("ctx.reviewFindings has source='semantic-review' so context renderer includes tool source in retry context", async () => {
-    const semanticFindings: ReviewFinding[] = [
-      { ruleId: "semantic", severity: "error", file: "src/a.ts", line: 1, message: "Critical issue", source: "semantic-review" },
+    const semanticFindings: Finding[] = [
+      {
+        source: "semantic-review",
+        rule: "semantic",
+        severity: "error",
+        category: "semantic",
+        file: "src/a.ts",
+        line: 1,
+        message: "Critical issue",
+      },
     ];
 
     const reviewResult = {
@@ -379,7 +391,7 @@ describe("reviewStage — semantic findings wired into ctx.reviewFindings (US-00
     // handleTierEscalation can attach them to priorFailures for retry context.
     expect(ctx.reviewFindings).toBeDefined();
     expect(ctx.reviewFindings![0].source).toBe("semantic-review");
-    expect(ctx.reviewFindings![0].ruleId).toBe("semantic");
+    expect(ctx.reviewFindings![0].rule).toBe("semantic");
     expect(typeof ctx.reviewFindings![0].message).toBe("string");
     expect(ctx.reviewFindings![0].message.length).toBeGreaterThan(0);
     reviewOrchestrator.review = original;
@@ -438,8 +450,16 @@ describe("reviewStage — semantic findings wired into ctx.reviewFindings (US-00
   });
 
   test("returns continue when semantic check fails with findings (autofix handles it)", async () => {
-    const semanticFindings: ReviewFinding[] = [
-      { ruleId: "semantic", severity: "error", file: "src/a.ts", line: 1, message: "Issue", source: "semantic-review" },
+    const semanticFindings: Finding[] = [
+      {
+        source: "semantic-review",
+        rule: "semantic",
+        severity: "error",
+        category: "semantic",
+        file: "src/a.ts",
+        line: 1,
+        message: "Issue",
+      },
     ];
 
     const reviewResult = {

--- a/test/unit/prompts/acceptance-builder.test.ts
+++ b/test/unit/prompts/acceptance-builder.test.ts
@@ -233,6 +233,12 @@ describe("builder.buildSourceFixPrompt()", () => {
     expect(builder.buildSourceFixPrompt(base)).toContain(base.diagnosisReasoning);
   });
 
+  test("includes prior iterations block when provided", () => {
+    const result = builder.buildSourceFixPrompt({ ...base, priorIterationsBlock: "## Prior Iterations\n\nprior table\n\n" });
+    expect(result).toContain("## Prior Iterations");
+    expect(result).toContain("prior table");
+  });
+
   test("includes acceptance test path", () => {
     expect(builder.buildSourceFixPrompt(base)).toContain(base.acceptanceTestPath);
   });
@@ -278,6 +284,12 @@ describe("builder.buildTestFixPrompt()", () => {
   test("includes diagnosis reasoning", () => {
     const result = builder.buildTestFixPrompt(base);
     expect(result).toContain(base.diagnosisReasoning);
+  });
+
+  test("includes prior iterations block when provided", () => {
+    const result = builder.buildTestFixPrompt({ ...base, priorIterationsBlock: "## Prior Iterations\n\nprior table\n\n" });
+    expect(result).toContain("## Prior Iterations");
+    expect(result).toContain("prior table");
   });
 
   test("includes test file content in fenced typescript block", () => {


### PR DESCRIPTION
## Summary

Fixes the follow-up gaps found in issue #867 after the ADR-021/ADR-022 implementation review.

- Route acceptance fix cycles from structured diagnosis findings when available, and from diagnosis verdict when falling back to AC parser findings.
- Preserve AC-HOOK / AC-ERROR sentinel routing as test-runner/test-targeted findings.
- Thread `buildPriorIterationsBlock(...)` into acceptance source/test fix prompts so repeated failed hypotheses are visible to the fixing agent.
- Mark adversarial `test-gap` findings as `fixTarget: "test"` at the adapter boundary, and semantic findings as source-targeted.
- Keep internal escalation/prior-failure review context on the unified `Finding[]` shape instead of downcasting to plugin `ReviewFinding[]`.
- Treat an empty `runFixCycle` with no pending verdict as resolved.

## Root Cause

The new Finding/FixCycle plumbing existed, but several consumers still routed from fallback or legacy-shaped data. Acceptance seeded the cycle from generic test-runner findings even after diagnosis, autofix expected `fixTarget` fields that the real adversarial adapter did not emit, and escalation context still converted findings back to plugin review shape.

## Validation

- `bun test test/unit/findings/cycle.test.ts test/unit/execution/lifecycle/acceptance-loop-cycle.test.ts test/unit/prompts/acceptance-builder.test.ts test/unit/pipeline/stages/autofix-cycle.test.ts test/unit/pipeline/stages/review.test.ts test/unit/context/prior-failures.test.ts --timeout=30000`
- `bun run typecheck`
- `bun run lint`
- pre-commit hooks: typecheck, lint, process.cwd check, adapter-wrap check, dispatch-context check

Refs #867