### PR TITLE
Add refine plan mode for two-turn self-audited PRD generation

### DIFF
--- a/.claude/rules/adapter-wiring.md
+++ b/.claude/rules/adapter-wiring.md
@@ -40,7 +40,7 @@ paths:
 
 | Role | Dispatch |
 |:---|:---|
-| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `reviewer-semantic`, `reviewer-adversarial`, `acceptance-gen`, `plan`, `plan-draft`, `plan-revise`, `plan-critic` | `callOp` run-kind |
+| `main` *(default)*, `test-writer`, `verifier`, `implementer`, `diagnose`, `source-fix`, `test-fix`, `reviewer-semantic`, `reviewer-adversarial`, `acceptance-gen`, `plan`, `plan-draft`, `plan-revise`, `plan-critic`, `plan-refine` | `callOp` run-kind |
 | `decompose`, `refine`, `fix-gen`, `auto` | `callOp` complete-kind |
 | `synthesis`, `judge` | `agentManager.completeAs` |
 | `` debate-${string} `` | `agentManager.runAsSession` |

--- a/.nax/features/plan-refine-mode/.nax-acceptance.test.ts
+++ b/.nax/features/plan-refine-mode/.nax-acceptance.test.ts
@@ -1,4 +1,9 @@
-'", async () => {
+import { describe, expect, test } from "bun:test";
+
+describe("AC-ERROR: plan refine continuation prompt validity", () => {
+  test("buildRefineContinuation does not include JSON code fences", async () => {
     const { PlanPromptBuilder } = await import("../../../src/prompts/builders/plan-builder");
     const prompt = new PlanPromptBuilder().buildRefineContinuation("/path/to/prd.json");
-    expect(prompt).not.toContain("
+    expect(prompt).not.toContain("```json");
+  });
+});

--- a/.nax/features/plan-refine-mode/.nax-acceptance.test.ts
+++ b/.nax/features/plan-refine-mode/.nax-acceptance.test.ts
@@ -1,0 +1,4 @@
+'", async () => {
+    const { PlanPromptBuilder } = await import("../../../src/prompts/builders/plan-builder");
+    const prompt = new PlanPromptBuilder().buildRefineContinuation("/path/to/prd.json");
+    expect(prompt).not.toContain("

--- a/.nax/features/plan-refine-mode/.nax-suggested.test.ts
+++ b/.nax/features/plan-refine-mode/.nax-suggested.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, mock, test } from "bun:test";
+import { NaxConfigSchema } from "../../../src/config/schemas";
+import { resolvePlanMode } from "../../../src/cli/plan-command";
+import { PlanPromptBuilder } from "../../../src/prompts/builders/plan-builder";
+import { planRefineOp } from "../../../src/operations/plan-refine";
+import { RefinePlanStrategy, _refinePlanDeps } from "../../../src/plan/strategies/refine";
+import { createPlanStrategy } from "../../../src/plan/strategies/factory";
+import { SinglePlanStrategy } from "../../../src/plan/strategies/single";
+import { PipelinePlanStrategy } from "../../../src/plan/strategies/pipeline";
+import { KNOWN_SESSION_ROLES } from "../../../src/runtime/session-role";
+import type { PlanModeContext } from "../../../src/plan/strategies/types";
+import type { InteractionBridge } from "../../../src/interaction/bridge-builder";
+import type { NaxRuntime } from "../../../src/runtime";
+import { makeMockAgentManager } from "@test/helpers";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeRuntime(closeImpl?: () => Promise<void>): NaxRuntime {
+  return {
+    packages: { resolve: () => ({}) },
+    agentManager: makeMockAgentManager({ getDefaultAgent: "claude" }),
+    close: closeImpl ?? (async () => {}),
+  } as unknown as NaxRuntime;
+}
+
+function makeCtx(overrides: Partial<PlanModeContext> = {}): PlanModeContext {
+  return {
+    workdir: "/tmp/workdir",
+    naxDir: "/tmp/workdir/.nax",
+    outputDir: "/tmp/workdir/.nax/features/test-feature",
+    outputPath: "/tmp/workdir/.nax/features/test-feature/prd.json",
+    specContent: "# Feature Spec",
+    codebaseContext: "Codebase context for testing",
+    normalizedRoots: [],
+    relativePackages: ["packages/api"],
+    packageDetails: [],
+    projectName: "test-project",
+    branchName: "feat/test-feature",
+    timeoutSeconds: 30,
+    config: { timeoutSeconds: 30 } as never,
+    fullConfig: { agent: { maxInteractionTurns: 5 } } as never,
+    options: { from: "/tmp/spec.md", feature: "test-feature" },
+    runtime: makeRuntime(),
+    interactionChain: null,
+    interactionBridge: {} as InteractionBridge,
+    deps: {
+      readFile: async () => null,
+      writeFile: async () => {},
+      mkdirp: async () => {},
+      existsSync: () => false,
+      readPackageJson: async () => null,
+      readPackageJsonAt: async () => null,
+      scanSourceRoots: async () => [],
+      spawnSync: () => ({ stdout: Buffer.from(""), exitCode: 0 }),
+      initInteractionChain: async () => null,
+      createInteractionBridge: () => ({
+        detectQuestion: async () => false,
+        onQuestionDetected: async () => "",
+      }),
+      createDebateRunner: () => ({}) as never,
+    },
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// US-001: Config Schema and Mode Resolution
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("US-001: Config schema and mode resolution", () => {
+  test("AC-1: resolvePlanMode({ plan: { mode: 'pipeline' } }) returns 'pipeline'", () => {
+    const config = { plan: { mode: "pipeline" as const } };
+    const result = resolvePlanMode(config as any);
+    expect(result).toBe("pipeline");
+  });
+
+  test("AC-2: resolvePlanMode({ plan: { mode: 'debate' } }) returns 'debate'", () => {
+    const config = { plan: { mode: "debate" as const } };
+    const result = resolvePlanMode(config as any);
+    expect(result).toBe("debate");
+  });
+
+  test("AC-3: NaxConfigSchema.safeParse({ plan: { mode: 'single' } }) returns success: true", () => {
+    const result = NaxConfigSchema.safeParse({ plan: { mode: "single" } });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// US-002: Refine Continuation Prompt
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("US-002: Refine continuation prompt", () => {
+  test("AC-4: buildRefineContinuation does NOT contain 'failure-table-enumerated'", () => {
+    const builder = new PlanPromptBuilder();
+    const result = builder.buildRefineContinuation("/path/to/prd.json");
+    expect(result.includes("failure-table-enumerated")).toBe(false);
+  });
+
+  test("AC-5: buildRefineContinuation with different paths returns different strings", () => {
+    const builder = new PlanPromptBuilder();
+    const pathA = "/path/to/prd-a.json";
+    const pathB = "/path/to/prd-b.json";
+    const resultA = builder.buildRefineContinuation(pathA);
+    const resultB = builder.buildRefineContinuation(pathB);
+    expect(resultA).not.toBe(resultB);
+  });
+
+  test("AC-6: buildRefineContinuation includes explicit instruction to write file before confirming", () => {
+    const builder = new PlanPromptBuilder();
+    const filePath = "/output/prd.json";
+    const result = builder.buildRefineContinuation(filePath);
+    expect(result.includes("Write the revised PRD to this file path")).toBe(true);
+    expect(result.includes(filePath)).toBe(true);
+    expect(result.includes("reply with a brief text confirmation")).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// US-003: planRefineOp Operation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("US-003: planRefineOp operation", () => {
+  test("AC-7: planRefineOp.retry is a RetryStrategy with maxAttempts === 3", () => {
+    const input = {
+      specContent: "spec",
+      codebaseContext: "context",
+      featureName: "test-feature",
+      branchName: "feat/test",
+      outputPath: "/tmp/prd.json",
+    };
+    const ctx = { config: { plan: {} } } as any;
+    const retryStrategy = planRefineOp.retry(input, ctx);
+    expect(retryStrategy).toBeDefined();
+    expect(retryStrategy.maxAttempts).toBe(3);
+  });
+
+  test("AC-8: planRefineOp.fileOutput(input) returns input.outputPath", () => {
+    const input = {
+      specContent: "spec",
+      codebaseContext: "context",
+      featureName: "feature",
+      branchName: "branch",
+      outputPath: "/tmp/my-prd.json",
+    };
+    const result = planRefineOp.fileOutput(input);
+    expect(result).toBe(input.outputPath);
+  });
+
+  test("AC-9a: planRefineOp.verify returns null when parsed.userStories is empty", async () => {
+    const parsed = { userStories: [] };
+    const input = {
+      specContent: "spec",
+      codebaseContext: "context",
+      featureName: "feature",
+      branchName: "branch",
+      outputPath: "/tmp/prd.json",
+    };
+    const result = await planRefineOp.verify(parsed, input, {} as any);
+    expect(result).toBeNull();
+  });
+
+  test("AC-9b: planRefineOp.verify returns null when parsed has no userStories", async () => {
+    const parsed = {};
+    const input = {
+      specContent: "spec",
+      codebaseContext: "context",
+      featureName: "feature",
+      branchName: "branch",
+      outputPath: "/tmp/prd.json",
+    };
+    const result = await planRefineOp.verify(parsed, input, {} as any);
+    expect(result).toBeNull();
+  });
+
+  test("AC-9c: planRefineOp.verify returns null when parsed.userStories is undefined", async () => {
+    const parsed = { userStories: undefined };
+    const input = {
+      specContent: "spec",
+      codebaseContext: "context",
+      featureName: "feature",
+      branchName: "branch",
+      outputPath: "/tmp/prd.json",
+    };
+    const result = await planRefineOp.verify(parsed, input, {} as any);
+    expect(result).toBeNull();
+  });
+
+  test("AC-10a: planRefineOp.recover returns null when ctx.readFile returns null", async () => {
+    const input = {
+      specContent: "spec",
+      codebaseContext: "context",
+      featureName: "feature",
+      branchName: "branch",
+      outputPath: "/tmp/prd.json",
+    };
+    const ctx = { readFile: async () => null } as any;
+    const result = await planRefineOp.recover(input, ctx);
+    expect(result).toBeNull();
+  });
+
+  test("AC-10b: planRefineOp.recover returns null when ctx.readFile returns undefined", async () => {
+    const input = {
+      specContent: "spec",
+      codebaseContext: "context",
+      featureName: "feature",
+      branchName: "branch",
+      outputPath: "/tmp/prd.json",
+    };
+    const ctx = { readFile: async () => undefined } as any;
+    const result = await planRefineOp.recover(input, ctx);
+    expect(result).toBeNull();
+  });
+
+  test("AC-11: planRefineOp.recover returns null (not throws) when file contains invalid JSON", async () => {
+    const input = {
+      specContent: "spec",
+      codebaseContext: "context",
+      featureName: "feature",
+      branchName: "branch",
+      outputPath: "/tmp/prd.json",
+    };
+    const ctx = { readFile: async () => "{ invalid json }" } as any;
+    const result = await planRefineOp.recover(input, ctx);
+    expect(result).toBeNull();
+  });
+
+  test("AC-12: planRefineOp.build returns { task: { content: string } } with codebaseContext substring", () => {
+    const input = {
+      specContent: "# Feature Spec",
+      codebaseContext: "Codebase context string",
+      featureName: "my-feature",
+      branchName: "feat/my-feature",
+      outputPath: "/tmp/prd.json",
+    };
+    const ctx = { config: { plan: {} } } as any;
+    const result = planRefineOp.build(input, ctx);
+    expect(result).toBeDefined();
+    expect(result.task).toBeDefined();
+    expect(result.task.content).toBeDefined();
+    expect(typeof result.task.content).toBe("string");
+    expect(result.task.content.includes("Codebase context string")).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// US-004: RefinePlanStrategy and Factory Wiring
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("US-004: RefinePlanStrategy and factory wiring", () => {
+  test("AC-13: RefinePlanStrategy.execute does NOT call ctx.runtime.close()", async () => {
+    const strategy = new RefinePlanStrategy();
+    const closeMock = mock(async () => {});
+    const runtime = makeRuntime(closeMock);
+    const ctx = makeCtx({ runtime });
+
+    // Mock callOp to return a valid PRD
+    const callOpMock = mock(async () => ({
+      userStories: [
+        {
+          id: "US-001",
+          title: "Test story",
+          description: "A test story",
+          acceptanceCriteria: ["AC1"],
+        },
+      ],
+    }));
+
+    const originalCallOp = _refinePlanDeps.callOp;
+    _refinePlanDeps.callOp = callOpMock as typeof _refinePlanDeps.callOp;
+
+    try {
+      await strategy.execute(ctx);
+      // Verify that runtime.close() was NOT called
+      expect(closeMock.mock.calls.length).toBe(0);
+    } finally {
+      _refinePlanDeps.callOp = originalCallOp;
+    }
+  });
+
+  test("AC-14a: When callOp rejects, execute returns path from writeOrRecoverPrd", async () => {
+    const strategy = new RefinePlanStrategy();
+    const ctx = makeCtx();
+    const testError = new Error("Call failed");
+
+    // Mock callOp to throw
+    const callOpMock = mock(async () => {
+      throw testError;
+    });
+
+    const originalCallOp = _refinePlanDeps.callOp;
+    _refinePlanDeps.callOp = callOpMock as typeof _refinePlanDeps.callOp;
+
+    try {
+      // This should call writeOrRecoverPrd with the error
+      await strategy.execute(ctx);
+    } catch {
+      // Expected to throw if no valid PRD on disk
+    } finally {
+      _refinePlanDeps.callOp = originalCallOp;
+    }
+  });
+
+  test("AC-15: createPlanStrategy('single') returns SinglePlanStrategy", () => {
+    const strategy = createPlanStrategy("single");
+    expect(strategy instanceof SinglePlanStrategy).toBe(true);
+  });
+
+  test("AC-16: createPlanStrategy('pipeline') returns PipelinePlanStrategy", () => {
+    const strategy = createPlanStrategy("pipeline");
+    expect(strategy instanceof PipelinePlanStrategy).toBe(true);
+  });
+
+  test("AC-17: RefinePlanStrategy.execute invokes callOp with interactionBridge in context", async () => {
+    const strategy = new RefinePlanStrategy();
+    const mockBridge = { detectQuestion: async () => false } as InteractionBridge;
+    const ctx = makeCtx({ interactionBridge: mockBridge });
+
+    const callOpMock = mock(async () => ({
+      userStories: [
+        {
+          id: "US-001",
+          title: "Test story",
+          description: "A test story",
+          acceptanceCriteria: ["AC1"],
+        },
+      ],
+    }));
+
+    const originalCallOp = _refinePlanDeps.callOp;
+    _refinePlanDeps.callOp = callOpMock as typeof _refinePlanDeps.callOp;
+
+    try {
+      await strategy.execute(ctx);
+      expect(callOpMock.mock.calls.length).toBe(1);
+      const callCtx = callOpMock.mock.calls[0][0] as Record<string, unknown>;
+      expect(callCtx.interactionBridge).toBe(mockBridge);
+    } finally {
+      _refinePlanDeps.callOp = originalCallOp;
+    }
+  });
+
+  test("Session role registry includes 'plan-refine'", () => {
+    expect((KNOWN_SESSION_ROLES as readonly string[]).includes("plan-refine")).toBe(true);
+  });
+});

--- a/.nax/features/plan-refine-mode/acceptance-meta.json
+++ b/.nax/features/plan-refine-mode/acceptance-meta.json
@@ -1,0 +1,7 @@
+{
+  "generatedAt": "2026-05-14T01:41:20.978Z",
+  "acFingerprint": "sha256:dbd1045c883e5e59937182f3137647d95b8a50a7794e6abdac5c813a16aadc48",
+  "storyCount": 4,
+  "acCount": 29,
+  "generator": "nax"
+}

--- a/.nax/features/plan-refine-mode/acceptance-refined.json
+++ b/.nax/features/plan-refine-mode/acceptance-refined.json
@@ -1,0 +1,205 @@
+[
+  {
+    "acId": "AC-1",
+    "original": "NaxConfigSchema.safeParse({ plan: { mode: \"refine\" } }) returns success: true",
+    "refined": "NaxConfigSchema.safeParse({ plan: { mode: \"refine\" } }) returns an object with success === true",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-2",
+    "original": "NaxConfigSchema.safeParse({ plan: { mode: \"unknown-mode\" } }) returns success: false",
+    "refined": "NaxConfigSchema.safeParse({ plan: { mode: \"unknown-mode\" } }) returns an object with success === false",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-3",
+    "original": "resolvePlanMode({ plan: { mode: \"refine\" } }) returns \"refine\"",
+    "refined": "resolvePlanMode({ plan: { mode: \"refine\" } }) returns the string \"refine\"",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-4",
+    "original": "resolvePlanMode({}) returns \"single\" (refine is never auto-selected)",
+    "refined": "resolvePlanMode({}) returns the string \"single\"",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-5",
+    "original": "resolvePlanMode({ debate: { enabled: true, stages: { plan: { enabled: true } } } }) returns \"debate\" — debate auto-selection takes priority over the default single, but not over an explicit plan.mode",
+    "refined": "resolvePlanMode({ debate: { enabled: true, stages: { plan: { enabled: true } } } }) returns the string \"debate\"",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-6",
+    "original": "resolvePlanMode({ plan: { mode: \"refine\" }, debate: { enabled: true, stages: { plan: { enabled: true } } } }) returns \"refine\" — explicit mode wins over debate auto-selection",
+    "refined": "resolvePlanMode({ plan: { mode: \"refine\" }, debate: { enabled: true, stages: { plan: { enabled: true } } } }) returns the string \"refine\"",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-7",
+    "original": "createPlanStrategy(\"refine\") in src/plan/strategies/index.ts returns a RefinePlanStrategy instance without a TypeScript exhaustiveness error — the switch in createPlanStrategy handles all four modes",
+    "refined": "createPlanStrategy(\"refine\") returns an instance of RefinePlanStrategy, and TypeScript compilation succeeds with no exhaustiveness errors in the switch statement",
+    "testable": true,
+    "storyId": "US-001"
+  },
+  {
+    "acId": "AC-8",
+    "original": "new PlanPromptBuilder().buildRefineContinuation(\"/path/to/prd.json\") returns a string with length greater than 200 characters",
+    "refined": "buildRefineContinuation(outputFilePath: string) returns a non-empty string with character length > 200",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-9",
+    "original": "The returned string contains the substring \"ac-testable\"",
+    "refined": "The returned string includes the literal substring 'ac-testable'",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-10",
+    "original": "The returned string contains the substring \"failure-modes-considered\"",
+    "refined": "The returned string includes the literal substring 'failure-modes-considered'",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-11",
+    "original": "The returned string contains the substring \"description-ac-contradiction\"",
+    "refined": "The returned string includes the literal substring 'description-ac-contradiction'",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-12",
+    "original": "The returned string contains the literal path passed as outputFilePath",
+    "refined": "The returned string includes the exact file path value that was passed as the outputFilePath parameter",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-13",
+    "original": "The returned string contains the word \"flaws\" or \"adversarial\" (adversarial framing is present)",
+    "refined": "The returned string contains at least one of the words: 'flaws' or 'adversarial'",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-14",
+    "original": "The returned string does NOT contain \"```json\" (no JSON output schema — turn 2 output is plain text confirmation)",
+    "refined": "The returned string does not contain the substring '```json'",
+    "testable": true,
+    "storyId": "US-002"
+  },
+  {
+    "acId": "AC-15",
+    "original": "planRefineOp.kind is \"run\" and planRefineOp.name is \"plan-refine\"",
+    "refined": "planRefineOp.kind property equals \"run\" and planRefineOp.name property equals \"plan-refine\"",
+    "testable": true,
+    "storyId": "US-003"
+  },
+  {
+    "acId": "AC-16",
+    "original": "planRefineOp.session.role is \"plan-refine\" and planRefineOp.session.lifetime is \"fresh\"",
+    "refined": "planRefineOp.session.role property equals \"plan-refine\" and planRefineOp.session.lifetime property equals \"fresh\"",
+    "testable": true,
+    "storyId": "US-003"
+  },
+  {
+    "acId": "AC-17",
+    "original": "planRefineOp.build(input, ctx) returns a ComposeInput whose task.content contains input.featureName",
+    "refined": "Calling planRefineOp.build(input, ctx) with a test input returns an object with task.content string that includes the value of input.featureName",
+    "testable": true,
+    "storyId": "US-003"
+  },
+  {
+    "acId": "AC-18",
+    "original": "planRefineOp.hopBody calls ctx.sendWithParseRetry for turn 1 (draft) and ctx.send — not ctx.sendWithParseRetry — for turn 2 (refine), so the text confirmation from turn 2 is never parse-retried",
+    "refined": "The hopBody implementation calls ctx.sendWithParseRetry once (for turn 1) with the initialPrompt, then calls ctx.send once (for turn 2) with the refine continuation prompt, without calling ctx.sendWithParseRetry a second time",
+    "testable": true,
+    "storyId": "US-003"
+  },
+  {
+    "acId": "AC-19",
+    "original": "planRefineOp.hopBody calls new PlanPromptBuilder().buildRefineContinuation(input.outputPath) as the prompt for turn 2",
+    "refined": "The hopBody implementation constructs the turn 2 prompt by calling new PlanPromptBuilder().buildRefineContinuation(ctx.input.outputPath) and passes the result to ctx.send",
+    "testable": true,
+    "storyId": "US-003"
+  },
+  {
+    "acId": "AC-20",
+    "original": "planRefineOp.hopBody returns the TurnResult from ctx.send with estimatedCostUsd overridden to the sum of turn 1 and turn 2 costs; it does NOT manually read the file (relying on callOp's fileOutput substitution to populate turn2.output)",
+    "refined": "The hopBody implementation returns an object with spread properties from turn2 where estimatedCostUsd is explicitly set to (turn1.estimatedCostUsd ?? 0) + (turn2.estimatedCostUsd ?? 0), and contains no calls to ctx.readFile() or Bun.file() after ctx.send",
+    "testable": true,
+    "storyId": "US-003"
+  },
+  {
+    "acId": "AC-21",
+    "original": "planRefineOp.hopBody returns a TurnResult whose estimatedCostUsd equals turn1.estimatedCostUsd + turn2.estimatedCostUsd",
+    "refined": "When hopBody completes, the returned TurnResult.estimatedCostUsd value equals the numeric sum of turn1.estimatedCostUsd and turn2.estimatedCostUsd (treating undefined values as 0)",
+    "testable": true,
+    "storyId": "US-003"
+  },
+  {
+    "acId": "AC-22",
+    "original": "planRefineOp.recover(input, ctx) returns a parsed PRD when input.outputPath exists on disk with valid PRD JSON; returns null when the file does not exist",
+    "refined": "Calling planRefineOp.recover(input, ctx) where input.outputPath contains valid PRD JSON returns a truthy PRD object; returns null when the file does not exist or contains invalid/unparseable JSON",
+    "testable": true,
+    "storyId": "US-003"
+  },
+  {
+    "acId": "AC-23",
+    "original": "planRefineOp is exported from src/operations/index.ts",
+    "refined": "Both planRefineOp and PlanRefineInput are named exports from src/operations/index.ts (the barrel)",
+    "testable": true,
+    "storyId": "US-003"
+  },
+  {
+    "acId": "AC-24",
+    "original": "createPlanStrategy(\"refine\") returns an instance of RefinePlanStrategy",
+    "refined": "Calling createPlanStrategy('refine') returns an object whose constructor is RefinePlanStrategy and has a mode property equal to 'refine'",
+    "testable": true,
+    "storyId": "US-004"
+  },
+  {
+    "acId": "AC-25",
+    "original": "RefinePlanStrategy.mode equals \"refine\"",
+    "refined": "A RefinePlanStrategy instance has a readonly mode property with the literal value 'refine'",
+    "testable": true,
+    "storyId": "US-004"
+  },
+  {
+    "acId": "AC-26",
+    "original": "RefinePlanStrategy.execute(ctx) calls callOp with planRefineOp (not planInteractiveOp)",
+    "refined": "RefinePlanStrategy.execute() invokes callOp with planRefineOp as the second positional argument (operation parameter), verified via spy or mock on callOp",
+    "testable": true,
+    "storyId": "US-004"
+  },
+  {
+    "acId": "AC-27",
+    "original": "RefinePlanStrategy.execute(ctx) returns ctx.outputPath on success",
+    "refined": "When callOp succeeds, RefinePlanStrategy.execute() returns the string value of ctx.outputPath",
+    "testable": true,
+    "storyId": "US-004"
+  },
+  {
+    "acId": "AC-28",
+    "original": "When callOp throws and ctx.outputPath exists on disk with valid PRD JSON, RefinePlanStrategy.execute reads and returns the disk-recovered path via writeOrRecoverPrd",
+    "refined": "When callOp rejects with an error and a valid PRD JSON file exists at ctx.outputPath on disk, RefinePlanStrategy.execute() catches the error, calls writeOrRecoverPrd(ctx, null, err), and returns the result",
+    "testable": true,
+    "storyId": "US-004"
+  },
+  {
+    "acId": "AC-29",
+    "original": "src/runtime/session-role.ts includes \"plan-refine\" in CanonicalSessionRole and KNOWN_SESSION_ROLES, and adapter-wiring.md includes \"plan-refine\" in the callOp run-kind row",
+    "refined": "The string literal 'plan-refine' appears as a member of CanonicalSessionRole union type in src/runtime/session-role.ts, is present in KNOWN_SESSION_ROLES constant array in the same file, and is listed in the callOp run-kind row in the session role registry table in .claude/rules/adapter-wiring.md",
+    "testable": true,
+    "storyId": "US-004"
+  }
+]

--- a/.nax/features/plan-refine-mode/prd.json
+++ b/.nax/features/plan-refine-mode/prd.json
@@ -3,7 +3,7 @@
   "feature": "plan-refine-mode",
   "branchName": "feat/plan-refine-mode",
   "createdAt": "2026-05-13T00:00:00.000Z",
-  "updatedAt": "2026-05-13T15:27:23.778Z",
+  "updatedAt": "2026-05-14T01:41:21.061Z",
   "userStories": [
     {
       "id": "US-001",
@@ -30,7 +30,9 @@
       "routing": {
         "complexity": "simple",
         "testStrategy": "tdd-simple",
-        "reasoning": "validated from LLM output"
+        "reasoning": "validated from LLM output",
+        "initialComplexity": "simple",
+        "modelTier": "fast"
       },
       "contextFiles": [
         "src/config/schemas-infra.ts",
@@ -42,7 +44,11 @@
         "resolvePlanMode({ plan: { mode: \"pipeline\" } }) returns \"pipeline\" — existing modes still resolve correctly after adding refine",
         "resolvePlanMode({ plan: { mode: \"debate\" } }) returns \"debate\" — explicit debate still wins over debate auto-selection",
         "NaxConfigSchema.safeParse({ plan: { mode: \"single\" } }) still returns success: true after the schema extension"
-      ]
+      ],
+      "priorErrors": [],
+      "priorFailures": [],
+      "storyPoints": 1,
+      "storyGitRef": "85187927462533b3d500c40f4bddc88372c40044"
     },
     {
       "id": "US-002",
@@ -80,7 +86,10 @@
         "The returned string does NOT contain \"failure-table-enumerated\" (this checklist item is intentionally excluded from turn 2)",
         "Calling buildRefineContinuation with two different outputFilePath values returns two different strings (the path is embedded, not ignored)",
         "The returned string contains an instruction to write to the file before replying (write-then-confirm ordering)"
-      ]
+      ],
+      "priorErrors": [],
+      "priorFailures": [],
+      "storyPoints": 1
     },
     {
       "id": "US-003",
@@ -127,7 +136,10 @@
         "planRefineOp.recover returns null when ctx.readFile returns null or undefined",
         "planRefineOp.recover returns null (not throws) when the file exists but contains invalid JSON",
         "planRefineOp.build task.content contains input.codebaseContext"
-      ]
+      ],
+      "priorErrors": [],
+      "priorFailures": [],
+      "storyPoints": 1
     },
     {
       "id": "US-004",
@@ -171,7 +183,10 @@
         "createPlanStrategy(\"single\") still returns SinglePlanStrategy after the factory is extended (no regression)",
         "createPlanStrategy(\"pipeline\") still returns PipelinePlanStrategy after the factory is extended (no regression)",
         "RefinePlanStrategy.execute passes ctx.interactionBridge to callOp's context object"
-      ]
+      ],
+      "priorErrors": [],
+      "priorFailures": [],
+      "storyPoints": 1
     }
   ],
   "analysis": "## Codebase Analysis\n\n- Core modifications identified across config, prompt builder, operations, strategy factory, and session-role registry.\n- PRD schema enforces dependencies as in-PRD story IDs only; external spec prerequisites belong in narrative context, not dependencies arrays.\n- callOp fileOutput substitution behavior is captured for the refine op design.\n- Implementation order: US-001 and US-002 can run in parallel; US-003 depends on US-002; US-004 depends on US-001 and US-003."

--- a/.nax/features/plan-refine-mode/prd.json
+++ b/.nax/features/plan-refine-mode/prd.json
@@ -3,7 +3,7 @@
   "feature": "plan-refine-mode",
   "branchName": "feat/plan-refine-mode",
   "createdAt": "2026-05-13T00:00:00.000Z",
-  "updatedAt": "2026-05-14T02:09:46.380Z",
+  "updatedAt": "2026-05-14T02:24:35.294Z",
   "userStories": [
     {
       "id": "US-001",
@@ -116,8 +116,8 @@
       "dependencies": [
         "US-002"
       ],
-      "status": "pending",
-      "passes": false,
+      "status": "passed",
+      "passes": true,
       "attempts": 1,
       "escalations": [],
       "routing": {
@@ -174,7 +174,9 @@
       "routing": {
         "complexity": "medium",
         "testStrategy": "tdd-simple",
-        "reasoning": "validated from LLM output"
+        "reasoning": "validated from LLM output",
+        "initialComplexity": "medium",
+        "modelTier": "balanced"
       },
       "contextFiles": [
         "src/plan/strategies/single.ts",
@@ -192,7 +194,8 @@
       ],
       "priorErrors": [],
       "priorFailures": [],
-      "storyPoints": 1
+      "storyPoints": 1,
+      "storyGitRef": "1f468d00c43e67956f6eae23e3932c04f8160524"
     }
   ],
   "analysis": "## Codebase Analysis\n\n- Core modifications identified across config, prompt builder, operations, strategy factory, and session-role registry.\n- PRD schema enforces dependencies as in-PRD story IDs only; external spec prerequisites belong in narrative context, not dependencies arrays.\n- callOp fileOutput substitution behavior is captured for the refine op design.\n- Implementation order: US-001 and US-002 can run in parallel; US-003 depends on US-002; US-004 depends on US-001 and US-003."

--- a/.nax/features/plan-refine-mode/prd.json
+++ b/.nax/features/plan-refine-mode/prd.json
@@ -3,7 +3,7 @@
   "feature": "plan-refine-mode",
   "branchName": "feat/plan-refine-mode",
   "createdAt": "2026-05-13T00:00:00.000Z",
-  "updatedAt": "2026-05-14T02:05:17.133Z",
+  "updatedAt": "2026-05-14T02:09:46.380Z",
   "userStories": [
     {
       "id": "US-001",
@@ -116,7 +116,7 @@
       "dependencies": [
         "US-002"
       ],
-      "status": "paused",
+      "status": "pending",
       "passes": false,
       "attempts": 1,
       "escalations": [],

--- a/.nax/features/plan-refine-mode/prd.json
+++ b/.nax/features/plan-refine-mode/prd.json
@@ -3,7 +3,7 @@
   "feature": "plan-refine-mode",
   "branchName": "feat/plan-refine-mode",
   "createdAt": "2026-05-13T00:00:00.000Z",
-  "updatedAt": "2026-05-14T02:01:06.798Z",
+  "updatedAt": "2026-05-14T02:05:17.133Z",
   "userStories": [
     {
       "id": "US-001",
@@ -116,9 +116,9 @@
       "dependencies": [
         "US-002"
       ],
-      "status": "pending",
+      "status": "paused",
       "passes": false,
-      "attempts": 0,
+      "attempts": 1,
       "escalations": [],
       "routing": {
         "complexity": "complex",

--- a/.nax/features/plan-refine-mode/prd.json
+++ b/.nax/features/plan-refine-mode/prd.json
@@ -3,7 +3,7 @@
   "feature": "plan-refine-mode",
   "branchName": "feat/plan-refine-mode",
   "createdAt": "2026-05-13T00:00:00.000Z",
-  "updatedAt": "2026-05-14T02:24:35.294Z",
+  "updatedAt": "2026-05-14T02:39:41.998Z",
   "userStories": [
     {
       "id": "US-001",
@@ -167,8 +167,8 @@
         "US-001",
         "US-003"
       ],
-      "status": "pending",
-      "passes": false,
+      "status": "passed",
+      "passes": true,
       "attempts": 0,
       "escalations": [],
       "routing": {

--- a/.nax/features/plan-refine-mode/prd.json
+++ b/.nax/features/plan-refine-mode/prd.json
@@ -3,7 +3,7 @@
   "feature": "plan-refine-mode",
   "branchName": "feat/plan-refine-mode",
   "createdAt": "2026-05-13T00:00:00.000Z",
-  "updatedAt": "2026-05-14T01:53:14.611Z",
+  "updatedAt": "2026-05-14T02:01:06.798Z",
   "userStories": [
     {
       "id": "US-001",
@@ -68,8 +68,8 @@
         "prompts"
       ],
       "dependencies": [],
-      "status": "pending",
-      "passes": false,
+      "status": "passed",
+      "passes": true,
       "attempts": 0,
       "escalations": [],
       "routing": {
@@ -123,7 +123,9 @@
       "routing": {
         "complexity": "complex",
         "testStrategy": "three-session-tdd-lite",
-        "reasoning": "validated from LLM output"
+        "reasoning": "validated from LLM output",
+        "initialComplexity": "complex",
+        "modelTier": "balanced"
       },
       "contextFiles": [
         "src/operations/plan.ts",
@@ -142,7 +144,8 @@
       ],
       "priorErrors": [],
       "priorFailures": [],
-      "storyPoints": 1
+      "storyPoints": 1,
+      "storyGitRef": "26846b6a93d4acdad9a01fe0bc530681a32b027d"
     },
     {
       "id": "US-004",

--- a/.nax/features/plan-refine-mode/prd.json
+++ b/.nax/features/plan-refine-mode/prd.json
@@ -3,7 +3,7 @@
   "feature": "plan-refine-mode",
   "branchName": "feat/plan-refine-mode",
   "createdAt": "2026-05-13T00:00:00.000Z",
-  "updatedAt": "2026-05-14T01:41:21.061Z",
+  "updatedAt": "2026-05-14T01:53:14.611Z",
   "userStories": [
     {
       "id": "US-001",
@@ -23,8 +23,8 @@
         "config"
       ],
       "dependencies": [],
-      "status": "pending",
-      "passes": false,
+      "status": "passed",
+      "passes": true,
       "attempts": 0,
       "escalations": [],
       "routing": {
@@ -75,7 +75,9 @@
       "routing": {
         "complexity": "simple",
         "testStrategy": "tdd-simple",
-        "reasoning": "validated from LLM output"
+        "reasoning": "validated from LLM output",
+        "initialComplexity": "simple",
+        "modelTier": "fast"
       },
       "contextFiles": [
         "src/prompts/builders/plan-builder.ts",
@@ -89,7 +91,8 @@
       ],
       "priorErrors": [],
       "priorFailures": [],
-      "storyPoints": 1
+      "storyPoints": 1,
+      "storyGitRef": "2e41d12ef77e8f86f832c1d8baa2f418f012df32"
     },
     {
       "id": "US-003",

--- a/.nax/features/plan-refine-mode/prd.json
+++ b/.nax/features/plan-refine-mode/prd.json
@@ -1,0 +1,178 @@
+{
+  "project": "@nathapp/nax",
+  "feature": "plan-refine-mode",
+  "branchName": "feat/plan-refine-mode",
+  "createdAt": "2026-05-13T00:00:00.000Z",
+  "updatedAt": "2026-05-13T15:27:23.778Z",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Config schema and mode resolution",
+      "description": "**Goal** — Extend the config schema to accept `\"refine\"` as a valid `plan.mode` value and update `resolvePlanMode()` to return it.\n\n**Motivation** — Cheap-model one-shot drafts predictably fall short on AC quality, failure-mode coverage, and description-AC consistency; a 2-turn refine mode targets this residual gap at only 2 LLM calls.\n\n**Approach** — Three additive changes:\n\n1. `src/config/schemas-infra.ts` line ~17: extend the `mode` enum:\n```typescript\nmode: z.enum([\"single\", \"debate\", \"pipeline\", \"refine\"]).optional(),\n```\n\n2. `src/config/runtime-types.ts` line ~285: extend the `PlanConfig.mode` type union:\n```typescript\nmode?: \"single\" | \"debate\" | \"pipeline\" | \"refine\";\n```\n\n3. `src/cli/plan-command.ts`: extend `resolvePlanMode()` return type and body — refine is only returned when explicitly configured and is **never** auto-selected:\n```typescript\nexport function resolvePlanMode(\n  config: NaxConfig\n): \"single\" | \"debate\" | \"pipeline\" | \"refine\" {\n  const explicit = config?.plan?.mode;\n  if (explicit) return explicit;\n  if (config?.debate?.enabled && config?.debate?.stages?.plan?.enabled) return \"debate\";\n  return \"single\";\n}\n```\n\nNote: AC7 (`createPlanStrategy(\"refine\")` returns `RefinePlanStrategy`) is included in the test file for this story (`test/unit/config/plan-mode-refine.test.ts`) but will only pass once US-004 implements the factory wiring.\n\n**Scope** — In: `src/config/schemas-infra.ts` mode enum, `src/config/runtime-types.ts` PlanConfig type, `src/cli/plan-command.ts` resolvePlanMode return type and body. Out: strategy class, op file, session role registry (those are US-004).",
+      "acceptanceCriteria": [
+        "NaxConfigSchema.safeParse({ plan: { mode: \"refine\" } }) returns success: true",
+        "NaxConfigSchema.safeParse({ plan: { mode: \"unknown-mode\" } }) returns success: false",
+        "resolvePlanMode({ plan: { mode: \"refine\" } }) returns \"refine\"",
+        "resolvePlanMode({}) returns \"single\" (refine is never auto-selected)",
+        "resolvePlanMode({ debate: { enabled: true, stages: { plan: { enabled: true } } } }) returns \"debate\" — debate auto-selection takes priority over the default single, but not over an explicit plan.mode",
+        "resolvePlanMode({ plan: { mode: \"refine\" }, debate: { enabled: true, stages: { plan: { enabled: true } } } }) returns \"refine\" — explicit mode wins over debate auto-selection",
+        "createPlanStrategy(\"refine\") in src/plan/strategies/index.ts returns a RefinePlanStrategy instance without a TypeScript exhaustiveness error — the switch in createPlanStrategy handles all four modes"
+      ],
+      "tags": [
+        "feature",
+        "config"
+      ],
+      "dependencies": [],
+      "status": "pending",
+      "passes": false,
+      "attempts": 0,
+      "escalations": [],
+      "routing": {
+        "complexity": "simple",
+        "testStrategy": "tdd-simple",
+        "reasoning": "validated from LLM output"
+      },
+      "contextFiles": [
+        "src/config/schemas-infra.ts",
+        "src/config/runtime-types.ts",
+        "src/cli/plan-command.ts",
+        "test/unit/cli/plan-mode.test.ts"
+      ],
+      "suggestedCriteria": [
+        "resolvePlanMode({ plan: { mode: \"pipeline\" } }) returns \"pipeline\" — existing modes still resolve correctly after adding refine",
+        "resolvePlanMode({ plan: { mode: \"debate\" } }) returns \"debate\" — explicit debate still wins over debate auto-selection",
+        "NaxConfigSchema.safeParse({ plan: { mode: \"single\" } }) still returns success: true after the schema extension"
+      ]
+    },
+    {
+      "id": "US-002",
+      "title": "Refine continuation prompt",
+      "description": "**Goal** — Add `buildRefineContinuation(outputFilePath: string): string` to `PlanPromptBuilder` for the adversarial self-audit second turn.\n\n**Motivation** — Turn 2 of refine mode forces a focused second pass on the three areas where cheap one-shot drafts predictably fall short: AC observability, negative-path coverage, and description-AC consistency.\n\n**Approach** — Add an instance method `buildRefineContinuation(outputFilePath: string): string` to `PlanPromptBuilder` in `src/prompts/builders/plan-builder.ts`. The method must:\n- Open with adversarial framing (\"assume this draft has flaws, find them\")\n- Include three checklist sections with their `#### <id>` headings matching the critic checklist item identifiers:\n  - `ac-testable` — for each AC, is the assertion observable (return value, exception, log, file content, state)? If not, rewrite it.\n  - `failure-modes-considered` — does each story have at least one negative-path AC? If not, add one.\n  - `description-ac-contradiction` — does any sentence in any description contradict an AC in the same story? If so, fix the description.\n- Instruct the model to write the revised PRD to `outputFilePath` (not output to conversation)\n- Instruct the model to reply with a brief text confirmation only after writing the file\n- NOT include a JSON output schema (turn 2 output is plain text confirmation; the file is the real output)\n\nNote: `failure-table-enumerated` (present in the pipeline critic) is intentionally omitted — turn 2 does not re-receive the original spec, so row-by-row table enumeration cannot be performed reliably.\n\n**Scope** — In: `src/prompts/builders/plan-builder.ts` (add one instance method). Out: all other files.",
+      "acceptanceCriteria": [
+        "new PlanPromptBuilder().buildRefineContinuation(\"/path/to/prd.json\") returns a string with length greater than 200 characters",
+        "The returned string contains the substring \"ac-testable\"",
+        "The returned string contains the substring \"failure-modes-considered\"",
+        "The returned string contains the substring \"description-ac-contradiction\"",
+        "The returned string contains the literal path passed as outputFilePath",
+        "The returned string contains the word \"flaws\" or \"adversarial\" (adversarial framing is present)",
+        "The returned string does NOT contain \"```json\" (no JSON output schema — turn 2 output is plain text confirmation)"
+      ],
+      "tags": [
+        "feature",
+        "prompts"
+      ],
+      "dependencies": [],
+      "status": "pending",
+      "passes": false,
+      "attempts": 0,
+      "escalations": [],
+      "routing": {
+        "complexity": "simple",
+        "testStrategy": "tdd-simple",
+        "reasoning": "validated from LLM output"
+      },
+      "contextFiles": [
+        "src/prompts/builders/plan-builder.ts",
+        "src/prompts/builders/critic-builder.ts",
+        "test/unit/prompts/builders/plan-builder.test.ts"
+      ],
+      "suggestedCriteria": [
+        "The returned string does NOT contain \"failure-table-enumerated\" (this checklist item is intentionally excluded from turn 2)",
+        "Calling buildRefineContinuation with two different outputFilePath values returns two different strings (the path is embedded, not ignored)",
+        "The returned string contains an instruction to write to the file before replying (write-then-confirm ordering)"
+      ]
+    },
+    {
+      "id": "US-003",
+      "title": "planRefineOp operation",
+      "description": "**Goal** — Create `src/operations/plan-refine.ts` implementing the 2-turn `hopBody` flow and export it from the operations barrel.\n\n**Motivation** — Pipeline mode already addresses PRD quality via a separate critic op at 3 LLM calls; refine mode achieves comparable quality improvement at 2 LLM calls within a single session where the model has full context of its own draft.\n\n**Approach** — Mirror `planInteractiveOp` in `src/operations/plan.ts` exactly for `build`, `parse`, `verify`, and `recover`. The key differences are: (1) `name: \"plan-refine\"`, (2) `session.role: \"plan-refine\"`, and (3) the addition of a `hopBody` implementing the 2-turn flow.\n\n**Interface**\n```typescript\n// src/operations/plan-refine.ts\n\n// Mirrors PlanInteractiveInput exactly — mutable arrays to match PlanPromptBuilder.build() signature\nexport interface PlanRefineInput {\n  specContent: string;\n  codebaseContext: string;\n  featureName: string;\n  branchName: string;\n  outputPath: string;\n  packages?: string[];\n  packageDetails?: PackageSummary[];\n  projectProfile?: ProjectProfile;\n}\n\nexport const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {\n  kind: \"run\",\n  name: \"plan-refine\",\n  stage: \"plan\",\n  session: { role: \"plan-refine\", lifetime: \"fresh\" },\n  config: planConfigSelector,\n  model: (_input, ctx) => ctx.config.plan.model,\n  timeoutMs: (_input, ctx) => (ctx.config.plan.timeoutSeconds ?? 600) * 1000,\n\n  // retry applies to turn 1 via ctx.sendWithParseRetry in hopBody.\n  // turn 2 uses ctx.send() — no retry loop on the text confirmation.\n  retry: makeParseRetryStrategy({\n    validate: (parsed) => {\n      if (parsed === null || typeof parsed !== \"object\") return false;\n      const obj = parsed as Record<string, unknown>;\n      return \"userStories\" in obj && Array.isArray(obj.userStories) && obj.userStories.length > 0;\n    },\n    reviewerKind: \"plan\",\n    maxAttempts: 3,\n    prompts: {\n      invalid: () => PlanPromptBuilder.jsonRepair(0, \"Invalid JSON — response was not parseable\"),\n      truncated: () => PlanPromptBuilder.jsonRepair(0, \"JSON appears truncated — please rewrite completely\"),\n    },\n    // No exhaustedFallback: disk recovery is handled by op.recover (same as planInteractiveOp).\n  }),\n\n  // fileOutput: callOp reads this file after every send (including plain ctx.send)\n  // and substitutes its content as TurnResult.output — so op.parse() always sees\n  // the written PRD JSON, not the model's text confirmation.\n  fileOutput: (input) => input.outputPath,\n\n  build(input, _ctx) {\n    // Mirrors planInteractiveOp.build() exactly\n    const { taskContext, outputFormat } = new PlanPromptBuilder().build(\n      input.specContent,\n      input.codebaseContext,\n      input.outputPath,\n      input.packages,\n      input.packageDetails,\n      input.projectProfile,\n    );\n    return {\n      role: { id: \"role\", content: \"\", overridable: false },\n      task: { id: \"task\", content: `${taskContext}\\n\\n${outputFormat}`, overridable: false },\n    };\n  },\n\n  async hopBody(initialPrompt, ctx) {\n    // Turn 1: draft — sendWithParseRetry applies op.retry; fileOutput substitution\n    // ensures op.parse() validates the written JSON, not the text confirmation.\n    const turn1 = await ctx.sendWithParseRetry(initialPrompt);\n\n    // Turn 2: adversarial self-audit — plain ctx.send(), NOT ctx.sendWithParseRetry.\n    // fileOutput substitution runs after ctx.send too, so turn2.output will\n    // already contain the revised file content when returned.\n    const refinePrompt = new PlanPromptBuilder().buildRefineContinuation(ctx.input.outputPath);\n    const turn2 = await ctx.send(refinePrompt);\n\n    return {\n      ...turn2,\n      estimatedCostUsd: (turn1.estimatedCostUsd ?? 0) + (turn2.estimatedCostUsd ?? 0),\n    };\n  },\n\n  parse(output, input) {\n    return validatePlanOutput(output, input.featureName, input.branchName);\n  },\n\n  verify: async (parsed, _input, _ctx) => {\n    if (!parsed.userStories || parsed.userStories.length === 0) return null;\n    return parsed;\n  },\n\n  recover: async (input, ctx) => {\n    const content = await ctx.readFile(input.outputPath);\n    if (!content) return null;\n    try {\n      return validatePlanOutput(content, input.featureName, input.branchName);\n    } catch {\n      return null;\n    }\n  },\n};\n```\n\n**Critical implementation note — fileOutput substitution:** `callOp` reads the file at `input.outputPath` after every `send` call (including plain `ctx.send`) and substitutes its content as `TurnResult.output`. The `hopBody` must NOT manually call `ctx.readFile()` or `Bun.file()` to read the output — doing so is redundant and breaks the substitution contract. Trust `callOp`'s mechanism.\n\n**Scope** — In: `src/operations/plan-refine.ts` (new file), `src/operations/index.ts` (barrel export of `planRefineOp` and `PlanRefineInput`). Out: strategy class, session role registry (those are US-004).",
+      "acceptanceCriteria": [
+        "planRefineOp.kind is \"run\" and planRefineOp.name is \"plan-refine\"",
+        "planRefineOp.session.role is \"plan-refine\" and planRefineOp.session.lifetime is \"fresh\"",
+        "planRefineOp.build(input, ctx) returns a ComposeInput whose task.content contains input.featureName",
+        "planRefineOp.hopBody calls ctx.sendWithParseRetry for turn 1 (draft) and ctx.send — not ctx.sendWithParseRetry — for turn 2 (refine), so the text confirmation from turn 2 is never parse-retried",
+        "planRefineOp.hopBody calls new PlanPromptBuilder().buildRefineContinuation(input.outputPath) as the prompt for turn 2",
+        "planRefineOp.hopBody returns the TurnResult from ctx.send with estimatedCostUsd overridden to the sum of turn 1 and turn 2 costs; it does NOT manually read the file (relying on callOp's fileOutput substitution to populate turn2.output)",
+        "planRefineOp.hopBody returns a TurnResult whose estimatedCostUsd equals turn1.estimatedCostUsd + turn2.estimatedCostUsd",
+        "planRefineOp.recover(input, ctx) returns a parsed PRD when input.outputPath exists on disk with valid PRD JSON; returns null when the file does not exist",
+        "planRefineOp is exported from src/operations/index.ts"
+      ],
+      "tags": [
+        "feature",
+        "operations"
+      ],
+      "dependencies": [
+        "US-002"
+      ],
+      "status": "pending",
+      "passes": false,
+      "attempts": 0,
+      "escalations": [],
+      "routing": {
+        "complexity": "complex",
+        "testStrategy": "three-session-tdd-lite",
+        "reasoning": "validated from LLM output"
+      },
+      "contextFiles": [
+        "src/operations/plan.ts",
+        "src/operations/types.ts",
+        "src/prompts/builders/plan-builder.ts",
+        "src/operations/index.ts",
+        "test/unit/operations/plan-interactive.test.ts"
+      ],
+      "suggestedCriteria": [
+        "planRefineOp.retry is defined and has maxAttempts of 3 (matching planInteractiveOp)",
+        "planRefineOp.fileOutput(input) returns input.outputPath",
+        "planRefineOp.verify returns null when parsed.userStories is empty or missing",
+        "planRefineOp.recover returns null when ctx.readFile returns null or undefined",
+        "planRefineOp.recover returns null (not throws) when the file exists but contains invalid JSON",
+        "planRefineOp.build task.content contains input.codebaseContext"
+      ]
+    },
+    {
+      "id": "US-004",
+      "title": "RefinePlanStrategy and factory wiring",
+      "description": "**Goal** — Create `RefinePlanStrategy`, wire it into `createPlanStrategy`, register `plan-refine` in the session role registry, and update the adapter-wiring docs.\n\n**Motivation** — The strategy factory and session role registry are the two remaining integration points needed to activate refine mode end-to-end.\n\n**Approach** — Four changes:\n\n1. **New strategy class** `src/plan/strategies/refine.ts` — nearly identical to `SinglePlanStrategy` but uses `planRefineOp`. Runtime lifecycle is NOT closed here — `planCommand()`'s finally block owns it:\n```typescript\nexport class RefinePlanStrategy implements IPlanStrategy {\n  readonly mode = \"refine\" as const;\n\n  async execute(ctx: PlanModeContext): Promise<string> {\n    // ctx.runtime is built once in buildPlanModeContext and closed by\n    // planCommand()'s finally block — this strategy does not close it.\n    try {\n      const prd = await callOp(\n        {\n          runtime: ctx.runtime,\n          packageView: ctx.runtime.packages.resolve(),\n          packageDir: ctx.workdir,\n          agentName: ctx.runtime.agentManager.getDefault(),\n          storyId: ctx.options.feature,\n          featureName: ctx.options.feature,\n          interactionBridge: ctx.interactionBridge,\n          maxInteractionTurns: ctx.fullConfig.agent?.maxInteractionTurns,\n        },\n        planRefineOp,\n        {\n          specContent: ctx.specContent,\n          codebaseContext: ctx.codebaseContext,\n          featureName: ctx.options.feature,\n          branchName: ctx.branchName,\n          outputPath: ctx.outputPath,\n          packages: ctx.relativePackages,\n          packageDetails: ctx.packageDetails,\n          projectProfile: ctx.fullConfig.project,\n        },\n      );\n      return writeOrRecoverPrd(ctx, prd);\n    } catch (err) {\n      return writeOrRecoverPrd(ctx, null, err);\n    }\n  }\n}\n```\n\n2. **Factory wiring** `src/plan/strategies/index.ts` — add `\"refine\"` arm to `createPlanStrategy` switch (and export `RefinePlanStrategy`). The switch must be exhaustive across all four modes: `single`, `debate`, `pipeline`, `refine`.\n\n3. **Session role registry** `src/runtime/session-role.ts` — add `\"plan-refine\"` to `CanonicalSessionRole` union type and to the `KNOWN_SESSION_ROLES` constant array.\n\n4. **Adapter wiring docs** `.claude/rules/adapter-wiring.md` — add `plan-refine` to the `callOp` run-kind row in the session role registry table alongside `plan`, `plan-draft`, `plan-revise`, `plan-critic`.\n\n**Scope** — In: `src/plan/strategies/refine.ts` (new), `src/plan/strategies/index.ts` (factory + export), `src/runtime/session-role.ts` (role registry), `.claude/rules/adapter-wiring.md` (docs). Out: op file, prompt builder, config schema (those are earlier stories).",
+      "acceptanceCriteria": [
+        "createPlanStrategy(\"refine\") returns an instance of RefinePlanStrategy",
+        "RefinePlanStrategy.mode equals \"refine\"",
+        "RefinePlanStrategy.execute(ctx) calls callOp with planRefineOp (not planInteractiveOp)",
+        "RefinePlanStrategy.execute(ctx) returns ctx.outputPath on success",
+        "When callOp throws and ctx.outputPath exists on disk with valid PRD JSON, RefinePlanStrategy.execute reads and returns the disk-recovered path via writeOrRecoverPrd",
+        "src/runtime/session-role.ts includes \"plan-refine\" in CanonicalSessionRole and KNOWN_SESSION_ROLES, and adapter-wiring.md includes \"plan-refine\" in the callOp run-kind row"
+      ],
+      "tags": [
+        "feature",
+        "strategy"
+      ],
+      "dependencies": [
+        "US-001",
+        "US-003"
+      ],
+      "status": "pending",
+      "passes": false,
+      "attempts": 0,
+      "escalations": [],
+      "routing": {
+        "complexity": "medium",
+        "testStrategy": "tdd-simple",
+        "reasoning": "validated from LLM output"
+      },
+      "contextFiles": [
+        "src/plan/strategies/single.ts",
+        "src/plan/strategies/write-prd.ts",
+        "src/plan/strategies/index.ts",
+        "src/runtime/session-role.ts",
+        "test/unit/plan/single-strategy.test.ts"
+      ],
+      "suggestedCriteria": [
+        "RefinePlanStrategy.execute does NOT call ctx.runtime.close() — runtime lifecycle is planCommand()'s responsibility",
+        "When callOp throws and no valid PRD exists on disk, RefinePlanStrategy.execute propagates the original error (fail-closed)",
+        "createPlanStrategy(\"single\") still returns SinglePlanStrategy after the factory is extended (no regression)",
+        "createPlanStrategy(\"pipeline\") still returns PipelinePlanStrategy after the factory is extended (no regression)",
+        "RefinePlanStrategy.execute passes ctx.interactionBridge to callOp's context object"
+      ]
+    }
+  ],
+  "analysis": "## Codebase Analysis\n\n- Core modifications identified across config, prompt builder, operations, strategy factory, and session-role registry.\n- PRD schema enforces dependencies as in-PRD story IDs only; external spec prerequisites belong in narrative context, not dependencies arrays.\n- callOp fileOutput substitution behavior is captured for the refine op design.\n- Implementation order: US-001 and US-002 can run in parallel; US-003 depends on US-002; US-004 depends on US-001 and US-003."
+}

--- a/.nax/features/plan-refine-mode/progress.txt
+++ b/.nax/features/plan-refine-mode/progress.txt
@@ -1,0 +1,1 @@
+[2026-05-14T01:53:11.856Z] US-001 — PASSED — Config schema and mode resolution — Cost: $0.0000

--- a/.nax/features/plan-refine-mode/progress.txt
+++ b/.nax/features/plan-refine-mode/progress.txt
@@ -1,1 +1,2 @@
 [2026-05-14T01:53:11.856Z] US-001 — PASSED — Config schema and mode resolution — Cost: $0.0000
+[2026-05-14T02:01:03.935Z] US-002 — PASSED — Refine continuation prompt — Cost: $0.0000

--- a/.nax/features/plan-refine-mode/progress.txt
+++ b/.nax/features/plan-refine-mode/progress.txt
@@ -1,2 +1,3 @@
 [2026-05-14T01:53:11.856Z] US-001 — PASSED — Config schema and mode resolution — Cost: $0.0000
 [2026-05-14T02:01:03.935Z] US-002 — PASSED — Refine continuation prompt — Cost: $0.0000
+[2026-05-14T02:24:32.474Z] US-003 — PASSED — planRefineOp operation — Cost: $0.0000

--- a/.nax/features/plan-refine-mode/progress.txt
+++ b/.nax/features/plan-refine-mode/progress.txt
@@ -1,3 +1,4 @@
 [2026-05-14T01:53:11.856Z] US-001 — PASSED — Config schema and mode resolution — Cost: $0.0000
 [2026-05-14T02:01:03.935Z] US-002 — PASSED — Refine continuation prompt — Cost: $0.0000
 [2026-05-14T02:24:32.474Z] US-003 — PASSED — planRefineOp operation — Cost: $0.0000
+[2026-05-14T02:39:41.994Z] US-004 — PASSED — RefinePlanStrategy and factory wiring — Cost: $0.0000

--- a/.nax/features/plan-refine-mode/status.json
+++ b/.nax/features/plan-refine-mode/status.json
@@ -1,20 +1,20 @@
 {
   "version": 1,
   "run": {
-    "id": "run-2026-05-14T01-38-55-978Z",
+    "id": "run-2026-05-14T02-09-46-270Z",
     "feature": "plan-refine-mode",
-    "startedAt": "2026-05-14T01:38:55.978Z",
-    "status": "failed",
+    "startedAt": "2026-05-14T02:09:46.270Z",
+    "status": "completed",
     "dryRun": false,
-    "pid": 95789
+    "pid": 17217
   },
   "progress": {
     "total": 4,
-    "passed": 2,
+    "passed": 4,
     "failed": 0,
-    "paused": 1,
+    "paused": 0,
     "blocked": 0,
-    "pending": 1
+    "pending": 0
   },
   "cost": {
     "spent": 0,
@@ -22,15 +22,16 @@
   },
   "current": null,
   "iterations": 3,
-  "updatedAt": "2026-05-14T02:07:50.529Z",
-  "durationMs": 1734551,
+  "updatedAt": "2026-05-14T02:43:17.508Z",
+  "durationMs": 2011238,
   "postRun": {
     "acceptance": {
-      "status": "not-run"
+      "status": "passed",
+      "lastRunAt": "2026-05-14T02:42:43.990Z"
     },
     "regression": {
       "status": "passed",
-      "lastRunAt": "2026-05-14T02:07:49.685Z"
+      "lastRunAt": "2026-05-14T02:43:16.743Z"
     }
   }
 }

--- a/.nax/features/plan-refine-mode/status.json
+++ b/.nax/features/plan-refine-mode/status.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "run": {
+    "id": "run-2026-05-14T01-38-55-978Z",
+    "feature": "plan-refine-mode",
+    "startedAt": "2026-05-14T01:38:55.978Z",
+    "status": "failed",
+    "dryRun": false,
+    "pid": 95789
+  },
+  "progress": {
+    "total": 4,
+    "passed": 2,
+    "failed": 0,
+    "paused": 1,
+    "blocked": 0,
+    "pending": 1
+  },
+  "cost": {
+    "spent": 0,
+    "limit": 50
+  },
+  "current": null,
+  "iterations": 3,
+  "updatedAt": "2026-05-14T02:07:50.529Z",
+  "durationMs": 1734551,
+  "postRun": {
+    "acceptance": {
+      "status": "not-run"
+    },
+    "regression": {
+      "status": "passed",
+      "lastRunAt": "2026-05-14T02:07:49.685Z"
+    }
+  }
+}

--- a/src/cli/plan-command.ts
+++ b/src/cli/plan-command.ts
@@ -34,7 +34,7 @@ export { DEFAULT_TIMEOUT_SECONDS, _planDeps, createPlanRuntime, resolvePlanModel
  * 2. debate (both debate.enabled and stages.plan.enabled must be true)
  * 3. single (default)
  */
-export function resolvePlanMode(config: NaxConfig): "single" | "debate" | "pipeline" {
+export function resolvePlanMode(config: NaxConfig): "single" | "debate" | "pipeline" | "refine" {
   const explicit = config?.plan?.mode;
   if (explicit) return explicit;
   if (config?.debate?.enabled && config?.debate?.stages?.plan?.enabled) return "debate";

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -282,7 +282,7 @@ export interface PlanConfig {
   /** Override timeout for decompose calls in seconds. Defaults to plan.timeoutSeconds. */
   decomposeTimeoutSeconds?: number;
   /** Orchestration mode. Resolved at runtime when absent; see resolvePlanMode(). */
-  mode?: "single" | "debate" | "pipeline";
+  mode?: "single" | "debate" | "pipeline" | "refine";
   /** Minimum citation overlap threshold for the pipeline drafter gate [0, 1]. Default: 0.5 */
   citationThreshold: number;
   /** Model tier for the pipeline LLM critic. Default: "fast" */

--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -14,7 +14,7 @@ export const PlanConfigSchema = z.object({
   /** Override timeout for decompose calls in seconds. Defaults to plan.timeoutSeconds. */
   decomposeTimeoutSeconds: z.number().int().min(30).max(1_800).optional(),
   /** Orchestration mode. Resolved at runtime when absent; see resolvePlanMode(). */
-  mode: z.enum(["single", "debate", "pipeline"]).optional(),
+  mode: z.enum(["single", "debate", "pipeline", "refine"]).optional(),
   /** Minimum citation overlap threshold for the pipeline drafter gate [0, 1]. */
   citationThreshold: z.number().min(0).max(1).default(0.5),
   /** Model tier for the pipeline LLM critic. */

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -16,6 +16,10 @@ import type { BuildContext, CallContext, CompleteOperation, Operation, RunOperat
 /** Injectable deps for testability — mirrors _agentManagerDeps pattern. */
 export const _callOpDeps = {
   sleep: (ms: number, signal?: AbortSignal) => cancellableDelay(ms, signal),
+  readFileOutput: async (path: string) =>
+    Bun.file(path)
+      .text()
+      .catch(() => null),
 };
 
 /** Hard ceiling for injected RetryStrategy instances that may not self-terminate. */
@@ -247,6 +251,21 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
   let maxRetriesExceeded = false;
   let lastRetryTurn: TurnResult | undefined;
 
+  const sendWithFileOutput = async (
+    promptText: string,
+    bodyCtx: { send: (p: string) => Promise<TurnResult> },
+  ): Promise<TurnResult> => {
+    const turn = await bodyCtx.send(promptText);
+    if (!fileOutputPath) return turn;
+
+    const fileContent = await _callOpDeps.readFileOutput(fileOutputPath);
+    if (fileContent === null) {
+      return turn;
+    }
+
+    return { ...turn, output: fileContent };
+  };
+
   // sendWithParseRetry: runs the retry loop inside one session turn.
   // The strategy's shouldRetry decides whether to retry on each turn's output
   // (using its own internal parse + validate, not op.parse()). This means the
@@ -262,21 +281,13 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
     retryFallback = undefined;
     maxRetriesExceeded = false;
     lastRetryTurn = undefined;
-    if (!retryStrategy) return bodyCtx.send(initialPrompt);
+    if (!retryStrategy) return sendWithFileOutput(initialPrompt, bodyCtx);
     let currentPrompt = initialPrompt;
     let attempt = 0;
     let cumCost = 0;
     let lastTurn!: TurnResult;
     while (attempt <= MAX_COMPLETE_RETRY_ATTEMPTS) {
-      lastTurn = await bodyCtx.send(currentPrompt);
-      // op.fileOutput: inject file content as output so the probe checks the
-      // file the agent wrote, not the text confirmation it replied with.
-      if (fileOutputPath) {
-        const fileContent = await Bun.file(fileOutputPath)
-          .text()
-          .catch(() => null);
-        if (fileContent !== null) lastTurn = { ...lastTurn, output: fileContent };
-      }
+      lastTurn = await sendWithFileOutput(currentPrompt, bodyCtx);
       cumCost += lastTurn.estimatedCostUsd ?? 0;
       const decision = retryStrategy.shouldRetry(
         new ParseValidationError(`[${op.name}] sendWithParseRetry: probe attempt ${attempt}`),
@@ -342,7 +353,7 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
   ): Promise<TurnResult> => {
     if (runOp.hopBody) {
       return runOp.hopBody(initialPrompt, {
-        send: bodyCtx.send,
+        send: (p) => sendWithFileOutput(p, bodyCtx),
         sendWithParseRetry: (p) => sendWithParseRetry(p, bodyCtx),
         input: bodyCtx.input as I,
       });

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,6 +1,8 @@
 export { callOp, _callOpDeps, _runPostParseForTest } from "./call";
 export { planInteractiveOp } from "./plan";
 export type { PlanInteractiveInput } from "./plan";
+export { planRefineOp } from "./plan-refine";
+export type { PlanRefineInput } from "./plan-refine";
 export { decomposeOp } from "./decompose";
 export type { DecomposeOpInput, DecomposeOpOutput } from "./decompose";
 export { buildHopCallback, _buildHopCallbackDeps } from "./build-hop-callback";

--- a/src/operations/plan-refine.ts
+++ b/src/operations/plan-refine.ts
@@ -27,21 +27,22 @@ export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
   config: planConfigSelector,
   model: (_input, ctx) => ctx.config.plan.model,
   timeoutMs: (_input, ctx) => (ctx.config.plan.timeoutSeconds ?? 600) * 1000,
-  retry: makeParseRetryStrategy({
-    validate: (parsed) => {
-      if (parsed === null || typeof parsed !== "object") return false;
-      const obj = parsed as Record<string, unknown>;
-      if (!("userStories" in obj)) return false;
-      if (!Array.isArray(obj.userStories)) return false;
-      return obj.userStories.length > 0;
-    },
-    reviewerKind: "plan",
-    maxAttempts: 3,
-    prompts: {
-      invalid: () => PlanPromptBuilder.jsonRepair(0, "Invalid JSON — response was not parseable"),
-      truncated: () => PlanPromptBuilder.jsonRepair(0, "JSON appears truncated — please rewrite completely"),
-    },
-  }),
+  retry: () =>
+    makeParseRetryStrategy({
+      validate: (parsed) => {
+        if (parsed === null || typeof parsed !== "object") return false;
+        const obj = parsed as Record<string, unknown>;
+        if (!("userStories" in obj)) return false;
+        if (!Array.isArray(obj.userStories)) return false;
+        return obj.userStories.length > 0;
+      },
+      reviewerKind: "plan",
+      maxAttempts: 3,
+      prompts: {
+        invalid: () => PlanPromptBuilder.jsonRepair(0, "Invalid JSON — response was not parseable"),
+        truncated: () => PlanPromptBuilder.jsonRepair(0, "JSON appears truncated — please rewrite completely"),
+      },
+    }),
   fileOutput: (input) => input.outputPath,
   build(input, _ctx) {
     const { taskContext, outputFormat } = new PlanPromptBuilder().build(
@@ -54,7 +55,11 @@ export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
     );
     return {
       role: { id: "role", content: "", overridable: false },
-      task: { id: "task", content: `${taskContext}\n\n${outputFormat}`, overridable: false },
+      task: {
+        id: "task",
+        content: `You are drafting a PRD for the feature: **${input.featureName}**.\n\n${taskContext}\n\n${outputFormat}`,
+        overridable: false,
+      },
     };
   },
   async hopBody(initialPrompt, ctx) {

--- a/src/operations/plan-refine.ts
+++ b/src/operations/plan-refine.ts
@@ -1,0 +1,86 @@
+import { makeParseRetryStrategy } from "../agents/retry";
+import { planConfigSelector } from "../config";
+import type { ProjectProfile } from "../config/runtime-types";
+import type { PlanConfig } from "../config/selectors";
+import { validatePlanOutput } from "../prd/schema";
+import type { PRD } from "../prd/types";
+import { PlanPromptBuilder } from "../prompts";
+import type { PackageSummary } from "../prompts";
+import type { RunOperation } from "./types";
+
+export interface PlanRefineInput {
+  specContent: string;
+  codebaseContext: string;
+  featureName: string;
+  branchName: string;
+  outputPath: string;
+  packages?: string[];
+  packageDetails?: PackageSummary[];
+  projectProfile?: ProjectProfile;
+}
+
+export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
+  kind: "run",
+  name: "plan-refine",
+  stage: "plan",
+  session: { role: "plan-refine", lifetime: "fresh" },
+  config: planConfigSelector,
+  model: (_input, ctx) => ctx.config.plan.model,
+  timeoutMs: (_input, ctx) => (ctx.config.plan.timeoutSeconds ?? 600) * 1000,
+  retry: makeParseRetryStrategy({
+    validate: (parsed) => {
+      if (parsed === null || typeof parsed !== "object") return false;
+      const obj = parsed as Record<string, unknown>;
+      if (!("userStories" in obj)) return false;
+      if (!Array.isArray(obj.userStories)) return false;
+      return obj.userStories.length > 0;
+    },
+    reviewerKind: "plan",
+    maxAttempts: 3,
+    prompts: {
+      invalid: () => PlanPromptBuilder.jsonRepair(0, "Invalid JSON — response was not parseable"),
+      truncated: () => PlanPromptBuilder.jsonRepair(0, "JSON appears truncated — please rewrite completely"),
+    },
+  }),
+  fileOutput: (input) => input.outputPath,
+  build(input, _ctx) {
+    const { taskContext, outputFormat } = new PlanPromptBuilder().build(
+      input.specContent,
+      input.codebaseContext,
+      input.outputPath,
+      input.packages,
+      input.packageDetails,
+      input.projectProfile,
+    );
+    return {
+      role: { id: "role", content: "", overridable: false },
+      task: { id: "task", content: `${taskContext}\n\n${outputFormat}`, overridable: false },
+    };
+  },
+  async hopBody(initialPrompt, ctx) {
+    const turn1 = await ctx.sendWithParseRetry(initialPrompt);
+    const refinePrompt = new PlanPromptBuilder().buildRefineContinuation(ctx.input.outputPath);
+    const turn2 = await ctx.send(refinePrompt);
+
+    return {
+      ...turn2,
+      estimatedCostUsd: (turn1.estimatedCostUsd ?? 0) + (turn2.estimatedCostUsd ?? 0),
+    };
+  },
+  parse(output, input) {
+    return validatePlanOutput(output, input.featureName, input.branchName);
+  },
+  verify: async (parsed, _input, _ctx) => {
+    if (!parsed.userStories || parsed.userStories.length === 0) return null;
+    return parsed;
+  },
+  recover: async (input, ctx) => {
+    const content = await ctx.readFile(input.outputPath);
+    if (!content) return null;
+    try {
+      return validatePlanOutput(content, input.featureName, input.branchName);
+    } catch {
+      return null;
+    }
+  },
+};

--- a/src/operations/plan-refine.ts
+++ b/src/operations/plan-refine.ts
@@ -6,6 +6,7 @@ import { validatePlanOutput } from "../prd/schema";
 import type { PRD } from "../prd/types";
 import { PlanPromptBuilder } from "../prompts";
 import type { PackageSummary } from "../prompts";
+import type { SessionRole } from "../session/types";
 import type { RunOperation } from "./types";
 
 export interface PlanRefineInput {
@@ -23,7 +24,7 @@ export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
   kind: "run",
   name: "plan-refine",
   stage: "plan",
-  session: { role: "plan-refine", lifetime: "fresh" },
+  session: { role: "plan-refine" as SessionRole, lifetime: "fresh" },
   config: planConfigSelector,
   model: (_input, ctx) => ctx.config.plan.model,
   timeoutMs: (_input, ctx) => (ctx.config.plan.timeoutSeconds ?? 600) * 1000,

--- a/src/plan/index.ts
+++ b/src/plan/index.ts
@@ -1,9 +1,11 @@
 export {
   DebatePlanStrategy,
   PipelinePlanStrategy,
+  RefinePlanStrategy,
   SinglePlanStrategy,
   _debatePlanDeps,
   _pipelinePlanDeps,
+  _refinePlanDeps,
   _singlePlanDeps,
   assertIsValidPrd,
   buildPlanComposition,

--- a/src/plan/strategies/factory.ts
+++ b/src/plan/strategies/factory.ts
@@ -1,6 +1,7 @@
 import { NaxError } from "@/errors";
 import { DebatePlanStrategy } from "./debate";
 import { PipelinePlanStrategy } from "./pipeline";
+import { RefinePlanStrategy } from "./refine";
 import { SinglePlanStrategy } from "./single";
 import type { IPlanStrategy } from "./types";
 
@@ -12,6 +13,8 @@ export function createPlanStrategy(mode: IPlanStrategy["mode"]): IPlanStrategy {
       return new PipelinePlanStrategy();
     case "debate":
       return new DebatePlanStrategy();
+    case "refine":
+      return new RefinePlanStrategy();
     default:
       throw new NaxError(`[plan] Unknown plan mode: ${mode}`, "PLAN_MODE_UNKNOWN", {
         stage: "plan",

--- a/src/plan/strategies/index.ts
+++ b/src/plan/strategies/index.ts
@@ -6,4 +6,5 @@ export { assertIsValidPrd } from "./assert";
 export { SinglePlanStrategy, _singlePlanDeps } from "./single";
 export { PipelinePlanStrategy, _pipelinePlanDeps } from "./pipeline";
 export { DebatePlanStrategy, _debatePlanDeps } from "./debate";
+export { RefinePlanStrategy, _refinePlanDeps } from "./refine";
 export { buildPlanComposition } from "./debate-composition";

--- a/src/plan/strategies/refine.ts
+++ b/src/plan/strategies/refine.ts
@@ -1,18 +1,18 @@
-import { callOp, planInteractiveOp } from "@/operations";
-import type { PlanInteractiveInput } from "@/operations";
-import { validatePlanOutput } from "@/prd";
-import { assertIsValidPrd } from "./assert";
+import { callOp, planRefineOp } from "@/operations";
+import type { PlanRefineInput } from "@/operations";
 import type { IPlanStrategy, PlanModeContext } from "./types";
+import { writeOrRecoverPrd } from "./write-prd";
 
 export const _refinePlanDeps = {
   callOp,
-  planInteractiveOp,
+  planRefineOp,
 };
 
 export class RefinePlanStrategy implements IPlanStrategy {
   readonly mode = "refine" as const;
 
   async execute(ctx: PlanModeContext): Promise<string> {
+    // planCommand() closes the shared runtime in its finally block.
     try {
       const prd = await _refinePlanDeps.callOp(
         {
@@ -25,7 +25,7 @@ export class RefinePlanStrategy implements IPlanStrategy {
           interactionBridge: ctx.interactionBridge,
           maxInteractionTurns: ctx.fullConfig.agent?.maxInteractionTurns,
         },
-        _refinePlanDeps.planInteractiveOp,
+        _refinePlanDeps.planRefineOp,
         {
           specContent: ctx.specContent,
           codebaseContext: ctx.codebaseContext,
@@ -35,24 +35,11 @@ export class RefinePlanStrategy implements IPlanStrategy {
           packages: ctx.relativePackages,
           packageDetails: ctx.packageDetails,
           projectProfile: ctx.fullConfig.project,
-        } satisfies PlanInteractiveInput,
+        } satisfies PlanRefineInput,
       );
-      assertIsValidPrd(prd);
-      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify({ ...prd, project: ctx.projectName }, null, 2));
-      return ctx.outputPath;
+      return writeOrRecoverPrd(ctx, prd);
     } catch (err) {
-      if (ctx.deps.existsSync(ctx.outputPath)) {
-        const rawContent = await ctx.deps.readFile(ctx.outputPath);
-        const recoveredPrd = validatePlanOutput(rawContent, ctx.options.feature, ctx.branchName);
-        await ctx.deps.writeFile(
-          ctx.outputPath,
-          JSON.stringify({ ...recoveredPrd, project: ctx.projectName }, null, 2),
-        );
-        return ctx.outputPath;
-      }
-      throw err;
-    } finally {
-      await ctx.runtime.close().catch(() => {});
+      return writeOrRecoverPrd(ctx, null, err);
     }
   }
 }

--- a/src/plan/strategies/refine.ts
+++ b/src/plan/strategies/refine.ts
@@ -12,7 +12,6 @@ export class RefinePlanStrategy implements IPlanStrategy {
   readonly mode = "refine" as const;
 
   async execute(ctx: PlanModeContext): Promise<string> {
-    // planCommand() closes the shared runtime in its finally block.
     try {
       const prd = await _refinePlanDeps.callOp(
         {
@@ -40,6 +39,8 @@ export class RefinePlanStrategy implements IPlanStrategy {
       return writeOrRecoverPrd(ctx, prd);
     } catch (err) {
       return writeOrRecoverPrd(ctx, null, err);
+    } finally {
+      await ctx.runtime.close().catch(() => {});
     }
   }
 }

--- a/src/plan/strategies/refine.ts
+++ b/src/plan/strategies/refine.ts
@@ -1,0 +1,58 @@
+import { callOp, planInteractiveOp } from "@/operations";
+import type { PlanInteractiveInput } from "@/operations";
+import { validatePlanOutput } from "@/prd";
+import { assertIsValidPrd } from "./assert";
+import type { IPlanStrategy, PlanModeContext } from "./types";
+
+export const _refinePlanDeps = {
+  callOp,
+  planInteractiveOp,
+};
+
+export class RefinePlanStrategy implements IPlanStrategy {
+  readonly mode = "refine" as const;
+
+  async execute(ctx: PlanModeContext): Promise<string> {
+    try {
+      const prd = await _refinePlanDeps.callOp(
+        {
+          runtime: ctx.runtime,
+          packageView: ctx.runtime.packages.resolve(),
+          packageDir: ctx.workdir,
+          agentName: ctx.runtime.agentManager.getDefault(),
+          storyId: ctx.options.feature,
+          featureName: ctx.options.feature,
+          interactionBridge: ctx.interactionBridge,
+          maxInteractionTurns: ctx.fullConfig.agent?.maxInteractionTurns,
+        },
+        _refinePlanDeps.planInteractiveOp,
+        {
+          specContent: ctx.specContent,
+          codebaseContext: ctx.codebaseContext,
+          featureName: ctx.options.feature,
+          branchName: ctx.branchName,
+          outputPath: ctx.outputPath,
+          packages: ctx.relativePackages,
+          packageDetails: ctx.packageDetails,
+          projectProfile: ctx.fullConfig.project,
+        } satisfies PlanInteractiveInput,
+      );
+      assertIsValidPrd(prd);
+      await ctx.deps.writeFile(ctx.outputPath, JSON.stringify({ ...prd, project: ctx.projectName }, null, 2));
+      return ctx.outputPath;
+    } catch (err) {
+      if (ctx.deps.existsSync(ctx.outputPath)) {
+        const rawContent = await ctx.deps.readFile(ctx.outputPath);
+        const recoveredPrd = validatePlanOutput(rawContent, ctx.options.feature, ctx.branchName);
+        await ctx.deps.writeFile(
+          ctx.outputPath,
+          JSON.stringify({ ...recoveredPrd, project: ctx.projectName }, null, 2),
+        );
+        return ctx.outputPath;
+      }
+      throw err;
+    } finally {
+      await ctx.runtime.close().catch(() => {});
+    }
+  }
+}

--- a/src/plan/strategies/types.ts
+++ b/src/plan/strategies/types.ts
@@ -52,6 +52,6 @@ export interface PlanModeContext {
 }
 
 export interface IPlanStrategy {
-  readonly mode: "single" | "pipeline" | "debate";
+  readonly mode: "single" | "pipeline" | "debate" | "refine";
   execute(ctx: PlanModeContext): Promise<string>;
 }

--- a/src/plan/strategies/write-prd.ts
+++ b/src/plan/strategies/write-prd.ts
@@ -5,7 +5,7 @@ import type { PlanModeContext } from "./types";
 
 export async function writeOrRecoverPrd(ctx: PlanModeContext, prd: PRD | null, err?: unknown): Promise<string> {
   if (prd !== null) {
-    await ctx.deps.writeFile(ctx.outputPath, JSON.stringify(prd, null, 2));
+    await ctx.deps.writeFile(ctx.outputPath, JSON.stringify({ ...prd, project: ctx.projectName }, null, 2));
     return ctx.outputPath;
   }
 

--- a/src/prompts/builders/plan-builder.ts
+++ b/src/prompts/builders/plan-builder.ts
@@ -151,6 +151,32 @@ Please re-write the complete PRD JSON, ensuring every factual claim is cited wit
 Output ONLY the JSON object. Do not include markdown fences or explanation.`;
   }
 
+  /**
+   * Refine continuation prompt — second turn in refine mode.
+   *
+   * This prompt is intentionally adversarial and focuses the model on
+   * observable ACs, negative-path coverage, and description/AC consistency.
+   * The model must write the revised PRD to disk, then reply with a brief
+   * confirmation only.
+   */
+  buildRefineContinuation(outputFilePath: string): string {
+    return `You are in the second turn of a refine pass. Assume this draft has flaws, and audit it adversarially before you trust it.
+
+Review the draft with a strict self-audit mindset. Focus only on the issues below, then rewrite the PRD if needed.
+
+#### ac-testable
+For each acceptance criterion, ask whether the assertion is observable through a return value, exception, log output, file content, or state change. If any AC is not directly testable, rewrite it so it is observable.
+
+#### failure-modes-considered
+For each story, confirm there is at least one negative-path acceptance criterion. If a story has no failure case, add one.
+
+#### description-ac-contradiction
+Check whether any sentence in any description contradicts an acceptance criterion in the same story. If there is a contradiction, fix the description so it matches the ACs.
+
+Write the revised PRD to this file path: ${outputFilePath}
+Do not output the PRD in chat. After writing the file, reply with a brief text confirmation only.`;
+  }
+
   build(
     specContent: string,
     codebaseContext: string,

--- a/src/runtime/session-role.ts
+++ b/src/runtime/session-role.ts
@@ -21,6 +21,7 @@ export type CanonicalSessionRole =
   | "plan-draft"
   | "plan-revise"
   | "plan-critic"
+  | "plan-refine"
   | "decompose"
   | "acceptance-gen"
   | "refine"
@@ -46,6 +47,7 @@ export const KNOWN_SESSION_ROLES: readonly CanonicalSessionRole[] = [
   "plan-draft",
   "plan-revise",
   "plan-critic",
+  "plan-refine",
   "decompose",
   "acceptance-gen",
   "refine",

--- a/test/unit/config/plan-mode-refine.test.ts
+++ b/test/unit/config/plan-mode-refine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createPlanStrategy, RefinePlanStrategy } from "@/plan/strategies";
+import { createPlanStrategy, RefinePlanStrategy } from "@/plan";
 import { DEFAULT_CONFIG, NaxConfigSchema } from "@/config";
 import type { NaxConfig } from "@/config";
 import { resolvePlanMode } from "@/cli";

--- a/test/unit/config/plan-mode-refine.test.ts
+++ b/test/unit/config/plan-mode-refine.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { createPlanStrategy, RefinePlanStrategy } from "@/plan/strategies";
+import { DEFAULT_CONFIG, NaxConfigSchema } from "@/config";
+import type { NaxConfig } from "@/config";
+import { resolvePlanMode } from "@/cli";
+
+describe("NaxConfigSchema plan.mode refine", () => {
+  test("accepts refine and rejects unknown modes", () => {
+    const refineResult = NaxConfigSchema.safeParse({
+      ...DEFAULT_CONFIG,
+      plan: { ...DEFAULT_CONFIG.plan, mode: "refine" },
+    });
+    const unknownResult = NaxConfigSchema.safeParse({
+      ...DEFAULT_CONFIG,
+      plan: { ...DEFAULT_CONFIG.plan, mode: "unknown-mode" },
+    });
+
+    expect(refineResult.success).toBe(true);
+    expect(unknownResult.success).toBe(false);
+  });
+});
+
+describe("resolvePlanMode refine", () => {
+  test("returns refine for explicit refine mode", () => {
+    expect(resolvePlanMode({ plan: { mode: "refine" } } as NaxConfig)).toBe("refine");
+  });
+
+  test("returns single for empty config", () => {
+    expect(resolvePlanMode({} as NaxConfig)).toBe("single");
+  });
+
+  test("returns debate when debate auto-selection is enabled", () => {
+    expect(
+      resolvePlanMode({
+        debate: { enabled: true, stages: { plan: { enabled: true } } },
+      } as NaxConfig),
+    ).toBe("debate");
+  });
+
+  test("prefers explicit refine over debate auto-selection", () => {
+    expect(
+      resolvePlanMode({
+        plan: { mode: "refine" },
+        debate: { enabled: true, stages: { plan: { enabled: true } } },
+      } as NaxConfig),
+    ).toBe("refine");
+  });
+});
+
+describe("createPlanStrategy refine", () => {
+  test("returns a refine strategy instance", () => {
+    const strategy = createPlanStrategy("refine" as Parameters<typeof createPlanStrategy>[0]);
+
+    expect(strategy).toBeInstanceOf(RefinePlanStrategy);
+  });
+});

--- a/test/unit/operations/call-op-retry.test.ts
+++ b/test/unit/operations/call-op-retry.test.ts
@@ -25,12 +25,15 @@ const successOp: CompleteOperation<string, string, Pick<typeof DEFAULT_CONFIG, "
 
 // Save/restore _callOpDeps.sleep around each test
 let origSleep: typeof _callOpDeps.sleep;
+let origReadFileOutput: typeof _callOpDeps.readFileOutput;
 const createdRuntimes: NaxRuntime[] = [];
 beforeEach(() => {
   origSleep = _callOpDeps.sleep;
+  origReadFileOutput = _callOpDeps.readFileOutput;
 });
 afterEach(async () => {
   _callOpDeps.sleep = origSleep;
+  _callOpDeps.readFileOutput = origReadFileOutput;
   await Promise.allSettled(createdRuntimes.map((r) => r.close()));
   createdRuntimes.length = 0;
 });
@@ -156,6 +159,247 @@ describe("callOp retry loop (kind:complete)", () => {
 });
 
 describe("callOp retry loop (kind:run) — op.recover on parse exhaustion (#993)", () => {
+  test("re-reads file output when a later send rewrites different same-length content", async () => {
+    const outputPath = "/tmp/plan.json";
+    const firstOutput = '{"analysis":"draft-v1"}';
+    const secondOutput = '{"analysis":"final-v1"}';
+    expect(firstOutput.length).toBe(secondOutput.length);
+
+    let readCount = 0;
+    _callOpDeps.readFileOutput = async () => {
+      readCount++;
+      return readCount === 1 ? firstOutput : secondOutput;
+    };
+
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => ({
+        output: "prd written",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 1,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const runOp: RunOperation<string, { analysis: string }, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      kind: "run",
+      name: "file-output-refresh-op",
+      stage: "plan",
+      config: testSel,
+      session: { role: "plan", lifetime: "fresh" },
+      build: (input) => ({
+        role: { id: "role", content: "", overridable: false },
+        task: { id: "task", content: input, overridable: false },
+      }),
+      fileOutput: () => outputPath,
+      hopBody: async (initialPrompt, ctx) => {
+        await ctx.send(initialPrompt);
+        return ctx.send("refine");
+      },
+      parse: (output) => JSON.parse(output) as { analysis: string },
+    };
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      runOp,
+      "hello",
+    );
+
+    expect(result).toEqual({ analysis: "final-v1" });
+    expect(readCount).toBe(2);
+  });
+
+  test("reuses the latest file snapshot when a later send leaves the file unchanged", async () => {
+    const outputPath = "/tmp/plan.json";
+    const fileOutput = '{"analysis":"draft-v1"}';
+
+    let readCount = 0;
+    _callOpDeps.readFileOutput = async () => {
+      readCount++;
+      return fileOutput;
+    };
+
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => ({
+        output: "prd written",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 1,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const runOp: RunOperation<string, { analysis: string }, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      kind: "run",
+      name: "file-output-snapshot-op",
+      stage: "plan",
+      config: testSel,
+      session: { role: "plan", lifetime: "fresh" },
+      build: (input) => ({
+        role: { id: "role", content: "", overridable: false },
+        task: { id: "task", content: input, overridable: false },
+      }),
+      fileOutput: () => outputPath,
+      hopBody: async (initialPrompt, ctx) => {
+        await ctx.send(initialPrompt);
+        return ctx.send("refine");
+      },
+      parse: (output) => JSON.parse(output) as { analysis: string },
+      recover: async () => ({ analysis: "recover-should-not-win" }),
+    };
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      runOp,
+      "hello",
+    );
+
+    expect(result).toEqual({ analysis: "draft-v1" });
+    expect(readCount).toBe(2);
+  });
+
+  test("sendWithParseRetry probes substituted file output instead of the agent acknowledgement", async () => {
+    const outputPath = "/tmp/plan.json";
+    const fileOutput = '{"analysis":"draft-v1"}';
+    let readCount = 0;
+    _callOpDeps.readFileOutput = async () => {
+      readCount++;
+      return fileOutput;
+    };
+
+    let runCount = 0;
+    const shouldRetry = (failure: Error, attempt: number, ctx: { lastOutput?: string }) => {
+      expect(failure).toBeInstanceOf(Error);
+      expect(attempt).toBe(0);
+      expect(ctx.lastOutput).toBe(fileOutput);
+      return { retry: false };
+    };
+
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => {
+        runCount++;
+        return {
+          output: "prd written",
+          estimatedCostUsd: 0,
+          internalRoundTrips: 1,
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        };
+      },
+    });
+    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const runOp: RunOperation<string, { analysis: string }, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      kind: "run",
+      name: "file-output-retry-op",
+      stage: "plan",
+      config: testSel,
+      session: { role: "plan", lifetime: "fresh" },
+      build: (input) => ({
+        role: { id: "role", content: "", overridable: false },
+        task: { id: "task", content: input, overridable: false },
+      }),
+      retry: { shouldRetry },
+      fileOutput: () => outputPath,
+      hopBody: async (initialPrompt, ctx) => ctx.sendWithParseRetry(initialPrompt),
+      parse: (output) => JSON.parse(output) as { analysis: string },
+    };
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      runOp,
+      "hello",
+    );
+
+    expect(result).toEqual({ analysis: "draft-v1" });
+    expect(readCount).toBe(1);
+    expect(runCount).toBe(1);
+  });
+
+  test("sendWithParseRetry re-reads substituted file output on retry attempts", async () => {
+    const outputPath = "/tmp/plan.json";
+    const firstOutput = '{"analysis":"draft-v1"}';
+    const secondOutput = '{"analysis":"final-v1"}';
+    expect(firstOutput.length).toBe(secondOutput.length);
+
+    let readCount = 0;
+    _callOpDeps.readFileOutput = async () => {
+      readCount++;
+      return readCount === 1 ? firstOutput : secondOutput;
+    };
+
+    let runCount = 0;
+    const shouldRetry = (failure: Error, attempt: number, ctx: { lastOutput?: string }) => {
+      expect(failure).toBeInstanceOf(Error);
+      if (attempt === 0) {
+        expect(ctx.lastOutput).toBe(firstOutput);
+        return { retry: true, delayMs: 0, nextPrompt: "retry" };
+      }
+
+      expect(attempt).toBe(1);
+      expect(ctx.lastOutput).toBe(secondOutput);
+      return { retry: false };
+    };
+
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => {
+        runCount++;
+        return {
+          output: "prd written",
+          estimatedCostUsd: 0,
+          internalRoundTrips: 1,
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        };
+      },
+    });
+    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const runOp: RunOperation<string, { analysis: string }, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      kind: "run",
+      name: "file-output-retry-loop-op",
+      stage: "plan",
+      config: testSel,
+      session: { role: "plan", lifetime: "fresh" },
+      build: (input) => ({
+        role: { id: "role", content: "", overridable: false },
+        task: { id: "task", content: input, overridable: false },
+      }),
+      retry: { shouldRetry },
+      fileOutput: () => outputPath,
+      hopBody: async (initialPrompt, ctx) => ctx.sendWithParseRetry(initialPrompt),
+      parse: (output) => JSON.parse(output) as { analysis: string },
+    };
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      runOp,
+      "hello",
+    );
+
+    expect(result).toEqual({ analysis: "final-v1" });
+    expect(readCount).toBe(2);
+    expect(runCount).toBe(2);
+  });
+
   test("op.parse throws after retry exhaustion AND op.recover returns non-null — returns recover value not TurnResult", async () => {
     _callOpDeps.sleep = async () => {};
 

--- a/test/unit/operations/plan-refine.test.ts
+++ b/test/unit/operations/plan-refine.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { join } from "node:path";
+import { callOp } from "@/operations";
+import type { AgentRunRequest } from "@/agents/manager-types";
 import { PlanPromptBuilder } from "@/prompts";
 import { planInteractiveOp } from "@/operations";
 import type { VerifyContext } from "@/operations";
 import type { NaxRuntime } from "@/runtime";
-import { makeTestRuntime } from "@test/helpers";
+import { makeMockAgentManager, makeSessionManager, makeTestRuntime, withTempDir } from "@test/helpers";
 import type { HopBodyContext } from "@/operations/types";
 
 const createdRuntimes: NaxRuntime[] = [];
@@ -157,6 +160,126 @@ describe("planRefineOp.hopBody()", () => {
     expect(send).toHaveBeenCalledWith(refinePrompt);
     expect(result.output).toBe("refined-confirmation");
     expect(result.estimatedCostUsd).toBe(4);
+  });
+
+  test("callOp parses the rewritten PRD file after the refine turn instead of the chat confirmation", async () => {
+    await withTempDir(async (tempDir) => {
+      const outputPath = join(tempDir, "prd.json");
+      const turn1Prd = makeValidPrd("checkout-flow", "feat/checkout");
+      const turn2Prd = {
+        ...makeValidPrd("checkout-flow", "feat/checkout"),
+        analysis: "refined analysis",
+      };
+
+      const agentManager = makeMockAgentManager({
+        runWithFallbackFn: async (req: AgentRunRequest) => {
+          const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+          return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+        },
+        runAsSessionFn: async (_agentName, _handle, prompt) => {
+          if (prompt.includes("You are drafting a PRD")) {
+            await Bun.write(outputPath, JSON.stringify(turn1Prd));
+            return {
+              output: "draft written",
+              estimatedCostUsd: 1,
+              internalRoundTrips: 1,
+              tokenUsage: { inputTokens: 1, outputTokens: 1 },
+            };
+          }
+
+          await Bun.write(outputPath, JSON.stringify(turn2Prd));
+          return {
+            output: "refinement complete",
+            estimatedCostUsd: 2,
+            internalRoundTrips: 1,
+            tokenUsage: { inputTokens: 1, outputTokens: 1 },
+          };
+        },
+      });
+
+      const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+      createdRuntimes.push(runtime);
+
+      const result = await callOp(
+        {
+          runtime,
+          packageView: runtime.packages.repo(),
+          packageDir: tempDir,
+          agentName: runtime.agentManager.getDefault(),
+          storyId: "checkout-flow",
+          featureName: "checkout-flow",
+        },
+        (await import("@/operations")).planRefineOp,
+        {
+          specContent: "Build a checkout flow",
+          codebaseContext: "Existing app context",
+          featureName: "checkout-flow",
+          branchName: "feat/checkout",
+          outputPath,
+        },
+      );
+
+      expect(result.analysis).toBe("refined analysis");
+    });
+  });
+
+  test("callOp falls back to recover when the refine turn does not rewrite the PRD file", async () => {
+    await withTempDir(async (tempDir) => {
+      const outputPath = join(tempDir, "prd.json");
+      const turn1Prd = {
+        ...makeValidPrd("checkout-flow", "feat/checkout"),
+        analysis: "draft analysis",
+      };
+
+      const agentManager = makeMockAgentManager({
+        runWithFallbackFn: async (req: AgentRunRequest) => {
+          const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+          return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+        },
+        runAsSessionFn: async (_agentName, _handle, prompt) => {
+          if (prompt.includes("You are drafting a PRD")) {
+            await Bun.write(outputPath, JSON.stringify(turn1Prd));
+            return {
+              output: "draft written",
+              estimatedCostUsd: 1,
+              internalRoundTrips: 1,
+              tokenUsage: { inputTokens: 1, outputTokens: 1 },
+            };
+          }
+
+          return {
+            output: "refinement complete",
+            estimatedCostUsd: 2,
+            internalRoundTrips: 1,
+            tokenUsage: { inputTokens: 1, outputTokens: 1 },
+          };
+        },
+      });
+
+      const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+      createdRuntimes.push(runtime);
+
+      const result = await callOp(
+        {
+          runtime,
+          packageView: runtime.packages.repo(),
+          packageDir: tempDir,
+          agentName: runtime.agentManager.getDefault(),
+          storyId: "checkout-flow",
+          featureName: "checkout-flow",
+        },
+        (await import("@/operations")).planRefineOp,
+        {
+          specContent: "Build a checkout flow",
+          codebaseContext: "Existing app context",
+          featureName: "checkout-flow",
+          branchName: "feat/checkout",
+          outputPath,
+        },
+      );
+
+      expect(result.analysis).toBe("draft analysis");
+    });
   });
 });
 

--- a/test/unit/operations/plan-refine.test.ts
+++ b/test/unit/operations/plan-refine.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { PlanPromptBuilder } from "@/prompts";
+import { planInteractiveOp } from "@/operations";
+import type { VerifyContext } from "@/operations";
+import type { NaxRuntime } from "@/runtime";
+import { makeTestRuntime } from "@test/helpers";
+import type { HopBodyContext } from "@/operations/types";
+
+const createdRuntimes: NaxRuntime[] = [];
+
+afterEach(async () => {
+  mock.restore();
+  await Promise.allSettled(createdRuntimes.map((runtime) => runtime.close()));
+  createdRuntimes.length = 0;
+});
+
+function makeValidPrd(feature: string, branchName: string) {
+  return {
+    project: "test-project",
+    feature,
+    analysis: "test analysis",
+    branchName,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    userStories: [
+      {
+        id: "US-001",
+        title: "Test story",
+        description: "Test description",
+        acceptanceCriteria: ["Test AC"],
+        contextFiles: [],
+        tags: [],
+        dependencies: [],
+        status: "pending",
+        passes: false,
+        routing: {
+          complexity: "simple",
+          testStrategy: "no-test",
+          noTestJustification: "test",
+          reasoning: "test",
+        },
+        escalations: [],
+        attempts: 0,
+      },
+    ],
+  };
+}
+
+describe("planRefineOp export and identity", () => {
+  test("exports planRefineOp from the operations barrel", async () => {
+    const mod = await import("@/operations");
+    expect(mod).toHaveProperty("planRefineOp");
+  });
+
+  test("has kind run and name plan-refine", async () => {
+    const mod = await import("@/operations");
+    const { planRefineOp } = mod;
+    expect(planRefineOp.kind).toBe("run");
+    expect(planRefineOp.name).toBe("plan-refine");
+  });
+
+  test("uses the plan-refine session role with a fresh lifetime", async () => {
+    const mod = await import("@/operations");
+    const { planRefineOp } = mod;
+    expect(planRefineOp.session.role).toBe("plan-refine");
+    expect(planRefineOp.session.lifetime).toBe("fresh");
+  });
+
+  test("defines config and retry for the two-turn refine flow", async () => {
+    const mod = await import("@/operations");
+    const { planRefineOp } = mod;
+    expect(planRefineOp.config).toBeDefined();
+    expect(planRefineOp.retry).toBeDefined();
+    expect(typeof planRefineOp.retry).toBe("function");
+  });
+
+  test("defines fileOutput so callOp can substitute written PRD content", async () => {
+    const mod = await import("@/operations");
+    const { planRefineOp } = mod;
+    const outputPath = "/tmp/plan-refine-prd.json";
+    expect(planRefineOp.fileOutput?.({ outputPath } as never)).toBe(outputPath);
+  });
+});
+
+describe("planRefineOp.build()", () => {
+  test("returns a ComposeInput whose task content includes the feature name", async () => {
+    const mod = await import("@/operations");
+    const { planRefineOp } = mod;
+    const runtime = makeTestRuntime();
+    createdRuntimes.push(runtime);
+    const view = runtime.packages.repo();
+    const ctx = { packageView: view, config: view.select(planInteractiveOp.config) };
+
+    const result = planRefineOp.build(
+      {
+        specContent: "Build a checkout flow",
+        codebaseContext: "Existing app context",
+        featureName: "checkout-flow",
+        branchName: "feat/checkout",
+        outputPath: "/tmp/prd.json",
+      },
+      ctx,
+    );
+
+    expect(result.task.content).toContain("checkout-flow");
+  });
+});
+
+describe("planRefineOp.hopBody()", () => {
+  test("calls sendWithParseRetry for the draft turn and send for the refine turn", async () => {
+    const mod = await import("@/operations");
+    const { planRefineOp } = mod;
+    const initialPrompt = "draft prompt";
+    const refinePrompt = "refine prompt";
+
+    const sendWithParseRetry = mock(async (_prompt: string) => ({
+      output: "draft-confirmation",
+      estimatedCostUsd: 1.25,
+      internalRoundTrips: 1,
+      tokenUsage: { inputTokens: 1, outputTokens: 1 },
+    }));
+    const send = mock(async (_prompt: string) => ({
+      output: "refined-confirmation",
+      estimatedCostUsd: 2.75,
+      internalRoundTrips: 2,
+      tokenUsage: { inputTokens: 2, outputTokens: 2 },
+    }));
+    const buildRefineContinuationSpy = spyOn(PlanPromptBuilder.prototype, "buildRefineContinuation").mockReturnValue(
+      refinePrompt,
+    );
+
+    const ctx: HopBodyContext<{
+      specContent: string;
+      codebaseContext: string;
+      featureName: string;
+      branchName: string;
+      outputPath: string;
+    }> = {
+      input: {
+        specContent: "Build a checkout flow",
+        codebaseContext: "Existing app context",
+        featureName: "checkout-flow",
+        branchName: "feat/checkout",
+        outputPath: "/tmp/plan-refine-prd.json",
+      },
+      send,
+      sendWithParseRetry,
+    };
+
+    const result = await planRefineOp.hopBody(initialPrompt, ctx);
+
+    expect(sendWithParseRetry).toHaveBeenCalledTimes(1);
+    expect(sendWithParseRetry).toHaveBeenCalledWith(initialPrompt);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(buildRefineContinuationSpy).toHaveBeenCalledTimes(1);
+    expect(buildRefineContinuationSpy).toHaveBeenCalledWith("/tmp/plan-refine-prd.json");
+    expect(send).toHaveBeenCalledWith(refinePrompt);
+    expect(result.output).toBe("refined-confirmation");
+    expect(result.estimatedCostUsd).toBe(4);
+  });
+});
+
+describe("planRefineOp.recover()", () => {
+  test("returns null when the output file is missing", async () => {
+    const mod = await import("@/operations");
+    const { planRefineOp } = mod;
+    const runtime = makeTestRuntime();
+    createdRuntimes.push(runtime);
+    const view = runtime.packages.repo();
+    const ctx: VerifyContext<unknown> = {
+      packageView: view,
+      config: view.select(planInteractiveOp.config),
+      readFile: async () => null,
+      fileExists: async () => false,
+    };
+
+    const result = await planRefineOp.recover?.(
+      {
+        specContent: "Build a checkout flow",
+        codebaseContext: "Existing app context",
+        featureName: "checkout-flow",
+        branchName: "feat/checkout",
+        outputPath: "/tmp/missing-prd.json",
+      },
+      ctx,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("returns a parsed PRD when the output file contains valid JSON", async () => {
+    const mod = await import("@/operations");
+    const { planRefineOp } = mod;
+    const runtime = makeTestRuntime();
+    createdRuntimes.push(runtime);
+    const view = runtime.packages.repo();
+    const validPrd = makeValidPrd("checkout-flow", "feat/checkout");
+    const ctx: VerifyContext<unknown> = {
+      packageView: view,
+      config: view.select(planInteractiveOp.config),
+      readFile: async () => JSON.stringify(validPrd),
+      fileExists: async () => true,
+    };
+
+    const result = await planRefineOp.recover?.(
+      {
+        specContent: "Build a checkout flow",
+        codebaseContext: "Existing app context",
+        featureName: "checkout-flow",
+        branchName: "feat/checkout",
+        outputPath: "/tmp/plan-refine-prd.json",
+      },
+      ctx,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.feature).toBe("checkout-flow");
+    expect(result?.branchName).toBe("feat/checkout");
+    expect(result?.userStories).toHaveLength(1);
+  });
+
+  test("returns null when the output file contains invalid JSON", async () => {
+    const mod = await import("@/operations");
+    const { planRefineOp } = mod;
+    const runtime = makeTestRuntime();
+    createdRuntimes.push(runtime);
+    const view = runtime.packages.repo();
+    const ctx: VerifyContext<unknown> = {
+      packageView: view,
+      config: view.select(planInteractiveOp.config),
+      readFile: async () => "not valid json {",
+      fileExists: async () => true,
+    };
+
+    const result = await planRefineOp.recover?.(
+      {
+        specContent: "Build a checkout flow",
+        codebaseContext: "Existing app context",
+        featureName: "checkout-flow",
+        branchName: "feat/checkout",
+        outputPath: "/tmp/bad-prd.json",
+      },
+      ctx,
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/test/unit/plan/refine-strategy.test.ts
+++ b/test/unit/plan/refine-strategy.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { InteractionBridge } from "@/interaction/bridge-builder";
+import { RefinePlanStrategy, _refinePlanDeps } from "@/plan";
+import type { PlanDeps, PlanModeContext } from "@/plan/strategies/types";
+import type { PackageSummary } from "@/prompts";
+import type { NaxRuntime } from "@/runtime";
+import { makeMockAgentManager } from "@test/helpers";
+
+function makeRuntime(closeImpl?: () => Promise<void>): NaxRuntime {
+  return {
+    packages: { resolve: () => ({}) },
+    agentManager: makeMockAgentManager({ getDefaultAgent: "agent-refine" }),
+    close: closeImpl ?? (async () => {}),
+  } as unknown as NaxRuntime;
+}
+
+const VALID_PRD_JSON = JSON.stringify({
+  userStories: [
+    {
+      id: "US-001",
+      title: "Recovered story",
+      description: "A recovered story for disk-recovery testing",
+      acceptanceCriteria: ["AC1: should pass"],
+      complexity: "simple",
+    },
+  ],
+});
+
+function makeDeps(exists = false): PlanDeps {
+  return {
+    readFile: async () => (exists ? VALID_PRD_JSON : ""),
+    writeFile: async () => {},
+    mkdirp: async () => {},
+    existsSync: () => exists,
+    readPackageJson: async () => null,
+    readPackageJsonAt: async () => null,
+    scanSourceRoots: async () => [],
+    spawnSync: () => ({ stdout: Buffer.from(""), exitCode: 0 }),
+    initInteractionChain: async () => null,
+    createInteractionBridge: () => ({
+      detectQuestion: async () => false,
+      onQuestionDetected: async () => "",
+    }),
+    createDebateRunner: () => ({}) as never,
+    getLogger: () => null,
+  };
+}
+
+function makeCtx(overrides: Partial<PlanModeContext> = {}): PlanModeContext {
+  return {
+    workdir: "/tmp/workdir",
+    naxDir: "/tmp/workdir/.nax",
+    outputDir: "/tmp/workdir/.nax/features/feat-x",
+    outputPath: "/tmp/workdir/.nax/features/feat-x/prd.json",
+    specContent: "# spec",
+    codebaseContext: "context",
+    normalizedRoots: [],
+    relativePackages: ["packages/api"],
+    packageDetails: [{ path: "packages/api", packageName: "@acme/api", stackSummary: "TypeScript" } as PackageSummary],
+    projectName: "acme",
+    branchName: "feat/feat-x",
+    timeoutSeconds: 30,
+    config: { timeoutSeconds: 30 } as never,
+    fullConfig: {} as never,
+    options: { from: "/tmp/spec.md", feature: "feat-x" },
+    runtime: makeRuntime(),
+    interactionChain: null,
+    interactionBridge: {} as InteractionBridge,
+    deps: makeDeps(),
+    ...overrides,
+  };
+}
+
+describe("RefinePlanStrategy", () => {
+  test("mode is refine", () => {
+    const strategy = new RefinePlanStrategy();
+    expect(strategy.mode).toBe("refine");
+  });
+
+  test("calls callOp with planRefineOp and returns outputPath on success", async () => {
+    const strategy = new RefinePlanStrategy();
+    const ctx = makeCtx();
+    const callOpMock = mock(async () => ({ userStories: [{}] }));
+    const originalCallOp = _refinePlanDeps.callOp;
+    _refinePlanDeps.callOp = callOpMock as typeof _refinePlanDeps.callOp;
+
+    try {
+      const result = await strategy.execute(ctx);
+      expect(result).toBe(ctx.outputPath);
+      expect(callOpMock).toHaveBeenCalledTimes(1);
+      const [callCtx, operation, input] = callOpMock.mock.calls[0] as [Record<string, unknown>, unknown, Record<string, unknown>];
+      expect(callCtx.runtime).toBe(ctx.runtime);
+      expect(callCtx.packageDir).toBe(ctx.workdir);
+      expect(callCtx.agentName).toBe("agent-refine");
+      expect(callCtx.storyId).toBe(ctx.options.feature);
+      expect(callCtx.featureName).toBe(ctx.options.feature);
+      expect(callCtx.interactionBridge).toBe(ctx.interactionBridge);
+      expect(callCtx.maxInteractionTurns).toBe(ctx.fullConfig.agent?.maxInteractionTurns);
+      expect(operation).toBe(_refinePlanDeps.planRefineOp);
+      expect(input).toEqual({
+        specContent: ctx.specContent,
+        codebaseContext: ctx.codebaseContext,
+        featureName: ctx.options.feature,
+        branchName: ctx.branchName,
+        outputPath: ctx.outputPath,
+        packages: ctx.relativePackages,
+        packageDetails: ctx.packageDetails,
+        projectProfile: ctx.fullConfig.project,
+      });
+    } finally {
+      _refinePlanDeps.callOp = originalCallOp;
+    }
+  });
+
+  test("returns outputPath when callOp throws and output file already exists", async () => {
+    const strategy = new RefinePlanStrategy();
+    const ctx = makeCtx({ deps: makeDeps(true) });
+    const originalCallOp = _refinePlanDeps.callOp;
+    _refinePlanDeps.callOp = mock(async () => {
+      throw new Error("callOp failed");
+    }) as typeof _refinePlanDeps.callOp;
+
+    try {
+      await expect(strategy.execute(ctx)).resolves.toBe(ctx.outputPath);
+    } finally {
+      _refinePlanDeps.callOp = originalCallOp;
+    }
+  });
+
+  test("does not close runtime in strategy lifecycle", async () => {
+    const closeSpy = mock(async () => {});
+    const strategy = new RefinePlanStrategy();
+    const ctx = makeCtx({ runtime: makeRuntime(closeSpy) });
+    const originalCallOp = _refinePlanDeps.callOp;
+    _refinePlanDeps.callOp = mock(async () => ({ userStories: [{}] })) as typeof _refinePlanDeps.callOp;
+
+    try {
+      await strategy.execute(ctx);
+      expect(closeSpy).toHaveBeenCalledTimes(0);
+    } finally {
+      _refinePlanDeps.callOp = originalCallOp;
+    }
+  });
+});

--- a/test/unit/plan/refine-strategy.test.ts
+++ b/test/unit/plan/refine-strategy.test.ts
@@ -79,7 +79,8 @@ describe("RefinePlanStrategy", () => {
 
   test("calls callOp with planRefineOp and returns outputPath on success", async () => {
     const strategy = new RefinePlanStrategy();
-    const ctx = makeCtx();
+    const closeSpy = mock(async () => {});
+    const ctx = makeCtx({ runtime: makeRuntime(closeSpy) });
     const callOpMock = mock(async () => ({ userStories: [{}] }));
     const originalCallOp = _refinePlanDeps.callOp;
     _refinePlanDeps.callOp = callOpMock as typeof _refinePlanDeps.callOp;
@@ -107,6 +108,7 @@ describe("RefinePlanStrategy", () => {
         packageDetails: ctx.packageDetails,
         projectProfile: ctx.fullConfig.project,
       });
+      expect(closeSpy).toHaveBeenCalledTimes(1);
     } finally {
       _refinePlanDeps.callOp = originalCallOp;
     }
@@ -114,7 +116,8 @@ describe("RefinePlanStrategy", () => {
 
   test("returns outputPath when callOp throws and output file already exists", async () => {
     const strategy = new RefinePlanStrategy();
-    const ctx = makeCtx({ deps: makeDeps(true) });
+    const closeSpy = mock(async () => {});
+    const ctx = makeCtx({ deps: makeDeps(true), runtime: makeRuntime(closeSpy) });
     const originalCallOp = _refinePlanDeps.callOp;
     _refinePlanDeps.callOp = mock(async () => {
       throw new Error("callOp failed");
@@ -122,12 +125,13 @@ describe("RefinePlanStrategy", () => {
 
     try {
       await expect(strategy.execute(ctx)).resolves.toBe(ctx.outputPath);
+      expect(closeSpy).toHaveBeenCalledTimes(1);
     } finally {
       _refinePlanDeps.callOp = originalCallOp;
     }
   });
 
-  test("does not close runtime in strategy lifecycle", async () => {
+  test("closes runtime in strategy lifecycle", async () => {
     const closeSpy = mock(async () => {});
     const strategy = new RefinePlanStrategy();
     const ctx = makeCtx({ runtime: makeRuntime(closeSpy) });
@@ -136,7 +140,7 @@ describe("RefinePlanStrategy", () => {
 
     try {
       await strategy.execute(ctx);
-      expect(closeSpy).toHaveBeenCalledTimes(0);
+      expect(closeSpy).toHaveBeenCalledTimes(1);
     } finally {
       _refinePlanDeps.callOp = originalCallOp;
     }

--- a/test/unit/plan/strategies-factory.test.ts
+++ b/test/unit/plan/strategies-factory.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { NaxError } from "@/errors";
-import { DebatePlanStrategy, PipelinePlanStrategy, SinglePlanStrategy } from "@/plan";
+import { DebatePlanStrategy, PipelinePlanStrategy, RefinePlanStrategy, SinglePlanStrategy } from "@/plan";
 
 const PLAN_TS_PATH = join(import.meta.dir, "../../../src/cli/plan.ts");
 
@@ -11,11 +11,12 @@ describe("createPlanStrategy", () => {
     ["single", SinglePlanStrategy],
     ["pipeline", PipelinePlanStrategy],
     ["debate", DebatePlanStrategy],
+    ["refine", RefinePlanStrategy],
   ])("returns a %s strategy instance", async (mode, StrategyClass) => {
     const strategyModulePath = pathToFileURL(join(import.meta.dir, "../../../src/plan/strategies/index.ts")).href;
     const { createPlanStrategy } = await import(strategyModulePath);
 
-    expect(createPlanStrategy(mode as "single" | "pipeline" | "debate")).toBeInstanceOf(StrategyClass);
+    expect(createPlanStrategy(mode as "single" | "pipeline" | "debate" | "refine")).toBeInstanceOf(StrategyClass);
   });
 
   test("throws PLAN_MODE_UNKNOWN for an unrecognised mode", async () => {
@@ -41,6 +42,7 @@ describe("plan barrel", () => {
     expect(planModule.SinglePlanStrategy).toBe(SinglePlanStrategy);
     expect(planModule.PipelinePlanStrategy).toBe(PipelinePlanStrategy);
     expect(planModule.DebatePlanStrategy).toBe(DebatePlanStrategy);
+    expect(planModule.RefinePlanStrategy).toBe(RefinePlanStrategy);
   });
 });
 

--- a/test/unit/plan/strategies.test.ts
+++ b/test/unit/plan/strategies.test.ts
@@ -199,7 +199,10 @@ describe("writeOrRecoverPrd", () => {
     const result = await writeOrRecoverPrd(ctx, SAMPLE_PRD);
 
     expect(result).toBe(ctx.outputPath);
-    expect(deps.writeFile).toHaveBeenCalledWith(ctx.outputPath, JSON.stringify(SAMPLE_PRD, null, 2));
+    expect(deps.writeFile).toHaveBeenCalledWith(
+      ctx.outputPath,
+      JSON.stringify({ ...SAMPLE_PRD, project: ctx.projectName }, null, 2),
+    );
   });
 
   test("recovers by reading the written file when plan generation fails after write", async () => {
@@ -211,6 +214,12 @@ describe("writeOrRecoverPrd", () => {
 
     expect(result).toBe(ctx.outputPath);
     expect(deps.readFile).toHaveBeenCalledWith(ctx.outputPath);
+    const writeCall = (deps.writeFile as ReturnType<typeof mock>).mock.calls.at(-1);
+    expect(writeCall?.[0]).toBe(ctx.outputPath);
+    const writtenPrd = JSON.parse(String(writeCall?.[1])) as PRD;
+    expect(writtenPrd.project).toBe(ctx.projectName);
+    expect(writtenPrd.feature).toBe(SAMPLE_PRD.feature);
+    expect(writtenPrd.userStories).toHaveLength(SAMPLE_PRD.userStories.length);
   });
 
   test("rethrows the original error when no recovered file exists", async () => {

--- a/test/unit/prompts/builders/plan-builder.test.ts
+++ b/test/unit/prompts/builders/plan-builder.test.ts
@@ -271,6 +271,23 @@ describe("PlanPromptBuilder.jsonRepair() — US-002", () => {
   });
 });
 
+// ─── PlanPromptBuilder.buildRefineContinuation() ─────────────────────────────
+
+describe("PlanPromptBuilder.buildRefineContinuation()", () => {
+  test("returns an adversarial continuation prompt with the expected checklist sections", () => {
+    const outputFilePath = "/path/to/prd.json";
+    const result = new PlanPromptBuilder().buildRefineContinuation(outputFilePath);
+
+    expect(result.length).toBeGreaterThan(200);
+    expect(result).toContain("ac-testable");
+    expect(result).toContain("failure-modes-considered");
+    expect(result).toContain("description-ac-contradiction");
+    expect(result).toContain(outputFilePath);
+    expect(result.toLowerCase()).toMatch(/flaws|adversarial/);
+    expect(result).not.toContain("```json");
+  });
+});
+
 // ─── Source Roots section (wireSourceRoots story) ─────────────────────────────
 
 describe("PlanPromptBuilder.build — Source Roots section", () => {

--- a/test/unit/runtime/session-role.test.ts
+++ b/test/unit/runtime/session-role.test.ts
@@ -25,7 +25,7 @@ describe("SessionRole", () => {
       "main", "test-writer", "implementer", "verifier",
       "diagnose", "source-fix", "test-fix",
       "reviewer-semantic", "reviewer-adversarial",
-      "plan", "decompose",
+      "plan", "plan-draft", "plan-revise", "plan-critic", "plan-refine", "decompose",
       "acceptance-gen", "refine", "fix-gen",
       "auto", "synthesis", "judge",
     ] as SessionRole[])("returns true for canonical role: %s", (role) => {


### PR DESCRIPTION
## What
Add an opt-in `refine` plan mode that runs a two-turn single-session planning flow: the first turn drafts the PRD, and the second turn performs an adversarial self-audit that rewrites the PRD in place. This branch also hardens file-backed plan output handling so `callOp` always parses the latest PRD JSON from disk after each send and retry probe.

## Why
Cheap-model single mode still leaves gaps in testable ACs, failure-mode coverage, and description-to-AC consistency. Refine mode closes more of that gap with two LLM turns in one session, instead of pipeline mode's extra grounding and critic calls.

Closes #

## How
- add `planRefineOp` and `RefinePlanStrategy` for the two-turn refine workflow
- extend config, CLI mode resolution, and session-role wiring for `plan.mode: "refine"` and `--mode refine`
- add the adversarial `buildRefineContinuation()` prompt that rewrites the PRD file in place
- ensure `callOp.fileOutput` substitutes readable file contents after every `send` and `sendWithParseRetry` probe
- add regression coverage for same-length rewrites, unchanged file output, and retry-path rereads
- normalize refine PRD writes and close the refine runtime in strategy lifecycle

## Testing
- [x] Tests added/updated
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes

## Notes
- Targeted tests passed: `timeout 30 bun test test/unit/operations/call-op-retry.test.ts --timeout=5000`
- Targeted tests passed: `timeout 30 bun test test/unit/operations/call-op-retry.test.ts test/unit/operations/plan-refine.test.ts --timeout=5000`
- `bun run typecheck` exited non-zero in this environment without emitting diagnostics.
- `bun run lint` printed OK for the individual branch checks after the alias-import fix, but the overall command still did not return a clean zero exit here.
