### PR TITLE
fix(rectification): route adversarial findings to implementer in single-session

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -90,4 +90,8 @@ export {
   getAcQualityRules,
   resolveTestStrategy,
   VALID_TEST_STRATEGIES,
+  THREE_SESSION_STRATEGIES,
+  SINGLE_SESSION_TEST_OWNING_STRATEGIES,
+  isThreeSessionStrategy,
+  isSingleSessionTestOwningStrategy,
 } from "./test-strategy";

--- a/src/config/test-strategy.ts
+++ b/src/config/test-strategy.ts
@@ -39,6 +39,44 @@ export function resolveTestStrategy(raw: string | undefined): TestStrategy {
   return "test-after"; // safe fallback
 }
 
+// ─── Classification predicates (SSOT) ────────────────────────────────────────
+
+/**
+ * Strategies that use the three-session TDD orchestration: a separate
+ * test-writer, implementer, and verifier session, with a full-suite gate
+ * between implementer and verifier. These are the only strategies that assemble
+ * the `autofix-test-writer` rectification strategy.
+ */
+export const THREE_SESSION_STRATEGIES: ReadonlySet<TestStrategy> = new Set([
+  "three-session-tdd",
+  "three-session-tdd-lite",
+]);
+
+/**
+ * Single-session strategies in which ONE agent writes both the tests and the
+ * implementation in the same session. The implementer authored its own tests
+ * and therefore MAY edit them during rectification (permit-with-guard) — unlike
+ * three-session TDD where the "do not modify test files" rule is absolute.
+ *
+ * `no-test` is excluded: it produces no tests, so there is nothing to own or edit.
+ */
+export const SINGLE_SESSION_TEST_OWNING_STRATEGIES: ReadonlySet<TestStrategy> = new Set(["tdd-simple", "test-after"]);
+
+/** True for strategies that run the three-session TDD orchestration. */
+export function isThreeSessionStrategy(strategy: TestStrategy | undefined): boolean {
+  return strategy !== undefined && THREE_SESSION_STRATEGIES.has(strategy);
+}
+
+/**
+ * True when the strategy makes the implementer the author of its own tests
+ * (single-session, test-owning), so it may edit test files to resolve genuine
+ * AC/spec contradictions during rectification. False for `no-test` and all
+ * three-session strategies.
+ */
+export function isSingleSessionTestOwningStrategy(strategy: TestStrategy | undefined): boolean {
+  return strategy !== undefined && SINGLE_SESSION_TEST_OWNING_STRATEGIES.has(strategy);
+}
+
 // ─── Prompt fragments (shared by plan.ts and claude-decompose.ts) ────────────
 
 export const COMPLEXITY_GUIDE = `## Complexity Classification Guide

--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -18,6 +18,7 @@
 
 import { join } from "node:path";
 import type { NaxConfig } from "../config";
+import { isThreeSessionStrategy } from "../config";
 import type { TestStrategy } from "../config/schema-types";
 import type { FixCycleContext } from "../findings/cycle-types";
 import type { FixStrategy } from "../findings/cycle-types";
@@ -41,25 +42,12 @@ import type { PlanInputs } from "./plan-inputs";
 import { type ExecutionPlan, type RectificationPhaseOptions, StoryOrchestratorBuilder } from "./story-orchestrator";
 
 /**
- * Strategies that use the three-session TDD orchestration (test-writer +
- * implementer + verifier, with full-suite gate between implementer and verifier).
- *
- * `tdd-simple` is NOT in this set — it is a single-session strategy where one
- * agent writes tests AND implements within the same session. The pre-US-005
- * execution stage gated the three-session path on the same two strategies
- * (see src/metrics/tracker.ts:142-143 and the archived single-session branch
- * in execution.ts before commit d97e25ae).
- */
-const THREE_SESSION_STRATEGIES = new Set<TestStrategy>(["three-session-tdd", "three-session-tdd-lite"]);
-
-export function isThreeSessionStrategy(strategy: TestStrategy): boolean {
-  return THREE_SESSION_STRATEGIES.has(strategy);
-}
-
-/**
  * Whether the wrapper must capture an initial git ref before the plan runs.
  * Only TDD strategies require this — non-TDD strategies have no rollback path.
  * Extracted so pipeline/stages/execution.ts can stay strategy-blind beyond this call.
+ *
+ * Strategy classification (`isThreeSessionStrategy`) is the SSOT in
+ * `src/config/test-strategy.ts` — do not re-declare the set here.
  */
 export function requiresInitialRefCapture(strategy: TestStrategy): boolean {
   return isThreeSessionStrategy(strategy);

--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -173,12 +173,28 @@ export async function buildPlanForStrategy(
       strategies.push(makeFullSuiteRectifyStrategy(story, config) as FixStrategy<Finding, unknown, unknown, unknown>);
     }
     if (config.quality.autofix?.enabled !== false) {
+      // Single-session strategies (tdd-simple / test-after / no-test) have no
+      // separate test-writer session — the one warm implementer session authored
+      // both source and tests. Route adversarial-review findings to that
+      // implementer instead of spinning up a fresh, context-less test-writer.
+      //
+      // Note: AC-HOOK / AC-ERROR sentinel findings (test-runner, fixTarget=test)
+      // are intentionally NOT re-routed here — they are owned by the acceptance
+      // loop, not the per-story rectification cycle, and a cold test-writer never
+      // resolved them usefully either.
       strategies.push(
-        makeAutofixImplementerStrategy(story, config, sink) as FixStrategy<Finding, unknown, unknown, unknown>,
+        makeAutofixImplementerStrategy(story, config, sink, {
+          includeAdversarialReview: !isThreeSession,
+        }) as FixStrategy<Finding, unknown, unknown, unknown>,
       );
-      strategies.push(
-        makeAutofixTestWriterStrategy(story, config, sink) as FixStrategy<Finding, unknown, unknown, unknown>,
-      );
+      // The autofix-test-writer strategy only belongs to three-session TDD,
+      // where the test-writer phase itself exists (see gating above where
+      // addTestWriter is conditioned on isThreeSession).
+      if (isThreeSession) {
+        strategies.push(
+          makeAutofixTestWriterStrategy(story, config, sink) as FixStrategy<Finding, unknown, unknown, unknown>,
+        );
+      }
     }
 
     const postValidate = async (findings: Finding[], _validateCtx: FixCycleContext): Promise<Finding[]> => {

--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -7,6 +7,7 @@
  */
 
 import { relative, sep } from "node:path";
+import { isThreeSessionStrategy } from "../config";
 import type { NaxConfig } from "../config/schema";
 import { filterContextByRole } from "../context";
 import { NaxError } from "../errors";
@@ -27,7 +28,6 @@ import { TddPromptBuilder } from "../prompts";
 import { prepareAdversarialReviewInput, prepareSemanticReviewInput } from "../review";
 import type { ResolvedTestPatterns } from "../test-runners";
 import { resolveTestFilePatterns } from "../test-runners/resolver";
-import { isThreeSessionStrategy } from "./build-plan-for-strategy";
 import type { RectificationPhaseOptions } from "./story-orchestrator";
 
 /**

--- a/src/operations/autofix-implementer-strategy.ts
+++ b/src/operations/autofix-implementer-strategy.ts
@@ -10,14 +10,32 @@ import type { DeclarationSink } from "./declaration-sink";
 
 const IMPLEMENTER_SOURCES = new Set(["lint", "typecheck", "semantic-review", "tdd-verifier"]);
 
+/** Options controlling which findings the implementer rectifier claims. */
+export interface AutofixImplementerStrategyOptions {
+  /**
+   * When true, the implementer also claims `adversarial-review` findings
+   * regardless of their `fixTarget`. Used for single-session strategies
+   * (tdd-simple / test-after / no-test) where there is no separate test-writer
+   * session — the one warm implementer session owns both source and tests, so
+   * routing adversarial findings to a fresh cold test-writer session (the
+   * three-session default) is wrong. See build-plan-for-strategy.ts.
+   * (default: false)
+   */
+  includeAdversarialReview?: boolean;
+}
+
 export function makeAutofixImplementerStrategy(
   story: UserStory,
   config: NaxConfig,
   sink: DeclarationSink,
+  opts: AutofixImplementerStrategyOptions = {},
 ): FixStrategy<Finding, AutofixImplementerInput, AutofixImplementerOutput, AutofixConfig> {
+  const claimsAdversarial = opts.includeAdversarialReview === true;
   return {
     name: "autofix-implementer",
-    appliesTo: (f) => f.fixTarget === "source" && IMPLEMENTER_SOURCES.has(f.source),
+    appliesTo: (f) =>
+      (f.fixTarget === "source" && IMPLEMENTER_SOURCES.has(f.source)) ||
+      (claimsAdversarial && f.source === "adversarial-review"),
     fixOp: implementerRectifyOp,
     buildInput: (findings, _prior, _cycleCtx): AutofixImplementerInput => ({
       failedChecks: findingsToFailedChecks(findings),

--- a/src/pipeline/stages/execution.ts
+++ b/src/pipeline/stages/execution.ts
@@ -9,14 +9,11 @@
  *   → applyPostRunInspection → decideStageAction.
  */
 
+import { isThreeSessionStrategy } from "@/config";
 import { validateAgentForTier } from "../../agents";
 import type { AgentAdapter } from "../../agents/types";
 import { NaxError } from "../../errors";
-import {
-  buildPlanForStrategy,
-  isThreeSessionStrategy,
-  requiresInitialRefCapture,
-} from "../../execution/build-plan-for-strategy";
+import { buildPlanForStrategy, requiresInitialRefCapture } from "../../execution/build-plan-for-strategy";
 import { assemblePlanInputsFromCtx } from "../../execution/plan-inputs";
 import { _postRunDeps, applyPostRunInspection, decideStageAction } from "../../execution/post-run";
 import type { TddMode } from "../../execution/post-run";

--- a/src/prompts/builders/rectifier-builder-helpers.ts
+++ b/src/prompts/builders/rectifier-builder-helpers.ts
@@ -5,6 +5,7 @@
  * All helpers are pure functions with no dependencies on the builder class.
  */
 
+import { isSingleSessionTestOwningStrategy, isThreeSessionStrategy } from "@/config";
 import type { UserStory } from "@/prd";
 import { isBlockingSeverity } from "@/review";
 import type { ReviewCheckResult } from "@/review/types";
@@ -130,27 +131,15 @@ declaration in your output. Outside these ${countWord} cases the rule is absolut
 ${exceptions.join("\n\n")}`;
 }
 
-/** Strategies that include a test-writer agent and therefore support Exception 4. */
-const THREE_SESSION_STRATEGIES = new Set(["three-session-tdd", "three-session-tdd-lite"]);
-
-/**
- * Single-session strategies in which ONE agent writes both the tests and the
- * implementation in the same session. No separate test-writer owns the test
- * contract, so the implementer authored the tests and MAY edit them during
- * rectification (permit-with-guard) — unlike three-session TDD where the
- * "do not modify test files" rule is absolute.
- *
- * `no-test` is excluded: it produces no tests, so there is nothing to own or edit.
- */
-const SINGLE_SESSION_TEST_OWNING_STRATEGIES = new Set(["tdd-simple", "test-after"]);
-
 /**
  * True when the story's strategy makes the implementer the author of its own
  * tests (single-session). Such an implementer may edit test files to resolve
  * genuine AC/spec contradictions during rectification.
+ *
+ * Strategy classification is the SSOT in `src/config/test-strategy.ts`.
  */
 export function implementerOwnsTests(story: UserStory): boolean {
-  return SINGLE_SESSION_TEST_OWNING_STRATEGIES.has(story.routing?.testStrategy ?? "");
+  return isSingleSessionTestOwningStrategy(story.routing?.testStrategy);
 }
 
 /**
@@ -202,7 +191,7 @@ export function testEditHeadline(story: UserStory, prohibition: string): string 
  * that sits outside the escape-hatch block.
  */
 export function exceptionCountWord(story: UserStory): "three" | "four" {
-  return THREE_SESSION_STRATEGIES.has(story.routing?.testStrategy ?? "") ? "four" : "three";
+  return isThreeSessionStrategy(story.routing?.testStrategy) ? "four" : "three";
 }
 
 /**
@@ -211,7 +200,7 @@ export function exceptionCountWord(story: UserStory): "three" | "four" {
  */
 export function escapeHatchFor(story: UserStory): string {
   if (implementerOwnsTests(story)) return SINGLE_SESSION_TEST_EDIT_POLICY;
-  const isTdd = THREE_SESSION_STRATEGIES.has(story.routing?.testStrategy ?? "");
+  const isTdd = isThreeSessionStrategy(story.routing?.testStrategy);
   return buildEscapeHatch({ includeMockHandoff: isTdd });
 }
 

--- a/test/integration/pipeline/gating-preservation.test.ts
+++ b/test/integration/pipeline/gating-preservation.test.ts
@@ -20,6 +20,7 @@ import {
   makeMechanicalLintFixStrategy,
 } from "@/operations";
 import type { CallContext } from "@/operations";
+import type { Finding } from "@/findings";
 import type { PipelineContext } from "@/pipeline/types";
 import type { NaxRuntime } from "@/runtime";
 import {
@@ -301,6 +302,123 @@ describe("AC4-AC5: fix strategy gating in rectification phase", () => {
     await plan.run();
     expect(capturedStrategyNames).not.toContain("mechanical-formatfix");
     expect(capturedStrategyNames).toContain("mechanical-lintfix");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Single-session adversarial routing: tdd-simple / no-test route adversarial-review
+// findings to the warm implementer, NOT a fresh test-writer session.
+// Regression for run 2026-06-01T16-27-51 (US-003 tdd-simple).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("single-session adversarial-review routing", () => {
+  let capturedCycle: { strategies: Array<{ name: string; appliesTo: (f: Finding) => boolean }> } | null;
+  let origRunFixCycle: typeof _storyOrchestratorDeps.runFixCycle;
+  let origCallOp: typeof _storyOrchestratorDeps.callOp;
+  let origCaptureGitRef: typeof _storyOrchestratorDeps.captureGitRef;
+  let runtime: NaxRuntime;
+
+  const adversarialFinding: Finding = {
+    source: "adversarial-review",
+    severity: "error",
+    category: "",
+    message: "AC11 not propagated",
+    file: "src/foo.ts",
+    line: 1,
+  };
+
+  beforeEach(() => {
+    capturedCycle = null;
+    origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
+    origCallOp = _storyOrchestratorDeps.callOp;
+    origCaptureGitRef = _storyOrchestratorDeps.captureGitRef;
+
+    _storyOrchestratorDeps.captureGitRef = mock(async () => "HEAD");
+    // Fail adversarial-review so the rectification cycle is actually entered;
+    // all other phases pass. This works for both single- and three-session plans.
+    _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+      if (op.name === "adversarial-review") {
+        return { success: false, passed: false, findings: [adversarialFinding] };
+      }
+      return { success: true, passed: true, findings: [] };
+    }) as typeof _storyOrchestratorDeps.callOp;
+    _storyOrchestratorDeps.runFixCycle = mock(async (cycle: unknown) => {
+      capturedCycle = cycle as typeof capturedCycle;
+      return { iterations: [], finalFindings: [], exitReason: "no-strategy" as const, costUsd: 0 };
+    }) as typeof _storyOrchestratorDeps.runFixCycle;
+  });
+
+  afterEach(async () => {
+    _storyOrchestratorDeps.runFixCycle = origRunFixCycle;
+    _storyOrchestratorDeps.callOp = origCallOp;
+    _storyOrchestratorDeps.captureGitRef = origCaptureGitRef;
+    await runtime?.close();
+  });
+
+  function rectifyInputs(story: ReturnType<typeof makeStory>, config: NaxConfig) {
+    runtime = makeTestRuntime({ config });
+    return {
+      ctx: makeMockCallContext({ runtime }),
+      inputs: makeMockPlanInputs({
+        story,
+        implementer: { story },
+        fullSuiteGate: { story, workdir: "/tmp/test" },
+        verifier: { story },
+        semanticReview: { story },
+        adversarialReview: { story },
+        rectification: { maxAttempts: 2, strategies: [], abortOnIncreasingFailures: false },
+      }),
+    };
+  }
+
+  test("tdd-simple: no autofix-test-writer strategy is assembled", async () => {
+    const story = makeStory({ attempts: 1 });
+    const config = makeNaxConfig({
+      quality: { autofix: { enabled: true } },
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
+    });
+    const { ctx, inputs } = rectifyInputs(story, config);
+    const plan = await buildPlanForStrategy(ctx, story, config, "tdd-simple", inputs);
+    await plan.run();
+
+    // Guard: the cycle must actually have been entered, otherwise the
+    // not.toContain assertion below would pass vacuously against [].
+    expect(capturedCycle).not.toBeNull();
+    const names = (capturedCycle?.strategies ?? []).map((s) => s.name);
+    expect(names).toContain("autofix-implementer");
+    expect(names).not.toContain("autofix-test-writer");
+  });
+
+  test("tdd-simple: autofix-implementer claims adversarial-review findings", async () => {
+    const story = makeStory({ attempts: 1 });
+    const config = makeNaxConfig({
+      quality: { autofix: { enabled: true } },
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
+    });
+    const { ctx, inputs } = rectifyInputs(story, config);
+    const plan = await buildPlanForStrategy(ctx, story, config, "tdd-simple", inputs);
+    await plan.run();
+
+    expect(capturedCycle).not.toBeNull();
+    const matching = (capturedCycle?.strategies ?? []).filter((s) => s.appliesTo(adversarialFinding));
+    expect(matching.map((s) => s.name)).toEqual(["autofix-implementer"]);
+  });
+
+  test("three-session-tdd: adversarial-review still routes to autofix-test-writer (unchanged)", async () => {
+    const story = makeStory({ attempts: 1 });
+    const config = makeNaxConfig({
+      quality: { autofix: { enabled: true } },
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
+    });
+    const { ctx, inputs } = rectifyInputs(story, config);
+    const plan = await buildPlanForStrategy(ctx, story, config, "three-session-tdd", inputs);
+    await plan.run();
+
+    const names = (capturedCycle?.strategies ?? []).map((s) => s.name);
+    expect(names).toContain("autofix-test-writer");
+
+    const matching = (capturedCycle?.strategies ?? []).filter((s) => s.appliesTo(adversarialFinding));
+    expect(matching.map((s) => s.name)).toEqual(["autofix-test-writer"]);
   });
 });
 

--- a/test/unit/config/test-strategy.test.ts
+++ b/test/unit/config/test-strategy.test.ts
@@ -3,9 +3,13 @@ import {
   AC_QUALITY_RULES,
   COMPLEXITY_GUIDE,
   GROUPING_RULES,
+  SINGLE_SESSION_TEST_OWNING_STRATEGIES,
   TEST_STRATEGY_GUIDE,
+  THREE_SESSION_STRATEGIES,
   VALID_TEST_STRATEGIES,
   getAcQualityRules,
+  isSingleSessionTestOwningStrategy,
+  isThreeSessionStrategy,
   resolveTestStrategy,
 } from "../../../src/config/test-strategy";
 
@@ -46,6 +50,50 @@ describe("VALID_TEST_STRATEGIES", () => {
     expect(VALID_TEST_STRATEGIES).toContain("tdd-simple");
     expect(VALID_TEST_STRATEGIES).toContain("three-session-tdd");
     expect(VALID_TEST_STRATEGIES).toContain("three-session-tdd-lite");
+  });
+});
+
+describe("strategy classification predicates (SSOT)", () => {
+  test("THREE_SESSION_STRATEGIES holds exactly the two three-session variants", () => {
+    expect([...THREE_SESSION_STRATEGIES].sort()).toEqual(["three-session-tdd", "three-session-tdd-lite"]);
+  });
+
+  test("SINGLE_SESSION_TEST_OWNING_STRATEGIES holds exactly tdd-simple and test-after", () => {
+    expect([...SINGLE_SESSION_TEST_OWNING_STRATEGIES].sort()).toEqual(["tdd-simple", "test-after"]);
+  });
+
+  test.each([
+    ["three-session-tdd", true],
+    ["three-session-tdd-lite", true],
+    ["tdd-simple", false],
+    ["test-after", false],
+    ["no-test", false],
+  ] as const)("isThreeSessionStrategy(%s) === %s", (strategy, expected) => {
+    expect(isThreeSessionStrategy(strategy)).toBe(expected);
+  });
+
+  test("isThreeSessionStrategy(undefined) is false", () => {
+    expect(isThreeSessionStrategy(undefined)).toBe(false);
+  });
+
+  test.each([
+    ["tdd-simple", true],
+    ["test-after", true],
+    ["no-test", false],
+    ["three-session-tdd", false],
+    ["three-session-tdd-lite", false],
+  ] as const)("isSingleSessionTestOwningStrategy(%s) === %s", (strategy, expected) => {
+    expect(isSingleSessionTestOwningStrategy(strategy)).toBe(expected);
+  });
+
+  test("isSingleSessionTestOwningStrategy(undefined) is false", () => {
+    expect(isSingleSessionTestOwningStrategy(undefined)).toBe(false);
+  });
+
+  test("three-session and single-session-test-owning sets are disjoint", () => {
+    for (const s of THREE_SESSION_STRATEGIES) {
+      expect(SINGLE_SESSION_TEST_OWNING_STRATEGIES.has(s)).toBe(false);
+    }
   });
 });
 

--- a/test/unit/operations/autofix-implementer-strategy.test.ts
+++ b/test/unit/operations/autofix-implementer-strategy.test.ts
@@ -76,6 +76,46 @@ describe("makeAutofixImplementerStrategy", () => {
     });
   });
 
+  describe("single-session: includeAdversarialReview opt-in", () => {
+    test("claims adversarial-review findings (fixTarget undefined) when includeAdversarialReview=true", () => {
+      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink(), {
+        includeAdversarialReview: true,
+      });
+      const finding = makeFinding({ fixTarget: undefined, source: "adversarial-review" });
+      expect(strategy.appliesTo(finding)).toBe(true);
+    });
+
+    test("claims adversarial-review test-gap findings (fixTarget=test) when includeAdversarialReview=true", () => {
+      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink(), {
+        includeAdversarialReview: true,
+      });
+      const finding = makeFinding({ fixTarget: "test", source: "adversarial-review" });
+      expect(strategy.appliesTo(finding)).toBe(true);
+    });
+
+    test("does NOT claim adversarial-review findings by default (three-session)", () => {
+      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink());
+      const finding = makeFinding({ fixTarget: undefined, source: "adversarial-review" });
+      expect(strategy.appliesTo(finding)).toBe(false);
+    });
+
+    test("still claims semantic-review source findings when includeAdversarialReview=true", () => {
+      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink(), {
+        includeAdversarialReview: true,
+      });
+      const finding = makeFinding({ fixTarget: "source", source: "semantic-review" });
+      expect(strategy.appliesTo(finding)).toBe(true);
+    });
+
+    test("does not claim unrelated test-runner findings even when includeAdversarialReview=true", () => {
+      const strategy = makeAutofixImplementerStrategy(mockCtx, makeNaxConfig(), makeSink(), {
+        includeAdversarialReview: true,
+      });
+      const finding = makeFinding({ fixTarget: "test", source: "test-runner" });
+      expect(strategy.appliesTo(finding)).toBe(false);
+    });
+  });
+
   test("AC2.3: buildInput converts semantic finding to ReviewCheckResult", () => {
     const story = makeStory();
     const strategy = makeAutofixImplementerStrategy(story, makeNaxConfig(), makeSink());


### PR DESCRIPTION
## What

Fixes rectification routing for **single-session** runs (`tdd-simple` / `test-after` / `no-test`): adversarial-review findings now go to the warm **implementer** session instead of a fresh, context-less **test-writer** session.

## Why

Observed on a real run (`logs/2026-06-01T16-27-51.jsonl`, story `US-003`, `tdd-simple`). The story runs in a single session — one warm `implementer` session authors both tests and source. When adversarial review failed, the rectification cycle spun up a brand-new `…-test-writer` session (`resume:false`) and ran the `autofix-test-writer` strategy.

Root cause: `buildPlanForStrategy` assembled **both** `autofix-implementer` and `autofix-test-writer` unconditionally, even though the test-writer *phase* itself is gated on `isThreeSession`. The routing split lives in the strategies' `appliesTo`:

- `autofix-implementer` claims `{lint, typecheck, semantic-review, tdd-verifier}` with `fixTarget=source` — it deliberately **excludes** `adversarial-review`.
- `autofix-test-writer` claims `source === "adversarial-review"`.

So once test-writer was in the array, every adversarial finding flowed to it regardless of TDD mode.


## How

- `src/operations/autofix-implementer-strategy.ts` — added an opt-in `{ includeAdversarialReview }`. When set, the implementer also claims `adversarial-review` findings (any `fixTarget`). Default (three-session) behavior is unchanged.
- `src/execution/build-plan-for-strategy.ts` — `autofix-test-writer` is now added **only when `isThreeSession`**; the implementer strategy receives `includeAdversarialReview: !isThreeSession`.

Net effect:
- **Single-session:** adversarial findings → warm `autofix-implementer`; no fresh test-writer session.
- **Three-session TDD:** unchanged — adversarial findings still route to `autofix-test-writer`.

## Testing

- [x] Tests added/updated
- [x] `bun test` passes
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

New coverage:
- 5 unit tests in `autofix-implementer-strategy.test.ts` for the opt-in `appliesTo` predicate.
- 3 integration tests in `gating-preservation.test.ts` (regression-tagged to this run) asserting single-session assembles no test-writer and routes adversarial findings to the implementer, while three-session is preserved.

## Notes

No breaking changes; three-session TDD routing is byte-for-byte unchanged.

Reviewed via `code-reviewer` agent — no CRITICAL/HIGH issues. One MEDIUM edge case was documented as deliberate in code: AC-HOOK / AC-ERROR sentinel findings (`test-runner`, `fixTarget=test`) are intentionally *not* re-routed to the single-session implementer — they are owned by the acceptance loop, not the per-story rectification cycle, and the previously-assembled cold test-writer never resolved them usefully either.



---

### Follow-up: test-strategy SSOT consolidation (commit 2)

While reviewing the routing fix, the `THREE_SESSION_STRATEGIES` set turned out to be **duplicated** — defined in both `src/execution/build-plan-for-strategy.ts` and `src/prompts/builders/rectifier-builder-helpers.ts` (the latter also held a parallel `SINGLE_SESSION_TEST_OWNING_STRATEGIES`). Consolidated all strategy classification into the existing SSOT module `src/config/test-strategy.ts`:

- `THREE_SESSION_STRATEGIES` / `SINGLE_SESSION_TEST_OWNING_STRATEGIES` (`ReadonlySet<TestStrategy>`)
- `isThreeSessionStrategy()` / `isSingleSessionTestOwningStrategy()` predicates (guard `undefined`)

`build-plan-for-strategy.ts`, `plan-inputs.ts`, `pipeline/stages/execution.ts`, and `rectifier-builder-helpers.ts` now import from the config barrel. Behavior is preserved (the `undefined` guard replaces the prior `?? ""` coercion, equivalent since `""` is not a `TestStrategy`). Added unit tests for the predicates incl. disjointness + `undefined` cases.
