### PR TITLE
refactor(tdd): remove dead NaxConfig import from rectification-gate

### DIFF
--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -8,7 +8,7 @@
 
 import type { IAgentManager } from "../agents";
 import type { SessionHandle } from "../agents/types";
-import type { ModelTier, NaxConfig } from "../config";
+import type { ModelTier } from "../config";
 import { resolveModelForAgent } from "../config";
 import type { RectificationGateConfig } from "../config/selectors";
 import type { getLogger } from "../logger";


### PR DESCRIPTION
## Summary

- The `config as unknown as NaxConfig` cast in `src/tdd/rectification-gate.ts` was removed in #851 when `AgentRunOptions.config` was narrowed to `AgentManagerConfig` (a structural subset of `RectificationGateConfig`)
- The `NaxConfig` import that existed solely to type that cast was left behind — this PR removes the now-dead import
- Part of the eliminate-silent-fail-NaxConfig-casts plan (`docs/superpowers/plans/2026-05-01-eliminate-naxconfig-silent-fail-casts.md`, Task 6)

## Test Plan

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes
- [x] `bun test ./test/unit/tdd/rectification-gate-session.test.ts` — 6/6 pass
- [x] `bun run test` — all phases passed