### PR TITLE
chore(test): silence bun test output — silent log level + preload console suppression

### DIFF
--- a/.claude/rules/testing-commands.md
+++ b/.claude/rules/testing-commands.md
@@ -8,10 +8,11 @@ This rule is enforced by a PreToolUse hook: `.claude/hooks/guard-bun-test.ts`. B
 
 | Goal | Use |
 |:---|:---|
-| Full suite | `bun run test` |
-| Full suite, bail on first failure | `bun run test:bail` |
+| Full suite (AGENT Friendly) | `bun run test` |
+| Full suite, bail on first failure (AGENT Friendly) | `bun run test:bail` |
 | One file / directory (iteration) | `timeout 30 bun test <path> --timeout=5000` |
 | Long-running targeted test | `timeout -k 5s 60s bun test <path> --timeout=60000` |
+| AGENT Friendly (Only print errors) | `AGENT=1 timeout 30 bun test <path> --timeout=5000` |
 
 ## Rules
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -17,6 +17,10 @@ import { buildInitConfig, detectStack } from "./init-detect";
 import type { ProjectStack } from "./init-detect";
 import { promptsInitCommand } from "./prompts";
 
+export const _initDeps = {
+  log: console.log.bind(console) as (...args: unknown[]) => void,
+};
+
 /** Result of project name validation */
 export interface ProjectNameValidationResult {
   valid: boolean;
@@ -362,18 +366,18 @@ export async function initProject(projectRoot: string, options?: InitProjectOpti
   await promptsInitCommand({ workdir: projectRoot, force: false, autoWireConfig: false });
 
   // Print summary
-  console.log("\n[OK] nax init complete. Created files:");
-  console.log("  - .nax/config.json");
-  console.log("  - .nax/context.md");
-  console.log("  - .nax/constitution.md");
-  console.log("  - .nax/hooks/");
-  console.log("  - .nax/templates/");
-  console.log("\nNext steps:");
-  console.log("  1. Review .nax/context.md and fill in TODOs");
-  console.log("  2. Review .nax/config.json and adjust quality commands");
-  console.log("  3. Run: nax generate");
-  console.log("  4. Run: nax plan");
-  console.log("  5. Run: nax run");
+  _initDeps.log("\n[OK] nax init complete. Created files:");
+  _initDeps.log("  - .nax/config.json");
+  _initDeps.log("  - .nax/context.md");
+  _initDeps.log("  - .nax/constitution.md");
+  _initDeps.log("  - .nax/hooks/");
+  _initDeps.log("  - .nax/templates/");
+  _initDeps.log("\nNext steps:");
+  _initDeps.log("  1. Review .nax/context.md and fill in TODOs");
+  _initDeps.log("  2. Review .nax/config.json and adjust quality commands");
+  _initDeps.log("  3. Run: nax generate");
+  _initDeps.log("  4. Run: nax plan");
+  _initDeps.log("  5. Run: nax run");
 
   logger.info("init", "Project config initialized successfully", { path: projectDir });
 }
@@ -387,11 +391,11 @@ export async function initCommand(options: InitOptions = {}): Promise<void> {
   } else if (options.package) {
     const projectRoot = options.projectRoot ?? process.cwd();
     await initPackage(projectRoot, options.package);
-    console.log("\n[OK] Package scaffold created.");
-    console.log(`  Created: .nax/mono/${options.package}/context.md`);
-    console.log("\nNext steps:");
-    console.log(`  1. Review .nax/mono/${options.package}/context.md and fill in TODOs`);
-    console.log(`  2. Run: nax generate --package ${options.package}`);
+    _initDeps.log("\n[OK] Package scaffold created.");
+    _initDeps.log(`  Created: .nax/mono/${options.package}/context.md`);
+    _initDeps.log("\nNext steps:");
+    _initDeps.log(`  1. Review .nax/mono/${options.package}/context.md and fill in TODOs`);
+    _initDeps.log(`  2. Run: nax generate --package ${options.package}`);
   } else {
     const projectRoot = options.projectRoot ?? process.cwd();
     await initProject(projectRoot, { name: options.name, force: options.force });

--- a/src/cli/prompts-init.ts
+++ b/src/cli/prompts-init.ts
@@ -8,6 +8,11 @@ import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { buildRoleTaskSection } from "../prompts/sections/role-task";
 
+export const _promptsInitDeps = {
+  log: console.log.bind(console) as (...args: unknown[]) => void,
+  warn: console.warn.bind(console) as (...args: unknown[]) => void,
+};
+
 export interface PromptsInitCommandOptions {
   /** Working directory (project root) */
   workdir: string;
@@ -62,7 +67,7 @@ export async function promptsInitCommand(options: PromptsInitCommandOptions): Pr
   const existingFiles = TEMPLATE_ROLES.map((t) => t.file).filter((f) => existsSync(join(templatesDir, f)));
 
   if (existingFiles.length > 0 && !force) {
-    console.warn(
+    _promptsInitDeps.warn(
       `[WARN] nax/templates/ already contains files: ${existingFiles.join(", ")}. No files overwritten.\n       Pass --force to overwrite existing templates.`,
     );
     return [];
@@ -81,9 +86,9 @@ export async function promptsInitCommand(options: PromptsInitCommandOptions): Pr
     written.push(filePath);
   }
 
-  console.log(`[OK] Written ${written.length} template files to nax/templates/:`);
+  _promptsInitDeps.log(`[OK] Written ${written.length} template files to nax/templates/:`);
   for (const filePath of written) {
-    console.log(`  - ${filePath.replace(`${workdir}/`, "")}`);
+    _promptsInitDeps.log(`  - ${filePath.replace(`${workdir}/`, "")}`);
   }
 
   // Auto-wire prompts.overrides in nax.config.json (if enabled)
@@ -123,7 +128,9 @@ async function autoWirePromptsConfig(workdir: string): Promise<void> {
       null,
       2,
     );
-    console.log(`\nNo nax.config.json found. To activate overrides, create nax/config.json with:\n${exampleConfig}`);
+    _promptsInitDeps.log(
+      `\nNo nax.config.json found. To activate overrides, create nax/config.json with:\n${exampleConfig}`,
+    );
     return;
   }
 
@@ -134,7 +141,7 @@ async function autoWirePromptsConfig(workdir: string): Promise<void> {
 
   // Check if prompts.overrides is already set
   if (config.prompts?.overrides && Object.keys(config.prompts.overrides).length > 0) {
-    console.log(
+    _promptsInitDeps.log(
       "[INFO] prompts.overrides already configured in nax.config.json. Skipping auto-wiring.\n" +
         "       To reset overrides, remove the prompts.overrides section and re-run this command.",
     );
@@ -161,7 +168,7 @@ async function autoWirePromptsConfig(workdir: string): Promise<void> {
   const updatedConfig = formatConfigJson(config);
   await Bun.write(configPath, updatedConfig);
 
-  console.log("[OK] Auto-wired prompts.overrides in nax.config.json");
+  _promptsInitDeps.log("[OK] Auto-wired prompts.overrides in nax.config.json");
 }
 
 /**

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -8,7 +8,7 @@
 export { promptsCommand, buildFrontmatter, type PromptsCommandOptions } from "./prompts-main";
 
 // Init command exports
-export { promptsInitCommand, type PromptsInitCommandOptions } from "./prompts-init";
+export { _promptsInitDeps, promptsInitCommand, type PromptsInitCommandOptions } from "./prompts-init";
 
 // Export command exports
 export { exportPromptCommand, type ExportPromptCommandOptions } from "./prompts-export";

--- a/src/commands/logs-formatter.ts
+++ b/src/commands/logs-formatter.ts
@@ -15,6 +15,7 @@ import { extractRunSummary } from "./logs-reader";
  * Log level hierarchy for filtering
  */
 const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  silent: -1,
   debug: 0,
   info: 1,
   warn: 2,

--- a/src/logger/formatters.ts
+++ b/src/logger/formatters.ts
@@ -27,7 +27,7 @@ export function formatConsole(entry: LogEntry): string {
   });
 
   // Level-specific color coding
-  let levelColor: (text: string) => string;
+  let levelColor: (text: string) => string = chalk.gray;
   switch (entry.level) {
     case "error":
       levelColor = chalk.red;
@@ -39,6 +39,7 @@ export function formatConsole(entry: LogEntry): string {
       levelColor = chalk.blue;
       break;
     case "debug":
+    case "silent":
       levelColor = chalk.gray;
       break;
   }

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -8,6 +8,7 @@ import type { LogEntry, LogLevel, LoggerOptions, StoryLogger } from "./types.js"
  * Severity ordering for log levels (lower number = more severe)
  */
 const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  silent: -1,
   error: 0,
   warn: 1,
   info: 2,
@@ -257,7 +258,7 @@ export class Logger {
  * });
  * ```
  */
-export function initLogger(options: LoggerOptions = { level: "warn" }): Logger {
+export function initLogger(options: LoggerOptions = { level: "silent" }): Logger {
   if (instance) {
     throw new Error("Logger already initialized. Call getLogger() to access existing instance.");
   }
@@ -280,7 +281,7 @@ export function initLogger(options: LoggerOptions = { level: "warn" }): Logger {
 /**
  * No-op logger for tests/environments where logger isn't initialized
  */
-const noopLogger: Logger = new Logger({ level: "error", useChalk: false, headless: false });
+const noopLogger: Logger = new Logger({ level: "silent", useChalk: false, headless: false });
 
 export function getLogger(): Logger {
   if (!instance) {

--- a/src/logger/types.ts
+++ b/src/logger/types.ts
@@ -1,7 +1,7 @@
 /**
  * Log level type — ordered from most to least severe
  */
-export type LogLevel = "error" | "warn" | "info" | "debug";
+export type LogLevel = "silent" | "error" | "warn" | "info" | "debug";
 
 /**
  * Structured log entry format

--- a/test/integration/acceptance/red-green-cycle.test.ts
+++ b/test/integration/acceptance/red-green-cycle.test.ts
@@ -116,7 +116,7 @@ let tmpDir: string;
 let savedDeps: typeof _acceptanceSetupDeps;
 
 beforeEach(async () => {
-  initLogger({ level: "error", useChalk: false });
+  initLogger({ level: "silent" });
   tmpDir = makeTempDir("nax-acc-cycle-");
   const featureDir = path.join(tmpDir, ".nax/features/test-feature");
   await fs.mkdir(featureDir, { recursive: true });

--- a/test/integration/execution/execution.test.ts
+++ b/test/integration/execution/execution.test.ts
@@ -37,7 +37,7 @@ const createTestPRD = (stories: Partial<UserStory>[]): PRD => ({
 
 describe("execution runner", () => {
   beforeEach(() => {
-    initLogger({ level: "error", useChalk: false });
+    initLogger({ level: "silent" });
   });
 
   afterEach(() => {
@@ -477,7 +477,7 @@ describe("execution runner", () => {
 
 describe("execution runner — lite mode routing", () => {
   beforeEach(() => {
-    initLogger({ level: "error", useChalk: false });
+    initLogger({ level: "silent" });
   });
 
   afterEach(() => {

--- a/test/integration/execution/story-id-in-events.test.ts
+++ b/test/integration/execution/story-id-in-events.test.ts
@@ -163,7 +163,7 @@ describe("StoryId is present in JSONL events emitted by pipeline stages", () => 
 
   beforeEach(() => {
     tempDir = makeTempDir("nax-storyid-test-");
-    initLogger({ level: "debug", useChalk: false });
+    initLogger({ level: "silent" });
     captureLogger();
   });
 

--- a/test/integration/pipeline/pipeline-acceptance.test.ts
+++ b/test/integration/pipeline/pipeline-acceptance.test.ts
@@ -18,7 +18,7 @@ let testDir: string;
 let featureDir: string;
 
 beforeEach(async () => {
-  initLogger({ level: "error", useChalk: false });
+  initLogger({ level: "silent" });
   testDir = makeTempDir("nax-acceptance-test-");
   featureDir = path.join(testDir, ".nax/features/test-feature");
   await fs.mkdir(featureDir, { recursive: true });

--- a/test/integration/pipeline/pipeline-events.test.ts
+++ b/test/integration/pipeline/pipeline-events.test.ts
@@ -127,7 +127,7 @@ const createMockContext = (): PipelineContext => ({
 
 describe("PipelineEventEmitter", () => {
   beforeEach(() => {
-    initLogger({ level: "error", useChalk: false });
+    initLogger({ level: "silent" });
   });
 
   afterEach(() => {
@@ -309,7 +309,7 @@ describe("PipelineEventEmitter", () => {
 
 describe("runPipeline event emission", () => {
   beforeEach(() => {
-    initLogger({ level: "error", useChalk: false });
+    initLogger({ level: "silent" });
   });
 
   afterEach(() => {

--- a/test/integration/pipeline/pipeline.test.ts
+++ b/test/integration/pipeline/pipeline.test.ts
@@ -68,7 +68,7 @@ function createContinueStage(name: string): PipelineStage {
 
 describe("Pipeline Runner", () => {
   beforeEach(() => {
-    initLogger({ level: "error", useChalk: false });
+    initLogger({ level: "silent" });
   });
 
   afterEach(() => {

--- a/test/integration/pipeline/verify-stage.test.ts
+++ b/test/integration/pipeline/verify-stage.test.ts
@@ -126,7 +126,7 @@ function createTestContext(overrides?: Partial<PipelineContext>): PipelineContex
 
 describe("Verify Stage", () => {
   beforeEach(() => {
-    initLogger({ level: "error", useChalk: false });
+    initLogger({ level: "silent" });
   });
 
   afterEach(() => {

--- a/test/integration/routing/routing-stage-final-state.test.ts
+++ b/test/integration/routing/routing-stage-final-state.test.ts
@@ -145,7 +145,7 @@ describe("Routing Stage - Task classified log shows final routing state after al
 
   beforeEach(async () => {
     workdir = makeTempDir("nax-routing-final-state-test-");
-    initLogger({ level: "debug" });
+    initLogger({ level: "silent" });
   });
 
   afterEach(async () => {

--- a/test/preload.ts
+++ b/test/preload.ts
@@ -20,6 +20,15 @@ const isolatedGlobalDir = mkdtempSync(join(tmpdir(), "nax-test-global-"));
 process.env.NAX_GLOBAL_CONFIG_DIR = isolatedGlobalDir;
 delete process.env.NAX_RUNS_DIR;
 
+// ─── Console suppression ──────────────────────────────────────────────────────
+// Suppress all console output in tests. Tests that need to capture output
+// should override _deps.log / _deps.warn in a local beforeEach, not rely on
+// global console. Tests that intentionally test console output (e.g. logger
+// unit tests) override console.log locally with their own capture functions.
+console.log = () => {};
+console.warn = () => {};
+console.error = () => {};
+
 // ─── ACP spawn sentinel ───────────────────────────────────────────────────────
 // Blocks real acpx sessions from being created in tests. Any test that calls
 // code leading to _acpAdapterDeps.createClient without first mocking it will

--- a/test/unit/cli/init-detect-ui.test.ts
+++ b/test/unit/cli/init-detect-ui.test.ts
@@ -21,6 +21,7 @@ import type { StackInfo } from "../../../src/cli/init-detect";
 import { initProject } from "../../../src/cli/init";
 import { withTempDir } from "../../helpers/temp";
 
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/test/unit/cli/init-detect.test.ts
+++ b/test/unit/cli/init-detect.test.ts
@@ -15,6 +15,7 @@ import {
 import { initProject } from "../../../src/cli/init";
 import { withTempDir } from "../../helpers/temp";
 
+
 // ---------------------------------------------------------------------------
 // detectProjectStack — runtime detection
 // ---------------------------------------------------------------------------

--- a/test/unit/cli/init.test.ts
+++ b/test/unit/cli/init.test.ts
@@ -8,10 +8,11 @@
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { _initContextDeps as contextDeps } from "../../../src/cli/init-context";
-import { initProject } from "../../../src/cli/init";
+import { _initDeps, initProject } from "../../../src/cli/init";
 import { withTempDir } from "../../helpers/temp";
+
 
 const TEMPLATE_FILES = [
   "test-writer.md",
@@ -216,7 +217,8 @@ describe("initProject — --ai flag wired through to context generation", () => 
 
   test("accepts options object with ai: false without error", async () => {
     await withTempDir(async (tempDir) => {
-      await expect(initProject(tempDir, { ai: false })).resolves.toBeUndefined();
+      const result = await initProject(tempDir, { ai: false });
+      expect(result).toBeUndefined();
     });
   });
 
@@ -253,93 +255,70 @@ describe("initProject — --ai flag wired through to context generation", () => 
 });
 
 describe("initProject — prints summary with created files and next steps", () => {
-  test("summary output includes nax/config.json", async () => {
-    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+  function captureInitLog(): { output: string[]; restore: () => void } {
+    const output: string[] = [];
+    const orig = _initDeps.log;
+    _initDeps.log = (...args: unknown[]) => { output.push(args.map(String).join(" ")); };
+    return { output, restore: () => { _initDeps.log = orig; } };
+  }
 
+  test("summary output includes nax/config.json", async () => {
+    const { output, restore } = captureInitLog();
     try {
       await withTempDir(async (tempDir) => {
         await initProject(tempDir);
-
-        const allOutput = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
-        expect(allOutput).toContain("config.json");
+        expect(output.join("\n")).toContain("config.json");
       });
-    } finally {
-      logSpy.mockRestore();
-    }
+    } finally { restore(); }
   });
 
   test("summary output includes nax/constitution.md", async () => {
-    const logSpy = spyOn(console, "log").mockImplementation(() => {});
-
+    const { output, restore } = captureInitLog();
     try {
       await withTempDir(async (tempDir) => {
         await initProject(tempDir);
-
-        const allOutput = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
-        expect(allOutput).toContain("constitution.md");
+        expect(output.join("\n")).toContain("constitution.md");
       });
-    } finally {
-      logSpy.mockRestore();
-    }
+    } finally { restore(); }
   });
 
   test("summary output includes nax/context.md", async () => {
-    const logSpy = spyOn(console, "log").mockImplementation(() => {});
-
+    const { output, restore } = captureInitLog();
     try {
       await withTempDir(async (tempDir) => {
         await initProject(tempDir);
-
-        const allOutput = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
-        expect(allOutput).toContain("context.md");
+        expect(output.join("\n")).toContain("context.md");
       });
-    } finally {
-      logSpy.mockRestore();
-    }
+    } finally { restore(); }
   });
 
   test("next-steps checklist includes nax generate", async () => {
-    const logSpy = spyOn(console, "log").mockImplementation(() => {});
-
+    const { output, restore } = captureInitLog();
     try {
       await withTempDir(async (tempDir) => {
         await initProject(tempDir);
-
-        const allOutput = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
-        expect(allOutput).toContain("nax generate");
+        expect(output.join("\n")).toContain("nax generate");
       });
-    } finally {
-      logSpy.mockRestore();
-    }
+    } finally { restore(); }
   });
 
   test("next-steps checklist includes nax plan", async () => {
-    const logSpy = spyOn(console, "log").mockImplementation(() => {});
-
+    const { output, restore } = captureInitLog();
     try {
       await withTempDir(async (tempDir) => {
         await initProject(tempDir);
-
-        const allOutput = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
-        expect(allOutput).toContain("nax plan");
+        expect(output.join("\n")).toContain("nax plan");
       });
-    } finally {
-      logSpy.mockRestore();
-    }
+    } finally { restore(); }
   });
 
   test("next-steps checklist includes nax run", async () => {
-    const logSpy = spyOn(console, "log").mockImplementation(() => {});
-
+    const { output, restore } = captureInitLog();
     try {
       await withTempDir(async (tempDir) => {
         await initProject(tempDir);
-
-        const allOutput = logSpy.mock.calls.map((args) => args.join(" ")).join("\n");
-        expect(allOutput).toContain("nax run");
+        expect(output.join("\n")).toContain("nax run");
       });
-    } finally {
-      logSpy.mockRestore();
-    }
+    } finally { restore(); }
   });
 });

--- a/test/unit/cli/prompts-init-config-wiring.test.ts
+++ b/test/unit/cli/prompts-init-config-wiring.test.ts
@@ -6,11 +6,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { promptsInitCommand } from "../../../src/cli/prompts";
+import { _promptsInitDeps, promptsInitCommand } from "../../../src/cli/prompts";
 import { makeTempDir } from "../../helpers/temp";
+
 
 const EXPECTED_OVERRIDES = {
   "test-writer": ".nax/templates/test-writer.md",
@@ -31,8 +31,8 @@ function writeConfigJson(workdir: string, config: Record<string, unknown>): void
 
 describe("promptsInitCommand — auto-wires prompts.overrides", () => {
   let tempDir: string;
-  let originalConsoleLog: typeof console.log;
-  let originalConsoleWarn: typeof console.warn;
+  let originalLog: typeof _promptsInitDeps.log;
+  let originalWarn: typeof _promptsInitDeps.warn;
   let consoleOutput: string[];
 
   beforeEach(() => {
@@ -40,19 +40,19 @@ describe("promptsInitCommand — auto-wires prompts.overrides", () => {
     mkdirSync(join(tempDir, ".nax"), { recursive: true });
 
     consoleOutput = [];
-    originalConsoleLog = console.log;
-    originalConsoleWarn = console.warn;
-    console.log = (...args: unknown[]) => {
+    originalLog = _promptsInitDeps.log;
+    originalWarn = _promptsInitDeps.warn;
+    _promptsInitDeps.log = (...args: unknown[]) => {
       consoleOutput.push(args.map((a) => String(a)).join(" "));
     };
-    console.warn = (...args: unknown[]) => {
+    _promptsInitDeps.warn = (...args: unknown[]) => {
       consoleOutput.push(args.map((a) => String(a)).join(" "));
     };
   });
 
   afterEach(() => {
-    console.log = originalConsoleLog;
-    console.warn = originalConsoleWarn;
+    _promptsInitDeps.log = originalLog;
+    _promptsInitDeps.warn = originalWarn;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -122,8 +122,8 @@ describe("promptsInitCommand — auto-wires prompts.overrides", () => {
 
 describe("promptsInitCommand — does not overwrite existing prompts.overrides", () => {
   let tempDir: string;
-  let originalConsoleLog: typeof console.log;
-  let originalConsoleWarn: typeof console.warn;
+  let originalLog: typeof _promptsInitDeps.log;
+  let originalWarn: typeof _promptsInitDeps.warn;
   let consoleOutput: string[];
 
   beforeEach(() => {
@@ -131,19 +131,19 @@ describe("promptsInitCommand — does not overwrite existing prompts.overrides",
     mkdirSync(join(tempDir, ".nax"), { recursive: true });
 
     consoleOutput = [];
-    originalConsoleLog = console.log;
-    originalConsoleWarn = console.warn;
-    console.log = (...args: unknown[]) => {
+    originalLog = _promptsInitDeps.log;
+    originalWarn = _promptsInitDeps.warn;
+    _promptsInitDeps.log = (...args: unknown[]) => {
       consoleOutput.push(args.map((a) => String(a)).join(" "));
     };
-    console.warn = (...args: unknown[]) => {
+    _promptsInitDeps.warn = (...args: unknown[]) => {
       consoleOutput.push(args.map((a) => String(a)).join(" "));
     };
   });
 
   afterEach(() => {
-    console.log = originalConsoleLog;
-    console.warn = originalConsoleWarn;
+    _promptsInitDeps.log = originalLog;
+    _promptsInitDeps.warn = originalWarn;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -195,8 +195,8 @@ describe("promptsInitCommand — does not overwrite existing prompts.overrides",
 
 describe("promptsInitCommand — handles missing nax.config.json gracefully", () => {
   let tempDir: string;
-  let originalConsoleLog: typeof console.log;
-  let originalConsoleWarn: typeof console.warn;
+  let originalLog: typeof _promptsInitDeps.log;
+  let originalWarn: typeof _promptsInitDeps.warn;
   let consoleOutput: string[];
 
   beforeEach(() => {
@@ -204,19 +204,19 @@ describe("promptsInitCommand — handles missing nax.config.json gracefully", ()
     mkdirSync(join(tempDir, ".nax"), { recursive: true });
 
     consoleOutput = [];
-    originalConsoleLog = console.log;
-    originalConsoleWarn = console.warn;
-    console.log = (...args: unknown[]) => {
+    originalLog = _promptsInitDeps.log;
+    originalWarn = _promptsInitDeps.warn;
+    _promptsInitDeps.log = (...args: unknown[]) => {
       consoleOutput.push(args.map((a) => String(a)).join(" "));
     };
-    console.warn = (...args: unknown[]) => {
+    _promptsInitDeps.warn = (...args: unknown[]) => {
       consoleOutput.push(args.map((a) => String(a)).join(" "));
     };
   });
 
   afterEach(() => {
-    console.log = originalConsoleLog;
-    console.warn = originalConsoleWarn;
+    _promptsInitDeps.log = originalLog;
+    _promptsInitDeps.warn = originalWarn;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -261,18 +261,18 @@ describe("promptsInitCommand — handles missing nax.config.json gracefully", ()
 
 describe("promptsInitCommand — headless/non-TTY mode auto-writes config", () => {
   let tempDir: string;
-  let originalConsoleLog: typeof console.log;
-  let originalConsoleWarn: typeof console.warn;
+  let originalLog: typeof _promptsInitDeps.log;
+  let originalWarn: typeof _promptsInitDeps.warn;
   let originalIsTTY: boolean | undefined;
 
   beforeEach(() => {
     tempDir = makeTempDir("nax-prompts-config-test-");
     mkdirSync(join(tempDir, ".nax"), { recursive: true });
 
-    originalConsoleLog = console.log;
-    originalConsoleWarn = console.warn;
-    console.log = () => {};
-    console.warn = () => {};
+    originalLog = _promptsInitDeps.log;
+    originalWarn = _promptsInitDeps.warn;
+    _promptsInitDeps.log = () => {};
+    _promptsInitDeps.warn = () => {};
 
     // Simulate non-TTY mode
     originalIsTTY = process.stdout.isTTY;
@@ -280,8 +280,8 @@ describe("promptsInitCommand — headless/non-TTY mode auto-writes config", () =
   });
 
   afterEach(() => {
-    console.log = originalConsoleLog;
-    console.warn = originalConsoleWarn;
+    _promptsInitDeps.log = originalLog;
+    _promptsInitDeps.warn = originalWarn;
     // Restore TTY state
     Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, configurable: true });
     rmSync(tempDir, { recursive: true, force: true });

--- a/test/unit/cli/prompts-init.test.ts
+++ b/test/unit/cli/prompts-init.test.ts
@@ -6,12 +6,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { promptsInitCommand } from "../../../src/cli/prompts";
+import { _promptsInitDeps, promptsInitCommand } from "../../../src/cli/prompts";
 import { buildRoleTaskSection } from "../../../src/prompts/sections/role-task";
 import { makeTempDir } from "../../helpers/temp";
+
 
 const TEMPLATE_FILES = [
   "test-writer.md",
@@ -186,27 +186,27 @@ describe("promptsInitCommand — header comment in each template", () => {
 describe("promptsInitCommand — no-overwrite protection", () => {
   let tempDir: string;
   let consoleOutput: string[];
-  let originalConsoleLog: typeof console.log;
-  let originalConsoleWarn: typeof console.warn;
+  let savedLog: typeof _promptsInitDeps.log;
+  let savedWarn: typeof _promptsInitDeps.warn;
 
   beforeEach(() => {
     tempDir = makeTempDir("nax-prompts-init-test-");
     mkdirSync(join(tempDir, ".nax", "templates"), { recursive: true });
 
     consoleOutput = [];
-    originalConsoleLog = console.log;
-    originalConsoleWarn = console.warn;
-    console.log = (...args: unknown[]) => {
+    savedLog = _promptsInitDeps.log;
+    savedWarn = _promptsInitDeps.warn;
+    _promptsInitDeps.log = (...args: unknown[]) => {
       consoleOutput.push(args.map((a) => String(a)).join(" "));
     };
-    console.warn = (...args: unknown[]) => {
+    _promptsInitDeps.warn = (...args: unknown[]) => {
       consoleOutput.push(args.map((a) => String(a)).join(" "));
     };
   });
 
   afterEach(() => {
-    console.log = originalConsoleLog;
-    console.warn = originalConsoleWarn;
+    _promptsInitDeps.log = savedLog;
+    _promptsInitDeps.warn = savedWarn;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -299,21 +299,27 @@ describe("promptsInitCommand — --force flag", () => {
 describe("promptsInitCommand — summary output", () => {
   let tempDir: string;
   let consoleOutput: string[];
-  let originalConsoleLog: typeof console.log;
+  let savedLog: typeof _promptsInitDeps.log;
+  let savedWarn: typeof _promptsInitDeps.warn;
 
   beforeEach(() => {
     tempDir = makeTempDir("nax-prompts-init-test-");
     mkdirSync(join(tempDir, ".nax"), { recursive: true });
 
     consoleOutput = [];
-    originalConsoleLog = console.log;
-    console.log = (...args: unknown[]) => {
+    savedLog = _promptsInitDeps.log;
+    savedWarn = _promptsInitDeps.warn;
+    _promptsInitDeps.log = (...args: unknown[]) => {
+      consoleOutput.push(args.map((a) => String(a)).join(" "));
+    };
+    _promptsInitDeps.warn = (...args: unknown[]) => {
       consoleOutput.push(args.map((a) => String(a)).join(" "));
     };
   });
 
   afterEach(() => {
-    console.log = originalConsoleLog;
+    _promptsInitDeps.log = savedLog;
+    _promptsInitDeps.warn = savedWarn;
     rmSync(tempDir, { recursive: true, force: true });
   });
 

--- a/test/unit/config/tdd-simple-strategy.test.ts
+++ b/test/unit/config/tdd-simple-strategy.test.ts
@@ -18,7 +18,7 @@ import { validateRoutingDecision } from "../../../src/routing/strategies/llm";
 
 beforeEach(() => {
   resetLogger();
-  initLogger({ level: "error", useChalk: false });
+  initLogger({ level: "silent" });
 });
 
 afterEach(() => {

--- a/test/unit/pipeline/routing-partial-override.test.ts
+++ b/test/unit/pipeline/routing-partial-override.test.ts
@@ -79,7 +79,7 @@ function makeCtx(story: UserStory): PipelineContext {
 
 beforeEach(() => {
   resetLogger();
-  initLogger({ level: "error", useChalk: false });
+  initLogger({ level: "silent" });
   _routingDeps.resolveRouting = mockResolveRouting as typeof _routingDeps.resolveRouting;
   _routingDeps.isGreenfieldStory = mockIsGreenfieldStory as typeof _routingDeps.isGreenfieldStory;
   _routingDeps.savePRD = mockSavePRD as typeof _routingDeps.savePRD;

--- a/test/unit/pipeline/stages/routing-greenfield-monorepo.test.ts
+++ b/test/unit/pipeline/stages/routing-greenfield-monorepo.test.ts
@@ -71,7 +71,7 @@ describe("MW-011: greenfield detection scopes to story package workdir", () => {
   let repoRoot: string;
 
   beforeEach(async () => {
-    initLogger({ level: "silent", format: "jsonl", logFilePath: undefined });
+    initLogger({ level: "silent" });
     repoRoot = makeTempDir("nax-mw011-");
 
     // Set up monorepo structure

--- a/test/unit/pipeline/storyid-events.test.ts
+++ b/test/unit/pipeline/storyid-events.test.ts
@@ -113,7 +113,7 @@ function makeCtx(
 beforeEach(() => {
   _executionDeps.getAgent = () => mockAgent as any;
   resetLogger();
-  initLogger({ level: "debug", useChalk: false });
+  initLogger({ level: "silent" });
   mockAgentRun.mockClear();
 });
 

--- a/test/unit/pipeline/verify-smart-runner.test.ts
+++ b/test/unit/pipeline/verify-smart-runner.test.ts
@@ -173,7 +173,7 @@ function makeContext(
 
 describe("Verify Stage --- Smart Runner Integration", () => {
   beforeEach(() => {
-    initLogger({ level: "error", useChalk: false });
+    initLogger({ level: "silent" });
     _smartRunnerDeps.getChangedTestFiles = mockGetChangedTestFiles as typeof _smartRunnerDeps.getChangedTestFiles;
     _smartRunnerDeps.getChangedNonTestFiles = mockGetChangedNonTestFiles;
     _smartRunnerDeps.mapSourceToTests = mockMapSourceToTests;

--- a/test/unit/plugins/plugin-logger.test.ts
+++ b/test/unit/plugins/plugin-logger.test.ts
@@ -13,7 +13,7 @@ describe("createPluginLogger", () => {
 
   beforeEach(() => {
     logFile = `${import.meta.dir}/test-plugin-logger-${Date.now()}.jsonl`;
-    initLogger({ level: "debug", filePath: logFile });
+    initLogger({ level: "silent", filePath: logFile });
     logger = createPluginLogger("test-plugin");
   });
 

--- a/test/unit/routing/routing-stability.test.ts
+++ b/test/unit/routing/routing-stability.test.ts
@@ -32,7 +32,7 @@ const routeCtxConfig: NaxConfig = { ...DEFAULT_CONFIG, routing: { ...DEFAULT_CON
 
 beforeEach(() => {
   resetLogger();
-  initLogger({ level: "error", useChalk: false });
+  initLogger({ level: "silent" });
 });
 
 afterEach(() => {

--- a/test/unit/routing/strategies/keyword.test.ts
+++ b/test/unit/routing/strategies/keyword.test.ts
@@ -49,7 +49,7 @@ function makeStory(overrides: Partial<UserStory> = {}): UserStory {
 
 beforeEach(() => {
   resetLogger();
-  initLogger({ level: "error", useChalk: false });
+  initLogger({ level: "silent" });
 });
 
 afterEach(() => {

--- a/test/unit/routing/strategies/llm-adapter.test.ts
+++ b/test/unit/routing/strategies/llm-adapter.test.ts
@@ -13,7 +13,7 @@ import { initLogger, resetLogger } from "../../../../src/logger";
 
 beforeEach(() => {
   resetLogger();
-  initLogger({ level: "error", useChalk: false });
+  initLogger({ level: "silent" });
 });
 
 afterEach(() => {

--- a/test/unit/routing/strategies/llm.test.ts
+++ b/test/unit/routing/strategies/llm.test.ts
@@ -41,7 +41,7 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   resetLogger();
-  initLogger({ level: "error", useChalk: false });
+  initLogger({ level: "silent" });
 });
 
 afterEach(() => {

--- a/test/unit/runtime/middleware/agent-stream-logging.test.ts
+++ b/test/unit/runtime/middleware/agent-stream-logging.test.ts
@@ -106,7 +106,7 @@ describe("attachAgentStreamLogging", () => {
   beforeEach(() => {
     tmpDir = makeTempDir("nax-test-agent-stream-logging-");
     logFile = join(tmpDir, `test-agent-stream-logging-${Date.now()}.jsonl`);
-    initLogger({ level: "debug", filePath: logFile, useChalk: false, headless: true });
+    initLogger({ level: "silent", filePath: logFile });
   });
 
   afterEach(async () => {

--- a/test/unit/runtime/middleware/idle-watchdog-tool-call.test.ts
+++ b/test/unit/runtime/middleware/idle-watchdog-tool-call.test.ts
@@ -99,7 +99,7 @@ describe("attachAgentIdleWatchdog — tool-call activity", () => {
   beforeEach(() => {
     tmpDir = makeTempDir("nax-test-idle-watchdog-tool-");
     logFile = join(tmpDir, `idle-watchdog-tool-${Date.now()}.jsonl`);
-    initLogger({ level: "debug", filePath: logFile, useChalk: false, headless: true });
+    initLogger({ level: "silent", filePath: logFile });
   });
 
   afterEach(async () => {

--- a/test/unit/runtime/middleware/idle-watchdog.test.ts
+++ b/test/unit/runtime/middleware/idle-watchdog.test.ts
@@ -143,7 +143,7 @@ describe("attachAgentIdleWatchdog", () => {
   beforeEach(() => {
     tmpDir = makeTempDir("nax-test-idle-watchdog-");
     logFile = join(tmpDir, `test-idle-watchdog-${Date.now()}.jsonl`);
-    initLogger({ level: "debug", filePath: logFile, useChalk: false, headless: true });
+    initLogger({ level: "silent", filePath: logFile });
     eventBus = new AgentStreamEventBus();
     controllerRegistry = new Map();
     currentUnsubscribe = undefined;

--- a/test/unit/runtime/middleware/logging.test.ts
+++ b/test/unit/runtime/middleware/logging.test.ts
@@ -75,7 +75,7 @@ describe("attachLoggingSubscriber", () => {
   beforeEach(() => {
     tmpDir = makeTempDir("nax-test-logging-sub-");
     logFile = join(tmpDir, `test-logging-sub-${Date.now()}.jsonl`);
-    initLogger({ level: "debug", filePath: logFile, useChalk: false, headless: true });
+    initLogger({ level: "silent", filePath: logFile });
   });
 
   afterEach(async () => {

--- a/test/unit/verification/rectification-loop-escalation.test.ts
+++ b/test/unit/verification/rectification-loop-escalation.test.ts
@@ -133,7 +133,7 @@ describe("runRectificationLoop — escalation on exhaustion", () => {
 
   beforeEach(() => {
     resetLogger();
-    initLogger({ level: "debug", headless: true });
+    initLogger({ level: "silent" });
     capturedInfos = [];
     capturedWarns = [];
 

--- a/test/unit/verification/rectification-loop.test.ts
+++ b/test/unit/verification/rectification-loop.test.ts
@@ -733,7 +733,7 @@ describe("runRectificationLoop — logging failing test names", () => {
 
   beforeEach(() => {
     resetLogger();
-    initLogger({ level: "warn", headless: true });
+    initLogger({ level: "silent" });
     capturedWarns = [];
 
     // Patch the logger to capture warn calls


### PR DESCRIPTION
## Summary

- Adds a `"silent"` log level (priority `-1`) to the logger so `initLogger()` with no args and the `noopLogger` fallback produce zero output
- Globally suppresses `console.log/warn/error` in `test/preload.ts` — eliminates CLI command noise (init, prompts) without per-file `_deps` boilerplate
- Exposes `_initDeps` / `_promptsInitDeps` on CLI modules so tests that need to *verify* output can capture it via local `beforeEach`/`afterEach` (consistent with the `_deps` pattern used across 70+ modules in this codebase)
- Switches 24 test files from `initLogger({ level: "error"/"debug"/"warn" })` to `"silent"` to stop routing/pipeline logs leaking during test runs

## Test plan

- [ ] `bun run test:bail` passes with 1288 tests, 0 failures
- [ ] `bun run test:bail` produces no console noise (routing logs, init summary, prompts warnings)
- [ ] Tests that capture CLI output (`init.test.ts` "prints summary" describe, `prompts-init.test.ts` "no-overwrite protection" + "summary output" describes) still assert correctly via `_deps` capture