### PR TITLE
feat(observability): enrich headless run log with agent identity, activity counts, session role, and progress counters

### DIFF
--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -656,13 +656,15 @@ function logDeterministicPhaseOutcome(
   durationMs: number,
   isTddPhase: boolean,
   stage?: string,
+  progressData: Record<string, unknown> = {},
 ): void {
   if (isTddPhase) return;
   if (opName === "semantic-review" || opName === "adversarial-review") return;
 
   const built = buildPhaseOutcomeLogData(storyId, opName, output, durationMs);
   if (!built) return;
-  const { success, data } = built;
+  const { success } = built;
+  const data = { ...built.data, ...progressData };
 
   const logger = getSafeLogger();
   const message = formatPhaseResultMessage(opName, success, stage);
@@ -754,9 +756,13 @@ async function runPhase(
   phaseCosts: Record<string, number>,
   phaseOutputs: Record<string, unknown>,
   isThreeSession = false,
+  progress?: { index: number; total: number },
 ): Promise<unknown> {
   const logger = getSafeLogger();
   const opName = slot.op.name;
+  // Phase progress counter (e.g. 5/8) for headless-log orientation in long runs.
+  // Only the canonical run() loop supplies it; rectification/fix-cycle callers omit it.
+  const progressData = progress ? { phaseIndex: progress.index, totalPhases: progress.total } : {};
   // Isolation enforcement + TDD-stage logs only apply when the orchestrator is
   // executing a three-session-tdd strategy. The single-session ("no-test") path
   // reuses implementerOp but has no boundary semantics to enforce, so capturing
@@ -771,9 +777,12 @@ async function runPhase(
   dispatchInput = await refreshReviewInputForDispatch(opName, dispatchInput);
 
   if (isTddPhase) {
-    logger?.info("tdd", `-> Session: ${opName}`, { storyId: ctx.storyId, role: opName });
+    logger?.info("tdd", `-> Session: ${opName}`, { storyId: ctx.storyId, role: opName, ...progressData });
   } else if (isThreeSession && opName === "full-suite-gate") {
-    logger?.info("tdd", "-> Running full test suite gate (before Verifier)", { storyId: ctx.storyId });
+    logger?.info("tdd", "-> Running full test suite gate (before Verifier)", {
+      storyId: ctx.storyId,
+      ...progressData,
+    });
   }
   logUnifiedReviewPhaseStart(ctx.storyId, opName);
 
@@ -784,7 +793,15 @@ async function runPhase(
     phaseOutputs[opName] = output;
     emitReviewDecision(ctx, opName, output);
     logUnifiedReviewPhaseResult(ctx.storyId, opName, output);
-    logDeterministicPhaseOutcome(ctx.storyId, opName, output, Date.now() - phaseStartedAt, isTddPhase, slot.op.stage);
+    logDeterministicPhaseOutcome(
+      ctx.storyId,
+      opName,
+      output,
+      Date.now() - phaseStartedAt,
+      isTddPhase,
+      slot.op.stage,
+      progressData,
+    );
 
     // Post-phase logs (TDD phases only).
     if (isTddPhase) {
@@ -1067,9 +1084,13 @@ export class ExecutionPlan {
     // the verifier run on broken-gate code as an "unrelated regression" escape
     // hatch, at the cost of every common case. The escalation boundary in
     // deriveTddFailureCategory now handles that case instead.
-    for (const phase of collectOrderedPhases(this.state)) {
+    const orderedPhases = collectOrderedPhases(this.state);
+    for (const [phaseIndex, phase] of orderedPhases.entries()) {
       try {
-        await runPhase(this.ctx, phase.slot, phaseCosts, phaseOutputs, this.isThreeSession);
+        await runPhase(this.ctx, phase.slot, phaseCosts, phaseOutputs, this.isThreeSession, {
+          index: phaseIndex + 1,
+          total: orderedPhases.length,
+        });
       } catch (error) {
         logger?.error("story-orchestrator", "Phase threw unexpected error", {
           storyId: this.ctx.storyId,

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -203,7 +203,10 @@ export async function executeUnified(
 
         if (batch.length > 1) {
           // Emit story:started for each batch story before dispatch (AC-5)
-          for (const story of batch) {
+          const batchAgent = ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config);
+          const batchCounts = countStories(prd);
+          const batchBaseDone = batchCounts.total - batchCounts.pending;
+          for (const [batchIndex, story] of batch.entries()) {
             const modelTier =
               story.routing?.modelTier ??
               ctx.config.autoMode.complexityRouting?.[story.routing?.complexity ?? "medium"] ??
@@ -214,7 +217,7 @@ export async function executeUnified(
               story: { id: story.id, title: story.title, status: story.status, attempts: story.attempts },
               workdir: ctx.workdir,
               modelTier,
-              agent: ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config),
+              agent: batchAgent,
               iteration: iterations,
             });
             logger?.info("story.start", `${story.title}`, {
@@ -222,6 +225,9 @@ export async function executeUnified(
               storyTitle: story.title,
               complexity: story.routing?.complexity ?? "unknown",
               modelTier,
+              agent: batchAgent,
+              storyNumber: batchBaseDone + batchIndex + 1,
+              storyTotal: batchCounts.total,
               attempt: story.attempts + 1,
             });
           }
@@ -412,6 +418,8 @@ export async function executeUnified(
           }
 
           const modelTier = singleSelection.routing.modelTier;
+          const singleAgent = ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config);
+          const singleCounts = countStories(prd);
           pipelineEventBus.emit({
             type: "story:started",
             storyId: singleStory.id,
@@ -423,7 +431,7 @@ export async function executeUnified(
             },
             workdir: ctx.workdir,
             modelTier,
-            agent: ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config),
+            agent: singleAgent,
             iteration: iterations,
           });
           logger?.info("story.start", `${singleStory.title}`, {
@@ -431,6 +439,9 @@ export async function executeUnified(
             storyTitle: singleStory.title,
             complexity: singleSelection.routing.complexity ?? "unknown",
             modelTier,
+            agent: singleAgent,
+            storyNumber: singleCounts.total - singleCounts.pending + 1,
+            storyTotal: singleCounts.total,
             attempt: singleStory.attempts + 1,
           });
 
@@ -502,6 +513,8 @@ export async function executeUnified(
       }
 
       const modelTier = selection.routing.modelTier;
+      const seqAgent = ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config);
+      const seqCounts = countStories(prd);
       pipelineEventBus.emit({
         type: "story:started",
         storyId: selection.story.id,
@@ -513,7 +526,7 @@ export async function executeUnified(
         },
         workdir: ctx.workdir,
         modelTier,
-        agent: ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config),
+        agent: seqAgent,
         iteration: iterations,
       });
       logger?.info("story.start", `${selection.story.title}`, {
@@ -521,6 +534,9 @@ export async function executeUnified(
         storyTitle: selection.story.title,
         complexity: selection.routing.complexity ?? "unknown",
         modelTier,
+        agent: seqAgent,
+        storyNumber: seqCounts.total - seqCounts.pending + 1,
+        storyTotal: seqCounts.total,
         attempt: selection.story.attempts + 1,
       });
 

--- a/src/logging/formatter.ts
+++ b/src/logging/formatter.ts
@@ -157,21 +157,31 @@ function formatStoryStart(entry: LogEntry, c: ChalkLike, _timestamp: string, mod
   const complexity = typeof data.complexity === "string" ? data.complexity : "unknown";
   const tier = typeof data.modelTier === "string" ? data.modelTier : "unknown";
   const attempt = typeof data.attempt === "number" ? data.attempt : 1;
+  const agent = typeof data.agent === "string" ? data.agent : undefined;
+  const progress =
+    typeof data.storyNumber === "number" && typeof data.storyTotal === "number"
+      ? `${data.storyNumber}/${data.storyTotal}`
+      : undefined;
 
   const lines: string[] = [];
   lines.push("");
   lines.push(c.bold(`${EMOJI.storyStart} ${c.cyan(storyId)}: ${title}`));
 
   if (mode === "verbose") {
+    if (progress) lines.push(`  ${c.gray("├─")} Story: ${c.cyan(progress)}`);
     lines.push(`  ${c.gray("├─")} Complexity: ${c.yellow(complexity)}`);
     lines.push(`  ${c.gray("├─")} Tier: ${c.magenta(tier)}`);
+    if (agent) lines.push(`  ${c.gray("├─")} Agent: ${c.cyan(agent)}`);
     if (attempt > 1) {
       lines.push(`  ${c.gray("└─")} Attempt: ${c.yellow(`#${attempt}`)} ${EMOJI.retry}`);
     } else {
       lines.push(`  ${c.gray("└─")} Status: ${c.green("starting")}`);
     }
   } else {
-    const metadata = [complexity, tier];
+    const metadata: string[] = [];
+    if (progress) metadata.push(progress);
+    metadata.push(complexity, tier);
+    if (agent) metadata.push(agent);
     if (attempt > 1) metadata.push(`attempt #${attempt} ${EMOJI.retry}`);
     lines.push(`  ${c.gray(metadata.join(" • "))}`);
   }
@@ -251,28 +261,30 @@ function formatDefault(entry: LogEntry, c: ChalkLike, timestamp: string, mode: s
   if (entry.storyId) {
     parts.push(c.dim(`[${entry.storyId}]`));
   }
+  // sessionRole is a first-class LogEntry field (stripped from data by the logger);
+  // render it as a tag so per-line provenance is visible without a JSONL cross-reference.
+  if (entry.sessionRole) {
+    parts.push(c.dim(`(${entry.sessionRole})`));
+  }
 
   parts.push(entry.message);
 
   let output = parts.join(" ");
 
-  // Always show key data fields (cost, duration, action, reason) in normal+ modes
+  // Surface key structured fields inline in normal+ modes. The headless console
+  // previously dropped agent identity, activity counts, status, and phase
+  // progress even though they are already present in the JSONL.
   const data = entry.data;
   if (data && typeof data === "object") {
-    const meta: string[] = [];
-    if (typeof data.cost === "number" && data.cost > 0) meta.push(`${EMOJI.cost} ${formatCost(data.cost)}`);
-    if (typeof data.durationMs === "number" && data.durationMs > 0)
-      meta.push(`${EMOJI.duration} ${formatDuration(data.durationMs)}`);
-    if (typeof data.action === "string") meta.push(`action: ${data.action}`);
-    if (typeof data.reason === "string" && mode !== "quiet") meta.push(data.reason);
+    const meta = buildDefaultMeta(data, mode);
     if (meta.length > 0) {
       output += `  ${c.gray(meta.join("  "))}`;
     }
 
-    // Full data dump only in verbose mode
+    // Full data dump only in verbose mode — exclude fields already surfaced
+    // above so they are not printed twice.
     if (mode === "verbose") {
-      // biome-ignore lint/suspicious/noExplicitAny: Intentional spread to filter known fields
-      const { cost: _c, durationMs: _d, action: _a, reason: _r, ...filtered } = data as any;
+      const filtered = stripConsumedMetaFields(data);
       if (Object.keys(filtered).length > 0) {
         output += `\n${c.gray(JSON.stringify(filtered, null, 2))}`;
       }
@@ -283,6 +295,84 @@ function formatDefault(entry: LogEntry, c: ChalkLike, timestamp: string, mode: s
     output,
     shouldDisplay: true,
   };
+}
+
+/** Data keys that {@link buildDefaultMeta} renders inline (excluded from the verbose JSON dump). */
+const CONSUMED_META_KEYS = [
+  "agentName",
+  "model",
+  "phaseIndex",
+  "totalPhases",
+  "status",
+  "findingsCount",
+  "messageUpdates",
+  "toolCallUpdates",
+  "thinkingUpdates",
+  "idleMs",
+  "cost",
+  "durationMs",
+  "action",
+  "reason",
+] as const;
+
+/**
+ * Build the inline metadata segment for a default log line.
+ *
+ * Order is fixed for scannability: identity (agent·model) → phase progress →
+ * status/findings → agent-stream activity counts → cost/duration → action/reason.
+ * Only present, meaningful fields are emitted, so unrelated lines stay terse.
+ */
+function buildDefaultMeta(data: Record<string, unknown>, mode: string): string[] {
+  const meta: string[] = [];
+
+  const identity = [data.agentName, data.model].filter((v): v is string => typeof v === "string" && v.length > 0);
+  if (identity.length > 0) meta.push(`${EMOJI.agent} ${identity.join("·")}`);
+
+  if (typeof data.phaseIndex === "number" && typeof data.totalPhases === "number") {
+    meta.push(`${data.phaseIndex}/${data.totalPhases}`);
+  }
+
+  if (typeof data.status === "string") meta.push(`status: ${data.status}`);
+  if (typeof data.findingsCount === "number")
+    meta.push(`${data.findingsCount} finding${data.findingsCount === 1 ? "" : "s"}`);
+
+  const activity = buildActivityMeta(data);
+  if (activity) meta.push(activity);
+
+  if (typeof data.cost === "number" && data.cost > 0) meta.push(`${EMOJI.cost} ${formatCost(data.cost)}`);
+  if (typeof data.durationMs === "number" && data.durationMs > 0)
+    meta.push(`${EMOJI.duration} ${formatDuration(data.durationMs)}`);
+  if (typeof data.action === "string") meta.push(`action: ${data.action}`);
+  if (typeof data.reason === "string" && mode !== "quiet") meta.push(data.reason);
+
+  return meta;
+}
+
+/**
+ * Compact agent-stream activity summary (message / tool-call / thinking update
+ * counts + idle time). Returns null when no activity field is present so
+ * non-agent-stream lines are unaffected.
+ */
+function buildActivityMeta(data: Record<string, unknown>): string | null {
+  const segments: string[] = [];
+  if (typeof data.messageUpdates === "number" && data.messageUpdates > 0) segments.push(`msg ${data.messageUpdates}`);
+  if (typeof data.toolCallUpdates === "number" && data.toolCallUpdates > 0)
+    segments.push(`tools ${data.toolCallUpdates}`);
+  if (typeof data.thinkingUpdates === "number" && data.thinkingUpdates > 0)
+    segments.push(`think ${data.thinkingUpdates}`);
+  if (typeof data.idleMs === "number" && data.idleMs > 0) segments.push(`idle ${formatDuration(data.idleMs)}`);
+  return segments.length > 0 ? segments.join(" ") : null;
+}
+
+/** Remove fields already rendered inline so the verbose JSON dump shows only the remainder. */
+function stripConsumedMetaFields(data: Record<string, unknown>): Record<string, unknown> {
+  const filtered: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (!(CONSUMED_META_KEYS as readonly string[]).includes(key)) {
+      filtered[key] = value;
+    }
+  }
+  return filtered;
 }
 
 /**

--- a/test/unit/logging/formatter.test.ts
+++ b/test/unit/logging/formatter.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import { formatLogEntry } from "../../../src/logging";
+import type { LogEntry } from "../../../src/logger/types";
+
+const TS = "2026-05-29T11:35:59.000Z";
+
+function entry(overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    timestamp: TS,
+    level: "info",
+    stage: "agent-stream",
+    message: "Agent call started",
+    ...overrides,
+  };
+}
+
+/** Strip ANSI color codes so assertions read against plain text. */
+function plain(s: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escapes
+  return s.replace(/\[[0-9;]*m/g, "");
+}
+
+function formatNormal(e: LogEntry): string {
+  const { output } = formatLogEntry(e, { mode: "normal", useColor: false });
+  return plain(output);
+}
+
+describe("formatLogEntry — default line enrichment (normal mode)", () => {
+  test("surfaces agent name and model on agent-call lines", () => {
+    const out = formatNormal(
+      entry({ data: { storyId: "s-1", agentName: "claude", model: "claude-sonnet-4-6" } }),
+    );
+    expect(out).toContain("claude");
+    expect(out).toContain("claude-sonnet-4-6");
+    // composed as agentName·model, not two separate dumps
+    expect(out).toContain("claude·claude-sonnet-4-6");
+  });
+
+  test("shows agent name alone when model is absent", () => {
+    const out = formatNormal(entry({ data: { agentName: "claude" } }));
+    expect(out).toContain("claude");
+    expect(out).not.toContain("·");
+  });
+
+  test("renders session role as a tag", () => {
+    const out = formatNormal(
+      entry({ stage: "tdd", message: "Session complete", sessionRole: "verifier" }),
+    );
+    expect(out).toContain("verifier");
+  });
+
+  test("surfaces agent-stream activity counts on call-ended lines", () => {
+    const out = formatNormal(
+      entry({
+        message: "Agent call ended",
+        data: {
+          storyId: "s-1",
+          messageUpdates: 12,
+          toolCallUpdates: 5,
+          thinkingUpdates: 3,
+          idleMs: 2500,
+        },
+      }),
+    );
+    expect(out).toContain("msg 12");
+    expect(out).toContain("tools 5");
+    expect(out).toContain("think 3");
+    expect(out).toContain("idle 2.5s");
+  });
+
+  test("omits zero-valued activity counts", () => {
+    const out = formatNormal(
+      entry({
+        message: "Agent call ended",
+        data: { messageUpdates: 4, toolCallUpdates: 0, thinkingUpdates: 0 },
+      }),
+    );
+    expect(out).toContain("msg 4");
+    expect(out).not.toContain("tools");
+    expect(out).not.toContain("think");
+  });
+
+  test("surfaces status and findings count on phase lines", () => {
+    const out = formatNormal(
+      entry({
+        stage: "story-orchestrator",
+        message: "Phase passed: verifier",
+        data: { storyId: "s-1", status: "passed", findingsCount: 2 },
+      }),
+    );
+    expect(out).toContain("status: passed");
+    expect(out).toContain("2 finding");
+  });
+
+  test("renders phase progress counter when present", () => {
+    const out = formatNormal(
+      entry({
+        stage: "story-orchestrator",
+        message: "Phase passed: verifier",
+        data: { storyId: "s-1", phaseIndex: 5, totalPhases: 8 },
+      }),
+    );
+    expect(out).toContain("5/8");
+  });
+
+  test("still renders cost and duration (existing behavior preserved)", () => {
+    const out = formatNormal(
+      entry({
+        stage: "middleware",
+        message: "Agent call complete",
+        data: { cost: 0.1234, durationMs: 32300 },
+      }),
+    );
+    expect(out).toContain("$0.1234");
+    expect(out).toContain("32.3s");
+  });
+
+  test("a bare line with no enrichable data renders message only", () => {
+    const out = formatNormal(entry({ stage: "execution", message: "Run initialization complete" }));
+    expect(out).toContain("Run initialization complete");
+    expect(out).not.toContain("·");
+    expect(out).not.toContain("msg ");
+  });
+});
+
+describe("formatLogEntry — story start enrichment", () => {
+  function storyStart(data: Record<string, unknown>): string {
+    return formatNormal(
+      entry({ stage: "story.start", message: "Implement slugify", data: { storyId: "US-001", ...data } }),
+    );
+  }
+
+  test("renders story progress counter and agent in normal mode", () => {
+    const out = storyStart({ complexity: "complex", modelTier: "fast", agent: "claude", storyNumber: 1, storyTotal: 3 });
+    expect(out).toContain("1/3");
+    expect(out).toContain("claude");
+    expect(out).toContain("complex");
+    expect(out).toContain("fast");
+  });
+
+  test("omits progress counter when counts are absent", () => {
+    const out = storyStart({ complexity: "complex", modelTier: "fast" });
+    expect(out).not.toContain("/");
+  });
+
+  test("shows agent row in verbose mode", () => {
+    const { output } = formatLogEntry(
+      entry({
+        stage: "story.start",
+        message: "Implement slugify",
+        data: { storyId: "US-001", complexity: "complex", modelTier: "fast", agent: "claude" },
+      }),
+      { mode: "verbose", useColor: false },
+    );
+    expect(plain(output)).toContain("claude");
+  });
+});
+
+describe("formatLogEntry — verbose mode does not double-print enriched fields", () => {
+  test("known enriched fields are not dumped again as raw JSON", () => {
+    const { output } = formatLogEntry(
+      entry({
+        stage: "agent-stream",
+        message: "Agent call ended",
+        data: { agentName: "claude", model: "m", messageUpdates: 2, status: "success" },
+      }),
+      { mode: "verbose", useColor: false },
+    );
+    const text = plain(output);
+    // The JSON dump (if any) must not re-include these consumed keys.
+    const jsonStart = text.indexOf("{");
+    const jsonPart = jsonStart >= 0 ? text.slice(jsonStart) : "";
+    expect(jsonPart).not.toContain("agentName");
+    expect(jsonPart).not.toContain("messageUpdates");
+  });
+});


### PR DESCRIPTION
## Summary

Enriches the `nax run --headless` console output with structured data that was **already present in the JSONL but dropped on screen**. The headless console routes every line through `formatLogEntry` → `formatDefault`, which previously surfaced only `cost`, `durationMs`, `action`, and `reason`.

Driven by screenshots of a real headless run where agent identity, model, session role, activity counts, and phase/story progress were all invisible despite being logged.

## What's surfaced now (normal+ modes)

| Field | Where | Example |
|:--|:--|:--|
| **Session role** | any line (first-class `LogEntry` field, never rendered before) | `tdd (implementer) -> Session: implementer` |
| **Agent + model** | agent-call lines | `🤖 claude·claude-sonnet-4-6` |
| **Activity counts** | "Agent call ended" | `msg 12 tools 5 think 3 idle 2.5s` |
| **Status / findings** | phase lines | `status: passed  0 findings` |
| **Phase progress** | TDD + deterministic phase lines | `5/8` |
| **Story progress + agent** | `story.start` | `1/3 • complex • fast • claude` |

Verbose mode no longer double-prints the now-consumed fields (excluded from the raw JSON dump).

### Sample output
```
▶ US-001: Implement slugify
  1/3 • complex • fast • claude
[19:59:08] ℹ agent-stream Agent call started  🤖 claude·claude-sonnet-4-6
[19:59:08] ℹ tdd (implementer) -> Session: implementer  3/8
[19:59:08] ℹ agent-stream Agent call ended  msg 12 tools 5 think 3 idle 2.5s
[19:59:08] ℹ middleware Agent call complete  🤖 claude  💰 $0.4200  ⏱️ 58.9s
[19:59:08] ℹ story-orchestrator Phase passed: verifier  5/8  status: passed  0 findings  ⏱️ 1m 8s
```

## Changes

- **`src/logging/formatter.ts`** — core enrichment in `formatDefault` (extracted `buildDefaultMeta` / `buildActivityMeta` / `stripConsumedMetaFields` helpers) + `formatStoryStart` progress/agent rendering.
- **`src/execution/unified-executor.ts`** — add `agent`, `storyNumber`, `storyTotal` to all three `story.start` emission sites (sequential, single-story, batch).
- **`src/execution/story-orchestrator.ts`** — thread an optional `{ index, total }` phase counter from the canonical `run()` loop through `runPhase` into the TDD session-begin and deterministic phase-outcome log lines (rectification/fix-cycle callers omit it).

## Tests

- New `test/unit/logging/formatter.test.ts` (13 tests, TDD red→green). `src/logging/formatter.ts` previously had **zero** test coverage.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean (baselines unchanged)
- 1,460 tests across logging / execution / runtime / pipeline — all pass

## Scope note

Per-line **token totals** are intentionally not added: agent-stream events carry *counts of update events* (`messageUpdates`, `usageUpdates`), not token totals. True input/output token totals live in the cost middleware (`DispatchEvent` / `CostAggregator`) and would need a separate, larger change to thread onto the "Agent call complete" line — left as a potential follow-up.
