### PR TITLE
[codex] fix semantic review requote recovery

### DIFF
--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -151,6 +151,12 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "review.semantic.resetRefOnRerun":
     "When true, clears storyGitRef on failed stories during re-run initialization so the ref is re-captured at the next story start. Prevents cross-story diff pollution when multiple stories exhaust all tiers and are re-run. Default: false.",
   "review.semantic.rules": "Custom semantic review rules to enforce",
+  "review.semantic.substantiation":
+    "Semantic evidence substantiation settings. Controls same-session recovery when a blocking finding's verified quote does not match the file on disk.",
+  "review.semantic.substantiation.requote":
+    "When true, semantic review asks the same reviewer session for one verbatim 1-3 line quote before downgrading an unmatched blocking finding.",
+  "review.semantic.substantiation.maxRequotes":
+    "Maximum number of same-session requote turns allowed per semantic review. Keeps worst-case cost bounded when multiple findings need evidence recovery.",
 
   // Plan
   plan: "Planning phase configuration",

--- a/src/config/schemas-review.ts
+++ b/src/config/schemas-review.ts
@@ -28,6 +28,15 @@ const SemanticReviewConfigSchema = z.object({
   resetRefOnRerun: z.boolean().default(false),
   rules: z.array(z.string()).default([]),
   timeoutMs: z.number().int().positive().default(600_000),
+  substantiation: z
+    .object({
+      requote: z.boolean().default(true),
+      maxRequotes: z.number().int().min(0).max(50).default(5),
+    })
+    .default({
+      requote: true,
+      maxRequotes: 5,
+    }),
   /**
    * Optional — undefined means "derive from testFilePatterns + well-known noise dirs".
    * Any user-set value (including []) is returned as-is. (ADR-009 §4.4)

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -224,6 +224,10 @@ export const NaxConfigSchema = z
         resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
+        substantiation: {
+          requote: true,
+          maxRequotes: 5,
+        },
         excludePatterns: [
           ":!test/",
           ":!tests/",

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -1,8 +1,10 @@
 import { reviewConfigSelector } from "../config";
 import type { ReviewConfig } from "../config/selectors";
 import type { Iteration } from "../findings";
+import { getSafeLogger } from "../logger";
 import { ReviewPromptBuilder } from "../prompts";
-import { validateLLMShape } from "../review/semantic-helpers";
+import { checkFindingEvidence, downgradeUnsubstantiatedFinding } from "../review/semantic-evidence";
+import { type LLMFinding, isBlockingSeverity, validateLLMShape } from "../review/semantic-helpers";
 import type { SemanticReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
 import { makeReviewRetryHopBody } from "./_review-retry";
@@ -11,6 +13,7 @@ import type { RunOperation } from "./types";
 export type { SemanticReviewConfig, SemanticStory };
 
 export interface SemanticReviewInput {
+  workdir: string;
   story: SemanticStory;
   semanticConfig: SemanticReviewConfig;
   mode: "embedded" | "ref";
@@ -38,11 +41,30 @@ export interface SemanticReviewOutput {
 }
 
 const FAIL_OPEN: SemanticReviewOutput = { passed: true, findings: [], failOpen: true };
+const SEMANTIC_REQUOTE_RECOVERED_EVENT = "review.semantic.finding.requote_recovered";
+const SEMANTIC_REQUOTE_FAILED_EVENT = "review.semantic.finding.requote_failed";
+const DEFAULT_MAX_REQUOTES = 5;
 
-const semanticReviewHopBody = makeReviewRetryHopBody<SemanticReviewInput>(
+const retrySemanticReviewHopBody = makeReviewRetryHopBody<SemanticReviewInput>(
   (parsed) => validateLLMShape(parsed) !== null,
   "semantic",
 );
+
+const semanticReviewHopBody: RunOperation<SemanticReviewInput, SemanticReviewOutput, ReviewConfig>["hopBody"] = async (
+  initialPrompt,
+  ctx,
+) => {
+  const turn = await retrySemanticReviewHopBody(initialPrompt, ctx);
+  const parsed = validateLLMShape(tryParseLLMJson<Record<string, unknown>>(turn.output));
+  if (!parsed) return turn;
+  const requoted = await requoteBlockingFindings(parsed.findings, ctx);
+  if (!requoted.changed) return turn;
+  return {
+    ...turn,
+    output: JSON.stringify({ passed: parsed.passed, findings: requoted.findings }),
+    estimatedCostUsd: (turn.estimatedCostUsd ?? 0) + requoted.extraCostUsd,
+  };
+};
 
 export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewOutput, ReviewConfig> = {
   kind: "run",
@@ -79,3 +101,89 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
     return FAIL_OPEN;
   },
 };
+
+async function requoteBlockingFindings(
+  findings: LLMFinding[],
+  ctx: { send: (prompt: string) => Promise<{ output: string; estimatedCostUsd?: number }>; input: SemanticReviewInput },
+): Promise<{ findings: LLMFinding[]; changed: boolean; extraCostUsd: number }> {
+  const threshold = ctx.input.blockingThreshold ?? "error";
+  const maxRequotes = ctx.input.semanticConfig.substantiation?.maxRequotes ?? DEFAULT_MAX_REQUOTES;
+  const requoteEnabled = ctx.input.semanticConfig.substantiation?.requote ?? true;
+  if (ctx.input.mode !== "ref" || !requoteEnabled || maxRequotes <= 0) {
+    return { findings, changed: false, extraCostUsd: 0 };
+  }
+  const next = [...findings];
+  let changed = false;
+  let extraCostUsd = 0;
+  let used = 0;
+  for (const [index, finding] of next.entries()) {
+    if (!isBlockingSeverity(finding.severity, threshold)) continue;
+    const initialEvidence = await checkFindingEvidence({ finding, workdir: ctx.input.workdir });
+    if (initialEvidence.status !== "unmatched") continue;
+    if (used >= maxRequotes) break;
+    used += 1;
+
+    const retry = await ctx.send(
+      ReviewPromptBuilder.requoteVerbatim({ finding, previousObserved: initialEvidence.observed ?? "" }),
+    );
+    extraCostUsd += retry.estimatedCostUsd ?? 0;
+    const requote = parseRequoteResponse(retry.output);
+    if (!requote) {
+      next[index] = downgradeUnsubstantiatedFinding({
+        finding,
+        storyId: ctx.input.story.id,
+        event: SEMANTIC_REQUOTE_FAILED_EVENT,
+        ...initialEvidence,
+      });
+      changed = true;
+      continue;
+    }
+
+    const updatedFinding: LLMFinding = {
+      ...finding,
+      verifiedBy: {
+        command: finding.verifiedBy?.command,
+        file: requote.file,
+        line: requote.line,
+        observed: requote.observed,
+      },
+    };
+    const requotedEvidence = await checkFindingEvidence({
+      finding: updatedFinding,
+      workdir: ctx.input.workdir,
+    });
+    if (requotedEvidence.status === "matched") {
+      getSafeLogger()?.info("review", "Recovered semantic finding via same-session requote", {
+        storyId: ctx.input.story.id,
+        event: SEMANTIC_REQUOTE_RECOVERED_EVENT,
+        file: requotedEvidence.file,
+        line: requotedEvidence.line,
+      });
+      next[index] = updatedFinding;
+      changed = true;
+      continue;
+    }
+
+    next[index] = downgradeUnsubstantiatedFinding({
+      finding: updatedFinding,
+      storyId: ctx.input.story.id,
+      event: SEMANTIC_REQUOTE_FAILED_EVENT,
+      file: requotedEvidence.file,
+      line: requotedEvidence.line,
+      observed: requotedEvidence.observed,
+    });
+    changed = true;
+  }
+  return { findings: next, changed, extraCostUsd };
+}
+
+function parseRequoteResponse(output: string): { file: string; line?: number; observed: string } | null {
+  const parsed = tryParseLLMJson<Record<string, unknown>>(output);
+  if (!parsed || typeof parsed.file !== "string" || typeof parsed.observed !== "string") return null;
+  if (parsed.line != null && typeof parsed.line !== "number") return null;
+  return {
+    file: parsed.file,
+    line: typeof parsed.line === "number" ? parsed.line : undefined,
+    observed: parsed.observed,
+  };
+}

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Iteration } from "../../findings";
+import type { LLMFinding } from "../../review/semantic-helpers";
 import type { SemanticReviewConfig, SemanticStory } from "../../review/types";
 import { wrapJsonPrompt } from "../../utils/llm-json";
 import { buildPriorIterationsBlock } from "./prior-iterations-builder";
@@ -191,6 +192,26 @@ Respond with a condensed summary:
 - Keep \`verifiedBy\` for every finding. If \`verifiedBy.observed\` is long, abbreviate it to one line — never drop the field.
 Output ONLY a complete, valid JSON object. It must start with { and end with }.
 Schema: {"passed": boolean, "findings": [{"severity": string, "category": string, "file": string, "line": number, "issue": string, "suggestion": string, "verifiedBy": {"command": string, "file": string, "line": number, "observed": string}}]}`;
+  }
+
+  static requoteVerbatim(opts: { finding: LLMFinding; previousObserved: string }): string {
+    const file = opts.finding.verifiedBy?.file ?? opts.finding.file;
+    const line = opts.finding.verifiedBy?.line ?? opts.finding.line;
+    return `Your previous verifiedBy.observed value did not match the referenced file on disk.
+
+Return ONLY this JSON object:
+{"file":"${file}","line":${line},"observed":"exact 1-3 line quote"}
+
+Finding issue: ${opts.finding.issue}
+Referenced file: ${file}
+Referenced line: ${line}
+Previous observed: ${opts.previousObserved}
+
+Rules:
+- Copy observed verbatim from the file. Do not paraphrase.
+- observed must be a 1-3 line excerpt that proves the claim.
+- If you cannot quote proof exactly, set observed to "".
+- Do not return a full review. Do not include markdown fences or explanation.`;
   }
 }
 

--- a/src/review/semantic-debate.ts
+++ b/src/review/semantic-debate.ts
@@ -241,7 +241,8 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
   }
 
   // Split debate findings by blocking threshold — drop ungrounded error findings first
-  const sanitized = sanitizeRefModeFindings(deduped, diffMode);
+  const debateThreshold = blockingThreshold ?? "error";
+  const sanitized = sanitizeRefModeFindings(deduped, diffMode, debateThreshold);
   const { accepted: debateFindings, dropped: acDropped } = filterByAcQuote(sanitized, story.acceptanceCriteria ?? []);
   if (acDropped.length > 0) {
     logger?.warn("review", "Semantic debate findings dropped: acQuote validation failed", {
@@ -249,7 +250,6 @@ export async function runSemanticDebate(opts: SemanticDebateOptions): Promise<Re
       dropped: acDropped.length,
     });
   }
-  const debateThreshold = blockingThreshold ?? "error";
   const debateBlocking = debateFindings.filter((f) => isBlockingSeverity(f.severity, debateThreshold));
   const debateAdvisory = debateFindings.filter((f) => !isBlockingSeverity(f.severity, debateThreshold));
 

--- a/src/review/semantic-evidence.ts
+++ b/src/review/semantic-evidence.ts
@@ -2,23 +2,21 @@ import { isAbsolute } from "node:path";
 import { getSafeLogger } from "../logger";
 import { validateModulePath } from "../utils/path-security";
 import type { LLMFinding } from "./semantic-helpers";
+import { isBlockingSeverity } from "./semantic-helpers";
 import type { SemanticReviewConfig } from "./types";
 
 const OBSERVED_PREVIEW_CHARS = 160;
 const ISSUE_PREVIEW_CHARS = 200;
 
-/**
- * Stable telemetry marker for the substring-substantiation downgrade.
- * Surfaced on every "Downgraded unsubstantiated semantic error finding" log
- * line so audit / dashboards can measure how often this filter suppresses
- * findings (#826).
- */
 export const SEMANTIC_FINDING_DOWNGRADED_EVENT = "review.semantic.finding.downgraded";
 
-/**
- * Injectable deps so tests can capture log calls without poking the logger
- * singleton. Production code should never override this.
- */
+export interface EvidenceCheckResult {
+  status: "matched" | "unmatched" | "unreadable" | "missing-observed";
+  file: string;
+  line?: number;
+  observed?: string;
+}
+
 export const _evidenceDeps = {
   getLogger: getSafeLogger,
 };
@@ -28,36 +26,51 @@ export async function substantiateSemanticEvidence(
   diffMode: SemanticReviewConfig["diffMode"],
   workdir: string,
   storyId: string,
+  blockingThreshold: "error" | "warning" | "info" = "error",
 ): Promise<LLMFinding[]> {
   if (diffMode !== "ref") return findings;
-  return Promise.all(findings.map((finding) => substantiateFinding(finding, workdir, storyId)));
+  return Promise.all(
+    findings.map(async (finding) => {
+      if (!isBlockingSeverity(finding.severity, blockingThreshold)) return finding;
+      const evidence = await checkFindingEvidence({ finding, workdir });
+      if (evidence.status !== "unmatched") return finding;
+      return downgradeUnsubstantiatedFinding({ finding, storyId, ...evidence });
+    }),
+  );
 }
 
-async function substantiateFinding(finding: LLMFinding, workdir: string, storyId: string): Promise<LLMFinding> {
-  if (finding.severity !== "error") return finding;
+export async function checkFindingEvidence(opts: {
+  finding: LLMFinding;
+  workdir: string;
+}): Promise<EvidenceCheckResult> {
+  const observed = opts.finding.verifiedBy?.observed?.trim();
+  const file = opts.finding.verifiedBy?.file?.trim() || opts.finding.file;
+  const line = opts.finding.verifiedBy?.line ?? opts.finding.line;
+  if (!observed) return { status: "missing-observed", file, line };
+  const contents = await readSafeFile(opts.workdir, file);
+  if (contents === null) return { status: "unreadable", file, line, observed };
+  return normalizedIncludes(contents, observed)
+    ? { status: "matched", file, line, observed }
+    : { status: "unmatched", file, line, observed };
+}
 
-  const observed = finding.verifiedBy?.observed?.trim();
-  if (!observed) return finding;
-
-  const file = finding.verifiedBy?.file?.trim() || finding.file;
-  const contents = await readSafeFile(workdir, file);
-
-  // File genuinely unreadable on this machine — cannot verify or refute.
-  // Preserve the finding rather than silently demoting a real AC violation.
-  if (contents === null) return finding;
-
-  if (normalizedIncludes(contents, observed)) return finding;
-
+export function downgradeUnsubstantiatedFinding(opts: {
+  finding: LLMFinding;
+  storyId: string;
+  event?: string;
+  file?: string;
+  line?: number;
+  observed?: string;
+}): LLMFinding {
   _evidenceDeps.getLogger()?.warn("review", "Downgraded unsubstantiated semantic error finding", {
-    storyId,
-    event: SEMANTIC_FINDING_DOWNGRADED_EVENT,
-    file,
-    line: finding.verifiedBy?.line ?? finding.line,
-    issue: finding.issue?.slice(0, ISSUE_PREVIEW_CHARS),
-    observed: observed.slice(0, OBSERVED_PREVIEW_CHARS),
+    storyId: opts.storyId,
+    event: opts.event ?? SEMANTIC_FINDING_DOWNGRADED_EVENT,
+    file: opts.file ?? opts.finding.verifiedBy?.file ?? opts.finding.file,
+    line: opts.line ?? opts.finding.verifiedBy?.line ?? opts.finding.line,
+    issue: opts.finding.issue?.slice(0, ISSUE_PREVIEW_CHARS),
+    observed: opts.observed?.slice(0, OBSERVED_PREVIEW_CHARS),
   });
-
-  return { ...finding, severity: "unverifiable" };
+  return { ...opts.finding, severity: "unverifiable" };
 }
 
 async function readSafeFile(workdir: string, file: string): Promise<string | null> {
@@ -69,10 +82,6 @@ async function readSafeFile(workdir: string, file: string): Promise<string | nul
       return null;
     }
   }
-
-  // Absolute path outside workdir — the LLM ran its tool against a different
-  // machine or repo root. Attempt a direct read so we can still verify the
-  // evidence rather than skipping substantiation entirely.
   if (isAbsolute(file)) {
     try {
       return await Bun.file(file).text();
@@ -80,7 +89,6 @@ async function readSafeFile(workdir: string, file: string): Promise<string | nul
       return null;
     }
   }
-
   return null;
 }
 

--- a/src/review/semantic-helpers.ts
+++ b/src/review/semantic-helpers.ts
@@ -88,15 +88,19 @@ export const UNVERIFIED_FINDING_PATTERNS = [
 export function sanitizeRefModeFindings(
   findings: LLMFinding[],
   diffMode: SemanticReviewConfig["diffMode"],
+  blockingThreshold: "error" | "warning" | "info" = "error",
 ): LLMFinding[] {
   if (diffMode !== "ref") return findings;
   return findings.map((finding) =>
-    needsDowngradeForMissingEvidence(finding) ? downgradeToUnverifiable(finding) : finding,
+    needsDowngradeForMissingEvidence(finding, blockingThreshold) ? downgradeToUnverifiable(finding) : finding,
   );
 }
 
-function needsDowngradeForMissingEvidence(finding: LLMFinding): boolean {
-  if ((SEVERITY_RANK[finding.severity] ?? 0) < SEVERITY_RANK.error) return false;
+function needsDowngradeForMissingEvidence(
+  finding: LLMFinding,
+  blockingThreshold: "error" | "warning" | "info",
+): boolean {
+  if (!isBlockingSeverity(finding.severity, blockingThreshold)) return false;
   return mentionsUnverifiedSource(finding) || !hasVerifiedEvidence(finding);
 }
 

--- a/src/review/semantic.ts
+++ b/src/review/semantic.ts
@@ -248,7 +248,19 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
 
   // Debate path: when debate is enabled for review stage, use DebateRunner instead of agent.complete()
   const reviewDebateEnabled = naxConfig?.debate?.enabled && naxConfig?.debate?.stages?.review?.enabled;
-  if (reviewDebateEnabled) {
+  const requoteEnabled = semanticConfig.substantiation?.requote ?? true;
+  const skipDebateForRequote = reviewDebateEnabled && diffMode === "ref" && requoteEnabled;
+  if (skipDebateForRequote) {
+    logger?.warn(
+      "review",
+      "Semantic debate skipped: ref-mode requote recovery requires the normal sessioned review path",
+      {
+        storyId: story.id,
+        diffMode,
+      },
+    );
+  }
+  if (reviewDebateEnabled && !skipDebateForRequote) {
     if (!runtime) {
       throw new NaxError("runtime required for debate path — legacy standalone path removed", "DISPATCH_NO_RUNTIME", {
         stage: "review-semantic-debate",
@@ -314,6 +326,7 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
   let opResult: import("../operations/semantic-review").SemanticReviewOutput;
   try {
     opResult = await _semanticDeps.callOp(callCtx, semanticReviewOp, {
+      workdir,
       story,
       semanticConfig,
       mode: diffMode,
@@ -404,10 +417,11 @@ export async function runSemanticReview(opts: RunSemanticReviewOptions): Promise
   const parsed: LLMResponse = { passed: opResult.passed, findings: opResult.findings as LLMFinding[] };
 
   const sanitizedFindings = await substantiateSemanticEvidence(
-    sanitizeRefModeFindings(parsed.findings, diffMode),
+    sanitizeRefModeFindings(parsed.findings, diffMode, blockingThreshold ?? "error"),
     diffMode,
     workdir,
     story.id,
+    blockingThreshold ?? "error",
   );
 
   // Issue #930 Part 1: drop error findings not grounded in AC text

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -60,6 +60,13 @@ export interface SemanticReviewConfig {
   rules: string[];
   /** Timeout in milliseconds for the LLM call (default: 600_000) */
   timeoutMs: number;
+  /** Controls bounded same-session recovery when verifiedBy.observed does not match disk. */
+  substantiation?: {
+    /** When true, ask the same reviewer session for one verbatim requote before downgrade. */
+    requote: boolean;
+    /** Maximum number of requote turns per semantic review. */
+    maxRequotes: number;
+  };
   /**
    * Git pathspec patterns to exclude from the semantic diff.
    * Optional — undefined means "derive from testFilePatterns + well-known noise dirs". (ADR-009 §4.4)

--- a/test/unit/config/semantic-review.test.ts
+++ b/test/unit/config/semantic-review.test.ts
@@ -54,6 +54,7 @@ describe("SemanticReviewConfig", () => {
       resetRefOnRerun: false,
       rules: [],
       timeoutMs: 600_000,
+      substantiation: { requote: true, maxRequotes: 5 },
       excludePatterns: [],
     };
     expect(config.model).toBe("balanced");
@@ -67,6 +68,7 @@ describe("SemanticReviewConfig", () => {
       resetRefOnRerun: false,
       rules: [],
       timeoutMs: 600_000,
+      substantiation: { requote: true, maxRequotes: 5 },
       excludePatterns: [],
     };
     expect(config.model).toEqual({ agent: "codex", model: "gpt-5.4" });
@@ -79,6 +81,7 @@ describe("SemanticReviewConfig", () => {
       resetRefOnRerun: false,
       rules: ["rule1", "rule2"],
       timeoutMs: 600_000,
+      substantiation: { requote: true, maxRequotes: 5 },
       excludePatterns: [],
     };
     expect(Array.isArray(config.rules)).toBe(true);
@@ -95,6 +98,7 @@ describe("SemanticReviewConfig", () => {
         resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
+        substantiation: { requote: true, maxRequotes: 5 },
         excludePatterns: [],
       };
       expect(config.model).toBe(tier);
@@ -123,6 +127,7 @@ describe("ReviewConfig semantic field", () => {
         resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
+        substantiation: { requote: true, maxRequotes: 5 },
         // excludePatterns is now optional (ADR-009): undefined means resolver will derive at runtime
       });
     }
@@ -268,6 +273,7 @@ describe("DEFAULT_CONFIG.review.semantic", () => {
       resetRefOnRerun: false,
       rules: [],
       timeoutMs: 600_000,
+      substantiation: { requote: true, maxRequotes: 5 },
       excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/", ":!.nax/", ":!.nax-pids"],
     });
   });

--- a/test/unit/operations/semantic-review.test.ts
+++ b/test/unit/operations/semantic-review.test.ts
@@ -17,9 +17,11 @@ const SAMPLE_CONFIG = {
   resetRefOnRerun: false,
   rules: [],
   timeoutMs: 600_000,
+  substantiation: { requote: true, maxRequotes: 5 },
 };
 
 const SAMPLE_INPUT: SemanticReviewInput = {
+  workdir: "/tmp/wd",
   story: SAMPLE_STORY,
   semanticConfig: SAMPLE_CONFIG,
   mode: "ref",

--- a/test/unit/prompts/review-builder.test.ts
+++ b/test/unit/prompts/review-builder.test.ts
@@ -29,6 +29,7 @@ const CONFIG_NO_RULES: SemanticReviewConfig = {
   resetRefOnRerun: false,
   rules: [],
   timeoutMs: 60_000,
+  substantiation: { requote: true, maxRequotes: 5 },
   excludePatterns: [],
 };
 
@@ -213,5 +214,31 @@ describe("ReviewPromptBuilder.jsonRetryCondensed()", () => {
     const result = ReviewPromptBuilder.jsonRetryCondensed();
     expect(result).toContain('"verifiedBy"');
     expect(result).toContain('"observed"');
+  });
+});
+
+describe("ReviewPromptBuilder.requoteVerbatim()", () => {
+  test("asks for JSON-only verbatim requote with original finding context", () => {
+    const result = ReviewPromptBuilder.requoteVerbatim({
+      finding: {
+        severity: "error",
+        file: "src/foo.ts",
+        line: 42,
+        issue: "Missing guard",
+        suggestion: "Add guard",
+        verifiedBy: {
+          file: "src/foo.ts",
+          line: 42,
+          observed: "described the issue instead of quoting it",
+        },
+      },
+      previousObserved: "described the issue instead of quoting it",
+    });
+    expect(result).toContain("did not match the referenced file on disk");
+    expect(result).toContain('"file":"src/foo.ts"');
+    expect(result).toContain('"line":42');
+    expect(result).toContain("observed\":\"exact 1-3 line quote");
+    expect(result).toContain('set observed to ""');
+    expect(result).toContain("Do not return a full review");
   });
 });

--- a/test/unit/review/semantic-debate.test.ts
+++ b/test/unit/review/semantic-debate.test.ts
@@ -39,6 +39,7 @@ const SEMANTIC_CONFIG: SemanticReviewConfig = {
   resetRefOnRerun: false,
   rules: [],
   timeoutMs: 30000,
+  substantiation: { requote: true, maxRequotes: 5 },
   excludePatterns: [":!test/", ":!*.test.ts"],
 };
 
@@ -183,6 +184,7 @@ const origSpawn = _diffUtilsDeps.spawn;
 const origIsGitRefValid = _diffUtilsDeps.isGitRefValid;
 const origGetMergeBase = _diffUtilsDeps.getMergeBase;
 const origCreateDebateSession = _semanticDeps.createDebateRunner;
+const origCallOp = _semanticDeps.callOp;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -255,6 +257,7 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     _diffUtilsDeps.isGitRefValid = origIsGitRefValid;
     _diffUtilsDeps.getMergeBase = origGetMergeBase;
     _semanticDeps.createDebateRunner = origCreateDebateSession;
+    _semanticDeps.callOp = origCallOp;
   });
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -294,7 +297,12 @@ describe("runSemanticReview — debate integration (US-004)", () => {
       workdir: WORKDIR,
       storyGitRef: STORY_GIT_REF,
       story: STORY,
-      semanticConfig: { ...SEMANTIC_CONFIG, diffMode: "ref", excludePatterns: undefined },
+      semanticConfig: {
+        ...SEMANTIC_CONFIG,
+        diffMode: "ref",
+        excludePatterns: undefined,
+        substantiation: { requote: false, maxRequotes: 5 },
+      },
       agentManager,
       naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
       runtime,
@@ -358,6 +366,30 @@ describe("runSemanticReview — debate integration (US-004)", () => {
     });
 
     expect(agentManager.complete as ReturnType<typeof mock>).not.toHaveBeenCalled();
+  });
+
+  test("ref mode + requote enabled skips debate and uses the normal sessioned semantic path", async () => {
+    const createDebateMock = mock(() => ({
+      run: mock(async () => DEBATE_MAJORITY_PASS_RESULT),
+    }));
+    _semanticDeps.createDebateRunner = createDebateMock as unknown as typeof _semanticDeps.createDebateRunner;
+    _semanticDeps.callOp = mock(async () => ({ passed: true, findings: [] }));
+
+    const agentManager = makeAgentManager(PROPOSAL_PASS);
+    const runtime = makeMockRuntime({ agentManager });
+
+    await runSemanticReview({
+      workdir: WORKDIR,
+      storyGitRef: STORY_GIT_REF,
+      story: STORY,
+      semanticConfig: { ...SEMANTIC_CONFIG, diffMode: "ref" },
+      agentManager,
+      naxConfig: DEBATE_REVIEW_ENABLED_CONFIG,
+      runtime,
+    });
+
+    expect(createDebateMock).not.toHaveBeenCalled();
+    expect(_semanticDeps.callOp).toHaveBeenCalledTimes(1);
   });
 
   test("AC3: agent.run() called once when debate is disabled — QUARANTINED: DISPATCH_NO_RUNTIME at line 332 despite runtime being defined", async () => {

--- a/test/unit/review/semantic-evidence.test.ts
+++ b/test/unit/review/semantic-evidence.test.ts
@@ -19,7 +19,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { _evidenceDeps, substantiateSemanticEvidence } from "../../../src/review/semantic-evidence";
+import {
+  _evidenceDeps,
+  checkFindingEvidence,
+  substantiateSemanticEvidence,
+} from "../../../src/review/semantic-evidence";
 import type { LLMFinding } from "../../../src/review/semantic-helpers";
 import { makeLogger, type MockLogger } from "../../helpers/mock-logger";
 import { withTempDir } from "../../helpers/temp";
@@ -238,6 +242,26 @@ describe("substantiateSemanticEvidence — ref mode", () => {
       expect(logger.calls.find((c) => c.message.includes("Downgraded"))).toBeUndefined();
     });
   });
+
+  test("downgrades warning finding when blockingThreshold is warning", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "export function foo() {}\n");
+
+      const finding = makeFinding({
+        severity: "warning",
+        verifiedBy: {
+          command: "Read src/foo.ts",
+          file: "src/foo.ts",
+          line: 1,
+          observed: "this prose does not appear in the file",
+        },
+      });
+
+      const result = await substantiateSemanticEvidence([finding], "ref", workdir, STORY_ID, "warning");
+      expect(result[0].severity).toBe("unverifiable");
+    });
+  });
 });
 
 describe("substantiateSemanticEvidence — embedded mode", () => {
@@ -255,6 +279,26 @@ describe("substantiateSemanticEvidence — embedded mode", () => {
 
       expect(result[0].severity).toBe("error");
       expect(logger.calls).toHaveLength(0);
+    });
+  });
+});
+
+describe("checkFindingEvidence()", () => {
+  test("returns unreadable when referenced file cannot be read", async () => {
+    await withTempDir(async (workdir) => {
+      const result = await checkFindingEvidence({
+        finding: makeFinding({
+          verifiedBy: {
+            command: "cat /missing/file.ts",
+            file: "/missing/file.ts",
+            line: 1,
+            observed: "missing snippet",
+          },
+        }),
+        workdir,
+      });
+
+      expect(result.status).toBe("unreadable");
     });
   });
 });

--- a/test/unit/review/semantic-retry-truncation.test.ts
+++ b/test/unit/review/semantic-retry-truncation.test.ts
@@ -30,6 +30,7 @@ const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
   resetRefOnRerun: false,
   rules: [],
   timeoutMs: 60_000,
+  substantiation: { requote: true, maxRequotes: 5 },
   excludePatterns: [":!test/", ":!*.test.ts"],
 };
 
@@ -149,6 +150,7 @@ describe("semanticReviewOp.hopBody — truncation-detected condensed retry", () 
     await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
       input: {
+        workdir: "/tmp/wd",
         story: STORY,
         semanticConfig: DEFAULT_SEMANTIC_CONFIG,
         mode: "embedded",
@@ -174,6 +176,7 @@ describe("semanticReviewOp.hopBody — truncation-detected condensed retry", () 
     await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
       input: {
+        workdir: "/tmp/wd",
         story: STORY,
         semanticConfig: DEFAULT_SEMANTIC_CONFIG,
         mode: "embedded",
@@ -198,6 +201,7 @@ describe("semanticReviewOp.hopBody — truncation-detected condensed retry", () 
     await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
       input: {
+        workdir: "/tmp/wd",
         story: STORY,
         semanticConfig: DEFAULT_SEMANTIC_CONFIG,
         mode: "embedded",
@@ -225,6 +229,7 @@ describe("semanticReviewOp.hopBody — truncation-detected condensed retry", () 
     const result = await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
       input: {
+        workdir: "/tmp/wd",
         story: STORY,
         semanticConfig: DEFAULT_SEMANTIC_CONFIG,
         mode: "embedded",
@@ -248,6 +253,7 @@ describe("semanticReviewOp.hopBody — truncation logging", () => {
     await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
       input: {
+        workdir: "/tmp/wd",
         story: STORY,
         semanticConfig: DEFAULT_SEMANTIC_CONFIG,
         mode: "embedded",
@@ -273,6 +279,7 @@ describe("semanticReviewOp.hopBody — truncation logging", () => {
     await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
       input: {
+        workdir: "/tmp/wd",
         story: STORY,
         semanticConfig: DEFAULT_SEMANTIC_CONFIG,
         mode: "embedded",
@@ -311,7 +318,7 @@ describe("semanticReviewOp.hopBody — Bug 4 regression: parser-first, length is
     const { semanticReviewOp } = await import("../../../src/operations/semantic-review");
     const result = await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
-      input: { story: STORY, semanticConfig: DEFAULT_SEMANTIC_CONFIG, mode: "embedded" },
+      input: { workdir: "/tmp/wd", story: STORY, semanticConfig: DEFAULT_SEMANTIC_CONFIG, mode: "embedded" },
     } as any);
 
     // Parser accepted the response — no retry should fire.
@@ -332,7 +339,7 @@ describe("semanticReviewOp.hopBody — Bug 4 regression: parser-first, length is
     const { semanticReviewOp } = await import("../../../src/operations/semantic-review");
     await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
-      input: { story: STORY, semanticConfig: DEFAULT_SEMANTIC_CONFIG, mode: "embedded" },
+      input: { workdir: "/tmp/wd", story: STORY, semanticConfig: DEFAULT_SEMANTIC_CONFIG, mode: "embedded" },
     } as any);
 
     expect(sendCalls).toHaveLength(2);
@@ -354,7 +361,7 @@ describe("semanticReviewOp.hopBody — Bug 4 regression: parser-first, length is
     const { semanticReviewOp } = await import("../../../src/operations/semantic-review");
     await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
-      input: { story: STORY, semanticConfig: DEFAULT_SEMANTIC_CONFIG, mode: "embedded" },
+      input: { workdir: "/tmp/wd", story: STORY, semanticConfig: DEFAULT_SEMANTIC_CONFIG, mode: "embedded" },
     } as any);
 
     expect(sendCalls).toHaveLength(2);

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import * as loggerModule from "../../../src/logger";
 import { _semanticDeps, runSemanticReview } from "../../../src/review/semantic";
 import { _diffUtilsDeps } from "../../../src/review/diff-utils";
@@ -14,6 +16,7 @@ import type { SemanticStory } from "../../../src/review/semantic";
 import type { SemanticReviewConfig } from "../../../src/review/types";
 import { makeMockAgentManager } from "../../helpers";
 import { makeMockRuntime } from "../../helpers/runtime";
+import { withTempDir } from "../../helpers/temp";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -32,6 +35,7 @@ const DEFAULT_SEMANTIC_CONFIG: SemanticReviewConfig = {
   resetRefOnRerun: false,
   rules: [],
   timeoutMs: 60_000,
+  substantiation: { requote: true, maxRequotes: 5 },
   excludePatterns: [":!test/", ":!*.test.ts"],
 };
 
@@ -371,6 +375,7 @@ describe("semanticReviewOp.hopBody — retry behaviour", () => {
     const result = await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
       input: {
+        workdir: "/tmp/wd",
         story: STORY,
         semanticConfig: DEFAULT_SEMANTIC_CONFIG,
         mode: "embedded",
@@ -392,6 +397,7 @@ describe("semanticReviewOp.hopBody — retry behaviour", () => {
     const result = await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
       input: {
+        workdir: "/tmp/wd",
         story: STORY,
         semanticConfig: DEFAULT_SEMANTIC_CONFIG,
         mode: "embedded",
@@ -418,6 +424,7 @@ describe("semanticReviewOp.hopBody — retry behaviour", () => {
     const result = await semanticReviewOp.hopBody!("initial prompt", {
       send: mockSend,
       input: {
+        workdir: "/tmp/wd",
         story: STORY,
         semanticConfig: DEFAULT_SEMANTIC_CONFIG,
         mode: "embedded",
@@ -425,5 +432,111 @@ describe("semanticReviewOp.hopBody — retry behaviour", () => {
     } as any);
 
     expect(result.estimatedCostUsd).toBe(1.0);
+  });
+});
+
+describe("semanticReviewOp.hopBody — same-session requote", () => {
+  test("recovers a blocking finding when requote returns a verbatim matching excerpt", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "export function foo() {\n  return 42;\n}\n");
+
+      const initial = JSON.stringify({
+        passed: false,
+        findings: [
+          {
+            severity: "error",
+            file: "src/foo.ts",
+            line: 1,
+            issue: "Missing proof",
+            suggestion: "Quote the file",
+            verifiedBy: {
+              file: "src/foo.ts",
+              line: 1,
+              observed: "this description does not match disk",
+            },
+          },
+        ],
+      });
+      const requote = JSON.stringify({
+        file: "src/foo.ts",
+        line: 1,
+        observed: "export function foo() {\n  return 42;\n}",
+      });
+      let callCount = 0;
+      const mockSend = mock(async () => {
+        callCount += 1;
+        return {
+          output: callCount === 1 ? initial : requote,
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          internalRoundTrips: 0,
+        };
+      });
+
+      const { semanticReviewOp } = await import("../../../src/operations/semantic-review");
+      const result = await semanticReviewOp.hopBody!("initial prompt", {
+        send: mockSend,
+        input: {
+          workdir,
+          story: STORY,
+          semanticConfig: { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+          mode: "ref",
+        },
+      } as any);
+
+      const parsed = JSON.parse(result.output);
+      expect(callCount).toBe(2);
+      expect(parsed.findings[0].severity).toBe("error");
+      expect(parsed.findings[0].verifiedBy.observed).toContain("return 42");
+    });
+  });
+
+  test("downgrades when requote response is invalid JSON", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "export function foo() {}\n");
+
+      const initial = JSON.stringify({
+        passed: false,
+        findings: [
+          {
+            severity: "error",
+            file: "src/foo.ts",
+            line: 1,
+            issue: "Missing proof",
+            suggestion: "Quote the file",
+            verifiedBy: {
+              file: "src/foo.ts",
+              line: 1,
+              observed: "this description does not match disk",
+            },
+          },
+        ],
+      });
+      let callCount = 0;
+      const mockSend = mock(async () => {
+        callCount += 1;
+        return {
+          output: callCount === 1 ? initial : "not json",
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          internalRoundTrips: 0,
+        };
+      });
+
+      const { semanticReviewOp } = await import("../../../src/operations/semantic-review");
+      const result = await semanticReviewOp.hopBody!("initial prompt", {
+        send: mockSend,
+        input: {
+          workdir,
+          story: STORY,
+          semanticConfig: { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+          mode: "ref",
+        },
+      } as any);
+
+      const parsed = JSON.parse(result.output);
+      expect(callCount).toBe(2);
+      expect(parsed.findings[0].severity).toBe("unverifiable");
+    });
   });
 });


### PR DESCRIPTION
## Summary
Fix semantic review evidence substantiation so blocking ref-mode findings get one bounded same-session requote before being downgraded to `unverifiable`.

Close #828 

## What Changed
- added `review.semantic.substantiation.{requote,maxRequotes}` config defaults and descriptions
- added a `ReviewPromptBuilder.requoteVerbatim()` follow-up prompt for JSON-only verbatim requotes
- moved evidence matching into reusable helpers and made substantiation threshold-aware
- updated `semanticReviewOp` to keep the reviewer session open, retry JSON if needed, then requote unmatched blocking findings before returning parsed output
- made ref-mode semantic sanitization respect `review.blockingThreshold`
- skipped review debate when ref-mode requote recovery is enabled, because only the normal sessioned semantic path can guarantee same-session recovery today
- added regression tests for requote recovery, threshold behavior, and debate bypass behavior

## Why
Semantic review was incorrectly downgrading real blocking findings when the reviewer supplied prose or a drifted excerpt in `verifiedBy.observed` even though the claim was otherwise valid. The fix keeps the same reviewer session alive long enough to ask for one exact quote before falling back to the existing downgrade path.

## Impact
- improves semantic review correctness for ref-mode blocking findings
- preserves existing downgrade behavior when the reviewer still cannot provide matching evidence
- keeps cost bounded with an explicit per-review requote cap

## Root Cause
The original substantiation step happened after the semantic review session was already closed, so there was no way to recover an unmatched `verifiedBy.observed` value from the same reviewer context.

## Validation
- `bun run test`
- `bun run typecheck`
- `bun run lint`