### PR TITLE
fix(rectification): run full-suite gate as final arbiter in terminal lite-validate

### DIFF
--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -41,6 +41,7 @@ export {
   _storyOrchestratorDeps,
   EXHAUSTED_EXIT_REASONS,
   phasesToRevalidate,
+  orderGateLast,
   formatPhaseResultMessage,
   buildPhaseOutcomeLogData,
   refreshReviewInputForDispatch,

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -526,6 +526,21 @@ export function phasesToRevalidate(
   return allPhases.filter((p) => needed.has(p.kind));
 }
 
+/**
+ * Move `full-suite-gate` phases to the end of the revalidation order, preserving
+ * the relative order of every other phase.
+ *
+ * Used by the terminal lite-validate so the expensive gate runs only after all
+ * cheaper phases have passed (they short-circuit first on failure), while still
+ * acting as the final arbiter of "resolved" rather than being skipped. Pure over
+ * its input — exported for unit testing.
+ */
+export function orderGateLast(phases: readonly InternalPhase[]): InternalPhase[] {
+  const rest = phases.filter((p) => p.kind !== "full-suite-gate");
+  const gates = phases.filter((p) => p.kind === "full-suite-gate");
+  return [...rest, ...gates];
+}
+
 function toReviewDecisionPayload(opName: string, output: unknown): ReviewDecisionPayload | null {
   if (output === null || output === undefined || typeof output !== "object") return null;
   const record = output as Record<string, unknown>;
@@ -950,7 +965,26 @@ export async function runRectification(
       // opts is required by the FixCycle.validate contract but guard defensively for
       // plugin-supplied cycles that may call validate without opts (legacy shape).
       const lite = (opts?.mode ?? "full") === "lite";
-      const phases = phasesToRevalidate(opts?.strategiesRun, validationPhases);
+      const selected = phasesToRevalidate(opts?.strategiesRun, validationPhases);
+      // Terminal lite-validate: the full-suite gate is the most expensive phase
+      // AND, for gate-seeded cycles (full-suite-rectify), the actual arbiter of
+      // "resolved". It used to be SKIPPED entirely in lite mode, which let the
+      // cycle declare "resolved" off the cheaper phases alone (semantic last)
+      // without ever re-running the gate that had just received a fix — a
+      // dishonest exit. Instead run it LAST: a failing cheaper phase
+      // short-circuits before the gate is ever dispatched (preserving the cost
+      // saving that motivated lite mode), and when everything cheaper is green
+      // the gate is re-run to validate the fix.
+      //
+      // Caveat — the verifier-SSOT carve-out still applies: when a verifier ran
+      // and passed, `shouldSkipPhaseForRectification` discards the gate's finding
+      // (unrelated-regression policy, lines ~430), so in that case the gate is
+      // dispatched (validating the just-applied fix per Q1) but does NOT block
+      // "resolved". The gate is the decisive arbiter only when no passing
+      // verifier overrides it (single-session, or a failed/absent verifier).
+      // Session-agnostic — also covers a single-session per-story
+      // full-suite-gate; verify-scoped was never skipped and is unaffected.
+      const phases = lite ? orderGateLast(selected) : selected;
       getSafeLogger()?.debug("story-orchestrator", "rectification validate scope", {
         storyId: ctx.storyId,
         mode: opts?.mode ?? "full",
@@ -960,9 +994,6 @@ export async function runRectification(
       const findings: Finding[] = [];
       let shortCircuited = false;
       for (const phase of phases) {
-        if (lite && phase.kind === "full-suite-gate") {
-          continue;
-        }
         await runPhase(ctx, phase.slot, phaseCosts, phaseOutputs);
         if (shouldSkipPhaseForRectification(phase, state, phaseOutputs)) continue;
         const output = phaseOutputs[phase.slot.op.name];

--- a/test/unit/execution/story-orchestrator-revalidation.test.ts
+++ b/test/unit/execution/story-orchestrator-revalidation.test.ts
@@ -14,13 +14,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { _storyOrchestratorDeps, StoryOrchestratorBuilder } from "@/execution";
+import { type DEFAULT_CONFIG, pickSelector } from "@/config";
+import { StoryOrchestratorBuilder, _storyOrchestratorDeps, orderGateLast } from "@/execution";
 import type { FixCycle, FixCycleContext, FixCycleExitReason } from "@/findings/cycle-types";
 import type { Finding } from "@/findings/types";
-import { pickSelector, DEFAULT_CONFIG } from "@/config";
-import { makeTestRuntime } from "@test/helpers";
+import type { CallContext, RunOperation } from "@/operations";
 import type { NaxRuntime } from "@/runtime";
-import type { RunOperation, CallContext } from "@/operations";
+import { makeTestRuntime } from "@test/helpers";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Test fixtures
@@ -430,5 +430,125 @@ describe("phasesToRevalidate — AC3.6: union of mechanical-lintfix + autofix-im
     expect(called.has("full-suite-gate")).toBe(true);
     expect(called.has("semantic-review")).toBe(true);
     expect(called.has("adversarial-review")).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Terminal lite-validate — the full-suite gate runs LAST as the final arbiter,
+// instead of being skipped. Previously lite mode skipped the gate entirely, so
+// the cycle declared "resolved" off the cheaper phases alone (semantic last)
+// without ever re-running the gate that had just received a fix — a dishonest
+// exit. The gate now runs after every cheaper phase: a failing cheaper phase
+// short-circuits before it (cost preserved), and when everything cheaper is
+// green the gate decides the verdict. Session-agnostic — also covers a
+// single-session per-story full-suite-gate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Capture the cycle, then install an ORDER-recording callOp with per-op failures. */
+async function captureWithOrderedTracker(
+  ctx: CallContext,
+  failingOps: ReadonlySet<string> = new Set(),
+): Promise<{
+  capturedCycle: FixCycle<Finding> | null;
+  capturedCtx: FixCycleContext | null;
+  order: string[];
+}> {
+  const { capturedCycle, capturedCtx } = await captureAndSetupValidate(ctx);
+  const order: string[] = [];
+  _storyOrchestratorDeps.callOp = mock(async (_ctx: unknown, op: { name: string }) => {
+    order.push(op.name);
+    if (failingOps.has(op.name)) return { success: false, passed: false, findings: [LINT_FINDING] };
+    return { success: true, passed: true, findings: [] };
+  }) as typeof _storyOrchestratorDeps.callOp;
+  return { capturedCycle, capturedCtx, order };
+}
+
+describe("terminal lite-validate — gate runs LAST as final arbiter (Q1/Q3)", () => {
+  test("lite mode: full-suite-gate IS re-run, and runs after every cheaper phase", async () => {
+    const ctx = makeCtx();
+    const { capturedCycle, capturedCtx, order } = await captureWithOrderedTracker(ctx);
+    expect(capturedCycle).not.toBeNull();
+
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "lite",
+      strategiesRun: ["full-suite-rectify"],
+    });
+
+    // Gate must actually run in lite mode (previously skipped -> dishonest "resolved").
+    expect(order).toContain("full-suite-gate");
+    // ...and it must be the LAST phase: every other revalidation phase precedes it.
+    expect(order[order.length - 1]).toBe("full-suite-gate");
+  });
+
+  test("lite mode: a failing cheaper phase short-circuits BEFORE the gate (cost preserved)", async () => {
+    const ctx = makeCtx();
+    // semantic-review is a cheaper phase than the full-suite gate.
+    const { capturedCycle, capturedCtx, order } = await captureWithOrderedTracker(ctx, new Set(["semantic-review"]));
+    expect(capturedCycle).not.toBeNull();
+
+    const result = await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "lite",
+      strategiesRun: ["full-suite-rectify"],
+    });
+
+    expect(order).toContain("semantic-review");
+    // Short-circuit on the cheaper failure means the expensive gate never runs.
+    expect(order).not.toContain("full-suite-gate");
+    // validate signals the short-circuit so the cycle cannot report a false "resolved".
+    expect((result as { shortCircuited?: boolean }).shortCircuited).toBe(true);
+  });
+
+  test("full mode is unchanged: gate keeps its canonical position (not forced last)", async () => {
+    const ctx = makeCtx();
+    const { capturedCycle, capturedCtx, order } = await captureWithOrderedTracker(ctx);
+    expect(capturedCycle).not.toBeNull();
+
+    await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "full",
+      strategiesRun: ["full-suite-rectify"],
+    });
+
+    // Canonical order places full-suite-gate before verifier; full mode preserves it.
+    expect(order).toContain("full-suite-gate");
+    expect(order.indexOf("full-suite-gate")).toBeLessThan(order.indexOf("verifier"));
+  });
+
+  test("lite mode: verifier-SSOT carve-out — a red gate is dispatched (last) but its finding is discarded when the verifier passed", async () => {
+    const ctx = makeCtx();
+    // Only the gate fails; the verifier (and everything cheaper) passes.
+    const { capturedCycle, capturedCtx, order } = await captureWithOrderedTracker(ctx, new Set(["full-suite-gate"]));
+    expect(capturedCycle).not.toBeNull();
+
+    const result = await (capturedCycle as FixCycle<Finding>).validate(capturedCtx as FixCycleContext, {
+      mode: "lite",
+      strategiesRun: ["full-suite-rectify"],
+    });
+
+    // The gate still RUNS (last) — it validates the just-applied fix (Q1) ...
+    expect(order[order.length - 1]).toBe("full-suite-gate");
+    // ... but because the verifier passed, shouldSkipPhaseForRectification discards
+    // the gate's finding (unrelated-regression policy). So the cycle is not blocked:
+    // no findings surface and it does NOT short-circuit on the gate failure.
+    expect(result.findings).toHaveLength(0);
+    expect((result as { shortCircuited?: boolean }).shortCircuited).toBe(false);
+  });
+});
+
+describe("orderGateLast — pure ordering helper", () => {
+  const mk = (kind: string) => ({ kind, slot: { op: { name: kind } } }) as never;
+
+  test("moves full-suite-gate to the end, preserving order of the other phases", () => {
+    const input = [mk("full-suite-gate"), mk("verifier"), mk("lint-check"), mk("semantic-review")];
+    expect(orderGateLast(input).map((p) => p.kind)).toEqual([
+      "verifier",
+      "lint-check",
+      "semantic-review",
+      "full-suite-gate",
+    ]);
+  });
+
+  test("is a no-op when there is no full-suite-gate phase", () => {
+    const input = [mk("lint-check"), mk("typecheck-check"), mk("semantic-review")];
+    expect(orderGateLast(input).map((p) => p.kind)).toEqual(["lint-check", "typecheck-check", "semantic-review"]);
   });
 });


### PR DESCRIPTION
## Problem

Found on a real `nax run` (`logs/head-shoulders-detector/runs/2026-05-31T14-39-12.jsonl`): a story was marked **resolved/passed** while the full test suite was red, and the rectification cycle logged `cycle exited — resolved after terminal lite validate` / `Rectification resolved all findings` **without ever re-running the gate that seeded the cycle**.

### Root cause
On the **terminal** rectification iteration, `validate` runs in `lite` mode, which **skipped `full-suite-gate` entirely**:

```ts
if (lite && phase.kind === "full-suite-gate") continue;
```

Since the gate was the originating finding (strategy `full-suite-rectify`, whose revalidation set *includes* `full-suite-gate`), skipping it silently dropped that finding. The remaining cheaper phases (ending with **semantic-review**) all passed, so the cycle concluded `exitReason: "resolved"` — driven entirely by the non-gate phases, never the gate. The just-applied implementer fix was never validated against the gate.

**Impact:**
- Dishonest exit: `Rectification resolved all findings` + `phaseOutputs.rectification.success = true` while the gate is still red.
- **Single-session per-story regression mode** (`#1116`) hits the same skip but has **no verifier carve-out** to exempt the gate — there a red full suite would actually be marked resolved.

## Fix

Run the gate **last** in lite mode instead of skipping it (new pure helper `orderGateLast`):

```
lite sweep: verifier → verify-scoped → lint → typecheck → semantic → [GATE last]
  any cheaper phase fails → short-circuit, gate never dispatched (cost preserved)
  all cheaper pass        → re-run gate to validate the fix
```

- **Cost preserved:** a failing cheaper phase short-circuits before the expensive gate is dispatched — the saving that motivated lite mode.
- **Honest:** when everything cheaper is green, the gate is re-run and decides the verdict.
- **Verifier-SSOT carve-out unchanged:** `shouldSkipPhaseForRectification` still discards the gate's finding when a verifier passed (unrelated-regression policy) — so in three-session the gate is dispatched (validating the fix) but does not block `resolved`. The gate is the decisive arbiter only when no passing verifier overrides it (single-session, or a failed/absent verifier).
- **Full mode untouched**; `verify-scoped` was never skipped and is unaffected.

## Tests
`test/unit/execution/story-orchestrator-revalidation.test.ts`:
- lite: full-suite-gate is re-run and runs after every cheaper phase (RED before fix — observed order was `[verifier, verify-scoped, lint, typecheck, semantic]`, gate absent)
- lite: a failing cheaper phase short-circuits before the gate (cost preserved; `shortCircuited === true`)
- lite: verifier-SSOT carve-out discards a red gate's finding when verifier passed
- full mode unchanged: gate keeps its canonical position
- `orderGateLast` pure-ordering unit tests

## Verification
- `bun run typecheck` ✓
- `bun run lint` ✓ (src/ + bin/ clean; all baseline checks pass)
- `bun run test` ✓ — **9486 pass / 0 fail** (unit 8427, integration 1048, ui 11)

## Note (out of scope)
In the verifier-passed + red-gate path, the gate now runs in the cycle *and* is re-run by the existing post-rectification resume block (`story-orchestrator.ts:~1137`), so that path does 2 full-suite runs. Making the resume skip re-running a gate the cycle already ran-and-exempted is a follow-up if desired.