### PR TITLE
fix(review/adversarial): flip to pass when all blocking findings dropped as ac_quote_not_substring

### DIFF
--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -155,6 +155,7 @@ Severity guide:
 - If you cannot quote an exact excerpt that proves your point, downgrade the finding to \`"unverifiable"\` rather than fabricating a quote.
 
 **AC-grounding rule — required for every "error" finding:**
+- Do NOT write an \`acQuote\` that does not appear verbatim in the listed AC text. If you cannot find an exact verbatim match, set severity to \`warning\` — never approximate, paraphrase, or synthesise a quote. A finding dropped for a fabricated quote wastes a review cycle and is worse than a correctly classified \`warning\`.
 - \`acQuote\` must be a verbatim substring of one AC bullet (from the Acceptance Criteria above) that names or constrains the exact **symbol** you are flagging — not merely the file the symbol lives in.
 - \`acIndex\` is the 1-based position of that AC bullet in the list.
 - Copy \`acQuote\` **exactly** from the AC text, including any backticks, asterisks, or punctuation. Do not paraphrase, strip formatting, or rewrite.

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -57,6 +57,7 @@ function recordAdversarialAudit(opts: {
   looksLikeFail?: boolean;
   failOpen?: boolean;
   passed?: boolean;
+  passReason?: string;
   blockingThreshold?: "error" | "warning" | "info";
   result: { passed: boolean; findings: unknown[] } | null;
   advisoryFindings?: unknown[];
@@ -77,6 +78,7 @@ function recordAdversarialAudit(opts: {
     looksLikeFail: opts.looksLikeFail,
     failOpen: opts.failOpen,
     passed: opts.passed,
+    passReason: opts.passReason,
     blockingThreshold: opts.blockingThreshold,
     result: opts.result,
     advisoryFindings: opts.advisoryFindings,

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -500,20 +500,15 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
       const demotedFindings = toAdversarialReviewFindings(
         acDropped.map((d) => ({ ...d.finding, severity: "warning" as const, acQuote: undefined, acIndex: undefined })),
       );
-      const existingAdvisory =
-        advisoryFindings.length > 0 ? toAdversarialReviewFindings(advisoryFindings) : [];
+      const existingAdvisory = advisoryFindings.length > 0 ? toAdversarialReviewFindings(advisoryFindings) : [];
       const allAdvisory = [...existingAdvisory, ...demotedFindings];
 
-      logger?.warn(
-        "review",
-        "Adversarial review passed: all blocking findings discarded as hallucinated AC quotes",
-        {
-          storyId: story.id,
-          durationMs,
-          droppedCount: acDropped.length,
-          drops: acDropped.map((d) => ({ file: d.finding.file, issue: d.finding.issue })),
-        },
-      );
+      logger?.warn("review", "Adversarial review passed: all blocking findings discarded as hallucinated AC quotes", {
+        storyId: story.id,
+        durationMs,
+        droppedCount: acDropped.length,
+        drops: acDropped.map((d) => ({ file: d.finding.file, issue: d.finding.issue })),
+      });
       recordAdversarialAudit({
         runtime,
         workdir,

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -491,6 +491,61 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
   }
 
   if (!opResult.passed && acDropped.length > 0) {
+    const allHallucinated = acDropped.every((d) => d.code === "ac_quote_not_substring");
+
+    if (allHallucinated) {
+      // Case A: every blocking finding cited a quote that does not exist in any AC.
+      // The model fabricated its grounding. Treat as pass — demote each dropped finding
+      // to "warning" and surface as advisory so it remains auditable.
+      const demotedFindings = toAdversarialReviewFindings(
+        acDropped.map((d) => ({ ...d.finding, severity: "warning" as const, acQuote: undefined, acIndex: undefined })),
+      );
+      const existingAdvisory =
+        advisoryFindings.length > 0 ? toAdversarialReviewFindings(advisoryFindings) : [];
+      const allAdvisory = [...existingAdvisory, ...demotedFindings];
+
+      logger?.warn(
+        "review",
+        "Adversarial review passed: all blocking findings discarded as hallucinated AC quotes",
+        {
+          storyId: story.id,
+          durationMs,
+          droppedCount: acDropped.length,
+          drops: acDropped.map((d) => ({ file: d.finding.file, issue: d.finding.issue })),
+        },
+      );
+      recordAdversarialAudit({
+        runtime,
+        workdir,
+        projectDir,
+        storyId: story.id,
+        featureName,
+        parsed: true,
+        failOpen: false,
+        passed: true,
+        passReason: "ac_quote_not_substring_demoted",
+        blockingThreshold: threshold,
+        result: { passed: true, findings: [] },
+        advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
+        diffAvailable,
+        adversarialDropAnalysis,
+        adversarialAcceptAnalysis: [],
+      });
+      return {
+        check: "adversarial",
+        success: true,
+        passReason: "ac_quote_not_substring_demoted",
+        command: "",
+        exitCode: 0,
+        output: "",
+        durationMs,
+        advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
+        cost: llmCost,
+      };
+    }
+
+    // Case B: mix includes missing_ac_quote or ac_quote_does_not_constrain_locus —
+    // fail-closed (existing behavior unchanged).
     logger?.warn("review", "Adversarial review fail-closed: blocking findings dropped as ungrounded", {
       storyId: story.id,
       durationMs,

--- a/src/review/adversarial.ts
+++ b/src/review/adversarial.ts
@@ -532,7 +532,7 @@ export async function runAdversarialReview(opts: RunAdversarialReviewOptions): P
         passReason: "ac_quote_not_substring_demoted",
         command: "",
         exitCode: 0,
-        output: "",
+        output: `Adversarial review passed: ${acDropped.length} blocking finding(s) demoted to advisory — all cited AC quotes were fabricated and could not be validated.`,
         durationMs,
         advisoryFindings: allAdvisory.length > 0 ? allAdvisory : undefined,
         cost: llmCost,

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -107,6 +107,13 @@ export interface ReviewCheckResult {
    * Consumers in a retry context (autofixAttempt > 0) must treat this as a non-genuine pass. */
   failOpen?: boolean;
   /**
+   * Set when the adversarial check passed because all blocking findings were
+   * discarded as hallucinated AC quotes (ac_quote_not_substring). Consumers
+   * in a retry context should treat this as a weaker pass signal than a genuine
+   * adversarial pass.
+   */
+  passReason?: "ac_quote_not_substring_demoted";
+  /**
    * Optional scoped-lint metadata for autofix/review consumers.
    * Provides explicit package grouping and structured out-of-scope status.
    */

--- a/src/runtime/dispatch-events.ts
+++ b/src/runtime/dispatch-events.ts
@@ -105,6 +105,8 @@ export interface ReviewDecisionEvent {
   readonly diffAvailable?: boolean;
   readonly adversarialDropAnalysis?: readonly unknown[];
   readonly adversarialAcceptAnalysis?: readonly unknown[];
+  /** Set when the adversarial check passed due to all drops being ac_quote_not_substring. */
+  readonly passReason?: string;
 }
 
 export interface ReviewRepromptEvent {

--- a/test/unit/prompts/adversarial-review-builder.test.ts
+++ b/test/unit/prompts/adversarial-review-builder.test.ts
@@ -357,3 +357,17 @@ describe("AdversarialReviewPromptBuilder — verifiedBy implementation-axis grou
     expect(result.toLowerCase()).toContain("downgrade");
   });
 });
+
+// ─── AC-grounding prohibition text (#1033 Obs 1) ──────────────────────────────
+
+describe("AdversarialReviewPromptBuilder — AC-grounding explicit prohibition", () => {
+  test("prompt contains explicit Do NOT write acQuote prohibition", () => {
+    const prompt = builder.buildAdversarialReviewPrompt(STORY, CONFIG, { mode: "ref", storyGitRef: STORY_GIT_REF });
+    expect(prompt).toContain("Do NOT write an `acQuote` that does not appear verbatim");
+  });
+
+  test("prompt instructs to set severity to warning rather than fabricating", () => {
+    const prompt = builder.buildAdversarialReviewPrompt(STORY, CONFIG, { mode: "ref", storyGitRef: STORY_GIT_REF });
+    expect(prompt).toContain("never approximate, paraphrase, or synthesise a quote");
+  });
+});

--- a/test/unit/review/adversarial-pass-fail.test.ts
+++ b/test/unit/review/adversarial-pass-fail.test.ts
@@ -210,6 +210,45 @@ const MIXED_DROP_RESPONSE = JSON.stringify({
   ],
 });
 
+// Fixture: LLM says passed:false; one error finding with no acQuote at all.
+// All drops should be missing_ac_quote → fail-closed (Case B regression).
+const ALL_MISSING_AC_QUOTE_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "error",
+      category: "error-path",
+      file: "src/log.ts",
+      line: 10,
+      issue: "Exit code not set on partial failure",
+      suggestion: "Set process.exit(1)",
+      // no acQuote → missing_ac_quote drop
+      verifiedBy: { file: "src/log.ts", observed: "login handler stub" },
+    },
+  ],
+});
+
+// Fixture: LLM says passed:false; one error finding whose acQuote IS a verbatim
+// substring of the AC but contains no locus keyword (file stem "process" / "handler"
+// / "exit" not in "Users can"). Drops as ac_quote_does_not_constrain_locus → fail-closed (Case B regression).
+const ALL_LOCUS_MISMATCH_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "error",
+      category: "error-path",
+      file: "src/process-handler.ts",   // locus keywords: process, handler
+      line: 10,
+      issue: "Process exit not triggered on failure",  // extra keywords: exit
+      suggestion: "Call process.exit(1)",
+      acQuote: "Users can",             // IS a substring of "Users can log in"
+      acIndex: 1,                       // valid index
+      // "users can" contains none of: process, handler, exit → ac_quote_does_not_constrain_locus
+      verifiedBy: { file: "src/log.ts", observed: "login handler stub" },
+    },
+  ],
+});
+
 // Fixture: LLM says passed:false; one error with fabricated acQuote (dropped),
 // plus a warning finding that passes through to advisory.
 const HALLUCINATED_QUOTE_WITH_ADVISORY_RESPONSE = JSON.stringify({
@@ -690,6 +729,18 @@ describe("runAdversarialReview — flip-to-pass on all-hallucinated drops", () =
 
   test("Case 2: mixed drops (hallucinated + missing_ac_quote) → success=false", async () => {
     const result = await callRunAdversarialReview(MIXED_DROP_RESPONSE);
+    expect(result.success).toBe(false);
+    expect(result.passReason).toBeUndefined();
+  });
+
+  test("Case 3: all drops missing_ac_quote → fail-closed (no regression)", async () => {
+    const result = await callRunAdversarialReview(ALL_MISSING_AC_QUOTE_RESPONSE);
+    expect(result.success).toBe(false);
+    expect(result.passReason).toBeUndefined();
+  });
+
+  test("Case 4: all drops ac_quote_does_not_constrain_locus → fail-closed (no regression)", async () => {
+    const result = await callRunAdversarialReview(ALL_LOCUS_MISMATCH_RESPONSE);
     expect(result.success).toBe(false);
     expect(result.passReason).toBeUndefined();
   });

--- a/test/unit/review/adversarial-pass-fail.test.ts
+++ b/test/unit/review/adversarial-pass-fail.test.ts
@@ -682,7 +682,7 @@ describe("runAdversarialReview — flip-to-pass on all-hallucinated drops", () =
     const result = await callRunAdversarialReview(HALLUCINATED_QUOTE_RESPONSE);
     expect(result.advisoryFindings).toBeDefined();
     expect(result.advisoryFindings!.length).toBeGreaterThan(0);
-    // Finding.message = joinMessage(issue, suggestion) = "Exit code not set on partial failure\n→ Set process.exit(1) on failure"
+    // Finding.message = f.issue (toAdversarialReviewFindings uses issue directly, not joinMessage)
     const demoted = result.advisoryFindings!.find((f) => f.message.includes("Exit code not set on partial failure"));
     expect(demoted).toBeDefined();
     expect(demoted!.severity).toBe("warning");
@@ -698,7 +698,7 @@ describe("runAdversarialReview — flip-to-pass on all-hallucinated drops", () =
     const result = await callRunAdversarialReview(HALLUCINATED_QUOTE_WITH_ADVISORY_RESPONSE);
     expect(result.success).toBe(true);
     expect(result.advisoryFindings).toBeDefined();
-    // Finding.message = joinMessage(issue, suggestion), so match with includes()
+    // Finding.message = f.issue (toAdversarialReviewFindings uses issue directly, not joinMessage)
     const hasDemoted = result.advisoryFindings!.some((f) => f.message.includes("Exit code not set on partial failure"));
     const hasOriginal = result.advisoryFindings!.some((f) => f.message.includes("Token never invalidated on logout"));
     expect(hasDemoted).toBe(true);

--- a/test/unit/review/adversarial-pass-fail.test.ts
+++ b/test/unit/review/adversarial-pass-fail.test.ts
@@ -160,6 +160,83 @@ const PASSED_TRUE_WITH_ERROR_RESPONSE = JSON.stringify({
   ],
 });
 
+// Fixture: LLM says passed:false; one error finding with a fabricated acQuote
+// (not a substring of any AC). This should produce ac_quote_not_substring drop.
+const HALLUCINATED_QUOTE_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "error",
+      category: "error-path",
+      file: "src/log.ts",
+      line: 10,
+      issue: "Exit code not set on partial failure",
+      suggestion: "Set process.exit(1) on failure",
+      acQuote: "this text does not appear in any acceptance criterion",
+      acIndex: 1,
+      verifiedBy: { file: "src/log.ts", observed: "login handler stub" },
+    },
+  ],
+});
+
+// Fixture: LLM says passed:false; two error findings.
+// First has fabricated acQuote (ac_quote_not_substring).
+// Second has no acQuote at all (missing_ac_quote).
+// Mixed drop codes → must stay fail-closed.
+const MIXED_DROP_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "error",
+      category: "error-path",
+      file: "src/log.ts",
+      line: 10,
+      issue: "Exit code not set on partial failure",
+      suggestion: "Set process.exit(1)",
+      acQuote: "this text does not appear in any acceptance criterion",
+      acIndex: 1,
+      verifiedBy: { file: "src/log.ts", observed: "login handler stub" },
+    },
+    {
+      severity: "error",
+      category: "input",
+      file: "src/log.ts",
+      line: 5,
+      issue: "Input not validated",
+      suggestion: "Add validation",
+      // no acQuote → missing_ac_quote drop; use same non-existent file as other fixtures
+      verifiedBy: { file: "src/log.ts", observed: "login handler stub" },
+    },
+  ],
+});
+
+// Fixture: LLM says passed:false; one error with fabricated acQuote (dropped),
+// plus a warning finding that passes through to advisory.
+const HALLUCINATED_QUOTE_WITH_ADVISORY_RESPONSE = JSON.stringify({
+  passed: false,
+  findings: [
+    {
+      severity: "error",
+      category: "error-path",
+      file: "src/log.ts",
+      line: 10,
+      issue: "Exit code not set on partial failure",
+      suggestion: "Set process.exit(1)",
+      acQuote: "this text does not appear in any acceptance criterion",
+      acIndex: 1,
+      verifiedBy: { file: "src/log.ts", observed: "login handler stub" },
+    },
+    {
+      severity: "warning",
+      category: "abandonment",
+      file: "src/auth.ts",
+      line: 20,
+      issue: "Token never invalidated on logout",
+      suggestion: "Call revokeToken()",
+    },
+  ],
+});
+
 // ---------------------------------------------------------------------------
 // Shared saved deps
 // ---------------------------------------------------------------------------
@@ -325,7 +402,7 @@ const FAILING_ERROR_UNGROUNDED_RESPONSE = JSON.stringify({
   ],
 });
 
-describe("runAdversarialReview — drops + fail-closed", () => {
+describe("runAdversarialReview — all drops ac_quote_not_substring flips to pass (#1031)", () => {
   beforeEach(() => {
     saveAllDeps();
     setupHappyPathDeps();
@@ -333,16 +410,15 @@ describe("runAdversarialReview — drops + fail-closed", () => {
 
   afterEach(restoreAllDeps);
 
-  test("fails closed when all blocking findings were dropped as ungrounded by acQuote validation", async () => {
+  test("passes when all blocking findings were dropped as ac_quote_not_substring", async () => {
     const result = await callRunAdversarialReview(FAILING_ERROR_UNGROUNDED_RESPONSE);
-    expect(result.success).toBe(false);
-    expect(result.exitCode).toBe(1);
+    expect(result.success).toBe(true);
+    expect(result.exitCode).toBe(0);
   });
 
-  test("output names the drop as the failure reason", async () => {
+  test("passReason is ac_quote_not_substring_demoted", async () => {
     const result = await callRunAdversarialReview(FAILING_ERROR_UNGROUNDED_RESPONSE);
-    expect(result.output).toContain("dropped as ungrounded");
-    expect(result.output).toContain("ExtendedPrismaClient");
+    expect(result.passReason).toBe("ac_quote_not_substring_demoted");
   });
 });
 
@@ -577,5 +653,55 @@ describe("runAdversarialReview — fail-open on LLM error", () => {
     });
 
     expect(result.output).toContain("skipped");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC: flip-to-pass when all drops are ac_quote_not_substring (#1031)
+// ---------------------------------------------------------------------------
+
+describe("runAdversarialReview — flip-to-pass on all-hallucinated drops", () => {
+  beforeEach(() => {
+    saveAllDeps();
+    setupHappyPathDeps();
+  });
+
+  afterEach(restoreAllDeps);
+
+  test("Case 1: all drops ac_quote_not_substring → success=true", async () => {
+    const result = await callRunAdversarialReview(HALLUCINATED_QUOTE_RESPONSE);
+    expect(result.success).toBe(true);
+  });
+
+  test("Case 1: passReason is ac_quote_not_substring_demoted", async () => {
+    const result = await callRunAdversarialReview(HALLUCINATED_QUOTE_RESPONSE);
+    expect(result.passReason).toBe("ac_quote_not_substring_demoted");
+  });
+
+  test("Case 1: demoted finding appears in advisoryFindings at warning severity", async () => {
+    const result = await callRunAdversarialReview(HALLUCINATED_QUOTE_RESPONSE);
+    expect(result.advisoryFindings).toBeDefined();
+    expect(result.advisoryFindings!.length).toBeGreaterThan(0);
+    // Finding.message = joinMessage(issue, suggestion) = "Exit code not set on partial failure\n→ Set process.exit(1) on failure"
+    const demoted = result.advisoryFindings!.find((f) => f.message.includes("Exit code not set on partial failure"));
+    expect(demoted).toBeDefined();
+    expect(demoted!.severity).toBe("warning");
+  });
+
+  test("Case 2: mixed drops (hallucinated + missing_ac_quote) → success=false", async () => {
+    const result = await callRunAdversarialReview(MIXED_DROP_RESPONSE);
+    expect(result.success).toBe(false);
+    expect(result.passReason).toBeUndefined();
+  });
+
+  test("Case 5: all drops hallucinated + pre-existing advisory → advisory merged", async () => {
+    const result = await callRunAdversarialReview(HALLUCINATED_QUOTE_WITH_ADVISORY_RESPONSE);
+    expect(result.success).toBe(true);
+    expect(result.advisoryFindings).toBeDefined();
+    // Finding.message = joinMessage(issue, suggestion), so match with includes()
+    const hasDemoted = result.advisoryFindings!.some((f) => f.message.includes("Exit code not set on partial failure"));
+    const hasOriginal = result.advisoryFindings!.some((f) => f.message.includes("Token never invalidated on logout"));
+    expect(hasDemoted).toBe(true);
+    expect(hasOriginal).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- **#1031** — When the adversarial reviewer emits `passed: false` but every blocking finding was dropped with code `ac_quote_not_substring` (model cited a quote that does not appear in any AC), the system now returns `success: true` with `passReason: "ac_quote_not_substring_demoted"` instead of failing closed. Each dropped finding is demoted to `warning` severity and surfaced as an advisory finding so it remains auditable. Mixed drops (any `missing_ac_quote` or `ac_quote_does_not_constrain_locus`) still fail closed unchanged (Case B).
- **#1033 Obs 1** — Added an explicit `"Do NOT write an acQuote that does not appear verbatim..."` prohibition to the adversarial reviewer prompt before the existing verbatim-copy rules, reducing upstream AC-quote fabrication.
- Adds `passReason?: "ac_quote_not_substring_demoted"` to `ReviewCheckResult` and `ReviewDecisionEvent` (threads through `recordAdversarialAudit`).

## Root cause

Observed in run `2026-05-14T02-46-16.jsonl` (v0.66.4): 1 blocking finding dropped as `ac_quote_not_substring` caused 3 wasted autofix implementer sessions on a ghost finding, then escalated to powerful tier. The finding was real; the AC quote was hallucinated. Failing closed on fabricated evidence had zero quality benefit.

## Test plan

- [ ] `AGENT=1 timeout 30 bun test test/unit/review/adversarial-pass-fail.test.ts --timeout=5000` — 29 tests pass (7 new: Cases 1–5 flip-to-pass, Cases 3 & 4 fail-closed regression; 2 existing tests updated to reflect new correct behavior for `ac_quote_not_substring` drops)
- [ ] `AGENT=1 timeout 30 bun test test/unit/prompts/adversarial-review-builder.test.ts --timeout=5000` — 30 tests pass (2 new: assert prohibition text present)
- [ ] `bun run typecheck` — 0 errors
- [ ] `bun run lint` — clean
- [ ] `bun run test` — full suite passes (1114 tests across 110 files)