### PR TITLE
fix(#736): Patches A+B — rich prior-iterations block + run-scoped orchestrator maps

### DIFF
--- a/docs/adr/ADR-022-fix-strategy-and-cycle.md
+++ b/docs/adr/ADR-022-fix-strategy-and-cycle.md
@@ -8,6 +8,8 @@
 **Related:** ADR-006 (Acceptance Retry Loop Restructure — superseded in part by phase 4 of this ADR)
 
 > **Implementation status (2026-05-04):** All 8 phases shipped. `acceptance.fix.cycleV2` and `quality.autofix.cycleV2` flags skipped — both cycles cut over directly. `runAgentRectification` re-exports `runAgentRectificationV2` from `src/pipeline/stages/autofix-cycle.ts`. Acceptance enters `runFixCycle` from `runAcceptanceLoop` after the stub-regen prelude. Carry-forward via `buildPriorIterationsBlock` is wired into review-builder, adversarial-review-builder, and acceptance-loop.
+>
+> **Amendment (2026-05-08, issue #736 Patches A + B):** The `buildPriorIterationsBlock` output was extended from a count-summary table to verdict-bound finding text (message, file:line, suggestion, acQuote) with a mandatory `addressed / still-blocking / never-an-issue` verdict template and a 6000-char token guard. Concurrently, the prior-iterations lifetime was moved from `PipelineContext` (attempt-scoped) to per-story maps on the `ReviewOrchestrator` singleton (run-scoped), so carry-forward survives "agent gave up" + fresh context recreation within a run. See [docs/findings/2026-05-08-issue-736-3.1-followup-plan.md](../findings/2026-05-08-issue-736-3.1-followup-plan.md).
 
 ---
 
@@ -269,15 +271,23 @@ Mirrors `quality.autofix.{maxAttempts, maxTotalAttempts}` ([autofix-agent.ts:96-
 
 ### 8. Shared `buildPriorIterationsBlock` prompt helper
 
-Verdict-first table consumed by all rectifier-class prompts:
+Verdict-first block consumed by all rectifier-class prompts. **Amended 2026-05-08** (issue #736 Patch A): the original count-summary table was replaced with rich finding text so reviewers can judge whether prior findings were addressed. A 6000-char token guard collapses rounds older than the last two to one-liners when the block would overflow.
 
 ```
 ## Prior Iterations — verdict required before new analysis
 
-| # | Strategies run                                | Files touched                  | Outcome    | Findings before → after   |
-|---|-----------------------------------------------|--------------------------------|------------|---------------------------|
-| 1 | acceptance-test-fix                           | .nax-acceptance.test.ts        | unchanged  | 1 [stdout-capture] → 1 [stdout-capture] |
-| 2 | acceptance-test-fix                           | .nax-acceptance.test.ts        | unchanged  | 1 [stdout-capture] → 1 [stdout-capture] |
+### Round 1 — outcome: unchanged (0 → 1)
+Findings flagged previously:
+1. [error / test-gap] src/handler.ts:42
+   Message: AC8 mock never invoked in test
+   Suggestion: Add a spy on the mock and assert it was called
+   acQuote: "AC8: mock adapter must be invoked for every call"
+
+**Required:** before adding any new finding, classify each of the 1 prior finding(s) above as one of:
+- `addressed` — the current diff resolves it (cite the diff line that fixes it in your `message` field)
+- `still-blocking` — the implementer did not fix it; re-flag it with the IDENTICAL `file`, `line`, `category`, and substantively the same `message` wording
+- `never-an-issue` — your prior judgment was wrong; explain why in `message` and emit severity `"info"`
+Then surface any genuinely new findings.
 
 When outcome is "unchanged", the prior hypothesis is FALSIFIED — the change did
 not affect what was tested. Choose a different category before producing a new
@@ -352,7 +362,7 @@ Bail events emit `"cycle exited"` with the same shape plus `reason` and (when ap
 
 ## Audit logging
 
-Cycle iteration history stays **ephemeral by default** — `Iteration<F>[]` lives in memory in the cycle's owning context, used for prompt carry-forward via `buildPriorIterationsBlock` and discarded at end of run.
+Cycle iteration history stays **ephemeral by default** — `Iteration<F>[]` lives in memory and is discarded at end of run. **Amended 2026-05-08 (Patch B):** for the review subsystem, history is held in per-story maps on the `ReviewOrchestrator` singleton (`priorAdversarialByStory`, `priorSemanticByStory`) rather than on `PipelineContext`, so it survives "agent gave up" + fresh context recreation within the same run. Maps are cleared per-story on pass/terminal-fail via `clearStory(storyId)`, and fully reset at run end via `reset()`.
 
 Forensic post-mortem persistence (writing iteration history to `.nax/cycle-history/<cycleId>.jsonl` for after-the-fact debugging) is deferred to the broader audit redesign tracked in [docs/findings/2026-04-30-context-curator-design.md](../findings/2026-04-30-context-curator-design.md). The shape is already well-defined here; the persistence policy and storage location belong with the broader audit work.
 

--- a/src/execution/iteration-runner.ts
+++ b/src/execution/iteration-runner.ts
@@ -15,6 +15,7 @@ import { defaultPipeline } from "../pipeline/stages";
 import type { PipelineContext } from "../pipeline/types";
 import { markStoryFailed, savePRD } from "../prd";
 import type { PRD } from "../prd/types";
+import { reviewOrchestrator } from "../review/orchestrator";
 import { errorMessage } from "../utils/errors";
 import { captureGitRef, isGitRefValid } from "../utils/git";
 import { prepareWorktreeDependencies } from "../worktree/dependencies";
@@ -127,6 +128,7 @@ export async function runIteration(
       });
     } catch (error) {
       markStoryFailed(prd, story.id, "dependency-prep", "worktree-dependencies", ctx.statusWriter);
+      reviewOrchestrator.clearStory(story.id);
       await savePRD(prd, ctx.prdPath);
       try {
         await _iterationRunnerDeps.worktreeManager.remove(ctx.workdir, story.id);

--- a/src/execution/parallel-coordinator.ts
+++ b/src/execution/parallel-coordinator.ts
@@ -16,6 +16,7 @@ import type { PluginRegistry } from "../plugins/registry";
 import type { PRD, UserStory } from "../prd";
 import { markStoryFailed, markStoryPassed, savePRD } from "../prd";
 import type { PostRunStatusWriter } from "../prd";
+import { reviewOrchestrator } from "../review/orchestrator";
 import { errorMessage } from "../utils/errors";
 import { WorktreeManager } from "../worktree/manager";
 import { MergeEngine, type StoryDependencies } from "../worktree/merge";
@@ -179,6 +180,7 @@ export async function executeParallel(
         }
       } catch (error) {
         markStoryFailed(currentPrd, story.id, undefined, undefined, statusWriter);
+        reviewOrchestrator.clearStory(story.id);
         logger?.error("parallel", "Failed to create worktree", {
           storyId: story.id,
           error: errorMessage(error),
@@ -235,6 +237,7 @@ export async function executeParallel(
         if (mergeResult.success) {
           // Update PRD: mark story as passed
           markStoryPassed(currentPrd, mergeResult.storyId);
+          reviewOrchestrator.clearStory(mergeResult.storyId);
           storiesCompleted++;
           const mergedStory = batchResult.pipelinePassed.find((s) => s.id === mergeResult.storyId);
           if (mergedStory) batchResult.merged.push(mergedStory);
@@ -246,6 +249,7 @@ export async function executeParallel(
         } else {
           // Merge conflict — mark story as failed
           markStoryFailed(currentPrd, mergeResult.storyId, undefined, undefined, statusWriter);
+          reviewOrchestrator.clearStory(mergeResult.storyId);
           batchResult.mergeConflicts.push({
             storyId: mergeResult.storyId,
             conflictFiles: mergeResult.conflictFiles || [],
@@ -269,6 +273,7 @@ export async function executeParallel(
     // Mark failed stories in PRD and clean up their worktrees
     for (const { story, error } of batchResult.failed) {
       markStoryFailed(currentPrd, story.id, undefined, undefined, statusWriter);
+      reviewOrchestrator.clearStory(story.id);
 
       logger?.error("parallel", "Cleaning up failed story worktree", {
         storyId: story.id,

--- a/src/execution/pipeline-result-handler.ts
+++ b/src/execution/pipeline-result-handler.ts
@@ -18,6 +18,7 @@ import type { PluginRegistry } from "../plugins";
 import { countStories, markStoryFailed, markStoryPaused, savePRD } from "../prd";
 import type { PostRunStatusWriter } from "../prd";
 import type { PRD, UserStory } from "../prd/types";
+import { reviewOrchestrator } from "../review/orchestrator";
 import type { routeTask } from "../routing";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import { spawn } from "../utils/bun-deps";
@@ -251,6 +252,7 @@ export async function handlePipelineFailure(
         pipelineResult.stoppedAtStage,
         ctx.statusWriter,
       );
+      reviewOrchestrator.clearStory(ctx.story.id);
       await savePRD(prd, ctx.prdPath);
       prdDirty = true;
       logger?.error("pipeline", "Story failed", { storyId: ctx.story.id, reason: pipelineResult.reason });

--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -16,6 +16,7 @@ import type { AgentGetFn } from "../pipeline/types";
 import type { PluginRegistry } from "../plugins/registry";
 import { isComplete } from "../prd";
 import type { PRD } from "../prd";
+import { reviewOrchestrator } from "../review/orchestrator";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import type { ISessionManager } from "../session";
 import { autoCommitIfDirty } from "../utils/git";
@@ -250,6 +251,9 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
   // Commit status.json and any other nax runtime files left dirty at run end
   logger?.debug("execution", "Completion phase — auto-committing dirty files");
   await autoCommitIfDirty(options.workdir, "run.complete", "run-summary", options.feature);
+
+  // Clear run-scoped review iteration history (issue #736 Patch B) before closing the runtime.
+  reviewOrchestrator.reset();
 
   // Close the NaxRuntime — flushes auditors, drains cost aggregator, aborts signal
   await options.runtime?.close();

--- a/src/pipeline/stages/completion.ts
+++ b/src/pipeline/stages/completion.ts
@@ -20,6 +20,7 @@ import { checkReviewGate, isTriggerEnabled } from "../../interaction/triggers";
 import { getLogger } from "../../logger";
 import { collectBatchMetrics, collectStoryMetrics } from "../../metrics";
 import { countStories, markStoryPassed, savePRD } from "../../prd";
+import { reviewOrchestrator } from "../../review/orchestrator";
 import { errorMessage } from "../../utils/errors";
 import { pipelineEventBus } from "../event-bus";
 import type { PipelineContext, PipelineStage, StageResult } from "../types";
@@ -68,6 +69,7 @@ export const completionStage: PipelineStage = {
     // Mark all stories in batch as passed
     for (const completedStory of ctx.stories) {
       markStoryPassed(ctx.prd, completedStory.id);
+      reviewOrchestrator.clearStory(completedStory.id);
 
       const costPerStory = sessionCost / ctx.stories.length;
       logger.info("completion", "Story passed", {

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -249,18 +249,6 @@ export interface PipelineContext extends DispatchContext {
    * for mechanical failures in files the agent cannot modify (e.g. lint in test files).
    */
   mechanicalFailedOnly?: boolean;
-  /**
-   * Carry-forward iteration history for adversarial review rounds (ADR-022 phase 5).
-   * Appended by reviewFromContext() when adversarial fails with blocking findings.
-   * Cleared when adversarial passes. Injected into the next round's prompt via
-   * buildPriorIterationsBlock so the reviewer sees prior-round findings verdict-first.
-   */
-  priorAdversarialIterations?: Iteration[];
-  /**
-   * Carry-forward iteration history for semantic review rounds (ADR-022 phase 6).
-   * Mirrors priorAdversarialIterations: appended on failure, cleared on pass.
-   */
-  priorSemanticIterations?: Iteration[];
 }
 
 /**

--- a/src/prompts/builders/prior-iterations-builder.ts
+++ b/src/prompts/builders/prior-iterations-builder.ts
@@ -1,17 +1,27 @@
 /**
  * ADR-022 Phase 3 — buildPriorIterationsBlock.
  *
- * Verdict-first table that replaced the three legacy carry-forward blocks:
+ * Verdict-first block that replaced the three legacy carry-forward blocks:
  *   - buildPriorFindingsBlock (adversarial-review-builder.ts) — deleted in ADR-022 phase 5
  *   - buildAttemptContextBlock (review-builder.ts) — deleted in ADR-022 phase 8
  *   - previousFailure accumulator (acceptance-loop.ts) — deleted in ADR-022 phase 8
  *
  * Consumed by all rectifier-class prompts to carry iteration history forward
  * so the model can avoid repeating falsified hypotheses.
+ *
+ * Issue #736 Patch A: rich finding text (message, file:line, suggestion, acQuote)
+ * replaces the count-only table that caused goalpost-moving across review rounds.
  */
 
 import type { Iteration } from "../../findings";
 import type { Finding } from "../../findings";
+
+/**
+ * Token guard: cap total rendered block at this character count. When exceeded,
+ * keep the 2 most recent rounds verbatim and collapse older rounds to one-liners.
+ * Prevents prompt blowup on long runs without losing the most recent context.
+ */
+const MAX_BLOCK_CHARS = 6000;
 
 /**
  * Build the prior iterations block for inclusion in a rectifier prompt.
@@ -20,72 +30,95 @@ import type { Finding } from "../../findings";
  * unconditionally include it without an "## Prior Iterations" section
  * appearing on the first attempt.
  *
- * Format (ADR-022 §8):
+ * Format (ADR-022 §8, issue #736 Patch A):
  *
  * ```
  * ## Prior Iterations — verdict required before new analysis
- * | # | Strategies run | Files touched | Outcome | Findings before → after |
- * ...
- * When outcome is "unchanged"...
+ *
+ * ### Round 1 — outcome: regressed (0 → 1)
+ * Findings flagged previously:
+ * 1. [error / test-gap] src/foo.ts:42
+ *    Message: Missing test for error path
+ *    Suggestion: Add a test asserting the function throws on null input
+ *    acQuote: "AC3: error path is covered"
+ *
+ * **Required:** before adding any new finding, classify each of the N prior finding(s)...
  * ```
  */
 export function buildPriorIterationsBlock<F extends Finding>(iterations: Iteration<F>[]): string {
   if (iterations.length === 0) return "";
 
-  const rows = iterations.map((iter) => {
-    const strategies = iter.fixesApplied.map((fa) => fa.strategyName).join(", ") || "-";
-    const files = iter.fixesApplied.flatMap((fa) => fa.targetFiles).join(", ") || "-";
-    const outcome = iter.outcome;
-    const findingSummary = formatFindingSummary(iter.findingsBefore, iter.findingsAfter);
-    return `| ${iter.iterationNum} | ${strategies} | ${files} | ${outcome} | ${findingSummary} |`;
-  });
+  const sections = iterations.map((iter) => renderIteration(iter));
+  const { displaySections, visibleIterations } = applyTokenGuard(sections, iterations);
+  const verdictTemplate = renderVerdictTemplate(visibleIterations);
 
-  const header = "| # | Strategies run | Files touched | Outcome | Findings before → after |";
-  const separator = "|---|----------------|---------------|---------|--------------------------|";
-  const table = [header, separator, ...rows].join("\n");
-
-  const hasUnchanged = iterations.some((i) => i.outcome === "unchanged");
-  const unchangedNote = hasUnchanged
-    ? `\nWhen outcome is "unchanged", the prior hypothesis is FALSIFIED — the change did not affect what was tested. Choose a different category before producing a new verdict. Do NOT repeat fixes listed above.`
-    : "";
-
-  return `## Prior Iterations — verdict required before new analysis\n\n${table}${unchangedNote}\n\n`;
+  return [
+    "## Prior Iterations — verdict required before new analysis",
+    "",
+    ...displaySections,
+    "",
+    verdictTemplate,
+    "",
+  ].join("\n");
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
-/**
- * Format the "Findings before → after" cell content.
- *
- * Shows count and top category per direction. When both sides are empty, shows
- * "resolved". Groups findings by category and shows the most frequent category
- * in brackets (e.g. "2 [stdout-capture]").
- */
-function formatFindingSummary<F extends Finding>(before: F[], after: F[]): string {
-  const beforeStr = before.length === 0 ? "0" : formatFindingCount(before);
-  const afterStr = after.length === 0 ? "0" : formatFindingCount(after);
-  return `${beforeStr} → ${afterStr}`;
+function applyTokenGuard<F extends Finding>(
+  sections: string[],
+  iterations: Iteration<F>[],
+): { displaySections: string[]; visibleIterations: Iteration<F>[] } {
+  if (sections.join("\n\n").length <= MAX_BLOCK_CHARS || sections.length <= 2) {
+    return { displaySections: sections, visibleIterations: iterations };
+  }
+
+  const n = sections.length;
+  const collapsed = iterations
+    .slice(0, n - 2)
+    .map(
+      (iter) =>
+        `### Round ${iter.iterationNum} — outcome: ${iter.outcome} (${iter.findingsAfter.length} findings, omitted for brevity)`,
+    );
+  const verbatim = sections.slice(n - 2);
+
+  return { displaySections: [...collapsed, ...verbatim], visibleIterations: iterations.slice(n - 2) };
 }
 
-function formatFindingCount<F extends Finding>(findings: F[]): string {
-  const count = findings.length;
-  const topCategory = mostFrequentCategory(findings);
-  return topCategory !== null ? `${count} [${topCategory}]` : `${count}`;
+function renderIteration<F extends Finding>(iter: Iteration<F>): string {
+  const header = `### Round ${iter.iterationNum} — outcome: ${iter.outcome} (${iter.findingsBefore.length} → ${iter.findingsAfter.length})`;
+  if (iter.findingsAfter.length === 0) {
+    return [header, "_All prior findings cleared._"].join("\n");
+  }
+  const lines = iter.findingsAfter.map((f, i) => renderFinding(f, i + 1));
+  return [header, "Findings flagged previously:", ...lines].join("\n");
 }
 
-function mostFrequentCategory<F extends Finding>(findings: F[]): string | null {
-  if (findings.length === 0) return null;
-  const freq = new Map<string, number>();
-  for (const f of findings) {
-    freq.set(f.category, (freq.get(f.category) ?? 0) + 1);
-  }
-  let top: string | null = null;
-  let topCount = 0;
-  for (const [cat, cnt] of freq) {
-    if (cnt > topCount) {
-      topCount = cnt;
-      top = cat;
-    }
-  }
-  return top;
+function renderFinding<F extends Finding>(f: F, n: number): string {
+  const message = truncate(f.message ?? "", 240);
+  const suggestion = truncate(f.suggestion ?? "", 200);
+  const loc = f.file ? (f.line != null ? `${f.file}:${f.line}` : f.file) : "(workdir-global)";
+  const tag = `[${f.severity} / ${f.category}]`;
+  const ac = typeof f.meta?.acQuote === "string" ? f.meta.acQuote : undefined;
+  const acLine = ac ? `\n   acQuote: "${truncate(ac, 160)}"` : "";
+  return `${n}. ${tag} ${loc}\n   Message: ${message}\n   Suggestion: ${suggestion}${acLine}`;
+}
+
+function renderVerdictTemplate<F extends Finding>(iterations: Iteration<F>[]): string {
+  const total = iterations.reduce((sum, it) => sum + it.findingsAfter.length, 0);
+  const hasUnchanged = iterations.some((i) => i.outcome === "unchanged");
+  const unchangedNote = hasUnchanged
+    ? `\n\nWhen outcome is "unchanged", the prior hypothesis is FALSIFIED — the change did not affect what was tested. Choose a different category before producing a new verdict. Do NOT repeat fixes listed above.`
+    : "";
+
+  return [
+    `**Required:** before adding any new finding, classify each of the ${total} prior finding(s) above as one of:`,
+    "- `addressed` — the current diff resolves it (cite the diff line that fixes it in your `message` field)",
+    "- `still-blocking` — the implementer did not fix it; re-flag it with the IDENTICAL `file`, `line`, `category`, and substantively the same `message` wording",
+    `- \`never-an-issue\` — your prior judgment was wrong; explain why in \`message\` and emit severity \`"info"\``,
+    `Then surface any genuinely new findings.${unchangedNote}`,
+  ].join("\n");
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
 }

--- a/src/review/orchestrator.ts
+++ b/src/review/orchestrator.ts
@@ -156,6 +156,36 @@ export interface OrchestratorReviewOptions {
 }
 
 export class ReviewOrchestrator {
+  /**
+   * Run-scoped per-story iteration history (issue #736 Patch B).
+   *
+   * Keyed by storyId. Lifetime: survives PipelineContext recreation (e.g. after
+   * "agent gave up" triggers a new TDD attempt with a fresh ctx). Cleared per-story
+   * on pass/terminal-fail, and fully reset at run end via reset().
+   */
+  private readonly priorAdversarialByStory = new Map<string, Iteration[]>();
+  private readonly priorSemanticByStory = new Map<string, Iteration[]>();
+
+  /**
+   * Remove iteration history for a single story.
+   * Call after markStoryPassed or markStoryFailed (terminal) so a subsequent
+   * re-run for the same story starts fresh.
+   */
+  clearStory(storyId: string): void {
+    this.priorAdversarialByStory.delete(storyId);
+    this.priorSemanticByStory.delete(storyId);
+  }
+
+  /**
+   * Remove all iteration history.
+   * Call at the end of runCompletionPhase so the singleton is clean for the
+   * next run in the same process.
+   */
+  reset(): void {
+    this.priorAdversarialByStory.clear();
+    this.priorSemanticByStory.clear();
+  }
+
   /** Run built-in checks + plugin reviewers. Returns unified result. */
   async review(opts: OrchestratorReviewOptions): Promise<OrchestratorReviewResult> {
     const {
@@ -559,6 +589,10 @@ export class ReviewOrchestrator {
         ? { semantic: semanticBundle ?? undefined, adversarial: adversarialBundle ?? undefined }
         : undefined;
 
+    // Read from run-scoped maps (Patch B) — survives PipelineContext recreation.
+    const priorAdversarialIterations = this.priorAdversarialByStory.get(ctx.story.id) ?? [];
+    const priorSemanticIterations = this.priorSemanticByStory.get(ctx.story.id) ?? [];
+
     const result = await this.review({
       reviewConfig: ctx.config.review,
       workdir: ctx.workdir,
@@ -580,32 +614,33 @@ export class ReviewOrchestrator {
       featureName: ctx.prd.feature,
       resolverSession,
       priorFailures: ctx.story.priorFailures,
-      priorSemanticIterations: ctx.priorSemanticIterations,
+      priorSemanticIterations,
       featureContextMarkdown: ctx.featureContextMarkdown,
       contextBundles,
       projectDir: ctx.projectDir,
       env: ctx.worktreeDependencyContext?.env,
       naxIgnoreIndex: ctx.naxIgnoreIndex,
       runtime: ctx.runtime,
-      priorAdversarialIterations: ctx.priorAdversarialIterations,
+      priorAdversarialIterations,
     });
 
-    // Update ctx.priorAdversarialIterations for the next review round (ADR-022 phase 5).
+    // Update run-scoped maps for the next review round (issue #736 Patch B).
     // When adversarial fails, append an Iteration so the next round's prompt carries
     // history forward via buildPriorIterationsBlock (verdict-first). This covers both
     // structured-findings failures and looksLikeFail (truncated JSON / no findings array).
-    // When adversarial passes, clear the history.
+    // When adversarial passes, remove the story from the map.
     //
     // fixesApplied is always [] here because adversarial fixes run in the implementation
     // session outside this subsystem — there is no FixApplied op to record.
+    const logger = getSafeLogger();
     const advCheck = result.builtIn.checks?.find((c) => c.check === "adversarial");
     if (advCheck) {
       if (!advCheck.success && !advCheck.skipped) {
-        const prior = ctx.priorAdversarialIterations ?? [];
+        const prior = this.priorAdversarialByStory.get(ctx.story.id) ?? [];
         const findingsBefore = prior.length > 0 ? (prior[prior.length - 1].findingsAfter ?? []) : [];
         const findingsAfter = advCheck.findings ?? [];
         const now = new Date().toISOString();
-        const newIteration: Iteration = {
+        const next: Iteration = {
           iterationNum: prior.length + 1,
           findingsBefore,
           fixesApplied: [],
@@ -614,27 +649,32 @@ export class ReviewOrchestrator {
           startedAt: now,
           finishedAt: now,
         };
-        ctx.priorAdversarialIterations = [...prior, newIteration];
+        this.priorAdversarialByStory.set(ctx.story.id, [...prior, next]);
+        logger?.debug("review", "Adversarial iteration recorded", {
+          storyId: ctx.story.id,
+          iterationNum: next.iterationNum,
+          outcome: next.outcome,
+          findingsCount: findingsAfter.length,
+        });
       } else if (advCheck.success && !advCheck.skipped) {
-        ctx.priorAdversarialIterations = undefined;
+        this.priorAdversarialByStory.delete(ctx.story.id);
       }
     } else if (retrySkipChecks?.has("adversarial")) {
       // Adversarial was skipped because it passed in the previous review pass.
       // Clear any stale iteration history — the reviewer already approved this code.
-      ctx.priorAdversarialIterations = undefined;
+      this.priorAdversarialByStory.delete(ctx.story.id);
     }
 
-    // Update ctx.priorSemanticIterations for the next review round (ADR-022 phase 6).
-    // Mirrors the adversarial carry-forward pattern: append on failure, clear on pass.
+    // Mirror the same pattern for semantic review (ADR-022 phase 6, issue #736 Patch B).
     // fixesApplied is always [] — semantic fixes run in the implementation session.
     const semCheck = result.builtIn.checks?.find((c) => c.check === "semantic");
     if (semCheck) {
       if (!semCheck.success && !semCheck.skipped) {
-        const prior = ctx.priorSemanticIterations ?? [];
+        const prior = this.priorSemanticByStory.get(ctx.story.id) ?? [];
         const findingsBefore = prior.length > 0 ? (prior[prior.length - 1].findingsAfter ?? []) : [];
         const findingsAfter = semCheck.findings ?? [];
         const now = new Date().toISOString();
-        const newIteration: Iteration = {
+        const next: Iteration = {
           iterationNum: prior.length + 1,
           findingsBefore,
           fixesApplied: [],
@@ -643,12 +683,18 @@ export class ReviewOrchestrator {
           startedAt: now,
           finishedAt: now,
         };
-        ctx.priorSemanticIterations = [...prior, newIteration];
+        this.priorSemanticByStory.set(ctx.story.id, [...prior, next]);
+        logger?.debug("review", "Semantic iteration recorded", {
+          storyId: ctx.story.id,
+          iterationNum: next.iterationNum,
+          outcome: next.outcome,
+          findingsCount: findingsAfter.length,
+        });
       } else if (semCheck.success && !semCheck.skipped) {
-        ctx.priorSemanticIterations = undefined;
+        this.priorSemanticByStory.delete(ctx.story.id);
       }
     } else if (retrySkipChecks?.has("semantic")) {
-      ctx.priorSemanticIterations = undefined;
+      this.priorSemanticByStory.delete(ctx.story.id);
     }
 
     return result;

--- a/test/integration/review/prior-iterations-survive-rectify.test.ts
+++ b/test/integration/review/prior-iterations-survive-rectify.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Integration test: prior-iterations survive PipelineContext recreation (issue #736 Patch B).
+ *
+ * Scenario: adversarial review fails on round 1, then an autofix session runs and
+ * recreates PipelineContext (simulating "cycle exited — agent gave up"). The second
+ * call to reviewFromContext must carry the round-1 iteration forward to the adversarial
+ * reviewer via priorAdversarialIterations, so the reviewer's prompt will contain the
+ * "## Prior Iterations" block with Round 1 finding text (verified by the unit tests for
+ * prior-iterations-builder; here we verify the data actually flows end-to-end).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Finding } from "../../../src/findings";
+import type { RunAdversarialReviewOptions } from "../../../src/review/adversarial";
+import { ReviewOrchestrator, _orchestratorDeps } from "../../../src/review/orchestrator";
+import { _reviewAdversarialDeps, _reviewGitDeps as _runnerDeps } from "../../../src/review/runner";
+import type { ReviewCheckResult } from "../../../src/review/types";
+import { withDepsRestore } from "../../helpers/deps";
+import { makeNaxConfig } from "../../helpers/mock-nax-config";
+import { makePRD, makeStory } from "../../helpers/mock-story";
+import type { PipelineContext } from "../../../src/pipeline/types";
+import type { NaxConfig } from "../../../src/config";
+
+// ─── Dep restore ──────────────────────────────────────────────────────────────
+
+withDepsRestore(_runnerDeps, ["getUncommittedFiles"]);
+withDepsRestore(_orchestratorDeps, ["spawn"]);
+withDepsRestore(_reviewAdversarialDeps, ["runAdversarialReview"]);
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const STORY_ID = "US-RECTIFY";
+
+function makeAdvFinding(msg: string): Finding {
+  return {
+    source: "adversarial-review",
+    severity: "error",
+    category: "test-gap",
+    message: msg,
+    file: "src/handler.ts",
+    line: 10,
+  };
+}
+
+function makeCheckResult(success: boolean, findings: Finding[]): ReviewCheckResult {
+  return {
+    check: "adversarial",
+    success,
+    skipped: false,
+    command: "adversarial-review",
+    exitCode: success ? 0 : 1,
+    output: "",
+    durationMs: 5,
+    findings: success ? [] : findings,
+  };
+}
+
+function makeCtx(storyId: string): PipelineContext {
+  const story = makeStory({ id: storyId, workdir: "" });
+  const prd = makePRD({ userStories: [story] });
+  const config = makeNaxConfig({
+    review: {
+      enabled: true,
+      checks: ["adversarial"],
+      commands: {},
+      adversarial: {
+        model: "balanced",
+        diffMode: "ref",
+        rules: [],
+        timeoutMs: 60_000,
+        excludePatterns: [],
+        parallel: false,
+        maxConcurrentSessions: 2,
+      },
+    } as unknown as NaxConfig["review"],
+  });
+  return {
+    config,
+    workdir: "/tmp/rectify-test",
+    story,
+    stories: [story],
+    prd,
+    plugins: undefined,
+    agentManager: undefined,
+    runtime: undefined,
+  } as unknown as PipelineContext;
+}
+
+beforeEach(() => {
+  _runnerDeps.getUncommittedFiles = mock(async () => []);
+  _orchestratorDeps.spawn = mock(() => ({
+    exited: Promise.resolve(0),
+    stdout: new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("")); c.close(); } }),
+    stderr: new ReadableStream({ start(c) { c.close(); } }),
+  })) as unknown as typeof _orchestratorDeps.spawn;
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+// ─── Integration scenario ─────────────────────────────────────────────────────
+
+describe("prior-iterations survive PipelineContext recreation", () => {
+  test("round-2 reviewFromContext receives round-1 findings in priorAdversarialIterations", async () => {
+    const round1Finding = makeAdvFinding("AC8 mock never invoked in test");
+    const capturedOpts: RunAdversarialReviewOptions[] = [];
+
+    _reviewAdversarialDeps.runAdversarialReview = mock(async (opts: RunAdversarialReviewOptions) => {
+      capturedOpts.push(opts);
+      return makeCheckResult(false, [round1Finding]);
+    });
+
+    const orchestrator = new ReviewOrchestrator();
+
+    // Round 1: adversarial fails → iteration stored in map
+    const ctx1 = makeCtx(STORY_ID);
+    await orchestrator.reviewFromContext(ctx1);
+    expect(capturedOpts).toHaveLength(1);
+    expect(capturedOpts[0].priorAdversarialIterations).toHaveLength(0);
+
+    // Simulate autofix: "cycle exited — agent gave up" → new PipelineContext (same storyId)
+    const ctx2 = makeCtx(STORY_ID);
+    await orchestrator.reviewFromContext(ctx2);
+
+    // Round 2 must have received the round-1 iteration from the orchestrator map
+    expect(capturedOpts).toHaveLength(2);
+    const priorPassedToRound2 = capturedOpts[1].priorAdversarialIterations;
+    expect(priorPassedToRound2).toHaveLength(1);
+    expect(priorPassedToRound2?.[0].iterationNum).toBe(1);
+    expect(priorPassedToRound2?.[0].findingsAfter).toHaveLength(1);
+    expect(priorPassedToRound2?.[0].findingsAfter[0].message).toBe("AC8 mock never invoked in test");
+  });
+
+  test("round-2 findings are also carried into round-3 after second failure", async () => {
+    const f1 = makeAdvFinding("finding round 1");
+    const f2 = makeAdvFinding("finding round 2");
+    let round = 0;
+    const capturedOpts: RunAdversarialReviewOptions[] = [];
+
+    _reviewAdversarialDeps.runAdversarialReview = mock(async (opts: RunAdversarialReviewOptions) => {
+      capturedOpts.push(opts);
+      round++;
+      const findings = round === 1 ? [f1] : [f2];
+      return makeCheckResult(false, findings);
+    });
+
+    const orchestrator = new ReviewOrchestrator();
+
+    await orchestrator.reviewFromContext(makeCtx(STORY_ID));
+    await orchestrator.reviewFromContext(makeCtx(STORY_ID));
+    await orchestrator.reviewFromContext(makeCtx(STORY_ID));
+
+    // Round 3 should have 2 prior iterations (rounds 1 and 2)
+    const priorRound3 = capturedOpts[2].priorAdversarialIterations;
+    expect(priorRound3).toHaveLength(2);
+    expect(priorRound3?.[0].iterationNum).toBe(1);
+    expect(priorRound3?.[1].iterationNum).toBe(2);
+    // Round 2's findingsBefore is round 1's findingsAfter
+    expect(priorRound3?.[1].findingsBefore[0].message).toBe("finding round 1");
+  });
+
+  test("prior iterations reset to empty after reset() is called between runs", async () => {
+    const finding = makeAdvFinding("stale");
+    const capturedOpts: RunAdversarialReviewOptions[] = [];
+
+    _reviewAdversarialDeps.runAdversarialReview = mock(async (opts: RunAdversarialReviewOptions) => {
+      capturedOpts.push(opts);
+      return makeCheckResult(false, [finding]);
+    });
+
+    const orchestrator = new ReviewOrchestrator();
+
+    // Run 1
+    await orchestrator.reviewFromContext(makeCtx(STORY_ID));
+    orchestrator.reset();
+
+    // Run 2 — after reset, second reviewFromContext should see no prior iterations
+    await orchestrator.reviewFromContext(makeCtx(STORY_ID));
+
+    expect(capturedOpts[1].priorAdversarialIterations).toHaveLength(0);
+  });
+});

--- a/test/unit/execution/lifecycle/acceptance-loop-cycle.test.ts
+++ b/test/unit/execution/lifecycle/acceptance-loop-cycle.test.ts
@@ -479,7 +479,7 @@ describe("strategy buildInput closures", () => {
 
     const input = capturedCycle!.strategies[0].buildInput([], [makeIteration()], {} as never) as Record<string, unknown>;
     expect(input.priorIterationsBlock).toContain("## Prior Iterations");
-    expect(input.priorIterationsBlock).toContain("acceptance-test-fix");
+    expect(input.priorIterationsBlock).toContain("AC-1 failed");
   });
 
   test("test-fix buildInput reflects currentFailedACs at call time", async () => {

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -114,8 +114,9 @@ describe("adversarialReviewOp.build()", () => {
     };
     const result = adversarialReviewOp.build(inputWithPrior, ctx);
     expect(result.task.content).toContain("## Prior Iterations — verdict required before new analysis");
-    expect(result.task.content).toContain("source-fix");
-    expect(result.task.content).toContain("partial");
+    expect(result.task.content).toContain("### Round 1 — outcome: partial");
+    // Finding text rendered verbatim
+    expect(result.task.content).toContain("Silent catch block");
   });
 
   test("task content has no prior iterations block when priorAdversarialIterations is absent", () => {

--- a/test/unit/operations/semantic-review.test.ts
+++ b/test/unit/operations/semantic-review.test.ts
@@ -110,8 +110,9 @@ describe("semanticReviewOp.build() — priorSemanticIterations", () => {
     };
     const result = semanticReviewOp.build(inputWithIterations, ctx);
     expect(result.task.content).toContain("## Prior Iterations — verdict required before new analysis");
-    expect(result.task.content).toContain("| 1 |");
-    expect(result.task.content).toContain("partial");
+    expect(result.task.content).toContain("### Round 1 — outcome: partial");
+    // Finding text rendered verbatim
+    expect(result.task.content).toContain("handler not wired");
   });
 
   test("omits prior iterations block when priorSemanticIterations is undefined", () => {

--- a/test/unit/prompts/adversarial-review-builder.test.ts
+++ b/test/unit/prompts/adversarial-review-builder.test.ts
@@ -332,34 +332,36 @@ describe("AdversarialReviewPromptBuilder — priorAdversarialIterations", () => 
     expect(result).toContain("## Prior Iterations — verdict required before new analysis");
   });
 
-  test("prior iterations block contains the iteration number", () => {
+  test("prior iterations block contains the round header with iteration number", () => {
     const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
       mode: "ref",
       storyGitRef: STORY_GIT_REF,
       priorAdversarialIterations: PRIOR_ITERATIONS,
     });
-    expect(result).toContain("| 1 |");
+    expect(result).toContain("### Round 1");
   });
 
-  test("prior iterations block contains strategy name and outcome", () => {
+  test("prior iterations block contains outcome and finding text", () => {
     const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
       mode: "ref",
       storyGitRef: STORY_GIT_REF,
       priorAdversarialIterations: PRIOR_ITERATIONS,
     });
-    expect(result).toContain("source-fix");
     expect(result).toContain("partial");
+    // Finding text (message) is rendered verbatim rather than as a count
+    expect(result).toContain("Null pointer dereference on empty input");
   });
 
-  test("prior iterations block contains finding count summary", () => {
+  test("prior iterations block contains file:line and count in round header", () => {
     const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
       mode: "ref",
       storyGitRef: STORY_GIT_REF,
       priorAdversarialIterations: PRIOR_ITERATIONS,
     });
-    // findingsBefore is empty (0), findingsAfter has 2 findings
-    expect(result).toContain("0 →");
-    expect(result).toContain("2 [");
+    // findingsBefore is empty (0), findingsAfter has 2 findings → header shows (0 → 2)
+    expect(result).toContain("(0 → 2)");
+    // Finding file:line rendered
+    expect(result).toContain("src/auth/login.ts:42");
   });
 
   test("prior iterations block appears before the story block (verdict-first)", () => {

--- a/test/unit/prompts/builders/prior-iterations-builder.test.ts
+++ b/test/unit/prompts/builders/prior-iterations-builder.test.ts
@@ -23,13 +23,6 @@ function makeIteration(overrides: Partial<Iteration<Finding>> & Pick<Iteration<F
   };
 }
 
-const acceptanceTestFix = {
-  strategyName: "acceptance-test-fix",
-  op: "acceptance-fix-test-op",
-  targetFiles: [".nax-acceptance.test.ts"],
-  summary: "adjusted stdout capture assertion",
-};
-
 // ─── Empty input ──────────────────────────────────────────────────────────────
 
 describe("buildPriorIterationsBlock — empty", () => {
@@ -38,164 +31,304 @@ describe("buildPriorIterationsBlock — empty", () => {
   });
 });
 
-// ─── Single iteration — resolved ─────────────────────────────────────────────
+// ─── Single iteration with findings ─────────────────────────────────────────
 
-describe("buildPriorIterationsBlock — single resolved iteration", () => {
-  test("renders table with resolved outcome", () => {
-    const finding = makeFinding({ source: "acceptance-diagnose", message: "wrong stream" });
+describe("buildPriorIterationsBlock — single round with findings", () => {
+  test("renders Round header and finding text fields", () => {
+    const finding = makeFinding({
+      source: "adversarial-review",
+      message: "Missing test for null input path",
+      suggestion: "Add a test asserting the function throws on null",
+      file: "src/foo.ts",
+      line: 42,
+      category: "test-gap",
+      severity: "error",
+    });
     const iter = makeIteration({
       iterationNum: 1,
-      outcome: "resolved",
-      findingsBefore: [finding],
-      findingsAfter: [],
-      fixesApplied: [acceptanceTestFix],
+      outcome: "regressed",
+      findingsBefore: [],
+      findingsAfter: [finding],
     });
 
     const output = buildPriorIterationsBlock([iter]);
 
     expect(output).toContain("## Prior Iterations — verdict required before new analysis");
-    expect(output).toContain("| # | Strategies run | Files touched | Outcome | Findings before → after |");
-    expect(output).toContain("| 1 | acceptance-test-fix | .nax-acceptance.test.ts | resolved |");
-    expect(output).toContain("1 [stdout-capture] → 0");
+    expect(output).toContain("### Round 1 — outcome: regressed (0 → 1)");
+    expect(output).toContain("Findings flagged previously:");
+    expect(output).toContain("src/foo.ts:42");
+    expect(output).toContain("[error / test-gap]");
+    expect(output).toContain("Message: Missing test for null input path");
+    expect(output).toContain("Suggestion: Add a test asserting the function throws on null");
   });
 
-  test("does NOT include unchanged note when no unchanged iterations", () => {
+  test("shows (workdir-global) when finding has no file", () => {
+    const finding = makeFinding({ source: "adversarial-review", message: "missing script" });
+    const iter = makeIteration({
+      iterationNum: 1,
+      outcome: "unchanged",
+      findingsAfter: [finding],
+    });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain("(workdir-global)");
+  });
+
+  test("shows file without line when line is absent", () => {
+    const finding = makeFinding({ source: "adversarial-review", message: "x", file: "src/bar.ts" });
+    const iter = makeIteration({
+      iterationNum: 1,
+      outcome: "partial",
+      findingsAfter: [finding],
+    });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain("src/bar.ts");
+    expect(output).not.toContain("src/bar.ts:");
+  });
+
+  test("renders _All prior findings cleared_ when findingsAfter is empty", () => {
+    const finding = makeFinding({ source: "adversarial-review", message: "x" });
     const iter = makeIteration({
       iterationNum: 1,
       outcome: "resolved",
-      findingsBefore: [makeFinding({ source: "acceptance-diagnose", message: "x" })],
+      findingsBefore: [finding],
       findingsAfter: [],
-      fixesApplied: [acceptanceTestFix],
     });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain("### Round 1 — outcome: resolved (1 → 0)");
+    expect(output).toContain("_All prior findings cleared._");
+    expect(output).not.toContain("Findings flagged previously:");
+  });
+});
+
+// ─── acQuote field ────────────────────────────────────────────────────────────
+
+describe("buildPriorIterationsBlock — acQuote", () => {
+  test("renders acQuote line when meta.acQuote is a string", () => {
+    const finding = makeFinding({
+      source: "adversarial-review",
+      message: "AC not covered",
+      meta: { acQuote: "AC3: error path is covered" },
+    });
+    const iter = makeIteration({ iterationNum: 1, outcome: "unchanged", findingsAfter: [finding] });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain('acQuote: "AC3: error path is covered"');
+  });
+
+  test("omits acQuote line when meta is absent", () => {
+    const finding = makeFinding({ source: "adversarial-review", message: "x" });
+    const iter = makeIteration({ iterationNum: 1, outcome: "partial", findingsAfter: [finding] });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).not.toContain("acQuote:");
+  });
+
+  test("omits acQuote line when meta.acQuote is not a string", () => {
+    const finding = makeFinding({ source: "adversarial-review", message: "x", meta: { acQuote: 42 } });
+    const iter = makeIteration({ iterationNum: 1, outcome: "partial", findingsAfter: [finding] });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).not.toContain("acQuote:");
+  });
+});
+
+// ─── Truncation ───────────────────────────────────────────────────────────────
+
+describe("buildPriorIterationsBlock — truncation", () => {
+  test("truncates message longer than 240 chars", () => {
+    const longMessage = "A".repeat(300);
+    const finding = makeFinding({ source: "adversarial-review", message: longMessage });
+    const iter = makeIteration({ iterationNum: 1, outcome: "unchanged", findingsAfter: [finding] });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain("…");
+    // The full 300-char message should not appear verbatim
+    expect(output).not.toContain("A".repeat(300));
+  });
+
+  test("does not truncate message at or under 240 chars", () => {
+    const exactMessage = "B".repeat(240);
+    const finding = makeFinding({ source: "adversarial-review", message: exactMessage });
+    const iter = makeIteration({ iterationNum: 1, outcome: "unchanged", findingsAfter: [finding] });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain("B".repeat(240));
+  });
+});
+
+// ─── Verdict template ─────────────────────────────────────────────────────────
+
+describe("buildPriorIterationsBlock — verdict template", () => {
+  test("includes verdict template with correct total count", () => {
+    const f1 = makeFinding({ source: "adversarial-review", message: "a" });
+    const f2 = makeFinding({ source: "adversarial-review", message: "b" });
+    const iter = makeIteration({ iterationNum: 1, outcome: "partial", findingsAfter: [f1, f2] });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain("classify each of the 2 prior finding(s) above");
+    expect(output).toContain("`addressed`");
+    expect(output).toContain("`still-blocking`");
+    expect(output).toContain("`never-an-issue`");
+  });
+
+  test("sums findingsAfter across multiple iterations for total count", () => {
+    const f1 = makeFinding({ source: "adversarial-review", message: "x" });
+    const f2 = makeFinding({ source: "adversarial-review", message: "y" });
+    const f3 = makeFinding({ source: "adversarial-review", message: "z" });
+    const iter1 = makeIteration({ iterationNum: 1, outcome: "partial", findingsBefore: [], findingsAfter: [f1] });
+    const iter2 = makeIteration({ iterationNum: 2, outcome: "unchanged", findingsBefore: [f1], findingsAfter: [f2, f3] });
+
+    const output = buildPriorIterationsBlock([iter1, iter2]);
+    expect(output).toContain("classify each of the 3 prior finding(s) above");
+  });
+
+  test("does NOT include FALSIFIED note when no unchanged iterations", () => {
+    const finding = makeFinding({ source: "adversarial-review", message: "x" });
+    const iter = makeIteration({ iterationNum: 1, outcome: "resolved", findingsAfter: [finding] });
 
     const output = buildPriorIterationsBlock([iter]);
     expect(output).not.toContain("FALSIFIED");
   });
 });
 
-// ─── Single iteration — unchanged ────────────────────────────────────────────
+// ─── Unchanged outcome ────────────────────────────────────────────────────────
 
 describe("buildPriorIterationsBlock — unchanged outcome", () => {
-  test("includes falsified-hypothesis note when outcome is unchanged", () => {
-    const finding = makeFinding({ source: "acceptance-diagnose", message: "wrong stream", category: "stdout-capture" });
+  test("includes falsified-hypothesis note when any iteration is unchanged", () => {
+    const finding = makeFinding({ source: "adversarial-review", message: "x", category: "test-gap" });
     const iter = makeIteration({
       iterationNum: 1,
       outcome: "unchanged",
       findingsBefore: [finding],
       findingsAfter: [finding],
-      fixesApplied: [acceptanceTestFix],
     });
 
     const output = buildPriorIterationsBlock([iter]);
-
-    expect(output).toContain("unchanged");
     expect(output).toContain('outcome is "unchanged", the prior hypothesis is FALSIFIED');
     expect(output).toContain("Do NOT repeat fixes listed above.");
   });
 
-  test("finding summary shows same count before and after for unchanged", () => {
-    const finding = makeFinding({ source: "acceptance-diagnose", message: "wrong stream", category: "stdout-capture" });
-    const iter = makeIteration({
-      iterationNum: 1,
-      outcome: "unchanged",
-      findingsBefore: [finding],
-      findingsAfter: [finding],
-      fixesApplied: [acceptanceTestFix],
-    });
+  test("includes FALSIFIED note even when only one of multiple iterations is unchanged", () => {
+    const f = makeFinding({ source: "adversarial-review", message: "x" });
+    const iter1 = makeIteration({ iterationNum: 1, outcome: "partial", findingsBefore: [], findingsAfter: [f] });
+    const iter2 = makeIteration({ iterationNum: 2, outcome: "unchanged", findingsBefore: [f], findingsAfter: [f] });
 
-    const output = buildPriorIterationsBlock([iter]);
-    expect(output).toContain("1 [stdout-capture] → 1 [stdout-capture]");
+    const output = buildPriorIterationsBlock([iter1, iter2]);
+    expect(output).toContain("FALSIFIED");
   });
 });
 
 // ─── Multiple iterations ──────────────────────────────────────────────────────
 
 describe("buildPriorIterationsBlock — multiple iterations", () => {
-  test("renders all iteration rows in order", () => {
-    const finding = makeFinding({ source: "acceptance-diagnose", message: "x", category: "stdout-capture" });
-    const iter1 = makeIteration({
-      iterationNum: 1,
-      outcome: "unchanged",
-      findingsBefore: [finding],
-      findingsAfter: [finding],
-      fixesApplied: [acceptanceTestFix],
-    });
-    const iter2 = makeIteration({
-      iterationNum: 2,
-      outcome: "resolved",
-      findingsBefore: [finding],
-      findingsAfter: [],
-      fixesApplied: [{ ...acceptanceTestFix, summary: "second attempt" }],
-    });
+  test("renders all rounds in order with correct headers", () => {
+    const f = makeFinding({ source: "adversarial-review", message: "finding" });
+    const iter1 = makeIteration({ iterationNum: 1, outcome: "partial", findingsBefore: [], findingsAfter: [f] });
+    const iter2 = makeIteration({ iterationNum: 2, outcome: "unchanged", findingsBefore: [f], findingsAfter: [f] });
+    const iter3 = makeIteration({ iterationNum: 3, outcome: "resolved", findingsBefore: [f], findingsAfter: [] });
+
+    const output = buildPriorIterationsBlock([iter1, iter2, iter3]);
+
+    expect(output).toContain("### Round 1 — outcome: partial");
+    expect(output).toContain("### Round 2 — outcome: unchanged");
+    expect(output).toContain("### Round 3 — outcome: resolved");
+    // Rounds appear in order
+    const r1Pos = output.indexOf("### Round 1");
+    const r2Pos = output.indexOf("### Round 2");
+    const r3Pos = output.indexOf("### Round 3");
+    expect(r1Pos).toBeLessThan(r2Pos);
+    expect(r2Pos).toBeLessThan(r3Pos);
+  });
+
+  test("numbers findings within a round starting at 1", () => {
+    const f1 = makeFinding({ source: "adversarial-review", message: "first" });
+    const f2 = makeFinding({ source: "adversarial-review", message: "second" });
+    const iter = makeIteration({ iterationNum: 1, outcome: "partial", findingsAfter: [f1, f2] });
+
+    const output = buildPriorIterationsBlock([iter]);
+    expect(output).toContain("1. [");
+    expect(output).toContain("2. [");
+  });
+});
+
+// ─── Token guard ──────────────────────────────────────────────────────────────
+
+describe("buildPriorIterationsBlock — token guard", () => {
+  test("collapses oldest rounds to one-liners when content exceeds MAX_BLOCK_CHARS", () => {
+    // 4 findings × 5 iterations ≈ 6600 chars → exceeds 6000-char budget
+    const verboseMessage = "X".repeat(300);
+    const perRoundFindings = Array.from({ length: 4 }, (_, j) =>
+      makeFinding({ source: "adversarial-review", message: `${verboseMessage}-${j}`, file: "src/big.ts", line: j + 1 }),
+    );
+    const iterations = Array.from({ length: 5 }, (_, i) =>
+      makeIteration({ iterationNum: i + 1, outcome: "unchanged", findingsBefore: [], findingsAfter: perRoundFindings }),
+    );
+
+    const output = buildPriorIterationsBlock(iterations);
+
+    // Oldest rounds (1, 2, 3) collapsed to one-liners
+    expect(output).toContain("Round 1 — outcome: unchanged (4 findings, omitted for brevity)");
+    expect(output).toContain("Round 2 — outcome: unchanged (4 findings, omitted for brevity)");
+    expect(output).toContain("Round 3 — outcome: unchanged (4 findings, omitted for brevity)");
+    // Most recent 2 rounds (4, 5) rendered verbatim
+    expect(output).toContain("### Round 4 — outcome: unchanged");
+    expect(output).toContain("### Round 5 — outcome: unchanged");
+    expect(output).toContain("Message:");
+  });
+
+  test("never collapses when 2 or fewer iterations even if large", () => {
+    const verboseMessage = "Y".repeat(1000);
+    const f1 = makeFinding({ source: "adversarial-review", message: verboseMessage });
+    const f2 = makeFinding({ source: "adversarial-review", message: verboseMessage });
+    const iter1 = makeIteration({ iterationNum: 1, outcome: "partial", findingsAfter: [f1] });
+    const iter2 = makeIteration({ iterationNum: 2, outcome: "unchanged", findingsAfter: [f2] });
 
     const output = buildPriorIterationsBlock([iter1, iter2]);
 
-    expect(output).toContain("| 1 |");
-    expect(output).toContain("| 2 |");
-    // unchanged note present because iter1 was unchanged
-    expect(output).toContain("FALSIFIED");
+    // Both rounds rendered verbatim even though content is large
+    expect(output).toContain("### Round 1 — outcome: partial");
+    expect(output).toContain("### Round 2 — outcome: unchanged");
+    expect(output).not.toContain("omitted for brevity");
   });
 
-  test("co-run strategies are joined with comma in Strategies run column", () => {
-    const sourceFix = { strategyName: "acceptance-source-fix", op: "op-a", targetFiles: ["src/foo.ts"], summary: "" };
-    const testFix = { strategyName: "acceptance-test-fix", op: "op-b", targetFiles: [".nax-acceptance.test.ts"], summary: "" };
-    const iter = makeIteration({
-      iterationNum: 1,
-      outcome: "partial",
-      findingsBefore: [makeFinding({ source: "acceptance-diagnose", message: "x" })],
-      findingsAfter: [],
-      fixesApplied: [sourceFix, testFix],
-    });
+  test("verdict count uses only visible rounds after collapse", () => {
+    // iter1 (7) + iter2 (6) → collapsed; iter3 (3) + iter4 (3) → visible → total = 6
+    const verboseMessage = "Z".repeat(300);
+    const makeFindings = (count: number) =>
+      Array.from({ length: count }, (_, i) =>
+        makeFinding({ source: "adversarial-review", message: `${verboseMessage}-${i}`, file: "src/big.ts", line: i }),
+      );
+    const iter1 = makeIteration({ iterationNum: 1, outcome: "partial", findingsAfter: makeFindings(7) });
+    const iter2 = makeIteration({ iterationNum: 2, outcome: "unchanged", findingsAfter: makeFindings(6) });
+    const iter3 = makeIteration({ iterationNum: 3, outcome: "unchanged", findingsAfter: makeFindings(3) });
+    const iter4 = makeIteration({ iterationNum: 4, outcome: "unchanged", findingsAfter: makeFindings(3) });
 
-    const output = buildPriorIterationsBlock([iter]);
-    expect(output).toContain("acceptance-source-fix, acceptance-test-fix");
-    expect(output).toContain("src/foo.ts, .nax-acceptance.test.ts");
+    const output = buildPriorIterationsBlock([iter1, iter2, iter3, iter4]);
+
+    // Only rounds 3 and 4 are visible (last 2), each with 3 findings → total = 6
+    expect(output).toContain("classify each of the 6 prior finding(s) above");
   });
 
-  test("no-files iteration shows dash in Files touched column", () => {
-    const iter = makeIteration({
-      iterationNum: 1,
-      outcome: "unchanged",
-      findingsBefore: [makeFinding({ source: "acceptance-diagnose", message: "x" })],
-      findingsAfter: [makeFinding({ source: "acceptance-diagnose", message: "x" })],
-      fixesApplied: [{ strategyName: "lint-fix", op: "lint-op", targetFiles: [], summary: "" }],
-    });
+  test("FALSIFIED note absent when only collapsed rounds have outcome=unchanged", () => {
+    // Rounds 1–2 are "unchanged" (will be collapsed); rounds 3–4 are "partial" (visible).
+    // verdictTemplate must NOT show the FALSIFIED note because no visible round is unchanged.
+    const verboseMessage = "W".repeat(300);
+    const makeFindings = (count: number) =>
+      Array.from({ length: count }, (_, i) =>
+        makeFinding({ source: "adversarial-review", message: `${verboseMessage}-${i}`, file: "src/big.ts", line: i }),
+      );
+    const iter1 = makeIteration({ iterationNum: 1, outcome: "unchanged", findingsAfter: makeFindings(5) });
+    const iter2 = makeIteration({ iterationNum: 2, outcome: "unchanged", findingsAfter: makeFindings(5) });
+    const iter3 = makeIteration({ iterationNum: 3, outcome: "partial", findingsAfter: makeFindings(5) });
+    const iter4 = makeIteration({ iterationNum: 4, outcome: "partial", findingsAfter: makeFindings(5) });
 
-    const output = buildPriorIterationsBlock([iter]);
-    expect(output).toContain("| 1 | lint-fix | - |");
-  });
+    const output = buildPriorIterationsBlock([iter1, iter2, iter3, iter4]);
 
-  test("empty fixesApplied (carry-forward iteration) shows dash in both strategy and files columns", () => {
-    // Adversarial carry-forward iterations have fixesApplied: [] because fixes run
-    // in the implementation session outside the FixCycle.
-    const iter = makeIteration({
-      iterationNum: 1,
-      outcome: "partial",
-      findingsBefore: [],
-      findingsAfter: [makeFinding({ source: "adversarial-review", message: "null dereference" })],
-      fixesApplied: [],
-    });
-
-    const output = buildPriorIterationsBlock([iter]);
-    expect(output).toContain("| 1 | - | - | partial |");
-  });
-
-  test("most-frequent category shown when findings have mixed categories", () => {
-    const f1 = makeFinding({ source: "lint", message: "a", category: "unused-var" });
-    const f2 = makeFinding({ source: "lint", message: "b", category: "unused-var" });
-    const f3 = makeFinding({ source: "lint", message: "c", category: "missing-semi" });
-    const iter = makeIteration({
-      iterationNum: 1,
-      outcome: "partial",
-      findingsBefore: [f1, f2, f3],
-      findingsAfter: [f3],
-      fixesApplied: [{ strategyName: "lint-fix", op: "lint-op", targetFiles: ["src/a.ts"], summary: "" }],
-    });
-
-    const output = buildPriorIterationsBlock([iter]);
-    // 3 before, top category "unused-var" (2 occurrences)
-    expect(output).toContain("3 [unused-var]");
-    // 1 after, category "missing-semi"
-    expect(output).toContain("1 [missing-semi]");
+    // Collapsed rounds are not shown verbatim, so FALSIFIED note must not appear
+    expect(output).toContain("omitted for brevity");
+    expect(output).not.toContain("FALSIFIED");
   });
 });

--- a/test/unit/prompts/review-builder.test.ts
+++ b/test/unit/prompts/review-builder.test.ts
@@ -153,7 +153,7 @@ describe("ReviewPromptBuilder.buildSemanticReviewPrompt() — priorSemanticItera
     expect(result).not.toContain("## Prior Iterations");
   });
 
-  test("includes prior iterations table when priorSemanticIterations has entries", () => {
+  test("includes prior iterations block with round header and finding text when priorSemanticIterations has entries", () => {
     const iteration: Iteration = {
       iterationNum: 1,
       findingsBefore: [],
@@ -171,10 +171,10 @@ describe("ReviewPromptBuilder.buildSemanticReviewPrompt() — priorSemanticItera
       priorSemanticIterations: [iteration],
     });
     expect(result).toContain("## Prior Iterations — verdict required before new analysis");
-    expect(result).toContain("| 1 |");
-    expect(result).toContain("partial");
-    expect(result).toContain("0 →");
-    expect(result).toContain("1 [ac-coverage]");
+    expect(result).toContain("### Round 1 — outcome: partial");
+    expect(result).toContain("(0 → 1)");
+    // Finding text rendered verbatim — not a count-category summary
+    expect(result).toContain("AC 2 not wired");
   });
 });
 

--- a/test/unit/review/orchestrator-prior-iterations.test.ts
+++ b/test/unit/review/orchestrator-prior-iterations.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Unit tests for ReviewOrchestrator — prior-iterations map lifecycle (issue #736 Patch B).
+ *
+ * Covers:
+ * - Adversarial fail: iteration appended to per-story map
+ * - Adversarial second fail: second iteration appended with correct findingsBefore
+ * - Adversarial pass: map entry deleted
+ * - Semantic fail/pass: mirrors adversarial behavior
+ * - PipelineContext recreation: map survives (ctx is not the source of truth)
+ * - clearStory: removes only the named story
+ * - reset: removes all stories
+ * - Cross-run isolation: reset() + new story starts fresh
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { NaxConfig } from "../../../src/config";
+import type { Finding, Iteration } from "../../../src/findings";
+import type { PipelineContext } from "../../../src/pipeline/types";
+import type { PRD } from "../../../src/prd/types";
+import { ReviewOrchestrator, _orchestratorDeps } from "../../../src/review/orchestrator";
+import { _reviewAdversarialDeps, _reviewGitDeps as _runnerDeps, _reviewSemanticDeps } from "../../../src/review/runner";
+import type { ReviewCheckResult } from "../../../src/review/types";
+import { withDepsRestore } from "../../helpers/deps";
+import { makeNaxConfig } from "../../helpers/mock-nax-config";
+import { makePRD, makeStory } from "../../helpers/mock-story";
+
+// ─── Dep restore ──────────────────────────────────────────────────────────────
+
+withDepsRestore(_runnerDeps, ["getUncommittedFiles"]);
+withDepsRestore(_orchestratorDeps, ["spawn"]);
+withDepsRestore(_reviewAdversarialDeps, ["runAdversarialReview"]);
+withDepsRestore(_reviewSemanticDeps, ["runSemanticReview"]);
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const STORY_ID = "US-042";
+
+function makeAdversarialFinding(msg: string): Finding {
+  return {
+    source: "adversarial-review",
+    severity: "error",
+    category: "test-gap",
+    message: msg,
+    file: "src/foo.ts",
+    line: 1,
+  };
+}
+
+function makeAdvCheckResult(success: boolean, findings: Finding[] = []): ReviewCheckResult {
+  return {
+    check: "adversarial",
+    success,
+    skipped: false,
+    command: "adversarial-review",
+    exitCode: success ? 0 : 1,
+    output: "",
+    durationMs: 10,
+    findings: success ? [] : findings,
+  };
+}
+
+function makeSemCheckResult(success: boolean, findings: Finding[] = []): ReviewCheckResult {
+  return {
+    check: "semantic",
+    success,
+    skipped: false,
+    command: "semantic-review",
+    exitCode: success ? 0 : 1,
+    output: "",
+    durationMs: 10,
+    findings: success ? [] : findings,
+  };
+}
+
+function makeAdvConfig(): NaxConfig["review"] {
+  return {
+    enabled: true,
+    checks: ["adversarial"] as NaxConfig["review"]["checks"],
+    commands: {},
+    adversarial: {
+      model: "balanced",
+      diffMode: "ref",
+      rules: [],
+      timeoutMs: 60_000,
+      excludePatterns: [],
+      parallel: false,
+      maxConcurrentSessions: 2,
+    },
+  } as unknown as NaxConfig["review"];
+}
+
+function makeSemConfig(): NaxConfig["review"] {
+  return {
+    enabled: true,
+    checks: ["semantic"] as NaxConfig["review"]["checks"],
+    commands: {},
+  } as unknown as NaxConfig["review"];
+}
+
+function makeMinimalCtx(storyId: string, reviewConfig: NaxConfig["review"]): PipelineContext {
+  const story = makeStory({ id: storyId, workdir: "" });
+  const prd: PRD = makePRD({ userStories: [story] });
+  const config = makeNaxConfig({ review: reviewConfig as NaxConfig["review"] });
+  return {
+    config,
+    workdir: "/tmp/test",
+    story,
+    stories: [story],
+    prd,
+    plugins: undefined,
+    agentManager: undefined,
+    runtime: undefined,
+  } as unknown as PipelineContext;
+}
+
+beforeEach(() => {
+  // Mechanical check: no dirty files → reviewer proceeds
+  _runnerDeps.getUncommittedFiles = mock(async () => []);
+  // Git spawn: empty diff output
+  _orchestratorDeps.spawn = mock(() => ({
+    exited: Promise.resolve(0),
+    stdout: new ReadableStream({ start(c) { c.enqueue(new TextEncoder().encode("")); c.close(); } }),
+    stderr: new ReadableStream({ start(c) { c.close(); } }),
+  })) as unknown as typeof _orchestratorDeps.spawn;
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+// ─── clearStory / reset — pure map operations ─────────────────────────────────
+
+describe("ReviewOrchestrator — clearStory / reset", () => {
+  test("clearStory removes only the named story", () => {
+    const orchestrator = new ReviewOrchestrator();
+    const maps = orchestrator as unknown as {
+      priorAdversarialByStory: Map<string, Iteration[]>;
+      priorSemanticByStory: Map<string, Iteration[]>;
+    };
+
+    const iter: Iteration = {
+      iterationNum: 1,
+      findingsBefore: [],
+      fixesApplied: [],
+      findingsAfter: [makeAdversarialFinding("x")],
+      outcome: "unchanged",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      finishedAt: "2026-01-01T00:00:01.000Z",
+    };
+    maps.priorAdversarialByStory.set("US-001", [iter]);
+    maps.priorAdversarialByStory.set("US-002", [iter]);
+
+    orchestrator.clearStory("US-001");
+
+    expect(maps.priorAdversarialByStory.has("US-001")).toBe(false);
+    expect(maps.priorAdversarialByStory.has("US-002")).toBe(true);
+  });
+
+  test("clearStory removes both adversarial and semantic maps for the story", () => {
+    const orchestrator = new ReviewOrchestrator();
+    const maps = orchestrator as unknown as {
+      priorAdversarialByStory: Map<string, Iteration[]>;
+      priorSemanticByStory: Map<string, Iteration[]>;
+    };
+
+    const iter: Iteration = {
+      iterationNum: 1, findingsBefore: [], fixesApplied: [],
+      findingsAfter: [], outcome: "resolved",
+      startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:01.000Z",
+    };
+    maps.priorAdversarialByStory.set("US-001", [iter]);
+    maps.priorSemanticByStory.set("US-001", [iter]);
+
+    orchestrator.clearStory("US-001");
+
+    expect(maps.priorAdversarialByStory.has("US-001")).toBe(false);
+    expect(maps.priorSemanticByStory.has("US-001")).toBe(false);
+  });
+
+  test("clearStory on absent storyId is a no-op", () => {
+    const orchestrator = new ReviewOrchestrator();
+    expect(() => orchestrator.clearStory("does-not-exist")).not.toThrow();
+  });
+
+  test("reset clears all stories from both maps", () => {
+    const orchestrator = new ReviewOrchestrator();
+    const maps = orchestrator as unknown as {
+      priorAdversarialByStory: Map<string, Iteration[]>;
+      priorSemanticByStory: Map<string, Iteration[]>;
+    };
+
+    const iter: Iteration = {
+      iterationNum: 1, findingsBefore: [], fixesApplied: [],
+      findingsAfter: [], outcome: "resolved",
+      startedAt: "2026-01-01T00:00:00.000Z", finishedAt: "2026-01-01T00:00:01.000Z",
+    };
+    maps.priorAdversarialByStory.set("US-001", [iter]);
+    maps.priorAdversarialByStory.set("US-002", [iter]);
+    maps.priorSemanticByStory.set("US-001", [iter]);
+
+    orchestrator.reset();
+
+    expect(maps.priorAdversarialByStory.size).toBe(0);
+    expect(maps.priorSemanticByStory.size).toBe(0);
+  });
+});
+
+// ─── Map write: adversarial fail / pass ──────────────────────────────────────
+
+describe("ReviewOrchestrator — adversarial map write via reviewFromContext", () => {
+  test("appends iteration to map on first adversarial failure", async () => {
+    const finding = makeAdversarialFinding("missing null check");
+    _reviewAdversarialDeps.runAdversarialReview = mock(async () => makeAdvCheckResult(false, [finding]));
+
+    const orchestrator = new ReviewOrchestrator();
+    const ctx = makeMinimalCtx(STORY_ID, makeAdvConfig());
+
+    await orchestrator.reviewFromContext(ctx);
+
+    const maps = orchestrator as unknown as { priorAdversarialByStory: Map<string, Iteration[]> };
+    const iterations = maps.priorAdversarialByStory.get(STORY_ID);
+    expect(iterations).toBeDefined();
+    expect(iterations?.length).toBe(1);
+    expect(iterations?.[0].iterationNum).toBe(1);
+    expect(iterations?.[0].findingsAfter).toHaveLength(1);
+    expect(iterations?.[0].findingsAfter[0].message).toBe("missing null check");
+  });
+
+  test("appends second iteration with findingsBefore from first round", async () => {
+    const f1 = makeAdversarialFinding("first finding");
+    const f2 = makeAdversarialFinding("second finding");
+    let callCount = 0;
+    _reviewAdversarialDeps.runAdversarialReview = mock(async () => {
+      callCount++;
+      return makeAdvCheckResult(false, callCount === 1 ? [f1] : [f2]);
+    });
+
+    const orchestrator = new ReviewOrchestrator();
+    const ctx1 = makeMinimalCtx(STORY_ID, makeAdvConfig());
+    const ctx2 = makeMinimalCtx(STORY_ID, makeAdvConfig());
+
+    await orchestrator.reviewFromContext(ctx1);
+    await orchestrator.reviewFromContext(ctx2);
+
+    const maps = orchestrator as unknown as { priorAdversarialByStory: Map<string, Iteration[]> };
+    const iterations = maps.priorAdversarialByStory.get(STORY_ID);
+    expect(iterations?.length).toBe(2);
+    expect(iterations?.[1].iterationNum).toBe(2);
+    expect(iterations?.[1].findingsBefore).toHaveLength(1);
+    expect(iterations?.[1].findingsBefore[0].message).toBe("first finding");
+    expect(iterations?.[1].findingsAfter[0].message).toBe("second finding");
+  });
+
+  test("deletes map entry when adversarial passes", async () => {
+    const finding = makeAdversarialFinding("x");
+    let passNext = false;
+    _reviewAdversarialDeps.runAdversarialReview = mock(async () =>
+      makeAdvCheckResult(passNext, passNext ? [] : [finding]),
+    );
+
+    const orchestrator = new ReviewOrchestrator();
+    const ctx1 = makeMinimalCtx(STORY_ID, makeAdvConfig());
+    await orchestrator.reviewFromContext(ctx1);
+
+    const maps = orchestrator as unknown as { priorAdversarialByStory: Map<string, Iteration[]> };
+    expect(maps.priorAdversarialByStory.has(STORY_ID)).toBe(true);
+
+    passNext = true;
+    const ctx2 = makeMinimalCtx(STORY_ID, makeAdvConfig());
+    await orchestrator.reviewFromContext(ctx2);
+
+    expect(maps.priorAdversarialByStory.has(STORY_ID)).toBe(false);
+  });
+
+  test("survives PipelineContext recreation — map entry from ctx_v1 is present for ctx_v2", async () => {
+    const finding = makeAdversarialFinding("stale finding");
+    const capturedPriorIterations: (Iteration[] | undefined)[] = [];
+    _reviewAdversarialDeps.runAdversarialReview = mock(async (opts) => {
+      capturedPriorIterations.push(opts.priorAdversarialIterations);
+      return makeAdvCheckResult(false, [finding]);
+    });
+
+    const orchestrator = new ReviewOrchestrator();
+    const ctx1 = makeMinimalCtx(STORY_ID, makeAdvConfig());
+    await orchestrator.reviewFromContext(ctx1);
+
+    // Simulate "agent gave up" → fresh PipelineContext created with same story
+    const ctx2 = makeMinimalCtx(STORY_ID, makeAdvConfig());
+    // ctx2 has NO priorAdversarialIterations (it's a fresh ctx, and the field no longer exists)
+    await orchestrator.reviewFromContext(ctx2);
+
+    // Second call should have received the first round's iterations from the map
+    expect(capturedPriorIterations[1]).toHaveLength(1);
+    expect(capturedPriorIterations[1]?.[0].iterationNum).toBe(1);
+  });
+});
+
+// ─── Map write: semantic mirroring ───────────────────────────────────────────
+
+describe("ReviewOrchestrator — semantic map mirrors adversarial behavior", () => {
+  test("appends semantic iteration on failure", async () => {
+    const finding: Finding = {
+      source: "semantic-review", severity: "error",
+      category: "ac-coverage", message: "AC not tested",
+    };
+    _reviewSemanticDeps.runSemanticReview = mock(async () => makeSemCheckResult(false, [finding]));
+
+    const orchestrator = new ReviewOrchestrator();
+    const ctx = makeMinimalCtx(STORY_ID, makeSemConfig());
+
+    await orchestrator.reviewFromContext(ctx);
+
+    const maps = orchestrator as unknown as { priorSemanticByStory: Map<string, Iteration[]> };
+    const iterations = maps.priorSemanticByStory.get(STORY_ID);
+    expect(iterations?.length).toBe(1);
+    expect(iterations?.[0].findingsAfter[0].message).toBe("AC not tested");
+  });
+
+  test("deletes semantic map entry when semantic passes", async () => {
+    const finding: Finding = {
+      source: "semantic-review", severity: "error",
+      category: "ac-coverage", message: "AC not tested",
+    };
+    let passNext = false;
+    _reviewSemanticDeps.runSemanticReview = mock(async () =>
+      makeSemCheckResult(passNext, passNext ? [] : [finding]),
+    );
+
+    const orchestrator = new ReviewOrchestrator();
+    const ctx1 = makeMinimalCtx(STORY_ID, makeSemConfig());
+    await orchestrator.reviewFromContext(ctx1);
+
+    const maps = orchestrator as unknown as { priorSemanticByStory: Map<string, Iteration[]> };
+    expect(maps.priorSemanticByStory.has(STORY_ID)).toBe(true);
+
+    passNext = true;
+    const ctx2 = makeMinimalCtx(STORY_ID, makeSemConfig());
+    await orchestrator.reviewFromContext(ctx2);
+
+    expect(maps.priorSemanticByStory.has(STORY_ID)).toBe(false);
+  });
+});
+
+// ─── Cross-run isolation ──────────────────────────────────────────────────────
+
+describe("ReviewOrchestrator — cross-run isolation via reset()", () => {
+  test("does not leak iterations across runs", async () => {
+    const finding = makeAdversarialFinding("from run 1");
+    const capturedPrior: (Iteration[] | undefined)[] = [];
+    _reviewAdversarialDeps.runAdversarialReview = mock(async (opts) => {
+      capturedPrior.push(opts.priorAdversarialIterations);
+      return makeAdvCheckResult(false, [finding]);
+    });
+
+    const orchestrator = new ReviewOrchestrator();
+
+    // Run 1: adversarial fails, map gets an entry
+    const ctx1 = makeMinimalCtx(STORY_ID, makeAdvConfig());
+    await orchestrator.reviewFromContext(ctx1);
+
+    // End of run 1: reset
+    orchestrator.reset();
+
+    // Run 2: fresh start, same storyId — should see no prior iterations
+    const ctx2 = makeMinimalCtx(STORY_ID, makeAdvConfig());
+    await orchestrator.reviewFromContext(ctx2);
+
+    expect(capturedPrior[1]).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Patch A (3.1.1):** Replace count-only table in `buildPriorIterationsBlock` with verdict-bound finding text. Each round now renders numbered findings with `[severity / category] file:line`, `Message:`, `Suggestion:`, and optional `acQuote:`. A mandatory `addressed / still-blocking / never-an-issue` verdict template forces the reviewer to classify each prior finding before producing new ones. 6000-char token guard collapses rounds older than the last two to one-liners.
- **Patch B (3.1.2):** Move prior-iterations lifetime from `PipelineContext` (attempt-scoped, dies on ctx recreation) to per-story maps on the `ReviewOrchestrator` singleton (run-scoped). `clearStory()` wired at all `markStoryPassed` / `markStoryFailed` terminal sites (completion stage, parallel coordinator ×4, iteration runner, pipeline result handler); `reset()` called at `runCompletionPhase` end.
- Both patches apply to adversarial **and** semantic reviewers.
- ADR-022 §8 and audit-logging section amended to reflect the new block format and map-based lifetime.

## Root cause

PR 3.1 (ADR-022 phase 5) wired `priorAdversarialIterations` carry-forward end-to-end but left two defects that kept goalpost-moving alive in the `retry-strategy-consolidation` runs (US-005b 4-round trace, US-004 semantic loop):
1. The block only showed counts (`1 [test-gap]`) — reviewers couldn't judge whether the prior finding was addressed.
2. State lived on `PipelineContext`; "agent gave up" → new attempt → new ctx → history lost mid-run.

## Test plan

- [ ] `bun run lint` — clean
- [ ] `bun run typecheck` — clean
- [ ] `timeout 90 bun test test/unit/prompts/builders/prior-iterations-builder.test.ts test/unit/review/orchestrator-prior-iterations.test.ts test/integration/review/prior-iterations-survive-rectify.test.ts --timeout=15000` — 35 pass
- [ ] Related ops/builder tests (adversarial-review, semantic-review, review-builder, adversarial-review-builder) — 94 pass
- [ ] Re-run `retry-strategy-consolidation` as 2nd-pass telemetry gate (out of scope for this PR — tracked in issue #736)