### PR TITLE
fix(plan): fix over-retry on valid output, plan-draft session naming, and citation threshold propagation

### DIFF
--- a/.claude/rules/adapter-wiring.md
+++ b/.claude/rules/adapter-wiring.md
@@ -40,7 +40,7 @@ paths:
 
 | Role | Dispatch |
 |:---|:---|
-| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `reviewer-semantic`, `reviewer-adversarial`, `acceptance-gen`, `plan`, `plan-draft`, `plan-critic` | `callOp` run-kind |
+| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `reviewer-semantic`, `reviewer-adversarial`, `acceptance-gen`, `plan`, `plan-draft`, `plan-revise`, `plan-critic` | `callOp` run-kind |
 | `decompose`, `refine`, `fix-gen`, `auto` | `callOp` complete-kind |
 | `synthesis`, `judge` | `agentManager.completeAs` |
 | `` debate-${string} `` | `agentManager.runAsSession` |

--- a/.claude/rules/adapter-wiring.md
+++ b/.claude/rules/adapter-wiring.md
@@ -40,8 +40,8 @@ paths:
 
 | Role | Dispatch |
 |:---|:---|
-| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `reviewer-semantic`, `reviewer-adversarial`, `acceptance-gen` | `callOp` run-kind |
-| `plan`, `decompose`, `refine`, `fix-gen`, `auto` | `callOp` complete-kind |
+| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `reviewer-semantic`, `reviewer-adversarial`, `acceptance-gen`, `plan`, `plan-draft`, `plan-critic` | `callOp` run-kind |
+| `decompose`, `refine`, `fix-gen`, `auto` | `callOp` complete-kind |
 | `synthesis`, `judge` | `agentManager.completeAs` |
 | `` debate-${string} `` | `agentManager.runAsSession` |
 

--- a/src/agents/retry/tiered-parse-retry.ts
+++ b/src/agents/retry/tiered-parse-retry.ts
@@ -30,6 +30,9 @@ export function makeTieredParseRetryStrategy<TOutput, TKind extends string, TPar
 
       const inspection = opts.inspect(ctx.lastOutput);
 
+      // Output is valid — no retry needed. Let op.parse() handle it.
+      if (inspection.ok) return { retry: false };
+
       if (attempt >= opts.maxAttempts - 1) {
         return { retry: false, fallback: opts.exhaustedFallback(inspection, ctx.lastOutput) };
       }

--- a/src/operations/plan-draft.ts
+++ b/src/operations/plan-draft.ts
@@ -52,7 +52,12 @@ interface DraftInspection extends TieredInspection<DraftFailureKind, PRD> {
 
 // ─── Inspection ───────────────────────────────────────────────────────────────
 
-export function inspectDraftOutput(output: string, feature = "", branch = ""): DraftInspection {
+export function inspectDraftOutput(
+  output: string,
+  feature = "",
+  branch = "",
+  citationThreshold = DEFAULT_CITATION_THRESHOLD,
+): DraftInspection {
   let raw: unknown;
   try {
     raw = parseLLMJson(output);
@@ -73,12 +78,12 @@ export function inspectDraftOutput(output: string, feature = "", branch = ""): D
 
   const claims = extractClaims(output);
   const rate = citationRate(claims);
-  if (rate < DEFAULT_CITATION_THRESHOLD) {
+  if (citationThreshold > 0 && rate < citationThreshold) {
     const uncited = claims.filter((c) => !c.cited).length;
     return {
       ok: false,
       kind: "citation-low",
-      message: `Citation rate ${rate.toFixed(2)} below default ${DEFAULT_CITATION_THRESHOLD} (${uncited} uncited claims).`,
+      message: `Citation rate ${rate.toFixed(2)} below threshold ${citationThreshold} (${uncited} uncited claims).`,
       partial: prd,
       citationRate: rate,
     };
@@ -135,13 +140,13 @@ function buildDraftRetryPrompt(inspection: DraftInspection, isTruncated: boolean
   return PlanPromptBuilder.citationRepair(message);
 }
 
-function createDraftRetryStrategy(): ReturnType<
-  typeof makeTieredParseRetryStrategy<PlanDraftOutput, DraftFailureKind, PRD>
-> {
+function createDraftRetryStrategy(
+  citationThreshold = DEFAULT_CITATION_THRESHOLD,
+): ReturnType<typeof makeTieredParseRetryStrategy<PlanDraftOutput, DraftFailureKind, PRD>> {
   return makeTieredParseRetryStrategy<PlanDraftOutput, DraftFailureKind, PRD>({
     reviewerKind: "plan-draft",
     maxAttempts: 2,
-    inspect: inspectDraftOutput,
+    inspect: (output) => inspectDraftOutput(output, "", "", citationThreshold),
     buildRetryPrompt: buildDraftRetryPrompt,
     exhaustedFallback(inspection, _lastOutput) {
       if (inspection.partial) {
@@ -162,12 +167,12 @@ export const planDraftOp: RunOperation<PlanDraftInput, PlanDraftOutput, PlanConf
   kind: "run",
   name: "plan-draft",
   stage: "plan",
-  session: { role: "plan", lifetime: "fresh" },
+  session: { role: "plan-draft", lifetime: "fresh" },
   noFallback: true,
   config: planConfigSelector,
   model: (_input, ctx) => ctx.config.plan?.model ?? "fast",
   timeoutMs: (_input, ctx) => (ctx.config.plan?.timeoutSeconds ?? 600) * 1000,
-  retry: createDraftRetryStrategy(),
+  retry: (input: PlanDraftInput) => createDraftRetryStrategy(input.citationThreshold),
   build(input, _ctx) {
     return new PlanPromptBuilder().buildDraft(input);
   },

--- a/src/plan/critic.ts
+++ b/src/plan/critic.ts
@@ -100,12 +100,13 @@ export async function runPlanCritic(input: PlanCriticInput): Promise<PlanCriticV
     return { outcome: "passed", prd, findings: allFindings };
   }
 
-  // 3. Revision via planDraftOp
+  // 3. Revision via planDraftOp (session named "plan-revise" to distinguish from initial draft)
   try {
-    const revisedDraft = await callOp(callCtx, planDraftOp, {
-      ...draftCtx,
-      revisionFindings: allBlockers,
-    });
+    const revisedDraft = await callOp(
+      { ...callCtx, sessionOverride: { role: "plan-revise" } },
+      planDraftOp,
+      { ...draftCtx, revisionFindings: allBlockers },
+    );
 
     const revisedMechFindings = runMechanicalChecks(revisedDraft.prd, workdir, manifest, draftCtx.citationThreshold);
     const revisedMechBlockers = revisedMechFindings.filter((f) => f.severity === "blocker");

--- a/src/plan/critic.ts
+++ b/src/plan/critic.ts
@@ -102,11 +102,10 @@ export async function runPlanCritic(input: PlanCriticInput): Promise<PlanCriticV
 
   // 3. Revision via planDraftOp (session named "plan-revise" to distinguish from initial draft)
   try {
-    const revisedDraft = await callOp(
-      { ...callCtx, sessionOverride: { role: "plan-revise" } },
-      planDraftOp,
-      { ...draftCtx, revisionFindings: allBlockers },
-    );
+    const revisedDraft = await callOp({ ...callCtx, sessionOverride: { role: "plan-revise" } }, planDraftOp, {
+      ...draftCtx,
+      revisionFindings: allBlockers,
+    });
 
     const revisedMechFindings = runMechanicalChecks(revisedDraft.prd, workdir, manifest, draftCtx.citationThreshold);
     const revisedMechBlockers = revisedMechFindings.filter((f) => f.severity === "blocker");

--- a/src/prompts/builders/plan-builder.ts
+++ b/src/prompts/builders/plan-builder.ts
@@ -101,9 +101,9 @@ Write the complete PRD JSON to the output file path specified in your instructio
 
 Schema error: ${message}
 
-Please re-write the complete PRD JSON from scratch, ensuring it conforms to the required schema. The PRD must be valid and complete — do not truncate it.
+Required field names (do not rename): \`userStories\` (array), each story must have \`description\` (not "story"), \`acceptanceCriteria\` (string array, not "ac"), and \`routing.complexity\` ("simple" | "medium" | "complex" | "expert").
 
-Output ONLY the JSON object. Do not include markdown fences or explanation.`;
+Please re-write the complete PRD JSON from scratch conforming to the required schema. Output ONLY the JSON object. Do not include markdown fences or explanation.`;
   }
 
   /**
@@ -280,9 +280,33 @@ ${input.manifestSection}
 
 Every concrete claim referencing existing code must cite [F-NNN] or [S-NNN] from the manifest. The required citation rate is ${input.citationThreshold}. Uncited factual claims will cause rejection.${revisionSection}
 
-## Output
+## Output Schema
 
-Produce a complete PRD JSON object. Do not include markdown fences or explanation.`,
+Produce a JSON object with this exact structure. Field names are mandatory — do not rename them.
+
+{
+  "project": "string — project name",
+  "feature": "string — feature name (copy from above)",
+  "branchName": "string — git branch name",
+  "userStories": [
+    {
+      "id": "string — e.g. US-001",
+      "title": "string — concise story title",
+      "description": "string — detailed description of what to implement",
+      "acceptanceCriteria": ["string — behavioral criterion, format: 'When [X], then [Y]'. One assertion per item."],
+      "contextFiles": ["string — relative paths the implementer should read (max 5)"],
+      "tags": ["string"],
+      "dependencies": ["string — story IDs this story depends on"],
+      "routing": {
+        "complexity": "simple | medium | complex | expert",
+        "testStrategy": "no-test | tdd-simple | three-session-tdd-lite | three-session-tdd | test-after",
+        "reasoning": "string — brief classification rationale"
+      }
+    }
+  ]
+}
+
+Output ONLY the JSON object. Do not include markdown fences or explanation.`,
       overridable: false,
     };
 

--- a/src/runtime/session-role.ts
+++ b/src/runtime/session-role.ts
@@ -19,6 +19,7 @@ export type CanonicalSessionRole =
   | "grounder"
   | "plan"
   | "plan-draft"
+  | "plan-revise"
   | "plan-critic"
   | "decompose"
   | "acceptance-gen"
@@ -43,6 +44,7 @@ export const KNOWN_SESSION_ROLES: readonly CanonicalSessionRole[] = [
   "grounder",
   "plan",
   "plan-draft",
+  "plan-revise",
   "plan-critic",
   "decompose",
   "acceptance-gen",

--- a/src/runtime/session-role.ts
+++ b/src/runtime/session-role.ts
@@ -18,6 +18,7 @@ export type CanonicalSessionRole =
   | "reviewer-adversarial"
   | "grounder"
   | "plan"
+  | "plan-draft"
   | "plan-critic"
   | "decompose"
   | "acceptance-gen"
@@ -41,6 +42,7 @@ export const KNOWN_SESSION_ROLES: readonly CanonicalSessionRole[] = [
   "reviewer-adversarial",
   "grounder",
   "plan",
+  "plan-draft",
   "plan-critic",
   "decompose",
   "acceptance-gen",

--- a/test/unit/agents/retry/tiered-parse-retry.test.ts
+++ b/test/unit/agents/retry/tiered-parse-retry.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { ParseValidationError } from "@/agents";
+import { makeTieredParseRetryStrategy, ParseValidationError } from "@/agents";
 import type { RetryContext, RetryStrategy } from "@/agents";
 
 // AC-1 & AC-2: Non-ParseValidationError and missing lastOutput should return { retry: false }
@@ -207,6 +207,69 @@ describe("makeTieredParseRetryStrategy — AC-4: exhaustion with fallback", () =
     expect(exhaustedCalls.length).toBe(1);
     expect((exhaustedCalls[0]?.inspection as any)?.kind).toBe("citation-low");
     expect(exhaustedCalls[0]?.lastOutput).toBe("bad output");
+  });
+});
+
+// Regression: inspection.ok === true must short-circuit retry (over-retry bug)
+describe("makeTieredParseRetryStrategy — real impl: ok:true short-circuits retry", () => {
+  test("returns { retry: false } immediately when inspect returns ok: true", () => {
+    const buildRetryPromptCalls: unknown[] = [];
+    const strategy = makeTieredParseRetryStrategy({
+      reviewerKind: "test-reviewer",
+      maxAttempts: 2,
+      inspect: (_output: string) => ({ ok: true }),
+      buildRetryPrompt: (inspection: unknown, isTruncated: boolean) => {
+        buildRetryPromptCalls.push({ inspection, isTruncated });
+        return "should not be called";
+      },
+      exhaustedFallback: () => ({ findings: [] }),
+    });
+
+    const result = strategy.shouldRetry(
+      new ParseValidationError("probe"),
+      0,
+      makeCtx({ lastOutput: '{"findings": []}' }),
+    );
+
+    expect(result).toEqual({ retry: false });
+    expect(buildRetryPromptCalls.length).toBe(0);
+  });
+
+  test("does not call exhaustedFallback when inspect returns ok: true", () => {
+    const exhaustedCalls: unknown[] = [];
+    const strategy = makeTieredParseRetryStrategy({
+      reviewerKind: "test-reviewer",
+      maxAttempts: 2,
+      inspect: (_output: string) => ({ ok: true }),
+      buildRetryPrompt: () => "prompt",
+      exhaustedFallback: (...args: unknown[]) => {
+        exhaustedCalls.push(args);
+        return { findings: [] };
+      },
+    });
+
+    strategy.shouldRetry(new ParseValidationError("probe"), 0, makeCtx({ lastOutput: "valid" }));
+
+    expect(exhaustedCalls.length).toBe(0);
+  });
+
+  test("ok: true at attempt >= maxAttempts-1 still returns { retry: false } without fallback", () => {
+    const strategy = makeTieredParseRetryStrategy({
+      reviewerKind: "test-reviewer",
+      maxAttempts: 2,
+      inspect: (_output: string) => ({ ok: true }),
+      buildRetryPrompt: () => "prompt",
+      exhaustedFallback: () => ({ findings: ["should-not-appear"] }),
+    });
+
+    const result = strategy.shouldRetry(
+      new ParseValidationError("probe"),
+      1,
+      makeCtx({ lastOutput: "valid" }),
+    );
+
+    expect(result).toEqual({ retry: false });
+    expect("fallback" in result && result.fallback).toBeFalsy();
   });
 });
 

--- a/test/unit/operations/plan-draft.test.ts
+++ b/test/unit/operations/plan-draft.test.ts
@@ -83,8 +83,8 @@ describe("planDraftOp — AC-5: identity properties", () => {
     expect(planDraftOp.stage).toBe("plan");
   });
 
-  test("session.role === 'plan'", () => {
-    expect(planDraftOp.session.role).toBe("plan");
+  test("session.role === 'plan-draft'", () => {
+    expect(planDraftOp.session.role).toBe("plan-draft");
   });
 
   test("session.lifetime === 'fresh'", () => {
@@ -95,9 +95,9 @@ describe("planDraftOp — AC-5: identity properties", () => {
     expect(planDraftOp.noFallback).toBe(true);
   });
 
-  test("retry strategy is set", () => {
+  test("retry is a function factory (returns strategy per input)", () => {
     expect(planDraftOp.retry).toBeDefined();
-    expect(typeof (planDraftOp.retry as any).shouldRetry).toBe("function");
+    expect(typeof planDraftOp.retry).toBe("function");
   });
 });
 
@@ -270,7 +270,8 @@ describe("planDraftOp.parse — AC-14, AC-15, AC-16: failure paths", () => {
 // ─── AC-17: retry strategy wiring ────────────────────────────────────────────
 
 describe("planDraftOp.retry — AC-17: retry strategy wiring", () => {
-  const retry = planDraftOp.retry as { shouldRetry: Function };
+  // retry is now a factory function; call it with a default input to get the strategy
+  const retry = (planDraftOp.retry as Function)(makeDraftInput()) as { shouldRetry: Function };
 
   test("returns { retry: false } when failure is not ParseValidationError", () => {
     const decision = retry.shouldRetry(new Error("network"), 0, { lastOutput: "{}", storyId: "s1" });


### PR DESCRIPTION
## Summary

- **Over-retry bug**: `makeTieredParseRetryStrategy` never checked `inspection.ok` before deciding to retry. When the critic (or draft) returned valid JSON, `inspect()` returned `ok: true` but the strategy still logged `"Parse retry — unknown"` and returned `{ retry: true }`, causing valid findings to be discarded via `exhaustedFallback` on the next probe. Added early `if (inspection.ok) return { retry: false }` guard.
- **Session naming**: `planDraftOp.session.role` was `"plan"` (same as `planInteractiveOp`), making all draft audit files show `…-plan-plan-t01.txt`. Changed to `"plan-draft"`; added to `SessionRole` union and `KNOWN_SESSION_ROLES`. Also corrected `adapter-wiring.md` which listed `plan`/`plan-critic` under complete-kind when both ops are run-kind.
- **Citation threshold mismatch**: `inspectDraftOutput` used a hardcoded `DEFAULT_CITATION_THRESHOLD=0.5` for retry decisions while `parsePlanDraft` used `config.plan.citationThreshold`. If the configured threshold differed, retries fired on the wrong value and logged `"below default 0.5"`. Now `inspectDraftOutput` accepts `citationThreshold` as a parameter, `createDraftRetryStrategy` takes it as an argument, and `planDraftOp.retry` is a factory function `(input) => createDraftRetryStrategy(input.citationThreshold)`. Added `citationThreshold > 0` guard so `threshold=0` disables the check entirely.
- **Draft prompt schema**: Added explicit output schema to `PlanPromptBuilder.buildDraft()` and field-name hints to `schemaRepair()` so the LLM uses the required field names (`userStories`, `description`, `acceptanceCriteria`) rather than its own variants.

## Test plan

- [ ] `timeout 30 bun test test/unit/agents/retry/tiered-parse-retry.test.ts --timeout=5000` — includes 3 new regression tests for `ok:true` short-circuit
- [ ] `timeout 30 bun test test/unit/operations/plan-draft.test.ts --timeout=5000` — updated role assertion (`plan-draft`), retry factory test, and AC-17 uses factory-resolved strategy
- [ ] `bun run typecheck` — `plan-draft` added to `SessionRole` union resolves the type error
- [ ] Re-run `nax plan --mode pipeline` — draft audit files should now show `…-plan-draft-plan-t01.txt`; no spurious `"Parse retry — unknown"` in the log