### PR TITLE
feat(operations): keep test-writer session warm across fix stages

### DIFF
--- a/src/agents/acp/adapter-lifecycle.ts
+++ b/src/agents/acp/adapter-lifecycle.ts
@@ -139,8 +139,11 @@ export function computeAcpHandle(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Ensure an ACP session exists: try to resume via loadSession, fall back to
- * createSession. Returns the AcpSession ready for prompt() calls.
+ * Ensure an ACP session exists: try to resume via loadSession (which runs
+ * `acpx sessions ensure` and resumes an OPEN session of that name), falling back to
+ * createSession when none is open. A session previously closed via closeSession is NOT
+ * resumable here — loadSession returns null and a fresh, context-less session is created.
+ * Keeping the session open (shouldKeepSessionOpen) is what preserves context across turns.
  */
 export async function ensureAcpSession(
   client: AcpClient,

--- a/src/agents/acp/spawn-client.ts
+++ b/src/agents/acp/spawn-client.ts
@@ -532,8 +532,13 @@ function parseSessionIds(stdout: string): { sessionId: string | undefined; recor
  * The cmdStr is parsed to extract --model and agent name:
  *   "acpx --model claude-sonnet-4-5 claude" → model=claude-sonnet-4-5, agent=claude
  *
- * createSession() spawns: acpx <agent> sessions ensure --name <name>
- * loadSession() tries to resume an existing named session.
+ * createSession() and loadSession() both run: acpx <agent> sessions ensure --name <name>
+ * `sessions ensure` resumes the named session ONLY while it is still open; if no open
+ * session with that name exists (e.g. it was previously `sessions close`d), acpx creates
+ * a fresh one. A session closed via closeSession() is therefore NOT resumable — the next
+ * loadSession() returns a brand-new, context-less session. Ops whose conversation context
+ * must survive across turns keep their session open via shouldKeepSessionOpen (the
+ * keepOpen resolver), which skips closeSession.
  */
 export class SpawnAcpClient implements AcpClient {
   private readonly model: string;
@@ -660,7 +665,9 @@ export class SpawnAcpClient implements AcpClient {
   }
 
   async loadSession(sessionName: string, agentName: string, permissionMode: string): Promise<AcpSession | null> {
-    // Try to ensure session exists — --format json surfaces the session UUID in stdout
+    // `sessions ensure` resumes an OPEN named session, or creates a new one if none is
+    // open (a closed session is not resumable — it yields a fresh, context-less session).
+    // --format json surfaces the session UUID in stdout.
     const cmd = ["acpx", "--cwd", this.cwd, "--format", "json", agentName, "sessions", "ensure", "--name", sessionName];
 
     const { exitCode, stdout } = await this.trackedSpawn(cmd);

--- a/src/operations/autofix-test-writer.ts
+++ b/src/operations/autofix-test-writer.ts
@@ -22,7 +22,10 @@ export const testWriterRectifyOp: RunOperation<AutofixTestWriterInput, AutofixTe
   kind: "run",
   name: "autofix-test-writer",
   stage: "rectification",
-  session: { role: "test-writer", lifetime: "fresh" },
+  // warm: resume the open test-writer session (from the test-writer phase) and keep it
+  // open across rectify iterations instead of `sessions ensure`-ing a cold session each
+  // turn. Unconditional, mirroring autofix-implementer.ts (already mid-rectification).
+  session: { role: "test-writer", lifetime: "warm" },
   config: autofixConfigSelector,
   build(input, _ctx) {
     const prompt = RectifierPromptBuilder.testWriterRectification(input.failedChecks, input.story, {

--- a/src/operations/execution-gates.ts
+++ b/src/operations/execution-gates.ts
@@ -19,7 +19,19 @@ export function shouldRunRectification(config: GatesConfig): boolean {
   return config.execution?.rectification?.enabled === true;
 }
 
-/** Returns true when the implementer session must stay open after the agent turn. */
+/**
+ * Roles whose ACP session is kept open across fix stages so the agent retains memory of
+ * what it produced: the implementer (the code it wrote) and the test-writer (the tests it
+ * wrote — resumed by autofix-test-writer). Verifier and reviewers are one-shot, so they
+ * stay fresh. Extends the implementer-only session continuity of ADR-007/008 to the
+ * test-writer; see docs/adr/ADR-008.
+ */
+const SESSION_CONTINUITY_ROLES = new Set<SessionRole>(["implementer", "test-writer"]);
+
+/**
+ * Returns true when the role's session must stay open after the agent turn so a later fix
+ * stage (review / rectification) can resume it with full context.
+ */
 export function shouldKeepSessionOpen(config: GatesConfig, role: SessionRole): boolean {
-  return role === "implementer" && (shouldRunReview(config) || shouldRunRectification(config));
+  return SESSION_CONTINUITY_ROLES.has(role) && (shouldRunReview(config) || shouldRunRectification(config));
 }

--- a/src/operations/write-test.ts
+++ b/src/operations/write-test.ts
@@ -4,6 +4,7 @@ import type { UserStory } from "../prd";
 import { _isolationDeps, verifyTestWriterIsolation } from "../tdd/isolation";
 import type { IsolationCheck } from "../tdd/types";
 import { parseSessionJsonOutput } from "./_session-output";
+import { shouldKeepSessionOpen } from "./execution-gates";
 import type { RunOperation } from "./types";
 
 void _isolationDeps; // re-export to keep test mocks pointed at the same singleton
@@ -43,8 +44,12 @@ export const testWriterOp: RunOperation<TestWriterInput, TestWriterOutput, TddCo
   kind: "run",
   name: "test-writer",
   stage: "run",
-  session: { role: "test-writer", lifetime: "fresh" },
+  // warm + keepOpen: keep the test-writer session open after RED (when review or
+  // rectification will run) so autofix-test-writer can resume the same ACP session.
+  // acpx `sessions ensure` only resumes a still-open session. Mirrors implement.ts.
+  session: { role: "test-writer", lifetime: "warm" },
   config: tddConfigSelector,
+  keepOpen: (_input, ctx) => shouldKeepSessionOpen(ctx.config, "test-writer"),
   build(input, _ctx) {
     if (input.promptMarkdown?.trim()) {
       return {

--- a/test/unit/operations/autofix-test-writer.test.ts
+++ b/test/unit/operations/autofix-test-writer.test.ts
@@ -42,6 +42,16 @@ describe("AutofixTestWriterInput", () => {
   });
 });
 
+describe("testWriterRectifyOp.session", () => {
+  test("role is 'test-writer'", () => {
+    expect(testWriterRectifyOp.session.role).toBe("test-writer");
+  });
+
+  test("lifetime is 'warm' (resumes the open test-writer session across iterations)", () => {
+    expect(testWriterRectifyOp.session.lifetime).toBe("warm");
+  });
+});
+
 describe("testWriterRectifyOp.build", () => {
   test("accepts mode: mock-restructure in input and builds prompt", () => {
     const story = makeStory({ description: "Test mock restructuring" });

--- a/test/unit/operations/build-hop-callback.test.ts
+++ b/test/unit/operations/build-hop-callback.test.ts
@@ -152,6 +152,22 @@ describe("buildHopCallback — primary hop (no failure)", () => {
     expect(hop.result.protocolIds).toEqual({ recordId: "rec-turn", sessionId: "sess-turn" });
     expect(hop.result.internalRoundTrips).toBe(1);
   });
+
+  test("keepOpen:true — closeSession is NOT called after the turn", async () => {
+    const sessionManager = makeSessionManager({
+      openSession: mock(async () => makeHandle("nax-warm-handle")),
+      closeSession: mock(async () => {}),
+    });
+    const agentManager = makeAgentManagerStub();
+    const ctx = makeCtx({ sessionManager, agentManager });
+    const warmOptions = { ...makeBaseOptions(), keepOpen: true } as AgentRunOptions;
+
+    const cb = buildHopCallback(ctx, SESSION_ID, warmOptions);
+    const hop = await cb("claude", makeBundle(), { kind: "primary" } satisfies HopKind, warmOptions);
+
+    expect(hop.result.success).toBe(true);
+    expect(sessionManager.closeSession).not.toHaveBeenCalled();
+  });
 });
 
 describe("buildHopCallback — failure hop (fallback)", () => {

--- a/test/unit/operations/execution-gates.test.ts
+++ b/test/unit/operations/execution-gates.test.ts
@@ -44,12 +44,16 @@ describe("shouldKeepSessionOpen", () => {
     expect(shouldKeepSessionOpen(withNeither(), "implementer")).toBe(false);
   });
 
-  test("returns false for test-writer when review is enabled (AC4)", () => {
-    expect(shouldKeepSessionOpen(withReview(true), "test-writer")).toBe(false);
+  test("returns true for test-writer when review is enabled (AC4 — extended for session continuity)", () => {
+    expect(shouldKeepSessionOpen(withReview(true), "test-writer")).toBe(true);
   });
 
-  test("returns false for test-writer when rectification is enabled (AC4)", () => {
-    expect(shouldKeepSessionOpen(withRectification(true), "test-writer")).toBe(false);
+  test("returns true for test-writer when rectification is enabled (AC4 — extended for session continuity)", () => {
+    expect(shouldKeepSessionOpen(withRectification(true), "test-writer")).toBe(true);
+  });
+
+  test("returns false for test-writer when both are absent or false (AC4)", () => {
+    expect(shouldKeepSessionOpen(withNeither(), "test-writer")).toBe(false);
   });
 
   test("returns false for verifier when review is enabled (AC5)", () => {

--- a/test/unit/operations/write-test-op.test.ts
+++ b/test/unit/operations/write-test-op.test.ts
@@ -6,7 +6,7 @@ import type { NaxConfig } from "@/config";
  * Tests for testWriterOp — the full RunOperation shape for the test-writer role.
  *
  * AC-2: testWriterOp.session.role equals "test-writer" and
- * testWriterOp.session.lifetime equals "fresh".
+ * testWriterOp.session.lifetime equals "warm" (keepOpen resolver gates actual retention).
  *
  * AC-4: Given testWriterOp.parse receives empty output, when parse executes,
  * then it returns TestWriterOutput with success: false and filesChanged: [].
@@ -27,9 +27,14 @@ describe("testWriterOp — RunOperation shape", () => {
     expect(testWriterOp.session.role).toBe("test-writer");
   });
 
-  test("testWriterOp.session.lifetime equals 'fresh'", async () => {
+  test("testWriterOp.session.lifetime equals 'warm'", async () => {
     const { testWriterOp } = await import("@/operations");
-    expect(testWriterOp.session.lifetime).toBe("fresh");
+    expect(testWriterOp.session.lifetime).toBe("warm");
+  });
+
+  test("testWriterOp declares a keepOpen resolver", async () => {
+    const { testWriterOp } = await import("@/operations");
+    expect(typeof testWriterOp.keepOpen).toBe("function");
   });
 
   test.each([


### PR DESCRIPTION
## What
Extend ACP session continuity to the three-session **test-writer** role, so `autofix-test-writer` resumes the session it used to write the tests instead of starting cold.

## Why
`acpx sessions ensure` resumes a named session only while it is open; a closed session yields a fresh, context-less one. The implementer already avoids this (ADR-007/008 → `shouldKeepSessionOpen` + a `keepOpen` resolver), but the test-writer was left `fresh`, so its rectify had no memory of the tests it wrote.

## How
- `shouldKeepSessionOpen` now returns true for `test-writer` (in addition to `implementer`) when review/rectification is enabled. Verifier stays one-shot.
- `write-test.ts` gains `lifetime: \"warm\"` + the config-gated `keepOpen` resolver (mirrors `implement.ts`).
- `autofix-test-writer.ts` becomes `lifetime: \"warm\"` (unconditional, mirrors `autofix-implementer.ts`).
- Corrected the misleading `loadSession`/`ensureAcpSession` doc comments.

## Reverses a prior decision
`execution-gates.test.ts` AC4 previously asserted the test-writer is NOT kept open. This PR flips AC4 — an intentional extension of ADR-007/008's implementer-only session continuity to the test-writer role.

## Scope / limitations
- Only `three-session-tdd` / `three-session-tdd-lite`. Single-session strategies never assemble the test-writer rectify.
- Retry attempts skip the test-writer phase, so there is no warm session to resume on retries — unchanged.

## Testing
- [x] Tests added/updated
- [x] `bun test` passes (1048 pass, 0 fail)
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes