### PR TITLE
fix(orchestrator/gate): synth finding on execution-failed so rectifier dispatches implementer

### DIFF
--- a/src/findings/adapters/index.ts
+++ b/src/findings/adapters/index.ts
@@ -5,6 +5,6 @@ export {
 export { lintDiagnosticToFinding } from "./lint";
 export { pluginToFinding } from "./plugin";
 export { reviewFindingToFinding } from "./semantic-review";
-export { acFailureToFinding, acSentinelToFinding } from "./test-runner";
+export { acFailureToFinding, acSentinelToFinding, executionFailureToFinding } from "./test-runner";
 export { tscDiagnosticToFinding } from "./typecheck";
 export { testFailureToFinding, testSummaryToFindings } from "./test-failure";

--- a/src/findings/adapters/test-runner.ts
+++ b/src/findings/adapters/test-runner.ts
@@ -19,6 +19,47 @@ export function acFailureToFinding(acId: string, output: string): Finding {
   };
 }
 
+/**
+ * Synth-finding for the `execution-failed` gate state: the runner exited
+ * non-zero but the parser found 0 structured test failures (e.g. config
+ * crash, missing dependency, wrong cwd, runner segfault). Without this,
+ * the rectifier no-ops on 0 findings and the orchestrator escalates
+ * without dispatching the implementer.
+ *
+ * Carries the actual command + exit code + a tail of the runner output so
+ * the implementer prompt has concrete repair context.
+ */
+export function executionFailureToFinding(params: {
+  command: string;
+  exitCode?: number;
+  output: string;
+  packageDir?: string;
+  cwd?: string;
+}): Finding {
+  const tail = tailLines(params.output, 40);
+  const exitStr = params.exitCode !== undefined ? ` (exit ${params.exitCode})` : "";
+  const message = `Test runner exited non-zero without structured failures${exitStr}. Command: \`${params.command}\`\n\n--- runner output (last 40 lines) ---\n${tail}`;
+  return {
+    source: "test-runner",
+    severity: "error",
+    category: "execution-failed",
+    message,
+    fixTarget: "source",
+    meta: {
+      command: params.command,
+      exitCode: params.exitCode,
+      packageDir: params.packageDir,
+      cwd: params.cwd,
+    },
+  };
+}
+
+function tailLines(s: string, n: number): string {
+  if (!s) return "(no output)";
+  const lines = s.split("\n");
+  return lines.slice(Math.max(0, lines.length - n)).join("\n");
+}
+
 export function acSentinelToFinding(sentinel: "AC-HOOK" | "AC-ERROR", _output: string): Finding {
   if (sentinel === "AC-HOOK") {
     return {

--- a/src/findings/index.ts
+++ b/src/findings/index.ts
@@ -25,6 +25,7 @@ export {
   acceptanceDiagnoseRawToFinding,
   acFailureToFinding,
   acSentinelToFinding,
+  executionFailureToFinding,
   lintDiagnosticToFinding,
   pluginToFinding,
   reviewFindingToFinding,

--- a/src/operations/full-suite-gate.ts
+++ b/src/operations/full-suite-gate.ts
@@ -19,7 +19,7 @@
 import type { NaxConfig } from "../config";
 import { rectificationGateConfigSelector } from "../config/selectors";
 import { NaxError } from "../errors";
-import { testSummaryToFindings } from "../findings";
+import { executionFailureToFinding, testSummaryToFindings } from "../findings";
 import type { Finding } from "../findings/types";
 import { getLogger } from "../logger";
 import type { UserStory } from "../prd";
@@ -85,6 +85,10 @@ interface RunTestsResult {
   readonly parsedSummary: TestSummary;
   /** True when the runner returned status=TIMEOUT — let execute() decide accept-on-timeout. */
   readonly timedOut: boolean;
+  /** Runner exit code (when known) — surfaced into synthetic findings on execution-failed. */
+  readonly exitCode?: number;
+  /** Final shell command actually executed (after buildTestCommand wrap) — for synth-finding context. */
+  readonly command?: string;
 }
 
 /**
@@ -156,6 +160,8 @@ export const _fullSuiteGateDeps: FullSuiteGateDeps = {
       output: result.output ?? "",
       parsedSummary,
       timedOut: result.status === "TIMEOUT",
+      exitCode: result.exitCode,
+      command: result.command ?? gateCtx.testCmd,
     };
   },
 };
@@ -208,6 +214,13 @@ export const fullSuiteGateOp: DeterministicOperation<
     }
 
     const gateCtx = await deps.resolveGateContext(input, ctx);
+    logger.info("verify[regression]", "Running full-suite gate", {
+      storyId: input.story.id,
+      packageDir: input.story.workdir,
+      cwd: input.workdir,
+      command: gateCtx.testCmd,
+      timeoutSeconds: gateCtx.fullSuiteTimeout,
+    });
     const testResult = await deps.runTests(input, gateCtx);
 
     if (testResult.passed) {
@@ -245,14 +258,32 @@ export const fullSuiteGateOp: DeterministicOperation<
 
     const findings = testSummaryToFindings(testResult.parsedSummary);
     if (findings.length === 0) {
-      // Runner exited non-zero but parser found 0 structured failures — environmental failure.
+      // Runner exited non-zero but parser found 0 structured failures — environmental
+      // failure (e.g. config crash, missing dep, wrong cwd). Emit a single synth
+      // finding so rectification dispatches the implementer with concrete repair
+      // context (command + exit code + output tail) instead of no-oping on 0 findings
+      // and silently escalating.
+      const cmd = testResult.command ?? gateCtx.testCmd;
+      const synth = executionFailureToFinding({
+        command: cmd,
+        exitCode: testResult.exitCode,
+        output: testResult.output,
+        packageDir: input.story.workdir,
+        cwd: input.workdir,
+      });
+      logger.warn("verify[regression]", "Full-suite gate execution-failed — emitting synth finding", {
+        storyId: input.story.id,
+        command: cmd,
+        exitCode: testResult.exitCode,
+        packageDir: input.story.workdir,
+      });
       return {
         success: false,
         passed: false,
         status: "execution-failed",
         estimatedCostUsd: 0,
         attempts: 0,
-        findings: [],
+        findings: [synth],
       };
     }
 

--- a/src/operations/full-suite-rectify.ts
+++ b/src/operations/full-suite-rectify.ts
@@ -20,7 +20,9 @@ export function makeFullSuiteRectifyStrategy(
 ): FixStrategy<Finding, ImplementerInput, ImplementerOutput, TddConfig> {
   return {
     name: "full-suite-rectify",
-    appliesTo: (finding) => finding.source === "test-runner" && finding.category === "failed-test",
+    appliesTo: (finding) =>
+      finding.source === "test-runner" &&
+      (finding.category === "failed-test" || finding.category === "execution-failed"),
     fixOp: implementerOp,
     buildInput: (findings) => ({
       story,

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -126,6 +126,15 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     // NOTE: regression() includes a 2s sleep before running tests (src/verification/runners.ts:142-145)
     // for agent-cleanup. The legacy ScopedStrategy also used regression(), so this preserves parity
     // — it is NOT a new perf regression introduced by this port.
+    const scopedTimeout = ctxConfig.execution?.regressionGate?.timeoutSeconds ?? 600;
+    logger.info("verify[scoped]", "Running scoped tests", {
+      storyId: input.storyId,
+      packageDir: input.packageDir,
+      cwd: input.workdir,
+      command: selection.effectiveCommand,
+      timeoutSeconds: scopedTimeout,
+      isFullSuite: selection.isFullSuite,
+    });
     const start = Date.now();
     const result = await deps.regression({
       workdir: input.workdir,

--- a/src/verification/runners.ts
+++ b/src/verification/runners.ts
@@ -76,6 +76,8 @@ async function runVerificationCore(options: VerificationGateOptions): Promise<Ve
       countsTowardEscalation: false,
       error: execution.error,
       output: execution.output,
+      exitCode: execution.exitCode,
+      command: finalCommand,
     };
   }
 
@@ -91,6 +93,8 @@ async function runVerificationCore(options: VerificationGateOptions): Promise<Ve
         output: execution.output,
         passCount: analysis.passCount,
         failCount: analysis.failCount,
+        exitCode,
+        command: finalCommand,
       };
     }
     return {
@@ -100,10 +104,19 @@ async function runVerificationCore(options: VerificationGateOptions): Promise<Ve
       output: execution.output,
       passCount: analysis.passCount,
       failCount: analysis.failCount,
+      exitCode,
+      command: finalCommand,
     };
   }
 
-  return { status: "SUCCESS", success: true, countsTowardEscalation: true, output: execution.output };
+  return {
+    status: "SUCCESS",
+    success: true,
+    countsTowardEscalation: true,
+    output: execution.output,
+    exitCode,
+    command: finalCommand,
+  };
 }
 
 /** Run entire test suite (regression gate). */

--- a/src/verification/types.ts
+++ b/src/verification/types.ts
@@ -50,6 +50,10 @@ export interface VerificationResult {
   missingFiles?: string[];
   passCount?: number;
   failCount?: number;
+  /** Runner exit code when known — surfaced on TEST_FAILURE / ENVIRONMENTAL_FAILURE paths. */
+  exitCode?: number;
+  /** Final shell command actually executed (post buildTestCommand wrap). */
+  command?: string;
 }
 
 /** Rectification state tracking per story execution */

--- a/test/unit/operations/full-suite-gate.test.ts
+++ b/test/unit/operations/full-suite-gate.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import { fullSuiteGateOp, _fullSuiteGateDeps } from "@/operations";
-import type { Finding } from "@/findings";
 
 const mockCtx = { runtime: {}, storyId: "US-001" } as any;
 
@@ -17,6 +16,7 @@ function makeDeps(overrides = {}) {
       output: "",
       parsedSummary: { passed: 5, failed: 0, failures: [] },
       timedOut: false,
+      command: "bun test",
     }),
     ...overrides,
   };
@@ -85,23 +85,38 @@ describe("fullSuiteGateOp — test execution logic (US-006)", () => {
     expect(out.status).not.toBe("rectification-exhausted");
   });
 
-  test("returns status=execution-failed and findings=[] when parser returns 0 structured failures despite non-zero exit", async () => {
+  test("returns status=execution-failed with a synth finding when parser returns 0 structured failures despite non-zero exit", async () => {
     const out = await fullSuiteGateOp.execute(
-      { story: { id: "US-001" } as any, workdir: "/tmp" },
+      { story: { id: "US-001", workdir: "packages/api" } as any, workdir: "/tmp" },
       mockCtx,
       makeDeps({
         runTests: async () => ({
           passed: false,
           failed: 3,
-          output: "process crashed",
+          output: "ModuleNotFoundError: stock_api._sse",
           parsedSummary: { passed: 0, failed: 3, failures: [] },
           timedOut: false,
+          exitCode: 2,
+          command: "pytest packages/api",
         }),
       }),
     );
     expect(out.success).toBe(false);
     expect(out.status).toBe("execution-failed");
-    expect(out.findings).toEqual([]);
+    expect(out.findings).toHaveLength(1);
+    const f = out.findings[0]!;
+    expect(f.source).toBe("test-runner");
+    expect(f.category).toBe("execution-failed");
+    expect(f.severity).toBe("error");
+    expect(f.message).toContain("pytest packages/api");
+    expect(f.message).toContain("exit 2");
+    expect(f.message).toContain("ModuleNotFoundError");
+    expect(f.meta).toMatchObject({
+      command: "pytest packages/api",
+      exitCode: 2,
+      packageDir: "packages/api",
+      cwd: "/tmp",
+    });
   });
 
   test("no runRectificationLoop dep exists on _fullSuiteGateDeps (AC-3)", () => {

--- a/test/unit/operations/full-suite-rectify.test.ts
+++ b/test/unit/operations/full-suite-rectify.test.ts
@@ -54,6 +54,12 @@ describe("makeFullSuiteRectifyStrategy", () => {
     expect(strategy.appliesTo(finding)).toBe(false);
   });
 
+  test("appliesTo returns true for test-runner + execution-failed (synth finding from gate)", () => {
+    const strategy = makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig());
+    const finding = makeTestFinding({ category: "execution-failed" });
+    expect(strategy.appliesTo(finding)).toBe(true);
+  });
+
   test("fixOp references implementerOp (name=implementer)", () => {
     const strategy = makeFullSuiteRectifyStrategy(makeTestStory(), makeNaxConfig());
     expect(strategy.fixOp.name).toBe("implementer");


### PR DESCRIPTION
## Summary

When the full-suite gate exits non-zero but the parser extracts **0 structured failures** (`status: "execution-failed"` — e.g. config crash, missing dep, wrong cwd, runner segfault), the rectifier currently no-ops because it has no findings to feed an implementer. The orchestrator then re-runs the gate via the post-rectification resume, fails identically, and escalates without ever dispatching a fix turn.

Observed in `logs/2026-05-28T12-03-35.jsonl:177-182` — two `Phase failed: full-suite-gate` lines ~3s apart with no implementer turn between them.

This PR makes `execution-failed` a fixable state:

- **Synthesizes one `Finding`** from the gate when `status=execution-failed`, carrying the command, exit code, and a 40-line tail of runner output. `full-suite-rectify` is broadened so `appliesTo` matches the new `category: "execution-failed"` in addition to `"failed-test"` — same strategy, same implementer, just routed for environmental failures too.
- **Plumbs `exitCode` + final shell command** through `VerificationResult` and the gate's `RunTestsResult` so the synth finding has concrete debug context.
- **Logs the resolved command / cwd / packageDir / timeout** right before every full-suite-gate and scoped-test spawn. In polyglot monorepos this is the missing piece for diagnosing "ran `bun test` in a Go package" or "ran from repo root instead of `packages/api`" from the JSONL alone.

## Files

| File | Change |
|:---|:---|
| `src/findings/adapters/test-runner.ts` | New `executionFailureToFinding({command, exitCode, output, packageDir, cwd})` adapter + export. |
| `src/findings/adapters/index.ts`, `src/findings/index.ts` | Re-export the adapter from the barrels. |
| `src/operations/full-suite-gate.ts` | Emit synth finding on `execution-failed`; pre-spawn log line; thread `exitCode`+`command` through `RunTestsResult`. |
| `src/operations/full-suite-rectify.ts` | Broaden `appliesTo` to accept `category: "execution-failed"`. |
| `src/operations/verify-scoped.ts` | Pre-spawn log line for scoped-test runs. |
| `src/verification/runners.ts`, `src/verification/types.ts` | Add optional `exitCode` + `command` to `VerificationResult` on every status branch. |

## Behaviour change

Before:
```
12:54:19 Phase failed: full-suite-gate (findingsCount: 0, execution-failed)
12:54:22 Phase failed: full-suite-gate (findingsCount: 0, execution-failed)
12:54:22 Terminal phase failure → escalate to powerful tier
```

After:
```
12:54:19 Running full-suite gate { command: "pytest packages/api", cwd, timeoutSeconds }
12:54:19 Phase failed: full-suite-gate (findingsCount: 1, execution-failed)
12:54:19 Full-suite gate execution-failed — emitting synth finding { command, exitCode, packageDir }
... rectifier dispatches implementer with the command + exit code + output tail as repair context ...
```

The cycle's change-detection (`findingKey`: source/file/line/rule/message) varies the synth finding's identity with the runner's output, so a fix that changes the output is classified "changed" and the cycle continues; a fix that leaves output unchanged is "unchanged" and the cycle exits — bounded by existing `maxAttempts` so no new unbounded loops.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint` (biome + 5 custom checkers)
- [x] `bun run test:bail` — 8297 unit / 1075 integration / 11 ui pass, 0 fail
- [x] `test/unit/operations/full-suite-gate.test.ts` updated to assert synth-finding shape (source, category, severity, message contains command + exit code + output tail, meta payload)
- [x] `test/unit/operations/full-suite-rectify.test.ts` adds positive case for `category: "execution-failed"`