### PR TITLE
Issue 928: add self-verification gate wiring across TDD and single-session flows

### DIFF
--- a/docs/specs/2026-05-06-issue-928-self-verification-plan.md
+++ b/docs/specs/2026-05-06-issue-928-self-verification-plan.md
@@ -1,0 +1,347 @@
+# Issue 928 Plan: Self-Verification Gates Across Execution Strategies
+
+## Context
+
+Issue #928 proposes a self-verification gate so coding agents catch lint and typecheck-class mistakes before handing control back to nax. nax already has hard lint/typecheck enforcement in the review stage; this issue is about moving obvious failures earlier, into the agent handoff, so they do not cost a full review/autofix or rectification round. The first pass at this plan only covered the three-session TDD roles (`test-writer` and `implementer`). That is incomplete.
+
+nax currently has two execution families:
+
+| Family | `testStrategy` values | Runtime path | Prompt role |
+|---|---|---|---|
+| Three-session TDD | `three-session-tdd`, `three-session-tdd-lite` | `executionStage` -> `runThreeSessionTddFromCtx()` -> `runTddSessionOp()` -> `runTddSession()` | `test-writer`, `implementer`, `verifier` |
+| Single-session | `no-test`, `test-after`, `tdd-simple` | `promptStage` builds one prompt, then `executionStage` runs one agent session | `no-test` for no-test stories; currently `tdd-simple` for both `test-after` and `tdd-simple` |
+
+There is also a `PromptRole: "single-session"` and a `buildRoleTaskSection("single-session")` template, but the current pipeline path does not use that prompt role for single-story runtime execution. It remains supported by prompt export, overrides, tests, and historical compatibility. Runtime single-session strategies are represented by `no-test`, `test-after`, and `tdd-simple`.
+
+`test-after` and `tdd-simple` can share the `tdd-simple` prompt role. `no-test` must stay on the dedicated `no-test` prompt role because it explicitly means no behavioral test creation or modification. Its self-verification gate is still useful, but only for static checks on whatever non-test files the story legitimately changed.
+
+## Relevant Code
+
+- `src/pipeline/stages/execution.ts`
+  - branches `three-session-tdd` and `three-session-tdd-lite` into `runThreeSessionTddFromCtx()`
+  - all other strategies use the one-session path with `ctx.prompt`
+  - single-session agent runs use `sessionRole: "implementer"`
+- `src/pipeline/stages/prompt.ts`
+  - disabled for three-session TDD
+  - builds prompts for `no-test`, `test-after`, `tdd-simple`, and batch
+  - currently maps `test-after` and `tdd-simple` to `PromptBuilder.for("tdd-simple")`
+- `src/tdd/session-runner.ts`
+  - builds the three TDD role prompts internally
+  - already computes `filesChanged` from `git diff` after each role
+  - records `TddSessionResult` for scratch through `recordTddSessionOutcome`
+- `src/tdd/orchestrator-ctx.ts`
+  - writes per-role TDD scratch entries when context v2 is enabled
+- `src/test-runners/resolver.ts`
+  - exports `findPackageDir(filePath, workdir)` for monorepo package boundary detection
+- `src/project/detector.ts`
+  - exports `detectLanguage(packageDir)`
+- `src/quality/runner.ts`
+  - shared process runner for configured quality commands
+- `src/quality/command-resolver.ts`
+  - currently resolves test commands only; lint/typecheck self-verification needs a sibling resolver
+- `src/review/runner.ts`
+  - already resolves and runs configured lint/typecheck/build/test review checks as hard quality gates
+  - #928 must not duplicate review ownership; it should reduce avoidable failures before review runs
+
+## Design Goal
+
+Add a self-verification contract once, then wire it into every agent role that creates or modifies code or tests:
+
+- three-session TDD `test-writer`
+- three-session TDD `implementer`
+- single-session `no-test` for lint/typecheck only, not test execution or test creation
+- single-session `test-after`
+- single-session `tdd-simple`
+- batch implementer, because batch sessions also create code and tests
+
+Do not add this gate to the three-session `verifier`. The verifier should inspect and report. It should not be asked to fix its own diff.
+
+This is an early feedback mechanism, not the authoritative quality gate. The review stage remains the hard enforcement point for configured lint/typecheck checks.
+
+## Key Decision
+
+Use a two-layer design:
+
+1. Prompt-level self-verification instructions tell the agent what it must run before declaring completion.
+2. Harness-level parsing and logging records the result, especially `PRE_EXISTING_FAILURES`, so downstream stages can distinguish "my changed file failed" from "unrelated existing debt".
+
+Do not rely only on prompt text. The prompt tells the agent what to do, but nax should parse and surface the declared outcome in structured run state.
+
+## Scope Rules
+
+`CHANGED` means files created or modified by the current agent turn, scoped to the current package.
+
+For three-session TDD, `runTddSession()` already receives `beforeRef` for the specific TDD role and calls `getChangedFiles(workdir, beforeRef)` after the role completes. This is the right baseline for `CHANGED`.
+
+For single-session execution, use `ctx.storyGitRef` when present, falling back to the captured pre-execution ref used by the existing pipeline. The execution stage already auto-commits after a successful single-session run, so parsing must happen before any future cleanup mutates the visible output. Changed-file calculation can happen after the run, before or near the existing `autoCommitIfDirty()` call.
+
+For monorepos, bucket changed files with `findPackageDir(file, ctx.projectDir)` or the appropriate repo root for the active worktree. Do not use naive path prefixes. If the current story has `story.workdir`, only files resolving to that package should be considered in-scope for that story. Other packages should become pre-existing or cross-package contamination notes, not blockers for the current story.
+
+## Command Resolution
+
+Create a new quality resolver, for example `src/quality/self-verification-resolver.ts`.
+
+Responsibilities:
+
+- Accept effective story config, repo root, package dir, role/strategy, and changed files.
+- Resolve the active package with `findPackageDir`.
+- Detect language with `detectLanguage(packageDir)`.
+- Read configured commands from `config.quality.commands.lint` and `config.quality.commands.typecheck`.
+- Do not hard-code tool names in the prompt.
+- Return a structured plan:
+
+```ts
+interface SelfVerificationPlan {
+  packageDir: string;
+  language?: string;
+  changedFiles: string[];
+  lint?: {
+    command: string;
+    scope: "changed-files";
+    files: string[];
+  };
+  typecheck?: {
+    command: string;
+    scope: "package" | "changed-files";
+  };
+  skipped: Array<{
+    tool: "lint" | "typecheck";
+    reason: "unconfigured" | "no-changed-files" | "unsupported-scope";
+  }>;
+}
+```
+
+The first implementation can be conservative:
+
+- lint: changed-file scoped when a lint command is configured and changed files exist
+- typecheck: package scoped when a typecheck command is configured
+- no config: skip with an explicit logged note
+
+Future language-specific changed-file typecheck support can extend the resolver without changing prompt call sites.
+
+## Prompt Section
+
+Add `src/prompts/sections/self-verification.ts` with a pure builder:
+
+```ts
+export function buildSelfVerificationSection(input: SelfVerificationPromptInput): string;
+```
+
+Inject it in `TddPromptBuilder.build()` after hermetic/isolation rules and before context/conventions. This is late enough to be operationally visible but still before the final story reminder.
+
+Roles receiving the section:
+
+- `test-writer`
+- `implementer`
+- `no-test`
+- `tdd-simple`
+- `single-session`
+- `batch`
+
+Roles not receiving it:
+
+- `verifier`
+
+The section should tell the agent:
+
+- compute or inspect the changed files for this turn
+- run the configured lint and typecheck gates if present
+- fix failures in changed files
+- do not modify unrelated files
+- if a configured check fails only outside changed files, emit `PRE_EXISTING_FAILURES`
+- if a gate is unconfigured, emit skip status rather than failing
+- end with a strict marker block:
+
+```text
+SELF_VERIFICATION:
+lint: pass|skip|pre_existing|fail
+typecheck: pass|skip|pre_existing|fail
+PRE_EXISTING_FAILURES: []
+```
+
+The prompt should include command labels and scope, not language/tool brand names. If commands are missing, it should explicitly say the gate is skipped because it is unconfigured.
+
+## Three-Session TDD Wiring
+
+Update `runTddSession()` in `src/tdd/session-runner.ts`.
+
+Build-time:
+
+- pass self-verification prompt input to `PromptBuilder.for("test-writer")`
+- pass self-verification prompt input to `PromptBuilder.for("implementer")`
+- do not pass it to `PromptBuilder.for("verifier")`
+
+Run-result handling:
+
+- parse `result.output` for `SELF_VERIFICATION`
+- include parsed data on `TddSessionResult`
+- keep `success` behavior conservative:
+  - if the agent explicitly reports `fail` for lint/typecheck on changed files, mark the session unsuccessful or attach a failure category that routes to rectification
+  - if it reports `pre_existing`, keep the session result successful but surface the data
+  - if no marker appears, initially warn rather than hard-fail behind a feature flag
+
+Scratch:
+
+- extend `TddSessionScratchEntry` with optional `selfVerification`
+- write parsed `PRE_EXISTING_FAILURES` through the existing scratch path in `src/tdd/orchestrator-ctx.ts`
+
+## Single-Session Wiring
+
+Update `promptStage` and `executionStage`.
+
+Prompt build:
+
+- `no-test`: inject the section into `PromptBuilder.for("no-test")`, with wording that preserves the no-tests contract and only asks for configured static checks
+- `test-after`: inject the section into the current runtime prompt role, which is `PromptBuilder.for("tdd-simple")`
+- `tdd-simple`: inject the section into `PromptBuilder.for("tdd-simple")`
+- batch: inject the section into `PromptBuilder.for("batch")`
+
+Execution result:
+
+- parse `ctx.agentResult.output`
+- store parsed result on `ctx.selfVerification` or a similar new `PipelineContext` field
+- append to the main session scratch entry when context v2 is enabled
+- log `PRE_EXISTING_FAILURES` as a separate structured field, not as a story failure
+
+Important: `test-after` and `tdd-simple` currently share the `tdd-simple` prompt role, and that is acceptable for this issue. `no-test` should not share that role because it must not receive RED-phase or test-writing instructions.
+
+## Data Types
+
+Add shared types, likely in `src/quality/self-verification.ts` or `src/quality/types.ts`:
+
+```ts
+export type SelfVerificationTool = "lint" | "typecheck";
+export type SelfVerificationStatus = "pass" | "skip" | "pre_existing" | "fail";
+
+export interface PreExistingFailure {
+  packageDir: string;
+  file?: string;
+  tool: SelfVerificationTool;
+  message: string;
+}
+
+export interface SelfVerificationResult {
+  lint: SelfVerificationStatus;
+  typecheck: SelfVerificationStatus;
+  preExistingFailures: PreExistingFailure[];
+  rawMarker?: string;
+  missingMarker?: boolean;
+}
+```
+
+Add:
+
+- `TddSessionResult.selfVerification?: SelfVerificationResult`
+- `PipelineContext.selfVerification?: SelfVerificationResult`
+- `TddSessionScratchEntry.selfVerification?: SelfVerificationResult`
+- a new scratch entry kind for single-session execution if the existing scratch model does not already have an execution-session entry
+
+## Parser
+
+Add `parseSelfVerificationMarker(output: string): SelfVerificationResult`.
+
+Keep the parser permissive enough for real agent output:
+
+- find the last `SELF_VERIFICATION:` block
+- parse `lint:` and `typecheck:` statuses case-insensitively
+- parse `PRE_EXISTING_FAILURES:` as JSON when possible
+- if JSON parsing fails, preserve the raw line as a message under `preExistingFailures`
+- if no marker exists, return `{ missingMarker: true, lint: "skip", typecheck: "skip", preExistingFailures: [] }` and let rollout policy decide warning vs failure
+
+## Rollout Policy
+
+Use a feature flag or config option for enforcement. Suggested default for first release:
+
+- inject prompt section by default when commands are configured
+- parse and log always
+- warn on missing marker
+- do not hard-fail missing marker until at least one release has prompt-audit data
+- hard-fail only explicit `fail` on changed files
+- never hard-fail `pre_existing`
+
+This avoids destabilizing runs while still collecting enough data to tune the marker format.
+
+## Tests
+
+Unit tests:
+
+- `test/unit/prompts/sections/self-verification.test.ts`
+  - renders configured lint and typecheck
+  - renders skip path when unconfigured
+  - does not name hard-coded tool brands
+  - includes strict marker format
+- `test/unit/prompts/builders/tdd-builder.test.ts`
+  - includes section for `test-writer`
+  - includes section for `implementer`
+  - includes section for `no-test`
+  - includes section for `tdd-simple`
+  - includes section for `batch`
+  - excludes section for `verifier`
+- `test/unit/quality/self-verification-resolver.test.ts`
+  - single repo changed files
+  - monorepo same-package changed files
+  - monorepo cross-package contamination
+  - skip when lint/typecheck commands are absent
+- `test/unit/quality/self-verification-parser.test.ts`
+  - parses pass/skip/fail/pre_existing
+  - parses JSON `PRE_EXISTING_FAILURES`
+  - handles malformed JSON without throwing
+  - handles missing marker
+- `test/unit/tdd/session-runner.test.ts`
+  - test-writer result includes parsed self-verification
+  - implementer result includes parsed self-verification
+  - verifier does not require marker
+- `test/unit/pipeline/stages/prompt-tdd-simple.test.ts`
+  - `test-after` prompt includes the section through the current `tdd-simple` role
+  - `tdd-simple` prompt includes the section
+  - `no-test` prompt includes the static-check section without test-writing or test-running instructions
+- `test/unit/pipeline/stages/execution-tdd-simple.test.ts`
+  - single-session execution parses and stores the marker
+  - explicit changed-file failure escalates or fails according to the rollout policy
+  - pre-existing failure logs but continues
+
+Integration tests:
+
+- one single-package fixture with configured lint/typecheck
+- one monorepo fixture with two packages where package B has lint debt and package A is the active story
+- one three-session-lite fixture where test-writer creates a source stub and self-verification is scoped to that role's changed files
+
+## Documentation
+
+Update `docs/architecture/subsystems.md` under:
+
+- TDD orchestration
+- Prompt / execution strategy descriptions
+- Review and quality subsystem notes
+
+The docs should say:
+
+- self-verification is an agent-turn handoff contract
+- it is not a replacement for review, verify, or autofix
+- review remains the hard lint/typecheck enforcement stage
+- `PRE_EXISTING_FAILURES` is observability, not a story failure
+- lint/typecheck command names come from config, not hard-coded prompt text
+
+## Decisions
+
+1. `test-after` continues to use the `tdd-simple` prompt role for #928.
+   - This is accepted. `test-after` and `tdd-simple` can share self-verification wording.
+   - `no-test` remains separate and must not receive test-writing or RED-phase instructions.
+2. Missing `SELF_VERIFICATION` marker warns first.
+   - Do not hard-fail a story only because the agent omitted the marker in the first implementation.
+   - Log the missing marker as structured observability so prompt compliance can be measured before enforcement.
+3. nax does not add a second post-agent harness-run gate in the first #928 slice.
+   - "Post-agent verification" would mean nax itself runs lint/typecheck after the agent returns, using the same `CHANGED` scope, regardless of whether the agent claims it already ran them.
+   - nax already runs hard lint/typecheck checks in the review stage, so adding another immediate harness-run gate would duplicate enforcement unless it also solved story-scoped filtering.
+   - A separate story-scoped harness gate overlaps with #931 because it needs robust changed-file/package scoping and cross-package contamination handling.
+   - For #928, implement prompt self-verification plus structured parsing/logging. Review remains the hard quality gate.
+
+## Proposed Implementation Order
+
+1. Add shared self-verification types and parser.
+2. Add resolver for package/language/config scoped self-verification prompt input.
+3. Add prompt section and inject it into all non-verifier roles.
+4. Wire three-session TDD parsing and scratch output.
+5. Wire single-session parsing and pipeline context output.
+6. Add tests for prompt coverage, parser, resolver, and strategy wiring.
+7. Update architecture docs.

--- a/src/context/engine/providers/session-scratch.ts
+++ b/src/context/engine/providers/session-scratch.ts
@@ -99,8 +99,15 @@ function renderEntry(
         const tail = neutralizeForAgent(entry.outputTail.trim(), entry.writtenByAgent ?? "", targetAgentId ?? "");
         lines.push("```", tail, "```");
       }
+      if (entry.selfVerification) {
+        lines.push(
+          `Self-verify: lint=${entry.selfVerification.lint}, typecheck=${entry.selfVerification.typecheck}, pre_existing=${entry.selfVerification.preExistingFailures.length}`,
+        );
+      }
       return lines.join("\n");
     }
+    case "self-verification":
+      return `**Self-verify** at ${entry.timestamp}: lint=${entry.selfVerification.lint}, typecheck=${entry.selfVerification.typecheck}, pre_existing=${entry.selfVerification.preExistingFailures.length}`;
     default:
       return JSON.stringify(entry);
   }

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -16,7 +16,10 @@ import { buildInteractionBridge } from "../../interaction/bridge-builder";
 import { checkMergeConflict, checkStoryAmbiguity, isTriggerEnabled } from "../../interaction/triggers";
 import { getLogger } from "../../logger";
 import { buildHopCallback } from "../../operations/build-hop-callback";
+import { parseSelfVerificationMarker } from "../../quality";
+import { appendScratchEntry } from "../../session/scratch-writer";
 import { runThreeSessionTddFromCtx } from "../../tdd";
+import { errorMessage } from "../../utils/errors";
 import { autoCommitIfDirty, detectMergeConflict } from "../../utils/git";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 import { isAmbiguousOutput, routeTddFailure } from "./execution-helpers";
@@ -233,6 +236,8 @@ export const executionStage: PipelineStage = {
     const result = await effectiveManager.run(request);
 
     ctx.agentResult = result;
+    ctx.selfVerification = parseSelfVerificationMarker(result.output ?? "", ctx.workdir);
+    const selfVerificationFailed = ctx.selfVerification.lint === "fail" || ctx.selfVerification.typecheck === "fail";
     const fallbacks = result.agentFallbacks ?? [];
 
     ctx.agentSwapCount = fallbacks.length;
@@ -246,6 +251,34 @@ export const executionStage: PipelineStage = {
         hop: f.hop,
         costUsd: f.costUsd,
       }));
+    }
+
+    if (ctx.config.context?.v2?.enabled && ctx.sessionScratchDir) {
+      try {
+        await appendScratchEntry(ctx.sessionScratchDir, {
+          kind: "self-verification",
+          timestamp: new Date().toISOString(),
+          storyId: ctx.story.id,
+          stage: "execution",
+          role: "implementer",
+          selfVerification: ctx.selfVerification,
+          writtenByAgent: ctx.routing?.agent ?? ctx.agentManager?.getDefault() ?? "claude",
+        });
+      } catch (scratchErr) {
+        logger.warn("execution", "Failed to write self-verification scratch entry — continuing", {
+          storyId: ctx.story.id,
+          error: errorMessage(scratchErr),
+        });
+      }
+    }
+
+    if (selfVerificationFailed) {
+      logger.warn("execution", "Self-verification reported explicit failure", {
+        storyId: ctx.story.id,
+        lint: ctx.selfVerification.lint,
+        typecheck: ctx.selfVerification.typecheck,
+      });
+      return { action: "escalate", reason: "Self-verification reported lint/typecheck failure" };
     }
 
     // @design: BUG-058: Auto-commit if agent left uncommitted changes (single-session/test-after)

--- a/src/pipeline/stages/prompt.ts
+++ b/src/pipeline/stages/prompt.ts
@@ -25,6 +25,7 @@ import { assembleForStage } from "../../context/engine";
 import { getLogger } from "../../logger";
 import { PromptBuilder } from "../../prompts";
 import type { AcceptanceEntry } from "../../prompts/sections/acceptance";
+import { resolveSelfVerificationPromptInput } from "../../quality";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
 
 export const _promptStageDeps = {
@@ -69,6 +70,7 @@ export const promptStage: PipelineStage = {
 
     // AC6–AC8: load acceptance test file content from ctx.acceptanceTestPaths
     const acceptanceEntries = await _loadAcceptanceEntries(ctx, logger);
+    const selfVerification = await resolveSelfVerificationPromptInput(ctx.config, ctx.workdir);
 
     // Assemble a stage-specific v2 bundle for the execution stage so the agent receives
     // the correct role/provider/budget context (Finding 1 fix).  Falls back to null when
@@ -89,7 +91,8 @@ export const promptStage: PipelineStage = {
         .featureContext(execBundle ? undefined : (ctx.featureContextMarkdown ?? ""))
         .constitution(ctx.constitution?.content)
         .testCommand(ctx.config.quality?.commands?.test)
-        .hermeticConfig(ctx.config.quality?.testing);
+        .hermeticConfig(ctx.config.quality?.testing)
+        .selfVerification(selfVerification);
       if (acceptanceEntries.length > 0) builder.acceptanceContext(acceptanceEntries);
       prompt = await builder.build();
     } else {
@@ -104,6 +107,7 @@ export const promptStage: PipelineStage = {
         .constitution(ctx.constitution?.content)
         .testCommand(ctx.config.quality?.commands?.test)
         .hermeticConfig(ctx.config.quality?.testing)
+        .selfVerification(selfVerification)
         .noTestJustification(ctx.story.routing?.noTestJustification);
       if (acceptanceEntries.length > 0) builder.acceptanceContext(acceptanceEntries);
       prompt = await builder.build();

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -161,6 +161,8 @@ export interface PipelineContext extends DispatchContext {
   prompt?: string;
   /** Agent execution result (set by executionStage) */
   agentResult?: AgentResult;
+  /** Parsed self-verification marker from the latest execution session. */
+  selfVerification?: import("../quality").SelfVerificationResult;
   /** Verify result (set by verifyStage) */
   verifyResult?: VerifyResult;
   /** Review result (set by reviewStage) */

--- a/src/prompts/builders/tdd-builder.ts
+++ b/src/prompts/builders/tdd-builder.ts
@@ -25,6 +25,7 @@ import type { PromptLoaderConfig } from "../../config/selectors";
 import type { NaxConfig } from "../../config/types";
 import { filterContextByRole, truncateToContextBudget } from "../../context";
 import type { UserStory } from "../../prd";
+import type { SelfVerificationPromptInput } from "../../quality/self-verification";
 import { SectionAccumulator } from "../core";
 import type { PromptOptions, PromptRole, PromptSection } from "../core";
 import { universalConstitutionSection, universalContextSection } from "../core";
@@ -36,6 +37,7 @@ import {
   buildHermeticSection,
   buildIsolationSection,
   buildRoleTaskSection,
+  buildSelfVerificationSection,
   buildStoryReminderSection,
   buildStorySection,
   buildTddLanguageSection,
@@ -60,6 +62,7 @@ export class TddPromptBuilder {
   private hermeticConfig_: { hermetic?: boolean; externalBoundaries?: string[]; mockGuidance?: string } | undefined;
   private noTestJustification_: string | undefined;
   private acceptanceEntries_: AcceptanceEntry[] | undefined;
+  private selfVerification_: SelfVerificationPromptInput | undefined;
 
   private constructor(role: PromptRole, options: PromptOptions = {}) {
     this.role = role;
@@ -144,6 +147,11 @@ export class TddPromptBuilder {
     return this;
   }
 
+  selfVerification(input: SelfVerificationPromptInput | undefined): this {
+    this.selfVerification_ = input;
+    return this;
+  }
+
   /**
    * Compose and return the final prompt string.
    *
@@ -217,6 +225,11 @@ export class TddPromptBuilder {
         this.loaderConfig_?.project,
       );
       if (hermeticSection) acc.add(this.s("hermetic", hermeticSection));
+    }
+
+    if (this.role !== "verifier") {
+      const selfVerify = buildSelfVerificationSection(this.role, this.selfVerification_);
+      if (selfVerify) acc.add(this.s("self-verification", selfVerify));
     }
 
     // (7) Context markdown

--- a/src/prompts/sections/index.ts
+++ b/src/prompts/sections/index.ts
@@ -13,3 +13,4 @@ export { buildConventionsSection } from "./conventions";
 export { buildTddLanguageSection } from "./tdd-conventions";
 export { buildAcceptanceSection } from "./acceptance";
 export type { AcceptanceEntry } from "./acceptance";
+export { buildSelfVerificationSection } from "./self-verification";

--- a/src/prompts/sections/self-verification.ts
+++ b/src/prompts/sections/self-verification.ts
@@ -1,0 +1,43 @@
+import type { SelfVerificationPromptInput } from "../../quality/self-verification";
+
+const CHECK_HEADER = "# Self-Verification Gate";
+
+function commandLine(label: "lint" | "typecheck", command: string | undefined): string {
+  if (!command) return `- ${label}: unconfigured -> report \`skip\``;
+  return `- ${label}: run \`${command}\``;
+}
+
+function roleSpecificLine(role: string): string {
+  if (role === "no-test") {
+    return "- Keep the no-test contract: do not create or modify behavioral tests in this step.";
+  }
+  return "- Use this gate before you declare your turn complete.";
+}
+
+export function buildSelfVerificationSection(role: string, input: SelfVerificationPromptInput | undefined): string {
+  if (!input) return "";
+
+  const lines = [
+    CHECK_HEADER,
+    "",
+    "Before you finish, run static checks for your own changes in this package.",
+    `- packageDir: \`${input.packageDir}\``,
+    input.language ? `- language: \`${input.language}\`` : "- language: unknown",
+    roleSpecificLine(role),
+    "- Scope: changed files from this turn (`CHANGED`) inside this package.",
+    commandLine("lint", input.lintCommand),
+    commandLine("typecheck", input.typecheckCommand),
+    "- If a configured check fails on files in CHANGED: fix and rerun.",
+    "- If a configured check fails only on files outside CHANGED: do not edit those files; report them under PRE_EXISTING_FAILURES.",
+    "",
+    "End your response with exactly this block:",
+    "```text",
+    "SELF_VERIFICATION:",
+    "lint: pass|skip|pre_existing|fail",
+    "typecheck: pass|skip|pre_existing|fail",
+    "PRE_EXISTING_FAILURES: []",
+    "```",
+  ];
+
+  return lines.join("\n");
+}

--- a/src/quality/index.ts
+++ b/src/quality/index.ts
@@ -8,3 +8,14 @@ export { runQualityCommand } from "./runner";
 export type { QualityCommandOptions, QualityCommandResult } from "./runner";
 export { resolveQualityTestCommands, _commandResolverDeps } from "./command-resolver";
 export type { ResolvedTestCommands } from "./command-resolver";
+export {
+  parseSelfVerificationMarker,
+  resolveSelfVerificationPromptInput,
+} from "./self-verification";
+export type {
+  PreExistingFailure,
+  SelfVerificationPromptInput,
+  SelfVerificationResult,
+  SelfVerificationStatus,
+  SelfVerificationTool,
+} from "./self-verification";

--- a/src/quality/self-verification.ts
+++ b/src/quality/self-verification.ts
@@ -1,0 +1,159 @@
+import type { NaxConfig } from "../config";
+import { detectLanguage } from "../project";
+
+export type SelfVerificationTool = "lint" | "typecheck";
+export type SelfVerificationStatus = "pass" | "skip" | "pre_existing" | "fail";
+
+export interface PreExistingFailure {
+  packageDir: string;
+  file?: string;
+  tool: SelfVerificationTool;
+  message: string;
+}
+
+export interface SelfVerificationResult {
+  lint: SelfVerificationStatus;
+  typecheck: SelfVerificationStatus;
+  preExistingFailures: PreExistingFailure[];
+  rawMarker?: string;
+  missingMarker?: boolean;
+}
+
+export interface SelfVerificationPromptInput {
+  packageDir: string;
+  language?: string;
+  lintCommand?: string;
+  typecheckCommand?: string;
+}
+
+interface MarkerParseState {
+  lint?: SelfVerificationStatus;
+  typecheck?: SelfVerificationStatus;
+  preExistingRaw?: string;
+  rawMarker: string;
+}
+
+const STATUS_SET = new Set<SelfVerificationStatus>(["pass", "skip", "pre_existing", "fail"]);
+
+function parseStatus(value: string | undefined): SelfVerificationStatus | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase() as SelfVerificationStatus;
+  return STATUS_SET.has(normalized) ? normalized : undefined;
+}
+
+function parseMarkerBlock(output: string): MarkerParseState | undefined {
+  const idx = output.lastIndexOf("SELF_VERIFICATION:");
+  if (idx < 0) return undefined;
+  const lines = output.slice(idx).split("\n");
+  const consumed: string[] = [];
+  const state: MarkerParseState = { rawMarker: "" };
+  let started = false;
+  let fieldsSeen = 0;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!started) {
+      if (trimmed !== "SELF_VERIFICATION:") continue;
+      started = true;
+      consumed.push(line);
+      continue;
+    }
+    if (trimmed.startsWith("# ") || trimmed.startsWith("## ")) break;
+    if (trimmed.startsWith("```")) break;
+    if (trimmed.length === 0 && fieldsSeen > 0) {
+      consumed.push(line);
+      continue;
+    }
+    consumed.push(line);
+    if (trimmed.toLowerCase().startsWith("lint:")) {
+      state.lint = parseStatus(trimmed.slice("lint:".length));
+      fieldsSeen++;
+      continue;
+    }
+    if (trimmed.toLowerCase().startsWith("typecheck:")) {
+      state.typecheck = parseStatus(trimmed.slice("typecheck:".length));
+      fieldsSeen++;
+      continue;
+    }
+    if (trimmed.toLowerCase().startsWith("pre_existing_failures:")) {
+      state.preExistingRaw = trimmed.slice("pre_existing_failures:".length).trim();
+      fieldsSeen++;
+    }
+  }
+  state.rawMarker = consumed.join("\n").trim();
+  return state;
+}
+
+function parsePreExisting(
+  raw: string | undefined,
+  packageDir: string,
+  lint: SelfVerificationStatus,
+  typecheck: SelfVerificationStatus,
+): PreExistingFailure[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const out: PreExistingFailure[] = [];
+    for (const item of parsed) {
+      if (!item || typeof item !== "object") continue;
+      const row = item as Record<string, unknown>;
+      const normalizedTool: SelfVerificationTool | undefined =
+        row.tool === "lint" || row.tool === "typecheck" ? (row.tool as SelfVerificationTool) : undefined;
+      const message = typeof row.message === "string" ? row.message : "";
+      if (!normalizedTool || !message) continue;
+      out.push({
+        packageDir: typeof row.packageDir === "string" ? row.packageDir : packageDir,
+        file: typeof row.file === "string" ? row.file : undefined,
+        tool: normalizedTool,
+        message,
+      });
+    }
+    return out;
+  } catch {
+    const fallbackTool: SelfVerificationTool =
+      typecheck === "pre_existing" && lint !== "pre_existing" ? "typecheck" : "lint";
+    return [
+      {
+        packageDir,
+        tool: fallbackTool,
+        message: raw,
+      },
+    ];
+  }
+}
+
+export function parseSelfVerificationMarker(output: string, packageDir = "."): SelfVerificationResult {
+  const parsed = parseMarkerBlock(output);
+  if (!parsed) {
+    return {
+      lint: "skip",
+      typecheck: "skip",
+      preExistingFailures: [],
+      missingMarker: true,
+    };
+  }
+  return {
+    lint: parsed.lint ?? "skip",
+    typecheck: parsed.typecheck ?? "skip",
+    preExistingFailures: parsePreExisting(
+      parsed.preExistingRaw,
+      packageDir,
+      parsed.lint ?? "skip",
+      parsed.typecheck ?? "skip",
+    ),
+    rawMarker: parsed.rawMarker,
+    missingMarker: false,
+  };
+}
+
+export async function resolveSelfVerificationPromptInput(
+  config: Pick<NaxConfig, "quality">,
+  packageDir: string,
+): Promise<SelfVerificationPromptInput> {
+  return {
+    packageDir,
+    language: await detectLanguage(packageDir),
+    lintCommand: config.quality?.commands?.lint,
+    typecheckCommand: config.quality?.commands?.typecheck,
+  };
+}

--- a/src/session/scratch-writer.ts
+++ b/src/session/scratch-writer.ts
@@ -65,11 +65,28 @@ export interface TddSessionScratchEntry {
   filesChanged: string[];
   /** Tail of agent output for lightweight cross-session continuity */
   outputTail: string;
+  /** Parsed self-verification output from the agent. */
+  selfVerification?: import("../quality").SelfVerificationResult;
   /** Agent id that produced this entry. For cross-agent scratch neutralization (AC-42). */
   writtenByAgent?: string;
 }
 
-export type ScratchEntry = VerifyScratchEntry | RectifyScratchEntry | TddSessionScratchEntry;
+/** Entry written by single-session execution after parsing self-verification marker */
+export interface SelfVerificationScratchEntry {
+  kind: "self-verification";
+  timestamp: string;
+  storyId: string;
+  stage: string;
+  role: "implementer";
+  selfVerification: import("../quality").SelfVerificationResult;
+  writtenByAgent?: string;
+}
+
+export type ScratchEntry =
+  | VerifyScratchEntry
+  | RectifyScratchEntry
+  | TddSessionScratchEntry
+  | SelfVerificationScratchEntry;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Injectable deps

--- a/src/tdd/orchestrator-ctx.ts
+++ b/src/tdd/orchestrator-ctx.ts
@@ -132,6 +132,7 @@ export async function runThreeSessionTddFromCtx(
           success: result.success,
           filesChanged: result.filesChanged,
           outputTail: result.outputTail ?? "",
+          selfVerification: result.selfVerification,
           writtenByAgent: ctx.routing?.agent ?? ctx.agentManager?.getDefault() ?? "claude",
         });
 

--- a/src/tdd/session-runner.ts
+++ b/src/tdd/session-runner.ts
@@ -14,6 +14,7 @@ import type { InteractionBridge } from "../interaction/bridge-builder";
 import { getLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { PromptBuilder } from "../prompts";
+import { parseSelfVerificationMarker, resolveSelfVerificationPromptInput } from "../quality";
 import type { ISessionManager } from "../session/types";
 import { autoCommitIfDirty as _autoCommitIfDirtyFn } from "../utils/git";
 import { captureGitRef as _captureGitRef } from "../utils/git";
@@ -139,6 +140,7 @@ export async function runTddSession(
   abortSignal?: AbortSignal,
 ): Promise<TddSessionResult> {
   const startTime = Date.now();
+  const selfVerification = await resolveSelfVerificationPromptInput(config, workdir);
 
   // Build prompt — use injectable buildPrompt if set, otherwise default PromptBuilder.
   // When a v2 ContextBundle is available, .v2FeatureContext() injects pushMarkdown directly
@@ -169,6 +171,7 @@ export async function runTddSession(
           .constitution(constitution)
           .testCommand(config.quality?.commands?.test)
           .hermeticConfig(config.quality?.testing)
+          .selfVerification(selfVerification)
           .build();
         break;
       case "implementer":
@@ -181,6 +184,7 @@ export async function runTddSession(
           .constitution(constitution)
           .testCommand(config.quality?.commands?.test)
           .hermeticConfig(config.quality?.testing)
+          .selfVerification(selfVerification)
           .build();
         break;
       case "verifier":
@@ -323,6 +327,10 @@ export async function runTddSession(
   const filesChanged = await _sessionRunnerDeps.getChangedFiles(workdir, beforeRef);
 
   const durationMs = Date.now() - startTime;
+  const selfVerificationResult =
+    role === "verifier" ? undefined : parseSelfVerificationMarker(result.output, selfVerification.packageDir);
+  const selfVerificationFailed =
+    selfVerificationResult?.lint === "fail" || selfVerificationResult?.typecheck === "fail";
 
   if (isolation && !isolation.passed) {
     logger.error("tdd", "Isolation violated", {
@@ -353,12 +361,13 @@ export async function runTddSession(
 
   return {
     role,
-    success: result.success && (!isolation || isolation.passed),
+    success: result.success && (!isolation || isolation.passed) && !selfVerificationFailed,
     isolation,
     filesChanged,
     durationMs,
     estimatedCostUsd: result.estimatedCostUsd,
     tokenUsage: result.tokenUsage,
     outputTail: result.output.slice(-500),
+    selfVerification: selfVerificationResult,
   };
 }

--- a/src/tdd/types.ts
+++ b/src/tdd/types.ts
@@ -61,6 +61,8 @@ export interface TddSessionResult {
   error?: string;
   /** Tail of the agent output for cross-session continuity/debugging */
   outputTail?: string;
+  /** Agent-declared self-verification status (Issue #928). */
+  selfVerification?: import("../quality").SelfVerificationResult;
   /** Number of tests written/passed/failed */
   tests?: {
     total: number;

--- a/test/unit/pipeline/stages/execution-tdd-simple.test.ts
+++ b/test/unit/pipeline/stages/execution-tdd-simple.test.ts
@@ -205,6 +205,32 @@ describe("executionStage — tdd-simple strategy", () => {
     expect(ctx.tddFailureCategory).toBeUndefined();
     expect(result.action).toBe("continue");
   });
+
+  test("explicit self-verification fail returns escalate", async () => {
+    const agent = makeAgentAdapter({
+      name: "test-agent",
+      capabilities: {
+        supportedTiers: ["fast", "balanced", "powerful"],
+        maxContextTokens: 100_000,
+        features: new Set<"tdd" | "review" | "refactor" | "batch">(),
+      },
+      openSession: mock(async () => ({ id: "mock-session", agentName: "test-agent" })),
+      sendTurn: mock(async () => ({
+        output: "SELF_VERIFICATION:\nlint: fail\ntypecheck: pass\nPRE_EXISTING_FAILURES: []",
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        internalRoundTrips: 1,
+      })),
+      closeSession: mock(async () => {}),
+    });
+    _executionDeps.getAgent = mock(() => agent as unknown as ReturnType<typeof _executionDeps.getAgent>);
+    _executionDeps.validateAgentForTier = mock(() => true);
+    _executionDeps.detectMergeConflict = mock(() => false);
+
+    const ctx = makeCtx("tdd-simple");
+    const result = await executionStage.execute(ctx);
+
+    expect(result.action).toBe("escalate");
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/prompts/sections/self-verification.test.ts
+++ b/test/unit/prompts/sections/self-verification.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { buildSelfVerificationSection } from "../../../../src/prompts/sections/self-verification";
+
+describe("buildSelfVerificationSection", () => {
+  test("renders commands when configured", () => {
+    const section = buildSelfVerificationSection("implementer", {
+      packageDir: "/repo/packages/api",
+      language: "typescript",
+      lintCommand: "bun run lint",
+      typecheckCommand: "bun run typecheck",
+    });
+    expect(section).toContain("# Self-Verification Gate");
+    expect(section).toContain("`bun run lint`");
+    expect(section).toContain("`bun run typecheck`");
+    expect(section).toContain("SELF_VERIFICATION:");
+  });
+
+  test("renders skip messaging for unconfigured commands", () => {
+    const section = buildSelfVerificationSection("implementer", {
+      packageDir: "/repo/packages/api",
+      language: "typescript",
+      lintCommand: undefined,
+      typecheckCommand: undefined,
+    });
+    expect(section).toContain("lint: unconfigured");
+    expect(section).toContain("typecheck: unconfigured");
+  });
+
+  test("preserves no-test contract language", () => {
+    const section = buildSelfVerificationSection("no-test", {
+      packageDir: "/repo",
+      language: "typescript",
+      lintCommand: "bun run lint",
+      typecheckCommand: "bun run typecheck",
+    });
+    expect(section).toContain("Keep the no-test contract");
+    expect(section).not.toContain("RED phase");
+  });
+});

--- a/test/unit/quality/self-verification.test.ts
+++ b/test/unit/quality/self-verification.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { parseSelfVerificationMarker } from "../../../src/quality/self-verification";
+
+describe("parseSelfVerificationMarker", () => {
+  test("parses explicit marker statuses", () => {
+    const output = `
+some output
+SELF_VERIFICATION:
+lint: pass
+typecheck: pre_existing
+PRE_EXISTING_FAILURES: [{"packageDir":"packages/api","file":"src/x.ts","tool":"typecheck","message":"existing error"}]
+`;
+    const parsed = parseSelfVerificationMarker(output, "packages/api");
+    expect(parsed.missingMarker).toBe(false);
+    expect(parsed.lint).toBe("pass");
+    expect(parsed.typecheck).toBe("pre_existing");
+    expect(parsed.preExistingFailures).toHaveLength(1);
+    expect(parsed.preExistingFailures[0]?.tool).toBe("typecheck");
+  });
+
+  test("returns missing marker when block is absent", () => {
+    const parsed = parseSelfVerificationMarker("plain output", "packages/web");
+    expect(parsed.missingMarker).toBe(true);
+    expect(parsed.lint).toBe("skip");
+    expect(parsed.typecheck).toBe("skip");
+    expect(parsed.preExistingFailures).toEqual([]);
+  });
+
+  test("keeps malformed PRE_EXISTING_FAILURES as raw fallback message", () => {
+    const output = `
+SELF_VERIFICATION:
+lint: pre_existing
+typecheck: skip
+PRE_EXISTING_FAILURES: [broken
+`;
+    const parsed = parseSelfVerificationMarker(output, "packages/api");
+    expect(parsed.preExistingFailures).toHaveLength(1);
+    expect(parsed.preExistingFailures[0]?.message).toContain("[broken");
+    expect(parsed.preExistingFailures[0]?.tool).toBe("lint");
+  });
+
+  test("infers typecheck fallback tool when typecheck is pre_existing", () => {
+    const output = `
+SELF_VERIFICATION:
+lint: skip
+typecheck: pre_existing
+PRE_EXISTING_FAILURES: [broken
+`;
+    const parsed = parseSelfVerificationMarker(output, "packages/api");
+    expect(parsed.preExistingFailures[0]?.tool).toBe("typecheck");
+  });
+
+  test("parses marker even when blank lines appear inside block", () => {
+    const output = `
+SELF_VERIFICATION:
+lint: pass
+
+typecheck: pass
+PRE_EXISTING_FAILURES: []
+
+next text
+`;
+    const parsed = parseSelfVerificationMarker(output, "packages/api");
+    expect(parsed.lint).toBe("pass");
+    expect(parsed.typecheck).toBe("pass");
+  });
+});

--- a/test/unit/tdd/session-runner-tokens.test.ts
+++ b/test/unit/tdd/session-runner-tokens.test.ts
@@ -128,6 +128,42 @@ describe("runTddSession — tokenUsage (#590)", () => {
 
     expect(outcome.tokenUsage).toBeUndefined();
   });
+
+  test("captures selfVerification for implementer output", async () => {
+    const agent = makeAgent({
+      output: "SELF_VERIFICATION:\nlint: pass\ntypecheck: pass\nPRE_EXISTING_FAILURES: []",
+    });
+    const outcome = await runTddSession(
+      "implementer",
+      agent as never,
+      fakeAgentManager(agent as never),
+      makeStory(),
+      makeConfig(),
+      "/tmp/fake",
+      "balanced",
+      "HEAD",
+    );
+    expect(outcome.selfVerification?.lint).toBe("pass");
+    expect(outcome.selfVerification?.typecheck).toBe("pass");
+  });
+
+  test("marks session unsuccessful when selfVerification reports fail", async () => {
+    const agent = makeAgent({
+      output: "SELF_VERIFICATION:\nlint: fail\ntypecheck: pass\nPRE_EXISTING_FAILURES: []",
+    });
+    const outcome = await runTddSession(
+      "implementer",
+      agent as never,
+      fakeAgentManager(agent as never),
+      makeStory(),
+      makeConfig(),
+      "/tmp/fake",
+      "balanced",
+      "HEAD",
+    );
+    expect(outcome.selfVerification?.lint).toBe("fail");
+    expect(outcome.success).toBe(false);
+  });
 });
 
 describe("runTddSession — state transitions via runInSession (#589)", () => {


### PR DESCRIPTION
## What

Implements Issue #928 self-verification gate wiring across three-session TDD and single-session execution flows.

## Why

This reduces avoidable review/autofix or rectification rounds by catching lint/typecheck-class issues earlier at agent handoff time, while keeping review as the hard quality gate.

Closes #928

## How

- Added shared self-verification parsing/resolution utilities in `src/quality/self-verification.ts` and re-exported from `src/quality/index.ts`.
- Added a non-overridable prompt section builder in `src/prompts/sections/self-verification.ts`, exported from `src/prompts/sections/index.ts`.
- Injected self-verification prompt section for non-verifier roles via `src/prompts/builders/tdd-builder.ts`.
- Wired single-session prompt construction in `src/pipeline/stages/prompt.ts` to provide self-verification input.
- Wired TDD session flow in `src/tdd/session-runner.ts`:
  - parse `SELF_VERIFICATION` marker output for test-writer/implementer
  - mark session unsuccessful on explicit `lint/typecheck: fail`
  - carry parsed result in `TddSessionResult` (`src/tdd/types.ts`)
- Wired single-session execution flow in `src/pipeline/stages/execution.ts`:
  - parse marker into `ctx.selfVerification` (`src/pipeline/types.ts`)
  - persist self-verification scratch entry
  - escalate on explicit `lint/typecheck: fail`
- Extended scratch/context surfacing:
  - scratch entry model updates in `src/session/scratch-writer.ts`
  - TDD scratch write-through in `src/tdd/orchestrator-ctx.ts`
  - session scratch rendering in `src/context/engine/providers/session-scratch.ts`
- Added/updated tests:
  - `test/unit/quality/self-verification.test.ts`
  - `test/unit/prompts/sections/self-verification.test.ts`
  - `test/unit/tdd/session-runner-tokens.test.ts`
  - `test/unit/pipeline/stages/execution-tdd-simple.test.ts`

## Testing

- [x] Tests added/updated
- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- `test-after` continues to use the `tdd-simple` prompt role (accepted decision for this issue).
- `no-test` remains on dedicated `no-test` prompt role and is not given test-writing instructions.
- Missing marker remains warn-first (`missingMarker=true`) while explicit self-verification `fail` is actionable.
- Executed targeted tests:
  - `bun test test/unit/quality/self-verification.test.ts`
  - `bun test test/unit/prompts/sections/self-verification.test.ts`
  - `bun test test/unit/tdd/session-runner-tokens.test.ts`
  - `bun test test/unit/pipeline/stages/execution-tdd-simple.test.ts`
  - `bun test test/unit/pipeline/stages/prompt-tdd-simple.test.ts`
