### PR TITLE
fix(cost): make costAggregator the SSOT for all cost reporting

### DIFF
--- a/src/execution/escalation/tier-outcome.ts
+++ b/src/execution/escalation/tier-outcome.ts
@@ -48,7 +48,7 @@ export async function handleNoTierAvailable(
       type: "story:paused",
       storyId: ctx.story.id,
       reason: `Execution stopped (${failureCategory ?? "unknown"} requires human review)`,
-      cost: ctx.totalCost,
+      cost: ctx.runtime?.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? ctx.totalCost,
     });
 
     return { outcome: "paused", prdDirty: true, prd: pausedPrd };
@@ -73,6 +73,7 @@ export async function handleNoTierAvailable(
     story: { id: ctx.story.id, title: ctx.story.title, status: ctx.story.status, attempts: ctx.story.attempts },
     reason: "Execution failed",
     countsTowardEscalation: true,
+    cost: ctx.runtime?.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? ctx.totalCost,
   });
 
   return { outcome: "failed", prdDirty: true, prd: failedPrd };
@@ -111,7 +112,7 @@ export async function handleMaxAttemptsReached(
       type: "story:paused",
       storyId: ctx.story.id,
       reason: `Max attempts reached (${failureCategory ?? "unknown"} requires human review)`,
-      cost: ctx.totalCost,
+      cost: ctx.runtime?.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? ctx.totalCost,
     });
 
     return { outcome: "paused", prdDirty: true, prd: pausedPrd };
@@ -137,6 +138,7 @@ export async function handleMaxAttemptsReached(
     story: { id: ctx.story.id, title: ctx.story.title, status: ctx.story.status, attempts: ctx.story.attempts },
     reason: "Max attempts reached",
     countsTowardEscalation: true,
+    cost: ctx.runtime?.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? ctx.totalCost,
   });
 
   return { outcome: "failed", prdDirty: true, prd: failedPrd };

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -77,13 +77,7 @@ export interface RunCompletionOptions extends DispatchContext {
 export interface RunCompletionResult {
   durationMs: number;
   runCompletedAt: string;
-  /**
-   * Authoritative run total — max of the legacy per-iteration accumulator and
-   * the cost aggregator snapshot. Callers MUST use this for downstream reporting
-   * (exit summary, headless footer, feature-status file) instead of the stale
-   * `options.totalCost`, which only covers execution-phase work and silently
-   * drops acceptance/review/diagnosis spend (issue #909).
-   */
+  /** Authoritative run total from the cost aggregator. Use for all downstream reporting. */
   reportedTotal: number;
   finalCounts: {
     total: number;
@@ -111,7 +105,6 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
     startedAt,
     prd,
     allStoryMetrics,
-    totalCost,
     storiesCompleted,
     iterations,
     startTime,
@@ -260,21 +253,8 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
     });
   }
 
-  // Bug 909 fix — consult the cost aggregator for the authoritative spend total.
-  // Every agent call dispatched through AgentManager emits a DispatchEvent with cost,
-  // captured by attachCostSubscriber into runtime.costAggregator. The legacy `totalCost`
-  // only counts execution-phase work and silently drops acceptance/hardening/diagnosis spend.
   const aggSnap = options.runtime.costAggregator.snapshot();
-  const aggregatorTotal = aggSnap.totalCostUsd;
-  const reportedTotal = Math.max(totalCost, aggregatorTotal);
-
-  if (aggregatorTotal > totalCost + 0.01) {
-    logger?.debug("run.complete", "Cost aggregator total exceeds accumulated totalCost", {
-      totalCost,
-      aggregatorTotal,
-      gap: aggregatorTotal - totalCost,
-    });
-  }
+  const reportedTotal = aggSnap.totalCostUsd;
 
   const aggByStage = options.runtime.costAggregator.byStage();
   const aggByStory = options.runtime.costAggregator.byStory();

--- a/src/execution/pipeline-result-handler.ts
+++ b/src/execution/pipeline-result-handler.ts
@@ -234,7 +234,7 @@ export async function handlePipelineFailure(
         type: "story:paused",
         storyId: ctx.story.id,
         reason: pipelineResult.reason || "Pipeline paused",
-        cost: ctx.totalCost,
+        cost: ctx.runtime.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? ctx.totalCost,
       });
       break;
 
@@ -281,6 +281,7 @@ export async function handlePipelineFailure(
         countsTowardEscalation: true,
         feature: ctx.feature,
         attempts: ctx.story.attempts,
+        cost: ctx.runtime.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? ctx.totalCost,
       });
 
       if (

--- a/src/metrics/tracker.ts
+++ b/src/metrics/tracker.ts
@@ -151,7 +151,7 @@ export async function collectStoryMetrics(ctx: PipelineContext, storyStartTime: 
     attempts,
     finalTier,
     success: agentResult?.success || false,
-    cost: (ctx.accumulatedAttemptCost ?? 0) + (agentResult?.estimatedCostUsd || 0),
+    cost: ctx.runtime.costAggregator.byStory()[story.id]?.totalCostUsd ?? 0,
     durationMs: agentResult?.durationMs || 0,
     firstPassSuccess,
     startedAt: storyStartTime,
@@ -196,9 +196,9 @@ export function collectBatchMetrics(ctx: PipelineContext, storyStartTime: string
   const routing = ctx.routing;
   const agentResult = ctx.agentResult;
 
-  const totalCost = agentResult?.estimatedCostUsd || 0;
+  const batchTotal = ctx.runtime.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? 0;
   const totalDuration = agentResult?.durationMs || 0;
-  const costPerStory = totalCost / stories.length;
+  const costPerStory = batchTotal / stories.length;
   const durationPerStory = totalDuration / stories.length;
 
   const batchAgentUsed = routing.agent ?? ctx.agentManager?.getDefault() ?? resolveDefaultAgent(ctx.config);

--- a/src/pipeline/event-bus.ts
+++ b/src/pipeline/event-bus.ts
@@ -67,6 +67,8 @@ export interface StoryFailedEvent {
   /** Optional: passed by executor for interaction subscriber */
   feature?: string;
   attempts?: number;
+  /** Total cost accumulated across all attempts for this story. */
+  cost?: number;
 }
 
 export interface RegressionDetectedEvent {

--- a/src/pipeline/stages/completion.ts
+++ b/src/pipeline/stages/completion.ts
@@ -30,7 +30,7 @@ export const completionStage: PipelineStage = {
   async execute(ctx: PipelineContext): Promise<StageResult> {
     const logger = getLogger();
     const isBatch = ctx.stories.length > 1;
-    const sessionCost = ctx.agentResult?.estimatedCostUsd || 0;
+    const sessionCost = ctx.runtime.costAggregator.byStory()[ctx.story.id]?.totalCostUsd ?? 0;
     // In parallel worktree mode, a shared PRD and prd.json file is managed by the
     // unified executor. Worktree pipelines must not race on it — skip both the in-memory
     // mutation and the disk write when skipPrdPersistence is set.

--- a/src/pipeline/subscribers/hooks.ts
+++ b/src/pipeline/subscribers/hooks.ts
@@ -85,7 +85,7 @@ export function wireHooks(
         fireHook(
           hooks,
           "on-story-fail",
-          hookCtx(feature, { storyId: ev.storyId, status: "failed", reason: ev.reason }),
+          hookCtx(feature, { storyId: ev.storyId, status: "failed", reason: ev.reason, cost: ev.cost }),
           workdir,
         ),
       );

--- a/test/integration/interaction/interaction-chain-pipeline.test.ts
+++ b/test/integration/interaction/interaction-chain-pipeline.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
+import { makeMockRuntime } from "../../helpers/runtime";
 import type { NaxConfig } from "../../../src/config";
 import { InteractionChain } from "../../../src/interaction/chain";
 import { pipelineEventBus } from "../../../src/pipeline/event-bus";
@@ -261,6 +262,7 @@ describe("AC2: max retries triggers human-review interaction", () => {
         allStoryMetrics: [],
         timeoutRetryCountMap: new Map(),
         storyGitRef: null,
+        runtime: makeMockRuntime(),
         // @ts-expect-error — interactionChain not in PipelineHandlerContext yet
         interactionChain: chain,
       },
@@ -333,6 +335,7 @@ describe("AC2: max retries triggers human-review interaction", () => {
         allStoryMetrics: [],
         timeoutRetryCountMap: new Map(),
         storyGitRef: null,
+        runtime: makeMockRuntime(),
         interactionChain: chain,
       },
       {

--- a/test/unit/execution/lifecycle-completion.test.ts
+++ b/test/unit/execution/lifecycle-completion.test.ts
@@ -284,13 +284,18 @@ describe("RL-002 AC#3: run:completed payload reflects final success status", () 
     const prd = makePRD([{ id: "US-001", status: "passed" }]);
     const config = makeConfig("disabled");
     const opts = makeOpts(config, prd);
-    opts.totalCost = 2.75;
+    opts.runtime.costAggregator.record({
+      ts: Date.now(), runId: "run-001", agentName: "claude", model: "test",
+      storyId: "US-001", tokens: { input: 0, output: 0 },
+      estimatedCostUsd: 2.75, exactCostUsd: 2.75, costUsd: 2.75,
+      confidence: "exact", durationMs: 0,
+    });
 
     try {
       await handleRunCompletion(opts);
 
       expect(capturedEvents).toHaveLength(1);
-      expect(capturedEvents[0]?.totalCost).toBe(2.75);
+      expect(capturedEvents[0]?.totalCost).toBeCloseTo(2.75, 2);
     } finally {
       unsub();
     }

--- a/test/unit/execution/lifecycle/run-completion-aggregator.test.ts
+++ b/test/unit/execution/lifecycle/run-completion-aggregator.test.ts
@@ -116,7 +116,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("handleRunCompletion — Bug 909: aggregator-driven totalCost reporting", () => {
-  test("reports max(legacyTotalCost, aggregatorTotal) when aggregator sees more spend", async () => {
+  test("reports aggregatorTotal as the authoritative run cost", async () => {
     const prd = makePRD(["US-001"]);
     const aggregator = makeMockAggregator({
       snapshot: () => ({ ...makeEmptySnapshot(), totalCostUsd: 6.21, totalEstimatedCostUsd: 6.21, callCount: 5 }),
@@ -130,21 +130,6 @@ describe("handleRunCompletion — Bug 909: aggregator-driven totalCost reporting
     await handleRunCompletion(makeOpts(prd, [], aggregator, 0));
 
     expect(capturedEvent?.totalCost).toBeCloseTo(6.21, 2);
-  });
-
-  test("uses legacyTotalCost when it exceeds the aggregator total", async () => {
-    const prd = makePRD(["US-001"]);
-    const aggregator = makeMockAggregator({
-      snapshot: () => ({ ...makeEmptySnapshot(), totalCostUsd: 1.0, callCount: 1 }),
-      byStory: () => ({ "US-001": { ...makeEmptySnapshot(), totalCostUsd: 1.0, callCount: 1 } }),
-    });
-
-    let capturedEvent: RunCompletedEvent | undefined;
-    pipelineEventBus.on("run:completed", (e) => { capturedEvent = e; });
-
-    await handleRunCompletion(makeOpts(prd, [], aggregator, 3.5));
-
-    expect(capturedEvent?.totalCost).toBeCloseTo(3.5, 2);
   });
 
   test("back-fills storyMetrics for stories with only completion-phase spend", async () => {

--- a/test/unit/execution/pipeline-result-handler.test.ts
+++ b/test/unit/execution/pipeline-result-handler.test.ts
@@ -4,6 +4,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { DEFAULT_CONFIG } from "../../../src/config/defaults";
+import { makeMockRuntime } from "../../helpers/runtime";
 import { _tierEscalationDeps } from "../../../src/execution/escalation/tier-escalation";
 import type { PRD, UserStory } from "../../../src/prd/types";
 import { _gitDeps } from "../../../src/utils/git";
@@ -77,6 +78,7 @@ function makeCtx(story: UserStory, overrides: Partial<PipelineHandlerContext> = 
     isBatchExecution: false,
     allStoryMetrics: [],
     storyGitRef: "abc123",
+    runtime: makeMockRuntime(),
     ...overrides,
   };
 }

--- a/test/unit/metrics/tracker-context-metrics.test.ts
+++ b/test/unit/metrics/tracker-context-metrics.test.ts
@@ -14,6 +14,7 @@ import type { ContextManifest } from "../../../src/context/engine/types";
 import { DEFAULT_CONFIG } from "../../../src/config/defaults";
 import type { PRD, UserStory } from "../../../src/prd";
 import { makeStory } from "../../helpers";
+import { makeMockRuntime } from "../../helpers/runtime";
 
 const PROJECT_DIR = "/repo";
 const FEATURE = "test-feature";
@@ -38,6 +39,7 @@ function makeCtx(overrides?: Partial<PipelineContext>): PipelineContext {
     projectDir: PROJECT_DIR,
     hooks: { hooks: {} },
     agentResult: { success: true, output: "", estimatedCostUsd: 0.01, durationMs: 5000 },
+    runtime: makeMockRuntime(),
     ...overrides,
   } as unknown as PipelineContext;
 }

--- a/test/unit/metrics/tracker-escalation.test.ts
+++ b/test/unit/metrics/tracker-escalation.test.ts
@@ -30,6 +30,7 @@ import type { PipelineContext } from "../../../src/pipeline/types";
 import type { PRD, UserStory } from "../../../src/prd";
 import type { StoryRouting } from "../../../src/prd/types";
 import { makeNaxConfig } from "../../helpers";
+import { makeMockRuntime } from "../../helpers/runtime";
 
 const WORKDIR = `/tmp/nax-escalation-test-${randomUUID()}`;
 const PRD_PATH = `/tmp/prd-${randomUUID()}.json`;
@@ -102,6 +103,7 @@ function makeCtx(story: UserStory, overrides: Record<string, unknown> = {}): Pip
       estimatedCostUsd: 0.10,
       durationMs: 5000,
     },
+    runtime: makeMockRuntime(),
     ...overrides,
   } as unknown as PipelineContext;
 }
@@ -315,6 +317,40 @@ describe("collectStoryMetrics — cost accumulates across all tier escalations",
         priorFailures,
       });
 
+      const runtime = makeMockRuntime();
+
+      // Record prior attempt spend to the aggregator
+      if (priorAttemptCost > 0) {
+        runtime.costAggregator.record({
+          ts: Date.now(),
+          runId: "test",
+          agentName: "claude",
+          model: "test",
+          storyId: story.id,
+          tokens: { input: 0, output: 0 },
+          estimatedCostUsd: priorAttemptCost,
+          exactCostUsd: priorAttemptCost,
+          costUsd: priorAttemptCost,
+          confidence: "exact",
+          durationMs: 0,
+        });
+      }
+
+      // Record current attempt spend to the aggregator
+      runtime.costAggregator.record({
+        ts: Date.now(),
+        runId: "test",
+        agentName: "claude",
+        model: "test",
+        storyId: story.id,
+        tokens: { input: 0, output: 0 },
+        estimatedCostUsd: currentAttemptCost,
+        exactCostUsd: currentAttemptCost,
+        costUsd: currentAttemptCost,
+        confidence: "exact",
+        durationMs: 0,
+      });
+
       const ctx = makeCtx(story, {
         routing:
           priorFailuresCount === 2
@@ -338,8 +374,8 @@ describe("collectStoryMetrics — cost accumulates across all tier escalations",
           estimatedCostUsd: currentAttemptCost,
           durationMs: priorFailuresCount === 2 ? 30000 : 5000,
         },
-        accumulatedAttemptCost: priorAttemptCost,
-      } as any);
+        runtime,
+      });
 
       const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
       expect(metrics.cost).toBeCloseTo(expectedCost, 5);

--- a/test/unit/metrics/tracker-full-suite-gate.test.ts
+++ b/test/unit/metrics/tracker-full-suite-gate.test.ts
@@ -14,6 +14,7 @@ import type { NaxConfig } from "../../../src/config";
 import type { PipelineContext } from "../../../src/pipeline/types";
 import type { PRD, UserStory } from "../../../src/prd";
 import { collectBatchMetrics, collectStoryMetrics } from "../../../src/metrics/tracker";
+import { makeMockRuntime } from "../../helpers/runtime";
 
 const WORKDIR = `/tmp/nax-tracker-gate-test-${randomUUID()}`;
 
@@ -73,6 +74,7 @@ function makeCtx(
       estimatedCostUsd: 0.01,
       durationMs: 5000,
     },
+    runtime: makeMockRuntime(),
     ...ctxOverrides,
   } as unknown as PipelineContext;
 }
@@ -213,6 +215,7 @@ describe("collectBatchMetrics - fullSuiteGatePassed always false", () => {
         durationMs: 10000,
       },
       fullSuiteGatePassed: true,
+      runtime: makeMockRuntime(),
     } as unknown as PipelineContext;
 
     const metrics = collectBatchMetrics(ctx, new Date().toISOString());

--- a/test/unit/metrics/tracker-provider-cost.test.ts
+++ b/test/unit/metrics/tracker-provider-cost.test.ts
@@ -13,6 +13,7 @@ import { _manifestStoreDeps } from "../../../src/context/engine/manifest-store";
 import type { ContextManifest } from "../../../src/context/engine/types";
 import { collectStoryMetrics } from "../../../src/metrics/tracker";
 import type { PipelineContext } from "../../../src/pipeline/types";
+import { makeMockRuntime } from "../../helpers/runtime";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Saved originals
@@ -78,6 +79,7 @@ function makeCtx(id: string, featureId: string): PipelineContext {
     workdir: "/repo",
     routing: { tier: "balanced" },
     agentResult: { success: true, cost: 0 },
+    runtime: makeMockRuntime(),
   } as unknown as PipelineContext;
 }
 

--- a/test/unit/metrics/tracker-runtime-crashes.test.ts
+++ b/test/unit/metrics/tracker-runtime-crashes.test.ts
@@ -18,6 +18,7 @@ import type { PipelineContext } from "../../../src/pipeline/types";
 import type { PRD, UserStory } from "../../../src/prd";
 import { collectStoryMetrics } from "../../../src/metrics/tracker";
 import { makeNaxConfig } from "../../helpers";
+import { makeMockRuntime } from "../../helpers/runtime";
 
 const WORKDIR = `/tmp/nax-test-metrics-${randomUUID()}`;
 const WORKDIR_BATCH = `/tmp/nax-test-metrics-batch-${randomUUID()}`;
@@ -67,6 +68,7 @@ function makeContext(story: UserStory, overrides?: Partial<PipelineContext>): Pi
     },
     workdir: WORKDIR,
     hooks: { hooks: {} },
+    runtime: makeMockRuntime(),
     ...overrides,
   } as PipelineContext;
 }
@@ -173,7 +175,8 @@ describe("collectBatchMetrics - runtimeCrashes per story", () => {
       workdir: WORKDIR_BATCH,
       hooks: { hooks: {} },
       agentResult: { success: true, estimatedCostUsd: 0.01, durationMs: 1000 },
-    } as PipelineContext;
+      runtime: makeMockRuntime(),
+    } as unknown as PipelineContext;
 
     const batchMetrics = collectBatchMetrics(ctx, STORY_START_TIME);
 

--- a/test/unit/metrics/tracker.test.ts
+++ b/test/unit/metrics/tracker.test.ts
@@ -28,6 +28,7 @@ interface VerifyResult {
   scopeTestFallback?: boolean;
 }
 import { makeNaxConfig } from "../../helpers";
+import { makeMockRuntime } from "../../helpers/runtime";
 
 const WORKDIR = `/tmp/nax-tracker-test-${randomUUID()}`;
 
@@ -89,6 +90,7 @@ function makeCtx(
       durationMs: 5000,
     },
     verifyResult,
+    runtime: makeMockRuntime(),
   } as unknown as PipelineContext;
 }
 
@@ -355,7 +357,7 @@ describe("collectStoryMetrics - AC-41 fallback.hops field", () => {
     const story = makeStory();
     const ctx = makeCtx(story);
     ctx.agentFallbacks = [
-      { storyId: "US-001", priorAgent: "claude", newAgent: "codex", outcome: "fail-quota", category: "availability", hop: 1 },
+      { storyId: "US-001", priorAgent: "claude", newAgent: "codex", outcome: "fail-quota", category: "availability", hop: 1, costUsd: 0 },
     ];
 
     const metrics = await collectStoryMetrics(ctx, new Date().toISOString());
@@ -390,8 +392,8 @@ describe("collectStoryMetrics - AC-41 fallback.hops field", () => {
     const story = makeStory();
     const ctx = makeCtx(story);
     ctx.agentFallbacks = [
-      { storyId: "US-001", priorAgent: "claude", newAgent: "codex", outcome: "fail-service-down", category: "availability", hop: 1 },
-      { storyId: "US-001", priorAgent: "codex", newAgent: "opencode", outcome: "fail-rate-limit", category: "availability", hop: 2 },
+      { storyId: "US-001", priorAgent: "claude", newAgent: "codex", outcome: "fail-service-down", category: "availability", hop: 1, costUsd: 0 },
+      { storyId: "US-001", priorAgent: "codex", newAgent: "opencode", outcome: "fail-rate-limit", category: "availability", hop: 2, costUsd: 0 },
     ];
 
     const metrics = await collectStoryMetrics(ctx, new Date().toISOString());

--- a/test/unit/pipeline/stages/completion-review-gate.test.ts
+++ b/test/unit/pipeline/stages/completion-review-gate.test.ts
@@ -16,6 +16,7 @@ import type { PipelineContext } from "../../../../src/pipeline/types";
 import type { PRD, UserStory } from "../../../../src/prd";
 import { withTempDir } from "../../../helpers/temp";
 import { makeNaxConfig } from "../../../helpers";
+import { makeMockRuntime } from "../../../helpers/runtime";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Save originals for restoration
@@ -103,6 +104,7 @@ function makeCtx(config: ReturnType<typeof makeNaxConfig>, tempDir: string, inte
     hooks: {} as PipelineContext["hooks"],
     interaction,
     storyStartTime: new Date().toISOString(),
+    runtime: makeMockRuntime(),
   } as unknown as PipelineContext;
 }
 

--- a/test/unit/pipeline/stages/completion-skip-persistence.test.ts
+++ b/test/unit/pipeline/stages/completion-skip-persistence.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { _completionDeps, completionStage } from "../../../../src/pipeline/stages/completion";
 import type { PipelineContext } from "../../../../src/pipeline/types";
 import { makeNaxConfig, makePRD, makeStory } from "../../../helpers";
+import { makeMockRuntime } from "../../../helpers/runtime";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Save originals for restoration
@@ -40,6 +41,7 @@ function makeCtx(overrides: Partial<PipelineContext>): PipelineContext {
     agentResult: { success: true, estimatedCostUsd: 0.01, output: "", stderr: "", exitCode: 0, rateLimited: false },
     hooks: {} as PipelineContext["hooks"],
     storyStartTime: new Date().toISOString(),
+    runtime: makeMockRuntime(),
     ...overrides,
   } as unknown as PipelineContext;
 }


### PR DESCRIPTION
## Summary

- **`completion.ts`** — stage now reads `costAggregator.byStory()[storyId].totalCostUsd` instead of `agentResult.estimatedCostUsd`; hooks receive resolved cost (exact when wire protocol reports it, otherwise estimated)
- **`metrics/tracker.ts`** — `collectStoryMetrics` and `collectBatchMetrics` replaced `accumulatedAttemptCost + estimatedCostUsd` formula with aggregator lookup, eliminating the duplicate accumulation path
- **`run-completion.ts`** — removed `Math.max(legacyTotal, aggregatorTotal)` workaround; uses `aggregatorTotal` directly now that all bypass paths are closed
- **`event-bus.ts` + `hooks.ts`** — `StoryFailedEvent` gains a `cost` field; all three `story:failed` emitters populate it; `on-story-fail` hook now receives cost
- **`tier-outcome.ts` + `pipeline-result-handler.ts`** — `story:paused` and `story:failed` events use `costAggregator.byStory()[storyId].totalCostUsd` with `ctx.totalCost` as fallback (for the optional-runtime escalation path)

## Root cause

The cost middleware (`src/runtime/middleware/cost.ts`) was already the correct SSOT — it resolves exact vs estimated cost and writes every dispatch event into `CostAggregator`. The bug was that downstream consumers (completion stage, metrics tracker, run-completion, escalation handlers) each had their own independent cost formulas that bypassed the aggregator entirely. The `Math.max` in `run-completion.ts` was the clearest symptom: it existed specifically because the legacy path was known to under-count.

## Test plan

- [ ] `bun run test` — all 8486 tests pass
- [ ] `bun run typecheck` — clean
- [ ] `bun run lint` — clean
- [ ] Verify `on-story-fail` hook receives non-zero cost when a story fails after agent calls
- [ ] Verify `StoryMetrics.cost` for an escalated story equals the sum across all tier attempts (covered by `tracker-escalation.test.ts`)
- [ ] Verify `RunCompletedEvent.totalCost` equals aggregator total (covered by `run-completion-aggregator.test.ts`)