### PR TITLE
feat: split .nax/ into VCS inputs, per-user outputs, and global state

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -35,7 +35,7 @@
 
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import chalk from "chalk";
 import { Command } from "commander";
 
@@ -80,6 +80,7 @@ import { run } from "../src/execution";
 import { loadHooksConfig } from "../src/hooks";
 import { type LogLevel, initLogger, resetLogger } from "../src/logger";
 import { countStories, loadPRD } from "../src/prd";
+import { projectOutputDir } from "../src/runtime";
 import { PipelineEventEmitter, type StoryDisplayState, renderTui } from "../src/tui";
 import { NAX_VERSION } from "../src/version";
 
@@ -136,6 +137,7 @@ program
   .command("init")
   .description("Initialize nax in the current project")
   .option("-d, --dir <path>", "Project directory", process.cwd())
+  .option("-n, --name <name>", "Project name for the output registry (default: directory name)")
   .option("-f, --force", "Force overwrite existing files", false)
   .option("--package <dir>", "Scaffold per-package nax/context.md (e.g. packages/api)")
   .action(async (options) => {
@@ -170,12 +172,42 @@ program
       return;
     }
 
+    // Validate and collision-check --name when explicitly provided
+    if (options.name) {
+      const { validateProjectName, checkInitCollision } = await import("../src/cli/init");
+      const nameValidation = validateProjectName(options.name);
+      if (!nameValidation.valid) {
+        console.error(chalk.red(`Invalid project name "${options.name}": ${nameValidation.error}`));
+        process.exit(1);
+      }
+      if (!options.force) {
+        const collision = await checkInitCollision(options.name, workdir, null);
+        if (collision.collision && collision.existing) {
+          console.error(
+            chalk.red(
+              [
+                `Project name collision: "${options.name}"`,
+                `  This project:    ${workdir}`,
+                `  Already in use:  ${collision.existing.workdir}  (last run: ${collision.existing.lastSeen})`,
+                "  Resolve:",
+                "    1. Rename: choose a different --name",
+                `    2. Reclaim: nax migrate --reclaim ${options.name}`,
+                `    3. Merge:   nax migrate --merge ${options.name}`,
+              ].join("\n"),
+            ),
+          );
+          process.exit(1);
+        }
+      }
+    }
+
     // Create directory structure
     mkdirSync(join(naxDir, "features"), { recursive: true });
     mkdirSync(join(naxDir, "hooks"), { recursive: true });
 
-    // Write default config
-    await Bun.write(join(naxDir, "config.json"), JSON.stringify(DEFAULT_CONFIG, null, 2));
+    // Write config (include name when explicitly provided)
+    const initConfig = options.name ? { ...DEFAULT_CONFIG, name: options.name } : DEFAULT_CONFIG;
+    await Bun.write(join(naxDir, "config.json"), JSON.stringify(initConfig, null, 2));
 
     // Write default hooks.json
     await Bun.write(
@@ -464,8 +496,12 @@ program
     // Reset plan logger (if plan phase ran) so the run logger can be initialized fresh
     resetLogger();
 
-    // Create run directory and JSONL log file path
-    const runsDir = join(featureDir, "runs");
+    // Resolve output directory: ~/.nax/<projectKey>/ or config.outputDir override
+    const projectKey = config.name?.trim() || basename(workdir);
+    const outputDir = projectOutputDir(projectKey, config.outputDir);
+
+    // Create run directory and JSONL log file path under the output dir
+    const runsDir = join(outputDir, "features", options.feature, "runs");
     mkdirSync(runsDir, { recursive: true });
 
     // Generate run ID from ISO timestamp
@@ -528,8 +564,8 @@ program
       console.log(chalk.dim("   [Headless mode — pipe output]"));
     }
 
-    // Compute status file path: <workdir>/.nax/status.json
-    const statusFilePath = join(workdir, ".nax", "status.json");
+    // Compute status file path under the output dir
+    const statusFilePath = join(outputDir, "status.json");
 
     // Parse --parallel option
     let parallel: number | undefined;
@@ -589,6 +625,37 @@ program
     }
 
     process.exit(result.success ? 0 : 1);
+  });
+
+// ── migrate ───────────────────────────────────────────
+program
+  .command("migrate")
+  .description("Migrate generated content from .nax/ to the output directory (~/.nax/<project>/)")
+  .option("-d, --dir <path>", "Project directory", process.cwd())
+  .option("--dry-run", "Preview moves without touching the filesystem", false)
+  .option("--reclaim <name>", "Archive ~/.nax/<name>/ to free the project name")
+  .option("--merge <name>", "Rewrite the identity for <name> to point to this workdir")
+  .action(async (options) => {
+    let workdir: string;
+    try {
+      workdir = validateDirectory(options.dir);
+    } catch (err) {
+      console.error(chalk.red(`Invalid directory: ${(err as Error).message}`));
+      process.exit(1);
+      return;
+    }
+    const { migrateCommand } = await import("../src/commands/migrate");
+    try {
+      await migrateCommand({
+        workdir,
+        dryRun: options.dryRun,
+        reclaim: options.reclaim,
+        merge: options.merge,
+      });
+    } catch (err) {
+      console.error(chalk.red(`Error: ${(err as Error).message}`));
+      process.exit(1);
+    }
   });
 
 // ── features ─────────────────────────────────────────

--- a/src/cli/diagnose.ts
+++ b/src/cli/diagnose.ts
@@ -6,11 +6,12 @@
  */
 
 import { existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { findProjectDir } from "../config";
 import type { NaxStatusFile } from "../execution/status-file";
 import { getLogger } from "../logger";
 import { loadPRD } from "../prd";
+import { projectOutputDir } from "../runtime";
 import { diagnoseStories, generateRecommendations } from "./diagnose-analysis";
 import { formatReport } from "./diagnose-formatter";
 
@@ -85,8 +86,8 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-async function loadStatusFile(workdir: string): Promise<NaxStatusFile | null> {
-  const statusPath = join(workdir, ".nax", "status.json");
+async function loadStatusFile(outputDir: string): Promise<NaxStatusFile | null> {
+  const statusPath = join(outputDir, "status.json");
   if (!existsSync(statusPath)) return null;
   try {
     return (await Bun.file(statusPath).json()) as NaxStatusFile;
@@ -140,13 +141,15 @@ export async function diagnoseCommand(options: DiagnoseOptions = {}): Promise<vo
   }
   if (!projectDir) throw new Error("Not in a nax project directory");
 
+  const outputDir = projectOutputDir(basename(projectDir), undefined);
+
   let feature = options.feature;
   if (!feature) {
-    const status = await loadStatusFile(projectDir);
+    const status = await loadStatusFile(outputDir);
     if (status) {
       feature = status.run.feature;
     } else {
-      const featuresDir = join(projectDir, ".nax", "features");
+      const featuresDir = join(outputDir, "features");
       if (!existsSync(featuresDir)) throw new Error("No features found in project");
       const features = readdirSync(featuresDir, { withFileTypes: true })
         .filter((e) => e.isDirectory())
@@ -157,12 +160,12 @@ export async function diagnoseCommand(options: DiagnoseOptions = {}): Promise<vo
     }
   }
 
-  const featureDir = join(projectDir, ".nax", "features", feature);
+  const featureDir = join(outputDir, "features", feature);
   const prdPath = join(featureDir, "prd.json");
   if (!existsSync(prdPath)) throw new Error(`Feature not found: ${feature}`);
 
   const prd = await loadPRD(prdPath);
-  const status = await loadStatusFile(projectDir);
+  const status = await loadStatusFile(outputDir);
   const lockCheck = await checkLock(projectDir);
   const commitCount = await countCommitsSince(projectDir, status?.run.startedAt);
 

--- a/src/cli/diagnose.ts
+++ b/src/cli/diagnose.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, readdirSync } from "node:fs";
 import { basename, join } from "node:path";
-import { findProjectDir } from "../config";
+import { findProjectDir, loadConfig } from "../config";
 import type { NaxStatusFile } from "../execution/status-file";
 import { getLogger } from "../logger";
 import { loadPRD } from "../prd";
@@ -17,6 +17,7 @@ import { formatReport } from "./diagnose-formatter";
 
 export const _diagnoseDeps = {
   projectOutputDir: projectOutputDir as typeof projectOutputDir,
+  loadConfig: loadConfig as typeof loadConfig,
 };
 
 export interface DiagnoseOptions {
@@ -145,7 +146,9 @@ export async function diagnoseCommand(options: DiagnoseOptions = {}): Promise<vo
   }
   if (!projectDir) throw new Error("Not in a nax project directory");
 
-  const outputDir = _diagnoseDeps.projectOutputDir(basename(projectDir), undefined);
+  const config = await _diagnoseDeps.loadConfig(projectDir).catch(() => null);
+  const projectKey = config?.name?.trim() || basename(projectDir);
+  const outputDir = _diagnoseDeps.projectOutputDir(projectKey, config?.outputDir);
 
   let feature = options.feature;
   if (!feature) {

--- a/src/cli/diagnose.ts
+++ b/src/cli/diagnose.ts
@@ -15,6 +15,10 @@ import { projectOutputDir } from "../runtime";
 import { diagnoseStories, generateRecommendations } from "./diagnose-analysis";
 import { formatReport } from "./diagnose-formatter";
 
+export const _diagnoseDeps = {
+  projectOutputDir: projectOutputDir as typeof projectOutputDir,
+};
+
 export interface DiagnoseOptions {
   feature?: string;
   workdir?: string;
@@ -141,7 +145,7 @@ export async function diagnoseCommand(options: DiagnoseOptions = {}): Promise<vo
   }
   if (!projectDir) throw new Error("Not in a nax project directory");
 
-  const outputDir = projectOutputDir(basename(projectDir), undefined);
+  const outputDir = _diagnoseDeps.projectOutputDir(basename(projectDir), undefined);
 
   let feature = options.feature;
   if (!feature) {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -312,7 +312,10 @@ export async function initProject(projectRoot: string, options?: InitProjectOpti
 
   // Detect project stack and build config
   const stack = detectStack(projectRoot);
-  const projectConfig = buildInitConfig(stack);
+  const projectConfig = {
+    ...buildInitConfig(stack),
+    ...(detectedName ? { name: detectedName } : {}),
+  };
   logger.info("init", "Detected project stack", {
     runtime: stack.runtime,
     language: stack.language,

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -6,14 +6,77 @@
 
 import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { globalConfigDir, projectConfigDir } from "../config/paths";
+import { NaxError } from "../errors";
 import { getLogger } from "../logger";
+import { readProjectIdentity } from "../runtime";
 import { NAX_GITIGNORE_ENTRIES } from "../utils/gitignore";
 import { initContext, initPackage } from "./init-context";
 import { buildInitConfig, detectStack } from "./init-detect";
 import type { ProjectStack } from "./init-detect";
 import { promptsInitCommand } from "./prompts";
+
+/** Result of project name validation */
+export interface ProjectNameValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Validate a project name.
+ * Must be lowercase alphanumeric with hyphens/underscores, 1–64 chars,
+ * must not start with '.' or '_', and must not be a reserved name.
+ */
+export function validateProjectName(name: string): ProjectNameValidationResult {
+  if (!name) return { valid: false, error: "name must be non-empty" };
+  if (name.length > 64) return { valid: false, error: "name must be at most 64 characters" };
+  if (!/^[a-z0-9_-]+$/.test(name))
+    return {
+      valid: false,
+      error: "name must contain only lowercase letters, digits, hyphens, and underscores",
+    };
+  if (name.startsWith(".") || name.startsWith("_")) return { valid: false, error: `name '${name}' is reserved` };
+  if (["global", "_archive"].includes(name)) return { valid: false, error: `name '${name}' is reserved` };
+  return { valid: true };
+}
+
+/** Result of collision check against the global identity registry */
+export interface InitCollisionResult {
+  collision: boolean;
+  existing?: {
+    workdir: string;
+    remoteUrl: string | null;
+    lastSeen: string;
+  };
+}
+
+/**
+ * Check whether a project name is already claimed by a different project.
+ * Returns `{ collision: false }` if the name is unclaimed or claimed by the
+ * same project (matched by remote URL or workdir when no remote exists).
+ */
+export async function checkInitCollision(
+  name: string,
+  currentWorkdir: string,
+  currentRemote: string | null,
+): Promise<InitCollisionResult> {
+  const identity = await readProjectIdentity(name);
+  if (!identity) return { collision: false };
+
+  const sameRemote = currentRemote !== null && identity.remoteUrl !== null && currentRemote === identity.remoteUrl;
+  const sameWorkdir = !currentRemote && !identity.remoteUrl && currentWorkdir === identity.workdir;
+  if (sameRemote || sameWorkdir) return { collision: false };
+
+  return {
+    collision: true,
+    existing: {
+      workdir: identity.workdir,
+      remoteUrl: identity.remoteUrl,
+      lastSeen: identity.lastSeen,
+    },
+  };
+}
 
 /** Init command options */
 export interface InitOptions {
@@ -26,6 +89,10 @@ export interface InitOptions {
    * Relative path from repo root, e.g. "packages/api".
    */
   package?: string;
+  /** Project name for the global identity registry */
+  name?: string;
+  /** Skip re-init collision guard */
+  force?: boolean;
 }
 
 /** Options for initProject */
@@ -34,6 +101,8 @@ export interface InitProjectOptions {
   ai?: boolean;
   /** Force overwrite of existing files */
   force?: boolean;
+  /** Project name for validation and identity registry */
+  name?: string;
 }
 
 /**
@@ -187,6 +256,49 @@ export async function initProject(projectRoot: string, options?: InitProjectOpti
   const logger = getLogger();
   const projectDir = projectConfigDir(projectRoot);
 
+  // Name validation and collision check
+  const detectedName = options?.name ?? basename(projectRoot);
+  const nameValidation = validateProjectName(detectedName);
+  if (!nameValidation.valid) {
+    logger.error("init", "Invalid project name", { name: detectedName, reason: nameValidation.error });
+    throw new NaxError(`Invalid project name "${detectedName}": ${nameValidation.error}`, "INIT_INVALID_NAME", {
+      stage: "init",
+      name: detectedName,
+    });
+  }
+
+  // Detect current git remote (best-effort; non-git projects are fine)
+  let currentRemote: string | null = null;
+  try {
+    const gitResult = Bun.spawnSync(["git", "remote", "get-url", "origin"], { cwd: projectRoot });
+    if (gitResult.exitCode === 0) {
+      currentRemote = new TextDecoder().decode(gitResult.stdout).trim() || null;
+    }
+  } catch {
+    /* non-git project — ok */
+  }
+
+  // Collision check (read-only; claim happens on first nax run via identity marker)
+  if (!options?.force) {
+    const collision = await checkInitCollision(detectedName, projectRoot, currentRemote);
+    if (collision.collision && collision.existing) {
+      const configPath = join(projectDir, "config.json");
+      throw new NaxError(
+        [
+          `Project name collision: "${detectedName}"`,
+          `  This project:    ${projectRoot}`,
+          `  Already in use:  ${collision.existing.workdir}  (last run: ${collision.existing.lastSeen})`,
+          "  Resolve:",
+          `    1. Rename: edit name in ${configPath}`,
+          `    2. Reclaim: nax migrate --reclaim ${detectedName}`,
+          `    3. Merge:   nax migrate --merge ${detectedName}`,
+        ].join("\n"),
+        "INIT_NAME_COLLISION",
+        { stage: "init", name: detectedName },
+      );
+    }
+  }
+
   // Create .nax/ directory if it doesn't exist
   if (!existsSync(projectDir)) {
     await mkdir(projectDir, { recursive: true });
@@ -274,6 +386,6 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
     console.log(`  2. Run: nax generate --package ${options.package}`);
   } else {
     const projectRoot = options.projectRoot ?? process.cwd();
-    await initProject(projectRoot);
+    await initProject(projectRoot, { name: options.name, force: options.force });
   }
 }

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -36,8 +36,9 @@ export function validateProjectName(name: string): ProjectNameValidationResult {
       valid: false,
       error: "name must contain only lowercase letters, digits, hyphens, and underscores",
     };
-  if (name.startsWith(".") || name.startsWith("_")) return { valid: false, error: `name '${name}' is reserved` };
   if (["global", "_archive"].includes(name)) return { valid: false, error: `name '${name}' is reserved` };
+  if (name.startsWith(".") || name.startsWith("_"))
+    return { valid: false, error: "name must not start with '.' or '_'" };
   return { valid: true };
 }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -6,7 +6,7 @@
 
 import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { join } from "node:path";
 import { globalConfigDir, projectConfigDir } from "../config/paths";
 import { NaxError } from "../errors";
 import { getLogger } from "../logger";
@@ -257,15 +257,19 @@ export async function initProject(projectRoot: string, options?: InitProjectOpti
   const logger = getLogger();
   const projectDir = projectConfigDir(projectRoot);
 
-  // Name validation and collision check
-  const detectedName = options?.name ?? basename(projectRoot);
-  const nameValidation = validateProjectName(detectedName);
-  if (!nameValidation.valid) {
-    logger.error("init", "Invalid project name", { name: detectedName, reason: nameValidation.error });
-    throw new NaxError(`Invalid project name "${detectedName}": ${nameValidation.error}`, "INIT_INVALID_NAME", {
-      stage: "init",
-      name: detectedName,
-    });
+  // Name validation and collision check — only for explicitly provided names.
+  // When no name is given, config.name stays "" and the runtime derives the key
+  // from basename(workdir) at run time, which need not pass schema validation.
+  const detectedName = options?.name ?? "";
+  if (detectedName) {
+    const nameValidation = validateProjectName(detectedName);
+    if (!nameValidation.valid) {
+      logger.error("init", "Invalid project name", { name: detectedName, reason: nameValidation.error });
+      throw new NaxError(`Invalid project name "${detectedName}": ${nameValidation.error}`, "INIT_INVALID_NAME", {
+        stage: "init",
+        name: detectedName,
+      });
+    }
   }
 
   // Detect current git remote (best-effort; non-git projects are fine)
@@ -279,8 +283,8 @@ export async function initProject(projectRoot: string, options?: InitProjectOpti
     /* non-git project — ok */
   }
 
-  // Collision check (read-only; claim happens on first nax run via identity marker)
-  if (!options?.force) {
+  // Collision check — only when a name is explicitly provided
+  if (detectedName && !options?.force) {
     const collision = await checkInitCollision(detectedName, projectRoot, currentRemote);
     if (collision.collision && collision.existing) {
       const configPath = join(projectDir, "config.json");

--- a/src/cli/runs.ts
+++ b/src/cli/runs.ts
@@ -6,10 +6,18 @@
 
 import { existsSync, readdirSync } from "node:fs";
 import { basename, join } from "node:path";
+import { loadConfig } from "../config";
 import { NaxError } from "../errors";
 import { getLogger } from "../logger";
 import type { LogEntry } from "../logger/types";
 import { projectOutputDir } from "../runtime";
+
+async function resolveOutputDir(workdir: string, override?: string): Promise<string> {
+  if (override) return override;
+  const config = await loadConfig(workdir).catch(() => null);
+  const projectKey = config?.name?.trim() || basename(workdir);
+  return projectOutputDir(projectKey, config?.outputDir);
+}
 
 /**
  * Options for runs list command.
@@ -69,7 +77,7 @@ export async function runsListCommand(options: RunsListOptions): Promise<void> {
   const logger = getLogger();
   const { feature, workdir } = options;
 
-  const outputDir = options.outputDir ?? projectOutputDir(basename(workdir), undefined);
+  const outputDir = await resolveOutputDir(workdir, options.outputDir);
   const runsDir = join(outputDir, "features", feature, "runs");
 
   if (!existsSync(runsDir)) {
@@ -132,7 +140,7 @@ export async function runsShowCommand(options: RunsShowOptions): Promise<void> {
   const logger = getLogger();
   const { runId, feature, workdir } = options;
 
-  const outputDir = options.outputDir ?? projectOutputDir(basename(workdir), undefined);
+  const outputDir = await resolveOutputDir(workdir, options.outputDir);
   const logPath = join(outputDir, "features", feature, "runs", `${runId}.jsonl`);
 
   if (!existsSync(logPath)) {

--- a/src/cli/runs.ts
+++ b/src/cli/runs.ts
@@ -5,10 +5,11 @@
  */
 
 import { existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { NaxError } from "../errors";
 import { getLogger } from "../logger";
 import type { LogEntry } from "../logger/types";
+import { projectOutputDir } from "../runtime";
 
 /**
  * Options for runs list command.
@@ -18,6 +19,8 @@ export interface RunsListOptions {
   feature: string;
   /** Project directory */
   workdir: string;
+  /** Config-derived output dir override — when absent, defaults to ~/.nax/<basename(workdir)> */
+  outputDir?: string;
 }
 
 /**
@@ -30,6 +33,8 @@ export interface RunsShowOptions {
   feature: string;
   /** Project directory */
   workdir: string;
+  /** Config-derived output dir override — when absent, defaults to ~/.nax/<basename(workdir)> */
+  outputDir?: string;
 }
 
 /**
@@ -64,7 +69,8 @@ export async function runsListCommand(options: RunsListOptions): Promise<void> {
   const logger = getLogger();
   const { feature, workdir } = options;
 
-  const runsDir = join(workdir, ".nax", "features", feature, "runs");
+  const outputDir = options.outputDir ?? projectOutputDir(basename(workdir), undefined);
+  const runsDir = join(outputDir, "features", feature, "runs");
 
   if (!existsSync(runsDir)) {
     logger.info("cli", "No runs found for feature", { feature, hint: `Directory not found: ${runsDir}` });
@@ -126,7 +132,8 @@ export async function runsShowCommand(options: RunsShowOptions): Promise<void> {
   const logger = getLogger();
   const { runId, feature, workdir } = options;
 
-  const logPath = join(workdir, ".nax", "features", feature, "runs", `${runId}.jsonl`);
+  const outputDir = options.outputDir ?? projectOutputDir(basename(workdir), undefined);
+  const logPath = join(outputDir, "features", feature, "runs", `${runId}.jsonl`);
 
   if (!existsSync(logPath)) {
     logger.error("cli", "Run not found", { runId, feature, logPath });

--- a/src/cli/status-cost.ts
+++ b/src/cli/status-cost.ts
@@ -4,8 +4,10 @@
  * Extracted from status.ts: cost metrics display functions for CLI output.
  */
 
+import { basename } from "node:path";
 import { getLogger } from "../logger";
 import { calculateAggregateMetrics, getLastRun, loadRunMetrics } from "../metrics";
+import { projectOutputDir } from "../runtime";
 
 /**
  * Display aggregate cost metrics across all runs.
@@ -19,7 +21,8 @@ import { calculateAggregateMetrics, getLastRun, loadRunMetrics } from "../metric
  */
 export async function displayCostMetrics(workdir: string): Promise<void> {
   const logger = getLogger();
-  const runs = await loadRunMetrics(workdir);
+  const outputDir = projectOutputDir(basename(workdir), undefined);
+  const runs = await loadRunMetrics(outputDir);
 
   if (runs.length === 0) {
     logger.info("cli", "No metrics data available yet", { hint: "Run nax run to generate metrics" });
@@ -51,7 +54,8 @@ export async function displayCostMetrics(workdir: string): Promise<void> {
  */
 export async function displayLastRunMetrics(workdir: string): Promise<void> {
   const logger = getLogger();
-  const runs = await loadRunMetrics(workdir);
+  const outputDir = projectOutputDir(basename(workdir), undefined);
+  const runs = await loadRunMetrics(outputDir);
 
   if (runs.length === 0) {
     logger.info("cli", "No metrics data available yet", { hint: "Run nax run to generate metrics" });
@@ -117,7 +121,8 @@ export async function displayLastRunMetrics(workdir: string): Promise<void> {
  */
 export async function displayModelEfficiency(workdir: string): Promise<void> {
   const logger = getLogger();
-  const runs = await loadRunMetrics(workdir);
+  const outputDir = projectOutputDir(basename(workdir), undefined);
+  const runs = await loadRunMetrics(outputDir);
 
   if (runs.length === 0) {
     logger.info("cli", "No metrics data available yet", { hint: "Run nax run to generate metrics" });

--- a/src/cli/status-cost.ts
+++ b/src/cli/status-cost.ts
@@ -5,9 +5,16 @@
  */
 
 import { basename } from "node:path";
+import { loadConfig } from "../config";
 import { getLogger } from "../logger";
 import { calculateAggregateMetrics, getLastRun, loadRunMetrics } from "../metrics";
 import { projectOutputDir } from "../runtime";
+
+async function resolveOutputDir(workdir: string): Promise<string> {
+  const config = await loadConfig(workdir).catch(() => null);
+  const projectKey = config?.name?.trim() || basename(workdir);
+  return projectOutputDir(projectKey, config?.outputDir);
+}
 
 /**
  * Display aggregate cost metrics across all runs.
@@ -21,7 +28,7 @@ import { projectOutputDir } from "../runtime";
  */
 export async function displayCostMetrics(workdir: string): Promise<void> {
   const logger = getLogger();
-  const outputDir = projectOutputDir(basename(workdir), undefined);
+  const outputDir = await resolveOutputDir(workdir);
   const runs = await loadRunMetrics(outputDir);
 
   if (runs.length === 0) {
@@ -54,7 +61,7 @@ export async function displayCostMetrics(workdir: string): Promise<void> {
  */
 export async function displayLastRunMetrics(workdir: string): Promise<void> {
   const logger = getLogger();
-  const outputDir = projectOutputDir(basename(workdir), undefined);
+  const outputDir = await resolveOutputDir(workdir);
   const runs = await loadRunMetrics(outputDir);
 
   if (runs.length === 0) {
@@ -121,7 +128,7 @@ export async function displayLastRunMetrics(workdir: string): Promise<void> {
  */
 export async function displayModelEfficiency(workdir: string): Promise<void> {
   const logger = getLogger();
-  const outputDir = projectOutputDir(basename(workdir), undefined);
+  const outputDir = await resolveOutputDir(workdir);
   const runs = await loadRunMetrics(outputDir);
 
   if (runs.length === 0) {

--- a/src/cli/status-features.ts
+++ b/src/cli/status-features.ts
@@ -436,7 +436,9 @@ export async function displayFeatureStatus(options: FeatureStatusOptions = {}): 
     // to avoid requiring config.json (status display only needs feature files)
     let featureDir: string;
     if (options.dir) {
-      featureDir = join(resolve(options.dir), ".nax", "features", options.feature);
+      const projectDir = resolve(options.dir);
+      const outputDir = projectOutputDir(basename(projectDir), undefined);
+      featureDir = join(outputDir, "features", options.feature);
     } else {
       const resolved = resolveProject({ feature: options.feature });
       if (!resolved.featureDir) {

--- a/src/cli/status-features.ts
+++ b/src/cli/status-features.ts
@@ -5,12 +5,13 @@
  */
 
 import { existsSync, readdirSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
 import chalk from "chalk";
 import { resolveProject } from "../commands/common";
 import type { NaxStatusFile } from "../execution/status-file";
 import { listPendingInteractions, loadPendingInteraction } from "../interaction";
 import { countStories, loadPRD } from "../prd";
+import { projectOutputDir } from "../runtime";
 
 /** Options for feature status command */
 export interface FeatureStatusOptions {
@@ -68,7 +69,8 @@ async function loadStatusFile(featureDir: string): Promise<NaxStatusFile | null>
 
 /** Load project-level status.json (if it exists) */
 async function loadProjectStatusFile(projectDir: string): Promise<NaxStatusFile | null> {
-  const statusPath = join(projectDir, ".nax", "status.json");
+  const outputDir = projectOutputDir(basename(projectDir), undefined);
+  const statusPath = join(outputDir, "status.json");
   if (!existsSync(statusPath)) {
     return null;
   }
@@ -160,7 +162,8 @@ async function getFeatureSummary(featureName: string, featureDir: string): Promi
 
 /** Display all features table */
 async function displayAllFeatures(projectDir: string): Promise<void> {
-  const featuresDir = join(projectDir, ".nax", "features");
+  const outputDir = projectOutputDir(basename(projectDir), undefined);
+  const featuresDir = join(outputDir, "features");
 
   if (!existsSync(featuresDir)) {
     console.log(chalk.dim("No features found."));

--- a/src/cli/status-features.ts
+++ b/src/cli/status-features.ts
@@ -13,6 +13,11 @@ import { listPendingInteractions, loadPendingInteraction } from "../interaction"
 import { countStories, loadPRD } from "../prd";
 import { projectOutputDir } from "../runtime";
 
+/** Injectable deps for status-features (enables test isolation of output dir derivation) */
+export const _statusFeaturesDeps = {
+  projectOutputDir: projectOutputDir as typeof projectOutputDir,
+};
+
 /** Options for feature status command */
 export interface FeatureStatusOptions {
   /** Feature name (from -f flag) */
@@ -69,7 +74,7 @@ async function loadStatusFile(featureDir: string): Promise<NaxStatusFile | null>
 
 /** Load project-level status.json (if it exists) */
 async function loadProjectStatusFile(projectDir: string): Promise<NaxStatusFile | null> {
-  const outputDir = projectOutputDir(basename(projectDir), undefined);
+  const outputDir = _statusFeaturesDeps.projectOutputDir(basename(projectDir), undefined);
   const statusPath = join(outputDir, "status.json");
   if (!existsSync(statusPath)) {
     return null;
@@ -162,7 +167,7 @@ async function getFeatureSummary(featureName: string, featureDir: string): Promi
 
 /** Display all features table */
 async function displayAllFeatures(projectDir: string): Promise<void> {
-  const outputDir = projectOutputDir(basename(projectDir), undefined);
+  const outputDir = _statusFeaturesDeps.projectOutputDir(basename(projectDir), undefined);
   const featuresDir = join(outputDir, "features");
 
   if (!existsSync(featuresDir)) {
@@ -437,7 +442,7 @@ export async function displayFeatureStatus(options: FeatureStatusOptions = {}): 
     let featureDir: string;
     if (options.dir) {
       const projectDir = resolve(options.dir);
-      const outputDir = projectOutputDir(basename(projectDir), undefined);
+      const outputDir = _statusFeaturesDeps.projectOutputDir(basename(projectDir), undefined);
       featureDir = join(outputDir, "features", options.feature);
     } else {
       const resolved = resolveProject({ feature: options.feature });

--- a/src/cli/status-features.ts
+++ b/src/cli/status-features.ts
@@ -8,6 +8,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import chalk from "chalk";
 import { resolveProject } from "../commands/common";
+import { loadConfig } from "../config";
 import type { NaxStatusFile } from "../execution/status-file";
 import { listPendingInteractions, loadPendingInteraction } from "../interaction";
 import { countStories, loadPRD } from "../prd";
@@ -16,6 +17,7 @@ import { projectOutputDir } from "../runtime";
 /** Injectable deps for status-features (enables test isolation of output dir derivation) */
 export const _statusFeaturesDeps = {
   projectOutputDir: projectOutputDir as typeof projectOutputDir,
+  loadConfig: loadConfig as typeof loadConfig,
 };
 
 /** Options for feature status command */
@@ -74,7 +76,9 @@ async function loadStatusFile(featureDir: string): Promise<NaxStatusFile | null>
 
 /** Load project-level status.json (if it exists) */
 async function loadProjectStatusFile(projectDir: string): Promise<NaxStatusFile | null> {
-  const outputDir = _statusFeaturesDeps.projectOutputDir(basename(projectDir), undefined);
+  const config = await _statusFeaturesDeps.loadConfig(projectDir).catch(() => null);
+  const projectKey = config?.name?.trim() || basename(projectDir);
+  const outputDir = _statusFeaturesDeps.projectOutputDir(projectKey, config?.outputDir);
   const statusPath = join(outputDir, "status.json");
   if (!existsSync(statusPath)) {
     return null;
@@ -167,7 +171,9 @@ async function getFeatureSummary(featureName: string, featureDir: string): Promi
 
 /** Display all features table */
 async function displayAllFeatures(projectDir: string): Promise<void> {
-  const outputDir = _statusFeaturesDeps.projectOutputDir(basename(projectDir), undefined);
+  const config = await _statusFeaturesDeps.loadConfig(projectDir).catch(() => null);
+  const projectKey = config?.name?.trim() || basename(projectDir);
+  const outputDir = _statusFeaturesDeps.projectOutputDir(projectKey, config?.outputDir);
   const featuresDir = join(outputDir, "features");
 
   if (!existsSync(featuresDir)) {
@@ -442,7 +448,9 @@ export async function displayFeatureStatus(options: FeatureStatusOptions = {}): 
     let featureDir: string;
     if (options.dir) {
       const projectDir = resolve(options.dir);
-      const outputDir = _statusFeaturesDeps.projectOutputDir(basename(projectDir), undefined);
+      const config = await _statusFeaturesDeps.loadConfig(projectDir).catch(() => null);
+      const projectKey = config?.name?.trim() || basename(projectDir);
+      const outputDir = _statusFeaturesDeps.projectOutputDir(projectKey, config?.outputDir);
       featureDir = join(outputDir, "features", options.feature);
     } else {
       const resolved = resolveProject({ feature: options.feature });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,3 +7,5 @@ export { logsCommand, type LogsOptions } from "./logs";
 export { precheckCommand, type PrecheckOptions } from "./precheck";
 export { runsCommand, type RunsOptions } from "./runs";
 export { unlockCommand, type UnlockOptions } from "./unlock";
+export { migrateCommand, detectGeneratedContent } from "./migrate";
+export type { MigrateOptions, MigrateCandidate } from "./migrate";

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -11,6 +11,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readdir, rename } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { validateProjectName } from "../cli/init";
 import { NaxError } from "../errors";
 import { getLogger } from "../logger";
 import { readProjectIdentity, writeProjectIdentity } from "../runtime";
@@ -129,12 +130,6 @@ export interface MigrateOptions {
   workdir: string;
   /** When true, log intended moves without touching the filesystem. */
   dryRun?: boolean;
-  /**
-   * When true, copy+delete instead of rename when the source and destination
-   * are on different filesystems (EXDEV). Slower and non-atomic; prefer
-   * configuring outputDir to a same-FS path instead.
-   */
-  crossFs?: boolean;
   /** Project name to archive-and-free from ~/.nax/<name>/. */
   reclaim?: string;
   /** Project name to rewrite identity for current workdir. */
@@ -149,6 +144,17 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 
   // --reclaim: archive ~/.nax/<name>/ to ~/.nax/_archive/<name>-<ts>/
   if (options.reclaim) {
+    const reclaimValidation = validateProjectName(options.reclaim);
+    if (!reclaimValidation.valid) {
+      throw new NaxError(
+        `Invalid project name "${options.reclaim}": ${reclaimValidation.error}`,
+        "MIGRATE_INVALID_NAME",
+        {
+          stage: "migrate",
+          name: options.reclaim,
+        },
+      );
+    }
     const src = path.join(os.homedir(), ".nax", options.reclaim);
     if (!existsSync(src)) {
       throw new NaxError(`Nothing to reclaim: ~/.nax/${options.reclaim} does not exist`, "MIGRATE_RECLAIM_NOT_FOUND", {
@@ -166,6 +172,13 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
 
   // --merge: rewrite identity to point to current workdir
   if (options.merge) {
+    const mergeValidation = validateProjectName(options.merge);
+    if (!mergeValidation.valid) {
+      throw new NaxError(`Invalid project name "${options.merge}": ${mergeValidation.error}`, "MIGRATE_INVALID_NAME", {
+        stage: "migrate",
+        name: options.merge,
+      });
+    }
     const existing = await readProjectIdentity(options.merge);
     if (!existing) {
       throw new NaxError(`Cannot merge: ~/.nax/${options.merge}/.identity not found`, "MIGRATE_MERGE_NOT_FOUND", {
@@ -247,14 +260,13 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
       await rename(candidate.srcPath, dest);
     } catch (err: unknown) {
       const isXdev = err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EXDEV";
-      if (isXdev && !options.crossFs) {
+      if (isXdev) {
         throw new NaxError(
           [
             "Cross-filesystem migration detected.",
             `  Source:      ${candidate.srcPath}`,
             `  Destination: ${dest}`,
-            "  Re-run with --cross-fs to copy+delete (slower, not atomic).",
-            "  Alternative: set outputDir in .nax/config.json to a path on the source filesystem.",
+            "  Set outputDir in .nax/config.json to a path on the same filesystem as .nax/.",
           ].join("\n"),
           "MIGRATE_CROSS_FS",
           { stage: "migrate", src: candidate.srcPath, dest },

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -13,6 +13,7 @@ import os from "node:os";
 import path from "node:path";
 import { NaxError } from "../errors";
 import { getLogger } from "../logger";
+import { readProjectIdentity, writeProjectIdentity } from "../runtime";
 
 export interface MigrateCandidate {
   name: string;
@@ -134,6 +135,10 @@ export interface MigrateOptions {
    * configuring outputDir to a same-FS path instead.
    */
   crossFs?: boolean;
+  /** Project name to archive-and-free from ~/.nax/<name>/. */
+  reclaim?: string;
+  /** Project name to rewrite identity for current workdir. */
+  merge?: string;
 }
 
 /**
@@ -141,6 +146,53 @@ export interface MigrateOptions {
  */
 export async function migrateCommand(options: MigrateOptions): Promise<void> {
   const logger = getLogger();
+
+  // --reclaim: archive ~/.nax/<name>/ to ~/.nax/_archive/<name>-<ts>/
+  if (options.reclaim) {
+    const src = path.join(os.homedir(), ".nax", options.reclaim);
+    if (!existsSync(src)) {
+      throw new NaxError(`Nothing to reclaim: ~/.nax/${options.reclaim} does not exist`, "MIGRATE_RECLAIM_NOT_FOUND", {
+        stage: "migrate",
+        name: options.reclaim,
+      });
+    }
+    const archiveBase = path.join(os.homedir(), ".nax", "_archive");
+    const archiveDest = path.join(archiveBase, `${options.reclaim}-${Date.now()}`);
+    await mkdir(archiveBase, { recursive: true });
+    await rename(src, archiveDest);
+    logger.info("migrate", `Reclaimed: archived to ${archiveDest}`, { storyId: "_migrate" });
+    return;
+  }
+
+  // --merge: rewrite identity to point to current workdir
+  if (options.merge) {
+    const existing = await readProjectIdentity(options.merge);
+    if (!existing) {
+      throw new NaxError(`Cannot merge: ~/.nax/${options.merge}/.identity not found`, "MIGRATE_MERGE_NOT_FOUND", {
+        stage: "migrate",
+        name: options.merge,
+      });
+    }
+    let currentRemote: string | null = null;
+    try {
+      const gitResult = Bun.spawnSync(["git", "remote", "get-url", "origin"], { cwd: options.workdir });
+      if (gitResult.exitCode === 0) {
+        currentRemote = new TextDecoder().decode(gitResult.stdout).trim() || null;
+      }
+    } catch {
+      /* non-git project */
+    }
+
+    await writeProjectIdentity(options.merge, {
+      ...existing,
+      workdir: options.workdir,
+      remoteUrl: currentRemote,
+      lastSeen: new Date().toISOString(),
+    });
+    logger.info("migrate", `Merged: identity for "${options.merge}" updated`, { storyId: "_migrate" });
+    return;
+  }
+
   const naxDir = path.join(options.workdir, ".nax");
 
   const configPath = path.join(naxDir, "config.json");

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,0 +1,235 @@
+/**
+ * nax migrate — moves generated content out of .nax/ into the output directory.
+ *
+ * Generated artefacts (runs/, metrics.json, prompt-audit/, etc.) accumulate under
+ * .nax/ in legacy installations. This command moves them to ~/.nax/<projectKey>/
+ * (or the path configured in outputDir) so that .nax/ can be treated as input-only
+ * and checked into version control safely.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, readdir, rename } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { NaxError } from "../errors";
+import { getLogger } from "../logger";
+
+export interface MigrateCandidate {
+  name: string;
+  srcPath: string;
+}
+
+/**
+ * Top-level .nax/ entries that are generated at runtime and should be moved out.
+ * Source-controlled entries (config.json, context.md, mono/, features/) are excluded.
+ */
+const GENERATED_NAMES = new Set([
+  "runs",
+  "prompt-audit",
+  "review-audit",
+  "cost",
+  "metrics.json",
+  "cycle-shadow",
+  "curator",
+]);
+
+/**
+ * Sub-entries inside .nax/features/<id>/ that are generated at runtime.
+ */
+const GENERATED_FEATURE_SUBNAMES = new Set(["runs", "sessions", "status.json"]);
+
+/**
+ * Scan a .nax/ directory and return all generated entries that can be migrated.
+ * Returns an empty array if there is nothing to migrate (idempotent: safe to call
+ * when already fully migrated).
+ */
+export async function detectGeneratedContent(naxDir: string): Promise<MigrateCandidate[]> {
+  if (!existsSync(naxDir)) return [];
+
+  const candidates: MigrateCandidate[] = [];
+  let entries: string[] = [];
+  try {
+    entries = await readdir(naxDir);
+  } catch {
+    return [];
+  }
+
+  // Top-level generated entries
+  for (const entry of entries) {
+    if (GENERATED_NAMES.has(entry)) {
+      candidates.push({ name: entry, srcPath: path.join(naxDir, entry) });
+    }
+  }
+
+  // Per-feature generated entries under .nax/features/<featureId>/
+  const featuresDir = path.join(naxDir, "features");
+  if (existsSync(featuresDir)) {
+    let featureDirs: string[] = [];
+    try {
+      featureDirs = await readdir(featuresDir);
+    } catch {
+      // ok — features dir may be empty or unreadable
+    }
+
+    for (const fid of featureDirs) {
+      const featureDir = path.join(featuresDir, fid);
+      let subEntries: string[] = [];
+      try {
+        subEntries = await readdir(featureDir);
+      } catch {
+        continue;
+      }
+
+      for (const sub of subEntries) {
+        if (GENERATED_FEATURE_SUBNAMES.has(sub)) {
+          candidates.push({
+            name: path.join("features", fid, sub),
+            srcPath: path.join(featureDir, sub),
+          });
+        }
+
+        // Context manifests inside .nax/features/<id>/stories/<storyId>/
+        if (sub === "stories") {
+          const storiesDir = path.join(featureDir, "stories");
+          let storyDirs: string[] = [];
+          try {
+            storyDirs = await readdir(storiesDir);
+          } catch {
+            continue;
+          }
+
+          for (const sid of storyDirs) {
+            const storyDir = path.join(storiesDir, sid);
+            let storyEntries: string[] = [];
+            try {
+              storyEntries = await readdir(storyDir);
+            } catch {
+              continue;
+            }
+
+            for (const se of storyEntries) {
+              if (se.startsWith("context-manifest-") && se.endsWith(".json")) {
+                candidates.push({
+                  name: path.join("features", fid, "stories", sid, se),
+                  srcPath: path.join(storyDir, se),
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
+export interface MigrateOptions {
+  workdir: string;
+  /** When true, log intended moves without touching the filesystem. */
+  dryRun?: boolean;
+  /**
+   * When true, copy+delete instead of rename when the source and destination
+   * are on different filesystems (EXDEV). Slower and non-atomic; prefer
+   * configuring outputDir to a same-FS path instead.
+   */
+  crossFs?: boolean;
+}
+
+/**
+ * Execute the migration: move generated content from .nax/ to the output directory.
+ */
+export async function migrateCommand(options: MigrateOptions): Promise<void> {
+  const logger = getLogger();
+  const naxDir = path.join(options.workdir, ".nax");
+
+  const configPath = path.join(naxDir, "config.json");
+  if (!existsSync(configPath)) {
+    throw new NaxError("No .nax/config.json found — run nax init first", "MIGRATE_NO_CONFIG", {
+      stage: "migrate",
+      workdir: options.workdir,
+    });
+  }
+
+  let config: { name?: string } = {};
+  try {
+    config = await Bun.file(configPath).json();
+  } catch (e) {
+    throw new NaxError("Failed to read .nax/config.json", "MIGRATE_CONFIG_READ_FAILED", {
+      stage: "migrate",
+      cause: e,
+    });
+  }
+
+  const projectKey = config.name?.trim() || path.basename(options.workdir);
+  const destBase = path.join(os.homedir(), ".nax", projectKey);
+  const candidates = await detectGeneratedContent(naxDir);
+
+  if (candidates.length === 0) {
+    logger.info("migrate", "Nothing to migrate — already up to date", { storyId: "_migrate" });
+    return;
+  }
+
+  if (options.dryRun) {
+    for (const c of candidates) {
+      logger.info("migrate", `[dry-run] Would move: ${c.srcPath} -> ${path.join(destBase, c.name)}`, {
+        storyId: "_migrate",
+      });
+    }
+    return;
+  }
+
+  await mkdir(destBase, { recursive: true });
+
+  let moved = 0;
+  for (const candidate of candidates) {
+    const dest = path.join(destBase, candidate.name);
+    await mkdir(path.dirname(dest), { recursive: true });
+
+    if (existsSync(dest)) {
+      throw new NaxError(`Migration conflict: destination already exists: ${dest}`, "MIGRATE_CONFLICT", {
+        stage: "migrate",
+        src: candidate.srcPath,
+        dest,
+      });
+    }
+
+    try {
+      await rename(candidate.srcPath, dest);
+    } catch (err: unknown) {
+      const isXdev = err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EXDEV";
+      if (isXdev && !options.crossFs) {
+        throw new NaxError(
+          [
+            "Cross-filesystem migration detected.",
+            `  Source:      ${candidate.srcPath}`,
+            `  Destination: ${dest}`,
+            "  Re-run with --cross-fs to copy+delete (slower, not atomic).",
+            "  Alternative: set outputDir in .nax/config.json to a path on the source filesystem.",
+          ].join("\n"),
+          "MIGRATE_CROSS_FS",
+          { stage: "migrate", src: candidate.srcPath, dest },
+        );
+      }
+      throw new NaxError(`Failed to move ${candidate.srcPath}`, "MIGRATE_MOVE_FAILED", {
+        stage: "migrate",
+        src: candidate.srcPath,
+        dest,
+        cause: err,
+      });
+    }
+
+    moved++;
+    logger.info("migrate", `Moved: ${candidate.name}`, { storyId: "_migrate" });
+  }
+
+  await Bun.write(
+    path.join(destBase, ".migrated-from"),
+    JSON.stringify({ from: options.workdir, migratedAt: new Date().toISOString() }, null, 2),
+  );
+
+  logger.info("migrate", `Migration complete: ${moved} entries moved`, {
+    storyId: "_migrate",
+    destBase,
+  });
+}

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -187,11 +187,8 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
     await mkdir(path.dirname(dest), { recursive: true });
 
     if (existsSync(dest)) {
-      throw new NaxError(`Migration conflict: destination already exists: ${dest}`, "MIGRATE_CONFLICT", {
-        stage: "migrate",
-        src: candidate.srcPath,
-        dest,
-      });
+      logger.warn("migrate", `Skipping — destination already exists: ${dest}`, { storyId: "_migrate" });
+      continue;
     }
 
     try {

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -14,7 +14,7 @@ import path from "node:path";
 import { validateProjectName } from "../cli/init";
 import { NaxError } from "../errors";
 import { getLogger } from "../logger";
-import { readProjectIdentity, writeProjectIdentity } from "../runtime";
+import { projectOutputDir, readProjectIdentity, writeProjectIdentity } from "../runtime";
 
 export interface MigrateCandidate {
   name: string;
@@ -216,7 +216,7 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
     });
   }
 
-  let config: { name?: string } = {};
+  let config: { name?: string; outputDir?: string } = {};
   try {
     config = await Bun.file(configPath).json();
   } catch (e) {
@@ -227,7 +227,7 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
   }
 
   const projectKey = config.name?.trim() || path.basename(options.workdir);
-  const destBase = path.join(os.homedir(), ".nax", projectKey);
+  const destBase = projectOutputDir(projectKey, config.outputDir);
   const candidates = await detectGeneratedContent(naxDir);
 
   if (candidates.length === 0) {
@@ -252,8 +252,11 @@ export async function migrateCommand(options: MigrateOptions): Promise<void> {
     await mkdir(path.dirname(dest), { recursive: true });
 
     if (existsSync(dest)) {
-      logger.warn("migrate", `Skipping — destination already exists: ${dest}`, { storyId: "_migrate" });
-      continue;
+      throw new NaxError(
+        `Migration conflict: destination already exists.\n  Source:      ${candidate.srcPath}\n  Destination: ${dest}\n  Remove the destination or run nax migrate --dry-run to inspect.`,
+        "MIGRATE_CONFLICT",
+        { stage: "migrate", src: candidate.srcPath, dest },
+      );
     }
 
     try {

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -505,6 +505,10 @@ export type {
 
 /** Full nax configuration */
 export interface NaxConfig {
+  /** Project name — used as the default projectKey for output directory. Lowercase alphanumeric, hyphens, underscores. */
+  name: string;
+  /** Output directory override — absolute path or ~/path. If absent, defaults to ~/.nax/<projectKey> */
+  outputDir?: string;
   /** Schema version */
   version: 1;
   /** Model mapping — per-agent tier map: Record<agentName, Record<tierName, ModelEntry>> */
@@ -551,8 +555,15 @@ export interface NaxConfig {
   project?: ProjectProfile;
   /** Multi-agent debate settings */
   debate?: import("../debate/types").DebateConfig;
+  /** Curator configuration */
+  curator?: CuratorConfig;
   /** Configuration profile name (default: "default") */
   profile: string;
+}
+
+export interface CuratorConfig {
+  /** Path to the rollup JSONL file for aggregated run results */
+  rollupPath?: string;
 }
 
 export type {

--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -183,5 +183,9 @@ export const GenerateConfigSchema = z.object({
   agents: z.array(z.enum(VALID_AGENT_TYPES)).optional(),
 });
 
+export const CuratorConfigSchema = z.object({
+  rollupPath: z.string().optional(),
+});
+
 // Re-export ModelTierSchema for consumers that currently import it from schemas-infra
 export { ModelTierSchema };

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -18,6 +18,7 @@ import {
 import {
   AcceptanceConfigSchema,
   AgentConfigSchema,
+  CuratorConfigSchema,
   GenerateConfigSchema,
   HooksConfigSchema,
   InteractionConfigSchema,
@@ -40,6 +41,27 @@ export { PromptsConfigSchema } from "./schemas-infra";
 
 export const NaxConfigSchema = z
   .object({
+    name: z
+      .string()
+      .default("")
+      .refine((v) => v === "" || /^[a-z0-9_-]+$/.test(v), {
+        message: "name must contain only lowercase letters, digits, hyphens, and underscores",
+      })
+      .refine((v) => v === "" || (!v.startsWith(".") && !v.startsWith("_")), {
+        message: "name must not start with '.' or '_'",
+      })
+      .refine((v) => !["global", "_archive"].includes(v), {
+        message: "name 'global' and '_archive' are reserved",
+      })
+      .refine((v) => v === "" || v.length <= 64, {
+        message: "name must be at most 64 characters",
+      }),
+    outputDir: z
+      .string()
+      .optional()
+      .refine((v) => v === undefined || v.startsWith("/") || v.startsWith("~/"), {
+        message: "outputDir must be absolute or start with ~/",
+      }),
     version: z.number().default(1),
     models: ModelMapSchema.default({
       claude: {
@@ -356,6 +378,7 @@ export const NaxConfigSchema = z
         },
       },
     })),
+    curator: CuratorConfigSchema.optional(),
     profile: z.string().default("default"),
   })
   .refine((data) => data.version === 1, {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -78,4 +78,5 @@ export type {
   AdaptiveRoutingConfig,
   AgentConfig,
   ProjectProfile,
+  CuratorConfig,
 } from "./runtime-types";

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -308,7 +308,7 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
   };
 
   try {
-    await saveRunMetrics(workdir, runMetrics);
+    await saveRunMetrics(options.runtime.outputDir, runMetrics);
   } catch (err) {
     logger?.warn("run.complete", "Failed to save run metrics", { error: String(err) });
   }

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -240,6 +240,27 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     }
   }
 
+  // Claim project identity on first run (no-op if already claimed for this workdir)
+  {
+    const { claimProjectIdentity } = await import("../../runtime");
+    let remoteUrl: string | null = null;
+    try {
+      const gitResult = Bun.spawnSync(["git", "remote", "get-url", "origin"], { cwd: workdir });
+      if (gitResult.exitCode === 0) {
+        remoteUrl = new TextDecoder().decode(gitResult.stdout).trim() || null;
+      }
+    } catch {
+      /* non-git project — remoteUrl stays null */
+    }
+    const projectKey = config.name?.trim() || path.basename(workdir);
+    await claimProjectIdentity(projectKey, workdir, remoteUrl).catch((err) => {
+      logger?.warn("setup", "Failed to claim project identity", {
+        storyId: "_setup",
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+  }
+
   // ── Run precheck validations (unless --skip-precheck) ──────────────────────
   if (!skipPrecheck) {
     const { runPrecheckValidation } = await import("./precheck-runner");

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -228,8 +228,15 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
         storyId: "_setup",
         count: candidates.length,
       });
-      await migrateCommand({ workdir });
-      logger?.info("setup", "Auto-migration complete", { storyId: "_setup" });
+      try {
+        await migrateCommand({ workdir });
+        logger?.info("setup", "Auto-migration complete", { storyId: "_setup" });
+      } catch (err) {
+        logger?.warn("setup", "Auto-migration failed — continuing without migration", {
+          storyId: "_setup",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
   }
 

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -218,6 +218,21 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
   // ── Prime StatusWriter with PRD so precheck-failed can be recorded ─────────
   statusWriter.setPrd(prd);
 
+  // Auto-migrate generated content out of .nax/ if needed (no-op when already migrated)
+  {
+    const { detectGeneratedContent, migrateCommand } = await import("../../commands/migrate");
+    const naxDir = path.join(workdir, ".nax");
+    const candidates = await detectGeneratedContent(naxDir).catch(() => []);
+    if (candidates.length > 0) {
+      logger?.info("setup", "Found generated content under .nax/ — migrating to output dir", {
+        storyId: "_setup",
+        count: candidates.length,
+      });
+      await migrateCommand({ workdir });
+      logger?.info("setup", "Auto-migration complete", { storyId: "_setup" });
+    }
+  }
+
   // ── Run precheck validations (unless --skip-precheck) ──────────────────────
   if (!skipPrecheck) {
     const { runPrecheckValidation } = await import("./precheck-runner");

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -15,7 +15,7 @@
 import * as os from "node:os";
 import path from "node:path";
 import type { NaxConfig } from "../../config";
-import { LockAcquisitionError } from "../../errors";
+import { LockAcquisitionError, NaxError } from "../../errors";
 import type { LoadedHooksConfig } from "../../hooks";
 import type { InteractionChain } from "../../interaction";
 import { initInteractionChain } from "../../interaction";
@@ -254,6 +254,9 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     }
     const projectKey = config.name?.trim() || path.basename(workdir);
     await claimProjectIdentity(projectKey, workdir, remoteUrl).catch((err) => {
+      if (err instanceof NaxError && err.code === "RUN_NAME_COLLISION") {
+        throw err;
+      }
       logger?.warn("setup", "Failed to claim project identity", {
         storyId: "_setup",
         error: err instanceof Error ? err.message : String(err),

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -86,7 +86,7 @@ export async function executeUnified(
   wireReporters(pipelineEventBus, ctx.pluginRegistry, ctx.runId, ctx.startTime);
   wireInteraction(pipelineEventBus, ctx.interactionChain, ctx.config);
   wireEventsWriter(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir);
-  wireRegistry(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir);
+  wireRegistry(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir, ctx.runtime.outputDir);
 
   // Emit run:started once — subscribers (hooks.ts, reporters.ts) own the fan-out.
   // Direct fireHook("on-start") and reporter.onRunStart() calls have been removed.

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -270,8 +270,8 @@ export function collectBatchMetrics(ctx: PipelineContext, storyStartTime: string
  * });
  * ```
  */
-export async function saveRunMetrics(workdir: string, runMetrics: RunMetrics): Promise<void> {
-  const metricsPath = path.join(workdir, ".nax", "metrics.json");
+export async function saveRunMetrics(outputDir: string, runMetrics: RunMetrics): Promise<void> {
+  const metricsPath = path.join(outputDir, "metrics.json");
 
   // Compute totalTokens by summing all story tokens
   let totalInputTokens = 0;
@@ -324,8 +324,8 @@ export async function saveRunMetrics(workdir: string, runMetrics: RunMetrics): P
  * console.log(`Total runs: ${runs.length}`);
  * ```
  */
-export async function loadRunMetrics(workdir: string): Promise<RunMetrics[]> {
-  const metricsPath = path.join(workdir, ".nax", "metrics.json");
+export async function loadRunMetrics(outputDir: string): Promise<RunMetrics[]> {
+  const metricsPath = path.join(outputDir, "metrics.json");
 
   const content = await loadJsonFile<RunMetrics[]>(metricsPath, "metrics");
   return Array.isArray(content) ? content : [];

--- a/src/pipeline/stages/autofix-cycle.ts
+++ b/src/pipeline/stages/autofix-cycle.ts
@@ -175,7 +175,7 @@ async function writeShadowReport(
   initialFindingsCount: number,
 ): Promise<void> {
   const logger = getLogger();
-  const shadowDir = join(ctx.workdir, ".nax", "cycle-shadow", ctx.story.id);
+  const shadowDir = join(ctx.runtime.outputDir, "cycle-shadow", ctx.story.id);
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const report: ShadowReport = {
     storyId: ctx.story.id,

--- a/src/pipeline/subscribers/registry.ts
+++ b/src/pipeline/subscribers/registry.ts
@@ -34,13 +34,20 @@ export interface MetaJson {
  * Listens to run:started and writes meta.json to
  * ~/.nax/runs/<project>-<feature>-<runId>/meta.json.
  *
- * @param bus     - The pipeline event bus
- * @param feature - Feature name
- * @param runId   - Current run ID
- * @param workdir - Working directory (project name derived via basename)
+ * @param bus       - The pipeline event bus
+ * @param feature   - Feature name
+ * @param runId     - Current run ID
+ * @param workdir   - Working directory (project name derived via basename)
+ * @param outputDir - Project output directory (where status.json and features/ live)
  * @returns Unsubscribe function
  */
-export function wireRegistry(bus: PipelineEventBus, feature: string, runId: string, workdir: string): UnsubscribeFn {
+export function wireRegistry(
+  bus: PipelineEventBus,
+  feature: string,
+  runId: string,
+  workdir: string,
+  outputDir: string,
+): UnsubscribeFn {
   const logger = getSafeLogger();
   const project = basename(workdir);
   const runDir = join(homedir(), ".nax", "runs", `${project}-${feature}-${runId}`);
@@ -55,8 +62,8 @@ export function wireRegistry(bus: PipelineEventBus, feature: string, runId: stri
           project,
           feature,
           workdir,
-          statusPath: join(workdir, ".nax", "features", feature, "status.json"),
-          eventsDir: join(workdir, ".nax", "features", feature, "runs"),
+          statusPath: join(outputDir, "features", feature, "status.json"),
+          eventsDir: join(outputDir, "features", feature, "runs"),
           registeredAt: new Date().toISOString(),
         };
         await writeFile(metaFile, JSON.stringify(meta, null, 2));

--- a/src/review/review-audit.ts
+++ b/src/review/review-audit.ts
@@ -32,6 +32,8 @@ export interface ReviewAuditEntry {
   workdir: string;
   /** Project root, when known. */
   projectDir?: string;
+  /** Output directory — when present, used as the first choice for resolvedDir. */
+  outputDir?: string;
   /** Agent that produced the reviewed response. */
   agentName?: string;
   /** Story ID for metadata. */
@@ -65,6 +67,8 @@ export interface ReviewAuditDispatch {
   recordId?: string | null;
   workdir?: string;
   projectDir?: string;
+  /** Output directory — when present, used as the first choice for resolvedDir. */
+  outputDir?: string;
   agentName?: string;
   storyId?: string;
   featureName?: string;
@@ -132,8 +136,13 @@ function toPersistedEntry(entry: ReviewAuditEntry, epochMs: number): string {
 }
 
 async function persistReviewAudit(entry: ReviewAuditEntry): Promise<void> {
-  const projectRoot = entry.projectDir ?? (await _reviewAuditDeps.findNaxProjectRoot(entry.workdir));
-  const resolvedDir = join(projectRoot, ".nax", "review-audit", entry.featureName ?? "_unknown");
+  let resolvedDir: string;
+  if (entry.outputDir) {
+    resolvedDir = join(entry.outputDir, "review-audit", entry.featureName ?? "_unknown");
+  } else {
+    const projectRoot = entry.projectDir ?? (await _reviewAuditDeps.findNaxProjectRoot(entry.workdir));
+    resolvedDir = join(projectRoot, ".nax", "review-audit", entry.featureName ?? "_unknown");
+  }
 
   await _reviewAuditDeps.mkdir(resolvedDir);
 
@@ -156,7 +165,7 @@ export class ReviewAuditor implements IReviewAuditor {
 
   constructor(
     private readonly _runId: string,
-    private readonly _workdir: string,
+    private readonly _outputDir: string,
   ) {}
 
   recordDispatch(entry: ReviewAuditDispatch): void {
@@ -173,7 +182,8 @@ export class ReviewAuditor implements IReviewAuditor {
       sessionName: entry.sessionName ?? dispatch?.sessionName ?? fallbackSessionName(entry),
       sessionId: entry.sessionId ?? dispatch?.sessionId ?? null,
       recordId: entry.recordId ?? dispatch?.recordId ?? null,
-      workdir: entry.workdir ?? dispatch?.workdir ?? this._workdir,
+      workdir: entry.workdir ?? dispatch?.workdir ?? "",
+      outputDir: entry.outputDir ?? dispatch?.outputDir ?? this._outputDir,
       projectDir: entry.projectDir ?? dispatch?.projectDir,
       agentName: entry.agentName ?? dispatch?.agentName,
       storyId: entry.storyId ?? dispatch?.storyId,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -26,6 +26,7 @@ export {
   identityPath,
   readProjectIdentity,
   writeProjectIdentity,
+  curatorRollupPath,
 } from "./paths";
 export type { ProjectIdentity } from "./paths";
 export { createPackageRegistry } from "./packages";
@@ -72,7 +73,7 @@ import {
 } from "./middleware";
 import { createPackageRegistry } from "./packages";
 import type { PackageRegistry } from "./packages";
-import { globalOutputDir, projectOutputDir } from "./paths";
+import { curatorRollupPath, globalOutputDir, projectOutputDir } from "./paths";
 import { PromptAuditor, createNoOpPromptAuditor } from "./prompt-auditor";
 import type { IPromptAuditor } from "./prompt-auditor";
 import { createSessionRunHop } from "./session-run-hop";
@@ -84,6 +85,7 @@ export interface NaxRuntime {
   readonly projectDir: string;
   readonly outputDir: string;
   readonly globalDir: string;
+  readonly curatorRollupPath: string; // ~/.nax/global/curator/rollup.jsonl or config override
   readonly projectKey: string;
   readonly agentManager: IAgentManager;
   readonly sessionManager: ISessionManager;
@@ -132,12 +134,13 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
   const projectKey = config.name?.trim() || basename(workdir);
   const outputDir = projectOutputDir(projectKey, config.outputDir);
   const globalDir = globalOutputDir();
+  const curatorRollupPathValue = curatorRollupPath(globalDir, config.curator?.rollupPath);
 
-  const costDir = join(workdir, ".nax", "cost");
+  const costDir = join(outputDir, "cost");
   const costAggregator = opts?.costAggregator ?? new CostAggregator(runId, costDir);
 
   const auditEnabled = config.agent?.promptAudit?.enabled ?? false;
-  const auditDir = config.agent?.promptAudit?.dir ?? join(workdir, ".nax", "prompt-audit");
+  const auditDir = config.agent?.promptAudit?.dir ?? join(outputDir, "prompt-audit");
   let promptAuditor: IPromptAuditor;
   if (opts?.promptAuditor) {
     promptAuditor = opts.promptAuditor;
@@ -156,7 +159,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
 
   const reviewAuditor =
     opts?.reviewAuditor ??
-    (config.review?.audit?.enabled ? new ReviewAuditor(runId, workdir) : createNoOpReviewAuditor());
+    (config.review?.audit?.enabled ? new ReviewAuditor(runId, outputDir) : createNoOpReviewAuditor());
 
   const defaultAgent = config.agent?.default ?? "claude";
   const pidRegistry = opts?.pidRegistry ?? new PidRegistry(workdir);
@@ -207,6 +210,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     projectDir: workdir, // Wave 1: equal to workdir; Wave 3 will separate worktree paths
     outputDir,
     globalDir,
+    curatorRollupPath: curatorRollupPathValue,
     projectKey,
     agentManager,
     sessionManager,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -19,6 +19,15 @@ export type {
   ReviewAuditEntry,
 } from "../review/review-audit";
 export type { PackageView, PackageRegistry } from "./packages";
+export {
+  projectInputDir,
+  projectOutputDir,
+  globalOutputDir,
+  identityPath,
+  readProjectIdentity,
+  writeProjectIdentity,
+} from "./paths";
+export type { ProjectIdentity } from "./paths";
 export { createPackageRegistry } from "./packages";
 export type { DispatchContext } from "./dispatch-context";
 export type { AgentMiddleware, MiddlewareContext } from "./agent-middleware";
@@ -120,6 +129,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
   const configLoader = createConfigLoader(config);
   const dispatchEvents: IDispatchEventBus = new DispatchEventBus();
 
+  // TODO(Task 2): replace casts once name/outputDir are added to NaxConfigSchema
   const projectKey = (config as { name?: string }).name?.trim() || basename(workdir);
   const outputDir = projectOutputDir(projectKey, (config as { outputDir?: string }).outputDir);
   const globalDir = globalOutputDir();

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -129,9 +129,8 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
   const configLoader = createConfigLoader(config);
   const dispatchEvents: IDispatchEventBus = new DispatchEventBus();
 
-  // TODO(Task 2): replace casts once name/outputDir are added to NaxConfigSchema
-  const projectKey = (config as { name?: string }).name?.trim() || basename(workdir);
-  const outputDir = projectOutputDir(projectKey, (config as { outputDir?: string }).outputDir);
+  const projectKey = config.name?.trim() || basename(workdir);
+  const outputDir = projectOutputDir(projectKey, config.outputDir);
   const globalDir = globalOutputDir();
 
   const costDir = join(workdir, ".nax", "cost");

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -33,7 +33,8 @@ export type {
 } from "./dispatch-events";
 export { DispatchEventBus } from "./dispatch-events";
 
-import { join } from "node:path";
+import os from "node:os";
+import { basename, join } from "node:path";
 import type { IAgentManager } from "../agents";
 import type { CreateAgentManagerOpts } from "../agents/factory";
 import { createAgentManager } from "../agents/factory";
@@ -63,6 +64,7 @@ import {
 } from "./middleware";
 import { createPackageRegistry } from "./packages";
 import type { PackageRegistry } from "./packages";
+import { globalOutputDir, projectOutputDir } from "./paths";
 import { PromptAuditor, createNoOpPromptAuditor } from "./prompt-auditor";
 import type { IPromptAuditor } from "./prompt-auditor";
 import { createSessionRunHop } from "./session-run-hop";
@@ -72,6 +74,9 @@ export interface NaxRuntime {
   readonly configLoader: ConfigLoader;
   readonly workdir: string;
   readonly projectDir: string;
+  readonly outputDir: string;
+  readonly globalDir: string;
+  readonly projectKey: string;
   readonly agentManager: IAgentManager;
   readonly sessionManager: ISessionManager;
   readonly costAggregator: ICostAggregator;
@@ -115,6 +120,10 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
 
   const configLoader = createConfigLoader(config);
   const dispatchEvents: IDispatchEventBus = new DispatchEventBus();
+
+  const projectKey = (config as { name?: string }).name?.trim() || basename(workdir);
+  const outputDir = projectOutputDir(projectKey, (config as { outputDir?: string }).outputDir);
+  const globalDir = globalOutputDir();
 
   const costDir = join(workdir, ".nax", "cost");
   const costAggregator = opts?.costAggregator ?? new CostAggregator(runId, costDir);
@@ -188,6 +197,9 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     configLoader,
     workdir,
     projectDir: workdir, // Wave 1: equal to workdir; Wave 3 will separate worktree paths
+    outputDir,
+    globalDir,
+    projectKey,
     agentManager,
     sessionManager,
     costAggregator,

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -33,7 +33,6 @@ export type {
 } from "./dispatch-events";
 export { DispatchEventBus } from "./dispatch-events";
 
-import os from "node:os";
 import { basename, join } from "node:path";
 import type { IAgentManager } from "../agents";
 import type { CreateAgentManagerOpts } from "../agents/factory";

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -26,6 +26,7 @@ export {
   identityPath,
   readProjectIdentity,
   writeProjectIdentity,
+  claimProjectIdentity,
   curatorRollupPath,
 } from "./paths";
 export type { ProjectIdentity } from "./paths";

--- a/src/runtime/paths.ts
+++ b/src/runtime/paths.ts
@@ -80,12 +80,23 @@ export async function claimProjectIdentity(
   const now = new Date().toISOString();
 
   if (existing) {
-    // Workdir matches — update lastSeen only
     if (existing.workdir === workdir) {
       await writeProjectIdentity(projectKey, { ...existing, lastSeen: now });
+      return;
     }
-    // Different workdir — do not overwrite (collision detection is nax init's job)
-    return;
+    throw new NaxError(
+      [
+        `Project name collision: "${projectKey}" is already claimed by a different project.`,
+        `  This project:    ${workdir}`,
+        `  Registered to:  ${existing.workdir}  (last seen: ${existing.lastSeen})`,
+        "  Resolve:",
+        "    1. Rename: set a different name in .nax/config.json",
+        `    2. Reclaim: nax migrate --reclaim ${projectKey}`,
+        `    3. Merge:   nax migrate --merge ${projectKey}`,
+      ].join("\n"),
+      "RUN_NAME_COLLISION",
+      { stage: "setup", projectKey, existingWorkdir: existing.workdir },
+    );
   }
 
   // First claim — Bun.write() creates parent dirs automatically

--- a/src/runtime/paths.ts
+++ b/src/runtime/paths.ts
@@ -63,3 +63,13 @@ export async function writeProjectIdentity(projectKey: string, identity: Project
   const p = identityPath(projectKey);
   await Bun.write(p, JSON.stringify(identity, null, 2));
 }
+
+export function curatorRollupPath(globalDir: string, rollupPathOverride: string | undefined): string {
+  if (!rollupPathOverride) {
+    return path.join(globalDir, "curator", "rollup.jsonl");
+  }
+  if (rollupPathOverride.startsWith("~/")) {
+    return path.join(os.homedir(), rollupPathOverride.slice(2));
+  }
+  return rollupPathOverride;
+}

--- a/src/runtime/paths.ts
+++ b/src/runtime/paths.ts
@@ -1,4 +1,3 @@
-import { mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { NaxError } from "../errors";
@@ -89,9 +88,7 @@ export async function claimProjectIdentity(
     return;
   }
 
-  // First claim — create the directory and write the identity
-  const identDir = path.dirname(identityPath(projectKey));
-  await mkdir(identDir, { recursive: true });
+  // First claim — Bun.write() creates parent dirs automatically
   await writeProjectIdentity(projectKey, {
     name: projectKey,
     workdir,

--- a/src/runtime/paths.ts
+++ b/src/runtime/paths.ts
@@ -71,5 +71,12 @@ export function curatorRollupPath(globalDir: string, rollupPathOverride: string 
   if (rollupPathOverride.startsWith("~/")) {
     return path.join(os.homedir(), rollupPathOverride.slice(2));
   }
-  return rollupPathOverride;
+  if (path.isAbsolute(rollupPathOverride)) {
+    return rollupPathOverride;
+  }
+  throw new NaxError("curator.rollupPath must be absolute or start with ~/", "CONFIG_INVALID", {
+    stage: "runtime",
+    field: "curator.rollupPath",
+    value: rollupPathOverride,
+  });
 }

--- a/src/runtime/paths.ts
+++ b/src/runtime/paths.ts
@@ -44,7 +44,16 @@ export async function readProjectIdentity(projectKey: string): Promise<ProjectId
   const file = Bun.file(p);
   if (!(await file.exists())) return null;
   try {
-    return (await file.json()) as ProjectIdentity;
+    const data = (await file.json()) as Record<string, unknown>;
+    if (
+      typeof data.name !== "string" ||
+      typeof data.workdir !== "string" ||
+      typeof data.createdAt !== "string" ||
+      typeof data.lastSeen !== "string"
+    ) {
+      return null;
+    }
+    return data as unknown as ProjectIdentity;
   } catch {
     return null;
   }

--- a/src/runtime/paths.ts
+++ b/src/runtime/paths.ts
@@ -1,0 +1,56 @@
+import os from "node:os";
+import path from "node:path";
+import { NaxError } from "../errors";
+
+export interface ProjectIdentity {
+  name: string;
+  workdir: string;
+  remoteUrl: string | null;
+  createdAt: string;
+  lastSeen: string;
+}
+
+export function projectInputDir(workdir: string): string {
+  return path.join(workdir, ".nax");
+}
+
+export function projectOutputDir(projectKey: string, outputDirOverride: string | undefined): string {
+  if (!outputDirOverride) {
+    return path.join(os.homedir(), ".nax", projectKey);
+  }
+  if (outputDirOverride.startsWith("~/")) {
+    return path.join(os.homedir(), outputDirOverride.slice(2));
+  }
+  if (path.isAbsolute(outputDirOverride)) {
+    return outputDirOverride;
+  }
+  throw new NaxError("outputDir must be absolute or start with ~/", "CONFIG_INVALID", {
+    stage: "runtime",
+    field: "outputDir",
+    value: outputDirOverride,
+  });
+}
+
+export function globalOutputDir(): string {
+  return path.join(os.homedir(), ".nax", "global");
+}
+
+export function identityPath(projectKey: string): string {
+  return path.join(os.homedir(), ".nax", projectKey, ".identity");
+}
+
+export async function readProjectIdentity(projectKey: string): Promise<ProjectIdentity | null> {
+  const p = identityPath(projectKey);
+  const file = Bun.file(p);
+  if (!(await file.exists())) return null;
+  try {
+    return (await file.json()) as ProjectIdentity;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeProjectIdentity(projectKey: string, identity: ProjectIdentity): Promise<void> {
+  const p = identityPath(projectKey);
+  await Bun.write(p, JSON.stringify(identity, null, 2));
+}

--- a/src/runtime/paths.ts
+++ b/src/runtime/paths.ts
@@ -1,3 +1,4 @@
+import { mkdir } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { NaxError } from "../errors";
@@ -62,6 +63,42 @@ export async function readProjectIdentity(projectKey: string): Promise<ProjectId
 export async function writeProjectIdentity(projectKey: string, identity: ProjectIdentity): Promise<void> {
   const p = identityPath(projectKey);
   await Bun.write(p, JSON.stringify(identity, null, 2));
+}
+
+/**
+ * Claim the project identity for the given projectKey and workdir.
+ *
+ * - First call: writes the identity file under ~/.nax/<projectKey>/.identity
+ * - Same workdir on subsequent calls: updates lastSeen only (idempotent)
+ * - Different workdir: no-op (collision detection is the responsibility of nax init)
+ */
+export async function claimProjectIdentity(
+  projectKey: string,
+  workdir: string,
+  remoteUrl: string | null,
+): Promise<void> {
+  const existing = await readProjectIdentity(projectKey);
+  const now = new Date().toISOString();
+
+  if (existing) {
+    // Workdir matches — update lastSeen only
+    if (existing.workdir === workdir) {
+      await writeProjectIdentity(projectKey, { ...existing, lastSeen: now });
+    }
+    // Different workdir — do not overwrite (collision detection is nax init's job)
+    return;
+  }
+
+  // First claim — create the directory and write the identity
+  const identDir = path.dirname(identityPath(projectKey));
+  await mkdir(identDir, { recursive: true });
+  await writeProjectIdentity(projectKey, {
+    name: projectKey,
+    workdir,
+    remoteUrl,
+    createdAt: now,
+    lastSeen: now,
+  });
 }
 
 export function curatorRollupPath(globalDir: string, rollupPathOverride: string | undefined): string {

--- a/test/integration/autofix/cycle-shadow.test.ts
+++ b/test/integration/autofix/cycle-shadow.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 function makeCtx(workdir: string): PipelineContext {
-  const runtime = makeMockRuntime({});
+  const runtime = makeMockRuntime({ config: { ...DEFAULT_CONFIG, outputDir: join(workdir, ".nax") } });
   return {
     config: {
       ...DEFAULT_CONFIG,

--- a/test/integration/cli/cli-core-diagnose-ac3.test.ts
+++ b/test/integration/cli/cli-core-diagnose-ac3.test.ts
@@ -7,7 +7,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { diagnoseCommand } from "../../../src/cli/diagnose";
+import { diagnoseCommand, _diagnoseDeps } from "../../../src/cli/diagnose";
 import type { PRD } from "../../../src/prd";
 import { savePRD } from "../../../src/prd";
 import { fullTest } from "../../helpers/env";
@@ -19,6 +19,7 @@ const skipInCI = fullTest;
 
 // Test fixture directory
 let testDir: string;
+let origProjectOutputDir: typeof _diagnoseDeps.projectOutputDir;
 
 beforeEach(() => {
   // Create unique test directory
@@ -26,9 +27,15 @@ beforeEach(() => {
 
   // Create nax directory structure
   mkdirSync(join(testDir, ".nax", "features"), { recursive: true });
+
+  // Redirect outputDir to testDir/.nax for isolation
+  origProjectOutputDir = _diagnoseDeps.projectOutputDir;
+  _diagnoseDeps.projectOutputDir = () => join(testDir, ".nax");
 });
 
 afterEach(() => {
+  _diagnoseDeps.projectOutputDir = origProjectOutputDir;
+
   // Clean up test directory
   if (existsSync(testDir)) {
     rmSync(testDir, { recursive: true, force: true });

--- a/test/integration/cli/cli-core-diagnose-ac5.test.ts
+++ b/test/integration/cli/cli-core-diagnose-ac5.test.ts
@@ -8,13 +8,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { diagnoseCommand } from "../../../src/cli/diagnose";
+import { diagnoseCommand, _diagnoseDeps } from "../../../src/cli/diagnose";
 import type { PRD } from "../../../src/prd";
 import { savePRD } from "../../../src/prd";
 import { makeTempDir } from "../../helpers/temp";
 
 // Test fixture directory
 let testDir: string;
+let origProjectOutputDir: typeof _diagnoseDeps.projectOutputDir;
 
 beforeEach(() => {
   // Create unique test directory
@@ -22,9 +23,15 @@ beforeEach(() => {
 
   // Create nax directory structure
   mkdirSync(join(testDir, ".nax", "features"), { recursive: true });
+
+  // Redirect outputDir to testDir/.nax for isolation
+  origProjectOutputDir = _diagnoseDeps.projectOutputDir;
+  _diagnoseDeps.projectOutputDir = () => join(testDir, ".nax");
 });
 
 afterEach(() => {
+  _diagnoseDeps.projectOutputDir = origProjectOutputDir;
+
   // Clean up test directory
   if (existsSync(testDir)) {
     rmSync(testDir, { recursive: true, force: true });

--- a/test/integration/cli/cli-core-diagnose.test.ts
+++ b/test/integration/cli/cli-core-diagnose.test.ts
@@ -8,7 +8,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
-import { diagnoseCommand } from "../../../src/cli/diagnose";
+import { diagnoseCommand, _diagnoseDeps } from "../../../src/cli/diagnose";
 import type { NaxStatusFile } from "../../../src/execution/status-file";
 import type { PRD } from "../../../src/prd";
 import { savePRD } from "../../../src/prd";
@@ -16,6 +16,7 @@ import { makeTempDir } from "../../helpers/temp";
 
 // Test fixture directory
 let testDir: string;
+let origProjectOutputDir: typeof _diagnoseDeps.projectOutputDir;
 
 beforeEach(() => {
   // Create unique test directory
@@ -23,9 +24,15 @@ beforeEach(() => {
 
   // Create nax directory structure
   mkdirSync(join(testDir, ".nax", "features"), { recursive: true });
+
+  // Redirect outputDir to testDir/.nax for isolation
+  origProjectOutputDir = _diagnoseDeps.projectOutputDir;
+  _diagnoseDeps.projectOutputDir = () => join(testDir, ".nax");
 });
 
 afterEach(() => {
+  _diagnoseDeps.projectOutputDir = origProjectOutputDir;
+
   // Clean up test directory
   if (existsSync(testDir)) {
     rmSync(testDir, { recursive: true, force: true });

--- a/test/integration/execution/_parallel-metrics-helpers.ts
+++ b/test/integration/execution/_parallel-metrics-helpers.ts
@@ -74,6 +74,7 @@ export function makeCtx(overrides: { parallelCount?: number; costLimit?: number;
     startTime: Date.now(),
     batchPlan: [],
     interactionChain: null,
+    runtime: { outputDir: "/tmp/nax-test-parallel-metrics-output" },
     parallelCount,
   };
 }

--- a/test/integration/execution/deferred-review-integration.test.ts
+++ b/test/integration/execution/deferred-review-integration.test.ts
@@ -173,6 +173,7 @@ function makeCtx(registry: PluginRegistry, config: NaxConfig): SequentialExecuti
     startTime: Date.now(),
     batchPlan: [],
     interactionChain: null,
+    runtime: { outputDir: "/tmp/nax-test-deferred-review-output" } as unknown as SequentialExecutionContext["runtime"],
   };
 }
 

--- a/test/integration/runtime/runtime-middleware.test.ts
+++ b/test/integration/runtime/runtime-middleware.test.ts
@@ -42,7 +42,7 @@ describe("Wave 2 exit criteria", () => {
       _promptAuditorDeps.write = async (_p, _d) => 0;
 
       try {
-        const rt = createRuntime(auditEnabledConfig, dir, { featureName: "my-feature" });
+        const rt = createRuntime({ ...auditEnabledConfig, outputDir: join(dir, ".nax") }, dir, { featureName: "my-feature" });
         rt.promptAuditor.record({
           ts: Date.now(),
           runId: rt.runId,
@@ -75,7 +75,7 @@ describe("Wave 2 exit criteria", () => {
       };
 
       try {
-        const rt = createRuntime(DEFAULT_CONFIG, dir);
+        const rt = createRuntime({ ...DEFAULT_CONFIG, outputDir: join(dir, ".nax") }, dir);
         rt.costAggregator.record({
           ts: Date.now(),
           runId: rt.runId,
@@ -119,7 +119,7 @@ describe("Wave 2 exit criteria", () => {
       };
 
       try {
-        const rt = createRuntime(auditEnabledConfig, dir, { featureName: "my-feature" });
+        const rt = createRuntime({ ...auditEnabledConfig, outputDir: join(dir, ".nax") }, dir, { featureName: "my-feature" });
         rt.promptAuditor.record({
           ts: Date.now(),
           runId: rt.runId,

--- a/test/unit/cli/cli-status-project-level.test.ts
+++ b/test/unit/cli/cli-status-project-level.test.ts
@@ -6,9 +6,8 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { displayFeatureStatus } from "../../../src/cli/status";
+import { _statusFeaturesDeps, displayFeatureStatus } from "../../../src/cli/status-features";
 import type { NaxStatusFile } from "../../../src/execution/status-file";
 import type { PRD } from "../../../src/prd";
 import { makeTempDir } from "../../helpers/temp";
@@ -18,12 +17,17 @@ describe("displayFeatureStatus - Project-level status (nax/status.json)", () => 
   let originalCwd: string;
   let consoleOutput: string[];
   const originalLog = console.log;
+  let origProjectOutputDir: typeof _statusFeaturesDeps.projectOutputDir;
 
   beforeEach(() => {
     // Create temp directory for test
     const rawTestDir = makeTempDir("nax-test-");
     testDir = realpathSync(rawTestDir);
     originalCwd = process.cwd();
+
+    // Redirect output dir derivation to testDir/.nax so test fixtures are found
+    origProjectOutputDir = _statusFeaturesDeps.projectOutputDir;
+    _statusFeaturesDeps.projectOutputDir = () => join(testDir, ".nax");
 
     // Mock console.log to capture output
     consoleOutput = [];
@@ -33,6 +37,7 @@ describe("displayFeatureStatus - Project-level status (nax/status.json)", () => 
   });
 
   afterEach(() => {
+    _statusFeaturesDeps.projectOutputDir = origProjectOutputDir;
     // Restore original CWD and console.log
     process.chdir(originalCwd);
     console.log = originalLog;

--- a/test/unit/cli/cli-status.test.ts
+++ b/test/unit/cli/cli-status.test.ts
@@ -6,9 +6,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { displayFeatureStatus } from "../../../src/cli/status";
+import { _statusFeaturesDeps, displayFeatureStatus } from "../../../src/cli/status-features";
 import type { NaxStatusFile } from "../../../src/execution/status-file";
 import type { PRD } from "../../../src/prd";
 // Requires real PID checks — skipped by default, run with FULL=1.
@@ -18,6 +17,7 @@ import { makeTempDir } from "../../helpers/temp";
 describe("displayFeatureStatus", () => {
   let testDir: string;
   let originalCwd: string;
+  let origProjectOutputDir: typeof _statusFeaturesDeps.projectOutputDir;
   let consoleOutput: string[];
   const originalLog = console.log;
 
@@ -27,6 +27,10 @@ describe("displayFeatureStatus", () => {
     testDir = realpathSync(rawTestDir);
     originalCwd = process.cwd();
 
+    // Redirect output dir derivation to testDir/.nax so test fixtures are found
+    origProjectOutputDir = _statusFeaturesDeps.projectOutputDir;
+    _statusFeaturesDeps.projectOutputDir = () => join(testDir, ".nax");
+
     // Mock console.log to capture output
     consoleOutput = [];
     console.log = mock((message: string) => {
@@ -35,6 +39,7 @@ describe("displayFeatureStatus", () => {
   });
 
   afterEach(() => {
+    _statusFeaturesDeps.projectOutputDir = origProjectOutputDir;
     // Restore original CWD and console.log
     process.chdir(originalCwd);
     console.log = originalLog;

--- a/test/unit/cli/init-name.test.ts
+++ b/test/unit/cli/init-name.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import os from "node:os";
 import path from "node:path";
+// Direct node:fs/promises is used here because writeProjectIdentity writes to ~/.nax/<key>/
+// which is outside os.tmpdir() — the test/helpers/temp.ts helpers only manage tmpdir paths.
 import { rm, mkdir } from "node:fs/promises";
 import { writeProjectIdentity } from "../../../src/runtime";
 import { validateProjectName, checkInitCollision } from "../../../src/cli/init";

--- a/test/unit/cli/status-features.test.ts
+++ b/test/unit/cli/status-features.test.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { realpathSync } from "node:fs";
 import { join } from "node:path";
-import { displayFeatureStatus } from "../../../src/cli/status";
+import { _statusFeaturesDeps, displayFeatureStatus } from "../../../src/cli/status-features";
 import type { NaxStatusFile } from "../../../src/execution/status-file";
 import type { PRD } from "../../../src/prd";
 import { makeTempDir } from "../../helpers/temp";
@@ -20,10 +20,16 @@ describe("displayFeatureDetails - PostRun Status Display (US-004)", () => {
   let consoleOutput: string[];
   const originalLog = console.log;
 
+  let origProjectOutputDir: typeof _statusFeaturesDeps.projectOutputDir;
+
   beforeEach(() => {
     const rawTestDir = makeTempDir("nax-test-");
     testDir = realpathSync(rawTestDir);
     originalCwd = process.cwd();
+
+    // Redirect output dir derivation to testDir/.nax so test fixtures are found
+    origProjectOutputDir = _statusFeaturesDeps.projectOutputDir;
+    _statusFeaturesDeps.projectOutputDir = () => join(testDir, ".nax");
 
     // Mock console.log to capture output
     consoleOutput = [];
@@ -33,6 +39,7 @@ describe("displayFeatureDetails - PostRun Status Display (US-004)", () => {
   });
 
   afterEach(() => {
+    _statusFeaturesDeps.projectOutputDir = origProjectOutputDir;
     process.chdir(originalCwd);
     console.log = originalLog;
 

--- a/test/unit/commands/init-name.test.ts
+++ b/test/unit/commands/init-name.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import {
+  validateProjectName,
+  checkInitCollision,
+  type ProjectNameValidationResult,
+} from "../../../src/cli/init";
+
+describe("validateProjectName", () => {
+  it("accepts 'my-project'", () => {
+    const r = validateProjectName("my-project");
+    expect(r.valid).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    const r = validateProjectName("");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("non-empty");
+  });
+
+  it("rejects 'global'", () => {
+    const r = validateProjectName("global");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("reserved");
+  });
+
+  it("rejects name with uppercase", () => {
+    const r = validateProjectName("MyProject");
+    expect(r.valid).toBe(false);
+  });
+
+  it("rejects name starting with '_'", () => {
+    const r = validateProjectName("_archive");
+    expect(r.valid).toBe(false);
+    expect(r.error).toContain("reserved");
+  });
+
+  it("rejects name longer than 64 chars", () => {
+    const r = validateProjectName("a".repeat(65));
+    expect(r.valid).toBe(false);
+  });
+});

--- a/test/unit/commands/init-name.test.ts
+++ b/test/unit/commands/init-name.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import { rm, mkdir } from "node:fs/promises";
+import { writeProjectIdentity } from "../../../src/runtime";
 import {
   validateProjectName,
   checkInitCollision,
@@ -37,5 +41,63 @@ describe("validateProjectName", () => {
   it("rejects name longer than 64 chars", () => {
     const r = validateProjectName("a".repeat(65));
     expect(r.valid).toBe(false);
+  });
+});
+
+const TEST_KEY = "__nax_test_init_collision__";
+
+describe("checkInitCollision", () => {
+  const identityDir = path.join(os.homedir(), ".nax", TEST_KEY);
+
+  beforeEach(async () => {
+    await rm(identityDir, { recursive: true, force: true });
+    await mkdir(identityDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(identityDir, { recursive: true, force: true });
+  });
+
+  it("returns no collision when identity does not exist", async () => {
+    const result = await checkInitCollision(TEST_KEY, "/tmp/my-project", null);
+    expect(result.collision).toBe(false);
+  });
+
+  it("returns no collision when workdir matches (no-remote case)", async () => {
+    await writeProjectIdentity(TEST_KEY, {
+      name: TEST_KEY,
+      workdir: "/tmp/my-project",
+      remoteUrl: null,
+      createdAt: new Date().toISOString(),
+      lastSeen: new Date().toISOString(),
+    });
+    const result = await checkInitCollision(TEST_KEY, "/tmp/my-project", null);
+    expect(result.collision).toBe(false);
+  });
+
+  it("returns no collision when remote URL matches", async () => {
+    const remote = "git@github.com:org/repo.git";
+    await writeProjectIdentity(TEST_KEY, {
+      name: TEST_KEY,
+      workdir: "/tmp/other-project",
+      remoteUrl: remote,
+      createdAt: new Date().toISOString(),
+      lastSeen: new Date().toISOString(),
+    });
+    const result = await checkInitCollision(TEST_KEY, "/tmp/my-project", remote);
+    expect(result.collision).toBe(false);
+  });
+
+  it("returns collision when different workdir and no remote", async () => {
+    await writeProjectIdentity(TEST_KEY, {
+      name: TEST_KEY,
+      workdir: "/tmp/other-project",
+      remoteUrl: null,
+      createdAt: new Date().toISOString(),
+      lastSeen: new Date().toISOString(),
+    });
+    const result = await checkInitCollision(TEST_KEY, "/tmp/my-project", null);
+    expect(result.collision).toBe(true);
+    expect(result.existing?.workdir).toBe("/tmp/other-project");
   });
 });

--- a/test/unit/commands/init-name.test.ts
+++ b/test/unit/commands/init-name.test.ts
@@ -3,11 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { rm, mkdir } from "node:fs/promises";
 import { writeProjectIdentity } from "../../../src/runtime";
-import {
-  validateProjectName,
-  checkInitCollision,
-  type ProjectNameValidationResult,
-} from "../../../src/cli/init";
+import { validateProjectName, checkInitCollision } from "../../../src/cli/init";
 
 describe("validateProjectName", () => {
   it("accepts 'my-project'", () => {

--- a/test/unit/commands/migrate.test.ts
+++ b/test/unit/commands/migrate.test.ts
@@ -1,6 +1,7 @@
 // test/unit/commands/migrate.test.ts
 import { describe, expect, it } from "bun:test";
 import path from "node:path";
+import { NaxError } from "../../../src/errors";
 import { withTempDir } from "../../helpers/temp";
 import { detectGeneratedContent, migrateCommand, type MigrateCandidate } from "../../../src/commands/migrate";
 
@@ -48,16 +49,16 @@ describe("detectGeneratedContent", () => {
 
 describe("migrateCommand --reclaim", () => {
   it("throws when name does not exist in ~/.nax/", async () => {
-    await expect(
-      migrateCommand({ workdir: "/tmp", reclaim: "__nonexistent_test_9999__" }),
-    ).rejects.toThrow("Nothing to reclaim");
+    const err = await migrateCommand({ workdir: "/tmp", reclaim: "__nonexistent_test_9999__" }).catch((e) => e);
+    expect(err).toBeInstanceOf(NaxError);
+    expect((err as NaxError).code).toBe("MIGRATE_RECLAIM_NOT_FOUND");
   });
 });
 
 describe("migrateCommand --merge", () => {
   it("throws when identity does not exist", async () => {
-    await expect(
-      migrateCommand({ workdir: "/tmp", merge: "__nonexistent_test_9999__" }),
-    ).rejects.toThrow("Cannot merge");
+    const err = await migrateCommand({ workdir: "/tmp", merge: "__nonexistent_test_9999__" }).catch((e) => e);
+    expect(err).toBeInstanceOf(NaxError);
+    expect((err as NaxError).code).toBe("MIGRATE_MERGE_NOT_FOUND");
   });
 });

--- a/test/unit/commands/migrate.test.ts
+++ b/test/unit/commands/migrate.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "bun:test";
 import path from "node:path";
 import { withTempDir } from "../../helpers/temp";
-import { detectGeneratedContent, type MigrateCandidate } from "../../../src/commands/migrate";
+import { detectGeneratedContent, migrateCommand, type MigrateCandidate } from "../../../src/commands/migrate";
 
 describe("detectGeneratedContent", () => {
   it("detects runs/ directory", async () => {
@@ -43,5 +43,21 @@ describe("detectGeneratedContent", () => {
       const candidates = await detectGeneratedContent(naxDir);
       expect(candidates).toEqual([]);
     });
+  });
+});
+
+describe("migrateCommand --reclaim", () => {
+  it("throws when name does not exist in ~/.nax/", async () => {
+    await expect(
+      migrateCommand({ workdir: "/tmp", reclaim: "__nonexistent_test_9999__" }),
+    ).rejects.toThrow("Nothing to reclaim");
+  });
+});
+
+describe("migrateCommand --merge", () => {
+  it("throws when identity does not exist", async () => {
+    await expect(
+      migrateCommand({ workdir: "/tmp", merge: "__nonexistent_test_9999__" }),
+    ).rejects.toThrow("Cannot merge");
   });
 });

--- a/test/unit/commands/migrate.test.ts
+++ b/test/unit/commands/migrate.test.ts
@@ -1,0 +1,47 @@
+// test/unit/commands/migrate.test.ts
+import { describe, expect, it } from "bun:test";
+import path from "node:path";
+import { withTempDir } from "../../helpers/temp";
+import { detectGeneratedContent, type MigrateCandidate } from "../../../src/commands/migrate";
+
+describe("detectGeneratedContent", () => {
+  it("detects runs/ directory", async () => {
+    await withTempDir(async (dir) => {
+      const naxDir = path.join(dir, ".nax");
+      await Bun.write(path.join(naxDir, "runs", "run-1", "log.jsonl"), "{}");
+
+      const candidates = await detectGeneratedContent(naxDir);
+      expect(candidates.some((c) => c.name === "runs")).toBe(true);
+    });
+  });
+
+  it("detects metrics.json", async () => {
+    await withTempDir(async (dir) => {
+      const naxDir = path.join(dir, ".nax");
+      await Bun.write(path.join(naxDir, "metrics.json"), "{}");
+
+      const candidates = await detectGeneratedContent(naxDir);
+      expect(candidates.some((c) => c.name === "metrics.json")).toBe(true);
+    });
+  });
+
+  it("returns empty array when nothing to migrate", async () => {
+    await withTempDir(async (dir) => {
+      const naxDir = path.join(dir, ".nax");
+      await Bun.write(path.join(naxDir, "config.json"), "{}");
+
+      const candidates = await detectGeneratedContent(naxDir);
+      expect(candidates).toEqual([]);
+    });
+  });
+
+  it("is idempotent — already-migrated state returns empty", async () => {
+    await withTempDir(async (dir) => {
+      const naxDir = path.join(dir, ".nax");
+      await Bun.write(path.join(naxDir, "config.json"), JSON.stringify({ name: "koda" }));
+
+      const candidates = await detectGeneratedContent(naxDir);
+      expect(candidates).toEqual([]);
+    });
+  });
+});

--- a/test/unit/commands/migrate.test.ts
+++ b/test/unit/commands/migrate.test.ts
@@ -49,16 +49,28 @@ describe("detectGeneratedContent", () => {
 
 describe("migrateCommand --reclaim", () => {
   it("throws when name does not exist in ~/.nax/", async () => {
-    const err = await migrateCommand({ workdir: "/tmp", reclaim: "__nonexistent_test_9999__" }).catch((e) => e);
+    const err = await migrateCommand({ workdir: "/tmp", reclaim: "nonexistent-test-9999" }).catch((e) => e);
     expect(err).toBeInstanceOf(NaxError);
     expect((err as NaxError).code).toBe("MIGRATE_RECLAIM_NOT_FOUND");
+  });
+
+  it("throws MIGRATE_INVALID_NAME when name contains path traversal characters", async () => {
+    const err = await migrateCommand({ workdir: "/tmp", reclaim: "../etc" }).catch((e) => e);
+    expect(err).toBeInstanceOf(NaxError);
+    expect((err as NaxError).code).toBe("MIGRATE_INVALID_NAME");
   });
 });
 
 describe("migrateCommand --merge", () => {
   it("throws when identity does not exist", async () => {
-    const err = await migrateCommand({ workdir: "/tmp", merge: "__nonexistent_test_9999__" }).catch((e) => e);
+    const err = await migrateCommand({ workdir: "/tmp", merge: "nonexistent-test-9999" }).catch((e) => e);
     expect(err).toBeInstanceOf(NaxError);
     expect((err as NaxError).code).toBe("MIGRATE_MERGE_NOT_FOUND");
+  });
+
+  it("throws MIGRATE_INVALID_NAME when name contains path traversal characters", async () => {
+    const err = await migrateCommand({ workdir: "/tmp", merge: "../etc" }).catch((e) => e);
+    expect(err).toBeInstanceOf(NaxError);
+    expect((err as NaxError).code).toBe("MIGRATE_INVALID_NAME");
   });
 });

--- a/test/unit/config/defaults-ssot.test.ts
+++ b/test/unit/config/defaults-ssot.test.ts
@@ -17,6 +17,8 @@ import { NaxConfigSchema } from "../../../src/config/schemas";
 import type { NaxConfig } from "../../../src/config/types";
 
 const NAX_CONFIG_KEYS: (keyof NaxConfig)[] = [
+  "name",
+  "outputDir",
   "version",
   "models",
   "autoMode",
@@ -40,6 +42,7 @@ const NAX_CONFIG_KEYS: (keyof NaxConfig)[] = [
   "agent",
   "generate",
   "project",
+  "curator",
   "debate",
   "profile",
 ];

--- a/test/unit/execution/unified-executor-cost.test.ts
+++ b/test/unit/execution/unified-executor-cost.test.ts
@@ -69,6 +69,7 @@ function makeCtx(overrides: { parallelCount?: number } = {}) {
     startTime: Date.now(),
     batchPlan: [],
     interactionChain: null,
+    runtime: { outputDir: "/tmp/nax-test-cost-output" },
     ...overrides,
   };
 }

--- a/test/unit/execution/unified-executor-dispatch.test.ts
+++ b/test/unit/execution/unified-executor-dispatch.test.ts
@@ -75,6 +75,7 @@ function makeCtx(overrides: { parallelCount?: number } = {}) {
     startTime: Date.now(),
     batchPlan: [],
     interactionChain: null,
+    runtime: { outputDir: "/tmp/nax-test-dispatch-output" },
     ...overrides,
   };
 }

--- a/test/unit/execution/unified-executor-logging.test.ts
+++ b/test/unit/execution/unified-executor-logging.test.ts
@@ -71,6 +71,7 @@ function makeCtx(overrides: { parallelCount?: number } = {}) {
     startTime: Date.now(),
     batchPlan: [],
     interactionChain: null,
+    runtime: { outputDir: "/tmp/nax-test-logging-output" },
     ...overrides,
   };
 }

--- a/test/unit/execution/unified-executor-rl002.test.ts
+++ b/test/unit/execution/unified-executor-rl002.test.ts
@@ -92,6 +92,7 @@ function makeMinimalContext(): SequentialExecutionContext {
     batchPlan: [],
     interactionChain: null,
     logFilePath: undefined,
+    runtime: { outputDir: "/tmp/nax-test-rl002-output" } as unknown as SequentialExecutionContext["runtime"],
   };
 }
 

--- a/test/unit/execution/unified-executor-rl007.test.ts
+++ b/test/unit/execution/unified-executor-rl007.test.ts
@@ -96,6 +96,7 @@ function makeMinimalContext(): SequentialExecutionContext {
     batchPlan: [],
     interactionChain: null,
     logFilePath: undefined,
+    runtime: { outputDir: "/tmp/nax-test-rl007-output" } as unknown as SequentialExecutionContext["runtime"],
   };
 }
 

--- a/test/unit/execution/unified-executor-session-close.test.ts
+++ b/test/unit/execution/unified-executor-session-close.test.ts
@@ -83,6 +83,7 @@ function makeCtx(sessionManager: ISessionManager) {
     batchPlan: [],
     interactionChain: null,
     sessionManager,
+    runtime: { outputDir: "/tmp/nax-test-session-close-output" },
   };
 }
 

--- a/test/unit/metrics/save-run-metrics.test.ts
+++ b/test/unit/metrics/save-run-metrics.test.ts
@@ -17,20 +17,22 @@ import { loadRunMetrics, saveRunMetrics } from "../../../src/metrics/tracker";
 import type { RunMetrics, StoryMetrics } from "../../../src/metrics/types";
 import { TokenUsage } from "../../../src/metrics/types";
 
-const WORKDIR = `/tmp/nax-save-run-metrics-test-${randomUUID()}`;
+// OUTPUT_DIR plays the role of outputDir (e.g. ~/.nax/<projectKey>): metrics are written
+// directly to OUTPUT_DIR/metrics.json, no .nax/ subdirectory.
+const OUTPUT_DIR = `/tmp/nax-save-run-metrics-test-${randomUUID()}`;
 
 async function setupWorkdir() {
-  await mkdir(`${WORKDIR}/.nax`, { recursive: true });
+  await mkdir(OUTPUT_DIR, { recursive: true });
 }
 
 async function cleanupWorkdir() {
-  if (existsSync(WORKDIR)) {
-    await rm(WORKDIR, { recursive: true, force: true });
+  if (existsSync(OUTPUT_DIR)) {
+    await rm(OUTPUT_DIR, { recursive: true, force: true });
   }
 }
 
 async function readMetricsFile(): Promise<RunMetrics[]> {
-  const content = await readFile(`${WORKDIR}/.nax/metrics.json`, "utf-8");
+  const content = await readFile(`${OUTPUT_DIR}/metrics.json`, "utf-8");
   return JSON.parse(content);
 }
 
@@ -89,7 +91,7 @@ describe("saveRunMetrics - totalTokens aggregation", () => {
       stories: [story1, story2],
     };
 
-    await saveRunMetrics(WORKDIR, runMetrics);
+    await saveRunMetrics(OUTPUT_DIR, runMetrics);
 
     const saved = await readMetricsFile();
     expect(saved).toHaveLength(1);
@@ -152,7 +154,7 @@ describe("saveRunMetrics - totalTokens aggregation", () => {
       stories: [story1, story2],
     };
 
-    await saveRunMetrics(WORKDIR, runMetrics);
+    await saveRunMetrics(OUTPUT_DIR, runMetrics);
 
     const saved = await readMetricsFile();
     expect(saved).toHaveLength(1);
@@ -206,7 +208,7 @@ describe("saveRunMetrics - totalTokens aggregation", () => {
       stories: [story1, story2],
     };
 
-    await saveRunMetrics(WORKDIR, runMetrics);
+    await saveRunMetrics(OUTPUT_DIR, runMetrics);
 
     const saved = await readMetricsFile();
     expect(saved).toHaveLength(1);
@@ -246,9 +248,9 @@ describe("loadRunMetrics - backward compatibility", () => {
       },
     ];
 
-    await writeFile(`${WORKDIR}/.nax/metrics.json`, JSON.stringify(existingMetrics, null, 2));
+    await writeFile(`${OUTPUT_DIR}/metrics.json`, JSON.stringify(existingMetrics, null, 2));
 
-    const runs = await loadRunMetrics(WORKDIR);
+    const runs = await loadRunMetrics(OUTPUT_DIR);
 
     expect(runs).toHaveLength(1);
     expect(runs[0].runId).toBe("run-old-001");

--- a/test/unit/pipeline/subscribers/registry.test.ts
+++ b/test/unit/pipeline/subscribers/registry.test.ts
@@ -13,11 +13,14 @@ describe("wireRegistry", () => {
   let runDir: string;
   let metaFile: string;
 
+  let outputDir: string;
+
   beforeEach(() => {
     workdir = join("/tmp", `nax-regtest-${Date.now()}`);
     feature = "auth-system";
     runId = `run-${Date.now()}`;
     const project = basename(workdir);
+    outputDir = join(homedir(), ".nax", project);
     runDir = join(homedir(), ".nax", "runs", `${project}-${feature}-${runId}`);
     metaFile = join(runDir, "meta.json");
   });
@@ -29,14 +32,14 @@ describe("wireRegistry", () => {
 
   test("returns an UnsubscribeFn", () => {
     const bus = new PipelineEventBus();
-    const unsub = wireRegistry(bus, feature, runId, workdir);
+    const unsub = wireRegistry(bus, feature, runId, workdir, outputDir);
     expect(typeof unsub).toBe("function");
     unsub();
   });
 
   test("creates meta.json on run:started", async () => {
     const bus = new PipelineEventBus();
-    wireRegistry(bus, feature, runId, workdir);
+    wireRegistry(bus, feature, runId, workdir, outputDir);
 
     bus.emit({ type: "run:started", feature, totalStories: 3, workdir });
 
@@ -48,7 +51,7 @@ describe("wireRegistry", () => {
 
   test("meta.json contains all required fields", async () => {
     const bus = new PipelineEventBus();
-    wireRegistry(bus, feature, runId, workdir);
+    wireRegistry(bus, feature, runId, workdir, outputDir);
 
     bus.emit({ type: "run:started", feature, totalStories: 1, workdir });
 
@@ -64,33 +67,33 @@ describe("wireRegistry", () => {
     expect(typeof meta.registeredAt).toBe("string");
   });
 
-  test("statusPath points to <workdir>/.nax/features/<feature>/status.json", async () => {
+  test("statusPath points to outputDir/features/<feature>/status.json", async () => {
     const bus = new PipelineEventBus();
-    wireRegistry(bus, feature, runId, workdir);
+    wireRegistry(bus, feature, runId, workdir, outputDir);
 
     bus.emit({ type: "run:started", feature, totalStories: 1, workdir });
 
     await waitForFile(metaFile, 500);
     const meta = JSON.parse(await readFile(metaFile, "utf8")) as MetaJson;
 
-    expect(meta.statusPath).toBe(join(workdir, ".nax", "features", feature, "status.json"));
+    expect(meta.statusPath).toBe(join(outputDir, "features", feature, "status.json"));
   });
 
-  test("eventsDir points to <workdir>/.nax/features/<feature>/runs", async () => {
+  test("eventsDir points to outputDir/features/<feature>/runs", async () => {
     const bus = new PipelineEventBus();
-    wireRegistry(bus, feature, runId, workdir);
+    wireRegistry(bus, feature, runId, workdir, outputDir);
 
     bus.emit({ type: "run:started", feature, totalStories: 1, workdir });
 
     await waitForFile(metaFile, 500);
     const meta = JSON.parse(await readFile(metaFile, "utf8")) as MetaJson;
 
-    expect(meta.eventsDir).toBe(join(workdir, ".nax", "features", feature, "runs"));
+    expect(meta.eventsDir).toBe(join(outputDir, "features", feature, "runs"));
   });
 
   test("registeredAt is valid ISO8601", async () => {
     const bus = new PipelineEventBus();
-    wireRegistry(bus, feature, runId, workdir);
+    wireRegistry(bus, feature, runId, workdir, outputDir);
 
     bus.emit({ type: "run:started", feature, totalStories: 1, workdir });
 
@@ -104,7 +107,7 @@ describe("wireRegistry", () => {
     const bus = new PipelineEventBus();
     // Point to an unwritable path to trigger write failure
     const badWorkdir = "/dev/null/nonexistent-project";
-    wireRegistry(bus, "feat-err", "run-err", badWorkdir);
+    wireRegistry(bus, "feat-err", "run-err", badWorkdir, "/tmp/nax-test-bad-output");
 
     expect(() => {
       bus.emit({ type: "run:started", feature: "feat-err", totalStories: 0, workdir: badWorkdir });
@@ -128,7 +131,7 @@ describe("wireRegistry", () => {
 
   test("unsubscribe stops further writes", async () => {
     const bus = new PipelineEventBus();
-    const unsub = wireRegistry(bus, feature, runId, workdir);
+    const unsub = wireRegistry(bus, feature, runId, workdir, outputDir);
 
     unsub();
 

--- a/test/unit/review/review-audit.test.ts
+++ b/test/unit/review/review-audit.test.ts
@@ -206,7 +206,7 @@ describe("ReviewAuditor", () => {
     Object.assign(_reviewAuditDeps, saved);
 
     const content = JSON.parse(written[0].content);
-    expect(written[0].path).toContain(".nax/review-audit/my-feature");
+    expect(written[0].path).toContain("review-audit/my-feature");
     expect(content.sessionName).toBe("nax-reviewer-semantic");
     expect(content.sessionId).toBe("sid-1");
     expect(content.recordId).toBe("rid-1");

--- a/test/unit/runtime/paths.test.ts
+++ b/test/unit/runtime/paths.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { NaxError } from "../../../src/errors";
@@ -6,11 +7,11 @@ import {
   globalOutputDir,
   projectInputDir,
   projectOutputDir,
+  identityPath,
   readProjectIdentity,
   writeProjectIdentity,
-  identityPath,
   type ProjectIdentity,
-} from "../../../src/runtime/paths";
+} from "../../../src/runtime";
 
 describe("projectInputDir", () => {
   it("returns workdir/.nax", () => {
@@ -49,15 +50,13 @@ describe("identity I/O", () => {
   const TEST_PROJECT_KEY = "__nax_test_paths_identity__";
   const identDir = path.join(os.homedir(), ".nax", TEST_PROJECT_KEY);
 
-  // cleanup before and after to ensure isolation
-  function cleanup() {
-    try {
-      const { rmSync } = require("node:fs");
-      rmSync(identDir, { recursive: true, force: true });
-    } catch {
-      // ok
-    }
-  }
+  beforeEach(async () => {
+    await rm(identDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await rm(identDir, { recursive: true, force: true });
+  });
 
   it("identityPath returns correct path", () => {
     expect(identityPath(TEST_PROJECT_KEY)).toBe(
@@ -66,15 +65,12 @@ describe("identity I/O", () => {
   });
 
   it("readProjectIdentity returns null when file does not exist", async () => {
-    cleanup();
     const result = await readProjectIdentity(TEST_PROJECT_KEY);
     expect(result).toBeNull();
   });
 
   it("writeProjectIdentity then readProjectIdentity round-trips", async () => {
-    cleanup();
-    const { mkdirSync } = require("node:fs");
-    mkdirSync(identDir, { recursive: true });
+    await mkdir(identDir, { recursive: true });
 
     const identity: ProjectIdentity = {
       name: TEST_PROJECT_KEY,
@@ -87,7 +83,13 @@ describe("identity I/O", () => {
     await writeProjectIdentity(TEST_PROJECT_KEY, identity);
     const read = await readProjectIdentity(TEST_PROJECT_KEY);
     expect(read).toEqual(identity);
+  });
 
-    cleanup();
+  it("readProjectIdentity returns null for malformed JSON file", async () => {
+    await mkdir(identDir, { recursive: true });
+    // Write malformed identity (missing required fields — shape guard should reject)
+    await Bun.write(path.join(identDir, ".identity"), JSON.stringify({ name: TEST_PROJECT_KEY }));
+    const result = await readProjectIdentity(TEST_PROJECT_KEY);
+    expect(result).toBeNull();
   });
 });

--- a/test/unit/runtime/paths.test.ts
+++ b/test/unit/runtime/paths.test.ts
@@ -10,6 +10,7 @@ import {
   identityPath,
   readProjectIdentity,
   writeProjectIdentity,
+  curatorRollupPath,
   type ProjectIdentity,
 } from "../../../src/runtime";
 
@@ -94,8 +95,6 @@ describe("identity I/O", () => {
   });
 });
 
-import { curatorRollupPath } from "../../../src/runtime";
-
 describe("curatorRollupPath", () => {
   it("defaults to globalDir/curator/rollup.jsonl", () => {
     const result = curatorRollupPath("/home/user/.nax/global", undefined);
@@ -110,6 +109,10 @@ describe("curatorRollupPath", () => {
   it("expands tilde in override", () => {
     const result = curatorRollupPath("/home/user/.nax/global", "~/custom/rollup.jsonl");
     expect(result).toBe(path.join(os.homedir(), "custom/rollup.jsonl"));
+  });
+
+  it("throws NaxError for relative override", () => {
+    expect(() => curatorRollupPath("/home/user/.nax/global", "relative/path")).toThrow(NaxError);
   });
 });
 

--- a/test/unit/runtime/paths.test.ts
+++ b/test/unit/runtime/paths.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import os from "node:os";
 import path from "node:path";
+import { NaxError } from "../../../src/errors";
 import {
   globalOutputDir,
   projectInputDir,
   projectOutputDir,
+  readProjectIdentity,
+  writeProjectIdentity,
+  identityPath,
+  type ProjectIdentity,
 } from "../../../src/runtime/paths";
 
 describe("projectInputDir", () => {
@@ -30,14 +35,59 @@ describe("projectOutputDir", () => {
   });
 
   it("throws NaxError for relative outputDir override", () => {
-    expect(() => projectOutputDir("myproject", "relative/path")).toThrow(
-      "outputDir must be absolute or start with ~/",
-    );
+    expect(() => projectOutputDir("myproject", "relative/path")).toThrow(NaxError);
   });
 });
 
 describe("globalOutputDir", () => {
   it("returns ~/.nax/global", () => {
     expect(globalOutputDir()).toBe(path.join(os.homedir(), ".nax", "global"));
+  });
+});
+
+describe("identity I/O", () => {
+  const TEST_PROJECT_KEY = "__nax_test_paths_identity__";
+  const identDir = path.join(os.homedir(), ".nax", TEST_PROJECT_KEY);
+
+  // cleanup before and after to ensure isolation
+  function cleanup() {
+    try {
+      const { rmSync } = require("node:fs");
+      rmSync(identDir, { recursive: true, force: true });
+    } catch {
+      // ok
+    }
+  }
+
+  it("identityPath returns correct path", () => {
+    expect(identityPath(TEST_PROJECT_KEY)).toBe(
+      path.join(os.homedir(), ".nax", TEST_PROJECT_KEY, ".identity"),
+    );
+  });
+
+  it("readProjectIdentity returns null when file does not exist", async () => {
+    cleanup();
+    const result = await readProjectIdentity(TEST_PROJECT_KEY);
+    expect(result).toBeNull();
+  });
+
+  it("writeProjectIdentity then readProjectIdentity round-trips", async () => {
+    cleanup();
+    const { mkdirSync } = require("node:fs");
+    mkdirSync(identDir, { recursive: true });
+
+    const identity: ProjectIdentity = {
+      name: TEST_PROJECT_KEY,
+      workdir: "/tmp/test-workdir",
+      remoteUrl: "git@github.com:test/test.git",
+      createdAt: "2026-05-04T00:00:00Z",
+      lastSeen: "2026-05-04T01:00:00Z",
+    };
+
+    await writeProjectIdentity(TEST_PROJECT_KEY, identity);
+    const read = await readProjectIdentity(TEST_PROJECT_KEY);
+    expect(read).toEqual(identity);
+
+    cleanup();
   });
 });

--- a/test/unit/runtime/paths.test.ts
+++ b/test/unit/runtime/paths.test.ts
@@ -138,11 +138,11 @@ describe("claimProjectIdentity", () => {
     expect(identity?.name).toBe(TEST_CLAIM_KEY);
   });
 
-  it("is idempotent — second call does not overwrite", async () => {
+  it("throws RUN_NAME_COLLISION when a different workdir claims the same key", async () => {
     await claimProjectIdentity(TEST_CLAIM_KEY, "/tmp/my-project", null);
-    await claimProjectIdentity(TEST_CLAIM_KEY, "/tmp/other-project", null);
-    const identity = await readProjectIdentity(TEST_CLAIM_KEY);
-    expect(identity?.workdir).toBe("/tmp/my-project");
+    const err = await claimProjectIdentity(TEST_CLAIM_KEY, "/tmp/other-project", null).catch((e) => e);
+    expect(err).toBeInstanceOf(NaxError);
+    expect((err as NaxError).code).toBe("RUN_NAME_COLLISION");
   });
 
   it("updates lastSeen on subsequent calls for same workdir", async () => {

--- a/test/unit/runtime/paths.test.ts
+++ b/test/unit/runtime/paths.test.ts
@@ -10,6 +10,7 @@ import {
   identityPath,
   readProjectIdentity,
   writeProjectIdentity,
+  claimProjectIdentity,
   curatorRollupPath,
   type ProjectIdentity,
 } from "../../../src/runtime";
@@ -113,6 +114,46 @@ describe("curatorRollupPath", () => {
 
   it("throws NaxError for relative override", () => {
     expect(() => curatorRollupPath("/home/user/.nax/global", "relative/path")).toThrow(NaxError);
+  });
+});
+
+const TEST_CLAIM_KEY = "__nax_test_claim_identity__";
+
+describe("claimProjectIdentity", () => {
+  const identityDir = path.join(os.homedir(), ".nax", TEST_CLAIM_KEY);
+
+  beforeEach(async () => {
+    await rm(identityDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await rm(identityDir, { recursive: true, force: true });
+  });
+
+  it("writes identity on first call", async () => {
+    await claimProjectIdentity(TEST_CLAIM_KEY, "/tmp/my-project", null);
+    const identity = await readProjectIdentity(TEST_CLAIM_KEY);
+    expect(identity).not.toBeNull();
+    expect(identity?.workdir).toBe("/tmp/my-project");
+    expect(identity?.name).toBe(TEST_CLAIM_KEY);
+  });
+
+  it("is idempotent — second call does not overwrite", async () => {
+    await claimProjectIdentity(TEST_CLAIM_KEY, "/tmp/my-project", null);
+    await claimProjectIdentity(TEST_CLAIM_KEY, "/tmp/other-project", null);
+    const identity = await readProjectIdentity(TEST_CLAIM_KEY);
+    expect(identity?.workdir).toBe("/tmp/my-project");
+  });
+
+  it("updates lastSeen on subsequent calls for same workdir", async () => {
+    await claimProjectIdentity(TEST_CLAIM_KEY, "/tmp/my-project", null);
+    const first = await readProjectIdentity(TEST_CLAIM_KEY);
+    // Small delay to ensure timestamps differ
+    await new Promise((r) => setTimeout(r, 5));
+    await claimProjectIdentity(TEST_CLAIM_KEY, "/tmp/my-project", null);
+    const second = await readProjectIdentity(TEST_CLAIM_KEY);
+    expect(second?.lastSeen).not.toBe(first?.lastSeen);
+    expect(second?.createdAt).toBe(first?.createdAt);
   });
 });
 

--- a/test/unit/runtime/paths.test.ts
+++ b/test/unit/runtime/paths.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import {
+  globalOutputDir,
+  projectInputDir,
+  projectOutputDir,
+} from "../../../src/runtime/paths";
+
+describe("projectInputDir", () => {
+  it("returns workdir/.nax", () => {
+    expect(projectInputDir("/home/user/myproject")).toBe("/home/user/myproject/.nax");
+  });
+});
+
+describe("projectOutputDir", () => {
+  it("defaults to ~/.nax/<projectKey> when no outputDir override", () => {
+    const result = projectOutputDir("myproject", undefined);
+    expect(result).toBe(path.join(os.homedir(), ".nax", "myproject"));
+  });
+
+  it("uses absolute outputDir override as-is", () => {
+    const result = projectOutputDir("myproject", "/mnt/fast/nax/myproject");
+    expect(result).toBe("/mnt/fast/nax/myproject");
+  });
+
+  it("expands tilde in outputDir override", () => {
+    const result = projectOutputDir("myproject", "~/custom-nax/myproject");
+    expect(result).toBe(path.join(os.homedir(), "custom-nax/myproject"));
+  });
+
+  it("throws NaxError for relative outputDir override", () => {
+    expect(() => projectOutputDir("myproject", "relative/path")).toThrow(
+      "outputDir must be absolute or start with ~/",
+    );
+  });
+});
+
+describe("globalOutputDir", () => {
+  it("returns ~/.nax/global", () => {
+    expect(globalOutputDir()).toBe(path.join(os.homedir(), ".nax", "global"));
+  });
+});

--- a/test/unit/runtime/paths.test.ts
+++ b/test/unit/runtime/paths.test.ts
@@ -94,6 +94,25 @@ describe("identity I/O", () => {
   });
 });
 
+import { curatorRollupPath } from "../../../src/runtime";
+
+describe("curatorRollupPath", () => {
+  it("defaults to globalDir/curator/rollup.jsonl", () => {
+    const result = curatorRollupPath("/home/user/.nax/global", undefined);
+    expect(result).toBe("/home/user/.nax/global/curator/rollup.jsonl");
+  });
+
+  it("uses override when provided as absolute path", () => {
+    const result = curatorRollupPath("/home/user/.nax/global", "/mnt/team/rollup.jsonl");
+    expect(result).toBe("/mnt/team/rollup.jsonl");
+  });
+
+  it("expands tilde in override", () => {
+    const result = curatorRollupPath("/home/user/.nax/global", "~/custom/rollup.jsonl");
+    expect(result).toBe(path.join(os.homedir(), "custom/rollup.jsonl"));
+  });
+});
+
 import { NaxConfigSchema } from "../../../src/config/schemas";
 
 describe("NaxConfigSchema name field", () => {

--- a/test/unit/runtime/paths.test.ts
+++ b/test/unit/runtime/paths.test.ts
@@ -93,3 +93,66 @@ describe("identity I/O", () => {
     expect(result).toBeNull();
   });
 });
+
+import { NaxConfigSchema } from "../../../src/config/schemas";
+
+describe("NaxConfigSchema name field", () => {
+  it("accepts a valid name", () => {
+    const result = NaxConfigSchema.safeParse({ name: "my-project" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a name with underscores and digits", () => {
+    const result = NaxConfigSchema.safeParse({ name: "proj_1" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a name with uppercase letters", () => {
+    const result = NaxConfigSchema.safeParse({ name: "MyProject" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects reserved name 'global'", () => {
+    const result = NaxConfigSchema.safeParse({ name: "global" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects reserved name '_archive'", () => {
+    const result = NaxConfigSchema.safeParse({ name: "_archive" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a name starting with '.'", () => {
+    const result = NaxConfigSchema.safeParse({ name: ".hidden" });
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults name to empty string when absent", () => {
+    const result = NaxConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.name).toBe("");
+  });
+
+  it("accepts optional outputDir as absolute path", () => {
+    const result = NaxConfigSchema.safeParse({ name: "koda", outputDir: "/mnt/fast/nax/koda" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts outputDir starting with ~/", () => {
+    const result = NaxConfigSchema.safeParse({ name: "koda", outputDir: "~/custom/koda" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects relative outputDir", () => {
+    const result = NaxConfigSchema.safeParse({ name: "koda", outputDir: "relative/path" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts curator.rollupPath", () => {
+    const result = NaxConfigSchema.safeParse({
+      name: "koda",
+      curator: { rollupPath: "/mnt/share/rollup.jsonl" },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/test/unit/runtime/runtime.test.ts
+++ b/test/unit/runtime/runtime.test.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect } from "bun:test";
+import os from "node:os";
+import path from "node:path";
 import { createRuntime } from "../../../src/runtime";
-import { DEFAULT_CONFIG } from "../../../src/config";
+import { DEFAULT_CONFIG, NaxConfigSchema } from "../../../src/config";
 import { makeNaxConfig, makeTestRuntime } from "../../helpers";
 
 describe("createRuntime", () => {
@@ -223,6 +225,23 @@ describe("createRuntime", () => {
     await rt.close();
 
     expect(reviewFlushCalled).toBe(true);
+  });
+});
+
+describe("createRuntime outputDir", () => {
+  test("sets outputDir to ~/.nax/<basename> when name is absent", () => {
+    const config = NaxConfigSchema.parse({});
+    const runtime = createRuntime(config, "/tmp/my-project");
+    expect(runtime.outputDir).toBe(path.join(os.homedir(), ".nax", "my-project"));
+    expect(runtime.projectKey).toBe("my-project");
+    expect(runtime.globalDir).toBe(path.join(os.homedir(), ".nax", "global"));
+  });
+
+  test("uses config.name as projectKey when present", () => {
+    const config = NaxConfigSchema.parse({ name: "koda" });
+    const runtime = createRuntime(config, "/tmp/any-path");
+    expect(runtime.projectKey).toBe("koda");
+    expect(runtime.outputDir).toBe(path.join(os.homedir(), ".nax", "koda"));
   });
 });
 


### PR DESCRIPTION
## Summary

Close #900 

Implements the `.nax/` folder split as designed in `docs/specs/SPEC-nax-folder-split.md`, separating three categories that were previously co-mingled in `workdir/.nax/`:

- **VCS inputs** (`workdir/.nax/`) — config, PRD, context files; tracked in git
- **Per-user outputs** (`~/.nax/<projectKey>/`) — run logs, metrics, status files; gitignored by design
- **Global state** (`~/.nax/global/`) — Central Run Registry; cross-project

Key changes:
- **`src/runtime/paths.ts`** — new `projectOutputDir(key, override?)` and `projectGlobalDir()` helpers; `ProjectIdentity` I/O for stable key binding
- **Config schema** — `name`, `outputDir`, `curator.rollupPath` fields added to `NaxConfigSchema`
- **`nax init`** — validates project name (rejects path traversal, reserved words, `_`/`.` prefixes); collision precheck against existing `~/.nax/` entries
- **`nax migrate`** — detects generated content in `workdir/.nax/` and moves it to `~/.nax/<key>/`; `--reclaim` to adopt an orphaned identity; `--merge` to merge two identities; first-run auto-migration on `nax run`
- **`runtime.outputDir`** — all 15 pipeline stages and lifecycle modules now use `ctx.runtime.outputDir` as the single source of truth for output paths
- **Curator rollup path** — resolved relative to `outputDir`; guarded against path traversal
- **CLI commands** (`status`, `status --cost`, `runs`, `diagnose`) — derive `projectKey` from `config.name` when present, honouring `outputDir` override

## Test Plan

- [ ] `bun run test` — full suite passes (1237 tests, 0 failures)
- [ ] `bun run typecheck` — no type errors
- [ ] `bun run lint` — no lint errors
- [ ] Manual: `nax init` in a new project sets `.nax/config.json` with validated name
- [ ] Manual: `nax run` in a project with old-style `.nax/runs/` auto-migrates to `~/.nax/<key>/`
- [ ] Manual: `nax migrate --reclaim <name>` and `--merge <name>` work for identity management
- [ ] Manual: `nax status`, `nax status --cost`, `nax runs list` resolve to correct `~/.nax/<key>/` path

## Notes

- Path traversal is rejected in `--reclaim`/`--merge` via `validateProjectName` (new `MIGRATE_INVALID_NAME` error code)
- Cross-filesystem EXDEV during migration throws `MIGRATE_CROSS_FS` with an actionable hint to set `outputDir`
- `_diagnoseDeps` and `_statusFeaturesDeps` extended with `loadConfig` injection for test isolation of output dir routing