### PR TITLE
fix(quality): wire quality-gate config through PackageView — eliminate phantom reads and per-package override stub

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -46,7 +46,8 @@ export {
 export { ConfiguredModelSchema, ModelTierSchema } from "./schemas-model";
 export { DebateConfigSchema } from "./schemas-debate";
 export { TddConfigSchema } from "./schemas-execution";
-export { loadConfig, loadConfigForWorkdir, findProjectDir, globalConfigPath } from "./loader";
+export { loadConfig, loadConfigForWorkdir, loadPackageOverride, findProjectDir, globalConfigPath } from "./loader";
+export { mergePackageConfig } from "./merge";
 export { validateConfig, type ValidationResult } from "./validate"; // @deprecated: Use NaxConfigSchema.safeParse() instead
 export { validateDirectory, validateFilePath, isWithinDirectory, MAX_DIRECTORY_DEPTH } from "./path-security";
 export { globalConfigDir, projectConfigDir } from "./paths";

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -438,6 +438,23 @@ export function _clearRootConfigCache(): void {
 }
 
 /**
+ * Read (but do NOT merge) the per-package override at
+ * <repoRoot>/.nax/mono/<packageDir>/config.json. Returns null when absent.
+ * The `profile` key (if present) is stripped — package profiles are resolved by
+ * loadConfigForWorkdir, not by the runtime registry.
+ */
+export async function loadPackageOverride(
+  repoRoot: string,
+  packageDir: string,
+): Promise<Partial<NaxConfig> | null> {
+  const packageConfigPath = join(repoRoot, PROJECT_NAX_DIR, "mono", packageDir, "config.json");
+  const override = await loadJsonFile<Partial<NaxConfig> & { profile?: string }>(packageConfigPath, "config");
+  if (!override) return null;
+  const { profile: _profile, ...fields } = override;
+  return fields;
+}
+
+/**
  * Load config for a specific working directory (monorepo package).
  *
  * Resolution order:

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -443,10 +443,7 @@ export function _clearRootConfigCache(): void {
  * The `profile` key (if present) is stripped — package profiles are resolved by
  * loadConfigForWorkdir, not by the runtime registry.
  */
-export async function loadPackageOverride(
-  repoRoot: string,
-  packageDir: string,
-): Promise<Partial<NaxConfig> | null> {
+export async function loadPackageOverride(repoRoot: string, packageDir: string): Promise<Partial<NaxConfig> | null> {
   const packageConfigPath = join(repoRoot, PROJECT_NAX_DIR, "mono", packageDir, "config.json");
   const override = await loadJsonFile<Partial<NaxConfig> & { profile?: string }>(packageConfigPath, "config");
   if (!override) return null;

--- a/src/execution/build-plan-for-strategy.ts
+++ b/src/execution/build-plan-for-strategy.ts
@@ -18,7 +18,7 @@
 
 import { join } from "node:path";
 import type { NaxConfig } from "../config";
-import { isThreeSessionStrategy } from "../config";
+import { isThreeSessionStrategy, qualityConfigSelector } from "../config";
 import type { TestStrategy } from "../config/schema-types";
 import type { FixCycleContext } from "../findings/cycle-types";
 import type { FixStrategy } from "../findings/cycle-types";
@@ -150,10 +150,12 @@ export async function buildPlanForStrategy(
 
     const strategies: FixStrategy<Finding, unknown, unknown, unknown>[] = [];
 
-    if (config.quality.commands.lintFix || config.quality.commands.lintFixScoped) {
+    // Use package-merged quality config so per-package lintFix/formatFix overrides are respected.
+    const pkgQuality = ctx.packageView.select(qualityConfigSelector).quality;
+    if (pkgQuality?.commands?.lintFix || pkgQuality?.commands?.lintFixScoped) {
       strategies.push(makeMechanicalLintFixStrategy() as FixStrategy<Finding, unknown, unknown, unknown>);
     }
-    if (config.quality.commands.formatFix || config.quality.commands.formatFixScoped) {
+    if (pkgQuality?.commands?.formatFix || pkgQuality?.commands?.formatFixScoped) {
       strategies.push(makeMechanicalFormatFixStrategy() as FixStrategy<Finding, unknown, unknown, unknown>);
     }
     // Mirror the primary gate condition: TDD always, non-TDD when mode=per-story.

--- a/src/execution/lifecycle/run-setup.ts
+++ b/src/execution/lifecycle/run-setup.ts
@@ -15,6 +15,8 @@
 import * as os from "node:os";
 import path from "node:path";
 import { pipelineEventBus } from "@/pipeline";
+import { discoverWorkspacePackages, resolveTestFilePatterns } from "@/test-runners";
+import { errorMessage } from "@/utils/errors";
 import type { NaxConfig } from "../../config";
 import { globalConfigDir } from "../../config/paths";
 import { LockAcquisitionError, NaxError } from "../../errors";
@@ -30,7 +32,6 @@ import { countStories, loadPRD, savePRD } from "../../prd";
 import { detectProjectProfile } from "../../project";
 import { type NaxRuntime, createRuntime } from "../../runtime";
 import { SessionManager } from "../../session";
-import { resolveTestFilePatterns } from "../../test-runners/resolver";
 import { NAX_BUILD_INFO, NAX_COMMIT, NAX_VERSION } from "../../version";
 import { installCrashHandlers } from "../crash-recovery";
 import { acquireLock, releaseLock } from "../helpers";
@@ -186,6 +187,21 @@ export async function setupRun(options: RunSetupOptions): Promise<RunSetupResult
     featureName: options.feature,
     agentStreamEvents: options.agentStreamEvents,
   });
+
+  // 2b: merge per-package .nax/mono/<pkg>/config.json into the runtime registry so
+  // every packageView consumer (quality gates, smart-runner, context) sees the
+  // package's own commands — not just root config. Failure is non-fatal (root fallback).
+  try {
+    const workspacePackages = await discoverWorkspacePackages(workdir);
+    if (workspacePackages.length > 0) {
+      await runtime.packages.hydrate(workspacePackages);
+    }
+  } catch (err) {
+    getSafeLogger()?.warn("run-setup", "Per-package config hydration failed — using root config", {
+      storyId: "_setup",
+      error: errorMessage(err),
+    });
+  }
 
   // Cleanup stale PIDs from previous crashed runs
   await runtime.pidRegistry.cleanupStale();

--- a/src/operations/full-suite-gate.ts
+++ b/src/operations/full-suite-gate.ts
@@ -108,7 +108,7 @@ export interface FullSuiteGateDeps {
 export const _fullSuiteGateDeps: FullSuiteGateDeps = {
   resolveGateContext: async (input, ctx) => {
     const { resolveQualityTestCommands } = await import("../quality/command-resolver");
-    const config = ctx.runtime.configLoader.current();
+    const config = ctx.packageView.config; // package-merged config (2b), not root
     // Prefer regressionGate.timeoutSeconds (matches legacy RegressionStrategy / issue #1116)
     // and fall back to rectification.fullSuiteTimeoutSeconds for backwards compatibility with
     // callers that still set the older key.
@@ -195,7 +195,7 @@ export const fullSuiteGateOp: DeterministicOperation<
     deps: FullSuiteGateDeps = _fullSuiteGateDeps,
   ): Promise<FullSuiteGateOutput> {
     const logger = getLogger();
-    const ctxConfig = (ctx as unknown as { config?: NaxConfig }).config;
+    const ctxConfig = ctx.packageView.config;
 
     // issue #1116: regressionGate.enabled=false → short-circuit as skipped.
     const enabled = ctxConfig?.execution?.regressionGate?.enabled ?? true;

--- a/src/operations/lint-check.ts
+++ b/src/operations/lint-check.ts
@@ -1,6 +1,7 @@
 import { qualityConfigSelector } from "../config";
 import type { QualityConfig } from "../config/selectors";
 import type { Finding } from "../findings/types";
+import { getSafeLogger } from "../logger";
 import type { QualityCommandOptions, QualityCommandResult } from "../quality/runner";
 import { runQualityCommand } from "../quality/runner";
 import type { LintOutputFormat, LintParseResult } from "../review/lint-parsing";
@@ -38,21 +39,26 @@ export const lintCheckOp: DeterministicOperation<LintCheckInput, LintCheckOutput
     ctx: CallContext,
     deps: LintCheckDeps = _lintCheckDeps,
   ): Promise<LintCheckOutput> {
-    // ctx.config is injected by tests; in production resolved via callOp's config slice
-    const ctxConfig = (ctx as unknown as { config?: QualityConfig }).config;
-    const command = ctxConfig?.quality?.commands?.lint;
+    const quality = ctx.packageView.select(qualityConfigSelector).quality;
+    const command = quality?.commands?.lint;
 
-    if (ctxConfig !== undefined && !command) {
+    // No command configured → skip (success, non-blocking) with a warning.
+    // Never spawn an empty command (that would exit 0 and read as a false pass).
+    if (!command) {
+      getSafeLogger()?.warn("quality", "No lint command configured — skipping lint gate", {
+        storyId: input.storyId,
+        packageDir: ctx.packageView.packageDir,
+      });
       return { success: true, findings: [], durationMs: 0 };
     }
 
     const start = Date.now();
     const result = await deps.runQualityCommand({
       commandName: "lint",
-      command: command ?? "",
+      command,
       workdir: input.workdir,
       storyId: input.storyId,
-      stripEnvVars: ctxConfig?.quality?.stripEnvVars ?? [],
+      stripEnvVars: quality?.stripEnvVars ?? [],
     });
 
     if (result.exitCode === 0) {

--- a/src/operations/mechanical-formatfix-strategy.ts
+++ b/src/operations/mechanical-formatfix-strategy.ts
@@ -57,9 +57,9 @@ const mechanicalFormatFixOp: DeterministicOperation<
     ctx: CallContext,
     deps: MechanicalFormatFixDeps = _mechanicalFormatFixDeps,
   ): Promise<MechanicalFormatFixOutput> {
-    const ctxConfig = (ctx as unknown as { config?: QualityConfig }).config;
-    const broad = ctxConfig?.quality?.commands?.formatFix;
-    const scoped = ctxConfig?.quality?.commands?.formatFixScoped;
+    const quality = ctx.packageView.select(qualityConfigSelector).quality;
+    const broad = quality?.commands?.formatFix;
+    const scoped = quality?.commands?.formatFixScoped;
     const command = buildCommand(broad, scoped, input.scopeFiles);
     if (!command) return { applied: true, exitCode: 0 };
     const result = await deps.runQualityCommand({
@@ -67,7 +67,7 @@ const mechanicalFormatFixOp: DeterministicOperation<
       command,
       workdir: input.workdir,
       storyId: input.storyId,
-      stripEnvVars: ctxConfig?.quality?.stripEnvVars ?? [],
+      stripEnvVars: quality?.stripEnvVars ?? [],
     });
     return { applied: true, exitCode: result.exitCode };
   },

--- a/src/operations/mechanical-lintfix-strategy.ts
+++ b/src/operations/mechanical-lintfix-strategy.ts
@@ -53,9 +53,9 @@ const mechanicalLintFixOp: DeterministicOperation<MechanicalLintFixInput, Mechan
     ctx: CallContext,
     deps: MechanicalLintFixDeps = _mechanicalLintFixDeps,
   ): Promise<MechanicalLintFixOutput> {
-    const ctxConfig = (ctx as unknown as { config?: QualityConfig }).config;
-    const broad = ctxConfig?.quality?.commands?.lintFix;
-    const scoped = ctxConfig?.quality?.commands?.lintFixScoped;
+    const quality = ctx.packageView.select(qualityConfigSelector).quality;
+    const broad = quality?.commands?.lintFix;
+    const scoped = quality?.commands?.lintFixScoped;
     const command = buildCommand(broad, scoped, input.scopeFiles);
     if (!command) return { applied: true, exitCode: 0 };
     const result = await deps.runQualityCommand({
@@ -63,7 +63,7 @@ const mechanicalLintFixOp: DeterministicOperation<MechanicalLintFixInput, Mechan
       command,
       workdir: input.workdir,
       storyId: input.storyId,
-      stripEnvVars: ctxConfig?.quality?.stripEnvVars ?? [],
+      stripEnvVars: quality?.stripEnvVars ?? [],
     });
     return { applied: true, exitCode: result.exitCode };
   },

--- a/src/operations/typecheck-check.ts
+++ b/src/operations/typecheck-check.ts
@@ -1,6 +1,7 @@
 import { qualityConfigSelector } from "../config";
 import type { QualityConfig } from "../config/selectors";
 import type { Finding } from "../findings/types";
+import { getSafeLogger } from "../logger";
 import type { QualityCommandOptions, QualityCommandResult } from "../quality/runner";
 import { runQualityCommand } from "../quality/runner";
 import { parseTypecheckOutput } from "../review/typecheck-parsing";
@@ -42,21 +43,24 @@ export const typecheckCheckOp: DeterministicOperation<TypecheckCheckInput, Typec
     ctx: CallContext,
     deps: TypecheckCheckDeps = _typecheckCheckDeps,
   ): Promise<TypecheckCheckOutput> {
-    // ctx.config is injected by tests; in production resolved via callOp's config slice
-    const ctxConfig = (ctx as unknown as { config?: QualityConfig }).config;
-    const command = ctxConfig?.quality?.commands?.typecheck;
+    const quality = ctx.packageView.select(qualityConfigSelector).quality;
+    const command = quality?.commands?.typecheck;
 
-    if (ctxConfig !== undefined && !command) {
+    if (!command) {
+      getSafeLogger()?.warn("quality", "No typecheck command configured — skipping typecheck gate", {
+        storyId: input.storyId,
+        packageDir: ctx.packageView.packageDir,
+      });
       return { success: true, findings: [], durationMs: 0 };
     }
 
     const start = Date.now();
     const result = await deps.runQualityCommand({
       commandName: "typecheck",
-      command: command ?? "",
+      command,
       workdir: input.workdir,
       storyId: input.storyId,
-      stripEnvVars: ctxConfig?.quality?.stripEnvVars ?? [],
+      stripEnvVars: quality?.stripEnvVars ?? [],
     });
 
     if (result.exitCode === 0) {

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -59,14 +59,18 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     deps: VerifyScopedDeps = _verifyScopedDeps,
   ): Promise<VerifyScopedOutput> {
     const logger = getLogger();
-    const ctxConfig = (ctx as unknown as { config?: QualityConfig }).config;
-    const baseCommand = ctxConfig?.quality?.commands?.test;
+    const quality = ctx.packageView.select(qualityConfigSelector);
+    const baseCommand = quality.quality?.commands?.test;
 
-    // Guard: no config at all, or config present but no test command → no-op.
-    if (!ctxConfig || !baseCommand) {
+    // No test command configured → skip (deferred run-end gate still covers regressions).
+    if (!baseCommand) {
+      logger.warn("quality", "No test command configured — skipping scoped verify", {
+        storyId: input.storyId,
+        packageDir: ctx.packageView.packageDir,
+      });
       return {
         success: true,
-        status: "passed",
+        status: "skipped",
         findings: [],
         durationMs: 0,
         passCount: 0,
@@ -81,13 +85,13 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
       workdir: input.workdir,
       storyId: input.storyId,
       storyGitRef: input.storyGitRef,
-      testCommand: baseCommand ?? "",
-      testScopedTemplate: ctxConfig.quality?.commands?.testScoped,
+      testCommand: baseCommand,
+      testScopedTemplate: quality.quality?.commands?.testScoped,
       // smartTestRunner lives at execution.smartTestRunner; QualityConfig includes execution
       // via qualityConfigSelector = pickSelector("quality", "quality", "execution").
-      smartRunnerConfig: ctxConfig.execution?.smartTestRunner,
-      scopeTestThreshold: ctxConfig.quality?.scopeTestThreshold,
-      fallbackFullSuiteCommand: ctxConfig.quality?.commands?.test,
+      smartRunnerConfig: quality.execution?.smartTestRunner,
+      scopeTestThreshold: quality.quality?.scopeTestThreshold,
+      fallbackFullSuiteCommand: quality.quality?.commands?.test,
       naxIgnoreIndex: input.naxIgnoreIndex,
     });
 
@@ -126,7 +130,7 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     // NOTE: regression() includes a 2s sleep before running tests (src/verification/runners.ts:142-145)
     // for agent-cleanup. The legacy ScopedStrategy also used regression(), so this preserves parity
     // — it is NOT a new perf regression introduced by this port.
-    const scopedTimeout = ctxConfig.execution?.regressionGate?.timeoutSeconds ?? 600;
+    const scopedTimeout = quality.execution?.regressionGate?.timeoutSeconds ?? 600;
     logger.info("verify[scoped]", "Running scoped tests", {
       storyId: input.storyId,
       packageDir: input.packageDir,
@@ -140,17 +144,17 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
       workdir: input.workdir,
       command: selection.effectiveCommand,
       // regressionGate.timeoutSeconds lives in execution; QualityConfig includes execution.
-      timeoutSeconds: ctxConfig.execution?.regressionGate?.timeoutSeconds ?? 600,
+      timeoutSeconds: quality.execution?.regressionGate?.timeoutSeconds ?? 600,
       // acceptOnTimeout is not consumed by runVerificationCore — the runner returns status="TIMEOUT"
       // and the caller (this op) decides accept-on-timeout policy. The op currently does not accept
       // scoped-test timeouts as pass; full-suite gate is the only place that does.
-      forceExit: ctxConfig.quality?.forceExit,
-      detectOpenHandles: ctxConfig.quality?.detectOpenHandles,
-      detectOpenHandlesRetries: ctxConfig.quality?.detectOpenHandlesRetries,
-      gracePeriodMs: ctxConfig.quality?.gracePeriodMs,
-      drainTimeoutMs: ctxConfig.quality?.drainTimeoutMs,
-      shell: ctxConfig.quality?.shell,
-      stripEnvVars: ctxConfig.quality?.stripEnvVars,
+      forceExit: quality.quality?.forceExit,
+      detectOpenHandles: quality.quality?.detectOpenHandles,
+      detectOpenHandlesRetries: quality.quality?.detectOpenHandlesRetries,
+      gracePeriodMs: quality.quality?.gracePeriodMs,
+      drainTimeoutMs: quality.quality?.drainTimeoutMs,
+      shell: quality.quality?.shell,
+      stripEnvVars: quality.quality?.stripEnvVars,
     });
     const durationMs = Date.now() - start;
     const parsed = result.output ? deps.parseTestOutput(result.output) : { passed: 0, failed: 0, failures: [] };

--- a/src/quality/runner.ts
+++ b/src/quality/runner.ts
@@ -82,6 +82,19 @@ function createDrainDeadline(deadlineMs: number): { promise: Promise<string>; ca
  */
 export async function runQualityCommand(opts: QualityCommandOptions): Promise<QualityCommandResult> {
   const { commandName, command, workdir, storyId, timeoutMs = DEFAULT_TIMEOUT_MS, env, stripEnvVars } = opts;
+
+  if (!command || command.trim() === "") {
+    return {
+      commandName,
+      command,
+      success: false,
+      exitCode: -1,
+      output: `[nax] ${commandName} skipped: empty command`,
+      durationMs: 0,
+      timedOut: false,
+    };
+  }
+
   const startTime = Date.now();
   const logger = getSafeLogger();
 

--- a/src/runtime/packages.ts
+++ b/src/runtime/packages.ts
@@ -1,10 +1,7 @@
 import type { ConfigLoader, ConfigSelector, NaxConfig } from "../config";
 import { mergePackageConfig } from "../config";
 
-export type PackageOverrideLoader = (
-  repoRoot: string,
-  packageDir: string,
-) => Promise<Partial<NaxConfig> | null>;
+export type PackageOverrideLoader = (repoRoot: string, packageDir: string) => Promise<Partial<NaxConfig> | null>;
 
 export interface PackageView {
   readonly packageDir: string;
@@ -60,13 +57,8 @@ export function createPackageRegistry(loader: ConfigLoader, repoRoot: string): P
     return view;
   }
 
-  async function hydrate(
-    packageDirs: readonly string[],
-    loadOverride?: PackageOverrideLoader,
-  ): Promise<void> {
-    const load =
-      loadOverride ??
-      (await import("../config")).loadPackageOverride;
+  async function hydrate(packageDirs: readonly string[], loadOverride?: PackageOverrideLoader): Promise<void> {
+    const load = loadOverride ?? (await import("../config")).loadPackageOverride;
 
     for (const dir of packageDirs) {
       if (!dir) {

--- a/src/runtime/packages.ts
+++ b/src/runtime/packages.ts
@@ -1,4 +1,10 @@
 import type { ConfigLoader, ConfigSelector, NaxConfig } from "../config";
+import { mergePackageConfig } from "../config";
+
+export type PackageOverrideLoader = (
+  repoRoot: string,
+  packageDir: string,
+) => Promise<Partial<NaxConfig> | null>;
 
 export interface PackageView {
   readonly packageDir: string;
@@ -11,6 +17,7 @@ export interface PackageRegistry {
   all(): readonly PackageView[];
   resolve(packageDir?: string): PackageView;
   repo(): PackageView;
+  hydrate(packageDirs: readonly string[], loadOverride?: PackageOverrideLoader): Promise<void>;
 }
 
 function createPackageView(config: NaxConfig, packageDir: string, repoRoot: string): PackageView {
@@ -38,6 +45,7 @@ function createPackageView(config: NaxConfig, packageDir: string, repoRoot: stri
 
 export function createPackageRegistry(loader: ConfigLoader, repoRoot: string): PackageRegistry {
   const cache = new Map<string, PackageView>();
+  const mergedConfigs = new Map<string, NaxConfig>();
 
   function resolve(packageDir?: string): PackageView {
     const key = packageDir ?? "";
@@ -45,12 +53,35 @@ export function createPackageRegistry(loader: ConfigLoader, repoRoot: string): P
     if (cached !== undefined) {
       return cached;
     }
-    // Wave 1: no per-package config merging — root config only.
-    // Wave 3 will call mergePackageConfig(root, loadPackageOverride(packageDir)).
-    const config = loader.current();
+    // Use merged config if hydration pre-loaded one for this package; otherwise root config.
+    const config = mergedConfigs.get(key) ?? loader.current();
     const view = createPackageView(config, key, repoRoot);
     cache.set(key, view);
     return view;
+  }
+
+  async function hydrate(
+    packageDirs: readonly string[],
+    loadOverride?: PackageOverrideLoader,
+  ): Promise<void> {
+    const load =
+      loadOverride ??
+      (await import("../config")).loadPackageOverride;
+
+    for (const dir of packageDirs) {
+      if (!dir) {
+        continue;
+      }
+      if (mergedConfigs.has(dir)) {
+        continue;
+      }
+      const override = await load(repoRoot, dir);
+      if (override !== null) {
+        mergedConfigs.set(dir, mergePackageConfig(loader.current(), override));
+        // Invalidate any stale root-config view so the next resolve() picks up the merge.
+        cache.delete(dir);
+      }
+    }
   }
 
   return {
@@ -61,5 +92,6 @@ export function createPackageRegistry(loader: ConfigLoader, repoRoot: string): P
     repo() {
       return resolve(undefined);
     },
+    hydrate,
   };
 }

--- a/src/runtime/packages.ts
+++ b/src/runtime/packages.ts
@@ -49,7 +49,7 @@ export function createPackageRegistry(loader: ConfigLoader, repoRoot: string): P
   // Pipeline stages pass absolute workdirs; without this, mergedConfigs.get() always misses.
   function toRelativeKey(packageDir: string | undefined): string {
     if (!packageDir) return "";
-    const prefix = repoRoot.endsWith("/") ? repoRoot : repoRoot + "/";
+    const prefix = repoRoot.endsWith("/") ? repoRoot : `${repoRoot}/`;
     if (packageDir.startsWith(prefix)) return packageDir.slice(prefix.length);
     if (packageDir === repoRoot) return "";
     return packageDir;

--- a/src/runtime/packages.ts
+++ b/src/runtime/packages.ts
@@ -44,8 +44,19 @@ export function createPackageRegistry(loader: ConfigLoader, repoRoot: string): P
   const cache = new Map<string, PackageView>();
   const mergedConfigs = new Map<string, NaxConfig>();
 
+  // Normalize to relative so cache and mergedConfigs keys are consistent with
+  // what hydrate() stores (discoverWorkspacePackages returns relative paths).
+  // Pipeline stages pass absolute workdirs; without this, mergedConfigs.get() always misses.
+  function toRelativeKey(packageDir: string | undefined): string {
+    if (!packageDir) return "";
+    const prefix = repoRoot.endsWith("/") ? repoRoot : repoRoot + "/";
+    if (packageDir.startsWith(prefix)) return packageDir.slice(prefix.length);
+    if (packageDir === repoRoot) return "";
+    return packageDir;
+  }
+
   function resolve(packageDir?: string): PackageView {
-    const key = packageDir ?? "";
+    const key = toRelativeKey(packageDir);
     const cached = cache.get(key);
     if (cached !== undefined) {
       return cached;

--- a/src/test-runners/index.ts
+++ b/src/test-runners/index.ts
@@ -33,6 +33,7 @@ export {
 } from "./resolver";
 export type { ResolvedTestPatterns } from "./resolver";
 export { analyzeTestExitCode, formatFailureSummary, parseBunTestOutput, parseTestOutput } from "./parser";
+export { discoverWorkspacePackages } from "./detect/workspace";
 export { parseTestFailures } from "./ac-parser";
 export type { TestFailure, TestOutputAnalysis, TestSummary } from "./types";
 export {

--- a/test/integration/pipeline/gating-preservation.test.ts
+++ b/test/integration/pipeline/gating-preservation.test.ts
@@ -554,7 +554,16 @@ describe("AC7: full-path regression scenarios under unified path", () => {
     const origRunFixCycle = _storyOrchestratorDeps.runFixCycle;
     const origCallOp = _storyOrchestratorDeps.callOp;
     const origCaptureGitRef = _storyOrchestratorDeps.captureGitRef;
-    const runtime = makeTestRuntime();
+    // Build config first so the runtime's packageView reflects lintFix —
+    // buildPlanForStrategy now reads ctx.packageView instead of the config param.
+    const config = makeNaxConfig({
+      quality: {
+        commands: { lintFix: "bun run lint:fix" },
+        autofix: { enabled: false },
+      },
+      execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
+    });
+    const runtime = makeTestRuntime({ config });
 
     try {
       _storyOrchestratorDeps.captureGitRef = mock(async () => "HEAD");
@@ -562,13 +571,6 @@ describe("AC7: full-path regression scenarios under unified path", () => {
       _storyOrchestratorDeps.runFixCycle = makeRunFixCycleMock(capturedNames);
 
       const story = makeStory({ attempts: 1 });
-      const config = makeNaxConfig({
-        quality: {
-          commands: { lintFix: "bun run lint:fix" },
-          autofix: { enabled: false },
-        },
-        execution: { rectification: { enabled: true, maxAttemptsTotal: 2 } },
-      });
       const ctx = makeMockCallContext({ runtime });
       const inputs = makeMockPlanInputs({
         story,

--- a/test/integration/pipeline/gating-preservation.test.ts
+++ b/test/integration/pipeline/gating-preservation.test.ts
@@ -429,7 +429,7 @@ describe("single-session adversarial-review routing", () => {
 describe("AC6: mechanical fix fixOp.execute returns early when both commands undefined", () => {
   test("makeMechanicalLintFixStrategy: returns {applied:true, exitCode:0} without calling runQualityCommand", async () => {
     const config = makeNaxConfig({ quality: { commands: {} } });
-    const mockCtx = { config } as unknown as CallContext;
+    const mockCtx = { packageView: { packageDir: "", config, select: (s: any) => s.select(config) } } as unknown as CallContext;
     let called = false;
     const mockDeps = {
       runQualityCommand: async () => {
@@ -449,7 +449,7 @@ describe("AC6: mechanical fix fixOp.execute returns early when both commands und
 
   test("makeMechanicalFormatFixStrategy: returns {applied:true, exitCode:0} without calling runQualityCommand", async () => {
     const config = makeNaxConfig({ quality: { commands: {} } });
-    const mockCtx = { config } as unknown as CallContext;
+    const mockCtx = { packageView: { packageDir: "", config, select: (s: any) => s.select(config) } } as unknown as CallContext;
     let called = false;
     const mockDeps = {
       runQualityCommand: async () => {

--- a/test/unit/config/load-package-override.test.ts
+++ b/test/unit/config/load-package-override.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { loadPackageOverride } from "@/config";
-import { makeTempDir, cleanupTempDir } from "@test/helpers/temp";
+import { makeTempDir, cleanupTempDir } from "@test/helpers";
 import { join } from "node:path";
 
 // NOTE: makeTempDir/cleanupTempDir are SYNCHRONOUS — do NOT await them.

--- a/test/unit/config/load-package-override.test.ts
+++ b/test/unit/config/load-package-override.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { loadPackageOverride } from "@/config";
+import { makeTempDir, cleanupTempDir } from "@test/helpers/temp";
+import { join } from "node:path";
+
+// NOTE: makeTempDir/cleanupTempDir are SYNCHRONOUS — do NOT await them.
+let tmp: string | undefined;
+afterEach(() => { cleanupTempDir(tmp); tmp = undefined; });
+
+describe("loadPackageOverride", () => {
+  test("returns the parsed mono config.json for a package", async () => {
+    tmp = makeTempDir("lpo");
+    const dir = join(tmp, ".nax", "mono", "packages", "agent");
+    await Bun.write(join(dir, "config.json"), JSON.stringify({ quality: { commands: { lint: "ruff check packages/agent" } } }));
+    const override = await loadPackageOverride(tmp, "packages/agent");
+    expect(override?.quality?.commands?.lint).toBe("ruff check packages/agent");
+  });
+
+  test("returns null when no per-package config exists", async () => {
+    tmp = makeTempDir("lpo");
+    expect(await loadPackageOverride(tmp, "packages/missing")).toBeNull();
+  });
+});

--- a/test/unit/operations/full-suite-gate.test.ts
+++ b/test/unit/operations/full-suite-gate.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { fullSuiteGateOp, _fullSuiteGateDeps } from "@/operations";
 
-const mockCtx = { runtime: {}, storyId: "US-001" } as any;
+function ctxWithConfig(config: any = {}) {
+  return {
+    runtime: {},
+    storyId: "US-001",
+    packageView: { packageDir: "", config, select: (s: any) => s.select(config) },
+  } as any;
+}
+const mockCtx = ctxWithConfig({});
 
 function makeDeps(overrides = {}) {
   return {
@@ -139,12 +146,10 @@ describe("fullSuiteGateOp — test execution logic (US-006)", () => {
 
 describe("fullSuiteGateOp — ported RegressionStrategy behavior (issue #1116)", () => {
   test("regressionGate.enabled=false → status=skipped, success=true", async () => {
-    const ctx = {
-      config: {
-        execution: { regressionGate: { enabled: false } },
-        quality: { commands: { test: "bun test" } },
-      },
-    } as any;
+    const ctx = ctxWithConfig({
+      execution: { regressionGate: { enabled: false } },
+      quality: { commands: { test: "bun test" } },
+    });
     const result = await fullSuiteGateOp.execute(
       { story: { id: "S-1" } as any, workdir: "/r" },
       ctx,
@@ -157,12 +162,10 @@ describe("fullSuiteGateOp — ported RegressionStrategy behavior (issue #1116)",
   });
 
   test("TIMEOUT + acceptOnTimeout=true → status=passed-on-timeout, success=true", async () => {
-    const ctx = {
-      config: {
-        execution: { regressionGate: { acceptOnTimeout: true } },
-        quality: { commands: { test: "bun test" } },
-      },
-    } as any;
+    const ctx = ctxWithConfig({
+      execution: { regressionGate: { acceptOnTimeout: true } },
+      quality: { commands: { test: "bun test" } },
+    });
     const result = await fullSuiteGateOp.execute(
       { story: { id: "S-1" } as any, workdir: "/r" },
       ctx,
@@ -182,12 +185,10 @@ describe("fullSuiteGateOp — ported RegressionStrategy behavior (issue #1116)",
   });
 
   test("TIMEOUT + acceptOnTimeout=false → status=timeout, success=false", async () => {
-    const ctx = {
-      config: {
-        execution: { regressionGate: { acceptOnTimeout: false } },
-        quality: { commands: { test: "bun test" } },
-      },
-    } as any;
+    const ctx = ctxWithConfig({
+      execution: { regressionGate: { acceptOnTimeout: false } },
+      quality: { commands: { test: "bun test" } },
+    });
     const result = await fullSuiteGateOp.execute(
       { story: { id: "S-1" } as any, workdir: "/r" },
       ctx,
@@ -208,9 +209,7 @@ describe("fullSuiteGateOp — ported RegressionStrategy behavior (issue #1116)",
 
   test("TIMEOUT with no acceptOnTimeout config → defaults to true (BUG-026 default preserved)", async () => {
     // Default is acceptOnTimeout=true when not configured
-    const ctx = {
-      config: { execution: {}, quality: { commands: { test: "bun test" } } },
-    } as any;
+    const ctx = ctxWithConfig({ execution: {}, quality: { commands: { test: "bun test" } } });
     const result = await fullSuiteGateOp.execute(
       { story: { id: "S-1" } as any, workdir: "/r" },
       ctx,

--- a/test/unit/operations/lint-check.test.ts
+++ b/test/unit/operations/lint-check.test.ts
@@ -3,7 +3,14 @@ import { lintCheckOp } from "@/operations";
 import type { LintCheckDeps } from "@/operations";
 import type { Finding } from "@/findings";
 
-const mockCtx = { runtime: {}, storyId: "US-003" } as any;
+function ctxWithQuality(quality?: Record<string, unknown>) {
+  const config = { quality, execution: {} } as any;
+  return {
+    runtime: {},
+    storyId: "US-003",
+    packageView: { packageDir: "packages/agent", config, select: (sel: any) => sel.select(config) },
+  } as any;
+}
 
 const passedResult = {
   commandName: "lint",
@@ -62,7 +69,7 @@ describe("lintCheckOp — AC3: execute returns success=true when command exits 0
   test("AC3: returns success=true and findings=[] when lint command exits 0", async () => {
     const out = await lintCheckOp.execute(
       { workdir: "/tmp", storyId: "US-003" },
-      mockCtx,
+      ctxWithQuality({ commands: { lint: "bun run lint" } }),
       makeDeps({ runQualityCommand: async () => passedResult }),
     );
     expect(out.success).toBe(true);
@@ -72,7 +79,7 @@ describe("lintCheckOp — AC3: execute returns success=true when command exits 0
   test("AC3: returns success=false and non-empty findings when lint command exits non-zero", async () => {
     const out = await lintCheckOp.execute(
       { workdir: "/tmp", storyId: "US-003" },
-      mockCtx,
+      ctxWithQuality({ commands: { lint: "bun run lint" } }),
       makeDeps({
         runQualityCommand: async () => failedResult,
         parseLintOutput: () => ({
@@ -89,7 +96,7 @@ describe("lintCheckOp — AC3: execute returns success=true when command exits 0
   test("AC3: every finding has source='lint' when command exits non-zero", async () => {
     const out = await lintCheckOp.execute(
       { workdir: "/tmp", storyId: "US-003" },
-      mockCtx,
+      ctxWithQuality({ commands: { lint: "bun run lint" } }),
       makeDeps({
         runQualityCommand: async () => failedResult,
         parseLintOutput: () => ({
@@ -103,53 +110,30 @@ describe("lintCheckOp — AC3: execute returns success=true when command exits 0
   });
 });
 
-describe("lintCheckOp — AC6: no-command early return", () => {
-  test("AC6: returns success=true, findings=[], durationMs=0 when lint command is undefined", async () => {
-    let runQualityCalled = false;
-    const deps = makeDeps({
-      runQualityCommand: async () => {
-        runQualityCalled = true;
-        return passedResult;
-      },
-    });
-
-    const ctxWithNoLintCommand = {
-      ...mockCtx,
-      config: { quality: { commands: { lint: undefined } } },
-    };
-
+describe("lintCheckOp — AC6: skip-with-warning when no lint command configured", () => {
+  test("skips with success+warning when no lint command is configured (no false command)", async () => {
+    let called = false;
+    const deps = makeDeps({ runQualityCommand: async () => { called = true; return passedResult; } });
     const out = await lintCheckOp.execute(
-      { workdir: "/tmp", storyId: "US-003" },
-      ctxWithNoLintCommand,
+      { workdir: "/w", storyId: "US-003" },
+      ctxWithQuality({ commands: {} }),
       deps,
     );
+    expect(called).toBe(false);
     expect(out.success).toBe(true);
     expect(out.findings).toEqual([]);
-    expect(out.durationMs).toBe(0);
-    expect(runQualityCalled).toBe(false);
   });
 });
 
 describe("lintCheckOp — AC10: per-package config override", () => {
-  test("AC10: uses the command from the config slice (not hardcoded)", async () => {
-    let capturedCommand: string | undefined;
-    const deps = makeDeps({
-      runQualityCommand: async (opts) => {
-        capturedCommand = opts.command;
-        return passedResult;
-      },
-    });
-
-    const ctxWithOverride = {
-      ...mockCtx,
-      config: { quality: { commands: { lint: "custom-lint-command" } } },
-    };
-
+  test("runs the lint command resolved from packageView", async () => {
+    let seen = "";
+    const deps = makeDeps({ runQualityCommand: async (o) => { seen = o.command; return passedResult; } });
     await lintCheckOp.execute(
-      { workdir: "/tmp", storyId: "US-003" },
-      ctxWithOverride,
+      { workdir: "/w", storyId: "US-003" },
+      ctxWithQuality({ commands: { lint: "ruff check packages/agent" } }),
       deps,
     );
-    expect(capturedCommand).toBe("custom-lint-command");
+    expect(seen).toBe("ruff check packages/agent");
   });
 });

--- a/test/unit/operations/mechanical-formatfix-strategy.test.ts
+++ b/test/unit/operations/mechanical-formatfix-strategy.test.ts
@@ -6,6 +6,15 @@ import type { QualityCommandOptions } from "@/quality";
 
 const mockCtx = { runtime: {}, storyId: "US-004" } as any;
 
+function ctxWithQuality(quality?: Record<string, unknown>) {
+  const config = { quality, execution: {} } as any;
+  return {
+    runtime: {},
+    storyId: "US-004",
+    packageView: { packageDir: "packages/agent", config, select: (s: any) => s.select(config) },
+  } as any;
+}
+
 const passedResult = {
   commandName: "formatFix",
   command: "bun run format:fix",
@@ -75,10 +84,7 @@ describe("makeMechanicalFormatFixStrategy — appliesTo predicate", () => {
 describe("makeMechanicalFormatFixStrategy — execute invokes runQualityCommand", () => {
   test("calls runQualityCommand with commandName=formatFix when formatFix is configured", async () => {
     const strategy = makeMechanicalFormatFixStrategy();
-    const ctxWithFormatFix = {
-      ...mockCtx,
-      config: { quality: { commands: { formatFix: "bun run format:fix" } } },
-    };
+    const ctxWithFormatFix = ctxWithQuality({ commands: { formatFix: "bun run format:fix" } });
 
     let capturedCommandName: string | undefined;
     let capturedCommand: string | undefined;
@@ -98,10 +104,7 @@ describe("makeMechanicalFormatFixStrategy — execute invokes runQualityCommand"
 
   test("uses scoped template with substituted files when formatFixScoped is configured", async () => {
     const strategy = makeMechanicalFormatFixStrategy();
-    const ctxWithScopedFormatFix = {
-      ...mockCtx,
-      config: { quality: { commands: { formatFixScoped: "biome format --write {{files}}" } } },
-    };
+    const ctxWithScopedFormatFix = ctxWithQuality({ commands: { formatFixScoped: "biome format --write {{files}}" } });
 
     let capturedCommand: string | undefined;
     const deps = makeDeps({
@@ -124,10 +127,7 @@ describe("makeMechanicalFormatFixStrategy — execute invokes runQualityCommand"
 describe("makeMechanicalFormatFixStrategy — AC6: no-command early return", () => {
   test("AC6: returns { applied: true, exitCode: 0 } without calling runQualityCommand when formatFix is undefined", async () => {
     const strategy = makeMechanicalFormatFixStrategy();
-    const ctxWithNoFormatFix = {
-      ...mockCtx,
-      config: { quality: { commands: { formatFix: undefined } } },
-    };
+    const ctxWithNoFormatFix = ctxWithQuality({ commands: { formatFix: undefined } });
 
     let runQualityCalled = false;
     const deps = makeDeps({
@@ -150,10 +150,7 @@ describe("makeMechanicalFormatFixStrategy — AC6: no-command early return", () 
 
   test("AC6: returns { applied: true, exitCode: 0 } without calling runQualityCommand when config has no formatFix key", async () => {
     const strategy = makeMechanicalFormatFixStrategy();
-    const ctxWithNoCommands = {
-      ...mockCtx,
-      config: { quality: { commands: {} } },
-    };
+    const ctxWithNoCommands = ctxWithQuality({ commands: {} });
 
     let runQualityCalled = false;
     const deps = makeDeps({

--- a/test/unit/operations/mechanical-formatfix-strategy.test.ts
+++ b/test/unit/operations/mechanical-formatfix-strategy.test.ts
@@ -4,8 +4,6 @@ import { _mechanicalFormatFixDeps, makeMechanicalFormatFixStrategy } from "@/ope
 import type { MechanicalFormatFixDeps } from "@/operations";
 import type { QualityCommandOptions } from "@/quality";
 
-const mockCtx = { runtime: {}, storyId: "US-004" } as any;
-
 function ctxWithQuality(quality?: Record<string, unknown>) {
   const config = { quality, execution: {} } as any;
   return {

--- a/test/unit/operations/mechanical-lintfix-strategy.test.ts
+++ b/test/unit/operations/mechanical-lintfix-strategy.test.ts
@@ -4,8 +4,6 @@ import { _mechanicalLintFixDeps, makeMechanicalLintFixStrategy } from "@/operati
 import type { MechanicalLintFixDeps } from "@/operations";
 import type { QualityCommandOptions } from "@/quality";
 
-const mockCtx = { runtime: {}, storyId: "US-004" } as any;
-
 function ctxWithQuality(quality?: Record<string, unknown>) {
   const config = { quality, execution: {} } as any;
   return {

--- a/test/unit/operations/mechanical-lintfix-strategy.test.ts
+++ b/test/unit/operations/mechanical-lintfix-strategy.test.ts
@@ -6,6 +6,15 @@ import type { QualityCommandOptions } from "@/quality";
 
 const mockCtx = { runtime: {}, storyId: "US-004" } as any;
 
+function ctxWithQuality(quality?: Record<string, unknown>) {
+  const config = { quality, execution: {} } as any;
+  return {
+    runtime: {},
+    storyId: "US-004",
+    packageView: { packageDir: "packages/agent", config, select: (s: any) => s.select(config) },
+  } as any;
+}
+
 const passedResult = {
   commandName: "lintFix",
   command: "bun run lint:fix",
@@ -80,10 +89,7 @@ describe("makeMechanicalLintFixStrategy — AC7: appliesTo predicate", () => {
 describe("makeMechanicalLintFixStrategy — AC5: execute invokes runQualityCommand", () => {
   test("AC5: calls runQualityCommand with commandName=lintFix when lintFix is configured", async () => {
     const strategy = makeMechanicalLintFixStrategy();
-    const ctxWithLintFix = {
-      ...mockCtx,
-      config: { quality: { commands: { lintFix: "bun run lint:fix" } } },
-    };
+    const ctxWithLintFix = ctxWithQuality({ commands: { lintFix: "bun run lint:fix" } });
 
     let capturedCommandName: string | undefined;
     let capturedCommand: string | undefined;
@@ -103,10 +109,7 @@ describe("makeMechanicalLintFixStrategy — AC5: execute invokes runQualityComma
 
   test("AC5: returns { applied: true, exitCode } from the quality command result", async () => {
     const strategy = makeMechanicalLintFixStrategy();
-    const ctxWithLintFix = {
-      ...mockCtx,
-      config: { quality: { commands: { lintFix: "bun run lint:fix" } } },
-    };
+    const ctxWithLintFix = ctxWithQuality({ commands: { lintFix: "bun run lint:fix" } });
     const deps = makeDeps({
       runQualityCommand: async () => ({ ...passedResult, exitCode: 0 }),
     });
@@ -122,10 +125,7 @@ describe("makeMechanicalLintFixStrategy — AC5: execute invokes runQualityComma
 
   test("AC5: scoped template uses {{files}} substitution when scopeFiles are present", async () => {
     const strategy = makeMechanicalLintFixStrategy();
-    const ctxWithScopedLintFix = {
-      ...mockCtx,
-      config: { quality: { commands: { lintFixScoped: "biome check --write {{files}}" } } },
-    };
+    const ctxWithScopedLintFix = ctxWithQuality({ commands: { lintFixScoped: "biome check --write {{files}}" } });
 
     let capturedCommand: string | undefined;
     const deps = makeDeps({
@@ -146,10 +146,7 @@ describe("makeMechanicalLintFixStrategy — AC5: execute invokes runQualityComma
 
   test("AC5: scoped-only config without scopeFiles returns early instead of executing raw template", async () => {
     const strategy = makeMechanicalLintFixStrategy();
-    const ctxWithScopedLintFix = {
-      ...mockCtx,
-      config: { quality: { commands: { lintFixScoped: "biome check --write {{files}}" } } },
-    };
+    const ctxWithScopedLintFix = ctxWithQuality({ commands: { lintFixScoped: "biome check --write {{files}}" } });
 
     let runQualityCalled = false;
     const deps = makeDeps({
@@ -173,10 +170,7 @@ describe("makeMechanicalLintFixStrategy — AC5: execute invokes runQualityComma
 describe("makeMechanicalLintFixStrategy — AC6: no-command early return", () => {
   test("AC6: returns { applied: true, exitCode: 0 } without calling runQualityCommand when lintFix is undefined", async () => {
     const strategy = makeMechanicalLintFixStrategy();
-    const ctxWithNoLintFix = {
-      ...mockCtx,
-      config: { quality: { commands: { lintFix: undefined } } },
-    };
+    const ctxWithNoLintFix = ctxWithQuality({ commands: { lintFix: undefined } });
 
     let runQualityCalled = false;
     const deps = makeDeps({
@@ -199,10 +193,7 @@ describe("makeMechanicalLintFixStrategy — AC6: no-command early return", () =>
 
   test("AC6: returns { applied: true, exitCode: 0 } without calling runQualityCommand when config has no lintFix key", async () => {
     const strategy = makeMechanicalLintFixStrategy();
-    const ctxWithNoCommands = {
-      ...mockCtx,
-      config: { quality: { commands: {} } },
-    };
+    const ctxWithNoCommands = ctxWithQuality({ commands: {} });
 
     let runQualityCalled = false;
     const deps = makeDeps({

--- a/test/unit/operations/quality-gate-packageview.test.ts
+++ b/test/unit/operations/quality-gate-packageview.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { typecheckCheckOp } from "@/operations";
+import { typecheckCheckOp, verifyScopedOp, _verifyScopedDeps } from "@/operations";
 
 function ctxWithQuality(quality?: Record<string, unknown>) {
   const config = { quality, execution: {} } as any;
@@ -33,5 +33,28 @@ describe("typecheckCheckOp via packageView", () => {
     const out = await typecheckCheckOp.execute({ workdir: "/w", storyId: "US-003" }, ctxWithQuality({ commands: {} }), deps);
     expect(called).toBe(false);
     expect(out.success).toBe(true);
+  });
+});
+
+describe("verifyScopedOp via packageView", () => {
+  test("reads quality.commands.test from packageView (not phantom ctx.config)", async () => {
+    let sawTestCommand: string | undefined;
+    const deps = {
+      ..._verifyScopedDeps,
+      selectScopedTests: async (o: any) => {
+        sawTestCommand = o.testCommand;
+        return { isFullSuite: true, isMonorepoOrchestrator: false, thresholdFallback: false, files: [], command: o.testCommand, effectiveCommand: o.testCommand, scopeTestFallback: false };
+      },
+      regression: async () => ({ success: true, status: "PASS" as any, output: "", exitCode: 0, durationMs: 0 }),
+      parseTestOutput: () => ({ passed: 1, failed: 0, failures: [] }),
+      testSummaryToFindings: () => [],
+    } as any;
+
+    await verifyScopedOp.execute(
+      { workdir: "/w", storyId: "US-003", regressionMode: "per-story" } as any,
+      ctxWithQuality({ commands: { test: "pytest packages/agent/tests" } }),
+      deps,
+    );
+    expect(sawTestCommand).toBe("pytest packages/agent/tests");
   });
 });

--- a/test/unit/operations/quality-gate-packageview.test.ts
+++ b/test/unit/operations/quality-gate-packageview.test.ts
@@ -58,3 +58,22 @@ describe("verifyScopedOp via packageView", () => {
     expect(sawTestCommand).toBe("pytest packages/agent/tests");
   });
 });
+
+import { _fullSuiteGateDeps } from "@/operations";
+
+describe("fullSuiteGateOp uses package config", () => {
+  test("resolveGateContext resolves the PACKAGE test command, not root", async () => {
+    const packageConfig = { quality: { commands: { test: "pytest packages/agent/tests" } }, execution: {} } as any;
+    const rootConfig = { quality: { commands: { test: "pytest" } }, execution: {} } as any;
+    const ctx = {
+      runtime: { configLoader: { current: () => rootConfig } },
+      storyId: "US-003",
+      packageView: { packageDir: "packages/agent", config: packageConfig, select: (s: any) => s.select(packageConfig) },
+    } as any;
+    const gateCtx = await _fullSuiteGateDeps.resolveGateContext(
+      { workdir: "/w", story: { id: "US-003", workdir: "packages/agent" } } as any,
+      ctx,
+    );
+    expect(gateCtx.testCmd).toBe("pytest packages/agent/tests");
+  });
+});

--- a/test/unit/operations/quality-gate-packageview.test.ts
+++ b/test/unit/operations/quality-gate-packageview.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { typecheckCheckOp } from "@/operations";
+
+function ctxWithQuality(quality?: Record<string, unknown>) {
+  const config = { quality, execution: {} } as any;
+  return {
+    runtime: {},
+    storyId: "US-003",
+    packageView: { packageDir: "packages/agent", config, select: (s: any) => s.select(config) },
+  } as any;
+}
+
+describe("typecheckCheckOp via packageView", () => {
+  test("runs the typecheck command from packageView", async () => {
+    let seen = "";
+    const deps = {
+      runQualityCommand: async (o: any) => {
+        seen = o.command;
+        return { commandName: "typecheck", command: o.command, success: true, exitCode: 0, output: "", durationMs: 1, timedOut: false };
+      },
+      parseTypecheckOutput: () => null,
+    } as any;
+    await typecheckCheckOp.execute({ workdir: "/w", storyId: "US-003" }, ctxWithQuality({ commands: { typecheck: "mypy packages/agent/src" } }), deps);
+    expect(seen).toBe("mypy packages/agent/src");
+  });
+
+  test("skips with success when no typecheck command configured", async () => {
+    let called = false;
+    const deps = {
+      runQualityCommand: async () => { called = true; return {} as any; },
+      parseTypecheckOutput: () => null,
+    } as any;
+    const out = await typecheckCheckOp.execute({ workdir: "/w", storyId: "US-003" }, ctxWithQuality({ commands: {} }), deps);
+    expect(called).toBe(false);
+    expect(out.success).toBe(true);
+  });
+});

--- a/test/unit/operations/typecheck-check.test.ts
+++ b/test/unit/operations/typecheck-check.test.ts
@@ -3,7 +3,14 @@ import { typecheckCheckOp } from "@/operations";
 import type { TypecheckCheckDeps } from "@/operations";
 import type { Finding } from "@/findings";
 
-const mockCtx = { runtime: {}, storyId: "US-003" } as any;
+function ctxWithQuality(quality?: Record<string, unknown>) {
+  const config = { quality, execution: {} } as any;
+  return {
+    runtime: {},
+    storyId: "US-003",
+    packageView: { packageDir: "packages/agent", config, select: (sel: any) => sel.select(config) },
+  } as any;
+}
 
 const passedResult = {
   commandName: "typecheck",
@@ -62,7 +69,7 @@ describe("typecheckCheckOp — AC4: execute returns success=true when command ex
   test("AC4: returns success=true and findings=[] when typecheck command exits 0", async () => {
     const out = await typecheckCheckOp.execute(
       { workdir: "/tmp", storyId: "US-003" },
-      mockCtx,
+      ctxWithQuality({ commands: { typecheck: "bun run typecheck" } }),
       makeDeps({ runQualityCommand: async () => passedResult }),
     );
     expect(out.success).toBe(true);
@@ -72,7 +79,7 @@ describe("typecheckCheckOp — AC4: execute returns success=true when command ex
   test("AC4: returns success=false and non-empty findings when typecheck command exits non-zero", async () => {
     const out = await typecheckCheckOp.execute(
       { workdir: "/tmp", storyId: "US-003" },
-      mockCtx,
+      ctxWithQuality({ commands: { typecheck: "bun run typecheck" } }),
       makeDeps({
         runQualityCommand: async () => failedResult,
         parseTypecheckOutput: () => ({
@@ -89,7 +96,7 @@ describe("typecheckCheckOp — AC4: execute returns success=true when command ex
   test("AC4: every finding has source='typecheck' when command exits non-zero", async () => {
     const out = await typecheckCheckOp.execute(
       { workdir: "/tmp", storyId: "US-003" },
-      mockCtx,
+      ctxWithQuality({ commands: { typecheck: "bun run typecheck" } }),
       makeDeps({
         runQualityCommand: async () => failedResult,
         parseTypecheckOutput: () => ({
@@ -113,14 +120,9 @@ describe("typecheckCheckOp — AC6: no-command early return", () => {
       },
     });
 
-    const ctxWithNoCommand = {
-      ...mockCtx,
-      config: { quality: { commands: { typecheck: undefined } } },
-    };
-
     const out = await typecheckCheckOp.execute(
       { workdir: "/tmp", storyId: "US-003" },
-      ctxWithNoCommand,
+      ctxWithQuality({ commands: {} }),
       deps,
     );
     expect(out.success).toBe(true);

--- a/test/unit/operations/verify-scoped.test.ts
+++ b/test/unit/operations/verify-scoped.test.ts
@@ -3,7 +3,14 @@ import { verifyScopedOp, _verifyScopedDeps } from "@/operations";
 import type { VerifyScopedDeps } from "@/operations";
 import type { Finding } from "@/findings";
 
-const mockCtx = { runtime: {}, storyId: "US-003" } as any;
+function ctxWithQuality(quality?: Record<string, unknown>) {
+  const config = { quality, execution: {} } as any;
+  return {
+    runtime: {},
+    storyId: "US-003",
+    packageView: { packageDir: "packages/agent", config, select: (s: any) => s.select(config) },
+  } as any;
+}
 
 const mockFinding: Finding = {
   source: "test-runner",
@@ -58,7 +65,7 @@ describe("verifyScopedOp — AC5: execute returns success=true when test command
   test("AC5: returns success=true and findings=[] when test command exits 0", async () => {
     const out = await verifyScopedOp.execute(
       { workdir: "/tmp", storyId: "US-003", regressionMode: "per-story" },
-      { ...mockCtx, config: { quality: { commands: { test: "bun test" } } } },
+      ctxWithQuality({ commands: { test: "bun test" } }),
       fakeDeps(),
     );
     expect(out.success).toBe(true);
@@ -71,7 +78,7 @@ describe("verifyScopedOp — AC5: execute returns success=true when test command
   test("AC5: returns success=false and non-empty findings when test command exits non-zero", async () => {
     const out = await verifyScopedOp.execute(
       { workdir: "/tmp", storyId: "US-003", regressionMode: "per-story" },
-      { ...mockCtx, config: { quality: { commands: { test: "bun test" } } } },
+      ctxWithQuality({ commands: { test: "bun test" } }),
       fakeDeps({
         regression: async () => ({
           status: "TEST_FAILURE" as const,
@@ -95,7 +102,7 @@ describe("verifyScopedOp — AC5: execute returns success=true when test command
   test("AC5: every finding has source='test-runner' when test command exits non-zero", async () => {
     const out = await verifyScopedOp.execute(
       { workdir: "/tmp", storyId: "US-003", regressionMode: "per-story" },
-      { ...mockCtx, config: { quality: { commands: { test: "bun test" } } } },
+      ctxWithQuality({ commands: { test: "bun test" } }),
       fakeDeps({
         regression: async () => ({
           status: "TEST_FAILURE" as const,
@@ -125,14 +132,9 @@ describe("verifyScopedOp — AC6: no-command early return", () => {
       },
     });
 
-    const ctxWithNoCommand = {
-      ...mockCtx,
-      config: { quality: { commands: { test: undefined } } },
-    };
-
     const out = await verifyScopedOp.execute(
       { workdir: "/tmp", storyId: "US-003" },
-      ctxWithNoCommand,
+      ctxWithQuality({ commands: {} }),
       deps,
     );
     expect(out.success).toBe(true);
@@ -145,7 +147,7 @@ describe("verifyScopedOp — AC6: no-command early return", () => {
 describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
   test("deferred mode + no mapped tests + not monorepo → skipped", async () => {
     const deps = fakeDeps();
-    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const ctx = ctxWithQuality({ commands: { test: "bun test" } });
     const result = await verifyScopedOp.execute(
       { workdir: "/r", storyId: "S-1", regressionMode: "deferred" },
       ctx,
@@ -157,7 +159,7 @@ describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
 
   test("per-story mode + no mapped tests → runs full suite (not skipped)", async () => {
     const deps = fakeDeps();
-    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const ctx = ctxWithQuality({ commands: { test: "bun test" } });
     const result = await verifyScopedOp.execute(
       { workdir: "/r", storyId: "S-1", regressionMode: "per-story" },
       ctx,
@@ -176,7 +178,7 @@ describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
         isMonorepoOrchestrator: true,
       }),
     });
-    const ctx = { config: { quality: { commands: { test: "turbo run test" } } } } as any;
+    const ctx = ctxWithQuality({ commands: { test: "turbo run test" } });
     const result = await verifyScopedOp.execute(
       { workdir: "/r", storyId: "S-1", regressionMode: "deferred" },
       ctx,
@@ -195,7 +197,7 @@ describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
         isMonorepoOrchestrator: false,
       }),
     });
-    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const ctx = ctxWithQuality({ commands: { test: "bun test" } });
     const result = await verifyScopedOp.execute(
       { workdir: "/r", storyId: "S-1", regressionMode: "deferred" },
       ctx,
@@ -214,7 +216,7 @@ describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
         isMonorepoOrchestrator: false,
       }),
     });
-    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const ctx = ctxWithQuality({ commands: { test: "bun test" } });
     const result = await verifyScopedOp.execute(
       { workdir: "/r", storyId: "S-1", storyGitRef: "abc", regressionMode: "per-story" },
       ctx,
@@ -238,7 +240,7 @@ describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
       }),
       testSummaryToFindings: () => [{ kind: "test", id: "f1" } as any],
     });
-    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const ctx = ctxWithQuality({ commands: { test: "bun test" } });
     const result = await verifyScopedOp.execute(
       { workdir: "/r", storyId: "S-1", regressionMode: "per-story" },
       ctx,
@@ -259,7 +261,7 @@ describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
       }),
       parseTestOutput: () => ({ passed: 0, failed: 0, failures: [] }),
     });
-    const ctx = { config: { quality: { commands: { test: "bun test" } } } } as any;
+    const ctx = ctxWithQuality({ commands: { test: "bun test" } });
     const result = await verifyScopedOp.execute(
       { workdir: "/r", storyId: "S-1", regressionMode: "per-story" },
       ctx,

--- a/test/unit/quality/runner-empty-command.test.ts
+++ b/test/unit/quality/runner-empty-command.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { runQualityCommand } from "@/quality";
+
+describe("runQualityCommand empty-command guard", () => {
+  test("returns failure (does not spawn) for an empty command", async () => {
+    const result = await runQualityCommand({ commandName: "lint", command: "", workdir: "/tmp", storyId: "US-001" });
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(-1);
+    expect(result.output).toContain("empty command");
+  });
+
+  test("returns failure for a whitespace-only command", async () => {
+    const result = await runQualityCommand({ commandName: "lint", command: "   ", workdir: "/tmp", storyId: "US-001" });
+    expect(result.success).toBe(false);
+    expect(result.exitCode).toBe(-1);
+  });
+});

--- a/test/unit/runtime/packages.test.ts
+++ b/test/unit/runtime/packages.test.ts
@@ -45,3 +45,22 @@ describe("PackageView.select()", () => {
     expect(first).toBe(second);
   });
 });
+
+describe("PackageRegistry.hydrate — per-package merge", () => {
+  test("resolve(pkg) returns merged config after hydrate", async () => {
+    const loader = createConfigLoader(makeNaxConfig({ quality: { commands: { lint: "root-lint" } } } as any));
+    const registry = createPackageRegistry(loader, "/repo");
+    // Inject a fake override loader to avoid disk I/O.
+    await registry.hydrate(["packages/agent"], async (_root, dir) =>
+      dir === "packages/agent" ? ({ quality: { commands: { lint: "pkg-lint" } } } as any) : null,
+    );
+    const view = registry.resolve("packages/agent");
+    expect(view.config.quality?.commands?.lint).toBe("pkg-lint");
+  });
+
+  test("resolve(unhydrated pkg) falls back to root config", () => {
+    const loader = createConfigLoader(makeNaxConfig({ quality: { commands: { lint: "root-lint" } } } as any));
+    const registry = createPackageRegistry(loader, "/repo");
+    expect(registry.resolve("packages/other").config.quality?.commands?.lint).toBe("root-lint");
+  });
+});

--- a/test/unit/runtime/packages.test.ts
+++ b/test/unit/runtime/packages.test.ts
@@ -63,4 +63,17 @@ describe("PackageRegistry.hydrate — per-package merge", () => {
     const registry = createPackageRegistry(loader, "/repo");
     expect(registry.resolve("packages/other").config.quality?.commands?.lint).toBe("root-lint");
   });
+
+  test("resolve(absolute path) hits the same merged config as resolve(relative)", async () => {
+    const loader = createConfigLoader(makeNaxConfig({ quality: { commands: { lint: "root-lint" } } } as any));
+    const registry = createPackageRegistry(loader, "/repo");
+    await registry.hydrate(["packages/agent"], async (_root, dir) =>
+      dir === "packages/agent" ? ({ quality: { commands: { lint: "pkg-lint" } } } as any) : null,
+    );
+    // Pipeline stages call resolve() with an absolute path like /repo/packages/agent.
+    const viewAbsolute = registry.resolve("/repo/packages/agent");
+    expect(viewAbsolute.config.quality?.commands?.lint).toBe("pkg-lint");
+    // Same instance — the cache key is normalized.
+    expect(viewAbsolute).toBe(registry.resolve("packages/agent"));
+  });
 });


### PR DESCRIPTION
## Summary

- **2a — Phantom config reads eliminated**: Six `DeterministicOperation`s (`lint-check`, `typecheck-check`, `verify-scoped`, `mechanical-lintfix`, `mechanical-formatfix`, `full-suite-gate`) were casting `ctx` to read a `.config` field that `CallContext` never carries. All six now read `ctx.packageView.select(qualityConfigSelector)` — the correct, production-safe path.
- **2b — Per-package config registry**: `PackageRegistry.resolve()` was a Wave-1 stub always returning root config. Added `hydrate(packageDirs)` to pre-load `.nax/mono/<pkg>/config.json` overrides at run setup, and `resolve()` now serves the merged config for hydrated packages.
- **Path normalization bug fix**: `resolve()` now normalizes absolute workdir paths to relative before key lookup, so pipeline stages passing `/repo/packages/agent` hit the same `mergedConfigs` entry that `hydrate()` stored under `packages/agent`.
- **Defense-in-depth**: `runQualityCommand` rejects empty/whitespace commands with `exitCode: -1` before spawning a shell process.
- **Skip-with-warning semantics**: `lint-check` and `typecheck-check` warn and return `success: true` when no command is configured, rather than silently false-passing via an empty shell invocation.
- **Rectification plan fix**: `buildPlanForStrategy` now consults `ctx.packageView` (package-merged) instead of root `config` when deciding whether to include mechanical lintfix/formatfix strategies.

## Test Plan

- [ ] `bun run test` — full suite passes (unit + integration + UI)
- [ ] `bun run typecheck` — no errors
- [ ] `bun run lint` — no violations
- [ ] New test: `resolve()` with absolute path hits the same merged config as relative — `test/unit/runtime/packages.test.ts`
- [ ] Existing tests updated: `lint-check`, `typecheck-check`, `verify-scoped`, `full-suite-gate`, `mechanical-lintfix/formatfix`, `gating-preservation` integration — all use `packageView` ctx helper
- [ ] New tests: `load-package-override`, `quality-gate-packageview`, `runner-empty-command`