### PR TITLE
feat(logging): add outcome logs for scoped tests, regression gate, and mechanical checks

### DIFF
--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -460,6 +460,21 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
         : normalizeMechanicalFindings(checkName, await runCheck(checkName, command, workdir, storyId, env), workdir);
     checks.push(result);
 
+    // Log outcome of mechanical checks (lint / typecheck / build).
+    // Semantic and adversarial checks log their own outcomes internally.
+    if (result.success) {
+      logger?.info("review", `${checkName} passed`, {
+        storyId,
+        durationMs: result.durationMs,
+      });
+    } else {
+      logger?.warn("review", `${checkName} failed`, {
+        storyId,
+        exitCode: result.exitCode,
+        durationMs: result.durationMs,
+      });
+    }
+
     // Track first failure
     if (!result.success && !firstFailure) {
       firstFailure = `${checkName} failed (exit code ${result.exitCode})`;

--- a/src/verification/strategies/regression.ts
+++ b/src/verification/strategies/regression.ts
@@ -48,6 +48,11 @@ export class RegressionStrategy implements IVerificationStrategy {
 
     if (result.success) {
       const parsed = result.output ? parseTestOutput(result.output) : { passed: 0, failed: 0, failures: [] };
+      logger?.info("verify[regression]", "Full-suite regression gate passed", {
+        storyId: ctx.storyId,
+        passCount: parsed.passed,
+        durationMs,
+      });
       return makePassResult(ctx.storyId, "regression", {
         rawOutput: result.output,
         passCount: parsed.passed,
@@ -64,10 +69,20 @@ export class RegressionStrategy implements IVerificationStrategy {
     }
 
     if (result.status === "TIMEOUT") {
+      logger?.warn("verify[regression]", "Full-suite regression gate timed out", {
+        storyId: ctx.storyId,
+        durationMs,
+      });
       return makeFailResult(ctx.storyId, "regression", "TIMEOUT", { rawOutput: result.output, durationMs });
     }
 
     const parsed = result.output ? parseTestOutput(result.output) : { passed: 0, failed: 0, failures: [] };
+    logger?.warn("verify[regression]", "Full-suite regression gate failed", {
+      storyId: ctx.storyId,
+      passCount: parsed.passed,
+      failCount: parsed.failed,
+      durationMs,
+    });
     return makeFailResult(ctx.storyId, "regression", "TEST_FAILURE", {
       rawOutput: result.output,
       passCount: parsed.passed,

--- a/src/verification/strategies/scoped.ts
+++ b/src/verification/strategies/scoped.ts
@@ -148,6 +148,13 @@ export class ScopedStrategy implements IVerificationStrategy {
 
     if (result.success) {
       const parsed = result.output ? parseTestOutput(result.output) : { passed: 0, failed: 0, failures: [] };
+      logger.info("verify[scoped]", "Scoped tests passed", {
+        storyId: ctx.storyId,
+        passCount: parsed.passed,
+        durationMs,
+        scopeTestFallback: scopeTestFallback ?? false,
+        isFullSuite,
+      });
       return makePassResult(ctx.storyId, "scoped", {
         rawOutput: result.output,
         passCount: parsed.passed,
@@ -157,6 +164,12 @@ export class ScopedStrategy implements IVerificationStrategy {
     }
 
     if (result.status === "TIMEOUT") {
+      logger.warn("verify[scoped]", "Scoped tests timed out", {
+        storyId: ctx.storyId,
+        durationMs,
+        scopeTestFallback: scopeTestFallback ?? false,
+        isFullSuite,
+      });
       return makeFailResult(ctx.storyId, "scoped", "TIMEOUT", {
         rawOutput: result.output,
         durationMs,
@@ -166,6 +179,14 @@ export class ScopedStrategy implements IVerificationStrategy {
     }
 
     const parsed = result.output ? parseTestOutput(result.output) : { passed: 0, failed: 0, failures: [] };
+    logger.warn("verify[scoped]", "Scoped tests failed", {
+      storyId: ctx.storyId,
+      passCount: parsed.passed,
+      failCount: parsed.failed,
+      durationMs,
+      scopeTestFallback: scopeTestFallback ?? false,
+      isFullSuite,
+    });
     return makeFailResult(ctx.storyId, "scoped", "TEST_FAILURE", {
       rawOutput: result.output,
       passCount: parsed.passed,


### PR DESCRIPTION
## Summary

Adds structured log entries for outcomes that were previously silent in the story orchestration pipeline.

### Gaps filled

| Stage | Previously logged | Now also logs |
|---|---|---|
| `verify[scoped]` | Which test files were selected (pass-1/pass-2/fallback/threshold) | **Pass** (passCount, isFullSuite, scopeTestFallback), **timeout**, **test-failure** (passCount, failCount) |
| `verify[regression]` | Run started; BUG-026 timeout-accepted-as-pass | **Pass** (passCount), **timeout-failed** (non-accepted), **test-failure** (passCount, failCount) |
| `review` | Semantic passed/failed, adversarial passed/failed | **lint/typecheck/build passed** (info), **lint/typecheck/build failed** (warn + exitCode) |

### Why this matters

- **Scoped strategy** — the strategy logged which files it chose but was completely silent on the actual run outcome. The deferred regression path calls the strategy directly, so there was no per-outcome trace there at all.
- **Regression strategy** — the pipeline-stage wrapper (`stages/regression.ts`) and deferred lifecycle (`run-regression.ts`) already had coverage, but the strategy itself ran silently. The deferred mode called the strategy directly, leaving gaps in that path.
- **Mechanical checks** — semantic and adversarial already log their outcomes internally; lint/typecheck/build did not. You had to correlate `firstFailure` assignment in the result to know which check failed.

### Test plan

- `bun run typecheck` — clean
- `timeout 30 bun test test/unit/verification/strategies/ --timeout=5000` — 28 pass
- `timeout 60 bun test test/unit/review/ --timeout=10000` — 512 pass