### PR TITLE
fix(audit): remove duplicate SessionTurnDispatchEvent emission from runTrackedSession

### DIFF
--- a/src/session/manager-run.ts
+++ b/src/session/manager-run.ts
@@ -10,7 +10,7 @@ import type { AgentResult } from "../agents/types";
 import { resolvePermissions } from "../config/permissions";
 import { NaxError } from "../errors";
 import { getLogger } from "../logger";
-import type { DispatchErrorEvent, IDispatchEventBus, SessionTurnDispatchEvent } from "../runtime/dispatch-events";
+import type { DispatchErrorEvent, IDispatchEventBus } from "../runtime/dispatch-events";
 import type { ProtocolIds } from "../runtime/protocol-types";
 import { errorMessage } from "../utils/errors";
 import { _sessionManagerDeps } from "./manager-deps";
@@ -157,40 +157,13 @@ export async function runTrackedSession(
   if (current?.state === "RUNNING") {
     state.transition(id, result.success ? "COMPLETED" : "FAILED");
   }
-  const protocolIds = result.protocolIds ?? current?.protocolIds;
-  const turn = Math.max((result as { internalRoundTrips?: number }).internalRoundTrips ?? 1, 1);
 
-  const sessionName = state.nameFor({
-    workdir: pre.workdir,
-    featureName: pre.featureName,
-    storyId: pre.storyId,
-    role: pre.role,
-  });
-
-  const event: SessionTurnDispatchEvent = {
-    kind: "session-turn",
-    sessionName,
-    sessionRole: pre.role,
-    prompt: request.runOptions.prompt,
-    response: result.output,
-    agentName: pre.agent ?? state.defaultAgent,
-    stage,
-    storyId: pre.storyId,
-    featureName: pre.featureName,
-    workdir: pre.workdir,
-    resolvedPermissions,
-    turn,
-    protocolIds: {
-      sessionId: protocolIds?.sessionId ?? null,
-      recordId: protocolIds?.recordId ?? null,
-    },
-    origin: "runTrackedSession",
-    tokenUsage: result.tokenUsage,
-    exactCostUsd: result.exactCostUsd,
-    durationMs: Date.now() - startedAt,
-    timestamp: Date.now(),
-  };
-  state.dispatchEvents.emitDispatch(event);
-
+  // Dispatch is intentionally omitted here. runTrackedSession is a lifecycle
+  // wrapper (descriptor state transitions, bindHandle, handoff reconciliation).
+  // The SessionTurnDispatchEvent is emitted by agentManager.runAsSession, which
+  // is called from within runner.run() via createSessionRunHop. Emitting here
+  // too produced duplicate audit files — one from runAsSession and one from
+  // runTrackedSession — for each TDD session turn. See PR #1007 (which wired
+  // runAsSession) and the fix that removed this second emission.
   return result;
 }

--- a/test/unit/agents/manager-dispatch-emission.test.ts
+++ b/test/unit/agents/manager-dispatch-emission.test.ts
@@ -7,7 +7,7 @@
  *
  * Boundaries under test:
  *   - runAsSession       → one SessionTurnDispatchEvent (origin:"runAsSession")
- *   - runTrackedSession  → one SessionTurnDispatchEvent (origin:"runTrackedSession")
+ *   - runTrackedSession  → zero SessionTurnDispatchEvents (dispatch deferred to runAsSession)
  *   - completeAs         → one CompleteDispatchEvent
  *   - runWithFallback    → N SessionTurnDispatchEvents + one OperationCompletedEvent
  *   - runAs envelope     → zero DispatchEvents + one OperationCompletedEvent
@@ -191,7 +191,12 @@ describe("runTrackedSession — dispatch emission", () => {
     };
   }
 
-  test("emits exactly one session-turn event with origin:runTrackedSession", async () => {
+  test("emits zero session-turn events (dispatch deferred to agentManager.runAsSession)", async () => {
+    // runTrackedSession is a lifecycle wrapper (descriptor state transitions,
+    // bindHandle, handoff reconciliation). The SessionTurnDispatchEvent is
+    // emitted by agentManager.runAsSession, which is called from within
+    // runner.run() via createSessionRunHop. Emitting here too would produce
+    // duplicate audit files — see the duplicate-audit fix in PR #1007+.
     const bus = new DispatchEventBus();
     const descriptor = makeDescriptor("implementer");
     const state = makeState(descriptor, bus);
@@ -226,11 +231,7 @@ describe("runTrackedSession — dispatch emission", () => {
       },
     });
 
-    expect(received).toHaveLength(1);
-    expect(received[0]?.origin).toBe("runTrackedSession");
-    expect(received[0]?.sessionRole).toBe("implementer");
-    expect(received[0]?.storyId).toBe("US-002");
-    expect(received[0]?.agentName).toBe("claude");
+    expect(received).toHaveLength(0);
   });
 });
 

--- a/test/unit/session/manager-run-in-session.test.ts
+++ b/test/unit/session/manager-run-in-session.test.ts
@@ -118,7 +118,11 @@ describe("SessionManager.runInSession — ADR-013 Phase 1", () => {
     expect(mgr.get(d.id)?.protocolIds).toEqual({ recordId: "rec-1", sessionId: "sess-1" });
   });
 
-  test("dispatch event falls back to descriptor protocolIds and turn=1 when result omits metadata", async () => {
+  test("emits zero session-turn dispatch events (dispatch is emitted by agentManager.runAsSession)", async () => {
+    // runTrackedSession is a lifecycle wrapper — it manages descriptor state
+    // transitions and bindHandle. The SessionTurnDispatchEvent is emitted by
+    // agentManager.runAsSession (called from createSessionRunHop inside runner.run).
+    // Emitting here too produced duplicate audit files. See PR #1007+.
     const bus = new DispatchEventBus();
     const events: SessionTurnDispatchEvent[] = [];
     bus.onDispatch((event) => {
@@ -130,9 +134,7 @@ describe("SessionManager.runInSession — ADR-013 Phase 1", () => {
 
     await mgr.runInSession(d.id, makeAgentManager(makeResult()), makeRequest());
 
-    expect(events).toHaveLength(1);
-    expect(events[0]?.protocolIds).toEqual({ recordId: "rec-bound", sessionId: "sess-bound" });
-    expect(events[0]?.turn).toBe(1);
+    expect(events).toHaveLength(0);
   });
 
   test("throws SESSION_NOT_FOUND for unknown id", async () => {


### PR DESCRIPTION
## Summary

- PR #1007 wired `createSessionRunHop` to call `agentManager.runAsSession`, which emits a `SessionTurnDispatchEvent`. But `runTrackedSession` also emitted its own event after `runner.run()` returned — producing two `.txt` audit files per TDD session turn with millisecond-apart timestamps (e.g. `*-test-writer-run-t01.txt` appearing twice).
- Removed the success-path `emitDispatch` from `runTrackedSession`. It is a lifecycle wrapper (descriptor state transitions, `bindHandle`, handoff reconciliation), not a dispatch boundary. `agentManager.runAsSession` is the canonical emitter (ADR-020); the `origin` field on `SessionTurnDispatchEvent` is explicitly documented as diagnostic-only.
- The error-path `emitDispatchError` in `runTrackedSession` is preserved — it fires only when `runner.run()` throws before `runAsSession` can emit its own error event.
- Side effect: cost aggregator and logging subscriber were also receiving duplicate entries for TDD sessions with `sessionBinding`; both are fixed.

## Blast radius

| Concern | Finding |
|:--------|:--------|
| Dispatch lost for any caller | None — `agentManager.runAsSession` still emits for the only production caller (`src/tdd/session-runner.ts:254`) |
| Subscriber logic broken | None — `origin` on success events is contractually diagnostic-only; no subscriber branches on it |
| Error dispatch lost | None — error path unchanged, still emits `origin: "runTrackedSession"` |
| Cost double-counting | Was broken before; now fixed |

## Test plan

- [ ] `timeout 30 bun test test/unit/agents/manager-dispatch-emission.test.ts --timeout=5000` — updated `runTrackedSession` section asserts 0 events
- [ ] `timeout 30 bun test test/unit/session/manager-run-in-session.test.ts --timeout=5000` — updated dispatch test asserts 0 events
- [ ] `timeout 30 bun test test/integration/tdd/audit-naming.test.ts --timeout=5000` — existing audit naming regression still passes
- [ ] `bun run test` — full suite passes
- [ ] Manually verify dogfood run produces one `.txt` per TDD session role (not two)