### PR TITLE
fix(review): prefer structured mechanical findings in rectification prompts

### DIFF
--- a/src/operations/autofix-implementer.ts
+++ b/src/operations/autofix-implementer.ts
@@ -10,6 +10,7 @@ import type { RunOperation } from "./types";
 export interface AutofixImplementerInput {
   failedChecks: ReviewCheckResult[];
   story: UserStory;
+  blockingThreshold?: "error" | "warning" | "info";
 }
 
 export interface AutofixImplementerOutput {
@@ -27,7 +28,9 @@ export const implementerRectifyOp: RunOperation<AutofixImplementerInput, Autofix
   session: { role: "implementer", lifetime: "warm" },
   config: autofixConfigSelector,
   build(input, _ctx) {
-    const prompt = RectifierPromptBuilder.reviewRectification(input.failedChecks, input.story);
+    const prompt = RectifierPromptBuilder.reviewRectification(input.failedChecks, input.story, {
+      blockingThreshold: input.blockingThreshold,
+    });
     return {
       role: { id: "role", content: "", overridable: false },
       task: { id: "task", content: prompt, overridable: false },

--- a/src/pipeline/stages/autofix-cycle.ts
+++ b/src/pipeline/stages/autofix-cycle.ts
@@ -113,6 +113,7 @@ export function buildAutofixStrategies(
     buildInput: (_findings, _prior, _cycleCtx): AutofixImplementerInput => ({
       failedChecks: collectFailedChecks(ctx),
       story: ctx.story,
+      blockingThreshold: ctx.config.review?.blockingThreshold,
     }),
     extractApplied: (output) => {
       const decls = output.testEditDeclarations ?? [];

--- a/src/prompts/builders/rectifier-builder-helpers.ts
+++ b/src/prompts/builders/rectifier-builder-helpers.ts
@@ -6,8 +6,13 @@
  */
 
 import type { UserStory } from "@/prd";
+import { isBlockingSeverity } from "@/review";
 import type { ReviewCheckResult } from "@/review/types";
 import { buildIsolationSection } from "../sections";
+
+interface CheckErrorFormatOptions {
+  blockingThreshold?: "error" | "warning" | "info";
+}
 
 /**
  * Reviewer contradiction escape hatch (REVIEW-003).
@@ -125,12 +130,59 @@ function noTestIsolationBlock(story: UserStory): string {
   return `\n\n${buildIsolationSection("no-test")}`;
 }
 
-export function formatCheckErrors(checks: ReviewCheckResult[]): string {
-  return checks.map((c) => `## ${c.check} errors (exit code ${c.exitCode})\n\`\`\`\n${c.output}\n\`\`\``).join("\n\n");
+export function formatCheckErrors(checks: ReviewCheckResult[], opts?: CheckErrorFormatOptions): string {
+  return checks.map((c) => formatCheckError(c, opts)).join("\n\n");
 }
 
-export function semanticRectification(checks: ReviewCheckResult[], story: UserStory, scopeConstraint: string): string {
-  const errors = formatCheckErrors(checks);
+const MAX_STRUCTURED_FINDINGS = 10;
+const RAW_WITH_FINDINGS_LIMIT = 1_000;
+const RAW_FALLBACK_LIMIT = 4_000;
+
+function capText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}\n... (truncated — ${value.length} chars total)`;
+}
+
+function formatFindingLine(finding: NonNullable<ReviewCheckResult["findings"]>[number]): string {
+  const location = typeof finding.line === "number" ? `${finding.file}:${finding.line}` : finding.file;
+  return `- [${finding.severity}] ${location} ${finding.rule ? `${finding.rule} ` : ""}— ${finding.message}`;
+}
+
+function formatCheckError(check: ReviewCheckResult, opts?: CheckErrorFormatOptions): string {
+  const lines: string[] = [`## ${check.check} errors (exit code ${check.exitCode})`];
+  const threshold = opts?.blockingThreshold ?? "error";
+  const blocking = (check.findings ?? []).filter((f) => isBlockingSeverity(f.severity, threshold));
+
+  if (blocking.length > 0) {
+    lines.push("Structured findings:");
+    for (const finding of blocking.slice(0, MAX_STRUCTURED_FINDINGS)) {
+      lines.push(formatFindingLine(finding));
+    }
+    const remaining = blocking.length - MAX_STRUCTURED_FINDINGS;
+    if (remaining > 0) {
+      lines.push(`...and ${remaining} more blocking findings`);
+    }
+    lines.push("");
+    lines.push("Raw output excerpt:");
+    lines.push("```");
+    lines.push(capText(check.output, RAW_WITH_FINDINGS_LIMIT));
+    lines.push("```");
+    return lines.join("\n");
+  }
+
+  lines.push("```");
+  lines.push(capText(check.output, RAW_FALLBACK_LIMIT));
+  lines.push("```");
+  return lines.join("\n");
+}
+
+export function semanticRectification(
+  checks: ReviewCheckResult[],
+  story: UserStory,
+  scopeConstraint: string,
+  opts?: CheckErrorFormatOptions,
+): string {
+  const errors = formatCheckErrors(checks, opts);
   const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
 
   return `You are fixing acceptance criteria compliance issues found during semantic review.
@@ -157,8 +209,9 @@ export function adversarialRectification(
   checks: ReviewCheckResult[],
   story: UserStory,
   scopeConstraint: string,
+  opts?: CheckErrorFormatOptions,
 ): string {
-  const errors = formatCheckErrors(checks);
+  const errors = formatCheckErrors(checks, opts);
   const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
 
   return `You are fixing issues found during an adversarial code review.
@@ -185,9 +238,10 @@ export function combinedLlmRectification(
   adversarialChecks: ReviewCheckResult[],
   story: UserStory,
   scopeConstraint: string,
+  opts?: CheckErrorFormatOptions,
 ): string {
-  const semanticErrors = formatCheckErrors(semanticChecks);
-  const adversarialErrors = formatCheckErrors(adversarialChecks);
+  const semanticErrors = formatCheckErrors(semanticChecks, opts);
+  const adversarialErrors = formatCheckErrors(adversarialChecks, opts);
   const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
 
   return `You are fixing issues found during LLM code review.
@@ -216,8 +270,9 @@ export function mechanicalRectification(
   checks: ReviewCheckResult[],
   story: UserStory,
   scopeConstraint: string,
+  opts?: CheckErrorFormatOptions,
 ): string {
-  const errors = formatCheckErrors(checks);
+  const errors = formatCheckErrors(checks, opts);
 
   return `You are fixing lint/typecheck errors from a code review.
 

--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -592,7 +592,11 @@ ${testCommands}
    *
    * Migrated from buildReviewRectificationPrompt() in src/pipeline/stages/autofix-prompts.ts.
    */
-  static reviewRectification(failedChecks: ReviewCheckResult[], story: UserStory): string {
+  static reviewRectification(
+    failedChecks: ReviewCheckResult[],
+    story: UserStory,
+    opts?: { blockingThreshold?: "error" | "warning" | "info" },
+  ): string {
     const scopeConstraint = story.workdir
       ? `\n\nIMPORTANT: Only modify files within \`${story.workdir}/\`. Do NOT touch files outside this directory.`
       : "";
@@ -605,29 +609,29 @@ ${testCommands}
 
     if (llmChecks.length > 0 && mechanicalChecks.length === 0) {
       if (adversarialChecks.length === 0) {
-        return semanticRectification(semanticChecks, story, scopeConstraint);
+        return semanticRectification(semanticChecks, story, scopeConstraint, opts);
       }
       if (semanticChecks.length === 0) {
-        return adversarialRectification(adversarialChecks, story, scopeConstraint);
+        return adversarialRectification(adversarialChecks, story, scopeConstraint, opts);
       }
       // Both semantic and adversarial failed — combined LLM reviewer prompt.
-      return combinedLlmRectification(semanticChecks, adversarialChecks, story, scopeConstraint);
+      return combinedLlmRectification(semanticChecks, adversarialChecks, story, scopeConstraint, opts);
     }
 
     if (mechanicalChecks.length > 0 && llmChecks.length === 0) {
-      return mechanicalRectification(mechanicalChecks, story, scopeConstraint);
+      return mechanicalRectification(mechanicalChecks, story, scopeConstraint, opts);
     }
 
     // Mixed: mechanical + one or more LLM reviewer checks.
-    const mechanicalSection = formatCheckErrors(mechanicalChecks);
+    const mechanicalSection = formatCheckErrors(mechanicalChecks, opts);
     const acList = story.acceptanceCriteria.map((ac, i) => `${i + 1}. ${ac}`).join("\n");
 
     const llmSection =
       semanticChecks.length > 0 && adversarialChecks.length > 0
-        ? `## Semantic Review Findings\n\n${formatCheckErrors(semanticChecks)}\n\n## Adversarial Review Findings\n\n${formatCheckErrors(adversarialChecks)}`
+        ? `## Semantic Review Findings\n\n${formatCheckErrors(semanticChecks, opts)}\n\n## Adversarial Review Findings\n\n${formatCheckErrors(adversarialChecks, opts)}`
         : semanticChecks.length > 0
-          ? `## Semantic Review Findings\n\n${formatCheckErrors(semanticChecks)}`
-          : `## Adversarial Review Findings\n\n${formatCheckErrors(adversarialChecks)}`;
+          ? `## Semantic Review Findings\n\n${formatCheckErrors(semanticChecks, opts)}`
+          : `## Adversarial Review Findings\n\n${formatCheckErrors(adversarialChecks, opts)}`;
 
     return `You are fixing issues from a code review.
 

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -18,6 +18,7 @@ import { resolveLanguageCommand } from "./language-commands";
 import { runScopedLintCheck } from "./scoped-lint";
 import { runSemanticReview as _runSemanticReviewImpl } from "./semantic";
 import type { SemanticStory } from "./semantic";
+import { parseTypecheckOutput } from "./typecheck-parsing";
 import type { ReviewCheckName, ReviewCheckResult, ReviewConfig, ReviewResult } from "./types";
 
 // Re-export for test compatibility
@@ -198,6 +199,18 @@ async function runCheck(
     output: result.output,
     durationMs: result.durationMs,
   };
+}
+
+function normalizeMechanicalFindings(
+  checkName: ReviewCheckName,
+  result: ReviewCheckResult,
+  workdir: string,
+): ReviewCheckResult {
+  if (result.success) return result;
+  if (checkName !== "typecheck") return result;
+  const parsed = parseTypecheckOutput(result.output, "auto", { workdir });
+  if (!parsed?.findings || parsed.findings.length === 0) return result;
+  return { ...result, findings: parsed.findings };
 }
 
 /**
@@ -444,7 +457,7 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
             env,
             naxIgnoreIndex,
           })
-        : await runCheck(checkName, command, workdir, storyId, env);
+        : normalizeMechanicalFindings(checkName, await runCheck(checkName, command, workdir, storyId, env), workdir);
     checks.push(result);
 
     // Track first failure

--- a/src/review/scoped-lint.ts
+++ b/src/review/scoped-lint.ts
@@ -191,6 +191,17 @@ function toReviewCheck(result: QualityCommandResult): ReviewCheckResult {
   };
 }
 
+function attachLintFindings(
+  result: ReviewCheckResult,
+  lintOutputFormat: LintOutputFormat | undefined,
+  workdir: string,
+): ReviewCheckResult {
+  if (result.success) return result;
+  const parsed = parseLintOutput(result.output, lintOutputFormat ?? "auto", { workdir });
+  if (!parsed?.findings || parsed.findings.length === 0) return result;
+  return { ...result, findings: parsed.findings };
+}
+
 function withLintScope(
   result: ReviewCheckResult,
   scope: ScopeResult,
@@ -218,7 +229,11 @@ export async function runScopedLintCheck(args: ScopedLintArgs): Promise<ReviewCh
         reason: scope.degradedReason,
       });
       const fullResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, fullLintCommand);
-      return withLintScope(toReviewCheck(fullResult), scope, "degraded");
+      return withLintScope(
+        attachLintFindings(toReviewCheck(fullResult), args.lintOutputFormat, args.workdir),
+        scope,
+        "degraded",
+      );
     }
     logger?.info("review", "lint_scope_empty", { storyId: args.storyId });
     return {
@@ -245,13 +260,13 @@ export async function runScopedLintCheck(args: ScopedLintArgs): Promise<ReviewCh
   if (scopedTemplate) {
     const scopedCommand = scopedTemplate.replaceAll("{{files}}", scope.files.map(shellQuotePath).join(" "));
     const scopedResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, scopedCommand);
-    return withLintScope(toReviewCheck(scopedResult), scope);
+    return withLintScope(attachLintFindings(toReviewCheck(scopedResult), args.lintOutputFormat, args.workdir), scope);
   }
 
   if (!scope.degradedReason && isSupportedDerivedScopedCommand(fullLintCommand)) {
     const scopedCommand = appendFilesToCommand(fullLintCommand, scope.files);
     const scopedResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, scopedCommand);
-    return withLintScope(toReviewCheck(scopedResult), scope);
+    return withLintScope(attachLintFindings(toReviewCheck(scopedResult), args.lintOutputFormat, args.workdir), scope);
   }
 
   // Degraded mode: run full lint then post-filter diagnostics to in-scope files.
@@ -304,6 +319,7 @@ export async function runScopedLintCheck(args: ScopedLintArgs): Promise<ReviewCh
       packageGroups: scope.packageGroups,
       outOfScopeDiagnosticCount: parsed.diagnostics.length - inScopeDiagnostics.length,
     },
+    findings: parsed.findings?.filter((f) => typeof f.file === "string" && scopedSet.has(normalizePath(f.file))),
   };
 }
 

--- a/test/unit/prompts/builders/rectifier-builder-review-labels.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder-review-labels.test.ts
@@ -184,4 +184,79 @@ describe("RectifierPromptBuilder.reviewRectification — mechanical-only regress
     expect(prompt).not.toContain("semantic review");
     expect(prompt.toLowerCase()).not.toContain("adversarial review findings");
   });
+
+  test("renders structured findings before raw output for mechanical checks", () => {
+    const checks: ReviewCheckResult[] = [
+      {
+        ...makeCheck("lint", "src/foo.ts:1:1 raw lint line"),
+        findings: [
+          {
+            ruleId: "lint/rule",
+            severity: "error",
+            file: "src/foo.ts",
+            line: 1,
+            message: "Structured lint issue",
+            source: "lint",
+          },
+        ],
+      },
+    ];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+
+    const structuredIdx = prompt.indexOf("Structured findings:");
+    const rawIdx = prompt.indexOf("Raw output excerpt:");
+    expect(structuredIdx).toBeGreaterThan(-1);
+    expect(rawIdx).toBeGreaterThan(-1);
+    expect(structuredIdx).toBeLessThan(rawIdx);
+  });
+
+  test("caps raw output excerpt when structured findings exist", () => {
+    const hugeOutput = `{${"x".repeat(10_000)}}`;
+    const checks: ReviewCheckResult[] = [
+      {
+        ...makeCheck("lint", hugeOutput),
+        findings: [
+          {
+            ruleId: "lint/rule",
+            severity: "error",
+            file: "src/foo.ts",
+            line: 1,
+            message: "Structured lint issue",
+            source: "lint",
+          },
+        ],
+      },
+    ];
+    const prompt = RectifierPromptBuilder.reviewRectification(checks, STORY);
+    expect(prompt).toContain("truncated");
+    const xCount = (prompt.match(/x/g) ?? []).length;
+    expect(xCount).toBeLessThan(10_000);
+  });
+
+  test("uses blockingThreshold mapping for structured findings", () => {
+    const checks: ReviewCheckResult[] = [
+      {
+        ...makeCheck("semantic", "raw semantic output"),
+        findings: [
+          {
+            ruleId: "semantic/rule",
+            severity: "warning",
+            file: "src/foo.ts",
+            line: 12,
+            message: "Warning-level finding",
+            source: "semantic-review",
+          },
+        ],
+      },
+    ];
+
+    const promptDefault = RectifierPromptBuilder.reviewRectification(checks, STORY);
+    expect(promptDefault).not.toContain("Structured findings:");
+
+    const promptWarning = RectifierPromptBuilder.reviewRectification(checks, STORY, {
+      blockingThreshold: "warning",
+    });
+    expect(promptWarning).toContain("Structured findings:");
+    expect(promptWarning).toContain("Warning-level finding");
+  });
 });

--- a/test/unit/review/runner.test.ts
+++ b/test/unit/review/runner.test.ts
@@ -113,6 +113,46 @@ describe("runReview — scoped lint integration", () => {
   });
 });
 
+describe("runReview — typecheck findings normalization", () => {
+  const originalGetUncommittedFiles = _deps.getUncommittedFiles;
+  const originalSpawn = _runnerDeps.spawn;
+
+  afterEach(() => {
+    mock.restore();
+    _deps.getUncommittedFiles = originalGetUncommittedFiles;
+    _runnerDeps.spawn = originalSpawn;
+  });
+
+  test("attaches structured findings when typecheck output is parseable", async () => {
+    _deps.getUncommittedFiles = mock(async () => []);
+    const toStream = (text: string): ReadableStream => {
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(text));
+          controller.close();
+        },
+      });
+    };
+    _runnerDeps.spawn = mock((_args: unknown) => {
+      return {
+        exited: Promise.resolve(1),
+        stdout: toStream("src/index.ts(10,3): error TS2304: Cannot find name 'foo'\nFound 1 error in 1 file."),
+        stderr: toStream(""),
+        kill: () => {},
+      } as unknown as ReturnType<typeof Bun.spawn>;
+    });
+
+    const result = await runReview({
+      config: { enabled: true, checks: ["typecheck"], commands: { typecheck: "bun run typecheck" } },
+      workdir: "/tmp/fake-workdir",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.checks[0]?.findings?.length).toBe(1);
+    expect(result.checks[0]?.findings?.[0]?.file).toContain("src/index.ts");
+  });
+});
+
 describe("nax runtime file exclusions", () => {
   let originalGetUncommittedFiles: typeof _deps.getUncommittedFiles;
 

--- a/test/unit/review/scoped-lint.test.ts
+++ b/test/unit/review/scoped-lint.test.ts
@@ -177,6 +177,7 @@ describe("runScopedLintCheck", () => {
     expect(result.output).not.toContain("src/out.ts");
     expect(result.lintScope?.status).toBe("in_scope");
     expect(result.lintScope?.outOfScopeDiagnosticCount).toBe(1);
+    expect(result.findings?.every((f) => f.file.includes("src/in.ts"))).toBe(true);
   });
 
   test("degraded mode fails closed when lint output is unparseable", async () => {
@@ -228,5 +229,29 @@ describe("runScopedLintCheck", () => {
     expect(result.lintScope?.status).toBe("out_of_scope");
     expect(result.lintScope?.packageGroups).toEqual([{ packageDir: "packages/api", files: ["packages/api/src/in.ts"] }]);
     expect(result.output).toContain("out of story scope");
+  });
+
+  test("attaches findings for failing scoped lint results when output is parseable", async () => {
+    _scopedLintDeps.runLintCommand = mock(async (_workdir, _storyId, _env, command) => ({
+      command,
+      success: false,
+      exitCode: 1,
+      output: "src/alpha.ts:10:4 Unexpected console statement",
+      durationMs: 7,
+    }));
+
+    const result = await runScopedLintCheck({
+      resolvedLintCommand: "custom-lint",
+      configCommands: { ...baseReviewConfig.commands, lintScoped: "custom-lint {{files}}" },
+      lintOutputFormat: "text",
+      qualityCommands: {},
+      workdir: "/repo",
+      storyId: "US-001",
+      storyGitRef: "abc123",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.findings?.length).toBeGreaterThan(0);
+    expect(result.findings?.[0]?.file).toContain("src/alpha.ts");
   });
 });


### PR DESCRIPTION
## Summary
- normalize failing mechanical checks to carry structured findings:
  - attach lint findings in scoped/degraded lint paths
  - attach typecheck findings in review runner
- make rectification prompt rendering findings-first with bounded raw-output fallback
- thread blockingThreshold into implementer review rectification so blocking mapping stays consistent for error, warning, and info
- preserve safe fallback behavior for unparseable/unstructured outputs

## Tests
- bun run lint
- bun run typecheck
- bun run test

All passing in the worktree.