### PR TITLE
fix(acp): thread retryable flag from SessionTurnError through to AdapterFailure

### DIFF
--- a/scripts/baselines/deep-relatives-baseline.json
+++ b/scripts/baselines/deep-relatives-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 3145,
-  "updatedAt": "2026-05-13T12:05:20.326Z",
+  "count": 3143,
+  "updatedAt": "2026-05-14T02:39:58.295Z",
   "byFile": {
     "src/context/engine/effectiveness.ts": 2,
     "src/context/engine/providers/feature-context.ts": 6,
@@ -53,7 +53,6 @@
     "src/agents/acp/spawn-client.ts": 3,
     "src/agents/acp/adapter-lifecycle.ts": 4,
     "src/agents/acp/adapter-session-types.ts": 2,
-    "src/agents/acp/adapter.ts": 2,
     "src/agents/shared/env.ts": 1,
     "src/agents/shared/validation.ts": 1,
     "src/agents/shared/types-extended.ts": 5,

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -575,14 +575,17 @@ export class AcpAgentAdapter implements AgentAdapter {
     }
 
     if (lastResponse?.stopReason === "error") {
-      // Surface the transport fact (`cancelled`) without classifying _why_.
+      // Surface the transport facts (`cancelled`, `retryable`) without classifying _why_.
       // SessionManager catches SessionTurnError and maps `cancelled: true`
       // to the `fail-stale` policy outcome.
+      // build-hop-callback maps `retryable: true` to AdapterFailure.retriable so
+      // manager-run's retry loop can apply the higher sessionErrorRetryableMaxRetries cap.
       throw new SessionTurnError(
         lastResponse.cancelled
           ? "Agent session ended with stop reason: error (externally cancelled)"
           : "Agent session ended with stop reason: error",
         lastResponse.cancelled === true,
+        lastResponse.retryable === true,
       );
     }
 

--- a/src/agents/acp/adapter.ts
+++ b/src/agents/acp/adapter.ts
@@ -11,8 +11,8 @@
  * See: docs/specs/acp-session-mode.md
  */
 
-import { getSafeLogger } from "../../logger";
-import type { ProtocolIds } from "../../runtime/protocol-types";
+import { getSafeLogger } from "@/logger";
+import type { ProtocolIds } from "@/runtime/protocol-types";
 import type { TokenUsage } from "../cost";
 import { addTokenUsage, estimateCostFromTokenUsage } from "../cost";
 import type { ITokenUsageMapper } from "../cost";

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -447,6 +447,7 @@ export class SessionTurnError extends Error {
   constructor(
     message: string,
     public readonly cancelled: boolean,
+    public readonly retryable: boolean = false,
   ) {
     super(message);
     this.name = "SessionTurnError";

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -7,7 +7,7 @@
 
 import { buildRunInteractionHandler } from "../agents/acp/adapter-output";
 import type { AgentRunRequest, IAgentManager } from "../agents/manager-types";
-import { SessionFailureError } from "../agents/types";
+import { SessionFailureError, SessionTurnError } from "../agents/types";
 import type { AgentResult, AgentRunOptions, TurnResult } from "../agents/types";
 import { resolveModelForAgent } from "../config";
 import type { NaxConfig } from "../config";
@@ -249,6 +249,7 @@ export function buildHopCallback(
       // swap policy sees the real outcome (rate-limit, auth, quota) instead of
       // a generic "fail-adapter-error" reclassification. Mirrors session-run-hop.ts.
       const sessionFailure = err instanceof SessionFailureError ? err.adapterFailure : undefined;
+      const turnError = err instanceof SessionTurnError ? err : undefined;
       const errMessage = err instanceof Error ? err.message : String(err);
       return {
         result: {
@@ -264,7 +265,7 @@ export function buildHopCallback(
           adapterFailure: sessionFailure ?? {
             category: "availability",
             outcome: "fail-adapter-error",
-            retriable: false,
+            retriable: turnError?.retryable ?? false,
             message: errMessage.slice(0, 500),
           },
         },

--- a/src/runtime/session-run-hop.ts
+++ b/src/runtime/session-run-hop.ts
@@ -1,6 +1,6 @@
 import { buildContextToolPreamble, buildRunInteractionHandler } from "../agents/acp/adapter";
 import type { IAgentManager } from "../agents/manager-types";
-import { SessionFailureError } from "../agents/types";
+import { SessionFailureError, SessionTurnError } from "../agents/types";
 import type { AgentResult, AgentRunOptions } from "../agents/types";
 import type { ISessionManager } from "../session";
 
@@ -88,20 +88,22 @@ export function createSessionRunHop(
       };
     } catch (err) {
       const sessionFailure = err instanceof SessionFailureError ? err.adapterFailure : undefined;
+      const turnError = err instanceof SessionTurnError ? err : undefined;
+      const errMessage = err instanceof Error ? err.message : String(err);
       return {
         prompt,
         result: {
           success: false,
           exitCode: 1,
-          output: err instanceof Error ? err.message : String(err),
+          output: errMessage,
           rateLimited: sessionFailure?.outcome === "fail-rate-limit",
           durationMs: Date.now() - startMs,
           estimatedCostUsd: 0,
           adapterFailure: sessionFailure ?? {
-            category: "quality",
-            outcome: "fail-unknown",
-            retriable: false,
-            message: String(err).slice(0, 500),
+            category: "availability",
+            outcome: "fail-adapter-error",
+            retriable: turnError?.retryable ?? false,
+            message: errMessage.slice(0, 500),
           },
         },
       };


### PR DESCRIPTION
## Summary

**Bug:** When acpx exits with `QUEUE_DISCONNECTED_BEFORE_COMPLETION` (or any session error marked `retryable: true`), the flag was silently dropped across two code paths, causing the retry loop to apply the non-retriable cap (1 retry) instead of `sessionErrorRetryableMaxRetries` (3).

**Root cause:** `AcpSessionResponse.retryable` (parsed correctly from the JSON-RPC error) was not threaded through `SessionTurnError` → `AdapterFailure` → `manager-run.ts`'s retry loop.

## Changes

1. **src/agents/types.ts** — Add `retryable: boolean = false` param to `SessionTurnError` (backward-compatible, default false)
2. **src/agents/acp/adapter.ts** — Pass `lastResponse.retryable === true` to the throw
3. **src/operations/build-hop-callback.ts** — Extract `SessionTurnError` and set `retriable: turnError?.retryable ?? false` on `AdapterFailure`
4. **src/runtime/session-run-hop.ts** — Apply same fix to the parallel run-kind ops path, plus correct `outcome: "fail-unknown"` → `"fail-adapter-error"` and `category: "quality"` → `"availability"`

The existing `manager-run.ts` retry loop (lines 115–128) already has the conditional logic to use `maxRetriable` (3) vs `maxNonRetriable` (1) — it just needed the correct `retriable` signal to reach it.

## Test Plan

- [x] `bun run typecheck` — passes
- [x] `timeout 60 bun test test/unit/session/ test/unit/runtime/ test/unit/agents/ test/unit/operations/ --timeout=10000` — 1291 tests pass
- [x] Code review via feature-dev:code-reviewer — verified signal path end-to-end

## Notes

- **No breaking changes** — `SessionTurnError` constructor param is optional with default `false`
- **No new abstractions** — only threading an existing signal through the call stack
- **Two code paths fixed** — `build-hop-callback.ts` (complete-kind) and `session-run-hop.ts` (run-kind via debate fan-out / `runAsSession`)