### PR TITLE
fix(review): correct biome-json parser for --reporter json format

### DIFF
--- a/src/review/lint-parsing/strategies/biome-json.ts
+++ b/src/review/lint-parsing/strategies/biome-json.ts
@@ -34,7 +34,14 @@ function extractLocation(record: Record<string, unknown>): { file?: string; line
 
   const location = asRecord(record.location);
   const span = asRecord(location?.span);
-  const file = readString(location ?? {}, "path") ?? readString(span ?? {}, "path") ?? readString(span ?? {}, "file");
+
+  // Biome --reporter json: location.path is {file: "..."}, not a plain string
+  const pathObj = asRecord(location?.path);
+  const file =
+    readString(pathObj ?? {}, "file") ??
+    readString(location ?? {}, "path") ??
+    readString(span ?? {}, "path") ??
+    readString(span ?? {}, "file");
   if (!file) return {};
 
   return {
@@ -56,7 +63,11 @@ function collectDiagnostics(node: unknown, sink: LocatedDiagnostic[]): void {
 
   const category = readString(record, "category");
   const severity = readString(record, "severity");
-  const message = readString(record, "message") ?? readString(asRecord(record.description) ?? {}, "text");
+  // Biome --reporter json: "message" is a content-fragment array; "description" is the plain string
+  const message =
+    readString(record, "description") ??
+    readString(record, "message") ??
+    readString(asRecord(record.description) ?? {}, "text");
   const { file, line, column } = extractLocation(record);
   if (file && message && (category?.startsWith("lint/") || severity !== undefined)) {
     sink.push({ file, line, column, message, ruleId: category });

--- a/test/unit/review/lint-parsing-biome-json.test.ts
+++ b/test/unit/review/lint-parsing-biome-json.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { parseBiomeJson } from "../../../src/review/lint-parsing/strategies/biome-json";
+
+const REAL_BIOME_ERROR_OUTPUT =
+  '{"summary":{"changed":0,"unchanged":1,"matches":0,"duration":{"secs":0,"nanos":1203755},"errors":1,"warnings":0,"skipped":0,"suggestedFixesSkipped":0,"diagnosticsNotPrinted":0},"diagnostics":[{"category":"lint/suspicious/noDebugger","severity":"error","description":"This is an unexpected use of the debugger statement.","message":[{"elements":[],"content":"This is an unexpected use of the "},{"elements":["Emphasis"],"content":"debugger"},{"elements":[],"content":" statement."}],"advices":{"advices":[]},"verboseAdvices":{"advices":[]},"location":{"path":{"file":"/repo/src/foo.ts"},"span":[26,35],"sourceCode":"const x = 1;\\nconst y = 2;\\ndebugger;\\n"},"tags":["fixable"],"source":null}],"command":"check"}';
+
+const REAL_BIOME_CLEAN_OUTPUT =
+  '{"summary":{"changed":0,"unchanged":570,"matches":0,"duration":{"secs":0,"nanos":322154954},"errors":0,"warnings":0,"skipped":0,"suggestedFixesSkipped":0,"diagnosticsNotPrinted":0},"diagnostics":[],"command":"check"}';
+
+describe("parseBiomeJson — actual --reporter json format", () => {
+  test("parses real biome error output", () => {
+    const result = parseBiomeJson(REAL_BIOME_ERROR_OUTPUT);
+    expect(result).not.toBeNull();
+    expect(result!.format).toBe("biome-json");
+    expect(result!.diagnostics).toHaveLength(1);
+
+    const diag = result!.diagnostics[0];
+    expect(diag.file).toBe("/repo/src/foo.ts");
+    expect(diag.ruleId).toBe("lint/suspicious/noDebugger");
+    expect(diag.message).toBe("This is an unexpected use of the debugger statement.");
+  });
+
+  test("returns null for clean output with no diagnostics", () => {
+    expect(parseBiomeJson(REAL_BIOME_CLEAN_OUTPUT)).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(parseBiomeJson("")).toBeNull();
+  });
+
+  test("returns null for plain text (non-JSON)", () => {
+    expect(parseBiomeJson("Checked 570 files. No bugs found.")).toBeNull();
+  });
+
+  test("handles multiple diagnostics", () => {
+    const multi = JSON.stringify({
+      diagnostics: [
+        {
+          category: "lint/suspicious/noDebugger",
+          severity: "error",
+          description: "Unexpected debugger.",
+          message: [],
+          location: { path: { file: "/repo/src/a.ts" }, span: [0, 8] },
+        },
+        {
+          category: "lint/correctness/noUnusedVariables",
+          severity: "error",
+          description: "Variable is unused.",
+          message: [],
+          location: { path: { file: "/repo/src/b.ts" }, span: [10, 20] },
+        },
+      ],
+      command: "check",
+    });
+
+    const result = parseBiomeJson(multi);
+    expect(result).not.toBeNull();
+    expect(result!.diagnostics).toHaveLength(2);
+    expect(result!.diagnostics[0].file).toBe("/repo/src/a.ts");
+    expect(result!.diagnostics[1].file).toBe("/repo/src/b.ts");
+  });
+});


### PR DESCRIPTION
## Summary

- Fix `parseBiomeJson` which silently produced zero diagnostics on actual `biome check --reporter json` output
- Two bugs fixed: `location.path` is a nested object `{file: "..."}` not a plain string, and `message` is a content-fragment array while the human-readable text lives in `description`
- Add unit tests covering real biome output, clean (no-error) output, plain text fallback, and multiple diagnostics

## Root cause

The parser was written expecting a hypothetical format. Actual biome `--reporter json` output (verified on biome ^1.9.4, confirmed compatible with v2) uses:
- `description`: plain string — the human-readable message
- `message`: array of `{elements, content}` fragments — not a string
- `location.path`: object `{file: "..."}` — not a plain string
- `location.span`: byte-offset array `[start, end]` — no line/column (line/column are undefined, which is acceptable)

## Test plan

- [ ] `timeout 30 bun test test/unit/review/lint-parsing-biome-json.test.ts --timeout=5000` — 5 tests pass
- [ ] `bun run typecheck` — no errors
- [ ] `bun run lint` — clean