### PR TITLE
feat(tui): blinking fix, post-run phases, version, tokens, and live step display

### DIFF
--- a/bin/nax.ts
+++ b/bin/nax.ts
@@ -81,7 +81,7 @@ import { type LogLevel, initLogger, resetLogger } from "../src/logger";
 import { countStories, loadPRD } from "../src/prd";
 import { AgentStreamEventBus, projectOutputDir } from "../src/runtime";
 import { PipelineEventEmitter, type StoryDisplayState, renderTui } from "../src/tui";
-import { NAX_VERSION } from "../src/version";
+import { NAX_BUILD_INFO, NAX_VERSION } from "../src/version";
 
 const program = new Command();
 
@@ -557,6 +557,7 @@ program
 
       tuiInstance = renderTui({
         feature: options.feature,
+        version: NAX_BUILD_INFO,
         stories: initialStories,
         events: eventEmitter,
         ptyOptions: null, // TODO: Pass actual PTY spawn options when runner supports it

--- a/src/execution/lifecycle/run-completion.ts
+++ b/src/execution/lifecycle/run-completion.ts
@@ -120,6 +120,7 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
     // Regression phase already passed on a prior run — skip
   } else if (regressionMode === "deferred" && config.quality.commands.test) {
     statusWriter.setPostRunPhase("regression", { status: "running" });
+    pipelineEventBus.emit({ type: "postrun:phase:started", phase: "regression" });
 
     const regressionResult = await _runCompletionDeps.runDeferredRegression({
       config,
@@ -138,6 +139,7 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
 
     if (regressionResult.success) {
       statusWriter.setPostRunPhase("regression", { status: "passed", lastRunAt });
+      pipelineEventBus.emit({ type: "postrun:phase:completed", phase: "regression", passed: true });
     } else {
       statusWriter.setPostRunPhase("regression", {
         status: "failed",
@@ -145,6 +147,7 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
         affectedStories: regressionResult.affectedStories,
         lastRunAt,
       });
+      pipelineEventBus.emit({ type: "postrun:phase:completed", phase: "regression", passed: false });
 
       // Mark affected stories as regression-failed in-memory for current-run event counts (RL-004).
       // Intentionally NOT saved to prd.json — rerun resume is driven by status.json via
@@ -242,6 +245,10 @@ export async function handleRunCompletion(options: RunCompletionOptions): Promis
   // returned pluginGateFailed flag, which runner-completion.ts folds into finalStatus.
   let pluginGateFailed = false;
   const deferredReview = options.deferredReview;
+  if (deferredReview !== undefined) {
+    // postrun:phase:started was already emitted in unified-executor.ts before the review ran.
+    pipelineEventBus.emit({ type: "postrun:phase:completed", phase: "review", passed: !deferredReview.anyFailed });
+  }
   if (deferredReview?.anyFailed) {
     const failedReviewers = deferredReview.reviewerResults.filter((r) => !r.passed).map((r) => r.name);
     pluginGateFailed = config.review.pluginMode === "gating";

--- a/src/execution/runner-completion.ts
+++ b/src/execution/runner-completion.ts
@@ -12,6 +12,7 @@ import type { LoadedHooksConfig } from "@/hooks";
 import { fireHook } from "@/hooks";
 import { getSafeLogger } from "@/logger";
 import type { StoryMetrics } from "@/metrics";
+import { pipelineEventBus } from "@/pipeline";
 import type { PipelineEventEmitter } from "@/pipeline/events";
 import type { AgentGetFn } from "@/pipeline/types";
 import type { PluginRegistry } from "@/plugins/registry";
@@ -126,6 +127,7 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
       logger?.info("execution", "Acceptance already passed — skipping acceptance phase");
     } else if (options.config.acceptance.enabled && isComplete(options.prd)) {
       options.statusWriter.setPostRunPhase("acceptance", { status: "running" });
+      pipelineEventBus.emit({ type: "postrun:phase:started", phase: "acceptance" });
 
       // Compute per-package acceptance test paths from PRD story workdirs.
       // This is necessary because preRunCtx.acceptanceTestPaths is ephemeral and
@@ -194,6 +196,7 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
       const lastRunAt = new Date().toISOString();
       if (acceptanceResult.success) {
         options.statusWriter.setPostRunPhase("acceptance", { status: "passed", lastRunAt });
+        pipelineEventBus.emit({ type: "postrun:phase:completed", phase: "acceptance", passed: true });
       } else {
         acceptancePassed = false;
         options.statusWriter.setPostRunPhase("acceptance", {
@@ -202,6 +205,7 @@ export async function runCompletionPhase(options: RunnerCompletionOptions): Prom
           retries: acceptanceResult.retries ?? 0,
           lastRunAt,
         });
+        pipelineEventBus.emit({ type: "postrun:phase:completed", phase: "acceptance", passed: false });
       }
 
       Object.assign(options, {

--- a/src/execution/story-orchestrator.ts
+++ b/src/execution/story-orchestrator.ts
@@ -31,6 +31,7 @@ import type {
 } from "../operations";
 import type { AdversarialReviewInput } from "../operations";
 import { callOp } from "../operations/call";
+import { pipelineEventBus } from "../pipeline/event-bus";
 import { prepareAdversarialReviewInput, prepareSemanticReviewInput } from "../review/prepare-inputs";
 import { errorMessage } from "../utils/errors";
 import { captureGitRef } from "../utils/git";
@@ -803,6 +804,11 @@ async function runPhase(
     });
   }
   logUnifiedReviewPhaseStart(ctx.storyId, opName);
+
+  // Emit TUI step event so the live activity panel can show the current orchestrator step.
+  if (ctx.storyId) {
+    pipelineEventBus.emit({ type: "story:step", storyId: ctx.storyId, step: opName });
+  }
 
   const phaseStartedAt = Date.now();
   const scope = ctx.runtime.costAggregator.openScope();

--- a/src/execution/unified-executor.ts
+++ b/src/execution/unified-executor.ts
@@ -125,6 +125,7 @@ export async function executeUnified(
     if (isComplete(prd)) {
       logger?.info("execution", "All stories already complete — skipping pre-run pipeline");
       const naxIgnoreIndex = await getRunNaxIgnoreIndex(prd);
+      pipelineEventBus.emit({ type: "postrun:phase:started", phase: "review" });
       deferredReview = await runDeferredReview(
         ctx.workdir,
         ctx.config.review,
@@ -190,6 +191,7 @@ export async function executeUnified(
           if (!shouldProceed) return buildResult("pre-merge-aborted");
         }
         logger?.debug("execution", "Running deferred review");
+        pipelineEventBus.emit({ type: "postrun:phase:started", phase: "review" });
         deferredReview = await runDeferredReview(
           ctx.workdir,
           ctx.config.review,

--- a/src/pipeline/event-bus.ts
+++ b/src/pipeline/event-bus.ts
@@ -147,6 +147,26 @@ export interface RunErroredEvent {
   feature?: string;
 }
 
+/** Emitted at the start of each orchestrator phase (test-writer, implementer, verifier, etc.). */
+export interface StoryStepEvent {
+  type: "story:step";
+  storyId: string;
+  /** Op name — e.g. "test-writer", "implementer", "verifier", "semantic-review", "adversarial-review",
+   *  "lint-check", "typecheck-check", "full-suite-gate", "greenfield-gate" */
+  step: string;
+}
+
+export interface PostRunPhaseStartedEvent {
+  type: "postrun:phase:started";
+  phase: "regression" | "acceptance" | "review";
+}
+
+export interface PostRunPhaseCompletedEvent {
+  type: "postrun:phase:completed";
+  phase: "regression" | "acceptance" | "review";
+  passed: boolean;
+}
+
 /** Discriminated union of all pipeline events. */
 export type PipelineEvent =
   | StoryStartedEvent
@@ -161,7 +181,10 @@ export type PipelineEvent =
   | StorySkippedEvent
   | StoryEscalatedEvent
   | RunResumedEvent
-  | RunErroredEvent;
+  | RunErroredEvent
+  | StoryStepEvent
+  | PostRunPhaseStartedEvent
+  | PostRunPhaseCompletedEvent;
 
 export type PipelineEventType = PipelineEvent["type"];
 

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -28,4 +28,7 @@ export type {
   StoryEscalatedEvent,
   StoryStartedEvent,
   StoryFailedEvent,
+  StoryStepEvent,
+  PostRunPhaseStartedEvent,
+  PostRunPhaseCompletedEvent,
 } from "./event-bus";

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Box, Text, useApp, useInput } from "ink";
-import { useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { writeQueueCommand } from "../utils/queue-writer";
 import { CostOverlay } from "./components/CostOverlay";
 import { HelpOverlay } from "./components/HelpOverlay";
@@ -21,6 +21,10 @@ import { usePty } from "./hooks/usePty";
 import { PanelFocus } from "./types";
 import type { TuiProps } from "./types";
 
+// Memoized panels — only re-render when their own props change, not on every timer tick
+const MemoStoriesPanel = memo(StoriesPanel);
+const MemoLiveActivityPanel = memo(LiveActivityPanel);
+
 /**
  * Format elapsed milliseconds as "Nm Ns" string.
  */
@@ -35,6 +39,15 @@ function formatElapsed(ms: number): string {
  */
 function formatCost(cost: number): string {
   return `$${cost.toFixed(4)}`;
+}
+
+/**
+ * Format token count as e.g. "21.1k" or "1.5M".
+ */
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return `${n}`;
 }
 
 /**
@@ -62,6 +75,7 @@ function formatCost(cost: number): string {
  */
 export function App({
   feature,
+  version,
   stories: initialStories,
   events,
   queueFilePath,
@@ -72,6 +86,16 @@ export function App({
   const busState = usePipelineBusEvents(initialStories);
   const { currentStage } = usePipelineEvents(events);
   const { exit } = useApp();
+
+  // Separate elapsed time state — isolated so the 1s timer only re-renders
+  // the header, not StoriesPanel or LiveActivityPanel (those are memoized).
+  const startTimeRef = useRef(Date.now());
+  const [elapsedMs, setElapsedMs] = useState(0);
+  useEffect(() => {
+    if (busState.runSummary) return; // Run complete — timer already frozen
+    const timer = setInterval(() => setElapsedMs(Date.now() - startTimeRef.current), 1000);
+    return () => clearInterval(timer);
+  }, [busState.runSummary]);
 
   // Focus management (Tab toggles between Stories and Agent panels)
   const [focus, setFocus] = useState<PanelFocus>(PanelFocus.Stories);
@@ -85,8 +109,8 @@ export function App({
   // Wire PTY hook for agent session
   const { handle: ptyHandle } = usePty(ptyOptions ?? null);
 
-  // Wire agent stream events for live call metadata
-  const { activeCalls } = useAgentStreamEvents(agentStreamEvents);
+  // Wire agent stream events for live call metadata and token accumulation
+  const { activeCalls, inputTokens, outputTokens } = useAgentStreamEvents(agentStreamEvents);
 
   // Derived state
   const isRunComplete = !!busState.runSummary;
@@ -204,12 +228,16 @@ export function App({
   // Warn if terminal is too small
   const isTooSmall = layout.width < MIN_TERMINAL_WIDTH;
 
-  // Header right side: "N running · $cost · elapsed"
+  // Header right side: "N running · $cost · Xk in / Yk out · elapsed"
   const activeCount = runningStories.length;
+  const displayElapsed = busState.runSummary ? busState.runSummary.durationMs : elapsedMs;
+  const tokensStr =
+    inputTokens > 0 || outputTokens > 0 ? `${formatTokens(inputTokens)} in / ${formatTokens(outputTokens)} out` : null;
   const headerRight = [
     activeCount > 0 ? `${activeCount} running` : null,
     formatCost(busState.totalCost),
-    formatElapsed(busState.elapsedMs),
+    tokensStr,
+    formatElapsed(displayElapsed),
   ]
     .filter(Boolean)
     .join("  ·  ");
@@ -222,6 +250,12 @@ export function App({
       <Box paddingX={1} borderStyle="single" borderBottom borderColor="cyan" justifyContent="space-between">
         <Text bold color="cyan">
           nax run — {feature}
+          {version ? (
+            <Text dimColor color="cyan">
+              {" "}
+              {version}
+            </Text>
+          ) : null}
         </Text>
         <Text dimColor>{headerRight}</Text>
       </Box>
@@ -238,17 +272,19 @@ export function App({
       {/* Main content area */}
       <Box flexDirection={layout.mode === "single" ? "column" : "row"} flexGrow={1}>
         {/* Stories panel */}
-        <StoriesPanel
+        <MemoStoriesPanel
           stories={busState.stories}
+          postRunPhases={busState.postRunPhases}
           width={layout.mode === "single" ? layout.width : layout.storiesPanelWidth}
           compact={layout.mode === "single"}
           maxHeight={maxHeight}
         />
 
         {/* Live activity panel */}
-        <LiveActivityPanel
+        <MemoLiveActivityPanel
           focused={focus === PanelFocus.Agent}
           activeCalls={activeCalls}
+          storySteps={busState.storySteps}
           runSummary={busState.runSummary}
           runErrored={runErroredForPanel}
           escalationLog={busState.escalationLog}

--- a/src/tui/components/LiveActivityPanel.tsx
+++ b/src/tui/components/LiveActivityPanel.tsx
@@ -19,6 +19,8 @@ export interface LiveActivityPanelProps {
   focused?: boolean;
   /** Active agent call states from stream events */
   activeCalls?: Map<string, ActiveCallState>;
+  /** Current orchestrator step per storyId (e.g. "test-writer", "implementer") */
+  storySteps?: Record<string, string>;
   /** Run completion summary, set when run:completed fires */
   runSummary?: RunSummary;
   /** Error message string, set when the run errors */
@@ -41,6 +43,7 @@ const MAX_ESCALATION_DISPLAY = 5;
 export function LiveActivityPanel({
   focused = false,
   activeCalls,
+  storySteps,
   runSummary,
   runErrored,
   escalationLog = [],
@@ -80,7 +83,7 @@ export function LiveActivityPanel({
       {hasActiveCalls && (
         <Box flexDirection="column" paddingX={1} paddingY={1}>
           {activeCallList.map((call) => (
-            <ActiveCallRow key={call.callId} call={call} />
+            <ActiveCallRow key={call.callId} call={call} step={call.storyId ? storySteps?.[call.storyId] : undefined} />
           ))}
         </Box>
       )}
@@ -95,8 +98,20 @@ export function LiveActivityPanel({
         </Box>
       )}
 
+      {/* Step-only rows: story step is known but no active LLM call yet (deterministic gates) */}
+      {!hasActiveCalls && storySteps && Object.keys(storySteps).length > 0 && (
+        <Box flexDirection="column" paddingX={1} paddingY={1}>
+          {Object.entries(storySteps).map(([sid, step]) => (
+            <Box key={sid} flexDirection="row" gap={1}>
+              <Text>{sid}</Text>
+              <Text color="yellow">[{step}]</Text>
+            </Box>
+          ))}
+        </Box>
+      )}
+
       {/* Waiting state when nothing to show */}
-      {!hasActiveCalls && !hasSummary && !hasError && (
+      {!hasActiveCalls && !hasSummary && !hasError && (!storySteps || Object.keys(storySteps).length === 0) && (
         <Box paddingX={1} paddingY={1}>
           <Text dimColor>Waiting for agent...</Text>
         </Box>
@@ -105,13 +120,13 @@ export function LiveActivityPanel({
   );
 }
 
-function ActiveCallRow({ call }: { call: ActiveCallState }) {
+function ActiveCallRow({ call, step }: { call: ActiveCallState; step?: string }) {
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Box flexDirection="row" gap={1}>
         <Text color="cyan">{call.agentName}</Text>
         {call.storyId && <Text>{call.storyId}</Text>}
-        {call.stage && <Text dimColor>[{call.stage}]</Text>}
+        {step ? <Text color="yellow">[{step}]</Text> : call.stage ? <Text dimColor>[{call.stage}]</Text> : null}
       </Box>
       <Box flexDirection="row" gap={1}>
         {call.model && <Text dimColor>model:{call.model}</Text>}

--- a/src/tui/components/StoriesPanel.tsx
+++ b/src/tui/components/StoriesPanel.tsx
@@ -7,6 +7,7 @@
 import { Box, Text } from "ink";
 import { useEffect, useState } from "react";
 import { COMPACT_MAX_VISIBLE_STORIES, MAX_VISIBLE_STORIES } from "../hooks/useLayout";
+import type { PostRunPhaseState } from "../hooks/usePipelineBusEvents";
 import type { StoryDisplayState } from "../types";
 
 /**
@@ -15,6 +16,12 @@ import type { StoryDisplayState } from "../types";
 export interface StoriesPanelProps {
   /** Stories to display */
   stories: StoryDisplayState[];
+  /** Post-run phase statuses (acceptance, regression, review) */
+  postRunPhases?: {
+    acceptance?: PostRunPhaseState;
+    regression?: PostRunPhaseState;
+    review?: PostRunPhaseState;
+  };
   /** Panel width (columns) */
   width?: number;
   /** Compact mode (fewer details, for single-column layout) */
@@ -60,7 +67,7 @@ function getStatusIcon(status: StoryDisplayState["status"]): string {
  * />
  * ```
  */
-export function StoriesPanel({ stories, width, compact = false, maxHeight }: StoriesPanelProps) {
+export function StoriesPanel({ stories, postRunPhases, width, compact = false, maxHeight }: StoriesPanelProps) {
   // Determine max visible stories based on mode
   const maxVisible = compact ? COMPACT_MAX_VISIBLE_STORIES : MAX_VISIBLE_STORIES;
   const needsScrolling = stories.length > maxVisible;
@@ -147,6 +154,33 @@ export function StoriesPanel({ stories, width, compact = false, maxHeight }: Sto
           <Text dimColor>▼ {stories.length - scrollOffset - maxVisible} more below</Text>
         </Box>
       )}
+
+      {/* Post-run phases */}
+      {postRunPhases && (postRunPhases.acceptance || postRunPhases.regression || postRunPhases.review) && (
+        <Box flexDirection="column" paddingX={1} paddingTop={1}>
+          <Box borderStyle="single" borderTop borderColor="gray" />
+          <Text dimColor>Post-Run</Text>
+          {postRunPhases.acceptance && (
+            <PostRunPhaseRow label="acceptance" phase={postRunPhases.acceptance} compact={compact} />
+          )}
+          {postRunPhases.regression && (
+            <PostRunPhaseRow label="regression" phase={postRunPhases.regression} compact={compact} />
+          )}
+          {postRunPhases.review && <PostRunPhaseRow label="review" phase={postRunPhases.review} compact={compact} />}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+function PostRunPhaseRow({ label, phase, compact }: { label: string; phase: PostRunPhaseState; compact: boolean }) {
+  const icon = phase.status === "running" ? ">" : phase.status === "passed" ? "[OK]" : "[X]";
+  const color = phase.status === "running" ? "cyan" : phase.status === "passed" ? "green" : "red";
+  return (
+    <Box>
+      <Text color={color}>
+        {icon} {compact ? label.slice(0, 3) : label}
+      </Text>
     </Box>
   );
 }

--- a/src/tui/hooks/useAgentStreamEvents.ts
+++ b/src/tui/hooks/useAgentStreamEvents.ts
@@ -1,5 +1,5 @@
 import type { AgentStreamEvent, IAgentStreamEventBus } from "@/runtime";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 export interface ActiveCallState {
   callId: string;
@@ -21,8 +21,15 @@ export interface ActiveCallState {
 
 export function useAgentStreamEvents(bus?: IAgentStreamEventBus | null): {
   activeCalls: Map<string, ActiveCallState>;
+  inputTokens: number;
+  outputTokens: number;
 } {
   const [activeCalls, setActiveCalls] = useState<Map<string, ActiveCallState>>(new Map());
+  const [inputTokens, setInputTokens] = useState(0);
+  const [outputTokens, setOutputTokens] = useState(0);
+  // Track the last cumulative token counts per callId so we add only the delta.
+  // ACP emits usage_update with cumulative totals, not incremental deltas.
+  const lastTokensRef = useRef<Map<string, { input: number; output: number }>>(new Map());
 
   useEffect(() => {
     if (!bus) return;
@@ -81,6 +88,17 @@ export function useAgentStreamEvents(bus?: IAgentStreamEventBus | null): {
                 lastActivityAt: event.timestamp,
               });
             }
+            // Add only the delta: ACP usage_update carries cumulative totals per call.
+            {
+              const last = lastTokensRef.current.get(event.callId) ?? { input: 0, output: 0 };
+              const newInput = event.inputTokens ?? last.input;
+              const newOutput = event.outputTokens ?? last.output;
+              const deltaIn = newInput - last.input;
+              const deltaOut = newOutput - last.output;
+              lastTokensRef.current.set(event.callId, { input: newInput, output: newOutput });
+              if (deltaIn > 0) setInputTokens((prev) => prev + deltaIn);
+              if (deltaOut > 0) setOutputTokens((prev) => prev + deltaOut);
+            }
             break;
           }
           case "agent.tool_call_update": {
@@ -102,6 +120,8 @@ export function useAgentStreamEvents(bus?: IAgentStreamEventBus | null): {
               // Remove ended calls to keep the map clean
               next.delete(event.callId);
             }
+            // Release the per-call token baseline to prevent unbounded map growth
+            lastTokensRef.current.delete(event.callId);
             break;
           }
           default:
@@ -115,5 +135,5 @@ export function useAgentStreamEvents(bus?: IAgentStreamEventBus | null): {
     return unsubscribe;
   }, [bus]);
 
-  return { activeCalls };
+  return { activeCalls, inputTokens, outputTokens };
 }

--- a/src/tui/hooks/usePipelineBusEvents.ts
+++ b/src/tui/hooks/usePipelineBusEvents.ts
@@ -2,17 +2,17 @@
  * usePipelineBusEvents hook — subscribe to the pipeline event bus and update TUI state.
  *
  * Listens to typed PipelineEventBus events (story:started, story:completed,
- * story:failed, story:skipped, story:escalated, run:completed) and updates
- * story display states, cost accumulator, elapsed time, escalation log, and
- * run summary.
+ * story:failed, story:skipped, story:escalated, run:completed, postrun:phase:*)
+ * and updates story display states, cost accumulator, post-run phase states,
+ * escalation log, and run summary.
  *
- * Uses setInterval (not Bun.sleep) because this is UI code that needs a
- * cancellable timer handle via clearInterval.
+ * Elapsed time is intentionally NOT tracked here — it lives in App.tsx as a
+ * separate useState so the 1s timer doesn't cause story/activity panels to re-render.
  */
 
 import { pipelineEventBus } from "@/pipeline";
 import type { RunCompletedEvent } from "@/pipeline";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { StoryDisplayState } from "../types";
 
 /** Entry in the escalation log. */
@@ -34,6 +34,11 @@ export interface RunSummary {
   totalCost?: number;
 }
 
+/** Status of a single post-run phase (acceptance, regression, or deferred review). */
+export interface PostRunPhaseState {
+  status: "running" | "passed" | "failed";
+}
+
 /**
  * State managed by the usePipelineBusEvents hook.
  */
@@ -42,8 +47,6 @@ export interface PipelineBusState {
   stories: StoryDisplayState[];
   /** Total cost accumulated across all stories */
   totalCost: number;
-  /** Elapsed time in milliseconds since hook mount */
-  elapsedMs: number;
   /** Whether the run is paused */
   runPaused: boolean;
   /** Run completion summary (set when run:completed fires) */
@@ -52,6 +55,14 @@ export interface PipelineBusState {
   runErrored: boolean;
   /** Log of escalation events (story:escalated) */
   escalationLog: EscalationEntry[];
+  /** Current orchestrator step per story (e.g. "test-writer", "implementer", "verifier") */
+  storySteps: Record<string, string>;
+  /** Post-run phase statuses (acceptance, regression, review) */
+  postRunPhases: {
+    acceptance?: PostRunPhaseState;
+    regression?: PostRunPhaseState;
+    review?: PostRunPhaseState;
+  };
 }
 
 /**
@@ -64,25 +75,14 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
   const [state, setState] = useState<PipelineBusState>(() => ({
     stories: initialStories,
     totalCost: 0,
-    elapsedMs: 0,
     runPaused: false,
     runErrored: false,
     escalationLog: [],
+    storySteps: {},
+    postRunPhases: {},
   }));
 
-  const startTimeRef = useRef(Date.now());
-
   useEffect(() => {
-    const startTime = startTimeRef.current;
-
-    // Elapsed timer — runs continuously while the hook is mounted
-    const timer = setInterval(() => {
-      setState((prev) => ({
-        ...prev,
-        elapsedMs: Date.now() - startTime,
-      }));
-    }, 1000);
-
     // story:started — mark story running, capture modelTier and iteration
     const unsubStarted = pipelineEventBus.on("story:started", (event) => {
       setState((prev) => ({
@@ -100,8 +100,7 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
       }));
     });
 
-    // story:completed — mark story passed/failed, set cost (replace, not accumulate,
-    // to avoid double-counting when a story is retried across tiers)
+    // story:completed — mark story passed/failed, set cost, clear step
     const unsubCompleted = pipelineEventBus.on("story:completed", (event) => {
       setState((prev) => {
         const newStories = prev.stories.map((s) => {
@@ -114,25 +113,24 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
         });
 
         const totalCost = newStories.reduce((sum, s) => sum + (s.cost ?? 0), 0);
+        const { [event.storyId]: _removed, ...remainingSteps } = prev.storySteps;
 
-        return { ...prev, stories: newStories, totalCost };
+        return { ...prev, stories: newStories, totalCost, storySteps: remainingSteps };
       });
     });
 
-    // story:failed — mark story failed, capture failure reason
+    // story:failed — mark story failed, capture failure reason, clear step
     const unsubFailed = pipelineEventBus.on("story:failed", (event) => {
-      setState((prev) => ({
-        ...prev,
-        stories: prev.stories.map((s) =>
-          s.story.id === event.storyId
-            ? {
-                ...s,
-                status: "failed" as const,
-                failureReason: event.reason,
-              }
-            : s,
-        ),
-      }));
+      setState((prev) => {
+        const { [event.storyId]: _removed, ...remainingSteps } = prev.storySteps;
+        return {
+          ...prev,
+          stories: prev.stories.map((s) =>
+            s.story.id === event.storyId ? { ...s, status: "failed" as const, failureReason: event.reason } : s,
+          ),
+          storySteps: remainingSteps,
+        };
+      });
     });
 
     // story:skipped — mark story skipped
@@ -178,9 +176,8 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
       setState((prev) => ({ ...prev, runPaused: false }));
     });
 
-    // run:completed — freeze elapsed timer at durationMs, set run summary and final total cost
+    // run:completed — set run summary and final total cost
     const unsubCompleted2 = pipelineEventBus.on("run:completed", (event: RunCompletedEvent) => {
-      clearInterval(timer);
       const summary: RunSummary = {
         totalStories: event.totalStories,
         passedStories: event.passedStories,
@@ -192,7 +189,6 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
       };
       setState((prev) => ({
         ...prev,
-        elapsedMs: event.durationMs,
         runSummary: summary,
         totalCost: event.totalCost ?? prev.totalCost,
       }));
@@ -203,8 +199,34 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
       setState((prev) => ({ ...prev, runErrored: true }));
     });
 
+    // story:step — update current orchestrator step for a story
+    const unsubStep = pipelineEventBus.on("story:step", (event) => {
+      setState((prev) => ({
+        ...prev,
+        storySteps: { ...prev.storySteps, [event.storyId]: event.step },
+      }));
+    });
+
+    // postrun:phase:started — mark phase as running
+    const unsubPostRunStarted = pipelineEventBus.on("postrun:phase:started", (event) => {
+      setState((prev) => ({
+        ...prev,
+        postRunPhases: { ...prev.postRunPhases, [event.phase]: { status: "running" } },
+      }));
+    });
+
+    // postrun:phase:completed — mark phase as passed/failed
+    const unsubPostRunCompleted = pipelineEventBus.on("postrun:phase:completed", (event) => {
+      setState((prev) => ({
+        ...prev,
+        postRunPhases: {
+          ...prev.postRunPhases,
+          [event.phase]: { status: event.passed ? "passed" : "failed" },
+        },
+      }));
+    });
+
     return () => {
-      clearInterval(timer);
       unsubStarted();
       unsubCompleted();
       unsubFailed();
@@ -215,6 +237,9 @@ export function usePipelineBusEvents(initialStories: StoryDisplayState[]): Pipel
       unsubResumed();
       unsubCompleted2();
       unsubErrored();
+      unsubStep();
+      unsubPostRunStarted();
+      unsubPostRunCompleted();
     };
   }, []);
 

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -64,6 +64,8 @@ export interface PtySpawnOptions {
 export interface TuiProps {
   /** Feature name */
   feature: string;
+  /** nax version string (e.g. "0.68.7"), shown in the header */
+  version?: string;
   /** All stories to display (initial state; updates come from pipeline bus) */
   stories: StoryDisplayState[];
   /** Pipeline event emitter for stage tracking (stage:enter/stage:exit) */


### PR DESCRIPTION
## Summary

- **Blinking fix**: `elapsedMs` moved to an isolated `useState` in `App.tsx` so the 1s timer only re-renders the header. `StoriesPanel` and `LiveActivityPanel` wrapped in `React.memo` — stories panel no longer re-renders every second.
- **Version in header**: header now shows `nax run — feature v0.68.7 (abc1234)` using `NAX_BUILD_INFO` (version + commit hash).
- **Token usage in header**: accumulates `inputTokens`/`outputTokens` from `agent.usage_update` events using per-call delta to avoid double-counting ACP's cumulative totals. Displays as `Xk in / Yk out`.
- **Live orchestrator step**: new `story:step` pipeline event emitted from `runPhase` in `story-orchestrator.ts` before each op. Tracked per-story in `usePipelineBusEvents`; shown as yellow `[test-writer]` / `[implementer]` / `[verifier]` / `[semantic-review]` etc. label in `LiveActivityPanel`. Deterministic gates show a step row even with no active LLM call. Step clears on story complete/failed.
- **Post-run phases**: new `postrun:phase:started` / `postrun:phase:completed` events on the pipeline bus. Emitted for acceptance (runner-completion), regression (run-completion), and deferred review (unified-executor + run-completion). `StoriesPanel` shows a "Post-Run" section with `>` (running), `[OK]`, `[X]` indicators.
- **Review phase ordering fix**: `postrun:phase:started` for review now emitted in `unified-executor.ts` *before* `runDeferredReview` runs, so the TUI can render the "running" state.

## Test plan

- [ ] `bun run lint` — green (5 files auto-fixed by `lint:fix`)
- [ ] `bun run typecheck` — clean
- [ ] `bun run test` — all phases pass (406 tests across unit + integration)
- [ ] Manual: run `nax run` and confirm header shows version + commit, token counts update live, step label in Live Activity changes per orchestrator phase, Post-Run section appears after stories complete