### PR TITLE
fix(execution): tighten detectMergeConflict to prevent false positives

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -181,11 +181,11 @@ export async function hasCommitsForStory(workdir: string, storyId: string, maxCo
 /**
  * Detect if git operation output contains merge conflict markers.
  *
- * Git outputs "CONFLICT" in uppercase for merge/rebase conflicts.
- * Also checks lowercase "conflict" for edge cases.
+ * Matches git-specific conflict signals only — not general use of the word
+ * "conflict" in agent output (e.g. HTTP 409 Conflict implementations).
  *
  * @param output - Combined stdout/stderr output from a git operation
- * @returns true if output contains CONFLICT markers
+ * @returns true if output contains git conflict markers
  *
  * @example
  * ```typescript
@@ -196,7 +196,14 @@ export async function hasCommitsForStory(workdir: string, storyId: string, maxCo
  * ```
  */
 export function detectMergeConflict(output: string): boolean {
-  return output.includes("CONFLICT") || output.includes("conflict");
+  return (
+    output.includes("<<<<<<<") ||
+    output.includes(">>>>>>>") ||
+    // "CONFLICT (content):", "CONFLICT (delete/modify):", etc.
+    /\bCONFLICT\s*\(/.test(output) ||
+    // "Merge conflict in <file>"
+    output.includes("Merge conflict in")
+  );
 }
 
 /**

--- a/test/unit/utils/git.test.ts
+++ b/test/unit/utils/git.test.ts
@@ -5,18 +5,15 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { _gitDeps, captureOutputFiles, detectMergeConflict } from "../../../src/utils/git";
+import { _gitDeps, captureOutputFiles, detectMergeConflict } from "@/utils/git";
 
 describe("detectMergeConflict", () => {
-  test("returns true when output contains uppercase CONFLICT", () => {
+  // True positives — real git conflict signals
+  test("returns true for CONFLICT (content): marker", () => {
     expect(detectMergeConflict("CONFLICT (content): Merge conflict in src/foo.ts")).toBe(true);
   });
 
-  test("returns true when output contains lowercase conflict", () => {
-    expect(detectMergeConflict("Auto-merging failed due to conflict in file")).toBe(true);
-  });
-
-  test("returns true for typical git merge CONFLICT output", () => {
+  test("returns true for typical git merge output with CONFLICT (content):", () => {
     const output = [
       "Auto-merging src/index.ts",
       "CONFLICT (content): Merge conflict in src/index.ts",
@@ -25,11 +22,48 @@ describe("detectMergeConflict", () => {
     expect(detectMergeConflict(output)).toBe(true);
   });
 
-  test("returns true for git rebase CONFLICT output", () => {
+  test("returns true for CONFLICT (modify/delete): rebase output", () => {
     const output = "CONFLICT (modify/delete): src/bar.ts deleted in HEAD";
     expect(detectMergeConflict(output)).toBe(true);
   });
 
+  test("returns true when <<<<<<< conflict marker is present", () => {
+    const output = "<<<<<<< HEAD\nconst x = 1;\n=======\nconst x = 2;\n>>>>>>> feature";
+    expect(detectMergeConflict(output)).toBe(true);
+  });
+
+  test("returns true when >>>>>>> conflict marker is present", () => {
+    expect(detectMergeConflict(">>>>>>> feature-branch")).toBe(true);
+  });
+
+  test("returns true for 'Merge conflict in <file>' message", () => {
+    expect(detectMergeConflict("Merge conflict in src/index.ts")).toBe(true);
+  });
+
+  test("returns true when git conflict markers appear in combined stderr output", () => {
+    const combined = "stdout: commit abc123\nstderr: CONFLICT (content): Merge conflict in src/foo.ts";
+    expect(detectMergeConflict(combined)).toBe(true);
+  });
+
+  // False positives — words that must NOT trigger the detector
+  test("returns false for bare lowercase 'conflict' (e.g. HTTP 409 implementation)", () => {
+    expect(detectMergeConflict("Auto-merging failed due to conflict in file")).toBe(false);
+  });
+
+  test("returns false for HTTP 409 Conflict in agent output", () => {
+    const output = "throw new HttpException('HTTP 409 Conflict: duplicate connection', 409)";
+    expect(detectMergeConflict(output)).toBe(false);
+  });
+
+  test("returns false for 'already-synced conflict' wording in code comments", () => {
+    expect(detectMergeConflict("// return 409 when there is a duplicate conflict")).toBe(false);
+  });
+
+  test("returns false for CONFLICT without parenthesised type (unstructured word)", () => {
+    expect(detectMergeConflict("stderr: CONFLICT detected in merge")).toBe(false);
+  });
+
+  // Unrelated output
   test("returns false when output has no conflict markers", () => {
     expect(detectMergeConflict("All changes committed successfully.")).toBe(false);
   });
@@ -41,11 +75,6 @@ describe("detectMergeConflict", () => {
   test("returns false for unrelated git output", () => {
     const output = "3 files changed, 10 insertions(+), 2 deletions(-)";
     expect(detectMergeConflict(output)).toBe(false);
-  });
-
-  test("returns true when CONFLICT appears in stderr portion of combined output", () => {
-    const combined = "stdout: commit abc123\nstderr: CONFLICT detected in merge";
-    expect(detectMergeConflict(combined)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- `detectMergeConflict` previously matched any occurrence of the word \"conflict\" (including lowercase) in agent output, causing false positives
- GAP-002 triggered the merge-conflict abort hook when implementing HTTP 409 Conflict endpoints — the agent output naturally contained \"conflict\" in code, comments, and strings
- Replaced broad string matching with git-specific pattern matching: `<<<<<<<`/`>>>>>>>` markers, `CONFLICT (<type>):` status lines, and `"Merge conflict in <file>"` messages

## Changes

- `src/utils/git.ts` — `detectMergeConflict` now only matches genuine git conflict signals
- `test/unit/utils/git.test.ts` — updated tests to cover the false-positive cases (HTTP 409, code comments) and verify they no longer trigger the detector

## Test plan

- [ ] `timeout 30 bun test test/unit/utils/git.test.ts --timeout=5000` — all 21 tests pass
- [ ] Verify that agent output containing "HTTP 409 Conflict", "conflict" in comments, or "CONFLICT" as a bare word does not fire the merge-conflict trigger
- [ ] Verify that real git conflict output (`CONFLICT (content):`, `<<<<<<<`, `Merge conflict in`) still triggers the detector