### PR TITLE
[codex] Enable idle watchdog by default

### DIFF
--- a/src/config/runtime-types-agent.ts
+++ b/src/config/runtime-types-agent.ts
@@ -42,15 +42,15 @@ export interface AgentFallbackConfig {
 
 /** Idle watchdog configuration */
 export interface IdleWatchdogConfig {
-  /** Whether the idle watchdog is enabled (default: false) */
+  /** Whether the idle watchdog is enabled (default: true) */
   enabled?: boolean;
   /** Watchdog mode: off (disabled), observe (log only), warn-then-cancel (log + grace period + cancel), cancel (immediate) */
   mode?: "off" | "observe" | "warn-then-cancel" | "cancel";
-  /** Idle timeout in seconds before watchdog triggers (default: 30) */
+  /** Idle timeout in seconds before watchdog triggers (default: 900) */
   idleTimeoutSeconds?: number;
   /** Activity kinds that reset the idle timer (default: all message, thinking, usage updates) */
   activityKinds?: Array<"message_update" | "thinking_update" | "usage_update">;
-  /** Grace period in seconds before cancel actually happens (used in warn-then-cancel mode, default: 5) */
+  /** Grace period in seconds before cancel actually happens (used in warn-then-cancel mode, default: 10) */
   cancelGraceSeconds?: number;
   /** Maximum retry attempts before emitting terminal failure (default: 3) */
   maxRetryAttempts?: number;

--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -131,6 +131,22 @@ const AgentFallbackConfigSchema = z.object({
   rebuildContext: z.boolean().default(true),
 });
 
+export const DEFAULT_AGENT_IDLE_WATCHDOG_CONFIG: {
+  enabled: boolean;
+  mode: "warn-then-cancel";
+  idleTimeoutSeconds: number;
+  activityKinds: Array<"message_update" | "thinking_update" | "usage_update">;
+  cancelGraceSeconds: number;
+  maxRetryAttempts: number;
+} = {
+  enabled: true,
+  mode: "warn-then-cancel",
+  idleTimeoutSeconds: 900,
+  activityKinds: ["message_update", "thinking_update", "usage_update"],
+  cancelGraceSeconds: 10,
+  maxRetryAttempts: 3,
+};
+
 const AgentIdleWatchdogConfigSchema = z
   .object({
     enabled: z.boolean().default(true),
@@ -163,7 +179,7 @@ export const AgentConfigSchema = z.object({
     rebuildContext: true,
   }),
   acp: AgentAcpConfigSchema.default({ promptRetries: 0 }),
-  idleWatchdog: AgentIdleWatchdogConfigSchema.optional(),
+  idleWatchdog: AgentIdleWatchdogConfigSchema.default(DEFAULT_AGENT_IDLE_WATCHDOG_CONFIG),
 });
 
 export const PrecheckConfigSchema = z.object({

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -19,6 +19,7 @@ import {
   AcceptanceConfigSchema,
   AgentConfigSchema,
   CuratorConfigSchema,
+  DEFAULT_AGENT_IDLE_WATCHDOG_CONFIG,
   GenerateConfigSchema,
   HooksConfigSchema,
   InteractionConfigSchema,
@@ -312,6 +313,7 @@ export const NaxConfigSchema = z
       promptAudit: { enabled: false },
       fallback: { enabled: false, map: {}, maxHopsPerStory: 2, onQualityFailure: false, rebuildContext: true },
       acp: { promptRetries: 0 },
+      idleWatchdog: DEFAULT_AGENT_IDLE_WATCHDOG_CONFIG,
     }),
     precheck: PrecheckConfigSchema.optional().default({
       storySizeGate: {

--- a/test/unit/agents/fail-stale-agent-manager.test.ts
+++ b/test/unit/agents/fail-stale-agent-manager.test.ts
@@ -206,6 +206,14 @@ describe("AgentManager.runWithFallback with fail-stale", () => {
         ...DEFAULT_CONFIG,
         agent: {
           ...DEFAULT_CONFIG.agent,
+          idleWatchdog: {
+            enabled: true,
+            mode: "warn-then-cancel",
+            idleTimeoutSeconds: 900,
+            activityKinds: ["message_update", "thinking_update", "usage_update"],
+            cancelGraceSeconds: 10,
+            maxRetryAttempts: 1,
+          },
           fallback: {
             enabled: true,
             map: { claude: ["codex", "opencode"] },

--- a/test/unit/agents/manager-swap-loop.test.ts
+++ b/test/unit/agents/manager-swap-loop.test.ts
@@ -9,6 +9,14 @@ function makeConfig(map: Record<string, string[]> = { claude: ["codex"] }) {
   return makeNaxConfig({
     agent: {
       fallback: { enabled: true, map, maxHopsPerStory: 2, onQualityFailure: false, rebuildContext: false },
+      idleWatchdog: {
+        enabled: true,
+        mode: "warn-then-cancel",
+        idleTimeoutSeconds: 900,
+        activityKinds: ["message_update", "thinking_update", "usage_update"],
+        cancelGraceSeconds: 10,
+        maxRetryAttempts: 1,
+      },
     },
   });
 }

--- a/test/unit/config/agent-schema.test.ts
+++ b/test/unit/config/agent-schema.test.ts
@@ -13,6 +13,8 @@ describe("AgentConfigSchema", () => {
     expect(result.agent?.fallback.maxHopsPerStory).toBe(2);
     expect(result.agent?.fallback.onQualityFailure).toBe(false);
     expect(result.agent?.fallback.rebuildContext).toBe(true);
+    expect(result.agent?.idleWatchdog?.enabled).toBe(true);
+    expect(result.agent?.idleWatchdog?.mode).toBe("warn-then-cancel");
   });
 
   test("accepts a fully populated agent block", () => {
@@ -65,10 +67,14 @@ describe("AgentConfigSchema", () => {
     expect(() => NaxConfigSchema.parse({ agent: { acp: { promptRetries: 6 } } })).toThrow();
   });
 
-  test("agent.idleWatchdog is optional by default", () => {
+  test("agent.idleWatchdog defaults to enabled", () => {
     const result = NaxConfigSchema.parse({});
-    // idleWatchdog is optional, so it should be undefined when not provided
-    expect(result.agent?.idleWatchdog).toBeUndefined();
+    expect(result.agent?.idleWatchdog?.enabled).toBe(true);
+    expect(result.agent?.idleWatchdog?.mode).toBe("warn-then-cancel");
+    expect(result.agent?.idleWatchdog?.idleTimeoutSeconds).toBe(900);
+    expect(result.agent?.idleWatchdog?.cancelGraceSeconds).toBe(10);
+    expect(result.agent?.idleWatchdog?.maxRetryAttempts).toBe(3);
+    expect(result.agent?.idleWatchdog?.activityKinds).toEqual(["message_update", "thinking_update", "usage_update"]);
   });
 
   test("agent.idleWatchdog internal defaults when provided", () => {


### PR DESCRIPTION
## What changed

- Default `agent.idleWatchdog` to the enabled watchdog configuration instead of leaving it absent.
- Reuse a shared watchdog default in both the agent schema and top-level config schema defaults.
- Update runtime type comments to match the actual watchdog defaults.
- Adjust fail-stale retry tests that intentionally expect a one-retry budget to set `maxRetryAttempts: 1` explicitly.

## Why

The watchdog's internal schema already defaulted to `enabled: true` when `idleWatchdog` was present, but the parent field was optional, so `NaxConfigSchema.parse({})` omitted it. This makes the enabled watchdog behavior the true default.

## Validation

- `bun test test/unit/config/agent-schema.test.ts --timeout=30000`
- `bun test test/unit/agents/manager-swap-loop.test.ts test/unit/agents/fail-stale-agent-manager.test.ts --timeout=30000`
- `bun run typecheck`
- pre-commit checks: typecheck, lint, no-real-global-nax, process.cwd(), adapter wrap, dispatch context