### PR TITLE
fix(context): language-aware glob, configurable cap, and visible truncation for CodeNeighborProvider (#895)

### DIFF
--- a/docs/guides/context-providers.md
+++ b/docs/guides/context-providers.md
@@ -1,0 +1,59 @@
+# Context Engine v2 — Built-in Providers
+
+## `context.v2.providers` configuration
+
+These keys live under `context.v2.providers` in `.nax/config.json` (or per-package in `.nax/mono/<pkg>/config.json`).
+
+| Key | Type | Default | Description |
+|:----|:-----|:--------|:------------|
+| `historyScope` | `"repo" \| "package"` | `"package"` | Working directory scope for `GitHistoryProvider`. `"package"` runs `git log` in `packageDir` (monorepo-safe). |
+| `neighborScope` | `"repo" \| "package"` | `"package"` | Working directory scope for `CodeNeighborProvider`. `"package"` scans from `packageDir`. |
+| `crossPackageDepth` | `number` | `1` | Cross-package scan depth for `CodeNeighborProvider`. `0` disables; `1` additionally scans workspace siblings. |
+| `sourceGlob` | `string?` | _(derived)_ | Override the source-file glob used for reverse-dep scanning. When omitted, derived from `detectLanguage(packageDir)` (TypeScript, Go, Python, Rust each get a narrow glob; unknown packages get the wide fallback). |
+| `maxGlobFiles` | `number` | `500` | Maximum files scanned per directory during reverse-dep glob. Truncation logs at `warn` level and appends a note to the context chunk. |
+
+### Language-derived glob defaults
+
+When `sourceGlob` is not set, `CodeNeighborProvider` derives the glob from the detected language:
+
+| Language | Glob |
+|:---------|:-----|
+| TypeScript | `**/*.{ts,tsx,js,jsx,mjs,cjs}` |
+| JavaScript | `**/*.{js,jsx,mjs,cjs}` |
+| Go | `**/*.go` |
+| Python | `**/*.py` |
+| Rust | `**/*.rs` |
+| Unknown / polyglot | `**/*.{ts,tsx,js,jsx,mjs,cjs,py,go,rs,java,rb,php,cs,cpp,c,h}` |
+
+### Monorepo per-package override example
+
+A monorepo with a large Go backend package can narrow the scan and raise the cap independently of the TypeScript frontend:
+
+```json
+// .nax/mono/packages/api/config.json  (Go package)
+{
+  "context": {
+    "v2": {
+      "providers": {
+        "sourceGlob": "**/*.go",
+        "maxGlobFiles": 1000
+      }
+    }
+  }
+}
+```
+
+```json
+// .nax/mono/packages/web/config.json  (TypeScript package)
+{
+  "context": {
+    "v2": {
+      "providers": {
+        "maxGlobFiles": 300
+      }
+    }
+  }
+}
+```
+
+If `sourceGlob` is omitted from the per-package config, the glob is still auto-derived from the package's detected language.

--- a/src/config/runtime-types-context.ts
+++ b/src/config/runtime-types-context.ts
@@ -118,6 +118,10 @@ export interface ContextV2Config {
     neighborScope: "repo" | "package";
     /** Cross-package scan depth for CodeNeighborProvider. Default: 1. */
     crossPackageDepth: number;
+    /** Override source-file glob for reverse-dep scanning (#895). Derived from language when omitted. */
+    sourceGlob?: string;
+    /** Max files scanned per directory during reverse-dep glob (#895). Default: 500. */
+    maxGlobFiles: number;
   };
 }
 

--- a/src/config/schemas-context.ts
+++ b/src/config/schemas-context.ts
@@ -170,8 +170,21 @@ export const ContextV2ConfigSchema = z
          * Only active when neighborScope is "package" and the story has a workdir.
          */
         crossPackageDepth: z.number().int().min(0).default(1),
+        /**
+         * Override the source-file glob for CodeNeighborProvider reverse-dep scanning.
+         * When omitted (default), the glob is derived from detectLanguage(packageDir).
+         * Tunable per-package via .nax/mono/<pkg>/config.json.
+         */
+        sourceGlob: z.string().optional(),
+        /**
+         * Maximum files scanned per directory during reverse-dep glob.
+         * Raised from 200 to 500: language-aware globbing now produces less noise,
+         * so a higher default rarely hurts and reduces silent truncation in mid-size
+         * monorepos. Tunable per-package via .nax/mono/<pkg>/config.json.
+         */
+        maxGlobFiles: z.number().int().min(1).default(500),
       })
-      .default({ historyScope: "package", neighborScope: "package", crossPackageDepth: 1 }),
+      .default({ historyScope: "package", neighborScope: "package", crossPackageDepth: 1, maxGlobFiles: 500 }),
     /**
      * Staleness detection for feature context entries (Amendment A AC-46/AC-47).
      * Downweights old or contradicted entries in context.md so stale advice
@@ -207,7 +220,7 @@ export const ContextV2ConfigSchema = z
     deterministic: false,
     session: { retentionDays: 7, archiveOnFeatureArchive: true },
     staleness: { enabled: true, maxStoryAge: 10, scoreMultiplier: 0.4 },
-    providers: { historyScope: "package" as const, neighborScope: "package" as const, crossPackageDepth: 1 },
+    providers: { historyScope: "package" as const, neighborScope: "package" as const, crossPackageDepth: 1, maxGlobFiles: 500 },
   }));
 
 export const ContextConfigSchema = z.object({

--- a/src/config/schemas-context.ts
+++ b/src/config/schemas-context.ts
@@ -220,7 +220,12 @@ export const ContextV2ConfigSchema = z
     deterministic: false,
     session: { retentionDays: 7, archiveOnFeatureArchive: true },
     staleness: { enabled: true, maxStoryAge: 10, scoreMultiplier: 0.4 },
-    providers: { historyScope: "package" as const, neighborScope: "package" as const, crossPackageDepth: 1, maxGlobFiles: 500 },
+    providers: {
+      historyScope: "package" as const,
+      neighborScope: "package" as const,
+      crossPackageDepth: 1,
+      maxGlobFiles: 500,
+    },
   }));
 
 export const ContextConfigSchema = z.object({

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -286,7 +286,7 @@ export const NaxConfigSchema = z
         deterministic: false,
         session: { retentionDays: 7, archiveOnFeatureArchive: true },
         staleness: { enabled: true, maxStoryAge: 10, scoreMultiplier: 0.4 },
-        providers: { historyScope: "package", neighborScope: "package", crossPackageDepth: 1 },
+        providers: { historyScope: "package", neighborScope: "package", crossPackageDepth: 1, maxGlobFiles: 500 },
       },
     }),
     optimizer: OptimizerConfigSchema.optional(),

--- a/src/context/engine/orchestrator-factory.ts
+++ b/src/context/engine/orchestrator-factory.ts
@@ -63,6 +63,8 @@ export function createDefaultOrchestrator(
     new CodeNeighborProvider({
       neighborScope: providerConfig?.neighborScope ?? "package",
       crossPackageDepth: providerConfig?.crossPackageDepth ?? 1,
+      sourceGlob: providerConfig?.sourceGlob,
+      maxGlobFiles: providerConfig?.maxGlobFiles,
     }),
   );
   // Phase 7: plugin providers (RAG, graph, KB, etc.)

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -42,6 +42,8 @@ export interface CodeNeighborProviderOptions {
   /**
    * Maximum files scanned per directory during reverse-dep glob (#895).
    * Default: 500 (raised from 200; language-aware glob reduces noise).
+   * Applied per-directory: with crossPackageDepth > 0, each workspace package
+   * dir counts separately, so effective total can be N × maxGlobFiles.
    */
   maxGlobFiles?: number;
 }
@@ -554,17 +556,16 @@ export class CodeNeighborProvider implements IContextProvider {
     }
 
     const header = "## Code Neighbors\n\nRelated files (imports, reverse-deps, tests):";
-    let rawContent = `${header}\n\n${sections.join("\n\n")}`;
+    const rawContent = `${header}\n\n${sections.join("\n\n")}`;
 
-    if (anyTruncated) {
-      rawContent +=
-        `\n\n> Note: reverse-dep scan capped at ${this.maxGlobFiles} files; some neighbors may be missing.` +
-        "\n> Increase `context.v2.providers.maxGlobFiles` or narrow `sourceGlob` to widen.";
-    }
-
-    // Cap content to avoid overrunning token budget
+    // Cap body first so the truncation note (when present) is never sliced off.
     const maxChars = MAX_CHUNK_TOKENS * 4;
-    const content = rawContent.length > maxChars ? rawContent.slice(0, maxChars) : rawContent;
+    const body = rawContent.length > maxChars ? rawContent.slice(0, maxChars) : rawContent;
+    const truncationNote = anyTruncated
+      ? `\n\n> Note: reverse-dep scan capped at ${this.maxGlobFiles} files; some neighbors may be missing.` +
+        `\n> Increase \`context.v2.providers.maxGlobFiles\` or set \`sourceGlob\` to a narrower pattern (e.g. \`**/*.go\`) to reduce the scan footprint.`
+      : "";
+    const content = body + truncationNote;
     const tokens = Math.ceil(content.length / 4);
 
     const chunk: RawChunk = {

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -324,15 +324,6 @@ function isTestFile(filePath: string, regex: readonly RegExp[]): boolean {
   return regex.some((re) => re.test(filePath));
 }
 
-/**
- * Collect neighbors for a single file:
- * - forward deps (JS/TS import parse only — empty for other languages)
- * - reverse deps (all common source extensions)
- * - sibling test file (derived from ResolvedTestPatterns, ADR-009 SSOT)
- *
- * extraGlobWorkdirs: when provided (AC-62 crossPackageDepth > 0), also scans
- * each directory for cross-package reverse deps (workspace package dirs or repoRoot).
- *
 /** Derive the source-file glob for reverse-dep scanning (#895, L1). */
 async function resolveSourceGlob(override: string | undefined, packageDir: string): Promise<string> {
   if (override) return override;
@@ -341,10 +332,9 @@ async function resolveSourceGlob(override: string | undefined, packageDir: strin
 }
 
 /**
- * siblingTestContext: when provided, enables sibling-test derivation via the
- * resolver's globs + testDirs. When omitted, sibling-test hinting is skipped
- * (the legacy `test/unit/` hardcoding is gone — callers must thread the
- * resolver per ADR-009).
+ * Collect neighbors for a single file: forward deps (JS/TS only), reverse deps
+ * (language-aware glob, configurable cap), and sibling test (ADR-009 SSOT).
+ * extraGlobWorkdirs enables cross-package reverse dep scanning (AC-62).
  */
 async function collectNeighbors(
   filePath: string,

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -1,22 +1,8 @@
 /**
- * Context Engine v2 — CodeNeighborProvider
+ * Context Engine v2 — CodeNeighborProvider (Phase 3)
  *
- * Surfaces import-graph neighbors for files this story touches:
- *   - Forward deps:  files imported by the touched file (import/require parse)
- *   - Reverse deps:  files that import the touched file (Bun.Glob scan, capped at 200 files)
- *   - Sibling test:  mirrored test file (src/foo/bar.ts → test/unit/foo/bar.test.ts)
- *
- * Language scope:
- *   Forward dep parsing is JavaScript/TypeScript-only (import/require syntax).
- *   For other languages (Python, Go, Rust, etc.), forward deps return empty;
- *   reverse deps and sibling tests are still attempted where applicable.
- *   The reverse-dep glob covers common source extensions across languages.
- *
- * The combined result is collapsed into a single "neighbor" kind chunk.
- * Files are capped at MAX_FILES; neighbors per file capped at MAX_NEIGHBORS_PER_FILE.
- * Chunk is capped at MAX_CHUNK_TOKENS to avoid budget overrun.
- *
- * Phase 3.
+ * Surfaces forward deps, reverse deps (language-aware glob, configurable cap),
+ * and sibling tests for files touched by the story.
  *
  * See: docs/specs/SPEC-context-engine-v2.md §CodeNeighborProvider
  */
@@ -24,6 +10,7 @@
 import { createHash } from "node:crypto";
 import { join, relative, resolve } from "node:path";
 import { getLogger } from "../../../logger";
+import { detectLanguage } from "../../../project";
 import { discoverWorkspacePackages } from "../../../test-runners/detect/workspace";
 import type { NaxIgnoreMatcher } from "../../../utils/path-filters";
 import { isRelativeAndSafe } from "../../../utils/path-security";
@@ -47,6 +34,16 @@ export interface CodeNeighborProviderOptions {
    * 1 (default) — additionally scans repoRoot for cross-package reverse deps.
    */
   crossPackageDepth?: number;
+  /**
+   * Override the source-file glob for reverse-dep scanning (#895).
+   * When omitted, derived from detectLanguage(packageDir) via SOURCE_GLOB_BY_LANGUAGE.
+   */
+  sourceGlob?: string;
+  /**
+   * Maximum files scanned per directory during reverse-dep glob (#895).
+   * Default: 500 (raised from 200; language-aware glob reduces noise).
+   */
+  maxGlobFiles?: number;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -59,35 +56,24 @@ const MAX_FILES = 10;
 /** Maximum number of neighbors (forward + reverse combined) per file */
 const MAX_NEIGHBORS_PER_FILE = 8;
 
-/** Maximum files scanned during reverse-dep glob */
-const MAX_GLOB_FILES = 200;
+/** Default maximum files scanned during reverse-dep glob (#895) */
+const MAX_GLOB_FILES_DEFAULT = 500;
 
 /** Token ceiling for the combined neighbor chunk */
 const MAX_CHUNK_TOKENS = 500;
 
-/**
- * Source file extensions to scan for reverse deps.
- *
- * TODO: temporary workaround — this list is hardcoded. Future work should make
- * it configurable via .nax/config.json or auto-detected from the package language
- * (via detectLanguage(packageDir)) so nax doesn't scan irrelevant extensions.
- *
- * No `src/` prefix: projects may use lib/, app/, cmd/, or root-level layouts.
- * Excluded directories (node_modules, .nax, vendor, etc.) are stripped at scan
- * time by EXCLUDED_DIR_PREFIXES rather than by glob pattern.
- */
-const SOURCE_GLOB = "**/*.{ts,tsx,js,jsx,py,go,rs,java,rb,php,cs,cpp,c,h}";
+// Per-language globs for reverse-dep scanning (#895, L1). Polyglot/unknown falls back to FALLBACK_SOURCE_GLOB.
+const SOURCE_GLOB_BY_LANGUAGE: Record<string, string> = {
+  typescript: "**/*.{ts,tsx,js,jsx,mjs,cjs}",
+  javascript: "**/*.{js,jsx,mjs,cjs}",
+  go: "**/*.go",
+  python: "**/*.py",
+  rust: "**/*.rs",
+};
 
-/**
- * Directory prefixes to exclude from the reverse-dep glob scan.
- *
- * TODO: temporary workaround — future work should make this configurable or
- * derive it from the package language / project type (e.g. only exclude vendor/
- * for Go projects). For now the list covers the most common noise sources.
- *
- * Checked as a startsWith prefix or an interior segment (`/prefix/`), so both
- * repo-root and nested occurrences (e.g. packages/api/.nax/) are excluded.
- */
+const FALLBACK_SOURCE_GLOB = "**/*.{ts,tsx,js,jsx,mjs,cjs,py,go,rs,java,rb,php,cs,cpp,c,h}";
+
+/** Directory prefixes excluded from reverse-dep glob; checked as startsWith or interior segment. */
 const EXCLUDED_DIR_PREFIXES = [
   "node_modules/",
   ".git/",
@@ -114,15 +100,22 @@ export const _codeNeighborDeps = {
   fileExists: (path: string): Promise<boolean> => Bun.file(path).exists(),
   readFile: (path: string): Promise<string> => Bun.file(path).text(),
   discoverWorkspacePackages: (repoRoot: string): Promise<string[]> => discoverWorkspacePackages(repoRoot),
+  detectLanguage: (packageDir: string) => detectLanguage(packageDir),
   getLogger,
-  glob: (pattern: string, cwd: string, ignoreMatchers: readonly NaxIgnoreMatcher[] = []): string[] => {
+  glob: (
+    pattern: string,
+    cwd: string,
+    ignoreMatchers: readonly NaxIgnoreMatcher[] = [],
+    cap: number = MAX_GLOB_FILES_DEFAULT,
+    ctx?: { storyId?: string; packageDir?: string },
+  ): { files: string[]; truncated: boolean } => {
     const g = new Bun.Glob(pattern);
     const results: string[] = [];
     let count = 0;
     let truncated = false;
     for (const file of g.scanSync({ cwd, absolute: false })) {
       if (isExcludedPath(file, ignoreMatchers)) continue;
-      if (count >= MAX_GLOB_FILES) {
+      if (count >= cap) {
         truncated = true;
         break;
       }
@@ -130,13 +123,16 @@ export const _codeNeighborDeps = {
       count++;
     }
     if (truncated) {
-      _codeNeighborDeps.getLogger().debug("context-v2", "Glob cap reached — results truncated", {
+      _codeNeighborDeps.getLogger().warn("context-v2", "Reverse-dep glob cap reached — results truncated", {
+        storyId: ctx?.storyId,
+        packageDir: ctx?.packageDir,
         pattern,
         cwd,
-        cap: MAX_GLOB_FILES,
+        cap,
+        hint: "Increase context.v2.providers.maxGlobFiles or narrow context.v2.providers.sourceGlob",
       });
     }
-    return results;
+    return { files: results, truncated };
   },
 };
 
@@ -337,6 +333,14 @@ function isTestFile(filePath: string, regex: readonly RegExp[]): boolean {
  * extraGlobWorkdirs: when provided (AC-62 crossPackageDepth > 0), also scans
  * each directory for cross-package reverse deps (workspace package dirs or repoRoot).
  *
+/** Derive the source-file glob for reverse-dep scanning (#895, L1). */
+async function resolveSourceGlob(override: string | undefined, packageDir: string): Promise<string> {
+  if (override) return override;
+  const language = await _codeNeighborDeps.detectLanguage(packageDir);
+  return (language && SOURCE_GLOB_BY_LANGUAGE[language]) ?? FALLBACK_SOURCE_GLOB;
+}
+
+/**
  * siblingTestContext: when provided, enables sibling-test derivation via the
  * resolver's globs + testDirs. When omitted, sibling-test hinting is skipped
  * (the legacy `test/unit/` hardcoding is gone — callers must thread the
@@ -345,11 +349,15 @@ function isTestFile(filePath: string, regex: readonly RegExp[]): boolean {
 async function collectNeighbors(
   filePath: string,
   workdir: string,
+  sourceGlob: string,
+  maxGlobFiles: number,
   extraGlobWorkdirs?: string[],
   siblingTestContext?: { globs: readonly string[]; regex: readonly RegExp[] },
   ignoreMatchers?: readonly NaxIgnoreMatcher[],
-): Promise<string[]> {
+  globCtx?: { storyId?: string; packageDir?: string },
+): Promise<{ neighbors: string[]; truncated: boolean }> {
   const neighbors = new Set<string>();
+  let anyTruncated = false;
 
   // Forward deps (JS/TS only)
   if (await _codeNeighborDeps.fileExists(join(workdir, filePath))) {
@@ -366,7 +374,14 @@ async function collectNeighbors(
   const fileNoExt = filePath.replace(/\.[^.]+$/, "");
 
   const scanForReverseDeps = async (scanWorkdir: string) => {
-    const srcFiles = _codeNeighborDeps.glob(SOURCE_GLOB, scanWorkdir, ignoreMatchers);
+    const { files: srcFiles, truncated } = _codeNeighborDeps.glob(
+      sourceGlob,
+      scanWorkdir,
+      ignoreMatchers,
+      maxGlobFiles,
+      globCtx,
+    );
+    if (truncated) anyTruncated = true;
     for (const srcFile of srcFiles) {
       if (neighbors.size >= MAX_NEIGHBORS_PER_FILE) break;
       if (srcFile === filePath) continue;
@@ -429,7 +444,7 @@ async function collectNeighbors(
     if (chosen !== null && chosen !== filePath) neighbors.add(chosen);
   }
 
-  return [...neighbors].slice(0, MAX_NEIGHBORS_PER_FILE);
+  return { neighbors: [...neighbors].slice(0, MAX_NEIGHBORS_PER_FILE), truncated: anyTruncated };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -480,10 +495,14 @@ export class CodeNeighborProvider implements IContextProvider {
 
   private readonly neighborScope: "repo" | "package";
   private readonly crossPackageDepth: number;
+  private readonly sourceGlobOverride: string | undefined;
+  private readonly maxGlobFiles: number;
 
   constructor(options: CodeNeighborProviderOptions = {}) {
     this.neighborScope = options.neighborScope ?? "package";
     this.crossPackageDepth = options.crossPackageDepth ?? 1;
+    this.sourceGlobOverride = options.sourceGlob;
+    this.maxGlobFiles = options.maxGlobFiles ?? MAX_GLOB_FILES_DEFAULT;
   }
 
   async fetch(request: ContextRequest): Promise<ContextProviderResult> {
@@ -517,9 +536,24 @@ export class CodeNeighborProvider implements IContextProvider {
 
     const ignoreMatchers = request.naxIgnoreIndex?.getMatchers(workdir);
 
+    // Resolve source glob once per request (lazy: detectLanguage called only if no override).
+    const sourceGlob = await resolveSourceGlob(this.sourceGlobOverride, request.packageDir);
+    const globCtx = { storyId: request.storyId, packageDir: request.packageDir };
+
     const sections: string[] = [];
+    let anyTruncated = false;
     for (const file of filesToProcess) {
-      const neighbors = await collectNeighbors(file, workdir, extraGlobWorkdirs, siblingTestContext, ignoreMatchers);
+      const { neighbors, truncated } = await collectNeighbors(
+        file,
+        workdir,
+        sourceGlob,
+        this.maxGlobFiles,
+        extraGlobWorkdirs,
+        siblingTestContext,
+        ignoreMatchers,
+        globCtx,
+      );
+      if (truncated) anyTruncated = true;
       if (neighbors.length > 0) {
         sections.push(`### ${file}\n${neighbors.map((n) => `- ${n}`).join("\n")}`);
       }
@@ -530,7 +564,13 @@ export class CodeNeighborProvider implements IContextProvider {
     }
 
     const header = "## Code Neighbors\n\nRelated files (imports, reverse-deps, tests):";
-    const rawContent = `${header}\n\n${sections.join("\n\n")}`;
+    let rawContent = `${header}\n\n${sections.join("\n\n")}`;
+
+    if (anyTruncated) {
+      rawContent +=
+        `\n\n> Note: reverse-dep scan capped at ${this.maxGlobFiles} files; some neighbors may be missing.` +
+        "\n> Increase `context.v2.providers.maxGlobFiles` or narrow `sourceGlob` to widen.";
+    }
 
     // Cap content to avoid overrunning token budget
     const maxChars = MAX_CHUNK_TOKENS * 4;

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -562,8 +562,7 @@ export class CodeNeighborProvider implements IContextProvider {
     const maxChars = MAX_CHUNK_TOKENS * 4;
     const body = rawContent.length > maxChars ? rawContent.slice(0, maxChars) : rawContent;
     const truncationNote = anyTruncated
-      ? `\n\n> Note: reverse-dep scan capped at ${this.maxGlobFiles} files; some neighbors may be missing.` +
-        `\n> Increase \`context.v2.providers.maxGlobFiles\` or set \`sourceGlob\` to a narrower pattern (e.g. \`**/*.go\`) to reduce the scan footprint.`
+      ? `\n\n> Note: reverse-dep scan capped at ${this.maxGlobFiles} files; some neighbors may be missing.\n> Increase \`context.v2.providers.maxGlobFiles\` or set \`sourceGlob\` to a narrower pattern (e.g. \`**/*.go\`) to reduce the scan footprint.`
       : "";
     const content = body + truncationNote;
     const tokens = Math.ceil(content.length / 4);

--- a/src/context/engine/pull-tools.ts
+++ b/src/context/engine/pull-tools.ts
@@ -215,10 +215,11 @@ export async function handleQueryNeighbor(
   maxTokensPerCall: number = DEFAULT_MAX_TOKENS_PER_CALL,
   resolvedTestPatterns?: import("../../test-runners/resolver").ResolvedTestPatterns,
   storyId?: string,
+  providerOptions?: { sourceGlob?: string; maxGlobFiles?: number },
 ): Promise<string> {
   budget.consume();
 
-  const provider = new CodeNeighborProvider();
+  const provider = new CodeNeighborProvider(providerOptions ?? {});
   const request: ContextRequest = {
     storyId: "_pull-tool",
     repoRoot,

--- a/src/context/engine/pull-tools.ts
+++ b/src/context/engine/pull-tools.ts
@@ -221,7 +221,7 @@ export async function handleQueryNeighbor(
 
   const provider = new CodeNeighborProvider(providerOptions ?? {});
   const request: ContextRequest = {
-    storyId: "_pull-tool",
+    storyId: storyId ?? "_pull-tool",
     repoRoot,
     packageDir: repoRoot,
     stage: "pull-tool",

--- a/src/context/engine/tool-runtime.ts
+++ b/src/context/engine/tool-runtime.ts
@@ -84,7 +84,7 @@ export function createContextToolRuntime(options: {
             getBudget(tool),
             tool.maxTokensPerCall,
             patterns,
-            undefined,
+            story.id,
             config.context?.v2?.providers,
           );
         }

--- a/src/context/engine/tool-runtime.ts
+++ b/src/context/engine/tool-runtime.ts
@@ -84,6 +84,8 @@ export function createContextToolRuntime(options: {
             getBudget(tool),
             tool.maxTokensPerCall,
             patterns,
+            undefined,
+            config.context?.v2?.providers,
           );
         }
         case "query_feature_context":

--- a/src/project/detector.ts
+++ b/src/project/detector.ts
@@ -34,7 +34,7 @@ const API_DEPS = new Set(["express", "fastify", "hono"]);
 
 // ── Language detection ────────────────────────────────────────────────────────
 
-async function detectLanguage(
+async function detectLanguageImpl(
   workdir: string,
   pkg: Record<string, unknown> | null,
 ): Promise<ProjectProfile["language"] | undefined> {
@@ -125,6 +125,12 @@ async function detectLintTool(
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
+/** Return the primary language for a package directory. Side-effect-free — no profile cache write. */
+export async function detectLanguage(packageDir: string): Promise<ProjectProfile["language"] | undefined> {
+  const pkg = await _detectorDeps.readJson(join(packageDir, "package.json"));
+  return detectLanguageImpl(packageDir, pkg);
+}
+
 /**
  * Detect project profile fields not already set in `existing`.
  * Detection priority: Go > Rust > Python > Node/Bun.
@@ -135,7 +141,7 @@ export async function detectProjectProfile(
 ): Promise<ProjectProfile> {
   const pkg = await _detectorDeps.readJson(join(workdir, "package.json"));
 
-  const language = existing.language !== undefined ? existing.language : await detectLanguage(workdir, pkg);
+  const language = existing.language !== undefined ? existing.language : await detectLanguageImpl(workdir, pkg);
 
   const type = existing.type !== undefined ? existing.type : detectType(pkg);
 

--- a/src/project/index.ts
+++ b/src/project/index.ts
@@ -1,1 +1,1 @@
-export { detectProjectProfile } from "./detector";
+export { detectProjectProfile, detectLanguage } from "./detector";

--- a/test/unit/context/engine/orchestrator-factory.test.ts
+++ b/test/unit/context/engine/orchestrator-factory.test.ts
@@ -88,21 +88,25 @@ function makeRequest(overrides: Partial<ContextRequest> = {}): ContextRequest {
 let origGitWithTimeout: typeof _gitHistoryDeps.gitWithTimeout;
 let origCodeNeighborReadFile: typeof _codeNeighborDeps.readFile;
 let origCodeNeighborGlob: typeof _codeNeighborDeps.glob;
+let origCodeNeighborDetectLanguage: typeof _codeNeighborDeps.detectLanguage;
 
 beforeEach(() => {
   origGitWithTimeout = _gitHistoryDeps.gitWithTimeout;
   origCodeNeighborReadFile = _codeNeighborDeps.readFile;
   origCodeNeighborGlob = _codeNeighborDeps.glob;
+  origCodeNeighborDetectLanguage = _codeNeighborDeps.detectLanguage;
   // Default: suppress real FS/git calls
   _gitHistoryDeps.gitWithTimeout = async () => ({ stdout: "", exitCode: 0, stderr: "" });
   _codeNeighborDeps.readFile = async () => "";
-  _codeNeighborDeps.glob = () => [];
+  _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
+  _codeNeighborDeps.detectLanguage = async () => undefined;
 });
 
 afterEach(() => {
   _gitHistoryDeps.gitWithTimeout = origGitWithTimeout;
   _codeNeighborDeps.readFile = origCodeNeighborReadFile;
   _codeNeighborDeps.glob = origCodeNeighborGlob;
+  _codeNeighborDeps.detectLanguage = origCodeNeighborDetectLanguage;
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -162,7 +166,7 @@ describe("createDefaultOrchestrator — #507 provider scope config", () => {
     const capturedGlobDirs: string[] = [];
     _codeNeighborDeps.glob = (_pattern, cwd) => {
       capturedGlobDirs.push(cwd);
-      return ["src/auth.ts"];
+      return { files: ["src/auth.ts"], truncated: false };
     };
     _codeNeighborDeps.readFile = async () => "export function auth() {}";
 
@@ -171,6 +175,19 @@ describe("createDefaultOrchestrator — #507 provider scope config", () => {
     await orchestrator.assemble(makeRequest());
 
     expect(capturedGlobDirs.some((d) => d === "/repo")).toBe(true);
+  });
+
+  test("maxGlobFiles=750 in config flows through to provider cap", async () => {
+    let capturedCap: number | undefined;
+    _codeNeighborDeps.glob = (_pattern, _cwd, _m, cap) => {
+      capturedCap = cap;
+      return { files: [], truncated: false };
+    };
+    const config = makeConfig();
+    (config.context!.v2!.providers as any).maxGlobFiles = 750;
+    const orchestrator = createDefaultOrchestrator(makeStory(), config);
+    await orchestrator.assemble(makeRequest());
+    expect(capturedCap).toBe(750);
   });
 });
 

--- a/test/unit/context/engine/providers/code-neighbor-cap.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor-cap.test.ts
@@ -1,0 +1,174 @@
+/**
+ * CodeNeighborProvider — #895 language-aware glob, configurable cap, visible truncation.
+ *
+ * Split from code-neighbor.test.ts per test-architecture.md (file exceeds 800-line limit).
+ * All filesystem I/O is intercepted via _codeNeighborDeps injection.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { CodeNeighborProvider, _codeNeighborDeps } from "../../../../../src/context/engine/providers/code-neighbor";
+import type { ContextRequest } from "../../../../../src/context/engine/types";
+import { extractTestDirs, globsToPathspec, globsToTestRegex } from "../../../../../src/test-runners/conventions";
+import type { ResolvedTestPatterns } from "../../../../../src/test-runners/resolver";
+
+function makePatterns(globs: readonly string[]): ResolvedTestPatterns {
+  return {
+    globs,
+    pathspec: globsToPathspec(globs),
+    regex: globsToTestRegex(globs),
+    testDirs: extractTestDirs(globs),
+    resolution: "root-config",
+  };
+}
+
+function makeRequest(overrides: Partial<ContextRequest> = {}): ContextRequest {
+  return {
+    storyId: "US-895",
+    repoRoot: "/repo",
+    packageDir: "/repo",
+    stage: "execution",
+    role: "implementer",
+    budgetTokens: 8_000,
+    resolvedTestPatterns: makePatterns(["test/unit/**/*.test.ts"]),
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Save / restore deps
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origFileExists: typeof _codeNeighborDeps.fileExists;
+let origReadFile: typeof _codeNeighborDeps.readFile;
+let origGlob: typeof _codeNeighborDeps.glob;
+let origDetectLanguage: typeof _codeNeighborDeps.detectLanguage;
+let origGetLogger: typeof _codeNeighborDeps.getLogger;
+let origDiscoverWorkspacePackages: typeof _codeNeighborDeps.discoverWorkspacePackages;
+
+beforeEach(() => {
+  origFileExists = _codeNeighborDeps.fileExists;
+  origReadFile = _codeNeighborDeps.readFile;
+  origGlob = _codeNeighborDeps.glob;
+  origDetectLanguage = _codeNeighborDeps.detectLanguage;
+  origGetLogger = _codeNeighborDeps.getLogger;
+  origDiscoverWorkspacePackages = _codeNeighborDeps.discoverWorkspacePackages;
+  // Quiet defaults
+  _codeNeighborDeps.fileExists = async () => false;
+  _codeNeighborDeps.readFile = async () => "";
+  _codeNeighborDeps.discoverWorkspacePackages = async () => [];
+  _codeNeighborDeps.detectLanguage = async () => undefined;
+  _codeNeighborDeps.getLogger = () => ({ debug: () => {}, warn: () => {}, info: () => {}, error: () => {} }) as any;
+});
+
+afterEach(() => {
+  _codeNeighborDeps.fileExists = origFileExists;
+  _codeNeighborDeps.readFile = origReadFile;
+  _codeNeighborDeps.glob = origGlob;
+  _codeNeighborDeps.detectLanguage = origDetectLanguage;
+  _codeNeighborDeps.getLogger = origGetLogger;
+  _codeNeighborDeps.discoverWorkspacePackages = origDiscoverWorkspacePackages;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Sets up glob spy that captures the pattern and cap arguments. */
+function spyGlob() {
+  let capturedPattern = "";
+  let capturedCap = 0;
+  _codeNeighborDeps.glob = (pattern, _cwd, _m, cap) => {
+    capturedPattern = pattern;
+    capturedCap = cap ?? 500;
+    return { files: [], truncated: false };
+  };
+  return {
+    get pattern() { return capturedPattern; },
+    get cap() { return capturedCap; },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("CodeNeighborProvider — language-aware glob and cap (#895)", () => {
+  test("derives TS glob when language=typescript", async () => {
+    _codeNeighborDeps.detectLanguage = async () => "typescript";
+    const spy = spyGlob();
+    await new CodeNeighborProvider().fetch(makeRequest({ touchedFiles: ["src/a.ts"] }));
+    expect(spy.pattern).toBe("**/*.{ts,tsx,js,jsx,mjs,cjs}");
+  });
+
+  test("derives Go glob when language=go", async () => {
+    _codeNeighborDeps.detectLanguage = async () => "go";
+    const spy = spyGlob();
+    await new CodeNeighborProvider().fetch(makeRequest({ touchedFiles: ["src/a.ts"] }));
+    expect(spy.pattern).toBe("**/*.go");
+  });
+
+  test("falls back to wide glob when language=undefined", async () => {
+    _codeNeighborDeps.detectLanguage = async () => undefined;
+    const spy = spyGlob();
+    await new CodeNeighborProvider().fetch(makeRequest({ touchedFiles: ["src/a.ts"] }));
+    expect(spy.pattern).toContain(".{ts,tsx,js,jsx,mjs,cjs,py,go,rs");
+  });
+
+  test("respects sourceGlob override — does not call detectLanguage", async () => {
+    let detectCalled = false;
+    _codeNeighborDeps.detectLanguage = async () => { detectCalled = true; return "typescript"; };
+    const spy = spyGlob();
+    await new CodeNeighborProvider({ sourceGlob: "lib/**/*.ts" }).fetch(makeRequest({ touchedFiles: ["src/a.ts"] }));
+    expect(detectCalled).toBe(false);
+    expect(spy.pattern).toBe("lib/**/*.ts");
+  });
+
+  test("respects maxGlobFiles override — passes cap to glob dep", async () => {
+    const spy = spyGlob();
+    await new CodeNeighborProvider({ maxGlobFiles: 50 }).fetch(makeRequest({ touchedFiles: ["src/a.ts"] }));
+    expect(spy.cap).toBe(50);
+  });
+
+  test("emits warn-level log on truncation with storyId, packageDir, pattern, cap, hint", async () => {
+    const warnArgs: unknown[][] = [];
+    _codeNeighborDeps.getLogger = () =>
+      ({ debug: () => {}, warn: (...a: unknown[]) => warnArgs.push(a), info: () => {}, error: () => {} }) as any;
+    // Simulate the real glob behaviour: when truncated=true it calls warn internally.
+    // We replace glob with one that calls getLogger().warn exactly as the real dep does.
+    _codeNeighborDeps.glob = (_p, _c, _m, cap, ctx) => {
+      _codeNeighborDeps.getLogger().warn("context-v2", "Reverse-dep glob cap reached — results truncated", {
+        storyId: ctx?.storyId,
+        packageDir: ctx?.packageDir,
+        pattern: _p,
+        cap,
+        hint: "Increase context.v2.providers.maxGlobFiles or narrow context.v2.providers.sourceGlob",
+      });
+      return { files: ["src/a.ts"], truncated: true };
+    };
+    await new CodeNeighborProvider().fetch(makeRequest({ touchedFiles: ["src/b.ts"] }));
+    expect(warnArgs.length).toBeGreaterThan(0);
+    const data = warnArgs[0]?.[2] as Record<string, unknown>;
+    expect(data).toHaveProperty("storyId");
+    expect(data).toHaveProperty("packageDir");
+    expect(data).toHaveProperty("pattern");
+    expect(data).toHaveProperty("cap");
+    expect(data).toHaveProperty("hint");
+  });
+
+  test("appends truncation note to chunk content when glob is truncated", async () => {
+    _codeNeighborDeps.glob = () => ({ files: ["src/a.ts"], truncated: true });
+    const result = await new CodeNeighborProvider().fetch(makeRequest({ touchedFiles: ["src/b.ts"] }));
+    const content = result.chunks[0]?.content ?? "";
+    expect(content).toContain("> Note: reverse-dep scan capped at");
+  });
+
+  test("does not warn or append note when glob is below cap", async () => {
+    const warnCalls: unknown[] = [];
+    _codeNeighborDeps.getLogger = () =>
+      ({ debug: () => {}, warn: (...a: unknown[]) => warnCalls.push(a), info: () => {}, error: () => {} }) as any;
+    _codeNeighborDeps.glob = () => ({ files: ["src/a.ts"], truncated: false });
+    const result = await new CodeNeighborProvider().fetch(makeRequest({ touchedFiles: ["src/b.ts"] }));
+    expect(warnCalls).toHaveLength(0);
+    expect(result.chunks[0]?.content ?? "").not.toContain("> Note:");
+  });
+});

--- a/test/unit/context/engine/providers/code-neighbor.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor.test.ts
@@ -42,12 +42,14 @@ let origFileExists: typeof _codeNeighborDeps.fileExists;
 let origReadFile: typeof _codeNeighborDeps.readFile;
 let origGlob: typeof _codeNeighborDeps.glob;
 let origDiscoverWorkspacePackages: typeof _codeNeighborDeps.discoverWorkspacePackages;
+let origDetectLanguage: typeof _codeNeighborDeps.detectLanguage;
 
 beforeEach(() => {
   origFileExists = _codeNeighborDeps.fileExists;
   origReadFile = _codeNeighborDeps.readFile;
   origGlob = _codeNeighborDeps.glob;
   origDiscoverWorkspacePackages = _codeNeighborDeps.discoverWorkspacePackages;
+  origDetectLanguage = _codeNeighborDeps.detectLanguage;
   // Default: no workspace packages (non-monorepo fallback)
   _codeNeighborDeps.discoverWorkspacePackages = async () => [];
 });
@@ -57,6 +59,7 @@ afterEach(() => {
   _codeNeighborDeps.readFile = origReadFile;
   _codeNeighborDeps.glob = origGlob;
   _codeNeighborDeps.discoverWorkspacePackages = origDiscoverWorkspacePackages;
+  _codeNeighborDeps.detectLanguage = origDetectLanguage;
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -89,7 +92,8 @@ function setupDeps(options: {
     const rel = path.replace("/repo/", "");
     return files[rel] ?? "";
   };
-  _codeNeighborDeps.glob = (_pattern: string, _cwd: string) => globFiles;
+  _codeNeighborDeps.glob = (_pattern: string, _cwd: string) => ({ files: globFiles, truncated: false });
+  _codeNeighborDeps.detectLanguage = async () => undefined;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -421,7 +425,7 @@ describe("CodeNeighborProvider — AC-56/AC-62 neighborScope + crossPackageDepth
     const captured: string[] = [];
     _codeNeighborDeps.glob = (_pattern: string, cwd: string) => {
       captured.push(cwd);
-      return [];
+      return { files: [], truncated: false };
     };
     _codeNeighborDeps.fileExists = async () => false;
     _codeNeighborDeps.readFile = async () => "";
@@ -508,7 +512,7 @@ describe("CodeNeighborProvider — SEC-503 path traversal prevention", () => {
       readPaths.push(p);
       return false;
     };
-    _codeNeighborDeps.glob = () => [];
+    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
 
     const p = new CodeNeighborProvider();
     await p.fetch(makeRequest({ touchedFiles: ["../../../etc/passwd", "src/valid.ts"] }));
@@ -522,7 +526,7 @@ describe("CodeNeighborProvider — SEC-503 path traversal prevention", () => {
       readPaths.push(p);
       return false;
     };
-    _codeNeighborDeps.glob = () => [];
+    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
 
     const p = new CodeNeighborProvider();
     await p.fetch(makeRequest({ touchedFiles: ["/etc/passwd", "src/valid.ts"] }));
@@ -537,7 +541,7 @@ describe("CodeNeighborProvider — SEC-503 path traversal prevention", () => {
       return true;
     };
     _codeNeighborDeps.readFile = async () => "";
-    _codeNeighborDeps.glob = () => [];
+    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
 
     const p = new CodeNeighborProvider();
     await p.fetch(makeRequest({ touchedFiles: ["../evil", "src/valid.ts"] }));
@@ -577,41 +581,43 @@ describe("CodeNeighborProvider — #508-M11 glob cap debug logging", () => {
     _codeNeighborDeps.getLogger = origGetLogger;
   });
 
-  test("logs debug when glob results are truncated at MAX_GLOB_FILES cap", () => {
-    const debugCalls: Array<[string, string, Record<string, unknown>]> = [];
+  test("logs warn when glob results are truncated at cap", () => {
+    const warnCalls: Array<[string, string, Record<string, unknown>]> = [];
     _codeNeighborDeps.getLogger = () =>
       ({
-        debug: (stage: string, msg: string, ctx: Record<string, unknown>) =>
-          debugCalls.push([stage, msg, ctx]),
-        warn: () => {},
+        debug: () => {},
+        warn: (stage: string, msg: string, ctx: Record<string, unknown>) =>
+          warnCalls.push([stage, msg, ctx]),
         info: () => {},
         error: () => {},
       }) as unknown as ReturnType<typeof _codeNeighborDeps.getLogger>;
 
-    // Call the real default glob implementation directly (not the mock from setupDeps)
-    const results = _codeNeighborDeps.glob("src/**/*.ts", tmpDir);
+    // Call the real default glob implementation directly with a small cap
+    const { files, truncated } = _codeNeighborDeps.glob("src/**/*.ts", tmpDir, [], 200);
 
-    expect(results).toHaveLength(200);
-    expect(debugCalls.length).toBeGreaterThan(0);
-    expect(debugCalls[0]?.[0]).toBe("context-v2");
-    expect(debugCalls[0]?.[2]).toMatchObject({ cap: 200 });
+    expect(files).toHaveLength(200);
+    expect(truncated).toBe(true);
+    expect(warnCalls.length).toBeGreaterThan(0);
+    expect(warnCalls[0]?.[0]).toBe("context-v2");
+    expect(warnCalls[0]?.[2]).toMatchObject({ cap: 200 });
   });
 
-  test("does not log debug when glob results are below the cap", () => {
-    const debugCalls: unknown[] = [];
+  test("does not log warn when glob results are below the cap", () => {
+    const warnCalls: unknown[] = [];
     _codeNeighborDeps.getLogger = () =>
       ({
-        debug: (...args: unknown[]) => debugCalls.push(args),
-        warn: () => {},
+        debug: () => {},
+        warn: (...args: unknown[]) => warnCalls.push(args),
         info: () => {},
         error: () => {},
       }) as unknown as ReturnType<typeof _codeNeighborDeps.getLogger>;
 
     // Only 1 file matches — well below cap
-    const results = _codeNeighborDeps.glob("src/file0.ts", tmpDir);
+    const { files, truncated } = _codeNeighborDeps.glob("src/file0.ts", tmpDir, [], 500);
 
-    expect(results.length).toBeLessThan(200);
-    expect(debugCalls.length).toBe(0);
+    expect(files.length).toBeLessThan(200);
+    expect(truncated).toBe(false);
+    expect(warnCalls.length).toBe(0);
   });
 });
 
@@ -643,28 +649,28 @@ describe("CodeNeighborProvider — glob source file exclusions", () => {
   });
 
   test("excludes node_modules/ from glob results", () => {
-    const results = _codeNeighborDeps.glob("**/*.ts", tmpDir);
-    expect(results.some((f) => f.startsWith("node_modules/"))).toBe(false);
+    const { files } = _codeNeighborDeps.glob("**/*.ts", tmpDir);
+    expect(files.some((f) => f.startsWith("node_modules/"))).toBe(false);
   });
 
   test("excludes .nax/ from glob results", () => {
-    const results = _codeNeighborDeps.glob("**/*.ts", tmpDir);
-    expect(results.some((f) => f.startsWith(".nax/"))).toBe(false);
+    const { files } = _codeNeighborDeps.glob("**/*.ts", tmpDir);
+    expect(files.some((f) => f.startsWith(".nax/"))).toBe(false);
   });
 
   test("excludes nested packages/api/.nax/ from glob results", () => {
-    const results = _codeNeighborDeps.glob("**/*.ts", tmpDir);
-    expect(results.some((f) => f.includes("/.nax/"))).toBe(false);
+    const { files } = _codeNeighborDeps.glob("**/*.ts", tmpDir);
+    expect(files.some((f) => f.includes("/.nax/"))).toBe(false);
   });
 
   test("includes files in lib/ (non-src/ layout)", () => {
-    const results = _codeNeighborDeps.glob("**/*.ts", tmpDir);
-    expect(results).toContain("lib/utils.ts");
+    const { files } = _codeNeighborDeps.glob("**/*.ts", tmpDir);
+    expect(files).toContain("lib/utils.ts");
   });
 
   test("includes files in src/ (standard layout)", () => {
-    const results = _codeNeighborDeps.glob("**/*.ts", tmpDir);
-    expect(results).toContain("src/main.ts");
+    const { files } = _codeNeighborDeps.glob("**/*.ts", tmpDir);
+    expect(files).toContain("src/main.ts");
   });
 
   test("excluded dirs do not count against MAX_GLOB_FILES cap", () => {
@@ -674,11 +680,11 @@ describe("CodeNeighborProvider — glob source file exclusions", () => {
     for (let i = 0; i < 205; i++) {
       writeFileSync(join(nmDir, `mod${i}.ts`), "");
     }
-    const results = _codeNeighborDeps.glob("**/*.ts", tmpDir);
+    const { files } = _codeNeighborDeps.glob("**/*.ts", tmpDir);
     // Real source files are still returned despite node_modules flood
-    expect(results).toContain("lib/utils.ts");
-    expect(results).toContain("src/main.ts");
-    expect(results.some((f) => f.startsWith("node_modules/"))).toBe(false);
+    expect(files).toContain("lib/utils.ts");
+    expect(files).toContain("src/main.ts");
+    expect(files.some((f) => f.startsWith("node_modules/"))).toBe(false);
   });
 
   test("respects naxIgnoreIndex matchers passed as third arg", () => {
@@ -687,9 +693,9 @@ describe("CodeNeighborProvider — glob source file exclusions", () => {
       pattern: "lib/**",
       test: (p: string) => p.startsWith("lib/"),
     };
-    const results = _codeNeighborDeps.glob("**/*.ts", tmpDir, [matcher]);
-    expect(results.some((f) => f.startsWith("lib/"))).toBe(false);
-    expect(results).toContain("src/main.ts");
+    const { files } = _codeNeighborDeps.glob("**/*.ts", tmpDir, [matcher]);
+    expect(files.some((f) => f.startsWith("lib/"))).toBe(false);
+    expect(files).toContain("src/main.ts");
   });
 });
 
@@ -702,7 +708,7 @@ describe("CodeNeighborProvider — naxIgnoreIndex threaded through fetch", () =>
     let capturedMatchers: readonly NaxIgnoreMatcher[] | undefined;
     _codeNeighborDeps.glob = (_pattern, _cwd, ignoreMatchers) => {
       capturedMatchers = ignoreMatchers;
-      return [];
+      return { files: [], truncated: false };
     };
 
     const matcher: NaxIgnoreMatcher = {
@@ -729,3 +735,4 @@ describe("CodeNeighborProvider — naxIgnoreIndex threaded through fetch", () =>
     expect(capturedMatchers).toEqual([matcher]);
   });
 });
+

--- a/test/unit/context/engine/pull-tools.test.ts
+++ b/test/unit/context/engine/pull-tools.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
   // Default: no files exist, no glob results
   _codeNeighborDeps.fileExists = async () => false;
   _codeNeighborDeps.readFile = async () => "";
-  _codeNeighborDeps.glob = () => [];
+  _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
   // Default: feature context returns null (no context.md)
   _featureContextV2Deps.createV1Provider = () => ({
     getContext: async () => null,
@@ -212,7 +212,7 @@ describe("handleQueryNeighbor", () => {
     // src/a.ts exists — sibling test is always added
     _codeNeighborDeps.fileExists = async (p) => p.includes("src/a.ts");
     _codeNeighborDeps.readFile = async () => "";
-    _codeNeighborDeps.glob = () => [];
+    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
 
     const result = await handleQueryNeighbor({ filePath: "src/a.ts" }, "/repo", makeBudget());
     expect(typeof result).toBe("string");
@@ -221,7 +221,7 @@ describe("handleQueryNeighbor", () => {
   test("returns empty string when file has no neighbors", async () => {
     // scripts/ file — no sibling test, no forward/reverse deps
     _codeNeighborDeps.fileExists = async () => false;
-    _codeNeighborDeps.glob = () => [];
+    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
     const result = await handleQueryNeighbor({ filePath: "scripts/build.ts" }, "/repo", makeBudget());
     expect(result).toBe("");
   });
@@ -230,7 +230,7 @@ describe("handleQueryNeighbor", () => {
     // Force many neighbors so content would exceed the cap
     const manyNeighbors = Array.from({ length: 20 }, (_, i) => `src/file${i}.ts`);
     _codeNeighborDeps.fileExists = async () => false;
-    _codeNeighborDeps.glob = () => manyNeighbors;
+    _codeNeighborDeps.glob = () => ({ files: manyNeighbors, truncated: false });
     _codeNeighborDeps.readFile = async (p) => {
       // Each file imports the query target
       if (manyNeighbors.some((f) => p.includes(f))) return 'import { x } from "./a"';
@@ -246,7 +246,7 @@ describe("handleQueryNeighbor", () => {
     const mockLogger = makeLogger();
     _pullToolsDeps.getLogger = () => mockLogger as any;
     _codeNeighborDeps.fileExists = async () => false;
-    _codeNeighborDeps.glob = () => [];
+    _codeNeighborDeps.glob = () => ({ files: [], truncated: false });
 
     await handleQueryNeighbor({ filePath: "src/a.ts" }, "/repo", makeBudget());
 
@@ -263,7 +263,7 @@ describe("handleQueryNeighbor", () => {
     _pullToolsDeps.getLogger = () => mockLogger as any;
     const manyNeighbors = Array.from({ length: 20 }, (_, i) => `src/file${i}.ts`);
     _codeNeighborDeps.fileExists = async () => false;
-    _codeNeighborDeps.glob = () => manyNeighbors;
+    _codeNeighborDeps.glob = () => ({ files: manyNeighbors, truncated: false });
     _codeNeighborDeps.readFile = async (p) => {
       if (manyNeighbors.some((f) => p.includes(f))) return 'import { x } from "./a"';
       return "";
@@ -281,7 +281,7 @@ describe("handleQueryNeighbor", () => {
     _pullToolsDeps.getLogger = () => mockLogger as any;
     // Simulate file with test and forward/reverse deps
     _codeNeighborDeps.fileExists = async (p) => p.includes("test/");
-    _codeNeighborDeps.glob = () => ["src/imported.ts"];
+    _codeNeighborDeps.glob = () => ({ files: ["src/imported.ts"], truncated: false });
     _codeNeighborDeps.readFile = async () => 'import { x } from "./a"';
 
     await handleQueryNeighbor({ filePath: "src/a.ts" }, "/repo", makeBudget());


### PR DESCRIPTION
## Summary

- **L1 — Language-aware glob**: `CodeNeighborProvider` now derives the reverse-dep scan glob from `detectLanguage(packageDir)` via a per-language table (`typescript → **/*.{ts,tsx,js,jsx,mjs,cjs}`, `go → **/*.go`, `python → **/*.py`, `rust → **/*.rs`). Polyglot/unknown packages fall back to the existing wide union — no regression.
- **L2 — Configurable cap**: `sourceGlob` (optional override) and `maxGlobFiles` (default raised 200 → 500) added to `CodeNeighborProviderOptions`, `context.v2.providers` Zod schema, and `ContextV2Config` runtime type. Both are tunable per-package via `.nax/mono/<pkg>/config.json`. Keys are threaded through `orchestrator-factory.ts` and `pull-tools.ts`.
- **L3 — Visible truncation**: glob cap now logs at `warn` level (was `debug`) with structured fields `storyId`, `packageDir`, `pattern`, `cap`, and an actionable `hint`. A two-line note is also appended to the chunk content after the body cap, so the agent sees the gap and knows how to fix it.

Supporting: exported `detectLanguage(packageDir)` as a cheap, side-effect-free public wrapper from `src/project/detector.ts`; added `docs/guides/context-providers.md` documenting all four `context.v2.providers.*` keys.

Closes #895.

## Test Plan

- [ ] `bun run typecheck` — passes (0 errors)
- [ ] `bun run test` — all phases pass (566 context-engine tests, full suite green)
- [ ] New `test/unit/context/engine/providers/code-neighbor-cap.test.ts` — 8 tests covering: TS glob derivation, Go glob derivation, unknown-language fallback, `sourceGlob` override (bypasses `detectLanguage`), `maxGlobFiles` cap enforcement, warn-level log with all required fields, truncation note in chunk content, no warn/note below cap
- [ ] `orchestrator-factory.test.ts` — 1 new test: `maxGlobFiles=750` flows through to provider cap
- [ ] `pull-tools.test.ts` — stale mocks updated to new `{ files, truncated }` return type; `story.id` correctly threaded as `storyId` in pull-tool path