### PR TITLE
feat(plan): warn on dropped [verbatim] spec ACs in debate synthesis path

### DIFF
--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -3,6 +3,7 @@ export { planInteractiveOp } from "./plan";
 export type { PlanInteractiveInput } from "./plan";
 export { planRefineOp, _planRefineDeps } from "./plan-refine";
 export type { PlanRefineInput } from "./plan-refine";
+export { warnOnDroppedVerbatimAcs } from "./verbatim-warn";
 export { decomposeOp } from "./decompose";
 export type { DecomposeOpInput, DecomposeOpOutput } from "./decompose";
 export { buildHopCallback, _buildHopCallbackDeps } from "./build-hop-callback";

--- a/src/plan/strategies/debate.ts
+++ b/src/plan/strategies/debate.ts
@@ -1,6 +1,6 @@
 import type { DebateStageConfig } from "@/debate/types";
 import { NaxError } from "@/errors";
-import { callOp, planInteractiveOp } from "@/operations";
+import { callOp, planInteractiveOp, warnOnDroppedVerbatimAcs } from "@/operations";
 import type { CallContext, PlanInteractiveInput } from "@/operations";
 import { validatePlanOutput } from "@/prd";
 import type { PRD } from "@/prd/types";
@@ -76,6 +76,11 @@ export class DebatePlanStrategy implements IPlanStrategy {
 
       if (debateResult.outcome !== "failed" && debateResult.output) {
         const prd = validatePlanOutput(debateResult.output, ctx.options.feature, ctx.branchName);
+        // Debate synthesis merges debater candidates and can paraphrase or drop a
+        // [verbatim] spec AC. The fallback planInteractiveOp path below already warns
+        // via its verify hook; the synthesis path has no op verify, so warn here for
+        // parity with refine/single. Warn-and-continue — spec-review --prd is the gate.
+        warnOnDroppedVerbatimAcs(prd, ctx.specContent, ctx.options.feature);
         const withProject = { ...prd, project: ctx.projectName } satisfies PRD;
         return _debatePlanDeps.writeOrRecoverPrd(ctx, withProject);
       }

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -33,3 +33,4 @@ export { waitForCondition } from "./timeout";
 export { makeLinkWithCosts } from "./link-with-costs";
 export { makeMockCallContext } from "./call-context";
 export { makeMockPlanInputs } from "./plan-inputs";
+export { verbatimWarn, withWarnSpy } from "./verbatim-warn-spy";

--- a/test/helpers/verbatim-warn-spy.ts
+++ b/test/helpers/verbatim-warn-spy.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared spy helpers for the `[verbatim]` spec-AC drift warning emitted by
+ * `warnOnDroppedVerbatimAcs` (src/operations/verbatim-warn.ts). All three plan
+ * modes (single / refine / debate) emit the same `logger.warn("plan", "[verbatim] …")`
+ * signal, so their tests assert against it identically.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { withWarnSpy, verbatimWarn } from "../../helpers";
+ *
+ * await withWarnSpy(async (warnSpy) => {
+ *   await runThePlanPath();
+ *   const warn = verbatimWarn(warnSpy);
+ *   expect(warn).toBeDefined();
+ *   expect((warn?.[2] as { missingCount: number }).missingCount).toBe(1);
+ * });
+ * ```
+ */
+
+import { spyOn } from "bun:test";
+
+type WarnSpy = ReturnType<typeof spyOn>;
+
+/**
+ * Install a spy on the logger's `warn` method for the duration of `fn`, then
+ * restore it. Resets the logger before and after so the spied instance is the
+ * one the code under test resolves via `getSafeLogger()`.
+ */
+export async function withWarnSpy<T>(fn: (warnSpy: WarnSpy) => Promise<T>): Promise<T> {
+  const { resetLogger, initLogger } = await import("@/logger");
+  resetLogger();
+  const warnSpy = spyOn(initLogger({ level: "silent" }), "warn");
+  try {
+    return await fn(warnSpy);
+  } finally {
+    warnSpy.mockRestore();
+    resetLogger();
+  }
+}
+
+/**
+ * The first `logger.warn` call on the `"plan"` channel whose message mentions
+ * `[verbatim]`, or `undefined` if none fired. The returned tuple is
+ * `[channel, message, data]`.
+ */
+export function verbatimWarn(warnSpy: WarnSpy) {
+  return warnSpy.mock.calls.find((c) => c[0] === "plan" && String(c[1]).includes("[verbatim]"));
+}

--- a/test/unit/operations/plan-interactive.test.ts
+++ b/test/unit/operations/plan-interactive.test.ts
@@ -10,12 +10,12 @@
  * - Has recover method for disk fallback
  */
 
-import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { ParseValidationError } from "@/agents";
 import type { RetryStrategy } from "@/agents";
 import { planInteractiveOp } from "@/operations";
 import { validatePlanOutput } from "@/prd";
-import { makeTestRuntime } from "@test/helpers";
+import { makeTestRuntime, verbatimWarn, withWarnSpy } from "@test/helpers";
 import type { NaxRuntime } from "@/runtime";
 
 const createdRuntimes: NaxRuntime[] = [];
@@ -276,22 +276,6 @@ describe("planInteractiveOp.verify — [verbatim] residual-drift warning (single
       createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
       userStories: [storyWith(acs)],
     };
-  }
-
-  async function withWarnSpy<T>(fn: (warnSpy: ReturnType<typeof spyOn>) => Promise<T>): Promise<T> {
-    const { resetLogger, initLogger } = await import("@/logger");
-    resetLogger();
-    const warnSpy = spyOn(initLogger({ level: "silent" }), "warn");
-    try {
-      return await fn(warnSpy);
-    } finally {
-      warnSpy.mockRestore();
-      resetLogger();
-    }
-  }
-
-  function verbatimWarn(warnSpy: ReturnType<typeof spyOn>) {
-    return warnSpy.mock.calls.find((c) => c[0] === "plan" && String(c[1]).includes("[verbatim]"));
   }
 
   const input = { specContent: SPEC_WITH_VERBATIM, codebaseContext: "", featureName: "test-feature", branchName: "feat/test", outputPath: "/tmp/prd.json" };

--- a/test/unit/operations/plan-refine.test.ts
+++ b/test/unit/operations/plan-refine.test.ts
@@ -6,7 +6,7 @@ import { PlanPromptBuilder } from "@/prompts";
 import { planInteractiveOp } from "@/operations";
 import type { VerifyContext } from "@/operations";
 import type { NaxRuntime } from "@/runtime";
-import { makeMockAgentManager, makeSessionManager, makeTestRuntime, withTempDir } from "@test/helpers";
+import { makeMockAgentManager, makeSessionManager, makeTestRuntime, verbatimWarn, withTempDir, withWarnSpy } from "@test/helpers";
 import type { HopBodyContext } from "@/operations/types";
 
 const createdRuntimes: NaxRuntime[] = [];
@@ -289,21 +289,6 @@ describe("planRefineOp.hopBody()", () => {
   });
 });
 
-async function withWarnSpy<T>(fn: (warnSpy: ReturnType<typeof spyOn>) => Promise<T>): Promise<T> {
-  const { resetLogger, initLogger } = await import("@/logger");
-  resetLogger();
-  const warnSpy = spyOn(initLogger({ level: "silent" }), "warn");
-  try {
-    return await fn(warnSpy);
-  } finally {
-    warnSpy.mockRestore();
-    resetLogger();
-  }
-}
-
-function verbatimWarn(warnSpy: ReturnType<typeof spyOn>) {
-  return warnSpy.mock.calls.find((c) => c[0] === "plan" && String(c[1]).includes("[verbatim]"));
-}
 
 describe("planRefineOp — warn-and-continue when self-heal still drops a verbatim AC", () => {
   test("callOp returns the PRD and warns (does not fail) after the repair turn still misses", async () => {

--- a/test/unit/plan/debate-strategy.test.ts
+++ b/test/unit/plan/debate-strategy.test.ts
@@ -8,7 +8,7 @@ import type { InteractionBridge } from "@/interaction/bridge-builder";
 import type { NaxRuntime } from "@/runtime";
 import type { PRD } from "@/prd/types";
 import { PlanPromptBuilder } from "@/prompts";
-import { makeMockAgentManager } from "@test/helpers";
+import { makeMockAgentManager, verbatimWarn, withWarnSpy } from "@test/helpers";
 
 function makeRuntime(closeImpl = mock(async () => {})): NaxRuntime {
   return {
@@ -196,22 +196,6 @@ describe("DebatePlanStrategy", () => {
     });
     expect(ctx.runtime.close).toHaveBeenCalledTimes(1);
   });
-
-  async function withWarnSpy<T>(fn: (warnSpy: ReturnType<typeof spyOn>) => Promise<T>): Promise<T> {
-    const { resetLogger, initLogger } = await import("@/logger");
-    resetLogger();
-    const warnSpy = spyOn(initLogger({ level: "silent" }), "warn");
-    try {
-      return await fn(warnSpy);
-    } finally {
-      warnSpy.mockRestore();
-      resetLogger();
-    }
-  }
-
-  function verbatimWarn(warnSpy: ReturnType<typeof spyOn>) {
-    return warnSpy.mock.calls.find((c) => c[0] === "plan" && String(c[1]).includes("[verbatim]"));
-  }
 
   // Debate parity (#1160 follow-up): the synthesis path has no op verify, so the
   // strategy must warn directly when synthesis drops a [verbatim] spec AC.

--- a/test/unit/plan/debate-strategy.test.ts
+++ b/test/unit/plan/debate-strategy.test.ts
@@ -197,6 +197,53 @@ describe("DebatePlanStrategy", () => {
     expect(ctx.runtime.close).toHaveBeenCalledTimes(1);
   });
 
+  async function withWarnSpy<T>(fn: (warnSpy: ReturnType<typeof spyOn>) => Promise<T>): Promise<T> {
+    const { resetLogger, initLogger } = await import("@/logger");
+    resetLogger();
+    const warnSpy = spyOn(initLogger({ level: "silent" }), "warn");
+    try {
+      return await fn(warnSpy);
+    } finally {
+      warnSpy.mockRestore();
+      resetLogger();
+    }
+  }
+
+  function verbatimWarn(warnSpy: ReturnType<typeof spyOn>) {
+    return warnSpy.mock.calls.find((c) => c[0] === "plan" && String(c[1]).includes("[verbatim]"));
+  }
+
+  // Debate parity (#1160 follow-up): the synthesis path has no op verify, so the
+  // strategy must warn directly when synthesis drops a [verbatim] spec AC.
+  test("warns when the synthesis PRD drops a [verbatim] spec AC", async () => {
+    const runPlanMock = mock(async () => ({ outcome: "passed", output: JSON.stringify(SAMPLE_PRD) }));
+    const ctx = makeContext({
+      specContent: '- [verbatim] `grep -rn "gone" src/` returns zero matches',
+      deps: makeDeps({ createDebateRunner: mock(() => ({ runPlan: runPlanMock })) }),
+    });
+
+    await withWarnSpy(async (warnSpy) => {
+      await new DebatePlanStrategy().execute(ctx);
+      const warn = verbatimWarn(warnSpy);
+      expect(warn).toBeDefined();
+      expect((warn?.[2] as { missingCount: number }).missingCount).toBe(1);
+    });
+  });
+
+  test("does not warn when the synthesis PRD preserves the [verbatim] spec AC", async () => {
+    const runPlanMock = mock(async () => ({ outcome: "passed", output: JSON.stringify(SAMPLE_PRD) }));
+    const ctx = makeContext({
+      // SAMPLE_PRD's only AC is "The plan is produced" — match it verbatim.
+      specContent: "- [verbatim] The plan is produced",
+      deps: makeDeps({ createDebateRunner: mock(() => ({ runPlan: runPlanMock })) }),
+    });
+
+    await withWarnSpy(async (warnSpy) => {
+      await new DebatePlanStrategy().execute(ctx);
+      expect(verbatimWarn(warnSpy)).toBeUndefined();
+    });
+  });
+
   test("falls back to callOp with planInteractiveOp and persists via writeOrRecoverPrd when runPlan fails", async () => {
     const fallbackPrd = SAMPLE_PRD;
     const runPlanMock = mock(async () => ({


### PR DESCRIPTION
## Summary

Closes the highest-leverage parity gap remaining from #1160: `debate` plan mode now warns when synthesis drops a `[verbatim]` spec acceptance criterion, matching `refine` and `single`.

#1160 added a warn-and-continue soft-gate (`warnOnDroppedVerbatimAcs`) to the plan ops via their `verify` hooks — `refine` (`planRefineOp.verify`) and `single` (`planInteractiveOp.verify`). Debate's **synthesis path** produces its PRD via `validatePlanOutput` with no op `verify`, so it silently shipped drift. The fidelity finding (`docs/findings/nax-plan-prd-fidelity.md`) flagged debate as the *worst* mode for AC preservation — its grounder pulls the PRD toward repo support and synthesis merges debater candidates — which made this the most valuable mode left to cover.

## Changes

- **`src/operations/index.ts`** — barrel-export `warnOnDroppedVerbatimAcs`.
- **`src/plan/strategies/debate.ts`** — call the helper in the synthesis path (after `validatePlanOutput`, before `writeOrRecoverPrd`). Only the synthesis path is wired: the debate **fallback path** dispatches `planInteractiveOp` via `callOp`, which already inherits the warn through its `verify` hook — so no double-warn.
- **`test/helpers/verbatim-warn-spy.ts`** (new) — shared `withWarnSpy` + `verbatimWarn`, extracted from three duplicate copies (crossed the project's 3-files-then-extract threshold). Refactored `plan-interactive`, `plan-refine`, and `debate-strategy` tests to import from `@test/helpers`.

## Design

Warn-and-continue, **not** a hard fail — `nax plan` is intentionally recovery-tolerant; spec-review Phase 9 (`--prd`) stays the explicit gate. Consistent with the #1160 decision.

## Test plan

- [x] `bun run typecheck` — exit 0
- [x] `bun run lint` — clean (alias / deep-relative / nax-error / storyid baselines all OK)
- [x] `AGENT=1 bun test test/unit/plan/ test/unit/operations/plan-refine.test.ts test/unit/operations/plan-interactive.test.ts` — all pass
- [x] New tests: warns on dropped `[verbatim]` AC (asserts `missingCount === 1`); silent when preserved
- [x] code-reviewer agent pass — APPROVE, no CRITICAL/HIGH

## Deferred (out of scope)

Layer C (`spec-trace.json` + similarity coverage for non-verbatim ACs), Layer D (spec-writing Design→AC matrix), and the known fenced/sub-bullet verbatim limitation (documented + test-pinned).
