### PR TITLE
feat(observability): surface verifier verdict detail + unparseable output in run log

### DIFF
--- a/src/agents/retry/parse-retry.ts
+++ b/src/agents/retry/parse-retry.ts
@@ -22,8 +22,22 @@ export interface ParseRetryOpts {
    * `storyId` and `originalByteSize` are always present; fields here are appended after them.
    */
   readonly logContext?: Record<string, unknown>;
+  /**
+   * When set, the warn log includes an `outputPreview` field — the first N bytes
+   * of the unparseable agent output (whitespace-collapsed). Without this, only
+   * `originalByteSize` is logged and the actual content is invisible in the run
+   * log, forcing a manual cross-reference against the prompt-audit files. Opt-in
+   * because some reviewers emit large or sensitive payloads. Off by default.
+   */
+  readonly outputPreviewBytes?: number;
   /** Injectable logger for testing. */
   readonly _logger?: { warn(kind: string, msg: string, data: Record<string, unknown>): void };
+}
+
+/** Collapse whitespace and clip to `maxBytes` so the preview stays a single, log-friendly line. */
+function previewOutput(output: string, maxBytes: number): string {
+  const collapsed = output.replace(/\s+/g, " ").trim();
+  return collapsed.length > maxBytes ? `${collapsed.slice(0, maxBytes)}…` : collapsed;
 }
 
 export function makeParseRetryStrategy(opts: ParseRetryOpts): RetryStrategy {
@@ -78,16 +92,22 @@ export function makeParseRetryStrategy(opts: ParseRetryOpts): RetryStrategy {
       const nextPrompt = isTruncated ? opts.prompts.truncated() : opts.prompts.invalid();
 
       const logger = opts._logger ?? getSafeLogger();
+      const preview =
+        opts.outputPreviewBytes && opts.outputPreviewBytes > 0
+          ? { outputPreview: previewOutput(ctx.lastOutput, opts.outputPreviewBytes) }
+          : {};
       if (isTruncated) {
         logger?.warn(opts.reviewerKind, "JSON parse retry — likely truncated", {
           storyId: ctx.storyId,
           originalByteSize: ctx.lastOutput.length,
+          ...preview,
           ...opts.logContext,
         });
       } else {
         logger?.warn(opts.reviewerKind, "JSON parse retry — invalid shape", {
           storyId: ctx.storyId,
           originalByteSize: ctx.lastOutput.length,
+          ...preview,
           ...opts.logContext,
         });
       }

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -42,6 +42,7 @@ export {
   EXHAUSTED_EXIT_REASONS,
   phasesToRevalidate,
   formatPhaseResultMessage,
+  buildPhaseOutcomeLogData,
   refreshReviewInputForDispatch,
   type OrchestratorSlot,
   type RectificationPhaseOptions,

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -606,6 +606,49 @@ function logUnifiedReviewPhaseStart(storyId: string | undefined, opName: string)
  * TDD phases and review phases have their own dedicated loggers — skip those here
  * so a single phase doesn't produce duplicate outcome lines.
  */
+/**
+ * Build the structured log fields for a deterministic phase outcome from the op
+ * output. Pure over `(storyId, opName, output, durationMs)` — exported for unit
+ * testing. Returns `null` when the output is not a loggable object.
+ *
+ * `findingsCount` prefers `normalizedFindings` (the verifier's envelope) and
+ * falls back to the legacy `findings` array. Reading only `findings` left the
+ * verifier's "Phase failed" line bare even when it emitted a tdd-verifier
+ * finding. Among ops that reach this function the two fields are mutually
+ * exclusive — verifier carries only `normalizedFindings`; verify-scoped /
+ * lint-check / typecheck-check / full-suite-gate carry only `findings`; the
+ * dual-field review ops (semantic / adversarial) are filtered out by the caller
+ * before this runs — so the simple precedence below never diverges from
+ * extractPhaseFindings in practice. `failureCategory` / `reviewReason` carry the
+ * verifier verdict's rejection detail so the line explains *why* without a
+ * prompt-audit cross-reference.
+ */
+export function buildPhaseOutcomeLogData(
+  storyId: string | undefined,
+  opName: string,
+  output: unknown,
+  durationMs: number,
+): { success: boolean; data: Record<string, unknown> } | null {
+  if (output === null || output === undefined || typeof output !== "object") return null;
+
+  const r = output as Record<string, unknown>;
+  const success = r.success === true || r.passed === true;
+  const findingsCount = Array.isArray(r.normalizedFindings)
+    ? r.normalizedFindings.length
+    : Array.isArray(r.findings)
+      ? r.findings.length
+      : undefined;
+  const status = typeof r.status === "string" ? r.status : undefined;
+
+  const data: Record<string, unknown> = { storyId, phase: opName, durationMs };
+  if (findingsCount !== undefined) data.findingsCount = findingsCount;
+  if (status !== undefined) data.status = status;
+  if (typeof r.failureCategory === "string") data.failureCategory = r.failureCategory;
+  if (typeof r.reviewReason === "string") data.reviewReason = r.reviewReason;
+
+  return { success, data };
+}
+
 function logDeterministicPhaseOutcome(
   storyId: string | undefined,
   opName: string,
@@ -616,18 +659,12 @@ function logDeterministicPhaseOutcome(
 ): void {
   if (isTddPhase) return;
   if (opName === "semantic-review" || opName === "adversarial-review") return;
-  if (output === null || output === undefined || typeof output !== "object") return;
+
+  const built = buildPhaseOutcomeLogData(storyId, opName, output, durationMs);
+  if (!built) return;
+  const { success, data } = built;
 
   const logger = getSafeLogger();
-  const r = output as Record<string, unknown>;
-  const success = r.success === true || r.passed === true;
-  const findingsCount = Array.isArray(r.findings) ? r.findings.length : undefined;
-  const status = typeof r.status === "string" ? r.status : undefined;
-
-  const data: Record<string, unknown> = { storyId, phase: opName, durationMs };
-  if (findingsCount !== undefined) data.findingsCount = findingsCount;
-  if (status !== undefined) data.status = status;
-
   const message = formatPhaseResultMessage(opName, success, stage);
 
   // Rectification ops complete successfully whenever the prompt finishes — the

--- a/src/operations/verify.ts
+++ b/src/operations/verify.ts
@@ -2,6 +2,7 @@ import { ParseValidationError, makeParseRetryStrategy } from "../agents/retry";
 import { tddConfigSelector } from "../config";
 import type { TddConfig } from "../config/selectors";
 import type { Finding } from "../findings/types";
+import { getSafeLogger } from "../logger";
 import type { UserStory } from "../prd";
 import { TddPromptBuilder } from "../prompts/builders/tdd-builder";
 import { _isolationDeps, verifyImplementerIsolation } from "../tdd/isolation";
@@ -143,6 +144,10 @@ export const verifierOp: RunOperation<VerifierInput, VerifierOutput, TddConfig> 
     },
     reviewerKind: "verifier",
     maxAttempts: 2,
+    // Surface the unparseable bytes in the run log — verifier verdicts are the
+    // single hardest phase to diagnose post-hoc, and "originalByteSize: 155"
+    // alone tells you nothing about what the agent actually emitted.
+    outputPreviewBytes: 600,
     prompts: {
       invalid: () => TddPromptBuilder.verdictRetry(),
       truncated: () => TddPromptBuilder.verdictRetryCondensed(),
@@ -180,24 +185,38 @@ export const verifierOp: RunOperation<VerifierInput, VerifierOutput, TddConfig> 
     // the orchestrator records an explicit failure (never null — satisfies
     // the parse-retry escape-hatch rule).
     const packageDir = verifyCtx.packageView.packageDir;
+    const logger = getSafeLogger();
+    const storyId = input.story.id;
     try {
       const verdict = await readVerdict(packageDir);
       if (verdict) {
         const testsAllPassing = verdict.tests.allPassing === true;
         const categorization = categorizeVerdict(verdict, testsAllPassing);
         const isolation = await runVerifierIsolation(input.beforeRef, verifyCtx);
+        const normalizedFindings = buildVerifierFindings(verdict, categorization);
+        logger?.warn("verifier", "Recovered verdict from disk after unparseable stdout", {
+          storyId,
+          packageDir,
+          success: categorization.success,
+          findingsCount: normalizedFindings.length,
+          ...(categorization.failureCategory && { failureCategory: categorization.failureCategory }),
+        });
         return {
           success: categorization.success,
           filesChanged: [],
           estimatedCostUsd: 0,
           durationMs: 0,
           output: "",
-          normalizedFindings: buildVerifierFindings(verdict, categorization),
+          normalizedFindings,
           ...(categorization.failureCategory && { failureCategory: categorization.failureCategory }),
           ...(categorization.reviewReason && { reviewReason: categorization.reviewReason }),
           ...(isolation && { isolation }),
         };
       }
+      logger?.error("verifier", "No usable verdict — unparseable stdout and no verdict file on disk (fail-closed)", {
+        storyId,
+        packageDir,
+      });
       return {
         success: false,
         filesChanged: [],

--- a/test/unit/agents/retry/parse-retry.test.ts
+++ b/test/unit/agents/retry/parse-retry.test.ts
@@ -244,6 +244,39 @@ describe("makeParseRetryStrategy", () => {
     });
   });
 
+  describe("AC-10b: outputPreview surfaces unparseable content", () => {
+    function captureWarn(opts: Partial<Parameters<typeof makeParseRetryStrategy>[0]>, lastOutput: string) {
+      const warnCalls: Array<[string, string, Record<string, unknown>]> = [];
+      const strategy = makeParseRetryStrategy({
+        validate: () => false,
+        reviewerKind: "verifier",
+        parse: () => null,
+        looksTruncated: () => false,
+        prompts: { invalid: () => "invalid-prompt", truncated: () => "truncated-prompt" },
+        _logger: { warn: (k, m, d) => warnCalls.push([k, m, d]) },
+        ...opts,
+      } as Parameters<typeof makeParseRetryStrategy>[0]);
+      strategy.shouldRetry(parseError, 0, makeCtx({ lastOutput }));
+      return warnCalls[0]![2];
+    }
+
+    test("includes whitespace-collapsed outputPreview when outputPreviewBytes is set", () => {
+      const data = captureWarn({ outputPreviewBytes: 600 }, "  not a\n\n verdict  ");
+      expect(data.outputPreview).toBe("not a verdict");
+      expect(data.originalByteSize).toBe("  not a\n\n verdict  ".length);
+    });
+
+    test("clips preview to outputPreviewBytes with an ellipsis", () => {
+      const data = captureWarn({ outputPreviewBytes: 10 }, "x".repeat(50));
+      expect(data.outputPreview).toBe(`${"x".repeat(10)}…`);
+    });
+
+    test("omits outputPreview when outputPreviewBytes is unset", () => {
+      const data = captureWarn({}, "some bad output");
+      expect(data).not.toHaveProperty("outputPreview");
+    });
+  });
+
   describe("AC-11: exported from index", () => {
     test("makeParseRetryStrategy is exported from src/agents/retry/index.ts", async () => {
       const mod = await import("../../../../src/agents/retry");

--- a/test/unit/execution/story-orchestrator-logging.test.ts
+++ b/test/unit/execution/story-orchestrator-logging.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { formatPhaseResultMessage } from "@/execution";
+import { buildPhaseOutcomeLogData, formatPhaseResultMessage } from "@/execution";
 
 describe("formatPhaseResultMessage — stage-aware messaging", () => {
   test("returns 'Phase passed' for a non-rectification op with success=true", () => {
@@ -26,5 +26,51 @@ describe("formatPhaseResultMessage — stage-aware messaging", () => {
     expect(formatPhaseResultMessage("greenfield-gate", false)).toBe(
       "Greenfield-gate: no pre-existing tests — greenfield run, pausing TDD test-writer",
     );
+  });
+});
+
+describe("buildPhaseOutcomeLogData — verdict detail surfacing", () => {
+  test("returns null for non-object output", () => {
+    expect(buildPhaseOutcomeLogData("US-001", "verifier", null, 100)).toBeNull();
+    expect(buildPhaseOutcomeLogData("US-001", "verifier", undefined, 100)).toBeNull();
+    expect(buildPhaseOutcomeLogData("US-001", "verifier", "string", 100)).toBeNull();
+  });
+
+  test("counts normalizedFindings (verifier shape), not legacy findings", () => {
+    const output = {
+      success: false,
+      normalizedFindings: [{ source: "tdd-verifier" }],
+      failureCategory: "tests-failing",
+      reviewReason: "1 story-scoped test failed",
+    };
+    const built = buildPhaseOutcomeLogData("US-001", "verifier", output, 956428);
+    expect(built).not.toBeNull();
+    expect(built?.success).toBe(false);
+    expect(built?.data).toMatchObject({
+      storyId: "US-001",
+      phase: "verifier",
+      durationMs: 956428,
+      findingsCount: 1,
+      failureCategory: "tests-failing",
+      reviewReason: "1 story-scoped test failed",
+    });
+  });
+
+  test("falls back to legacy findings array when normalizedFindings absent", () => {
+    const built = buildPhaseOutcomeLogData("US-001", "lint-check", { passed: false, findings: [{}, {}] }, 50);
+    expect(built?.data.findingsCount).toBe(2);
+  });
+
+  test("omits findingsCount/failureCategory/reviewReason when not present", () => {
+    const built = buildPhaseOutcomeLogData("US-001", "full-suite-gate", { success: true, status: "passed" }, 200);
+    expect(built?.success).toBe(true);
+    expect(built?.data).toEqual({ storyId: "US-001", phase: "full-suite-gate", durationMs: 200, status: "passed" });
+    expect(built?.data).not.toHaveProperty("findingsCount");
+    expect(built?.data).not.toHaveProperty("failureCategory");
+  });
+
+  test("storyId is the first key (parallel-log correlation)", () => {
+    const built = buildPhaseOutcomeLogData("US-001", "verifier", { success: false, normalizedFindings: [] }, 10);
+    expect(Object.keys(built!.data)[0]).toBe("storyId");
   });
 });


### PR DESCRIPTION
## Why

Follow-up to #1145. While re-testing a run (`logs/2026-05-29T08-45-43.jsonl`), the verifier phase failed in a way that was nearly impossible to diagnose from the run log alone. PR #1145's findings + cycle-honesty behavior actually **worked correctly** — the verifier legitimately rejected the story on a real failing test (AC12) and rectification honestly exited via `validate-short-circuit`. But the log made none of that visible:

| Attempt | Returned | Log said |
|---|---|---|
| 1 | 155-byte non-verdict | `JSON parse retry — invalid shape {originalByteSize:155}` — **content not logged** |
| 2 | empty response | nothing useful |
| 3 (stale re-open) | valid `approved:false` verdict, AC12 failing | `Phase failed: verifier {durationMs:956428}` — **no verdict detail** |

The verdict reasoning + finding only existed in `logs/prompt-audit/`, forcing a manual cross-reference.

## What

Three observability gaps closed. **No behavior change** — logging only.

1. **`parse-retry.ts`** — add opt-in `outputPreviewBytes`; the warn log now includes a whitespace-collapsed `outputPreview` of the unparseable bytes. `verifierOp` opts in at 600. Purely additive — every other parse-retry op (semantic/adversarial review, plan-critic, classify-route) is unchanged because the field is `{}` unless the opt is set.

2. **`story-orchestrator.ts`** — `logDeterministicPhaseOutcome` counted `r.findings`, but `VerifierOutput` carries `normalizedFindings`, so the verifier's "Phase failed" line logged no `findingsCount` even when it emitted a `tdd-verifier` finding (the rectification engine read it correctly all along). Now reads `normalizedFindings` (fallback to `findings`) and surfaces `failureCategory` / `reviewReason`. Extraction split into a pure exported `buildPhaseOutcomeLogData` for testability.

3. **`verify.ts`** — `verifierOp.recover` was a silent dead-end; now logs disk-verdict recovery (`success`/`findingsCount`/`failureCategory`) vs the fail-closed no-usable-verdict case.

## Risk

Audited the shared `parse-retry.ts` and the all-phases `logDeterministicPhaseOutcome`:

- Reachable deterministic ops carry the two finding fields **mutually exclusively** — `verifier` has only `normalizedFindings`; `verify-scoped`/`lint-check`/`typecheck-check`/`full-suite-gate` have only `findings`; the dual-field review ops (`semantic`/`adversarial`) return early before this code. So the `findingsCount` precedence never diverges from `extractPhaseFindings` in practice.
- `parse-retry` change is opt-in; only `verifierOp` sets it. `storyId` stays the first log key.
- `recover` return values unchanged; only adds logs.
- No new data-exposure class (`outputPreview` content already lives in prompt-audit + run-log prompts).

## Test plan

- [x] +3 `parse-retry` preview cases (collapse, clip+ellipsis, omit-when-unset)
- [x] +5 `buildPhaseOutcomeLogData` cases (normalizedFindings precedence, legacy fallback, omit-when-absent, storyId-first)
- [x] targeted unit suites (review, operations, agents, execution) — all pass
- [x] typecheck clean, lint clean, `logger-storyid` under baseline
