### PR TITLE
fix(rectifier): prompt count + Exception 4 wording + broken non-TDD strip (Fix C)

### DIFF
--- a/src/prompts/builders/rectifier-builder-helpers.ts
+++ b/src/prompts/builders/rectifier-builder-helpers.ts
@@ -14,25 +14,9 @@ interface CheckErrorFormatOptions {
   blockingThreshold?: "error" | "warning" | "info";
 }
 
-/**
- * Reviewer contradiction escape hatch (REVIEW-003).
- *
- * Appended to all rectification prompts so the implementer can signal
- * when two findings cannot both be satisfied. The autofix stage detects
- * "UNRESOLVED: <explanation>" in the agent output and escalates instead
- * of retrying — avoiding an infinite loop on an unresolvable conflict.
- */
-export const CONTRADICTION_ESCAPE_HATCH = `
-If two findings in this list contradict each other and you cannot satisfy both, do not guess.
-Emit fixes for defects you can resolve, then output a line in this exact format:
-UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+// ─── Individual exception constants ───────────────────────────────────────────
 
-## Test-file edit exceptions
-
-The "do not modify test files" rule has three narrow escape valves. Each requires a
-declaration in your output. Outside these three cases the rule is absolute.
-
-### Exception 1 — Lint-only edit
+const EXCEPTION_1_LINT_ONLY = `### Exception 1 — Lint-only edit
 
 You MAY edit a test file ONLY when ALL of the following hold:
 - The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
@@ -48,9 +32,9 @@ TEST_EDIT_REASON: lint_only
 FILE: <test file path>
 FINDING: <lint rule or message verbatim>
 CHANGE: <before line> → <after line>
-\`\`\`
+\`\`\``;
 
-### Exception 2 — PRD-contract mismatch
+const EXCEPTION_2_PRD_CONTRACT = `### Exception 2 — PRD-contract mismatch
 
 You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
 call contradicts a literal interface signature stated in this story's description or
@@ -66,9 +50,9 @@ TEST_AFTER: <corrected call line>
 \`\`\`
 
 Do NOT use this exception to change test logic, assertions, or mock setup — only call
-signatures that directly contradict a quoted PRD interface.
+signatures that directly contradict a quoted PRD interface.`;
 
-### Exception 3 — Unrelated sibling spillover
+const EXCEPTION_3_SIBLING_SCOPE = `### Exception 3 — Unrelated sibling spillover
 
 When a lint or typecheck error is outside this story's intended scope, do NOT edit that
 file. If the smallest package-local fix is required to satisfy this story's acceptance
@@ -78,19 +62,32 @@ TEST_EDIT_REASON: sibling_scope
 SIBLING_FILE: <file path>
 FINDING: <error summary>
 \`\`\`
-and continue. Sibling-scope failures do not block your story.
+and continue. Sibling-scope failures do not block your story.`;
 
-### Exception 4 — Mock-structure handoff
+/**
+ * Exception 4 is only valid for three-session TDD flows that have a test-writer.
+ * Broadened to cover both case (a) wrong mocks and case (b) missing test infrastructure.
+ */
+const EXCEPTION_4_MOCK_HANDOFF = `### Exception 4 — Mock-structure handoff
 
 Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Examples: mocks reference primitives the new code
-bypasses; assertion topology must change to match a new dispatch shape.
+that does NOT fit Exception 2. Two cases qualify:
+
+  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
+      or assertion topology must change to match a new dispatch shape.
+
+  (b) Required test-infrastructure does not yet exist and must be introduced —
+      e.g. in-process fake servers, network-level request interception, hermetic
+      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
+      hermetic/fixture-backed test surface that the current test setup cannot
+      satisfy without new infrastructure.
 
 Declare with:
 \`\`\`
 TEST_EDIT_REASON: mock_structure
 FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
+REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
+         or what infrastructure must be introduced>
 \`\`\`
 
 Rules:
@@ -98,31 +95,62 @@ Rules:
 - Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
 - FILES must list real test files. Each path must exist and be a test file.`;
 
-/** Exception 4 is only valid for three-session TDD flows that have a test-writer. */
-const EXCEPTION_4_MOCK_HANDOFF = `
-### Exception 4 — Mock-structure handoff
+// ─── Escape hatch builder ─────────────────────────────────────────────────────
 
-Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Examples: mocks reference primitives the new code
-bypasses; assertion topology must change to match a new dispatch shape.
+interface EscapeHatchOptions {
+  includeMockHandoff: boolean;
+}
 
-Declare with:
-\`\`\`
-TEST_EDIT_REASON: mock_structure
-FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
-\`\`\`
+/**
+ * Builds the contradiction escape hatch section for rectification prompts.
+ *
+ * Dynamically includes or excludes Exception 4 (mock-structure handoff) based on
+ * whether the story runs a three-session TDD flow that has a test-writer agent.
+ * The intro count always matches the number of included exceptions.
+ */
+export function buildEscapeHatch(opts: EscapeHatchOptions): string {
+  const exceptions: string[] = [EXCEPTION_1_LINT_ONLY, EXCEPTION_2_PRD_CONTRACT, EXCEPTION_3_SIBLING_SCOPE];
+  if (opts.includeMockHandoff) exceptions.push(EXCEPTION_4_MOCK_HANDOFF);
 
-Rules:
-- Do NOT make any edits yourself; the test-writer will fulfill.
-- Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file.`;
+  const count = exceptions.length;
+  const countWord = ["zero", "one", "two", "three", "four"][count];
+
+  return `
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+Before emitting UNRESOLVED, confirm none of Exceptions 1–${count} apply.
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has ${countWord} narrow escape valves. Each requires a
+declaration in your output. Outside these ${countWord} cases the rule is absolute.
+
+${exceptions.join("\n\n")}`;
+}
+
+/**
+ * Returns "three" or "four" depending on whether the story uses a three-session TDD
+ * flow that includes a test-writer agent. Use to interpolate counts in prompt text
+ * that sits outside the escape-hatch block.
+ */
+export function exceptionCountWord(story: UserStory): "three" | "four" {
+  return THREE_SESSION_STRATEGIES.has(story.routing?.testStrategy ?? "") ? "four" : "three";
+}
+
+/**
+ * Backward-compatible alias: always includes all four exceptions.
+ * Used by methods that lack story context (continuation, noOpReprompt).
+ * Prefer escapeHatchFor(story) in story-aware contexts.
+ */
+export const CONTRADICTION_ESCAPE_HATCH = buildEscapeHatch({ includeMockHandoff: true });
 
 const THREE_SESSION_STRATEGIES = new Set(["three-session-tdd", "three-session-tdd-lite"]);
 
-function escapeHatchFor(story: UserStory): string {
+export function escapeHatchFor(story: UserStory): string {
   const isTdd = THREE_SESSION_STRATEGIES.has(story.routing?.testStrategy ?? "");
-  return isTdd ? CONTRADICTION_ESCAPE_HATCH : CONTRADICTION_ESCAPE_HATCH.replace(EXCEPTION_4_MOCK_HANDOFF, "");
+  return buildEscapeHatch({ includeMockHandoff: isTdd });
 }
 
 function noTestIsolationBlock(story: UserStory): string {
@@ -200,7 +228,7 @@ ${errors}
 2. Only fix findings that are actually valid problems
 3. Do NOT add keys, functions, or imports that already exist — check first
 
-Do NOT change test files or test behavior — see the three narrow exceptions appended below.
+Do NOT change test files or test behavior — see the ${exceptionCountWord(story)} narrow exceptions appended below.
 Do NOT add new features — only fix valid issues.
 Commit your fixes when done.${scopeConstraint}${noTestIsolationBlock(story)}${escapeHatchFor(story)}`;
 }
@@ -282,7 +310,7 @@ The following quality checks failed after implementation:
 
 ${errors}
 
-Fix all errors listed above that are within this story's scope — see the three narrow exceptions appended below for sibling-story spillover. Do NOT change test files or test behavior except via those exceptions.
+Fix all errors listed above that are within this story's scope — see the ${exceptionCountWord(story)} narrow exceptions appended below for sibling-story spillover. Do NOT change test files or test behavior except via those exceptions.
 Do NOT add new features — only fix the quality check errors.
 After fixing, re-run the failing check(s) to verify they pass, then commit your changes.${scopeConstraint}${noTestIsolationBlock(story)}${escapeHatchFor(story)}`;
 }

--- a/src/prompts/builders/rectifier-builder-helpers.ts
+++ b/src/prompts/builders/rectifier-builder-helpers.ts
@@ -130,6 +130,9 @@ declaration in your output. Outside these ${countWord} cases the rule is absolut
 ${exceptions.join("\n\n")}`;
 }
 
+/** Strategies that include a test-writer agent and therefore support Exception 4. */
+const THREE_SESSION_STRATEGIES = new Set(["three-session-tdd", "three-session-tdd-lite"]);
+
 /**
  * Returns "three" or "four" depending on whether the story uses a three-session TDD
  * flow that includes a test-writer agent. Use to interpolate counts in prompt text
@@ -140,18 +143,23 @@ export function exceptionCountWord(story: UserStory): "three" | "four" {
 }
 
 /**
- * Backward-compatible alias: always includes all four exceptions.
- * Used by methods that lack story context (continuation, noOpReprompt).
- * Prefer escapeHatchFor(story) in story-aware contexts.
+ * Builds the story-specific escape-hatch section, including or excluding Exception 4
+ * based on whether the story runs a three-session TDD flow with a test-writer.
  */
-export const CONTRADICTION_ESCAPE_HATCH = buildEscapeHatch({ includeMockHandoff: true });
-
-const THREE_SESSION_STRATEGIES = new Set(["three-session-tdd", "three-session-tdd-lite"]);
-
 export function escapeHatchFor(story: UserStory): string {
   const isTdd = THREE_SESSION_STRATEGIES.has(story.routing?.testStrategy ?? "");
   return buildEscapeHatch({ includeMockHandoff: isTdd });
 }
+
+/**
+ * Safe-default escape-hatch constant for callers that lack story context
+ * (e.g. continuation, noOpReprompt without story param).
+ *
+ * Uses three exceptions (no Exception 4) — the safe default that avoids
+ * advertising a mock-structure handoff to non-TDD stories. Pass story to
+ * escapeHatchFor(story) whenever story context is available.
+ */
+export const CONTRADICTION_ESCAPE_HATCH = buildEscapeHatch({ includeMockHandoff: false });
 
 function noTestIsolationBlock(story: UserStory): string {
   if (story.routing?.testStrategy !== "no-test") return "";

--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -32,6 +32,8 @@ import {
   CONTRADICTION_ESCAPE_HATCH,
   adversarialRectification,
   combinedLlmRectification,
+  escapeHatchFor,
+  exceptionCountWord,
   formatCheckErrors,
   mechanicalRectification,
   semanticRectification,
@@ -189,9 +191,11 @@ export class RectifierPromptBuilder {
     failedChecks: ReviewCheckResult[],
     maxAttempts: number,
     guardrailLevel?: GuardrailLevel,
+    story?: UserStory,
   ): string {
     const parts: string[] = [];
     const attemptWord = maxAttempts === 1 ? "1 attempt" : `${maxAttempts} attempts`;
+    const exCount = story ? exceptionCountWord(story) : "three";
 
     parts.push(
       `Review failed after your implementation. Fix the following issues (${attemptWord} available before escalation):\n`,
@@ -200,9 +204,9 @@ export class RectifierPromptBuilder {
     parts.push(renderPrioritizedFailures(failedChecks));
 
     parts.push(
-      "\nFix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior — see the three narrow exceptions appended below. Commit your changes when all checks pass.",
+      `\nFix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior — see the ${exCount} narrow exceptions appended below. Commit your changes when all checks pass.`,
     );
-    parts.push(CONTRADICTION_ESCAPE_HATCH);
+    parts.push(story ? escapeHatchFor(story) : CONTRADICTION_ESCAPE_HATCH);
 
     const guardrails = buildBehavioralGuardrailsSection("implementer", guardrailLevel ?? "lite");
     if (guardrails) {
@@ -574,7 +578,7 @@ ${testCommands}
 6. Ensure ALL tests pass before completing.
 
 **IMPORTANT:**
-- Do NOT modify test files — see the three narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
+- Do NOT modify test files — see the ${exceptionCountWord(story)} narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements.
 - When running tests, run ONLY the failing test files shown above${cmd ? ` — NEVER run \`${cmd}\` without a file filter` : " — never run the full test suite without a file filter"}.
@@ -654,7 +658,7 @@ ${llmSection}
 **Important:** LLM reviewers may flag false positives. Before making changes for LLM review findings, read the relevant files to verify each finding is a real issue. Do NOT add keys, functions, or imports that already exist.
 
 Do NOT add new features — only fix the identified issues.
-Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
+Commit your fixes when done.${scopeConstraint}${escapeHatchFor(story)}`;
   }
 
   /**
@@ -704,9 +708,9 @@ ${errors}${reasoningSection}${historySection}
 2. Only fix findings that are actually valid problems
 3. Do NOT add keys, functions, or imports that already exist — check first
 
-Do NOT change test files or test behavior — see the three narrow exceptions appended below.
+Do NOT change test files or test behavior — see the ${exceptionCountWord(story)} narrow exceptions appended below.
 Do NOT add new features — only fix valid issues.
-Commit your fixes when done.${scopeConstraint}${CONTRADICTION_ESCAPE_HATCH}`;
+Commit your fixes when done.${scopeConstraint}${escapeHatchFor(story)}`;
   }
 
   /**
@@ -840,7 +844,7 @@ Tests are failing. Fix the source so all tests pass — not just the ones listed
 4. Do not declare done until step 3 shows 0 failures.
 
 **IMPORTANT:**
-- Do NOT modify test files — see the three narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
+- Do NOT modify test files — see the ${exceptionCountWord(opts.story)} narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements.`);
 

--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -229,6 +229,7 @@ export class RectifierPromptBuilder {
     rethinkAtAttempt: number,
     urgencyAtAttempt: number,
     guardrailLevel?: GuardrailLevel,
+    story?: UserStory,
   ): string {
     const parts: string[] = [];
 
@@ -247,7 +248,7 @@ export class RectifierPromptBuilder {
       );
     }
 
-    parts.push(CONTRADICTION_ESCAPE_HATCH);
+    parts.push(story ? escapeHatchFor(story) : CONTRADICTION_ESCAPE_HATCH);
 
     const guardrails = buildBehavioralGuardrailsSection("implementer", guardrailLevel ?? "lite");
     if (guardrails) {
@@ -438,6 +439,7 @@ Commit your fixes when done.${scopeConstraint}`;
     noOpCount: number,
     maxNoOpReprompts: number,
     opts?: RectifierRenderOpts,
+    story?: UserStory,
   ): string {
     const parts: string[] = [];
 
@@ -476,7 +478,7 @@ Commit your fixes when done.${scopeConstraint}`;
       }
     }
 
-    parts.push(CONTRADICTION_ESCAPE_HATCH);
+    parts.push(story ? escapeHatchFor(story) : CONTRADICTION_ESCAPE_HATCH);
     return parts.join("");
   }
 
@@ -578,11 +580,11 @@ ${testCommands}
 6. Ensure ALL tests pass before completing.
 
 **IMPORTANT:**
-- Do NOT modify test files — see the ${exceptionCountWord(story)} narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
+- Do NOT modify test files — see the ${exceptionCountWord(story)} narrow exceptions appended below if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements.
 - When running tests, run ONLY the failing test files shown above${cmd ? ` — NEVER run \`${cmd}\` without a file filter` : " — never run the full test suite without a file filter"}.
-`;
+${escapeHatchFor(story)}`;
   }
 
   /**
@@ -844,10 +846,11 @@ Tests are failing. Fix the source so all tests pass — not just the ones listed
 4. Do not declare done until step 3 shows 0 failures.
 
 **IMPORTANT:**
-- Do NOT modify test files — see the ${exceptionCountWord(opts.story)} narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
+- Do NOT modify test files — see the ${exceptionCountWord(opts.story)} narrow exceptions appended below if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements.`);
 
+    parts.push(escapeHatchFor(opts.story));
     return parts.join("");
   }
 

--- a/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
@@ -206,10 +206,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
+Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has three narrow escape valves. Each requires a
-declaration in your output. Outside these three cases the rule is absolute.
+The "do not modify test files" rule has four narrow escape valves. Each requires a
+declaration in your output. Outside these four cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -262,14 +264,23 @@ and continue. Sibling-scope failures do not block your story.
 ### Exception 4 — Mock-structure handoff
 
 Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Examples: mocks reference primitives the new code
-bypasses; assertion topology must change to match a new dispatch shape.
+that does NOT fit Exception 2. Two cases qualify:
+
+  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
+      or assertion topology must change to match a new dispatch shape.
+
+  (b) Required test-infrastructure does not yet exist and must be introduced —
+      e.g. in-process fake servers, network-level request interception, hermetic
+      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
+      hermetic/fixture-backed test surface that the current test setup cannot
+      satisfy without new infrastructure.
 
 Declare with:
 \`\`\`
 TEST_EDIT_REASON: mock_structure
 FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
+REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
+         or what infrastructure must be introduced>
 \`\`\`
 
 Rules:
@@ -319,10 +330,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
+Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has three narrow escape valves. Each requires a
-declaration in your output. Outside these three cases the rule is absolute.
+The "do not modify test files" rule has four narrow escape valves. Each requires a
+declaration in your output. Outside these four cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -375,14 +388,23 @@ and continue. Sibling-scope failures do not block your story.
 ### Exception 4 — Mock-structure handoff
 
 Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Examples: mocks reference primitives the new code
-bypasses; assertion topology must change to match a new dispatch shape.
+that does NOT fit Exception 2. Two cases qualify:
+
+  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
+      or assertion topology must change to match a new dispatch shape.
+
+  (b) Required test-infrastructure does not yet exist and must be introduced —
+      e.g. in-process fake servers, network-level request interception, hermetic
+      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
+      hermetic/fixture-backed test surface that the current test setup cannot
+      satisfy without new infrastructure.
 
 Declare with:
 \`\`\`
 TEST_EDIT_REASON: mock_structure
 FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
+REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
+         or what infrastructure must be introduced>
 \`\`\`
 
 Rules:
@@ -472,10 +494,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
+Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has three narrow escape valves. Each requires a
-declaration in your output. Outside these three cases the rule is absolute.
+The "do not modify test files" rule has four narrow escape valves. Each requires a
+declaration in your output. Outside these four cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -528,14 +552,23 @@ and continue. Sibling-scope failures do not block your story.
 ### Exception 4 — Mock-structure handoff
 
 Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Examples: mocks reference primitives the new code
-bypasses; assertion topology must change to match a new dispatch shape.
+that does NOT fit Exception 2. Two cases qualify:
+
+  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
+      or assertion topology must change to match a new dispatch shape.
+
+  (b) Required test-infrastructure does not yet exist and must be introduced —
+      e.g. in-process fake servers, network-level request interception, hermetic
+      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
+      hermetic/fixture-backed test surface that the current test setup cannot
+      satisfy without new infrastructure.
 
 Declare with:
 \`\`\`
 TEST_EDIT_REASON: mock_structure
 FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
+REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
+         or what infrastructure must be introduced>
 \`\`\`
 
 Rules:
@@ -573,10 +606,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
+Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has three narrow escape valves. Each requires a
-declaration in your output. Outside these three cases the rule is absolute.
+The "do not modify test files" rule has four narrow escape valves. Each requires a
+declaration in your output. Outside these four cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -629,14 +664,23 @@ and continue. Sibling-scope failures do not block your story.
 ### Exception 4 — Mock-structure handoff
 
 Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Examples: mocks reference primitives the new code
-bypasses; assertion topology must change to match a new dispatch shape.
+that does NOT fit Exception 2. Two cases qualify:
+
+  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
+      or assertion topology must change to match a new dispatch shape.
+
+  (b) Required test-infrastructure does not yet exist and must be introduced —
+      e.g. in-process fake servers, network-level request interception, hermetic
+      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
+      hermetic/fixture-backed test surface that the current test setup cannot
+      satisfy without new infrastructure.
 
 Declare with:
 \`\`\`
 TEST_EDIT_REASON: mock_structure
 FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
+REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
+         or what infrastructure must be introduced>
 \`\`\`
 
 Rules:
@@ -684,10 +728,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
+Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has three narrow escape valves. Each requires a
-declaration in your output. Outside these three cases the rule is absolute.
+The "do not modify test files" rule has four narrow escape valves. Each requires a
+declaration in your output. Outside these four cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -740,14 +786,23 @@ and continue. Sibling-scope failures do not block your story.
 ### Exception 4 — Mock-structure handoff
 
 Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Examples: mocks reference primitives the new code
-bypasses; assertion topology must change to match a new dispatch shape.
+that does NOT fit Exception 2. Two cases qualify:
+
+  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
+      or assertion topology must change to match a new dispatch shape.
+
+  (b) Required test-infrastructure does not yet exist and must be introduced —
+      e.g. in-process fake servers, network-level request interception, hermetic
+      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
+      hermetic/fixture-backed test surface that the current test setup cannot
+      satisfy without new infrastructure.
 
 Declare with:
 \`\`\`
 TEST_EDIT_REASON: mock_structure
 FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
+REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
+         or what infrastructure must be introduced>
 \`\`\`
 
 Rules:
@@ -841,10 +896,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
+Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has three narrow escape valves. Each requires a
-declaration in your output. Outside these three cases the rule is absolute.
+The "do not modify test files" rule has four narrow escape valves. Each requires a
+declaration in your output. Outside these four cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -897,14 +954,23 @@ and continue. Sibling-scope failures do not block your story.
 ### Exception 4 — Mock-structure handoff
 
 Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Examples: mocks reference primitives the new code
-bypasses; assertion topology must change to match a new dispatch shape.
+that does NOT fit Exception 2. Two cases qualify:
+
+  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
+      or assertion topology must change to match a new dispatch shape.
+
+  (b) Required test-infrastructure does not yet exist and must be introduced —
+      e.g. in-process fake servers, network-level request interception, hermetic
+      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
+      hermetic/fixture-backed test surface that the current test setup cannot
+      satisfy without new infrastructure.
 
 Declare with:
 \`\`\`
 TEST_EDIT_REASON: mock_structure
 FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses>
+REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
+         or what infrastructure must be introduced>
 \`\`\`
 
 Rules:

--- a/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/rectifier-builder.test.ts.snap
@@ -72,9 +72,67 @@ Tests are failing. Fix the source so all tests pass — not just the ones listed
 4. Do not declare done until step 3 shows 0 failures.
 
 **IMPORTANT:**
-- Do NOT modify test files — see the three narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
+- Do NOT modify test files — see the three narrow exceptions appended below if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
 - Do NOT loosen assertions to mask implementation bugs.
-- Focus on fixing the source code to meet the test requirements."
+- Focus on fixing the source code to meet the test requirements.
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+Before emitting UNRESOLVED, confirm none of Exceptions 1–3 apply.
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
+
+### Exception 1 — Lint-only edit
+
+You MAY edit a test file ONLY when ALL of the following hold:
+- The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
+- Your edit removes or reformats a lint violation without altering any \`expect\`, \`assert\`,
+  \`toBe\`, \`toEqual\`, \`toThrow\`, \`not.\`, or equivalent assertion call, its arguments, its
+  input data, its mock setup, or its \`describe\`/\`it\`/\`test\` block text.
+- If you are uncertain whether your edit is assertion-neutral, do NOT make it — emit
+  \`UNRESOLVED\` instead.
+
+Declare every lint-only test edit with:
+\`\`\`
+TEST_EDIT_REASON: lint_only
+FILE: <test file path>
+FINDING: <lint rule or message verbatim>
+CHANGE: <before line> → <after line>
+\`\`\`
+
+### Exception 2 — PRD-contract mismatch
+
+You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
+call contradicts a literal interface signature stated in this story's description or
+acceptance criteria.
+
+Declare every contract-mismatch edit with:
+\`\`\`
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "<verbatim signature line from the story description or acceptance criteria>"
+FILE: <test file path>
+TEST_BEFORE: <offending call line>
+TEST_AFTER: <corrected call line>
+\`\`\`
+
+Do NOT use this exception to change test logic, assertions, or mock setup — only call
+signatures that directly contradict a quoted PRD interface.
+
+### Exception 3 — Unrelated sibling spillover
+
+When a lint or typecheck error is outside this story's intended scope, do NOT edit that
+file. If the smallest package-local fix is required to satisfy this story's acceptance
+criteria, you MAY make that fix instead. Otherwise declare:
+\`\`\`
+TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: <file path>
+FINDING: <error summary>
+\`\`\`
+and continue. Sibling-scope failures do not block your story."
 `;
 
 exports[`RectifierPromptBuilder.regressionFailure() snapshot: regressionFailure() with all options 1`] = `
@@ -179,9 +237,67 @@ Tests are failing. Fix the source so all tests pass — not just the ones listed
 4. Do not declare done until step 3 shows 0 failures.
 
 **IMPORTANT:**
-- Do NOT modify test files — see the three narrow exceptions in the escape valve section if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
+- Do NOT modify test files — see the three narrow exceptions appended below if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
 - Do NOT loosen assertions to mask implementation bugs.
-- Focus on fixing the source code to meet the test requirements."
+- Focus on fixing the source code to meet the test requirements.
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+Before emitting UNRESOLVED, confirm none of Exceptions 1–3 apply.
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
+
+### Exception 1 — Lint-only edit
+
+You MAY edit a test file ONLY when ALL of the following hold:
+- The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
+- Your edit removes or reformats a lint violation without altering any \`expect\`, \`assert\`,
+  \`toBe\`, \`toEqual\`, \`toThrow\`, \`not.\`, or equivalent assertion call, its arguments, its
+  input data, its mock setup, or its \`describe\`/\`it\`/\`test\` block text.
+- If you are uncertain whether your edit is assertion-neutral, do NOT make it — emit
+  \`UNRESOLVED\` instead.
+
+Declare every lint-only test edit with:
+\`\`\`
+TEST_EDIT_REASON: lint_only
+FILE: <test file path>
+FINDING: <lint rule or message verbatim>
+CHANGE: <before line> → <after line>
+\`\`\`
+
+### Exception 2 — PRD-contract mismatch
+
+You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
+call contradicts a literal interface signature stated in this story's description or
+acceptance criteria.
+
+Declare every contract-mismatch edit with:
+\`\`\`
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "<verbatim signature line from the story description or acceptance criteria>"
+FILE: <test file path>
+TEST_BEFORE: <offending call line>
+TEST_AFTER: <corrected call line>
+\`\`\`
+
+Do NOT use this exception to change test logic, assertions, or mock setup — only call
+signatures that directly contradict a quoted PRD interface.
+
+### Exception 3 — Unrelated sibling spillover
+
+When a lint or typecheck error is outside this story's intended scope, do NOT edit that
+file. If the smallest package-local fix is required to satisfy this story's acceptance
+criteria, you MAY make that fix instead. Otherwise declare:
+\`\`\`
+TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: <file path>
+FINDING: <error summary>
+\`\`\`
+and continue. Sibling-scope failures do not block your story."
 `;
 
 exports[`RectifierPromptBuilder.firstAttemptDelta single-category: renders only the matching priority bucket 1`] = `
@@ -206,12 +322,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
-Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+Before emitting UNRESOLVED, confirm none of Exceptions 1–3 apply.
 
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has four narrow escape valves. Each requires a
-declaration in your output. Outside these four cases the rule is absolute.
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -260,33 +376,6 @@ SIBLING_FILE: <file path>
 FINDING: <error summary>
 \`\`\`
 and continue. Sibling-scope failures do not block your story.
-
-### Exception 4 — Mock-structure handoff
-
-Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Two cases qualify:
-
-  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
-      or assertion topology must change to match a new dispatch shape.
-
-  (b) Required test-infrastructure does not yet exist and must be introduced —
-      e.g. in-process fake servers, network-level request interception, hermetic
-      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
-      hermetic/fixture-backed test surface that the current test setup cannot
-      satisfy without new infrastructure.
-
-Declare with:
-\`\`\`
-TEST_EDIT_REASON: mock_structure
-FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
-         or what infrastructure must be introduced>
-\`\`\`
-
-Rules:
-- Do NOT make any edits yourself; the test-writer will fulfill.
-- Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file.
 
 
 # Behavioral Guardrails
@@ -330,12 +419,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
-Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+Before emitting UNRESOLVED, confirm none of Exceptions 1–3 apply.
 
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has four narrow escape valves. Each requires a
-declaration in your output. Outside these four cases the rule is absolute.
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -384,33 +473,6 @@ SIBLING_FILE: <file path>
 FINDING: <error summary>
 \`\`\`
 and continue. Sibling-scope failures do not block your story.
-
-### Exception 4 — Mock-structure handoff
-
-Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Two cases qualify:
-
-  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
-      or assertion topology must change to match a new dispatch shape.
-
-  (b) Required test-infrastructure does not yet exist and must be introduced —
-      e.g. in-process fake servers, network-level request interception, hermetic
-      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
-      hermetic/fixture-backed test surface that the current test setup cannot
-      satisfy without new infrastructure.
-
-Declare with:
-\`\`\`
-TEST_EDIT_REASON: mock_structure
-FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
-         or what infrastructure must be introduced>
-\`\`\`
-
-Rules:
-- Do NOT make any edits yourself; the test-writer will fulfill.
-- Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file.
 
 
 # Behavioral Guardrails
@@ -494,12 +556,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
-Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+Before emitting UNRESOLVED, confirm none of Exceptions 1–3 apply.
 
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has four narrow escape valves. Each requires a
-declaration in your output. Outside these four cases the rule is absolute.
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -548,33 +610,6 @@ SIBLING_FILE: <file path>
 FINDING: <error summary>
 \`\`\`
 and continue. Sibling-scope failures do not block your story.
-
-### Exception 4 — Mock-structure handoff
-
-Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Two cases qualify:
-
-  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
-      or assertion topology must change to match a new dispatch shape.
-
-  (b) Required test-infrastructure does not yet exist and must be introduced —
-      e.g. in-process fake servers, network-level request interception, hermetic
-      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
-      hermetic/fixture-backed test surface that the current test setup cannot
-      satisfy without new infrastructure.
-
-Declare with:
-\`\`\`
-TEST_EDIT_REASON: mock_structure
-FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
-         or what infrastructure must be introduced>
-\`\`\`
-
-Rules:
-- Do NOT make any edits yourself; the test-writer will fulfill.
-- Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file.
 
 
 # Behavioral Guardrails
@@ -606,12 +641,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
-Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+Before emitting UNRESOLVED, confirm none of Exceptions 1–3 apply.
 
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has four narrow escape valves. Each requires a
-declaration in your output. Outside these four cases the rule is absolute.
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -660,33 +695,6 @@ SIBLING_FILE: <file path>
 FINDING: <error summary>
 \`\`\`
 and continue. Sibling-scope failures do not block your story.
-
-### Exception 4 — Mock-structure handoff
-
-Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Two cases qualify:
-
-  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
-      or assertion topology must change to match a new dispatch shape.
-
-  (b) Required test-infrastructure does not yet exist and must be introduced —
-      e.g. in-process fake servers, network-level request interception, hermetic
-      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
-      hermetic/fixture-backed test surface that the current test setup cannot
-      satisfy without new infrastructure.
-
-Declare with:
-\`\`\`
-TEST_EDIT_REASON: mock_structure
-FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
-         or what infrastructure must be introduced>
-\`\`\`
-
-Rules:
-- Do NOT make any edits yourself; the test-writer will fulfill.
-- Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file.
 
 
 # Behavioral Guardrails
@@ -728,12 +736,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
-Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+Before emitting UNRESOLVED, confirm none of Exceptions 1–3 apply.
 
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has four narrow escape valves. Each requires a
-declaration in your output. Outside these four cases the rule is absolute.
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -782,33 +790,6 @@ SIBLING_FILE: <file path>
 FINDING: <error summary>
 \`\`\`
 and continue. Sibling-scope failures do not block your story.
-
-### Exception 4 — Mock-structure handoff
-
-Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Two cases qualify:
-
-  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
-      or assertion topology must change to match a new dispatch shape.
-
-  (b) Required test-infrastructure does not yet exist and must be introduced —
-      e.g. in-process fake servers, network-level request interception, hermetic
-      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
-      hermetic/fixture-backed test surface that the current test setup cannot
-      satisfy without new infrastructure.
-
-Declare with:
-\`\`\`
-TEST_EDIT_REASON: mock_structure
-FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
-         or what infrastructure must be introduced>
-\`\`\`
-
-Rules:
-- Do NOT make any edits yourself; the test-writer will fulfill.
-- Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file.
 
 
 # Behavioral Guardrails
@@ -896,12 +877,12 @@ If two findings in this list contradict each other and you cannot satisfy both, 
 Emit fixes for defects you can resolve, then output a line in this exact format:
 UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
 
-Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+Before emitting UNRESOLVED, confirm none of Exceptions 1–3 apply.
 
 ## Test-file edit exceptions
 
-The "do not modify test files" rule has four narrow escape valves. Each requires a
-declaration in your output. Outside these four cases the rule is absolute.
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
 
 ### Exception 1 — Lint-only edit
 
@@ -950,33 +931,6 @@ SIBLING_FILE: <file path>
 FINDING: <error summary>
 \`\`\`
 and continue. Sibling-scope failures do not block your story.
-
-### Exception 4 — Mock-structure handoff
-
-Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
-that does NOT fit Exception 2. Two cases qualify:
-
-  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
-      or assertion topology must change to match a new dispatch shape.
-
-  (b) Required test-infrastructure does not yet exist and must be introduced —
-      e.g. in-process fake servers, network-level request interception, hermetic
-      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
-      hermetic/fixture-backed test surface that the current test setup cannot
-      satisfy without new infrastructure.
-
-Declare with:
-\`\`\`
-TEST_EDIT_REASON: mock_structure
-FILES: <comma-separated test file paths>
-REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
-         or what infrastructure must be introduced>
-\`\`\`
-
-Rules:
-- Do NOT make any edits yourself; the test-writer will fulfill.
-- Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
-- FILES must list real test files. Each path must exist and be a test file.
 
 
 # Behavioral Guardrails

--- a/test/unit/prompts/builders/__snapshots__/rectifier-builder-helpers.test.ts.snap
+++ b/test/unit/prompts/builders/__snapshots__/rectifier-builder-helpers.test.ts.snap
@@ -1,0 +1,152 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`buildEscapeHatch TDD path (includeMockHandoff: true) snapshot: full TDD escape hatch 1`] = `
+"
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+Before emitting UNRESOLVED, confirm none of Exceptions 1–4 apply.
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has four narrow escape valves. Each requires a
+declaration in your output. Outside these four cases the rule is absolute.
+
+### Exception 1 — Lint-only edit
+
+You MAY edit a test file ONLY when ALL of the following hold:
+- The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
+- Your edit removes or reformats a lint violation without altering any \`expect\`, \`assert\`,
+  \`toBe\`, \`toEqual\`, \`toThrow\`, \`not.\`, or equivalent assertion call, its arguments, its
+  input data, its mock setup, or its \`describe\`/\`it\`/\`test\` block text.
+- If you are uncertain whether your edit is assertion-neutral, do NOT make it — emit
+  \`UNRESOLVED\` instead.
+
+Declare every lint-only test edit with:
+\`\`\`
+TEST_EDIT_REASON: lint_only
+FILE: <test file path>
+FINDING: <lint rule or message verbatim>
+CHANGE: <before line> → <after line>
+\`\`\`
+
+### Exception 2 — PRD-contract mismatch
+
+You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
+call contradicts a literal interface signature stated in this story's description or
+acceptance criteria.
+
+Declare every contract-mismatch edit with:
+\`\`\`
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "<verbatim signature line from the story description or acceptance criteria>"
+FILE: <test file path>
+TEST_BEFORE: <offending call line>
+TEST_AFTER: <corrected call line>
+\`\`\`
+
+Do NOT use this exception to change test logic, assertions, or mock setup — only call
+signatures that directly contradict a quoted PRD interface.
+
+### Exception 3 — Unrelated sibling spillover
+
+When a lint or typecheck error is outside this story's intended scope, do NOT edit that
+file. If the smallest package-local fix is required to satisfy this story's acceptance
+criteria, you MAY make that fix instead. Otherwise declare:
+\`\`\`
+TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: <file path>
+FINDING: <error summary>
+\`\`\`
+and continue. Sibling-scope failures do not block your story.
+
+### Exception 4 — Mock-structure handoff
+
+Use ONLY when the only path to satisfy the ACs requires a structural test rewrite
+that does NOT fit Exception 2. Two cases qualify:
+
+  (a) Existing mocks are wrong — mocks reference primitives the new code bypasses,
+      or assertion topology must change to match a new dispatch shape.
+
+  (b) Required test-infrastructure does not yet exist and must be introduced —
+      e.g. in-process fake servers, network-level request interception, hermetic
+      fixture-backed HTTP, or equivalent. Applies whenever the AC describes a
+      hermetic/fixture-backed test surface that the current test setup cannot
+      satisfy without new infrastructure.
+
+Declare with:
+\`\`\`
+TEST_EDIT_REASON: mock_structure
+FILES: <comma-separated test file paths>
+REASON: <one paragraph: which mock is wrong vs which dispatch the new code uses,
+         or what infrastructure must be introduced>
+\`\`\`
+
+Rules:
+- Do NOT make any edits yourself; the test-writer will fulfill.
+- Do NOT also emit \`UNRESOLVED:\` in the same turn — this declaration IS the handoff.
+- FILES must list real test files. Each path must exist and be a test file."
+`;
+
+exports[`buildEscapeHatch non-TDD path (includeMockHandoff: false) snapshot: full non-TDD escape hatch 1`] = `
+"
+If two findings in this list contradict each other and you cannot satisfy both, do not guess.
+Emit fixes for defects you can resolve, then output a line in this exact format:
+UNRESOLVED: <brief explanation of which findings conflicted and why they cannot both be satisfied>
+
+Before emitting UNRESOLVED, confirm none of Exceptions 1–3 apply.
+
+## Test-file edit exceptions
+
+The "do not modify test files" rule has three narrow escape valves. Each requires a
+declaration in your output. Outside these three cases the rule is absolute.
+
+### Exception 1 — Lint-only edit
+
+You MAY edit a test file ONLY when ALL of the following hold:
+- The failing check is \`lint\` — not \`test\`, \`typecheck\`, \`semantic\`, or \`adversarial\`.
+- Your edit removes or reformats a lint violation without altering any \`expect\`, \`assert\`,
+  \`toBe\`, \`toEqual\`, \`toThrow\`, \`not.\`, or equivalent assertion call, its arguments, its
+  input data, its mock setup, or its \`describe\`/\`it\`/\`test\` block text.
+- If you are uncertain whether your edit is assertion-neutral, do NOT make it — emit
+  \`UNRESOLVED\` instead.
+
+Declare every lint-only test edit with:
+\`\`\`
+TEST_EDIT_REASON: lint_only
+FILE: <test file path>
+FINDING: <lint rule or message verbatim>
+CHANGE: <before line> → <after line>
+\`\`\`
+
+### Exception 2 — PRD-contract mismatch
+
+You MAY correct a test's argument arity, type, or return-handling ONLY when the test's
+call contradicts a literal interface signature stated in this story's description or
+acceptance criteria.
+
+Declare every contract-mismatch edit with:
+\`\`\`
+TEST_EDIT_REASON: prd_contract
+PRD_QUOTE: "<verbatim signature line from the story description or acceptance criteria>"
+FILE: <test file path>
+TEST_BEFORE: <offending call line>
+TEST_AFTER: <corrected call line>
+\`\`\`
+
+Do NOT use this exception to change test logic, assertions, or mock setup — only call
+signatures that directly contradict a quoted PRD interface.
+
+### Exception 3 — Unrelated sibling spillover
+
+When a lint or typecheck error is outside this story's intended scope, do NOT edit that
+file. If the smallest package-local fix is required to satisfy this story's acceptance
+criteria, you MAY make that fix instead. Otherwise declare:
+\`\`\`
+TEST_EDIT_REASON: sibling_scope
+SIBLING_FILE: <file path>
+FINDING: <error summary>
+\`\`\`
+and continue. Sibling-scope failures do not block your story."
+`;

--- a/test/unit/prompts/builders/rectifier-builder-helpers.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder-helpers.test.ts
@@ -188,10 +188,11 @@ describe("RectifierPromptBuilder.firstAttemptDelta — story-aware escape hatch"
     expect(result).not.toContain("### Exception 4 — Mock-structure handoff");
   });
 
-  test("no story (backward compat): falls back to four-exception hatch", () => {
+  test("no story (backward compat): falls back to three-exception safe-default hatch", () => {
     const result = RectifierPromptBuilder.firstAttemptDelta([makeCheck()], 3);
-    // Backward compat: no story → default "three" in inline text, full hatch appended
+    // Backward compat: no story → "three" in both inline text and the hatch (safe default)
     expect(result).toContain("three narrow exceptions appended below");
-    expect(result).toContain("four narrow escape valves"); // CONTRADICTION_ESCAPE_HATCH always has 4
+    expect(result).toContain("three narrow escape valves");
+    expect(result).not.toContain("### Exception 4 — Mock-structure handoff");
   });
 });

--- a/test/unit/prompts/builders/rectifier-builder-helpers.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder-helpers.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for rectifier-builder-helpers — buildEscapeHatch + exceptionCountWord
+ *
+ * Verifies that the escape-hatch section dynamically matches the story's TDD strategy:
+ * - TDD path: 4 exceptions, "four" in count text, includes Exception 4 with both cases
+ * - Non-TDD path: 3 exceptions, "three" in count text, excludes Exception 4
+ */
+
+import { describe, expect, test } from "bun:test";
+import { makeStory } from "../../../helpers";
+import { buildEscapeHatch, exceptionCountWord } from "../../../../src/prompts/builders/rectifier-builder-helpers";
+import { RectifierPromptBuilder } from "../../../../src/prompts";
+import type { ReviewCheckResult } from "../../../../src/review/types";
+
+const TDD_STORY = makeStory({
+  id: "US-TDD",
+  title: "TDD story",
+  description: "A story with three-session TDD.",
+  acceptanceCriteria: ["AC1"],
+  routing: { testStrategy: "three-session-tdd", complexity: "simple", reasoning: "test" },
+});
+
+const NO_TEST_STORY = makeStory({
+  id: "US-NT",
+  title: "No-test story",
+  description: "A story without test generation.",
+  acceptanceCriteria: ["AC1"],
+  routing: { testStrategy: "no-test", complexity: "simple", reasoning: "test" },
+});
+
+const TDD_LITE_STORY = makeStory({
+  id: "US-LITE",
+  title: "TDD-lite story",
+  description: "A story with three-session-tdd-lite.",
+  acceptanceCriteria: ["AC1"],
+  routing: { testStrategy: "three-session-tdd-lite", complexity: "simple", reasoning: "test" },
+});
+
+// ─── buildEscapeHatch ─────────────────────────────────────────────────────────
+
+describe("buildEscapeHatch", () => {
+  describe("TDD path (includeMockHandoff: true)", () => {
+    const hatch = buildEscapeHatch({ includeMockHandoff: true });
+
+    test("says 'four narrow escape valves'", () => {
+      expect(hatch).toContain("four narrow escape valves");
+    });
+
+    test("'Outside these four cases the rule is absolute'", () => {
+      expect(hatch).toContain("Outside these four cases the rule is absolute");
+    });
+
+    test("'Exceptions 1–4' line present", () => {
+      expect(hatch).toContain("Exceptions 1–4");
+    });
+
+    test("includes Exception 4 — Mock-structure handoff", () => {
+      expect(hatch).toContain("### Exception 4 — Mock-structure handoff");
+    });
+
+    test("Exception 4 case (a): wrong mocks", () => {
+      expect(hatch).toContain("mocks reference primitives the new code bypasses");
+    });
+
+    test("Exception 4 case (b): required test-infrastructure", () => {
+      expect(hatch).toContain("Required test-infrastructure does not yet exist and must be introduced");
+    });
+
+    test("case (b) hermetic language", () => {
+      expect(hatch).toContain("hermetic/fixture-backed test surface");
+    });
+
+    test("includes all four exception headings", () => {
+      expect(hatch).toContain("### Exception 1 — Lint-only edit");
+      expect(hatch).toContain("### Exception 2 — PRD-contract mismatch");
+      expect(hatch).toContain("### Exception 3 — Unrelated sibling spillover");
+      expect(hatch).toContain("### Exception 4 — Mock-structure handoff");
+    });
+
+    test("snapshot: full TDD escape hatch", () => {
+      expect(hatch).toMatchSnapshot();
+    });
+  });
+
+  describe("non-TDD path (includeMockHandoff: false)", () => {
+    const hatch = buildEscapeHatch({ includeMockHandoff: false });
+
+    test("says 'three narrow escape valves'", () => {
+      expect(hatch).toContain("three narrow escape valves");
+    });
+
+    test("'Outside these three cases the rule is absolute'", () => {
+      expect(hatch).toContain("Outside these three cases the rule is absolute");
+    });
+
+    test("'Exceptions 1–3' line present", () => {
+      expect(hatch).toContain("Exceptions 1–3");
+    });
+
+    test("excludes Exception 4", () => {
+      expect(hatch).not.toContain("### Exception 4 — Mock-structure handoff");
+      expect(hatch).not.toContain("mock_structure");
+    });
+
+    test("includes three exception headings only", () => {
+      expect(hatch).toContain("### Exception 1 — Lint-only edit");
+      expect(hatch).toContain("### Exception 2 — PRD-contract mismatch");
+      expect(hatch).toContain("### Exception 3 — Unrelated sibling spillover");
+    });
+
+    test("snapshot: full non-TDD escape hatch", () => {
+      expect(hatch).toMatchSnapshot();
+    });
+  });
+});
+
+// ─── exceptionCountWord ───────────────────────────────────────────────────────
+
+describe("exceptionCountWord", () => {
+  test("three-session-tdd → 'four'", () => {
+    expect(exceptionCountWord(TDD_STORY)).toBe("four");
+  });
+
+  test("three-session-tdd-lite → 'four'", () => {
+    expect(exceptionCountWord(TDD_LITE_STORY)).toBe("four");
+  });
+
+  test("no-test → 'three'", () => {
+    expect(exceptionCountWord(NO_TEST_STORY)).toBe("three");
+  });
+
+  test("no routing → 'three'", () => {
+    const story = makeStory({ id: "US-X", routing: undefined });
+    expect(exceptionCountWord(story)).toBe("three");
+  });
+});
+
+// ─── Integration: prompt strings embed correct count ─────────────────────────
+
+const makeCheck = (check: ReviewCheckResult["check"] = "lint"): ReviewCheckResult => ({
+  check,
+  success: false,
+  command: `${check}`,
+  exitCode: 1,
+  output: `${check} output`,
+  durationMs: 10,
+});
+
+describe("RectifierPromptBuilder.reviewRectification — story-aware escape hatch", () => {
+  test("TDD story: escape hatch has 'four narrow escape valves' and Exceptions 1–4", () => {
+    const result = RectifierPromptBuilder.reviewRectification([makeCheck("lint")], TDD_STORY);
+    expect(result).toContain("four narrow escape valves");
+    expect(result).toContain("Exceptions 1–4");
+    expect(result).toContain("### Exception 4 — Mock-structure handoff");
+  });
+
+  test("non-TDD story: escape hatch has 'three narrow escape valves', no Exception 4", () => {
+    const result = RectifierPromptBuilder.reviewRectification([makeCheck("lint")], NO_TEST_STORY);
+    expect(result).toContain("three narrow escape valves");
+    expect(result).toContain("Exceptions 1–3");
+    expect(result).not.toContain("### Exception 4 — Mock-structure handoff");
+  });
+
+  test("TDD story: inline text says 'three' for mechanical checks (mechanicalRectification)", () => {
+    // mechanicalRectification uses exceptionCountWord — TDD story should say "four" inline
+    const result = RectifierPromptBuilder.reviewRectification([makeCheck("typecheck")], TDD_STORY);
+    expect(result).toContain("four narrow exceptions appended below");
+  });
+
+  test("non-TDD story: inline text says 'three' for mechanical checks", () => {
+    const result = RectifierPromptBuilder.reviewRectification([makeCheck("typecheck")], NO_TEST_STORY);
+    expect(result).toContain("three narrow exceptions appended below");
+  });
+});
+
+describe("RectifierPromptBuilder.firstAttemptDelta — story-aware escape hatch", () => {
+  test("TDD story: says 'four' and includes Exception 4", () => {
+    const result = RectifierPromptBuilder.firstAttemptDelta([makeCheck()], 3, undefined, TDD_STORY);
+    expect(result).toContain("four narrow exceptions appended below");
+    expect(result).toContain("four narrow escape valves");
+    expect(result).toContain("### Exception 4 — Mock-structure handoff");
+  });
+
+  test("non-TDD story: says 'three', no Exception 4", () => {
+    const result = RectifierPromptBuilder.firstAttemptDelta([makeCheck()], 3, undefined, NO_TEST_STORY);
+    expect(result).toContain("three narrow exceptions appended below");
+    expect(result).toContain("three narrow escape valves");
+    expect(result).not.toContain("### Exception 4 — Mock-structure handoff");
+  });
+
+  test("no story (backward compat): falls back to four-exception hatch", () => {
+    const result = RectifierPromptBuilder.firstAttemptDelta([makeCheck()], 3);
+    // Backward compat: no story → default "three" in inline text, full hatch appended
+    expect(result).toContain("three narrow exceptions appended below");
+    expect(result).toContain("four narrow escape valves"); // CONTRADICTION_ESCAPE_HATCH always has 4
+  });
+});

--- a/test/unit/prompts/builders/rectifier-builder.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder.test.ts
@@ -388,22 +388,24 @@ describe("RectifierPromptBuilder.testWriterRectification — write-failing-test 
 });
 
 // ---------------------------------------------------------------------------
-// CONTRADICTION_ESCAPE_HATCH — Exception 4 (mock-structure handoff)
+// buildEscapeHatch({ includeMockHandoff: true }) — Exception 4 (mock-structure handoff)
 // ---------------------------------------------------------------------------
 
-import { CONTRADICTION_ESCAPE_HATCH } from "@/prompts";
+import { buildEscapeHatch } from "../../../../src/prompts/builders/rectifier-builder-helpers";
 
-describe("CONTRADICTION_ESCAPE_HATCH — Exception 4", () => {
+describe("buildEscapeHatch({ includeMockHandoff: true }) — Exception 4", () => {
+  const tddHatch = buildEscapeHatch({ includeMockHandoff: true });
+
   test("includes Exception 4 title, required fields, and UNRESOLVED handoff rule", () => {
-    expect(CONTRADICTION_ESCAPE_HATCH).toContain("Exception 4 — Mock-structure handoff");
-    expect(CONTRADICTION_ESCAPE_HATCH).toContain("TEST_EDIT_REASON: mock_structure");
-    expect(CONTRADICTION_ESCAPE_HATCH).toContain(
+    expect(tddHatch).toContain("Exception 4 — Mock-structure handoff");
+    expect(tddHatch).toContain("TEST_EDIT_REASON: mock_structure");
+    expect(tddHatch).toContain(
       "Do NOT also emit `UNRESOLVED:` in the same turn — this declaration IS the handoff.",
     );
   });
 
   test.each(["FILES:", "REASON:"])("lists %s as a required field", (field) => {
-    const afterException4 = CONTRADICTION_ESCAPE_HATCH.slice(CONTRADICTION_ESCAPE_HATCH.indexOf("Exception 4"));
+    const afterException4 = tddHatch.slice(tddHatch.indexOf("Exception 4"));
     expect(afterException4).toContain(field);
   });
 });


### PR DESCRIPTION
## Summary

Implements Fix C from `docs/specs/2026-05-26-rectifier-handoff-restoration.md`.

The rectifier prompt had three related bugs that caused the implementer agent to refuse valid Exception 4 cases (silent pause in screener-ui-web US-001):

| Bug | Root cause | Fix |
|:----|:-----------|:----|
| Count said "three" but listed four exceptions | Static `CONTRADICTION_ESCAPE_HATCH` string hardcoded the count | Dynamic `buildEscapeHatch(opts)` computes count from the exception list |
| Non-TDD stories still saw Exception 4 | `.replace(EXCEPTION_4_MOCK_HANDOFF, "")` never matched (prefix whitespace mismatch) | `escapeHatchFor(story)` calls `buildEscapeHatch({ includeMockHandoff: isTdd })` |
| Exception 4 only described case (a) (wrong mocks) | Wording omitted case (b) (missing test infrastructure) | Added case (b): hermetic/fixture-backed test surface language |

---

## Changes

### `src/prompts/builders/rectifier-builder-helpers.ts`

- **C1**: Replaced static `CONTRADICTION_ESCAPE_HATCH` with:
  - Individual exception constants (`EXCEPTION_1_LINT_ONLY` … `EXCEPTION_4_MOCK_HANDOFF`)
  - `buildEscapeHatch({ includeMockHandoff })` — builds the section dynamically; count always matches included exceptions; adds "Before emitting UNRESOLVED, confirm none of Exceptions 1–N apply" line
  - `CONTRADICTION_ESCAPE_HATCH` kept as **3-exception safe-default alias** (not 4 — avoids advertising Exception 4 to non-TDD stories on continuation turns that lack story context)
  - `escapeHatchFor(story)` and `exceptionCountWord(story)` exported for story-aware callers
  - `THREE_SESSION_STRATEGIES` moved before its consumers
- **C3**: Exception 4 broadened with case (b) — language-neutral wording covering missing test infrastructure (hermetic/fixture-backed test surfaces)

### `src/prompts/builders/rectifier-builder.ts`

- **C2**: Six hardcoded "three" strings replaced with `exceptionCountWord(story)`
- `firstAttemptDelta` gains optional `story?: UserStory` — uses `escapeHatchFor(story)` and correct count when provided
- `continuation` and `noOpReprompt` gain optional `story?: UserStory` — use `escapeHatchFor(story)` when provided, 3-exception safe-default otherwise
- `reviewRectification` and `dialogueAwareRectification` use `escapeHatchFor(story)` (were using the static constant)
- `escalated` and `regressionFailure`: appended `escapeHatchFor(story)` — both previously referenced "N narrow exceptions appended below" but never rendered the section; also corrected the dangling phrase "escape valve section" → "appended below"

---

## Tests

**New:** `test/unit/prompts/builders/rectifier-builder-helpers.test.ts` (26 tests)
- TDD path: "four narrow escape valves", "Exceptions 1–4", Exception 4 present with cases (a) and (b)
- Non-TDD path: "three narrow escape valves", "Exceptions 1–3", no Exception 4
- `exceptionCountWord` for all strategy variants
- Integration: `reviewRectification` and `firstAttemptDelta` respect story context

**Updated:** `test/unit/prompts/builders/rectifier-builder.test.ts`
- `CONTRADICTION_ESCAPE_HATCH` suite updated to test `buildEscapeHatch({ includeMockHandoff: true })` directly (the 4-exception TDD hatch)

**Snapshots rebaked:** continuation/noOpReprompt/firstAttemptDelta (no story) now show 3-exception hatch; regressionFailure/escalated now include the full hatch block.

---

## Spec note

The verbatim AC at spec line 454 reads "required mock infrastructure does not yet exist" — this is a copy-paste error; lines 409 and 547 (the authoritative design text) both say "test-infrastructure", which the implementation follows.

---

## Test plan

- `bun run typecheck` — passes
- `bun run lint` — passes  
- `bun run test:bail` — 1106 pass, 0 fail
- Spec ACs manually verified against `buildEscapeHatch` output