### PR TITLE
fix: prevent acpx session leaks in agent unit tests

### DIFF
--- a/test/preload.ts
+++ b/test/preload.ts
@@ -3,13 +3,34 @@
  *
  * Redirects global nax state into a temp directory so tests never write to the
  * real ~/.nax, while still starting from a deterministic clean environment.
+ *
+ * Also installs a sentinel on _acpAdapterDeps.createClient that throws if
+ * called without a test-level mock, preventing accidental real acpx session
+ * leaks. To allow real spawns (rare), override the dep in your describe block:
+ *   _acpAdapterDeps.createClient = mock(() => makeClient(makeSession()));
  */
 
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { _acpAdapterDeps } from "../src/agents/acp/adapter";
 
 const isolatedGlobalDir = mkdtempSync(join(tmpdir(), "nax-test-global-"));
 
 process.env.NAX_GLOBAL_CONFIG_DIR = isolatedGlobalDir;
 delete process.env.NAX_RUNS_DIR;
+
+// ─── ACP spawn sentinel ───────────────────────────────────────────────────────
+// Blocks real acpx sessions from being created in tests. Any test that calls
+// code leading to _acpAdapterDeps.createClient without first mocking it will
+// fail fast with a clear message instead of leaking into the acpx session
+// registry. To opt in to a real client, replace this dep in beforeEach/afterEach.
+_acpAdapterDeps.createClient = () => {
+  throw new Error(
+    "[test-preload] _acpAdapterDeps.createClient called without a mock — " +
+      "this would spawn a real acpx session and pollute the session registry. " +
+      "Add to your describe block:\n" +
+      "  beforeEach(() => { _acpAdapterDeps.createClient = mock(() => makeClient(makeSession())); })\n" +
+      "  afterEach(() => { _acpAdapterDeps.createClient = <saved original>; mock.restore(); })",
+  );
+};

--- a/test/unit/agents/manager-dispatch-emission.test.ts
+++ b/test/unit/agents/manager-dispatch-emission.test.ts
@@ -13,8 +13,10 @@
  *   - runAs envelope     → zero DispatchEvents + one OperationCompletedEvent
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { AgentManager } from "../../../src/agents/manager";
+import { _acpAdapterDeps } from "../../../src/agents/acp/adapter";
+import { makeClient, makeSession } from "./acp/adapter.test";
 import type { SessionHandle, TurnResult } from "../../../src/agents/types";
 import { DEFAULT_CONFIG } from "../../../src/config";
 import { NaxConfigSchema } from "../../../src/config/schemas";
@@ -235,41 +237,37 @@ describe("runTrackedSession — dispatch emission", () => {
 // ─── completeAs ─────────────────────────────────────────────────────────────
 
 describe("completeAs — dispatch emission", () => {
+  const origCreateClient = _acpAdapterDeps.createClient;
+  beforeEach(() => {
+    _acpAdapterDeps.createClient = mock(() => makeClient(makeSession()));
+  });
+  afterEach(() => {
+    _acpAdapterDeps.createClient = origCreateClient;
+    mock.restore();
+  });
+
   test("emits exactly one complete event", async () => {
     const bus = new DispatchEventBus();
     const manager = new AgentManager(DEFAULT_CONFIG, undefined, { dispatchEvents: bus });
-    const adapter = manager["_resolveRegistry"]?.();
-    if (!adapter) {
-      // Registry not available; use adapter injection via private field for isolation.
-    }
 
     const received: CompleteDispatchEvent[] = [];
     bus.onDispatch((e) => {
       if (e.kind === "complete") received.push(e);
     });
 
-    try {
-      await manager.completeAs("claude", "summarise this", {
-        modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} },
-        workdir: "/tmp/test",
-        storyId: "US-003",
-        sessionRole: "synthesis",
-        pipelineStage: "complete",
-        timeoutMs: 100,
-      });
-    } catch {
-      // Adapter not wired in unit test — error is expected; emission still happens if adapter path reached.
-    }
+    await manager.completeAs("claude", "summarise this", {
+      modelDef: { provider: "anthropic", model: "claude-sonnet-4-6", env: {} },
+      workdir: "/tmp/test",
+      storyId: "US-003",
+      sessionRole: "synthesis",
+      pipelineStage: "complete",
+      timeoutMs: 100,
+    });
 
-    // completeAs emits on success only — error path emits DispatchErrorEvent.
-    // If completeWithFallback fails before calling adapter, no complete event is emitted.
-    // Assert: at most one complete event (zero if adapter not available).
-    expect(received.length).toBeLessThanOrEqual(1);
-    if (received.length === 1) {
-      expect(received[0]?.kind).toBe("complete");
-      expect(received[0]?.sessionRole).toBe("synthesis");
-      expect(received[0]?.storyId).toBe("US-003");
-    }
+    expect(received).toHaveLength(1);
+    expect(received[0]?.kind).toBe("complete");
+    expect(received[0]?.sessionRole).toBe("synthesis");
+    expect(received[0]?.storyId).toBe("US-003");
   });
 });
 

--- a/test/unit/agents/manager.test.ts
+++ b/test/unit/agents/manager.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { AgentManager } from "../../../src/agents/manager";
 import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import type { NaxConfig } from "../../../src/config";
 import { NaxConfigSchema } from "../../../src/config/schemas";
 import { MiddlewareChain, type AgentMiddleware, type MiddlewareContext } from "../../../src/runtime/agent-middleware";
+import { _acpAdapterDeps } from "../../../src/agents/acp/adapter";
+import { makeClient, makeSession } from "./acp/adapter.test";
 
 function makeManager(fallback: Record<string, unknown> = {}) {
   return new AgentManager({
@@ -205,6 +207,15 @@ describe("AgentManager.nextCandidate (Phase 4)", () => {
 });
 
 describe("AgentManager — middleware envelope", () => {
+  const origCreateClient = _acpAdapterDeps.createClient;
+  beforeEach(() => {
+    _acpAdapterDeps.createClient = mock(() => makeClient(makeSession()));
+  });
+  afterEach(() => {
+    _acpAdapterDeps.createClient = origCreateClient;
+    mock.restore();
+  });
+
   function makeMiddlewareManager(mw?: AgentMiddleware): AgentManager {
     return new AgentManager(DEFAULT_CONFIG, undefined, {
       middleware: mw ? MiddlewareChain.from([mw]) : MiddlewareChain.empty(),


### PR DESCRIPTION
## Summary
- mock ACP client creation in middleware envelope manager tests to prevent real `acpx` session creation
- mock ACP client creation in dispatch-emission completeAs test to avoid spawning real sessions
- add a preload sentinel in test runtime that fails fast when `_acpAdapterDeps.createClient` is called without a test mock

## Why
Several unit tests invoked `AgentManager.completeAs(...)` with `/tmp/test` and no ACP mock, which could create real ACP sessions (e.g. `nax-0872effe*`) in the local registry.

## Validation
- timeout 60 bun test test/unit/agents/manager.test.ts test/unit/agents/manager-dispatch-emission.test.ts --timeout=10000
- timeout 60 bun test test/unit/agents/ --timeout=10000