### PR TITLE
feat(precheck): add canonical rules lint blocker

### DIFF
--- a/src/precheck/checks-blockers.ts
+++ b/src/precheck/checks-blockers.ts
@@ -20,4 +20,5 @@ export {
   checkTestCommand,
   checkLintCommand,
   checkTypecheckCommand,
+  checkCanonicalRulesLint,
 } from "./checks-system";

--- a/src/precheck/checks-system.ts
+++ b/src/precheck/checks-system.ts
@@ -4,7 +4,21 @@
 
 import { existsSync, statSync } from "node:fs";
 import type { PrecheckConfig } from "../config/selectors";
+import {
+  NeutralityLintError,
+  loadCanonicalRules,
+} from "../context/rules/canonical-loader";
+import { errorMessage } from "../utils/errors";
 import type { Check } from "./types";
+
+function discoverCanonicalRuleRoots(workdir: string): string[] {
+  return [workdir];
+}
+
+export const _checkCanonicalRulesDeps = {
+  discoverRoots: discoverCanonicalRuleRoots,
+  loadCanonicalRules,
+};
 
 /** Check if dependencies are installed (language-aware). Detects: node_modules, target, venv, vendor */
 export async function checkDependenciesInstalled(workdir: string): Promise<Check> {
@@ -97,5 +111,50 @@ export async function checkTypecheckCommand(config: PrecheckConfig): Promise<Che
     tier: "warning",
     passed: true,
     message: `Typecheck command configured: ${typecheckCommand}`,
+  };
+}
+
+/**
+ * Check if canonical rules lint passes for the repository root store.
+ *
+ * Minimal integration scope: root-only. Package overlays are intentionally
+ * excluded for this first rollout.
+ */
+export async function checkCanonicalRulesLint(workdir: string): Promise<Check> {
+  const roots = _checkCanonicalRulesDeps.discoverRoots(workdir);
+  let ruleCount = 0;
+
+  try {
+    for (const root of roots) {
+      const rules = await _checkCanonicalRulesDeps.loadCanonicalRules(root);
+      ruleCount += rules.length;
+    }
+  } catch (err) {
+    if (err instanceof NeutralityLintError) {
+      const first = err.violations[0];
+      const detail = first
+        ? `${first.file}:${first.lineNumber} (${first.ruleId})`
+        : "unknown location";
+      return {
+        name: "canonical-rules-lint",
+        tier: "blocker",
+        passed: false,
+        message: `Canonical rules lint failed (${err.violations.length} violation(s)): ${detail}`,
+      };
+    }
+
+    return {
+      name: "canonical-rules-lint",
+      tier: "blocker",
+      passed: false,
+      message: `Canonical rules lint failed: ${errorMessage(err)}`,
+    };
+  }
+
+  return {
+    name: "canonical-rules-lint",
+    tier: "blocker",
+    passed: true,
+    message: `Canonical rules lint passed (${ruleCount} file(s) across ${roots.length} root(s))`,
   };
 }

--- a/src/precheck/checks-system.ts
+++ b/src/precheck/checks-system.ts
@@ -4,10 +4,7 @@
 
 import { existsSync, statSync } from "node:fs";
 import type { PrecheckConfig } from "../config/selectors";
-import {
-  NeutralityLintError,
-  loadCanonicalRules,
-} from "../context/rules/canonical-loader";
+import { NeutralityLintError, loadCanonicalRules } from "../context/rules/canonical-loader";
 import { errorMessage } from "../utils/errors";
 import type { Check } from "./types";
 
@@ -132,9 +129,7 @@ export async function checkCanonicalRulesLint(workdir: string): Promise<Check> {
   } catch (err) {
     if (err instanceof NeutralityLintError) {
       const first = err.violations[0];
-      const detail = first
-        ? `${first.file}:${first.lineNumber} (${first.ruleId})`
-        : "unknown location";
+      const detail = first ? `${first.file}:${first.lineNumber} (${first.ruleId})` : "unknown location";
       return {
         name: "canonical-rules-lint",
         tier: "blocker",

--- a/src/precheck/checks.ts
+++ b/src/precheck/checks.ts
@@ -18,6 +18,7 @@ export {
   checkTestCommand,
   checkLintCommand,
   checkTypecheckCommand,
+  checkCanonicalRulesLint,
   checkGitUserConfigured,
 } from "./checks-blockers";
 

--- a/src/precheck/index.ts
+++ b/src/precheck/index.ts
@@ -15,6 +15,7 @@ import type { PRD } from "../prd/types";
 import {
   checkAgentCLI,
   checkBuildCommandInReviewChecks,
+  checkCanonicalRulesLint,
   checkClaudeMdExists,
   checkDependenciesInstalled,
   checkDiskSpace,
@@ -114,6 +115,7 @@ function getLateEnvironmentBlockers(config: PrecheckConfig, workdir: string): Ch
     () => checkTestCommand(config),
     () => checkLintCommand(config),
     () => checkTypecheckCommand(config),
+    () => checkCanonicalRulesLint(workdir),
     () => checkGitUserConfigured(workdir),
   ];
 }

--- a/test/unit/precheck/precheck-canonical-lint-orchestrator.test.ts
+++ b/test/unit/precheck/precheck-canonical-lint-orchestrator.test.ts
@@ -1,0 +1,149 @@
+/**
+ * runPrecheck canonical-rules-lint orchestrator behavior
+ *
+ * Ensures canonical rules neutrality violations surface as Tier 1 blockers.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ExecutionConfig, NaxConfig } from "../../../src/config";
+import type { PRD, UserStory } from "../../../src/prd/types";
+import { runEnvironmentPrecheck, runPrecheck } from "../../../src/precheck";
+import { _checkCliDeps } from "../../../src/precheck/checks-cli";
+import { makeTempDir } from "../../helpers/temp";
+
+const createMockConfig = (cwd: string, overrides: Partial<ExecutionConfig> = {}): NaxConfig => ({
+  execution: {
+    maxIterations: 10,
+    iterationDelayMs: 0,
+    maxCostUSD: 10,
+    testCommand: "echo 'test'",
+    lintCommand: "echo 'lint'",
+    typecheckCommand: "echo 'typecheck'",
+    contextProviderTokenBudget: 2000,
+    requireExplicitContextFiles: false,
+    preflightExpectedFilesEnabled: false,
+    cwd,
+    ...overrides,
+  },
+  autoMode: {
+    enabled: false,
+    defaultAgent: "test-agent",
+    fallbackOrder: [],
+    complexityRouting: {
+      simple: "fast",
+      medium: "balanced",
+      complex: "powerful",
+      expert: "ultra",
+    },
+    escalation: {
+      enabled: true,
+      tierOrder: [],
+    },
+  },
+  quality: {
+    minTestCoverage: 80,
+    requireTypecheck: true,
+    requireLint: true,
+  },
+  tdd: {
+    strategy: "auto",
+    skipGeneratedVerificationTests: false,
+  },
+  models: {},
+  rectification: {
+    enabled: true,
+    maxRetries: 2,
+    fullSuiteTimeoutSeconds: 120,
+    maxFailureSummaryChars: 2000,
+    abortOnIncreasingFailures: true,
+  },
+});
+
+const createMockStory = (overrides: Partial<UserStory> = {}): UserStory => ({
+  id: "US-001",
+  title: "Test story",
+  description: "Test description",
+  acceptanceCriteria: ["AC1"],
+  tags: [],
+  dependencies: [],
+  status: "pending",
+  passes: false,
+  escalations: [],
+  attempts: 0,
+  ...overrides,
+});
+
+const createMockPRD = (stories: UserStory[] = []): PRD => ({
+  project: "test-project",
+  feature: "test-feature",
+  branchName: "test-branch",
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  userStories: stories.length > 0 ? stories : [createMockStory()],
+});
+
+describe("runPrecheck canonical-rules-lint blocker", () => {
+  let testDir: string;
+  let originalSpawn: typeof _checkCliDeps.spawn;
+
+  beforeEach(async () => {
+    testDir = makeTempDir("nax-precheck-canonical-lint-");
+
+    const git = (args: string[]) =>
+      Bun.spawnSync(["git", ...args], { cwd: testDir, stdout: "ignore", stderr: "ignore" });
+
+    git(["init"]);
+    git(["config", "user.name", "Test"]);
+    git(["config", "user.email", "test@test.com"]);
+    writeFileSync(join(testDir, "README.md"), "# test");
+    mkdirSync(join(testDir, "node_modules"), { recursive: true });
+    git(["add", "."]);
+    git(["commit", "-m", "init"]);
+
+    originalSpawn = _checkCliDeps.spawn;
+    _checkCliDeps.spawn = ((_args: string[], _opts: unknown) => ({
+      exited: Promise.resolve(0),
+      stdout: null,
+      stderr: null,
+    })) as typeof _checkCliDeps.spawn;
+  });
+
+  afterEach(() => {
+    _checkCliDeps.spawn = originalSpawn;
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("adds canonical-rules-lint as Tier 1 blocker when neutrality lint fails", async () => {
+    const rulesDir = join(testDir, ".nax", "rules");
+    mkdirSync(rulesDir, { recursive: true });
+    writeFileSync(join(rulesDir, "bad.md"), "Follow AGENTS.md exactly.");
+
+    const config = createMockConfig(testDir);
+    const prd = createMockPRD();
+
+    const { output, exitCode } = await runPrecheck(config, prd, { workdir: testDir, format: "json", silent: true });
+
+    const blocker = output.blockers.find((check) => check.name === "canonical-rules-lint");
+    expect(blocker).toBeDefined();
+    expect(blocker?.passed).toBe(false);
+    expect(output.passed).toBe(false);
+    expect(exitCode).toBe(1);
+  });
+
+  test("blocks runEnvironmentPrecheck when canonical rules lint fails", async () => {
+    const rulesDir = join(testDir, ".nax", "rules");
+    mkdirSync(rulesDir, { recursive: true });
+    writeFileSync(join(rulesDir, "bad.md"), "Follow AGENTS.md exactly.");
+
+    const config = createMockConfig(testDir);
+
+    const result = await runEnvironmentPrecheck(config, testDir, { silent: true });
+
+    expect(result.passed).toBe(false);
+    const blocker = result.blockers.find((check) => check.name === "canonical-rules-lint");
+    expect(blocker).toBeDefined();
+    expect(blocker?.passed).toBe(false);
+  });
+});

--- a/test/unit/precheck/precheck-checks-tier1-blockers.test.ts
+++ b/test/unit/precheck/precheck-checks-tier1-blockers.test.ts
@@ -10,6 +10,7 @@ import type { ExecutionConfig, NaxConfig } from "../../../src/config";
 import type { PRD, UserStory } from "../../../src/prd/types";
 import { makeTempDir } from "../../helpers/temp";
 import {
+  checkCanonicalRulesLint,
   checkClaudeCLI,
   checkDependenciesInstalled,
   checkGitRepoExists,
@@ -18,6 +19,7 @@ import {
   checkStaleLock,
   checkWorkingTreeClean,
 } from "../../../src/precheck/checks";
+import { _checkCanonicalRulesDeps } from "../../../src/precheck/checks-system";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Test fixtures
@@ -432,6 +434,77 @@ describe("checkDependenciesInstalled (Tier 1 blocker)", () => {
     const result = await checkDependenciesInstalled(testDir);
 
     expect(result.passed).toBe(true);
+  });
+});
+
+describe("checkCanonicalRulesLint (Tier 1 blocker)", () => {
+  let testDir: string;
+  let originalLoadCanonicalRules: typeof _checkCanonicalRulesDeps.loadCanonicalRules;
+
+  beforeEach(() => {
+    testDir = makeTempDir("nax-test-precheck-");
+    originalLoadCanonicalRules = _checkCanonicalRulesDeps.loadCanonicalRules;
+  });
+
+  afterEach(() => {
+    _checkCanonicalRulesDeps.loadCanonicalRules = originalLoadCanonicalRules;
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("passes when no canonical rules store exists", async () => {
+    const result = await checkCanonicalRulesLint(testDir);
+
+    expect(result.name).toBe("canonical-rules-lint");
+    expect(result.tier).toBe("blocker");
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("passed");
+  });
+
+  test("passes when canonical rules are neutral", async () => {
+    const rulesDir = join(testDir, ".nax", "rules");
+    mkdirSync(rulesDir, { recursive: true });
+    writeFileSync(join(rulesDir, "style.md"), "Use clear naming.\nPrefer immutable updates.");
+
+    const result = await checkCanonicalRulesLint(testDir);
+
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("1 file(s)");
+  });
+
+  test("fails when canonical rules contain banned markers", async () => {
+    const rulesDir = join(testDir, ".nax", "rules");
+    mkdirSync(rulesDir, { recursive: true });
+    writeFileSync(join(rulesDir, "bad.md"), "Do exactly what AGENTS.md says.");
+
+    const result = await checkCanonicalRulesLint(testDir);
+
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("violation");
+    expect(result.message).toContain("bad.md");
+  });
+
+  test("minimal integration lints repository root canonical rules", async () => {
+    mkdirSync(join(testDir, ".nax", "rules"), { recursive: true });
+    writeFileSync(join(testDir, ".nax", "rules", "root.md"), "Root guidance.");
+    mkdirSync(join(testDir, "packages", "api", ".nax", "rules"), { recursive: true });
+    writeFileSync(join(testDir, "packages", "api", ".nax", "rules", "api.md"), "API guidance.");
+
+    const result = await checkCanonicalRulesLint(testDir);
+
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("1 file(s)");
+    expect(result.message).toContain("1 root(s)");
+  });
+
+  test("fails with generic message when canonical loader throws non-neutrality error", async () => {
+    _checkCanonicalRulesDeps.loadCanonicalRules = async () => {
+      throw new Error("boom");
+    };
+
+    const result = await checkCanonicalRulesLint(testDir);
+
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("Canonical rules lint failed: boom");
   });
 });
 


### PR DESCRIPTION
## Summary
- add a new Tier 1 precheck blocker `canonical-rules-lint`
- wire canonical rules lint into precheck late environment blockers
- implement minimal rollout scope (repository root canonical store only) and document that explicitly
- map neutrality lint failures and generic loader failures into structured precheck blocker messages
- add orchestrator coverage for both `runPrecheck` and `runEnvironmentPrecheck`
- add unit coverage for the non-neutrality generic error branch

## Files Changed
- src/precheck/checks-system.ts
- src/precheck/checks-blockers.ts
- src/precheck/checks.ts
- src/precheck/index.ts
- test/unit/precheck/precheck-checks-tier1-blockers.test.ts
- test/unit/precheck/precheck-canonical-lint-orchestrator.test.ts

## Validation
- `timeout 120 bun test test/unit/precheck/precheck-checks-tier1-blockers.test.ts test/unit/precheck/precheck-canonical-lint-orchestrator.test.ts --timeout=15000`
- Result: 34 passed, 3 skipped, 0 failed
