### PR TITLE
fix(callop): honor exhaustedFallback on empty-output path (#1092)

### DIFF
--- a/src/agents/retry/parse-retry.ts
+++ b/src/agents/retry/parse-retry.ts
@@ -47,6 +47,13 @@ export function makeParseRetryStrategy(opts: ParseRetryOpts): RetryStrategy {
         }
         // Empty output: if exhaustedFallback is declared, surface it so callOp can
         // return a safe degraded value rather than throwing CALL_OP_NO_OUTPUT.
+        //
+        // For run-kind ops this branch is only reached after sendWithFileOutput in
+        // call.ts synthesizes a fail-stale AdapterFailure for empty/whitespace output —
+        // the manager-tier retry/swap runs first (via the `adapterFailure` signal), and
+        // only after exhaustion does the hop body exit with rawOutput="", which then
+        // triggers callOp's `!rawOutput` guard. The fallback captured here is what
+        // callOp reads from retryFallback at that point.
         const fallback = opts.exhaustedFallback ? opts.exhaustedFallback("") : undefined;
         return { retry: false, ...(fallback !== undefined ? { fallback } : {}) };
       }

--- a/src/agents/retry/parse-retry.ts
+++ b/src/agents/retry/parse-retry.ts
@@ -45,7 +45,10 @@ export function makeParseRetryStrategy(opts: ParseRetryOpts): RetryStrategy {
             { storyId: ctx.storyId },
           );
         }
-        return { retry: false };
+        // Empty output: if exhaustedFallback is declared, surface it so callOp can
+        // return a safe degraded value rather than throwing CALL_OP_NO_OUTPUT.
+        const fallback = opts.exhaustedFallback ? opts.exhaustedFallback("") : undefined;
+        return { retry: false, ...(fallback !== undefined ? { fallback } : {}) };
       }
 
       let parsed: unknown;

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -468,6 +468,33 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
   const totalCost = outcome.result.estimatedCostUsd ?? 0;
 
   if (!rawOutput) {
+    if (retryFallback !== undefined) {
+      if (typeof retryFallback !== "object" || retryFallback === null) {
+        throw new NaxError(
+          `callOp[${op.name}]: exhaustedFallback returned a non-object (${typeof retryFallback}); fallback must be a plain object`,
+          "CALL_OP_INVALID_FALLBACK",
+          { stage: op.stage, storyId: ctx.storyId },
+        );
+      }
+      getSafeLogger()?.warn("callop", "Returning exhaustedFallback on empty output", {
+        storyId: ctx.storyId,
+        opName: op.name,
+        agentName: dispatchAgent,
+      });
+      return { ...retryFallback, estimatedCostUsd: totalCost } as O;
+    }
+    if (op.recover) {
+      const verifyCtx = makeVerifyCtx(buildCtx);
+      const recovered = await op.recover(input, verifyCtx);
+      if (recovered !== null) {
+        getSafeLogger()?.warn("callop", "Recovered from empty output via op.recover", {
+          storyId: ctx.storyId,
+          opName: op.name,
+          agentName: dispatchAgent,
+        });
+        return recovered;
+      }
+    }
     throw new NaxError(`callOp[${op.name}]: agent returned no output`, "CALL_OP_NO_OUTPUT", {
       stage: op.stage,
       storyId: ctx.storyId,

--- a/src/operations/call.ts
+++ b/src/operations/call.ts
@@ -468,6 +468,19 @@ export async function callOp<I, O, C>(ctx: CallContext, op: Operation<I, O, C>, 
   const totalCost = outcome.result.estimatedCostUsd ?? 0;
 
   if (!rawOutput) {
+    if (maxRetriesExceeded) {
+      getSafeLogger()?.error("callop", "Op retry budget exhausted (empty output)", {
+        storyId: ctx.storyId,
+        opName: op.name,
+        site: "run" as const,
+        totalAttempts: MAX_COMPLETE_RETRY_ATTEMPTS + 1,
+      });
+      throw new NaxError(
+        `callOp[${op.name}]: CALL_OP_MAX_RETRIES — exceeded MAX_COMPLETE_RETRY_ATTEMPTS (${MAX_COMPLETE_RETRY_ATTEMPTS})`,
+        "CALL_OP_MAX_RETRIES",
+        { stage: op.stage, storyId: ctx.storyId },
+      );
+    }
     if (retryFallback !== undefined) {
       if (typeof retryFallback !== "object" || retryFallback === null) {
         throw new NaxError(

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -92,6 +92,10 @@ export const semanticReviewOp: RunOperation<SemanticReviewInput, SemanticReviewO
         invalid: () => ReviewPromptBuilder.jsonRetry(),
         truncated: () => ReviewPromptBuilder.jsonRetryCondensed({ blockingThreshold: input.blockingThreshold }),
       },
+      exhaustedFallback: (lastOutput) =>
+        /"passed"\s*:\s*false/.test(lastOutput)
+          ? { passed: false, findings: [], normalizedFindings: [], looksLikeFail: true }
+          : FAIL_OPEN,
       logContext: { blockingThreshold: input.blockingThreshold ?? "error" },
     }),
   hopBody: semanticReviewHopBody,

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { makeMockAgentManager, makeMockRuntime, makeSessionManager, makeTestRuntime } from "../../helpers";
+import { adversarialReviewOp } from "../../../src/operations/adversarial-review";
 import type { AdversarialReviewInput } from "../../../src/operations/adversarial-review";
 import { callOp } from "../../../src/operations";
+import { makeMockAgentManager, makeMockRuntime, makeSessionManager, makeTestRuntime } from "../../helpers";
 import type { NaxRuntime } from "../../../src/runtime";
 
 const createdRuntimes: NaxRuntime[] = [];
@@ -9,7 +10,6 @@ afterEach(async () => {
   await Promise.allSettled(createdRuntimes.map((r) => r.close()));
   createdRuntimes.length = 0;
 });
-import { adversarialReviewOp } from "../../../src/operations/adversarial-review";
 
 const SAMPLE_STORY = {
   id: "STORY-002",

--- a/test/unit/operations/adversarial-review.test.ts
+++ b/test/unit/operations/adversarial-review.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { makeTestRuntime } from "../../helpers";
+import { makeMockAgentManager, makeMockRuntime, makeSessionManager, makeTestRuntime } from "../../helpers";
 import type { AdversarialReviewInput } from "../../../src/operations/adversarial-review";
+import { callOp } from "../../../src/operations";
 import type { NaxRuntime } from "../../../src/runtime";
 
 const createdRuntimes: NaxRuntime[] = [];
@@ -237,5 +238,35 @@ describe("adversarialReviewOp.retry", () => {
 
   test("hopBody field does NOT exist (removed in US-005c)", () => {
     expect(adversarialReviewOp).not.toHaveProperty("hopBody");
+  });
+});
+
+describe("adversarialReviewOp — AC3: empty-output exhaustion returns FAIL_OPEN", () => {
+  test("returns FAIL_OPEN when agent returns empty output after retries", async () => {
+    // adversarialReviewOp has exhaustedFallback declared; callOp now honors it on empty output.
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => ({
+        output: "",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-002" },
+      adversarialReviewOp,
+      SAMPLE_INPUT,
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.failOpen).toBe(true);
+    expect(result.normalizedFindings).toEqual([]);
   });
 });

--- a/test/unit/operations/call-exhausted-fallback.test.ts
+++ b/test/unit/operations/call-exhausted-fallback.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { callOp } from "../../../src/operations";
+import type { RunOperation } from "../../../src/operations";
+import { DEFAULT_CONFIG, pickSelector } from "../../../src/config";
+import { ParseValidationError } from "../../../src/agents/retry";
+import type { RetryStrategy } from "../../../src/agents/retry";
+import { makeMockAgentManager, makeMockRuntime, makeSessionManager } from "../../helpers";
+import type { NaxRuntime } from "../../../src/runtime";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const testSel = pickSelector("exhausted-fallback-test", "routing");
+const createdRuntimes: NaxRuntime[] = [];
+
+afterEach(async () => {
+  await Promise.allSettled(createdRuntimes.map((r) => r.close()));
+  createdRuntimes.length = 0;
+});
+
+/** Creates an agent manager that returns empty output from runAsSession. */
+function makeEmptyOutputAgentManager(costUsd = 0) {
+  return makeMockAgentManager({
+    runWithFallbackFn: async (req) => {
+      const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+      return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+    },
+    runAsSessionFn: async () => ({
+      output: "",
+      estimatedCostUsd: costUsd,
+      internalRoundTrips: 0,
+      tokenUsage: { inputTokens: 0, outputTokens: 0 },
+    }),
+  });
+}
+
+/** Creates a callOp context using the provided runtime. */
+function makeCallCtx(runtime: NaxRuntime) {
+  return {
+    runtime,
+    packageView: runtime.packages.repo(),
+    packageDir: "/tmp",
+    agentName: "claude",
+    storyId: "US-001",
+  };
+}
+
+/**
+ * Creates a custom RetryStrategy that always exhausts immediately with the given fallback value.
+ * This bypasses makeParseRetryStrategy's early return on empty lastOutput so we can test
+ * callOp's empty-output path with retryFallback set.
+ */
+function makeAlwaysExhaustStrategy(fallback: unknown): RetryStrategy {
+  return {
+    shouldRetry(_failure, _attempt, _ctx) {
+      // Immediately exhaust and provide fallback, regardless of output content.
+      return { retry: false, fallback };
+    },
+  };
+}
+
+/**
+ * Creates a RunOp where op.retry always exhausts with the given fallback value.
+ * parse() throws on empty output to ensure the empty-output branch in callOp fires.
+ */
+function makeOpWithFallback<O>(
+  name: string,
+  fallback: unknown,
+): RunOperation<string, O, Pick<typeof DEFAULT_CONFIG, "routing">> {
+  return {
+    kind: "run",
+    name,
+    stage: "run",
+    config: testSel,
+    session: { role: "implementer", lifetime: "fresh" },
+    build: (input) => ({
+      role: { id: "role", content: "You process input.", overridable: false },
+      task: { id: "task", content: input, overridable: false },
+    }),
+    retry: () => makeAlwaysExhaustStrategy(fallback),
+    parse: (output) => {
+      // Throw on empty output so callOp's !rawOutput branch fires after sendWithParseRetry.
+      if (!output.trim()) throw new ParseValidationError(`[${name}] empty output`);
+      return output as unknown as O;
+    },
+  };
+}
+
+/** Creates a RunOp with no retry strategy (retryFallback stays undefined). */
+function makeOpNoRetry(
+  name: string,
+  recoverFn?: (input: string) => Promise<unknown> | null,
+): RunOperation<string, Record<string, unknown>, Pick<typeof DEFAULT_CONFIG, "routing">> {
+  return {
+    kind: "run",
+    name,
+    stage: "run",
+    config: testSel,
+    session: { role: "implementer", lifetime: "fresh" },
+    build: (input) => ({
+      role: { id: "role", content: "You process input.", overridable: false },
+      task: { id: "task", content: input, overridable: false },
+    }),
+    parse: (output) => {
+      if (!output.trim()) throw new ParseValidationError(`[${name}] empty output`);
+      return { result: output } as Record<string, unknown>;
+    },
+    ...(recoverFn
+      ? { recover: async (input: string) => (await recoverFn(input)) as Record<string, unknown> | null }
+      : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AC1: exhaustedFallback returns FAIL_OPEN merged with estimatedCostUsd
+// ---------------------------------------------------------------------------
+
+describe("callOp empty-output + exhaustedFallback — AC1: fallback returned with cost", () => {
+  test("returns exhaustedFallback value merged with estimatedCostUsd when output is empty", async () => {
+    const agentManager = makeEmptyOutputAgentManager(0.05);
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const op = makeOpWithFallback<{ passed: boolean; findings: unknown[]; failOpen: boolean }>(
+      "fallback-cost-op",
+      { passed: true, findings: [], failOpen: true },
+    );
+
+    const result = await callOp(makeCallCtx(runtime), op, "hello");
+
+    expect(result.passed).toBe(true);
+    expect(result.failOpen).toBe(true);
+    expect(result.findings).toEqual([]);
+    expect(result.estimatedCostUsd).toBe(0.05);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC2: no exhaustedFallback → throws CALL_OP_NO_OUTPUT
+// ---------------------------------------------------------------------------
+
+describe("callOp empty-output + no exhaustedFallback — AC2: throws CALL_OP_NO_OUTPUT", () => {
+  test("throws CALL_OP_NO_OUTPUT when there is no retry strategy and output is empty", async () => {
+    const agentManager = makeEmptyOutputAgentManager(0);
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    let thrown: { code?: string; message?: string } | null = null;
+    try {
+      await callOp(makeCallCtx(runtime), makeOpNoRetry("no-retry-op"), "hello");
+    } catch (err) {
+      thrown = err as { code?: string; message?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    expect(thrown?.code).toBe("CALL_OP_NO_OUTPUT");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC6a: exhaustedFallback returning null → throws CALL_OP_INVALID_FALLBACK
+// ---------------------------------------------------------------------------
+
+describe("callOp empty-output — AC6a: null fallback → CALL_OP_INVALID_FALLBACK", () => {
+  test("throws CALL_OP_INVALID_FALLBACK when exhaustedFallback returns null", async () => {
+    const agentManager = makeEmptyOutputAgentManager(0);
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const op = makeOpWithFallback("null-fallback-op", null);
+
+    let thrown: { code?: string } | null = null;
+    try {
+      await callOp(makeCallCtx(runtime), op, "hello");
+    } catch (err) {
+      thrown = err as { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    expect(thrown?.code).toBe("CALL_OP_INVALID_FALLBACK");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC6b: exhaustedFallback returning string → throws CALL_OP_INVALID_FALLBACK
+// ---------------------------------------------------------------------------
+
+describe("callOp empty-output — AC6b: string fallback → CALL_OP_INVALID_FALLBACK", () => {
+  test("throws CALL_OP_INVALID_FALLBACK when exhaustedFallback returns a string", async () => {
+    const agentManager = makeEmptyOutputAgentManager(0);
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const op = makeOpWithFallback("string-fallback-op", "some string");
+
+    let thrown: { code?: string } | null = null;
+    try {
+      await callOp(makeCallCtx(runtime), op, "hello");
+    } catch (err) {
+      thrown = err as { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    expect(thrown?.code).toBe("CALL_OP_INVALID_FALLBACK");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC1 cost-merging: cumulative cost merged onto fallback
+// ---------------------------------------------------------------------------
+
+describe("callOp empty-output — AC1 cost-merging: cumulative cost in result", () => {
+  test("estimatedCostUsd from runAsSession is merged onto fallback result", async () => {
+    const agentManager = makeEmptyOutputAgentManager(0.07);
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const op = makeOpWithFallback<{ passed: boolean; findings: unknown[]; estimatedCostUsd?: number }>(
+      "cost-merge-op",
+      { passed: true, findings: [] },
+    );
+
+    const result = await callOp(makeCallCtx(runtime), op, "hello");
+
+    expect(result.estimatedCostUsd).toBe(0.07);
+    expect(result.passed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC7a: op.recover returning non-null, no exhaustedFallback → returns recovered value
+// ---------------------------------------------------------------------------
+
+describe("callOp empty-output — AC7a: op.recover returns non-null value", () => {
+  test("returns recovered value when op.recover returns non-null and no exhaustedFallback", async () => {
+    const agentManager = makeEmptyOutputAgentManager(0);
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const op = makeOpNoRetry("recover-non-null-op", async () => ({ passed: true, recovered: true }));
+
+    const result = await callOp(makeCallCtx(runtime), op, "hello");
+
+    expect(result.recovered).toBe(true);
+    expect(result.passed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC7b: op.recover returning null, no exhaustedFallback → throws CALL_OP_NO_OUTPUT
+// ---------------------------------------------------------------------------
+
+describe("callOp empty-output — AC7b: op.recover returns null → CALL_OP_NO_OUTPUT", () => {
+  test("throws CALL_OP_NO_OUTPUT when op.recover returns null and no exhaustedFallback", async () => {
+    const agentManager = makeEmptyOutputAgentManager(0);
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const op = makeOpNoRetry("recover-null-op", async () => null);
+
+    let thrown: { code?: string } | null = null;
+    try {
+      await callOp(makeCallCtx(runtime), op, "hello");
+    } catch (err) {
+      thrown = err as { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    expect(thrown?.code).toBe("CALL_OP_NO_OUTPUT");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC7 ordering: exhaustedFallback wins over op.recover
+// ---------------------------------------------------------------------------
+
+describe("callOp empty-output — AC7 ordering: exhaustedFallback wins over op.recover", () => {
+  test("returns exhaustedFallback result when both exhaustedFallback and op.recover are set", async () => {
+    const agentManager = makeEmptyOutputAgentManager(0);
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    // Op has both: exhaustedFallback (via retry) and op.recover
+    const op: RunOperation<string, Record<string, unknown>, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      kind: "run",
+      name: "fallback-beats-recover-op",
+      stage: "run",
+      config: testSel,
+      session: { role: "implementer", lifetime: "fresh" },
+      build: (input) => ({
+        role: { id: "role", content: "You process input.", overridable: false },
+        task: { id: "task", content: input, overridable: false },
+      }),
+      retry: () => makeAlwaysExhaustStrategy({ fromFallback: true }),
+      parse: (output) => {
+        if (!output.trim()) throw new ParseValidationError("[ordering-op] empty output");
+        return { result: output };
+      },
+      recover: async () => ({ fromRecover: true }),
+    };
+
+    const result = await callOp(makeCallCtx(runtime), op, "hello");
+
+    // exhaustedFallback should win — fromFallback is set, fromRecover is not
+    expect(result.fromFallback).toBe(true);
+    expect(result.fromRecover).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No regression: non-empty output flows through op.parse unchanged
+// ---------------------------------------------------------------------------
+
+describe("callOp empty-output — no regression: non-empty output uses op.parse", () => {
+  test("non-empty output is parsed normally, fallback is NOT used as output", async () => {
+    // Even if retryFallback is set (strategy always exhausts), when rawOutput is non-empty
+    // the !rawOutput branch does NOT fire — op.parse handles the output instead.
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => ({
+        output: "hello world",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    // Op with makeAlwaysExhaustStrategy (retryFallback is set), but parse succeeds for non-empty output.
+    const op: RunOperation<string, string, Pick<typeof DEFAULT_CONFIG, "routing">> = {
+      kind: "run",
+      name: "non-empty-op",
+      stage: "run",
+      config: testSel,
+      session: { role: "implementer", lifetime: "fresh" },
+      build: (input) => ({
+        role: { id: "role", content: "You echo input.", overridable: false },
+        task: { id: "task", content: input, overridable: false },
+      }),
+      // Always-exhaust strategy sets retryFallback, but rawOutput is non-empty so this branch won't fire.
+      retry: () => makeAlwaysExhaustStrategy({ fromFallback: true }),
+      parse: (output) => output.trim(),
+    };
+
+    const result = await callOp(makeCallCtx(runtime), op, "hello");
+
+    // op.parse ran and returned the trimmed output — the fallback was NOT returned
+    expect(result).toBe("hello world");
+  });
+});

--- a/test/unit/operations/call-exhausted-fallback.test.ts
+++ b/test/unit/operations/call-exhausted-fallback.test.ts
@@ -90,7 +90,7 @@ function makeOpWithFallback<O>(
 /** Creates a RunOp with no retry strategy (retryFallback stays undefined). */
 function makeOpNoRetry(
   name: string,
-  recoverFn?: (input: string) => Promise<unknown> | null,
+  recoverFn?: (input: string) => Promise<Record<string, unknown> | null>,
 ): RunOperation<string, Record<string, unknown>, Pick<typeof DEFAULT_CONFIG, "routing">> {
   return {
     kind: "run",
@@ -122,7 +122,7 @@ describe("callOp empty-output + exhaustedFallback — AC1: fallback returned wit
     const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
     createdRuntimes.push(runtime);
 
-    const op = makeOpWithFallback<{ passed: boolean; findings: unknown[]; failOpen: boolean }>(
+    const op = makeOpWithFallback<{ passed: boolean; findings: unknown[]; failOpen: boolean; estimatedCostUsd?: number }>(
       "fallback-cost-op",
       { passed: true, findings: [], failOpen: true },
     );

--- a/test/unit/operations/call-exhausted-fallback.test.ts
+++ b/test/unit/operations/call-exhausted-fallback.test.ts
@@ -207,6 +207,50 @@ describe("callOp empty-output — AC6b: string fallback → CALL_OP_INVALID_FALL
 });
 
 // ---------------------------------------------------------------------------
+// AC6c/d: boolean and number fallbacks → CALL_OP_INVALID_FALLBACK
+// ---------------------------------------------------------------------------
+
+describe("callOp empty-output — AC6c: boolean fallback → CALL_OP_INVALID_FALLBACK", () => {
+  test("throws CALL_OP_INVALID_FALLBACK when exhaustedFallback returns true", async () => {
+    const agentManager = makeEmptyOutputAgentManager(0);
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const op = makeOpWithFallback("bool-fallback-op", true);
+
+    let thrown: { code?: string } | null = null;
+    try {
+      await callOp(makeCallCtx(runtime), op, "hello");
+    } catch (err) {
+      thrown = err as { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    expect(thrown?.code).toBe("CALL_OP_INVALID_FALLBACK");
+  });
+});
+
+describe("callOp empty-output — AC6d: number fallback → CALL_OP_INVALID_FALLBACK", () => {
+  test("throws CALL_OP_INVALID_FALLBACK when exhaustedFallback returns a number", async () => {
+    const agentManager = makeEmptyOutputAgentManager(0);
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const op = makeOpWithFallback("number-fallback-op", 42);
+
+    let thrown: { code?: string } | null = null;
+    try {
+      await callOp(makeCallCtx(runtime), op, "hello");
+    } catch (err) {
+      thrown = err as { code?: string };
+    }
+
+    expect(thrown).not.toBeNull();
+    expect(thrown?.code).toBe("CALL_OP_INVALID_FALLBACK");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // AC1 cost-merging: cumulative cost merged onto fallback
 // ---------------------------------------------------------------------------
 

--- a/test/unit/operations/semantic-review.test.ts
+++ b/test/unit/operations/semantic-review.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { Iteration } from "../../../src/findings";
-import { makeTestRuntime } from "../../helpers";
+import { makeMockAgentManager, makeMockRuntime, makeSessionManager, makeTestRuntime } from "../../helpers";
+import { callOp } from "../../../src/operations";
 import type { SemanticReviewInput } from "../../../src/operations/semantic-review";
 import type { NaxRuntime } from "../../../src/runtime";
 
@@ -216,5 +217,45 @@ describe("semanticReviewOp.hopBody", () => {
 
   test("retry field exists (parse-retry SSOT)", () => {
     expect(semanticReviewOp).toHaveProperty("retry");
+  });
+});
+
+describe("semanticReviewOp — AC4: empty-output exhaustion returns FAIL_OPEN", () => {
+  test("returns FAIL_OPEN when agent returns empty output after retries", async () => {
+    // semanticReviewOp now has exhaustedFallback; empty-output exhaustion should
+    // produce the same FAIL_OPEN that parse failure already produces.
+    const agentManager = makeMockAgentManager({
+      runWithFallbackFn: async (req) => {
+        const hopResult = await req.executeHop!("claude", undefined, { kind: "primary" }, req.runOptions);
+        return { result: { ...hopResult.result, agentFallbacks: [] }, fallbacks: [] };
+      },
+      runAsSessionFn: async () => ({
+        output: "",
+        estimatedCostUsd: 0,
+        internalRoundTrips: 0,
+        tokenUsage: { inputTokens: 0, outputTokens: 0 },
+      }),
+    });
+    const runtime = makeMockRuntime({ agentManager, sessionManager: makeSessionManager() });
+    createdRuntimes.push(runtime);
+
+    const result = await callOp(
+      { runtime, packageView: runtime.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-001" },
+      semanticReviewOp,
+      SAMPLE_INPUT,
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.failOpen).toBe(true);
+    expect(result.normalizedFindings).toEqual([]);
+  });
+
+  test("parse-failure path still returns FAIL_OPEN — no regression", () => {
+    // Direct parse call with unparseable output should still return FAIL_OPEN (existing behavior).
+    const ctx = makeBuildCtx();
+    const result = semanticReviewOp.parse("not json at all", SAMPLE_INPUT, ctx);
+    expect(result.passed).toBe(true);
+    expect(result.failOpen).toBe(true);
+    expect(result.normalizedFindings).toEqual([]);
   });
 });

--- a/test/unit/operations/semantic-review.test.ts
+++ b/test/unit/operations/semantic-review.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { Iteration } from "../../../src/findings";
-import { makeMockAgentManager, makeMockRuntime, makeSessionManager, makeTestRuntime } from "../../helpers";
-import { callOp } from "../../../src/operations";
+import { semanticReviewOp } from "../../../src/operations/semantic-review";
 import type { SemanticReviewInput } from "../../../src/operations/semantic-review";
+import { callOp } from "../../../src/operations";
+import { makeMockAgentManager, makeMockRuntime, makeSessionManager, makeTestRuntime } from "../../helpers";
 import type { NaxRuntime } from "../../../src/runtime";
 
 const createdRuntimes: NaxRuntime[] = [];
@@ -10,7 +11,6 @@ afterEach(async () => {
   await Promise.allSettled(createdRuntimes.map((r) => r.close()));
   createdRuntimes.length = 0;
 });
-import { semanticReviewOp } from "../../../src/operations/semantic-review";
 
 const SAMPLE_STORY = {
   id: "STORY-001",


### PR DESCRIPTION
## Summary

- **Patches  empty-output branch** () to mirror the parse-failure escape-hatch ladder: `maxRetriesExceeded` → `exhaustedFallback` → `op.recover` → throw `CALL_OP_NO_OUTPUT`. Previously the empty-output path threw unconditionally, silently ignoring any `exhaustedFallback` declared on the retry strategy.
- **Fixes `makeParseRetryStrategy`** (`src/agents/retry/parse-retry.ts`) to surface `exhaustedFallback` in the `{ retry: false }` decision when `lastOutput` is empty, so `callOp` captures it in `retryFallback`.
- **Declares `exhaustedFallback` on `semanticReviewOp`** (`src/operations/semantic-review.ts`) so empty-output exhaustion produces the same FAIL_OPEN result the op already returns on parse failure. `adversarialReviewOp` already had `exhaustedFallback` and benefits immediately.

## Acceptance Criteria

| AC | Status |
|---|---|
| AC1 — empty output + `exhaustedFallback` → returns fallback merged with `estimatedCostUsd` | ✅ |
| AC2 — empty output + no `exhaustedFallback` → throws `CALL_OP_NO_OUTPUT` | ✅ |
| AC3 — `adversarialReviewOp` empty-output exhaustion → FAIL_OPEN | ✅ |
| AC4 — `semanticReviewOp` empty-output exhaustion → FAIL_OPEN; parse-failure no regression | ✅ |
| AC5 — no changes to review consumers | ✅ |
| AC6 — non-object fallback (null / string / boolean / number) → `CALL_OP_INVALID_FALLBACK` | ✅ |
| AC7 — `op.recover` escape-hatch order: `exhaustedFallback` wins; `op.recover` fallback if no fallback; throw if recover returns null | ✅ |

## Files Changed

| File | Change |
|---|---|
| `src/operations/call.ts` | Empty-output branch reads `retryFallback` before throwing |
| `src/agents/retry/parse-retry.ts` | Surface `exhaustedFallback` when `lastOutput` is empty |
| `src/operations/semantic-review.ts` | Declare `exhaustedFallback` on retry strategy |
| `test/unit/operations/call-exhausted-fallback.test.ts` | New — 11 unit tests (AC1, AC2, AC6a–d, AC7, regression) |
| `test/unit/operations/adversarial-review.test.ts` | +1 integration test (AC3) |
| `test/unit/operations/semantic-review.test.ts` | +2 integration tests (AC4) |

## Test Plan

- [x] `bun test test/unit/operations/call-exhausted-fallback.test.ts` — 11 pass
- [x] `bun test test/unit/operations/adversarial-review.test.ts` — all pass
- [x] `bun test test/unit/operations/semantic-review.test.ts` — all pass
- [x] `bun run test:bail` — 1064 pass, 0 fail

## Out of scope

- #1093 — adversarial same-session requote recovery
- #1100 — orchestrator/wrapper filter parity

Closes #1092