### PR TITLE
fix(curator): populate review-finding payload.message from LLM `issue`

### DIFF
--- a/src/plugins/builtin/curator/collect.ts
+++ b/src/plugins/builtin/curator/collect.ts
@@ -122,6 +122,24 @@ function findingRuleId(finding: JsonRecord): string {
   return stringValue(finding.rule ?? finding.ruleId ?? finding.checkId ?? finding.category, "unknown");
 }
 
+/**
+ * Extract a human-readable message from a finding record.
+ *
+ * Two on-disk shapes coexist in `review-audit/*.json`:
+ * - Canonical `ReviewFinding` (lint-style): has `message`.
+ * - `LLMFinding` (semantic/adversarial reviewers): has `issue` + optional `suggestion`,
+ *   no `message` field. Without this fallback, `payload.message` is always empty
+ *   for LLM findings — the dominant source today.
+ */
+function findingMessage(finding: JsonRecord): string {
+  const message = stringValue(finding.message);
+  if (message) return message;
+  const issue = stringValue(finding.issue);
+  const suggestion = stringValue(finding.suggestion);
+  if (issue && suggestion) return `${issue}\n→ ${suggestion}`;
+  return issue;
+}
+
 async function collectFromReviewAudit(context: CuratorPostRunContext): Promise<Observation[]> {
   const observations: Observation[] = [];
   const auditDir = path.join(context.outputDir, "review-audit");
@@ -154,7 +172,7 @@ async function collectFromReviewAudit(context: CuratorPostRunContext): Promise<O
               severity: stringValue(finding.severity, "info"),
               file: stringValue(finding.file),
               line: numberValue(finding.line, 0),
-              message: stringValue(finding.message),
+              message: findingMessage(finding),
             },
           };
           observations.push(obs);

--- a/test/unit/plugins/builtin/curator-collector.test.ts
+++ b/test/unit/plugins/builtin/curator-collector.test.ts
@@ -363,4 +363,142 @@ describe("collectObservations", () => {
     expect(observations.some((o) => o.kind === "acceptance-verdict" && o.payload.failedACs?.includes("AC-2"))).toBe(true);
     expect(observations.some((o) => o.kind === "fix-cycle-iteration" && o.payload.outcome === "unchanged")).toBe(true);
   });
+
+  test("projects LLM-shaped review findings (issue/suggestion) into payload.message", async () => {
+    const root = await mkdtemp(join(tmpdir(), "curator-llm-finding-"));
+    const outputDir = join(root, "out");
+    const auditDir = join(outputDir, "review-audit", "feat-x");
+    await mkdir(auditDir, { recursive: true });
+
+    await writeFile(
+      join(auditDir, "1-review-semantic-US-001.json"),
+      JSON.stringify({
+        timestamp: "2026-05-06T00:00:00.000Z",
+        storyId: "US-001",
+        featureName: "feat-x",
+        reviewer: "semantic",
+        result: {
+          findings: [
+            {
+              severity: "warning",
+              category: "input",
+              file: "src/foo.ts",
+              line: 73,
+              issue: "onAgentStream(listener) does not validate that `listener` is a function.",
+              suggestion: "Add a guard: `if (typeof listener !== 'function') return () => {};` at the top.",
+            },
+            {
+              severity: "info",
+              category: "error-path",
+              file: "src/foo.ts",
+              line: 81,
+              issue: "Listener errors are swallowed when logger is null.",
+              // no suggestion
+            },
+          ],
+        },
+      }),
+    );
+
+    const context: CuratorPostRunContext = {
+      runId: "run-llm",
+      feature: "feat-x",
+      workdir: root,
+      prdPath: join(root, "prd.json"),
+      branch: "main",
+      totalDurationMs: 1000,
+      totalCost: 0,
+      storySummary: { completed: 1, failed: 0, skipped: 0, paused: 0 },
+      stories: [],
+      version: "0.1.0",
+      pluginConfig: {},
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+      config: {} as any,
+      outputDir,
+      globalDir: join(root, "global"),
+      projectKey: "test-project",
+      curatorRollupPath: join(root, "rollup.jsonl"),
+    };
+
+    const observations = await collectObservations(context);
+    const findings = observations.filter((o) => o.kind === "review-finding");
+    expect(findings.length).toBe(2);
+
+    const withSuggestion = findings.find(
+      (o) => o.kind === "review-finding" && o.payload.line === 73,
+    );
+    expect(withSuggestion).toBeDefined();
+    if (withSuggestion?.kind === "review-finding") {
+      expect(withSuggestion.payload.message).toContain(
+        "onAgentStream(listener) does not validate",
+      );
+      expect(withSuggestion.payload.message).toContain("Add a guard");
+    }
+
+    const noSuggestion = findings.find(
+      (o) => o.kind === "review-finding" && o.payload.line === 81,
+    );
+    expect(noSuggestion).toBeDefined();
+    if (noSuggestion?.kind === "review-finding") {
+      expect(noSuggestion.payload.message).toBe(
+        "Listener errors are swallowed when logger is null.",
+      );
+    }
+  });
+
+  test("prefers canonical `message` field when both message and issue are present", async () => {
+    const root = await mkdtemp(join(tmpdir(), "curator-canonical-finding-"));
+    const outputDir = join(root, "out");
+    const auditDir = join(outputDir, "review-audit", "feat-y");
+    await mkdir(auditDir, { recursive: true });
+
+    await writeFile(
+      join(auditDir, "1-review.json"),
+      JSON.stringify({
+        timestamp: "2026-05-06T00:00:00.000Z",
+        storyId: "US-002",
+        featureName: "feat-y",
+        result: {
+          findings: [
+            {
+              ruleId: "no-foo",
+              severity: "error",
+              file: "src/bar.ts",
+              line: 10,
+              message: "canonical message wins",
+              issue: "should be ignored",
+              suggestion: "also ignored",
+            },
+          ],
+        },
+      }),
+    );
+
+    const context: CuratorPostRunContext = {
+      runId: "run-canonical",
+      feature: "feat-y",
+      workdir: root,
+      prdPath: join(root, "prd.json"),
+      branch: "main",
+      totalDurationMs: 1000,
+      totalCost: 0,
+      storySummary: { completed: 1, failed: 0, skipped: 0, paused: 0 },
+      stories: [],
+      version: "0.1.0",
+      pluginConfig: {},
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+      config: {} as any,
+      outputDir,
+      globalDir: join(root, "global"),
+      projectKey: "test-project",
+      curatorRollupPath: join(root, "rollup.jsonl"),
+    };
+
+    const observations = await collectObservations(context);
+    const finding = observations.find((o) => o.kind === "review-finding");
+    expect(finding).toBeDefined();
+    if (finding?.kind === "review-finding") {
+      expect(finding.payload.message).toBe("canonical message wins");
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Curator's `collectFromReviewAudit` projector read `finding.message`, but semantic and adversarial reviewers serialize findings with the `LLMFinding` shape (`issue` + optional `suggestion`) — no `message` field. Result: every review-finding observation in `observations.jsonl` had `message: ""`, hiding the actual problem text from `curator-proposals.md`.
- Map `issue` (with `suggestion` appended) into `payload.message` when canonical `message` is absent. Canonical `ReviewFinding` records (lint-style) keep their existing precedence.
- Source-side normalization (the deeper shape mismatch — `ruleId` falling through to `category` and producing coarse H1 buckets like `input`/`unknown`) is tracked separately in #942.

## Repro / evidence

`runs/<runId>/observations.jsonl` from a real koda-style run before this fix:

```json
{"kind":"review-finding","payload":{"ruleId":"input","checkId":"input","severity":"warning","file":"src/runtime/agent-stream-events.ts","line":73,"message":""}}
```

The on-disk audit record actually carried `issue: "onAgentStream(listener) does not validate that listener is a function..."` — silently dropped by the projector.

## Test plan

- [x] New unit test asserts LLM-shape findings (with and without `suggestion`) project into a non-empty `payload.message`
- [x] New unit test asserts canonical `message` still wins when both are present
- [x] Watched RED → GREEN on the new tests (12 pass, was 11/1)
- [x] Full curator suite green (70 tests across 5 files)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean

## Follow-up

#942 — normalize LLM findings to canonical `ReviewFinding` shape at the reviewer (so the fallback in this PR can be deleted and H1 groupings stop collapsing to coarse categories).
