### PR TITLE
fix: surface rectification exhaustion correctly

### DIFF
--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -375,6 +375,10 @@ export async function decideStageAction(
   const { agentResult, selfVerificationFailed, pauseReason, failureCategory, needsHumanReview, combinedOutput } =
     inspection;
 
+  if (isTdd && !planResult.success) {
+    ctx.tddFailureCategory = failureCategory;
+  }
+
   // Mechanical-only failure: if rectification exhausted but all unfixed findings are from
   // mechanical sources (lint/typecheck), LLM review passed — proceed rather than escalating.
   if (planResult.rectificationExhausted && planResult.unfixedFindings && planResult.unfixedFindings.length > 0) {
@@ -385,6 +389,17 @@ export async function decideStageAction(
         storyId: ctx.story.id,
       });
       return { action: "continue" };
+    }
+
+    if (!(isTdd && shouldRollback)) {
+      const findingSources = [...sources].filter((source): source is string => typeof source === "string");
+      logger.error("execution", "Rectification exhausted with unfixed findings", {
+        storyId: ctx.story.id,
+        findingsCount: planResult.unfixedFindings.length,
+        findingSources,
+      });
+      await cleanupSessionOnFailure(ctx);
+      return { action: "escalate", reason: "Rectification exhausted with unfixed findings" };
     }
   }
 
@@ -426,8 +441,6 @@ export async function decideStageAction(
 
   // TDD failure → isolation rollback (only) + route
   if (isTdd && !planResult.success) {
-    ctx.tddFailureCategory = failureCategory;
-
     if (shouldRollback && opts.initialRef) {
       try {
         await _postRunDeps.rollbackToRef(ctx.workdir, opts.initialRef);

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -177,7 +177,6 @@ function collectOrderedPhases(state: InternalBuildState): InternalPhase[] {
     return [];
   });
 }
-
 /**
  * Stricter variant of `phasePassed` for SSOT carve-out logic. Where `phasePassed`
  * defensively treats missing/undefined/non-object outputs as "passed" (to avoid
@@ -533,7 +532,12 @@ async function runRectification(
     });
   }
 
-  const exhaustedReasons = new Set<string>(["max-attempts-total", "max-attempts-per-strategy", "bail-when"]);
+  const exhaustedReasons = new Set<string>([
+    "max-attempts-total",
+    "max-attempts-per-strategy",
+    "bail-when",
+    "no-strategy",
+  ]);
   if (exhaustedReasons.has(cycleResult.exitReason) && cycleResult.finalFindings.length > 0) {
     return { rectificationExhausted: true, unfixedFindings: cycleResult.finalFindings };
   }

--- a/test/unit/execution/post-run-inspection.test.ts
+++ b/test/unit/execution/post-run-inspection.test.ts
@@ -162,6 +162,13 @@ function makeInspectionOpts(overrides: Partial<InspectionOptions> = {}): Inspect
 const LINT_FINDING: Finding = { source: "lint", severity: "error", message: "unused var", category: "lint" };
 const TYPECHECK_FINDING: Finding = { source: "typecheck", severity: "error", message: "type error", category: "type" };
 const TEST_RUNNER_FINDING: Finding = { source: "test-runner", severity: "error", message: "test failed", category: "test" };
+const SEMANTIC_REVIEW_FINDING: Finding = {
+  source: "semantic-review",
+  severity: "error",
+  message: "semantic review failed",
+  category: "ac-coverage",
+  fixTarget: "source",
+};
 
 describe("AC7: mechanicalFailedOnly — all lint/typecheck unfixed → continue action", () => {
   let origAutoCommit: typeof _postRunDeps.autoCommitIfDirty;
@@ -267,6 +274,117 @@ describe("AC8: mechanicalFailedOnly — non-mechanical source present → escala
     const inspection = await applyPostRunInspection(ctx, planResult, opts);
     const result = await decideStageAction(ctx, planResult, inspection, opts);
     expect(result.action).toBe("escalate");
+  });
+
+  test("rectificationExhausted + semantic-review finding returns explicit exhaustion reason", async () => {
+    const ctx = makeTestContext();
+    const planResult = makePlanResult({
+      success: false,
+      rectificationExhausted: true,
+      unfixedFindings: [SEMANTIC_REVIEW_FINDING],
+    });
+    const opts = makeInspectionOpts();
+    const inspection = await applyPostRunInspection(ctx, planResult, opts);
+    const result = await decideStageAction(ctx, planResult, inspection, opts);
+
+    if (result.action !== "escalate") {
+      throw new Error(`Expected escalate action, got ${result.action}`);
+    }
+    expect(result.reason).toBe("Rectification exhausted with unfixed findings");
+  });
+
+  test("rectificationExhausted + semantic-review finding in TDD mode bypasses pause routing", async () => {
+    const ctx = makeTestContext();
+    const rollbackCalls: Array<{ workdir: string; ref: string }> = [];
+    const origRollback = _postRunDeps.rollbackToRef;
+    _postRunDeps.rollbackToRef = mock(async (workdir: string, ref: string) => {
+      rollbackCalls.push({ workdir, ref });
+    }) as typeof _postRunDeps.rollbackToRef;
+
+    try {
+      const planResult = makePlanResult({
+        success: false,
+        rectificationExhausted: true,
+        unfixedFindings: [SEMANTIC_REVIEW_FINDING],
+        phaseOutputs: {
+          [testWriterOp.name]: { success: true },
+          [implementerOp.name]: { success: true, estimatedCostUsd: 0, durationMs: 50 },
+          [fullSuiteGateOp.name]: { success: true, passed: true, findings: [] },
+          [verifierOp.name]: { success: true },
+          "semantic-review": { passed: false, findings: [SEMANTIC_REVIEW_FINDING] },
+        },
+      });
+      const opts = makeInspectionOpts({
+        tddMode: { isLite: false, rollbackEnabled: true },
+        initialRef: "abc123",
+      });
+      const inspection = await applyPostRunInspection(ctx, planResult, opts);
+      const result = await decideStageAction(ctx, planResult, inspection, opts);
+
+      if (result.action !== "escalate") {
+        throw new Error(`Expected escalate action, got ${result.action}`);
+      }
+      expect(result.reason).toBe("Rectification exhausted with unfixed findings");
+      expect(rollbackCalls).toHaveLength(0);
+    } finally {
+      _postRunDeps.rollbackToRef = origRollback;
+    }
+  });
+
+  test("rectificationExhausted does not bypass TDD isolation rollback", async () => {
+    const ctx = makeTestContext();
+    const rollbackCalls: Array<{ workdir: string; ref: string }> = [];
+    const origRollback = _postRunDeps.rollbackToRef;
+    _postRunDeps.rollbackToRef = mock(async (workdir: string, ref: string) => {
+      rollbackCalls.push({ workdir, ref });
+    }) as typeof _postRunDeps.rollbackToRef;
+
+    try {
+      const planResult = makePlanResult({
+        success: false,
+        rectificationExhausted: true,
+        unfixedFindings: [TEST_RUNNER_FINDING],
+        phaseOutputs: {
+          [testWriterOp.name]: { success: true },
+          [implementerOp.name]: { success: true, estimatedCostUsd: 0, durationMs: 50 },
+          [verifierOp.name]: { success: false, failureCategory: "isolation-violation" },
+        },
+      });
+      const opts = makeInspectionOpts({
+        tddMode: { isLite: false, rollbackEnabled: true },
+        initialRef: "def456",
+      });
+      const inspection = await applyPostRunInspection(ctx, planResult, opts);
+      const result = await decideStageAction(ctx, planResult, inspection, opts);
+
+      expect(result.action).toBe("escalate");
+      expect(rollbackCalls).toEqual([{ workdir: ctx.workdir, ref: "def456" }]);
+    } finally {
+      _postRunDeps.rollbackToRef = origRollback;
+    }
+  });
+
+  test("rectificationExhausted preserves TDD failure category for downstream escalation", async () => {
+    const ctx = makeTestContext();
+    const planResult = makePlanResult({
+      success: false,
+      rectificationExhausted: true,
+      unfixedFindings: [TEST_RUNNER_FINDING],
+      phaseOutputs: {
+        [testWriterOp.name]: { success: true },
+        [implementerOp.name]: { success: true, estimatedCostUsd: 0, durationMs: 50 },
+        [verifierOp.name]: { success: false, failureCategory: "verifier-rejected" },
+      },
+    });
+    const opts = makeInspectionOpts({
+      tddMode: { isLite: false, rollbackEnabled: true },
+      initialRef: "ghi789",
+    });
+    const inspection = await applyPostRunInspection(ctx, planResult, opts);
+    const result = await decideStageAction(ctx, planResult, inspection, opts);
+
+    expect(result.action).toBe("escalate");
+    expect(ctx.tddFailureCategory).toBe("verifier-rejected");
   });
 });
 

--- a/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
+++ b/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
@@ -171,6 +171,7 @@ describe("ExecutionPlan.run() — AC6: rectificationExhausted on cycle exhaustio
     ["max-attempts-total" as FixCycleExitReason],
     ["max-attempts-per-strategy" as FixCycleExitReason],
     ["bail-when" as FixCycleExitReason],
+    ["no-strategy" as FixCycleExitReason],
   ])("AC6: exitReason '%s' with remaining findings → rectificationExhausted=true", async (exitReason) => {
     _storyOrchestratorDeps.runFixCycle = mock(async () => ({
       iterations: [],


### PR DESCRIPTION
## What

Surface rectification exhaustion explicitly when unfixed findings remain, including the `no-strategy` exit path.

## Why

Semantic and adversarial review findings could end rectification without a matching fix strategy, but the run was not being surfaced consistently as rectification exhaustion. That produced misleading downstream failure handling instead of a clear exhausted/escalate path.

Closes #

## How

- treat `no-strategy` as a rectification-exhausted exit reason in the story orchestrator
- route non-mechanical exhausted findings through explicit escalation in post-run inspection
- preserve existing TDD rollback and failure-category behavior
- extend unit coverage for semantic-review exhaustion and `no-strategy` exhaustion

## Testing

- [x] Tests added/updated
- [ ] `bun test` passes
- [x] `bun run typecheck` passes
- [ ] `bun run lint` passes

## Notes

Validated with targeted checks:
- `timeout 30 bun test test/unit/execution/post-run-inspection.test.ts --timeout=5000`
- `timeout 30 bun test test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts --timeout=5000`
- `bun run lint src/execution/story-orchestrator.ts test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts`
