### PR TITLE
fix: stable RecordId across story lifecycle (keepOpen + warm-lifetime ops)

### DIFF
--- a/src/operations/autofix-implementer.ts
+++ b/src/operations/autofix-implementer.ts
@@ -24,7 +24,7 @@ export const implementerRectifyOp: RunOperation<AutofixImplementerInput, Autofix
   kind: "run",
   name: "autofix-implementer",
   stage: "rectification",
-  session: { role: "implementer", lifetime: "fresh" },
+  session: { role: "implementer", lifetime: "warm" },
   config: autofixConfigSelector,
   build(input, _ctx) {
     const prompt = RectifierPromptBuilder.reviewRectification(input.failedChecks, input.story);

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -285,7 +285,11 @@ export function buildHopCallback(
       // STALE-RETRY: keep the handle open for the next attempt. The session stays
       // cached in _liveHandles; the subsequent hop (success, swap, or exhaustion)
       // either closes it in its own finally or SessionManager teardown handles it.
-      if (hopKind.kind !== "stale-retry") {
+      // keepOpen: callers that need session continuity across pipeline stages (e.g.
+      // execution.ts with review/rectification enabled, or warm-lifetime callOp ops
+      // like implementerRectifyOp) set this flag so downstream stages can reuse the
+      // same ACP session via sessionManager.getLiveHandle().
+      if (hopKind.kind !== "stale-retry" && !resolvedRunOptions.keepOpen) {
         await sessionManager.closeSession(handle);
       }
     }

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -251,6 +251,11 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
     featureName: ctx.featureName,
     storyId: ctx.storyId,
     callId,
+    // "warm" lifetime: the op expects to reuse the same ACP session across multiple
+    // callOp invocations (e.g. autofix-implementer across fix-cycle iterations).
+    // keepOpen=true prevents buildHopCallback from closing the session after each hop
+    // so subsequent openSession calls find the live handle and return it immediately.
+    ...(runOp.session.lifetime === "warm" ? { keepOpen: true } : {}),
     ...(ctx.scopeId !== undefined ? { scopeId: ctx.scopeId } : {}),
     ...(ctx.interactionBridge ? { interactionBridge: ctx.interactionBridge } : {}),
     ...(ctx.maxInteractionTurns !== undefined ? { maxInteractionTurns: ctx.maxInteractionTurns } : {}),

--- a/src/tdd/orchestrator.ts
+++ b/src/tdd/orchestrator.ts
@@ -294,7 +294,7 @@ export async function runThreeSessionTdd(options: ThreeSessionTddOptions): Promi
     logger,
     featureName,
     projectDir,
-    implementerBinding?.sessionId,
+    implementerBinding?.sessionManager,
     runtime,
   );
   const { cost: fullSuiteGateCost, fullSuiteGatePassed } = fullSuiteGate;

--- a/src/tdd/rectification-gate.ts
+++ b/src/tdd/rectification-gate.ts
@@ -9,14 +9,15 @@
 import type { IAgentManager } from "../agents";
 import type { SessionHandle } from "../agents/types";
 import { SessionTurnError } from "../agents/types";
-import type { ModelTier } from "../config";
 import { resolveModelForAgent } from "../config";
+import type { ModelTier } from "../config";
 import type { RectificationGateConfig } from "../config/selectors";
-import type { getLogger } from "../logger";
 import { getSafeLogger } from "../logger";
+import type { getLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { RectifierPromptBuilder } from "../prompts";
 import { resolveQualityTestCommands } from "../quality/command-resolver";
+import type { ISessionManager } from "../session";
 import { formatSessionName } from "../session/naming";
 import { autoCommitIfDirty, captureGitRef } from "../utils/git";
 import {
@@ -89,7 +90,7 @@ export async function runFullSuiteGate(
   logger: ReturnType<typeof getLogger>,
   featureName: string | undefined,
   projectDir: string | undefined,
-  sessionId: string | undefined,
+  sessionManager: ISessionManager | undefined,
   runtime: import("../runtime").NaxRuntime,
 ): Promise<FullSuiteGateResult> {
   const rectificationEnabled = config.execution.rectification?.enabled ?? false;
@@ -152,7 +153,7 @@ export async function runFullSuiteGate(
         runtime,
         featureName,
         projectDir,
-        sessionId,
+        sessionManager,
       );
     }
 
@@ -221,7 +222,7 @@ async function runRectificationLoop(
   runtime: import("../runtime").NaxRuntime,
   featureName?: string,
   projectDir?: string,
-  sessionId?: string,
+  sessionManager?: ISessionManager,
 ): Promise<FullSuiteGateResult> {
   logger.warn("tdd", "Full suite gate detected regressions", {
     storyId: story.id,
@@ -297,7 +298,8 @@ async function runRectificationLoop(
       // ADR-008 §6 / ADR-018 §7 Pattern B: open the implementer session once
       // and reuse across attempts. openSession is idempotent (session/manager.ts:354)
       // so we attach to any session opened upstream by execution.ts when one
-      // is still alive.
+      // is still alive. If keepOpen was set, the implementer session handle is
+      // still in _liveHandles and getLiveHandle finds it without re-connecting.
       //
       // Transport retry: QUEUE_DISCONNECTED_BEFORE_COMPLETION is retryable (acpx
       // signals retryable:true). The runtime path bypasses runWithFallback so we
@@ -306,17 +308,24 @@ async function runRectificationLoop(
       const maxTransportRetries = config.execution?.sessionErrorRetryableMaxRetries ?? 3;
       while (true) {
         if (!heldHandle) {
-          heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
-            agentName: defaultAgent,
-            role: "implementer",
-            workdir,
-            pipelineStage: "rectification",
-            modelDef: runOptions.modelDef,
-            timeoutSeconds: config.execution.sessionTimeoutSeconds,
-            featureName,
-            storyId: story.id,
-            signal: runtime.signal,
-          });
+          // First: try to resume the implementer session left open by execution.ts.
+          const existingHandle = sessionManager?.getLiveHandle(rectificationSessionName);
+          if (existingHandle && existingHandle.agentName === defaultAgent) {
+            heldHandle = existingHandle;
+          } else {
+            // No live handle — open a fresh session for this rectification cycle.
+            heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
+              agentName: defaultAgent,
+              role: "implementer",
+              workdir,
+              pipelineStage: "rectification",
+              modelDef: runOptions.modelDef,
+              timeoutSeconds: config.execution.sessionTimeoutSeconds,
+              featureName,
+              storyId: story.id,
+              signal: runtime.signal,
+            });
+          }
         }
         // ADR-020 single-emission invariant: each runAsSession emits one
         // session-turn event for audit/cost subscribers, regardless of handle
@@ -364,9 +373,9 @@ async function runRectificationLoop(
 
       // G5: bind updated protocolIds after each rectification attempt so the session descriptor
       // reflects the session that actually ran (may change after internal session retries).
-      if (sessionId && rectifyResult.protocolIds) {
+      if (sessionManager && heldHandle && rectifyResult.protocolIds) {
         try {
-          runtime.sessionManager.bindHandle(sessionId, rectificationSessionName, rectifyResult.protocolIds);
+          sessionManager.bindHandle(heldHandle.id, rectificationSessionName, rectifyResult.protocolIds);
         } catch {
           // Session may not exist in manager (e.g. v2 context disabled) — ignore.
         }

--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -309,7 +309,9 @@ export async function runRectificationLoop(
         // ADR-008 §6 / ADR-018 §7 Pattern B: open the implementer session
         // once and reuse across attempts. openSession is idempotent on a live
         // handle (session/manager.ts:354) so we attach to any session opened
-        // upstream by execution.ts when one is still alive.
+        // upstream by execution.ts when one is still alive. If keepOpen was set,
+        // the implementer session handle is still in _liveHandles and
+        // getLiveHandle finds it without re-connecting.
         //
         // Transport retry: QUEUE_DISCONNECTED_BEFORE_COMPLETION is retryable (acpx
         // signals retryable:true). The runtime path bypasses runWithFallback so we
@@ -318,17 +320,24 @@ export async function runRectificationLoop(
         const maxTransportRetries = config.execution?.sessionErrorRetryableMaxRetries ?? 3;
         while (true) {
           if (!heldHandle) {
-            heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
-              agentName: defaultAgent,
-              role: "implementer",
-              workdir,
-              pipelineStage: "rectification",
-              modelDef,
-              timeoutSeconds: config.execution.sessionTimeoutSeconds,
-              featureName,
-              storyId: story.id,
-              signal: runtime.signal,
-            });
+            // First: try to resume the implementer session left open by execution.ts.
+            const existingHandle = runtime.sessionManager.getLiveHandle(rectificationSessionName);
+            if (existingHandle && existingHandle.agentName === defaultAgent) {
+              heldHandle = existingHandle;
+            } else {
+              // No live handle — open a fresh session for this rectification cycle.
+              heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
+                agentName: defaultAgent,
+                role: "implementer",
+                workdir,
+                pipelineStage: "rectification",
+                modelDef,
+                timeoutSeconds: config.execution.sessionTimeoutSeconds,
+                featureName,
+                storyId: story.id,
+                signal: runtime.signal,
+              });
+            }
           }
           // ADR-020 single-emission invariant: each runAsSession emits one
           // session-turn event for audit/cost subscribers, regardless of handle

--- a/test/unit/tdd/rectification-gate-session.test.ts
+++ b/test/unit/tdd/rectification-gate-session.test.ts
@@ -45,6 +45,7 @@ function makeRuntime(handleOverrides: Record<string, unknown> = {}) {
     openSession: mock(async () => handle),
     closeSession: mock(async () => {}),
     bindHandle: mock(() => {}),
+    getLiveHandle: mock(() => undefined),
   };
   return {
     sessionManager,
@@ -367,8 +368,8 @@ src/foo.ts:12:8 - error TS2304: Cannot find name 'missingSymbol'
     expect(warn).toHaveBeenCalledTimes(1);
   });
 
-  // AC4: bindHandle is called when sessionId is provided and attempt result includes protocolIds.
-  test("calls runtime.sessionManager.bindHandle when sessionId is provided and protocolIds present", async () => {
+  // AC4: bindHandle is called when sessionManager is provided and attempt result includes protocolIds.
+  test("calls sessionManager.bindHandle when sessionManager is provided and protocolIds present", async () => {
     const story = makeStory({ id: "US-AC4" });
     const config = makeConfig(1);
     const protocolIds = { recordId: "rec-abc", sessionId: "sess-abc" };
@@ -401,20 +402,20 @@ src/foo.ts:12:8 - error TS2304: Cannot find name 'missingSymbol'
       { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any,
       "my-feature",
       "/tmp/project",
-      "the-session-id", // sessionId provided → bindHandle must be called
+      sessionManager as any, // sessionManager provided → bindHandle must be called
       runtime as any,
     );
 
     expect(sessionManager.bindHandle).toHaveBeenCalledTimes(1);
     expect(sessionManager.bindHandle).toHaveBeenCalledWith(
-      "the-session-id",
+      "nax-rectify",
       expect.any(String),
       protocolIds,
     );
   });
 
-  // AC5: bindHandle is NOT called when sessionId is absent.
-  test("does not call runtime.sessionManager.bindHandle when sessionId is absent", async () => {
+  // AC5: bindHandle is NOT called when sessionManager is absent.
+  test("does not call sessionManager.bindHandle when sessionManager is absent", async () => {
     const story = makeStory({ id: "US-AC5" });
     const config = makeConfig(1);
     const protocolIds = { recordId: "rec-xyz", sessionId: "sess-xyz" };
@@ -446,7 +447,7 @@ src/foo.ts:12:8 - error TS2304: Cannot find name 'missingSymbol'
       { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} } as any,
       "my-feature",
       "/tmp/project",
-      undefined, // no sessionId → bindHandle must NOT be called
+      undefined, // no sessionManager → bindHandle must NOT be called
       runtime as any,
     );
 


### PR DESCRIPTION
## Summary

- **`build-hop-callback.ts`** — `buildHopCallback` always closed the ACP session after each hop, ignoring `resolvedRunOptions.keepOpen`. `execution.ts` correctly set `keepOpen=true` so the initial run's session could be reused by rectification, but the flag had no effect — the session was torn down before `getLiveHandle` could find anything.
- **`call.ts`** — `callOp` never emitted `keepOpen:true` for run-kind ops, even when the op declared `session.lifetime: "warm"`. Each autofix iteration therefore opened a fresh ACP session (new `RecordId`).
- **`autofix-implementer.ts`** — `implementerRectifyOp` used `lifetime: "fresh"` (the default). Changed to `"warm"` so `callOp` propagates `keepOpen:true` through `buildHopCallback`.

Together with the `getLiveHandle` plumbing added in `15de89c9`, this makes the `RecordId` stable across the **entire story lifecycle** — initial run + all rectification/autofix iterations — for both the non-TDD (`hello-lint`) and TDD-with-autofix (`tdd-calc`) paths.

### Root cause recap

| Path | Symptom | Root cause |
|---|---|---|
| Non-TDD + rectification (`hello-lint`) | `RecordId` always differed between run and rectification | `buildHopCallback` ignored `keepOpen` → session closed → `getLiveHandle` returned nothing |
| TDD + autofix cycle (`tdd-calc`) | First rectification inherited session; second did not | Same `buildHopCallback` bug + `lifetime:"fresh"` meant `callOp` never set `keepOpen` for fix-cycle iterations |

## Test plan

- [ ] Run `hello-lint` story end-to-end with rectification enabled — verify `acpxRecordId` is identical in initial-run and rectification prompt audit files
- [ ] Run `tdd-calc` story end-to-end with autofix cycle — verify `acpxRecordId` is identical across all autofix iterations
- [ ] `bun run typecheck` — passes clean (verified before commit)
- [ ] `bun run test` — full suite green