### PR TITLE
fix(escalation): meaningful failure reasons + wire story-orchestrator outcome logs

### DIFF
--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -26,18 +26,29 @@ import { handleMaxAttemptsReached, handleNoTierAvailable } from "./tier-outcome"
 function buildEscalationFailure(
   story: UserStory,
   currentTier: string,
-  reviewFindings?: Finding[],
-  cost?: number,
+  reviewFindings: Finding[] | undefined,
+  cost: number | undefined,
+  pipelineReason: string | undefined,
+  failureCategory: FailureCategory | undefined,
 ): StructuredFailure {
   // AC-3: Use stage='review' when there are semantic review findings
   const stage: import("../../prd/types").VerificationStage =
     reviewFindings && reviewFindings.length > 0 ? "review" : "escalation";
 
+  // Compose a meaningful summary from the actual failure context so priorFailures
+  // surfaces real signal (category + pipeline reason) into the next tier's prompt
+  // instead of the previous hardcoded "Failed with tier X, escalating".
+  const trimmedReason = pipelineReason?.trim();
+  const categoryPart = failureCategory ? ` [${failureCategory}]` : "";
+  const summary = trimmedReason
+    ? `Tier ${currentTier}${categoryPart}: ${trimmedReason}`
+    : `Tier ${currentTier}${categoryPart} failed — no pipeline reason recorded`;
+
   return {
     attempt: (story.attempts ?? 0) + 1,
     modelTier: currentTier,
     stage,
-    summary: `Failed with tier ${currentTier}, escalating to next tier`,
+    summary,
     reviewFindings: reviewFindings && reviewFindings.length > 0 ? reviewFindings : undefined,
     cost: cost ?? 0,
     timestamp: new Date().toISOString(),
@@ -387,7 +398,14 @@ export async function handleTierEscalation(ctx: EscalationHandlerContext): Promi
           : undefined;
 
       // Build escalation failure (BUG-067: include cost for accumulatedAttemptCost in metrics)
-      const escalationFailure = buildEscalationFailure(s, currentStoryTier, escalateReviewFindings, ctx.attemptCost);
+      const escalationFailure = buildEscalationFailure(
+        s,
+        currentStoryTier,
+        escalateReviewFindings,
+        ctx.attemptCost,
+        verifiedPipelineReason,
+        escalateFailureCategory,
+      );
 
       return {
         ...s,

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -529,7 +529,13 @@ export async function decideStageAction(
       logger.warn("execution", "Rate limited — will retry", { storyId: ctx.story.id });
     }
     await cleanupSessionOnFailure(ctx);
-    return { action: "escalate" };
+    const failedPhaseNames = Object.keys(failedPhases);
+    const reasonParts: string[] = [];
+    reasonParts.push(`agent session failed (exit ${agentResult.exitCode ?? "?"})`);
+    if (failureCategory) reasonParts.push(`category=${failureCategory}`);
+    if (agentResult.rateLimited) reasonParts.push("rate-limited");
+    if (failedPhaseNames.length > 0) reasonParts.push(`phases=${failedPhaseNames.join(",")}`);
+    return { action: "escalate", reason: reasonParts.join("; ") };
   }
 
   // Non-TDD success → auto-commit

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -202,10 +202,10 @@ function phaseExplicitlyPassed(output: unknown): boolean {
   return r.success === true || r.passed === true;
 }
 
-function phasePassed(opName: string, output: unknown): boolean {
+function phasePassed(opName: string, output: unknown, storyId?: string): boolean {
   if (output === null || output === undefined) {
     getSafeLogger()?.warn("story-orchestrator", "Phase produced no output — treating as pass", {
-      storyId: undefined,
+      storyId,
       phase: opName,
     });
     return true;
@@ -215,7 +215,7 @@ function phasePassed(opName: string, output: unknown): boolean {
   if ("success" in r) return r.success !== false;
   if ("passed" in r) return r.passed !== false;
   getSafeLogger()?.warn("story-orchestrator", "Phase output has neither 'success' nor 'passed' — treating as pass", {
-    storyId: undefined,
+    storyId,
     phase: opName,
   });
   return true;
@@ -430,6 +430,41 @@ function logUnifiedReviewPhaseStart(storyId: string | undefined, opName: string)
   }
 }
 
+/**
+ * Generic phase outcome log for deterministic / verify / mechanical ops
+ * (verify-scoped, full-suite-gate, lint-check, typecheck-check, etc.).
+ *
+ * TDD phases and review phases have their own dedicated loggers — skip those here
+ * so a single phase doesn't produce duplicate outcome lines.
+ */
+function logDeterministicPhaseOutcome(
+  storyId: string | undefined,
+  opName: string,
+  output: unknown,
+  durationMs: number,
+  isTddPhase: boolean,
+): void {
+  if (isTddPhase) return;
+  if (opName === "semantic-review" || opName === "adversarial-review") return;
+  if (output === null || output === undefined || typeof output !== "object") return;
+
+  const logger = getSafeLogger();
+  const r = output as Record<string, unknown>;
+  const success = r.success === true || r.passed === true;
+  const findingsCount = Array.isArray(r.findings) ? r.findings.length : undefined;
+  const status = typeof r.status === "string" ? r.status : undefined;
+
+  const data: Record<string, unknown> = { storyId, phase: opName, durationMs };
+  if (findingsCount !== undefined) data.findingsCount = findingsCount;
+  if (status !== undefined) data.status = status;
+
+  if (success) {
+    logger?.info("story-orchestrator", `Phase passed: ${opName}`, data);
+  } else {
+    logger?.warn("story-orchestrator", `Phase failed: ${opName}`, data);
+  }
+}
+
 function logUnifiedReviewPhaseResult(storyId: string | undefined, opName: string, output: unknown): void {
   const logger = getSafeLogger();
   const payload = toReviewDecisionPayload(opName, output);
@@ -531,6 +566,7 @@ async function runPhase(
     phaseOutputs[opName] = output;
     emitReviewDecision(ctx, opName, output);
     logUnifiedReviewPhaseResult(ctx.storyId, opName, output);
+    logDeterministicPhaseOutcome(ctx.storyId, opName, output, Date.now() - phaseStartedAt, isTddPhase);
 
     // Post-phase logs (TDD phases only).
     if (isTddPhase) {
@@ -697,11 +733,28 @@ async function runRectification(
 
   phaseOutputs.rectification = { iterationCount: cycleResult.iterations.length };
 
+  // Rectification cycle summary — one line so the JSONL records what happened
+  // (entry findings, iterations run, unfixed findings, exit reason, total cost).
+  const rectLogger = getSafeLogger();
+  const rectSummary = {
+    storyId: ctx.storyId,
+    initialFindingsCount: initialFindings.length,
+    iterationCount: cycleResult.iterations.length,
+    finalFindingsCount: cycleResult.finalFindings.length,
+    exitReason: cycleResult.exitReason,
+    costUsd: cycleResult.costUsd,
+  };
+  if (cycleResult.exitReason === "resolved") {
+    rectLogger?.info("story-orchestrator", "Rectification resolved all findings", rectSummary);
+  } else {
+    rectLogger?.warn("story-orchestrator", `Rectification exited: ${cycleResult.exitReason}`, rectSummary);
+  }
+
   // "validator-error" means runPhase threw during re-validation (e.g. session failure).
   // runFixCycle demotes it to a clean exit rather than throwing, so we surface it here
   // to prevent the failure from being completely silent.
   if (cycleResult.exitReason === "validator-error") {
-    getSafeLogger()?.warn("story-orchestrator", "rectification cycle aborted — validator infrastructure error", {
+    rectLogger?.warn("story-orchestrator", "rectification cycle aborted — validator infrastructure error", {
       storyId: ctx.storyId,
     });
   }
@@ -783,8 +836,12 @@ export class ExecutionPlan {
 
       // Short-circuit on any phase failure (spec §2C: any phase returning success=false halts execution).
       // Exception: phases in shortCircuitExempt continue so rectification can consume their findings.
-      if (!phasePassed(phase.slot.op.name, phaseOutputs[phase.slot.op.name])) {
+      if (!phasePassed(phase.slot.op.name, phaseOutputs[phase.slot.op.name], this.ctx.storyId)) {
         if (!shortCircuitExempt.has(phase.slot.op.name)) {
+          logger?.warn("story-orchestrator", "Short-circuiting on phase failure", {
+            storyId: this.ctx.storyId,
+            phase: phase.slot.op.name,
+          });
           break;
         }
       }
@@ -806,7 +863,11 @@ export class ExecutionPlan {
     // SSOT requires an explicit pass — see `phaseExplicitlyPassed` for why we
     // don't use the defensive `phasePassed` here.
     const verifierPassedSsot = verifierName !== undefined && phaseExplicitlyPassed(phaseOutputs[verifierName]);
-    if (verifierPassedSsot && gateName !== undefined && !phasePassed(gateName, phaseOutputs[gateName])) {
+    if (
+      verifierPassedSsot &&
+      gateName !== undefined &&
+      !phasePassed(gateName, phaseOutputs[gateName], this.ctx.storyId)
+    ) {
       logger?.warn(
         "story-orchestrator",
         "Full-suite gate failed but verifier judged story OK — treating gate failures as unrelated regressions",
@@ -815,15 +876,40 @@ export class ExecutionPlan {
     }
     const success = Object.entries(phaseOutputs).every(([name, output]) => {
       if (verifierPassedSsot && name === gateName) return true;
-      return phasePassed(name, output);
+      return phasePassed(name, output, this.ctx.storyId);
     });
     const totalCostUsd = Object.values(phaseCosts).reduce((sum, cost) => sum + cost, 0);
+    const durationMs = Date.now() - startedAt;
+
+    // Final aggregate log — single end-of-run summary so anyone reading the JSONL
+    // can see the orchestrator's verdict without correlating per-phase lines.
+    const failedPhases = Object.entries(phaseOutputs)
+      .filter(([name, output]) => {
+        if (verifierPassedSsot && name === gateName) return false;
+        return !phasePassed(name, output, this.ctx.storyId);
+      })
+      .map(([name]) => name);
+    const summary: Record<string, unknown> = {
+      storyId: this.ctx.storyId,
+      success,
+      totalCostUsd,
+      durationMs,
+      phaseCount: Object.keys(phaseOutputs).length,
+      failedPhases: failedPhases.length > 0 ? failedPhases : undefined,
+    };
+    if (rectResult.rectificationExhausted) summary.rectificationExhausted = true;
+    if (rectResult.unfixedFindings) summary.unfixedFindingsCount = rectResult.unfixedFindings.length;
+    if (success) {
+      logger?.info("story-orchestrator", "Story orchestration complete", summary);
+    } else {
+      logger?.warn("story-orchestrator", "Story orchestration failed", summary);
+    }
 
     return {
       success,
       phaseCosts,
       totalCostUsd,
-      durationMs: Date.now() - startedAt,
+      durationMs,
       phaseOutputs,
       ...rectResult,
     };

--- a/src/pipeline/stages/execution-helpers.ts
+++ b/src/pipeline/stages/execution-helpers.ts
@@ -40,12 +40,21 @@ export function routeTddFailure(
   isLiteMode: boolean,
   ctx: Pick<PipelineContext, "retryAsLite">,
   reviewReason?: string,
+  failureDetail?: string,
 ): StageResult {
+  // Build a meaningful reason for escalation so priorErrors/priorFailures carry
+  // the failure category (and any extra detail) into the next tier's prompt
+  // instead of a generic "Failed with tier X, escalating".
+  const buildReason = (category: FailureCategory): string => {
+    const trimmedDetail = failureDetail?.trim();
+    return trimmedDetail ? `TDD ${category}: ${trimmedDetail}` : `TDD ${category}`;
+  };
+
   if (failureCategory === "isolation-violation") {
     if (!isLiteMode) {
       ctx.retryAsLite = true;
     }
-    return { action: "escalate" };
+    return { action: "escalate", reason: buildReason("isolation-violation") };
   }
 
   if (
@@ -54,12 +63,12 @@ export function routeTddFailure(
     failureCategory === "full-suite-gate-exhausted" ||
     failureCategory === "verifier-rejected"
   ) {
-    return { action: "escalate" };
+    return { action: "escalate", reason: buildReason(failureCategory) };
   }
 
   // S5: greenfield-no-tests → escalate so tier-escalation can switch to test-after
   if (failureCategory === "greenfield-no-tests") {
-    return { action: "escalate" };
+    return { action: "escalate", reason: buildReason("greenfield-no-tests") };
   }
 
   return {

--- a/test/unit/execution/execution-stage.test.ts
+++ b/test/unit/execution/execution-stage.test.ts
@@ -22,11 +22,12 @@ interface MockContext {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("routeTddFailure", () => {
-  it("escalates on isolation-violation in strict mode", () => {
+  it("escalates on isolation-violation in strict mode with category in reason", () => {
     const ctx: MockContext = {};
     const result = routeTddFailure("isolation-violation", false, ctx);
 
     expect(result.action).toBe("escalate");
+    if (result.action === "escalate") expect(result.reason).toBe("TDD isolation-violation");
     expect(ctx.retryAsLite).toBe(true);
   });
 
@@ -35,47 +36,61 @@ describe("routeTddFailure", () => {
     const result = routeTddFailure("isolation-violation", true, ctx);
 
     expect(result.action).toBe("escalate");
+    if (result.action === "escalate") expect(result.reason).toBe("TDD isolation-violation");
     expect(ctx.retryAsLite).toBeUndefined();
   });
 
-  it("escalates on session-failure", () => {
+  it("escalates on session-failure with category in reason", () => {
     const ctx: MockContext = {};
     const result = routeTddFailure("session-failure", false, ctx);
 
     expect(result.action).toBe("escalate");
+    if (result.action === "escalate") expect(result.reason).toBe("TDD session-failure");
     expect(ctx.retryAsLite).toBeUndefined();
   });
 
-  it("escalates on tests-failing", () => {
+  it("escalates on tests-failing with category in reason", () => {
     const ctx: MockContext = {};
     const result = routeTddFailure("tests-failing", false, ctx);
 
     expect(result.action).toBe("escalate");
+    if (result.action === "escalate") expect(result.reason).toBe("TDD tests-failing");
     expect(ctx.retryAsLite).toBeUndefined();
   });
 
-  it("escalates on full-suite-gate-exhausted", () => {
+  it("escalates on full-suite-gate-exhausted with category in reason", () => {
     const ctx: MockContext = {};
     const result = routeTddFailure("full-suite-gate-exhausted", false, ctx);
 
     expect(result.action).toBe("escalate");
+    if (result.action === "escalate") expect(result.reason).toBe("TDD full-suite-gate-exhausted");
     expect(ctx.retryAsLite).toBeUndefined();
   });
 
-  it("escalates on verifier-rejected", () => {
+  it("escalates on verifier-rejected with category in reason", () => {
     const ctx: MockContext = {};
     const result = routeTddFailure("verifier-rejected", false, ctx);
 
     expect(result.action).toBe("escalate");
+    if (result.action === "escalate") expect(result.reason).toBe("TDD verifier-rejected");
     expect(ctx.retryAsLite).toBeUndefined();
   });
 
-  it("escalates on greenfield-no-tests (tier-escalation will switch to test-after)", () => {
+  it("escalates on greenfield-no-tests with category in reason", () => {
     const ctx: MockContext = {};
     const result = routeTddFailure("greenfield-no-tests", false, ctx);
 
     expect(result.action).toBe("escalate");
+    if (result.action === "escalate") expect(result.reason).toBe("TDD greenfield-no-tests");
     expect(ctx.retryAsLite).toBeUndefined();
+  });
+
+  it("appends failureDetail to escalate reason when provided", () => {
+    const ctx: MockContext = {};
+    const result = routeTddFailure("tests-failing", false, ctx, undefined, "3 tests failing in foo.test.ts");
+
+    expect(result.action).toBe("escalate");
+    if (result.action === "escalate") expect(result.reason).toBe("TDD tests-failing: 3 tests failing in foo.test.ts");
   });
 
   it("pauses on undefined failureCategory", () => {
@@ -83,7 +98,7 @@ describe("routeTddFailure", () => {
     const result = routeTddFailure(undefined, false, ctx, "Unknown failure");
 
     expect(result.action).toBe("pause");
-    expect(result.reason).toBe("Unknown failure");
+    if (result.action === "pause") expect(result.reason).toBe("Unknown failure");
     expect(ctx.retryAsLite).toBeUndefined();
   });
 
@@ -92,7 +107,7 @@ describe("routeTddFailure", () => {
     const result = routeTddFailure("unknown" as FailureCategory, false, ctx);
 
     expect(result.action).toBe("pause");
-    expect(result.reason).toBe("Three-session TDD requires review");
+    if (result.action === "pause") expect(result.reason).toBe("Three-session TDD requires review");
     expect(ctx.retryAsLite).toBeUndefined();
   });
 
@@ -101,7 +116,7 @@ describe("routeTddFailure", () => {
     const result = routeTddFailure(undefined, false, ctx, "Custom reason for pause");
 
     expect(result.action).toBe("pause");
-    expect(result.reason).toBe("Custom reason for pause");
+    if (result.action === "pause") expect(result.reason).toBe("Custom reason for pause");
   });
 
   it("defaults to generic pause message when no reviewReason provided", () => {
@@ -109,7 +124,7 @@ describe("routeTddFailure", () => {
     const result = routeTddFailure(undefined, false, ctx);
 
     expect(result.action).toBe("pause");
-    expect(result.reason).toBe("Three-session TDD requires review");
+    if (result.action === "pause") expect(result.reason).toBe("Three-session TDD requires review");
   });
 
   it("handles all known failure categories correctly", () => {


### PR DESCRIPTION
## Summary

Two related observability fixes uncovered while investigating why escalations carried only "Failed with tier balanced, escalating to next tier" into the next tier's prompt, and why PR #1109's new outcome logs were not appearing in run JSONLs.

### 1. Escalation reasons (commits 1–2)

Before, every tier escalation wrote a generic `Failed with tier X, escalating to next tier` string into `priorErrors` and `priorFailures`. Those then got injected into the next tier's prompt at priority 95/90 — section heading, no signal.

Two root causes:

- `routeTddFailure` (`src/pipeline/stages/execution-helpers.ts`) returned bare `{ action: "escalate" }` for every TDD failure category. `tier-escalation.ts` builds its `errorMessage` from `ctx.pipelineResult.reason`, so an empty reason collapsed the message to `Attempt N failed with model tier: balanced` with no detail.
- `buildEscalationFailure` (`src/execution/escalation/tier-escalation.ts`) hardcoded `summary: "Failed with tier X, escalating to next tier"` instead of using the pipeline reason that just came in.

Fix:

- `routeTddFailure` now attaches `reason: "TDD <failureCategory>[: <detail>]"` to every escalate branch.
- `buildEscalationFailure` now composes its summary from the verified pipeline reason and `failureCategory`, falling back to a clearly diagnostic message when no reason was recorded (so missing reasons are visible, not silent).
- Audit of all 7 `{ action: "escalate" }` sites confirmed the last remaining bare escalate in `post-run.ts:532` (agent-session-failed path) now carries exit code, category, rate-limit flag, and failed phase names.

Wire-up verified end-to-end:

```
stage.execute()  → StageResult.reason
runner.ts:135    → PipelineRunResult.reason
pipeline-result-handler.ts:296 → handleTierEscalation(pipelineResult)
tier-escalation.ts:358 → rawPipelineReason
                     → verifyEscalationQuotes (preserves on no citations)
                     → errorMessage (priorErrors)
                     → buildEscalationFailure.summary (priorFailures)
context/builder.ts:100-114 → next-tier prompt @ priority 95/90
```

Parallel-batch path also verified through `parallel-worker.ts` → `parallel-batch.ts` → `unified-executor.ts`.

### 2. Story-orchestrator outcome logging (commit 4)

PR #1109 added outcome logs to `ScopedStrategy` / `RegressionStrategy`, but those classes are only invoked through `verificationOrchestrator`, reached from a single site (`src/pipeline/stages/regression.ts`). The story orchestrator's actual execution path dispatches `verifyScopedOp` / `fullSuiteGateOp` / `lintCheckOp` / `typecheckCheckOp` / `verifierOp` / `semanticReviewOp` / `adversarialReviewOp` through `callOp` and those ops call the underlying quality/verification helpers directly — never touching the strategy classes. PR #1109's logs still fire on the older pipeline-stage path but are dead for the orchestrator-driven path.

Fix: wire outcome logging at the single dispatch point (`runPhase`) so coverage is uniform across every phase:

- `logDeterministicPhaseOutcome` — new helper emitting `Phase passed: <opName>` / `Phase failed: <opName>` (warn) with `durationMs`, `findingsCount`, `status`. Skips TDD and review phases so each phase produces exactly one outcome line.
- Short-circuit log when a non-exempt phase failure halts execution — previously the loop just `break`ed silently.
- Rectification cycle summary (`Rectification resolved all findings` / `Rectification exited: <reason>`) with initial/final findings counts, iteration count, exit reason, and `costUsd`.
- Final aggregate (`Story orchestration complete` / `... failed`) with `success`, `totalCostUsd`, `durationMs`, `phaseCount`, and `failedPhases` (excluding the gate when verifier-SSOT exempts it).
- `phasePassed()` defensive warns ("no output" / "neither success nor passed") now carry real `storyId` instead of `undefined`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `timeout 120 bun test test/unit/execution/ test/unit/review/ test/unit/verification/ test/integration/pipeline/ test/unit/operations/ test/unit/tdd/ --timeout=10000` — 2392 pass / 0 fail
- [x] `timeout 60 bun test test/unit/execution/escalation/ test/unit/metrics/tracker-escalation.test.ts --timeout=10000` — 77 pass / 0 fail
- [ ] Run a failing story locally and confirm priorErrors contains the new reason instead of the generic "Failed with tier X" string
- [ ] Run a story locally and confirm the JSONL now contains `Phase passed/failed`, `Rectification exited`, and `Story orchestration complete` lines