### PR TITLE
fix(review): fail-closed when blocking findings dropped as ungrounded; harden AC-grounding prompt

### DIFF
--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -141,10 +141,22 @@ Severity guide:
 \`passed\` may be \`true\` with findings if all findings are \`"info"\` or \`"unverifiable"\`.
 
 **AC-grounding rule — required for every "error" finding:**
-- \`acQuote\` must be a verbatim substring of one AC bullet (from the Acceptance Criteria above) that names or constrains the exact file, function, or symbol you are flagging.
+- \`acQuote\` must be a verbatim substring of one AC bullet (from the Acceptance Criteria above) that names or constrains the exact **symbol** you are flagging — not merely the file the symbol lives in.
 - \`acIndex\` is the 1-based position of that AC bullet in the list.
-- If no AC bullet mentions the file, function, or symbol being flagged, emit the finding as \`"info"\` instead — it cannot block the story.
-- Do not paraphrase the AC text — copy it exactly.`;
+- Copy \`acQuote\` **exactly** from the AC text, including any backticks, asterisks, or punctuation. Do not paraphrase, strip formatting, or rewrite.
+
+**The "AC names the file but not the symbol" trap (most common failure mode):**
+If the AC bullet mentions a file or component but the **specific symbol you are flagging** (the function, class, interface, type, or convention) is not named in that bullet, the AC does **not** constrain your finding. Emit it as \`"info"\` — not \`"error"\`.
+
+Worked example:
+- AC#1 reads: \`\`\`\`AstIndexService.indexCommit() is called by the code_commit outbox handler\`\`\`\`
+- You found that \`code-commit-outbox-handler.ts\` defines a custom \`ExtendedPrismaClient\` interface, violating a project convention rule.
+- WRONG: severity \`"error"\`, \`acQuote: "AstIndexService.indexCommit() is called by the code_commit outbox handler"\`, \`acIndex: 1\`. — AC#1 is about *who calls indexCommit*; it says nothing about Prisma typing. Picking it because the file is named is mis-grounding.
+- RIGHT: severity \`"info"\`, no \`acQuote\`. The convention violation is real, but no AC constrains \`ExtendedPrismaClient\`, so it cannot block the story.
+
+**Convention / coding-standard violations almost always belong as \`"info"\`** unless an AC specifically names the convention or the symbol it concerns.
+
+If you cannot find an AC that names the **specific symbol** in your finding, downgrade to \`"info"\`. A finding dropped by the validator is worse than one correctly classified as advisory.`;
 
 /**
  * Build the diff section for "ref" mode.

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -32,10 +32,14 @@ For each acceptance criterion, verify the current codebase implements it correct
 - The \`verifiedBy.observed\` field MUST be a **verbatim** 1-3 line code excerpt copy-pasted from the file — not a description. Paste the actual source lines (or a substring of them) that prove your claim. A description like "function X does not check Y" is not a verifiable observation; quote the lines that demonstrate the omission instead. If you cannot quote an exact excerpt that proves your point, downgrade the finding to "unverifiable".
 
 **AC-grounding rule — required for every "error" finding:**
-- Every "error" finding MUST include \`acQuote\`: a verbatim substring of one AC bullet that names or constrains the exact file, function, or symbol you are flagging.
+- Every "error" finding MUST include \`acQuote\`: a verbatim substring of one AC bullet that names or constrains the exact **symbol** you are flagging — not merely the file the symbol lives in.
 - Include \`acIndex\` (1-based) indicating which AC bullet you are quoting.
-- If no AC bullet mentions the file, function, or symbol being flagged, the finding is out-of-scope. Emit it as \`severity: "info"\` instead — it cannot block the story.
-- Copy \`acQuote\` directly from the Acceptance Criteria text — do not paraphrase.
+- Copy \`acQuote\` directly from the Acceptance Criteria — including any backticks, asterisks, or punctuation. Do not paraphrase, strip formatting, or rewrite.
+
+**The "AC names the file but not the symbol" trap (most common failure mode):**
+If the AC bullet mentions a file or component but the **specific symbol you are flagging** (the function, class, interface, type, or convention) is not named in that bullet, the AC does **not** constrain your finding. Emit it as \`severity: "info"\` — not \`"error"\`. **Convention / coding-standard violations almost always belong as \`"info"\`** unless an AC specifically names the convention or the symbol it concerns.
+
+If you cannot find an AC that names the **specific symbol** in your finding, downgrade to \`"info"\`. A finding dropped by the validator as ungrounded is worse than one correctly classified as advisory.
 
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -440,7 +440,52 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   }
 
   // If all findings are advisory (below threshold), override to pass regardless of passed field.
+  //
+  // Guard: when blocking-severity findings were dropped by filterByAcQuote, "no blocking
+  // findings remaining" is NOT evidence of "all advisory" — it is evidence of "the model
+  // produced blocking concerns that it could not ground in any AC." Silently flipping to
+  // pass in that case turns "model misclassified findings as `error`" into "story shipped."
+  // Fail closed and surface the drops so the curator can act on them. (Issue: 2 stories
+  // observed passing this way after acQuote drops; see logs/prompt-audit.txt.)
   if (!parsed.passed && blockingFindings.length === 0) {
+    if (acDropped.length > 0) {
+      const durationMs = Date.now() - startTime;
+      logger?.warn("review", "Adversarial review fail-closed: blocking findings dropped as ungrounded", {
+        storyId: story.id,
+        durationMs,
+        droppedCount: acDropped.length,
+        dropCodes: acDropped.map((d) => d.code),
+      });
+      const dropSummary = acDropped
+        .map((d, i) => `${i + 1}. [${d.code}] ${d.finding.file ?? "<unknown>"}: ${d.finding.issue}`)
+        .join("\n");
+      recordAdversarialAudit({
+        runtime,
+        workdir,
+        projectDir,
+        storyId: story.id,
+        featureName,
+        parsed: true,
+        failOpen: false,
+        passed: false,
+        blockingThreshold: threshold,
+        result: { passed: false, findings: [] },
+        advisoryFindings:
+          advisoryFindings.length > 0
+            ? llmFindingsToReviewFindings(advisoryFindings, { source: "adversarial-review" })
+            : undefined,
+      });
+      return {
+        check: "adversarial",
+        success: false,
+        command: "",
+        exitCode: 1,
+        output: `Adversarial review failed: ${acDropped.length} blocking finding(s) dropped as ungrounded — the model emitted "passed: false" with concerns it could not ground in any acceptance criterion. Either re-classify these as "info" upstream or extend the ACs. Drops:\n\n${dropSummary}`,
+        durationMs,
+        advisoryFindings: advisoryFindings.length > 0 ? toAdversarialReviewFindings(advisoryFindings) : undefined,
+        cost: llmCost,
+      };
+    }
     const durationMs = Date.now() - startTime;
     logger?.info("review", "Adversarial review passed (all findings below blocking threshold)", {
       storyId: story.id,

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -490,8 +490,52 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
     };
   }
 
-  // If LLM said failed but all findings are advisory (below threshold), override to pass
+  // If LLM said failed but all findings are advisory (below threshold), override to pass.
+  //
+  // Guard: when blocking-severity findings were dropped by filterByAcQuote, "no blocking
+  // findings remaining" is NOT evidence of "all advisory" — it is evidence of "the model
+  // produced blocking concerns that it could not ground in any AC." Silently flipping to
+  // pass in that case turns "model misclassified findings as `error`" into "story shipped."
+  // Fail closed and surface the drops so the curator can act on them.
   if (!sanitizedParsed.passed && blockingFindings.length === 0) {
+    if (acDropped.length > 0) {
+      const durationMs = Date.now() - startTime;
+      logger?.warn("review", "Semantic review fail-closed: blocking findings dropped as ungrounded", {
+        storyId: story.id,
+        durationMs,
+        droppedCount: acDropped.length,
+        dropCodes: acDropped.map((d) => d.code),
+      });
+      const dropSummary = acDropped
+        .map((d, i) => `${i + 1}. [${d.code}] ${d.finding.file ?? "<unknown>"}: ${d.finding.issue}`)
+        .join("\n");
+      recordSemanticAudit({
+        runtime,
+        workdir,
+        projectDir,
+        storyId: story.id,
+        featureName,
+        parsed: true,
+        failOpen: false,
+        passed: false,
+        blockingThreshold: threshold,
+        result: { passed: false, findings: [] },
+        advisoryFindings:
+          advisoryFindings.length > 0
+            ? llmFindingsToReviewFindings(advisoryFindings, { source: "semantic-review" })
+            : undefined,
+      });
+      return {
+        check: "semantic",
+        success: false,
+        command: "",
+        exitCode: 1,
+        output: `Semantic review failed: ${acDropped.length} blocking finding(s) dropped as ungrounded — the model emitted "passed: false" with concerns it could not ground in any acceptance criterion. Either re-classify these as "info" upstream or extend the ACs. Drops:\n\n${dropSummary}`,
+        durationMs,
+        advisoryFindings: advisoryFindings.length > 0 ? toReviewFindings(advisoryFindings) : undefined,
+        cost: llmCost,
+      };
+    }
     const durationMs = Date.now() - startTime;
     logger?.info("review", "Semantic review passed (all findings below blocking threshold)", {
       storyId: story.id,

--- a/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
@@ -33,10 +33,14 @@ For each acceptance criterion, verify the current codebase implements it correct
 - The \`verifiedBy.observed\` field MUST be a **verbatim** 1-3 line code excerpt copy-pasted from the file — not a description. Paste the actual source lines (or a substring of them) that prove your claim. A description like "function X does not check Y" is not a verifiable observation; quote the lines that demonstrate the omission instead. If you cannot quote an exact excerpt that proves your point, downgrade the finding to "unverifiable".
 
 **AC-grounding rule — required for every "error" finding:**
-- Every "error" finding MUST include \`acQuote\`: a verbatim substring of one AC bullet that names or constrains the exact file, function, or symbol you are flagging.
+- Every "error" finding MUST include \`acQuote\`: a verbatim substring of one AC bullet that names or constrains the exact **symbol** you are flagging — not merely the file the symbol lives in.
 - Include \`acIndex\` (1-based) indicating which AC bullet you are quoting.
-- If no AC bullet mentions the file, function, or symbol being flagged, the finding is out-of-scope. Emit it as \`severity: "info"\` instead — it cannot block the story.
-- Copy \`acQuote\` directly from the Acceptance Criteria text — do not paraphrase.
+- Copy \`acQuote\` directly from the Acceptance Criteria — including any backticks, asterisks, or punctuation. Do not paraphrase, strip formatting, or rewrite.
+
+**The "AC names the file but not the symbol" trap (most common failure mode):**
+If the AC bullet mentions a file or component but the **specific symbol you are flagging** (the function, class, interface, type, or convention) is not named in that bullet, the AC does **not** constrain your finding. Emit it as \`severity: "info"\` — not \`"error"\`. **Convention / coding-standard violations almost always belong as \`"info"\`** unless an AC specifically names the convention or the symbol it concerns.
+
+If you cannot find an AC that names the **specific symbol** in your finding, downgrade to \`"info"\`. A finding dropped by the validator as ungrounded is worse than one correctly classified as advisory.
 
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)
@@ -112,10 +116,14 @@ For each acceptance criterion, verify the current codebase implements it correct
 - The \`verifiedBy.observed\` field MUST be a **verbatim** 1-3 line code excerpt copy-pasted from the file — not a description. Paste the actual source lines (or a substring of them) that prove your claim. A description like "function X does not check Y" is not a verifiable observation; quote the lines that demonstrate the omission instead. If you cannot quote an exact excerpt that proves your point, downgrade the finding to "unverifiable".
 
 **AC-grounding rule — required for every "error" finding:**
-- Every "error" finding MUST include \`acQuote\`: a verbatim substring of one AC bullet that names or constrains the exact file, function, or symbol you are flagging.
+- Every "error" finding MUST include \`acQuote\`: a verbatim substring of one AC bullet that names or constrains the exact **symbol** you are flagging — not merely the file the symbol lives in.
 - Include \`acIndex\` (1-based) indicating which AC bullet you are quoting.
-- If no AC bullet mentions the file, function, or symbol being flagged, the finding is out-of-scope. Emit it as \`severity: "info"\` instead — it cannot block the story.
-- Copy \`acQuote\` directly from the Acceptance Criteria text — do not paraphrase.
+- Copy \`acQuote\` directly from the Acceptance Criteria — including any backticks, asterisks, or punctuation. Do not paraphrase, strip formatting, or rewrite.
+
+**The "AC names the file but not the symbol" trap (most common failure mode):**
+If the AC bullet mentions a file or component but the **specific symbol you are flagging** (the function, class, interface, type, or convention) is not named in that bullet, the AC does **not** constrain your finding. Emit it as \`severity: "info"\` — not \`"error"\`. **Convention / coding-standard violations almost always belong as \`"info"\`** unless an AC specifically names the convention or the symbol it concerns.
+
+If you cannot find an AC that names the **specific symbol** in your finding, downgrade to \`"info"\`. A finding dropped by the validator as ungrounded is worse than one correctly classified as advisory.
 
 Flag issues only when you have confirmed:
 1. An AC is not implemented or partially implemented (verified by reading the actual files)

--- a/test/unit/review/adversarial-pass-fail.test.ts
+++ b/test/unit/review/adversarial-pass-fail.test.ts
@@ -320,6 +320,52 @@ describe("runAdversarialReview — non-blocking only findings", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Regression: passed:false with all blocking findings dropped as ungrounded
+// must fail-closed (must NOT silently flip to pass)
+// ---------------------------------------------------------------------------
+
+const FAILING_ERROR_UNGROUNDED_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "error",
+      category: "convention",
+      file: "src/log.ts",
+      line: 10,
+      issue: "Defines custom ExtendedPrismaClient interface, violating convention",
+      suggestion: "Use Record<string, unknown> cast",
+      // AC#1 reads "Users can log in" — a quote about Prisma typing cannot be a substring,
+      // and even if it were, the locus check would fail. The validator drops this.
+      acQuote: "convention forbids custom ExtendedPrismaClient",
+      acIndex: 1,
+    },
+  ],
+});
+
+describe("runAdversarialReview — drops + passed:false (fail-closed regression)", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("fails closed when all blocking findings were dropped as ungrounded by acQuote validation", async () => {
+    const result = await callRunAdversarialReview(FAILING_ERROR_UNGROUNDED_RESPONSE);
+    // Before this fix: success was true (silent pass) because blockingFindings.length === 0
+    // after the validator drop, and the "all advisory" branch overrode passed:false → true.
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("output names the drop as the failure reason", async () => {
+    const result = await callRunAdversarialReview(FAILING_ERROR_UNGROUNDED_RESPONSE);
+    expect(result.output).toContain("dropped as ungrounded");
+    expect(result.output).toContain("ExtendedPrismaClient");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // AC-5: Skip when no git ref
 // ---------------------------------------------------------------------------
 

--- a/test/unit/review/semantic-findings.test.ts
+++ b/test/unit/review/semantic-findings.test.ts
@@ -286,4 +286,33 @@ describe("runSemanticReview — structured findings in result (US-003 AC-2)", ()
 
     expect(!result.findings || result.findings.length === 0).toBe(true);
   });
+
+  // Regression: passed:false with all blocking findings dropped as ungrounded
+  // must fail-closed (must NOT silently flip to pass).
+  test("fails closed when all blocking findings are dropped as ungrounded by acQuote", async () => {
+    _diffUtilsDeps.spawn = makeSpawnMock("some diff");
+    // The acQuote does not appear in any AC — validator drops; previously the
+    // "all advisory" branch silently flipped success to true.
+    const llmResponse = JSON.stringify({
+      passed: false,
+      findings: [
+        {
+          severity: "error",
+          file: "src/log.ts",
+          line: 10,
+          issue: "Defines custom ExtendedPrismaClient interface, violating convention",
+          suggestion: "Use a Record<string, unknown> cast",
+          acQuote: "convention forbids custom ExtendedPrismaClient",
+          acIndex: 1,
+        },
+      ],
+    });
+
+    const result = await callRunSemanticReview(llmResponse);
+
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("dropped as ungrounded");
+    expect(result.output).toContain("ExtendedPrismaClient");
+  });
 });


### PR DESCRIPTION
Closes #949.

## Summary

- Fix silent fail-open in `runAdversarialReview` / `runSemanticReview`: when `filterByAcQuote` drops all blocking findings, the previously-firing "all advisory, override to pass" branch now fails closed and surfaces the drops in the output.
- Harden the AC-grounding prompt in both adversarial and semantic builders with a worked example of the "AC names the file but not the symbol" trap and explicit guidance for convention/coding-standard violations.
- The acQuote validator (`src/review/ac-quote-validator.ts`) is unchanged — its strictness is the forcing function, not the bug.

## Behavior matrix after this change

| LLM `passed` | Surviving blocking | Dropped | Result |
|:---:|:---:|:---:|:---|
| `false` | ≥1 | any | Fail closed (existing) — output names surviving findings. |
| `false` | 0 | ≥1 | **NEW: Fail closed** — output names dropped findings. (Was: silent pass.) |
| `false` | 0 | 0 | Pass (legit advisory-override). |
| `true` | ≥1 | any | Fail closed (existing — findings take precedence). |
| `true` | 0 | ≥1 | Pass (mirror gap — known follow-up, see #949). |
| `true` | 0 | 0 | Pass. |

## Files

- `src/review/adversarial.ts` — fail-closed branch when drops + advisory-override would fire
- `src/review/semantic.ts` — same fix
- `src/prompts/builders/adversarial-review-builder.ts` — worked example, formatting rules
- `src/prompts/builders/review-builder.ts` — same hardening
- `test/unit/review/adversarial-pass-fail.test.ts` — regression test
- `test/unit/review/semantic-findings.test.ts` — regression test
- `test/unit/prompts/__snapshots__/review-builder.test.ts.snap` — intentional snapshot update for the prompt change

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Targeted unit tests: `test/unit/review/` and `test/unit/prompts/` → 1066 pass, 0 fail (2 pre-existing skips)
- [x] New regression: adversarial — `passed:false` with all `error` findings ungrounded → `success:false`, output contains "dropped as ungrounded"
- [x] New regression: semantic — same
- [x] Existing advisory-override path (no drops) still passes
- [x] Snapshot updates reviewed and intentional
- [ ] Manual verification: re-run a story that previously hit the silent-pass path; confirm review now fails closed with drop list visible

## Notes

The fail-closed message tells the curator/next iteration: "re-classify these as info upstream or extend the ACs." The carry-forward `priorAdversarialIterations` mechanism feeds this output into the next adversarial-review iteration; combined with the hardened prompt, the next iteration has explicit guidance to make the right downgrade. No changes to escalation policy are needed.

## Out of scope (follow-ups, see #949)

- Strengthen the locus check inside `validateAcQuote` once we have real run data.
- Close the mirror gap (`passed: true` + all-error-dropped still passes).
