### PR TITLE
fix(review): restore unified review logging

### DIFF
--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -253,12 +253,7 @@ function toReviewDecisionPayload(opName: string, output: unknown): ReviewDecisio
   if (output === null || output === undefined || typeof output !== "object") return null;
   const record = output as Record<string, unknown>;
 
-  const reviewer =
-    opName === "semantic-review"
-      ? "semantic"
-      : opName === "adversarial-review"
-        ? "adversarial"
-        : null;
+  const reviewer = opName === "semantic-review" ? "semantic" : opName === "adversarial-review" ? "adversarial" : null;
   if (!reviewer) return null;
 
   if (record.failOpen === true) {

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -75,6 +75,22 @@ type PhaseKind =
   | "typecheck-check"
   | "semantic-review"
   | "adversarial-review";
+
+type ReviewDecisionPayload =
+  | {
+      reviewer: "semantic" | "adversarial";
+      parsed: true;
+      passed: boolean;
+      result: { passed: boolean; findings: unknown[] };
+    }
+  | {
+      reviewer: "semantic" | "adversarial";
+      parsed: false;
+      passed?: boolean;
+      failOpen?: boolean;
+      looksLikeFail?: boolean;
+      result: null;
+    };
 // biome-ignore lint/suspicious/noExplicitAny: heterogeneous slot list is intentionally erased internally
 type AnySlot = { op: RunOperation<any, any, any> | DeterministicOperation<any, any, any>; input: unknown };
 
@@ -233,6 +249,95 @@ function collectRectificationPhases(state: InternalBuildState): InternalPhase[] 
   ].filter((phase): phase is InternalPhase => phase !== undefined);
 }
 
+function toReviewDecisionPayload(opName: string, output: unknown): ReviewDecisionPayload | null {
+  if (output === null || output === undefined || typeof output !== "object") return null;
+  const record = output as Record<string, unknown>;
+
+  const reviewer =
+    opName === "semantic-review"
+      ? "semantic"
+      : opName === "adversarial-review"
+        ? "adversarial"
+        : null;
+  if (!reviewer) return null;
+
+  if (record.failOpen === true) {
+    return { reviewer, parsed: false, passed: true, failOpen: true, result: null };
+  }
+  if (record.looksLikeFail === true) {
+    return { reviewer, parsed: false, passed: false, looksLikeFail: true, result: null };
+  }
+
+  if (typeof record.passed !== "boolean" || !Array.isArray(record.findings)) {
+    return null;
+  }
+
+  return {
+    reviewer,
+    parsed: true,
+    passed: record.passed,
+    result: { passed: record.passed, findings: record.findings },
+  };
+}
+
+function emitReviewDecision(ctx: CallContext, opName: string, output: unknown): void {
+  const payload = toReviewDecisionPayload(opName, output);
+  if (!payload) return;
+
+  ctx.runtime.dispatchEvents.emitReviewDecision({
+    kind: "review-decision",
+    runId: ctx.runtime.runId,
+    reviewer: payload.reviewer,
+    workdir: ctx.packageDir,
+    projectDir: ctx.runtime.projectDir,
+    outputDir: ctx.runtime.outputDir,
+    storyId: ctx.storyId,
+    featureName: ctx.featureName,
+    timestamp: Date.now(),
+    parsed: payload.parsed,
+    looksLikeFail: payload.parsed ? undefined : payload.looksLikeFail,
+    failOpen: payload.parsed ? false : payload.failOpen,
+    passed: payload.passed,
+    result: payload.result,
+  });
+}
+
+function logUnifiedReviewPhaseStart(storyId: string | undefined, opName: string): void {
+  const logger = getSafeLogger();
+  if (opName === "semantic-review") {
+    logger?.info("review", "Running semantic check", { storyId });
+  } else if (opName === "adversarial-review") {
+    logger?.info("review", "Running adversarial check", { storyId });
+  }
+}
+
+function logUnifiedReviewPhaseResult(storyId: string | undefined, opName: string, output: unknown): void {
+  const logger = getSafeLogger();
+  const payload = toReviewDecisionPayload(opName, output);
+  if (!payload) return;
+
+  if (!payload.parsed) {
+    if (payload.failOpen) {
+      logger?.warn("review", `${payload.reviewer} review fail-open`, { storyId });
+    } else if (payload.looksLikeFail) {
+      logger?.warn("review", `${payload.reviewer} review returned truncated failure`, { storyId });
+    }
+    return;
+  }
+
+  const findingsCount = payload.result.findings.length;
+  const title = payload.reviewer === "semantic" ? "Semantic review" : "Adversarial review";
+
+  if (payload.passed) {
+    logger?.info("review", `${title} passed`, { storyId });
+  } else {
+    logger?.warn("review", `${title} failed: ${findingsCount} findings`, {
+      storyId,
+      findingsCount,
+    });
+  }
+}
+
 async function runPhase(
   ctx: CallContext,
   slot: AnySlot,
@@ -259,12 +364,15 @@ async function runPhase(
   } else if (isThreeSession && opName === "full-suite-gate") {
     logger?.info("tdd", "-> Running full test suite gate (before Verifier)", { storyId: ctx.storyId });
   }
+  logUnifiedReviewPhaseStart(ctx.storyId, opName);
 
   const phaseStartedAt = Date.now();
   const scope = ctx.runtime.costAggregator.openScope();
   try {
     const output = await _storyOrchestratorDeps.callOp({ ...ctx, scopeId: scope.scopeId }, slot.op, dispatchInput);
     phaseOutputs[opName] = output;
+    emitReviewDecision(ctx, opName, output);
+    logUnifiedReviewPhaseResult(ctx.storyId, opName, output);
 
     // Post-phase logs (TDD phases only).
     if (isTddPhase) {

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -42,6 +42,7 @@ export type {
   CompleteDispatchEvent,
   DispatchErrorEvent,
   OperationCompletedEvent,
+  ReviewDecisionEvent,
 } from "./dispatch-events";
 export { DispatchEventBus } from "./dispatch-events";
 export type {

--- a/test/unit/execution/story-orchestrator-logs.test.ts
+++ b/test/unit/execution/story-orchestrator-logs.test.ts
@@ -275,4 +275,126 @@ describe("StoryOrchestrator runPhase — log emission", () => {
     expect(logs.some((l) => l.stage === "tdd" && l.msg === "Session complete: implementer")).toBe(false);
     expect(logs.some((l) => l.stage === "tdd" && l.msg === "Isolation maintained")).toBe(false);
   });
+
+  test("emits review-decision events for unified semantic review phases", async () => {
+    const { StoryOrchestratorBuilder } = await import("@/execution");
+    const { implementerOp, semanticReviewOp } = await import("@/operations");
+
+    _storyOrchestratorDeps.callOp = (async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "semantic-review") {
+        return { passed: false, findings: [{ issue: "missing acceptance criterion" }] };
+      }
+      return {
+        success: true,
+        filesChanged: ["src/foo.ts"],
+        estimatedCostUsd: 0,
+        durationMs: 0,
+        output: "",
+      };
+    }) as typeof _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.captureGitRef = async () => "abc1234";
+
+    const runtime = makeTestRuntime();
+    const received: Array<import("@/runtime/dispatch-events").ReviewDecisionEvent> = [];
+    const off = runtime.dispatchEvents.onReviewDecision((event) => received.push(event));
+
+    try {
+      const builder = new StoryOrchestratorBuilder();
+      builder.addImplementer({ op: implementerOp, input: { story: { id: "US-001" } as any } });
+      builder.addSemanticReview({
+        op: semanticReviewOp,
+        input: {
+          workdir: "/tmp/x",
+          story: { id: "US-001" } as any,
+          semanticConfig: { model: "balanced", timeoutMs: 1_000 },
+          mode: "ref",
+        },
+      });
+      const plan = builder.build({
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: "/tmp/x",
+        agentName: "claude",
+        storyId: "US-001",
+        featureName: "feat-a",
+      });
+
+      await plan.run();
+    } finally {
+      off();
+      await runtime.close();
+    }
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      kind: "review-decision",
+      reviewer: "semantic",
+      storyId: "US-001",
+      featureName: "feat-a",
+      parsed: true,
+      passed: false,
+      result: { passed: false, findings: [{ issue: "missing acceptance criterion" }] },
+    });
+  });
+
+  test("logs semantic review start and failure in unified execution path", async () => {
+    const { StoryOrchestratorBuilder } = await import("@/execution");
+    const { implementerOp, semanticReviewOp } = await import("@/operations");
+
+    _storyOrchestratorDeps.callOp = (async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "semantic-review") {
+        return { passed: false, findings: [{ issue: "missing acceptance criterion" }] };
+      }
+      return {
+        success: true,
+        filesChanged: ["src/foo.ts"],
+        estimatedCostUsd: 0,
+        durationMs: 0,
+        output: "",
+      };
+    }) as typeof _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.captureGitRef = async () => "abc1234";
+
+    const logs: Array<{ stage: string; msg: string; data?: any }> = [];
+    const logger = getSafeLogger();
+    const origInfo = logger!.info;
+    const origWarn = logger!.warn;
+    logger!.info = ((stage: string, msg: string, data?: unknown) => {
+      logs.push({ stage, msg, data });
+    }) as any;
+    logger!.warn = ((stage: string, msg: string, data?: unknown) => {
+      logs.push({ stage, msg, data });
+    }) as any;
+
+    const runtime = makeTestRuntime();
+    try {
+      const builder = new StoryOrchestratorBuilder();
+      builder.addImplementer({ op: implementerOp, input: { story: { id: "US-001" } as any } });
+      builder.addSemanticReview({
+        op: semanticReviewOp,
+        input: {
+          workdir: "/tmp/x",
+          story: { id: "US-001" } as any,
+          semanticConfig: { model: "balanced", timeoutMs: 1_000 },
+          mode: "ref",
+        },
+      });
+      const plan = builder.build({
+        runtime,
+        packageView: runtime.packages.repo(),
+        packageDir: "/tmp/x",
+        agentName: "claude",
+        storyId: "US-001",
+      });
+
+      await plan.run();
+    } finally {
+      logger!.info = origInfo;
+      logger!.warn = origWarn;
+      await runtime.close();
+    }
+
+    expect(logs.some((l) => l.stage === "review" && l.msg === "Running semantic check")).toBe(true);
+    expect(logs.some((l) => l.stage === "review" && l.msg === "Semantic review failed: 1 findings")).toBe(true);
+  });
 });

--- a/test/unit/execution/story-orchestrator-logs.test.ts
+++ b/test/unit/execution/story-orchestrator-logs.test.ts
@@ -295,7 +295,7 @@ describe("StoryOrchestrator runPhase — log emission", () => {
     _storyOrchestratorDeps.captureGitRef = async () => "abc1234";
 
     const runtime = makeTestRuntime();
-    const received: Array<import("@/runtime/dispatch-events").ReviewDecisionEvent> = [];
+    const received: Array<import("@/runtime").ReviewDecisionEvent> = [];
     const off = runtime.dispatchEvents.onReviewDecision((event) => received.push(event));
 
     try {


### PR DESCRIPTION
## Summary
- restore semantic and adversarial review logging from the unified story orchestrator path
- emit review-decision events for unified semantic and adversarial phases so existing audit subscribers still work
- add regression tests covering unified review events and logs

## Context
This regression was introduced by commit f38aedf216800cea9f0490bb3eca6b6663e34917, which moved review execution into StoryOrchestrator and bypassed the older review wrappers that emitted these logs.

## Testing
- bun test test/unit/execution/story-orchestrator-logs.test.ts test/unit/runtime/middleware/logging.test.ts --timeout=30000
