### PR TITLE
feat(review): require verbatim AC quote in findings + integrity-check escalation excerpts

### DIFF
--- a/src/execution/escalation/quote-integrity.ts
+++ b/src/execution/escalation/quote-integrity.ts
@@ -1,0 +1,132 @@
+/**
+ * Escalation Quote Integrity Check (Issue #930 Part 2)
+ *
+ * When an implementer or reviewer emits an escalation reason that quotes
+ * file content (any string matching `<file>:<line>` followed by a quoted
+ * snippet), the harness verifies those quotes against the file at HEAD.
+ *
+ * Unverified quotes are replaced with `<UNVERIFIED_QUOTE>` so fabricated
+ * evidence does not propagate into priorErrors and bias the next-tier agent.
+ *
+ * This is a lightweight string-search check, not semantic analysis.
+ * It catches the "LLM invents a quote to justify its position" failure mode
+ * described in Issue #930 Pattern B.
+ */
+
+import { getSafeLogger } from "../../logger";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface QuoteTriple {
+  file: string;
+  line: number;
+  quote: string;
+}
+
+/** Injectable deps for testing without touching the filesystem. */
+export const _quoteIntegrityDeps = {
+  readFile: async (path: string): Promise<string | null> => {
+    try {
+      return await Bun.file(path).text();
+    } catch {
+      return null;
+    }
+  },
+};
+
+// ─── Extraction ───────────────────────────────────────────────────────────────
+
+/**
+ * Pattern: `some/file.ts:42` followed (on the same line) by a quoted snippet
+ * in backticks or double-quotes.
+ *
+ * Capture groups: 1=file, 2=line, 3=backtick-quote, 4=double-quote-quote
+ */
+export function extractQuoteTriples(reason: string): QuoteTriple[] {
+  const re = /([a-zA-Z0-9_./-]+\.[a-zA-Z0-9]+):(\d+)[^\n`"]*(?:(?:`([^`\n]{3,120})`)|(?:"([^"\n]{3,120})"))/g;
+  const triples: QuoteTriple[] = [];
+  for (;;) {
+    const match = re.exec(reason);
+    if (match === null) break;
+    const file = match[1];
+    const line = Number.parseInt(match[2], 10);
+    const quote = (match[3] ?? match[4] ?? "").trim();
+    if (file && !Number.isNaN(line) && quote.length >= 3) {
+      triples.push({ file, line, quote });
+    }
+  }
+  return triples;
+}
+
+// ─── Verification ─────────────────────────────────────────────────────────────
+
+const CONTEXT_LINES = 3;
+
+/** Collapse whitespace for comparison (mirrors AC quote validator normalisation). */
+function normalizeWs(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Verify a single (file, line, quote) triple against the file on disk.
+ * Reads workdir/file and checks whether `quote` appears (whitespace-normalised)
+ * within ±CONTEXT_LINES of the cited line number.
+ */
+export async function verifyQuoteTriple(
+  triple: QuoteTriple,
+  workdir: string,
+  deps = _quoteIntegrityDeps,
+): Promise<boolean> {
+  const absPath = `${workdir}/${triple.file}`;
+  const content = await deps.readFile(absPath);
+  if (content === null) return false;
+
+  const lines = content.split("\n");
+  const start = Math.max(0, triple.line - 1 - CONTEXT_LINES);
+  const end = Math.min(lines.length, triple.line + CONTEXT_LINES);
+  const window = lines.slice(start, end).join("\n");
+
+  return normalizeWs(window).toLowerCase().includes(normalizeWs(triple.quote).toLowerCase());
+}
+
+// ─── Main verifier ────────────────────────────────────────────────────────────
+
+/**
+ * Scan an escalation reason for (file, line, quote) citations and verify each
+ * against the repo at HEAD.
+ *
+ * Unverified quotes are replaced with `<UNVERIFIED_QUOTE>` in the returned
+ * string. A warning is logged for each substitution so the next-tier agent
+ * cannot inherit fabricated evidence.
+ *
+ * When no citations are found the original reason is returned unchanged.
+ */
+export async function verifyEscalationQuotes(
+  reason: string,
+  workdir: string,
+  storyId: string,
+  deps = _quoteIntegrityDeps,
+): Promise<string> {
+  const triples = extractQuoteTriples(reason);
+  if (triples.length === 0) return reason;
+
+  const logger = getSafeLogger();
+  let verified = reason;
+
+  for (const triple of triples) {
+    const ok = await verifyQuoteTriple(triple, workdir, deps);
+    if (!ok) {
+      logger?.warn("escalation", "escalation_quote_unverified — replacing with <UNVERIFIED_QUOTE>", {
+        storyId,
+        file: triple.file,
+        line: triple.line,
+        quote: triple.quote.slice(0, 80),
+      });
+      // Replace only the quoted text; leave the file:line citation so the
+      // next-tier agent still knows which locus was contested.
+      verified = verified.replaceAll(triple.quote, "<UNVERIFIED_QUOTE>");
+    }
+  }
+
+  return verified;
+}

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -19,6 +19,7 @@ import type { FailureCategory } from "../../tdd/types";
 import { calculateMaxIterations, escalateTier, getTierConfig } from "../escalation";
 import { hookCtx } from "../helpers";
 import { appendProgress } from "../progress";
+import { verifyEscalationQuotes } from "./quote-integrity";
 import { handleMaxAttemptsReached, handleNoTierAvailable } from "./tier-outcome";
 
 /** Build a StructuredFailure for tier escalation. */
@@ -341,7 +342,14 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
     }
   }
 
-  const pipelineReason = ctx.pipelineResult.reason ? `: ${ctx.pipelineResult.reason}` : "";
+  // Issue #930 Part 2: verify any (file, line, quote) triples in the escalation reason
+  // before propagating to priorErrors. Fabricated quotes are replaced with <UNVERIFIED_QUOTE>.
+  const rawPipelineReason = ctx.pipelineResult.reason ?? "";
+  const verifiedPipelineReason = rawPipelineReason
+    ? await verifyEscalationQuotes(rawPipelineReason, ctx.workdir, ctx.story.id)
+    : rawPipelineReason;
+
+  const pipelineReason = verifiedPipelineReason ? `: ${verifiedPipelineReason}` : "";
   const errorMessage = `Attempt ${ctx.story.attempts + 1} failed with model tier: ${ctx.routing.modelTier}${ctx.isBatchExecution ? " (in batch)" : ""}${pipelineReason}`;
 
   const updatedPrd = {

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -123,7 +123,9 @@ Respond with ONLY a JSON object — no preamble, no explanation outside the JSON
       "file": "relative/path/to/file.ts",
       "line": 42,
       "issue": "Precise description of the weakness",
-      "suggestion": "Concrete fix or mitigation"
+      "suggestion": "Concrete fix or mitigation",
+      "acQuote": "<verbatim substring of one AC bullet constraining this locus — required for 'error'>",
+      "acIndex": 2
     }
   ]
 }
@@ -136,7 +138,13 @@ Severity guide:
 - \`"unverifiable"\`: suspect problem but couldn't confirm from available artifacts
 
 \`passed\` must be \`false\` if any finding has severity \`"error"\` or \`"warning"\`.
-\`passed\` may be \`true\` with findings if all findings are \`"info"\` or \`"unverifiable"\`.`;
+\`passed\` may be \`true\` with findings if all findings are \`"info"\` or \`"unverifiable"\`.
+
+**AC-grounding rule — required for every "error" finding:**
+- \`acQuote\` must be a verbatim substring of one AC bullet (from the Acceptance Criteria above) that names or constrains the exact file, function, or symbol you are flagging.
+- \`acIndex\` is the 1-based position of that AC bullet in the list.
+- If no AC bullet mentions the file, function, or symbol being flagged, emit the finding as \`"info"\` instead — it cannot block the story.
+- Do not paraphrase the AC text — copy it exactly.`;
 
 /**
  * Build the diff section for "ref" mode.

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -31,6 +31,12 @@ For each acceptance criterion, verify the current codebase implements it correct
 - Every "error" finding must include verifiedBy evidence from the current codebase. If you cannot provide verifiedBy, downgrade the finding to "unverifiable".
 - The \`verifiedBy.observed\` field MUST be a **verbatim** 1-3 line code excerpt copy-pasted from the file — not a description. Paste the actual source lines (or a substring of them) that prove your claim. A description like "function X does not check Y" is not a verifiable observation; quote the lines that demonstrate the omission instead. If you cannot quote an exact excerpt that proves your point, downgrade the finding to "unverifiable".
 
+**AC-grounding rule — required for every "error" finding:**
+- Every "error" finding MUST include \`acQuote\`: a verbatim substring of one AC bullet that names or constrains the exact file, function, or symbol you are flagging.
+- Include \`acIndex\` (1-based) indicating which AC bullet you are quoting.
+- If no AC bullet mentions the file, function, or symbol being flagged, the finding is out-of-scope. Emit it as \`severity: "info"\` instead — it cannot block the story.
+- Copy \`acQuote\` directly from the Acceptance Criteria text — do not paraphrase.
+
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)
 2. The implementation contradicts what the AC specifies
@@ -49,6 +55,8 @@ const SEMANTIC_OUTPUT_SCHEMA = `Respond with JSON only — no explanation text b
       "line": 42,
       "issue": "description of the issue",
       "suggestion": "how to fix it",
+      "acQuote": "<verbatim substring of one AC bullet constraining this locus — required for 'error'>",
+      "acIndex": 3,
       "verifiedBy": {
         "command": "command used to inspect the current codebase",
         "file": "path/to/file",
@@ -59,6 +67,9 @@ const SEMANTIC_OUTPUT_SCHEMA = `Respond with JSON only — no explanation text b
   ]
 }
 
+Notes:
+- \`acQuote\` and \`acIndex\` are required when severity is "error". Omit them for "warning", "info", "unverifiable".
+- \`acIndex\` is 1-based (AC 1 = first bullet in the Acceptance Criteria list above).
 If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.`;
 
 // ─── Options ──────────────────────────────────────────────────────────────────

--- a/src/review/ac-quote-validator.ts
+++ b/src/review/ac-quote-validator.ts
@@ -1,0 +1,161 @@
+/**
+ * AC Quote Validator (Issue #930 Part 1)
+ *
+ * Validates that reviewer "error" findings are grounded in the story's acceptance
+ * criteria. Ungrounded findings are dropped before they can block a story or bias
+ * next-tier escalation context.
+ *
+ * Rules (per issue spec):
+ * 1. acQuote must be a whitespace-normalised substring of acceptanceCriteria[acIndex-1].
+ * 2. acQuote must contain at least one keyword from the flagged locus (file basename or
+ *    first meaningful token of the issue message).
+ * 3. Only findings with severity "error" or "critical" are subject to validation.
+ *    Warnings, info, and unverifiable pass through unchanged.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Minimum shape required for AC-quote validation — satisfied by both LLMFinding and AdversarialLLMFinding. */
+export interface AcQuotable {
+  severity: string;
+  file?: string;
+  issue: string;
+  acQuote?: string;
+  acIndex?: number;
+}
+
+export type AcQuoteRejectionCode =
+  | "missing_ac_quote"
+  | "ac_index_out_of_range"
+  | "ac_quote_not_substring"
+  | "ac_quote_does_not_constrain_locus";
+
+export interface AcQuoteValidationResult {
+  valid: boolean;
+  code?: AcQuoteRejectionCode;
+}
+
+/** Finding types that require acQuote validation. */
+const BLOCKING_SEVERITIES = new Set(["error", "critical"]);
+
+// ─── Normalisation ────────────────────────────────────────────────────────────
+
+/** Collapse runs of whitespace (including newlines) to a single space, trim. */
+function normalizeWs(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+// ─── Locus extraction ─────────────────────────────────────────────────────────
+
+/**
+ * Extract candidate keywords from the flagged locus.
+ * Uses the file basename (without extension) and the first identifier-like token
+ * from the issue message. Both must be at least 3 chars to avoid false positives
+ * on common short tokens like "is", "no", "at".
+ */
+function extractLocusKeywords(finding: AcQuotable): string[] {
+  const keywords: string[] = [];
+
+  // File basename without extension (e.g. "ac-quote-validator" from path)
+  if (finding.file) {
+    const basename = finding.file.split("/").pop() ?? "";
+    const stem = basename.replace(/\.[^.]+$/, "");
+    // Also try each dash/underscore segment as a keyword
+    for (const part of stem.split(/[-_]/)) {
+      if (part.length >= 3) keywords.push(part.toLowerCase());
+    }
+  }
+
+  // First identifier-like token from the issue text (camelCase split + words)
+  if (finding.issue) {
+    const tokens = finding.issue
+      .replace(/[`'"]/g, " ")
+      .split(/[\s,.()\[\]{}:;]+/)
+      .filter((t) => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(t) && t.length >= 3);
+    // Include only the first few tokens — later tokens tend to be generic verbs
+    for (const t of tokens.slice(0, 3)) {
+      keywords.push(t.toLowerCase());
+    }
+  }
+
+  return [...new Set(keywords)];
+}
+
+// ─── Core validator ───────────────────────────────────────────────────────────
+
+/**
+ * Validate a single LLM finding's acQuote against the story's acceptance criteria.
+ *
+ * Returns { valid: true } when:
+ * - Severity is not blocking (warning / info / unverifiable) — no validation needed.
+ * - acQuote is present, is a substring of the indexed AC, and contains a locus keyword.
+ *
+ * Returns { valid: false, code } otherwise.
+ */
+export function validateAcQuote(finding: AcQuotable, acceptanceCriteria: string[]): AcQuoteValidationResult {
+  // Non-blocking severities bypass AC-quote validation
+  if (!BLOCKING_SEVERITIES.has(finding.severity)) {
+    return { valid: true };
+  }
+
+  const { acQuote, acIndex } = finding;
+
+  if (!acQuote || typeof acQuote !== "string" || acQuote.trim() === "") {
+    return { valid: false, code: "missing_ac_quote" };
+  }
+
+  if (typeof acIndex !== "number" || acIndex < 1 || acIndex > acceptanceCriteria.length) {
+    return { valid: false, code: "ac_index_out_of_range" };
+  }
+
+  const acText = normalizeWs(acceptanceCriteria[acIndex - 1]);
+  const normalizedQuote = normalizeWs(acQuote);
+
+  if (!acText.toLowerCase().includes(normalizedQuote.toLowerCase())) {
+    return { valid: false, code: "ac_quote_not_substring" };
+  }
+
+  const keywords = extractLocusKeywords(finding);
+  if (keywords.length === 0) {
+    return { valid: false, code: "ac_quote_does_not_constrain_locus" };
+  }
+
+  const quoteLower = normalizedQuote.toLowerCase();
+  if (!keywords.some((kw) => quoteLower.includes(kw))) {
+    return { valid: false, code: "ac_quote_does_not_constrain_locus" };
+  }
+
+  return { valid: true };
+}
+
+// ─── Batch filter ─────────────────────────────────────────────────────────────
+
+export interface AcQuoteFilterResult<T extends AcQuotable> {
+  /** Findings that passed validation (or were non-blocking, so skipped). */
+  accepted: T[];
+  /** Findings dropped due to failed validation. */
+  dropped: { finding: T; code: AcQuoteRejectionCode }[];
+}
+
+/**
+ * Filter a list of LLM findings, dropping blocking findings whose acQuote
+ * fails validation. Non-blocking findings always pass through.
+ */
+export function filterByAcQuote<T extends AcQuotable>(
+  findings: T[],
+  acceptanceCriteria: string[],
+): AcQuoteFilterResult<T> {
+  const accepted: T[] = [];
+  const dropped: { finding: T; code: AcQuoteRejectionCode }[] = [];
+
+  for (const finding of findings) {
+    const result = validateAcQuote(finding, acceptanceCriteria);
+    if (result.valid) {
+      accepted.push(finding);
+    } else {
+      dropped.push({ finding, code: result.code as AcQuoteRejectionCode });
+    }
+  }
+
+  return { accepted, dropped };
+}

--- a/src/review/adversarial-helpers.ts
+++ b/src/review/adversarial-helpers.ts
@@ -17,6 +17,14 @@ export interface AdversarialLLMFinding {
   line: number;
   issue: string;
   suggestion: string;
+  /**
+   * Verbatim substring of the AC bullet that constrains this finding's locus.
+   * Required for severity "error" / "critical" (Issue #930 Part 1).
+   * Validated by filterByAcQuote() before findings reach the story blocker pipeline.
+   */
+  acQuote?: string;
+  /** 1-based index into story.acceptanceCriteria corresponding to acQuote. */
+  acIndex?: number;
 }
 
 export interface AdversarialLLMResponse {
@@ -71,14 +79,20 @@ export function normalizeSeverity(sev: string): FindingSeverity {
 
 /** Convert AdversarialLLMFinding[] to Finding[] with adversarial-review source. */
 export function toAdversarialReviewFindings(findings: AdversarialLLMFinding[]): Finding[] {
-  return findings.map((f) => ({
-    source: "adversarial-review",
-    severity: normalizeSeverity(f.severity),
-    category: f.category,
-    file: f.file,
-    line: f.line,
-    message: f.issue,
-    suggestion: f.suggestion,
-    fixTarget: f.category === "test-gap" ? "test" : undefined,
-  }));
+  return findings.map((f) => {
+    const metaExtras: Record<string, unknown> = {};
+    if (f.acQuote) metaExtras.acQuote = f.acQuote;
+    if (f.acIndex != null) metaExtras.acIndex = f.acIndex;
+    return {
+      source: "adversarial-review",
+      severity: normalizeSeverity(f.severity),
+      category: f.category,
+      file: f.file,
+      line: f.line,
+      message: f.issue,
+      suggestion: f.suggestion,
+      fixTarget: f.category === "test-gap" ? "test" : undefined,
+      meta: Object.keys(metaExtras).length > 0 ? metaExtras : undefined,
+    };
+  });
 }

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -25,6 +25,7 @@ import { adversarialReviewOp } from "../operations/adversarial-review";
 import { callOp as _callOp } from "../operations/call";
 import { resolveReviewExcludePatterns, resolveTestFilePatterns } from "../test-runners";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
+import { filterByAcQuote } from "./ac-quote-validator";
 import {
   type AdversarialLLMFinding,
   type AdversarialLLMResponse,
@@ -351,10 +352,23 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       durationMs: Date.now() - startTime,
     };
   }
-  const parsed: AdversarialLLMResponse = {
+  const rawParsed: AdversarialLLMResponse = {
     passed: opResult.passed,
     findings: opResult.findings as AdversarialLLMFinding[],
   };
+
+  // Issue #930 Part 1: drop error findings not grounded in AC text
+  const { accepted: acGroundedFindings, dropped: acDropped } = filterByAcQuote(
+    rawParsed.findings,
+    story.acceptanceCriteria,
+  );
+  if (acDropped.length > 0) {
+    logger?.warn("review", "Adversarial findings dropped: acQuote validation failed", {
+      storyId: story.id,
+      dropped: acDropped.map((d) => ({ file: d.finding.file, issue: d.finding.issue, code: d.code })),
+    });
+  }
+  const parsed: AdversarialLLMResponse = { ...rawParsed, findings: acGroundedFindings };
 
   const threshold = blockingThreshold ?? "error";
   const blockingFindings = parsed.findings.filter((f) => isBlockingSeverity(f.severity, threshold));

--- a/src/review/semantic-debate.ts
+++ b/src/review/semantic-debate.ts
@@ -11,6 +11,7 @@ import type { NaxConfig } from "../config";
 import type { ReviewConfig } from "../config/selectors";
 import type { DebateRunner, DebateRunnerOptions } from "../debate";
 import { getSafeLogger } from "../logger";
+import { filterByAcQuote } from "./ac-quote-validator";
 import {
   type LLMFinding,
   formatFindings,
@@ -232,8 +233,15 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
     }
   }
 
-  // Split debate findings by blocking threshold
-  const debateFindings = sanitizeRefModeFindings(deduped, diffMode);
+  // Split debate findings by blocking threshold — drop ungrounded error findings first
+  const sanitized = sanitizeRefModeFindings(deduped, diffMode);
+  const { accepted: debateFindings, dropped: acDropped } = filterByAcQuote(sanitized, story.acceptanceCriteria ?? []);
+  if (acDropped.length > 0) {
+    logger?.warn("review", "Semantic debate findings dropped: acQuote validation failed", {
+      storyId: story.id,
+      dropped: acDropped.length,
+    });
+  }
   const debateThreshold = blockingThreshold ?? "error";
   const debateBlocking = debateFindings.filter((f) => isBlockingSeverity(f.severity, debateThreshold));
   const debateAdvisory = debateFindings.filter((f) => !isBlockingSeverity(f.severity, debateThreshold));

--- a/src/review/semantic-helpers.ts
+++ b/src/review/semantic-helpers.ts
@@ -16,6 +16,14 @@ export interface LLMFinding {
   issue: string;
   suggestion: string;
   acId?: string;
+  /**
+   * Verbatim substring of the AC bullet that constrains this finding's locus.
+   * Required for severity "error" / "critical" (Issue #930 Part 1).
+   * Validated by filterByAcQuote() before findings reach the story blocker pipeline.
+   */
+  acQuote?: string;
+  /** 1-based index into story.acceptanceCriteria corresponding to acQuote. */
+  acIndex?: number;
   verifiedBy?: {
     command?: string;
     file: string;
@@ -111,6 +119,10 @@ function downgradeToUnverifiable(finding: LLMFinding): LLMFinding {
 
 /** Convert a single LLMFinding to the unified Finding wire format. */
 export function llmFindingToFinding(f: LLMFinding): Finding {
+  const metaExtras: Record<string, unknown> = {};
+  if (f.verifiedBy) metaExtras.verifiedBy = f.verifiedBy;
+  if (f.acQuote) metaExtras.acQuote = f.acQuote;
+  if (f.acIndex != null) metaExtras.acIndex = f.acIndex;
   return {
     source: "semantic-review",
     severity: normalizeSeverity(f.severity),
@@ -120,7 +132,7 @@ export function llmFindingToFinding(f: LLMFinding): Finding {
     message: f.issue,
     suggestion: f.suggestion ?? undefined,
     fixTarget: "source",
-    meta: f.verifiedBy ? { verifiedBy: f.verifiedBy } : undefined,
+    meta: Object.keys(metaExtras).length > 0 ? metaExtras : undefined,
   };
 }
 

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -23,6 +23,7 @@ import { semanticReviewOp } from "../operations/semantic-review";
 import { ReviewPromptBuilder } from "../prompts";
 import { resolveReviewExcludePatterns, resolveTestFilePatterns } from "../test-runners";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
+import { filterByAcQuote } from "./ac-quote-validator";
 import { DIFF_CAP_BYTES, collectDiff, collectDiffStat, resolveEffectiveRef, truncateDiff } from "./diff-utils";
 import { writeReviewAudit } from "./review-audit";
 import { runSemanticDebate } from "./semantic-debate";
@@ -407,7 +408,20 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     workdir,
     story.id,
   );
-  const sanitizedParsed: LLMResponse = { ...parsed, findings: sanitizedFindings };
+
+  // Issue #930 Part 1: drop error findings not grounded in AC text
+  const { accepted: acGroundedFindings, dropped: acDropped } = filterByAcQuote(
+    sanitizedFindings,
+    story.acceptanceCriteria,
+  );
+  if (acDropped.length > 0) {
+    logger?.warn("review", "Semantic findings dropped: acQuote validation failed", {
+      storyId: story.id,
+      dropped: acDropped.map((d) => ({ file: d.finding.file, issue: d.finding.issue, code: d.code })),
+    });
+  }
+
+  const sanitizedParsed: LLMResponse = { ...parsed, findings: acGroundedFindings };
 
   // Split findings by blocking threshold
   const threshold = blockingThreshold ?? "error";

--- a/test/unit/execution/escalation/quote-integrity.test.ts
+++ b/test/unit/execution/escalation/quote-integrity.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for Escalation Quote Integrity Check (Issue #930 Part 2)
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  _quoteIntegrityDeps,
+  extractQuoteTriples,
+  verifyEscalationQuotes,
+  verifyQuoteTriple,
+} from "../../../../src/execution/escalation/quote-integrity";
+
+// ─── extractQuoteTriples ──────────────────────────────────────────────────────
+
+describe("extractQuoteTriples", () => {
+  test("no citations → empty array", () => {
+    expect(extractQuoteTriples("No file references here.")).toEqual([]);
+  });
+
+  test("backtick-quoted snippet after file:line", () => {
+    const reason = "lines 42–44 of src/review/semantic.ts:42 `const x = foo()` are wrong";
+    const triples = extractQuoteTriples(reason);
+    expect(triples).toHaveLength(1);
+    expect(triples[0]).toMatchObject({ file: "src/review/semantic.ts", line: 42, quote: "const x = foo()" });
+  });
+
+  test("double-quoted snippet after file:line", () => {
+    const reason = `test/unit/foo.test.ts:106 "expect(result).toBe(true)" asserts the opposite`;
+    const triples = extractQuoteTriples(reason);
+    expect(triples).toHaveLength(1);
+    expect(triples[0]).toMatchObject({ file: "test/unit/foo.test.ts", line: 106, quote: "expect(result).toBe(true)" });
+  });
+
+  test("multiple citations in one reason string", () => {
+    const reason = [
+      "At src/a.ts:10 `doThing()` and",
+      "also src/b.ts:20 `otherThing()` both fail",
+    ].join(" ");
+    const triples = extractQuoteTriples(reason);
+    expect(triples).toHaveLength(2);
+    expect(triples[0].file).toBe("src/a.ts");
+    expect(triples[1].file).toBe("src/b.ts");
+  });
+
+  test("quote shorter than 3 chars is ignored", () => {
+    const reason = "src/foo.ts:5 `x` is bad";
+    expect(extractQuoteTriples(reason)).toHaveLength(0);
+  });
+
+  test("file without extension is not matched", () => {
+    const reason = "Makefile:10 `build` target is wrong";
+    // "Makefile" has no extension — CITATION_RE requires an extension
+    expect(extractQuoteTriples(reason)).toHaveLength(0);
+  });
+});
+
+// ─── verifyQuoteTriple ────────────────────────────────────────────────────────
+
+describe("verifyQuoteTriple", () => {
+  function makeDeps(fileContent: string | null) {
+    return {
+      readFile: async (_path: string) => fileContent,
+    };
+  }
+
+  const FILE_CONTENT = [
+    "line 1",
+    "line 2",
+    "const validateAcQuote = (finding) => {",
+    "  return { valid: true };",
+    "}",
+    "line 6",
+    "line 7",
+  ].join("\n");
+
+  test("quote found within ±3 lines of cited line → true", async () => {
+    const triple = { file: "src/review/validator.ts", line: 3, quote: "validateAcQuote" };
+    expect(await verifyQuoteTriple(triple, "/workdir", makeDeps(FILE_CONTENT))).toBe(true);
+  });
+
+  test("quote found just outside window (line 7 in content, cited line 1) → false", async () => {
+    const triple = { file: "src/f.ts", line: 1, quote: "line 7" };
+    expect(await verifyQuoteTriple(triple, "/workdir", makeDeps(FILE_CONTENT))).toBe(false);
+  });
+
+  test("file does not exist → false", async () => {
+    const triple = { file: "src/missing.ts", line: 1, quote: "anything" };
+    expect(await verifyQuoteTriple(triple, "/workdir", makeDeps(null))).toBe(false);
+  });
+
+  test("quote match is case-insensitive", async () => {
+    const triple = { file: "src/f.ts", line: 3, quote: "VALIDATEACQUOTE" };
+    expect(await verifyQuoteTriple(triple, "/workdir", makeDeps(FILE_CONTENT))).toBe(true);
+  });
+
+  test("quote with extra whitespace is normalised for comparison", async () => {
+    const triple = { file: "src/f.ts", line: 3, quote: "validateAcQuote  =  (finding)" };
+    expect(await verifyQuoteTriple(triple, "/workdir", makeDeps(FILE_CONTENT))).toBe(true);
+  });
+});
+
+// ─── verifyEscalationQuotes ───────────────────────────────────────────────────
+
+describe("verifyEscalationQuotes", () => {
+  function makeDeps(fileContent: string | null) {
+    return { readFile: async (_path: string) => fileContent };
+  }
+
+  const REAL_CONTENT = [
+    "function doStuff() {",
+    "  return 42;",
+    "}",
+  ].join("\n");
+
+  test("reason with no citations returned unchanged", async () => {
+    const reason = "Just a plain failure reason with no file references.";
+    expect(await verifyEscalationQuotes(reason, "/workdir", "story-1", makeDeps(null))).toBe(reason);
+  });
+
+  test("verified quote retained in output", async () => {
+    const reason = "At src/foo.ts:2 `return 42;` is the problem";
+    const result = await verifyEscalationQuotes(reason, "/workdir", "story-1", makeDeps(REAL_CONTENT));
+    expect(result).toContain("return 42;");
+    expect(result).not.toContain("<UNVERIFIED_QUOTE>");
+  });
+
+  test("fabricated quote replaced with <UNVERIFIED_QUOTE>", async () => {
+    const reason = "At src/foo.ts:2 `fabricatedQuoteNotInFile()` is the smoking gun";
+    const result = await verifyEscalationQuotes(reason, "/workdir", "story-1", makeDeps(REAL_CONTENT));
+    expect(result).toContain("<UNVERIFIED_QUOTE>");
+    expect(result).not.toContain("fabricatedQuoteNotInFile");
+    // File:line citation should remain for debugging
+    expect(result).toContain("src/foo.ts:2");
+  });
+
+  test("file:line citation preserved when quote is replaced", async () => {
+    const reason = "src/foo.ts:99 `definitelyNotHere()` is wrong";
+    const result = await verifyEscalationQuotes(reason, "/workdir", "story-1", makeDeps(REAL_CONTENT));
+    expect(result).toContain("src/foo.ts:99");
+  });
+
+  test("multiple citations: verified retained, fabricated replaced", async () => {
+    const reason = [
+      "First: src/foo.ts:2 `return 42;` is correct.",
+      "Second: src/foo.ts:2 `impostor()` is fabricated.",
+    ].join(" ");
+    const result = await verifyEscalationQuotes(reason, "/workdir", "story-1", makeDeps(REAL_CONTENT));
+    expect(result).toContain("return 42;");
+    expect(result).toContain("<UNVERIFIED_QUOTE>");
+    expect(result).not.toContain("impostor()");
+  });
+
+  test("missing file → quote replaced with <UNVERIFIED_QUOTE>", async () => {
+    const reason = "src/missing.ts:1 `someQuote()` is the issue";
+    const result = await verifyEscalationQuotes(reason, "/workdir", "story-1", makeDeps(null));
+    expect(result).toContain("<UNVERIFIED_QUOTE>");
+  });
+});

--- a/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
@@ -32,6 +32,12 @@ For each acceptance criterion, verify the current codebase implements it correct
 - Every "error" finding must include verifiedBy evidence from the current codebase. If you cannot provide verifiedBy, downgrade the finding to "unverifiable".
 - The \`verifiedBy.observed\` field MUST be a **verbatim** 1-3 line code excerpt copy-pasted from the file — not a description. Paste the actual source lines (or a substring of them) that prove your claim. A description like "function X does not check Y" is not a verifiable observation; quote the lines that demonstrate the omission instead. If you cannot quote an exact excerpt that proves your point, downgrade the finding to "unverifiable".
 
+**AC-grounding rule — required for every "error" finding:**
+- Every "error" finding MUST include \`acQuote\`: a verbatim substring of one AC bullet that names or constrains the exact file, function, or symbol you are flagging.
+- Include \`acIndex\` (1-based) indicating which AC bullet you are quoting.
+- If no AC bullet mentions the file, function, or symbol being flagged, the finding is out-of-scope. Emit it as \`severity: "info"\` instead — it cannot block the story.
+- Copy \`acQuote\` directly from the Acceptance Criteria text — do not paraphrase.
+
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)
 2. The implementation contradicts what the AC specifies
@@ -49,6 +55,8 @@ Respond with JSON only — no explanation text before or after:
       "line": 42,
       "issue": "description of the issue",
       "suggestion": "how to fix it",
+      "acQuote": "<verbatim substring of one AC bullet constraining this locus — required for 'error'>",
+      "acIndex": 3,
       "verifiedBy": {
         "command": "command used to inspect the current codebase",
         "file": "path/to/file",
@@ -59,6 +67,9 @@ Respond with JSON only — no explanation text before or after:
   ]
 }
 
+Notes:
+- \`acQuote\` and \`acIndex\` are required when severity is "error". Omit them for "warning", "info", "unverifiable".
+- \`acIndex\` is 1-based (AC 1 = first bullet in the Acceptance Criteria list above).
 If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.
 
 YOUR RESPONSE MUST START WITH { OR [ AND END WITH } OR ]. No other text."
@@ -100,6 +111,12 @@ For each acceptance criterion, verify the current codebase implements it correct
 - Every "error" finding must include verifiedBy evidence from the current codebase. If you cannot provide verifiedBy, downgrade the finding to "unverifiable".
 - The \`verifiedBy.observed\` field MUST be a **verbatim** 1-3 line code excerpt copy-pasted from the file — not a description. Paste the actual source lines (or a substring of them) that prove your claim. A description like "function X does not check Y" is not a verifiable observation; quote the lines that demonstrate the omission instead. If you cannot quote an exact excerpt that proves your point, downgrade the finding to "unverifiable".
 
+**AC-grounding rule — required for every "error" finding:**
+- Every "error" finding MUST include \`acQuote\`: a verbatim substring of one AC bullet that names or constrains the exact file, function, or symbol you are flagging.
+- Include \`acIndex\` (1-based) indicating which AC bullet you are quoting.
+- If no AC bullet mentions the file, function, or symbol being flagged, the finding is out-of-scope. Emit it as \`severity: "info"\` instead — it cannot block the story.
+- Copy \`acQuote\` directly from the Acceptance Criteria text — do not paraphrase.
+
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)
 2. The implementation contradicts what the AC specifies
@@ -117,6 +134,8 @@ Respond with JSON only — no explanation text before or after:
       "line": 42,
       "issue": "description of the issue",
       "suggestion": "how to fix it",
+      "acQuote": "<verbatim substring of one AC bullet constraining this locus — required for 'error'>",
+      "acIndex": 3,
       "verifiedBy": {
         "command": "command used to inspect the current codebase",
         "file": "path/to/file",
@@ -127,6 +146,9 @@ Respond with JSON only — no explanation text before or after:
   ]
 }
 
+Notes:
+- \`acQuote\` and \`acIndex\` are required when severity is "error". Omit them for "warning", "info", "unverifiable".
+- \`acIndex\` is 1-based (AC 1 = first bullet in the Acceptance Criteria list above).
 If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.
 
 YOUR RESPONSE MUST START WITH { OR [ AND END WITH } OR ]. No other text."

--- a/test/unit/review/ac-quote-validator.test.ts
+++ b/test/unit/review/ac-quote-validator.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for AC Quote Validator (Issue #930 Part 1)
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  type AcQuotable,
+  filterByAcQuote,
+  validateAcQuote,
+} from "../../../src/review/ac-quote-validator";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const ACS = [
+  "The validateAcQuote function must return a rejection code when acQuote is absent",
+  "The filterByAcQuote function must drop all error findings without a valid acQuote",
+  "Warning and info findings must pass through without acQuote validation",
+];
+
+function makeFinding(overrides: Partial<AcQuotable> & { severity: string }): AcQuotable {
+  return {
+    file: "src/review/ac-quote-validator.ts",
+    issue: "validateAcQuote does not check acQuote presence",
+    acQuote: undefined,
+    acIndex: undefined,
+    ...overrides,
+  };
+}
+
+// ─── validateAcQuote ──────────────────────────────────────────────────────────
+
+describe("validateAcQuote", () => {
+  describe("non-blocking severities bypass validation", () => {
+    test.each(["warning", "info", "unverifiable", "low"] as const)("%s severity → valid", (severity) => {
+      const finding = makeFinding({ severity });
+      expect(validateAcQuote(finding, ACS)).toEqual({ valid: true });
+    });
+  });
+
+  describe("blocking severities require acQuote", () => {
+    test("error with no acQuote → missing_ac_quote", () => {
+      const finding = makeFinding({ severity: "error" });
+      expect(validateAcQuote(finding, ACS)).toEqual({ valid: false, code: "missing_ac_quote" });
+    });
+
+    test("critical with empty acQuote → missing_ac_quote", () => {
+      const finding = makeFinding({ severity: "critical", acQuote: "   " });
+      expect(validateAcQuote(finding, ACS)).toEqual({ valid: false, code: "missing_ac_quote" });
+    });
+
+    test("error with acIndex 0 → ac_index_out_of_range", () => {
+      const finding = makeFinding({ severity: "error", acQuote: "validateAcQuote", acIndex: 0 });
+      expect(validateAcQuote(finding, ACS)).toEqual({ valid: false, code: "ac_index_out_of_range" });
+    });
+
+    test("error with acIndex beyond array → ac_index_out_of_range", () => {
+      const finding = makeFinding({ severity: "error", acQuote: "validateAcQuote", acIndex: 99 });
+      expect(validateAcQuote(finding, ACS)).toEqual({ valid: false, code: "ac_index_out_of_range" });
+    });
+
+    test("error with acQuote not in AC text → ac_quote_not_substring", () => {
+      const finding = makeFinding({
+        severity: "error",
+        acQuote: "this text is not in any AC",
+        acIndex: 1,
+      });
+      expect(validateAcQuote(finding, ACS)).toEqual({ valid: false, code: "ac_quote_not_substring" });
+    });
+
+    test("error with valid acQuote but no locus keyword in quote → ac_quote_does_not_constrain_locus", () => {
+      // AC 3 text contains "Warning" and "info" but the file being flagged is
+      // something like "src/random-unrelated.ts" with no shared token in the quote
+      const finding = makeFinding({
+        severity: "error",
+        file: "src/xyzzy-module.ts",
+        issue: "xyzzy function missing",
+        acQuote: "Warning and info findings must pass",
+        acIndex: 3,
+      });
+      expect(validateAcQuote(finding, ACS)).toEqual({
+        valid: false,
+        code: "ac_quote_does_not_constrain_locus",
+      });
+    });
+
+    test("error with valid acQuote and matching locus keyword → valid", () => {
+      const finding = makeFinding({
+        severity: "error",
+        file: "src/review/ac-quote-validator.ts",
+        issue: "validateAcQuote does not return rejection code",
+        acQuote: "validateAcQuote function must return a rejection code",
+        acIndex: 1,
+      });
+      expect(validateAcQuote(finding, ACS)).toEqual({ valid: true });
+    });
+
+    test("acQuote match is case-insensitive", () => {
+      const finding = makeFinding({
+        severity: "error",
+        file: "src/review/ac-quote-validator.ts",
+        issue: "validateAcQuote check broken",
+        acQuote: "VALIDATEACQUOTE FUNCTION MUST RETURN A REJECTION CODE",
+        acIndex: 1,
+      });
+      expect(validateAcQuote(finding, ACS)).toEqual({ valid: true });
+    });
+
+    test("acQuote with extra internal whitespace is normalised and matches", () => {
+      const finding = makeFinding({
+        severity: "error",
+        file: "src/review/ac-quote-validator.ts",
+        issue: "validateAcQuote not checked",
+        acQuote: "validateAcQuote  function   must return",
+        acIndex: 1,
+      });
+      expect(validateAcQuote(finding, ACS)).toEqual({ valid: true });
+    });
+
+    test("no acceptanceCriteria → ac_index_out_of_range", () => {
+      const finding = makeFinding({ severity: "error", acQuote: "something", acIndex: 1 });
+      expect(validateAcQuote(finding, [])).toEqual({ valid: false, code: "ac_index_out_of_range" });
+    });
+
+    test("finding with no file uses only issue-token as locus → valid when keyword present", () => {
+      const finding: AcQuotable = {
+        severity: "error",
+        issue: "filterByAcQuote not dropping findings",
+        acQuote: "filterByAcQuote function must drop all error findings",
+        acIndex: 2,
+      };
+      expect(validateAcQuote(finding, ACS)).toEqual({ valid: true });
+    });
+  });
+});
+
+// ─── filterByAcQuote ──────────────────────────────────────────────────────────
+
+describe("filterByAcQuote", () => {
+  test("empty findings → empty accepted and dropped", () => {
+    const result = filterByAcQuote([], ACS);
+    expect(result.accepted).toHaveLength(0);
+    expect(result.dropped).toHaveLength(0);
+  });
+
+  test("non-blocking findings always accepted", () => {
+    const findings: AcQuotable[] = [
+      makeFinding({ severity: "warning" }),
+      makeFinding({ severity: "info" }),
+      makeFinding({ severity: "unverifiable" }),
+    ];
+    const result = filterByAcQuote(findings, ACS);
+    expect(result.accepted).toHaveLength(3);
+    expect(result.dropped).toHaveLength(0);
+  });
+
+  test("error finding without acQuote is dropped with missing_ac_quote", () => {
+    const findings = [makeFinding({ severity: "error" })];
+    const result = filterByAcQuote(findings, ACS);
+    expect(result.accepted).toHaveLength(0);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe("missing_ac_quote");
+  });
+
+  test("error finding with valid acQuote is accepted", () => {
+    const findings = [
+      makeFinding({
+        severity: "error",
+        file: "src/review/ac-quote-validator.ts",
+        issue: "validateAcQuote broken",
+        acQuote: "validateAcQuote function must return a rejection code",
+        acIndex: 1,
+      }),
+    ];
+    const result = filterByAcQuote(findings, ACS);
+    expect(result.accepted).toHaveLength(1);
+    expect(result.dropped).toHaveLength(0);
+  });
+
+  test("mixed findings: valid errors accepted, invalid errors dropped, non-blocking pass through", () => {
+    const findings: AcQuotable[] = [
+      // Valid error
+      makeFinding({
+        severity: "error",
+        file: "src/review/ac-quote-validator.ts",
+        issue: "validateAcQuote broken",
+        acQuote: "validateAcQuote function must return a rejection code",
+        acIndex: 1,
+      }),
+      // Invalid error (no acQuote)
+      makeFinding({ severity: "error" }),
+      // Non-blocking — always pass
+      makeFinding({ severity: "warning" }),
+    ];
+    const result = filterByAcQuote(findings, ACS);
+    expect(result.accepted).toHaveLength(2);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe("missing_ac_quote");
+  });
+
+  test("dropped entry preserves the original finding reference", () => {
+    const finding = makeFinding({ severity: "error", issue: "sentinel-issue" });
+    const result = filterByAcQuote([finding], ACS);
+    expect(result.dropped[0].finding.issue).toBe("sentinel-issue");
+  });
+
+  test("critical severity is also subject to validation", () => {
+    const findings = [makeFinding({ severity: "critical" })];
+    const result = filterByAcQuote(findings, ACS);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe("missing_ac_quote");
+  });
+
+  test("preserves concrete AdversarialLLMFinding shape (category field)", () => {
+    type AdversarialShape = AcQuotable & { category: string };
+    const finding: AdversarialShape = {
+      severity: "error",
+      file: "src/review/ac-quote-validator.ts",
+      issue: "validateAcQuote broken",
+      category: "convention",
+      acQuote: "validateAcQuote function must return a rejection code",
+      acIndex: 1,
+    };
+    const result = filterByAcQuote([finding], ACS);
+    expect(result.accepted).toHaveLength(1);
+    expect((result.accepted[0] as AdversarialShape).category).toBe("convention");
+  });
+});

--- a/test/unit/review/adversarial-metadata-audit.test.ts
+++ b/test/unit/review/adversarial-metadata-audit.test.ts
@@ -85,10 +85,12 @@ const CATEGORY_FINDING_RESPONSE = JSON.stringify({
     {
       severity: "error",
       category: "test-gap",
-      file: "src/auth.ts",
+      file: "src/log.ts",
       line: 30,
       issue: "Missing test for edge case",
       suggestion: "Add test",
+      acQuote: "can log in",
+      acIndex: 1,
     },
   ],
 });

--- a/test/unit/review/adversarial-pass-fail.test.ts
+++ b/test/unit/review/adversarial-pass-fail.test.ts
@@ -112,10 +112,12 @@ const FAILING_ERROR_RESPONSE = JSON.stringify({
     {
       severity: "error",
       category: "error-path",
-      file: "src/auth.ts",
+      file: "src/log.ts",
       line: 10,
       issue: "No error handling on login",
       suggestion: "Add try/catch",
+      acQuote: "can log in",
+      acIndex: 1,
     },
   ],
 });
@@ -168,10 +170,12 @@ const PASSED_TRUE_WITH_ERROR_RESPONSE = JSON.stringify({
     {
       severity: "error",
       category: "error-path",
-      file: "src/auth.ts",
+      file: "src/log.ts",
       line: 15,
       issue: "Unhandled promise rejection",
       suggestion: "Add .catch()",
+      acQuote: "can log in",
+      acIndex: 1,
     },
   ],
 });

--- a/test/unit/review/adversarial-retry.test.ts
+++ b/test/unit/review/adversarial-retry.test.ts
@@ -208,7 +208,7 @@ describe("runAdversarialReview — JSON retry outcomes", () => {
   test("returns failure with blocking findings when callOp returns findings", async () => {
     _adversarialDeps.callOp = mock(async () => ({
       passed: false,
-      findings: [{ severity: "error", file: "src/foo.ts", line: 1, issue: "Bug", suggestion: "Fix" }],
+      findings: [{ severity: "error", file: "src/log.ts", line: 1, issue: "Bug", suggestion: "Fix", acQuote: "can log in", acIndex: 1 }],
     }));
     const agentManager = makeAgentManager(PASSING_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });

--- a/test/unit/review/adversarial-threshold.test.ts
+++ b/test/unit/review/adversarial-threshold.test.ts
@@ -53,7 +53,7 @@ const WARNING_ONLY_RESPONSE = JSON.stringify({
 const ERROR_ONLY_RESPONSE = JSON.stringify({
   passed: false,
   findings: [
-    { severity: "error", category: "error-path", file: "src/bar.ts", line: 2, issue: "An error", suggestion: "Fix error" },
+    { severity: "error", category: "error-path", file: "src/findings-bar.ts", line: 2, issue: "An error", suggestion: "Fix error", acQuote: "findings", acIndex: 1 },
   ],
 });
 
@@ -61,7 +61,7 @@ const MIXED_RESPONSE = JSON.stringify({
   passed: false,
   findings: [
     { severity: "warning", category: "input", file: "src/foo.ts", line: 1, issue: "A warning", suggestion: "Fix w" },
-    { severity: "error", category: "error-path", file: "src/bar.ts", line: 2, issue: "An error", suggestion: "Fix e" },
+    { severity: "error", category: "error-path", file: "src/findings-bar.ts", line: 2, issue: "An error", suggestion: "Fix e", acQuote: "findings", acIndex: 1 },
   ],
 });
 

--- a/test/unit/review/semantic-agent-session.test.ts
+++ b/test/unit/review/semantic-agent-session.test.ts
@@ -171,6 +171,8 @@ const FAILING_LLM_RESPONSE = JSON.stringify({
       line: 42,
       issue: "Function is a stub",
       suggestion: "Implement the function",
+      acQuote: "semanticConfig",
+      acIndex: 1,
     },
   ],
 });

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -97,8 +97,10 @@ const PROPOSAL_FAIL_A = JSON.stringify({
       severity: "error",
       file: "src/review/semantic.ts",
       line: 10,
-      issue: "AC1 not implemented",
+      issue: "debate branch not implemented",
       suggestion: "Implement debate branch",
+      acQuote: "debate enabled for review",
+      acIndex: 1,
     },
   ],
 });
@@ -111,8 +113,10 @@ const PROPOSAL_FAIL_B = JSON.stringify({
       severity: "error",
       file: "src/review/semantic.ts",
       line: 10,
-      issue: "AC1 not implemented",
+      issue: "debate branch not implemented",
       suggestion: "Implement debate branch",
+      acQuote: "debate enabled for review",
+      acIndex: 1,
     },
     {
       severity: "warn",

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -27,7 +27,10 @@ const STORY: SemanticStory = {
   id: "US-003",
   title: "Wire semantic findings",
   description: "Wire findings into autofix context",
-  acceptanceCriteria: ["ctx.reviewFindings is populated when semantic fails"],
+  acceptanceCriteria: [
+    "ctx.reviewFindings is populated when semantic fails",
+    "Each src module error finding must be included in the result",
+  ],
 };
 
 const CFG: SemanticReviewConfig = {
@@ -117,7 +120,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
-        { severity: "error", file: "src/foo.ts", line: 10, issue: "Stub left in code", suggestion: "Remove stub" },
+        { severity: "error", file: "src/foo.ts", line: 10, issue: "Stub left in code", suggestion: "Remove stub", acQuote: "Each src module error finding", acIndex: 2 },
       ],
     });
     const result = await callRunSemanticReview(llmResponse);
@@ -128,13 +131,13 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
-        { severity: "error", file: "src/foo.ts", line: 5, issue: "Missing wiring in runner", suggestion: "Fix it" },
+        { severity: "error", file: "src/foo.ts", line: 5, issue: "src module wiring missing in runner", suggestion: "Fix it", acQuote: "Each src module error finding", acIndex: 2 },
       ],
     });
 
     const result = await callRunSemanticReview(llmResponse);
 
-    expect(result.findings![0].message).toBe("Missing wiring in runner");
+    expect(result.findings![0].message).toBe("src module wiring missing in runner");
   });
 
   test("sets source='semantic-review' on blocking ReviewFindings", async () => {
@@ -142,8 +145,8 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
-        { severity: "error", file: "src/a.ts", line: 1, issue: "An issue", suggestion: "Fix" },
-        { severity: "error", file: "src/b.ts", line: 2, issue: "Another issue", suggestion: "Fix" },
+        { severity: "error", file: "src/a.ts", line: 1, issue: "src module error in a", suggestion: "Fix", acQuote: "Each src module error finding", acIndex: 2 },
+        { severity: "error", file: "src/b.ts", line: 2, issue: "src module error in b", suggestion: "Fix", acQuote: "Each src module error finding", acIndex: 2 },
       ],
     });
 
@@ -175,7 +178,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
-        { severity: "error", file: "src/review/runner.ts", line: 42, issue: "Issue", suggestion: "Fix" },
+        { severity: "error", file: "src/review/runner.ts", line: 42, issue: "src module error not wired", suggestion: "Fix", acQuote: "Each src module error finding", acIndex: 2 },
       ],
     });
 
@@ -189,7 +192,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
-        { severity: "error", file: "src/foo.ts", line: 99, issue: "Issue", suggestion: "Fix" },
+        { severity: "error", file: "src/foo.ts", line: 99, issue: "src module error missing", suggestion: "Fix", acQuote: "Each src module error finding", acIndex: 2 },
       ],
     });
     const result = await callRunSemanticReview(llmResponse);
@@ -202,7 +205,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
-        { severity: "error", file: "src/foo.ts", line: 1, issue: "Issue", suggestion: "Fix" },
+        { severity: "error", file: "src/foo.ts", line: 1, issue: "src module error not flagged", suggestion: "Fix", acQuote: "Each src module error finding", acIndex: 2 },
       ],
     });
     const result = await callRunSemanticReview(llmResponse);
@@ -243,7 +246,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
     const llmResponse = JSON.stringify({
       passed: false,
       findings: [
-        { severity: "error", file: "src/a.ts", line: 1, issue: "Issue A", suggestion: "Fix A" },
+        { severity: "error", file: "src/a.ts", line: 1, issue: "src module error missing in A", suggestion: "Fix A", acQuote: "Each src module error finding", acIndex: 2 },
         { severity: "warn", file: "src/b.ts", line: 20, issue: "Issue B", suggestion: "Fix B" },
         { severity: "info", file: "src/c.ts", line: 5, issue: "Issue C", suggestion: "Fix C" },
       ],
@@ -252,7 +255,7 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
 
     // Only error blocks by default
     expect(result.findings!.length).toBe(1);
-    expect(result.findings![0].message).toBe("Issue A");
+    expect(result.findings![0].message).toBe("src module error missing in A");
     // warn + info are advisory
     expect(result.advisoryFindings!.length).toBe(2);
     expect(result.advisoryFindings![0].message).toBe("Issue B");

--- a/test/unit/review/semantic-parsing.test.ts
+++ b/test/unit/review/semantic-parsing.test.ts
@@ -149,7 +149,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const payload = {
       passed: false,
-      findings: [{ severity: "error", file: "src/foo.ts", line: 10, issue: "missing impl", suggestion: "implement it" }],
+      findings: [{ severity: "error", file: "src/foo.ts", line: 10, issue: "Parser missing impl", suggestion: "implement it", acQuote: "Parser handles preamble + fenced JSON", acIndex: 1 }],
     };
     const response =
       "Let me check the implementation.\n```json\n" + JSON.stringify(payload) + "\n```";
@@ -184,7 +184,7 @@ describe("runSemanticReview — multi-tier JSON parsing", () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const payload = {
       passed: false,
-      findings: [{ severity: "error", file: "src/bar.ts", line: 5, issue: "stub", suggestion: "implement" }],
+      findings: [{ severity: "error", file: "src/bar.ts", line: 5, issue: "Parser finds stub in bar", suggestion: "implement", acQuote: "Parser handles bare JSON in narration", acIndex: 2 }],
     };
     const response = "I found issues. " + JSON.stringify(payload) + " That concludes my review.";
     const result = await callRunSemanticReview(response);

--- a/test/unit/review/semantic-prompt-response.test.ts
+++ b/test/unit/review/semantic-prompt-response.test.ts
@@ -92,6 +92,8 @@ const FAILING_LLM_RESPONSE = JSON.stringify({
       line: 42,
       issue: "Function is a stub",
       suggestion: "Implement the function",
+      acQuote: "semanticConfig",
+      acIndex: 1,
     },
   ],
 });
@@ -329,8 +331,8 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
     const multiFindings = JSON.stringify({
       passed: false,
       findings: [
-        { severity: "error", file: "src/a.ts", line: 1, issue: "Issue A", suggestion: "Fix A" },
-        { severity: "error", file: "src/b.ts", line: 99, issue: "Issue B", suggestion: "Fix B" },
+        { severity: "error", file: "src/a.ts", line: 1, issue: "storyGitRef missing on a", suggestion: "Fix A", acQuote: "storyGitRef", acIndex: 1 },
+        { severity: "error", file: "src/b.ts", line: 99, issue: "git diff not called for b", suggestion: "Fix B", acQuote: "git diff", acIndex: 2 },
       ],
     });
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
@@ -344,9 +346,9 @@ describe("runSemanticReview — LLM response parsing (passed=false)", () => {
       runtime: makeMockRuntime({ agentManager }),
     });
     expect(result.output).toContain("src/a.ts");
-    expect(result.output).toContain("Issue A");
+    expect(result.output).toContain("storyGitRef missing on a");
     expect(result.output).toContain("src/b.ts");
-    expect(result.output).toContain("Issue B");
+    expect(result.output).toContain("git diff not called for b");
   });
 });
 
@@ -559,7 +561,7 @@ describe("runSemanticReview — markdown fence stripping (BUG-090)", () => {
     _diffUtilsDeps.spawn = makeSpawnMock("some diff", 0);
     const payload = {
       passed: false,
-      findings: [{ severity: "error", file: "src/foo.ts", line: 1, issue: "bad code", suggestion: "fix it" }],
+      findings: [{ severity: "error", file: "src/foo.ts", line: 1, issue: "storyGitRef bad code in foo", suggestion: "fix it", acQuote: "storyGitRef", acIndex: 1 }],
     };
     const fencedResponse = "```json\n" + JSON.stringify(payload) + "\n```";
     const agentManager = makeAgentManager(fencedResponse);

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -216,7 +216,7 @@ describe("runSemanticReview — JSON retry outcomes", () => {
   test("returns failure with blocking findings when callOp returns findings", async () => {
     _semanticDeps.callOp = mock(async () => ({
       passed: false,
-      findings: [{ severity: "error", file: "src/foo.ts", line: 1, issue: "Bug", suggestion: "Fix" }],
+      findings: [{ severity: "error", file: "src/workdir.ts", line: 1, issue: "Bug", suggestion: "Fix", acQuote: "accepts workdir, storyGitRef", acIndex: 1 }],
     }));
     const agentManager = makeAgentManager(PASSING_LLM_RESPONSE);
     const runtime = makeMockRuntime({ agentManager });

--- a/test/unit/review/semantic-threshold.test.ts
+++ b/test/unit/review/semantic-threshold.test.ts
@@ -43,7 +43,7 @@ const MIXED_RESPONSE = JSON.stringify({
   passed: false,
   findings: [
     { severity: "warning", file: "src/foo.ts", line: 1, issue: "A warning", suggestion: "Fix warning" },
-    { severity: "error", file: "src/bar.ts", line: 2, issue: "An error", suggestion: "Fix error" },
+    { severity: "error", file: "src/blockingThreshold.ts", line: 2, issue: "An error", suggestion: "Fix error", acQuote: "blockingThreshold controls which findings block", acIndex: 1 },
   ],
 });
 
@@ -156,7 +156,7 @@ describe("runSemanticReview — blockingThreshold defaults to 'error'", () => {
   test("error finding blocks by default (goes to findings)", async () => {
     const errorOnly = JSON.stringify({
       passed: false,
-      findings: [{ severity: "error", file: "src/a.ts", line: 1, issue: "An error", suggestion: "Fix" }],
+      findings: [{ severity: "error", file: "src/blockingThreshold.ts", line: 1, issue: "An error", suggestion: "Fix", acQuote: "blockingThreshold controls which findings block", acIndex: 1 }],
     });
     const agentManager = makeAgentManager(errorOnly);
     const runtime = makeMockRuntime({ agentManager });

--- a/test/unit/review/semantic-unverifiable.test.ts
+++ b/test/unit/review/semantic-unverifiable.test.ts
@@ -154,6 +154,8 @@ describe("unverifiable finding handling", () => {
           line: 5,
           issue: "AC not implemented",
           suggestion: "Implement it",
+          acQuote: "foo.bar",
+          acIndex: 1,
         },
         {
           severity: "unverifiable",
@@ -284,6 +286,8 @@ describe("unverifiable finding handling", () => {
           line: 5,
           issue: "AC not implemented",
           suggestion: "Implement it",
+          acQuote: "foo.bar",
+          acIndex: 1,
           verifiedBy: {
             command: "sed -n '1,80p' src/foo.ts",
             file: "src/foo.ts",


### PR DESCRIPTION
## Summary

- **Part 1**: Adds `filterByAcQuote<T extends AcQuotable>` in `src/review/ac-quote-validator.ts` — drops `error`/`critical` findings that cannot cite a verbatim substring of the story's acceptance criteria. Wired into `runSemanticReview`, `runAdversarialReview`, and the semantic debate path. Prompt builders updated to instruct the LLM to include `acQuote`/`acIndex` on every error finding.
- **Part 2**: Adds `verifyEscalationQuotes()` in `src/execution/escalation/quote-integrity.ts` — scans escalation reason text for `file:line "quote"` citations, verifies each against the file at HEAD (±3 line window), and replaces fabricated quotes with `<UNVERIFIED_QUOTE>`. Wired into `handleTierEscalation`.

Fixes two evidence-fabrication patterns from dogfood runs (issue #930).

## Code review fixes applied (from self-review)

- `CITATION_RE` moved inside `extractQuoteTriples` (was module-level with mutable `lastIndex` — unsafe under parallel escalation)
- `replace()` → `replaceAll()` to catch repeated fabricated quote occurrences
- Empty locus keywords now fail-closed (`ac_quote_does_not_constrain_locus`) instead of bypassing the constraint
- `filterByAcQuote` wired into the semantic debate path (`semantic-debate.ts`) which previously bypassed Part 1 entirely

## Test plan

- [ ] `bun run test` passes all phases (unit, integration, ui) — 7349+ tests, 0 failures
- [ ] `bun run typecheck` — no errors
- [ ] `bun run lint` — no errors
- [ ] 40 new unit tests in `test/unit/review/ac-quote-validator.test.ts` and `test/unit/execution/escalation/quote-integrity.test.ts`
- [ ] All existing review test fixtures updated with valid `acQuote`/`acIndex` fields
- [ ] Snapshot updated for `ReviewPromptBuilder.buildSemanticReviewPrompt()`