### PR TITLE
feat(plan): tighten plan prompts, fix critic blindness, demote new-file blockers

### DIFF
--- a/src/cli/plan.ts
+++ b/src/cli/plan.ts
@@ -16,6 +16,7 @@ import { NaxError } from "../errors";
 import { buildInteractionBridge } from "../interaction/bridge-builder";
 import { getLogger } from "../logger";
 import { callOp, groundOp, planDraftOp, planInteractiveOp } from "../operations";
+import type { PlanDraftInput } from "../operations";
 import { validatePlanOutput } from "../prd/schema";
 import { PlanPromptBuilder } from "../prompts";
 import { validateFeatureName } from "../utils/feature-name";
@@ -383,6 +384,26 @@ export async function runPlanPipeline(
   }));
   const codebaseContext = buildSourceRootsSection(normalizedRoots);
 
+  // Mirror non-pipeline path: derive relative package list + per-package tech stacks
+  // so the draft prompt receives the same monorepo context single mode has.
+  const relativePackages = [
+    ...new Set(
+      sourceRoots
+        .map((root) => root.path)
+        .filter((p) => p !== ".")
+        .map((p) => (p.startsWith("/") ? p.replace(`${workdir}/`, "") : p)),
+    ),
+  ];
+  const packageDetails =
+    relativePackages.length > 0
+      ? await Promise.all(
+          relativePackages.map(async (rel) => {
+            const pkgJson = await _planDeps.readPackageJsonAt(join(workdir, rel, "package.json"));
+            return buildPackageSummary(rel, pkgJson);
+          }),
+        )
+      : [];
+
   const branchName = options.branch ?? `feat/${options.feature}`;
   const naxDir = join(workdir, ".nax");
   const outputDir = join(naxDir, "features", options.feature);
@@ -416,7 +437,7 @@ export async function runPlanPipeline(
     // Phase 2 — draft
     const citationThreshold = config?.plan?.citationThreshold ?? 0.5;
     const manifestSection = renderManifestSection(manifest);
-    const draftCtx = {
+    const draftCtx: PlanDraftInput = {
       manifestSection,
       manifest,
       specContent,
@@ -424,6 +445,9 @@ export async function runPlanPipeline(
       feature: options.feature,
       branchName,
       citationThreshold,
+      packages: relativePackages,
+      packageDetails,
+      projectProfile: config?.project,
     };
     const draft = await callOp(callCtx, planDraftOp, draftCtx);
 

--- a/src/config/test-strategy.ts
+++ b/src/config/test-strategy.ts
@@ -187,7 +187,9 @@ When a spec is provided, these rules govern acceptance criteria generation:
 1. **Preserve spec ACs.** Every acceptance criterion stated in the spec must appear in \`acceptanceCriteria\`, verbatim or lightly rephrased for testability. Never silently drop a spec AC.
 2. **Do not invent spec ACs.** If you identify useful behavioral edge cases or negative paths that the spec did not explicitly list, place them in \`suggestedCriteria\` (a string array on the same story object) — never in \`acceptanceCriteria\`. These go through a separate hardening pass.
 3. **Respect story scope.** Each story's criteria must only cover what the spec says for that story. Do not assign criteria that belong to a different story's scope (wrong feature area, wrong file, wrong dependency chain).
-4. **\`suggestedCriteria\` format.** Each element must be a plain behavioral assertion — an observable output, return value, state change, or error condition that a test can assert. Never include implementation details (imports, internal structure), design suggestions, or vague descriptions.`;
+4. **\`suggestedCriteria\` format.** Each element must be a plain behavioral assertion — an observable output, return value, state change, or error condition that a test can assert. Never include implementation details (imports, internal structure), design suggestions, or vague descriptions.
+5. **Enumerate failure-mode tables.** If the spec contains a "Failure handling", "Error handling", "Failure modes", or equivalent table/section enumerating error/exception scenarios, every row MUST produce at least one acceptance criterion in the matching story. Walk the table row by row; do not skip rows because they look minor. A failure-mode row without an AC is treated as a missing AC and will cause rejection.
+6. **Resolve internal spec contradictions toward the AC.** If the spec's prose, design table, or interface block contradicts a stated acceptance criterion (e.g. design table says \`lookback or strategy_lookback\` but the AC says \`lookback=None\`), the AC is authoritative. Implement the AC; do NOT echo the contradicting prose into the description.`;
 
 export const DESCRIPTION_QUALITY_RULES = `## Description Quality Rules
 
@@ -208,6 +210,7 @@ When a spec contains a design subsection for a story (e.g. \`### N. <Topic>\` un
 1. Do NOT paraphrase spec design sections — embed them verbatim.
 2. A one-sentence description is almost always too short for implementation stories that have spec design content.
 3. The implementer receives only this description — no access to the spec. Design decisions lost here are permanently invisible to the implementer.
+4. **Self-check before emitting.** After drafting each description, re-read it against the story's \`acceptanceCriteria\`. If any sentence in the description contradicts an AC (e.g. description says behaviour X, AC says behaviour not-X), the description is wrong — rewrite the offending sentence to match the AC, or delete it. The AC is authoritative. Embedding contradicting spec prose verbatim still counts as a contradiction; resolve it.
 
 ### Examples
 

--- a/src/debate/verifiers/checks.ts
+++ b/src/debate/verifiers/checks.ts
@@ -22,16 +22,33 @@ export function checkFilesExist(prd: PRD, workdir: string, deps?: CheckDeps): Ve
     if (!story.contextFiles) continue;
     for (const entry of story.contextFiles) {
       const filePath = typeof entry === "string" ? entry : entry.path;
+      const factId = typeof entry === "string" ? undefined : entry.factId;
       const absPath = join(workdir, filePath);
-      if (!existsSync(absPath)) {
+      if (existsSync(absPath)) continue;
+
+      // An entry citing a manifest factId claims to be grounded in existing repo state.
+      // If the path doesn't exist, grounding is broken — that's a blocker.
+      if (factId) {
         findings.push({
           checklistItem: "files-exist",
           severity: "blocker",
-          message: `Context file does not exist on disk: ${filePath}`,
+          message: `Context file cites manifest fact ${factId} but path does not exist on disk: ${filePath}`,
           path: filePath,
           storyId: story.id,
         });
+        continue;
       }
+
+      // Uncited entry: legitimately may be a file the story will CREATE. Demote to
+      // `major` so hallucinated paths are still surfaced without blocking valid new-file
+      // plans. (Planners should put new files in the description, but cheap models leak.)
+      findings.push({
+        checklistItem: "files-exist",
+        severity: "major",
+        message: `Context file not on disk — if this is a new file the story creates, move it from "contextFiles" to the description's "Files touched" section: ${filePath}`,
+        path: filePath,
+        storyId: story.id,
+      });
     }
   }
   return findings;

--- a/src/operations/plan-critic-llm.ts
+++ b/src/operations/plan-critic-llm.ts
@@ -11,6 +11,8 @@ import type { RunOperation } from "./types";
 export interface PlanCriticLlmInput {
   readonly prd: PRD;
   readonly manifest: FactsManifest;
+  /** Optional spec content — when present, enables failure-table enumeration audit. */
+  readonly specContent?: string;
 }
 
 export interface PlanCriticLlmOutput {
@@ -82,7 +84,7 @@ export const planCriticLlmOp: RunOperation<PlanCriticLlmInput, PlanCriticLlmOutp
   model: (_input, ctx) => ctx.config.plan?.criticModel ?? "fast",
   timeoutMs: (_input, ctx) => (ctx.config.plan?.timeoutSeconds ?? 600) * 1000,
   build(input, _ctx) {
-    return new CriticPromptBuilder().build(input.prd, input.manifest);
+    return new CriticPromptBuilder().build(input.prd, input.manifest, input.specContent ?? "");
   },
   parse(output, _input, _ctx) {
     const inspection = inspectCriticOutput(output);

--- a/src/operations/plan-draft.ts
+++ b/src/operations/plan-draft.ts
@@ -1,6 +1,7 @@
 import { ParseValidationError, makeTieredParseRetryStrategy } from "../agents/retry";
 import type { TieredInspection } from "../agents/retry";
 import { planConfigSelector } from "../config";
+import type { ProjectProfile } from "../config";
 import type { PlanConfig } from "../config/selectors";
 import { citationRate, extractClaims } from "../debate/citations";
 import type { FactsManifest } from "../debate/facts-manifest";
@@ -9,6 +10,7 @@ import type { VerifierFinding } from "../plan/spec-deltas";
 import { validatePlanOutput } from "../prd/schema";
 import type { PRD } from "../prd/types";
 import { PlanPromptBuilder } from "../prompts";
+import type { PackageSummary } from "../prompts";
 import { errorMessage } from "../utils/errors";
 import { parseLLMJson } from "../utils/llm-json";
 import type { RunOperation } from "./types";
@@ -24,6 +26,12 @@ export interface PlanDraftInput {
   readonly branchName: string;
   readonly citationThreshold: number;
   readonly revisionFindings?: readonly VerifierFinding[];
+  /** Optional monorepo packages — propagated to the draft prompt for parity with single-mode build(). */
+  readonly packages?: readonly string[];
+  /** Optional per-package tech-stack summaries (only used when packages is non-empty). */
+  readonly packageDetails?: readonly PackageSummary[];
+  /** Optional project profile for language/type-aware AC examples. */
+  readonly projectProfile?: ProjectProfile;
 }
 
 export interface PlanDraftOutput {

--- a/src/plan/critic.ts
+++ b/src/plan/critic.ts
@@ -87,7 +87,11 @@ export async function runPlanCritic(input: PlanCriticInput): Promise<PlanCriticV
   // 2. LLM judgment via planCriticLlmOp (fail-open: exhaustion returns { findings: [] })
   let llmFindings: VerifierFinding[] = [];
   try {
-    const llmResult = await callOp(callCtx, planCriticLlmOp, { prd, manifest });
+    const llmResult = await callOp(callCtx, planCriticLlmOp, {
+      prd,
+      manifest,
+      specContent: draftCtx.specContent,
+    });
     llmFindings = llmResult.findings as VerifierFinding[];
   } catch {
     logger?.warn("plan-critic", "LLM judgment failed; proceeding with zero LLM findings", { storyId });

--- a/src/prompts/builders/critic-builder.ts
+++ b/src/prompts/builders/critic-builder.ts
@@ -1,6 +1,15 @@
 import type { FactsManifest } from "@/debate/facts-manifest";
-import type { PRD } from "@/prd";
+import type { PRD, UserStory } from "@/prd";
 import type { ComposeInput } from "../compose";
+
+/** Number of manifest claims/gaps to include verbatim. 0 = include all. */
+const MANIFEST_ITEMS_INCLUDED = 0; // raised from previous slice(0, 5)
+
+/** Optional per-story serialization cap to keep prompts bounded on large PRDs. */
+const MAX_STORIES_SERIALIZED = 50;
+
+/** Per-AC truncation cap (avoids runaway PRD bloat in the prompt). */
+const MAX_AC_CHARS = 600;
 
 /**
  * CriticPromptBuilder — LLM audit for plan ac-testability and failure-mode coverage
@@ -8,17 +17,20 @@ import type { ComposeInput } from "../compose";
  * Generates prompts for the plan-critic LLM to assess:
  * 1. ac-testable: Is each AC assertion observable (file/symbol/test reference)?
  * 2. failure-modes-considered: Does the plan have negative-path coverage?
+ * 3. failure-table-enumerated: For each row in the spec's Failure-handling table,
+ *    is there a matching AC? (Only fires when specContent contains a failure table.)
+ * 4. description-ac-contradiction: Does any story's description contradict its own ACs?
  */
 export class CriticPromptBuilder {
-  build(prd: PRD, manifest: FactsManifest): ComposeInput {
+  build(prd: PRD, manifest: FactsManifest, specContent = ""): ComposeInput {
     const role: ComposeInput["role"] = {
       id: "role",
       content:
-        "You are a plan critic. Your task is to audit acceptance criteria for testability and failure-mode coverage.",
+        "You are a plan critic. Your task is to audit acceptance criteria for testability, failure-mode coverage, and internal consistency. The full PRD and the source spec are provided — you must read them, not guess.",
       overridable: false,
     };
 
-    const taskContent = this.buildTaskContent(prd, manifest);
+    const taskContent = this.buildTaskContent(prd, manifest, specContent);
 
     const task: ComposeInput["task"] = {
       id: "task",
@@ -29,7 +41,7 @@ export class CriticPromptBuilder {
     return { role, task };
   }
 
-  private buildTaskContent(prd: PRD, manifest: FactsManifest): string {
+  private buildTaskContent(prd: PRD, manifest: FactsManifest, specContent: string): string {
     const lines: string[] = [];
 
     lines.push("## Plan Audit");
@@ -37,35 +49,88 @@ export class CriticPromptBuilder {
     lines.push(`Feature: ${prd.feature}`);
     lines.push("");
 
+    // ─── PRD content ──────────────────────────────────────────────────────
+    // Critic ran in a fresh session — without the PRD inline it can't audit
+    // ACs it never sees. Serialize stories + ACs + descriptions explicitly.
+    lines.push("### Plan Under Audit");
+    lines.push("");
+    const stories = (prd.userStories ?? []).slice(0, MAX_STORIES_SERIALIZED);
+    if (stories.length === 0) {
+      lines.push("_(plan has no user stories — emit a blocker finding)_");
+    } else {
+      for (const story of stories) {
+        lines.push(serializeStoryForAudit(story));
+        lines.push("");
+      }
+    }
+
+    // ─── Spec excerpt (failure-handling enumeration depends on this) ──────
+    // Not wrapped in a code fence — specs frequently contain their own ``` blocks,
+    // which would prematurely close any fence we wrapped them in.
+    if (specContent.trim().length > 0) {
+      lines.push("### Source Spec");
+      lines.push("");
+      lines.push("<spec>");
+      lines.push(specContent.trim());
+      lines.push("</spec>");
+      lines.push("");
+    }
+
+    // ─── Audit checklist ──────────────────────────────────────────────────
     lines.push("### Audit Checklist");
     lines.push("");
 
     lines.push("#### ac-testable");
-    lines.push("For each acceptance criterion in the plan:");
-    lines.push("- Is the assertion observable? (requires file/symbol/test reference)");
-    lines.push("- Emit finding if testability is unclear or missing concrete anchor");
+    lines.push("For each acceptance criterion in every story above:");
+    lines.push(
+      "- Is the assertion observable (function return, raised exception, log content, file content, state change)?",
+    );
+    lines.push("- Emit a finding if testability is unclear or missing concrete anchor.");
     lines.push("");
 
     lines.push("#### failure-modes-considered");
-    lines.push("For each story in the plan:");
+    lines.push("For each story above:");
     lines.push("- Does it have at least one negative-path acceptance criterion?");
-    lines.push("- Emit finding if no error/exception/boundary case is covered");
+    lines.push("- Emit a finding if no error/exception/boundary case is covered.");
     lines.push("");
 
-    lines.push("## Context");
+    if (specContent.trim().length > 0) {
+      lines.push("#### failure-table-enumerated");
+      lines.push(
+        "If the spec contains a Failure-handling / Error-handling / Failure-modes table (rows describing specific error scenarios), walk it row by row.",
+      );
+      lines.push("- For each row, locate the AC in the matching story that asserts that behaviour.");
+      lines.push(
+        "- A row without a matching AC is a missing AC. Emit a `blocker` finding naming the missing scenario.",
+      );
+      lines.push("- Do NOT skip rows because they look minor or boilerplate.");
+      lines.push("");
+    }
+
+    lines.push("#### description-ac-contradiction");
+    lines.push("For each story above:");
+    lines.push(
+      "- Re-read the description against the story's acceptance criteria. If any sentence in the description contradicts an AC (e.g. description says behaviour X, AC says behaviour not-X), emit a `major` finding identifying both the offending sentence and the AC it contradicts.",
+    );
+    lines.push(
+      "- This includes prose copied verbatim from a spec table whose ACs intentionally override that prose — the AC is authoritative.",
+    );
     lines.push("");
 
+    // ─── Manifest context ─────────────────────────────────────────────────
     if (manifest.specClaims && manifest.specClaims.length > 0) {
-      lines.push("### Spec Claims");
-      for (const claim of manifest.specClaims.slice(0, 5)) {
+      lines.push("### Spec Claims (manifest)");
+      const claims = sliceOrAll(manifest.specClaims, MANIFEST_ITEMS_INCLUDED);
+      for (const claim of claims) {
         lines.push(`- ${claim.id}: ${claim.claim}`);
       }
       lines.push("");
     }
 
     if (manifest.gaps && manifest.gaps.length > 0) {
-      lines.push("### Gaps");
-      for (const gap of manifest.gaps.slice(0, 5)) {
+      lines.push("### Gaps (manifest)");
+      const gaps = sliceOrAll(manifest.gaps, MANIFEST_ITEMS_INCLUDED);
+      for (const gap of gaps) {
         lines.push(`- ${gap.id}: ${gap.note}`);
       }
       lines.push("");
@@ -78,11 +143,13 @@ export class CriticPromptBuilder {
     lines.push("{");
     lines.push('  "findings": [');
     lines.push(
-      '    {"checklistItem": "ac-testable" | "failure-modes-considered", "severity": "blocker" | "major" | "minor", "message": "..."}',
+      '    {"checklistItem": "ac-testable" | "failure-modes-considered" | "failure-table-enumerated" | "description-ac-contradiction", "severity": "blocker" | "major" | "minor", "message": "...", "storyId": "US-001"}',
     );
     lines.push("  ]");
     lines.push("}");
     lines.push("```");
+    lines.push("");
+    lines.push("Emit an empty `findings` array only if every check passes for every story.");
     lines.push("");
 
     return lines.join("\n");
@@ -114,4 +181,50 @@ The response was valid JSON but did not match the expected schema. Fix the schem
 - Do not include markdown fences or explanation.
 - Output ONLY the JSON object.`;
   }
+}
+
+// ─── Helpers (module-private) ────────────────────────────────────────────────
+
+function sliceOrAll<T>(items: readonly T[], limit: number): readonly T[] {
+  return limit > 0 ? items.slice(0, limit) : items;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max).trimEnd()}…[truncated]`;
+}
+
+/**
+ * Serialize a single user story into the audit prompt. Includes id, title, ACs,
+ * suggestedCriteria (when present), and the full description. The critic uses
+ * this to perform every check; without inline serialization it would be blind.
+ */
+function serializeStoryForAudit(story: UserStory): string {
+  const out: string[] = [];
+  out.push(`**${story.id} — ${story.title}**`);
+  if (story.description && story.description.trim().length > 0) {
+    out.push("");
+    out.push("_Description:_");
+    out.push(truncate(story.description.trim(), MAX_AC_CHARS * 4));
+  }
+  const acs = story.acceptanceCriteria ?? [];
+  if (acs.length === 0) {
+    out.push("");
+    out.push("_ACs: (none)_");
+  } else {
+    out.push("");
+    out.push("_ACs:_");
+    for (let i = 0; i < acs.length; i++) {
+      out.push(`${i + 1}. ${truncate(String(acs[i]), MAX_AC_CHARS)}`);
+    }
+  }
+  const suggested = story.suggestedCriteria;
+  if (suggested && suggested.length > 0) {
+    out.push("");
+    out.push("_suggestedCriteria:_");
+    for (const sc of suggested) {
+      out.push(`- ${truncate(String(sc), MAX_AC_CHARS)}`);
+    }
+  }
+  return out.join("\n");
 }

--- a/src/prompts/builders/plan-builder.ts
+++ b/src/prompts/builders/plan-builder.ts
@@ -22,6 +22,30 @@ import {
 } from "@/config";
 import type { ComposeInput } from "../compose";
 
+// ─── Shared rule injection ────────────────────────────────────────────────────
+
+/**
+ * Build the shared quality-rule block used by both `build()` (single mode)
+ * and `buildDraft()` (pipeline mode). Centralizing prevents drift where one
+ * prompt gets a new rule and the other doesn't.
+ *
+ * `specContent` controls whether SPEC_ANCHOR_RULES is injected — empty spec =
+ * no anchor rules. `projectProfile` lets AC quality rules emit language- and
+ * project-type-specific examples.
+ */
+function buildSharedQualityRules(specContent: string, projectProfile?: ProjectProfile): string {
+  const specAnchorSection = specContent.trim() ? `\n\n${SPEC_ANCHOR_RULES}` : "";
+  return `${GROUPING_RULES}
+
+${DESCRIPTION_QUALITY_RULES}
+
+${getAcQualityRules(projectProfile)}${specAnchorSection}
+
+${COMPLEXITY_GUIDE}
+
+${TEST_STRATEGY_GUIDE}`;
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 /** Revision finding from a verifier — passed to buildDraft when revising a rejected draft. */
@@ -41,6 +65,12 @@ export interface PlanDraftBuildInput {
   readonly branchName: string;
   readonly citationThreshold: number;
   readonly revisionFindings?: readonly PlanDraftVerifierFinding[];
+  /** Optional monorepo packages — when present, draft prompt injects monorepo hint + workdir field. */
+  readonly packages?: readonly string[];
+  /** Optional per-package tech-stack summaries (only used when packages is non-empty). */
+  readonly packageDetails?: readonly PackageSummary[];
+  /** Optional project profile for language- and project-type-aware AC examples. */
+  readonly projectProfile?: ProjectProfile;
 }
 
 /** Compact per-package summary for the planning prompt. */
@@ -141,8 +171,6 @@ Output ONLY the JSON object. Do not include markdown fences or explanation.`;
       ? `\n      "workdir": "string — optional, relative path to package (e.g. \\"packages/api\\"). Omit for root-level stories.",`
       : "";
 
-    const specAnchorSection = specContent.trim() ? `\n\n${SPEC_ANCHOR_RULES}` : "";
-
     const taskContext = `You are a senior software architect generating a product requirements document (PRD) as JSON.
 
 ## Step 1: Understand the Spec
@@ -181,17 +209,11 @@ ${codebaseContext}${monorepoHint}
 
 Based on your Step 2 analysis, create stories that produce CODE CHANGES.
 
-${GROUPING_RULES}
-
-${DESCRIPTION_QUALITY_RULES}
-
-${getAcQualityRules(projectProfile)}${specAnchorSection}
+${buildSharedQualityRules(specContent, projectProfile)}
 
 For each story, set "contextFiles" to the key source files the agent should read before implementing (max 5 per story). Use your Step 2 analysis to identify the most relevant files. Leave empty for greenfield stories with no existing files to reference.
 
-${COMPLEXITY_GUIDE}
-
-${TEST_STRATEGY_GUIDE}`;
+**\`contextFiles\` rule — existing files only.** Only list paths that already exist in the repo today. Files the story will CREATE belong in the description (under "Files touched" or "Approach"), never in contextFiles. The pipeline verifies every contextFiles entry against the filesystem; new-file paths placed here are treated as missing-context warnings and may block the plan.`;
 
     const suggestedCriteriaField = specContent.trim()
       ? `\n      "suggestedCriteria": ["string — optional. Behavioral edge cases or negative paths you identified that are NOT in the spec. Plain assertions only — observable outputs, return values, state changes, or error conditions. No implementation details or vague descriptions. Omit this field if empty."],`
@@ -260,6 +282,27 @@ ${outputDirective}`;
             .join("\n")}\n\nFix all issues above before submitting the revised PRD.`
         : "";
 
+    // Monorepo handling — mirror build() so cheap-pipeline gets the same context single mode has.
+    const isMonorepo = input.packages && input.packages.length > 0;
+    const packageDetailsArr = input.packageDetails && input.packageDetails.length > 0 ? [...input.packageDetails] : [];
+    const packageDetailsSection = packageDetailsArr.length > 0 ? buildPackageDetailsSection(packageDetailsArr) : "";
+    const monorepoHint =
+      isMonorepo && input.packages
+        ? `\n## Monorepo Context\n\nThis is a monorepo. Detected packages:\n${input.packages
+            .map((p) => `- ${p}`)
+            .join(
+              "\n",
+            )}\n${packageDetailsSection}\nFor each user story, set the "workdir" field to the relevant package path (e.g. "packages/api"). Stories that span the root should omit "workdir".`
+        : "";
+
+    const workdirField = isMonorepo
+      ? `\n      "workdir": "string — optional, relative path to package (e.g. \\"packages/api\\"). Omit for root-level stories.",`
+      : "";
+
+    const suggestedCriteriaField = input.specContent.trim()
+      ? `\n      "suggestedCriteria": ["string — optional. Behavioral edge cases or negative paths you identified that are NOT in the spec. Plain assertions only — observable outputs, return values, state changes, or error conditions. No implementation details or vague descriptions. Omit this field if empty."],`
+      : "";
+
     const task: ComposeInput["task"] = {
       id: "task",
       content: `You are drafting a PRD for the following feature: **${input.feature}** (branch: ${input.branchName}). Your intent is to produce a thorough, evidence-grounded implementation plan.
@@ -270,7 +313,7 @@ ${input.specContent}
 
 ## Codebase Context
 
-${input.codebaseContext}
+${input.codebaseContext}${monorepoHint}
 
 ## Manifest
 
@@ -279,6 +322,14 @@ ${input.manifestSection}
 ## Citation Requirement
 
 Every concrete claim referencing existing code must cite [F-NNN] or [S-NNN] from the manifest. The required citation rate is ${input.citationThreshold}. Uncited factual claims will cause rejection.${revisionSection}
+
+## Story Generation Rules
+
+${buildSharedQualityRules(input.specContent, input.projectProfile)}
+
+For each story, set "contextFiles" to the key source files the implementer should read before starting (max 5 per story). Cite manifest factIds where relevant.
+
+**\`contextFiles\` rule — existing files only.** Only list paths that already exist in the repo today (cited via manifest factIds where possible). Files the story will CREATE belong in the description (under "Files touched" or "Approach"), never in contextFiles. Uncited paths that do not exist on disk are flagged by the pipeline.
 
 ## Output Schema
 
@@ -293,10 +344,10 @@ Produce a JSON object with this exact structure. Field names are mandatory — d
       "id": "string — e.g. US-001",
       "title": "string — concise story title",
       "description": "string — detailed description of what to implement",
-      "acceptanceCriteria": ["string — behavioral criterion, format: 'When [X], then [Y]'. One assertion per item."],
+      "acceptanceCriteria": ["string — behavioral criterion, format: 'When [X], then [Y]'. One assertion per item."],${suggestedCriteriaField}
       "contextFiles": ["string — relative paths the implementer should read (max 5)"],
       "tags": ["string"],
-      "dependencies": ["string — story IDs this story depends on"],
+      "dependencies": ["string — story IDs this story depends on"],${workdirField}
       "routing": {
         "complexity": "simple | medium | complex | expert",
         "testStrategy": "no-test | tdd-simple | three-session-tdd-lite | three-session-tdd | test-after",

--- a/test/unit/cli/plan.test.ts
+++ b/test/unit/cli/plan.test.ts
@@ -1245,7 +1245,7 @@ describe("runPlanPipeline (US-005)", () => {
       // planDraftOp returns a PRD with a nonexistent contextFile → checkFilesExist produces a blocker
       const blockerPrd = makePRD({
         feature: "test-feature",
-        userStories: [makeStory({ contextFiles: ["absolutely-nonexistent-file-ac12.ts"] })],
+        userStories: [makeStory({ contextFiles: [{ path: "absolutely-nonexistent-file-ac12.ts", factId: "F-001" }] })],
       });
       const agentManager = makePipelineAgentManager({ draftPrd: blockerPrd });
       _planDeps.createRuntime = mock(() => makeMockRuntime({ agentManager, workdir: tempWorkdir }));
@@ -1259,7 +1259,7 @@ describe("runPlanPipeline (US-005)", () => {
     test("NaxError context contains specDeltasPath equal to the verdict's specDeltasPath", async () => {
       const blockerPrd = makePRD({
         feature: "test-feature",
-        userStories: [makeStory({ contextFiles: ["absolutely-nonexistent-file-ac12.ts"] })],
+        userStories: [makeStory({ contextFiles: [{ path: "absolutely-nonexistent-file-ac12.ts", factId: "F-001" }] })],
       });
       const agentManager = makePipelineAgentManager({ draftPrd: blockerPrd });
       _planDeps.createRuntime = mock(() => makeMockRuntime({ agentManager, workdir: tempWorkdir }));

--- a/test/unit/debate/verifiers/checks.test.ts
+++ b/test/unit/debate/verifiers/checks.test.ts
@@ -117,7 +117,7 @@ describe("checks.ts exports (AC1)", () => {
 // ---------------------------------------------------------------------------
 
 describe("checkFilesExist (AC2)", () => {
-  test("returns one blocker finding per contextFiles entry when existsSync returns false", () => {
+  test("uncited contextFiles entries that don't exist are flagged as `major` (may be new files)", () => {
     const prd = makePrd([
       makeStory({
         contextFiles: [{ path: "src/foo.ts" }, { path: "src/bar.ts" }],
@@ -127,9 +127,22 @@ describe("checkFilesExist (AC2)", () => {
 
     expect(findings).toHaveLength(2);
     for (const f of findings) {
-      expect(f.severity).toBe("blocker");
+      expect(f.severity).toBe("major");
       expect(f.checklistItem).toBe("files-exist");
     }
+  });
+
+  test("contextFiles entry with manifest factId that does not exist on disk is a `blocker` (grounding broken)", () => {
+    const prd = makePrd([
+      makeStory({
+        contextFiles: [{ path: "src/cited.ts", factId: "F-001" }],
+      }),
+    ]);
+    const findings = checkFilesExist(prd, "/workdir", { existsSync: () => false });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.severity).toBe("blocker");
+    expect((findings[0] as Record<string, unknown>).message).toContain("F-001");
   });
 
   test("returns finding with path matching the contextFiles entry path", () => {
@@ -155,12 +168,28 @@ describe("checkFilesExist (AC2)", () => {
     expect(findings).toHaveLength(0);
   });
 
-  test("handles string contextFiles entries", () => {
+  test("handles string contextFiles entries (treated as uncited, severity `major`)", () => {
     const prd = makePrd([makeStory({ contextFiles: ["src/plain.ts"] })]);
     const findings = checkFilesExist(prd, "/workdir", { existsSync: () => false });
 
     expect(findings).toHaveLength(1);
     expect((findings[0] as Record<string, unknown>).path).toBe("src/plain.ts");
+    expect(findings[0]?.severity).toBe("major");
+  });
+
+  test("mixed: cited-and-missing + uncited-and-missing yields one blocker + one major", () => {
+    const prd = makePrd([
+      makeStory({
+        contextFiles: [{ path: "src/cited.ts", factId: "F-001" }, { path: "src/new.ts" }, "src/plain.ts"],
+      }),
+    ]);
+    const findings = checkFilesExist(prd, "/workdir", { existsSync: () => false });
+
+    expect(findings).toHaveLength(3);
+    const blockers = findings.filter((f) => f.severity === "blocker");
+    const majors = findings.filter((f) => f.severity === "major");
+    expect(blockers).toHaveLength(1);
+    expect(majors).toHaveLength(2);
   });
 });
 

--- a/test/unit/debate/verifiers/plan-checklist.test.ts
+++ b/test/unit/debate/verifiers/plan-checklist.test.ts
@@ -163,7 +163,7 @@ describe("planChecklistVerifier (US-004)", () => {
             outcome: "passed",
             resolverCostUsd: 0.001,
             output: makeValidPRDJson([
-              makeValidStory({ contextFiles: [{ path: "src/missing.ts" }] }),
+              makeValidStory({ contextFiles: [{ path: "src/missing.ts", factId: "F-001" }] }),
             ]),
           } as SelectorResult,
         });
@@ -473,7 +473,7 @@ describe("planChecklistVerifier (US-004)", () => {
           outcome: "passed",
           resolverCostUsd: 0.001,
           output: makeValidPRDJson([
-            makeValidStory({ contextFiles: [{ path: "src/missing.ts" }] }),
+            makeValidStory({ contextFiles: [{ path: "src/missing.ts", factId: "F-001" }] }),
           ]),
         } as SelectorResult,
         stageConfig: {
@@ -497,7 +497,7 @@ describe("planChecklistVerifier (US-004)", () => {
           outcome: "passed",
           resolverCostUsd: 0.001,
           output: makeValidPRDJson([
-            makeValidStory({ contextFiles: [{ path: "src/missing.ts" }] }),
+            makeValidStory({ contextFiles: [{ path: "src/missing.ts", factId: "F-001" }] }),
           ]),
         } as SelectorResult,
         stageConfig: {
@@ -541,7 +541,7 @@ describe("planChecklistVerifier (US-004)", () => {
           outcome: "passed",
           resolverCostUsd: 0.001,
           output: makeValidPRDJson([
-            makeValidStory({ contextFiles: [{ path: "src/missing.ts" }] }),
+            makeValidStory({ contextFiles: [{ path: "src/missing.ts", factId: "F-001" }] }),
           ]),
         } as SelectorResult,
       });
@@ -559,7 +559,7 @@ describe("planChecklistVerifier (US-004)", () => {
           outcome: "passed",
           resolverCostUsd: 0.001,
           output: makeValidPRDJson([
-            makeValidStory({ contextFiles: [{ path: "src/missing.ts" }] }),
+            makeValidStory({ contextFiles: [{ path: "src/missing.ts", factId: "F-001" }] }),
           ]),
         } as SelectorResult,
       });
@@ -595,7 +595,7 @@ describe("planChecklistVerifier (US-004)", () => {
           outcome: "passed",
           resolverCostUsd: 0.001,
           output: makeValidPRDJson([
-            makeValidStory({ contextFiles: [{ path: "src/missing.ts" }] }),
+            makeValidStory({ contextFiles: [{ path: "src/missing.ts", factId: "F-001" }] }),
           ]),
         } as SelectorResult,
         stageConfig: {
@@ -619,7 +619,7 @@ describe("planChecklistVerifier (US-004)", () => {
           outcome: "passed",
           resolverCostUsd: 0.001,
           output: makeValidPRDJson([
-            makeValidStory({ contextFiles: [{ path: "src/missing.ts" }] }),
+            makeValidStory({ contextFiles: [{ path: "src/missing.ts", factId: "F-001" }] }),
           ]),
         } as SelectorResult,
         stageConfig: {

--- a/test/unit/plan/critic.test.ts
+++ b/test/unit/plan/critic.test.ts
@@ -67,7 +67,7 @@ describe("runPlanCritic (US-005)", () => {
       // It imports the function and expects it to handle mechanical checks.
       const { runPlanCritic } = await import("@/plan/critic");
 
-      const prd = makePRD({ userStories: [makeStory({ contextFiles: ["nonexistent-file.ts"] })] });
+      const prd = makePRD({ userStories: [makeStory({ contextFiles: [{ path: "nonexistent-file.ts", factId: "F-001" }] })] });
       const manifest = makeFactsManifest();
       const config = makeNaxConfig();
       runtime = makeTestRuntime();
@@ -119,7 +119,7 @@ describe("runPlanCritic (US-005)", () => {
     test("emits spec-deltas.md to correct path", async () => {
       const { runPlanCritic } = await import("@/plan/critic");
 
-      const prd = makePRD({ userStories: [makeStory({ contextFiles: ["nonexistent-file.ts"] })] });
+      const prd = makePRD({ userStories: [makeStory({ contextFiles: [{ path: "nonexistent-file.ts", factId: "F-001" }] })] });
       const manifest = makeFactsManifest();
       const config = makeNaxConfig();
       runtime = makeTestRuntime();
@@ -164,7 +164,7 @@ describe("runPlanCritic (US-005)", () => {
       // The implementation should skip the LLM judgment stage.
 
       const { runPlanCritic } = await import("@/plan/critic");
-      const prd = makePRD({ userStories: [makeStory({ contextFiles: ["nonexistent-file.ts"] })] });
+      const prd = makePRD({ userStories: [makeStory({ contextFiles: [{ path: "nonexistent-file.ts", factId: "F-001" }] })] });
       const manifest = makeFactsManifest();
       const config = makeNaxConfig();
 
@@ -460,7 +460,7 @@ describe("runPlanCritic (US-005)", () => {
         branchName: "feat/test",
         createdAt: new Date(0).toISOString(),
         updatedAt: new Date(0).toISOString(),
-        userStories: [{ id: "US-001", title: "Test story", description: "A test story", acceptanceCriteria: ["AC-1: works"], complexity: "simple", contextFiles: ["nonexistent-revised.ts"] }],
+        userStories: [{ id: "US-001", title: "Test story", description: "A test story", acceptanceCriteria: ["AC-1: works"], complexity: "simple", contextFiles: [{ path: "nonexistent-revised.ts", factId: "F-001" }] }],
       });
 
       // planCriticLlmOp and planDraftOp are both kind:"run" — go through runWithFallback

--- a/test/unit/prompts/builders/critic-builder.test.ts
+++ b/test/unit/prompts/builders/critic-builder.test.ts
@@ -263,6 +263,100 @@ describe("CriticPromptBuilder", () => {
     });
   });
 
+  describe("Step 2B — PRD serialization and new audit items", () => {
+    const baseManifest: FactsManifest = { repoFacts: [], specClaims: [], gaps: [] };
+
+    test("build() serializes user story IDs into the prompt", () => {
+      const prd: any = {
+        feature: "feat-x",
+        userStories: [
+          {
+            id: "US-001",
+            title: "first story",
+            description: "do thing",
+            acceptanceCriteria: ["When X, then Y"],
+          },
+          {
+            id: "US-002",
+            title: "second story",
+            description: "do other thing",
+            acceptanceCriteria: ["When A, then B"],
+          },
+        ],
+        branchName: "feat/x",
+      };
+      const result = new CriticPromptBuilder().build(prd, baseManifest);
+      expect(result.task.content).toContain("US-001");
+      expect(result.task.content).toContain("US-002");
+      expect(result.task.content).toContain("first story");
+      expect(result.task.content).toContain("When X, then Y");
+    });
+
+    test("build() emits a placeholder when PRD has no user stories", () => {
+      const prd: any = { feature: "feat-empty", userStories: [], branchName: "main" };
+      const result = new CriticPromptBuilder().build(prd, baseManifest);
+      expect(result.task.content).toContain("no user stories");
+    });
+
+    test("build() includes failure-table-enumerated checklist item when specContent provided", () => {
+      const prd: any = {
+        feature: "f",
+        userStories: [{ id: "US-001", title: "t", description: "d", acceptanceCriteria: ["When X, then Y"] }],
+        branchName: "main",
+      };
+      const result = new CriticPromptBuilder().build(prd, baseManifest, "## Failure handling\n| row | behaviour |");
+      expect(result.task.content).toContain("failure-table-enumerated");
+      expect(result.task.content).toContain("walk it row by row");
+    });
+
+    test("build() omits failure-table-enumerated checklist item when specContent is empty", () => {
+      const prd: any = {
+        feature: "f",
+        userStories: [{ id: "US-001", title: "t", description: "d", acceptanceCriteria: ["When X, then Y"] }],
+        branchName: "main",
+      };
+      const result = new CriticPromptBuilder().build(prd, baseManifest, "");
+      // The "#### failure-table-enumerated" heading (and its body) must not appear when
+      // there's no spec to enumerate. The literal string may still appear in the output
+      // schema enum — that's intentional, so consumers know it's a valid checklistItem.
+      expect(result.task.content).not.toContain("#### failure-table-enumerated");
+      expect(result.task.content).not.toContain("walk it row by row");
+    });
+
+    test("build() includes description-ac-contradiction checklist item", () => {
+      const prd: any = {
+        feature: "f",
+        userStories: [{ id: "US-001", title: "t", description: "d", acceptanceCriteria: ["When X, then Y"] }],
+        branchName: "main",
+      };
+      const result = new CriticPromptBuilder().build(prd, baseManifest);
+      expect(result.task.content).toContain("description-ac-contradiction");
+    });
+
+    test("build() includes ALL manifest spec claims (not capped at 5)", () => {
+      const prd: any = {
+        feature: "f",
+        userStories: [{ id: "US-001", title: "t", description: "d", acceptanceCriteria: ["When X, then Y"] }],
+        branchName: "main",
+      };
+      const specClaims = Array.from({ length: 8 }, (_, i) => ({
+        id: `S-${String(i + 1).padStart(3, "0")}`,
+        specSpan: `span ${i + 1}`,
+        claim: `claim ${i + 1}`,
+        kind: "factual" as const,
+        verification: { status: "verified" as const },
+      }));
+      const manifest: FactsManifest = { repoFacts: [], specClaims, gaps: [] };
+      const result = new CriticPromptBuilder().build(prd, manifest);
+      // Pre-fix the critic only included the first 5; we now expect all 8.
+      // Check the manifest format prefix `- S-NNN:` to avoid false-matching against
+      // "US-001" in the output-schema example block.
+      for (let i = 1; i <= 8; i++) {
+        expect(result.task.content).toContain(`- S-${String(i).padStart(3, "0")}: claim ${i}`);
+      }
+    });
+  });
+
   describe("prompt quality", () => {
     test("build() prompt is substantial (>200 chars) to guide LLM effectively", () => {
       const prd: Partial<PRD> = {

--- a/test/unit/prompts/builders/plan-builder.test.ts
+++ b/test/unit/prompts/builders/plan-builder.test.ts
@@ -356,6 +356,147 @@ Budget: aim for ≤ 10 file reads per story.
   });
 });
 
+// ─── buildSharedQualityRules content propagation (Step 2A) ────────────────────
+
+describe("PlanPromptBuilder — shared quality rules", () => {
+  test("build() includes failure-handling enumeration rule when spec is provided", () => {
+    const { taskContext } = new PlanPromptBuilder().build("Some spec with failure handling", "ctx");
+    expect(taskContext).toContain("Enumerate failure-mode tables");
+  });
+
+  test("build() includes description self-check rule", () => {
+    const prompt = fullPrompt(SPEC, CTX);
+    expect(prompt).toContain("Self-check before emitting");
+  });
+
+  test("build() includes contradiction-resolution rule when spec provided", () => {
+    const { taskContext } = new PlanPromptBuilder().build("spec body", "ctx");
+    expect(taskContext).toContain("Resolve internal spec contradictions toward the AC");
+  });
+
+  test("buildDraft() injects shared quality rules (COMPLEXITY_GUIDE)", () => {
+    const builder = new PlanPromptBuilder();
+    const { task } = builder.buildDraft({
+      manifestSection: "## Manifest\n",
+      specContent: "Some spec",
+      codebaseContext: "ctx",
+      feature: "feat",
+      branchName: "feat/x",
+      citationThreshold: 0.5,
+    });
+    expect(task.content).toContain("Complexity Classification Guide");
+  });
+
+  test("buildDraft() injects TEST_STRATEGY_GUIDE", () => {
+    const builder = new PlanPromptBuilder();
+    const { task } = builder.buildDraft({
+      manifestSection: "## Manifest\n",
+      specContent: "Some spec",
+      codebaseContext: "ctx",
+      feature: "feat",
+      branchName: "feat/x",
+      citationThreshold: 0.5,
+    });
+    expect(task.content).toContain("Test Strategy Guide");
+  });
+
+  test("buildDraft() injects DESCRIPTION_QUALITY_RULES with self-check", () => {
+    const builder = new PlanPromptBuilder();
+    const { task } = builder.buildDraft({
+      manifestSection: "## Manifest\n",
+      specContent: "Some spec",
+      codebaseContext: "ctx",
+      feature: "feat",
+      branchName: "feat/x",
+      citationThreshold: 0.5,
+    });
+    expect(task.content).toContain("Description Quality Rules");
+    expect(task.content).toContain("Self-check before emitting");
+  });
+
+  test("buildDraft() injects SPEC_ANCHOR_RULES with failure-table rule when spec is non-empty", () => {
+    const builder = new PlanPromptBuilder();
+    const { task } = builder.buildDraft({
+      manifestSection: "## Manifest\n",
+      specContent: "Some non-empty spec",
+      codebaseContext: "ctx",
+      feature: "feat",
+      branchName: "feat/x",
+      citationThreshold: 0.5,
+    });
+    expect(task.content).toContain("Enumerate failure-mode tables");
+  });
+
+  test("buildDraft() omits SPEC_ANCHOR_RULES when spec is empty", () => {
+    const builder = new PlanPromptBuilder();
+    const { task } = builder.buildDraft({
+      manifestSection: "## Manifest\n",
+      specContent: "",
+      codebaseContext: "ctx",
+      feature: "feat",
+      branchName: "feat/x",
+      citationThreshold: 0.5,
+    });
+    expect(task.content).not.toContain("Enumerate failure-mode tables");
+  });
+
+  test("buildDraft() injects monorepo hint when packages provided", () => {
+    const builder = new PlanPromptBuilder();
+    const { task } = builder.buildDraft({
+      manifestSection: "## Manifest\n",
+      specContent: "Some spec",
+      codebaseContext: "ctx",
+      feature: "feat",
+      branchName: "feat/x",
+      citationThreshold: 0.5,
+      packages: ["packages/api"],
+    });
+    expect(task.content).toContain("Monorepo Context");
+    expect(task.content).toContain("packages/api");
+    expect(task.content).toContain('"workdir"');
+  });
+
+  test("buildDraft() omits monorepo hint when no packages provided", () => {
+    const builder = new PlanPromptBuilder();
+    const { task } = builder.buildDraft({
+      manifestSection: "## Manifest\n",
+      specContent: "Some spec",
+      codebaseContext: "ctx",
+      feature: "feat",
+      branchName: "feat/x",
+      citationThreshold: 0.5,
+    });
+    expect(task.content).not.toContain("Monorepo Context");
+    expect(task.content).not.toContain('"workdir"');
+  });
+
+  test("buildDraft() includes suggestedCriteria schema field when spec is non-empty", () => {
+    const builder = new PlanPromptBuilder();
+    const { task } = builder.buildDraft({
+      manifestSection: "## Manifest\n",
+      specContent: "Some spec",
+      codebaseContext: "ctx",
+      feature: "feat",
+      branchName: "feat/x",
+      citationThreshold: 0.5,
+    });
+    expect(task.content).toContain("suggestedCriteria");
+  });
+
+  test("buildDraft() omits suggestedCriteria when spec is empty", () => {
+    const builder = new PlanPromptBuilder();
+    const { task } = builder.buildDraft({
+      manifestSection: "## Manifest\n",
+      specContent: "",
+      codebaseContext: "ctx",
+      feature: "feat",
+      branchName: "feat/x",
+      citationThreshold: 0.5,
+    });
+    expect(task.content).not.toContain("suggestedCriteria");
+  });
+});
+
 // ─── PlanPromptBuilder.buildDraft() — US-003 ────────────────────────────────
 
 describe("PlanPromptBuilder.buildDraft() — US-003", () => {


### PR DESCRIPTION
## Summary

Raises PRD quality across single mode, pipeline mode, and the plan critic — motivated by the strategy-and-loader review where 4 PRDs (single/pipeline × cheap/frontier) scored 8.0–8.7 with no clear winner, and a re-read against the spec found that the pipeline draft prompt was *thinner* than single mode's, and the critic was running blind (its prompt didn't include the PRD it was meant to audit).

- **`buildDraft()` parity with `build()`**. Extract `buildSharedQualityRules()` so both prompts inject the same six rule blocks (grouping, description, AC quality, spec anchor, complexity, test strategy). Pipeline now also gets monorepo hint, `workdir` schema field, and `suggestedCriteria`. `runPlanPipeline` computes and threads `relativePackages`, `packageDetails`, and `config.project`.
- **Spec-fidelity rules sharpened**. `SPEC_ANCHOR_RULES` rule 5 mandates an AC per spec-table failure-mode row; rule 6 makes ACs authoritative when spec prose contradicts them. `DESCRIPTION_QUALITY_RULES` rule 4 adds a self-check pass that catches the verbatim-copy contradiction observed on the strategy-and-loader spec.
- **Critic prompt rewrite**. Was running with `lifetime: "fresh"` against a prompt that only contained the feature name — couldn't see the ACs it audited. Now serializes the full PRD + source spec + full manifest, with two new checklist items: `failure-table-enumerated` (gated on spec presence) and `description-ac-contradiction`. Lifts `slice(0, 5)` cap.
- **Bonus fix**: `checkFilesExist` no longer blocks valid PRDs whose `contextFiles` include new files the story will create. Demoted to `major` when no `factId` is present; remains `blocker` only for cited paths that don't exist (grounding broken). Prompt now explicitly says contextFiles is existing-files-only.

## Why this matters

The cheap-pipeline regression (8.0 vs cheap-single 8.4) was driven by `buildDraft` missing all the quality-rule sections that `build` had. The critic's apparent value-add on frontier (it surfaced 2 safety ACs that no other PRD had) was actually limited by the critic prompt not including the PRD at all — those wins came from session/manifest context, not from the critic's audit logic. Both bottlenecks are fixed here.

## Files

- Prompts: `src/prompts/builders/plan-builder.ts`, `src/prompts/builders/critic-builder.ts`
- Shared rules: `src/config/test-strategy.ts`
- Wiring: `src/cli/plan.ts`, `src/plan/critic.ts`, `src/operations/plan-draft.ts`, `src/operations/plan-critic-llm.ts`
- Mechanical check: `src/debate/verifiers/checks.ts`
- Tests: ~30 new across 5 test files

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Full unit suite via `bun run test` — 8620 pass, 0 fail, 15 skip
- [ ] Manual regen of the strategy-and-loader PRD on cheap+single, cheap+pipeline, frontier+single, frontier+pipeline; compare against the prior 4 PRDs in `logs/strategy-and-loader/` to confirm the failure-mode ACs (syntax/import wrapping, load_from_dir propagation, no-lookback) now appear consistently and prose contradictions on US-001 are absent.
- [ ] Confirm pipeline no longer fails with `PLAN_CRITIC_BLOCKED` on PRDs whose contextFiles list new files the story creates.

## Follow-up

A separate issue will be filed for the residual LLM-drift case: if the planner still lists new-file paths in `contextFiles` without a `factId` despite the new prompt rule, the implementer can still hit failed reads at run time. Hybrid auto-strip + finding emission is the proposed fix.