### PR TITLE
fix(watchdog): fail-stale retry lost due to agent.call_ended race

### DIFF
--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -123,8 +123,14 @@ export class SessionManager implements ISessionManager {
       this._agentStreamUnsubscribe?.();
       this._agentStreamUnsubscribe = opts.agentStreamEvents.onAgentStream((event) => {
         if (event.kind === "agent.call_ended") {
+          // Only clean up the controller registry here. Do NOT drain
+          // _watchdogCancelledCalls from this subscriber: agent.call_ended is
+          // emitted synchronously inside SpawnAcpSession.prompt() before the
+          // error propagates into sendPrompt. Draining here would clear the flag
+          // before sendPrompt checks it, preventing fail-stale classification.
+          // _watchdogCancelledCalls is drained by sendPrompt instead (on both
+          // the error path and the success path to prevent stale entries).
           this._watchdogControllerRegistry?.delete(event.callId);
-          this._watchdogCancelledCalls.delete(event.callId);
         }
       });
     }
@@ -562,6 +568,11 @@ export class SessionManager implements ISessionManager {
         signal: opts?.signal,
         maxTurns: opts?.maxTurns,
       });
+      // Drain any stale watchdog entry: the watchdog may have fired and set a
+      // callId here just before the call completed successfully. The success path
+      // never reaches the SessionTurnError handler below, so we clear here to
+      // prevent the stale entry from misclassifying a future unrelated cancel.
+      this._watchdogCancelledCalls.clear();
       return { ...result, protocolIds: result.protocolIds ?? handle.protocolIds };
     } catch (err) {
       // Map the adapter's transport-level cancel signal to the policy-level

--- a/test/unit/session/manager-phase-b-prompt.test.ts
+++ b/test/unit/session/manager-phase-b-prompt.test.ts
@@ -199,10 +199,11 @@ describe("sendPrompt()", () => {
     expect(caught).not.toBeInstanceOf(SessionFailureError);
   });
 
-  test("agent.call_ended event drains watchdog registry and bookkeeping", async () => {
-    // Standardised cleanup: SessionManager subscribes once to the stream bus
-    // and depopulates both the controller registry and its cancelled-call
-    // bookkeeping when agent.call_ended fires.
+  test("agent.call_ended event drains watchdog controller registry", async () => {
+    // SessionManager subscribes once to the stream bus and depopulates the
+    // controller registry when agent.call_ended fires. Note: _watchdogCancelledCalls
+    // is NOT drained from this subscriber to avoid the race where agent.call_ended
+    // fires inside SpawnAcpSession.prompt() before sendPrompt sees the error.
     const adapter = makeAgentAdapter({
       openSession: mock(async (name: string) => ({ id: name, agentName: "claude" }) as SessionHandle),
       sendTurn: mock(async () => MOCK_TURN),
@@ -227,6 +228,55 @@ describe("sendPrompt()", () => {
     });
 
     expect(registry.size).toBe(0);
+  });
+
+  test("fail-stale classification survives agent.call_ended emitted before SessionTurnError throws", async () => {
+    // Regression: agent.call_ended fires synchronously inside SpawnAcpSession.prompt()
+    // BEFORE the error propagates as a SessionTurnError. Previously the agent.call_ended
+    // subscriber drained _watchdogCancelledCalls, causing sendPrompt to see an empty
+    // set and miss the fail-stale classification. The fix: only drain from sendPrompt.
+    let capturedActiveCall: ((callId: string, cancel: () => Promise<void>) => void) | undefined;
+    const registry = new Map<string, () => Promise<void>>();
+    const bus = new AgentStreamEventBus();
+    const adapter = makeAgentAdapter({
+      openSession: mock(async (name: string, opts: OpenSessionOpts) => {
+        capturedActiveCall = opts.onActiveCall;
+        return { id: name, agentName: "claude" } as SessionHandle;
+      }),
+      sendTurn: mock(async () => {
+        // 1. Register the in-flight call via onActiveCall.
+        capturedActiveCall?.("call-race", async () => {});
+        // 2. Watchdog fires: wrapped cancel records callId in _watchdogCancelledCalls.
+        await registry.get("call-race")?.();
+        // 3. Simulate agent.call_ended fired by SpawnAcpSession BEFORE throwing —
+        //    this is what happens in production (event emitted on non-zero exit path).
+        bus.emitAgentStream({
+          kind: "agent.call_ended",
+          callId: "call-race",
+          runId: "r-1",
+          agentName: "claude",
+          sessionName: "nax-test",
+          status: "error",
+          timestamp: Date.now(),
+        });
+        // 4. Now throw — like the adapter does after emitting call_ended.
+        throw new SessionTurnError("Agent session ended with stop reason: error (externally cancelled)", true);
+      }),
+    });
+
+    const sm = new SessionManager({ getAdapter: () => adapter });
+    sm.configureRuntime({ watchdogControllerRegistry: registry, agentStreamEvents: bus });
+    const handle = await sm.openSession("nax-race-test", makeOpenRequest());
+
+    let caught: unknown;
+    try {
+      await sm.sendPrompt(handle, "test");
+    } catch (err) {
+      caught = err;
+    }
+    // Must still be classified as fail-stale despite agent.call_ended firing first.
+    expect(caught).toBeInstanceOf(SessionFailureError);
+    expect((caught as SessionFailureError).adapterFailure.outcome).toBe("fail-stale");
   });
 
   test("forwards maxTurns to adapter.sendTurn", async () => {


### PR DESCRIPTION
## What

Fixes a race condition that caused idle watchdog cancellations to silently skip the `fail-stale` retry, resulting in the story stopping immediately instead of retrying.

## Root cause

`agent.call_ended` is emitted **synchronously inside** `SpawnAcpSession.prompt()` on the non-zero exit path — *before* the error propagates as a `SessionTurnError`. The `agent.call_ended` subscriber in `SessionManager.configureRuntime` was calling `_watchdogCancelledCalls.delete(event.callId)`, so by the time `sendPrompt` caught the `SessionTurnError` and checked `_watchdogCancelledCalls.size > 0`, the set was already empty:

- `wasWatchdog = false`
- No `SessionFailureError` with `outcome: "fail-stale"` thrown
- `AgentManager.runWithFallback` never saw `isFailStale = true` → no retry

Observed in production: idle watchdog fired at 08:58:49, killed the session at 08:58:59, and the story immediately transitioned to review phase with no retry log entry.

## Fix

**`src/session/manager.ts`**
- Remove `_watchdogCancelledCalls.delete(event.callId)` from the `agent.call_ended` subscriber — only `_watchdogControllerRegistry` is cleaned up there now
- Add `_watchdogCancelledCalls.clear()` to the `sendPrompt` success path — drains stale entries for the rare race where a watchdog cancel arrives just before a call completes successfully

**`test/unit/session/manager-phase-b-prompt.test.ts`**
- Update the existing test description (no longer drains bookkeeping from the event)
- Add regression test that reproduces the exact race: emits `agent.call_ended` inside `sendTurn` before throwing `SessionTurnError`, asserts result is still classified as `fail-stale`

## Test plan

- [x] New regression test in `test/unit/session/manager-phase-b-prompt.test.ts` reproducing the race
- [x] All existing fail-stale tests pass: `fail-stale-agent-manager`, `fail-stale-complete`, `fail-stale-session-error`, `fail-stale-watchdog` (integration)
- [x] All session manager tests pass (15/15)
- [x] All session + agent tests pass (627/627)