### PR TITLE
feat(rectification): require N consecutive regressions before increasing-failures bail

### DIFF
--- a/src/cli/config-descriptions.ts
+++ b/src/cli/config-descriptions.ts
@@ -79,6 +79,8 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
   "execution.rectification.fullSuiteTimeoutSeconds": "Timeout for full test suite run in seconds",
   "execution.rectification.maxFailureSummaryChars": "Max characters in failure summary",
   "execution.rectification.abortOnIncreasingFailures": "Abort if failure count increases",
+  "execution.rectification.consecutiveIncreasesToBail":
+    "Consecutive regressing iterations required before abortOnIncreasingFailures bails (default: 2; 1 = legacy behaviour)",
   "execution.rectification.escalateOnExhaustion":
     "Enable model tier escalation when attempts are exhausted with remaining failures",
   "execution.rectification.rethinkAtAttempt":

--- a/src/config/runtime-types.ts
+++ b/src/config/runtime-types.ts
@@ -55,6 +55,9 @@ export interface RectificationConfig {
   maxFailureSummaryChars: number;
   /** Abort rectification if failure count increases (default: true) */
   abortOnIncreasingFailures: boolean;
+  /** Consecutive regressing iterations required before abortOnIncreasingFailures
+   * bails. 1 = legacy single-iteration behaviour. (default: 2) */
+  consecutiveIncreasesToBail: number;
   /** Escalate to higher model tier after exhausting maxAttemptsTotal (default: true) */
   escalateOnExhaustion: boolean;
   /** Per-strategy attempt number at which "rethink your approach" language is

--- a/src/config/schemas-execution.ts
+++ b/src/config/schemas-execution.ts
@@ -33,6 +33,12 @@ const RectificationConfigSchema = z.object({
   fullSuiteTimeoutSeconds: z.number().int().min(10).max(600).default(120),
   maxFailureSummaryChars: z.number().int().min(500).max(10000).default(2000),
   abortOnIncreasingFailures: z.boolean().default(true),
+  /** Number of consecutive iterations whose finding count must increase
+   * (findingsAfter > findingsBefore) before `abortOnIncreasingFailures` bails.
+   * 1 = bail on the first regressing iteration (legacy behaviour); higher
+   * values tolerate transient regressions (e.g. a tightened test temporarily
+   * surfacing more verifier failures before the implementer fixes the source). */
+  consecutiveIncreasesToBail: z.number().int().min(1).max(10).default(2),
   escalateOnExhaustion: z.boolean().optional().default(true),
   // Per-strategy attempt counters — reset when a new strategy runs.
   // Under maxAttemptsPerStrategy=3: rethink on attempt 2, urgency on attempt 3 (final).

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -113,6 +113,7 @@ export const NaxConfigSchema = z
         fullSuiteTimeoutSeconds: 300,
         maxFailureSummaryChars: 2000,
         abortOnIncreasingFailures: true,
+        consecutiveIncreasesToBail: 2,
         escalateOnExhaustion: true,
         rethinkAtAttempt: 2,
         urgencyAtAttempt: 3,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -45,6 +45,7 @@ export {
   formatPhaseResultMessage,
   buildPhaseOutcomeLogData,
   refreshReviewInputForDispatch,
+  withIncreasingFailuresBail,
   type OrchestratorSlot,
   type RectificationPhaseOptions,
   type StoryOrchestratorResult,

--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -406,6 +406,7 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
           maxAttempts: ctx.config.execution.rectification.maxAttemptsTotal,
           strategies: [], // base — buildPlanForStrategy prepends makeFullSuiteRectifyStrategy(story) for TDD+gate plans
           abortOnIncreasingFailures: ctx.config.execution.rectification.abortOnIncreasingFailures,
+          consecutiveIncreasesToBail: ctx.config.execution.rectification.consecutiveIncreasesToBail,
         }
       : undefined;
 

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -183,6 +183,9 @@ export interface RectificationPhaseOptions {
   // biome-ignore lint/suspicious/noExplicitAny: rectification strategies are heterogeneous over their fixOp input/output
   readonly strategies: FixStrategy<Finding, any, any, any>[];
   readonly abortOnIncreasingFailures: boolean;
+  /** Consecutive regressing iterations required before the increasing-failures
+   * bail fires. Defaults to 1 (legacy single-iteration behaviour) when omitted. */
+  readonly consecutiveIncreasesToBail?: number;
   /** Optional: transform findings after validate() returns, before next iteration's strategy selection. */
   readonly postValidate?: (findings: Finding[], ctx: FixCycleContext) => Promise<Finding[]>;
 }
@@ -858,23 +861,35 @@ async function runPhase(
 }
 
 /**
- * Wrap each strategy with a bailWhen predicate that fires when the last iteration's
- * findingsAfter count exceeds its findingsBefore count. Preserves user-supplied bailWhen
- * if present (user predicate wins). Returns the unchanged strategies when the option is off.
+ * Wrap each strategy with a bailWhen predicate that fires only after
+ * `consecutiveIncreases` *trailing* iterations have each regressed the finding
+ * count (findingsAfter > findingsBefore). A threshold of 1 reproduces the legacy
+ * "bail on the first regressing iteration" behaviour; higher values tolerate a
+ * transient regression — e.g. a tightened test surfacing more verifier failures
+ * before the implementer fixes the source. Preserves user-supplied bailWhen if
+ * present (user predicate wins). Returns the unchanged strategies when off.
+ *
+ * @internal Exported for unit testing; not for external callers.
  */
-function withIncreasingFailuresBail(
+export function withIncreasingFailuresBail(
   strategies: FixStrategy<Finding, unknown, unknown, unknown>[],
   enabled: boolean,
+  consecutiveIncreases: number,
 ): FixStrategy<Finding, unknown, unknown, unknown>[] {
   if (!enabled) return strategies;
+  const threshold = Math.max(1, consecutiveIncreases);
   return strategies.map((strategy) => ({
     ...strategy,
     bailWhen: (iterations: Iteration<Finding>[]): string | null => {
       const userReason = strategy.bailWhen?.(iterations) ?? null;
       if (userReason !== null) return userReason;
-      const last = iterations[iterations.length - 1];
-      if (last && last.findingsAfter.length > last.findingsBefore.length) {
-        return `failure count increased: ${last.findingsBefore.length} -> ${last.findingsAfter.length}`;
+      if (iterations.length < threshold) return null;
+      const trailing = iterations.slice(-threshold);
+      const allRegressed = trailing.every((it) => it.findingsAfter.length > it.findingsBefore.length);
+      if (allRegressed) {
+        const first = trailing[0];
+        const last = trailing[trailing.length - 1];
+        return `failure count increased for ${threshold} consecutive iteration(s): ${first.findingsBefore.length} -> ${last.findingsAfter.length}`;
       }
       return null;
     },
@@ -958,6 +973,7 @@ export async function runRectification(
     strategies: withIncreasingFailuresBail(
       rectification.strategies as FixStrategy<Finding, unknown, unknown, unknown>[],
       rectification.abortOnIncreasingFailures,
+      rectification.consecutiveIncreasesToBail ?? 1,
     ),
     config: { maxAttemptsTotal: rectification.maxAttempts, validatorRetries: 1 },
     validate: async (_validateCtx, opts) => {

--- a/test/unit/execution/story-orchestrator-bail.test.ts
+++ b/test/unit/execution/story-orchestrator-bail.test.ts
@@ -1,0 +1,90 @@
+/**
+ * withIncreasingFailuresBail — consecutive-increase bail predicate.
+ *
+ * Verifies the `abortOnIncreasingFailures` bail fires only after N *trailing*
+ * iterations have each regressed the finding count (findingsAfter > findingsBefore).
+ * A threshold of 1 reproduces the legacy single-iteration behaviour; the
+ * production default of 2 tolerates one transient regression (e.g. a tightened
+ * test surfacing more verifier failures before the implementer fixes the source).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { withIncreasingFailuresBail } from "@/execution";
+import type { FixStrategy, Iteration } from "@/findings";
+import type { Finding } from "@/findings";
+
+function finding(message: string): Finding {
+  return { severity: "error", category: "test", source: "tdd-verifier", message };
+}
+
+function iter(beforeCount: number, afterCount: number, num = 1): Iteration<Finding> {
+  return {
+    iterationNum: num,
+    findingsBefore: Array.from({ length: beforeCount }, (_, i) => finding(`before-${i}`)),
+    findingsAfter: Array.from({ length: afterCount }, (_, i) => finding(`after-${i}`)),
+    fixesApplied: [{ strategyName: "s", op: "noop-op", targetFiles: [], summary: "" }],
+    outcome: afterCount > beforeCount ? "regressed" : "unchanged",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    finishedAt: "2026-01-01T00:00:01.000Z",
+  };
+}
+
+function baseStrategy(): FixStrategy<Finding, unknown, unknown, unknown> {
+  return {
+    name: "autofix-test-writer",
+    appliesTo: () => true,
+    fixOp: { name: "noop" } as unknown as FixStrategy<Finding, unknown, unknown, unknown>["fixOp"],
+    buildInput: () => ({}),
+    maxAttempts: 3,
+    coRun: "co-run-sequential",
+  };
+}
+
+function bailOf(strategies: FixStrategy<Finding, unknown, unknown, unknown>[]): (iters: Iteration<Finding>[]) => string | null {
+  const fn = strategies[0]?.bailWhen;
+  if (!fn) throw new Error("expected bailWhen to be wrapped");
+  return fn;
+}
+
+describe("withIncreasingFailuresBail — consecutive threshold", () => {
+  test("disabled: returns strategies unchanged (no bailWhen wrapping)", () => {
+    const original = baseStrategy();
+    const [wrapped] = withIncreasingFailuresBail([original], false, 2);
+    expect(wrapped).toBe(original);
+    expect(wrapped.bailWhen).toBeUndefined();
+  });
+
+  test("threshold 2: a single regressing iteration does NOT bail", () => {
+    const bail = bailOf(withIncreasingFailuresBail([baseStrategy()], true, 2));
+    // The flailing scenario from the log: churn (1->1) then one increase (1->2).
+    expect(bail([iter(1, 1, 1)])).toBeNull();
+    expect(bail([iter(1, 1, 1), iter(1, 2, 2)])).toBeNull();
+  });
+
+  test("threshold 2: two consecutive regressing iterations bail", () => {
+    const bail = bailOf(withIncreasingFailuresBail([baseStrategy()], true, 2));
+    const reason = bail([iter(1, 2, 1), iter(2, 3, 2)]);
+    expect(reason).toContain("2 consecutive");
+    expect(reason).toContain("1 -> 3");
+  });
+
+  test("threshold 2: a non-regressing iteration between increases resets the run", () => {
+    const bail = bailOf(withIncreasingFailuresBail([baseStrategy()], true, 2));
+    // increase, then flat — trailing window [flat, ...] is not all-regressed.
+    expect(bail([iter(1, 2, 1), iter(2, 2, 2)])).toBeNull();
+    // ...but two increases AFTER the flat one do bail.
+    expect(bail([iter(1, 2, 1), iter(2, 2, 2), iter(2, 3, 3), iter(3, 4, 4)])).toContain("2 consecutive");
+  });
+
+  test("threshold 1: reproduces legacy bail-on-first-increase behaviour", () => {
+    const bail = bailOf(withIncreasingFailuresBail([baseStrategy()], true, 1));
+    expect(bail([iter(1, 1, 1)])).toBeNull();
+    expect(bail([iter(1, 2, 1)])).toContain("1 -> 2");
+  });
+
+  test("user-supplied bailWhen wins over the increasing-failures predicate", () => {
+    const strat = { ...baseStrategy(), bailWhen: () => "user-reason" };
+    const bail = bailOf(withIncreasingFailuresBail([strat], true, 2));
+    expect(bail([iter(1, 2, 1), iter(2, 3, 2)])).toBe("user-reason");
+  });
+});


### PR DESCRIPTION
## What

Make the rectification `abortOnIncreasingFailures` guard require **N consecutive trailing regressing iterations** before bailing, instead of bailing on any single per-iteration increase in finding count. Adds a configurable threshold `execution.rectification.consecutiveIncreasesToBail` (default **2**, min 1, max 10; `1` = legacy behaviour).

## Why

The old predicate bailed the cycle the moment one iteration went `findingsAfter > findingsBefore`. That is too tight for the three-session `adversarial-review → test-writer → implementer` flow:

1. An adversarial-review finding is routed to `autofix-test-writer`.
2. The test-writer **correctly tightens** the test, which makes the verifier surface more failures (`tdd-verifier`, `fixTarget: source`).
3. Those failures are exactly what `autofix-implementer` claims — the implementer should run next and fix the source.

In a real run this never happened: the cycle bailed on the `1 -> 2` increase at iteration 2, one iteration before the implementer would have been selected, failing the story terminally after ~\$7.60. With a threshold of 2 the transient regression is tolerated and the implementer gets its turn.

Closes #

## How

- New Zod key in `RectificationConfigSchema` with `.default(2)`; mirrored in `runtime-types.ts`, the `schemas.ts` default literal, and `config-descriptions.ts`.
- Threaded through `plan-inputs.ts` → `RectificationPhaseOptions` → `withIncreasingFailuresBail`.
- `withIncreasingFailuresBail` now slices the trailing `threshold` iterations and bails only if **all** regressed; a flat/improving iteration resets the run. Exported for unit testing.
- The orchestrator call site uses `?? 1` so directly-constructed options (plugins/tests) keep legacy single-iteration behaviour; production always populates `2` from config.

## Testing

- [x] Tests added/updated — `test/unit/execution/story-orchestrator-bail.test.ts` (6 cases: threshold 1/2 parity, single-increase no-bail, reset-on-flat, user-predicate precedence, disabled passthrough)
- [x] `bun test` passes — 8433 unit + 1048 integration + 11 ui, 0 fail
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes

## Notes

No breaking change — default of 2 only loosens an existing guard. Set `consecutiveIncreasesToBail: 1` to restore the previous bail-on-first-increase behaviour.