### PR TITLE
[codex] Fix pid registry cleanup

### DIFF
--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -24,4 +24,4 @@ export {
   resetCrashHandlers,
   type CrashRecoveryContext,
 } from "./crash-recovery";
-export { PidRegistry } from "./pid-registry";
+export { PidRegistry, _pidRegistryDeps } from "./pid-registry";

--- a/src/execution/pid-registry.ts
+++ b/src/execution/pid-registry.ts
@@ -1,104 +1,50 @@
-/**
- * PID Registry — Track and cleanup spawned agent processes
- *
- * Implements BUG-002:
- * - Track PIDs of spawned Claude Code processes
- * - Write .nax-pids file for persistence across crashes
- * - Support killAll() for crash signal handlers
- * - Support cleanupStale() for startup cleanup
- *
- * Safety: signals are sent to a single PID, never to a process group. The previous
- * Linux code path used `kill -TERM -<pid>` (negative pid = process group) under the
- * assumption every spawned acpx was a session leader. That assumption fails for
- * per-call acpx invocations (not setsid'd) and, combined with PID recycling between
- * the existence check and the signal, could SIGTERM unrelated process groups —
- * including the user's desktop session. Direct PID-only signaling avoids that
- * blast radius. If a single descendant survives this signal, the OS reaps it when
- * nax exits; orphan acpx queue-owners are addressed independently by
- * `complete()` calling `session.close({ forceTerminate: true })`.
- */
+/** Track spawned agent PIDs and clean them up on crash without process-group kills. */
 
 import { existsSync } from "node:fs";
 import { appendFile } from "node:fs/promises";
-import { getSafeLogger } from "../logger";
+import { getSafeLogger } from "@/logger";
 
-/**
- * PID registry file name
- */
 const PID_REGISTRY_FILE = ".nax-pids";
+const PID_TREE_KILL_GRACE_MS = 250;
 
-/**
- * PID registry entry
- */
+export const _pidRegistryDeps = {
+  spawn: Bun.spawn as typeof Bun.spawn,
+  sleep: Bun.sleep,
+};
+
 interface PidEntry {
   pid: number;
   spawnedAt: string;
   workdir: string;
 }
 
-/**
- * PID Registry — Track spawned agent processes and cleanup orphans
- *
- * Maintains a .nax-pids file in the workdir to track spawned processes.
- * On crash, signal handlers call killAll() to terminate all tracked PIDs.
- * On startup, runner calls cleanupStale() to kill any orphaned processes from previous runs.
- *
- * @example
- * ```ts
- * const registry = new PidRegistry("/path/to/project");
- * await registry.register(12345);
- * // ... later, on crash or shutdown
- * await registry.killAll();
- * ```
- */
+interface ProcessIdentity {
+  pid: number;
+  parentPid: number;
+  startedAt: string;
+}
+
 export class PidRegistry {
   private readonly workdir: string;
   private readonly pidsFilePath: string;
   private readonly pids: Set<number> = new Set();
   private frozen = false;
 
-  /**
-   * Create a new PID registry for the given workdir.
-   *
-   * @param workdir - Working directory where .nax-pids will be stored
-   * @param _platform - Reserved for backward compatibility; signals are now
-   *   sent identically across platforms (single PID, not process group).
-   */
   constructor(workdir: string, _platform?: NodeJS.Platform) {
     this.workdir = workdir;
     this.pidsFilePath = `${workdir}/${PID_REGISTRY_FILE}`;
   }
 
-  /**
-   * Mark the registry frozen. After freeze, `register()` is a no-op that logs
-   * a warning, and `killAll()` still works on already-registered PIDs. Called
-   * by signal handlers at shutdown so in-flight retry paths cannot register
-   * newly-spawned processes that would then outlive the process.
-   *
-   * Idempotent.
-   */
   freeze(): void {
     if (this.frozen) return;
     this.frozen = true;
     getSafeLogger()?.debug("pid-registry", "Registry frozen — new registrations blocked");
   }
 
-  /** Whether the registry currently rejects new registrations. */
   isFrozen(): boolean {
     return this.frozen;
   }
 
-  /**
-   * Register a spawned process PID.
-   *
-   * Adds the PID to the in-memory set and writes to .nax-pids file.
-   *
-   * When the registry is frozen (see `freeze()`), the PID is NOT recorded and
-   * a warning is logged. Callers spawning during shutdown should not register
-   * their children; let the OS reap them once the process exits.
-   *
-   * @param pid - Process ID to register
-   */
   async register(pid: number): Promise<void> {
     const logger = getSafeLogger();
     if (this.frozen) {
@@ -114,7 +60,6 @@ export class PidRegistry {
     };
 
     try {
-      // Atomically append to .nax-pids file (one JSON entry per line)
       const line = `${JSON.stringify(entry)}\n`;
       await appendFile(this.pidsFilePath, line);
       logger?.debug("pid-registry", `Registered PID ${pid}`, { pid });
@@ -125,19 +70,11 @@ export class PidRegistry {
     }
   }
 
-  /**
-   * Unregister a process PID (e.g., after clean exit).
-   *
-   * Removes the PID from the in-memory set and rewrites .nax-pids file.
-   *
-   * @param pid - Process ID to unregister
-   */
   async unregister(pid: number): Promise<void> {
     const logger = getSafeLogger();
     this.pids.delete(pid);
 
     try {
-      // Rewrite .nax-pids file without the unregistered PID
       await this.writePidsFile();
       logger?.debug("pid-registry", `Unregistered PID ${pid}`, { pid });
     } catch (err) {
@@ -147,17 +84,6 @@ export class PidRegistry {
     }
   }
 
-  /**
-   * Kill all registered processes.
-   *
-   * Called by crash signal handlers to cleanup spawned agent processes.
-   * Signals each registered PID directly (single process, never a process group).
-   *
-   * Process-group kill (`kill -TERM -<pid>`) is intentionally avoided: with PID
-   * recycling between the existence check and the signal, a recycled PID that
-   * happens to be a session leader would receive SIGTERM across its entire
-   * group — potentially including the user's desktop session.
-   */
   async killAll(): Promise<void> {
     const logger = getSafeLogger();
     const pids = Array.from(this.pids);
@@ -169,10 +95,9 @@ export class PidRegistry {
 
     logger?.info("pid-registry", `Killing ${pids.length} registered processes`, { pids });
 
-    const killPromises = pids.map((pid) => this.killPid(pid));
+    const killPromises = pids.map((pid) => this.killPidTree(pid));
     await Promise.allSettled(killPromises);
 
-    // Clear the registry file
     try {
       await Bun.write(this.pidsFilePath, "");
       this.pids.clear();
@@ -184,20 +109,6 @@ export class PidRegistry {
     }
   }
 
-  /**
-   * Cleanup stale PIDs from previous runs.
-   *
-   * Called at runner startup before lock acquisition. Reads `.nax-pids` only to
-   * record what was left over for diagnostics, then truncates the file.
-   *
-   * IMPORTANT: this method does NOT signal any of the recorded PIDs. Stale PIDs
-   * from a previous run have almost certainly been recycled by the kernel, and
-   * signaling a recycled PID would target an unrelated process — most often
-   * something belonging to the user's desktop session. Orphan acpx processes
-   * from a prior crashed run are reaped by acpx's own queue-owner TTL and by
-   * `complete()` always closing its session with `forceTerminate: true`. The
-   * file is treated as a leak indicator, not a kill list.
-   */
   async cleanupStale(): Promise<void> {
     const logger = getSafeLogger();
 
@@ -233,7 +144,6 @@ export class PidRegistry {
         { pids: stalePids },
       );
 
-      // Clear the registry file. Do NOT call killPid on these — see method docs.
       await Bun.write(this.pidsFilePath, "");
       logger?.info("pid-registry", "Stale PIDs file cleared");
     } catch (err) {
@@ -243,17 +153,136 @@ export class PidRegistry {
     }
   }
 
-  /**
-   * Kill a single PID.
-   *
-   * Signals the specific PID only — never a process group. Reject pid<=1 to
-   * make the bad-input case impossible (kill 0 = caller's group, kill 1 = init,
-   * kill -1 = "every process the caller can signal"). Ignores ESRCH (process
-   * not found) errors.
-   *
-   * @param pid - Process ID to kill
-   */
-  private async killPid(pid: number): Promise<void> {
+  private async killPidTree(rootPid: number): Promise<void> {
+    const logger = getSafeLogger();
+
+    if (!Number.isInteger(rootPid) || rootPid <= 1) {
+      logger?.warn("pid-registry", `Refusing to signal non-positive or reserved PID ${rootPid}`, { pid: rootPid });
+      return;
+    }
+
+    const rootIdentity = await this.readProcessIdentity(rootPid);
+    if (!rootIdentity) {
+      logger?.debug("pid-registry", `PID ${rootPid} not found before tree kill`, { pid: rootPid });
+      return;
+    }
+
+    const descendants = await this.listDescendantProcesses(rootPid);
+    const targets = [...descendants.reverse(), rootIdentity];
+    await Promise.allSettled(targets.map((proc) => this.signalIfUnchanged(proc, "TERM")));
+    await _pidRegistryDeps.sleep(PID_TREE_KILL_GRACE_MS);
+    await Promise.allSettled(targets.map((proc) => this.signalIfUnchanged(proc, "KILL")));
+  }
+
+  private async listDescendantProcesses(rootPid: number): Promise<ProcessIdentity[]> {
+    const logger = getSafeLogger();
+    try {
+      const proc = _pidRegistryDeps.spawn(["ps", "-eo", "pid=,ppid=,lstart="], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text().catch(() => "")]);
+      if (exitCode !== 0) {
+        return [];
+      }
+
+      const processesByPid = new Map<number, ProcessIdentity>();
+      const childrenByParent = new Map<number, number[]>();
+      for (const line of stdout.split("\n")) {
+        const parsed = this.parsePsTreeLine(line);
+        if (!parsed || parsed.pid <= 1 || parsed.parentPid <= 1) continue;
+        const { pid, parentPid } = parsed;
+        processesByPid.set(pid, parsed);
+        const siblings = childrenByParent.get(parentPid) ?? [];
+        siblings.push(pid);
+        childrenByParent.set(parentPid, siblings);
+      }
+
+      const descendants: ProcessIdentity[] = [];
+      const queue = [...(childrenByParent.get(rootPid) ?? [])];
+      const seen = new Set<number>();
+      while (queue.length > 0) {
+        const pid = queue.shift();
+        if (pid === undefined || seen.has(pid)) continue;
+        seen.add(pid);
+        const process = processesByPid.get(pid);
+        if (process) descendants.push(process);
+        queue.push(...(childrenByParent.get(pid) ?? []));
+      }
+      return descendants;
+    } catch (err) {
+      logger?.warn("pid-registry", `Failed to inspect descendants for PID ${rootPid}`, {
+        pid: rootPid,
+        error: (err as Error).message,
+      });
+      return [];
+    }
+  }
+
+  private parsePsTreeLine(line: string): ProcessIdentity | null {
+    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
+    if (!match) return null;
+    const pid = Number.parseInt(match[1], 10);
+    const parentPid = Number.parseInt(match[2], 10);
+    const startedAt = match[3]?.trim() ?? "";
+    if (!Number.isInteger(pid) || !Number.isInteger(parentPid) || startedAt.length === 0) {
+      return null;
+    }
+    return { pid, parentPid, startedAt };
+  }
+
+  private async readProcessIdentity(pid: number): Promise<ProcessIdentity | null> {
+    const logger = getSafeLogger();
+    if (!Number.isInteger(pid) || pid <= 1) return null;
+
+    try {
+      const proc = _pidRegistryDeps.spawn(["ps", "-o", "ppid=,lstart=", "-p", String(pid)], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [exitCode, stdout] = await Promise.all([proc.exited, new Response(proc.stdout).text().catch(() => "")]);
+      if (exitCode !== 0) {
+        return null;
+      }
+      const match = stdout.trim().match(/^(\d+)\s+(.+)$/);
+      if (!match) return null;
+      const parentPid = Number.parseInt(match[1], 10);
+      const startedAt = match[2]?.trim() ?? "";
+      if (!Number.isInteger(parentPid) || startedAt.length === 0) return null;
+      return { pid, parentPid, startedAt };
+    } catch (err) {
+      logger?.warn("pid-registry", `Failed to inspect PID ${pid}`, {
+        pid,
+        error: (err as Error).message,
+      });
+      return null;
+    }
+  }
+
+  private async signalIfUnchanged(proc: ProcessIdentity, signal: "TERM" | "KILL"): Promise<void> {
+    const current = await this.readProcessIdentity(proc.pid);
+    if (!current) {
+      getSafeLogger()?.debug("pid-registry", `PID ${proc.pid} exited before SIG${signal}`, {
+        pid: proc.pid,
+        signal,
+      });
+      return;
+    }
+    if (current.parentPid !== proc.parentPid || current.startedAt !== proc.startedAt) {
+      getSafeLogger()?.warn("pid-registry", `Skipping SIG${signal} for PID ${proc.pid} after identity changed`, {
+        pid: proc.pid,
+        signal,
+        expectedParentPid: proc.parentPid,
+        currentParentPid: current.parentPid,
+        expectedStartedAt: proc.startedAt,
+        currentStartedAt: current.startedAt,
+      });
+      return;
+    }
+    await this.signalPid(proc.pid, signal);
+  }
+
+  private async signalPid(pid: number, signal: "TERM" | "KILL"): Promise<void> {
     const logger = getSafeLogger();
 
     if (!Number.isInteger(pid) || pid <= 1) {
@@ -267,21 +296,18 @@ export class PidRegistry {
       // and the explicit single-PID (non-group) signaling bound the worst case
       // to "we signal a recycled, unrelated process" rather than "we slaughter
       // an entire process group containing the user's desktop session."
-      const checkProc = Bun.spawn(["kill", "-0", String(pid)], {
+      const checkProc = _pidRegistryDeps.spawn(["kill", "-0", String(pid)], {
         stdout: "pipe",
         stderr: "pipe",
       });
       const checkCode = await checkProc.exited;
 
       if (checkCode !== 0) {
-        // Process doesn't exist, skip
         logger?.debug("pid-registry", `PID ${pid} not found (already exited)`, { pid });
         return;
       }
 
-      // Signal a single PID. Do NOT use `-${pid}` (process-group kill) —
-      // see class header for rationale.
-      const killProc = Bun.spawn(["kill", "-TERM", String(pid)], {
+      const killProc = _pidRegistryDeps.spawn(["kill", `-${signal}`, String(pid)], {
         stdout: "pipe",
         stderr: "pipe",
       });
@@ -289,26 +315,25 @@ export class PidRegistry {
       const killCode = await killProc.exited;
 
       if (killCode === 0) {
-        logger?.debug("pid-registry", `Killed PID ${pid}`, { pid });
+        logger?.debug("pid-registry", `Sent SIG${signal} to PID ${pid}`, { pid, signal });
       } else {
         const stderr = await new Response(killProc.stderr).text();
-        logger?.warn("pid-registry", `Failed to kill PID ${pid}`, {
+        logger?.warn("pid-registry", `Failed to send SIG${signal} to PID ${pid}`, {
           pid,
+          signal,
           exitCode: killCode,
           stderr: stderr.trim(),
         });
       }
     } catch (err) {
-      logger?.warn("pid-registry", `Error killing PID ${pid}`, {
+      logger?.warn("pid-registry", `Error sending SIG${signal} to PID ${pid}`, {
         pid,
+        signal,
         error: (err as Error).message,
       });
     }
   }
 
-  /**
-   * Rewrite .nax-pids file with current in-memory PIDs.
-   */
   private async writePidsFile(): Promise<void> {
     const entries = Array.from(this.pids).map((pid) => ({
       pid,
@@ -320,9 +345,6 @@ export class PidRegistry {
     await Bun.write(this.pidsFilePath, content ? `${content}\n` : "");
   }
 
-  /**
-   * Get all registered PIDs (for testing)
-   */
   getPids(): number[] {
     return Array.from(this.pids);
   }

--- a/test/unit/execution/pid-registry.test.ts
+++ b/test/unit/execution/pid-registry.test.ts
@@ -3,13 +3,25 @@
  * PID Registry Tests
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { PidRegistry } from "../../../src/execution/pid-registry";
+import { PidRegistry, _pidRegistryDeps } from "@/execution";
+import { withDepsRestore } from "@test/helpers";
 
 const TEST_WORKDIR = `/tmp/nax-pid-registry-test-${randomUUID()}`;
 const PID_FILE = `${TEST_WORKDIR}/.nax-pids`;
+
+withDepsRestore(_pidRegistryDeps, ["spawn", "sleep"]);
+
+function makeStream(text = ""): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      if (text) controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
 
 describe("PidRegistry", () => {
   beforeEach(() => {
@@ -220,6 +232,120 @@ describe("PidRegistry", () => {
     await registry.register(-5);
     await registry.killAll();
 
+    expect(registry.getPids()).toEqual([]);
+  });
+
+  test("killAll() terminates tracked descendants before clearing the registry", async () => {
+    const calls: string[][] = [];
+
+    _pidRegistryDeps.spawn = mock((cmd: string[]) => {
+      calls.push(cmd);
+      if (cmd[0] === "ps" && cmd[1] === "-eo") {
+        return {
+          pid: 2000,
+          stdout: makeStream(
+            "172446 1 Thu May 15 11:52:44 2026\n172468 172446 Thu May 15 11:52:45 2026\n172469 172468 Thu May 15 11:52:46 2026\n172552 172469 Thu May 15 11:52:47 2026\n",
+          ),
+          stderr: makeStream(),
+          exited: Promise.resolve(0),
+        } as unknown as ReturnType<typeof Bun.spawn>;
+      }
+      if (cmd[0] === "ps" && cmd[1] === "-o") {
+        const pid = cmd[4];
+        const byPid: Record<string, string> = {
+          "172446": "1 Thu May 15 11:52:44 2026\n",
+          "172468": "172446 Thu May 15 11:52:45 2026\n",
+          "172469": "172468 Thu May 15 11:52:46 2026\n",
+          "172552": "172469 Thu May 15 11:52:47 2026\n",
+        };
+        return {
+          pid: 2000,
+          stdout: makeStream(byPid[pid] ?? ""),
+          stderr: makeStream(),
+          exited: Promise.resolve(byPid[pid] ? 0 : 1),
+        } as unknown as ReturnType<typeof Bun.spawn>;
+      }
+      return {
+        pid: 2001,
+        stdout: makeStream(),
+        stderr: makeStream(),
+        exited: Promise.resolve(0),
+      } as unknown as ReturnType<typeof Bun.spawn>;
+    }) as typeof Bun.spawn;
+    _pidRegistryDeps.sleep = mock(async () => {}) as typeof Bun.sleep;
+
+    const registry = new PidRegistry(TEST_WORKDIR);
+    await registry.register(172446);
+    await registry.killAll();
+
+    expect(calls).toContainEqual(["kill", "-TERM", "172552"]);
+    expect(calls).toContainEqual(["kill", "-TERM", "172469"]);
+    expect(calls).toContainEqual(["kill", "-TERM", "172468"]);
+    expect(calls).toContainEqual(["kill", "-TERM", "172446"]);
+    expect(calls).toContainEqual(["kill", "-KILL", "172552"]);
+    expect(calls).toContainEqual(["kill", "-KILL", "172469"]);
+    expect(calls).toContainEqual(["kill", "-KILL", "172468"]);
+    expect(calls).toContainEqual(["kill", "-KILL", "172446"]);
+    expect(registry.getPids()).toEqual([]);
+  });
+
+  test("killAll() skips SIGKILL when a PID identity changes after SIGTERM", async () => {
+    const calls: string[][] = [];
+    let lookup172552 = 0;
+
+    _pidRegistryDeps.spawn = mock((cmd: string[]) => {
+      calls.push(cmd);
+      if (cmd[0] === "ps" && cmd[1] === "-eo") {
+        return {
+          pid: 2000,
+          stdout: makeStream(
+            "172446 1 Thu May 15 11:52:44 2026\n172468 172446 Thu May 15 11:52:45 2026\n172469 172468 Thu May 15 11:52:46 2026\n172552 172469 Thu May 15 11:52:47 2026\n",
+          ),
+          stderr: makeStream(),
+          exited: Promise.resolve(0),
+        } as unknown as ReturnType<typeof Bun.spawn>;
+      }
+      if (cmd[0] === "ps" && cmd[1] === "-o") {
+        const pid = cmd[4];
+        if (pid === "172552") {
+          lookup172552 += 1;
+          const output =
+            lookup172552 < 2 ? "172469 Thu May 15 11:52:47 2026\n" : "999999 Thu May 15 11:59:59 2026\n";
+          return {
+            pid: 2000,
+            stdout: makeStream(output),
+            stderr: makeStream(),
+            exited: Promise.resolve(0),
+          } as unknown as ReturnType<typeof Bun.spawn>;
+        }
+        const byPid: Record<string, string> = {
+          "172446": "1 Thu May 15 11:52:44 2026\n",
+          "172468": "172446 Thu May 15 11:52:45 2026\n",
+          "172469": "172468 Thu May 15 11:52:46 2026\n",
+        };
+        return {
+          pid: 2000,
+          stdout: makeStream(byPid[pid] ?? ""),
+          stderr: makeStream(),
+          exited: Promise.resolve(byPid[pid] ? 0 : 1),
+        } as unknown as ReturnType<typeof Bun.spawn>;
+      }
+      return {
+        pid: 2001,
+        stdout: makeStream(),
+        stderr: makeStream(),
+        exited: Promise.resolve(0),
+      } as unknown as ReturnType<typeof Bun.spawn>;
+    }) as typeof Bun.spawn;
+    _pidRegistryDeps.sleep = mock(async () => {}) as typeof Bun.sleep;
+
+    const registry = new PidRegistry(TEST_WORKDIR);
+    await registry.register(172446);
+    await registry.killAll();
+
+    expect(calls).toContainEqual(["kill", "-TERM", "172552"]);
+    expect(calls).not.toContainEqual(["kill", "-KILL", "172552"]);
+    expect(calls).toContainEqual(["kill", "-KILL", "172469"]);
     expect(registry.getPids()).toEqual([]);
   });
 


### PR DESCRIPTION
## What changed
- taught `PidRegistry.killAll()` to inspect the live process tree and target tracked ACP wrapper descendants directly
- added process identity checks (`ppid` + `lstart`) before both `SIGTERM` and `SIGKILL` so recycled PIDs are skipped instead of being signaled
- migrated the touched imports to repo alias/barrel conventions and exported `_pidRegistryDeps` through `@/execution`
- added regression coverage for wrapper-child cleanup and the PID-identity-change case

## Why
Ctrl+C shutdown was only signaling the tracked wrapper PID, which could leave the real `npm -> sh -> node -> claude` chain behind as a stale process. A naive descendant kill fixed the leak but reopened PID-reuse risk during the delayed `SIGKILL` pass.

## Impact
ACP crash cleanup is more reliable for stale child trees, while staying safer around PID reuse during shutdown.

## Root cause
The registry tracked only the root spawned PID and assumed single-PID signaling was enough. In the ACP wrapper stack, killing the wrapper alone can leave grandchildren alive.

## Validation
- `bun run lint`
- `bun run typecheck`
- `bun test test/unit/execution/pid-registry.test.ts test/unit/execution/pid-registry-freeze.test.ts test/unit/execution/pid-registry-race.test.ts --timeout=30000`