### PR TITLE
fix(context): separate created files from read references in the PRD pipeline

### DIFF
--- a/src/context/builder.ts
+++ b/src/context/builder.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { getLogger } from "../logger";
 import { estimateTokens } from "../optimizer/types";
 import type { UserStory } from "../prd";
-import { countStories, getContextFiles } from "../prd";
+import { countStories, getContextFiles, getExpectedFiles } from "../prd";
 import { resolveTestFilePatterns } from "../test-runners/resolver";
 import { errorMessage } from "../utils/errors";
 import { autoDetectContextFiles } from "./auto-detect";
@@ -29,6 +29,21 @@ import type { BuiltContext, ContextBudget, ContextElement, StoryContext } from "
 export const _contextBuilderDeps = {
   autoDetectContextFiles,
 };
+
+/** Max number of explicit context/expected files surfaced into the prompt. */
+const FILE_INJECTION_MAX_FILES = 5;
+/** Base priority for file-path context elements (decremented per file). */
+const FILE_CONTEXT_PRIORITY_BASE = 60;
+
+/** Path-only "read this" hint for an existing reference file. */
+function readContextMessage(relativeFilePath: string): string {
+  return `_Path: \`${relativeFilePath}\` — read this file before implementing._`;
+}
+
+/** Path-only "you will create this" hint for a declared-but-absent output file. */
+function createIntentMessage(relativeFilePath: string): string {
+  return `_Path: \`${relativeFilePath}\` — this file does not exist yet; you will CREATE it as part of this story._`;
+}
 
 // Re-export for backward compatibility
 export {
@@ -207,7 +222,6 @@ async function addFileElements(
   storyContext: StoryContext,
   story: UserStory,
 ): Promise<void> {
-  const MAX_FILES = 5;
   const fileInjection = storyContext.config?.context?.fileInjection;
 
   // Explicit contextFiles from the PRD are always honored regardless of fileInjection setting.
@@ -257,30 +271,76 @@ async function addFileElements(
     }
   }
 
-  if (contextFiles.length === 0) return;
-  const filesToLoad = contextFiles.slice(0, MAX_FILES);
+  const expectedFiles = getExpectedFiles(story);
+  if (contextFiles.length === 0 && expectedFiles.length === 0) return;
   const { workdir } = storyContext;
   if (!workdir) {
     getLogger().warn("context", "workdir not set — cannot load context files", { storyId: story.id });
     return;
   }
 
+  const expectedSet = new Set(expectedFiles);
+  // Tracks paths already surfaced (read or create-intent) so the expectedFiles
+  // recovery pass below does not emit a duplicate element for the same path.
+  const surfaced = new Set<string>();
+  const filesToLoad = contextFiles.slice(0, FILE_INJECTION_MAX_FILES);
+
   for (let i = 0; i < filesToLoad.length; i++) {
     const relativeFilePath = filesToLoad[i];
+    surfaced.add(relativeFilePath);
     const absolutePath = path.resolve(workdir, relativeFilePath);
-    const file = Bun.file(absolutePath);
-    if (!(await file.exists())) {
-      getLogger().warn("context", "Relevant file not found", { filePath: relativeFilePath, storyId: story.id });
-      continue;
-    }
     // Always emit path-only — agent reads when needed; avoids token bloat from inlining.
     // Use decreasing priority per index so insertion order is preserved after sort.
+    if (await Bun.file(absolutePath).exists()) {
+      elements.push(
+        createFileContext(relativeFilePath, readContextMessage(relativeFilePath), FILE_CONTEXT_PRIORITY_BASE - i),
+      );
+      continue;
+    }
+    // Missing on disk. A file the story CREATES (declared in expectedFiles) is not
+    // a hallucinated reference — surface it as create-intent so the path hint is
+    // not lost. Genuinely-absent references (not expected) still warn.
+    if (expectedSet.has(relativeFilePath)) {
+      elements.push(
+        createFileContext(relativeFilePath, createIntentMessage(relativeFilePath), FILE_CONTEXT_PRIORITY_BASE - i),
+      );
+      getLogger().debug("context", "Context file does not exist yet — treated as to-be-created", {
+        storyId: story.id,
+        filePath: relativeFilePath,
+      });
+    } else {
+      getLogger().warn("context", "Relevant file not found", { filePath: relativeFilePath, storyId: story.id });
+    }
+  }
+
+  await addCreateIntentElements(elements, workdir, expectedFiles, surfaced);
+}
+
+/**
+ * Surface declared-but-absent `expectedFiles` as create-intent context so the
+ * agent still receives the path hint even when an output file was never listed
+ * in (or was mislisted into) `contextFiles`. Files already on disk or already
+ * surfaced by the contextFiles pass are skipped.
+ */
+async function addCreateIntentElements(
+  elements: ContextElement[],
+  workdir: string,
+  expectedFiles: string[],
+  surfaced: Set<string>,
+): Promise<void> {
+  let idx = 0;
+  for (const relativeFilePath of expectedFiles.slice(0, FILE_INJECTION_MAX_FILES)) {
+    if (surfaced.has(relativeFilePath)) continue;
+    const absolutePath = path.resolve(workdir, relativeFilePath);
+    if (await Bun.file(absolutePath).exists()) continue;
     elements.push(
       createFileContext(
         relativeFilePath,
-        `_Path: \`${relativeFilePath}\` — read this file before implementing._`,
-        60 - i,
+        createIntentMessage(relativeFilePath),
+        FILE_CONTEXT_PRIORITY_BASE - FILE_INJECTION_MAX_FILES - idx,
       ),
     );
+    surfaced.add(relativeFilePath);
+    idx++;
   }
 }

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,7 +1,7 @@
 export { callOp, newCorrelationId, _callOpDeps, _runPostParseForTest } from "./call";
 export { planInteractiveOp } from "./plan";
 export type { PlanInteractiveInput } from "./plan";
-export { planRefineOp, _planRefineDeps } from "./plan-refine";
+export { planRefineOp, _planRefineDeps, auditContextFileExistence } from "./plan-refine";
 export type { PlanRefineInput } from "./plan-refine";
 export { warnOnDroppedVerbatimAcs } from "./verbatim-warn";
 export { decomposeOp } from "./decompose";

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,7 +1,7 @@
 export { callOp, newCorrelationId, _callOpDeps, _runPostParseForTest } from "./call";
 export { planInteractiveOp } from "./plan";
 export type { PlanInteractiveInput } from "./plan";
-export { planRefineOp, _planRefineDeps, auditContextFileExistence } from "./plan-refine";
+export { planRefineOp, _planRefineDeps, normalizeCreatedContextFiles } from "./plan-refine";
 export type { PlanRefineInput } from "./plan-refine";
 export { warnOnDroppedVerbatimAcs } from "./verbatim-warn";
 export { decomposeOp } from "./decompose";

--- a/src/operations/plan-refine.ts
+++ b/src/operations/plan-refine.ts
@@ -8,7 +8,7 @@ import { getSafeLogger } from "../logger";
 import { findMissingVerbatimAcs, findSpecDriftViolations, getExpectedFiles } from "../prd";
 import { validatePlanOutput } from "../prd/schema";
 import type { SpecDriftViolation } from "../prd/spec-drift";
-import type { PRD } from "../prd/types";
+import type { ContextFileEntry, PRD } from "../prd/types";
 import type { UserStory } from "../prd/types";
 import { PlanPromptBuilder } from "../prompts";
 import type { PackageSummary } from "../prompts";
@@ -166,36 +166,80 @@ async function readSpecDriftViolations(input: PlanRefineInput): Promise<SpecDrif
   }
 }
 
+/** Result of normalizing one story's contextFiles against the filesystem. */
+interface StoryNormalization {
+  story: UserStory;
+  changed: boolean;
+}
+
 /**
- * Non-fatal safety net: warn when a story's `contextFiles` entry is absent on
- * disk and is NOT already declared as an output in `expectedFiles`. Such an
- * entry is either a file the story creates (it belongs in `expectedFiles`, not
- * `contextFiles`) or a hallucinated reference. Either way it should not sit in
- * `contextFiles`, whose contract is "existing files to read before coding".
- *
- * Warns only — planning stays resilient; the convention fix lives in the spec
- * writer and plan mapping (layers 1–2). Skipped when `workdir` is unset.
+ * Normalize one story: an uncited `contextFiles` entry that is absent on disk is
+ * a file the story CREATES — move it to `expectedFiles`. A cited entry (factId)
+ * that is absent claims broken manifest grounding, so it is kept and warned
+ * (not silently moved). Existing files and already-declared outputs are left
+ * untouched. Returns a new story object when anything moved (immutable update).
  */
-export async function auditContextFileExistence(
+async function normalizeStoryFiles(
+  story: UserStory,
+  workdir: string,
+  fileExists: (path: string) => Promise<boolean>,
+): Promise<StoryNormalization> {
+  const contextFiles = story.contextFiles ?? [];
+  if (contextFiles.length === 0) return { story, changed: false };
+
+  const logger = getSafeLogger();
+  const expected = new Set(getExpectedFiles(story));
+  const kept: Array<string | ContextFileEntry> = [];
+  const moved: string[] = [];
+
+  for (const entry of contextFiles) {
+    const filePath = typeof entry === "string" ? entry : entry.path;
+    const factId = typeof entry === "string" ? undefined : entry.factId;
+    if (expected.has(filePath) || (await fileExists(join(workdir, filePath)))) {
+      kept.push(entry); // already an output, or a legitimate existing read
+      continue;
+    }
+    if (factId) {
+      logger?.warn("plan", "Context file cites a manifest fact but is absent on disk", {
+        storyId: story.id,
+        filePath,
+        factId,
+      });
+      kept.push(entry); // broken grounding — keep so the citation check still flags it
+      continue;
+    }
+    moved.push(filePath); // uncited + absent → the story creates it
+  }
+
+  if (moved.length === 0) return { story, changed: false };
+
+  const newExpected = [...getExpectedFiles(story)];
+  for (const filePath of moved) {
+    if (!newExpected.includes(filePath)) newExpected.push(filePath);
+  }
+  logger?.info("plan", "Moved absent contextFiles entries to expectedFiles (story creates them)", {
+    storyId: story.id,
+    moved,
+  });
+  return { story: { ...story, contextFiles: kept, expectedFiles: newExpected }, changed: true };
+}
+
+/**
+ * Deterministic safety net that closes the read/create gap left when a spec or
+ * plan routes a created file into `contextFiles`. For every story, an uncited
+ * `contextFiles` entry absent on disk is moved to `expectedFiles` (its correct
+ * home — a post-run asset gate, not a read list). Returns a new PRD when any
+ * entry moved; otherwise the input PRD unchanged. Skipped when `workdir` is unset.
+ */
+export async function normalizeCreatedContextFiles(
   prd: PRD,
   workdir: string | undefined,
   fileExists: (path: string) => Promise<boolean>,
-): Promise<void> {
-  if (!workdir) return;
-  const logger = getSafeLogger();
-  if (!logger) return;
-  for (const story of prd.userStories) {
-    const expected = new Set(getExpectedFiles(story));
-    for (const entry of story.contextFiles ?? []) {
-      const filePath = typeof entry === "string" ? entry : entry.path;
-      if (expected.has(filePath)) continue; // already declared as a created file — absence is expected
-      if (await fileExists(join(workdir, filePath))) continue;
-      logger.warn("plan", "Context file not on disk — if the story creates it, move it to expectedFiles", {
-        storyId: story.id,
-        filePath,
-      });
-    }
-  }
+): Promise<PRD> {
+  if (!workdir) return prd;
+  const results = await Promise.all(prd.userStories.map((story) => normalizeStoryFiles(story, workdir, fileExists)));
+  if (!results.some((r) => r.changed)) return prd;
+  return { ...prd, userStories: results.map((r) => r.story) };
 }
 
 export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
@@ -294,8 +338,7 @@ export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
     if (ctx.config.plan.specGuard) {
       warnOnSpecDrift(validated, input.featureName);
     }
-    await auditContextFileExistence(validated, input.workdir, ctx.fileExists);
-    return validated;
+    return await normalizeCreatedContextFiles(validated, input.workdir, ctx.fileExists);
   },
   recover: async (input, ctx) => {
     const content = await ctx.readFile(input.outputPath);

--- a/src/operations/plan-refine.ts
+++ b/src/operations/plan-refine.ts
@@ -213,6 +213,12 @@ async function normalizeStoryFiles(
 
   if (moved.length === 0) return { story, changed: false };
 
+  // NOTE: `expectedFiles` currently only drives context create-intent hints
+  // (src/context/builder.ts). It is NOT yet wired into the post-run asset gate
+  // (verifyAssets in src/verification/runners.ts). This move is a best-effort
+  // heuristic — an LLM typo or incidental path could land here. If expectedFiles
+  // is ever promoted to a hard gate, promotion must stay opt-in (or this move
+  // must require explicit create-intent), so a misclassified path cannot fail a run.
   const newExpected = [...getExpectedFiles(story)];
   for (const filePath of moved) {
     if (!newExpected.includes(filePath)) newExpected.push(filePath);

--- a/src/operations/plan-refine.ts
+++ b/src/operations/plan-refine.ts
@@ -1,10 +1,11 @@
+import { join } from "node:path";
 import { makeParseRetryStrategy } from "../agents/retry";
 import { planConfigSelector } from "../config";
 import type { ProjectProfile } from "../config/runtime-types";
 import type { PlanConfig } from "../config/selectors";
 import { NaxError } from "../errors";
 import { getSafeLogger } from "../logger";
-import { findMissingVerbatimAcs, findSpecDriftViolations } from "../prd";
+import { findMissingVerbatimAcs, findSpecDriftViolations, getExpectedFiles } from "../prd";
 import { validatePlanOutput } from "../prd/schema";
 import type { SpecDriftViolation } from "../prd/spec-drift";
 import type { PRD } from "../prd/types";
@@ -37,6 +38,11 @@ export interface PlanRefineInput {
   projectProfile?: ProjectProfile;
   /** When true, enables the deterministic spec-drift repair turn (Turn 4). */
   specGuard?: boolean;
+  /**
+   * Absolute repo/package root used by `verify` to audit `contextFiles`
+   * existence on disk. When omitted, the existence audit is skipped.
+   */
+  workdir?: string;
 }
 
 const NEGATIVE_PATH_TOKENS = [
@@ -160,6 +166,38 @@ async function readSpecDriftViolations(input: PlanRefineInput): Promise<SpecDrif
   }
 }
 
+/**
+ * Non-fatal safety net: warn when a story's `contextFiles` entry is absent on
+ * disk and is NOT already declared as an output in `expectedFiles`. Such an
+ * entry is either a file the story creates (it belongs in `expectedFiles`, not
+ * `contextFiles`) or a hallucinated reference. Either way it should not sit in
+ * `contextFiles`, whose contract is "existing files to read before coding".
+ *
+ * Warns only — planning stays resilient; the convention fix lives in the spec
+ * writer and plan mapping (layers 1–2). Skipped when `workdir` is unset.
+ */
+export async function auditContextFileExistence(
+  prd: PRD,
+  workdir: string | undefined,
+  fileExists: (path: string) => Promise<boolean>,
+): Promise<void> {
+  if (!workdir) return;
+  const logger = getSafeLogger();
+  if (!logger) return;
+  for (const story of prd.userStories) {
+    const expected = new Set(getExpectedFiles(story));
+    for (const entry of story.contextFiles ?? []) {
+      const filePath = typeof entry === "string" ? entry : entry.path;
+      if (expected.has(filePath)) continue; // already declared as a created file — absence is expected
+      if (await fileExists(join(workdir, filePath))) continue;
+      logger.warn("plan", "Context file not on disk — if the story creates it, move it to expectedFiles", {
+        storyId: story.id,
+        filePath,
+      });
+    }
+  }
+}
+
 export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
   kind: "run",
   name: "plan-refine",
@@ -256,6 +294,7 @@ export const planRefineOp: RunOperation<PlanRefineInput, PRD, PlanConfig> = {
     if (ctx.config.plan.specGuard) {
       warnOnSpecDrift(validated, input.featureName);
     }
+    await auditContextFileExistence(validated, input.workdir, ctx.fileExists);
     return validated;
   },
   recover: async (input, ctx) => {

--- a/src/plan/strategies/refine.ts
+++ b/src/plan/strategies/refine.ts
@@ -35,6 +35,7 @@ export class RefinePlanStrategy implements IPlanStrategy {
           packageDetails: ctx.packageDetails,
           projectProfile: ctx.config.project,
           specGuard: ctx.config.plan.specGuard ?? false,
+          workdir: ctx.workdir,
         } satisfies PlanRefineInput,
       );
       return writeOrRecoverPrd(ctx, prd);

--- a/src/prd/schema.ts
+++ b/src/prd/schema.ts
@@ -233,6 +233,28 @@ function validateStory(raw: unknown, index: number, allIds: Set<string>): UserSt
     }
   }
 
+  // expectedFiles — optional array of relative paths the story CREATES. Same
+  // path rules as contextFiles, but plain strings only (no factId citations —
+  // a file that does not exist yet cannot be grounded in the facts manifest).
+  const rawExpectedFiles = s.expectedFiles;
+  const expectedFiles: string[] = [];
+  if (Array.isArray(rawExpectedFiles)) {
+    for (const f of rawExpectedFiles as unknown[]) {
+      if (typeof f !== "string") continue; // non-string entries silently filtered
+      const trimmed = f.trim();
+      if (trimmed === "") continue;
+      if (trimmed.startsWith("/")) {
+        throw new Error(
+          `[schema] story[${index}].expectedFiles entry must be relative (no absolute paths): "${trimmed}"`,
+        );
+      }
+      if (trimmed.includes("..")) {
+        throw new Error(`[schema] story[${index}].expectedFiles entry must not contain '..': "${trimmed}"`);
+      }
+      expectedFiles.push(trimmed);
+    }
+  }
+
   // verifiedBy — optional citation anchor (Phase 2)
   const VALID_VERIFIED_BY_KINDS = ["test", "symbol", "file"] as const;
   type VerifiedByKind = (typeof VALID_VERIFIED_BY_KINDS)[number];
@@ -274,6 +296,7 @@ function validateStory(raw: unknown, index: number, allIds: Set<string>): UserSt
     },
     ...(workdir !== undefined ? { workdir } : {}),
     ...(contextFiles.length > 0 ? { contextFiles } : {}),
+    ...(expectedFiles.length > 0 ? { expectedFiles } : {}),
     ...(suggestedCriteria !== undefined ? { suggestedCriteria } : {}),
     ...(verifiedBy !== undefined ? { verifiedBy } : {}),
     ...(intent !== undefined ? { intent } : {}),

--- a/src/prompts/builders/plan-builder.ts
+++ b/src/prompts/builders/plan-builder.ts
@@ -46,6 +46,19 @@ ${COMPLEXITY_GUIDE}
 ${TEST_STRATEGY_GUIDE}`;
 }
 
+/**
+ * Shared `contextFiles` (read) vs `expectedFiles` (create) rule. Both the main
+ * `build()` and the cited `buildDraft()` prompts emit this so the read/create
+ * split stays identical across plan modes. Created files route to
+ * `expectedFiles` (a post-run asset gate), never to `contextFiles`.
+ */
+const CONTEXT_VS_EXPECTED_FILES_RULE = `**\`contextFiles\` rule — existing files only.** Only list paths that already exist in the repo today. The pipeline verifies every \`contextFiles\` entry against the filesystem; a path that does not exist is treated as a missing-context warning.
+
+**\`expectedFiles\` rule — files this story CREATES.** List every NEW file the story authors (relative paths). A file the story will create belongs here, NEVER in \`contextFiles\` — these are the story's outputs, not files to read first. A single path may appear in \`contextFiles\` (an existing sibling to mirror) AND \`expectedFiles\` (the new file itself), but the same path must never be in both.`;
+
+/** Output-schema line for the `expectedFiles` field, shared by both prompts. */
+const EXPECTED_FILES_SCHEMA_FIELD = `"expectedFiles": ["string — NEW files this story creates (relative paths, omit if none)"],`;
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 /** Revision finding from a verifier — passed to buildDraft when revising a rejected draft. */
@@ -324,9 +337,9 @@ Based on your Step 2 analysis, create stories that produce CODE CHANGES.
 
 ${buildSharedQualityRules(specContent, projectProfile)}
 
-For each story, set "contextFiles" to the key source files the agent should read before implementing (max 5 per story). Use your Step 2 analysis to identify the most relevant files. Leave empty for greenfield stories with no existing files to reference.
+For each story, set "contextFiles" to the key source files the agent should read before implementing (max 5 per story). Use your Step 2 analysis to identify the most relevant files. Leave empty for greenfield stories with no existing files to reference. Set "expectedFiles" to the NEW files the story creates.
 
-**\`contextFiles\` rule — existing files only.** Only list paths that already exist in the repo today. Files the story will CREATE belong in the description (under "Files touched" or "Approach"), never in contextFiles. The pipeline verifies every contextFiles entry against the filesystem; new-file paths placed here are treated as missing-context warnings and may block the plan.`;
+${CONTEXT_VS_EXPECTED_FILES_RULE}`;
 
     const suggestedCriteriaField = specContent.trim()
       ? `\n      "suggestedCriteria": ["string — optional. Behavioral edge cases or negative paths you identified that are NOT in the spec. Plain assertions only — observable outputs, return values, state changes, or error conditions. No implementation details or vague descriptions. Omit this field if empty."],`
@@ -353,7 +366,8 @@ Generate a JSON object with this exact structure (no markdown, no explanation �
       "title": "string — concise story title",
       "description": "string — detailed description of the story",
       "acceptanceCriteria": ["string — behavioral, testable criteria. Format: 'When [X], then [Y]'. One assertion per AC. Never include quality gates."],${suggestedCriteriaField}
-      "contextFiles": ["string — key source files the agent should read (max 5, relative paths)"],
+      "contextFiles": ["string — EXISTING source files the agent should read (max 5, relative paths)"],
+      ${EXPECTED_FILES_SCHEMA_FIELD}
       "tags": ["string — routing tags, e.g. feature, security, api"],
       "dependencies": ["string — story IDs this story depends on"],${workdirField}
       "status": "pending",
@@ -440,9 +454,9 @@ Every concrete claim referencing existing code must cite [F-NNN] or [S-NNN] from
 
 ${buildSharedQualityRules(input.specContent, input.projectProfile)}
 
-For each story, set "contextFiles" to the key source files the implementer should read before starting (max 5 per story). Cite manifest factIds where relevant.
+For each story, set "contextFiles" to the key source files the implementer should read before starting (max 5 per story). Cite manifest factIds where relevant. Set "expectedFiles" to the NEW files the story creates.
 
-**\`contextFiles\` rule — existing files only.** Only list paths that already exist in the repo today (cited via manifest factIds where possible). Files the story will CREATE belong in the description (under "Files touched" or "Approach"), never in contextFiles. Uncited paths that do not exist on disk are flagged by the pipeline.
+${CONTEXT_VS_EXPECTED_FILES_RULE}
 
 ## Output Schema
 
@@ -458,7 +472,8 @@ Produce a JSON object with this exact structure. Field names are mandatory — d
       "title": "string — concise story title",
       "description": "string — detailed description of what to implement",
       "acceptanceCriteria": ["string — behavioral criterion, format: 'When [X], then [Y]'. One assertion per item."],${suggestedCriteriaField}
-      "contextFiles": ["string — relative paths the implementer should read (max 5)"],
+      "contextFiles": ["string — EXISTING relative paths the implementer should read (max 5)"],
+      ${EXPECTED_FILES_SCHEMA_FIELD}
       "tags": ["string"],
       "dependencies": ["string — story IDs this story depends on"],${workdirField}
       "routing": {

--- a/test/unit/context/file-injection.test.ts
+++ b/test/unit/context/file-injection.test.ts
@@ -555,3 +555,133 @@ describe("fileInjection modes — mock-based (CTX-003)", () => {
     expect(fileElements[0].filePath).toBe("explicit.ts");
   });
 });
+
+describe("contextFiles vs expectedFiles — created files (created-vs-read)", () => {
+  const CREATE_HINT = "you will CREATE it";
+  const READ_HINT = "read this file before implementing";
+
+  test("missing contextFile declared in expectedFiles is surfaced as create-intent, not dropped", async () => {
+    const tempDir = await setupGitRepo({ "src/existing.ts": "export const existing = true;" });
+    try {
+      const prd = createTestPRD([
+        {
+          id: "US-001",
+          title: "Create the chat store",
+          description: "Mirror _history.py",
+          acceptanceCriteria: ["Works"],
+          // _chat.py is a NEW file the story creates — mislisted into contextFiles
+          // by the spec writer but also (correctly) declared in expectedFiles.
+          contextFiles: ["src/existing.ts", "src/_chat.ts"],
+          expectedFiles: ["src/_chat.ts"],
+        },
+      ]);
+      const storyContext: StoryContext = {
+        prd,
+        currentStoryId: "US-001",
+        workdir: tempDir,
+        config: { context: { fileInjection: "disabled", testCoverage: { enabled: false } } } as any,
+      };
+
+      const built = await buildContext(storyContext, BUDGET);
+      const fileElements = built.elements.filter((e) => e.type === "file");
+      const byPath = Object.fromEntries(fileElements.map((e) => [e.filePath, e.content]));
+
+      // Existing file → read hint; absent-but-expected file → create-intent hint (not dropped).
+      expect(byPath["src/existing.ts"]).toContain(READ_HINT);
+      expect(byPath["src/_chat.ts"]).toContain(CREATE_HINT);
+      expect(byPath["src/_chat.ts"]).not.toContain(READ_HINT);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("missing contextFile NOT declared in expectedFiles is dropped (genuine missing reference)", async () => {
+    const tempDir = await setupGitRepo({ "src/existing.ts": "export const existing = true;" });
+    try {
+      const prd = createTestPRD([
+        {
+          id: "US-001",
+          title: "Hallucinated reference",
+          description: "References a file that does not exist and is not created",
+          acceptanceCriteria: ["Works"],
+          contextFiles: ["src/existing.ts", "src/ghost.ts"],
+          // no expectedFiles — src/ghost.ts is a genuine missing reference
+        },
+      ]);
+      const storyContext: StoryContext = {
+        prd,
+        currentStoryId: "US-001",
+        workdir: tempDir,
+        config: { context: { fileInjection: "disabled", testCoverage: { enabled: false } } } as any,
+      };
+
+      const built = await buildContext(storyContext, BUDGET);
+      const paths = built.elements.filter((e) => e.type === "file").map((e) => e.filePath);
+
+      expect(paths).toContain("src/existing.ts");
+      expect(paths).not.toContain("src/ghost.ts");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("expectedFiles absent on disk are surfaced as create-intent even with no contextFiles", async () => {
+    const tempDir = await setupGitRepo({ "src/existing.ts": "export const existing = true;" });
+    try {
+      const prd = createTestPRD([
+        {
+          id: "US-001",
+          title: "Pure create story",
+          description: "Creates a brand new module",
+          acceptanceCriteria: ["Works"],
+          // No contextFiles at all — only expectedFiles.
+          expectedFiles: ["src/brand_new.ts"],
+        },
+      ]);
+      const storyContext: StoryContext = {
+        prd,
+        currentStoryId: "US-001",
+        workdir: tempDir,
+        config: { context: { fileInjection: "disabled", testCoverage: { enabled: false } } } as any,
+      };
+
+      const built = await buildContext(storyContext, BUDGET);
+      const fileElements = built.elements.filter((e) => e.type === "file");
+
+      expect(fileElements.length).toBe(1);
+      expect(fileElements[0].filePath).toBe("src/brand_new.ts");
+      expect(fileElements[0].content).toContain(CREATE_HINT);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("expectedFiles already on disk get no create-intent element", async () => {
+    const tempDir = await setupGitRepo({ "src/already.ts": "export const already = true;" });
+    try {
+      const prd = createTestPRD([
+        {
+          id: "US-001",
+          title: "Expected file already produced by a prior story",
+          description: "Depends on earlier work",
+          acceptanceCriteria: ["Works"],
+          expectedFiles: ["src/already.ts"],
+        },
+      ]);
+      const storyContext: StoryContext = {
+        prd,
+        currentStoryId: "US-001",
+        workdir: tempDir,
+        config: { context: { fileInjection: "disabled", testCoverage: { enabled: false } } } as any,
+      };
+
+      const built = await buildContext(storyContext, BUDGET);
+      const fileElements = built.elements.filter((e) => e.type === "file");
+
+      // It exists on disk and was not in contextFiles → nothing to surface.
+      expect(fileElements.length).toBe(0);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/operations/plan-refine.test.ts
+++ b/test/unit/operations/plan-refine.test.ts
@@ -741,4 +741,29 @@ describe("normalizeCreatedContextFiles — move absent reads to expectedFiles", 
     expect(out).toBe(prd as never);
     expect(fileExists).not.toHaveBeenCalled();
   });
+
+  test("across multiple stories: moves in the changed story, preserves the unchanged story's reference", async () => {
+    await withWarnSpy(async () => {
+      const base = makeValidPrd("f", "feat/f");
+      const s0 = { ...base.userStories[0], id: "US-001", contextFiles: ["src/real.ts"] }; // exists → unchanged
+      const s1 = { ...base.userStories[0], id: "US-002", contextFiles: ["src/_new.ts"] }; // absent → moved
+      const prd = { ...base, userStories: [s0, s1] };
+      // Only src/real.ts exists on disk.
+      const fileExists = mock(async (p: string) => p.endsWith("src/real.ts"));
+
+      const out = (await normalizeCreatedContextFiles(prd as never, WORKDIR, fileExists)) as never as {
+        userStories: Array<{ id: string; contextFiles?: unknown[]; expectedFiles?: string[] }>;
+      };
+
+      expect(out).not.toBe(prd as never); // a story changed → new PRD object
+      const a = out.userStories.find((s) => s.id === "US-001")!;
+      const b = out.userStories.find((s) => s.id === "US-002")!;
+      // Unchanged story keeps its original object reference (no needless copy).
+      expect(a).toBe(s0 as never);
+      expect(a.contextFiles).toEqual(["src/real.ts"]);
+      // Changed story moved its absent read to expectedFiles.
+      expect(b.contextFiles ?? []).toEqual([]);
+      expect(b.expectedFiles).toEqual(["src/_new.ts"]);
+    });
+  });
 });

--- a/test/unit/operations/plan-refine.test.ts
+++ b/test/unit/operations/plan-refine.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { join } from "node:path";
-import { _planRefineDeps, auditContextFileExistence, callOp, planRefineOp } from "@/operations";
+import { _planRefineDeps, callOp, normalizeCreatedContextFiles, planRefineOp } from "@/operations";
 import type { AgentRunRequest } from "@/agents/manager-types";
 import { PlanPromptBuilder } from "@/prompts";
 import { planInteractiveOp } from "@/operations";
@@ -667,11 +667,10 @@ describe("planRefineOp.recover()", () => {
   });
 });
 
-describe("auditContextFileExistence — contextFiles existence safety net", () => {
+describe("normalizeCreatedContextFiles — move absent reads to expectedFiles", () => {
   const WORKDIR = "/repo";
-  const MSG = "Context file not on disk";
 
-  function prdWith(contextFiles: string[], expectedFiles?: string[]) {
+  function prdWith(contextFiles: Array<string | { path: string; factId?: string }>, expectedFiles?: string[]) {
     const base = makeValidPrd("f", "feat/f");
     return {
       ...base,
@@ -679,44 +678,67 @@ describe("auditContextFileExistence — contextFiles existence safety net", () =
     };
   }
 
-  function contextFileWarn(warnSpy: ReturnType<typeof spyOn>) {
-    return warnSpy.mock.calls.filter((c) => c[0] === "plan" && String(c[1]).includes(MSG));
+  function story0(prd: { userStories: Array<Record<string, unknown>> }) {
+    return prd.userStories[0] as { contextFiles?: unknown[]; expectedFiles?: string[] };
   }
 
-  test("warns for a contextFile absent on disk and not declared in expectedFiles", async () => {
-    await withWarnSpy(async (warnSpy) => {
+  test("moves an uncited contextFile absent on disk into expectedFiles", async () => {
+    await withWarnSpy(async () => {
       const fileExists = mock(async () => false);
-      await auditContextFileExistence(prdWith(["src/ghost.ts"]) as never, WORKDIR, fileExists);
-      const warns = contextFileWarn(warnSpy);
-      expect(warns.length).toBe(1);
-      expect((warns[0][2] as Record<string, unknown>).filePath).toBe("src/ghost.ts");
-      expect(fileExists).toHaveBeenCalledWith(join(WORKDIR, "src/ghost.ts"));
+      const out = await normalizeCreatedContextFiles(prdWith(["src/_chat.ts"]) as never, WORKDIR, fileExists);
+      const s = story0(out as never);
+      expect(s.expectedFiles).toEqual(["src/_chat.ts"]);
+      expect(s.contextFiles ?? []).toEqual([]); // removed from the read list
+      expect(fileExists).toHaveBeenCalledWith(join(WORKDIR, "src/_chat.ts"));
     });
   });
 
-  test("does not warn when the contextFile exists on disk", async () => {
-    await withWarnSpy(async (warnSpy) => {
+  test("keeps a contextFile that exists on disk as a read (no move)", async () => {
+    await withWarnSpy(async () => {
       const fileExists = mock(async () => true);
-      await auditContextFileExistence(prdWith(["src/real.ts"]) as never, WORKDIR, fileExists);
-      expect(contextFileWarn(warnSpy).length).toBe(0);
+      const prd = prdWith(["src/real.ts"]);
+      const out = await normalizeCreatedContextFiles(prd as never, WORKDIR, fileExists);
+      expect(out).toBe(prd as never); // unchanged → same reference
     });
   });
 
-  test("does not warn when an absent contextFile is declared in expectedFiles (a created file)", async () => {
-    await withWarnSpy(async (warnSpy) => {
+  test("does not duplicate a path already declared in expectedFiles", async () => {
+    await withWarnSpy(async () => {
       const fileExists = mock(async () => false);
-      await auditContextFileExistence(prdWith(["src/_chat.ts"], ["src/_chat.ts"]) as never, WORKDIR, fileExists);
-      // absence is expected for a file the story creates — no warn, no disk check needed
-      expect(contextFileWarn(warnSpy).length).toBe(0);
+      const out = await normalizeCreatedContextFiles(
+        prdWith(["src/_chat.ts"], ["src/_chat.ts"]) as never,
+        WORKDIR,
+        fileExists,
+      );
+      const s = story0(out as never);
+      // already an output — absence is expected, no move, no duplicate
+      expect(s.expectedFiles).toEqual(["src/_chat.ts"]);
     });
   });
 
-  test("is a no-op when workdir is undefined", async () => {
+  test("keeps and warns for a CITED contextFile absent on disk (broken grounding, not a create)", async () => {
     await withWarnSpy(async (warnSpy) => {
       const fileExists = mock(async () => false);
-      await auditContextFileExistence(prdWith(["src/ghost.ts"]) as never, undefined, fileExists);
-      expect(contextFileWarn(warnSpy).length).toBe(0);
-      expect(fileExists).not.toHaveBeenCalled();
+      const out = await normalizeCreatedContextFiles(
+        prdWith([{ path: "src/cited.ts", factId: "F-001" }]) as never,
+        WORKDIR,
+        fileExists,
+      );
+      const s = story0(out as never);
+      expect(s.contextFiles).toEqual([{ path: "src/cited.ts", factId: "F-001" }]); // kept
+      expect(s.expectedFiles ?? []).toEqual([]); // NOT moved
+      const warns = warnSpy.mock.calls.filter(
+        (c) => c[0] === "plan" && String(c[1]).includes("cites a manifest fact"),
+      );
+      expect(warns.length).toBe(1);
     });
+  });
+
+  test("is a no-op (returns input) when workdir is undefined", async () => {
+    const fileExists = mock(async () => false);
+    const prd = prdWith(["src/ghost.ts"]);
+    const out = await normalizeCreatedContextFiles(prd as never, undefined, fileExists);
+    expect(out).toBe(prd as never);
+    expect(fileExists).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/operations/plan-refine.test.ts
+++ b/test/unit/operations/plan-refine.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { join } from "node:path";
-import { _planRefineDeps, callOp, planRefineOp } from "@/operations";
+import { _planRefineDeps, auditContextFileExistence, callOp, planRefineOp } from "@/operations";
 import type { AgentRunRequest } from "@/agents/manager-types";
 import { PlanPromptBuilder } from "@/prompts";
 import { planInteractiveOp } from "@/operations";
@@ -664,5 +664,59 @@ describe("planRefineOp.recover()", () => {
     );
 
     expect(result).toBeNull();
+  });
+});
+
+describe("auditContextFileExistence — contextFiles existence safety net", () => {
+  const WORKDIR = "/repo";
+  const MSG = "Context file not on disk";
+
+  function prdWith(contextFiles: string[], expectedFiles?: string[]) {
+    const base = makeValidPrd("f", "feat/f");
+    return {
+      ...base,
+      userStories: [{ ...base.userStories[0], contextFiles, expectedFiles }],
+    };
+  }
+
+  function contextFileWarn(warnSpy: ReturnType<typeof spyOn>) {
+    return warnSpy.mock.calls.filter((c) => c[0] === "plan" && String(c[1]).includes(MSG));
+  }
+
+  test("warns for a contextFile absent on disk and not declared in expectedFiles", async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const fileExists = mock(async () => false);
+      await auditContextFileExistence(prdWith(["src/ghost.ts"]) as never, WORKDIR, fileExists);
+      const warns = contextFileWarn(warnSpy);
+      expect(warns.length).toBe(1);
+      expect((warns[0][2] as Record<string, unknown>).filePath).toBe("src/ghost.ts");
+      expect(fileExists).toHaveBeenCalledWith(join(WORKDIR, "src/ghost.ts"));
+    });
+  });
+
+  test("does not warn when the contextFile exists on disk", async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const fileExists = mock(async () => true);
+      await auditContextFileExistence(prdWith(["src/real.ts"]) as never, WORKDIR, fileExists);
+      expect(contextFileWarn(warnSpy).length).toBe(0);
+    });
+  });
+
+  test("does not warn when an absent contextFile is declared in expectedFiles (a created file)", async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const fileExists = mock(async () => false);
+      await auditContextFileExistence(prdWith(["src/_chat.ts"], ["src/_chat.ts"]) as never, WORKDIR, fileExists);
+      // absence is expected for a file the story creates — no warn, no disk check needed
+      expect(contextFileWarn(warnSpy).length).toBe(0);
+    });
+  });
+
+  test("is a no-op when workdir is undefined", async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const fileExists = mock(async () => false);
+      await auditContextFileExistence(prdWith(["src/ghost.ts"]) as never, undefined, fileExists);
+      expect(contextFileWarn(warnSpy).length).toBe(0);
+      expect(fileExists).not.toHaveBeenCalled();
+    });
   });
 });

--- a/test/unit/plan/refine-strategy.test.ts
+++ b/test/unit/plan/refine-strategy.test.ts
@@ -107,6 +107,7 @@ describe("RefinePlanStrategy", () => {
         packageDetails: ctx.packageDetails,
         projectProfile: ctx.config.project,
         specGuard: false,
+        workdir: ctx.workdir,
       });
       expect(closeSpy).toHaveBeenCalledTimes(1);
     } finally {

--- a/test/unit/prd/schema.test.ts
+++ b/test/unit/prd/schema.test.ts
@@ -349,6 +349,40 @@ describe("validatePlanOutput — SEC-503 contextFiles path security", () => {
 });
 
 // ---------------------------------------------------------------------------
+// expectedFiles (files the story creates) — Layer 2
+// ---------------------------------------------------------------------------
+
+describe("validatePlanOutput — expectedFiles parsing", () => {
+  test("preserves expectedFiles on story when present", () => {
+    const story = makeStory({ expectedFiles: ["src/_chat.ts", "src/_tools/web.ts"] });
+    const prd = validatePlanOutput(makeInput([story]), "feat", "feat/feat");
+    expect(prd.userStories[0].expectedFiles).toEqual(["src/_chat.ts", "src/_tools/web.ts"]);
+  });
+
+  test("filters non-string and empty entries from expectedFiles", () => {
+    const story = makeStory({ expectedFiles: ["src/new.ts", "", 42, null, "  src/two.ts  "] });
+    const prd = validatePlanOutput(makeInput([story]), "feat", "feat/feat");
+    expect(prd.userStories[0].expectedFiles).toEqual(["src/new.ts", "src/two.ts"]);
+  });
+
+  test.each([
+    ["not present on story", makeStory()],
+    ["empty array", makeStory({ expectedFiles: [] })],
+  ])("omits expectedFiles when %s", (_label, story) => {
+    const prd = validatePlanOutput(makeInput([story]), "feat", "feat/feat");
+    expect(prd.userStories[0].expectedFiles).toBeUndefined();
+  });
+
+  test.each([
+    ["contains '..'", "../../../etc/passwd", /expectedFiles.*\.\./i],
+    ["is an absolute path", "/etc/passwd", /expectedFiles.*absolute/i],
+  ])("throws when an expectedFiles entry %s", (_label, path, pattern) => {
+    const story = makeStory({ expectedFiles: [path] });
+    expect(() => validatePlanOutput(makeInput([story]), "feat", "feat/feat")).toThrow(pattern);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // suggestedCriteria validation
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`contextFiles` in a story means *"existing files the agent reads before implementing"* — the runtime asserts each one exists and warns `Relevant file not found` when it doesn't. But spec writers and `nax plan` were leaking **to-be-created** files (e.g. `_chat.py`, `_tools/results.py`) into `contextFiles`. The runtime then emitted a false warning and **dropped the path**, losing the create-intent hint entirely.

Observed in a real PRD (`rs-stock/.nax/features/agent-chat-api/prd.json`): stories listing new files under `contextFiles`, all reported as "Relevant file not found".

## Fix — four composing layers

The schema already had the right field (`expectedFiles` — *files that must exist after execution*), it was just never populated. This wires the read-vs-create split end to end.

| Layer | Where | What |
|:--|:--|:--|
| **1** | spec-writing skill (`nax-spec-kit` v0.1.2, separate repo) | Split the spec's `Context Files` into `Context Files` (reads → `contextFiles`) and `Creates` (new files → `expectedFiles`) |
| **2** | `src/prompts/builders/plan-builder.ts`, `src/prd/schema.ts` | Teach both plan prompts to emit `expectedFiles`; parse + validate it (relative paths, no `..`) |
| **2/3** | `src/operations/plan-refine.ts` | `normalizeCreatedContextFiles`: an **uncited** `contextFiles` entry absent on disk is moved to `expectedFiles`; a **cited** absent entry is kept + warned (broken manifest grounding, not a create) |
| **4** | `src/context/builder.ts` | A missing `contextFiles` entry declared in `expectedFiles` is surfaced as a *"you will CREATE this"* hint instead of being dropped; genuinely-absent references still warn. `expectedFiles` absent on disk are recovered as create-intent even when never listed in `contextFiles` |

Net effect: created files stop landing in `contextFiles`, the false "not found" warning disappears at the source, the agent keeps the path hint, and the previously-dormant `expectedFiles` asset gate finally has data.

## Code review

Reviewed via the `code-reviewer` agent — **Approve**, no CRITICAL/HIGH. One MEDIUM (M1) addressed with a guard comment: `expectedFiles` is not yet wired into the post-run asset gate, and any future promotion to a hard gate must stay opt-in so a misclassified path can't fail a run. The flagged multi-story test gap was added.

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — exit 0
- [x] `bun run test` (full suite, all phases) — green
- [x] New unit tests: builder create-intent vs drop (4); `normalizeCreatedContextFiles` move/keep/cite/no-op/multi-story (6); `expectedFiles` schema parsing + path security (4)

## Not in scope

The **decompose** path (`src/agents/shared/decompose-prompt.ts`) still threads only `contextFiles`, not `expectedFiles`. The plan-refine auto-move still protects it; full decompose fidelity is a small follow-up.