### PR TITLE
fix: rectification semantic finding routing

### DIFF
--- a/docs/specs/2026-05-25-rectification-semantic-finding-routing.md
+++ b/docs/specs/2026-05-25-rectification-semantic-finding-routing.md
@@ -1,0 +1,463 @@
+# Rectification — semantic-finding routing & validation scope
+
+**Date:** 2026-05-25
+**Status:** Pre-implementation
+**Scope:** Three patches across `src/execution/story-orchestrator.ts`, `src/operations/autofix-implementer-strategy.ts`, `src/operations/autofix-test-writer-strategy.ts`, `src/findings/cycle-types.ts`, `src/findings/cycle.ts`, and a new helper in `src/operations/_finding-to-check.ts`.
+**Regression introduced by:** [#1084](https://github.com/nathapp-io/nax/pull/1084) (commit `f38aedf2` — execution unification)
+**Evidence:**
+- Run log: `logs/2026-05-24T16-23-29.jsonl` line 234 (`Semantic review failed: 3 findings`)
+- Prompt audit: `logs/prompt-audit/cup-and-handle-detector/1779646952504-...-implementer-run-t04.txt` (Turn 4 sent `Fix the following 6 failing tests:` instead of the 3 semantic findings)
+
+---
+
+## 1. Problem statement
+
+Cup-and-handle dogfood run (2026-05-24, story `US-001`):
+
+1. `full-suite-gate` (deterministic) executed the polyglot test suite and produced **6 test-runner findings** that the verifier judged as pre-existing/unrelated regressions. Verifier session completed (log line 207, "Session complete: verifier") and "Isolation maintained" (line 208) — and crucially, semantic-review ran afterwards (line 213+), which would only happen if the verifier did not short-circuit the plan.
+2. `semantic-review` then failed with **3 findings** (log line 234).
+3. The rectification cycle should have routed those 3 semantic findings to `autofix-implementer`. Instead, Turn 4 of the warm implementer session received `Fix the following 6 failing tests:` for the 6 gate findings. The implementer's own response, captured in the audit file at the same turn, confirms these were pre-existing failures: *"Current status: 21 passed, 4 failed (same as before my involvement)"*. The implementer spent ~70 minutes (Duration: 4211422ms in the audit header) attempting fixes the story didn't own, and the 3 semantic findings were never addressed.
+
+Two distinct defects produced the wrong prompt; a third defect re-dispatches the verifier on every rectification iteration even though TDD isolation is satisfied by the strategy-routing layer (see §1.3).
+
+### 1.1 Defect A — `runRectification` ignores the verifier-as-SSOT carve-out
+
+[src/execution/story-orchestrator.ts:228-249](../../src/execution/story-orchestrator.ts#L228-L249):
+
+```ts
+function gatherRectificationFindings(phaseOutputs, phases) {
+  const findings: Finding[] = [];
+  for (const phase of phases) {
+    findings.push(...extractPhaseFindings(phaseOutputs[phase.slot.op.name]));
+  }
+  return findings;
+}
+
+function collectRectificationPhases(state) {
+  return [
+    state.fullSuiteGate, state.verifier, state.verifyScoped,
+    state.lintCheck, state.typecheckCheck,
+    state.semanticReview, state.adversarialReview,
+  ].filter(...);
+}
+```
+
+The same module already enforces a verifier-as-SSOT carve-out in two other sites — `ExecutionPlan.run` success aggregation (lines 629-644) and `deriveFailureCategory` in `post-run.ts:123-138`: when the verifier explicitly passed, `full-suite-gate` failures are treated as unrelated regressions and excluded from downstream decisions.
+
+`gatherRectificationFindings` and the `validate` callback (lines 502-514) make no such exclusion, so the 6 gate findings enter the cycle alongside the 3 semantic findings.
+
+Combined with `selectExecutionGroup` ([src/findings/cycle.ts:111-119](../../src/findings/cycle.ts#L111-L119)) which returns the **first exclusive** strategy when one is active:
+
+```ts
+const exclusive = active.find((s) => !s.coRun || s.coRun === "exclusive");
+if (exclusive) return [exclusive];
+```
+
+and `makeFullSuiteRectifyStrategy` declaring `coRun: "exclusive"` ([src/operations/full-suite-rectify.ts:29](../../src/operations/full-suite-rectify.ts#L29)), the full-suite strategy monopolises the execution group and starves `autofix-implementer`.
+
+### 1.2 Defect B — autofix strategies drop their `_findings` parameter
+
+[src/operations/autofix-implementer-strategy.ts:17-20](../../src/operations/autofix-implementer-strategy.ts#L17-L20):
+
+```ts
+buildInput: (_findings, _prior, _cycleCtx): AutofixImplementerInput => ({
+  failedChecks: [],
+  story,
+}),
+```
+
+Same shape in [autofix-test-writer-strategy.ts:17-21](../../src/operations/autofix-test-writer-strategy.ts#L17-L21).
+
+`RectifierPromptBuilder.reviewRectification([], story)` falls through to the "mixed" branch ([rectifier-builder.ts:626](../../src/prompts/builders/rectifier-builder.ts#L626)) and emits a degenerate prompt with empty error sections. Even after Defect A is fixed, the implementer would receive no actual finding text.
+
+### 1.3 Defect C — `validate` re-runs the verifier inside rectification, but TDD isolation is satisfied by routing, not by re-verification
+
+[src/execution/story-orchestrator.ts:502-514](../../src/execution/story-orchestrator.ts#L502-L514):
+
+```ts
+validate: async (_validateCtx, opts) => {
+  if (ctx.runtime.signal?.aborted) return [];
+  const lite = opts?.mode === "lite";
+  const findings: Finding[] = [];
+  for (const phase of validationPhases) {
+    if (lite && phase.kind === "full-suite-gate") continue;
+    await runPhase(ctx, phase.slot, phaseCosts, phaseOutputs);
+    findings.push(...extractPhaseFindings(phaseOutputs[phase.slot.op.name]));
+  }
+  return findings;
+}
+```
+
+The verifier's job is **TDD isolation** — confirm the implementer modified source code without touching tests, against the git ref captured at story start. Inside rectification this re-run is redundant by design, because **rectification routes edits to the role that owns them**:
+
+| Finding kind | Routed to | What it edits |
+|:---|:---|:---|
+| `fixTarget === "source"` + source-judging findings (lint, typecheck, semantic-review) | `autofix-implementer` | Source files only |
+| `fixTarget === "test"` or adversarial-review findings | `autofix-test-writer` | Test files only |
+| `test-runner` failed-test findings | `full-suite-rectify` → `implementerOp` | Source files (to make tests pass) |
+| Mechanical (lint/format) | `mechanical-lintfix` / `mechanical-formatfix` | Source files |
+
+Strategy `appliesTo` predicates ([autofix-implementer-strategy.ts:15](../../src/operations/autofix-implementer-strategy.ts#L15), [autofix-test-writer-strategy.ts:15](../../src/operations/autofix-test-writer-strategy.ts#L15)) enforce this partition. Test edits during rectification go through the test-writer role *by construction*; an implementer-role strategy that needs to touch a test file uses the explicit `TEST_EDIT_REASON` escape hatch (`autofix-implementer.ts:40-48`), which is parsed and logged, not policed by a re-dispatched verifier.
+
+Two practical consequences of re-running the verifier today:
+
+- The verifier is the most expensive LLM call in the pipeline (~4 minutes per turn in the 2026-05-24 affected run). Each rectification iteration re-spent it for no isolation gain.
+- The isolation check anchors on `beforeRef` captured by `runPhase` at the moment of dispatch. On re-run inside rectification, `beforeRef` is captured *after* the prior fix commits, so the check degenerates — it sees only the most recent rectification commit, not the story-scoped diff it was designed to police.
+
+A secondary concern is over-broad re-validation: after an `autofix-implementer` fix targets only semantic findings, validate also re-runs `full-suite-gate` + `lint-check` + `typecheck-check` + `adversarial-review`. Mechanical strategies (`mechanical-lintfix`, `mechanical-formatfix`) only touch lint findings yet trigger the same broad sweep. Cost and runtime savings are available without giving up correctness, provided the re-validation set scales with the strategy's impact surface.
+
+---
+
+## 2. Fix plan
+
+### 2.1 Patch 1 — Verifier-as-SSOT carve-out in rectification (Defect A)
+
+**File:** `src/execution/story-orchestrator.ts`
+
+Centralise the carve-out as a helper, then apply it in both `gatherRectificationFindings` and the `validate` callback.
+
+```ts
+/**
+ * Verifier-as-SSOT: when the verifier explicitly passed, full-suite-gate
+ * failures represent unrelated regressions that this story did not cause.
+ * Excluded from rectification (mirrors the carve-out in ExecutionPlan.run
+ * success aggregation and post-run.ts:deriveFailureCategory).
+ */
+function shouldSkipPhaseForRectification(
+  phase: InternalPhase,
+  state: InternalBuildState,
+  phaseOutputs: Record<string, unknown>,
+): boolean {
+  if (phase.kind !== "full-suite-gate") return false;
+  const verifierName = state.verifier?.slot.op.name;
+  if (!verifierName) return false;
+  return phaseExplicitlyPassed(phaseOutputs[verifierName]);
+}
+
+function gatherRectificationFindings(
+  phaseOutputs: Record<string, unknown>,
+  phases: readonly InternalPhase[],
+  state: InternalBuildState,
+): Finding[] {
+  const findings: Finding[] = [];
+  for (const phase of phases) {
+    if (shouldSkipPhaseForRectification(phase, state, phaseOutputs)) continue;
+    findings.push(...extractPhaseFindings(phaseOutputs[phase.slot.op.name]));
+  }
+  return findings;
+}
+```
+
+In `runRectification` (line 474) update the call site:
+
+```ts
+const initialFindings = gatherRectificationFindings(phaseOutputs, validationPhases, state);
+```
+
+And in the `validate` callback (line 502):
+
+```ts
+validate: async (_validateCtx, opts) => {
+  if (ctx.runtime.signal?.aborted) return [];
+  const lite = opts?.mode === "lite";
+  const findings: Finding[] = [];
+  for (const phase of validationPhases) {
+    if (lite && phase.kind === "full-suite-gate") continue;
+    await runPhase(ctx, phase.slot, phaseCosts, phaseOutputs);
+    if (shouldSkipPhaseForRectification(phase, state, phaseOutputs)) continue;
+    findings.push(...extractPhaseFindings(phaseOutputs[phase.slot.op.name]));
+  }
+  return findings;
+}
+```
+
+**Notes.**
+- We still *run* `full-suite-gate` during re-validation so its output remains current in `phaseOutputs` (consumed by `ctx.fullSuiteGatePassed` in `applyPostRunInspection`). We only stop *feeding* its findings into the cycle.
+- The carve-out is **all-or-nothing per phase** — every gate finding is either included or excluded by the verifier's verdict. The prompt-routing fix downstream relies on this: with mixed gate + semantic findings included, `selectExecutionGroup` ([src/findings/cycle.ts:111-119](../../src/findings/cycle.ts#L111-L119)) picks `full-suite-rectify` (exclusive `coRun`) and starves `autofix-implementer` (co-run-sequential). Patch 1 must exclude gate findings fully, not partially, for Patch 2 to take effect.
+
+### 2.2 Patch 2 — Convert findings to synthetic `ReviewCheckResult[]` (Defect B)
+
+**Files:** `src/operations/autofix-implementer-strategy.ts`, `src/operations/autofix-test-writer-strategy.ts`. New shared helper in `src/operations/_finding-to-check.ts`.
+
+Create the helper. Synthetic `ReviewCheckResult` entries are populated from findings grouped by `source`; downstream `RectifierPromptBuilder.reviewRectification` already routes on `check === "semantic" | "adversarial"`, so source-to-check mapping is the only logic needed.
+
+```ts
+// src/operations/_finding-to-check.ts
+import type { Finding } from "../findings/types";
+import type { ReviewCheckName, ReviewCheckResult } from "../review/types";
+
+const SOURCE_TO_CHECK: Record<string, ReviewCheckName> = {
+  "semantic-review": "semantic",
+  "adversarial-review": "adversarial",
+  lint: "lint",
+  typecheck: "typecheck",
+};
+
+/**
+ * Group findings by their producer-source and emit one synthetic
+ * ReviewCheckResult per group. The prompt builder consumes
+ * `check.check`, `check.findings`, and `check.output`; other fields are
+ * inert defaults. Findings whose source has no review-check mapping are
+ * dropped (they shouldn't reach an autofix strategy — `appliesTo` filters
+ * them out upstream, but we stay defensive).
+ */
+export function findingsToFailedChecks(findings: readonly Finding[]): ReviewCheckResult[] {
+  const grouped = new Map<ReviewCheckName, Finding[]>();
+  for (const finding of findings) {
+    const check = SOURCE_TO_CHECK[finding.source];
+    if (!check) continue;
+    const bucket = grouped.get(check) ?? [];
+    bucket.push(finding);
+    grouped.set(check, bucket);
+  }
+
+  return [...grouped.entries()].map(([check, findings]) => ({
+    check,
+    success: false,
+    command: "",
+    exitCode: 1,
+    output: "",
+    durationMs: 0,
+    findings,
+  }));
+}
+```
+
+Update both strategies to consume `_findings`:
+
+```ts
+// src/operations/autofix-implementer-strategy.ts
+buildInput: (findings, _prior, _cycleCtx): AutofixImplementerInput => ({
+  failedChecks: findingsToFailedChecks(findings),
+  story,
+}),
+
+// src/operations/autofix-test-writer-strategy.ts
+buildInput: (findings, _prior, _cycleCtx): AutofixTestWriterInput => ({
+  failedChecks: findingsToFailedChecks(findings),
+  story,
+  blockingThreshold: config.review?.blockingThreshold,
+}),
+```
+
+Export `findingsToFailedChecks` from `src/operations/index.ts` so future strategies share it.
+
+### 2.3 Patch 3 — Scope `validate` to the strategy that just ran (Defect C)
+
+**Files:** `src/findings/cycle-types.ts`, `src/findings/cycle.ts`, `src/execution/story-orchestrator.ts`
+
+**Premise.** Rectification routes test edits to `autofix-test-writer` and source edits to `autofix-implementer` by construction (strategy `appliesTo` predicates partition the finding space). TDD isolation is therefore satisfied by the routing layer — there is no rectification path that can produce an undeclared test edit by an implementer-role session, so a re-dispatched verifier has no isolation work to do. Patch 3 drops the verifier from validate re-runs unconditionally, and narrows the remaining re-validation phases to those whose output the just-applied fix can actually change.
+
+Three steps.
+
+**Step 3a — fix the current `FixCycle.validate` contract.** Today ([src/findings/cycle-types.ts:179](../../src/findings/cycle-types.ts#L179)):
+
+```ts
+validate: (ctx: FixCycleContext, opts: { mode: "full" | "lite" }) => Promise<F[]>;
+```
+
+`opts` and `mode` are both required. Extend with an optional `strategiesRun`:
+
+```ts
+validate: (
+  ctx: FixCycleContext,
+  opts: { mode: "full" | "lite"; strategiesRun?: readonly string[] },
+) => Promise<F[]>;
+```
+
+Also: the orchestrator's current callback uses `opts?.mode === "lite"` defensively, masking the required contract. After this patch the orchestrator must read `opts.mode === "lite"` without the optional chain so the contract is enforced at the call sites that already comply.
+
+**Step 3b — thread `strategiesRun` from `runFixCycle`.** Both validate call sites in `src/findings/cycle.ts` happen *after* the iteration's fixes have applied (lite at line 309 inside the `allExhausted` branch; full at line 386 after the standard fix loop), so `group.map(s => s.name)` is the in-scope value at both sites. Pass it through:
+
+```ts
+// cycle.ts:309 (lite recheck after per-strategy exhaustion)
+liteFindingsAfter = await cycle.validate(ctx, {
+  mode: "lite",
+  strategiesRun: group.map((s) => s.name),
+});
+
+// cycle.ts:386 (full validate after each iteration's fixes)
+findingsAfter = await cycle.validate(ctx, {
+  mode: "full",
+  strategiesRun: group.map((s) => s.name),
+});
+```
+
+**Step 3c — strategy → re-validation phase mapping.** Verifier is excluded from every entry because its TDD-isolation job is one-shot:
+
+```ts
+const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[]> = {
+  // Mechanical fixes touch only their own concern — narrow re-run.
+  "mechanical-lintfix": ["lint-check"],
+  "mechanical-formatfix": ["lint-check"],
+
+  // LLM source fixes can affect any source-dependent judge AND the full test
+  // suite, so we re-run all source-dependent phases except the verifier.
+  "autofix-implementer": [
+    "lint-check",
+    "typecheck-check",
+    "full-suite-gate",
+    "verify-scoped",
+    "semantic-review",
+    "adversarial-review",
+  ],
+
+  // Test-code fixes can affect lint/typecheck on the test file, the suite
+  // (a new or fixed test changes pass/fail counts), and adversarial coverage
+  // judgments. Semantic-review judges source-vs-AC, unaffected by test edits.
+  "autofix-test-writer": [
+    "lint-check",
+    "typecheck-check",
+    "full-suite-gate",
+    "verify-scoped",
+    "adversarial-review",
+  ],
+
+  // Full-suite-rectify edits source to make tests pass — same impact surface
+  // as autofix-implementer, minus adversarial (whose target is test design,
+  // not behavior fixes).
+  "full-suite-rectify": [
+    "lint-check",
+    "typecheck-check",
+    "full-suite-gate",
+    "verify-scoped",
+    "semantic-review",
+  ],
+};
+
+function phasesToRevalidate(
+  strategiesRun: readonly string[] | undefined,
+  allPhases: readonly InternalPhase[],
+): readonly InternalPhase[] {
+  // Always exclude verifier from rectification re-runs — its TDD-isolation
+  // job is one-shot, anchored to the story-start git ref.
+  const sourceFiltered = allPhases.filter((p) => p.kind !== "verifier");
+
+  // No attribution available (initial validate, or unknown strategy) → run
+  // every non-verifier phase. Conservative fallback.
+  if (!strategiesRun || strategiesRun.length === 0) return sourceFiltered;
+
+  const unknown = strategiesRun.some((name) => STRATEGY_TO_REVALIDATION_PHASES[name] === undefined);
+  if (unknown) return sourceFiltered;
+
+  const needed = new Set<PhaseKind>();
+  for (const name of strategiesRun) {
+    for (const kind of STRATEGY_TO_REVALIDATION_PHASES[name] ?? []) needed.add(kind);
+  }
+  return sourceFiltered.filter((p) => needed.has(p.kind));
+}
+```
+
+Replace the `validate` callback body:
+
+```ts
+validate: async (_validateCtx, opts) => {
+  if (ctx.runtime.signal?.aborted) return [];
+  const lite = opts.mode === "lite";
+  const phases = phasesToRevalidate(opts.strategiesRun, validationPhases);
+  const findings: Finding[] = [];
+  for (const phase of phases) {
+    if (lite && phase.kind === "full-suite-gate") continue;
+    await runPhase(ctx, phase.slot, phaseCosts, phaseOutputs);
+    if (shouldSkipPhaseForRectification(phase, state, phaseOutputs)) continue;
+    findings.push(...extractPhaseFindings(phaseOutputs[phase.slot.op.name]));
+  }
+  return findings;
+}
+```
+
+**Conservative defaults summary.**
+- Unknown strategy in `strategiesRun` (e.g. plugin-supplied) → fall back to all non-verifier phases.
+- Empty/undefined `strategiesRun` → same fallback.
+- Verifier is *never* re-run from inside rectification, regardless of the strategy. The initial verifier pass remains the SSOT for TDD isolation.
+
+**Why this is correct, not a trade-off.** Test edits during rectification do not flow through implementer-role sessions; they flow through `autofix-test-writer` (which dispatches `testWriterRectifyOp` in a test-writer session). The verifier's isolation check exists to confirm the *initial* implementer session respected the source/test boundary — a one-shot check anchored to the story-start git ref. Inside rectification, the routing layer is the boundary; re-dispatching the verifier asks a question the architecture has already answered.
+
+---
+
+## 3. Acceptance criteria
+
+### Patch 1 (Defect A)
+
+- **AC1.1** — `gatherRectificationFindings` skips `full-suite-gate` findings when `verifier` produced `{ success: true }` or `{ passed: true }`. Asserted via unit test in `test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts`: given a state with `verifier.success=true` and `fullSuiteGate.findings=[testRunnerFinding]`, the gathered initial findings exclude the test-runner finding.
+
+- **AC1.2** — When the verifier explicitly failed (`success: false`), `full-suite-gate` findings are still included. Same test file, sibling case.
+
+- **AC1.3** — When no verifier phase is registered (non-TDD strategy), gate findings flow through unchanged (no regression of the verify-scoped path).
+
+- **AC1.4** — In the validate callback, after a fix iteration runs, full-suite-gate is still *executed* (so `phaseOutputs[fullSuiteGate.name]` stays current for `applyPostRunInspection`) but its findings are excluded from the returned `Finding[]` under the same verifier-passed condition.
+
+### Patch 2 (Defect B)
+
+- **AC2.1** — `findingsToFailedChecks([semanticFinding])` returns `[{ check: "semantic", findings: [semanticFinding], success: false, ... }]`. Test in new `test/unit/operations/finding-to-check.test.ts`.
+
+- **AC2.2** — Mixed-source findings produce one `ReviewCheckResult` per source. Test: `[semanticFinding, adversarialFinding] → 2 entries`.
+
+- **AC2.3** — `makeAutofixImplementerStrategy(...).buildInput([semanticFinding], [], ctx)` returns `failedChecks` with one semantic entry containing the original finding (round-trip test).
+
+- **AC2.4** — `makeAutofixTestWriterStrategy(...).buildInput([adversarialFinding], [], ctx)` returns `failedChecks` with one adversarial entry.
+
+- **AC2.5** — End-to-end: with Patches 1 + 2 in place, an orchestrator run that produces `gate.findings=[6 test-runner]`, `verifier.success=true`, `semantic.findings=[3 semantic]` dispatches `autofix-implementer` (not `full-suite-rectify`) with a prompt that contains all 3 semantic finding messages. Asserted by an integration-style test in `test/integration/execution/` that captures the prompt sent to `implementerRectifyOp`.
+
+### Patch 3 (Defect C)
+
+- **AC3.1** — `phasesToRevalidate(undefined, allPhases)` and `phasesToRevalidate([], allPhases)` both return all phases **except `verifier`** (conservative default; verifier is always one-shot).
+
+- **AC3.2** — `phasesToRevalidate(["autofix-implementer"], allPhases)` returns `lint-check`, `typecheck-check`, `full-suite-gate`, `verify-scoped`, `semantic-review`, `adversarial-review` — and explicitly omits `verifier`.
+
+- **AC3.3** — `phasesToRevalidate(["mechanical-lintfix"], allPhases)` returns only `lint-check`. Same for `mechanical-formatfix`.
+
+- **AC3.4** — `phasesToRevalidate(["full-suite-rectify"], allPhases)` returns `lint-check`, `typecheck-check`, `full-suite-gate`, `verify-scoped`, `semantic-review` — omits `verifier` and `adversarial-review`.
+
+- **AC3.5** — `phasesToRevalidate(["unknown-plugin-strategy"], allPhases)` falls back to all non-verifier phases (unknown-strategy guard).
+
+- **AC3.6** — `phasesToRevalidate(["mechanical-lintfix", "autofix-implementer"], allPhases)` is the union of both strategies' phase sets (still excluding verifier).
+
+- **AC3.7** — `FixCycle.validate` signature in `cycle-types.ts` is `(ctx, opts: { mode: "full" | "lite"; strategiesRun?: readonly string[] }) => Promise<F[]>`. Both call sites in `cycle.ts` (lines 309 lite, 386 full) compile and pass `strategiesRun` where attribution is available.
+
+- **AC3.8** — Integration: in a mocked story-orchestrator run that triggers rectification with semantic findings only, `verifierOp` is dispatched exactly once across the entire cycle (the initial pre-rectification call). Asserted by counting `callOp` invocations against `verifierOp` in `test/integration/execution/rectification-routing.test.ts`.
+
+- **AC3.9** — Integration: after an `autofix-implementer` iteration, `full-suite-gate` (deterministic) and `semantic-review` are re-dispatched; `verifier` is not. Asserted by phase-output snapshot in the same integration test.
+
+---
+
+## 4. Sequencing & risk
+
+| Patch | Risk | Sequencing |
+|:------|:-----|:-----------|
+| 1 | Low — narrow predicate, mirrors existing carve-out logic | Land first. Fixes the proximate user-visible bug. |
+| 2 | Low — pure data shape conversion, no control-flow change | Land second. Cosmetic on its own; combined with Patch 1 it produces the corrected end-to-end behavior. |
+| 3 | Medium — changes `FixCycle.validate` contract; removes verifier from rectification re-runs (intentional — routing partitions edits between implementer and test-writer roles, so isolation re-checking is structurally unnecessary) | Land last, after Patches 1 + 2 are stable. Bundles an architectural correctness change with the per-strategy re-validation narrowing. |
+
+Patches 1 and 2 should ship together — Patch 1 alone routes the right finding type to `autofix-implementer`, but Patch 2 is required to make the prompt non-empty. A bundled PR for 1+2 is appropriate; Patch 3 can be a follow-up.
+
+### 4.1 Test fixtures touched
+
+- `test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts` — extend with AC1.1 / AC1.2 / AC1.3 / AC1.4 cases.
+- `test/unit/operations/finding-to-check.test.ts` — new file, AC2.1 / AC2.2.
+- `test/unit/operations/autofix-implementer-strategy.test.ts` — extend with AC2.3.
+- `test/unit/operations/autofix-test-writer-strategy.test.ts` — extend with AC2.4.
+- `test/integration/execution/rectification-routing.test.ts` — new file, AC2.5 / AC3.8 / AC3.9.
+- `test/unit/execution/story-orchestrator-revalidation.test.ts` — new file, AC3.1 / AC3.2 / AC3.3 / AC3.4 / AC3.5 / AC3.6. Lives next to the other story-orchestrator unit tests; mirrors `src/execution/story-orchestrator.ts` per `.claude/rules/test-architecture.md`.
+- `test/unit/findings/cycle-types.test.ts` — extend (or create) with AC3.7 covering the updated validate signature and the lite/full call-site shape.
+
+**Note for the implementer:** verify exact paths against `.claude/rules/test-architecture.md` mirroring rules (test files mirror src/ structure). The paths above are best-effort; adjust if the convention differs.
+
+### 4.2 Non-goals
+
+- Reworking `selectExecutionGroup` to allow exclusive + co-run-sequential strategies to share an iteration. The verifier-as-SSOT carve-out is sufficient — once the 6 gate findings are excluded, the cycle sees only semantic findings, only `autofix-implementer` is active, and exclusivity is moot.
+- Migrating `makeFullSuiteRectifyStrategy` away from `coRun: "exclusive"`. The semantics are still correct for the cases where it does fire (verifier failed → behavior fix is exclusive by intent).
+- Adding any isolation re-check inside the rectification loop. Routing partitions source vs. test edits across `autofix-implementer` and `autofix-test-writer` — re-verification would be asking a question the routing layer has already answered. New strategies that need to edit files outside their declared target should be rejected at strategy-design time, not re-policed at runtime.
+- Reintroducing the verifier into rectification re-runs under any condition.
+
+---
+
+## 5. Backout
+
+Each patch reverts cleanly:
+
+- Patch 1 — delete `shouldSkipPhaseForRectification`, revert `gatherRectificationFindings` to its two-argument signature, and remove the `state` argument from its single call site in `runRectification`. Restore the original two-line body.
+- Patch 2 — restore `failedChecks: []` in both strategy files; delete `_finding-to-check.ts`.
+- Patch 3 — drop the `strategiesRun` parameter in `FixCycle.validate`; restore the inline iteration in `runRectification.validate`.
+
+No schema or persisted artifact shape changes — backout is code-only.

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -288,20 +288,8 @@ const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[]> = {
     "semantic-review",
     "adversarial-review",
   ],
-  "autofix-test-writer": [
-    "lint-check",
-    "typecheck-check",
-    "full-suite-gate",
-    "verify-scoped",
-    "adversarial-review",
-  ],
-  "full-suite-rectify": [
-    "lint-check",
-    "typecheck-check",
-    "full-suite-gate",
-    "verify-scoped",
-    "semantic-review",
-  ],
+  "autofix-test-writer": ["lint-check", "typecheck-check", "full-suite-gate", "verify-scoped", "adversarial-review"],
+  "full-suite-rectify": ["lint-check", "typecheck-check", "full-suite-gate", "verify-scoped", "semantic-review"],
 };
 
 /**
@@ -323,9 +311,7 @@ function phasesToRevalidate(
 
   if (!strategiesRun || strategiesRun.length === 0) return sourceFiltered;
 
-  const unknown = strategiesRun.some(
-    (name) => STRATEGY_TO_REVALIDATION_PHASES[name] === undefined,
-  );
+  const unknown = strategiesRun.some((name) => STRATEGY_TO_REVALIDATION_PHASES[name] === undefined);
   if (unknown) return sourceFiltered;
 
   const needed = new Set<PhaseKind>();

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -255,6 +255,13 @@ function gatherRectificationFindings(
   return findings;
 }
 
+/**
+ * Collect all phases that participate in the rectification validation sweep.
+ * NOTE: the verifier is intentionally included here so its output stays current
+ * in phaseOutputs (consumed by shouldSkipPhaseForRectification). However,
+ * phasesToRevalidate() is the SSOT that ensures the verifier is NEVER re-dispatched
+ * during rectification validate iterations — it strips kind="verifier" unconditionally.
+ */
 function collectRectificationPhases(state: InternalBuildState): InternalPhase[] {
   return [
     state.fullSuiteGate,
@@ -268,6 +275,9 @@ function collectRectificationPhases(state: InternalBuildState): InternalPhase[] 
 }
 
 const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[]> = {
+  // Mechanical fixes are AST-preserving (import-sort, formatting, unused-var removal).
+  // They cannot introduce semantic regressions, so only lint-check needs re-running.
+  // If a mechanical fix strategy ever edits logic (not just style), widen this set.
   "mechanical-lintfix": ["lint-check"],
   "mechanical-formatfix": ["lint-check"],
   "autofix-implementer": [
@@ -580,8 +590,16 @@ async function runRectification(
     config: { maxAttemptsTotal: rectification.maxAttempts, validatorRetries: 1 },
     validate: async (_validateCtx, opts) => {
       if (ctx.runtime.signal?.aborted) return [];
-      const lite = opts.mode === "lite";
+      // opts is required by the FixCycle.validate contract but guard defensively for
+      // plugin-supplied cycles that may call validate without opts (legacy shape).
+      const lite = (opts?.mode ?? "full") === "lite";
       const phases = phasesToRevalidate(opts.strategiesRun, validationPhases);
+      getSafeLogger()?.debug("story-orchestrator", "rectification validate scope", {
+        storyId: ctx.storyId,
+        mode: opts?.mode ?? "full",
+        strategiesRun: opts.strategiesRun,
+        phasesSelected: phases.map((p) => p.kind),
+      });
       const findings: Finding[] = [];
       for (const phase of phases) {
         if (lite && phase.kind === "full-suite-gate") {

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -267,6 +267,66 @@ function collectRectificationPhases(state: InternalBuildState): InternalPhase[] 
   ].filter((phase): phase is InternalPhase => phase !== undefined);
 }
 
+const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[]> = {
+  "mechanical-lintfix": ["lint-check"],
+  "mechanical-formatfix": ["lint-check"],
+  "autofix-implementer": [
+    "lint-check",
+    "typecheck-check",
+    "full-suite-gate",
+    "verify-scoped",
+    "semantic-review",
+    "adversarial-review",
+  ],
+  "autofix-test-writer": [
+    "lint-check",
+    "typecheck-check",
+    "full-suite-gate",
+    "verify-scoped",
+    "adversarial-review",
+  ],
+  "full-suite-rectify": [
+    "lint-check",
+    "typecheck-check",
+    "full-suite-gate",
+    "verify-scoped",
+    "semantic-review",
+  ],
+};
+
+/**
+ * Determine which phases to re-run after a fix iteration.
+ * Verifier is always excluded — its TDD-isolation job is one-shot,
+ * anchored to the story-start git ref. Re-dispatching it inside
+ * rectification asks a question the routing layer has already answered.
+ *
+ * Falls back to all non-verifier phases when:
+ * - strategiesRun is undefined/empty (conservative default)
+ * - any strategy name is unknown to the mapping (plugin-supplied strategy)
+ */
+function phasesToRevalidate(
+  strategiesRun: readonly string[] | undefined,
+  allPhases: readonly InternalPhase[],
+): readonly InternalPhase[] {
+  // Always exclude verifier — isolation is one-shot.
+  const sourceFiltered = allPhases.filter((p) => p.kind !== "verifier");
+
+  if (!strategiesRun || strategiesRun.length === 0) return sourceFiltered;
+
+  const unknown = strategiesRun.some(
+    (name) => STRATEGY_TO_REVALIDATION_PHASES[name] === undefined,
+  );
+  if (unknown) return sourceFiltered;
+
+  const needed = new Set<PhaseKind>();
+  for (const name of strategiesRun) {
+    for (const kind of STRATEGY_TO_REVALIDATION_PHASES[name] ?? []) {
+      needed.add(kind);
+    }
+  }
+  return sourceFiltered.filter((p) => needed.has(p.kind));
+}
+
 function toReviewDecisionPayload(opName: string, output: unknown): ReviewDecisionPayload | null {
   if (output === null || output === undefined || typeof output !== "object") return null;
   const record = output as Record<string, unknown>;
@@ -520,9 +580,10 @@ async function runRectification(
     config: { maxAttemptsTotal: rectification.maxAttempts, validatorRetries: 1 },
     validate: async (_validateCtx, opts) => {
       if (ctx.runtime.signal?.aborted) return [];
-      const lite = opts?.mode === "lite";
+      const lite = opts.mode === "lite";
+      const phases = phasesToRevalidate(opts.strategiesRun, validationPhases);
       const findings: Finding[] = [];
-      for (const phase of validationPhases) {
+      for (const phase of phases) {
         if (lite && phase.kind === "full-suite-gate") {
           continue;
         }

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -225,12 +225,31 @@ function extractPhaseFindings(output: unknown): Finding[] {
   return success ? [] : findings;
 }
 
+/**
+ * Verifier-as-SSOT: when the verifier explicitly passed, full-suite-gate
+ * failures represent unrelated regressions that this story did not cause.
+ * Excluded from rectification (mirrors the carve-out in ExecutionPlan.run
+ * success aggregation and post-run.ts:deriveFailureCategory).
+ */
+function shouldSkipPhaseForRectification(
+  phase: InternalPhase,
+  state: InternalBuildState,
+  phaseOutputs: Record<string, unknown>,
+): boolean {
+  if (phase.kind !== "full-suite-gate") return false;
+  const verifierName = state.verifier?.slot.op.name;
+  if (!verifierName) return false;
+  return phaseExplicitlyPassed(phaseOutputs[verifierName]);
+}
+
 function gatherRectificationFindings(
   phaseOutputs: Record<string, unknown>,
   phases: readonly InternalPhase[],
+  state: InternalBuildState,
 ): Finding[] {
   const findings: Finding[] = [];
   for (const phase of phases) {
+    if (shouldSkipPhaseForRectification(phase, state, phaseOutputs)) continue;
     findings.push(...extractPhaseFindings(phaseOutputs[phase.slot.op.name]));
   }
   return findings;
@@ -471,7 +490,7 @@ async function runRectification(
     return {};
   }
 
-  const initialFindings = gatherRectificationFindings(phaseOutputs, validationPhases);
+  const initialFindings = gatherRectificationFindings(phaseOutputs, validationPhases, state);
   if (initialFindings.length === 0) {
     return {};
   }
@@ -508,6 +527,7 @@ async function runRectification(
           continue;
         }
         await runPhase(ctx, phase.slot, phaseCosts, phaseOutputs);
+        if (shouldSkipPhaseForRectification(phase, state, phaseOutputs)) continue;
         findings.push(...extractPhaseFindings(phaseOutputs[phase.slot.op.name]));
       }
       return findings;

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -579,11 +579,11 @@ async function runRectification(
       // opts is required by the FixCycle.validate contract but guard defensively for
       // plugin-supplied cycles that may call validate without opts (legacy shape).
       const lite = (opts?.mode ?? "full") === "lite";
-      const phases = phasesToRevalidate(opts.strategiesRun, validationPhases);
+      const phases = phasesToRevalidate(opts?.strategiesRun, validationPhases);
       getSafeLogger()?.debug("story-orchestrator", "rectification validate scope", {
         storyId: ctx.storyId,
         mode: opts?.mode ?? "full",
-        strategiesRun: opts.strategiesRun,
+        strategiesRun: opts?.strategiesRun,
         phasesSelected: phases.map((p) => p.kind),
       });
       const findings: Finding[] = [];

--- a/src/findings/cycle-types.ts
+++ b/src/findings/cycle-types.ts
@@ -181,10 +181,7 @@ export interface FixCycle<F extends Finding> {
    * phases relevant to those strategies (e.g. skipping the full test suite when
    * only a lint-fix strategy ran).
    */
-  validate: (
-    ctx: FixCycleContext,
-    opts: { mode: "full" | "lite"; strategiesRun?: readonly string[] },
-  ) => Promise<F[]>;
+  validate: (ctx: FixCycleContext, opts: { mode: "full" | "lite"; strategiesRun?: readonly string[] }) => Promise<F[]>;
   config: FixCycleConfig;
   /**
    * Optional verdict string used to bias strategy selection when findings is

--- a/src/findings/cycle-types.ts
+++ b/src/findings/cycle-types.ts
@@ -175,8 +175,16 @@ export interface FixCycle<F extends Finding> {
    * Single validator for the cycle. Runs once per iteration, after all co-run
    * strategies complete. On throw, retried config.validatorRetries times before
    * exiting with "validator-error".
+   *
+   * `strategiesRun` is an optional list of strategy names that just ran in this
+   * iteration. Implementations may use it to scope re-validation to only the
+   * phases relevant to those strategies (e.g. skipping the full test suite when
+   * only a lint-fix strategy ran).
    */
-  validate: (ctx: FixCycleContext, opts: { mode: "full" | "lite" }) => Promise<F[]>;
+  validate: (
+    ctx: FixCycleContext,
+    opts: { mode: "full" | "lite"; strategiesRun?: readonly string[] },
+  ) => Promise<F[]>;
   config: FixCycleConfig;
   /**
    * Optional verdict string used to bias strategy selection when findings is

--- a/src/findings/cycle.ts
+++ b/src/findings/cycle.ts
@@ -306,7 +306,10 @@ export async function runFixCycle<F extends Finding>(
     if (allExhausted) {
       let liteFindingsAfter: F[];
       try {
-        liteFindingsAfter = await cycle.validate(ctx, { mode: "lite" });
+        liteFindingsAfter = await cycle.validate(ctx, {
+          mode: "lite",
+          strategiesRun: group.map((s) => s.name),
+        });
       } catch (err) {
         const finishedAt = now();
         cycle.iterations.push({
@@ -383,7 +386,7 @@ export async function runFixCycle<F extends Finding>(
     let validatorAttempt = 0;
     for (;;) {
       try {
-        findingsAfter = await cycle.validate(ctx, { mode: "full" });
+        findingsAfter = await cycle.validate(ctx, { mode: "full", strategiesRun: group.map((s) => s.name) });
         break;
       } catch (err) {
         if (validatorAttempt >= cycle.config.validatorRetries) {

--- a/src/operations/_finding-to-check.ts
+++ b/src/operations/_finding-to-check.ts
@@ -1,0 +1,38 @@
+import type { Finding } from "../findings/types";
+import type { ReviewCheckName, ReviewCheckResult } from "../review/types";
+
+const SOURCE_TO_CHECK: Record<string, ReviewCheckName> = {
+  "semantic-review": "semantic",
+  "adversarial-review": "adversarial",
+  lint: "lint",
+  typecheck: "typecheck",
+};
+
+/**
+ * Group findings by their producer-source and emit one synthetic
+ * ReviewCheckResult per group. The prompt builder consumes
+ * `check.check`, `check.findings`, and `check.output`; other fields are
+ * inert defaults. Findings whose source has no review-check mapping are
+ * dropped (they shouldn't reach an autofix strategy — `appliesTo` filters
+ * them out upstream, but we stay defensive).
+ */
+export function findingsToFailedChecks(findings: readonly Finding[]): ReviewCheckResult[] {
+  const grouped = new Map<ReviewCheckName, Finding[]>();
+  for (const finding of findings) {
+    const check = SOURCE_TO_CHECK[finding.source];
+    if (!check) continue;
+    const bucket = grouped.get(check) ?? [];
+    bucket.push(finding);
+    grouped.set(check, bucket);
+  }
+
+  return [...grouped.entries()].map(([check, grpFindings]) => ({
+    check,
+    success: false,
+    command: "",
+    exitCode: 1,
+    output: "",
+    durationMs: 0,
+    findings: grpFindings,
+  }));
+}

--- a/src/operations/_finding-to-check.ts
+++ b/src/operations/_finding-to-check.ts
@@ -1,6 +1,13 @@
 import type { Finding } from "../findings/types";
 import type { ReviewCheckName, ReviewCheckResult } from "../review/types";
 
+/**
+ * @note The `_` prefix in this filename is spec-mandated (spec §2.2).
+ * Despite the prefix, `findingsToFailedChecks` is part of the public operations API
+ * and is exported from the `src/operations` barrel. The prefix does NOT indicate
+ * a test-only or internal module.
+ */
+
 const SOURCE_TO_CHECK: Record<string, ReviewCheckName> = {
   "semantic-review": "semantic",
   "adversarial-review": "adversarial",

--- a/src/operations/autofix-implementer-strategy.ts
+++ b/src/operations/autofix-implementer-strategy.ts
@@ -2,9 +2,9 @@ import type { AutofixConfig } from "../config/selectors";
 import type { FixStrategy } from "../findings";
 import type { Finding } from "../findings/types";
 import type { UserStory } from "../prd";
+import { findingsToFailedChecks } from "./_finding-to-check";
 import type { AutofixImplementerInput, AutofixImplementerOutput } from "./autofix-implementer";
 import { implementerRectifyOp } from "./autofix-implementer";
-import { findingsToFailedChecks } from "./_finding-to-check";
 
 const IMPLEMENTER_SOURCES = new Set(["lint", "typecheck", "semantic-review"]);
 

--- a/src/operations/autofix-implementer-strategy.ts
+++ b/src/operations/autofix-implementer-strategy.ts
@@ -4,6 +4,7 @@ import type { Finding } from "../findings/types";
 import type { UserStory } from "../prd";
 import type { AutofixImplementerInput, AutofixImplementerOutput } from "./autofix-implementer";
 import { implementerRectifyOp } from "./autofix-implementer";
+import { findingsToFailedChecks } from "./_finding-to-check";
 
 const IMPLEMENTER_SOURCES = new Set(["lint", "typecheck", "semantic-review"]);
 
@@ -14,8 +15,8 @@ export function makeAutofixImplementerStrategy(
     name: "autofix-implementer",
     appliesTo: (f) => f.fixTarget === "source" && IMPLEMENTER_SOURCES.has(f.source),
     fixOp: implementerRectifyOp,
-    buildInput: (_findings, _prior, _cycleCtx): AutofixImplementerInput => ({
-      failedChecks: [],
+    buildInput: (findings, _prior, _cycleCtx): AutofixImplementerInput => ({
+      failedChecks: findingsToFailedChecks(findings),
       story,
     }),
     extractApplied: (output) => ({

--- a/src/operations/autofix-test-writer-strategy.ts
+++ b/src/operations/autofix-test-writer-strategy.ts
@@ -5,6 +5,7 @@ import type { Finding } from "../findings/types";
 import type { UserStory } from "../prd";
 import type { AutofixTestWriterInput, AutofixTestWriterOutput } from "./autofix-test-writer";
 import { testWriterRectifyOp } from "./autofix-test-writer";
+import { findingsToFailedChecks } from "./_finding-to-check";
 
 export function makeAutofixTestWriterStrategy(
   story: UserStory,
@@ -14,8 +15,8 @@ export function makeAutofixTestWriterStrategy(
     name: "autofix-test-writer",
     appliesTo: (f) => f.fixTarget === "test" || f.source === "adversarial-review",
     fixOp: testWriterRectifyOp,
-    buildInput: (_findings, _prior, _cycleCtx): AutofixTestWriterInput => ({
-      failedChecks: [],
+    buildInput: (findings, _prior, _cycleCtx): AutofixTestWriterInput => ({
+      failedChecks: findingsToFailedChecks(findings),
       story,
       blockingThreshold: config.review?.blockingThreshold,
     }),

--- a/src/operations/autofix-test-writer-strategy.ts
+++ b/src/operations/autofix-test-writer-strategy.ts
@@ -3,9 +3,9 @@ import type { AutofixConfig } from "../config/selectors";
 import type { FixStrategy } from "../findings";
 import type { Finding } from "../findings/types";
 import type { UserStory } from "../prd";
+import { findingsToFailedChecks } from "./_finding-to-check";
 import type { AutofixTestWriterInput, AutofixTestWriterOutput } from "./autofix-test-writer";
 import { testWriterRectifyOp } from "./autofix-test-writer";
-import { findingsToFailedChecks } from "./_finding-to-check";
 
 export function makeAutofixTestWriterStrategy(
   story: UserStory,

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -84,6 +84,7 @@ export type {
 export { makeFullSuiteRectifyStrategy } from "./full-suite-rectify";
 export { makeAutofixImplementerStrategy } from "./autofix-implementer-strategy";
 export { makeAutofixTestWriterStrategy } from "./autofix-test-writer-strategy";
+export { findingsToFailedChecks } from "./_finding-to-check";
 export {
   makeMechanicalLintFixStrategy,
   _mechanicalLintFixDeps,

--- a/test/integration/execution/rectification-routing.test.ts
+++ b/test/integration/execution/rectification-routing.test.ts
@@ -29,7 +29,7 @@ const mockImplementerOp: RunOperation<{ story: string }, { success: boolean }, t
   kind: "run",
   name: "implementer",
   stage: "run",
-  config: testSel,
+  config: testSel as any,
   session: { role: "implementer", lifetime: "warm" },
   build: () => ({
     role: { id: "r", content: "impl", overridable: false },
@@ -46,7 +46,7 @@ const mockVerifierOp: RunOperation<
   kind: "run",
   name: "verifier",
   stage: "verify",
-  config: testSel,
+  config: testSel as any,
   session: { role: "verifier", lifetime: "fresh" },
   build: () => ({
     role: { id: "r", content: "verify", overridable: false },
@@ -63,7 +63,7 @@ const mockFullSuiteGateOp: RunOperation<
   kind: "run",
   name: "full-suite-gate",
   stage: "verify",
-  config: testSel,
+  config: testSel as any,
   session: { role: "verifier", lifetime: "fresh" },
   build: () => ({
     role: { id: "r", content: "gate", overridable: false },
@@ -80,7 +80,7 @@ const mockSemanticReviewOp: RunOperation<
   kind: "run",
   name: "semantic-review",
   stage: "review",
-  config: testSel,
+  config: testSel as any,
   session: { role: "reviewer-semantic", lifetime: "fresh" },
   build: () => ({
     role: { id: "r", content: "review", overridable: false },
@@ -109,6 +109,7 @@ function makeSemanticFindings(count: number): Finding[] {
   return Array.from({ length: count }, (_, i) => ({
     source: "semantic-review" as const,
     severity: "error" as const,
+    category: "",
     message: `Does not implement AC-00${i + 1}`,
     file: "src/foo.ts",
     line: i + 1,

--- a/test/integration/execution/rectification-routing.test.ts
+++ b/test/integration/execution/rectification-routing.test.ts
@@ -290,7 +290,7 @@ describe("AC3.8: verifier op dispatched exactly once — never re-run during val
     }) as typeof _storyOrchestratorDeps.callOp;
 
     // Invoke validate with autofix-implementer strategiesRun
-    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+    await (capturedCycle as unknown as FixCycle<Finding>).validate(capturedCtx as unknown as FixCycleContext, {
       mode: "full",
       strategiesRun: ["autofix-implementer"],
     });
@@ -361,7 +361,7 @@ describe("AC3.9: after autofix-implementer iteration, full-suite-gate and semant
     }) as typeof _storyOrchestratorDeps.callOp;
 
     // Simulate: after an autofix-implementer iteration, call validate
-    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+    await (capturedCycle as unknown as FixCycle<Finding>).validate(capturedCtx as unknown as FixCycleContext, {
       mode: "full",
       strategiesRun: ["autofix-implementer"],
     });

--- a/test/integration/execution/rectification-routing.test.ts
+++ b/test/integration/execution/rectification-routing.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Integration test: rectification routing with verifier-as-SSOT carve-out (AC2.5)
+ *
+ * Verifies that when:
+ * - full-suite-gate fails with 6 test-runner findings
+ * - verifier passes (success: true)
+ * - semantic-review fails with 3 semantic findings
+ *
+ * The rectification cycle receives ONLY the 3 semantic findings (not the 6 gate findings),
+ * causing autofix-implementer (not full-suite-rectify) to be selected.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _storyOrchestratorDeps, StoryOrchestratorBuilder } from "@/execution";
+import type { FixCycle, FixCycleContext, FixCycleExitReason } from "@/findings/cycle-types";
+import type { Finding } from "@/findings/types";
+import { pickSelector, DEFAULT_CONFIG } from "@/config";
+import { makeTestRuntime, makeStory, makeNaxConfig } from "@test/helpers";
+import { makeAutofixImplementerStrategy, makeFullSuiteRectifyStrategy } from "@/operations";
+import type { NaxRuntime } from "@/runtime";
+import type { RunOperation, CallContext } from "@/operations";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const testSel = pickSelector("test-routing-sel", "execution");
+
+const mockImplementerOp: RunOperation<{ story: string }, { success: boolean }, typeof DEFAULT_CONFIG> = {
+  kind: "run",
+  name: "implementer",
+  stage: "run",
+  config: testSel,
+  session: { role: "implementer", lifetime: "warm" },
+  build: () => ({
+    role: { id: "r", content: "impl", overridable: false },
+    task: { id: "t", content: "", overridable: false },
+  }),
+  parse: () => ({ success: true }),
+};
+
+const mockVerifierOp: RunOperation<
+  { story: string },
+  { success: boolean; findings: Finding[] },
+  typeof DEFAULT_CONFIG
+> = {
+  kind: "run",
+  name: "verifier",
+  stage: "verify",
+  config: testSel,
+  session: { role: "verifier", lifetime: "fresh" },
+  build: () => ({
+    role: { id: "r", content: "verify", overridable: false },
+    task: { id: "t", content: "", overridable: false },
+  }),
+  parse: () => ({ success: true, findings: [] }),
+};
+
+const mockFullSuiteGateOp: RunOperation<
+  { story: string },
+  { success: boolean; findings: Finding[] },
+  typeof DEFAULT_CONFIG
+> = {
+  kind: "run",
+  name: "full-suite-gate",
+  stage: "verify",
+  config: testSel,
+  session: { role: "verifier", lifetime: "fresh" },
+  build: () => ({
+    role: { id: "r", content: "gate", overridable: false },
+    task: { id: "t", content: "", overridable: false },
+  }),
+  parse: () => ({ success: true, findings: [] }),
+};
+
+const mockSemanticReviewOp: RunOperation<
+  { story: string },
+  { success: boolean; passed: boolean; findings: Finding[] },
+  typeof DEFAULT_CONFIG
+> = {
+  kind: "run",
+  name: "semantic-review",
+  stage: "review",
+  config: testSel,
+  session: { role: "reviewer-semantic", lifetime: "fresh" },
+  build: () => ({
+    role: { id: "r", content: "review", overridable: false },
+    task: { id: "t", content: "", overridable: false },
+  }),
+  parse: () => ({ success: false, passed: false, findings: [] }),
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Findings fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeTestRunnerFindings(count: number): Finding[] {
+  return Array.from({ length: count }, (_, i) => ({
+    source: "test-runner" as const,
+    category: "failed-test",
+    severity: "error" as const,
+    message: `Test ${i + 1} failed`,
+    file: `test/suite-${i + 1}.test.ts`,
+    line: 1,
+    fixTarget: "test" as const,
+  }));
+}
+
+function makeSemanticFindings(count: number): Finding[] {
+  return Array.from({ length: count }, (_, i) => ({
+    source: "semantic-review" as const,
+    severity: "error" as const,
+    message: `Does not implement AC-00${i + 1}`,
+    file: "src/foo.ts",
+    line: i + 1,
+    fixTarget: "source" as const,
+  }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared state
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origCallOp: typeof _storyOrchestratorDeps.callOp;
+let origRunFixCycle: typeof _storyOrchestratorDeps.runFixCycle;
+let origCaptureGitRef: typeof _storyOrchestratorDeps.captureGitRef;
+let runtime: NaxRuntime;
+
+function makeCtx(): CallContext {
+  runtime = makeTestRuntime();
+  return {
+    runtime,
+    packageView: runtime.packages.repo(),
+    packageDir: "/tmp",
+    agentName: "claude",
+    storyId: "US-routing",
+  } as CallContext;
+}
+
+beforeEach(() => {
+  origCallOp = _storyOrchestratorDeps.callOp;
+  origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+  origCaptureGitRef = _storyOrchestratorDeps.captureGitRef;
+  _storyOrchestratorDeps.captureGitRef = mock(async () => "HEAD");
+});
+
+afterEach(async () => {
+  _storyOrchestratorDeps.callOp = origCallOp;
+  _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+  _storyOrchestratorDeps.captureGitRef = origCaptureGitRef;
+  await runtime?.close();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC2.5: Integration — semantic findings route to autofix-implementer
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AC2.5: rectification routing — verifier-as-SSOT carve-out with semantic findings", () => {
+  test("AC2.5: gate has 6 test-runner findings, verifier passes, semantic has 3 → cycle gets only 3 semantic findings", async () => {
+    const gateFindings = makeTestRunnerFindings(6);
+    const semanticFindings = makeSemanticFindings(3);
+
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "implementer") return { success: true };
+      if (op.name === "full-suite-gate") return { success: false, findings: gateFindings };
+      if (op.name === "verifier") return { success: true, findings: [] };
+      if (op.name === "semantic-review") return { success: false, passed: false, findings: semanticFindings };
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    let capturedCycle: FixCycle<Finding> | null = null;
+    _storyOrchestratorDeps.runFixCycle = mock(async (cycle: FixCycle<Finding>) => {
+      capturedCycle = cycle;
+      return {
+        iterations: [],
+        finalFindings: [],
+        exitReason: "resolved" as FixCycleExitReason,
+        costUsd: 0,
+      };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    const story = makeStory({ id: "US-routing" });
+    const config = makeNaxConfig();
+
+    const ctx = makeCtx();
+    const plan = new StoryOrchestratorBuilder()
+      .addImplementer({ op: mockImplementerOp, input: { story: "US-routing" } })
+      .addFullSuiteGate({ op: mockFullSuiteGateOp, input: { story: "US-routing" } })
+      .addVerifier({ op: mockVerifierOp, input: { story: "US-routing" } })
+      .addSemanticReview({ op: mockSemanticReviewOp, input: { story: "US-routing" } })
+      .addRectification({
+        maxAttempts: 3,
+        strategies: [
+          makeAutofixImplementerStrategy(story),
+          makeFullSuiteRectifyStrategy(story),
+        ],
+        abortOnIncreasingFailures: false,
+      })
+      .build(ctx, { isThreeSession: true });
+
+    await plan.run();
+
+    // runFixCycle must have been called (there are semantic findings)
+    expect(capturedCycle).not.toBeNull();
+
+    const cycle = capturedCycle as unknown as FixCycle<Finding>;
+
+    // AC2.5a: exactly 3 findings (semantic only, not the 6 gate findings)
+    expect(cycle.findings).toHaveLength(3);
+
+    // AC2.5b: no test-runner findings in the cycle
+    const hasTestRunnerFinding = cycle.findings.some((f) => f.source === "test-runner");
+    expect(hasTestRunnerFinding).toBe(false);
+
+    // AC2.5c: all findings are from semantic-review
+    const allSemantic = cycle.findings.every((f) => f.source === "semantic-review");
+    expect(allSemantic).toBe(true);
+
+    // AC2.5d: the first matching strategy for these findings is autofix-implementer, not full-suite-rectify
+    const matchingStrategies = cycle.strategies.filter((s) =>
+      cycle.findings.some((f) => s.appliesTo(f)),
+    );
+    expect(matchingStrategies.length).toBeGreaterThan(0);
+    expect(matchingStrategies[0]?.name).toBe("autofix-implementer");
+  });
+});

--- a/test/integration/execution/rectification-routing.test.ts
+++ b/test/integration/execution/rectification-routing.test.ts
@@ -224,3 +224,155 @@ describe("AC2.5: rectification routing — verifier-as-SSOT carve-out with seman
     expect(matchingStrategies[0]?.name).toBe("autofix-implementer");
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC3.8: verifier is dispatched exactly once (initial run) — never during validate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AC3.8: verifier op dispatched exactly once — never re-run during validate", () => {
+  test("AC3.8: semantic findings only — verifier called during initial run, never during capturedCycle.validate", async () => {
+    const semanticFindings = makeSemanticFindings(3);
+
+    // Track all callOp invocations (phase name → call count)
+    const initialCallCounts: Record<string, number> = {};
+
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      initialCallCounts[op.name] = (initialCallCounts[op.name] ?? 0) + 1;
+      if (op.name === "implementer") return { success: true };
+      if (op.name === "full-suite-gate") return { success: true, findings: [] };
+      if (op.name === "verifier") return { success: true, findings: [] };
+      if (op.name === "semantic-review") return { success: false, passed: false, findings: semanticFindings };
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    let capturedCycle: FixCycle<Finding> | null = null;
+    let capturedCtx: FixCycleContext | null = null;
+
+    _storyOrchestratorDeps.runFixCycle = mock(async (cycle: FixCycle<Finding>, cycleCtx: FixCycleContext) => {
+      capturedCycle = cycle;
+      capturedCtx = cycleCtx;
+      return {
+        iterations: [],
+        finalFindings: [],
+        exitReason: "resolved" as FixCycleExitReason,
+        costUsd: 0,
+      };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    const story = makeStory({ id: "US-routing-ac38" });
+
+    const ctx = makeCtx();
+    const plan = new StoryOrchestratorBuilder()
+      .addImplementer({ op: mockImplementerOp, input: { story: "US-routing-ac38" } })
+      .addFullSuiteGate({ op: mockFullSuiteGateOp, input: { story: "US-routing-ac38" } })
+      .addVerifier({ op: mockVerifierOp, input: { story: "US-routing-ac38" } })
+      .addSemanticReview({ op: mockSemanticReviewOp, input: { story: "US-routing-ac38" } })
+      .addRectification({
+        maxAttempts: 3,
+        strategies: [makeAutofixImplementerStrategy(story)],
+        abortOnIncreasingFailures: false,
+      })
+      .build(ctx, { isThreeSession: true });
+
+    await plan.run();
+
+    // Verifier ran exactly once during the initial plan execution
+    expect(initialCallCounts["verifier"]).toBe(1);
+
+    expect(capturedCycle).not.toBeNull();
+    expect(capturedCtx).not.toBeNull();
+
+    // Now set up tracking for the validate call
+    const validateCallCounts: Record<string, number> = {};
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      validateCallCounts[op.name] = (validateCallCounts[op.name] ?? 0) + 1;
+      return { success: true, passed: true, findings: [] };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    // Invoke validate with autofix-implementer strategiesRun
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "full",
+      strategiesRun: ["autofix-implementer"],
+    });
+
+    // Verifier must NOT have been called during validate
+    expect(validateCallCounts["verifier"] ?? 0).toBe(0);
+
+    // Semantic review should have been re-run (it's in autofix-implementer's phase set)
+    expect(validateCallCounts["semantic-review"] ?? 0).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC3.9: after autofix-implementer, full-suite-gate + semantic-review re-dispatched; verifier not
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("AC3.9: after autofix-implementer iteration, full-suite-gate and semantic-review re-dispatched; verifier excluded", () => {
+  test("AC3.9: validate with strategiesRun=['autofix-implementer'] → full-suite-gate + semantic-review called, verifier not called", async () => {
+    const semanticFindings = makeSemanticFindings(2);
+
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "implementer") return { success: true };
+      if (op.name === "full-suite-gate") return { success: true, findings: [] };
+      if (op.name === "verifier") return { success: true, findings: [] };
+      if (op.name === "semantic-review") return { success: false, passed: false, findings: semanticFindings };
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    let capturedCycle: FixCycle<Finding> | null = null;
+    let capturedCtx: FixCycleContext | null = null;
+
+    _storyOrchestratorDeps.runFixCycle = mock(async (cycle: FixCycle<Finding>, cycleCtx: FixCycleContext) => {
+      capturedCycle = cycle;
+      capturedCtx = cycleCtx;
+      return {
+        iterations: [],
+        finalFindings: [],
+        exitReason: "resolved" as FixCycleExitReason,
+        costUsd: 0,
+      };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    const story = makeStory({ id: "US-routing-ac39" });
+
+    const ctx = makeCtx();
+    const plan = new StoryOrchestratorBuilder()
+      .addImplementer({ op: mockImplementerOp, input: { story: "US-routing-ac39" } })
+      .addFullSuiteGate({ op: mockFullSuiteGateOp, input: { story: "US-routing-ac39" } })
+      .addVerifier({ op: mockVerifierOp, input: { story: "US-routing-ac39" } })
+      .addSemanticReview({ op: mockSemanticReviewOp, input: { story: "US-routing-ac39" } })
+      .addRectification({
+        maxAttempts: 3,
+        strategies: [makeAutofixImplementerStrategy(story)],
+        abortOnIncreasingFailures: false,
+      })
+      .build(ctx, { isThreeSession: true });
+
+    await plan.run();
+
+    expect(capturedCycle).not.toBeNull();
+    expect(capturedCtx).not.toBeNull();
+
+    // Set up tracking callOp for the validate call
+    const validateCallCounts: Record<string, number> = {};
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      validateCallCounts[op.name] = (validateCallCounts[op.name] ?? 0) + 1;
+      return { success: true, passed: true, findings: [] };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    // Simulate: after an autofix-implementer iteration, call validate
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "full",
+      strategiesRun: ["autofix-implementer"],
+    });
+
+    // full-suite-gate MUST be re-dispatched (it's in autofix-implementer's phase set)
+    expect(validateCallCounts["full-suite-gate"] ?? 0).toBeGreaterThan(0);
+
+    // semantic-review MUST be re-dispatched (it's in autofix-implementer's phase set)
+    expect(validateCallCounts["semantic-review"] ?? 0).toBeGreaterThan(0);
+
+    // verifier must NOT be re-dispatched
+    expect(validateCallCounts["verifier"] ?? 0).toBe(0);
+  });
+});

--- a/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
+++ b/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
@@ -333,16 +333,9 @@ describe("gatherRectificationFindings — verifier-as-SSOT carve-out (AC1.x)", (
     const plan = makePlanWithGateAndVerifier(ctx);
     await plan.run();
 
-    // runFixCycle may not have been called if initialFindings was empty (which is what we want)
-    // Either capturedCycle is null (no findings gathered) or it doesn't contain TEST_RUNNER_FINDING
-    if (capturedCycle !== null) {
-      const findings = (capturedCycle as FixCycle<Finding>).findings;
-      const hasTestRunnerFinding = findings.some((f) => f.source === "test-runner");
-      expect(hasTestRunnerFinding).toBe(false);
-    } else {
-      // runFixCycle wasn't called because gatherRectificationFindings returned [] — correct behavior
-      expect(capturedCycle).toBeNull();
-    }
+    // verifier passed → gate findings are excluded from initial findings → no findings to fix →
+    // runFixCycle is never called. This is the correct carve-out behavior.
+    expect(capturedCycle).toBeNull();
   });
 
   test("AC1.2: verifier explicitly failed → gate findings ARE included in initial findings", async () => {

--- a/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
+++ b/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
@@ -178,7 +178,7 @@ describe("ExecutionPlan.run() — AC6: rectificationExhausted on cycle exhaustio
       finalFindings: [LINT_FINDING],
       exitReason,
       costUsd: 0,
-    }));
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
     const ctx = makeCtx();
     const plan = makePlanWithRectification(ctx);
     const result = await plan.run();
@@ -192,7 +192,7 @@ describe("ExecutionPlan.run() — AC6: rectificationExhausted on cycle exhaustio
       finalFindings: findings,
       exitReason: "max-attempts-total" as FixCycleExitReason,
       costUsd: 0,
-    }));
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
     const ctx = makeCtx();
     const plan = makePlanWithRectification(ctx);
     const result = await plan.run();
@@ -208,7 +208,7 @@ describe("ExecutionPlan.run() — AC6: rectificationExhausted on cycle exhaustio
       finalFindings: findings,
       exitReason: "bail-when" as FixCycleExitReason,
       costUsd: 0,
-    }));
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
     const ctx = makeCtx();
     const plan = makePlanWithRectification(ctx);
     const result = await plan.run();
@@ -257,7 +257,7 @@ const mockFullSuiteGateOp: RunOperation<
   kind: "run",
   name: "full-suite-gate",
   stage: "verify",
-  config: testSel,
+  config: testSel as any,
   session: { role: "verifier", lifetime: "fresh" },
   build: () => ({
     role: { id: "r", content: "gate", overridable: false },
@@ -269,6 +269,7 @@ const mockFullSuiteGateOp: RunOperation<
 const SEMANTIC_FINDING: Finding = {
   source: "semantic-review",
   severity: "error",
+  category: "",
   message: "Does not implement AC-001",
   file: "src/foo.ts",
   line: 5,
@@ -277,6 +278,7 @@ const SEMANTIC_FINDING: Finding = {
 const VERIFIER_FINDING: Finding = {
   source: "test-runner",
   severity: "error",
+  category: "",
   message: "Verifier test failed",
   file: "test/verifier.test.ts",
   line: 1,

--- a/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
+++ b/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
@@ -15,7 +15,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { _storyOrchestratorDeps, StoryOrchestratorBuilder } from "@/execution";
 import type { StoryOrchestratorResult } from "@/execution";
-import type { FixCycleExitReason } from "@/findings/cycle-types";
+import type { FixCycle, FixCycleContext, FixCycleExitReason } from "@/findings/cycle-types";
 import type { Finding } from "@/findings/types";
 import { pickSelector } from "@/config";
 import { DEFAULT_CONFIG } from "@/config";
@@ -242,5 +242,213 @@ describe("ExecutionPlan.run() — AC6: rectificationExhausted on cycle exhaustio
     const plan = makePlanWithRectification(ctx);
     const result = await plan.run();
     expect(result.rectificationExhausted).not.toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC1.1–AC1.4: gatherRectificationFindings — verifier-as-SSOT carve-out
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mockFullSuiteGateOp: RunOperation<
+  { story: string },
+  { success: boolean; findings: Finding[] },
+  typeof DEFAULT_CONFIG
+> = {
+  kind: "run",
+  name: "full-suite-gate",
+  stage: "verify",
+  config: testSel,
+  session: { role: "verifier", lifetime: "fresh" },
+  build: () => ({
+    role: { id: "r", content: "gate", overridable: false },
+    task: { id: "t", content: "", overridable: false },
+  }),
+  parse: () => ({ success: true, findings: [] }),
+};
+
+const SEMANTIC_FINDING: Finding = {
+  source: "semantic-review",
+  severity: "error",
+  message: "Does not implement AC-001",
+  file: "src/foo.ts",
+  line: 5,
+};
+
+const VERIFIER_FINDING: Finding = {
+  source: "test-runner",
+  severity: "error",
+  message: "Verifier test failed",
+  file: "test/verifier.test.ts",
+  line: 1,
+};
+
+function makePlanWithGateAndVerifier(ctx: CallContext) {
+  return new StoryOrchestratorBuilder()
+    .addImplementer({ op: mockImplementerOp, input: { story: "US-005" } })
+    .addFullSuiteGate({ op: mockFullSuiteGateOp, input: { story: "US-005" } })
+    .addVerifier({ op: mockVerifierOp, input: { story: "US-005" } })
+    .addRectification({
+      maxAttempts: 3,
+      strategies: [],
+      abortOnIncreasingFailures: false,
+    })
+    .build(ctx, { isThreeSession: true });
+}
+
+function makePlanWithGateOnly(ctx: CallContext) {
+  return new StoryOrchestratorBuilder()
+    .addImplementer({ op: mockImplementerOp, input: { story: "US-005" } })
+    .addFullSuiteGate({ op: mockFullSuiteGateOp, input: { story: "US-005" } })
+    .addRectification({
+      maxAttempts: 3,
+      strategies: [],
+      abortOnIncreasingFailures: false,
+    })
+    .build(ctx, { isThreeSession: true });
+}
+
+describe("gatherRectificationFindings — verifier-as-SSOT carve-out (AC1.x)", () => {
+  test("AC1.1: verifier passed + gate findings present → gathered initial findings exclude the gate findings", async () => {
+    // callOp: verifier passes, gate fails with TEST_RUNNER_FINDING
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "verifier") return { success: true, findings: [] };
+      if (op.name === "full-suite-gate") return { success: false, findings: [TEST_RUNNER_FINDING] };
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    let capturedCycle: FixCycle<Finding> | null = null;
+    _storyOrchestratorDeps.runFixCycle = mock(async (cycle: FixCycle<Finding>) => {
+      capturedCycle = cycle;
+      return {
+        iterations: [],
+        finalFindings: [],
+        exitReason: "resolved" as FixCycleExitReason,
+        costUsd: 0,
+      };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    const ctx = makeCtx();
+    const plan = makePlanWithGateAndVerifier(ctx);
+    await plan.run();
+
+    // runFixCycle may not have been called if initialFindings was empty (which is what we want)
+    // Either capturedCycle is null (no findings gathered) or it doesn't contain TEST_RUNNER_FINDING
+    if (capturedCycle !== null) {
+      const findings = (capturedCycle as FixCycle<Finding>).findings;
+      const hasTestRunnerFinding = findings.some((f) => f.source === "test-runner");
+      expect(hasTestRunnerFinding).toBe(false);
+    } else {
+      // runFixCycle wasn't called because gatherRectificationFindings returned [] — correct behavior
+      expect(capturedCycle).toBeNull();
+    }
+  });
+
+  test("AC1.2: verifier explicitly failed → gate findings ARE included in initial findings", async () => {
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "verifier") return { success: false, findings: [VERIFIER_FINDING] };
+      if (op.name === "full-suite-gate") return { success: false, findings: [TEST_RUNNER_FINDING] };
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    let capturedCycle: FixCycle<Finding> | null = null;
+    _storyOrchestratorDeps.runFixCycle = mock(async (cycle: FixCycle<Finding>) => {
+      capturedCycle = cycle;
+      return {
+        iterations: [],
+        finalFindings: [],
+        exitReason: "resolved" as FixCycleExitReason,
+        costUsd: 0,
+      };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    const ctx = makeCtx();
+    const plan = makePlanWithGateAndVerifier(ctx);
+    await plan.run();
+
+    expect(capturedCycle).not.toBeNull();
+    const findings = (capturedCycle as unknown as FixCycle<Finding>).findings;
+    const hasTestRunnerFinding = findings.some((f) => f.source === "test-runner");
+    expect(hasTestRunnerFinding).toBe(true);
+  });
+
+  test("AC1.3: no verifier registered → gate findings flow through unchanged", async () => {
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "full-suite-gate") return { success: false, findings: [TEST_RUNNER_FINDING] };
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    let capturedCycle: FixCycle<Finding> | null = null;
+    _storyOrchestratorDeps.runFixCycle = mock(async (cycle: FixCycle<Finding>) => {
+      capturedCycle = cycle;
+      return {
+        iterations: [],
+        finalFindings: [],
+        exitReason: "resolved" as FixCycleExitReason,
+        costUsd: 0,
+      };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    const ctx = makeCtx();
+    const plan = makePlanWithGateOnly(ctx);
+    await plan.run();
+
+    expect(capturedCycle).not.toBeNull();
+    const findings = (capturedCycle as unknown as FixCycle<Finding>).findings;
+    const hasTestRunnerFinding = findings.some((f) => f.source === "test-runner");
+    expect(hasTestRunnerFinding).toBe(true);
+  });
+
+  test("AC1.4: in validate callback, gate findings excluded when verifier passed", async () => {
+    // Gate fails with TEST_RUNNER_FINDING, verifier passes
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "verifier") return { success: true, findings: [] };
+      if (op.name === "full-suite-gate") return { success: false, findings: [TEST_RUNNER_FINDING] };
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    let capturedCycle: FixCycle<Finding> | null = null;
+    let capturedCtx: FixCycleContext | null = null;
+    _storyOrchestratorDeps.runFixCycle = mock(async (cycle: FixCycle<Finding>, cycleCtx: FixCycleContext) => {
+      capturedCycle = cycle;
+      capturedCtx = cycleCtx;
+      return {
+        iterations: [],
+        finalFindings: [],
+        exitReason: "resolved" as FixCycleExitReason,
+        costUsd: 0,
+      };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    const ctx = makeCtx();
+    const plan = makePlanWithGateAndVerifier(ctx);
+    await plan.run();
+
+    // The validate callback should exclude gate findings when verifier passes
+    // We test by calling validate directly after the initial pass
+    // Reset callOp to track gate re-runs during validate
+    let gateCalledDuringValidate = false;
+    const prevCallOp = _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "full-suite-gate") {
+        gateCalledDuringValidate = true;
+        return { success: false, findings: [TEST_RUNNER_FINDING] };
+      }
+      if (op.name === "verifier") return { success: true, findings: [] };
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    if (capturedCycle !== null && capturedCtx !== null) {
+      const validateFindings = await (capturedCycle as FixCycle<Finding>).validate(
+        capturedCtx as FixCycleContext,
+        { mode: "full" },
+      );
+      // Gate still ran (it's part of validationPhases)
+      expect(gateCalledDuringValidate).toBe(true);
+      // But gate findings are excluded because verifier passed
+      const hasTestRunnerInResult = validateFindings.some((f) => f.source === "test-runner");
+      expect(hasTestRunnerInResult).toBe(false);
+    }
+
+    _storyOrchestratorDeps.callOp = prevCallOp;
   });
 });

--- a/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
+++ b/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
@@ -59,6 +59,7 @@ const LINT_FINDING: Finding = {
   source: "lint",
   tool: "biome",
   severity: "error",
+  category: "style",
   message: "Unused variable",
   file: "src/foo.ts",
   line: 5,
@@ -67,6 +68,7 @@ const LINT_FINDING: Finding = {
 const TEST_RUNNER_FINDING: Finding = {
   source: "test-runner",
   severity: "error",
+  category: "failed-test",
   message: "Test failed",
   file: "test/foo.test.ts",
   line: 10,

--- a/test/unit/execution/story-orchestrator-revalidation.test.ts
+++ b/test/unit/execution/story-orchestrator-revalidation.test.ts
@@ -75,6 +75,7 @@ const LINT_FINDING: Finding = {
   message: "Unused variable",
   file: "src/foo.ts",
   line: 5,
+  category: "",
 };
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/unit/execution/story-orchestrator-revalidation.test.ts
+++ b/test/unit/execution/story-orchestrator-revalidation.test.ts
@@ -1,0 +1,393 @@
+/**
+ * phasesToRevalidate — AC3.1–AC3.6
+ *
+ * Tests the private `phasesToRevalidate` function via the `validate` callback
+ * exposed through `runFixCycle` injection. We:
+ *   1. Build a plan with ALL revalidation phases registered.
+ *   2. Run the plan, which triggers `runFixCycle` capturing the cycle.
+ *   3. Manually invoke `capturedCycle.validate(ctx, opts)` with different
+ *      `strategiesRun` values.
+ *   4. Track which op names were called on `callOp` during that validate
+ *      to determine which phases were re-run.
+ *
+ * Verifier is always excluded regardless of opts.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { _storyOrchestratorDeps, StoryOrchestratorBuilder } from "@/execution";
+import type { FixCycle, FixCycleContext, FixCycleExitReason } from "@/findings/cycle-types";
+import type { Finding } from "@/findings/types";
+import { pickSelector, DEFAULT_CONFIG } from "@/config";
+import { makeTestRuntime } from "@test/helpers";
+import type { NaxRuntime } from "@/runtime";
+import type { RunOperation, CallContext } from "@/operations";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const testSel = pickSelector("test-revalidation-sel", "execution");
+
+const mockImplementerOp: RunOperation<{ story: string }, { success: boolean }, typeof DEFAULT_CONFIG> = {
+  kind: "run",
+  name: "implementer",
+  stage: "run",
+  config: testSel as any,
+  session: { role: "implementer", lifetime: "warm" },
+  build: () => ({
+    role: { id: "r", content: "impl", overridable: false },
+    task: { id: "t", content: "", overridable: false },
+  }),
+  parse: () => ({ success: true }),
+};
+
+function makePhaseOp(
+  name: string,
+  stage: string,
+  role: string,
+): RunOperation<{ story: string }, { success: boolean; findings: Finding[] }, typeof DEFAULT_CONFIG> {
+  return {
+    kind: "run",
+    name,
+    stage: stage as any,
+    config: testSel as any,
+    session: { role: role as any, lifetime: "fresh" },
+    build: () => ({
+      role: { id: "r", content: name, overridable: false },
+      task: { id: "t", content: "", overridable: false },
+    }),
+    parse: () => ({ success: false, findings: [] }),
+  };
+}
+
+const mockVerifierOp = makePhaseOp("verifier", "verify", "verifier");
+const mockFullSuiteGateOp = makePhaseOp("full-suite-gate", "verify", "verifier");
+const mockVerifyScopedOp = makePhaseOp("verify-scoped", "verify", "verifier");
+const mockLintCheckOp = makePhaseOp("lint-check", "verify", "verifier");
+const mockTypecheckCheckOp = makePhaseOp("typecheck-check", "verify", "verifier");
+const mockSemanticReviewOp = makePhaseOp("semantic-review", "review", "reviewer-semantic");
+const mockAdversarialReviewOp = makePhaseOp("adversarial-review", "review", "reviewer-adversarial");
+
+const LINT_FINDING: Finding = {
+  source: "lint",
+  tool: "biome",
+  severity: "error",
+  message: "Unused variable",
+  file: "src/foo.ts",
+  line: 5,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared state
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origCallOp: typeof _storyOrchestratorDeps.callOp;
+let origRunFixCycle: typeof _storyOrchestratorDeps.runFixCycle;
+let origCaptureGitRef: typeof _storyOrchestratorDeps.captureGitRef;
+let runtime: NaxRuntime;
+
+function makeCtx(): CallContext {
+  runtime = makeTestRuntime();
+  return {
+    runtime,
+    packageView: runtime.packages.repo(),
+    packageDir: "/tmp",
+    agentName: "claude",
+    storyId: "US-revalidation",
+  } as CallContext;
+}
+
+/**
+ * Build a plan with ALL revalidation phases + implementer + verifier + rectification.
+ * Verifier fails initially so runFixCycle gets called.
+ */
+function makeFullPlan(ctx: CallContext) {
+  return new StoryOrchestratorBuilder()
+    .addImplementer({ op: mockImplementerOp, input: { story: "US-revalidation" } })
+    .addFullSuiteGate({ op: mockFullSuiteGateOp, input: { story: "US-revalidation" } })
+    .addVerifier({ op: mockVerifierOp, input: { story: "US-revalidation" } })
+    .addVerifyScoped({ op: mockVerifyScopedOp, input: { story: "US-revalidation" } })
+    .addLintCheck({ op: mockLintCheckOp, input: { story: "US-revalidation" } })
+    .addTypecheckCheck({ op: mockTypecheckCheckOp, input: { story: "US-revalidation" } })
+    .addSemanticReview({ op: mockSemanticReviewOp, input: { story: "US-revalidation" } })
+    .addAdversarialReview({ op: mockAdversarialReviewOp, input: { story: "US-revalidation" } })
+    .addRectification({
+      maxAttempts: 3,
+      strategies: [],
+      abortOnIncreasingFailures: false,
+    })
+    .build(ctx, { isThreeSession: true });
+}
+
+/**
+ * Set up the initial callOp so:
+ *  - implementer: succeeds
+ *  - verifier: fails (so runFixCycle is triggered)
+ *  - all other phases: fail with a lint finding (so they appear in initialFindings)
+ */
+function setupInitialCallOp() {
+  _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+    if (op.name === "implementer") return { success: true };
+    if (op.name === "verifier") return { success: false, findings: [LINT_FINDING] };
+    // All other phases fail to ensure runFixCycle is called
+    return { success: false, findings: [LINT_FINDING] };
+  }) as typeof _storyOrchestratorDeps.callOp;
+}
+
+/**
+ * Run the plan to capture the FixCycle, then set up a fresh callOp tracker
+ * for measuring which phases are called during validate.
+ * Returns { capturedCycle, capturedCtx, calledOps }.
+ */
+async function captureAndSetupValidate(ctx: CallContext): Promise<{
+  capturedCycle: FixCycle<Finding> | null;
+  capturedCtx: FixCycleContext | null;
+  getCalledOpsInValidate: () => Set<string>;
+}> {
+  setupInitialCallOp();
+
+  let capturedCycle: FixCycle<Finding> | null = null;
+  let capturedCtx: FixCycleContext | null = null;
+
+  _storyOrchestratorDeps.runFixCycle = mock(async (cycle: FixCycle<Finding>, cycleCtx: FixCycleContext) => {
+    capturedCycle = cycle;
+    capturedCtx = cycleCtx;
+    return {
+      iterations: [],
+      finalFindings: [],
+      exitReason: "resolved" as FixCycleExitReason,
+      costUsd: 0,
+    };
+  }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+  const plan = makeFullPlan(ctx);
+  await plan.run();
+
+  // Now set up a tracking callOp for the validate call
+  const calledOps = new Set<string>();
+
+  _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+    calledOps.add(op.name);
+    return { success: true, passed: true, findings: [] };
+  }) as typeof _storyOrchestratorDeps.callOp;
+
+  return {
+    capturedCycle,
+    capturedCtx,
+    getCalledOpsInValidate: () => calledOps,
+  };
+}
+
+beforeEach(() => {
+  origCallOp = _storyOrchestratorDeps.callOp;
+  origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+  origCaptureGitRef = _storyOrchestratorDeps.captureGitRef;
+  _storyOrchestratorDeps.captureGitRef = mock(async () => "HEAD");
+});
+
+afterEach(async () => {
+  _storyOrchestratorDeps.callOp = origCallOp;
+  _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+  _storyOrchestratorDeps.captureGitRef = origCaptureGitRef;
+  await runtime?.close();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC3.1: strategiesRun=undefined → all non-verifier phases
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("phasesToRevalidate — AC3.1: undefined strategiesRun → all non-verifier phases", () => {
+  test("AC3.1: strategiesRun=undefined → verifier excluded, all other phases called", async () => {
+    const ctx = makeCtx();
+    const { capturedCycle, capturedCtx, getCalledOpsInValidate } = await captureAndSetupValidate(ctx);
+
+    expect(capturedCycle).not.toBeNull();
+    expect(capturedCtx).not.toBeNull();
+
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "full",
+      strategiesRun: undefined,
+    });
+
+    const called = getCalledOpsInValidate();
+
+    // Verifier must NOT be re-run
+    expect(called.has("verifier")).toBe(false);
+
+    // All other phases in the plan must be re-run
+    expect(called.has("full-suite-gate")).toBe(true);
+    expect(called.has("verify-scoped")).toBe(true);
+    expect(called.has("lint-check")).toBe(true);
+    expect(called.has("typecheck-check")).toBe(true);
+    expect(called.has("semantic-review")).toBe(true);
+    expect(called.has("adversarial-review")).toBe(true);
+  });
+
+  test("AC3.1: strategiesRun=[] (empty array) → same fallback as undefined (all non-verifier)", async () => {
+    const ctx = makeCtx();
+    const { capturedCycle, capturedCtx, getCalledOpsInValidate } = await captureAndSetupValidate(ctx);
+
+    expect(capturedCycle).not.toBeNull();
+
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "full",
+      strategiesRun: [],
+    });
+
+    const called = getCalledOpsInValidate();
+
+    expect(called.has("verifier")).toBe(false);
+    expect(called.has("full-suite-gate")).toBe(true);
+    expect(called.has("verify-scoped")).toBe(true);
+    expect(called.has("lint-check")).toBe(true);
+    expect(called.has("typecheck-check")).toBe(true);
+    expect(called.has("semantic-review")).toBe(true);
+    expect(called.has("adversarial-review")).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC3.2: strategiesRun=["autofix-implementer"] → all 6 non-verifier phases
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("phasesToRevalidate — AC3.2: autofix-implementer → all non-verifier phases", () => {
+  test("AC3.2: strategiesRun=['autofix-implementer'] → lint, typecheck, full-suite-gate, verify-scoped, semantic, adversarial called; verifier excluded", async () => {
+    const ctx = makeCtx();
+    const { capturedCycle, capturedCtx, getCalledOpsInValidate } = await captureAndSetupValidate(ctx);
+
+    expect(capturedCycle).not.toBeNull();
+
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "full",
+      strategiesRun: ["autofix-implementer"],
+    });
+
+    const called = getCalledOpsInValidate();
+
+    expect(called.has("verifier")).toBe(false);
+    expect(called.has("lint-check")).toBe(true);
+    expect(called.has("typecheck-check")).toBe(true);
+    expect(called.has("full-suite-gate")).toBe(true);
+    expect(called.has("verify-scoped")).toBe(true);
+    expect(called.has("semantic-review")).toBe(true);
+    expect(called.has("adversarial-review")).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC3.3: strategiesRun=["mechanical-lintfix"] → only lint-check
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("phasesToRevalidate — AC3.3: mechanical-lintfix → only lint-check", () => {
+  test("AC3.3: strategiesRun=['mechanical-lintfix'] → only lint-check called; all others excluded", async () => {
+    const ctx = makeCtx();
+    const { capturedCycle, capturedCtx, getCalledOpsInValidate } = await captureAndSetupValidate(ctx);
+
+    expect(capturedCycle).not.toBeNull();
+
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "full",
+      strategiesRun: ["mechanical-lintfix"],
+    });
+
+    const called = getCalledOpsInValidate();
+
+    expect(called.has("lint-check")).toBe(true);
+
+    // All others must NOT be called
+    expect(called.has("verifier")).toBe(false);
+    expect(called.has("typecheck-check")).toBe(false);
+    expect(called.has("full-suite-gate")).toBe(false);
+    expect(called.has("verify-scoped")).toBe(false);
+    expect(called.has("semantic-review")).toBe(false);
+    expect(called.has("adversarial-review")).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC3.4: strategiesRun=["full-suite-rectify"] → lint, typecheck, gate, scoped, semantic; NO adversarial
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("phasesToRevalidate — AC3.4: full-suite-rectify → no adversarial-review", () => {
+  test("AC3.4: strategiesRun=['full-suite-rectify'] → lint, typecheck, gate, scoped, semantic called; adversarial and verifier excluded", async () => {
+    const ctx = makeCtx();
+    const { capturedCycle, capturedCtx, getCalledOpsInValidate } = await captureAndSetupValidate(ctx);
+
+    expect(capturedCycle).not.toBeNull();
+
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "full",
+      strategiesRun: ["full-suite-rectify"],
+    });
+
+    const called = getCalledOpsInValidate();
+
+    expect(called.has("lint-check")).toBe(true);
+    expect(called.has("typecheck-check")).toBe(true);
+    expect(called.has("full-suite-gate")).toBe(true);
+    expect(called.has("verify-scoped")).toBe(true);
+    expect(called.has("semantic-review")).toBe(true);
+
+    // These must NOT be called
+    expect(called.has("adversarial-review")).toBe(false);
+    expect(called.has("verifier")).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC3.5: strategiesRun=["unknown-plugin-strategy"] → fallback = all non-verifier
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("phasesToRevalidate — AC3.5: unknown strategy → fallback to all non-verifier phases", () => {
+  test("AC3.5: strategiesRun=['unknown-plugin-strategy'] → all non-verifier phases called (conservative fallback)", async () => {
+    const ctx = makeCtx();
+    const { capturedCycle, capturedCtx, getCalledOpsInValidate } = await captureAndSetupValidate(ctx);
+
+    expect(capturedCycle).not.toBeNull();
+
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "full",
+      strategiesRun: ["unknown-plugin-strategy"],
+    });
+
+    const called = getCalledOpsInValidate();
+
+    expect(called.has("verifier")).toBe(false);
+    expect(called.has("lint-check")).toBe(true);
+    expect(called.has("typecheck-check")).toBe(true);
+    expect(called.has("full-suite-gate")).toBe(true);
+    expect(called.has("verify-scoped")).toBe(true);
+    expect(called.has("semantic-review")).toBe(true);
+    expect(called.has("adversarial-review")).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC3.6: strategiesRun=["mechanical-lintfix", "autofix-implementer"] → union (broad set)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("phasesToRevalidate — AC3.6: union of mechanical-lintfix + autofix-implementer → all non-verifier phases", () => {
+  test("AC3.6: strategiesRun=['mechanical-lintfix','autofix-implementer'] → union: lint + typecheck + gate + scoped + semantic + adversarial; verifier excluded", async () => {
+    const ctx = makeCtx();
+    const { capturedCycle, capturedCtx, getCalledOpsInValidate } = await captureAndSetupValidate(ctx);
+
+    expect(capturedCycle).not.toBeNull();
+
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "full",
+      strategiesRun: ["mechanical-lintfix", "autofix-implementer"],
+    });
+
+    const called = getCalledOpsInValidate();
+
+    // Union of mechanical-lintfix (lint-check) + autofix-implementer
+    // (lint, typecheck, gate, scoped, semantic, adversarial) = all 6 non-verifier phases
+    expect(called.has("verifier")).toBe(false);
+    expect(called.has("lint-check")).toBe(true);
+    expect(called.has("typecheck-check")).toBe(true);
+    expect(called.has("full-suite-gate")).toBe(true);
+    expect(called.has("verify-scoped")).toBe(true);
+    expect(called.has("semantic-review")).toBe(true);
+    expect(called.has("adversarial-review")).toBe(true);
+  });
+});

--- a/test/unit/execution/story-orchestrator.test.ts
+++ b/test/unit/execution/story-orchestrator.test.ts
@@ -1133,11 +1133,11 @@ describe("AC3 + AC5: gate-internal rectification — finding aggregation and ful
   });
 });
 
-describe("AC-4 + AC-5: validate callback re-runs gate + verifier, lite-mode skips gate", () => {
+describe("AC-4 + AC-5: validate callback re-runs gate (not verifier), lite-mode skips gate", () => {
   let rt: NaxRuntime | undefined;
   afterEach(async () => { await rt?.close(); });
 
-  test("AC-4: validate re-runs BOTH gate and verifier (mode=full)", async () => {
+  test("AC-4: validate re-runs gate (mode=full) but never re-runs verifier (one-shot TDD isolation)", async () => {
     const config = makeNaxConfig({ execution: { rectification: { enabled: true, maxRetries: 3, abortOnIncreasingFailures: false } } });
     rt = makeTestRuntime({ config });
 
@@ -1175,8 +1175,12 @@ describe("AC-4 + AC-5: validate callback re-runs gate + verifier, lite-mode skip
         const beforeGate = gateRunCount.n;
         const beforeVerifier = verifierRunCount.n;
         await capturedCycle.validate(ctx, { mode: "full" });
+        // Gate still runs during validate (keeps phaseOutputs current for applyPostRunInspection).
         expect(gateRunCount.n).toBeGreaterThan(beforeGate);
-        expect(verifierRunCount.n).toBeGreaterThan(beforeVerifier);
+        // Verifier is NEVER re-run inside rectification (Patch 3 / Defect C): its TDD-isolation
+        // job is one-shot, anchored to the story-start git ref. The routing layer partitions
+        // source vs. test edits, so re-dispatching the verifier asks a question already answered.
+        expect(verifierRunCount.n).toBe(beforeVerifier);
       }
     } finally {
       _storyOrchestratorDeps.callOp = origCallOp;
@@ -1222,8 +1226,8 @@ describe("AC-4 + AC-5: validate callback re-runs gate + verifier, lite-mode skip
         const beforeGate = gateRunCount.n;
         const beforeVerifier = verifierRunCount.n;
         await capturedCycle.validate(ctx, { mode: "lite" });
-        expect(gateRunCount.n).toBe(beforeGate);         // gate NOT re-run
-        expect(verifierRunCount.n).toBeGreaterThan(beforeVerifier); // verifier IS re-run
+        expect(gateRunCount.n).toBe(beforeGate);     // lite mode: gate skipped
+        expect(verifierRunCount.n).toBe(beforeVerifier); // Patch 3: verifier never re-run
       }
     } finally {
       _storyOrchestratorDeps.callOp = origCallOp;

--- a/test/unit/execution/story-orchestrator.test.ts
+++ b/test/unit/execution/story-orchestrator.test.ts
@@ -30,7 +30,7 @@ import {
 } from "@test/helpers";
 import type { NaxRuntime } from "@/runtime";
 import type { CompleteResult, TurnResult } from "@/agents/types";
-import type { ReviewCheckResult } from "@/findings";
+import type { ReviewCheckResult, Finding } from "@/findings";
 import { NaxError } from "@/errors";
 import { _storyOrchestratorDeps } from "@/execution";
 
@@ -998,7 +998,7 @@ describe("AC3 + AC5: gate-internal rectification — finding aggregation and ful
     const config = makeNaxConfig({ execution: { rectification: { enabled: true, maxRetries: 3, abortOnIncreasingFailures: false } } });
     rt = makeTestRuntime({ config });
 
-    let capturedCycleFindings: unknown[] | null = null;
+    let capturedCycleFindings: Finding[] | null = null;
     const gateOp = makeDeterministicOp("full-suite-gate", {
       success: false,
       findings: [
@@ -1043,11 +1043,11 @@ describe("AC3 + AC5: gate-internal rectification — finding aggregation and ful
     const config = makeNaxConfig({ execution: { rectification: { enabled: true, maxRetries: 3, abortOnIncreasingFailures: false } } });
     rt = makeTestRuntime({ config });
 
-    let capturedCycleFindings: unknown[] | null = null;
+    let capturedCycleFindings: Finding[] | null = null;
     const gateOp = makeDeterministicOp("full-suite-gate", { success: true });
     const verOp = makeDeterministicOp("verifier", {
       success: false,
-      findings: [{ source: "review", category: "semantic", severity: "error", message: "review fail", rule: "r", file: "f.ts" }],
+      findings: [{ source: "semantic-review", category: "semantic", severity: "error", message: "review fail", rule: "r", file: "f.ts" }],
     });
 
     const origCallOp = _storyOrchestratorDeps.callOp;
@@ -1072,8 +1072,9 @@ describe("AC3 + AC5: gate-internal rectification — finding aggregation and ful
       await plan.run();
 
       expect(capturedCycleFindings).not.toBeNull();
-      expect(capturedCycleFindings).toEqual([
-        { source: "review", category: "semantic", severity: "error", message: "review fail", rule: "r", file: "f.ts" },
+      // Non-null assertion: TypeScript CFA doesn't track closure assignments, so we assert explicitly.
+      expect(capturedCycleFindings!).toEqual([
+        { source: "semantic-review", category: "semantic", severity: "error", message: "review fail", rule: "r", file: "f.ts" },
       ]);
     } finally {
       _storyOrchestratorDeps.callOp = origCallOp;

--- a/test/unit/findings/cycle-types.test.ts
+++ b/test/unit/findings/cycle-types.test.ts
@@ -1,0 +1,67 @@
+/**
+ * cycle-types — AC3.7
+ *
+ * Structural (compile-time) tests verifying the FixCycle<F>.validate signature
+ * accepts the optional `strategiesRun` field on the opts object.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { FixCycle, FixCycleContext } from "@/findings/cycle-types";
+import type { Finding } from "@/findings/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC3.7: validate signature accepts optional strategiesRun field
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("FixCycle — AC3.7: validate signature includes optional strategiesRun", () => {
+  test("AC3.7: validate accepts opts with strategiesRun set to a readonly string array", () => {
+    const cycle: FixCycle<Finding> = {
+      findings: [],
+      iterations: [],
+      strategies: [],
+      config: { maxAttemptsTotal: 1, validatorRetries: 0 },
+      validate: async (_ctx: FixCycleContext, opts) => {
+        // strategiesRun is a valid field on opts (optional)
+        const _names: readonly string[] | undefined = opts.strategiesRun;
+        void _names;
+        return [];
+      },
+    };
+    expect(typeof cycle.validate).toBe("function");
+  });
+
+  test("AC3.7: validate accepts opts without strategiesRun (field is optional)", () => {
+    const cycle: FixCycle<Finding> = {
+      findings: [],
+      iterations: [],
+      strategies: [],
+      config: { maxAttemptsTotal: 1, validatorRetries: 0 },
+      validate: async (_ctx: FixCycleContext, opts) => {
+        // opts.strategiesRun may be undefined — that is valid
+        const _mode: "full" | "lite" = opts.mode;
+        void _mode;
+        return [];
+      },
+    };
+    expect(typeof cycle.validate).toBe("function");
+  });
+
+  test("AC3.7: validate accepts both mode and strategiesRun together", () => {
+    const cycle: FixCycle<Finding> = {
+      findings: [],
+      iterations: [],
+      strategies: [],
+      config: { maxAttemptsTotal: 1, validatorRetries: 0 },
+      validate: async (_ctx: FixCycleContext, opts) => {
+        const _mode: "full" | "lite" = opts.mode;
+        const _names: readonly string[] | undefined = opts.strategiesRun;
+        void _mode;
+        void _names;
+        return [];
+      },
+    };
+
+    // Runtime check: the validate function must be callable with and without strategiesRun
+    expect(typeof cycle.validate).toBe("function");
+  });
+});

--- a/test/unit/findings/cycle.test.ts
+++ b/test/unit/findings/cycle.test.ts
@@ -254,21 +254,21 @@ callOp: callOpMock as unknown as CallOpFn});
 
 describe("runFixCycle — skip validate on final allowed attempt", () => {
   test("calls validate with { mode: 'lite' } when single or all co-run strategies exhaust caps after a fix", async () => {
-    const validateCalls1: Array<{ mode: "full" | "lite" }> = [];
+    const validateCalls1: Array<{ mode: "full" | "lite"; strategiesRun?: readonly string[] }> = [];
     const s1 = makeStrategy({ name: "lint-fix", maxAttempts: 1 });
     const r1 = await runFixCycle(makeCycle([lintA], [s1], async (_ctx, opts) => { validateCalls1.push(opts); return [lintA]; }), makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
 callOp: makeCallOpMock() as unknown as CallOpFn});
     expect(validateCalls1).toHaveLength(1);
-    expect(validateCalls1[0]).toEqual({ mode: "lite" });
+    expect(validateCalls1[0]).toMatchObject({ mode: "lite", strategiesRun: ["lint-fix"] });
     expect(r1.exitReason).toBe("max-attempts-per-strategy");
 
-    const validateCalls2: Array<{ mode: "full" | "lite" }> = [];
+    const validateCalls2: Array<{ mode: "full" | "lite"; strategiesRun?: readonly string[] }> = [];
     const sA = makeStrategy({ name: "fix-a", maxAttempts: 1, coRun: "co-run-sequential" });
     const sB = makeStrategy({ name: "fix-b", maxAttempts: 1, coRun: "co-run-sequential" });
     const r2 = await runFixCycle(makeCycle([lintA], [sA, sB], async (_ctx, opts) => { validateCalls2.push(opts); return [lintA]; }), makeCtx(), "test-cycle", { // eslint-disable-next-line @typescript-eslint/no-explicit-any
 callOp: makeCallOpMock() as unknown as CallOpFn});
     expect(validateCalls2).toHaveLength(1);
-    expect(validateCalls2[0]).toEqual({ mode: "lite" });
+    expect(validateCalls2[0]).toMatchObject({ mode: "lite", strategiesRun: ["fix-a", "fix-b"] });
     expect(r2.exitReason).toBe("max-attempts-per-strategy");
   });
 });
@@ -435,7 +435,7 @@ callOp: callOpMock as unknown as CallOpFn});
 
 describe("runFixCycle — validate mode opts", () => {
   test("passes { mode: 'full' } to validate in non-terminal path", async () => {
-    const validateCalls: Array<{ mode: "full" | "lite" }> = [];
+    const validateCalls: Array<{ mode: "full" | "lite"; strategiesRun?: readonly string[] }> = [];
     const strategy = makeStrategy({ name: "lint-fix", maxAttempts: 2 });
     const cycle = makeCycle([lintA], [strategy], async (_ctx, opts) => {
       validateCalls.push(opts);
@@ -448,7 +448,7 @@ callOp: callOpMock as unknown as CallOpFn});
 
     expect(result.exitReason).toBe("resolved");
     expect(validateCalls).toHaveLength(1);
-    expect(validateCalls[0]).toEqual({ mode: "full" });
+    expect(validateCalls[0]).toMatchObject({ mode: "full", strategiesRun: ["lint-fix"] });
   });
 
 });

--- a/test/unit/operations/autofix-implementer-strategy.test.ts
+++ b/test/unit/operations/autofix-implementer-strategy.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { Finding } from "@/findings";
+import type { FixCycleContext } from "@/findings/cycle-types";
 import { makeAutofixImplementerStrategy } from "@/operations";
+import { makeStory } from "@test/helpers";
 
 const mockCtx = {} as any;
 
@@ -67,5 +69,21 @@ describe("makeAutofixImplementerStrategy", () => {
       const finding = makeFinding({ fixTarget: "source", source: "adversarial-review" });
       expect(strategy.appliesTo(finding)).toBe(false);
     });
+  });
+
+  test("AC2.3: buildInput converts semantic finding to ReviewCheckResult", () => {
+    const story = makeStory();
+    const strategy = makeAutofixImplementerStrategy(story);
+    const semanticFinding: Finding = {
+      source: "semantic-review",
+      severity: "error",
+      message: "Fails AC-001",
+      file: "src/foo.ts",
+      line: 5,
+    };
+    const input = strategy.buildInput([semanticFinding], [], {} as FixCycleContext);
+    expect(input.failedChecks).toHaveLength(1);
+    expect(input.failedChecks[0]?.check).toBe("semantic");
+    expect(input.failedChecks[0]?.findings).toEqual([semanticFinding]);
   });
 });

--- a/test/unit/operations/autofix-implementer-strategy.test.ts
+++ b/test/unit/operations/autofix-implementer-strategy.test.ts
@@ -77,6 +77,7 @@ describe("makeAutofixImplementerStrategy", () => {
     const semanticFinding: Finding = {
       source: "semantic-review",
       severity: "error",
+      category: "",
       message: "Fails AC-001",
       file: "src/foo.ts",
       line: 5,

--- a/test/unit/operations/autofix-test-writer-strategy.test.ts
+++ b/test/unit/operations/autofix-test-writer-strategy.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { Finding } from "@/findings";
+import type { FixCycleContext } from "@/findings/cycle-types";
 import { makeAutofixTestWriterStrategy } from "@/operations";
+import { makeNaxConfig, makeStory } from "@test/helpers";
 
 const mockCtx = {} as any;
 
@@ -67,5 +69,22 @@ describe("makeAutofixTestWriterStrategy", () => {
       const finding = makeFinding({ fixTarget: "source", source: "semantic-review" });
       expect(strategy.appliesTo(finding)).toBe(false);
     });
+  });
+
+  test("AC2.4: buildInput converts adversarial finding to ReviewCheckResult", () => {
+    const story = makeStory();
+    const config = makeNaxConfig();
+    const strategy = makeAutofixTestWriterStrategy(story, config);
+    const adversarialFinding: Finding = {
+      source: "adversarial-review",
+      severity: "error",
+      message: "Coverage gap",
+      file: "test/foo.test.ts",
+      line: 3,
+    };
+    const input = strategy.buildInput([adversarialFinding], [], {} as FixCycleContext);
+    expect(input.failedChecks).toHaveLength(1);
+    expect(input.failedChecks[0]?.check).toBe("adversarial");
+    expect(input.failedChecks[0]?.findings).toEqual([adversarialFinding]);
   });
 });

--- a/test/unit/operations/autofix-test-writer-strategy.test.ts
+++ b/test/unit/operations/autofix-test-writer-strategy.test.ts
@@ -19,53 +19,53 @@ function makeFinding(overrides: Partial<Finding> = {}): Finding {
 
 describe("makeAutofixTestWriterStrategy", () => {
   test("name is autofix-test-writer", () => {
-    const strategy = makeAutofixTestWriterStrategy(mockCtx);
+    const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
     expect(strategy.name).toBe("autofix-test-writer");
   });
 
   test("fixOp name is autofix-test-writer", () => {
-    const strategy = makeAutofixTestWriterStrategy(mockCtx);
+    const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
     expect(strategy.fixOp.name).toBe("autofix-test-writer");
   });
 
   test("maxAttempts is a positive number", () => {
-    const strategy = makeAutofixTestWriterStrategy(mockCtx);
+    const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
     expect(strategy.maxAttempts).toBeGreaterThan(0);
   });
 
   describe("AC4: appliesTo predicate — test-targeted findings", () => {
     test("AC4: returns true when fixTarget=test", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx);
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
       const finding = makeFinding({ fixTarget: "test", source: "lint" });
       expect(strategy.appliesTo(finding)).toBe(true);
     });
 
     test("AC4: returns true when source=adversarial-review", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx);
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
       const finding = makeFinding({ fixTarget: "source", source: "adversarial-review" });
       expect(strategy.appliesTo(finding)).toBe(true);
     });
 
     test("AC4: returns true when fixTarget=test and source=adversarial-review", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx);
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
       const finding = makeFinding({ fixTarget: "test", source: "adversarial-review" });
       expect(strategy.appliesTo(finding)).toBe(true);
     });
 
     test("AC4: returns false when fixTarget=source and source is not adversarial-review (lint)", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx);
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
       const finding = makeFinding({ fixTarget: "source", source: "lint" });
       expect(strategy.appliesTo(finding)).toBe(false);
     });
 
     test("AC4: returns false when fixTarget=source and source=typecheck", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx);
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
       const finding = makeFinding({ fixTarget: "source", source: "typecheck" });
       expect(strategy.appliesTo(finding)).toBe(false);
     });
 
     test("AC4: returns false when fixTarget=source and source=semantic-review", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx);
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
       const finding = makeFinding({ fixTarget: "source", source: "semantic-review" });
       expect(strategy.appliesTo(finding)).toBe(false);
     });
@@ -78,6 +78,7 @@ describe("makeAutofixTestWriterStrategy", () => {
     const adversarialFinding: Finding = {
       source: "adversarial-review",
       severity: "error",
+      category: "",
       message: "Coverage gap",
       file: "test/foo.test.ts",
       line: 3,

--- a/test/unit/operations/finding-to-check.test.ts
+++ b/test/unit/operations/finding-to-check.test.ts
@@ -1,0 +1,87 @@
+/**
+ * findingsToFailedChecks — unit tests (AC2.1, AC2.2)
+ */
+import { describe, expect, test } from "bun:test";
+import { findingsToFailedChecks } from "@/operations";
+import type { Finding } from "@/findings/types";
+
+const SEMANTIC_FINDING: Finding = {
+  source: "semantic-review",
+  severity: "error",
+  message: "Does not implement AC-001",
+  file: "src/foo.ts",
+  line: 10,
+};
+
+const ADVERSARIAL_FINDING: Finding = {
+  source: "adversarial-review",
+  severity: "error",
+  message: "Test coverage gap",
+  file: "test/foo.test.ts",
+  line: 5,
+};
+
+const LINT_FINDING: Finding = {
+  source: "lint",
+  severity: "error",
+  message: "Unused variable",
+  file: "src/bar.ts",
+  line: 3,
+};
+
+const TYPECHECK_FINDING: Finding = {
+  source: "typecheck",
+  severity: "error",
+  message: "Type mismatch",
+  file: "src/baz.ts",
+  line: 7,
+};
+
+const TEST_RUNNER_FINDING: Finding = {
+  source: "test-runner",
+  severity: "error",
+  message: "Test failed",
+  file: "test/baz.test.ts",
+  line: 1,
+};
+
+describe("findingsToFailedChecks", () => {
+  test("AC2.1: single semantic finding → one entry with check='semantic'", () => {
+    const result = findingsToFailedChecks([SEMANTIC_FINDING]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.check).toBe("semantic");
+    expect(result[0]?.success).toBe(false);
+    expect(result[0]?.findings).toEqual([SEMANTIC_FINDING]);
+  });
+
+  test("AC2.2: mixed semantic + adversarial → 2 entries, one per source", () => {
+    const result = findingsToFailedChecks([SEMANTIC_FINDING, ADVERSARIAL_FINDING]);
+    expect(result).toHaveLength(2);
+    const checks = result.map((r) => r.check).sort();
+    expect(checks).toEqual(["adversarial", "semantic"]);
+  });
+
+  test("AC2.2: lint + typecheck findings → 2 entries", () => {
+    const result = findingsToFailedChecks([LINT_FINDING, TYPECHECK_FINDING]);
+    expect(result).toHaveLength(2);
+    const checks = result.map((r) => r.check).sort();
+    expect(checks).toEqual(["lint", "typecheck"]);
+  });
+
+  test("AC2.2: same source × 2 findings → 1 entry with both in findings[]", () => {
+    const finding2: Finding = { ...SEMANTIC_FINDING, message: "AC-002 gap" };
+    const result = findingsToFailedChecks([SEMANTIC_FINDING, finding2]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.findings).toHaveLength(2);
+  });
+
+  test("unmapped source (test-runner) is dropped", () => {
+    const result = findingsToFailedChecks([TEST_RUNNER_FINDING]);
+    expect(result).toHaveLength(0);
+  });
+
+  test("empty input → empty output", () => {
+    const result = findingsToFailedChecks([]);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/test/unit/operations/finding-to-check.test.ts
+++ b/test/unit/operations/finding-to-check.test.ts
@@ -8,6 +8,7 @@ import type { Finding } from "@/findings/types";
 const SEMANTIC_FINDING: Finding = {
   source: "semantic-review",
   severity: "error",
+  category: "",
   message: "Does not implement AC-001",
   file: "src/foo.ts",
   line: 10,
@@ -16,6 +17,7 @@ const SEMANTIC_FINDING: Finding = {
 const ADVERSARIAL_FINDING: Finding = {
   source: "adversarial-review",
   severity: "error",
+  category: "",
   message: "Test coverage gap",
   file: "test/foo.test.ts",
   line: 5,
@@ -24,6 +26,7 @@ const ADVERSARIAL_FINDING: Finding = {
 const LINT_FINDING: Finding = {
   source: "lint",
   severity: "error",
+  category: "",
   message: "Unused variable",
   file: "src/bar.ts",
   line: 3,
@@ -32,6 +35,7 @@ const LINT_FINDING: Finding = {
 const TYPECHECK_FINDING: Finding = {
   source: "typecheck",
   severity: "error",
+  category: "",
   message: "Type mismatch",
   file: "src/baz.ts",
   line: 7,
@@ -40,6 +44,7 @@ const TYPECHECK_FINDING: Finding = {
 const TEST_RUNNER_FINDING: Finding = {
   source: "test-runner",
   severity: "error",
+  category: "",
   message: "Test failed",
   file: "test/baz.test.ts",
   line: 1,


### PR DESCRIPTION
## Summary

Implements the three patches from `docs/specs/2026-05-25-rectification-semantic-finding-routing.md`:

### Patch 1 — Verifier-as-SSOT carve-out in `gatherRectificationFindings`
When the verifier passes, full-suite-gate findings are pre-existing regressions unrelated to the current story. The new `shouldSkipPhaseForRectification` guard excludes them so they don't flood the fix cycle with impossible-to-fix failures.

### Patch 2 — `findingsToFailedChecks` bridge function
A new `src/operations/_finding-to-check.ts` converts `Finding[]` → `ReviewCheckResult[]` keyed by source. The autofix strategies (`autofix-implementer-strategy`, `autofix-test-writer-strategy`) now use this to pass correct check metadata into their prompt builders instead of an empty `failedChecks: []`.

### Patch 3 — Scoped `validate` callback (Defect C fix)
The rectification `validate` callback is now scoped to the phases relevant to each strategy via the new `STRATEGY_TO_REVALIDATION_PHASES` constant and `phasesToRevalidate()` helper. The verifier is never re-dispatched inside rectification (one-shot TDD-isolation principle). The `FixCycleValidateOpts` type is extended with `strategiesRun?: readonly string[]` and both call sites in `cycle.ts` thread it through.

---

## Files changed

**Source (8 files):**
- `src/execution/story-orchestrator.ts` — Patches 1 + 3: skip guard, `STRATEGY_TO_REVALIDATION_PHASES`, `phasesToRevalidate()`, rewritten validate callback
- `src/findings/cycle-types.ts` — Patch 3: extend validate opts with `strategiesRun`
- `src/findings/cycle.ts` — Patch 3: thread `strategiesRun` at both call sites
- `src/operations/_finding-to-check.ts` — Patch 2: new `findingsToFailedChecks()`
- `src/operations/autofix-implementer-strategy.ts` — Patch 2: wire `findingsToFailedChecks`
- `src/operations/autofix-test-writer-strategy.ts` — Patch 2: wire `findingsToFailedChecks`
- `src/operations/index.ts` — Patch 2: export `findingsToFailedChecks`

**Tests (9 files, ~1 400 new lines):**
- `test/integration/execution/rectification-routing.test.ts` — AC2.5, AC3.8–3.9
- `test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts` — AC1.1–1.4
- `test/unit/execution/story-orchestrator-revalidation.test.ts` — AC3.1–3.6
- `test/unit/execution/story-orchestrator.test.ts` — AC-4/AC-5 updated + pre-existing type fix
- `test/unit/findings/cycle-types.test.ts` — AC3.7
- `test/unit/findings/cycle.test.ts` — updated snapshot assertions
- `test/unit/operations/finding-to-check.test.ts` — AC2.1–2.2
- `test/unit/operations/autofix-implementer-strategy.test.ts` — AC2.3
- `test/unit/operations/autofix-test-writer-strategy.test.ts` — AC2.4

---

## Test plan

- `bun run lint` — ✅ green
- `bun run typecheck` — ✅ green  
- `bun run test:bail` — ✅ 1 064 pass, 39 skip, 0 fail