### PR TITLE
fix(orchestrator): retry rectification once for fresh failures in resume block

### DIFF
--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -1028,6 +1028,15 @@ export class ExecutionPlan {
     // Halts on first failure (same RED→GREEN contract as the main loop). Skipped
     // entirely when rectification was exhausted — the story is already terminal.
     if (this.state.rectification && !rectResult.rectificationExhausted) {
+      // The first rectification ran with a strategy-specific revalidation set
+      // (STRATEGY_TO_REVALIDATION_PHASES) that may have excluded phases this
+      // resume block runs for the first time (e.g. full-suite-rectify excludes
+      // adversarial-review). A failure here is therefore a *new* finding that
+      // rectification never had as input — distinct from "rectification tried
+      // and could not fix this." Allow one additional rectification pass per
+      // story for such fresh failures before declaring terminal. Per-story
+      // (not per-phase) on purpose: bounds total LLM cost on the recovery path.
+      let resumeRectifyUsed = false;
       for (const phase of collectOrderedPhases(this.state)) {
         const name = phase.slot.op.name;
         if (name in phaseOutputs && phasePassed(name, phaseOutputs[name], this.ctx.storyId)) {
@@ -1044,11 +1053,33 @@ export class ExecutionPlan {
           throw error;
         }
         if (!phasePassed(name, phaseOutputs[name], this.ctx.storyId)) {
-          // Terminal failure: rectification already exited "resolved" (per the
-          // guard above), so this failure happens AFTER the fix-cycle — it cannot
-          // trigger another rectification iteration. The story will be marked
-          // failed downstream. Surface this distinctly so operators don't confuse
-          // it with an in-cycle revalidation failure.
+          if (!resumeRectifyUsed) {
+            // Fresh failure: this phase was not in the prior strategy's
+            // revalidation scope, so rectification has never seen its findings.
+            // Invoke rectification once more on the now-current phaseOutputs.
+            // Bounded to a single retry per story; the inner cycle has its own
+            // maxAttempts budget so this cannot loop.
+            resumeRectifyUsed = true;
+            logger?.info(
+              "story-orchestrator",
+              "Phase failed in post-rectification resume — invoking second rectification pass",
+              { storyId: this.ctx.storyId, phase: name, source: "post-rectification-resume" },
+            );
+            const secondRect = await runRectification(this.ctx, this.state, phaseCosts, phaseOutputs);
+            if (secondRect.rectificationExhausted) {
+              logger?.warn("story-orchestrator", "Second rectification pass exhausted — terminal failure", {
+                storyId: this.ctx.storyId,
+                phase: name,
+                source: "post-rectification-resume",
+              });
+              break;
+            }
+            // Re-check the failed phase: revalidation inside runRectification
+            // may have re-run it. If it now passes, continue; otherwise terminal.
+            if (phasePassed(name, phaseOutputs[name], this.ctx.storyId)) {
+              continue;
+            }
+          }
           logger?.warn(
             "story-orchestrator",
             "Terminal phase failure (post-rectification resume — bypasses rectification)",
@@ -1056,6 +1087,7 @@ export class ExecutionPlan {
               storyId: this.ctx.storyId,
               phase: name,
               source: "post-rectification-resume",
+              secondRectifyUsed: resumeRectifyUsed,
             },
           );
           break;


### PR DESCRIPTION
## What

Allows one additional `runRectification` pass per story when the post-rectification resume block discovers a failure on a phase that the prior strategy's revalidation set excluded.

## Why

The post-rectification resume block (#1129) re-runs phases the strategy's `STRATEGY_TO_REVALIDATION_PHASES` set omitted — e.g. `full-suite-rectify` excludes `adversarial-review`. Previously a failure here was always terminal, with a comment claiming rectification was exhausted; but for excluded phases, rectification *never had their findings as input*. Combined with the fact that `deriveTddFailureCategory` has no branch for review-phase failures (so `failureCategory = undefined` → `routeTddFailure` defaults to `pause`), stories paused without rectification ever attempting to address the new finding.

Closes #1134

## How

In `src/execution/story-orchestrator.ts`, when a phase fails inside the resume loop, invoke `runRectification` once on the now-current `phaseOutputs`. If it exhausts, terminal. If revalidation re-ran the failing phase and it now passes, continue. Otherwise terminal.

- Budget is **per-story** (single boolean flag), not per-phase, to bound total LLM cost on the recovery path.
- The inner cycle has its own `maxAttempts` budget so this cannot loop.
- Diagnostic logs: `info` on second-pass invocation, `warn` on exhaustion, existing terminal-failure `warn` augmented with `secondRectifyUsed: true` for post-mortem clarity.

## Testing

- [x] Full unit suite for `story-orchestrator`, `operations`, `review` — 1383 pass / 0 fail
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Tests added/updated — not in this PR; resume-block orchestration glue needs a substantial fixture. See note below.

## Notes

**Test gap left intentionally:** writing a focused unit test for this path requires a sizable orchestrator fixture (real rectification strategy + multiple phases + faked findings). Worth a follow-up for integration coverage — would prefer to land the orchestrator fix first since it's already a small, well-scoped change.

**Related but out of scope:** the originating run (`logs/2026-05-27T10-41-43.jsonl`) also showed `adversarialReviewOp.verify` receiving `parsed.passed: false` despite the hopBody requote rewrite computing `passed: true`. Unit-test probes confirm the rewrite is correct in isolation, so the propagation bug is deeper (likely wrapper-vs-orchestrator wiring or version skew). Tracked in #1134; this PR resolves the symptom for this and similar future cases by re-routing through rectification.
