### PR TITLE
feat(prompts): implementer/test-writer prompt overhaul + behavioral guardrails section

### DIFF
--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -483,6 +483,7 @@ export interface PromptsConfig {
   overrides?: Partial<
     Record<"no-test" | "test-writer" | "implementer" | "verifier" | "single-session" | "tdd-simple" | "batch", string>
   >;
+  behavioralGuardrails?: "off" | "lite" | "strict";
 }
 
 /** Hermetic test enforcement configuration (ENH-010) */

--- a/src/config/schemas-infra.ts
+++ b/src/config/schemas-infra.ts
@@ -209,6 +209,7 @@ export const PromptsConfigSchema = z.object({
       z.string().min(1, "Override path must be non-empty"),
     )
     .optional(),
+  behavioralGuardrails: z.enum(["off", "lite", "strict"]).default("lite"),
 });
 
 export const ProjectProfileSchema = z.object({

--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -21,7 +21,13 @@ import { formatFailureSummary } from "@/test-runners";
 import type { TestFailure } from "@/verification";
 import { priorFailuresSection, universalConstitutionSection, universalContextSection } from "../core";
 import type { FailureRecord, ReviewFinding } from "../core";
-import { buildConventionsSection, buildIsolationSection, buildStorySection } from "../sections";
+import {
+  buildBehavioralGuardrailsSection,
+  buildConventionsSection,
+  buildIsolationSection,
+  buildStorySection,
+} from "../sections";
+import type { GuardrailLevel } from "../sections";
 import {
   CONTRADICTION_ESCAPE_HATCH,
   adversarialRectification,
@@ -179,7 +185,11 @@ export class RectifierPromptBuilder {
    * the review findings need to be delivered. Avoids re-sending story title, ACs,
    * and other context that is already in the conversation history.
    */
-  static firstAttemptDelta(failedChecks: ReviewCheckResult[], maxAttempts: number): string {
+  static firstAttemptDelta(
+    failedChecks: ReviewCheckResult[],
+    maxAttempts: number,
+    guardrailLevel?: GuardrailLevel,
+  ): string {
     const parts: string[] = [];
     const attemptWord = maxAttempts === 1 ? "1 attempt" : `${maxAttempts} attempts`;
 
@@ -193,6 +203,11 @@ export class RectifierPromptBuilder {
       "\nFix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior — see the three narrow exceptions appended below. Commit your changes when all checks pass.",
     );
     parts.push(CONTRADICTION_ESCAPE_HATCH);
+
+    const guardrails = buildBehavioralGuardrailsSection("implementer", guardrailLevel ?? "lite");
+    if (guardrails) {
+      parts.push(`\n\n${guardrails}`);
+    }
 
     return parts.join("\n");
   }
@@ -209,6 +224,7 @@ export class RectifierPromptBuilder {
     attempt: number,
     rethinkAtAttempt: number,
     urgencyAtAttempt: number,
+    guardrailLevel?: GuardrailLevel,
   ): string {
     const parts: string[] = [];
 
@@ -228,6 +244,11 @@ export class RectifierPromptBuilder {
     }
 
     parts.push(CONTRADICTION_ESCAPE_HATCH);
+
+    const guardrails = buildBehavioralGuardrailsSection("implementer", guardrailLevel ?? "lite");
+    if (guardrails) {
+      parts.push(`\n\n${guardrails}`);
+    }
 
     return parts.join("\n");
   }
@@ -732,6 +753,7 @@ Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
     constitution?: string;
     context?: string;
     promptPrefix?: string;
+    guardrailLevel?: GuardrailLevel;
   }): string {
     const parts: string[] = [];
 
@@ -777,6 +799,13 @@ Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
     // 7. Isolation (optional)
     if (opts.isolation) {
       parts.push(buildIsolationSection("implementer", opts.isolation, undefined));
+      parts.push("\n\n");
+    }
+
+    // 7.5. Behavioral Guardrails (gated by config, not injected for review-finding rectifications)
+    const guardrails = buildBehavioralGuardrailsSection("implementer", opts.guardrailLevel ?? "lite");
+    if (guardrails) {
+      parts.push(guardrails);
       parts.push("\n\n");
     }
 

--- a/src/prompts/builders/tdd-builder.ts
+++ b/src/prompts/builders/tdd-builder.ts
@@ -33,6 +33,7 @@ import type { AcceptanceEntry } from "../sections";
 import {
   buildAcceptanceSection,
   buildBatchStorySection,
+  buildBehavioralGuardrailsSection,
   buildConventionsSection,
   buildHermeticSection,
   buildIsolationSection,
@@ -43,6 +44,7 @@ import {
   buildTddLanguageSection,
   buildVerdictSection,
 } from "../sections";
+import type { GuardrailRole } from "../sections";
 
 export class TddPromptBuilder {
   private readonly role: PromptRole;
@@ -227,6 +229,18 @@ export class TddPromptBuilder {
       if (hermeticSection) acc.add(this.s("hermetic", hermeticSection));
     }
 
+    // (6.7) Behavioral Guardrails
+    const guardrailLevel = this.loaderConfig_?.prompts?.behavioralGuardrails ?? "lite";
+    const guardrailVariant = this.options.variant as "standard" | "lite" | undefined;
+    const guardrailIsolation = this.options.isolation as "strict" | "lite" | undefined;
+    const guardrails = buildBehavioralGuardrailsSection(
+      this.role as GuardrailRole,
+      guardrailLevel,
+      guardrailVariant,
+      guardrailIsolation,
+    );
+    if (guardrails) acc.add(this.s("guardrails", guardrails));
+
     if (this.role !== "verifier") {
       const selfVerify = buildSelfVerificationSection(this.role, this.selfVerification_);
       if (selfVerify) acc.add(this.s("self-verification", selfVerify));
@@ -301,6 +315,13 @@ export class TddPromptBuilder {
 
     const variant = this.options.variant as "standard" | "lite" | undefined;
     const isolation = this.options.isolation as "strict" | "lite" | undefined;
-    return buildRoleTaskSection(this.role, variant, this.testCommand_, isolation, this.noTestJustification_);
+    return buildRoleTaskSection(
+      this.role,
+      variant,
+      this.testCommand_,
+      isolation,
+      this.noTestJustification_,
+      this.story_?.id,
+    );
   }
 }

--- a/src/prompts/sections/behavioral-guardrails.ts
+++ b/src/prompts/sections/behavioral-guardrails.ts
@@ -1,0 +1,76 @@
+export type GuardrailLevel = "off" | "lite" | "strict";
+
+export type GuardrailRole =
+  | "no-test"
+  | "implementer"
+  | "test-writer"
+  | "verifier"
+  | "single-session"
+  | "tdd-simple"
+  | "batch";
+
+export function buildBehavioralGuardrailsSection(
+  role: GuardrailRole,
+  level: GuardrailLevel,
+  // Reserved for Phase 2: per-variant and per-isolation rule differentiation.
+  // Currently unused — all variants/isolation modes produce identical output per role.
+  _variant?: "standard" | "lite",
+  _isolation?: "strict" | "lite",
+): string | null {
+  if (level === "off" || role === "verifier" || role === "no-test") {
+    return null;
+  }
+
+  if (role === "test-writer") {
+    return buildTestWriterGuardrails(level);
+  }
+
+  return buildImplementerGuardrails(level);
+}
+
+function buildTestWriterGuardrails(level: GuardrailLevel): string {
+  const lines = [
+    "# Behavioral Guardrails",
+    "",
+    "- Simplicity: write tests that cover the acceptance criteria. No tests for behaviors the story does not require.",
+    "- Surgical: do not modify source files beyond the stub allowance in the Isolation Rules above. Do not add tests for unrelated existing code.",
+  ];
+  if (level === "strict") {
+    lines.push(
+      "- State Assumptions: when the story is ambiguous, pick an interpretation, proceed, and document the choice in the commit body under `Assumptions:`. Do not invent requirements; do not silently choose when the story is genuinely under-specified — note it.",
+    );
+  }
+  return lines.join("\n");
+}
+
+function buildImplementerGuardrails(level: GuardrailLevel): string {
+  if (level === "lite") {
+    return `# Behavioral Guardrails
+
+- Simplicity: write the minimum code that makes the tests pass. No speculative abstractions, configurability, or error handling for scenarios that cannot occur.
+- Surgical: every changed line must trace to the story. Do not refactor adjacent code, reformat unrelated files, or rename symbols beyond what the story requires.
+- Anti-cheat: do not weaken assertions, catch-and-swallow exceptions in tests, or add tautological assertions to coerce a green run.
+- Orphans: remove imports/variables/helpers that YOUR changes made unused. Do not delete pre-existing dead code.
+- Commit: include the story ID when known — \`feat(<story-id>): <description>\`.`;
+  }
+
+  return `# Behavioral Guardrails
+
+## Simplicity
+Write the minimum code that makes the tests pass. Every line you add is a line someone else must read, understand, and maintain. Do not add speculative abstractions, configurability, or error handling for scenarios that cannot occur given the story's constraints. If it isn't required by a test or acceptance criterion, don't write it.
+
+## Surgical
+Every changed line must trace directly to a story requirement or a failing test. Do not refactor adjacent code, reformat unrelated files, or rename symbols beyond what the story requires. Reviewers will flag any change that cannot be linked to a specific requirement.
+
+## Anti-cheat
+Do not weaken assertions, catch-and-swallow exceptions in tests, or add tautological assertions to coerce a green run. A green test suite achieved by weakening tests is not a passing implementation — it is a failing one with hidden evidence.
+
+## Orphans
+Remove imports, variables, and helpers that YOUR changes made unused. Do not delete pre-existing dead code that was already there before your changes.
+
+## Commit
+Include the story ID when known — \`feat(<story-id>): <description>\`.
+
+## State Assumptions
+When the story is ambiguous, pick an interpretation, proceed, and document the choice in the commit body under \`Assumptions:\`. Do not invent requirements; do not silently choose when the story is genuinely under-specified — note it.`;
+}

--- a/src/prompts/sections/index.ts
+++ b/src/prompts/sections/index.ts
@@ -14,3 +14,5 @@ export { buildTddLanguageSection } from "./tdd-conventions";
 export { buildAcceptanceSection } from "./acceptance";
 export type { AcceptanceEntry } from "./acceptance";
 export { buildSelfVerificationSection } from "./self-verification";
+export { buildBehavioralGuardrailsSection } from "./behavioral-guardrails";
+export type { GuardrailLevel, GuardrailRole } from "./behavioral-guardrails";

--- a/src/prompts/sections/role-task.ts
+++ b/src/prompts/sections/role-task.ts
@@ -1,12 +1,14 @@
 /**
  * Role-Task Section
  *
- * Generates role definition for all 5 roles in nax prompt orchestration:
+ * Generates role definition for all roles in nax prompt orchestration:
  * - implementer: Make failing tests pass (standard/lite variants)
- * - test-writer: Write tests first (RED phase)
- * - verifier: Review and verify implementation
+ * - test-writer: Write tests first (RED phase) (strict/lite isolation)
+ * - verifier: Review and verify TDD handoff integrity
  * - single-session: Write tests AND implement in one session
- * - tdd-simple: Write failing tests FIRST, then implement in one session
+ * - tdd-simple: RED → GREEN → REFACTOR in one session
+ * - batch: Per-story TDD loop (RED → GREEN, one commit per story)
+ * - no-test: Implement without tests (config/docs changes)
  *
  * Backwards compatible: also accepts old API (variant only)
  * - buildRoleTaskSection("standard") → implementer, standard
@@ -30,10 +32,11 @@ export function buildRoleTaskSection(
   testCommand?: string,
   isolation?: "strict" | "lite",
   noTestJustification?: string,
+  storyId?: string,
 ): string {
   // Old API support: buildRoleTaskSection("standard") or buildRoleTaskSection("lite")
   if ((roleOrVariant === "standard" || roleOrVariant === "lite") && variant === undefined) {
-    return buildRoleTaskSection("implementer", roleOrVariant, testCommand, isolation);
+    return buildRoleTaskSection("implementer", roleOrVariant, testCommand, isolation, noTestJustification, storyId);
   }
 
   const role = roleOrVariant as
@@ -46,6 +49,7 @@ export function buildRoleTaskSection(
     | "batch";
   const testCmd = testCommand ?? "";
   const frameworkHint = buildTestFrameworkHint(testCmd);
+  const commitMsg = storyId ? `feat(${storyId}): <description>` : "feat: <description>";
 
   if (role === "no-test") {
     const justification = noTestJustification ?? "No behavioral changes — tests not required";
@@ -57,7 +61,7 @@ Instructions:
 - Implement the change as described in the story
 - Do NOT create or modify test files
 - Justification for no tests: ${justification}
-- When done, stage and commit ALL changed files with: git commit -m 'feat: <description>'
+- When done, stage and commit ALL changed files with: git commit -m '${commitMsg}'
 - Goal: change implemented, no test files created or modified, all changes committed`;
   }
 
@@ -66,66 +70,82 @@ Instructions:
     if (v === "standard") {
       return `# Role: Implementer
 
-Your task: make failing tests pass.
+Your task: make the failing tests pass by writing real source code.
 
-Instructions:
-- Implement source code in src/ to make tests pass
-- Do NOT modify test files — three narrow lint/contract/sibling exceptions exist; see the escape valve section in the rectification prompt if you encounter one
-- Run tests frequently to track progress
-- When all tests are green, stage and commit ALL changed files with: git commit -m 'feat: <description>'
-- Goal: all tests green, all changes committed`;
+Workflow:
+1. Read every failing test in scope. The tests are the contract — understand what each one asserts before editing source.
+2. Run the scoped test files once to establish the baseline (which fail, which pass, and why).
+3. Implement source code in the package's source location (the project context names it).
+4. After each meaningful change, re-run only the scoped test files — never the full suite.
+5. When all scoped tests pass, stage and commit ALL changed files: \`git commit -m '${commitMsg}'\`.
+
+Rules:
+- Do NOT modify test files. Three narrow exceptions: (a) a lint-only fix to a test, (b) a contract drift where the test imports a removed/renamed symbol, (c) a sibling test file rename forced by your source change. Name which exception applies in the commit body before editing any test file.
+- Goal: every acceptance criterion covered by at least one passing test; all changes committed.`;
     }
 
     // lite variant — session 2 of three-session-tdd-lite
     return `# Role: Implementer (Lite)
 
-Your task: Make the failing tests pass AND add any missing test coverage.
+Your task: make the failing tests pass AND fill any test coverage gaps an earlier session left.
 
-Context: A test-writer session has already created test files with failing tests and possibly minimal stubs in src/. Your job is to make those tests pass by implementing the real logic.
+Context: A test-writer session has already created tests and may have added minimal stubs in the package's source location. Your job is to (a) replace stubs with real implementations and (b) confirm every AC has test coverage before committing.
 
-Instructions:
-- Start by running the existing tests to see what's failing
-- Implement source code in src/ to make all failing tests pass
-- You MAY add additional tests if you find gaps in coverage
-- Replace any stubs with real implementations
+Workflow:
+1. Run the existing scoped tests to see which fail and why (assertion failure vs import error).
+2. Read each failing test. Note which ACs they cover and which they DON'T.
+3. Replace stubs with real implementations. A stub is one of: a type-only declaration, a function returning a placeholder/throwing "not implemented", or a const placeholder.
+4. If any AC has no test, add one before implementing — do not implement uncovered behavior.
+5. Re-run only the scoped test files after each meaningful change.
+6. When all scoped tests pass, stage and commit ALL changed files: \`git commit -m '${commitMsg}'\`.
+
+Rules:
+- Three test-modification exceptions apply (lint-only fix, contract drift, sibling rename). Name the exception in the commit body before editing any test the test-writer wrote.
 - ${frameworkHint}
-- When all tests are green, stage and commit ALL changed files with: git commit -m 'feat: <description>'
-- Goal: all tests green, all criteria met, all changes committed`;
+- Goal: every AC has at least one passing test; all stubs replaced with real logic; all changes committed.`;
   }
 
   if (role === "test-writer") {
     if (isolation === "lite") {
       return `# Role: Test-Writer (Lite)
 
-Your task: Write failing tests for the feature. You may create minimal stubs to support imports.
+Your task: write failing tests AND minimal stubs that let the tests compile.
 
 Context: You are session 1 of a multi-session workflow. An implementer will follow to make your tests pass.
 
-Instructions:
-- Create test files in test/ directory that cover all acceptance criteria
-- Tests must fail initially (RED phase) — do NOT implement real logic
+Workflow:
+1. Re-read the acceptance criteria above.
+2. Create test files in the location the project uses for tests.
+3. Create stubs in the package's source location so the tests can import and compile. A stub is one of: a type/interface declaration, a function returning a placeholder/throwing "not implemented" (no more than 3 lines of body), or a const placeholder. If a stub body needs real logic, you have crossed into implementer territory — stop.
+4. For each AC: at least one success-path test and one boundary/failure-path test.
+5. Run the new test files. Confirm tests compile (stubs work) AND fail with ASSERTION failures — NOT import errors or compile errors. A test that errors before reaching its assertion does not prove the behavior is missing.
+
+Rules:
+- Stubs are NOT implementations. The implementer in the next session writes real logic.
+- Each test name describes ONE behavior. Use AC IDs in test names when available (e.g. \`it('AC4: throws Division by zero when b === 0')\`).
+- Assert on observable outputs.
 - ${frameworkHint}
-- You MAY read src/ files and import types/interfaces from them
-- You MAY create minimal stubs in src/ (type definitions, empty functions) so tests can import and compile
-- Write clear test names that document expected behavior
-- Focus on behavior, not implementation details
-- Goal: comprehensive failing test suite with compilable imports, ready for implementation`;
+- Goal: comprehensive failing test suite that compiles, with stubs ≤3 lines each, ready for implementation.`;
     }
 
     return `# Role: Test-Writer
 
-Your task: Write comprehensive failing tests for the feature.
+Your task: write failing tests that pin down every acceptance criterion. An implementer will follow.
 
-Context: You are session 1 of a multi-session workflow. An implementer will follow to make your tests pass.
+Context: You are session 1 of a multi-session workflow.
 
-Instructions:
-- Create test files in test/ directory that cover all acceptance criteria
-- Tests must fail initially (RED phase) — the feature is not yet implemented
-- Do NOT create or modify any files in src/
+Workflow:
+1. Re-read the acceptance criteria above.
+2. Create test files in the location the project uses for tests (project context names it).
+3. For each AC: write at least one test for the success path AND at least one for a boundary/failure path (zero, empty, negative, missing, throws). ACs worded as "throws X" require a test asserting the throw.
+4. Run the new test files. Confirm every test fails with an ASSERTION failure — NOT an import error, compile error, or runtime crash before assertion. A test that errors before reaching its assertion does not prove the behavior is missing.
+
+Rules:
+- Do NOT create or modify any source files. Read source for types/interfaces only.
+- Each test name describes ONE behavior; each test asserts ONE behavior. When the AC has a number or ID, prefix the test name (e.g. \`it('AC4: throws Division by zero when b === 0')\`).
+- Assert on observable outputs (return values, thrown errors, file contents, log output, boundary state). Do not assert on private helpers, internal call counts, or implementation-level mocks unless the AC requires it.
 - ${frameworkHint}
-- Write clear test names that document expected behavior
-- Focus on behavior, not implementation details
-- Goal: comprehensive failing test suite ready for implementation`;
+- Goal: every AC has at least one failing test that fails at assertion time and clearly documents what the implementer must build.`;
   }
 
   if (role === "verifier") {
@@ -148,48 +168,62 @@ Instructions:
   if (role === "single-session") {
     return `# Role: Single-Session
 
-Your task: Write tests AND implement the feature in a single focused session.
+Your task: write tests AND implement the feature in one session.
 
-Instructions:
-- Phase 1: Write comprehensive tests (test/ directory)
-- Phase 2: Implement to make all tests pass (src/ directory)
+Workflow:
+1. Read the acceptance criteria. For each AC, plan one success-path test and one boundary/failure test.
+2. Create test files in the location the project uses for tests. Cover every AC.
+3. Run the tests to confirm they fail with ASSERTION failures — NOT import errors or compile errors. A test that errors before reaching its assertion does not prove the behavior is missing.
+4. Implement source code in the package's source location to make the tests pass.
+5. After each meaningful change, re-run only the scoped test files — never the full suite.
+6. When all scoped tests pass, stage and commit ALL changed files: \`git commit -m '${commitMsg}'\`.
+
+Rules:
+- Each test name describes ONE behavior; use AC IDs when available.
+- Assert on observable outputs.
 - ${frameworkHint}
-- Run tests frequently throughout implementation
-- When all tests are green, stage and commit ALL changed files with: git commit -m 'feat: <description>'
-- Goal: all tests passing, all changes committed, full story complete`;
+- Goal: every AC has at least one passing test; all changes committed.`;
   }
 
   if (role === "batch") {
     const verifyCmdLine = testCmd
-      ? `  - Verify all tests pass: ${testCmd}`
-      : "  - Verify all tests pass using your project's test command";
+      ? `  - Re-run only the scoped test files after each meaningful change: ${testCmd}`
+      : "  - Re-run only the scoped test files after each meaningful change";
     return `# Role: Batch Implementer
 
-Your task: Implement each story in order using TDD — write tests first, then implement, then verify.
+Your task: implement each story in order using TDD — write tests first, then implement, then commit per story.
 
-Instructions:
-- Process each story in order (Story 1, Story 2, …)
-- For each story:
-  - Write failing tests FIRST covering the acceptance criteria
-  - Run tests to confirm they fail (RED phase)
-  - Implement the minimum code to make tests pass (GREEN phase)
-${verifyCmdLine}
-  - Commit the story with its story ID in the commit message: git commit -m 'feat(<story-id>): <description>'
+Per-story workflow (RED → GREEN):
+1. RED — write failing tests in the location the project uses for tests covering the story's ACs (success + boundary).
+2. RED — run the new test files. Confirm assertion failures — NOT import errors or compile errors. A test that errors before reaching its assertion does not prove the behavior is missing.
+3. GREEN — implement source code in the package's source location.
+4. GREEN — re-run only the scoped test files after each meaningful change.
+5. Commit the story with its ID: \`git commit -m 'feat(<story-id>): <description>'\`.
+
+Rules:
+- One commit per story — never bundle stories.
+- Process stories in order (Story 1, Story 2, …).
+- Each test name describes ONE behavior; use AC IDs when available.
 - ${frameworkHint}
-- Do NOT commit multiple stories together — each story gets its own commit
-- Goal: all stories implemented, all tests passing, each story committed with its story ID`;
+${verifyCmdLine}
+- Goal: every story implemented with passing tests; one commit per story tagged with the story ID.`;
   }
 
-  // tdd-simple role — test-driven development in one session
+  // tdd-simple role — RED → GREEN → REFACTOR
   return `# Role: TDD-Simple
 
-Your task: Write failing tests FIRST, then implement to make them pass.
+Your task: write failing tests FIRST, then implement in one session.
 
-Instructions:
-- RED phase: Write failing tests FIRST for the acceptance criteria
-- RED phase: Run the tests to confirm they fail
-- GREEN phase: Implement the minimum code to make tests pass
-- REFACTOR phase: Refactor while keeping tests green
-- When all tests are green, stage and commit ALL changed files with: git commit -m 'feat: <description>'
-- Goal: all tests passing, feature complete, all changes committed`;
+Workflow (RED → GREEN → REFACTOR):
+1. RED — write failing tests in the location the project uses for tests covering every AC (success + boundary).
+2. RED — run the tests. Confirm they fail with ASSERTION failures — NOT import errors or compile errors. A test that errors before reaching its assertion does not prove the behavior is missing.
+3. GREEN — implement minimum source code in the package's source location to make the tests pass.
+4. GREEN — re-run only the scoped test files after each meaningful change.
+5. REFACTOR — clean up while keeping tests green. No new behavior; no expanded scope.
+6. Stage and commit ALL changed files: \`git commit -m '${commitMsg}'\`.
+
+Rules:
+- Each test name describes ONE behavior; use AC IDs when available.
+- ${frameworkHint}
+- Goal: every AC covered by passing tests; refactor complete; all changes committed.`;
 }

--- a/test/unit/pipeline/stages/prompt-tdd-simple.test.ts
+++ b/test/unit/pipeline/stages/prompt-tdd-simple.test.ts
@@ -131,19 +131,19 @@ describe("promptStage.execute() — tdd-simple strategy", () => {
   test("prompt contains RED phase instructions", async () => {
     const ctx = makeCtx("tdd-simple");
     await promptStage.execute(ctx);
-    expect(ctx.prompt).toContain("RED phase");
+    expect(ctx.prompt).toMatch(/RED\s*[—-]/);
   });
 
   test("prompt contains GREEN phase instructions", async () => {
     const ctx = makeCtx("tdd-simple");
     await promptStage.execute(ctx);
-    expect(ctx.prompt).toContain("GREEN phase");
+    expect(ctx.prompt).toMatch(/GREEN\s*[—-]/);
   });
 
   test("prompt contains REFACTOR phase instructions", async () => {
     const ctx = makeCtx("tdd-simple");
     await promptStage.execute(ctx);
-    expect(ctx.prompt).toContain("REFACTOR phase");
+    expect(ctx.prompt).toMatch(/REFACTOR\s*[—-]/);
   });
 
   test("prompt contains 'Write failing tests FIRST' instruction", async () => {
@@ -200,7 +200,7 @@ describe("promptStage.execute() — test-after strategy (unified with tdd-simple
   test("test-after prompt contains RED phase instructions (unified with tdd-simple)", async () => {
     const ctx = makeCtx("test-after");
     await promptStage.execute(ctx);
-    expect(ctx.prompt).toContain("RED phase");
+    expect(ctx.prompt).toMatch(/RED\s*[—-]/);
   });
 });
 

--- a/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
@@ -32,6 +32,14 @@ at test/unit/rate-limiter.test.ts:34
 
 \`bun test test/unit/\`
 
+# Behavioral Guardrails
+
+- Simplicity: write the minimum code that makes the tests pass. No speculative abstractions, configurability, or error handling for scenarios that cannot occur.
+- Surgical: every changed line must trace to the story. Do not refactor adjacent code, reformat unrelated files, or rename symbols beyond what the story requires.
+- Anti-cheat: do not weaken assertions, catch-and-swallow exceptions in tests, or add tautological assertions to coerce a green run.
+- Orphans: remove imports/variables/helpers that YOUR changes made unused. Do not delete pre-existing dead code.
+- Commit: include the story ID when known — \`feat(<story-id>): <description>\`.
+
 # Conventions
 
 Follow existing code patterns and conventions. Write idiomatic, maintainable code.
@@ -130,6 +138,14 @@ at test/unit/rate-limiter.test.ts:34
 isolation scope: Implement source code in src/ to make tests pass. Do not modify test files. Run tests frequently to track progress.
 
 When running tests, run ONLY test files related to your changes (scope each run to the files you changed). NEVER run the full test suite without a filter — full suite output will flood your context window and cause failures.
+
+# Behavioral Guardrails
+
+- Simplicity: write the minimum code that makes the tests pass. No speculative abstractions, configurability, or error handling for scenarios that cannot occur.
+- Surgical: every changed line must trace to the story. Do not refactor adjacent code, reformat unrelated files, or rename symbols beyond what the story requires.
+- Anti-cheat: do not weaken assertions, catch-and-swallow exceptions in tests, or add tautological assertions to coerce a green run.
+- Orphans: remove imports/variables/helpers that YOUR changes made unused. Do not delete pre-existing dead code.
+- Commit: include the story ID when known — \`feat(<story-id>): <description>\`.
 
 # Conventions
 
@@ -259,7 +275,16 @@ REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
 Rules:
 - Do NOT make any edits yourself; the test-writer will fulfill.
 - Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file."
+- FILES must list real test files. Each path must exist and be a test file.
+
+
+# Behavioral Guardrails
+
+- Simplicity: write the minimum code that makes the tests pass. No speculative abstractions, configurability, or error handling for scenarios that cannot occur.
+- Surgical: every changed line must trace to the story. Do not refactor adjacent code, reformat unrelated files, or rename symbols beyond what the story requires.
+- Anti-cheat: do not weaken assertions, catch-and-swallow exceptions in tests, or add tautological assertions to coerce a green run.
+- Orphans: remove imports/variables/helpers that YOUR changes made unused. Do not delete pre-existing dead code.
+- Commit: include the story ID when known — \`feat(<story-id>): <description>\`."
 `;
 
 exports[`RectifierPromptBuilder.firstAttemptDelta two-categories: renders in fixed priority order, not input order 1`] = `
@@ -363,7 +388,16 @@ REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
 Rules:
 - Do NOT make any edits yourself; the test-writer will fulfill.
 - Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file."
+- FILES must list real test files. Each path must exist and be a test file.
+
+
+# Behavioral Guardrails
+
+- Simplicity: write the minimum code that makes the tests pass. No speculative abstractions, configurability, or error handling for scenarios that cannot occur.
+- Surgical: every changed line must trace to the story. Do not refactor adjacent code, reformat unrelated files, or rename symbols beyond what the story requires.
+- Anti-cheat: do not weaken assertions, catch-and-swallow exceptions in tests, or add tautological assertions to coerce a green run.
+- Orphans: remove imports/variables/helpers that YOUR changes made unused. Do not delete pre-existing dead code.
+- Commit: include the story ID when known — \`feat(<story-id>): <description>\`."
 `;
 
 exports[`RectifierPromptBuilder.firstAttemptDelta all-categories: renders all five buckets with expected grouping 1`] = `
@@ -507,7 +541,16 @@ REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
 Rules:
 - Do NOT make any edits yourself; the test-writer will fulfill.
 - Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file."
+- FILES must list real test files. Each path must exist and be a test file.
+
+
+# Behavioral Guardrails
+
+- Simplicity: write the minimum code that makes the tests pass. No speculative abstractions, configurability, or error handling for scenarios that cannot occur.
+- Surgical: every changed line must trace to the story. Do not refactor adjacent code, reformat unrelated files, or rename symbols beyond what the story requires.
+- Anti-cheat: do not weaken assertions, catch-and-swallow exceptions in tests, or add tautological assertions to coerce a green run.
+- Orphans: remove imports/variables/helpers that YOUR changes made unused. Do not delete pre-existing dead code.
+- Commit: include the story ID when known — \`feat(<story-id>): <description>\`."
 `;
 
 exports[`RectifierPromptBuilder.continuation single-category: renders only the matching priority bucket 1`] = `
@@ -599,7 +642,16 @@ REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
 Rules:
 - Do NOT make any edits yourself; the test-writer will fulfill.
 - Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file."
+- FILES must list real test files. Each path must exist and be a test file.
+
+
+# Behavioral Guardrails
+
+- Simplicity: write the minimum code that makes the tests pass. No speculative abstractions, configurability, or error handling for scenarios that cannot occur.
+- Surgical: every changed line must trace to the story. Do not refactor adjacent code, reformat unrelated files, or rename symbols beyond what the story requires.
+- Anti-cheat: do not weaken assertions, catch-and-swallow exceptions in tests, or add tautological assertions to coerce a green run.
+- Orphans: remove imports/variables/helpers that YOUR changes made unused. Do not delete pre-existing dead code.
+- Commit: include the story ID when known — \`feat(<story-id>): <description>\`."
 `;
 
 exports[`RectifierPromptBuilder.continuation two-categories: renders in fixed priority order, not input order 1`] = `
@@ -701,7 +753,16 @@ REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
 Rules:
 - Do NOT make any edits yourself; the test-writer will fulfill.
 - Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file."
+- FILES must list real test files. Each path must exist and be a test file.
+
+
+# Behavioral Guardrails
+
+- Simplicity: write the minimum code that makes the tests pass. No speculative abstractions, configurability, or error handling for scenarios that cannot occur.
+- Surgical: every changed line must trace to the story. Do not refactor adjacent code, reformat unrelated files, or rename symbols beyond what the story requires.
+- Anti-cheat: do not weaken assertions, catch-and-swallow exceptions in tests, or add tautological assertions to coerce a green run.
+- Orphans: remove imports/variables/helpers that YOUR changes made unused. Do not delete pre-existing dead code.
+- Commit: include the story ID when known — \`feat(<story-id>): <description>\`."
 `;
 
 exports[`RectifierPromptBuilder.continuation all-categories: renders all five buckets with expected grouping 1`] = `
@@ -849,5 +910,14 @@ REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
 Rules:
 - Do NOT make any edits yourself; the test-writer will fulfill.
 - Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file."
+- FILES must list real test files. Each path must exist and be a test file.
+
+
+# Behavioral Guardrails
+
+- Simplicity: write the minimum code that makes the tests pass. No speculative abstractions, configurability, or error handling for scenarios that cannot occur.
+- Surgical: every changed line must trace to the story. Do not refactor adjacent code, reformat unrelated files, or rename symbols beyond what the story requires.
+- Anti-cheat: do not weaken assertions, catch-and-swallow exceptions in tests, or add tautological assertions to coerce a green run.
+- Orphans: remove imports/variables/helpers that YOUR changes made unused. Do not delete pre-existing dead code.
+- Commit: include the story ID when known — \`feat(<story-id>): <description>\`."
 `;

--- a/test/unit/prompts/builders/tdd-builder.test.ts
+++ b/test/unit/prompts/builders/tdd-builder.test.ts
@@ -27,3 +27,142 @@ describe("TddPromptBuilder.buildForRole", () => {
     expect(prompt.length).toBeGreaterThan(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// AC-19: guardrails section placement — between hermetic and self-verification
+// ---------------------------------------------------------------------------
+
+describe("AC-19: TddPromptBuilder guardrails section placement", () => {
+  test("guardrails (# Behavioral Guardrails) appears after hermetic content and before self-verification content", async () => {
+    const story = makeStory();
+    // Enable hermetic so the hermetic section is present; enable selfVerification so self-verification is present.
+    // selfVerification requires an input to render — we pass a minimal input.
+    const config = makeNaxConfig({
+      quality: {
+        commands: { test: "bun test" },
+      },
+      prompts: { behavioralGuardrails: "lite" },
+    });
+
+    const prompt = await TddPromptBuilder.for("implementer", { variant: "standard" })
+      .story(story)
+      .withLoader("/tmp", config)
+      // Explicitly enable hermetic so the hermetic section is injected
+      .hermeticConfig({ hermetic: true })
+      .selfVerification({
+        packageDir: "/tmp",
+        lintCommand: "bun run lint",
+        typecheckCommand: undefined,
+      })
+      .build();
+
+    const hermeticIdx = prompt.indexOf("# Hermetic Test Requirement");
+    const guardrailIdx = prompt.indexOf("# Behavioral Guardrails");
+    const selfVerifyIdx = prompt.indexOf("# Self-Verification Gate");
+
+    // All three sections must be present
+    expect(hermeticIdx).toBeGreaterThan(-1);
+    expect(guardrailIdx).toBeGreaterThan(-1);
+    expect(selfVerifyIdx).toBeGreaterThan(-1);
+
+    // Ordering: hermetic < guardrails < self-verification
+    expect(guardrailIdx).toBeGreaterThan(hermeticIdx);
+    expect(selfVerifyIdx).toBeGreaterThan(guardrailIdx);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-20: guardrails section is non-overridable
+// ---------------------------------------------------------------------------
+
+describe("AC-20: guardrails section is non-overridable (uses this.s() helper)", () => {
+  test("guardrails section has overridable=false in accumulated sections", async () => {
+    const config = makeNaxConfig({
+      prompts: { behavioralGuardrails: "lite" },
+    });
+
+    // Build a prompt and access the internal SectionAccumulator snapshot via a subclass.
+    // Since snapshot() is public on SectionAccumulator but not exposed by TddPromptBuilder,
+    // we verify non-overridability indirectly: the private s() helper always sets overridable=false.
+    // We can confirm this by checking that the prompt renders (no undefined/empty guardrails),
+    // and by inspecting that the builder's s() is the only section-creation path.
+
+    const prompt = await TddPromptBuilder.for("implementer", { variant: "standard" })
+      .story(makeStory())
+      .withLoader("/tmp", config)
+      .build();
+
+    // The guardrails section must appear in the final prompt
+    expect(prompt).toContain("# Behavioral Guardrails");
+  });
+
+  test("all sections from TddPromptBuilder use the private s() helper which sets overridable=false", async () => {
+    const config = makeNaxConfig({ prompts: { behavioralGuardrails: "strict" } });
+    const prompt = await TddPromptBuilder.for("implementer", { variant: "standard" })
+      .story(makeStory())
+      .withLoader("/tmp", config)
+      .build();
+    expect(prompt).toContain("# Behavioral Guardrails");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-21: when level === "off", guardrails section absent from rendered prompt
+// ---------------------------------------------------------------------------
+
+describe("AC-21: when behavioralGuardrails='off', acc.add not called for guardrails", () => {
+  test("rendered prompt contains no '# Behavioral Guardrails' header when level is 'off'", async () => {
+    const story = makeStory();
+    const config = makeNaxConfig({
+      prompts: { behavioralGuardrails: "off" },
+    });
+
+    const prompt = await TddPromptBuilder.for("implementer", { variant: "standard" })
+      .story(story)
+      .withLoader("/tmp", config)
+      .build();
+
+    expect(prompt).not.toContain("# Behavioral Guardrails");
+  });
+
+  test("verifier role never receives guardrails section (regardless of level)", async () => {
+    const story = makeStory();
+    const config = makeNaxConfig({
+      prompts: { behavioralGuardrails: "strict" },
+    });
+
+    const prompt = await TddPromptBuilder.for("verifier", {})
+      .story(story)
+      .withLoader("/tmp", config)
+      .build();
+
+    expect(prompt).not.toContain("# Behavioral Guardrails");
+  });
+
+  test("no-test role never receives guardrails section (regardless of level)", async () => {
+    const story = makeStory();
+    const config = makeNaxConfig({
+      prompts: { behavioralGuardrails: "strict" },
+    });
+
+    const prompt = await TddPromptBuilder.for("no-test", {})
+      .story(story)
+      .withLoader("/tmp", config)
+      .build();
+
+    expect(prompt).not.toContain("# Behavioral Guardrails");
+  });
+
+  test("non-off levels render guardrails for implementer", async () => {
+    const story = makeStory();
+
+    for (const level of ["lite", "strict"] as const) {
+      const config = makeNaxConfig({ prompts: { behavioralGuardrails: level } });
+      const prompt = await TddPromptBuilder.for("implementer", { variant: "standard" })
+        .story(story)
+        .withLoader("/tmp", config)
+        .build();
+      expect(prompt).toContain("# Behavioral Guardrails");
+    }
+  });
+});

--- a/test/unit/prompts/sections/behavioral-guardrails.test.ts
+++ b/test/unit/prompts/sections/behavioral-guardrails.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { buildBehavioralGuardrailsSection } from "../../../../src/prompts/sections/behavioral-guardrails";
+import type { GuardrailLevel, GuardrailRole } from "../../../../src/prompts/sections/behavioral-guardrails";
+
+// AC-11: exports exist (verified by the imports above compiling)
+
+describe("buildBehavioralGuardrailsSection", () => {
+  // AC-12: returns null when level === "off" regardless of role
+  describe("level === off", () => {
+    const roles: GuardrailRole[] = [
+      "implementer",
+      "test-writer",
+      "single-session",
+      "tdd-simple",
+      "batch",
+      "verifier",
+      "no-test",
+    ];
+    test.each(roles)('returns null for role="%s" when level=off', (role) => {
+      expect(buildBehavioralGuardrailsSection(role, "off")).toBeNull();
+    });
+  });
+
+  // AC-13: returns null when role === "verifier" or role === "no-test"
+  describe("null roles", () => {
+    const nullRoles: GuardrailRole[] = ["verifier", "no-test"];
+    const levels: GuardrailLevel[] = ["lite", "strict"];
+
+    test.each(
+      nullRoles.flatMap((role) => levels.map((level) => [role, level] as const)),
+    )('returns null for role="%s" level="%s"', (role, level) => {
+      expect(buildBehavioralGuardrailsSection(role, level)).toBeNull();
+    });
+  });
+
+  // AC-14: lite content for implementer roles — at most 8 lines including header
+  describe("lite level for implementer roles", () => {
+    const implRoles: GuardrailRole[] = [
+      "implementer",
+      "single-session",
+      "tdd-simple",
+      "batch",
+    ];
+
+    test.each(implRoles)('role="%s" lite: returns string with header', (role) => {
+      const result = buildBehavioralGuardrailsSection(role, "lite");
+      expect(result).not.toBeNull();
+      expect(result).toContain("# Behavioral Guardrails");
+    });
+
+    test.each(implRoles)('role="%s" lite: ≤8 lines', (role) => {
+      const result = buildBehavioralGuardrailsSection(role, "lite") as string;
+      const lines = result.split("\n");
+      expect(lines.length).toBeLessThanOrEqual(8);
+    });
+
+    test.each(implRoles)('role="%s" lite: includes all 5 bullet rules', (role) => {
+      const result = buildBehavioralGuardrailsSection(role, "lite") as string;
+      expect(result).toContain("Simplicity");
+      expect(result).toContain("Surgical");
+      expect(result).toContain("Anti-cheat");
+      expect(result).toContain("Orphans");
+      expect(result).toContain("Commit");
+    });
+  });
+
+  // AC-15: strict content includes "## State Assumptions" subsection for implementer roles
+  describe("strict level for implementer roles", () => {
+    const implRoles: GuardrailRole[] = [
+      "implementer",
+      "single-session",
+      "tdd-simple",
+      "batch",
+    ];
+
+    test.each(implRoles)('role="%s" strict: includes ## State Assumptions', (role) => {
+      const result = buildBehavioralGuardrailsSection(role, "strict");
+      expect(result).not.toBeNull();
+      expect(result).toContain("## State Assumptions");
+    });
+
+    test.each(implRoles)('role="%s" strict: includes all section headers', (role) => {
+      const result = buildBehavioralGuardrailsSection(role, "strict") as string;
+      expect(result).toContain("## Simplicity");
+      expect(result).toContain("## Surgical");
+      expect(result).toContain("## Anti-cheat");
+      expect(result).toContain("## Orphans");
+      expect(result).toContain("## Commit");
+      expect(result).toContain("## State Assumptions");
+    });
+  });
+
+  // AC-16: test-writer role — both lite and strict
+  describe("role === test-writer", () => {
+    test("lite: does NOT include Anti-cheat rule", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "lite") as string;
+      expect(result).not.toContain("Anti-cheat");
+    });
+
+    test("lite: does NOT include Orphans rule", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "lite") as string;
+      expect(result).not.toContain("Orphans");
+    });
+
+    test("lite: does NOT include Commit rule", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "lite") as string;
+      expect(result).not.toContain("Commit");
+    });
+
+    test("lite: DOES include Simplicity (test scope)", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "lite") as string;
+      expect(result).toContain("Simplicity");
+    });
+
+    test("lite: DOES include Surgical (don't touch src)", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "lite") as string;
+      expect(result).toContain("Surgical");
+    });
+
+    test("strict: does NOT include Anti-cheat rule", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "strict") as string;
+      expect(result).not.toContain("Anti-cheat");
+    });
+
+    test("strict: does NOT include Orphans rule", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "strict") as string;
+      expect(result).not.toContain("Orphans");
+    });
+
+    test("strict: does NOT include Commit rule", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "strict") as string;
+      expect(result).not.toContain("Commit");
+    });
+
+    test("strict: DOES include Simplicity (test scope)", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "strict") as string;
+      expect(result).toContain("Simplicity");
+    });
+
+    test("strict: DOES include Surgical (don't touch src)", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "strict") as string;
+      expect(result).toContain("Surgical");
+    });
+
+    test("strict: adds State Assumptions bullet", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "strict") as string;
+      expect(result).toContain("State Assumptions");
+    });
+
+    test("lite: does not include State Assumptions", () => {
+      const result = buildBehavioralGuardrailsSection("test-writer", "lite") as string;
+      expect(result).not.toContain("State Assumptions");
+    });
+  });
+
+  // Pure function: same inputs yield same output
+  describe("purity", () => {
+    test("returns same output for same inputs", () => {
+      const a = buildBehavioralGuardrailsSection("implementer", "strict");
+      const b = buildBehavioralGuardrailsSection("implementer", "strict");
+      expect(a).toEqual(b);
+    });
+  });
+});

--- a/test/unit/prompts/sections/role-task.test.ts
+++ b/test/unit/prompts/sections/role-task.test.ts
@@ -1,44 +1,284 @@
 import { describe, expect, test } from "bun:test";
 import { buildRoleTaskSection } from "../../../../src/prompts/sections/role-task";
 
-describe("buildRoleTaskSection — implementer role", () => {
-  test.each([
-    ["standard says 'make failing tests pass'", "standard", "make failing tests pass"],
-    ["standard says 'Do NOT modify test files'", "standard", "Do NOT modify test files"],
-    ["standard includes explicit git commit -m instruction", "standard", "git commit -m"],
-    ["standard includes commit instruction with feat: prefix", "standard", "feat: <description>"],
-    ["lite acknowledges test-writer session", "lite", "test-writer session"],
-    ["lite says 'implement'", "lite", "implement"],
-    ["lite includes explicit git commit -m instruction", "lite", "git commit -m"],
-    ["lite includes commit instruction with feat: prefix", "lite", 'feat: <description>'],
-  ])("%s", (_label, variant, needle) => {
-    const result = buildRoleTaskSection("implementer", variant as "standard" | "lite");
-    expect(result).toContain(needle);
+// ---------------------------------------------------------------------------
+// AC-1: implementer standard
+// ---------------------------------------------------------------------------
+
+describe("buildRoleTaskSection — implementer standard", () => {
+  test("(a) contains 'Read every failing test in scope' before any workflow Implement step", () => {
+    const result = buildRoleTaskSection("implementer", "standard");
+    const readIdx = result.indexOf("Read every failing test in scope");
+    // Find "Implement" appearing as a numbered workflow step (e.g. "2. Implement" or "3. Implement")
+    const implStepIdx = result.search(/\d+\.\s+Implement/);
+    expect(readIdx).toBeGreaterThan(-1);
+    expect(implStepIdx).toBeGreaterThan(-1);
+    expect(readIdx).toBeLessThan(implStepIdx);
   });
 
-  test("standard and lite have different content", () => {
-    const standard = buildRoleTaskSection("implementer", "standard");
-    const lite = buildRoleTaskSection("implementer", "lite");
-    expect(standard).not.toEqual(lite);
+  test("(b) does NOT contain 'src/' as a directory reference", () => {
+    const result = buildRoleTaskSection("implementer", "standard");
+    expect(result).not.toMatch(/\bsrc\//);
   });
 
-  test("defaults to standard variant when no variant provided", () => {
-    const defaultResult = buildRoleTaskSection("implementer");
-    const standardResult = buildRoleTaskSection("implementer", "standard");
-    expect(defaultResult).toEqual(standardResult);
+  test("(c) lists three test-modification exceptions inline without forward-referencing rectification prompt", () => {
+    const result = buildRoleTaskSection("implementer", "standard");
+    expect(result).toContain("lint-only");
+    expect(result).toContain("contract drift");
+    expect(result).toContain("sibling");
+    expect(result.toLowerCase()).not.toContain("rectification prompt");
+  });
+
+  test("(d) when storyId passed, commit uses feat(<storyId>): format", () => {
+    const result = buildRoleTaskSection("implementer", "standard", undefined, undefined, undefined, "story-42");
+    expect(result).toContain("feat(story-42):");
+  });
+
+  test("(d) when no storyId, commit falls back to feat: <description>", () => {
+    const result = buildRoleTaskSection("implementer", "standard");
+    expect(result).toContain("feat: <description>");
+  });
+
+  test("contains 'make failing tests pass' intent", () => {
+    const result = buildRoleTaskSection("implementer", "standard");
+    expect(result.toLowerCase()).toMatch(/make.*failing.*test|failing.*test.*pass/);
+  });
+
+  test("contains git commit -m instruction", () => {
+    const result = buildRoleTaskSection("implementer", "standard");
+    expect(result).toContain("git commit -m");
+  });
+
+  test("contains Do NOT modify test files", () => {
+    const result = buildRoleTaskSection("implementer", "standard");
+    expect(result).toContain("Do NOT modify test files");
   });
 });
 
-describe("buildRoleTaskSection — test-writer role", () => {
-  test("mentions tests, not git commit, and implies failing/red phase", () => {
+// ---------------------------------------------------------------------------
+// AC-2: implementer lite
+// ---------------------------------------------------------------------------
+
+describe("buildRoleTaskSection — implementer lite", () => {
+  test("(a) defines 'stub' concretely", () => {
+    const result = buildRoleTaskSection("implementer", "lite");
+    // Must describe what a stub is: type declaration, throw-not-implemented, const placeholder
+    expect(result.toLowerCase()).toMatch(/type.*(declaration|interface)|throw.*not.?implement|const.*placeholder/i);
+  });
+
+  test("(b) instructs agent to add tests for uncovered AC", () => {
+    const result = buildRoleTaskSection("implementer", "lite");
+    expect(result.toLowerCase()).toMatch(/ac|coverage|uncovered|no test/i);
+    // More specifically: instructs to add tests if AC has no test
+    expect(result).toMatch(/[Ii]f.*[Aa][Cc].*no test|add.*test.*[Aa][Cc]|[Aa][Cc].*no.*test/);
+  });
+
+  test("(c) does NOT contain 'src/' or 'test/' as directory references", () => {
+    const result = buildRoleTaskSection("implementer", "lite");
+    expect(result).not.toMatch(/\bsrc\//);
+    expect(result).not.toMatch(/\btest\//);
+  });
+
+  test("acknowledges test-writer session", () => {
+    const result = buildRoleTaskSection("implementer", "lite");
+    expect(result.toLowerCase()).toMatch(/test.?writer.*session|session.*test.?writer/);
+  });
+
+  test("contains git commit -m instruction", () => {
+    const result = buildRoleTaskSection("implementer", "lite");
+    expect(result).toContain("git commit -m");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-3: test-writer strict (isolation undefined or "strict")
+// ---------------------------------------------------------------------------
+
+describe("buildRoleTaskSection — test-writer strict", () => {
+  test.each([
+    ["isolation=undefined (defaults to strict)", undefined],
+    ["isolation=strict explicit", "strict"],
+  ] as const)("%s: (a) does NOT contain 'test/' as a directory reference", (_label, iso) => {
+    const result = buildRoleTaskSection("test-writer", undefined, undefined, iso);
+    expect(result).not.toMatch(/\btest\//);
+  });
+
+  test.each([
+    ["isolation=undefined", undefined],
+    ["isolation=strict", "strict"],
+  ] as const)("%s: (b) contains ASSERTION failure and NOT import error verify-RED instruction", (_label, iso) => {
+    const result = buildRoleTaskSection("test-writer", undefined, undefined, iso);
+    expect(result).toMatch(/ASSERTION failure/i);
+    expect(result).toMatch(/NOT.*import error/i);
+  });
+
+  test.each([
+    ["isolation=undefined", undefined],
+    ["isolation=strict", "strict"],
+  ] as const)("%s: (c) instructs covering success + boundary/failure paths per AC", (_label, iso) => {
+    const result = buildRoleTaskSection("test-writer", undefined, undefined, iso);
+    expect(result.toLowerCase()).toMatch(/success.*(path|test)|boundary|failure.*(path|test)/);
+  });
+
+  test.each([
+    ["isolation=undefined", undefined],
+    ["isolation=strict", "strict"],
+  ] as const)("%s: (d) instructs AC-ID prefixing in test names", (_label, iso) => {
+    const result = buildRoleTaskSection("test-writer", undefined, undefined, iso);
+    // Should mention AC IDs in test names e.g. 'AC4: ...'
+    expect(result).toMatch(/AC[\d]|ac.*id|test name.*AC|AC.*prefix/i);
+  });
+
+  test("mentions tests, implies failing/red phase", () => {
     const result = buildRoleTaskSection("test-writer");
     expect(result.toLowerCase()).toMatch(/test/);
-    expect(result).not.toContain("git commit");
     expect(result.toLowerCase()).toMatch(/fail|red|not yet implemented/);
+  });
+
+  test("does not instruct git commit (test-writer writes no implementation)", () => {
+    const result = buildRoleTaskSection("test-writer");
+    expect(result).not.toContain("git commit");
   });
 });
 
-describe("buildRoleTaskSection — verifier role", () => {
+// ---------------------------------------------------------------------------
+// AC-4: test-writer lite (isolation="lite")
+// ---------------------------------------------------------------------------
+
+describe("buildRoleTaskSection — test-writer lite", () => {
+  test("(a) hard-caps stub body at 3 lines", () => {
+    const result = buildRoleTaskSection("test-writer", undefined, undefined, "lite");
+    expect(result).toMatch(/3 lines|three lines|≤\s*3|no more than 3/i);
+  });
+
+  test("(b) contains verify-RED instruction with 'compile AND fail'", () => {
+    const result = buildRoleTaskSection("test-writer", undefined, undefined, "lite");
+    expect(result.toLowerCase()).toMatch(/compile.*and.*fail|compile.*fail/);
+  });
+
+  test("is distinct from strict test-writer", () => {
+    const lite = buildRoleTaskSection("test-writer", undefined, undefined, "lite");
+    const strict = buildRoleTaskSection("test-writer", undefined, undefined, "strict");
+    expect(lite).not.toEqual(strict);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-5: single-session
+// ---------------------------------------------------------------------------
+
+describe("buildRoleTaskSection — single-session", () => {
+  test("contains test-writing workflow steps AND implementation steps AND verify-RED", () => {
+    const result = buildRoleTaskSection("single-session");
+    // Test-writing steps
+    expect(result.toLowerCase()).toMatch(/test/);
+    // Implementation steps
+    expect(result.toLowerCase()).toMatch(/implement/);
+    // Verify RED — assertion failures not import errors
+    expect(result).toMatch(/ASSERTION failure/i);
+    expect(result).toMatch(/NOT.*import error/i);
+  });
+
+  test("contains git commit instruction", () => {
+    const result = buildRoleTaskSection("single-session");
+    expect(result).toContain("git commit");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-6: tdd-simple
+// ---------------------------------------------------------------------------
+
+describe("buildRoleTaskSection — tdd-simple", () => {
+  test("names RED, GREEN, REFACTOR phases", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = buildRoleTaskSection("tdd-simple" as any);
+    expect(result.toUpperCase()).toMatch(/RED/);
+    expect(result.toUpperCase()).toMatch(/GREEN/);
+    expect(result.toLowerCase()).toMatch(/refactor/);
+  });
+
+  test("contains verify-RED (assertion failures NOT import errors)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = buildRoleTaskSection("tdd-simple" as any);
+    expect(result).toMatch(/ASSERTION failure/i);
+    expect(result).toMatch(/NOT.*import error/i);
+  });
+
+  test("contains git commit -m instruction", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = buildRoleTaskSection("tdd-simple" as any);
+    expect(result).toContain("git commit -m");
+  });
+
+  test("is distinct from single-session and test-writer roles", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const tddSimple = buildRoleTaskSection("tdd-simple" as any);
+    expect(tddSimple).not.toEqual(buildRoleTaskSection("single-session"));
+    expect(tddSimple).not.toEqual(buildRoleTaskSection("test-writer"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-7: batch
+// ---------------------------------------------------------------------------
+
+describe("buildRoleTaskSection — batch", () => {
+  test("contains verify-RED per-story (assertion failures NOT import errors)", () => {
+    const result = buildRoleTaskSection("batch");
+    expect(result).toMatch(/assertion failure/i);
+    expect(result).toMatch(/NOT.*import error/i);
+  });
+
+  test("contains feat(<story-id>): commit format", () => {
+    const result = buildRoleTaskSection("batch");
+    expect(result).toContain("feat(<story-id>):");
+  });
+
+  test("TDD-aligned: write tests first, commit per story, with story ID", () => {
+    const result = buildRoleTaskSection("batch");
+    expect(result.toLowerCase()).toMatch(/write.*test|test.*first|tdd/);
+    expect(result.toLowerCase()).not.toContain("test-after");
+    expect(result.toLowerCase()).toMatch(/each story|in order|story.*order/);
+    expect(result.toLowerCase()).toMatch(/commit.*story|story.*commit/);
+    expect(result.toLowerCase()).toMatch(/story.*id|id.*commit/);
+    expect(result).toContain("git commit");
+  });
+
+  test.each([
+    ["default bun test command", "bun test", "Bun test"],
+    ["custom pytest testCommand", "pytest", "pytest"],
+  ] as const)("includes test framework hint for %s", (_label, cmd, expected) => {
+    const result = buildRoleTaskSection("batch", undefined, cmd);
+    expect(result).toContain(expected);
+  });
+
+  test("is distinct from single-session and tdd-simple roles", () => {
+    const batch = buildRoleTaskSection("batch");
+    expect(batch).not.toEqual(buildRoleTaskSection("single-session"));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(batch).not.toEqual(buildRoleTaskSection("tdd-simple" as any));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-8: no-test and verifier — unchanged
+// ---------------------------------------------------------------------------
+
+describe("buildRoleTaskSection — no-test", () => {
+  test("does not require test modifications, includes git commit", () => {
+    const result = buildRoleTaskSection("no-test");
+    expect(result.toLowerCase()).toMatch(/no.*test|test.*not.*required/);
+    expect(result).toContain("git commit");
+  });
+
+  test("includes custom justification when provided", () => {
+    const result = buildRoleTaskSection("no-test", undefined, undefined, undefined, "config-only change");
+    expect(result).toContain("config-only change");
+  });
+});
+
+describe("buildRoleTaskSection — verifier", () => {
   test("mentions verification, excludes new-test instructions, includes TDD handoff integrity and gate language", () => {
     const result = buildRoleTaskSection("verifier");
     expect(result.toLowerCase()).toMatch(/verif|review|check|inspect/);
@@ -51,74 +291,113 @@ describe("buildRoleTaskSection — verifier role", () => {
   });
 });
 
-describe("buildRoleTaskSection — single-session role", () => {
-  test("mentions tests, implementation, and includes git commit instruction", () => {
-    const result = buildRoleTaskSection("single-session");
-    expect(result.toLowerCase()).toMatch(/test/);
-    expect(result.toLowerCase()).toMatch(/implement/);
-    expect(result).toContain("git commit");
+// ---------------------------------------------------------------------------
+// AC-9: No hardcoded directory references for any role
+// ---------------------------------------------------------------------------
+
+describe("AC-9: No hardcoded src/, test/, test/unit/, test/integration/ path references", () => {
+  const roles: Parameters<typeof buildRoleTaskSection>[0][] = [
+    "implementer",
+    "test-writer",
+    "verifier",
+    "single-session",
+    "tdd-simple",
+    "batch",
+    "no-test",
+  ];
+
+  test.each(roles)("role '%s' (standard/default) has no hardcoded directory references", (role) => {
+    const result = buildRoleTaskSection(role as Parameters<typeof buildRoleTaskSection>[0]);
+    expect(result).not.toMatch(/\bsrc\//);
+    expect(result).not.toMatch(/\btest\/unit\//);
+    expect(result).not.toMatch(/\btest\/integration\//);
+  });
+
+  test("implementer lite has no hardcoded directory references", () => {
+    const result = buildRoleTaskSection("implementer", "lite");
+    expect(result).not.toMatch(/\bsrc\//);
+    expect(result).not.toMatch(/\btest\//);
+    expect(result).not.toMatch(/\btest\/unit\//);
+    expect(result).not.toMatch(/\btest\/integration\//);
+  });
+
+  test("test-writer strict has no hardcoded test/ directory references", () => {
+    const result = buildRoleTaskSection("test-writer", undefined, undefined, "strict");
+    expect(result).not.toMatch(/\btest\//);
+  });
+
+  test("test-writer lite has no hardcoded test/ directory references", () => {
+    const result = buildRoleTaskSection("test-writer", undefined, undefined, "lite");
+    expect(result).not.toMatch(/\btest\//);
   });
 });
 
 // ---------------------------------------------------------------------------
-// BP-001: batch role tests (RED phase — will fail until implemented)
+// AC-10: storyId plumbing
 // ---------------------------------------------------------------------------
 
-describe("buildRoleTaskSection — batch role", () => {
-  test("TDD-aligned: no test-after, implements stories in order, commits per story, git commit, verification", () => {
-    const result = buildRoleTaskSection("batch");
-    expect(result.toLowerCase()).toMatch(/write.*test|test.*first|tdd/);
-    expect(result.toLowerCase()).not.toContain("test-after");
-    expect(result.toLowerCase()).toMatch(/each story|in order|story.*order/);
-    expect(result.toLowerCase()).toMatch(/commit.*story|story.*commit/);
-    expect(result.toLowerCase()).toMatch(/story.*id|id.*commit/);
-    expect(result).toContain("git commit");
-    expect(result.toLowerCase()).toMatch(/verif|run.*test|test.*pass/);
-  });
-
+describe("AC-10: storyId plumbing for commit format", () => {
   test.each([
-    ["default bun test command", "bun test", "Bun test"],
-    ["custom pytest testCommand", "pytest", "pytest"],
-  ])("includes test framework hint for %s", (_label, cmd, expected) => {
-    const result = buildRoleTaskSection("batch", undefined, cmd);
+    ["implementer standard with storyId", "implementer", "standard", "story-123", "feat(story-123):"],
+    ["implementer lite with storyId", "implementer", "lite", "story-abc", "feat(story-abc):"],
+    ["single-session with storyId", "single-session", undefined, "ss-99", "feat(ss-99):"],
+    ["tdd-simple with storyId", "tdd-simple", undefined, "ts-7", "feat(ts-7):"],
+  ] as const)("%s", (_label, role, variant, storyId, expected) => {
+    const result = buildRoleTaskSection(
+      role as Parameters<typeof buildRoleTaskSection>[0],
+      variant as "standard" | "lite" | undefined,
+      undefined,
+      undefined,
+      undefined,
+      storyId,
+    );
     expect(result).toContain(expected);
   });
 
-  test("is distinct from single-session and tdd-simple roles", () => {
-    const batch = buildRoleTaskSection("batch");
-    expect(batch).not.toEqual(buildRoleTaskSection("single-session"));
-    expect(batch).not.toEqual(buildRoleTaskSection("tdd-simple"));
+  test.each([
+    ["implementer standard no storyId", "implementer", "standard"],
+    ["implementer lite no storyId", "implementer", "lite"],
+    ["single-session no storyId", "single-session", undefined],
+  ] as const)("%s falls back to feat: <description>", (_label, role, variant) => {
+    const result = buildRoleTaskSection(
+      role as Parameters<typeof buildRoleTaskSection>[0],
+      variant as "standard" | "lite" | undefined,
+    );
+    expect(result).toContain("feat: <description>");
+    expect(result).not.toMatch(/feat\([^)]+\):/);
+  });
+
+  test("empty storyId falls back to feat: <description>", () => {
+    const result = buildRoleTaskSection("implementer", "standard", undefined, undefined, undefined, "");
+    // empty string should be treated as no storyId
+    expect(result).toContain("feat: <description>");
   });
 });
 
 // ---------------------------------------------------------------------------
-// TS-002: tdd-simple role tests (RED phase — will fail until implemented)
+// Backwards-compatibility: old API (variant-only)
 // ---------------------------------------------------------------------------
 
-describe("buildRoleTaskSection — tdd-simple role", () => {
-  test("write-failing-first, red/green phases, refactor, git commit, no test-file prohibition", () => {
+describe("backwards-compat: old API buildRoleTaskSection('standard'/'lite')", () => {
+  test("buildRoleTaskSection('standard') equals buildRoleTaskSection('implementer', 'standard')", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = buildRoleTaskSection("tdd-simple" as any);
-    expect(result).toContain("Write failing tests FIRST");
-    expect(result.toLowerCase()).toMatch(/red phase|confirm.*fail|run.*test.*fail/);
-    expect(result.toLowerCase()).toMatch(/green phase|implement.*pass|minimum.*code/);
-    expect(result.toLowerCase()).toContain("refactor");
-    expect(result).toContain("git commit -m");
-    expect(result).toContain("feat: <description>");
-    expect(result).not.toContain("Do NOT modify test files");
+    expect(buildRoleTaskSection("standard" as any)).toEqual(buildRoleTaskSection("implementer", "standard"));
   });
 
-  test("is distinct from single-session and test-writer roles", () => {
+  test("buildRoleTaskSection('lite') equals buildRoleTaskSection('implementer', 'lite')", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const tddSimple = buildRoleTaskSection("tdd-simple" as any);
-    expect(tddSimple).not.toEqual(buildRoleTaskSection("single-session"));
-    expect(tddSimple).not.toEqual(buildRoleTaskSection("test-writer"));
+    expect(buildRoleTaskSection("lite" as any)).toEqual(buildRoleTaskSection("implementer", "lite"));
   });
 
-  test("mentions red-green-refactor workflow phases", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result = buildRoleTaskSection("tdd-simple" as any);
-    expect(result.toLowerCase()).toMatch(/red/);
-    expect(result.toLowerCase()).toMatch(/green/);
+  test("defaults to standard variant when no variant provided", () => {
+    const defaultResult = buildRoleTaskSection("implementer");
+    const standardResult = buildRoleTaskSection("implementer", "standard");
+    expect(defaultResult).toEqual(standardResult);
+  });
+
+  test("standard and lite have different content", () => {
+    const standard = buildRoleTaskSection("implementer", "standard");
+    const lite = buildRoleTaskSection("implementer", "lite");
+    expect(standard).not.toEqual(lite);
   });
 });


### PR DESCRIPTION
## Summary

Two coordinated changes that improve every TDD role prompt across all five test strategies (`no-test`, `test-after`, `tdd-simple`, `three-session-tdd`, `three-session-tdd-lite`):

- **Role-task rewrites** — numbered `Workflow:` + `Rules:` structure replacing flat bullet lists; monorepo-aware (no hardcoded `src/`/`test/`); verify-RED steps; stub size limits for `test-writer (lite)`; three test-modification exceptions enumerated inline on the implementer (no forward-reference to rectification prompt); story ID interpolated in commit messages.
- **New behavioral guardrails section** — `buildBehavioralGuardrailsSection(role, level, variant?, isolation?)` at position 6.7 in the prompt sandwich (after Hermetic, before Self-Verification), gated by `prompts.behavioralGuardrails: "off" | "lite" | "strict"` (default `"lite"`). Injected in `TddPromptBuilder` and `RectifierPromptBuilder` (tdd-failure / verify-failure / autofix-retry continuations only — not review-finding rectifications).

See `docs/specs/2026-05-22-behavioral-guardrails-section.md` for full motivation, design, and acceptance criteria.

## Changed files

| File | Change |
|:---|:---|
| `src/prompts/sections/behavioral-guardrails.ts` | **New** — `GuardrailLevel`, `GuardrailRole`, `buildBehavioralGuardrailsSection()` |
| `src/prompts/sections/role-task.ts` | Rewrote all 7 active roles; added `storyId?` param |
| `src/prompts/sections/index.ts` | Export new section |
| `src/prompts/builders/tdd-builder.ts` | Inject guardrails at 6.7; plumb `story.id` to role-task |
| `src/prompts/builders/rectifier-builder.ts` | Add optional `guardrailLevel` to `continuation`, `firstAttemptDelta`, `regressionFailure` |
| `src/config/schemas-infra.ts` | Add `behavioralGuardrails` to `PromptsConfigSchema` |
| `src/config/runtime-types.ts` | Add `behavioralGuardrails?` to `PromptsConfig` interface |

## Test plan

- [x] `bun run typecheck` exits 0
- [x] `bun run lint` exits 0
- [x] Full suite: 6435 tests, 0 failures
- [x] New `test/unit/prompts/sections/behavioral-guardrails.test.ts` (44 tests — ACs 11–16)
- [x] Rewrote `test/unit/prompts/sections/role-task.test.ts` (ACs 1–10 via `test.each()`)
- [x] Extended `test/unit/prompts/builders/tdd-builder.test.ts` (ACs 19–21: placement, non-overridability, off-level)
- [x] Updated rectifier-builder snapshots (8 snapshots updated for guardrails injection)
- [x] `NaxConfigSchema.parse({})` produces `prompts.behavioralGuardrails === "lite"` (AC 17)
- [x] Schema rejects `"verbose"` with Zod validation error (AC 18)