### PR TITLE
fix(orchestrator/verifier): three TDD orchestrator fixes 

### DIFF
--- a/src/execution/post-run.ts
+++ b/src/execution/post-run.ts
@@ -358,9 +358,12 @@ export async function applyPostRunInspection(
   const needsHumanReview = failureCategory === "session-failure";
   const combinedOutput = (agentResult.output ?? "") + ((agentResult as { stderr?: string }).stderr ?? "");
 
-  // Belt-and-suspenders: verifierOp.recover cleans up on its happy path, but if the
-  // verifier never ran (short-circuit before verify) the file from a prior story may
-  // still be on disk. Best-effort — ignored failures.
+  // Primary success-path cleanup: verifierOp.parse (strict) + verifierOp.verify handle
+  // the normal flow without calling recover, so cleanupVerdict is never invoked inside
+  // verify.ts on the happy path. verifierOp.recover (disk-fallback after retry exhaustion)
+  // does call cleanupVerdict in its finally block — but this call here is the primary
+  // cleanup for the success path and also covers the case where the verifier never ran
+  // at all (short-circuit before verify). Best-effort — failures ignored.
   if (isTdd) {
     const { cleanupVerdict } = await import("../tdd/verdict");
     await cleanupVerdict(ctx.workdir).catch(() => undefined);

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -470,22 +470,11 @@ const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[]> = {
   // code. It does NOT modify the test-writer/implementer TDD boundary, so the
   // verifier (TDD isolation judge) is intentionally excluded — the verifier is a
   // once-per-story phase, picked up by post-rectification-resume if not yet run.
-  "autofix-implementer": [
-    "lint-check",
-    "typecheck-check",
-    "full-suite-gate",
-    "semantic-review",
-    "adversarial-review",
-  ],
+  "autofix-implementer": ["lint-check", "typecheck-check", "full-suite-gate", "semantic-review", "adversarial-review"],
   // autofix-test-writer rewrites tests in response to adversarial-review findings.
   // It does not re-do the TDD test-writer/implementer pair, so verifier stays
   // excluded. Same once-per-story semantics as above.
-  "autofix-test-writer": [
-    "lint-check",
-    "typecheck-check",
-    "full-suite-gate",
-    "adversarial-review",
-  ],
+  "autofix-test-writer": ["lint-check", "typecheck-check", "full-suite-gate", "adversarial-review"],
   // full-suite-rectify edits TEST code to fix failing tests — this legitimately
   // changes the verifier's verdict, so verifier IS re-judged.
   "full-suite-rectify": [

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -432,12 +432,12 @@ function gatherRectificationFindings(
 
 /**
  * Collect all phases that participate in the rectification validation sweep.
- * Verifier is included here because phasesToRevalidate() now allows it to be
- * re-dispatched when a code-editing strategy (full-suite-rectify, autofix-implementer,
- * autofix-test-writer) ran. Without this, a stale verifier failure from before
- * rectification would remain in phaseOutputs and mark the story failed even after
- * the gate goes green. shouldSkipPhaseForRectification() gates the gate phase
- * when verifier already explicitly passed (unrelated-regression case).
+ * Verifier is included here because phasesToRevalidate() allows it to be
+ * re-dispatched when a code-editing strategy (full-suite-rectify only) ran.
+ * Without this, a stale verifier failure from before rectification would remain
+ * in phaseOutputs and mark the story failed even after the gate goes green.
+ * shouldSkipPhaseForRectification() gates the gate phase when verifier already
+ * explicitly passed (unrelated-regression case).
  */
 function collectRectificationPhases(state: InternalBuildState): InternalPhase[] {
   return [
@@ -457,24 +457,28 @@ const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[]> = {
   // If a mechanical fix strategy ever edits logic (not just style), widen this set.
   "mechanical-lintfix": ["lint-check"],
   "mechanical-formatfix": ["lint-check"],
-  // Code-editing strategies may change behaviour — verifier re-judges the TDD verdict.
+  // autofix-implementer addresses semantic/adversarial review findings on source
+  // code. It does NOT modify the test-writer/implementer TDD boundary, so the
+  // verifier (TDD isolation judge) is intentionally excluded — the verifier is a
+  // once-per-story phase, picked up by post-rectification-resume if not yet run.
   "autofix-implementer": [
     "lint-check",
     "typecheck-check",
     "full-suite-gate",
-    "verifier",
-    "verify-scoped",
     "semantic-review",
     "adversarial-review",
   ],
+  // autofix-test-writer rewrites tests in response to adversarial-review findings.
+  // It does not re-do the TDD test-writer/implementer pair, so verifier stays
+  // excluded. Same once-per-story semantics as above.
   "autofix-test-writer": [
     "lint-check",
     "typecheck-check",
     "full-suite-gate",
-    "verifier",
-    "verify-scoped",
     "adversarial-review",
   ],
+  // full-suite-rectify edits TEST code to fix failing tests — this legitimately
+  // changes the verifier's verdict, so verifier IS re-judged.
   "full-suite-rectify": [
     "lint-check",
     "typecheck-check",
@@ -489,9 +493,9 @@ const STRATEGY_TO_REVALIDATION_PHASES: Record<string, readonly PhaseKind[]> = {
  * Determine which phases to re-run after a fix iteration.
  *
  * The verifier IS eligible for revalidation when a strategy mapped to include
- * it ran (e.g. full-suite-rectify, autofix-implementer). Before this fix,
- * verifier was hard-stripped — leaving a stale failure verdict in phaseOutputs
- * after rectification fixed the underlying gate failure.
+ * it ran (full-suite-rectify only — it edits test code, changing the verdict).
+ * autofix-implementer and autofix-test-writer address review findings, not the
+ * TDD isolation boundary, so verifier is excluded from their sets.
  *
  * Falls back to all phases when:
  * - strategiesRun is undefined/empty (conservative default)

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -143,13 +143,22 @@ export async function refreshReviewInputForDispatch(opName: string, input: unkno
  * reads as the opposite of what greenfield-gate actually decided, so we override
  * the message text for that phase only.
  *
- * Exported for unit testing — pure function over (opName, success).
+ * For rectification-stage ops (autofix-implementer, autofix-test-writer,
+ * mechanical-*), the op completing successfully is the entire success
+ * contract — whether the fix worked is judged by subsequent validation phases.
+ * Emitting "Phase failed: <name>" here is misleading because the op did run
+ * to completion. Return a rectification-specific message when stage="rectification".
+ *
+ * Exported for unit testing — pure function over (opName, success, stage?).
  */
-export function formatPhaseResultMessage(opName: string, success: boolean): string {
+export function formatPhaseResultMessage(opName: string, success: boolean, stage?: string): string {
   if (opName === "greenfield-gate") {
     return success
       ? "Greenfield-gate: pre-existing tests detected (not greenfield) — proceeding with normal TDD"
       : "Greenfield-gate: no pre-existing tests — greenfield run, pausing TDD test-writer";
+  }
+  if (stage === "rectification") {
+    return `Rectification strategy completed: ${opName}`;
   }
   return success ? `Phase passed: ${opName}` : `Phase failed: ${opName}`;
 }
@@ -607,6 +616,7 @@ function logDeterministicPhaseOutcome(
   output: unknown,
   durationMs: number,
   isTddPhase: boolean,
+  stage?: string,
 ): void {
   if (isTddPhase) return;
   if (opName === "semantic-review" || opName === "adversarial-review") return;
@@ -622,7 +632,16 @@ function logDeterministicPhaseOutcome(
   if (findingsCount !== undefined) data.findingsCount = findingsCount;
   if (status !== undefined) data.status = status;
 
-  const message = formatPhaseResultMessage(opName, success);
+  const message = formatPhaseResultMessage(opName, success, stage);
+
+  // Rectification ops complete successfully whenever the prompt finishes — the
+  // "did the fix work?" question is answered by subsequent validation phases.
+  // Always log at info for these; never emit a misleading "Phase failed" warn.
+  if (stage === "rectification") {
+    logger?.info("story-orchestrator", message, data);
+    return;
+  }
+
   if (success) {
     logger?.info("story-orchestrator", message, data);
   } else {
@@ -732,7 +751,7 @@ async function runPhase(
     phaseOutputs[opName] = output;
     emitReviewDecision(ctx, opName, output);
     logUnifiedReviewPhaseResult(ctx.storyId, opName, output);
-    logDeterministicPhaseOutcome(ctx.storyId, opName, output, Date.now() - phaseStartedAt, isTddPhase);
+    logDeterministicPhaseOutcome(ctx.storyId, opName, output, Date.now() - phaseStartedAt, isTddPhase, slot.op.stage);
 
     // Post-phase logs (TDD phases only).
     if (isTddPhase) {

--- a/src/operations/verify.ts
+++ b/src/operations/verify.ts
@@ -1,11 +1,13 @@
+import { ParseValidationError, makeParseRetryStrategy } from "../agents/retry";
 import { tddConfigSelector } from "../config";
 import type { TddConfig } from "../config/selectors";
 import type { UserStory } from "../prd";
+import { TddPromptBuilder } from "../prompts/builders/tdd-builder";
 import { _isolationDeps, verifyImplementerIsolation } from "../tdd/isolation";
 import type { FailureCategory, IsolationCheck } from "../tdd/types";
-import { categorizeVerdict, cleanupVerdict, readVerdict } from "../tdd/verdict";
-import { parseSessionJsonOutput } from "./_session-output";
-import type { RunOperation, VerifyContext } from "./types";
+import { categorizeVerdict, cleanupVerdict, coerceVerdict, isValidVerdict, readVerdict } from "../tdd/verdict";
+import { tryParseLLMJson } from "../utils/llm-json";
+import type { BuildContext, RunOperation, VerifyContext } from "./types";
 
 void _isolationDeps; // re-export to keep test mocks pointed at the same singleton
 
@@ -34,6 +36,36 @@ export interface VerifierOutput {
   readonly reviewReason?: string;
 }
 
+/**
+ * Parse the agent's stdout into a VerifierOutput using the project's tolerant
+ * JSON extractor. Throws ParseValidationError when the output is empty, not
+ * JSON, or missing the required VerifierVerdict shape — the parse-retry
+ * strategy converts this into an in-session re-prompt.
+ */
+function parseVerdictFromStdout(output: string, _input: VerifierInput, _ctx: BuildContext<TddConfig>): VerifierOutput {
+  if (!output || !output.trim()) {
+    throw new ParseValidationError("verifier produced no stdout");
+  }
+  const raw = tryParseLLMJson<Record<string, unknown>>(output);
+  if (!raw || typeof raw !== "object") {
+    throw new ParseValidationError("verifier stdout is not a JSON object");
+  }
+  const verdict = isValidVerdict(raw) ? raw : coerceVerdict(raw);
+  if (!verdict) {
+    throw new ParseValidationError("verifier stdout JSON missing required VerifierVerdict fields");
+  }
+  const categorization = categorizeVerdict(verdict, verdict.tests.allPassing === true);
+  return {
+    success: categorization.success,
+    filesChanged: [],
+    estimatedCostUsd: 0,
+    durationMs: 0,
+    output,
+    ...(categorization.failureCategory && { failureCategory: categorization.failureCategory }),
+    ...(categorization.reviewReason && { reviewReason: categorization.reviewReason }),
+  };
+}
+
 async function runVerifierIsolation(
   beforeRef: string | undefined,
   ctx: VerifyContext<TddConfig>,
@@ -53,6 +85,23 @@ export const verifierOp: RunOperation<VerifierInput, VerifierOutput, TddConfig> 
   stage: "verify",
   session: { role: "verifier", lifetime: "fresh" },
   config: tddConfigSelector,
+  // Mirror semantic-review: maxAttempts=2, in-session re-prompt on parse failure.
+  retry: makeParseRetryStrategy({
+    validate: (parsed) => {
+      if (!parsed || typeof parsed !== "object") return false;
+      const r = parsed as Record<string, unknown>;
+      return isValidVerdict(r) || coerceVerdict(r) !== null;
+    },
+    reviewerKind: "verifier",
+    maxAttempts: 2,
+    prompts: {
+      invalid: () => TddPromptBuilder.verdictRetry(),
+      truncated: () => TddPromptBuilder.verdictRetryCondensed(),
+    },
+    // No exhaustedFallback — let callOp fall through to op.recover so we keep
+    // the existing disk-file fallback path. op.recover always returns non-null,
+    // satisfying the retry-strategy escape-hatch rule.
+  }),
   build(input, _ctx) {
     if (input.promptMarkdown?.trim()) {
       return {
@@ -69,35 +118,44 @@ export const verifierOp: RunOperation<VerifierInput, VerifierOutput, TddConfig> 
       },
     };
   },
-  parse(output, _input, _ctx): VerifierOutput {
-    const envelope = parseSessionJsonOutput(output);
-    return { ...envelope, estimatedCostUsd: 0, durationMs: 0 };
-  },
+  parse: parseVerdictFromStdout,
   async verify(parsed, input, ctx): Promise<VerifierOutput | null> {
-    // Signal to recover when parse produced no usable value (success=false).
-    if (!parsed.success) return null;
+    // parsed is the result of op.parse — parse only returns for valid verdicts,
+    // so we don't need to signal recover here. Just attach isolation when configured.
     const isolation = await runVerifierIsolation(input.beforeRef, ctx);
     return isolation ? { ...parsed, isolation } : parsed;
   },
-  async recover(input, verifyCtx): Promise<VerifierOutput | null> {
-    // Derive outcome from the verdict file the verifier agent writes to disk (AC-5).
-    // Use try/finally to ensure verdict cleanup on every code path.
+  async recover(input, verifyCtx): Promise<VerifierOutput> {
+    // Last-ditch fallback: read .nax-verifier-verdict.json from disk. If the
+    // file is missing or unparseable, return a fail-closed VerifierOutput so
+    // the orchestrator records an explicit failure (never null — satisfies
+    // the parse-retry escape-hatch rule).
     const packageDir = verifyCtx.packageView.packageDir;
     try {
       const verdict = await readVerdict(packageDir);
-      if (!verdict) return null;
-      const testsAllPassing = verdict.tests.allPassing === true;
-      const categorization = categorizeVerdict(verdict, testsAllPassing);
-      const isolation = await runVerifierIsolation(input.beforeRef, verifyCtx);
+      if (verdict) {
+        const testsAllPassing = verdict.tests.allPassing === true;
+        const categorization = categorizeVerdict(verdict, testsAllPassing);
+        const isolation = await runVerifierIsolation(input.beforeRef, verifyCtx);
+        return {
+          success: categorization.success,
+          filesChanged: [],
+          estimatedCostUsd: 0,
+          durationMs: 0,
+          output: "",
+          ...(categorization.failureCategory && { failureCategory: categorization.failureCategory }),
+          ...(categorization.reviewReason && { reviewReason: categorization.reviewReason }),
+          ...(isolation && { isolation }),
+        };
+      }
       return {
-        success: categorization.success,
+        success: false,
         filesChanged: [],
         estimatedCostUsd: 0,
         durationMs: 0,
         output: "",
-        ...(categorization.failureCategory && { failureCategory: categorization.failureCategory }),
-        ...(categorization.reviewReason && { reviewReason: categorization.reviewReason }),
-        ...(isolation && { isolation }),
+        reviewReason:
+          "verifier produced unparseable verdict in stdout after retries and no usable verdict file on disk",
       };
     } finally {
       await cleanupVerdict(packageDir);

--- a/src/prompts/builders/tdd-builder.ts
+++ b/src/prompts/builders/tdd-builder.ts
@@ -290,6 +290,42 @@ export class TddPromptBuilder {
       .build();
   }
 
+  /**
+   * Follow-up prompt sent in the same verifier session when the previous
+   * reply could not be parsed as a valid VerifierVerdict JSON object.
+   * The verifier still has full session context — this turn only asks
+   * it to re-emit the verdict in the correct format.
+   */
+  static verdictRetry(): string {
+    return (
+      "Your previous reply could not be parsed as a valid VerifierVerdict JSON object.\n" +
+      "Re-emit the verdict as the FINAL content of your reply.\n" +
+      "Output ONLY the JSON object — no markdown fences, no explanation, no prose.\n" +
+      "The reply must start with { and end with } on its own line.\n" +
+      "Required top-level fields: version, approved, tests, testModifications, acceptanceCriteria, quality, fixes, reasoning."
+    );
+  }
+
+  /**
+   * Follow-up prompt when the previous verifier reply was truncated mid-JSON.
+   * Asks for a condensed verdict that drops the long acceptanceCriteria.criteria[]
+   * array (the most common source of truncation) and keeps only the minimal
+   * required fields so the JSON fits in the output budget.
+   */
+  static verdictRetryCondensed(): string {
+    return (
+      "Your previous reply was truncated and could not be parsed as valid JSON.\n" +
+      "Re-emit a CONDENSED verdict that omits the acceptanceCriteria.criteria[] entries:\n" +
+      "- Keep acceptanceCriteria.allMet (boolean) but use criteria=[] (empty array).\n" +
+      "- Keep quality.issues=[] and fixes=[] empty.\n" +
+      "- Set testModifications.reasoning to a single sentence.\n" +
+      "- Set reasoning to a single sentence.\n" +
+      "Output ONLY the JSON object — no markdown fences, no prose.\n" +
+      "Schema (minimal):\n" +
+      `{"version":1,"approved":boolean,"tests":{"allPassing":boolean,"passCount":number,"failCount":number},"testModifications":{"detected":boolean,"files":[],"legitimate":boolean,"reasoning":"..."},"acceptanceCriteria":{"allMet":boolean,"criteria":[]},"quality":{"rating":"good"|"acceptable"|"poor","issues":[]},"fixes":[],"reasoning":"..."}`
+    );
+  }
+
   /** Wrap a string-returning section builder into a PromptSection for the accumulator. */
   private s(id: string, content: string): PromptSection {
     return { id, content, overridable: false };

--- a/src/prompts/sections/verdict.ts
+++ b/src/prompts/sections/verdict.ts
@@ -10,11 +10,14 @@ import type { UserStory } from "../../prd/types";
 export function buildVerdictSection(story: UserStory): string {
   return `# Verdict Instructions
 
-## Write Verdict File
+## Write Verdict File and Emit JSON in Final Reply
 
-After completing your verification, you **MUST** write a verdict file at the **project root**:
+After completing your verification, you **MUST** do BOTH of the following:
 
-**File:** \`.nax-verifier-verdict.json\`
+1. Write the verdict file at the **project root**: \`.nax-verifier-verdict.json\`
+2. Emit the same verdict JSON as the FINAL content of your reply — no prose
+   before or after, no markdown fences. Your reply must end with a closing
+   brace \`}\` on its own line. The orchestrator parses your reply as JSON.
 
 Set \`approved: true\` when ALL of these conditions are met:
 - All story-scoped tests pass (the orchestrator already attempted the full-suite gate — you only need to verify the story's own tests)
@@ -38,5 +41,5 @@ Set \`approved: false\` when ANY of these conditions are true:
 - \`fixes\` — keep this empty; the verifier must not apply code or test fixes
 - \`reasoning\` — brief summary of your overall assessment
 
-When done, do not commit code changes. Only write the verdict file.`;
+When done, do not commit code changes. Write the verdict file, then end your reply with the JSON object.`;
 }

--- a/test/integration/execution/rectification-routing.test.ts
+++ b/test/integration/execution/rectification-routing.test.ts
@@ -233,12 +233,12 @@ describe("AC2.5: rectification routing — gate failure halts loop, gate finding
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// AC3.8: verifier is dispatched during initial run and again during validate
-//        (new: autofix-implementer maps to verifier in phasesToRevalidate)
+// AC3.8: verifier is dispatched during initial run; NOT re-dispatched for autofix-implementer
+//        (autofix-implementer addresses review findings, not the TDD isolation boundary)
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe("AC3.8: verifier op dispatched during initial run and re-dispatched during validate for code-editing strategies", () => {
-  test("AC3.8: semantic findings only — verifier called during initial run, also called during capturedCycle.validate with autofix-implementer", async () => {
+  test("AC3.8: semantic findings only — verifier called during initial run, NOT called during capturedCycle.validate with autofix-implementer", async () => {
     const semanticFindings = makeSemanticFindings(3);
 
     // Track all callOp invocations (phase name → call count)
@@ -303,11 +303,11 @@ describe("AC3.8: verifier op dispatched during initial run and re-dispatched dur
       strategiesRun: ["autofix-implementer"],
     });
 
-    // New contract (Task 2): verifier IS re-dispatched during validate when autofix-implementer ran.
-    // autofix-implementer is a code-editing strategy → its revalidation set includes verifier.
-    expect(validateCallCounts["verifier"] ?? 0).toBeGreaterThan(0);
+    // autofix-implementer addresses review findings, not the TDD isolation boundary.
+    // Verifier is a once-per-story phase and is NOT re-dispatched after autofix-implementer.
+    expect(validateCallCounts["verifier"] ?? 0).toBe(0);
 
-    // Semantic review should have been re-run (it's in autofix-implementer's phase set)
+    // Semantic review MUST be re-run (it's in autofix-implementer's phase set)
     expect(validateCallCounts["semantic-review"] ?? 0).toBeGreaterThan(0);
   });
 });
@@ -316,8 +316,8 @@ describe("AC3.8: verifier op dispatched during initial run and re-dispatched dur
 // AC3.9: after autofix-implementer, full-suite-gate + verifier + semantic-review re-dispatched
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("AC3.9: after autofix-implementer iteration, full-suite-gate and semantic-review re-dispatched; verifier also re-dispatched (new contract)", () => {
-  test("AC3.9: validate with strategiesRun=['autofix-implementer'] → full-suite-gate + semantic-review + verifier called", async () => {
+describe("AC3.9: after autofix-implementer iteration, full-suite-gate and semantic-review re-dispatched; verifier excluded", () => {
+  test("AC3.9: validate with strategiesRun=['autofix-implementer'] → full-suite-gate + semantic-review called; verifier excluded", async () => {
     const semanticFindings = makeSemanticFindings(2);
 
     _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
@@ -381,8 +381,8 @@ describe("AC3.9: after autofix-implementer iteration, full-suite-gate and semant
     // semantic-review MUST be re-dispatched (it's in autofix-implementer's phase set)
     expect(validateCallCounts["semantic-review"] ?? 0).toBeGreaterThan(0);
 
-    // New contract (Task 2): verifier MUST be re-dispatched — autofix-implementer is a code-editing
-    // strategy whose revalidation set includes verifier so it can re-judge the TDD verdict.
-    expect(validateCallCounts["verifier"] ?? 0).toBeGreaterThan(0);
+    // autofix-implementer addresses review findings, not the TDD isolation boundary.
+    // Verifier is excluded from autofix-implementer's revalidation set (once-per-story phase).
+    expect(validateCallCounts["verifier"] ?? 0).toBe(0);
   });
 });

--- a/test/integration/tdd/_tdd-test-helpers.ts
+++ b/test/integration/tdd/_tdd-test-helpers.ts
@@ -85,7 +85,10 @@ export function createMockAgent(results: Partial<AgentResult>[]): AgentAdapter {
       // Default to a parseable JSON envelope so callOp's CALL_OP_NO_OUTPUT
       // guard accepts the response. Callers supplying explicit `output` (e.g.
       // for parser-specific assertions) override this default.
-      const defaultOutput = JSON.stringify({ success: r.success ?? true, filesChanged: [] });
+      // Include `approved` so verifierOp.parse (which uses coerceVerdict) can
+      // derive the correct approval status from the same envelope.
+      const approved = !!(r.success ?? true);
+      const defaultOutput = JSON.stringify({ success: r.success ?? true, filesChanged: [], approved });
       return {
         output: r.output ?? defaultOutput,
         tokenUsage: { inputTokens: 0, outputTokens: 0 },

--- a/test/unit/execution/story-orchestrator-logging.test.ts
+++ b/test/unit/execution/story-orchestrator-logging.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { formatPhaseResultMessage } from "@/execution";
+
+describe("formatPhaseResultMessage — stage-aware messaging", () => {
+  test("returns 'Phase passed' for a non-rectification op with success=true", () => {
+    expect(formatPhaseResultMessage("verifier", true)).toBe("Phase passed: verifier");
+  });
+
+  test("returns 'Phase failed' for a non-rectification op with success=false", () => {
+    expect(formatPhaseResultMessage("verifier", false)).toBe("Phase failed: verifier");
+  });
+
+  test("returns 'Rectification strategy completed' for a rectification-stage op regardless of success flag", () => {
+    expect(formatPhaseResultMessage("autofix-implementer", false, "rectification")).toBe(
+      "Rectification strategy completed: autofix-implementer",
+    );
+    expect(formatPhaseResultMessage("autofix-test-writer", true, "rectification")).toBe(
+      "Rectification strategy completed: autofix-test-writer",
+    );
+  });
+
+  test("keeps the greenfield-gate carve-out", () => {
+    expect(formatPhaseResultMessage("greenfield-gate", true)).toBe(
+      "Greenfield-gate: pre-existing tests detected (not greenfield) — proceeding with normal TDD",
+    );
+    expect(formatPhaseResultMessage("greenfield-gate", false)).toBe(
+      "Greenfield-gate: no pre-existing tests — greenfield run, pausing TDD test-writer",
+    );
+  });
+});

--- a/test/unit/execution/story-orchestrator-revalidation.test.ts
+++ b/test/unit/execution/story-orchestrator-revalidation.test.ts
@@ -249,11 +249,11 @@ describe("phasesToRevalidate — AC3.1: undefined strategiesRun → conservative
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// AC3.2: strategiesRun=["autofix-implementer"] → all 6 non-verifier phases
+// AC3.2: strategiesRun=["autofix-implementer"] → review-relevant phases (verifier excluded)
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("phasesToRevalidate — AC3.2: autofix-implementer → all phases including verifier", () => {
-  test("AC3.2: strategiesRun=['autofix-implementer'] → lint, typecheck, full-suite-gate, verifier, verify-scoped, semantic, adversarial called", async () => {
+describe("phasesToRevalidate — AC3.2: autofix-implementer → review-relevant phases (verifier excluded)", () => {
+  test("AC3.2: strategiesRun=['autofix-implementer'] → lint, typecheck, full-suite-gate, semantic, adversarial called; verifier and verify-scoped excluded", async () => {
     const ctx = makeCtx();
     const { capturedCycle, capturedCtx, getCalledOpsInValidate } = await captureAndSetupValidate(ctx);
 
@@ -266,13 +266,49 @@ describe("phasesToRevalidate — AC3.2: autofix-implementer → all phases inclu
 
     const called = getCalledOpsInValidate();
 
-    // autofix-implementer is a code-editing strategy — verifier re-judges the TDD verdict
-    expect(called.has("verifier")).toBe(true);
+    // autofix-implementer addresses review findings — it cannot legitimately
+    // change the TDD isolation verdict. Verifier stays a once-per-story phase.
+    expect(called.has("verifier")).toBe(false);
+    expect(called.has("verify-scoped")).toBe(false);
+
+    // Lint, typecheck, full-suite-gate, semantic-review, adversarial-review
+    // all remain in the revalidation set.
     expect(called.has("lint-check")).toBe(true);
     expect(called.has("typecheck-check")).toBe(true);
     expect(called.has("full-suite-gate")).toBe(true);
-    expect(called.has("verify-scoped")).toBe(true);
     expect(called.has("semantic-review")).toBe(true);
+    expect(called.has("adversarial-review")).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AC3.2b: strategiesRun=["autofix-test-writer"] → test-impacting phases without verifier
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("phasesToRevalidate — AC3.2b: autofix-test-writer → test-impacting phases without verifier", () => {
+  test("AC3.2b: strategiesRun=['autofix-test-writer'] → lint, typecheck, full-suite-gate, adversarial called; verifier and verify-scoped excluded", async () => {
+    const ctx = makeCtx();
+    const { capturedCycle, capturedCtx, getCalledOpsInValidate } = await captureAndSetupValidate(ctx);
+
+    expect(capturedCycle).not.toBeNull();
+
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "full",
+      strategiesRun: ["autofix-test-writer"],
+    });
+
+    const called = getCalledOpsInValidate();
+
+    // autofix-test-writer rewrites tests to satisfy adversarial-review — it
+    // does not re-do the TDD test-writer/implementer pair, so verifier stays
+    // out of the loop. The post-rectification-resume picks verifier up if it
+    // was never run.
+    expect(called.has("verifier")).toBe(false);
+    expect(called.has("verify-scoped")).toBe(false);
+
+    expect(called.has("lint-check")).toBe(true);
+    expect(called.has("typecheck-check")).toBe(true);
+    expect(called.has("full-suite-gate")).toBe(true);
     expect(called.has("adversarial-review")).toBe(true);
   });
 });
@@ -371,8 +407,8 @@ describe("phasesToRevalidate — AC3.5: unknown strategy → conservative fallba
 // AC3.6: strategiesRun=["mechanical-lintfix", "autofix-implementer"] → union (broad set)
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe("phasesToRevalidate — AC3.6: union of mechanical-lintfix + autofix-implementer → all phases including verifier", () => {
-  test("AC3.6: strategiesRun=['mechanical-lintfix','autofix-implementer'] → union includes verifier (from autofix-implementer)", async () => {
+describe("phasesToRevalidate — AC3.6: union of mechanical-lintfix + autofix-implementer → review phases without verifier", () => {
+  test("AC3.6: strategiesRun=['mechanical-lintfix','autofix-implementer'] → union excludes verifier (neither strategy includes it)", async () => {
     const ctx = makeCtx();
     const { capturedCycle, capturedCtx, getCalledOpsInValidate } = await captureAndSetupValidate(ctx);
 
@@ -386,13 +422,12 @@ describe("phasesToRevalidate — AC3.6: union of mechanical-lintfix + autofix-im
     const called = getCalledOpsInValidate();
 
     // Union of mechanical-lintfix (lint-check) + autofix-implementer
-    // (lint, typecheck, gate, verifier, scoped, semantic, adversarial) = all 7 phases
-    // autofix-implementer is a code-editing strategy — verifier is part of its set
-    expect(called.has("verifier")).toBe(true);
+    // (lint, typecheck, gate, semantic, adversarial) — verifier excluded from both.
+    expect(called.has("verifier")).toBe(false);
+    expect(called.has("verify-scoped")).toBe(false);
     expect(called.has("lint-check")).toBe(true);
     expect(called.has("typecheck-check")).toBe(true);
     expect(called.has("full-suite-gate")).toBe(true);
-    expect(called.has("verify-scoped")).toBe(true);
     expect(called.has("semantic-review")).toBe(true);
     expect(called.has("adversarial-review")).toBe(true);
   });

--- a/test/unit/execution/story-orchestrator.test.ts
+++ b/test/unit/execution/story-orchestrator.test.ts
@@ -1566,14 +1566,23 @@ describe("phasesToRevalidate — verifier inclusion after fix strategies", () =>
     expect(kinds).toContain("full-suite-gate");
   });
 
-  test("autofix-implementer strategy re-runs verifier", () => {
+  test("autofix-implementer strategy does NOT re-run verifier (once-per-story TDD isolation check)", () => {
     const result = phasesToRevalidate(["autofix-implementer"], allPhases);
-    expect(result.map((p: any) => p.kind)).toContain("verifier");
+    const kinds = result.map((p: any) => p.kind);
+    // autofix-implementer addresses review findings, not the TDD boundary — verifier excluded.
+    expect(kinds).not.toContain("verifier");
+    // Lint, typecheck, gate, semantic, adversarial are still re-run.
+    expect(kinds).toContain("full-suite-gate");
+    expect(kinds).toContain("lint-check");
   });
 
-  test("autofix-test-writer strategy re-runs verifier", () => {
+  test("autofix-test-writer strategy does NOT re-run verifier (once-per-story TDD isolation check)", () => {
     const result = phasesToRevalidate(["autofix-test-writer"], allPhases);
-    expect(result.map((p: any) => p.kind)).toContain("verifier");
+    const kinds = result.map((p: any) => p.kind);
+    // autofix-test-writer rewrites tests for adversarial-review — not re-doing TDD boundary.
+    expect(kinds).not.toContain("verifier");
+    expect(kinds).toContain("full-suite-gate");
+    expect(kinds).toContain("lint-check");
   });
 
   test("mechanical-lintfix does NOT re-run verifier (style-only, no semantic regression risk)", () => {

--- a/test/unit/operations/verify-op-parse-retry.test.ts
+++ b/test/unit/operations/verify-op-parse-retry.test.ts
@@ -1,14 +1,16 @@
 /**
- * Tests for verifierOp strict parse + parse-retry contract.
+ * Tests for verifierOp parse-retry contract and recover fail-closed behavior.
  *
- * After the Issue 3 fix, verifierOp.parse throws ParseValidationError for
- * empty/non-JSON/missing-field output. The retry strategy then re-prompts
- * the same session. verifierOp.recover is the last-ditch disk fallback and
- * must always return non-null (fail-closed VerifierOutput).
+ * Covers the unique concerns of this file:
+ *   - op.parse success path (valid verdict JSON → VerifierOutput)
+ *   - op.retry is declared
+ *   - op.recover is fail-closed (always non-null) when disk is missing/invalid
+ *
+ * Parse *failure* cases (empty stdout, non-JSON, truncated) are covered in
+ * verify-op.test.ts to avoid duplication.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
-import { ParseValidationError } from "../../../src/agents/retry";
 import { verifierOp } from "../../../src/operations";
 import { makeTempDir, cleanupTempDir } from "../../helpers/temp";
 
@@ -31,28 +33,6 @@ function makeCtx(packageDir: string) {
 
 const STORY = { id: "US-001", title: "t", workdir: "" } as any;
 const INPUT = { story: STORY };
-
-// ─────────────────────────────────────────────────────────────────────────────
-// op.parse — strict: throws ParseValidationError for invalid/empty stdout
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("verifierOp.parse — strict: throws ParseValidationError", () => {
-  test("throws ParseValidationError when stdout is empty", () => {
-    expect(() => verifierOp.parse("", INPUT, makeCtx("/tmp"))).toThrow(ParseValidationError);
-  });
-
-  test("throws ParseValidationError when stdout is non-JSON prose", () => {
-    expect(() =>
-      verifierOp.parse("I finished verifying everything looks good.", INPUT, makeCtx("/tmp")),
-    ).toThrow(ParseValidationError);
-  });
-
-  test("throws ParseValidationError on truncated JSON (mid-array)", () => {
-    const truncated =
-      '{"version":1,"approved":true,"tests":{"allPassing":true,"passCount":17,"failCount":0},"acceptanceCriteria":{"allMet":true,"criteria":[{"criterion":"AC1",';
-    expect(() => verifierOp.parse(truncated, INPUT, makeCtx("/tmp"))).toThrow(ParseValidationError);
-  });
-});
 
 // ─────────────────────────────────────────────────────────────────────────────
 // op.parse — success path: returns VerifierOutput when stdout is valid

--- a/test/unit/operations/verify-op-parse-retry.test.ts
+++ b/test/unit/operations/verify-op-parse-retry.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for verifierOp strict parse + parse-retry contract.
+ *
+ * After the Issue 3 fix, verifierOp.parse throws ParseValidationError for
+ * empty/non-JSON/missing-field output. The retry strategy then re-prompts
+ * the same session. verifierOp.recover is the last-ditch disk fallback and
+ * must always return non-null (fail-closed VerifierOutput).
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { ParseValidationError } from "../../../src/agents/retry";
+import { verifierOp } from "../../../src/operations";
+import { makeTempDir, cleanupTempDir } from "../../helpers/temp";
+
+const VALID_VERDICT = {
+  version: 1,
+  approved: true,
+  tests: { allPassing: true, passCount: 17, failCount: 0 },
+  testModifications: { detected: false, files: [], legitimate: true, reasoning: "n/a" },
+  acceptanceCriteria: { allMet: true, criteria: [] },
+  quality: { rating: "good", issues: [] },
+  fixes: [],
+  reasoning: "Story complete and tests pass.",
+};
+
+const VALID_VERDICT_JSON = JSON.stringify(VALID_VERDICT);
+
+function makeCtx(packageDir: string) {
+  return { packageView: { packageDir } } as any;
+}
+
+const STORY = { id: "US-001", title: "t", workdir: "" } as any;
+const INPUT = { story: STORY };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// op.parse — strict: throws ParseValidationError for invalid/empty stdout
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("verifierOp.parse — strict: throws ParseValidationError", () => {
+  test("throws ParseValidationError when stdout is empty", () => {
+    expect(() => verifierOp.parse("", INPUT, makeCtx("/tmp"))).toThrow(ParseValidationError);
+  });
+
+  test("throws ParseValidationError when stdout is non-JSON prose", () => {
+    expect(() =>
+      verifierOp.parse("I finished verifying everything looks good.", INPUT, makeCtx("/tmp")),
+    ).toThrow(ParseValidationError);
+  });
+
+  test("throws ParseValidationError on truncated JSON (mid-array)", () => {
+    const truncated =
+      '{"version":1,"approved":true,"tests":{"allPassing":true,"passCount":17,"failCount":0},"acceptanceCriteria":{"allMet":true,"criteria":[{"criterion":"AC1",';
+    expect(() => verifierOp.parse(truncated, INPUT, makeCtx("/tmp"))).toThrow(ParseValidationError);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// op.parse — success path: returns VerifierOutput when stdout is valid
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("verifierOp.parse — success: returns VerifierOutput for valid verdict JSON", () => {
+  test("returns VerifierOutput with success=true when approved=true", () => {
+    const out = verifierOp.parse(VALID_VERDICT_JSON, INPUT, makeCtx("/tmp"));
+    expect(out.success).toBe(true);
+    expect(out.filesChanged).toBeDefined();
+    expect(typeof out.estimatedCostUsd).toBe("number");
+    expect(typeof out.durationMs).toBe("number");
+  });
+
+  test("returns VerifierOutput with success=false when approved=false with illegitimate test mods", () => {
+    // categorizeVerdict only blocks on illegitimate test mods or failing tests.
+    // Use illegitimate test mods to trigger a real failure.
+    const failedJson = JSON.stringify({
+      ...VALID_VERDICT,
+      approved: false,
+      testModifications: { detected: true, files: ["foo.test.ts"], legitimate: false, reasoning: "weakened assertions" },
+    });
+    const out = verifierOp.parse(failedJson, INPUT, makeCtx("/tmp"));
+    expect(out.success).toBe(false);
+    expect(out.reviewReason).toBeDefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// op.retry — declared
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("verifierOp.retry — parse-retry strategy", () => {
+  test("retry strategy is declared on the op", () => {
+    expect(verifierOp.retry).toBeDefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// op.recover — always non-null (fail-closed when disk is missing/invalid)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("verifierOp.recover — fail-closed when no usable disk verdict", () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = makeTempDir("nax-verifier-recover-");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(workdir);
+  });
+
+  test("returns non-null fail-closed VerifierOutput when disk verdict is missing", async () => {
+    const out = await verifierOp.recover!(INPUT, makeCtx(workdir));
+    expect(out).not.toBeNull();
+    expect(out!.success).toBe(false);
+    expect(out!.reviewReason).toMatch(/verdict|unparseable|invalid/i);
+  });
+
+  test("returns non-null fail-closed VerifierOutput when disk verdict is invalid JSON", async () => {
+    await Bun.write(join(workdir, ".nax-verifier-verdict.json"), '{"approved":');
+    const out = await verifierOp.recover!(INPUT, makeCtx(workdir));
+    expect(out).not.toBeNull();
+    expect(out!.success).toBe(false);
+  });
+
+  test("returns success=true when disk verdict is valid and approved", async () => {
+    await Bun.write(join(workdir, ".nax-verifier-verdict.json"), VALID_VERDICT_JSON);
+    const out = await verifierOp.recover!(INPUT, makeCtx(workdir));
+    expect(out).not.toBeNull();
+    expect(out!.success).toBe(true);
+  });
+});

--- a/test/unit/operations/verify-op.test.ts
+++ b/test/unit/operations/verify-op.test.ts
@@ -58,84 +58,38 @@ describe("verifierOp — RunOperation shape", () => {
   });
 });
 
-describe("verifierOp.parse — error handling", () => {
-  test("returns VerifierOutput with success=false when output is empty", async () => {
+describe("verifierOp.parse — error handling (strict: throws ParseValidationError)", () => {
+  test("throws ParseValidationError when output is empty", async () => {
     const { verifierOp } = await import("@/operations");
+    const { ParseValidationError } = await import("../../../src/agents/retry");
     const { DEFAULT_CONFIG } = await import("@/config");
 
-    const ctx = {
-      packageView: {} as any,
-      config: DEFAULT_CONFIG,
-    };
+    const ctx = { packageView: {} as any, config: DEFAULT_CONFIG };
+    const input = { story: { id: "US-001" } as any };
 
-    const input = {
-      story: { id: "US-001" } as any,
-    };
-
-    const result = verifierOp.parse("", input, ctx);
-
-    expect(result.success).toBe(false);
-    expect(result.filesChanged).toEqual([]);
+    expect(() => verifierOp.parse("", input, ctx)).toThrow(ParseValidationError);
   });
 
-  test("returns VerifierOutput with success=false when output is unparseable", async () => {
+  test("throws ParseValidationError when output is unparseable prose", async () => {
     const { verifierOp } = await import("@/operations");
+    const { ParseValidationError } = await import("../../../src/agents/retry");
     const { DEFAULT_CONFIG } = await import("@/config");
 
-    const ctx = {
-      packageView: {} as any,
-      config: DEFAULT_CONFIG,
-    };
+    const ctx = { packageView: {} as any, config: DEFAULT_CONFIG };
+    const input = { story: { id: "US-001" } as any };
 
-    const input = {
-      story: { id: "US-001" } as any,
-    };
-
-    const result = verifierOp.parse("could not parse", input, ctx);
-
-    expect(result.success).toBe(false);
-    expect(result.filesChanged).toEqual([]);
+    expect(() => verifierOp.parse("could not parse", input, ctx)).toThrow(ParseValidationError);
   });
 
-  test("returns VerifierOutput with success=false when output is malformed JSON", async () => {
+  test("throws ParseValidationError when output is malformed JSON", async () => {
     const { verifierOp } = await import("@/operations");
+    const { ParseValidationError } = await import("../../../src/agents/retry");
     const { DEFAULT_CONFIG } = await import("@/config");
 
-    const ctx = {
-      packageView: {} as any,
-      config: DEFAULT_CONFIG,
-    };
+    const ctx = { packageView: {} as any, config: DEFAULT_CONFIG };
+    const input = { story: { id: "US-001" } as any };
 
-    const input = {
-      story: { id: "US-001" } as any,
-    };
-
-    const result = verifierOp.parse('{ "incomplete":', input, ctx);
-
-    expect(result.success).toBe(false);
-    expect(result.filesChanged).toEqual([]);
-  });
-
-  test("returns VerifierOutput with all required fields on parse failure", async () => {
-    const { verifierOp } = await import("@/operations");
-    const { DEFAULT_CONFIG } = await import("@/config");
-
-    const ctx = {
-      packageView: {} as any,
-      config: DEFAULT_CONFIG,
-    };
-
-    const input = {
-      story: { id: "US-001" } as any,
-    };
-
-    const result = verifierOp.parse("", input, ctx);
-
-    expect(result.success).toBeDefined();
-    expect(result.filesChanged).toBeDefined();
-    expect(typeof result.estimatedCostUsd).toBe("number");
-    expect(typeof result.durationMs).toBe("number");
-    expect(typeof result.output).toBe("string");
+    expect(() => verifierOp.parse('{ "incomplete":', input, ctx)).toThrow(ParseValidationError);
   });
 });
 
@@ -159,21 +113,26 @@ describe("verifierOp input type", () => {
   });
 });
 
+const VALID_VERDICT_JSON = JSON.stringify({
+  version: 1,
+  approved: true,
+  tests: { allPassing: true, passCount: 5, failCount: 0 },
+  testModifications: { detected: false, files: [], legitimate: true, reasoning: "n/a" },
+  acceptanceCriteria: { allMet: true, criteria: [] },
+  quality: { rating: "good", issues: [] },
+  fixes: [],
+  reasoning: "ok",
+});
+
 describe("verifierOp output type", () => {
   test("verifierOp output includes success, filesChanged, estimatedCostUsd, durationMs", async () => {
     const { verifierOp } = await import("@/operations");
     const { DEFAULT_CONFIG } = await import("@/config");
 
-    const ctx = {
-      packageView: {} as any,
-      config: DEFAULT_CONFIG,
-    };
+    const ctx = { packageView: {} as any, config: DEFAULT_CONFIG };
+    const input = { story: { id: "US-001" } as any };
 
-    const input = {
-      story: { id: "US-001" } as any,
-    };
-
-    const result = verifierOp.parse("", input, ctx);
+    const result = verifierOp.parse(VALID_VERDICT_JSON, input, ctx);
 
     expect("success" in result).toBe(true);
     expect("filesChanged" in result).toBe(true);
@@ -186,16 +145,10 @@ describe("verifierOp output type", () => {
     const { verifierOp } = await import("@/operations");
     const { DEFAULT_CONFIG } = await import("@/config");
 
-    const ctx = {
-      packageView: {} as any,
-      config: DEFAULT_CONFIG,
-    };
+    const ctx = { packageView: {} as any, config: DEFAULT_CONFIG };
+    const input = { story: { id: "US-001" } as any };
 
-    const input = {
-      story: { id: "US-001" } as any,
-    };
-
-    const result = verifierOp.parse("", input, ctx);
+    const result = verifierOp.parse(VALID_VERDICT_JSON, input, ctx);
 
     // isolation is optional, may be present or absent
     if ("isolation" in result) {
@@ -251,7 +204,10 @@ describe("verifierOp.verify — isolation", () => {
     }
   });
 
-  test("still returns null when parsed.success=false (defer to recover)", async () => {
+  test("returns parsed unchanged (non-null) for a failed verdict when no beforeRef (isolation skipped)", async () => {
+    // After the Issue 3 fix, verify() no longer returns null for failed parsed verdicts.
+    // parse() only succeeds when the verdict is structurally valid; the failure outcome
+    // is encoded in success=false on the output. verify() just attaches isolation.
     const { verifierOp } = await import("@/operations");
     const { DEFAULT_CONFIG } = await import("@/config");
 
@@ -262,7 +218,7 @@ describe("verifierOp.verify — isolation", () => {
       durationMs: 0,
       output: "",
     };
-    const input = { story: { id: "US-001" } as any, beforeRef: "HEAD~1" };
+    const input = { story: { id: "US-001" } as any };
     const ctx = {
       packageView: { packageDir: "/tmp/x", config: DEFAULT_CONFIG } as any,
       config: DEFAULT_CONFIG.tdd,
@@ -271,6 +227,7 @@ describe("verifierOp.verify — isolation", () => {
     };
 
     const result = await verifierOp.verify!(parsed, input, ctx as any);
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result!.success).toBe(false);
   });
 });

--- a/test/unit/prompts/builders/tdd-builder.test.ts
+++ b/test/unit/prompts/builders/tdd-builder.test.ts
@@ -166,3 +166,24 @@ describe("AC-21: when behavioralGuardrails='off', acc.add not called for guardra
     }
   });
 });
+
+describe("TddPromptBuilder.verdictRetry", () => {
+  test("returns a re-emit instruction with explicit start/end markers", () => {
+    const out = TddPromptBuilder.verdictRetry();
+    expect(out).toContain("could not be parsed");
+    expect(out).toContain("start with {");
+    expect(out).toContain("end with }");
+    expect(out).toContain("version");
+    expect(out).toContain("approved");
+  });
+});
+
+describe("TddPromptBuilder.verdictRetryCondensed", () => {
+  test("instructs the agent to drop acceptanceCriteria.criteria entries", () => {
+    const out = TddPromptBuilder.verdictRetryCondensed();
+    expect(out).toContain("truncated");
+    expect(out).toContain("criteria=[] (empty array)");
+    expect(out).toContain("acceptanceCriteria");
+    expect(out).toContain("allMet");
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix 1:** Remove `verifier` and `verify-scoped` from `autofix-implementer` and `autofix-test-writer` revalidation sets. The verifier judges TDD isolation — a once-per-story check that autofix strategies cannot legitimately change. `full-suite-rectify` keeps verifier since it edits test code.
- **Fix 2:** Emit `info "Rectification strategy completed: <name>"` instead of `warn "Phase failed: <name>"` for `stage=rectification` ops. The rectification op completing is its entire success contract; downstream validation phases judge whether the fix worked.
- **Fix 3:** Add in-session parse-retry to `verifierOp` mirroring `semanticReviewOp`. When the verifier emits malformed/truncated verdict JSON, the same session is re-prompted via `makeParseRetryStrategy` instead of falling through to `op.recover` and opening a fresh verifier session (which re-billed the user for a full verifier pass).

## Root causes (from `logs/2026-05-27T13-04-44.jsonl`)

- Line ~702: Semantic review fails → autofix-implementer runs → verifier re-runs (wasteful — Fix 1)
- Line ~720: `warn "Phase failed: autofix-implementer"` emitted even though op completed (misleading — Fix 2)
- Line ~747: `.nax-verifier-verdict.json` truncated mid-JSON → `readVerdict` returns null → post-rectification-resume opens a fresh verifier session (Fix 3)

## Architecture

**Fix 3 contract compliance:**
- `op.parse` ↔ `validate` agreement: both use `isValidVerdict(r) || coerceVerdict(r) !== null`
- `op.recover` always returns non-null (`VerifierOutput`) — satisfies the retry-strategy escape-hatch rule
- No `exhaustedFallback` on the strategy — falls through to `op.recover` for async disk-file recovery
- `verdictRetryCondensed()` addresses the common truncation cause: `acceptanceCriteria.criteria[]` array exceeding output budget

## Test plan

- [ ] `bun run test` — all phases pass (8303 unit + 1114 integration + 13 UI)
- [ ] `bun run lint && bun run typecheck` — clean
- [ ] Revalidation: `test/unit/execution/story-orchestrator-revalidation.test.ts` — AC3.2 asserts verifier excluded for autofix-implementer
- [ ] Logging: `test/unit/execution/story-orchestrator-logging.test.ts` — all 4 stage-aware message tests pass
- [ ] Parse-retry: `test/unit/operations/verify-op-parse-retry.test.ts` — success path, retry declaration, recover fail-closed
- [ ] Integration: `test/integration/execution/rectification-routing.test.ts` — AC3.8/AC3.9 updated to assert verifier excluded
- [ ] Integration: `test/integration/tdd/` — all TDD integration tests pass with updated mock fixture