### PR TITLE
fix(orchestrator): resume canonical phases after rectification + dispatch-time review refresh

### DIFF
--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -41,6 +41,7 @@ export {
   _storyOrchestratorDeps,
   phasesToRevalidate,
   formatPhaseResultMessage,
+  refreshReviewInputForDispatch,
   type OrchestratorSlot,
   type RectificationPhaseOptions,
   type StoryOrchestratorResult,

--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -306,6 +306,13 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
     !!ctx.config.review.semantic;
   const semanticReviewInput: SemanticReviewInput | undefined = semanticEnabled
     ? await (async (): Promise<SemanticReviewInput | undefined> => {
+        // Plan-build's diff is stale: test-writer/implementer haven't run yet, so
+        // `stat` is typically empty at this point. We still call prepare for the
+        // initial snapshot, but DO NOT drop the slot on `skipReason` — the
+        // orchestrator's runPhase re-runs prepare at dispatch time (see `_refresh`
+        // payload below) using the post-implementer diff. Dropping here would
+        // permanently strip the review from the plan even when the story later
+        // produces real changes (issue: US-002 in 2026-05-27T05-06-41.jsonl).
         const prepared = await prepareSemanticReviewInput({
           workdir: ctx.workdir,
           projectDir: ctx.projectDir,
@@ -317,9 +324,6 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
           // biome-ignore lint/style/noNonNullAssertion: semanticEnabled guards presence
           semanticConfig: ctx.config.review!.semantic!,
         });
-        // Skip slot entirely when stat is empty / no ref — orchestrator will see no
-        // semantic-review phase and mark the check as not-applicable.
-        if (prepared.skipReason) return undefined;
         return {
           workdir: ctx.workdir,
           story,
@@ -335,6 +339,14 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
           priorSemanticIterations: ctx.priorSemanticIterations,
           // biome-ignore lint/style/noNonNullAssertion: semanticEnabled guards presence
           blockingThreshold: ctx.config.review!.blockingThreshold,
+          _refresh: {
+            projectDir: ctx.projectDir,
+            storyId: story.id,
+            storyGitRef: ctx.storyGitRef,
+            config: ctx.config,
+            naxIgnoreIndex: ctx.naxIgnoreIndex,
+            resolvedTestPatterns,
+          },
         };
       })()
     : undefined;
@@ -345,6 +357,8 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
     !!ctx.config.review.adversarial;
   const adversarialReviewInput: AdversarialReviewInput | undefined = adversarialEnabled
     ? await (async (): Promise<AdversarialReviewInput | undefined> => {
+        // Same rationale as semanticReviewInput above: plan-build diff is stale;
+        // orchestrator's runPhase re-prepares at dispatch via `_refresh`.
         const prepared = await prepareAdversarialReviewInput({
           workdir: ctx.workdir,
           projectDir: ctx.projectDir,
@@ -356,7 +370,6 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
           // biome-ignore lint/style/noNonNullAssertion: adversarialEnabled guards presence
           adversarialConfig: ctx.config.review!.adversarial!,
         });
-        if (prepared.skipReason) return undefined;
         return {
           workdir: ctx.workdir,
           story,
@@ -375,6 +388,14 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
           priorAdversarialIterations: ctx.priorAdversarialIterations,
           // biome-ignore lint/style/noNonNullAssertion: adversarialEnabled guards presence
           blockingThreshold: ctx.config.review!.blockingThreshold,
+          _refresh: {
+            projectDir: ctx.projectDir,
+            storyId: story.id,
+            storyGitRef: ctx.storyGitRef,
+            config: ctx.config,
+            naxIgnoreIndex: ctx.naxIgnoreIndex,
+            resolvedTestPatterns,
+          },
         };
       })()
     : undefined;

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -31,6 +31,7 @@ import type {
 } from "../operations";
 import type { AdversarialReviewInput } from "../operations";
 import { callOp } from "../operations/call";
+import { prepareAdversarialReviewInput, prepareSemanticReviewInput } from "../review/prepare-inputs";
 import { errorMessage } from "../utils/errors";
 import { captureGitRef } from "../utils/git";
 
@@ -38,7 +39,88 @@ export const _storyOrchestratorDeps = {
   callOp,
   runFixCycle,
   captureGitRef,
+  prepareSemanticReviewInput,
+  prepareAdversarialReviewInput,
 };
+
+/**
+ * @internal
+ * Refresh stat/diff/excludePatterns/effectiveRef on a semantic-review or
+ * adversarial-review input just before dispatch. Plan-build captures these
+ * fields too early (before test-writer/implementer have produced a real diff)
+ * so they go stale by the time the review actually runs.
+ *
+ * Behavior:
+ *   - Non-review phases pass through unchanged.
+ *   - Inputs without `_refresh` pass through unchanged (backward compat).
+ *   - The `_refresh` field is stripped from the returned input so the op
+ *     handler never sees the plan-time payload.
+ *   - If the prepare call throws (e.g. mid-write worktree, git errors), the
+ *     stale input is returned with a warn log — preserves the prior dispatch
+ *     rather than aborting the whole story.
+ *
+ * Exported for unit testing; not for external callers — use `runPhase`.
+ */
+export async function refreshReviewInputForDispatch(opName: string, input: unknown): Promise<unknown> {
+  if (opName !== "semantic-review" && opName !== "adversarial-review") return input;
+  const i = input as { _refresh?: SemanticReviewInput["_refresh"]; workdir?: string };
+  const { _refresh } = i;
+  if (!_refresh || !i.workdir) return input;
+  try {
+    if (opName === "semantic-review") {
+      const { _refresh: _, ...semInput } = input as SemanticReviewInput;
+      const fresh = await _storyOrchestratorDeps.prepareSemanticReviewInput({
+        workdir: semInput.workdir,
+        projectDir: _refresh.projectDir,
+        storyId: _refresh.storyId,
+        storyGitRef: _refresh.storyGitRef,
+        config: _refresh.config,
+        naxIgnoreIndex: _refresh.naxIgnoreIndex,
+        resolvedTestPatterns: _refresh.resolvedTestPatterns,
+        semanticConfig: semInput.semanticConfig,
+      });
+      return {
+        ...semInput,
+        stat: fresh.stat,
+        diff: fresh.diff,
+        excludePatterns: fresh.excludePatterns,
+        storyGitRef: fresh.effectiveRef ?? semInput.storyGitRef,
+      };
+    }
+    const { _refresh: __, ...advInput } = input as AdversarialReviewInput;
+    const fresh = await _storyOrchestratorDeps.prepareAdversarialReviewInput({
+      workdir: advInput.workdir,
+      projectDir: _refresh.projectDir,
+      storyId: _refresh.storyId,
+      storyGitRef: _refresh.storyGitRef,
+      config: _refresh.config,
+      naxIgnoreIndex: _refresh.naxIgnoreIndex,
+      resolvedTestPatterns: _refresh.resolvedTestPatterns,
+      adversarialConfig: advInput.adversarialConfig,
+    });
+    return {
+      ...advInput,
+      stat: fresh.stat,
+      diff: fresh.diff,
+      testInventory: fresh.testInventory,
+      excludePatterns: fresh.excludePatterns,
+      testGlobs: fresh.testGlobs,
+      refExcludePatterns: fresh.refExcludePatterns,
+      storyGitRef: fresh.effectiveRef ?? advInput.storyGitRef,
+    };
+  } catch (err) {
+    getSafeLogger()?.warn("story-orchestrator", "review input refresh failed — dispatching with stale input", {
+      storyId: _refresh.storyId,
+      phase: opName,
+      error: errorMessage(err),
+    });
+    // Strip _refresh even on the fallback so the op handler never sees it.
+    const { _refresh: _stripped, ...fallback } = input as Record<string, unknown> & {
+      _refresh?: unknown;
+    };
+    return fallback;
+  }
+}
 
 /**
  * Greenfield-gate has inverse semantics: it "passes" when pre-existing tests
@@ -614,8 +696,9 @@ async function runPhase(
 
   // Pre-phase: capture git ref for TDD phases; emit phase-begin log.
   const beforeRef = isTddPhase ? await _storyOrchestratorDeps.captureGitRef(ctx.packageDir) : undefined;
-  const dispatchInput =
-    isTddPhase && beforeRef ? { ...(slot.input as Record<string, unknown>), beforeRef } : slot.input;
+  let dispatchInput = isTddPhase && beforeRef ? { ...(slot.input as Record<string, unknown>), beforeRef } : slot.input;
+  // Refresh stat/diff/etc for review phases — plan-build's snapshot is stale.
+  dispatchInput = await refreshReviewInputForDispatch(opName, dispatchInput);
 
   if (isTddPhase) {
     logger?.info("tdd", `-> Session: ${opName}`, { storyId: ctx.storyId, role: opName });
@@ -783,7 +866,19 @@ async function runRectification(
         }
         await runPhase(ctx, phase.slot, phaseCosts, phaseOutputs);
         if (shouldSkipPhaseForRectification(phase, state, phaseOutputs)) continue;
-        findings.push(...extractPhaseFindings(phaseOutputs[phase.slot.op.name]));
+        const output = phaseOutputs[phase.slot.op.name];
+        findings.push(...extractPhaseFindings(output));
+        // Mirror the main loop's halt-on-failure contract (spec §2C, PR #1127):
+        // verifier and reviews must never judge broken-gate code, even inside the
+        // rectification revalidation sweep. Findings collected so far feed the next
+        // fix iteration; downstream phases are skipped to avoid stale-verdict pollution.
+        if (!phasePassed(phase.slot.op.name, output, ctx.storyId)) {
+          getSafeLogger()?.warn("story-orchestrator", "Short-circuiting revalidation on phase failure", {
+            storyId: ctx.storyId,
+            phase: phase.slot.op.name,
+          });
+          break;
+        }
       }
       return rectification.postValidate ? await rectification.postValidate(findings, _validateCtx) : findings;
     },
@@ -914,6 +1009,52 @@ export class ExecutionPlan {
     }
 
     const rectResult = await runRectification(this.ctx, this.state, phaseCosts, phaseOutputs);
+
+    // Resume the canonical loop after rectification resolves. The strategy-specific
+    // revalidation set (STRATEGY_TO_REVALIDATION_PHASES) intentionally narrow — e.g.
+    // full-suite-rectify excludes adversarial-review, autofix-test-writer excludes
+    // semantic-review — so without this resume, any phase NOT in the active strategy's
+    // set is silently skipped after the main loop short-circuited on gate failure.
+    //
+    // Restores prior behavior: rectify → gate green → verifier → reviews. Walks the
+    // canonical sequence and runs any phase whose output is missing or non-passing.
+    // Halts on first failure (same RED→GREEN contract as the main loop). Skipped
+    // entirely when rectification was exhausted — the story is already terminal.
+    if (this.state.rectification && !rectResult.rectificationExhausted) {
+      for (const phase of collectOrderedPhases(this.state)) {
+        const name = phase.slot.op.name;
+        if (name in phaseOutputs && phasePassed(name, phaseOutputs[name], this.ctx.storyId)) {
+          continue;
+        }
+        try {
+          await runPhase(this.ctx, phase.slot, phaseCosts, phaseOutputs, this.isThreeSession);
+        } catch (error) {
+          logger?.error("story-orchestrator", "Phase threw unexpected error (post-rectification resume)", {
+            storyId: this.ctx.storyId,
+            phase: name,
+            error: errorMessage(error),
+          });
+          throw error;
+        }
+        if (!phasePassed(name, phaseOutputs[name], this.ctx.storyId)) {
+          // Terminal failure: rectification already exited "resolved" (per the
+          // guard above), so this failure happens AFTER the fix-cycle — it cannot
+          // trigger another rectification iteration. The story will be marked
+          // failed downstream. Surface this distinctly so operators don't confuse
+          // it with an in-cycle revalidation failure.
+          logger?.warn(
+            "story-orchestrator",
+            "Terminal phase failure (post-rectification resume — bypasses rectification)",
+            {
+              storyId: this.ctx.storyId,
+              phase: name,
+              source: "post-rectification-resume",
+            },
+          );
+          break;
+        }
+      }
+    }
 
     // Aggregate success across every op that produced output, including fix-ops
     // dispatched during rectification (spec §2C / AC: "success === false when

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -46,6 +46,19 @@ export interface AdversarialReviewInput {
   priorAdversarialIterations?: Iteration[];
   /** Severity threshold from review config — drives the JSON-retry condensation prompt. */
   blockingThreshold?: "error" | "warning" | "info";
+  /**
+   * Optional refresh payload — see SemanticReviewInput._refresh. Lets the
+   * orchestrator re-prepare stat/diff/testInventory at dispatch time, after
+   * test-writer/implementer have produced a real diff.
+   */
+  _refresh?: {
+    projectDir?: string;
+    storyId: string;
+    storyGitRef: string | undefined;
+    config?: import("../config/schema").NaxConfig;
+    naxIgnoreIndex?: import("../utils/path-filters").NaxIgnoreIndex;
+    resolvedTestPatterns?: import("../test-runners").ResolvedTestPatterns;
+  };
 }
 
 type RepromptInfo = {

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -36,6 +36,24 @@ export interface SemanticReviewInput {
   excludePatterns?: string[];
   featureCtxBlock?: string;
   blockingThreshold?: "error" | "warning" | "info";
+  /**
+   * Optional refresh payload — when present, the orchestrator re-runs
+   * `prepareSemanticReviewInput` at dispatch time and overlays the fresh
+   * `stat`/`diff`/`excludePatterns`/`effectiveRef` onto this input.
+   *
+   * Required because plan-build happens BEFORE test-writer/implementer
+   * touch files, so the diff captured at plan-build is stale (often
+   * empty). Without dispatch-time refresh, the reviewer LLM sees no
+   * changes and silently fail-opens.
+   */
+  _refresh?: {
+    projectDir?: string;
+    storyId: string;
+    storyGitRef: string | undefined;
+    config?: import("../config/schema").NaxConfig;
+    naxIgnoreIndex?: import("../utils/path-filters").NaxIgnoreIndex;
+    resolvedTestPatterns?: import("../test-runners").ResolvedTestPatterns;
+  };
 }
 
 type RepromptInfo = {

--- a/test/unit/execution/plan-inputs-review-wiring.test.ts
+++ b/test/unit/execution/plan-inputs-review-wiring.test.ts
@@ -136,14 +136,20 @@ describe("assemblePlanInputsFromCtx — review + rectification wiring", () => {
     expect(inputs.semanticReview!.diff).toBeUndefined();
   });
 
-  test("semantic review slot is omitted when no changes detected", async () => {
-    _diffUtilsDeps.spawn = makeSpawnSequence([""]); // empty stat
+  test("semantic review slot is registered with _refresh payload even when plan-build diff is empty", async () => {
+    // Bug A regression: plan-build runs BEFORE test-writer/implementer, so the diff
+    // is naturally empty at this moment. Previously the slot was dropped permanently;
+    // now it stays registered and carries `_refresh` so the orchestrator re-prepares
+    // stat/diff at dispatch time (after the story has produced real changes).
+    _diffUtilsDeps.spawn = makeSpawnSequence([""]); // empty stat at plan-build
     const ctx = makeCtx({
       review: { ...DEFAULT_CONFIG.review, enabled: true, checks: ["semantic"] },
     });
     ctx.storyGitRef = "abc123";
     const inputs = await assemblePlanInputsFromCtx(ctx);
-    expect(inputs.semanticReview).toBeUndefined();
+    expect(inputs.semanticReview).toBeDefined();
+    expect(inputs.semanticReview!._refresh).toBeDefined();
+    expect(inputs.semanticReview!._refresh!.storyGitRef).toBe("abc123");
   });
 
   test("adversarial review input carries stat, testGlobs, refExcludePatterns", async () => {

--- a/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
+++ b/test/unit/execution/story-orchestrator-rectification-exhaustion.test.ts
@@ -474,24 +474,23 @@ describe("gatherRectificationFindings — verifier-as-SSOT carve-out (AC1.x)", (
 
     if (capturedCycle === null || capturedCtx === null) return;
 
-    // First validate call: gate runs → fails → shouldSkipPhaseForRectification sees no prior
-    // verifier pass → gate findings included. Then verifier runs → passes → populates phaseOutputs.
+    // First validate call: gate PASSES (simulating fix landed) → loop proceeds to verifier
+    // → verifier passes → populates phaseOutputs[verifier]. Under the new halt contract
+    // (PR #1127 + revalidation short-circuit), verifier only judges green-gate code, so
+    // this iteration MUST have gate=passing for the carve-out to establish.
     _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
-      if (op.name === "full-suite-gate") return { success: false, findings: [TEST_RUNNER_FINDING] };
+      if (op.name === "full-suite-gate") return { success: true, findings: [] };
       if (op.name === "verifier") return { success: true, findings: [] };
       return { success: true };
     }) as typeof _storyOrchestratorDeps.callOp;
 
-    const firstCallFindings = await (capturedCycle as FixCycle<Finding>).validate(
+    await (capturedCycle as FixCycle<Finding>).validate(
       capturedCtx as FixCycleContext,
       { mode: "full" },
     );
-    // First call: verifier hadn't pre-passed in phaseOutputs → gate findings included
-    const firstHasTestRunner = firstCallFindings.some((f) => f.source === "test-runner");
-    expect(firstHasTestRunner).toBe(true);
 
-    // Second validate call: now phaseOutputs[verifier] has the prior passing result →
-    // shouldSkipPhaseForRectification fires on gate → gate findings excluded.
+    // Second validate call: gate regresses to failing. phaseOutputs[verifier] still holds the
+    // prior passing result → shouldSkipPhaseForRectification fires on gate → gate findings excluded.
     let gateCalledSecondTime = false;
     _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
       if (op.name === "full-suite-gate") {
@@ -511,5 +510,44 @@ describe("gatherRectificationFindings — verifier-as-SSOT carve-out (AC1.x)", (
     // But gate findings are excluded because verifier passed in the previous iteration
     const secondHasTestRunner = secondCallFindings.some((f) => f.source === "test-runner");
     expect(secondHasTestRunner).toBe(false);
+  });
+
+  test("AC1.5: gate fails in validate with no prior verifier pass — findings still collected before short-circuit", async () => {
+    // Companion to AC1.4: confirms that when verifier has NEVER passed (no SSOT
+    // carve-out), gate findings are still pushed into the findings array even
+    // though the new revalidation short-circuit breaks the sweep. The cycle
+    // needs those findings to drive the next fix iteration.
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "full-suite-gate") return { success: false, findings: [TEST_RUNNER_FINDING] };
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    let capturedCycle: FixCycle<Finding> | null = null;
+    let capturedCtx: FixCycleContext | null = null;
+    _storyOrchestratorDeps.runFixCycle = mock(async (cycle: FixCycle<Finding>, cycleCtx: FixCycleContext) => {
+      capturedCycle = cycle;
+      capturedCtx = cycleCtx;
+      return { iterations: [], finalFindings: [], exitReason: "resolved" as FixCycleExitReason, costUsd: 0 };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+
+    const ctx = makeCtx();
+    const plan = makePlanWithGateAndVerifier(ctx);
+    await plan.run();
+    if (capturedCycle === null || capturedCtx === null) return;
+
+    // Fresh validate with gate failing — phaseOutputs has no prior verifier pass.
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "full-suite-gate") return { success: false, findings: [TEST_RUNNER_FINDING] };
+      if (op.name === "verifier") return { success: true, findings: [] };
+      return { success: true };
+    }) as typeof _storyOrchestratorDeps.callOp;
+
+    const findings = await (capturedCycle as FixCycle<Finding>).validate(
+      capturedCtx as FixCycleContext,
+      { mode: "full" },
+    );
+    // Short-circuit fires AFTER pushing the gate finding into the findings array,
+    // so the cycle can still drive the next fix iteration.
+    expect(findings.some((f) => f.source === "test-runner")).toBe(true);
   });
 });

--- a/test/unit/execution/story-orchestrator.test.ts
+++ b/test/unit/execution/story-orchestrator.test.ts
@@ -32,7 +32,13 @@ import type { NaxRuntime } from "@/runtime";
 import type { CompleteResult, TurnResult } from "@/agents/types";
 import type { ReviewCheckResult, Finding } from "@/findings";
 import { NaxError } from "@/errors";
-import { _storyOrchestratorDeps, phasesToRevalidate, formatPhaseResultMessage } from "@/execution";
+import {
+  _storyOrchestratorDeps,
+  formatPhaseResultMessage,
+  phasesToRevalidate,
+  refreshReviewInputForDispatch,
+  StoryOrchestratorBuilder,
+} from "@/execution";
 
 // ============================================================================
 // Test Helper: Mock Operations
@@ -1246,7 +1252,10 @@ describe("AC-4 + AC-5: validate callback re-runs gate and verifier, lite-mode sk
     const verifierRunCount = { n: 0 };
     let capturedCycle: any = null;
 
-    const gateOp = makeDeterministicOp("full-suite-gate", { success: false, findings: [{ source: "test-runner", category: "failed-test", severity: "error", message: "f", rule: "r", file: "f.ts" }] });
+    // Gate passes during validate so the revalidation short-circuit doesn't fire;
+    // this test asserts "verifier IS re-run when strategy maps to it", not gate-halt.
+    // Short-circuit behavior is covered by the dedicated test below.
+    const gateOp = makeDeterministicOp("full-suite-gate", { success: true, findings: [] });
     const verOp = makeDeterministicOp("verifier", { success: false });
 
     const origCallOp = _storyOrchestratorDeps.callOp;
@@ -1335,6 +1344,200 @@ describe("AC-4 + AC-5: validate callback re-runs gate and verifier, lite-mode sk
       _storyOrchestratorDeps.callOp = origCallOp;
       _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
     }
+  });
+
+  test("AC-6: validate short-circuits on phase failure — verifier does not run on broken-gate code", async () => {
+    const config = makeNaxConfig({ execution: { rectification: { enabled: true, maxAttemptsTotal: 3, abortOnIncreasingFailures: false } } });
+    rt = makeTestRuntime({ config });
+
+    const gateRunCount = { n: 0 };
+    const verifierRunCount = { n: 0 };
+    let capturedCycle: any = null;
+
+    const gateOp = makeDeterministicOp("full-suite-gate", { success: false, findings: [{ source: "test-runner", category: "failed-test", severity: "error", message: "f", rule: "r", file: "f.ts" }] });
+    const verOp = makeDeterministicOp("verifier", { success: true });
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    const origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.callOp = async (_ctx: any, op: any, input: any) => {
+      if (op.name === "full-suite-gate") gateRunCount.n++;
+      if (op.name === "verifier") verifierRunCount.n++;
+      if (op.kind === "deterministic") return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    };
+    _storyOrchestratorDeps.runFixCycle = async (cycle: any) => {
+      capturedCycle = cycle;
+      return { iterations: [], finalFindings: [], exitReason: "resolved" as const, costUsd: 0 };
+    };
+
+    try {
+      const ctx: CallContext = { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-t" } as any;
+      const plan = new (require("@/execution/story-orchestrator").StoryOrchestratorBuilder)()
+        .addImplementer({ op: mockImplementerOp, input: { code: "" } })
+        .addFullSuiteGate({ op: gateOp, input: { story: { id: "US-t" } as any, workdir: "/tmp" } })
+        .addVerifier({ op: verOp, input: { code: "" } })
+        .addRectification({ maxAttempts: 3, strategies: [{ name: "s", appliesTo: () => true, fixOp: mockImplementerOp, buildInput: () => ({ code: "" }), maxAttempts: 1, coRun: "exclusive" as const }], abortOnIncreasingFailures: false })
+        .build(ctx);
+      await plan.run();
+
+      if (capturedCycle) {
+        const beforeGate = gateRunCount.n;
+        const beforeVerifier = verifierRunCount.n;
+        await capturedCycle.validate(ctx, { mode: "full" });
+        // Gate runs during validate and fails.
+        expect(gateRunCount.n).toBeGreaterThan(beforeGate);
+        // Verifier MUST NOT run after a failing gate (spec §2C halt contract,
+        // mirrors the main loop's short-circuit; prevents verifier from judging
+        // broken-gate code, which was the bug in the 2026-05-27T05-06-41 run).
+        expect(verifierRunCount.n).toBe(beforeVerifier);
+      }
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+      _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+    }
+  });
+
+  test("AC-7: post-rectification resume runs canonical phases skipped by short-circuit (e.g. adversarial-review)", async () => {
+    // Restores prior orchestrator behavior: after rectification resolves all findings,
+    // the canonical loop resumes from where it short-circuited so reviewers run on the
+    // fixed code. STRATEGY_TO_REVALIDATION_PHASES["full-suite-rectify"] intentionally
+    // excludes adversarial-review; without the resume, it never runs. See log
+    // 2026-05-27T05-06-41.jsonl line 521 — phasesSelected omitted adversarial.
+    const config = makeNaxConfig({ execution: { rectification: { enabled: true, maxAttemptsTotal: 3, abortOnIncreasingFailures: false } } });
+    rt = makeTestRuntime({ config });
+
+    const opRuns: Record<string, number> = {};
+    const gateOp = makeDeterministicOp("full-suite-gate", { success: false, findings: [{ source: "test-runner", category: "failed-test", severity: "error", message: "f", rule: "r", file: "f.ts" }] });
+    const verOp = makeDeterministicOp("verifier", { success: true });
+    const advOp = makeDeterministicOp("adversarial-review", { success: true, findings: [] });
+
+    const origCallOp = _storyOrchestratorDeps.callOp;
+    const origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+    _storyOrchestratorDeps.callOp = async (_ctx: any, op: any, input: any) => {
+      opRuns[op.name] = (opRuns[op.name] ?? 0) + 1;
+      if (op.kind === "deterministic") return op.execute(input, _ctx);
+      return { success: true, filesChanged: [], estimatedCostUsd: 0, durationMs: 0 };
+    };
+    // Simulate rectification resolving the gate: swap gateOp.execute to succeed
+    // during the validate sweep, then restore. After the swap, the cycle reports
+    // "resolved" so the post-rectification resume kicks in.
+    _storyOrchestratorDeps.runFixCycle = async (cycle: any, cycleCtx: any) => {
+      const origGateExecute = gateOp.execute;
+      (gateOp as any).execute = () => ({ success: true, findings: [] });
+      try {
+        await cycle.validate(cycleCtx, { mode: "full", strategiesRun: ["full-suite-rectify"] });
+      } finally {
+        (gateOp as any).execute = origGateExecute;
+      }
+      return { iterations: [{ strategyName: "full-suite-rectify" }], finalFindings: [], exitReason: "resolved" as const, costUsd: 0 };
+    };
+
+    try {
+      const ctx: CallContext = { runtime: rt, packageView: rt.packages.repo(), packageDir: "/tmp", agentName: "claude", storyId: "US-t" } as any;
+      const plan = new StoryOrchestratorBuilder()
+        .addImplementer({ op: mockImplementerOp, input: { code: "" } })
+        .addFullSuiteGate({ op: gateOp, input: { story: { id: "US-t" } as any, workdir: "/tmp" } })
+        .addVerifier({ op: verOp, input: { code: "" } })
+        .addAdversarialReview({ op: advOp, input: { code: "" } })
+        .addRectification({ maxAttempts: 3, strategies: [{ name: "full-suite-rectify", appliesTo: () => true, fixOp: mockImplementerOp, buildInput: () => ({ code: "" }), maxAttempts: 1, coRun: "exclusive" as const }], abortOnIncreasingFailures: false })
+        .build(ctx);
+      await plan.run();
+
+      // Main loop short-circuited at gate, so adversarial never ran there.
+      // Rectification revalidation doesn't include adversarial in its set.
+      // Post-rectification resume MUST dispatch adversarial-review on the fixed code.
+      expect(opRuns["adversarial-review"] ?? 0).toBeGreaterThan(0);
+    } finally {
+      _storyOrchestratorDeps.callOp = origCallOp;
+      _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+    }
+  });
+});
+
+// ============================================================================
+// refreshReviewInputForDispatch — re-prepare review inputs at dispatch time
+// ============================================================================
+
+describe("refreshReviewInputForDispatch — re-prepare review inputs at dispatch time (Bug A)", () => {
+  test("semantic-review input is refreshed with fresh stat/diff at dispatch", async () => {
+    
+    const origPrepare = _storyOrchestratorDeps.prepareSemanticReviewInput;
+    _storyOrchestratorDeps.prepareSemanticReviewInput = mock(async () => ({
+      effectiveRef: "fresh-ref",
+      stat: "src/foo.ts | 5 ++++-",
+      diff: "diff content",
+      excludePatterns: ["test/**"],
+    })) as typeof _storyOrchestratorDeps.prepareSemanticReviewInput;
+
+    try {
+      const staleInput = {
+        workdir: "/tmp/repo",
+        story: { id: "US-x" } as any,
+        semanticConfig: { diffMode: "ref" } as any,
+        mode: "ref" as const,
+        stat: "",
+        diff: undefined,
+        storyGitRef: "stale-ref",
+        excludePatterns: [],
+        _refresh: {
+          projectDir: "/tmp/repo",
+          storyId: "US-x",
+          storyGitRef: "stale-ref",
+        },
+      };
+      const refreshed = (await refreshReviewInputForDispatch("semantic-review", staleInput)) as any;
+      expect(refreshed.stat).toBe("src/foo.ts | 5 ++++-");
+      expect(refreshed.diff).toBe("diff content");
+      expect(refreshed.excludePatterns).toEqual(["test/**"]);
+      expect(refreshed.storyGitRef).toBe("fresh-ref");
+    } finally {
+      _storyOrchestratorDeps.prepareSemanticReviewInput = origPrepare;
+    }
+  });
+
+  test("adversarial-review input is refreshed with fresh stat/diff/testInventory at dispatch", async () => {
+    
+    const origPrepare = _storyOrchestratorDeps.prepareAdversarialReviewInput;
+    _storyOrchestratorDeps.prepareAdversarialReviewInput = mock(async () => ({
+      effectiveRef: "fresh-ref",
+      stat: "src/foo.ts | 5",
+      diff: "diff",
+      testInventory: { tests: 3 } as any,
+      excludePatterns: ["test/**"],
+      testGlobs: ["test/**/*.test.ts"],
+      refExcludePatterns: [":(exclude)test/**"],
+    })) as typeof _storyOrchestratorDeps.prepareAdversarialReviewInput;
+
+    try {
+      const refreshed = (await refreshReviewInputForDispatch("adversarial-review", {
+        workdir: "/tmp/repo",
+        story: { id: "US-x" } as any,
+        adversarialConfig: { diffMode: "ref" } as any,
+        mode: "ref" as const,
+        stat: "",
+        diff: undefined,
+        _refresh: { projectDir: "/tmp/repo", storyId: "US-x", storyGitRef: undefined },
+      })) as any;
+      expect(refreshed.stat).toBe("src/foo.ts | 5");
+      expect(refreshed.testInventory).toEqual({ tests: 3 });
+      expect(refreshed.testGlobs).toEqual(["test/**/*.test.ts"]);
+    } finally {
+      _storyOrchestratorDeps.prepareAdversarialReviewInput = origPrepare;
+    }
+  });
+
+  test("non-review phases pass through unchanged", async () => {
+    
+    const input = { foo: "bar" };
+    const result = await refreshReviewInputForDispatch("full-suite-gate", input);
+    expect(result).toBe(input);
+  });
+
+  test("input without _refresh payload passes through unchanged (backward compat)", async () => {
+    
+    const input = { workdir: "/tmp", semanticConfig: {} };
+    const result = await refreshReviewInputForDispatch("semantic-review", input);
+    expect(result).toBe(input);
   });
 });
 


### PR DESCRIPTION
## Summary

Three related fixes addressing behavioral regressions seen in `logs/2026-05-27T05-06-41.jsonl`:
- verifier judging broken-gate code during rectification revalidation
- `adversarial-review` silently never running after the main loop short-circuits
- `semantic-review` slot dropped at plan-build for US-002 because the diff was empty at that instant

PR #1127 fixed the main canonical loop's halt contract; this PR fixes its three counterparts.

## Changes

### 1. Revalidation short-circuit (Bug B inside `runRectification.validate`)
The rectification validate sweep now halts on the first failing phase, mirroring the main canonical loop's RED→GREEN→handover contract. Verifier/reviews must never judge broken-gate code, even mid-cycle. Findings collected so far still feed the next fix iteration.

### 2. Post-rectification resume (Bug B outside rectification)
After `runRectification` returns without exhaustion, walk `collectOrderedPhases` again and run any phase whose output is missing or non-passing. Halts on first failure. Restores prior behavior: `rectify → gate green → verifier → reviews`. `STRATEGY_TO_REVALIDATION_PHASES` is intentionally narrow (e.g. `full-suite-rectify` excludes `adversarial-review`); without this resume, any phase outside the strategy's set is silently skipped.

### 3. Dispatch-time review-input refresh (Bug A)
Plan-build runs before test-writer/implementer write code, so the diff snapshot captured for semantic/adversarial review is typically empty. Previously the slot was dropped permanently on `skipReason`. Now:
- The slot stays registered with a `_refresh` payload carrying prepare params (including `config`).
- `runPhase` calls `refreshReviewInputForDispatch` just before dispatching `semantic-review` / `adversarial-review`, re-running `prepareSemanticReviewInput` / `prepareAdversarialReviewInput` against the current working tree.
- Refresh failures (worktree race, git errors) fall back to the stale input with a `warn` log rather than aborting the story.
- `_refresh` is stripped from `dispatchInput` so op handlers never see plan-time metadata.

## End-to-end effect on US-002

```
plan-build       Register semantic + adversarial slots with _refresh
                 (diff at plan-build is empty — irrelevant now)

main loop        impl → gate FAIL → short-circuit

rectification    autofix iter 1 → validate (short-circuits on failure)
                 → resolved

resume           Walk ordered phases, dispatch verifier / lint / typecheck /
                 semantic-review / adversarial-review (the last two would
                 otherwise be silently skipped)
                 Each review's runPhase refreshes its stat/diff/etc.
                 against the post-implementer working tree.

aggregate        success=true, phaseCount=9 (was 8)
```

## Code review

A code-reviewer agent flagged 2 HIGH and 4 MEDIUM issues; all addressed before pushing:
- **H1** `config` now threaded through `_refresh` (was `undefined`)
- **H2** refresh wrapped in try/catch with stale-input fallback
- **M1** `_refresh` stripped from `dispatchInput` so op handlers don't see it
- **M2** added AC1.5 for the gate-fail-no-prior-verifier-pass case
- **M3** resume-failure log now distinct (`source: "post-rectification-resume"`)
- **M4** marked refresh helper `@internal`

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (no baseline regressions)
- [x] Full unit suite — 8603 pass, 14 pre-existing skips, 0 fail
- [x] TDD + execution integration suites pass
- [x] AC-6 short-circuit assertion
- [x] AC-7 post-rectification resume dispatches adversarial-review
- [x] AC1.4 rewritten + AC1.5 added for new gate-halt contract
- [x] 4 `refreshReviewInputForDispatch` unit tests (both review types, pass-through, backward compat)
- [x] `plan-inputs-review-wiring` updated to assert slot stays registered with `_refresh`
- [ ] End-to-end validation against a real run (next nax invocation against the originally failing scenario)
