### PR TITLE
fix(curator): resolve -p by project name and surface gc no-op diagnostics

### DIFF
--- a/src/commands/common.ts
+++ b/src/commands/common.ts
@@ -7,6 +7,7 @@
 import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { MAX_DIRECTORY_DEPTH } from "../config/path-security";
+import { globalConfigDir } from "../config/paths";
 import { NaxError } from "../errors";
 import { validateFeatureName } from "../utils/feature-name";
 
@@ -141,6 +142,68 @@ export function resolveProject(options: ResolveProjectOptions = {}): ResolvedPro
     configPath,
     featureDir,
   };
+}
+
+/**
+ * Resolves a project by name from the global identity registry (~/.nax/<name>/.identity).
+ * Falls back to path-based resolution when the value looks like a filesystem path.
+ *
+ * Resolution order:
+ * 1. Try path-based resolution (existing behaviour — handles absolute, relative, and CWD walk-up)
+ * 2. If the path doesn't exist on disk, try name-based lookup via the identity registry
+ *
+ * @param options - Resolution options (dir may be a name or a path, feature optional)
+ * @returns Resolved project paths
+ * @throws {NaxError} If project cannot be resolved by either strategy
+ */
+export async function resolveProjectAsync(options: ResolveProjectOptions = {}): Promise<ResolvedProject> {
+  const { dir } = options;
+
+  if (!dir) {
+    return resolveProject(options);
+  }
+
+  // Path wins when it exists on disk — no ambiguity.
+  if (existsSync(resolve(dir))) {
+    return resolveProject(options);
+  }
+
+  // Only attempt name lookup when `dir` is a plain name (no path separators).
+  // If it contains separators it was meant as a path; let resolveProject throw the normal error.
+  const isPlainName = !dir.includes("/") && !dir.includes("\\");
+  if (isPlainName) {
+    const registryIdentityPath = join(globalConfigDir(), dir, ".identity");
+    const identityFile = Bun.file(registryIdentityPath);
+    if (await identityFile.exists()) {
+      try {
+        const identity = (await identityFile.json()) as Record<string, unknown>;
+        if (typeof identity.workdir === "string") {
+          return resolveProject({ ...options, dir: identity.workdir });
+        }
+      } catch {
+        // Corrupt identity file — fall through to the informative error below
+      }
+    }
+    throw new NaxError(
+      `No project found for name or path: "${dir}"\nChecked filesystem path: ${resolve(dir)}\nChecked identity registry: ${registryIdentityPath}\nTip: use an absolute or relative path, or run "nax init" in your project directory first.`,
+      "PROJECT_NOT_FOUND",
+      { dir, resolvedPath: resolve(dir), registryIdentityPath },
+    );
+  }
+
+  try {
+    return resolveProject(options);
+  } catch (err) {
+    // realpathSync throws a raw ENOENT when the path doesn't exist — wrap it as a NaxError
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new NaxError(`Path does not exist: ${resolve(dir)}`, "PROJECT_NOT_FOUND", {
+        dir,
+        resolvedPath: resolve(dir),
+        cause: err,
+      });
+    }
+    throw err;
+  }
 }
 
 /**

--- a/src/commands/curator.ts
+++ b/src/commands/curator.ts
@@ -16,7 +16,7 @@ import { renderProposals } from "../plugins/builtin/curator/render";
 import type { Observation } from "../plugins/builtin/curator/types";
 import { curatorRollupPath, globalOutputDir, projectOutputDir } from "../runtime/paths";
 import type { ResolveProjectOptions, ResolvedProject } from "./common";
-import { resolveProject } from "./common";
+import { resolveProjectAsync } from "./common";
 
 // ─── Interfaces ───────────────────────────────────────────────────────────────
 
@@ -43,7 +43,7 @@ export interface CuratorGcOptions {
 // ─── Injectable deps ──────────────────────────────────────────────────────────
 
 export const _curatorCmdDeps = {
-  resolveProject: (opts?: ResolveProjectOptions): ResolvedProject => resolveProject(opts),
+  resolveProject: (opts?: ResolveProjectOptions): Promise<ResolvedProject> => resolveProjectAsync(opts),
   loadConfig: (dir?: string): Promise<NaxConfig> => loadConfig(dir),
   projectOutputDir: (key: string, override?: string): string => projectOutputDir(key, override),
   globalOutputDir: (): string => globalOutputDir(),
@@ -183,7 +183,7 @@ function parseCheckedProposals(markdown: string): ParsedProposal[] {
 // ─── curatorStatus ────────────────────────────────────────────────────────────
 
 export async function curatorStatus(options: CuratorStatusOptions): Promise<void> {
-  const resolved = _curatorCmdDeps.resolveProject({ dir: options.project });
+  const resolved = await _curatorCmdDeps.resolveProject({ dir: options.project });
   const config = await _curatorCmdDeps.loadConfig(resolved.projectDir);
   const projectKey = getProjectKey(config, resolved.projectDir);
   const outputDir = _curatorCmdDeps.projectOutputDir(projectKey, config.outputDir as string | undefined);
@@ -237,7 +237,7 @@ export async function curatorStatus(options: CuratorStatusOptions): Promise<void
 // ─── curatorCommit ────────────────────────────────────────────────────────────
 
 export async function curatorCommit(options: CuratorCommitOptions): Promise<void> {
-  const resolved = _curatorCmdDeps.resolveProject({ dir: options.project });
+  const resolved = await _curatorCmdDeps.resolveProject({ dir: options.project });
   const config = await _curatorCmdDeps.loadConfig(resolved.projectDir);
   const projectKey = getProjectKey(config, resolved.projectDir);
   const outputDir = _curatorCmdDeps.projectOutputDir(projectKey, config.outputDir as string | undefined);
@@ -364,7 +364,7 @@ function buildAddContent(proposal: ParsedProposal): string {
 // ─── curatorDryrun ────────────────────────────────────────────────────────────
 
 export async function curatorDryrun(options: CuratorDryrunOptions): Promise<void> {
-  const resolved = _curatorCmdDeps.resolveProject({ dir: options.project });
+  const resolved = await _curatorCmdDeps.resolveProject({ dir: options.project });
   const config = await _curatorCmdDeps.loadConfig(resolved.projectDir);
   const projectKey = getProjectKey(config, resolved.projectDir);
   const outputDir = _curatorCmdDeps.projectOutputDir(projectKey, config.outputDir as string | undefined);
@@ -398,13 +398,14 @@ export async function curatorDryrun(options: CuratorDryrunOptions): Promise<void
 const DEFAULT_KEEP = 50;
 
 export async function curatorGc(options: CuratorGcOptions): Promise<void> {
-  const resolved = _curatorCmdDeps.resolveProject({ dir: options.project });
+  const resolved = await _curatorCmdDeps.resolveProject({ dir: options.project });
   const config = await _curatorCmdDeps.loadConfig(resolved.projectDir);
   const gDir = _curatorCmdDeps.globalOutputDir();
   const rollupPath = _curatorCmdDeps.curatorRollupPath(gDir, config.curator?.rollupPath as string | undefined);
 
   const rollupText = await _curatorCmdDeps.readFile(rollupPath).catch(() => null);
   if (rollupText === null) {
+    console.log(`[gc] No rollup file found at ${rollupPath}. Nothing to prune.`);
     return;
   }
 
@@ -426,6 +427,7 @@ export async function curatorGc(options: CuratorGcOptions): Promise<void> {
     .map(([runId]) => runId);
 
   if (uniqueRunIds.length <= keep) {
+    console.log(`[gc] ${uniqueRunIds.length} unique run(s) in rollup — at or below keep=${keep}. Nothing to prune.`);
     return;
   }
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,7 +2,7 @@
  * Common utilities for CLI commands
  */
 
-export { resolveProject, type ResolveProjectOptions, type ResolvedProject } from "./common";
+export { resolveProject, resolveProjectAsync, type ResolveProjectOptions, type ResolvedProject } from "./common";
 export {
   curatorStatus,
   curatorCommit,

--- a/test/unit/commands/common.test.ts
+++ b/test/unit/commands/common.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { resolveProject } from "../../../src/commands/common";
+import { resolveProject, resolveProjectAsync } from "../../../src/commands/common";
 import { NaxError } from "../../../src/errors";
 import { makeTempDir } from "../../helpers/temp";
 
@@ -317,5 +317,113 @@ describe("resolveProject", () => {
         expect(naxError.context?.availableFeatures).toEqual(["existing-feature"]);
       }
     });
+  });
+});
+
+describe("resolveProjectAsync", () => {
+  let testDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    const rawTestDir = makeTempDir("nax-test-async-");
+    testDir = realpathSync(rawTestDir);
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (testDir) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  test("resolves by filesystem path when path exists", async () => {
+    const naxDir = join(testDir, ".nax");
+    mkdirSync(naxDir, { recursive: true });
+    writeFileSync(join(naxDir, "config.json"), "{}");
+
+    const result = await resolveProjectAsync({ dir: testDir });
+    expect(result.projectDir).toBe(testDir);
+  });
+
+  test("resolves by project name via identity registry", async () => {
+    // Set up real project directory with .nax/config.json
+    const projectDir = join(testDir, "my-project");
+    const naxDir = join(projectDir, ".nax");
+    mkdirSync(naxDir, { recursive: true });
+    writeFileSync(join(naxDir, "config.json"), "{}");
+
+    // Set up identity registry entry pointing to it
+    // globalConfigDir() is redirected to a temp dir in tests via preload.ts
+    const { globalConfigDir } = await import("../../../src/config/paths");
+    const registryDir = join(globalConfigDir(), "my-project");
+    mkdirSync(registryDir, { recursive: true });
+    writeFileSync(join(registryDir, ".identity"), JSON.stringify({ workdir: projectDir, name: "my-project", createdAt: "", lastSeen: "", remoteUrl: null }));
+
+    const result = await resolveProjectAsync({ dir: "my-project" });
+    expect(result.projectDir).toBe(projectDir);
+  });
+
+  test("path wins over name lookup when path exists", async () => {
+    // Create a directory that would match by path
+    const naxDir = join(testDir, ".nax");
+    mkdirSync(naxDir, { recursive: true });
+    writeFileSync(join(naxDir, "config.json"), "{}");
+
+    // Change to parent so testDir is a relative path component
+    process.chdir(join(testDir, ".."));
+    const result = await resolveProjectAsync({ dir: testDir });
+    expect(result.projectDir).toBe(testDir);
+  });
+
+  test("throws PROJECT_NOT_FOUND with informative message when name not in registry", async () => {
+    process.chdir(testDir);
+    try {
+      await resolveProjectAsync({ dir: "nonexistent-project" });
+      expect.unreachable("Should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(NaxError);
+      const naxErr = err as NaxError;
+      expect(naxErr.code).toBe("PROJECT_NOT_FOUND");
+      expect(naxErr.message).toContain("nonexistent-project");
+      expect(naxErr.message).toContain("identity registry");
+    }
+  });
+
+  test("falls through to resolveProject error for paths with separators that don't exist", async () => {
+    try {
+      await resolveProjectAsync({ dir: "some/nonexistent/path" });
+      expect.unreachable("Should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(NaxError);
+      // Should be the NAX_DIR_NOT_FOUND error from resolveProject, not PROJECT_NOT_FOUND
+      const naxErr = err as NaxError;
+      expect(["NAX_DIR_NOT_FOUND", "PROJECT_NOT_FOUND"]).toContain(naxErr.code);
+    }
+  });
+
+  test("falls back to CWD walk-up when no dir provided", async () => {
+    const naxDir = join(testDir, ".nax");
+    mkdirSync(naxDir, { recursive: true });
+    writeFileSync(join(naxDir, "config.json"), "{}");
+    process.chdir(testDir);
+
+    const result = await resolveProjectAsync();
+    expect(result.projectDir).toBe(testDir);
+  });
+
+  test("corrupt identity file falls through to informative error", async () => {
+    const { globalConfigDir } = await import("../../../src/config/paths");
+    const registryDir = join(globalConfigDir(), "corrupt-project");
+    mkdirSync(registryDir, { recursive: true });
+    writeFileSync(join(registryDir, ".identity"), "not valid json{{{");
+
+    try {
+      await resolveProjectAsync({ dir: "corrupt-project" });
+      expect.unreachable("Should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(NaxError);
+      expect((err as NaxError).code).toBe("PROJECT_NOT_FOUND");
+    }
   });
 });


### PR DESCRIPTION
## Summary

- `nax curator <subcmd> -p <name>` now resolves `<name>` against the global identity registry (`~/.nax/<name>/.identity`) when no path with that name exists on disk — matching the UX of `nax runs --project <name>`.
- Path-based resolution still wins when the path exists, so existing usages are unaffected.
- Raw `ENOENT` from `realpathSync` is now wrapped in a `NaxError` with a clean message instead of leaking the Node.js stack.
- `nax curator gc` now logs an informative message when there's nothing to prune (rollup missing, or unique-runIds <= keep) instead of returning silently.

## Why

User ran `nax curator gc -p nax` expecting name lookup, got `ENOENT: lstat '/.../nax/nax'`. Separately, `nax curator gc` (no args) silently exited with no output, leaving the user unsure whether GC actually ran. Both issues addressed in one branch since both surface in the curator `-p` flow.

## Implementation

New async `resolveProjectAsync()` wraps the existing sync `resolveProject()`:
1. No `dir` -> CWD walk-up (existing behaviour)
2. Path exists on disk -> path resolution (existing behaviour, wins over names)
3. Plain name (no `/` or `\`) + path missing -> identity registry lookup -> resolve to `workdir`
4. Path with separators that doesn't exist -> wrapped `ENOENT` as `NaxError`

Only curator commands switched to the async variant via `_curatorCmdDeps` injection point — no blast radius on the other 30+ `resolveProject` callers.

## Test plan

- [x] `timeout 30 bun-test test/unit/commands/common.test.ts` — 24 pass (7 new tests for `resolveProjectAsync`)
- [x] `timeout 60 bun-test test/unit/commands/` — 120 pass / 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Manual: `nax curator gc -p nax` from a different directory -> resolves via registry, prunes (or reports nothing to prune)
- [ ] Manual: `nax curator gc -p ./nonexistent` -> clean `NaxError` instead of raw ENOENT
- [ ] Manual: `nax curator gc` with < keep runs -> prints "Nothing to prune" instead of silent exit
