### PR TITLE
fix(tui): fix event wiring, logger stdout leak, blinking, and subscription lifecycle

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -79,7 +79,7 @@ import { run } from "../src/execution";
 import { loadHooksConfig } from "../src/hooks";
 import { type LogLevel, initLogger, resetLogger } from "../src/logger";
 import { countStories, loadPRD } from "../src/prd";
-import { projectOutputDir } from "../src/runtime";
+import { AgentStreamEventBus, projectOutputDir } from "../src/runtime";
 import { PipelineEventEmitter, type StoryDisplayState, renderTui } from "../src/tui";
 import { NAX_VERSION } from "../src/version";
 
@@ -539,6 +539,9 @@ program
     // Create event emitter for TUI integration
     const eventEmitter = new PipelineEventEmitter();
 
+    // Shared agent stream bus — created here so TUI can subscribe before run() starts
+    const agentStreamEvents = useHeadless ? undefined : new AgentStreamEventBus();
+
     // Render TUI if not in headless mode
     let tuiInstance: ReturnType<typeof renderTui> | undefined;
     if (!useHeadless) {
@@ -556,6 +559,7 @@ program
         stories: initialStories,
         events: eventEmitter,
         ptyOptions: null, // TODO: Pass actual PTY spawn options when runner supports it
+        agentStreamEvents,
       });
     } else {
       console.log(chalk.dim("   [Headless mode — pipe output]"));
@@ -590,6 +594,7 @@ program
       formatterMode: useHeadless ? formatterMode : undefined,
       headless: useHeadless,
       skipPrecheck: options.skipPrecheck ?? false,
+      agentStreamEvents,
     });
 
     // Create/update latest.jsonl symlink

--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -524,6 +524,7 @@ program
       useChalk: true,
       formatterMode: useHeadless ? formatterMode : undefined,
       headless: useHeadless,
+      suppressConsole: !useHeadless,
     });
 
     // Override config from CLI

--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -561,6 +561,7 @@ program
         events: eventEmitter,
         ptyOptions: null, // TODO: Pass actual PTY spawn options when runner supports it
         agentStreamEvents,
+        queueFilePath: join(workdir, ".queue.txt"),
       });
     } else {
       console.log(chalk.dim("   [Headless mode — pipe output]"));

--- a/src/execution/dry-run.ts
+++ b/src/execution/dry-run.ts
@@ -5,7 +5,7 @@
  */
 
 import { getSafeLogger } from "../logger";
-import { pipelineEventBus } from "../pipeline/event-bus";
+import { pipelineEventBus } from "@/pipeline";
 import type { PluginRegistry } from "../plugins";
 import { markStoryPassed, savePRD } from "../prd";
 import type { PRD, UserStory } from "../prd/types";

--- a/src/execution/dry-run.ts
+++ b/src/execution/dry-run.ts
@@ -4,8 +4,8 @@
  * Extracted from pipeline-result-handler.ts to slim that file below 200 lines.
  */
 
-import { getSafeLogger } from "../logger";
 import { pipelineEventBus } from "@/pipeline";
+import { getSafeLogger } from "../logger";
 import type { PluginRegistry } from "../plugins";
 import { markStoryPassed, savePRD } from "../prd";
 import type { PRD, UserStory } from "../prd/types";

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -11,7 +11,7 @@ import type { NaxConfig } from "../../config";
 import type { Finding } from "../../findings";
 import { type LoadedHooksConfig, fireHook } from "../../hooks";
 import { getSafeLogger } from "../../logger";
-import { pipelineEventBus } from "../../pipeline/event-bus";
+import { pipelineEventBus } from "@/pipeline";
 import type { PRD, StructuredFailure, UserStory } from "../../prd";
 import { markStoryFailed, savePRD } from "../../prd";
 import { tryLlmBatchRoute } from "../../routing";

--- a/src/execution/escalation/tier-escalation.ts
+++ b/src/execution/escalation/tier-escalation.ts
@@ -7,11 +7,11 @@
  * - Max attempts outcome resolution (pause vs fail)
  */
 
+import { pipelineEventBus } from "@/pipeline";
 import type { NaxConfig } from "../../config";
 import type { Finding } from "../../findings";
 import { type LoadedHooksConfig, fireHook } from "../../hooks";
 import { getSafeLogger } from "../../logger";
-import { pipelineEventBus } from "@/pipeline";
 import type { PRD, StructuredFailure, UserStory } from "../../prd";
 import { markStoryFailed, savePRD } from "../../prd";
 import { tryLlmBatchRoute } from "../../routing";

--- a/src/execution/escalation/tier-outcome.ts
+++ b/src/execution/escalation/tier-outcome.ts
@@ -8,7 +8,7 @@
  */
 
 import { getSafeLogger } from "../../logger";
-import { pipelineEventBus } from "../../pipeline/event-bus";
+import { pipelineEventBus } from "@/pipeline";
 import { markStoryFailed, markStoryPaused, savePRD } from "../../prd";
 import type { FailureCategory } from "../../tdd/types";
 import { appendProgress } from "../progress";

--- a/src/execution/escalation/tier-outcome.ts
+++ b/src/execution/escalation/tier-outcome.ts
@@ -7,8 +7,8 @@
  * Phase 3 (ADR-005): Replaced direct fireHook() calls with event bus emissions.
  */
 
-import { getSafeLogger } from "../../logger";
 import { pipelineEventBus } from "@/pipeline";
+import { getSafeLogger } from "../../logger";
 import { markStoryFailed, markStoryPaused, savePRD } from "../../prd";
 import type { FailureCategory } from "../../tdd/types";
 import { appendProgress } from "../progress";

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -8,6 +8,7 @@
  * - Update final status
  */
 
+import { pipelineEventBus } from "@/pipeline";
 import { resolveDefaultAgent } from "../../agents";
 import type { IAgentManager } from "../../agents";
 import type { NaxConfig } from "../../config";
@@ -16,7 +17,6 @@ import type { HooksConfig } from "../../hooks/types";
 import { getSafeLogger } from "../../logger";
 import type { StoryMetrics } from "../../metrics";
 import { deriveRunFallbackAggregates, saveRunMetrics } from "../../metrics";
-import { pipelineEventBus } from "@/pipeline";
 import { countStories, isComplete, isStalled } from "../../prd";
 import type { PRD } from "../../prd";
 import { clearLanguageCache } from "../../project/detector";

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -16,7 +16,7 @@ import type { HooksConfig } from "../../hooks/types";
 import { getSafeLogger } from "../../logger";
 import type { StoryMetrics } from "../../metrics";
 import { deriveRunFallbackAggregates, saveRunMetrics } from "../../metrics";
-import { pipelineEventBus } from "../../pipeline/event-bus";
+import { pipelineEventBus } from "@/pipeline";
 import { countStories, isComplete, isStalled } from "../../prd";
 import type { PRD } from "../../prd";
 import { clearLanguageCache } from "../../project/detector";

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -21,7 +21,7 @@ import type { LoadedHooksConfig } from "../../hooks";
 import type { InteractionChain } from "../../interaction";
 import { initInteractionChain } from "../../interaction";
 import { getSafeLogger } from "../../logger";
-import { pipelineEventBus } from "../../pipeline/event-bus";
+import { pipelineEventBus } from "@/pipeline";
 import type { AgentGetFn } from "../../pipeline/types";
 import { loadPlugins } from "../../plugins/loader";
 import type { PluginRegistry } from "../../plugins/registry";
@@ -98,6 +98,8 @@ export interface RunSetupOptions {
   agentGetFn?: AgentGetFn;
   /** Per-run AgentManager (ADR-012). When provided, validateCredentials() is called at run start. */
   agentManager?: import("../../agents").IAgentManager;
+  /** Pre-built AgentStreamEventBus to inject into the runtime so external subscribers (e.g. TUI) can receive events. */
+  agentStreamEvents?: import("../../runtime").IAgentStreamEventBus;
 }
 
 export interface RunSetupResult {
@@ -182,6 +184,7 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     sessionManager,
     agentManager: options.agentManager,
     featureName: options.feature,
+    agentStreamEvents: options.agentStreamEvents,
   });
 
   // Cleanup stale PIDs from previous crashed runs

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -14,6 +14,7 @@
 
 import * as os from "node:os";
 import path from "node:path";
+import { pipelineEventBus } from "@/pipeline";
 import type { NaxConfig } from "../../config";
 import { globalConfigDir } from "../../config/paths";
 import { LockAcquisitionError, NaxError } from "../../errors";
@@ -21,7 +22,6 @@ import type { LoadedHooksConfig } from "../../hooks";
 import type { InteractionChain } from "../../interaction";
 import { initInteractionChain } from "../../interaction";
 import { getSafeLogger } from "../../logger";
-import { pipelineEventBus } from "@/pipeline";
 import type { AgentGetFn } from "../../pipeline/types";
 import { loadPlugins } from "../../plugins/loader";
 import type { PluginRegistry } from "../../plugins/registry";

--- a/src/execution/pipeline-result-handler.ts
+++ b/src/execution/pipeline-result-handler.ts
@@ -7,12 +7,12 @@
  */
 
 import { join } from "node:path";
+import { pipelineEventBus } from "@/pipeline";
 import type { NaxConfig } from "../config";
 import type { LoadedHooksConfig } from "../hooks";
 import type { InteractionChain } from "../interaction/chain";
 import { getSafeLogger } from "../logger";
 import type { StoryMetrics } from "../metrics";
-import { pipelineEventBus } from "@/pipeline";
 import type { PipelineRunResult } from "../pipeline/runner";
 import type { PluginRegistry } from "../plugins";
 import { countStories, markStoryFailed, markStoryPaused, savePRD } from "../prd";

--- a/src/execution/pipeline-result-handler.ts
+++ b/src/execution/pipeline-result-handler.ts
@@ -12,7 +12,7 @@ import type { LoadedHooksConfig } from "../hooks";
 import type { InteractionChain } from "../interaction/chain";
 import { getSafeLogger } from "../logger";
 import type { StoryMetrics } from "../metrics";
-import { pipelineEventBus } from "../pipeline/event-bus";
+import { pipelineEventBus } from "@/pipeline";
 import type { PipelineRunResult } from "../pipeline/runner";
 import type { PluginRegistry } from "../plugins";
 import { countStories, markStoryFailed, markStoryPaused, savePRD } from "../prd";

--- a/src/execution/runner-setup.ts
+++ b/src/execution/runner-setup.ts
@@ -36,6 +36,8 @@ export interface RunnerSetupOptions {
   agentGetFn?: AgentGetFn;
   /** Per-run AgentManager (ADR-012). When provided, validateCredentials() is called during setup. */
   agentManager?: import("../agents").IAgentManager;
+  /** Pre-built AgentStreamEventBus injected so TUI can subscribe to live agent events. */
+  agentStreamEvents?: import("../runtime").IAgentStreamEventBus;
 }
 
 /**
@@ -85,6 +87,7 @@ export async function runSetupPhase(options: RunnerSetupOptions): Promise<Runner
     getTotalStories: options.getTotalStories,
     agentGetFn: options.agentGetFn,
     agentManager: options.agentManager,
+    agentStreamEvents: options.agentStreamEvents,
   });
 
   return setupResult;

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -73,6 +73,8 @@ export interface RunOptions {
   headless?: boolean;
   /** Skip precheck validations (for advanced users) */
   skipPrecheck?: boolean;
+  /** Pre-built AgentStreamEventBus so the TUI can subscribe to live agent events. */
+  agentStreamEvents?: import("../runtime").IAgentStreamEventBus;
 }
 
 /** Run result */
@@ -104,6 +106,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
     formatterMode = "normal",
     headless = false,
     skipPrecheck = false,
+    agentStreamEvents,
   } = options;
   const startTime = Date.now();
   const runStartedAt = new Date().toISOString();
@@ -136,6 +139,7 @@ export async function run(options: RunOptions): Promise<RunResult> {
     skipPrecheck,
     headless,
     formatterMode,
+    agentStreamEvents,
     getTotalCost: () => totalCost,
     getIterations: () => iterations,
     // @design: BUG-017: Pass getters for run.complete event on SIGTERM

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -4,7 +4,7 @@ import { resolveDefaultAgent } from "../agents";
 import { checkCostExceeded, checkCostWarning, checkPreMerge, isTriggerEnabled } from "../interaction/triggers";
 import { getSafeLogger } from "../logger";
 import type { StoryMetrics } from "../metrics";
-import { pipelineEventBus } from "../pipeline/event-bus";
+import { pipelineEventBus } from "@/pipeline";
 import { runPipeline } from "../pipeline/runner";
 import { postRunPipeline, preRunPipeline } from "../pipeline/stages";
 import { wireEventsWriter } from "../pipeline/subscribers/events-writer";

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -1,10 +1,10 @@
 /** Unified Story Executor (ADR-005, Phase 4) — sequential loop with optional parallel dispatch. */
 
+import { pipelineEventBus } from "@/pipeline";
 import { resolveDefaultAgent } from "../agents";
 import { checkCostExceeded, checkCostWarning, checkPreMerge, isTriggerEnabled } from "../interaction/triggers";
 import { getSafeLogger } from "../logger";
 import type { StoryMetrics } from "../metrics";
-import { pipelineEventBus } from "@/pipeline";
 import { runPipeline } from "../pipeline/runner";
 import { postRunPipeline, preRunPipeline } from "../pipeline/stages";
 import { wireEventsWriter } from "../pipeline/subscribers/events-writer";

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -33,6 +33,11 @@ export type { SequentialExecutionContext, SequentialExecutionResult } from "./ex
 
 const TERMINAL_ACTIONS = new Set(["fail", "skip", "pause"]);
 
+// Tracks internal run-scoped unsubscribers so we can tear them down without
+// calling pipelineEventBus.clear(), which would also wipe external subscribers
+// like the TUI's usePipelineBusEvents hook.
+let _prevRunUnsubscribers: Array<() => void> = [];
+
 async function closeStoryIfTerminal(
   ctx: SequentialExecutionContext,
   storyId: string,
@@ -78,15 +83,17 @@ export async function executeUnified(
     return nextIndex;
   };
 
-  pipelineEventBus.clear();
-  // Wire subscribers — unsubscribe fns are NOT called here because run:completed
-  // fires after executeUnified() returns (in runCompletionPhase). Cleanup happens
-  // via pipelineEventBus.clear() at the start of the next run.
-  wireHooks(pipelineEventBus, ctx.hooks, ctx.workdir, ctx.feature);
-  wireReporters(pipelineEventBus, ctx.pluginRegistry, ctx.runId, ctx.startTime);
-  wireInteraction(pipelineEventBus, ctx.interactionChain, ctx.config);
-  wireEventsWriter(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir);
-  wireRegistry(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir, ctx.runtime.outputDir);
+  // Tear down previous run's internal subscribers before wiring fresh ones.
+  // Calling stored unsubscribers instead of pipelineEventBus.clear() preserves
+  // external subscribers (e.g. TUI's usePipelineBusEvents) across run boundaries.
+  for (const fn of _prevRunUnsubscribers) fn();
+  _prevRunUnsubscribers = [
+    wireHooks(pipelineEventBus, ctx.hooks, ctx.workdir, ctx.feature),
+    wireReporters(pipelineEventBus, ctx.pluginRegistry, ctx.runId, ctx.startTime),
+    wireInteraction(pipelineEventBus, ctx.interactionChain, ctx.config),
+    wireEventsWriter(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir),
+    wireRegistry(pipelineEventBus, ctx.feature, ctx.runId, ctx.workdir, ctx.runtime.outputDir),
+  ];
 
   // Emit run:started once — subscribers (hooks.ts, reporters.ts) own the fan-out.
   // Direct fireHook("on-start") and reporter.onRunStart() calls have been removed.

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -43,7 +43,7 @@ export class Logger {
   private readonly filePath?: string;
   private readonly useChalk: boolean;
   private readonly formatterMode?: VerbosityMode;
-  private readonly headless: boolean;
+  private readonly suppressConsole: boolean;
   /** Tail of the async write chain — await this to know all writes have landed */
   private writeQueueTail: Promise<void> = Promise.resolve();
 
@@ -52,7 +52,7 @@ export class Logger {
     this.filePath = options.filePath;
     this.useChalk = options.useChalk ?? true;
     this.formatterMode = options.formatterMode;
-    this.headless = options.headless ?? false;
+    this.suppressConsole = options.suppressConsole ?? false;
 
     // Ensure parent directory exists if file path provided
     if (this.filePath) {
@@ -108,7 +108,7 @@ export class Logger {
     };
 
     // Console output (level-gated, suppressed in TUI mode to avoid corrupting Ink's terminal)
-    if (this.shouldLog(level) && this.headless) {
+    if (this.shouldLog(level) && !this.suppressConsole) {
       let consoleOutput: string | null = null;
 
       if (this.formatterMode) {

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -107,12 +107,11 @@ export class Logger {
       ...(strippedData && { data: strippedData }),
     };
 
-    // Console output (level-gated)
-    if (this.shouldLog(level)) {
+    // Console output (level-gated, suppressed in TUI mode to avoid corrupting Ink's terminal)
+    if (this.shouldLog(level) && this.headless) {
       let consoleOutput: string | null = null;
 
-      // Use formatter in headless mode if mode is specified
-      if (this.headless && this.formatterMode) {
+      if (this.formatterMode) {
         const formatterOptions: FormatterOptions = {
           mode: this.formatterMode,
           useColor: this.useChalk,
@@ -121,13 +120,10 @@ export class Logger {
         if (formatted.shouldDisplay) {
           consoleOutput = formatted.output;
         }
-        // If formatter says not to display, consoleOutput stays null
       } else {
-        // Default console formatting (existing behavior)
         consoleOutput = this.useChalk ? formatConsole(entry) : this.formatPlainConsole(entry);
       }
 
-      // Only log if we have output to display
       if (consoleOutput !== null) {
         console.log(consoleOutput);
       }

--- a/src/logger/types.ts
+++ b/src/logger/types.ts
@@ -41,6 +41,8 @@ export interface LoggerOptions {
   formatterMode?: "quiet" | "normal" | "verbose" | "json";
   /** Whether running in headless mode (enables formatter) */
   headless?: boolean;
+  /** Suppress all console output (file-only logging). Set true in TUI mode so Ink's terminal is not corrupted. */
+  suppressConsole?: boolean;
 }
 
 /**

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -145,6 +145,12 @@ export interface CreateRuntimeOptions {
    * PidRegistry(workdir). Supply one in tests to control lifecycle.
    */
   pidRegistry?: PidRegistry;
+  /**
+   * Pre-built AgentStreamEventBus. When provided (e.g. from bin/nax.ts so the
+   * TUI can subscribe before run() starts), the runtime uses it instead of
+   * creating a new one. Callers must not close or replace the bus mid-run.
+   */
+  agentStreamEvents?: IAgentStreamEventBus;
 }
 
 export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateRuntimeOptions): NaxRuntime {
@@ -159,7 +165,7 @@ export function createRuntime(config: NaxConfig, workdir: string, opts?: CreateR
 
   const configLoader = createConfigLoader(config);
   const dispatchEvents: IDispatchEventBus = new DispatchEventBus();
-  const agentStreamEvents: IAgentStreamEventBus = new AgentStreamEventBus();
+  const agentStreamEvents: IAgentStreamEventBus = opts?.agentStreamEvents ?? new AgentStreamEventBus();
 
   const projectKey = config.name?.trim() || basename(workdir);
   const outputDir = projectOutputDir(projectKey, config.outputDir);

--- a/src/tui/components/LiveActivityPanel.tsx
+++ b/src/tui/components/LiveActivityPanel.tsx
@@ -8,7 +8,6 @@
  */
 
 import { Box, Text } from "ink";
-import Spinner from "ink-spinner";
 import type { ActiveCallState } from "../hooks/useAgentStreamEvents";
 import type { EscalationEntry, RunSummary } from "../hooks/usePipelineBusEvents";
 
@@ -99,9 +98,7 @@ export function LiveActivityPanel({
       {/* Waiting state when nothing to show */}
       {!hasActiveCalls && !hasSummary && !hasError && (
         <Box paddingX={1} paddingY={1}>
-          <Text dimColor>
-            <Spinner type="dots" /> Waiting for agent...
-          </Text>
+          <Text dimColor>Waiting for agent...</Text>
         </Box>
       )}
     </Box>


### PR DESCRIPTION
## Summary

The TUI introduced in #1178 had four bugs that prevented it from showing live updates, and two additional issues found during pre-PR review.

### Bugs fixed

**1. `pipelineEventBus` singleton fragmentation (stories stuck pending, cost $0.0000)**
Seven execution files imported `pipelineEventBus` directly from the leaf path (`"../pipeline/event-bus"`) while `usePipelineBusEvents` imported from the barrel (`"@/pipeline"`). Bun's module registry creates separate instances for these paths, so events emitted by the runner never reached the TUI. Changed all 7 files to import from `@/pipeline`.

**2. `pipelineEventBus.clear()` wiping TUI subscriptions (stories still stuck after singleton fix)**
`executeUnified()` called `pipelineEventBus.clear()` at run start to reset the previous run's subscribers. This also wiped the TUI's `usePipelineBusEvents` hook subscribers, which registered before `run()` was called. Replaced `clear()` with explicit unsubscriber tracking — `wire*` functions return unsubscribe callbacks that are now stored in `_prevRunUnsubscribers` and called at the next run start, preserving external subscribers.

**3. Logger stdout leak corrupting Ink's terminal (log lines appearing above TUI)**
`Logger` wrote to `console.log` regardless of mode. In TUI mode, any stdout write scrolls Ink's output. Added `suppressConsole: boolean` to `LoggerOptions`; `bin/nax.ts` passes `suppressConsole: !useHeadless` so TUI runs are file-only.

**4. `agentStreamEvents` not wired (Live Activity always "Waiting for agent...")**
The `AgentStreamEventBus` was created inside `createRuntime()` and never surfaced to the TUI. Fixed by creating the bus in `bin/nax.ts` before `renderTui()`, passing it to both `renderTui({ agentStreamEvents })` and `run({ agentStreamEvents })`, and threading it through `RunOptions → RunnerSetupOptions → RunSetupOptions → CreateRuntimeOptions`.

**5. `queueFilePath` not passed to `renderTui()` (pause/skip/abort did nothing)**
The TUI's keyboard handlers for PAUSE/ABORT/SKIP write to `.queue.txt`, but `queueFilePath` was never passed to `renderTui()`. Added `queueFilePath: join(workdir, ".queue.txt")`.

**6. `<Spinner>` causing constant TUI blinking**
`ink-spinner` fires ~10× per second, triggering full Ink repaints. Replaced with static `"Waiting for agent..."` text.

## Files changed

| File | Change |
|:---|:---|
| `src/execution/unified-executor.ts` | Replace `clear()` with explicit unsubscriber tracking |
| `src/execution/{pipeline-result-handler,dry-run,escalation/*,lifecycle/*}.ts` | Leaf → barrel import for `pipelineEventBus` (7 files) |
| `src/logger/logger.ts` + `types.ts` | Add `suppressConsole` option |
| `src/runtime/index.ts` | Accept injected `agentStreamEvents` in `CreateRuntimeOptions` |
| `src/execution/runner.ts` + `runner-setup.ts` + `lifecycle/run-setup.ts` | Thread `agentStreamEvents` through setup chain |
| `bin/nax.ts` | Create `AgentStreamEventBus`, wire `suppressConsole`, `agentStreamEvents`, `queueFilePath` |
| `src/tui/components/LiveActivityPanel.tsx` | Remove `<Spinner>`, static waiting text |

## Test plan

- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] `bun run test` — 1077 pass, 0 fail (integration + UI)
- [ ] Manual: run `nax run` against a feature — stories transition pending → running → passed/failed in real time
- [ ] Manual: cost updates as stories complete
- [ ] Manual: Live Activity panel shows agent name, stage, model, tool name during execution
- [ ] Manual: no log lines appear above the TUI during a run
- [ ] Manual: `p` key pauses, `a` key aborts (writes to `.queue.txt`)
- [ ] Manual: TUI does not blink/flicker during a run