### PR TITLE
feat(prompts): break work into small verified steps for implementer/test-writer/autofix

### DIFF
--- a/src/prompts/builders/rectifier-builder-helpers.ts
+++ b/src/prompts/builders/rectifier-builder-helpers.ts
@@ -288,6 +288,7 @@ ${errors}
 1. Read the relevant files to verify each finding is a real issue
 2. Only fix findings that are actually valid problems
 3. Do NOT add keys, functions, or imports that already exist — check first
+4. Break the fix into one small step per valid finding before touching code, each verified by re-running the relevant check
 
 ${testEditHeadline(story, `Do NOT change test files or test behavior — see the ${exceptionCountWord(story)} narrow exceptions appended below.`)}
 Do NOT add new features — only fix valid issues.
@@ -317,6 +318,7 @@ ${errors}
 1. Read the relevant files to verify each finding is a real issue
 2. Only fix findings that are actually valid problems
 3. Do NOT add keys, functions, or imports that already exist — check first
+4. Break the fix into one small step per valid finding before touching code, each verified by re-running the relevant check
 
 Do NOT add new features — only fix valid issues.
 Commit your fixes when done.${scopeConstraint}${noTestIsolationBlock(story)}${escapeHatchFor(story)}`;
@@ -350,6 +352,7 @@ ${adversarialErrors}
 1. Read the relevant files to verify each finding is a real issue
 2. Only fix findings that are actually valid problems
 3. Do NOT add keys, functions, or imports that already exist — check first
+4. Break the fix into one small step per valid finding before touching code, each verified by re-running the relevant check
 
 Do NOT add new features — only fix valid issues.
 Commit your fixes when done.${scopeConstraint}${noTestIsolationBlock(story)}${escapeHatchFor(story)}`;

--- a/src/prompts/builders/rectifier-builder.ts
+++ b/src/prompts/builders/rectifier-builder.ts
@@ -323,6 +323,8 @@ ${findingLines}
 
 **Task:** For each bug above, write a NEW failing test that asserts the spec-correct behavior described in the finding. The test should FAIL with the current (buggy) implementation and PASS once the implementer fixes the source.
 
+Break the work into one small task per bug before writing: for each, note the failing test's name and which spec-correct behavior it pins down.
+
 Rules:
 1. Write the test against the SPECIFICATION, not the current behavior.
 2. Do NOT fix the source files — only write test files.
@@ -352,6 +354,8 @@ ${fileList}
 
 ### Implementer handoff
 ${reason}
+
+Break the work into one small task per listed file before editing: for each, note how its mock setup and dispatch wiring must change to match the AC-mandated dispatch shape.
 
 Rules:
 1. Modify ONLY the files listed above.
@@ -413,7 +417,8 @@ Before making any changes:
 2. Do NOT loosen assertions to match current implementation behavior. If a test is failing because the source is wrong, the source is the suspect — not the test.
 3. Do NOT delete a failing test because the implementation makes it hard to assert on. Refactor the test structure if needed; never silently drop coverage.
 4. If the current behavior disagrees with the acceptance criteria, write the test against the spec and let the implementer fix the source.
-5. Do NOT modify source implementation files.`;
+5. Do NOT modify source implementation files.
+6. Break the work into one small change per flagged test before editing, each verified by re-running that test.`;
 
     return `${opener}
 
@@ -660,7 +665,7 @@ ${acList}
 ### Findings
 ${llmSection}
 
-**Important:** LLM reviewers may flag false positives. Before making changes for LLM review findings, read the relevant files to verify each finding is a real issue. Do NOT add keys, functions, or imports that already exist.
+**Important:** LLM reviewers may flag false positives. Before making changes for LLM review findings, read the relevant files to verify each finding is a real issue, then break the fix into one small step per valid finding before touching code, each verified by re-running the relevant check. Do NOT add keys, functions, or imports that already exist.
 
 Do NOT add new features — only fix the identified issues.
 Commit your fixes when done.${scopeConstraint}${escapeHatchFor(story)}`;
@@ -869,7 +874,9 @@ Tests are failing. Fix the source so all tests pass — not just the ones listed
       const detail = reasoning ? `  Reasoning: ${reasoning}\n` : "";
       lines.push(`- [${f.category}] ${f.message}\n${detail}`);
     }
-    lines.push("\nFix the implementation to resolve all verifier findings.");
+    lines.push(
+      "\nBefore editing, break the work into one small fix per finding above (fix -> re-run to verify). Then fix the implementation to resolve all verifier findings.",
+    );
     return lines.join("\n");
   }
 

--- a/src/prompts/sections/role-task.ts
+++ b/src/prompts/sections/role-task.ts
@@ -75,9 +75,10 @@ Your task: make the failing tests pass by writing real source code.
 Workflow:
 1. Read every failing test in scope. The tests are the contract — understand what each one asserts before editing source.
 2. Run the scoped test files once to establish the baseline (which fail, which pass, and why).
-3. Implement source code in the package's source location (the project context names it).
-4. After each meaningful change, re-run only the scoped test files — never the full suite.
-5. When all scoped tests pass, stage and commit ALL changed files: \`git commit -m '${commitMsg}'\`.
+3. Break the work into small steps before writing: for each step, note the source change and the failing test that verifies it (step -> verify). Resolve ambiguities now, not mid-edit.
+4. Implement source code in the package's source location (the project context names it).
+5. After each meaningful change, re-run only the scoped test files — never the full suite.
+6. When all scoped tests pass, stage and commit ALL changed files: \`git commit -m '${commitMsg}'\`.
 
 Rules:
 - Do NOT modify test files. Three narrow exceptions: (a) a lint-only fix to a test, (b) a contract drift where the test imports a removed/renamed symbol, (c) a sibling test file rename forced by your source change. Name which exception applies in the commit body before editing any test file.
@@ -94,10 +95,11 @@ Context: A test-writer session has already created tests and may have added mini
 Workflow:
 1. Run the existing scoped tests to see which fail and why (assertion failure vs import error).
 2. Read each failing test. Note which ACs they cover and which they DON'T.
-3. Replace stubs with real implementations. A stub is one of: a type-only declaration, a function returning a placeholder/throwing "not implemented", or a const placeholder.
-4. If any AC has no test, add one before implementing — do not implement uncovered behavior.
-5. Re-run only the scoped test files after each meaningful change.
-6. When all scoped tests pass, stage and commit ALL changed files: \`git commit -m '${commitMsg}'\`.
+3. Break the work into small steps before writing: for each stub, note the real implementation that replaces it and the test that verifies it (step -> verify); flag any AC still missing a test. Resolve ambiguities now, not mid-edit.
+4. Replace stubs with real implementations. A stub is one of: a type-only declaration, a function returning a placeholder/throwing "not implemented", or a const placeholder.
+5. If any AC has no test, add one before implementing — do not implement uncovered behavior.
+6. Re-run only the scoped test files after each meaningful change.
+7. When all scoped tests pass, stage and commit ALL changed files: \`git commit -m '${commitMsg}'\`.
 
 Rules:
 - Three test-modification exceptions apply (lint-only fix, contract drift, sibling rename). Name the exception in the commit body before editing any test the test-writer wrote.
@@ -115,10 +117,11 @@ Context: You are session 1 of a multi-session workflow. An implementer will foll
 
 Workflow:
 1. Re-read the acceptance criteria above.
-2. Create test files in the location the project uses for tests.
-3. Create stubs in the package's source location so the tests can import and compile. A stub is one of: a type/interface declaration, a function returning a placeholder/throwing "not implemented" (no more than 3 lines of body), or a const placeholder. If a stub body needs real logic, you have crossed into implementer territory — stop.
-4. For each AC: at least one success-path test and one boundary/failure-path test.
-5. Run the new test files. Confirm tests compile (stubs work) AND fail with ASSERTION failures — NOT import errors or compile errors. A test that errors before reaching its assertion does not prove the behavior is missing.
+2. Break the work into small tasks before writing: treat each AC as one task and note the test name(s) you will add (success + boundary) and the minimal stub each test needs to compile. This per-AC list is your checklist.
+3. Create test files in the location the project uses for tests.
+4. Create stubs in the package's source location so the tests can import and compile. A stub is one of: a type/interface declaration, a function returning a placeholder/throwing "not implemented" (no more than 3 lines of body), or a const placeholder. If a stub body needs real logic, you have crossed into implementer territory — stop.
+5. For each AC: at least one success-path test and one boundary/failure-path test.
+6. Run the new test files. Confirm tests compile (stubs work) AND fail with ASSERTION failures — NOT import errors or compile errors. A test that errors before reaching its assertion does not prove the behavior is missing.
 
 Rules:
 - Stubs are NOT implementations. The implementer in the next session writes real logic.
@@ -136,9 +139,10 @@ Context: You are session 1 of a multi-session workflow.
 
 Workflow:
 1. Re-read the acceptance criteria above.
-2. Create test files in the location the project uses for tests (project context names it).
-3. For each AC: write at least one test for the success path AND at least one for a boundary/failure path (zero, empty, negative, missing, throws). ACs worded as "throws X" require a test asserting the throw.
-4. Run the new test files. Confirm every test fails with an ASSERTION failure — NOT an import error, compile error, or runtime crash before assertion. A test that errors before reaching its assertion does not prove the behavior is missing.
+2. Break the work into small tasks before writing: treat each AC as one task and note the test name(s) you will write (success + boundary) and which file they belong in. This per-AC list is your checklist.
+3. Create test files in the location the project uses for tests (project context names it).
+4. For each AC: write at least one test for the success path AND at least one for a boundary/failure path (zero, empty, negative, missing, throws). ACs worded as "throws X" require a test asserting the throw.
+5. Run the new test files. Confirm every test fails with an ASSERTION failure — NOT an import error, compile error, or runtime crash before assertion. A test that errors before reaching its assertion does not prove the behavior is missing.
 
 Rules:
 - Do NOT create or modify any source files. Read source for types/interfaces only.


### PR DESCRIPTION
## Summary

Adds a **task-decomposition step** to the prompts for the four execution roles, instructing agents to break work into small steps (each tied to its verify check) before editing — rather than jumping straight into implementation. Framing follows the "state a brief plan: step → verify" guidance.

This replaces an earlier "plan first" wording with the stronger, more concrete "break into small steps, each verified" framing.

## What changed

**TDD roles** (`src/prompts/sections/role-task.ts`)
- **implementer (standard / lite)** — new Workflow step: break the work into small steps, noting the source change and the failing test that verifies each (`step -> verify`)
- **test-writer (strict / lite)** — new Workflow step: treat each AC as one small task and note the test name(s) (success + boundary) and target file; this per-AC list is the checklist

**Autofix-implementer** (`rectifier-builder.ts` / `rectifier-builder-helpers.ts`)
- semantic / adversarial / combined / mixed prompts — decompose the fix into one small step per valid finding, each verified by re-running the relevant check
- verifier-context prompt — one small fix per finding (`fix -> re-run to verify`)

**Autofix-test-writer** (`rectifier-builder.ts`)
- fix-test-files — one small change per flagged test, each verified by re-running that test
- write-failing-test — one small task per bug
- mock-restructure — one small task per listed file

### Deliberate omission
`mechanicalRectification` (pure lint/typecheck autofix) is **left untouched** — those fixes are deterministic and gain nothing from decomposition.

### Design notes
- **Inline, not a separate planning turn** — no extra agent round-trip; the agent decomposes within its existing turn.
- **Role-specific & concrete** — each step is tied to a real unit (a source change, an AC, a finding, a file) and its verify check.
- Uses `->` per the project's no-emoji / machine-parseable convention.

## Test plan
- [x] `bun run lint` — clean (all gate scripts pass)
- [x] `bun run typecheck` — clean
- [x] `bun run test` — unit 8455 pass, integration 1039 pass, ui 11 pass, 0 fail

Pure prompt-wording change; no behavioral/code-path changes.
