### PR TITLE
fix(execution): close three post-refactor migration gaps (#1131)

### DIFF
--- a/src/agents/manager.ts
+++ b/src/agents/manager.ts
@@ -201,6 +201,11 @@ export class AgentManager implements IAgentManager {
     return candidates[0] ?? null;
   }
 
+  // TODO(#1131): Agent-swap metric propagation is deferred. When swaps occur here,
+  // the hop count and AgentFallbackRecord[] should surface in story metrics
+  // (StoryMetrics.fallback). Per .claude/rules/adapter-wiring.md Rule 6, result-side
+  // data must not back-flow through CallContext — wiring requires a dedicated spec.
+  // See follow-up after issue #1131 is closed.
   async runWithFallback(request: AgentRunRequest, primaryAgentOverride?: string): Promise<AgentRunOutcome> {
     const logger = getSafeLogger();
     const fallbacks: AgentFallbackRecord[] = [];

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -12,6 +12,7 @@
  */
 
 import type { AgentResult } from "../agents/types";
+import type { Finding } from "../findings/types";
 import { checkMergeConflict, isTriggerEnabled } from "../interaction/triggers";
 import { getLogger } from "../logger";
 import {
@@ -30,6 +31,7 @@ import { rollbackToRef } from "../tdd/rollback";
 import { errorMessage } from "../utils/errors";
 import { autoCommitIfDirty, detectMergeConflict } from "../utils/git";
 import { failAndClose } from "./session-manager-runtime";
+import { EXHAUSTED_EXIT_REASONS } from "./story-orchestrator";
 import type { StoryOrchestratorResult } from "./story-orchestrator";
 import type { FailureCategory } from "./types";
 
@@ -94,7 +96,10 @@ export function extractPauseReason(phaseOutputs: Record<string, unknown>): strin
 }
 
 /** Derive TDD failure category from phase outputs after plan.run(). */
-export function deriveTddFailureCategory(phaseOutputs: Record<string, unknown>): FailureCategory | undefined {
+export function deriveTddFailureCategory(
+  phaseOutputs: Record<string, unknown>,
+  unfixedFindings?: readonly Finding[],
+): FailureCategory | undefined {
   // Test-writer failure → session-failure
   const testWriterOutput = phaseOutputs[testWriterOp.name] as { success?: boolean } | undefined;
   if (testWriterOutput?.success === false) {
@@ -124,6 +129,21 @@ export function deriveTddFailureCategory(phaseOutputs: Record<string, unknown>):
   // failures, the verifier has judged this story OK (e.g. unrelated regressions).
   // Skip the gate-derived category in that case.
   const verifierPassed = verifierOutput?.success === true;
+
+  // Full-suite gate exhausted: rectification ran out of retry budget AND at least
+  // one test-runner finding remains unfixed. Takes priority over the plain
+  // tests-failing branch below, but only fires when verifier did NOT pass (the
+  // verifierPassed guard above already short-circuits when verifier succeeded).
+  if (!verifierPassed && unfixedFindings && unfixedFindings.length > 0) {
+    const rectOutput = phaseOutputs.rectification as { exitReason?: string } | undefined;
+    if (
+      rectOutput?.exitReason &&
+      EXHAUSTED_EXIT_REASONS.has(rectOutput.exitReason) &&
+      unfixedFindings.some((f) => f.source === "test-runner")
+    ) {
+      return "full-suite-gate-exhausted";
+    }
+  }
 
   // Full-suite gate failure without an overriding verifier verdict → tests-failing.
   // Reached only when verifier either failed-without-category-but-handled-above, did
@@ -285,7 +305,10 @@ export async function applyPostRunInspection(
   }
 
   const pauseReason = extractPauseReason(planResult.phaseOutputs);
-  const failureCategory = isTdd && !planResult.success ? deriveTddFailureCategory(planResult.phaseOutputs) : undefined;
+  const failureCategory =
+    isTdd && !planResult.success
+      ? deriveTddFailureCategory(planResult.phaseOutputs, planResult.unfixedFindings)
+      : undefined;
 
   // Diagnostic: if a TDD plan failed but no category was derived, the routing path
   // falls back to the generic "requires review" pause. Surface the per-phase

--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -217,7 +217,6 @@ export async function applyPostRunInspection(
     ...(capturedTokenUsage ? { tokenUsage: capturedTokenUsage } : {}),
   };
   ctx.agentResult = agentResult;
-  ctx.agentSwapCount = 0;
 
   // Propagate full-suite gate result so verify stage can skip redundant run (BUG-054)
   const fullSuiteGateOutput = planResult.phaseOutputs[fullSuiteGateOp.name] as { passed?: boolean } | undefined;

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -44,6 +44,20 @@ export const _storyOrchestratorDeps = {
 };
 
 /**
+ * Exit reasons from runRectification that indicate all retry budget was spent
+ * without resolving findings. Used by both runRectification (locally) and
+ * deriveTddFailureCategory (post-run.ts) to assign the full-suite-gate-exhausted
+ * FailureCategory. Single source of truth — import from here; do not redeclare.
+ */
+export const EXHAUSTED_EXIT_REASONS = new Set<string>([
+  "max-attempts-total",
+  "max-attempts-per-strategy",
+  "bail-when",
+  "no-strategy",
+  "agent-gave-up",
+]);
+
+/**
  * @internal
  * Refresh stat/diff/excludePatterns/effectiveRef on a semantic-review or
  * adversarial-review input just before dispatch. Plan-build captures these
@@ -924,14 +938,7 @@ async function runRectification(
     });
   }
 
-  const exhaustedReasons = new Set<string>([
-    "max-attempts-total",
-    "max-attempts-per-strategy",
-    "bail-when",
-    "no-strategy",
-    "agent-gave-up",
-  ]);
-  if (exhaustedReasons.has(cycleResult.exitReason) && cycleResult.finalFindings.length > 0) {
+  if (EXHAUSTED_EXIT_REASONS.has(cycleResult.exitReason) && cycleResult.finalFindings.length > 0) {
     return { rectificationExhausted: true, unfixedFindings: cycleResult.finalFindings };
   }
 

--- a/src/pipeline/event-bus.ts
+++ b/src/pipeline/event-bus.ts
@@ -18,19 +18,6 @@
  */
 
 import { getLogger } from "../logger";
-// VerifyResult inlined here after orchestrator-types.ts deletion (issue #1116).
-// VerifyCompletedEvent is defined but not yet emitted — kept for future use.
-interface VerifyResult {
-  success: boolean;
-  status: string;
-  storyId: string;
-  passCount: number;
-  failCount: number;
-  durationMs: number;
-  countsTowardEscalation: boolean;
-  rawOutput?: string;
-}
-
 // ---------------------------------------------------------------------------
 // Event types
 // ---------------------------------------------------------------------------
@@ -80,38 +67,6 @@ export interface StoryFailedEvent {
   /** Optional: passed by executor for interaction subscriber */
   feature?: string;
   attempts?: number;
-}
-
-export interface VerifyCompletedEvent {
-  type: "verify:completed";
-  storyId: string;
-  result: VerifyResult;
-}
-
-export interface RectifyStartedEvent {
-  type: "rectify:started";
-  storyId: string;
-  attempt: number;
-  testOutput: string;
-}
-
-export interface RectifyCompletedEvent {
-  type: "rectify:completed";
-  storyId: string;
-  attempt: number;
-  fixed: boolean;
-}
-
-export interface AutofixStartedEvent {
-  type: "autofix:started";
-  storyId: string;
-  command: string;
-}
-
-export interface AutofixCompletedEvent {
-  type: "autofix:completed";
-  storyId: string;
-  fixed: boolean;
 }
 
 export interface RegressionDetectedEvent {
@@ -182,11 +137,6 @@ export type PipelineEvent =
   | StoryStartedEvent
   | StoryCompletedEvent
   | StoryFailedEvent
-  | VerifyCompletedEvent
-  | RectifyStartedEvent
-  | RectifyCompletedEvent
-  | AutofixStartedEvent
-  | AutofixCompletedEvent
   | RegressionDetectedEvent
   | RunCompletedEvent
   | HumanReviewRequestedEvent

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -225,12 +225,6 @@ export interface PipelineContext extends DispatchContext {
   /** Accumulated cost across all prior escalation attempts (BUG-067) */
   accumulatedAttemptCost?: number;
   /**
-   * Number of agent-swap hops completed for this story (Phase 5.5).
-   * Incremented by executionStage each time rebuildForSwap triggers a new agent.
-   * Checked against config.agent.fallback.maxHopsPerStory to cap swaps.
-   */
-  agentSwapCount?: number;
-  /**
    * Ordered log of agent-swap hops for this story (AC-41).
    * Each entry captures the agents involved, the failure that triggered the swap,
    * and the 1-indexed hop number. Surfaced in StoryMetrics.fallback.hops.

--- a/test/unit/execution/post-run-inspection.test.ts
+++ b/test/unit/execution/post-run-inspection.test.ts
@@ -14,6 +14,7 @@ import {
   _postRunDeps,
 } from "../../../src/execution/post-run";
 import type { InspectionOptions } from "../../../src/execution/post-run";
+import { EXHAUSTED_EXIT_REASONS } from "../../../src/execution/story-orchestrator";
 import type { StoryOrchestratorResult } from "../../../src/execution/story-orchestrator";
 import type { Finding } from "../../../src/findings/types";
 import {
@@ -128,6 +129,96 @@ describe("deriveTddFailureCategory", () => {
       [fullSuiteGateOp.name]: { success: false, passed: false, findings: [] },
       [verifierOp.name]: { success: true },
     });
+    expect(result).toBeUndefined();
+  });
+
+  // ─── US-001: full-suite-gate-exhausted derivation ─────────────────────────
+
+  test("returns full-suite-gate-exhausted when rectification exhausted with max-attempts-total and test-runner finding", () => {
+    // AC-001-1
+    const unfixedFindings: Finding[] = [
+      { source: "test-runner", severity: "error", category: "test-failure", message: "failing test" },
+    ];
+    const result = deriveTddFailureCategory(
+      { rectification: { exitReason: "max-attempts-total", success: false } },
+      unfixedFindings,
+    );
+    expect(result).toBe("full-suite-gate-exhausted");
+  });
+
+  test("returns full-suite-gate-exhausted for every member of EXHAUSTED_EXIT_REASONS with a test-runner finding", () => {
+    // AC-001-2: confirms all members of EXHAUSTED_EXIT_REASONS trigger the branch
+    for (const exitReason of EXHAUSTED_EXIT_REASONS) {
+      const unfixedFindings: Finding[] = [
+        { source: "test-runner", severity: "error", category: "test-failure", message: "failing" },
+      ];
+      const result = deriveTddFailureCategory(
+        { rectification: { exitReason, success: false } },
+        unfixedFindings,
+      );
+      expect(result).toBe("full-suite-gate-exhausted");
+    }
+  });
+
+  test("does NOT return full-suite-gate-exhausted when rectification exitReason is resolved", () => {
+    // AC-001-3: non-exhausted exit reasons must not trigger the branch
+    const unfixedFindings: Finding[] = [
+      { source: "test-runner", severity: "error", category: "test-failure", message: "failing" },
+    ];
+    const result = deriveTddFailureCategory(
+      { rectification: { exitReason: "resolved", success: true } },
+      unfixedFindings,
+    );
+    expect(result).not.toBe("full-suite-gate-exhausted");
+  });
+
+  test("does NOT return full-suite-gate-exhausted when unfixedFindings has only lint source", () => {
+    // AC-001-4: lint-only findings must not trigger the branch
+    const unfixedFindings: Finding[] = [
+      { source: "lint", severity: "warning", category: "style", message: "lint issue" },
+    ];
+    const result = deriveTddFailureCategory(
+      { rectification: { exitReason: "max-attempts-total", success: false } },
+      unfixedFindings,
+    );
+    expect(result).not.toBe("full-suite-gate-exhausted");
+  });
+
+  test("verifier-SSOT short-circuit wins over full-suite-gate-exhausted when verifier passed", () => {
+    // AC-001-5: verifier pass still produces undefined even with exhausted rectification
+    const unfixedFindings: Finding[] = [
+      { source: "test-runner", severity: "error", category: "test-failure", message: "failing" },
+    ];
+    const result = deriveTddFailureCategory(
+      {
+        [verifierOp.name]: { success: true },
+        rectification: { exitReason: "max-attempts-total", success: false },
+      },
+      unfixedFindings,
+    );
+    expect(result).toBeUndefined();
+  });
+
+  test("does NOT return full-suite-gate-exhausted when unfixedFindings omitted (backwards compat)", () => {
+    // AC-001-6: single-arg call must not throw and must not return the new category
+    let threw = false;
+    let result: string | undefined;
+    try {
+      result = deriveTddFailureCategory({
+        rectification: { exitReason: "max-attempts-total", success: false },
+      });
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+    expect(result).not.toBe("full-suite-gate-exhausted");
+  });
+
+  test("returns undefined for empty phaseOutputs regardless of unfixedFindings", () => {
+    // AC-001-7: no false-positive on completely empty outputs
+    const result = deriveTddFailureCategory({}, [
+      { source: "test-runner", severity: "error", category: "test-failure", message: "failing" },
+    ]);
     expect(result).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes three orphaned behaviors from the StoryOrchestrator unification refactor ([#1131](https://github.com/nathapp-io/nax/issues/1131)).

- **US-001 (additive):** Wire `full-suite-gate-exhausted` FailureCategory — `deriveTddFailureCategory` now accepts `unfixedFindings` and returns this category when rectification exhausted with test-runner findings. `EXHAUSTED_EXIT_REASONS` extracted to module scope in `story-orchestrator.ts` and imported in `post-run.ts` (single source of truth, AC-001-9).
- **US-002 (deletion):** Remove five dead `PipelineEvent` union members (`verify:completed`, `rectify:started`, `rectify:completed`, `autofix:started`, `autofix:completed`) and their interface definitions — never emitted, zero consumers in `src/` or `test/`.
- **US-003 (deletion):** Remove always-zero `agentSwapCount` field from `PipelineContext` and its `= 0` initialization. Add TODO comment near `runWithFallback` in `manager.ts` documenting deferred metric propagation per `adapter-wiring.md` Rule 6.

Runtime-crash `FailureCategory` assignment is out of scope — tracked in #1132.

## Test Plan

- [ ] `bun run test` — 1127 tests pass (7 new unit tests for US-001 exhaustion derivation)
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] Grep AC-001-8: `return "full-suite-gate-exhausted"` present in `post-run.ts`
- [ ] Grep AC-001-9: `EXHAUSTED_EXIT_REASONS` imported, not redeclared in `post-run.ts`
- [ ] Grep AC-002-1…10: no dead event type strings/names remain in `src/`
- [ ] Grep AC-003-1…3: no `agentSwapCount` remains in `src/`
- [ ] Grep AC-003-5: TODO comment present near `runWithFallback` in `manager.ts`