### PR TITLE
feat(tui): unified Progress panel, phase labels, blink fix, and input token fix

### DIFF
--- a/src/agents/acp/parser.ts
+++ b/src/agents/acp/parser.ts
@@ -107,14 +107,26 @@ export function parseAcpxJsonLine(line: string, state: AcpxParseState): AcpxLine
         // Usage update — emit activity metadata with token/cost info
         if (update.sessionUpdate === "usage_update") {
           const activity: AcpxLineActivity = { kind: "usage_update" };
-          // Extract token counts if available
-          if (typeof update.used === "number") {
+          // _meta.usage carries the per-turn breakdown (inputTokens, outputTokens) when
+          // the agent reports it (Claude Code does; other adapters may omit it).
+          const metaUsage =
+            update._meta != null && typeof update._meta === "object"
+              ? ((update._meta as Record<string, unknown>).usage as Record<string, unknown> | undefined)
+              : undefined;
+          if (metaUsage != null && typeof metaUsage === "object") {
+            const inp = metaUsage.inputTokens ?? metaUsage.input_tokens;
+            if (typeof inp === "number") activity.inputTokens = inp;
+            const out = metaUsage.outputTokens ?? metaUsage.output_tokens;
+            if (typeof out === "number") activity.outputTokens = out;
+          }
+          // Fall back to update.used for output tokens if breakdown was absent
+          if (activity.outputTokens == null && typeof update.used === "number") {
             activity.outputTokens = update.used;
           }
           // Extract cost if available
-          if (typeof update.cost?.amount === "number") {
-            activity.costUsd = update.cost.amount;
-            state.exactCostUsd = update.cost.amount;
+          if (typeof (update.cost as Record<string, unknown> | undefined)?.amount === "number") {
+            activity.costUsd = (update.cost as Record<string, unknown>).amount as number;
+            state.exactCostUsd = activity.costUsd;
           }
           return activity;
         }

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -84,7 +84,7 @@ export function App({
 }: TuiProps) {
   const layout = useLayout();
   const busState = usePipelineBusEvents(initialStories);
-  const { currentStage } = usePipelineEvents(events);
+  const { currentStage, preRunPhases } = usePipelineEvents(events);
   const { exit } = useApp();
 
   // Separate elapsed time state — isolated so the 1s timer only re-renders
@@ -117,6 +117,17 @@ export function App({
   const runningStories = busState.stories.filter((s) => s.status === "running");
   const isParallel = runningStories.length > 1;
   const currentRunningStory = runningStories[0];
+
+  // Resolve current phase label for Live Activity: post-run phases take priority over pipeline stage
+  const runningPostRunPhase =
+    busState.postRunPhases.acceptance?.status === "running"
+      ? "post-run: acceptance"
+      : busState.postRunPhases.regression?.status === "running"
+        ? "post-run: regression"
+        : busState.postRunPhases.review?.status === "running"
+          ? "post-run: review"
+          : undefined;
+  const currentPhaseLabel = runningPostRunPhase ?? currentStage;
 
   // Adapt busState.runErrored (boolean) to string | undefined for LiveActivityPanel
   const runErroredForPanel = busState.runErrored ? "Run encountered an error" : undefined;
@@ -231,8 +242,11 @@ export function App({
   // Header right side: "N running · $cost · Xk in / Yk out · elapsed"
   const activeCount = runningStories.length;
   const displayElapsed = busState.runSummary ? busState.runSummary.durationMs : elapsedMs;
-  const tokensStr =
-    inputTokens > 0 || outputTokens > 0 ? `${formatTokens(inputTokens)} in / ${formatTokens(outputTokens)} out` : null;
+  const tokenParts = [
+    inputTokens > 0 ? `${formatTokens(inputTokens)} in` : null,
+    outputTokens > 0 ? `${formatTokens(outputTokens)} out` : null,
+  ].filter(Boolean);
+  const tokensStr = tokenParts.length > 0 ? tokenParts.join(" / ") : null;
   const headerRight = [
     activeCount > 0 ? `${activeCount} running` : null,
     formatCost(busState.totalCost),
@@ -274,6 +288,7 @@ export function App({
         {/* Stories panel */}
         <MemoStoriesPanel
           stories={busState.stories}
+          preRunPhases={preRunPhases}
           postRunPhases={busState.postRunPhases}
           width={layout.mode === "single" ? layout.width : layout.storiesPanelWidth}
           compact={layout.mode === "single"}
@@ -288,6 +303,7 @@ export function App({
           runSummary={busState.runSummary}
           runErrored={runErroredForPanel}
           escalationLog={busState.escalationLog}
+          currentStage={currentPhaseLabel}
         />
       </Box>
 

--- a/src/tui/components/LiveActivityPanel.tsx
+++ b/src/tui/components/LiveActivityPanel.tsx
@@ -136,11 +136,13 @@ export function LiveActivityPanel({
 }
 
 function ActiveCallRow({ call, step, currentStage }: { call: ActiveCallState; step?: string; currentStage?: string }) {
-  const stageLabel =
-    step ? <Text color="yellow">[{step}]</Text>
-    : call.stage ? <Text dimColor>[{call.stage}]</Text>
-    : currentStage ? <Text dimColor>[{currentStage}]</Text>
-    : null;
+  const stageLabel = step ? (
+    <Text color="yellow">[{step}]</Text>
+  ) : call.stage ? (
+    <Text dimColor>[{call.stage}]</Text>
+  ) : currentStage ? (
+    <Text dimColor>[{currentStage}]</Text>
+  ) : null;
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Box flexDirection="row" gap={1}>

--- a/src/tui/components/LiveActivityPanel.tsx
+++ b/src/tui/components/LiveActivityPanel.tsx
@@ -27,6 +27,8 @@ export interface LiveActivityPanelProps {
   runErrored?: string;
   /** Log of escalation events from pipeline bus */
   escalationLog?: EscalationEntry[];
+  /** Current phase/stage label for display (e.g. "acceptance-setup", "post-run: acceptance") */
+  currentStage?: string;
 }
 
 /**
@@ -47,6 +49,7 @@ export function LiveActivityPanel({
   runSummary,
   runErrored,
   escalationLog = [],
+  currentStage,
 }: LiveActivityPanelProps) {
   const borderColor = focused ? "cyan" : "gray";
   const activeCallList = activeCalls ? Array.from(activeCalls.values()) : [];
@@ -83,7 +86,12 @@ export function LiveActivityPanel({
       {hasActiveCalls && (
         <Box flexDirection="column" paddingX={1} paddingY={1}>
           {activeCallList.map((call) => (
-            <ActiveCallRow key={call.callId} call={call} step={call.storyId ? storySteps?.[call.storyId] : undefined} />
+            <ActiveCallRow
+              key={call.callId}
+              call={call}
+              step={call.storyId ? storySteps?.[call.storyId] : undefined}
+              currentStage={currentStage}
+            />
           ))}
         </Box>
       )}
@@ -113,20 +121,32 @@ export function LiveActivityPanel({
       {/* Waiting state when nothing to show */}
       {!hasActiveCalls && !hasSummary && !hasError && (!storySteps || Object.keys(storySteps).length === 0) && (
         <Box paddingX={1} paddingY={1}>
-          <Text dimColor>Waiting for agent...</Text>
+          {currentStage ? (
+            <Box flexDirection="row" gap={1}>
+              <Text color="yellow">[{currentStage}]</Text>
+              <Text dimColor>preparing...</Text>
+            </Box>
+          ) : (
+            <Text dimColor>Waiting for agent...</Text>
+          )}
         </Box>
       )}
     </Box>
   );
 }
 
-function ActiveCallRow({ call, step }: { call: ActiveCallState; step?: string }) {
+function ActiveCallRow({ call, step, currentStage }: { call: ActiveCallState; step?: string; currentStage?: string }) {
+  const stageLabel =
+    step ? <Text color="yellow">[{step}]</Text>
+    : call.stage ? <Text dimColor>[{call.stage}]</Text>
+    : currentStage ? <Text dimColor>[{currentStage}]</Text>
+    : null;
   return (
     <Box flexDirection="column" marginBottom={1}>
       <Box flexDirection="row" gap={1}>
         <Text color="cyan">{call.agentName}</Text>
         {call.storyId && <Text>{call.storyId}</Text>}
-        {step ? <Text color="yellow">[{step}]</Text> : call.stage ? <Text dimColor>[{call.stage}]</Text> : null}
+        {stageLabel}
       </Box>
       <Box flexDirection="row" gap={1}>
         {call.model && <Text dimColor>model:{call.model}</Text>}

--- a/src/tui/components/StoriesPanel.tsx
+++ b/src/tui/components/StoriesPanel.tsx
@@ -70,7 +70,14 @@ function getStatusIcon(status: StoryDisplayState["status"]): string {
  * />
  * ```
  */
-export function StoriesPanel({ stories, preRunPhases, postRunPhases, width, compact = false, maxHeight }: StoriesPanelProps) {
+export function StoriesPanel({
+  stories,
+  preRunPhases,
+  postRunPhases,
+  width,
+  compact = false,
+  maxHeight,
+}: StoriesPanelProps) {
   // Determine max visible stories based on mode
   const maxVisible = compact ? COMPACT_MAX_VISIBLE_STORIES : MAX_VISIBLE_STORIES;
   const needsScrolling = stories.length > maxVisible;

--- a/src/tui/components/StoriesPanel.tsx
+++ b/src/tui/components/StoriesPanel.tsx
@@ -8,6 +8,7 @@ import { Box, Text } from "ink";
 import { useEffect, useState } from "react";
 import { COMPACT_MAX_VISIBLE_STORIES, MAX_VISIBLE_STORIES } from "../hooks/useLayout";
 import type { PostRunPhaseState } from "../hooks/usePipelineBusEvents";
+import type { PreRunPhaseState } from "../hooks/usePipelineEvents";
 import type { StoryDisplayState } from "../types";
 
 /**
@@ -16,6 +17,8 @@ import type { StoryDisplayState } from "../types";
 export interface StoriesPanelProps {
   /** Stories to display */
   stories: StoryDisplayState[];
+  /** Pre-run phase statuses keyed by stage name (e.g. "acceptance-setup") */
+  preRunPhases?: Record<string, PreRunPhaseState>;
   /** Post-run phase statuses (acceptance, regression, review) */
   postRunPhases?: {
     acceptance?: PostRunPhaseState;
@@ -67,7 +70,7 @@ function getStatusIcon(status: StoryDisplayState["status"]): string {
  * />
  * ```
  */
-export function StoriesPanel({ stories, postRunPhases, width, compact = false, maxHeight }: StoriesPanelProps) {
+export function StoriesPanel({ stories, preRunPhases, postRunPhases, width, compact = false, maxHeight }: StoriesPanelProps) {
   // Determine max visible stories based on mode
   const maxVisible = compact ? COMPACT_MAX_VISIBLE_STORIES : MAX_VISIBLE_STORIES;
   const needsScrolling = stories.length > maxVisible;
@@ -98,9 +101,18 @@ export function StoriesPanel({ stories, postRunPhases, width, compact = false, m
     <Box flexDirection="column" width={width} height={maxHeight} borderStyle="single" borderColor="gray">
       {/* Header */}
       <Box paddingX={1} borderStyle="single" borderBottom borderColor="gray">
-        <Text bold>Stories</Text>
+        <Text bold>Progress</Text>
         {needsScrolling && <Text dimColor> ({stories.length} total)</Text>}
       </Box>
+
+      {/* Pre-run phase rows */}
+      {preRunPhases && Object.keys(preRunPhases).length > 0 && (
+        <Box flexDirection="column" paddingX={1} paddingTop={1}>
+          {Object.entries(preRunPhases).map(([name, phase]) => (
+            <PreRunPhaseRow key={name} label={name} phase={phase} compact={compact} />
+          ))}
+        </Box>
+      )}
 
       {/* Scroll indicator (top) */}
       {needsScrolling && canScrollUp && (
@@ -158,7 +170,6 @@ export function StoriesPanel({ stories, postRunPhases, width, compact = false, m
       {/* Post-run phases */}
       {postRunPhases && (postRunPhases.acceptance || postRunPhases.regression || postRunPhases.review) && (
         <Box flexDirection="column" paddingX={1} paddingTop={1}>
-          <Box borderStyle="single" borderTop borderColor="gray" />
           <Text dimColor>Post-Run</Text>
           {postRunPhases.acceptance && (
             <PostRunPhaseRow label="acceptance" phase={postRunPhases.acceptance} compact={compact} />
@@ -169,6 +180,19 @@ export function StoriesPanel({ stories, postRunPhases, width, compact = false, m
           {postRunPhases.review && <PostRunPhaseRow label="review" phase={postRunPhases.review} compact={compact} />}
         </Box>
       )}
+    </Box>
+  );
+}
+
+function PreRunPhaseRow({ label, phase, compact }: { label: string; phase: PreRunPhaseState; compact: boolean }) {
+  const icon = phase.status === "running" ? "●" : phase.status === "passed" ? "✓" : "✗";
+  const color = phase.status === "running" ? "yellow" : phase.status === "passed" ? "green" : "red";
+  const displayLabel = compact ? label.slice(0, 6) : label;
+  return (
+    <Box>
+      <Text color={color}>
+        {icon} {displayLabel}
+      </Text>
     </Box>
   );
 }

--- a/src/tui/hooks/useAgentStreamEvents.ts
+++ b/src/tui/hooks/useAgentStreamEvents.ts
@@ -19,121 +19,135 @@ export interface ActiveCallState {
   lastToolName?: string;
 }
 
+/** How often (ms) to flush buffered stream events into React state. */
+const RENDER_INTERVAL_MS = 150;
+
 export function useAgentStreamEvents(bus?: IAgentStreamEventBus | null): {
   activeCalls: Map<string, ActiveCallState>;
   inputTokens: number;
   outputTokens: number;
 } {
+  // Refs hold the latest in-flight state — updated synchronously on every event,
+  // never trigger re-renders directly.
+  const activeCallsRef = useRef<Map<string, ActiveCallState>>(new Map());
+  const inputTokensRef = useRef(0);
+  const outputTokensRef = useRef(0);
+  const lastTokensRef = useRef<Map<string, { input: number; output: number }>>(new Map());
+  const dirtyRef = useRef(false);
+
+  // State holds the displayed snapshot — drained from refs at RENDER_INTERVAL_MS.
   const [activeCalls, setActiveCalls] = useState<Map<string, ActiveCallState>>(new Map());
   const [inputTokens, setInputTokens] = useState(0);
   const [outputTokens, setOutputTokens] = useState(0);
-  // Track the last cumulative token counts per callId so we add only the delta.
-  // ACP emits usage_update with cumulative totals, not incremental deltas.
-  const lastTokensRef = useRef<Map<string, { input: number; output: number }>>(new Map());
 
+  // Subscribe to stream events: process into refs only, no setState.
   useEffect(() => {
     if (!bus) return;
 
     const unsubscribe = bus.onAgentStream((event: AgentStreamEvent) => {
-      setActiveCalls((prev) => {
-        const next = new Map(prev);
+      const next = new Map(activeCallsRef.current);
 
-        switch (event.kind) {
-          case "agent.call_started": {
-            const now = event.timestamp;
-            next.set(event.callId, {
-              callId: event.callId,
-              agentName: event.agentName,
-              storyId: event.storyId,
-              stage: event.stage,
-              startedAt: now,
-              lastActivityAt: now,
-              messageUpdates: 0,
-              thinkingUpdates: 0,
-              usageUpdates: 0,
-              toolCallUpdates: 0,
-              status: "active",
-              model: event.model,
-            });
-            break;
-          }
-          case "agent.message_update": {
-            const state = next.get(event.callId);
-            if (state) {
-              next.set(event.callId, {
-                ...state,
-                messageUpdates: state.messageUpdates + 1,
-                lastActivityAt: event.timestamp,
-              });
-            }
-            break;
-          }
-          case "agent.thinking_update": {
-            const state = next.get(event.callId);
-            if (state) {
-              next.set(event.callId, {
-                ...state,
-                thinkingUpdates: state.thinkingUpdates + 1,
-                lastActivityAt: event.timestamp,
-              });
-            }
-            break;
-          }
-          case "agent.usage_update": {
-            const state = next.get(event.callId);
-            if (state) {
-              next.set(event.callId, {
-                ...state,
-                usageUpdates: state.usageUpdates + 1,
-                lastActivityAt: event.timestamp,
-              });
-            }
-            // Add only the delta: ACP usage_update carries cumulative totals per call.
-            {
-              const last = lastTokensRef.current.get(event.callId) ?? { input: 0, output: 0 };
-              const newInput = event.inputTokens ?? last.input;
-              const newOutput = event.outputTokens ?? last.output;
-              const deltaIn = newInput - last.input;
-              const deltaOut = newOutput - last.output;
-              lastTokensRef.current.set(event.callId, { input: newInput, output: newOutput });
-              if (deltaIn > 0) setInputTokens((prev) => prev + deltaIn);
-              if (deltaOut > 0) setOutputTokens((prev) => prev + deltaOut);
-            }
-            break;
-          }
-          case "agent.tool_call_update": {
-            const state = next.get(event.callId);
-            if (state) {
-              next.set(event.callId, {
-                ...state,
-                toolCallUpdates: state.toolCallUpdates + 1,
-                lastActivityAt: event.timestamp,
-                lastToolName: event.toolName,
-              });
-            }
-            break;
-          }
-          case "agent.call_ended": {
-            const state = next.get(event.callId);
-            if (state) {
-              next.set(event.callId, { ...state, status: "ended" });
-              // Remove ended calls to keep the map clean
-              next.delete(event.callId);
-            }
-            // Release the per-call token baseline to prevent unbounded map growth
-            lastTokensRef.current.delete(event.callId);
-            break;
-          }
-          default:
-            break;
+      switch (event.kind) {
+        case "agent.call_started": {
+          next.set(event.callId, {
+            callId: event.callId,
+            agentName: event.agentName,
+            storyId: event.storyId,
+            stage: event.stage,
+            startedAt: event.timestamp,
+            lastActivityAt: event.timestamp,
+            messageUpdates: 0,
+            thinkingUpdates: 0,
+            usageUpdates: 0,
+            toolCallUpdates: 0,
+            status: "active",
+            model: event.model,
+          });
+          break;
         }
+        case "agent.message_update": {
+          const state = next.get(event.callId);
+          if (state) {
+            next.set(event.callId, {
+              ...state,
+              messageUpdates: state.messageUpdates + 1,
+              lastActivityAt: event.timestamp,
+            });
+          }
+          break;
+        }
+        case "agent.thinking_update": {
+          const state = next.get(event.callId);
+          if (state) {
+            next.set(event.callId, {
+              ...state,
+              thinkingUpdates: state.thinkingUpdates + 1,
+              lastActivityAt: event.timestamp,
+            });
+          }
+          break;
+        }
+        case "agent.usage_update": {
+          const state = next.get(event.callId);
+          if (state) {
+            next.set(event.callId, {
+              ...state,
+              usageUpdates: state.usageUpdates + 1,
+              lastActivityAt: event.timestamp,
+            });
+          }
+          // ACP emits cumulative totals per call — add only the delta.
+          {
+            const last = lastTokensRef.current.get(event.callId) ?? { input: 0, output: 0 };
+            const newInput = event.inputTokens ?? last.input;
+            const newOutput = event.outputTokens ?? last.output;
+            const deltaIn = newInput - last.input;
+            const deltaOut = newOutput - last.output;
+            lastTokensRef.current.set(event.callId, { input: newInput, output: newOutput });
+            if (deltaIn > 0) inputTokensRef.current += deltaIn;
+            if (deltaOut > 0) outputTokensRef.current += deltaOut;
+          }
+          break;
+        }
+        case "agent.tool_call_update": {
+          const state = next.get(event.callId);
+          if (state) {
+            next.set(event.callId, {
+              ...state,
+              toolCallUpdates: state.toolCallUpdates + 1,
+              lastActivityAt: event.timestamp,
+              lastToolName: event.toolName,
+            });
+          }
+          break;
+        }
+        case "agent.call_ended": {
+          next.delete(event.callId);
+          lastTokensRef.current.delete(event.callId);
+          break;
+        }
+        default:
+          break;
+      }
 
-        return next;
-      });
+      activeCallsRef.current = next;
+      dirtyRef.current = true;
     });
 
     return unsubscribe;
   }, [bus]);
+
+  // Drain refs into state at a fixed interval — decouples render rate from event rate.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (!dirtyRef.current) return;
+      dirtyRef.current = false;
+      setActiveCalls(new Map(activeCallsRef.current));
+      setInputTokens(inputTokensRef.current);
+      setOutputTokens(outputTokensRef.current);
+    }, RENDER_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
 
   return { activeCalls, inputTokens, outputTokens };
 }

--- a/src/tui/hooks/usePipelineEvents.ts
+++ b/src/tui/hooks/usePipelineEvents.ts
@@ -1,22 +1,55 @@
 /**
- * usePipelineEvents — stage tracking only.
+ * usePipelineEvents — stage tracking for pre-run phases and current stage.
  *
- * Subscribes to stage:enter on the PipelineEventEmitter (old bus) which
- * is still used by pipeline/runner.ts to emit stage transitions.
+ * Subscribes to stage:enter/stage:exit on the PipelineEventEmitter (old bus)
+ * which is still used by pipeline/runner.ts to emit stage transitions.
  * All story lifecycle state comes from usePipelineBusEvents.
+ *
+ * Pre-run stages (e.g. "acceptance-setup") are tracked as phase rows
+ * in the Progress panel; other stages update currentStage for Live Activity.
  */
 
 import { useEffect, useState } from "react";
 import type { PipelineEventEmitter } from "../../pipeline/events";
+import type { StageResult } from "../../pipeline/types";
 
-export function usePipelineEvents(events: PipelineEventEmitter): { currentStage: string | undefined } {
+/** Status of a pre-run pipeline stage. */
+export interface PreRunPhaseState {
+  status: "running" | "passed" | "failed";
+}
+
+/** Stage names that appear as pre-run phase rows in the Progress panel. */
+const PRE_RUN_STAGES = new Set(["acceptance-setup"]);
+
+export function usePipelineEvents(events: PipelineEventEmitter): {
+  currentStage: string | undefined;
+  preRunPhases: Record<string, PreRunPhaseState>;
+} {
   const [currentStage, setCurrentStage] = useState<string | undefined>(undefined);
+  const [preRunPhases, setPreRunPhases] = useState<Record<string, PreRunPhaseState>>({});
 
   useEffect(() => {
-    const onStageEnter = (stage: string) => setCurrentStage(stage);
+    const onStageEnter = (stage: string) => {
+      setCurrentStage(stage);
+      if (PRE_RUN_STAGES.has(stage)) {
+        setPreRunPhases((prev) => ({ ...prev, [stage]: { status: "running" } }));
+      }
+    };
+    const onStageExit = (stage: string, result: StageResult) => {
+      if (PRE_RUN_STAGES.has(stage)) {
+        setPreRunPhases((prev) => ({
+          ...prev,
+          [stage]: { status: result.action === "fail" ? "failed" : "passed" },
+        }));
+      }
+    };
     events.on("stage:enter", onStageEnter as Parameters<typeof events.on<"stage:enter">>[1]);
-    return () => events.off("stage:enter", onStageEnter as Parameters<typeof events.off<"stage:enter">>[1]);
+    events.on("stage:exit", onStageExit as Parameters<typeof events.on<"stage:exit">>[1]);
+    return () => {
+      events.off("stage:enter", onStageEnter as Parameters<typeof events.off<"stage:enter">>[1]);
+      events.off("stage:exit", onStageExit as Parameters<typeof events.off<"stage:exit">>[1]);
+    };
   }, [events]);
 
-  return { currentStage };
+  return { currentStage, preRunPhases };
 }

--- a/test/unit/ui/tui-layout.test.ts
+++ b/test/unit/ui/tui-layout.test.ts
@@ -195,7 +195,7 @@ describe("Edge cases", () => {
 
     const output = lastFrame();
     // Should still show header
-    expect(output).toContain("Stories");
+    expect(output).toContain("Progress");
   });
 
   test("no scroll at exactly MAX_VISIBLE_STORIES; scroll indicator at MAX+1", () => {


### PR DESCRIPTION
## Summary

- **Unified Progress panel**: renames the Stories panel to "Progress" and shows the full run lifecycle in one place — pre-run phases (e.g. `acceptance-setup`) at the top as status rows (● running / ✓ passed / ✗ failed), stories in the middle, post-run phases at the bottom. Removes the empty-box separator that rendered like a progress bar.
- **Phase labels in Live Activity**: passes a `currentPhaseLabel` to the Live Activity panel so it always shows context — `[acceptance-setup]` during pre-run, `[post-run: acceptance/regression/review]` during post-run, and as a fallback label on active agent calls that have no storyId or stage attached.
- **Blink fix**: stream events in `useAgentStreamEvents` now write to refs only (zero re-renders per event); a 150 ms interval drains the refs into React state, capping TUI re-renders at ~6/sec regardless of event volume.
- **Input token fix**: `parser.ts` now reads `_meta.usage.inputTokens` and `_meta.usage.outputTokens` from the ACP `usage_update` notification. Previously only `update.used` (context window utilization) was read for output tokens, and input tokens were never populated. Falls back to `update.used` for adapters that omit `_meta.usage`.
- **Token display**: header only shows the `N in` part when `inputTokens > 0`, hiding the misleading `0 in` for adapters that don't report input tokens.

## Test plan

- [ ] Run `nax run` against a feature with acceptance tests enabled — confirm Progress panel shows `● acceptance-setup` at top during pre-run, then stories, then `> acceptance` / `> review` at bottom after run completes
- [ ] Confirm Live Activity shows `[acceptance-setup]` label during pre-run agent calls (images 1 & 2 scenario)
- [ ] Confirm Live Activity shows `[post-run: acceptance]` label during post-run fix agent calls (image 3 scenario)
- [ ] Confirm TUI no longer blinks during active agent output (high tool/message event rate)
- [ ] Confirm header shows `1.2M out` (not `0 in / 1.2M out`) for adapters that don't report input tokens
- [ ] Confirm header shows `42k in / 1.2M out` for Claude Code adapter where `_meta.usage` is populated
- [ ] `bun run lint && bun run typecheck && bun run test` — all green ✓