### PR TITLE
fix(pipeline): fix rectify retry counter, env-failure escalation, and retry-limit escalation

### DIFF
--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -12,9 +12,9 @@ export type {
   RoutingResult,
 } from "./types";
 
-export { runPipeline } from "./runner";
+export { runPipeline, MAX_STAGE_RETRIES, MAX_STAGE_RESETS } from "./runner";
 export type { PipelineRunResult } from "./runner";
 
 export { PipelineEventEmitter } from "./events";
 export type { PipelineEvents, RunSummary } from "./events";
-export { executionStage, _executionDeps } from "./stages";
+export { executionStage, _executionDeps, rectifyStage, _rectifyDeps } from "./stages";

--- a/src/pipeline/runner.ts
+++ b/src/pipeline/runner.ts
@@ -38,6 +38,14 @@ export interface PipelineRunResult {
 export const MAX_STAGE_RETRIES = 5;
 
 /**
+ * Maximum number of times a fixer stage (rectify/autofix) may reset the retry
+ * counter for a target stage via `resetRetryCount: true`. Capped at 1 so that
+ * a divergence between the fixer's internal verify and the outer pipeline verify
+ * cannot produce an infinite reset loop.
+ */
+export const MAX_STAGE_RESETS = 1;
+
+/**
  * Run a pipeline of stages against a context.
  *
  * Supports a `retry` action that jumps back to a named stage (used by
@@ -53,6 +61,10 @@ export async function runPipeline(
 ): Promise<PipelineRunResult> {
   const logger = getLogger();
   const retryCountMap = new Map<string, number>();
+  // Tracks how many times each stage's counter has been reset via resetRetryCount.
+  // Capped at MAX_STAGE_RESETS to prevent infinite loops when the fixer's internal
+  // verify diverges from the outer pipeline verify (e.g. different timeout/command).
+  const retryResetCountMap = new Map<string, number>();
   let i = 0;
   let stageCostAccum = 0;
 
@@ -137,12 +149,21 @@ export async function runPipeline(
         };
 
       case "retry": {
+        if (result.resetRetryCount) {
+          const resets = (retryResetCountMap.get(result.fromStage) ?? 0) + 1;
+          if (resets <= MAX_STAGE_RESETS) {
+            retryResetCountMap.set(result.fromStage, resets);
+            retryCountMap.delete(result.fromStage);
+          }
+          // If reset cap is exceeded, fall through — counter continues incrementing
+          // normally and the stage will escalate once MAX_STAGE_RETRIES is reached.
+        }
         const retries = (retryCountMap.get(result.fromStage) ?? 0) + 1;
         if (retries > MAX_STAGE_RETRIES) {
           logger.warn("pipeline", `Stage retry limit reached for "${result.fromStage}" (max ${MAX_STAGE_RETRIES})`);
           return {
             success: false,
-            finalAction: "fail",
+            finalAction: "escalate",
             reason: `Stage "${stage.name}" exceeded max retries (${MAX_STAGE_RETRIES}) for "${result.fromStage}"`,
             stoppedAtStage: stage.name,
             context,

--- a/src/pipeline/stages/autofix.ts
+++ b/src/pipeline/stages/autofix.ts
@@ -119,7 +119,7 @@ export const autofixStage: PipelineStage = {
           });
         }
         logger.info("autofix", "Mechanical autofix succeeded — retrying review", { storyId: ctx.story.id });
-        return { action: "retry", fromStage: "review" };
+        return { action: "retry", fromStage: "review", resetRetryCount: true };
       }
 
       logger.info("autofix", "Mechanical autofix did not resolve all failures — proceeding to agent rectification", {
@@ -212,7 +212,7 @@ export const autofixStage: PipelineStage = {
         });
       }
       logger.info("autofix", "Agent rectification succeeded — retrying review", { storyId: ctx.story.id });
-      return { action: "retry", fromStage: "review", cost: agentCost };
+      return { action: "retry", fromStage: "review", resetRetryCount: true, cost: agentCost };
     }
 
     // Partial-progress retry: if the agent cleared at least one check this cycle but not all,

--- a/src/pipeline/stages/index.ts
+++ b/src/pipeline/stages/index.ts
@@ -78,7 +78,7 @@ export { promptStage } from "./prompt";
 export { optimizerStage } from "./optimizer";
 export { executionStage, _executionDeps } from "./execution";
 export { verifyStage } from "./verify";
-export { rectifyStage } from "./rectify";
+export { rectifyStage, _rectifyDeps } from "./rectify";
 export { reviewStage } from "./review";
 export { autofixStage } from "./autofix";
 export { regressionStage } from "./regression";

--- a/src/pipeline/stages/rectify.ts
+++ b/src/pipeline/stages/rectify.ts
@@ -43,6 +43,22 @@ export const rectifyStage: PipelineStage = {
       return { action: "continue" };
     }
 
+    // If failCount is 0 but verify still failed, the process exited non-zero due
+    // to an environmental issue (e.g. resource warnings, open handles, infra crash)
+    // rather than test assertion failures. The agent cannot fix environmental issues
+    // by changing code, so skip rectification and escalate immediately.
+    if ((verifyResult.failCount ?? 0) === 0) {
+      logger.warn("rectify", "Verify failed with 0 test failures — escalating without rectification", {
+        storyId: ctx.story.id,
+        failCount: verifyResult.failCount,
+        verifyStatus: verifyResult.status,
+      });
+      return {
+        action: "escalate",
+        reason: `Verify failed with 0 test failures (status: ${verifyResult.status} — not fixable by code changes)`,
+      };
+    }
+
     const testOutput = verifyResult.rawOutput ?? "";
     const maxRetries = ctx.config.execution.rectification?.maxRetries ?? 3;
 
@@ -106,7 +122,7 @@ export const rectifyStage: PipelineStage = {
       logger.info("rectify", "Rectification succeeded — retrying verify", { storyId: ctx.story.id });
       // Clear verifyResult so verify stage re-runs fresh
       ctx.verifyResult = undefined;
-      return { action: "retry", fromStage: "verify", cost };
+      return { action: "retry", fromStage: "verify", resetRetryCount: true, cost };
     }
 
     logger.warn("rectify", "Rectification exhausted — escalating", { storyId: ctx.story.id });

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -280,7 +280,18 @@ export type StageAction =
   /** Pause execution (user intervention required via queue command) */
   | { action: "pause"; reason: string; cost?: number }
   /** Retry from a specific stage (used by rectify/autofix stages) */
-  | { action: "retry"; fromStage: string; cost?: number };
+  | {
+      action: "retry";
+      fromStage: string;
+      cost?: number;
+      /**
+       * When true, the retry counter for `fromStage` is reset to zero before
+       * this retry is counted. Use when the fixing stage (e.g. rectify/autofix)
+       * has genuinely resolved the problem and the target stage should get a
+       * fresh attempt budget.
+       */
+      resetRetryCount?: boolean;
+    };
 
 /**
  * Result returned by a pipeline stage after execution.

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -455,7 +455,15 @@ export async function runRectificationLoop(
         // either the runner exited clean (status SUCCESS) or it saw passing
         // tests (passed > 0). If both are 0, the parser couldn't read the
         // output format — treat it as unresolved to avoid false-positives.
-        if (newTestSummary.failed === 0 && (retryVerification.status === "SUCCESS" || newTestSummary.passed > 0)) {
+        // Exclude ENVIRONMENTAL_FAILURE: the process exited non-zero due to an
+        // infrastructure issue (resource warnings, open handles) that is not
+        // fixable by code changes. Even with 0 failures and passing tests, the
+        // outer verify stage will still fail — do not declare success here.
+        if (
+          newTestSummary.failed === 0 &&
+          retryVerification.status !== "ENVIRONMENTAL_FAILURE" &&
+          (retryVerification.status === "SUCCESS" || newTestSummary.passed > 0)
+        ) {
           logger?.info("rectification", `[OK] ${label} succeeded after parsing retry output`, {
             storyId: story.id,
             attempt: currentAttempt,

--- a/test/unit/pipeline/runner-retry.test.ts
+++ b/test/unit/pipeline/runner-retry.test.ts
@@ -1,8 +1,8 @@
 // RE-ARCH: keep
 import { describe, expect, test } from "bun:test";
-import { MAX_STAGE_RETRIES, runPipeline } from "../../../src/pipeline/runner";
-import type { PipelineContext, PipelineStage } from "../../../src/pipeline/types";
-import { DEFAULT_CONFIG } from "../../../src/config";
+import { MAX_STAGE_RETRIES, runPipeline } from "@/pipeline";
+import type { PipelineContext, PipelineStage } from "@/pipeline";
+import { DEFAULT_CONFIG } from "@/config";
 
 function makeCtx(): PipelineContext {
   return {

--- a/test/unit/pipeline/runner-retry.test.ts
+++ b/test/unit/pipeline/runner-retry.test.ts
@@ -43,7 +43,7 @@ describe("runPipeline retry action", () => {
     expect(order).toEqual(["a", "b", "c", "b", "c", "d"]);
   });
 
-  test("retry fails after MAX_STAGE_RETRIES exceeded", async () => {
+  test("retry escalates after MAX_STAGE_RETRIES exceeded", async () => {
     let calls = 0;
     const stages = [
       stage("verify", () => { return { action: "continue" }; }),
@@ -52,7 +52,7 @@ describe("runPipeline retry action", () => {
 
     const result = await runPipeline(stages, makeCtx());
 
-    expect(result.finalAction).toBe("fail");
+    expect(result.finalAction).toBe("escalate");
     expect(calls).toBe(MAX_STAGE_RETRIES + 1);
     expect(result.reason).toContain("exceeded max retries");
   });
@@ -65,6 +65,38 @@ describe("runPipeline retry action", () => {
     const result = await runPipeline(stages, makeCtx());
     expect(result.finalAction).toBe("escalate");
     expect(result.reason).toContain("not found");
+  });
+
+  test("resetRetryCount resets counter so fixer gets fresh budget after success", async () => {
+    // Scenario: rectify uses up MAX_STAGE_RETRIES-1 failed retries (counter at
+    // MAX_STAGE_RETRIES-1), then on the next call signals success via
+    // resetRetryCount:true. Without the reset, the subsequent verify retry would
+    // push the counter to MAX_STAGE_RETRIES+1 and escalate. With the reset it
+    // starts from 0, so the pipeline can complete.
+    let rectifyCalls = 0;
+
+    const stages = [
+      stage("verify", () => ({ action: "continue" })),
+      stage("rectify", () => {
+        rectifyCalls++;
+        if (rectifyCalls === MAX_STAGE_RETRIES) {
+          // Successful fix on the MAX_STAGE_RETRIES-th call — reset counter
+          return { action: "retry", fromStage: "verify", resetRetryCount: true };
+        }
+        if (rectifyCalls > MAX_STAGE_RETRIES) {
+          // After reset verify ran successfully; rectify is done
+          return { action: "continue" };
+        }
+        return { action: "retry", fromStage: "verify" };
+      }),
+    ];
+
+    // Flow: verify+rectify cycle MAX_STAGE_RETRIES times (counter hits max without
+    // reset). On the MAX_STAGE_RETRIES-th rectify call, counter is reset → verify
+    // retries cleanly → rectify returns continue → pipeline completes.
+    const result = await runPipeline(stages, makeCtx());
+    expect(result.finalAction).toBe("complete");
+    expect(rectifyCalls).toBe(MAX_STAGE_RETRIES + 1);
   });
 
   test("disabled stages are skipped during retry", async () => {

--- a/test/unit/pipeline/stages/rectify.test.ts
+++ b/test/unit/pipeline/stages/rectify.test.ts
@@ -76,7 +76,7 @@ describe("rectifyStage", () => {
 
   test("returns retry when rectification succeeds", async () => {
     const saved = { ..._rectifyDeps };
-    _rectifyDeps.runRectificationLoop = async () => ({ succeeded: true, cost: 0 });
+    _rectifyDeps.runRectificationLoop = async () => ({ succeeded: true, cost: 0, durationMs: 0 });
 
     const ctx = makeCtx({ verifyResult: makeVerifyResult(false) });
     const result = await rectifyStage.execute(ctx);
@@ -91,7 +91,7 @@ describe("rectifyStage", () => {
 
   test("returns escalate when rectification exhausted", async () => {
     const saved = { ..._rectifyDeps };
-    _rectifyDeps.runRectificationLoop = async () => ({ succeeded: false, cost: 0 });
+    _rectifyDeps.runRectificationLoop = async () => ({ succeeded: false, cost: 0, durationMs: 0 });
 
     const ctx = makeCtx({ verifyResult: makeVerifyResult(false) });
     const result = await rectifyStage.execute(ctx);
@@ -99,5 +99,44 @@ describe("rectifyStage", () => {
     Object.assign(_rectifyDeps, saved);
 
     expect(result.action).toBe("escalate");
+  });
+
+  test("escalates immediately when failCount is 0 (environmental failure — nothing for agent to fix)", async () => {
+    const saved = { ..._rectifyDeps };
+    // Ensure runRectificationLoop is never called for this path
+    let loopCalled = false;
+    _rectifyDeps.runRectificationLoop = async () => { loopCalled = true; return { succeeded: false, cost: 0, durationMs: 0 }; };
+
+    const envVerifyResult = {
+      ...makeVerifyResult(false),
+      failCount: 0,
+      status: "TEST_FAILURE" as const,
+    };
+    const ctx = makeCtx({ verifyResult: envVerifyResult });
+    const result = await rectifyStage.execute(ctx);
+
+    Object.assign(_rectifyDeps, saved);
+
+    expect(result.action).toBe("escalate");
+    expect(loopCalled).toBe(false);
+    if (result.action === "escalate") {
+      expect(result.reason).toContain("0 test failures");
+    }
+  });
+
+  test("returns retry with resetRetryCount:true when rectification succeeds", async () => {
+    const saved = { ..._rectifyDeps };
+    _rectifyDeps.runRectificationLoop = async () => ({ succeeded: true, cost: 0, durationMs: 0 });
+
+    const ctx = makeCtx({ verifyResult: makeVerifyResult(false) });
+    const result = await rectifyStage.execute(ctx);
+
+    Object.assign(_rectifyDeps, saved);
+
+    expect(result.action).toBe("retry");
+    if (result.action === "retry") {
+      expect(result.fromStage).toBe("verify");
+      expect(result.resetRetryCount).toBe(true);
+    }
   });
 });

--- a/test/unit/pipeline/stages/rectify.test.ts
+++ b/test/unit/pipeline/stages/rectify.test.ts
@@ -1,8 +1,8 @@
 // RE-ARCH: keep
 import { describe, expect, test } from "bun:test";
-import { rectifyStage, _rectifyDeps } from "../../../../src/pipeline/stages/rectify";
-import type { PipelineContext } from "../../../../src/pipeline/types";
-import { DEFAULT_CONFIG } from "../../../../src/config";
+import { rectifyStage, _rectifyDeps } from "@/pipeline";
+import type { PipelineContext } from "@/pipeline";
+import { DEFAULT_CONFIG } from "@/config";
 
 function makeCtx(overrides: Partial<PipelineContext> = {}): PipelineContext {
   return {


### PR DESCRIPTION
Closes #1018

## Summary

- **Stale retry counter** blocked successful rectification: added `resetRetryCount` flag to `StageAction` retry so fixer stages (rectify/autofix) give the target stage a fresh attempt budget after a genuine fix. A `MAX_STAGE_RESETS = 1` cap prevents infinite loops if the fixer's internal verify diverges from the outer pipeline verify.
- **Retry-limit breach bypassed tier escalation**: `runPipeline` returned `finalAction: "fail"` on retry exhaustion, skipping `handleTierEscalation()` entirely. Changed to `finalAction: "escalate"`.
- **Environmental failures triggered futile rectification**: when `verifyResult.failCount === 0` (e.g. pytest exits non-zero due to `PytestUnraisableExceptionWarning` from unclosed SQLite connections), the agent has nothing to fix. Fixed in two layers: (a) `rectify.ts` escalates immediately; (b) `rectification-loop.ts` excludes `ENVIRONMENTAL_FAILURE` from the "0 failures + passing tests = done" success path.

## Root cause (from log analysis)

Real run showed 6 identical cycles:
```
[rectify] Starting rectification loop | failCount: 0
[rectification] [OK] rectification succeeded! | initialFailures: 0
[verify] Tests failed | exitCode: ENVIRONMENTAL_FAILURE
```
The rectification loop declared success immediately every time because `initialFailures === 0`, burning ~$0.10/cycle in agent calls while making no progress.

## Test plan

- [ ] `bun run typecheck` — clean
- [ ] `timeout 30 bun test ./test/unit/pipeline/ --timeout=5000` — 657 pass, 0 fail
- [ ] New test: `failCount === 0` → escalate (no loop entered)
- [ ] New test: `resetRetryCount` gives fresh budget and pipeline completes
- [ ] Updated test: retry-limit → `"escalate"` (was `"fail"`)
- [ ] New test: `resetRetryCount: true` on rectify success return