### PR TITLE
fix: rectification fails with terminal COMPLETED session after deferred regression

### DIFF
--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -308,10 +308,11 @@ export async function runRectificationLoop(
       {
         // ADR-008 §6 / ADR-018 §7 Pattern B: open the implementer session
         // once and reuse across attempts. openSession is idempotent on a live
-        // handle (session/manager.ts:354) so we attach to any session opened
-        // upstream by execution.ts when one is still alive. If keepOpen was set,
-        // the implementer session handle is still in _liveHandles and
-        // getLiveHandle finds it without re-connecting.
+        // handle (session/manager.ts:427) — it returns the existing handle when
+        // the session is still alive, and opens a fresh one (clearing the stale
+        // _liveHandles entry) when keepOpen left a completed descriptor behind.
+        // Always go through openSession rather than getLiveHandle so the terminal-
+        // state guard in openSession runs on every attempt.
         //
         // Transport retry: QUEUE_DISCONNECTED_BEFORE_COMPLETION is retryable (acpx
         // signals retryable:true). The runtime path bypasses runWithFallback so we
@@ -320,24 +321,17 @@ export async function runRectificationLoop(
         const maxTransportRetries = config.execution?.sessionErrorRetryableMaxRetries ?? 3;
         while (true) {
           if (!heldHandle) {
-            // First: try to resume the implementer session left open by execution.ts.
-            const existingHandle = runtime.sessionManager.getLiveHandle(rectificationSessionName);
-            if (existingHandle && existingHandle.agentName === defaultAgent) {
-              heldHandle = existingHandle;
-            } else {
-              // No live handle — open a fresh session for this rectification cycle.
-              heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
-                agentName: defaultAgent,
-                role: "implementer",
-                workdir,
-                pipelineStage: "rectification",
-                modelDef,
-                timeoutSeconds: config.execution.sessionTimeoutSeconds,
-                featureName,
-                storyId: story.id,
-                signal: runtime.signal,
-              });
-            }
+            heldHandle = await runtime.sessionManager.openSession(rectificationSessionName, {
+              agentName: defaultAgent,
+              role: "implementer",
+              workdir,
+              pipelineStage: "rectification",
+              modelDef,
+              timeoutSeconds: config.execution.sessionTimeoutSeconds,
+              featureName,
+              storyId: story.id,
+              signal: runtime.signal,
+            });
           }
           // ADR-020 single-emission invariant: each runAsSession emits one
           // session-turn event for audit/cost subscribers, regardless of handle

--- a/test/unit/verification/rectification-loop.test.ts
+++ b/test/unit/verification/rectification-loop.test.ts
@@ -638,6 +638,65 @@ describe("runRectificationLoop — runtime required and legacy path removed", ()
     expect(closeSessionCalls[0].id).toBe("test-session-hold");
   });
 
+  test("calls openSession unconditionally — does not shortcut via getLiveHandle (regression: terminal COMPLETED session)", async () => {
+    // Regression guard for the deferred-regression bug: execution.ts marks the
+    // implementer session COMPLETED via closeStory(), but keepOpen leaves a stale
+    // handle in _liveHandles. The old code called getLiveHandle() and used that
+    // stale handle directly, bypassing openSession's terminal-state reset logic,
+    // which caused "Session is in terminal state COMPLETED" from sendPrompt.
+    //
+    // With the fix, openSession is always called. getLiveHandle must NOT be called.
+    const openSessionCalls: string[] = [];
+    const getLiveHandleCalls: string[] = [];
+
+    const mockSessionManager = makeSessionManager({
+      openSession: mock(async (name: string) => {
+        openSessionCalls.push(name);
+        return { id: name, agentName: "claude" };
+      }),
+      getLiveHandle: mock((name: string) => {
+        getLiveHandleCalls.push(name);
+        // Simulate a stale handle that exists in _liveHandles after closeStory()
+        return { id: name, agentName: "claude" };
+      }),
+      closeSession: mock(async () => {}),
+    });
+
+    const mockAgentManager = makeMockAgentManager({
+      runAsSessionFn: mock(async () => ({
+        output: "fixed",
+        estimatedCostUsd: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        internalRoundTrips: 0,
+      })),
+    });
+
+    _rectificationDeps.agentManager = mockAgentManager;
+    _rectificationDeps.runVerification = mock(async () => ({
+      success: true,
+      output: "1 pass, 0 fail",
+      status: "SUCCESS" as const,
+      countsTowardEscalation: true,
+    }));
+
+    const runtime = makeMockRuntime({ sessionManager: mockSessionManager });
+
+    await runRectificationLoop({
+      config: makeConfig(),
+      workdir: "/tmp/test",
+      story: makeStory({ id: "TS-TERMINAL-REGRESSION" }),
+      testCommand: "bun test",
+      timeoutSeconds: 30,
+      testOutput: FAILING_TEST_OUTPUT,
+      featureName: "my-feature",
+      agentManager: mockAgentManager,
+      runtime,
+    });
+
+    expect(openSessionCalls).toHaveLength(1);
+    expect(getLiveHandleCalls).toHaveLength(0);
+  });
+
   test("does not call runtime.sessionManager.closeSession when runtime is not provided", async () => {
     const closeSessionCalls: Array<{ id: string }> = [];
 


### PR DESCRIPTION
## Summary

- During deferred regression, all story sessions are already in `COMPLETED` state when rectification starts — `closeStory()` marks them terminal at the end of main execution, but `keepOpen: true` leaves stale handles in `_liveHandles`
- The old `getLiveHandle()` shortcut in `rectification-loop.ts` grabbed the stale handle directly and passed it to `runAsSession`, bypassing `openSession`'s terminal-state recovery; `sendPrompt` then threw `"Session is in terminal state COMPLETED — call openSession first to resume"`
- Fix: remove the shortcut and always call `openSession`, which already handles this case at `session/manager.ts:427–492` (detects COMPLETED descriptor → clears stale handle → opens fresh adapter session → resets descriptor to RUNNING)

## Test plan

- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `bun run test` — 1288 tests pass (was 1287 before the new regression test)
- [ ] New regression test `"calls openSession unconditionally — does not shortcut via getLiveHandle"` asserts `openSession` is called and `getLiveHandle` is never called directly, guarding against reintroduction