### PR TITLE
fix(prd): preserve routing.reasoning from LLM output in schema sanitizer

### DIFF
--- a/src/prd/schema.ts
+++ b/src/prd/schema.ts
@@ -291,7 +291,10 @@ function validateStory(raw: unknown, index: number, allIds: Set<string>): UserSt
     routing: {
       complexity,
       testStrategy,
-      reasoning: "validated from LLM output",
+      reasoning:
+        typeof routing.reasoning === "string" && routing.reasoning.trim().length > 0
+          ? routing.reasoning.trim()
+          : "validated from LLM output",
       ...(noTestJustification !== undefined ? { noTestJustification } : {}),
     },
     ...(workdir !== undefined ? { workdir } : {}),

--- a/test/unit/prd/schema.test.ts
+++ b/test/unit/prd/schema.test.ts
@@ -202,6 +202,19 @@ describe("validatePlanOutput — auto-fix LLM quirks (AC-7)", () => {
   });
 
   test.each([
+    ["substantive reasoning is preserved", "Single module with clear interfaces and low risk.", "Single module with clear interfaces and low risk."],
+    ["whitespace is trimmed", "  Single module with clear interfaces.  ", "Single module with clear interfaces."],
+    ["empty string falls back to placeholder", "", "validated from LLM output"],
+    ["missing reasoning falls back to placeholder", undefined, "validated from LLM output"],
+  ] as const)("routing.reasoning: %s", (_label, input, expected) => {
+    const overrides: Record<string, unknown> = input !== undefined
+      ? { routing: { complexity: "simple", testStrategy: "tdd-simple", reasoning: input } }
+      : {};
+    const prd = validatePlanOutput(makeInput([makeStory(overrides)]), "feat", "branch");
+    expect(prd.userStories[0]!.routing?.reasoning).toBe(expected);
+  });
+
+  test.each([
     ["\\xNN escape (LLM quirk)", "\\x41", "A"],
     ["\\u0041 (covers \\uXXX/\\uXX/\\uX short-unicode variants)", "\\u0041", "A"],
   ] as const)("fixes %s to correct unicode char", (_label, escaped, expected) => {


### PR DESCRIPTION
## Summary

- `sanitizeStory()` in `src/prd/schema.ts` was unconditionally hardcoding `routing.reasoning` to `"validated from LLM output"`, discarding the substantive reasoning the LLM produces during `nax plan` and `nax plan --refine`
- This contradicted the refine prompt (`plan-builder.ts:213`), which explicitly instructs the LLM to replace the placeholder with a real explanation — the schema parser was immediately overwriting whatever it returned
- Fix: preserve the LLM-provided reasoning when it is a non-empty string; fall back to `"validated from LLM output"` only when the field is absent or blank

## Root Cause

The comment at `schema.ts:286` says "Force runtime state — never trust LLM output" and guards `status`, `passes`, `attempts`, and `escalations`. The same hardcoding was applied to `routing.reasoning`, but that field is a descriptive annotation (like `complexity` and `testStrategy`), not runtime state.

## Test Plan

- [x] `routing.reasoning: substantive reasoning is preserved` — LLM-provided text is kept verbatim after trim
- [x] `routing.reasoning: whitespace is trimmed` — leading/trailing whitespace stripped
- [x] `routing.reasoning: empty string falls back to placeholder` — blank string yields `"validated from LLM output"`
- [x] `routing.reasoning: missing reasoning falls back to placeholder` — absent field yields `"validated from LLM output"`
- [x] Full suite: 9626 pass, 0 fail