### PR TITLE
fix(auto-commit): stage from gitRoot to capture cross-package changes

### DIFF
--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -309,23 +309,15 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
   // Pass workdir as packageDir so per-package .naxignore rules apply in monorepos.
   const uncommittedFiles = naxIgnoreIndex ? naxIgnoreIndex.filter(afterRuntimeFilter, workdir) : afterRuntimeFilter;
   if (uncommittedFiles.length > 0) {
+    // Warn but continue — autoCommitIfDirty already ran above as the primary guard.
+    // Any files still dirty here are either infra artifacts or edge cases (e.g. a
+    // cross-package file the add missed). Escalation cannot fix structural commit-scope
+    // gaps and only wastes tokens, so we proceed with the review on what IS committed.
     const fileList = uncommittedFiles.join(", ");
-    logger?.warn("review", `Uncommitted changes detected before review: ${fileList}`);
-    return {
-      success: false,
-      checks: [
-        {
-          check: "git-clean",
-          success: false,
-          command: "git diff --name-only HEAD",
-          exitCode: 1,
-          output: uncommittedFiles.join("\n"),
-          durationMs: 0,
-        },
-      ],
-      totalDurationMs: Date.now() - startTime,
-      failureReason: `Working tree has uncommitted changes:\n${uncommittedFiles.map((f) => `  - ${f}`).join("\n")}\n\nStage and commit these files before running review.`,
-    };
+    logger?.warn("review", `Uncommitted changes detected before review (proceeding): ${fileList}`, {
+      storyId,
+      uncommittedCount: uncommittedFiles.length,
+    });
   }
 
   for (const checkName of config.checks) {

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -274,11 +274,11 @@ export async function autoCommitIfDirty(workdir: string, stage: string, role: st
       dirtyFiles: statusOutput.trim().split("\n").length,
     });
 
-    // Use "git add ." when workdir is a monorepo package subdir — only stages files under
-    // that package, preventing accidental cross-package commits.
-    // Use "git add -A" at repo root to capture renames/deletions across the full tree.
-    const addArgs = isSubdir ? ["git", "add", "."] : ["git", "add", "-A"];
-    const addProc = _gitDeps.spawn(addArgs, { cwd: workdir, stdout: "pipe", stderr: "pipe" });
+    // Always stage from gitRoot with -A so that agent changes outside packageDir
+    // (e.g. monorepo root package.json after `bun add`) are captured. Using
+    // "git add . from workdir" misses those files, leaving them permanently dirty
+    // and causing false-positive escalations in the review dirty-file check.
+    const addProc = _gitDeps.spawn(["git", "add", "-A"], { cwd: realGitRoot, stdout: "pipe", stderr: "pipe" });
     await addProc.exited;
 
     const commitProc = _gitDeps.spawn(["git", "commit", "-m", `chore(${storyId}): auto-commit after ${role} session`], {

--- a/test/unit/review/orchestrator.test.ts
+++ b/test/unit/review/orchestrator.test.ts
@@ -128,13 +128,22 @@ describe("ReviewOrchestrator — pluginMode deferred", () => {
   });
 
   test("propagates built-in failure when pluginMode is deferred", async () => {
-    // Built-in failure: simulate dirty working tree (triggers runner failure)
-    _runnerDeps.getUncommittedFiles = mock(async () => ["src/changed.ts"]);
+    // Built-in failure: semantic review fails. Dirty files are no longer a hard
+    // failure (warn-and-continue), so we use a mocked semantic failure to verify
+    // that deferred mode still propagates built-in outcomes without invoking plugins.
     const registry = makeRegistry([makeReviewer("semgrep")]);
     const orchestrator = new ReviewOrchestrator();
+    _reviewSemanticDeps.runSemanticReview = mock(async () => ({
+      check: "semantic" as const,
+      success: false,
+      command: "semantic-review",
+      exitCode: 1,
+      output: "findings: critical issue",
+      durationMs: 100,
+    }));
 
     const result = await orchestrator.review({
-      reviewConfig: makeReviewConfig("deferred"),
+      reviewConfig: { enabled: true, checks: ["semantic"], commands: {}, pluginMode: "deferred", gateLLMChecksOnMechanicalPass: false } as unknown as Parameters<ReviewOrchestrator["review"]>[0]["reviewConfig"],
       workdir: "/tmp/workdir",
       executionConfig: minimalExecConfig,
       plugins: registry,

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -50,35 +50,38 @@ describe("runReview — dirty working tree guard (RQ-001)", () => {
   });
 
   describe("dirty working tree", () => {
-    test("returns failure with uncommitted files listed in failureReason", async () => {
+    test("logs warning but does not fail review when dirty files are found", async () => {
+      // autoCommitIfDirty is the primary guard. Any remaining dirty files after
+      // auto-commit produce a warning but review continues — escalation cannot fix
+      // structural commit-scope gaps (e.g. monorepo root package.json after bun add).
       _deps.getUncommittedFiles = mock(async (_workdir: string) => [
         "src/types.ts",
         "src/routing.ts",
       ]);
 
-      const result = await runReview({ config: typecheckConfig, workdir: "/tmp/fake-workdir" });
+      const result = await runReview({ config: noChecksConfig, workdir: "/tmp/fake-workdir" });
 
-      expect(result.success).toBe(false);
-      expect(result.failureReason).toBeDefined();
-      expect(result.failureReason).toContain("src/types.ts");
-      expect(result.failureReason).toContain("src/routing.ts");
+      // Review proceeds — no early failure due to dirty files.
+      expect(result.success).toBe(true);
+      // No git-clean synthetic check is added to the checks array.
+      expect(result.checks.some((c) => c.check === "git-clean")).toBe(false);
     });
 
-    test("does not run typecheck when working tree is dirty", async () => {
+    test("proceeds to run configured checks even when working tree is dirty", async () => {
       _deps.getUncommittedFiles = mock(async (_workdir: string) => ["src/types.ts"]);
 
-      // Early return with a single git-clean failed check — typecheck is never executed.
-      const result = await runReview({ config: typecheckConfig, workdir: "/tmp/fake-workdir" });
+      // With noChecksConfig no checks run, so result succeeds regardless of dirty files.
+      const result = await runReview({ config: noChecksConfig, workdir: "/tmp/fake-workdir" });
 
-      expect(result.checks).toHaveLength(1);
-      expect(result.checks[0]).toMatchObject({ check: "git-clean", success: false });
+      expect(result.success).toBe(true);
+      expect(result.checks).toHaveLength(0);
     });
 
     test("calls getUncommittedFiles with the provided workdir", async () => {
       const mockFn = mock(async (_workdir: string) => ["src/types.ts"]);
       _deps.getUncommittedFiles = mockFn;
 
-      await runReview({ config: typecheckConfig, workdir: "/tmp/my-project" });
+      await runReview({ config: noChecksConfig, workdir: "/tmp/my-project" });
 
       expect(mockFn).toHaveBeenCalledWith("/tmp/my-project");
     });
@@ -236,15 +239,16 @@ describe("nax runtime file exclusions", () => {
     expect(result.success).toBe(true);
   });
 
-  test("agent source files are still caught by uncommitted check", async () => {
+  test("agent source files trigger a warning but review still proceeds", async () => {
+    // Dirty agent files produce a warning; review is not failed/escalated since
+    // escalation cannot fix structural commit-scope gaps in auto-commit.
     _deps.getUncommittedFiles = mock(async (_workdir: string) => [
       ".nax/status.json",
       "src/config/types.ts",
     ]);
     const result = await runReview({ config: noChecksConfig, workdir: "/tmp/fake-workdir" });
-    expect(result.success).toBe(false);
-    expect(result.failureReason).toContain("src/config/types.ts");
-    expect(result.failureReason).not.toContain(".nax/status.json");
+    expect(result.success).toBe(true);
+    expect(result.checks.some((c) => c.check === "git-clean")).toBe(false);
   });
 
   test("test-output .jsonl files under test/ are excluded from uncommitted check", async () => {
@@ -267,19 +271,20 @@ describe("nax runtime file exclusions", () => {
     expect(result.success).toBe(true);
   });
 
-  test("test artifact mixed with real file — real file still triggers failure", async () => {
+  test("test artifact mixed with real file — real file triggers warning, test artifact is excluded", async () => {
+    // The nax-ignore filtering still applies: test artifacts are filtered out of
+    // the warning; real agent files remain in the warning. Review proceeds either way.
     _deps.getUncommittedFiles = mock(async (_workdir: string) => [
       "test/unit/runtime/middleware/test-logging-sub-abc123.jsonl",
       "src/real.ts",
     ]);
     const result = await runReview({ config: noChecksConfig, workdir: "/tmp/fake-workdir" });
-    expect(result.success).toBe(false);
-    expect(result.checks[0]?.output).toContain("src/real.ts");
-    expect(result.checks[0]?.output).not.toContain("test-logging-sub");
+    expect(result.success).toBe(true);
+    expect(result.checks.some((c) => c.check === "git-clean")).toBe(false);
   });
 });
 
-describe("runReview — git-clean named check (2C)", () => {
+describe("runReview — git-clean warn-and-continue (2C)", () => {
   let originalGetUncommittedFiles: typeof _deps.getUncommittedFiles;
 
   beforeEach(() => {
@@ -291,28 +296,24 @@ describe("runReview — git-clean named check (2C)", () => {
     _deps.getUncommittedFiles = originalGetUncommittedFiles;
   });
 
-  test("uncommitted changes return a named git-clean failed check", async () => {
+  test("uncommitted changes do not produce a git-clean check entry in results", async () => {
+    // Dirty files are logged as a warning; no synthetic git-clean check is added
+    // to result.checks so downstream consumers see only real check outcomes.
     _deps.getUncommittedFiles = mock(async (_workdir: string) => ["src/foo.ts"]);
 
     const result = await runReview({ config: noChecksConfig, workdir: "/tmp/fake-workdir" });
 
-    expect(result.success).toBe(false);
-    expect(result.checks).toHaveLength(1);
-    expect(result.checks[0]).toMatchObject({
-      check: "git-clean",
-      success: false,
-      command: "git diff --name-only HEAD",
-      exitCode: 1,
-    });
-    expect(result.checks[0]?.output).toContain("src/foo.ts");
+    expect(result.success).toBe(true);
+    expect(result.checks.some((c) => c.check === "git-clean")).toBe(false);
   });
 
-  test("git-clean check has no findings field (non-LLM check)", async () => {
+  test("review succeeds with no checks configured even when dirty files exist", async () => {
     _deps.getUncommittedFiles = mock(async (_workdir: string) => ["src/foo.ts"]);
 
     const result = await runReview({ config: noChecksConfig, workdir: "/tmp/fake-workdir" });
 
-    expect((result.checks[0] as any).findings).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(result.checks).toHaveLength(0);
   });
 });
 

--- a/test/unit/utils/auto-commit.test.ts
+++ b/test/unit/utils/auto-commit.test.ts
@@ -4,7 +4,7 @@
  * Covers monorepo subdir guard: workdir = git root, workdir = subdir (monorepo), and unrelated dir.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { _gitDeps, autoCommitIfDirty } from "../../../src/utils/git";
 import { withDepsRestore } from "../../helpers/deps";
 
@@ -44,98 +44,104 @@ function makeProc(stdout: string, exitCode = 0): SpawnResult {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("autoCommitIfDirty", () => {
-  const commands: string[][] = [];
+  const calls: { cmd: string[]; cwd?: string }[] = [];
 
   withDepsRestore(_gitDeps, ["spawn"]);
   beforeEach(() => {
-    commands.length = 0;
+    calls.length = 0;
   });
 
   test("commits when workdir is the git root", async () => {
     const gitRoot = "/repo";
-    _gitDeps.spawn = mock((cmd: string[]) => {
-      commands.push(cmd);
+    _gitDeps.spawn = mock((cmd: string[], opts?: { cwd?: string }) => {
+      calls.push({ cmd, cwd: opts?.cwd });
       if (cmd.includes("rev-parse")) return makeProc(gitRoot + "\n");
       if (cmd.includes("status")) return makeProc(" M src/foo.ts\n");
       return makeProc("");
-    }) as typeof _gitDeps.spawn;
+    }) as unknown as typeof _gitDeps.spawn;
 
     await autoCommitIfDirty(gitRoot, "tdd", "implementer", "US-001");
 
-    const addCmd = commands.find((c) => c.includes("add"));
-    expect(addCmd).toBeDefined();
-    expect(commands.some((c) => c.includes("commit"))).toBe(true);
+    const addCall = calls.find((c) => c.cmd.includes("add"));
+    expect(addCall).toBeDefined();
+    expect(calls.some((c) => c.cmd.includes("commit"))).toBe(true);
   });
 
-  test("commits using 'git add .' (not -A) when workdir is a monorepo package subdir", async () => {
+  test("commits using 'git add -A' from gitRoot even when workdir is a monorepo package subdir", async () => {
+    // Regression: previously used 'git add .' from packageDir, which silently
+    // skipped files outside packageDir (e.g. monorepo root package.json after
+    // 'bun add'), leaving them permanently dirty and causing false-positive
+    // escalations in the review dirty-file check.
     const gitRoot = "/repo";
     const workdir = "/repo/apps/cli";
-    _gitDeps.spawn = mock((cmd: string[]) => {
-      commands.push(cmd);
+    _gitDeps.spawn = mock((cmd: string[], opts?: { cwd?: string }) => {
+      calls.push({ cmd, cwd: opts?.cwd });
       if (cmd.includes("rev-parse")) return makeProc(gitRoot + "\n");
       if (cmd.includes("status")) return makeProc(" M src/config.ts\n");
       return makeProc("");
-    }) as typeof _gitDeps.spawn;
+    }) as unknown as typeof _gitDeps.spawn;
 
     await autoCommitIfDirty(workdir, "tdd", "implementer", "US-004");
 
-    const addCmd = commands.find((c) => c.includes("add"));
-    expect(addCmd).toEqual(["git", "add", "."]);
-    expect(commands.some((c) => c.includes("commit"))).toBe(true);
+    const addCall = calls.find((c) => c.cmd.includes("add"));
+    expect(addCall?.cmd).toEqual(["git", "add", "-A"]);
+    expect(addCall?.cwd).toBe(gitRoot);
+    expect(calls.some((c) => c.cmd.includes("commit"))).toBe(true);
   });
 
-  test("uses 'git add -A' when workdir is the repo root", async () => {
+  test("uses 'git add -A' from gitRoot when workdir is the repo root", async () => {
     const gitRoot = "/repo";
-    _gitDeps.spawn = mock((cmd: string[]) => {
-      commands.push(cmd);
+    _gitDeps.spawn = mock((cmd: string[], opts?: { cwd?: string }) => {
+      calls.push({ cmd, cwd: opts?.cwd });
       if (cmd.includes("rev-parse")) return makeProc(gitRoot + "\n");
       if (cmd.includes("status")) return makeProc(" M src/index.ts\n");
       return makeProc("");
-    }) as typeof _gitDeps.spawn;
+    }) as unknown as typeof _gitDeps.spawn;
 
     await autoCommitIfDirty(gitRoot, "tdd", "test-writer", "US-001");
 
-    const addCmd = commands.find((c) => c.includes("add"));
-    expect(addCmd).toEqual(["git", "add", "-A"]);
+    const addCall = calls.find((c) => c.cmd.includes("add"));
+    expect(addCall?.cmd).toEqual(["git", "add", "-A"]);
+    expect(addCall?.cwd).toBe(gitRoot);
   });
 
   test("skips commit when workdir is unrelated to git root", async () => {
     const gitRoot = "/other-repo";
     const workdir = "/my-project";
-    _gitDeps.spawn = mock((cmd: string[]) => {
-      commands.push(cmd);
+    _gitDeps.spawn = mock((cmd: string[], opts?: { cwd?: string }) => {
+      calls.push({ cmd, cwd: opts?.cwd });
       if (cmd.includes("rev-parse")) return makeProc(gitRoot + "\n");
       return makeProc("");
-    }) as typeof _gitDeps.spawn;
+    }) as unknown as typeof _gitDeps.spawn;
 
     await autoCommitIfDirty(workdir, "tdd", "implementer", "US-001");
 
-    expect(commands.some((c) => c.includes("commit"))).toBe(false);
+    expect(calls.some((c) => c.cmd.includes("commit"))).toBe(false);
   });
 
   test("skips commit when working tree is clean", async () => {
     const gitRoot = "/repo";
-    _gitDeps.spawn = mock((cmd: string[]) => {
-      commands.push(cmd);
+    _gitDeps.spawn = mock((cmd: string[], opts?: { cwd?: string }) => {
+      calls.push({ cmd, cwd: opts?.cwd });
       if (cmd.includes("rev-parse")) return makeProc(gitRoot + "\n");
       if (cmd.includes("status")) return makeProc(""); // clean
       return makeProc("");
-    }) as typeof _gitDeps.spawn;
+    }) as unknown as typeof _gitDeps.spawn;
 
     await autoCommitIfDirty(gitRoot, "tdd", "implementer", "US-001");
 
-    expect(commands.some((c) => c.includes("commit"))).toBe(false);
+    expect(calls.some((c) => c.cmd.includes("commit"))).toBe(false);
   });
 
   // Issue 5 (#369): warn→debug when auto-committing after agent session
   test("logs at debug level (not warn) when auto-committing dirty files", async () => {
     const gitRoot = "/repo";
-    _gitDeps.spawn = mock((cmd: string[]) => {
-      commands.push(cmd);
+    _gitDeps.spawn = mock((cmd: string[], opts?: { cwd?: string }) => {
+      calls.push({ cmd, cwd: opts?.cwd });
       if (cmd.includes("rev-parse")) return makeProc(gitRoot + "\n");
       if (cmd.includes("status")) return makeProc(" M src/foo.ts\n");
       return makeProc("");
-    }) as typeof _gitDeps.spawn;
+    }) as unknown as typeof _gitDeps.spawn;
 
     let warnCalled = false;
     let debugCalled = false;
@@ -143,7 +149,7 @@ describe("autoCommitIfDirty", () => {
     _gitDeps.getSafeLogger = mock(() => ({
       warn: () => { warnCalled = true; },
       debug: () => { debugCalled = true; },
-    })) as typeof _gitDeps.getSafeLogger;
+    })) as unknown as typeof _gitDeps.getSafeLogger;
 
     try {
       await autoCommitIfDirty(gitRoot, "tdd", "implementer", "US-001");


### PR DESCRIPTION
## Summary

- **Root cause:** `autoCommitIfDirty` used `git add .` scoped to `packageDir` when workdir is a monorepo subdir, silently missing files outside that directory (e.g. monorepo root `package.json` after `bun add bun-types`). Those files stayed permanently dirty, triggering the review dirty-file check and causing false-positive escalations. Every subsequent tier hit the same structural constraint and also escalated — wasting tokens without ever fixing the problem.
- **Fix 1 (`src/utils/git.ts`):** Always use `git add -A` from `realGitRoot` so all agent changes are captured regardless of which directory they live in.
- **Fix 2 (`src/review/runner.ts`):** Change the dirty-file check from hard failure → warn-and-continue. `autoCommitIfDirty` is the primary guard; escalation cannot fix commit-scope gaps, so remaining dirty files produce a log warning and review proceeds on what IS committed.

## Test plan

- [ ] `bun run test:bail` — all 1282 tests pass
- [ ] `bun run lint` — clean (deep-relatives baseline unchanged, no alias-into-internal violations)
- [ ] `test/unit/utils/auto-commit.test.ts` — updated to assert `git add -A` from `gitRoot` including `cwd` assertion; regression test documents the monorepo root `package.json` scenario
- [ ] `test/unit/review/runner.test.ts` — updated dirty-file tests to reflect warn-and-continue contract
- [ ] `test/unit/review/orchestrator.test.ts` — updated "propagates built-in failure" test to use semantic review failure (not dirty files) as the trigger