### PR TITLE
chore: release v0.67.0-canary.5 (canary)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.67.0-canary.4",
+  "version": "0.67.0-canary.5",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.67.0-canary.5

Bumps version: 0.67.0-canary.4 → 0.67.0-canary.5

After merging, run:
```bash
git checkout main && git pull origin main
bun run release tag
```