### PR TITLE
fix(rectification): retry QUEUE_DISCONNECTED in runtime path of rectification loops

### DIFF
--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -7,6 +7,7 @@
  */
 
 import type { IAgentManager } from "../agents";
+import { SessionTurnError } from "../agents/types";
 import type { SessionHandle } from "../agents/types";
 import type { ModelTier } from "../config";
 import { resolveModelForAgent } from "../config";
@@ -311,55 +312,74 @@ async function runRectificationLoop(
         sessionRole: "implementer" as const,
       };
 
-      let rectifyResult: import("../agents").AgentResult;
+      let rectifyResult!: import("../agents").AgentResult;
       if (runtime) {
         // ADR-008 §6 / ADR-018 §7 Pattern B: open the implementer session once
         // and reuse across attempts. openSession is idempotent (session/manager.ts:354)
         // so we attach to any session opened upstream by execution.ts when one
         // is still alive.
-        if (!heldHandle) {
-          heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
-            agentName: defaultAgent,
-            role: "implementer",
-            workdir,
-            pipelineStage: "rectification",
-            modelDef: runOptions.modelDef,
-            timeoutSeconds: config.execution.sessionTimeoutSeconds,
-            featureName,
-            storyId: story.id,
-            signal: runtime.signal,
-          });
-        }
-        // ADR-020 single-emission invariant: each runAsSession emits one
-        // session-turn event for audit/cost subscribers, regardless of handle
-        // reuse across attempts.
-        try {
-          const turn = await agentManager.runAsSession(defaultAgent, heldHandle, prompt, {
-            storyId: story.id,
-            featureName,
-            workdir,
-            projectDir,
-            pipelineStage: "rectification",
-            sessionRole: "implementer",
-            signal: runtime.signal,
-            maxTurns: config.agent?.maxInteractionTurns,
-          });
-          rectifyResult = {
-            success: true,
-            exitCode: 0,
-            output: turn.output,
-            rateLimited: false,
-            durationMs: 0,
-            estimatedCostUsd: turn.estimatedCostUsd,
-            ...(turn.exactCostUsd !== undefined && { exactCostUsd: turn.exactCostUsd }),
-            ...(turn.tokenUsage && { tokenUsage: turn.tokenUsage }),
-            ...(heldHandle.protocolIds && { protocolIds: heldHandle.protocolIds }),
-          };
-        } catch (err) {
-          const stale = heldHandle;
-          heldHandle = undefined;
-          await runtime.sessionManager.closeSession(stale).catch(() => {});
-          throw err;
+        //
+        // Transport retry: QUEUE_DISCONNECTED_BEFORE_COMPLETION is retryable (acpx
+        // signals retryable:true). The runtime path bypasses runWithFallback so we
+        // must handle it locally — mirrors the fail-adapter-error retry in manager.ts.
+        let transportRetries = 0;
+        const maxTransportRetries = config.execution?.sessionErrorRetryableMaxRetries ?? 3;
+        while (transportRetries <= maxTransportRetries) {
+          if (!heldHandle) {
+            heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
+              agentName: defaultAgent,
+              role: "implementer",
+              workdir,
+              pipelineStage: "rectification",
+              modelDef: runOptions.modelDef,
+              timeoutSeconds: config.execution.sessionTimeoutSeconds,
+              featureName,
+              storyId: story.id,
+              signal: runtime.signal,
+            });
+          }
+          // ADR-020 single-emission invariant: each runAsSession emits one
+          // session-turn event for audit/cost subscribers, regardless of handle
+          // reuse across attempts.
+          try {
+            const turn = await agentManager.runAsSession(defaultAgent, heldHandle, prompt, {
+              storyId: story.id,
+              featureName,
+              workdir,
+              projectDir,
+              pipelineStage: "rectification",
+              sessionRole: "implementer",
+              signal: runtime.signal,
+              maxTurns: config.agent?.maxInteractionTurns,
+            });
+            rectifyResult = {
+              success: true,
+              exitCode: 0,
+              output: turn.output,
+              rateLimited: false,
+              durationMs: 0,
+              estimatedCostUsd: turn.estimatedCostUsd,
+              ...(turn.exactCostUsd !== undefined && { exactCostUsd: turn.exactCostUsd }),
+              ...(turn.tokenUsage && { tokenUsage: turn.tokenUsage }),
+              ...(heldHandle.protocolIds && { protocolIds: heldHandle.protocolIds }),
+            };
+            break;
+          } catch (err) {
+            const stale = heldHandle;
+            heldHandle = undefined;
+            await runtime.sessionManager.closeSession(stale).catch(() => {});
+            if (err instanceof SessionTurnError && err.retryable && transportRetries < maxTransportRetries) {
+              transportRetries++;
+              getSafeLogger()?.warn("tdd", "fail-adapter-error: same-agent retry with fresh session", {
+                storyId: story.id,
+                attempt: transportRetries,
+                maxAttempts: maxTransportRetries,
+                retriable: true,
+              });
+              continue;
+            }
+            throw err;
+          }
         }
       } else {
         // Legacy keepOpen path — used when no runtime is available (standalone callers).

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -10,6 +10,7 @@
 import type { IAgentManager } from "../agents";
 import { resolveDefaultAgent } from "../agents";
 import { estimateCostByDuration } from "../agents/cost";
+import { SessionTurnError } from "../agents/types";
 import type { SessionHandle } from "../agents/types";
 import type { NaxConfig } from "../config";
 import { resolveConfiguredModel, resolveModelForAgent } from "../config";
@@ -328,57 +329,75 @@ export async function runRectificationLoop(
         sessionRole: "implementer" as const,
       };
 
-      let agentResult: import("../agents").AgentResult;
+      let agentResult!: import("../agents").AgentResult;
       if (runtime) {
         // ADR-008 §6 / ADR-018 §7 Pattern B: open the implementer session
         // once and reuse across attempts. openSession is idempotent on a live
         // handle (session/manager.ts:354) so we attach to any session opened
         // upstream by execution.ts when one is still alive.
-        if (!heldHandle) {
-          heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
-            agentName: defaultAgent,
-            role: "implementer",
-            workdir,
-            pipelineStage: "rectification",
-            modelDef,
-            timeoutSeconds: config.execution.sessionTimeoutSeconds,
-            featureName,
-            storyId: story.id,
-            signal: runtime.signal,
-          });
-        }
-        // ADR-020 single-emission invariant: each runAsSession emits one
-        // session-turn event for audit/cost subscribers, regardless of handle
-        // reuse across attempts.
-        try {
-          const turn = await agentManager.runAsSession(defaultAgent, heldHandle, prompt, {
-            storyId: story.id,
-            featureName,
-            workdir,
-            projectDir,
-            pipelineStage: "rectification",
-            sessionRole: "implementer",
-            signal: runtime.signal,
-            maxTurns: config.agent?.maxInteractionTurns,
-          });
-          agentResult = {
-            success: true,
-            exitCode: 0,
-            output: turn.output,
-            rateLimited: false,
-            durationMs: 0,
-            estimatedCostUsd: turn.estimatedCostUsd,
-            ...(turn.exactCostUsd !== undefined && { exactCostUsd: turn.exactCostUsd }),
-            ...(turn.tokenUsage && { tokenUsage: turn.tokenUsage }),
-            ...(heldHandle.protocolIds && { protocolIds: heldHandle.protocolIds }),
-          };
-        } catch (err) {
-          // Discard the held handle on error — the previous session may be in
-          // a terminal/cancelled state. Next attempt will reopen.
-          const stale = heldHandle;
-          heldHandle = undefined;
-          await runtime.sessionManager.closeSession(stale).catch(() => {});
-          throw err;
+        //
+        // Transport retry: QUEUE_DISCONNECTED_BEFORE_COMPLETION is retryable (acpx
+        // signals retryable:true). The runtime path bypasses runWithFallback so we
+        // must handle it locally — mirrors the fail-adapter-error retry in manager.ts.
+        let transportRetries = 0;
+        const maxTransportRetries = config.execution?.sessionErrorRetryableMaxRetries ?? 3;
+        while (true) {
+          if (!heldHandle) {
+            heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
+              agentName: defaultAgent,
+              role: "implementer",
+              workdir,
+              pipelineStage: "rectification",
+              modelDef,
+              timeoutSeconds: config.execution.sessionTimeoutSeconds,
+              featureName,
+              storyId: story.id,
+              signal: runtime.signal,
+            });
+          }
+          // ADR-020 single-emission invariant: each runAsSession emits one
+          // session-turn event for audit/cost subscribers, regardless of handle
+          // reuse across attempts.
+          try {
+            const turn = await agentManager.runAsSession(defaultAgent, heldHandle, prompt, {
+              storyId: story.id,
+              featureName,
+              workdir,
+              projectDir,
+              pipelineStage: "rectification",
+              sessionRole: "implementer",
+              signal: runtime.signal,
+              maxTurns: config.agent?.maxInteractionTurns,
+            });
+            agentResult = {
+              success: true,
+              exitCode: 0,
+              output: turn.output,
+              rateLimited: false,
+              durationMs: 0,
+              estimatedCostUsd: turn.estimatedCostUsd,
+              ...(turn.exactCostUsd !== undefined && { exactCostUsd: turn.exactCostUsd }),
+              ...(turn.tokenUsage && { tokenUsage: turn.tokenUsage }),
+              ...(heldHandle.protocolIds && { protocolIds: heldHandle.protocolIds }),
+            };
+            break;
+          } catch (err) {
+            // Discard the held handle — terminal/cancelled session. Next iteration reopens.
+            const stale = heldHandle;
+            heldHandle = undefined;
+            await runtime.sessionManager.closeSession(stale).catch(() => {});
+            if (err instanceof SessionTurnError && err.retryable && transportRetries < maxTransportRetries) {
+              transportRetries++;
+              getSafeLogger()?.warn("rectification", "fail-adapter-error: same-agent retry with fresh session", {
+                storyId: story.id,
+                attempt: transportRetries,
+                maxAttempts: maxTransportRetries,
+                retriable: true,
+              });
+              continue;
+            }
+            throw err;
+          }
         }
       } else {
         // Legacy keepOpen path — used when no runtime is available (standalone callers).


### PR DESCRIPTION
## Summary

- **Root cause of #1043 regression**: `runWithFallback` retry added in #1043 only applies when the call goes *through* `runWithFallback`. The runtime path in both `tdd/rectification-gate.ts` and `verification/rectification-loop.ts` calls `agentManager.runAsSession()` directly, bypassing it entirely.
- **Why US-005 failed but US-004 retried**: US-005 was on the TDD path (`execution` stage → `tdd/rectification-gate.ts` with `runtime` set) — `runAsSession` threw `SessionTurnError`, propagated through `runRetryLoop` uncaught, surfaced as `Stage "execution" threw error`. US-004 was on the non-TDD path (`pipeline/stages/rectify.ts`) which omits `runtime`, taking the legacy `agentManager.run()` → `runWithFallback` route where retry worked.
- **Fix**: wrap the `runAsSession` call in a bounded `while (transportRetries <= maxTransportRetries)` loop in both runtime paths. Retryable `SessionTurnError` (acpx signals `retryable: true` for `QUEUE_DISCONNECTED_BEFORE_COMPLETION`) discards the stale handle and reopens a fresh session, mirroring the `fail-adapter-error` retry in `manager.ts`. Respects `sessionErrorRetryableMaxRetries` config (default 3).

## Files changed

- `src/tdd/rectification-gate.ts` — transport retry loop in TDD runtime path
- `src/verification/rectification-loop.ts` — transport retry loop in verification runtime path

## Test plan

- [ ] Existing unit tests pass: `timeout 60 bun test test/unit/tdd/ test/unit/verification/ --timeout=10000` (286 tests)
- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean
- [ ] Verify: on QUEUE_DISCONNECTED in a TDD story, logs show `fail-adapter-error: same-agent retry with fresh session` from `tdd` stage (not `agent-manager`, since this is the runtime path)
- [ ] Verify: retry respects `sessionErrorRetryableMaxRetries` cap (default 3 attempts after the initial failure)