### PR TITLE
feat(prompts): test-immutability escape valve for lint, PRD-contract, and sibling-scope cases (#929)

### DIFF
--- a/src/operations/autofix-implementer.ts
+++ b/src/operations/autofix-implementer.ts
@@ -1,5 +1,6 @@
 import { autofixConfigSelector } from "../config";
 import type { AutofixConfig } from "../config/selectors";
+import { getSafeLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
 import type { ReviewCheckResult } from "../review/types";
@@ -29,8 +30,15 @@ export const implementerRectifyOp: RunOperation<AutofixImplementerInput, Autofix
       task: { id: "task", content: prompt, overridable: false },
     };
   },
-  parse(output, _input, _ctx) {
+  parse(output, input, _ctx) {
     const match = output.match(/^UNRESOLVED:\s*(.+)$/ms);
+    const editReasonMatch = output.match(/TEST_EDIT_REASON:\s*(\w+)/);
+    if (editReasonMatch) {
+      getSafeLogger()?.info("autofix", "test_edit_declared", {
+        storyId: input.story.id,
+        reason: editReasonMatch[1],
+      });
+    }
     return { applied: true, ...(match ? { unresolvedReason: match[1]?.trim() } : {}) };
   },
 };

--- a/src/prompts/builders/rectifier-builder-helpers.ts
+++ b/src/prompts/builders/rectifier-builder-helpers.ts
@@ -19,7 +19,59 @@ import type { ReviewCheckResult } from "../../review/types";
 export const CONTRADICTION_ESCAPE_HATCH = `
 If two findings in this list contradict each other and you cannot satisfy both, do not guess.
 Emit fixes for defects you can resolve, then output a line in this exact format:
-UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>`;
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
+
+### Exception 1 — Lint-only edit
+
+You MAY edit a test file ONLY when ALL of the following hold:
+- The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
+- Your edit removes or reformats a lint violation without altering any \`expect\`, \`assert\`,
+  \`toBe\`, \`toEqual\`, \`toThrow\`, \`not.\`, or equivalent assertion call, its arguments, its
+  input data, its mock setup, or its \`describe\`/\`it\`/\`test\` block text.
+- If you are uncertain whether your edit is assertion-neutral, do NOT make it — emit
+  \`UNRESOLVED\` instead.
+
+Declare every lint-only test edit with:
+\`\`\`
+TEST_EDIT_REASON: lint_only
+FILE: <test file path>
+FINDING: <lint rule or message verbatim>
+CHANGE: <before line> → <after line>
+\`\`\`
+
+### Exception 2 — PRD-contract mismatch
+
+You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
+call contradicts a literal interface signature stated in this story's description or
+acceptance criteria.
+
+Declare every contract-mismatch edit with:
+\`\`\`
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "<verbatim signature line from the story description or acceptance criteria>"
+FILE: <test file path>
+TEST_BEFORE: <offending call line>
+TEST_AFTER: <corrected call line>
+\`\`\`
+
+Do NOT use this exception to change test logic, assertions, or mock setup — only call
+signatures that directly contradict a quoted PRD interface.
+
+### Exception 3 — Sibling-story lint spillover
+
+When a lint or typecheck error is in a file you did NOT create or modify in this turn,
+do NOT edit that file. Instead declare:
+\`\`\`
+TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: <file path>
+FINDING: <error summary>
+\`\`\`
+and continue. Sibling-scope failures do not block your story.`;
 
 export function formatCheckErrors(checks: ReviewCheckResult[]): string {
   return checks.map((c) => `## ${c.check} errors (exit code ${c.exitCode})\n\`\`\`\n${c.output}\n\`\`\``).join("\n\n");

--- a/src/prompts/builders/rectifier-builder-helpers.ts
+++ b/src/prompts/builders/rectifier-builder-helpers.ts
@@ -96,7 +96,7 @@ ${errors}
 2. Only fix findings that are actually valid problems
 3. Do NOT add keys, functions, or imports that already exist — check first
 
-Do NOT change test files or test behavior.
+Do NOT change test files or test behavior — see the three narrow exceptions appended below.
 Do NOT add new features — only fix valid issues.
 Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
 }
@@ -175,7 +175,7 @@ The following quality checks failed after implementation:
 
 ${errors}
 
-Fix ALL errors listed above. Do NOT change test files or test behavior.
+Fix all errors listed above that are within this story's scope — see the three narrow exceptions appended below for sibling-story spillover. Do NOT change test files or test behavior except via those exceptions.
 Do NOT add new features — only fix the quality check errors.
 After fixing, re-run the failing check(s) to verify they pass, then commit your changes.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
 }

--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -189,7 +189,7 @@ export class RectifierPromptBuilder {
     parts.push(renderPrioritizedFailures(failedChecks));
 
     parts.push(
-      "\nFix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior. Commit your changes when all checks pass.",
+      "\nFix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior — see the three narrow exceptions appended below. Commit your changes when all checks pass.",
     );
     parts.push(CONTRADICTION_ESCAPE_HATCH);
 
@@ -511,7 +511,7 @@ ${testCommands}
 6. Ensure ALL tests pass before completing.
 
 **IMPORTANT:**
-- Do NOT modify test files unless there is a legitimate bug in the test itself.
+- Do NOT modify test files — see the three narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements.
 - When running tests, run ONLY the failing test files shown above${cmd ? ` — NEVER run \`${cmd}\` without a file filter` : " — never run the full test suite without a file filter"}.
@@ -637,7 +637,7 @@ ${errors}${reasoningSection}${historySection}
 2. Only fix findings that are actually valid problems
 3. Do NOT add keys, functions, or imports that already exist — check first
 
-Do NOT change test files or test behavior.
+Do NOT change test files or test behavior — see the three narrow exceptions appended below.
 Do NOT add new features — only fix valid issues.
 Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
   }
@@ -765,7 +765,7 @@ Tests are failing. Fix the source so all tests pass — not just the ones listed
 4. Do not declare done until step 3 shows 0 failures.
 
 **IMPORTANT:**
-- Do NOT modify test files unless there is a legitimate bug in the test itself.
+- Do NOT modify test files — see the three narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements.`);
 

--- a/src/prompts/sections/role-task.ts
+++ b/src/prompts/sections/role-task.ts
@@ -70,7 +70,7 @@ Your task: make failing tests pass.
 
 Instructions:
 - Implement source code in src/ to make tests pass
-- Do NOT modify test files
+- Do NOT modify test files — three narrow lint/contract/sibling exceptions exist; see the escape valve section in the rectification prompt if you encounter one
 - Run tests frequently to track progress
 - When all tests are green, stage and commit ALL changed files with: git commit -m 'feat: <description>'
 - Goal: all tests green, all changes committed`;

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -12,6 +12,7 @@ import type { ModelTier } from "../config";
 import { resolveModelForAgent } from "../config";
 import type { RectificationGateConfig } from "../config/selectors";
 import type { getLogger } from "../logger";
+import { getSafeLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
 import { resolveQualityTestCommands } from "../quality/command-resolver";
@@ -349,6 +350,14 @@ async function runRectificationLoop(
 
       if (!rectifyResult.success && rectifyResult.pid) {
         await cleanupProcessTree(rectifyResult.pid);
+      }
+
+      const editReasonMatch = rectifyResult.output?.match(/TEST_EDIT_REASON:\s*(\w+)/);
+      if (editReasonMatch) {
+        getSafeLogger()?.info("tdd", "test_edit_declared", {
+          storyId: story.id,
+          reason: editReasonMatch[1],
+        });
       }
 
       gateCostAccum += rectifyResult.estimatedCostUsd ?? 0;

--- a/test/unit/pipeline/stages/autofix-prompts.test.ts
+++ b/test/unit/pipeline/stages/autofix-prompts.test.ts
@@ -81,7 +81,7 @@ describe("buildReviewRectificationPrompt", () => {
 
       expect(prompt).toContain("lint/typecheck errors");
       expect(prompt).toContain("Unexpected console.log");
-      expect(prompt).not.toContain("acceptance criteria");
+      expect(prompt.toLowerCase()).not.toContain("### acceptance criteria");
       expect(prompt).not.toContain("false positives");
     });
 

--- a/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
@@ -64,7 +64,7 @@ Tests are failing. Fix the source so all tests pass — not just the ones listed
 4. Do not declare done until step 3 shows 0 failures.
 
 **IMPORTANT:**
-- Do NOT modify test files unless there is a legitimate bug in the test itself.
+- Do NOT modify test files — see the three narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements."
 `;
@@ -163,7 +163,7 @@ Tests are failing. Fix the source so all tests pass — not just the ones listed
 4. Do not declare done until step 3 shows 0 failures.
 
 **IMPORTANT:**
-- Do NOT modify test files unless there is a legitimate bug in the test itself.
+- Do NOT modify test files — see the three narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements."
 `;
@@ -184,11 +184,63 @@ lint output
 \`\`\`
 
 
-Fix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior. Commit your changes when all checks pass.
+Fix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior — see the three narrow exceptions appended below. Commit your changes when all checks pass.
 
 If two findings in this list contradict each other and you cannot satisfy both, do not guess.
 Emit fixes for defects you can resolve, then output a line in this exact format:
-UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
+
+### Exception 1 — Lint-only edit
+
+You MAY edit a test file ONLY when ALL of the following hold:
+- The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
+- Your edit removes or reformats a lint violation without altering any \`expect\`, \`assert\`,
+  \`toBe\`, \`toEqual\`, \`toThrow\`, \`not.\`, or equivalent assertion call, its arguments, its
+  input data, its mock setup, or its \`describe\`/\`it\`/\`test\` block text.
+- If you are uncertain whether your edit is assertion-neutral, do NOT make it — emit
+  \`UNRESOLVED\` instead.
+
+Declare every lint-only test edit with:
+\`\`\`
+TEST_EDIT_REASON: lint_only
+FILE: <test file path>
+FINDING: <lint rule or message verbatim>
+CHANGE: <before line> → <after line>
+\`\`\`
+
+### Exception 2 — PRD-contract mismatch
+
+You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
+call contradicts a literal interface signature stated in this story's description or
+acceptance criteria.
+
+Declare every contract-mismatch edit with:
+\`\`\`
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "<verbatim signature line from the story description or acceptance criteria>"
+FILE: <test file path>
+TEST_BEFORE: <offending call line>
+TEST_AFTER: <corrected call line>
+\`\`\`
+
+Do NOT use this exception to change test logic, assertions, or mock setup — only call
+signatures that directly contradict a quoted PRD interface.
+
+### Exception 3 — Sibling-story lint spillover
+
+When a lint or typecheck error is in a file you did NOT create or modify in this turn,
+do NOT edit that file. Instead declare:
+\`\`\`
+TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: <file path>
+FINDING: <error summary>
+\`\`\`
+and continue. Sibling-scope failures do not block your story."
 `;
 
 exports[`RectifierPromptBuilder.firstAttemptDelta two-categories: renders in fixed priority order, not input order 1`] = `
@@ -217,11 +269,63 @@ semantic output
 \`\`\`
 
 
-Fix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior. Commit your changes when all checks pass.
+Fix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior — see the three narrow exceptions appended below. Commit your changes when all checks pass.
 
 If two findings in this list contradict each other and you cannot satisfy both, do not guess.
 Emit fixes for defects you can resolve, then output a line in this exact format:
-UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
+
+### Exception 1 — Lint-only edit
+
+You MAY edit a test file ONLY when ALL of the following hold:
+- The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
+- Your edit removes or reformats a lint violation without altering any \`expect\`, \`assert\`,
+  \`toBe\`, \`toEqual\`, \`toThrow\`, \`not.\`, or equivalent assertion call, its arguments, its
+  input data, its mock setup, or its \`describe\`/\`it\`/\`test\` block text.
+- If you are uncertain whether your edit is assertion-neutral, do NOT make it — emit
+  \`UNRESOLVED\` instead.
+
+Declare every lint-only test edit with:
+\`\`\`
+TEST_EDIT_REASON: lint_only
+FILE: <test file path>
+FINDING: <lint rule or message verbatim>
+CHANGE: <before line> → <after line>
+\`\`\`
+
+### Exception 2 — PRD-contract mismatch
+
+You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
+call contradicts a literal interface signature stated in this story's description or
+acceptance criteria.
+
+Declare every contract-mismatch edit with:
+\`\`\`
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "<verbatim signature line from the story description or acceptance criteria>"
+FILE: <test file path>
+TEST_BEFORE: <offending call line>
+TEST_AFTER: <corrected call line>
+\`\`\`
+
+Do NOT use this exception to change test logic, assertions, or mock setup — only call
+signatures that directly contradict a quoted PRD interface.
+
+### Exception 3 — Sibling-story lint spillover
+
+When a lint or typecheck error is in a file you did NOT create or modify in this turn,
+do NOT edit that file. Instead declare:
+\`\`\`
+TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: <file path>
+FINDING: <error summary>
+\`\`\`
+and continue. Sibling-scope failures do not block your story."
 `;
 
 exports[`RectifierPromptBuilder.firstAttemptDelta all-categories: renders all five buckets with expected grouping 1`] = `
@@ -290,11 +394,63 @@ adversarial output
 \`\`\`
 
 
-Fix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior. Commit your changes when all checks pass.
+Fix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior — see the three narrow exceptions appended below. Commit your changes when all checks pass.
 
 If two findings in this list contradict each other and you cannot satisfy both, do not guess.
 Emit fixes for defects you can resolve, then output a line in this exact format:
-UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
+
+### Exception 1 — Lint-only edit
+
+You MAY edit a test file ONLY when ALL of the following hold:
+- The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
+- Your edit removes or reformats a lint violation without altering any \`expect\`, \`assert\`,
+  \`toBe\`, \`toEqual\`, \`toThrow\`, \`not.\`, or equivalent assertion call, its arguments, its
+  input data, its mock setup, or its \`describe\`/\`it\`/\`test\` block text.
+- If you are uncertain whether your edit is assertion-neutral, do NOT make it — emit
+  \`UNRESOLVED\` instead.
+
+Declare every lint-only test edit with:
+\`\`\`
+TEST_EDIT_REASON: lint_only
+FILE: <test file path>
+FINDING: <lint rule or message verbatim>
+CHANGE: <before line> → <after line>
+\`\`\`
+
+### Exception 2 — PRD-contract mismatch
+
+You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
+call contradicts a literal interface signature stated in this story's description or
+acceptance criteria.
+
+Declare every contract-mismatch edit with:
+\`\`\`
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "<verbatim signature line from the story description or acceptance criteria>"
+FILE: <test file path>
+TEST_BEFORE: <offending call line>
+TEST_AFTER: <corrected call line>
+\`\`\`
+
+Do NOT use this exception to change test logic, assertions, or mock setup — only call
+signatures that directly contradict a quoted PRD interface.
+
+### Exception 3 — Sibling-story lint spillover
+
+When a lint or typecheck error is in a file you did NOT create or modify in this turn,
+do NOT edit that file. Instead declare:
+\`\`\`
+TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: <file path>
+FINDING: <error summary>
+\`\`\`
+and continue. Sibling-scope failures do not block your story."
 `;
 
 exports[`RectifierPromptBuilder.continuation single-category: renders only the matching priority bucket 1`] = `
@@ -315,7 +471,59 @@ lint output
 
 If two findings in this list contradict each other and you cannot satisfy both, do not guess.
 Emit fixes for defects you can resolve, then output a line in this exact format:
-UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
+
+### Exception 1 — Lint-only edit
+
+You MAY edit a test file ONLY when ALL of the following hold:
+- The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
+- Your edit removes or reformats a lint violation without altering any \`expect\`, \`assert\`,
+  \`toBe\`, \`toEqual\`, \`toThrow\`, \`not.\`, or equivalent assertion call, its arguments, its
+  input data, its mock setup, or its \`describe\`/\`it\`/\`test\` block text.
+- If you are uncertain whether your edit is assertion-neutral, do NOT make it — emit
+  \`UNRESOLVED\` instead.
+
+Declare every lint-only test edit with:
+\`\`\`
+TEST_EDIT_REASON: lint_only
+FILE: <test file path>
+FINDING: <lint rule or message verbatim>
+CHANGE: <before line> → <after line>
+\`\`\`
+
+### Exception 2 — PRD-contract mismatch
+
+You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
+call contradicts a literal interface signature stated in this story's description or
+acceptance criteria.
+
+Declare every contract-mismatch edit with:
+\`\`\`
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "<verbatim signature line from the story description or acceptance criteria>"
+FILE: <test file path>
+TEST_BEFORE: <offending call line>
+TEST_AFTER: <corrected call line>
+\`\`\`
+
+Do NOT use this exception to change test logic, assertions, or mock setup — only call
+signatures that directly contradict a quoted PRD interface.
+
+### Exception 3 — Sibling-story lint spillover
+
+When a lint or typecheck error is in a file you did NOT create or modify in this turn,
+do NOT edit that file. Instead declare:
+\`\`\`
+TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: <file path>
+FINDING: <error summary>
+\`\`\`
+and continue. Sibling-scope failures do not block your story."
 `;
 
 exports[`RectifierPromptBuilder.continuation two-categories: renders in fixed priority order, not input order 1`] = `
@@ -346,7 +554,59 @@ semantic output
 
 If two findings in this list contradict each other and you cannot satisfy both, do not guess.
 Emit fixes for defects you can resolve, then output a line in this exact format:
-UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
+
+### Exception 1 — Lint-only edit
+
+You MAY edit a test file ONLY when ALL of the following hold:
+- The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
+- Your edit removes or reformats a lint violation without altering any \`expect\`, \`assert\`,
+  \`toBe\`, \`toEqual\`, \`toThrow\`, \`not.\`, or equivalent assertion call, its arguments, its
+  input data, its mock setup, or its \`describe\`/\`it\`/\`test\` block text.
+- If you are uncertain whether your edit is assertion-neutral, do NOT make it — emit
+  \`UNRESOLVED\` instead.
+
+Declare every lint-only test edit with:
+\`\`\`
+TEST_EDIT_REASON: lint_only
+FILE: <test file path>
+FINDING: <lint rule or message verbatim>
+CHANGE: <before line> → <after line>
+\`\`\`
+
+### Exception 2 — PRD-contract mismatch
+
+You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
+call contradicts a literal interface signature stated in this story's description or
+acceptance criteria.
+
+Declare every contract-mismatch edit with:
+\`\`\`
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "<verbatim signature line from the story description or acceptance criteria>"
+FILE: <test file path>
+TEST_BEFORE: <offending call line>
+TEST_AFTER: <corrected call line>
+\`\`\`
+
+Do NOT use this exception to change test logic, assertions, or mock setup — only call
+signatures that directly contradict a quoted PRD interface.
+
+### Exception 3 — Sibling-story lint spillover
+
+When a lint or typecheck error is in a file you did NOT create or modify in this turn,
+do NOT edit that file. Instead declare:
+\`\`\`
+TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: <file path>
+FINDING: <error summary>
+\`\`\`
+and continue. Sibling-scope failures do not block your story."
 `;
 
 exports[`RectifierPromptBuilder.continuation all-categories: renders all five buckets with expected grouping 1`] = `
@@ -423,5 +683,57 @@ adversarial output
 
 If two findings in this list contradict each other and you cannot satisfy both, do not guess.
 Emit fixes for defects you can resolve, then output a line in this exact format:
-UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>"
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
+
+### Exception 1 — Lint-only edit
+
+You MAY edit a test file ONLY when ALL of the following hold:
+- The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
+- Your edit removes or reformats a lint violation without altering any \`expect\`, \`assert\`,
+  \`toBe\`, \`toEqual\`, \`toThrow\`, \`not.\`, or equivalent assertion call, its arguments, its
+  input data, its mock setup, or its \`describe\`/\`it\`/\`test\` block text.
+- If you are uncertain whether your edit is assertion-neutral, do NOT make it — emit
+  \`UNRESOLVED\` instead.
+
+Declare every lint-only test edit with:
+\`\`\`
+TEST_EDIT_REASON: lint_only
+FILE: <test file path>
+FINDING: <lint rule or message verbatim>
+CHANGE: <before line> → <after line>
+\`\`\`
+
+### Exception 2 — PRD-contract mismatch
+
+You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
+call contradicts a literal interface signature stated in this story's description or
+acceptance criteria.
+
+Declare every contract-mismatch edit with:
+\`\`\`
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "<verbatim signature line from the story description or acceptance criteria>"
+FILE: <test file path>
+TEST_BEFORE: <offending call line>
+TEST_AFTER: <corrected call line>
+\`\`\`
+
+Do NOT use this exception to change test logic, assertions, or mock setup — only call
+signatures that directly contradict a quoted PRD interface.
+
+### Exception 3 — Sibling-story lint spillover
+
+When a lint or typecheck error is in a file you did NOT create or modify in this turn,
+do NOT edit that file. Instead declare:
+\`\`\`
+TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: <file path>
+FINDING: <error summary>
+\`\`\`
+and continue. Sibling-scope failures do not block your story."
 `;

--- a/test/unit/prompts/builders/rectifier-builder-review-labels.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder-review-labels.test.ts
@@ -101,7 +101,7 @@ describe("RectifierPromptBuilder.reviewRectification — semantic-only", () => {
     const checks = [makeCheck("semantic", "AC-1 not implemented")];
     const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
 
-    expect(prompt.toLowerCase()).not.toContain("adversarial");
+    expect(prompt.toLowerCase()).not.toContain("adversarial review findings");
   });
 });
 
@@ -182,6 +182,6 @@ describe("RectifierPromptBuilder.reviewRectification — mechanical-only regress
 
     expect(prompt).toContain("lint/typecheck");
     expect(prompt).not.toContain("semantic review");
-    expect(prompt.toLowerCase()).not.toContain("adversarial");
+    expect(prompt.toLowerCase()).not.toContain("adversarial review findings");
   });
 });

--- a/test/unit/prompts/builders/rectifier-builder.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder.test.ts
@@ -102,7 +102,7 @@ describe("RectifierPromptBuilder.firstAttemptDelta", () => {
     );
 
     const qCount = (prompt.match(/Q/g) ?? []).length;
-    expect(qCount).toBeLessThanOrEqual(4000);
+    expect(qCount).toBeLessThanOrEqual(4010);
     expect(qCount).toBeLessThan(10_000);
     expect(prompt).toContain("truncated");
     expect(prompt).toContain("10000 chars total");
@@ -153,7 +153,7 @@ describe("RectifierPromptBuilder.firstAttemptDelta", () => {
       2,
     );
 
-    expect(prompt.toLowerCase()).not.toContain("acceptance criteria");
+    expect(prompt.toLowerCase()).not.toContain("### acceptance criteria");
     expect(prompt).not.toMatch(/^Story:/m);
     expect(prompt.toLowerCase()).not.toContain("constitution");
   });
@@ -312,7 +312,7 @@ describe("RectifierPromptBuilder.continuation", () => {
     );
 
     // Should not have the full AC list or the "Acceptance Criteria" section found in full prompts
-    expect(prompt.toLowerCase()).not.toContain("acceptance criteria");
+    expect(prompt.toLowerCase()).not.toContain("### acceptance criteria");
   });
 
   test("continuation prompt does NOT contain story title section", () => {

--- a/test/unit/prompts/builders/rectifier-builder.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder.test.ts
@@ -102,7 +102,7 @@ describe("RectifierPromptBuilder.firstAttemptDelta", () => {
     );
 
     const qCount = (prompt.match(/Q/g) ?? []).length;
-    expect(qCount).toBeLessThanOrEqual(4010);
+    expect(qCount).toBeLessThanOrEqual(4010); // +10 slack: CONTRADICTION_ESCAPE_HATCH contains "PRD_QUOTE" (one uppercase Q)
     expect(qCount).toBeLessThan(10_000);
     expect(prompt).toContain("truncated");
     expect(prompt).toContain("10000 chars total");


### PR DESCRIPTION
## Summary

- Extends `CONTRADICTION_ESCAPE_HATCH` (appended to all rectification prompts) with three narrow escape valves so the implementer can edit test files in specific situations instead of always emitting `UNRESOLVED:`
- Updates all 6 inline "do not modify test files" strings across `rectifier-builder.ts`, `rectifier-builder-helpers.ts`, and `role-task.ts` to reference the new exceptions
- Adds `TEST_EDIT_REASON:` audit log in `autofix-implementer.ts` (`parse()`) and `rectification-gate.ts` for observability

## Motivation

Forensic audit (`logs/FORENSIC-AUDIT-2026-05-05.md`) identified the absolute test-immutability rule as the dominant failure mode in 2 of 3 failed dogfood stories:

- **US-004**: test-writer wrote a 2-arg call against a PRD-declared 3-arg interface; implementer could not fix and could not satisfy the broken assertion
- **US-006**: project-wide lint flagged `!` non-null assertions in sibling-story test files; rectification prompt simultaneously said "fix ALL errors" and "do NOT change test files" — irreconcilable; implementer correctly emitted `UNRESOLVED` and exhausted retries

## The three exception cases

| Case | Condition | Required declaration |
|---|---|---|
| `lint_only` | Lint-only check, assertion-neutral reformat | `TEST_EDIT_REASON: lint_only` + FILE + FINDING + CHANGE |
| `prd_contract` | Test call contradicts verbatim PRD interface signature | `TEST_EDIT_REASON: prd_contract` + PRD_QUOTE + FILE + TEST_BEFORE + TEST_AFTER |
| `sibling_scope` | Error in a file not created/modified in this turn | `TEST_EDIT_REASON: sibling_scope` + SIBLING_FILE + FINDING (declare, do not edit) |

Outside these three cases the rule remains absolute.

## Scope

Prompt-only changes — no new code paths, no harness enforcement. Deferred items (typed UNRESOLVED subtypes, PRD_QUOTE validation, implementer→test-writer feedback loop) tracked in #933.

## Test Plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun run test` passes (8 snapshots updated, 4 overly-broad assertions narrowed)
- [ ] Re-run `memory-phase4-graph-code-intelligence` dogfood PRD — US-004 should resolve without escalation; US-006 should declare sibling files instead of blocking