### PR TITLE
fix(rectification): restore implementer→test-writer handoff (Fix B)

### DIFF
--- a/docs/specs/2026-05-26-rectifier-handoff-restoration.md
+++ b/docs/specs/2026-05-26-rectifier-handoff-restoration.md
@@ -1,0 +1,573 @@
+# Rectifier Handoff Restoration — Implementer→Test-Writer + Escalation Fixes
+
+**Date:** 2026-05-26
+**Trigger:** Run `logs/2026-05-26T05-04-43.jsonl` line 275–278 — screener-ui-web US-001 paused silently after `findings.cycle` exited with `agent-gave-up`. Audit log `logs/prompt-audit/screener-ui-web/1779775142402-…-implementer-rectification-t01.txt` showed the implementer emitted `UNRESOLVED` without trying Exception 4 (mock_structure handoff) despite the case fitting it.
+
+**Scope:** Three independent bugs that compound. Each ships in its own PR.
+
+---
+
+## Background
+
+Before `f38aedf2` ("Unify story execution around builder phases and finding-driven rectification", 2026-05-23), the implementer→test-writer handoff worked as follows:
+
+1. Rectifier prompt advertised four `TEST_EDIT_REASON` escape valves.
+2. `implementerRectifyOp.parse()` extracted `TestEditDeclaration[]` from agent output.
+3. `extractApplied` on the implementer strategy stashed declarations into `ctx.testEditDeclarations` (and `mock_structure` ones into `ctx.pendingMockStructureHandoffs`).
+4. The cycle's `validate` hook (in `src/pipeline/stages/autofix-cycle.ts`) called `applyTestEditDeclarations(findings, declarations, story)` which re-tagged `fixTarget: "source" → "test"` for findings matching a valid `prd_contract` declaration's `FILE`.
+5. Next iteration, `runFixCycle` selected `makeAutofixTestWriterStrategy` (appliesTo: `fixTarget === "test"`) — handoff complete.
+6. For `mock_structure` declarations, `validateMockStructureFiles` partitioned them, populated `ctx.pendingMockStructureHandoffs`, and the test-writer strategy's `buildInput` consumed them with `mode: "mock-restructure"`.
+
+Commit `f38aedf2` deleted `src/pipeline/stages/autofix-cycle.ts` (602 lines) and replaced it with a generic `runFixCycle` invocation through `src/execution/build-plan-for-strategy.ts:140-162`. Both strategies were kept but no consumer of `TEST_EDIT_REASON` declarations was carried over. The parser, the side-channel fields on `PipelineContext`, the test-writer's `mode: "mock-restructure"` input shape, and the prompt sections — all remain in place as dead plumbing.
+
+Additionally, `findings/cycle.ts` distinguishes `agent-gave-up` from cap-exhausted exits with semantically equivalent findings, but `story-orchestrator.ts` only promotes the cap exits to `rectificationExhausted`. The `agent-gave-up` exit is dropped, leaving the run to pause without escalation.
+
+---
+
+## Bug Summary
+
+| ID | Bug | Site | Severity |
+|:---|:---|:---|:---|
+| A | `agent-gave-up` cycle exit does not trigger `rectificationExhausted` | `src/execution/story-orchestrator.ts:707-715` | high — silent pause where escalation expected |
+| B | Implementer→test-writer handoff broken: declarations parsed, never routed | `src/operations/autofix-{implementer,test-writer}-strategy.ts`, missing `validate` hook | high — escape valves 2 and 4 are unreachable |
+| C | Rectifier prompt says "three" exceptions but lists four for TDD; non-TDD strip is also broken | `src/prompts/builders/rectifier-builder-helpers.ts`, 6 call sites in `rectifier-builder.ts` | medium — agent refuses valid Exception 4 cases |
+
+All three reproduced in the screener-ui-web run. Fix C alone restores the prompt; Fix B routes a now-emitted declaration; Fix A escalates if the agent still gives up despite a working handoff.
+
+---
+
+## Fix A — Promote `agent-gave-up` to `rectificationExhausted`
+
+### Change
+
+`src/execution/story-orchestrator.ts:707`
+
+```ts
+const exhaustedReasons = new Set<string>([
+  "max-attempts-total",
+  "max-attempts-per-strategy",
+  "bail-when",
+  "no-strategy",
+  "agent-gave-up",   // NEW
+]);
+```
+
+### Rationale
+
+`src/findings/cycle.ts:289-295` returns `exitReason: "agent-gave-up"` with `finalFindings: cycle.findings` (populated). This is semantically equivalent to running out of retries — the findings remain unfixed and the agent voluntarily declined to continue. The existing escalate branch at `src/execution/post-run.ts:402` (`return { action: "escalate", reason: "Rectification exhausted with unfixed findings" }`) is the correct response.
+
+### Files
+
+- `src/execution/story-orchestrator.ts` — 1-line addition
+
+### Tests
+
+- `test/unit/execution/story-orchestrator.test.ts` — new case: cycle returns `{exitReason: "agent-gave-up", finalFindings: [synthetic]}` → orchestrator returns `{rectificationExhausted: true, unfixedFindings: [...]}`.
+- `test/unit/execution/post-run.test.ts` — verify the existing escalate branch handles the new path (no change needed; covered by existing tests if `rectificationExhausted` already exercises that branch).
+
+### Risk
+
+- Stories that previously paused silently now escalate to the next tier. This is the intended behaviour and matches what the user expected when filing the report. A run that previously stalled at `balanced` will now retry at `powerful`, costing one additional tier attempt. Acceptable.
+- Watch for: tests that asserted `action: "pause"` for the `agent-gave-up` path. Grep before merging.
+
+### Acceptance
+
+- [verbatim] Given a rectification cycle that exits with `exitReason: "agent-gave-up"` and non-empty `finalFindings`, the story orchestrator returns `{rectificationExhausted: true, unfixedFindings: cycleResult.finalFindings}`.
+- [verbatim] Given `rectificationExhausted: true` from the orchestrator, `decideStageAction` returns `{action: "escalate", reason: "Rectification exhausted with unfixed findings"}`.
+
+### Effort
+
+~30 minutes including test.
+
+---
+
+## Fix B — Restore implementer→test-writer handoff plumbing
+
+### Goal
+
+Re-wire the four-step chain so a `TEST_EDIT_REASON` block in the implementer's output causes the next iteration to run the test-writer strategy on the affected finding.
+
+### Strategy
+
+Port the deleted logic from commits `84d81324`, `367a61bb`, `5f55e27c`, `44731506` into the new `runFixCycle`-driven architecture. Keep the same public shapes (`TestEditDeclaration`, `pendingMockStructureHandoffs`, `mode: "mock-restructure"`) — only the wiring needs work.
+
+### Sub-steps
+
+#### B1 — Port `applyTestEditDeclarations` helper
+
+Recreate from commit `84d81324`. Pure function; no `ctx` dependency.
+
+**New file:** `src/operations/apply-test-edit-declarations.ts`
+
+```ts
+export function applyTestEditDeclarations(
+  findings: Finding[],
+  declarations: TestEditDeclaration[],
+  story: UserStory,
+  invalidMockStructure?: TestEditDeclaration[],
+): Finding[]
+```
+
+Behaviour:
+- For `prd_contract`: validate `validatePrdQuote(d.prdQuote, story)`. If pass, re-tag any matching `findings[i].file === d.file` from `fixTarget: "source"` to `"test"` and attach `meta.prdContractDeclaration`. If fail, append an advisory finding (`category: "prd_quote_mismatch"`, `severity: "warning"`).
+- For invalid `mock_structure` (file doesn't exist or doesn't match test pattern): append an advisory finding (`category: "mock_structure_invalid_files"`, `severity: "warning"`).
+- For `lint_only` / `sibling_scope`: passthrough (parsed for telemetry only).
+- Pure — does not mutate input arrays.
+
+Export from `src/operations/index.ts`.
+
+#### B2 — Port `validateMockStructureFiles` helper
+
+Recreate from commit `367a61bb`. Pure function; takes resolved test patterns + package dir + a file-existence check.
+
+**New file:** `src/operations/validate-mock-structure-files.ts`
+
+```ts
+export function validateMockStructureFiles(
+  declarations: TestEditDeclaration[],
+  resolvedTestPatterns: ResolvedTestPatterns,
+  packageDir: string,
+  deps?: { fileExists?: (path: string) => Promise<boolean> },
+): Promise<{ valid: TestEditDeclaration[]; invalid: TestEditDeclaration[] }>
+```
+
+Behaviour:
+- Non-`mock_structure` declarations passthrough to `valid` unchanged.
+- For `mock_structure`: each file in `decl.files` must (a) exist on disk and (b) match `resolvedTestPatterns.regex`. If any file fails, the whole declaration goes to `invalid`.
+- Inject `deps` for testability (default: `Bun.file(p).exists()`).
+
+Export from `src/operations/index.ts`.
+
+#### B3 — Declaration sink type
+
+Define the shared mutable sink that the implementer strategy writes to and the postValidate hook + test-writer strategy read from. One instance per rectification cycle, created in `build-plan-for-strategy.ts` and captured by closure.
+
+```ts
+// New: src/operations/declaration-sink.ts
+export interface DeclarationSink {
+  testEdits: TestEditDeclaration[];        // all non-mock_structure (prd_contract, lint_only, sibling_scope)
+  mockHandoffs: { files: string[]; reasonDetail: string }[];
+}
+
+export function makeDeclarationSink(): DeclarationSink {
+  return { testEdits: [], mockHandoffs: [] };
+}
+```
+
+Export from `src/operations/index.ts`.
+
+#### B4 — Wire implementer strategy `extractApplied`
+
+`src/operations/autofix-implementer-strategy.ts`
+
+Add a `sink` parameter to the factory:
+
+```ts
+export function makeAutofixImplementerStrategy(
+  story: UserStory,
+  config: NaxConfig,
+  sink: DeclarationSink,
+): FixStrategy<Finding, AutofixImplementerInput, AutofixImplementerOutput, AutofixConfig>
+```
+
+Inside `extractApplied`:
+- Partition `output.testEditDeclarations` by reason: `mock_structure` → push to `sink.mockHandoffs` (as `{files: d.files!, reasonDetail: d.reasonDetail!}`); others → push to `sink.testEdits`.
+- Return `{summary: output.unresolvedReason ?? "", unresolved: output.unresolvedReason}` (unchanged from current shape).
+
+#### B5 — Wire test-writer strategy `buildInput` + `appliesTo`
+
+`src/operations/autofix-test-writer-strategy.ts`
+
+Add a `sink` parameter:
+
+```ts
+export function makeAutofixTestWriterStrategy(
+  story: UserStory,
+  config: NaxConfig,
+  sink: DeclarationSink,
+): FixStrategy<Finding, AutofixTestWriterInput, AutofixTestWriterOutput, AutofixConfig>
+```
+
+- `appliesTo`: existing `(f) => f.fixTarget === "test" || f.source === "adversarial-review"` PLUS `|| sink.mockHandoffs.length > 0`. The handoff length is read synchronously each call — no peek API needed since `sink` is captured by closure.
+- `buildInput`:
+  - If `sink.mockHandoffs.length > 0`: dedupe files across all entries (Set), join `reasonDetail` with `\n---\n`, set `mode: "mock-restructure"`, `handoffFiles`, `handoffReason`. Then clear: `sink.mockHandoffs.length = 0`.
+  - Otherwise default behaviour (current shape).
+
+#### B6 — Add `postValidate` to `RectificationPhaseOptions` and call it
+
+`src/execution/story-orchestrator.ts:50-55` — add the optional field:
+
+```ts
+export interface RectificationPhaseOptions {
+  readonly maxAttempts: number;
+  readonly strategies: FixStrategy<Finding, any, any, any>[];
+  readonly abortOnIncreasingFailures: boolean;
+  /** Optional: transform findings after validate() returns, before next iteration's strategy selection. */
+  readonly postValidate?: (findings: Finding[], ctx: FixCycleContext) => Promise<Finding[]>;
+}
+```
+
+`src/execution/story-orchestrator.ts:664-686` (`runRectification`) — wrap the existing `validate` closure tail:
+
+```ts
+validate: async (validateCtx, opts) => {
+  // ...existing verifier/gate re-run, populates `findings` array...
+  return rectification.postValidate ? await rectification.postValidate(findings, validateCtx) : findings;
+}
+```
+
+#### B7 — Register the postValidate hook + construct sink
+
+`src/execution/build-plan-for-strategy.ts:140-162` — refactor:
+
+```ts
+if (shouldRunRectification(config) && inputs.rectification) {
+  const strategies: FixStrategy<Finding, unknown, unknown, unknown>[] = [];
+  const sink = makeDeclarationSink();          // NEW
+
+  // mechanical fixes — unchanged
+  if (config.quality.commands.lintFix || config.quality.commands.lintFixScoped) { ... }
+  if (config.quality.commands.formatFix || config.quality.commands.formatFixScoped) { ... }
+  if (isThreeSession && inputs.fullSuiteGate) { ... }
+
+  if (config.quality.autofix?.enabled !== false) {
+    strategies.push(makeAutofixImplementerStrategy(story, config, sink) as ...);   // pass sink
+    strategies.push(makeAutofixTestWriterStrategy(story, config, sink) as ...);    // pass sink
+  }
+
+  // NEW — resolve test patterns ONCE (not per iteration)
+  const resolvedTestPatterns = await resolveTestFilePatterns(config, ctx.workdir, story.workdir);
+  const packageDir = join(ctx.workdir, story.workdir);
+
+  const postValidate = async (findings: Finding[], _validateCtx: FixCycleContext): Promise<Finding[]> => {
+    if (sink.testEdits.length === 0 && sink.mockHandoffs.length === 0) return findings;
+
+    // Partition mock-structure declarations by existence + test-pattern match.
+    // Wrap them as TestEditDeclaration shape for validateMockStructureFiles.
+    const pendingMock: TestEditDeclaration[] = sink.mockHandoffs.map(h => ({
+      reason: "mock_structure",
+      file: h.files[0]!,
+      files: h.files,
+      reasonDetail: h.reasonDetail,
+    }));
+    const { valid, invalid } = await validateMockStructureFiles(pendingMock, resolvedTestPatterns, packageDir);
+
+    // Replace sink.mockHandoffs with only the validated entries so the next test-writer
+    // iteration consumes only valid ones. Invalid ones become advisory findings (below).
+    sink.mockHandoffs = valid.map(d => ({ files: d.files!, reasonDetail: d.reasonDetail! }));
+
+    const allDeclarations = [...sink.testEdits, ...valid];
+    sink.testEdits = [];  // consumed
+
+    return applyTestEditDeclarations(findings, allDeclarations, story, invalid);
+  };
+
+  const rectOpts: RectificationPhaseOptions = {
+    ...inputs.rectification,
+    strategies: [...strategies, ...inputs.rectification.strategies],
+    postValidate,
+  };
+  builder.addRectification(rectOpts);
+}
+```
+
+**Performance:** `resolveTestFilePatterns` is called once at plan-build time, captured by the closure. `validateMockStructureFiles` is called only when sink is non-empty (typical: 0–2 declarations per iteration).
+
+#### B8 — Delete dead `PipelineContext` fields
+
+Once B3-B7 are wired through the sink, the unused fields can go:
+
+- Remove `testEditDeclarations?: TestEditDeclaration[]` from `src/pipeline/types.ts:191`
+- Remove `pendingMockStructureHandoffs?: { files: string[]; reasonDetail: string }[]` from `src/pipeline/types.ts:198`
+
+Both fields have zero current consumers (verified). The sink supersedes them with proper scoping. Grep `testEditDeclarations` and `pendingMockStructureHandoffs` before deletion to confirm no stragglers were missed during this work.
+
+### Files
+
+- New: `src/operations/apply-test-edit-declarations.ts`
+- New: `src/operations/validate-mock-structure-files.ts`
+- New: `src/operations/declaration-sink.ts`
+- Modified: `src/operations/autofix-implementer-strategy.ts` — add `sink` param
+- Modified: `src/operations/autofix-test-writer-strategy.ts` — add `sink` param, expand `appliesTo`, drain in `buildInput`
+- Modified: `src/operations/index.ts` — re-export `applyTestEditDeclarations`, `validateMockStructureFiles`, `makeDeclarationSink`, `DeclarationSink`
+- Modified: `src/execution/story-orchestrator.ts` — add `postValidate?` to `RectificationPhaseOptions`, call it inside `runRectification`
+- Modified: `src/execution/build-plan-for-strategy.ts` — construct sink, resolve test patterns once, register `postValidate`, thread sink through both autofix strategy factories
+- Modified: `src/pipeline/types.ts` — remove dead `testEditDeclarations` and `pendingMockStructureHandoffs` fields (B8)
+
+### Tests
+
+- `test/unit/operations/apply-test-edit-declarations.test.ts` — port from `test/unit/pipeline/stages/autofix-cycle.test.ts` in commit `84d81324`. Cases: valid `prd_contract` re-tags; invalid `prd_quote` synthesizes advisory; `mock_structure` invalid synthesizes advisory; `lint_only`/`sibling_scope` passthrough.
+- `test/unit/operations/validate-mock-structure-files.test.ts` — file exists + matches pattern → valid; file missing → invalid; file exists but not test pattern → invalid.
+- `test/unit/operations/autofix-implementer-strategy.test.ts` — `extractApplied` pushes declarations to sinks.
+- `test/unit/operations/autofix-test-writer-strategy.test.ts` — `appliesTo` fires when handoffs pending; `buildInput` returns `mode: "mock-restructure"` with deduped files.
+- `test/integration/findings/autofix-handoff.test.ts` — end-to-end: implementer emits `prd_contract` → next iteration re-tags + runs test-writer; implementer emits `mock_structure` → next iteration runs test-writer with `mode: "mock-restructure"` and the file list.
+
+### Risk
+
+- The `DeclarationSink` is mutable shared state. Acceptable because it is scoped to a single rectification cycle's closure (one per story per run) — no cross-story leakage possible. Document the pattern at `src/operations/declaration-sink.ts`.
+- `validateMockStructureFiles` does async disk I/O. The plan resolves test patterns ONCE at plan-build time (B7) and stamps them into the closure — `postValidate` calls `validateMockStructureFiles` only when the sink is non-empty.
+- The `postValidate` field is added to `RectificationPhaseOptions` (nax-internal), not to `FixCycle<F>` (findings framework). No public-API change to `src/findings/`.
+- Other rectification consumers (`run-regression.ts`, `acceptance-loop.ts`) construct their own `FixCycle` directly — they are NOT affected by the `RectificationPhaseOptions` change, which is only consumed by `story-orchestrator.runRectification`. Verify by grepping `RectificationPhaseOptions` before merging.
+
+### Acceptance
+
+- [verbatim] Given an `autofix-implementer` op emits a `TEST_EDIT_REASON: prd_contract` block with a `PRD_QUOTE` that appears in the story's description or acceptance criteria, the matching finding's `fixTarget` is set to `"test"` before the next iteration's strategy selection.
+- [verbatim] Given an `autofix-implementer` op emits a `TEST_EDIT_REASON: mock_structure` block with FILES that exist on disk and match the resolved test-file patterns, the next iteration runs `autofix-test-writer` with `mode: "mock-restructure"`, `handoffFiles` equal to the deduped union of declared files, and `handoffReason` equal to the joined `REASON` paragraphs.
+- [verbatim] Given an `autofix-implementer` op emits a `TEST_EDIT_REASON: prd_contract` block with a `PRD_QUOTE` that does NOT appear verbatim in the story text, an advisory finding with `category: "prd_quote_mismatch"` and `severity: "warning"` is appended to the next iteration's findings and no re-tag occurs.
+- [verbatim] Given an `autofix-implementer` op emits a `TEST_EDIT_REASON: mock_structure` block referencing a FILE that does not exist on disk or does not match the resolved test-file patterns, an advisory finding with `category: "mock_structure_invalid_files"` and `severity: "warning"` is appended to the next iteration's findings and no handoff is staged.
+
+### Effort
+
+~1 day — most of it porting and re-testing. Helpers are mechanical translations of deleted code.
+
+---
+
+## Fix C — Rectifier prompt count + Exception 4 wording + broken non-TDD strip
+
+### Changes
+
+#### C1 — Replace static `CONTRADICTION_ESCAPE_HATCH` with a builder
+
+`src/prompts/builders/rectifier-builder-helpers.ts`
+
+Replace lines 25-126 with:
+
+```ts
+interface EscapeHatchOptions {
+  includeMockHandoff: boolean;
+}
+
+export function buildEscapeHatch(opts: EscapeHatchOptions): string {
+  const exceptions: string[] = [
+    EXCEPTION_1_LINT_ONLY,
+    EXCEPTION_2_PRD_CONTRACT,
+    EXCEPTION_3_SIBLING_SCOPE,
+  ];
+  if (opts.includeMockHandoff) exceptions.push(EXCEPTION_4_MOCK_HANDOFF);
+
+  const count = exceptions.length;
+  const countWord = ["zero", "one", "two", "three", "four"][count];
+
+  return `
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+Before emitting UNRESOLVED, confirm none of Exceptions 1–${count} apply.
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has ${countWord} narrow escape valves. Each requires a
+declaration in your output. Outside these ${countWord} cases the rule is absolute.
+
+${exceptions.join("\n\n")}`;
+}
+```
+
+Each exception becomes its own const (`EXCEPTION_1_LINT_ONLY`, etc.) defined separately. This eliminates the broken `.replace` at line 125 and guarantees the count matches the included exceptions.
+
+`escapeHatchFor(story)` becomes:
+
+```ts
+function escapeHatchFor(story: UserStory): string {
+  const isTdd = THREE_SESSION_STRATEGIES.has(story.routing?.testStrategy ?? "");
+  return buildEscapeHatch({ includeMockHandoff: isTdd });
+}
+```
+
+#### C2 — Update all "three" hardcoded strings
+
+Six call sites currently say "the three narrow exceptions":
+- `src/prompts/builders/rectifier-builder-helpers.ts:203, 285`
+- `src/prompts/builders/rectifier-builder.ts:203, 577, 707, 843`
+
+Replace with a helper:
+
+```ts
+export function exceptionCountWord(story: UserStory): "three" | "four" {
+  return THREE_SESSION_STRATEGIES.has(story.routing?.testStrategy ?? "") ? "four" : "three";
+}
+```
+
+And inline-interpolate at each site: `… see the ${exceptionCountWord(story)} narrow exceptions appended below.`
+
+The two bullet-list mentions at `rectifier-builder.ts:577` and `rectifier-builder.ts:843` also need to mention Exception 4 conditionally — convert to a builder call.
+
+#### C3 — Broaden Exception 4 wording (language-neutral, see Q2)
+
+`EXCEPTION_4_MOCK_HANDOFF` body becomes (no tool names; generalises across JS/TS, Python, Go, Rust):
+
+```
+### Exception 4 — Mock-structure handoff
+
+Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
+that does NOT fit Exception 2. Two cases qualify:
+
+  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
+      or assertion topology must change to match a new dispatch shape.
+
+  (b) Required test-infrastructure does not yet exist and must be introduced —
+      e.g. in-process fake servers, network-level request interception, hermetic
+      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
+      hermetic/fixture-backed test surface that the current test setup cannot
+      satisfy without new infrastructure.
+
+Declare with:
+\`\`\`
+TEST_EDIT_REASON: mock_structure
+FILES: <comma-separated test file paths>
+REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
+         or what infrastructure must be introduced>
+\`\`\`
+
+Rules:
+- Do NOT make any edits yourself; the test-writer will fulfill.
+- Do NOT also emit `UNRESOLVED:` in the same turn — this declaration IS the handoff.
+- FILES must list real test files. Each path must exist and be a test file.
+```
+
+This is what unblocks the rs-stock E2E case. The current wording reads as case (a) only; case (b) is exactly what the screener-ui-web run needed. The phrase "hermetic/fixture-backed test surface" mirrors verbatim AC wording in such cases ("Given a hermetic Playwright fixture-backed API …") giving the agent a textual anchor.
+
+### Files
+
+- Modified: `src/prompts/builders/rectifier-builder-helpers.ts`
+- Modified: `src/prompts/builders/rectifier-builder.ts` — six sites
+
+### Tests
+
+- `test/unit/prompts/rectifier-builder-helpers.test.ts` — snapshot the rectifier prompt for `{testStrategy: "three-session-tdd"}` and `{testStrategy: "no-test"}`. Assert:
+  - TDD path includes Exception 4 and says "four narrow escape valves".
+  - Non-TDD path excludes Exception 4 and says "three narrow escape valves".
+  - `Exceptions 1–N` line interpolates correctly.
+  - Case (b) wording appears in Exception 4.
+- Update existing snapshot tests that may capture the prompt — re-bake.
+
+### Risk
+
+- Prompt change → agent behaviour change. The `four` count is more permissive than `three` (one more escape valve available). Watch for false-positive Exception 4 usage on the first few runs; the `validateMockStructureFiles` guard from Fix B catches fabricated declarations.
+- Snapshot tests in `test/unit/prompts/` will need re-baking.
+
+### Acceptance
+
+- [verbatim] For a story with `routing.testStrategy === "three-session-tdd"`, the rectifier prompt's escape-hatch section includes Exception 4 (Mock-structure handoff) and the intro count reads "four narrow escape valves" / "Outside these four cases the rule is absolute".
+- [verbatim] For a story with `routing.testStrategy === "no-test"`, the rectifier prompt's escape-hatch section excludes Exception 4 and the intro count reads "three narrow escape valves" / "Outside these three cases the rule is absolute".
+- [verbatim] Exception 4's body contains both case (a) — "mocks reference primitives the new code bypasses" — and case (b) — "required mock infrastructure does not yet exist and must be introduced".
+- [verbatim] The escape-hatch section contains the line `Before emitting UNRESOLVED, confirm none of Exceptions 1–N apply` where N is the count of included exceptions.
+
+### Effort
+
+~2-3 hours including snapshot rebake.
+
+---
+
+## Ordering & PR plan
+
+| PR | Bug | Why this order |
+|:---|:---|:---|
+| 1 | B — handoff plumbing | Largest surface (~1 day). Land first so C and A have somewhere to route declarations. |
+| 2 | C — prompt | Cheapest (~2-3h). Activates the now-wired handoff by making the agent actually emit `TEST_EDIT_REASON: mock_structure` in case-(b) situations. |
+| 3 | A — escalate on agent-gave-up | One-line + test (~30 min). Safety net for the residual case where the agent still gives up despite the working handoff. |
+
+**Why not C first:** shipping C alone changes the agent's reply from `UNRESOLVED outside the three exceptions` to `TEST_EDIT_REASON: mock_structure …` — but with B unmerged, the declaration goes to /dev/null and the story still pauses. C-first would look like a regression in logs ("agent now claims handoff but nothing happens"). Ship B first so C has somewhere to route to; the order above gives every PR a visible user-facing improvement on merge.
+
+**Alternative:** ship B+C together as one PR. Either is acceptable; the three-PR sequence above keeps reviews small and lets each one ship without holding up the others if the queue stalls.
+
+Each PR is independently shippable — they fix non-overlapping failure modes. B unblocks the routing; C activates the route by fixing the prompt; A handles the residual case where higher capability is needed.
+
+### Not in scope
+
+- Adding a fifth exception or new escape valve.
+- Changing the rectification cap config (recently raised 2→12 in `d5a02f41`).
+- Reworking `deriveTddFailureCategory` to consider semantic-review / rectification outputs — Fix A handles the symptom via the existing escalate branch; a deeper refactor is overkill for this case.
+
+---
+
+## Resolved questions
+
+### Q1 — `FixCycle` seam — RESOLVED: use existing `validate`, add `postValidate?` to `RectificationPhaseOptions`
+
+`src/findings/cycle-types.ts:184` already defines `FixCycle.validate: (ctx, opts) => Promise<F[]>` as a mandatory hook. `src/execution/story-orchestrator.ts:664-686` (`runRectification`) builds the validate closure that re-runs verifier/gate phases between iterations.
+
+**No change needed to the findings framework.** The cleanest seam is at the nax-layer above:
+
+1. Add an optional field to `RectificationPhaseOptions` in `src/execution/story-orchestrator.ts:50-55`:
+   ```ts
+   export interface RectificationPhaseOptions {
+     readonly maxAttempts: number;
+     readonly strategies: FixStrategy<Finding, any, any, any>[];
+     readonly abortOnIncreasingFailures: boolean;
+     /** Optional: transform findings after validate(), before next iteration's strategy selection. */
+     readonly postValidate?: (findings: Finding[], ctx: FixCycleContext) => Promise<Finding[]>;
+   }
+   ```
+
+2. In `runRectification` (`story-orchestrator.ts:664`), wrap the existing validate closure:
+   ```ts
+   validate: async (validateCtx, opts) => {
+     const fresh = /* ...existing verifier re-run, returns Finding[]... */;
+     return rectification.postValidate ? await rectification.postValidate(fresh, validateCtx) : fresh;
+   }
+   ```
+
+3. In `build-plan-for-strategy.ts:140-162`, construct a `declarationSink` closure object shared between the implementer strategy (writer) and the postValidate hook (reader). The test-writer strategy reads the same sink to drain handoffs in `buildInput`.
+
+This keeps the change off the `findings/` framework. The sink object is plain (`{ testEdits: TestEditDeclaration[]; mockHandoffs: { files: string[]; reasonDetail: string }[] }`) and is mutated inside `extractApplied` of the implementer strategy, consumed by `postValidate`, and partially-consumed by the test-writer's `buildInput`.
+
+**Trade-off:** the sink is mutable shared state. Acceptable because (a) it's scoped to one rectification cycle's closure (no cross-story leakage), (b) all mutations happen on a single thread, and (c) the prior architecture used `PipelineContext.testEditDeclarations` for the same purpose — this is a more localised version of that.
+
+### Q2 — Exception 4 case (b) wording — RESOLVED: language-neutral, no tool names
+
+Verified against the pre-implement rs-stock repo at `/home/williamkhoo/Desktop/projects/work/rs-stock/rs-stock/`. Tech: Next.js + Vitest + Playwright + TanStack Query, JS/TS only. The failing ACs read verbatim:
+
+- **AC29:** *"Given `web/tests/e2e/screener.spec.ts`, when inspecting the repository, then the file exists and defines the screener happy-path flow **against fixture-backed API data**."*
+- **AC30:** *"Given a **hermetic Playwright fixture-backed API**, when `web/tests/e2e/screener.spec.ts` runs, then it loads `/`, observes at least 12 strategy options, selects `golden-cross`, …"*
+
+The AC itself says "hermetic" and "fixture-backed" — the spec explicitly requires test-infrastructure that does not yet exist (`web/tests/` contains only one vitest smoke test, no Playwright fixtures, no MSW). The implementer's failure mode was exactly: prompt said "fix existing mocks", AC said "introduce a hermetic fixture layer", implementer concluded "no match" → `UNRESOLVED`.
+
+For language-neutrality, the case (b) example list should not pin specific tool names. nax orchestrates Go / Python / Rust / polyglot monorepos per `.claude/rules/monorepo-awareness.md`. Equivalent infrastructure across languages:
+
+| Language | Examples |
+|:---|:---|
+| JS/TS | MSW, Playwright `page.route()`, nock, vitest fetch mock |
+| Python | `responses`, `respx`, `pytest-httpserver`, Django `TestCase` client |
+| Go | `httptest.NewServer`, `gock` |
+| Rust | `wiremock`, `mockito` |
+
+**Final wording** (replaces lines 105-107 of `rectifier-builder-helpers.ts`):
+
+```
+### Exception 4 — Mock-structure handoff
+
+Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
+that does NOT fit Exception 2. Two cases qualify:
+
+  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
+      or assertion topology must change to match a new dispatch shape.
+
+  (b) Required test-infrastructure does not yet exist and must be introduced —
+      e.g. in-process fake servers, network-level request interception, hermetic
+      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
+      hermetic/fixture-backed test surface that the current test setup cannot
+      satisfy without new infrastructure.
+```
+
+No tool names. The phrase "hermetic/fixture-backed test surface" mirrors AC wording in the rs-stock case and generalises across languages.
+
+---
+
+## Verification
+
+After all three PRs merge, re-run the screener-ui-web feature against the same PRD (pre-implement repo: `/home/williamkhoo/Desktop/projects/work/rs-stock/rs-stock/`). Expected behaviour:
+
+1. Implementer reaches the AC29/AC30 finding, recognises it fits Exception 4 case (b) (AC text uses "hermetic Playwright fixture-backed API"), emits `TEST_EDIT_REASON: mock_structure` with `FILES=web/tests/e2e/screener.spec.ts,web/playwright.config.ts` and a REASON paragraph naming the missing fixture layer.
+2. `runRectification.validate` closure runs the verifier re-run as today, then calls `rectification.postValidate` (B6). `postValidate` calls `validateMockStructureFiles` — both files exist and match resolved test patterns → both go to `valid` → sink's `mockHandoffs` is replaced with just the valid entries.
+3. `applyTestEditDeclarations` returns findings unchanged in this case (no `prd_contract` declarations to re-tag).
+4. Next iteration: `makeAutofixTestWriterStrategy.appliesTo` returns true because `sink.mockHandoffs.length > 0`. `buildInput` drains the sink, returns `mode: "mock-restructure"`, `handoffFiles: [...]`, `handoffReason: "..."`.
+5. Test-writer agent introduces a fixture layer (Playwright `page.route()`, MSW handlers, or equivalent — agent picks) and reconfigures `playwright.config.ts` for hermetic mode.
+6. Verifier re-runs E2E → passes → story completes at `balanced` tier with `firstPassSuccess: false` but `success: true`.
+
+If the agent still cannot fulfil the handoff at `balanced` (e.g. the test-writer also gives up), the cycle exits with `agent-gave-up`, Fix A promotes that to `rectificationExhausted`, post-run.ts:402 returns `{action: "escalate"}`, and the run retries at `powerful` tier.
+
+### Regression guard
+
+Add an integration test under `test/integration/findings/autofix-handoff.test.ts` that reproduces the screener-ui-web shape: an implementer that always emits `TEST_EDIT_REASON: mock_structure` for a synthetic finding, and assert the test-writer fires in the next iteration with the declared files in `handoffFiles`. This catches future refactors that disconnect the sink, the same way `f38aedf2` did silently.

--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -16,20 +16,27 @@
  * addX(input: I) overload of StoryOrchestratorBuilder.
  */
 
+import { join } from "node:path";
 import type { NaxConfig } from "../config";
 import type { TestStrategy } from "../config/schema-types";
+import type { FixCycleContext } from "../findings/cycle-types";
 import type { FixStrategy } from "../findings/cycle-types";
 import type { Finding } from "../findings/types";
 import {
+  applyTestEditDeclarations,
   makeAutofixImplementerStrategy,
   makeAutofixTestWriterStrategy,
+  makeDeclarationSink,
   makeMechanicalFormatFixStrategy,
   makeMechanicalLintFixStrategy,
+  validateMockStructureFiles,
 } from "../operations";
+import type { TestEditDeclaration } from "../operations";
 import { shouldRunRectification } from "../operations/execution-gates";
 import { makeFullSuiteRectifyStrategy } from "../operations/full-suite-rectify";
 import type { CallContext } from "../operations/types";
 import type { UserStory } from "../prd/types";
+import { resolveTestFilePatterns } from "../test-runners";
 import type { PlanInputs } from "./plan-inputs";
 import { type ExecutionPlan, type RectificationPhaseOptions, StoryOrchestratorBuilder } from "./story-orchestrator";
 
@@ -72,6 +79,10 @@ function isFreshRun(story: UserStory): boolean {
 /**
  * Build an ExecutionPlan from strategy + story state + typed inputs.
  *
+ * This function is async because it eagerly resolves test-file patterns
+ * (needed for the postValidate closure that validates mock-structure handoffs
+ * during the rectification cycle).
+ *
  * Slot inclusion is determined by:
  *   1. test strategy (which phases are eligible)
  *   2. story state (fresh vs. retry — derived, never passed externally)
@@ -85,13 +96,13 @@ function isFreshRun(story: UserStory): boolean {
  * Rectification runs after all phases if both config.execution.rectification.enabled
  * and inputs.rectification are defined.
  */
-export function buildPlanForStrategy(
+export async function buildPlanForStrategy(
   ctx: CallContext,
   story: UserStory,
   config: NaxConfig,
   testStrategy: TestStrategy,
   inputs: PlanInputs,
-): ExecutionPlan {
+): Promise<ExecutionPlan> {
   const isThreeSession = isThreeSessionStrategy(testStrategy);
   const freshRun = isFreshRun(story);
 
@@ -138,6 +149,16 @@ export function buildPlanForStrategy(
   // Rectification: requires both config gate and typed inputs.
   // Assemble strategies: mechanical fixes first, then full-suite (TDD), then autofix agents.
   if (shouldRunRectification(config) && inputs.rectification) {
+    // One shared sink for the implementer and test-writer strategies so
+    // declarations accumulate and mock handoffs are consumed by postValidate.
+    const sink = makeDeclarationSink();
+
+    // Resolve test-file patterns once at plan-build time — postValidate uses
+    // them to validate mock-structure file paths during the rectification cycle.
+    // ctx.packageDir = repo root (absolute); story.workdir = relative sub-path to package.
+    const packageDir = join(ctx.packageDir, story.workdir ?? "");
+    const resolvedTestPatterns = await resolveTestFilePatterns(config, ctx.packageDir, story.workdir);
+
     const strategies: FixStrategy<Finding, unknown, unknown, unknown>[] = [];
 
     if (config.quality.commands.lintFix || config.quality.commands.lintFixScoped) {
@@ -150,13 +171,40 @@ export function buildPlanForStrategy(
       strategies.push(makeFullSuiteRectifyStrategy(story, config) as FixStrategy<Finding, unknown, unknown, unknown>);
     }
     if (config.quality.autofix?.enabled !== false) {
-      strategies.push(makeAutofixImplementerStrategy(story, config) as FixStrategy<Finding, unknown, unknown, unknown>);
-      strategies.push(makeAutofixTestWriterStrategy(story, config) as FixStrategy<Finding, unknown, unknown, unknown>);
+      strategies.push(
+        makeAutofixImplementerStrategy(story, config, sink) as FixStrategy<Finding, unknown, unknown, unknown>,
+      );
+      strategies.push(
+        makeAutofixTestWriterStrategy(story, config, sink) as FixStrategy<Finding, unknown, unknown, unknown>,
+      );
     }
+
+    const postValidate = async (findings: Finding[], _validateCtx: FixCycleContext): Promise<Finding[]> => {
+      if (sink.testEdits.length === 0 && sink.mockHandoffs.length === 0) return findings;
+
+      // Wrap mock handoffs as TestEditDeclaration shape for validateMockStructureFiles.
+      const pendingMock: TestEditDeclaration[] = sink.mockHandoffs.map((h) => ({
+        reason: "mock_structure" as const,
+        file: h.files[0] ?? "",
+        files: h.files,
+        reasonDetail: h.reasonDetail,
+      }));
+
+      const { valid, invalid } = await validateMockStructureFiles(pendingMock, resolvedTestPatterns, packageDir);
+
+      // Replace sink.mockHandoffs with only valid entries for test-writer to consume.
+      sink.mockHandoffs = valid.map((d) => ({ files: d.files ?? [], reasonDetail: d.reasonDetail ?? "" }));
+
+      const allDeclarations = [...sink.testEdits, ...valid];
+      sink.testEdits = []; // consumed
+
+      return applyTestEditDeclarations(findings, allDeclarations, story, invalid);
+    };
 
     const rectOpts: RectificationPhaseOptions = {
       ...inputs.rectification,
       strategies: [...strategies, ...inputs.rectification.strategies],
+      postValidate,
     };
     builder.addRectification(rectOpts);
   }

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -52,6 +52,8 @@ export interface RectificationPhaseOptions {
   // biome-ignore lint/suspicious/noExplicitAny: rectification strategies are heterogeneous over their fixOp input/output
   readonly strategies: FixStrategy<Finding, any, any, any>[];
   readonly abortOnIncreasingFailures: boolean;
+  /** Optional: transform findings after validate() returns, before next iteration's strategy selection. */
+  readonly postValidate?: (findings: Finding[], ctx: FixCycleContext) => Promise<Finding[]>;
 }
 
 export interface StoryOrchestratorResult {
@@ -682,7 +684,7 @@ async function runRectification(
         if (shouldSkipPhaseForRectification(phase, state, phaseOutputs)) continue;
         findings.push(...extractPhaseFindings(phaseOutputs[phase.slot.op.name]));
       }
-      return findings;
+      return rectification.postValidate ? await rectification.postValidate(findings, _validateCtx) : findings;
     },
   };
 

--- a/src/findings/types.ts
+++ b/src/findings/types.ts
@@ -36,7 +36,8 @@ export type FindingSource =
   | "acceptance-diagnose"
   | "tdd-verifier"
   | "plugin"
-  | "implementer-handoff";
+  | "implementer-handoff"
+  | "autofix";
 
 /**
  * Severity scale. Standardised on "warning" (not "warn") to align with

--- a/src/operations/apply-test-edit-declarations.ts
+++ b/src/operations/apply-test-edit-declarations.ts
@@ -1,0 +1,80 @@
+/**
+ * Apply test-edit declarations emitted by the implementer rectification agent
+ * to findings, re-tagging source→test on valid prd_contract declarations and
+ * appending advisory findings for invalid quotes or invalid mock-structure refs.
+ *
+ * Pure function — never mutates inputs.
+ */
+import type { Finding } from "@/findings";
+import type { UserStory } from "@/prd";
+import { validatePrdQuote } from "./test-edit-declaration";
+import type { TestEditDeclaration } from "./test-edit-declaration";
+
+/**
+ * Apply declarations to the findings array.
+ *
+ * @param findings - Current findings from the fix cycle.
+ * @param declarations - Parsed TEST_EDIT_REASON declarations from the implementer.
+ * @param story - The user story (used to validate prd_contract quotes).
+ * @param invalidMockStructure - Mock-structure declarations that failed file/pattern validation.
+ * @returns New findings array with re-tags and advisory findings applied.
+ */
+export function applyTestEditDeclarations(
+  findings: Finding[],
+  declarations: TestEditDeclaration[],
+  story: UserStory,
+  invalidMockStructure?: TestEditDeclaration[],
+): Finding[] {
+  let result: Finding[] = [...findings];
+  const advisories: Finding[] = [];
+
+  for (const d of declarations) {
+    if (d.reason === "prd_contract") {
+      const prdQuote = d.prdQuote ?? "";
+      const valid = validatePrdQuote(prdQuote, story);
+
+      if (valid) {
+        // Re-tag matching findings: same file, fixTarget was "source" → "test"
+        result = result.map((f) => {
+          if (f.file === d.file && f.fixTarget === "source") {
+            return {
+              ...f,
+              fixTarget: "test" as const,
+              meta: {
+                ...f.meta,
+                prdContractDeclaration: d,
+              },
+            };
+          }
+          return f;
+        });
+      } else {
+        advisories.push({
+          source: "autofix",
+          severity: "warning",
+          category: "prd_quote_mismatch",
+          message: `PRD quote not found verbatim in story text for file: ${d.file}`,
+          file: d.file,
+          fixTarget: "source",
+        });
+      }
+    }
+    // lint_only and sibling_scope: passthrough — no changes to findings
+  }
+
+  // Advisory findings for invalid mock_structure declarations
+  if (invalidMockStructure && invalidMockStructure.length > 0) {
+    for (const d of invalidMockStructure) {
+      const fileList = (d.files ?? [d.file]).join(", ");
+      advisories.push({
+        source: "autofix",
+        severity: "warning",
+        category: "mock_structure_invalid_files",
+        message: `Mock structure handoff references file that does not exist or is not a test file: ${fileList}`,
+        fixTarget: "source",
+      });
+    }
+  }
+
+  return [...result, ...advisories];
+}

--- a/src/operations/autofix-implementer-strategy.ts
+++ b/src/operations/autofix-implementer-strategy.ts
@@ -6,12 +6,14 @@ import type { UserStory } from "../prd";
 import { findingsToFailedChecks } from "./_finding-to-check";
 import type { AutofixImplementerInput, AutofixImplementerOutput } from "./autofix-implementer";
 import { implementerRectifyOp } from "./autofix-implementer";
+import type { DeclarationSink } from "./declaration-sink";
 
 const IMPLEMENTER_SOURCES = new Set(["lint", "typecheck", "semantic-review"]);
 
 export function makeAutofixImplementerStrategy(
   story: UserStory,
   config: NaxConfig,
+  sink: DeclarationSink,
 ): FixStrategy<Finding, AutofixImplementerInput, AutofixImplementerOutput, AutofixConfig> {
   return {
     name: "autofix-implementer",
@@ -21,10 +23,21 @@ export function makeAutofixImplementerStrategy(
       failedChecks: findingsToFailedChecks(findings),
       story,
     }),
-    extractApplied: (output) => ({
-      summary: output.unresolvedReason ?? "",
-      unresolved: output.unresolvedReason,
-    }),
+    extractApplied: (output) => {
+      // Accumulate test-edit declarations and mock handoffs into the shared sink
+      // so postValidate can inspect them after each validate() pass.
+      for (const decl of output.testEditDeclarations) {
+        if (decl.reason === "mock_structure" && decl.files && decl.reasonDetail) {
+          sink.mockHandoffs.push({ files: decl.files, reasonDetail: decl.reasonDetail });
+        } else if (decl.reason !== "mock_structure") {
+          sink.testEdits.push(decl);
+        }
+      }
+      return {
+        summary: output.unresolvedReason ?? "",
+        unresolved: output.unresolvedReason,
+      };
+    },
     maxAttempts: config.execution.rectification.maxAttemptsPerStrategy,
     coRun: "co-run-sequential",
   };

--- a/src/operations/autofix-test-writer-strategy.ts
+++ b/src/operations/autofix-test-writer-strategy.ts
@@ -6,20 +6,48 @@ import type { UserStory } from "../prd";
 import { findingsToFailedChecks } from "./_finding-to-check";
 import type { AutofixTestWriterInput, AutofixTestWriterOutput } from "./autofix-test-writer";
 import { testWriterRectifyOp } from "./autofix-test-writer";
+import type { DeclarationSink } from "./declaration-sink";
 
 export function makeAutofixTestWriterStrategy(
   story: UserStory,
   config: NaxConfig,
+  sink: DeclarationSink,
 ): FixStrategy<Finding, AutofixTestWriterInput, AutofixTestWriterOutput, AutofixConfig> {
   return {
     name: "autofix-test-writer",
-    appliesTo: (f) => f.fixTarget === "test" || f.source === "adversarial-review",
+    appliesTo: (f) => f.fixTarget === "test" || f.source === "adversarial-review" || sink.mockHandoffs.length > 0,
     fixOp: testWriterRectifyOp,
-    buildInput: (findings, _prior, _cycleCtx): AutofixTestWriterInput => ({
-      failedChecks: findingsToFailedChecks(findings),
-      story,
-      blockingThreshold: config.review?.blockingThreshold,
-    }),
+    buildInput: (findings, _prior, _cycleCtx): AutofixTestWriterInput => {
+      // Consume mock-structure handoffs from the shared sink (one-shot).
+      if (sink.mockHandoffs.length > 0) {
+        const handoffs = sink.mockHandoffs.splice(0);
+        // Deduplicate FILES across all handoffs.
+        const seenFiles = new Set<string>();
+        const handoffFiles: string[] = [];
+        for (const h of handoffs) {
+          for (const f of h.files) {
+            if (!seenFiles.has(f)) {
+              seenFiles.add(f);
+              handoffFiles.push(f);
+            }
+          }
+        }
+        const handoffReason = handoffs.map((h) => h.reasonDetail).join("\n---\n");
+        return {
+          failedChecks: findingsToFailedChecks(findings),
+          story,
+          mode: "mock-restructure",
+          blockingThreshold: config.review?.blockingThreshold,
+          handoffReason,
+          handoffFiles,
+        };
+      }
+      return {
+        failedChecks: findingsToFailedChecks(findings),
+        story,
+        blockingThreshold: config.review?.blockingThreshold,
+      };
+    },
     maxAttempts: config.execution.rectification.maxAttemptsPerStrategy,
     coRun: "co-run-sequential",
   };

--- a/src/operations/declaration-sink.ts
+++ b/src/operations/declaration-sink.ts
@@ -1,0 +1,19 @@
+/**
+ * DeclarationSink — mutable shared state scoped to a single rectification cycle.
+ *
+ * The implementer strategy (writer) pushes declarations here in extractApplied.
+ * The postValidate hook reads testEdits + drains mockHandoffs via validateMockStructureFiles.
+ * The test-writer strategy reads mockHandoffs to decide appliesTo + drain in buildInput.
+ *
+ * Mutation is safe: one sink per closure, single-threaded, no cross-story leakage.
+ */
+import type { TestEditDeclaration } from "./test-edit-declaration";
+
+export interface DeclarationSink {
+  testEdits: TestEditDeclaration[];
+  mockHandoffs: { files: string[]; reasonDetail: string }[];
+}
+
+export function makeDeclarationSink(): DeclarationSink {
+  return { testEdits: [], mockHandoffs: [] };
+}

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -84,6 +84,11 @@ export type {
 export { makeFullSuiteRectifyStrategy } from "./full-suite-rectify";
 export { makeAutofixImplementerStrategy } from "./autofix-implementer-strategy";
 export { makeAutofixTestWriterStrategy } from "./autofix-test-writer-strategy";
+export { applyTestEditDeclarations } from "./apply-test-edit-declarations";
+export { validateMockStructureFiles } from "./validate-mock-structure-files";
+export type { ValidateMockStructureDeps } from "./validate-mock-structure-files";
+export { makeDeclarationSink } from "./declaration-sink";
+export type { DeclarationSink } from "./declaration-sink";
 export { findingsToFailedChecks } from "./_finding-to-check";
 export {
   makeMechanicalLintFixStrategy,

--- a/src/operations/validate-mock-structure-files.ts
+++ b/src/operations/validate-mock-structure-files.ts
@@ -1,0 +1,74 @@
+/**
+ * Partition mock_structure TestEditDeclarations into valid/invalid.
+ *
+ * A declaration is valid when ALL its declared files:
+ *   (a) exist on disk, AND
+ *   (b) match at least one resolved test-file pattern regex.
+ *
+ * Non-mock_structure declarations pass through unchanged to `valid`.
+ *
+ * Injectable _deps for testability (default: Bun.file(p).exists()).
+ */
+import { join } from "node:path";
+import type { ResolvedTestPatterns } from "@/test-runners";
+import type { TestEditDeclaration } from "./test-edit-declaration";
+
+export interface ValidateMockStructureDeps {
+  fileExists?: (path: string) => Promise<boolean>;
+}
+
+const defaultFileExists = (p: string): Promise<boolean> => Bun.file(p).exists();
+
+/**
+ * Partition mock_structure declarations into valid/invalid.
+ *
+ * @param declarations - All declarations (any reason).
+ * @param resolvedTestPatterns - Resolved test file patterns for the package.
+ * @param packageDir - Absolute path to the package directory.
+ * @param deps - Injectable deps for testing (fileExists override).
+ * @returns { valid, invalid } — non-mock_structure always go to valid.
+ */
+export async function validateMockStructureFiles(
+  declarations: TestEditDeclaration[],
+  resolvedTestPatterns: ResolvedTestPatterns,
+  packageDir: string,
+  deps?: ValidateMockStructureDeps,
+): Promise<{ valid: TestEditDeclaration[]; invalid: TestEditDeclaration[] }> {
+  const fileExists = deps?.fileExists ?? defaultFileExists;
+  const valid: TestEditDeclaration[] = [];
+  const invalid: TestEditDeclaration[] = [];
+
+  for (const d of declarations) {
+    if (d.reason !== "mock_structure") {
+      valid.push(d);
+      continue;
+    }
+
+    const files = d.files ?? [d.file];
+
+    // Check all files: must exist on disk AND match at least one test pattern regex
+    let allValid = true;
+    for (const file of files) {
+      const absolutePath = join(packageDir, file);
+      const exists = await fileExists(absolutePath);
+      if (!exists) {
+        allValid = false;
+        break;
+      }
+      // Test the relative file path (as stored in the declaration) against the regex
+      const matchesPattern = resolvedTestPatterns.regex.some((re) => re.test(file));
+      if (!matchesPattern) {
+        allValid = false;
+        break;
+      }
+    }
+
+    if (allValid) {
+      valid.push(d);
+    } else {
+      invalid.push(d);
+    }
+  }
+
+  return { valid, invalid };
+}

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -100,7 +100,7 @@ export const executionStage: PipelineStage = {
     const initialRef = tddMode ? ((await _executionDeps.captureGitRef(ctx.workdir)) ?? "HEAD") : null;
 
     const inputs = await _executionDeps.assemblePlanInputsFromCtx(ctx);
-    const plan = buildPlanForStrategy(callCtx, ctx.story, ctx.config, ctx.routing.testStrategy, inputs);
+    const plan = await buildPlanForStrategy(callCtx, ctx.story, ctx.config, ctx.routing.testStrategy, inputs);
 
     let planResult: StoryOrchestratorResult;
     try {

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -13,7 +13,6 @@ import type { Iteration } from "@/findings";
 import type { HooksConfig } from "@/hooks/types";
 import type { InteractionChain } from "@/interaction/chain";
 import type { StoryMetrics } from "@/metrics/types";
-import type { TestEditDeclaration } from "@/operations";
 import type { PluginRegistry } from "@/plugins/registry";
 import type { PRD, UserStory } from "@/prd/types";
 import type { DispatchContext } from "@/runtime/dispatch-context";
@@ -182,20 +181,6 @@ export interface PipelineContext extends DispatchContext {
   rectifyAttempt?: number;
   /** ADR-022 Phase 7: prior fix-cycle iterations carried across pipeline retries. */
   autofixPriorIterations?: Iteration[];
-  /**
-   * Pending TEST_EDIT_REASON declarations from the most recent implementer
-   * rectification attempt. Populated by autofix-cycle implementer strategy's
-   * extractApplied; consumed by the cycle's validate() to re-tag fixTarget on
-   * fresh findings. Always cleared after consumption.
-   */
-  testEditDeclarations?: TestEditDeclaration[];
-  /**
-   * Pending mock_structure handoff metadata from the most recent implementer
-   * rectification attempt. Populated by the cycle's validate() callback when
-   * validateMockStructureFiles classifies mock_structure declarations as valid.
-   * Contains file lists and reasoning detail for the TDD orchestrator to use.
-   */
-  pendingMockStructureHandoffs?: { files: string[]; reasonDetail: string }[];
   /** Git HEAD ref captured before agent ran this attempt (FEAT-010: precise smart-runner diff) */
   storyGitRef?: string;
   /** Collected story metrics (set by completionStage) */

--- a/test/integration/pipeline/gating-preservation.test.ts
+++ b/test/integration/pipeline/gating-preservation.test.ts
@@ -122,7 +122,7 @@ describe("AC1: review.checks=['lint'] gates lint-check in, typecheck/semantic/ad
     });
     const inputs = await assemblePlanInputsFromCtx(makeNonTddCtx(config));
     const ctx = makeMockCallContext();
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     const names = plan.phaseNames();
     expect(names).toContain("lint-check");
     expect(names).not.toContain("typecheck-check");
@@ -147,12 +147,12 @@ describe("AC2: review.enabled=false → no review/check phases in plan", () => {
     expect(inputs.adversarialReview).toBeUndefined();
   });
 
-  test("plan phaseNames contains none of lint-check, typecheck-check, semantic-review, adversarial-review", () => {
+  test("plan phaseNames contains none of lint-check, typecheck-check, semantic-review, adversarial-review", async () => {
     const story = makeStory();
     const config = makeNaxConfig({ review: { enabled: false } });
     const inputs = makeMockPlanInputs({ story, config, implementer: { story } });
     const ctx = makeMockCallContext();
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     const names = plan.phaseNames();
     expect(names).not.toContain("lint-check");
     expect(names).not.toContain("typecheck-check");
@@ -249,7 +249,7 @@ describe("AC4-AC5: fix strategy gating in rectification phase", () => {
       execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
     });
     const { ctx, inputs } = makeRectifyInputs(story, config);
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     await plan.run();
     expect(capturedStrategyNames).not.toContain("autofix-implementer");
     expect(capturedStrategyNames).not.toContain("autofix-test-writer");
@@ -265,7 +265,7 @@ describe("AC4-AC5: fix strategy gating in rectification phase", () => {
       execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
     });
     const { ctx, inputs } = makeRectifyInputs(story, config);
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     await plan.run();
     expect(capturedStrategyNames).toContain("mechanical-lintfix");
   });
@@ -281,7 +281,7 @@ describe("AC4-AC5: fix strategy gating in rectification phase", () => {
       execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
     });
     const { ctx, inputs } = makeRectifyInputs(story, config);
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     await plan.run();
     expect(capturedStrategyNames).not.toContain("mechanical-lintfix");
     expect(capturedStrategyNames).toContain("mechanical-formatfix");
@@ -297,7 +297,7 @@ describe("AC4-AC5: fix strategy gating in rectification phase", () => {
       execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
     });
     const { ctx, inputs } = makeRectifyInputs(story, config);
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     await plan.run();
     expect(capturedStrategyNames).not.toContain("mechanical-formatfix");
     expect(capturedStrategyNames).toContain("mechanical-lintfix");
@@ -355,7 +355,7 @@ describe("AC6: mechanical fix fixOp.execute returns early when both commands und
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("AC7: full-path regression scenarios under unified path", () => {
-  test("TDD success path: fresh three-session plan includes test-writer through verifier in order", () => {
+  test("TDD success path: fresh three-session plan includes test-writer through verifier in order", async () => {
     const story = makeStory({ attempts: 0 });
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
@@ -367,7 +367,7 @@ describe("AC7: full-path regression scenarios under unified path", () => {
       fullSuiteGate: { story, workdir: "/tmp/test" },
       verifier: { story },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     expect(plan.phaseNames()).toEqual([
       "test-writer",
       "greenfield-gate",
@@ -377,7 +377,7 @@ describe("AC7: full-path regression scenarios under unified path", () => {
     ]);
   });
 
-  test("partial-progress retry: story.attempts=1 omits test-writer and greenfield-gate", () => {
+  test("partial-progress retry: story.attempts=1 omits test-writer and greenfield-gate", async () => {
     const story = makeStory({ attempts: 1 });
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
@@ -387,7 +387,7 @@ describe("AC7: full-path regression scenarios under unified path", () => {
       fullSuiteGate: { story, workdir: "/tmp/test" },
       verifier: { story },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     const names = plan.phaseNames();
     expect(names).not.toContain("test-writer");
     expect(names).not.toContain("greenfield-gate");
@@ -396,7 +396,7 @@ describe("AC7: full-path regression scenarios under unified path", () => {
     expect(names).toContain("verifier");
   });
 
-  test("non-TDD path: no-test strategy includes implementer and verify-scoped, excludes TDD phases", () => {
+  test("non-TDD path: no-test strategy includes implementer and verify-scoped, excludes TDD phases", async () => {
     const story = makeStory();
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
@@ -405,7 +405,7 @@ describe("AC7: full-path regression scenarios under unified path", () => {
       implementer: { story },
       verifyScoped: { workdir: "/tmp/test", storyId: story.id },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     const names = plan.phaseNames();
     expect(names).toContain("implementer");
     expect(names).toContain("verify-scoped");
@@ -414,7 +414,7 @@ describe("AC7: full-path regression scenarios under unified path", () => {
     expect(names).not.toContain("verifier");
   });
 
-  test("TDD failure-then-fix path: rectification phase included when enabled and inputs present", () => {
+  test("TDD failure-then-fix path: rectification phase included when enabled and inputs present", async () => {
     const story = makeStory({ attempts: 1 });
     const config = makeNaxConfig({
       execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
@@ -427,7 +427,7 @@ describe("AC7: full-path regression scenarios under unified path", () => {
       verifier: { story },
       rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: true },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     expect(plan.phaseNames()).toContain("rectification");
   });
 
@@ -459,7 +459,7 @@ describe("AC7: full-path regression scenarios under unified path", () => {
         verifier: { story },
         rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
       });
-      const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+      const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
       await plan.run();
 
       expect(capturedNames).toContain("mechanical-lintfix");

--- a/test/integration/tdd/story-orchestrator-core.test.ts
+++ b/test/integration/tdd/story-orchestrator-core.test.ts
@@ -95,7 +95,7 @@ describe("buildPlanForStrategy — three-session-tdd", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(true);
@@ -112,7 +112,7 @@ describe("buildPlanForStrategy — three-session-tdd", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(false);
@@ -135,7 +135,7 @@ describe("buildPlanForStrategy — three-session-tdd", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(false);
@@ -161,7 +161,7 @@ describe("buildPlanForStrategy — three-session-tdd", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(true);
@@ -186,7 +186,7 @@ describe("buildPlanForStrategy — three-session-tdd", () => {
 
       const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
       const callCtx = makeMockCallContext({ runtime });
-      const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsWithGreenfield(tmpDir));
+      const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsWithGreenfield(tmpDir));
       const result = await plan.run();
 
       // Greenfield gate detects no test files → pipeline stops
@@ -215,7 +215,7 @@ describe("buildPlanForStrategy — three-session-tdd", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(true);
@@ -259,7 +259,7 @@ describe("test-writer skip on review escalation", () => {
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
     const inputs = makePlanInputsNoGreenfield(storyWithReviewEscalation);
-    const plan = buildPlanForStrategy(callCtx, storyWithReviewEscalation, DEFAULT_CONFIG, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(callCtx, storyWithReviewEscalation, DEFAULT_CONFIG, "three-session-tdd", inputs);
     const result = await plan.run();
 
     expect(result.success).toBe(true);
@@ -293,7 +293,7 @@ describe("test-writer skip on review escalation", () => {
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
     const inputs = makePlanInputsNoGreenfield(freshStory);
-    const plan = buildPlanForStrategy(callCtx, freshStory, DEFAULT_CONFIG, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(callCtx, freshStory, DEFAULT_CONFIG, "three-session-tdd", inputs);
     const result = await plan.run();
 
     expect(result.success).toBe(true);
@@ -335,7 +335,7 @@ describe("test-writer skip on review escalation", () => {
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
     const inputs = makePlanInputsNoGreenfield(storyWithEscalationFailure);
-    const plan = buildPlanForStrategy(callCtx, storyWithEscalationFailure, DEFAULT_CONFIG, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(callCtx, storyWithEscalationFailure, DEFAULT_CONFIG, "three-session-tdd", inputs);
     const result = await plan.run();
 
     expect(result.success).toBe(true);

--- a/test/integration/tdd/story-orchestrator-failureCategory.test.ts
+++ b/test/integration/tdd/story-orchestrator-failureCategory.test.ts
@@ -62,7 +62,7 @@ describe("buildPlanForStrategy — failure scenarios", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(false);
@@ -82,7 +82,7 @@ describe("buildPlanForStrategy — failure scenarios", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(false);
@@ -105,7 +105,7 @@ describe("buildPlanForStrategy — failure scenarios", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(false);
@@ -124,7 +124,7 @@ describe("buildPlanForStrategy — failure scenarios", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(true);
@@ -181,7 +181,7 @@ describe("buildPlanForStrategy — failure scenarios", () => {
       fullSuiteGate: { story, workdir: "/tmp/test" },
       verifier: { story },
     };
-    const plan = buildPlanForStrategy(callCtx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(callCtx, story, config, "three-session-tdd", inputs);
     const result = await plan.run();
 
     expect(result.success).toBe(false);
@@ -225,7 +225,7 @@ describe("buildPlanForStrategy — failure scenarios", () => {
         fullSuiteGate: { story, workdir: tmpDir },
         verifier: { story },
       };
-      const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", inputs);
+      const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", inputs);
       const result = await plan.run();
 
       expect(result.success).toBe(false);

--- a/test/integration/tdd/story-orchestrator-fallback.test.ts
+++ b/test/integration/tdd/story-orchestrator-fallback.test.ts
@@ -83,7 +83,7 @@ describe("buildPlanForStrategy — zero-file greenfield scenarios", () => {
         fullSuiteGate: { story, workdir: tmpDir },
         verifier: { story },
       };
-      const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", inputs);
+      const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", inputs);
       const result = await plan.run();
 
       // Greenfield gate stops the plan; no auto-fallback to lite mode
@@ -115,7 +115,7 @@ describe("buildPlanForStrategy — zero-file greenfield scenarios", () => {
         fullSuiteGate: { story, workdir: tmpDir },
         verifier: { story },
       };
-      const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd-lite", inputs);
+      const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd-lite", inputs);
       const result = await plan.run();
 
       expect(result.success).toBe(false);
@@ -149,7 +149,7 @@ describe("buildPlanForStrategy — zero-file greenfield scenarios", () => {
         fullSuiteGate: { story, workdir: tmpDir },
         verifier: { story },
       };
-      const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", inputs);
+      const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", inputs);
       const result = await plan.run();
 
       expect(result.success).toBe(false);
@@ -194,7 +194,7 @@ describe("buildPlanForStrategy — zero-file greenfield scenarios", () => {
         fullSuiteGate: { story, workdir: tmpDir },
         verifier: { story },
       };
-      const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", inputs);
+      const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", inputs);
       const result = await plan.run();
 
       // Pre-existing tests found → greenfield gate passes → plan succeeds

--- a/test/integration/tdd/story-orchestrator-lite.test.ts
+++ b/test/integration/tdd/story-orchestrator-lite.test.ts
@@ -1,8 +1,7 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../../src/config";
 import { buildPlanForStrategy } from "../../../src/execution/build-plan-for-strategy";
 import type { PlanInputs } from "../../../src/execution/plan-inputs";
-import type { ResolvedTestPatterns } from "../../../src/test-runners";
 import { makeMockCallContext } from "../../helpers/call-context";
 import { makeRuntimeWithFakeAgent } from "../../helpers/runtime";
 import type { UserStory } from "../../../src/prd";
@@ -31,15 +30,6 @@ const story: UserStory = {
   escalations: [],
   attempts: 0,
 };
-
-function defaultPatterns(): ResolvedTestPatterns {
-  return {
-    globs: ["test/**/*.test.ts"],
-    regex: [/\.test\.ts$/],
-    pathspec: [":(exclude)test/**/*.test.ts"],
-    testDirs: ["test/unit", "test/integration"],
-  };
-}
 
 function makePlanInputsNoGreenfield(storyArg: UserStory = story): PlanInputs {
   return {
@@ -74,7 +64,7 @@ describe("buildPlanForStrategy — three-session-tdd-lite strategy", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd-lite", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd-lite", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(true);
@@ -102,7 +92,7 @@ describe("buildPlanForStrategy — three-session-tdd-lite strategy", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(true);
@@ -127,7 +117,7 @@ describe("buildPlanForStrategy — three-session-tdd-lite strategy", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd-lite", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd-lite", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(true);
@@ -144,7 +134,7 @@ describe("buildPlanForStrategy — three-session-tdd-lite strategy", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd-lite", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd-lite", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(false);
@@ -168,7 +158,7 @@ describe("buildPlanForStrategy — three-session-tdd-lite strategy", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd-lite", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd-lite", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect("test-writer" in result.phaseOutputs).toBe(true);

--- a/test/integration/tdd/story-orchestrator-verdict.test.ts
+++ b/test/integration/tdd/story-orchestrator-verdict.test.ts
@@ -116,7 +116,7 @@ describe("buildPlanForStrategy — three-session-tdd verdict", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(true);
@@ -133,7 +133,7 @@ describe("buildPlanForStrategy — three-session-tdd verdict", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(false);
@@ -174,7 +174,7 @@ describe("buildPlanForStrategy — three-session-tdd verdict", () => {
       fullSuiteGate: { story, workdir: "/tmp/test" },
       verifier: { story },
     };
-    const plan = buildPlanForStrategy(callCtx, story, configNoRectification, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(callCtx, story, configNoRectification, "three-session-tdd", inputs);
     const result = await plan.run();
 
     expect(result.success).toBe(true);
@@ -194,7 +194,7 @@ describe("buildPlanForStrategy — three-session-tdd verdict", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.success).toBe(false);
@@ -219,7 +219,7 @@ describe("buildPlanForStrategy — three-session-tdd verdict", () => {
 
     const { runtime } = makeRuntimeWithFakeAgent(agent, { config: DEFAULT_CONFIG });
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
+    const plan = await buildPlanForStrategy(callCtx, story, DEFAULT_CONFIG, "three-session-tdd", makePlanInputsNoGreenfield());
     const result = await plan.run();
 
     expect(result.phaseOutputs).toBeDefined();

--- a/test/unit/execution/build-plan-for-strategy.test.ts
+++ b/test/unit/execution/build-plan-for-strategy.test.ts
@@ -101,21 +101,21 @@ function withRectification(enabled: boolean) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("buildPlanForStrategy — returns ExecutionPlan", () => {
-  test("returns an ExecutionPlan instance", () => {
+  test("returns an ExecutionPlan instance", async () => {
     const story = makeStory();
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
     const inputs = makeNonTddInputs(story);
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     expect(plan).toBeInstanceOf(ExecutionPlan);
   });
 
-  test("plan has phaseNames() method", () => {
+  test("plan has phaseNames() method", async () => {
     const story = makeStory();
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
     const inputs = makeNonTddInputs(story);
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     expect(typeof plan.phaseNames).toBe("function");
     expect(Array.isArray(plan.phaseNames())).toBe(true);
   });
@@ -126,47 +126,47 @@ describe("buildPlanForStrategy — returns ExecutionPlan", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("buildPlanForStrategy — fresh vs retry detection", () => {
-  test("story.attempts=0 (fresh) includes test-writer and greenfield-gate for TDD", () => {
+  test("story.attempts=0 (fresh) includes test-writer and greenfield-gate for TDD", async () => {
     const story = makeStory({ attempts: 0 });
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
     const inputs = makeTddFreshInputs(story);
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     const names = plan.phaseNames();
     expect(names).toContain("test-writer");
     expect(names).toContain("greenfield-gate");
   });
 
-  test("story.attempts=0 full TDD fresh run includes all core phases", () => {
+  test("story.attempts=0 full TDD fresh run includes all core phases", async () => {
     const story = makeStory({ attempts: 0 });
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
     const inputs = makeTddFreshInputs(story);
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     expect(plan.phaseNames()).toEqual(["test-writer", "greenfield-gate", "implementer", "full-suite-gate", "verifier"]);
   });
 
-  test("story.attempts=1 (retry) omits test-writer and greenfield-gate for TDD", () => {
+  test("story.attempts=1 (retry) omits test-writer and greenfield-gate for TDD", async () => {
     const story = makeStory({ attempts: 1 });
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
     const inputs = makeTddRetryInputs(story);
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     const names = plan.phaseNames();
     expect(names).not.toContain("test-writer");
     expect(names).not.toContain("greenfield-gate");
   });
 
-  test("story.attempts=1 retry includes implementer, full-suite-gate, verifier", () => {
+  test("story.attempts=1 retry includes implementer, full-suite-gate, verifier", async () => {
     const story = makeStory({ attempts: 1 });
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
     const inputs = makeTddRetryInputs(story);
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     expect(plan.phaseNames()).toEqual(["implementer", "full-suite-gate", "verifier"]);
   });
 
-  test("story with priorFailures stage=review is treated as retry", () => {
+  test("story with priorFailures stage=review is treated as retry", async () => {
     const story = makeStory({
       attempts: 0,
       priorFailures: [{ attempt: 0, modelTier: "fast", stage: "review", summary: "review failed", timestamp: new Date().toISOString() }],
@@ -174,7 +174,7 @@ describe("buildPlanForStrategy — fresh vs retry detection", () => {
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
     const inputs = makeTddRetryInputs(story);
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     const names = plan.phaseNames();
     expect(names).not.toContain("test-writer");
     expect(names).not.toContain("greenfield-gate");
@@ -186,25 +186,25 @@ describe("buildPlanForStrategy — fresh vs retry detection", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("buildPlanForStrategy — non-TDD single-session", () => {
-  test("no-test strategy includes only implementer", () => {
+  test("no-test strategy includes only implementer", async () => {
     const story = makeStory();
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
     const inputs = makeNonTddInputs(story);
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     expect(plan.phaseNames()).toEqual(["implementer"]);
   });
 
-  test("test-after strategy includes only implementer", () => {
+  test("test-after strategy includes only implementer", async () => {
     const story = makeStory();
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
     const inputs = makeNonTddInputs(story);
-    const plan = buildPlanForStrategy(ctx, story, config, "test-after", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "test-after", inputs);
     expect(plan.phaseNames()).toEqual(["implementer"]);
   });
 
-  test("tdd-simple strategy includes only implementer (single-session, no test-writer/verifier)", () => {
+  test("tdd-simple strategy includes only implementer (single-session, no test-writer/verifier)", async () => {
     // tdd-simple is a SINGLE-SESSION strategy: one agent writes tests AND
     // implements within the same session. It must NOT trigger the three-session
     // orchestration (no test-writer, greenfield-gate, full-suite-gate, or verifier).
@@ -213,7 +213,7 @@ describe("buildPlanForStrategy — non-TDD single-session", () => {
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
     const inputs = makeTddFreshInputs(story); // even with all inputs available
-    const plan = buildPlanForStrategy(ctx, story, config, "tdd-simple", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "tdd-simple", inputs);
     expect(plan.phaseNames()).toEqual(["implementer"]);
   });
 });
@@ -230,18 +230,18 @@ describe("buildPlanForStrategy — three-session TDD strategy variants", () => {
     "three-session-tdd-lite",
   ];
 
-  test.each(tddStrategies)("%s fresh includes full-suite-gate and verifier", (strategy) => {
+  test.each(tddStrategies)("%s fresh includes full-suite-gate and verifier", async (strategy) => {
     const story = makeStory({ attempts: 0 });
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
     const inputs = makeTddFreshInputs(story);
-    const plan = buildPlanForStrategy(ctx, story, config, strategy, inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, strategy, inputs);
     const names = plan.phaseNames();
     expect(names).toContain("full-suite-gate");
     expect(names).toContain("verifier");
   });
 
-  test.each(tddStrategies)("%s fresh omits full-suite-gate and verifier when inputs missing", (strategy) => {
+  test.each(tddStrategies)("%s fresh omits full-suite-gate and verifier when inputs missing", async (strategy) => {
     const story = makeStory({ attempts: 0 });
     const config = makeNaxConfig();
     const ctx = makeMockCallContext();
@@ -253,7 +253,7 @@ describe("buildPlanForStrategy — three-session TDD strategy variants", () => {
       implementer: makeImplementerInput(story),
       // fullSuiteGate and verifier intentionally omitted
     });
-    const plan = buildPlanForStrategy(ctx, story, config, strategy, inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, strategy, inputs);
     const names = plan.phaseNames();
     expect(names).not.toContain("full-suite-gate");
     expect(names).not.toContain("verifier");
@@ -265,7 +265,7 @@ describe("buildPlanForStrategy — three-session TDD strategy variants", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("buildPlanForStrategy — rectification", () => {
-  test("rectification appears last when enabled and inputs.rectification provided", () => {
+  test("rectification appears last when enabled and inputs.rectification provided", async () => {
     const story = makeStory({ attempts: 0 });
     const config = withRectification(true);
     const ctx = makeMockCallContext();
@@ -276,12 +276,12 @@ describe("buildPlanForStrategy — rectification", () => {
         abortOnIncreasingFailures: false,
       },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     const names = plan.phaseNames();
     expect(names[names.length - 1]).toBe("rectification");
   });
 
-  test("rectification omitted when not enabled in config", () => {
+  test("rectification omitted when not enabled in config", async () => {
     const story = makeStory({ attempts: 0 });
     const config = withRectification(false);
     const ctx = makeMockCallContext();
@@ -292,21 +292,21 @@ describe("buildPlanForStrategy — rectification", () => {
         abortOnIncreasingFailures: false,
       },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     expect(plan.phaseNames()).not.toContain("rectification");
   });
 
-  test("rectification omitted when inputs.rectification is undefined even if config enabled", () => {
+  test("rectification omitted when inputs.rectification is undefined even if config enabled", async () => {
     const story = makeStory({ attempts: 0 });
     const config = withRectification(true);
     const ctx = makeMockCallContext();
     const inputs = makeTddFreshInputs(story);
     // No rectification in inputs
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     expect(plan.phaseNames()).not.toContain("rectification");
   });
 
-  test("AC-7: TDD with fullSuiteGate + rectification includes rectification phase", () => {
+  test("AC-7: TDD with fullSuiteGate + rectification includes rectification phase", async () => {
     // When isTdd && inputs.fullSuiteGate, buildPlanForStrategy prepends fullSuiteRectifyStrategy.
     // phaseNames() confirms the rectification phase is wired.
     const story = makeStory({ attempts: 1 }); // retry — no test-writer
@@ -315,18 +315,18 @@ describe("buildPlanForStrategy — rectification", () => {
     const inputs = makeTddRetryInputs(story, {
       rectification: { maxAttempts: 3, strategies: [], abortOnIncreasingFailures: true },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     expect(plan.phaseNames()).toContain("rectification");
   });
 
-  test("AC-7: non-TDD with rectification still includes rectification phase (no gate strategy prepended)", () => {
+  test("AC-7: non-TDD with rectification still includes rectification phase (no gate strategy prepended)", async () => {
     const story = makeStory();
     const config = withRectification(true);
     const ctx = makeMockCallContext();
     const inputs = makeNonTddInputs(story, {
       rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     expect(plan.phaseNames()).toContain("rectification");
   });
 });
@@ -336,40 +336,40 @@ describe("buildPlanForStrategy — rectification", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("buildPlanForStrategy — AC3: new check phase wiring (US-005)", () => {
-  test("AC3: non-TDD + verifyScoped input → plan includes 'verify-scoped' phase", () => {
+  test("AC3: non-TDD + verifyScoped input → plan includes 'verify-scoped' phase", async () => {
     const story = makeStory();
     const ctx = makeMockCallContext();
     const config = makeNaxConfig();
     const inputs = makeNonTddInputs(story, {
       verifyScoped: { workdir: "/tmp/test", storyId: story.id },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     expect(plan.phaseNames()).toContain("verify-scoped");
   });
 
-  test("AC3: lintCheck input → plan includes 'lint-check' phase", () => {
+  test("AC3: lintCheck input → plan includes 'lint-check' phase", async () => {
     const story = makeStory();
     const ctx = makeMockCallContext();
     const config = makeNaxConfig();
     const inputs = makeNonTddInputs(story, {
       lintCheck: { workdir: "/tmp/test", storyId: story.id },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     expect(plan.phaseNames()).toContain("lint-check");
   });
 
-  test("AC3: typecheckCheck input → plan includes 'typecheck-check' phase", () => {
+  test("AC3: typecheckCheck input → plan includes 'typecheck-check' phase", async () => {
     const story = makeStory();
     const ctx = makeMockCallContext();
     const config = makeNaxConfig();
     const inputs = makeNonTddInputs(story, {
       typecheckCheck: { workdir: "/tmp/test", storyId: story.id },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     expect(plan.phaseNames()).toContain("typecheck-check");
   });
 
-  test("AC3: semanticReview input → plan includes 'semantic-review' phase", () => {
+  test("AC3: semanticReview input → plan includes 'semantic-review' phase", async () => {
     const story = makeStory();
     const ctx = makeMockCallContext();
     const config = makeNaxConfig();
@@ -381,11 +381,11 @@ describe("buildPlanForStrategy — AC3: new check phase wiring (US-005)", () => 
         mode: config.review.semantic!.diffMode,
       },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     expect(plan.phaseNames()).toContain("semantic-review");
   });
 
-  test("AC3: adversarialReview input → plan includes 'adversarial-review' phase", () => {
+  test("AC3: adversarialReview input → plan includes 'adversarial-review' phase", async () => {
     const story = makeStory();
     const ctx = makeMockCallContext();
     const config = makeNaxConfig({
@@ -407,22 +407,22 @@ describe("buildPlanForStrategy — AC3: new check phase wiring (US-005)", () => 
         mode: config.review.adversarial!.diffMode,
       },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     expect(plan.phaseNames()).toContain("adversarial-review");
   });
 
-  test("AC3: TDD strategy does NOT receive verifyScoped phase (verifyScoped is non-TDD only)", () => {
+  test("AC3: TDD strategy does NOT receive verifyScoped phase (verifyScoped is non-TDD only)", async () => {
     const story = makeStory({ attempts: 1 });
     const ctx = makeMockCallContext();
     const config = makeNaxConfig();
     const inputs = makeTddRetryInputs(story, {
       verifyScoped: { workdir: "/tmp/test", storyId: story.id },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     expect(plan.phaseNames()).not.toContain("verify-scoped");
   });
 
-  test("AC3: canonical order places post-implementer phases in sequence", () => {
+  test("AC3: canonical order places post-implementer phases in sequence", async () => {
     const story = makeStory();
     const ctx = makeMockCallContext();
     const config = makeNaxConfig({
@@ -453,7 +453,7 @@ describe("buildPlanForStrategy — AC3: new check phase wiring (US-005)", () => 
         mode: config.review.adversarial!.diffMode,
       },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     expect(plan.phaseNames()).toEqual([
       "implementer",
       "verify-scoped",
@@ -518,7 +518,7 @@ describe("buildPlanForStrategy — AC4: fix strategy assembly (US-005)", () => {
     const inputs = makeTddRetryInputs(story, {
       rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     await plan.run();
     expect(capturedStrategyNames).toContain("mechanical-lintfix");
   });
@@ -533,7 +533,7 @@ describe("buildPlanForStrategy — AC4: fix strategy assembly (US-005)", () => {
     const inputs = makeTddRetryInputs(story, {
       rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     await plan.run();
     expect(capturedStrategyNames).toContain("mechanical-formatfix");
   });
@@ -559,7 +559,7 @@ describe("buildPlanForStrategy — AC4: fix strategy assembly (US-005)", () => {
       verifyScoped: { workdir: "/tmp/test", storyId: story.id },
       rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "no-test", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "no-test", inputs);
     await plan.run();
     expect(capturedStrategyNames.length).toBeGreaterThan(0);
   });
@@ -574,7 +574,7 @@ describe("buildPlanForStrategy — AC4: fix strategy assembly (US-005)", () => {
     const inputs = makeTddRetryInputs(story, {
       rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     await plan.run();
     expect(capturedStrategyNames).toContain("autofix-implementer");
   });
@@ -589,7 +589,7 @@ describe("buildPlanForStrategy — AC4: fix strategy assembly (US-005)", () => {
     const inputs = makeTddRetryInputs(story, {
       rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     await plan.run();
     expect(capturedStrategyNames).toContain("autofix-test-writer");
   });
@@ -604,7 +604,7 @@ describe("buildPlanForStrategy — AC4: fix strategy assembly (US-005)", () => {
     const inputs = makeTddRetryInputs(story, {
       rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
     });
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     await plan.run();
     // Only the fullSuiteRectifyStrategy should be present (prepended by buildPlanForStrategy for TDD+gate)
     expect(capturedStrategyNames).not.toContain("mechanical-lintfix");
@@ -619,12 +619,12 @@ describe("buildPlanForStrategy — AC4: fix strategy assembly (US-005)", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("buildPlanForStrategy — canonical phase ordering", () => {
-  test("full TDD fresh run phases appear in canonical order", () => {
+  test("full TDD fresh run phases appear in canonical order", async () => {
     const story = makeStory({ attempts: 0 });
     const config = makeNaxConfig({ review: { enabled: true, checks: ["typecheck", "lint", "test", "build"] as any } });
     const ctx = makeMockCallContext();
     const inputs = makeTddFreshInputs(story);
-    const plan = buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
     expect(plan.phaseNames()).toEqual([
       "test-writer",
       "greenfield-gate",

--- a/test/unit/operations/apply-test-edit-declarations.test.ts
+++ b/test/unit/operations/apply-test-edit-declarations.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, test } from "bun:test";
+import { applyTestEditDeclarations } from "@/operations";
+import type { Finding } from "@/findings";
+import type { TestEditDeclaration } from "@/operations";
+import { makeStory } from "@test/helpers";
+
+// Helper to create a basic source-targeted finding
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    source: "lint",
+    severity: "error",
+    category: "style",
+    message: "A lint error",
+    file: "src/foo.ts",
+    fixTarget: "source",
+    ...overrides,
+  };
+}
+
+describe("applyTestEditDeclarations", () => {
+  describe("prd_contract — valid quote", () => {
+    test("re-tags matching finding from source to test", () => {
+      const story = makeStory({ description: "The function getChangeImpact(repoId: string) must return Promise<ImpactReport>" });
+      const findings: Finding[] = [
+        makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" }),
+      ];
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/foo.test.ts",
+        prdQuote: "getChangeImpact(repoId: string)",
+        testBefore: "old line",
+        testAfter: "new line",
+      };
+
+      const result = applyTestEditDeclarations(findings, [decl], story);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.fixTarget).toBe("test");
+    });
+
+    test("attaches prdContractDeclaration to meta", () => {
+      const story = makeStory({ description: "The function doSomething() is required" });
+      const findings: Finding[] = [
+        makeFinding({ file: "test/unit/bar.test.ts", fixTarget: "source" }),
+      ];
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/bar.test.ts",
+        prdQuote: "doSomething()",
+        testBefore: "before",
+        testAfter: "after",
+      };
+
+      const result = applyTestEditDeclarations(findings, [decl], story);
+
+      expect(result[0]!.meta?.prdContractDeclaration).toEqual(decl);
+    });
+
+    test("preserves existing meta alongside prdContractDeclaration", () => {
+      const story = makeStory({ description: "Call checkHealth() on startup" });
+      const findings: Finding[] = [
+        makeFinding({
+          file: "test/unit/health.test.ts",
+          fixTarget: "source",
+          meta: { existingKey: "existingValue" },
+        }),
+      ];
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/health.test.ts",
+        prdQuote: "checkHealth()",
+        testBefore: "old",
+        testAfter: "new",
+      };
+
+      const result = applyTestEditDeclarations(findings, [decl], story);
+
+      expect(result[0]!.meta?.existingKey).toBe("existingValue");
+      expect(result[0]!.meta?.prdContractDeclaration).toEqual(decl);
+    });
+
+    test("does not re-tag finding with different file", () => {
+      const story = makeStory({ description: "Call processItem() for each entry" });
+      const findings: Finding[] = [
+        makeFinding({ file: "test/unit/other.test.ts", fixTarget: "source" }),
+      ];
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/foo.test.ts",
+        prdQuote: "processItem()",
+        testBefore: "old",
+        testAfter: "new",
+      };
+
+      const result = applyTestEditDeclarations(findings, [decl], story);
+
+      expect(result[0]!.fixTarget).toBe("source");
+      expect(result[0]!.meta?.prdContractDeclaration).toBeUndefined();
+    });
+
+    test("does not re-tag findings that are already fixTarget: test", () => {
+      const story = makeStory({ description: "Use renderWidget() in the UI" });
+      const findings: Finding[] = [
+        makeFinding({ file: "test/unit/widget.test.ts", fixTarget: "test" }),
+      ];
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/widget.test.ts",
+        prdQuote: "renderWidget()",
+        testBefore: "old",
+        testAfter: "new",
+      };
+
+      const result = applyTestEditDeclarations(findings, [decl], story);
+
+      // fixTarget was already "test", meta should still be set
+      expect(result[0]!.fixTarget).toBe("test");
+    });
+  });
+
+  describe("prd_contract — invalid quote", () => {
+    test("appends advisory finding when quote not found in story", () => {
+      const story = makeStory({ description: "This is a story about widgets" });
+      const findings: Finding[] = [
+        makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" }),
+      ];
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/foo.test.ts",
+        prdQuote: "nonExistentFunction()",
+        testBefore: "old",
+        testAfter: "new",
+      };
+
+      const result = applyTestEditDeclarations(findings, [decl], story);
+
+      // Original finding unchanged
+      expect(result[0]!.fixTarget).toBe("source");
+      // Advisory appended
+      expect(result).toHaveLength(2);
+      const advisory = result[1]!;
+      expect(advisory.source).toBe("autofix");
+      expect(advisory.severity).toBe("warning");
+      expect(advisory.category).toBe("prd_quote_mismatch");
+      expect(advisory.message).toContain("test/unit/foo.test.ts");
+      expect(advisory.fixTarget).toBe("source");
+    });
+
+    test("does not re-tag finding when quote is invalid", () => {
+      const story = makeStory({ description: "A story without the quote" });
+      const findings: Finding[] = [
+        makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" }),
+      ];
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/foo.test.ts",
+        prdQuote: "missingFunction()",
+        testBefore: "old",
+        testAfter: "new",
+      };
+
+      const result = applyTestEditDeclarations(findings, [decl], story);
+
+      expect(result[0]!.fixTarget).toBe("source");
+    });
+  });
+
+  describe("lint_only", () => {
+    test("passthrough — no changes to findings", () => {
+      const story = makeStory();
+      const findings: Finding[] = [
+        makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" }),
+      ];
+      const decl: TestEditDeclaration = {
+        reason: "lint_only",
+        file: "test/unit/foo.test.ts",
+        finding: "no-non-null-assertion",
+      };
+
+      const result = applyTestEditDeclarations(findings, [decl], story);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.fixTarget).toBe("source");
+    });
+  });
+
+  describe("sibling_scope", () => {
+    test("passthrough — no changes to findings", () => {
+      const story = makeStory();
+      const findings: Finding[] = [
+        makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" }),
+      ];
+      const decl: TestEditDeclaration = {
+        reason: "sibling_scope",
+        file: "test/unit/other.test.ts",
+        finding: "TS2304",
+      };
+
+      const result = applyTestEditDeclarations(findings, [decl], story);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]!.fixTarget).toBe("source");
+    });
+  });
+
+  describe("invalidMockStructure", () => {
+    test("appends advisory finding with category mock_structure_invalid_files", () => {
+      const story = makeStory();
+      const findings: Finding[] = [makeFinding()];
+      const invalidDecl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/mock.test.ts",
+        files: ["test/unit/mock.test.ts", "test/unit/other.test.ts"],
+        reasonDetail: "Mock setup is wrong",
+      };
+
+      const result = applyTestEditDeclarations(findings, [], story, [invalidDecl]);
+
+      expect(result).toHaveLength(2);
+      const advisory = result[1]!;
+      expect(advisory.source).toBe("autofix");
+      expect(advisory.severity).toBe("warning");
+      expect(advisory.category).toBe("mock_structure_invalid_files");
+      expect(advisory.message).toContain("test/unit/mock.test.ts");
+      expect(advisory.message).toContain("test/unit/other.test.ts");
+      expect(advisory.fixTarget).toBe("source");
+    });
+
+    test("includes file names in advisory message", () => {
+      const story = makeStory();
+      const invalidDecl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/a.test.ts",
+        files: ["test/unit/a.test.ts", "test/unit/b.test.ts"],
+        reasonDetail: "needs mock",
+      };
+
+      const result = applyTestEditDeclarations([], [], story, [invalidDecl]);
+
+      expect(result[0]!.message).toContain("test/unit/a.test.ts");
+      expect(result[0]!.message).toContain("test/unit/b.test.ts");
+    });
+
+    test("uses d.file when d.files is absent", () => {
+      const story = makeStory();
+      const invalidDecl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/only.test.ts",
+        reasonDetail: "only file",
+      };
+
+      const result = applyTestEditDeclarations([], [], story, [invalidDecl]);
+
+      expect(result[0]!.message).toContain("test/unit/only.test.ts");
+    });
+  });
+
+  describe("immutability", () => {
+    test("does not mutate input findings array", () => {
+      const story = makeStory({ description: "Call doWork() somewhere" });
+      const original: Finding[] = [
+        makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" }),
+      ];
+      const originalRef = original[0];
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/foo.test.ts",
+        prdQuote: "doWork()",
+        testBefore: "old",
+        testAfter: "new",
+      };
+
+      const result = applyTestEditDeclarations(original, [decl], story);
+
+      // Input array not mutated
+      expect(original).toHaveLength(1);
+      expect(original[0]).toBe(originalRef);
+      expect(original[0]!.fixTarget).toBe("source");
+      // Result is a different array
+      expect(result).not.toBe(original);
+    });
+
+    test("does not mutate input finding objects", () => {
+      const story = makeStory({ description: "Call doWork() somewhere" });
+      const finding = makeFinding({ file: "test/unit/foo.test.ts", fixTarget: "source" });
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/foo.test.ts",
+        prdQuote: "doWork()",
+        testBefore: "old",
+        testAfter: "new",
+      };
+
+      applyTestEditDeclarations([finding], [decl], story);
+
+      // Original finding object not mutated
+      expect(finding.fixTarget).toBe("source");
+      expect(finding.meta?.prdContractDeclaration).toBeUndefined();
+    });
+  });
+});

--- a/test/unit/operations/autofix-implementer-strategy.test.ts
+++ b/test/unit/operations/autofix-implementer-strategy.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import type { Finding } from "@/findings";
 import type { FixCycleContext } from "@/findings/cycle-types";
-import { makeAutofixImplementerStrategy } from "@/operations";
+import { makeAutofixImplementerStrategy, makeDeclarationSink } from "@/operations";
+import type { AutofixImplementerOutput } from "@/operations/autofix-implementer";
 import { makeNaxConfig, makeStory } from "@test/helpers";
 
 const mockCtx = {} as any;
+
+function makeSink() {
+  return makeDeclarationSink();
+}
 
 function makeFinding(overrides: Partial<Finding> = {}): Finding {
   return {
@@ -19,53 +24,53 @@ function makeFinding(overrides: Partial<Finding> = {}): Finding {
 
 describe("makeAutofixImplementerStrategy", () => {
   test("name is autofix-implementer", () => {
-    const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig());
+    const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink());
     expect(strategy.name).toBe("autofix-implementer");
   });
 
   test("fixOp name is autofix-implementer", () => {
-    const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig());
+    const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink());
     expect(strategy.fixOp.name).toBe("autofix-implementer");
   });
 
   test("maxAttempts is a positive number", () => {
-    const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig());
+    const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink());
     expect(strategy.maxAttempts).toBeGreaterThan(0);
   });
 
   describe("AC3: appliesTo predicate — source includes list", () => {
     test("AC3: returns true when fixTarget=source and source=lint", () => {
-      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "source", source: "lint" });
       expect(strategy.appliesTo(finding)).toBe(true);
     });
 
     test("AC3: returns true when fixTarget=source and source=typecheck", () => {
-      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "source", source: "typecheck" });
       expect(strategy.appliesTo(finding)).toBe(true);
     });
 
     test("AC3: returns true when fixTarget=source and source=semantic-review", () => {
-      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "source", source: "semantic-review" });
       expect(strategy.appliesTo(finding)).toBe(true);
     });
 
     test("AC3: returns false when fixTarget=test", () => {
-      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "test", source: "lint" });
       expect(strategy.appliesTo(finding)).toBe(false);
     });
 
     test("AC3: returns false when source=test-runner", () => {
-      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "source", source: "test-runner" });
       expect(strategy.appliesTo(finding)).toBe(false);
     });
 
     test("AC3: returns false when source is not in allowed list (adversarial-review with fixTarget=source)", () => {
-      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "source", source: "adversarial-review" });
       expect(strategy.appliesTo(finding)).toBe(false);
     });
@@ -73,7 +78,7 @@ describe("makeAutofixImplementerStrategy", () => {
 
   test("AC2.3: buildInput converts semantic finding to ReviewCheckResult", () => {
     const story = makeStory();
-    const strategy = makeAutofixImplementerStrategy(story, makeNaxConfig());
+    const strategy = makeAutofixImplementerStrategy(story, makeNaxConfig(), makeSink());
     const semanticFinding: Finding = {
       source: "semantic-review",
       severity: "error",
@@ -86,5 +91,82 @@ describe("makeAutofixImplementerStrategy", () => {
     expect(input.failedChecks).toHaveLength(1);
     expect(input.failedChecks[0]?.check).toBe("semantic");
     expect(input.failedChecks[0]?.findings).toEqual([semanticFinding]);
+  });
+
+  describe("extractApplied — sink partitioning", () => {
+    function makeOutput(
+      declarations: AutofixImplementerOutput["testEditDeclarations"],
+      unresolvedReason?: string,
+    ): AutofixImplementerOutput {
+      return {
+        applied: true,
+        testEditDeclarations: declarations,
+        ...(unresolvedReason !== undefined ? { unresolvedReason } : {}),
+      };
+    }
+
+    test("pushes mock_structure declarations to sink.mockHandoffs", () => {
+      const sink = makeSink();
+      const strategy = makeAutofixImplementerStrategy(makeStory(), makeNaxConfig(), sink);
+      const output = makeOutput([
+        { reason: "mock_structure", file: "test/foo.test.ts", files: ["test/foo.test.ts", "test/bar.test.ts"], reasonDetail: "needs mock restructure" },
+      ]);
+      strategy.extractApplied!(output, [], {} as FixCycleContext);
+      expect(sink.mockHandoffs).toHaveLength(1);
+      expect(sink.mockHandoffs[0]).toEqual({ files: ["test/foo.test.ts", "test/bar.test.ts"], reasonDetail: "needs mock restructure" });
+      expect(sink.testEdits).toHaveLength(0);
+    });
+
+    test("pushes non-mock_structure declarations to sink.testEdits", () => {
+      const sink = makeSink();
+      const strategy = makeAutofixImplementerStrategy(makeStory(), makeNaxConfig(), sink);
+      const lintDecl = { reason: "lint_only" as const, file: "test/foo.test.ts", finding: "some lint" };
+      const prdDecl = { reason: "prd_contract" as const, file: "test/bar.test.ts" };
+      const output = makeOutput([lintDecl, prdDecl]);
+      strategy.extractApplied!(output, [], {} as FixCycleContext);
+      expect(sink.testEdits).toHaveLength(2);
+      expect(sink.mockHandoffs).toHaveLength(0);
+    });
+
+    test("with empty declarations: sink unchanged", () => {
+      const sink = makeSink();
+      const strategy = makeAutofixImplementerStrategy(makeStory(), makeNaxConfig(), sink);
+      const output = makeOutput([]);
+      strategy.extractApplied!(output, [], {} as FixCycleContext);
+      expect(sink.testEdits).toHaveLength(0);
+      expect(sink.mockHandoffs).toHaveLength(0);
+    });
+
+    test("returns summary from unresolvedReason", () => {
+      const sink = makeSink();
+      const strategy = makeAutofixImplementerStrategy(makeStory(), makeNaxConfig(), sink);
+      const output = makeOutput([], "reviewer contradiction");
+      const result = strategy.extractApplied!(output, [], {} as FixCycleContext);
+      expect(result.summary).toBe("reviewer contradiction");
+      expect(result.unresolved).toBe("reviewer contradiction");
+    });
+
+    test("returns empty summary when no unresolvedReason", () => {
+      const sink = makeSink();
+      const strategy = makeAutofixImplementerStrategy(makeStory(), makeNaxConfig(), sink);
+      const output = makeOutput([]);
+      const result = strategy.extractApplied!(output, [], {} as FixCycleContext);
+      expect(result.summary).toBe("");
+      expect(result.unresolved).toBeUndefined();
+    });
+
+    test("partitions mixed declarations correctly", () => {
+      const sink = makeSink();
+      const strategy = makeAutofixImplementerStrategy(makeStory(), makeNaxConfig(), sink);
+      const output = makeOutput([
+        { reason: "mock_structure", file: "test/a.test.ts", files: ["test/a.test.ts"], reasonDetail: "mock reason" },
+        { reason: "lint_only", file: "test/b.test.ts", finding: "lint error" },
+        { reason: "mock_structure", file: "test/c.test.ts", files: ["test/c.test.ts"], reasonDetail: "another mock reason" },
+        { reason: "prd_contract", file: "test/d.test.ts" },
+      ]);
+      strategy.extractApplied!(output, [], {} as FixCycleContext);
+      expect(sink.mockHandoffs).toHaveLength(2);
+      expect(sink.testEdits).toHaveLength(2);
+    });
   });
 });

--- a/test/unit/operations/autofix-test-writer-strategy.test.ts
+++ b/test/unit/operations/autofix-test-writer-strategy.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import type { Finding } from "@/findings";
 import type { FixCycleContext } from "@/findings/cycle-types";
-import { makeAutofixTestWriterStrategy } from "@/operations";
+import { makeAutofixTestWriterStrategy, makeDeclarationSink } from "@/operations";
 import { makeNaxConfig, makeStory } from "@test/helpers";
 
 const mockCtx = {} as any;
+
+function makeSink() {
+  return makeDeclarationSink();
+}
 
 function makeFinding(overrides: Partial<Finding> = {}): Finding {
   return {
@@ -19,62 +23,71 @@ function makeFinding(overrides: Partial<Finding> = {}): Finding {
 
 describe("makeAutofixTestWriterStrategy", () => {
   test("name is autofix-test-writer", () => {
-    const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
+    const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig(), makeSink());
     expect(strategy.name).toBe("autofix-test-writer");
   });
 
   test("fixOp name is autofix-test-writer", () => {
-    const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
+    const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig(), makeSink());
     expect(strategy.fixOp.name).toBe("autofix-test-writer");
   });
 
   test("maxAttempts is a positive number", () => {
-    const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
+    const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig(), makeSink());
     expect(strategy.maxAttempts).toBeGreaterThan(0);
   });
 
   describe("AC4: appliesTo predicate — test-targeted findings", () => {
     test("AC4: returns true when fixTarget=test", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "test", source: "lint" });
       expect(strategy.appliesTo(finding)).toBe(true);
     });
 
     test("AC4: returns true when source=adversarial-review", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "source", source: "adversarial-review" });
       expect(strategy.appliesTo(finding)).toBe(true);
     });
 
     test("AC4: returns true when fixTarget=test and source=adversarial-review", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "test", source: "adversarial-review" });
       expect(strategy.appliesTo(finding)).toBe(true);
     });
 
     test("AC4: returns false when fixTarget=source and source is not adversarial-review (lint)", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "source", source: "lint" });
       expect(strategy.appliesTo(finding)).toBe(false);
     });
 
     test("AC4: returns false when fixTarget=source and source=typecheck", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "source", source: "typecheck" });
       expect(strategy.appliesTo(finding)).toBe(false);
     });
 
     test("AC4: returns false when fixTarget=source and source=semantic-review", () => {
-      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig());
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig(), makeSink());
       const finding = makeFinding({ fixTarget: "source", source: "semantic-review" });
       expect(strategy.appliesTo(finding)).toBe(false);
+    });
+
+    test("AC4: returns true when sink.mockHandoffs is non-empty (even source finding)", () => {
+      const sink = makeSink();
+      sink.mockHandoffs.push({ files: ["test/foo.test.ts"], reasonDetail: "mock reason" });
+      const strategy = makeAutofixTestWriterStrategy(mockCtx, makeNaxConfig(), sink);
+      // A source finding that would normally not match
+      const finding = makeFinding({ fixTarget: "source", source: "lint" });
+      expect(strategy.appliesTo(finding)).toBe(true);
     });
   });
 
   test("AC2.4: buildInput converts adversarial finding to ReviewCheckResult", () => {
     const story = makeStory();
     const config = makeNaxConfig();
-    const strategy = makeAutofixTestWriterStrategy(story, config);
+    const strategy = makeAutofixTestWriterStrategy(story, config, makeSink());
     const adversarialFinding: Finding = {
       source: "adversarial-review",
       severity: "error",
@@ -87,5 +100,56 @@ describe("makeAutofixTestWriterStrategy", () => {
     expect(input.failedChecks).toHaveLength(1);
     expect(input.failedChecks[0]?.check).toBe("adversarial");
     expect(input.failedChecks[0]?.findings).toEqual([adversarialFinding]);
+  });
+
+  describe("buildInput — mock-restructure mode", () => {
+    test("returns mode=mock-restructure when sink.mockHandoffs is populated", () => {
+      const sink = makeSink();
+      sink.mockHandoffs.push({ files: ["test/foo.test.ts", "test/bar.test.ts"], reasonDetail: "mock reason A" });
+      const strategy = makeAutofixTestWriterStrategy(makeStory(), makeNaxConfig(), sink);
+      const input = strategy.buildInput([], [], {} as FixCycleContext);
+      expect(input.mode).toBe("mock-restructure");
+    });
+
+    test("dedupes files across all handoff entries", () => {
+      const sink = makeSink();
+      sink.mockHandoffs.push({ files: ["test/foo.test.ts", "test/shared.test.ts"], reasonDetail: "reason A" });
+      sink.mockHandoffs.push({ files: ["test/bar.test.ts", "test/shared.test.ts"], reasonDetail: "reason B" });
+      const strategy = makeAutofixTestWriterStrategy(makeStory(), makeNaxConfig(), sink);
+      const input = strategy.buildInput([], [], {} as FixCycleContext);
+      expect(input.handoffFiles).toBeDefined();
+      const files = input.handoffFiles!;
+      const unique = new Set(files);
+      expect(files.length).toBe(unique.size);
+      expect(files).toContain("test/foo.test.ts");
+      expect(files).toContain("test/bar.test.ts");
+      expect(files).toContain("test/shared.test.ts");
+    });
+
+    test("joins reasonDetail with newline separator", () => {
+      const sink = makeSink();
+      sink.mockHandoffs.push({ files: ["test/a.test.ts"], reasonDetail: "reason A" });
+      sink.mockHandoffs.push({ files: ["test/b.test.ts"], reasonDetail: "reason B" });
+      const strategy = makeAutofixTestWriterStrategy(makeStory(), makeNaxConfig(), sink);
+      const input = strategy.buildInput([], [], {} as FixCycleContext);
+      expect(input.handoffReason).toBe("reason A\n---\nreason B");
+    });
+
+    test("clears sink.mockHandoffs after draining", () => {
+      const sink = makeSink();
+      sink.mockHandoffs.push({ files: ["test/foo.test.ts"], reasonDetail: "reason" });
+      const strategy = makeAutofixTestWriterStrategy(makeStory(), makeNaxConfig(), sink);
+      strategy.buildInput([], [], {} as FixCycleContext);
+      expect(sink.mockHandoffs).toHaveLength(0);
+    });
+
+    test("uses default mode when sink is empty", () => {
+      const sink = makeSink();
+      const strategy = makeAutofixTestWriterStrategy(makeStory(), makeNaxConfig(), sink);
+      const input = strategy.buildInput([], [], {} as FixCycleContext);
+      expect(input.mode).toBeUndefined();
+      expect(input.handoffFiles).toBeUndefined();
+      expect(input.handoffReason).toBeUndefined();
+    });
   });
 });

--- a/test/unit/operations/validate-mock-structure-files.test.ts
+++ b/test/unit/operations/validate-mock-structure-files.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "bun:test";
+import { validateMockStructureFiles } from "@/operations";
+import type { TestEditDeclaration } from "@/operations";
+import type { ResolvedTestPatterns } from "@/test-runners";
+
+// Mock test patterns that match *.test.ts files
+const testPatterns: ResolvedTestPatterns = {
+  regex: [/\.test\.ts$/],
+  globs: ["**/*.test.ts"],
+  pathspec: [":(exclude)src/**"],
+  testDirs: ["test/unit"],
+};
+
+// Helper to create a file existence mock
+function makeFileExists(existingFiles: string[]): (path: string) => Promise<boolean> {
+  const set = new Set(existingFiles);
+  return (path: string) => Promise.resolve(set.has(path));
+}
+
+describe("validateMockStructureFiles", () => {
+  describe("non-mock_structure declarations", () => {
+    test("prd_contract declaration always goes to valid", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "prd_contract",
+        file: "test/unit/foo.test.ts",
+        prdQuote: "doSomething()",
+        testBefore: "old",
+        testAfter: "new",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles(
+        [decl],
+        testPatterns,
+        "/repo",
+        { fileExists: makeFileExists([]) },
+      );
+
+      expect(valid).toHaveLength(1);
+      expect(invalid).toHaveLength(0);
+      expect(valid[0]).toBe(decl);
+    });
+
+    test("lint_only declaration always goes to valid", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "lint_only",
+        file: "test/unit/foo.test.ts",
+        finding: "no-non-null-assertion",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles(
+        [decl],
+        testPatterns,
+        "/repo",
+        { fileExists: makeFileExists([]) },
+      );
+
+      expect(valid).toHaveLength(1);
+      expect(invalid).toHaveLength(0);
+    });
+
+    test("sibling_scope declaration always goes to valid", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "sibling_scope",
+        file: "test/unit/foo.test.ts",
+        finding: "TS2304",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles(
+        [decl],
+        testPatterns,
+        "/repo",
+        { fileExists: makeFileExists([]) },
+      );
+
+      expect(valid).toHaveLength(1);
+      expect(invalid).toHaveLength(0);
+    });
+  });
+
+  describe("mock_structure declarations", () => {
+    test("goes to valid when all files exist AND match test pattern", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/foo.test.ts",
+        files: ["test/unit/foo.test.ts", "test/unit/bar.test.ts"],
+        reasonDetail: "mock setup",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles(
+        [decl],
+        testPatterns,
+        "/repo",
+        {
+          fileExists: makeFileExists([
+            "/repo/test/unit/foo.test.ts",
+            "/repo/test/unit/bar.test.ts",
+          ]),
+        },
+      );
+
+      expect(valid).toHaveLength(1);
+      expect(invalid).toHaveLength(0);
+      expect(valid[0]).toBe(decl);
+    });
+
+    test("goes to invalid when a file does not exist on disk", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/foo.test.ts",
+        files: ["test/unit/foo.test.ts", "test/unit/missing.test.ts"],
+        reasonDetail: "mock setup",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles(
+        [decl],
+        testPatterns,
+        "/repo",
+        {
+          fileExists: makeFileExists([
+            "/repo/test/unit/foo.test.ts",
+            // missing.test.ts does NOT exist
+          ]),
+        },
+      );
+
+      expect(valid).toHaveLength(0);
+      expect(invalid).toHaveLength(1);
+      expect(invalid[0]).toBe(decl);
+    });
+
+    test("goes to invalid when file exists but does not match test pattern", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "src/utils.ts",
+        files: ["src/utils.ts"],
+        reasonDetail: "not a test file",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles(
+        [decl],
+        testPatterns,
+        "/repo",
+        {
+          fileExists: makeFileExists(["/repo/src/utils.ts"]),
+        },
+      );
+
+      expect(valid).toHaveLength(0);
+      expect(invalid).toHaveLength(1);
+      expect(invalid[0]).toBe(decl);
+    });
+
+    test("uses d.file when d.files is absent", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/only.test.ts",
+        reasonDetail: "only one file",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles(
+        [decl],
+        testPatterns,
+        "/repo",
+        {
+          fileExists: makeFileExists(["/repo/test/unit/only.test.ts"]),
+        },
+      );
+
+      expect(valid).toHaveLength(1);
+      expect(invalid).toHaveLength(0);
+    });
+
+    test("single file that fails existence check → invalid", async () => {
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/gone.test.ts",
+        files: ["test/unit/gone.test.ts"],
+        reasonDetail: "deleted file",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles(
+        [decl],
+        testPatterns,
+        "/repo",
+        { fileExists: makeFileExists([]) },
+      );
+
+      expect(valid).toHaveLength(0);
+      expect(invalid).toHaveLength(1);
+    });
+
+    test("tests relative path against pattern (not absolute)", async () => {
+      // /repo/test/unit/foo.test.ts — absolute path should NOT be tested against regex,
+      // only relative path "test/unit/foo.test.ts" should be
+      const patterns: ResolvedTestPatterns = {
+        regex: [/^test\/unit\/.+\.test\.ts$/],
+        globs: [],
+        pathspec: [],
+        testDirs: ["test/unit"],
+      };
+
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/foo.test.ts",
+        files: ["test/unit/foo.test.ts"],
+        reasonDetail: "relative path check",
+      };
+
+      const { valid } = await validateMockStructureFiles(
+        [decl],
+        patterns,
+        "/repo",
+        { fileExists: makeFileExists(["/repo/test/unit/foo.test.ts"]) },
+      );
+
+      expect(valid).toHaveLength(1);
+    });
+
+    test("mixes valid and invalid declarations correctly", async () => {
+      const validDecl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/good.test.ts",
+        files: ["test/unit/good.test.ts"],
+        reasonDetail: "valid one",
+      };
+      const invalidDecl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/bad.test.ts",
+        files: ["test/unit/bad.test.ts"],
+        reasonDetail: "invalid one",
+      };
+
+      const { valid, invalid } = await validateMockStructureFiles(
+        [validDecl, invalidDecl],
+        testPatterns,
+        "/repo",
+        {
+          fileExists: makeFileExists(["/repo/test/unit/good.test.ts"]),
+          // bad.test.ts does not exist
+        },
+      );
+
+      expect(valid).toHaveLength(1);
+      expect(invalid).toHaveLength(1);
+      expect(valid[0]).toBe(validDecl);
+      expect(invalid[0]).toBe(invalidDecl);
+    });
+  });
+
+  describe("injectable deps", () => {
+    test("uses injectable fileExists (no real disk I/O)", async () => {
+      let callCount = 0;
+      const customFileExists = (path: string): Promise<boolean> => {
+        callCount++;
+        return Promise.resolve(path.includes("good"));
+      };
+
+      const decl: TestEditDeclaration = {
+        reason: "mock_structure",
+        file: "test/unit/good.test.ts",
+        files: ["test/unit/good.test.ts"],
+        reasonDetail: "injectable test",
+      };
+
+      await validateMockStructureFiles([decl], testPatterns, "/repo", {
+        fileExists: customFileExists,
+      });
+
+      expect(callCount).toBeGreaterThan(0);
+    });
+  });
+});

--- a/test/unit/tdd/orchestrator-totals.test.ts
+++ b/test/unit/tdd/orchestrator-totals.test.ts
@@ -145,7 +145,7 @@ describe("buildPlanForStrategy — cost + duration aggregation", () => {
     });
 
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, config, "three-session-tdd", makePlanInputsNoGreenfield(story, config));
+    const plan = await buildPlanForStrategy(callCtx, story, config, "three-session-tdd", makePlanInputsNoGreenfield(story, config));
     const result = await plan.run();
 
     // totalCostUsd should be non-negative (may be 0 if agent doesn't emit costs in test mode)
@@ -168,7 +168,7 @@ describe("buildPlanForStrategy — cost + duration aggregation", () => {
     });
 
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, config, "three-session-tdd", makePlanInputsNoGreenfield(story, config));
+    const plan = await buildPlanForStrategy(callCtx, story, config, "three-session-tdd", makePlanInputsNoGreenfield(story, config));
     const result = await plan.run();
 
     expect(typeof result.durationMs).toBe("number");
@@ -190,7 +190,7 @@ describe("buildPlanForStrategy — cost + duration aggregation", () => {
     });
 
     const callCtx = makeMockCallContext({ runtime });
-    const plan = buildPlanForStrategy(callCtx, story, config, "three-session-tdd", makePlanInputsNoGreenfield(story, config));
+    const plan = await buildPlanForStrategy(callCtx, story, config, "three-session-tdd", makePlanInputsNoGreenfield(story, config));
     const result = await plan.run();
 
     // phaseCosts should have entries for at least the executed phases


### PR DESCRIPTION
## Summary

Restores the four-step TEST\_EDIT\_REASON handoff chain (implementer → post-validate → test-writer) that was broken when `autofix-cycle.ts` was deleted in commit `f38aedf2`. The fix is spec-driven from `docs/specs/2026-05-26-rectifier-handoff-restoration.md`.

## Root Cause

The old `PipelineContext` fields (`testEditDeclarations`, `pendingMockStructureHandoffs`) carried declaration state across the rectification cycle. When the autofix-cycle layer was removed, these fields were deleted from `PipelineContext` but the wiring that populated them (in `AutofixImplementerStrategy.extractApplied`) and consumed them (in the test-writer strategy and postValidate) was never re-implemented.

## Changes (B1–B8)

### B1 — `DeclarationSink` (new: `src/operations/declaration-sink.ts`)
Mutable shared state scoped to one rectification closure. Factory `makeDeclarationSink()` returns `{ testEdits: TestEditDeclaration[], mockHandoffs: { files, reasonDetail }[] }`. Safe because single-threaded, one instance per cycle.

### B2 — `applyTestEditDeclarations` (new: `src/operations/apply-test-edit-declarations.ts`)
Pure function. Re-tags `source` findings → `test` fixTarget for `prd_contract` declarations (validates PRD quote, attaches `meta.prdContractDeclaration`). Invalid quotes emit advisory warning findings. Appends `mock_structure_invalid_files` advisory findings for invalid mock declarations.

### B3 — `validateMockStructureFiles` (new: `src/operations/validate-mock-structure-files.ts`)
Async partitioner for `mock_structure` declarations. Each file must (a) exist on disk via `Bun.file(p).exists()` and (b) match at least one `resolvedTestPatterns.regex` (tested against the relative path). Non-mock\_structure declarations pass through to `valid` unchanged. Injectable `fileExists` dep for testability.

### B4 — `makeAutofixImplementerStrategy` updated (`src/operations/autofix-implementer-strategy.ts`)
- `sink: DeclarationSink` is now a **required** third parameter (no default — prevents silent separate-sink foot-gun)
- `extractApplied`: partitions `output.testEditDeclarations`: `mock_structure` with files+reasonDetail → `sink.mockHandoffs`; others → `sink.testEdits`

### B5 — `makeAutofixTestWriterStrategy` updated (`src/operations/autofix-test-writer-strategy.ts`)
- `sink: DeclarationSink` required third parameter
- `appliesTo`: adds `|| sink.mockHandoffs.length > 0` — triggers test-writer when mock handoffs are pending
- `buildInput`: when handoffs present, drains via `splice(0)`, deduplicates files with a Set, joins reasonDetails with ```\n---\n```, returns `mode: "mock-restructure"`

### B6 — `RectificationPhaseOptions.postValidate` (modified: `src/execution/story-orchestrator.ts`)
Added optional `postValidate?: (findings, ctx) => Promise<Finding[]>` to `RectificationPhaseOptions`. Called at the end of the validate closure in `runRectification` after each cycle pass.

### B7 — `buildPlanForStrategy` wiring (modified: `src/execution/build-plan-for-strategy.ts`)
- Function is now `async` (eagerly resolves test-file patterns at plan-build time)
- Creates ONE shared `sink = makeDeclarationSink()` passed to both implementer and test-writer factories
- Resolves `resolvedTestPatterns = await resolveTestFilePatterns(config, ctx.packageDir, story.workdir)` once
- Builds `postValidate` closure: wraps pending mockHandoffs as declarations, calls `validateMockStructureFiles`, updates sink, calls `applyTestEditDeclarations` with valid+testEdits+invalid

### B8 — Barrel exports and call-site updates
- `src/operations/index.ts`: exports all new symbols
- `src/pipeline/stages/execution.ts`: adds `await` to `buildPlanForStrategy` call
- `src/pipeline/types.ts`: removes deleted `testEditDeclarations` and `pendingMockStructureHandoffs` fields
- `src/findings/types.ts`: adds `"autofix"` to `FindingSource` union (for advisory findings)
- All test files calling `buildPlanForStrategy`: added `await` + `async` function declarations

## Tests

- **New**: `test/unit/operations/apply-test-edit-declarations.test.ts` (14 cases)
- **New**: `test/unit/operations/validate-mock-structure-files.test.ts` (11 cases)
- **Updated**: `test/unit/operations/autofix-implementer-strategy.test.ts` — sink injection, extractApplied partitioning
- **Updated**: `test/unit/operations/autofix-test-writer-strategy.test.ts` — appliesTo-with-handoffs, buildInput-drains
- **Updated**: 6 integration test files — async buildPlanForStrategy call-sites

## Verification

```
bun run lint     ✅
bun run typecheck ✅
bun run test     ✅
```

## Spec Reference

`docs/specs/2026-05-26-rectifier-handoff-restoration.md` — Fix B (B1–B8)