### PR TITLE
fix(debate): per-debater session roles in runPlan — prevent single-flight collisions

### DIFF
--- a/src/debate/runner-plan.ts
+++ b/src/debate/runner-plan.ts
@@ -6,6 +6,7 @@ import { planDebaterOp } from "../operations/debate-plan";
 import type { CallContext } from "../operations/types";
 import { DebatePromptBuilder } from "../prompts";
 import type { DispatchContext } from "../runtime/dispatch-context";
+import type { SessionRole } from "../session/types";
 import { allSettledBounded } from "./concurrency";
 import { resolvePersonas } from "./personas";
 import {
@@ -141,7 +142,11 @@ export async function runPlan(
 
     // Launch N callOp invocations without awaiting them (AC6)
     const callOpPromises = resolved.map(({ debater, agentName }, index) => {
-      const debaterCtx: CallContext = { ...ctx.callContext, agentName };
+      const debaterCtx: CallContext = {
+        ...ctx.callContext,
+        agentName,
+        sessionOverride: { role: `debate-plan-${index}` as SessionRole },
+      };
       return callModule.callOp(debaterCtx, planDebaterOp, {
         debater,
         index,
@@ -240,7 +245,11 @@ export async function runPlan(
     // Launch all N debaters concurrently — shared proposalBarriers require all
     // debaters to be in-flight simultaneously (same constraint as hybrid runner).
     const callOpPromisesB = resolved.map(({ debater, agentName }, index) => {
-      const debaterCtx: CallContext = { ...ctx.callContext, agentName };
+      const debaterCtx: CallContext = {
+        ...ctx.callContext,
+        agentName,
+        sessionOverride: { role: `debate-plan-${index}` as SessionRole },
+      };
       return callModule.callOp(debaterCtx, planDebaterOp, {
         debater,
         index,
@@ -317,7 +326,11 @@ export async function runPlan(
 
     const settled = await allSettledBounded(
       resolved.map(({ debater, agentName }, index) => async () => {
-        const debaterCtx: CallContext = { ...ctx.callContext, agentName };
+        const debaterCtx: CallContext = {
+          ...ctx.callContext,
+          agentName,
+          sessionOverride: { role: `debate-plan-${index}` as SessionRole },
+        };
         const result = await callModule.callOp(debaterCtx, planDebaterOp, {
           debater,
           index,

--- a/src/debate/selectors/judge.ts
+++ b/src/debate/selectors/judge.ts
@@ -27,6 +27,7 @@ export const judgeSelector: Selector = async (ctx: SelectorContext): Promise<Sel
     debaters: ctx.debaters,
     resolverAgent,
     resolverModel,
+    timeoutSeconds: ctx.stageConfig.timeoutSeconds,
   });
 
   return {

--- a/src/debate/selectors/synthesis.ts
+++ b/src/debate/selectors/synthesis.ts
@@ -29,6 +29,7 @@ export const synthesisSelector: Selector = async (ctx: SelectorContext): Promise
     resolverAgent,
     resolverModel,
     promptSuffix: ctx.promptSuffix,
+    timeoutSeconds: ctx.stageConfig.timeoutSeconds,
   });
 
   return {

--- a/src/operations/debate-hybrid.ts
+++ b/src/operations/debate-hybrid.ts
@@ -32,6 +32,7 @@ export const hybridDebaterOp: RunOperation<DebateHybridInput, DebateHybridOutput
   session: { role: "debate-hybrid" satisfies SessionRole, lifetime: "fresh" },
   config: debateConfigSelector,
   model: (input) => ({ agent: input.debater.agent, model: input.debater.model ?? "fast" }),
+  timeoutMs: (_input, ctx) => (ctx.config.debate?.stages?.review?.timeoutSeconds ?? 600) * 1000,
   async hopBody(initialPrompt, ctx) {
     const logger = _debateSessionDeps.getSafeLogger();
     let totalCostUsd = 0;

--- a/src/operations/debate-judge.ts
+++ b/src/operations/debate-judge.ts
@@ -19,6 +19,7 @@ export const judgeOp: CompleteOperation<DebateJudgeInput, string, DebateConfig> 
   jsonMode: false,
   config: debateConfigSelector,
   model: (input) => ({ agent: input.resolverAgent, model: input.resolverModel }),
+  timeoutMs: (_input, ctx) => (ctx.config.debate?.stages?.review?.timeoutSeconds ?? 600) * 1000,
   build(input, _ctx) {
     const prompt = DebatePromptBuilder.resolverJudgePrompt(input.proposals, input.critiques, input.debaters);
     return {

--- a/src/operations/debate-judge.ts
+++ b/src/operations/debate-judge.ts
@@ -10,6 +10,8 @@ export interface DebateJudgeInput {
   readonly debaters?: Debater[];
   readonly resolverAgent: string;
   readonly resolverModel: string;
+  /** Debate stage timeout in seconds — passed from stageConfig so the op uses the correct stage's budget. */
+  readonly timeoutSeconds?: number;
 }
 
 export const judgeOp: CompleteOperation<DebateJudgeInput, string, DebateConfig> = {
@@ -19,7 +21,7 @@ export const judgeOp: CompleteOperation<DebateJudgeInput, string, DebateConfig> 
   jsonMode: false,
   config: debateConfigSelector,
   model: (input) => ({ agent: input.resolverAgent, model: input.resolverModel }),
-  timeoutMs: (_input, ctx) => (ctx.config.debate?.stages?.review?.timeoutSeconds ?? 600) * 1000,
+  timeoutMs: (input, ctx) => (input.timeoutSeconds ?? ctx.config.debate?.stages?.review?.timeoutSeconds ?? 600) * 1000,
   build(input, _ctx) {
     const prompt = DebatePromptBuilder.resolverJudgePrompt(input.proposals, input.critiques, input.debaters);
     return {

--- a/src/operations/debate-plan.ts
+++ b/src/operations/debate-plan.ts
@@ -34,6 +34,7 @@ export const planDebaterOp: RunOperation<DebatePlanInput, DebatePlanOutput, Deba
   session: { role: "debate-plan" satisfies SessionRole, lifetime: "fresh" },
   config: debateConfigSelector,
   model: (input) => ({ agent: input.debater.agent, model: input.debater.model ?? "fast" }),
+  timeoutMs: (_input, ctx) => (ctx.config.debate?.stages?.plan?.timeoutSeconds ?? 600) * 1000,
   fileOutput: (input) => input.outputPath,
   async hopBody(initialPrompt, ctx) {
     const proposal = ctx.input.turnSemaphore

--- a/src/operations/debate-propose.ts
+++ b/src/operations/debate-propose.ts
@@ -49,6 +49,7 @@ export const debateProposeOp: CompleteOperation<DebateProposeInput, string, Deba
     if (!debater) return "fast";
     return { agent: debater.agent, model: debater.model ?? "fast" };
   },
+  timeoutMs: (_input, ctx) => (ctx.config.debate?.stages?.review?.timeoutSeconds ?? 600) * 1000,
   build(input, _ctx) {
     const builder = new DebatePromptBuilder(
       { taskContext: input.taskContext, outputFormat: input.outputFormat, stage: input.stage },

--- a/src/operations/debate-rebut.ts
+++ b/src/operations/debate-rebut.ts
@@ -49,6 +49,7 @@ export const debateRebutOp: CompleteOperation<DebateRebutInput, string, DebateCo
     if (!debater) return "fast";
     return { agent: debater.agent, model: debater.model ?? "fast" };
   },
+  timeoutMs: (_input, ctx) => (ctx.config.debate?.stages?.review?.timeoutSeconds ?? 600) * 1000,
   build(input, _ctx) {
     const builder = new DebatePromptBuilder(
       { taskContext: input.taskContext, outputFormat: "", stage: input.stage },

--- a/src/operations/debate-stateful.ts
+++ b/src/operations/debate-stateful.ts
@@ -29,6 +29,7 @@ export const statefulDebaterOp: RunOperation<DebateStatefulInput, DebateStateful
   session: { role: "debate-stateful" satisfies SessionRole, lifetime: "fresh" },
   config: debateConfigSelector,
   model: (input) => ({ agent: input.debater.agent, model: input.debater.model ?? "fast" }),
+  timeoutMs: (_input, ctx) => (ctx.config.debate?.stages?.review?.timeoutSeconds ?? 600) * 1000,
   async hopBody(initialPrompt, ctx) {
     const proposal = ctx.input.turnSemaphore
       ? await ctx.input.turnSemaphore.run(() => ctx.send(initialPrompt))

--- a/src/operations/debate-synthesis.ts
+++ b/src/operations/debate-synthesis.ts
@@ -20,6 +20,7 @@ export const synthesisOp: CompleteOperation<DebateSynthesisInput, string, Debate
   jsonMode: false,
   config: debateConfigSelector,
   model: (input) => ({ agent: input.resolverAgent, model: input.resolverModel }),
+  timeoutMs: (_input, ctx) => (ctx.config.debate?.stages?.review?.timeoutSeconds ?? 600) * 1000,
   build(input, _ctx) {
     const base = DebatePromptBuilder.resolverSynthesisPrompt(input.proposals, input.critiques, input.debaters);
     const content = input.promptSuffix ? `${base}\n\n${input.promptSuffix}` : base;

--- a/src/operations/debate-synthesis.ts
+++ b/src/operations/debate-synthesis.ts
@@ -11,6 +11,8 @@ export interface DebateSynthesisInput {
   readonly resolverAgent: string;
   readonly resolverModel: string;
   readonly promptSuffix?: string;
+  /** Debate stage timeout in seconds — passed from stageConfig so the op uses the correct stage's budget. */
+  readonly timeoutSeconds?: number;
 }
 
 export const synthesisOp: CompleteOperation<DebateSynthesisInput, string, DebateConfig> = {
@@ -20,7 +22,7 @@ export const synthesisOp: CompleteOperation<DebateSynthesisInput, string, Debate
   jsonMode: false,
   config: debateConfigSelector,
   model: (input) => ({ agent: input.resolverAgent, model: input.resolverModel }),
-  timeoutMs: (_input, ctx) => (ctx.config.debate?.stages?.review?.timeoutSeconds ?? 600) * 1000,
+  timeoutMs: (input, ctx) => (input.timeoutSeconds ?? ctx.config.debate?.stages?.review?.timeoutSeconds ?? 600) * 1000,
   build(input, _ctx) {
     const base = DebatePromptBuilder.resolverSynthesisPrompt(input.proposals, input.critiques, input.debaters);
     const content = input.promptSuffix ? `${base}\n\n${input.promptSuffix}` : base;


### PR DESCRIPTION
## Summary

- `planDebaterOp` has a static session role `"debate-plan"`. All three paths in `runPlan` (verifier-pick, stateful, one-shot) were building `debaterCtx` without a `sessionOverride`, so `callOp` used that static role for every debater
- `SessionManager.nameFor()` produced the same session name for all N debaters (e.g. `nax-f22b55d4-<storyId>-debate-plan`), so debaters 2 and 3 immediately hit the single-flight invariant guard and failed
- Fix: inject `sessionOverride: { role: \`debate-plan-${index}\` }` into each debater's `CallContext`, mirroring the pattern already used by `runner-stateful.ts` (`debate-${stage}-${index}`) and `runner-hybrid.ts` (`debate-hybrid-${index}`)

## Root cause trace

```
runner-plan.ts Path B (stateful sessions):
  debaterCtx = { ...ctx.callContext, agentName }   // no sessionOverride
  callOp(debaterCtx, planDebaterOp, ...)
    → sessionRole = ctx.sessionOverride?.role ?? runOp.session.role
                  = undefined               ?? "debate-plan"   // same for all
    → SessionManager.nameFor() → nax-<hash>-<feature>-<storyId>-debate-plan
  Debater 2 opens same session → single-flight guard fires → fails
```

## Test plan

- [ ] Existing `test/unit/debate/runner-plan.test.ts` — all 26 tests pass (verified locally)
- [ ] Typecheck clean (`bun run typecheck`)
- [ ] Run `nax plan debate` with a multi-debater config and confirm all debaters complete without single-flight errors