### PR TITLE
fix: always run deferred regression after acceptance

### DIFF
--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -77,32 +77,6 @@ export interface RunCompletionResult {
 }
 
 /**
- * Check if deferred regression should be skipped (RL-006).
- *
- * Smart-skip applies when:
- * 1. All stories have fullSuiteGatePassed === true
- * 2. Execution is sequential (or defaults to sequential when not specified)
- * 3. There is at least one story metric
- */
-function shouldSkipDeferredRegression(allStoryMetrics: StoryMetrics[], isSequential: boolean | undefined): boolean {
-  // Default to sequential mode
-  const effectiveSequential = isSequential !== false;
-
-  // Must be sequential mode
-  if (!effectiveSequential) {
-    return false;
-  }
-
-  // Must have at least one story metric
-  if (allStoryMetrics.length === 0) {
-    return false;
-  }
-
-  // All stories must have fullSuiteGatePassed === true
-  return allStoryMetrics.every((m) => m.fullSuiteGatePassed === true);
-}
-
-/**
  * Handle final run completion: save metrics, log summary, update status
  */
 export async function handleRunCompletion(options: RunCompletionOptions): Promise<RunCompletionResult> {
@@ -121,7 +95,6 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
     statusWriter,
     config,
     hooksConfig,
-    isSequential,
   } = options;
 
   // Run deferred regression gate before final metrics
@@ -129,128 +102,116 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
   if (options.skipRegression) {
     // Regression phase already passed on a prior run — skip
   } else if (regressionMode === "deferred" && config.quality.commands.test) {
-    if (shouldSkipDeferredRegression(allStoryMetrics, isSequential)) {
-      logger?.info(
-        "regression",
-        "Smart-skip: skipping deferred regression (all stories passed full-suite gate in sequential mode)",
-      );
-      statusWriter.setPostRunPhase("regression", {
-        status: "passed",
-        skipped: true,
-        lastRunAt: new Date().toISOString(),
-      });
+    statusWriter.setPostRunPhase("regression", { status: "running" });
+
+    const regressionResult = await _runCompletionDeps.runDeferredRegression({
+      config,
+      prd,
+      workdir,
+      runtime: options.runtime,
+    });
+
+    const lastRunAt = new Date().toISOString();
+
+    logger?.info("regression", "Deferred regression gate completed", {
+      success: regressionResult.success,
+      failedTests: regressionResult.failedTests,
+      affectedStories: regressionResult.affectedStories,
+    });
+
+    if (regressionResult.success) {
+      statusWriter.setPostRunPhase("regression", { status: "passed", lastRunAt });
     } else {
-      statusWriter.setPostRunPhase("regression", { status: "running" });
-
-      const regressionResult = await _runCompletionDeps.runDeferredRegression({
-        config,
-        prd,
-        workdir,
-        runtime: options.runtime,
-      });
-
-      const lastRunAt = new Date().toISOString();
-
-      logger?.info("regression", "Deferred regression gate completed", {
-        success: regressionResult.success,
-        failedTests: regressionResult.failedTests,
+      statusWriter.setPostRunPhase("regression", {
+        status: "failed",
+        failedTests: regressionResult.failedTestFiles,
         affectedStories: regressionResult.affectedStories,
+        lastRunAt,
       });
 
-      if (regressionResult.success) {
-        statusWriter.setPostRunPhase("regression", { status: "passed", lastRunAt });
-      } else {
-        statusWriter.setPostRunPhase("regression", {
-          status: "failed",
-          failedTests: regressionResult.failedTestFiles,
-          affectedStories: regressionResult.affectedStories,
-          lastRunAt,
-        });
-
-        // Mark affected stories as regression-failed in-memory for current-run event counts (RL-004).
-        // Intentionally NOT saved to prd.json — rerun resume is driven by status.json via
-        // setPostRunPhase("regression", { status: "failed" }) above. On rerun, runner-completion.ts
-        // reads getPostRunStatus().regression.status from status.json and re-runs the regression
-        // phase when it is not "passed". Saving this to prd.json is unnecessary and would require
-        // prdPath to be threaded into handleRunCompletion. See PR #254 / issue #250.
-        for (const storyId of regressionResult.affectedStories) {
-          const story = prd.userStories.find((s) => s.id === storyId);
-          if (story) {
-            story.status = "regression-failed";
-          }
-        }
-        // Reflect regression gate failure in run status (RL-004)
-        statusWriter.setRunStatus("failed");
-
-        if (hooksConfig) {
-          await _runCompletionDeps.fireHook(
-            hooksConfig as import("../../hooks/runner").LoadedHooksConfig,
-            "on-final-regression-fail",
-            {
-              event: "on-final-regression-fail",
-              feature,
-              status: "failed",
-              failedTests: regressionResult.failedTests,
-              affectedStories: regressionResult.affectedStories,
-            },
-            workdir,
-          );
+      // Mark affected stories as regression-failed in-memory for current-run event counts (RL-004).
+      // Intentionally NOT saved to prd.json — rerun resume is driven by status.json via
+      // setPostRunPhase("regression", { status: "failed" }) above. On rerun, runner-completion.ts
+      // reads getPostRunStatus().regression.status from status.json and re-runs the regression
+      // phase when it is not "passed". Saving this to prd.json is unnecessary and would require
+      // prdPath to be threaded into handleRunCompletion. See PR #254 / issue #250.
+      for (const storyId of regressionResult.affectedStories) {
+        const story = prd.userStories.find((s) => s.id === storyId);
+        if (story) {
+          story.status = "regression-failed";
         }
       }
+      // Reflect regression gate failure in run status (RL-004)
+      statusWriter.setRunStatus("failed");
 
-      // Back-fill or merge storyMetrics for stories rectified by the regression gate (issue #679).
-      // Two cases:
-      //   1. Story has no existing entry (prior run-resume or earlier execution batch): inject a
-      //      synthetic "rectification" entry so cost and outcome show up in run.complete analytics.
-      //   2. Story already has an entry (normal execution loop + regression-gate rectification in
-      //      the same run): fold the rectification cost + duration into the existing entry so the
-      //      regression-gate effort isn't silently dropped.
-      const regressionStoryCosts = regressionResult.storyCosts ?? {};
-      const regressionStoryDurations = regressionResult.storyDurations ?? {};
-      const regressionStoryOutcomes = regressionResult.storyOutcomes ?? {};
-      if (Object.keys(regressionStoryCosts).length > 0) {
-        const existingIndex = new Map(allStoryMetrics.map((m, i) => [m.storyId, i]));
-        const rectCompletedAt = new Date().toISOString();
-        const defaultAgent = options.agentManager?.getDefault() ?? resolveDefaultAgent(config);
-        for (const [storyId, storyCost] of Object.entries(regressionStoryCosts)) {
-          const storyDuration = regressionStoryDurations[storyId] ?? 0;
-          // Per-story outcome; fall back to the overall regression result only when missing
-          // (e.g. older mocks emit storyCosts without storyOutcomes).
-          const storySuccess = regressionStoryOutcomes[storyId] ?? regressionResult.success;
-          const existingIdx = existingIndex.get(storyId);
-          if (existingIdx === undefined) {
-            const regrStory = prd.userStories.find((s) => s.id === storyId);
-            allStoryMetrics.push({
-              storyId,
-              complexity: regrStory?.routing?.complexity ?? "medium",
-              modelTier: "balanced",
-              modelUsed: defaultAgent,
-              attempts: 1,
-              finalTier: "balanced",
-              success: storySuccess,
-              cost: storyCost,
-              durationMs: storyDuration,
-              firstPassSuccess: false,
-              startedAt: rectCompletedAt,
-              completedAt: rectCompletedAt,
-              source: "rectification" as const,
-              rectificationCost: storyCost,
-              fullSuiteGatePassed: false,
-              runtimeCrashes: 0,
-            });
-          } else {
-            const existing = allStoryMetrics[existingIdx];
-            allStoryMetrics[existingIdx] = {
-              ...existing,
-              cost: existing.cost + storyCost,
-              durationMs: existing.durationMs + storyDuration,
-              rectificationCost: (existing.rectificationCost ?? 0) + storyCost,
-              // A story that needed regression-gate rectification was not a clean first pass.
-              firstPassSuccess: false,
-              // Preserve the normal-loop success flag unless the regression attempt actually failed.
-              success: existing.success && storySuccess,
-            };
-          }
+      if (hooksConfig) {
+        await _runCompletionDeps.fireHook(
+          hooksConfig as import("../../hooks/runner").LoadedHooksConfig,
+          "on-final-regression-fail",
+          {
+            event: "on-final-regression-fail",
+            feature,
+            status: "failed",
+            failedTests: regressionResult.failedTests,
+            affectedStories: regressionResult.affectedStories,
+          },
+          workdir,
+        );
+      }
+    }
+
+    // Back-fill or merge storyMetrics for stories rectified by the regression gate (issue #679).
+    // Two cases:
+    //   1. Story has no existing entry (prior run-resume or earlier execution batch): inject a
+    //      synthetic "rectification" entry so cost and outcome show up in run.complete analytics.
+    //   2. Story already has an entry (normal execution loop + regression-gate rectification in
+    //      the same run): fold the rectification cost + duration into the existing entry so the
+    //      regression-gate effort isn't silently dropped.
+    const regressionStoryCosts = regressionResult.storyCosts ?? {};
+    const regressionStoryDurations = regressionResult.storyDurations ?? {};
+    const regressionStoryOutcomes = regressionResult.storyOutcomes ?? {};
+    if (Object.keys(regressionStoryCosts).length > 0) {
+      const existingIndex = new Map(allStoryMetrics.map((m, i) => [m.storyId, i]));
+      const rectCompletedAt = new Date().toISOString();
+      const defaultAgent = options.agentManager?.getDefault() ?? resolveDefaultAgent(config);
+      for (const [storyId, storyCost] of Object.entries(regressionStoryCosts)) {
+        const storyDuration = regressionStoryDurations[storyId] ?? 0;
+        // Per-story outcome; fall back to the overall regression result only when missing
+        // (e.g. older mocks emit storyCosts without storyOutcomes).
+        const storySuccess = regressionStoryOutcomes[storyId] ?? regressionResult.success;
+        const existingIdx = existingIndex.get(storyId);
+        if (existingIdx === undefined) {
+          const regrStory = prd.userStories.find((s) => s.id === storyId);
+          allStoryMetrics.push({
+            storyId,
+            complexity: regrStory?.routing?.complexity ?? "medium",
+            modelTier: "balanced",
+            modelUsed: defaultAgent,
+            attempts: 1,
+            finalTier: "balanced",
+            success: storySuccess,
+            cost: storyCost,
+            durationMs: storyDuration,
+            firstPassSuccess: false,
+            startedAt: rectCompletedAt,
+            completedAt: rectCompletedAt,
+            source: "rectification" as const,
+            rectificationCost: storyCost,
+            fullSuiteGatePassed: false,
+            runtimeCrashes: 0,
+          });
+        } else {
+          const existing = allStoryMetrics[existingIdx];
+          allStoryMetrics[existingIdx] = {
+            ...existing,
+            cost: existing.cost + storyCost,
+            durationMs: existing.durationMs + storyDuration,
+            rectificationCost: (existing.rectificationCost ?? 0) + storyCost,
+            // A story that needed regression-gate rectification was not a clean first pass.
+            firstPassSuccess: false,
+            // Preserve the normal-loop success flag unless the regression attempt actually failed.
+            success: existing.success && storySuccess,
+          };
         }
       }
     }

--- a/test/unit/execution/lifecycle-completion.test.ts
+++ b/test/unit/execution/lifecycle-completion.test.ts
@@ -299,7 +299,7 @@ describe("RL-002 AC#3: run:completed payload reflects final success status", () 
 });
 
 // ---------------------------------------------------------------------------
-// handleRunCompletion - smart-skip deferred regression (RL-006)
+// handleRunCompletion - deferred regression always runs in deferred mode
 // ---------------------------------------------------------------------------
 
 let mockRunDeferredRegression: ReturnType<typeof mock>;
@@ -316,8 +316,8 @@ beforeEach(() => {
     mockRunDeferredRegression as typeof _runCompletionDeps.runDeferredRegression;
 });
 
-describe("handleRunCompletion - smart-skip deferred regression (RL-006)", () => {
-  test("skips regression when all stories have fullSuiteGatePassed=true in sequential mode", async () => {
+describe("handleRunCompletion - deferred regression is not smart-skipped", () => {
+  test("runs regression when all stories have fullSuiteGatePassed=true in sequential mode", async () => {
     const metrics = [makeStoryMetrics("US-001", true), makeStoryMetrics("US-002", true)];
     const prd = makePRD([
       { id: "US-001", status: "passed" },
@@ -331,7 +331,7 @@ describe("handleRunCompletion - smart-skip deferred regression (RL-006)", () => 
       }),
     );
 
-    expect(mockRunDeferredRegression).not.toHaveBeenCalled();
+    expect(mockRunDeferredRegression).toHaveBeenCalledTimes(1);
   });
 
   test("does NOT skip regression when at least one story has fullSuiteGatePassed=false", async () => {
@@ -412,7 +412,7 @@ describe("handleRunCompletion - smart-skip deferred regression (RL-006)", () => 
     expect(mockRunDeferredRegression).toHaveBeenCalledTimes(1);
   });
 
-  test("skips regression with a single story with fullSuiteGatePassed=true in sequential mode", async () => {
+  test("runs regression with a single story with fullSuiteGatePassed=true in sequential mode", async () => {
     const metrics = [makeStoryMetrics("US-001", true)];
     const prd = makePRD([{ id: "US-001", status: "passed" }]);
 
@@ -423,10 +423,10 @@ describe("handleRunCompletion - smart-skip deferred regression (RL-006)", () => 
       }),
     );
 
-    expect(mockRunDeferredRegression).not.toHaveBeenCalled();
+    expect(mockRunDeferredRegression).toHaveBeenCalledTimes(1);
   });
 
-  test("skip applies when isSequential is not provided (defaults to sequential)", async () => {
+  test("still runs regression when isSequential is not provided", async () => {
     const metrics = [makeStoryMetrics("US-001", true), makeStoryMetrics("US-002", true)];
     const prd = makePRD([
       { id: "US-001", status: "passed" },
@@ -440,10 +440,10 @@ describe("handleRunCompletion - smart-skip deferred regression (RL-006)", () => 
 
     await handleRunCompletion(opts);
 
-    expect(mockRunDeferredRegression).not.toHaveBeenCalled();
+    expect(mockRunDeferredRegression).toHaveBeenCalledTimes(1);
   });
 
-  test("result has correct shape even when regression is skipped", async () => {
+  test("result has correct shape when regression runs despite prior full-suite-gate passes", async () => {
     const metrics = [makeStoryMetrics("US-001", true)];
     const prd = makePRD([{ id: "US-001", status: "passed" }]);
 

--- a/test/unit/execution/lifecycle/run-completion-postrun.test.ts
+++ b/test/unit/execution/lifecycle/run-completion-postrun.test.ts
@@ -7,7 +7,7 @@
  * AC4: calls setPostRunPhase("regression", { status: "running" }) before runDeferredRegression()
  * AC5: calls setPostRunPhase("regression", { status: "passed", lastRunAt }) on success
  * AC6: calls setPostRunPhase("regression", { status: "failed", affectedStories, lastRunAt }) on failure
- * AC7: calls setPostRunPhase("regression", { status: "passed", skipped: true, lastRunAt }) on smart-skip
+ * AC7: deferred regression is not smart-skipped when stories previously passed full-suite gates
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -409,11 +409,11 @@ describe("handleRunCompletion - AC6: sets regression failed on failure", () => {
 });
 
 // ---------------------------------------------------------------------------
-// AC7: setPostRunPhase("regression", { status: "passed", skipped: true, lastRunAt }) on smart-skip
+// AC7: deferred regression still runs after acceptance/hardening changes
 // ---------------------------------------------------------------------------
 
-describe("handleRunCompletion - AC7: sets regression passed+skipped on smart-skip", () => {
-  test("calls setPostRunPhase('regression', { status: 'passed', skipped: true, lastRunAt }) when smart-skipped", async () => {
+describe("handleRunCompletion - AC7: deferred regression is not smart-skipped", () => {
+  test("still calls runDeferredRegression when all stories report fullSuiteGatePassed=true", async () => {
     const regressionCalls: Array<Record<string, unknown>> = [];
 
     const statusWriter = makeStatusWriter();
@@ -438,15 +438,9 @@ describe("handleRunCompletion - AC7: sets regression passed+skipped on smart-ski
       }),
     );
 
-    // runDeferredRegression should NOT have been called (smart-skip)
-    expect(_runCompletionDeps.runDeferredRegression).not.toHaveBeenCalled();
-
-    // But setPostRunPhase should have been called with skipped=true
-    const skippedCall = regressionCalls.find((u) => u.skipped === true);
-    expect(skippedCall).toBeDefined();
-    expect(skippedCall?.status).toBe("passed");
-    expect(typeof skippedCall?.lastRunAt).toBe("string");
-    expect(new Date(skippedCall?.lastRunAt as string).toISOString()).toBe(skippedCall?.lastRunAt);
+    expect(_runCompletionDeps.runDeferredRegression).toHaveBeenCalledTimes(1);
+    expect(regressionCalls.some((u) => u.status === "running")).toBe(true);
+    expect(regressionCalls.some((u) => u.skipped === true)).toBe(false);
   });
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -471,7 +465,7 @@ describe("handleRunCompletion - AC7: sets regression passed+skipped on smart-ski
     expect(capturedArgs?.agentManager).toBeUndefined();
   });
 
-  test("smart-skip: setPostRunPhase is called even though runDeferredRegression is not", async () => {
+  test("setPostRunPhase tracks running then terminal status when all stories previously passed full-suite gates", async () => {
     const setPostRunPhaseCalls: Array<[string, Record<string, unknown>]> = [];
 
     const statusWriter = makeStatusWriter();
@@ -493,9 +487,10 @@ describe("handleRunCompletion - AC7: sets regression passed+skipped on smart-ski
 
     const regressionCalls = setPostRunPhaseCalls.filter(([p]) => p === "regression");
     expect(regressionCalls.length).toBeGreaterThan(0);
+    expect(_runCompletionDeps.runDeferredRegression).toHaveBeenCalledTimes(1);
   });
 
-  test("smart-skip: setPostRunPhase skipped call is separate from running call", async () => {
+  test("records running before passed instead of emitting a skipped status", async () => {
     const callOrder: string[] = [];
 
     const statusWriter = makeStatusWriter();
@@ -517,7 +512,8 @@ describe("handleRunCompletion - AC7: sets regression passed+skipped on smart-ski
       }),
     );
 
-    // Should have at least: running, then skipped-passed
-    expect(callOrder).toContain("skipped-passed");
+    expect(callOrder.indexOf("running")).toBeGreaterThanOrEqual(0);
+    expect(callOrder.indexOf("passed")).toBeGreaterThan(callOrder.indexOf("running"));
+    expect(callOrder).not.toContain("skipped-passed");
   });
 });


### PR DESCRIPTION
## What

Remove the deferred-regression smart-skip in run completion so the full-suite gate still runs after acceptance and acceptance hardening.

## Why

Acceptance and acceptance hardening can still modify source after per-story full-suite gates have passed. Skipping the deferred regression gate can miss those cross-story regressions.

Closes #

## How

- Delete the completion-time smart-skip check based on `fullSuiteGatePassed` metrics.
- Always enter the deferred regression gate in deferred mode when a test command is configured.
- Update completion tests to assert deferred regression still runs even when prior story metrics report `fullSuiteGatePassed=true`.

## Testing

- [x] Tests added/updated
- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

- Focused tests run:
- `bun test test/unit/execution/lifecycle/run-completion-postrun.test.ts`
- `bun test test/unit/execution/lifecycle-completion.test.ts`
- `bun test test/unit/verification/rectification-loop.test.ts`
- The ACP terminal-session rectification fix is already present in this branch history via commit `d5f9793fe8a37fe84969e3acb1b7a353bf6b51fe`.
