### PR TITLE
refactor(agents/ops/routing): unify retry strategy behind RetryStrategy interface (#856)

### DIFF
--- a/.claude/rules/retry-strategy.md
+++ b/.claude/rules/retry-strategy.md
@@ -1,0 +1,96 @@
+---
+paths:
+  - "src/agents/**/*.ts"
+  - "src/operations/**/*.ts"
+  - "src/routing/**/*.ts"
+  - "src/pipeline/**/*.ts"
+  - "src/execution/**/*.ts"
+---
+
+# Retry Strategy
+
+> Introduced in issue #856. SSOT: `src/agents/retry/`.
+
+All retry logic in nax is expressed through the `RetryStrategy` interface — no inline retry loops, no hardcoded delay constants, no `while (true)` with a counter elsewhere in the codebase.
+
+## Two-tier model
+
+| Tier | Site | Default | Override |
+|:---|:---|:---|:---|
+| **Manager** | `AgentManager.runWithFallback` (site #1) | `defaultRetryStrategy` — rate-limit only, 3 retries, 2s/4s/8s exponential | Pass `retryStrategy` to `AgentManager` constructor via `_agentManagerDeps` injection |
+| **Op** | `callOp` complete-kind (site #2) | none — throws on first failure | Declare `retry` on `CompleteOperation` |
+
+## Declaring retry on a `CompleteOperation`
+
+Use the `retry` field. It accepts three forms:
+
+```typescript
+// 1. Declarative preset (most common — configurable at runtime)
+retry: (_input, ctx) => ({
+  preset: "transient-network" as const,
+  maxAttempts: (ctx.config.routing.llm?.retries ?? 1) + 1,
+  baseDelayMs: ctx.config.routing.llm?.retryDelayMs ?? 1000,
+}),
+
+// 2. Static preset (fixed policy, no config-driven tuning)
+retry: {
+  preset: "transient-network" as const,
+  maxAttempts: 3,
+  baseDelayMs: 500,
+},
+
+// 3. Custom RetryStrategy (fine-grained control)
+retry: {
+  shouldRetry(failure, attempt, ctx) {
+    if (attempt >= 2) return { retry: false };
+    if (failure instanceof Error && failure.message.includes("timeout")) {
+      return { retry: true, delayMs: 1000 };
+    }
+    return { retry: false };
+  },
+},
+```
+
+`callOp` is bounded by `MAX_COMPLETE_RETRY_ATTEMPTS = 20` regardless of the strategy. If that ceiling is hit, it throws `CALL_OP_MAX_RETRIES`.
+
+## `RetryPreset` semantics
+
+| Field | Meaning |
+|:---|:---|
+| `preset: "transient-network"` | Retry on any thrown `Error` or `AdapterFailure` where `af.retriable === true` |
+| `maxAttempts` | Total call attempts including the first (2 = one retry, 3 = two retries) |
+| `baseDelayMs` | Fixed wait between attempts (no backoff) |
+
+`resolveRetryPreset` in `src/agents/retry/presets.ts` converts a `RetryPreset` to a live `RetryStrategy`.
+
+## `defaultRetryStrategy` (manager tier)
+
+Lives in `src/agents/retry/default-strategy.ts`. Fires **only** on `fail-rate-limit` outcome; all other failures pass through immediately. Backoff: `2^(attempt+1) * 1000` ms — 2s, 4s, 8s across 3 retries. Injected into `AgentManager` via the constructor; tests override via `_agentManagerDeps.sleep` + a custom strategy.
+
+## What NOT to convert to RetryStrategy
+
+`HopBody` callbacks on `RunOperation` are multi-turn session continuations, not single-call retries. Do not express them as `RetryStrategy`. They stay as `hopBody` on `RunOperation` (site outside callOp's retry path).
+
+## `routing.llm.retries` / `retryDelayMs` — deprecation bridge
+
+These config keys are deprecated (issue #856). They are still applied but warn at load time via `applyRoutingRetryDeprecationWarning` in `src/config/loader.ts`. The `classifyRouteOp` / `classifyRouteBatchOp` retry resolvers read them as a bridge until users migrate to op-level retry config. Do not add new readers of these keys.
+
+## Abort-signal threading
+
+`callOp`'s retry sleep is cancellable:
+
+```typescript
+await _callOpDeps.sleep(decision.delayMs, ctx.runtime.signal);
+```
+
+`_callOpDeps.sleep` uses `cancellableDelay` from `src/utils/bun-deps`. Always thread `ctx.runtime.signal` through; never call `Bun.sleep` directly inside a retry loop.
+
+## Forbidden patterns
+
+| ❌ Forbidden | ✅ Use Instead |
+|:---|:---|
+| Inline `while` / `for` retry loops with hardcoded counters | `retry` field on `CompleteOperation`, or `RetryStrategy` injected at construction |
+| `while (true)` retry loops | `while (attempt <= MAX_COMPLETE_RETRY_ATTEMPTS)` — or better, declare `retry` on the op |
+| Hardcoded `await Bun.sleep(2000)` between attempts | `_callOpDeps.sleep(decision.delayMs, signal)` (testable, cancellable) |
+| New readers of `config.routing.llm?.retries` outside `classify-route.ts` | Op-level `retry` resolver reading from config slice |
+| `MAX_RATE_LIMIT_RETRIES` constant (deleted) | `defaultRetryStrategy` / `RetryPreset.maxAttempts` |

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -39,6 +39,8 @@ import type {
 } from "./manager-types";
 import { createAgentRegistry } from "./registry";
 import type { AgentRegistry } from "./registry";
+import { defaultRetryStrategy } from "./retry/default-strategy";
+import type { RetryContext, RetryStrategy } from "./retry/types";
 import type { AgentResult, CompleteOptions, CompleteResult, ResolvedCompleteOptions } from "./types";
 
 type LoggerLike = {
@@ -75,6 +77,7 @@ export class AgentManager implements IAgentManager {
   private _runHop: SessionRunHopFn | undefined;
   private _dispatchEvents: IDispatchEventBus;
   private _pidRegistry: PidRegistry | undefined;
+  private readonly _retryStrategy: RetryStrategy;
   readonly events: AgentManagerEvents;
 
   constructor(
@@ -87,6 +90,7 @@ export class AgentManager implements IAgentManager {
       sendPrompt?: SendPromptFn;
       runHop?: SessionRunHopFn;
       dispatchEvents?: IDispatchEventBus;
+      retryStrategy?: RetryStrategy;
     },
   ) {
     this._config = config;
@@ -97,6 +101,7 @@ export class AgentManager implements IAgentManager {
     this._sendPrompt = opts?.sendPrompt;
     this._runHop = opts?.runHop;
     this._dispatchEvents = opts?.dispatchEvents ?? new DispatchEventBus();
+    this._retryStrategy = opts?.retryStrategy ?? defaultRetryStrategy;
     this.events = {
       on: (event, listener) => {
         this._emitter.on(event as AgentManagerEventName, listener as (...args: unknown[]) => void);
@@ -202,7 +207,6 @@ export class AgentManager implements IAgentManager {
     const primaryAgent = primaryAgentOverride ?? this.getDefault();
     let currentAgent = primaryAgent;
     let hopsSoFar = 0;
-    const MAX_RATE_LIMIT_RETRIES = 3;
     let rateLimitRetry = 0;
     let currentBundle = request.bundle;
     let currentFailure: AdapterFailure | undefined;
@@ -262,27 +266,35 @@ export class AgentManager implements IAgentManager {
           // Preserve legacy rate-limit backoff when no swap candidates are available.
           // #585 Path B: race the sleep against the shutdown signal — an abort during
           // backoff settles within milliseconds instead of the full exponential wait.
-          if (result.adapterFailure?.outcome === "fail-rate-limit" && rateLimitRetry < MAX_RATE_LIMIT_RETRIES) {
-            if (request.signal?.aborted) {
-              logger?.info("agent-manager", "Rate-limited backoff aborted — shutdown in progress", {
-                storyId: request.runOptions.storyId,
-              });
-              _finalStatus = "cancelled";
-              return { result, fallbacks, finalBundle: updatedBundle, finalPrompt, finalAgent: currentAgent };
-            }
-            rateLimitRetry += 1;
-            const backoffMs = 2 ** rateLimitRetry * 1000;
-            logger?.info("agent-manager", "Rate-limited with no swap candidate — backing off", {
+          if (result.adapterFailure) {
+            const retryCtx: RetryContext = {
+              site: "run",
+              agentName: currentAgent,
+              stage: request.runOptions.pipelineStage ?? "run",
               storyId: request.runOptions.storyId,
-              attempt: rateLimitRetry,
-              backoffMs,
-            });
-            await _agentManagerDeps.sleep(backoffMs, request.signal);
-            if (request.signal?.aborted) {
-              _finalStatus = "cancelled";
-              return { result, fallbacks, finalBundle: updatedBundle, finalPrompt, finalAgent: currentAgent };
+            };
+            const decision = this._retryStrategy.shouldRetry(result.adapterFailure, rateLimitRetry, retryCtx);
+            if (decision.retry) {
+              if (request.signal?.aborted) {
+                logger?.info("agent-manager", "Rate-limited backoff aborted — shutdown in progress", {
+                  storyId: request.runOptions.storyId,
+                });
+                _finalStatus = "cancelled";
+                return { result, fallbacks, finalBundle: updatedBundle, finalPrompt, finalAgent: currentAgent };
+              }
+              rateLimitRetry += 1;
+              logger?.info("agent-manager", "Rate-limited with no swap candidate — backing off", {
+                storyId: request.runOptions.storyId,
+                attempt: rateLimitRetry,
+                backoffMs: decision.delayMs,
+              });
+              await _agentManagerDeps.sleep(decision.delayMs, request.signal);
+              if (request.signal?.aborted) {
+                _finalStatus = "cancelled";
+                return { result, fallbacks, finalBundle: updatedBundle, finalPrompt, finalAgent: currentAgent };
+              }
+              continue;
             }
-            continue;
           }
           if (hopsSoFar > 0) {
             this._emitter.emit("onSwapExhausted", { storyId: request.runOptions.storyId, hops: hopsSoFar });

--- a/src/agents/retry/default-strategy.ts
+++ b/src/agents/retry/default-strategy.ts
@@ -1,0 +1,4 @@
+// Stub - implementation in Task 2
+export function defaultRetryStrategy(): never {
+  throw new Error("not yet implemented");
+}

--- a/src/agents/retry/default-strategy.ts
+++ b/src/agents/retry/default-strategy.ts
@@ -1,4 +1,26 @@
-// Stub - implementation in Task 2
-export function defaultRetryStrategy(): never {
-  throw new Error("not yet implemented");
-}
+import type { AdapterFailure } from "../../context/engine";
+import type { RetryContext, RetryDecision, RetryStrategy } from "./types";
+
+const MAX_RETRIES = 3;
+
+/**
+ * Default manager-level retry strategy.
+ *
+ * Governs rate-limit backoff in `AgentManager.runWithFallback` when no swap
+ * candidates are available (site #1). Fires only on `fail-rate-limit` outcomes;
+ * all other failure types are returned as `{ retry: false }` so the caller
+ * falls through to its normal exhaustion / error path.
+ *
+ * Backoff: 2^(attempt+1) * 1000ms → 2s, 4s, 8s across 3 retries.
+ * This matches the original MAX_RATE_LIMIT_RETRIES = 3 behavior exactly.
+ */
+export const defaultRetryStrategy: RetryStrategy = {
+  shouldRetry(failure: AdapterFailure | Error, attempt: number, _ctx: RetryContext): RetryDecision {
+    if (attempt >= MAX_RETRIES) return { retry: false };
+    if (failure instanceof Error) return { retry: false };
+    const af = failure as AdapterFailure;
+    if (af.outcome !== "fail-rate-limit") return { retry: false };
+    const delayMs = 2 ** (attempt + 1) * 1000;
+    return { retry: true, delayMs };
+  },
+};

--- a/src/agents/retry/index.ts
+++ b/src/agents/retry/index.ts
@@ -1,0 +1,3 @@
+export type { RetryContext, RetryDecision, RetryPreset, RetryStrategy } from "./types";
+export { defaultRetryStrategy } from "./default-strategy";
+export { resolveRetryPreset } from "./presets";

--- a/src/agents/retry/presets.ts
+++ b/src/agents/retry/presets.ts
@@ -1,0 +1,4 @@
+// Stub - implementation in Task 3
+export function resolveRetryPreset(): never {
+  throw new Error("not yet implemented");
+}

--- a/src/agents/retry/presets.ts
+++ b/src/agents/retry/presets.ts
@@ -1,4 +1,23 @@
-// Stub - implementation in Task 3
-export function resolveRetryPreset(): never {
-  throw new Error("not yet implemented");
+import type { AdapterFailure } from "../../context/engine";
+import type { RetryContext, RetryDecision, RetryPreset, RetryStrategy } from "./types";
+
+/**
+ * Converts a declarative `RetryPreset` into a live `RetryStrategy`.
+ *
+ * "transient-network": retries on any thrown Error or retriable AdapterFailure
+ * with a fixed baseDelayMs, up to (maxAttempts - 1) retries.
+ */
+export function resolveRetryPreset(preset: RetryPreset): RetryStrategy {
+  return {
+    shouldRetry(failure: AdapterFailure | Error, attempt: number, _ctx: RetryContext): RetryDecision {
+      if (attempt >= preset.maxAttempts - 1) return { retry: false };
+      if (preset.preset === "transient-network") {
+        if (failure instanceof Error) return { retry: true, delayMs: preset.baseDelayMs };
+        const af = failure as AdapterFailure;
+        if (af.retriable) return { retry: true, delayMs: preset.baseDelayMs };
+        return { retry: false };
+      }
+      return { retry: false };
+    },
+  };
 }

--- a/src/agents/retry/types.ts
+++ b/src/agents/retry/types.ts
@@ -1,0 +1,34 @@
+import type { PipelineStage } from "../../config/permissions";
+import type { AdapterFailure } from "../../context/engine";
+
+export type RetryDecision = { retry: false } | { retry: true; delayMs: number };
+
+export interface RetryContext {
+  readonly site: "run" | "complete";
+  readonly agentName: string;
+  readonly stage: PipelineStage;
+  readonly storyId?: string;
+}
+
+export interface RetryStrategy {
+  shouldRetry(
+    failure: AdapterFailure | Error,
+    /** Zero-based count of retries already attempted. 0 = deciding on first retry. */
+    attempt: number,
+    ctx: RetryContext,
+  ): RetryDecision;
+}
+
+/**
+ * Declarative retry configuration for `CompleteOperation.retry`.
+ * `callOp` converts this to a `RetryStrategy` via `resolveRetryPreset`.
+ *
+ * - `maxAttempts`: total call attempts including the first (2 = 1 retry, 3 = 2 retries).
+ * - `baseDelayMs`: fixed delay between attempts for "transient-network" preset.
+ * - `preset: "transient-network"`: retry on any thrown Error or retriable AdapterFailure.
+ */
+export interface RetryPreset {
+  readonly preset: "transient-network";
+  readonly maxAttempts: number;
+  readonly baseDelayMs: number;
+}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -140,6 +140,46 @@ function applyBatchModeCompat(conf: Record<string, unknown>): Record<string, unk
 }
 
 /**
+ * @internal Warn when deprecated routing.llm.retries / retryDelayMs are present.
+ *
+ * These keys are deprecated in favour of op-level `retry` presets (issue #856).
+ * Values are preserved for the classifyRouteOp.retry resolver during the transition
+ * period — this function only emits a warning so users know to remove them.
+ *
+ * Returns the same object — values must not be stripped yet.
+ */
+export function applyRoutingRetryDeprecationWarning(
+  conf: Record<string, unknown>,
+  warn: (msg: string) => void = (msg) => {
+    try {
+      getLogger().warn("config", msg);
+    } catch {
+      /* logger may not be init yet */
+    }
+  },
+): Record<string, unknown> {
+  const routing = conf.routing as Record<string, unknown> | undefined;
+  const llm = routing?.llm as Record<string, unknown> | undefined;
+  if (!llm) return conf;
+
+  if ("retries" in llm) {
+    warn(
+      "routing.llm.retries is deprecated (issue #856). " +
+        "This value is still applied but will be removed in v1.0. " +
+        "Retry policy is now declared on each operation — remove this key from your config.",
+    );
+  }
+  if ("retryDelayMs" in llm) {
+    warn(
+      "routing.llm.retryDelayMs is deprecated (issue #856). " +
+        "This value is still applied but will be removed in v1.0. " +
+        "Retry policy is now declared on each operation — remove this key from your config.",
+    );
+  }
+  return conf;
+}
+
+/**
  * Load merged configuration (defaults < global < project < CLI overrides).
  *
  * @param startDir - Either the project root (workdir) OR the `.nax/` directory.
@@ -185,9 +225,11 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
   }
   if (globalConfRaw) {
     const { profile: _gProfile, ...globalConfStripped } = globalConfRaw;
-    const globalConf = applyBatchModeCompat(
-      applyRemovedStrategyCompat(
-        migrateLegacyReviewModelKey(migrateLegacyTestPattern(globalConfStripped, logger), logger),
+    const globalConf = applyRoutingRetryDeprecationWarning(
+      applyBatchModeCompat(
+        applyRemovedStrategyCompat(
+          migrateLegacyReviewModelKey(migrateLegacyTestPattern(globalConfStripped, logger), logger),
+        ),
       ),
     );
     rawConfig = deepMergeConfig(rawConfig, globalConf);
@@ -198,9 +240,11 @@ export async function loadConfig(startDir?: string, cliOverrides?: Record<string
     const projConf = await loadJsonFile<Record<string, unknown>>(join(projDir, "config.json"), "config");
     if (projConf) {
       const { profile: _pProfile, ...projConfStripped } = projConf;
-      const resolvedProjConf = applyBatchModeCompat(
-        applyRemovedStrategyCompat(
-          migrateLegacyReviewModelKey(migrateLegacyTestPattern(projConfStripped, logger), logger),
+      const resolvedProjConf = applyRoutingRetryDeprecationWarning(
+        applyBatchModeCompat(
+          applyRemovedStrategyCompat(
+            migrateLegacyReviewModelKey(migrateLegacyTestPattern(projConfStripped, logger), logger),
+          ),
         ),
       );
       rawConfig = deepMergeConfig(rawConfig, resolvedProjConf);

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -15,6 +15,9 @@ export const _callOpDeps = {
   sleep: (ms: number) => Bun.sleep(ms),
 };
 
+/** Hard ceiling for injected RetryStrategy instances that may not self-terminate. */
+const MAX_COMPLETE_RETRY_ATTEMPTS = 20;
+
 function normalizeSelector<C>(s: ConfigSelector<C> | readonly (keyof NaxConfig)[], opName: string): ConfigSelector<C> {
   if (Array.isArray(s)) {
     return pickSelector(`anonymous:${opName}`, ...(s as readonly (keyof NaxConfig)[])) as unknown as ConfigSelector<C>;
@@ -118,7 +121,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
 
     const retryStrategy = resolveOpRetry(completeOp, input, buildCtx);
     let attempt = 0;
-    while (true) {
+    while (attempt <= MAX_COMPLETE_RETRY_ATTEMPTS) {
       try {
         const raw = await ctx.runtime.agentManager.completeAs(dispatchAgent, prompt, completeOptions);
         const parsedComplete = op.parse(raw.output, input, buildCtx);
@@ -142,10 +145,15 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
             delayMs: decision.delayMs,
           },
         );
-        await _callOpDeps.sleep(decision.delayMs ?? 0);
+        await _callOpDeps.sleep(decision.delayMs);
         attempt++;
       }
     }
+    throw new NaxError(
+      `callOp[${op.name}]: exceeded MAX_COMPLETE_RETRY_ATTEMPTS (${MAX_COMPLETE_RETRY_ATTEMPTS})`,
+      "CALL_OP_MAX_RETRIES",
+      { stage: op.stage, storyId: ctx.storyId },
+    );
   }
 
   // kind:"run" — ADR-019 §5: route through runWithFallback + buildHopCallback.

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -1,11 +1,19 @@
+import { resolveRetryPreset } from "../agents/retry";
+import type { RetryPreset, RetryStrategy } from "../agents/retry";
 import type { TurnResult } from "../agents/types";
 import { pickSelector, resolveConfiguredModel } from "../config";
 import type { ConfigSelector, ConfiguredModel, NaxConfig } from "../config";
 import { NaxError } from "../errors";
+import { getSafeLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { composeSections, join } from "../prompts/compose";
 import { buildHopCallback } from "./build-hop-callback";
 import type { BuildContext, CallContext, CompleteOperation, Operation, RunOperation, VerifyContext } from "./types";
+
+/** Injectable deps for testability — mirrors _agentManagerDeps pattern. */
+export const _callOpDeps = {
+  sleep: (ms: number) => Bun.sleep(ms),
+};
 
 function normalizeSelector<C>(s: ConfigSelector<C> | readonly (keyof NaxConfig)[], opName: string): ConfigSelector<C> {
   if (Array.isArray(s)) {
@@ -34,6 +42,20 @@ function resolveTimeoutMs<I, O, C>(op: Operation<I, O, C>, input: I, buildCtx: B
     });
   }
   return timeoutMs;
+}
+
+function resolveOpRetry<I, O, C>(
+  op: CompleteOperation<I, O, C>,
+  input: I,
+  buildCtx: BuildContext<C>,
+): RetryStrategy | null {
+  if (!op.retry) return null;
+  if (typeof op.retry === "function") {
+    const preset = op.retry(input, buildCtx);
+    return preset ? resolveRetryPreset(preset) : null;
+  }
+  if ("shouldRetry" in op.retry) return op.retry as RetryStrategy;
+  return resolveRetryPreset(op.retry as RetryPreset);
 }
 
 /**
@@ -83,7 +105,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
   if (op.kind === "complete") {
     const completeOp = op as CompleteOperation<I, O, C>;
     const sessionRole = ctx.sessionOverride?.role;
-    const raw = await ctx.runtime.agentManager.completeAs(dispatchAgent, prompt, {
+    const completeOptions = {
       modelDef: resolved.modelDef,
       jsonMode: completeOp.jsonMode ?? false,
       pipelineStage: op.stage,
@@ -92,9 +114,38 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       featureName: ctx.featureName,
       ...(sessionRole !== undefined ? { sessionRole } : {}),
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-    });
-    const parsedComplete = op.parse(raw.output, input, buildCtx);
-    return runPostParse(op, parsedComplete, input, buildCtx);
+    };
+
+    const retryStrategy = resolveOpRetry(completeOp, input, buildCtx);
+    let attempt = 0;
+    while (true) {
+      try {
+        const raw = await ctx.runtime.agentManager.completeAs(dispatchAgent, prompt, completeOptions);
+        const parsedComplete = op.parse(raw.output, input, buildCtx);
+        return await runPostParse(op, parsedComplete, input, buildCtx);
+      } catch (err) {
+        if (!retryStrategy) throw err;
+        const decision = retryStrategy.shouldRetry(err as Error, attempt, {
+          site: "complete",
+          agentName: dispatchAgent,
+          stage: op.stage,
+          storyId: ctx.storyId,
+        });
+        if (!decision.retry) throw err;
+        getSafeLogger()?.warn(
+          "call-op",
+          `LLM call failed (attempt ${attempt + 1}), retrying in ${decision.delayMs}ms`,
+          {
+            storyId: ctx.storyId,
+            op: op.name,
+            attempt,
+            delayMs: decision.delayMs,
+          },
+        );
+        await _callOpDeps.sleep(decision.delayMs ?? 0);
+        attempt++;
+      }
+    }
   }
 
   // kind:"run" — ADR-019 §5: route through runWithFallback + buildHopCallback.

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -7,12 +7,13 @@ import { NaxError } from "../errors";
 import { getSafeLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { composeSections, join } from "../prompts/compose";
+import { cancellableDelay } from "../utils/bun-deps";
 import { buildHopCallback } from "./build-hop-callback";
 import type { BuildContext, CallContext, CompleteOperation, Operation, RunOperation, VerifyContext } from "./types";
 
 /** Injectable deps for testability — mirrors _agentManagerDeps pattern. */
 export const _callOpDeps = {
-  sleep: (ms: number) => Bun.sleep(ms),
+  sleep: (ms: number, signal?: AbortSignal) => cancellableDelay(ms, signal),
 };
 
 /** Hard ceiling for injected RetryStrategy instances that may not self-terminate. */
@@ -135,6 +136,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
           storyId: ctx.storyId,
         });
         if (!decision.retry) throw err;
+        if (ctx.runtime.signal?.aborted) throw err;
         getSafeLogger()?.warn(
           "call-op",
           `LLM call failed (attempt ${attempt + 1}), retrying in ${decision.delayMs}ms`,
@@ -145,7 +147,8 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
             delayMs: decision.delayMs,
           },
         );
-        await _callOpDeps.sleep(decision.delayMs);
+        await _callOpDeps.sleep(decision.delayMs, ctx.runtime.signal);
+        if (ctx.runtime.signal?.aborted) throw err;
         attempt++;
       }
     }

--- a/src/operations/classify-route.ts
+++ b/src/operations/classify-route.ts
@@ -27,6 +27,13 @@ export const classifyRouteOp: CompleteOperation<ClassifyRouteInput, ClassifyRout
   jsonMode: true,
   config: routingConfigSelector,
   model: (_input, ctx) => ctx.config.routing.llm?.model ?? "balanced",
+  retry: (_input, ctx) => ({
+    preset: "transient-network" as const,
+    // routing.llm.retries (deprecated, see issue #856) feeds into maxAttempts during
+    // the deprecation period. Default: 2 total attempts (1 retry), matching retries ?? 1.
+    maxAttempts: (ctx.config.routing.llm?.retries ?? 1) + 1,
+    baseDelayMs: ctx.config.routing.llm?.retryDelayMs ?? 1000,
+  }),
   build(input: ClassifyRouteInput, _ctx: BuildContext<RoutingConfig>) {
     const criteria = input.acceptanceCriteria.map((c, i) => `${i + 1}. ${c}`).join("\n");
     const storyBody = [
@@ -62,6 +69,11 @@ export const classifyRouteBatchOp: CompleteOperation<UserStory[], Map<string, Ro
   jsonMode: true,
   config: routingConfigSelector,
   model: (_input, ctx) => ctx.config.routing.llm?.model ?? "balanced",
+  retry: (_input, ctx) => ({
+    preset: "transient-network" as const,
+    maxAttempts: (ctx.config.routing.llm?.retries ?? 1) + 1,
+    baseDelayMs: ctx.config.routing.llm?.retryDelayMs ?? 1000,
+  }),
   build(input: UserStory[], _ctx: BuildContext<RoutingConfig>) {
     const storyBlocks = input
       .map((story, idx) => {

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,4 +1,4 @@
-export { callOp, _runPostParseForTest } from "./call";
+export { callOp, _callOpDeps, _runPostParseForTest } from "./call";
 export { planOp } from "./plan";
 export type { PlanOpInput } from "./plan";
 export { decomposeOp } from "./decompose";

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -1,3 +1,4 @@
+import type { RetryPreset, RetryStrategy } from "../agents/retry";
 import type { TurnResult } from "../agents/types";
 import type { ConfigSelector, ConfiguredModel } from "../config";
 import type { NaxConfig } from "../config";
@@ -154,6 +155,15 @@ export interface CompleteOperation<I, O, C> extends OperationBase<I, O, C> {
    * in callOp.
    */
   readonly model?: OperationModel<I, C>;
+  /**
+   * Optional retry policy for this op.
+   * - `RetryPreset`: declarative config converted to `RetryStrategy` by `callOp`
+   *   via `resolveRetryPreset`.
+   * - `RetryStrategy`: custom strategy injected directly (discriminant: `"shouldRetry" in retry`).
+   * - function: resolver reading per-call input and build context; return `undefined`
+   *   to disable retry for this invocation.
+   */
+  readonly retry?: RetryPreset | RetryStrategy | ((input: I, ctx: BuildContext<C>) => RetryPreset | undefined);
 }
 
 /**

--- a/src/routing/router.ts
+++ b/src/routing/router.ts
@@ -13,7 +13,7 @@ import type { Complexity, ModelTier, NaxConfig, TddStrategy } from "../config";
 import { getSafeLogger } from "../logger";
 import { callOp } from "../operations";
 import { classifyRouteBatchOp, classifyRouteOp } from "../operations";
-import type { CallContext, CompleteOperation, Operation } from "../operations";
+import type { CallContext } from "../operations";
 import type { PluginRegistry } from "../plugins/registry";
 import type { UserStory } from "../prd/types";
 import type { NaxRuntime } from "../runtime";
@@ -126,38 +126,6 @@ function keywordRoute(story: UserStory, config: RoutingConfig): RoutingDecision 
 }
 
 // ---------------------------------------------------------------------------
-// classifyWithRetry — retry wrapper for callOp-based LLM routing calls
-// ---------------------------------------------------------------------------
-
-async function classifyWithRetry<T>(
-  ctx: CallContext,
-  op: CompleteOperation<unknown, T, RoutingConfig>,
-  input: unknown,
-  opts: { retries: number; retryDelayMs: number },
-): Promise<T> {
-  let lastErr: Error | undefined;
-  for (let i = 0; i <= opts.retries; i++) {
-    try {
-      return await callOp(ctx, op as Operation<unknown, T, RoutingConfig>, input as unknown);
-    } catch (err) {
-      lastErr = err as Error;
-      if (i < opts.retries) {
-        const logger = getSafeLogger();
-        logger?.warn(
-          "routing",
-          `LLM call failed (attempt ${i + 1}/${opts.retries + 1}), retrying in ${opts.retryDelayMs}ms`,
-          {
-            error: lastErr.message,
-          },
-        );
-        await Bun.sleep(opts.retryDelayMs);
-      }
-    }
-  }
-  throw lastErr ?? new Error("classifyWithRetry: unknown failure");
-}
-
-// ---------------------------------------------------------------------------
 // resolveRouting — main entry point
 // ---------------------------------------------------------------------------
 
@@ -258,19 +226,12 @@ export async function resolveRouting(
             agentName: resolveDefaultAgent(runtime.configLoader.current()),
             storyId: story.id,
           };
-          const retries = llmConfig.retries ?? 1;
-          const retryDelayMs = llmConfig.retryDelayMs ?? 1000;
-          const decision = await classifyWithRetry(
-            ctx,
-            classifyRouteOp as CompleteOperation<unknown, RoutingDecision, RoutingConfig>,
-            {
-              title: story.title,
-              description: story.description,
-              acceptanceCriteria: story.acceptanceCriteria,
-              tags: story.tags,
-            },
-            { retries, retryDelayMs },
-          );
+          const decision = await callOp(ctx, classifyRouteOp, {
+            title: story.title,
+            description: story.description,
+            acceptanceCriteria: story.acceptanceCriteria,
+            tags: story.tags,
+          });
 
           if (llmConfig.cacheDecisions) {
             if (cachedDecisions.size >= MAX_CACHE_SIZE) evictOldest();
@@ -416,15 +377,7 @@ export async function tryLlmBatchRoute(
       packageDir: runtime.workdir,
       agentName: resolveDefaultAgent(runtime.configLoader.current()),
     };
-    const retries = llmConfig.retries ?? 1;
-    const retryDelayMs = llmConfig.retryDelayMs ?? 1000;
-
-    const decisions = await classifyWithRetry(
-      ctx,
-      classifyRouteBatchOp as CompleteOperation<unknown, Map<string, RoutingDecision>, RoutingConfig>,
-      needsRouting,
-      { retries, retryDelayMs },
-    );
+    const decisions = await callOp(ctx, classifyRouteBatchOp, needsRouting);
 
     if (llmConfig.cacheDecisions) {
       for (const [storyId, decision] of decisions.entries()) {

--- a/test/unit/agents/manager-rate-limit.test.ts
+++ b/test/unit/agents/manager-rate-limit.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, test } from "bun:test";
-import { AgentManager, _agentManagerDeps } from "../../../../src/agents/manager";
-import type { RetryContext, RetryDecision, RetryStrategy } from "../../../../src/agents/retry";
-import type { AdapterFailure } from "../../../../src/context/engine";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AgentManager, _agentManagerDeps } from "../../../src/agents/manager";
+import type { RetryDecision, RetryStrategy } from "../../../src/agents/retry";
+import type { AdapterFailure } from "../../../src/context/engine";
 
 const rateLimitFailure: AdapterFailure = {
   category: "availability",
@@ -14,6 +14,10 @@ const baseConfig = {
   models: { claude: { fast: "claude-haiku-4-5", balanced: "claude-sonnet-4-6", powerful: "claude-opus-4-7" } },
   agent: { default: "claude", fallback: { enabled: false, map: {} } },
 };
+
+let origSleep: typeof _agentManagerDeps.sleep;
+beforeEach(() => { origSleep = _agentManagerDeps.sleep; });
+afterEach(() => { _agentManagerDeps.sleep = origSleep; });
 
 describe("AgentManager — injectable retryStrategy", () => {
   test("uses injected strategy instead of hardcoded logic when no swap candidates", async () => {
@@ -31,7 +35,7 @@ describe("AgentManager — injectable retryStrategy", () => {
     const manager = new AgentManager(baseConfig as never, undefined, { retryStrategy: neverRetry });
 
     const outcome = await manager.runWithFallback({
-      runOptions: { prompt: "test", workdir: "/tmp", modelTier: "fast", modelDef: { model: "claude-haiku-4-5" }, config: baseConfig as never, pipelineStage: "run" },
+      runOptions: { prompt: "test", workdir: "/tmp", modelTier: "fast", modelDef: { provider: "anthropic", model: "claude-haiku-4-5" }, timeoutSeconds: 30, config: baseConfig as never, pipelineStage: "run" },
       executeHop: async () => ({
         result: { success: false, exitCode: 1, output: "", rateLimited: false, durationMs: 0, estimatedCostUsd: 0, adapterFailure: rateLimitFailure },
         bundle: undefined,
@@ -52,7 +56,7 @@ describe("AgentManager — injectable retryStrategy", () => {
     const manager = new AgentManager(baseConfig as never);
 
     await manager.runWithFallback({
-      runOptions: { prompt: "test", workdir: "/tmp", modelTier: "fast", modelDef: { model: "claude-haiku-4-5" }, config: baseConfig as never, pipelineStage: "run" },
+      runOptions: { prompt: "test", workdir: "/tmp", modelTier: "fast", modelDef: { provider: "anthropic", model: "claude-haiku-4-5" }, timeoutSeconds: 30, config: baseConfig as never, pipelineStage: "run" },
       executeHop: async () => ({
         result: { success: false, exitCode: 1, output: "", rateLimited: false, durationMs: 0, estimatedCostUsd: 0, adapterFailure: rateLimitFailure },
         bundle: undefined,
@@ -60,6 +64,8 @@ describe("AgentManager — injectable retryStrategy", () => {
       }),
     });
 
-    expect(sleepCalls).toEqual([2000, 4000, 8000]);
+    // defaultRetryStrategy: 3 retries, delayMs = 2^(attempt+1) * 1000 → 2s, 4s, 8s
+    const expectedDelays = [0, 1, 2].map((a) => 2 ** (a + 1) * 1000);
+    expect(sleepCalls).toEqual(expectedDelays);
   });
 });

--- a/test/unit/agents/retry/default-strategy.test.ts
+++ b/test/unit/agents/retry/default-strategy.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { defaultRetryStrategy } from "../../../../src/agents/retry/index";
+import type { AdapterFailure } from "../../../../src/context/engine";
+
+const rateLimitFailure: AdapterFailure = {
+  category: "availability",
+  outcome: "fail-rate-limit",
+  retriable: true,
+  message: "rate limited",
+};
+
+const quotaFailure: AdapterFailure = {
+  category: "availability",
+  outcome: "fail-quota",
+  retriable: false,
+  message: "quota exceeded",
+};
+
+const ctx = { site: "run" as const, agentName: "claude", stage: "run" as const, storyId: "US-001" };
+
+describe("defaultRetryStrategy", () => {
+  test("retries rate-limit failure up to 3 times with exponential backoff", () => {
+    expect(defaultRetryStrategy.shouldRetry(rateLimitFailure, 0, ctx)).toEqual({ retry: true, delayMs: 2000 });
+    expect(defaultRetryStrategy.shouldRetry(rateLimitFailure, 1, ctx)).toEqual({ retry: true, delayMs: 4000 });
+    expect(defaultRetryStrategy.shouldRetry(rateLimitFailure, 2, ctx)).toEqual({ retry: true, delayMs: 8000 });
+  });
+
+  test("does not retry on 4th rate-limit attempt (max 3 retries)", () => {
+    expect(defaultRetryStrategy.shouldRetry(rateLimitFailure, 3, ctx)).toEqual({ retry: false });
+  });
+
+  test("does not retry non-rate-limit failures", () => {
+    expect(defaultRetryStrategy.shouldRetry(quotaFailure, 0, ctx)).toEqual({ retry: false });
+    expect(defaultRetryStrategy.shouldRetry(new Error("generic"), 0, ctx)).toEqual({ retry: false });
+  });
+
+  test("backoff: attempt=0 → 2s, attempt=1 → 4s, attempt=2 → 8s", () => {
+    const delays = [0, 1, 2].map((a) => {
+      const d = defaultRetryStrategy.shouldRetry(rateLimitFailure, a, ctx);
+      return d.retry ? d.delayMs : -1;
+    });
+    expect(delays).toEqual([2000, 4000, 8000]);
+  });
+});

--- a/test/unit/agents/retry/manager-rate-limit.test.ts
+++ b/test/unit/agents/retry/manager-rate-limit.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { AgentManager, _agentManagerDeps } from "../../../../src/agents/manager";
+import type { RetryContext, RetryDecision, RetryStrategy } from "../../../../src/agents/retry";
+import type { AdapterFailure } from "../../../../src/context/engine";
+
+const rateLimitFailure: AdapterFailure = {
+  category: "availability",
+  outcome: "fail-rate-limit",
+  retriable: true,
+  message: "rate limited",
+};
+
+const baseConfig = {
+  models: { claude: { fast: "claude-haiku-4-5", balanced: "claude-sonnet-4-6", powerful: "claude-opus-4-7" } },
+  agent: { default: "claude", fallback: { enabled: false, map: {} } },
+};
+
+describe("AgentManager — injectable retryStrategy", () => {
+  test("uses injected strategy instead of hardcoded logic when no swap candidates", async () => {
+    const decisions: Array<{ attempt: number; failure: AdapterFailure | Error }> = [];
+    const neverRetry: RetryStrategy = {
+      shouldRetry(failure, attempt, _ctx): RetryDecision {
+        decisions.push({ attempt, failure });
+        return { retry: false };
+      },
+    };
+
+    const sleepCalls: number[] = [];
+    _agentManagerDeps.sleep = async (ms: number) => { sleepCalls.push(ms); };
+
+    const manager = new AgentManager(baseConfig as never, undefined, { retryStrategy: neverRetry });
+
+    const outcome = await manager.runWithFallback({
+      runOptions: { prompt: "test", workdir: "/tmp", modelTier: "fast", modelDef: { model: "claude-haiku-4-5" }, config: baseConfig as never, pipelineStage: "run" },
+      executeHop: async () => ({
+        result: { success: false, exitCode: 1, output: "", rateLimited: false, durationMs: 0, estimatedCostUsd: 0, adapterFailure: rateLimitFailure },
+        bundle: undefined,
+        prompt: undefined,
+      }),
+    });
+
+    expect(outcome.result.success).toBe(false);
+    expect(decisions.length).toBeGreaterThan(0);
+    expect(decisions[0].attempt).toBe(0);
+    expect(sleepCalls).toHaveLength(0);
+  });
+
+  test("defaultRetryStrategy fires 3 sleeps with exponential backoff", async () => {
+    const sleepCalls: number[] = [];
+    _agentManagerDeps.sleep = async (ms: number) => { sleepCalls.push(ms); };
+
+    const manager = new AgentManager(baseConfig as never);
+
+    await manager.runWithFallback({
+      runOptions: { prompt: "test", workdir: "/tmp", modelTier: "fast", modelDef: { model: "claude-haiku-4-5" }, config: baseConfig as never, pipelineStage: "run" },
+      executeHop: async () => ({
+        result: { success: false, exitCode: 1, output: "", rateLimited: false, durationMs: 0, estimatedCostUsd: 0, adapterFailure: rateLimitFailure },
+        bundle: undefined,
+        prompt: undefined,
+      }),
+    });
+
+    expect(sleepCalls).toEqual([2000, 4000, 8000]);
+  });
+});

--- a/test/unit/agents/retry/presets.test.ts
+++ b/test/unit/agents/retry/presets.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { resolveRetryPreset } from "../../../../src/agents/retry";
+import type { RetryPreset } from "../../../../src/agents/retry";
+
+const ctx = { site: "complete" as const, agentName: "claude", stage: "run" as const };
+const preset: RetryPreset = { preset: "transient-network", maxAttempts: 2, baseDelayMs: 1000 };
+
+describe("resolveRetryPreset", () => {
+  test("retries on thrown Error when attempt < maxAttempts-1", () => {
+    const strategy = resolveRetryPreset(preset);
+    expect(strategy.shouldRetry(new Error("timeout"), 0, ctx)).toEqual({ retry: true, delayMs: 1000 });
+  });
+
+  test("stops after maxAttempts-1 retries", () => {
+    const strategy = resolveRetryPreset(preset);
+    // maxAttempts=2 → only 1 retry allowed (attempt 0). attempt 1 → stop.
+    expect(strategy.shouldRetry(new Error("timeout"), 1, ctx)).toEqual({ retry: false });
+  });
+
+  test("retries on retriable AdapterFailure", () => {
+    const strategy = resolveRetryPreset(preset);
+    const af = { category: "availability" as const, outcome: "fail-rate-limit" as const, retriable: true, message: "" };
+    expect(strategy.shouldRetry(af, 0, ctx)).toEqual({ retry: true, delayMs: 1000 });
+  });
+
+  test("does not retry non-retriable AdapterFailure", () => {
+    const strategy = resolveRetryPreset(preset);
+    const af = { category: "availability" as const, outcome: "fail-auth" as const, retriable: false, message: "" };
+    expect(strategy.shouldRetry(af, 0, ctx)).toEqual({ retry: false });
+  });
+
+  test("maxAttempts: 3 allows 2 retries", () => {
+    const s = resolveRetryPreset({ preset: "transient-network", maxAttempts: 3, baseDelayMs: 500 });
+    expect(s.shouldRetry(new Error("x"), 0, ctx)).toEqual({ retry: true, delayMs: 500 });
+    expect(s.shouldRetry(new Error("x"), 1, ctx)).toEqual({ retry: true, delayMs: 500 });
+    expect(s.shouldRetry(new Error("x"), 2, ctx)).toEqual({ retry: false });
+  });
+});

--- a/test/unit/config/deprecation-routing-retry.test.ts
+++ b/test/unit/config/deprecation-routing-retry.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { applyRoutingRetryDeprecationWarning } from "../../../src/config/loader";
+
+describe("applyRoutingRetryDeprecationWarning", () => {
+  test("warns when routing.llm.retries is set", () => {
+    const warnings: string[] = [];
+    const conf = { routing: { strategy: "llm", llm: { mode: "per-story", retries: 2 } } };
+    applyRoutingRetryDeprecationWarning(conf, (msg: string) => warnings.push(msg));
+    expect(warnings.some((w) => w.includes("routing.llm.retries"))).toBe(true);
+    expect(warnings.some((w) => w.includes("deprecated"))).toBe(true);
+  });
+
+  test("warns when routing.llm.retryDelayMs is set", () => {
+    const warnings: string[] = [];
+    const conf = { routing: { strategy: "llm", llm: { mode: "per-story", retryDelayMs: 500 } } };
+    applyRoutingRetryDeprecationWarning(conf, (msg: string) => warnings.push(msg));
+    expect(warnings.some((w) => w.includes("routing.llm.retryDelayMs"))).toBe(true);
+  });
+
+  test("emits no warning when neither key is set", () => {
+    const warnings: string[] = [];
+    const conf = { routing: { strategy: "llm", llm: { mode: "per-story" } } };
+    applyRoutingRetryDeprecationWarning(conf, (msg: string) => warnings.push(msg));
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("returns the same object unchanged (values preserved for op resolver)", () => {
+    const conf = { routing: { strategy: "llm", llm: { mode: "per-story", retries: 3, retryDelayMs: 2000 } } };
+    const result = applyRoutingRetryDeprecationWarning(conf, () => {});
+    expect(result).toBe(conf);
+  });
+});

--- a/test/unit/operations/call-op-retry.test.ts
+++ b/test/unit/operations/call-op-retry.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { _callOpDeps, callOp } from "../../../src/operations/call";
-import type { CompleteOperation } from "../../../src/operations/types";
+import { _callOpDeps, callOp } from "../../../src/operations";
+import type { CompleteOperation } from "../../../src/operations";
 import type { RetryPreset } from "../../../src/agents/retry";
 import { DEFAULT_CONFIG } from "../../../src/config";
 import { makeMockAgentManager, makeTestRuntime } from "../../helpers";

--- a/test/unit/operations/call-op-retry.test.ts
+++ b/test/unit/operations/call-op-retry.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { _callOpDeps, callOp } from "../../../src/operations/call";
+import type { CompleteOperation } from "../../../src/operations/types";
+import type { RetryPreset } from "../../../src/agents/retry";
+import { DEFAULT_CONFIG } from "../../../src/config";
+import { makeMockAgentManager, makeTestRuntime } from "../../helpers";
+import { pickSelector } from "../../../src/config";
+import type { CompleteResult } from "../../../src/agents/types";
+
+const testSel = pickSelector("retry-op-test", "routing");
+
+// Minimal complete op used across all retry tests
+const successOp: CompleteOperation<string, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+  kind: "complete",
+  name: "retry-test-op",
+  stage: "run",
+  config: testSel,
+  build: (input) => ({
+    role: { id: "role", content: "", overridable: false },
+    task: { id: "task", content: input, overridable: false },
+  }),
+  parse: (output) => output,
+};
+
+// Save/restore _callOpDeps.sleep around each test
+let origSleep: typeof _callOpDeps.sleep;
+beforeEach(() => {
+  origSleep = _callOpDeps.sleep;
+});
+afterEach(() => {
+  _callOpDeps.sleep = origSleep;
+});
+
+describe("callOp retry loop (kind:complete)", () => {
+  test("no retry field — throws immediately on error", async () => {
+    let callCount = 0;
+    const agentManager = makeMockAgentManager({
+      completeAsFn: async () => {
+        callCount++;
+        throw new Error("transient");
+      },
+    });
+    const runtime = makeTestRuntime({ agentManager });
+    const ctx = {
+      runtime,
+      packageView: runtime.packages.repo(),
+      packageDir: "/tmp",
+      agentName: "claude",
+      storyId: "US-001",
+    };
+
+    await expect(callOp(ctx, { ...successOp }, "hello")).rejects.toThrow("transient");
+    expect(callCount).toBe(1);
+  });
+
+  test("retry: transient-network, maxAttempts:2 — retries once then throws", async () => {
+    const sleepCalls: number[] = [];
+    _callOpDeps.sleep = async (ms: number) => {
+      sleepCalls.push(ms);
+    };
+
+    let callCount = 0;
+    const agentManager = makeMockAgentManager({
+      completeAsFn: async () => {
+        callCount++;
+        throw new Error("transient");
+      },
+    });
+    const runtime = makeTestRuntime({ agentManager });
+    const ctx = {
+      runtime,
+      packageView: runtime.packages.repo(),
+      packageDir: "/tmp",
+      agentName: "claude",
+      storyId: "US-001",
+    };
+
+    const preset: RetryPreset = { preset: "transient-network", maxAttempts: 2, baseDelayMs: 500 };
+
+    await expect(callOp(ctx, { ...successOp, retry: preset }, "hello")).rejects.toThrow("transient");
+    expect(callCount).toBe(2); // 1 initial + 1 retry
+    expect(sleepCalls).toEqual([500]); // slept once (baseDelayMs at attempt 0)
+  });
+
+  test("retry: transient-network — succeeds on second attempt", async () => {
+    const sleepCalls: number[] = [];
+    _callOpDeps.sleep = async (ms: number) => {
+      sleepCalls.push(ms);
+    };
+
+    let callCount = 0;
+    const agentManager = makeMockAgentManager({
+      completeAsFn: async () => {
+        callCount++;
+        if (callCount === 1) throw new Error("transient");
+        return { output: "pong", tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 } satisfies CompleteResult;
+      },
+    });
+    const runtime = makeTestRuntime({ agentManager });
+    const ctx = {
+      runtime,
+      packageView: runtime.packages.repo(),
+      packageDir: "/tmp",
+      agentName: "claude",
+      storyId: "US-001",
+    };
+
+    const preset: RetryPreset = { preset: "transient-network", maxAttempts: 2, baseDelayMs: 500 };
+    const result = await callOp(ctx, { ...successOp, retry: preset }, "hello");
+
+    expect(result).toBe("pong");
+    expect(callCount).toBe(2);
+    expect(sleepCalls).toEqual([500]);
+  });
+
+  test("retry: function resolver returning undefined — no retry", async () => {
+    const sleepCalls: number[] = [];
+    _callOpDeps.sleep = async (ms: number) => {
+      sleepCalls.push(ms);
+    };
+
+    let callCount = 0;
+    const agentManager = makeMockAgentManager({
+      completeAsFn: async () => {
+        callCount++;
+        throw new Error("transient");
+      },
+    });
+    const runtime = makeTestRuntime({ agentManager });
+    const ctx = {
+      runtime,
+      packageView: runtime.packages.repo(),
+      packageDir: "/tmp",
+      agentName: "claude",
+      storyId: "US-001",
+    };
+
+    // resolver returning undefined → no retry
+    const opWithNullResolver: CompleteOperation<string, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      ...successOp,
+      retry: () => undefined,
+    };
+
+    await expect(callOp(ctx, opWithNullResolver, "hello")).rejects.toThrow("transient");
+    expect(callCount).toBe(1);
+    expect(sleepCalls).toHaveLength(0);
+  });
+});

--- a/test/unit/routing/routing-stability.test.ts
+++ b/test/unit/routing/routing-stability.test.ts
@@ -230,4 +230,18 @@ describe("classifyRouteOp declares retry preset (issue #856 site #4)", () => {
     expect(preset?.maxAttempts).toBe(4); // retries: 3 → maxAttempts: 4
     expect(preset?.baseDelayMs).toBe(2000);
   });
+
+  test("retry resolver yields maxAttempts: 1 when retries: 0 (single attempt, no retry)", () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      routing: { ...DEFAULT_CONFIG.routing, llm: { mode: "per-story" as const, retries: 0, retryDelayMs: 500 } },
+    };
+    const buildCtx = {
+      packageView: null as never,
+      config: { routing: config.routing, autoMode: config.autoMode } as never,
+    };
+    const resolver = classifyRouteOp.retry as (input: unknown, ctx: typeof buildCtx) => { maxAttempts: number } | undefined;
+    const preset = resolver({}, buildCtx);
+    expect(preset?.maxAttempts).toBe(1);
+  });
 });

--- a/test/unit/routing/routing-stability.test.ts
+++ b/test/unit/routing/routing-stability.test.ts
@@ -12,6 +12,7 @@ import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import { initLogger, resetLogger } from "../../../src/logger";
 import type { UserStory } from "../../../src/prd/types";
 import { classifyComplexity, complexityToModelTier, determineTestStrategy } from "../../../src/routing";
+import { classifyRouteOp, classifyRouteBatchOp } from "../../../src/operations";
 import { makeStory } from "../../helpers";
 
 /** Minimal keyword-route helper replacing the deleted keywordStrategy object. */
@@ -199,5 +200,34 @@ describe("LLM routing config accepts retry and timeout fields with correct defau
     });
 
     expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #856 site #4: classifyRouteOp / classifyRouteBatchOp retry preset
+// ---------------------------------------------------------------------------
+
+describe("classifyRouteOp declares retry preset (issue #856 site #4)", () => {
+  test("classifyRouteOp has a retry field", () => {
+    expect(classifyRouteOp.retry).toBeDefined();
+  });
+
+  test("classifyRouteBatchOp has a retry field", () => {
+    expect(classifyRouteBatchOp.retry).toBeDefined();
+  });
+
+  test("retry resolver uses routing.llm.retries when set (deprecation bridge)", () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      routing: { ...DEFAULT_CONFIG.routing, llm: { mode: "per-story" as const, retries: 3, retryDelayMs: 2000 } },
+    };
+    const buildCtx = {
+      packageView: null as never,
+      config: { routing: config.routing, autoMode: config.autoMode } as never,
+    };
+    const resolver = classifyRouteOp.retry as (input: unknown, ctx: typeof buildCtx) => { maxAttempts: number; baseDelayMs: number } | undefined;
+    const preset = resolver({}, buildCtx);
+    expect(preset?.maxAttempts).toBe(4); // retries: 3 → maxAttempts: 4
+    expect(preset?.baseDelayMs).toBe(2000);
   });
 });


### PR DESCRIPTION
## Summary

Closes #856 — unifies ad-hoc retry logic scattered across `AgentManager`, `classifyWithRetry`, and future call sites behind a single injectable `RetryStrategy` interface.

- **New `src/agents/retry/` module** — `RetryStrategy`, `RetryContext`, `RetryDecision`, `RetryPreset` types; `defaultRetryStrategy` (rate-limit exponential backoff: 3 retries, 2s/4s/8s); `resolveRetryPreset` for op-level "transient-network" preset (configurable `maxAttempts` + `baseDelayMs`)
- **`AgentManager` wired** — constructor accepts optional `retryStrategy` (`_deps`-injectable); `MAX_RATE_LIMIT_RETRIES` constant deleted; hardcoded retry block replaced with `this._retryStrategy.shouldRetry(...)` + cancellable sleep
- **`CompleteOperation.retry?`** — new field (`RetryPreset | RetryStrategy | ((input, ctx) => RetryPreset | undefined)`); `callOp` resolves it and runs a bounded retry loop (`MAX_COMPLETE_RETRY_ATTEMPTS = 20`) with abort-signal-aware sleep via `_callOpDeps.sleep`
- **`classifyRouteOp` / `classifyRouteBatchOp`** declare `retry` resolver — reads `routing.llm.retries` / `retryDelayMs` as a deprecation bridge; `classifyWithRetry` (~30 lines) deleted from `router.ts`
- **Deprecation shim** — `applyRoutingRetryDeprecationWarning` (exported from `src/config/loader.ts`) warns on `routing.llm.retries` and `routing.llm.retryDelayMs` at config load time; values preserved for the op resolver during transition

## Abort-signal threading

`_callOpDeps.sleep(ms, signal)` uses `cancellableDelay` so a mid-retry `AbortSignal` abort resolves immediately rather than blocking the full delay. Pre- and post-sleep abort checks ensure the loop exits cleanly.

## What was NOT migrated

`HopBody` callbacks on `RunOperation` (semantic/adversarial review ops) — these are a different abstraction (multi-turn session continuations) and don't map onto `RetryStrategy`. Unchanged.

## Test plan

- [ ] `test/unit/agents/retry/default-strategy.test.ts` — exponential backoff formula, only retries `fail-rate-limit`, non-rate-limit failures rejected
- [ ] `test/unit/agents/retry/presets.test.ts` — transient-network preset, `maxAttempts` ceiling, fixed `baseDelayMs`
- [ ] `test/unit/agents/manager-rate-limit.test.ts` — `AgentManager` retry via `_agentManagerDeps.sleep` injection; backoff delays match formula; signals abort cleanly
- [ ] `test/unit/operations/call-op-retry.test.ts` — no-retry (op without `retry`), exhaustion throws `CALL_OP_MAX_RETRIES`, success-on-retry, function resolver returning `undefined` disables retry
- [ ] `test/unit/routing/routing-stability.test.ts` — `classifyRouteOp.retry` defined; `retries:3 → maxAttempts:4`; `retries:0 → maxAttempts:1`
- [ ] `test/unit/config/deprecation-routing-retry.test.ts` — warns on `routing.llm.retries`, warns on `retryDelayMs`, no warning when neither set, returns same object (values preserved)
- [ ] Full suite: 1208 tests passing, 0 failures