### PR TITLE
refactor: extract acceptance diagnose findings adapter

### DIFF
--- a/docs/adr/ADR-021-findings-and-fix-strategy-ssot.md
+++ b/docs/adr/ADR-021-findings-and-fix-strategy-ssot.md
@@ -1,10 +1,13 @@
 # ADR-021: Finding Type SSOT
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-02
+**Accepted:** 2026-05-04
 **Author:** William Khoo, Claude
 **Supersedes:** —
 **Related:** ADR-022 (Fix Strategy + Cycle Orchestration — companion ADR built on this type)
+
+> **Implementation status (2026-05-04):** Phases 1–4 and 6–9 shipped. **Phase 5 (TDD verifier producer) is suggestion-only and not on the implementation roadmap** — the TDD subsystem already has its own self-contained fix mechanism (3-session orchestration + tier escalation; see [src/tdd/verdict.ts](../../src/tdd/verdict.ts), [src/pipeline/stages/execution-helpers.ts:56](../../src/pipeline/stages/execution-helpers.ts#L56), [src/execution/escalation/tier-escalation.ts:68](../../src/execution/escalation/tier-escalation.ts#L68)). Verifier failures route through `categorizeVerdict()` → `routeTddFailure()` → tier escalation, never through `runFixCycle`. The `"tdd-verifier"` `FindingSource` enum value is preserved as a reserved slot but has no producer adapter and no consumer; building one today would be unread emission. Revisit only if a per-finding TDD rectification path is introduced (would require its own ADR). The `acceptance.fix.findingsV2` flag was skipped — schema rolled out unconditionally after dogfood validation.
 
 ---
 
@@ -160,7 +163,7 @@ Each phase after phase 1 is a **fold-per-producer** PR — the producer's adapte
 | **2. Plugin adapter** | `IReviewPlugin` boundary | `failedChecks` aggregator in autofix; review-result audit serialiser | Plugin contract (`ReviewFinding`) unchanged. Internal nax converts to `Finding` at the IReviewPlugin call site. |
 | **3. Lint** | Biome JSON parser | `splitFindingsByScope` lint branch; lint output rendering | Replaces raw output parsing. Mechanical, deterministic. |
 | **4. Typecheck** | tsc `--pretty=false` parser | `splitFindingsByScope` typecheck branch | Same shape change as lint. |
-| **5. TDD verifier** | TDD verifier output parser | Verifier verdict consumer | Small. User confirmed scope (item 7 in design discussion). |
+| **5. TDD verifier** | TDD verifier output parser | Verifier verdict consumer | **Suggestion only — not on roadmap.** TDD has its own fix mechanism (3-session + tier escalation); `categorizeVerdict()` → `routeTddFailure()` never enters `runFixCycle`. The `"tdd-verifier"` enum slot stays reserved but unproduced. Revisit only if a per-finding TDD rectification path is introduced (separate ADR). |
 | **6. Adversarial** | `acceptanceDiagnoseOp` and the adversarial review op | `buildPriorFindingsBlock` reads `Finding[]`; `AdversarialFindingsCache.findings[]` becomes `Finding[]` | Severity rename `"warn"` → `"warning"` in OUTPUT_SCHEMA block lands here. Read-path `normalizeSeverity` adapters in `semantic-helpers.ts`/`adversarial-helpers.ts`/`dialogue.ts` already handle the rename. |
 | **7. Semantic** | semantic review op | `buildAttemptContextBlock`, `SemanticVerdict.findings`, semantic evidence verifier | `verifiedBy` → `meta.verifiedBy`; AC ID → `rule`. |
 | **8. Acceptance diagnose** | `acceptanceDiagnoseOp` prompt schema | `applyFix` consumes `findings: Finding[]` (with `fixTarget` per item) instead of `testIssues`/`sourceIssues`. AC-HOOK / AC-ERROR sentinels emitted as findings (§5). | Behind `acceptance.fix.findingsV2` flag, default off. Bench against `nax-dogfood/fixtures/hello-lint`. Largest behaviour change in the ADR; lands last to benefit from prior phases' patterns. |

--- a/docs/adr/ADR-022-fix-strategy-and-cycle.md
+++ b/docs/adr/ADR-022-fix-strategy-and-cycle.md
@@ -1,10 +1,13 @@
 # ADR-022: Fix Strategy and Cycle Orchestration
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-02
+**Accepted:** 2026-05-04
 **Author:** William Khoo, Claude
 **Builds on:** ADR-021 (Finding Type SSOT)
 **Related:** ADR-006 (Acceptance Retry Loop Restructure — superseded in part by phase 4 of this ADR)
+
+> **Implementation status (2026-05-04):** All 8 phases shipped. `acceptance.fix.cycleV2` and `quality.autofix.cycleV2` flags skipped — both cycles cut over directly. `runAgentRectification` re-exports `runAgentRectificationV2` from `src/pipeline/stages/autofix-cycle.ts`. Acceptance enters `runFixCycle` from `runAcceptanceLoop` after the stub-regen prelude. Carry-forward via `buildPriorIterationsBlock` is wired into review-builder, adversarial-review-builder, and acceptance-loop.
 
 ---
 

--- a/docs/specs/2026-05-04-acceptance-diagnose-adapter.md
+++ b/docs/specs/2026-05-04-acceptance-diagnose-adapter.md
@@ -1,0 +1,196 @@
+# Acceptance-Diagnose Adapter Extraction
+
+**Date:** 2026-05-04
+**Author:** William Khoo, Claude
+**Related:** ADR-021 (Finding Type SSOT) — phase 8 follow-up
+**Scope:** Refactor only. No behaviour change.
+**Risk:** Low.
+
+---
+
+## Context
+
+ADR-021 phase 8 migrated the `acceptanceDiagnoseOp` LLM schema to emit `findings: Finding[]` instead of `testIssues: string[]` / `sourceIssues: string[]`. The schema migration shipped, but the raw-record-to-`Finding` conversion was implemented **inline in the op's `parse()` callback** at [src/operations/acceptance-diagnose.ts:62-77](../../src/operations/acceptance-diagnose.ts#L62) rather than in a named adapter under [src/findings/adapters/](../../src/findings/adapters/).
+
+Every other producer follows the "one adapter file per producer" pattern:
+
+| Producer | Adapter file |
+|:---|:---|
+| Lint (Biome) | [src/findings/adapters/lint.ts](../../src/findings/adapters/lint.ts) — `lintDiagnosticToFinding` |
+| Typecheck (tsc) | [src/findings/adapters/typecheck.ts](../../src/findings/adapters/typecheck.ts) — `tscDiagnosticToFinding` |
+| Plugin reviewers | [src/findings/adapters/plugin.ts](../../src/findings/adapters/plugin.ts) — `pluginToFinding` |
+| Semantic review | [src/findings/adapters/semantic-review.ts](../../src/findings/adapters/semantic-review.ts) — `reviewFindingToFinding` |
+| Test runner (AC failure / sentinel) | [src/findings/adapters/test-runner.ts](../../src/findings/adapters/test-runner.ts) — `acFailureToFinding`, `acSentinelToFinding` |
+| **Acceptance diagnose** | **inline in `parse()` — inconsistent** |
+
+The inline mapping is functionally correct but:
+- Cannot be unit-tested in isolation (must mock the full op)
+- Cannot be reused if another diagnose-style op (e.g. a future `tddVerifierToFindings`) wants the same record-validation logic
+- Is the only adapter whose tests live in `test/unit/operations/` rather than `test/unit/findings/adapters/`
+
+## Goals
+
+1. Extract the raw-record-to-`Finding` mapping into `src/findings/adapters/acceptance-diagnose.ts`.
+2. Re-export from the `src/findings/adapters/index.ts` barrel and `src/findings/index.ts` top-level barrel.
+3. Replace the inline block in `acceptanceDiagnoseOp.parse()` with a single adapter call.
+4. Move existing tests of the inline mapping (if any) to `test/unit/findings/adapters/acceptance-diagnose.test.ts`. Add coverage for malformed records, missing `category`, missing `message`, and the empty-array case.
+
+## Non-goals
+
+- No prompt schema changes.
+- No changes to the `AcceptanceDiagnoseOutput` shape.
+- No changes to fallback semantics (`FALLBACK` constant stays in the op).
+- No changes to acceptance fix routing or `runFixCycle` integration.
+
+## Design
+
+### Adapter signature
+
+```typescript
+// src/findings/adapters/acceptance-diagnose.ts
+
+import type { Finding, FindingSeverity, FixTarget } from "../types";
+
+/**
+ * Convert a single raw record from the LLM-emitted `findings[]` array into
+ * a Finding. Returns null when the record is malformed (missing required
+ * fields). Callers filter nulls.
+ *
+ * Required fields on the raw record:
+ *   - message: string
+ *   - category: string
+ *
+ * Optional fields (preserved when present and well-typed):
+ *   severity, fixTarget, file, line, suggestion
+ */
+export function acceptanceDiagnoseRawToFinding(
+  raw: Record<string, unknown>,
+): Finding | null {
+  if (typeof raw.message !== "string" || typeof raw.category !== "string") {
+    return null;
+  }
+  return {
+    source: "acceptance-diagnose",
+    severity: (typeof raw.severity === "string" ? raw.severity : "error") as FindingSeverity,
+    category: String(raw.category),
+    message: String(raw.message),
+    fixTarget: (raw.fixTarget as FixTarget | undefined) ?? undefined,
+    file: typeof raw.file === "string" ? raw.file : undefined,
+    line: typeof raw.line === "number" ? raw.line : undefined,
+    suggestion: typeof raw.suggestion === "string" ? raw.suggestion : undefined,
+  };
+}
+
+/**
+ * Bulk variant — converts an array of raw records, dropping malformed entries.
+ * Returns [] when input is not an array or all entries are malformed.
+ */
+export function acceptanceDiagnoseRawArrayToFindings(
+  raw: unknown,
+): Finding[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((r): r is Record<string, unknown> => r !== null && typeof r === "object")
+    .map(acceptanceDiagnoseRawToFinding)
+    .filter((f): f is Finding => f !== null);
+}
+```
+
+The bulk variant carries the array-shape guard so the op's `parse()` becomes a one-liner.
+
+### Op-side change
+
+```typescript
+// src/operations/acceptance-diagnose.ts — parse() body
+
+const raw = tryParseLLMJson<Record<string, unknown>>(output);
+if (
+  raw &&
+  typeof raw.verdict === "string" &&
+  typeof raw.reasoning === "string" &&
+  typeof raw.confidence === "number"
+) {
+  const base = {
+    verdict: raw.verdict as AcceptanceDiagnoseOutput["verdict"],
+    reasoning: raw.reasoning,
+    confidence: raw.confidence,
+  };
+  const findings = acceptanceDiagnoseRawArrayToFindings(raw.findings);
+  if (findings.length > 0) return { ...base, findings };
+  return base;
+}
+return FALLBACK;
+```
+
+Net delta: ~16 lines removed from the op, ~40 lines added in the adapter (most are doc comments and the bulk variant).
+
+### Barrel exports
+
+```typescript
+// src/findings/adapters/index.ts
+export {
+  acceptanceDiagnoseRawToFinding,
+  acceptanceDiagnoseRawArrayToFindings,
+} from "./acceptance-diagnose";
+
+// src/findings/index.ts
+export {
+  acceptanceDiagnoseRawArrayToFindings,
+  acceptanceDiagnoseRawToFinding,
+  // …existing exports
+} from "./adapters";
+```
+
+## Test plan
+
+New file: `test/unit/findings/adapters/acceptance-diagnose.test.ts`.
+
+| Case | Input | Expected |
+|:---|:---|:---|
+| Well-formed minimal record | `{ message: "x", category: "stdout-capture" }` | `Finding{ source: "acceptance-diagnose", severity: "error", category: "stdout-capture", message: "x" }` |
+| All optional fields present | `{ message, category, severity: "warning", fixTarget: "test", file, line: 12, suggestion }` | All fields preserved |
+| Missing `message` | `{ category: "x" }` | `null` (single) / `[]` (bulk) |
+| Missing `category` | `{ message: "x" }` | `null` (single) / `[]` (bulk) |
+| Wrong types | `{ message: 1, category: 2 }` | `null` |
+| Mixed array — one valid, one malformed | `[{ message, category }, { message }]` | length 1, valid record only |
+| Non-array bulk input | `"not an array"`, `null`, `undefined`, `{}` | `[]` |
+| Empty array | `[]` | `[]` |
+| Severity coercion | `{ message, category, severity: 42 }` | `severity: "error"` (default) |
+| `fixTarget` coercion | `{ message, category, fixTarget: "weird" }` | Passes through (no enum check at this layer — runtime trusts ADR-021 schema; future tightening tracked separately) |
+
+Additionally — port any existing inline-mapping coverage from `test/unit/operations/acceptance-diagnose.test.ts` into the new file; thin the op's tests down to verdict/reasoning/confidence parsing and the FALLBACK path.
+
+## Migration steps
+
+1. Create `src/findings/adapters/acceptance-diagnose.ts` with both functions.
+2. Re-export from `src/findings/adapters/index.ts` and `src/findings/index.ts`.
+3. Replace the inline mapping block in `src/operations/acceptance-diagnose.ts` with the bulk-adapter call. Import from the `src/findings` barrel (not the leaf path) per `forbidden-patterns.md`.
+4. Add `test/unit/findings/adapters/acceptance-diagnose.test.ts` with the table above.
+5. Trim `test/unit/operations/acceptance-diagnose.test.ts` if it duplicates the new coverage.
+6. Run:
+   - `timeout 30 bun test test/unit/findings/adapters/ --timeout=5000`
+   - `timeout 30 bun test test/unit/operations/acceptance-diagnose.test.ts --timeout=5000`
+   - `timeout 60 bun test test/unit/execution/lifecycle/acceptance-loop.test.ts --timeout=5000`
+   - `bun run lint`
+   - `bun run typecheck`
+
+## Acceptance criteria
+
+- `src/operations/acceptance-diagnose.ts` no longer constructs `Finding` objects directly — it imports the adapter and delegates.
+- All existing acceptance-loop / acceptance-fix tests pass without modification.
+- New adapter test file covers the 10 cases in the test plan above.
+- `grep -rn "source: \"acceptance-diagnose\"" src/` returns hits **only** in `src/findings/adapters/acceptance-diagnose.ts` and `src/findings/types.ts` (doc-comment) — no inline construction elsewhere.
+- Biome and tsc both pass clean.
+
+## Out of scope
+
+- Tightening the runtime severity / fixTarget / category enum checks. The current behaviour preserves whatever the LLM emits (matching pre-migration behaviour); a stricter validator is a separate change.
+- Promoting the inline construction in [src/operations/acceptance-diagnose.ts:62-77](../../src/operations/acceptance-diagnose.ts#L62) into a Zod schema. Tracked under the broader LLM-schema-validation work — out of scope here.
+- Sharing the record-shape with a future TDD verifier adapter (see ADR-021 status banner — not consumed today).
+
+## References
+
+- ADR-021 §6 — Acceptance diagnose prompt schema change (the source of the original migration)
+- [src/operations/acceptance-diagnose.ts:62-77](../../src/operations/acceptance-diagnose.ts#L62) — current inline construction
+- [src/findings/adapters/](../../src/findings/adapters/) — sibling adapters for reference
+- `.claude/rules/forbidden-patterns.md` — barrel-import discipline

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "bun build bin/nax.ts --outdir dist --target bun --define \"GIT_COMMIT=\\\"$(git rev-parse --short HEAD)\\\"\"",
     "typecheck": "bun x tsc --noEmit",
     "lint": "bun x biome check src/ bin/",
+    "lint:json": "bun x biome check src/ bin/ --reporter json",
     "lint:fix": "bun x biome check --write src/ bin/",
     "release": "bun scripts/release.ts",
     "test": "bun run scripts/run-tests.ts",

--- a/src/findings/adapters/acceptance-diagnose.ts
+++ b/src/findings/adapters/acceptance-diagnose.ts
@@ -1,0 +1,35 @@
+import type { Finding, FindingSeverity, FixTarget } from "../types";
+
+/**
+ * Convert one raw finding record from the acceptance diagnose LLM output into
+ * the normalized Finding format. Returns null when required fields are missing.
+ */
+export function acceptanceDiagnoseRawToFinding(raw: Record<string, unknown>): Finding | null {
+  if (typeof raw.message !== "string" || typeof raw.category !== "string") {
+    return null;
+  }
+
+  return {
+    source: "acceptance-diagnose",
+    severity: (typeof raw.severity === "string" ? raw.severity : "error") as FindingSeverity,
+    category: String(raw.category),
+    message: String(raw.message),
+    fixTarget: (raw.fixTarget as FixTarget | undefined) ?? undefined,
+    file: typeof raw.file === "string" ? raw.file : undefined,
+    line: typeof raw.line === "number" ? raw.line : undefined,
+    suggestion: typeof raw.suggestion === "string" ? raw.suggestion : undefined,
+  };
+}
+
+/**
+ * Convert raw acceptance diagnose findings into normalized findings, dropping
+ * malformed records. Returns an empty array for non-array inputs.
+ */
+export function acceptanceDiagnoseRawArrayToFindings(raw: unknown): Finding[] {
+  if (!Array.isArray(raw)) return [];
+
+  return raw
+    .filter((record): record is Record<string, unknown> => record !== null && typeof record === "object")
+    .map(acceptanceDiagnoseRawToFinding)
+    .filter((finding): finding is Finding => finding !== null);
+}

--- a/src/findings/adapters/index.ts
+++ b/src/findings/adapters/index.ts
@@ -1,3 +1,7 @@
+export {
+  acceptanceDiagnoseRawArrayToFindings,
+  acceptanceDiagnoseRawToFinding,
+} from "./acceptance-diagnose";
 export { lintDiagnosticToFinding } from "./lint";
 export { pluginToFinding } from "./plugin";
 export { reviewFindingToFinding } from "./semantic-review";

--- a/src/findings/index.ts
+++ b/src/findings/index.ts
@@ -21,6 +21,8 @@ export type {
 export { SEVERITY_ORDER, compareSeverity, findingKey } from "./types";
 
 export {
+  acceptanceDiagnoseRawArrayToFindings,
+  acceptanceDiagnoseRawToFinding,
   acFailureToFinding,
   acSentinelToFinding,
   lintDiagnosticToFinding,

--- a/src/operations/acceptance-diagnose.ts
+++ b/src/operations/acceptance-diagnose.ts
@@ -1,7 +1,8 @@
 import type { SemanticVerdict } from "../acceptance/types";
 import { acceptanceConfigSelector } from "../config";
 import type { AcceptanceConfig } from "../config/selectors";
-import type { Finding, FindingSeverity, FixTarget } from "../findings";
+import { acceptanceDiagnoseRawArrayToFindings } from "../findings";
+import type { Finding } from "../findings";
 import { AcceptancePromptBuilder } from "../prompts";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { RunOperation } from "./types";
@@ -59,23 +60,8 @@ export const acceptanceDiagnoseOp: RunOperation<AcceptanceDiagnoseInput, Accepta
         confidence: raw.confidence,
       };
 
-      if (Array.isArray(raw.findings) && raw.findings.length > 0) {
-        const findings = (raw.findings as Array<Record<string, unknown>>)
-          .filter((f) => typeof f.message === "string" && typeof f.category === "string")
-          .map(
-            (f): Finding => ({
-              source: "acceptance-diagnose",
-              severity: (typeof f.severity === "string" ? f.severity : "error") as FindingSeverity,
-              category: String(f.category),
-              message: String(f.message),
-              fixTarget: (f.fixTarget as FixTarget | undefined) ?? undefined,
-              file: typeof f.file === "string" ? f.file : undefined,
-              line: typeof f.line === "number" ? f.line : undefined,
-              suggestion: typeof f.suggestion === "string" ? f.suggestion : undefined,
-            }),
-          );
-        if (findings.length > 0) return { ...base, findings };
-      }
+      const findings = acceptanceDiagnoseRawArrayToFindings(raw.findings);
+      if (findings.length > 0) return { ...base, findings };
 
       return base;
     }

--- a/test/unit/findings/adapters/acceptance-diagnose.test.ts
+++ b/test/unit/findings/adapters/acceptance-diagnose.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import {
+  acceptanceDiagnoseRawArrayToFindings,
+  acceptanceDiagnoseRawToFinding,
+} from "../../../../src/findings";
+
+describe("acceptanceDiagnoseRawToFinding", () => {
+  test("maps well-formed minimal record with default severity", () => {
+    const finding = acceptanceDiagnoseRawToFinding({
+      message: "wrong output stream",
+      category: "stdout-capture",
+    });
+
+    expect(finding).toMatchObject({
+      source: "acceptance-diagnose",
+      severity: "error",
+      category: "stdout-capture",
+      message: "wrong output stream",
+    });
+  });
+
+  test("preserves optional fields when well-typed", () => {
+    const finding = acceptanceDiagnoseRawToFinding({
+      message: "bad import",
+      category: "import-path",
+      severity: "warning",
+      fixTarget: "test",
+      file: "test/foo.test.ts",
+      line: 12,
+      suggestion: "fix path",
+    });
+
+    expect(finding).toMatchObject({
+      source: "acceptance-diagnose",
+      severity: "warning",
+      fixTarget: "test",
+      file: "test/foo.test.ts",
+      line: 12,
+      suggestion: "fix path",
+      category: "import-path",
+      message: "bad import",
+    });
+  });
+
+  test("returns null when message is missing", () => {
+    const finding = acceptanceDiagnoseRawToFinding({ category: "stdout-capture" });
+    expect(finding).toBeNull();
+  });
+
+  test("returns null when category is missing", () => {
+    const finding = acceptanceDiagnoseRawToFinding({ message: "x" });
+    expect(finding).toBeNull();
+  });
+
+  test("returns null for wrong required field types", () => {
+    const finding = acceptanceDiagnoseRawToFinding({ message: 1, category: 2 });
+    expect(finding).toBeNull();
+  });
+
+  test("defaults severity to error when severity is non-string", () => {
+    const finding = acceptanceDiagnoseRawToFinding({
+      message: "x",
+      category: "other",
+      severity: 42,
+    });
+
+    expect(finding?.severity).toBe("error");
+  });
+
+  test("passes through unknown fixTarget string", () => {
+    const finding = acceptanceDiagnoseRawToFinding({
+      message: "x",
+      category: "other",
+      fixTarget: "weird",
+    });
+
+    expect(finding?.fixTarget).toBe("weird");
+  });
+});
+
+describe("acceptanceDiagnoseRawArrayToFindings", () => {
+  test("returns [] for non-array input", () => {
+    expect(acceptanceDiagnoseRawArrayToFindings("not an array")).toEqual([]);
+    expect(acceptanceDiagnoseRawArrayToFindings(null)).toEqual([]);
+    expect(acceptanceDiagnoseRawArrayToFindings(undefined)).toEqual([]);
+    expect(acceptanceDiagnoseRawArrayToFindings({})).toEqual([]);
+  });
+
+  test("returns [] for empty array", () => {
+    expect(acceptanceDiagnoseRawArrayToFindings([])).toEqual([]);
+  });
+
+  test("drops malformed records and keeps valid ones", () => {
+    const findings = acceptanceDiagnoseRawArrayToFindings([
+      { message: "valid", category: "ac-mismatch" },
+      { message: "missing category" },
+      { category: "missing message" },
+    ]);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      source: "acceptance-diagnose",
+      message: "valid",
+      category: "ac-mismatch",
+    });
+  });
+});

--- a/test/unit/operations/acceptance-diagnose.test.ts
+++ b/test/unit/operations/acceptance-diagnose.test.ts
@@ -109,33 +109,6 @@ describe("acceptanceDiagnoseOp.parse()", () => {
     expect(result.findings?.length).toBe(1);
     expect(result.findings?.[0]).toMatchObject({ fixTarget: "test", category: "import-path", message: "wrong relative path" });
   });
-  test("injects source:'acceptance-diagnose' into LLM findings (LLM does not emit source)", () => {
-    const ctx = makeBuildCtx();
-    const json = JSON.stringify({
-      verdict: "test_bug",
-      reasoning: "bad import",
-      confidence: 0.9,
-      findings: [{ fixTarget: "test", category: "import-path", message: "wrong path" }],
-    });
-    const result = acceptanceDiagnoseOp.parse(json, SAMPLE_INPUT, ctx);
-    expect(result.findings?.[0].source).toBe("acceptance-diagnose");
-  });
-  test("drops findings items missing required message or category", () => {
-    const ctx = makeBuildCtx();
-    const json = JSON.stringify({
-      verdict: "test_bug",
-      reasoning: "bad import",
-      confidence: 0.9,
-      findings: [
-        { fixTarget: "test", category: "import-path", message: "valid" },
-        { fixTarget: "test", message: "missing category" },
-        { fixTarget: "source", category: "missing-impl" },
-      ],
-    });
-    const result = acceptanceDiagnoseOp.parse(json, SAMPLE_INPUT, ctx);
-    expect(result.findings?.length).toBe(1);
-    expect(result.findings?.[0].message).toBe("valid");
-  });
   test("falls back gracefully when findings[] is empty array", () => {
     const ctx = makeBuildCtx();
     const json = JSON.stringify({


### PR DESCRIPTION
## Summary
- extract acceptance-diagnose raw finding normalization into a dedicated adapter
- export the new adapter from findings barrels and delegate acceptance diagnose parse mapping to it
- add adapter-focused unit coverage and trim duplicated operation-level mapping tests
- include implementation spec for this refactor in docs/specs

## Validation
- timeout 30 bun test test/unit/findings/adapters/ --timeout=5000
- timeout 30 bun test test/unit/operations/acceptance-diagnose.test.ts --timeout=5000
- timeout 60 bun test test/unit/execution/lifecycle/acceptance-loop.test.ts --timeout=5000
- timeout 60 bun test test/unit/execution/lifecycle/acceptance-fix.test.ts --timeout=5000
- bun run lint
- bun run typecheck
- grep -Rni "source: \"acceptance-diagnose\"" src

## Notes
- fallback semantics and AcceptanceDiagnoseOutput shape are unchanged
- unrelated local ADR edits were intentionally left out of this commit