### PR TITLE
fix: convert acceptanceGenerateOp to RunOperation for idle watchdog coverage

### DIFF
--- a/.claude/rules/adapter-wiring.md
+++ b/.claude/rules/adapter-wiring.md
@@ -40,8 +40,8 @@ paths:
 
 | Role | Dispatch |
 |:---|:---|
-| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `reviewer-semantic`, `reviewer-adversarial` | `callOp` run-kind |
-| `plan`, `decompose`, `acceptance-gen`, `refine`, `fix-gen`, `auto` | `callOp` complete-kind |
+| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `reviewer-semantic`, `reviewer-adversarial`, `acceptance-gen` | `callOp` run-kind |
+| `plan`, `decompose`, `refine`, `fix-gen`, `auto` | `callOp` complete-kind |
 | `synthesis`, `judge` | `agentManager.completeAs` |
 | `` debate-${string} `` | `agentManager.runAsSession` |
 

--- a/src/operations/acceptance-generate.ts
+++ b/src/operations/acceptance-generate.ts
@@ -3,7 +3,7 @@ import { hasLikelyTestContent, isStubTestContent } from "../acceptance/heuristic
 import { acceptanceGenConfigSelector } from "../config";
 import type { AcceptanceGenConfig } from "../config/selectors";
 import { AcceptancePromptBuilder } from "../prompts";
-import type { CompleteOperation } from "./types";
+import type { RunOperation } from "./types";
 
 export interface AcceptanceGenerateInput {
   featureName: string;
@@ -17,15 +17,15 @@ export interface AcceptanceGenerateOutput {
   testCode: string | null;
 }
 
-export const acceptanceGenerateOp: CompleteOperation<
+export const acceptanceGenerateOp: RunOperation<
   AcceptanceGenerateInput,
   AcceptanceGenerateOutput,
   AcceptanceGenConfig
 > = {
-  kind: "complete",
+  kind: "run",
   name: "acceptance-generate",
   stage: "acceptance",
-  jsonMode: false,
+  session: { role: "acceptance-gen", lifetime: "fresh" },
   config: acceptanceGenConfigSelector,
   model: (_input, ctx) => ctx.config.acceptance.model,
   timeoutMs: (_input, ctx) => ctx.config.execution.sessionTimeoutSeconds * 1000,

--- a/test/integration/acceptance/agent-file-recovery.test.ts
+++ b/test/integration/acceptance/agent-file-recovery.test.ts
@@ -44,9 +44,9 @@ describe("acceptanceGenerateOp.verify — agent-file recovery (bug #774)", () =>
       const testFilePath = join(dir, "test-feature.nax-acceptance.test.ts");
 
       const agentManager = makeMockAgentManager({
-        completeAsFn: async () => {
+        runWithFallbackFn: async (_req) => {
           await Bun.write(testFilePath, REAL_TEST_CODE);
-          return { output: CONVERSATIONAL_OUTPUT, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
+          return { result: { success: true, exitCode: 0, output: CONVERSATIONAL_OUTPUT, rateLimited: false, durationMs: 0, estimatedCostUsd: 0, agentFallbacks: [] }, fallbacks: [] };
         },
       });
       const runtime = makeTestRuntime({ agentManager, workdir: dir });
@@ -78,9 +78,9 @@ describe("acceptanceGenerateOp.verify — agent-file recovery (bug #774)", () =>
       const testFilePath = join(dir, "test-feature.nax-acceptance.test.ts");
 
       const agentManager = makeMockAgentManager({
-        completeAsFn: async () => {
+        runWithFallbackFn: async (_req) => {
           await Bun.write(testFilePath, STUB_TEST_CODE);
-          return { output: CONVERSATIONAL_OUTPUT, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 };
+          return { result: { success: true, exitCode: 0, output: CONVERSATIONAL_OUTPUT, rateLimited: false, durationMs: 0, estimatedCostUsd: 0, agentFallbacks: [] }, fallbacks: [] };
         },
       });
       const runtime = makeTestRuntime({ agentManager, workdir: dir });
@@ -110,7 +110,7 @@ describe("acceptanceGenerateOp.verify — agent-file recovery (bug #774)", () =>
       const testFilePath = join(dir, "test-feature.nax-acceptance.test.ts");
 
       const agentManager = makeMockAgentManager({
-        completeAsFn: async () => ({ output: CONVERSATIONAL_OUTPUT, tokenUsage: { inputTokens: 0, outputTokens: 0 }, estimatedCostUsd: 0 }),
+        runWithFallbackFn: async (_req) => ({ result: { success: true, exitCode: 0, output: CONVERSATIONAL_OUTPUT, rateLimited: false, durationMs: 0, estimatedCostUsd: 0, agentFallbacks: [] }, fallbacks: [] }),
       });
       const runtime = makeTestRuntime({ agentManager, workdir: dir });
       const ctx: CallContext = {

--- a/test/unit/operations/acceptance-generate.test.ts
+++ b/test/unit/operations/acceptance-generate.test.ts
@@ -34,14 +34,14 @@ function makeVerifyCtx(overrides: {
 }
 
 describe("acceptanceGenerateOp shape", () => {
-  test("kind is complete", () => {
-    expect(acceptanceGenerateOp.kind).toBe("complete");
+  test("kind is run", () => {
+    expect(acceptanceGenerateOp.kind).toBe("run");
   });
   test("name is acceptance-generate", () => {
     expect(acceptanceGenerateOp.name).toBe("acceptance-generate");
   });
-  test("jsonMode is false", () => {
-    expect(acceptanceGenerateOp.jsonMode).toBe(false);
+  test("session role is acceptance-gen with fresh lifetime", () => {
+    expect(acceptanceGenerateOp.session).toEqual({ role: "acceptance-gen", lifetime: "fresh" });
   });
   test("stage is acceptance", () => {
     expect(acceptanceGenerateOp.stage).toBe("acceptance");


### PR DESCRIPTION
## Summary

Fixes the watchdog gap described in `docs/findings/acceptance-generator-watchdog-gap.md`.

`acceptanceGenerateOp` was a `CompleteOperation`, which routes through `agentManager.completeAs()` → `adapter.complete()`. This path has no `onActiveCall` / `onStreamActivity` wiring, so the idle watchdog never observes the call. Long-running acceptance generation calls (30+ min observed) could hang indefinitely.

Converting to `RunOperation` routes through `sessionManager.sendPrompt()`, which registers a cancel handler in `watchdogControllerRegistry` and emits stream events to the watchdog bus.

## Changes

| File | Change |
|:-----|:-------|
| `src/operations/acceptance-generate.ts` | `kind:"complete"` → `kind:"run"`, add `session:{role:"acceptance-gen",lifetime:"fresh"}`, remove `jsonMode:false` |
| `.claude/rules/adapter-wiring.md` | Move `acceptance-gen` from complete-kind to run-kind in session role registry |
| `test/unit/operations/acceptance-generate.test.ts` | Update shape tests for new `RunOperation` contract |
| `test/integration/acceptance/agent-file-recovery.test.ts` | Switch mocks from `completeAsFn` → `runWithFallbackFn` |

## Notes

- `acceptanceRefineOp` stays as `CompleteOperation` — quick JSON transformation, low stall risk (per finding doc recommendation)
- `acceptance-gen` session role was already registered in `src/runtime/session-role.ts` — no new registration needed
- All 1250 tests pass (1207 pass, 40 skip, 0 fail)