### PR TITLE
fix: honor profile model routing in review and op dispatch

### DIFF
--- a/.nax/profiles/opencode-review.json
+++ b/.nax/profiles/opencode-review.json
@@ -1,0 +1,13 @@
+{
+  "review": {
+    "adversarial": {
+      "model": { "agent": "opencode", "model": "opencode-go/deepseek-v4-pro" }
+    },
+    "semantic": {
+      "model": { "agent": "opencode", "model": "opencode-go/kimi-k2.6" }
+    }
+  },
+  "acceptance": {
+    "model": { "agent": "opencode", "model": "opencode-go/minimax-m2.7" }
+  }  
+}

--- a/src/operations/acceptance-diagnose.ts
+++ b/src/operations/acceptance-diagnose.ts
@@ -33,6 +33,7 @@ export const acceptanceDiagnoseOp: RunOperation<AcceptanceDiagnoseInput, Accepta
   stage: "acceptance",
   session: { role: "diagnose", lifetime: "fresh" },
   config: acceptanceConfigSelector,
+  model: (_input, ctx) => ctx.config.acceptance.fix?.diagnoseModel ?? ctx.config.acceptance.model,
   timeoutMs: (_input, ctx) => ctx.config.acceptance.timeoutMs,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildDiagnosisPrompt({

--- a/src/operations/acceptance-fix.ts
+++ b/src/operations/acceptance-fix.ts
@@ -30,6 +30,7 @@ export const acceptanceFixSourceOp: RunOperation<AcceptanceFixSourceInput, Accep
   stage: "acceptance",
   session: { role: "source-fix", lifetime: "fresh" },
   config: acceptanceFixConfigSelector,
+  model: (_input, ctx) => ctx.config.acceptance.fix?.fixModel ?? ctx.config.acceptance.model,
   timeoutMs: (_input, ctx) => ctx.config.execution.sessionTimeoutSeconds * 1000,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildSourceFixPrompt({
@@ -55,6 +56,7 @@ export const acceptanceFixTestOp: RunOperation<AcceptanceFixTestInput, Acceptanc
   stage: "acceptance",
   session: { role: "test-fix", lifetime: "fresh" },
   config: acceptanceFixConfigSelector,
+  model: (_input, ctx) => ctx.config.acceptance.fix?.fixModel ?? ctx.config.acceptance.model,
   timeoutMs: (_input, ctx) => ctx.config.execution.sessionTimeoutSeconds * 1000,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildTestFixPrompt({

--- a/src/operations/acceptance-generate.ts
+++ b/src/operations/acceptance-generate.ts
@@ -27,6 +27,7 @@ export const acceptanceGenerateOp: CompleteOperation<
   stage: "acceptance",
   jsonMode: false,
   config: acceptanceGenConfigSelector,
+  model: (_input, ctx) => ctx.config.acceptance.model,
   timeoutMs: (_input, ctx) => ctx.config.execution.sessionTimeoutSeconds * 1000,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildGeneratorFromPRDPrompt({

--- a/src/operations/acceptance-refine.ts
+++ b/src/operations/acceptance-refine.ts
@@ -23,6 +23,7 @@ export const acceptanceRefineOp: CompleteOperation<AcceptanceRefineInput, Accept
   stage: "acceptance",
   jsonMode: true,
   config: acceptanceConfigSelector,
+  model: (_input, ctx) => ctx.config.acceptance.model,
   timeoutMs: (_input, ctx) => ctx.config.acceptance.timeoutMs,
   build(input, _ctx) {
     const prompt = new AcceptancePromptBuilder().buildRefinementPrompt(input.criteria, input.codebaseContext, {

--- a/src/operations/auto-approve.ts
+++ b/src/operations/auto-approve.ts
@@ -14,6 +14,20 @@ import type { SchemaDescriptor } from "../prompts";
 import { parseLLMJson } from "../utils/llm-json";
 import type { BuildContext, CompleteOperation } from "./types";
 
+function resolveAutoApproveModel(config: InteractionConfig): string {
+  const root =
+    typeof config === "object" &&
+    config !== null &&
+    "interaction" in config &&
+    typeof config.interaction === "object" &&
+    config.interaction !== null
+      ? config.interaction
+      : config;
+  const value = (root as { config?: Record<string, unknown> }).config?.model;
+  if (typeof value === "string") return value;
+  return "fast";
+}
+
 const AUTO_APPROVER_SCHEMA: SchemaDescriptor = {
   name: "ApprovalDecision",
   description: "Respond with ONLY this JSON — no markdown, no explanation.",
@@ -59,6 +73,7 @@ export const autoApproveOp: CompleteOperation<AutoApproveInput, AutoApproveOutpu
   stage: "run",
   jsonMode: true,
   config: interactionConfigSelector,
+  model: (_input, ctx) => resolveAutoApproveModel(ctx.config),
 
   build(input: AutoApproveInput, _ctx: BuildContext<InteractionConfig>) {
     const requestLines = [

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -153,7 +153,10 @@ export function buildHopCallback(
       role: resolvedRunOptions.sessionRole ?? "implementer",
       pipelineStage: stage,
     });
-    const modelDef = resolveModelForAgent(config.models, agentName, effectiveTier, defaultAgent);
+    const modelDef =
+      failure === undefined
+        ? (resolvedRunOptions.modelDef ?? resolveModelForAgent(config.models, agentName, effectiveTier, defaultAgent))
+        : resolveModelForAgent(config.models, agentName, effectiveTier, defaultAgent);
     const timeoutSeconds = resolvedRunOptions.timeoutSeconds ?? config.execution.sessionTimeoutSeconds;
 
     // openSession errors propagate naturally — no handle, no closeSession needed

--- a/src/operations/classify-route.ts
+++ b/src/operations/classify-route.ts
@@ -26,6 +26,7 @@ export const classifyRouteOp: CompleteOperation<ClassifyRouteInput, ClassifyRout
   stage: "run",
   jsonMode: true,
   config: routingConfigSelector,
+  model: (_input, ctx) => ctx.config.routing.llm?.model ?? "balanced",
   build(input: ClassifyRouteInput, _ctx: BuildContext<RoutingConfig>) {
     const criteria = input.acceptanceCriteria.map((c, i) => `${i + 1}. ${c}`).join("\n");
     const storyBody = [
@@ -60,6 +61,7 @@ export const classifyRouteBatchOp: CompleteOperation<UserStory[], Map<string, Ro
   stage: "run",
   jsonMode: true,
   config: routingConfigSelector,
+  model: (_input, ctx) => ctx.config.routing.llm?.model ?? "balanced",
   build(input: UserStory[], _ctx: BuildContext<RoutingConfig>) {
     const storyBlocks = input
       .map((story, idx) => {

--- a/src/operations/debate-propose.ts
+++ b/src/operations/debate-propose.ts
@@ -40,6 +40,11 @@ export const debateProposeOp: CompleteOperation<DebateProposeInput, string, Deba
   stage: "review",
   jsonMode: false,
   config: debateConfigSelector,
+  model: (input) => {
+    const debater = input.debaters[input.debaterIndex];
+    if (!debater) return "fast";
+    return { agent: debater.agent, model: debater.model ?? "fast" };
+  },
   build(input, _ctx) {
     const builder = new DebatePromptBuilder(
       { taskContext: input.taskContext, outputFormat: input.outputFormat, stage: input.stage },

--- a/src/operations/debate-rebut.ts
+++ b/src/operations/debate-rebut.ts
@@ -44,6 +44,11 @@ export const debateRebutOp: CompleteOperation<DebateRebutInput, string, DebateCo
   stage: "review",
   jsonMode: false,
   config: debateConfigSelector,
+  model: (input) => {
+    const debater = input.debaters[input.debaterIndex];
+    if (!debater) return "fast";
+    return { agent: debater.agent, model: debater.model ?? "fast" };
+  },
   build(input, _ctx) {
     const builder = new DebatePromptBuilder(
       { taskContext: input.taskContext, outputFormat: "", stage: input.stage },

--- a/src/operations/decompose.ts
+++ b/src/operations/decompose.ts
@@ -22,6 +22,7 @@ export const decomposeOp: CompleteOperation<DecomposeOpInput, DecomposeOpOutput,
   stage: "plan",
   jsonMode: false,
   config: decomposeConfigSelector,
+  model: (_input, ctx) => ctx.config.plan.model,
   timeoutMs: (_input, ctx) => (ctx.config.plan.decomposeTimeoutSeconds ?? ctx.config.plan.timeoutSeconds ?? 600) * 1000,
   build(input, _ctx) {
     const prompt = buildDecomposePromptSync({

--- a/src/operations/plan.ts
+++ b/src/operations/plan.ts
@@ -23,6 +23,7 @@ export const planOp: CompleteOperation<PlanOpInput, PRD, PlanConfig> = {
   stage: "plan",
   jsonMode: false,
   config: planConfigSelector,
+  model: (_input, ctx) => ctx.config.plan.model,
   timeoutMs: (_input, ctx) => (ctx.config.plan.timeoutSeconds ?? 600) * 1000,
   build(input, _ctx) {
     const { taskContext, outputFormat } = new PlanPromptBuilder().build(

--- a/src/review/dialogue.ts
+++ b/src/review/dialogue.ts
@@ -238,6 +238,7 @@ export function createReviewerSession(
   // When compaction occurs, the summary is stored here so the next agent call
   // prepends it as initial context for the fresh session.
   let pendingCompactionContext: string | null = null;
+  let currentSessionSignature: string | null = null;
   // Shared builder instance — review-specific methods are self-contained and don't use stageContext/options.
   const promptBuilder = new DebatePromptBuilder(
     { taskContext: "", outputFormat: "", stage: "review" },
@@ -247,11 +248,19 @@ export function createReviewerSession(
   function resolveRunParams(semanticConfig: SemanticReviewConfig) {
     const defaultAgent = agentManager.getDefault();
     const resolved = resolveConfiguredModel(_config.models, defaultAgent, semanticConfig.model, defaultAgent);
-    const modelTier = resolved.modelTier ?? "balanced";
+    const agentName = resolved.agent;
     const timeoutSeconds = semanticConfig.timeoutMs
       ? Math.ceil(semanticConfig.timeoutMs / 1000)
       : (_config.execution?.sessionTimeoutSeconds ?? 3600);
-    return { modelTier, modelDef: resolved.modelDef, timeoutSeconds };
+    return { agentName, modelDef: resolved.modelDef, timeoutSeconds };
+  }
+
+  function toSessionSignature(params: {
+    agentName: string;
+    modelDef: { provider: string; model: string };
+    timeoutSeconds: number;
+  }): string {
+    return `${params.agentName}|${params.modelDef.provider}|${params.modelDef.model}|${params.timeoutSeconds}`;
   }
 
   function buildEffectivePrompt(prompt: string): string {
@@ -264,19 +273,30 @@ export function createReviewerSession(
   }
 
   async function getOrOpenHandle(semanticConfig: SemanticReviewConfig): Promise<SessionHandle> {
-    if (_handle !== null) return _handle;
-    const { modelDef, timeoutSeconds } = resolveRunParams(semanticConfig);
+    const params = resolveRunParams(semanticConfig);
+    const nextSignature = toSessionSignature(params);
+
+    if (_handle !== null && currentSessionSignature === nextSignature) {
+      return _handle;
+    }
+
+    if (_handle !== null && currentSessionSignature !== nextSignature) {
+      await sessionManager.closeSession(_handle);
+      _handle = null;
+    }
+
     const sessionName = sessionManager.nameFor({ workdir, featureName, storyId, role: "reviewer-semantic" });
     _handle = await sessionManager.openSession(sessionName, {
-      agentName: agentManager.getDefault(),
+      agentName: params.agentName,
       role: "reviewer-semantic",
       workdir,
       pipelineStage: "review",
-      modelDef,
-      timeoutSeconds,
+      modelDef: params.modelDef,
+      timeoutSeconds: params.timeoutSeconds,
       featureName,
       storyId,
     });
+    currentSessionSignature = nextSignature;
     return _handle;
   }
 
@@ -303,7 +323,7 @@ export function createReviewerSession(
       const prompt = promptBuilder.buildReviewPrompt(diff, story);
       const effectivePrompt = buildEffectivePrompt(prompt);
       const handle = await getOrOpenHandle(semanticConfig);
-      const turnResult = await agentManager.runAsSession(agentManager.getDefault(), handle, effectivePrompt, {
+      const turnResult = await agentManager.runAsSession(handle.agentName, handle, effectivePrompt, {
         storyId,
         pipelineStage: "review",
       });
@@ -338,7 +358,7 @@ export function createReviewerSession(
       const prompt = promptBuilder.buildReReviewPrompt(updatedDiff, previousFindings);
       const effectivePrompt = buildEffectivePrompt(prompt);
       const handle = await getOrOpenHandle(lastSemanticConfig);
-      const turnResult = await agentManager.runAsSession(agentManager.getDefault(), handle, effectivePrompt, {
+      const turnResult = await agentManager.runAsSession(handle.agentName, handle, effectivePrompt, {
         storyId,
         pipelineStage: "review",
       });
@@ -358,6 +378,7 @@ export function createReviewerSession(
         if (_handle !== null) {
           await sessionManager.closeSession(_handle);
           _handle = null;
+          currentSessionSignature = null;
         }
       }
 
@@ -384,7 +405,7 @@ export function createReviewerSession(
         } as SemanticReviewConfig);
       const effectivePrompt = buildEffectivePrompt(question);
       const handle = await getOrOpenHandle(effectiveSemanticConfig);
-      const turnResult = await agentManager.runAsSession(agentManager.getDefault(), handle, effectivePrompt, {
+      const turnResult = await agentManager.runAsSession(handle.agentName, handle, effectivePrompt, {
         storyId,
         pipelineStage: "review",
       });
@@ -413,7 +434,7 @@ export function createReviewerSession(
       const prompt = promptBuilder.buildResolverPrompt(proposals, critiques, diffContext, story, resolverContext);
       const effectivePrompt = buildEffectivePrompt(prompt);
       const handle = await getOrOpenHandle(semanticConfig);
-      const turnResult = await agentManager.runAsSession(agentManager.getDefault(), handle, effectivePrompt, {
+      const turnResult = await agentManager.runAsSession(handle.agentName, handle, effectivePrompt, {
         storyId,
         pipelineStage: "review",
       });
@@ -460,7 +481,7 @@ export function createReviewerSession(
       );
       const effectivePrompt = buildEffectivePrompt(prompt);
       const handle = await getOrOpenHandle(lastSemanticConfig);
-      const turnResult = await agentManager.runAsSession(agentManager.getDefault(), handle, effectivePrompt, {
+      const turnResult = await agentManager.runAsSession(handle.agentName, handle, effectivePrompt, {
         storyId,
         pipelineStage: "review",
       });
@@ -480,6 +501,7 @@ export function createReviewerSession(
         if (_handle !== null) {
           await sessionManager.closeSession(_handle);
           _handle = null;
+          currentSessionSignature = null;
         }
       }
 
@@ -507,6 +529,7 @@ export function createReviewerSession(
       if (_handle !== null) {
         await sessionManager.closeSession(_handle);
         _handle = null;
+        currentSessionSignature = null;
       }
       history.length = 0;
     },

--- a/test/unit/debate/runner-events.test.ts
+++ b/test/unit/debate/runner-events.test.ts
@@ -211,7 +211,7 @@ describe("DebateRunner.run() — JSONL log events", () => {
 
     const agentManager = makeMockAgentManager({
       completeAsFn: async (agentName, _prompt, opts) => {
-        completeCalls.push({ agent: agentName, model: opts?.model });
+        completeCalls.push({ agent: agentName, model: opts?.modelDef?.model });
         return { output: `output from ${agentName}`, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
       },
     });

--- a/test/unit/operations/acceptance-diagnose.test.ts
+++ b/test/unit/operations/acceptance-diagnose.test.ts
@@ -35,6 +35,23 @@ describe("acceptanceDiagnoseOp shape", () => {
   test("stage is acceptance", () => {
     expect(acceptanceDiagnoseOp.stage).toBe("acceptance");
   });
+  test("model resolves from acceptance.fix.diagnoseModel", () => {
+    const config = makeNaxConfig({
+      acceptance: {
+        fix: {
+          diagnoseModel: { agent: "opencode", model: "opencode-go/deepseek-v4-pro" },
+        },
+      },
+    });
+    const runtime = makeTestRuntime({ config });
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(acceptanceDiagnoseOp.config) };
+
+    expect(acceptanceDiagnoseOp.model?.(SAMPLE_INPUT, ctx)).toEqual({
+      agent: "opencode",
+      model: "opencode-go/deepseek-v4-pro",
+    });
+  });
 });
 
 describe("acceptanceDiagnoseOp.build()", () => {

--- a/test/unit/operations/acceptance-fix.test.ts
+++ b/test/unit/operations/acceptance-fix.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { makeTestRuntime } from "../../helpers";
+import { makeNaxConfig, makeTestRuntime } from "../../helpers";
 import type { AcceptanceFixSourceInput, AcceptanceFixTestInput } from "../../../src/operations/acceptance-fix";
 import { acceptanceFixSourceOp, acceptanceFixTestOp } from "../../../src/operations/acceptance-fix";
 
@@ -48,6 +48,23 @@ describe("acceptanceFixSourceOp shape", () => {
     const ctx = makeSourceCtx();
     const timeoutMs = acceptanceFixSourceOp.timeoutMs?.(SOURCE_INPUT, ctx);
     expect(timeoutMs).toBe((ctx.config.execution.sessionTimeoutSeconds ?? 0) * 1000);
+  });
+  test("model resolves from acceptance.fix.fixModel", () => {
+    const config = makeNaxConfig({
+      acceptance: {
+        fix: {
+          fixModel: { agent: "opencode", model: "opencode-go/minimax-m2.7" },
+        },
+      },
+    });
+    const runtime = makeTestRuntime({ config });
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(acceptanceFixSourceOp.config) };
+
+    expect(acceptanceFixSourceOp.model?.(SOURCE_INPUT, ctx)).toEqual({
+      agent: "opencode",
+      model: "opencode-go/minimax-m2.7",
+    });
   });
 });
 
@@ -102,6 +119,23 @@ describe("acceptanceFixTestOp shape", () => {
     const ctx = makeTestCtx();
     const timeoutMs = acceptanceFixTestOp.timeoutMs?.(TEST_INPUT, ctx);
     expect(timeoutMs).toBe((ctx.config.execution.sessionTimeoutSeconds ?? 0) * 1000);
+  });
+  test("model resolves from acceptance.fix.fixModel", () => {
+    const config = makeNaxConfig({
+      acceptance: {
+        fix: {
+          fixModel: { agent: "opencode", model: "opencode-go/minimax-m2.7" },
+        },
+      },
+    });
+    const runtime = makeTestRuntime({ config });
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(acceptanceFixTestOp.config) };
+
+    expect(acceptanceFixTestOp.model?.(TEST_INPUT, ctx)).toEqual({
+      agent: "opencode",
+      model: "opencode-go/minimax-m2.7",
+    });
   });
 });
 

--- a/test/unit/operations/acceptance-generate.test.ts
+++ b/test/unit/operations/acceptance-generate.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { acceptanceGenerateOp } from "../../../src/operations/acceptance-generate";
 import type { AcceptanceGenerateInput } from "../../../src/operations/acceptance-generate";
 import type { VerifyContext } from "../../../src/operations/types";
-import { makeTestRuntime } from "../../helpers";
+import { makeNaxConfig, makeTestRuntime } from "../../helpers";
 import { withTempDir } from "../../helpers/temp";
 
 const SAMPLE_INPUT: AcceptanceGenerateInput = {
@@ -45,6 +45,21 @@ describe("acceptanceGenerateOp shape", () => {
   });
   test("stage is acceptance", () => {
     expect(acceptanceGenerateOp.stage).toBe("acceptance");
+  });
+  test("model resolves from acceptance.model config", () => {
+    const config = makeNaxConfig({
+      acceptance: {
+        model: { agent: "opencode", model: "opencode-go/minimax-m2.7" },
+      },
+    });
+    const runtime = makeTestRuntime({ config });
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(acceptanceGenerateOp.config) };
+
+    expect(acceptanceGenerateOp.model?.(SAMPLE_INPUT, ctx)).toEqual({
+      agent: "opencode",
+      model: "opencode-go/minimax-m2.7",
+    });
   });
 });
 

--- a/test/unit/operations/acceptance-refine.test.ts
+++ b/test/unit/operations/acceptance-refine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { makeTestRuntime } from "../../helpers";
+import { makeNaxConfig, makeTestRuntime } from "../../helpers";
 import type { AcceptanceRefineInput } from "../../../src/operations/acceptance-refine";
 import { acceptanceRefineOp } from "../../../src/operations/acceptance-refine";
 
@@ -31,6 +31,21 @@ describe("acceptanceRefineOp shape", () => {
   });
   test("stage is acceptance", () => {
     expect(acceptanceRefineOp.stage).toBe("acceptance");
+  });
+  test("model resolves from acceptance.model config", () => {
+    const config = makeNaxConfig({
+      acceptance: {
+        model: { agent: "opencode", model: "opencode-go/minimax-m2.7" },
+      },
+    });
+    const runtime = makeTestRuntime({ config });
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(acceptanceRefineOp.config) };
+
+    expect(acceptanceRefineOp.model?.(SAMPLE_INPUT, ctx)).toEqual({
+      agent: "opencode",
+      model: "opencode-go/minimax-m2.7",
+    });
   });
 });
 

--- a/test/unit/operations/auto-approve.test.ts
+++ b/test/unit/operations/auto-approve.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { makeNaxConfig, makeTestRuntime } from "../../helpers";
+import { autoApproveOp } from "../../../src/operations/auto-approve";
+import type { AutoApproveInput } from "../../../src/operations/auto-approve";
+
+const SAMPLE_INPUT: AutoApproveInput = {
+  id: "req-1",
+  type: "review",
+  stage: "review",
+  featureName: "feature-a",
+  summary: "Run reviewer",
+  fallback: "escalate",
+  createdAt: Date.now(),
+};
+
+function makeCtx(overrides: Record<string, unknown> = {}) {
+  const config = makeNaxConfig({
+    interaction: {
+      ...overrides,
+    },
+  });
+  const runtime = makeTestRuntime({ config });
+  const view = runtime.packages.repo();
+  return { packageView: view, config: view.select(autoApproveOp.config) };
+}
+
+describe("autoApproveOp model resolution", () => {
+  test("uses interaction.config.model when set to tier string", () => {
+    const ctx = makeCtx({ config: { model: "powerful" } });
+    expect(autoApproveOp.model?.(SAMPLE_INPUT, ctx)).toBe("powerful");
+  });
+
+  test("falls back to fast when interaction.config.model is invalid shape", () => {
+    const ctx = makeCtx({ config: { model: { agent: "opencode", model: "opencode-go/kimi-k2.6" } } });
+    expect(autoApproveOp.model?.(SAMPLE_INPUT, ctx)).toBe("fast");
+  });
+
+  test("defaults to fast when interaction.config.model is missing", () => {
+    const ctx = makeCtx({});
+    expect(autoApproveOp.model?.(SAMPLE_INPUT, ctx)).toBe("fast");
+  });
+});

--- a/test/unit/operations/build-hop-callback.test.ts
+++ b/test/unit/operations/build-hop-callback.test.ts
@@ -98,6 +98,30 @@ afterEach(() => {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe("buildHopCallback — primary hop (no failure)", () => {
+  test("uses resolvedRunOptions.modelDef on primary hop", async () => {
+    const sessionManager = makeSessionManager({ openSession: mock(async () => makeHandle("nax-modeldef-handle")) });
+    const agentManager = makeAgentManagerStub();
+    const config = makeNaxConfig({
+      models: {
+        claude: {
+          balanced: { provider: "anthropic", model: "claude-balanced-from-tier" },
+        },
+      },
+    });
+    const ctx = makeCtx({ sessionManager, agentManager, config });
+    const baseOptions = makeBaseOptions("do the work", config);
+    const pinnedModelDef = { provider: "unknown", model: "opencode-go/kimi-k2.6" };
+    const optionsWithPinnedModel = { ...baseOptions, modelDef: pinnedModelDef } as AgentRunOptions;
+    const cb = buildHopCallback(ctx, SESSION_ID, optionsWithPinnedModel);
+
+    await cb("claude", makeBundle(), undefined, optionsWithPinnedModel);
+
+    const openOpts = (sessionManager.openSession as ReturnType<typeof mock>).mock.calls[0]?.[1] as {
+      modelDef: { provider: string; model: string };
+    };
+    expect(openOpts.modelDef).toEqual(pinnedModelDef);
+  });
+
   test("opens and closes session; calls runAsSession with initial prompt; wraps TurnResult", async () => {
     const turnResult = makeStubTurnResult("hello from agent");
     const agentManager = makeAgentManagerStub(() => Promise.resolve(turnResult));
@@ -130,6 +154,40 @@ describe("buildHopCallback — primary hop (no failure)", () => {
 });
 
 describe("buildHopCallback — failure hop (fallback)", () => {
+  test("uses tier-derived modelDef on failure hop", async () => {
+    const failure: AdapterFailure = {
+      outcome: "fail-rate-limit",
+      category: "availability",
+      message: "rate limit hit",
+      retriable: true,
+    };
+    _buildHopCallbackDeps.rebuildForAgent = mock(() => makeBundle({ pushMarkdown: "## Rebuilt context" }));
+
+    const config = makeNaxConfig({
+      models: {
+        codex: {
+          balanced: { provider: "openai", model: "gpt-5" },
+        },
+      },
+    });
+    const sessionManager = makeSessionManager();
+    const agentManager = makeAgentManagerStub();
+    const ctx = makeCtx({ sessionManager, agentManager, config });
+    const baseOptions = makeBaseOptions("original prompt", config);
+    const optionsWithPinnedModel = {
+      ...baseOptions,
+      modelDef: { provider: "unknown", model: "opencode-go/kimi-k2.6" },
+    } as AgentRunOptions;
+    const cb = buildHopCallback(ctx, SESSION_ID, optionsWithPinnedModel);
+
+    await cb("codex", makeBundle(), failure, optionsWithPinnedModel);
+
+    const openOpts = (sessionManager.openSession as ReturnType<typeof mock>).mock.calls[0]?.[1] as {
+      modelDef: { provider: string; model: string };
+    };
+    expect(openOpts.modelDef).toEqual({ provider: "openai", model: "gpt-5" });
+  });
+
   test("rebuilds bundle; calls handoff; rewrites prompt via swapHandoff; closes session", async () => {
     const failure: AdapterFailure = {
       outcome: "fail-rate-limit",

--- a/test/unit/operations/classify-route.test.ts
+++ b/test/unit/operations/classify-route.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { routingConfigSelector } from "../../../src/config";
 import type { ClassifyRouteInput } from "../../../src/operations/classify-route";
-import { classifyRouteOp } from "../../../src/operations/classify-route";
-import { makeTestRuntime } from "../../helpers";
+import { classifyRouteBatchOp, classifyRouteOp } from "../../../src/operations/classify-route";
+import { makeNaxConfig, makeTestRuntime } from "../../helpers";
 
 const SAMPLE_INPUT: ClassifyRouteInput = {
   title: "Add button",
@@ -26,6 +26,51 @@ describe("classifyRouteOp shape", () => {
   });
   test("jsonMode is true", () => {
     expect(classifyRouteOp.jsonMode).toBe(true);
+  });
+
+  test("model resolves from routing.llm.model config", () => {
+    const config = makeNaxConfig({
+      routing: {
+        strategy: "llm",
+        llm: {
+          model: { agent: "opencode", model: "opencode-go/kimi-k2.6" },
+        },
+      },
+    });
+    const runtime = makeTestRuntime({ config });
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(routingConfigSelector) };
+
+    expect(classifyRouteOp.model?.(SAMPLE_INPUT, ctx)).toEqual({
+      agent: "opencode",
+      model: "opencode-go/kimi-k2.6",
+    });
+  });
+
+  test("batch model resolves from routing.llm.model config", () => {
+    const config = makeNaxConfig({
+      routing: {
+        strategy: "llm",
+        llm: {
+          model: "powerful",
+        },
+      },
+    });
+    const runtime = makeTestRuntime({ config });
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(routingConfigSelector) };
+    const stories = [
+      {
+        id: "US-001",
+        title: "Add button",
+        description: "Add a red button",
+        acceptanceCriteria: ["Button exists"],
+        tags: [],
+      },
+    ];
+    expect(classifyRouteBatchOp.model?.(stories as unknown as Parameters<typeof classifyRouteBatchOp.model>[0], ctx)).toBe(
+      "powerful",
+    );
   });
 });
 

--- a/test/unit/operations/debate-propose.test.ts
+++ b/test/unit/operations/debate-propose.test.ts
@@ -28,6 +28,31 @@ describe("debateProposeOp", () => {
     expect(debateProposeOp.stage).toBe("review");
   });
 
+  test("model resolves from selected debater", () => {
+    const input = {
+      taskContext: "implement X",
+      outputFormat: "json",
+      stage: "review",
+      debaterIndex: 1,
+      debaters,
+    };
+    expect(debateProposeOp.model?.(input, makeBuildCtx())).toEqual({
+      agent: "opencode",
+      model: "fast",
+    });
+  });
+
+  test("model falls back to fast for invalid debater index", () => {
+    const input = {
+      taskContext: "implement X",
+      outputFormat: "json",
+      stage: "review",
+      debaterIndex: 99,
+      debaters,
+    };
+    expect(debateProposeOp.model?.(input, makeBuildCtx())).toBe("fast");
+  });
+
   test("build returns ComposeInput with proposal prompt", () => {
     const input = {
       taskContext: "implement X",

--- a/test/unit/operations/debate-rebut.test.ts
+++ b/test/unit/operations/debate-rebut.test.ts
@@ -32,6 +32,31 @@ describe("debateRebutOp", () => {
     expect(debateRebutOp.stage).toBe("review");
   });
 
+  test("model resolves from selected debater", () => {
+    const input = {
+      taskContext: "review code changes",
+      stage: "review",
+      debaterIndex: 1,
+      proposals,
+      debaters,
+    };
+    expect(debateRebutOp.model?.(input, makeBuildCtx())).toEqual({
+      agent: "opencode",
+      model: "fast",
+    });
+  });
+
+  test("model falls back to fast for invalid debater index", () => {
+    const input = {
+      taskContext: "review code changes",
+      stage: "review",
+      debaterIndex: 99,
+      proposals,
+      debaters,
+    };
+    expect(debateRebutOp.model?.(input, makeBuildCtx())).toBe("fast");
+  });
+
   test("build returns ComposeInput with rebuttal prompt", () => {
     const input = {
       taskContext: "review code changes",

--- a/test/unit/operations/timeout-resolvers.test.ts
+++ b/test/unit/operations/timeout-resolvers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { makeTestRuntime } from "../../helpers";
+import { makeNaxConfig, makeTestRuntime } from "../../helpers";
 import { adversarialReviewOp } from "../../../src/operations/adversarial-review";
 import { decomposeOp } from "../../../src/operations/decompose";
 import { planOp } from "../../../src/operations/plan";
@@ -22,6 +22,29 @@ describe("operation timeout resolvers", () => {
     expect(timeoutMs).toBe((ctx.config.plan.timeoutSeconds ?? 600) * 1000);
   });
 
+  test("planOp model resolves from plan.model config", () => {
+    const config = makeNaxConfig({
+      plan: {
+        model: { agent: "opencode", model: "opencode-go/kimi-k2.6" },
+      },
+    });
+    const runtime = makeTestRuntime({ config });
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(planOp.config) };
+
+    const model = planOp.model?.(
+      {
+        specContent: "spec",
+        codebaseContext: "",
+        featureName: "feature",
+        branchName: "feature-branch",
+      },
+      ctx,
+    );
+
+    expect(model).toEqual({ agent: "opencode", model: "opencode-go/kimi-k2.6" });
+  });
+
   test("decomposeOp timeoutMs prefers plan.decomposeTimeoutSeconds", () => {
     const runtime = makeTestRuntime();
     const view = runtime.packages.repo();
@@ -34,6 +57,27 @@ describe("operation timeout resolvers", () => {
       ctx,
     );
     expect(timeoutMs).toBe((ctx.config.plan.decomposeTimeoutSeconds ?? ctx.config.plan.timeoutSeconds ?? 600) * 1000);
+  });
+
+  test("decomposeOp model resolves from plan.model config", () => {
+    const config = makeNaxConfig({
+      plan: {
+        model: { agent: "opencode", model: "opencode-go/deepseek-v4-pro" },
+      },
+    });
+    const runtime = makeTestRuntime({ config });
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(decomposeOp.config) };
+
+    const model = decomposeOp.model?.(
+      {
+        specContent: "spec",
+        codebaseContext: "",
+      },
+      ctx,
+    );
+
+    expect(model).toEqual({ agent: "opencode", model: "opencode-go/deepseek-v4-pro" });
   });
 
   test("semanticReviewOp timeoutMs resolves from semanticConfig.timeoutMs input", () => {

--- a/test/unit/review/dialogue-debate.test.ts
+++ b/test/unit/review/dialogue-debate.test.ts
@@ -105,6 +105,50 @@ const MOCK_CONFIG = {
 // ---------------------------------------------------------------------------
 
 describe("ReviewerSession.resolveDebate()", () => {
+  test("uses semantic configured agent/model for session open and run", async () => {
+    let capturedOpenOptions: unknown;
+    const sessionManager = makeSessionManager({
+      openSession: mock(async (_name: string, options: unknown) => {
+        capturedOpenOptions = options;
+        return { id: "mock-session", agentName: (options as { agentName: string }).agentName };
+      }),
+    });
+
+    const runFn = makeRunFn(PASSING_RESPONSE);
+    const configWithOpencode = {
+      ...MOCK_CONFIG,
+      models: {
+        ...MOCK_CONFIG.models,
+        opencode: {
+          fast: { model: "opencode-go/minimax-m2.7" },
+          balanced: { model: "opencode-go/deepseek-v4-pro" },
+          powerful: { model: "opencode-go/kimi-k2.6" },
+        },
+      },
+    } as ReviewConfig;
+
+    const session = createReviewerSession(
+      makeAgentManager(runFn),
+      sessionManager,
+      "story-1",
+      "/workdir",
+      "feature",
+      configWithOpencode,
+    );
+    const ctx: DebateResolverContext = { resolverType: "synthesis" };
+    const pinnedSemanticConfig: SemanticReviewConfig = {
+      ...SEMANTIC_CONFIG,
+      model: { agent: "opencode", model: "opencode-go/kimi-k2.6" },
+    };
+
+    await session.resolveDebate(PROPOSALS, CRITIQUES, DIFF, STORY, pinnedSemanticConfig, ctx);
+
+    expect((capturedOpenOptions as { agentName: string }).agentName).toBe("opencode");
+    expect((capturedOpenOptions as { modelDef: { model: string } }).modelDef.model).toBe("opencode-go/kimi-k2.6");
+    expect((runFn as ReturnType<typeof mock>).mock.calls[0][0]).toBe("opencode");
+    await session.destroy();
+  });
+
   test("calls agentManager.runAsSession() with pipelineStage: review (ADR-019)", async () => {
     let capturedOpts: RunAsSessionOpts | undefined;
     const runFn = mock(async (_agentName: string, _handle: SessionHandle, _prompt: string, opts: RunAsSessionOpts): Promise<TurnResult> => {


### PR DESCRIPTION
## Summary
- add explicit model resolvers to operations that were still missing profile-aware model selection (acceptance generate/refine/diagnose/fix, plan, decompose, classify-route, debate propose/rebut, auto-approve)
- fix run hop dispatch so the primary hop preserves resolved modelDef instead of re-deriving from tier defaults
- update review dialogue session management to reopen on agent/model/timeout signature changes and execute with the resolved agent
- add and update unit tests to cover model resolver behavior and run-hop model propagation

## Validation
- bun run test

Closes #904