### PR TITLE
fix(config): resolve circular import causing ReferenceError (fixes #1039)

### DIFF
--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -4,8 +4,8 @@
  * Extracted from schemas.ts to stay within the 600-line file limit.
  */
 
-import { ConfiguredModelSchema, ModelTierSchema } from "@/config";
 import { z } from "zod";
+import { ConfiguredModelSchema, ModelTierSchema } from "./schemas-model";
 
 export const PlanConfigSchema = z.object({
   model: ConfiguredModelSchema,


### PR DESCRIPTION
## Summary
- Fix circular import in `schemas-infra.ts` by replacing `@/config` barrel import with direct `./schemas-model` import
- `RoutingConfigSchema` was being referenced before initialization when tests ran individually

## Root Cause
`@/config` → `schema.ts` → `schemas.ts` → `schemas-infra.ts` (exports `RoutingConfigSchema`) created a circular dependency when running tests directly.

## Testing
- `bun run build` passes
- `bun run typecheck` passes  
- `bun run lint` passes