### PR TITLE
fix(rectification): run full-suite pre-check to fix abort baseline scope mismatch

### DIFF
--- a/src/verification/rectification-loop.ts
+++ b/src/verification/rectification-loop.ts
@@ -248,11 +248,39 @@ export async function runRectificationLoop(
     },
   });
 
-  // Initial failure snapshot for the retry loop
-  const initialFailure: RectificationFailure = {
-    testOutput,
-    testSummary,
-  };
+  // Establish the initial failure snapshot for the retry loop. The testOutput
+  // passed in comes from the pipeline's verify stage, which may have used a
+  // scoped/smart runner covering fewer files than testCommand (the full suite).
+  // If abortOnIncreasingFailures is enabled we need the full-suite baseline so
+  // shouldAbort doesn't fire on scope-expansion (e.g. scoped=3 failures vs.
+  // full-suite=4 pre-existing failures). Run a pre-check with testCommand first
+  // and use its output as both the baseline and the agent's context.
+  let initialFailure: RectificationFailure = { testOutput, testSummary };
+  if (rectificationConfig.abortOnIncreasingFailures) {
+    const preCheck = await _rectificationDeps.runVerification({
+      workdir,
+      expectedFiles: getExpectedFiles(story),
+      command: testCommand,
+      timeoutSeconds,
+      forceExit: config.quality.forceExit,
+      detectOpenHandles: config.quality.detectOpenHandles,
+      detectOpenHandlesRetries: config.quality.detectOpenHandlesRetries,
+      timeoutRetryCount: 0,
+      gracePeriodMs: config.quality.gracePeriodMs,
+      drainTimeoutMs: config.quality.drainTimeoutMs,
+      shell: config.quality.shell,
+      stripEnvVars: config.quality.stripEnvVars,
+    });
+    if (preCheck.output) {
+      const preCheckSummary = parseTestOutput(preCheck.output);
+      initialFailure = { testOutput: preCheck.output, testSummary: preCheckSummary };
+    } else {
+      logger?.warn("rectification", "pre-check returned no output — abort baseline may be scope-mismatched", {
+        storyId: story.id,
+        preCheckStatus: preCheck.status,
+      });
+    }
+  }
 
   const outcome = await runRetryLoop<RectificationFailure, RectificationAttemptResult>({
     stage: "rectification",

--- a/test/unit/verification/rectification-loop-escalation.test.ts
+++ b/test/unit/verification/rectification-loop-escalation.test.ts
@@ -424,8 +424,9 @@ describe("runRectificationLoop — escalation on exhaustion", () => {
 
     _rectificationDeps.agentManager = mockAgentManager as any;
 
-    // Return more failures than initial to trigger abortOnIncreasingFailures
-    // Initial output has 1 failure; retry output has 5 failures
+    // The pre-check (first runVerification call) establishes the full-suite baseline.
+    // Subsequent calls (post-attempt verify) return 5 failures to trigger abort.
+    // Initial testOutput has 1 failure; pre-check confirms 1; post-attempt shows 5 → regression.
     const worseOutput =
       "✗ test1 [1ms]\n(fail) test1 [1ms]\nerror: err\n" +
       "✗ test2 [1ms]\n(fail) test2 [1ms]\nerror: err\n" +
@@ -434,9 +435,14 @@ describe("runRectificationLoop — escalation on exhaustion", () => {
       "✗ test5 [1ms]\n(fail) test5 [1ms]\nerror: err\n" +
       "5 passed, 5 failed [5ms]";
 
-    _rectificationDeps.runVerification = mock(async () =>
-      makeVerificationResult(false, worseOutput),
-    );
+    let verifyCallCount = 0;
+    _rectificationDeps.runVerification = mock(async () => {
+      // First call is the pre-check: return the same 1-failure baseline as testOutput.
+      // Subsequent calls are post-attempt verifies: return 5 failures (regression).
+      verifyCallCount++;
+      if (verifyCallCount === 1) return makeVerificationResult(false, FAILING_TEST_OUTPUT);
+      return makeVerificationResult(false, worseOutput);
+    });
 
     const config = makeConfig({
       execution: {

--- a/test/unit/verification/rectification-loop.test.ts
+++ b/test/unit/verification/rectification-loop.test.ts
@@ -1045,6 +1045,49 @@ Error: Test failed
 
     expect(result.succeeded).toBe(true);
     expect(agentRunCount).toBe(1);
+    // +1 for the pre-check that establishes the full-suite baseline before the loop
+    // (runs when abortOnIncreasingFailures is enabled, which is the default).
+    expect(verificationCalls).toBe(2);
+  });
+
+  test("skips pre-check when abortOnIncreasingFailures is disabled", async () => {
+    let verificationCalls = 0;
+    const mockAgentManager = makeMockAgentManager({
+      runAsSessionFn: mock(async () => ({
+        output: "",
+        estimatedCostUsd: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        internalRoundTrips: 0,
+      })),
+    });
+    _rectificationDeps.agentManager = mockAgentManager;
+    _rectificationDeps.runVerification = mock(async () => {
+      verificationCalls++;
+      return {
+        success: true,
+        status: "SUCCESS" as const,
+        output: "1 passed, 0 failed [1ms]",
+        countsTowardEscalation: false,
+      };
+    });
+
+    const runtime = makeMockRuntime();
+
+    const result = await runRectificationLoop({
+      config: makeConfig({
+        execution: { rectification: { abortOnIncreasingFailures: false } },
+      } as any),
+      workdir: "/tmp/test",
+      story: makeStory({ id: "TS-NO-ABORT" }),
+      testCommand: "bun test",
+      timeoutSeconds: 30,
+      testOutput: FAILING_TEST_OUTPUT,
+      agentManager: mockAgentManager,
+      runtime,
+    });
+
+    expect(result.succeeded).toBe(true);
+    // No pre-check: only the single verify call from the passing loop attempt.
     expect(verificationCalls).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- **Bug**: `abortOnIncreasingFailures` was comparing failure counts from two different test scopes. The baseline came from `ctx.verifyResult.rawOutput` (smart/scoped runner, e.g. 3 failures from 1 changed file), while the loop's own verification always runs the full `testCommand` (full suite, which could surface pre-existing failures in other files, e.g. 4). This caused `shouldAbort` to fire after attempt 1 (`4 > 3`) even though the agent had not regressed anything — exhausting rectification with `maxRetries=2` as if only 1 attempt ran.
- **Fix**: When `abortOnIncreasingFailures` is enabled, run a full-suite pre-check with `testCommand` before the retry loop to establish a baseline matching the same scope as the loop's own verification. If the pre-check returns no output (env crash, timeout), emit a `logger.warn` and keep the original scoped baseline.
- **Bonus**: The pre-check output replaces `testOutput` for the agent's first prompt, giving it a more complete failure picture across all files.

## Root cause trace (from production log)

```
verify: [smart-runner] Pass 0: 1 changed test file(s) detected directly
verify: Tests failed | failCount: 3          <- scoped run, 1 file
rectify: Starting rectification loop | maxRetries: 2
rectification: still failing after attempt | attempt: 1, remainingFailures: 4  <- full suite
rectify: Rectification exhausted - escalating  <- shouldAbort(4 > 3) fired
```

The 4th failure was pre-existing in an unrelated file not covered by the scoped run.

## Test plan

- [ ] All 249 verification unit tests pass
- [ ] `bun run typecheck` clean
- [ ] Updated escalation test uses sequence mock: call 1 (pre-check) returns 1-failure baseline, subsequent calls return 5-failure regression — correctly tests "agent broke things -> abort" path
- [ ] New test: "skips pre-check when abortOnIncreasingFailures is disabled" — verifies verificationCalls=1 (no pre-check) when flag is off
- [ ] Updated zero-failures test: verificationCalls=2 (+1 for pre-check) when flag is on (default)