### PR TITLE
[codex] Fix watchdog handling for ACP tool-call activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `autoMode.defaultAgent`, `autoMode.fallbackOrder`, and `context.v2.fallback` config fields removed. Use `agent.default` and `agent.fallback.map` instead (ADR-012 Phase 6). Loading a config containing any of these keys throws `NaxError CONFIG_LEGACY_AGENT_KEYS` with a per-key migration pointer.
 
+### Fixed
+
+- **watchdog:** Count ACP `tool_call` / `tool_call_update` stream activity by default, and add `agent.idleWatchdog.toolCallOnlyIdleTimeoutSeconds` (default 1800s) so long-running tool-only sessions stay alive without masking runaway tool loops.
+
 ## [0.51.2] — 2026-03-22
 
 ### Added  

--- a/src/agents/acp/index.ts
+++ b/src/agents/acp/index.ts
@@ -9,7 +9,23 @@ export {
   _fallbackDeps,
   MAX_AGENT_OUTPUT_CHARS,
 } from "./adapter";
-export { createSpawnAcpClient } from "./spawn-client";
+export type { AcpClient, AcpSession, AcpSessionResponse } from "./adapter-session-types";
+export type { AcpClientOptions } from "./adapter-session-types";
+export {
+  SpawnAcpClient,
+  _spawnClientDeps,
+  createSpawnAcpClient,
+} from "./spawn-client";
+export type {
+  AcpxLineActivity as AcpLineActivity,
+  AcpxParseState as AcpParseState,
+} from "./parser";
+export {
+  createParseState,
+  finalizeParseState,
+  parseAcpxJsonLine,
+  parseAcpxJsonOutput,
+} from "./parser";
 export { parseAgentError } from "./parse-agent-error";
 export type { AgentRegistryEntry } from "./types";
 export type { SessionTokenUsage } from "./wire-types";

--- a/src/agents/acp/parser.ts
+++ b/src/agents/acp/parser.ts
@@ -25,11 +25,12 @@ export interface AcpxTokenUsage {
 
 /** Activity metadata from a single parsed line — emitted to stream listeners. */
 export interface AcpxLineActivity {
-  kind?: "message_update" | "thinking_update" | "usage_update";
+  kind?: "message_update" | "thinking_update" | "usage_update" | "tool_call_update";
   deltaBytes?: number;
   inputTokens?: number;
   outputTokens?: number;
   costUsd?: number;
+  toolName?: string;
 }
 
 /** Mutable accumulator for incremental NDJSON line parsing. */
@@ -61,7 +62,8 @@ export function createParseState(): AcpxParseState {
 /**
  * Process a single NDJSON line into the accumulator state.
  * Handles JSON-RPC envelope format (acpx v0.3+) and legacy flat NDJSON.
- * Returns activity metadata if the line contains a stream event (message_update, thinking_update, usage_update).
+ * Returns activity metadata if the line contains a stream event
+ * (message_update, thinking_update, usage_update, tool_call_update).
  * Activity metadata includes only deltaBytes/tokens/cost — never raw text content.
  */
 export function parseAcpxJsonLine(line: string, state: AcpxParseState): AcpxLineActivity | undefined {
@@ -115,6 +117,13 @@ export function parseAcpxJsonLine(line: string, state: AcpxParseState): AcpxLine
             state.exactCostUsd = update.cost.amount;
           }
           return activity;
+        }
+
+        if (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") {
+          return {
+            kind: "tool_call_update",
+            toolName: extractToolName(update),
+          };
         }
       }
 
@@ -177,6 +186,17 @@ export function parseAcpxJsonLine(line: string, state: AcpxParseState): AcpxLine
     }
   } catch {
     if (!state.text) state.text = line;
+  }
+  return undefined;
+}
+
+function extractToolName(update: Record<string, unknown>): string | undefined {
+  const directName = update.toolName;
+  if (typeof directName === "string" && directName.trim()) return directName;
+  const nestedTool = update.tool;
+  if (nestedTool && typeof nestedTool === "object") {
+    const name = (nestedTool as Record<string, unknown>).name;
+    if (typeof name === "string" && name.trim()) return name;
   }
   return undefined;
 }

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -51,7 +51,8 @@ export const _spawnClientDeps = {
  * where piped streams may not close after SIGTERM.
  *
  * When onActivity is provided, it is called immediately for each line that
- * produces activity metadata (message_update, thinking_update, usage_update).
+ * produces activity metadata
+ * (message_update, thinking_update, usage_update, tool_call_update).
  */
 async function readAndParseLines(
   stream: ReadableStream<Uint8Array>,
@@ -284,7 +285,7 @@ export class SpawnAcpSession implements AcpSession {
       // the full NDJSON output. Only extracted fields (strings + numbers) are held in
       // memory — raw bytes are discarded immediately after each line is processed.
       // .catch(() => {}) guards against stream errors (e.g. acpx crash mid-run).
-      // AC7: Emit message_update/thinking_update/usage_update events during stdout reading.
+      // AC7: Emit activity events during stdout reading.
       const parseState = createParseState();
       const onActivity = emit
         ? (activity: import("./parser").AcpxLineActivity) => {
@@ -299,6 +300,13 @@ export class SpawnAcpSession implements AcpSession {
                 inputTokens: activity.inputTokens,
                 outputTokens: activity.outputTokens,
                 costUsd: activity.costUsd,
+                timestamp: now(),
+              });
+            } else if (activity.kind === "tool_call_update") {
+              emit({
+                ...baseEvent,
+                kind: "agent.tool_call_update",
+                toolName: activity.toolName,
                 timestamp: now(),
               });
             }

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -13,12 +13,21 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { getSafeLogger } from "../../logger";
-import type { AgentStreamEvent } from "../../runtime/agent-stream-events";
-import { typedSpawn } from "../../utils/bun-deps";
+import {
+  type AcpClient,
+  type AcpClientOptions,
+  type AcpLineActivity,
+  type AcpParseState,
+  type AcpSession,
+  type AcpSessionResponse,
+  createParseState,
+  finalizeParseState,
+  parseAcpxJsonLine,
+} from "@/agents";
+import { getSafeLogger } from "@/logger";
+import type { AgentStreamEvent } from "@/runtime";
+import { typedSpawn } from "@/utils/bun-deps";
 import { buildAllowedEnv } from "../shared/env";
-import type { AcpClient, AcpClientOptions, AcpSession, AcpSessionResponse } from "./adapter-session-types";
-import { type AcpxParseState, createParseState, finalizeParseState, parseAcpxJsonLine } from "./parser";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
@@ -56,8 +65,8 @@ export const _spawnClientDeps = {
  */
 async function readAndParseLines(
   stream: ReadableStream<Uint8Array>,
-  state: AcpxParseState,
-  onActivity?: (activity: import("./parser").AcpxLineActivity) => void,
+  state: AcpParseState,
+  onActivity?: (activity: AcpLineActivity) => void,
 ): Promise<void> {
   const decoder = new TextDecoder();
   let remainder = "";
@@ -288,7 +297,7 @@ export class SpawnAcpSession implements AcpSession {
       // AC7: Emit activity events during stdout reading.
       const parseState = createParseState();
       const onActivity = emit
-        ? (activity: import("./parser").AcpxLineActivity) => {
+        ? (activity: AcpLineActivity) => {
             if (activity.kind === "message_update") {
               emit({ ...baseEvent, kind: "agent.message_update", deltaBytes: activity.deltaBytes, timestamp: now() });
             } else if (activity.kind === "thinking_update") {

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -2,6 +2,25 @@ export type { AgentAdapter, AgentCapabilities, AgentResult, AgentRunOptions, Com
 export type { InteractionHandler } from "./interaction-handler";
 export { NO_OP_INTERACTION_HANDLER } from "./interaction-handler";
 export { CompleteError, SessionFailureError } from "./types";
+export {
+  AcpAgentAdapter,
+  SpawnAcpClient,
+  _acpAdapterDeps,
+  _spawnClientDeps,
+  createParseState,
+  createSpawnAcpClient,
+  finalizeParseState,
+  parseAcpxJsonLine,
+  parseAcpxJsonOutput,
+} from "./acp";
+export type {
+  AcpClient,
+  AcpClientOptions,
+  AcpLineActivity,
+  AcpParseState,
+  AcpSession,
+  AcpSessionResponse,
+} from "./acp";
 export { getAllAgentNames, getInstalledAgents, checkAgentHealth, KNOWN_AGENT_NAMES } from "./registry";
 export type { ModelCostRates, TokenUsage, CostEstimate, TokenUsageWithConfidence } from "./cost";
 export {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -41,11 +41,13 @@ export {
   NaxConfigSchema,
   AcceptanceConfigSchema,
 } from "./schema";
+export { ConfiguredModelSchema, ModelTierSchema } from "./schemas-model";
 export { loadConfig, findProjectDir, globalConfigPath } from "./loader";
 export { validateConfig, type ValidationResult } from "./validate"; // @deprecated: Use NaxConfigSchema.safeParse() instead
 export { validateDirectory, validateFilePath, isWithinDirectory, MAX_DIRECTORY_DEPTH } from "./path-security";
 export { globalConfigDir, projectConfigDir } from "./paths";
 export { deepMergeConfig } from "./merger";
+export type { PipelineStage } from "./permissions";
 export { resolveProfileName, loadProfile, loadProfileEnv, listProfiles } from "./profile";
 export { pickSelector, reshapeSelector } from "./selector";
 export type { ConfigSelector } from "./selector";

--- a/src/config/runtime-types-agent.ts
+++ b/src/config/runtime-types-agent.ts
@@ -48,8 +48,10 @@ export interface IdleWatchdogConfig {
   mode?: "off" | "observe" | "warn-then-cancel" | "cancel";
   /** Idle timeout in seconds before watchdog triggers (default: 900) */
   idleTimeoutSeconds?: number;
-  /** Activity kinds that reset the idle timer (default: all message, thinking, usage updates) */
-  activityKinds?: Array<"message_update" | "thinking_update" | "usage_update">;
+  /** Max seconds a call may emit only tool-call activity before watchdog triggers (default: 1800, 0 disables this cap) */
+  toolCallOnlyIdleTimeoutSeconds?: number;
+  /** Activity kinds that reset the idle timer (default: all message, thinking, usage, and tool-call updates) */
+  activityKinds?: Array<"message_update" | "thinking_update" | "usage_update" | "tool_call_update">;
   /** Grace period in seconds before cancel actually happens (used in warn-then-cancel mode, default: 10) */
   cancelGraceSeconds?: number;
   /** Maximum retry attempts before emitting terminal failure (default: 3) */

--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -4,8 +4,8 @@
  * Extracted from schemas.ts to stay within the 600-line file limit.
  */
 
+import { ConfiguredModelSchema, ModelTierSchema } from "@/config";
 import { z } from "zod";
-import { ConfiguredModelSchema, ModelTierSchema } from "./schemas-model";
 
 export const PlanConfigSchema = z.object({
   model: ConfiguredModelSchema,

--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -135,14 +135,16 @@ export const DEFAULT_AGENT_IDLE_WATCHDOG_CONFIG: {
   enabled: boolean;
   mode: "warn-then-cancel";
   idleTimeoutSeconds: number;
-  activityKinds: Array<"message_update" | "thinking_update" | "usage_update">;
+  toolCallOnlyIdleTimeoutSeconds: number;
+  activityKinds: Array<"message_update" | "thinking_update" | "usage_update" | "tool_call_update">;
   cancelGraceSeconds: number;
   maxRetryAttempts: number;
 } = {
   enabled: true,
   mode: "warn-then-cancel",
   idleTimeoutSeconds: 900,
-  activityKinds: ["message_update", "thinking_update", "usage_update"],
+  toolCallOnlyIdleTimeoutSeconds: 1800,
+  activityKinds: ["message_update", "thinking_update", "usage_update", "tool_call_update"],
   cancelGraceSeconds: 10,
   maxRetryAttempts: 3,
 };
@@ -152,9 +154,10 @@ const AgentIdleWatchdogConfigSchema = z
     enabled: z.boolean().default(true),
     mode: z.enum(["off", "observe", "warn-then-cancel", "cancel"]).default("warn-then-cancel"),
     idleTimeoutSeconds: z.number().nonnegative().default(900),
+    toolCallOnlyIdleTimeoutSeconds: z.number().nonnegative().default(1800),
     activityKinds: z
-      .array(z.enum(["message_update", "thinking_update", "usage_update"]))
-      .default(["message_update", "thinking_update", "usage_update"]),
+      .array(z.enum(["message_update", "thinking_update", "usage_update", "tool_call_update"]))
+      .default(["message_update", "thinking_update", "usage_update", "tool_call_update"]),
     cancelGraceSeconds: z.number().nonnegative().default(10),
     maxRetryAttempts: z.number().int().nonnegative().default(3),
   })

--- a/src/runtime/agent-stream-events.ts
+++ b/src/runtime/agent-stream-events.ts
@@ -36,6 +36,11 @@ export interface AgentUsageUpdateEvent extends AgentStreamEventBase {
   readonly costUsd?: number;
 }
 
+export interface AgentToolCallUpdateEvent extends AgentStreamEventBase {
+  readonly kind: "agent.tool_call_update";
+  readonly toolName?: string;
+}
+
 export interface AgentProcessUpdateEvent extends AgentStreamEventBase {
   readonly kind: "agent.process_update";
   readonly status: "spawned" | "stderr" | "cancelled" | "exited";
@@ -53,6 +58,7 @@ export type AgentStreamEvent =
   | AgentMessageUpdateEvent
   | AgentThinkingUpdateEvent
   | AgentUsageUpdateEvent
+  | AgentToolCallUpdateEvent
   | AgentProcessUpdateEvent
   | AgentCallEndedEvent;
 

--- a/src/runtime/agent-stream-events.ts
+++ b/src/runtime/agent-stream-events.ts
@@ -1,6 +1,6 @@
-import type { PipelineStage } from "../config/permissions";
-import { getSafeLogger } from "../logger";
-import { errorMessage } from "../utils/errors";
+import type { PipelineStage } from "@/config";
+import { getSafeLogger } from "@/logger";
+import { errorMessage } from "@/utils/errors";
 
 export interface AgentStreamEventBase {
   readonly callId: string;

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -50,12 +50,15 @@ export type {
   AgentCallStartedEvent,
   AgentMessageUpdateEvent,
   AgentThinkingUpdateEvent,
+  AgentToolCallUpdateEvent,
   AgentUsageUpdateEvent,
   AgentProcessUpdateEvent,
   AgentCallEndedEvent,
   AgentStreamListener,
 } from "./agent-stream-events";
 export { AgentStreamEventBus } from "./agent-stream-events";
+export { attachAgentIdleWatchdog, attachAgentStreamLogging } from "./middleware";
+export type { WatchdogState } from "./middleware";
 
 import { basename, join } from "node:path";
 import type { IAgentManager } from "../agents";

--- a/src/runtime/middleware/agent-stream-logging.ts
+++ b/src/runtime/middleware/agent-stream-logging.ts
@@ -1,5 +1,5 @@
-import { getSafeLogger } from "../../logger";
-import type { AgentStreamEvent, IAgentStreamEventBus } from "../agent-stream-events";
+import { getSafeLogger } from "@/logger";
+import type { AgentStreamEvent, IAgentStreamEventBus } from "@/runtime";
 
 interface CallTrackingState {
   callId: string;

--- a/src/runtime/middleware/agent-stream-logging.ts
+++ b/src/runtime/middleware/agent-stream-logging.ts
@@ -11,6 +11,7 @@ interface CallTrackingState {
   messageUpdates: number;
   thinkingUpdates: number;
   usageUpdates: number;
+  toolCallUpdates: number;
 }
 
 export function attachAgentStreamLogging(bus: IAgentStreamEventBus, runId: string): () => void {
@@ -30,6 +31,7 @@ export function attachAgentStreamLogging(bus: IAgentStreamEventBus, runId: strin
           messageUpdates: 0,
           thinkingUpdates: 0,
           usageUpdates: 0,
+          toolCallUpdates: 0,
         });
         getSafeLogger()?.info("agent-stream", "Agent call started", {
           storyId: event.storyId,
@@ -66,6 +68,14 @@ export function attachAgentStreamLogging(bus: IAgentStreamEventBus, runId: strin
         }
         break;
       }
+      case "agent.tool_call_update": {
+        const state = activeCalls.get(event.callId);
+        if (state) {
+          state.toolCallUpdates++;
+          state.lastActivityAt = event.timestamp;
+        }
+        break;
+      }
       case "agent.process_update":
         // Intentionally ignored — process lifecycle events are not activity signals
         break;
@@ -82,6 +92,7 @@ export function attachAgentStreamLogging(bus: IAgentStreamEventBus, runId: strin
             messageUpdates: state.messageUpdates,
             thinkingUpdates: state.thinkingUpdates,
             usageUpdates: state.usageUpdates,
+            toolCallUpdates: state.toolCallUpdates,
             lastActivityAt: state.lastActivityAt,
             idleMs,
             status: event.status,

--- a/src/runtime/middleware/idle-watchdog.ts
+++ b/src/runtime/middleware/idle-watchdog.ts
@@ -12,16 +12,21 @@ export interface WatchdogState {
   readonly pid?: number;
   startedAt: number;
   lastActivityAt: number;
+  lastNonToolCallActivityAt: number;
   messageUpdates: number;
   thinkingUpdates: number;
   usageUpdates: number;
+  toolCallUpdates: number;
 }
+
+type IdleTimeoutReason = "idle_timeout_exceeded" | "tool_call_only_idle_timeout_exceeded";
 
 interface WatchdogStateInternal extends WatchdogState {
   cancelAttempts: number;
   graceTimer?: ReturnType<typeof setTimeout>;
   inGracePeriod: boolean;
   warnedForCurrentIdlePeriod: boolean;
+  graceReason?: IdleTimeoutReason;
 }
 
 // setTimeout is permitted here for the recurring tick and grace period cancellation via clearTimeout
@@ -34,20 +39,32 @@ function scheduleTickIfNeeded(
   tickRef.handle = setTimeout(tick, intervalMs);
 }
 
-function handleObserveTimeout(state: WatchdogStateInternal, idleDurationMs: number): void {
+function handleObserveTimeout(
+  state: WatchdogStateInternal,
+  reason: IdleTimeoutReason,
+  idleDurationMs: number,
+  nonToolCallIdleMs: number,
+): void {
   if (state.warnedForCurrentIdlePeriod) return;
   state.warnedForCurrentIdlePeriod = true;
-  getSafeLogger()?.warn("idle-watchdog", "Idle timeout exceeded", {
-    storyId: state.storyId,
-    key: "idle_timeout_exceeded",
-    callId: state.callId,
-    mode: "observe",
-    idleDurationMs,
-  });
+  getSafeLogger()?.warn(
+    "idle-watchdog",
+    reason === "tool_call_only_idle_timeout_exceeded" ? "Tool-call-only idle timeout exceeded" : "Idle timeout exceeded",
+    {
+      storyId: state.storyId,
+      key: reason,
+      callId: state.callId,
+      mode: "observe",
+      idleDurationMs,
+      nonToolCallIdleMs,
+      toolCallUpdates: state.toolCallUpdates,
+    },
+  );
 }
 
 async function handleCancelTimeout(
   state: WatchdogStateInternal,
+  reason: IdleTimeoutReason,
   controllerRegistry: Map<string, () => Promise<void>>,
   maxRetryAttempts: number,
   activeStates: Map<string, WatchdogStateInternal>,
@@ -65,22 +82,29 @@ async function handleCancelTimeout(
   state.cancelAttempts++;
   // Reset synchronously to prevent double-trigger in next tick
   state.lastActivityAt = Date.now();
-  getSafeLogger()?.warn("idle-watchdog", "Canceling idle call", {
-    storyId: state.storyId,
-    key: "idle_timeout_exceeded",
-    callId: state.callId,
-    mode: "cancel",
-    action: "cancel",
-  });
+  getSafeLogger()?.warn(
+    "idle-watchdog",
+    reason === "tool_call_only_idle_timeout_exceeded" ? "Canceling tool-call-only idle call" : "Canceling idle call",
+    {
+      storyId: state.storyId,
+      key: reason,
+      callId: state.callId,
+      mode: "cancel",
+      action: "cancel",
+      toolCallUpdates: state.toolCallUpdates,
+    },
+  );
   const cancel = controllerRegistry.get(state.callId);
   if (cancel) await cancel().catch(() => {});
 }
 
 function handleWarnThenCancelTimeout(
   state: WatchdogStateInternal,
+  reason: IdleTimeoutReason,
   controllerRegistry: Map<string, () => Promise<void>>,
   maxRetryAttempts: number,
   idleTimeoutMs: number,
+  toolCallOnlyTimeoutMs: number,
   graceMs: number,
   activeStates: Map<string, WatchdogStateInternal>,
 ): void {
@@ -94,20 +118,30 @@ function handleWarnThenCancelTimeout(
     activeStates.delete(state.callId);
     return;
   }
-  getSafeLogger()?.warn("idle-watchdog", "Idle timeout exceeded, entering grace period", {
-    storyId: state.storyId,
-    key: "idle_timeout_exceeded",
-    callId: state.callId,
-    mode: "warn-then-cancel",
-    gracePeriodMs: graceMs,
-  });
+  getSafeLogger()?.warn(
+    "idle-watchdog",
+    reason === "tool_call_only_idle_timeout_exceeded"
+      ? "Tool-call-only idle timeout exceeded, entering grace period"
+      : "Idle timeout exceeded, entering grace period",
+    {
+      storyId: state.storyId,
+      key: reason,
+      callId: state.callId,
+      mode: "warn-then-cancel",
+      gracePeriodMs: graceMs,
+      toolCallUpdates: state.toolCallUpdates,
+    },
+  );
   state.inGracePeriod = true;
+  state.graceReason = reason;
   // setTimeout permitted here for grace period cancellation via clearTimeout
   state.graceTimer = setTimeout(async () => {
     if (!activeStates.has(state.callId)) return;
     state.inGracePeriod = false;
     state.graceTimer = undefined;
-    if (Date.now() - state.lastActivityAt < idleTimeoutMs) return;
+    state.graceReason = undefined;
+    const currentReason = getTimeoutReason(state, Date.now(), idleTimeoutMs, toolCallOnlyTimeoutMs);
+    if (currentReason !== reason) return;
     state.cancelAttempts++;
     state.lastActivityAt = Date.now();
     const cancel = controllerRegistry.get(state.callId);
@@ -115,14 +149,36 @@ function handleWarnThenCancelTimeout(
   }, graceMs);
 }
 
-function resetActivity(state: WatchdogStateInternal, newTimestamp: number): void {
-  state.lastActivityAt = newTimestamp;
-  state.warnedForCurrentIdlePeriod = false;
+function clearGrace(state: WatchdogStateInternal): void {
   if (state.inGracePeriod && state.graceTimer !== undefined) {
     clearTimeout(state.graceTimer);
     state.graceTimer = undefined;
     state.inGracePeriod = false;
+    state.graceReason = undefined;
   }
+}
+
+function resetActivity(
+  state: WatchdogStateInternal,
+  newTimestamp: number,
+  options: { clearGrace: boolean },
+): void {
+  state.lastActivityAt = newTimestamp;
+  state.warnedForCurrentIdlePeriod = false;
+  if (options.clearGrace) clearGrace(state);
+}
+
+function getTimeoutReason(
+  state: WatchdogStateInternal,
+  now: number,
+  idleTimeoutMs: number,
+  toolCallOnlyTimeoutMs: number,
+): IdleTimeoutReason | undefined {
+  if (now - state.lastActivityAt >= idleTimeoutMs) return "idle_timeout_exceeded";
+  if (toolCallOnlyTimeoutMs > idleTimeoutMs && now - state.lastNonToolCallActivityAt >= toolCallOnlyTimeoutMs) {
+    return "tool_call_only_idle_timeout_exceeded";
+  }
+  return undefined;
 }
 
 export function attachAgentIdleWatchdog(
@@ -137,10 +193,11 @@ export function attachAgentIdleWatchdog(
 
   const mode = watchdogConfig.mode;
   const idleTimeoutMs = (watchdogConfig.idleTimeoutSeconds ?? 30) * 1000;
+  const toolCallOnlyTimeoutMs = (watchdogConfig.toolCallOnlyIdleTimeoutSeconds ?? 0) * 1000;
   const graceMs = (watchdogConfig.cancelGraceSeconds ?? 5) * 1000;
   const maxRetryAttempts = watchdogConfig.maxRetryAttempts ?? 3;
   const activityKinds = new Set<string>(
-    watchdogConfig.activityKinds ?? ["message_update", "thinking_update", "usage_update"],
+    watchdogConfig.activityKinds ?? ["message_update", "thinking_update", "usage_update", "tool_call_update"],
   );
   // Poll at 1/4 of the idle timeout so detection latency is at most idleTimeout * 5/4
   // rather than up to 2× idleTimeout when the tick interval equals idleTimeoutMs.
@@ -155,11 +212,24 @@ export function attachAgentIdleWatchdog(
     for (const [, state] of activeStates) {
       if (state.inGracePeriod) continue;
       const idleDurationMs = now - state.lastActivityAt;
-      if (idleDurationMs < idleTimeoutMs) continue;
-      if (mode === "observe") handleObserveTimeout(state, idleDurationMs);
-      else if (mode === "cancel") void handleCancelTimeout(state, controllerRegistry, maxRetryAttempts, activeStates);
+      const nonToolCallIdleMs = now - state.lastNonToolCallActivityAt;
+      const reason = getTimeoutReason(state, now, idleTimeoutMs, toolCallOnlyTimeoutMs);
+      if (!reason) continue;
+      if (mode === "observe") handleObserveTimeout(state, reason, idleDurationMs, nonToolCallIdleMs);
+      else if (mode === "cancel") {
+        void handleCancelTimeout(state, reason, controllerRegistry, maxRetryAttempts, activeStates);
+      }
       else if (mode === "warn-then-cancel") {
-        handleWarnThenCancelTimeout(state, controllerRegistry, maxRetryAttempts, idleTimeoutMs, graceMs, activeStates);
+        handleWarnThenCancelTimeout(
+          state,
+          reason,
+          controllerRegistry,
+          maxRetryAttempts,
+          idleTimeoutMs,
+          toolCallOnlyTimeoutMs,
+          graceMs,
+          activeStates,
+        );
       }
     }
     if (activeStates.size > 0) scheduleTickIfNeeded(tickRef, tick, tickIntervalMs);
@@ -178,9 +248,11 @@ export function attachAgentIdleWatchdog(
           pid: event.pid,
           startedAt: now,
           lastActivityAt: now,
+          lastNonToolCallActivityAt: now,
           messageUpdates: 0,
           thinkingUpdates: 0,
           usageUpdates: 0,
+          toolCallUpdates: 0,
           cancelAttempts: 0,
           inGracePeriod: false,
           warnedForCurrentIdlePeriod: false,
@@ -190,6 +262,7 @@ export function attachAgentIdleWatchdog(
           callId: event.callId,
           mode,
           idleTimeoutMs,
+          toolCallOnlyTimeoutMs,
         });
         scheduleTickIfNeeded(tickRef, tick, tickIntervalMs);
         break;
@@ -198,7 +271,8 @@ export function attachAgentIdleWatchdog(
         const state = activeStates.get(event.callId);
         if (state && activityKinds.has("message_update")) {
           state.messageUpdates++;
-          resetActivity(state, event.timestamp);
+          state.lastNonToolCallActivityAt = event.timestamp;
+          resetActivity(state, event.timestamp, { clearGrace: true });
         }
         break;
       }
@@ -206,7 +280,8 @@ export function attachAgentIdleWatchdog(
         const state = activeStates.get(event.callId);
         if (state && activityKinds.has("thinking_update")) {
           state.thinkingUpdates++;
-          resetActivity(state, event.timestamp);
+          state.lastNonToolCallActivityAt = event.timestamp;
+          resetActivity(state, event.timestamp, { clearGrace: true });
         }
         break;
       }
@@ -214,7 +289,18 @@ export function attachAgentIdleWatchdog(
         const state = activeStates.get(event.callId);
         if (state && activityKinds.has("usage_update")) {
           state.usageUpdates++;
-          resetActivity(state, event.timestamp);
+          state.lastNonToolCallActivityAt = event.timestamp;
+          resetActivity(state, event.timestamp, { clearGrace: true });
+        }
+        break;
+      }
+      case "agent.tool_call_update": {
+        const state = activeStates.get(event.callId);
+        if (state && activityKinds.has("tool_call_update")) {
+          state.toolCallUpdates++;
+          resetActivity(state, event.timestamp, {
+            clearGrace: state.graceReason === "idle_timeout_exceeded",
+          });
         }
         break;
       }

--- a/src/runtime/middleware/idle-watchdog.ts
+++ b/src/runtime/middleware/idle-watchdog.ts
@@ -49,7 +49,9 @@ function handleObserveTimeout(
   state.warnedForCurrentIdlePeriod = true;
   getSafeLogger()?.warn(
     "idle-watchdog",
-    reason === "tool_call_only_idle_timeout_exceeded" ? "Tool-call-only idle timeout exceeded" : "Idle timeout exceeded",
+    reason === "tool_call_only_idle_timeout_exceeded"
+      ? "Tool-call-only idle timeout exceeded"
+      : "Idle timeout exceeded",
     {
       storyId: state.storyId,
       key: reason,
@@ -158,11 +160,7 @@ function clearGrace(state: WatchdogStateInternal): void {
   }
 }
 
-function resetActivity(
-  state: WatchdogStateInternal,
-  newTimestamp: number,
-  options: { clearGrace: boolean },
-): void {
+function resetActivity(state: WatchdogStateInternal, newTimestamp: number, options: { clearGrace: boolean }): void {
   state.lastActivityAt = newTimestamp;
   state.warnedForCurrentIdlePeriod = false;
   if (options.clearGrace) clearGrace(state);
@@ -218,8 +216,7 @@ export function attachAgentIdleWatchdog(
       if (mode === "observe") handleObserveTimeout(state, reason, idleDurationMs, nonToolCallIdleMs);
       else if (mode === "cancel") {
         void handleCancelTimeout(state, reason, controllerRegistry, maxRetryAttempts, activeStates);
-      }
-      else if (mode === "warn-then-cancel") {
+      } else if (mode === "warn-then-cancel") {
         handleWarnThenCancelTimeout(
           state,
           reason,

--- a/src/runtime/middleware/idle-watchdog.ts
+++ b/src/runtime/middleware/idle-watchdog.ts
@@ -1,7 +1,6 @@
-import type { NaxConfig } from "../../config";
-import type { PipelineStage } from "../../config/permissions";
-import { getSafeLogger } from "../../logger";
-import type { AgentStreamEvent, IAgentStreamEventBus } from "../agent-stream-events";
+import type { NaxConfig, PipelineStage } from "@/config";
+import { getSafeLogger } from "@/logger";
+import type { AgentStreamEvent, IAgentStreamEventBus } from "@/runtime";
 
 export interface WatchdogState {
   readonly callId: string;

--- a/src/tui/hooks/useAgentStreamEvents.ts
+++ b/src/tui/hooks/useAgentStreamEvents.ts
@@ -11,6 +11,7 @@ export interface ActiveCallState {
   messageUpdates: number;
   thinkingUpdates: number;
   usageUpdates: number;
+  toolCallUpdates: number;
   status: "active" | "ended";
 }
 
@@ -39,6 +40,7 @@ export function useAgentStreamEvents(bus?: IAgentStreamEventBus | null): {
               messageUpdates: 0,
               thinkingUpdates: 0,
               usageUpdates: 0,
+              toolCallUpdates: 0,
               status: "active",
             });
             break;
@@ -71,6 +73,17 @@ export function useAgentStreamEvents(bus?: IAgentStreamEventBus | null): {
               next.set(event.callId, {
                 ...state,
                 usageUpdates: state.usageUpdates + 1,
+                lastActivityAt: event.timestamp,
+              });
+            }
+            break;
+          }
+          case "agent.tool_call_update": {
+            const state = next.get(event.callId);
+            if (state) {
+              next.set(event.callId, {
+                ...state,
+                toolCallUpdates: state.toolCallUpdates + 1,
                 lastActivityAt: event.timestamp,
               });
             }

--- a/src/tui/hooks/useAgentStreamEvents.ts
+++ b/src/tui/hooks/useAgentStreamEvents.ts
@@ -1,5 +1,5 @@
+import type { AgentStreamEvent, IAgentStreamEventBus } from "@/runtime";
 import { useEffect, useState } from "react";
-import type { AgentStreamEvent, IAgentStreamEventBus } from "../../runtime/agent-stream-events";
 
 export interface ActiveCallState {
   callId: string;

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -22,3 +22,4 @@ export {
   makeSpawnMock,
   mockDiffUtilsDeps,
 } from "./review-audit";
+export { withDepsRestore } from "./deps";

--- a/test/integration/agents/fail-stale-watchdog.test.ts
+++ b/test/integration/agents/fail-stale-watchdog.test.ts
@@ -20,13 +20,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { AcpAgentAdapter, _acpAdapterDeps } from "../../../src/agents/acp/adapter";
-import type { AcpClient, AcpSession, AcpSessionResponse } from "../../../src/agents/acp/adapter";
-import type { AcpClientOptions } from "../../../src/agents/acp/adapter-session-types";
-import { AgentStreamEventBus } from "../../../src/runtime/agent-stream-events";
-import type { AgentStreamEvent } from "../../../src/runtime/agent-stream-events";
-import { attachAgentIdleWatchdog } from "../../../src/runtime/middleware";
-import { makeNaxConfig } from "../../helpers";
+import { AcpAgentAdapter, type AcpClient, type AcpClientOptions, type AcpSession, type AcpSessionResponse, _acpAdapterDeps } from "@/agents";
+import { AgentStreamEventBus, attachAgentIdleWatchdog, type AgentStreamEvent } from "@/runtime";
+import { makeNaxConfig } from "@test/helpers";
 
 // setTimeout is permitted here for controlled test delays (not Bun.sleep — see testing-rules.md)
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/integration/agents/fail-stale-watchdog.test.ts
+++ b/test/integration/agents/fail-stale-watchdog.test.ts
@@ -37,11 +37,13 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 
 function makeWatchdogConfig(
   idleTimeoutMs: number,
-  activityKinds: ("message_update" | "thinking_update" | "usage_update")[] = [
+  activityKinds: ("message_update" | "thinking_update" | "usage_update" | "tool_call_update")[] = [
     "message_update",
     "thinking_update",
     "usage_update",
+    "tool_call_update",
   ],
+  toolCallOnlyIdleTimeoutMs = idleTimeoutMs * 2,
 ) {
   return makeNaxConfig({
     agent: {
@@ -49,6 +51,7 @@ function makeWatchdogConfig(
         enabled: true,
         mode: "cancel",
         idleTimeoutSeconds: idleTimeoutMs / 1000,
+        toolCallOnlyIdleTimeoutSeconds: toolCallOnlyIdleTimeoutMs / 1000,
         activityKinds,
         cancelGraceSeconds: 0,
         maxRetryAttempts: 1,
@@ -154,7 +157,11 @@ function makeHangingMockClient(opts: AcpClientOptions | undefined): AcpClient {
  */
 function makeActiveSessionMockClient(
   opts: AcpClientOptions | undefined,
-  activityKind: "agent.message_update" | "agent.thinking_update" | "agent.usage_update",
+  activityKind:
+    | "agent.message_update"
+    | "agent.thinking_update"
+    | "agent.usage_update"
+    | "agent.tool_call_update",
   intervalMs: number,
   durationMs: number,
 ): AcpClient {
@@ -181,6 +188,8 @@ function makeActiveSessionMockClient(
         const activityBase = { ...BASE_STREAM_EVENT, callId, timestamp: Date.now() };
         if (activityKind === "agent.usage_update") {
           opts?.onStreamActivity?.({ ...activityBase, kind: activityKind, inputTokens: 10, outputTokens: 5 });
+        } else if (activityKind === "agent.tool_call_update") {
+          opts?.onStreamActivity?.({ ...activityBase, kind: activityKind, toolName: "bash" });
         } else {
           opts?.onStreamActivity?.({ ...activityBase, kind: activityKind, deltaBytes: 16 });
         }
@@ -312,6 +321,37 @@ describe("Idle watchdog stale cancellation (ACP)", () => {
       });
 
       // Watchdog must NOT have fired — usage_update resets the timer
+      expect(result.adapterFailure).toBeUndefined();
+      expect(result.output).toBe("done");
+    } finally {
+      detach();
+    }
+  });
+
+  test("prompt emitting only periodic tool_call_update events is NOT cancelled before the secondary cap", async () => {
+    const IDLE_TIMEOUT_MS = 80;
+    const TOOL_CALL_ONLY_TIMEOUT_MS = 220;
+    const ACTIVITY_INTERVAL_MS = 30;
+    const PROMPT_DURATION_MS = 170;
+
+    const eventBus = new AgentStreamEventBus();
+    const registry = new Map<string, () => Promise<void>>();
+    const config = makeWatchdogConfig(
+      IDLE_TIMEOUT_MS,
+      ["message_update", "thinking_update", "usage_update", "tool_call_update"],
+      TOOL_CALL_ONLY_TIMEOUT_MS,
+    );
+    const detach = attachAgentIdleWatchdog(eventBus, registry, config);
+
+    _acpAdapterDeps.createClient = (_cmd, _cwd, _timeout, _onPid, _retries, _onExit, opts) =>
+      makeActiveSessionMockClient(opts, "agent.tool_call_update", ACTIVITY_INTERVAL_MS, PROMPT_DURATION_MS);
+
+    try {
+      const adapter = new AcpAgentAdapter("claude");
+      const result = await adapter.complete("test prompt", {
+        ...makeCompleteOptions(registry, eventBus.emitAgentStream.bind(eventBus)),
+      });
+
       expect(result.adapterFailure).toBeUndefined();
       expect(result.output).toBe("done");
     } finally {

--- a/test/unit/agents/acp/activity-emission.test.ts
+++ b/test/unit/agents/acp/activity-emission.test.ts
@@ -12,10 +12,9 @@
 
 import { describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { createParseState, parseAcpxJsonLine, type AcpxLineActivity } from "../../../../src/agents/acp/parser";
-import { SpawnAcpClient, _spawnClientDeps } from "../../../../src/agents/acp/spawn-client";
-import type { AgentStreamEvent } from "../../../../src/runtime/agent-stream-events";
-import { withDepsRestore } from "../../../helpers/deps";
+import { createParseState, parseAcpxJsonLine, SpawnAcpClient, type AcpLineActivity, _spawnClientDeps } from "@/agents";
+import type { AgentStreamEvent } from "@/runtime";
+import { withDepsRestore } from "@test/helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // parseAcpxJsonLine activity metadata tests
@@ -219,7 +218,7 @@ describe("parseAcpxJsonLine — no raw content in activity metadata (AC4)", () =
 
   test("activity type has no message or thought fields in its interface", () => {
     // This test validates the type definition itself
-    const activity: AcpxLineActivity = {
+    const activity: AcpLineActivity = {
       kind: "message_update",
       deltaBytes: 42,
     };

--- a/test/unit/agents/acp/activity-emission.test.ts
+++ b/test/unit/agents/acp/activity-emission.test.ts
@@ -397,6 +397,16 @@ describe("Stream callback in AcpClient/AcpSession types", () => {
       deltaBytes: 42,
     };
 
+    const toolCallUpdate = {
+      kind: "agent.tool_call_update" as const,
+      callId: callStarted.callId,
+      runId: callStarted.runId,
+      agentName: "claude",
+      sessionName: "test-session",
+      timestamp: Date.now(),
+      toolName: "bash",
+    };
+
     const callEnded = {
       kind: "agent.call_ended" as const,
       callId: callStarted.callId,
@@ -409,12 +419,14 @@ describe("Stream callback in AcpClient/AcpSession types", () => {
 
     onStreamActivity(callStarted);
     onStreamActivity(messageUpdate);
+    onStreamActivity(toolCallUpdate);
     onStreamActivity(callEnded);
 
-    expect(events).toHaveLength(3);
+    expect(events).toHaveLength(4);
     expect(events[0]?.kind).toBe("agent.call_started");
     expect(events[1]?.kind).toBe("agent.message_update");
-    expect(events[2]?.kind).toBe("agent.call_ended");
+    expect(events[2]?.kind).toBe("agent.tool_call_update");
+    expect(events[3]?.kind).toBe("agent.call_ended");
   });
 });
 
@@ -615,5 +627,55 @@ describe("AC10 — correlation metadata flows from AcpClientOptions to session s
       expect(event.runId).toBe("run-abc");
       expect(event.storyId).toBe("story-123");
     }
+  });
+
+  test("tool_call stream updates are emitted through onStreamActivity", async () => {
+    let callCount = 0;
+    const events: AgentStreamEvent[] = [];
+
+    _spawnClientDeps.spawn = (_cmd, _opts) => {
+      callCount++;
+      if (callCount === 1) return makeSpawnResult(0);
+      const ndjson =
+        JSON.stringify({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId: "x",
+            update: {
+              sessionUpdate: "tool_call",
+              toolName: "bash",
+            },
+          },
+        }) +
+        "\n" +
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            stopReason: "end_turn",
+            usage: { inputTokens: 1, outputTokens: 1, cachedReadTokens: 0, cachedWriteTokens: 0 },
+          },
+        }) +
+        "\n";
+      return makeSpawnResult(0, ndjson);
+    };
+
+    const client = new SpawnAcpClient(
+      "acpx --model claude-sonnet-4-5 claude",
+      "/tmp",
+      30,
+      undefined,
+      0,
+      undefined,
+      { onStreamActivity: (event) => events.push(event) },
+    );
+
+    const session = await client.loadSession("test-session", "claude", "approve-reads");
+    await session!.prompt("hello");
+
+    const toolCallEvent = events.find((event) => event.kind === "agent.tool_call_update");
+    expect(toolCallEvent).toBeDefined();
+    expect(toolCallEvent).toMatchObject({ kind: "agent.tool_call_update", toolName: "bash" });
   });
 });

--- a/test/unit/agents/acp/parser.test.ts
+++ b/test/unit/agents/acp/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createParseState, finalizeParseState, parseAcpxJsonLine, parseAcpxJsonOutput } from "../../../../src/agents/acp/parser";
+import { createParseState, finalizeParseState, parseAcpxJsonLine, parseAcpxJsonOutput } from "@/agents";
 
 // Real acpx JSON-RPC envelope format (captured from live acpx v0.3.0)
 const REAL_ACPX_OUTPUT = [

--- a/test/unit/agents/acp/parser.test.ts
+++ b/test/unit/agents/acp/parser.test.ts
@@ -157,4 +157,38 @@ describe("incremental API — createParseState / parseAcpxJsonLine / finalizePar
     expect(activity?.kind).toBe("thinking_update");
     expect(activity?.deltaBytes).toBe(8); // "thinking".length
   });
+
+  test("tool_call returns tool_call_update activity", () => {
+    const state = createParseState();
+    const line = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "x",
+        update: {
+          sessionUpdate: "tool_call",
+          toolName: "bash",
+        },
+      },
+    });
+    const activity = parseAcpxJsonLine(line, state);
+    expect(activity).toEqual({ kind: "tool_call_update", toolName: "bash" });
+  });
+
+  test("tool_call_update returns tool_call_update activity", () => {
+    const state = createParseState();
+    const line = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "session/update",
+      params: {
+        sessionId: "x",
+        update: {
+          sessionUpdate: "tool_call_update",
+          tool: { name: "read_file" },
+        },
+      },
+    });
+    const activity = parseAcpxJsonLine(line, state);
+    expect(activity).toEqual({ kind: "tool_call_update", toolName: "read_file" });
+  });
 });

--- a/test/unit/config/agent-schema.test.ts
+++ b/test/unit/config/agent-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { NaxConfigSchema } from "../../../src/config/schemas";
+import { NaxConfigSchema } from "@/config";
 
 describe("AgentConfigSchema", () => {
   test("default values", () => {

--- a/test/unit/config/agent-schema.test.ts
+++ b/test/unit/config/agent-schema.test.ts
@@ -72,9 +72,15 @@ describe("AgentConfigSchema", () => {
     expect(result.agent?.idleWatchdog?.enabled).toBe(true);
     expect(result.agent?.idleWatchdog?.mode).toBe("warn-then-cancel");
     expect(result.agent?.idleWatchdog?.idleTimeoutSeconds).toBe(900);
+    expect(result.agent?.idleWatchdog?.toolCallOnlyIdleTimeoutSeconds).toBe(1800);
     expect(result.agent?.idleWatchdog?.cancelGraceSeconds).toBe(10);
     expect(result.agent?.idleWatchdog?.maxRetryAttempts).toBe(3);
-    expect(result.agent?.idleWatchdog?.activityKinds).toEqual(["message_update", "thinking_update", "usage_update"]);
+    expect(result.agent?.idleWatchdog?.activityKinds).toEqual([
+      "message_update",
+      "thinking_update",
+      "usage_update",
+      "tool_call_update",
+    ]);
   });
 
   test("agent.idleWatchdog internal defaults when provided", () => {
@@ -87,9 +93,15 @@ describe("AgentConfigSchema", () => {
     expect(result.agent?.idleWatchdog?.enabled).toBe(true);
     expect(result.agent?.idleWatchdog?.mode).toBe("warn-then-cancel");
     expect(result.agent?.idleWatchdog?.idleTimeoutSeconds).toBe(900);
+    expect(result.agent?.idleWatchdog?.toolCallOnlyIdleTimeoutSeconds).toBe(1800);
     expect(result.agent?.idleWatchdog?.cancelGraceSeconds).toBe(10);
     expect(result.agent?.idleWatchdog?.maxRetryAttempts).toBe(3);
-    expect(result.agent?.idleWatchdog?.activityKinds).toEqual(["message_update", "thinking_update", "usage_update"]);
+    expect(result.agent?.idleWatchdog?.activityKinds).toEqual([
+      "message_update",
+      "thinking_update",
+      "usage_update",
+      "tool_call_update",
+    ]);
   });
 
   test("agent.idleWatchdog accepts fully populated config", () => {
@@ -99,6 +111,7 @@ describe("AgentConfigSchema", () => {
           enabled: true,
           mode: "warn-then-cancel",
           idleTimeoutSeconds: 60,
+          toolCallOnlyIdleTimeoutSeconds: 120,
           cancelGraceSeconds: 10,
           maxRetryAttempts: 5,
           activityKinds: ["message_update"],
@@ -108,6 +121,7 @@ describe("AgentConfigSchema", () => {
     const result = NaxConfigSchema.parse(raw);
     expect(result.agent?.idleWatchdog?.mode).toBe("warn-then-cancel");
     expect(result.agent?.idleWatchdog?.idleTimeoutSeconds).toBe(60);
+    expect(result.agent?.idleWatchdog?.toolCallOnlyIdleTimeoutSeconds).toBe(120);
     expect(result.agent?.idleWatchdog?.cancelGraceSeconds).toBe(10);
     expect(result.agent?.idleWatchdog?.maxRetryAttempts).toBe(5);
     expect(result.agent?.idleWatchdog?.activityKinds).toEqual(["message_update"]);
@@ -230,15 +244,20 @@ describe("AgentConfigSchema", () => {
   });
 
   test("agent.idleWatchdog accepts all valid activityKinds combinations", () => {
-    const validCombinations: Array<Array<"message_update" | "thinking_update" | "usage_update">> = [
+    const validCombinations: Array<Array<"message_update" | "thinking_update" | "usage_update" | "tool_call_update">> = [
       [],
       ["message_update"],
       ["thinking_update"],
       ["usage_update"],
+      ["tool_call_update"],
       ["message_update", "thinking_update"],
       ["message_update", "usage_update"],
       ["thinking_update", "usage_update"],
+      ["message_update", "tool_call_update"],
+      ["thinking_update", "tool_call_update"],
+      ["usage_update", "tool_call_update"],
       ["message_update", "thinking_update", "usage_update"],
+      ["message_update", "thinking_update", "usage_update", "tool_call_update"],
     ];
 
     for (const kinds of validCombinations) {

--- a/test/unit/runtime/middleware/idle-watchdog-tool-call.test.ts
+++ b/test/unit/runtime/middleware/idle-watchdog-tool-call.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { getLogger, initLogger, resetLogger } from "../../../../src/logger";
+import type { LogEntry } from "../../../../src/logger/types";
+import { AgentStreamEventBus, type AgentStreamEvent } from "../../../../src/runtime/agent-stream-events";
+import { attachAgentIdleWatchdog } from "../../../../src/runtime/middleware/idle-watchdog";
+import { makeNaxConfig } from "../../../helpers";
+import { cleanupTempDir, makeTempDir } from "../../../helpers";
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+type ActivityKind = "message_update" | "thinking_update" | "usage_update" | "tool_call_update";
+
+function makeWatchdogConfig(overrides: {
+  mode?: "off" | "observe" | "warn-then-cancel" | "cancel";
+  idleTimeoutSeconds?: number;
+  toolCallOnlyIdleTimeoutSeconds?: number;
+  activityKinds?: ActivityKind[];
+} = {}) {
+  return makeNaxConfig({
+    agent: {
+      idleWatchdog: {
+        enabled: true,
+        mode: "cancel",
+        idleTimeoutSeconds: 0.04,
+        toolCallOnlyIdleTimeoutSeconds: 0.12,
+        activityKinds: ["message_update", "thinking_update", "usage_update", "tool_call_update"],
+        cancelGraceSeconds: 0,
+        maxRetryAttempts: 1,
+        ...overrides,
+      },
+    },
+  });
+}
+
+function makeBaseEvent(timestamp = Date.now()) {
+  return {
+    callId: "call-123",
+    runId: "run-001",
+    agentName: "claude",
+    sessionName: "test-session",
+    storyId: "story-42",
+    stage: "run" as const,
+    pid: 1234,
+    timestamp,
+  };
+}
+
+function makeCallStartedEvent(timestamp = Date.now()): AgentStreamEvent {
+  return {
+    ...makeBaseEvent(timestamp),
+    kind: "agent.call_started",
+    model: "claude-sonnet-4-5",
+    timeoutSeconds: 60,
+  };
+}
+
+function makeThinkingUpdateEvent(timestamp = Date.now()): AgentStreamEvent {
+  return {
+    ...makeBaseEvent(timestamp),
+    kind: "agent.thinking_update",
+    deltaBytes: 12,
+  };
+}
+
+function makeToolCallUpdateEvent(timestamp = Date.now()): AgentStreamEvent {
+  return {
+    ...makeBaseEvent(timestamp),
+    kind: "agent.tool_call_update",
+    toolName: "bash",
+  };
+}
+
+async function parseAllEntries(logFile: string): Promise<LogEntry[]> {
+  const content = await Bun.file(logFile).text();
+  return content
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as LogEntry);
+}
+
+describe("attachAgentIdleWatchdog — tool-call activity", () => {
+  let tmpDir: string;
+  let logFile: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir("nax-test-idle-watchdog-tool-");
+    logFile = join(tmpDir, `idle-watchdog-tool-${Date.now()}.jsonl`);
+    initLogger({ level: "debug", filePath: logFile, useChalk: false, headless: true });
+  });
+
+  afterEach(async () => {
+    await getLogger().flush();
+    resetLogger();
+    cleanupTempDir(tmpDir);
+  });
+
+  test("tool-call updates keep the primary idle timeout alive until the secondary cap is reached", async () => {
+    const eventBus = new AgentStreamEventBus();
+    let cancelCount = 0;
+    const registry = new Map<string, () => Promise<void>>([
+      [
+        "call-123",
+        async () => {
+          cancelCount++;
+        },
+      ],
+    ]);
+    const detach = attachAgentIdleWatchdog(
+      eventBus,
+      registry,
+      makeWatchdogConfig({ toolCallOnlyIdleTimeoutSeconds: 0.25 }),
+    );
+
+    try {
+      eventBus.emitAgentStream(makeCallStartedEvent());
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < 70) {
+        eventBus.emitAgentStream(makeToolCallUpdateEvent());
+        await sleep(15);
+      }
+      await sleep(10);
+
+      expect(cancelCount).toBe(0);
+      const entries = await parseAllEntries(logFile);
+      expect(entries.some((entry) => entry.data?.key === "idle_timeout_exceeded")).toBe(false);
+    } finally {
+      detach();
+    }
+  });
+
+  test("tool-call-only activity hits the secondary timeout with a distinct log key", async () => {
+    const eventBus = new AgentStreamEventBus();
+    let cancelCount = 0;
+    const registry = new Map<string, () => Promise<void>>([
+      [
+        "call-123",
+        async () => {
+          cancelCount++;
+        },
+      ],
+    ]);
+    const detach = attachAgentIdleWatchdog(eventBus, registry, makeWatchdogConfig());
+
+    try {
+      eventBus.emitAgentStream(makeCallStartedEvent());
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < 170) {
+        eventBus.emitAgentStream(makeToolCallUpdateEvent());
+        await sleep(15);
+      }
+      await sleep(40);
+
+      expect(cancelCount).toBe(1);
+      const entries = await parseAllEntries(logFile);
+      expect(entries.some((entry) => entry.data?.key === "tool_call_only_idle_timeout_exceeded")).toBe(true);
+      expect(entries.some((entry) => entry.data?.key === "idle_timeout_exceeded")).toBe(false);
+    } finally {
+      detach();
+    }
+  });
+
+  test("non-tool activity resets the secondary timer", async () => {
+    const eventBus = new AgentStreamEventBus();
+    let cancelCount = 0;
+    const registry = new Map<string, () => Promise<void>>([
+      [
+        "call-123",
+        async () => {
+          cancelCount++;
+        },
+      ],
+    ]);
+    const detach = attachAgentIdleWatchdog(
+      eventBus,
+      registry,
+      makeWatchdogConfig({
+        idleTimeoutSeconds: 0.08,
+        toolCallOnlyIdleTimeoutSeconds: 0.2,
+      }),
+    );
+
+    try {
+      eventBus.emitAgentStream(makeCallStartedEvent());
+      const firstWindowStart = Date.now();
+      while (Date.now() - firstWindowStart < 60) {
+        eventBus.emitAgentStream(makeToolCallUpdateEvent());
+        await sleep(15);
+      }
+
+      eventBus.emitAgentStream(makeThinkingUpdateEvent());
+
+      const secondWindowStart = Date.now();
+      while (Date.now() - secondWindowStart < 60) {
+        eventBus.emitAgentStream(makeToolCallUpdateEvent());
+        await sleep(15);
+      }
+
+      expect(cancelCount).toBe(0);
+    } finally {
+      detach();
+    }
+  });
+
+  test("excluding tool_call_update from activityKinds preserves the legacy primary timeout behavior", async () => {
+    const eventBus = new AgentStreamEventBus();
+    let cancelCount = 0;
+    const registry = new Map<string, () => Promise<void>>([
+      [
+        "call-123",
+        async () => {
+          cancelCount++;
+        },
+      ],
+    ]);
+    const detach = attachAgentIdleWatchdog(
+      eventBus,
+      registry,
+      makeWatchdogConfig({ activityKinds: ["message_update", "thinking_update", "usage_update"] }),
+    );
+
+    try {
+      eventBus.emitAgentStream(makeCallStartedEvent());
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < 90) {
+        eventBus.emitAgentStream(makeToolCallUpdateEvent());
+        await sleep(15);
+      }
+      await sleep(30);
+
+      expect(cancelCount).toBe(1);
+      const entries = await parseAllEntries(logFile);
+      expect(entries.some((entry) => entry.data?.key === "idle_timeout_exceeded")).toBe(true);
+    } finally {
+      detach();
+    }
+  });
+
+  test("toolCallOnlyIdleTimeoutSeconds=0 disables the secondary cap", async () => {
+    const eventBus = new AgentStreamEventBus();
+    let cancelCount = 0;
+    const registry = new Map<string, () => Promise<void>>([
+      [
+        "call-123",
+        async () => {
+          cancelCount++;
+        },
+      ],
+    ]);
+    const detach = attachAgentIdleWatchdog(
+      eventBus,
+      registry,
+      makeWatchdogConfig({ toolCallOnlyIdleTimeoutSeconds: 0 }),
+    );
+
+    try {
+      eventBus.emitAgentStream(makeCallStartedEvent());
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < 170) {
+        eventBus.emitAgentStream(makeToolCallUpdateEvent());
+        await sleep(15);
+      }
+      await sleep(10);
+
+      expect(cancelCount).toBe(0);
+      const entries = await parseAllEntries(logFile);
+      expect(entries.some((entry) => entry.data?.key === "tool_call_only_idle_timeout_exceeded")).toBe(false);
+    } finally {
+      detach();
+    }
+  });
+
+  test("toolCallOnlyIdleTimeoutSeconds less than or equal to the primary timeout does not create an earlier cancel path", async () => {
+    const eventBus = new AgentStreamEventBus();
+    let cancelCount = 0;
+    const registry = new Map<string, () => Promise<void>>([
+      [
+        "call-123",
+        async () => {
+          cancelCount++;
+        },
+      ],
+    ]);
+    const detach = attachAgentIdleWatchdog(
+      eventBus,
+      registry,
+      makeWatchdogConfig({
+        idleTimeoutSeconds: 0.12,
+        toolCallOnlyIdleTimeoutSeconds: 0.08,
+      }),
+    );
+
+    try {
+      eventBus.emitAgentStream(makeCallStartedEvent());
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < 70) {
+        eventBus.emitAgentStream(makeToolCallUpdateEvent());
+        await sleep(15);
+      }
+      await sleep(10);
+
+      expect(cancelCount).toBe(0);
+      const entries = await parseAllEntries(logFile);
+      expect(entries.some((entry) => entry.data?.key === "tool_call_only_idle_timeout_exceeded")).toBe(false);
+    } finally {
+      detach();
+    }
+  });
+});

--- a/test/unit/runtime/middleware/idle-watchdog-tool-call.test.ts
+++ b/test/unit/runtime/middleware/idle-watchdog-tool-call.test.ts
@@ -1,11 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
-import { getLogger, initLogger, resetLogger } from "../../../../src/logger";
-import type { LogEntry } from "../../../../src/logger/types";
-import { AgentStreamEventBus, type AgentStreamEvent } from "../../../../src/runtime/agent-stream-events";
-import { attachAgentIdleWatchdog } from "../../../../src/runtime/middleware/idle-watchdog";
-import { makeNaxConfig } from "../../../helpers";
-import { cleanupTempDir, makeTempDir } from "../../../helpers";
+import { getLogger, initLogger, resetLogger } from "@/logger";
+import type { LogEntry } from "@/logger/types";
+import { AgentStreamEventBus, attachAgentIdleWatchdog, type AgentStreamEvent } from "@/runtime";
+import { cleanupTempDir, makeTempDir, makeNaxConfig } from "@test/helpers";
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 


### PR DESCRIPTION
## Summary
- count ACP `tool_call` and `tool_call_update` stream events as watchdog activity
- add a secondary `toolCallOnlyIdleTimeoutSeconds` cap so tool-only progress does not mask runaway tool loops
- extend parser, stream events, logging, TUI state, config defaults, and tests to cover the new behavior

Close (#976)

## Root Cause
The ACP parser only treated `agent_message_chunk`, `agent_thought_chunk`, and `usage_update` as activity. During long tool-call sequences, the idle watchdog saw no activity and incorrectly cancelled healthy calls as stale.

## Validation
- `bun run typecheck`
- `bun run test`