### PR TITLE
fix(plan): invoke op.recover before TurnResult envelope passthrough (#993)

### DIFF
--- a/.claude/rules/retry-strategy.md
+++ b/.claude/rules/retry-strategy.md
@@ -152,7 +152,13 @@ type RetryDecision =
 
 When `exhaustedFallback` is absent, `callOp` returns the last `TurnResult` as-is (typed as `O`). **Ops that cannot tolerate a raw `TurnResult` as their output MUST provide `exhaustedFallback`.**
 
-**Strict-parser interaction:** when an op's `parse()` throws on unparseable input (e.g. `adversarialReviewOp`), the strategy MUST provide `exhaustedFallback` — otherwise retry exhaustion throws `ParseValidationError` to the caller. Graceful parsers (returning `FAIL_OPEN`-style values, e.g. `semanticReviewOp`) make `exhaustedFallback` optional.
+**Strict-parser interaction:** when an op's `parse()` throws on unparseable input (e.g. `adversarialReviewOp`), the op MUST use one of three sanctioned escape hatches to avoid `ParseValidationError` propagating to the caller:
+
+1. **`exhaustedFallback`** on the strategy — synchronous, receives `lastOutput`; ideal when a safe degraded value can be synthesised from the agent's last output.
+2. **Graceful-degradation `parse()`** — returns a `FAIL_OPEN`-style value instead of throwing (e.g. `semanticReviewOp`).
+3. **`op.recover`** — async, receives the full `input` and a `VerifyContext` (file I/O); invoked by `callOp`'s catch path before the envelope passthrough. Ideal for disk-recovery ops that cannot synthesise from `lastOutput` alone (e.g. `planInteractiveOp` re-reads `outputPath` from disk, see issue #993).
+
+`callOp` tries the escape hatches in order: `exhaustedFallback` wins if present on the strategy decision; then `op.recover` if defined and returns non-null; then the last-resort TurnResult passthrough (logged as warn — indicates a missing escape hatch). Graceful parsers make all three optional.
 
 ```typescript
 // ✅ Always provide exhaustedFallback for ops with structured output types
@@ -209,4 +215,4 @@ await _callOpDeps.sleep(decision.delayMs, ctx.runtime.signal);
 | `MAX_RATE_LIMIT_RETRIES` constant (deleted) | `defaultRetryStrategy` / `RetryPreset.maxAttempts` |
 | Hand-rolled parse-retry loops inside an `op.hopBody` | `ctx.sendWithParseRetry` — declare `op.retry` and call `sendWithParseRetry` in the body |
 | Strategy `validate` and `op.parse` having different acceptance criteria | Define a shared validator helper (e.g. `validateLLMShape`) and call it from both |
-| Run-kind op with strict (throwing) `parse()` and `op.retry` but no `exhaustedFallback` | Either provide `exhaustedFallback` on the strategy OR return a graceful degradation value from `parse()` for unparseable inputs |
+| Run-kind op with strict (throwing) `parse()` and `op.retry` but no `exhaustedFallback` AND no `op.recover` that returns a non-null value | Provide `exhaustedFallback` on the strategy, OR a graceful-degradation `parse()`, OR `op.recover` — see "Strict-parser interaction" above |

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -11,6 +11,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { NaxConfig } from "../config";
+import { NaxError } from "../errors";
 import { buildInteractionBridge } from "../interaction/bridge-builder";
 import { getLogger } from "../logger";
 import { callOp, planInteractiveOp } from "../operations";
@@ -169,6 +170,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
         });
         if (debateResult.outcome !== "failed" && debateResult.output) {
           const finalPrd = validatePlanOutput(debateResult.output, options.feature, branchName);
+          assertIsValidPrd(finalPrd);
           await _planDeps.writeFile(outputPath, JSON.stringify({ ...finalPrd, project: projectName }, null, 2));
           logger?.info("plan", "[OK] PRD written via debate", { outputPath });
           return outputPath;
@@ -185,6 +187,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
               packageView: debateRt.packages.resolve(),
               packageDir: workdir,
               agentName: debateRt.agentManager.getDefault(),
+              storyId: options.feature,
               featureName: options.feature,
               interactionBridge,
               maxInteractionTurns: config?.agent?.maxInteractionTurns,
@@ -201,6 +204,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
               projectProfile: config?.project,
             },
           );
+          assertIsValidPrd(prd);
           await _planDeps.writeFile(outputPath, JSON.stringify({ ...prd, project: projectName }, null, 2));
           logger?.info("plan", "[OK] PRD written via debate fallback", { outputPath });
           return outputPath;
@@ -233,6 +237,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
           packageView: rt.packages.resolve(),
           packageDir: workdir,
           agentName: rt.agentManager.getDefault(),
+          storyId: options.feature,
           featureName: options.feature,
           interactionBridge,
           maxInteractionTurns: config?.agent?.maxInteractionTurns,
@@ -249,6 +254,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
           projectProfile: config?.project,
         },
       );
+      assertIsValidPrd(prd);
       await _planDeps.writeFile(outputPath, JSON.stringify({ ...prd, project: projectName }, null, 2));
       logger?.info("plan", "[OK] PRD written", { outputPath });
       return outputPath;
@@ -277,6 +283,25 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
 // ─────────────────────────────────────────────────────────────────────────────
 // Private helpers
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Constant-time envelope check: confirms callOp returned a PRD, not a TurnResult.
+ * Does NOT call validatePlanOutput to avoid re-stamping updatedAt (timestamp drift).
+ * Defence-in-depth for issue #993 — the primary fix lives in callOp's catch path.
+ */
+function assertIsValidPrd(prd: unknown): asserts prd is import("../prd/types").PRD {
+  if (typeof prd !== "object" || prd === null || Array.isArray(prd)) {
+    throw new NaxError("plan: callOp returned a non-PRD value", "PLAN_INVALID_RESULT", { stage: "plan" });
+  }
+  const obj = prd as Record<string, unknown>;
+  if (!Array.isArray(obj.userStories) || obj.userStories.length === 0) {
+    throw new NaxError(
+      "plan: callOp returned an envelope-shaped object (no userStories) — likely retry exhaustion (#993)",
+      "PLAN_ENVELOPE_LEAK",
+      { stage: "plan", keys: Object.keys(obj).join(",") },
+    );
+  }
+}
 
 /**
  * Detect project name from package.json or git remote.

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -416,25 +416,34 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       }
       return { ...retryFallback, estimatedCostUsd: totalCost } as O;
     }
-    // When retryStrategy engaged but provided no fallback, return the last TurnResult
-    // as-is (per spec: "ops must provide exhaustedFallback if they cannot tolerate a
-    // raw TurnResult as output").
+    // When retryStrategy engaged but provided no fallback, prefer op.recover before
+    // falling back to envelope passthrough. recover is the disk-recovery escape hatch
+    // (#993: silently returning a TurnResult typed-as-O corrupted prd.json).
+    if (op.recover) {
+      const verifyCtx = makeVerifyCtx(buildCtx);
+      const recovered = await op.recover(input, verifyCtx);
+      if (recovered !== null) return recovered;
+    }
+
     if (lastRetryTurn !== undefined) {
+      // Last-resort envelope passthrough. Logged so silent corruption stops being silent.
+      getSafeLogger()?.warn(
+        "callop",
+        "Op exhausted retries with no fallback and no recover — returning raw TurnResult",
+        {
+          storyId: ctx.storyId,
+          opName: op.name,
+          site: "run" as const,
+        },
+      );
       return lastRetryTurn as unknown as O;
     }
     throw _parseErr;
   }
 }
 
-async function runPostParse<I, O, C>(
-  op: Operation<I, O, C>,
-  parsed: O,
-  input: I,
-  buildCtx: BuildContext<C>,
-): Promise<O> {
-  if (!op.verify && !op.recover) return parsed;
-
-  const verifyCtx: VerifyContext<C> = {
+function makeVerifyCtx<C>(buildCtx: BuildContext<C>): VerifyContext<C> {
+  return {
     packageView: buildCtx.packageView,
     config: buildCtx.config,
     readFile: async (p) => {
@@ -446,6 +455,17 @@ async function runPostParse<I, O, C>(
     },
     fileExists: async (p) => Bun.file(p).exists(),
   };
+}
+
+async function runPostParse<I, O, C>(
+  op: Operation<I, O, C>,
+  parsed: O,
+  input: I,
+  buildCtx: BuildContext<C>,
+): Promise<O> {
+  if (!op.verify && !op.recover) return parsed;
+
+  const verifyCtx = makeVerifyCtx(buildCtx);
 
   let final: O | null = parsed;
 

--- a/src/operations/plan.ts
+++ b/src/operations/plan.ts
@@ -41,6 +41,12 @@ export const planInteractiveOp: RunOperation<PlanInteractiveInput, PRD, PlanConf
       invalid: () => PlanPromptBuilder.jsonRepair(0, "Invalid JSON — response was not parseable"),
       truncated: () => PlanPromptBuilder.jsonRepair(0, "JSON appears truncated — please rewrite completely"),
     },
+    // Intentionally no exhaustedFallback: it is synchronous and only receives
+    // lastOutput, so it cannot read outputPath from disk. Disk recovery is
+    // handled by op.recover below, which callOp's catch path invokes when retry
+    // exhausts. See issue #993 and .claude/rules/retry-strategy.md
+    // "Strict-parser interaction" — op.recover is the third sanctioned escape
+    // hatch alongside exhaustedFallback and graceful-degradation parse().
   }),
   hopBody: async (initialPrompt, ctx) => {
     return ctx.sendWithParseRetry(initialPrompt);

--- a/test/integration/plan/plan-prd-preservation.test.ts
+++ b/test/integration/plan/plan-prd-preservation.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Integration test — issue #993 regression: prd.json preservation
+ *
+ * AC1: When the agent declines to regenerate an existing valid prd.json
+ * (returning chat acknowledgements on every turn), the op.recover path reads
+ * the real file from disk and the planCommand returns with userStories intact.
+ *
+ * This differs from the unit tests in plan.test.ts which mock _planDeps.readFile.
+ * Here the prd.json is a real file on disk so op.recover actually reads it via
+ * Bun.file(outputPath).text(), exercising the full recovery path end-to-end.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { _planDeps, planCommand } from "@/cli";
+import { DEFAULT_CONFIG } from "@/config";
+import type { PRD } from "@/prd/types";
+import { cleanupTempDir, makeMockAgentManager, makeMockRuntime, makeTempDir } from "@test/helpers";
+
+const EXISTING_PRD: PRD = {
+  project: "my-project",
+  feature: "url-shortener",
+  branchName: "feat/url-shortener",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  userStories: [
+    {
+      id: "US-001",
+      title: "Shorten URL",
+      description: "User can shorten a long URL",
+      acceptanceCriteria: ["AC-1: Returns shortened URL"],
+      tags: ["feature"],
+      dependencies: [],
+      status: "pending",
+      passes: false,
+      escalations: [],
+      attempts: 0,
+      routing: {
+        complexity: "simple",
+        testStrategy: "test-after",
+        reasoning: "Single function, clear output",
+      },
+    },
+    {
+      id: "US-002",
+      title: "Redirect URL",
+      description: "Short URL redirects to original",
+      acceptanceCriteria: ["AC-2: Redirect returns 302"],
+      tags: ["feature"],
+      dependencies: ["US-001"],
+      status: "pending",
+      passes: false,
+      escalations: [],
+      attempts: 0,
+      routing: {
+        complexity: "simple",
+        testStrategy: "test-after",
+        reasoning: "HTTP redirect",
+      },
+    },
+  ],
+};
+
+const origReadFile = _planDeps.readFile;
+const origWriteFile = _planDeps.writeFile;
+const origScanCodebase = _planDeps.scanCodebase;
+const origCreateRuntime = _planDeps.createRuntime;
+const origReadPackageJson = _planDeps.readPackageJson;
+const origSpawnSync = _planDeps.spawnSync;
+const origMkdirp = _planDeps.mkdirp;
+const origExistsSync = _planDeps.existsSync;
+
+describe("plan PRD preservation — issue #993 regression (AC1)", () => {
+  let tmpDir: string;
+  let outputPath: string;
+
+  beforeEach(async () => {
+    tmpDir = makeTempDir("nax-plan-prd-preservation-");
+    const featureDir = join(tmpDir, ".nax", "features", "url-shortener");
+    outputPath = join(featureDir, "prd.json");
+
+    // Write real prd.json on disk so op.recover can read it via Bun.file()
+    await mkdir(featureDir, { recursive: true });
+    await Bun.write(outputPath, JSON.stringify(EXISTING_PRD, null, 2));
+
+    // Stub infrastructure deps
+    _planDeps.scanCodebase = mock(async () => ({
+      fileTree: "└── src/\n    └── index.ts",
+      dependencies: {},
+      devDependencies: {},
+      testPatterns: [],
+    }));
+    _planDeps.readPackageJson = mock(async () => ({ name: "my-project" }));
+    _planDeps.spawnSync = mock(() => ({ stdout: Buffer.from(""), exitCode: 1 }));
+    _planDeps.mkdirp = mock(async (_path: string) => {});
+    _planDeps.existsSync = mock((_p: string) => true);
+
+    // readFile: return spec content for the spec path; real file read for prd.json paths.
+    // op.recover bypasses _planDeps.readFile entirely (uses Bun.file directly), but the
+    // cli/plan.ts catch-block recovery does use _planDeps.readFile for the secondary path.
+    _planDeps.readFile = mock(async (p: string) => {
+      if (p === outputPath) return Bun.file(p).text();
+      return "# Spec\n## Acceptance Criteria\n- AC-1: URL shortened";
+    });
+
+    // writeFile: write to real disk so we can verify the output
+    _planDeps.writeFile = mock(async (path: string, content: string) => {
+      await Bun.write(path, content);
+    });
+  });
+
+  afterEach(() => {
+    mock.restore();
+    _planDeps.readFile = origReadFile;
+    _planDeps.writeFile = origWriteFile;
+    _planDeps.scanCodebase = origScanCodebase;
+    _planDeps.createRuntime = origCreateRuntime;
+    _planDeps.readPackageJson = origReadPackageJson;
+    _planDeps.spawnSync = origSpawnSync;
+    _planDeps.mkdirp = origMkdirp;
+    _planDeps.existsSync = origExistsSync;
+    cleanupTempDir(tmpDir);
+  });
+
+  test("AC1: agent returns chat ack on all turns — prd.json userStories preserved via op.recover", async () => {
+    // Simulate issue #993: agent declines regeneration on every retry attempt.
+    // With the fix, callOp invokes op.recover which reads the real prd.json
+    // from disk. planCommand writes back the recovered PRD. userStories unchanged.
+    _planDeps.createRuntime = mock((_cfg: any) =>
+      makeMockRuntime({
+        agentManager: makeMockAgentManager({
+          runAsSessionFn: async () => ({
+            output: "File already valid and complete. No rewrite needed.",
+            tokenUsage: { inputTokens: 0, outputTokens: 0 },
+            estimatedCostUsd: 0,
+            internalRoundTrips: 0,
+          }),
+          runWithFallbackFn: async (req: any) => {
+            const result = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+            return {
+              result: {
+                success: true,
+                exitCode: 0,
+                rateLimited: false,
+                durationMs: 1,
+                output: result.result.output,
+                estimatedCostUsd: result.result.estimatedCostUsd ?? 0,
+                agentFallbacks: [],
+              },
+              fallbacks: [],
+            };
+          },
+        }),
+      }),
+    );
+
+    await planCommand(tmpDir, DEFAULT_CONFIG as never, {
+      from: join(tmpDir, "spec.md"),
+      feature: "url-shortener",
+    });
+
+    // Read the written prd.json from real disk
+    const afterContent = await Bun.file(outputPath).text();
+    const afterPrd = JSON.parse(afterContent) as PRD;
+
+    // Field-equality on stable identity fields — validatePlanOutput may transform
+    // routing.reasoning, so compare ids/titles rather than the full object.
+    // Core invariant: all story IDs are preserved (nothing overwritten by envelope).
+    expect(afterPrd.userStories).toHaveLength(EXISTING_PRD.userStories.length);
+    expect(afterPrd.userStories.map((s) => s.id)).toEqual(EXISTING_PRD.userStories.map((s) => s.id));
+    expect(afterPrd.userStories.map((s) => s.title)).toEqual(EXISTING_PRD.userStories.map((s) => s.title));
+  });
+});

--- a/test/unit/cli/plan.test.ts
+++ b/test/unit/cli/plan.test.ts
@@ -12,8 +12,7 @@ import { _planDeps, planCommand } from "@/cli";
 import { DEFAULT_CONFIG } from "@/config";
 import type { PRD } from "@/prd/types";
 import { PlanPromptBuilder } from "@/prompts";
-import { makeMockAgentManager, makeMockRuntime } from "@test/helpers";
-import { makeTempDir } from "@test/helpers";
+import { makeMockAgentManager, makeMockRuntime, makeTempDir } from "@test/helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixtures
@@ -637,5 +636,155 @@ describe("buildPlanningPrompt — spec anchor (fix #346)", () => {
   test("taskContext instructs planner to keep story scope — no cross-story ACs", () => {
     const { taskContext } = new PlanPromptBuilder().build(spec, ctx);
     expect(taskContext).toContain("story scope");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// assertIsValidPrd guard — issue #993 regression tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("assertIsValidPrd guard (#993)", () => {
+  let tmpDir993: string;
+  let capturedWrites993: Array<[string, string]>;
+
+  const origCreateRuntime993 = _planDeps.createRuntime;
+  const origExistsSync993 = _planDeps.existsSync;
+  const origReadFile993 = _planDeps.readFile;
+  const origWriteFile993 = _planDeps.writeFile;
+
+  beforeEach(async () => {
+    tmpDir993 = makeTempDir("nax-plan-993-");
+    capturedWrites993 = [];
+    await mkdir(join(tmpDir993, ".nax"), { recursive: true });
+
+    _planDeps.scanCodebase = mock(async () => ({
+      fileTree: "└── src/\n    └── index.ts",
+      dependencies: {},
+      devDependencies: {},
+      testPatterns: [],
+    }));
+    _planDeps.readPackageJson = mock(async () => ({ name: "my-project" }));
+    _planDeps.spawnSync = mock(() => ({ stdout: Buffer.from(""), exitCode: 1 }));
+    _planDeps.mkdirp = mock(async () => {});
+    _planDeps.writeFile = mock(async (path: string, content: string) => {
+      capturedWrites993.push([path, content]);
+    });
+  });
+
+  afterEach(async () => {
+    mock.restore();
+    _planDeps.createRuntime = origCreateRuntime993;
+    _planDeps.existsSync = origExistsSync993;
+    _planDeps.readFile = origReadFile993;
+    _planDeps.writeFile = origWriteFile993;
+    await rm(tmpDir993, { recursive: true, force: true });
+  });
+
+  function makeHopInvokingRuntime() {
+    return makeMockRuntime({
+      agentManager: makeMockAgentManager({
+        runAsSessionFn: async () => ({
+          output: "File already valid. No changes needed.",
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          estimatedCostUsd: 0,
+          internalRoundTrips: 0,
+        }),
+        runWithFallbackFn: async (req: any) => {
+          const result = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+          return {
+            result: {
+              success: true,
+              exitCode: 0,
+              rateLimited: false,
+              durationMs: 1,
+              output: result.result.output,
+              estimatedCostUsd: result.result.estimatedCostUsd ?? 0,
+              agentFallbacks: [],
+            },
+            fallbacks: [],
+          };
+        },
+      }),
+    });
+  }
+
+  test("chat-ack on all retry attempts with no prd.json on disk throws PLAN_ENVELOPE_LEAK", async () => {
+    // op.recover reads Bun.file(outputPath) — file not on real disk → returns null.
+    // callOp returns lastRetryTurn (envelope). assertIsValidPrd throws PLAN_ENVELOPE_LEAK.
+    // No prd.json → catch block re-throws.
+    _planDeps.createRuntime = mock(() => makeHopInvokingRuntime());
+    _planDeps.existsSync = mock(() => false);
+    _planDeps.readFile = mock(async () => SAMPLE_SPEC);
+
+    await expect(
+      planCommand(tmpDir993, DEFAULT_CONFIG as never, {
+        from: "/spec.md",
+        feature: "url-shortener",
+      }),
+    ).rejects.toThrow("envelope-shaped object");
+  });
+
+  test("chat-ack on all retry attempts triggers _planDeps disk recovery when existsSync is true", async () => {
+    // op.recover reads Bun.file(outputPath) — real file absent → returns null.
+    // callOp returns lastRetryTurn (TurnResult envelope).
+    // assertIsValidPrd throws PLAN_ENVELOPE_LEAK.
+    // planCommand catch: existsSync → true; _planDeps.readFile returns valid PRD → recovered.
+    _planDeps.createRuntime = mock(() => makeHopInvokingRuntime());
+    _planDeps.existsSync = mock((p: string) => p.endsWith("prd.json"));
+    _planDeps.readFile = mock(async (p: string) => {
+      if (p.endsWith("prd.json")) return JSON.stringify(SAMPLE_PRD);
+      return SAMPLE_SPEC;
+    });
+
+    const result = await planCommand(tmpDir993, DEFAULT_CONFIG as never, {
+      from: "/spec.md",
+      feature: "url-shortener",
+    });
+
+    expect(result).toContain("url-shortener");
+    expect(result).toContain("prd.json");
+    // Field-equality on stable identity fields — validatePlanOutput may transform
+    // routing.reasoning, so compare id/title rather than the full object.
+    expect(capturedWrites993.length).toBeGreaterThan(0);
+    const written = JSON.parse(capturedWrites993[capturedWrites993.length - 1]?.[1] ?? "{}");
+    const writtenIds = (written.userStories as Array<{ id: string; title: string }>).map((s) => s.id);
+    const expectedIds = SAMPLE_PRD.userStories.map((s) => s.id);
+    expect(writtenIds).toEqual(expectedIds);
+  });
+
+  test("success path: valid PRD from agent preserves all userStories (field-equality regression guard)", async () => {
+    // Regression guard: on the normal success path, userStories must be preserved exactly.
+    _planDeps.createRuntime = mock((_cfg: any) =>
+      makeMockRuntime({
+        agentManager: makeMockAgentManager({
+          runWithFallbackFn: async () => ({
+            result: {
+              success: true,
+              exitCode: 0,
+              output: JSON.stringify(SAMPLE_PRD),
+              rateLimited: false,
+              durationMs: 1,
+              estimatedCostUsd: 0,
+              agentFallbacks: [],
+            },
+            fallbacks: [],
+          }),
+        }),
+      }),
+    );
+    _planDeps.existsSync = mock(() => false);
+    _planDeps.readFile = mock(async () => SAMPLE_SPEC);
+
+    await planCommand(tmpDir993, DEFAULT_CONFIG as never, {
+      from: "/spec.md",
+      feature: "url-shortener",
+    });
+
+    expect(capturedWrites993.length).toBeGreaterThan(0);
+    const written = JSON.parse(capturedWrites993[capturedWrites993.length - 1]?.[1] ?? "{}");
+    // Field-equality on stable identity fields — validatePlanOutput may transform
+    // routing.reasoning, so compare ids rather than the full object.
+    const writtenIds = (written.userStories as Array<{ id: string }>).map((s) => s.id);
+    expect(writtenIds).toEqual(SAMPLE_PRD.userStories.map((s) => s.id));
   });
 });

--- a/test/unit/operations/call-op-retry.test.ts
+++ b/test/unit/operations/call-op-retry.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { _callOpDeps, callOp } from "../../../src/operations";
-import type { CompleteOperation } from "../../../src/operations";
+import type { CompleteOperation, RunOperation } from "../../../src/operations";
 import type { RetryPreset } from "../../../src/agents/retry";
 import { DEFAULT_CONFIG } from "../../../src/config";
-import { makeMockAgentManager, makeTestRuntime } from "../../helpers";
+import { makeMockAgentManager, makeSessionManager, makeTestRuntime } from "../../helpers";
 import type { NaxRuntime } from "../../../src/runtime";
 import { pickSelector } from "../../../src/config";
 import type { CompleteResult } from "../../../src/agents/types";
@@ -152,5 +152,50 @@ describe("callOp retry loop (kind:complete)", () => {
     await expect(callOp(ctx, opWithNullResolver, "hello")).rejects.toThrow("transient");
     expect(callCount).toBe(1);
     expect(sleepCalls).toHaveLength(0);
+  });
+});
+
+describe("callOp retry loop (kind:run) — op.recover on parse exhaustion (#993)", () => {
+  test("op.parse throws after retry exhaustion AND op.recover returns non-null — returns recover value not TurnResult", async () => {
+    _callOpDeps.sleep = async () => {};
+
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (_req) => ({
+        result: { success: true, exitCode: 0, output: "File already valid.", rateLimited: false, durationMs: 1, estimatedCostUsd: 0, agentFallbacks: [] },
+        fallbacks: [],
+      }),
+    });
+    const sessionManager = makeSessionManager();
+    const runtime = makeTestRuntime({ agentManager, sessionManager });
+    createdRuntimes.push(runtime);
+
+    const recovered = { userStories: [{ id: "US-001", title: "existing" }] };
+
+    const runOp: RunOperation<string, typeof recovered, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      kind: "run",
+      name: "strict-parse-run-op",
+      stage: "plan",
+      config: testSel,
+      session: { role: "plan", lifetime: "fresh" },
+      build: (input) => ({
+        role: { id: "role", content: "", overridable: false },
+        task: { id: "task", content: input, overridable: false },
+      }),
+      parse: (_output) => { throw new Error("cannot parse chat ack"); },
+      retry: {
+        shouldRetry: (_failure, attempt) =>
+          attempt < 2 ? { retry: true, delayMs: 0, nextPrompt: "retry" } : { retry: false },
+      },
+      recover: async () => recovered,
+    };
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      runOp,
+      "feature-x",
+    );
+
+    expect(result).toBe(recovered);
+    expect(result.userStories[0]?.id).toBe("US-001");
   });
 });

--- a/test/unit/operations/call.test.ts
+++ b/test/unit/operations/call.test.ts
@@ -687,3 +687,156 @@ describe("callOp — kind:run — interactionBridge threading (AC3/AC4/AC8)", ()
     expect("interactionBridge" in reqArg.runOptions).toBe(false);
   });
 });
+
+describe("callOp — run-kind op.recover invocation on retry exhaustion (#993)", () => {
+  // A run-kind op whose parse() always throws to simulate unparseable agent output.
+  function makeStrictRunOp(overrides: Partial<RunOperation<{ id: string }, { value: string }, Pick<typeof DEFAULT_CONFIG, "routing">>> = {}): RunOperation<{ id: string }, { value: string }, Pick<typeof DEFAULT_CONFIG, "routing">> {
+    return {
+      kind: "run",
+      name: "strict-parse-op",
+      stage: "plan",
+      config: testSel,
+      session: { role: "plan", lifetime: "fresh" },
+      build: (input) => ({
+        role: { id: "role", content: "", overridable: false },
+        task: { id: "task", content: input.id, overridable: false },
+      }),
+      parse: (_output) => { throw new Error("parse always throws"); },
+      retry: {
+        shouldRetry: (_failure, attempt) =>
+          attempt < 2 ? { retry: true, delayMs: 0, nextPrompt: "retry" } : { retry: false },
+      },
+      ...overrides,
+    };
+  }
+
+  // Builds an agentManager that actually invokes req.executeHop so sendWithParseRetry
+  // runs and sets lastRetryTurn. Necessary for testing (b), (c), (d) which depend on
+  // lastRetryTurn / retryFallback being set inside the retry loop closure.
+  function makeHopInvokingAgentManager() {
+    return makeMockAgentManager({
+      runAsSessionFn: async () => ({
+        output: "File already valid.",
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+      }),
+      runWithFallbackFn: async (req) => {
+        const result = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return {
+          result: { success: true, exitCode: 0, rateLimited: false, durationMs: 1, output: result.result.output, estimatedCostUsd: result.result.estimatedCostUsd ?? 0, agentFallbacks: [] },
+          fallbacks: [],
+        };
+      },
+    });
+  }
+
+  // For tests (a) and (e), the mock doesn't need to invoke executeHop because
+  // op.recover is called from the catch block regardless of lastRetryTurn.
+  function makeChatAckAgentManager() {
+    return makeMockAgentManager({
+      runWithFallbackFn: async (_req) => ({
+        result: { success: true, exitCode: 0, output: "File already valid.", rateLimited: false, durationMs: 1, estimatedCostUsd: 0, agentFallbacks: [] },
+        fallbacks: [],
+      }),
+    });
+  }
+
+  test("(a) op.recover defined and returns non-null — returns recovered value, not TurnResult", async () => {
+    const agentManager = makeChatAckAgentManager();
+    const sessionManager = makeSessionManager();
+    runtime = makeTestRuntime({ agentManager, sessionManager });
+
+    const recovered = { value: "from-disk" };
+    const op = makeStrictRunOp({ recover: async () => recovered });
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      op,
+      { id: "f1" },
+    );
+
+    expect(result).toBe(recovered);
+  });
+
+  test("(b) op.recover undefined — falls through to envelope passthrough with warn log", async () => {
+    // Uses hop-invoking mock so sendWithParseRetry actually runs and sets lastRetryTurn.
+    const agentManager = makeHopInvokingAgentManager();
+    const sessionManager = makeSessionManager();
+    runtime = makeTestRuntime({ agentManager, sessionManager });
+
+    const op = makeStrictRunOp(); // no recover
+
+    // Should not throw; returns the TurnResult-shaped last turn (envelope passthrough)
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      op,
+      { id: "f1" },
+    ) as unknown as { output: string };
+
+    expect(typeof result).toBe("object");
+    expect("output" in result).toBe(true);
+  });
+
+  test("(c) both exhaustedFallback and op.recover — exhaustedFallback wins", async () => {
+    // Uses hop-invoking mock so sendWithParseRetry runs and retryFallback is set.
+    const agentManager = makeHopInvokingAgentManager();
+    const sessionManager = makeSessionManager();
+    runtime = makeTestRuntime({ agentManager, sessionManager });
+
+    const recoverCalled: boolean[] = [];
+    const op = makeStrictRunOp({
+      retry: {
+        shouldRetry: (_failure, attempt) =>
+          attempt < 2
+            ? { retry: true, delayMs: 0, nextPrompt: "retry" }
+            : { retry: false, fallback: { value: "from-exhausted-fallback" } },
+      },
+      recover: async () => { recoverCalled.push(true); return { value: "from-recover" }; },
+    });
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      op,
+      { id: "f1" },
+    );
+
+    // exhaustedFallback value wins; recover never called
+    expect((result as { value: string }).value).toBe("from-exhausted-fallback");
+    expect(recoverCalled).toHaveLength(0);
+  });
+
+  test("(d) op.recover returns null — falls through to envelope passthrough", async () => {
+    // Uses hop-invoking mock so sendWithParseRetry runs and sets lastRetryTurn.
+    const agentManager = makeHopInvokingAgentManager();
+    const sessionManager = makeSessionManager();
+    runtime = makeTestRuntime({ agentManager, sessionManager });
+
+    const op = makeStrictRunOp({ recover: async () => null });
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      op,
+      { id: "f1" },
+    ) as unknown as { output: string };
+
+    // Falls through to envelope passthrough
+    expect("output" in result).toBe(true);
+  });
+
+  test("(e) op.recover throws — error propagates out of callOp", async () => {
+    const agentManager = makeChatAckAgentManager();
+    const sessionManager = makeSessionManager();
+    runtime = makeTestRuntime({ agentManager, sessionManager });
+
+    const op = makeStrictRunOp({ recover: async () => { throw new Error("disk-read-error"); } });
+
+    await expect(
+      callOp(
+        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+        op,
+        { id: "f1" },
+      ),
+    ).rejects.toThrow("disk-read-error");
+  });
+});

--- a/test/unit/operations/plan-interactive.test.ts
+++ b/test/unit/operations/plan-interactive.test.ts
@@ -535,3 +535,108 @@ describe("planInteractiveOp.retry — validate/parse consistency (adversarial AC
     expect(decision.retry).toBe(true);
   });
 });
+
+// ─── US-002 (#993): op.recover is the load-bearing escape hatch ──────────────
+//
+// planInteractiveOp deliberately omits exhaustedFallback (it is synchronous
+// and only receives lastOutput, so it cannot read outputPath from disk).
+// op.recover is the third sanctioned escape hatch per retry-strategy.md.
+// These tests verify the three required recover behaviours.
+
+describe("planInteractiveOp.recover — disk-recovery escape hatch (#993)", () => {
+  const baseInput = {
+    specContent: "spec",
+    codebaseContext: "ctx",
+    featureName: "test-feature",
+    branchName: "feat/test",
+    outputPath: "/tmp/prd.json",
+  };
+
+  const validPrdJson = JSON.stringify({
+    project: "test-project",
+    feature: "test-feature",
+    analysis: "analysis",
+    branchName: "feat/test",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    userStories: [
+      {
+        id: "US-001",
+        title: "Story",
+        description: "desc",
+        acceptanceCriteria: ["AC1"],
+        contextFiles: [],
+        tags: [],
+        dependencies: [],
+        status: "pending",
+        passes: false,
+        routing: { complexity: "simple", testStrategy: "no-test", noTestJustification: "test", reasoning: "test" },
+        escalations: [],
+        attempts: 0,
+      },
+    ],
+  });
+
+  const envelopeJson = JSON.stringify({
+    output: "File already valid.",
+    tokenUsage: { inputTokens: 10, outputTokens: 5 },
+    estimatedCostUsd: 0.001,
+    internalRoundTrips: 3,
+  });
+
+  test("(a) recover returns valid PRD when outputPath exists with parseable userStories", async () => {
+    const { planInteractiveOp } = await import("@/operations");
+    const runtime = makeTestRuntime();
+    createdRuntimes.push(runtime);
+    const view = runtime.packages.repo();
+
+    const ctx = {
+      packageView: view,
+      config: view.select(planInteractiveOp.config),
+      readFile: async (_path: string) => validPrdJson,
+      fileExists: async (_path: string) => true,
+    };
+
+    const result = await planInteractiveOp.recover!(baseInput, ctx as any);
+
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result!.userStories)).toBe(true);
+    expect(result!.userStories.length).toBe(1);
+    expect(result!.userStories[0]?.id).toBe("US-001");
+  });
+
+  test("(b) recover returns null when outputPath is missing (readFile returns null)", async () => {
+    const { planInteractiveOp } = await import("@/operations");
+    const runtime = makeTestRuntime();
+    createdRuntimes.push(runtime);
+    const view = runtime.packages.repo();
+
+    const ctx = {
+      packageView: view,
+      config: view.select(planInteractiveOp.config),
+      readFile: async (_path: string) => null,
+      fileExists: async (_path: string) => false,
+    };
+
+    const result = await planInteractiveOp.recover!(baseInput, ctx as any);
+    expect(result).toBeNull();
+  });
+
+  test("(c) recover returns null when outputPath contains the envelope shape (not a valid PRD)", async () => {
+    const { planInteractiveOp } = await import("@/operations");
+    const runtime = makeTestRuntime();
+    createdRuntimes.push(runtime);
+    const view = runtime.packages.repo();
+
+    const ctx = {
+      packageView: view,
+      config: view.select(planInteractiveOp.config),
+      readFile: async (_path: string) => envelopeJson,
+      fileExists: async (_path: string) => true,
+    };
+
+    // validatePlanOutput throws inside recover's try/catch → recover returns null
+    const result = await planInteractiveOp.recover!(baseInput, ctx as any);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Close (#993)

- **Root cause:** When `planInteractiveOp`'s parse-retry loop exhausted all 3 attempts without producing valid JSON (e.g. agent returned a chat acknowledgement), `callOp`'s catch block silently returned the raw `TurnResult` as-is typed as `PRD`. The write at `cli/plan.ts` then overwrote a previously-valid `prd.json` with the envelope object, corrupting it. Regression introduced in PR #990 (v0.66.1).
- **Fix (3-layer defence):**
  1. `src/operations/call.ts` — invoke `op.recover` before the `lastRetryTurn` envelope passthrough; extract `makeVerifyCtx` helper; add warn log on the last-resort passthrough path.
  2. `src/operations/plan.ts` — document why `exhaustedFallback` is intentionally absent; `op.recover` (already on the op, reading `outputPath` from disk) is now the load-bearing escape hatch.
  3. `src/cli/plan.ts` — add `assertIsValidPrd` envelope guard at all three write sites (debate happy path, debate fallback, non-debate); add missing `storyId: options.feature` to the debate fallback and non-debate `CallContext`.
- `.claude/rules/retry-strategy.md` updated to sanction `op.recover` as a third escape hatch alongside `exhaustedFallback` and graceful-degradation `parse()`.

## Test plan

- [ ] `test/unit/operations/call.test.ts` — 5 new cases: recover invoked and returned; no-recover falls through to warn+envelope; exhaustedFallback wins over recover; recover returns null → fallthrough; recover throws → error propagates
- [ ] `test/unit/operations/call-op-retry.test.ts` — 1 new case: op.parse throws after retry exhaustion + op.recover returns non-null → callOp returns recover's value, not TurnResult
- [ ] `test/unit/operations/plan-interactive.test.ts` — 3 new cases: recover with valid PRD on disk; recover with missing file returns null; recover with envelope-shaped file returns null
- [ ] `test/unit/cli/plan.test.ts` — 3 new cases: chat-ack exhaustion with no disk file throws; chat-ack exhaustion with disk file triggers recovery; success path field-equality guard
- [ ] `test/integration/plan/plan-prd-preservation.test.ts` (new) — end-to-end: real `prd.json` on disk + agent returns chat ack on all turns → `userStories` preserved after `planCommand` returns
- [ ] `bun run test:bail` — 1278 tests, 0 failures
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean