### PR TITLE
fix(autofix): resolve D1–D6 autofix cycle defects (#897)

### DIFF
--- a/docs/findings/2026-05-04-autofix-cycle-tdd-ordering-and-bail-signals.md
+++ b/docs/findings/2026-05-04-autofix-cycle-tdd-ordering-and-bail-signals.md
@@ -1,0 +1,231 @@
+# Autofix Cycle — TDD Ordering, Test-Writer Cover-Up, and Missing Bail Signals
+
+**Date:** 2026-05-04
+**Project under test:** [koda](https://github.com/nathapp-io/koda) — feature branch `feat/memory-phase4-graph-code-intelligence`
+**Run:** `logs/memory-phase4-graph-code-intelligence/run/2026-05-03T11-36-49.jsonl`
+**Affected story:** US-001 (Incremental Graph Diff)
+**Status:** Proposed — implementation plan below; partial mitigations from prior session already landed (see [Prior fixes already in place](#prior-fixes-already-in-place))
+
+Five concrete defects were observed in the V2 fix cycle (`runFixCycle` + `runAgentRectificationV2`). They compound: the test-writer locks bugs in, the cycle ignores the agent's "I give up" signal, and budget is wasted on a final validate that has no fix attempt to feed.
+
+---
+
+## Evidence
+
+US-001 trajectory in `2026-05-03T11-36-49.jsonl`:
+
+```
+12:56  Initial: 1 finding (lint failure)
+12:58  Iter 1: 1 → 5 findings  outcome=regressed-different-source
+13:44  Iter 2: 5 → 5 findings  outcome=regressed-different-source
+14:53  Iter 3: 5 → 5 findings  outcome=regressed   (implementer + test-writer)
+14:53  Cycle exit: max-attempts-per-strategy
+```
+
+Three prompt-audit files anchor the analysis:
+
+- `logs/prompt-audit/.../1777815886251-...-reviewer-adversarial-review-t01.txt` — **Adversarial round at 13:44** flags `incremental-graph-diff.service.ts:203`: *"upsertNode deleteMany uses node.id (graphify identifier) instead of GraphNode.id (cuid). This will delete zero rows."*
+- `logs/prompt-audit/.../1777818360282-...-implementer-rectification-t01.txt` — **Implementer at 14:26** receives the 5 findings; ends with `UNRESOLVED: The e2e tests expect the old deleteAllBySourceType + {imported, cleared} behavior...`
+- `logs/prompt-audit/.../1777819395655-...-test-writer-rectification-t01.txt` — **Test-writer at 14:43** receives the same 5 source-bug findings and reports:
+  > Fixed `loads links from GraphLink table` test: now expects **`cuid2`** as target (matches **actual** `getStoredGraph` behavior — it stores cuid in target field)
+  >
+  > Removed `upsertNode` describe block: the test asserted on `graphNodeUpsert.mock.calls[0][0]` but the actual implementation uses `txManager.run` so `mock.calls[0]` is empty
+
+The test-writer rewrote the assertion to expect the cuid bug the adversarial reviewer had just flagged at line 203, then deleted a failing test entirely. The next adversarial pass at 14:53 reports the same identifier-space bug again, sharper:
+
+> `storedLinkSet` is built from `storedLinks` using `l.target` which is `targetGraphNodeId` (cuid), while `newLink` key uses `link.target` which is the graphify nodeId. **These are different identifier spaces — the comparison will always fail.**
+
+---
+
+## Defect inventory
+
+### D1 — Test-writer covers up source bugs by loosening assertions [BLOCKING]
+
+**Location:** [`src/prompts/builders/rectifier-builder.ts`](../../src/prompts/builders/rectifier-builder.ts) (test-writer prompt) and [`src/pipeline/stages/autofix-cycle.ts:104-114`](../../src/pipeline/stages/autofix-cycle.ts#L104-L114) (test-writer strategy).
+
+The test-writer prompt forbids removing tests but permits rewriting assertions to "match actual behavior." When adversarial review's whole point is *"actual behavior is wrong,"* the test-writer's natural response is to lock the wrong behavior in.
+
+**Concrete instance:** Test-writer at 14:43 changed the test expectation from the *spec-correct* graphify nodeId to the *bug-introducing* cuid, citing *"matches actual `getStoredGraph` behavior"* as justification. This is the exact bug the reviewer flagged.
+
+### D2 — Strategy ordering is implementer-then-test-writer; should be inverted (TDD) [BLOCKING]
+
+**Location:** [`src/pipeline/stages/autofix-cycle.ts:83-117`](../../src/pipeline/stages/autofix-cycle.ts#L83-L117).
+
+`buildAutofixStrategies` returns `[implementer, testWriter]`. With both `coRun: "co-run-sequential"`, `selectExecutionGroup` runs implementer first then test-writer in the same iteration. This is the wrong order:
+
+- **Current**: implementer fixes source → test-writer writes tests → tests get bent to match (possibly still-broken) source.
+- **TDD-correct**: test-writer writes a *failing* test that captures expected behavior → implementer makes the test pass → bug cannot be locked in by an over-permissive test.
+
+### D3 — `collectTestTargetedChecks` leaks source findings into test-writer prompt [HIGH]
+
+**Location:** [`src/pipeline/stages/autofix-cycle.ts:77-79`](../../src/pipeline/stages/autofix-cycle.ts#L77-L79).
+
+```ts
+function collectTestTargetedChecks(ctx: PipelineContext): ReviewCheckResult[] {
+  return collectFailedChecks(ctx).filter((c) => c.findings?.some((f) => f.fixTarget === "test"));
+}
+```
+
+Filters at the **check** granularity but the test-writer's `buildInput` uses the entire check (with all findings, source-targeted ones included). Result: when the adversarial check has any test-targeted finding, the test-writer also receives the source-bug findings — exactly what happened in iter 3 (test-writer prompt at 14:43 lists 5 errors, all about source files like `incremental-graph-diff.service.ts:240`).
+
+### D4 — Implementer's `UNRESOLVED:` signal is ignored [HIGH]
+
+**Location:** [`src/findings/cycle.ts:243-261`](../../src/findings/cycle.ts#L243-L261) (no bail signal extraction) and [`src/pipeline/stages/autofix-cycle.ts:94-102`](../../src/pipeline/stages/autofix-cycle.ts#L94-L102) (implementer strategy surfaces `unresolvedReason` only via `extractApplied.summary`).
+
+When the implementer's response ends with `UNRESOLVED: <reason>`, the agent has explicitly given up. The cycle nonetheless runs the full validate (semantic + adversarial LLM calls — observed at ~6 minutes wall-clock for iter 3) and only notices on the *next* loop iteration that the cap is hit.
+
+The signal exists in `output.unresolvedReason` and is captured into `fa.summary`, but no bail predicate consumes it.
+
+### D5 — Off-by-one: validate runs after the final allowed fix attempt [MEDIUM]
+
+**Location:** [`src/findings/cycle.ts:156-200`](../../src/findings/cycle.ts#L156-L200).
+
+Loop order:
+1. Cap check (passes — `attempts < max`)
+2. Execute fix (counter += 1)
+3. Validate (full LLM review)
+4. Push iteration; loop top
+5. Cap check fails → exit
+
+The validate at step 3 on the last allowed attempt produces findings the cycle has no budget to act on. They are recorded in `finalFindings` but never given a fix attempt. With `maxAttempts=N`, the cycle does N fix attempts and produces N+1 validation reports — the last one is diagnostic-only.
+
+### D6 — Escalation reason discards the actual blocking findings [LOW]
+
+**Location:** [`src/pipeline/stages/autofix.ts:243-248`](../../src/pipeline/stages/autofix.ts#L243-L248).
+
+Cap-exhausted escalation surfaces `"Autofix exhausted: review still failing after fix attempts"`. The next escalation tier receives no information about *which* findings remain. `result.finalFindings` is available but discarded.
+
+---
+
+## Prior fixes already in place
+
+From the prior compacted session (do not redo):
+
+| Fix | Location | What it does |
+|:---|:---|:---|
+| Reverse `findUnresolvedReason` iteration order | `autofix-cycle.ts:127-135` | Most recent UNRESOLVED wins over stale iter-1 messages |
+| Suppress `unresolvedReason` on cap exit | `autofix-cycle.ts:230-231` | Cap-bound exits no longer attribute escalation to a stale UNRESOLVED |
+| Gate `if (!agentFixed && unresolvedReason)` | `autofix.ts:182` | Don't escalate "reviewer contradiction" when validate confirmed all findings resolved |
+| Merge blocking findings into single warn log | `adversarial.ts:382-392` | Removes the split debug+warn pair that hid finding details |
+
+These remove the *misleading* escalation messages, but do not address D1–D6: the test-writer still covers up bugs, the cycle still wastes a validate after UNRESOLVED, and the escalation message is still uninformative.
+
+---
+
+## Implementation plan
+
+Five PRs, roughly ordered by value-to-risk. PRs 1–3 close the cover-up loop; 4–5 cut wasted budget; 6 improves escalation hand-off.
+
+### PR 1 — Tighten test-writer prompt against assertion-loosening (D1)
+
+**Touches:** `src/prompts/builders/rectifier-builder.ts` (test-writer rectification builder).
+
+Add explicit constraints to the test-writer prompt:
+
+> - Do NOT loosen assertions to match current implementation behavior. If a test is failing, the source code is the suspect — not the test.
+> - Do NOT delete a failing test because the implementation makes it hard to assert on. Refactor the test if needed; never silently drop coverage.
+> - You are encoding the **specification**, not the **current behavior**. If the two disagree, write the test against the spec and let the implementer fix the source.
+
+Add a regression test asserting the new strings are in the prompt output.
+
+**Risk:** Low. Pure prompt change.
+
+### PR 2 — Fix `collectTestTargetedChecks` finding leak (D3)
+
+**Touches:** `src/pipeline/stages/autofix-cycle.ts`.
+
+Two changes:
+
+1. Filter `c.findings` down to test-targeted findings before passing to the test-writer's `buildInput`.
+2. If the filtered findings list is empty for a check, drop the check entirely from the test-writer's input.
+
+Add unit test: a check with mixed source/test findings yields a test-writer input containing only the test-targeted ones.
+
+**Risk:** Low. Localized; test-writer prompt is already only meant for test-file work.
+
+### PR 3 — Invert strategy order to TDD-style: test-writer before implementer (D2)
+
+**Touches:** `src/pipeline/stages/autofix-cycle.ts` (`buildAutofixStrategies`); possibly `src/findings/cycle.ts` if order-of-execution semantics need reinforcing.
+
+Two parts:
+
+**3a. Reorder.** Return `[testWriter, implementer]` from `buildAutofixStrategies`. With `co-run-sequential`, `selectExecutionGroup` runs them in the order returned, so the test-writer runs first within an iteration.
+
+**3b. Broaden test-writer applicability.** Today `appliesTo: (f) => f.fixTarget === "test"` — only fires on test-file findings. To convert *source-bug* adversarial findings into TDD cycles, the test-writer needs a second mode: when it sees a `severity: "error"` finding with `fixTarget: "source"` from an adversarial source, it writes a *failing* test capturing the spec-correct behavior described by the finding. The implementer then sees both the original finding and the failing test.
+
+This requires a new prompt mode in the test-writer builder ("write a failing test that captures this expected behavior; do not modify source") and a small extension to the strategy's `appliesTo` and `buildInput`.
+
+**3c. Pass test-writer output to implementer in same iteration.** Today `implementer.buildInput` reads `failedChecks` from `ctx`, which is the *previous* validate snapshot. After 3a runs the test-writer first, the implementer needs to know about the new failing tests. Two options:
+
+- **Lightweight:** include the names of the test files the test-writer touched (from the iteration's `fixesApplied[].targetFiles`) in the implementer's input.
+- **Heavier:** re-run lint/typecheck (cheap mechanical) between strategies in an iteration so the implementer's `failedChecks` reflects the new failing tests; skip the expensive LLM checks.
+
+Start with lightweight; revisit if implementer regression rate doesn't drop.
+
+**Risk:** Medium. The TDD inversion is a real behavior change; needs an integration test that simulates an adversarial finding round-trip and verifies the cycle no longer locks in the bug.
+
+### PR 4 — Bail on `UNRESOLVED:` before running validate (D4)
+
+**Touches:** `src/findings/cycle.ts`, `src/pipeline/stages/autofix-cycle.ts`.
+
+Add a typed bail signal. Two-step:
+
+**4a.** Extend `FixApplied` (or a sibling extracted field) to carry an explicit `unresolved?: string` set by `extractApplied`. Today the implementer surfaces this in `summary`, but `summary` is a free-form field also used for non-bail cases — collisions risk false bails.
+
+**4b.** In `runFixCycle`, after `fixesApplied` is populated and *before* `cycle.validate(ctx)` runs, check: if any `fa.unresolved` is set, exit with `exitReason: "agent-gave-up"` (new variant) and `bailDetail: <reason>`. Skip validate.
+
+Update `runAgentRectificationV2`:
+- Map the new exit reason to `succeeded: false` and propagate `unresolvedReason`.
+- The `if (!agentFixed && unresolvedReason)` gate in `autofix.ts` already routes this correctly to the "reviewer contradiction" escalation.
+
+**Risk:** Low-medium. Skipping validate means the cycle never gets a chance to detect "implementer was wrong, validate confirms all clean." This is acceptable: the agent's UNRESOLVED is treated as authoritative; the next escalation tier picks up.
+
+### PR 5 — Skip the wasted validate on the final allowed attempt (D5)
+
+**Touches:** `src/findings/cycle.ts`.
+
+After executing the fix in step 2 of the loop, before calling `cycle.validate`, check: if every active strategy has now reached its `maxAttempts`, the next loop pass would exit on cap regardless. In that case:
+
+- Option A: skip validate entirely; exit immediately with `cycle.findings` (the pre-fix snapshot).
+- Option B: run a "cheap-only" validate (mechanical checks, no LLM) — caller-supplied via a new optional `cycle.cheapValidate` hook. If it returns empty findings, exit `resolved`; otherwise exit `max-attempts-per-strategy`.
+
+Start with A. Cost saving is the wall-clock of the entire LLM review (~6 min observed in this run). Loses the ability to detect "last fix actually resolved everything" — acceptable; if the agent emitted UNRESOLVED, PR 4 already short-circuits this path.
+
+**Risk:** Medium. Changes cycle exit semantics on the last attempt. Update tests asserting `exitReason` for cap-bound cycles.
+
+### PR 6 — Surface `finalFindings` in the cap-exhausted escalation reason (D6)
+
+**Touches:** `src/pipeline/stages/autofix-cycle.ts` (compute digest), `src/pipeline/stages/autofix.ts` (use it).
+
+When `result.exitReason === "max-attempts-per-strategy"` and `result.finalFindings.length > 0`, build a one-line digest:
+
+```
+Autofix exhausted: 5 adversarial findings remain
+  - error-path × 2 in apps/api/src/rag/incremental-graph-diff.service.ts
+  - assumption × 1 in apps/api/src/rag/incremental-graph-diff.service.ts
+  - convention × 1, abandonment × 1 in apps/api/src/rag/rag.controller.ts
+```
+
+Pass this string as the escalation `reason` instead of the generic `"Autofix exhausted: review still failing after fix attempts"`.
+
+**Risk:** Low. Pure message change; no behavior change.
+
+---
+
+## Sequencing
+
+Recommended PR order: **1 → 2 → 4 → 6 → 3 → 5**.
+
+- 1 + 2 stop the test-writer from making things worse (cheap, low-risk).
+- 4 + 6 stop wasted work and improve escalation messages (low-risk).
+- 3 is the structural TDD inversion — higher value but needs careful integration testing.
+- 5 is an efficiency win that depends on the cycle exit semantics not surprising other consumers.
+
+Each PR includes its own regression test against a synthetic finding fixture.
+
+---
+
+## Out of scope (recorded for a follow-up)
+
+- **D7 — Reset per-strategy attempt cap on `regressed-different-source`.** When iter 1 introduces a totally new family of bugs, the original attempt budget is "stolen" from the new family. A smarter cap could track attempts per finding-source. Risky (cycle-forever potential); deferred until the TDD inversion in PR 3 has been observed in practice — it may render this moot by reducing regression rate.
+- **D8 — `priorityForCheck` maps `adversarial` to `"architectural"` (Priority 5, lowest).** When test failures coexist with adversarial findings, the rectifier prompt buries adversarial bugs below test failures. Tracked separately; not on this critical path.

--- a/src/findings/cycle-types.ts
+++ b/src/findings/cycle-types.ts
@@ -27,6 +27,8 @@ export interface FixApplied {
   targetFiles: string[];
   /** First ~500 chars of agent response or stdout. Empty when unavailable. */
   summary: string;
+  /** Set when the agent explicitly signals it cannot resolve the findings. Triggers agent-gave-up exit. */
+  unresolved?: string;
   costUsd?: number;
 }
 
@@ -58,7 +60,8 @@ export type FixCycleExitReason =
   | "max-attempts-total"
   | "max-attempts-per-strategy"
   | "validator-error"
-  | "bail-when";
+  | "bail-when"
+  | "agent-gave-up";
 
 export interface FixCycleResult<F extends Finding = Finding> {
   iterations: Iteration<F>[];
@@ -68,6 +71,8 @@ export interface FixCycleResult<F extends Finding = Finding> {
   exhaustedStrategy?: string;
   /** Human-readable detail from strategy.bailWhen(). Set when exitReason is "bail-when". */
   bailDetail?: string;
+  /** Reason text from the agent's UNRESOLVED sentinel. Set when exitReason is "agent-gave-up". */
+  unresolvedDetail?: string;
   /** Total cost of all fix attempts in the cycle. Only present when strategies surface cost via extractApplied. */
   costUsd?: number;
 }
@@ -132,7 +137,10 @@ export interface FixStrategy<
    * record-keeping. When absent, targetFiles defaults to [], summary to "", and costUsd
    * is omitted ( FixApplied.costUsd stays undefined).
    */
-  extractApplied?: (output: O, input: I) => { targetFiles?: string[]; summary?: string; costUsd?: number };
+  extractApplied?: (
+    output: O,
+    input: I,
+  ) => { targetFiles?: string[]; summary?: string; costUsd?: number; unresolved?: string };
 
   /**
    * Optional bail predicate called before each iteration. Return a non-null

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -256,8 +256,73 @@ export async function runFixCycle<F extends Finding>(
         op: strategy.fixOp.name,
         targetFiles: extracted.targetFiles ?? [],
         summary: extracted.summary ?? "",
+        ...(extracted.unresolved ? { unresolved: extracted.unresolved } : {}),
         costUsd: extracted.costUsd,
       });
+    }
+
+    // ── Bail on agent-gave-up ─────────────────────────────────────────────────
+    // Must run before the cap-exhausted skip-validate check: if the agent signals
+    // UNRESOLVED on its final attempt, agent-gave-up takes priority so the
+    // unresolvedDetail is surfaced rather than silently folded into a cap-exit.
+    const unresolvedFa = fixesApplied.find((fa) => fa.unresolved);
+    if (unresolvedFa) {
+      const finishedAt = now();
+      cycle.iterations.push({
+        iterationNum: cycle.iterations.length + 1,
+        findingsBefore,
+        fixesApplied,
+        findingsAfter: cycle.findings,
+        outcome: "unchanged",
+        startedAt,
+        finishedAt,
+      });
+      logger?.info("findings.cycle", "cycle exited — agent gave up", {
+        storyId,
+        packageDir,
+        cycleName,
+        reason: "agent-gave-up",
+        strategyName: unresolvedFa.strategyName,
+        unresolvedDetail: unresolvedFa.unresolved,
+      });
+      return {
+        iterations: cycle.iterations,
+        finalFindings: cycle.findings,
+        exitReason: "agent-gave-up",
+        unresolvedDetail: unresolvedFa.unresolved,
+        costUsd: totalCostUsd,
+      };
+    }
+
+    // ── Skip validate if all active strategies are now at their cap ───────────
+    // Counting provisional attempts (including this iteration's fixesApplied).
+    const provisionalIterations = [...cycle.iterations, { fixesApplied } as Iteration<F>];
+    const allExhausted = group.every((s) => countStrategyAttempts(provisionalIterations, s.name) >= s.maxAttempts);
+    if (allExhausted) {
+      const finishedAt = now();
+      cycle.iterations.push({
+        iterationNum: cycle.iterations.length + 1,
+        findingsBefore,
+        fixesApplied,
+        findingsAfter: cycle.findings,
+        outcome: "unchanged",
+        startedAt,
+        finishedAt,
+      });
+      logger?.info("findings.cycle", "cycle exited — strategy attempt cap reached (skipped final validate)", {
+        storyId,
+        packageDir,
+        cycleName,
+        reason: "max-attempts-per-strategy",
+        exhaustedStrategy: group[0]?.name,
+      });
+      return {
+        iterations: cycle.iterations,
+        finalFindings: cycle.findings,
+        exitReason: "max-attempts-per-strategy",
+        exhaustedStrategy: group[0]?.name,
+        costUsd: totalCostUsd,
+      };
     }
 
     // ── Validate ──────────────────────────────────────────────────────────────

--- a/src/operations/autofix-test-writer.ts
+++ b/src/operations/autofix-test-writer.ts
@@ -8,6 +8,7 @@ import type { RunOperation } from "./types";
 export interface AutofixTestWriterInput {
   failedChecks: ReviewCheckResult[];
   story: UserStory;
+  mode?: "fix-test-files" | "write-failing-test";
 }
 
 export interface AutofixTestWriterOutput {
@@ -21,7 +22,9 @@ export const testWriterRectifyOp: RunOperation<AutofixTestWriterInput, AutofixTe
   session: { role: "test-writer", lifetime: "fresh" },
   config: autofixConfigSelector,
   build(input, _ctx) {
-    const prompt = RectifierPromptBuilder.testWriterRectification(input.failedChecks, input.story);
+    const prompt = RectifierPromptBuilder.testWriterRectification(input.failedChecks, input.story, {
+      mode: input.mode,
+    });
     return {
       role: { id: "role", content: "", overridable: false },
       task: { id: "task", content: prompt, overridable: false },

--- a/src/pipeline/stages/autofix-cycle.ts
+++ b/src/pipeline/stages/autofix-cycle.ts
@@ -75,7 +75,20 @@ function collectCurrentFindings(ctx: PipelineContext): Finding[] {
 }
 
 function collectTestTargetedChecks(ctx: PipelineContext): ReviewCheckResult[] {
-  return collectFailedChecks(ctx).filter((c) => c.findings?.some((f) => f.fixTarget === "test"));
+  return collectFailedChecks(ctx)
+    .map((c) => ({ ...c, findings: (c.findings ?? []).filter((f) => f.fixTarget === "test") }))
+    .filter((c) => c.findings.length > 0);
+}
+
+function collectAdversarialSourceChecks(ctx: PipelineContext): ReviewCheckResult[] {
+  return collectFailedChecks(ctx)
+    .map((c) => ({
+      ...c,
+      findings: (c.findings ?? []).filter(
+        (f) => (f.fixTarget ?? "source") === "source" && f.severity === "error" && f.source === "adversarial-review",
+      ),
+    }))
+    .filter((c) => c.check === "adversarial" && c.findings.length > 0);
 }
 
 // ─── Strategies ───────────────────────────────────────────────────────────────
@@ -96,42 +109,52 @@ function buildAutofixStrategies(
       story: ctx.story,
     }),
     extractApplied: (output) => ({
-      // Surface the UNRESOLVED sentinel in summary so post-cycle scan can detect it
       summary: output.unresolvedReason ?? "",
+      unresolved: output.unresolvedReason,
     }),
   };
 
   const testWriter: FixStrategy<Finding, AutofixTestWriterInput, { applied: true }, AutofixConfig> = {
     name: "autofix-test-writer",
-    appliesTo: (f) => f.fixTarget === "test",
+    // D2: also fires for adversarial source-bug error findings so the test-writer can
+    // generate a failing test that documents spec-correct behavior before the implementer runs.
+    appliesTo: (f) =>
+      f.fixTarget === "test" ||
+      ((f.fixTarget ?? "source") === "source" && f.severity === "error" && f.source === "adversarial-review"),
     fixOp: testWriterRectifyOp,
     maxAttempts: 1,
     coRun: "co-run-sequential",
-    buildInput: (_findings, _prior, _cycleCtx): AutofixTestWriterInput => ({
-      failedChecks: collectTestTargetedChecks(ctx),
-      story: ctx.story,
-    }),
+    buildInput: (findings, _prior, _cycleCtx): AutofixTestWriterInput => {
+      const hasSourceBug = findings.some(
+        (f) => (f.fixTarget ?? "source") === "source" && f.source === "adversarial-review",
+      );
+      if (hasSourceBug) {
+        return { failedChecks: collectAdversarialSourceChecks(ctx), story: ctx.story, mode: "write-failing-test" };
+      }
+      return { failedChecks: collectTestTargetedChecks(ctx), story: ctx.story };
+    },
   };
 
-  return [implementer, testWriter];
+  // D2: test-writer runs before implementer (TDD order) — test-writer writes the failing
+  // test first, then implementer makes it pass. Both run co-run-sequential in the same iteration.
+  return [testWriter, implementer];
 }
 
-// ─── UNRESOLVED detection ─────────────────────────────────────────────────────
+// ─── Escalation digest ───────────────────────────────────────────────────────
 
-/**
- * Scan iteration history for an UNRESOLVED sentinel emitted by the implementer.
- * The reason is surfaced via extractApplied.summary on the autofix-implementer strategy.
- * Iterates in reverse so the most recent sentinel wins over stale early-iteration messages.
- */
-function findUnresolvedReason(result: FixCycleResult<Finding>): string | undefined {
-  for (let i = result.iterations.length - 1; i >= 0; i--) {
-    for (const fa of result.iterations[i].fixesApplied) {
-      if (fa.strategyName === "autofix-implementer" && fa.summary) {
-        return fa.summary;
-      }
-    }
+function buildEscalationDigest(findings: Finding[]): string {
+  const byFile = new Map<string, Finding[]>();
+  for (const f of findings) {
+    const file = f.file ?? "unknown";
+    const list = byFile.get(file) ?? [];
+    list.push(f);
+    byFile.set(file, list);
   }
-  return undefined;
+  const lines = [...byFile.entries()].map(([file, fs]) => {
+    const categories = fs.map((f) => f.category ?? f.source).join(", ");
+    return `  - ${categories} in ${file}`;
+  });
+  return `Autofix exhausted: ${findings.length} finding${findings.length !== 1 ? "s" : ""} remain\n${lines.join("\n")}`;
 }
 
 // ─── Shadow mode ──────────────────────────────────────────────────────────────
@@ -184,7 +207,7 @@ export async function runAgentRectificationV2(
   _lintFixCmd: string | undefined,
   _formatFixCmd: string | undefined,
   _effectiveWorkdir: string,
-): Promise<{ succeeded: boolean; cost: number; unresolvedReason?: string }> {
+): Promise<{ succeeded: boolean; cost: number; unresolvedReason?: string; escalationDigest?: string }> {
   const logger = getLogger();
   const storyId = ctx.story.id;
 
@@ -222,12 +245,13 @@ export async function runAgentRectificationV2(
 
   await writeShadowReport(ctx, result, initialFindings.length);
 
-  // Only surface unresolvedReason when the implementer explicitly gave up (not when the
-  // cycle simply hit the cap). When exitReason is "max-attempts-per-strategy", the natural
-  // "autofix exhausted" escalation path in autofix.ts fires with the correct message.
-  // Using unresolvedReason from cap-hit runs causes misleading "reviewer contradiction"
-  // escalation driven by a stale early-iteration UNRESOLVED message.
-  const unresolvedReason = result.exitReason !== "max-attempts-per-strategy" ? findUnresolvedReason(result) : undefined;
+  // Surface unresolvedReason only when the agent explicitly gave up mid-cycle.
+  // Cap-exhausted exits ("max-attempts-per-strategy") use the escalation digest path instead.
+  const unresolvedReason = result.exitReason === "agent-gave-up" ? result.unresolvedDetail : undefined;
+  const escalationDigest =
+    result.exitReason === "max-attempts-per-strategy" && result.finalFindings.length > 0
+      ? buildEscalationDigest(result.finalFindings)
+      : undefined;
   const succeeded = result.exitReason === "resolved" || result.finalFindings.length === 0;
 
   logger.info("autofix-cycle", "V2 fix cycle complete", {
@@ -237,7 +261,13 @@ export async function runAgentRectificationV2(
     finalFindingsCount: result.finalFindings.length,
     succeeded,
     ...(unresolvedReason ? { unresolvedReason } : {}),
+    ...(escalationDigest ? { escalationDigest } : {}),
   });
 
-  return { succeeded, cost: 0, ...(unresolvedReason ? { unresolvedReason } : {}) };
+  return {
+    succeeded,
+    cost: 0,
+    ...(unresolvedReason ? { unresolvedReason } : {}),
+    ...(escalationDigest ? { escalationDigest } : {}),
+  };
 }

--- a/src/pipeline/stages/autofix-cycle.ts
+++ b/src/pipeline/stages/autofix-cycle.ts
@@ -121,10 +121,11 @@ function buildAutofixStrategies(
 /**
  * Scan iteration history for an UNRESOLVED sentinel emitted by the implementer.
  * The reason is surfaced via extractApplied.summary on the autofix-implementer strategy.
+ * Iterates in reverse so the most recent sentinel wins over stale early-iteration messages.
  */
 function findUnresolvedReason(result: FixCycleResult<Finding>): string | undefined {
-  for (const iter of result.iterations) {
-    for (const fa of iter.fixesApplied) {
+  for (let i = result.iterations.length - 1; i >= 0; i--) {
+    for (const fa of result.iterations[i].fixesApplied) {
       if (fa.strategyName === "autofix-implementer" && fa.summary) {
         return fa.summary;
       }
@@ -221,7 +222,12 @@ export async function runAgentRectificationV2(
 
   await writeShadowReport(ctx, result, initialFindings.length);
 
-  const unresolvedReason = findUnresolvedReason(result);
+  // Only surface unresolvedReason when the implementer explicitly gave up (not when the
+  // cycle simply hit the cap). When exitReason is "max-attempts-per-strategy", the natural
+  // "autofix exhausted" escalation path in autofix.ts fires with the correct message.
+  // Using unresolvedReason from cap-hit runs causes misleading "reviewer contradiction"
+  // escalation driven by a stale early-iteration UNRESOLVED message.
+  const unresolvedReason = result.exitReason !== "max-attempts-per-strategy" ? findUnresolvedReason(result) : undefined;
   const succeeded = result.exitReason === "resolved" || result.finalFindings.length === 0;
 
   logger.info("autofix-cycle", "V2 fix cycle complete", {

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -176,7 +176,10 @@ export const autofixStage: PipelineStage = {
     } = await _autofixDeps.runAgentRectification(ctx, lintFixCmd, formatFixCmd, ctx.workdir);
 
     // REVIEW-003: Implementer signalled an unresolvable reviewer contradiction.
-    if (unresolvedReason) {
+    // Only act on unresolvedReason when the fix actually failed — if agentFixed is true,
+    // all findings were resolved and the UNRESOLVED note is informational (one finding
+    // was abandoned but the validate step confirmed nothing is left blocking).
+    if (!agentFixed && unresolvedReason) {
       // When only mechanical checks failed (LLM/semantic passed), the code is functionally
       // correct — the agent cannot fix lint/typecheck errors in test files per its constraints.
       // Suppress tier escalation and proceed; log a warning so the issue remains visible.

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -173,6 +173,7 @@ export const autofixStage: PipelineStage = {
       succeeded: agentFixed,
       cost: agentCost,
       unresolvedReason,
+      escalationDigest,
     } = await _autofixDeps.runAgentRectification(ctx, lintFixCmd, formatFixCmd, ctx.workdir);
 
     // REVIEW-003: Implementer signalled an unresolvable reviewer contradiction.
@@ -243,7 +244,7 @@ export const autofixStage: PipelineStage = {
     logger.warn("autofix", "Autofix exhausted — escalating", { storyId: ctx.story.id });
     return {
       action: "escalate",
-      reason: "Autofix exhausted: review still failing after fix attempts",
+      reason: escalationDigest ?? "Autofix exhausted: review still failing after fix attempts",
       cost: agentCost,
     };
   },

--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -219,12 +219,58 @@ export class RectifierPromptBuilder {
   }
 
   /**
-   * Prompt for the test-writer to fix test file issues routed from review (#409).
+   * Prompt for the test-writer to fix test file issues or write failing tests (D2, #897).
    *
-   * Sent when review found problems in test files that the implementer cannot fix
-   * (isolation constraint). Handles both adversarial-review findings and lint failures.
+   * Two modes:
+   * - "fix-test-files" (default): fix existing test files flagged by review (#409).
+   * - "write-failing-test": write a NEW failing test that documents spec-correct behavior
+   *   described in an adversarial source-bug finding. The implementer then makes it pass.
    */
-  static testWriterRectification(testFileFindings: ReviewCheckResult[], story: UserStory): string {
+  static testWriterRectification(
+    findings: ReviewCheckResult[],
+    story: UserStory,
+    options?: { mode?: "fix-test-files" | "write-failing-test" },
+  ): string {
+    if (options?.mode === "write-failing-test") {
+      return RectifierPromptBuilder._testWriterWriteFailingTest(findings, story);
+    }
+    return RectifierPromptBuilder._testWriterFixTestFiles(findings, story);
+  }
+
+  private static _testWriterWriteFailingTest(findings: ReviewCheckResult[], story: UserStory): string {
+    const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
+    const findingLines = findings
+      .flatMap((c) =>
+        (c.findings ?? []).map((f) => `- [${f.severity}] ${f.file ?? "unknown"}:${f.line ?? "?"} — ${f.message}`),
+      )
+      .join("\n");
+
+    const scopeConstraint = story.workdir
+      ? `\n\nIMPORTANT: Only create or modify test files within \`${story.workdir}/\`. Do NOT touch source files.`
+      : "\n\nIMPORTANT: Only create or modify test files. Do NOT touch source implementation files.";
+
+    return `You are writing a failing test that documents spec-correct behavior.
+
+Story: ${story.title} (${story.id})
+
+### Acceptance Criteria
+${acList}
+
+### Source Bugs Found by Adversarial Review
+${findingLines}
+
+**Task:** For each bug above, write a NEW failing test that asserts the spec-correct behavior described in the finding. The test should FAIL with the current (buggy) implementation and PASS once the implementer fixes the source.
+
+Rules:
+1. Write the test against the SPECIFICATION, not the current behavior.
+2. Do NOT fix the source files — only write test files.
+3. Do NOT modify existing passing tests.
+4. The test must fail with the current code.
+
+Commit your new tests when done.${scopeConstraint}`;
+  }
+
+  private static _testWriterFixTestFiles(testFileFindings: ReviewCheckResult[], story: UserStory): string {
     const scopeConstraint = story.workdir
       ? `\n\nIMPORTANT: Only modify test files within \`${story.workdir}/\`. Do NOT touch source files.`
       : "\n\nIMPORTANT: Only modify test files. Do NOT touch source implementation files.";
@@ -261,10 +307,14 @@ export class RectifierPromptBuilder {
 
     const importantNote = isLintOnly
       ? "**Important:** Fix the lint errors in the test files listed above. Do NOT modify source implementation files."
-      : `**Important:** These findings are in test files. Before making any changes:
-1. Read the flagged test files to verify each finding is a real issue
-2. Only fix findings that are genuinely incorrect or missing — do NOT remove tests
-3. Do NOT modify source implementation files`;
+      : `**Important:** You are encoding the SPECIFICATION, not the current behavior.
+
+Before making any changes:
+1. Read the flagged test files to verify each finding is a real issue.
+2. Do NOT loosen assertions to match current implementation behavior. If a test is failing because the source is wrong, the source is the suspect — not the test.
+3. Do NOT delete a failing test because the implementation makes it hard to assert on. Refactor the test structure if needed; never silently drop coverage.
+4. If the current behavior disagrees with the acceptance criteria, write the test against the spec and let the implementer fix the source.
+5. Do NOT modify source implementation files.`;
 
     return `${opener}
 

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -382,9 +382,6 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     logger?.warn("review", `Adversarial review failed: ${blockingFindings.length} blocking findings`, {
       storyId: story.id,
       durationMs,
-    });
-    logger?.debug("review", "Adversarial review findings", {
-      storyId: story.id,
       findings: blockingFindings.map((f) => ({
         severity: f.severity,
         category: f.category,

--- a/test/unit/findings/cycle.test.ts
+++ b/test/unit/findings/cycle.test.ts
@@ -303,6 +303,122 @@ callOp: callOpMock as unknown as CallOpFn});
   });
 });
 
+// ─── runFixCycle — bail: skip validate on final attempt (#897) ───────────────
+
+describe("runFixCycle — skip validate on final allowed attempt", () => {
+  test("skips validate when the only strategy hits its cap after a fix", async () => {
+    let validateCalled = false;
+    const strategy = makeStrategy({ name: "lint-fix", maxAttempts: 1 });
+    const cycle = makeCycle([lintA], [strategy], async () => {
+      validateCalled = true;
+      return [lintA];
+    });
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("max-attempts-per-strategy");
+    expect(validateCalled).toBe(false);
+    expect(callOpMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("still runs validate when strategy has remaining attempts after a fix", async () => {
+    let validateCalled = false;
+    const strategy = makeStrategy({ name: "lint-fix", maxAttempts: 3 });
+    const cycle = makeCycle([lintA], [strategy], async () => {
+      validateCalled = true;
+      return []; // resolved
+    });
+    const callOpMock = makeCallOpMock();
+
+    await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(validateCalled).toBe(true);
+  });
+
+  test("skips validate when all co-run strategies hit their caps simultaneously", async () => {
+    let validateCalled = false;
+    const strategyA = makeStrategy({ name: "fix-a", maxAttempts: 1, coRun: "co-run-sequential" });
+    const strategyB = makeStrategy({ name: "fix-b", maxAttempts: 1, coRun: "co-run-sequential" });
+    const cycle = makeCycle([lintA], [strategyA, strategyB], async () => {
+      validateCalled = true;
+      return [lintA];
+    });
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("max-attempts-per-strategy");
+    expect(validateCalled).toBe(false);
+  });
+});
+
+// ─── runFixCycle — bail: agent-gave-up (#897) ────────────────────────────────
+
+describe("runFixCycle — bail: agent-gave-up", () => {
+  test("exits with agent-gave-up when extractApplied returns unresolved string", async () => {
+    let validateCalled = false;
+    const strategy = makeStrategy({
+      name: "source-fix",
+      extractApplied: () => ({ summary: "", unresolved: "Cannot resolve — conflicting requirements" }),
+    });
+    const cycle = makeCycle([lintA], [strategy], async () => {
+      validateCalled = true;
+      return [];
+    });
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("agent-gave-up");
+    expect(result.unresolvedDetail).toBe("Cannot resolve — conflicting requirements");
+    expect(validateCalled).toBe(false);
+  });
+
+  test("records the iteration without findingsAfter when bailing on UNRESOLVED", async () => {
+    const strategy = makeStrategy({
+      name: "source-fix",
+      extractApplied: () => ({ summary: "", unresolved: "Cannot proceed" }),
+    });
+    const cycle = makeCycle([lintA], [strategy], async () => []);
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.iterations).toHaveLength(1);
+    expect(result.finalFindings).toEqual([lintA]);
+  });
+
+  test("agent-gave-up takes priority over cap-exhausted when UNRESOLVED on final attempt", async () => {
+    // maxAttempts: 1 — the first (and only) fix signals UNRESOLVED.
+    // Both agent-gave-up and skip-validate conditions fire simultaneously.
+    // agent-gave-up must win so unresolvedDetail is surfaced.
+    let validateCalled = false;
+    const strategy = makeStrategy({
+      name: "source-fix",
+      maxAttempts: 1,
+      extractApplied: () => ({ summary: "", unresolved: "conflicting spec" }),
+    });
+    const cycle = makeCycle([lintA], [strategy], async () => {
+      validateCalled = true;
+      return [];
+    });
+    const callOpMock = makeCallOpMock();
+
+    const result = await runFixCycle(cycle, makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
+callOp: callOpMock as unknown as CallOpFn});
+
+    expect(result.exitReason).toBe("agent-gave-up");
+    expect(result.unresolvedDetail).toBe("conflicting spec");
+    expect(validateCalled).toBe(false);
+  });
+});
+
 // ─── runFixCycle — bail: validator-error ─────────────────────────────────────
 
 describe("runFixCycle — bail: validator-error", () => {
@@ -432,9 +548,10 @@ callOp: callOpMock as unknown as CallOpFn});
     expect(called).toEqual(["op-a", "op-b"]);
   });
 
-  test("iterates until resolved", async () => {
+  test("iterates until resolved (maxAttempts exceeds iteration count)", async () => {
     let validateCall = 0;
-    const strategy = makeStrategy({ name: "lint-fix" });
+    // maxAttempts=4 so the 3rd validate still runs (not skipped as final attempt)
+    const strategy = makeStrategy({ name: "lint-fix", maxAttempts: 4 });
     // First two validations return a finding, third returns empty
     const cycle = makeCycle([lintA], [strategy], async () => {
       validateCall++;

--- a/test/unit/pipeline/stages/autofix-core.test.ts
+++ b/test/unit/pipeline/stages/autofix-core.test.ts
@@ -238,6 +238,28 @@ describe("autofixStage", () => {
     expect(result.action).toBe("escalate");
   });
 
+  // D6 — escalation digest used as reason when available (#897)
+  test("escalation reason uses digest from rectification when available", async () => {
+    const saved = { ..._autofixDeps };
+    _autofixDeps.recheckReview = async () => false;
+    _autofixDeps.runAgentRectification = async () => ({
+      succeeded: false,
+      cost: 0,
+      escalationDigest: "Autofix exhausted: 3 findings remain\n  - error-path × 2 in src/foo.ts",
+    });
+
+    const ctx = makeCtx({ reviewResult: makeReviewResult(false) });
+    const result = await autofixStage.execute(ctx);
+
+    Object.assign(_autofixDeps, saved);
+
+    expect(result.action).toBe("escalate");
+    if (result.action === "escalate") {
+      expect(result.reason).toContain("error-path");
+      expect(result.reason).toContain("src/foo.ts");
+    }
+  });
+
   test("partial progress — cleared checks added to skip list, returns retry when budget remains", async () => {
     const saved = { ..._autofixDeps };
     _autofixDeps.runAgentRectification = async (mockCtx: PipelineContext) => {

--- a/test/unit/pipeline/stages/autofix-cycle.test.ts
+++ b/test/unit/pipeline/stages/autofix-cycle.test.ts
@@ -223,6 +223,165 @@ describe("runAgentRectificationV2", () => {
     expect(capturedChecks[1]?.some((c) => c.check === "lint")).toBe(false);
   });
 
+  // D2 — TDD inversion: test-writer runs before implementer (#897)
+  test("test-writer runs before implementer within the same iteration", async () => {
+    const opOrder: string[] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any): Promise<any> => {
+      opOrder.push(op.name as string);
+      return { applied: true };
+    });
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
+      return true;
+    });
+
+    const ctx = makeCtx();
+    ctx.reviewResult = {
+      success: false,
+      checks: [
+        {
+          ...failedCheck("adversarial", "mixed"),
+          findings: [
+            { source: "adversarial-review", severity: "error", category: "source-bug", message: "source bug", fixTarget: "source" as const },
+            { source: "adversarial-review", severity: "error", category: "test-gap", message: "missing test", fixTarget: "test" as const },
+          ],
+        },
+      ],
+    } as unknown as PipelineContext["reviewResult"];
+
+    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    const testWriterIdx = opOrder.indexOf("autofix-test-writer");
+    const implementerIdx = opOrder.indexOf("autofix-implementer");
+    expect(testWriterIdx).toBeGreaterThanOrEqual(0);
+    expect(implementerIdx).toBeGreaterThanOrEqual(0);
+    expect(testWriterIdx).toBeLessThan(implementerIdx);
+  });
+
+  // D6 — escalation digest when cap exhausted (#897)
+  test("returns escalationDigest describing remaining findings when cycle exhausts attempts", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (): Promise<any> => ({ applied: true }));
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = {
+        success: false,
+        checks: [
+          {
+            ...failedCheck("adversarial", "still failing"),
+            findings: [
+              {
+                source: "adversarial-review",
+                severity: "error",
+                category: "error-path",
+                message: "bug persists",
+                fixTarget: "source" as const,
+                file: "src/foo.ts",
+              },
+            ],
+          },
+        ],
+      } as unknown as PipelineContext["reviewResult"];
+      return false;
+    });
+
+    // maxAttempts: 2 so the first fix runs validate, which updates ctx to adversarial findings.
+    // The second fix then hits the cap and skips validate, using the adversarial findings as finalFindings.
+    const ctx = makeCtx({
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          autofix: { enabled: true, maxAttempts: 2, maxTotalAttempts: 4 },
+        },
+      } as PipelineContext["config"],
+    });
+    // Initial review has an adversarial finding with a file path in the finding list
+    ctx.reviewResult = {
+      success: false,
+      checks: [
+        {
+          ...failedCheck("adversarial", "still failing"),
+          findings: [
+            {
+              source: "adversarial-review",
+              severity: "error",
+              category: "error-path",
+              message: "bug remains",
+              fixTarget: "source" as const,
+              file: "src/foo.ts",
+            },
+          ],
+        },
+      ],
+    } as unknown as PipelineContext["reviewResult"];
+
+    const result = await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    expect(result.succeeded).toBe(false);
+    expect(result.escalationDigest).toBeDefined();
+    expect(result.escalationDigest).toContain("remain");
+    expect(result.escalationDigest).toContain("src/foo.ts");
+  });
+
+  // D4 — UNRESOLVED bail before validate (#897)
+  test("returns unresolvedReason when implementer op signals UNRESOLVED via extractApplied", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (): Promise<any> => ({
+      unresolvedReason: "conflicting requirements — test asserts wrong identifier space",
+    }));
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = {
+        success: false,
+        checks: [failedCheck("adversarial", "still failing")],
+      } as unknown as PipelineContext["reviewResult"];
+      return false;
+    });
+
+    const result = await runAgentRectificationV2(makeCtx(), undefined, undefined, "/tmp");
+
+    expect(result.succeeded).toBe(false);
+    expect(result.unresolvedReason).toBe("conflicting requirements — test asserts wrong identifier space");
+  });
+
+  // D3 — collectTestTargetedChecks finding leak (#897)
+  // When a check has test-targeted findings mixed with non-adversarial source findings,
+  // the fix-test-files path must only pass test-targeted findings to the test-writer.
+  test("test-writer receives only test-targeted findings in fix-test-files mode (semantic + mixed check)", async () => {
+    const capturedTestWriterChecks: ReviewCheckResult[][] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any, input: any): Promise<any> => {
+      if (op.name === "autofix-test-writer") capturedTestWriterChecks.push(input?.failedChecks ?? []);
+      return { applied: true };
+    });
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
+      return true;
+    });
+
+    const ctx = makeCtx();
+    // Semantic check (not adversarial) with mixed findings — only test-targeted should reach the test-writer
+    ctx.reviewResult = {
+      success: false,
+      checks: [
+        {
+          ...failedCheck("semantic", "mixed findings"),
+          findings: [
+            { source: "semantic-review", severity: "error", category: "logic", message: "source bug", fixTarget: "source" as const },
+            { source: "semantic-review", severity: "error", category: "test-gap", message: "missing test", fixTarget: "test" as const },
+          ],
+        },
+      ],
+    } as unknown as PipelineContext["reviewResult"];
+
+    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    expect(capturedTestWriterChecks.length).toBeGreaterThan(0);
+    const receivedFindings = capturedTestWriterChecks[0]?.[0]?.findings ?? [];
+    expect(receivedFindings).toHaveLength(1);
+    expect(receivedFindings[0]?.fixTarget).toBe("test");
+  });
+
   test("persists iterations to autofixPriorIterations on ctx", async () => {
     // biome-ignore lint/suspicious/noExplicitAny: test mock
     _cycleDeps.callOp = mock(async (): Promise<any> => ({ applied: true }));

--- a/test/unit/prompts/builders/rectifier-builder.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder.test.ts
@@ -442,11 +442,11 @@ describe("RectifierPromptBuilder.testWriterRectification", () => {
     expect(prompt).toContain("Resolve deadlock");
   });
 
-  test("instructs not to remove tests or modify source files", () => {
+  test("instructs not to delete failing tests or modify source files", () => {
     const checks = [makeTestFileCheck("test/unit/foo.test.ts", "finding")];
     const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory());
 
-    expect(prompt).toContain("do NOT remove tests");
+    expect(prompt).toContain("Do NOT delete a failing test");
     expect(prompt).toContain("Do NOT modify source implementation files");
   });
 
@@ -476,7 +476,7 @@ describe("RectifierPromptBuilder.testWriterRectification", () => {
 
     expect(prompt).toContain("You are fixing test file issues flagged by an adversarial code reviewer.");
     expect(prompt).toContain("### Test File Findings (adversarial review)");
-    expect(prompt).toContain("do NOT remove tests");
+    expect(prompt).toContain("Do NOT delete a failing test");
   });
 
   test("lint-only check: uses lint opener and section label", () => {
@@ -522,5 +522,87 @@ describe("RectifierPromptBuilder.testWriterRectification", () => {
 
     expect(prompt).toContain("Fix the lint errors");
     expect(prompt).not.toContain("verify each finding is a real issue");
+  });
+
+  // D1 — Anti-assertion-loosening constraints (#897)
+  test("adversarial check: forbids loosening assertions to match current implementation behavior", () => {
+    const checks = [makeTestFileCheck("test/unit/foo.test.ts", "finding")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory());
+
+    expect(prompt).toContain("Do NOT loosen assertions to match current implementation behavior");
+  });
+
+  test("adversarial check: instructs to encode spec not current behavior", () => {
+    const checks = [makeTestFileCheck("test/unit/foo.test.ts", "finding")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory());
+
+    expect(prompt).toContain("SPECIFICATION");
+    expect(prompt).toContain("not the current behavior");
+  });
+
+  test("adversarial check: forbids deleting failing tests", () => {
+    const checks = [makeTestFileCheck("test/unit/foo.test.ts", "finding")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory());
+
+    expect(prompt).toContain("Do NOT delete a failing test");
+  });
+});
+
+// D2 — write-failing-test mode (#897)
+describe("RectifierPromptBuilder.testWriterRectification — write-failing-test mode", () => {
+  function makeSourceBugCheck(file: string, message: string): import("../../../../src/review/types").ReviewCheckResult {
+    return {
+      check: "adversarial",
+      success: false,
+      command: "adversarial-review",
+      exitCode: 1,
+      output: "adversarial output",
+      durationMs: 100,
+      findings: [
+        {
+          severity: "error",
+          file,
+          line: 203,
+          message,
+          source: "adversarial-review",
+          fixTarget: "source" as const,
+          category: "error-path",
+        },
+      ],
+    };
+  }
+
+  function makeStory() {
+    return {
+      id: "US-897",
+      title: "Incremental Graph Diff",
+      workdir: undefined,
+      acceptanceCriteria: ["AC-1: Graph diffs are computed correctly"],
+    } as any;
+  }
+
+  test("write-failing-test mode: instructs to write a failing test, not fix source", () => {
+    const checks = [makeSourceBugCheck("src/service.ts", "upsertNode uses wrong identifier space")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory(), { mode: "write-failing-test" });
+
+    expect(prompt).toContain("failing test");
+    expect(prompt).toContain("spec-correct");
+    expect(prompt).toContain("FAIL with the current");
+  });
+
+  test("write-failing-test mode: does not instruct to fix source files", () => {
+    const checks = [makeSourceBugCheck("src/service.ts", "wrong id")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory(), { mode: "write-failing-test" });
+
+    expect(prompt).not.toContain("Fix the lint errors");
+    expect(prompt).not.toContain("You are fixing test file");
+  });
+
+  test("write-failing-test mode: includes the source bug finding details", () => {
+    const checks = [makeSourceBugCheck("src/service.ts", "deleteMany uses node.id instead of GraphNode.id")];
+    const prompt = RectifierPromptBuilder.testWriterRectification(checks, makeStory(), { mode: "write-failing-test" });
+
+    expect(prompt).toContain("deleteMany uses node.id instead of GraphNode.id");
+    expect(prompt).toContain("src/service.ts");
   });
 });


### PR DESCRIPTION
Closes #897

## Summary

Fixes 6 compounding defects identified in `docs/findings/2026-05-04-autofix-cycle-tdd-ordering-and-bail-signals.md`, all traced to a koda run (US-001, 2026-05-03) where the test-writer locked in a source bug by loosening assertions to match buggy behavior.

- **D1** — Tighten test-writer prompt: forbid assertion-loosening, test deletion, and spec drift. The prompt now explicitly instructs the agent to write against the specification, not the current (potentially buggy) implementation.
- **D2** — TDD inversion: reverse co-run-sequential order so test-writer runs before implementer. Extend `appliesTo` to fire on adversarial source-bug findings, adding a new `write-failing-test` mode where the test-writer writes a failing test encoding spec-correct behavior before the implementer fixes the source.
- **D3** — `collectTestTargetedChecks` now filters at the finding level (not check level), preventing source-bug findings from leaking into the test-writer input when a check has mixed `fixTarget` values.
- **D4** — Typed UNRESOLVED bail: `extractApplied` on the implementer strategy surfaces `unresolvedReason` as a typed `unresolved` field on `FixApplied`. `runFixCycle` exits with `agent-gave-up` + `unresolvedDetail` when any strategy signals UNRESOLVED, skipping validate. `autofix-cycle` routes this to `unresolvedReason`; cap exits use the escalation digest path.
- **D5** — Skip validate on final attempt: when all active strategies hit their per-strategy cap after executing (counting provisional attempts), `runFixCycle` exits without calling validate, preventing a wasted review invocation.
- **D6** — Escalation digest: `runAgentRectificationV2` returns a human-readable `escalationDigest` (findings grouped by file) when the cycle exhausts its cap. `autofix.ts` uses this as the escalation reason.
- **Ordering fix** (post-review): `agent-gave-up` check now runs before `skip-validate`, ensuring UNRESOLVED on the final allowed attempt is surfaced as `agent-gave-up` with `unresolvedDetail` rather than silently folded into a cap-exit.

## Files changed

| File | Change |
|:-----|:-------|
| `src/prompts/builders/rectifier-builder.ts` | D1: stricter importantNote; D2: write-failing-test mode |
| `src/findings/cycle-types.ts` | D4: `unresolved` on `FixApplied`; `agent-gave-up` exit reason; `unresolvedDetail` on result |
| `src/findings/cycle.ts` | D4: agent-gave-up bail; D5: skip-validate on final attempt; ordering fix |
| `src/pipeline/stages/autofix-cycle.ts` | D2: TDD order + extended appliesTo; D3: finding-level filter; D4: extractApplied; D6: escalationDigest |
| `src/pipeline/stages/autofix.ts` | D6: use escalationDigest as escalation reason |
| `src/operations/autofix-test-writer.ts` | D2: mode field on AutofixTestWriterInput |

## Test plan

- [ ] `timeout 30 bun test test/unit/findings/cycle.test.ts --timeout=10000` — 28 tests including new D4/D5 coverage and ordering fix test
- [ ] `timeout 30 bun test test/unit/pipeline/stages/autofix-cycle.test.ts --timeout=10000` — 11 tests including D2/D3/D4/D6 scenarios
- [ ] `timeout 30 bun test test/unit/prompts/builders/rectifier-builder.test.ts --timeout=10000` — D1/D2 prompt tests
- [ ] `timeout 30 bun test test/unit/pipeline/stages/autofix-core.test.ts --timeout=10000` — D6 escalation digest integration
- [ ] `bun run test` — full suite green