### PR TITLE
chore: release v0.66.5-canary.1 (canary)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.66.4",
+  "version": "0.66.5-canary.1",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.66.5-canary.1

Bumps version: 0.66.4 → 0.66.5-canary.1

After merging, run:
```bash
git checkout main && git pull origin main
bun run release tag
```