### PR TITLE
fix(review): wire stat/diff/testInventory into orchestrator review inputs

### DIFF
--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -23,6 +23,7 @@ import type {
 } from "../operations";
 import type { UserStory } from "../prd/types";
 import { TddPromptBuilder } from "../prompts";
+import { prepareAdversarialReviewInput, prepareSemanticReviewInput } from "../review";
 import type { ResolvedTestPatterns } from "../test-runners";
 import { resolveTestFilePatterns } from "../test-runners/resolver";
 import { isThreeSessionStrategy } from "./build-plan-for-strategy";
@@ -258,33 +259,88 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
       ? { workdir: ctx.workdir, storyId: story.id }
       : undefined;
 
-  const semanticReviewInput: SemanticReviewInput | undefined =
-    ctx.config.review?.enabled === true && ctx.config.review.checks?.includes("semantic") && ctx.config.review.semantic
-      ? {
+  // Semantic and adversarial review inputs must carry stat/diff (and for adversarial,
+  // testInventory) so the prompt's "## Changed Files" block is populated. The legacy
+  // runSemanticCheck / runAdversarialReview paths collected these before calling callOp;
+  // the orchestrator path must do the same or the reviewer LLM falsely concludes
+  // "diff is empty" and skips every AC. prepareSemanticReviewInput / prepareAdversarialReviewInput
+  // are the shared SSOT for that collection.
+  const semanticEnabled =
+    ctx.config.review?.enabled === true &&
+    ctx.config.review.checks?.includes("semantic") &&
+    !!ctx.config.review.semantic;
+  const semanticReviewInput: SemanticReviewInput | undefined = semanticEnabled
+    ? await (async (): Promise<SemanticReviewInput | undefined> => {
+        const prepared = await prepareSemanticReviewInput({
+          workdir: ctx.workdir,
+          projectDir: ctx.projectDir,
+          storyId: story.id,
+          storyGitRef: ctx.storyGitRef,
+          config: ctx.config,
+          naxIgnoreIndex: ctx.naxIgnoreIndex,
+          // biome-ignore lint/style/noNonNullAssertion: semanticEnabled guards presence
+          semanticConfig: ctx.config.review!.semantic!,
+        });
+        // Skip slot entirely when stat is empty / no ref — orchestrator will see no
+        // semantic-review phase and mark the check as not-applicable.
+        if (prepared.skipReason) return undefined;
+        return {
           workdir: ctx.workdir,
           story,
-          semanticConfig: ctx.config.review.semantic,
-          mode: ctx.config.review.semantic.diffMode,
-          storyGitRef: ctx.storyGitRef,
+          // biome-ignore lint/style/noNonNullAssertion: semanticEnabled guards presence
+          semanticConfig: ctx.config.review!.semantic!,
+          // biome-ignore lint/style/noNonNullAssertion: semanticEnabled guards presence
+          mode: ctx.config.review!.semantic!.diffMode,
+          storyGitRef: prepared.effectiveRef,
+          stat: prepared.stat,
+          diff: prepared.diff,
+          excludePatterns: prepared.excludePatterns,
           featureCtxBlock: buildFeatureCtxBlock(ctx, "reviewer-semantic"),
-          blockingThreshold: ctx.config.review.blockingThreshold,
-        }
-      : undefined;
+          priorSemanticIterations: ctx.priorSemanticIterations,
+          // biome-ignore lint/style/noNonNullAssertion: semanticEnabled guards presence
+          blockingThreshold: ctx.config.review!.blockingThreshold,
+        };
+      })()
+    : undefined;
 
-  const adversarialReviewInput: AdversarialReviewInput | undefined =
+  const adversarialEnabled =
     ctx.config.review?.enabled === true &&
     ctx.config.review.checks?.includes("adversarial") &&
-    ctx.config.review.adversarial
-      ? {
+    !!ctx.config.review.adversarial;
+  const adversarialReviewInput: AdversarialReviewInput | undefined = adversarialEnabled
+    ? await (async (): Promise<AdversarialReviewInput | undefined> => {
+        const prepared = await prepareAdversarialReviewInput({
+          workdir: ctx.workdir,
+          projectDir: ctx.projectDir,
+          storyId: story.id,
+          storyGitRef: ctx.storyGitRef,
+          config: ctx.config,
+          naxIgnoreIndex: ctx.naxIgnoreIndex,
+          // biome-ignore lint/style/noNonNullAssertion: adversarialEnabled guards presence
+          adversarialConfig: ctx.config.review!.adversarial!,
+        });
+        if (prepared.skipReason) return undefined;
+        return {
           workdir: ctx.workdir,
           story,
-          adversarialConfig: ctx.config.review.adversarial,
-          mode: ctx.config.review.adversarial.diffMode,
-          storyGitRef: ctx.storyGitRef,
+          // biome-ignore lint/style/noNonNullAssertion: adversarialEnabled guards presence
+          adversarialConfig: ctx.config.review!.adversarial!,
+          // biome-ignore lint/style/noNonNullAssertion: adversarialEnabled guards presence
+          mode: ctx.config.review!.adversarial!.diffMode,
+          storyGitRef: prepared.effectiveRef,
+          stat: prepared.stat,
+          diff: prepared.diff,
+          testInventory: prepared.testInventory,
+          excludePatterns: prepared.excludePatterns,
+          testGlobs: prepared.testGlobs,
+          refExcludePatterns: prepared.refExcludePatterns,
           featureCtxBlock: buildFeatureCtxBlock(ctx, "reviewer-adversarial"),
-          blockingThreshold: ctx.config.review.blockingThreshold,
-        }
-      : undefined;
+          priorAdversarialIterations: ctx.priorAdversarialIterations,
+          // biome-ignore lint/style/noNonNullAssertion: adversarialEnabled guards presence
+          blockingThreshold: ctx.config.review!.blockingThreshold,
+        };
+      })()
+    : undefined;
 
   const rectificationInput: RectificationPhaseOptions | undefined =
     ctx.config.execution?.rectification?.enabled === true

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -181,6 +181,16 @@ export interface PipelineContext extends DispatchContext {
   rectifyAttempt?: number;
   /** ADR-022 Phase 7: prior fix-cycle iterations carried across pipeline retries. */
   autofixPriorIterations?: Iteration[];
+  /**
+   * Prior semantic review iterations carried into this pipeline pass — populated by
+   * escalation/rectification orchestrators on re-run so the reviewer LLM can see
+   * what the prior reviewer flagged and classify each finding as
+   * addressed / still-blocking / never-an-issue. Forwarded into the review op input
+   * by plan-inputs.ts.
+   */
+  priorSemanticIterations?: Iteration[];
+  /** Mirror of priorSemanticIterations for adversarial review. */
+  priorAdversarialIterations?: Iteration[];
   /** Git HEAD ref captured before agent ran this attempt (FEAT-010: precise smart-runner diff) */
   storyGitRef?: string;
   /** Collected story metrics (set by completionStage) */

--- a/src/review/index.ts
+++ b/src/review/index.ts
@@ -10,6 +10,7 @@ export * from "./adversarial";
 export * from "./semantic-evidence";
 export * from "./categorization";
 export * from "./diff-utils";
+export * from "./prepare-inputs";
 export * from "./finding-projection";
 export * from "./types";
 export * from "./runner";

--- a/src/review/prepare-inputs.ts
+++ b/src/review/prepare-inputs.ts
@@ -1,0 +1,223 @@
+/**
+ * Prepare review op inputs.
+ *
+ * Shared collection logic that gathers stat / diff / testInventory for the
+ * semantic and adversarial review ops. Called from plan-inputs.ts so the
+ * orchestrator path produces the same SemanticReviewInput / AdversarialReviewInput
+ * shape that the legacy runSemanticCheck / runAdversarialReview paths produce.
+ *
+ * Without this, the orchestrator was constructing inputs with stat/diff/testInventory
+ * left undefined, causing the prompt's "## Changed Files" block to render as an
+ * empty code fence and misleading the reviewer LLM into emitting a spurious
+ * "diff is empty — cannot verify ACs" finding.
+ */
+
+import { relative, sep } from "node:path";
+import { DEFAULT_CONFIG, reviewConfigSelector } from "../config";
+import type { NaxConfig } from "../config/schema";
+import type { AdversarialReviewConfig, SemanticReviewConfig } from "../review/types";
+import { resolveReviewExcludePatterns, resolveTestFilePatterns } from "../test-runners";
+import type { NaxIgnoreIndex } from "../utils/path-filters";
+import {
+  DIFF_CAP_BYTES,
+  collectDiff,
+  collectDiffStat,
+  computeTestInventory,
+  resolveEffectiveRef,
+  truncateDiff,
+} from "./diff-utils";
+import type { TestInventory } from "./diff-utils";
+
+export interface PrepareReviewInputArgs {
+  workdir: string;
+  projectDir?: string;
+  storyId: string;
+  storyGitRef: string | undefined;
+  config: NaxConfig;
+  naxIgnoreIndex?: NaxIgnoreIndex;
+}
+
+export interface PreparedSemanticReviewInput {
+  /** Resolved git baseline ref to diff against. Undefined => skip review. */
+  effectiveRef: string | undefined;
+  /** `git diff --stat` output (file inventory + change counts). */
+  stat: string;
+  /** Full diff text (embedded mode only; truncated if oversize). */
+  diff: string | undefined;
+  /** Pathspec exclude patterns (test files etc.) used to build diff. */
+  excludePatterns: string[];
+  /** When set, callers should skip the review and report this reason. */
+  skipReason?: string;
+}
+
+export interface PreparedAdversarialReviewInput {
+  effectiveRef: string | undefined;
+  stat: string;
+  diff: string | undefined;
+  testInventory: TestInventory | undefined;
+  excludePatterns: string[];
+  /** Test-file globs surfaced for the adversarial test-gap audit prompt. */
+  testGlobs: readonly string[];
+  /** Pathspec excludes for production-only diff command in the prompt. */
+  refExcludePatterns: readonly string[];
+  skipReason?: string;
+}
+
+function derivePackageDirs(
+  workdir: string,
+  projectDir: string | undefined,
+): {
+  repoRoot: string;
+  packageDir: string | undefined;
+  packageDirRelative: string | undefined;
+} {
+  const repoRoot = projectDir ?? workdir;
+  const packageDir = workdir !== repoRoot ? workdir : undefined;
+  let packageDirRelative: string | undefined;
+  if (projectDir && workdir !== projectDir) {
+    const rel = relative(projectDir, workdir);
+    if (rel !== ".." && !rel.startsWith(`..${sep}`)) {
+      packageDirRelative = rel && rel !== "." ? rel : undefined;
+    }
+  }
+  return { repoRoot, packageDir, packageDirRelative };
+}
+
+/**
+ * Collect stat/diff for semantic review.
+ *
+ * - Always collects `stat` (file inventory rendered in both modes).
+ * - Collects `diff` only when `semanticConfig.diffMode === "embedded"`.
+ * - Returns `skipReason` when stat is empty (no changes) so the caller can
+ *   short-circuit and avoid spawning the reviewer for a no-op.
+ */
+export async function prepareSemanticReviewInput(
+  args: PrepareReviewInputArgs & { semanticConfig: SemanticReviewConfig },
+): Promise<PreparedSemanticReviewInput> {
+  const { workdir, projectDir, storyId, storyGitRef, config, naxIgnoreIndex, semanticConfig } = args;
+
+  const effectiveRef = await resolveEffectiveRef(workdir, storyGitRef, storyId);
+  if (!effectiveRef) {
+    return {
+      effectiveRef: undefined,
+      stat: "",
+      diff: undefined,
+      excludePatterns: [],
+      skipReason: "no git ref",
+    };
+  }
+
+  const { packageDir, packageDirRelative } = derivePackageDirs(workdir, projectDir);
+  const stat = await collectDiffStat(workdir, effectiveRef, { naxIgnoreIndex, packageDir });
+
+  const resolved = await resolveTestFilePatterns(
+    config ?? reviewConfigSelector.select(DEFAULT_CONFIG),
+    projectDir ?? workdir,
+    packageDirRelative,
+  );
+  const excludePatterns = [...resolveReviewExcludePatterns(semanticConfig.excludePatterns, resolved)];
+
+  const diffMode = semanticConfig.diffMode ?? "ref";
+
+  if (diffMode === "ref") {
+    if (!stat) {
+      return { effectiveRef, stat: "", diff: undefined, excludePatterns, skipReason: "no changes detected" };
+    }
+    return { effectiveRef, stat, diff: undefined, excludePatterns };
+  }
+
+  const rawDiff = await collectDiff(workdir, effectiveRef, excludePatterns, { naxIgnoreIndex, packageDir });
+  const diff = truncateDiff(rawDiff, rawDiff.length > DIFF_CAP_BYTES ? stat : undefined);
+  if (!diff) {
+    return { effectiveRef, stat, diff: undefined, excludePatterns, skipReason: "no production code changes" };
+  }
+  return { effectiveRef, stat, diff, excludePatterns };
+}
+
+/**
+ * Collect stat/diff/testInventory for adversarial review.
+ *
+ * - Always collects `stat`.
+ * - In `embedded` mode: collects full diff (test files included — adversarial
+ *   sees everything) + precomputed TestInventory for the test-gap audit.
+ * - In `ref` mode: testInventory is left undefined; the reviewer self-serves
+ *   the file list via the diff command in the prompt.
+ */
+export async function prepareAdversarialReviewInput(
+  args: PrepareReviewInputArgs & { adversarialConfig: AdversarialReviewConfig },
+): Promise<PreparedAdversarialReviewInput> {
+  const { workdir, projectDir, storyId, storyGitRef, config, naxIgnoreIndex, adversarialConfig } = args;
+
+  const effectiveRef = await resolveEffectiveRef(workdir, storyGitRef, storyId);
+  if (!effectiveRef) {
+    return {
+      effectiveRef: undefined,
+      stat: "",
+      diff: undefined,
+      testInventory: undefined,
+      excludePatterns: [],
+      testGlobs: [],
+      refExcludePatterns: [],
+      skipReason: "no git ref",
+    };
+  }
+
+  const { packageDir, packageDirRelative } = derivePackageDirs(workdir, projectDir);
+  const stat = await collectDiffStat(workdir, effectiveRef, { naxIgnoreIndex, packageDir });
+
+  const effectiveConfig = config ?? reviewConfigSelector.select(DEFAULT_CONFIG);
+  const resolved = await resolveTestFilePatterns(effectiveConfig, projectDir ?? workdir, packageDirRelative);
+  const refExcludePatterns = [...resolveReviewExcludePatterns(adversarialConfig.excludePatterns, resolved)];
+  const testGlobs = resolved.globs ?? [];
+  const excludePatterns: string[] = [...(adversarialConfig.excludePatterns ?? [])];
+
+  const diffMode = adversarialConfig.diffMode ?? "ref";
+  const testFilePatterns =
+    (typeof config?.execution?.smartTestRunner === "object"
+      ? config.execution.smartTestRunner?.testFilePatterns
+      : undefined) ?? undefined;
+
+  if (diffMode === "ref") {
+    if (!stat) {
+      return {
+        effectiveRef,
+        stat: "",
+        diff: undefined,
+        testInventory: undefined,
+        excludePatterns,
+        testGlobs,
+        refExcludePatterns,
+        skipReason: "no changes detected",
+      };
+    }
+    return {
+      effectiveRef,
+      stat,
+      diff: undefined,
+      testInventory: undefined,
+      excludePatterns,
+      testGlobs,
+      refExcludePatterns,
+    };
+  }
+
+  // embedded mode
+  const diff = await collectDiff(workdir, effectiveRef, excludePatterns, { naxIgnoreIndex, packageDir });
+  if (!diff) {
+    return {
+      effectiveRef,
+      stat,
+      diff: undefined,
+      testInventory: undefined,
+      excludePatterns,
+      testGlobs,
+      refExcludePatterns,
+      skipReason: "no code changes",
+    };
+  }
+  const testInventory = await computeTestInventory(workdir, effectiveRef, testFilePatterns, {
+    naxIgnoreIndex,
+    packageDir,
+  });
+  return { effectiveRef, stat, diff, testInventory, excludePatterns, testGlobs, refExcludePatterns };
+}

--- a/test/unit/execution/plan-inputs-review-wiring.test.ts
+++ b/test/unit/execution/plan-inputs-review-wiring.test.ts
@@ -1,7 +1,51 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import { assemblePlanInputsFromCtx } from "../../../src/execution/plan-inputs";
 import type { NaxConfig } from "../../../src/config/schema";
+import { _diffUtilsDeps } from "../../../src/review";
+
+// ─── Spawn mock for diff-utils used inside prepare-inputs ──────────────────────
+
+function makeSpawnSequence(outputs: string[]) {
+  let i = 0;
+  return mock((_opts: unknown) => {
+    const out = outputs[i] ?? "";
+    i += 1;
+    return {
+      exited: Promise.resolve(0),
+      stdout: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(out));
+          c.close();
+        },
+      }),
+      stderr: new ReadableStream({ start: (c) => c.close() }),
+      kill: () => {},
+    };
+  }) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+const STAT_OUT = " src/foo.ts | 5 +-\n 1 file changed, 5 insertions(+)\n";
+
+let origSpawn: typeof _diffUtilsDeps.spawn;
+let origIsValid: typeof _diffUtilsDeps.isGitRefValid;
+let origMergeBase: typeof _diffUtilsDeps.getMergeBase;
+
+beforeEach(() => {
+  origSpawn = _diffUtilsDeps.spawn;
+  origIsValid = _diffUtilsDeps.isGitRefValid;
+  origMergeBase = _diffUtilsDeps.getMergeBase;
+  _diffUtilsDeps.isGitRefValid = mock(async () => true);
+  _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+  // Default: stat returns something so review slot populates.
+  _diffUtilsDeps.spawn = makeSpawnSequence([STAT_OUT, STAT_OUT]);
+});
+
+afterEach(() => {
+  _diffUtilsDeps.spawn = origSpawn;
+  _diffUtilsDeps.isGitRefValid = origIsValid;
+  _diffUtilsDeps.getMergeBase = origMergeBase;
+});
 
 function makeCtx(configOverride: Partial<NaxConfig> = {}) {
   const config: NaxConfig = {
@@ -80,4 +124,55 @@ describe("assemblePlanInputsFromCtx — review + rectification wiring", () => {
     expect(inputs.rectification!.maxAttempts).toBe(2);
   });
 
+  test("semantic review input carries stat and effectiveRef in ref mode", async () => {
+    const ctx = makeCtx({
+      review: { ...DEFAULT_CONFIG.review, enabled: true, checks: ["semantic"] },
+    });
+    ctx.storyGitRef = "abc123";
+    const inputs = await assemblePlanInputsFromCtx(ctx);
+    expect(inputs.semanticReview).toBeDefined();
+    expect(inputs.semanticReview!.stat).toContain("src/foo.ts");
+    expect(inputs.semanticReview!.storyGitRef).toBe("abc123");
+    expect(inputs.semanticReview!.diff).toBeUndefined();
+  });
+
+  test("semantic review slot is omitted when no changes detected", async () => {
+    _diffUtilsDeps.spawn = makeSpawnSequence([""]); // empty stat
+    const ctx = makeCtx({
+      review: { ...DEFAULT_CONFIG.review, enabled: true, checks: ["semantic"] },
+    });
+    ctx.storyGitRef = "abc123";
+    const inputs = await assemblePlanInputsFromCtx(ctx);
+    expect(inputs.semanticReview).toBeUndefined();
+  });
+
+  test("adversarial review input carries stat, testGlobs, refExcludePatterns", async () => {
+    const ctx = makeCtx({
+      review: { ...DEFAULT_CONFIG.review, enabled: true, checks: ["adversarial"] },
+    });
+    ctx.storyGitRef = "abc123";
+    const inputs = await assemblePlanInputsFromCtx(ctx);
+    expect(inputs.adversarialReview).toBeDefined();
+    expect(inputs.adversarialReview!.stat).toContain("src/foo.ts");
+    expect(inputs.adversarialReview!.refExcludePatterns?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  test("priorSemanticIterations on ctx threads into semantic input", async () => {
+    const ctx = makeCtx({
+      review: { ...DEFAULT_CONFIG.review, enabled: true, checks: ["semantic"] },
+    });
+    ctx.storyGitRef = "abc123";
+    const priorIter = {
+      iterationNum: 1,
+      findingsBefore: [],
+      fixesApplied: [],
+      findingsAfter: [],
+      outcome: "unchanged" as const,
+      startedAt: "2026-01-01T00:00:00Z",
+      finishedAt: "2026-01-01T00:00:01Z",
+    };
+    ctx.priorSemanticIterations = [priorIter];
+    const inputs = await assemblePlanInputsFromCtx(ctx);
+    expect(inputs.semanticReview!.priorSemanticIterations).toEqual([priorIter]);
+  });
 });

--- a/test/unit/execution/plan-inputs.test.ts
+++ b/test/unit/execution/plan-inputs.test.ts
@@ -11,12 +11,33 @@
  * - AC6: Validation behavior is covered by targeted unit tests
  */
 
-import { describe, test, expect } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { NaxError } from "@/errors";
 import { assemblePlanInputs, assemblePlanInputsFromCtx, type PlanInputs } from "@/execution";
+import { _diffUtilsDeps } from "@/review";
 import type { ResolvedTestPatterns } from "@/test-runners";
 import { makeStory, makeNaxConfig } from "@test/helpers";
 import { DEFAULT_CONFIG } from "@/config";
+
+// Helper: stub git-diff spawn so review-input prep can resolve stat. The orchestrator
+// path calls collectDiffStat before constructing review inputs; tests that assert
+// the slots populate must provide a non-empty stat or the slot is correctly skipped.
+function makeStatSpawn(stat: string) {
+  return mock(
+    (_opts: unknown) =>
+      ({
+        exited: Promise.resolve(0),
+        stdout: new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode(stat));
+            c.close();
+          },
+        }),
+        stderr: new ReadableStream({ start: (c) => c.close() }),
+        kill: () => {},
+      }) as unknown,
+  ) as unknown as typeof _diffUtilsDeps.spawn;
+}
 
 const FAKE_PATTERNS: ResolvedTestPatterns = {
   globs: [],
@@ -407,39 +428,57 @@ describe("PlanInputs — AC1: new optional slots (US-005)", () => {
   });
 
   test("AC1: assemblePlanInputsFromCtx populates semanticReview when check enabled and config present", async () => {
-    const ctx = makeNonTddCtx({
-      review: {
-        ...DEFAULT_CONFIG.review,
-        enabled: true,
-        checks: ["semantic"],
-      },
-    });
-    ctx.storyGitRef = "abc123";
-    const inputs = await assemblePlanInputsFromCtx(ctx);
-    expect(inputs.semanticReview).toBeDefined();
-    expect(inputs.semanticReview?.storyGitRef).toBe("abc123");
+    const origSpawn = _diffUtilsDeps.spawn;
+    const origIsValid = _diffUtilsDeps.isGitRefValid;
+    _diffUtilsDeps.spawn = makeStatSpawn(" src/foo.ts | 5 +-\n 1 file changed\n");
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    try {
+      const ctx = makeNonTddCtx({
+        review: {
+          ...DEFAULT_CONFIG.review,
+          enabled: true,
+          checks: ["semantic"],
+        },
+      });
+      ctx.storyGitRef = "abc123";
+      const inputs = await assemblePlanInputsFromCtx(ctx);
+      expect(inputs.semanticReview).toBeDefined();
+      expect(inputs.semanticReview?.storyGitRef).toBe("abc123");
+    } finally {
+      _diffUtilsDeps.spawn = origSpawn;
+      _diffUtilsDeps.isGitRefValid = origIsValid;
+    }
   });
 
   test("AC1: assemblePlanInputsFromCtx populates adversarialReview when check enabled and config present", async () => {
-    const ctx = makeNonTddCtx({
-      review: {
-        ...DEFAULT_CONFIG.review,
-        enabled: true,
-        checks: ["adversarial"],
-        adversarial: {
-          model: "balanced",
-          diffMode: "ref",
-          rules: [],
-          timeoutMs: 600_000,
-          parallel: false,
-          maxConcurrentSessions: 2,
+    const origSpawn = _diffUtilsDeps.spawn;
+    const origIsValid = _diffUtilsDeps.isGitRefValid;
+    _diffUtilsDeps.spawn = makeStatSpawn(" src/foo.ts | 5 +-\n 1 file changed\n");
+    _diffUtilsDeps.isGitRefValid = mock(async () => true);
+    try {
+      const ctx = makeNonTddCtx({
+        review: {
+          ...DEFAULT_CONFIG.review,
+          enabled: true,
+          checks: ["adversarial"],
+          adversarial: {
+            model: "balanced",
+            diffMode: "ref",
+            rules: [],
+            timeoutMs: 600_000,
+            parallel: false,
+            maxConcurrentSessions: 2,
+          },
         },
-      },
-    });
-    ctx.storyGitRef = "abc123";
-    const inputs = await assemblePlanInputsFromCtx(ctx);
-    expect(inputs.adversarialReview).toBeDefined();
-    expect(inputs.adversarialReview?.storyGitRef).toBe("abc123");
+      });
+      ctx.storyGitRef = "abc123";
+      const inputs = await assemblePlanInputsFromCtx(ctx);
+      expect(inputs.adversarialReview).toBeDefined();
+      expect(inputs.adversarialReview?.storyGitRef).toBe("abc123");
+    } finally {
+      _diffUtilsDeps.spawn = origSpawn;
+      _diffUtilsDeps.isGitRefValid = origIsValid;
+    }
   });
 });
 

--- a/test/unit/review/prepare-inputs.test.ts
+++ b/test/unit/review/prepare-inputs.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for src/review/prepare-inputs.ts
+ *
+ * Validates that:
+ *  - stat is always collected (both modes)
+ *  - skip-on-empty-stat triggers in ref mode
+ *  - diff is collected only in embedded mode
+ *  - adversarial computeTestInventory runs only in embedded mode
+ *  - excludePatterns / testGlobs / refExcludePatterns flow through
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { DEFAULT_CONFIG } from "@/config";
+import { _diffUtilsDeps } from "@/review";
+import { prepareAdversarialReviewInput, prepareSemanticReviewInput } from "@/review";
+import type { AdversarialReviewConfig, SemanticReviewConfig } from "@/review/types";
+
+function makeSpawnSequence(outputs: string[]) {
+  let i = 0;
+  return mock((_opts: unknown) => {
+    const out = outputs[i] ?? "";
+    i += 1;
+    return {
+      exited: Promise.resolve(0),
+      stdout: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode(out));
+          c.close();
+        },
+      }),
+      stderr: new ReadableStream({ start: (c) => c.close() }),
+      kill: () => {},
+    };
+  }) as unknown as typeof _diffUtilsDeps.spawn;
+}
+
+const STAT_OUT = " src/foo.ts | 5 +-\n 1 file changed, 5 insertions(+)\n";
+const DIFF_OUT = "diff --git a/src/foo.ts b/src/foo.ts\n+const x = 1;\n";
+
+const baseSemanticConfig: SemanticReviewConfig = {
+  model: "balanced" as const,
+  diffMode: "ref",
+  resetRefOnRerun: false,
+  rules: [],
+  timeoutMs: 600_000,
+};
+
+const baseAdversarialConfig: AdversarialReviewConfig = {
+  ...baseSemanticConfig,
+} as AdversarialReviewConfig;
+
+let origSpawn: typeof _diffUtilsDeps.spawn;
+let origIsValid: typeof _diffUtilsDeps.isGitRefValid;
+let origMergeBase: typeof _diffUtilsDeps.getMergeBase;
+
+beforeEach(() => {
+  origSpawn = _diffUtilsDeps.spawn;
+  origIsValid = _diffUtilsDeps.isGitRefValid;
+  origMergeBase = _diffUtilsDeps.getMergeBase;
+  _diffUtilsDeps.isGitRefValid = mock(async () => true);
+  _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+});
+
+afterEach(() => {
+  _diffUtilsDeps.spawn = origSpawn;
+  _diffUtilsDeps.isGitRefValid = origIsValid;
+  _diffUtilsDeps.getMergeBase = origMergeBase;
+});
+
+describe("prepareSemanticReviewInput", () => {
+  test("ref mode: collects stat, no diff, returns effectiveRef and excludePatterns", async () => {
+    _diffUtilsDeps.spawn = makeSpawnSequence([STAT_OUT]);
+    const result = await prepareSemanticReviewInput({
+      workdir: "/tmp/repo",
+      storyId: "S1",
+      storyGitRef: "abc123",
+      config: DEFAULT_CONFIG,
+      semanticConfig: baseSemanticConfig,
+    });
+    expect(result.effectiveRef).toBe("abc123");
+    expect(result.stat).toContain("src/foo.ts");
+    expect(result.diff).toBeUndefined();
+    expect(result.skipReason).toBeUndefined();
+    expect(result.excludePatterns.length).toBeGreaterThan(0);
+  });
+
+  test("ref mode: empty stat returns skipReason", async () => {
+    _diffUtilsDeps.spawn = makeSpawnSequence([""]);
+    const result = await prepareSemanticReviewInput({
+      workdir: "/tmp/repo",
+      storyId: "S1",
+      storyGitRef: "abc123",
+      config: DEFAULT_CONFIG,
+      semanticConfig: baseSemanticConfig,
+    });
+    expect(result.skipReason).toBe("no changes detected");
+    expect(result.stat).toBe("");
+  });
+
+  test("embedded mode: collects both stat and diff", async () => {
+    _diffUtilsDeps.spawn = makeSpawnSequence([STAT_OUT, DIFF_OUT]);
+    const result = await prepareSemanticReviewInput({
+      workdir: "/tmp/repo",
+      storyId: "S1",
+      storyGitRef: "abc123",
+      config: DEFAULT_CONFIG,
+      semanticConfig: { ...baseSemanticConfig, diffMode: "embedded" },
+    });
+    expect(result.stat).toContain("src/foo.ts");
+    expect(result.diff).toContain("diff --git");
+    expect(result.skipReason).toBeUndefined();
+  });
+
+  test("no ref + no merge-base fallback returns skipReason", async () => {
+    _diffUtilsDeps.isGitRefValid = mock(async () => false);
+    _diffUtilsDeps.getMergeBase = mock(async () => undefined);
+    _diffUtilsDeps.spawn = makeSpawnSequence([""]);
+    const result = await prepareSemanticReviewInput({
+      workdir: "/tmp/repo",
+      storyId: "S1",
+      storyGitRef: undefined,
+      config: DEFAULT_CONFIG,
+      semanticConfig: baseSemanticConfig,
+    });
+    expect(result.skipReason).toBe("no git ref");
+    expect(result.effectiveRef).toBeUndefined();
+  });
+});
+
+describe("prepareAdversarialReviewInput", () => {
+  test("ref mode: collects stat, no diff, no testInventory; surfaces testGlobs", async () => {
+    _diffUtilsDeps.spawn = makeSpawnSequence([STAT_OUT]);
+    const result = await prepareAdversarialReviewInput({
+      workdir: "/tmp/repo",
+      storyId: "S1",
+      storyGitRef: "abc123",
+      config: DEFAULT_CONFIG,
+      adversarialConfig: baseAdversarialConfig,
+    });
+    expect(result.stat).toContain("src/foo.ts");
+    expect(result.diff).toBeUndefined();
+    expect(result.testInventory).toBeUndefined();
+    expect(result.refExcludePatterns.length).toBeGreaterThan(0);
+    // testGlobs surface is non-empty for the default TS config
+    expect(Array.isArray(result.testGlobs)).toBe(true);
+  });
+
+  test("ref mode: empty stat returns skipReason", async () => {
+    _diffUtilsDeps.spawn = makeSpawnSequence([""]);
+    const result = await prepareAdversarialReviewInput({
+      workdir: "/tmp/repo",
+      storyId: "S1",
+      storyGitRef: "abc123",
+      config: DEFAULT_CONFIG,
+      adversarialConfig: baseAdversarialConfig,
+    });
+    expect(result.skipReason).toBe("no changes detected");
+  });
+
+  test("embedded mode: collects stat, diff, and computes testInventory", async () => {
+    // sequence: stat, diff, computeTestInventory (--name-only --diff-filter=A)
+    _diffUtilsDeps.spawn = makeSpawnSequence([STAT_OUT, DIFF_OUT, "src/foo.ts\nsrc/foo.test.ts\n"]);
+    const result = await prepareAdversarialReviewInput({
+      workdir: "/tmp/repo",
+      storyId: "S1",
+      storyGitRef: "abc123",
+      config: DEFAULT_CONFIG,
+      adversarialConfig: { ...baseAdversarialConfig, diffMode: "embedded" },
+    });
+    expect(result.stat).toContain("src/foo.ts");
+    expect(result.diff).toContain("diff --git");
+    expect(result.testInventory).toBeDefined();
+    expect(result.testInventory?.addedTestFiles ?? []).toContain("src/foo.test.ts");
+  });
+});


### PR DESCRIPTION
## What

Fixes a regression where the story-orchestrator's review path constructed `SemanticReviewInput` / `AdversarialReviewInput` with `stat`, `diff`, and `testInventory` left undefined. The prompt's `## Changed Files` block rendered as an empty code fence, and the reviewer LLM concluded *"diff is empty — cannot verify ACs 1-N"* even when the working tree had real changes against the story baseline.

## Why

Real-world report against v0.67.12: a story (`screener-ui-web-us-001`) hit semantic review with a single finding *"Cannot verify ACs 1-30: The diff is empty"*, yet `git diff --name-only $baseline..HEAD` from the CLI returned 26 changed files. The PRD's `storyGitRef` was correct and the prompt was structurally well-formed; the bug was that the orchestrator never collected the diff stat before dispatching the reviewer.

Root cause: `plan-inputs.ts:261-287` built the review input from `ctx` directly and skipped the stat/diff collection that the legacy `runSemanticCheck` / `runAdversarialReview` paths (`src/review/semantic.ts:144-194`, `src/review/adversarial.ts:142-220`) perform. As a result every orchestrator-driven review saw an empty stat block and the LLM short-circuited without running the `git diff` commands in the prompt.

The same hole affected adversarial review (missing `stat`, `diff`, `testInventory`, `testGlobs`, `refExcludePatterns`, `priorAdversarialIterations`) and prior-iteration context was never threaded for either reviewer.

Closes #

## How

- **`src/review/prepare-inputs.ts`** (new) — single source of truth for review-input collection. `prepareSemanticReviewInput` / `prepareAdversarialReviewInput` resolve the effective git ref, run `collectDiffStat`, optionally `collectDiff` + `truncateDiff` (embedded mode) and `computeTestInventory` (adversarial embedded mode), and compute exclude patterns. Returns `skipReason` for the empty-stat / no-ref short-circuits so callers omit the slot entirely instead of scheduling a no-op review.
- **`src/execution/plan-inputs.ts`** — calls the new helpers; when `skipReason` is set the review slot resolves to `undefined` and the orchestrator skips that phase, matching legacy `runSemanticCheck` behavior.
- **`src/pipeline/types.ts`** — adds `priorSemanticIterations` / `priorAdversarialIterations` fields on `PipelineContext`. `plan-inputs.ts` forwards them into the review input so escalation/rectification orchestrators can carry prior reviewer findings into the next pass once they begin populating these fields.
- **`src/review/index.ts`** — barrel re-export.

### Design notes

- "Option 2" (move collection into the op) was the preferred plan, but `RunOperation.build()` is sync by contract and adding an async prep hook would ripple through every op. The shared helper called from `plan-inputs.ts` keeps a single SSOT for the collection logic without changing the op interface.
- In `ref` mode the `## Changed Files` block stays — it's `git diff --stat` output (file names + change counts), which is the right scope hint for a self-serving reviewer. The bug was *not* the block existing; it was the block being empty.

## Testing

- [x] Tests added/updated
- [x] Full test suite passes (unit + integration + ui via `bun run test:bail`)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

New / updated tests:
- `test/unit/review/prepare-inputs.test.ts` (new, 7 cases) — both diff modes, skip-on-empty-stat, no-git-ref fallback, `computeTestInventory` in adversarial embedded mode.
- `test/unit/execution/plan-inputs-review-wiring.test.ts` (+4 cases) — semantic + adversarial slots populate with stat in ref mode; empty stat skips the slot; `priorSemanticIterations` threads through.
- `test/unit/execution/plan-inputs.test.ts` — existing AC1 tests updated to mock the new `_diffUtilsDeps.spawn` calls.

## Notes

- **Follow-up #1120 (deliberately out of scope here):** the legacy `runSemanticCheck` / `runAdversarialReview` paths still inline their own stat / ref / pattern resolution. They should adopt `prepareSemanticReviewInput` / `prepareAdversarialReviewInput` to collapse the SSOT — tracked separately to keep this PR focused on the user-reported bug.
- **Follow-up (deliberately out of scope):** the new `priorSemanticIterations` / `priorAdversarialIterations` fields on `PipelineContext` are wired through to the input but no producer populates them yet. Populating requires per-iteration before/after finding tracking in the escalation orchestrator — a separate change.
- No `mock.module()` introduced. All new test mocks use the existing `_diffUtilsDeps` DI pattern.
- No changes to prompt builders.
