### PR TITLE
fix: tighten debate grounder flow and diagnostics

### DIFF
--- a/.nax/features/plan-asymmetric-pipeline/grounder-evaluation.md
+++ b/.nax/features/plan-asymmetric-pipeline/grounder-evaluation.md
@@ -1,0 +1,61 @@
+# Grounder Evaluation
+
+Date: 2026-05-11
+Branch: `fix/plan-debate-grounder-packageview`
+
+## Summary
+
+The grounder is working mechanically, but it does not yet produce a clearly better PRD than the single-session planner.
+
+## What Worked
+
+- The debate pre-phase now runs without the earlier `ctx.packageView.select` crash.
+- The grounder prompt is now much smaller and uses source-root context instead of the older large file-tree dump.
+- Grounder retries now support same-session repair and use a stronger repair prompt.
+- Retry diagnostics now distinguish:
+  - invalid JSON
+  - valid JSON but invalid schema
+  - near-output-cap schema failures
+
+## Observations From Prompt Audits
+
+- Earlier grounder prompt audit size was about 1030 lines.
+- After tightening to source-root context, a later grounder prompt audit dropped to about 611 lines.
+- This likely reduced prompt overload, but did not fully solve manifest quality issues.
+
+## Retry Findings
+
+- Several grounder retries were not true JSON-parse failures.
+- The model returned valid JSON, but the manifest still failed schema validation.
+- The most common issue was using `null` for optional string fields such as:
+  - `verification.factId`
+  - `verification.evidence`
+  - `gaps[].evidence`
+- The schema expects these fields to be omitted when absent, not set to `null`.
+
+## PRD Quality Comparison
+
+Compared:
+
+- Grounder + debate: `.nax/features/plan-asymmetric-pipeline/prd.json`
+- Single session: `.nax/features/plan-asymmetric-pipeline/prd-single.json`
+
+Result:
+
+- The grounder-assisted PRD is not clearly better overall.
+- It did help some architecture and rollout details, especially around `config.plan.pipeline`.
+- But it did not reliably correct stale or incorrect assumptions inherited from the spec.
+- It also did not consistently improve factual precision enough to make the final PRD decisively better than the single-session version.
+
+## Current Verdict
+
+- Grounder wiring: yes
+- Grounder influence on planner output: yes
+- Clear PRD quality win over single-session planning: not yet
+
+## Main Follow-Up Areas
+
+- Continue tightening the repair prompt and schema guidance.
+- Make absence claims even more conservative.
+- Consider improving negative-claim validation before manifest injection into debate.
+- Evaluate on a small fixed benchmark set instead of a single feature.

--- a/.nax/profiles/opencode-debate.json
+++ b/.nax/profiles/opencode-debate.json
@@ -21,6 +21,9 @@
     "debate": {
         "enabled": true,
         "agents": 2,
+        "grounder": {
+            "timeoutSeconds":1800
+        },
         "stages": {
             "plan": {
                 "enabled": true,
@@ -28,8 +31,10 @@
                 "sessionMode": "stateful",
                 "resolver": {
                     "type": "synthesis",
-                    "agent": "claude"
+                    "agent": "opencode"
                 },
+                "autoPersona": true,
+                "evidenceMode": "asymmetric",
                 "debaters": [
                     {
                         "agent": "opencode",
@@ -39,7 +44,11 @@
                         "agent": "opencode",
                         "model": "fast"
                     }
-                ]
+                ],
+                "preDebatePhase": {
+                    "kind": "grounder"
+                },
+                "timeoutSeconds": 1800
             },
             "review": {
                 "enabled": true,

--- a/src/cli/plan-helpers.ts
+++ b/src/cli/plan-helpers.ts
@@ -6,7 +6,7 @@
 
 import { createInterface } from "node:readline";
 import { inferFrameworkAndTestRunner } from "../project";
-import type { PackageSummary } from "../prompts";
+import { type PackageSummary, buildSourceRootsSection } from "../prompts";
 
 /**
  * Create a CLI interaction bridge for stdin-based human interaction.
@@ -72,28 +72,4 @@ export function buildPackageSummary(rel: string, pkg: Record<string, unknown> | 
   return { path: rel, name, runtime, framework, testRunner, keyDeps };
 }
 
-/**
- * Build source roots section markdown for planning prompt.
- * Renders discovered source roots with their language, framework, and test runner.
- * When no roots are provided, renders a single entry for the root directory.
- */
-export function buildSourceRootsSection(roots: import("../analyze/types").SourceRoot[]): string {
-  const sections: string[] = [];
-
-  sections.push("## Source Roots\n");
-  sections.push("You have Read, Grep, and Glob tools — explore on demand. Cite findings as `path:line`.");
-  sections.push("Budget: aim for ≤ 10 file reads per story.\n");
-
-  if (roots.length === 0) {
-    sections.push("- .  (unknown, framework: —, tests: —)");
-  } else {
-    for (const root of roots) {
-      const language = root.language ?? "unknown";
-      const framework = root.framework || "—";
-      const testRunner = root.testRunner || "—";
-      sections.push(`- ${root.path}  (${language}, framework: ${framework}, tests: ${testRunner})`);
-    }
-  }
-
-  return sections.join("\n");
-}
+export { buildSourceRootsSection };

--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -216,7 +216,7 @@ export async function planCommand(workdir: string, config: NaxConfig, options: P
           logger?.info("plan", "[OK] PRD written via debate", { outputPath });
           return outputPath;
         }
-        logger?.warn("debate", "All plan debaters failed — falling back to single agent", {
+        logger?.warn("debate", "Plan debate returned failed outcome — falling back to single agent", {
           stage: "plan",
           event: "fallback",
         });

--- a/src/config/schemas-debate.ts
+++ b/src/config/schemas-debate.ts
@@ -10,7 +10,7 @@ const DebaterPersonaEnum = z.enum(["challenger", "pragmatist", "completionist", 
 
 const GrounderConfigSchema = z.object({
   model: ConfiguredModelSchema.default("fast"),
-  timeoutSeconds: z.number().int().positive().default(300),
+  timeoutSeconds: z.number().int().positive().default(1800),
 });
 
 const DebaterSchema = z.object({

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -337,7 +337,7 @@ export const NaxConfigSchema = z
       enabled: false,
       agents: 3,
       maxConcurrentDebaters: 2,
-      grounder: { model: "fast" as const, timeoutSeconds: 300 },
+      grounder: { model: "fast" as const, timeoutSeconds: 1800 },
       stages: {
         plan: {
           enabled: true,

--- a/src/debate/pre-phase/grounder.ts
+++ b/src/debate/pre-phase/grounder.ts
@@ -6,36 +6,29 @@
  */
 
 import { join } from "node:path";
-import { scanCodebase } from "@/analyze";
+import { type SourceRoot, scanSourceRoots } from "@/analyze";
 import { callOp } from "@/operations";
 import { groundOp } from "@/operations";
+import { buildSourceRootsSection } from "@/prompts";
 import type { FactsManifest } from "../facts-manifest";
 import { renderManifestSection } from "../facts-manifest";
 import type { PreDebatePhase, PreDebatePhaseContext } from "./types";
 
 export const _grounderDeps = {
-  scanCodebase,
+  scanSourceRoots,
   write: (path: string, data: string) => Bun.write(path, data),
 };
 
 async function buildCodebaseContext(workdir: string): Promise<string> {
-  const scan = await _grounderDeps.scanCodebase(workdir);
-  const sections: string[] = [];
+  const roots = await _grounderDeps.scanSourceRoots(workdir);
+  return buildSourceRootsSection(normalizeRoots(workdir, roots));
+}
 
-  if (scan.fileTree) {
-    sections.push(`## Codebase Structure\n\`\`\`\n${scan.fileTree}\n\`\`\``);
-  }
-
-  const allDeps = { ...scan.dependencies, ...scan.devDependencies };
-  const depList = Object.entries(allDeps)
-    .map(([name, version]) => `- ${name}@${version}`)
-    .join("\n");
-
-  if (depList) {
-    sections.push(`## Dependencies\n${depList}`);
-  }
-
-  return sections.join("\n\n");
+function normalizeRoots(workdir: string, roots: SourceRoot[]): SourceRoot[] {
+  return roots.map((root) => ({
+    ...root,
+    path: root.path.startsWith("/") ? root.path.replace(`${workdir}/`, "") : root.path,
+  }));
 }
 
 async function writeManifestArtifact(ctx: PreDebatePhaseContext, manifest: FactsManifest): Promise<void> {

--- a/src/debate/runner-plan-helpers.ts
+++ b/src/debate/runner-plan-helpers.ts
@@ -9,6 +9,7 @@ import { resolveDefaultAgent } from "../agents";
 import type { SessionHandle } from "../agents/types";
 import type { ConfiguredModel, ModelDef } from "../config";
 import type { DebateConfig } from "../config/selectors";
+import type { CallContext } from "../operations/types";
 import type { SessionRole } from "../runtime/session-role";
 import type { ISessionManager } from "../session/types";
 import type { PreDebatePhaseContext } from "./pre-phase";
@@ -42,9 +43,9 @@ interface PlanCtxMinimal {
   readonly stage: string;
   readonly stageConfig: DebateStageConfig;
   readonly config: DebateConfig;
+  readonly callContext: CallContext;
   readonly abortSignal?: AbortSignal;
   readonly sessionManager?: ISessionManager;
-  readonly ctx?: unknown;
 }
 
 /** Run the pre-debate phase, returning the manifest section and accumulated cost. */
@@ -55,7 +56,7 @@ export async function runPrePhase(
 ): Promise<{ manifestSection: string; costUsd: number; block: boolean }> {
   const logger = _debateSessionDeps.getSafeLogger();
   const prePhaseCtx: PreDebatePhaseContext = {
-    ctx: ctx as unknown as import("../operations/types").CallContext,
+    ctx: ctx.callContext,
     stage: ctx.stage,
     stageConfig: config,
     workdir: opts.workdir,

--- a/src/debate/runner-plan.ts
+++ b/src/debate/runner-plan.ts
@@ -9,6 +9,7 @@ import { resolveDefaultAgent } from "../agents";
 import type { ConfiguredModel, ModelDef } from "../config";
 import type { DebateConfig } from "../config/selectors";
 import { NaxError } from "../errors";
+import type { CallContext } from "../operations/types";
 import { DebatePromptBuilder } from "../prompts";
 import type { DispatchContext } from "../runtime/dispatch-context";
 import { allSettledBounded } from "./concurrency";
@@ -44,6 +45,7 @@ interface PlanCtx extends DispatchContext {
   readonly stage: string;
   readonly stageConfig: DebateStageConfig;
   readonly config: DebateConfig;
+  readonly callContext: CallContext;
 }
 
 export async function runPlan(

--- a/src/debate/runner.ts
+++ b/src/debate/runner.ts
@@ -356,6 +356,7 @@ export class DebateRunner {
       stage: this.stage,
       stageConfig: this.stageConfig,
       config: this.config,
+      callContext: this.ctx,
       agentManager: this.ctx.runtime.agentManager,
       sessionManager: this.sessionManager ?? this.ctx.runtime.sessionManager,
       runtime: this.ctx.runtime,

--- a/src/operations/ground.ts
+++ b/src/operations/ground.ts
@@ -1,11 +1,14 @@
+import { ParseValidationError } from "../agents/retry";
 import { debateConfigSelector } from "../config";
 import type { DebateConfig } from "../config/selectors";
 import type { FactsManifest } from "../debate/facts-manifest";
 import { parseFactsManifest } from "../debate/facts-manifest";
 import { NaxError } from "../errors";
+import { getSafeLogger } from "../logger";
 import { GrounderPromptBuilder } from "../prompts";
+import { looksLikeTruncatedJson } from "../review/truncation";
 import { parseLLMJson } from "../utils/llm-json";
-import type { CompleteOperation } from "./types";
+import type { RunOperation } from "./types";
 
 export interface GrounderInput {
   readonly specContent: string;
@@ -13,28 +16,159 @@ export interface GrounderInput {
   readonly workdir: string;
 }
 
-export const groundOp: CompleteOperation<GrounderInput, FactsManifest, DebateConfig> = {
-  kind: "complete",
+function parseGrounderManifest(output: string): FactsManifest {
+  let raw: unknown;
+  try {
+    raw = parseLLMJson(output);
+  } catch {
+    throw new NaxError("Grounder output failed schema validation: not valid JSON", "GROUNDER_PARSE_FAILED", {});
+  }
+  const result = parseFactsManifest(raw);
+  if (!result.ok) {
+    throw new NaxError(`Grounder output failed schema validation: ${result.error}`, "GROUNDER_PARSE_FAILED", {});
+  }
+  return result.manifest;
+}
+
+type GrounderFailureKind = "not-json" | "schema-invalid";
+
+interface GrounderRetryInspection {
+  readonly ok: boolean;
+  readonly kind?: GrounderFailureKind;
+  readonly message?: string;
+  readonly usedNullOptionalField?: boolean;
+}
+
+function inspectGrounderOutput(output: string): GrounderRetryInspection {
+  let raw: unknown;
+  try {
+    raw = parseLLMJson(output);
+  } catch {
+    return {
+      ok: false,
+      kind: "not-json",
+      message: "Response was not valid JSON.",
+      usedNullOptionalField: false,
+    };
+  }
+
+  const result = parseFactsManifest(raw);
+  if (result.ok) return { ok: true };
+
+  return {
+    ok: false,
+    kind: "schema-invalid",
+    message: buildGrounderSchemaMessage(result.error, raw),
+    usedNullOptionalField: hasNullOptionalManifestField(raw),
+  };
+}
+
+function hasNullOptionalManifestField(raw: unknown): boolean {
+  if (!raw || typeof raw !== "object") return false;
+
+  const manifest = raw as {
+    specClaims?: Array<{ verification?: { factId?: unknown; evidence?: unknown } }>;
+    gaps?: Array<{ evidence?: unknown }>;
+  };
+
+  const specClaims = manifest.specClaims ?? [];
+  for (const claim of specClaims) {
+    const verification = claim.verification;
+    if (!verification) continue;
+    if (verification.factId === null || verification.evidence === null) return true;
+  }
+
+  const gaps = manifest.gaps ?? [];
+  for (const gap of gaps) {
+    if (gap.evidence === null) return true;
+  }
+
+  return false;
+}
+
+function buildGrounderSchemaMessage(error: string, raw: unknown): string {
+  const base = `Response was valid JSON but failed facts manifest schema validation: ${error}`;
+  if (!hasNullOptionalManifestField(raw)) return base;
+  return `${base} Optional fields must be omitted instead of set to null (for example verification.factId, verification.evidence, or gaps[].evidence).`;
+}
+
+function buildGrounderRetryPrompt(output: string, isTruncated: boolean): string {
+  const inspection = inspectGrounderOutput(output);
+  const reason =
+    inspection.ok || !inspection.message
+      ? "Response did not match the expected facts manifest schema."
+      : isTruncated && inspection.kind === "not-json"
+        ? `${inspection.message} The response also appears near the output cap and may be truncated.`
+        : inspection.message;
+  return GrounderPromptBuilder.jsonRepair(0, reason);
+}
+
+function createGrounderRetryStrategy(): NonNullable<RunOperation<GrounderInput, FactsManifest, DebateConfig>["retry"]> {
+  return {
+    shouldRetry(failure, attempt, ctx) {
+      if (!(failure instanceof ParseValidationError)) return { retry: false };
+      if (!ctx.lastOutput) return { retry: false };
+
+      const inspection = inspectGrounderOutput(ctx.lastOutput);
+      if (inspection.ok) return { retry: false };
+
+      if (attempt >= 2) return { retry: false };
+
+      const isTruncated = looksLikeTruncatedJson(ctx.lastOutput);
+      const logger = getSafeLogger();
+
+      if (inspection.kind === "not-json") {
+        logger?.warn(
+          "grounder",
+          isTruncated ? "JSON parse retry — likely truncated" : "JSON parse retry — not valid JSON",
+          {
+            storyId: ctx.storyId,
+            originalByteSize: ctx.lastOutput.length,
+          },
+        );
+      } else {
+        logger?.warn(
+          "grounder",
+          isTruncated
+            ? "JSON parse retry — near output cap and invalid schema"
+            : "JSON parse retry — valid JSON but invalid schema",
+          {
+            storyId: ctx.storyId,
+            originalByteSize: ctx.lastOutput.length,
+            schemaReason: inspection.message,
+            usedNullOptionalField: inspection.usedNullOptionalField,
+          },
+        );
+      }
+
+      return {
+        retry: true,
+        delayMs: 0,
+        nextPrompt: buildGrounderRetryPrompt(ctx.lastOutput, isTruncated),
+      };
+    },
+  };
+}
+
+export const groundOp: RunOperation<GrounderInput, FactsManifest, DebateConfig> = {
+  kind: "run",
   name: "ground",
   stage: "plan",
-  jsonMode: true,
+  session: { role: "grounder", lifetime: "fresh" },
+  noFallback: true,
   config: debateConfigSelector,
   model: (_input, ctx) => ctx.config.debate?.grounder.model ?? "fast",
-  timeoutMs: (_input, ctx) => (ctx.config.debate?.grounder.timeoutSeconds ?? 300) * 1000,
+  timeoutMs: (_input, ctx) => (ctx.config.debate?.grounder.timeoutSeconds ?? 1800) * 1000,
+  retry: createGrounderRetryStrategy(),
+  hopBody: async (initialPrompt, ctx) => {
+    const turn = await ctx.sendWithParseRetry(initialPrompt);
+    parseGrounderManifest(turn.output);
+    return turn;
+  },
   build(input, _ctx) {
     return new GrounderPromptBuilder().build(input.specContent, input.codebaseContext, input.workdir);
   },
   parse(output, _input, _ctx) {
-    let raw: unknown;
-    try {
-      raw = parseLLMJson(output);
-    } catch {
-      throw new NaxError("Grounder output failed schema validation: not valid JSON", "GROUNDER_PARSE_FAILED", {});
-    }
-    const result = parseFactsManifest(raw);
-    if (!result.ok) {
-      throw new NaxError(`Grounder output failed schema validation: ${result.error}`, "GROUNDER_PARSE_FAILED", {});
-    }
-    return result.manifest;
+    return parseGrounderManifest(output);
   },
 };

--- a/src/prompts/builders/grounder-builder.ts
+++ b/src/prompts/builders/grounder-builder.ts
@@ -1,6 +1,25 @@
 import type { ComposeInput } from "../compose";
 
 export class GrounderPromptBuilder {
+  static jsonRepair(_attempt: number, parseError: string): string {
+    return `Your previous response was rejected.
+
+Failure reason: ${parseError}
+
+Re-write the complete facts manifest JSON from scratch and fix the schema issues before replying.
+
+Requirements:
+- Return exactly one JSON object matching the facts manifest schema.
+- If an optional field has no value, OMIT the field. Do NOT use null.
+- verification.factId must be a string like "F-001" when present; otherwise omit it.
+- verification.evidence and gaps[].evidence must be strings when present; otherwise omit them.
+- Keep IDs sequential within each array (F-001, F-002; S-001; G-001).
+- Do not include markdown fences, comments, or explanation.
+- If the previous response was long, keep summaries concise so the full JSON fits in one reply.
+
+Output ONLY the JSON object. Do not include markdown fences or explanation.`;
+  }
+
   build(specContent: string, codebaseContext: string, _workdir: string): ComposeInput {
     const role: ComposeInput["role"] = {
       id: "role",
@@ -23,7 +42,16 @@ ${codebaseContext}
 
 ## Instructions
 
-Analyze the specification and codebase context above. Produce a JSON object conforming exactly to this schema:
+Analyze the specification and source-root context above. Verify concrete claims against the repo before you assert them.
+
+Grounding rules:
+- Prefer verified positive facts over broad interpretation.
+- Do not claim a file, symbol, builder, schema, or contract is missing unless you directly verified that absence via repo exploration.
+- If something looks plausible but you did not verify it, mark the related spec claim as "unverified" or "partial" instead of inventing a repoFact or gap.
+- Every repoFact must cite concrete evidence using real repo paths and line references.
+- Keep gaps focused on genuinely missing context, ignored conventions, or unconsidered boundaries that you can support with evidence.
+
+Produce a JSON object conforming exactly to this schema:
 
 {
   "repoFacts": [
@@ -60,6 +88,7 @@ Analyze the specification and codebase context above. Produce a JSON object conf
 Rules:
 - IDs must be sequential starting at 001 within each array (F-001, F-002, ...; S-001, ...; G-001, ...).
 - All required string fields must be non-empty.
+- Negative or absence claims require direct evidence from repo exploration; otherwise keep them unverified.
 - Output ONLY the JSON object — no markdown, no explanation.`,
       overridable: false,
     };

--- a/src/prompts/builders/source-roots-builder.ts
+++ b/src/prompts/builders/source-roots-builder.ts
@@ -1,0 +1,27 @@
+import type { SourceRoot } from "@/analyze";
+
+/**
+ * Build source roots section markdown for planning- and grounding-style prompts.
+ * Renders discovered source roots with their language, framework, and test runner.
+ * When no roots are provided, renders a single entry for the root directory.
+ */
+export function buildSourceRootsSection(roots: SourceRoot[]): string {
+  const sections: string[] = [];
+
+  sections.push("## Source Roots\n");
+  sections.push("You have Read, Grep, and Glob tools — explore on demand. Cite findings as `path:line`.");
+  sections.push("Budget: aim for ≤ 10 file reads per story.\n");
+
+  if (roots.length === 0) {
+    sections.push("- .  (unknown, framework: —, tests: —)");
+  } else {
+    for (const root of roots) {
+      const language = root.language ?? "unknown";
+      const framework = root.framework || "—";
+      const testRunner = root.testRunner || "—";
+      sections.push(`- ${root.path}  (${language}, framework: ${framework}, tests: ${testRunner})`);
+    }
+  }
+
+  return sections.join("\n");
+}

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -53,6 +53,7 @@ export type { PlanningPromptParts, PackageSummary } from "./builders/plan-builde
 
 // Grounder prompt builder — facts manifest grounding prompt construction.
 export { GrounderPromptBuilder } from "./builders/grounder-builder";
+export { buildSourceRootsSection } from "./builders/source-roots-builder";
 
 // Patch prompt builder — patch step prompt construction for verifier-pick selector.
 export { PatchPromptBuilder } from "./builders/patch-builder";

--- a/src/runtime/session-role.ts
+++ b/src/runtime/session-role.ts
@@ -16,6 +16,7 @@ export type CanonicalSessionRole =
   | "test-fix"
   | "reviewer-semantic"
   | "reviewer-adversarial"
+  | "grounder"
   | "plan"
   | "decompose"
   | "acceptance-gen"
@@ -37,6 +38,7 @@ export const KNOWN_SESSION_ROLES: readonly CanonicalSessionRole[] = [
   "test-fix",
   "reviewer-semantic",
   "reviewer-adversarial",
+  "grounder",
   "plan",
   "decompose",
   "acceptance-gen",

--- a/test/unit/debate/pre-phase/grounder.test.ts
+++ b/test/unit/debate/pre-phase/grounder.test.ts
@@ -198,13 +198,13 @@ describe("grounderStrategy", () => {
   });
 
   // ──────────────────────────────────────────────────────────────────────────
-  // AC-15: grounderStrategy uses scanCodebase (not scanSourceRoots)
+  // AC-15: grounderStrategy uses scanSourceRoots
   // ──────────────────────────────────────────────────────────────────────────
 
-  test("AC-15: grounderStrategy invokes _grounderDeps.scanCodebase (not scanSourceRoots)", async () => {
+  test("AC-15: grounderStrategy invokes _grounderDeps.scanSourceRoots(workdir)", async () => {
     runtime = await makeTestRuntime();
     const { _grounderDeps } = require("@/debate/pre-phase/grounder");
-    const originalScanCodebase = _grounderDeps.scanCodebase;
+    const originalScanSourceRoots = _grounderDeps.scanSourceRoots;
 
     const ctx: PreDebatePhaseContext = {
       ctx: {
@@ -228,22 +228,22 @@ describe("grounderStrategy", () => {
       specContent: "Test spec content",
     };
 
-    // Force a sentinel error at scanCodebase call site to prove invocation.
-    _grounderDeps.scanCodebase = async () => {
-      throw new Error("scanCodebase sentinel");
+    // Force a sentinel error at scanSourceRoots call site to prove invocation.
+    _grounderDeps.scanSourceRoots = async () => {
+      throw new Error("scanSourceRoots sentinel");
     };
 
     try {
-      await expect(grounderStrategy(ctx)).rejects.toThrow("scanCodebase sentinel");
+      await expect(grounderStrategy(ctx)).rejects.toThrow("scanSourceRoots sentinel");
     } finally {
-      _grounderDeps.scanCodebase = originalScanCodebase;
+      _grounderDeps.scanSourceRoots = originalScanSourceRoots;
     }
   });
 
-  test("AC-15: _grounderDeps exports scanCodebase function", () => {
-    // Verify the grounder has access to scanCodebase via its deps
+  test("AC-15: _grounderDeps exports scanSourceRoots function", () => {
+    // Verify the grounder has access to scanSourceRoots via its deps
     const { _grounderDeps } = require("@/debate/pre-phase/grounder");
-    expect(_grounderDeps).toHaveProperty("scanCodebase");
-    expect(typeof _grounderDeps.scanCodebase).toBe("function");
+    expect(_grounderDeps).toHaveProperty("scanSourceRoots");
+    expect(typeof _grounderDeps.scanSourceRoots).toBe("function");
   });
 });

--- a/test/unit/debate/runner-plan.test.ts
+++ b/test/unit/debate/runner-plan.test.ts
@@ -768,6 +768,51 @@ describe("runner-plan — preDebatePhase invocation", () => {
     expect(prePhaseCalled).toEqual(["grounder"]);
   });
 
+  test("AC-3: threads packageView through the plan pre-phase context", async () => {
+    const packageView = {
+      config: DEFAULT_CONFIG,
+      select: mock((_sel: unknown) => DEFAULT_CONFIG),
+    } as any;
+    let receivedPackageView: unknown;
+
+    _runPlanDeps.resolvePreDebatePhase = mock((_kind: string) =>
+      async (preCtx) => {
+        receivedPackageView = preCtx.ctx.packageView;
+        preCtx.ctx.packageView.select(() => DEFAULT_CONFIG);
+        return { manifestSection: "## Grounded Facts\n- F-001", costUsd: 0 };
+      },
+    ) as any;
+
+    const sm = makeSessionManager({
+      runInSession: mock(async () => ({ output: "ok", tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 })) as any,
+      nameFor: mock((req: any) => `nax-${req?.role ?? "unknown"}`),
+    });
+    _debateSessionDeps.readFile = mock(async () => "{}");
+
+    const config = { ...TEST_CONFIG, debate: { enabled: true, agents: 2, maxConcurrentDebaters: 2 } } as unknown as NaxConfig;
+    const agentManager = makeMockAgentManager();
+    const ctx = makeCallCtxWithIds("package-view-test", agentManager, sm, config);
+    ctx.packageView = packageView;
+
+    const runner = new DebateRunner({
+      ctx,
+      stage: "plan",
+      stageConfig: makePlanStageConfig({ preDebatePhase: { kind: "grounder" } }),
+      config,
+      workdir: "/tmp/workdir",
+      sessionManager: sm,
+    });
+
+    await runner.runPlan("task context", "output format", {
+      workdir: "/tmp/workdir",
+      feature: "package-view-test",
+      outputDir: "/tmp/out",
+    });
+
+    expect(receivedPackageView).toBe(packageView);
+    expect(packageView.select).toHaveBeenCalled();
+  });
+
   test("AC-3: prepends prePhase manifestSection to proposal taskContext", async () => {
     _runPlanDeps.resolvePreDebatePhase = mock((_kind: string) =>
       async () => ({ manifestSection: "## Grounded Facts\n- F-001: critical fact", costUsd: 0 }),

--- a/test/unit/debate/schemas-debate.test.ts
+++ b/test/unit/debate/schemas-debate.test.ts
@@ -120,16 +120,16 @@ describe("DebateStageConfigSchema — preDebatePhase field", () => {
 // ─── AC 5: DebateConfigSchema grounder block ─────────────────────────────────
 
 describe("DebateConfigSchema — grounder block", () => {
-  it("parse({}) returns grounder.model === 'fast' and grounder.timeoutSeconds === 300", () => {
+  it("parse({}) returns grounder.model === 'fast' and grounder.timeoutSeconds === 1800", () => {
     const result = DebateConfigSchema.parse({});
     expect(result.grounder.model).toBe("fast");
-    expect(result.grounder.timeoutSeconds).toBe(300);
+    expect(result.grounder.timeoutSeconds).toBe(1800);
   });
 
   it("parse({ grounder: { model: 'balanced' } }) returns grounder.model === 'balanced'", () => {
     const result = DebateConfigSchema.parse({ grounder: { model: "balanced" } });
     expect(result.grounder.model).toBe("balanced");
-    expect(result.grounder.timeoutSeconds).toBe(300);
+    expect(result.grounder.timeoutSeconds).toBe(1800);
   });
 
   it("parse with object model returns grounder.model.agent === 'claude'", () => {

--- a/test/unit/operations/ground.test.ts
+++ b/test/unit/operations/ground.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { ParseValidationError } from "@/agents";
+import type { RetryStrategy } from "@/agents";
 import { NaxError } from "@/errors";
 import { groundOp } from "@/operations";
 import type { NaxRuntime } from "@/runtime";
@@ -20,8 +22,8 @@ function makeBuildCtx(grounderOverrides?: { model?: unknown; timeoutSeconds?: nu
 }
 
 describe("groundOp — identity", () => {
-  test("kind is complete", () => {
-    expect(groundOp.kind).toBe("complete");
+  test("kind is run", () => {
+    expect(groundOp.kind).toBe("run");
   });
 
   test("name is ground", () => {
@@ -32,8 +34,16 @@ describe("groundOp — identity", () => {
     expect(groundOp.stage).toBe("plan");
   });
 
-  test("jsonMode is true", () => {
-    expect(groundOp.jsonMode).toBe(true);
+  test("session role is grounder", () => {
+    expect(groundOp.session.role).toBe("grounder");
+  });
+
+  test("session lifetime is fresh", () => {
+    expect(groundOp.session.lifetime).toBe("fresh");
+  });
+
+  test("noFallback is true", () => {
+    expect(groundOp.noFallback).toBe(true);
   });
 });
 
@@ -79,10 +89,10 @@ describe("groundOp — timeoutMs", () => {
     expect(result).toBe(120_000);
   });
 
-  test("timeoutMs uses default timeoutSeconds (300) from DEFAULT_CONFIG", () => {
+  test("timeoutMs uses default timeoutSeconds (1800) from DEFAULT_CONFIG", () => {
     const ctx = makeBuildCtx();
     const result = groundOp.timeoutMs?.(input, ctx);
-    expect(result).toBe(300_000);
+    expect(result).toBe(1_800_000);
   });
 });
 
@@ -177,6 +187,72 @@ describe("groundOp — parse", () => {
     if (caught instanceof NaxError) {
       expect(caught.code).toBe("GROUNDER_PARSE_FAILED");
     }
+  });
+});
+
+describe("groundOp — retry", () => {
+  const input = { specContent: "spec", codebaseContext: "ctx", workdir: "/tmp" };
+
+  test("retry resolves to a RetryStrategy-like object with shouldRetry method", () => {
+    const ctx = makeBuildCtx();
+    const retryResult = typeof groundOp.retry === "function" ? groundOp.retry(input, ctx) : groundOp.retry;
+    expect(retryResult).toBeDefined();
+    if (retryResult && typeof retryResult === "object" && "shouldRetry" in retryResult) {
+      expect(typeof retryResult.shouldRetry).toBe("function");
+    }
+  });
+
+  test("retry requests another turn for invalid JSON output", () => {
+    const ctx = makeBuildCtx();
+    const retryResult = (typeof groundOp.retry === "function" ? groundOp.retry(input, ctx) : groundOp.retry) as
+      | RetryStrategy
+      | undefined;
+    expect(retryResult).toBeDefined();
+    const decision = retryResult?.shouldRetry(new ParseValidationError("probe"), 0, {
+      site: "run",
+      agentName: "claude",
+      stage: "plan",
+      storyId: "US-001",
+      lastOutput: "not json",
+    });
+    expect(decision).toEqual({
+      retry: true,
+      delayMs: 0,
+      nextPrompt: expect.stringContaining("Response was not valid JSON"),
+    });
+  });
+
+  test("retry requests another turn for schema-invalid JSON and explains null optional fields", () => {
+    const ctx = makeBuildCtx();
+    const retryResult = (typeof groundOp.retry === "function" ? groundOp.retry(input, ctx) : groundOp.retry) as
+      | RetryStrategy
+      | undefined;
+    expect(retryResult).toBeDefined();
+    const invalidManifest = JSON.stringify({
+      repoFacts: [{ id: "F-001", kind: "file", evidence: "src/x.ts:1", summary: "summary" }],
+      specClaims: [
+        {
+          id: "S-001",
+          specSpan: "span",
+          claim: "claim",
+          kind: "factual",
+          verification: { status: "verified", factId: null, evidence: null },
+        },
+      ],
+      gaps: [{ id: "G-001", kind: "missing-context", note: "note", evidence: null }],
+    });
+    const decision = retryResult?.shouldRetry(new ParseValidationError("probe"), 0, {
+      site: "run",
+      agentName: "claude",
+      stage: "plan",
+      storyId: "US-001",
+      lastOutput: invalidManifest,
+    });
+    expect(decision).toEqual({
+      retry: true,
+      delayMs: 0,
+      nextPrompt: expect.stringContaining("Do NOT use null"),
+    });
   });
 });
 


### PR DESCRIPTION
## What

- fix the plan debate grounder pre-phase crash by threading a real `CallContext` through the plan runner
- refactor the plan context to carry `callContext` explicitly instead of mirroring `CallContext` fields
- switch the grounder prompt context from large `scanCodebase()` output to compact source-root context
- improve grounder retry behavior and diagnostics for schema-invalid JSON, especially `null` optional fields
- export a short evaluation note comparing grounder-assisted planning vs single-session planning

## Why

- `plan debate + grounder` could crash before debate started because the pre-phase path passed an incomplete context to `callOp()`
- the old grounder prompt was too large and noisy, which made grounding quality less reliable
- retry logs were misleading when output was valid JSON but still failed manifest schema validation
- we wanted a written record of whether the grounder was actually improving PRD quality

## How

- thread `callContext` through the plan debate path and use it in the pre-phase runner
- extract a shared `buildSourceRootsSection()` renderer and reuse it for both single-session plan and the grounder
- make the grounder use `scanSourceRoots()` instead of the older large file-tree context
- replace the generic grounder retry wiring with grounder-specific inspection so logs distinguish:
  - invalid JSON
  - valid JSON but invalid schema
  - near-output-cap schema failures
- strengthen the grounder repair prompt to explicitly require omitting optional fields instead of using `null`
- add `.nax/features/plan-asymmetric-pipeline/grounder-evaluation.md`

## Testing

- `bun test test/unit/debate/pre-phase/grounder.test.ts test/unit/debate/runner-plan.test.ts test/unit/operations/ground.test.ts test/unit/debate/schemas-debate.test.ts --timeout=10000`
- `bun run typecheck`

## Notes

- local `.nax/profiles/opencode-debate.json` was intentionally left uncommitted
- generated PRD artifacts under `.nax/features/plan-asymmetric-pipeline/` were intentionally left out except for `grounder-evaluation.md`
