### PR TITLE
fix: harden scoped test execution and path safety

### DIFF
--- a/src/acceptance/test-path.ts
+++ b/src/acceptance/test-path.ts
@@ -34,7 +34,8 @@ export function acceptanceTestFilename(language?: string): string {
  * Resolve acceptance test filename based on explicit config override and language.
  */
 export function resolveAcceptanceTestFile(language?: string, testPathConfig?: string): string {
-  return testPathConfig ?? acceptanceTestFilename(language);
+  const candidate = testPathConfig ?? acceptanceTestFilename(language);
+  return sanitizeTestFileName(candidate, "acceptance.testPath");
 }
 
 /**
@@ -161,7 +162,22 @@ export function suggestedTestFilename(language?: string): string {
  * Resolve suggested test filename based on explicit config override and language.
  */
 export function resolveSuggestedTestFile(language?: string, testPathConfig?: string): string {
-  return testPathConfig ?? suggestedTestFilename(language);
+  const candidate = testPathConfig ?? suggestedTestFilename(language);
+  return sanitizeTestFileName(candidate, "acceptance.suggestedTestPath");
+}
+
+function sanitizeTestFileName(value: string, fieldName: string): string {
+  const filename = value.trim();
+  if (filename.length === 0) {
+    throw new Error(`${fieldName} must be non-empty`);
+  }
+  if (filename.includes("/") || filename.includes("\\")) {
+    throw new Error(`${fieldName} must be a filename, not a path: ${filename}`);
+  }
+  if (filename.includes("..")) {
+    throw new Error(`${fieldName} cannot contain '..': ${filename}`);
+  }
+  return filename;
 }
 
 /**

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -19,6 +19,7 @@ import { callOp, planOp } from "../operations";
 import { validatePlanOutput } from "../prd/schema";
 import type { PRD } from "../prd/types";
 import { PlanPromptBuilder } from "../prompts";
+import { validateFeatureName } from "../utils/feature-name";
 import { buildCodebaseContext, buildPackageSummary } from "./plan-helpers";
 import { DEFAULT_TIMEOUT_SECONDS, _planDeps, createPlanRuntime, resolvePlanModelSelection } from "./plan-runtime";
 
@@ -53,6 +54,7 @@ export interface PlanCommandOptions {
  * @returns Path to generated prd.json
  */
 export async function planCommand(workdir: string, config: NaxConfig, options: PlanCommandOptions): Promise<string> {
+  validateFeatureName(options.feature);
   const naxDir = join(workdir, ".nax");
 
   if (!existsSync(naxDir)) {

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -54,12 +54,13 @@ export interface PlanCommandOptions {
  * @returns Path to generated prd.json
  */
 export async function planCommand(workdir: string, config: NaxConfig, options: PlanCommandOptions): Promise<string> {
-  validateFeatureName(options.feature);
   const naxDir = join(workdir, ".nax");
 
   if (!existsSync(naxDir)) {
     throw new Error(`.nax directory not found. Run 'nax init' first in ${workdir}`);
   }
+
+  validateFeatureName(options.feature);
 
   const logger = getLogger();
 

--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -8,6 +8,7 @@ import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { MAX_DIRECTORY_DEPTH } from "../config/path-security";
 import { NaxError } from "../errors";
+import { validateFeatureName } from "../utils/feature-name";
 
 /**
  * Options for project resolution
@@ -106,6 +107,11 @@ export function resolveProject(options: ResolveProjectOptions = {}): ResolvedPro
   // Step 4: Validate feature directory (if specified)
   let featureDir: string | undefined;
   if (feature) {
+    try {
+      validateFeatureName(feature);
+    } catch (error) {
+      throw new NaxError((error as Error).message, "FEATURE_INVALID", { feature });
+    }
     const featuresDir = join(naxDir, "features");
     featureDir = join(featuresDir, feature);
 

--- a/src/hooks/runner.ts
+++ b/src/hooks/runner.ts
@@ -13,6 +13,22 @@ import { killProcessGroup } from "../utils/process-kill";
 import type { HookContext, HookDef, HookEvent, HooksConfig } from "./types";
 
 const DEFAULT_TIMEOUT = 5000;
+const STREAM_DRAIN_TIMEOUT_MS = 2000;
+
+function createDrainDeadline(deadlineMs: number): { promise: Promise<string>; cancel: () => void } {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const promise = new Promise<string>((resolve) => {
+    timeoutId = setTimeout(() => resolve(""), deadlineMs);
+  });
+  return {
+    promise,
+    cancel: () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    },
+  };
+}
 
 /** Extended hooks config that tracks global vs project hooks */
 export interface LoadedHooksConfig extends HooksConfig {
@@ -202,20 +218,37 @@ async function executeHook(
   });
 
   // Timeout handling
+  let timedOut = false;
   const timeoutId = setTimeout(() => {
+    timedOut = true;
     killProcessGroup(proc.pid, "SIGTERM");
   }, timeout);
 
+  const stdoutPromise = new Response(proc.stdout).text().catch(() => "");
+  const stderrPromise = new Response(proc.stderr).text().catch(() => "");
   const exitCode = await proc.exited;
   clearTimeout(timeoutId);
 
-  const stdout = await new Response(proc.stdout).text();
-  const stderr = await new Response(proc.stderr).text();
+  const [stdout, stderr] = timedOut
+    ? await (async () => {
+        const stdoutDrain = createDrainDeadline(STREAM_DRAIN_TIMEOUT_MS);
+        const stderrDrain = createDrainDeadline(STREAM_DRAIN_TIMEOUT_MS);
+        try {
+          return await Promise.all([
+            Promise.race([stdoutPromise, stdoutDrain.promise]),
+            Promise.race([stderrPromise, stderrDrain.promise]),
+          ]);
+        } finally {
+          stdoutDrain.cancel();
+          stderrDrain.cancel();
+        }
+      })()
+    : await Promise.all([stdoutPromise, stderrPromise]);
 
   const output = (stdout + stderr).trim();
 
   // Check if process was killed by timeout
-  if (exitCode !== 0 && output === "") {
+  if (timedOut) {
     return {
       success: false,
       output: `Hook timed out after ${timeout}ms`,

--- a/src/quality/runner.ts
+++ b/src/quality/runner.ts
@@ -19,6 +19,7 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 
 /** Grace period between SIGTERM and SIGKILL on timeout. */
 const SIGKILL_GRACE_PERIOD_MS = 5_000;
+const STREAM_DRAIN_TIMEOUT_MS = 2_000;
 
 export interface QualityCommandOptions {
   /** Short name used in logs (e.g. "lint", "typecheck", "lintFix"). */
@@ -54,6 +55,21 @@ export interface QualityCommandResult {
 export const _qualityRunnerDeps = {
   spawn: spawn as typeof Bun.spawn,
 };
+
+function createDrainDeadline(deadlineMs: number): { promise: Promise<string>; cancel: () => void } {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const promise = new Promise<string>((resolve) => {
+    timeoutId = setTimeout(() => resolve(""), deadlineMs);
+  });
+  return {
+    promise,
+    cancel: () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    },
+  };
+}
 
 /**
  * Spawn a quality-check command, collect its output, and enforce a hard
@@ -105,11 +121,24 @@ export async function runQualityCommand(opts: QualityCommandOptions): Promise<Qu
 
     // Drain stdout and stderr concurrently with proc.exited to avoid deadlock
     // when process output exceeds the OS pipe buffer (~64 KB).
-    const [exitCode, stdout, stderr] = await Promise.all([
-      proc.exited,
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-    ]);
+    const stdoutPromise = new Response(proc.stdout).text().catch(() => "");
+    const stderrPromise = new Response(proc.stderr).text().catch(() => "");
+    const exitCode = await proc.exited;
+    const [stdout, stderr] = timedOut
+      ? await (async () => {
+          const stdoutDrain = createDrainDeadline(STREAM_DRAIN_TIMEOUT_MS);
+          const stderrDrain = createDrainDeadline(STREAM_DRAIN_TIMEOUT_MS);
+          try {
+            return await Promise.all([
+              Promise.race([stdoutPromise, stdoutDrain.promise]),
+              Promise.race([stderrPromise, stderrDrain.promise]),
+            ]);
+          } finally {
+            stdoutDrain.cancel();
+            stderrDrain.cancel();
+          }
+        })()
+      : await Promise.all([stdoutPromise, stderrPromise]);
 
     clearTimeout(killTimer);
     if (sigkillTimer !== undefined) {

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -143,8 +143,10 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
   const runId = crypto.randomUUID();
 
   const controller = new AbortController();
+  let parentAbortHandler: (() => void) | undefined;
   if (opts?.parentSignal) {
-    opts.parentSignal.addEventListener("abort", () => controller.abort(opts.parentSignal?.reason), { once: true });
+    parentAbortHandler = () => controller.abort(opts.parentSignal?.reason);
+    opts.parentSignal.addEventListener("abort", parentAbortHandler, { once: true });
   }
 
   const configLoader = createConfigLoader(config);
@@ -262,6 +264,9 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
       offReviewAudit();
       offAgentStreamLogging();
       offWatchdog();
+      if (opts?.parentSignal && parentAbortHandler) {
+        opts.parentSignal.removeEventListener("abort", parentAbortHandler);
+      }
       const results = await Promise.allSettled([promptAuditor.flush(), reviewAuditor.flush(), costAggregator.drain()]);
       for (const r of results) {
         if (r.status === "rejected") {

--- a/src/utils/feature-name.ts
+++ b/src/utils/feature-name.ts
@@ -1,0 +1,21 @@
+/**
+ * Validates user-supplied feature names that become directory segments.
+ */
+export function validateFeatureName(feature: string): void {
+  if (!feature || feature.trim() === "") {
+    throw new Error("Feature name must be non-empty");
+  }
+
+  if (feature.includes("/") || feature.includes("\\")) {
+    throw new Error(`Feature name must be a single path segment: ${feature}`);
+  }
+
+  if (feature.includes("..")) {
+    throw new Error(`Feature name cannot contain '..': ${feature}`);
+  }
+
+  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+  if (!validPattern.test(feature)) {
+    throw new Error(`Feature name contains invalid characters: ${feature}`);
+  }
+}

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -244,6 +244,9 @@ export function buildSmartTestCommand(testFiles: string[], baseCommand: string):
     return baseCommand;
   }
 
+  const shellQuote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`;
+  const quotedTestFiles = testFiles.map(shellQuote);
+
   const parts = baseCommand.trim().split(/\s+/);
 
   // Find the last token that looks like a path (contains '/')
@@ -257,14 +260,14 @@ export function buildSmartTestCommand(testFiles: string[], baseCommand: string):
 
   if (lastPathIndex === -1) {
     // No path argument — append test files
-    return `${baseCommand} ${testFiles.join(" ")}`;
+    return `${baseCommand} ${quotedTestFiles.join(" ")}`;
   }
 
   // Replace the last path argument with the specific test files,
   // preserving any flags that appear after the path (e.g. --timeout=60000).
   const beforePath = parts.slice(0, lastPathIndex);
   const afterPath = parts.slice(lastPathIndex + 1);
-  const newParts = [...beforePath, ...testFiles, ...afterPath];
+  const newParts = [...beforePath, ...quotedTestFiles, ...afterPath];
   return newParts.join(" ");
 }
 

--- a/src/verification/strategies/scoped.ts
+++ b/src/verification/strategies/scoped.ts
@@ -32,7 +32,8 @@ function coerceSmartRunner(val: unknown) {
 
 function buildScopedCommand(testFiles: string[], baseCommand: string, testScopedTemplate?: string): string {
   if (testScopedTemplate) {
-    return testScopedTemplate.replace("{{files}}", testFiles.join(" "));
+    const quotedFiles = testFiles.map((file) => `'${file.replaceAll("'", "'\\''")}'`);
+    return testScopedTemplate.replace("{{files}}", quotedFiles.join(" "));
   }
   return _scopedDeps.buildSmartTestCommand(testFiles, baseCommand);
 }

--- a/test/unit/verification/smart-runner.test.ts
+++ b/test/unit/verification/smart-runner.test.ts
@@ -22,7 +22,7 @@ describe("buildSmartTestCommand", () => {
 
   test("replaces last path argument with specific test file", () => {
     const result = buildSmartTestCommand(["test/unit/foo.test.ts"], "bun test test/");
-    expect(result).toBe("bun test test/unit/foo.test.ts");
+    expect(result).toBe("bun test 'test/unit/foo.test.ts'");
   });
 
   test("joins multiple test files with spaces", () => {
@@ -30,12 +30,12 @@ describe("buildSmartTestCommand", () => {
       ["test/unit/foo.test.ts", "test/unit/bar.test.ts"],
       "bun test test/",
     );
-    expect(result).toBe("bun test test/unit/foo.test.ts test/unit/bar.test.ts");
+    expect(result).toBe("bun test 'test/unit/foo.test.ts' 'test/unit/bar.test.ts'");
   });
 
   test("appends test files when command has no path argument", () => {
     const result = buildSmartTestCommand(["test/unit/foo.test.ts"], "bun test");
-    expect(result).toBe("bun test test/unit/foo.test.ts");
+    expect(result).toBe("bun test 'test/unit/foo.test.ts'");
   });
 
   test("replaces last path-like token even when flags precede it", () => {
@@ -43,7 +43,7 @@ describe("buildSmartTestCommand", () => {
       ["test/unit/foo.test.ts"],
       "bun test --coverage test/",
     );
-    expect(result).toBe("bun test --coverage test/unit/foo.test.ts");
+    expect(result).toBe("bun test --coverage 'test/unit/foo.test.ts'");
   });
 
   test("preserves trailing flags after path argument (BUG-043)", () => {
@@ -51,7 +51,7 @@ describe("buildSmartTestCommand", () => {
       ["test/unit/foo.test.ts"],
       "bun test test/ --timeout=60000",
     );
-    expect(result).toBe("bun test test/unit/foo.test.ts --timeout=60000");
+    expect(result).toBe("bun test 'test/unit/foo.test.ts' --timeout=60000");
   });
 
   test("preserves trailing flags with multiple test files", () => {
@@ -59,7 +59,7 @@ describe("buildSmartTestCommand", () => {
       ["test/unit/foo.test.ts", "test/unit/bar.test.ts"],
       "bun test test/ --timeout=60000 --bail",
     );
-    expect(result).toBe("bun test test/unit/foo.test.ts test/unit/bar.test.ts --timeout=60000 --bail");
+    expect(result).toBe("bun test 'test/unit/foo.test.ts' 'test/unit/bar.test.ts' --timeout=60000 --bail");
   });
 });
 


### PR DESCRIPTION
## What

Harden scoped test execution and path handling, plus follow-up fixes for timeout-drain behavior and plan-command error precedence.

## Why

Scoped test paths and feature/path inputs were susceptible to injection/traversal-style misuse, and timeout drain changes introduced output truncation risk on normal runs.

Closes #

## How

- shell-quote mapped test file paths in scoped verification command builders
- add `validateFeatureName()` and apply it in plan/feature resolution boundaries
- restrict acceptance test override values to filenames (not arbitrary paths)
- preserve full subprocess output on normal completion; use bounded stream drain only on timeout paths (quality + hooks)
- clean up runtime parent-abort listener on close
- restore plan command behavior so `.nax` initialization error precedence is preserved

## Testing

- [x] Tests added/updated
- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

Focused tests run locally:
- `bun test test/unit/verification/smart-runner.test.ts test/unit/verification/strategies/scoped.test.ts test/unit/runtime/runtime.test.ts test/unit/acceptance/test-path.test.ts --timeout=120000`
- `bun test test/unit/quality/runner.test.ts --timeout=120000`
- `bun test test/integration/plan/plan.test.ts --timeout=120000`

`bun test` for the entire repository was not run locally in this pass.