### PR TITLE
fix: semantic requote recovery + final pass recomputation

### DIFF
--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -4,6 +4,7 @@ import type { ReviewConfig } from "../config/selectors";
 import type { Iteration } from "../findings";
 import { getSafeLogger } from "../logger";
 import { ReviewPromptBuilder } from "../prompts";
+import { parseRequoteResponse } from "../review/requote-response";
 import { checkFindingEvidence, downgradeUnsubstantiatedFinding } from "../review/semantic-evidence";
 import { type LLMFinding, isBlockingSeverity, validateLLMShape } from "../review/semantic-helpers";
 import type { SemanticReviewConfig, SemanticStory } from "../review/types";
@@ -54,9 +55,12 @@ const semanticReviewHopBody: RunOperation<SemanticReviewInput, SemanticReviewOut
   if (!parsed) return turn;
   const requoted = await requoteBlockingFindings(parsed.findings, ctx);
   if (!requoted.changed) return turn;
+  const passed = !requoted.findings.some((finding) =>
+    isBlockingSeverity(finding.severity, ctx.input.blockingThreshold ?? "error"),
+  );
   return {
     ...turn,
-    output: JSON.stringify({ passed: parsed.passed, findings: requoted.findings }),
+    output: JSON.stringify({ passed, findings: requoted.findings }),
     estimatedCostUsd: (turn.estimatedCostUsd ?? 0) + requoted.extraCostUsd,
   };
 };
@@ -181,15 +185,4 @@ async function requoteBlockingFindings(
     changed = true;
   }
   return { findings: next, changed, extraCostUsd };
-}
-
-function parseRequoteResponse(output: string): { file: string; line?: number; observed: string } | null {
-  const parsed = tryParseLLMJson<Record<string, unknown>>(output);
-  if (!parsed || typeof parsed.file !== "string" || typeof parsed.observed !== "string") return null;
-  if (parsed.line != null && typeof parsed.line !== "number") return null;
-  return {
-    file: parsed.file,
-    line: typeof parsed.line === "number" ? parsed.line : undefined,
-    observed: parsed.observed,
-  };
 }

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -13,5 +13,6 @@ export * from "./diff-utils";
 export * from "./finding-projection";
 export * from "./types";
 export * from "./runner";
+export * from "./requote-response";
 export * from "./severity";
 export { validateLLMShape } from "./semantic-helpers";

--- a/src/review/requote-response.ts
+++ b/src/review/requote-response.ts
@@ -1,0 +1,50 @@
+import { tryParseLLMJson } from "../utils/llm-json";
+
+export type ParsedRequoteResponse = {
+  file: string;
+  line?: number;
+  observed: string;
+};
+
+export function parseRequoteResponse(output: string): ParsedRequoteResponse | null {
+  const parsed = tryParseLLMJson<unknown>(output);
+  if (!isRecord(parsed)) return null;
+
+  const canonical = extractCanonical(parsed);
+  if (canonical) return canonical;
+
+  const findings = parsed.findings;
+  if (!Array.isArray(findings) || findings.length !== 1) return null;
+  const finding = findings[0];
+  if (!isRecord(finding)) return null;
+
+  return extractCanonical(finding.verifiedBy) ?? extractCanonical(finding);
+}
+
+function extractCanonical(value: unknown): ParsedRequoteResponse | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.file !== "string" || typeof value.observed !== "string") return null;
+
+  const file = value.file.trim();
+  if (!file) return null;
+
+  const line = coerceLine(value.line);
+  if (line === null) return null;
+
+  return {
+    file,
+    line: line === undefined ? undefined : line,
+    observed: value.observed,
+  };
+}
+
+function coerceLine(value: unknown): number | undefined | null {
+  if (value == null) return undefined;
+  if (typeof value === "number") return value;
+  if (typeof value === "string" && /^\d+$/.test(value)) return Number.parseInt(value, 10);
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/test/unit/review/requote-response.test.ts
+++ b/test/unit/review/requote-response.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { parseRequoteResponse } from "@/review";
+
+describe("parseRequoteResponse", () => {
+  test("parses canonical quote object", () => {
+    const parsed = parseRequoteResponse('{"file":"src/x.ts","line":1,"observed":"quote"}');
+    expect(parsed).toEqual({ file: "src/x.ts", line: 1, observed: "quote" });
+  });
+
+  test("coerces digit-only string line", () => {
+    const parsed = parseRequoteResponse('{"file":"src/x.ts","line":"1","observed":"quote"}');
+    expect(parsed).toEqual({ file: "src/x.ts", line: 1, observed: "quote" });
+  });
+
+  test("accepts canonical object with extra keys", () => {
+    const parsed = parseRequoteResponse('{"file":"src/x.ts","line":1,"observed":"quote","passed":true}');
+    expect(parsed).toEqual({ file: "src/x.ts", line: 1, observed: "quote" });
+  });
+
+  test("parses single-finding fallback with nested verifiedBy", () => {
+    const parsed = parseRequoteResponse(
+      '{"passed":true,"findings":[{"verifiedBy":{"file":"src/x.ts","line":1,"observed":"quote"}}]}',
+    );
+    expect(parsed).toEqual({ file: "src/x.ts", line: 1, observed: "quote" });
+  });
+
+  test("parses single-finding fallback with top-level finding fields", () => {
+    const parsed = parseRequoteResponse(
+      '{"passed":false,"findings":[{"file":"src/x.ts","line":1,"observed":"quote"}]}',
+    );
+    expect(parsed).toEqual({ file: "src/x.ts", line: 1, observed: "quote" });
+  });
+
+  test("returns null for multi-finding fallback", () => {
+    const parsed = parseRequoteResponse(
+      '{"passed":false,"findings":[{"file":"a.ts","observed":"a"},{"file":"b.ts","observed":"b"}]}',
+    );
+    expect(parsed).toBeNull();
+  });
+
+  test("returns null for top-level array", () => {
+    const parsed = parseRequoteResponse('[{"file":"src/x.ts","observed":"quote"}]');
+    expect(parsed).toBeNull();
+  });
+
+  test("returns null when observed is missing", () => {
+    const parsed = parseRequoteResponse('{"file":"src/x.ts","line":1}');
+    expect(parsed).toBeNull();
+  });
+
+  test("returns null when observed is not a string", () => {
+    const parsed = parseRequoteResponse('{"file":"src/x.ts","line":1,"observed":123}');
+    expect(parsed).toBeNull();
+  });
+});

--- a/test/unit/review/semantic-retry.test.ts
+++ b/test/unit/review/semantic-retry.test.ts
@@ -556,3 +556,185 @@ describe("semanticReviewOp.hopBody — same-session requote", () => {
     });
   });
 });
+
+describe("semanticReviewOp.hopBody — requote recovery regressions", () => {
+  test("accepts salvageable single-finding full-review requote JSON", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "export function foo() {\n  return 42;\n}\n");
+
+      const initial = JSON.stringify({
+        passed: false,
+        findings: [
+          {
+            severity: "error",
+            file: "src/foo.ts",
+            line: 1,
+            issue: "Missing proof",
+            suggestion: "Quote the file",
+            verifiedBy: {
+              file: "src/foo.ts",
+              line: 1,
+              observed: "does not match",
+            },
+          },
+        ],
+      });
+      const requote = JSON.stringify({
+        passed: true,
+        findings: [
+          {
+            verifiedBy: {
+              file: "src/foo.ts",
+              line: 1,
+              observed: "export function foo() {\n  return 42;\n}",
+            },
+          },
+        ],
+      });
+
+      let callCount = 0;
+      const mockSend = mock(async () => {
+        callCount += 1;
+        return {
+          output: callCount === 1 ? initial : requote,
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          internalRoundTrips: 0,
+        };
+      });
+
+      const { semanticReviewOp } = await import("@/operations");
+      const result = await semanticReviewOp.hopBody!("initial prompt", {
+        send: mockSend,
+        sendWithParseRetry: mockSend,
+        input: {
+          workdir,
+          story: STORY,
+          semanticConfig: { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+          mode: "ref",
+        },
+      } as any);
+
+      const parsed = JSON.parse(result.output);
+      expect(callCount).toBe(2);
+      expect(parsed.findings[0].verifiedBy.observed).toContain("return 42");
+    });
+  });
+
+  test("sets passed true when requote fails and the only blocking finding is downgraded", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "export function foo() {}\n");
+
+      const initial = JSON.stringify({
+        passed: false,
+        findings: [
+          {
+            severity: "error",
+            file: "src/foo.ts",
+            line: 1,
+            issue: "Missing proof",
+            suggestion: "Quote the file",
+            verifiedBy: {
+              file: "src/foo.ts",
+              line: 1,
+              observed: "does not match",
+            },
+          },
+        ],
+      });
+
+      let callCount = 0;
+      const mockSend = mock(async () => {
+        callCount += 1;
+        return {
+          output: callCount === 1 ? initial : "not json",
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          internalRoundTrips: 0,
+        };
+      });
+
+      const { semanticReviewOp } = await import("@/operations");
+      const result = await semanticReviewOp.hopBody!("initial prompt", {
+        send: mockSend,
+        sendWithParseRetry: mockSend,
+        input: {
+          workdir,
+          story: STORY,
+          semanticConfig: { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+          mode: "ref",
+        },
+      } as any);
+
+      const parsed = JSON.parse(result.output);
+      expect(callCount).toBe(2);
+      expect(parsed.findings[0].severity).toBe("unverifiable");
+      expect(parsed.passed).toBe(true);
+    });
+  });
+
+  test("keeps passed false when another blocking finding remains after requote downgrade", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), "export function foo() {}\n");
+
+      const initial = JSON.stringify({
+        passed: false,
+        findings: [
+          {
+            severity: "error",
+            file: "src/foo.ts",
+            line: 1,
+            issue: "Missing proof",
+            suggestion: "Quote the file",
+            verifiedBy: {
+              file: "src/foo.ts",
+              line: 1,
+              observed: "does not match",
+            },
+          },
+          {
+            severity: "error",
+            file: "src/foo.ts",
+            line: 1,
+            issue: "Real blocking issue",
+            suggestion: "Fix bug",
+            verifiedBy: {
+              file: "src/foo.ts",
+              line: 1,
+              observed: "export function foo() {}",
+            },
+          },
+        ],
+      });
+
+      let callCount = 0;
+      const mockSend = mock(async () => {
+        callCount += 1;
+        return {
+          output: callCount === 1 ? initial : "not json",
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          internalRoundTrips: 0,
+        };
+      });
+
+      const { semanticReviewOp } = await import("@/operations");
+      const result = await semanticReviewOp.hopBody!("initial prompt", {
+        send: mockSend,
+        sendWithParseRetry: mockSend,
+        input: {
+          workdir,
+          story: STORY,
+          semanticConfig: { ...DEFAULT_SEMANTIC_CONFIG, diffMode: "ref" },
+          mode: "ref",
+        },
+      } as any);
+
+      const parsed = JSON.parse(result.output);
+      expect(callCount).toBe(2);
+      expect(parsed.findings[0].severity).toBe("unverifiable");
+      expect(parsed.findings[1].severity).toBe("error");
+      expect(parsed.passed).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared `parseRequoteResponse` helper for review requote flows
- accept canonical requote JSON plus safe single-finding full-review fallback shapes
- keep rejection for ambiguous responses (top-level arrays, multi-finding payloads, missing/invalid fields)
- wire semantic requote flow to shared helper
- recompute final semantic `passed` from post-requote blocking findings to avoid stale `passed:false`
- add parser unit tests and semantic regression tests for fallback parsing + pass/fail recomputation

## Validation
- bun run lint
- bun run typecheck
- bun run test