### PR TITLE
fix(ac-quote-validator): normalize inline markdown before substring match

### DIFF
--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -156,7 +156,10 @@ Worked example:
 
 **Convention / coding-standard violations almost always belong as \`"info"\`** unless an AC specifically names the convention or the symbol it concerns.
 
-If you cannot find an AC that names the **specific symbol** in your finding, downgrade to \`"info"\`. A finding dropped by the validator is worse than one correctly classified as advisory.`;
+**Scope constraints are not Acceptance Criteria:**
+The story description may contain a "Scope" section with "In:" and "Out:" bullets. These are implementation guidelines, not ACs. A finding about code changed outside the stated scope (e.g., a file listed under "Out:") cannot cite a scope constraint as its \`acQuote\`/\`acIndex\` because scope text is not in the numbered AC list. Emit scope-violation findings as \`"warning"\` — never \`"error"\`. Never use \`acIndex: 0\`; \`acIndex\` is 1-based (first AC bullet = 1).
+
+If you cannot find an AC that names the **specific symbol** in your finding, downgrade to \`"info"\` or \`"warning"\`. A finding dropped by the validator is worse than one correctly classified as advisory.`;
 
 /**
  * Build the diff section for "ref" mode.

--- a/src/review/ac-quote-validator.ts
+++ b/src/review/ac-quote-validator.ts
@@ -45,6 +45,18 @@ function normalizeWs(s: string): string {
   return s.replace(/\s+/g, " ").trim();
 }
 
+/**
+ * Strip inline markdown formatting (backticks, bold, italic) for substring matching.
+ *
+ * The AC-quote validator's purpose is to confirm the model cited real AC text, not to
+ * enforce markdown formatting fidelity. LLMs routinely drop backtick spans when quoting
+ * — this normalisation prevents false `ac_quote_not_substring` rejections caused solely
+ * by backtick presence/absence.
+ */
+function stripMarkdownInline(s: string): string {
+  return s.replace(/`/g, "").replace(/\*\*/g, "").replace(/\*/g, "");
+}
+
 // ─── Locus extraction ─────────────────────────────────────────────────────────
 
 /**
@@ -108,8 +120,8 @@ export function validateAcQuote(finding: AcQuotable, acceptanceCriteria: string[
     return { valid: false, code: "ac_index_out_of_range" };
   }
 
-  const acText = normalizeWs(acceptanceCriteria[acIndex - 1]);
-  const normalizedQuote = normalizeWs(acQuote);
+  const acText = normalizeWs(stripMarkdownInline(acceptanceCriteria[acIndex - 1]));
+  const normalizedQuote = normalizeWs(stripMarkdownInline(acQuote));
 
   if (!acText.toLowerCase().includes(normalizedQuote.toLowerCase())) {
     return { valid: false, code: "ac_quote_not_substring" };

--- a/test/unit/review/ac-quote-validator.test.ts
+++ b/test/unit/review/ac-quote-validator.test.ts
@@ -116,6 +116,39 @@ describe("validateAcQuote", () => {
       expect(validateAcQuote(finding, ACS)).toEqual({ valid: true });
     });
 
+    test("acQuote without backticks matches AC text that has backtick formatting", () => {
+      // Regression: adversarial reviewer dropped backticks when copying AC text verbatim.
+      // The validator must normalise inline markdown before substring matching so that
+      // `planInteractiveOp` in the AC matches planInteractiveOp in the quote.
+      const backtickAcs = [
+        "`planInteractiveOp` is a `RunOperation` exported from `src/operations/plan.ts` with `kind: \"run\"`.",
+        "The `jsonRepair` method must return a non-empty string containing the word JSON.",
+      ];
+      const finding: AcQuotable = {
+        severity: "error",
+        file: "src/operations/plan.ts",
+        issue: "planInteractiveOp is not exported",
+        // acQuote is the AC text with backticks stripped — as the LLM commonly produces
+        acQuote: "planInteractiveOp is a RunOperation exported from src/operations/plan.ts",
+        acIndex: 1,
+      };
+      expect(validateAcQuote(finding, backtickAcs)).toEqual({ valid: true });
+    });
+
+    test("acQuote with backticks also matches AC text that has backtick formatting", () => {
+      const backtickAcs = [
+        "`planInteractiveOp` is a `RunOperation` exported from `src/operations/plan.ts`.",
+      ];
+      const finding: AcQuotable = {
+        severity: "error",
+        file: "src/operations/plan.ts",
+        issue: "planInteractiveOp missing",
+        acQuote: "`planInteractiveOp` is a `RunOperation` exported from `src/operations/plan.ts`",
+        acIndex: 1,
+      };
+      expect(validateAcQuote(finding, backtickAcs)).toEqual({ valid: true });
+    });
+
     test("no acceptanceCriteria → ac_index_out_of_range", () => {
       const finding = makeFinding({ severity: "error", acQuote: "something", acIndex: 1 });
       expect(validateAcQuote(finding, [])).toEqual({ valid: false, code: "ac_index_out_of_range" });


### PR DESCRIPTION
## Summary

Fixes #978.

- **`src/review/ac-quote-validator.ts`**: add `stripMarkdownInline()` to strip backticks and bold/italic markers from both the AC text and `acQuote` before the substring comparison. LLMs routinely drop formatting when quoting — the validator's job is to confirm the model cited real AC text, not to enforce backtick fidelity.
- **`src/prompts/builders/adversarial-review-builder.ts`**: add guidance that scope constraints (In:/Out: bullets) are not ACs, scope-violation findings must be `"warning"` not `"error"`, and `acIndex: 0` is always invalid (1-based).
- **`test/unit/review/ac-quote-validator.test.ts`**: two regression tests — backtick-stripped quote against backtick-decorated AC text, and the converse (both with backticks).

## Root Cause

In the `plan-interactive-callop` dogfood run, the adversarial reviewer quoted AC #3 without backticks while the stored AC text had inline backtick spans. `String.includes()` failed, the finding was dropped as ungrounded, and the fail-closed guard blocked the story twice across two escalation tiers. All 528 existing review unit tests continue to pass.

## Test plan

- [ ] `timeout 30 bun test test/unit/review/ac-quote-validator.test.ts` — 25 pass (was 23)
- [ ] `timeout 60 bun test test/unit/review/` — 528 pass
- [ ] Re-run `plan-interactive-callop` dogfood with fix applied — adversarial reviewer's backtick-stripped findings now validate correctly