### PR TITLE
fix(tdd/integration): stub regression() sleep to restore CI speed

### DIFF
--- a/test/integration/tdd/_tdd-test-helpers.ts
+++ b/test/integration/tdd/_tdd-test-helpers.ts
@@ -12,6 +12,7 @@ import { _isolationDeps } from "../../../src/tdd/isolation";
 import { _rollbackDeps } from "../../../src/tdd/rollback";
 import { _gitDeps } from "../../../src/utils/git";
 import { _executorDeps } from "../../../src/verification/executor";
+import { _regressionRunnerDeps } from "../../../src/verification/runners";
 
 /** Saved originals for teardown */
 export interface SavedDeps {
@@ -20,6 +21,7 @@ export interface SavedDeps {
   gitSpawn: typeof _gitDeps.spawn;
   rollbackSpawn: typeof _rollbackDeps.spawn;
   fullSuiteGateResolveCtx: typeof _fullSuiteGateDeps.resolveGateContext;
+  regressionSleep: typeof _regressionRunnerDeps.sleep;
 }
 
 /** Save current deps state */
@@ -30,6 +32,7 @@ export function saveDeps(): SavedDeps {
     gitSpawn: _gitDeps.spawn,
     rollbackSpawn: _rollbackDeps.spawn,
     fullSuiteGateResolveCtx: _fullSuiteGateDeps.resolveGateContext,
+    regressionSleep: _regressionRunnerDeps.sleep,
   };
 }
 
@@ -40,6 +43,7 @@ export function restoreDeps(saved: SavedDeps): void {
   _gitDeps.spawn = saved.gitSpawn;
   _rollbackDeps.spawn = saved.rollbackSpawn;
   _fullSuiteGateDeps.resolveGateContext = saved.fullSuiteGateResolveCtx;
+  _regressionRunnerDeps.sleep = saved.regressionSleep;
 }
 
 /**
@@ -47,6 +51,10 @@ export function restoreDeps(saved: SavedDeps): void {
  * the full-suite gate without a real .nax/config.json. The TEST_COMMAND_MISSING
  * NaxError thrown by the production resolver is intentional at runtime — tests
  * bypass it by short-circuiting config resolution.
+ *
+ * Also stubs `_regressionRunnerDeps.sleep` to eliminate the 2s agent-cleanup delay
+ * that regression() inserts before every test run — without this, each fullSuiteGate
+ * call adds 2s of wall-clock time to integration tests.
  */
 export function stubFullSuiteGateContext(testCmd = "bun test"): void {
   _fullSuiteGateDeps.resolveGateContext = async () =>
@@ -55,6 +63,7 @@ export function stubFullSuiteGateContext(testCmd = "bun test"): void {
       testCmd,
       fullSuiteTimeout: 60,
     }) as any;
+  _regressionRunnerDeps.sleep = async () => {};
 }
 
 /** Create a mock agent that returns sequential results */


### PR DESCRIPTION
## Summary

- `regression()` in `src/verification/runners.ts` has a 2s `sleep(2000)` before running tests (to let agent processes terminate)
- When `full-suite-gate.ts` switched from calling `executeWithTimeout` directly to `regression()` (in #1125), TDD integration tests started hitting this sleep on every `fullSuiteGateOp` call
- ~16 calls × 2s = **32 seconds** added to CI integration step (5s → 37s; full suite 27s → 59s)

**Fix:** `stubFullSuiteGateContext()` in `_tdd-test-helpers.ts` now also stubs `_regressionRunnerDeps.sleep` to a no-op. `saveDeps`/`restoreDeps` saves and restores the real sleep function per-test.

**Result:** Integration suite 37s → 5s. Full suite 59s → 27s. CI back to ~45s.

## Test plan

- [x] `bun test test/integration/tdd/` — 42 pass, 192ms (was 32s)
- [x] `bun run test` — all phases pass, 27s total (was 59s)