### PR TITLE
fix(agent-manager): retry fail-adapter-error in runWithFallback for QUEUE_DISCONNECTED

### DIFF
--- a/scripts/check-alias-internals.ts
+++ b/scripts/check-alias-internals.ts
@@ -208,3 +208,4 @@ export function main(): void {
 if (import.meta.main) {
   main();
 }
+

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -9,7 +9,7 @@ export type {
 } from "./types";
 export type { InteractionHandler } from "./interaction-handler";
 export { NO_OP_INTERACTION_HANDLER } from "./interaction-handler";
-export { CompleteError, SessionFailureError } from "./types";
+export { CompleteError, SessionFailureError, SessionTurnError } from "./types";
 export {
   AcpAgentAdapter,
   SpawnAcpClient,

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -209,6 +209,7 @@ export class AgentManager implements IAgentManager {
     let hopsSoFar = 0;
     let rateLimitRetry = 0;
     let staleRetryAttempts = 0;
+    let adapterErrorRetries = 0;
     let currentBundle = request.bundle;
     let currentHopKind: import("./manager-types").HopKind = { kind: "primary" };
     let finalPrompt: string | undefined;
@@ -294,6 +295,31 @@ export class AgentManager implements IAgentManager {
           });
           currentHopKind = { kind: "stale-retry", attempt: staleRetryAttempts };
           continue;
+        }
+
+        // fail-adapter-error: same-agent retry when acpx signals retryable (e.g.
+        // QUEUE_DISCONNECTED_BEFORE_COMPLETION). Uses sessionErrorRetryableMaxRetries
+        // for retryable errors and sessionErrorMaxRetries for non-retryable ones.
+        // Uses stale-retry kind so the retry hop reuses the live handle if still cached,
+        // or reconnects via openSession(resume:true) on cache miss — same as fail-stale.
+        const isFailAdapterError = result.adapterFailure?.outcome === "fail-adapter-error";
+        if (isFailAdapterError && !request.signal?.aborted) {
+          const runConfig = request.runOptions.config ?? this._config;
+          const maxAdapterRetries = result.adapterFailure?.retriable
+            ? (runConfig.execution?.sessionErrorRetryableMaxRetries ?? 3)
+            : (runConfig.execution?.sessionErrorMaxRetries ?? 1);
+          if (adapterErrorRetries < maxAdapterRetries) {
+            adapterErrorRetries++;
+            logger?.warn("agent-manager", "fail-adapter-error: same-agent retry with fresh session", {
+              storyId: request.runOptions.storyId,
+              attempt: adapterErrorRetries,
+              maxAttempts: maxAdapterRetries,
+              retriable: result.adapterFailure?.retriable ?? false,
+              agent: currentAgent,
+            });
+            currentHopKind = { kind: "stale-retry", attempt: adapterErrorRetries };
+            continue;
+          }
         }
 
         // For fail-stale, treat hasBundle as true: session restarts don't require

--- a/test/integration/agents/stale-then-swap.test.ts
+++ b/test/integration/agents/stale-then-swap.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { AgentManager, SessionFailureError } from "@/agents";
+import { AgentManager, SessionFailureError, SessionTurnError } from "@/agents";
 import { buildHopCallback, _buildHopCallbackDeps } from "@/operations";
 import type { SessionHandle, TurnResult } from "@/agents/types";
 import type { AdapterFailure, ContextBundle } from "@/context/engine";
@@ -214,5 +214,132 @@ describe("stale-then-swap — full runWithFallback loop", () => {
     expect(agents).toEqual(["claude", "claude", "codex"]);
     expect(outcome.result.success).toBe(true);
     expect(outcome.finalAgent).toBe("codex");
+  });
+});
+
+describe("fail-adapter-error retry — QUEUE_DISCONNECTED_BEFORE_COMPLETION (#1027 follow-up)", () => {
+  // Config: sessionErrorRetryableMaxRetries=2, no fallback agents so retries exhaust cleanly
+  function makeAdapterErrorConfig(retryableMax = 2, nonRetryableMax = 1) {
+    return makeNaxConfig({
+      execution: { sessionErrorRetryableMaxRetries: retryableMax, sessionErrorMaxRetries: nonRetryableMax },
+      agent: {
+        default: "claude",
+        fallback: { enabled: false, map: {}, maxHopsPerStory: 0, onQualityFailure: false, rebuildContext: false },
+      },
+    });
+  }
+
+  test("retryable fail-adapter-error retries up to sessionErrorRetryableMaxRetries then succeeds", async () => {
+    const config = makeAdapterErrorConfig(2);
+    const manager = new AgentManager(config);
+
+    const openSession = mock(async () => ({ id: "ses_01", agentName: "claude" } as SessionHandle));
+    const sessionMgr = makeSessionManager({ openSession });
+
+    let callCount = 0;
+    const runAsSessionFn = mock(async () => {
+      callCount++;
+      if (callCount <= 2) throw new SessionTurnError("Queue owner disconnected", false, true);
+      return STUB_TURN;
+    });
+
+    const hopCtx = {
+      sessionManager: sessionMgr,
+      agentManager: makeMockAgentManager({ runAsSessionFn }),
+      story: makeStory({ id: "US-1027" }),
+      config,
+      featureName: "adapter-error-retry",
+      workdir: "/tmp",
+      effectiveTier: "balanced" as const,
+      defaultAgent: "claude",
+      pipelineStage: "run" as const,
+    };
+    const hopCb = buildHopCallback(hopCtx, undefined, { ...STUB_RUN_OPTIONS, storyId: "US-1027" } as any);
+    const outcome = await manager.runWithFallback({
+      runOptions: { ...STUB_RUN_OPTIONS, storyId: "US-1027", config } as any,
+      bundle: STUB_BUNDLE,
+      executeHop: hopCb,
+    });
+
+    // 2 retryable failures + 1 success = 3 total calls
+    expect(callCount).toBe(3);
+    expect(outcome.result.success).toBe(true);
+  });
+
+  test("retryable fail-adapter-error exhausted → result is failure (no swap when fallback disabled)", async () => {
+    const config = makeAdapterErrorConfig(2);
+    const manager = new AgentManager(config);
+
+    const openSession = mock(async () => ({ id: "ses_01", agentName: "claude" } as SessionHandle));
+    const sessionMgr = makeSessionManager({ openSession });
+
+    let callCount = 0;
+    const runAsSessionFn = mock(async () => {
+      callCount++;
+      throw new SessionTurnError("Queue owner disconnected", false, true);
+    });
+
+    const hopCtx = {
+      sessionManager: sessionMgr,
+      agentManager: makeMockAgentManager({ runAsSessionFn }),
+      story: makeStory({ id: "US-1027b" }),
+      config,
+      featureName: "adapter-error-retry-exhaust",
+      workdir: "/tmp",
+      effectiveTier: "balanced" as const,
+      defaultAgent: "claude",
+      pipelineStage: "run" as const,
+    };
+    const hopCb = buildHopCallback(hopCtx, undefined, { ...STUB_RUN_OPTIONS, storyId: "US-1027b" } as any);
+    const outcome = await manager.runWithFallback({
+      runOptions: { ...STUB_RUN_OPTIONS, storyId: "US-1027b", config } as any,
+      bundle: STUB_BUNDLE,
+      executeHop: hopCb,
+    });
+
+    // 1 primary + 2 retries = 3 total calls (sessionErrorRetryableMaxRetries=2)
+    expect(callCount).toBe(3);
+    expect(outcome.result.success).toBe(false);
+    expect(outcome.result.adapterFailure?.outcome).toBe("fail-adapter-error");
+    expect(outcome.result.adapterFailure?.retriable).toBe(true);
+  });
+
+  test("retry reuses live handle (stale-retry style): getLiveHandle called, openSession called once (primary only)", async () => {
+    const config = makeAdapterErrorConfig(1);
+    const manager = new AgentManager(config);
+
+    const openSession = mock(async () => ({ id: "ses_01", agentName: "claude" } as SessionHandle));
+    const getLiveHandle = mock((_name: string) => ({ id: "ses_01", agentName: "claude" } as SessionHandle));
+    const sessionMgr = makeSessionManager({ openSession, getLiveHandle });
+
+    let callCount = 0;
+    const runAsSessionFn = mock(async () => {
+      callCount++;
+      if (callCount === 1) throw new SessionTurnError("Queue owner disconnected", false, true);
+      return STUB_TURN;
+    });
+
+    const hopCtx = {
+      sessionManager: sessionMgr,
+      agentManager: makeMockAgentManager({ runAsSessionFn }),
+      story: makeStory({ id: "US-1027c" }),
+      config,
+      featureName: "adapter-error-fresh-session",
+      workdir: "/tmp",
+      effectiveTier: "balanced" as const,
+      defaultAgent: "claude",
+      pipelineStage: "run" as const,
+    };
+    const hopCb = buildHopCallback(hopCtx, undefined, { ...STUB_RUN_OPTIONS, storyId: "US-1027c" } as any);
+    await manager.runWithFallback({
+      runOptions: { ...STUB_RUN_OPTIONS, storyId: "US-1027c", config } as any,
+      bundle: STUB_BUNDLE,
+      executeHop: hopCb,
+    });
+
+    // openSession called once (primary only); retry uses getLiveHandle (stale-retry kind)
+    expect(openSession).toHaveBeenCalledTimes(1);
+    expect(getLiveHandle).toHaveBeenCalledTimes(1);
+    expect(callCount).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

- PR #1027 threaded `retryable:true` from `SessionTurnError` through to `AdapterFailure.retriable`, but `runWithFallback` had no branch to consume it — `QUEUE_DISCONNECTED_BEFORE_COMPLETION` still never retried on the main execution path
- `sessionErrorRetryableMaxRetries` was only read in `runTrackedSession` (TDD path via `runInSession`); the execution stage goes through `callOp → runWithFallback` which skipped `fail-adapter-error` entirely
- Added a retry branch in `runWithFallback` after the `fail-stale` block, using `stale-retry` hop kind so the retry reuses the live handle (or reconnects via `openSession(resume:true)` on cache miss) — same semantics as `fail-stale`

## Test plan

- [ ] `timeout 30 bun test test/integration/agents/stale-then-swap.test.ts --timeout=5000` — 6 tests pass (3 existing + 3 new)
- [ ] `timeout 60 bun test test/integration/agents/ --timeout=10000` — full agent integration suite passes
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean