### PR TITLE
fix: acceptance parse extractJsonFromMarkdown & extractJsonObject wro…

### DIFF
--- a/src/utils/llm-json.ts
+++ b/src/utils/llm-json.ts
@@ -95,21 +95,40 @@ export function wrapJsonPrompt(prompt: string): string {
 /**
  * Parse JSON from raw LLM output using multi-tier extraction.
  *
- * Tier 1: Direct JSON.parse (clean responses)
- * Tier 2: Markdown fence extraction — non-anchored, handles preamble text
- * Tier 3: Bare JSON object/array extraction — handles JSON embedded in narration
+ * Tier 1:   Direct JSON.parse (clean responses)
+ * Tier 1.5: Explicit ```json fence — prioritised over generic fences to avoid
+ *           matching an earlier plain ``` fence (e.g. bun test output blocks)
+ * Tier 2:   Generic markdown fence — non-anchored, handles preamble text
+ * Tier 3a:  Bare JSON object extraction — first { … last }
+ * Tier 3b:  Bare JSON array extraction — first [ … last ] (fallback)
  *
- * @throws {SyntaxError} when all three tiers fail to produce valid JSON
+ * Tier 3 tries objects before arrays because almost all LLM responses are
+ * objects; this avoids the bug where "[7.00ms]" in assistant narration is
+ * mistaken for the start of a JSON array.
+ *
+ * @throws {SyntaxError} when all tiers fail to produce valid JSON
  */
 export function parseLLMJson<T = unknown>(text: string): T {
   const trimmed = text.trim();
 
+  // Tier 1: direct parse
   try {
     return JSON.parse(trimmed) as T;
   } catch {
     /* not raw JSON */
   }
 
+  // Tier 1.5: explicit ```json fence (must come before generic fence search)
+  const jsonFenceContent = trimmed.match(/```json\s*\n([\s\S]*?)\n?\s*```/)?.[1];
+  if (jsonFenceContent) {
+    try {
+      return JSON.parse(stripTrailingCommas(jsonFenceContent)) as T;
+    } catch {
+      /* json-tagged fence content not valid JSON */
+    }
+  }
+
+  // Tier 2: generic markdown fence
   const fromFence = extractJsonFromMarkdown(trimmed);
   if (fromFence !== trimmed) {
     try {
@@ -119,12 +138,25 @@ export function parseLLMJson<T = unknown>(text: string): T {
     }
   }
 
-  const bareJson = extractJsonObject(trimmed);
-  if (bareJson) {
+  // Tier 3a: bare JSON object — try { … } first
+  const objStart = trimmed.indexOf("{");
+  const objEnd = trimmed.lastIndexOf("}");
+  if (objStart !== -1 && objEnd > objStart) {
     try {
-      return JSON.parse(stripTrailingCommas(bareJson)) as T;
+      return JSON.parse(stripTrailingCommas(trimmed.slice(objStart, objEnd + 1))) as T;
     } catch {
-      /* extracted text not valid JSON */
+      /* extracted object not valid JSON */
+    }
+  }
+
+  // Tier 3b: bare JSON array — fallback to [ … ]
+  const arrStart = trimmed.indexOf("[");
+  const arrEnd = trimmed.lastIndexOf("]");
+  if (arrStart !== -1 && arrEnd > arrStart) {
+    try {
+      return JSON.parse(stripTrailingCommas(trimmed.slice(arrStart, arrEnd + 1))) as T;
+    } catch {
+      /* extracted array not valid JSON */
     }
   }
 

--- a/test/unit/utils/llm-json.test.ts
+++ b/test/unit/utils/llm-json.test.ts
@@ -8,7 +8,13 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { extractJsonFromMarkdown, extractJsonObject, stripTrailingCommas, wrapJsonPrompt } from "../../../src/utils/llm-json";
+import {
+  extractJsonFromMarkdown,
+  extractJsonObject,
+  parseLLMJson,
+  stripTrailingCommas,
+  wrapJsonPrompt,
+} from "../../../src/utils/llm-json";
 
 // ---------------------------------------------------------------------------
 // extractJsonFromMarkdown
@@ -132,6 +138,71 @@ describe("extractJsonObject", () => {
 
   test("returns null for empty string", () => {
     expect(extractJsonObject("")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLLMJson — regression tests for multi-fence and bracket-in-text bugs
+// ---------------------------------------------------------------------------
+
+describe("parseLLMJson", () => {
+  type Obj = Record<string, unknown>;
+
+  test("parses clean JSON directly", () => {
+    const input = '{"verdict":"test_bug","confidence":1}';
+    expect(parseLLMJson<Obj>(input)).toEqual({ verdict: "test_bug", confidence: 1 });
+  });
+
+  test("extracts JSON from ```json fence with preamble reasoning", () => {
+    const json = '{"verdict":"test_bug","confidence":1}';
+    const input = `Some reasoning here.\n\`\`\`json\n${json}\n\`\`\``;
+    expect(parseLLMJson<Obj>(input)).toEqual({ verdict: "test_bug", confidence: 1 });
+  });
+
+  // Regression: plain ``` fence (e.g. bun test output) appears before ```json fence.
+  // Bug: tier 2 used to match the plain fence and extract non-JSON content.
+  test("prefers ```json fence over earlier plain ``` fence", () => {
+    const json = '{"verdict":"test_bug","confidence":1}';
+    const input = [
+      "Analysis:\n",
+      "```\nbun test v1.3.13\n  5 pass\n  0 fail\nRan 5 tests [7.00ms]\n```\n",
+      "The assertion is wrong.\n",
+      "```json\n",
+      json,
+      "\n```",
+    ].join("");
+    expect(parseLLMJson<Obj>(input)).toEqual({ verdict: "test_bug", confidence: 1 });
+  });
+
+  // Regression: bun test output contains "[7.00ms]" before the JSON object.
+  // Bug: tier 3 used to pick "[" from "[7.00ms]" as the JSON array start,
+  // extracting garbage from there to the last "]" in the findings array.
+  test("extracts JSON object when [ appears before { in narration text", () => {
+    const json = '{"verdict":"test_bug","findings":[{"id":1}]}';
+    const input = `Ran 5 tests [7.00ms]\n\nResult: ${json}`;
+    expect(parseLLMJson<Obj>(input)).toEqual({ verdict: "test_bug", findings: [{ id: 1 }] });
+  });
+
+  // Combined regression: both problems at once — same shape as the real failing response.
+  test("handles plain-fence-before-json-fence AND [time] before JSON object", () => {
+    const json = '{"verdict":"test_bug","confidence":1,"findings":[{"fixTarget":"test"}]}';
+    const input = [
+      "Looking at the failing test.\n",
+      "```\nbun test v1.3.13\n 5 pass\n 0 fail\nRan 5 tests [7.00ms]\n```\n",
+      "The string '0 failures' never appears in the output.\n",
+      "```json\n",
+      json,
+      "\n```",
+    ].join("");
+    expect(parseLLMJson<Obj>(input)).toEqual({
+      verdict: "test_bug",
+      confidence: 1,
+      findings: [{ fixTarget: "test" }],
+    });
+  });
+
+  test("throws SyntaxError when all tiers fail", () => {
+    expect(() => parseLLMJson("no JSON here at all")).toThrow(SyntaxError);
   });
 });
 


### PR DESCRIPTION
This pull request improves the robustness and correctness of the `parseLLMJson` function in `src/utils/llm-json.ts`, ensuring it can accurately extract JSON from LLM outputs that may contain markdown fences, preamble text, or extraneous bracketed timing information. It also adds comprehensive regression tests to prevent similar bugs in the future.

**Enhancements to JSON extraction logic:**

* Improved the tiered parsing strategy in `parseLLMJson` to prioritize explicit ```json fences over generic fences, and to extract bare JSON objects before arrays, preventing misinterpretation of bracketed timing (e.g., `[7.00ms]`) as JSON arrays. [[1]](diffhunk://#diff-bb504b05dfb64723641ca519eff3caaeb3f1c9c674b0d03edc709217f9b75515L99-R131) [[2]](diffhunk://#diff-bb504b05dfb64723641ca519eff3caaeb3f1c9c674b0d03edc709217f9b75515L122-R159)

**Testing improvements:**

* Added a suite of regression tests in `llm-json.test.ts` to cover cases such as multiple markdown fences, preamble text, timing brackets before JSON, and combinations of these scenarios, ensuring correct extraction and error handling.
* Updated test imports to include the new `parseLLMJson` function.…ngly
