### PR TITLE
[codex] fix TDD semantic rollback gating

### DIFF
--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -72,10 +72,7 @@ export const _postRunDeps = {
   autoCommitIfDirty,
 };
 
-function shouldRollbackTddFailure(
-  tddMode: TddMode | null,
-  failureCategory: FailureCategory | undefined,
-): boolean {
+function shouldRollbackTddFailure(tddMode: TddMode | null, failureCategory: FailureCategory | undefined): boolean {
   return tddMode?.rollbackEnabled === true && failureCategory === "isolation-violation";
 }
 

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -72,6 +72,13 @@ export const _postRunDeps = {
   autoCommitIfDirty,
 };
 
+function shouldRollbackTddFailure(
+  tddMode: TddMode | null,
+  failureCategory: FailureCategory | undefined,
+): boolean {
+  return tddMode?.rollbackEnabled === true && failureCategory === "isolation-violation";
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Pure helpers
 // ─────────────────────────────────────────────────────────────────────────────
@@ -367,7 +374,7 @@ export async function decideStageAction(
   const logger = getLogger();
   const isTdd = opts.tddMode !== null;
   const isLiteMode = opts.tddMode?.isLite ?? false;
-  const shouldRollback = opts.tddMode?.rollbackEnabled === true;
+  const shouldRollback = shouldRollbackTddFailure(opts.tddMode, inspection.failureCategory);
   const { agentResult, selfVerificationFailed, pauseReason, failureCategory, needsHumanReview, combinedOutput } =
     inspection;
 
@@ -420,7 +427,7 @@ export async function decideStageAction(
     return { action: "pause", reason: pauseReason };
   }
 
-  // TDD failure → rollback + route
+  // TDD failure → isolation rollback (only) + route
   if (isTdd && !planResult.success) {
     ctx.tddFailureCategory = failureCategory;
 

--- a/test/unit/execution/post-run-inspection.test.ts
+++ b/test/unit/execution/post-run-inspection.test.ts
@@ -360,6 +360,91 @@ describe("AC9: applyPostRunInspection ctx field derivations", () => {
   });
 });
 
+describe("TDD rollback gating", () => {
+  let origRollback: typeof _postRunDeps.rollbackToRef;
+  let origAutoCommit: typeof _postRunDeps.autoCommitIfDirty;
+  let origDetect: typeof _postRunDeps.detectMergeConflict;
+  let origFailClose: typeof _postRunDeps.failAndClose;
+
+  beforeEach(() => {
+    origRollback = _postRunDeps.rollbackToRef;
+    origAutoCommit = _postRunDeps.autoCommitIfDirty;
+    origDetect = _postRunDeps.detectMergeConflict;
+    origFailClose = _postRunDeps.failAndClose;
+    _postRunDeps.autoCommitIfDirty = mock(async () => undefined) as typeof _postRunDeps.autoCommitIfDirty;
+    _postRunDeps.detectMergeConflict = mock(() => false) as typeof _postRunDeps.detectMergeConflict;
+    _postRunDeps.failAndClose = mock(async () => undefined) as typeof _postRunDeps.failAndClose;
+  });
+
+  afterEach(() => {
+    _postRunDeps.rollbackToRef = origRollback;
+    _postRunDeps.autoCommitIfDirty = origAutoCommit;
+    _postRunDeps.detectMergeConflict = origDetect;
+    _postRunDeps.failAndClose = origFailClose;
+  });
+
+  test("semantic review failure in TDD mode pauses without git rollback", async () => {
+    const ctx = makeTestContext();
+    const rollbackCalls: Array<{ workdir: string; ref: string }> = [];
+    _postRunDeps.rollbackToRef = mock(async (workdir: string, ref: string) => {
+      rollbackCalls.push({ workdir, ref });
+    }) as typeof _postRunDeps.rollbackToRef;
+
+    const planResult = makePlanResult({
+      success: false,
+      phaseOutputs: {
+        [testWriterOp.name]: { success: true },
+        [implementerOp.name]: { success: true, estimatedCostUsd: 0, durationMs: 50 },
+        [fullSuiteGateOp.name]: { success: true, passed: true, findings: [] },
+        [verifierOp.name]: { success: true },
+        "semantic-review": {
+          passed: false,
+          findings: [{ source: "semantic-review", severity: "error", message: "semantic fail", category: "semantic" }],
+        },
+      },
+    });
+    const opts = makeInspectionOpts({
+      tddMode: { isLite: false, rollbackEnabled: true },
+      initialRef: "abc123",
+    });
+
+    const inspection = await applyPostRunInspection(ctx, planResult, opts);
+    const result = await decideStageAction(ctx, planResult, inspection, opts);
+
+    expect(inspection.failureCategory).toBeUndefined();
+    expect(result.action).toBe("pause");
+    expect(rollbackCalls).toHaveLength(0);
+  });
+
+  test("isolation violation in TDD mode still rolls back before escalating", async () => {
+    const ctx = makeTestContext();
+    const rollbackCalls: Array<{ workdir: string; ref: string }> = [];
+    _postRunDeps.rollbackToRef = mock(async (workdir: string, ref: string) => {
+      rollbackCalls.push({ workdir, ref });
+    }) as typeof _postRunDeps.rollbackToRef;
+
+    const planResult = makePlanResult({
+      success: false,
+      phaseOutputs: {
+        [testWriterOp.name]: { success: true },
+        [implementerOp.name]: { success: true, estimatedCostUsd: 0, durationMs: 50 },
+        [verifierOp.name]: { success: false, failureCategory: "isolation-violation" },
+      },
+    });
+    const opts = makeInspectionOpts({
+      tddMode: { isLite: false, rollbackEnabled: true },
+      initialRef: "def456",
+    });
+
+    const inspection = await applyPostRunInspection(ctx, planResult, opts);
+    const result = await decideStageAction(ctx, planResult, inspection, opts);
+
+    expect(inspection.failureCategory).toBe("isolation-violation");
+    expect(result.action).toBe("escalate");
+    expect(rollbackCalls).toEqual([{ workdir: ctx.workdir, ref: "def456" }]);
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // _postRunDeps rollback injection
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Gate TDD rollback to isolation violations only, instead of rolling back for every failed TDD plan.

## Why

A regression after commit `f38aedf216800cea9f0490bb3eca6b6663e34917` caused semantic review failures to trigger `git` rollback even when the failure was not a TDD isolation violation. In the reported run log, `semantic-review` failed, no TDD failure category was derived, and the wrapper still reset git state.

Closes #

## How

- Added a narrow rollback guard in `post-run.ts` so rollback only occurs when `failureCategory === "isolation-violation"` and rollback is enabled.
- Kept the existing TDD routing behavior intact for pause/escalate decisions.
- Added regression tests covering:
  - semantic review failure in TDD mode does not rollback
  - isolation violation in TDD mode still rolls back

## Testing

- [x] Tests added/updated
- [ ] `bun test` passes
- [ ] `bun run typecheck` passes
- [ ] `bun run lint` passes

Focused validation run:
- `bun test test/unit/execution/post-run-inspection.test.ts --timeout=30000`

## Notes

This PR intentionally does not introduce a new explicit semantic-review failure category. It only fixes the destructive rollback behavior so semantic/adversarial review failures can pause for review without resetting the worktree.