### PR TITLE
feat(review): curator finding normalization — canonical ReviewFinding on disk (#942 Phase 1)

### DIFF
--- a/src/plugins/extensions.ts
+++ b/src/plugins/extensions.ts
@@ -40,6 +40,13 @@ export interface ReviewFinding {
   source?: string;
   /** Finding category (e.g., "security", "performance", "style", "bug") */
   category?: string;
+  /**
+   * Producer-defined sidecar metadata. LLM reviewers populate this with the
+   * raw `issue` / `suggestion` strings, AC-binding (`acQuote`, `acIndex`,
+   * `acId`), and `verifiedBy` evidence so on-disk audits remain debuggable
+   * without re-introducing the LLMFinding shape at the top level.
+   */
+  meta?: Record<string, unknown>;
 }
 
 /**

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -34,6 +34,7 @@ import {
   toAdversarialReviewFindings,
 } from "./adversarial-helpers";
 import { collectDiff, collectDiffStat, computeTestInventory, resolveEffectiveRef } from "./diff-utils";
+import { llmFindingsToReviewFindings } from "./finding-projection";
 import { writeReviewAudit } from "./review-audit";
 import type { AdversarialReviewConfig, ReviewCheckResult, SemanticStory } from "./types";
 
@@ -416,8 +417,14 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       failOpen: false,
       passed: false,
       blockingThreshold: threshold,
-      result: { passed: false, findings: parsed.findings },
-      advisoryFindings,
+      result: {
+        passed: false,
+        findings: llmFindingsToReviewFindings(parsed.findings, { source: "adversarial-review" }),
+      },
+      advisoryFindings:
+        advisoryFindings.length > 0
+          ? llmFindingsToReviewFindings(advisoryFindings, { source: "adversarial-review" })
+          : undefined,
     });
     return {
       check: "adversarial",
@@ -449,8 +456,14 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       failOpen: false,
       passed: true,
       blockingThreshold: threshold,
-      result: { passed: true, findings: parsed.findings },
-      advisoryFindings,
+      result: {
+        passed: true,
+        findings: llmFindingsToReviewFindings(parsed.findings, { source: "adversarial-review" }),
+      },
+      advisoryFindings:
+        advisoryFindings.length > 0
+          ? llmFindingsToReviewFindings(advisoryFindings, { source: "adversarial-review" })
+          : undefined,
     });
     return {
       check: "adversarial",
@@ -478,8 +491,14 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
     failOpen: false,
     passed: parsed.passed,
     blockingThreshold: threshold,
-    result: { passed: parsed.passed, findings: parsed.findings },
-    advisoryFindings,
+    result: {
+      passed: parsed.passed,
+      findings: llmFindingsToReviewFindings(parsed.findings, { source: "adversarial-review" }),
+    },
+    advisoryFindings:
+      advisoryFindings.length > 0
+        ? llmFindingsToReviewFindings(advisoryFindings, { source: "adversarial-review" })
+        : undefined,
   });
   return {
     check: "adversarial",

--- a/src/review/finding-projection.ts
+++ b/src/review/finding-projection.ts
@@ -13,6 +13,7 @@
  * dashboards) only deal with the canonical shape.
  */
 
+import type { Finding } from "../findings";
 import type { ReviewFinding } from "../plugins/extensions";
 import type { AdversarialLLMFinding } from "./adversarial-helpers";
 import type { LLMFinding } from "./semantic-helpers";
@@ -109,4 +110,37 @@ export function llmFindingToReviewFinding(f: AnyLLMFinding, opts: ProjectionOpti
 
 export function llmFindingsToReviewFindings(findings: AnyLLMFinding[], opts: ProjectionOptions = {}): ReviewFinding[] {
   return findings.map((f) => llmFindingToReviewFinding(f, opts));
+}
+
+/**
+ * Project a unified `Finding` (ADR-021 wire format, e.g. from the
+ * dialogue/verdict path) to canonical `ReviewFinding` for audit persistence.
+ *
+ * `Finding` already carries `message` and an optional `rule`; this mapper
+ * promotes `rule` to `ruleId` when present, falls back to deriving a ruleId
+ * from `category` + slug of the message when `rule` is absent, and routes
+ * any sidecar fields into `meta`.
+ */
+export function findingToReviewFinding(f: Finding, opts: ProjectionOptions = {}): ReviewFinding {
+  const narrowed = narrowSeverity(f.severity);
+  const ruleId = f.rule?.trim() ? f.rule.trim() : deriveRuleId(f.category, f.message);
+  const result: ReviewFinding = {
+    ruleId,
+    severity: narrowed,
+    file: f.file ?? "",
+    line: f.line ?? 0,
+    message: f.message,
+  };
+  if (f.category) result.category = f.category;
+  const effectiveSource = opts.source ?? (f.source as string | undefined);
+  if (effectiveSource) result.source = effectiveSource;
+  const meta: Record<string, unknown> = { ...(f.meta ?? {}) };
+  if (f.suggestion) meta.suggestion = f.suggestion;
+  if (f.severity !== narrowed) meta.originalSeverity = f.severity;
+  if (Object.keys(meta).length > 0) result.meta = meta;
+  return result;
+}
+
+export function findingsToReviewFindings(findings: Finding[], opts: ProjectionOptions = {}): ReviewFinding[] {
+  return findings.map((f) => findingToReviewFinding(f, opts));
 }

--- a/src/review/finding-projection.ts
+++ b/src/review/finding-projection.ts
@@ -37,12 +37,14 @@ function narrowSeverity(raw: string): ReviewFinding["severity"] {
   return SEVERITY_MAP[raw] ?? "info";
 }
 
+/** Six tokens balances clustering (related findings collide) and specificity (genuinely different issues stay distinct). */
+const RULE_ID_SLUG_TOKENS = 6;
+
 /**
  * Slugify the leading tokens of an issue string into a stable, human-readable
- * key fragment. Six tokens balances clustering (related findings collide) and
- * specificity (genuinely different issues stay distinct).
+ * key fragment.
  */
-function slugLeadingTokens(text: string, tokenCount = 6): string {
+function slugLeadingTokens(text: string, tokenCount = RULE_ID_SLUG_TOKENS): string {
   return text
     .toLowerCase()
     .replace(/[^a-z0-9\s-]/g, " ")
@@ -67,22 +69,21 @@ function joinMessage(issue: string, suggestion: string | undefined): string {
   return trimmedIssue;
 }
 
-function buildMeta(f: AnyLLMFinding): Record<string, unknown> | undefined {
-  // Only populate meta when LLM-specific annotation fields are present.
-  // issue/suggestion are always on LLMFinding and are also included in meta
-  // for debuggability, but only when an annotation field anchors the meta.
-  const hasAnnotation =
-    !!f.acQuote || f.acIndex != null || ("acId" in f && !!f.acId) || ("verifiedBy" in f && !!f.verifiedBy);
-  if (!hasAnnotation) return undefined;
-
+function buildMeta(f: AnyLLMFinding, originalSeverity?: string): Record<string, unknown> | undefined {
   const meta: Record<string, unknown> = {};
+  // Always persist raw issue/suggestion so autofix consumers can address them separately.
   if (f.issue) meta.issue = f.issue;
   if (f.suggestion) meta.suggestion = f.suggestion;
+  // AC-annotation fields — only when present and valid.
   if (f.acQuote) meta.acQuote = f.acQuote;
-  if (f.acIndex != null) meta.acIndex = f.acIndex;
+  // acIndex is 1-based; 0 is a buggy LLM emission and must not be persisted.
+  if (typeof f.acIndex === "number" && f.acIndex >= 1) meta.acIndex = f.acIndex;
   if ("acId" in f && f.acId) meta.acId = f.acId;
   if ("verifiedBy" in f && f.verifiedBy) meta.verifiedBy = f.verifiedBy;
-  return meta;
+  // Preserve the raw severity when narrowing changes the value so consumers
+  // can still bucket "unverifiable" separately from genuine info findings.
+  if (originalSeverity !== undefined) meta.originalSeverity = originalSeverity;
+  return Object.keys(meta).length > 0 ? meta : undefined;
 }
 
 function findingCategory(f: AnyLLMFinding): string | undefined {
@@ -91,16 +92,17 @@ function findingCategory(f: AnyLLMFinding): string | undefined {
 
 export function llmFindingToReviewFinding(f: AnyLLMFinding, opts: ProjectionOptions = {}): ReviewFinding {
   const category = findingCategory(f);
+  const narrowed = narrowSeverity(f.severity);
   const result: ReviewFinding = {
     ruleId: deriveRuleId(category, f.issue),
-    severity: narrowSeverity(f.severity),
+    severity: narrowed,
     file: f.file,
     line: f.line,
     message: joinMessage(f.issue, f.suggestion),
   };
   if (category) result.category = category;
   if (opts.source) result.source = opts.source;
-  const meta = buildMeta(f);
+  const meta = buildMeta(f, f.severity !== narrowed ? f.severity : undefined);
   if (meta) result.meta = meta;
   return result;
 }

--- a/src/review/finding-projection.ts
+++ b/src/review/finding-projection.ts
@@ -1,0 +1,110 @@
+/**
+ * Source-side projection of LLM reviewer findings → canonical ReviewFinding.
+ *
+ * Issue #942 — semantic / adversarial / semantic-debate reviewers historically
+ * persisted their LLMFinding shape (issue/suggestion, no ruleId/message) to
+ * `.nax/review-audit/*.json`, which forced the curator collector to fall back
+ * to `category` for ruleId and collapsed H1 buckets to coarse single words
+ * ("assumption" / "input" / "unknown" 39×).
+ *
+ * This module is the SSOT for the projection. Every audit-write call site
+ * must convert LLMFinding[] → ReviewFinding[] through these helpers BEFORE
+ * persisting to disk so downstream consumers (curator, future review
+ * dashboards) only deal with the canonical shape.
+ */
+
+import type { ReviewFinding } from "../plugins/extensions";
+import type { AdversarialLLMFinding } from "./adversarial-helpers";
+import type { LLMFinding } from "./semantic-helpers";
+
+type AnyLLMFinding = LLMFinding | AdversarialLLMFinding;
+
+export interface ProjectionOptions {
+  /** Producer label for `ReviewFinding.source` (e.g. "semantic-review"). */
+  source?: string;
+}
+
+const SEVERITY_MAP: Record<string, ReviewFinding["severity"]> = {
+  critical: "critical",
+  error: "error",
+  warning: "warning",
+  warn: "warning",
+  info: "info",
+  low: "low",
+};
+
+function narrowSeverity(raw: string): ReviewFinding["severity"] {
+  return SEVERITY_MAP[raw] ?? "info";
+}
+
+/**
+ * Slugify the leading tokens of an issue string into a stable, human-readable
+ * key fragment. Six tokens balances clustering (related findings collide) and
+ * specificity (genuinely different issues stay distinct).
+ */
+function slugLeadingTokens(text: string, tokenCount = 6): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, tokenCount)
+    .join("-");
+}
+
+function deriveRuleId(category: string | undefined, issue: string): string {
+  const prefix = category?.trim() ? category.trim() : "review";
+  const slug = slugLeadingTokens(issue) || "unspecified";
+  return `${prefix}:${slug}`;
+}
+
+function joinMessage(issue: string, suggestion: string | undefined): string {
+  const trimmedIssue = issue.trim();
+  const trimmedSuggestion = (suggestion ?? "").trim();
+  if (trimmedIssue && trimmedSuggestion) {
+    return `${trimmedIssue}\n→ ${trimmedSuggestion}`;
+  }
+  return trimmedIssue;
+}
+
+function buildMeta(f: AnyLLMFinding): Record<string, unknown> | undefined {
+  // Only populate meta when LLM-specific annotation fields are present.
+  // issue/suggestion are always on LLMFinding and are also included in meta
+  // for debuggability, but only when an annotation field anchors the meta.
+  const hasAnnotation =
+    !!f.acQuote || f.acIndex != null || ("acId" in f && !!f.acId) || ("verifiedBy" in f && !!f.verifiedBy);
+  if (!hasAnnotation) return undefined;
+
+  const meta: Record<string, unknown> = {};
+  if (f.issue) meta.issue = f.issue;
+  if (f.suggestion) meta.suggestion = f.suggestion;
+  if (f.acQuote) meta.acQuote = f.acQuote;
+  if (f.acIndex != null) meta.acIndex = f.acIndex;
+  if ("acId" in f && f.acId) meta.acId = f.acId;
+  if ("verifiedBy" in f && f.verifiedBy) meta.verifiedBy = f.verifiedBy;
+  return meta;
+}
+
+function findingCategory(f: AnyLLMFinding): string | undefined {
+  return "category" in f && f.category ? f.category : undefined;
+}
+
+export function llmFindingToReviewFinding(f: AnyLLMFinding, opts: ProjectionOptions = {}): ReviewFinding {
+  const category = findingCategory(f);
+  const result: ReviewFinding = {
+    ruleId: deriveRuleId(category, f.issue),
+    severity: narrowSeverity(f.severity),
+    file: f.file,
+    line: f.line,
+    message: joinMessage(f.issue, f.suggestion),
+  };
+  if (category) result.category = category;
+  if (opts.source) result.source = opts.source;
+  const meta = buildMeta(f);
+  if (meta) result.meta = meta;
+  return result;
+}
+
+export function llmFindingsToReviewFindings(findings: AnyLLMFinding[], opts: ProjectionOptions = {}): ReviewFinding[] {
+  return findings.map((f) => llmFindingToReviewFinding(f, opts));
+}

--- a/src/review/finding-projection.ts
+++ b/src/review/finding-projection.ts
@@ -55,6 +55,16 @@ function slugLeadingTokens(text: string, tokenCount = RULE_ID_SLUG_TOKENS): stri
     .join("-");
 }
 
+/**
+ * Derive a stable ruleId from `category` + slug of the leading issue tokens.
+ *
+ * Empty or punctuation-only `issue` values (malformed LLM output) fall back
+ * to the `"unspecified"` slug — e.g. `"review:unspecified"` or
+ * `"input:unspecified"`. Multiple such findings will share the same bucket,
+ * which is acceptable: they represent broken LLM output rather than distinct
+ * signal. Callers should not rely on `unspecified` buckets for anything other
+ * than "something went wrong with the LLM response."
+ */
 function deriveRuleId(category: string | undefined, issue: string): string {
   const prefix = category?.trim() ? category.trim() : "review";
   const slug = slugLeadingTokens(issue) || "unspecified";
@@ -72,7 +82,7 @@ function joinMessage(issue: string, suggestion: string | undefined): string {
 
 function buildMeta(f: AnyLLMFinding, originalSeverity?: string): Record<string, unknown> | undefined {
   const meta: Record<string, unknown> = {};
-  // Always persist raw issue/suggestion so autofix consumers can address them separately.
+  // Persist non-empty issue/suggestion so autofix consumers can address them separately.
   if (f.issue) meta.issue = f.issue;
   if (f.suggestion) meta.suggestion = f.suggestion;
   // AC-annotation fields — only when present and valid.

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -7,5 +7,6 @@
 export * from "./adversarial";
 export * from "./categorization";
 export * from "./diff-utils";
+export * from "./finding-projection";
 export * from "./types";
 export * from "./runner";

--- a/src/review/semantic-debate.ts
+++ b/src/review/semantic-debate.ts
@@ -12,6 +12,7 @@ import type { ReviewConfig } from "../config/selectors";
 import type { DebateRunner, DebateRunnerOptions } from "../debate";
 import { getSafeLogger } from "../logger";
 import { filterByAcQuote } from "./ac-quote-validator";
+import { llmFindingsToReviewFindings } from "./finding-projection";
 import {
   type LLMFinding,
   formatFindings,
@@ -261,8 +262,14 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
         parsed: true,
         passed: false,
         blockingThreshold: debateThreshold,
-        result: { passed: false, findings: debateFindings },
-        advisoryFindings: debateAdvisory,
+        result: {
+          passed: false,
+          findings: llmFindingsToReviewFindings(debateFindings, { source: "semantic-debate-review" }),
+        },
+        advisoryFindings:
+          debateAdvisory.length > 0
+            ? llmFindingsToReviewFindings(debateAdvisory, { source: "semantic-debate-review" })
+            : undefined,
       });
       return {
         check: "semantic",
@@ -289,8 +296,14 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
       parsed: true,
       passed: true,
       blockingThreshold: debateThreshold,
-      result: { passed: true, findings: debateFindings },
-      advisoryFindings: debateAdvisory,
+      result: {
+        passed: true,
+        findings: llmFindingsToReviewFindings(debateFindings, { source: "semantic-debate-review" }),
+      },
+      advisoryFindings:
+        debateAdvisory.length > 0
+          ? llmFindingsToReviewFindings(debateAdvisory, { source: "semantic-debate-review" })
+          : undefined,
     });
     return {
       check: "semantic",
@@ -312,8 +325,14 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
     parsed: true,
     passed: true,
     blockingThreshold: debateThreshold,
-    result: { passed: true, findings: debateFindings },
-    advisoryFindings: debateAdvisory,
+    result: {
+      passed: true,
+      findings: llmFindingsToReviewFindings(debateFindings, { source: "semantic-debate-review" }),
+    },
+    advisoryFindings:
+      debateAdvisory.length > 0
+        ? llmFindingsToReviewFindings(debateAdvisory, { source: "semantic-debate-review" })
+        : undefined,
   });
   return {
     check: "semantic",

--- a/src/review/semantic-debate.ts
+++ b/src/review/semantic-debate.ts
@@ -12,7 +12,7 @@ import type { ReviewConfig } from "../config/selectors";
 import type { DebateRunner, DebateRunnerOptions } from "../debate";
 import { getSafeLogger } from "../logger";
 import { filterByAcQuote } from "./ac-quote-validator";
-import { llmFindingsToReviewFindings } from "./finding-projection";
+import { findingsToReviewFindings, llmFindingsToReviewFindings } from "./finding-projection";
 import {
   type LLMFinding,
   formatFindings,
@@ -169,7 +169,10 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
           parsed: true,
           passed: false,
           blockingThreshold,
-          result: { passed: false, findings },
+          result: {
+            passed: false,
+            findings: findingsToReviewFindings(findings, { source: "semantic-debate-review" }),
+          },
         });
         return {
           check: "semantic",
@@ -194,7 +197,10 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
         parsed: true,
         passed: true,
         blockingThreshold,
-        result: { passed: true, findings },
+        result: {
+          passed: true,
+          findings: findingsToReviewFindings(findings, { source: "semantic-debate-review" }),
+        },
       });
       return {
         check: "semantic",

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -27,6 +27,7 @@ import { filterByAcQuote } from "./ac-quote-validator";
 import { DIFF_CAP_BYTES, collectDiff, collectDiffStat, resolveEffectiveRef, truncateDiff } from "./diff-utils";
 import { writeReviewAudit } from "./review-audit";
 import { runSemanticDebate } from "./semantic-debate";
+import { llmFindingsToReviewFindings } from "./finding-projection";
 import { substantiateSemanticEvidence } from "./semantic-evidence";
 import {
   type LLMFinding,
@@ -467,8 +468,14 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       failOpen: false,
       passed: false,
       blockingThreshold: threshold,
-      result: { passed: false, findings: sanitizedParsed.findings },
-      advisoryFindings,
+      result: {
+        passed: false,
+        findings: llmFindingsToReviewFindings(sanitizedParsed.findings, { source: "semantic-review" }),
+      },
+      advisoryFindings:
+        advisoryFindings.length > 0
+          ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review" })
+          : undefined,
     });
     return {
       check: "semantic",
@@ -500,8 +507,14 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
       failOpen: false,
       passed: true,
       blockingThreshold: threshold,
-      result: { passed: true, findings: sanitizedParsed.findings },
-      advisoryFindings,
+      result: {
+        passed: true,
+        findings: llmFindingsToReviewFindings(sanitizedParsed.findings, { source: "semantic-review" }),
+      },
+      advisoryFindings:
+        advisoryFindings.length > 0
+          ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review" })
+          : undefined,
     });
     return {
       check: "semantic",
@@ -529,8 +542,14 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     failOpen: false,
     passed: sanitizedParsed.passed,
     blockingThreshold: threshold,
-    result: { passed: sanitizedParsed.passed, findings: sanitizedParsed.findings },
-    advisoryFindings,
+    result: {
+      passed: sanitizedParsed.passed,
+      findings: llmFindingsToReviewFindings(sanitizedParsed.findings, { source: "semantic-review" }),
+    },
+    advisoryFindings:
+      advisoryFindings.length > 0
+        ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review" })
+        : undefined,
   });
   return {
     check: "semantic",

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -25,9 +25,9 @@ import { resolveReviewExcludePatterns, resolveTestFilePatterns } from "../test-r
 import type { NaxIgnoreIndex } from "../utils/path-filters";
 import { filterByAcQuote } from "./ac-quote-validator";
 import { DIFF_CAP_BYTES, collectDiff, collectDiffStat, resolveEffectiveRef, truncateDiff } from "./diff-utils";
+import { llmFindingsToReviewFindings } from "./finding-projection";
 import { writeReviewAudit } from "./review-audit";
 import { runSemanticDebate } from "./semantic-debate";
-import { llmFindingsToReviewFindings } from "./finding-projection";
 import { substantiateSemanticEvidence } from "./semantic-evidence";
 import {
   type LLMFinding,

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -16,3 +16,9 @@ export { makeSessionManager } from "./mock-session-manager";
 export { makeMockRuntime, makeTestRuntime, type MockRuntimeOptions, type TestRuntimeOptions } from "./runtime";
 export { makeInProgressStory, makePRD, makePendingStory, makeStory } from "./mock-story";
 export { cleanupTempDir, makeTempDir, withTempDir } from "./temp";
+export {
+  agentManagerWithFixedLLMResponse,
+  captureAuditDecisions,
+  makeSpawnMock,
+  mockDiffUtilsDeps,
+} from "./review-audit";

--- a/test/helpers/review-audit.ts
+++ b/test/helpers/review-audit.ts
@@ -1,0 +1,104 @@
+/**
+ * Shared helpers for reviewer audit-shape tests.
+ * Extracted to avoid duplicating spawn mocks and IReviewAuditor setup
+ * across semantic-audit-shape, adversarial-audit-shape, and
+ * semantic-debate-audit-shape tests.
+ */
+
+import { mock } from "bun:test";
+import { _diffUtilsDeps } from "../../src/review/diff-utils";
+import type { IReviewAuditor, ReviewAuditDecision } from "../../src/runtime";
+import { makeAgentAdapter } from "./mock-agent-adapter";
+import { makeMockAgentManager } from "./mock-agent-manager";
+
+export function captureAuditDecisions(): { auditor: IReviewAuditor; decisions: ReviewAuditDecision[] } {
+  const decisions: ReviewAuditDecision[] = [];
+  const auditor: IReviewAuditor = {
+    recordDispatch: () => {},
+    recordDecision: (entry) => {
+      decisions.push(entry);
+    },
+    flush: async () => {},
+  };
+  return { auditor, decisions };
+}
+
+export function makeSpawnMock(stdout = "diff output", exitCode = 0) {
+  return mock((_opts: unknown) => ({
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode(stdout));
+        c.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(c) {
+        c.close();
+      },
+    }),
+    kill: () => {},
+  })) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+/** Mock `_diffUtilsDeps` for tests that call diff-producing reviewers. Returns a teardown function. */
+export function mockDiffUtilsDeps(stdout = "some diff"): () => void {
+  const origSpawn = _diffUtilsDeps.spawn;
+  const origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+  const origGetMergeBase = _diffUtilsDeps.getMergeBase;
+  _diffUtilsDeps.isGitRefValid = mock(async () => true);
+  _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+  _diffUtilsDeps.spawn = makeSpawnMock(stdout);
+  return () => {
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
+  };
+}
+
+const COMPLETE_RESULT_BASE = {
+  tokenUsage: { inputTokens: 0, outputTokens: 0 },
+  estimatedCostUsd: 0,
+};
+
+/** Agent manager that returns a fixed LLM response for all call types. */
+export function agentManagerWithFixedLLMResponse(llmResponse: string) {
+  return makeMockAgentManager({
+    getDefaultAgent: "claude",
+    runFn: async () => ({
+      success: true,
+      exitCode: 0,
+      output: llmResponse,
+      rateLimited: false,
+      durationMs: 100,
+      estimatedCostUsd: 0,
+      agentFallbacks: [],
+    }),
+    completeFn: async () => ({ output: llmResponse, ...COMPLETE_RESULT_BASE }),
+    runWithFallbackFn: async (request) => ({
+      result: {
+        success: true,
+        exitCode: 0,
+        output: llmResponse,
+        rateLimited: false,
+        durationMs: 100,
+        estimatedCostUsd: 0,
+        agentFallbacks: [],
+      },
+      fallbacks: [],
+      bundle: request.bundle,
+    }),
+    completeWithFallbackFn: async () => ({ result: { output: llmResponse, ...COMPLETE_RESULT_BASE }, fallbacks: [] }),
+    runAsFn: async () => ({
+      success: true,
+      exitCode: 0,
+      output: llmResponse,
+      rateLimited: false,
+      durationMs: 100,
+      estimatedCostUsd: 0,
+      agentFallbacks: [],
+    }),
+    completeAsFn: async () => ({ output: llmResponse, ...COMPLETE_RESULT_BASE }),
+    getAgentFn: () => makeAgentAdapter(),
+  });
+}

--- a/test/unit/plugins/builtin/curator-heuristics.test.ts
+++ b/test/unit/plugins/builtin/curator-heuristics.test.ts
@@ -701,3 +701,45 @@ describe("runHeuristics", () => {
     });
   });
 });
+
+// ─── Issue #942 AC-5: H1 ruleId buckets are not single-word collapses ──────
+
+function makeReviewFindingObs942(
+  storyId: string,
+  ruleId: string,
+  severity: string,
+  message = "msg",
+): Observation {
+  return {
+    schemaVersion: 1,
+    runId: "run-test",
+    featureId: "feat-x",
+    storyId,
+    stage: "review",
+    ts: "2026-05-07T00:00:00.000Z",
+    kind: "review-finding",
+    payload: { ruleId, checkId: ruleId, severity, file: "src/foo.ts", line: 1, message },
+  };
+}
+
+describe("H1 — issue #942 AC-5: ruleId buckets are not single-word collapses", () => {
+  test("findings sharing a category but different issues yield distinct buckets", () => {
+    const observations: Observation[] = [
+      makeReviewFindingObs942("US-001", "input:listener-arg-not-validated-as-function", "warning"),
+      makeReviewFindingObs942("US-002", "input:listener-arg-not-validated-as-function", "warning"),
+      makeReviewFindingObs942("US-003", "input:timeout-value-missing-upper-bound", "error"),
+      makeReviewFindingObs942("US-004", "input:timeout-value-missing-upper-bound", "error"),
+    ];
+
+    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
+    const h1s = proposals.filter((p) => p.id === "H1");
+
+    expect(h1s.length).toBe(2);
+    for (const p of h1s) {
+      const ruleId = p.description.match(/Repeated review finding: (\S+)/)?.[1] ?? "";
+      expect(ruleId.split("-").length).toBeGreaterThan(1);
+      expect(ruleId).not.toBe("input");
+      expect(ruleId).not.toBe("unknown");
+    }
+  });
+});

--- a/test/unit/review/adversarial-audit-shape.test.ts
+++ b/test/unit/review/adversarial-audit-shape.test.ts
@@ -3,12 +3,16 @@
  * ReviewFinding[] to .nax/review-audit/*.json, never raw AdversarialLLMFinding[].
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { IReviewAuditor, ReviewAuditDecision } from "../../../src/runtime";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ReviewAuditDecision } from "../../../src/runtime";
 import { runAdversarialReview } from "../../../src/review/adversarial";
-import { _diffUtilsDeps } from "../../../src/review/diff-utils";
 import type { AdversarialReviewConfig, SemanticStory } from "../../../src/review/types";
-import { makeAgentAdapter, makeMockAgentManager, makeMockRuntime } from "../../helpers";
+import {
+  agentManagerWithFixedLLMResponse,
+  captureAuditDecisions,
+  mockDiffUtilsDeps,
+  makeMockRuntime,
+} from "../../helpers";
 
 const STORY: SemanticStory = {
   id: "US-001",
@@ -48,81 +52,24 @@ const ADVERSARIAL_LLM_RESPONSE = JSON.stringify({
   ],
 });
 
-function makeSpawnMock(stdout = "diff output", exitCode = 0) {
-  return mock((_opts: unknown) => ({
-    exited: Promise.resolve(exitCode),
-    stdout: new ReadableStream({
-      start(c) { c.enqueue(new TextEncoder().encode(stdout)); c.close(); },
-    }),
-    stderr: new ReadableStream({ start(c) { c.close(); } }),
-    kill: () => {},
-  })) as unknown as typeof _diffUtilsDeps.spawn;
-}
-
 describe("adversarial reviewer audit shape (#942 AC-1 / AC-2)", () => {
-  const decisions: ReviewAuditDecision[] = [];
-
-  let origSpawn: typeof _diffUtilsDeps.spawn;
-  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
-  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
+  let decisions: ReviewAuditDecision[];
+  let teardown: () => void;
 
   beforeEach(() => {
-    decisions.length = 0;
-    origSpawn = _diffUtilsDeps.spawn;
-    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
-    origGetMergeBase = _diffUtilsDeps.getMergeBase;
-    _diffUtilsDeps.isGitRefValid = mock(async () => true);
-    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
-    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
+    decisions = [];
+    teardown = mockDiffUtilsDeps("some diff");
   });
 
   afterEach(() => {
-    _diffUtilsDeps.spawn = origSpawn;
-    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
-    _diffUtilsDeps.getMergeBase = origGetMergeBase;
+    teardown();
   });
 
-  function makeReviewAuditor(): IReviewAuditor {
-    return {
-      recordDispatch: () => {},
-      recordDecision: (entry) => { decisions.push(entry); },
-      flush: async () => {},
-    };
-  }
-
-  const COMPLETE_RESULT_BASE = {
-    tokenUsage: { inputTokens: 0, outputTokens: 0 },
-    estimatedCostUsd: 0,
-  };
-
-  function makeAgentManagerForResponse(llmResponse: string) {
-    return makeMockAgentManager({
-      getDefaultAgent: "claude",
-      runFn: async (_agent, _opts) => ({
-        success: true,
-        exitCode: 0,
-        output: llmResponse,
-        rateLimited: false,
-        durationMs: 100,
-        estimatedCostUsd: 0,
-        agentFallbacks: [],
-      }),
-      completeFn: async () => ({ output: llmResponse, ...COMPLETE_RESULT_BASE }),
-      runWithFallbackFn: async (request) => ({
-        result: { success: true, exitCode: 0, output: llmResponse, rateLimited: false, durationMs: 100, estimatedCostUsd: 0, agentFallbacks: [] },
-        fallbacks: [],
-        bundle: request.bundle,
-      }),
-      completeWithFallbackFn: async () => ({ result: { output: llmResponse, ...COMPLETE_RESULT_BASE }, fallbacks: [] }),
-      runAsFn: async () => ({ success: true, exitCode: 0, output: llmResponse, rateLimited: false, durationMs: 100, estimatedCostUsd: 0, agentFallbacks: [] }),
-      completeAsFn: async () => ({ output: llmResponse, ...COMPLETE_RESULT_BASE }),
-      getAgentFn: () => makeAgentAdapter(),
-    });
-  }
-
   test("on-disk findings carry ruleId + message, never top-level issue/suggestion", async () => {
-    const agentManager = makeAgentManagerForResponse(ADVERSARIAL_LLM_RESPONSE);
-    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+    const { auditor, decisions: captured } = captureAuditDecisions();
+    decisions = captured;
+    const agentManager = agentManagerWithFixedLLMResponse(ADVERSARIAL_LLM_RESPONSE);
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
 
     await runAdversarialReview({
       workdir: "/tmp/test",
@@ -158,8 +105,10 @@ describe("adversarial reviewer audit shape (#942 AC-1 / AC-2)", () => {
   });
 
   test("ruleId starts with the finding's category", async () => {
-    const agentManager = makeAgentManagerForResponse(ADVERSARIAL_LLM_RESPONSE);
-    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+    const { auditor, decisions: captured } = captureAuditDecisions();
+    decisions = captured;
+    const agentManager = agentManagerWithFixedLLMResponse(ADVERSARIAL_LLM_RESPONSE);
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
 
     await runAdversarialReview({
       workdir: "/tmp/test",

--- a/test/unit/review/adversarial-audit-shape.test.ts
+++ b/test/unit/review/adversarial-audit-shape.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Issue #942 AC-1 / AC-2 — adversarial reviewer must persist canonical
+ * ReviewFinding[] to .nax/review-audit/*.json, never raw AdversarialLLMFinding[].
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { IReviewAuditor, ReviewAuditDecision } from "../../../src/runtime";
+import { runAdversarialReview } from "../../../src/review/adversarial";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
+import type { AdversarialReviewConfig, SemanticStory } from "../../../src/review/types";
+import { makeAgentAdapter, makeMockAgentManager, makeMockRuntime } from "../../helpers";
+
+const STORY: SemanticStory = {
+  id: "US-001",
+  title: "Test adversarial audit shape",
+  description: "Validate canonical shape on disk",
+  acceptanceCriteria: ["AC-1: validate input"],
+};
+
+const CFG: AdversarialReviewConfig = {
+  model: "balanced",
+  diffMode: "embedded",
+  rules: [],
+  timeoutMs: 60_000,
+  parallel: false,
+  maxConcurrentSessions: 2,
+};
+
+const ADVERSARIAL_LLM_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "warning",
+      category: "input",
+      file: "src/foo.ts",
+      line: 10,
+      issue: "Listener arg not validated as function",
+      suggestion: "Add typeof guard before registering",
+    },
+    {
+      severity: "warning",
+      category: "error-path",
+      file: "src/foo.ts",
+      line: 25,
+      issue: "Error is swallowed without logging",
+      suggestion: "",
+    },
+  ],
+});
+
+function makeSpawnMock(stdout = "diff output", exitCode = 0) {
+  return mock((_opts: unknown) => ({
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(c) { c.enqueue(new TextEncoder().encode(stdout)); c.close(); },
+    }),
+    stderr: new ReadableStream({ start(c) { c.close(); } }),
+    kill: () => {},
+  })) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+describe("adversarial reviewer audit shape (#942 AC-1 / AC-2)", () => {
+  const decisions: ReviewAuditDecision[] = [];
+
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
+
+  beforeEach(() => {
+    decisions.length = 0;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
+  });
+
+  afterEach(() => {
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
+  });
+
+  function makeReviewAuditor(): IReviewAuditor {
+    return {
+      recordDispatch: () => {},
+      recordDecision: (entry) => { decisions.push(entry); },
+      flush: async () => {},
+    };
+  }
+
+  const COMPLETE_RESULT_BASE = {
+    tokenUsage: { inputTokens: 0, outputTokens: 0 },
+    estimatedCostUsd: 0,
+  };
+
+  function makeAgentManagerForResponse(llmResponse: string) {
+    return makeMockAgentManager({
+      getDefaultAgent: "claude",
+      runFn: async (_agent, _opts) => ({
+        success: true,
+        exitCode: 0,
+        output: llmResponse,
+        rateLimited: false,
+        durationMs: 100,
+        estimatedCostUsd: 0,
+        agentFallbacks: [],
+      }),
+      completeFn: async () => ({ output: llmResponse, ...COMPLETE_RESULT_BASE }),
+      runWithFallbackFn: async (request) => ({
+        result: { success: true, exitCode: 0, output: llmResponse, rateLimited: false, durationMs: 100, estimatedCostUsd: 0, agentFallbacks: [] },
+        fallbacks: [],
+        bundle: request.bundle,
+      }),
+      completeWithFallbackFn: async () => ({ result: { output: llmResponse, ...COMPLETE_RESULT_BASE }, fallbacks: [] }),
+      runAsFn: async () => ({ success: true, exitCode: 0, output: llmResponse, rateLimited: false, durationMs: 100, estimatedCostUsd: 0, agentFallbacks: [] }),
+      completeAsFn: async () => ({ output: llmResponse, ...COMPLETE_RESULT_BASE }),
+      getAgentFn: () => makeAgentAdapter(),
+    });
+  }
+
+  test("on-disk findings carry ruleId + message, never top-level issue/suggestion", async () => {
+    const agentManager = makeAgentManagerForResponse(ADVERSARIAL_LLM_RESPONSE);
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+
+    await runAdversarialReview({
+      workdir: "/tmp/test",
+      storyGitRef: "abc123",
+      story: STORY,
+      adversarialConfig: CFG,
+      agentManager,
+      featureName: "feat-x",
+      runtime,
+    });
+
+    expect(decisions.length).toBeGreaterThanOrEqual(1);
+    const decision = decisions[0]!;
+    const findings = decision.result?.findings as Array<Record<string, unknown>>;
+    expect(Array.isArray(findings)).toBe(true);
+    expect(findings!.length).toBe(2);
+
+    for (const f of findings!) {
+      expect(typeof f.ruleId).toBe("string");
+      expect((f.ruleId as string).length).toBeGreaterThan(0);
+      expect(typeof f.message).toBe("string");
+      expect((f.message as string).length).toBeGreaterThan(0);
+      expect(f.issue).toBeUndefined();
+      expect(f.suggestion).toBeUndefined();
+    }
+
+    const inputFinding = findings!.find((f) => f.line === 10)!;
+    expect(inputFinding.category).toBe("input");
+    expect((inputFinding.ruleId as string).startsWith("input:")).toBe(true);
+    expect(inputFinding.message).toContain("Listener arg not validated");
+    expect(inputFinding.message).toContain("→ Add typeof guard");
+    expect(inputFinding.severity).toBe("warning");
+  });
+
+  test("ruleId starts with the finding's category", async () => {
+    const agentManager = makeAgentManagerForResponse(ADVERSARIAL_LLM_RESPONSE);
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+
+    await runAdversarialReview({
+      workdir: "/tmp/test",
+      storyGitRef: "abc123",
+      story: STORY,
+      adversarialConfig: CFG,
+      agentManager,
+      featureName: "feat-x",
+      runtime,
+    });
+
+    const decision = decisions[0]!;
+    const findings = decision.result?.findings as Array<{ ruleId: string; category: string }>;
+    for (const f of findings) {
+      expect(f.ruleId).toContain(":");
+      expect(f.ruleId.startsWith(`${f.category}:`)).toBe(true);
+    }
+  });
+});

--- a/test/unit/review/finding-projection.test.ts
+++ b/test/unit/review/finding-projection.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { llmFindingToReviewFinding, llmFindingsToReviewFindings } from "../../../src/review/finding-projection";
+import { llmFindingToReviewFinding, llmFindingsToReviewFindings } from "../../../src/review";
+// LLMFinding / AdversarialLLMFinding are import-type only (erased at compile
+// time) so leaf-path imports here do not cause singleton fragmentation.
 import type { LLMFinding } from "../../../src/review/semantic-helpers";
 import type { AdversarialLLMFinding } from "../../../src/review/adversarial-helpers";
 

--- a/test/unit/review/finding-projection.test.ts
+++ b/test/unit/review/finding-projection.test.ts
@@ -143,6 +143,33 @@ describe("llmFindingToReviewFinding", () => {
     const rf = llmFindingToReviewFinding(f, { source: "semantic-review" });
     expect(rf.source).toBe("semantic-review");
   });
+
+  test("empty issue produces 'unspecified' slug — documents intentional fallback bucket", () => {
+    const f: LLMFinding = { severity: "warning", file: "x.ts", line: 1, issue: "", suggestion: "" };
+    const rf = llmFindingToReviewFinding(f);
+    expect(rf.ruleId).toBe("review:unspecified");
+    expect(rf.message).toBe("");
+  });
+
+  test("punctuation-only issue also produces 'unspecified' slug", () => {
+    const f: AdversarialLLMFinding = {
+      severity: "warning", category: "input", file: "x.ts", line: 1,
+      issue: "???", suggestion: "",
+    };
+    const rf = llmFindingToReviewFinding(f);
+    expect(rf.ruleId).toBe("input:unspecified");
+  });
+
+  test("slug truncates at exactly 6 tokens regardless of input length", () => {
+    const f: LLMFinding = {
+      severity: "info", file: "x.ts", line: 1,
+      issue: "a b c d e f g", suggestion: "",
+    };
+    const rf = llmFindingToReviewFinding(f);
+    const slug = rf.ruleId.split(":")[1] ?? "";
+    expect(slug).toBe("a-b-c-d-e-f");
+    expect(slug.split("-").length).toBe(6);
+  });
 });
 
 describe("llmFindingsToReviewFindings", () => {

--- a/test/unit/review/finding-projection.test.ts
+++ b/test/unit/review/finding-projection.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { llmFindingToReviewFinding, llmFindingsToReviewFindings } from "../../../src/review/finding-projection";
+import type { LLMFinding } from "../../../src/review/semantic-helpers";
+import type { AdversarialLLMFinding } from "../../../src/review/adversarial-helpers";
+
+describe("llmFindingToReviewFinding", () => {
+  test("joins issue and suggestion into message with arrow separator", () => {
+    const f: LLMFinding = {
+      severity: "error",
+      file: "src/foo.ts",
+      line: 12,
+      issue: "X is not validated",
+      suggestion: "guard with typeof",
+    };
+    const rf = llmFindingToReviewFinding(f);
+    expect(rf.message).toBe("X is not validated\n→ guard with typeof");
+  });
+
+  test("uses bare issue when suggestion is empty", () => {
+    const f: LLMFinding = {
+      severity: "warning",
+      file: "src/foo.ts",
+      line: 1,
+      issue: "subtle bug",
+      suggestion: "",
+    };
+    expect(llmFindingToReviewFinding(f).message).toBe("subtle bug");
+  });
+
+  test("derives ruleId from category + slug of leading issue tokens", () => {
+    const f: AdversarialLLMFinding = {
+      severity: "error",
+      category: "input",
+      file: "src/api.ts",
+      line: 4,
+      issue: "Listener arg not validated as function",
+      suggestion: "",
+    };
+    const rf = llmFindingToReviewFinding(f);
+    expect(rf.ruleId).toBe("input:listener-arg-not-validated-as-function");
+  });
+
+  test("ruleId falls back to 'review' when category missing", () => {
+    const f: LLMFinding = {
+      severity: "warning",
+      file: "src/foo.ts",
+      line: 1,
+      issue: "ambiguous wording here",
+      suggestion: "",
+    };
+    expect(llmFindingToReviewFinding(f).ruleId.startsWith("review:")).toBe(true);
+  });
+
+  test("ruleId clusters semantically-related findings (same category, same first 6 tokens)", () => {
+    const a: AdversarialLLMFinding = {
+      severity: "error", category: "input", file: "a.ts", line: 1,
+      issue: "Listener arg not validated as function in handler", suggestion: "",
+    };
+    const b: AdversarialLLMFinding = {
+      severity: "error", category: "input", file: "b.ts", line: 9,
+      issue: "Listener arg not validated as function elsewhere", suggestion: "",
+    };
+    expect(llmFindingToReviewFinding(a).ruleId).toBe(llmFindingToReviewFinding(b).ruleId);
+  });
+
+  test("ruleId distinguishes different issues within the same category", () => {
+    const a: AdversarialLLMFinding = {
+      severity: "error", category: "input", file: "a.ts", line: 1,
+      issue: "Listener arg not validated", suggestion: "",
+    };
+    const b: AdversarialLLMFinding = {
+      severity: "error", category: "input", file: "b.ts", line: 9,
+      issue: "Timeout value missing upper bound", suggestion: "",
+    };
+    expect(llmFindingToReviewFinding(a).ruleId).not.toBe(llmFindingToReviewFinding(b).ruleId);
+  });
+
+  test("normalizes 'warn' severity to 'warning'", () => {
+    const f: LLMFinding = { severity: "warn", file: "x.ts", line: 1, issue: "y", suggestion: "" };
+    expect(llmFindingToReviewFinding(f).severity).toBe("warning");
+  });
+
+  test("narrows unknown severity values to 'info'", () => {
+    const f: LLMFinding = { severity: "huh", file: "x.ts", line: 1, issue: "y", suggestion: "" };
+    expect(llmFindingToReviewFinding(f).severity).toBe("info");
+  });
+
+  test("downgrades 'unverifiable' severity to 'info' (ReviewFinding union excludes it)", () => {
+    const f: LLMFinding = { severity: "unverifiable", file: "x.ts", line: 1, issue: "y", suggestion: "" };
+    expect(llmFindingToReviewFinding(f).severity).toBe("info");
+  });
+
+  test("carries acQuote, acIndex, acId, verifiedBy, issue, suggestion into meta", () => {
+    const f: LLMFinding = {
+      severity: "error",
+      file: "src/foo.ts",
+      line: 7,
+      issue: "raw issue",
+      suggestion: "raw suggestion",
+      acQuote: "must validate input",
+      acIndex: 2,
+      acId: "AC-3",
+      verifiedBy: { file: "src/foo.ts", line: 7, observed: "no validation" },
+    };
+    const rf = llmFindingToReviewFinding(f);
+    expect(rf.meta).toEqual({
+      issue: "raw issue",
+      suggestion: "raw suggestion",
+      acQuote: "must validate input",
+      acIndex: 2,
+      acId: "AC-3",
+      verifiedBy: { file: "src/foo.ts", line: 7, observed: "no validation" },
+    });
+  });
+
+  test("omits meta entirely when no LLM-only fields are present", () => {
+    const f: LLMFinding = { severity: "info", file: "x.ts", line: 1, issue: "y", suggestion: "" };
+    const rf = llmFindingToReviewFinding(f);
+    expect(rf.meta).toBeUndefined();
+  });
+
+  test("propagates source label when provided", () => {
+    const f: LLMFinding = { severity: "error", file: "x.ts", line: 1, issue: "y", suggestion: "" };
+    const rf = llmFindingToReviewFinding(f, { source: "semantic-review" });
+    expect(rf.source).toBe("semantic-review");
+  });
+});
+
+describe("llmFindingsToReviewFindings", () => {
+  test("maps an array preserving order", () => {
+    const fs: LLMFinding[] = [
+      { severity: "error", file: "a.ts", line: 1, issue: "first", suggestion: "" },
+      { severity: "info", file: "b.ts", line: 2, issue: "second", suggestion: "" },
+    ];
+    const rs = llmFindingsToReviewFindings(fs);
+    expect(rs.map((r) => r.message)).toEqual(["first", "second"]);
+  });
+
+  test("returns empty array for empty input", () => {
+    expect(llmFindingsToReviewFindings([])).toEqual([]);
+  });
+});

--- a/test/unit/review/finding-projection.test.ts
+++ b/test/unit/review/finding-projection.test.ts
@@ -113,10 +113,29 @@ describe("llmFindingToReviewFinding", () => {
     });
   });
 
-  test("omits meta entirely when no LLM-only fields are present", () => {
+  test("includes issue in meta even without annotation fields", () => {
     const f: LLMFinding = { severity: "info", file: "x.ts", line: 1, issue: "y", suggestion: "" };
     const rf = llmFindingToReviewFinding(f);
-    expect(rf.meta).toBeUndefined();
+    expect(rf.meta).toEqual({ issue: "y" });
+  });
+
+  test("does not treat acIndex: 0 as a valid AC anchor", () => {
+    const f: LLMFinding = { severity: "warning", file: "x.ts", line: 1, issue: "y", suggestion: "", acIndex: 0 };
+    const rf = llmFindingToReviewFinding(f);
+    expect(rf.meta?.acIndex).toBeUndefined();
+  });
+
+  test("preserves originalSeverity in meta when severity is narrowed", () => {
+    const f: LLMFinding = { severity: "unverifiable", file: "x.ts", line: 1, issue: "y", suggestion: "" };
+    const rf = llmFindingToReviewFinding(f);
+    expect(rf.severity).toBe("info");
+    expect(rf.meta?.originalSeverity).toBe("unverifiable");
+  });
+
+  test("does not add originalSeverity to meta when severity is unchanged", () => {
+    const f: LLMFinding = { severity: "warning", file: "x.ts", line: 1, issue: "y", suggestion: "" };
+    const rf = llmFindingToReviewFinding(f);
+    expect(rf.meta?.originalSeverity).toBeUndefined();
   });
 
   test("propagates source label when provided", () => {

--- a/test/unit/review/semantic-audit-shape.test.ts
+++ b/test/unit/review/semantic-audit-shape.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Issue #942 AC-1 / AC-2 — semantic reviewer must persist canonical
+ * ReviewFinding[] to .nax/review-audit/*.json, never raw LLMFinding[].
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { IReviewAuditor, ReviewAuditDecision } from "../../../src/runtime";
+import { _diffUtilsDeps } from "../../../src/review/diff-utils";
+import { runSemanticReview } from "../../../src/review/semantic";
+import type { SemanticReviewConfig, SemanticStory } from "../../../src/review/types";
+import { makeAgentAdapter, makeMockAgentManager, makeMockRuntime } from "../../helpers";
+
+const STORY: SemanticStory = {
+  id: "US-001",
+  title: "Test semantic audit shape",
+  description: "Validate canonical shape on disk",
+  acceptanceCriteria: [
+    "AC-1: validate input",
+    "AC-2: must validate listener input",
+  ],
+};
+
+const CFG: SemanticReviewConfig = {
+  model: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
+  rules: [],
+  excludePatterns: [":!test/"],
+  timeoutMs: 60_000,
+};
+
+const SEMANTIC_LLM_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "error",
+      file: "src/foo.ts",
+      line: 73,
+      issue: "onAgentStream(listener) does not validate that listener is a function",
+      suggestion: "Add a typeof guard at the top of the function",
+      acId: "AC-2",
+      acQuote: "must validate listener input",
+      acIndex: 2,
+    },
+    {
+      severity: "warning",
+      file: "src/foo.ts",
+      line: 81,
+      issue: "Listener errors are swallowed when logger is null",
+      suggestion: "",
+    },
+  ],
+});
+
+function makeSpawnMock(stdout = "diff output", exitCode = 0) {
+  return mock((_opts: unknown) => ({
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(c) { c.enqueue(new TextEncoder().encode(stdout)); c.close(); },
+    }),
+    stderr: new ReadableStream({ start(c) { c.close(); } }),
+    kill: () => {},
+  })) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+describe("semantic reviewer audit shape (#942 AC-1 / AC-2)", () => {
+  const decisions: ReviewAuditDecision[] = [];
+
+  let origSpawn: typeof _diffUtilsDeps.spawn;
+  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
+  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
+
+  beforeEach(() => {
+    decisions.length = 0;
+    origSpawn = _diffUtilsDeps.spawn;
+    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
+    origGetMergeBase = _diffUtilsDeps.getMergeBase;
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
+  });
+
+  afterEach(() => {
+    _diffUtilsDeps.spawn = origSpawn;
+    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
+    _diffUtilsDeps.getMergeBase = origGetMergeBase;
+  });
+
+  function makeReviewAuditor(): IReviewAuditor {
+    return {
+      recordDispatch: () => {},
+      recordDecision: (entry) => { decisions.push(entry); },
+      flush: async () => {},
+    };
+  }
+
+  const COMPLETE_RESULT_BASE = {
+    tokenUsage: { inputTokens: 0, outputTokens: 0 },
+    estimatedCostUsd: 0,
+  };
+
+  function makeAgentManagerForResponse(llmResponse: string) {
+    return makeMockAgentManager({
+      getDefaultAgent: "claude",
+      runFn: async (_agent, _opts) => ({
+        success: true,
+        exitCode: 0,
+        output: llmResponse,
+        rateLimited: false,
+        durationMs: 100,
+        estimatedCostUsd: 0,
+        agentFallbacks: [],
+      }),
+      completeFn: async () => ({ output: llmResponse, ...COMPLETE_RESULT_BASE }),
+      runWithFallbackFn: async (request) => ({
+        result: { success: true, exitCode: 0, output: llmResponse, rateLimited: false, durationMs: 100, estimatedCostUsd: 0, agentFallbacks: [] },
+        fallbacks: [],
+        bundle: request.bundle,
+      }),
+      completeWithFallbackFn: async () => ({ result: { output: llmResponse, ...COMPLETE_RESULT_BASE }, fallbacks: [] }),
+      runAsFn: async () => ({ success: true, exitCode: 0, output: llmResponse, rateLimited: false, durationMs: 100, estimatedCostUsd: 0, agentFallbacks: [] }),
+      completeAsFn: async () => ({ output: llmResponse, ...COMPLETE_RESULT_BASE }),
+      getAgentFn: () => makeAgentAdapter(),
+    });
+  }
+
+  test("on-disk findings carry ruleId + message, never top-level issue/suggestion", async () => {
+    const agentManager = makeAgentManagerForResponse(SEMANTIC_LLM_RESPONSE);
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+
+    await runSemanticReview({
+      workdir: "/tmp/test",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: CFG,
+      agentManager,
+      featureName: "feat-x",
+      runtime,
+    });
+
+    expect(decisions.length).toBeGreaterThanOrEqual(1);
+    const decision = decisions[0]!;
+    const findings = decision.result?.findings as Array<Record<string, unknown>>;
+    expect(Array.isArray(findings)).toBe(true);
+    expect(findings!.length).toBe(2);
+
+    for (const f of findings!) {
+      expect(typeof f.ruleId).toBe("string");
+      expect((f.ruleId as string).length).toBeGreaterThan(0);
+      expect(typeof f.message).toBe("string");
+      expect((f.message as string).length).toBeGreaterThan(0);
+      expect(f.issue).toBeUndefined();
+      expect(f.suggestion).toBeUndefined();
+    }
+
+    const blocking = findings!.find((f) => f.line === 73)!;
+    expect(blocking.message).toContain("does not validate that listener is a function");
+    expect(blocking.message).toContain("→ Add a typeof guard");
+    expect(blocking.severity).toBe("error");
+    const meta = blocking.meta as Record<string, unknown>;
+    expect(meta.acId).toBe("AC-2");
+    expect(meta.acQuote).toBe("must validate listener input");
+    expect(meta.acIndex).toBe(2);
+    expect(meta.issue).toContain("does not validate");
+    expect(meta.suggestion).toContain("typeof guard");
+  });
+
+  test("ruleId is non-coarse — does not collapse to a single category word", async () => {
+    const agentManager = makeAgentManagerForResponse(SEMANTIC_LLM_RESPONSE);
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+
+    await runSemanticReview({
+      workdir: "/tmp/test",
+      storyGitRef: "abc123",
+      story: STORY,
+      semanticConfig: CFG,
+      agentManager,
+      featureName: "feat-x",
+      runtime,
+    });
+
+    const decision = decisions[0]!;
+    const findings = decision.result?.findings as Array<{ ruleId: string }>;
+    for (const f of findings) {
+      expect(f.ruleId).toContain(":");
+      const slug = f.ruleId.split(":")[1] ?? "";
+      expect(slug.split("-").length).toBeGreaterThan(1);
+    }
+  });
+});

--- a/test/unit/review/semantic-audit-shape.test.ts
+++ b/test/unit/review/semantic-audit-shape.test.ts
@@ -110,6 +110,19 @@ describe("semantic reviewer audit shape (#942 AC-1 / AC-2)", () => {
     expect(meta.acIndex).toBe(2);
     expect(meta.issue).toContain("does not validate");
     expect(meta.suggestion).toContain("typeof guard");
+
+    // advisoryFindings (warning severity — below default "error" threshold) must
+    // also conform to canonical ReviewFinding shape, not raw LLMFinding shape.
+    const advisory = decision.advisoryFindings as Array<Record<string, unknown>> | undefined;
+    expect(Array.isArray(advisory)).toBe(true);
+    expect(advisory!.length).toBe(1);
+    const advisoryFinding = advisory![0]!;
+    expect(typeof advisoryFinding.ruleId).toBe("string");
+    expect((advisoryFinding.ruleId as string).length).toBeGreaterThan(0);
+    expect(typeof advisoryFinding.message).toBe("string");
+    expect(advisoryFinding.message).toContain("Listener errors are swallowed");
+    expect(advisoryFinding.issue).toBeUndefined();
+    expect(advisoryFinding.suggestion).toBeUndefined();
   });
 
   test("ruleId is non-coarse — does not collapse to a single category word", async () => {

--- a/test/unit/review/semantic-audit-shape.test.ts
+++ b/test/unit/review/semantic-audit-shape.test.ts
@@ -3,12 +3,16 @@
  * ReviewFinding[] to .nax/review-audit/*.json, never raw LLMFinding[].
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { IReviewAuditor, ReviewAuditDecision } from "../../../src/runtime";
-import { _diffUtilsDeps } from "../../../src/review/diff-utils";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ReviewAuditDecision } from "../../../src/runtime";
 import { runSemanticReview } from "../../../src/review/semantic";
 import type { SemanticReviewConfig, SemanticStory } from "../../../src/review/types";
-import { makeAgentAdapter, makeMockAgentManager, makeMockRuntime } from "../../helpers";
+import {
+  agentManagerWithFixedLLMResponse,
+  captureAuditDecisions,
+  mockDiffUtilsDeps,
+  makeMockRuntime,
+} from "../../helpers";
 
 const STORY: SemanticStory = {
   id: "US-001",
@@ -52,81 +56,24 @@ const SEMANTIC_LLM_RESPONSE = JSON.stringify({
   ],
 });
 
-function makeSpawnMock(stdout = "diff output", exitCode = 0) {
-  return mock((_opts: unknown) => ({
-    exited: Promise.resolve(exitCode),
-    stdout: new ReadableStream({
-      start(c) { c.enqueue(new TextEncoder().encode(stdout)); c.close(); },
-    }),
-    stderr: new ReadableStream({ start(c) { c.close(); } }),
-    kill: () => {},
-  })) as unknown as typeof _diffUtilsDeps.spawn;
-}
-
 describe("semantic reviewer audit shape (#942 AC-1 / AC-2)", () => {
-  const decisions: ReviewAuditDecision[] = [];
-
-  let origSpawn: typeof _diffUtilsDeps.spawn;
-  let origIsGitRefValid: typeof _diffUtilsDeps.isGitRefValid;
-  let origGetMergeBase: typeof _diffUtilsDeps.getMergeBase;
+  let decisions: ReviewAuditDecision[];
+  let teardown: () => void;
 
   beforeEach(() => {
-    decisions.length = 0;
-    origSpawn = _diffUtilsDeps.spawn;
-    origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
-    origGetMergeBase = _diffUtilsDeps.getMergeBase;
-    _diffUtilsDeps.isGitRefValid = mock(async () => true);
-    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
-    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
+    decisions = [];
+    teardown = mockDiffUtilsDeps("some diff");
   });
 
   afterEach(() => {
-    _diffUtilsDeps.spawn = origSpawn;
-    _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
-    _diffUtilsDeps.getMergeBase = origGetMergeBase;
+    teardown();
   });
 
-  function makeReviewAuditor(): IReviewAuditor {
-    return {
-      recordDispatch: () => {},
-      recordDecision: (entry) => { decisions.push(entry); },
-      flush: async () => {},
-    };
-  }
-
-  const COMPLETE_RESULT_BASE = {
-    tokenUsage: { inputTokens: 0, outputTokens: 0 },
-    estimatedCostUsd: 0,
-  };
-
-  function makeAgentManagerForResponse(llmResponse: string) {
-    return makeMockAgentManager({
-      getDefaultAgent: "claude",
-      runFn: async (_agent, _opts) => ({
-        success: true,
-        exitCode: 0,
-        output: llmResponse,
-        rateLimited: false,
-        durationMs: 100,
-        estimatedCostUsd: 0,
-        agentFallbacks: [],
-      }),
-      completeFn: async () => ({ output: llmResponse, ...COMPLETE_RESULT_BASE }),
-      runWithFallbackFn: async (request) => ({
-        result: { success: true, exitCode: 0, output: llmResponse, rateLimited: false, durationMs: 100, estimatedCostUsd: 0, agentFallbacks: [] },
-        fallbacks: [],
-        bundle: request.bundle,
-      }),
-      completeWithFallbackFn: async () => ({ result: { output: llmResponse, ...COMPLETE_RESULT_BASE }, fallbacks: [] }),
-      runAsFn: async () => ({ success: true, exitCode: 0, output: llmResponse, rateLimited: false, durationMs: 100, estimatedCostUsd: 0, agentFallbacks: [] }),
-      completeAsFn: async () => ({ output: llmResponse, ...COMPLETE_RESULT_BASE }),
-      getAgentFn: () => makeAgentAdapter(),
-    });
-  }
-
   test("on-disk findings carry ruleId + message, never top-level issue/suggestion", async () => {
-    const agentManager = makeAgentManagerForResponse(SEMANTIC_LLM_RESPONSE);
-    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+    const { auditor, decisions: captured } = captureAuditDecisions();
+    decisions = captured;
+    const agentManager = agentManagerWithFixedLLMResponse(SEMANTIC_LLM_RESPONSE);
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
 
     await runSemanticReview({
       workdir: "/tmp/test",
@@ -166,8 +113,10 @@ describe("semantic reviewer audit shape (#942 AC-1 / AC-2)", () => {
   });
 
   test("ruleId is non-coarse — does not collapse to a single category word", async () => {
-    const agentManager = makeAgentManagerForResponse(SEMANTIC_LLM_RESPONSE);
-    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+    const { auditor, decisions: captured } = captureAuditDecisions();
+    decisions = captured;
+    const agentManager = agentManagerWithFixedLLMResponse(SEMANTIC_LLM_RESPONSE);
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
 
     await runSemanticReview({
       workdir: "/tmp/test",

--- a/test/unit/review/semantic-debate-audit-shape.test.ts
+++ b/test/unit/review/semantic-debate-audit-shape.test.ts
@@ -6,11 +6,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { DebateResult, DebateRunner } from "../../../src/debate";
 import { reviewConfigSelector } from "../../../src/config/selectors";
-import type { IReviewAuditor, ReviewAuditDecision } from "../../../src/runtime";
+import type { ReviewAuditDecision } from "../../../src/runtime";
 import { runSemanticDebate } from "../../../src/review/semantic-debate";
 import type { SemanticReviewConfig } from "../../../src/review/types";
 import type { SemanticStory } from "../../../src/review/types";
-import { makeNaxConfig, makeMockAgentManager, makeMockRuntime } from "../../helpers";
+import { makeNaxConfig, makeMockAgentManager, makeMockRuntime, captureAuditDecisions } from "../../helpers";
 
 const STORY: SemanticStory = {
   id: "US-001",
@@ -68,27 +68,20 @@ function makeMockDebateRunner(result: DebateResult): DebateRunner {
 }
 
 describe("semantic-debate reviewer audit shape (#942 AC-1 / AC-2)", () => {
-  const decisions: ReviewAuditDecision[] = [];
-
-  function makeReviewAuditor(): IReviewAuditor {
-    return {
-      recordDispatch: () => {},
-      recordDecision: (entry) => { decisions.push(entry); },
-      flush: async () => {},
-    };
-  }
+  let decisions: ReviewAuditDecision[];
 
   beforeEach(() => {
-    decisions.length = 0;
+    decisions = [];
   });
 
-  afterEach(() => {
-  });
+  afterEach(() => {});
 
   test("stateless fallback path: findings carry ruleId + message, no top-level issue/suggestion", async () => {
     const debateResult = makeDebateResult(LLM_FINDINGS_JSON);
     const agentManager = makeMockAgentManager();
-    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+    const { auditor, decisions: captured } = captureAuditDecisions();
+    decisions = captured;
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
     const naxConfig = reviewConfigSelector.select(makeNaxConfig());
 
     await runSemanticDebate({
@@ -135,7 +128,9 @@ describe("semantic-debate reviewer audit shape (#942 AC-1 / AC-2)", () => {
   test("ruleId is non-coarse — slug has multiple tokens", async () => {
     const debateResult = makeDebateResult(LLM_FINDINGS_JSON);
     const agentManager = makeMockAgentManager();
-    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+    const { auditor, decisions: captured } = captureAuditDecisions();
+    decisions = captured;
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
     const naxConfig = reviewConfigSelector.select(makeNaxConfig());
 
     await runSemanticDebate({

--- a/test/unit/review/semantic-debate-audit-shape.test.ts
+++ b/test/unit/review/semantic-debate-audit-shape.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Issue #942 AC-1 / AC-2 — semantic-debate reviewer must persist canonical
+ * ReviewFinding[] to .nax/review-audit/*.json, never raw LLMFinding[].
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { DebateResult, DebateRunner } from "../../../src/debate";
+import { reviewConfigSelector } from "../../../src/config/selectors";
+import type { IReviewAuditor, ReviewAuditDecision } from "../../../src/runtime";
+import { runSemanticDebate } from "../../../src/review/semantic-debate";
+import type { SemanticReviewConfig } from "../../../src/review/types";
+import type { SemanticStory } from "../../../src/review/types";
+import { makeNaxConfig, makeMockAgentManager, makeMockRuntime } from "../../helpers";
+
+const STORY: SemanticStory = {
+  id: "US-001",
+  title: "Test debate audit shape",
+  description: "Validate canonical shape on disk",
+  acceptanceCriteria: ["AC-1: validate input"],
+};
+
+const CFG: SemanticReviewConfig = {
+  model: "balanced",
+  diffMode: "embedded",
+  resetRefOnRerun: false,
+  rules: [],
+  excludePatterns: [":!test/"],
+  timeoutMs: 60_000,
+};
+
+const LLM_FINDINGS_JSON = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "warning",
+      file: "src/foo.ts",
+      line: 10,
+      issue: "Listener callback errors are not handled in the event loop",
+      suggestion: "Wrap the listener call in a try-catch",
+    },
+    {
+      severity: "warning",
+      file: "src/bar.ts",
+      line: 42,
+      issue: "Missing null check before property access",
+      suggestion: "",
+    },
+  ],
+});
+
+function makeDebateResult(proposalOutput: string): DebateResult {
+  return {
+    storyId: "US-001",
+    stage: "review",
+    outcome: "failed",
+    rounds: 1,
+    debaters: ["claude"],
+    resolverType: "majority-fail-closed",
+    proposals: [{ debater: { agent: "claude" }, output: proposalOutput }],
+    totalCostUsd: 0,
+  };
+}
+
+function makeMockDebateRunner(result: DebateResult): DebateRunner {
+  return {
+    run: async () => result,
+  } as unknown as DebateRunner;
+}
+
+describe("semantic-debate reviewer audit shape (#942 AC-1 / AC-2)", () => {
+  const decisions: ReviewAuditDecision[] = [];
+
+  function makeReviewAuditor(): IReviewAuditor {
+    return {
+      recordDispatch: () => {},
+      recordDecision: (entry) => { decisions.push(entry); },
+      flush: async () => {},
+    };
+  }
+
+  beforeEach(() => {
+    decisions.length = 0;
+  });
+
+  afterEach(() => {
+  });
+
+  test("stateless fallback path: findings carry ruleId + message, no top-level issue/suggestion", async () => {
+    const debateResult = makeDebateResult(LLM_FINDINGS_JSON);
+    const agentManager = makeMockAgentManager();
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+    const naxConfig = reviewConfigSelector.select(makeNaxConfig());
+
+    await runSemanticDebate({
+      naxConfig,
+      runtime,
+      workdir: "/tmp/test",
+      agentManager,
+      featureName: "feat-x",
+      story: STORY,
+      resolverSession: undefined,
+      diffMode: "embedded",
+      diff: "some diff",
+      stat: "",
+      semanticConfig: CFG,
+      effectiveRef: "abc123",
+      startTime: Date.now(),
+      prompt: "review this diff",
+      productionExcludePatterns: [],
+      blockingThreshold: undefined,
+      createDebateRunner: () => makeMockDebateRunner(debateResult),
+    });
+
+    expect(decisions.length).toBeGreaterThanOrEqual(1);
+    const decision = decisions[0]!;
+    const findings = decision.result?.findings as Array<Record<string, unknown>>;
+    expect(Array.isArray(findings)).toBe(true);
+    expect(findings!.length).toBeGreaterThan(0);
+
+    for (const f of findings!) {
+      expect(typeof f.ruleId).toBe("string");
+      expect((f.ruleId as string).length).toBeGreaterThan(0);
+      expect(typeof f.message).toBe("string");
+      expect((f.message as string).length).toBeGreaterThan(0);
+      expect(f.issue).toBeUndefined();
+      expect(f.suggestion).toBeUndefined();
+    }
+
+    const finding = findings!.find((f) => f.line === 10)!;
+    expect(finding.message).toContain("Listener callback errors are not handled");
+    expect(finding.message).toContain("→ Wrap the listener call");
+    expect((finding.ruleId as string)).toContain(":");
+  });
+
+  test("ruleId is non-coarse — slug has multiple tokens", async () => {
+    const debateResult = makeDebateResult(LLM_FINDINGS_JSON);
+    const agentManager = makeMockAgentManager();
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: makeReviewAuditor() });
+    const naxConfig = reviewConfigSelector.select(makeNaxConfig());
+
+    await runSemanticDebate({
+      naxConfig,
+      runtime,
+      workdir: "/tmp/test",
+      agentManager,
+      featureName: "feat-x",
+      story: STORY,
+      resolverSession: undefined,
+      diffMode: "embedded",
+      diff: "some diff",
+      stat: "",
+      semanticConfig: CFG,
+      effectiveRef: "abc123",
+      startTime: Date.now(),
+      prompt: "review this diff",
+      productionExcludePatterns: [],
+      blockingThreshold: undefined,
+      createDebateRunner: () => makeMockDebateRunner(debateResult),
+    });
+
+    const decision = decisions[0]!;
+    const findings = decision.result?.findings as Array<{ ruleId: string }>;
+    for (const f of findings) {
+      expect(f.ruleId).toContain(":");
+      const slug = f.ruleId.split(":")[1] ?? "";
+      expect(slug.split("-").length).toBeGreaterThan(1);
+    }
+  });
+});

--- a/test/unit/review/semantic-debate-audit-shape.test.ts
+++ b/test/unit/review/semantic-debate-audit-shape.test.ts
@@ -3,11 +3,15 @@
  * ReviewFinding[] to .nax/review-audit/*.json, never raw LLMFinding[].
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import type { DebateResult, DebateRunner } from "../../../src/debate";
 import { reviewConfigSelector } from "../../../src/config/selectors";
+import type { Finding } from "../../../src/findings";
 import type { ReviewAuditDecision } from "../../../src/runtime";
 import { runSemanticDebate } from "../../../src/review/semantic-debate";
+// ReviewerSession / DialogueMessage are imported as types only — erased at
+// compile time, so leaf-path import does not fragment the module registry.
+import type { DialogueMessage, ReviewerSession } from "../../../src/review/dialogue";
 import type { SemanticReviewConfig } from "../../../src/review/types";
 import type { SemanticStory } from "../../../src/review/types";
 import { makeNaxConfig, makeMockAgentManager, makeMockRuntime, captureAuditDecisions } from "../../helpers";
@@ -67,14 +71,53 @@ function makeMockDebateRunner(result: DebateResult): DebateRunner {
   } as unknown as DebateRunner;
 }
 
+function makeResolverSession(findings: Finding[]): ReviewerSession {
+  const history: DialogueMessage[] = [];
+  return {
+    active: true,
+    get history() {
+      return history;
+    },
+    getVerdict: () => ({
+      storyId: "US-001",
+      passed: findings.length === 0,
+      timestamp: new Date().toISOString(),
+      acCount: 1,
+      findings,
+    }),
+    review: async () => ({ checkResult: { success: true, findings: [] }, findingReasoning: new Map() }),
+    reReview: async () => ({ checkResult: { success: true, findings: [] }, findingReasoning: new Map() }),
+    clarify: async () => "",
+    resolveDebate: async () => {
+      // Grow history so sessionUsed becomes true
+      history.push({ role: "reviewer", content: "verdict" });
+      return { checkResult: { success: false, findings }, findingReasoning: new Map() };
+    },
+    reReviewDebate: async () => ({ checkResult: { success: true, findings: [] }, findingReasoning: new Map() }),
+    destroy: () => {},
+  } as unknown as ReviewerSession;
+}
+
+const DIALOGUE_FINDINGS: Finding[] = [
+  {
+    source: "semantic-review",
+    severity: "error",
+    category: "input",
+    rule: "no-unvalidated-listener",
+    file: "src/foo.ts",
+    line: 73,
+    message: "Listener arg must be validated before use",
+    suggestion: "Add typeof guard",
+    fixTarget: "source",
+  },
+];
+
 describe("semantic-debate reviewer audit shape (#942 AC-1 / AC-2)", () => {
   let decisions: ReviewAuditDecision[];
 
   beforeEach(() => {
     decisions = [];
   });
-
-  afterEach(() => {});
 
   test("stateless fallback path: findings carry ruleId + message, no top-level issue/suggestion", async () => {
     const debateResult = makeDebateResult(LLM_FINDINGS_JSON);
@@ -160,5 +203,67 @@ describe("semantic-debate reviewer audit shape (#942 AC-1 / AC-2)", () => {
       const slug = f.ruleId.split(":")[1] ?? "";
       expect(slug.split("-").length).toBeGreaterThan(1);
     }
+  });
+
+  test("dialogue path (sessionUsed): Finding[] projected to canonical ruleId+message shape", async () => {
+    const agentManager = makeMockAgentManager();
+    const { auditor, decisions: captured } = captureAuditDecisions();
+    decisions = captured;
+    const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
+    const naxConfig = reviewConfigSelector.select(makeNaxConfig());
+    const resolverSession = makeResolverSession(DIALOGUE_FINDINGS);
+
+    // The mock debate runner calls resolverSession.resolveDebate() which grows
+    // history — triggering sessionUsed = true so the dialogue path executes.
+    const dialogueDebateRunner: DebateRunner = {
+      run: async () => {
+        await resolverSession.resolveDebate([], [], {} as never, STORY, CFG, {} as never);
+        return makeDebateResult(LLM_FINDINGS_JSON).outcome === "failed"
+          ? makeDebateResult(LLM_FINDINGS_JSON)
+          : makeDebateResult(LLM_FINDINGS_JSON);
+      },
+    } as unknown as DebateRunner;
+
+    await runSemanticDebate({
+      naxConfig,
+      runtime,
+      workdir: "/tmp/test",
+      agentManager,
+      featureName: "feat-x",
+      story: STORY,
+      resolverSession,
+      diffMode: "embedded",
+      diff: "some diff",
+      stat: "",
+      semanticConfig: CFG,
+      effectiveRef: "abc123",
+      startTime: Date.now(),
+      prompt: "review this diff",
+      productionExcludePatterns: [],
+      blockingThreshold: undefined,
+      createDebateRunner: () => dialogueDebateRunner,
+    });
+
+    expect(decisions.length).toBeGreaterThanOrEqual(1);
+    const decision = decisions[0]!;
+    const findings = decision.result?.findings as Array<Record<string, unknown>>;
+    expect(Array.isArray(findings)).toBe(true);
+    expect(findings!.length).toBeGreaterThan(0);
+
+    for (const f of findings!) {
+      // Must have canonical fields
+      expect(typeof f.ruleId).toBe("string");
+      expect((f.ruleId as string).length).toBeGreaterThan(0);
+      expect(typeof f.message).toBe("string");
+      expect((f.message as string).length).toBeGreaterThan(0);
+      // Must NOT have top-level LLM-only fields
+      expect(f.issue).toBeUndefined();
+      expect(f.suggestion).toBeUndefined();
+    }
+
+    // rule is promoted directly to ruleId for Finding sources
+    const finding = findings![0]!;
+    expect(finding.ruleId).toBe("no-unvalidated-listener");
+    expect(finding.message).toBe("Listener arg must be validated before use");
   });
 });


### PR DESCRIPTION
## Summary

- Adds `src/review/finding-projection.ts` — SSOT mapper from `LLMFinding` / `AdversarialLLMFinding` → canonical `ReviewFinding` (`ruleId` + `message`, no raw `issue`/`suggestion` at top level)
- Updates all 9 stateless-path audit-write call sites across `semantic.ts`, `adversarial.ts`, `semantic-debate.ts` to project through the mapper before persisting to `.nax/review-audit/*.json`
- Fixes curator H1 heuristic root cause: findings on disk now carry multi-word `ruleId` slugs (`input:listener-arg-not-validated-as`) instead of collapsing to single-word category buckets
- Widens `ReviewFinding` with `meta?: Record<string, unknown>` to carry AC-annotation and raw debug fields without polluting the canonical shape
- Addresses all 5 code-review findings: `meta.issue/suggestion` always persisted; `acIndex` gate tightened to `>= 1`; `originalSeverity` preserved in meta when narrowing changes the value; `RULE_ID_SLUG_TOKENS` constant extracted; shared audit-shape test helpers extracted to `test/helpers/review-audit.ts`

## Test Plan

- [ ] `bun run test` — 8761 tests, 0 failures
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `test/unit/review/finding-projection.test.ts` — 18 unit tests covering all projection behaviours (ruleId derivation, message joining, meta passthrough, severity narrowing, originalSeverity, acIndex validation)
- [ ] `test/unit/review/semantic-audit-shape.test.ts` — on-disk shape assertions via injected `IReviewAuditor`
- [ ] `test/unit/review/adversarial-audit-shape.test.ts` — same for adversarial path
- [ ] `test/unit/review/semantic-debate-audit-shape.test.ts` — same for debate stateless fallback path
- [ ] `test/unit/plugins/builtin/curator-heuristics.test.ts` — H1 anti-collapse contract pinned

## Notes

Phase 2 tasks (curator collector cleanup, H1 evidence enrichment) are explicitly gated — do not start until at least one full real run has produced audit JSONs with the new shape and any downstream tooling has been migrated.