### PR TITLE
fix(session): isolate watchdog fail-stale bookkeeping per session handle

### DIFF
--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -75,13 +75,12 @@ export class SessionManager implements ISessionManager {
   private _watchdogControllerRegistry: Map<string, () => Promise<void>> | undefined;
   private _onStreamActivity: ((event: import("../runtime/agent-stream-events").AgentStreamEvent) => void) | undefined;
   /**
-   * Bookkeeping: callIds whose cancel was invoked via the watchdog registry.
-   * Populated by the wrapped `onActiveCall` cancel closure; consumed when the
-   * adapter surfaces `cancelled: true` so we can map the failure to fail-stale.
-   * Drained via `agent.call_ended` events on the stream bus (and as a backstop
-   * when sendPrompt observes the cancellation).
+   * Bookkeeping: per-session callIds whose cancel was invoked via the watchdog
+   * registry. Populated by the wrapped `onActiveCall` cancel closure; consumed
+   * when the adapter surfaces `cancelled: true` so we can map the failure to
+   * fail-stale without cross-session contamination in parallel runs.
    */
-  private readonly _watchdogCancelledCalls = new Set<string>();
+  private readonly _watchdogCancelledCallsBySession = new Map<string, Set<string>>();
   /** Disposer for the agent.call_ended subscription; cleared in `close()` if added. */
   private _agentStreamUnsubscribe: (() => void) | undefined;
 
@@ -144,15 +143,21 @@ export class SessionManager implements ISessionManager {
    * it was the watchdog (vs an unrelated process kill) and classify as
    * fail-stale. Returns undefined when no registry is configured.
    */
-  private _buildOnActiveCall(): ((callId: string, cancel: () => Promise<void>) => void) | undefined {
+  private _buildOnActiveCall(sessionName: string): ((callId: string, cancel: () => Promise<void>) => void) | undefined {
     const registry = this._watchdogControllerRegistry;
     if (!registry) return undefined;
     return (callId, cancel) => {
       registry.set(callId, async () => {
-        this._watchdogCancelledCalls.add(callId);
+        const cancelledCalls = this._watchdogCancelledCallsBySession.get(sessionName) ?? new Set<string>();
+        cancelledCalls.add(callId);
+        this._watchdogCancelledCallsBySession.set(sessionName, cancelledCalls);
         await cancel();
       });
     };
+  }
+
+  private _clearWatchdogCancelledCalls(sessionName: string): void {
+    this._watchdogCancelledCallsBySession.delete(sessionName);
   }
 
   /**
@@ -448,7 +453,7 @@ export class SessionManager implements ISessionManager {
       onSessionEstablished: opts.onSessionEstablished,
       signal: opts.signal,
       resume,
-      onActiveCall: this._buildOnActiveCall(),
+      onActiveCall: this._buildOnActiveCall(name),
       onStreamActivity: this._onStreamActivity,
     });
     this._liveHandles.set(name, handle);
@@ -568,11 +573,6 @@ export class SessionManager implements ISessionManager {
         signal: opts?.signal,
         maxTurns: opts?.maxTurns,
       });
-      // Drain any stale watchdog entry: the watchdog may have fired and set a
-      // callId here just before the call completed successfully. The success path
-      // never reaches the SessionTurnError handler below, so we clear here to
-      // prevent the stale entry from misclassifying a future unrelated cancel.
-      this._watchdogCancelledCalls.clear();
       return { ...result, protocolIds: result.protocolIds ?? handle.protocolIds };
     } catch (err) {
       // Map the adapter's transport-level cancel signal to the policy-level
@@ -585,8 +585,7 @@ export class SessionManager implements ISessionManager {
         // recorded as watchdog-cancelled is the one we just observed. Drain
         // all of them — there should only be one in-flight call per handle
         // due to the single-flight (_busySessions) invariant above.
-        const wasWatchdog = this._watchdogCancelledCalls.size > 0;
-        this._watchdogCancelledCalls.clear();
+        const wasWatchdog = (this._watchdogCancelledCallsBySession.get(handle.id)?.size ?? 0) > 0;
         if (wasWatchdog) {
           throw new SessionFailureError("idle watchdog cancelled session — no stream activity", {
             category: "availability",
@@ -608,6 +607,9 @@ export class SessionManager implements ISessionManager {
       }
       throw err;
     } finally {
+      // Clear per-session watchdog-cancel bookkeeping after each turn: this
+      // call is complete (success or error), and single-flight is per session.
+      this._clearWatchdogCancelledCalls(handle.id);
       this._busySessions.delete(handle.id);
     }
   }

--- a/test/unit/session/manager-phase-b-prompt.test.ts
+++ b/test/unit/session/manager-phase-b-prompt.test.ts
@@ -279,6 +279,50 @@ describe("sendPrompt()", () => {
     expect((caught as SessionFailureError).adapterFailure.outcome).toBe("fail-stale");
   });
 
+  test("watchdog fail-stale classification is isolated per session handle during parallel prompts", async () => {
+    let capturedA: ((callId: string, cancel: () => Promise<void>) => void) | undefined;
+    let capturedB: ((callId: string, cancel: () => Promise<void>) => void) | undefined;
+    const registry = new Map<string, () => Promise<void>>();
+    let releaseB: (() => void) | undefined;
+    const allowBToFinish = new Promise<void>((resolve) => {
+      releaseB = resolve;
+    });
+
+    const adapter = makeAgentAdapter({
+      openSession: mock(async (name: string, opts: OpenSessionOpts) => {
+        if (name === "nax-session-a") capturedA = opts.onActiveCall;
+        if (name === "nax-session-b") capturedB = opts.onActiveCall;
+        return { id: name, agentName: "claude" } as SessionHandle;
+      }),
+      sendTurn: mock(async (handle: SessionHandle) => {
+        if (handle.id === "nax-session-a") {
+          capturedA?.("call-a", async () => {});
+          await registry.get("call-a")?.();
+          await allowBToFinish;
+          throw new SessionTurnError("Agent session ended with stop reason: error (externally cancelled)", true);
+        }
+        if (handle.id === "nax-session-b") {
+          capturedB?.("call-b", async () => {});
+          releaseB?.();
+          return MOCK_TURN;
+        }
+        return MOCK_TURN;
+      }),
+    });
+
+    const sm = new SessionManager({ getAdapter: () => adapter });
+    sm.configureRuntime({ watchdogControllerRegistry: registry });
+    const handleA = await sm.openSession("nax-session-a", makeOpenRequest());
+    const handleB = await sm.openSession("nax-session-b", makeOpenRequest());
+
+    const promiseA = sm.sendPrompt(handleA, "prompt-a").catch((err) => err);
+    const promiseB = sm.sendPrompt(handleB, "prompt-b");
+    const [resultA] = await Promise.all([promiseA, promiseB]);
+
+    expect(resultA).toBeInstanceOf(SessionFailureError);
+    expect((resultA as SessionFailureError).adapterFailure.outcome).toBe("fail-stale");
+  });
+
   test("forwards maxTurns to adapter.sendTurn", async () => {
     let capturedMaxTurns: number | undefined;
     const adapter = makeAgentAdapter({


### PR DESCRIPTION
## Summary
- scope watchdog-cancel bookkeeping by session handle instead of a manager-global set
- prevent cross-session contamination where one prompt could clear or consume another session's watchdog cancel marker
- keep fail-stale mapping for watchdog-triggered cancelled SessionTurnError while preserving pass-through behavior for unrelated cancels

## Tests
- bun test test/unit/session/manager-phase-b-prompt.test.ts --timeout=30000
- adds regression test: watchdog fail-stale classification is isolated per session handle during parallel prompts

## Context
A prior fix addressed the same-session race where agent.call_ended could fire before SessionTurnError propagation. This PR closes the remaining parallel-session interleaving gap by making bookkeeping session-local.