### PR TITLE
feat: promote empty agent output to fail-stale AdapterFailure for manager-tier retry

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -273,7 +273,7 @@ export class AgentManager implements IAgentManager {
         // Session idle timeouts warrant fast retries (no backoff) — the session was
         // cancelled due to inactivity, not server load, so the next attempt may succeed.
         const isFailStale = result.adapterFailure?.outcome === "fail-stale";
-        const maxStaleRetries = this._config.agent?.idleWatchdog?.maxRetryAttempts ?? 1;
+        const maxStaleRetries = this._config.agent?.idleWatchdog?.maxRetryAttempts ?? 3;
         if (isFailStale && result.adapterFailure?.retriable && staleRetryAttempts < maxStaleRetries) {
           staleRetryAttempts++;
           const retryHop: AgentFallbackRecord = {
@@ -524,6 +524,18 @@ export class AgentManager implements IAgentManager {
         const isFailStale = result.adapterFailure.outcome === "fail-stale";
         if (isFailStale && result.adapterFailure.retriable && staleRetryAttempts < maxStaleRetries) {
           staleRetryAttempts++;
+          const retryHop: AgentFallbackRecord = {
+            storyId: options.storyId,
+            priorAgent: currentAgent,
+            newAgent: currentAgent,
+            hop: staleRetryAttempts,
+            outcome: result.adapterFailure.outcome,
+            category: result.adapterFailure.category,
+            timestamp: new Date().toISOString(),
+            costUsd: result.estimatedCostUsd,
+          };
+          fallbacks.push(retryHop);
+          this._emitter.emit("onSwapAttempt", retryHop);
           logger?.info("agent-manager", "completeWithFallback: fail-stale same-agent retry", {
             storyId: options.storyId,
             attempt: staleRetryAttempts,

--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -292,6 +292,7 @@ export class AgentManager implements IAgentManager {
             storyId: request.runOptions.storyId,
             attempt: staleRetryAttempts,
             agent: currentAgent,
+            reason: result.adapterFailure?.reason,
           });
           currentHopKind = { kind: "stale-retry", attempt: staleRetryAttempts };
           continue;
@@ -454,6 +455,8 @@ export class AgentManager implements IAgentManager {
     const primaryAgent = primaryAgentOverride ?? this.getDefault();
     let currentAgent = primaryAgent;
     let hopsSoFar = 0;
+    let staleRetryAttempts = 0;
+    const maxStaleRetries = this._config.agent?.idleWatchdog?.maxRetryAttempts ?? 3;
 
     const _opStartMs = Date.now();
     const _agentChain: string[] = [primaryAgent];
@@ -497,9 +500,37 @@ export class AgentManager implements IAgentManager {
 
         _totalCostUsd += result.estimatedCostUsd;
 
+        // Synthesize fail-stale when agent returns empty output with no pre-existing failure.
+        // Mirrors sendWithFileOutput synthesis in call.ts for run-kind ops (spec §B2).
+        if (!result.adapterFailure && !result.output?.trim()) {
+          result = {
+            ...result,
+            adapterFailure: {
+              outcome: "fail-stale",
+              category: "availability",
+              retriable: true,
+              message: "[completeWithFallback] agent returned no output",
+              reason: "empty-output",
+            },
+          };
+        }
+
         if (!result.adapterFailure) {
           _finalStatus = "ok";
           return { result, fallbacks };
+        }
+
+        // fail-stale same-agent retry (mirrors runWithFallback pattern at manager.ts:275-298).
+        const isFailStale = result.adapterFailure.outcome === "fail-stale";
+        if (isFailStale && result.adapterFailure.retriable && staleRetryAttempts < maxStaleRetries) {
+          staleRetryAttempts++;
+          logger?.info("agent-manager", "completeWithFallback: fail-stale same-agent retry", {
+            storyId: options.storyId,
+            attempt: staleRetryAttempts,
+            agent: currentAgent,
+            reason: result.adapterFailure.reason,
+          });
+          continue;
         }
 
         // completeWithFallback has no ContextBundle object, but swap is still allowed on

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -442,6 +442,13 @@ export interface TurnResult {
   internalRoundTrips: number;
   /** Protocol-specific IDs for prompt-audit correlation. */
   protocolIds?: ProtocolIds;
+  /**
+   * Set when the hop body synthesises a failure (e.g. empty output) rather than
+   * receiving a real adapter error. Propagated through buildHopCallback into
+   * AgentResult.adapterFailure so the manager's swap/retry policy sees the correct
+   * outcome (e.g. `fail-stale` on empty output).
+   */
+  adapterFailure?: AdapterFailure;
 }
 
 /**

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -34,8 +34,10 @@ export interface AdapterFailure {
    *
    * `fail-aborted` — the run was cancelled via AgentRunOptions.abortSignal
    * (shutdown in progress). Not retriable; fallback chains should not fire.
-   * `fail-stale` — the idle watchdog cancelled the prompt due to no stream activity
-   * within the configured idle timeout. Retriable up to maxRetryAttempts.
+   * `fail-stale` — either (a) the idle watchdog cancelled due to no stream activity
+   * within the configured idle timeout, or (b) the agent finished cleanly with empty
+   * output. The `reason` field distinguishes: "idle-watchdog" vs "empty-output".
+   * Retriable up to maxRetryAttempts.
    */
   outcome:
     | "fail-quota"
@@ -54,6 +56,12 @@ export interface AdapterFailure {
   retriable: boolean;
   /** Seconds to wait before retrying (for rate-limit failures) */
   retryAfterSeconds?: number;
+  /**
+   * Observability tag — distinguishes outcome subtypes. No semantic effect on retry/swap.
+   * Examples: "idle-watchdog" (fail-stale from idle watchdog cancellation),
+   * "empty-output" (fail-stale synthesized when agent returned no output).
+   */
+  reason?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/operations/build-hop-callback.ts
+++ b/src/operations/build-hop-callback.ts
@@ -68,8 +68,8 @@ export interface BuildHopCallbackContext {
 
 function turnResultToAgentResult(r: TurnResult): AgentResult {
   return {
-    success: true,
-    exitCode: 0,
+    success: !r.adapterFailure,
+    exitCode: r.adapterFailure ? 1 : 0,
     output: r.output,
     rateLimited: false,
     durationMs: 0,
@@ -78,6 +78,7 @@ function turnResultToAgentResult(r: TurnResult): AgentResult {
     tokenUsage: r.tokenUsage,
     protocolIds: r.protocolIds,
     internalRoundTrips: r.internalRoundTrips,
+    ...(r.adapterFailure ? { adapterFailure: r.adapterFailure } : {}),
   };
 }
 

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -313,6 +313,11 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
         effective = { ...turn, output: fileContent };
       }
     }
+    // Synthesize fail-stale for empty or whitespace-only output so the manager-tier
+    // retry/swap logic handles transient agent stalls uniformly (spec §B1).
+    // Note: the outer `if (!rawOutput)` guard in callOp uses a falsy check, so
+    // whitespace-only output ("  ") reaches op.parse at exhaustion rather than
+    // throwing CALL_OP_NO_OUTPUT — op.parse is expected to handle or reject it.
     if (!effective.output?.trim() && !effective.adapterFailure) {
       return {
         ...effective,

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -306,14 +306,26 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
     bodyCtx: { send: (p: string) => Promise<TurnResult> },
   ): Promise<TurnResult> => {
     const turn = await bodyCtx.send(promptText);
-    if (!fileOutputPath) return turn;
-
-    const fileContent = await _callOpDeps.readFileOutput(fileOutputPath);
-    if (fileContent === null) {
-      return turn;
+    let effective = turn;
+    if (fileOutputPath) {
+      const fileContent = await _callOpDeps.readFileOutput(fileOutputPath);
+      if (fileContent !== null) {
+        effective = { ...turn, output: fileContent };
+      }
     }
-
-    return { ...turn, output: fileContent };
+    if (!effective.output?.trim() && !effective.adapterFailure) {
+      return {
+        ...effective,
+        adapterFailure: {
+          outcome: "fail-stale",
+          category: "availability",
+          retriable: true,
+          message: `[${op.name}] agent returned no output`,
+          reason: "empty-output",
+        },
+      };
+    }
+    return effective;
   };
 
   // sendWithParseRetry: runs the retry loop inside one session turn.

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -596,6 +596,7 @@ export class SessionManager implements ISessionManager {
             outcome: "fail-stale",
             retriable: true,
             message: "idle watchdog cancelled session — no stream activity",
+            reason: "idle-watchdog",
           });
         }
       }

--- a/test/integration/operations/complete-empty-output-retry.test.ts
+++ b/test/integration/operations/complete-empty-output-retry.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Integration test — AC5, AC6: complete-kind callOp empty-output retry via completeWithFallback.
+ *
+ * When a complete-kind op returns empty agent output, completeWithFallback synthesises
+ * a retriable fail-stale AdapterFailure (spec §B2). AgentManager.completeWithFallback
+ * recognises this and retries the same agent up to idleWatchdog.maxRetryAttempts times
+ * before exhaustion (or fallback agent swap).
+ *
+ * These tests exercise the full dispatch path through the real AgentManager:
+ *   callOp → completeAs → completeWithFallback → synthesis → same-agent retry → success
+ *
+ * Pattern:
+ *   - makeTestRuntime({ config }) for tests that need the real AgentManager
+ *   - Inject mock adapters via (rt.agentManager as any)._resolveRegistry
+ *   - Track created runtimes for mandatory afterEach cleanup
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { callOp } from "../../../src/operations";
+import type { CompleteOperation } from "../../../src/operations";
+import { DEFAULT_CONFIG, pickSelector } from "../../../src/config";
+import { makeNaxConfig, makeTestRuntime } from "../../helpers";
+import type { NaxRuntime } from "../../../src/runtime";
+
+const sel = pickSelector("complete-empty-output-retry-test", "routing");
+
+function makeCompleteOp(name: string): CompleteOperation<string, string, Pick<typeof DEFAULT_CONFIG, "routing">> {
+  return {
+    kind: "complete",
+    name,
+    stage: "run",
+    config: sel,
+    build: (input) => ({
+      role: { id: "role", content: "Echo the input.", overridable: false },
+      task: { id: "task", content: input, overridable: false },
+    }),
+    parse: (output) => output.trim(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Runtime cleanup (mandatory per project rules)
+// ---------------------------------------------------------------------------
+
+const createdRuntimes: NaxRuntime[] = [];
+afterEach(async () => {
+  await Promise.allSettled(createdRuntimes.map((r) => r.close()));
+  createdRuntimes.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// AC5 + AC6: happy path — empty on first attempt, success on retry
+// ---------------------------------------------------------------------------
+
+describe("AC5+AC6: complete-kind empty-output → completeWithFallback retry (same agent)", () => {
+  test("empty output on first attempt → same-agent retry → returns success on second", async () => {
+    let callCount = 0;
+    const config = makeNaxConfig({
+      agent: {
+        idleWatchdog: { maxRetryAttempts: 3, enabled: true, idleTimeoutSeconds: 900 },
+        fallback: { enabled: false, map: {}, maxHopsPerStory: 0, onQualityFailure: false, rebuildContext: false },
+      },
+    });
+    const rt = makeTestRuntime({ config });
+    createdRuntimes.push(rt);
+
+    // Inject mock adapter: empty on first, success on second.
+    const adapter = {
+      complete: mock(async () => {
+        callCount++;
+        return {
+          output: callCount === 1 ? "" : "success on retry",
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          estimatedCostUsd: 0,
+        };
+      }),
+    };
+    (rt.agentManager as unknown as { _resolveRegistry: () => { getAgent: (name: string) => typeof adapter } })
+      ._resolveRegistry = () => ({ getAgent: () => adapter });
+
+    const result = await callOp(
+      { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      makeCompleteOp("ac5-ac6-happy-path"),
+      "hello",
+    );
+
+    expect(result).toBe("success on retry");
+    // 1 initial + 1 retry = 2 total adapter calls
+    expect(callCount).toBe(2);
+  });
+
+  test("empty on first two → retry twice → returns success on third", async () => {
+    let callCount = 0;
+    const config = makeNaxConfig({
+      agent: {
+        idleWatchdog: { maxRetryAttempts: 3, enabled: true, idleTimeoutSeconds: 900 },
+        fallback: { enabled: false, map: {}, maxHopsPerStory: 0, onQualityFailure: false, rebuildContext: false },
+      },
+    });
+    const rt = makeTestRuntime({ config });
+    createdRuntimes.push(rt);
+
+    const adapter = {
+      complete: mock(async () => {
+        callCount++;
+        return {
+          output: callCount <= 2 ? "" : "eventual success",
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          estimatedCostUsd: 0,
+        };
+      }),
+    };
+    (rt.agentManager as unknown as { _resolveRegistry: () => { getAgent: (name: string) => typeof adapter } })
+      ._resolveRegistry = () => ({ getAgent: () => adapter });
+
+    const result = await callOp(
+      { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-002" },
+      makeCompleteOp("ac5-two-retries-then-success"),
+      "hello",
+    );
+
+    expect(result).toBe("eventual success");
+    expect(callCount).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC5 exhaustion: maxRetryAttempts=1, all-empty → parse receives empty string
+// The complete-kind path does not throw CALL_OP_NO_OUTPUT — op.parse("") returns ""
+// ---------------------------------------------------------------------------
+
+describe("AC5: complete-kind empty-output — retries exhausted", () => {
+  test("maxRetryAttempts=1: 2 total calls (initial + 1 retry), parse receives empty string", async () => {
+    let callCount = 0;
+    const config = makeNaxConfig({
+      agent: {
+        idleWatchdog: { maxRetryAttempts: 1, enabled: true, idleTimeoutSeconds: 900 },
+        fallback: { enabled: false, map: {}, maxHopsPerStory: 0, onQualityFailure: false, rebuildContext: false },
+      },
+    });
+    const rt = makeTestRuntime({ config });
+    createdRuntimes.push(rt);
+
+    const adapter = {
+      complete: mock(async () => {
+        callCount++;
+        return {
+          output: "", // always empty
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          estimatedCostUsd: 0,
+        };
+      }),
+    };
+    (rt.agentManager as unknown as { _resolveRegistry: () => { getAgent: (name: string) => typeof adapter } })
+      ._resolveRegistry = () => ({ getAgent: () => adapter });
+
+    // op.parse("".trim()) returns "" — callOp returns "".
+    const result = await callOp(
+      { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-003" },
+      makeCompleteOp("ac5-exhaustion-maxretry-1"),
+      "hello",
+    );
+
+    // 1 initial + 1 retry = 2 total calls (maxRetryAttempts=1)
+    expect(callCount).toBe(2);
+    // parse("") = "" — callOp returns empty string on complete-kind exhaustion
+    expect(result).toBe("");
+  });
+
+  test("maxRetryAttempts=3: 4 total calls (initial + 3 retries) on all-empty output", async () => {
+    let callCount = 0;
+    const config = makeNaxConfig({
+      agent: {
+        idleWatchdog: { maxRetryAttempts: 3, enabled: true, idleTimeoutSeconds: 900 },
+        fallback: { enabled: false, map: {}, maxHopsPerStory: 0, onQualityFailure: false, rebuildContext: false },
+      },
+    });
+    const rt = makeTestRuntime({ config });
+    createdRuntimes.push(rt);
+
+    const adapter = {
+      complete: mock(async () => {
+        callCount++;
+        return {
+          output: "",
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          estimatedCostUsd: 0,
+        };
+      }),
+    };
+    (rt.agentManager as unknown as { _resolveRegistry: () => { getAgent: (name: string) => typeof adapter } })
+      ._resolveRegistry = () => ({ getAgent: () => adapter });
+
+    await callOp(
+      { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-004" },
+      makeCompleteOp("ac5-exhaustion-maxretry-3"),
+      "hello",
+    );
+
+    // 1 initial + 3 retries = 4 total
+    expect(callCount).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC6 swap: all-empty claude + working codex → callOp returns codex output
+// ---------------------------------------------------------------------------
+
+describe("AC6: complete-kind empty-output → agent swap to fallback", () => {
+  test("claude exhausted + codex configured → callOp returns codex output", async () => {
+    const config = makeNaxConfig({
+      agent: {
+        idleWatchdog: { maxRetryAttempts: 1, enabled: true, idleTimeoutSeconds: 900 },
+        fallback: {
+          enabled: true,
+          map: { claude: ["codex"] },
+          maxHopsPerStory: 3,
+          onQualityFailure: false,
+          rebuildContext: false,
+        },
+      },
+    });
+    const rt = makeTestRuntime({ config });
+    createdRuntimes.push(rt);
+
+    let claudeCallCount = 0;
+    let codexCallCount = 0;
+
+    // Multi-agent adapter registry: claude always empty, codex returns success
+    const adapters: Record<string, { complete: ReturnType<typeof mock> }> = {
+      claude: {
+        complete: mock(async () => {
+          claudeCallCount++;
+          return {
+            output: "",
+            tokenUsage: { inputTokens: 0, outputTokens: 0 },
+            estimatedCostUsd: 0,
+          };
+        }),
+      },
+      codex: {
+        complete: mock(async () => {
+          codexCallCount++;
+          return {
+            output: "codex output",
+            tokenUsage: { inputTokens: 0, outputTokens: 0 },
+            estimatedCostUsd: 0,
+          };
+        }),
+      },
+    };
+
+    (rt.agentManager as unknown as { _resolveRegistry: () => { getAgent: (name: string) => { complete: ReturnType<typeof mock> } | undefined } })
+      ._resolveRegistry = () => ({
+        getAgent: (name: string) => adapters[name],
+      });
+
+    const result = await callOp(
+      { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-005" },
+      makeCompleteOp("ac6-swap-to-codex"),
+      "hello",
+    );
+
+    expect(result).toBe("codex output");
+    // claude called: 1 initial + 1 retry (maxRetryAttempts=1) = 2 times
+    expect(claudeCallCount).toBe(2);
+    // codex called once after swap
+    expect(codexCallCount).toBe(1);
+  });
+
+  test("claude immediate-swap (no retries) + codex → callOp returns codex output with maxRetryAttempts=0", async () => {
+    const config = makeNaxConfig({
+      agent: {
+        idleWatchdog: { maxRetryAttempts: 0, enabled: true, idleTimeoutSeconds: 900 },
+        fallback: {
+          enabled: true,
+          map: { claude: ["codex"] },
+          maxHopsPerStory: 3,
+          onQualityFailure: false,
+          rebuildContext: false,
+        },
+      },
+    });
+    const rt = makeTestRuntime({ config });
+    createdRuntimes.push(rt);
+
+    let claudeCallCount = 0;
+    let codexCallCount = 0;
+
+    const adapters: Record<string, { complete: ReturnType<typeof mock> }> = {
+      claude: {
+        complete: mock(async () => {
+          claudeCallCount++;
+          return {
+            output: "",
+            tokenUsage: { inputTokens: 0, outputTokens: 0 },
+            estimatedCostUsd: 0,
+          };
+        }),
+      },
+      codex: {
+        complete: mock(async () => {
+          codexCallCount++;
+          return {
+            output: "codex success",
+            tokenUsage: { inputTokens: 0, outputTokens: 0 },
+            estimatedCostUsd: 0,
+          };
+        }),
+      },
+    };
+
+    (rt.agentManager as unknown as { _resolveRegistry: () => { getAgent: (name: string) => { complete: ReturnType<typeof mock> } | undefined } })
+      ._resolveRegistry = () => ({
+        getAgent: (name: string) => adapters[name],
+      });
+
+    const result = await callOp(
+      { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-006" },
+      makeCompleteOp("ac6-immediate-swap"),
+      "hello",
+    );
+
+    expect(result).toBe("codex success");
+    // claude called once only (maxRetryAttempts=0 → no same-agent retries)
+    expect(claudeCallCount).toBe(1);
+    // codex called once after swap
+    expect(codexCallCount).toBe(1);
+  });
+});

--- a/test/integration/operations/run-empty-output-retry.test.ts
+++ b/test/integration/operations/run-empty-output-retry.test.ts
@@ -15,12 +15,11 @@
  *   - runWithFallbackFn calls req.executeHop multiple times to simulate retry loop
  *   - runAsSessionFn controls what the underlying send returns (stateful via counter)
  */
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { callOp } from "../../../src/operations";
 import type { RunOperation } from "../../../src/operations";
 import { DEFAULT_CONFIG, pickSelector } from "../../../src/config";
-import { makeMockAgentManager, makeMockRuntime, makeSessionManager } from "../../helpers";
-import type { NaxRuntime } from "../../../src/runtime";
+import { makeMockAgentManager, makeMockCallContext, makeMockRuntime, makeSessionManager } from "../../helpers";
 import type { TurnResult } from "../../../src/agents/types";
 
 const sel = pickSelector("run-empty-output-retry-test", "routing");
@@ -48,16 +47,6 @@ function makeTurnResult(output: string): TurnResult {
     tokenUsage: { inputTokens: 0, outputTokens: 0 },
   };
 }
-
-// ---------------------------------------------------------------------------
-// Runtime cleanup (mandatory per project rules)
-// ---------------------------------------------------------------------------
-
-const createdRuntimes: NaxRuntime[] = [];
-afterEach(async () => {
-  await Promise.allSettled(createdRuntimes.map((r) => r.close()));
-  createdRuntimes.length = 0;
-});
 
 // ---------------------------------------------------------------------------
 // AC3 — happy path: empty output on first attempt, success on retry
@@ -99,10 +88,9 @@ describe("AC3: run-kind empty-output → runWithFallback retry (same agent)", ()
     });
 
     const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
-    createdRuntimes.push(runtime);
 
     const result = await callOp(
-      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      makeMockCallContext({ runtime }),
       makeRunOp("retry-happy-path"),
       "hello",
     );
@@ -141,10 +129,9 @@ describe("AC3: run-kind empty-output → runWithFallback retry (same agent)", ()
     });
 
     const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
-    createdRuntimes.push(runtime);
 
     const result = await callOp(
-      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      makeMockCallContext({ runtime }),
       makeRunOp("retry-two-failures"),
       "hello",
     );
@@ -188,15 +175,10 @@ describe("AC3: run-kind empty-output — all retries exhausted → CALL_OP_NO_OU
     });
 
     const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
-    createdRuntimes.push(runtime);
 
     let thrown: Error & { code?: string } | null = null;
     try {
-      await callOp(
-        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
-        makeRunOp("exhaust-retries"),
-        "hello",
-      );
+      await callOp(makeMockCallContext({ runtime }), makeRunOp("exhaust-retries"), "hello");
     } catch (err) {
       thrown = err as Error & { code?: string };
     }
@@ -223,15 +205,10 @@ describe("AC3: run-kind empty-output — all retries exhausted → CALL_OP_NO_OU
     });
 
     const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
-    createdRuntimes.push(runtime);
 
     let thrown: Error & { code?: string } | null = null;
     try {
-      await callOp(
-        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
-        makeRunOp("zero-retries"),
-        "hello",
-      );
+      await callOp(makeMockCallContext({ runtime }), makeRunOp("zero-retries"), "hello");
     } catch (err) {
       thrown = err as Error & { code?: string };
     }
@@ -261,14 +238,9 @@ describe("AC3: sendWithFileOutput synthesises fail-stale on empty run-kind outpu
     });
 
     const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
-    createdRuntimes.push(runtime);
 
     try {
-      await callOp(
-        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
-        makeRunOp("synthesis-check"),
-        "hello",
-      );
+      await callOp(makeMockCallContext({ runtime }), makeRunOp("synthesis-check"), "hello");
     } catch {
       // expected CALL_OP_NO_OUTPUT — we only care about the synthesised failure shape
     }

--- a/test/integration/operations/run-empty-output-retry.test.ts
+++ b/test/integration/operations/run-empty-output-retry.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Integration test — AC3: run-kind callOp empty-output retry via runWithFallback.
+ *
+ * When a run-kind op receives empty agent output, sendWithFileOutput synthesises
+ * a retriable fail-stale AdapterFailure. AgentManager.runWithFallback recognises
+ * this and retries the same agent up to idleWatchdog.maxRetryAttempts times before
+ * exhaustion (or fallback agent swap).
+ *
+ * These tests exercise the full dispatch path:
+ *   callOp → runWithFallback → executeHop (sendWithFileOutput synthesis) → fail-stale
+ *   → same-agent retry → success / exhaustion
+ *
+ * Pattern (from test/unit/operations/call-empty-output.test.ts):
+ *   - makeMockAgentManager({ runWithFallbackFn, runAsSessionFn })
+ *   - runWithFallbackFn calls req.executeHop multiple times to simulate retry loop
+ *   - runAsSessionFn controls what the underlying send returns (stateful via counter)
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { callOp } from "../../../src/operations";
+import type { RunOperation } from "../../../src/operations";
+import { DEFAULT_CONFIG, pickSelector } from "../../../src/config";
+import { makeMockAgentManager, makeMockRuntime, makeSessionManager } from "../../helpers";
+import type { NaxRuntime } from "../../../src/runtime";
+import type { TurnResult } from "../../../src/agents/types";
+
+const sel = pickSelector("run-empty-output-retry-test", "routing");
+
+function makeRunOp(name: string): RunOperation<string, string, Pick<typeof DEFAULT_CONFIG, "routing">> {
+  return {
+    kind: "run",
+    name,
+    stage: "run",
+    config: sel,
+    session: { role: "implementer", lifetime: "fresh" },
+    build: (input) => ({
+      role: { id: "role", content: "Echo the input.", overridable: false },
+      task: { id: "task", content: input, overridable: false },
+    }),
+    parse: (output) => output.trim(),
+  };
+}
+
+function makeTurnResult(output: string): TurnResult {
+  return {
+    output,
+    estimatedCostUsd: 0,
+    internalRoundTrips: 0,
+    tokenUsage: { inputTokens: 0, outputTokens: 0 },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Runtime cleanup (mandatory per project rules)
+// ---------------------------------------------------------------------------
+
+const createdRuntimes: NaxRuntime[] = [];
+afterEach(async () => {
+  await Promise.allSettled(createdRuntimes.map((r) => r.close()));
+  createdRuntimes.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// AC3 — happy path: empty output on first attempt, success on retry
+// ---------------------------------------------------------------------------
+
+describe("AC3: run-kind empty-output → runWithFallback retry (same agent)", () => {
+  test("empty output on first hop → retry engages → returns success on second hop", async () => {
+    let hopCallCount = 0;
+
+    // runAsSessionFn is the underlying send. Return empty on first call, success on second.
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        // Simulate retry: first hop triggers fail-stale synthesis, second succeeds.
+        // executeHop calls sendWithFileOutput internally which synthesises fail-stale
+        // when output is empty — we call it twice to exercise the retry loop.
+        const firstHop = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+
+        // After first hop with empty output, adapterFailure is synthesised (fail-stale).
+        // Retry by calling executeHop again (same agent).
+        if (firstHop.result.adapterFailure?.outcome === "fail-stale") {
+          const retryHop = await req.executeHop!(
+            "claude",
+            undefined,
+            { kind: "stale-retry", attempt: 1 },
+            req.runOptions,
+          );
+          return { result: { ...retryHop.result, agentFallbacks: [] }, fallbacks: [] };
+        }
+
+        return { result: { ...firstHop.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => {
+        hopCallCount++;
+        if (hopCallCount === 1) {
+          return makeTurnResult(""); // empty — triggers fail-stale synthesis
+        }
+        return makeTurnResult("success on retry");
+      },
+    });
+
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      makeRunOp("retry-happy-path"),
+      "hello",
+    );
+
+    expect(result).toBe("success on retry");
+    expect(hopCallCount).toBe(2);
+  });
+
+  test("empty output on first two hops → retries → returns success on third hop", async () => {
+    let hopCallCount = 0;
+
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        // Loop up to 3 times, retrying when fail-stale is synthesised.
+        let lastHop = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+
+        for (let attempt = 1; attempt <= 2; attempt++) {
+          if (lastHop.result.adapterFailure?.outcome !== "fail-stale") break;
+          lastHop = await req.executeHop!(
+            "claude",
+            undefined,
+            { kind: "stale-retry", attempt },
+            req.runOptions,
+          );
+        }
+
+        return { result: { ...lastHop.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => {
+        hopCallCount++;
+        if (hopCallCount <= 2) {
+          return makeTurnResult(""); // empty — triggers fail-stale synthesis
+        }
+        return makeTurnResult("eventual success");
+      },
+    });
+
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      makeRunOp("retry-two-failures"),
+      "hello",
+    );
+
+    expect(result).toBe("eventual success");
+    expect(hopCallCount).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC3 — exhaustion path: all retries produce empty output → CALL_OP_NO_OUTPUT
+// ---------------------------------------------------------------------------
+
+describe("AC3: run-kind empty-output — all retries exhausted → CALL_OP_NO_OUTPUT", () => {
+  test("all hops return empty output → runWithFallback passes empty result → callOp throws CALL_OP_NO_OUTPUT", async () => {
+    let hopCallCount = 0;
+
+    // maxRetryAttempts=2: simulate 3 total hops (1 initial + 2 retries), all empty.
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        // 1 initial + 2 retries = 3 hops, all producing empty output.
+        let lastHop = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+
+        for (let attempt = 1; attempt <= 2; attempt++) {
+          if (lastHop.result.adapterFailure?.outcome !== "fail-stale") break;
+          lastHop = await req.executeHop!(
+            "claude",
+            undefined,
+            { kind: "stale-retry", attempt },
+            req.runOptions,
+          );
+        }
+
+        // All retries exhausted — pass empty result back to callOp.
+        return { result: { ...lastHop.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => {
+        hopCallCount++;
+        return makeTurnResult(""); // always empty
+      },
+    });
+
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    let thrown: Error & { code?: string } | null = null;
+    try {
+      await callOp(
+        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+        makeRunOp("exhaust-retries"),
+        "hello",
+      );
+    } catch (err) {
+      thrown = err as Error & { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    expect(thrown?.code).toBe("CALL_OP_NO_OUTPUT");
+    // 1 initial + 2 retries = 3 total send calls
+    expect(hopCallCount).toBe(3);
+  });
+
+  test("single hop with empty output and no retry → immediately throws CALL_OP_NO_OUTPUT", async () => {
+    let hopCallCount = 0;
+
+    // runWithFallbackFn performs no retry — simulates maxRetryAttempts=0 case.
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hop = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hop.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => {
+        hopCallCount++;
+        return makeTurnResult(""); // always empty, no retry in manager
+      },
+    });
+
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    let thrown: Error & { code?: string } | null = null;
+    try {
+      await callOp(
+        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+        makeRunOp("zero-retries"),
+        "hello",
+      );
+    } catch (err) {
+      thrown = err as Error & { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    expect(thrown?.code).toBe("CALL_OP_NO_OUTPUT");
+    expect(hopCallCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC3 — synthesis verification: empty output sets adapterFailure with correct shape
+// ---------------------------------------------------------------------------
+
+describe("AC3: sendWithFileOutput synthesises fail-stale on empty run-kind output", () => {
+  test("synthesised adapterFailure has outcome=fail-stale, reason=empty-output, retriable=true", async () => {
+    let capturedAdapterFailure: unknown;
+
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        // Capture what sendWithFileOutput synthesised on the hop result.
+        capturedAdapterFailure = (hopResult.result as { adapterFailure?: unknown }).adapterFailure;
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => makeTurnResult(""),
+    });
+
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    try {
+      await callOp(
+        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+        makeRunOp("synthesis-check"),
+        "hello",
+      );
+    } catch {
+      // expected CALL_OP_NO_OUTPUT — we only care about the synthesised failure shape
+    }
+
+    const f = capturedAdapterFailure as { outcome?: string; category?: string; retriable?: boolean; reason?: string } | undefined;
+    expect(f?.outcome).toBe("fail-stale");
+    expect(f?.category).toBe("availability");
+    expect(f?.retriable).toBe(true);
+    expect(f?.reason).toBe("empty-output");
+  });
+});

--- a/test/unit/agents/manager-complete-empty-output.test.ts
+++ b/test/unit/agents/manager-complete-empty-output.test.ts
@@ -9,8 +9,9 @@ const baseOptions = {
   resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const },
 };
 
-function makeConfig(maxRetryAttempts = 3, enableFallback = true) {
-  return makeNaxConfig({
+/** Build a NaxConfig slice for watchdog + fallback tuning used by these tests. */
+const naxConfigWith = (maxRetryAttempts = 3, enableFallback = true) =>
+  makeNaxConfig({
     agent: {
       idleWatchdog: {
         enabled: true,
@@ -26,7 +27,6 @@ function makeConfig(maxRetryAttempts = 3, enableFallback = true) {
       },
     },
   });
-}
 
 function makeStaticRegistry(agentName: string, outputSequence: string[]) {
   let callCount = 0;
@@ -88,7 +88,7 @@ describe("completeWithFallback empty-output synthesis (AC4)", () => {
   test("AC4a: empty output with no adapterFailure synthesizes fail-stale with reason empty-output", async () => {
     const { registry } = makeStaticRegistry("claude", [""]);
     // maxStaleRetries=0, no fallback — so synthesized failure is returned immediately
-    const config = makeConfig(0, false);
+    const config = naxConfigWith(0, false);
     const m = new AgentManager(config, registry);
     const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
     const failure = outcome.result.adapterFailure;
@@ -100,7 +100,7 @@ describe("completeWithFallback empty-output synthesis (AC4)", () => {
 
   test("AC4b: non-empty output returns success with no synthesis", async () => {
     const { registry } = makeStaticRegistry("claude", ["hello world"]);
-    const m = new AgentManager(makeConfig(), registry);
+    const m = new AgentManager(naxConfigWith(), registry);
     const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
     expect(outcome.result.output).toBe("hello world");
     expect(outcome.result.adapterFailure).toBeUndefined();
@@ -108,7 +108,7 @@ describe("completeWithFallback empty-output synthesis (AC4)", () => {
 
   test("AC4c: whitespace-only output triggers synthesis", async () => {
     const { registry } = makeStaticRegistry("claude", ["   "]);
-    const config = makeConfig(0, false);
+    const config = naxConfigWith(0, false);
     const m = new AgentManager(config, registry);
     const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
     expect(outcome.result.adapterFailure?.outcome).toBe("fail-stale");
@@ -137,7 +137,7 @@ describe("completeWithFallback empty-output synthesis (AC4)", () => {
       },
     } as unknown as AgentRegistry;
 
-    const config = makeConfig(0, false);
+    const config = naxConfigWith(0, false);
     const m = new AgentManager(config, registry);
     const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
     // Should NOT be overwritten with fail-stale
@@ -149,7 +149,7 @@ describe("completeWithFallback staleRetryAttempts counter (AC5)", () => {
   test("AC5a: retries same agent up to maxRetryAttempts=3 before exhausting (adapter called 4 times total)", async () => {
     // 4 calls all return empty: initial + 3 retries = 4 total; no fallback so we stop there
     const { registry, getCallCount } = makeStaticRegistry("claude", ["", "", "", ""]);
-    const config = makeConfig(3, false);
+    const config = naxConfigWith(3, false);
     const m = new AgentManager(config, registry);
     await m.completeWithFallback("prompt", baseOptions, "claude");
     expect(getCallCount()).toBe(4);
@@ -157,7 +157,7 @@ describe("completeWithFallback staleRetryAttempts counter (AC5)", () => {
 
   test("AC5b: maxRetryAttempts=1 results in 2 calls total (1 initial + 1 retry)", async () => {
     const { registry, getCallCount } = makeStaticRegistry("claude", ["", ""]);
-    const config = makeConfig(1, false);
+    const config = naxConfigWith(1, false);
     const m = new AgentManager(config, registry);
     await m.completeWithFallback("prompt", baseOptions, "claude");
     expect(getCallCount()).toBe(2);
@@ -168,7 +168,7 @@ describe("completeWithFallback retry success (AC6)", () => {
   test("AC6a: retry succeeds on second attempt — only 2 calls, no fallback", async () => {
     // First call returns empty, second returns non-empty
     const { registry, getCallCount } = makeStaticRegistry("claude", ["", "success output"]);
-    const m = new AgentManager(makeConfig(3, false), registry);
+    const m = new AgentManager(naxConfigWith(3, false), registry);
     const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
     expect(outcome.result.output).toBe("success output");
     expect(outcome.result.adapterFailure).toBeUndefined();
@@ -184,7 +184,7 @@ describe("completeWithFallback retry success (AC6)", () => {
       claude: { outputs: ["", "", "", ""] },  // 4 empties: initial + 3 retries
       codex: { outputs: ["from codex"] },
     });
-    const m = new AgentManager(makeConfig(3), registry);
+    const m = new AgentManager(naxConfigWith(3), registry);
     const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
     expect(outcome.result.output).toBe("from codex");
     expect(outcome.fallbacks.length).toBeGreaterThan(0);

--- a/test/unit/agents/manager-complete-empty-output.test.ts
+++ b/test/unit/agents/manager-complete-empty-output.test.ts
@@ -172,7 +172,10 @@ describe("completeWithFallback retry success (AC6)", () => {
     const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
     expect(outcome.result.output).toBe("success output");
     expect(outcome.result.adapterFailure).toBeUndefined();
-    expect(outcome.fallbacks).toHaveLength(0);
+    // Stale-retry hop is recorded in fallbacks (mirrors runWithFallback behavior)
+    expect(outcome.fallbacks).toHaveLength(1);
+    expect(outcome.fallbacks[0].priorAgent).toBe("claude");
+    expect(outcome.fallbacks[0].newAgent).toBe("claude"); // same-agent retry
     expect(getCallCount()).toBe(2);
   });
 

--- a/test/unit/agents/manager-complete-empty-output.test.ts
+++ b/test/unit/agents/manager-complete-empty-output.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, mock, test } from "bun:test";
+import { AgentManager } from "../../../src/agents/manager";
+import type { AgentRegistry } from "../../../src/agents/registry";
+import { makeNaxConfig } from "../../helpers";
+
+const baseOptions = {
+  modelDef: { provider: "anthropic" as const, model: "claude-sonnet-4-6", env: {} as Record<string, string> },
+  workdir: "/tmp/test",
+  resolvedPermissions: { skipPermissions: false, mode: "approve-reads" as const },
+};
+
+function makeConfig(maxRetryAttempts = 3, enableFallback = true) {
+  return makeNaxConfig({
+    agent: {
+      idleWatchdog: {
+        enabled: true,
+        idleTimeoutMs: 30000,
+        pingIntervalMs: 10000,
+        maxRetryAttempts,
+      },
+      fallback: {
+        enabled: enableFallback,
+        map: enableFallback ? { claude: ["codex"] } : {},
+        maxHopsPerStory: 2,
+        onQualityFailure: false,
+        rebuildContext: false,
+      },
+    },
+  });
+}
+
+function makeStaticRegistry(agentName: string, outputSequence: string[]) {
+  let callCount = 0;
+  const completeMock = mock(async () => {
+    const output = outputSequence[callCount] ?? "";
+    callCount++;
+    return {
+      output,
+      tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      estimatedCostUsd: 0,
+    };
+  });
+  return {
+    registry: {
+      getAgent: (name: string) => {
+        if (name !== agentName) return undefined;
+        return { complete: completeMock };
+      },
+    } as unknown as AgentRegistry,
+    completeMock,
+    getCallCount: () => callCount,
+  };
+}
+
+function makeMultiAgentRegistry(
+  agents: Record<string, { outputs: string[] }>,
+) {
+  const mocks: Record<string, ReturnType<typeof mock>> = {};
+  const callCounts: Record<string, number> = {};
+
+  for (const [name, cfg] of Object.entries(agents)) {
+    callCounts[name] = 0;
+    const localName = name;
+    mocks[localName] = mock(async () => {
+      const output = cfg.outputs[callCounts[localName]] ?? "";
+      callCounts[localName]++;
+      return {
+        output,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        estimatedCostUsd: 0,
+      };
+    });
+  }
+
+  return {
+    registry: {
+      getAgent: (name: string) => {
+        const m = mocks[name];
+        if (!m) return undefined;
+        return { complete: m };
+      },
+    } as unknown as AgentRegistry,
+    mocks,
+    callCounts,
+  };
+}
+
+describe("completeWithFallback empty-output synthesis (AC4)", () => {
+  test("AC4a: empty output with no adapterFailure synthesizes fail-stale with reason empty-output", async () => {
+    const { registry } = makeStaticRegistry("claude", [""]);
+    // maxStaleRetries=0, no fallback — so synthesized failure is returned immediately
+    const config = makeConfig(0, false);
+    const m = new AgentManager(config, registry);
+    const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
+    const failure = outcome.result.adapterFailure;
+    expect(failure).toBeDefined();
+    expect(failure?.outcome).toBe("fail-stale");
+    expect(failure?.reason).toBe("empty-output");
+    expect(failure?.retriable).toBe(true);
+  });
+
+  test("AC4b: non-empty output returns success with no synthesis", async () => {
+    const { registry } = makeStaticRegistry("claude", ["hello world"]);
+    const m = new AgentManager(makeConfig(), registry);
+    const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
+    expect(outcome.result.output).toBe("hello world");
+    expect(outcome.result.adapterFailure).toBeUndefined();
+  });
+
+  test("AC4c: whitespace-only output triggers synthesis", async () => {
+    const { registry } = makeStaticRegistry("claude", ["   "]);
+    const config = makeConfig(0, false);
+    const m = new AgentManager(config, registry);
+    const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
+    expect(outcome.result.adapterFailure?.outcome).toBe("fail-stale");
+    expect(outcome.result.adapterFailure?.reason).toBe("empty-output");
+  });
+
+  test("AC4d: pre-existing adapterFailure on empty output is NOT overwritten", async () => {
+    // Registry returns empty output but also a pre-existing failure
+    const existingFailure = {
+      outcome: "fail-auth" as const,
+      category: "availability" as const,
+      retriable: false,
+      message: "auth failed",
+    };
+    const registry = {
+      getAgent: (name: string) => {
+        if (name !== "claude") return undefined;
+        return {
+          complete: mock(async () => ({
+            output: "",
+            tokenUsage: { inputTokens: 0, outputTokens: 0 },
+            estimatedCostUsd: 0,
+            adapterFailure: existingFailure,
+          })),
+        };
+      },
+    } as unknown as AgentRegistry;
+
+    const config = makeConfig(0, false);
+    const m = new AgentManager(config, registry);
+    const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
+    // Should NOT be overwritten with fail-stale
+    expect(outcome.result.adapterFailure?.outcome).toBe("fail-auth");
+  });
+});
+
+describe("completeWithFallback staleRetryAttempts counter (AC5)", () => {
+  test("AC5a: retries same agent up to maxRetryAttempts=3 before exhausting (adapter called 4 times total)", async () => {
+    // 4 calls all return empty: initial + 3 retries = 4 total; no fallback so we stop there
+    const { registry, getCallCount } = makeStaticRegistry("claude", ["", "", "", ""]);
+    const config = makeConfig(3, false);
+    const m = new AgentManager(config, registry);
+    await m.completeWithFallback("prompt", baseOptions, "claude");
+    expect(getCallCount()).toBe(4);
+  });
+
+  test("AC5b: maxRetryAttempts=1 results in 2 calls total (1 initial + 1 retry)", async () => {
+    const { registry, getCallCount } = makeStaticRegistry("claude", ["", ""]);
+    const config = makeConfig(1, false);
+    const m = new AgentManager(config, registry);
+    await m.completeWithFallback("prompt", baseOptions, "claude");
+    expect(getCallCount()).toBe(2);
+  });
+});
+
+describe("completeWithFallback retry success (AC6)", () => {
+  test("AC6a: retry succeeds on second attempt — only 2 calls, no fallback", async () => {
+    // First call returns empty, second returns non-empty
+    const { registry, getCallCount } = makeStaticRegistry("claude", ["", "success output"]);
+    const m = new AgentManager(makeConfig(3, false), registry);
+    const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
+    expect(outcome.result.output).toBe("success output");
+    expect(outcome.result.adapterFailure).toBeUndefined();
+    expect(outcome.fallbacks).toHaveLength(0);
+    expect(getCallCount()).toBe(2);
+  });
+
+  test("AC6b: exhausted retries + fallback configured → swaps to fallback agent", async () => {
+    const { registry, callCounts } = makeMultiAgentRegistry({
+      claude: { outputs: ["", "", "", ""] },  // 4 empties: initial + 3 retries
+      codex: { outputs: ["from codex"] },
+    });
+    const m = new AgentManager(makeConfig(3), registry);
+    const outcome = await m.completeWithFallback("prompt", baseOptions, "claude");
+    expect(outcome.result.output).toBe("from codex");
+    expect(outcome.fallbacks.length).toBeGreaterThan(0);
+    expect(callCounts["claude"]).toBe(4);
+    expect(callCounts["codex"]).toBe(1);
+  });
+});

--- a/test/unit/agents/manager-complete-empty-output.test.ts
+++ b/test/unit/agents/manager-complete-empty-output.test.ts
@@ -14,8 +14,7 @@ function makeConfig(maxRetryAttempts = 3, enableFallback = true) {
     agent: {
       idleWatchdog: {
         enabled: true,
-        idleTimeoutMs: 30000,
-        pingIntervalMs: 10000,
+        idleTimeoutSeconds: 900,
         maxRetryAttempts,
       },
       fallback: {

--- a/test/unit/operations/call-empty-output.test.ts
+++ b/test/unit/operations/call-empty-output.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { AdapterFailure } from "@/context/engine";
+import type { AdapterFailure } from "../../../src/context/engine";
 
 describe("AdapterFailure.reason field (AC9)", () => {
   test("AdapterFailure accepts optional reason field", () => {

--- a/test/unit/operations/call-empty-output.test.ts
+++ b/test/unit/operations/call-empty-output.test.ts
@@ -114,17 +114,24 @@ describe("sendWithFileOutput — AC1: empty output synthesises fail-stale Adapte
     expect((thrown as { code?: string })?.code).toBe("CALL_OP_NO_OUTPUT");
   });
 
-  test("strictly empty string output (output: '') → synthesis fires → CALL_OP_NO_OUTPUT", async () => {
-    // Verify the explicit empty-string case is the trigger for synthesis,
-    // distinct from whitespace-only (which does not reach callOp's no-output check
-    // because turnResultToAgentResult preserves the whitespace string as-is).
+  test("whitespace-only output → synthesis fires (adapterFailure set) → manager sees fail-stale", async () => {
+    // Whitespace-only output triggers synthesis (!output.trim() is true) and
+    // causes turnResultToAgentResult to mark success:false so the manager's
+    // fail-stale retry path engages. Behavioral asymmetry note: the outer
+    // callOp guard `if (!rawOutput)` uses a falsy check and will NOT throw
+    // CALL_OP_NO_OUTPUT for "   " at exhaustion — op.parse("   ") is called
+    // instead. This is acceptable: synthesis + retry is correct on the success
+    // path; at exhaustion, op.parse rejects or trims to "" per its own contract.
+    let capturedAdapterFailure: unknown;
     const agentManager = makeMockAgentManager({
       runWithFallbackFn: async (req) => {
         const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        // Capture what sendWithFileOutput synthesised on the TurnResult
+        capturedAdapterFailure = (hopResult.result as { adapterFailure?: unknown }).adapterFailure;
         return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
       },
       runAsSessionFn: async () => ({
-        output: "",
+        output: "   ",
         estimatedCostUsd: 0,
         internalRoundTrips: 0,
         tokenUsage: { inputTokens: 0, outputTokens: 0 },
@@ -133,19 +140,21 @@ describe("sendWithFileOutput — AC1: empty output synthesises fail-stale Adapte
     const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
     createdRuntimes.push(runtime);
 
-    let thrown: Error & { code?: string } | null = null;
+    // op.parse trims "   " → ""; the mock manager passes output straight through,
+    // so callOp sees rawOutput="" (falsy) and throws CALL_OP_NO_OUTPUT.
     try {
       await callOp(
         { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
-        makeRunOp("empty-string-op"),
+        makeRunOp("whitespace-op"),
         "hello",
       );
-    } catch (err) {
-      thrown = err as Error & { code?: string };
+    } catch {
+      // expected — the mock manager doesn't retry
     }
 
-    expect(thrown).not.toBeNull();
-    expect((thrown as { code?: string })?.code).toBe("CALL_OP_NO_OUTPUT");
+    // Synthesis fired: adapterFailure has the correct shape
+    expect((capturedAdapterFailure as { outcome?: string } | undefined)?.outcome).toBe("fail-stale");
+    expect((capturedAdapterFailure as { reason?: string } | undefined)?.reason).toBe("empty-output");
   });
 
   test("synthesised adapterFailure message references the op name", async () => {

--- a/test/unit/operations/call-empty-output.test.ts
+++ b/test/unit/operations/call-empty-output.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { AdapterFailure } from "../../../src/context/engine";
+import { _callOpDeps, callOp } from "../../../src/operations";
+import type { RunOperation } from "../../../src/operations";
+import { DEFAULT_CONFIG, pickSelector } from "../../../src/config";
+import { makeMockAgentManager, makeSessionManager, makeTestRuntime } from "../../helpers";
+import type { NaxRuntime } from "../../../src/runtime";
 
 // This file covers synthesis logic in sendWithFileOutput (src/operations/call.ts).
 // The AC9 tests below are a forward-declaration placeholder — Task 2 adds
@@ -24,5 +29,260 @@ describe("AdapterFailure – optional reason field", () => {
       message: "idle watchdog",
     };
     expect(f.reason).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shared test helpers
+// ---------------------------------------------------------------------------
+
+const testSel = pickSelector("empty-output-test", "routing");
+
+/** A minimal run-kind op that expects JSON object output. */
+function makeRunOp(
+  name: string,
+  fileOutputPath?: string,
+): RunOperation<string, string, Pick<typeof DEFAULT_CONFIG, "routing">> {
+  return {
+    kind: "run",
+    name,
+    stage: "run",
+    config: testSel,
+    session: { role: "implementer", lifetime: "fresh" },
+    build: (input) => ({
+      role: { id: "role", content: "You echo input.", overridable: false },
+      task: { id: "task", content: input, overridable: false },
+    }),
+    ...(fileOutputPath ? { fileOutput: () => fileOutputPath } : {}),
+    parse: (output) => output.trim(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle: save/restore _callOpDeps + runtime cleanup
+// ---------------------------------------------------------------------------
+
+let origReadFileOutput: typeof _callOpDeps.readFileOutput;
+const createdRuntimes: NaxRuntime[] = [];
+
+beforeEach(() => {
+  origReadFileOutput = _callOpDeps.readFileOutput;
+});
+afterEach(async () => {
+  _callOpDeps.readFileOutput = origReadFileOutput;
+  await Promise.allSettled(createdRuntimes.map((r) => r.close()));
+  createdRuntimes.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// AC1: empty agent output → synthesis fires → callOp throws CALL_OP_NO_OUTPUT
+// ---------------------------------------------------------------------------
+
+describe("sendWithFileOutput — AC1: empty output synthesises fail-stale AdapterFailure", () => {
+  test("empty turn output with no fileOutput → throws CALL_OP_NO_OUTPUT (not CALL_OP_PARSE_FAILED)", async () => {
+    // runWithFallbackFn invokes executeHop so sendWithFileOutput runs.
+    // runAsSessionFn is the underlying send stub that returns empty output.
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => ({
+        output: "",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    let thrown: Error & { code?: string } | null = null;
+    try {
+      await callOp(
+        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+        makeRunOp("empty-output-no-file"),
+        "hello",
+      );
+    } catch (err) {
+      thrown = err as Error & { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    // Must throw CALL_OP_NO_OUTPUT, not CALL_OP_PARSE_FAILED
+    expect(thrown?.message).toContain("agent returned no output");
+    expect((thrown as { code?: string })?.code).toBe("CALL_OP_NO_OUTPUT");
+  });
+
+  test("strictly empty string output (output: '') → synthesis fires → CALL_OP_NO_OUTPUT", async () => {
+    // Verify the explicit empty-string case is the trigger for synthesis,
+    // distinct from whitespace-only (which does not reach callOp's no-output check
+    // because turnResultToAgentResult preserves the whitespace string as-is).
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => ({
+        output: "",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    let thrown: Error & { code?: string } | null = null;
+    try {
+      await callOp(
+        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+        makeRunOp("empty-string-op"),
+        "hello",
+      );
+    } catch (err) {
+      thrown = err as Error & { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    expect((thrown as { code?: string })?.code).toBe("CALL_OP_NO_OUTPUT");
+  });
+
+  test("synthesised adapterFailure message references the op name", async () => {
+    // Capture the hop result to inspect the synthesised adapterFailure before
+    // it propagates through runWithFallback → CALL_OP_NO_OUTPUT.
+    let capturedOutput: string | undefined;
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        capturedOutput = hopResult.result.output;
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => ({
+        output: "",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    let thrown: Error & { code?: string; context?: { storyId?: string } } | null = null;
+    try {
+      await callOp(
+        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+        makeRunOp("my-named-op"),
+        "hello",
+      );
+    } catch (err) {
+      thrown = err as Error & { code?: string; context?: { storyId?: string } };
+    }
+
+    expect(thrown).not.toBeNull();
+    // The synthesised failure output is empty string (no content injected).
+    // The CALL_OP_NO_OUTPUT error message confirms synthesis did fire (op name in msg).
+    expect(thrown?.message).toContain("my-named-op");
+    expect((thrown as { code?: string })?.code).toBe("CALL_OP_NO_OUTPUT");
+    // The hop result output is empty because sendWithFileOutput set adapterFailure
+    // but left output as-is (empty), which then flows to callOp as rawOutput="".
+    expect(capturedOutput).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC2: file-overlay with non-empty content → synthesis does NOT fire
+// ---------------------------------------------------------------------------
+
+describe("sendWithFileOutput — AC2: file overlay with content suppresses synthesis", () => {
+  test("file overlay returns non-empty content → callOp succeeds (no synthesis)", async () => {
+    const outputPath = "/tmp/plan-ac2.json";
+    _callOpDeps.readFileOutput = async (path) => {
+      expect(path).toBe(outputPath);
+      return "file content from overlay";
+    };
+
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => ({
+        // Agent acknowledged but wrote nothing to stdout — the file has the real output.
+        output: "",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      makeRunOp("file-overlay-op", outputPath),
+      "hello",
+    );
+
+    // parse trims — content from file is used directly
+    expect(result).toBe("file content from overlay");
+  });
+
+  test("file overlay returns null (file missing) → synthesis still fires → CALL_OP_NO_OUTPUT", async () => {
+    _callOpDeps.readFileOutput = async () => null;
+
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => ({
+        output: "",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    let thrown: { code?: string } | null = null;
+    try {
+      await callOp(
+        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+        makeRunOp("file-missing-op", "/tmp/missing-file.txt"),
+        "hello",
+      );
+    } catch (err) {
+      thrown = err as { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    expect(thrown?.code).toBe("CALL_OP_NO_OUTPUT");
+  });
+
+  test("non-empty agent output without fileOutput → synthesis does NOT fire", async () => {
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => ({
+        output: "substantial agent output",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      makeRunOp("non-empty-op"),
+      "hello",
+    );
+
+    expect(result).toBe("substantial agent output");
   });
 });

--- a/test/unit/operations/call-empty-output.test.ts
+++ b/test/unit/operations/call-empty-output.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import type { AdapterFailure } from "@/context/engine";
+
+describe("AdapterFailure.reason field (AC9)", () => {
+  test("AdapterFailure accepts optional reason field", () => {
+    const f: AdapterFailure = {
+      category: "availability",
+      outcome: "fail-stale",
+      retriable: true,
+      message: "test",
+      reason: "empty-output",
+    };
+    expect(f.reason).toBe("empty-output");
+  });
+
+  test("AdapterFailure without reason still compiles and has undefined reason", () => {
+    const f: AdapterFailure = {
+      category: "availability",
+      outcome: "fail-stale",
+      retriable: true,
+      message: "idle watchdog",
+    };
+    expect(f.reason).toBeUndefined();
+  });
+});

--- a/test/unit/operations/call-empty-output.test.ts
+++ b/test/unit/operations/call-empty-output.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { AdapterFailure } from "../../../src/context/engine";
 
-describe("AdapterFailure.reason field (AC9)", () => {
+// This file covers synthesis logic in sendWithFileOutput (src/operations/call.ts).
+// The AC9 tests below are a forward-declaration placeholder — Task 2 adds
+// behavioral tests once the synthesis is implemented.
+describe("AdapterFailure – optional reason field", () => {
   test("AdapterFailure accepts optional reason field", () => {
     const f: AdapterFailure = {
       category: "availability",

--- a/test/unit/operations/call-empty-output.test.ts
+++ b/test/unit/operations/call-empty-output.test.ts
@@ -3,7 +3,7 @@ import type { AdapterFailure } from "../../../src/context/engine";
 import { _callOpDeps, callOp } from "../../../src/operations";
 import type { RunOperation } from "../../../src/operations";
 import { DEFAULT_CONFIG, pickSelector } from "../../../src/config";
-import { makeMockAgentManager, makeSessionManager, makeTestRuntime } from "../../helpers";
+import { makeMockAgentManager, makeMockRuntime, makeSessionManager } from "../../helpers";
 import type { NaxRuntime } from "../../../src/runtime";
 
 // This file covers synthesis logic in sendWithFileOutput (src/operations/call.ts).
@@ -94,7 +94,7 @@ describe("sendWithFileOutput — AC1: empty output synthesises fail-stale Adapte
         tokenUsage: { inputTokens: 0, outputTokens: 0 },
       }),
     });
-    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
     createdRuntimes.push(runtime);
 
     let thrown: Error & { code?: string } | null = null;
@@ -130,7 +130,7 @@ describe("sendWithFileOutput — AC1: empty output synthesises fail-stale Adapte
         tokenUsage: { inputTokens: 0, outputTokens: 0 },
       }),
     });
-    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
     createdRuntimes.push(runtime);
 
     let thrown: Error & { code?: string } | null = null;
@@ -165,7 +165,7 @@ describe("sendWithFileOutput — AC1: empty output synthesises fail-stale Adapte
         tokenUsage: { inputTokens: 0, outputTokens: 0 },
       }),
     });
-    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
     createdRuntimes.push(runtime);
 
     let thrown: Error & { code?: string; context?: { storyId?: string } } | null = null;
@@ -215,7 +215,7 @@ describe("sendWithFileOutput — AC2: file overlay with content suppresses synth
         tokenUsage: { inputTokens: 0, outputTokens: 0 },
       }),
     });
-    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
     createdRuntimes.push(runtime);
 
     const result = await callOp(
@@ -243,7 +243,7 @@ describe("sendWithFileOutput — AC2: file overlay with content suppresses synth
         tokenUsage: { inputTokens: 0, outputTokens: 0 },
       }),
     });
-    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
     createdRuntimes.push(runtime);
 
     let thrown: { code?: string } | null = null;
@@ -274,7 +274,7 @@ describe("sendWithFileOutput — AC2: file overlay with content suppresses synth
         tokenUsage: { inputTokens: 0, outputTokens: 0 },
       }),
     });
-    const runtime = makeTestRuntime({ agentManager, sessionManager: makeSessionManager() });
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
     createdRuntimes.push(runtime);
 
     const result = await callOp(

--- a/test/unit/operations/call-exhaustion.test.ts
+++ b/test/unit/operations/call-exhaustion.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Unit test — AC7: exhaustion boundary — callOp throws CALL_OP_NO_OUTPUT when all retries exhaust.
+ *
+ * Tests that after all manager-tier retries and swaps exhaust with empty output,
+ * callOp throws NaxError with code CALL_OP_NO_OUTPUT (not CALL_OP_PARSE_FAILED
+ * or any other code).
+ *
+ * - Run-kind: CALL_OP_NO_OUTPUT is thrown at call.ts line 471 when rawOutput is falsy.
+ * - Complete-kind: completeWithFallback exhaustion returns empty output; op.parse receives "".
+ *   When op.parse throws on empty, the error propagates through callOp (not as CALL_OP_NO_OUTPUT).
+ *   When op.parse succeeds on empty (returns ""), callOp returns "".
+ *   The AC7 test for complete-kind verifies callOp does NOT throw CALL_OP_PARSE_FAILED —
+ *   it either returns empty or the error from op.parse, preserving the correct code boundary.
+ *
+ * Pattern:
+ *   - makeMockAgentManager for tests that control dispatch at the manager level
+ *   - makeTestRuntime for tests that use the real AgentManager
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { callOp } from "../../../src/operations";
+import type { CompleteOperation, RunOperation } from "../../../src/operations";
+import { DEFAULT_CONFIG, pickSelector } from "../../../src/config";
+import { makeMockAgentManager, makeMockRuntime, makeNaxConfig, makeSessionManager, makeTestRuntime } from "../../helpers";
+import type { NaxRuntime } from "../../../src/runtime";
+import type { TurnResult } from "../../../src/agents/types";
+
+const sel = pickSelector("call-exhaustion-test", "routing");
+
+function makeRunOp(name: string): RunOperation<string, string, Pick<typeof DEFAULT_CONFIG, "routing">> {
+  return {
+    kind: "run",
+    name,
+    stage: "run",
+    config: sel,
+    session: { role: "implementer", lifetime: "fresh" },
+    build: (input) => ({
+      role: { id: "role", content: "Echo the input.", overridable: false },
+      task: { id: "task", content: input, overridable: false },
+    }),
+    parse: (output) => output.trim(),
+  };
+}
+
+function makeCompleteOp(name: string): CompleteOperation<string, string, Pick<typeof DEFAULT_CONFIG, "routing">> {
+  return {
+    kind: "complete",
+    name,
+    stage: "run",
+    config: sel,
+    build: (input) => ({
+      role: { id: "role", content: "Echo the input.", overridable: false },
+      task: { id: "task", content: input, overridable: false },
+    }),
+    parse: (output) => output.trim(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Runtime cleanup (mandatory per project rules)
+// ---------------------------------------------------------------------------
+
+const createdRuntimes: NaxRuntime[] = [];
+afterEach(async () => {
+  await Promise.allSettled(createdRuntimes.map((r) => r.close()));
+  createdRuntimes.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// AC7: run-kind exhaustion → CALL_OP_NO_OUTPUT
+// ---------------------------------------------------------------------------
+
+describe("AC7: run-kind — all retries exhaust → CALL_OP_NO_OUTPUT", () => {
+  test("maxRetryAttempts=0, no fallback, empty output → throws CALL_OP_NO_OUTPUT", async () => {
+    // runWithFallbackFn performs a single hop with empty output (no same-agent retry).
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hop = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hop.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async (): Promise<TurnResult> => ({
+        output: "",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    let thrown: (Error & { code?: string }) | null = null;
+    try {
+      await callOp(
+        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "us-001" },
+        makeRunOp("run-exhaustion-no-retry"),
+        "hello",
+      );
+    } catch (err) {
+      thrown = err as Error & { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    expect(thrown?.code).toBe("CALL_OP_NO_OUTPUT");
+  });
+
+  test("multiple retries all return empty → throws CALL_OP_NO_OUTPUT (not CALL_OP_PARSE_FAILED)", async () => {
+    let hopCount = 0;
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        // Simulate 3 retries (1 initial + 2 retries), all returning empty.
+        let lastHop = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        hopCount++;
+        for (let attempt = 1; attempt <= 2; attempt++) {
+          if (lastHop.result.adapterFailure?.outcome !== "fail-stale") break;
+          lastHop = await req.executeHop!("claude", undefined, { kind: "stale-retry", attempt }, req.runOptions);
+          hopCount++;
+        }
+        return { result: { ...lastHop.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async (): Promise<TurnResult> => ({
+        output: "", // always empty
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    let thrown: (Error & { code?: string }) | null = null;
+    try {
+      await callOp(
+        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "us-002" },
+        makeRunOp("run-exhaustion-after-retries"),
+        "hello",
+      );
+    } catch (err) {
+      thrown = err as Error & { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    // Error code must specifically be CALL_OP_NO_OUTPUT, not CALL_OP_PARSE_FAILED
+    expect(thrown?.code).toBe("CALL_OP_NO_OUTPUT");
+    expect(thrown?.code).not.toBe("CALL_OP_PARSE_FAILED");
+    expect(hopCount).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC7: complete-kind exhaustion via real AgentManager
+// ---------------------------------------------------------------------------
+
+describe("AC7: complete-kind — all retries exhaust → parse receives empty string", () => {
+  test("maxRetryAttempts=0, no fallback, empty output → callOp returns empty string (parse succeeds)", async () => {
+    const config = makeNaxConfig({
+      agent: {
+        idleWatchdog: { maxRetryAttempts: 0, enabled: true, idleTimeoutSeconds: 900 },
+        fallback: { enabled: false, map: {}, maxHopsPerStory: 0, onQualityFailure: false, rebuildContext: false },
+      },
+    });
+    const rt = makeTestRuntime({ config });
+    createdRuntimes.push(rt);
+
+    let callCount = 0;
+    const adapter = {
+      complete: async () => {
+        callCount++;
+        return {
+          output: "",
+          tokenUsage: { inputTokens: 0, outputTokens: 0 },
+          estimatedCostUsd: 0,
+        };
+      },
+    };
+    (rt.agentManager as unknown as { _resolveRegistry: () => { getAgent: () => typeof adapter } })
+      ._resolveRegistry = () => ({ getAgent: () => adapter });
+
+    // complete-kind: completeWithFallback exhausts, completeAs returns empty output,
+    // callOp calls op.parse("") → returns "" (trim of empty string).
+    const result = await callOp(
+      { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "us-003" },
+      makeCompleteOp("complete-exhaustion-no-retry"),
+      "hello",
+    );
+
+    // No exception thrown — op.parse("") returns "" which callOp returns as-is.
+    expect(result).toBe("");
+    // maxRetryAttempts=0 → only 1 call (no same-agent retries)
+    expect(callCount).toBe(1);
+  });
+
+  test("complete-kind exhaustion error code is NOT CALL_OP_PARSE_FAILED when parse rejects empty", async () => {
+    // When op.parse throws on empty output and there is no op.retry strategy,
+    // callOp re-throws the parse error directly (not wrapped as CALL_OP_PARSE_FAILED).
+    // This verifies the error code boundary — parse errors are not confused with
+    // agent-level no-output errors.
+    const config = makeNaxConfig({
+      agent: {
+        idleWatchdog: { maxRetryAttempts: 0, enabled: true, idleTimeoutSeconds: 900 },
+        fallback: { enabled: false, map: {}, maxHopsPerStory: 0, onQualityFailure: false, rebuildContext: false },
+      },
+    });
+    const rt = makeTestRuntime({ config });
+    createdRuntimes.push(rt);
+
+    const adapter = {
+      complete: async () => ({
+        output: "",
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+        estimatedCostUsd: 0,
+      }),
+    };
+    (rt.agentManager as unknown as { _resolveRegistry: () => { getAgent: () => typeof adapter } })
+      ._resolveRegistry = () => ({ getAgent: () => adapter });
+
+    // Op that throws on empty output (no retry strategy)
+    const rejectEmptyOp: CompleteOperation<string, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      kind: "complete",
+      name: "reject-empty-parse",
+      stage: "run",
+      config: sel,
+      build: (input) => ({
+        role: { id: "role", content: "Echo the input.", overridable: false },
+        task: { id: "task", content: input, overridable: false },
+      }),
+      parse: (output) => {
+        if (!output.trim()) throw new Error("parse-rejected-empty");
+        return output.trim();
+      },
+    };
+
+    let thrown: (Error & { code?: string }) | null = null;
+    try {
+      await callOp(
+        { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "us-004" },
+        rejectEmptyOp,
+        "hello",
+      );
+    } catch (err) {
+      thrown = err as Error & { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    // Parse error propagates as-is (no retry strategy) — NOT CALL_OP_PARSE_FAILED
+    expect(thrown?.message).toContain("parse-rejected-empty");
+    expect(thrown?.code).not.toBe("CALL_OP_PARSE_FAILED");
+    expect(thrown?.code).not.toBe("CALL_OP_NO_OUTPUT");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC7: error code discrimination — CALL_OP_NO_OUTPUT vs CALL_OP_PARSE_FAILED
+// ---------------------------------------------------------------------------
+
+describe("AC7: error code is CALL_OP_NO_OUTPUT specifically (run-kind)", () => {
+  test("run-kind empty output throws with code CALL_OP_NO_OUTPUT", async () => {
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hop = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hop.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async (): Promise<TurnResult> => ({
+        output: "",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    let thrown: (Error & { code?: string }) | null = null;
+    try {
+      await callOp(
+        { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "us-005" },
+        makeRunOp("error-code-check"),
+        "hello",
+      );
+    } catch (err) {
+      thrown = err as Error & { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    // Specifically CALL_OP_NO_OUTPUT — not a parse failure or generic error
+    expect(thrown?.code).toBe("CALL_OP_NO_OUTPUT");
+    expect(thrown?.code).not.toBe("CALL_OP_PARSE_FAILED");
+    expect(thrown?.code).not.toBe("CALL_OP_MAX_RETRIES");
+    expect(thrown?.code).not.toBe("CALL_OP_ABORTED");
+  });
+});

--- a/test/unit/session/manager-phase-b-prompt.test.ts
+++ b/test/unit/session/manager-phase-b-prompt.test.ts
@@ -170,6 +170,7 @@ describe("sendPrompt()", () => {
     expect((caught as SessionFailureError).adapterFailure.outcome).toBe("fail-stale");
     expect((caught as SessionFailureError).adapterFailure.category).toBe("availability");
     expect((caught as SessionFailureError).adapterFailure.retriable).toBe(true);
+    expect((caught as SessionFailureError).adapterFailure.reason).toBe("idle-watchdog");
   });
 
   test("does not rewrap SessionTurnError(cancelled=true) when watchdog did not trigger the cancel", async () => {
@@ -277,6 +278,7 @@ describe("sendPrompt()", () => {
     // Must still be classified as fail-stale despite agent.call_ended firing first.
     expect(caught).toBeInstanceOf(SessionFailureError);
     expect((caught as SessionFailureError).adapterFailure.outcome).toBe("fail-stale");
+    expect((caught as SessionFailureError).adapterFailure.reason).toBe("idle-watchdog");
   });
 
   test("watchdog fail-stale classification is isolated per session handle during parallel prompts", async () => {
@@ -321,6 +323,7 @@ describe("sendPrompt()", () => {
 
     expect(resultA).toBeInstanceOf(SessionFailureError);
     expect((resultA as SessionFailureError).adapterFailure.outcome).toBe("fail-stale");
+    expect((resultA as SessionFailureError).adapterFailure.reason).toBe("idle-watchdog");
   });
 
   test("forwards maxTurns to adapter.sendTurn", async () => {


### PR DESCRIPTION
## Summary

Implements `docs/specs/SPEC-empty-output-retry.md` — promotes \"agent finished with empty output\" from a silent parse failure into a first-class `AdapterFailure { outcome: \"fail-stale\", reason: \"empty-output\", retriable: true }` so the existing retry + agent-swap infrastructure handles transient agent stalls uniformly.

### What changed

- **`src/context/engine/types.ts`** — `AdapterFailure` gains optional `reason?: string` field (observability tag, no semantic effect on retry/swap logic)
- **`src/agents/types.ts`** — `TurnResult` gains `adapterFailure?: AdapterFailure` so synthesis in the operations layer propagates through the hop callback
- **`src/operations/call.ts`** — `sendWithFileOutput` synthesises `fail-stale` when effective output is empty/whitespace-only and no pre-existing `adapterFailure` is set (file-overlay content suppresses synthesis)
- **`src/operations/build-hop-callback.ts`** — `turnResultToAgentResult` forwards `TurnResult.adapterFailure` to `AgentResult.adapterFailure`; sets `success: false` / `exitCode: 1` when present so `runWithFallback` engages its retry path
- **`src/agents/manager.ts`** — `completeWithFallback` gains synthesis block + `staleRetryAttempts` counter (up to `idleWatchdog.maxRetryAttempts`, default 3) + `AgentFallbackRecord` push + `onSwapAttempt` emission for stale-retries; `runWithFallback` default fixed from `?? 1` → `?? 3` to match schema; fail-stale log gains `reason` field

### Test coverage (1,242 new lines across 5 new test files)

| File | Tests | Covers |
|:---|:---|:---|
| `test/unit/operations/call-empty-output.test.ts` | 8 | AC1 (run-kind synthesis), AC2 (file-overlay suppression), AC9 (AdapterFailure.reason field) |
| `test/unit/agents/manager-complete-empty-output.test.ts` | 8 | AC4 (synthesis shape), AC5 (retry counter), AC6 (retry success + agent swap) |
| `test/integration/operations/run-empty-output-retry.test.ts` | 5 | AC3 (run-kind end-to-end retry via callOp) |
| `test/integration/operations/complete-empty-output-retry.test.ts` | 7 | AC5/AC6 (complete-kind retry + agent swap via real runtime) |
| `test/unit/operations/call-exhaustion.test.ts` | 4 | AC7 (exhaustion boundary: run-kind → CALL_OP_NO_OUTPUT; complete-kind → op.parse) |

Full suite: **9,098 tests pass, 0 failures.**

## Test Plan

- [x] `bun run test` — 9098 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Spec coverage verified against `docs/specs/SPEC-empty-output-retry.md` AC1–AC10