### PR TITLE
fix(plan): fix three nax plan pipeline bugs (parse corruption, session naming, wasted retries)

### DIFF
--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -272,7 +272,9 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
       // op.fileOutput: inject file content as output so the probe checks the
       // file the agent wrote, not the text confirmation it replied with.
       if (fileOutputPath) {
-        const fileContent = await Bun.file(fileOutputPath).text().catch(() => null);
+        const fileContent = await Bun.file(fileOutputPath)
+          .text()
+          .catch(() => null);
         if (fileContent !== null) lastTurn = { ...lastTurn, output: fileContent };
       }
       cumCost += lastTurn.estimatedCostUsd ?? 0;

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -198,6 +198,12 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
   // ctx.sendWithParseRetry which applies this strategy per call.
   const retryStrategy = resolveOpRetry(runOp, input, buildCtx);
 
+  // op.fileOutput: when set, callOp reads this file after each agent send and
+  // replaces the turn's text output with the file content before the probe fires.
+  // This makes the retry probe check the actual written file, not the text
+  // confirmation — so retries only fire when the file is missing or invalid.
+  const fileOutputPath = runOp.fileOutput?.(input);
+
   const runOptions = {
     prompt,
     workdir: ctx.packageDir,
@@ -263,6 +269,12 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
     let lastTurn!: TurnResult;
     while (attempt <= MAX_COMPLETE_RETRY_ATTEMPTS) {
       lastTurn = await bodyCtx.send(currentPrompt);
+      // op.fileOutput: inject file content as output so the probe checks the
+      // file the agent wrote, not the text confirmation it replied with.
+      if (fileOutputPath) {
+        const fileContent = await Bun.file(fileOutputPath).text().catch(() => null);
+        if (fileContent !== null) lastTurn = { ...lastTurn, output: fileContent };
+      }
       cumCost += lastTurn.estimatedCostUsd ?? 0;
       const decision = retryStrategy.shouldRetry(
         new ParseValidationError(`[${op.name}] sendWithParseRetry: probe attempt ${attempt}`),

--- a/src/operations/plan.ts
+++ b/src/operations/plan.ts
@@ -27,6 +27,11 @@ export const planInteractiveOp: RunOperation<PlanInteractiveInput, PRD, PlanConf
   config: planConfigSelector,
   model: (_input, ctx) => ctx.config.plan.model,
   timeoutMs: (_input, ctx) => (ctx.config.plan.timeoutSeconds ?? 600) * 1000,
+  // fileOutput: the plan prompt instructs the agent to write JSON to disk and reply
+  // with a brief text confirmation. callOp reads this file after each send and
+  // substitutes its content as the probe output — so retries only fire when the
+  // file is missing or contains invalid JSON, not on every text-confirmation turn.
+  fileOutput: (input) => input.outputPath,
   retry: makeParseRetryStrategy({
     validate: (parsed) => {
       if (parsed === null || typeof parsed !== "object") return false;
@@ -41,16 +46,10 @@ export const planInteractiveOp: RunOperation<PlanInteractiveInput, PRD, PlanConf
       invalid: () => PlanPromptBuilder.jsonRepair(0, "Invalid JSON — response was not parseable"),
       truncated: () => PlanPromptBuilder.jsonRepair(0, "JSON appears truncated — please rewrite completely"),
     },
-    // Intentionally no exhaustedFallback: it is synchronous and only receives
-    // lastOutput, so it cannot read outputPath from disk. Disk recovery is
-    // handled by op.recover below, which callOp's catch path invokes when retry
-    // exhausts. See issue #993 and .claude/rules/retry-strategy.md
-    // "Strict-parser interaction" — op.recover is the third sanctioned escape
-    // hatch alongside exhaustedFallback and graceful-degradation parse().
+    // Intentionally no exhaustedFallback: synchronous and only receives lastOutput.
+    // Disk recovery is handled by op.recover. See issue #993 and retry-strategy.md
+    // "Strict-parser interaction".
   }),
-  hopBody: async (initialPrompt, ctx) => {
-    return ctx.sendWithParseRetry(initialPrompt);
-  },
   build(input, _ctx) {
     const { taskContext, outputFormat } = new PlanPromptBuilder().build(
       input.specContent,

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -194,6 +194,17 @@ export interface RunOperation<I, O, C> extends OperationBase<I, O, C> {
     | RetryPreset
     | RetryStrategy
     | ((input: I, ctx: BuildContext<C>) => RetryPreset | RetryStrategy | undefined);
+  /**
+   * Optional file-output path resolver. When set, `callOp` reads this file
+   * after each agent send (inside `sendWithParseRetry`) and replaces the
+   * turn's text output with the file content before the retry probe fires.
+   *
+   * Use for ops where the agent writes its output to disk and replies with
+   * a text confirmation (not JSON) — e.g. the plan op. This makes the probe
+   * check the actual file content, so retries only fire when the file is
+   * missing or contains invalid JSON, not on every text-confirmation turn.
+   */
+  readonly fileOutput?: (input: I) => string | undefined;
 }
 
 export interface CompleteOperation<I, O, C> extends OperationBase<I, O, C> {

--- a/src/prd/schema.ts
+++ b/src/prd/schema.ts
@@ -265,9 +265,12 @@ function sanitizeInvalidEscapes(text: string): string {
   result = result.replace(/\\u([0-9a-fA-F]{1,3})(?![0-9a-fA-F])/g, (_, digits) => `\\u${digits.padStart(4, "0")}`);
   result = result.replace(/\\u(?![0-9a-fA-F])/g, "\\");
 
-  // Remove backslash before any character that is NOT a valid JSON escape char
+  // Remove backslash before any character that is NOT a valid JSON escape char.
   // Valid: " \ / b f n r t u
-  result = result.replace(/\\([^"\\\/bfnrtu])/g, "$1");
+  // Match valid \\ pairs first (to preserve them), then strip lone \ before invalid char.
+  // Without the pair-first branch, \\( would corrupt to \( (invalid), because the regex
+  // would match the second \ + ( after skipping the first \ + \ (which IS in the exclusion).
+  result = result.replace(/(\\\\)|\\([^"\\\/bfnrtu])/g, (_, pair, bad) => pair ?? bad);
 
   return result;
 }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -59,6 +59,7 @@ export type {
 export { AgentStreamEventBus } from "./agent-stream-events";
 export { attachAgentIdleWatchdog, attachAgentStreamLogging } from "./middleware";
 export type { WatchdogState } from "./middleware";
+export { formatSessionName } from "./session-name";
 
 import { basename, join } from "node:path";
 import type { IAgentManager } from "../agents";

--- a/src/runtime/session-name.ts
+++ b/src/runtime/session-name.ts
@@ -19,7 +19,11 @@ export function formatSessionName(req: SessionNameRequest): string {
 
   const parts = ["nax", hash];
   if (req.featureName) parts.push(sanitize(req.featureName));
-  if (req.storyId) parts.push(sanitize(req.storyId));
+  // Skip storyId when it equals featureName to avoid duplicate segments in the name
+  // (e.g. plan op passes both as options.feature → would produce …-feat-feat-plan)
+  if (req.storyId && sanitize(req.storyId) !== sanitize(req.featureName ?? "")) {
+    parts.push(sanitize(req.storyId));
+  }
 
   const suffix =
     req.role && req.role !== "main"

--- a/test/unit/operations/plan-interactive.test.ts
+++ b/test/unit/operations/plan-interactive.test.ts
@@ -13,7 +13,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { ParseValidationError } from "@/agents";
 import type { RetryStrategy } from "@/agents";
-import type { TurnResult } from "@/agents/types";
 import { validatePlanOutput } from "@/prd";
 import { makeTestRuntime } from "@test/helpers";
 import type { NaxRuntime } from "@/runtime";
@@ -113,51 +112,29 @@ describe("planInteractiveOp.retry", () => {
   });
 });
 
-describe("planInteractiveOp.hopBody", () => {
-  test("hopBody is defined", async () => {
+describe("planInteractiveOp.fileOutput", () => {
+  test("fileOutput is defined and returns outputPath", async () => {
+    // The plan op uses file-based output: the agent writes JSON to disk and
+    // replies with a text confirmation. callOp reads the file via fileOutput
+    // and substitutes it as the probe output so retries check the actual JSON.
     const mod = await import("@/operations");
     const { planInteractiveOp } = mod;
-    expect(planInteractiveOp.hopBody).toBeDefined();
+    expect(planInteractiveOp.fileOutput).toBeDefined();
+    const path = planInteractiveOp.fileOutput?.({
+      specContent: "",
+      codebaseContext: "",
+      featureName: "f",
+      branchName: "feat/f",
+      outputPath: "/tmp/prd.json",
+    });
+    expect(path).toBe("/tmp/prd.json");
   });
 
-  test("hopBody is an async function", async () => {
+  test("hopBody is NOT defined (file-reading done by callOp via fileOutput)", async () => {
+    // hopBody is no longer needed — callOp injects file content directly.
     const mod = await import("@/operations");
     const { planInteractiveOp } = mod;
-    expect(typeof planInteractiveOp.hopBody).toBe("function");
-  });
-
-  test("hopBody calls ctx.sendWithParseRetry (not ctx.send)", async () => {
-    const mod = await import("@/operations");
-    const { planInteractiveOp } = mod;
-
-    // Create a mock context to verify sendWithParseRetry is called
-    let sendWithParseRetryCalled = false;
-    const mockCtx = {
-      send: async (prompt: string) => {
-        throw new Error("send should not be called, use sendWithParseRetry");
-      },
-      sendWithParseRetry: async (prompt: string): Promise<TurnResult> => {
-        sendWithParseRetryCalled = true;
-        return {
-          output: '{"userStories": []}',
-          estimatedCostUsd: 0.01,
-          tokenUsage: { inputTokens: 0, outputTokens: 0 },
-          internalRoundTrips: 1,
-        };
-      },
-      input: {
-        specContent: "Test",
-        codebaseContext: "Test",
-        featureName: "test",
-        branchName: "feat/test",
-        outputPath: "/tmp/prd.json",
-      },
-    };
-
-    if (planInteractiveOp.hopBody) {
-      await planInteractiveOp.hopBody("initial prompt", mockCtx as any);
-      expect(sendWithParseRetryCalled).toBe(true);
-    }
+    expect(planInteractiveOp.hopBody).toBeUndefined();
   });
 });
 

--- a/test/unit/prd/schema.test.ts
+++ b/test/unit/prd/schema.test.ts
@@ -372,6 +372,15 @@ describe("validatePlanOutput — auto-fix LLM quirks (AC-7)", () => {
     expect(prd.userStories[0]!.description).toBe('line1\nline2\ttab"quote\\backslash/slash\rCR');
   });
 
+  test("preserves \\\\( (valid JSON escaped backslash+paren) — regression for sanitizeInvalidEscapes corruption", () => {
+    // \\( in JSON represents the string \( (backslash-paren), as seen in regex literals in descriptions.
+    // The old code would incorrectly strip the second \ in \\(, producing \( which JSON.parse rejects.
+    const escaped = "regex /expect\\\\(|foo/";
+    const json = `{"userStories":[{"id":"ST-001","title":"T","description":"${escaped}","acceptanceCriteria":["AC-1"],"complexity":"simple","testStrategy":"tdd-simple","dependencies":[]}]}`;
+    const prd = validatePlanOutput(json, "feat", "branch");
+    expect(prd.userStories[0]!.description).toBe("regex /expect\\(|foo/");
+  });
+
   test("fixes \\x escape in markdown-wrapped JSON", () => {
     const escaped = "\\x41";
     const wrapped = `\`\`\`json\n{"userStories":[{"id":"ST-001","title":"T","description":"${escaped}","acceptanceCriteria":["AC-1"],"complexity":"simple","testStrategy":"tdd-simple","dependencies":[]}]}\n\`\`\``;

--- a/test/unit/runtime/session-name.test.ts
+++ b/test/unit/runtime/session-name.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { formatSessionName } from "../../../src/runtime/session-name";
+import { formatSessionName } from "@/runtime";
 
 describe("formatSessionName", () => {
   test("includes featureName and storyId when they differ", () => {

--- a/test/unit/runtime/session-name.test.ts
+++ b/test/unit/runtime/session-name.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { formatSessionName } from "../../../src/runtime/session-name";
+
+describe("formatSessionName", () => {
+  test("includes featureName and storyId when they differ", () => {
+    const name = formatSessionName({ workdir: "/repo", featureName: "my-feature", storyId: "US-001", role: "main" });
+    expect(name).toContain("my-feature");
+    expect(name).toContain("us-001");
+  });
+
+  test("deduplicates when storyId equals featureName — plan-op regression", () => {
+    // plan op passes both storyId and featureName as options.feature (same value).
+    // Previously produced: nax-<hash>-mock-structure-handoff-mock-structure-handoff-plan
+    const name = formatSessionName({
+      workdir: "/repo",
+      featureName: "mock-structure-handoff",
+      storyId: "mock-structure-handoff",
+      role: "plan",
+    });
+    const segments = name.split("-");
+    const occurrences = segments.filter((s: string) => s === "mock").length;
+    expect(occurrences).toBe(1);
+    expect(name).toMatch(/^nax-[a-f0-9]{8}-mock-structure-handoff-plan$/);
+  });
+
+  test("deduplicates case-insensitively (sanitized form comparison)", () => {
+    const name = formatSessionName({
+      workdir: "/repo",
+      featureName: "My Feature",
+      storyId: "my-feature",
+      role: "plan",
+    });
+    expect(name).not.toMatch(/my-feature-my-feature/);
+  });
+
+  test("omits storyId segment when featureName is absent", () => {
+    const name = formatSessionName({ workdir: "/repo", storyId: "US-001", role: "plan" });
+    expect(name).toContain("us-001");
+  });
+
+  test("omits role segment when role is 'main'", () => {
+    const name = formatSessionName({ workdir: "/repo", featureName: "feat", storyId: "US-001", role: "main" });
+    expect(name).not.toMatch(/main/);
+  });
+});


### PR DESCRIPTION
## Summary

Three bugs diagnosed from a failed `nax plan` run (prompt audit + JSONL log analysis).

- **`sanitizeInvalidEscapes` corrupts `\\(` in PRD JSON** — the regex matched the second `\` in `\\(` (valid JSON for backslash+paren) and stripped it to `\(`, causing `JSON.parse` to throw `Invalid escape character (`. This fired whenever PRD descriptions contained regex literals like `expect\(`. Fixed by consuming valid `\\` pairs first before stripping lone backslashes.

- **Plan session name duplicated featureName** — `formatSessionName` appended both `featureName` and `storyId` unconditionally. The plan op passes both as `options.feature`, producing `nax-<hash>-mock-structure-handoff-mock-structure-handoff-plan`. Fixed by skipping `storyId` when its sanitized form equals `featureName`.

- **`sendWithParseRetry` wasted 2 retries on text confirmations** — the plan prompt tells the agent to write JSON to disk and reply with a brief text confirmation. The probe fired on the text ("PRD written…"), which is never JSON, so every turn triggered a retry. Two wasted agent calls (including a 164s call) before `op.recover` read the file. Fixed by adding `fileOutput?: (input: I) => string | undefined` to `RunOperation` — when set, `callOp` reads the file after each send and substitutes its content as the probe output before the retry strategy fires. Retries now only trigger when the file is actually missing or contains invalid JSON.

## Files changed

| File | Change |
|---|---|
| `src/prd/schema.ts` | Fix `sanitizeInvalidEscapes` regex |
| `src/runtime/session-name.ts` | Skip duplicate storyId in session name |
| `src/operations/types.ts` | Add `fileOutput` field to `RunOperation` |
| `src/operations/call.ts` | Wire file-read into `sendWithParseRetry` |
| `src/operations/plan.ts` | Use `fileOutput`, remove `hopBody`, restore `retry` |
| `test/unit/prd/schema.test.ts` | Regression test for `\\(` corruption |
| `test/unit/runtime/session-name.test.ts` | New tests for deduplication |
| `test/unit/operations/plan-interactive.test.ts` | Update for `fileOutput` design |

## Test plan

- [ ] `bun test test/unit/prd/schema.test.ts` — passes regression test for `\\(` corruption
- [ ] `bun test test/unit/runtime/session-name.test.ts` — passes deduplication tests
- [ ] `bun test test/unit/operations/plan-interactive.test.ts` — passes `fileOutput` tests
- [ ] `bun run test` — full suite green
- [ ] `nax plan --from <spec> -f <feature>` — no wasted retries in prompt audit, session name has no duplicates