### PR TITLE
fix(audit): route TDD session hops through agentManager.runAsSession

### DIFF
--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -211,7 +211,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
     middleware,
     runId,
     sendPrompt: (handle, prompt, sendOpts) => sessionManager.sendPrompt(handle, prompt, sendOpts),
-    runHop: createSessionRunHop(sessionManager),
+    runHop: createSessionRunHop(sessionManager, () => agentManager),
     dispatchEvents,
   };
   if (opts?.agentManager instanceof AgentManager) {

--- a/src/runtime/session-run-hop.ts
+++ b/src/runtime/session-run-hop.ts
@@ -1,4 +1,5 @@
 import { buildContextToolPreamble, buildRunInteractionHandler } from "../agents/acp/adapter";
+import type { IAgentManager } from "../agents/manager-types";
 import { SessionFailureError } from "../agents/types";
 import type { AgentResult, AgentRunOptions } from "../agents/types";
 import type { ISessionManager } from "../session";
@@ -10,7 +11,10 @@ export interface SessionRunHopResult {
 
 export type SessionRunHopFn = (agentName: string, options: AgentRunOptions) => Promise<SessionRunHopResult>;
 
-export function createSessionRunHop(sessionManager: ISessionManager): SessionRunHopFn {
+export function createSessionRunHop(
+  sessionManager: ISessionManager,
+  getAgentManager?: () => IAgentManager | undefined,
+): SessionRunHopFn {
   return async (agentName: string, options: AgentRunOptions): Promise<SessionRunHopResult> => {
     const startMs = Date.now();
     const prompt = buildContextToolPreamble(options);
@@ -44,11 +48,28 @@ export function createSessionRunHop(sessionManager: ISessionManager): SessionRun
           ? (options.maxInteractionTurns ?? 10)
           : (options.maxInteractionTurns ?? 1);
 
-      const turnResult = await sessionManager.sendPrompt(handle, prompt, {
-        interactionHandler: buildRunInteractionHandler(options),
-        signal: options.abortSignal,
-        maxTurns,
-      });
+      const interactionHandler = buildRunInteractionHandler(options);
+      const am = getAgentManager?.();
+      // Route through agentManager.runAsSession when available so dispatch
+      // events are emitted and captured by the prompt auditor. Falls back to
+      // sessionManager.sendPrompt for callers without an agentManager (tests).
+      const turnResult = am
+        ? await am.runAsSession(agentName, handle, prompt, {
+            storyId: options.storyId,
+            featureName: options.featureName,
+            workdir: options.workdir,
+            projectDir: options.projectDir,
+            pipelineStage: options.pipelineStage ?? "run",
+            sessionRole: options.sessionRole,
+            signal: options.abortSignal,
+            interactionHandler,
+            maxTurns,
+          })
+        : await sessionManager.sendPrompt(handle, prompt, {
+            interactionHandler,
+            signal: options.abortSignal,
+            maxTurns,
+          });
 
       return {
         prompt,


### PR DESCRIPTION
## Summary

- `createSessionRunHop` was calling `sessionManager.sendPrompt()` directly, bypassing the dispatch layer where `SessionTurnDispatchEvent` is emitted
- Three-session TDD sessions (test-writer, implementer, verifier) were invisible to the prompt auditor and cost aggregator
- Fix: pass a lazy `agentManager` getter to `createSessionRunHop` and route through `agentManager.runAsSession()`, which emits the dispatch event after each turn

## Root cause

The audit path requires `agentManager.runAsSession()` — that is the only place `SessionTurnDispatchEvent` is emitted. Two dispatch paths exist:

| Path | How it dispatches | Audit? |
|---|---|---|
| Pipeline stages (`callOp`) | `buildHopCallback` → `agentManager.runAsSession()` | ✅ |
| TDD sessions (before fix) | `_runHop` → `createSessionRunHop` → `sessionManager.sendPrompt()` | ❌ |
| TDD sessions (after fix) | `_runHop` → `createSessionRunHop` → `agentManager.runAsSession()` | ✅ |

Single-session execution already used `buildHopCallback`, which is why it had audit entries while three-session-tdd did not.

## Risk analysis

- **Cost accounting**: TDD turn costs now appear in `CostAggregator.snapshot()` for the first time. `recordOperationSummary` is a no-op so there is no double-count — costs were simply missing before
- **Existing tests**: `session-run-hop.test.ts` calls `createSessionRunHop(sessionManager)` with no `getAgentManager` → falls back to `sessionManager.sendPrompt` → passes unchanged
- **Other callOp callers**: unaffected — `callOp` always sets `executeHop` on the run request, so `runWithFallback` never reaches `_runHop`
- **Rectification legacy paths**: `rectification-loop.ts:385` and `rectification-gate.ts:366` also call `agentManager.run()` without `executeHop`, but only when `runtime` is null. Tracked separately in #1006

## Test plan

- [ ] Run a three-session-tdd story with `agent.promptAudit.enabled = true` and verify `.txt` audit files are created for test-writer, implementer, and verifier sessions
- [ ] Verify `costAggregator.snapshot().callCount` increases for TDD runs
- [ ] Confirm `bun run test` passes