### PR TITLE
fix(review): tag finding source so rectification strategies match

### DIFF
--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -210,16 +210,25 @@ function phasePassed(opName: string, output: unknown): boolean {
 }
 
 /**
- * Extract structured Findings from a phase output. Each op produces `findings: Finding[]`
- * in its parsed envelope (verifierOp / semanticReviewOp / adversarialReviewOp all conform);
- * we only need to read the array when the phase did not pass.
+ * Extract structured Findings from a phase output. Ops that produce LLM-shape findings
+ * (semanticReviewOp / adversarialReviewOp) expose a `normalizedFindings: Finding[]`
+ * field with `source` already tagged — strategies' `appliesTo` gates on `source`, so
+ * the un-tagged raw `findings` must NEVER reach the rectification cycle (issue: when
+ * the cast lied, `source` was undefined and every strategy was filtered out, producing
+ * "no matching strategy" exits despite real blocking findings). We prefer
+ * `normalizedFindings` when present and fall back to `findings` for ops whose envelope
+ * already speaks the `Finding` wire format (verifierOp etc.).
  */
 function extractPhaseFindings(output: unknown): Finding[] {
   if (output === null || output === undefined || typeof output !== "object") {
     return [];
   }
   const record = output as Record<string, unknown>;
-  const findings = Array.isArray(record.findings) ? (record.findings as Finding[]) : [];
+  const findings: Finding[] = Array.isArray(record.normalizedFindings)
+    ? (record.normalizedFindings as Finding[])
+    : Array.isArray(record.findings)
+      ? (record.findings as Finding[])
+      : [];
   const success =
     "success" in record ? record.success === true : "passed" in record ? record.passed === true : findings.length === 0;
   return success ? [] : findings;

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -219,16 +219,29 @@ function phasePassed(opName: string, output: unknown): boolean {
  * `normalizedFindings` when present and fall back to `findings` for ops whose envelope
  * already speaks the `Finding` wire format (verifierOp etc.).
  */
+function isFinding(value: unknown): value is Finding {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { source?: unknown }).source === "string" &&
+    (value as { source: string }).source.length > 0
+  );
+}
+
 function extractPhaseFindings(output: unknown): Finding[] {
   if (output === null || output === undefined || typeof output !== "object") {
     return [];
   }
   const record = output as Record<string, unknown>;
-  const findings: Finding[] = Array.isArray(record.normalizedFindings)
-    ? (record.normalizedFindings as Finding[])
+  const rawArray = Array.isArray(record.normalizedFindings)
+    ? record.normalizedFindings
     : Array.isArray(record.findings)
-      ? (record.findings as Finding[])
+      ? record.findings
       : [];
+  // Runtime guard: strip anything that isn't a source-tagged Finding. Strategies'
+  // `appliesTo` predicates gate on `f.source` — entries without it cannot be
+  // routed and previously caused the cycle to exit with "no matching strategy".
+  const findings = rawArray.filter(isFinding);
   const success =
     "success" in record ? record.success === true : "passed" in record ? record.passed === true : findings.length === 0;
   return success ? [] : findings;

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -1,10 +1,10 @@
 import { ParseValidationError, makeParseRetryStrategy } from "../agents/retry";
 import { reviewConfigSelector } from "../config";
 import type { ReviewConfig } from "../config/selectors";
-import type { Iteration } from "../findings";
+import type { Finding, Iteration } from "../findings";
 import { AdversarialReviewPromptBuilder, ReviewPromptBuilder } from "../prompts";
 import type { TestInventory } from "../prompts";
-import { validateAdversarialShape } from "../review/adversarial-helpers";
+import { toAdversarialReviewFindings, validateAdversarialShape } from "../review/adversarial-helpers";
 import type { AdversarialReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { RunOperation } from "./types";
@@ -32,7 +32,14 @@ export interface AdversarialReviewInput {
 
 export interface AdversarialReviewOutput {
   passed: boolean;
+  /** Raw AdversarialLLMFinding[]. Consumed by `src/review/adversarial.ts`. */
   findings: unknown[];
+  /**
+   * Source-tagged Finding[] (`source: "adversarial-review"`), used by the rectification
+   * cycle's `extractPhaseFindings` → strategy `appliesTo` routing. Empty for fail-open
+   * / looksLikeFail outcomes.
+   */
+  normalizedFindings: Finding[];
   failOpen?: boolean;
   /**
    * True when the raw output could not be parsed but contained `"passed": false`.
@@ -41,7 +48,7 @@ export interface AdversarialReviewOutput {
   looksLikeFail?: boolean;
 }
 
-const FAIL_OPEN: AdversarialReviewOutput = { passed: true, findings: [], failOpen: true };
+const FAIL_OPEN: AdversarialReviewOutput = { passed: true, findings: [], normalizedFindings: [], failOpen: true };
 
 const adversarialParseRetry = (input: AdversarialReviewInput) =>
   makeParseRetryStrategy({
@@ -53,7 +60,9 @@ const adversarialParseRetry = (input: AdversarialReviewInput) =>
       truncated: () => ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold: input.blockingThreshold }),
     },
     exhaustedFallback: (lastOutput) =>
-      /"passed"\s*:\s*false/.test(lastOutput) ? { passed: false, findings: [], looksLikeFail: true } : FAIL_OPEN,
+      /"passed"\s*:\s*false/.test(lastOutput)
+        ? { passed: false, findings: [], normalizedFindings: [], looksLikeFail: true }
+        : FAIL_OPEN,
     logContext: { blockingThreshold: input.blockingThreshold ?? "error" },
   });
 
@@ -93,9 +102,15 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
   parse(output, _input, _ctx) {
     const raw = tryParseLLMJson<Record<string, unknown>>(output);
     const parsed = validateAdversarialShape(raw);
-    if (parsed) return { passed: parsed.passed, findings: parsed.findings };
+    if (parsed) {
+      return {
+        passed: parsed.passed,
+        findings: parsed.findings,
+        normalizedFindings: toAdversarialReviewFindings(parsed.findings),
+      };
+    }
     if (/"passed"\s*:\s*false/.test(output) && !/"findings"\s*:\s*\[\s*\{/.test(output)) {
-      return { passed: false, findings: [], looksLikeFail: true };
+      return { passed: false, findings: [], normalizedFindings: [], looksLikeFail: true };
     }
     throw new ParseValidationError("[adversarial-review] parse failed: invalid JSON shape");
   },

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -4,7 +4,11 @@ import type { ReviewConfig } from "../config/selectors";
 import type { Finding, Iteration } from "../findings";
 import { AdversarialReviewPromptBuilder, ReviewPromptBuilder } from "../prompts";
 import type { TestInventory } from "../prompts";
-import { toAdversarialReviewFindings, validateAdversarialShape } from "../review/adversarial-helpers";
+import {
+  isBlockingSeverity,
+  toAdversarialReviewFindings,
+  validateAdversarialShape,
+} from "../review/adversarial-helpers";
 import type { AdversarialReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { RunOperation } from "./types";
@@ -99,14 +103,19 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
       task: { id: "task", content, overridable: false },
     };
   },
-  parse(output, _input, _ctx) {
+  parse(output, input, _ctx) {
     const raw = tryParseLLMJson<Record<string, unknown>>(output);
     const parsed = validateAdversarialShape(raw);
     if (parsed) {
+      // Match the wrapper's advisory split (src/review/adversarial.ts) so the
+      // orchestrator-direct path doesn't push below-threshold findings into the
+      // rectification cycle.
+      const threshold = input.blockingThreshold ?? "error";
+      const blocking = parsed.findings.filter((f) => isBlockingSeverity(f.severity, threshold));
       return {
         passed: parsed.passed,
         findings: parsed.findings,
-        normalizedFindings: toAdversarialReviewFindings(parsed.findings),
+        normalizedFindings: toAdversarialReviewFindings(blocking),
       };
     }
     if (/"passed"\s*:\s*false/.test(output) && !/"findings"\s*:\s*\[\s*\{/.test(output)) {

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -110,14 +110,20 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
       task: { id: "task", content, overridable: false },
     };
   },
-  parse(output, _input, _ctx) {
+  parse(output, input, _ctx) {
     const raw = tryParseLLMJson<Record<string, unknown>>(output);
     const parsed = validateLLMShape(raw);
     if (parsed) {
+      // Match the wrapper's advisory split (src/review/semantic.ts:443) so the
+      // orchestrator-direct path doesn't push below-threshold findings into the
+      // rectification cycle. The wrapper still owns AC-grounding + evidence
+      // substantiation — orchestrator-path parity is tracked as a follow-up.
+      const threshold = input.blockingThreshold ?? "error";
+      const blocking = parsed.findings.filter((f) => isBlockingSeverity(f.severity, threshold));
       return {
         passed: parsed.passed,
         findings: parsed.findings,
-        normalizedFindings: toReviewFindings(parsed.findings),
+        normalizedFindings: toReviewFindings(blocking),
       };
     }
     if (/"passed"\s*:\s*false/.test(output)) {

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -1,12 +1,12 @@
 import { makeParseRetryStrategy } from "../agents/retry";
 import { reviewConfigSelector } from "../config";
 import type { ReviewConfig } from "../config/selectors";
-import type { Iteration } from "../findings";
+import type { Finding, Iteration } from "../findings";
 import { getSafeLogger } from "../logger";
 import { ReviewPromptBuilder } from "../prompts";
 import { parseRequoteResponse } from "../review/requote-response";
 import { checkFindingEvidence, downgradeUnsubstantiatedFinding } from "../review/semantic-evidence";
-import { type LLMFinding, isBlockingSeverity, validateLLMShape } from "../review/semantic-helpers";
+import { type LLMFinding, isBlockingSeverity, toReviewFindings, validateLLMShape } from "../review/semantic-helpers";
 import type { SemanticReviewConfig, SemanticStory } from "../review/types";
 import { tryParseLLMJson } from "../utils/llm-json";
 import type { HopBodyContext, RunOperation } from "./types";
@@ -31,7 +31,14 @@ export interface SemanticReviewInput {
 
 export interface SemanticReviewOutput {
   passed: boolean;
+  /** Raw LLM-shape findings (LLMFinding[]). Consumed by `src/review/semantic.ts`. */
   findings: unknown[];
+  /**
+   * Source-tagged Finding[] (`source: "semantic-review"`), used by the rectification
+   * cycle's `extractPhaseFindings` → strategy `appliesTo` routing. Populated whenever
+   * `findings` came from a successful LLM parse; empty for fail-open / looksLikeFail.
+   */
+  normalizedFindings: Finding[];
   failOpen?: boolean;
   /**
    * True when the raw output could not be parsed but contained `"passed": false` —
@@ -41,7 +48,7 @@ export interface SemanticReviewOutput {
   looksLikeFail?: boolean;
 }
 
-const FAIL_OPEN: SemanticReviewOutput = { passed: true, findings: [], failOpen: true };
+const FAIL_OPEN: SemanticReviewOutput = { passed: true, findings: [], normalizedFindings: [], failOpen: true };
 const SEMANTIC_REQUOTE_RECOVERED_EVENT = "review.semantic.finding.requote_recovered";
 const SEMANTIC_REQUOTE_FAILED_EVENT = "review.semantic.finding.requote_failed";
 const DEFAULT_MAX_REQUOTES = 5;
@@ -106,8 +113,16 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
   parse(output, _input, _ctx) {
     const raw = tryParseLLMJson<Record<string, unknown>>(output);
     const parsed = validateLLMShape(raw);
-    if (parsed) return { passed: parsed.passed, findings: parsed.findings };
-    if (/"passed"\s*:\s*false/.test(output)) return { passed: false, findings: [], looksLikeFail: true };
+    if (parsed) {
+      return {
+        passed: parsed.passed,
+        findings: parsed.findings,
+        normalizedFindings: toReviewFindings(parsed.findings),
+      };
+    }
+    if (/"passed"\s*:\s*false/.test(output)) {
+      return { passed: false, findings: [], normalizedFindings: [], looksLikeFail: true };
+    }
     return FAIL_OPEN;
   },
 };

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -163,6 +163,21 @@ describe("adversarialReviewOp.parse()", () => {
     expect(result.normalizedFindings[1]?.fixTarget).toBe("test");
     expect(result.normalizedFindings[0]?.message).toBe("x");
   });
+  test("normalizedFindings drops findings below blockingThreshold (mirrors wrapper advisory split)", () => {
+    const ctx = makeBuildCtx();
+    const inputWithThreshold: AdversarialReviewInput = { ...SAMPLE_INPUT, blockingThreshold: "error" };
+    const json = JSON.stringify({
+      passed: false,
+      findings: [
+        { severity: "error", category: "logic-bug", file: "src/a.ts", line: 1, issue: "real", suggestion: "fix" },
+        { severity: "warning", category: "style", file: "src/b.ts", line: 2, issue: "advisory", suggestion: "consider" },
+      ],
+    });
+    const result = adversarialReviewOp.parse(json, inputWithThreshold, ctx);
+    expect(result.findings).toHaveLength(2);
+    expect(result.normalizedFindings).toHaveLength(1);
+    expect(result.normalizedFindings[0]?.message).toBe("real");
+  });
   test("normalizedFindings is [] on looksLikeFail / no-findings paths", () => {
     const ctx = makeBuildCtx();
     expect(

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -144,7 +144,33 @@ describe("adversarialReviewOp.parse()", () => {
     const result = adversarialReviewOp.parse(json, SAMPLE_INPUT, ctx);
     expect(result.passed).toBe(false);
     expect(result.findings).toHaveLength(1);
-    expect(result.findings[0].issue).toBe("error swallowed");
+    expect((result.findings[0] as { issue: string }).issue).toBe("error swallowed");
+  });
+  test("normalizedFindings tags each finding with source:'adversarial-review' for cycle routing", () => {
+    const ctx = makeBuildCtx();
+    const json = JSON.stringify({
+      passed: false,
+      findings: [
+        { severity: "error", category: "logic-bug", file: "src/a.ts", line: 1, issue: "x", suggestion: "y" },
+        { severity: "error", category: "test-gap", file: "test/a.test.ts", line: 9, issue: "z", suggestion: "w" },
+      ],
+    });
+    const result = adversarialReviewOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.normalizedFindings).toHaveLength(2);
+    expect(result.normalizedFindings.every((f) => f.source === "adversarial-review")).toBe(true);
+    // test-gap findings target tests so the test-writer strategy picks them up.
+    expect(result.normalizedFindings[0]?.fixTarget).toBeUndefined();
+    expect(result.normalizedFindings[1]?.fixTarget).toBe("test");
+    expect(result.normalizedFindings[0]?.message).toBe("x");
+  });
+  test("normalizedFindings is [] on looksLikeFail / no-findings paths", () => {
+    const ctx = makeBuildCtx();
+    expect(
+      adversarialReviewOp.parse('{"passed":false}', SAMPLE_INPUT, ctx).normalizedFindings,
+    ).toEqual([]);
+    expect(
+      adversarialReviewOp.parse(JSON.stringify({ passed: true, findings: [] }), SAMPLE_INPUT, ctx).normalizedFindings,
+    ).toEqual([]);
   });
   test("throws ParseValidationError on unparseable output (triggers retry)", () => {
     const ctx = makeBuildCtx();

--- a/test/unit/operations/semantic-review.test.ts
+++ b/test/unit/operations/semantic-review.test.ts
@@ -140,7 +140,7 @@ describe("semanticReviewOp.parse()", () => {
     const result = semanticReviewOp.parse(json, SAMPLE_INPUT, ctx);
     expect(result.passed).toBe(false);
     expect(result.findings).toHaveLength(1);
-    expect(result.findings[0].severity).toBe("error");
+    expect((result.findings[0] as { severity: string }).severity).toBe("error");
   });
   test("returns fail-open for unparseable output (retry handled in hopBody, not callOp parse)", () => {
     const ctx = makeBuildCtx();
@@ -160,6 +160,30 @@ describe("semanticReviewOp.parse()", () => {
     const result = semanticReviewOp.parse(json, SAMPLE_INPUT, ctx);
     expect(result.passed).toBe(true);
     expect(result.failOpen).toBeUndefined();
+  });
+  test("normalizedFindings tags each finding with source:'semantic-review' for cycle routing", () => {
+    const ctx = makeBuildCtx();
+    const json = JSON.stringify({
+      passed: false,
+      findings: [
+        { severity: "error", file: "src/a.ts", line: 1, issue: "x", suggestion: "y", acIndex: 1 },
+        { severity: "error", file: "src/b.ts", line: 2, issue: "z", suggestion: "w", acIndex: 2 },
+      ],
+    });
+    const result = semanticReviewOp.parse(json, SAMPLE_INPUT, ctx);
+    expect(result.normalizedFindings).toHaveLength(2);
+    expect(result.normalizedFindings.every((f) => f.source === "semantic-review")).toBe(true);
+    expect(result.normalizedFindings.every((f) => f.fixTarget === "source")).toBe(true);
+    // LLM-shape `issue` projected onto Finding `message`
+    expect(result.normalizedFindings[0]?.message).toBe("x");
+  });
+  test("normalizedFindings is [] on fail-open / looksLikeFail / no-findings paths", () => {
+    const ctx = makeBuildCtx();
+    expect(semanticReviewOp.parse("not json", SAMPLE_INPUT, ctx).normalizedFindings).toEqual([]);
+    expect(semanticReviewOp.parse('{"passed":false}', SAMPLE_INPUT, ctx).normalizedFindings).toEqual([]);
+    expect(
+      semanticReviewOp.parse(JSON.stringify({ passed: true, findings: [] }), SAMPLE_INPUT, ctx).normalizedFindings,
+    ).toEqual([]);
   });
 });
 

--- a/test/unit/operations/semantic-review.test.ts
+++ b/test/unit/operations/semantic-review.test.ts
@@ -177,6 +177,24 @@ describe("semanticReviewOp.parse()", () => {
     // LLM-shape `issue` projected onto Finding `message`
     expect(result.normalizedFindings[0]?.message).toBe("x");
   });
+  test("normalizedFindings drops findings below blockingThreshold (mirrors wrapper advisory split)", () => {
+    const ctx = makeBuildCtx();
+    const inputWithThreshold: SemanticReviewInput = { ...SAMPLE_INPUT, blockingThreshold: "error" };
+    const json = JSON.stringify({
+      passed: false,
+      findings: [
+        { severity: "error", file: "src/a.ts", line: 1, issue: "real", suggestion: "fix" },
+        { severity: "warning", file: "src/b.ts", line: 2, issue: "advisory", suggestion: "consider" },
+        { severity: "info", file: "src/c.ts", line: 3, issue: "fyi", suggestion: "noop" },
+      ],
+    });
+    const result = semanticReviewOp.parse(json, inputWithThreshold, ctx);
+    // Raw `findings` retains all three for the wrapper's downstream processing.
+    expect(result.findings).toHaveLength(3);
+    // normalizedFindings (consumed by rectification) only carries the blocking one.
+    expect(result.normalizedFindings).toHaveLength(1);
+    expect(result.normalizedFindings[0]?.message).toBe("real");
+  });
   test("normalizedFindings is [] on fail-open / looksLikeFail / no-findings paths", () => {
     const ctx = makeBuildCtx();
     expect(semanticReviewOp.parse("not json", SAMPLE_INPUT, ctx).normalizedFindings).toEqual([]);


### PR DESCRIPTION
## Summary

- `semanticReviewOp.parse` / `adversarialReviewOp.parse` returned raw LLM-shape findings (no `source` field). `extractPhaseFindings` in the story orchestrator cast them as `Finding[]` (lie cast) and every strategy's \`appliesTo\` gate (which filters on \`f.source\`) returned false. Rectification exited with \"no matching strategy\" while real blocking findings sat unaddressed.
- Adds a \`normalizedFindings: Finding[]\` field on both review outputs, populated in \`parse()\` via the existing \`toReviewFindings\` / \`toAdversarialReviewFindings\` helpers (correct \`source\` stamping) and filtered to the configured \`blockingThreshold\` so the orchestrator-direct path honors the wrapper's advisory split.
- Replaces the \`as Finding[]\` lie cast in \`extractPhaseFindings\` with a runtime \`isFinding\` guard — closes the bug class against any future op that forgets to tag findings.
- Raw \`findings: unknown[]\` is preserved; \`src/review/semantic.ts\` and \`src/review/adversarial.ts\` still consume the LLM shape for AC-grounding + evidence-substantiation downstream.

## Repro

See \`logs/2026-05-25T04-14-52.jsonl\` line 411-413: 13 blocking findings produced, then \`cycle exited — no matching strategy\` with \`findingSources: []\`.

## Follow-up

The orchestrator-direct path still skips \`substantiateSemanticEvidence\`, \`sanitizeRefModeFindings\`, and \`filterByAcGroundingMinimal\` that the wrapper applies. Tracked in #1100 — proper unification belongs in its own PR.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean (no new baseline violations)
- [x] \`bun run test:bail\` green (unit + integration + ui)
- [x] New \`parse()\` tests assert \`source\` is stamped on every normalized finding and below-threshold findings are dropped
- [x] Existing \`gatherRectificationFindings\` tests still pass (back-compat fallback to \`findings\` for verifier/lint/typecheck ops)