### PR TITLE
fix(execution): fail-closed malformed outputs for strict verdict phases

### DIFF
--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -41,6 +41,13 @@ export const _storyOrchestratorDeps = {
 };
 
 const TDD_OP_NAMES = new Set<string>(["test-writer", "implementer", "verifier"]);
+const STRICT_VERDICT_PHASE_NAMES = new Set<string>([
+  fullSuiteGateOp.name,
+  verifyScopedOp.name,
+  lintCheckOp.name,
+  typecheckCheckOp.name,
+  verifierOp.name,
+]);
 
 export interface OrchestratorSlot<I, O, C> {
   readonly op: RunOperation<I, O, C>;
@@ -203,22 +210,42 @@ function phaseExplicitlyPassed(output: unknown): boolean {
 }
 
 function phasePassed(opName: string, output: unknown, storyId?: string): boolean {
+  const strictVerdictPhase = STRICT_VERDICT_PHASE_NAMES.has(opName);
   if (output === null || output === undefined) {
-    getSafeLogger()?.warn("story-orchestrator", "Phase produced no output — treating as pass", {
+    getSafeLogger()?.warn(
+      "story-orchestrator",
+      strictVerdictPhase
+        ? "Strict phase produced no output — treating as fail"
+        : "Phase produced no output — treating as pass",
+      {
+        storyId,
+        phase: opName,
+      },
+    );
+    return !strictVerdictPhase;
+  }
+  if (typeof output !== "object") {
+    if (!strictVerdictPhase) return true;
+    getSafeLogger()?.warn("story-orchestrator", "Strict phase produced non-object output — treating as fail", {
       storyId,
       phase: opName,
     });
-    return true;
+    return false;
   }
-  if (typeof output !== "object") return true;
   const r = output as Record<string, unknown>;
   if ("success" in r) return r.success !== false;
   if ("passed" in r) return r.passed !== false;
-  getSafeLogger()?.warn("story-orchestrator", "Phase output has neither 'success' nor 'passed' — treating as pass", {
-    storyId,
-    phase: opName,
-  });
-  return true;
+  getSafeLogger()?.warn(
+    "story-orchestrator",
+    strictVerdictPhase
+      ? "Strict phase output has neither 'success' nor 'passed' — treating as fail"
+      : "Phase output has neither 'success' nor 'passed' — treating as pass",
+    {
+      storyId,
+      phase: opName,
+    },
+  );
+  return !strictVerdictPhase;
 }
 
 /**

--- a/test/unit/execution/story-orchestrator.test.ts
+++ b/test/unit/execution/story-orchestrator.test.ts
@@ -953,6 +953,103 @@ describe("AC-6: short-circuit carve-out for gate + verifier when rectification c
     }
   });
 
+  test("strict verdict phases fail-closed when output has no success/passed keys", async () => {
+    const config = makeNaxConfig();
+    rt = makeTestRuntime({ config });
+
+    const malformedGateOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG> = {
+      kind: "deterministic",
+      name: "full-suite-gate",
+      stage: "verify",
+      config: testSel,
+      execute: async () => ({ status: "execution-failed", findings: [] }),
+    };
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.callOp = async (_ctx: any, op: any, input: any) => {
+      if (op.kind === "deterministic") return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    };
+
+    try {
+      const ctx: CallContext = {
+        runtime: rt,
+        packageView: rt.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-t",
+      } as any;
+
+      const plan = new (require("@/execution/story-orchestrator").StoryOrchestratorBuilder)()
+        .addImplementer({ op: mockImplementerOp, input: { code: "" } })
+        .addFullSuiteGate({ op: malformedGateOp, input: { story: { id: "US-t" } as any, workdir: "/tmp" } })
+        .build(ctx);
+
+      const result = await plan.run();
+      expect(result.success).toBe(false);
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+    }
+  });
+
+  test.each([
+    ["full-suite-gate", undefined],
+    ["verify-scoped", "not-an-object"],
+    ["lint-check", { status: "execution-failed" }],
+    ["typecheck-check", { findings: [] }],
+    ["verifier", { filesChanged: [], estimatedCostUsd: 0 }],
+  ] as const)("strict phase %s fails-closed on malformed output", async (phaseName, malformedOutput) => {
+    const config = makeNaxConfig();
+    rt = makeTestRuntime({ config });
+
+    const malformedStrictOp: DeterministicOperation<unknown, unknown, typeof DEFAULT_CONFIG> = {
+      kind: "deterministic",
+      name: phaseName,
+      stage: "verify",
+      config: testSel,
+      execute: async () => malformedOutput,
+    };
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.callOp = async (_ctx: any, op: any, input: any) => {
+      if (op.kind === "deterministic") return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    };
+
+    try {
+      const ctx: CallContext = {
+        runtime: rt,
+        packageView: rt.packages.repo(),
+        packageDir: "/tmp",
+        agentName: "claude",
+        storyId: "US-t",
+      } as any;
+
+      const builder = new (require("@/execution/story-orchestrator").StoryOrchestratorBuilder)().addImplementer({
+        op: mockImplementerOp,
+        input: { code: "" },
+      });
+
+      if (phaseName === "full-suite-gate") {
+        builder.addFullSuiteGate({ op: malformedStrictOp, input: { story: { id: "US-t" } as any, workdir: "/tmp" } });
+      } else if (phaseName === "verify-scoped") {
+        builder.addVerifyScoped({ op: malformedStrictOp, input: { story: { id: "US-t" } as any, workdir: "/tmp" } });
+      } else if (phaseName === "lint-check") {
+        builder.addLintCheck({ op: malformedStrictOp, input: { story: { id: "US-t" } as any, workdir: "/tmp" } });
+      } else if (phaseName === "typecheck-check") {
+        builder.addTypecheckCheck({ op: malformedStrictOp, input: { story: { id: "US-t" } as any, workdir: "/tmp" } });
+      } else {
+        builder.addVerifier({ op: malformedStrictOp, input: { code: "" } });
+      }
+
+      const plan = builder.build(ctx);
+      const result = await plan.run();
+      expect(result.success).toBe(false);
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+    }
+  });
+
   test("verifier-failed: gate failure still fails the plan (no SSOT override)", async () => {
     // Verifier-as-SSOT only applies when verifier passed. If verifier also failed,
     // aggregation must reflect both failures.


### PR DESCRIPTION
## Summary
- make strict verdict phases fail-closed when phase output is malformed (missing `success`/`passed`, null/undefined, or non-object)
- remove string-literal drift risk by deriving strict phase names from operation constants (`*.name`)
- add table-driven tests for malformed outputs across strict phases (`full-suite-gate`, `verify-scoped`, `lint-check`, `typecheck-check`, `verifier`)

## Why
This prevents silent pass behavior when full-suite/lint/typecheck/verifier style phases return malformed envelopes, which could hide compilation/typecheck/test execution failures.

## Validation
- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run test` ✅
