### PR TITLE
feat(plan): keep upstream-dependency-produced files in contextFiles

### DIFF
--- a/docs/architecture/spec-to-prd-pipeline.md
+++ b/docs/architecture/spec-to-prd-pipeline.md
@@ -1,0 +1,171 @@
+# Spec → PRD Pipeline: how spec-writing, nax plan, and spec-review work together
+
+> **Audience:** anyone touching the spec-kit skills (`spec-writing`, `spec-review`)
+> or the nax planner (`src/operations/plan-refine.ts`, `src/prompts/builders/plan-builder.ts`).
+> **Status:** SSOT for the three-component contract around per-story **file roles**
+> (`contextFiles` vs `expectedFiles`) and the **cross-story produced-file** rule.
+
+## The four-stage workflow
+
+```
+brainstorming      → spec-writing          → spec-review         → nax plan
+(intent)             (intent → SPEC.md)       (codebase audit)      (decompose → prd.json)
+                                                                         │
+                                                                         ▼
+                                                  spec-review --prd (Phase 9: fidelity gate)
+                                                                         │
+                                                                         ▼
+                                                            per-story execution (runner)
+```
+
+Each stage hands a structured artifact to the next:
+
+| Stage | Owns | Produces | Lives in |
+|---|---|---|---|
+| **spec-writing** | authoring rules, sizing, seams | `SPEC-*.md` (`Context Files` + `Creates` per story) | `nax-spec-kit/skills/spec-writing/` |
+| **nax plan** | decomposition into executable slices | `prd.json` (`contextFiles` + `expectedFiles` per story) | `nax/src/operations/plan-refine.ts`, `src/prompts/builders/plan-builder.ts` |
+| **spec-review** | grounding + fidelity audit | review report / `prd-fidelity-report.md` | `nax-spec-kit/skills/spec-review/` |
+| **runner** | execution | merged code | `nax/src/execution/`, `src/context/builder.ts` |
+
+The three upstream stages must agree on one model, or information silently
+leaks between them. The model is **file roles**.
+
+## The file-role model
+
+Every file a story touches has exactly one role per story:
+
+| Spec term | PRD key | Meaning | Existence at **plan** time | Existence at **this story's runtime** |
+|---|---|---|---|---|
+| `Context Files` | `contextFiles` | files the agent **reads** before coding | normally already on disk | on disk |
+| `Creates` | `expectedFiles` | files **this story authors** | absent | created by this story |
+
+`contextFiles` entries are surfaced to the agent as **path-only read hints**
+(`src/context/builder.ts` — `readContextMessage`), not inlined content. A
+`contextFiles` entry that is missing at the consuming story's runtime produces a
+**`logger.warn("context", "Relevant file not found")`** and the run continues —
+it is **not** a hard error (`src/context/builder.ts`).
+
+## The third role: cross-story produced files
+
+The two-role model has a blind spot. Consider a dependency chain where US-A
+**creates** a file and a later US-B **reads/modifies** it:
+
+```
+US-002  Creates:        apps/web/components/ProposalCard.tsx
+US-003  Context Files:  apps/web/components/ProposalCard.tsx   (US-003 integrates into it)
+        depends on:     US-002
+```
+
+From US-003's perspective `ProposalCard.tsx` is:
+
+- **not** an "existing file to read" — it does not exist at **plan** time, and
+- **not** a file "US-003 authors" — **US-002** authors it.
+
+It is a **third category**: *a file produced by an upstream dependency and
+consumed by this story.* The naïve "absent at plan time ⇒ this story creates it"
+heuristic mis-classifies it.
+
+### Why it is safe to keep it in `contextFiles`
+
+The discriminator that matters is **runtime existence relative to dependency
+order**, not plan-time existence. A file produced by an upstream dependency
+**does exist** by the time the consuming story runs, in **both** execution modes:
+
+- **Sequential mode** — stories share one workdir; the producer ran first, so
+  the file is on disk.
+- **Parallel mode** — `groupStoriesByDependencies` puts the consumer in a
+  **later batch**; successful stories **merge back to the project root before the
+  next batch starts** (`src/execution/parallel-coordinator.ts`); the consumer's
+  worktree is then created with `git worktree add … -b …` **with no commit-ish**,
+  which branches from the current `HEAD` — now containing the producer's file
+  (`src/worktree/manager.ts`).
+
+So a cross-story produced file listed in the consumer's `contextFiles` is found
+on disk at the consumer's runtime (`src/context/builder.ts`): **no warning, a
+correct read hint.** Conversely, mis-moving it to the consumer's `expectedFiles`
+is wrong — the consumer does not author it, and if `expectedFiles` is ever
+promoted to a hard post-run asset gate, the consumer would fail for "not
+creating" a file it only modifies.
+
+### The rule (all three components)
+
+> A `contextFiles` entry that is absent at plan time but appears in the
+> `Creates`/`expectedFiles` of an **upstream dependency** story is a **legitimate
+> read**. Keep it in `contextFiles`; never move it to `expectedFiles`; never drop
+> it. Only an absent entry produced by **no** story is "this story creates it."
+
+This is distinct from the still-valid rule: **never list a file _this_ story
+creates under its own `Context Files`** — that file is genuinely absent at the
+story's own runtime and belongs in `Creates`/`expectedFiles`.
+
+## Where each component enforces the rule
+
+- **spec-writing** (`reference/spec-writing-guide.md` § Context Hints, `SKILL.md`
+  Phase 4): may list an upstream-produced file under the consumer's
+  `Context Files`, annotated with its producer (e.g.
+  `` `ProposalCard.tsx` — created by US-002, integrated here ``). The "do not
+  list a file _this story_ creates" prohibition is narrowed to self-created files.
+- **nax plan** (`src/operations/plan-refine.ts` → `normalizeCreatedContextFiles`):
+  before classifying an absent `contextFiles` entry as "this story creates it",
+  computes the union of files produced by the story's **transitive upstream
+  dependencies**. If the entry is in that set, it is **kept** in `contextFiles`.
+  The plan prompt (`src/prompts/builders/plan-builder.ts`) tells the LLM the same.
+- **spec-review** (`skills/spec-review/SKILL.md` Phase 9 §4): the file-role delta
+  check distinguishes the two sub-cases:
+  - file in **this** story's `Creates` → absence from `contextFiles` is correct,
+    **not a finding**;
+  - file in an **upstream dependency's** `Creates`, consumed here, dropped from
+    `contextFiles` → **fidelity finding** (the spec listed it; the PRD lost the
+    read hint). Remediation is upstream (planner dependency-aware classification),
+    **not** "add it to `contextFiles`" of a planner that would strip it again.
+
+## Failure mode this prevents
+
+Before this rule was made explicit, the chain silently lost the hand-off:
+
+1. spec-writing's guide said "Context Files must already exist" with no
+   cross-story carve-out → authors had no correct bucket;
+2. an author honestly listed the upstream-produced file under the consumer's
+   `Context Files` (technically violating the guide);
+3. nax plan dropped it (prompt: "existing files only") or **mis-moved** it to the
+   consumer's `expectedFiles` (`normalizeStoryFiles`: "absent ⇒ this story
+   creates it");
+4. spec-review's fidelity audit was told this was "correct nax behaviour, never
+   flag" — so the loss was un-auditable.
+
+Net effect: the consuming story received **no explicit pointer** to the file it
+was supposed to modify, relying only on the dependency edge (which controls
+ordering, not context injection) and the code-neighbor provider.
+
+## Known limitation (deferred)
+
+`collectUpstreamProducedFiles` (`src/operations/plan-refine.ts`) detects an
+upstream-produced file via the producer's **declared `expectedFiles`** only. If a
+producer story mis-files its own output under its **`contextFiles`** (absent on
+disk) instead of `expectedFiles`, the consumer will not recognize the file as
+upstream-produced during the same normalization pass, and it falls back to the
+old behaviour (the consumer's reference is mis-moved into the consumer's
+`expectedFiles`).
+
+This requires a **double** spec-writing violation — the producer mis-roles its
+own output **and** a consumer references it — which the plan prompt and
+spec-writing guide now actively steer away from (created files go to
+`expectedFiles`). The canonical path is therefore solid; this is residual
+defensive depth only.
+
+**Status: deferred.** The fix is a precomputed per-story "effective produced set"
+(declared `expectedFiles` ∪ uncited `contextFiles` entries absent on disk) driving
+the upstream lookup, with a memoized `fileExists` so the I/O is shared with the
+normalize pass (~25 lines). Over-inclusion is benign — it only ever errs toward
+keeping a file as a read hint, never toward a wrong move. Not implemented because
+the guarded scenario is a double violation the upstream rules already prevent;
+revisit if a real PRD exhibits the producer-mis-files-own-output pattern.
+
+## Quick reference
+
+| Situation | `contextFiles`? | `expectedFiles`? | spec-review verdict |
+|---|---|---|---|
+| Existing file, read only | ✅ | — | drop = major (lost context) |
+| File this story creates | ❌ | ✅ | in `contextFiles` = blocker |
+| File an upstream dep creates, read/modified here | ✅ (annotated) | ❌ | kept = correct; dropped or mis-moved to `expectedFiles` = major |
+| Absent, produced by no story | ❌ | ✅ (best-effort) | move is correct |

--- a/src/operations/plan-refine.ts
+++ b/src/operations/plan-refine.ts
@@ -173,16 +173,49 @@ interface StoryNormalization {
 }
 
 /**
- * Normalize one story: an uncited `contextFiles` entry that is absent on disk is
- * a file the story CREATES — move it to `expectedFiles`. A cited entry (factId)
- * that is absent claims broken manifest grounding, so it is kept and warned
- * (not silently moved). Existing files and already-declared outputs are left
- * untouched. Returns a new story object when anything moved (immutable update).
+ * Collect every file produced (created) by the stories `story` transitively
+ * depends on. A file created by an upstream dependency does not exist at plan
+ * time but WILL exist at this story's execution time — sequential mode shares one
+ * workdir (the producer ran first), and parallel mode merges each batch back to
+ * HEAD before the next batch's worktrees branch from it (see
+ * docs/architecture/spec-to-prd-pipeline.md, src/execution/parallel-coordinator.ts,
+ * src/worktree/manager.ts). So an absent `contextFiles` entry that an upstream
+ * story creates is a legitimate read hint, NOT a file this story authors.
+ */
+function collectUpstreamProducedFiles(story: UserStory, byId: Map<string, UserStory>): Set<string> {
+  const produced = new Set<string>();
+  const seen = new Set<string>();
+  const stack = [...(story.dependencies ?? [])];
+  while (stack.length > 0) {
+    const depId = stack.pop();
+    if (!depId || seen.has(depId)) continue;
+    seen.add(depId);
+    const dep = byId.get(depId);
+    if (!dep) continue;
+    for (const filePath of getExpectedFiles(dep)) produced.add(filePath);
+    stack.push(...(dep.dependencies ?? []));
+  }
+  return produced;
+}
+
+/**
+ * Normalize one story's `contextFiles` against the filesystem and the dependency
+ * graph:
+ * - An entry that exists on disk, or is already a declared output, is kept.
+ * - An entry absent on disk but produced by an UPSTREAM dependency is kept as a
+ *   read hint — it exists at this story's runtime; moving it to `expectedFiles`
+ *   would wrongly claim this story authors it (see spec-to-prd-pipeline.md).
+ * - An uncited entry absent on disk and produced by no upstream story is a file
+ *   this story CREATES — move it to `expectedFiles`.
+ * - A cited entry (factId) that is absent claims broken manifest grounding, so it
+ *   is kept and warned (not silently moved).
+ * Returns a new story object when anything moved (immutable update).
  */
 async function normalizeStoryFiles(
   story: UserStory,
   workdir: string,
   fileExists: (path: string) => Promise<boolean>,
+  upstreamProduced: Set<string>,
 ): Promise<StoryNormalization> {
   const contextFiles = story.contextFiles ?? [];
   if (contextFiles.length === 0) return { story, changed: false };
@@ -197,6 +230,17 @@ async function normalizeStoryFiles(
     const factId = typeof entry === "string" ? undefined : entry.factId;
     if (expected.has(filePath) || (await fileExists(join(workdir, filePath)))) {
       kept.push(entry); // already an output, or a legitimate existing read
+      continue;
+    }
+    if (upstreamProduced.has(filePath)) {
+      // Created by an upstream dependency — absent at plan time, present at this
+      // story's runtime. Keep it as a read hint; do NOT move to expectedFiles
+      // (this story reads/modifies it but does not author it).
+      kept.push(entry);
+      logger?.debug("plan", "Kept cross-story produced file in contextFiles (upstream dependency creates it)", {
+        storyId: story.id,
+        filePath,
+      });
       continue;
     }
     if (factId) {
@@ -233,8 +277,10 @@ async function normalizeStoryFiles(
 /**
  * Deterministic safety net that closes the read/create gap left when a spec or
  * plan routes a created file into `contextFiles`. For every story, an uncited
- * `contextFiles` entry absent on disk is moved to `expectedFiles` (its correct
- * home — a post-run asset gate, not a read list). Returns a new PRD when any
+ * `contextFiles` entry absent on disk AND produced by no upstream dependency is
+ * moved to `expectedFiles` (its correct home — a post-run asset gate, not a read
+ * list). An absent entry an upstream dependency creates is kept (it exists at
+ * this story's runtime — see spec-to-prd-pipeline.md). Returns a new PRD when any
  * entry moved; otherwise the input PRD unchanged. Skipped when `workdir` is unset.
  */
 export async function normalizeCreatedContextFiles(
@@ -243,7 +289,12 @@ export async function normalizeCreatedContextFiles(
   fileExists: (path: string) => Promise<boolean>,
 ): Promise<PRD> {
   if (!workdir) return prd;
-  const results = await Promise.all(prd.userStories.map((story) => normalizeStoryFiles(story, workdir, fileExists)));
+  const byId = new Map(prd.userStories.map((story) => [story.id, story]));
+  const results = await Promise.all(
+    prd.userStories.map((story) =>
+      normalizeStoryFiles(story, workdir, fileExists, collectUpstreamProducedFiles(story, byId)),
+    ),
+  );
   if (!results.some((r) => r.changed)) return prd;
   return { ...prd, userStories: results.map((r) => r.story) };
 }

--- a/src/prompts/builders/plan-builder.ts
+++ b/src/prompts/builders/plan-builder.ts
@@ -52,9 +52,9 @@ ${TEST_STRATEGY_GUIDE}`;
  * split stays identical across plan modes. Created files route to
  * `expectedFiles` (a post-run asset gate), never to `contextFiles`.
  */
-const CONTEXT_VS_EXPECTED_FILES_RULE = `**\`contextFiles\` rule — existing files only.** Only list paths that already exist in the repo today. The pipeline verifies every \`contextFiles\` entry against the filesystem; a path that does not exist is treated as a missing-context warning.
+const CONTEXT_VS_EXPECTED_FILES_RULE = `**\`contextFiles\` rule — files readable when this story runs.** List paths that already exist in the repo today, PLUS any file an UPSTREAM dependency story creates (it does not exist now but will exist by the time this story runs, because dependencies execute first). The pipeline verifies every \`contextFiles\` entry against the filesystem; a path that exists neither on disk nor in an upstream dependency's outputs is treated as a missing-context warning.
 
-**\`expectedFiles\` rule — files this story CREATES.** List every NEW file the story authors (relative paths). A file the story will create belongs here, NEVER in \`contextFiles\` — these are the story's outputs, not files to read first. A single path may appear in \`contextFiles\` (an existing sibling to mirror) AND \`expectedFiles\` (the new file itself), but the same path must never be in both.`;
+**\`expectedFiles\` rule — files THIS story CREATES.** List every NEW file this story authors (relative paths). A file this story creates belongs here, NEVER in \`contextFiles\` — these are the story's outputs, not files to read first. A file created by an upstream dependency and only read/modified here belongs in \`contextFiles\`, NOT here (this story does not author it). A single path may appear in \`contextFiles\` (an existing sibling to mirror) AND \`expectedFiles\` (the new file itself), but the same path must never be in both.`;
 
 /** Output-schema line for the `expectedFiles` field, shared by both prompts. */
 const EXPECTED_FILES_SCHEMA_FIELD = `"expectedFiles": ["string — NEW files this story creates (relative paths, omit if none)"],`;

--- a/test/unit/operations/plan-refine.test.ts
+++ b/test/unit/operations/plan-refine.test.ts
@@ -734,6 +734,55 @@ describe("normalizeCreatedContextFiles — move absent reads to expectedFiles", 
     });
   });
 
+  test("keeps an absent contextFile produced by an upstream dependency (cross-story read, not a create)", async () => {
+    await withWarnSpy(async () => {
+      const base = makeValidPrd("f", "feat/f");
+      const producer = { ...base.userStories[0], id: "US-001", contextFiles: [], expectedFiles: ["src/Card.tsx"] };
+      const consumer = {
+        ...base.userStories[0],
+        id: "US-002",
+        dependencies: ["US-001"],
+        contextFiles: ["src/Card.tsx"], // created by US-001 — absent on disk at plan time
+        expectedFiles: ["src/Badge.tsx"],
+      };
+      const prd = { ...base, userStories: [producer, consumer] };
+      const fileExists = mock(async () => false); // nothing on disk yet
+
+      const out = (await normalizeCreatedContextFiles(prd as never, WORKDIR, fileExists)) as never as {
+        userStories: Array<{ id: string; contextFiles?: unknown[]; expectedFiles?: string[] }>;
+      };
+
+      const b = out.userStories.find((s) => s.id === "US-002")!;
+      // Kept as a read hint — NOT moved to expectedFiles (US-002 reads it but does not author it).
+      expect(b.contextFiles).toEqual(["src/Card.tsx"]);
+      expect(b.expectedFiles).toEqual(["src/Badge.tsx"]);
+    });
+  });
+
+  test("moves an absent contextFile to expectedFiles when NO upstream dependency produces it", async () => {
+    await withWarnSpy(async () => {
+      const base = makeValidPrd("f", "feat/f");
+      // US-002 depends on US-001, but US-001 does not create src/own.tsx → US-002 creates it.
+      const producer = { ...base.userStories[0], id: "US-001", contextFiles: [], expectedFiles: ["src/Card.tsx"] };
+      const consumer = {
+        ...base.userStories[0],
+        id: "US-002",
+        dependencies: ["US-001"],
+        contextFiles: ["src/own.tsx"],
+      };
+      const prd = { ...base, userStories: [producer, consumer] };
+      const fileExists = mock(async () => false);
+
+      const out = (await normalizeCreatedContextFiles(prd as never, WORKDIR, fileExists)) as never as {
+        userStories: Array<{ id: string; contextFiles?: unknown[]; expectedFiles?: string[] }>;
+      };
+
+      const b = out.userStories.find((s) => s.id === "US-002")!;
+      expect(b.contextFiles ?? []).toEqual([]);
+      expect(b.expectedFiles).toEqual(["src/own.tsx"]);
+    });
+  });
+
   test("is a no-op (returns input) when workdir is undefined", async () => {
     const fileExists = mock(async () => false);
     const prd = prdWith(["src/ghost.ts"]);


### PR DESCRIPTION
## Summary

A file **created by an upstream dependency story** and **read/modified by a downstream story** is absent at plan time but present at the consumer's runtime — sequential mode shares one workdir (producer ran first); parallel mode merges each batch back to `HEAD` before the next batch's worktrees branch from it (`src/execution/parallel-coordinator.ts`, `src/worktree/manager.ts`).

Previously the planner's `normalizeStoryFiles` mis-classified such an absent `contextFiles` entry as "this story creates it" and moved it into the **consumer's** `expectedFiles`, dropping the read hint (and risking a false post-run asset-gate failure if `expectedFiles` is ever promoted to a hard gate). The spec for `agent-actions-web` (US-002 creates `ProposalCard.tsx`; US-003 integrates into it) surfaced this.

## Changes

- **`src/operations/plan-refine.ts`** — `collectUpstreamProducedFiles` walks the transitive dependency graph (cycle/diamond-safe). An absent `contextFiles` entry produced by an upstream dependency is **kept** as a read hint instead of moved to `expectedFiles`. An absent entry produced by no upstream story still moves (unchanged behaviour).
- **`src/prompts/builders/plan-builder.ts`** — the `contextFiles`/`expectedFiles` prompt rule now tells the LLM that `contextFiles` may include files an upstream dependency creates, and that a cross-story read must never land in the consumer's `expectedFiles`.
- **`docs/architecture/spec-to-prd-pipeline.md`** — new SSOT documenting how **spec-writing + nax plan + spec-review** share the file-role model, the third "cross-story produced file" role, the execution-model proof, and a **deferred-hardening** note for the producer-mis-files-own-output edge case.

## Companion changes

The `spec-writing` and `spec-review` skills were updated in the **nax-spec-kit** repo (released as v0.1.3) to match this model: spec-writing narrows the "never list a to-be-created file" rule to self-created files and adds the upstream exception; spec-review corrects the false "nax errors on an unreadable context file" premise (it warns) and flags a dropped/mis-moved cross-story file as a major.

## Test plan

- [x] `bun test test/unit/operations/plan-refine.test.ts` — 31/31 pass (two new regression tests: cross-story file kept; non-upstream file still moved)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean