### PR TITLE
fix(review): force file-read tool call + line-anchor evidence check in semantic requote

### DIFF
--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -133,9 +133,7 @@ async function requoteBlockingFindings(
     if (used >= maxRequotes) break;
     used += 1;
 
-    const retry = await ctx.send(
-      ReviewPromptBuilder.requoteVerbatim({ finding, previousObserved: initialEvidence.observed ?? "" }),
-    );
+    const retry = await ctx.send(ReviewPromptBuilder.requoteVerbatim({ finding }));
     extraCostUsd += retry.estimatedCostUsd ?? 0;
     const requote = parseRequoteResponse(retry.output);
     if (!requote) {

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -194,10 +194,12 @@ Output ONLY a complete, valid JSON object. It must start with { and end with }.
 Schema: {"passed": boolean, "findings": [{"severity": string, "category": string, "file": string, "line": number, "issue": string, "suggestion": string, "verifiedBy": {"command": string, "file": string, "line": number, "observed": string}}]}`;
   }
 
-  static requoteVerbatim(opts: { finding: LLMFinding; previousObserved: string }): string {
+  static requoteVerbatim(opts: { finding: LLMFinding }): string {
     const file = opts.finding.verifiedBy?.file ?? opts.finding.file;
     const line = opts.finding.verifiedBy?.line ?? opts.finding.line;
     return `Your previous verifiedBy.observed value did not match the referenced file on disk.
+
+You MUST use your file-reading tool to open ${file} and copy the actual bytes around line ${line}. Do NOT quote from memory or from the prior conversation — the previous quote was wrong precisely because it was not read from disk. If you reply without a file-read tool call, the quote will be rejected.
 
 Return ONLY this JSON object:
 {"file":"${file}","line":${line},"observed":"exact 1-3 line quote"}
@@ -205,12 +207,11 @@ Return ONLY this JSON object:
 Finding issue: ${opts.finding.issue}
 Referenced file: ${file}
 Referenced line: ${line}
-Previous observed: ${opts.previousObserved}
 
 Rules:
-- Copy observed verbatim from the file. Do not paraphrase.
-- observed must be a 1-3 line excerpt that proves the claim.
-- If you cannot quote proof exactly, set observed to "".
+- Read ${file} with your file tool first. Then copy observed verbatim from the read result.
+- observed must be a 1-3 line excerpt that proves the claim, taken from at or near line ${line}.
+- If after reading the file you cannot find anything that proves the claim, set observed to "".
 - Do not return a full review. Do not include markdown fences or explanation.`;
   }
 }

--- a/src/review/semantic-evidence.ts
+++ b/src/review/semantic-evidence.ts
@@ -7,6 +7,16 @@ import type { SemanticReviewConfig } from "./types";
 
 const OBSERVED_PREVIEW_CHARS = 160;
 const ISSUE_PREVIEW_CHARS = 200;
+/**
+ * Line-anchor window. When `verifiedBy.line` is set we only accept the quote if
+ * it appears within ±EVIDENCE_LINE_WINDOW of that line. Full-file substring
+ * matching previously let recovered findings reinstate themselves with quotes
+ * lifted from anywhere in the file, regardless of where the finding actually
+ * claimed the bug was. 10 lines tolerates LLM off-by-some on line numbers and
+ * multi-line observed blocks up to ~20 lines (the longest realistic finding
+ * excerpt we've seen).
+ */
+const EVIDENCE_LINE_WINDOW = 10;
 
 export const SEMANTIC_FINDING_DOWNGRADED_EVENT = "review.semantic.finding.downgraded";
 export const ADVERSARIAL_FINDING_DOWNGRADED_EVENT = "review.adversarial.finding.downgraded";
@@ -68,9 +78,32 @@ export async function checkFindingEvidence(opts: {
   if (!observed) return { status: "missing-observed", file, line };
   const contents = await readSafeFile(opts.workdir, file);
   if (contents === null) return { status: "unreadable", file, line, observed };
-  return normalizedIncludes(contents, observed)
+  return matchesEvidence(contents, observed, line)
     ? { status: "matched", file, line, observed }
     : { status: "unmatched", file, line, observed };
+}
+
+/**
+ * Two-pass evidence check:
+ *   1. If `line` is set, look for the quote within a ±EVIDENCE_LINE_WINDOW
+ *      window around that line. This is the strict check that prevents
+ *      "recovered" findings from being substantiated by quoting anywhere in
+ *      the file.
+ *   2. If `line` is absent (e.g. AdversarialLLMFinding without a referenced
+ *      line, or legacy findings), fall back to full-file substring match.
+ */
+function matchesEvidence(contents: string, observed: string, line: number | undefined): boolean {
+  if (!line || line <= 0) {
+    return normalizedIncludes(contents, observed);
+  }
+  const lines = contents.split("\n");
+  // Convert to 0-based index. Clamp to [0, lines.length - 1] to keep the slice
+  // sane even when the LLM cites a line past the file's end.
+  const cited = Math.min(Math.max(0, line - 1), lines.length - 1);
+  const start = Math.max(0, cited - EVIDENCE_LINE_WINDOW);
+  const end = Math.min(lines.length, cited + EVIDENCE_LINE_WINDOW + 1);
+  const windowText = lines.slice(start, end).join("\n");
+  return normalizedIncludes(windowText, observed);
 }
 
 export function downgradeUnsubstantiatedFinding<F extends FindingWithEvidence>(opts: {

--- a/test/unit/prompts/review-builder.test.ts
+++ b/test/unit/prompts/review-builder.test.ts
@@ -200,7 +200,6 @@ describe("ReviewPromptBuilder.requoteVerbatim()", () => {
           observed: "described the issue instead of quoting it",
         },
       },
-      previousObserved: "described the issue instead of quoting it",
     });
     expect(result).toContain("did not match the referenced file on disk");
     expect(result).toContain('"file":"src/foo.ts"');
@@ -208,5 +207,31 @@ describe("ReviewPromptBuilder.requoteVerbatim()", () => {
     expect(result).toContain("observed\":\"exact 1-3 line quote");
     expect(result).toContain('set observed to ""');
     expect(result).toContain("Do not return a full review");
+  });
+
+  test("forces a file-read tool call and omits the prior observed value", () => {
+    const result = ReviewPromptBuilder.requoteVerbatim({
+      finding: {
+        severity: "error",
+        file: "src/foo.ts",
+        line: 42,
+        issue: "Missing guard",
+        suggestion: "Add guard",
+        verifiedBy: {
+          file: "src/foo.ts",
+          line: 42,
+          observed: "hallucinated quote that was rejected",
+        },
+      },
+    });
+    // The previous observed must not be echoed back — that was the regurgitation
+    // surface that let the model re-emit the same wrong quote (observed in a real
+    // run: opencode semantic requote returning toolCallUpdates=0 and the same
+    // hallucinated string).
+    expect(result).not.toContain("hallucinated quote that was rejected");
+    expect(result).not.toContain("Previous observed");
+    // The prompt must demand an actual file-read tool call.
+    expect(result).toMatch(/file-reading tool|file tool/);
+    expect(result).toMatch(/quote from memory/i);
   });
 });

--- a/test/unit/review/semantic-evidence.test.ts
+++ b/test/unit/review/semantic-evidence.test.ts
@@ -305,6 +305,112 @@ describe("checkFindingEvidence()", () => {
   });
 });
 
+describe("checkFindingEvidence — line-anchored window", () => {
+  // Defense-in-depth for the requote loop. The original full-file substring
+  // check let "recovered" findings reinstate themselves with a quote from
+  // anywhere in the file — line numbers could drift freely. These tests pin
+  // the behaviour: the observed must appear within ±10 lines of the cited line.
+  function makeMultiLineFile(): string {
+    return Array.from({ length: 60 }, (_, i) => `// line ${i + 1}`).join("\n") + "\n";
+  }
+
+  test("matches when observed appears at the cited line", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), makeMultiLineFile());
+
+      const result = await checkFindingEvidence({
+        finding: makeFinding({
+          line: 30,
+          verifiedBy: { command: "cat src/foo.ts", file: "src/foo.ts", line: 30, observed: "// line 30" },
+        }),
+        workdir,
+      });
+
+      expect(result.status).toBe("matched");
+    });
+  });
+
+  test("matches when observed appears within the ±10 line window", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), makeMultiLineFile());
+
+      // Cited line 30, observed lives at line 38 — inside the ±10 window.
+      const result = await checkFindingEvidence({
+        finding: makeFinding({
+          line: 30,
+          verifiedBy: { command: "cat src/foo.ts", file: "src/foo.ts", line: 30, observed: "// line 38" },
+        }),
+        workdir,
+      });
+
+      expect(result.status).toBe("matched");
+    });
+  });
+
+  test("does NOT match when observed appears in the file but outside the cited window", async () => {
+    await writeMultiAndCheck("// line 50", 1, "unmatched");
+  });
+
+  test("matches when line is undefined (falls back to full-file scan)", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), makeMultiLineFile());
+
+      // Both finding.line and verifiedBy.line omitted (using `0` to mean
+      // "no usable line" since the type requires a number).
+      const finding = makeFinding({
+        line: 0,
+        verifiedBy: { command: "cat src/foo.ts", file: "src/foo.ts", line: 0, observed: "// line 50" },
+      });
+      const result = await checkFindingEvidence({ finding, workdir });
+
+      expect(result.status).toBe("matched");
+    });
+  });
+
+  test("clamps cited line past EOF to the file's last line", async () => {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), makeMultiLineFile());
+
+      // File has 60 lines; cited line is 200. Window clamps to lines 50-60,
+      // so a quote of "// line 55" (within that clamped window) still matches.
+      const result = await checkFindingEvidence({
+        finding: makeFinding({
+          line: 200,
+          verifiedBy: { command: "cat src/foo.ts", file: "src/foo.ts", line: 200, observed: "// line 55" },
+        }),
+        workdir,
+      });
+
+      expect(result.status).toBe("matched");
+    });
+  });
+
+  async function writeMultiAndCheck(
+    observed: string,
+    line: number,
+    expected: "matched" | "unmatched" | "unreadable" | "missing-observed",
+  ): Promise<void> {
+    await withTempDir(async (workdir) => {
+      mkdirSync(join(workdir, "src"), { recursive: true });
+      writeFileSync(join(workdir, "src/foo.ts"), makeMultiLineFile());
+
+      const result = await checkFindingEvidence({
+        finding: makeFinding({
+          line,
+          verifiedBy: { command: "cat src/foo.ts", file: "src/foo.ts", line, observed },
+        }),
+        workdir,
+      });
+
+      expect(result.status).toBe(expected);
+    });
+  }
+});
+
 describe("checkFindingEvidence — generalized over Finding shape (Issue #987)", () => {
   test("accepts AdversarialLLMFinding shape and substantiates against disk", async () => {
     await withTempDir(async (workdir) => {


### PR DESCRIPTION
## Summary

- `ReviewPromptBuilder.requoteVerbatim` drops `previousObserved` and the prompt now explicitly mandates a file-read tool call. The prior hallucinated quote is no longer echoed back, so the model cannot regurgitate it from context.
- `checkFindingEvidence` now line-anchors the substring search to a ±10 line window around `verifiedBy.line` when that line is set; falls back to full-file scan when absent.

## Root cause

In `logs/2026-05-24T16-23-29.jsonl` (~18:30, US-001), semantic review produced 4 blocking findings. The per-finding requote loop ended with:

| Line | toolCallUpdates | Outcome |
|---:|---:|---|
| 130 | **0** | downgraded |
| 160 | **0** | downgraded |
| 190 | 3 | recovered |
| 220 | 3 | recovered |

The two `toolCallUpdates: 0` turns: the model didn't re-read the file — it just re-emitted the same hallucinated quote it had in context (it appears under `Previous observed:` in the prompt audit).

The two recovered findings exposed a second weakness: `checkFindingEvidence` only did a full-file substring match, so a recovered finding could reinstate itself with a quote from anywhere in the file regardless of the cited line.

## Fix

1. **Prompt change** (`src/prompts/builders/review-builder.ts`, `src/operations/semantic-review.ts`): `requoteVerbatim` drops the `previousObserved` parameter. The new prompt body mandates *"You MUST use your file-reading tool to open <file> and copy the actual bytes around line <N>. Do NOT quote from memory…"* This removes the regurgitation anchor.

2. **Line-anchor gate** (`src/review/semantic-evidence.ts`): when `verifiedBy.line` is set, the substring search runs only over a ±10 line window around that line. `EVIDENCE_LINE_WINDOW = 10` gives a 21-line tolerance to absorb LLM line-number drift and multi-line quotes. Falls back to full-file scan when line is absent.

The same `checkFindingEvidence` is used by adversarial review (`src/review/adversarial.ts:397`). Both subsystems prompt the model for accurate `verifiedBy.line` the same way, so the gate is symmetric — existing adversarial tests pass unchanged.

## Test plan

- [x] New `forces a file-read tool call and omits the prior observed value` test in `test/unit/prompts/review-builder.test.ts` — asserts the prompt no longer contains `Previous observed`, no longer echoes the prior quote, requires `file-reading tool`/`file tool`, and warns against quoting from memory.
- [x] Five new tests in `test/unit/review/semantic-evidence.test.ts` cover the line-anchor behaviour: match at cited line, match within ±10 window, no-match outside the window, full-file fallback when line is absent, clamp when cited line is past EOF.
- [x] Existing `requoteVerbatim` test updated to the new signature.
- [x] Existing semantic-evidence, semantic-retry, adversarial-verifiedby tests all unchanged and passing.
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run test:bail` — 8057 unit + 1100 integration + 13 ui all green