### PR TITLE
feat(verification): port ScopedStrategy into verifyScopedOp — Phase 1+2 (issue #1116)

### DIFF
--- a/docs/architecture/subsystems.md
+++ b/docs/architecture/subsystems.md
@@ -308,6 +308,29 @@ interface VerifyResult {
 }
 ```
 
+### Strategy → Op envelope mapping (issue #1116)
+
+`ScopedStrategy.VerifyResult` → `VerifyScopedOutput`:
+
+| Strategy field | Op field | Notes |
+|:---|:---|:---|
+| `status: "PASS" \| "FAIL" \| "SKIPPED"` | `success` + `status: "passed" \| "failed" \| "skipped" \| "timeout"` | Op uses explicit status union |
+| `rawOutput` | (in `findings` + log) | Raw output goes through findings + outcome log, not envelope |
+| `passCount` | `passCount` | Same |
+| `failCount` | (in `findings.length`) | Derived |
+| `durationMs` | `durationMs` | Same |
+| `scopeTestFallback` | `scopeTestFallback?: boolean` | New |
+| `failures: StructuredTestFailure[]` | `findings: Finding[]` | Already converted via `testSummaryToFindings` |
+| `countsTowardEscalation` | (in outcome log only) | Story-orchestrator decides escalation |
+
+`RegressionStrategy.VerifyResult` → `FullSuiteGateOutput`:
+
+| Strategy field | Op field | Notes |
+|:---|:---|:---|
+| `status: "PASS" \| "FAIL" \| "SKIPPED"` | `status: "passed" \| "failed" \| "skipped" \| "passed-on-timeout" \| "execution-failed"` | Op adds explicit timeout-accept status |
+| acceptOnTimeout TIMEOUT → PASS | TIMEOUT → `status: "passed-on-timeout"`, `passed: true` | BUG-026 semantics preserved |
+| `enabled: false` → SKIPPED | `status: "skipped"`, `success: true` | Same |
+
 ---
 
 ## §22 Routing & Classification

--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -108,9 +108,7 @@ export function validatePlanInputs(story: UserStory, config: NaxConfig): void {
  * build-plan-for-strategy.ts), so verifyScopedOp's deferred skip — "no mapped tests → SKIPPED" —
  * is already the correct no-op behavior for scope-level verification.
  */
-function toVerifyScopedMode(
-  mode: "deferred" | "per-story" | "disabled" | undefined,
-): "deferred" | "per-story" {
+function toVerifyScopedMode(mode: "deferred" | "per-story" | "disabled" | undefined): "deferred" | "per-story" {
   if (mode === "per-story") return "per-story";
   return "deferred"; // "deferred", "disabled", and undefined all produce deferred behavior
 }

--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -100,6 +100,14 @@ export function validatePlanInputs(story: UserStory, config: NaxConfig): void {
   }
 }
 
+/** Maps the full regressionGate.mode union to the two-value subset accepted by VerifyScopedInput. */
+function toVerifyScopedMode(
+  mode: "deferred" | "per-story" | "disabled" | undefined,
+): "deferred" | "per-story" {
+  if (mode === "per-story") return "per-story";
+  return "deferred"; // "deferred", "disabled", and undefined all fall through to deferred
+}
+
 export function assemblePlanInputs(
   story: UserStory,
   config: NaxConfig,
@@ -248,7 +256,15 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
 
   // verifyScoped: present for non-TDD strategies (TDD uses fullSuiteGate + verifier instead)
   const verifyScopedInput: VerifyScopedInput | undefined = !_isTdd
-    ? { workdir: ctx.workdir, storyId: story.id }
+    ? {
+        workdir: ctx.workdir,
+        storyId: story.id,
+        storyGitRef: ctx.storyGitRef,
+        naxIgnoreIndex: ctx.naxIgnoreIndex,
+        // "disabled" mode means the regression gate is fully off; treat as "deferred" for
+        // verifyScopedOp (scope-level behavior unchanged — fullSuiteGateOp handles enabled=false).
+        regressionMode: toVerifyScopedMode(ctx.config.execution?.regressionGate?.mode),
+      }
     : undefined;
 
   // lintCheck: gated by review.checks includes "lint" and a lint command is configured

--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -100,12 +100,19 @@ export function validatePlanInputs(story: UserStory, config: NaxConfig): void {
   }
 }
 
-/** Maps the full regressionGate.mode union to the two-value subset accepted by VerifyScopedInput. */
+/**
+ * Maps the full regressionGate.mode union to the two-value subset accepted by VerifyScopedInput.
+ *
+ * "disabled" maps to "deferred" because verifyScopedOp doesn't need a separate disabled path:
+ * when mode is "disabled", fullSuiteGateOp is never added to the plan (handled in
+ * build-plan-for-strategy.ts), so verifyScopedOp's deferred skip — "no mapped tests → SKIPPED" —
+ * is already the correct no-op behavior for scope-level verification.
+ */
 function toVerifyScopedMode(
   mode: "deferred" | "per-story" | "disabled" | undefined,
 ): "deferred" | "per-story" {
   if (mode === "per-story") return "per-story";
-  return "deferred"; // "deferred", "disabled", and undefined all fall through to deferred
+  return "deferred"; // "deferred", "disabled", and undefined all produce deferred behavior
 }
 
 export function assemblePlanInputs(

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -2,32 +2,51 @@ import { qualityConfigSelector } from "../config";
 import type { QualityConfig } from "../config/selectors";
 import { testSummaryToFindings } from "../findings";
 import type { Finding } from "../findings/types";
-import type { QualityCommandOptions, QualityCommandResult } from "../quality/runner";
-import { runQualityCommand } from "../quality/runner";
-import { parseTestOutput } from "../test-runners";
-import type { TestSummary } from "../test-runners";
+import { getLogger } from "../logger";
+import { parseTestOutput, selectScopedTests, _scopedSelectionDeps } from "../test-runners";
+import type { SelectScopedTestsResult, TestSummary } from "../test-runners";
+import type { NaxIgnoreIndex } from "../utils/path-filters";
+import { regression } from "../verification/runners";
+import type { VerificationGateOptions, VerificationResult } from "../verification/types";
 import type { CallContext, DeterministicOperation } from "./types";
+
+// Re-export _scopedSelectionDeps so tests can snapshot/restore it alongside _verifyScopedDeps.
+export { _scopedSelectionDeps };
 
 export interface VerifyScopedInput {
   readonly workdir: string;
   readonly storyId: string;
   readonly packageDir?: string;
+  /** Git ref to diff against for smart-runner change detection. Required for change-aware scoping. */
+  readonly storyGitRef?: string;
+  /** Resolved `.naxignore` index passed through to smart-runner. */
+  readonly naxIgnoreIndex?: NaxIgnoreIndex;
+  /** Regression-gate mode — controls SKIPPED behavior when no tests are mapped. */
+  readonly regressionMode?: "deferred" | "per-story";
 }
+
+export type VerifyScopedStatus = "passed" | "failed" | "skipped" | "timeout";
 
 export interface VerifyScopedOutput {
   readonly success: boolean;
+  readonly status: VerifyScopedStatus;
   readonly findings: Finding[];
   readonly durationMs: number;
+  readonly passCount: number;
+  readonly isFullSuite: boolean;
+  readonly scopeTestFallback?: boolean;
 }
 
 export interface VerifyScopedDeps {
-  runQualityCommand: (opts: QualityCommandOptions) => Promise<QualityCommandResult>;
+  selectScopedTests: (input: Parameters<typeof selectScopedTests>[0]) => Promise<SelectScopedTestsResult>;
+  regression: (opts: VerificationGateOptions) => Promise<VerificationResult>;
   parseTestOutput: (output: string) => TestSummary;
   testSummaryToFindings: (summary: TestSummary) => Finding[];
 }
 
 export const _verifyScopedDeps: VerifyScopedDeps = {
-  runQualityCommand,
+  selectScopedTests,
+  regression,
   parseTestOutput,
   testSummaryToFindings,
 };
@@ -42,28 +61,146 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     ctx: CallContext,
     deps: VerifyScopedDeps = _verifyScopedDeps,
   ): Promise<VerifyScopedOutput> {
-    // ctx.config is injected by tests; in production resolved via callOp's config slice
+    const logger = getLogger();
     const ctxConfig = (ctx as unknown as { config?: QualityConfig }).config;
-    const command = ctxConfig?.quality?.commands?.test;
+    const baseCommand = ctxConfig?.quality?.commands?.test;
 
-    if (ctxConfig !== undefined && !command) {
-      return { success: true, findings: [], durationMs: 0 };
+    if (ctxConfig !== undefined && !baseCommand) {
+      // No test command configured — preserve current no-op behavior.
+      return {
+        success: true,
+        status: "passed",
+        findings: [],
+        durationMs: 0,
+        passCount: 0,
+        isFullSuite: true,
+      };
     }
 
-    const start = Date.now();
-    const result = await deps.runQualityCommand({
-      commandName: "test",
-      command: command ?? "",
+    const regressionMode = input.regressionMode ?? "deferred";
+    // Note: smart-runner config lives at execution.smartTestRunner (not quality.smartRunner).
+    // qualityConfigSelector picks both "quality" and "execution" keys (see src/config/selectors.ts:74).
+    const selection = await deps.selectScopedTests({
       workdir: input.workdir,
       storyId: input.storyId,
+      storyGitRef: input.storyGitRef,
+      testCommand: baseCommand ?? "",
+      testScopedTemplate: ctxConfig?.quality?.commands?.testScoped,
+      smartRunnerConfig: (ctxConfig as unknown as { execution?: { smartTestRunner?: unknown } })?.execution
+        ?.smartTestRunner,
+      scopeTestThreshold: ctxConfig?.quality?.scopeTestThreshold,
+      fallbackFullSuiteCommand: ctxConfig?.quality?.commands?.test,
+      naxIgnoreIndex: input.naxIgnoreIndex,
     });
 
-    if (result.exitCode === 0) {
-      return { success: true, findings: [], durationMs: Date.now() - start };
+    // Deferred mode + no mapped tests + not a monorepo orchestrator → SKIP.
+    if (
+      selection.isFullSuite &&
+      regressionMode === "deferred" &&
+      !selection.isMonorepoOrchestrator &&
+      !selection.thresholdFallback
+    ) {
+      logger.info("verify[scoped]", "No mapped tests — deferring to run-end (mode: deferred)", {
+        storyId: input.storyId,
+      });
+      return {
+        success: true,
+        status: "skipped",
+        findings: [],
+        durationMs: 0,
+        passCount: 0,
+        isFullSuite: true,
+        scopeTestFallback: selection.scopeTestFallback,
+      };
     }
 
-    const summary = deps.parseTestOutput(result.output);
-    const findings = deps.testSummaryToFindings(summary);
-    return { success: false, findings, durationMs: Date.now() - start };
+    if (selection.isFullSuite && !selection.isMonorepoOrchestrator) {
+      logger.info("verify[scoped]", "No mapped tests — falling back to full suite", {
+        storyId: input.storyId,
+      });
+    } else if (selection.isMonorepoOrchestrator) {
+      logger.info("verify[scoped]", "Monorepo orchestrator detected — delegating scoping to tool", {
+        storyId: input.storyId,
+        command: selection.effectiveCommand,
+      });
+    }
+
+    // NOTE: regression() includes a 2s sleep before running tests (src/verification/runners.ts:142-145)
+    // for agent-cleanup. The legacy ScopedStrategy also used regression(), so this preserves parity
+    // — it is NOT a new perf regression introduced by this port.
+    const start = Date.now();
+    const result = await deps.regression({
+      workdir: input.workdir,
+      command: selection.effectiveCommand,
+      timeoutSeconds: (ctxConfig as unknown as { execution?: { regressionGate?: { timeoutSeconds?: number } } })
+        ?.execution?.regressionGate?.timeoutSeconds ?? 600,
+      // acceptOnTimeout is not consumed by runVerificationCore — the runner returns status="TIMEOUT"
+      // and the caller (this op) decides accept-on-timeout policy. The op currently does not accept
+      // scoped-test timeouts as pass; full-suite gate is the only place that does.
+      forceExit: ctxConfig?.quality?.forceExit,
+      detectOpenHandles: ctxConfig?.quality?.detectOpenHandles,
+      detectOpenHandlesRetries: ctxConfig?.quality?.detectOpenHandlesRetries,
+      gracePeriodMs: ctxConfig?.quality?.gracePeriodMs,
+      drainTimeoutMs: ctxConfig?.quality?.drainTimeoutMs,
+      shell: ctxConfig?.quality?.shell,
+      stripEnvVars: ctxConfig?.quality?.stripEnvVars,
+    });
+    const durationMs = Date.now() - start;
+    const parsed = result.output ? deps.parseTestOutput(result.output) : { passed: 0, failed: 0, failures: [] };
+
+    if (result.success) {
+      logger.info("verify[scoped]", "Scoped tests passed", {
+        storyId: input.storyId,
+        passCount: parsed.passed,
+        durationMs,
+        scopeTestFallback: selection.scopeTestFallback ?? false,
+        isFullSuite: selection.isFullSuite,
+      });
+      return {
+        success: true,
+        status: "passed",
+        findings: [],
+        durationMs,
+        passCount: parsed.passed,
+        isFullSuite: selection.isFullSuite,
+        scopeTestFallback: selection.scopeTestFallback,
+      };
+    }
+
+    if (result.status === "TIMEOUT") {
+      logger.warn("verify[scoped]", "Scoped tests timed out", {
+        storyId: input.storyId,
+        durationMs,
+        scopeTestFallback: selection.scopeTestFallback ?? false,
+        isFullSuite: selection.isFullSuite,
+      });
+      return {
+        success: false,
+        status: "timeout",
+        findings: [],
+        durationMs,
+        passCount: parsed.passed,
+        isFullSuite: selection.isFullSuite,
+        scopeTestFallback: selection.scopeTestFallback,
+      };
+    }
+
+    logger.warn("verify[scoped]", "Scoped tests failed", {
+      storyId: input.storyId,
+      passCount: parsed.passed,
+      failCount: parsed.failed,
+      durationMs,
+      scopeTestFallback: selection.scopeTestFallback ?? false,
+      isFullSuite: selection.isFullSuite,
+    });
+    return {
+      success: false,
+      status: "failed",
+      findings: deps.testSummaryToFindings(parsed),
+      durationMs,
+      passCount: parsed.passed,
+      isFullSuite: selection.isFullSuite,
+      scopeTestFallback: selection.scopeTestFallback,
+    };
   },
 };

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -3,13 +3,12 @@ import type { QualityConfig } from "../config/selectors";
 import { testSummaryToFindings } from "../findings";
 import type { Finding } from "../findings/types";
 import { getLogger } from "../logger";
-import { parseTestOutput, selectScopedTests, _scopedSelectionDeps } from "../test-runners";
+import { _scopedSelectionDeps, parseTestOutput, selectScopedTests } from "../test-runners";
 import type { SelectScopedTestsResult, TestSummary } from "../test-runners";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
 import { regression } from "../verification/runners";
 import type { VerificationGateOptions, VerificationResult } from "../verification/types";
 import type { CallContext, DeterministicOperation } from "./types";
-
 
 export interface VerifyScopedInput {
   readonly workdir: string;

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -10,8 +10,6 @@ import { regression } from "../verification/runners";
 import type { VerificationGateOptions, VerificationResult } from "../verification/types";
 import type { CallContext, DeterministicOperation } from "./types";
 
-// Re-export _scopedSelectionDeps so tests can snapshot/restore it alongside _verifyScopedDeps.
-export { _scopedSelectionDeps };
 
 export interface VerifyScopedInput {
   readonly workdir: string;
@@ -65,8 +63,8 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     const ctxConfig = (ctx as unknown as { config?: QualityConfig }).config;
     const baseCommand = ctxConfig?.quality?.commands?.test;
 
-    if (ctxConfig !== undefined && !baseCommand) {
-      // No test command configured — preserve current no-op behavior.
+    // Guard: no config at all, or config present but no test command → no-op.
+    if (!ctxConfig || !baseCommand) {
       return {
         success: true,
         status: "passed",
@@ -85,11 +83,12 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
       storyId: input.storyId,
       storyGitRef: input.storyGitRef,
       testCommand: baseCommand ?? "",
-      testScopedTemplate: ctxConfig?.quality?.commands?.testScoped,
-      smartRunnerConfig: (ctxConfig as unknown as { execution?: { smartTestRunner?: unknown } })?.execution
-        ?.smartTestRunner,
-      scopeTestThreshold: ctxConfig?.quality?.scopeTestThreshold,
-      fallbackFullSuiteCommand: ctxConfig?.quality?.commands?.test,
+      testScopedTemplate: ctxConfig.quality?.commands?.testScoped,
+      // smartTestRunner lives at execution.smartTestRunner; QualityConfig includes execution
+      // via qualityConfigSelector = pickSelector("quality", "quality", "execution").
+      smartRunnerConfig: ctxConfig.execution?.smartTestRunner,
+      scopeTestThreshold: ctxConfig.quality?.scopeTestThreshold,
+      fallbackFullSuiteCommand: ctxConfig.quality?.commands?.test,
       naxIgnoreIndex: input.naxIgnoreIndex,
     });
 
@@ -132,18 +131,18 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     const result = await deps.regression({
       workdir: input.workdir,
       command: selection.effectiveCommand,
-      timeoutSeconds: (ctxConfig as unknown as { execution?: { regressionGate?: { timeoutSeconds?: number } } })
-        ?.execution?.regressionGate?.timeoutSeconds ?? 600,
+      // regressionGate.timeoutSeconds lives in execution; QualityConfig includes execution.
+      timeoutSeconds: ctxConfig.execution?.regressionGate?.timeoutSeconds ?? 600,
       // acceptOnTimeout is not consumed by runVerificationCore — the runner returns status="TIMEOUT"
       // and the caller (this op) decides accept-on-timeout policy. The op currently does not accept
       // scoped-test timeouts as pass; full-suite gate is the only place that does.
-      forceExit: ctxConfig?.quality?.forceExit,
-      detectOpenHandles: ctxConfig?.quality?.detectOpenHandles,
-      detectOpenHandlesRetries: ctxConfig?.quality?.detectOpenHandlesRetries,
-      gracePeriodMs: ctxConfig?.quality?.gracePeriodMs,
-      drainTimeoutMs: ctxConfig?.quality?.drainTimeoutMs,
-      shell: ctxConfig?.quality?.shell,
-      stripEnvVars: ctxConfig?.quality?.stripEnvVars,
+      forceExit: ctxConfig.quality?.forceExit,
+      detectOpenHandles: ctxConfig.quality?.detectOpenHandles,
+      detectOpenHandlesRetries: ctxConfig.quality?.detectOpenHandlesRetries,
+      gracePeriodMs: ctxConfig.quality?.gracePeriodMs,
+      drainTimeoutMs: ctxConfig.quality?.drainTimeoutMs,
+      shell: ctxConfig.quality?.shell,
+      stripEnvVars: ctxConfig.quality?.stripEnvVars,
     });
     const durationMs = Date.now() - start;
     const parsed = result.output ? deps.parseTestOutput(result.output) : { passed: 0, failed: 0, failures: [] };

--- a/src/test-runners/index.ts
+++ b/src/test-runners/index.ts
@@ -35,3 +35,11 @@ export type { ResolvedTestPatterns } from "./resolver";
 export { analyzeTestExitCode, formatFailureSummary, parseBunTestOutput, parseTestOutput } from "./parser";
 export { parseTestFailures } from "./ac-parser";
 export type { TestFailure, TestOutputAnalysis, TestSummary } from "./types";
+export {
+  selectScopedTests,
+  buildScopedCommand,
+  coerceSmartRunner,
+  isMonorepoOrchestratorCommand,
+  _scopedSelectionDeps,
+} from "./scoped-selection";
+export type { SelectScopedTestsInput, SelectScopedTestsResult } from "./scoped-selection";

--- a/src/test-runners/scoped-selection.ts
+++ b/src/test-runners/scoped-selection.ts
@@ -25,7 +25,7 @@ const DEFAULT_SMART_RUNNER_CONFIG = {
 export interface SmartRunnerConfigRaw {
   enabled?: boolean;
   testFilePatterns?: string[];
-  fallback?: "import-grep" | "none";
+  fallback?: "import-grep" | "full-suite";
 }
 
 export function coerceSmartRunner(val: unknown) {
@@ -81,61 +81,74 @@ export async function selectScopedTests(input: SelectScopedTestsInput): Promise<
   const isMonorepoOrchestrator = isMonorepoOrchestratorCommand(input.testCommand);
   const threshold = input.scopeTestThreshold ?? 10;
 
-  let effectiveCommand = input.testCommand;
-  let isFullSuite = true;
-  let scopeTestFallback: boolean | undefined;
-  let thresholdFallback = false;
+  const fullSuite = (opts?: { scopeTestFallback?: boolean; thresholdFallback?: boolean }): SelectScopedTestsResult => ({
+    effectiveCommand: input.fallbackFullSuiteCommand ?? input.testCommand,
+    isFullSuite: true,
+    scopeTestFallback: opts?.scopeTestFallback,
+    thresholdFallback: opts?.thresholdFallback ?? false,
+    isMonorepoOrchestrator,
+  });
 
-  if (smartCfg.enabled && input.storyGitRef && !isMonorepoOrchestrator) {
-    const nonTestFiles = await _scopedSelectionDeps.getChangedNonTestFiles(
-      input.workdir,
-      input.storyGitRef,
-      undefined,
-      globsToTestRegex(smartCfg.testFilePatterns),
-      input.naxIgnoreIndex,
-    );
-    const pass1Files = await _scopedSelectionDeps.mapSourceToTests(nonTestFiles, input.workdir);
-    if (pass1Files.length > threshold) {
-      logger.warn(
-        "verify[scoped]",
-        `Scoped test file count ${pass1Files.length} exceeds threshold ${threshold} — falling back to full suite`,
-        { storyId: input.storyId },
-      );
-      effectiveCommand = input.fallbackFullSuiteCommand ?? input.testCommand;
-      scopeTestFallback = true;
-      thresholdFallback = true;
-    } else if (pass1Files.length > 0) {
-      logger.info("verify[scoped]", `Pass 1: path convention matched ${pass1Files.length} test files`, {
-        storyId: input.storyId,
-      });
-      effectiveCommand = buildScopedCommand(pass1Files, input.testCommand, input.testScopedTemplate);
-      isFullSuite = false;
-    } else if (smartCfg.fallback === "import-grep") {
-      const pass2Files = await _scopedSelectionDeps.importGrepFallback(
-        nonTestFiles,
-        input.workdir,
-        smartCfg.testFilePatterns,
-      );
-      if (pass2Files.length > threshold) {
-        logger.warn(
-          "verify[scoped]",
-          `Scoped test file count ${pass2Files.length} exceeds threshold ${threshold} — falling back to full suite`,
-          { storyId: input.storyId },
-        );
-        effectiveCommand = input.fallbackFullSuiteCommand ?? input.testCommand;
-        scopeTestFallback = true;
-        thresholdFallback = true;
-      } else if (pass2Files.length > 0) {
-        logger.info("verify[scoped]", `Pass 2: import-grep matched ${pass2Files.length} test files`, {
-          storyId: input.storyId,
-        });
-        effectiveCommand = buildScopedCommand(pass2Files, input.testCommand, input.testScopedTemplate);
-        isFullSuite = false;
-      }
-    }
+  const scoped = (files: string[]): SelectScopedTestsResult => ({
+    effectiveCommand: buildScopedCommand(files, input.testCommand, input.testScopedTemplate),
+    isFullSuite: false,
+    thresholdFallback: false,
+    isMonorepoOrchestrator,
+  });
+
+  if (!smartCfg.enabled || !input.storyGitRef || isMonorepoOrchestrator) {
+    return { effectiveCommand: input.testCommand, isFullSuite: true, thresholdFallback: false, isMonorepoOrchestrator };
   }
 
-  return { effectiveCommand, isFullSuite, scopeTestFallback, thresholdFallback, isMonorepoOrchestrator };
+  const nonTestFiles = await _scopedSelectionDeps.getChangedNonTestFiles(
+    input.workdir,
+    input.storyGitRef,
+    undefined,
+    globsToTestRegex(smartCfg.testFilePatterns),
+    input.naxIgnoreIndex,
+  );
+
+  const pass1Files = await _scopedSelectionDeps.mapSourceToTests(nonTestFiles, input.workdir);
+  if (pass1Files.length > threshold) {
+    logger.warn(
+      "verify[scoped]",
+      `Scoped test file count ${pass1Files.length} exceeds threshold ${threshold} — falling back to full suite`,
+      { storyId: input.storyId },
+    );
+    return fullSuite({ scopeTestFallback: true, thresholdFallback: true });
+  }
+  if (pass1Files.length > 0) {
+    logger.info("verify[scoped]", `Pass 1: path convention matched ${pass1Files.length} test files`, {
+      storyId: input.storyId,
+    });
+    return scoped(pass1Files);
+  }
+
+  if (smartCfg.fallback !== "import-grep") {
+    return fullSuite();
+  }
+
+  const pass2Files = await _scopedSelectionDeps.importGrepFallback(
+    nonTestFiles,
+    input.workdir,
+    smartCfg.testFilePatterns,
+  );
+  if (pass2Files.length > threshold) {
+    logger.warn(
+      "verify[scoped]",
+      `Scoped test file count ${pass2Files.length} exceeds threshold ${threshold} — falling back to full suite`,
+      { storyId: input.storyId },
+    );
+    return fullSuite({ scopeTestFallback: true, thresholdFallback: true });
+  }
+  if (pass2Files.length > 0) {
+    logger.info("verify[scoped]", `Pass 2: import-grep matched ${pass2Files.length} test files`, {
+      storyId: input.storyId,
+    });
+    return scoped(pass2Files);
+  }
+
+  return fullSuite();
 }
 
 /** Injectable deps for testing. Mirrors `_scopedDeps` from strategies/scoped.ts. */

--- a/src/test-runners/scoped-selection.ts
+++ b/src/test-runners/scoped-selection.ts
@@ -1,0 +1,147 @@
+/**
+ * Scoped Test Selection (issue #1116)
+ *
+ * Pure helper: given a story's changed files + smart-runner config + base
+ * test command, return the effective command + selection metadata.
+ *
+ * Extracted from src/verification/strategies/scoped.ts (lines 27-120). No
+ * behavior change — every code path is preserved verbatim, just behind a
+ * stable `selectScopedTests()` boundary so `verifyScopedOp` can call it.
+ *
+ * Scope: package-scoped (operates on `workdir` + the story's git ref).
+ */
+
+import { getLogger } from "@/logger";
+import { DEFAULT_TEST_FILE_PATTERNS, globsToTestRegex } from "@/test-runners";
+import { _smartRunnerDeps } from "@/verification/smart-runner";
+import type { NaxIgnoreIndex } from "@/utils/path-filters";
+
+const DEFAULT_SMART_RUNNER_CONFIG = {
+  enabled: true,
+  testFilePatterns: [...DEFAULT_TEST_FILE_PATTERNS],
+  fallback: "import-grep" as const,
+};
+
+export interface SmartRunnerConfigRaw {
+  enabled?: boolean;
+  testFilePatterns?: string[];
+  fallback?: "import-grep" | "none";
+}
+
+export function coerceSmartRunner(val: unknown) {
+  if (val === undefined || val === true) return DEFAULT_SMART_RUNNER_CONFIG;
+  if (val === false) return { ...DEFAULT_SMART_RUNNER_CONFIG, enabled: false };
+  return { ...DEFAULT_SMART_RUNNER_CONFIG, ...(val as Partial<typeof DEFAULT_SMART_RUNNER_CONFIG>) };
+}
+
+export function buildScopedCommand(
+  testFiles: string[],
+  baseCommand: string,
+  testScopedTemplate: string | undefined,
+): string {
+  if (testScopedTemplate) {
+    const quotedFiles = testFiles.map((file) => `'${file.replaceAll("'", "'\\''")}'`);
+    return testScopedTemplate.replace("{{files}}", quotedFiles.join(" "));
+  }
+  return _scopedSelectionDeps.buildSmartTestCommand(testFiles, baseCommand);
+}
+
+/**
+ * Monorepo orchestrators (turbo, nx) carry their own change-filter syntax
+ * (e.g. `--filter=...[HEAD~1]`, `nx affected`). Smart-runner must not append
+ * file paths to such commands — it would produce invalid syntax.
+ */
+export function isMonorepoOrchestratorCommand(command: string): boolean {
+  return /\bturbo\b/.test(command) || /\bnx\b/.test(command);
+}
+
+export interface SelectScopedTestsInput {
+  workdir: string;
+  storyId: string;
+  storyGitRef?: string;
+  testCommand: string;
+  testScopedTemplate?: string;
+  smartRunnerConfig: unknown;
+  scopeTestThreshold?: number;
+  fallbackFullSuiteCommand?: string;
+  naxIgnoreIndex?: NaxIgnoreIndex;
+}
+
+export interface SelectScopedTestsResult {
+  effectiveCommand: string;
+  isFullSuite: boolean;
+  scopeTestFallback?: boolean;
+  thresholdFallback: boolean;
+  isMonorepoOrchestrator: boolean;
+}
+
+export async function selectScopedTests(input: SelectScopedTestsInput): Promise<SelectScopedTestsResult> {
+  const logger = getLogger();
+  const smartCfg = coerceSmartRunner(input.smartRunnerConfig);
+  const isMonorepoOrchestrator = isMonorepoOrchestratorCommand(input.testCommand);
+  const threshold = input.scopeTestThreshold ?? 10;
+
+  let effectiveCommand = input.testCommand;
+  let isFullSuite = true;
+  let scopeTestFallback: boolean | undefined;
+  let thresholdFallback = false;
+
+  if (smartCfg.enabled && input.storyGitRef && !isMonorepoOrchestrator) {
+    const nonTestFiles = await _scopedSelectionDeps.getChangedNonTestFiles(
+      input.workdir,
+      input.storyGitRef,
+      undefined,
+      globsToTestRegex(smartCfg.testFilePatterns),
+      input.naxIgnoreIndex,
+    );
+    const pass1Files = await _scopedSelectionDeps.mapSourceToTests(nonTestFiles, input.workdir);
+    if (pass1Files.length > threshold) {
+      logger.warn(
+        "verify[scoped]",
+        `Scoped test file count ${pass1Files.length} exceeds threshold ${threshold} — falling back to full suite`,
+        { storyId: input.storyId },
+      );
+      effectiveCommand = input.fallbackFullSuiteCommand ?? input.testCommand;
+      scopeTestFallback = true;
+      thresholdFallback = true;
+    } else if (pass1Files.length > 0) {
+      logger.info("verify[scoped]", `Pass 1: path convention matched ${pass1Files.length} test files`, {
+        storyId: input.storyId,
+      });
+      effectiveCommand = buildScopedCommand(pass1Files, input.testCommand, input.testScopedTemplate);
+      isFullSuite = false;
+    } else if (smartCfg.fallback === "import-grep") {
+      const pass2Files = await _scopedSelectionDeps.importGrepFallback(
+        nonTestFiles,
+        input.workdir,
+        smartCfg.testFilePatterns,
+      );
+      if (pass2Files.length > threshold) {
+        logger.warn(
+          "verify[scoped]",
+          `Scoped test file count ${pass2Files.length} exceeds threshold ${threshold} — falling back to full suite`,
+          { storyId: input.storyId },
+        );
+        effectiveCommand = input.fallbackFullSuiteCommand ?? input.testCommand;
+        scopeTestFallback = true;
+        thresholdFallback = true;
+      } else if (pass2Files.length > 0) {
+        logger.info("verify[scoped]", `Pass 2: import-grep matched ${pass2Files.length} test files`, {
+          storyId: input.storyId,
+        });
+        effectiveCommand = buildScopedCommand(pass2Files, input.testCommand, input.testScopedTemplate);
+        isFullSuite = false;
+      }
+    }
+  }
+
+  return { effectiveCommand, isFullSuite, scopeTestFallback, thresholdFallback, isMonorepoOrchestrator };
+}
+
+/** Injectable deps for testing. Mirrors `_scopedDeps` from strategies/scoped.ts. */
+export const _scopedSelectionDeps = {
+  getChangedNonTestFiles: _smartRunnerDeps.getChangedNonTestFiles,
+  mapSourceToTests: _smartRunnerDeps.mapSourceToTests,
+  importGrepFallback: _smartRunnerDeps.importGrepFallback,
+  buildSmartTestCommand: _smartRunnerDeps.buildSmartTestCommand,
+};

--- a/src/test-runners/scoped-selection.ts
+++ b/src/test-runners/scoped-selection.ts
@@ -13,8 +13,8 @@
 
 import { getLogger } from "@/logger";
 import { DEFAULT_TEST_FILE_PATTERNS, globsToTestRegex } from "@/test-runners";
-import { _smartRunnerDeps } from "@/verification/smart-runner";
 import type { NaxIgnoreIndex } from "@/utils/path-filters";
+import { _smartRunnerDeps } from "../verification/smart-runner";
 
 const DEFAULT_SMART_RUNNER_CONFIG = {
   enabled: true,

--- a/test/integration/verification/strategy-vs-op-parity.test.ts
+++ b/test/integration/verification/strategy-vs-op-parity.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ScopedStrategy } from "@/verification/strategies/scoped";
+import { RegressionStrategy } from "@/verification/strategies/regression";
+import type { VerifyContext } from "@/verification/orchestrator-types";
+import { verifyScopedOp } from "@/operations";
+import { fullSuiteGateOp } from "@/operations";
+
+/**
+ * Parity gate for issue #1116.
+ *
+ * THROWAWAY MIGRATION SAFETY NET — this file is DELETED in Phase 5 along with
+ * the strategy classes it imports. Do not extend it for long-term coverage;
+ * port that coverage into test/unit/operations/*.test.ts instead (Phase 2.7,
+ * Phase 3.5). The point of this file is to prove envelope equivalence DURING
+ * the migration, then disappear.
+ */
+
+let tmpRoot: string;
+beforeEach(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), "nax-parity-"));
+});
+
+describe("scoped: strategy ↔ op parity", () => {
+  test("PASS case — same passCount, isFullSuite, scopeTestFallback", async () => {
+    // Stub _scopedDeps / _verifyScopedDeps with identical fakes that both
+    // resolve to: 0 mapped tests, full-suite fallback, exit code 0, parsed 5 passes.
+    // Assert both envelopes carry passCount=5, isFullSuite=true, scopeTestFallback=undefined.
+    // (Real implementation in Phase 1: stub here, fill body in Phase 2 after op grows.)
+    expect(true).toBe(true); // placeholder — fleshed out after Phase 2.4
+  });
+
+  test("SKIPPED case — deferred + no mapped tests + not monorepo orchestrator", async () => {
+    expect(true).toBe(true);
+  });
+
+  test("THRESHOLD fallback — scope > threshold → full suite with scopeTestFallback=true", async () => {
+    expect(true).toBe(true);
+  });
+
+  test("MONOREPO orchestrator — turbo command bypasses smart runner", async () => {
+    expect(true).toBe(true);
+  });
+});
+
+describe("full-suite: strategy ↔ op parity", () => {
+  test("PASS case", async () => {
+    expect(true).toBe(true);
+  });
+
+  test("ENABLED=false → skipped", async () => {
+    expect(true).toBe(true);
+  });
+
+  test("TIMEOUT + acceptOnTimeout=true → passed", async () => {
+    expect(true).toBe(true);
+  });
+
+  test("TIMEOUT + acceptOnTimeout=false → failed", async () => {
+    expect(true).toBe(true);
+  });
+});

--- a/test/integration/verification/strategy-vs-op-parity.test.ts
+++ b/test/integration/verification/strategy-vs-op-parity.test.ts
@@ -1,13 +1,4 @@
-import { describe, test, expect, beforeEach } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-
-import { ScopedStrategy } from "@/verification/strategies/scoped";
-import { RegressionStrategy } from "@/verification/strategies/regression";
-import type { VerifyContext } from "@/verification/orchestrator-types";
-import { verifyScopedOp } from "@/operations";
-import { fullSuiteGateOp } from "@/operations";
+import { describe, test, expect } from "bun:test";
 
 /**
  * Parity gate for issue #1116.
@@ -17,12 +8,11 @@ import { fullSuiteGateOp } from "@/operations";
  * port that coverage into test/unit/operations/*.test.ts instead (Phase 2.7,
  * Phase 3.5). The point of this file is to prove envelope equivalence DURING
  * the migration, then disappear.
+ *
+ * TODO(Phase 3 / Task 12): fill placeholder bodies with real strategy↔op assertions.
+ * Imports for ScopedStrategy, RegressionStrategy, verifyScopedOp, fullSuiteGateOp,
+ * and a tmpdir fixture will be added at that point.
  */
-
-let tmpRoot: string;
-beforeEach(async () => {
-  tmpRoot = await mkdtemp(join(tmpdir(), "nax-parity-"));
-});
 
 describe("scoped: strategy ↔ op parity", () => {
   test("PASS case — same passCount, isFullSuite, scopeTestFallback", async () => {

--- a/test/unit/execution/plan-inputs.test.ts
+++ b/test/unit/execution/plan-inputs.test.ts
@@ -370,6 +370,24 @@ describe("PlanInputs — AC1: new optional slots (US-005)", () => {
     expect(inputs.verifyScoped).toBeDefined();
   });
 
+  test("AC1: verifyScoped.regressionMode is 'deferred' when regressionGate.mode is 'deferred'", async () => {
+    const ctx = makeNonTddCtx({ execution: { ...DEFAULT_CONFIG.execution, regressionGate: { ...DEFAULT_CONFIG.execution.regressionGate, mode: "deferred" } } });
+    const inputs = await assemblePlanInputsFromCtx(ctx);
+    expect(inputs.verifyScoped?.regressionMode).toBe("deferred");
+  });
+
+  test("AC1: verifyScoped.regressionMode is 'per-story' when regressionGate.mode is 'per-story'", async () => {
+    const ctx = makeNonTddCtx({ execution: { ...DEFAULT_CONFIG.execution, regressionGate: { ...DEFAULT_CONFIG.execution.regressionGate, mode: "per-story" } } });
+    const inputs = await assemblePlanInputsFromCtx(ctx);
+    expect(inputs.verifyScoped?.regressionMode).toBe("per-story");
+  });
+
+  test("AC1: verifyScoped.regressionMode is 'deferred' when regressionGate.mode is 'disabled' (fullSuiteGate handles disabled, not verifyScopedOp)", async () => {
+    const ctx = makeNonTddCtx({ execution: { ...DEFAULT_CONFIG.execution, regressionGate: { ...DEFAULT_CONFIG.execution.regressionGate, mode: "disabled" } } });
+    const inputs = await assemblePlanInputsFromCtx(ctx);
+    expect(inputs.verifyScoped?.regressionMode).toBe("deferred");
+  });
+
   test("AC1: assemblePlanInputsFromCtx populates lintCheck when 'lint' in review.checks and lint command configured", async () => {
     const ctx = makeNonTddCtx({
       review: {

--- a/test/unit/operations/verify-scoped.test.ts
+++ b/test/unit/operations/verify-scoped.test.ts
@@ -1,29 +1,9 @@
-import { describe, expect, test } from "bun:test";
-import { verifyScopedOp } from "@/operations";
+import { describe, expect, test, afterEach } from "bun:test";
+import { verifyScopedOp, _verifyScopedDeps } from "@/operations";
 import type { VerifyScopedDeps } from "@/operations";
 import type { Finding } from "@/findings";
 
 const mockCtx = { runtime: {}, storyId: "US-003" } as any;
-
-const passedResult = {
-  commandName: "test",
-  command: "bun test",
-  success: true,
-  exitCode: 0,
-  output: "All tests passed",
-  durationMs: 100,
-  timedOut: false,
-};
-
-const failedResult = {
-  commandName: "test",
-  command: "bun test",
-  success: false,
-  exitCode: 1,
-  output: "1 test failed",
-  durationMs: 100,
-  timedOut: false,
-};
 
 const mockFinding: Finding = {
   source: "test-runner",
@@ -34,10 +14,25 @@ const mockFinding: Finding = {
   rule: "my test",
 };
 
-function makeDeps(overrides: Partial<VerifyScopedDeps> = {}): VerifyScopedDeps {
+// Snapshot/restore so mutations don't bleed across tests.
+const originalVerifyScopedDeps = { ..._verifyScopedDeps };
+afterEach(() => Object.assign(_verifyScopedDeps, originalVerifyScopedDeps));
+
+function fakeDeps(overrides: Partial<VerifyScopedDeps> = {}): VerifyScopedDeps {
   return {
-    runQualityCommand: async () => passedResult,
-    parseTestOutput: () => ({ passed: 5, failed: 0, failures: [] }),
+    selectScopedTests: async () => ({
+      effectiveCommand: "bun test",
+      isFullSuite: true,
+      thresholdFallback: false,
+      isMonorepoOrchestrator: false,
+    }),
+    regression: async () => ({
+      status: "SUCCESS" as const,
+      success: true,
+      countsTowardEscalation: true,
+      output: "1 pass\n0 fail",
+    }),
+    parseTestOutput: () => ({ passed: 1, failed: 0, failures: [] }),
     testSummaryToFindings: () => [],
     ...overrides,
   };
@@ -62,20 +57,28 @@ describe("verifyScopedOp — AC2: DeterministicOperation shape", () => {
 describe("verifyScopedOp — AC5: execute returns success=true when test command exits 0", () => {
   test("AC5: returns success=true and findings=[] when test command exits 0", async () => {
     const out = await verifyScopedOp.execute(
-      { workdir: "/tmp", storyId: "US-003" },
-      mockCtx,
-      makeDeps({ runQualityCommand: async () => passedResult }),
+      { workdir: "/tmp", storyId: "US-003", regressionMode: "per-story" },
+      { ...mockCtx, config: { quality: { commands: { test: "bun test" } } } },
+      fakeDeps(),
     );
     expect(out.success).toBe(true);
     expect(out.findings).toEqual([]);
+    expect(out.status).toBe("passed");
+    expect(out.passCount).toBe(1);
+    expect(out.isFullSuite).toBe(true);
   });
 
   test("AC5: returns success=false and non-empty findings when test command exits non-zero", async () => {
     const out = await verifyScopedOp.execute(
-      { workdir: "/tmp", storyId: "US-003" },
-      mockCtx,
-      makeDeps({
-        runQualityCommand: async () => failedResult,
+      { workdir: "/tmp", storyId: "US-003", regressionMode: "per-story" },
+      { ...mockCtx, config: { quality: { commands: { test: "bun test" } } } },
+      fakeDeps({
+        regression: async () => ({
+          status: "TEST_FAILURE" as const,
+          success: false,
+          countsTowardEscalation: true,
+          output: "1 test failed",
+        }),
         parseTestOutput: () => ({
           passed: 0,
           failed: 1,
@@ -86,14 +89,20 @@ describe("verifyScopedOp — AC5: execute returns success=true when test command
     );
     expect(out.success).toBe(false);
     expect(out.findings.length).toBeGreaterThan(0);
+    expect(out.status).toBe("failed");
   });
 
   test("AC5: every finding has source='test-runner' when test command exits non-zero", async () => {
     const out = await verifyScopedOp.execute(
-      { workdir: "/tmp", storyId: "US-003" },
-      mockCtx,
-      makeDeps({
-        runQualityCommand: async () => failedResult,
+      { workdir: "/tmp", storyId: "US-003", regressionMode: "per-story" },
+      { ...mockCtx, config: { quality: { commands: { test: "bun test" } } } },
+      fakeDeps({
+        regression: async () => ({
+          status: "TEST_FAILURE" as const,
+          success: false,
+          countsTowardEscalation: true,
+          output: "1 test failed",
+        }),
         parseTestOutput: () => ({
           passed: 0,
           failed: 1,
@@ -108,11 +117,11 @@ describe("verifyScopedOp — AC5: execute returns success=true when test command
 
 describe("verifyScopedOp — AC6: no-command early return", () => {
   test("AC6: returns success=true, findings=[], durationMs=0 when test command is undefined", async () => {
-    let runQualityCalled = false;
-    const deps = makeDeps({
-      runQualityCommand: async () => {
-        runQualityCalled = true;
-        return passedResult;
+    let selectionCalled = false;
+    const deps = fakeDeps({
+      selectScopedTests: async () => {
+        selectionCalled = true;
+        return { effectiveCommand: "bun test", isFullSuite: true, thresholdFallback: false, isMonorepoOrchestrator: false };
       },
     });
 
@@ -129,6 +138,134 @@ describe("verifyScopedOp — AC6: no-command early return", () => {
     expect(out.success).toBe(true);
     expect(out.findings).toEqual([]);
     expect(out.durationMs).toBe(0);
-    expect(runQualityCalled).toBe(false);
+    expect(selectionCalled).toBe(false);
+  });
+});
+
+describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
+  test("deferred mode + no mapped tests + not monorepo → skipped", async () => {
+    const deps = fakeDeps();
+    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", regressionMode: "deferred" },
+      ctx,
+      deps,
+    );
+    expect(result.status).toBe("skipped");
+    expect(result.success).toBe(true);
+  });
+
+  test("per-story mode + no mapped tests → runs full suite (not skipped)", async () => {
+    const deps = fakeDeps();
+    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", regressionMode: "per-story" },
+      ctx,
+      deps,
+    );
+    expect(result.status).toBe("passed");
+    expect(result.isFullSuite).toBe(true);
+  });
+
+  test("monorepo orchestrator → runs even in deferred mode", async () => {
+    const deps = fakeDeps({
+      selectScopedTests: async () => ({
+        effectiveCommand: "turbo run test",
+        isFullSuite: true,
+        thresholdFallback: false,
+        isMonorepoOrchestrator: true,
+      }),
+    });
+    const ctx = { config: { quality: { commands: { test: "turbo run test" } } } } as any;
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", regressionMode: "deferred" },
+      ctx,
+      deps,
+    );
+    expect(result.status).toBe("passed");
+  });
+
+  test("threshold fallback → scopeTestFallback=true in envelope", async () => {
+    const deps = fakeDeps({
+      selectScopedTests: async () => ({
+        effectiveCommand: "bun test",
+        isFullSuite: true,
+        thresholdFallback: true,
+        scopeTestFallback: true,
+        isMonorepoOrchestrator: false,
+      }),
+    });
+    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", regressionMode: "deferred" },
+      ctx,
+      deps,
+    );
+    expect(result.status).toBe("passed");
+    expect(result.scopeTestFallback).toBe(true);
+  });
+
+  test("scoped match → isFullSuite=false", async () => {
+    const deps = fakeDeps({
+      selectScopedTests: async () => ({
+        effectiveCommand: "bun test test/a.test.ts",
+        isFullSuite: false,
+        thresholdFallback: false,
+        isMonorepoOrchestrator: false,
+      }),
+    });
+    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", storyGitRef: "abc", regressionMode: "per-story" },
+      ctx,
+      deps,
+    );
+    expect(result.isFullSuite).toBe(false);
+  });
+
+  test("test failure → status=failed with findings", async () => {
+    const deps = fakeDeps({
+      regression: async () => ({
+        status: "TEST_FAILURE" as const,
+        success: false,
+        countsTowardEscalation: true,
+        output: "1 pass\n2 fail",
+      }),
+      parseTestOutput: () => ({
+        passed: 1,
+        failed: 2,
+        failures: [{ testName: "t1", file: "a.test.ts", error: "boom", stackTrace: [] }],
+      }),
+      testSummaryToFindings: () => [{ kind: "test", id: "f1" } as any],
+    });
+    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", regressionMode: "per-story" },
+      ctx,
+      deps,
+    );
+    expect(result.status).toBe("failed");
+    expect(result.success).toBe(false);
+    expect(result.findings.length).toBe(1);
+  });
+
+  test("timeout → status=timeout, success=false", async () => {
+    const deps = fakeDeps({
+      regression: async () => ({
+        status: "TIMEOUT" as const,
+        success: false,
+        countsTowardEscalation: false,
+        output: "",
+      }),
+      parseTestOutput: () => ({ passed: 0, failed: 0, failures: [] }),
+    });
+    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const result = await verifyScopedOp.execute(
+      { workdir: "/r", storyId: "S-1", regressionMode: "per-story" },
+      ctx,
+      deps,
+    );
+    expect(result.status).toBe("timeout");
+    expect(result.success).toBe(false);
   });
 });

--- a/test/unit/operations/verify-scoped.test.ts
+++ b/test/unit/operations/verify-scoped.test.ts
@@ -111,7 +111,7 @@ describe("verifyScopedOp — AC5: execute returns success=true when test command
         testSummaryToFindings: () => [mockFinding],
       }),
     );
-    expect(out.findings.every((f) => f.source === "test-runner")).toBe(true);
+    expect(out.findings.every((f: Finding) => f.source === "test-runner")).toBe(true);
   });
 });
 

--- a/test/unit/test-runners/scoped-selection.test.ts
+++ b/test/unit/test-runners/scoped-selection.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { selectScopedTests, _scopedSelectionDeps } from "@/test-runners";
+
+function makeFakeDeps(overrides: Partial<typeof _scopedSelectionDeps> = {}) {
+  return {
+    getChangedNonTestFiles: async () => ["src/a.ts"],
+    mapSourceToTests: async () => [] as string[],
+    importGrepFallback: async () => [] as string[],
+    buildSmartTestCommand: (files: string[], base: string) => `${base} ${files.join(" ")}`,
+    ...overrides,
+  };
+}
+
+// Snapshot/restore so Object.assign mutations don't bleed across tests.
+const originalDeps = { ..._scopedSelectionDeps };
+afterEach(() => Object.assign(_scopedSelectionDeps, originalDeps));
+
+describe("selectScopedTests", () => {
+  const baseInput = {
+    workdir: "/repo",
+    storyId: "S-1",
+    storyGitRef: "abc123",
+    testCommand: "bun test",
+    smartRunnerConfig: { enabled: true, fallback: "import-grep" as const, testFilePatterns: ["**/*.test.ts"] },
+  };
+
+  test("monorepo orchestrator command bypasses smart runner", async () => {
+    const fakeDeps = makeFakeDeps({
+      getChangedNonTestFiles: async () => {
+        throw new Error("should not be called");
+      },
+    });
+    Object.assign(_scopedSelectionDeps, fakeDeps);
+    const result = await selectScopedTests({ ...baseInput, testCommand: "turbo run test" });
+    expect(result.isMonorepoOrchestrator).toBe(true);
+    expect(result.isFullSuite).toBe(true);
+    expect(result.effectiveCommand).toBe("turbo run test");
+  });
+
+  test("Pass 1 match below threshold → scoped command", async () => {
+    Object.assign(
+      _scopedSelectionDeps,
+      makeFakeDeps({
+        mapSourceToTests: async () => ["test/a.test.ts", "test/b.test.ts"],
+      }),
+    );
+    const result = await selectScopedTests({ ...baseInput, scopeTestThreshold: 10 });
+    expect(result.isFullSuite).toBe(false);
+    expect(result.effectiveCommand).toBe("bun test test/a.test.ts test/b.test.ts");
+    expect(result.scopeTestFallback).toBeUndefined();
+  });
+
+  test("Pass 1 above threshold → fallback to full suite", async () => {
+    const manyFiles = Array.from({ length: 15 }, (_, i) => `test/t${i}.test.ts`);
+    Object.assign(_scopedSelectionDeps, makeFakeDeps({ mapSourceToTests: async () => manyFiles }));
+    const result = await selectScopedTests({
+      ...baseInput,
+      scopeTestThreshold: 10,
+      fallbackFullSuiteCommand: "bun test --all",
+    });
+    expect(result.thresholdFallback).toBe(true);
+    expect(result.scopeTestFallback).toBe(true);
+    expect(result.effectiveCommand).toBe("bun test --all");
+    expect(result.isFullSuite).toBe(true);
+  });
+
+  test("Pass 1 empty + Pass 2 match → import-grep result", async () => {
+    Object.assign(
+      _scopedSelectionDeps,
+      makeFakeDeps({
+        mapSourceToTests: async () => [],
+        importGrepFallback: async () => ["test/x.test.ts"],
+      }),
+    );
+    const result = await selectScopedTests(baseInput);
+    expect(result.isFullSuite).toBe(false);
+    expect(result.effectiveCommand).toBe("bun test test/x.test.ts");
+  });
+
+  test("Pass 1 + Pass 2 both empty → full-suite, no fallback flag", async () => {
+    Object.assign(
+      _scopedSelectionDeps,
+      makeFakeDeps({
+        mapSourceToTests: async () => [],
+        importGrepFallback: async () => [],
+      }),
+    );
+    const result = await selectScopedTests(baseInput);
+    expect(result.isFullSuite).toBe(true);
+    expect(result.scopeTestFallback).toBeUndefined();
+    expect(result.thresholdFallback).toBe(false);
+  });
+
+  test("testScopedTemplate overrides buildSmartTestCommand", async () => {
+    Object.assign(
+      _scopedSelectionDeps,
+      makeFakeDeps({
+        mapSourceToTests: async () => ["test/a.test.ts"],
+        buildSmartTestCommand: () => {
+          throw new Error("should not be called");
+        },
+      }),
+    );
+    const result = await selectScopedTests({
+      ...baseInput,
+      testScopedTemplate: "pytest {{files}}",
+    });
+    expect(result.effectiveCommand).toBe("pytest 'test/a.test.ts'");
+  });
+
+  test("smart runner disabled → base command, no smart-runner call", async () => {
+    Object.assign(
+      _scopedSelectionDeps,
+      makeFakeDeps({
+        getChangedNonTestFiles: async () => {
+          throw new Error("should not be called");
+        },
+      }),
+    );
+    const result = await selectScopedTests({
+      ...baseInput,
+      smartRunnerConfig: { enabled: false },
+    });
+    expect(result.isFullSuite).toBe(true);
+    expect(result.effectiveCommand).toBe("bun test");
+  });
+
+  test("missing storyGitRef → base command", async () => {
+    Object.assign(
+      _scopedSelectionDeps,
+      makeFakeDeps({
+        getChangedNonTestFiles: async () => {
+          throw new Error("should not be called");
+        },
+      }),
+    );
+    const result = await selectScopedTests({ ...baseInput, storyGitRef: undefined });
+    expect(result.isFullSuite).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phases 1 and 2 of the verification unification plan ([docs/superpowers/plans/2026-05-26-issue-1116-verification-unification.md](docs/superpowers/plans/2026-05-26-issue-1116-verification-unification.md)).

### Phase 1 — Parity gate

- **docs**: Added `Strategy → Op envelope mapping (issue #1116)` subsection to `docs/architecture/subsystems.md §21` documenting the field-by-field mapping from `ScopedStrategy.VerifyResult → VerifyScopedOutput` and `RegressionStrategy.VerifyResult → FullSuiteGateOutput`
- **test scaffold**: Created `test/integration/verification/strategy-vs-op-parity.test.ts` with 8 placeholder tests (bodies filled in Phase 3 / Task 12, file deleted in Phase 5)

### Phase 2 — Port `ScopedStrategy` into `verifyScopedOp`

- **`src/test-runners/scoped-selection.ts`** (new): Extracted `selectScopedTests()` pure helper from `ScopedStrategy` — smart-runner change-aware selection, Pass 1/Pass 2 fallback, monorepo orchestrator detection (turbo/nx), `testScopedTemplate` substitution, threshold-based full-suite fallback. Exports `_scopedSelectionDeps` for test injection.
- **`src/test-runners/index.ts`**: Barrel exports for the new helper.
- **`test/unit/test-runners/scoped-selection.test.ts`** (new): 8 unit tests covering all selection paths.
- **`src/operations/verify-scoped.ts`**: Rewrote from the thin `runQualityCommand` stub to the full `ScopedStrategy` behavior:
  - New `VerifyScopedInput` fields: `storyGitRef`, `naxIgnoreIndex`, `regressionMode`
  - New `VerifyScopedOutput` fields: `status`, `passCount`, `isFullSuite`, `scopeTestFallback`
  - Deferred-mode skip (no mapped tests → `status: "skipped"`)
  - Monorepo orchestrator detection runs even in deferred mode
  - Quality config forwarding (`forceExit`, `detectOpenHandles*`, `gracePeriodMs`, `drainTimeoutMs`, `shell`, `stripEnvVars`)
  - Timeout sourced from `execution.regressionGate.timeoutSeconds` (no `as unknown` casts — `QualityConfig` includes `execution` via `qualityConfigSelector`)
- **`test/unit/operations/verify-scoped.test.ts`**: Updated to new envelope shape + 7 new ported-behavior cases (deferred/per-story mode, monorepo, threshold fallback, scoped match, fail, timeout).
- **`src/execution/plan-inputs.ts`**: Threads `storyGitRef`, `naxIgnoreIndex`, and `regressionMode` into `verifyScopedInput`. Added `toVerifyScopedMode()` helper mapping the 3-value schema union (`deferred | per-story | disabled`) to the 2-value op type.
- **`test/unit/execution/plan-inputs.test.ts`**: Added 3 tests covering `deferred`, `per-story`, and `disabled` mode mappings.

### Code review fixes (post-review commit)

- Removed all `as unknown` double-casts — replaced with direct typed access via `QualityConfig`
- Early-return guard unified to `!ctxConfig || !baseCommand`
- Removed spurious `_scopedSelectionDeps` re-export from the operations module
- Replaced mutable `let` vars in `selectScopedTests` with immutable early-return helpers (`fullSuite()` / `scoped()`)
- Fixed `SmartRunnerConfigRaw.fallback`: `"none"` → `"full-suite"` to match schema enum
- Expanded `toVerifyScopedMode` comment; added 3 mode-mapping tests

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean  
- [x] `bun run test` — **9,418 pass / 0 fail** across 782 files (unit + integration + ui)

## What's NOT in this PR (Phases 3–5)

- Phase 3: Port `RegressionStrategy` into `fullSuiteGateOp` (`enabled`, `acceptOnTimeout` BUG-026, quality knobs)
- Phase 4: Plan-builder wiring for `regressionGate.mode === "per-story"`
- Phase 5: Delete `VerificationOrchestrator`, all three strategy classes, `regressionStage`, and their tests

Part of #1116.