### PR TITLE
fix: parallel-mode PRD data-loss, performance hotspots, and security hardening (CR-1/H/M)

### DIFF
--- a/src/context/engine/orchestrator.ts
+++ b/src/context/engine/orchestrator.ts
@@ -80,13 +80,39 @@ type ProviderActivationSource = NonNullable<NonNullable<ContextManifest["provide
 
 const PROVIDER_FETCH_TIMEOUT_MS = 5_000;
 
-async function fetchWithTimeout(provider: IContextProvider, request: ContextRequest): Promise<ContextProviderResult> {
+export async function fetchWithTimeout(
+  provider: IContextProvider,
+  request: ContextRequest,
+  timeoutMs = PROVIDER_FETCH_TIMEOUT_MS,
+): Promise<ContextProviderResult> {
+  const controller = new AbortController();
   let handle: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+
   const timeout = new Promise<ContextProviderResult>((_, reject) => {
-    handle = setTimeout(() => reject(new Error(`Provider "${provider.id}" timed out`)), PROVIDER_FETCH_TIMEOUT_MS);
+    handle = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+      reject(new Error(`Provider "${provider.id}" timed out`));
+    }, timeoutMs);
   });
+
+  // Wrap the fetch so that if the abort fires synchronously inside abort(),
+  // we map it to a "timed out" rejection rather than letting the raw "aborted"
+  // error win the race against the timeout rejection.
+  const fetchPromise = provider.fetch(request, controller.signal).then(
+    (result) => result,
+    (err) => {
+      if (timedOut) {
+        // The abort we fired — suppress by never settling, letting timeout win.
+        return new Promise<ContextProviderResult>(() => {});
+      }
+      throw err;
+    },
+  );
+
   try {
-    return await Promise.race([provider.fetch(request), timeout]);
+    return await Promise.race([fetchPromise, timeout]);
   } finally {
     clearTimeout(handle);
   }

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -351,13 +351,7 @@ function scanDirectory(
   maxGlobFiles: number,
   globCtx: { storyId?: string; packageDir?: string } | undefined,
 ): ScannedDir {
-  const { files, truncated } = _codeNeighborDeps.glob(
-    sourceGlob,
-    workdir,
-    ignoreMatchers,
-    maxGlobFiles,
-    globCtx,
-  );
+  const { files, truncated } = _codeNeighborDeps.glob(sourceGlob, workdir, ignoreMatchers, maxGlobFiles, globCtx);
   return { workdir, files, truncated };
 }
 
@@ -365,10 +359,7 @@ function scanDirectory(
  * Read a file's content, using the shared cache to avoid redundant disk reads
  * when multiple touched files inspect the same candidate.
  */
-async function readCached(
-  absolutePath: string,
-  cache: Map<string, string>,
-): Promise<string | null> {
+async function readCached(absolutePath: string, cache: Map<string, string>): Promise<string | null> {
   const cached = cache.get(absolutePath);
   if (cached !== undefined) return cached;
   try {
@@ -423,7 +414,7 @@ async function collectNeighbors(
       if (neighbors.size >= MAX_NEIGHBORS_PER_FILE) break;
       if (srcFile === filePath) continue;
       const content = await readCached(join(scanWorkdir, srcFile), contentCache);
-      if (content !== null && content.includes(fileBaseName)) {
+      if (content?.includes(fileBaseName)) {
         for (const spec of parseImportSpecifiers(content)) {
           const resolved = resolveImport(spec, srcFile, scanWorkdir);
           if (resolved === filePath || resolved === fileNoExt) {
@@ -567,9 +558,7 @@ export class CodeNeighborProvider implements IContextProvider {
     // re-glob the same directory N times (once per touched file). A shared
     // content cache further ensures each candidate file is read at most once
     // across all touched files in this fetch() call.
-    const scannedDirs: ScannedDir[] = [
-      scanDirectory(sourceGlob, workdir, ignoreMatchers, this.maxGlobFiles, globCtx),
-    ];
+    const scannedDirs: ScannedDir[] = [scanDirectory(sourceGlob, workdir, ignoreMatchers, this.maxGlobFiles, globCtx)];
     if (extraGlobWorkdirs) {
       for (const extraDir of extraGlobWorkdirs) {
         scannedDirs.push(scanDirectory(sourceGlob, extraDir, ignoreMatchers, this.maxGlobFiles, globCtx));

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -408,10 +408,10 @@ async function collectNeighbors(
   const fileBaseName = (filePath.split("/").pop() ?? filePath).replace(/\.[^.]+$/, "");
   const fileNoExt = filePath.replace(/\.[^.]+$/, "");
 
-  for (const { workdir: scanWorkdir, files: srcFiles, truncated } of scannedDirs) {
+  outer: for (const { workdir: scanWorkdir, files: srcFiles, truncated } of scannedDirs) {
     if (truncated) anyTruncated = true;
     for (const srcFile of srcFiles) {
-      if (neighbors.size >= MAX_NEIGHBORS_PER_FILE) break;
+      if (neighbors.size >= MAX_NEIGHBORS_PER_FILE) break outer;
       if (srcFile === filePath) continue;
       const content = await readCached(join(scanWorkdir, srcFile), contentCache);
       if (content?.includes(fileBaseName)) {

--- a/src/context/engine/providers/code-neighbor.ts
+++ b/src/context/engine/providers/code-neighbor.ts
@@ -333,30 +333,82 @@ async function resolveSourceGlob(override: string | undefined, packageDir: strin
   return (language && SOURCE_GLOB_BY_LANGUAGE[language]) ?? FALLBACK_SOURCE_GLOB;
 }
 
+/** Result of a pre-scanned directory for reverse-dep matching. */
+interface ScannedDir {
+  workdir: string;
+  files: string[];
+  truncated: boolean;
+}
+
+/**
+ * Scan a directory once for candidate source files.
+ * Results are meant to be shared across all per-file calls in one fetch().
+ */
+function scanDirectory(
+  sourceGlob: string,
+  workdir: string,
+  ignoreMatchers: readonly NaxIgnoreMatcher[] | undefined,
+  maxGlobFiles: number,
+  globCtx: { storyId?: string; packageDir?: string } | undefined,
+): ScannedDir {
+  const { files, truncated } = _codeNeighborDeps.glob(
+    sourceGlob,
+    workdir,
+    ignoreMatchers,
+    maxGlobFiles,
+    globCtx,
+  );
+  return { workdir, files, truncated };
+}
+
+/**
+ * Read a file's content, using the shared cache to avoid redundant disk reads
+ * when multiple touched files inspect the same candidate.
+ */
+async function readCached(
+  absolutePath: string,
+  cache: Map<string, string>,
+): Promise<string | null> {
+  const cached = cache.get(absolutePath);
+  if (cached !== undefined) return cached;
+  try {
+    const content = await _codeNeighborDeps.readFile(absolutePath);
+    cache.set(absolutePath, content);
+    return content;
+  } catch {
+    // Mark as unreadable so we don't retry
+    cache.set(absolutePath, "");
+    return null;
+  }
+}
+
 /**
  * Collect neighbors for a single file: forward deps (JS/TS only), reverse deps
  * (language-aware glob, configurable cap), and sibling test (ADR-009 SSOT).
- * extraGlobWorkdirs enables cross-package reverse dep scanning (AC-62).
+ *
+ * Accepts pre-scanned directory results and a shared content cache so that
+ * the glob and file reads are not repeated across touched files in one fetch().
  */
 async function collectNeighbors(
   filePath: string,
   workdir: string,
-  sourceGlob: string,
-  maxGlobFiles: number,
-  extraGlobWorkdirs?: string[],
+  scannedDirs: ScannedDir[],
+  contentCache: Map<string, string>,
   siblingTestContext?: { globs: readonly string[]; regex: readonly RegExp[] },
-  ignoreMatchers?: readonly NaxIgnoreMatcher[],
-  globCtx?: { storyId?: string; packageDir?: string },
 ): Promise<{ neighbors: string[]; truncated: boolean }> {
   const neighbors = new Set<string>();
   let anyTruncated = false;
 
-  // Forward deps (JS/TS only)
-  if (await _codeNeighborDeps.fileExists(join(workdir, filePath))) {
-    const content = await _codeNeighborDeps.readFile(join(workdir, filePath));
-    for (const spec of parseImportSpecifiers(content)) {
-      const resolved = resolveImport(spec, filePath, workdir);
-      if (resolved && resolved !== filePath) neighbors.add(resolved);
+  // Forward deps (JS/TS only) — check existence first (consistent with original
+  // behaviour), then read via the shared cache.
+  const ownAbsPath = join(workdir, filePath);
+  if (await _codeNeighborDeps.fileExists(ownAbsPath)) {
+    const ownContent = await readCached(ownAbsPath, contentCache);
+    if (ownContent !== null && ownContent.length > 0) {
+      for (const spec of parseImportSpecifiers(ownContent)) {
+        const resolved = resolveImport(spec, filePath, workdir);
+        if (resolved && resolved !== filePath) neighbors.add(resolved);
+      }
     }
   }
 
@@ -365,42 +417,21 @@ async function collectNeighbors(
   const fileBaseName = (filePath.split("/").pop() ?? filePath).replace(/\.[^.]+$/, "");
   const fileNoExt = filePath.replace(/\.[^.]+$/, "");
 
-  const scanForReverseDeps = async (scanWorkdir: string) => {
-    const { files: srcFiles, truncated } = _codeNeighborDeps.glob(
-      sourceGlob,
-      scanWorkdir,
-      ignoreMatchers,
-      maxGlobFiles,
-      globCtx,
-    );
+  for (const { workdir: scanWorkdir, files: srcFiles, truncated } of scannedDirs) {
     if (truncated) anyTruncated = true;
     for (const srcFile of srcFiles) {
       if (neighbors.size >= MAX_NEIGHBORS_PER_FILE) break;
       if (srcFile === filePath) continue;
-      try {
-        const content = await _codeNeighborDeps.readFile(join(scanWorkdir, srcFile));
-        if (content.includes(fileBaseName)) {
-          for (const spec of parseImportSpecifiers(content)) {
-            const resolved = resolveImport(spec, srcFile, scanWorkdir);
-            if (resolved === filePath || resolved === fileNoExt) {
-              neighbors.add(srcFile);
-              break;
-            }
+      const content = await readCached(join(scanWorkdir, srcFile), contentCache);
+      if (content !== null && content.includes(fileBaseName)) {
+        for (const spec of parseImportSpecifiers(content)) {
+          const resolved = resolveImport(spec, srcFile, scanWorkdir);
+          if (resolved === filePath || resolved === fileNoExt) {
+            neighbors.add(srcFile);
+            break;
           }
         }
-      } catch {
-        // Skip unreadable files
       }
-    }
-  };
-
-  await scanForReverseDeps(workdir);
-
-  // AC-62: cross-package reverse deps — scan each extra workdir (workspace packages)
-  if (extraGlobWorkdirs) {
-    for (const extraDir of extraGlobWorkdirs) {
-      if (neighbors.size >= MAX_NEIGHBORS_PER_FILE) break;
-      await scanForReverseDeps(extraDir);
     }
   }
 
@@ -532,18 +563,29 @@ export class CodeNeighborProvider implements IContextProvider {
     const sourceGlob = await resolveSourceGlob(this.sourceGlobOverride, request.packageDir);
     const globCtx = { storyId: request.storyId, packageDir: request.packageDir };
 
+    // Hoist the reverse-dep glob scan outside the per-file loop so we never
+    // re-glob the same directory N times (once per touched file). A shared
+    // content cache further ensures each candidate file is read at most once
+    // across all touched files in this fetch() call.
+    const scannedDirs: ScannedDir[] = [
+      scanDirectory(sourceGlob, workdir, ignoreMatchers, this.maxGlobFiles, globCtx),
+    ];
+    if (extraGlobWorkdirs) {
+      for (const extraDir of extraGlobWorkdirs) {
+        scannedDirs.push(scanDirectory(sourceGlob, extraDir, ignoreMatchers, this.maxGlobFiles, globCtx));
+      }
+    }
+    const contentCache = new Map<string, string>();
+
     const sections: string[] = [];
     let anyTruncated = false;
     for (const file of filesToProcess) {
       const { neighbors, truncated } = await collectNeighbors(
         file,
         workdir,
-        sourceGlob,
-        this.maxGlobFiles,
-        extraGlobWorkdirs,
+        scannedDirs,
+        contentCache,
         siblingTestContext,
-        ignoreMatchers,
-        globCtx,
       );
       if (truncated) anyTruncated = true;
       if (neighbors.length > 0) {

--- a/src/context/engine/providers/git-history.ts
+++ b/src/context/engine/providers/git-history.ts
@@ -105,9 +105,9 @@ export class GitHistoryProvider implements IContextProvider {
 
     const filesToProcess = touchedFiles.filter(isRelativeAndSafe).slice(0, MAX_FILES);
 
-    const sections = (
-      await Promise.all(filesToProcess.map((file) => fetchFileHistory(file, workdir)))
-    ).filter((section): section is string => section !== null);
+    const sections = (await Promise.all(filesToProcess.map((file) => fetchFileHistory(file, workdir)))).filter(
+      (section): section is string => section !== null,
+    );
 
     if (sections.length === 0) {
       return { chunks: [], pullTools: [] };

--- a/src/context/engine/providers/git-history.ts
+++ b/src/context/engine/providers/git-history.ts
@@ -105,11 +105,9 @@ export class GitHistoryProvider implements IContextProvider {
 
     const filesToProcess = touchedFiles.filter(isRelativeAndSafe).slice(0, MAX_FILES);
 
-    const sections: string[] = [];
-    for (const file of filesToProcess) {
-      const section = await fetchFileHistory(file, workdir);
-      if (section) sections.push(section);
-    }
+    const sections = (
+      await Promise.all(filesToProcess.map((file) => fetchFileHistory(file, workdir)))
+    ).filter((section): section is string => section !== null);
 
     if (sections.length === 0) {
       return { chunks: [], pullTools: [] };

--- a/src/context/engine/types.ts
+++ b/src/context/engine/types.ts
@@ -550,5 +550,5 @@ export interface IContextProvider {
    * share provider instances across parallel stories. Implementations must not
    * rely on per-call mutable state on the provider instance.
    */
-  fetch(request: ContextRequest): Promise<ContextProviderResult>;
+  fetch(request: ContextRequest, signal?: AbortSignal): Promise<ContextProviderResult>;
 }

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -10,9 +10,6 @@
 
 import { resolveDefaultAgent } from "../../agents";
 import type { IAgentManager } from "../../agents";
-import { clearLanguageCache } from "../../project/detector";
-import { clearWorkspaceCache } from "../../test-runners/detect/workspace";
-import { clearGitRootCache } from "../../verification/smart-runner";
 import type { NaxConfig } from "../../config";
 import { fireHook } from "../../hooks/runner";
 import type { HooksConfig } from "../../hooks/types";
@@ -22,9 +19,12 @@ import { deriveRunFallbackAggregates, saveRunMetrics } from "../../metrics";
 import { pipelineEventBus } from "../../pipeline/event-bus";
 import { countStories, isComplete, isStalled } from "../../prd";
 import type { PRD } from "../../prd";
+import { clearLanguageCache } from "../../project/detector";
 import type { DispatchContext } from "../../runtime/dispatch-context";
 import type { ISessionManager } from "../../session";
 import { purgeStaleScratch } from "../../session/scratch-purge";
+import { clearWorkspaceCache } from "../../test-runners/detect/workspace";
+import { clearGitRootCache } from "../../verification/smart-runner";
 import type { DeferredReviewResult } from "../deferred-review";
 import { closeAllRunSessions } from "../session-manager-runtime";
 import type { StatusWriter } from "../status-writer";

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -10,6 +10,8 @@
 
 import { resolveDefaultAgent } from "../../agents";
 import type { IAgentManager } from "../../agents";
+import { clearLanguageCache } from "../../project/detector";
+import { clearWorkspaceCache } from "../../test-runners/detect/workspace";
 import type { NaxConfig } from "../../config";
 import { fireHook } from "../../hooks/runner";
 import type { HooksConfig } from "../../hooks/types";
@@ -327,6 +329,10 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
   if (options.pluginProviderCache) {
     await options.pluginProviderCache.disposeAll();
   }
+
+  // Clear per-run detection memos so subsequent runs in the same process start fresh.
+  clearLanguageCache();
+  clearWorkspaceCache();
 
   // Compute final story counts before emitting completion event (RL-002)
   const finalCounts = countStories(prd);

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -12,6 +12,7 @@ import { resolveDefaultAgent } from "../../agents";
 import type { IAgentManager } from "../../agents";
 import { clearLanguageCache } from "../../project/detector";
 import { clearWorkspaceCache } from "../../test-runners/detect/workspace";
+import { clearGitRootCache } from "../../verification/smart-runner";
 import type { NaxConfig } from "../../config";
 import { fireHook } from "../../hooks/runner";
 import type { HooksConfig } from "../../hooks/types";
@@ -333,6 +334,7 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
   // Clear per-run detection memos so subsequent runs in the same process start fresh.
   clearLanguageCache();
   clearWorkspaceCache();
+  clearGitRootCache();
 
   // Compute final story counts before emitting completion event (RL-002)
   const finalCounts = countStories(prd);

--- a/src/execution/parallel-worker.ts
+++ b/src/execution/parallel-worker.ts
@@ -10,11 +10,24 @@ import { runPipeline } from "../pipeline/runner";
 import type { PipelineRunResult } from "../pipeline/runner";
 import { defaultPipeline } from "../pipeline/stages";
 import type { PipelineContext, RoutingResult } from "../pipeline/types";
-import type { UserStory } from "../prd";
+import type { PRD, UserStory } from "../prd";
 import { routeTask } from "../routing";
 import { errorMessage } from "../utils/errors";
 import { captureGitRef, isGitRefValid } from "../utils/git";
 import type { WorktreeDependencyContext } from "../worktree/types";
+
+/**
+ * Build the per-story pipeline context for a worktree run.
+ * Deep-clones `prd` so concurrent stories never mutate a shared object.
+ * Inherits `skipPrdPersistence` from the base (set by the executor) so the
+ * unified executor is the single PRD writer after the batch (CR-1/H-1).
+ */
+export function buildWorktreePipelineContext(
+  base: Omit<PipelineContext, "story" | "stories" | "workdir" | "routing" | "storyGitRef">,
+  _story: UserStory,
+): Omit<PipelineContext, "story" | "stories" | "workdir" | "routing" | "storyGitRef"> {
+  return { ...base, prd: structuredClone(base.prd) as PRD };
+}
 
 export const _parallelWorkerDeps = {
   routeTask,
@@ -50,7 +63,7 @@ export async function executeStoryInWorktree(
     }
 
     const pipelineContext: PipelineContext = {
-      ...context,
+      ...buildWorktreePipelineContext(context, story),
       config: context.config,
       rootConfig: context.rootConfig,
       story,

--- a/src/execution/pid-registry.ts
+++ b/src/execution/pid-registry.ts
@@ -2,6 +2,7 @@
 
 import { existsSync } from "node:fs";
 import { getSafeLogger } from "@/logger";
+import { errorMessage } from "@/utils/errors";
 
 const PID_REGISTRY_FILE = ".nax-pids";
 const PID_TREE_KILL_GRACE_MS = 250;
@@ -374,7 +375,13 @@ export class PidRegistry {
   }
 
   private enqueueWrite(): Promise<void> {
-    this.writeQueueTail = this.writeQueueTail.then(() => this.writePidsFile());
+    this.writeQueueTail = this.writeQueueTail.then(() =>
+      this.writePidsFile().catch((err) => {
+        getSafeLogger()?.warn("pid-registry", "Failed to flush PID file — on-disk registry may be stale", {
+          error: errorMessage(err),
+        });
+      }),
+    );
     return this.writeQueueTail;
   }
 }

--- a/src/execution/pid-registry.ts
+++ b/src/execution/pid-registry.ts
@@ -1,7 +1,6 @@
 /** Track spawned agent PIDs and clean them up on crash without process-group kills. */
 
 import { existsSync } from "node:fs";
-import { appendFile } from "node:fs/promises";
 import { getSafeLogger } from "@/logger";
 
 const PID_REGISTRY_FILE = ".nax-pids";
@@ -29,6 +28,7 @@ export class PidRegistry {
   private readonly pidsFilePath: string;
   private readonly pids: Set<number> = new Set();
   private frozen = false;
+  private writeQueueTail: Promise<void> = Promise.resolve();
 
   constructor(workdir: string, _platform?: NodeJS.Platform) {
     this.workdir = workdir;
@@ -53,15 +53,8 @@ export class PidRegistry {
     }
     this.pids.add(pid);
 
-    const entry: PidEntry = {
-      pid,
-      spawnedAt: new Date().toISOString(),
-      workdir: this.workdir,
-    };
-
     try {
-      const line = `${JSON.stringify(entry)}\n`;
-      await appendFile(this.pidsFilePath, line);
+      await this.enqueueWrite();
       logger?.debug("pid-registry", `Registered PID ${pid}`, { pid });
     } catch (err) {
       logger?.warn("pid-registry", `Failed to write PID ${pid} to registry`, {
@@ -75,7 +68,7 @@ export class PidRegistry {
     this.pids.delete(pid);
 
     try {
-      await this.writePidsFile();
+      await this.enqueueWrite();
       logger?.debug("pid-registry", `Unregistered PID ${pid}`, { pid });
     } catch (err) {
       logger?.warn("pid-registry", `Failed to unregister PID ${pid}`, {
@@ -99,8 +92,8 @@ export class PidRegistry {
     await Promise.allSettled(killPromises);
 
     try {
-      await Bun.write(this.pidsFilePath, "");
       this.pids.clear();
+      await this.enqueueWrite();
       logger?.info("pid-registry", "All registered PIDs killed and registry cleared");
     } catch (err) {
       logger?.warn("pid-registry", "Failed to clear registry file", {
@@ -347,5 +340,41 @@ export class PidRegistry {
 
   getPids(): number[] {
     return Array.from(this.pids);
+  }
+
+  /** Returns the current in-memory PID set as an array. */
+  snapshot(): number[] {
+    return Array.from(this.pids);
+  }
+
+  /** Wait for all pending disk writes to complete. */
+  async flush(): Promise<void> {
+    await this.writeQueueTail;
+  }
+
+  /** Read PIDs from disk. Useful for testing consistency between disk and in-memory state. */
+  async readPidsFromDisk(): Promise<number[]> {
+    try {
+      if (!existsSync(this.pidsFilePath)) return [];
+      const content = await Bun.file(this.pidsFilePath).text();
+      return content
+        .split("\n")
+        .filter((line) => line.trim())
+        .map((line) => {
+          try {
+            return (JSON.parse(line) as PidEntry).pid;
+          } catch {
+            return null;
+          }
+        })
+        .filter((pid): pid is number => pid !== null);
+    } catch {
+      return [];
+    }
+  }
+
+  private enqueueWrite(): Promise<void> {
+    this.writeQueueTail = this.writeQueueTail.then(() => this.writePidsFile());
+    return this.writeQueueTail;
   }
 }

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -248,6 +248,7 @@ export async function executeUnified(
                 config: ctx.config,
                 rootConfig: ctx.config,
                 prd,
+                skipPrdPersistence: true, // CR-1: worktree pipelines must not persist PRD
                 projectDir: ctx.workdir,
                 naxIgnoreIndex,
                 hooks: ctx.hooks,

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -13,7 +13,7 @@ import { wireInteraction } from "../pipeline/subscribers/interaction";
 import { wireRegistry } from "../pipeline/subscribers/registry";
 import { wireReporters } from "../pipeline/subscribers/reporters";
 import type { PipelineContext } from "../pipeline/types";
-import { countStories, isComplete, isStalled, loadPRD } from "../prd";
+import { countStories, isComplete, isStalled, loadPRD, markStoryFailed, markStoryPassed, savePRD } from "../prd";
 import type { PRD } from "../prd/types";
 import { buildNaxIgnoreIndex } from "../utils/path-filters";
 import { precomputeBatchPlan } from "./batching";
@@ -301,6 +301,11 @@ export async function executeUnified(
               pipelineResult,
             );
           }
+
+          // Single-writer PRD reconciliation (H-1): worktree pipelines skipped
+          // persistence, so record completed + merge-conflict outcomes here.
+          reconcileBatchOutcome(prd, batchResult);
+          await savePRD(prd, ctx.prdPath);
 
           await pipelineEventBus.drain();
           totalCost += batchResult.totalCost;
@@ -614,6 +619,32 @@ export async function executeUnified(
     // regression gate and exit summary — those run AFTER executeUnified returns.
     // stopHeartbeat() is called by runner.ts:finally (catches all exit paths)
     // and by runner-completion.ts after handleRunCompletion().
+  }
+}
+
+/**
+ * Single-writer reconciliation of a parallel batch outcome onto the in-memory PRD.
+ * Worktree pipelines no longer persist PRD (skipPrdPersistence), so the executor
+ * is the authority for:
+ *   - completed       → passed
+ *   - mergeConflicts  → passed iff rectified, else failed
+ * FAILED stories are intentionally NOT handled here — handlePipelineFailure
+ * (pipeline-result-handler.ts) already marks + saves them; touching them again
+ * double-increments attempts.
+ */
+export function reconcileBatchOutcome(
+  prd: PRD,
+  batchResult: Pick<RunParallelBatchResult, "completed" | "mergeConflicts">,
+): void {
+  for (const story of batchResult.completed) {
+    markStoryPassed(prd, story.id);
+  }
+  for (const conflict of batchResult.mergeConflicts) {
+    if (conflict.rectified) {
+      markStoryPassed(prd, conflict.story.id);
+    } else {
+      markStoryFailed(prd, conflict.story.id, undefined, "merge-conflict");
+    }
   }
 }
 

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from "node:fs";
 import { appendFile } from "node:fs/promises";
 import { type FormatterOptions, type VerbosityMode, formatLogEntry } from "../logging/index.js";
 import { formatConsole, formatJsonl } from "./formatters.js";
+import { redactSecrets } from "./redact.js";
 import type { LogEntry, LogLevel, LoggerOptions, StoryLogger } from "./types.js";
 
 /**
@@ -164,7 +165,10 @@ export class Logger {
    */
   private writeToFile(entry: LogEntry): void {
     if (!this.filePath) return;
-    const line = `${formatJsonl(entry)}\n`;
+    const safeEntry = entry.data
+      ? { ...entry, data: redactSecrets(entry.data) as Record<string, unknown> }
+      : entry;
+    const line = `${formatJsonl(safeEntry)}\n`;
     const filePath = this.filePath;
     this.writeQueueTail = this.writeQueueTail.then(() =>
       appendFile(filePath, line).catch((error) => {

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -165,9 +165,7 @@ export class Logger {
    */
   private writeToFile(entry: LogEntry): void {
     if (!this.filePath) return;
-    const safeEntry = entry.data
-      ? { ...entry, data: redactSecrets(entry.data) as Record<string, unknown> }
-      : entry;
+    const safeEntry = entry.data ? { ...entry, data: redactSecrets(entry.data) as Record<string, unknown> } : entry;
     const line = `${formatJsonl(safeEntry)}\n`;
     const filePath = this.filePath;
     this.writeQueueTail = this.writeQueueTail.then(() =>

--- a/src/logger/redact.ts
+++ b/src/logger/redact.ts
@@ -8,8 +8,7 @@
  *     are scanned for token-shaped substrings (API keys, PATs, etc.).
  */
 
-const SECRET_KEY_PATTERN =
-  /(SECRET|TOKEN|API_?KEY|PASSWORD|PRIVATE_?KEY|ACCESS_?KEY|WEBHOOK)/i;
+const SECRET_KEY_PATTERN = /(SECRET|TOKEN|API_?KEY|PASSWORD|PRIVATE_?KEY|ACCESS_?KEY|WEBHOOK)/i;
 
 /**
  * Patterns are reset via `re.lastIndex = 0` before every call because they carry

--- a/src/logger/redact.ts
+++ b/src/logger/redact.ts
@@ -1,0 +1,59 @@
+/**
+ * Secret-redaction helper for the JSONL logger write path.
+ *
+ * Two layers of protection:
+ *  1. Key-based: any field whose name matches SECRET_KEY_PATTERN gets its value
+ *     replaced with "[REDACTED]" regardless of content.
+ *  2. Pattern-based: free-text strings (in values that did NOT trigger layer 1)
+ *     are scanned for token-shaped substrings (API keys, PATs, etc.).
+ */
+
+const SECRET_KEY_PATTERN =
+  /(SECRET|TOKEN|API_?KEY|PASSWORD|PRIVATE_?KEY|ACCESS_?KEY|WEBHOOK)/i;
+
+/**
+ * Patterns are reset via `re.lastIndex = 0` before every call because they carry
+ * the `/g` flag (required for `String.replace`). Resetting prevents the stale
+ * `lastIndex` bug that skips matches on subsequent calls.
+ */
+const SECRET_VALUE_PATTERNS: RegExp[] = [
+  /sk-[A-Za-z0-9_-]{16,}/g,
+  /ghp_[A-Za-z0-9]{16,}/g,
+  /gh[opsu]_[A-Za-z0-9]{16,}/g,
+  /npm_[A-Za-z0-9]{8,}/g,
+  /AKIA[0-9A-Z]{16}/g,
+  /xox[baprs]-[A-Za-z0-9-]{10,}/g,
+  // KEY=value assignments inside strings (e.g. "NPM_TOKEN=somevalue")
+  /(?:SECRET|TOKEN|API_?KEY|PASSWORD|PRIVATE_?KEY|ACCESS_?KEY|WEBHOOK)=[^\s"',]+/gi,
+];
+
+const REDACTED = "[REDACTED]";
+
+function redactString(value: string): string {
+  let out = value;
+  for (const re of SECRET_VALUE_PATTERNS) {
+    re.lastIndex = 0;
+    out = out.replace(re, REDACTED);
+  }
+  return out;
+}
+
+/**
+ * Recursively walk `input` and return a new value with secrets removed.
+ * - Primitive non-strings are returned as-is.
+ * - Object keys matching SECRET_KEY_PATTERN → value replaced with "[REDACTED]".
+ * - String values (not key-redacted) → token-pattern scan.
+ * - Arrays and nested objects are walked recursively.
+ */
+export function redactSecrets(input: unknown): unknown {
+  if (typeof input === "string") return redactString(input);
+  if (Array.isArray(input)) return input.map(redactSecrets);
+  if (input !== null && typeof input === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+      out[key] = SECRET_KEY_PATTERN.test(key) ? REDACTED : redactSecrets(value);
+    }
+    return out;
+  }
+  return input;
+}

--- a/src/operations/lint-check.ts
+++ b/src/operations/lint-check.ts
@@ -52,6 +52,7 @@ export const lintCheckOp: DeterministicOperation<LintCheckInput, LintCheckOutput
       command: command ?? "",
       workdir: input.workdir,
       storyId: input.storyId,
+      stripEnvVars: ctxConfig?.quality?.stripEnvVars ?? [],
     });
 
     if (result.exitCode === 0) {

--- a/src/operations/mechanical-formatfix-strategy.ts
+++ b/src/operations/mechanical-formatfix-strategy.ts
@@ -67,6 +67,7 @@ const mechanicalFormatFixOp: DeterministicOperation<
       command,
       workdir: input.workdir,
       storyId: input.storyId,
+      stripEnvVars: ctxConfig?.quality?.stripEnvVars ?? [],
     });
     return { applied: true, exitCode: result.exitCode };
   },

--- a/src/operations/mechanical-lintfix-strategy.ts
+++ b/src/operations/mechanical-lintfix-strategy.ts
@@ -63,6 +63,7 @@ const mechanicalLintFixOp: DeterministicOperation<MechanicalLintFixInput, Mechan
       command,
       workdir: input.workdir,
       storyId: input.storyId,
+      stripEnvVars: ctxConfig?.quality?.stripEnvVars ?? [],
     });
     return { applied: true, exitCode: result.exitCode };
   },

--- a/src/operations/typecheck-check.ts
+++ b/src/operations/typecheck-check.ts
@@ -56,6 +56,7 @@ export const typecheckCheckOp: DeterministicOperation<TypecheckCheckInput, Typec
       command: command ?? "",
       workdir: input.workdir,
       storyId: input.storyId,
+      stripEnvVars: ctxConfig?.quality?.stripEnvVars ?? [],
     });
 
     if (result.exitCode === 0) {

--- a/src/pipeline/stages/completion.ts
+++ b/src/pipeline/stages/completion.ts
@@ -31,6 +31,10 @@ export const completionStage: PipelineStage = {
     const logger = getLogger();
     const isBatch = ctx.stories.length > 1;
     const sessionCost = ctx.agentResult?.estimatedCostUsd || 0;
+    // In parallel worktree mode, a shared PRD and prd.json file is managed by the
+    // unified executor. Worktree pipelines must not race on it — skip both the in-memory
+    // mutation and the disk write when skipPrdPersistence is set.
+    const persistPrd = ctx.skipPrdPersistence !== true;
 
     // Calculate PRD path — prefer ctx.prdPath (already resolved by runner), fall back to
     // featureDir reconstruction, with a last-resort for contexts where neither is set (e.g. tests).
@@ -64,9 +68,11 @@ export const completionStage: PipelineStage = {
       }
     }
 
-    // Mark all stories in batch as passed
+    // Mark all stories in batch as passed (skipped in parallel worktree mode)
     for (const completedStory of ctx.stories) {
-      markStoryPassed(ctx.prd, completedStory.id);
+      if (persistPrd) {
+        markStoryPassed(ctx.prd, completedStory.id);
+      }
 
       const costPerStory = sessionCost / ctx.stories.length;
       logger.info("completion", "Story passed", {
@@ -118,8 +124,10 @@ export const completionStage: PipelineStage = {
       // Verdict is now written by the execution stage directly when available.
     }
 
-    // Save PRD
-    await _completionDeps.savePRD(ctx.prd, prdPath);
+    // Save PRD (skipped in parallel worktree mode — unified executor is the single writer)
+    if (persistPrd) {
+      await _completionDeps.savePRD(ctx.prd, prdPath);
+    }
 
     // Display progress
     const updatedCounts = countStories(ctx.prd);

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -98,6 +98,13 @@ export interface PipelineContext extends DispatchContext {
   worktreeDependencyContext?: import("../worktree/types").WorktreeDependencyContext;
   /** Absolute path to the prd.json file (used by routing stage to persist initial classification) */
   prdPath?: string;
+  /**
+   * When true, the completion stage must NOT mutate or save the shared PRD.
+   * Set by the parallel batch orchestrator so concurrent worktree pipelines
+   * do not race on the shared `prd` object or `prd.json` file. The unified
+   * executor becomes the single PRD writer after the batch (see plan A4).
+   */
+  skipPrdPersistence?: boolean;
   /** Feature directory (optional, e.g., nax/features/my-feature/) */
   featureDir?: string;
   /** Hooks configuration */

--- a/src/project/detector.ts
+++ b/src/project/detector.ts
@@ -104,17 +104,30 @@ async function detectTestFramework(
   return undefined;
 }
 
+// ── Language Detection Memo ───────────────────────────────────────────────────
+
+const _languageCache = new Map<string, ProjectProfile["language"] | undefined>();
+
+/** Clear the language-detection memo. Call in test teardown for isolation. */
+export function clearLanguageCache(): void {
+  _languageCache.clear();
+}
+
 // ── Public API (Language Detection) ───────────────────────────────────────────
 
 /**
- * Detect the language of a package directory.
+ * Detect the language of a package directory (memoized per process).
  *
  * Detection priority: Go > Rust > Python > TypeScript > JavaScript.
  * Returns `undefined` if no language markers are found.
+ * Call `clearLanguageCache()` in test teardown to reset the memo.
  */
 export async function detectLanguage(packageDir: string): Promise<ProjectProfile["language"] | undefined> {
+  if (_languageCache.has(packageDir)) return _languageCache.get(packageDir);
   const pkg = await _detectorDeps.readJson(join(packageDir, "package.json"));
-  return _detectLanguageImpl(packageDir, pkg);
+  const result = await _detectLanguageImpl(packageDir, pkg);
+  _languageCache.set(packageDir, result);
+  return result;
 }
 
 // ── lintTool inference ────────────────────────────────────────────────────────

--- a/src/quality/runner.ts
+++ b/src/quality/runner.ts
@@ -34,6 +34,8 @@ export interface QualityCommandOptions {
   timeoutMs?: number;
   /** Optional environment overrides for the spawned process. */
   env?: Record<string, string | undefined>;
+  /** Secret env var names to strip before spawning the shell command. */
+  stripEnvVars?: string[];
 }
 
 export interface QualityCommandResult {
@@ -79,13 +81,21 @@ function createDrainDeadline(deadlineMs: number): { promise: Promise<string>; ca
  * to avoid deadlocking on output larger than the OS pipe buffer (~64 KB).
  */
 export async function runQualityCommand(opts: QualityCommandOptions): Promise<QualityCommandResult> {
-  const { commandName, command, workdir, storyId, timeoutMs = DEFAULT_TIMEOUT_MS, env } = opts;
+  const { commandName, command, workdir, storyId, timeoutMs = DEFAULT_TIMEOUT_MS, env, stripEnvVars } = opts;
   const startTime = Date.now();
   const logger = getSafeLogger();
 
   logger?.info("quality", `Running ${commandName}`, { storyId, commandName, command, workdir });
 
   try {
+    // Build the base env, stripping any configured secret vars before spawning.
+    const baseEnv: Record<string, string | undefined> = {
+      ...(process.env as Record<string, string | undefined>),
+    };
+    for (const key of stripEnvVars ?? []) {
+      delete baseEnv[key];
+    }
+
     // Execute via shell to preserve quoting semantics of configured commands.
     // Splitting on whitespace loses quoted args and escaped spaces.
     const proc = _qualityRunnerDeps.spawn({
@@ -93,10 +103,7 @@ export async function runQualityCommand(opts: QualityCommandOptions): Promise<Qu
       cwd: workdir,
       stdout: "pipe",
       stderr: "pipe",
-      env: {
-        ...(process.env as Record<string, string | undefined>),
-        ...(env ?? {}),
-      },
+      env: { ...baseEnv, ...(env ?? {}) },
     });
 
     let timedOut = false;

--- a/src/review/runner.ts
+++ b/src/review/runner.ts
@@ -188,8 +188,9 @@ async function runCheck(
   workdir: string,
   storyId?: string,
   env?: Record<string, string | undefined>,
+  stripEnvVars?: string[],
 ): Promise<ReviewCheckResult> {
-  const result = await runQualityCommand({ commandName: check, command, workdir, storyId, env });
+  const result = await runQualityCommand({ commandName: check, command, workdir, storyId, env, stripEnvVars });
   return {
     check,
     command: result.command,
@@ -452,9 +453,14 @@ export async function runReview(opts: RunReviewOptions): Promise<ReviewResult> {
             story: story as UserStory | undefined,
             storyGitRef,
             env,
+            stripEnvVars: naxConfig?.quality?.stripEnvVars ?? [],
             naxIgnoreIndex,
           })
-        : normalizeMechanicalFindings(checkName, await runCheck(checkName, command, workdir, storyId, env), workdir);
+        : normalizeMechanicalFindings(
+            checkName,
+            await runCheck(checkName, command, workdir, storyId, env, naxConfig?.quality?.stripEnvVars ?? []),
+            workdir,
+          );
     checks.push(result);
 
     // Log outcome of mechanical checks (lint / typecheck / build).

--- a/src/review/scoped-lint.ts
+++ b/src/review/scoped-lint.ts
@@ -26,6 +26,8 @@ interface ScopedLintArgs {
   story?: UserStory;
   storyGitRef?: string;
   env?: Record<string, string | undefined>;
+  /** Secret env var names to strip before spawning the lint command. */
+  stripEnvVars?: string[];
   naxIgnoreIndex?: NaxIgnoreIndex;
   scope?: AutofixLintScope;
 }
@@ -170,6 +172,7 @@ async function runLintCommand(
   storyId: string | undefined,
   env: Record<string, string | undefined> | undefined,
   command: string,
+  stripEnvVars?: string[],
 ): Promise<QualityCommandResult> {
   return runQualityCommand({
     commandName: SCOPED_LINT_CHECK,
@@ -177,6 +180,7 @@ async function runLintCommand(
     workdir,
     storyId,
     env,
+    stripEnvVars,
   });
 }
 
@@ -228,7 +232,7 @@ export async function runScopedLintCheck(args: ScopedLintArgs): Promise<ReviewCh
         storyId: args.storyId,
         reason: scope.degradedReason,
       });
-      const fullResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, fullLintCommand);
+      const fullResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, fullLintCommand, args.stripEnvVars);
       return withLintScope(
         attachLintFindings(toReviewCheck(fullResult), args.lintOutputFormat, args.workdir),
         scope,
@@ -259,13 +263,13 @@ export async function runScopedLintCheck(args: ScopedLintArgs): Promise<ReviewCh
 
   if (scopedTemplate) {
     const scopedCommand = scopedTemplate.replaceAll("{{files}}", scope.files.map(shellQuotePath).join(" "));
-    const scopedResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, scopedCommand);
+    const scopedResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, scopedCommand, args.stripEnvVars);
     return withLintScope(attachLintFindings(toReviewCheck(scopedResult), args.lintOutputFormat, args.workdir), scope);
   }
 
   if (!scope.degradedReason && isSupportedDerivedScopedCommand(fullLintCommand)) {
     const scopedCommand = appendFilesToCommand(fullLintCommand, scope.files);
-    const scopedResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, scopedCommand);
+    const scopedResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, scopedCommand, args.stripEnvVars);
     return withLintScope(attachLintFindings(toReviewCheck(scopedResult), args.lintOutputFormat, args.workdir), scope);
   }
 
@@ -274,7 +278,7 @@ export async function runScopedLintCheck(args: ScopedLintArgs): Promise<ReviewCh
     storyId: args.storyId,
     reason: scope.degradedReason ?? "unsupported_scoped_command_shape",
   });
-  const fullResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, fullLintCommand);
+  const fullResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, fullLintCommand, args.stripEnvVars);
   if (fullResult.exitCode === 0) return withLintScope(toReviewCheck(fullResult), scope, "degraded");
 
   const parsed = parseLintOutput(fullResult.output, args.lintOutputFormat ?? "auto", {
@@ -332,6 +336,8 @@ export async function runAutofixLint(args: {
   projectDir?: string;
   storyId?: string;
   env?: Record<string, string | undefined>;
+  /** Secret env var names to strip before spawning the lint command. */
+  stripEnvVars?: string[];
   naxIgnoreIndex?: NaxIgnoreIndex;
   scope: AutofixLintScope;
 }): Promise<ReviewCheckResult> {

--- a/src/review/scoped-lint.ts
+++ b/src/review/scoped-lint.ts
@@ -232,7 +232,13 @@ export async function runScopedLintCheck(args: ScopedLintArgs): Promise<ReviewCh
         storyId: args.storyId,
         reason: scope.degradedReason,
       });
-      const fullResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, fullLintCommand, args.stripEnvVars);
+      const fullResult = await _scopedLintDeps.runLintCommand(
+        args.workdir,
+        args.storyId,
+        args.env,
+        fullLintCommand,
+        args.stripEnvVars,
+      );
       return withLintScope(
         attachLintFindings(toReviewCheck(fullResult), args.lintOutputFormat, args.workdir),
         scope,
@@ -263,13 +269,25 @@ export async function runScopedLintCheck(args: ScopedLintArgs): Promise<ReviewCh
 
   if (scopedTemplate) {
     const scopedCommand = scopedTemplate.replaceAll("{{files}}", scope.files.map(shellQuotePath).join(" "));
-    const scopedResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, scopedCommand, args.stripEnvVars);
+    const scopedResult = await _scopedLintDeps.runLintCommand(
+      args.workdir,
+      args.storyId,
+      args.env,
+      scopedCommand,
+      args.stripEnvVars,
+    );
     return withLintScope(attachLintFindings(toReviewCheck(scopedResult), args.lintOutputFormat, args.workdir), scope);
   }
 
   if (!scope.degradedReason && isSupportedDerivedScopedCommand(fullLintCommand)) {
     const scopedCommand = appendFilesToCommand(fullLintCommand, scope.files);
-    const scopedResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, scopedCommand, args.stripEnvVars);
+    const scopedResult = await _scopedLintDeps.runLintCommand(
+      args.workdir,
+      args.storyId,
+      args.env,
+      scopedCommand,
+      args.stripEnvVars,
+    );
     return withLintScope(attachLintFindings(toReviewCheck(scopedResult), args.lintOutputFormat, args.workdir), scope);
   }
 
@@ -278,7 +296,13 @@ export async function runScopedLintCheck(args: ScopedLintArgs): Promise<ReviewCh
     storyId: args.storyId,
     reason: scope.degradedReason ?? "unsupported_scoped_command_shape",
   });
-  const fullResult = await _scopedLintDeps.runLintCommand(args.workdir, args.storyId, args.env, fullLintCommand, args.stripEnvVars);
+  const fullResult = await _scopedLintDeps.runLintCommand(
+    args.workdir,
+    args.storyId,
+    args.env,
+    fullLintCommand,
+    args.stripEnvVars,
+  );
   if (fullResult.exitCode === 0) return withLintScope(toReviewCheck(fullResult), scope, "degraded");
 
   const parsed = parseLintOutput(fullResult.output, args.lintOutputFormat ?? "auto", {

--- a/src/test-runners/detect/workspace.ts
+++ b/src/test-runners/detect/workspace.ts
@@ -182,7 +182,7 @@ async function discoverWorkspacePackagesUncached(workdir: string): Promise<strin
  * Wraps `discoverWorkspacePackagesUncached` — same return value, cached after first call.
  */
 export async function discoverWorkspacePackages(workdir: string): Promise<string[]> {
-  if (_workspaceCache.has(workdir)) return _workspaceCache.get(workdir)!;
+  if (_workspaceCache.has(workdir)) return _workspaceCache.get(workdir) ?? [];
   const result = await discoverWorkspacePackagesUncached(workdir);
   _workspaceCache.set(workdir, result);
   return result;

--- a/src/test-runners/detect/workspace.ts
+++ b/src/test-runners/detect/workspace.ts
@@ -139,12 +139,22 @@ async function detectNaxMonoLayout(workdir: string): Promise<string[]> {
   return dirs;
 }
 
+// ── Workspace Discovery Memo ──────────────────────────────────────────────────
+
+const _workspaceCache = new Map<string, string[]>();
+
+/** Clear the workspace-discovery memo. Call in test teardown for isolation. */
+export function clearWorkspaceCache(): void {
+  _workspaceCache.clear();
+}
+
 /**
- * Discover all monorepo package directories in the given workdir.
+ * Discover all monorepo package directories in the given workdir (memoized per process).
  * Returns a deduplicated list of relative paths.
  * Returns empty array for single-package projects.
+ * Call `clearWorkspaceCache()` in test teardown to reset the memo.
  */
-export async function discoverWorkspacePackages(workdir: string): Promise<string[]> {
+async function discoverWorkspacePackagesUncached(workdir: string): Promise<string[]> {
   const [fromPnpm, fromNpm, fromLerna, fromTurboNx, fromNaxMono] = await Promise.all([
     detectPnpmWorkspace(workdir),
     detectNpmWorkspaces(workdir),
@@ -165,4 +175,15 @@ export async function discoverWorkspacePackages(workdir: string): Promise<string
   }
 
   return unique;
+}
+
+/**
+ * Discover all monorepo package directories in the given workdir (memoized per process).
+ * Wraps `discoverWorkspacePackagesUncached` — same return value, cached after first call.
+ */
+export async function discoverWorkspacePackages(workdir: string): Promise<string[]> {
+  if (_workspaceCache.has(workdir)) return _workspaceCache.get(workdir)!;
+  const result = await discoverWorkspacePackagesUncached(workdir);
+  _workspaceCache.set(workdir, result);
+  return result;
 }

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -41,6 +41,28 @@ export const _gitUtilDeps = {
   getGitRoot,
 };
 
+/** Per-process memo: workdir → resolved git root. Cleared at run end via clearGitRootCache(). */
+const _gitRootCache = new Map<string, string>();
+
+/**
+ * Clear the git-root memo cache.
+ * Called by run-completion.ts to reset state between runs in the same process.
+ */
+export function clearGitRootCache(): void {
+  _gitRootCache.clear();
+}
+
+/** Memoized git-root resolver — delegates to the injectable _gitUtilDeps.getGitRoot. */
+async function getGitRootMemo(workdir: string): Promise<string | null> {
+  const cached = _gitRootCache.get(workdir);
+  if (cached !== undefined) return cached;
+  const result = await _gitUtilDeps.getGitRoot(workdir);
+  if (result !== null && result !== undefined) {
+    _gitRootCache.set(workdir, result);
+  }
+  return result ?? null;
+}
+
 /**
  * Map source files to their corresponding test files.
  *
@@ -316,7 +338,7 @@ export async function getChangedNonTestFiles(
     // regardless of where the git root sits relative to the project root.
     let effectivePrefix = packagePrefix;
     if (packagePrefix && repoRoot) {
-      const gitRoot = await _gitUtilDeps.getGitRoot(workdir);
+      const gitRoot = await getGitRootMemo(workdir);
       const extraPrefix = gitRoot && gitRoot !== repoRoot ? relative(gitRoot, repoRoot) : "";
       effectivePrefix = extraPrefix ? `${extraPrefix}/${packagePrefix}` : packagePrefix;
     }
@@ -377,7 +399,7 @@ export async function getChangedTestFiles(
     // Issue #565: git diff paths are relative to the true git root, which may be an
     // ancestor of repoRoot. Compute the extra prefix so startsWith filtering works
     // regardless of where the git root sits relative to the project root.
-    const gitRoot = await _gitUtilDeps.getGitRoot(workdir);
+    const gitRoot = await getGitRootMemo(workdir);
     const extraPrefix = gitRoot && gitRoot !== repoRoot ? relative(gitRoot, repoRoot) : "";
     const effectivePrefix = packagePrefix
       ? extraPrefix

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -206,11 +206,10 @@ export async function mapSourceToTests(
       candidates.push(`${workdir}/${sourceWithoutExt}${suffix}`);
     }
 
-    for (const candidate of candidates) {
-      if (await _bunDeps.file(candidate).exists()) {
-        result.push(candidate);
-      }
-    }
+    const existsFlags = await Promise.all(candidates.map((c) => _bunDeps.file(c).exists()));
+    candidates.forEach((c, i) => {
+      if (existsFlags[i]) result.push(c);
+    });
   }
 
   return result;

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -11,6 +11,7 @@
  * classification is hard-filtered here. Everything else stays generic.
  */
 import { join, relative } from "node:path";
+import { getSafeLogger } from "../logger";
 import { DEFAULT_SEPARATED_TEST_DIRS, DEFAULT_TEST_FILE_PATTERNS } from "../test-runners/conventions";
 import { getGitRoot, gitWithTimeout } from "../utils/git";
 import { type NaxIgnoreIndex, filterNaxInternalPaths, resolveNaxIgnorePatterns } from "../utils/path-filters";
@@ -164,6 +165,9 @@ export async function importGrepFallback(
     for await (const file of g.scan(workdir)) {
       testFilePaths.push(`${workdir}/${file}`);
       if (testFilePaths.length >= MAX_GREP_TEST_FILES) {
+        getSafeLogger()?.debug("smart-runner", "import-grep glob cap reached — results truncated", {
+          cap: MAX_GREP_TEST_FILES,
+        });
         break outer;
       }
     }

--- a/src/verification/smart-runner.ts
+++ b/src/verification/smart-runner.ts
@@ -22,10 +22,13 @@ import { type NaxIgnoreIndex, filterNaxInternalPaths, resolveNaxIgnorePatterns }
  *
  * @internal
  */
-const _bunDeps = {
+export const _bunDeps = {
   glob: (p: string) => new Bun.Glob(p),
   file: (path: string) => Bun.file(path),
 };
+
+/** Cap on test files scanned by the import-grep fallback. */
+export const MAX_GREP_TEST_FILES = 200;
 
 /**
  * Injectable git utilities — defined before functions so getChangedTestFiles and
@@ -132,33 +135,30 @@ export async function importGrepFallback(
   // Collect search terms from all changed source files
   const searchTerms = sourceFiles.flatMap(extractSearchTerms);
 
-  // Scan all test files matching the configured patterns
+  // Scan all test files matching the configured patterns, capped at MAX_GREP_TEST_FILES
   const testFilePaths: string[] = [];
-  for (const pattern of testFilePatterns) {
-    const glob = _bunDeps.glob(pattern);
-    for await (const file of glob.scan(workdir)) {
+  outer: for (const pattern of testFilePatterns) {
+    const g = _bunDeps.glob(pattern);
+    for await (const file of g.scan(workdir)) {
       testFilePaths.push(`${workdir}/${file}`);
-    }
-  }
-
-  // Return test files that contain any of the search terms
-  const matched: string[] = [];
-  for (const testFile of testFilePaths) {
-    let content: string;
-    try {
-      content = await _bunDeps.file(testFile).text();
-    } catch {
-      continue;
-    }
-    for (const term of searchTerms) {
-      if (content.includes(term)) {
-        matched.push(testFile);
-        break;
+      if (testFilePaths.length >= MAX_GREP_TEST_FILES) {
+        break outer;
       }
     }
   }
 
-  return matched;
+  // Read all collected files concurrently and filter to those containing any search term
+  const results = await Promise.all(
+    testFilePaths.map(async (testFile) => {
+      try {
+        const content = await _bunDeps.file(testFile).text();
+        return searchTerms.some((t) => content.includes(t)) ? testFile : null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return results.filter((p): p is string => p !== null);
 }
 
 export async function mapSourceToTests(

--- a/test/unit/context/engine/providers/code-neighbor-scan-cost.test.ts
+++ b/test/unit/context/engine/providers/code-neighbor-scan-cost.test.ts
@@ -1,0 +1,129 @@
+/**
+ * CodeNeighborProvider — scan-cost test
+ *
+ * Verifies that the reverse-dep glob scan is performed once per fetch() call
+ * (not once per touched file) and that each candidate file is read at most once
+ * across the entire fetch(), regardless of how many touched files are processed.
+ *
+ * All I/O is intercepted via _codeNeighborDeps injection; no real filesystem access.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { CodeNeighborProvider, _codeNeighborDeps } from "../../../../../src/context/engine/providers/code-neighbor";
+import type { ContextRequest } from "../../../../../src/context/engine/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Saved originals
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origGlob: typeof _codeNeighborDeps.glob;
+let origReadFile: typeof _codeNeighborDeps.readFile;
+let origFileExists: typeof _codeNeighborDeps.fileExists;
+let origDetectLanguage: typeof _codeNeighborDeps.detectLanguage;
+let origDiscoverWorkspacePackages: typeof _codeNeighborDeps.discoverWorkspacePackages;
+
+beforeEach(() => {
+  origGlob = _codeNeighborDeps.glob;
+  origReadFile = _codeNeighborDeps.readFile;
+  origFileExists = _codeNeighborDeps.fileExists;
+  origDetectLanguage = _codeNeighborDeps.detectLanguage;
+  origDiscoverWorkspacePackages = _codeNeighborDeps.discoverWorkspacePackages;
+});
+
+afterEach(() => {
+  _codeNeighborDeps.glob = origGlob;
+  _codeNeighborDeps.readFile = origReadFile;
+  _codeNeighborDeps.fileExists = origFileExists;
+  _codeNeighborDeps.detectLanguage = origDetectLanguage;
+  _codeNeighborDeps.discoverWorkspacePackages = origDiscoverWorkspacePackages;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeRequest(overrides: Partial<ContextRequest> = {}): ContextRequest {
+  return {
+    storyId: "US-001",
+    repoRoot: "/repo",
+    packageDir: "/repo",
+    stage: "execution",
+    role: "implementer",
+    budgetTokens: 8_000,
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("CodeNeighborProvider — scan cost", () => {
+  test("reads each candidate source file at most once per fetch across multiple touched files", async () => {
+    // Three touched source files in the same package.
+    const touchedFiles = ["src/a.ts", "src/b.ts", "src/c.ts"];
+
+    // Two candidate files returned by the glob.
+    const candidateFiles = ["src/x.ts", "src/y.ts"];
+
+    // Track how many times each absolute path is read.
+    const reads = new Map<string, number>();
+
+    _codeNeighborDeps.detectLanguage = async () => "typescript";
+    _codeNeighborDeps.discoverWorkspacePackages = async () => [];
+
+    // Glob returns the same candidate list regardless of call count.
+    // We also count glob invocations to ensure it is called exactly once.
+    let globCallCount = 0;
+    _codeNeighborDeps.glob = (_pattern, _cwd, _ignore, _cap, _ctx) => {
+      globCallCount++;
+      return { files: candidateFiles, truncated: false };
+    };
+
+    // fileExists: touched files exist; candidates do not (simplifies sibling test logic).
+    _codeNeighborDeps.fileExists = async (p: string) => {
+      return touchedFiles.some((tf) => p.endsWith(tf));
+    };
+
+    // readFile: track read counts; return content with no imports so forward-dep
+    // and reverse-dep processing completes cleanly without adding neighbors.
+    _codeNeighborDeps.readFile = async (p: string) => {
+      reads.set(p, (reads.get(p) ?? 0) + 1);
+      // Return empty content — no imports, no reverse-dep matches.
+      return "";
+    };
+
+    const provider = new CodeNeighborProvider({ crossPackageDepth: 0 });
+    await provider.fetch(makeRequest({ touchedFiles }));
+
+    // Core assertion: each candidate file should be read at most once.
+    for (const [path, count] of reads) {
+      expect(count).toBeLessThanOrEqual(1);
+      void path; // suppress unused variable warning
+    }
+
+    // Bonus: the glob should have been called exactly once (hoisted outside loop).
+    expect(globCallCount).toBe(1);
+  });
+
+  test("glob count equals number of unique scan dirs (1 primary + N extra), not number of touched files", async () => {
+    const touchedFiles = ["src/a.ts", "src/b.ts", "src/c.ts", "src/d.ts", "src/e.ts"];
+
+    let globCallCount = 0;
+    _codeNeighborDeps.detectLanguage = async () => "typescript";
+    _codeNeighborDeps.discoverWorkspacePackages = async () => [];
+    _codeNeighborDeps.glob = () => {
+      globCallCount++;
+      return { files: [], truncated: false };
+    };
+    _codeNeighborDeps.fileExists = async () => false;
+    _codeNeighborDeps.readFile = async () => "";
+
+    const provider = new CodeNeighborProvider({ crossPackageDepth: 0 });
+    await provider.fetch(makeRequest({ touchedFiles }));
+
+    // With 5 touched files but crossPackageDepth=0, the glob must be called
+    // exactly once (one primary workdir scan), not 5 times.
+    expect(globCallCount).toBe(1);
+  });
+});

--- a/test/unit/context/engine/providers/git-history-parallel.test.ts
+++ b/test/unit/context/engine/providers/git-history-parallel.test.ts
@@ -1,0 +1,99 @@
+/**
+ * GitHistoryProvider — concurrency test
+ *
+ * Verifies that per-file git log calls are issued concurrently (Promise.all)
+ * rather than serially. All git calls are intercepted via _gitHistoryDeps injection.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { GitHistoryProvider, _gitHistoryDeps } from "../../../../../src/context/engine/providers/git-history";
+import type { ContextRequest } from "../../../../../src/context/engine/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Saved originals
+// ─────────────────────────────────────────────────────────────────────────────
+
+let origGitWithTimeout: typeof _gitHistoryDeps.gitWithTimeout;
+
+beforeEach(() => {
+  origGitWithTimeout = _gitHistoryDeps.gitWithTimeout;
+});
+
+afterEach(() => {
+  _gitHistoryDeps.gitWithTimeout = origGitWithTimeout;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeRequest(overrides: Partial<ContextRequest> = {}): ContextRequest {
+  return {
+    storyId: "US-001",
+    repoRoot: "/repo",
+    packageDir: "/repo",
+    stage: "execution",
+    role: "implementer",
+    budgetTokens: 8_000,
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("GitHistoryProvider — concurrency", () => {
+  test("fetches file history concurrently, not serially", async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    // Track how many git invocations are in-flight simultaneously.
+    // Each fake call bumps active on entry, defers, then decrements on resolution.
+    _gitHistoryDeps.gitWithTimeout = async (args: string[], _workdir: string) => {
+      active++;
+      if (active > maxActive) maxActive = active;
+      // Yield to the event loop so all concurrent calls can reach their peak
+      await Promise.resolve();
+      active--;
+      const fileArg = args[args.length - 1] ?? "file";
+      return { stdout: `abc1234 feat: change in ${fileArg}`, exitCode: 0 };
+    };
+
+    const provider = new GitHistoryProvider();
+    const result = await provider.fetch(
+      makeRequest({
+        touchedFiles: ["src/a.ts", "src/b.ts", "src/c.ts"],
+      }),
+    );
+
+    // All three files should have history sections in the output
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0].content).toContain("src/a.ts");
+    expect(result.chunks[0].content).toContain("src/b.ts");
+    expect(result.chunks[0].content).toContain("src/c.ts");
+
+    // Concurrency assertion — with Promise.all the 3 calls must overlap
+    expect(maxActive).toBeGreaterThan(1);
+  });
+
+  test("collects all file sections even when some files have no history", async () => {
+    _gitHistoryDeps.gitWithTimeout = async (args: string[], _workdir: string) => {
+      const fileArg = args[args.length - 1] ?? "";
+      if (fileArg === "src/b.ts") return { stdout: "", exitCode: 0 }; // no history
+      return { stdout: `abc1234 feat: change in ${fileArg}`, exitCode: 0 };
+    };
+
+    const provider = new GitHistoryProvider();
+    const result = await provider.fetch(
+      makeRequest({
+        touchedFiles: ["src/a.ts", "src/b.ts", "src/c.ts"],
+      }),
+    );
+
+    expect(result.chunks).toHaveLength(1);
+    expect(result.chunks[0].content).toContain("src/a.ts");
+    expect(result.chunks[0].content).not.toContain("src/b.ts");
+    expect(result.chunks[0].content).toContain("src/c.ts");
+  });
+});

--- a/test/unit/context/provider-timeout-abort.test.ts
+++ b/test/unit/context/provider-timeout-abort.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { fetchWithTimeout } from "../../../src/context/engine/orchestrator";
+
+describe("fetchWithTimeout", () => {
+  test("aborts the losing provider fetch when the timeout wins and does not throw unhandled", async () => {
+    let aborted = false;
+    const slowProvider = {
+      id: "slow",
+      fetch: (_req: any, signal?: AbortSignal) =>
+        new Promise((_res, rej) => {
+          signal?.addEventListener("abort", () => {
+            aborted = true;
+            rej(new Error("aborted"));
+          });
+          // never resolves on its own
+        }),
+    };
+    await expect(
+      fetchWithTimeout(slowProvider as any, {} as any, 20)
+    ).rejects.toThrow(/timed out/);
+    // Give the abort event a tick to fire
+    await new Promise((r) => setTimeout(r, 5));
+    expect(aborted).toBe(true);
+  });
+});

--- a/test/unit/execution/parallel-worker-isolation.test.ts
+++ b/test/unit/execution/parallel-worker-isolation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { buildWorktreePipelineContext } from "../../../src/execution/parallel-worker";
+
+describe("buildWorktreePipelineContext", () => {
+  test("deep-clones prd so concurrent stories never share one object", () => {
+    const base = {
+      prd: { feature: "f", userStories: [{ id: "US-001", status: "pending" }] },
+      skipPrdPersistence: true,
+    } as any;
+    const story = { id: "US-001", title: "t", status: "pending", attempts: 0, passes: false } as any;
+    const a = buildWorktreePipelineContext(base, story);
+    const b = buildWorktreePipelineContext(base, story);
+    expect(a.prd).not.toBe(base.prd);
+    expect(a.prd).not.toBe(b.prd);
+    expect(a.skipPrdPersistence).toBe(true); // inherited from base
+    // Mutating one story's clone must not affect the base
+    a.prd.userStories[0].status = "passed";
+    expect(base.prd.userStories[0].status).toBe("pending");
+  });
+});

--- a/test/unit/execution/pid-registry-serialization.test.ts
+++ b/test/unit/execution/pid-registry-serialization.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { cleanupTempDir, makeTempDir } from "../../helpers/temp";
+import { PidRegistry } from "../../../src/execution/pid-registry";
+
+describe("PidRegistry concurrent writes", () => {
+  test("interleaved register/unregister leave the file consistent with the live set", async () => {
+    const dir = makeTempDir("nax-pid-serial-test-");
+    try {
+      const reg = new PidRegistry(dir);
+      // Fire many concurrent register + unregister ops
+      await Promise.all([
+        reg.register(101),
+        reg.register(102),
+        reg.register(103),
+        reg.unregister(101),
+        reg.register(104),
+        reg.unregister(102),
+      ]);
+      await reg.flush(); // new API
+      const onDisk = await reg.readPidsFromDisk(); // new test helper
+      // Disk must match the in-memory set exactly (no orphaned/duplicate lines)
+      expect(new Set(onDisk)).toEqual(new Set(reg.snapshot()));
+    } finally {
+      cleanupTempDir(dir);
+    }
+  });
+});

--- a/test/unit/execution/unified-executor-reconcile.test.ts
+++ b/test/unit/execution/unified-executor-reconcile.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { reconcileBatchOutcome } from "../../../src/execution/unified-executor";
+import type { PRD } from "../../../src/prd/types";
+
+function prdWith(...ids: string[]): PRD {
+  return {
+    feature: "f",
+    userStories: ids.map((id) => ({ id, status: "pending", attempts: 0, passes: false, title: id })),
+  } as PRD;
+}
+
+describe("reconcileBatchOutcome (single PRD writer)", () => {
+  test("marks completed stories passed", () => {
+    const prd = prdWith("US-001", "US-002");
+    reconcileBatchOutcome(prd, {
+      completed: [{ id: "US-001", title: "t", status: "pending", attempts: 0, passes: false } as any],
+      mergeConflicts: [],
+    });
+    expect(prd.userStories.find((s) => s.id === "US-001")?.status).toBe("passed");
+    expect(prd.userStories.find((s) => s.id === "US-002")?.status).toBe("pending");
+  });
+
+  test("does NOT touch failed stories (handlePipelineFailure owns them — no double attempts++)", () => {
+    const prd = prdWith("US-001");
+    prd.userStories[0].attempts = 1;
+    reconcileBatchOutcome(prd, { completed: [], mergeConflicts: [] });
+    expect(prd.userStories[0].attempts).toBe(1);
+  });
+
+  test("marks unrectified merge conflicts failed", () => {
+    const prd = prdWith("US-001");
+    reconcileBatchOutcome(prd, {
+      completed: [],
+      mergeConflicts: [{ story: { id: "US-001" } as any, rectified: false, cost: 0 }],
+    });
+    expect(prd.userStories.find((s) => s.id === "US-001")?.status).toBe("failed");
+  });
+
+  test("marks rectified merge conflicts passed", () => {
+    const prd = prdWith("US-001");
+    reconcileBatchOutcome(prd, {
+      completed: [],
+      mergeConflicts: [{ story: { id: "US-001" } as any, rectified: true, cost: 0 }],
+    });
+    expect(prd.userStories.find((s) => s.id === "US-001")?.status).toBe("passed");
+  });
+});

--- a/test/unit/logger/logger-redaction.test.ts
+++ b/test/unit/logger/logger-redaction.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Logger, resetLogger } from "../../../src/logger/logger";
+import { makeTempDir, cleanupTempDir } from "../../helpers/temp";
+
+describe("logger redaction in JSONL output", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("nax-logger-redact-");
+    resetLogger();
+  });
+
+  afterEach(() => {
+    resetLogger();
+    cleanupTempDir(tempDir);
+  });
+
+  test("redacts secret key values from persisted log file", async () => {
+    const logPath = join(tempDir, "run.jsonl");
+    const logger = new Logger({ level: "info", filePath: logPath });
+
+    logger.info("test", "Running with credentials", {
+      storyId: "story-001",
+      GITHUB_TOKEN: "ghp_supersecrettoken1234567890",
+      note: "safe value",
+    });
+    await logger.flush();
+
+    const content = readFileSync(logPath, "utf8");
+    const entry = JSON.parse(content.trim());
+
+    expect(JSON.stringify(entry)).not.toContain("ghp_supersecrettoken1234567890");
+    expect(entry.data.GITHUB_TOKEN).toBe("[REDACTED]");
+    expect(entry.data.note).toBe("safe value");
+  });
+
+  test("redacts token-shaped substrings in free-text values", async () => {
+    const logPath = join(tempDir, "run.jsonl");
+    const logger = new Logger({ level: "info", filePath: logPath });
+
+    logger.info("test", "Output logged", {
+      storyId: "story-002",
+      output: "agent used sk-ant-aaaaaaaaaaaaaaaaaaa for the call",
+    });
+    await logger.flush();
+
+    const content = readFileSync(logPath, "utf8");
+    const entry = JSON.parse(content.trim());
+
+    expect(JSON.stringify(entry)).not.toContain("sk-ant-aaaaaaaaaaaaaaaaaaa");
+    expect(entry.data.output).toContain("[REDACTED]");
+  });
+
+  test("leaves non-secret fields intact", async () => {
+    const logPath = join(tempDir, "run.jsonl");
+    const logger = new Logger({ level: "info", filePath: logPath });
+
+    logger.info("test", "Normal log", {
+      storyId: "story-003",
+      count: 42,
+      message: "no secrets here",
+    });
+    await logger.flush();
+
+    const content = readFileSync(logPath, "utf8");
+    const entry = JSON.parse(content.trim());
+
+    expect(entry.data.count).toBe(42);
+    expect(entry.data.message).toBe("no secrets here");
+  });
+
+  test("redacts nested secret keys", async () => {
+    const logPath = join(tempDir, "run.jsonl");
+    const logger = new Logger({ level: "info", filePath: logPath });
+
+    logger.info("test", "Nested secrets", {
+      storyId: "story-004",
+      env: { AWS_SECRET_ACCESS_KEY: "AKIAsecret0000000000" },
+    });
+    await logger.flush();
+
+    const content = readFileSync(logPath, "utf8");
+    const entry = JSON.parse(content.trim());
+
+    expect(JSON.stringify(entry)).not.toContain("AKIAsecret0000000000");
+    expect(entry.data.env.AWS_SECRET_ACCESS_KEY).toBe("[REDACTED]");
+  });
+});

--- a/test/unit/logger/redact.test.ts
+++ b/test/unit/logger/redact.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { redactSecrets } from "../../../src/logger/redact";
+
+describe("redactSecrets", () => {
+  test("masks values of known secret keys", () => {
+    const out = redactSecrets({ AWS_SECRET_ACCESS_KEY: "AKIAabc123", note: "ok" }) as any;
+    expect(out.AWS_SECRET_ACCESS_KEY).toBe("[REDACTED]");
+    expect(out.note).toBe("ok");
+  });
+
+  test("masks token-shaped substrings in free text", () => {
+    const out = redactSecrets({
+      output: "using sk-ant-aaaaaaaaaaaaaaaaaaaa and ghp_bbbbbbbbbbbbbbbbbbbb",
+    }) as any;
+    expect(out.output).not.toContain("sk-ant-aaaaaaaaaaaaaaaaaaaa");
+    expect(out.output).not.toContain("ghp_bbbbbbbbbbbbbbbbbbbb");
+    expect(out.output).toContain("[REDACTED]");
+  });
+
+  test("recurses nested objects", () => {
+    const out = redactSecrets({ a: { GITHUB_TOKEN: "ghp_xxxxxxxxxxxxxxxxxxxx" } }) as any;
+    expect(JSON.stringify(out)).not.toContain("ghp_xxxxxxxxxxxxxxxxxxxx");
+  });
+
+  test("recurses arrays", () => {
+    const out = redactSecrets({ list: ["NPM_TOKEN=npm_yyyy"] }) as any;
+    expect(JSON.stringify(out)).not.toContain("npm_yyyy");
+  });
+
+  test("leaves non-secret values unchanged", () => {
+    const out = redactSecrets({ message: "hello world", count: 42 }) as any;
+    expect(out.message).toBe("hello world");
+    expect(out.count).toBe(42);
+  });
+});

--- a/test/unit/pipeline/stages/completion-skip-persistence.test.ts
+++ b/test/unit/pipeline/stages/completion-skip-persistence.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for skipPrdPersistence gate in completion stage (CR-1)
+ *
+ * Covers:
+ * - savePRD is NOT called when skipPrdPersistence is true (parallel worktree mode)
+ * - Story status is NOT mutated to "passed" when skipPrdPersistence is true
+ * - savePRD IS called and story IS marked passed when skipPrdPersistence is unset (serial mode)
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { _completionDeps, completionStage } from "../../../../src/pipeline/stages/completion";
+import type { PipelineContext } from "../../../../src/pipeline/types";
+import { makeNaxConfig, makePRD, makeStory } from "../../../helpers";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Save originals for restoration
+// ─────────────────────────────────────────────────────────────────────────────
+
+const origSavePRD = _completionDeps.savePRD;
+const origGetDiffText = _completionDeps.getDiffText;
+const origCheckReviewGate = _completionDeps.checkReviewGate;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeCtx(overrides: Partial<PipelineContext>): PipelineContext {
+  const story = makeStory({ id: "US-001", status: "in-progress" });
+  const prd = makePRD({ userStories: [story] });
+  return {
+    config: makeNaxConfig(),
+    rootConfig: makeNaxConfig(),
+    prd,
+    story,
+    stories: [story],
+    routing: { complexity: "simple", modelTier: "fast", testStrategy: "test-after", reasoning: "" },
+    workdir: "/tmp/x",
+    projectDir: "/tmp/x",
+    prdPath: "/tmp/x/prd.json",
+    agentResult: { success: true, estimatedCostUsd: 0.01, output: "", stderr: "", exitCode: 0, rateLimited: false },
+    hooks: {} as PipelineContext["hooks"],
+    storyStartTime: new Date().toISOString(),
+    ...overrides,
+  } as unknown as PipelineContext;
+}
+
+afterEach(() => {
+  _completionDeps.savePRD = origSavePRD;
+  _completionDeps.getDiffText = origGetDiffText;
+  _completionDeps.checkReviewGate = origCheckReviewGate;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// skipPrdPersistence tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("completionStage skipPrdPersistence", () => {
+  test("does NOT call savePRD when skipPrdPersistence is true", async () => {
+    const saveSpy = mock(async () => {});
+    _completionDeps.savePRD = saveSpy;
+    _completionDeps.getDiffText = mock(async () => "");
+    const ctx = makeCtx({ skipPrdPersistence: true });
+
+    await completionStage.execute(ctx);
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  test("does NOT mutate story status to passed when skipPrdPersistence is true", async () => {
+    _completionDeps.savePRD = mock(async () => {});
+    _completionDeps.getDiffText = mock(async () => "");
+    const ctx = makeCtx({ skipPrdPersistence: true });
+
+    await completionStage.execute(ctx);
+
+    // Shared PRD must not be mutated to "passed" by a parallel worktree pipeline
+    expect(ctx.prd.userStories[0].status).not.toBe("passed");
+  });
+
+  test("calls savePRD and marks story passed when skipPrdPersistence is unset (serial mode)", async () => {
+    const saveSpy = mock(async () => {});
+    _completionDeps.savePRD = saveSpy;
+    _completionDeps.getDiffText = mock(async () => "");
+    const ctx = makeCtx({});
+
+    await completionStage.execute(ctx);
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(ctx.prd.userStories[0].status).toBe("passed");
+  });
+
+  test("still returns { action: continue } when skipPrdPersistence is true", async () => {
+    _completionDeps.savePRD = mock(async () => {});
+    _completionDeps.getDiffText = mock(async () => "");
+    const ctx = makeCtx({ skipPrdPersistence: true });
+
+    const result = await completionStage.execute(ctx);
+
+    expect(result.action).toBe("continue");
+  });
+});

--- a/test/unit/project/detect-language-memo.test.ts
+++ b/test/unit/project/detect-language-memo.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for detectLanguage memoization (B1).
+ *
+ * Verifies that calling detectLanguage twice on the same directory
+ * returns the same cached reference (no second filesystem read).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { clearLanguageCache, detectLanguage, _detectorDeps } from "../../../src/project/detector";
+import { withTempDir } from "../../helpers/temp";
+
+describe("detectLanguage memoization", () => {
+  afterEach(() => clearLanguageCache());
+
+  test("returns the same reference for repeated calls on the same dir (cache hit)", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/package.json`, JSON.stringify({ name: "x", devDependencies: { typescript: "^5" } }));
+      const a = await detectLanguage(dir);
+      const b = await detectLanguage(dir);
+      // Same value
+      expect(b).toEqual(a);
+      // Same reference — proves the second call did NOT re-run detection
+      expect(b).toBe(a);
+    });
+  });
+
+  test("calls the underlying filesystem accessor only once per dir", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/package.json`, JSON.stringify({ name: "x", devDependencies: { typescript: "^5" } }));
+
+      let readCount = 0;
+      const originalReadJson = _detectorDeps.readJson;
+      _detectorDeps.readJson = async (path) => {
+        readCount++;
+        return originalReadJson(path);
+      };
+      try {
+        await detectLanguage(dir);
+        await detectLanguage(dir);
+        expect(readCount).toBe(1);
+      } finally {
+        _detectorDeps.readJson = originalReadJson;
+      }
+    });
+  });
+
+  test("different directories get independent cache entries", async () => {
+    await withTempDir(async (dir1) => {
+      await withTempDir(async (dir2) => {
+        await Bun.write(`${dir1}/package.json`, JSON.stringify({ name: "a", devDependencies: { typescript: "^5" } }));
+        await Bun.write(`${dir2}/go.mod`, "module example.com/b\n");
+        const lang1 = await detectLanguage(dir1);
+        const lang2 = await detectLanguage(dir2);
+        expect(lang1).toBe("typescript");
+        expect(lang2).toBe("go");
+      });
+    });
+  });
+
+  test("clearLanguageCache resets memo so next call re-detects", async () => {
+    await withTempDir(async (dir) => {
+      await Bun.write(`${dir}/package.json`, JSON.stringify({ name: "x", devDependencies: { typescript: "^5" } }));
+      const a = await detectLanguage(dir);
+
+      clearLanguageCache();
+
+      let readCount = 0;
+      const originalReadJson = _detectorDeps.readJson;
+      _detectorDeps.readJson = async (path) => {
+        readCount++;
+        return originalReadJson(path);
+      };
+      try {
+        const b = await detectLanguage(dir);
+        expect(readCount).toBe(1); // re-ran detection after cache clear
+        expect(b).toEqual(a);
+      } finally {
+        _detectorDeps.readJson = originalReadJson;
+      }
+    });
+  });
+});

--- a/test/unit/quality/runner-env-strip.test.ts
+++ b/test/unit/quality/runner-env-strip.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { runQualityCommand, _qualityRunnerDeps } from "../../../src/quality/runner";
+
+function makeEnvCapturingSpawn(exitCode: number): {
+  spawnMock: ReturnType<typeof mock>;
+  getLastEnv: () => Record<string, string | undefined>;
+} {
+  let lastEnv: Record<string, string | undefined> = {};
+  const spawnMock = mock((_args: unknown) => {
+    const args = _args as { env?: Record<string, string | undefined> };
+    lastEnv = args.env ?? {};
+    return {
+      exited: Promise.resolve(exitCode),
+      stdout: new ReadableStream({ start(c) { c.close(); } }),
+      stderr: new ReadableStream({ start(c) { c.close(); } }),
+      kill: mock(() => {}),
+    } as unknown as ReturnType<typeof Bun.spawn>;
+  });
+  return { spawnMock, getLastEnv: () => lastEnv };
+}
+
+describe("runQualityCommand env stripping", () => {
+  let originalSpawn: typeof _qualityRunnerDeps.spawn;
+
+  beforeEach(() => {
+    originalSpawn = _qualityRunnerDeps.spawn;
+  });
+
+  afterEach(() => {
+    _qualityRunnerDeps.spawn = originalSpawn;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.MY_VAR;
+  });
+
+  test("removes configured secret vars from the spawned env", async () => {
+    process.env.AWS_SECRET_ACCESS_KEY = "leak-me";
+    const { spawnMock, getLastEnv } = makeEnvCapturingSpawn(0);
+    _qualityRunnerDeps.spawn = spawnMock as unknown as typeof Bun.spawn;
+
+    await runQualityCommand({
+      commandName: "lint",
+      command: "true",
+      workdir: "/tmp",
+      stripEnvVars: ["AWS_SECRET_ACCESS_KEY"],
+    });
+
+    expect(getLastEnv()["AWS_SECRET_ACCESS_KEY"]).toBeUndefined();
+  });
+
+  test("passes env unchanged when no stripEnvVars provided", async () => {
+    process.env.MY_VAR = "keep-me";
+    const { spawnMock, getLastEnv } = makeEnvCapturingSpawn(0);
+    _qualityRunnerDeps.spawn = spawnMock as unknown as typeof Bun.spawn;
+
+    await runQualityCommand({
+      commandName: "lint",
+      command: "true",
+      workdir: "/tmp",
+    });
+
+    expect(getLastEnv()["MY_VAR"]).toBe("keep-me");
+  });
+
+  test("strips multiple vars when multiple are configured", async () => {
+    process.env.AWS_SECRET_ACCESS_KEY = "secret1";
+    process.env.MY_VAR = "secret2";
+    const { spawnMock, getLastEnv } = makeEnvCapturingSpawn(0);
+    _qualityRunnerDeps.spawn = spawnMock as unknown as typeof Bun.spawn;
+
+    await runQualityCommand({
+      commandName: "lint",
+      command: "true",
+      workdir: "/tmp",
+      stripEnvVars: ["AWS_SECRET_ACCESS_KEY", "MY_VAR"],
+    });
+
+    expect(getLastEnv()["AWS_SECRET_ACCESS_KEY"]).toBeUndefined();
+    expect(getLastEnv()["MY_VAR"]).toBeUndefined();
+  });
+
+  test("env override still applies after stripping", async () => {
+    process.env.AWS_SECRET_ACCESS_KEY = "leak-me";
+    const { spawnMock, getLastEnv } = makeEnvCapturingSpawn(0);
+    _qualityRunnerDeps.spawn = spawnMock as unknown as typeof Bun.spawn;
+
+    await runQualityCommand({
+      commandName: "lint",
+      command: "true",
+      workdir: "/tmp",
+      stripEnvVars: ["AWS_SECRET_ACCESS_KEY"],
+      env: { OVERRIDE_VAR: "override-value" },
+    });
+
+    expect(getLastEnv()["AWS_SECRET_ACCESS_KEY"]).toBeUndefined();
+    expect(getLastEnv()["OVERRIDE_VAR"]).toBe("override-value");
+  });
+});

--- a/test/unit/test-runners/workspace-memo.test.ts
+++ b/test/unit/test-runners/workspace-memo.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for discoverWorkspacePackages memoization (B1).
+ *
+ * Verifies that calling discoverWorkspacePackages twice on the same directory
+ * returns the same cached reference (no second filesystem read).
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  clearWorkspaceCache,
+  discoverWorkspacePackages,
+  _workspaceDeps,
+} from "../../../src/test-runners/detect/workspace";
+import { withTempDir } from "../../helpers/temp";
+
+describe("discoverWorkspacePackages memoization", () => {
+  afterEach(() => clearWorkspaceCache());
+
+  test("returns the same array reference for repeated calls on the same dir (cache hit)", async () => {
+    await withTempDir(async (dir) => {
+      const a = await discoverWorkspacePackages(dir);
+      const b = await discoverWorkspacePackages(dir);
+      // Same reference — proves second call served from cache
+      expect(b).toBe(a);
+    });
+  });
+
+  test("calls the underlying readText only once per dir", async () => {
+    await withTempDir(async (dir) => {
+      let readCount = 0;
+      const originalReadText = _workspaceDeps.readText;
+      _workspaceDeps.readText = async (path) => {
+        readCount++;
+        return originalReadText(path);
+      };
+      try {
+        await discoverWorkspacePackages(dir);
+        const countAfterFirst = readCount;
+        await discoverWorkspacePackages(dir);
+        // No additional reads on second call
+        expect(readCount).toBe(countAfterFirst);
+      } finally {
+        _workspaceDeps.readText = originalReadText;
+      }
+    });
+  });
+
+  test("different directories get independent cache entries", async () => {
+    await withTempDir(async (dir1) => {
+      await withTempDir(async (dir2) => {
+        const a = await discoverWorkspacePackages(dir1);
+        const b = await discoverWorkspacePackages(dir2);
+        // Both are arrays, independent references
+        expect(Array.isArray(a)).toBe(true);
+        expect(Array.isArray(b)).toBe(true);
+        // Second call on each still returns the cached reference
+        expect(await discoverWorkspacePackages(dir1)).toBe(a);
+        expect(await discoverWorkspacePackages(dir2)).toBe(b);
+      });
+    });
+  });
+
+  test("clearWorkspaceCache resets memo so next call re-runs detection", async () => {
+    await withTempDir(async (dir) => {
+      const a = await discoverWorkspacePackages(dir);
+
+      clearWorkspaceCache();
+
+      let readCount = 0;
+      const originalReadText = _workspaceDeps.readText;
+      _workspaceDeps.readText = async (path) => {
+        readCount++;
+        return originalReadText(path);
+      };
+      try {
+        const b = await discoverWorkspacePackages(dir);
+        expect(readCount).toBeGreaterThan(0); // re-ran detection after cache clear
+        expect(b).toEqual(a);
+      } finally {
+        _workspaceDeps.readText = originalReadText;
+      }
+    });
+  });
+});

--- a/test/unit/verification/git-root-memo.test.ts
+++ b/test/unit/verification/git-root-memo.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, mock, test } from "bun:test";
+import { _gitDeps } from "../../../src/utils/git";
+import {
+  getChangedTestFiles,
+  _gitUtilDeps,
+  clearGitRootCache,
+} from "../../../src/verification/smart-runner";
+
+function makeProc(stdout: string, exitCode: number) {
+  return {
+    exited: Promise.resolve(exitCode),
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(stdout));
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+  };
+}
+
+describe("git-root memoization", () => {
+  test("getGitRoot is computed once per workdir across multiple classifier calls", async () => {
+    clearGitRootCache();
+    let gitRootCalls = 0;
+    const origGetGitRoot = _gitUtilDeps.getGitRoot;
+    const origSpawn = _gitDeps.spawn;
+    _gitUtilDeps.getGitRoot = async (_workdir: string) => {
+      gitRootCalls++;
+      return "/repo";
+    };
+    // Make git diff succeed with empty output so we reach the getGitRoot call
+    _gitDeps.spawn = mock(() => makeProc("", 0)) as unknown as typeof _gitDeps.spawn;
+
+    try {
+      // Both calls use the same workdir — should only compute git root once
+      await getChangedTestFiles("/repo", "/repo", undefined, "packages/api", [/\.test\.ts$/]);
+      await getChangedTestFiles("/repo", "/repo", undefined, "packages/api", [/\.test\.ts$/]);
+      expect(gitRootCalls).toBeLessThanOrEqual(1);
+    } finally {
+      _gitUtilDeps.getGitRoot = origGetGitRoot;
+      _gitDeps.spawn = origSpawn;
+      clearGitRootCache();
+    }
+  });
+
+  test("clearGitRootCache resets the memo", async () => {
+    clearGitRootCache();
+    let callCount = 0;
+    const origGetGitRoot = _gitUtilDeps.getGitRoot;
+    const origSpawn = _gitDeps.spawn;
+    _gitUtilDeps.getGitRoot = async (_workdir: string) => {
+      callCount++;
+      return "/repo";
+    };
+    _gitDeps.spawn = mock(() => makeProc("", 0)) as unknown as typeof _gitDeps.spawn;
+
+    try {
+      // First call populates cache
+      await getChangedTestFiles("/repo", "/repo", undefined, "packages/api", [/\.test\.ts$/]);
+      expect(callCount).toBe(1);
+
+      // Clear the cache
+      clearGitRootCache();
+
+      // Next call should recompute
+      await getChangedTestFiles("/repo", "/repo", undefined, "packages/api", [/\.test\.ts$/]);
+      expect(callCount).toBe(2);
+    } finally {
+      _gitUtilDeps.getGitRoot = origGetGitRoot;
+      _gitDeps.spawn = origSpawn;
+      clearGitRootCache();
+    }
+  });
+});

--- a/test/unit/verification/import-grep-fallback.test.ts
+++ b/test/unit/verification/import-grep-fallback.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { importGrepFallback, _bunDeps, MAX_GREP_TEST_FILES } from "../../../src/verification/smart-runner";
+
+describe("importGrepFallback", () => {
+  test("caps the number of scanned test files at MAX_GREP_TEST_FILES", async () => {
+    const many = Array.from({ length: 1000 }, (_, i) => `test/a${i}.test.ts`);
+    // Patch glob to return 1000 files
+    const origGlob = _bunDeps.glob;
+    _bunDeps.glob = (() => ({
+      async *scan() { for (const f of many) yield f; }
+    })) as any;
+    let reads = 0;
+    const origFile = _bunDeps.file;
+    _bunDeps.file = ((p: string) => ({
+      async text() { reads++; return "needle"; },
+      async exists() { return true; },
+    })) as any;
+
+    try {
+      await importGrepFallback(["src/x.ts"], "/repo", ["test/**/*.test.ts"]);
+      expect(reads).toBeLessThanOrEqual(MAX_GREP_TEST_FILES);
+    } finally {
+      _bunDeps.glob = origGlob;
+      _bunDeps.file = origFile;
+    }
+  });
+});

--- a/test/unit/verification/import-grep-fallback.test.ts
+++ b/test/unit/verification/import-grep-fallback.test.ts
@@ -11,7 +11,7 @@ describe("importGrepFallback", () => {
     })) as any;
     let reads = 0;
     const origFile = _bunDeps.file;
-    _bunDeps.file = ((p: string) => ({
+    _bunDeps.file = ((_p: string) => ({
       async text() { reads++; return "needle"; },
       async exists() { return true; },
     })) as any;

--- a/test/unit/verification/map-source-to-tests-parallel.test.ts
+++ b/test/unit/verification/map-source-to-tests-parallel.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { mapSourceToTests, _bunDeps } from "../../../src/verification/smart-runner";
+
+describe("mapSourceToTests", () => {
+  test("runs candidate existence checks concurrently", async () => {
+    let active = 0, maxActive = 0;
+    const origFile = _bunDeps.file;
+    _bunDeps.file = ((p: string) => ({
+      async exists() {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 2));
+        active--;
+        return p.includes("foo");
+      },
+      async text() { return ""; },
+    })) as any;
+    try {
+      await mapSourceToTests(["src/foo.ts", "src/bar.ts", "src/baz.ts"], "/repo");
+      expect(maxActive).toBeGreaterThan(1);
+    } finally {
+      _bunDeps.file = origFile;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **CR-1 / H-1 (data-loss):** In parallel mode, concurrent worktree pipelines raced on a shared `prd` object and `prd.json` file. Fixed with a `skipPrdPersistence` flag that gates the completion stage's `markStoryPassed`+`savePRD` writes, a per-story `structuredClone` of the PRD in `executeStoryInWorktree`, and a single-writer `reconcileBatchOutcome` in the unified executor for completed + merge-conflict outcomes after each batch. Failed stories continue to be owned by `handlePipelineFailure` (no double `attempts++`).
- **M-5:** Serialized PidRegistry file writes (`register`/`unregister`/`killAll`) behind a `writeQueueTail` promise chain to prevent on-disk `.nax-pids` desync under concurrent story execution.
- **H-2 / H-3 / M-3 / M-4 / M-6 (performance):** Memoize `detectLanguage` + `discoverWorkspacePackages` per run; parallelize `GitHistoryProvider` per-file `git log`; hoist CodeNeighbor reverse-dep glob scan out of the per-file loop and cache file reads within one `fetch()`; export `_bunDeps`, add `MAX_GREP_TEST_FILES=200` cap, and parallelize reads in `importGrepFallback`; parallelize `mapSourceToTests` existence checks with `Promise.all`; memoize `getGitRoot` per workdir across change classifiers; abort losing provider fetch on timeout via `AbortController` and suppress late rejection.
- **M-1 (security):** Strip configured secret env vars (from `config.quality.stripEnvVars`) before spawning any quality shell command — wired through all five call paths (`lint-check`, `typecheck-check`, `mechanical-lintfix`, `mechanical-formatfix`, `review/runner` + `scoped-lint`).
- **M-2 (security):** New `src/logger/redact.ts` helper (`redactSecrets`) applied in the JSONL logger write path — two-layer protection: key-name pattern matching + token-shape regex scanning of string values. Console output intentionally untouched.

## Test Plan

- [ ] All 36 new unit tests pass (`bun run test`)
- [ ] No regressions in execution/pipeline/context/verification suites (1200+ tests)
- [ ] `bun run typecheck` clean
- [ ] `bun run lint` clean
- [ ] Parallel run smoke: `parallelCount: 2` with one failing story confirms `prd.json` records failed story exactly once, `attempts` not double-incremented, completed story marked passed
- [ ] Quality command run confirms `AWS_SECRET_ACCESS_KEY` / `GITHUB_TOKEN` absent from spawned env
- [ ] JSONL run log confirms tokens matching `sk-…` / `ghp_…` shapes are redacted