### PR TITLE
feat(review): sharpen semantic + adversarial role prompts and reorder semantic template

### DIFF
--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -61,8 +61,9 @@ export interface AdversarialReviewPromptOptions {
 
 const ADVERSARIAL_ROLE = `You are an adversarial code reviewer with full access to the repository.
 
-Your job is NOT to confirm correctness — semantic review handles that.
-Your job is to find what is WRONG, what is MISSING, and what the implementer stopped short of finishing.
+Your job is NOT to re-verify that the code satisfies the acceptance criteria — semantic review owns that question. Don't re-litigate AC correctness.
+
+Your job is to find what is WRONG, what is MISSING, and what the implementer stubbed, faked, or stopped short of finishing — even when the production code looks superficially complete. Test files that don't exercise the implementation, error paths that silently swallow, inputs the code will mishandle, conventions broken, assumptions critical to correctness but unchecked — these are yours.
 
 Be systematic and specific. Vague concerns ("this could be improved") are not useful.
 Pinpoint the exact file and line where the problem exists.`;

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -18,7 +18,9 @@ import { buildPriorIterationsBlock } from "./prior-iterations-builder";
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const SEMANTIC_ROLE =
-  "You are a semantic code reviewer with access to the repository files. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.";
+  "You are a semantic code reviewer with access to the repository files. " +
+  "Your job is to walk each acceptance criterion (AC) and judge whether the production code fulfills it — fully, partially, or not at all. " +
+  "Test coverage gaps and convention/lint issues are out of scope — adversarial review and lint/typecheck handle those.";
 
 const SEMANTIC_INSTRUCTIONS = `## Instructions
 
@@ -131,9 +133,11 @@ ${story.description}
 
 ### Acceptance Criteria
 ${acList}
-${customRulesBlock}${priorIterationsBlock}${diffSection}
+${customRulesBlock}${priorIterationsBlock}
 ${SEMANTIC_INSTRUCTIONS}
-${SEMANTIC_OUTPUT_SCHEMA}`;
+${SEMANTIC_OUTPUT_SCHEMA}
+
+${diffSection}`;
 
     return wrapJsonPrompt(core);
   }

--- a/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`ReviewPromptBuilder.buildSemanticReviewPrompt() snapshot stability no custom rules — output is stable 1`] = `
 "IMPORTANT: Your entire response must be a single JSON object or array. Do not explain your reasoning. Do not use markdown formatting. Output ONLY the JSON.
 
-You are a semantic code reviewer with access to the repository files. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.
+You are a semantic code reviewer with access to the repository files. Your job is to walk each acceptance criterion (AC) and judge whether the production code fulfills it — fully, partially, or not at all. Test coverage gaps and convention/lint issues are out of scope — adversarial review and lint/typecheck handle those.
 
 ## Story: Add semantic review
 
@@ -13,12 +13,6 @@ Implement LLM-based semantic review for story diffs.
 ### Acceptance Criteria
 1. LLM is called with story diff
 2. Findings are returned as structured JSON
-## Git Diff (production code only — test files excluded)
-
-\`\`\`diff
-diff --git a/src/review/semantic.ts b/src/review/semantic.ts
-+export async function runSemanticReview() {}\`\`\`
-
 
 ## Instructions
 
@@ -72,13 +66,19 @@ Notes:
 - Omit both for "warning", "info", "unverifiable".
 If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.
 
+## Git Diff (production code only — test files excluded)
+
+\`\`\`diff
+diff --git a/src/review/semantic.ts b/src/review/semantic.ts
++export async function runSemanticReview() {}\`\`\`
+
 YOUR RESPONSE MUST START WITH { OR [ AND END WITH } OR ]. No other text."
 `;
 
 exports[`ReviewPromptBuilder.buildSemanticReviewPrompt() snapshot stability with custom rules — output is stable 1`] = `
 "IMPORTANT: Your entire response must be a single JSON object or array. Do not explain your reasoning. Do not use markdown formatting. Output ONLY the JSON.
 
-You are a semantic code reviewer with access to the repository files. Your job is to verify that the implementation satisfies the story's acceptance criteria (ACs). You are NOT a linter or style checker — lint, typecheck, and convention checks are handled separately.
+You are a semantic code reviewer with access to the repository files. Your job is to walk each acceptance criterion (AC) and judge whether the production code fulfills it — fully, partially, or not at all. Test coverage gaps and convention/lint issues are out of scope — adversarial review and lint/typecheck handle those.
 
 ## Story: Add semantic review
 
@@ -92,12 +92,6 @@ Implement LLM-based semantic review for story diffs.
 ## Additional Review Rules
 1. Do not flag style issues
 2. Verify AC 1 using GREP before flagging
-## Git Diff (production code only — test files excluded)
-
-\`\`\`diff
-diff --git a/src/review/semantic.ts b/src/review/semantic.ts
-+export async function runSemanticReview() {}\`\`\`
-
 
 ## Instructions
 
@@ -150,6 +144,12 @@ Notes:
 - \`acQuote\` is optional advisory metadata for human auditors — not validated.
 - Omit both for "warning", "info", "unverifiable".
 If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.
+
+## Git Diff (production code only — test files excluded)
+
+\`\`\`diff
+diff --git a/src/review/semantic.ts b/src/review/semantic.ts
++export async function runSemanticReview() {}\`\`\`
 
 YOUR RESPONSE MUST START WITH { OR [ AND END WITH } OR ]. No other text."
 `;

--- a/test/unit/prompts/review-builder.test.ts
+++ b/test/unit/prompts/review-builder.test.ts
@@ -110,7 +110,8 @@ describe("ReviewPromptBuilder.buildSemanticReviewPrompt()", () => {
     test("includes semantic reviewer role", () => {
       const result = builder.buildSemanticReviewPrompt(STORY, CONFIG_NO_RULES, { mode: "embedded", diff: DIFF });
       expect(result).toContain("You are a semantic code reviewer");
-      expect(result).toContain("NOT a linter or style checker");
+      // Role names the codebase's role boundary: test-gap + lint/convention are out of scope.
+      expect(result).toContain("Test coverage gaps and convention/lint issues are out of scope");
     });
   });
 


### PR DESCRIPTION
## Summary

- **Semantic role**: switch from confirmatory verb ("verify ... satisfies") to active ("walk each AC and judge — fully, partially, or not at all") and explicitly name test-gap + convention/lint as out-of-scope (matching the codebase role boundary already documented in `src/review/adversarial.ts:1-14`).
- **Semantic template**: move the diff section to the end so instructions + output schema prime the model before it sees the code. This mirrors the adversarial template structure and addresses the most likely mechanical cause of the 86% empty-findings rate observed in post-2026-05-11 dogfood telemetry.
- **Adversarial role**: codify non-overlap with semantic ("Don't re-litigate AC correctness"), replace vague "stopped short" with concrete verbs ("stubbed, faked, or stopped short"), and add a one-sentence preview of the six heuristics so the role primes attention before the full heuristics list is read.

No filter, schema, or AC-grounding rule changes — text + structural reorder only.

## Why

Telemetry from three recent nax dogfood runs (`enhanced-debate-phase-1`, `enhanced-debate-phase-2`, `plan-asymmetric-pipeline`) showed semantic block-rate at 5.6% post-2026-05-11 vs 28.2% pre-2026-05-11, with 86% of semantic reviews returning `{"passed":true,"findings":[]}`. Investigation traced this to two specific gaps:

1. The semantic role's confirmatory framing biased the LLM toward default-pass.
2. The semantic template placed flag-conditions *after* the diff, so the LLM read code before being primed on what to look for. Adversarial already orders instructions-before-diff, which is plausibly why adversarial kept emitting findings while semantic went quiet.

Telemetry analysis also confirmed the part of the block-rate drop that *was* correct rescoping (test-gap findings the codebase explicitly assigns to adversarial). The new role text codifies that boundary in the prompt rather than leaving it implicit.

## Test plan

- [x] Prompt builder unit tests pass; snapshot updated; one assertion updated to track new role text.
- [x] Full prompts + review suite (1269 tests) green.
- [x] Typecheck clean.
- [x] Lint clean (baselines unchanged).
- [x] Section ordering verified at runtime: Story (481) → ACs (524) → Instructions (574) → Schema (2764) → Diff (3769). Diff is now last.
- [ ] Dogfood: re-run a small story post-merge and check that semantic emits findings on partial-satisfaction cases (e.g., AC verb "rejects" but implementation uses Zod strip) while still staying silent on pure test-gap stories.
