### PR TITLE
fix(tdd): code-review follow-ups — lite mode in autofix, strict SSOT check

### DIFF
--- a/docs/20260523-review-tdd-fixes.md
+++ b/docs/20260523-review-tdd-fixes.md
@@ -1,0 +1,244 @@
+# Deep Code Review: TDD fixes (`ff640e6b` + `c668be23`)
+
+**Date:** 2026-05-23
+**Reviewer:** Subrina (AI), deep review
+**Scope:** Both commits landed in this session — `ff640e6b` (lite isolation + verifier-after-gate, via PR #1079) and `c668be23` (verifier-SSOT aggregation + diagnostic, direct to main)
+**Stack:** nax (Bun + TypeScript)
+**Files reviewed:** `src/tdd/isolation.ts`, `src/operations/write-test.ts`, `src/execution/plan-inputs.ts`, `src/execution/story-orchestrator.ts`, `src/execution/post-run.ts`, `src/pipeline/stages/autofix-guards.ts`, test files
+
+---
+
+## Overall Grade: B+ (82/100)
+
+The two commits ship two genuine bug fixes (lite-mode stub isolation, verifier-as-SSOT after gate failure) plus a defensive diagnostic. The logic is sound, the tests cover the new contracts, typecheck and lint are clean, and 1896 tests pass.
+
+Three issues prevent an A-range grade. The most consequential is **BUG-1** — the lite-mode `mode` parameter is wired only into the initial test-writer phase but not into the autofix test-writer rectification path. A lite-mode story that hits autofix's test-writer rectification would re-introduce the strict-isolation bug we just fixed. Two smaller issues: the SSOT carve-out trusts `phasePassed`'s fallback-to-true behavior (a verifier that emits malformed output silently triggers the carve-out), and the new diagnostic logs `undefined` values that get stripped at serialization time.
+
+| Dimension | Score | Notes |
+|:---|:---|:---|
+| Security | 19/20 | No new attack surface. Glob-based path matching reuses existing pattern; numstat input is from local git. |
+| Reliability | 15/20 | SSOT carve-out has a silent-fail edge (BUG-2). Lite-mode mode flag inconsistent across call sites (BUG-1). |
+| API Design | 17/20 | Optional `mode` param + default keeps backward compat; clear typed flag on `TestWriterInput`. Lite ceiling is an exported named constant. |
+| Code Quality | 16/20 | Logic is clear and well-commented. SSOT computation is slightly redundant (computed for warn + aggregation). |
+| Best Practices | 15/20 | Uses `_isolationDeps` injection. Threads `storyId` in logger calls. Misses `packageDir` in one log line per project convention. |
+
+---
+
+## Findings
+
+### 🟡 MEDIUM
+
+#### BUG-1: Lite-mode isolation not threaded through autofix test-writer rectification
+**Severity:** MEDIUM | **Category:** Bug
+
+`runIsolationGuard` in `src/pipeline/stages/autofix-guards.ts:85-108` calls `verifyTestWriterIsolation` without passing the new `mode` parameter:
+
+```typescript
+const result = await _guardDeps.verifyTestWriterIsolation(
+  workdir,
+  beforeRef,
+  config.tdd?.testWriterAllowedPaths,
+  resolved.globs,
+);
+// mode defaults to "strict"
+```
+
+It's called from `autofix-cycle.ts:503` when the autofix flow's test-writer rectification produces a diff. If the parent story uses `three-session-tdd-lite`, the autofix-driven test-writer rectification (which is also a "test-writer" role conceptually) gets the strict check — re-introducing the bug we just fixed for the initial test-writer phase. A user editing a lite-mode story that bounces through autofix's test-writer rectification path would see the same "stubs in src/ violate isolation" failure that motivated `ff640e6b`.
+
+**Risk:** Silent regression of the lite-mode fix on the autofix-rectification path. Hard to spot in CI because the unit tests for `runIsolationGuard` don't exercise lite-mode.
+
+**Fix:** Thread `routing.testStrategy` into `runIsolationGuard` and pass `mode: testStrategy === "three-session-tdd-lite" ? "lite" : "strict"`. Two-line change: extend `runIsolationGuard`'s signature, update the single call site in `autofix-cycle.ts:503-508`.
+
+```typescript
+// autofix-guards.ts
+export async function runIsolationGuard(
+  workdir: string,
+  beforeRef: string,
+  config: NaxConfig,
+  packageDir?: string,
+  mode: "strict" | "lite" = "strict",
+): Promise<IsolationGuardResult> {
+  // ...
+  const result = await _guardDeps.verifyTestWriterIsolation(
+    workdir,
+    beforeRef,
+    config.tdd?.testWriterAllowedPaths,
+    resolved.globs,
+    mode,
+  );
+  // ...
+}
+
+// autofix-cycle.ts
+const isolationResult = await _autofixCycleGuardDeps.runIsolationGuard(
+  ctx.workdir,
+  beforeRef,
+  ctx.config,
+  ctx.story.workdir || undefined,
+  ctx.routing?.testStrategy === "three-session-tdd-lite" ? "lite" : "strict",
+);
+```
+
+---
+
+#### BUG-2: SSOT carve-out trusts `phasePassed`'s fallback-to-true for verifier
+**Severity:** MEDIUM | **Category:** Bug
+
+In `src/execution/story-orchestrator.ts:480-484`:
+
+```typescript
+const verifierPassedSsot =
+  verifierName !== undefined &&
+  phaseOutputs[verifierName] !== undefined &&
+  phasePassed(verifierName, phaseOutputs[verifierName]);
+```
+
+`phasePassed` (defined at `story-orchestrator.ts:142-159`) returns `true` in two defensive cases:
+1. Output is non-null object with `success: undefined` and `passed: undefined` (emits a warn).
+2. Output is non-object (e.g., string) — returns `true` silently.
+
+Either case can fire if the verifier op produces a malformed envelope (e.g., parse failure + `recover` returns null + the fallback `final ?? parsed` path returns a stripped envelope). Under those conditions `verifierPassedSsot` evaluates true even though the verifier didn't actually verdict-pass. The gate then gets exempted, and a gate failure is silently dismissed with just the warn line "treating gate failures as unrelated regressions" — even though the verifier never made that judgment.
+
+In practice, `verifierOp.parse` always populates `success`, so this is a defensive concern rather than an active failure mode. But the SSOT semantic is supposed to mean *"verifier explicitly judged this OK"*, and trusting `phasePassed`'s fallback weakens that.
+
+**Risk:** A malformed verifier output silently passes a story that has real gate failures. The added warn log gives the operator a chance to spot it, but only after the fact.
+
+**Fix:** Inline an explicit-pass check instead of `phasePassed`:
+
+```typescript
+function verifierExplicitlyPassed(output: unknown): boolean {
+  if (output === null || output === undefined || typeof output !== "object") return false;
+  const r = output as Record<string, unknown>;
+  // Require an affirmative pass signal — neither "missing fields → assume pass"
+  // nor "non-object → assume pass" should trigger SSOT carve-out.
+  return r.success === true || r.passed === true;
+}
+
+const verifierPassedSsot =
+  verifierName !== undefined && verifierExplicitlyPassed(phaseOutputs[verifierName]);
+```
+
+The defensive fallback in `phasePassed` stays put (other call sites depend on it for non-TDD phases), but SSOT uses the stricter check.
+
+---
+
+### 🟢 LOW
+
+#### STYLE-1: Diagnostic log emits `undefined` values that JSON-strip at serialization
+**Severity:** LOW | **Category:** Style
+
+In `src/execution/post-run.ts:281-292`:
+
+```typescript
+phaseSignals[name] = {
+  success: typeof r.success === "boolean" ? r.success : undefined,
+  passed: typeof r.passed === "boolean" ? r.passed : undefined,
+};
+```
+
+The values can be `undefined`. When the JSONL logger serializes the data object, `undefined` keys are dropped — so a phase with neither boolean ends up logged as `{}`. Slightly misleading: the operator can't distinguish "phase produced no signal" from "phase signal was logged with undefined values."
+
+**Risk:** Cosmetic — the diagnostic still works, it just leaves a slightly less informative artifact.
+
+**Fix:** Either omit keys when the value isn't a boolean (cleaner JSONL) or replace `undefined` with the sentinel string `"missing"` (clearer signal). Prefer the omit:
+
+```typescript
+const signal: Record<string, boolean> = {};
+if (typeof r.success === "boolean") signal.success = r.success;
+if (typeof r.passed === "boolean") signal.passed = r.passed;
+phaseSignals[name] = signal;
+```
+
+---
+
+#### STYLE-2: `verifierPassedSsot` computed twice (warn condition + aggregation)
+**Severity:** LOW | **Category:** Style
+
+`src/execution/story-orchestrator.ts:480-495`. The same boolean is read once for the warn-line condition and again inside the `every()` lambda. Minor — the compiler can't hoist the lambda check out of the loop, so the second read is per-phase. Effectively negligible (3-7 phases), but tidier as:
+
+```typescript
+const success = !verifierPassedSsot
+  ? Object.entries(phaseOutputs).every(([name, output]) => phasePassed(name, output))
+  : Object.entries(phaseOutputs).every(([name, output]) => {
+      if (name === gateName) return true;
+      return phasePassed(name, output);
+    });
+```
+
+Or just leave it — the readability cost of the branch isn't worth saving 3 calls per run.
+
+---
+
+#### STYLE-3: `logger?.warn` in SSOT carve-out missing `packageDir`
+**Severity:** LOW | **Category:** Best Practice
+
+Per `.claude/rules/project-conventions.md` (Structured Log Fields), pipeline-stage logs should include `storyId` (✓) and, where cross-package work is happening, `packageDir`. The new warn line in `story-orchestrator.ts:485-491` only includes `storyId`. For consistency with neighbour code, add `packageDir: this.ctx.packageDir`.
+
+The convention rule is *"applies to `src/pipeline/stages/` and `src/review/`"* — `src/execution/` isn't explicitly named, so this is technically advisory rather than required. Worth following anyway for parallel-run log correlation.
+
+---
+
+#### ENH-1: New SSOT test coverage doesn't exercise gate-pass + verifier-pass
+**Severity:** LOW | **Category:** Enhancement
+
+The two new tests in `test/unit/execution/story-orchestrator.test.ts:862-918` cover:
+1. Gate fail + verifier pass → success=true (SSOT)
+2. Gate fail + verifier fail → success=false
+
+Missing: gate pass + verifier pass → success=true (sanity check that SSOT carve-out doesn't accidentally invert the happy path). It's effectively covered by other tests in the file but worth an explicit case for the SSOT describe block.
+
+---
+
+#### ENH-2: BUG-2 + BUG-1 hint at a deeper API smell
+**Severity:** LOW | **Category:** Enhancement
+
+`verifyTestWriterIsolation` has 5 positional params with defaults. The recent additions (lite mode + ceiling const) push toward the "function with 5+ positional params" anti-pattern. If a third mode lands or the ceiling becomes per-call, refactor to an options object:
+
+```typescript
+verifyTestWriterIsolation({
+  workdir,
+  beforeRef,
+  allowedPaths?,
+  testFilePatterns?,
+  mode?,
+  stubLineCeiling?,
+})
+```
+
+Not urgent — current 5 params with defaults still readable.
+
+---
+
+## Priority Fix Order
+
+| Priority | ID | Effort | Description |
+|:---|:---|:---|:---|
+| P0 | BUG-1 | S | Thread lite-mode through `runIsolationGuard` → `autofix-cycle.ts` |
+| P1 | BUG-2 | S | Tighten SSOT carve-out to require explicit `success === true \|\| passed === true` |
+| P2 | STYLE-1 | XS | Omit undefined keys in the new diagnostic log |
+| P3 | STYLE-3 | XS | Add `packageDir` to SSOT warn line |
+| P4 | ENH-1 | XS | Add gate-pass + verifier-pass sanity test |
+| P5 | STYLE-2 | XS | Optional: hoist `verifierPassedSsot` branch out of the `every()` lambda |
+| P6 | ENH-2 | M | Defer until a third lite-mode tunable surfaces |
+
+P0 and P1 are real fixes worth a follow-up branch. P2-P5 are polish that can ride along on that branch.
+
+---
+
+## What's strong
+
+- The SSOT semantic is consistently applied across `story-orchestrator.ts` (aggregation) and `post-run.ts` (`deriveTddFailureCategory`) — no asymmetric trust model.
+- Lite-mode change is opt-in (default `"strict"`) — no breaking impact on strict callers.
+- `LITE_STUB_ADDED_LINES_CEILING` is exported, named, and the rationale (≤3 lines per stub + headroom) is documented at the constant.
+- The added warn lines on the SSOT carve-out and uncategorized failures are *future-debugging gifts* — the next time this surface misbehaves, the operator gets data instead of a silent pause.
+- Test updates correctly distinguish "gate failed but verifier passed" (new SSOT contract) from "gate AND verifier failed" (preserve original intent).
+- `getAddedLinesPerFile` correctly handles binary diff `-` markers via `Number.isFinite`.
+- Numstat parser uses `_isolationDeps.spawn` so the new fetch is testable without touching globals.
+
+---
+
+## Recommended next steps
+
+1. Create a follow-up branch `fix/tdd-isolation-autofix-mode-thread` covering BUG-1 + BUG-2 + STYLE-1 + STYLE-3 + ENH-1.
+2. After merge, re-run the rs-stock scenario one more time — the verifier-SSOT carve-out should now correctly handle the gate-fail + verifier-pass case.
+3. Open an issue for ENH-2 (`verifyTestWriterIsolation` options-object refactor) only if a third lite-mode tunable lands.

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -281,14 +281,17 @@ export async function applyPostRunInspection(
   // success/passed signals so we can attribute the failure post-mortem instead of
   // staring at a silent log line.
   if (isTdd && !planResult.success && !failureCategory) {
-    const phaseSignals: Record<string, { success?: boolean; passed?: boolean }> = {};
+    const phaseSignals: Record<string, Record<string, boolean>> = {};
     for (const [name, output] of Object.entries(planResult.phaseOutputs)) {
       if (output && typeof output === "object") {
         const r = output as Record<string, unknown>;
-        phaseSignals[name] = {
-          success: typeof r.success === "boolean" ? r.success : undefined,
-          passed: typeof r.passed === "boolean" ? r.passed : undefined,
-        };
+        const signal: Record<string, boolean> = {};
+        if (typeof r.success === "boolean") signal.success = r.success;
+        if (typeof r.passed === "boolean") signal.passed = r.passed;
+        // Omit keys when neither boolean is present so the log distinguishes
+        // "phase emitted no clear signal" (entry value `{}`) from a real
+        // success/fail boolean.
+        phaseSignals[name] = signal;
       }
     }
     logger.warn("execution", "TDD plan failed but no failure category derived — defaulting to pause", {

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -139,6 +139,19 @@ function collectOrderedPhases(state: InternalBuildState): InternalPhase[] {
   });
 }
 
+/**
+ * Stricter variant of `phasePassed` for SSOT carve-out logic. Where `phasePassed`
+ * defensively treats missing/undefined/non-object outputs as "passed" (to avoid
+ * fail-closing on ops that don't conform to the envelope), this requires an
+ * affirmative `success === true` or `passed === true`. SSOT semantics ("verifier
+ * judged this OK") must not trigger off a malformed envelope.
+ */
+function phaseExplicitlyPassed(output: unknown): boolean {
+  if (output === null || output === undefined || typeof output !== "object") return false;
+  const r = output as Record<string, unknown>;
+  return r.success === true || r.passed === true;
+}
+
 function phasePassed(opName: string, output: unknown): boolean {
   if (output === null || output === undefined) {
     getSafeLogger()?.warn("story-orchestrator", "Phase produced no output — treating as pass", {
@@ -478,15 +491,14 @@ export class ExecutionPlan {
     // diagnostics; rectification (when configured) still consumes its findings.
     const verifierName = this.state.verifier?.slot.op.name;
     const gateName = this.state.fullSuiteGate?.slot.op.name;
-    const verifierPassedSsot =
-      verifierName !== undefined &&
-      phaseOutputs[verifierName] !== undefined &&
-      phasePassed(verifierName, phaseOutputs[verifierName]);
+    // SSOT requires an explicit pass — see `phaseExplicitlyPassed` for why we
+    // don't use the defensive `phasePassed` here.
+    const verifierPassedSsot = verifierName !== undefined && phaseExplicitlyPassed(phaseOutputs[verifierName]);
     if (verifierPassedSsot && gateName !== undefined && !phasePassed(gateName, phaseOutputs[gateName])) {
       logger?.warn(
         "story-orchestrator",
         "Full-suite gate failed but verifier judged story OK — treating gate failures as unrelated regressions",
-        { storyId: this.ctx.storyId },
+        { storyId: this.ctx.storyId, packageDir: this.ctx.packageDir },
       );
     }
     const success = Object.entries(phaseOutputs).every(([name, output]) => {

--- a/src/pipeline/stages/autofix-cycle.ts
+++ b/src/pipeline/stages/autofix-cycle.ts
@@ -505,6 +505,7 @@ export async function runAgentRectificationV2(
         beforeRef,
         ctx.config,
         ctx.story.workdir || undefined,
+        ctx.routing?.testStrategy === "three-session-tdd-lite" ? "lite" : "strict",
       );
       if (isolationResult.violated) {
         await _autofixCycleGuardDeps.revertDiff(ctx.workdir, isolationResult.files);

--- a/src/pipeline/stages/autofix-guards.ts
+++ b/src/pipeline/stages/autofix-guards.ts
@@ -81,12 +81,17 @@ export type IsolationGuardResult = { violated: true; files: string[] } | { viola
 /**
  * Runs verifyTestWriterIsolation unless enforceTestWriterIsolation is false.
  * Returns violated with the list of offending files, or skipped when disabled.
+ *
+ * `mode` mirrors the test-writer prompt contract: `"lite"` lets stub-sized src/
+ * writes ride as soft violations to match the three-session-tdd-lite prompt;
+ * `"strict"` (default) is the three-session-tdd contract.
  */
 export async function runIsolationGuard(
   workdir: string,
   beforeRef: string,
   config: NaxConfig,
   packageDir?: string,
+  mode: "strict" | "lite" = "strict",
 ): Promise<IsolationGuardResult> {
   if (config.quality.autofix?.enforceTestWriterIsolation === false) {
     return { violated: false, skipped: true };
@@ -98,6 +103,7 @@ export async function runIsolationGuard(
     beforeRef,
     config.tdd?.testWriterAllowedPaths,
     resolved.globs,
+    mode,
   );
 
   if (!result.passed) {

--- a/test/unit/execution/story-orchestrator.test.ts
+++ b/test/unit/execution/story-orchestrator.test.ts
@@ -890,6 +890,73 @@ describe("AC-6: short-circuit carve-out for gate + verifier when rectification c
     }
   });
 
+  test("happy path: gate-pass + verifier-pass → success=true (SSOT carve-out does not invert)", async () => {
+    // Sanity: the SSOT carve-out must not accidentally invert success when both
+    // gate and verifier passed — that is the normal happy path.
+    const config = makeNaxConfig();
+    rt = makeTestRuntime({ config });
+
+    const gateOp = makeDeterministicOp("full-suite-gate", { success: true });
+    const verOp = makeDeterministicOp("verifier", { success: true });
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.callOp = async (_ctx: any, op: any, input: any) => {
+      if (op.kind === "deterministic") return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    };
+
+    try {
+      const ctx: CallContext = { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-t" } as any;
+      const plan = new (require("@/execution/story-orchestrator").StoryOrchestratorBuilder)()
+        .addImplementer({ op: mockImplementerOp, input: { code: "" } })
+        .addFullSuiteGate({ op: gateOp, input: { story: { id: "US-t" } as any, workdir: "/tmp" } })
+        .addVerifier({ op: verOp, input: { code: "" } })
+        .build(ctx);
+      const result = await plan.run();
+      expect(result.success).toBe(true);
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+    }
+  });
+
+  test("SSOT requires EXPLICIT verifier pass — output without success/passed keys does NOT trigger carve-out", async () => {
+    // Defensive: a verifier op that produces a malformed envelope (no success or
+    // passed key) must not silently pass the story. SSOT means "verifier
+    // explicitly judged this OK", not "verifier produced something parseable".
+    const config = makeNaxConfig();
+    rt = makeTestRuntime({ config });
+
+    const gateOp = makeDeterministicOp("full-suite-gate", { success: false, findings: [] });
+    // Malformed verifier output — neither `success` nor `passed` set.
+    const malformedVerifierOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG> = {
+      kind: "deterministic",
+      name: "verifier",
+      stage: "verify",
+      config: testSel,
+      execute: async () => ({ filesChanged: [], estimatedCostUsd: 0 }),
+    };
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.callOp = async (_ctx: any, op: any, input: any) => {
+      if (op.kind === "deterministic") return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    };
+
+    try {
+      const ctx: CallContext = { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-t" } as any;
+      const plan = new (require("@/execution/story-orchestrator").StoryOrchestratorBuilder)()
+        .addImplementer({ op: mockImplementerOp, input: { code: "" } })
+        .addFullSuiteGate({ op: gateOp, input: { story: { id: "US-t" } as any, workdir: "/tmp" } })
+        .addVerifier({ op: malformedVerifierOp, input: { code: "" } })
+        .build(ctx);
+      const result = await plan.run();
+      // Gate explicitly failed AND verifier didn't explicitly pass → plan fails.
+      expect(result.success).toBe(false);
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+    }
+  });
+
   test("verifier-failed: gate failure still fails the plan (no SSOT override)", async () => {
     // Verifier-as-SSOT only applies when verifier passed. If verifier also failed,
     // aggregation must reflect both failures.

--- a/test/unit/pipeline/stages/autofix-guards.test.ts
+++ b/test/unit/pipeline/stages/autofix-guards.test.ts
@@ -238,6 +238,30 @@ describe("runIsolationGuard — spec-correct behavior (AC4, AC5)", () => {
 		// Call succeeds with optional packageDir
 		expect(result.violated).toBe(false);
 	});
+
+	test("threads mode='lite' through to verifyTestWriterIsolation (BUG-1 from code review)", async () => {
+		// Without this thread-through, autofix's test-writer rectification path
+		// would re-introduce the strict-isolation violation for lite-mode stories.
+		let receivedMode: string | undefined;
+		_guardDeps.verifyTestWriterIsolation = mock(async (_w, _r, _allow, _pat, mode) => {
+			receivedMode = mode;
+			return { passed: true, violations: [], description: "" };
+		}) as typeof _guardDeps.verifyTestWriterIsolation;
+		const config = makeNaxConfig();
+		await runIsolationGuard("/workdir", "abc123", config, "packages/lib", "lite");
+		expect(receivedMode).toBe("lite");
+	});
+
+	test("defaults mode to 'strict' when caller omits the argument", async () => {
+		let receivedMode: string | undefined;
+		_guardDeps.verifyTestWriterIsolation = mock(async (_w, _r, _allow, _pat, mode) => {
+			receivedMode = mode;
+			return { passed: true, violations: [], description: "" };
+		}) as typeof _guardDeps.verifyTestWriterIsolation;
+		const config = makeNaxConfig();
+		await runIsolationGuard("/workdir", "abc123", config);
+		expect(receivedMode).toBe("strict");
+	});
 });
 
 // ─── revertDiff — spec-correct git command ────────────────────────────────────


### PR DESCRIPTION
## Summary

Code review of the two recent TDD-fix commits (`ff640e6b` via PR #1079 and `c668be23` direct-to-main) surfaced two real bugs and a few polish items. Full review is committed at `docs/20260523-review-tdd-fixes.md`. This PR addresses **P0 + P1 + P2 + P3 + ENH-1**.

### BUG-1 (MEDIUM): lite-mode flag not threaded through autofix's test-writer rectification

`runIsolationGuard` in `src/pipeline/stages/autofix-guards.ts` defaulted to `mode: "strict"` regardless of the story's `routing.testStrategy`. So a lite-mode story that hit autofix's test-writer rectification path (which is also conceptually a "test-writer" role) would re-trigger the strict-isolation violation that `ff640e6b` fixed for the initial phase.

Fix: extend `runIsolationGuard` to accept `mode: "strict" | "lite"`. `autofix-cycle.ts:503` threads `ctx.routing?.testStrategy === "three-session-tdd-lite" ? "lite" : "strict"`. Strict is the default — backward compatible.

### BUG-2 (MEDIUM): SSOT carve-out trusted `phasePassed`'s fallback-to-true

`phasePassed` defensively returns `true` for outputs with neither `success` nor `passed` key (and for non-object outputs). That meant a malformed verifier envelope silently triggered the verifier-as-SSOT carve-out and dismissed gate failures — exactly the opposite of "verifier explicitly judged this OK."

Fix: added `phaseExplicitlyPassed` that requires an affirmative `success === true || passed === true`. SSOT now needs a real verifier verdict, not just a parseable envelope. The defensive `phasePassed` stays put for the per-phase aggregation; SSOT just uses the stricter version.

### STYLE-1: post-run diagnostic dropped undefined values at serialization

The new diagnostic in `c668be23` built `{ success: undefined, passed: undefined }` per phase. JSON.stringify drops `undefined` keys, so the log artifact was `{}` for a phase with no boolean — indistinguishable from "I logged nothing." Now omits keys when neither boolean is present so `{}` carries the explicit "no signal" meaning.

### STYLE-3: missing `packageDir` in SSOT warn line

Per `.claude/rules/project-conventions.md` (Structured Log Fields), pipeline logs include `packageDir` for parallel-run correlation. Added.

### ENH-1: sanity tests for SSOT corner cases

Two new cases in `test/unit/execution/story-orchestrator.test.ts`:
- gate-pass + verifier-pass → `success=true` (happy-path non-inversion check)
- verifier output without `success`/`passed` keys → `success=false` (SSOT requires explicit pass)

Two new cases in `test/unit/pipeline/stages/autofix-guards.test.ts`:
- `runIsolationGuard("lite")` threads `mode` through to `verifyTestWriterIsolation`
- omitted `mode` defaults to `"strict"`

## What's not in this PR

- **ENH-2** (`verifyTestWriterIsolation` options-object refactor) — deferred until a third lite-mode tunable surfaces. Five positional params with defaults are still readable.
- **STYLE-2** (`verifierPassedSsot` computed twice) — leaving as-is. The readability cost of branching the aggregation isn't worth saving 3-7 lambda calls per run.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] 2507 pass / 3 skip / 0 fail across execution + tdd + verification + operations + pipeline + integration suites
- [x] Two new isolation-guard cases (lite thread / strict default)
- [x] Two new story-orchestrator cases (happy path / explicit-pass requirement)
- [ ] Re-run the rs-stock scenario one more time after merge to confirm the verifier-SSOT carve-out behaves correctly end-to-end