### PR TITLE
chore: release v0.67.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nathapp/nax",
-  "version": "0.67.15",
+  "version": "0.67.16",
   "description": "AI Coding Agent Orchestrator — loops until done",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.67.16

Bumps version: 0.67.15 → 0.67.16

After merging, run:
```bash
git checkout main && git pull origin main
bun run release tag
```