### PR TITLE
fix(review): close review-quality gaps from prompt-audit (#2, #3A, #3B)

### DIFF
--- a/docs/findings/2026-05-30-prompt-audit-analysis.md
+++ b/docs/findings/2026-05-30-prompt-audit-analysis.md
@@ -1,0 +1,96 @@
+# Prompt-Audit Analysis — nax & rs-stock (post 2026-05-15)
+
+**Date:** 2026-05-30
+**Scope:** `~/.nax/{nax,rs-stock}/prompt-audit/**`, entries with `ts > 2026-05-15`
+**Volume:** 493 nax + 974 rs-stock audit entries across stages `review / run / rectification / acceptance / verify`; agents `claude`, `codex`, `opencode`.
+**Method:** Each finding re-verified against the raw JSONL twice — once over the full window (after 2026-05-15) and once over the **last-2-days window** (after 2026-05-28) to separate *still-live* defects from *already-resolved* ones. Recent runs confirmed present (nax 2026-05-29: 30 entries; rs-stock 2026-05-28→29: 74 entries), so an empty last-2-days result is a real "fixed" signal, not "no data."
+
+## How prompts are assembled (context)
+
+Prompts are **composed from section builders**, not templated. `src/prompts/compose.ts` concatenates `src/prompts/sections/*` (constitution → role/task → story → isolation → hermetic → behavioral-guardrails → self-verification → context.md → conventions/security → story reminder). Stage-specific prompts come from class builders in `src/prompts/builders/` (`AdversarialReviewBuilder`, `ReviewPromptBuilder`, `RectifierPromptBuilder`, `AcceptancePromptBuilder`, …). Story text is injected **verbatim** by `sections/story.ts`; the constitution is layered global + project by `constitution/loader.ts`.
+
+---
+
+## Status summary
+
+| # | Finding | Origin | Full window | Last 2 days | Action |
+|---|---------|--------|:-----------:|:-----------:|--------|
+| 1 | Literal `\n` leaks into story descriptions | Upstream (PRD/spec authoring) + unguarded render seam | nax 6, rs-stock 61 | **0** | Defensive render-time normalization (latent risk) |
+| 2 | Adversarial review downgrades fake/placeholder tests to non-blocking | Prompt builder | Live | Live | **Fix prompt** |
+| 3 | `opencode` rubber-stamps reviews / no-ops acceptance | Prompt builder + agent capability | nax 14/103, rs-stock 69/298 | rs-stock **8** | **Fix prompt** |
+| 4 | Contradictory full-suite test instruction across stages | Prompt builder | nax 52 vs 129, rs-stock 17 vs 202 | Live | **Fix prompt** |
+| 5 | Run-prompt bloat (2× constitution, 2× ACs) | Prompt builder | nax 95, rs-stock 5 | nax 7, rs-stock 5 | Trim (low priority) |
+| 6 | `grep \| wc -l` ACs are environment-fragile | **PRD/spec authoring** — *out of scope for prompt builder* | nax 46, rs-stock 21 | **0** | Already resolved upstream; no prompt change |
+
+> **#6 is excluded** from prompt-builder remediation — confirmed a PRD-writing / spec-writing concern. It does not appear in any run from the last two days. No action in the prompt layer.
+
+---
+
+## Findings
+
+### 🔴 2. Adversarial review downgrades genuinely-fake tests to non-blocking — *still live*
+
+The AC-grounding rules in `src/prompts/builders/adversarial-review-builder.ts` are tuned so hard against false positives (the *"AC names the file but not the symbol"* trap → emit `info`/`warning`) that real blockers slip through as advisory and the story passes.
+
+**Canonical evidence** — nax `US-005.S1` (`story-orchestrator-consolidation`), adversarial reviewer:
+- Found a 460-line test file where **every body is `expect(true).toBe(true)`** covering AC1 and AC2.
+- Quoted the proof: `expect(true).toBe(true); // Placeholder - will fail when implementation missing`.
+- Returned **`"passed": true`** with the finding as `"warning"` — because no AC bullet named the exact symbol.
+
+A green suite that is green only because the assertions are placeholders is precisely what adversarial review exists to catch. Corroborating: multiple `review` responses that mention `placeholder` / `expect(true)` / `no-op` still return `passed:true` (nax `US-004`, `US-005.S2/S3`, `US-002`; rs-stock `US-001` backtester-phase-2, `US-002` universe-multi-source).
+
+**Recommendation:** add a carve-out in the adversarial builder — tautological/placeholder/empty test bodies (`expect(true)`, `expect(x).toBe(x)`, empty body, `it.skip` covering an AC) that cover an acceptance criterion are **always `"error"`**, exempt from the symbol-naming requirement. The AC's behavior is provably unverified, so it must block regardless of which symbol the AC names.
+
+### 🟠 3. `opencode` rubber-stamps reviews and no-ops acceptance — *still live in rs-stock*
+
+Weaker agents don't engage with the long review/acceptance prompts; they emit an empty pass or nothing at all.
+
+- **Review rubber-stamp** (`passed:true`, empty findings, <120-char response, zero tool calls):
+  - nax: **14 / 103** opencode reviews (full window); **0** in last 2 days.
+  - rs-stock: **69 / 298** opencode reviews (~23%); **8 still in the last 2 days**.
+- **Acceptance no-op** (len-0 response): rs-stock `acceptance|opencode` **13** (full window); the JSON-only one-shot refinement frequently returns nothing.
+- **Empty responses generally** (len-0, no error): rs-stock `acceptance|opencode` 13, `review|opencode` 3, `run|opencode` 1, `verify|opencode` 1; nax `rectification|claude` 4. Last-2-days: only rs-stock `verify|opencode` 1 remains.
+
+Compare `claude`/`codex`, which read files and grep before verdicting (see the semantic-review transcript that inspects `_portfolio.py` line-by-line).
+
+**Recommendation:**
+1. **Review prompt** — require an evidence trail before `passed:true` is accepted: at least one `verifiedBy.observed` quote **or** an explicit "files inspected" list. Reject a verdict that claims `passed:true` with no investigation (treat as parse-retry, not a pass).
+2. **Acceptance prompt** — route len-0 / non-JSON responses through `op.retry` / `sendWithParseRetry` (the consolidated parse-retry framework) instead of silently accepting an empty refinement.
+
+### 🟠 4. Contradictory full-suite test instruction across stages — *live at scale*
+
+The same agent, across one story lifecycle, receives opposite instructions about running the full suite:
+
+- **Rectification prompt** (`RectifierPromptBuilder`): *"run the FULL repo test suite — the EXACT command below: `bun run test`"* — nax **52**, rs-stock **17** prompts.
+- **Run / verify prompt** (`sections/isolation.ts`): *"NEVER run the full test suite without a filter — full suite output will flood your context window and cause failures."* — nax **129**, rs-stock **202** prompts.
+
+This whiplash correlates with stalled rectification: the deferred-regression rectification transcript (nax `US-002`, `rectification-runtime-required`) returned a **len-0 response** — the agent produced nothing. nax `rectification|claude` had **4** empty responses overall.
+
+**Recommendation:** reconcile the two. In the rectification prompt, point at the time-boxed wrapper from `.claude/rules/testing-commands.md` (`bun run test` already process-group-boxed) and **explicitly state the context-flood guardrail is intentionally lifted for this gate** — so the rectifier and the run/verify isolation rules stop contradicting each other.
+
+### 🟡 1. Literal `\n` leaks into story descriptions — *dormant, latent risk*
+
+`sections/story.ts` (`buildStorySection` / `buildBatchStorySection` / `buildStoryReminderSection`) and the review/acceptance builders inject `story.description` **verbatim**. Specs authored with escaped newlines render Python code blocks and paragraph breaks as literal `\n` on one logical line.
+
+- Full window: nax 6 (rectification 5, acceptance 1), rs-stock 61 (review 22, acceptance 19, run 14, rectification 6).
+- **Last 2 days: 0** — consistent with the root cause being **upstream PRD/spec authoring** (same family as #6), which appears to have been corrected.
+- Evidence: rs-stock `backtester-phase-1` review prompt — `...validation.\n\n**Approach** — verbatim from spec:\n\nNew module...\n\nclass BacktestEngineError(Exception):` all on one line.
+
+**Recommendation (optional, defensive):** normalize `description.replace(/\\n/g, "\n")` (plus `\\t`, `\\"`) at the single PRD-load boundary so every downstream builder is protected even if a future spec reintroduces escaped newlines. Not urgent — currently dormant.
+
+### 🟡 5. Run-prompt bloat — *low priority*
+
+- **2× constitution:** nax 95/128 run prompts carry both the global `# nax Constitution` and the project `# nax Project Constitution` (heavy overlap: both restate Bun-native, testing, error-handling). This is intentional layering in `constitution/loader.ts:87`, not a bug — but for projects that ship a complete constitution, `skipGlobal` removes the redundant generic copy.
+- **2× acceptance criteria:** ACs print verbatim in the story section and again in the end-of-prompt "reminder" recency anchor (`buildStoryReminderSection`). The reminder repeat is by design; harmless but worth trimming for smaller-context agents.
+
+---
+
+## Suggested priority order (prompt-builder scope)
+
+1. **#2** — placeholder-test carve-out in `adversarial-review-builder.ts`. Closes a real quality-gate hole; still live.
+2. **#3** — evidence-required review verdict + acceptance parse-retry. Stops silent rubber-stamps/no-ops; still live in rs-stock.
+3. **#4** — reconcile the full-suite test instruction between rectification and run/verify. Live at scale; correlated with stalled cycles.
+4. **#1** — defensive `\n` normalization at the PRD-load seam. Dormant; do opportunistically.
+5. **#5** — trim constitution/AC duplication. Cosmetic.
+
+*#6 intentionally omitted — PRD/spec-writing origin, already absent from recent runs.*

--- a/src/acceptance/refinement.ts
+++ b/src/acceptance/refinement.ts
@@ -44,6 +44,28 @@ export function parseRefinementResponse(response: string, criteria: string[]): R
 }
 
 /**
+ * True when `parseRefinementResponse` would discard the agent's output and fall
+ * back to the unrefined criteria — i.e. empty/whitespace response, output that
+ * fails JSON extraction/parse, or a non-array result. An empty array `[]` is a
+ * *successful* parse (returns `[]`), so it is NOT a fallback.
+ *
+ * Mirrors the fallback triggers in `parseRefinementResponse` above and lives
+ * beside it so the two stay in sync. Used by the acceptance-refine op (#3B) to
+ * log an accurate degradation warning — the log must only claim "fell back to
+ * unrefined criteria" when that is what actually happened.
+ */
+export function refinementWouldFallback(response: string): boolean {
+  if (!response || !response.trim()) return true;
+  try {
+    const fromFence = extractJsonFromMarkdown(response);
+    const cleaned = stripTrailingCommas(fromFence !== response ? fromFence : response);
+    return !Array.isArray(JSON.parse(cleaned));
+  } catch {
+    return true;
+  }
+}
+
+/**
  * Build fallback RefinedCriterion[] using original criterion text.
  */
 function fallbackCriteria(criteria: string[], storyId = ""): RefinedCriterion[] {

--- a/src/config/schemas-review.ts
+++ b/src/config/schemas-review.ts
@@ -88,6 +88,15 @@ export const AdversarialReviewConfigSchema = z.object({
    * grounding formatting errors rather than model reasoning failure.
    */
   acRegroundOnDrop: z.boolean().default(true),
+  /**
+   * When true (default), in ref mode an empty-findings `passed:true` verdict that
+   * reports no inspected files (`inspectedFiles` absent/empty) triggers exactly one
+   * same-session re-prompt demanding the reviewer actually open the changed code
+   * before passing. Guards against weaker agents rubber-stamping reviews with a bare
+   * `{"passed":true,"findings":[]}` and zero investigation. See
+   * docs/findings/2026-05-30-prompt-audit-analysis.md (#3A).
+   */
+  demandInspectionTrail: z.boolean().default(true),
   /** Controls bounded same-session recovery when verifiedBy.observed does not match disk. */
   substantiation: z
     .object({

--- a/src/config/schemas-review.ts
+++ b/src/config/schemas-review.ts
@@ -42,6 +42,13 @@ const SemanticReviewConfigSchema = z.object({
    * Any user-set value (including []) is returned as-is. (ADR-009 §4.4)
    */
   excludePatterns: z.array(z.string()).optional(),
+  /**
+   * When true (default), a ref-mode empty-findings `passed:true` verdict with no
+   * declared `inspectedFiles` triggers one same-session re-prompt demanding the
+   * reviewer actually open the code before passing (#3A inspection-trail guard).
+   * Mirrors the adversarial field so the guard is configurable on both reviewers.
+   */
+  demandInspectionTrail: z.boolean().default(true),
 });
 
 /**

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -222,6 +222,7 @@ export const NaxConfigSchema = z
         resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
+        demandInspectionTrail: true,
         substantiation: {
           requote: true,
           maxRequotes: 5,

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -245,6 +245,7 @@ export const NaxConfigSchema = z
         parallel: false,
         maxConcurrentSessions: 2,
         acRegroundOnDrop: true,
+        demandInspectionTrail: true,
         substantiation: {
           requote: true,
           maxRequotes: 5,

--- a/src/operations/acceptance-refine.ts
+++ b/src/operations/acceptance-refine.ts
@@ -1,24 +1,10 @@
-import { parseRefinementResponse } from "../acceptance/refinement";
+import { parseRefinementResponse, refinementWouldFallback } from "../acceptance/refinement";
 import type { RefinedCriterion } from "../acceptance/types";
 import { acceptanceConfigSelector } from "../config";
 import type { AcceptanceConfig } from "../config/selectors";
 import { getSafeLogger } from "../logger";
 import { AcceptancePromptBuilder } from "../prompts";
-import { tryParseLLMJson } from "../utils/llm-json";
 import type { CompleteOperation } from "./types";
-
-/**
- * True when the agent's response cannot yield a usable refinement and
- * `parseRefinementResponse` will silently fall back to the unrefined criteria —
- * empty/whitespace output, non-JSON, or an empty array. Used purely for
- * observability (#3B): the degradation was previously invisible, so a no-op from
- * a weaker agent looked identical to a successful refinement in the run log.
- */
-export function refinementDegraded(output: string): boolean {
-  if (!output || !output.trim()) return true;
-  const parsed = tryParseLLMJson<unknown>(output);
-  return !Array.isArray(parsed) || parsed.length === 0;
-}
 
 export interface AcceptanceRefineInput {
   criteria: string[];
@@ -53,7 +39,7 @@ export const acceptanceRefineOp: CompleteOperation<AcceptanceRefineInput, Accept
     };
   },
   parse(output, input, _ctx) {
-    if (refinementDegraded(output)) {
+    if (refinementWouldFallback(output)) {
       getSafeLogger()?.warn(
         "acceptance",
         "AC refinement returned no usable JSON — falling back to unrefined criteria",

--- a/src/operations/acceptance-refine.ts
+++ b/src/operations/acceptance-refine.ts
@@ -2,8 +2,23 @@ import { parseRefinementResponse } from "../acceptance/refinement";
 import type { RefinedCriterion } from "../acceptance/types";
 import { acceptanceConfigSelector } from "../config";
 import type { AcceptanceConfig } from "../config/selectors";
+import { getSafeLogger } from "../logger";
 import { AcceptancePromptBuilder } from "../prompts";
+import { tryParseLLMJson } from "../utils/llm-json";
 import type { CompleteOperation } from "./types";
+
+/**
+ * True when the agent's response cannot yield a usable refinement and
+ * `parseRefinementResponse` will silently fall back to the unrefined criteria —
+ * empty/whitespace output, non-JSON, or an empty array. Used purely for
+ * observability (#3B): the degradation was previously invisible, so a no-op from
+ * a weaker agent looked identical to a successful refinement in the run log.
+ */
+export function refinementDegraded(output: string): boolean {
+  if (!output || !output.trim()) return true;
+  const parsed = tryParseLLMJson<unknown>(output);
+  return !Array.isArray(parsed) || parsed.length === 0;
+}
 
 export interface AcceptanceRefineInput {
   criteria: string[];
@@ -38,6 +53,13 @@ export const acceptanceRefineOp: CompleteOperation<AcceptanceRefineInput, Accept
     };
   },
   parse(output, input, _ctx) {
+    if (refinementDegraded(output)) {
+      getSafeLogger()?.warn(
+        "acceptance",
+        "AC refinement returned no usable JSON — falling back to unrefined criteria",
+        { storyId: input.storyId, criteriaCount: input.criteria.length, responseBytes: output?.length ?? 0 },
+      );
+    }
     const items = parseRefinementResponse(output, input.criteria);
     return items.map((item) => ({ ...item, storyId: item.storyId || input.storyId }));
   },

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -16,6 +16,7 @@ import {
   checkFindingEvidence,
   downgradeUnsubstantiatedFinding,
   filterByAcQuote,
+  hasInspectionTrail,
   substantiateAdversarialFindings,
 } from "../review/finding-filters";
 import type { AcDroppedEntry, AcQuoteRejectionCode } from "../review/finding-filters";
@@ -323,6 +324,39 @@ async function performAdversarialReground(
   };
 }
 
+/**
+ * Inspection-trail guard (#3A). Fires only on the rubber-stamp signature: ref
+ * mode + passed:true + zero findings + no `inspectedFiles`. Issues exactly one
+ * re-prompt demanding the reviewer open the code, then returns the second turn's
+ * verdict (which flows through parse/verify substantiation normally). Returns
+ * null when the guard does not apply, so the caller falls through to the normal
+ * reground/requote logic. Cost is charged only on the rare suspicious case.
+ */
+async function maybeRepromptForInspection(
+  turn: TurnResult,
+  parsed: ValidatedAdversarialShape,
+  rawObject: Record<string, unknown> | null | undefined,
+  ctx: HopBodyContext<AdversarialReviewInput>,
+): Promise<TurnResult | null> {
+  if (ctx.input.adversarialConfig.demandInspectionTrail === false) return null;
+  if (!parsed.passed || parsed.findings.length !== 0) return null;
+  if (hasInspectionTrail(rawObject)) return null;
+
+  const secondTurn = await ctx.send(AdversarialReviewPromptBuilder.demandInspection());
+  const costUsd = (turn.estimatedCostUsd ?? 0) + (secondTurn.estimatedCostUsd ?? 0);
+  const secondParsed = validateAdversarialShape(tryParseLLMJson<Record<string, unknown>>(secondTurn.output));
+  getSafeLogger()?.warn("review", "Adversarial reviewer returned empty pass with no inspection trail — re-prompted", {
+    storyId: ctx.input.story.id,
+    event: "review.adversarial.inspection_trail.reprompted",
+    recovered: secondParsed !== null,
+  });
+  // Parseable second turn: adopt it (verify() substantiates any new findings).
+  // Unparseable second turn: keep the original pass (fail-open) but bank the cost.
+  return secondParsed
+    ? { ...turn, output: secondTurn.output, estimatedCostUsd: costUsd }
+    : { ...turn, estimatedCostUsd: costUsd };
+}
+
 export const adversarialReviewOp: RunOperation<AdversarialReviewInput, AdversarialReviewOutput, ReviewConfig> = {
   kind: "run",
   name: "adversarial-review",
@@ -334,10 +368,17 @@ export const adversarialReviewOp: RunOperation<AdversarialReviewInput, Adversari
   retry: (input) => adversarialParseRetry(input),
   async hopBody(initialPrompt, ctx) {
     const turn = await ctx.sendWithParseRetry(initialPrompt);
-    const parsed = validateAdversarialShape(tryParseLLMJson<Record<string, unknown>>(turn.output));
+    const rawObject = tryParseLLMJson<Record<string, unknown>>(turn.output);
+    const parsed = validateAdversarialShape(rawObject);
     if (!parsed) return turn;
 
     if (ctx.input.mode !== "ref") return turn;
+
+    // Inspection-trail guard (#3A): a ref-mode empty-findings pass with no declared
+    // inspectedFiles is a rubber-stamp — the reviewer never opened the code. Give it
+    // exactly one chance to actually inspect before we trust the pass.
+    const inspectionGuard = await maybeRepromptForInspection(turn, parsed, rawObject, ctx);
+    if (inspectionGuard) return inspectionGuard;
 
     // Same-session AC-grounding re-prompt (issue #1105). Gated solely on
     // acRegroundOnDrop; independent of requote / maxRequotes which address a

--- a/src/operations/adversarial-review.ts
+++ b/src/operations/adversarial-review.ts
@@ -331,6 +331,11 @@ async function performAdversarialReground(
  * verdict (which flows through parse/verify substantiation normally). Returns
  * null when the guard does not apply, so the caller falls through to the normal
  * reground/requote logic. Cost is charged only on the rare suspicious case.
+ *
+ * Asymmetry (intentional): findings produced on the adopted second turn still
+ * flow through parse()/verify() substantiation + AC-grounding, but skip the
+ * hopBody-level same-session reground/requote recovery that first-turn findings
+ * get. A reviewer that opened with a rubber-stamp forfeits that rescue turn.
  */
 async function maybeRepromptForInspection(
   turn: TurnResult,

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -9,6 +9,7 @@ import {
   checkFindingEvidence,
   downgradeUnsubstantiatedFinding,
   filterByAcGroundingMinimal,
+  hasInspectionTrail,
   isBlockingSeverity,
   sanitizeRefModeFindings,
   substantiateSemanticEvidence,
@@ -124,13 +125,54 @@ function evaluateRepromptTrigger(
   return { shouldReprompt: true, acDropped: dropped };
 }
 
+/**
+ * Inspection-trail guard (#3A). Fires only on the rubber-stamp signature: ref
+ * mode + passed:true + zero findings + no `inspectedFiles`. Issues exactly one
+ * re-prompt demanding the reviewer open the code, then returns the second turn's
+ * verdict (which flows through parse/verify substantiation normally). Returns
+ * null when the guard does not apply, so the caller falls through to the normal
+ * requote/reground logic. Cost is charged only on the rare suspicious case.
+ */
+async function maybeRepromptForInspection(
+  turn: TurnResult,
+  parsed: ValidatedSemanticShape,
+  rawObject: Record<string, unknown> | null | undefined,
+  ctx: HopBodyContext<SemanticReviewInput>,
+): Promise<TurnResult | null> {
+  if (ctx.input.mode !== "ref") return null;
+  if (ctx.input.semanticConfig.demandInspectionTrail === false) return null;
+  if (!parsed.passed || parsed.findings.length !== 0) return null;
+  if (hasInspectionTrail(rawObject)) return null;
+
+  const secondTurn = await ctx.send(ReviewPromptBuilder.demandInspection());
+  const costUsd = (turn.estimatedCostUsd ?? 0) + (secondTurn.estimatedCostUsd ?? 0);
+  const secondParsed = validateLLMShape(tryParseLLMJson<Record<string, unknown>>(secondTurn.output));
+  getSafeLogger()?.warn("review", "Semantic reviewer returned empty pass with no inspection trail — re-prompted", {
+    storyId: ctx.input.story.id,
+    event: "review.semantic.inspection_trail.reprompted",
+    recovered: secondParsed !== null,
+  });
+  // Parseable second turn: adopt it (verify() substantiates any new findings).
+  // Unparseable second turn: keep the original pass (fail-open) but bank the cost.
+  return secondParsed
+    ? { ...turn, output: secondTurn.output, estimatedCostUsd: costUsd }
+    : { ...turn, estimatedCostUsd: costUsd };
+}
+
 const semanticReviewHopBody: RunOperation<SemanticReviewInput, SemanticReviewOutput, ReviewConfig>["hopBody"] = async (
   initialPrompt,
   ctx,
 ) => {
   const turn = await ctx.sendWithParseRetry(initialPrompt);
-  const parsed = validateLLMShape(tryParseLLMJson<Record<string, unknown>>(turn.output));
+  const rawObject = tryParseLLMJson<Record<string, unknown>>(turn.output);
+  const parsed = validateLLMShape(rawObject);
   if (!parsed) return turn;
+
+  // Inspection-trail guard (#3A): a ref-mode empty-findings pass with no declared
+  // inspectedFiles is a rubber-stamp — the reviewer never opened the code. Give it
+  // exactly one chance to actually inspect before we trust the pass.
+  const inspectionGuard = await maybeRepromptForInspection(turn, parsed, rawObject, ctx);
+  if (inspectionGuard) return inspectionGuard;
 
   const requoted = await requoteBlockingFindings(parsed.findings, ctx);
   if (requoted.changed) {

--- a/src/operations/semantic-review.ts
+++ b/src/operations/semantic-review.ts
@@ -132,6 +132,11 @@ function evaluateRepromptTrigger(
  * verdict (which flows through parse/verify substantiation normally). Returns
  * null when the guard does not apply, so the caller falls through to the normal
  * requote/reground logic. Cost is charged only on the rare suspicious case.
+ *
+ * Asymmetry (intentional): findings produced on the adopted second turn still
+ * flow through parse()/verify() substantiation + AC-grounding, but skip the
+ * hopBody-level same-session requote/reground recovery that first-turn findings
+ * get. A reviewer that opened with a rubber-stamp forfeits that rescue turn.
  */
 async function maybeRepromptForInspection(
   turn: TurnResult,

--- a/src/prompts/builders/adversarial-review-builder.ts
+++ b/src/prompts/builders/adversarial-review-builder.ts
@@ -100,6 +100,13 @@ What new exported units lack corresponding test files?
 - New public functions that only appear in implementation, not in tests
 - Acceptance criteria that touch a code path with no test coverage
 
+**Placeholder / tautological tests (blocking).** A test that exists but verifies nothing is worse than a missing test — it manufactures a false green. Treat the following as a **\`severity:"error"\`, \`category:"test-gap"\`** finding whenever the fake test is the only coverage for an acceptance criterion:
+- Bodies that always pass: \`expect(true).toBe(true)\`, \`expect(x).toBe(x)\`, \`expect(1).toBe(1)\`, an empty test body, or \`assert(true)\`.
+- Tests skipped/disabled (\`it.skip\`, \`test.todo\`, \`xit\`, commented-out assertions) that an AC depends on.
+- Assertions that never exercise the implementation (e.g. asserting on a literal, not on a value the production code produced).
+
+For each such finding: set \`acIndex\` to the AC the fake test purports to cover, \`acQuote\` to a verbatim substring of that AC, and \`verifiedBy.observed\` to the placeholder line itself (e.g. \`expect(true).toBe(true)\`). Do **not** downgrade these to \`warning\` — a green suite built on placeholder assertions is a failing implementation with hidden evidence.
+
 ### 5. Convention Breaks
 What pattern exists elsewhere that this code does not follow?
 - Logger calls missing \`storyId\` as first key in data object
@@ -121,6 +128,7 @@ Respond with ONLY a JSON object — no preamble, no explanation outside the JSON
 \`\`\`json
 {
   "passed": true | false,
+  "inspectedFiles": ["relative/path/you/actually/opened.ts"],
   "findings": [
     {
       "severity": "error" | "warning" | "info" | "unverifiable",
@@ -141,6 +149,8 @@ Respond with ONLY a JSON object — no preamble, no explanation outside the JSON
   ]
 }
 \`\`\`
+
+**No rubber-stamping:** \`inspectedFiles\` must list the relative paths you actually opened with your tools while reviewing. A \`passed:true\` verdict with an empty or absent \`inspectedFiles\` is invalid — it means you never looked at the code. Fetch the diff and open the changed files before forming any verdict.
 
 Severity guide:
 - \`"error"\`: confident this will cause real failure or regression
@@ -170,6 +180,8 @@ Worked example:
 - RIGHT: severity \`"info"\`, no \`acQuote\`. The convention violation is real, but no AC constrains \`ExtendedPrismaClient\`, so it cannot block the story.
 
 **Convention / coding-standard violations almost always belong as \`"info"\`** unless an AC specifically names the convention or the symbol it concerns.
+
+**Exception — the trap does NOT apply to \`category:"test-gap"\` findings.** A fake/placeholder/missing test is the *absence* of verification for an AC's behaviour; it cannot name a symbol that is present in the (worthless) test file, because the defect is precisely that the symbol-under-test is never exercised. A \`test-gap\` finding is grounded by the AC whose behaviour goes unverified — cite that AC's \`acIndex\` and a verbatim \`acQuote\` substring from it, and keep severity \`"error"\`. The symbol-naming requirement is waived for this category.
 
 **Scope constraints are not Acceptance Criteria:**
 The story description may contain a "Scope" section with "In:" and "Out:" bullets. These are implementation guidelines, not ACs. A finding about code changed outside the stated scope (e.g., a file listed under "Out:") cannot cite a scope constraint as its \`acQuote\`/\`acIndex\` because scope text is not in the numbered AC list. Emit scope-violation findings as \`"warning"\` — never \`"error"\`. Never use \`acIndex: 0\`; \`acIndex\` is 1-based (first AC bullet = 1).
@@ -376,6 +388,24 @@ Rules:
 - observed must be a 1-3 line excerpt that proves the claim, taken from at or near line ${line}.
 - If after reading the file you cannot find anything that proves the claim, set observed to "".
 - Do not return a full review. Do not include markdown fences or explanation.`;
+  }
+
+  /**
+   * Same-session re-prompt issued when the first verdict is a bare
+   * `passed:true` with no findings and an empty `inspectedFiles` list — the
+   * signature of a rubber-stamp review where the agent never opened the code.
+   * Gives the reviewer exactly one chance to actually inspect before the pass
+   * is trusted. See docs/findings/2026-05-30-prompt-audit-analysis.md (#3A).
+   */
+  static demandInspection(): string {
+    return `Your previous review returned \`passed:true\` with no findings and an empty (or absent) \`inspectedFiles\` list. That means you did not open any of the changed files — a verdict reached without inspecting the code is not valid.
+
+Use your git and file-reading tools NOW to fetch the diff and open the changed files for this story. Then re-issue your verdict as the same JSON object.
+
+Rules:
+- Populate \`inspectedFiles\` with the relative paths you actually opened.
+- If, after genuinely inspecting the code, there is truly nothing to flag, you may still return \`passed:true\` — but \`inspectedFiles\` must list the files you read.
+- Return ONLY the JSON object — no markdown fences, no explanation.`;
   }
 
   /**

--- a/src/prompts/builders/review-builder.ts
+++ b/src/prompts/builders/review-builder.ts
@@ -51,6 +51,7 @@ Do NOT flag: style issues, naming conventions, import ordering, file length, or 
 const SEMANTIC_OUTPUT_SCHEMA = `Respond with JSON only — no explanation text before or after:
 {
   "passed": boolean,
+  "inspectedFiles": ["relative/path/you/actually/opened.ts"],
   "findings": [
     {
       "severity": "error" | "warning" | "info" | "unverifiable",
@@ -74,7 +75,8 @@ Notes:
 - \`acIndex\` is required when severity is "error" (1-based, into the Acceptance Criteria list above).
 - \`acQuote\` is optional advisory metadata for human auditors — not validated.
 - Omit both for "warning", "info", "unverifiable".
-If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.`;
+- \`inspectedFiles\` must list the relative paths you actually opened while reviewing. A \`passed:true\` verdict with an empty or absent \`inspectedFiles\` is invalid — walk each AC against the real files before passing.
+If all ACs are correctly implemented after inspecting the code, respond with { "passed": true, "inspectedFiles": ["..."], "findings": [] }.`;
 
 // ─── Options ──────────────────────────────────────────────────────────────────
 
@@ -193,6 +195,24 @@ Respond with a condensed summary:
 - Keep \`verifiedBy\` for every finding. If \`verifiedBy.observed\` is long, abbreviate it to one line — never drop the field.
 Output ONLY a complete, valid JSON object. It must start with { and end with }.
 Schema: {"passed": boolean, "findings": [{"severity": string, "category": string, "file": string, "line": number, "issue": string, "suggestion": string, "verifiedBy": {"command": string, "file": string, "line": number, "observed": string}}]}`;
+  }
+
+  /**
+   * Same-session re-prompt issued when the first semantic verdict is a bare
+   * `passed:true` with no findings and an empty `inspectedFiles` list — the
+   * signature of a rubber-stamp review where the agent never opened the code.
+   * Gives the reviewer one chance to actually inspect before the pass is
+   * trusted. See docs/findings/2026-05-30-prompt-audit-analysis.md (#3A).
+   */
+  static demandInspection(): string {
+    return `Your previous review returned \`passed:true\` with no findings and an empty (or absent) \`inspectedFiles\` list. That means you did not open any of the changed files — a verdict reached without reading the code is not valid.
+
+Use your file-reading tools NOW to open the changed files and walk each acceptance criterion against the real implementation. Then re-issue your verdict as the same JSON object.
+
+Rules:
+- Populate \`inspectedFiles\` with the relative paths you actually opened.
+- If, after genuinely inspecting the code, every AC is satisfied, you may still return \`passed:true\` — but \`inspectedFiles\` must list the files you read.
+- Return ONLY the JSON object — no markdown fences, no explanation.`;
   }
 
   static requoteVerbatim(opts: { finding: LLMFinding }): string {

--- a/src/review/ac-quote-validator.ts
+++ b/src/review/ac-quote-validator.ts
@@ -26,6 +26,16 @@ export interface AcQuotable {
   issue: string;
   acQuote?: string;
   acIndex?: number;
+  /**
+   * Adversarial finding category. When `"test-gap"`, the locus-keyword check is
+   * waived: a test-gap is the *absence* of a verifying test for an AC's behaviour,
+   * so its acQuote is grounded by the AC it covers — not by a symbol present in
+   * the (fake/placeholder) test file. Without this waiver, a genuinely fake test
+   * (`expect(true).toBe(true)` covering AC-N) is dropped as
+   * `ac_quote_does_not_constrain_locus` and the story passes. See
+   * docs/findings/2026-05-30-prompt-audit-analysis.md (#2).
+   */
+  category?: string;
 }
 
 export type AcQuoteRejectionCode =
@@ -134,6 +144,15 @@ export function validateAcQuote(finding: AcQuotable, acceptanceCriteria: string[
 
   if (!acText.toLowerCase().includes(normalizedQuote.toLowerCase())) {
     return { valid: false, code: "ac_quote_not_substring" };
+  }
+
+  // test-gap carve-out: a fake/placeholder/missing test is the absence of a
+  // verifying symbol, so it cannot — and must not be required to — name a symbol
+  // present in the test file. Grounding by a valid acIndex + AC substring is
+  // sufficient. This lets adversarial review block stories whose ACs are
+  // "covered" only by tautological tests. (#2 / 2026-05-30 prompt-audit analysis.)
+  if (finding.category === "test-gap") {
+    return { valid: true };
   }
 
   const keywords = extractLocusKeywords(finding);

--- a/src/review/ac-quote-validator.ts
+++ b/src/review/ac-quote-validator.ts
@@ -151,6 +151,12 @@ export function validateAcQuote(finding: AcQuotable, acceptanceCriteria: string[
   // present in the test file. Grounding by a valid acIndex + AC substring is
   // sufficient. This lets adversarial review block stories whose ACs are
   // "covered" only by tautological tests. (#2 / 2026-05-30 prompt-audit analysis.)
+  //
+  // `category` is LLM-controlled, so this only RELAXES the locus check — never
+  // evidence. A finding mislabelled "test-gap" still needs a valid acIndex +
+  // verbatim AC substring here, and still passes through verifiedBy / evidence
+  // substantiation in the op's verify(). Mislabelling makes a finding more
+  // likely to block (stricter), never bypass-to-pass.
   if (finding.category === "test-gap") {
     return { valid: true };
   }

--- a/src/review/finding-filters.ts
+++ b/src/review/finding-filters.ts
@@ -31,6 +31,20 @@ export { filterByAcGroundingMinimal, filterByAcQuote } from "./ac-quote-validato
 export type { AcQuoteRejectionCode, AcDroppedEntry, AcGroundingMinimalRejection } from "./ac-quote-validator";
 
 /**
+ * True when the reviewer's raw response declares a non-empty `inspectedFiles`
+ * array — evidence that it actually opened the changed code. Used by the
+ * inspection-trail guard (#3A) to distinguish a genuine empty-findings pass
+ * from a rubber-stamp `{"passed":true,"findings":[]}` with no investigation.
+ *
+ * `raw` is the already-parsed JSON object (from `tryParseLLMJson`), or null
+ * when the response was unparseable (treated as "no trail").
+ */
+export function hasInspectionTrail(raw: Record<string, unknown> | null | undefined): boolean {
+  const files = raw?.inspectedFiles;
+  return Array.isArray(files) && files.some((f) => typeof f === "string" && f.trim().length > 0);
+}
+
+/**
  * Per-finding adversarial evidence substantiation.
  * Extracted from src/review/adversarial.ts:393-409.
  * Blocking findings whose verifiedBy.observed does not match HEAD are downgraded to

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -79,6 +79,12 @@ export interface SemanticReviewConfig {
    * findings against the AC text.
    */
   acRegroundOnDrop?: boolean;
+  /**
+   * When true (default), a ref-mode empty-findings `passed:true` verdict with no
+   * declared `inspectedFiles` triggers one same-session re-prompt demanding the
+   * reviewer actually open the code before passing (#3A inspection-trail guard).
+   */
+  demandInspectionTrail?: boolean;
 }
 
 /** Review check result */
@@ -206,6 +212,12 @@ export interface AdversarialReviewConfig {
    * asking the reviewer to re-ground their findings against the AC text.
    */
   acRegroundOnDrop?: boolean;
+  /**
+   * When true (default), a ref-mode empty-findings `passed:true` verdict with no
+   * declared `inspectedFiles` triggers one same-session re-prompt demanding the
+   * reviewer actually open the code before passing (#3A inspection-trail guard).
+   */
+  demandInspectionTrail?: boolean;
 }
 
 /** Review configuration */

--- a/test/unit/config/semantic-review.test.ts
+++ b/test/unit/config/semantic-review.test.ts
@@ -127,6 +127,7 @@ describe("ReviewConfig semantic field", () => {
         resetRefOnRerun: false,
         rules: [],
         timeoutMs: 600_000,
+        demandInspectionTrail: true,
         substantiation: { requote: true, maxRequotes: 5 },
         // excludePatterns is now optional (ADR-009): undefined means resolver will derive at runtime
       });
@@ -245,10 +246,7 @@ describe("ReviewConfigSchema semantic validation", () => {
     const result = NaxConfigSchema.safeParse(config);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.review.semantic?.rules).toEqual([
-        "no-mutations",
-        "immutable-defaults",
-      ]);
+      expect(result.data.review.semantic?.rules).toEqual(["no-mutations", "immutable-defaults"]);
     }
   });
 });
@@ -273,8 +271,18 @@ describe("DEFAULT_CONFIG.review.semantic", () => {
       resetRefOnRerun: false,
       rules: [],
       timeoutMs: 600_000,
+      demandInspectionTrail: true,
       substantiation: { requote: true, maxRequotes: 5 },
-      excludePatterns: [":!test/", ":!tests/", ":!*_test.go", ":!*.test.ts", ":!*.spec.ts", ":!**/__tests__/", ":!.nax/", ":!.nax-pids"],
+      excludePatterns: [
+        ":!test/",
+        ":!tests/",
+        ":!*_test.go",
+        ":!*.test.ts",
+        ":!*.spec.ts",
+        ":!**/__tests__/",
+        ":!.nax/",
+        ":!.nax-pids",
+      ],
     });
   });
 });
@@ -296,6 +304,41 @@ describe("Semantic check in review.checks with semantic config", () => {
       expect(result.data.review.semantic).toBeDefined();
       expect(result.data.review.semantic?.model).toBe("balanced");
       expect(result.data.review.semantic?.rules).toEqual([]);
+    }
+  });
+});
+
+describe("demandInspectionTrail (#3A) — configurable on both reviewers", () => {
+  test("defaults to true on the DEFAULT_CONFIG for both reviewers", () => {
+    expect(DEFAULT_CONFIG.review?.semantic?.demandInspectionTrail).toBe(true);
+    expect(DEFAULT_CONFIG.review?.adversarial?.demandInspectionTrail).toBe(true);
+  });
+
+  test("defaults to true after parsing when omitted (not schema-stripped)", () => {
+    const parsed = NaxConfigSchema.parse({});
+    expect(parsed.review.semantic?.demandInspectionTrail).toBe(true);
+    expect(parsed.review.adversarial?.demandInspectionTrail).toBe(true);
+  });
+
+  test("an explicit false survives parse on the semantic reviewer", () => {
+    const result = NaxConfigSchema.safeParse({
+      ...DEFAULT_CONFIG,
+      review: { ...DEFAULT_CONFIG.review, semantic: { demandInspectionTrail: false } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.review.semantic?.demandInspectionTrail).toBe(false);
+    }
+  });
+
+  test("an explicit false survives parse on the adversarial reviewer", () => {
+    const result = NaxConfigSchema.safeParse({
+      ...DEFAULT_CONFIG,
+      review: { ...DEFAULT_CONFIG.review, adversarial: { demandInspectionTrail: false } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.review.adversarial?.demandInspectionTrail).toBe(false);
     }
   });
 });

--- a/test/unit/operations/acceptance-refine.test.ts
+++ b/test/unit/operations/acceptance-refine.test.ts
@@ -1,14 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { makeNaxConfig, makeTestRuntime } from "../../helpers";
 import type { AcceptanceRefineInput } from "../../../src/operations/acceptance-refine";
 import type { NaxRuntime } from "../../../src/runtime";
+import { makeNaxConfig, makeTestRuntime } from "../../helpers";
 
 const createdRuntimes: NaxRuntime[] = [];
 afterEach(async () => {
   await Promise.allSettled(createdRuntimes.map((r) => r.close()));
   createdRuntimes.length = 0;
 });
-import { acceptanceRefineOp } from "../../../src/operations/acceptance-refine";
+import { acceptanceRefineOp, refinementDegraded } from "../../../src/operations/acceptance-refine";
 
 const SAMPLE_INPUT: AcceptanceRefineInput = {
   criteria: ["User can log in", "User can log out"],
@@ -83,7 +83,12 @@ describe("acceptanceRefineOp.parse()", () => {
   test("parses valid JSON array of RefinedCriterion", () => {
     const ctx = makeBuildCtx();
     const json = JSON.stringify([
-      { original: "User can log in", refined: "login() returns true for valid credentials", testable: true, storyId: "US-001" },
+      {
+        original: "User can log in",
+        refined: "login() returns true for valid credentials",
+        testable: true,
+        storyId: "US-001",
+      },
       { original: "User can log out", refined: "logout() clears session token", testable: true, storyId: "US-001" },
     ]);
     const result = acceptanceRefineOp.parse(json, SAMPLE_INPUT, ctx);
@@ -104,6 +109,28 @@ describe("acceptanceRefineOp.parse()", () => {
     const result = acceptanceRefineOp.parse("", SAMPLE_INPUT, ctx);
     expect(result).toHaveLength(2);
     expect(result[0].original).toBe("User can log in");
+  });
+});
+
+describe("refinementDegraded (#3B observability)", () => {
+  test.each([
+    ["", true],
+    ["   \n  ", true],
+    ["not json", true],
+    ["[]", true],
+    ['{"passed":true}', true],
+  ] as const)("degraded(%p) === %p", (output, expected) => {
+    expect(refinementDegraded(output)).toBe(expected);
+  });
+
+  test("usable refinement array is not degraded", () => {
+    const usable = JSON.stringify([{ original: "a", refined: "a()", testable: true, storyId: "" }]);
+    expect(refinementDegraded(usable)).toBe(false);
+  });
+
+  test("fenced JSON array is not degraded", () => {
+    const fenced = '```json\n[{"original":"a","refined":"a()","testable":true,"storyId":""}]\n```';
+    expect(refinementDegraded(fenced)).toBe(false);
   });
   test("parses JSON wrapped in code fence", () => {
     const ctx = makeBuildCtx();

--- a/test/unit/operations/acceptance-refine.test.ts
+++ b/test/unit/operations/acceptance-refine.test.ts
@@ -8,7 +8,8 @@ afterEach(async () => {
   await Promise.allSettled(createdRuntimes.map((r) => r.close()));
   createdRuntimes.length = 0;
 });
-import { acceptanceRefineOp, refinementDegraded } from "../../../src/operations/acceptance-refine";
+import { parseRefinementResponse, refinementWouldFallback } from "../../../src/acceptance/refinement";
+import { acceptanceRefineOp } from "../../../src/operations/acceptance-refine";
 
 const SAMPLE_INPUT: AcceptanceRefineInput = {
   criteria: ["User can log in", "User can log out"],
@@ -112,25 +113,36 @@ describe("acceptanceRefineOp.parse()", () => {
   });
 });
 
-describe("refinementDegraded (#3B observability)", () => {
+describe("refinementWouldFallback (#3B observability)", () => {
+  // The predicate must agree with parseRefinementResponse's ACTUAL fallback:
+  // true only when the parser discards output and returns the unrefined criteria.
   test.each([
     ["", true],
     ["   \n  ", true],
     ["not json", true],
-    ["[]", true],
-    ['{"passed":true}', true],
-  ] as const)("degraded(%p) === %p", (output, expected) => {
-    expect(refinementDegraded(output)).toBe(expected);
+    ['{"passed":true}', true], // non-array → fallback
+    ["[]", false], // empty array is a successful parse (returns []), NOT a fallback
+  ] as const)("wouldFallback(%p) === %p", (output, expected) => {
+    expect(refinementWouldFallback(output)).toBe(expected);
   });
 
-  test("usable refinement array is not degraded", () => {
+  test("agrees with parseRefinementResponse on the fallback cases", () => {
+    const criteria = ["User can log in", "User can log out"];
+    for (const output of ["", "not json", '{"x":1}']) {
+      // When wouldFallback is true, the parser returns exactly the unrefined criteria.
+      expect(refinementWouldFallback(output)).toBe(true);
+      expect(parseRefinementResponse(output, criteria).map((c) => c.refined)).toEqual(criteria);
+    }
+  });
+
+  test("usable refinement array does not fall back", () => {
     const usable = JSON.stringify([{ original: "a", refined: "a()", testable: true, storyId: "" }]);
-    expect(refinementDegraded(usable)).toBe(false);
+    expect(refinementWouldFallback(usable)).toBe(false);
   });
 
-  test("fenced JSON array is not degraded", () => {
+  test("fenced JSON array does not fall back", () => {
     const fenced = '```json\n[{"original":"a","refined":"a()","testable":true,"storyId":""}]\n```';
-    expect(refinementDegraded(fenced)).toBe(false);
+    expect(refinementWouldFallback(fenced)).toBe(false);
   });
   test("parses JSON wrapped in code fence", () => {
     const ctx = makeBuildCtx();

--- a/test/unit/operations/adversarial-review-inspection-trail.test.ts
+++ b/test/unit/operations/adversarial-review-inspection-trail.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for adversarialReviewOp.hopBody — inspection-trail guard (#3A).
+ *
+ * A ref-mode `passed:true` verdict with zero findings and no `inspectedFiles`
+ * is the rubber-stamp signature (the reviewer never opened the code). The guard
+ * issues exactly one same-session re-prompt demanding inspection, then adopts the
+ * second turn's verdict. It is gated on `adversarialConfig.demandInspectionTrail`
+ * and only fires in ref mode.
+ *
+ * See docs/findings/2026-05-30-prompt-audit-analysis.md (#3A).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { adversarialReviewOp } from "../../../src/operations/adversarial-review";
+import { AdversarialReviewPromptBuilder } from "../../../src/prompts";
+
+const ADVERSARIAL_CONFIG = {
+  model: "balanced" as const,
+  diffMode: "ref" as const,
+  rules: [] as string[],
+  timeoutMs: 600_000,
+  parallel: false,
+  maxConcurrentSessions: 2,
+  acRegroundOnDrop: true,
+  demandInspectionTrail: true,
+  substantiation: { requote: false, maxRequotes: 0 },
+};
+
+const STORY = {
+  id: "STORY-INSPECT",
+  title: "Inspection trail guard",
+  description: "guard against rubber-stamp reviews",
+  acceptanceCriteria: ["auth login must not allow SQL injection attacks"],
+};
+
+function turn(output: string) {
+  return { output, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
+}
+
+async function runHopBody(opts: {
+  responses: string[];
+  config?: Partial<typeof ADVERSARIAL_CONFIG>;
+  mode?: "ref" | "embedded";
+}) {
+  let callCount = 0;
+  const mockSend = mock(async () => turn(opts.responses[Math.min(callCount++, opts.responses.length - 1)]));
+  const result = await adversarialReviewOp.hopBody!("initial prompt", {
+    send: mockSend,
+    sendWithParseRetry: mockSend,
+    input: {
+      workdir: "/tmp",
+      story: STORY,
+      adversarialConfig: { ...ADVERSARIAL_CONFIG, ...opts.config },
+      mode: opts.mode ?? "ref",
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal HopBodyContext stub for unit test
+  } as any);
+  return { result, callCount };
+}
+
+describe("adversarialReviewOp.hopBody — inspection-trail guard (#3A)", () => {
+  const RUBBER_STAMP = JSON.stringify({ passed: true, findings: [] });
+
+  test("empty pass with no inspectedFiles → one re-prompt (two sends)", async () => {
+    const second = JSON.stringify({ passed: true, inspectedFiles: ["src/auth.ts"], findings: [] });
+    const { callCount } = await runHopBody({ responses: [RUBBER_STAMP, second] });
+    expect(callCount).toBe(2);
+  });
+
+  test("re-prompt uses the demandInspection prompt", async () => {
+    let secondPrompt: string | undefined;
+    let n = 0;
+    const second = JSON.stringify({ passed: true, inspectedFiles: ["src/auth.ts"], findings: [] });
+    const mockSend = mock(async (p: string) => {
+      if (n === 1) secondPrompt = p;
+      n += 1;
+      return turn(n === 1 ? RUBBER_STAMP : second);
+    });
+    await adversarialReviewOp.hopBody!("initial prompt", {
+      send: mockSend,
+      sendWithParseRetry: mockSend,
+      input: { workdir: "/tmp", story: STORY, adversarialConfig: ADVERSARIAL_CONFIG, mode: "ref" },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal HopBodyContext stub
+    } as any);
+    expect(secondPrompt).toBe(AdversarialReviewPromptBuilder.demandInspection());
+  });
+
+  test("second turn's verdict is adopted (findings flow downstream)", async () => {
+    const second = JSON.stringify({
+      passed: false,
+      inspectedFiles: ["src/auth.ts"],
+      findings: [
+        { severity: "error", category: "test-gap", file: "src/auth.ts", line: 1, issue: "x", suggestion: "y" },
+      ],
+    });
+    const { result } = await runHopBody({ responses: [RUBBER_STAMP, second] });
+    expect(result.output).toBe(second);
+  });
+
+  test("empty pass WITH inspectedFiles → no re-prompt (single send)", async () => {
+    const passed = JSON.stringify({ passed: true, inspectedFiles: ["src/auth.ts"], findings: [] });
+    const { callCount } = await runHopBody({ responses: [passed] });
+    expect(callCount).toBe(1);
+  });
+
+  test("demandInspectionTrail:false → no re-prompt", async () => {
+    const { callCount } = await runHopBody({
+      responses: [RUBBER_STAMP],
+      config: { demandInspectionTrail: false },
+    });
+    expect(callCount).toBe(1);
+  });
+
+  test("embedded mode → guard does not fire (ref-only)", async () => {
+    const { callCount } = await runHopBody({ responses: [RUBBER_STAMP], mode: "embedded" });
+    expect(callCount).toBe(1);
+  });
+
+  test("unparseable second turn → keep original pass, still two sends", async () => {
+    const { result, callCount } = await runHopBody({ responses: [RUBBER_STAMP, "not json at all"] });
+    expect(callCount).toBe(2);
+    expect(result.output).toBe(RUBBER_STAMP);
+  });
+});

--- a/test/unit/operations/adversarial-review-reground.test.ts
+++ b/test/unit/operations/adversarial-review-reground.test.ts
@@ -551,7 +551,9 @@ describe("adversarialReviewOp.hopBody — reground AC7: no reprompt when trigger
       mkdirSync(join(workdir, "src"), { recursive: true });
       writeFileSync(join(workdir, "src", "auth.ts"), "function login(u, p) { return db.rawQuery(u + p); }\n");
 
-      const firstTurn = JSON.stringify({ passed: true, findings: [] });
+      // inspectedFiles present → the #3A inspection-trail guard is satisfied,
+      // so this test isolates the reground precondition (no reprompt on pass).
+      const firstTurn = JSON.stringify({ passed: true, inspectedFiles: ["src/auth.ts"], findings: [] });
 
       let callCount = 0;
       const mockSend = mock(async () => {

--- a/test/unit/operations/adversarial-review-requote.test.ts
+++ b/test/unit/operations/adversarial-review-requote.test.ts
@@ -332,7 +332,9 @@ describe("adversarialReviewOp.hopBody — same-session requote (AC16)", () => {
   });
 
   test("no-op when findings are empty (no requote needed)", async () => {
-    const initial = JSON.stringify({ passed: true, findings: [] });
+    // inspectedFiles present → the #3A inspection-trail guard is satisfied,
+    // so this test isolates the requote no-op (no findings to requote).
+    const initial = JSON.stringify({ passed: true, inspectedFiles: ["src/foo.ts"], findings: [] });
 
     let callCount = 0;
     const mockSend = mock(async () => {

--- a/test/unit/operations/semantic-review-inspection-trail.test.ts
+++ b/test/unit/operations/semantic-review-inspection-trail.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for semanticReviewOp.hopBody — inspection-trail guard (#3A).
+ *
+ * A ref-mode `passed:true` verdict with zero findings and no `inspectedFiles`
+ * is the rubber-stamp signature (the reviewer never opened the code). The guard
+ * issues exactly one same-session re-prompt demanding inspection, then adopts the
+ * second turn's verdict. It is gated on `semanticConfig.demandInspectionTrail`
+ * and only fires in ref mode.
+ *
+ * See docs/findings/2026-05-30-prompt-audit-analysis.md (#3A).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { semanticReviewOp } from "../../../src/operations/semantic-review";
+import { ReviewPromptBuilder } from "../../../src/prompts";
+
+const SEMANTIC_CONFIG = {
+  model: "balanced" as const,
+  diffMode: "ref" as const,
+  rules: [] as string[],
+  timeoutMs: 600_000,
+  substantiation: { requote: false, maxRequotes: 0 },
+  acRegroundOnDrop: true,
+  demandInspectionTrail: true,
+};
+
+const STORY = {
+  id: "STORY-INSPECT",
+  title: "Inspection trail guard",
+  description: "guard against rubber-stamp reviews",
+  acceptanceCriteria: ["auth login must not allow SQL injection attacks"],
+};
+
+function turn(output: string) {
+  return { output, tokenUsage: { inputTokens: 0, outputTokens: 0 }, internalRoundTrips: 0 };
+}
+
+async function runHopBody(opts: {
+  responses: string[];
+  config?: Partial<typeof SEMANTIC_CONFIG>;
+  mode?: "ref" | "embedded";
+}) {
+  let callCount = 0;
+  const mockSend = mock(async () => turn(opts.responses[Math.min(callCount++, opts.responses.length - 1)]));
+  const result = await semanticReviewOp.hopBody!("initial prompt", {
+    send: mockSend,
+    sendWithParseRetry: mockSend,
+    input: {
+      workdir: "/tmp",
+      story: STORY,
+      semanticConfig: { ...SEMANTIC_CONFIG, ...opts.config },
+      mode: opts.mode ?? "ref",
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal HopBodyContext stub for unit test
+  } as any);
+  return { result, callCount };
+}
+
+describe("semanticReviewOp.hopBody — inspection-trail guard (#3A)", () => {
+  const RUBBER_STAMP = JSON.stringify({ passed: true, findings: [] });
+
+  test("empty pass with no inspectedFiles → one re-prompt (two sends)", async () => {
+    const second = JSON.stringify({ passed: true, inspectedFiles: ["src/auth.ts"], findings: [] });
+    const { callCount } = await runHopBody({ responses: [RUBBER_STAMP, second] });
+    expect(callCount).toBe(2);
+  });
+
+  test("re-prompt uses the demandInspection prompt", async () => {
+    let secondPrompt: string | undefined;
+    let n = 0;
+    const second = JSON.stringify({ passed: true, inspectedFiles: ["src/auth.ts"], findings: [] });
+    const mockSend = mock(async (p: string) => {
+      if (n === 1) secondPrompt = p;
+      n += 1;
+      return turn(n === 1 ? RUBBER_STAMP : second);
+    });
+    await semanticReviewOp.hopBody!("initial prompt", {
+      send: mockSend,
+      sendWithParseRetry: mockSend,
+      input: { workdir: "/tmp", story: STORY, semanticConfig: SEMANTIC_CONFIG, mode: "ref" },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal HopBodyContext stub
+    } as any);
+    expect(secondPrompt).toBe(ReviewPromptBuilder.demandInspection());
+  });
+
+  test("second turn's verdict is adopted", async () => {
+    const second = JSON.stringify({
+      passed: false,
+      inspectedFiles: ["src/auth.ts"],
+      findings: [{ severity: "error", file: "src/auth.ts", line: 1, issue: "x", suggestion: "y", acIndex: 1 }],
+    });
+    const { result } = await runHopBody({ responses: [RUBBER_STAMP, second] });
+    expect(result.output).toBe(second);
+  });
+
+  test("empty pass WITH inspectedFiles → no re-prompt (single send)", async () => {
+    const passed = JSON.stringify({ passed: true, inspectedFiles: ["src/auth.ts"], findings: [] });
+    const { callCount } = await runHopBody({ responses: [passed] });
+    expect(callCount).toBe(1);
+  });
+
+  test("demandInspectionTrail:false → no re-prompt", async () => {
+    const { callCount } = await runHopBody({
+      responses: [RUBBER_STAMP],
+      config: { demandInspectionTrail: false },
+    });
+    expect(callCount).toBe(1);
+  });
+
+  test("embedded mode → guard does not fire (ref-only)", async () => {
+    const { callCount } = await runHopBody({ responses: [RUBBER_STAMP], mode: "embedded" });
+    expect(callCount).toBe(1);
+  });
+
+  test("unparseable second turn → keep original pass, still two sends", async () => {
+    const { result, callCount } = await runHopBody({ responses: [RUBBER_STAMP, "not json at all"] });
+    expect(callCount).toBe(2);
+    expect(result.output).toBe(RUBBER_STAMP);
+  });
+});

--- a/test/unit/operations/semantic-review-reground.test.ts
+++ b/test/unit/operations/semantic-review-reground.test.ts
@@ -505,6 +505,9 @@ describe("semanticReviewOp.hopBody — reground preconditions not met (AC7)", ()
 
       const firstTurn = JSON.stringify({
         passed: true,
+        // inspectedFiles present → the #3A inspection-trail guard is satisfied,
+        // so this test isolates the reground precondition (no reprompt on pass).
+        inspectedFiles: ["src/foo.ts"],
         findings: [],
       });
 

--- a/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
+++ b/test/unit/prompts/__snapshots__/review-builder.test.ts.snap
@@ -41,6 +41,7 @@ Do NOT flag: style issues, naming conventions, import ordering, file length, or 
 Respond with JSON only — no explanation text before or after:
 {
   "passed": boolean,
+  "inspectedFiles": ["relative/path/you/actually/opened.ts"],
   "findings": [
     {
       "severity": "error" | "warning" | "info" | "unverifiable",
@@ -64,7 +65,8 @@ Notes:
 - \`acIndex\` is required when severity is "error" (1-based, into the Acceptance Criteria list above).
 - \`acQuote\` is optional advisory metadata for human auditors — not validated.
 - Omit both for "warning", "info", "unverifiable".
-If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.
+- \`inspectedFiles\` must list the relative paths you actually opened while reviewing. A \`passed:true\` verdict with an empty or absent \`inspectedFiles\` is invalid — walk each AC against the real files before passing.
+If all ACs are correctly implemented after inspecting the code, respond with { "passed": true, "inspectedFiles": ["..."], "findings": [] }.
 
 ## Git Diff (production code only — test files excluded)
 
@@ -120,6 +122,7 @@ Do NOT flag: style issues, naming conventions, import ordering, file length, or 
 Respond with JSON only — no explanation text before or after:
 {
   "passed": boolean,
+  "inspectedFiles": ["relative/path/you/actually/opened.ts"],
   "findings": [
     {
       "severity": "error" | "warning" | "info" | "unverifiable",
@@ -143,7 +146,8 @@ Notes:
 - \`acIndex\` is required when severity is "error" (1-based, into the Acceptance Criteria list above).
 - \`acQuote\` is optional advisory metadata for human auditors — not validated.
 - Omit both for "warning", "info", "unverifiable".
-If all ACs are correctly implemented, respond with { "passed": true, "findings": [] }.
+- \`inspectedFiles\` must list the relative paths you actually opened while reviewing. A \`passed:true\` verdict with an empty or absent \`inspectedFiles\` is invalid — walk each AC against the real files before passing.
+If all ACs are correctly implemented after inspecting the code, respond with { "passed": true, "inspectedFiles": ["..."], "findings": [] }.
 
 ## Git Diff (production code only — test files excluded)
 

--- a/test/unit/prompts/adversarial-review-builder.test.ts
+++ b/test/unit/prompts/adversarial-review-builder.test.ts
@@ -154,6 +154,28 @@ describe("AdversarialReviewPromptBuilder — embedded mode", () => {
 
 // ─── custom rules ─────────────────────────────────────────────────────────────
 
+describe("AdversarialReviewPromptBuilder — placeholder-test carve-out (#2) and inspection trail (#3A)", () => {
+  test("instructs emitting placeholder/tautological tests as error/test-gap", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, { mode: "ref", storyGitRef: STORY_GIT_REF });
+    expect(result).toContain("expect(true).toBe(true)");
+    expect(result).toContain('`category:"test-gap"`');
+    // The carve-out must override the "AC names the file but not the symbol" trap.
+    expect(result).toContain("The symbol-naming requirement is waived for this category.");
+  });
+
+  test("output schema requires an inspectedFiles trail and forbids rubber-stamping", () => {
+    const result = builder.buildAdversarialReviewPrompt(STORY, CONFIG, { mode: "ref", storyGitRef: STORY_GIT_REF });
+    expect(result).toContain('"inspectedFiles"');
+    expect(result).toContain("No rubber-stamping");
+  });
+
+  test("demandInspection re-prompt names inspectedFiles and demands tool use", () => {
+    const reprompt = AdversarialReviewPromptBuilder.demandInspection();
+    expect(reprompt).toContain("inspectedFiles");
+    expect(reprompt).toContain("did not open any of the changed files");
+  });
+});
+
 describe("AdversarialReviewPromptBuilder — custom rules", () => {
   test("prompt contains custom rule text when rules are set in config", () => {
     const configWithRules: AdversarialReviewConfig = {

--- a/test/unit/review/ac-quote-validator.test.ts
+++ b/test/unit/review/ac-quote-validator.test.ts
@@ -4,8 +4,6 @@
 
 import { describe, expect, test } from "bun:test";
 import {
-  type AcDroppedEntry,
-  type AcGroundingMinimalRejection,
   type AcQuotable,
   filterByAcGroundingMinimal,
   filterByAcQuote,
@@ -79,6 +77,61 @@ describe("validateAcQuote", () => {
       });
     });
 
+    describe("test-gap carve-out (placeholder/fake tests — #2)", () => {
+      // A fake test (`expect(true).toBe(true)`) covering an AC cannot name a
+      // symbol from the AC in its quote — the whole point is the test verifies
+      // nothing. The carve-out waives only the locus-keyword requirement; the
+      // acIndex + substring checks still apply.
+      test("test-gap error with valid acQuote but NO locus keyword → valid (waived)", () => {
+        const finding = makeFinding({
+          severity: "error",
+          category: "test-gap",
+          file: "test/unit/execution/story-orchestrator-gates.test.ts",
+          issue: "every test body is expect(true).toBe(true) — AC behaviour unverified",
+          acQuote: "must return a rejection code when acQuote is absent",
+          acIndex: 1,
+        });
+        expect(validateAcQuote(finding, ACS)).toEqual({ valid: true });
+      });
+
+      test("test-gap error still requires acQuote to be a substring of the AC", () => {
+        const finding = makeFinding({
+          severity: "error",
+          category: "test-gap",
+          file: "test/unit/foo.test.ts",
+          issue: "placeholder test",
+          acQuote: "this text is not in any AC",
+          acIndex: 1,
+        });
+        expect(validateAcQuote(finding, ACS)).toEqual({ valid: false, code: "ac_quote_not_substring" });
+      });
+
+      test("test-gap error still requires acIndex in range", () => {
+        const finding = makeFinding({
+          severity: "error",
+          category: "test-gap",
+          acQuote: "must return a rejection code",
+          acIndex: 0,
+        });
+        expect(validateAcQuote(finding, ACS)).toEqual({ valid: false, code: "ac_index_out_of_range" });
+      });
+
+      test("non-test-gap category with no locus keyword is still dropped (carve-out is scoped)", () => {
+        const finding = makeFinding({
+          severity: "error",
+          category: "convention",
+          file: "src/xyzzy-module.ts",
+          issue: "xyzzy function missing",
+          acQuote: "Warning and info findings must pass",
+          acIndex: 3,
+        });
+        expect(validateAcQuote(finding, ACS)).toEqual({
+          valid: false,
+          code: "ac_quote_does_not_constrain_locus",
+        });
+      });
+    });
+
     test("error with valid acQuote and matching locus keyword → valid", () => {
       const finding = makeFinding({
         severity: "error",
@@ -116,9 +169,7 @@ describe("validateAcQuote", () => {
       ["without backticks", "planInteractiveOp is a RunOperation exported from src/operations/plan.ts"],
       ["with backticks", "`planInteractiveOp` is a `RunOperation` exported from `src/operations/plan.ts`"],
     ] as const)("acQuote %s matches AC text that has backtick formatting", (_label, acQuote) => {
-      const backtickAcs = [
-        "`planInteractiveOp` is a `RunOperation` exported from `src/operations/plan.ts`.",
-      ];
+      const backtickAcs = ["`planInteractiveOp` is a `RunOperation` exported from `src/operations/plan.ts`."];
       const finding: AcQuotable = {
         severity: "error",
         file: "src/operations/plan.ts",
@@ -171,8 +222,18 @@ test.each(FILTER_FNS)("%s — non-blocking findings always accepted", (_name, fn
 });
 
 test.each([
-  ["filterByAcQuote (missing_ac_quote)", filterByAcQuote, makeFinding({ severity: "error", issue: "sentinel" }), "missing_ac_quote"],
-  ["filterByAcGroundingMinimal (missing_ac_index)", filterByAcGroundingMinimal, makeFinding({ severity: "error", issue: "sentinel-minimal" }), "missing_ac_index"],
+  [
+    "filterByAcQuote (missing_ac_quote)",
+    filterByAcQuote,
+    makeFinding({ severity: "error", issue: "sentinel" }),
+    "missing_ac_quote",
+  ],
+  [
+    "filterByAcGroundingMinimal (missing_ac_index)",
+    filterByAcGroundingMinimal,
+    makeFinding({ severity: "error", issue: "sentinel-minimal" }),
+    "missing_ac_index",
+  ],
 ] as const)("%s — dropped entry preserves original finding reference", (_name, fn, finding, code) => {
   const result = fn([finding], ACS);
   expect(result.dropped[0].finding.issue).toBe(finding.issue);
@@ -182,7 +243,6 @@ test.each([
 // ─── filterByAcQuote ──────────────────────────────────────────────────────────
 
 describe("filterByAcQuote", () => {
-
   test("error finding without acQuote is dropped with missing_ac_quote", () => {
     const findings = [makeFinding({ severity: "error" })];
     const result = filterByAcQuote(findings, ACS);
@@ -227,7 +287,6 @@ describe("filterByAcQuote", () => {
     expect(result.dropped[0].code).toBe("missing_ac_quote");
   });
 
-
   test("preserves concrete AdversarialLLMFinding shape (category field)", () => {
     type AdversarialShape = AcQuotable & { category: string };
     const finding: AdversarialShape = {
@@ -271,7 +330,10 @@ describe("validateAcGroundingMinimal", () => {
 
     // Contract regression test: acQuote content is NEVER inspected — only acIndex range matters
     test.each<[string, ReturnType<typeof makeFinding>]>([
-      ["acQuote not in any AC", makeFinding({ severity: "error", acIndex: 1, acQuote: "this text is nowhere in any AC" })],
+      [
+        "acQuote not in any AC",
+        makeFinding({ severity: "error", acIndex: 1, acQuote: "this text is nowhere in any AC" }),
+      ],
       ["no acQuote", makeFinding({ severity: "error", acIndex: 1 })],
       ["acIndex at last AC", makeFinding({ severity: "error", acIndex: ACS.length })],
     ])("valid for %s", (_label, finding) => {


### PR DESCRIPTION
## Summary

Closes three review-quality gaps found by a prompt-audit analysis of recent **nax** and **rs-stock** runs (`docs/findings/2026-05-30-prompt-audit-analysis.md`). All three were still live or latent in the audited data.

### #2 — Adversarial review now blocks fake/placeholder tests
A 460-line test file where every body was `expect(true).toBe(true)` (covering ACs) passed review as a non-blocking *warning*. Two coordinated changes fix this:
- **Prompt** (`adversarial-review-builder.ts`): instruct emitting tautological/placeholder/skipped test bodies that cover an AC as `severity:"error"`, `category:"test-gap"`, and carve them out of the "AC names the file but not the symbol" downgrade trap.
- **Validator** (`ac-quote-validator.ts`): waive the locus-keyword check for `category:"test-gap"` findings (still requires a valid `acIndex` + verbatim AC substring). A test-gap is the *absence* of a symbol, so requiring the quote to name a present symbol was self-defeating and silently dropped the finding.

### #3A — Inspection-trail guard against rubber-stamp reviews
`opencode` reviews frequently returned a bare `{"passed":true,"findings":[]}` with zero investigation (≈23% of its rs-stock reviews; an empty-findings pass also bypasses `verify()` substantiation entirely).
- Both review output schemas now require an `inspectedFiles` trail + a "no rubber-stamping" instruction.
- Both review op hopBodies (`semantic-review.ts`, `adversarial-review.ts`): in ref mode, an empty-findings `passed:true` verdict with no `inspectedFiles` triggers **exactly one** same-session `demandInspection()` re-prompt before the pass is trusted. Gated by `review.demandInspectionTrail` (default `true`, configurable on both reviewers).

### #3B — Observable AC-refinement degradation
When a weaker agent returns an empty/non-JSON response, `parseRefinementResponse` silently falls back to *unrefined* criteria — previously invisible in the run log. `acceptance-refine` now logs a structured warn when (and only when) an actual fallback occurs.

> Note on #3B scope: a true `op.retry` was descoped because `acceptance-refine` is a complete-kind op (`makeParseRetryStrategy` can't re-prompt there — `lastOutput` is unpopulated for `site:"complete"`) and the graceful "never throws → fall back" behavior is a tested contract relied on by two callers. The observability fix preserves that contract. See the findings doc for the full rationale.

## Test plan
- [x] New tests: validator test-gap carve-out; both hopBody guards (fires / has-trail / disabled / embedded / unparseable-second-turn); `refinementWouldFallback` agreement with the parser; `demandInspectionTrail` defaulting + disablability on both reviewers; adversarial prompt-shape assertions.
- [x] Existing reground/requote fixtures updated with `inspectedFiles` to isolate their own concern.
- [x] `bun run typecheck` clean; `bun run lint` clean.
- [x] **2630 pass / 0 fail** across `config` + `operations` + `review` + `prompts` + `acceptance` unit suites; `integration/review` 30 pass.

## Review notes
A code review pass caught and this PR fixes: **H1** (the `demandInspectionTrail` flag was schema-stripped/undisablable on the semantic reviewer) and **M1** (the degradation predicate disagreed with the real parser on empty `[]`). L1/L2 clarifying comments added (`category` is untrusted input → relaxes locus only; second-turn findings skip the requote/reground rescue — intentional).

Pre-existing, out of scope: `acRegroundOnDrop` is likewise missing from `SemanticReviewConfigSchema` (same always-on situation) — not touched here.