### PR TITLE
[codex] Fix prompt audit for rectification sessions

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -532,7 +532,11 @@ export class AgentManager implements IAgentManager {
     const sessionRole = handle.role ?? opts.sessionRole ?? "main";
     const start = Date.now();
     try {
-      const result = await this._sendPrompt(handle, prompt, opts);
+      const rawResult = await this._sendPrompt(handle, prompt, opts);
+      const result = {
+        ...rawResult,
+        protocolIds: rawResult.protocolIds ?? handle.protocolIds,
+      };
       const event: SessionTurnDispatchEvent = {
         kind: "session-turn",
         sessionName: handle.id,

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -393,6 +393,8 @@ export interface TurnResult {
   exactCostUsd?: number;
   /** Number of session.prompt() calls made. */
   internalRoundTrips: number;
+  /** Protocol-specific IDs for prompt-audit correlation. */
+  protocolIds?: ProtocolIds;
 }
 
 /**

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -65,6 +65,8 @@ function turnResultToAgentResult(r: TurnResult): AgentResult {
     estimatedCostUsd: r.estimatedCostUsd ?? 0,
     exactCostUsd: r.exactCostUsd,
     tokenUsage: r.tokenUsage,
+    protocolIds: r.protocolIds,
+    internalRoundTrips: r.internalRoundTrips,
   };
 }
 

--- a/src/runtime/session-run-hop.ts
+++ b/src/runtime/session-run-hop.ts
@@ -61,6 +61,8 @@ export function createSessionRunHop(sessionManager: ISessionManager): SessionRun
           estimatedCostUsd: turnResult.estimatedCostUsd ?? 0,
           exactCostUsd: turnResult.exactCostUsd,
           tokenUsage: turnResult.tokenUsage,
+          protocolIds: handle.protocolIds,
+          internalRoundTrips: turnResult.internalRoundTrips,
         },
       };
     } catch (err) {

--- a/src/session/manager-run.ts
+++ b/src/session/manager-run.ts
@@ -157,6 +157,8 @@ export async function runTrackedSession(
   if (current?.state === "RUNNING") {
     state.transition(id, result.success ? "COMPLETED" : "FAILED");
   }
+  const protocolIds = result.protocolIds ?? current?.protocolIds;
+  const turn = Math.max((result as { internalRoundTrips?: number }).internalRoundTrips ?? 1, 1);
 
   const sessionName = state.nameFor({
     workdir: pre.workdir,
@@ -177,10 +179,10 @@ export async function runTrackedSession(
     featureName: pre.featureName,
     workdir: pre.workdir,
     resolvedPermissions,
-    turn: (result as { internalRoundTrips?: number }).internalRoundTrips ?? 0,
+    turn,
     protocolIds: {
-      sessionId: result.protocolIds?.sessionId ?? null,
-      recordId: result.protocolIds?.recordId ?? null,
+      sessionId: protocolIds?.sessionId ?? null,
+      recordId: protocolIds?.recordId ?? null,
     },
     origin: "runTrackedSession",
     tokenUsage: result.tokenUsage,

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -504,11 +504,12 @@ export class SessionManager implements ISessionManager {
     this._busySessions.add(handle.id);
 
     try {
-      return await adapter.sendTurn(handle, prompt, {
+      const result = await adapter.sendTurn(handle, prompt, {
         interactionHandler: opts?.interactionHandler ?? NO_OP_INTERACTION_HANDLER,
         signal: opts?.signal,
         maxTurns: opts?.maxTurns,
       });
+      return { ...result, protocolIds: result.protocolIds ?? handle.protocolIds };
     } catch (err) {
       // Check signal.aborted OR an AbortError thrown by the adapter to avoid
       // false-positive cancellation when a non-abort error races with an

--- a/src/tdd/orchestrator-ctx.ts
+++ b/src/tdd/orchestrator-ctx.ts
@@ -169,5 +169,6 @@ export async function runThreeSessionTddFromCtx(
     projectDir: ctx.projectDir,
     abortSignal: ctx.abortSignal,
     agentManager: ctx.agentManager,
+    runtime: ctx.runtime,
   });
 }

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -38,6 +38,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     _recursionDepth = 0,
     projectDir,
     agentManager,
+    runtime,
   } = options;
   const logger = getLogger();
 
@@ -270,6 +271,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     projectDir,
     implementerBinding?.sessionManager,
     implementerBinding?.sessionId,
+    runtime,
   );
 
   // Session 3: Verifier

--- a/src/tdd/types.ts
+++ b/src/tdd/types.ts
@@ -117,6 +117,8 @@ export interface ThreeSessionTddOptions {
    * the middleware chain (audit, cost, cancellation).
    */
   agentManager: import("../agents/manager-types").IAgentManager;
+  /** Runtime services used by rectification to emit prompt audit/cost events. */
+  runtime?: import("../runtime").NaxRuntime;
 }
 
 /**

--- a/test/unit/operations/build-hop-callback.test.ts
+++ b/test/unit/operations/build-hop-callback.test.ts
@@ -38,6 +38,7 @@ function makeStubTurnResult(output = "agent output"): TurnResult {
     internalRoundTrips: 1,
     estimatedCostUsd: 0.001 ,
     exactCostUsd: 0.002,
+    protocolIds: { recordId: "rec-turn", sessionId: "sess-turn" },
   };
 }
 
@@ -123,6 +124,8 @@ describe("buildHopCallback — primary hop (no failure)", () => {
     expect(hop.result.estimatedCostUsd).toBe(0.001);
     expect(hop.result.exactCostUsd).toBe(0.002);
     expect(hop.result.tokenUsage).toEqual(turnResult.tokenUsage);
+    expect(hop.result.protocolIds).toEqual({ recordId: "rec-turn", sessionId: "sess-turn" });
+    expect(hop.result.internalRoundTrips).toBe(1);
   });
 });
 

--- a/test/unit/runtime/session-run-hop.test.ts
+++ b/test/unit/runtime/session-run-hop.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AgentRunOptions, SessionHandle, TurnResult } from "../../../src/agents/types";
+import { createSessionRunHop } from "../../../src/runtime/session-run-hop";
+import type { ISessionManager } from "../../../src/session";
+
+function makeRunOptions(): AgentRunOptions {
+  return {
+    prompt: "do the work",
+    workdir: "/tmp/work",
+    modelTier: "balanced",
+    modelDef: { provider: "anthropic", model: "claude-sonnet-4-5" },
+    timeoutSeconds: 60,
+    config: {},
+    pipelineStage: "run",
+    sessionRole: "implementer",
+    featureName: "feat",
+    storyId: "US-001",
+  } as AgentRunOptions;
+}
+
+describe("createSessionRunHop", () => {
+  test("preserves handle protocolIds and internalRoundTrips in AgentResult", async () => {
+    const handle: SessionHandle = {
+      id: "nax-session",
+      agentName: "claude",
+      protocolIds: { recordId: "rec-hop", sessionId: "sess-hop" },
+    };
+    const turnResult: TurnResult = {
+      output: "done",
+      tokenUsage: { inputTokens: 1, outputTokens: 2 },
+      estimatedCostUsd: 0.003,
+      internalRoundTrips: 2,
+    };
+    const sessionManager = {
+      nameFor: mock(() => "nax-session"),
+      openSession: mock(async () => handle),
+      sendPrompt: mock(async () => turnResult),
+      closeSession: mock(async () => {}),
+    } as unknown as ISessionManager;
+
+    const hop = createSessionRunHop(sessionManager);
+    const result = await hop("claude", makeRunOptions());
+
+    expect(result.result.protocolIds).toEqual({ recordId: "rec-hop", sessionId: "sess-hop" });
+    expect(result.result.internalRoundTrips).toBe(2);
+  });
+});

--- a/test/unit/session/manager-run-in-session.test.ts
+++ b/test/unit/session/manager-run-in-session.test.ts
@@ -17,6 +17,7 @@ import type { IAgentManager } from "../../../src/agents/manager-types";
 import type { AgentRunRequest } from "../../../src/agents/manager-types";
 import type { AgentResult } from "../../../src/agents/types";
 import type { NaxConfig } from "../../../src/config";
+import { DispatchEventBus, type SessionTurnDispatchEvent } from "../../../src/runtime/dispatch-events";
 import { SessionManager } from "../../../src/session/manager";
 import { makeMockAgentManager } from "../../../test/helpers";
 
@@ -115,6 +116,23 @@ describe("SessionManager.runInSession — ADR-013 Phase 1", () => {
     );
 
     expect(mgr.get(d.id)?.protocolIds).toEqual({ recordId: "rec-1", sessionId: "sess-1" });
+  });
+
+  test("dispatch event falls back to descriptor protocolIds and turn=1 when result omits metadata", async () => {
+    const bus = new DispatchEventBus();
+    const events: SessionTurnDispatchEvent[] = [];
+    bus.onDispatch((event) => {
+      if (event.kind === "session-turn") events.push(event);
+    });
+    const mgr = new SessionManager({ dispatchEvents: bus });
+    const d = mgr.create({ role: "main", agent: "claude", workdir: "/tmp/x", handle: "nax-test" });
+    mgr.bindHandle(d.id, "nax-test", { recordId: "rec-bound", sessionId: "sess-bound" });
+
+    await mgr.runInSession(d.id, makeAgentManager(makeResult()), makeRequest());
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.protocolIds).toEqual({ recordId: "rec-bound", sessionId: "sess-bound" });
+    expect(events[0]?.turn).toBe(1);
   });
 
   test("throws SESSION_NOT_FOUND for unknown id", async () => {

--- a/test/unit/tdd/rectification-gate-session.test.ts
+++ b/test/unit/tdd/rectification-gate-session.test.ts
@@ -102,6 +102,62 @@ afterEach(() => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("rectification session reuse", () => {
+  test("uses runtime runAsSession branch so each rectification attempt emits dispatch events", async () => {
+    const story = makeStory();
+    const config = makeConfig(2);
+    const handle = {
+      id: "nax-rectify",
+      agentName: "claude",
+      protocolIds: { recordId: "rec-1", sessionId: "sess-1" },
+    };
+
+    mockSuiteResults = [
+      { success: false, exitCode: 1, output: FAILING_OUTPUT },
+      { success: false, exitCode: 1, output: FAILING_OUTPUT },
+      { success: false, exitCode: 1, output: FAILING_OUTPUT },
+    ];
+
+    const agentManager = makeMockAgentManager({
+      getDefaultAgent: "claude",
+      runAsSessionFn: async () => ({
+        output: "fixed something",
+        tokenUsage: { inputTokens: 1, outputTokens: 2 },
+        estimatedCostUsd: 0.01,
+        internalRoundTrips: 1,
+      }),
+      runFn: async () => {
+        throw new Error("legacy run path should not be used when runtime is provided");
+      },
+    });
+    const runtime = {
+      sessionManager: {
+        openSession: mock(async () => handle),
+        closeSession: mock(async () => {}),
+      },
+      signal: new AbortController().signal,
+    };
+
+    await runFullSuiteGate(
+      story,
+      config,
+      "/tmp/fake-workdir",
+      agentManager,
+      "balanced",
+      true,
+      { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any,
+      "my-feature",
+      "/tmp/project",
+      undefined,
+      undefined,
+      runtime as any,
+    );
+
+    expect(agentManager.runAsSession).toHaveBeenCalledTimes(2);
+    expect(agentManager.run).not.toHaveBeenCalled();
+    expect(runtime.sessionManager.openSession).toHaveBeenCalledTimes(1);
+    expect(runtime.sessionManager.closeSession).toHaveBeenCalledTimes(1);
+  });
+
   test("all attempts use the same sessionRole", async () => {
     const story = makeStory();
     const config = makeConfig(2); // maxRetries=2


### PR DESCRIPTION
## Summary

Fix prompt audit coverage and correlation for TDD rectification sessions.

Closes #894.

## What changed

- Thread the runtime into the TDD full-suite rectification gate so fix attempts use the audit-wired `runAsSession` path.
- Preserve `protocolIds` and `internalRoundTrips` when session turn results are converted back into agent results.
- Fall back to descriptor-bound protocol IDs and a non-zero turn number when emitting tracked-session dispatch events.
- Add regression tests for rectification audit routing and session metadata preservation.

## Root cause

Rectification/fix prompts had a runtime-aware path that emits dispatch events, but TDD did not pass `runtime` into the full-suite gate, so fix attempts used the legacy `agentManager.run()` path and bypassed prompt audit. Separately, session metadata was dropped across `TurnResult` to `AgentResult` conversion, causing null `sessionId` / `recordId` and `t00` audit filenames.

## Validation

- `bun test test/unit/runtime/session-run-hop.test.ts test/unit/session/manager-run-in-session.test.ts test/unit/operations/build-hop-callback.test.ts test/unit/tdd/rectification-gate-session.test.ts --timeout=30000`
- `bun run typecheck`
- `bun run lint`
- Pre-commit hooks: typecheck, lint, process.cwd check, adapter wrap check, dispatch context check