### PR TITLE
feat(curator): finding normalization Phase 2 — canonical-first read + H1 sample evidence (#942)

### DIFF
--- a/src/plugins/builtin/curator/collect.ts
+++ b/src/plugins/builtin/curator/collect.ts
@@ -119,17 +119,16 @@ async function collectFromMetrics(context: CuratorPostRunContext): Promise<Obser
 }
 
 function findingRuleId(finding: JsonRecord): string {
-  return stringValue(finding.rule ?? finding.ruleId ?? finding.checkId ?? finding.category, "unknown");
+  return stringValue(finding.ruleId ?? finding.rule ?? finding.checkId ?? finding.category, "unknown");
 }
 
 /**
  * Extract a human-readable message from a finding record.
  *
- * Two on-disk shapes coexist in `review-audit/*.json`:
- * - Canonical `ReviewFinding` (lint-style): has `message`.
- * - `LLMFinding` (semantic/adversarial reviewers): has `issue` + optional `suggestion`,
- *   no `message` field. Without this fallback, `payload.message` is always empty
- *   for LLM findings — the dominant source today.
+ * Issue #942 Phase 1 normalized semantic/adversarial/debate reviewers to write
+ * canonical `ReviewFinding` (with `message`) before persistence. The
+ * `issue`/`suggestion` fallback is retained ONLY for legacy on-disk audits
+ * written before that change landed (AC-4 transition compatibility).
  */
 function findingMessage(finding: JsonRecord): string {
   const message = stringValue(finding.message);

--- a/src/plugins/builtin/curator/collect.ts
+++ b/src/plugins/builtin/curator/collect.ts
@@ -118,6 +118,7 @@ async function collectFromMetrics(context: CuratorPostRunContext): Promise<Obser
   return observations;
 }
 
+// Prefer canonical Phase-1 fields first; fall back to legacy on-disk variants for pre-normalization audits.
 function findingRuleId(finding: JsonRecord): string {
   return stringValue(finding.ruleId ?? finding.rule ?? finding.checkId ?? finding.category, "unknown");
 }

--- a/src/plugins/builtin/curator/heuristics.ts
+++ b/src/plugins/builtin/curator/heuristics.ts
@@ -66,33 +66,42 @@ function uniqueStoryIds(storyIds: string[]): string[] {
   return [...new Set(storyIds)];
 }
 
+function firstLine(message: string): string {
+  return message.split("\n")[0] ?? message;
+}
+
 /** H1: Repeated review finding — same ruleId appearing across stories */
 function h1RepeatedReviewFinding(observations: Observation[], threshold: number): Proposal[] {
   const findings = observations.filter((o): o is ReviewFindingObservation => o.kind === "review-finding");
 
-  const byRuleId = new Map<string, string[]>();
+  const groups = new Map<string, { storyIds: string[]; samples: string[] }>();
   for (const obs of findings) {
     const ruleId = obs.payload.ruleId;
-    const existing = byRuleId.get(ruleId);
+    const message = obs.payload.message;
+    const existing = groups.get(ruleId);
     if (existing) {
-      existing.push(obs.storyId);
+      existing.storyIds.push(obs.storyId);
+      if (existing.samples.length < 2 && message && !existing.samples.includes(message)) {
+        existing.samples.push(message);
+      }
     } else {
-      byRuleId.set(ruleId, [obs.storyId]);
+      groups.set(ruleId, { storyIds: [obs.storyId], samples: message ? [message] : [] });
     }
   }
 
   const proposals: Proposal[] = [];
-  for (const [ruleId, storyIds] of byRuleId.entries()) {
+  for (const [ruleId, { storyIds, samples }] of groups.entries()) {
     if (storyIds.length < threshold) continue;
     const count = storyIds.length;
     const severity = count >= 4 ? "HIGH" : "MED";
     const unique = uniqueStoryIds(storyIds);
+    const sampleSection = samples.length > 0 ? `\n  Examples: ${samples.map(firstLine).join(" | ")}` : "";
     proposals.push({
       id: "H1",
       severity,
       target: { canonicalFile: ".nax/rules/curator-suggestions.md", action: "add" },
       description: `Repeated review finding: ${ruleId} appeared ${count}x across stories`,
-      evidence: `Rule ${ruleId} fired ${count}× in stories: ${unique.join(", ")}`,
+      evidence: `Rule ${ruleId} fired ${count}× in stories: ${unique.join(", ")}${sampleSection}`,
       sourceKinds: ["review-finding"],
       storyIds: unique,
     });

--- a/src/plugins/builtin/curator/heuristics.ts
+++ b/src/plugins/builtin/curator/heuristics.ts
@@ -81,11 +81,13 @@ function h1RepeatedReviewFinding(observations: Observation[], threshold: number)
     const existing = groups.get(ruleId);
     if (existing) {
       existing.storyIds.push(obs.storyId);
-      if (existing.samples.length < 2 && message && !existing.samples.includes(message)) {
-        existing.samples.push(message);
+      const sampleKey = firstLine(message);
+      if (existing.samples.length < 2 && sampleKey && !existing.samples.includes(sampleKey)) {
+        existing.samples.push(sampleKey);
       }
     } else {
-      groups.set(ruleId, { storyIds: [obs.storyId], samples: message ? [message] : [] });
+      const sampleKey = firstLine(message);
+      groups.set(ruleId, { storyIds: [obs.storyId], samples: sampleKey ? [sampleKey] : [] });
     }
   }
 
@@ -95,7 +97,7 @@ function h1RepeatedReviewFinding(observations: Observation[], threshold: number)
     const count = storyIds.length;
     const severity = count >= 4 ? "HIGH" : "MED";
     const unique = uniqueStoryIds(storyIds);
-    const sampleSection = samples.length > 0 ? `\n  Examples: ${samples.map(firstLine).join(" | ")}` : "";
+    const sampleSection = samples.length > 0 ? `\n  Examples: ${samples.join(" | ")}` : "";
     proposals.push({
       id: "H1",
       severity,

--- a/test/unit/plugins/builtin/curator-collector.test.ts
+++ b/test/unit/plugins/builtin/curator-collector.test.ts
@@ -466,9 +466,9 @@ describe("collectObservations", () => {
               severity: "error",
               file: "src/foo.ts",
               line: 73,
-              message: "X is not validated\n→ guard with typeof",
+              message: "CANONICAL_SENTINEL — pre-formatted message from Phase-1 normalization",
               category: "input",
-              meta: { issue: "X is not validated", suggestion: "guard with typeof" },
+              meta: { issue: "stale issue text", suggestion: "stale suggestion text" },
             },
           ],
         },
@@ -500,8 +500,7 @@ describe("collectObservations", () => {
     expect(finding).toBeDefined();
     if (finding?.kind === "review-finding") {
       expect(finding.payload.ruleId).toBe("input:listener-arg-not-validated");
-      expect(finding.payload.message).toContain("X is not validated");
-      expect(finding.payload.message).toContain("→ guard with typeof");
+      expect(finding.payload.message).toBe("CANONICAL_SENTINEL — pre-formatted message from Phase-1 normalization");
     }
   });
 

--- a/test/unit/plugins/builtin/curator-collector.test.ts
+++ b/test/unit/plugins/builtin/curator-collector.test.ts
@@ -364,7 +364,7 @@ describe("collectObservations", () => {
     expect(observations.some((o) => o.kind === "fix-cycle-iteration" && o.payload.outcome === "unchanged")).toBe(true);
   });
 
-  test("projects LLM-shaped review findings (issue/suggestion) into payload.message", async () => {
+  test("AC-4: legacy on-disk LLM-shape audits remain readable", async () => {
     const root = await mkdtemp(join(tmpdir(), "curator-llm-finding-"));
     const outputDir = join(root, "out");
     const auditDir = join(outputDir, "review-audit", "feat-x");
@@ -443,6 +443,65 @@ describe("collectObservations", () => {
       expect(noSuggestion.payload.message).toBe(
         "Listener errors are swallowed when logger is null.",
       );
+    }
+  });
+
+  test("AC-3: canonical-shape audits pass through without fallback logic", async () => {
+    const root = await mkdtemp(join(tmpdir(), "curator-canonical-pass-"));
+    const outputDir = join(root, "out");
+    const auditDir = join(outputDir, "review-audit", "feat-z");
+    await mkdir(auditDir, { recursive: true });
+
+    await writeFile(
+      join(auditDir, "1-review-semantic-US-005.json"),
+      JSON.stringify({
+        timestamp: "2026-05-07T00:00:00.000Z",
+        storyId: "US-005",
+        featureName: "feat-z",
+        reviewer: "semantic",
+        result: {
+          findings: [
+            {
+              ruleId: "input:listener-arg-not-validated",
+              severity: "error",
+              file: "src/foo.ts",
+              line: 73,
+              message: "X is not validated\n→ guard with typeof",
+              category: "input",
+              meta: { issue: "X is not validated", suggestion: "guard with typeof" },
+            },
+          ],
+        },
+      }),
+    );
+
+    const context: CuratorPostRunContext = {
+      runId: "run-canonical-pass",
+      feature: "feat-z",
+      workdir: root,
+      prdPath: join(root, "prd.json"),
+      branch: "main",
+      totalDurationMs: 1000,
+      totalCost: 0,
+      storySummary: { completed: 1, failed: 0, skipped: 0, paused: 0 },
+      stories: [],
+      version: "0.1.0",
+      pluginConfig: {},
+      logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+      config: {} as any,
+      outputDir,
+      globalDir: join(root, "global"),
+      projectKey: "test-project",
+      curatorRollupPath: join(root, "rollup.jsonl"),
+    };
+
+    const observations = await collectObservations(context);
+    const finding = observations.find((o) => o.kind === "review-finding");
+    expect(finding).toBeDefined();
+    if (finding?.kind === "review-finding") {
+      expect(finding.payload.ruleId).toBe("input:listener-arg-not-validated");
+      expect(finding.payload.message).toContain("X is not validated");
+      expect(finding.payload.message).toContain("→ guard with typeof");
     }
   });
 

--- a/test/unit/plugins/builtin/curator-heuristics.test.ts
+++ b/test/unit/plugins/builtin/curator-heuristics.test.ts
@@ -762,6 +762,18 @@ describe("H1 — sample messages in evidence", () => {
     expect(h1.evidence).toContain("Null check missing");
     expect(h1.evidence).not.toContain("→ Add a guard");
   });
+
+  test("first finding with empty message does not block later real message from appearing", () => {
+    const observations: Observation[] = [
+      makeReviewFindingObs942("US-001", "review:null-check", "warning", ""),
+      makeReviewFindingObs942("US-002", "review:null-check", "warning", "Null check missing"),
+    ];
+
+    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
+    const h1 = proposals.find((p) => p.id === "H1")!;
+    expect(h1).toBeDefined();
+    expect(h1.evidence).toContain("Null check missing");
+  });
 });
 
 describe("H1 — issue #942 AC-5: ruleId buckets are not single-word collapses", () => {

--- a/test/unit/plugins/builtin/curator-heuristics.test.ts
+++ b/test/unit/plugins/builtin/curator-heuristics.test.ts
@@ -722,6 +722,48 @@ function makeReviewFindingObs942(
   };
 }
 
+describe("H1 — sample messages in evidence", () => {
+  test("evidence includes up to two sample messages drawn from the group", () => {
+    const observations: Observation[] = [
+      makeReviewFindingObs942("US-001", "input:listener-arg-not-validated", "warning", "Listener arg not validated as a function"),
+      makeReviewFindingObs942("US-002", "input:listener-arg-not-validated", "warning", "Listener arg not validated as a function — handler path"),
+      makeReviewFindingObs942("US-003", "input:listener-arg-not-validated", "warning", "Third example should not appear"),
+    ];
+
+    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
+    const h1 = proposals.find((p) => p.id === "H1")!;
+
+    expect(h1).toBeDefined();
+    expect(h1.evidence).toContain("Listener arg not validated as a function");
+    expect(h1.evidence).toContain("Listener arg not validated as a function — handler path");
+    expect(h1.evidence).not.toContain("Third example should not appear");
+  });
+
+  test("evidence omits sample section when all messages are empty", () => {
+    const observations: Observation[] = [
+      makeReviewFindingObs942("US-001", "input:listener-arg-not-validated", "warning", ""),
+      makeReviewFindingObs942("US-002", "input:listener-arg-not-validated", "warning", ""),
+    ];
+
+    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
+    const h1 = proposals.find((p) => p.id === "H1")!;
+    expect(h1).toBeDefined();
+    expect(h1.evidence).not.toContain("Examples:");
+  });
+
+  test("sample uses only the first line of a multi-line message", () => {
+    const observations: Observation[] = [
+      makeReviewFindingObs942("US-001", "review:null-check", "warning", "Null check missing\n→ Add a guard before access"),
+      makeReviewFindingObs942("US-002", "review:null-check", "warning", "Null check missing\n→ Add a guard before access"),
+    ];
+
+    const proposals = runHeuristics(observations, { repeatedFinding: 2 } as CuratorThresholds);
+    const h1 = proposals.find((p) => p.id === "H1")!;
+    expect(h1.evidence).toContain("Null check missing");
+    expect(h1.evidence).not.toContain("→ Add a guard");
+  });
+});
+
 describe("H1 — issue #942 AC-5: ruleId buckets are not single-word collapses", () => {
   test("findings sharing a category but different issues yield distinct buckets", () => {
     const observations: Observation[] = [


### PR DESCRIPTION
## Summary

Phase 2 of Issue #942. Depends on Phase 1 (#944, merged).

- **AC-3 (test + collector):** Added `"AC-3: canonical-shape audits pass through without fallback logic"` test using a Phase 1 canonical fixture (`ruleId` + `message` + `meta` sidecar, no top-level `issue`/`suggestion`). Renamed the old LLM-shape replay test to `"AC-4: legacy on-disk LLM-shape audits remain readable"`.
- **AC-3 (source):** `findingRuleId` in `collect.ts` now prefers `ruleId` over `rule` (canonical shape from Phase 1 uses `ruleId`; the old `rule`-first order was a latent bug). `findingMessage` doc comment updated to reference AC-4 transition.
- **H1 evidence enrichment:** `h1RepeatedReviewFinding` now tracks up to 2 distinct sample messages per ruleId group and appends `Examples: …` (first line only) to the evidence string. Tests cover deduplication, empty-message suppression, and first-line truncation.

## Test Plan

- [ ] `bun run test` — 8769 tests, 0 failures
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `curator-collector.test.ts` — AC-3 canonical pass-through + AC-4 legacy compatibility both green
- [ ] `curator-heuristics.test.ts` — 3 new H1 sample-evidence tests + existing AC-5 anti-collapse test all green