### PR TITLE
fix(rectify): permit test edits for single-session implementers

### DIFF
--- a/src/prompts/builders/rectifier-builder-helpers.ts
+++ b/src/prompts/builders/rectifier-builder-helpers.ts
@@ -134,6 +134,69 @@ ${exceptions.join("\n\n")}`;
 const THREE_SESSION_STRATEGIES = new Set(["three-session-tdd", "three-session-tdd-lite"]);
 
 /**
+ * Single-session strategies in which ONE agent writes both the tests and the
+ * implementation in the same session. No separate test-writer owns the test
+ * contract, so the implementer authored the tests and MAY edit them during
+ * rectification (permit-with-guard) — unlike three-session TDD where the
+ * "do not modify test files" rule is absolute.
+ *
+ * `no-test` is excluded: it produces no tests, so there is nothing to own or edit.
+ */
+const SINGLE_SESSION_TEST_OWNING_STRATEGIES = new Set(["tdd-simple", "test-after"]);
+
+/**
+ * True when the story's strategy makes the implementer the author of its own
+ * tests (single-session). Such an implementer may edit test files to resolve
+ * genuine AC/spec contradictions during rectification.
+ */
+export function implementerOwnsTests(story: UserStory): boolean {
+  return SINGLE_SESSION_TEST_OWNING_STRATEGIES.has(story.routing?.testStrategy ?? "");
+}
+
+/**
+ * Permit-with-guard headline for single-session implementers. Replaces the
+ * "Do NOT change test files…" prohibition that three-session stories receive.
+ */
+const SINGLE_SESSION_PERMIT_HEADLINE =
+  "You authored these tests in the same session as the implementation, so you MAY edit test files — but ONLY to resolve a genuine contradiction between a test and this story's acceptance criteria (or between two acceptance criteria). NEVER weaken, delete, loosen, or skip a test merely to make it pass. See the test-edit guidance appended below.";
+
+/**
+ * Appended guidance block for single-session implementers. Stands in for the
+ * Exception 1–4 escape hatch (which encodes an absolute prohibition with narrow
+ * valves). Here the rule is inverted: edits are permitted but bounded.
+ */
+const SINGLE_SESSION_TEST_EDIT_POLICY = `
+
+## Test-edit guidance (single-session implementer)
+
+You wrote both the tests and the implementation for this story in one session, so no
+separate test-writer owns the test contract. You therefore MAY edit test files during
+rectification — subject to these limits:
+
+- Edit a test ONLY to resolve a genuine contradiction between the test and an acceptance
+  criterion, a contradiction between two acceptance criteria, or a clear defect in a test
+  you authored (wrong arity/type, impossible setup, or asserting behavior the ACs do not require).
+- NEVER weaken, delete, loosen, or \`skip\` a test simply because the implementation fails it.
+  A failing test usually means the SOURCE is wrong — fix the source first.
+- The semantic and adversarial reviewers still gate correctness; gaming a test to pass will be caught.
+
+If two findings or two acceptance criteria contradict each other and you cannot satisfy
+both even after adjusting tests, do not guess. Emit:
+UNRESOLVED: <which findings/ACs conflicted and why they cannot both be satisfied>`;
+
+/**
+ * Returns the test-edit directive sentence for a rectification prompt.
+ *
+ * For single-session strategies the implementer authored its own tests, so the
+ * directive permits bounded test edits. For all other strategies the caller's
+ * `prohibition` text (the existing "Do NOT … test files …" sentence) is returned
+ * verbatim, keeping three-session/no-test prompts byte-identical.
+ */
+export function testEditHeadline(story: UserStory, prohibition: string): string {
+  return implementerOwnsTests(story) ? SINGLE_SESSION_PERMIT_HEADLINE : prohibition;
+}
+
+/**
  * Returns "three" or "four" depending on whether the story uses a three-session TDD
  * flow that includes a test-writer agent. Use to interpolate counts in prompt text
  * that sits outside the escape-hatch block.
@@ -147,6 +210,7 @@ export function exceptionCountWord(story: UserStory): "three" | "four" {
  * based on whether the story runs a three-session TDD flow with a test-writer.
  */
 export function escapeHatchFor(story: UserStory): string {
+  if (implementerOwnsTests(story)) return SINGLE_SESSION_TEST_EDIT_POLICY;
   const isTdd = THREE_SESSION_STRATEGIES.has(story.routing?.testStrategy ?? "");
   return buildEscapeHatch({ includeMockHandoff: isTdd });
 }
@@ -236,7 +300,7 @@ ${errors}
 2. Only fix findings that are actually valid problems
 3. Do NOT add keys, functions, or imports that already exist — check first
 
-Do NOT change test files or test behavior — see the ${exceptionCountWord(story)} narrow exceptions appended below.
+${testEditHeadline(story, `Do NOT change test files or test behavior — see the ${exceptionCountWord(story)} narrow exceptions appended below.`)}
 Do NOT add new features — only fix valid issues.
 Commit your fixes when done.${scopeConstraint}${noTestIsolationBlock(story)}${escapeHatchFor(story)}`;
 }
@@ -309,6 +373,9 @@ export function mechanicalRectification(
   opts?: CheckErrorFormatOptions,
 ): string {
   const errors = formatCheckErrors(checks, opts);
+  const scopeDirective = implementerOwnsTests(story)
+    ? `Fix all errors listed above that are within this story's scope. ${SINGLE_SESSION_PERMIT_HEADLINE}`
+    : `Fix all errors listed above that are within this story's scope — see the ${exceptionCountWord(story)} narrow exceptions appended below for sibling-story spillover. Do NOT change test files or test behavior except via those exceptions.`;
 
   return `You are fixing lint/typecheck errors from a code review.
 
@@ -318,7 +385,7 @@ The following quality checks failed after implementation:
 
 ${errors}
 
-Fix all errors listed above that are within this story's scope — see the ${exceptionCountWord(story)} narrow exceptions appended below for sibling-story spillover. Do NOT change test files or test behavior except via those exceptions.
+${scopeDirective}
 Do NOT add new features — only fix the quality check errors.
 After fixing, re-run the failing check(s) to verify they pass, then commit your changes.${scopeConstraint}${noTestIsolationBlock(story)}${escapeHatchFor(story)}`;
 }

--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -37,6 +37,7 @@ import {
   formatCheckErrors,
   mechanicalRectification,
   semanticRectification,
+  testEditHeadline,
 } from "./rectifier-builder-helpers";
 
 export { CONTRADICTION_ESCAPE_HATCH } from "./rectifier-builder-helpers";
@@ -196,6 +197,8 @@ export class RectifierPromptBuilder {
     const parts: string[] = [];
     const attemptWord = maxAttempts === 1 ? "1 attempt" : `${maxAttempts} attempts`;
     const exCount = story ? exceptionCountWord(story) : "three";
+    const prohibition = `Do NOT change test files or test behavior — see the ${exCount} narrow exceptions appended below.`;
+    const testDirective = story ? testEditHeadline(story, prohibition) : prohibition;
 
     parts.push(
       `Review failed after your implementation. Fix the following issues (${attemptWord} available before escalation):\n`,
@@ -204,7 +207,7 @@ export class RectifierPromptBuilder {
     parts.push(renderPrioritizedFailures(failedChecks));
 
     parts.push(
-      `\nFix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. Do NOT change test files or test behavior — see the ${exCount} narrow exceptions appended below. Commit your changes when all checks pass.`,
+      `\nFix in priority order. After fixing each priority, re-run the failing check(s) at that level to verify they pass before moving on. ${testDirective} Commit your changes when all checks pass.`,
     );
     parts.push(story ? escapeHatchFor(story) : CONTRADICTION_ESCAPE_HATCH);
 
@@ -580,7 +583,7 @@ ${testCommands}
 6. Ensure ALL tests pass before completing.
 
 **IMPORTANT:**
-- Do NOT modify test files — see the ${exceptionCountWord(story)} narrow exceptions appended below if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
+- ${testEditHeadline(story, `Do NOT modify test files — see the ${exceptionCountWord(story)} narrow exceptions appended below if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.`)}
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements.
 - When running tests, run ONLY the failing test files shown above${cmd ? ` — NEVER run \`${cmd}\` without a file filter` : " — never run the full test suite without a file filter"}.
@@ -710,7 +713,7 @@ ${errors}${reasoningSection}${historySection}
 2. Only fix findings that are actually valid problems
 3. Do NOT add keys, functions, or imports that already exist — check first
 
-Do NOT change test files or test behavior — see the ${exceptionCountWord(story)} narrow exceptions appended below.
+${testEditHeadline(story, `Do NOT change test files or test behavior — see the ${exceptionCountWord(story)} narrow exceptions appended below.`)}
 Do NOT add new features — only fix valid issues.
 Commit your fixes when done.${scopeConstraint}${escapeHatchFor(story)}`;
   }
@@ -846,7 +849,7 @@ Tests are failing. Fix the source so all tests pass — not just the ones listed
 4. Do not declare done until step 3 shows 0 failures.
 
 **IMPORTANT:**
-- Do NOT modify test files — see the ${exceptionCountWord(opts.story)} narrow exceptions appended below if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.
+- ${testEditHeadline(opts.story, `Do NOT modify test files — see the ${exceptionCountWord(opts.story)} narrow exceptions appended below if you believe a test has a lint error, a PRD-contract mismatch, or belongs to a sibling story.`)}
 - Do NOT loosen assertions to mask implementation bugs.
 - Focus on fixing the source code to meet the test requirements.`);
 

--- a/test/unit/prompts/builders/rectifier-builder-helpers.test.ts
+++ b/test/unit/prompts/builders/rectifier-builder-helpers.test.ts
@@ -8,7 +8,13 @@
 
 import { describe, expect, test } from "bun:test";
 import { makeStory } from "../../../helpers";
-import { buildEscapeHatch, exceptionCountWord } from "../../../../src/prompts/builders/rectifier-builder-helpers";
+import {
+  buildEscapeHatch,
+  exceptionCountWord,
+  implementerOwnsTests,
+  testEditHeadline,
+  escapeHatchFor,
+} from "../../../../src/prompts/builders/rectifier-builder-helpers";
 import { RectifierPromptBuilder } from "../../../../src/prompts";
 import type { ReviewCheckResult } from "../../../../src/review/types";
 
@@ -34,6 +40,22 @@ const TDD_LITE_STORY = makeStory({
   description: "A story with three-session-tdd-lite.",
   acceptanceCriteria: ["AC1"],
   routing: { testStrategy: "three-session-tdd-lite", complexity: "simple", reasoning: "test" },
+});
+
+const TDD_SIMPLE_STORY = makeStory({
+  id: "US-SIMPLE",
+  title: "Single-session story",
+  description: "A story where one agent writes tests AND implementation.",
+  acceptanceCriteria: ["AC1"],
+  routing: { testStrategy: "tdd-simple", complexity: "medium", reasoning: "test" },
+});
+
+const TEST_AFTER_STORY = makeStory({
+  id: "US-AFTER",
+  title: "Test-after story",
+  description: "A story where the implementer writes tests after implementation.",
+  acceptanceCriteria: ["AC1"],
+  routing: { testStrategy: "test-after", complexity: "simple", reasoning: "test" },
 });
 
 // ─── buildEscapeHatch ─────────────────────────────────────────────────────────
@@ -194,5 +216,152 @@ describe("RectifierPromptBuilder.firstAttemptDelta — story-aware escape hatch"
     expect(result).toContain("three narrow exceptions appended below");
     expect(result).toContain("three narrow escape valves");
     expect(result).not.toContain("### Exception 4 — Mock-structure handoff");
+  });
+});
+
+// ─── Single-session implementer test-edit policy ──────────────────────────────
+//
+// In single-session strategies (tdd-simple, test-after) ONE agent writes both the
+// tests and the implementation. No separate test-writer owns the test contract, so
+// the implementer MAY edit test files during rectification (permit-with-guard) —
+// unlike three-session TDD where the prohibition is absolute. See US-003 in the
+// 2026-06-01 run: a single-session implementer punted with UNRESOLVED because the
+// rectification prompt forbade the test edit needed to resolve an AC contradiction.
+
+describe("implementerOwnsTests", () => {
+  test("tdd-simple → true (single-session, implementer authors tests)", () => {
+    expect(implementerOwnsTests(TDD_SIMPLE_STORY)).toBe(true);
+  });
+
+  test("test-after → true (single-session, implementer authors tests)", () => {
+    expect(implementerOwnsTests(TEST_AFTER_STORY)).toBe(true);
+  });
+
+  test("three-session-tdd → false (separate test-writer owns tests)", () => {
+    expect(implementerOwnsTests(TDD_STORY)).toBe(false);
+  });
+
+  test("three-session-tdd-lite → false (separate test-writer owns tests)", () => {
+    expect(implementerOwnsTests(TDD_LITE_STORY)).toBe(false);
+  });
+
+  test("no-test → false (no tests to own)", () => {
+    expect(implementerOwnsTests(NO_TEST_STORY)).toBe(false);
+  });
+
+  test("no routing → false (safe default: keep prohibition)", () => {
+    expect(implementerOwnsTests(makeStory({ id: "US-X", routing: undefined }))).toBe(false);
+  });
+});
+
+describe("testEditHeadline", () => {
+  const PROHIBITION = "Do NOT change test files or test behavior — see the three narrow exceptions appended below.";
+
+  test("single-session story → permit headline (MAY edit), not the prohibition", () => {
+    const headline = testEditHeadline(TDD_SIMPLE_STORY, PROHIBITION);
+    expect(headline).toContain("MAY edit test files");
+    expect(headline).not.toContain("Do NOT change test files");
+  });
+
+  test("test-after story → permit headline", () => {
+    expect(testEditHeadline(TEST_AFTER_STORY, PROHIBITION)).toContain("MAY edit test files");
+  });
+
+  test("three-session story → returns the prohibition text verbatim (unchanged)", () => {
+    expect(testEditHeadline(TDD_STORY, PROHIBITION)).toBe(PROHIBITION);
+  });
+
+  test("no-test story → returns the prohibition text verbatim (unchanged)", () => {
+    expect(testEditHeadline(NO_TEST_STORY, PROHIBITION)).toBe(PROHIBITION);
+  });
+});
+
+describe("escapeHatchFor — single-session permit block", () => {
+  test("tdd-simple: emits permit-with-guard guidance, not the absolute prohibition", () => {
+    const hatch = escapeHatchFor(TDD_SIMPLE_STORY);
+    expect(hatch).toContain("Test-edit guidance (single-session implementer)");
+    expect(hatch).toContain("MAY edit test files");
+    expect(hatch).toContain("NEVER weaken, delete, loosen");
+    // The absolute-prohibition framing and Exception 4 handoff must NOT appear.
+    expect(hatch).not.toContain("the rule is absolute");
+    expect(hatch).not.toContain("### Exception 4 — Mock-structure handoff");
+  });
+
+  test("test-after: emits permit-with-guard guidance", () => {
+    expect(escapeHatchFor(TEST_AFTER_STORY)).toContain("Test-edit guidance (single-session implementer)");
+  });
+
+  test("three-session-tdd: unchanged — four-exception prohibition hatch", () => {
+    const hatch = escapeHatchFor(TDD_STORY);
+    expect(hatch).toContain("four narrow escape valves");
+    expect(hatch).toContain("the rule is absolute");
+    expect(hatch).toContain("### Exception 4 — Mock-structure handoff");
+    expect(hatch).not.toContain("Test-edit guidance (single-session implementer)");
+  });
+
+  test("no-test: unchanged — three-exception prohibition hatch", () => {
+    const hatch = escapeHatchFor(NO_TEST_STORY);
+    expect(hatch).toContain("three narrow escape valves");
+    expect(hatch).not.toContain("Test-edit guidance (single-session implementer)");
+  });
+});
+
+describe("rectification prompts — single-session permits test edits (US-003 regression)", () => {
+  test("reviewRectification(semantic) for tdd-simple: permits edits, drops the prohibition", () => {
+    const result = RectifierPromptBuilder.reviewRectification([makeCheck("semantic")], TDD_SIMPLE_STORY);
+    expect(result).toContain("MAY edit test files");
+    expect(result).toContain("Test-edit guidance (single-session implementer)");
+    expect(result).not.toContain("Do NOT change test files or test behavior");
+    expect(result).not.toContain("the rule is absolute");
+  });
+
+  test("reviewRectification(semantic) for three-session: still forbids test edits", () => {
+    const result = RectifierPromptBuilder.reviewRectification([makeCheck("semantic")], TDD_STORY);
+    expect(result).toContain("Do NOT change test files or test behavior");
+    expect(result).toContain("the rule is absolute");
+    expect(result).not.toContain("MAY edit test files");
+  });
+
+  test("firstAttemptDelta for tdd-simple: permits edits", () => {
+    const result = RectifierPromptBuilder.firstAttemptDelta([makeCheck("semantic")], 3, undefined, TDD_SIMPLE_STORY);
+    expect(result).toContain("MAY edit test files");
+    expect(result).not.toContain("Do NOT change test files or test behavior");
+  });
+
+  test("regressionFailure for tdd-simple: permits edits", () => {
+    const result = RectifierPromptBuilder.regressionFailure({
+      story: TDD_SIMPLE_STORY,
+      failures: [],
+      testCommand: "bun test",
+    });
+    expect(result).toContain("MAY edit test files");
+    expect(result).not.toContain("Do NOT modify test files");
+  });
+
+  test("mechanicalRectification(typecheck) for tdd-simple: permits edits", () => {
+    const result = RectifierPromptBuilder.reviewRectification([makeCheck("typecheck")], TDD_SIMPLE_STORY);
+    expect(result).toContain("MAY edit test files");
+    expect(result).not.toContain("Do NOT change test files or test behavior except via those exceptions");
+  });
+
+  test("escalated for tdd-simple: permits edits; three-session still forbids", () => {
+    const permitted = RectifierPromptBuilder.escalated([], TDD_SIMPLE_STORY, 2, "fast", "powerful");
+    expect(permitted).toContain("MAY edit test files");
+    expect(permitted).not.toContain("Do NOT modify test files");
+
+    const forbidden = RectifierPromptBuilder.escalated([], TDD_STORY, 2, "fast", "powerful");
+    expect(forbidden).toContain("Do NOT modify test files");
+    expect(forbidden).not.toContain("MAY edit test files");
+  });
+
+  test("dialogueAwareRectification for tdd-simple: permits edits; three-session still forbids", () => {
+    const opts = { findingReasoning: new Map<string, string>(), history: [] };
+    const permitted = RectifierPromptBuilder.dialogueAwareRectification([makeCheck("semantic")], TDD_SIMPLE_STORY, opts);
+    expect(permitted).toContain("MAY edit test files");
+    expect(permitted).not.toContain("Do NOT change test files or test behavior");
+
+    const forbidden = RectifierPromptBuilder.dialogueAwareRectification([makeCheck("semantic")], TDD_STORY, opts);
+    expect(forbidden).toContain("Do NOT change test files or test behavior");
+    expect(forbidden).not.toContain("MAY edit test files");
   });
 });


### PR DESCRIPTION
## Problem

Single-session strategies (`tdd-simple`, `test-after`) run **one** agent that writes both the tests and the implementation. No separate test-writer owns the test contract — yet every rectification prompt unconditionally told the implementer **"Do NOT change test files."**

In the `chart-pattern-strategy-wrappers` run (2026-06-01), **US-003** ran as `tdd-simple` ("Single session prepared"). Semantic review flagged a genuine acceptance-criteria contradiction (AC11 requires an invalid `direction` to reach `populate_indicators` so the detector's `ValueError` propagates, but `Literal["top","bottom"]` + AC6/AC7's construction-time assertions block it). The only fix required editing a test the implementer had authored — which the prompt forbade — so it punted with `UNRESOLVED`.

The codebase already distinguished TDD mode via `THREE_SESSION_STRATEGIES`, but used it **only** to gate Exception 4 (mock handoff). The core prohibition was hardcoded for all strategies.

## Fix (permit-with-guard)

- **`implementerOwnsTests(story)`** — new predicate; true for `tdd-simple`/`test-after` (implementer authors its own tests), false for three-session (separate test-writer) and `no-test`.
- **`escapeHatchFor(story)`** — returns a single-session test-edit policy block for those stories: permits bounded edits (resolve genuine AC/test contradictions) while explicitly forbidding weaken/delete/loosen/skip to make a test pass, and notes the semantic/adversarial reviewers still gate correctness.
- **`testEditHeadline(story, prohibition)`** — swaps the inline "Do NOT change test files" sentence for permit language in single-session; returns the prohibition **verbatim** otherwise.
- Wired through all rectification prompt sites: `semantic`, `adversarial`, `combined`, `mechanical`, `firstAttemptDelta`, `dialogueAware`, `escalated`, `regressionFailure`.

## Safety

- **Three-session-TDD, `no-test`, and no-routing stories are byte-identical** — snapshots unchanged.
- **No downstream collision**: the TDD verifier that re-rejects illegitimate test edits (`verdict.ts`) runs only for three-session; single-session uses `verifyScoped`, which does not judge edit legitimacy. So the permit cannot be silently re-rejected by a later gate.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] New tests in `rectifier-builder-helpers.test.ts`: predicate truth table (incl. `no-test`/undefined safe defaults), headline permit vs. verbatim-prohibition passthrough, `escapeHatchFor` permit block vs. unchanged 3/4-exception hatches, and end-to-end rendering through `reviewRectification`, `firstAttemptDelta`, `regressionFailure`, `escalated`, `dialogueAwareRectification`, mechanical — including a direct US-003 regression case.
- [x] Full suite: 8408 unit + 1077 integration + 11 UI, 0 failures, 24 snapshots intact.
- [x] Code review (code-reviewer agent): APPROVE, no CRITICAL/HIGH.