### PR TITLE
fix(migrate): initialize logger so dry-run and migrate output are visible

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -645,6 +645,7 @@ program
       return;
     }
     const { migrateCommand } = await import("../src/commands/migrate");
+    initLogger({ level: "info", useChalk: true });
     try {
       await migrateCommand({
         workdir,


### PR DESCRIPTION
## Summary

- `nax migrate --dry-run` and `nax migrate` were silently producing no output, even though the migration succeeded.
- Root cause: [src/commands/migrate.ts](src/commands/migrate.ts) emits all user-facing output through `getLogger().info(...)`, but the CLI handler at [bin/nax.ts:638-659](bin/nax.ts#L638-L659) never called `initLogger()`. Without initialization, `getLogger()` returns the noop logger ([src/logger/logger.ts:283-289](src/logger/logger.ts#L283-L289)) which is hard-coded to `level: "error"` — so every `logger.info(...)` (`[dry-run] Would move...`, `Moved: ...`, `Migration complete: ...`, `Nothing to migrate`) was dropped.
- Fix: initialize the logger at `info` level in the migrate CLI handler before invoking `migrateCommand`, matching the pattern used by the main `run` command at [bin/nax.ts:522](bin/nax.ts#L522). Single-line change.

## Test plan

- [x] `bun run typecheck` — clean (pre-existing unreachable-code diagnostics in `bin/nax.ts` only, unrelated to this change)
- [x] Smoke test: created `/tmp/nax-migrate-test` with `.nax/config.json` + `.nax/runs/` + `.nax/prompt-audit/`, ran `bun bin/nax.ts migrate --dir /tmp/nax-migrate-test --dry-run` — now prints `[dry-run] Would move: ...` lines as expected.
- [ ] Reviewer: confirm no other CLI subcommands rely on `getLogger()` without `initLogger()` (search showed migrate is the only affected path)