### PR TITLE
fix(rectifier): promote agent-gave-up exit to rectificationExhausted (Fix A)

### DIFF
--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -711,6 +711,7 @@ async function runRectification(
     "max-attempts-per-strategy",
     "bail-when",
     "no-strategy",
+    "agent-gave-up",
   ]);
   if (exhaustedReasons.has(cycleResult.exitReason) && cycleResult.finalFindings.length > 0) {
     return { rectificationExhausted: true, unfixedFindings: cycleResult.finalFindings };

--- a/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
+++ b/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
@@ -174,6 +174,7 @@ describe("ExecutionPlan.run() — AC6: rectificationExhausted on cycle exhaustio
     ["max-attempts-per-strategy" as FixCycleExitReason],
     ["bail-when" as FixCycleExitReason],
     ["no-strategy" as FixCycleExitReason],
+    ["agent-gave-up" as FixCycleExitReason],
   ])("AC6: exitReason '%s' with remaining findings → rectificationExhausted=true", async (exitReason) => {
     _storyOrchestratorDeps.runFixCycle = mock(async () => ({
       iterations: [],
@@ -217,6 +218,40 @@ describe("ExecutionPlan.run() — AC6: rectificationExhausted on cycle exhaustio
     expect(result.rectificationExhausted).toBe(true);
     expect(result.unfixedFindings).toBeDefined();
     expect(result.unfixedFindings?.length).toBe(2);
+  });
+
+  test("Fix-A: exitReason 'agent-gave-up' with non-empty finalFindings → rectificationExhausted=true, unfixedFindings populated", async () => {
+    // Spec verbatim AC: Given a rectification cycle that exits with exitReason: "agent-gave-up"
+    // and non-empty finalFindings, the story orchestrator returns
+    // { rectificationExhausted: true, unfixedFindings: cycleResult.finalFindings }.
+    const findings: Finding[] = [LINT_FINDING, TEST_RUNNER_FINDING];
+    _storyOrchestratorDeps.runFixCycle = mock(async () => ({
+      iterations: [],
+      finalFindings: findings,
+      exitReason: "agent-gave-up" as FixCycleExitReason,
+      costUsd: 0,
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
+    const ctx = makeCtx();
+    const plan = makePlanWithRectification(ctx);
+    const result = await plan.run();
+    expect(result.rectificationExhausted).toBe(true);
+    expect(result.unfixedFindings).toBeDefined();
+    expect(result.unfixedFindings?.length).toBe(2);
+    expect(result.unfixedFindings).toEqual(findings);
+  });
+
+  test("Fix-A: exitReason 'agent-gave-up' with EMPTY finalFindings → rectificationExhausted NOT set", async () => {
+    // Edge case: agent gave up but there are no remaining findings — should NOT exhaust
+    _storyOrchestratorDeps.runFixCycle = mock(async () => ({
+      iterations: [],
+      finalFindings: [],
+      exitReason: "agent-gave-up" as FixCycleExitReason,
+      costUsd: 0,
+    })) as typeof _storyOrchestratorDeps.runFixCycle;
+    const ctx = makeCtx();
+    const plan = makePlanWithRectification(ctx);
+    const result = await plan.run();
+    expect(result.rectificationExhausted).not.toBe(true);
   });
 
   test("AC6: exitReason 'resolved' → rectificationExhausted is NOT set to true", async () => {


### PR DESCRIPTION
## Summary

Closes the silent-pause regression introduced when `f38aedf2` deleted `autofix-cycle.ts`. When a rectification cycle exits with `exitReason: "agent-gave-up"` (the agent emits `UNRESOLVED` and voluntarily stops), the orchestrator now returns `{ rectificationExhausted: true, unfixedFindings: [...] }` instead of `{}`, triggering the existing escalate branch in `post-run.ts` to retry at the next model tier.

## Root cause

`src/findings/cycle.ts:289-295` returns `exitReason: "agent-gave-up"` when the agent signals it cannot resolve findings. This is semantically equivalent to running out of retries — findings remain unfixed. However `"agent-gave-up"` was not in the `exhaustedReasons` set in `story-orchestrator.ts`, so the run fell through to `{}` (no action) and paused silently instead of escalating.

## Change

`src/execution/story-orchestrator.ts` — 1 line added to `exhaustedReasons` Set:
- `"agent-gave-up"` now treated identically to `"max-attempts-total"` / `"bail-when"` / `"no-strategy"`
- Existing `finalFindings.length > 0` guard is unchanged — empty-findings case still returns `{}`

## Tests

- Extended `test.each` parametric suite with `"agent-gave-up"` (membership proof)
- Added two explicit Fix-A tests: non-empty findings → `rectificationExhausted=true` + `unfixedFindings` deep-equals cycle result; empty findings → field NOT set
- Existing `post-run-inspection.test.ts` escalation tests already cover the `decideStageAction` downstream path

## Risk

Stories that previously paused silently now escalate to the next tier. This is intended. No callers expect pause semantics on `agent-gave-up` — confirmed by grep of `src/`.

## Spec

`docs/specs/2026-05-26-rectifier-handoff-restoration.md` Fix A

## Test plan

- [x] 17/17 pass in `story-orchestrator-rectification-exhaustion.test.ts`
- [x] 33/33 pass in `post-run-inspection.test.ts`
- [x] 829/829 pass across `test/unit/execution/`
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean