### PR TITLE
refactor(debate): remove completeConfig — #853 already removed CompleteOptions.config

### DIFF
--- a/src/debate/runner-hybrid.ts
+++ b/src/debate/runner-hybrid.ts
@@ -6,7 +6,7 @@
 
 import type { DebateConfig } from "@/config/selectors";
 import { resolveDefaultAgent } from "../agents";
-import type { ConfiguredModel, NaxConfig } from "../config";
+import type { ConfiguredModel } from "../config";
 import { DebatePromptBuilder } from "../prompts";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import type { SessionRole } from "../runtime/session-role";
@@ -38,8 +38,6 @@ export interface HybridCtx extends DispatchContext {
   readonly stage: string;
   readonly stageConfig: DebateStageConfig;
   readonly config: DebateConfig;
-  /** TODO(#853): remove when CompleteOptions.config is eliminated at the manager boundary. */
-  readonly completeConfig?: NaxConfig;
   readonly workdir: string;
   readonly featureName: string;
   readonly timeoutSeconds: number;
@@ -332,7 +330,7 @@ export async function runHybrid(ctx: HybridCtx, prompt: string): Promise<DebateR
       proposalOutputs,
       critiqueOutputs,
       ctx.stageConfig,
-      ctx.completeConfig,
+      ctx.config,
       ctx.storyId,
       ctx.timeoutSeconds * 1000,
       ctx.workdir,

--- a/src/debate/runner-plan.ts
+++ b/src/debate/runner-plan.ts
@@ -6,7 +6,7 @@
 
 import { join } from "node:path";
 import { resolveDefaultAgent } from "../agents";
-import type { ConfiguredModel, ModelDef, NaxConfig } from "../config";
+import type { ConfiguredModel, ModelDef } from "../config";
 import type { DebateConfig } from "../config/selectors";
 import { NaxError } from "../errors";
 import { DebatePromptBuilder } from "../prompts";
@@ -31,8 +31,6 @@ interface PlanCtx extends DispatchContext {
   readonly stage: string;
   readonly stageConfig: DebateStageConfig;
   readonly config: DebateConfig;
-  /** TODO(#853): remove when CompleteOptions.config is eliminated at the manager boundary. */
-  readonly completeConfig?: NaxConfig;
 }
 
 export async function runPlan(
@@ -205,7 +203,6 @@ export async function runPlan(
       stage: ctx.stage,
       stageConfig: ctx.stageConfig,
       config: ctx.config,
-      completeConfig: ctx.completeConfig,
       workdir: opts.workdir,
       featureName: opts.feature,
       timeoutSeconds: opts.timeoutSeconds ?? 600,
@@ -238,7 +235,7 @@ export async function runPlan(
     proposalOutputs,
     critiqueOutputs,
     ctx.stageConfig,
-    ctx.completeConfig,
+    ctx.config,
     ctx.storyId,
     resolverTimeoutMs,
     opts.workdir,

--- a/src/debate/runner-stateful.ts
+++ b/src/debate/runner-stateful.ts
@@ -6,7 +6,7 @@
 
 import { resolveDefaultAgent } from "../agents";
 import type { IAgentManager } from "../agents";
-import type { ConfiguredModel, ModelDef, NaxConfig } from "../config";
+import type { ConfiguredModel, ModelDef } from "../config";
 import type { DebateConfig } from "../config/selectors";
 import { DebatePromptBuilder } from "../prompts";
 import type { DispatchContext } from "../runtime/dispatch-context";
@@ -32,8 +32,6 @@ interface StatefulCtx extends DispatchContext {
   readonly stage: string;
   readonly stageConfig: DebateStageConfig;
   readonly config: DebateConfig;
-  /** TODO(#853): remove when CompleteOptions.config is eliminated at the manager boundary. */
-  readonly completeConfig?: NaxConfig;
   readonly workdir: string;
   readonly featureName: string;
   readonly timeoutSeconds: number;
@@ -304,7 +302,7 @@ export async function runStateful(ctx: StatefulCtx, prompt: string): Promise<Deb
       proposalOutputs,
       critiqueOutputs,
       ctx.stageConfig,
-      ctx.completeConfig,
+      ctx.config,
       ctx.storyId,
       ctx.timeoutSeconds * 1000,
       ctx.workdir,

--- a/src/debate/runner.ts
+++ b/src/debate/runner.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_CONFIG } from "../config";
 import { debateConfigSelector } from "../config";
-import type { NaxConfig } from "../config";
 import type { DebateConfig } from "../config/selectors";
 import { callOp } from "../operations/call";
 import { debateProposeOp } from "../operations/debate-propose";
@@ -43,8 +42,6 @@ export class DebateRunner {
   private readonly stage: string;
   private readonly stageConfig: DebateStageConfig;
   private readonly config: DebateConfig;
-  /** TODO(#853): remove when CompleteOptions.config is eliminated at the manager boundary. */
-  private readonly completeConfig: NaxConfig | undefined;
   private readonly workdir: string;
   private readonly featureName: string;
   private readonly timeoutSeconds: number;
@@ -57,10 +54,6 @@ export class DebateRunner {
     this.stage = opts.stage;
     this.stageConfig = opts.stageConfig;
     this.config = opts.config ?? debateConfigSelector.select(DEFAULT_CONFIG);
-    // TODO(#853 Phase 2): remove with the CompleteOptions.config field. Until then,
-    // callers that pass a DebateConfig slice may not have NaxConfig keys —
-    // completeConfig stays optional and downstream guards on undefined.
-    this.completeConfig = opts.config as NaxConfig | undefined;
     this.workdir = opts.workdir ?? opts.ctx.packageDir;
     this.featureName = opts.featureName ?? opts.stage;
     this.timeoutSeconds = opts.timeoutSeconds ?? opts.stageConfig.timeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
@@ -253,7 +246,7 @@ export class DebateRunner {
       proposalOutputs,
       critiqueOutputs,
       this.stageConfig,
-      this.completeConfig,
+      this.config,
       this.ctx.storyId ?? "",
       this.timeoutSeconds * 1000,
       this.workdir,
@@ -286,7 +279,6 @@ export class DebateRunner {
       stage: this.stage,
       stageConfig: this.stageConfig,
       config: this.config,
-      completeConfig: this.completeConfig,
       workdir: this.workdir,
       featureName: this.featureName,
       timeoutSeconds: this.timeoutSeconds,
@@ -305,7 +297,6 @@ export class DebateRunner {
       stage: this.stage,
       stageConfig: this.stageConfig,
       config: this.config,
-      completeConfig: this.completeConfig,
       agentManager: this.ctx.runtime.agentManager,
       sessionManager: this.sessionManager ?? this.ctx.runtime.sessionManager,
       runtime: this.ctx.runtime,

--- a/src/debate/session-helpers.ts
+++ b/src/debate/session-helpers.ts
@@ -1,11 +1,12 @@
 import { resolveDefaultAgent } from "../agents";
 import type { IAgentManager } from "../agents";
 import type { CompleteOptions, CompleteResult } from "../agents/types";
-import type { ConfiguredModel, ModelTier, NaxConfig, ResolvedConfiguredModel } from "../config";
+import type { ConfiguredModel, ModelTier, ResolvedConfiguredModel } from "../config";
 import { DEFAULT_CONFIG, resolveConfiguredModel, resolveModelForAgent } from "../config";
 import type { PipelineStage } from "../config/permissions";
 import type { ModelsConfig } from "../config/schema-types";
 import type { ModelDef } from "../config/schema-types";
+import type { DebateConfig } from "../config/selectors";
 import { getSafeLogger } from "../logger";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import { formatSessionName } from "../session/naming";
@@ -75,7 +76,7 @@ export interface DebateSessionOptions extends DispatchContext {
   storyId: string;
   stage: string;
   stageConfig: DebateStageConfig;
-  config?: NaxConfig;
+  config?: DebateConfig;
   workdir?: string;
   featureName?: string;
   timeoutSeconds?: number;
@@ -93,7 +94,7 @@ export const _debateSessionDeps = {
 };
 
 /** Resolve the model string for a debater. Defaults to "fast" tier; falls back to raw model string on config error. */
-export function resolveDebaterModel(debater: Debater, config?: NaxConfig): string | undefined {
+export function resolveDebaterModel(debater: Debater, config?: DebateConfig): string | undefined {
   const modelSelection = { agent: debater.agent, model: debater.model ?? "fast" };
   if (!config?.models) return debater.model;
   try {
@@ -183,8 +184,7 @@ export async function resolveOutcome(
   proposalOutputs: string[],
   critiqueOutputs: string[],
   stageConfig: DebateStageConfig,
-  // TODO(#853): remove when CompleteOptions.config is eliminated at the manager boundary.
-  config: NaxConfig | undefined,
+  config: DebateConfig,
   storyId: string,
   timeoutMs: number,
   workdir: string | undefined,
@@ -301,8 +301,8 @@ export async function resolveOutcome(
     const agentName = resolverConfig.agent ?? RESOLVER_FALLBACK_AGENT;
     const manager = agentManager ?? _debateSessionDeps.agentManager;
     if (manager !== undefined && manager.getAgent(agentName) !== undefined) {
-      const configModels = config?.models ?? DEFAULT_CONFIG.models;
-      const configDefaultAgent = resolveDefaultAgent(config ?? DEFAULT_CONFIG);
+      const configModels = config.models ?? DEFAULT_CONFIG.models;
+      const configDefaultAgent = resolveDefaultAgent(config);
       const synthesisSessionName =
         workdir !== undefined ? formatSessionName({ workdir, featureName, storyId, role: "synthesis" }) : undefined;
       const resolverDebater: Debater = { agent: agentName, model: resolverConfig.model };
@@ -347,8 +347,8 @@ export async function resolveOutcome(
     if (!manager) {
       return { outcome: "passed", resolverCostUsd: 0 };
     }
-    const configModels = config?.models ?? DEFAULT_CONFIG.models;
-    const configDefaultAgent = resolveDefaultAgent(config ?? DEFAULT_CONFIG);
+    const configModels = config.models ?? DEFAULT_CONFIG.models;
+    const configDefaultAgent = resolveDefaultAgent(config);
     const judgeSessionName =
       workdir !== undefined ? formatSessionName({ workdir, featureName, storyId, role: "judge" }) : undefined;
     const resolverDebater: Debater = { agent: agentName, model: resolverConfig.model };

--- a/test/unit/debate/session-helpers-resolver-model.test.ts
+++ b/test/unit/debate/session-helpers-resolver-model.test.ts
@@ -10,11 +10,10 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { _debateSessionDeps, resolveOutcome } from "../../../src/debate/session-helpers";
 import type { CompleteOptions } from "../../../src/agents/types";
 import type { DebateStageConfig } from "../../../src/debate/types";
-import type { NaxConfig } from "../../../src/config";
+import { debateConfigSelector, DEFAULT_CONFIG } from "../../../src/config";
 import { makeMockAgentManager } from "../../helpers";
 
-// Tests use undefined config — resolveModelDefForDebater falls back to DEFAULT_CONFIG when config is absent
-const NO_CONFIG = undefined as unknown as NaxConfig;
+const DEFAULT_DEBATE_CONFIG = debateConfigSelector.select(DEFAULT_CONFIG);
 
 function makeStageConfig(
   resolverType: "synthesis" | "custom",
@@ -57,7 +56,7 @@ describe("resolveOutcome() synthesis — resolver.model → modelDef (#352)", ()
     const captured: { opts?: CompleteOptions }[] = [];
     _debateSessionDeps.agentManager = makeCaptureManager(captured);
 
-    await resolveOutcome(["proposal-a", "proposal-b"], [], makeStageConfig("synthesis", "powerful"), NO_CONFIG, "US-352", 30_000, undefined, undefined, undefined, undefined, undefined, undefined, undefined as unknown as import("../../../src/agents").IAgentManager);
+    await resolveOutcome(["proposal-a", "proposal-b"], [], makeStageConfig("synthesis", "powerful"), DEFAULT_DEBATE_CONFIG, "US-352", 30_000, undefined, undefined, undefined, undefined, undefined, undefined, undefined as unknown as import("../../../src/agents").IAgentManager);
 
     expect(captured.length).toBeGreaterThan(0);
     expect(captured[0]?.opts?.modelDef?.model).toBeDefined();
@@ -69,7 +68,7 @@ describe("resolveOutcome() synthesis — resolver.model → modelDef (#352)", ()
     const captured: { opts?: CompleteOptions }[] = [];
     _debateSessionDeps.agentManager = makeCaptureManager(captured);
 
-    await resolveOutcome(["proposal-a", "proposal-b"], [], makeStageConfig("synthesis"), NO_CONFIG, "US-352", 30_000, undefined, undefined, undefined, undefined, undefined, undefined, undefined as unknown as import("../../../src/agents").IAgentManager);
+    await resolveOutcome(["proposal-a", "proposal-b"], [], makeStageConfig("synthesis"), DEFAULT_DEBATE_CONFIG, "US-352", 30_000, undefined, undefined, undefined, undefined, undefined, undefined, undefined as unknown as import("../../../src/agents").IAgentManager);
 
     expect(captured.length).toBeGreaterThan(0);
     expect(captured[0]?.opts?.modelDef?.model).toBeDefined();
@@ -80,7 +79,7 @@ describe("resolveOutcome() synthesis — resolver.model → modelDef (#352)", ()
     const captured: { opts?: CompleteOptions }[] = [];
     _debateSessionDeps.agentManager = makeCaptureManager(captured);
 
-    await resolveOutcome(["proposal-a", "proposal-b"], [], makeStageConfig("synthesis", "sonnet"), NO_CONFIG, "US-352", 30_000, undefined, undefined, undefined, undefined, undefined, undefined, undefined as unknown as import("../../../src/agents").IAgentManager);
+    await resolveOutcome(["proposal-a", "proposal-b"], [], makeStageConfig("synthesis", "sonnet"), DEFAULT_DEBATE_CONFIG, "US-352", 30_000, undefined, undefined, undefined, undefined, undefined, undefined, undefined as unknown as import("../../../src/agents").IAgentManager);
 
     expect(captured.length).toBeGreaterThan(0);
     expect(captured[0]?.opts?.modelDef?.model).toBeDefined();
@@ -106,7 +105,7 @@ describe("resolveOutcome() custom/judge — resolver.model → modelDef (#352)",
     const captured: { opts?: CompleteOptions }[] = [];
     _debateSessionDeps.agentManager = makeCaptureManager(captured);
 
-    await resolveOutcome(["proposal-a"], [], makeStageConfig("custom", "powerful"), NO_CONFIG, "US-352", 30_000, undefined, undefined, undefined, undefined, undefined, undefined, undefined as unknown as import("../../../src/agents").IAgentManager);
+    await resolveOutcome(["proposal-a"], [], makeStageConfig("custom", "powerful"), DEFAULT_DEBATE_CONFIG, "US-352", 30_000, undefined, undefined, undefined, undefined, undefined, undefined, undefined as unknown as import("../../../src/agents").IAgentManager);
 
     expect(captured.length).toBeGreaterThan(0);
     expect(captured[0]?.opts?.modelDef?.model).toBeDefined();
@@ -117,7 +116,7 @@ describe("resolveOutcome() custom/judge — resolver.model → modelDef (#352)",
     const captured: { opts?: CompleteOptions }[] = [];
     _debateSessionDeps.agentManager = makeCaptureManager(captured);
 
-    await resolveOutcome(["proposal-a"], [], makeStageConfig("custom"), NO_CONFIG, "US-352", 30_000, undefined, undefined, undefined, undefined, undefined, undefined, undefined as unknown as import("../../../src/agents").IAgentManager);
+    await resolveOutcome(["proposal-a"], [], makeStageConfig("custom"), DEFAULT_DEBATE_CONFIG, "US-352", 30_000, undefined, undefined, undefined, undefined, undefined, undefined, undefined as unknown as import("../../../src/agents").IAgentManager);
 
     expect(captured.length).toBeGreaterThan(0);
     expect(captured[0]?.opts?.modelDef?.model).toBeDefined();

--- a/test/unit/debate/session-helpers.test.ts
+++ b/test/unit/debate/session-helpers.test.ts
@@ -18,7 +18,10 @@ import type { DebateSessionOptions } from "../../../src/debate/session-helpers";
 import { computeAcpHandle } from "../../../src/agents/acp/adapter";
 import type { CompleteOptions } from "../../../src/agents/types";
 import type { DebateStageConfig } from "../../../src/debate/types";
+import { debateConfigSelector, DEFAULT_CONFIG } from "../../../src/config";
 import { makeMockAgentManager } from "../../helpers";
+
+const DEFAULT_DEBATE_CONFIG = debateConfigSelector.select(DEFAULT_CONFIG);
 
 // Barrel re-export checks (resolveDebaterModel is also not yet in barrel — both are RED)
 import {
@@ -258,12 +261,11 @@ describe("resolveOutcome() — synthesis resolver sessionHandle (US-004 AC2)", (
     const featureName = "semantic-continuity";
     const storyId = "US-004";
 
-    // @ts-ignore — RED: resolveOutcome does not yet accept workdir/featureName params
     await resolveOutcome(
       ["proposal-a", "proposal-b"],
       ["critique-a"],
       stageConfig,
-      undefined,
+      DEFAULT_DEBATE_CONFIG,
       storyId,
       30_000,
       workdir,
@@ -286,7 +288,7 @@ describe("resolveOutcome() — synthesis resolver sessionHandle (US-004 AC2)", (
       ["proposal-a", "proposal-b"],
       ["critique-a"],
       stageConfig,
-      undefined,
+      DEFAULT_DEBATE_CONFIG,
       "US-004",
       30_000,
       // workdir intentionally omitted (AC7)
@@ -321,12 +323,11 @@ describe("resolveOutcome() — custom/judge resolver sessionHandle (US-004 AC3)"
     const featureName = "judge-feature";
     const storyId = "US-004";
 
-    // @ts-ignore — RED: resolveOutcome does not yet accept workdir/featureName params
     await resolveOutcome(
       ["proposal-a"],
       ["critique-a"],
       stageConfig,
-      undefined,
+      DEFAULT_DEBATE_CONFIG,
       storyId,
       30_000,
       workdir,
@@ -349,7 +350,7 @@ describe("resolveOutcome() — custom/judge resolver sessionHandle (US-004 AC3)"
       ["proposal-a"],
       ["critique-a"],
       stageConfig,
-      undefined,
+      DEFAULT_DEBATE_CONFIG,
       "US-004",
       30_000,
       // workdir intentionally omitted (AC7)


### PR DESCRIPTION
## Summary

- **`#853` is already done** — `CompleteOptions.config` was removed from the agent boundary. The `completeConfig` field in `DebateRunner` and its four sub-runner context types (`StatefulCtx`, `HybridCtx`, `PlanCtx`, `DebateSessionOptions`) was a bridge that became dead weight.
- `resolveOutcome`, `resolveDebaterModel`, and the sub-runner contexts only needed `config.models` and `config.agent` — both keys present in `DebateConfig = pick(debate, models, agent)`.
- All callers now pass `this.config` / `ctx.config` directly (always a non-optional `DebateConfig`, defaulting to `debateConfigSelector.select(DEFAULT_CONFIG)`).
- Removes the last `as NaxConfig` cast in the debate subsystem, closing **Step 5** of `docs/superpowers/plans/2026-05-01-eliminate-naxconfig-silent-fail-casts.md`.

## Changes

| File | Change |
|------|--------|
| `src/debate/runner.ts` | Remove `completeConfig` field + assignment; pass `this.config` to `resolveOutcome` |
| `src/debate/runner-stateful.ts` | Remove `completeConfig` from `StatefulCtx`; pass `ctx.config` |
| `src/debate/runner-hybrid.ts` | Remove `completeConfig` from `HybridCtx`; pass `ctx.config` |
| `src/debate/runner-plan.ts` | Remove `completeConfig` from `PlanCtx`; pass `ctx.config` |
| `src/debate/session-helpers.ts` | Narrow `resolveOutcome` config param to required `DebateConfig`; remove `?? DEFAULT_CONFIG` fallbacks; narrow `DebateSessionOptions.config` and `resolveDebaterModel` |
| `test/unit/debate/session-helpers*.test.ts` | Update tests that passed `undefined` config to pass `debateConfigSelector.select(DEFAULT_CONFIG)` |

## Test Plan

- [x] `bun run typecheck` — passes (0 errors)
- [x] `bun run lint` — passes
- [x] `timeout 60 bun test test/unit/debate/ test/unit/review/ --timeout=10000` — 697 pass, 0 fail