### PR TITLE
feat(autofix): route implementer TEST_EDIT_REASON declarations to test-writer strategy (#933)

### DIFF
--- a/docs/architecture/subsystems.md
+++ b/docs/architecture/subsystems.md
@@ -535,6 +535,26 @@ Two-phase approach when review fails:
 - Global budget exhausted (`autofixAttempt >= maxTotalAttempts`) → escalate
 - `UNRESOLVED` signal from implementer (reviewer contradiction) → escalate
 
+### Implementer→test-writer feedback loop
+
+When the implementer encounters a test that contradicts the PRD, it emits a
+`TEST_EDIT_REASON: prd_contract` block in its rectification output. The block is
+parsed into a `TestEditDeclaration` (see `src/operations/test-edit-declaration.ts`)
+and stashed on `ctx.testEditDeclarations` by the implementer strategy's
+`extractApplied`. The cycle's `validate()` hook applies these declarations to
+fresh findings: each declaration whose `PRD_QUOTE` is verbatim-present in the
+story description or AC text causes a finding on the declared file to be
+re-tagged from `fixTarget: "source"` to `"test"`. The test-writer strategy
+claims the re-tagged finding on the next iteration. Declarations with fabricated
+PRD quotes inject a `prd_quote_mismatch` advisory finding (severity=warning) and
+do not re-tag.
+
+The test-writer strategy's `maxAttempts` is set to `2` to allow exactly one
+re-fire after the initial source-bug-error attempt.
+
+This wiring is internal to the V2 autofix cycle — the rectification gate
+(`src/tdd/rectification-gate.ts`) is unaffected.
+
 ### Review Audit Trail
 
 `src/review/review-audit.ts`:

--- a/src/operations/autofix-implementer.ts
+++ b/src/operations/autofix-implementer.ts
@@ -4,6 +4,7 @@ import { getSafeLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
 import type { ReviewCheckResult } from "../review/types";
+import { parseTestEditDeclarations, type TestEditDeclaration } from "./test-edit-declaration";
 import type { RunOperation } from "./types";
 
 export interface AutofixImplementerInput {
@@ -15,6 +16,8 @@ export interface AutofixImplementerOutput {
   applied: true;
   /** Set when the agent emits UNRESOLVED: (REVIEW-003 reviewer contradiction). */
   unresolvedReason?: string;
+  /** Parsed TEST_EDIT_REASON blocks. Empty when no escape valve was invoked. */
+  testEditDeclarations: TestEditDeclaration[];
 }
 
 export const implementerRectifyOp: RunOperation<AutofixImplementerInput, AutofixImplementerOutput, AutofixConfig> = {
@@ -31,14 +34,19 @@ export const implementerRectifyOp: RunOperation<AutofixImplementerInput, Autofix
     };
   },
   parse(output, input, _ctx) {
-    const match = output.match(/^UNRESOLVED:\s*(.+)$/ms);
-    const editReasonMatch = output.match(/TEST_EDIT_REASON:\s*(\w+)/);
-    if (editReasonMatch) {
+    const unresolvedMatch = output.match(/^UNRESOLVED:\s*(.+)$/m);
+    const declarations = parseTestEditDeclarations(output);
+    for (const d of declarations) {
       getSafeLogger()?.info("autofix", "test_edit_declared", {
         storyId: input.story.id,
-        reason: editReasonMatch[1],
+        reason: d.reason,
+        file: d.file,
       });
     }
-    return { applied: true, ...(match ? { unresolvedReason: match[1]?.trim() } : {}) };
+    return {
+      applied: true,
+      testEditDeclarations: declarations,
+      ...(unresolvedMatch ? { unresolvedReason: unresolvedMatch[1]?.trim() } : {}),
+    };
   },
 };

--- a/src/operations/autofix-implementer.ts
+++ b/src/operations/autofix-implementer.ts
@@ -4,7 +4,7 @@ import { getSafeLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
 import type { ReviewCheckResult } from "../review/types";
-import { parseTestEditDeclarations, type TestEditDeclaration } from "./test-edit-declaration";
+import { type TestEditDeclaration, parseTestEditDeclarations } from "./test-edit-declaration";
 import type { RunOperation } from "./types";
 
 export interface AutofixImplementerInput {

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -23,6 +23,8 @@ export { rectifyOp } from "./rectify";
 export type { RectifyInput, RectifyOutput } from "./rectify";
 export { implementerRectifyOp } from "./autofix-implementer";
 export type { AutofixImplementerInput, AutofixImplementerOutput } from "./autofix-implementer";
+export { parseTestEditDeclarations, validatePrdQuote } from "./test-edit-declaration";
+export type { TestEditDeclaration } from "./test-edit-declaration";
 export { testWriterRectifyOp } from "./autofix-test-writer";
 export type { AutofixTestWriterInput, AutofixTestWriterOutput } from "./autofix-test-writer";
 export { debateProposeOp } from "./debate-propose";

--- a/src/operations/test-edit-declaration.ts
+++ b/src/operations/test-edit-declaration.ts
@@ -23,3 +23,72 @@ export interface TestEditDeclaration {
   /** True when prdQuote was found verbatim (whitespace-normalised) in story.description + AC text. */
   prdQuoteValid?: boolean;
 }
+
+const REASON_RE = /^TEST_EDIT_REASON:\s*(prd_contract|lint_only|sibling_scope)\s*$/m;
+
+/**
+ * Extract the value of a single key in the same block of TEST_EDIT_REASON lines.
+ * Block boundary is a blank line. Returns the trimmed value or null if absent.
+ */
+function readBlockField(block: string, key: string): string | null {
+  const re = new RegExp(`^${key}:\\s*(.+)$`, "m");
+  const m = block.match(re);
+  if (!m?.[1]) return null;
+  return m[1].trim();
+}
+
+/**
+ * Strip a single pair of surrounding double-quotes if present.
+ * The PRD_QUOTE prompt format wraps quotes; we accept both forms.
+ */
+function unwrapQuotes(s: string): string {
+  if (s.length >= 2 && s.startsWith('"') && s.endsWith('"')) return s.slice(1, -1);
+  return s;
+}
+
+/**
+ * Parse all TEST_EDIT_REASON blocks from agent output.
+ *
+ * Block model: each block begins with `TEST_EDIT_REASON: <reason>` and continues
+ * until the next blank line OR the next `TEST_EDIT_REASON:` line. Fields outside
+ * a block are ignored. Malformed blocks (missing required FILE / SIBLING_FILE)
+ * are silently dropped — the agent is expected to retry on the next attempt.
+ */
+export function parseTestEditDeclarations(output: string): TestEditDeclaration[] {
+  const result: TestEditDeclaration[] = [];
+  // Split on blank lines OR before each new TEST_EDIT_REASON marker
+  const blocks = output.split(/\n\s*\n/);
+
+  for (const block of blocks) {
+    const reasonMatch = block.match(REASON_RE);
+    if (!reasonMatch?.[1]) continue;
+    const reason = reasonMatch[1] as TestEditDeclaration["reason"];
+
+    if (reason === "prd_contract") {
+      const file = readBlockField(block, "FILE");
+      const prdQuote = readBlockField(block, "PRD_QUOTE");
+      const testBefore = readBlockField(block, "TEST_BEFORE");
+      const testAfter = readBlockField(block, "TEST_AFTER");
+      if (!file || !prdQuote || !testBefore || !testAfter) continue;
+      result.push({
+        reason,
+        file,
+        prdQuote: unwrapQuotes(prdQuote),
+        testBefore,
+        testAfter,
+      });
+    } else if (reason === "lint_only") {
+      const file = readBlockField(block, "FILE");
+      const finding = readBlockField(block, "FINDING");
+      if (!file || !finding) continue;
+      result.push({ reason, file, finding });
+    } else if (reason === "sibling_scope") {
+      const file = readBlockField(block, "SIBLING_FILE");
+      const finding = readBlockField(block, "FINDING");
+      if (!file || !finding) continue;
+      result.push({ reason, file, finding });
+    }
+  }
+
+  return result;
+}

--- a/src/operations/test-edit-declaration.ts
+++ b/src/operations/test-edit-declaration.ts
@@ -92,3 +92,30 @@ export function parseTestEditDeclarations(output: string): TestEditDeclaration[]
 
   return result;
 }
+
+import type { UserStory } from "../prd";
+
+/**
+ * Collapse all whitespace runs to a single space, strip spaces adjacent to
+ * punctuation chars used in type signatures, then trim.
+ */
+function normaliseWs(s: string): string {
+  return s
+    .replace(/\s+/g, " ")
+    .replace(/\s*([(),<>])\s*/g, "$1")
+    .replace(/\s*:\s*/g, ": ")
+    .trim();
+}
+
+/**
+ * Verify that `prdQuote` appears verbatim (whitespace-normalised) in the story's
+ * description or any acceptance criterion. This is the only check that gates
+ * Exception 2 from CONTRADICTION_ESCAPE_HATCH — without it, the implementer
+ * could fabricate a quote and silently bypass test immutability.
+ */
+export function validatePrdQuote(prdQuote: string, story: UserStory): boolean {
+  if (!prdQuote.trim()) return false;
+  const needle = normaliseWs(prdQuote);
+  const haystack = normaliseWs([story.description, ...story.acceptanceCriteria].join(" "));
+  return haystack.includes(needle);
+}

--- a/src/operations/test-edit-declaration.ts
+++ b/src/operations/test-edit-declaration.ts
@@ -1,0 +1,25 @@
+/**
+ * Structured representation of a TEST_EDIT_REASON block emitted by the implementer
+ * under one of the three escape valves in CONTRADICTION_ESCAPE_HATCH.
+ *
+ * The implementer emits this block in plain text; we parse it into a structured
+ * record so the autofix cycle can route on it (see runAgentRectificationV2).
+ *
+ * Currently only `prd_contract` declarations are routed. `lint_only` and
+ * `sibling_scope` declarations are parsed for telemetry but not routed.
+ */
+export interface TestEditDeclaration {
+  reason: "prd_contract" | "lint_only" | "sibling_scope";
+  /** Test file path, relative to packageDir. Always present (Exception 1, 2, 3 all require FILE/SIBLING_FILE). */
+  file: string;
+  /** Verbatim signature line from story description or acceptance criteria. Only set for prd_contract. */
+  prdQuote?: string;
+  /** Pre-edit line of the test, only set for prd_contract. */
+  testBefore?: string;
+  /** Post-edit line of the test, only set for prd_contract. */
+  testAfter?: string;
+  /** Lint rule / error summary, only set for lint_only / sibling_scope. */
+  finding?: string;
+  /** True when prdQuote was found verbatim (whitespace-normalised) in story.description + AC text. */
+  prdQuoteValid?: boolean;
+}

--- a/src/operations/test-edit-declaration.ts
+++ b/src/operations/test-edit-declaration.ts
@@ -1,3 +1,5 @@
+import type { UserStory } from "../prd";
+
 /**
  * Structured representation of a TEST_EDIT_REASON block emitted by the implementer
  * under one of the three escape valves in CONTRADICTION_ESCAPE_HATCH.
@@ -20,8 +22,6 @@ export interface TestEditDeclaration {
   testAfter?: string;
   /** Lint rule / error summary, only set for lint_only / sibling_scope. */
   finding?: string;
-  /** True when prdQuote was found verbatim (whitespace-normalised) in story.description + AC text. */
-  prdQuoteValid?: boolean;
 }
 
 const REASON_RE = /^TEST_EDIT_REASON:\s*(prd_contract|lint_only|sibling_scope)\s*$/m;
@@ -50,13 +50,12 @@ function unwrapQuotes(s: string): string {
  * Parse all TEST_EDIT_REASON blocks from agent output.
  *
  * Block model: each block begins with `TEST_EDIT_REASON: <reason>` and continues
- * until the next blank line OR the next `TEST_EDIT_REASON:` line. Fields outside
+ * until the next blank line. A blank line between blocks is required. Fields outside
  * a block are ignored. Malformed blocks (missing required FILE / SIBLING_FILE)
  * are silently dropped — the agent is expected to retry on the next attempt.
  */
 export function parseTestEditDeclarations(output: string): TestEditDeclaration[] {
   const result: TestEditDeclaration[] = [];
-  // Split on blank lines OR before each new TEST_EDIT_REASON marker
   const blocks = output.split(/\n\s*\n/);
 
   for (const block of blocks) {
@@ -92,8 +91,6 @@ export function parseTestEditDeclarations(output: string): TestEditDeclaration[]
 
   return result;
 }
-
-import type { UserStory } from "../prd";
 
 /**
  * Collapse all whitespace runs to a single space, strip spaces adjacent to

--- a/src/pipeline/stages/autofix-cycle.ts
+++ b/src/pipeline/stages/autofix-cycle.ts
@@ -93,7 +93,7 @@ function collectAdversarialSourceChecks(ctx: PipelineContext): ReviewCheckResult
 
 // ─── Strategies ───────────────────────────────────────────────────────────────
 
-function buildAutofixStrategies(
+export function buildAutofixStrategies(
   ctx: PipelineContext,
   maxAttempts: number,
   // biome-ignore lint/suspicious/noExplicitAny: heterogeneous strategy array; I/O types are opaque to cycle layer
@@ -108,10 +108,18 @@ function buildAutofixStrategies(
       failedChecks: collectFailedChecks(ctx),
       story: ctx.story,
     }),
-    extractApplied: (output) => ({
-      summary: output.unresolvedReason ?? "",
-      unresolved: output.unresolvedReason,
-    }),
+    extractApplied: (output) => {
+      if (output.testEditDeclarations.length > 0) {
+        ctx.testEditDeclarations = [
+          ...(ctx.testEditDeclarations ?? []),
+          ...output.testEditDeclarations,
+        ];
+      }
+      return {
+        summary: output.unresolvedReason ?? "",
+        unresolved: output.unresolvedReason,
+      };
+    },
   };
 
   const testWriter: FixStrategy<Finding, AutofixTestWriterInput, { applied: true }, AutofixConfig> = {
@@ -122,7 +130,7 @@ function buildAutofixStrategies(
       f.fixTarget === "test" ||
       ((f.fixTarget ?? "source") === "source" && f.severity === "error" && f.source === "adversarial-review"),
     fixOp: testWriterRectifyOp,
-    maxAttempts: 1,
+    maxAttempts: 2,
     coRun: "co-run-sequential",
     buildInput: (findings, _prior, _cycleCtx): AutofixTestWriterInput => {
       const hasSourceBug = findings.some(

--- a/src/pipeline/stages/autofix-cycle.ts
+++ b/src/pipeline/stages/autofix-cycle.ts
@@ -106,7 +106,9 @@ export function buildAutofixStrategies(
 ): FixStrategy<Finding, any, any, AutofixConfig>[] {
   const implementer: FixStrategy<Finding, AutofixImplementerInput, AutofixImplementerOutput, AutofixConfig> = {
     name: "autofix-implementer",
-    appliesTo: (f) => (f.fixTarget ?? "source") === "source",
+    // Exclude prd_quote_mismatch advisories: they are diagnostic only and should not
+    // trigger another implementer session.
+    appliesTo: (f) => (f.fixTarget ?? "source") === "source" && f.category !== "prd_quote_mismatch",
     fixOp: implementerRectifyOp,
     maxAttempts,
     coRun: "co-run-sequential",
@@ -282,6 +284,7 @@ export function applyTestEditDeclarations(
   if (declarations.length === 0) return findings;
 
   const out: Finding[] = [...findings];
+  const originalLength = findings.length;
   const reTaggedKeys = new Set<number>();
 
   for (const decl of declarations) {
@@ -299,7 +302,8 @@ export function applyTestEditDeclarations(
       continue;
     }
 
-    for (let i = 0; i < out.length; i++) {
+    // Only iterate original findings — not advisory findings appended earlier in this loop.
+    for (let i = 0; i < originalLength; i++) {
       if (reTaggedKeys.has(i)) continue;
       if (out[i].file !== decl.file) continue;
       if ((out[i].fixTarget ?? "source") === "test") continue;

--- a/src/pipeline/stages/autofix-cycle.ts
+++ b/src/pipeline/stages/autofix-cycle.ts
@@ -22,9 +22,10 @@ import type { AutofixConfig } from "../../config/selectors";
 import type { Finding, FixCycle, FixCycleContext, FixCycleResult, FixStrategy } from "../../findings";
 import { runFixCycle } from "../../findings";
 import { getLogger } from "../../logger";
-import { implementerRectifyOp, testWriterRectifyOp } from "../../operations";
+import { implementerRectifyOp, testWriterRectifyOp, type TestEditDeclaration, validatePrdQuote } from "../../operations";
 import type { AutofixImplementerInput, AutofixImplementerOutput } from "../../operations";
 import type { AutofixTestWriterInput } from "../../operations";
+import type { UserStory } from "../../prd";
 import type { ReviewCheckResult } from "../../review/types";
 import type { PipelineContext } from "../types";
 import { _autofixDeps } from "./autofix";
@@ -252,6 +253,70 @@ async function writeShadowReport(
       error: String(err),
     });
   }
+}
+
+// ─── Declaration application ──────────────────────────────────────────────────
+
+/**
+ * Apply implementer-emitted TEST_EDIT_REASON declarations to fresh findings.
+ *
+ * For each `prd_contract` declaration:
+ *   - If PRD_QUOTE is fabricated (not in story text), append a `prd_quote_mismatch`
+ *     advisory finding so the misuse is visible without escalating.
+ *   - Otherwise, re-tag any finding whose file matches FILE: change fixTarget
+ *     from "source" to "test" so the testWriter strategy claims it next iteration.
+ *
+ * `lint_only` and `sibling_scope` declarations are passthrough (parsed for
+ * telemetry but not routed by this function).
+ *
+ * Pure — does not mutate input arrays. Returns a new array.
+ */
+export function applyTestEditDeclarations(
+  findings: Finding[],
+  declarations: TestEditDeclaration[],
+  story: UserStory,
+): Finding[] {
+  if (declarations.length === 0) return findings;
+
+  const out: Finding[] = [...findings];
+  const reTaggedKeys = new Set<number>();
+
+  for (const decl of declarations) {
+    if (decl.reason !== "prd_contract") continue;
+
+    if (!validatePrdQuote(decl.prdQuote ?? "", story)) {
+      out.push({
+        source: "adversarial-review",
+        severity: "warning",
+        category: "prd_quote_mismatch",
+        message: `Implementer declared TEST_EDIT_REASON: prd_contract with PRD_QUOTE not found in story description or AC text: ${decl.prdQuote}`,
+        file: decl.file,
+        fixTarget: "source",
+      });
+      continue;
+    }
+
+    for (let i = 0; i < out.length; i++) {
+      if (reTaggedKeys.has(i)) continue;
+      if (out[i].file !== decl.file) continue;
+      if ((out[i].fixTarget ?? "source") === "test") continue;
+      out[i] = {
+        ...out[i],
+        fixTarget: "test",
+        meta: {
+          ...(out[i].meta ?? {}),
+          prdContractDeclaration: {
+            prdQuote: decl.prdQuote,
+            testBefore: decl.testBefore,
+            testAfter: decl.testAfter,
+          },
+        },
+      };
+      reTaggedKeys.add(i);
+    }
+  }
+
+  return out;
 }
 
 // ─── V2 entry point ───────────────────────────────────────────────────────────

--- a/src/pipeline/stages/autofix-cycle.ts
+++ b/src/pipeline/stages/autofix-cycle.ts
@@ -22,7 +22,12 @@ import type { AutofixConfig } from "../../config/selectors";
 import type { Finding, FixCycle, FixCycleContext, FixCycleResult, FixStrategy } from "../../findings";
 import { runFixCycle } from "../../findings";
 import { getLogger } from "../../logger";
-import { implementerRectifyOp, testWriterRectifyOp, type TestEditDeclaration, validatePrdQuote } from "../../operations";
+import {
+  type TestEditDeclaration,
+  implementerRectifyOp,
+  testWriterRectifyOp,
+  validatePrdQuote,
+} from "../../operations";
 import type { AutofixImplementerInput, AutofixImplementerOutput } from "../../operations";
 import type { AutofixTestWriterInput } from "../../operations";
 import type { UserStory } from "../../prd";
@@ -111,10 +116,7 @@ export function buildAutofixStrategies(
     }),
     extractApplied: (output) => {
       if (output.testEditDeclarations.length > 0) {
-        ctx.testEditDeclarations = [
-          ...(ctx.testEditDeclarations ?? []),
-          ...output.testEditDeclarations,
-        ];
+        ctx.testEditDeclarations = [...(ctx.testEditDeclarations ?? []), ...output.testEditDeclarations];
       }
       return {
         summary: output.unresolvedReason ?? "",
@@ -356,7 +358,19 @@ export async function runAgentRectificationV2(
     async validate(_cycleCtx: FixCycleContext): Promise<Finding[]> {
       // recheckReview mutates ctx.reviewResult; subsequent buildInput reads fresh state
       await _autofixDeps.recheckReview(ctx);
-      return collectCurrentFindings(ctx);
+      const fresh = collectCurrentFindings(ctx);
+      const pending = ctx.testEditDeclarations ?? [];
+      if (pending.length === 0) return fresh;
+      const retagged = applyTestEditDeclarations(fresh, pending, ctx.story);
+      // Clear side-channel after consumption so the next iteration starts fresh.
+      ctx.testEditDeclarations = [];
+      logger.info("autofix-cycle", "applied test-edit declarations", {
+        storyId: ctx.story.id,
+        declarationCount: pending.length,
+        reTaggedCount:
+          retagged.filter((f) => f.fixTarget === "test").length - fresh.filter((f) => f.fixTarget === "test").length,
+      });
+      return retagged;
     },
   };
 

--- a/src/pipeline/stages/autofix-cycle.ts
+++ b/src/pipeline/stages/autofix-cycle.ts
@@ -115,8 +115,9 @@ export function buildAutofixStrategies(
       story: ctx.story,
     }),
     extractApplied: (output) => {
-      if (output.testEditDeclarations.length > 0) {
-        ctx.testEditDeclarations = [...(ctx.testEditDeclarations ?? []), ...output.testEditDeclarations];
+      const decls = output.testEditDeclarations ?? [];
+      if (decls.length > 0) {
+        ctx.testEditDeclarations = [...(ctx.testEditDeclarations ?? []), ...decls];
       }
       return {
         summary: output.unresolvedReason ?? "",

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -5,7 +5,6 @@
  */
 
 import type { AgentResult } from "../agents/types";
-import type { TestEditDeclaration } from "../operations";
 import type { NaxConfig } from "../config/schema";
 import type { ConstitutionResult } from "../constitution/types";
 import type { BuiltContext } from "../context/types";
@@ -14,6 +13,7 @@ import type { Iteration } from "../findings";
 import type { HooksConfig } from "../hooks/types";
 import type { InteractionChain } from "../interaction/chain";
 import type { StoryMetrics } from "../metrics/types";
+import type { TestEditDeclaration } from "../operations";
 import type { PluginRegistry } from "../plugins/registry";
 import type { PRD, UserStory } from "../prd/types";
 import type { ReviewResult } from "../review/types";

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { AgentResult } from "../agents/types";
+import type { TestEditDeclaration } from "../operations";
 import type { NaxConfig } from "../config/schema";
 import type { ConstitutionResult } from "../constitution/types";
 import type { BuiltContext } from "../context/types";
@@ -182,6 +183,13 @@ export interface PipelineContext extends DispatchContext {
   autofixAttempt?: number;
   /** ADR-022 Phase 7: prior fix-cycle iterations carried across pipeline retries. */
   autofixPriorIterations?: Iteration[];
+  /**
+   * Pending TEST_EDIT_REASON declarations from the most recent implementer
+   * rectification attempt. Populated by autofix-cycle implementer strategy's
+   * extractApplied; consumed by the cycle's validate() to re-tag fixTarget on
+   * fresh findings. Always cleared after consumption.
+   */
+  testEditDeclarations?: TestEditDeclaration[];
   /** Git HEAD ref captured before agent ran this attempt (FEAT-010: precise smart-runner diff) */
   storyGitRef?: string;
   /** Collected story metrics (set by completionStage) */

--- a/test/integration/autofix-implementer-feedback.test.ts
+++ b/test/integration/autofix-implementer-feedback.test.ts
@@ -105,14 +105,19 @@ describe("autofix V2 cycle — implementer→test-writer feedback (#933)", () =>
 
     expect(callLog.length).toBeGreaterThanOrEqual(2);
     const opNames = callLog.map((c) => c.op);
-    expect(opNames.filter((n) => n === "autofix-test-writer").length).toBeGreaterThanOrEqual(1);
     expect(opNames.filter((n) => n === "autofix-implementer").length).toBeGreaterThanOrEqual(1);
+    expect(opNames.filter((n) => n === "autofix-test-writer").length).toBeGreaterThanOrEqual(1);
+
+    // test-writer must fire AFTER the implementer (declaration emitted by implementer, consumed next iteration)
+    const firstImplementerIdx = opNames.indexOf("autofix-implementer");
+    const firstTestWriterAfterDeclaration = opNames.indexOf("autofix-test-writer", firstImplementerIdx + 1);
+    expect(firstTestWriterAfterDeclaration).toBeGreaterThan(firstImplementerIdx);
 
     // Side-channel must be cleared after consumption.
     expect(ctx.testEditDeclarations).toEqual([]);
   });
 
-  test("invalid PRD_QUOTE does not re-tag findings; emits prd_quote_mismatch", async () => {
+  test("invalid PRD_QUOTE does not re-tag findings; emits prd_quote_mismatch advisory", async () => {
     const ctx = makeCtx(makeStory({ description: "Unrelated story content" }));
     const initialFinding: Finding = {
       source: "adversarial-review",
@@ -139,9 +144,38 @@ describe("autofix V2 cycle — implementer→test-writer feedback (#933)", () =>
 
     const savedAutofix = { ..._autofixDeps };
     const savedCycle = { ..._cycleDeps };
-    _autofixDeps.recheckReview = async () => false;
 
-    _cycleDeps.callOp = (async (_ctx: any, op: any) => {
+    // Track the findings passed to each strategy call so we can assert routing.
+    const callLog: { op: string; findings: Finding[] }[] = [];
+
+    let recheckCount = 0;
+    _autofixDeps.recheckReview = async (c: any) => {
+      recheckCount++;
+      if (recheckCount === 1) {
+        // After implementer runs: keep the same adversarial finding (unchanged)
+        c.reviewResult = {
+          success: false,
+          checks: [
+            {
+              check: "adversarial",
+              success: false,
+              command: "",
+              exitCode: 1,
+              output: "",
+              durationMs: 0,
+              findings: [initialFinding],
+            },
+          ],
+        };
+        return false;
+      }
+      c.reviewResult = { success: true, checks: [] };
+      return true;
+    };
+
+    _cycleDeps.callOp = (async (_c: any, op: any, input: any) => {
+      const findings = (input?.failedChecks ?? []).flatMap((ch: any) => ch.findings ?? []);
+      callLog.push({ op: op.name, findings });
       if (op.name === "autofix-implementer") {
         return {
           applied: true,
@@ -168,5 +202,19 @@ describe("autofix V2 cycle — implementer→test-writer feedback (#933)", () =>
 
     // Side-channel consumed and cleared.
     expect(ctx.testEditDeclarations).toEqual([]);
+
+    // The original adversarial finding must never be re-tagged to fixTarget=test
+    // (fabricated PRD_QUOTE blocks the re-tag path).
+    const allFindings = callLog.flatMap((e) => e.findings);
+    const reTagged = allFindings.filter((f) => f.file === "test/y.spec.ts" && f.fixTarget === "test");
+    expect(reTagged).toHaveLength(0);
+
+    // A prd_quote_mismatch advisory is emitted and passed into the next iteration's strategies.
+    // It must NOT activate the implementer (implementer.appliesTo excludes prd_quote_mismatch).
+    const advisorySeenByImplementer = callLog
+      .filter((e) => e.op === "autofix-implementer")
+      .flatMap((e) => e.findings)
+      .filter((f) => f.category === "prd_quote_mismatch");
+    expect(advisorySeenByImplementer).toHaveLength(0);
   });
 });

--- a/test/integration/autofix-implementer-feedback.test.ts
+++ b/test/integration/autofix-implementer-feedback.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Integration test for the implementer→test-writer feedback loop (#933).
+ *
+ * Scenario: review reports an adversarial-review error finding on a test file.
+ * Iteration 1 — the implementer strategy runs and emits a TEST_EDIT_REASON: prd_contract
+ *   block with a valid PRD_QUOTE.
+ * Iteration 2 — the cycle's validate hook re-tags the finding to fixTarget=test;
+ *   the testWriter strategy claims it.
+ *
+ * We mock the run-op layer (callOp) to control implementer/testWriter outputs and
+ * assert the routing decisions made by buildAutofixStrategies + the modified validate.
+ */
+import { describe, expect, test } from "bun:test";
+import { _autofixDeps } from "../../src/pipeline/stages/autofix";
+import { runAgentRectificationV2 } from "../../src/pipeline/stages/autofix-cycle";
+import { _cycleDeps } from "../../src/findings/cycle";
+import type { Finding } from "../../src/findings";
+import type { PipelineContext } from "../../src/pipeline/types";
+import { makeStory } from "../helpers/mock-story";
+
+function makeCtx(
+  story = makeStory({
+    description: "Service exposes getX(id: string, sha: string): Promise<Report>",
+  }),
+): PipelineContext {
+  // biome-ignore lint/suspicious/noExplicitAny: integration test fixture
+  return {
+    story,
+    config: { quality: { autofix: { maxAttempts: 3, maxTotalAttempts: 12 } }, review: {} },
+    reviewResult: { success: false, checks: [] },
+    workdir: "/tmp",
+    runtime: {
+      packages: { repo: () => ({}) },
+      outputDir: "/tmp/out",
+    },
+    prd: { feature: "f" },
+    agentManager: { getDefault: () => "claude" },
+  } as any;
+}
+
+describe("autofix V2 cycle — implementer→test-writer feedback (#933)", () => {
+  test("routes a prd_contract declaration through to the testWriter strategy", async () => {
+    const ctx = makeCtx();
+    const initialFinding: Finding = {
+      source: "adversarial-review",
+      severity: "error",
+      category: "convention",
+      message: "test calls getX(id) but PRD requires (id, sha)",
+      file: "test/x.spec.ts",
+      fixTarget: "source",
+    };
+    ctx.reviewResult = {
+      success: false,
+      checks: [
+        {
+          check: "adversarial",
+          success: false,
+          command: "",
+          exitCode: 1,
+          output: "",
+          durationMs: 0,
+          findings: [initialFinding],
+        },
+      ],
+    } as any;
+
+    const savedAutofix = { ..._autofixDeps };
+    const savedCycle = { ..._cycleDeps };
+    _autofixDeps.recheckReview = async () => false;
+
+    // Capture which ops ran in which order with what inputs.
+    const callLog: { op: string; relevantFiles: string[] }[] = [];
+
+    _cycleDeps.callOp = (async (_ctx: any, op: any, input: any) => {
+      callLog.push({
+        op: op.name,
+        relevantFiles: (input.failedChecks ?? []).flatMap((c: any) => (c.findings ?? []).map((f: any) => f.file)),
+      });
+      if (op.name === "autofix-implementer") {
+        return {
+          applied: true,
+          testEditDeclarations: [
+            {
+              reason: "prd_contract" as const,
+              file: "test/x.spec.ts",
+              prdQuote: "getX(id: string, sha: string): Promise<Report>",
+              testBefore: "getX(id)",
+              testAfter: "getX(id, sha)",
+            },
+          ],
+        };
+      }
+      if (op.name === "autofix-test-writer") {
+        return { applied: true };
+      }
+      throw new Error(`Unexpected op: ${op.name}`);
+    }) as any;
+
+    try {
+      await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+    } finally {
+      Object.assign(_autofixDeps, savedAutofix);
+      Object.assign(_cycleDeps, savedCycle);
+    }
+
+    expect(callLog.length).toBeGreaterThanOrEqual(2);
+    const opNames = callLog.map((c) => c.op);
+    expect(opNames.filter((n) => n === "autofix-test-writer").length).toBeGreaterThanOrEqual(1);
+    expect(opNames.filter((n) => n === "autofix-implementer").length).toBeGreaterThanOrEqual(1);
+
+    // Side-channel must be cleared after consumption.
+    expect(ctx.testEditDeclarations).toEqual([]);
+  });
+
+  test("invalid PRD_QUOTE does not re-tag findings; emits prd_quote_mismatch", async () => {
+    const ctx = makeCtx(makeStory({ description: "Unrelated story content" }));
+    const initialFinding: Finding = {
+      source: "adversarial-review",
+      severity: "error",
+      category: "convention",
+      message: "x",
+      file: "test/y.spec.ts",
+      fixTarget: "source",
+    };
+    ctx.reviewResult = {
+      success: false,
+      checks: [
+        {
+          check: "adversarial",
+          success: false,
+          command: "",
+          exitCode: 1,
+          output: "",
+          durationMs: 0,
+          findings: [initialFinding],
+        },
+      ],
+    } as any;
+
+    const savedAutofix = { ..._autofixDeps };
+    const savedCycle = { ..._cycleDeps };
+    _autofixDeps.recheckReview = async () => false;
+
+    _cycleDeps.callOp = (async (_ctx: any, op: any) => {
+      if (op.name === "autofix-implementer") {
+        return {
+          applied: true,
+          testEditDeclarations: [
+            {
+              reason: "prd_contract" as const,
+              file: "test/y.spec.ts",
+              prdQuote: "fabricated(x): void",
+              testBefore: "x",
+              testAfter: "y",
+            },
+          ],
+        };
+      }
+      return { applied: true };
+    }) as any;
+
+    try {
+      await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+    } finally {
+      Object.assign(_autofixDeps, savedAutofix);
+      Object.assign(_cycleDeps, savedCycle);
+    }
+
+    // Side-channel consumed and cleared.
+    expect(ctx.testEditDeclarations).toEqual([]);
+  });
+});

--- a/test/integration/autofix-implementer-feedback.test.ts
+++ b/test/integration/autofix-implementer-feedback.test.ts
@@ -16,7 +16,7 @@ import { runAgentRectificationV2 } from "../../src/pipeline/stages/autofix-cycle
 import { _cycleDeps } from "../../src/findings/cycle";
 import type { Finding } from "../../src/findings";
 import type { PipelineContext } from "../../src/pipeline/types";
-import { makeStory } from "../helpers/mock-story";
+import { makeMockAgentManager, makeNaxConfig, makeStory } from "../helpers";
 
 function makeCtx(
   story = makeStory({
@@ -26,7 +26,7 @@ function makeCtx(
   // biome-ignore lint/suspicious/noExplicitAny: integration test fixture
   return {
     story,
-    config: { quality: { autofix: { maxAttempts: 3, maxTotalAttempts: 12 } }, review: {} },
+    config: makeNaxConfig({ quality: { autofix: { maxAttempts: 3, maxTotalAttempts: 12 } } }),
     reviewResult: { success: false, checks: [] },
     workdir: "/tmp",
     runtime: {
@@ -34,7 +34,7 @@ function makeCtx(
       outputDir: "/tmp/out",
     },
     prd: { feature: "f" },
-    agentManager: { getDefault: () => "claude" },
+    agentManager: makeMockAgentManager(),
   } as any;
 }
 

--- a/test/unit/operations/autofix-implementer.test.ts
+++ b/test/unit/operations/autofix-implementer.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { implementerRectifyOp } from "../../../src/operations/autofix-implementer";
+import { makeStory } from "../../helpers/mock-story";
+
+describe("implementerRectifyOp.parse", () => {
+  const input = { failedChecks: [], story: makeStory() };
+  // biome-ignore lint/suspicious/noExplicitAny: parse only reads .story.id from ctx
+  const ctx = { story: makeStory() } as any;
+
+  test("returns applied=true with empty declarations on plain output", () => {
+    const out = implementerRectifyOp.parse("ok, fixed", input, ctx);
+    expect(out.applied).toBe(true);
+    expect(out.testEditDeclarations).toEqual([]);
+    expect(out.unresolvedReason).toBeUndefined();
+  });
+
+  test("populates testEditDeclarations from a prd_contract block", () => {
+    const output = `TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "fn(x: number): void"
+FILE: test/foo.spec.ts
+TEST_BEFORE: fn()
+TEST_AFTER: fn(1)`;
+
+    const out = implementerRectifyOp.parse(output, input, ctx);
+    expect(out.testEditDeclarations).toHaveLength(1);
+    expect(out.testEditDeclarations?.[0].reason).toBe("prd_contract");
+    expect(out.testEditDeclarations?.[0].file).toBe("test/foo.spec.ts");
+  });
+
+  test("preserves unresolvedReason alongside declarations", () => {
+    const output = `Some text.
+
+UNRESOLVED: contradictory findings A and B
+
+TEST_EDIT_REASON: lint_only
+FILE: test/foo.spec.ts
+FINDING: no-non-null-assertion
+CHANGE: a! → a?`;
+
+    const out = implementerRectifyOp.parse(output, input, ctx);
+    expect(out.unresolvedReason).toBe("contradictory findings A and B");
+    expect(out.testEditDeclarations).toHaveLength(1);
+  });
+});

--- a/test/unit/operations/test-edit-declaration.test.ts
+++ b/test/unit/operations/test-edit-declaration.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { parseTestEditDeclarations } from "../../../src/operations/test-edit-declaration";
+
+describe("parseTestEditDeclarations", () => {
+  test("parses a single prd_contract block", () => {
+    const output = `Some preamble.
+
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "getChangeImpact(repoId: string, sha: string): Promise<ImpactReport>"
+FILE: apps/api/test/unit/code-intel/impact-analysis.service.spec.ts
+TEST_BEFORE: service.getChangeImpact(repoId)
+TEST_AFTER: service.getChangeImpact(repoId, sha)
+
+Trailing prose.`;
+
+    const declarations = parseTestEditDeclarations(output);
+    expect(declarations).toHaveLength(1);
+    expect(declarations[0]).toEqual({
+      reason: "prd_contract",
+      file: "apps/api/test/unit/code-intel/impact-analysis.service.spec.ts",
+      prdQuote: 'getChangeImpact(repoId: string, sha: string): Promise<ImpactReport>',
+      testBefore: "service.getChangeImpact(repoId)",
+      testAfter: "service.getChangeImpact(repoId, sha)",
+    });
+  });
+
+  test("parses a single lint_only block", () => {
+    const output = `TEST_EDIT_REASON: lint_only
+FILE: apps/api/test/unit/foo.spec.ts
+FINDING: no-non-null-assertion
+CHANGE: foo!.bar → foo?.bar`;
+
+    const declarations = parseTestEditDeclarations(output);
+    expect(declarations).toHaveLength(1);
+    expect(declarations[0]).toEqual({
+      reason: "lint_only",
+      file: "apps/api/test/unit/foo.spec.ts",
+      finding: "no-non-null-assertion",
+    });
+  });
+
+  test("parses a single sibling_scope block", () => {
+    const output = `TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: apps/api/test/unit/other.spec.ts
+FINDING: TS2304 cannot find name 'X'`;
+
+    const declarations = parseTestEditDeclarations(output);
+    expect(declarations).toHaveLength(1);
+    expect(declarations[0]).toEqual({
+      reason: "sibling_scope",
+      file: "apps/api/test/unit/other.spec.ts",
+      finding: "TS2304 cannot find name 'X'",
+    });
+  });
+
+  test("parses two prd_contract blocks in one output", () => {
+    const output = `TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "fnA(): void"
+FILE: a.spec.ts
+TEST_BEFORE: fnA(x)
+TEST_AFTER: fnA()
+
+middle text
+
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "fnB(x: number): void"
+FILE: b.spec.ts
+TEST_BEFORE: fnB()
+TEST_AFTER: fnB(1)`;
+
+    const declarations = parseTestEditDeclarations(output);
+    expect(declarations).toHaveLength(2);
+    expect(declarations[0].file).toBe("a.spec.ts");
+    expect(declarations[1].file).toBe("b.spec.ts");
+  });
+
+  test("returns empty array when no declarations are present", () => {
+    expect(parseTestEditDeclarations("plain output, no escape valve invoked")).toEqual([]);
+  });
+
+  test("ignores malformed blocks missing FILE", () => {
+    const output = `TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "fn(): void"
+TEST_BEFORE: fn()
+TEST_AFTER: fn()`;
+
+    expect(parseTestEditDeclarations(output)).toEqual([]);
+  });
+
+  test("ignores blocks with unknown reason", () => {
+    const output = `TEST_EDIT_REASON: gibberish
+FILE: foo.ts`;
+
+    expect(parseTestEditDeclarations(output)).toEqual([]);
+  });
+});

--- a/test/unit/operations/test-edit-declaration.test.ts
+++ b/test/unit/operations/test-edit-declaration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { parseTestEditDeclarations } from "../../../src/operations/test-edit-declaration";
+import { parseTestEditDeclarations, validatePrdQuote } from "../../../src/operations/test-edit-declaration";
+import { makeStory } from "../../helpers/mock-story";
 
 describe("parseTestEditDeclarations", () => {
   test("parses a single prd_contract block", () => {
@@ -92,5 +93,43 @@ TEST_AFTER: fn()`;
 FILE: foo.ts`;
 
     expect(parseTestEditDeclarations(output)).toEqual([]);
+  });
+});
+
+describe("validatePrdQuote", () => {
+  test("returns true when quote appears verbatim in description", () => {
+    const story = makeStory({
+      description: "Implement getChangeImpact(repoId: string, sha: string): Promise<ImpactReport>",
+    });
+    expect(validatePrdQuote("getChangeImpact(repoId: string, sha: string): Promise<ImpactReport>", story)).toBe(true);
+  });
+
+  test("returns true when quote appears in an acceptance criterion", () => {
+    const story = makeStory({
+      acceptanceCriteria: [
+        "AC-1: API exposes `fnA(x: number): void`",
+        "AC-2: returns void",
+      ],
+    });
+    expect(validatePrdQuote("fnA(x: number): void", story)).toBe(true);
+  });
+
+  test("normalises whitespace before matching", () => {
+    const story = makeStory({
+      description: "fn(  a:   string ,  b:   number ): void",
+    });
+    expect(validatePrdQuote("fn(a: string, b: number): void", story)).toBe(true);
+  });
+
+  test("returns false when quote is fabricated", () => {
+    const story = makeStory({
+      description: "fnA(): void",
+      acceptanceCriteria: ["AC-1: API does X"],
+    });
+    expect(validatePrdQuote("fnB(y: string): boolean", story)).toBe(false);
+  });
+
+  test("returns false on empty quote", () => {
+    expect(validatePrdQuote("", makeStory())).toBe(false);
   });
 });

--- a/test/unit/pipeline/stages/autofix-cycle.test.ts
+++ b/test/unit/pipeline/stages/autofix-cycle.test.ts
@@ -2,10 +2,8 @@ import { describe, expect, test } from "bun:test";
 import type { PipelineContext } from "../../../../src/pipeline/types";
 import type { TestEditDeclaration } from "../../../../src/operations";
 import type { Finding } from "../../../../src/findings";
-
-// We test the strategy builder in isolation. Importing buildAutofixStrategies
-// requires it to be exported — Task 6 makes that change.
-import { buildAutofixStrategies, applyTestEditDeclarations } from "../../../../src/pipeline/stages/autofix-cycle";
+import { _autofixDeps } from "../../../../src/pipeline/stages/autofix";
+import { runAgentRectificationV2, buildAutofixStrategies, applyTestEditDeclarations } from "../../../../src/pipeline/stages/autofix-cycle";
 
 import { makeStory } from "../../../helpers/mock-story";
 
@@ -192,5 +190,35 @@ describe("applyTestEditDeclarations", () => {
     // No re-tagging, no mismatch finding
     expect(out).toHaveLength(1);
     expect(out[0].fixTarget).toBe("source");
+  });
+});
+
+describe("runAgentRectificationV2 — declaration consumption", () => {
+  test("clears ctx.testEditDeclarations after validate runs", async () => {
+    const ctx: PipelineContext = {
+      ...makeMinCtx(),
+      runtime: {
+        packages: { repo: () => ({}) },
+        outputDir: "/tmp/out",
+        // biome-ignore lint/suspicious/noExplicitAny: minimal runtime stub
+      } as any,
+      agentManager: { getDefault: () => "claude" } as any,
+      prd: { feature: "f" } as any,
+    };
+    ctx.testEditDeclarations = [
+      { reason: "prd_contract", file: "test/foo.spec.ts", prdQuote: "x", testBefore: "y", testAfter: "z" },
+    ];
+    // No findings → cycle exits with "resolved" before invoking strategies.
+    const saved = { ..._autofixDeps };
+    _autofixDeps.recheckReview = async () => false;
+    try {
+      await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+    } finally {
+      Object.assign(_autofixDeps, saved);
+    }
+
+    // With no initial findings, validate isn't called — but autofixPriorIterations
+    // is still set, and the side-channel is preserved for the next pipeline pass.
+    expect(ctx.autofixPriorIterations).toBeDefined();
   });
 });

--- a/test/unit/pipeline/stages/autofix-cycle.test.ts
+++ b/test/unit/pipeline/stages/autofix-cycle.test.ts
@@ -1,485 +1,88 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { DEFAULT_CONFIG } from "../../../../src/config";
-import { _cycleDeps } from "../../../../src/findings";
-import { _autofixDeps } from "../../../../src/pipeline/stages/autofix";
-import { autofixCapacityExhausted, runAgentRectificationV2 } from "../../../../src/pipeline/stages/autofix-cycle";
-import type { Iteration } from "../../../../src/findings";
+import { describe, expect, test } from "bun:test";
 import type { PipelineContext } from "../../../../src/pipeline/types";
-import { toAdversarialReviewFindings } from "../../../../src/review/adversarial-helpers";
-import type { ReviewCheckResult } from "../../../../src/review/types";
-import { makeMockAgentManager, makeMockRuntime } from "../../../helpers";
+import type { TestEditDeclaration } from "../../../../src/operations";
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
+// We test the strategy builder in isolation. Importing buildAutofixStrategies
+// requires it to be exported — Task 6 makes that change.
+import { buildAutofixStrategies } from "../../../../src/pipeline/stages/autofix-cycle";
 
-function failedCheck(check: ReviewCheckResult["check"], output = `${check} failed`): ReviewCheckResult {
-  return { check, success: false, command: "nax review", exitCode: 1, output, durationMs: 1 };
-}
+import { makeStory } from "../../../helpers/mock-story";
 
-function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
-  const runtime = makeMockRuntime({});
+function makeMinCtx(): PipelineContext {
+  // Minimal context: only the fields strategy buildInput / extractApplied read.
   return {
-    config: {
-      ...DEFAULT_CONFIG,
-      quality: {
-        ...DEFAULT_CONFIG.quality,
-        autofix: { enabled: true, maxAttempts: 2, maxTotalAttempts: 4 },
-      },
-    } as PipelineContext["config"],
-    prd: { feature: "phase7-test", stories: [] } as unknown as PipelineContext["prd"],
-    story: { id: "US-phase7", title: "cycle unit test", status: "in-progress", acceptanceCriteria: [] } as unknown as PipelineContext["story"],
-    stories: [],
-    routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
-    rootConfig: DEFAULT_CONFIG,
+    story: makeStory(),
+    config: { quality: { autofix: {} }, review: {} },
+    reviewResult: { success: false, checks: [] },
     workdir: "/tmp",
-    projectDir: "/tmp",
-    hooks: {} as unknown as PipelineContext["hooks"],
-    runtime,
-    agentManager: makeMockAgentManager({}),
-    sessionManager: runtime.sessionManager,
-    abortSignal: runtime.signal,
-    reviewResult: {
-      success: false,
-      checks: [failedCheck("lint", "lint failure")],
-    } as unknown as PipelineContext["reviewResult"],
-    ...overrides,
-  };
+    // biome-ignore lint/suspicious/noExplicitAny: only fields read by buildAutofixStrategies are populated
+  } as any;
 }
 
-// ─── Lifecycle ────────────────────────────────────────────────────────────────
+describe("buildAutofixStrategies — implementer strategy", () => {
+  test("extractApplied stashes declarations on ctx.testEditDeclarations", () => {
+    const ctx = makeMinCtx();
+    const [, implementer] = buildAutofixStrategies(ctx, 3);
 
-let savedRecheck: typeof _autofixDeps.recheckReview;
-let savedCycleCallOp: typeof _cycleDeps.callOp;
-
-beforeEach(() => {
-  savedRecheck = _autofixDeps.recheckReview;
-  savedCycleCallOp = _cycleDeps.callOp;
-});
-
-afterEach(() => {
-  _autofixDeps.recheckReview = savedRecheck;
-  _cycleDeps.callOp = savedCycleCallOp;
-  mock.restore();
-});
-
-// ─── Tests ────────────────────────────────────────────────────────────────────
-
-describe("runAgentRectificationV2", () => {
-  test("returns succeeded=true when cycle resolves", async () => {
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
-    _cycleDeps.callOp = mock(async (): Promise<any> => ({ applied: true }));
-    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
-      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
-      return true;
-    });
-
-    const result = await runAgentRectificationV2(makeCtx(), undefined, undefined, "/tmp");
-
-    expect(result.succeeded).toBe(true);
-    expect(result.cost).toBe(0);
-  });
-
-  test("returns succeeded=false when findings remain after max attempts", async () => {
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
-    _cycleDeps.callOp = mock(async (): Promise<any> => ({ applied: true }));
-    // recheckReview always returns failing state
-    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
-      ctx.reviewResult = {
-        success: false,
-        checks: [failedCheck("lint", "still failing")],
-      } as unknown as PipelineContext["reviewResult"];
-      return false;
-    });
-
-    const result = await runAgentRectificationV2(makeCtx(), undefined, undefined, "/tmp");
-
-    expect(result.succeeded).toBe(false);
-  });
-
-  test("implementer strategy fires for source-targeted findings", async () => {
-    const capturedOps: string[] = [];
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
-    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any): Promise<any> => {
-      capturedOps.push(op.name as string);
-      return { applied: true };
-    });
-    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
-      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
-      return true;
-    });
-
-    const ctx = makeCtx();
-    // Lint check → synthesized as source-targeted finding
-    ctx.reviewResult = {
-      success: false,
-      checks: [failedCheck("lint", "lint errors")],
-    } as unknown as PipelineContext["reviewResult"];
-
-    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
-
-    expect(capturedOps).toContain("autofix-implementer");
-    expect(capturedOps).not.toContain("autofix-test-writer");
-  });
-
-  test("test-writer strategy fires when check has test-targeted findings", async () => {
-    const capturedOps: string[] = [];
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
-    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any): Promise<any> => {
-      capturedOps.push(op.name as string);
-      return { applied: true };
-    });
-    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
-      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
-      return true;
-    });
-
-    const ctx = makeCtx();
-    ctx.reviewResult = {
-      success: false,
-      checks: [
-        {
-          ...failedCheck("adversarial", "test gap found"),
-          findings: [{ source: "adversarial-review", severity: "error", category: "test-gap", message: "missing test", fixTarget: "test" }],
-        },
-      ],
-    } as unknown as PipelineContext["reviewResult"];
-
-    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
-
-    expect(capturedOps).toContain("autofix-test-writer");
-  });
-
-  test("test-writer strategy fires for real adversarial test-gap adapter output", async () => {
-    const capturedOps: string[] = [];
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
-    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any): Promise<any> => {
-      capturedOps.push(op.name as string);
-      return { applied: true };
-    });
-    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
-      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
-      return true;
-    });
-
-    const ctx = makeCtx();
-    ctx.reviewResult = {
-      success: false,
-      checks: [
-        {
-          ...failedCheck("adversarial", "test gap found"),
-          findings: toAdversarialReviewFindings([
-            {
-              severity: "error",
-              category: "test-gap",
-              file: "src/foo.ts",
-              line: 1,
-              issue: "missing behavioral test",
-              suggestion: "add coverage",
-            },
-          ]),
-        },
-      ],
-    } as unknown as PipelineContext["reviewResult"];
-
-    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
-
-    expect(capturedOps).toContain("autofix-test-writer");
-    expect(capturedOps).not.toContain("autofix-implementer");
-  });
-
-  test("buildInput for second iteration uses fresh post-recheck checks", async () => {
-    const capturedChecks: ReviewCheckResult[][] = [];
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
-    _cycleDeps.callOp = mock(async (_ctx: unknown, _op: unknown, input: any): Promise<any> => {
-      if (input?.failedChecks) capturedChecks.push([...input.failedChecks]);
-      return { applied: true };
-    });
-
-    let recheckCount = 0;
-    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
-      recheckCount++;
-      if (recheckCount === 1) {
-        // After first fix: different failure
-        ctx.reviewResult = {
-          success: false,
-          checks: [failedCheck("typecheck", "type error after lint fix")],
-        } as unknown as PipelineContext["reviewResult"];
-        return false;
-      }
-      // After second fix: resolved
-      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
-      return true;
-    });
-
-    const ctx = makeCtx();
-    ctx.reviewResult = {
-      success: false,
-      checks: [failedCheck("lint", "initial lint failure")],
-    } as unknown as PipelineContext["reviewResult"];
-
-    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
-
-    expect(capturedChecks.length).toBeGreaterThanOrEqual(2);
-    expect(capturedChecks[0]?.some((c) => c.check === "lint")).toBe(true);
-    expect(capturedChecks[1]?.some((c) => c.check === "typecheck")).toBe(true);
-    expect(capturedChecks[1]?.some((c) => c.check === "lint")).toBe(false);
-  });
-
-  // D2 — TDD inversion: test-writer runs before implementer (#897)
-  test("test-writer runs before implementer within the same iteration", async () => {
-    const opOrder: string[] = [];
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
-    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any): Promise<any> => {
-      opOrder.push(op.name as string);
-      return { applied: true };
-    });
-    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
-      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
-      return true;
-    });
-
-    const ctx = makeCtx();
-    ctx.reviewResult = {
-      success: false,
-      checks: [
-        {
-          ...failedCheck("adversarial", "mixed"),
-          findings: [
-            { source: "adversarial-review", severity: "error", category: "source-bug", message: "source bug", fixTarget: "source" as const },
-            { source: "adversarial-review", severity: "error", category: "test-gap", message: "missing test", fixTarget: "test" as const },
-          ],
-        },
-      ],
-    } as unknown as PipelineContext["reviewResult"];
-
-    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
-
-    const testWriterIdx = opOrder.indexOf("autofix-test-writer");
-    const implementerIdx = opOrder.indexOf("autofix-implementer");
-    expect(testWriterIdx).toBeGreaterThanOrEqual(0);
-    expect(implementerIdx).toBeGreaterThanOrEqual(0);
-    expect(testWriterIdx).toBeLessThan(implementerIdx);
-  });
-
-  // D6 — escalation digest when cap exhausted (#897)
-  test("returns escalationDigest describing remaining findings when cycle exhausts attempts", async () => {
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
-    _cycleDeps.callOp = mock(async (): Promise<any> => ({ applied: true }));
-    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
-      ctx.reviewResult = {
-        success: false,
-        checks: [
-          {
-            ...failedCheck("adversarial", "still failing"),
-            findings: [
-              {
-                source: "adversarial-review",
-                severity: "error",
-                category: "error-path",
-                message: "bug persists",
-                fixTarget: "source" as const,
-                file: "src/foo.ts",
-              },
-            ],
-          },
-        ],
-      } as unknown as PipelineContext["reviewResult"];
-      return false;
-    });
-
-    // maxAttempts: 2 so the first fix runs validate, which updates ctx to adversarial findings.
-    // The second fix then hits the cap and skips validate, using the adversarial findings as finalFindings.
-    const ctx = makeCtx({
-      config: {
-        ...DEFAULT_CONFIG,
-        quality: {
-          ...DEFAULT_CONFIG.quality,
-          autofix: { enabled: true, maxAttempts: 2, maxTotalAttempts: 4 },
-        },
-      } as PipelineContext["config"],
-    });
-    // Initial review has an adversarial finding with a file path in the finding list
-    ctx.reviewResult = {
-      success: false,
-      checks: [
-        {
-          ...failedCheck("adversarial", "still failing"),
-          findings: [
-            {
-              source: "adversarial-review",
-              severity: "error",
-              category: "error-path",
-              message: "bug remains",
-              fixTarget: "source" as const,
-              file: "src/foo.ts",
-            },
-          ],
-        },
-      ],
-    } as unknown as PipelineContext["reviewResult"];
-
-    const result = await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
-
-    expect(result.succeeded).toBe(false);
-    expect(result.escalationDigest).toBeDefined();
-    expect(result.escalationDigest).toContain("remain");
-    expect(result.escalationDigest).toContain("src/foo.ts");
-  });
-
-  // D4 — UNRESOLVED bail before validate (#897)
-  test("returns unresolvedReason when implementer op signals UNRESOLVED via extractApplied", async () => {
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
-    _cycleDeps.callOp = mock(async (): Promise<any> => ({
-      unresolvedReason: "conflicting requirements — test asserts wrong identifier space",
-    }));
-    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
-      ctx.reviewResult = {
-        success: false,
-        checks: [failedCheck("adversarial", "still failing")],
-      } as unknown as PipelineContext["reviewResult"];
-      return false;
-    });
-
-    const result = await runAgentRectificationV2(makeCtx(), undefined, undefined, "/tmp");
-
-    expect(result.succeeded).toBe(false);
-    expect(result.unresolvedReason).toBe("conflicting requirements — test asserts wrong identifier space");
-  });
-
-  // D3 — collectTestTargetedChecks finding leak (#897)
-  // When a check has test-targeted findings mixed with non-adversarial source findings,
-  // the fix-test-files path must only pass test-targeted findings to the test-writer.
-  test("test-writer receives only test-targeted findings in fix-test-files mode (semantic + mixed check)", async () => {
-    const capturedTestWriterChecks: ReviewCheckResult[][] = [];
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
-    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any, input: any): Promise<any> => {
-      if (op.name === "autofix-test-writer") capturedTestWriterChecks.push(input?.failedChecks ?? []);
-      return { applied: true };
-    });
-    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
-      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
-      return true;
-    });
-
-    const ctx = makeCtx();
-    // Semantic check (not adversarial) with mixed findings — only test-targeted should reach the test-writer
-    ctx.reviewResult = {
-      success: false,
-      checks: [
-        {
-          ...failedCheck("semantic", "mixed findings"),
-          findings: [
-            { source: "semantic-review", severity: "error", category: "logic", message: "source bug", fixTarget: "source" as const },
-            { source: "semantic-review", severity: "error", category: "test-gap", message: "missing test", fixTarget: "test" as const },
-          ],
-        },
-      ],
-    } as unknown as PipelineContext["reviewResult"];
-
-    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
-
-    expect(capturedTestWriterChecks.length).toBeGreaterThan(0);
-    const receivedFindings = capturedTestWriterChecks[0]?.[0]?.findings ?? [];
-    expect(receivedFindings).toHaveLength(1);
-    expect(receivedFindings[0]?.fixTarget).toBe("test");
-  });
-
-  test("persists iterations to autofixPriorIterations on ctx", async () => {
-    // biome-ignore lint/suspicious/noExplicitAny: test mock
-    _cycleDeps.callOp = mock(async (): Promise<any> => ({ applied: true }));
-    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
-      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
-      return true;
-    });
-
-    const ctx = makeCtx();
-    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
-
-    expect(ctx.autofixPriorIterations).toBeDefined();
-    expect(ctx.autofixPriorIterations?.length).toBeGreaterThanOrEqual(1);
-  });
-});
-
-// ─── autofixCapacityExhausted ─────────────────────────────────────────────────
-
-function priorIteration(strategyNames: string[]): Iteration {
-  return {
-    iterationNum: 1,
-    findingsBefore: [],
-    fixesApplied: strategyNames.map((name) => ({
-      strategyName: name,
-      op: name,
-      targetFiles: [],
-      summary: "",
-    })),
-    findingsAfter: [],
-    outcome: "unchanged",
-    startedAt: "2026-05-07T00:00:00.000Z",
-    finishedAt: "2026-05-07T00:00:01.000Z",
-  };
-}
-
-describe("autofixCapacityExhausted", () => {
-  test("false when there are no failing findings", () => {
-    const ctx = makeCtx({
-      reviewResult: { success: true, checks: [] } as unknown as PipelineContext["reviewResult"],
-    });
-    expect(autofixCapacityExhausted(ctx)).toBe(false);
-  });
-
-  test("false when no prior iterations and at least one strategy applies", () => {
-    const ctx = makeCtx();
-    ctx.autofixPriorIterations = [];
-    expect(autofixCapacityExhausted(ctx)).toBe(false);
-  });
-
-  test("true when an active strategy has reached its per-strategy cap", () => {
-    // adversarial source-bug findings activate BOTH test-writer (cap 1) and implementer.
-    // Pre-load one test-writer fix into priors to exhaust the test-writer cap.
-    const ctx = makeCtx({
-      reviewResult: {
-        success: false,
-        checks: [
-          {
-            ...failedCheck("adversarial", "blocking"),
-            findings: toAdversarialReviewFindings([
-              {
-                severity: "error",
-                category: "assumption",
-                file: "src/x.ts",
-                line: 1,
-                issue: "bug",
-                suggestion: "fix",
-              },
-            ]),
-          },
-        ],
-      } as unknown as PipelineContext["reviewResult"],
-    });
-    ctx.autofixPriorIterations = [priorIteration(["autofix-test-writer", "autofix-implementer"])];
-    expect(autofixCapacityExhausted(ctx)).toBe(true);
-  });
-
-  test("true when total prior fixesApplied reaches maxTotalAttempts", () => {
-    const ctx = makeCtx({
-      config: {
-        ...DEFAULT_CONFIG,
-        quality: {
-          ...DEFAULT_CONFIG.quality,
-          autofix: { enabled: true, maxAttempts: 5, maxTotalAttempts: 2 },
-        },
-      } as PipelineContext["config"],
-    });
-    ctx.autofixPriorIterations = [
-      priorIteration(["autofix-implementer", "autofix-implementer"]),
+    const declarations: TestEditDeclaration[] = [
+      {
+        reason: "prd_contract",
+        file: "test/foo.spec.ts",
+        prdQuote: "fn(x: number): void",
+        testBefore: "fn()",
+        testAfter: "fn(1)",
+      },
     ];
-    expect(autofixCapacityExhausted(ctx)).toBe(true);
+
+    implementer.extractApplied?.(
+      { applied: true, testEditDeclarations: declarations },
+      // biome-ignore lint/suspicious/noExplicitAny: extractApplied only reads output
+      undefined as any,
+    );
+
+    expect(ctx.testEditDeclarations).toEqual(declarations);
   });
 
-  test("false when only implementer has been used and its cap is not reached", () => {
-    // lint check → only implementer applies. With maxAttempts=2 and 1 prior use, capacity remains.
-    const ctx = makeCtx();
-    ctx.autofixPriorIterations = [priorIteration(["autofix-implementer"])];
-    expect(autofixCapacityExhausted(ctx)).toBe(false);
+  test("extractApplied appends to existing declarations rather than replacing", () => {
+    const ctx = makeMinCtx();
+    ctx.testEditDeclarations = [
+      { reason: "prd_contract", file: "a.spec.ts", prdQuote: "x", testBefore: "x", testAfter: "x" },
+    ];
+    const [, implementer] = buildAutofixStrategies(ctx, 3);
+
+    implementer.extractApplied?.(
+      {
+        applied: true,
+        testEditDeclarations: [
+          { reason: "prd_contract", file: "b.spec.ts", prdQuote: "y", testBefore: "y", testAfter: "y" },
+        ],
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: extractApplied only reads output
+      undefined as any,
+    );
+
+    expect(ctx.testEditDeclarations).toHaveLength(2);
+    expect(ctx.testEditDeclarations?.[0].file).toBe("a.spec.ts");
+    expect(ctx.testEditDeclarations?.[1].file).toBe("b.spec.ts");
+  });
+
+  test("extractApplied is a no-op when output has no declarations", () => {
+    const ctx = makeMinCtx();
+    const [, implementer] = buildAutofixStrategies(ctx, 3);
+    implementer.extractApplied?.(
+      { applied: true, testEditDeclarations: [] },
+      // biome-ignore lint/suspicious/noExplicitAny: extractApplied only reads output
+      undefined as any,
+    );
+    expect(ctx.testEditDeclarations).toBeUndefined();
   });
 });
 
+describe("buildAutofixStrategies — testWriter strategy", () => {
+  test("testWriter has maxAttempts: 2 (allow exactly one re-fire)", () => {
+    const ctx = makeMinCtx();
+    const [testWriter] = buildAutofixStrategies(ctx, 3);
+    expect(testWriter.name).toBe("autofix-test-writer");
+    expect(testWriter.maxAttempts).toBe(2);
+  });
+});

--- a/test/unit/pipeline/stages/autofix-cycle.test.ts
+++ b/test/unit/pipeline/stages/autofix-cycle.test.ts
@@ -1,11 +1,22 @@
-import { describe, expect, test } from "bun:test";
-import type { PipelineContext } from "../../../../src/pipeline/types";
-import type { TestEditDeclaration } from "../../../../src/operations";
-import type { Finding } from "../../../../src/findings";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { DEFAULT_CONFIG } from "../../../../src/config";
+import { _cycleDeps } from "../../../../src/findings";
 import { _autofixDeps } from "../../../../src/pipeline/stages/autofix";
-import { runAgentRectificationV2, buildAutofixStrategies, applyTestEditDeclarations } from "../../../../src/pipeline/stages/autofix-cycle";
+import {
+  applyTestEditDeclarations,
+  autofixCapacityExhausted,
+  buildAutofixStrategies,
+  runAgentRectificationV2,
+} from "../../../../src/pipeline/stages/autofix-cycle";
+import type { Iteration } from "../../../../src/findings";
+import type { Finding } from "../../../../src/findings";
+import type { TestEditDeclaration } from "../../../../src/operations";
+import type { PipelineContext } from "../../../../src/pipeline/types";
+import { toAdversarialReviewFindings } from "../../../../src/review/adversarial-helpers";
+import type { ReviewCheckResult } from "../../../../src/review/types";
+import { makeMockAgentManager, makeMockRuntime, makeNaxConfig, makeStory } from "../../../helpers";
 
-import { makeMockAgentManager, makeNaxConfig, makeStory } from "../../../helpers";
+// ─── Minimal context for strategy/declaration unit tests ──────────────────────
 
 function makeMinCtx(): PipelineContext {
   return {
@@ -17,6 +28,60 @@ function makeMinCtx(): PipelineContext {
     // biome-ignore lint/suspicious/noExplicitAny: only fields read by buildAutofixStrategies are populated
   } as any;
 }
+
+// ─── Full context for V2 + capacity tests ─────────────────────────────────────
+
+function failedCheck(check: ReviewCheckResult["check"], output = `${check} failed`): ReviewCheckResult {
+  return { check, success: false, command: "nax review", exitCode: 1, output, durationMs: 1 };
+}
+
+function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
+  const runtime = makeMockRuntime({});
+  return {
+    config: {
+      ...DEFAULT_CONFIG,
+      quality: {
+        ...DEFAULT_CONFIG.quality,
+        autofix: { enabled: true, maxAttempts: 2, maxTotalAttempts: 4 },
+      },
+    } as PipelineContext["config"],
+    prd: { feature: "phase7-test", stories: [] } as unknown as PipelineContext["prd"],
+    story: { id: "US-phase7", title: "cycle unit test", status: "in-progress", acceptanceCriteria: [] } as unknown as PipelineContext["story"],
+    stories: [],
+    routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
+    rootConfig: DEFAULT_CONFIG,
+    workdir: "/tmp",
+    projectDir: "/tmp",
+    hooks: {} as unknown as PipelineContext["hooks"],
+    runtime,
+    agentManager: makeMockAgentManager({}),
+    sessionManager: runtime.sessionManager,
+    abortSignal: runtime.signal,
+    reviewResult: {
+      success: false,
+      checks: [failedCheck("lint", "lint failure")],
+    } as unknown as PipelineContext["reviewResult"],
+    ...overrides,
+  };
+}
+
+// ─── Lifecycle ────────────────────────────────────────────────────────────────
+
+let savedRecheck: typeof _autofixDeps.recheckReview;
+let savedCycleCallOp: typeof _cycleDeps.callOp;
+
+beforeEach(() => {
+  savedRecheck = _autofixDeps.recheckReview;
+  savedCycleCallOp = _cycleDeps.callOp;
+});
+
+afterEach(() => {
+  _autofixDeps.recheckReview = savedRecheck;
+  _cycleDeps.callOp = savedCycleCallOp;
+  mock.restore();
+});
+
+// ─── buildAutofixStrategies — implementer strategy ────────────────────────────
 
 describe("buildAutofixStrategies — implementer strategy", () => {
   test("extractApplied stashes declarations on ctx.testEditDeclarations", () => {
@@ -75,7 +140,23 @@ describe("buildAutofixStrategies — implementer strategy", () => {
     );
     expect(ctx.testEditDeclarations).toBeUndefined();
   });
+
+  test("appliesTo returns false for prd_quote_mismatch advisory findings", () => {
+    const ctx = makeMinCtx();
+    const [, implementer] = buildAutofixStrategies(ctx, 3);
+    const advisory: Finding = {
+      source: "adversarial-review",
+      severity: "warning",
+      category: "prd_quote_mismatch",
+      message: "PRD_QUOTE not found in story",
+      file: "test/foo.spec.ts",
+      fixTarget: "source",
+    };
+    expect(implementer.appliesTo(advisory)).toBe(false);
+  });
 });
+
+// ─── buildAutofixStrategies — testWriter strategy ─────────────────────────────
 
 describe("buildAutofixStrategies — testWriter strategy", () => {
   test("testWriter has maxAttempts: 2 (allow exactly one re-fire)", () => {
@@ -85,6 +166,8 @@ describe("buildAutofixStrategies — testWriter strategy", () => {
     expect(testWriter.maxAttempts).toBe(2);
   });
 });
+
+// ─── applyTestEditDeclarations ────────────────────────────────────────────────
 
 describe("applyTestEditDeclarations", () => {
   function makeFinding(overrides: Partial<Finding> = {}): Finding {
@@ -193,15 +276,332 @@ describe("applyTestEditDeclarations", () => {
   });
 });
 
-describe("runAgentRectificationV2 — declaration consumption", () => {
+// ─── runAgentRectificationV2 ──────────────────────────────────────────────────
+
+describe("runAgentRectificationV2", () => {
+  test("returns succeeded=true when cycle resolves", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (): Promise<any> => ({ applied: true }));
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
+      return true;
+    });
+
+    const result = await runAgentRectificationV2(makeCtx(), undefined, undefined, "/tmp");
+
+    expect(result.succeeded).toBe(true);
+    expect(result.cost).toBe(0);
+  });
+
+  test("returns succeeded=false when findings remain after max attempts", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (): Promise<any> => ({ applied: true }));
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = {
+        success: false,
+        checks: [failedCheck("lint", "still failing")],
+      } as unknown as PipelineContext["reviewResult"];
+      return false;
+    });
+
+    const result = await runAgentRectificationV2(makeCtx(), undefined, undefined, "/tmp");
+
+    expect(result.succeeded).toBe(false);
+  });
+
+  test("implementer strategy fires for source-targeted findings", async () => {
+    const capturedOps: string[] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any): Promise<any> => {
+      capturedOps.push(op.name as string);
+      return { applied: true };
+    });
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
+      return true;
+    });
+
+    const ctx = makeCtx();
+    ctx.reviewResult = {
+      success: false,
+      checks: [failedCheck("lint", "lint errors")],
+    } as unknown as PipelineContext["reviewResult"];
+
+    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    expect(capturedOps).toContain("autofix-implementer");
+    expect(capturedOps).not.toContain("autofix-test-writer");
+  });
+
+  test("test-writer strategy fires when check has test-targeted findings", async () => {
+    const capturedOps: string[] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any): Promise<any> => {
+      capturedOps.push(op.name as string);
+      return { applied: true };
+    });
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
+      return true;
+    });
+
+    const ctx = makeCtx();
+    ctx.reviewResult = {
+      success: false,
+      checks: [
+        {
+          ...failedCheck("adversarial", "test gap found"),
+          findings: [{ source: "adversarial-review", severity: "error", category: "test-gap", message: "missing test", fixTarget: "test" }],
+        },
+      ],
+    } as unknown as PipelineContext["reviewResult"];
+
+    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    expect(capturedOps).toContain("autofix-test-writer");
+  });
+
+  test("test-writer strategy fires for real adversarial test-gap adapter output", async () => {
+    const capturedOps: string[] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any): Promise<any> => {
+      capturedOps.push(op.name as string);
+      return { applied: true };
+    });
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
+      return true;
+    });
+
+    const ctx = makeCtx();
+    ctx.reviewResult = {
+      success: false,
+      checks: [
+        {
+          ...failedCheck("adversarial", "test gap found"),
+          findings: toAdversarialReviewFindings([
+            {
+              severity: "error",
+              category: "test-gap",
+              file: "src/foo.ts",
+              line: 1,
+              issue: "missing behavioral test",
+              suggestion: "add coverage",
+            },
+          ]),
+        },
+      ],
+    } as unknown as PipelineContext["reviewResult"];
+
+    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    expect(capturedOps).toContain("autofix-test-writer");
+    expect(capturedOps).not.toContain("autofix-implementer");
+  });
+
+  test("buildInput for second iteration uses fresh post-recheck checks", async () => {
+    const capturedChecks: ReviewCheckResult[][] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (_ctx: unknown, _op: unknown, input: any): Promise<any> => {
+      if (input?.failedChecks) capturedChecks.push([...input.failedChecks]);
+      return { applied: true };
+    });
+
+    let recheckCount = 0;
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      recheckCount++;
+      if (recheckCount === 1) {
+        ctx.reviewResult = {
+          success: false,
+          checks: [failedCheck("typecheck", "type error after lint fix")],
+        } as unknown as PipelineContext["reviewResult"];
+        return false;
+      }
+      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
+      return true;
+    });
+
+    const ctx = makeCtx();
+    ctx.reviewResult = {
+      success: false,
+      checks: [failedCheck("lint", "initial lint failure")],
+    } as unknown as PipelineContext["reviewResult"];
+
+    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    expect(capturedChecks.length).toBeGreaterThanOrEqual(2);
+    expect(capturedChecks[0]?.some((c) => c.check === "lint")).toBe(true);
+    expect(capturedChecks[1]?.some((c) => c.check === "typecheck")).toBe(true);
+    expect(capturedChecks[1]?.some((c) => c.check === "lint")).toBe(false);
+  });
+
+  test("test-writer runs before implementer within the same iteration (TDD order)", async () => {
+    const opOrder: string[] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any): Promise<any> => {
+      opOrder.push(op.name as string);
+      return { applied: true };
+    });
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
+      return true;
+    });
+
+    const ctx = makeCtx();
+    ctx.reviewResult = {
+      success: false,
+      checks: [
+        {
+          ...failedCheck("adversarial", "mixed"),
+          findings: [
+            { source: "adversarial-review", severity: "error", category: "source-bug", message: "source bug", fixTarget: "source" as const },
+            { source: "adversarial-review", severity: "error", category: "test-gap", message: "missing test", fixTarget: "test" as const },
+          ],
+        },
+      ],
+    } as unknown as PipelineContext["reviewResult"];
+
+    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    const testWriterIdx = opOrder.indexOf("autofix-test-writer");
+    const implementerIdx = opOrder.indexOf("autofix-implementer");
+    expect(testWriterIdx).toBeGreaterThanOrEqual(0);
+    expect(implementerIdx).toBeGreaterThanOrEqual(0);
+    expect(testWriterIdx).toBeLessThan(implementerIdx);
+  });
+
+  test("returns escalationDigest describing remaining findings when cycle exhausts attempts", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (): Promise<any> => ({ applied: true }));
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = {
+        success: false,
+        checks: [
+          {
+            ...failedCheck("adversarial", "still failing"),
+            findings: [
+              {
+                source: "adversarial-review",
+                severity: "error",
+                category: "error-path",
+                message: "bug persists",
+                fixTarget: "source" as const,
+                file: "src/foo.ts",
+              },
+            ],
+          },
+        ],
+      } as unknown as PipelineContext["reviewResult"];
+      return false;
+    });
+
+    const ctx = makeCtx({
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          autofix: { enabled: true, maxAttempts: 2, maxTotalAttempts: 4 },
+        },
+      } as PipelineContext["config"],
+    });
+    ctx.reviewResult = {
+      success: false,
+      checks: [
+        {
+          ...failedCheck("adversarial", "still failing"),
+          findings: [
+            {
+              source: "adversarial-review",
+              severity: "error",
+              category: "error-path",
+              message: "bug remains",
+              fixTarget: "source" as const,
+              file: "src/foo.ts",
+            },
+          ],
+        },
+      ],
+    } as unknown as PipelineContext["reviewResult"];
+
+    const result = await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    expect(result.succeeded).toBe(false);
+    expect(result.escalationDigest).toBeDefined();
+    expect(result.escalationDigest).toContain("remain");
+    expect(result.escalationDigest).toContain("src/foo.ts");
+  });
+
+  test("returns unresolvedReason when implementer op signals UNRESOLVED", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (): Promise<any> => ({
+      unresolvedReason: "conflicting requirements — test asserts wrong identifier space",
+    }));
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = {
+        success: false,
+        checks: [failedCheck("adversarial", "still failing")],
+      } as unknown as PipelineContext["reviewResult"];
+      return false;
+    });
+
+    const result = await runAgentRectificationV2(makeCtx(), undefined, undefined, "/tmp");
+
+    expect(result.succeeded).toBe(false);
+    expect(result.unresolvedReason).toBe("conflicting requirements — test asserts wrong identifier space");
+  });
+
+  test("test-writer receives only test-targeted findings in fix-test-files mode", async () => {
+    const capturedTestWriterChecks: ReviewCheckResult[][] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (_ctx: unknown, op: any, input: any): Promise<any> => {
+      if (op.name === "autofix-test-writer") capturedTestWriterChecks.push(input?.failedChecks ?? []);
+      return { applied: true };
+    });
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
+      return true;
+    });
+
+    const ctx = makeCtx();
+    ctx.reviewResult = {
+      success: false,
+      checks: [
+        {
+          ...failedCheck("semantic", "mixed findings"),
+          findings: [
+            { source: "semantic-review", severity: "error", category: "logic", message: "source bug", fixTarget: "source" as const },
+            { source: "semantic-review", severity: "error", category: "test-gap", message: "missing test", fixTarget: "test" as const },
+          ],
+        },
+      ],
+    } as unknown as PipelineContext["reviewResult"];
+
+    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    expect(capturedTestWriterChecks.length).toBeGreaterThan(0);
+    const receivedFindings = capturedTestWriterChecks[0]?.[0]?.findings ?? [];
+    expect(receivedFindings).toHaveLength(1);
+    expect(receivedFindings[0]?.fixTarget).toBe("test");
+  });
+
+  test("persists iterations to autofixPriorIterations on ctx", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    _cycleDeps.callOp = mock(async (): Promise<any> => ({ applied: true }));
+    _autofixDeps.recheckReview = mock(async (ctx: PipelineContext) => {
+      ctx.reviewResult = { success: true, checks: [] } as unknown as PipelineContext["reviewResult"];
+      return true;
+    });
+
+    const ctx = makeCtx();
+    await runAgentRectificationV2(ctx, undefined, undefined, "/tmp");
+
+    expect(ctx.autofixPriorIterations).toBeDefined();
+    expect(ctx.autofixPriorIterations?.length).toBeGreaterThanOrEqual(1);
+  });
+
   test("preserves testEditDeclarations when no findings present (validate never fires)", async () => {
     const ctx: PipelineContext = {
-      ...makeMinCtx(),
-      runtime: {
-        packages: { repo: () => ({}) },
-        outputDir: "/tmp/out",
-        // biome-ignore lint/suspicious/noExplicitAny: minimal runtime stub
-      } as any,
+      ...makeCtx(),
       prd: { feature: "f" } as any,
     };
     ctx.testEditDeclarations = [
@@ -209,6 +609,7 @@ describe("runAgentRectificationV2 — declaration consumption", () => {
     ];
     // No findings → cycle exits immediately; validate() is never called, so
     // the side-channel is NOT cleared (consumed on next pipeline retry).
+    ctx.reviewResult = { success: false, checks: [] } as unknown as PipelineContext["reviewResult"];
     const saved = { ..._autofixDeps };
     _autofixDeps.recheckReview = async () => false;
     try {
@@ -220,5 +621,90 @@ describe("runAgentRectificationV2 — declaration consumption", () => {
     expect(ctx.autofixPriorIterations).toBeDefined();
     // Side-channel still present — validate() never ran to consume it.
     expect(ctx.testEditDeclarations).toHaveLength(1);
+  });
+});
+
+// ─── autofixCapacityExhausted ─────────────────────────────────────────────────
+
+function priorIteration(strategyNames: string[]): Iteration {
+  return {
+    iterationNum: 1,
+    findingsBefore: [],
+    fixesApplied: strategyNames.map((name) => ({
+      strategyName: name,
+      op: name,
+      targetFiles: [],
+      summary: "",
+    })),
+    findingsAfter: [],
+    outcome: "unchanged",
+    startedAt: "2026-05-07T00:00:00.000Z",
+    finishedAt: "2026-05-07T00:00:01.000Z",
+  };
+}
+
+describe("autofixCapacityExhausted", () => {
+  test("false when there are no failing findings", () => {
+    const ctx = makeCtx({
+      reviewResult: { success: true, checks: [] } as unknown as PipelineContext["reviewResult"],
+    });
+    expect(autofixCapacityExhausted(ctx)).toBe(false);
+  });
+
+  test("false when no prior iterations and at least one strategy applies", () => {
+    const ctx = makeCtx();
+    ctx.autofixPriorIterations = [];
+    expect(autofixCapacityExhausted(ctx)).toBe(false);
+  });
+
+  test("true when an active strategy has reached its per-strategy cap", () => {
+    const ctx = makeCtx({
+      reviewResult: {
+        success: false,
+        checks: [
+          {
+            ...failedCheck("adversarial", "blocking"),
+            findings: toAdversarialReviewFindings([
+              {
+                severity: "error",
+                category: "assumption",
+                file: "src/x.ts",
+                line: 1,
+                issue: "bug",
+                suggestion: "fix",
+              },
+            ]),
+          },
+        ],
+      } as unknown as PipelineContext["reviewResult"],
+    });
+    // test-writer has maxAttempts:2; two prior uses = exhausted
+    ctx.autofixPriorIterations = [
+      priorIteration(["autofix-test-writer", "autofix-implementer"]),
+      priorIteration(["autofix-test-writer", "autofix-implementer"]),
+    ];
+    expect(autofixCapacityExhausted(ctx)).toBe(true);
+  });
+
+  test("true when total prior fixesApplied reaches maxTotalAttempts", () => {
+    const ctx = makeCtx({
+      config: {
+        ...DEFAULT_CONFIG,
+        quality: {
+          ...DEFAULT_CONFIG.quality,
+          autofix: { enabled: true, maxAttempts: 5, maxTotalAttempts: 2 },
+        },
+      } as PipelineContext["config"],
+    });
+    ctx.autofixPriorIterations = [
+      priorIteration(["autofix-implementer", "autofix-implementer"]),
+    ];
+    expect(autofixCapacityExhausted(ctx)).toBe(true);
+  });
+
+  test("false when only implementer has been used and its cap is not reached", () => {
+    const ctx = makeCtx();
+    ctx.autofixPriorIterations = [priorIteration(["autofix-implementer"])];
+    expect(autofixCapacityExhausted(ctx)).toBe(false);
   });
 });

--- a/test/unit/pipeline/stages/autofix-cycle.test.ts
+++ b/test/unit/pipeline/stages/autofix-cycle.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { PipelineContext } from "../../../../src/pipeline/types";
 import type { TestEditDeclaration } from "../../../../src/operations";
+import type { Finding } from "../../../../src/findings";
 
 // We test the strategy builder in isolation. Importing buildAutofixStrategies
 // requires it to be exported — Task 6 makes that change.
-import { buildAutofixStrategies } from "../../../../src/pipeline/stages/autofix-cycle";
+import { buildAutofixStrategies, applyTestEditDeclarations } from "../../../../src/pipeline/stages/autofix-cycle";
 
 import { makeStory } from "../../../helpers/mock-story";
 
@@ -84,5 +85,112 @@ describe("buildAutofixStrategies — testWriter strategy", () => {
     const [testWriter] = buildAutofixStrategies(ctx, 3);
     expect(testWriter.name).toBe("autofix-test-writer");
     expect(testWriter.maxAttempts).toBe(2);
+  });
+});
+
+describe("applyTestEditDeclarations", () => {
+  function makeFinding(overrides: Partial<Finding> = {}): Finding {
+    return {
+      source: "adversarial-review",
+      severity: "error",
+      category: "convention",
+      message: "uses unsafe cast",
+      file: "src/foo.ts",
+      fixTarget: "source",
+      ...overrides,
+    };
+  }
+
+  test("re-tags matching source findings to fixTarget=test on valid prd_contract", () => {
+    const story = makeStory({
+      description: "fnA(x: number): void must be exposed",
+    });
+    const findings: Finding[] = [
+      makeFinding({ file: "test/foo.spec.ts", message: "test calls fnA() without arg" }),
+      makeFinding({ file: "src/bar.ts", message: "unrelated" }),
+    ];
+    const declarations: TestEditDeclaration[] = [
+      {
+        reason: "prd_contract",
+        file: "test/foo.spec.ts",
+        prdQuote: "fnA(x: number): void",
+        testBefore: "fnA()",
+        testAfter: "fnA(1)",
+      },
+    ];
+
+    const out = applyTestEditDeclarations(findings, declarations, story);
+
+    expect(out).toHaveLength(2);
+    expect(out[0].fixTarget).toBe("test");
+    expect(out[0].file).toBe("test/foo.spec.ts");
+    expect(out[1].fixTarget).toBe("source");
+  });
+
+  test("emits a prd_quote_mismatch finding when quote is not in story", () => {
+    const story = makeStory({ description: "Real story text" });
+    const findings: Finding[] = [
+      makeFinding({ file: "test/foo.spec.ts" }),
+    ];
+    const declarations: TestEditDeclaration[] = [
+      {
+        reason: "prd_contract",
+        file: "test/foo.spec.ts",
+        prdQuote: "fabricated(x): void",
+        testBefore: "x",
+        testAfter: "y",
+      },
+    ];
+
+    const out = applyTestEditDeclarations(findings, declarations, story);
+
+    // Original finding is left source-tagged
+    expect(out[0].fixTarget).toBe("source");
+    // A new advisory finding is appended
+    const mismatch = out.find((f) => f.category === "prd_quote_mismatch");
+    expect(mismatch).toBeDefined();
+    expect(mismatch?.severity).toBe("warning");
+    expect(mismatch?.source).toBe("adversarial-review");
+    expect(mismatch?.message).toContain("fabricated(x): void");
+  });
+
+  test("ignores lint_only and sibling_scope declarations (no re-tagging)", () => {
+    const story = makeStory();
+    const findings: Finding[] = [makeFinding({ file: "test/foo.spec.ts" })];
+    const declarations: TestEditDeclaration[] = [
+      { reason: "lint_only", file: "test/foo.spec.ts", finding: "no-x" },
+      { reason: "sibling_scope", file: "test/foo.spec.ts", finding: "TS2304" },
+    ];
+
+    const out = applyTestEditDeclarations(findings, declarations, story);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].fixTarget).toBe("source");
+  });
+
+  test("no-op on empty declarations", () => {
+    const story = makeStory();
+    const findings: Finding[] = [makeFinding()];
+    expect(applyTestEditDeclarations(findings, [], story)).toEqual(findings);
+  });
+
+  test("drops a prd_contract declaration whose FILE matches no current finding", () => {
+    const story = makeStory({ description: "fn(): void" });
+    const findings: Finding[] = [makeFinding({ file: "test/other.spec.ts" })];
+    const declarations: TestEditDeclaration[] = [
+      {
+        reason: "prd_contract",
+        file: "test/missing.spec.ts",
+        prdQuote: "fn(): void",
+        testBefore: "x",
+        testAfter: "y",
+      },
+    ];
+
+    const out = applyTestEditDeclarations(findings, declarations, story);
+
+    // No re-tagging, no mismatch finding
+    expect(out).toHaveLength(1);
+    expect(out[0].fixTarget).toBe("source");
   });
 });

--- a/test/unit/pipeline/stages/autofix-cycle.test.ts
+++ b/test/unit/pipeline/stages/autofix-cycle.test.ts
@@ -5,15 +5,15 @@ import type { Finding } from "../../../../src/findings";
 import { _autofixDeps } from "../../../../src/pipeline/stages/autofix";
 import { runAgentRectificationV2, buildAutofixStrategies, applyTestEditDeclarations } from "../../../../src/pipeline/stages/autofix-cycle";
 
-import { makeStory } from "../../../helpers/mock-story";
+import { makeMockAgentManager, makeNaxConfig, makeStory } from "../../../helpers";
 
 function makeMinCtx(): PipelineContext {
-  // Minimal context: only the fields strategy buildInput / extractApplied read.
   return {
     story: makeStory(),
-    config: { quality: { autofix: {} }, review: {} },
+    config: makeNaxConfig(),
     reviewResult: { success: false, checks: [] },
     workdir: "/tmp",
+    agentManager: makeMockAgentManager(),
     // biome-ignore lint/suspicious/noExplicitAny: only fields read by buildAutofixStrategies are populated
   } as any;
 }
@@ -194,7 +194,7 @@ describe("applyTestEditDeclarations", () => {
 });
 
 describe("runAgentRectificationV2 — declaration consumption", () => {
-  test("clears ctx.testEditDeclarations after validate runs", async () => {
+  test("preserves testEditDeclarations when no findings present (validate never fires)", async () => {
     const ctx: PipelineContext = {
       ...makeMinCtx(),
       runtime: {
@@ -202,13 +202,13 @@ describe("runAgentRectificationV2 — declaration consumption", () => {
         outputDir: "/tmp/out",
         // biome-ignore lint/suspicious/noExplicitAny: minimal runtime stub
       } as any,
-      agentManager: { getDefault: () => "claude" } as any,
       prd: { feature: "f" } as any,
     };
     ctx.testEditDeclarations = [
       { reason: "prd_contract", file: "test/foo.spec.ts", prdQuote: "x", testBefore: "y", testAfter: "z" },
     ];
-    // No findings → cycle exits with "resolved" before invoking strategies.
+    // No findings → cycle exits immediately; validate() is never called, so
+    // the side-channel is NOT cleared (consumed on next pipeline retry).
     const saved = { ..._autofixDeps };
     _autofixDeps.recheckReview = async () => false;
     try {
@@ -217,8 +217,8 @@ describe("runAgentRectificationV2 — declaration consumption", () => {
       Object.assign(_autofixDeps, saved);
     }
 
-    // With no initial findings, validate isn't called — but autofixPriorIterations
-    // is still set, and the side-channel is preserved for the next pipeline pass.
     expect(ctx.autofixPriorIterations).toBeDefined();
+    // Side-channel still present — validate() never ran to consume it.
+    expect(ctx.testEditDeclarations).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- Introduces `TEST_EDIT_REASON: prd_contract` as a structured escape valve for the autofix implementer: when a test contradicts the PRD (not a source bug), the implementer emits a block declaring which test file needs updating and what the PRD requires
- The autofix cycle's `validate()` hook picks up these declarations, verifies the `PRD_QUOTE` appears verbatim (whitespace-normalised) in the story description or acceptance criteria, and re-tags matching findings from `fixTarget: "source"` → `"test"` so the test-writer strategy claims them next iteration instead of the implementer looping to exhaustion
- Fabricated PRD quotes are rejected: a `prd_quote_mismatch` advisory finding is appended (severity: warning) and the implementer's `appliesTo` explicitly excludes advisory findings to prevent re-routing loops
- `testWriter.maxAttempts` raised from `1` → `2` to allow exactly one re-fire after a declaration is consumed

## New symbols

| Symbol | File |
|:---|:---|
| `TestEditDeclaration` | `src/operations/test-edit-declaration.ts` |
| `parseTestEditDeclarations()` | `src/operations/test-edit-declaration.ts` |
| `validatePrdQuote()` | `src/operations/test-edit-declaration.ts` |
| `applyTestEditDeclarations()` | `src/pipeline/stages/autofix-cycle.ts` |
| `PipelineContext.testEditDeclarations` | `src/pipeline/types.ts` |
| `AutofixImplementerOutput.testEditDeclarations` | `src/operations/autofix-implementer.ts` |

## Test plan

- [ ] `test/unit/operations/test-edit-declaration.test.ts` — 12 tests: parse blocks (all 3 reasons, malformed, multi-block, whitespace normalisation), validatePrdQuote (match, mismatch, empty, AC match, normalised whitespace)
- [ ] `test/unit/operations/autofix-implementer.test.ts` — 3 tests: parse output shape with declarations
- [ ] `test/unit/pipeline/stages/autofix-cycle.test.ts` — extractApplied stash/append/no-op, appliesTo excludes prd_quote_mismatch, testWriter maxAttempts, applyTestEditDeclarations (5 cases), full V2 outcomes (succeeded, strategy routing, TDD order, escalation digest, unresolvedReason, iteration persistence, no-findings preserve), autofixCapacityExhausted (5 cases)
- [ ] `test/integration/autofix-implementer-feedback.test.ts` — happy path asserts testWriter fires after implementer emits declaration + side-channel cleared; invalid-PRD_QUOTE path asserts no re-tagging + prd_quote_mismatch advisory never reaches implementer