### PR TITLE
[codex] fix adversarial verifiedBy grounding gaps

### DIFF
--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -81,6 +81,7 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
         testGlobs: input.testGlobs,
         refExcludePatterns: input.refExcludePatterns,
         priorAdversarialIterations: input.priorAdversarialIterations,
+        blockingThreshold: input.blockingThreshold,
       },
     );
     const content = input.featureCtxBlock ? `${input.featureCtxBlock}${base}` : base;

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -55,6 +55,8 @@ export interface AdversarialReviewPromptOptions {
    * for adversarial carry-forward iterations (fix ran in the implementation session).
    */
   priorAdversarialIterations?: Iteration[];
+  /** Minimum severity that blocks the story for this run. Defaults to "error". */
+  blockingThreshold?: "error" | "warning" | "info";
 }
 
 const ADVERSARIAL_ROLE = `You are an adversarial code reviewer with full access to the repository.
@@ -143,11 +145,8 @@ Severity guide:
 - \`"info"\`: noteworthy but not actionable as a blocker
 - \`"unverifiable"\`: suspect problem but couldn't confirm from available artifacts
 
-\`passed\` must be \`false\` if any finding has severity \`"error"\` or \`"warning"\`.
-\`passed\` may be \`true\` with findings if all findings are \`"info"\` or \`"unverifiable"\`.
-
-**Implementation-axis grounding — required for every "error" finding:**
-- Every "error" finding MUST include \`verifiedBy.observed\`: a verbatim 1–3 line code excerpt copy-pasted from the cited file that demonstrates the issue.
+**Implementation-axis grounding — required for every blocking finding:**
+- Every finding at or above the configured blocking threshold MUST include \`verifiedBy.observed\`: a verbatim 1–3 line code excerpt copy-pasted from the cited file that demonstrates the issue.
 - A description like "function X does not check Y" is not a verifiable observation; quote the lines that prove the omission instead.
 - The \`verifiedBy.observed\` field is substring-checked against the file at HEAD. If your quoted text does not appear in the file, the finding will be silently downgraded to \`"unverifiable"\`.
 - If you cannot quote an exact excerpt that proves your point, downgrade the finding to \`"unverifiable"\` rather than fabricating a quote.
@@ -172,6 +171,29 @@ Worked example:
 The story description may contain a "Scope" section with "In:" and "Out:" bullets. These are implementation guidelines, not ACs. A finding about code changed outside the stated scope (e.g., a file listed under "Out:") cannot cite a scope constraint as its \`acQuote\`/\`acIndex\` because scope text is not in the numbered AC list. Emit scope-violation findings as \`"warning"\` — never \`"error"\`. Never use \`acIndex: 0\`; \`acIndex\` is 1-based (first AC bullet = 1).
 
 If you cannot find an AC that names the **specific symbol** in your finding, downgrade to \`"info"\` or \`"warning"\`. A finding dropped by the validator is worse than one correctly classified as advisory.`;
+
+function buildBlockingThresholdBlock(threshold: "error" | "warning" | "info"): string {
+  const blocking =
+    threshold === "info"
+      ? '`"error"`, `"warning"`, and `"info"`'
+      : threshold === "warning"
+        ? '`"error"` and `"warning"`'
+        : '`"error"`';
+  const advisory =
+    threshold === "info"
+      ? '`"unverifiable"`'
+      : threshold === "warning"
+        ? '`"info"` and `"unverifiable"`'
+        : '`"warning"`, `"info"`, and `"unverifiable"`';
+  return `## Blocking Threshold
+
+The configured blocking threshold is \`"${threshold}"\`. Findings with severity ${blocking} can block this story, so they MUST include \`verifiedBy.observed\`.
+
+\`passed\` must be \`false\` if any finding has blocking severity ${blocking}.
+\`passed\` may be \`true\` with findings only if all findings are advisory (${advisory}).
+
+`;
+}
 
 /**
  * Build the diff section for "ref" mode.
@@ -273,6 +295,7 @@ export class AdversarialReviewPromptBuilder {
       testGlobs,
       refExcludePatterns,
       priorAdversarialIterations,
+      blockingThreshold,
     } = options;
 
     const priorFindingsBlock = buildPriorIterationsBlock(priorAdversarialIterations ?? []);
@@ -316,6 +339,7 @@ ${story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n")}
       ADVERSARIAL_INSTRUCTIONS,
       "\n\n",
       customRulesBlock,
+      buildBlockingThresholdBlock(blockingThreshold ?? "error"),
       OUTPUT_SCHEMA,
       "\n\n",
       diffBlock,

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -388,33 +388,24 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   // as substantiateSemanticEvidence (#826/#827) on the semantic side. Mirrors that
   // gate so adversarial findings can no longer fabricate code claims.
   //
-  // Only runs in "ref" mode (LLM self-serves files via git; diff is not inlined).
-  // In "embedded" mode the LLM only sees a diff snippet, so file-on-disk checks
-  // would be unreliable. Mirrors the same diffMode guard in substantiateSemanticEvidence.
-  //
   // Order matters: this runs BEFORE filterByAcQuote so AC-axis validation only
   // sees implementation-axis-grounded findings.
   const blockingThresholdEffective = blockingThreshold ?? "error";
-  let substantiatedFindings: AdversarialLLMFinding[];
-  if (diffMode === "ref") {
-    substantiatedFindings = await Promise.all(
-      rawParsedRaw.findings.map(async (finding) => {
-        if (!isBlockingSeverity(finding.severity, blockingThresholdEffective)) return finding;
-        const evidence = await checkFindingEvidence({ finding, workdir });
-        if (evidence.status !== "unmatched" && evidence.status !== "missing-observed") return finding;
-        return downgradeUnsubstantiatedFinding({
-          finding,
-          storyId: story.id,
-          event: ADVERSARIAL_FINDING_DOWNGRADED_EVENT,
-          file: evidence.file,
-          line: evidence.line,
-          observed: evidence.observed,
-        });
-      }),
-    );
-  } else {
-    substantiatedFindings = rawParsedRaw.findings;
-  }
+  const substantiatedFindings = await Promise.all(
+    rawParsedRaw.findings.map(async (finding) => {
+      if (!isBlockingSeverity(finding.severity, blockingThresholdEffective)) return finding;
+      const evidence = await checkFindingEvidence({ finding, workdir });
+      if (evidence.status !== "unmatched" && evidence.status !== "missing-observed") return finding;
+      return downgradeUnsubstantiatedFinding({
+        finding,
+        storyId: story.id,
+        event: ADVERSARIAL_FINDING_DOWNGRADED_EVENT,
+        file: evidence.file,
+        line: evidence.line,
+        observed: evidence.observed,
+      });
+    }),
+  );
   const rawParsed: AdversarialLLMResponse = { ...rawParsedRaw, findings: substantiatedFindings };
 
   // Issue #986 — build diff file set for structural counterfactual telemetry.

--- a/test/unit/prompts/adversarial-review-builder.test.ts
+++ b/test/unit/prompts/adversarial-review-builder.test.ts
@@ -426,6 +426,31 @@ describe("AdversarialReviewPromptBuilder — verifiedBy implementation-axis grou
     });
     expect(result).toContain("verifiedBy.observed");
     expect(result.toLowerCase()).toContain("verbatim");
+    expect(result).toContain('blocking threshold is `"error"`');
+  });
+
+  test("instructions align verifiedBy requirement with warning blocking threshold", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      blockingThreshold: "warning",
+    });
+    expect(result).toContain('blocking threshold is `"warning"`');
+    expect(result).toContain('`"error"` and `"warning"`');
+    expect(result).toContain("MUST include `verifiedBy.observed`");
+  });
+
+  test("passed guidance aligns with info blocking threshold", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, {
+      mode: "ref",
+      storyGitRef: STORY_GIT_REF,
+      blockingThreshold: "info",
+    });
+    expect(result).toContain('blocking threshold is `"info"`');
+    expect(result).toContain('`"error"`, `"warning"`, and `"info"`');
+    expect(result).toContain("`passed` must be `false` if any finding has blocking severity");
+    expect(result).toContain('advisory (`"unverifiable"`)');
+    expect(result).not.toContain('all findings are `"info"` or `"unverifiable"`');
   });
 
   test("instructions tell LLM to downgrade rather than fabricate quotes", () => {

--- a/test/unit/review/adversarial-audit-shape.test.ts
+++ b/test/unit/review/adversarial-audit-shape.test.ts
@@ -4,6 +4,8 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { ReviewAuditDecision } from "@/runtime";
 import { _diffUtilsDeps, runAdversarialReview } from "@/review";
 import type { AdversarialReviewConfig, SemanticStory } from "@/review/types";
@@ -12,6 +14,7 @@ import {
   captureAuditDecisions,
   makeMockRuntime,
   mockDiffUtilsDeps,
+  withTempDir,
 } from "@test/helpers";
 
 const STORY: SemanticStory = {
@@ -146,102 +149,122 @@ describe("adversarial structural counterfactual telemetry (#986)", () => {
   afterEach(() => teardown());
 
   test("dropped finding gets adversarialDropAnalysis with counterfactual", async () => {
-    // Drop trigger: missing acQuote on a "error" finding.
-    const llmResponse = JSON.stringify({
-      passed: false,
-      findings: [
-        {
-          severity: "error",
-          category: "input",
-          file: "src/foo.ts",
-          line: 10,
-          issue: "missing input validation",
-          suggestion: "add zod schema",
-          // No acQuote / acIndex → filterByAcQuote drops with missing_ac_quote.
-        },
-      ],
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "export const foo = 1;\n");
+
+      // Drop trigger: missing acQuote on a "error" finding.
+      const llmResponse = JSON.stringify({
+        passed: false,
+        findings: [
+          {
+            severity: "error",
+            category: "input",
+            file: "src/foo.ts",
+            line: 10,
+            issue: "missing input validation",
+            suggestion: "add zod schema",
+            verifiedBy: {
+              file: "src/foo.ts",
+              line: 1,
+              observed: "export const foo = 1;",
+            },
+            // No acQuote / acIndex → filterByAcQuote drops with missing_ac_quote.
+          },
+        ],
+      });
+
+      const { auditor, decisions } = captureAuditDecisions();
+      const agentManager = agentManagerWithFixedLLMResponse(llmResponse);
+      const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
+
+      await runAdversarialReview({
+        workdir,
+        storyGitRef: "abc123",
+        story: STORY,
+        adversarialConfig: { ...CFG, diffMode: "embedded" },
+        agentManager,
+        featureName: "feat-x",
+        runtime,
+      });
+
+      expect(decisions.length).toBeGreaterThanOrEqual(1);
+      const decision = decisions[0]!;
+      expect(decision.diffAvailable).toBe(true);
+      expect(Array.isArray(decision.adversarialDropAnalysis)).toBe(true);
+      expect(decision.adversarialDropAnalysis!.length).toBe(1);
+
+      const drop = decision.adversarialDropAnalysis![0]!;
+      expect(drop.dropCode).toBe("missing_ac_quote");
+      expect(drop.finding.file).toBe("src/foo.ts");
+      expect(drop.rawCategory).toBe("input");
+      expect(drop.counterfactual.fileInDiff).toBe(true);
+      expect(drop.counterfactual.categoryBlocking).toBe(true);
+      expect(drop.counterfactual.acIndexInRange).toBe(false); // no acIndex
+      expect(drop.counterfactual.wouldSurviveStructural).toBe(false);
     });
-
-    const { auditor, decisions } = captureAuditDecisions();
-    const agentManager = agentManagerWithFixedLLMResponse(llmResponse);
-    const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
-
-    await runAdversarialReview({
-      workdir: "/tmp/test",
-      storyGitRef: "abc123",
-      story: STORY,
-      adversarialConfig: { ...CFG, diffMode: "embedded" },
-      agentManager,
-      featureName: "feat-x",
-      runtime,
-    });
-
-    expect(decisions.length).toBeGreaterThanOrEqual(1);
-    const decision = decisions[0]!;
-    expect(decision.diffAvailable).toBe(true);
-    expect(Array.isArray(decision.adversarialDropAnalysis)).toBe(true);
-    expect(decision.adversarialDropAnalysis!.length).toBe(1);
-
-    const drop = decision.adversarialDropAnalysis![0]!;
-    expect(drop.dropCode).toBe("missing_ac_quote");
-    expect(drop.finding.file).toBe("src/foo.ts");
-    expect(drop.rawCategory).toBe("input");
-    expect(drop.counterfactual.fileInDiff).toBe(true);
-    expect(drop.counterfactual.categoryBlocking).toBe(true);
-    expect(drop.counterfactual.acIndexInRange).toBe(false); // no acIndex
-    expect(drop.counterfactual.wouldSurviveStructural).toBe(false);
   });
 
   test("accepted blocking finding gets adversarialAcceptAnalysis", async () => {
-    // Accept path: valid acQuote substring + locus keyword present.
-    const story: SemanticStory = {
-      id: "US-002",
-      title: "Accept path",
-      description: "",
-      acceptanceCriteria: ["The foo function must validate input arguments"],
-    };
-    const llmResponse = JSON.stringify({
-      passed: false,
-      findings: [
-        {
-          severity: "error",
-          category: "input",
-          file: "src/foo.ts",
-          line: 10,
-          issue: "foo missing validation",
-          suggestion: "add check",
-          acQuote: "foo function must validate",
-          acIndex: 1,
-        },
-      ],
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "export function foo(input: string) { return input; }\n");
+
+      // Accept path: valid acQuote substring + locus keyword present.
+      const story: SemanticStory = {
+        id: "US-002",
+        title: "Accept path",
+        description: "",
+        acceptanceCriteria: ["The foo function must validate input arguments"],
+      };
+      const llmResponse = JSON.stringify({
+        passed: false,
+        findings: [
+          {
+            severity: "error",
+            category: "input",
+            file: "src/foo.ts",
+            line: 10,
+            issue: "foo missing validation",
+            suggestion: "add check",
+            acQuote: "foo function must validate",
+            acIndex: 1,
+            verifiedBy: {
+              file: "src/foo.ts",
+              line: 1,
+              observed: "export function foo(input: string) { return input; }",
+            },
+          },
+        ],
+      });
+
+      const { auditor, decisions } = captureAuditDecisions();
+      const agentManager = agentManagerWithFixedLLMResponse(llmResponse);
+      const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
+
+      await runAdversarialReview({
+        workdir,
+        storyGitRef: "abc123",
+        story,
+        adversarialConfig: { ...CFG, diffMode: "embedded" },
+        agentManager,
+        featureName: "feat-y",
+        runtime,
+      });
+
+      const decision = decisions[0]!;
+      expect(decision.adversarialDropAnalysis ?? []).toEqual([]);
+      expect(Array.isArray(decision.adversarialAcceptAnalysis)).toBe(true);
+      expect(decision.adversarialAcceptAnalysis!.length).toBe(1);
+
+      const accept = decision.adversarialAcceptAnalysis![0]!;
+      expect(accept.finding.file).toBe("src/foo.ts");
+      expect(accept.acIndex).toBe(1);
+      expect(accept.counterfactual.acIndexInRange).toBe(true);
+      expect(accept.counterfactual.categoryBlocking).toBe(true);
+      expect(accept.counterfactual.fileInDiff).toBe(true);
+      expect(accept.counterfactual.wouldSurviveStructural).toBe(true);
     });
-
-    const { auditor, decisions } = captureAuditDecisions();
-    const agentManager = agentManagerWithFixedLLMResponse(llmResponse);
-    const runtime = makeMockRuntime({ agentManager, reviewAuditor: auditor });
-
-    await runAdversarialReview({
-      workdir: "/tmp/test",
-      storyGitRef: "abc123",
-      story,
-      adversarialConfig: { ...CFG, diffMode: "embedded" },
-      agentManager,
-      featureName: "feat-y",
-      runtime,
-    });
-
-    const decision = decisions[0]!;
-    expect(decision.adversarialDropAnalysis ?? []).toEqual([]);
-    expect(Array.isArray(decision.adversarialAcceptAnalysis)).toBe(true);
-    expect(decision.adversarialAcceptAnalysis!.length).toBe(1);
-
-    const accept = decision.adversarialAcceptAnalysis![0]!;
-    expect(accept.finding.file).toBe("src/foo.ts");
-    expect(accept.acIndex).toBe(1);
-    expect(accept.counterfactual.acIndexInRange).toBe(true);
-    expect(accept.counterfactual.categoryBlocking).toBe(true);
-    expect(accept.counterfactual.fileInDiff).toBe(true);
-    expect(accept.counterfactual.wouldSurviveStructural).toBe(true);
   });
 
   test("ref mode without diff records diffAvailable=false", async () => {

--- a/test/unit/review/adversarial-verifiedby.test.ts
+++ b/test/unit/review/adversarial-verifiedby.test.ts
@@ -216,6 +216,87 @@ describe("runAdversarialReview — verifiedBy.observed substantiation (#987)", (
     });
   });
 
+  test("downgrades blocking finding with phantom evidence in embedded diff mode", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/auth.ts"), "export function login() {}\n");
+
+      const llmResponse = JSON.stringify({
+        passed: false,
+        findings: [
+          {
+            severity: "error",
+            category: "abandonment",
+            file: "src/auth.ts",
+            line: 1,
+            issue: "login is broken",
+            suggestion: "Fix it",
+            acQuote: "can log in",
+            acIndex: 1,
+            verifiedBy: {
+              command: "cat src/auth.ts",
+              file: "src/auth.ts",
+              line: 1,
+              observed: "this embedded-mode quote is not in the file",
+            },
+          },
+        ],
+      });
+
+      const agentManager = makeAgentManager(llmResponse);
+      const runtime = makeMockRuntime({ agentManager });
+      const result = await runAdversarialReview({
+        workdir,
+        storyGitRef: "abc123",
+        story: STORY,
+        adversarialConfig: { ...ADVERSARIAL_CONFIG, diffMode: "embedded" },
+        agentManager,
+        runtime,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.findings).toBeUndefined();
+      expect(result.advisoryFindings?.[0]?.severity).toBe("unverifiable");
+    });
+  });
+
+  test("downgrades warning finding without verifiedBy when warning threshold blocks", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/auth.ts"), "export function login() {}\n");
+
+      const llmResponse = JSON.stringify({
+        passed: false,
+        findings: [
+          {
+            severity: "warning",
+            category: "input",
+            file: "src/auth.ts",
+            line: 1,
+            issue: "login mishandles empty input",
+            suggestion: "Validate input",
+          },
+        ],
+      });
+
+      const agentManager = makeAgentManager(llmResponse);
+      const runtime = makeMockRuntime({ agentManager });
+      const result = await runAdversarialReview({
+        workdir,
+        storyGitRef: "abc123",
+        story: STORY,
+        adversarialConfig: ADVERSARIAL_CONFIG,
+        agentManager,
+        runtime,
+        blockingThreshold: "warning",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.findings).toBeUndefined();
+      expect(result.advisoryFindings?.[0]?.severity).toBe("unverifiable");
+    });
+  });
+
   test("preserves blocking finding when verifiedBy.observed matches source verbatim", async () => {
     await withTempDir(async (workdir) => {
       mkdirSync(join(workdir, "src"), { recursive: true });


### PR DESCRIPTION
## Summary

Fixes follow-up gaps in the adversarial `verifiedBy.observed` implementation-axis grounding gate from #987.

- Runs adversarial evidence substantiation in both `ref` and `embedded` diff modes before AC quote validation.
- Threads `blockingThreshold` into the adversarial prompt so evidence and `passed` guidance match runtime behavior.
- Adds coverage for embedded-mode downgrades, warning-threshold downgrades, and info-threshold prompt guidance.
- Updates structural counterfactual telemetry fixtures so blocking findings pass the implementation-axis gate before exercising AC-axis telemetry.

## Why

The initial implementation skipped the new evidence gate in embedded mode and only asked for `verifiedBy.observed` on `error` findings even though runtime substantiates every severity that is blocking under the configured threshold. This left a behavioral gap and a prompt/runtime mismatch.

## Validation

- `bun test test/unit/prompts/adversarial-review-builder.test.ts --timeout=10000`
- `bun test test/unit/review/adversarial-audit-shape.test.ts test/unit/review/adversarial-verifiedby.test.ts --timeout=10000`
- `bun run typecheck`
- `bun run lint`
- `bun run test`