### PR TITLE
fix(quality): use repoRoot as cwd for root-config quality commands in monorepo runs

### DIFF
--- a/src/operations/full-suite-gate.ts
+++ b/src/operations/full-suite-gate.ts
@@ -221,7 +221,7 @@ export const fullSuiteGateOp: DeterministicOperation<
     logger.info("verify[regression]", "Running full-suite gate", {
       storyId: input.story.id,
       packageDir: input.story.workdir,
-      cwd: input.workdir,
+      cwd: gateCtx.cmdWorkdir,
       command: gateCtx.testCmd,
       timeoutSeconds: gateCtx.fullSuiteTimeout,
     });

--- a/src/operations/full-suite-gate.ts
+++ b/src/operations/full-suite-gate.ts
@@ -98,6 +98,8 @@ export interface FullSuiteGateContext {
   readonly config: NaxConfig;
   readonly testCmd: string;
   readonly fullSuiteTimeout: number;
+  /** cwd for the test subprocess — packageDir when per-package override exists, repoRoot otherwise. */
+  readonly cmdWorkdir: string;
 }
 
 export interface FullSuiteGateDeps {
@@ -134,13 +136,15 @@ export const _fullSuiteGateDeps: FullSuiteGateDeps = {
         },
       );
     }
-    return { config, testCmd: resolvedTestCmd, fullSuiteTimeout };
+    // Root-config fallback: command was not defined per-package, so run from repo root.
+    const cmdWorkdir = ctx.packageView.hasOverride ? input.workdir : ctx.packageView.repoRoot;
+    return { config, testCmd: resolvedTestCmd, fullSuiteTimeout, cmdWorkdir };
   },
-  runTests: async (input, gateCtx) => {
+  runTests: async (_input, gateCtx) => {
     const { regression } = await import("../verification/runners");
     const { parseTestOutput } = await import("../test-runners");
     const result = await regression({
-      workdir: input.workdir,
+      workdir: gateCtx.cmdWorkdir,
       command: gateCtx.testCmd,
       timeoutSeconds: gateCtx.fullSuiteTimeout,
       // Op decides accept-on-timeout itself; runner stays neutral.

--- a/src/operations/lint-check.ts
+++ b/src/operations/lint-check.ts
@@ -53,11 +53,13 @@ export const lintCheckOp: DeterministicOperation<LintCheckInput, LintCheckOutput
       return { success: true, status: "skipped", findings: [], durationMs: 0 };
     }
 
+    // Root-config fallback: command was not defined per-package, so run from repo root.
+    const cmdWorkdir = ctx.packageView.hasOverride ? input.workdir : ctx.packageView.repoRoot;
     const start = Date.now();
     const result = await deps.runQualityCommand({
       commandName: "lint",
       command,
-      workdir: input.workdir,
+      workdir: cmdWorkdir,
       storyId: input.storyId,
       stripEnvVars: quality?.stripEnvVars ?? [],
     });

--- a/src/operations/typecheck-check.ts
+++ b/src/operations/typecheck-check.ts
@@ -55,11 +55,13 @@ export const typecheckCheckOp: DeterministicOperation<TypecheckCheckInput, Typec
       return { success: true, status: "skipped", findings: [], durationMs: 0 };
     }
 
+    // Root-config fallback: command was not defined per-package, so run from repo root.
+    const cmdWorkdir = ctx.packageView.hasOverride ? input.workdir : ctx.packageView.repoRoot;
     const start = Date.now();
     const result = await deps.runQualityCommand({
       commandName: "typecheck",
       command,
-      workdir: input.workdir,
+      workdir: cmdWorkdir,
       storyId: input.storyId,
       stripEnvVars: quality?.stripEnvVars ?? [],
     });

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -131,16 +131,16 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
     // for agent-cleanup. The legacy ScopedStrategy also used regression(), so this preserves parity
     // — it is NOT a new perf regression introduced by this port.
     const scopedTimeout = quality.execution?.regressionGate?.timeoutSeconds ?? 600;
+    // Root-config fallback: command was not defined per-package, so run from repo root.
+    const cmdWorkdir = ctx.packageView.hasOverride ? input.workdir : ctx.packageView.repoRoot;
     logger.info("verify[scoped]", "Running scoped tests", {
       storyId: input.storyId,
       packageDir: input.packageDir,
-      cwd: input.workdir,
+      cwd: cmdWorkdir,
       command: selection.effectiveCommand,
       timeoutSeconds: scopedTimeout,
       isFullSuite: selection.isFullSuite,
     });
-    // Root-config fallback: command was not defined per-package, so run from repo root.
-    const cmdWorkdir = ctx.packageView.hasOverride ? input.workdir : ctx.packageView.repoRoot;
     const start = Date.now();
     const result = await deps.regression({
       workdir: cmdWorkdir,

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -139,9 +139,11 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
       timeoutSeconds: scopedTimeout,
       isFullSuite: selection.isFullSuite,
     });
+    // Root-config fallback: command was not defined per-package, so run from repo root.
+    const cmdWorkdir = ctx.packageView.hasOverride ? input.workdir : ctx.packageView.repoRoot;
     const start = Date.now();
     const result = await deps.regression({
-      workdir: input.workdir,
+      workdir: cmdWorkdir,
       command: selection.effectiveCommand,
       // regressionGate.timeoutSeconds lives in execution; QualityConfig includes execution.
       timeoutSeconds: quality.execution?.regressionGate?.timeoutSeconds ?? 600,

--- a/src/runtime/packages.ts
+++ b/src/runtime/packages.ts
@@ -6,6 +6,10 @@ export type PackageOverrideLoader = (repoRoot: string, packageDir: string) => Pr
 export interface PackageView {
   readonly packageDir: string;
   readonly relativeFromRoot: string;
+  /** Absolute path to the repo root (.nax/ anchor). Use as cwd when running root-config commands. */
+  readonly repoRoot: string;
+  /** True when a per-package config override was hydrated for this package. */
+  readonly hasOverride: boolean;
   readonly config: NaxConfig;
   select<C>(selector: ConfigSelector<C>): C;
 }
@@ -17,7 +21,7 @@ export interface PackageRegistry {
   hydrate(packageDirs: readonly string[], loadOverride?: PackageOverrideLoader): Promise<void>;
 }
 
-function createPackageView(config: NaxConfig, packageDir: string, repoRoot: string): PackageView {
+function createPackageView(config: NaxConfig, packageDir: string, repoRoot: string, hasOverride: boolean): PackageView {
   const memo = new Map<string, unknown>();
   const relativeFromRoot = packageDir
     ? packageDir.startsWith(repoRoot)
@@ -28,6 +32,8 @@ function createPackageView(config: NaxConfig, packageDir: string, repoRoot: stri
   return {
     packageDir,
     relativeFromRoot,
+    repoRoot,
+    hasOverride,
     config,
     select<C>(selector: ConfigSelector<C>): C {
       if (memo.has(selector.name)) {
@@ -62,8 +68,10 @@ export function createPackageRegistry(loader: ConfigLoader, repoRoot: string): P
       return cached;
     }
     // Use merged config if hydration pre-loaded one for this package; otherwise root config.
-    const config = mergedConfigs.get(key) ?? loader.current();
-    const view = createPackageView(config, key, repoRoot);
+    const overrideConfig = mergedConfigs.get(key);
+    const hasOverride = overrideConfig !== undefined;
+    const config = overrideConfig ?? loader.current();
+    const view = createPackageView(config, key, repoRoot, hasOverride);
     cache.set(key, view);
     return view;
   }

--- a/test/unit/operations/full-suite-gate.test.ts
+++ b/test/unit/operations/full-suite-gate.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { fullSuiteGateOp, _fullSuiteGateDeps } from "@/operations";
 
-function ctxWithConfig(config: any = {}) {
+function ctxWithConfig(config: any = {}, opts: { hasOverride?: boolean; repoRoot?: string } = {}) {
   return {
     runtime: {},
     storyId: "US-001",
-    packageView: { packageDir: "", config, select: (s: any) => s.select(config) },
+    packageView: {
+      packageDir: "",
+      repoRoot: opts.repoRoot ?? "/repo",
+      hasOverride: opts.hasOverride ?? false,
+      config,
+      select: (s: any) => s.select(config),
+    },
   } as any;
 }
 const mockCtx = ctxWithConfig({});
@@ -16,6 +22,7 @@ function makeDeps(overrides = {}) {
       config: {} as any,
       testCmd: "bun test",
       fullSuiteTimeout: 60,
+      cmdWorkdir: "/repo",
     }),
     runTests: async () => ({
       passed: true,
@@ -238,6 +245,7 @@ describe("fullSuiteGateOp — ported RegressionStrategy behavior (issue #1116)",
         config: {} as any,
         testCmd: "bun test",
         fullSuiteTimeout: 999,
+        cmdWorkdir: "/repo",
       }),
       runTests: async (_input: any, gateCtx: any) => {
         capturedTimeout = gateCtx.fullSuiteTimeout;
@@ -250,5 +258,27 @@ describe("fullSuiteGateOp — ported RegressionStrategy behavior (issue #1116)",
       deps,
     );
     expect(capturedTimeout).toBe(999);
+  });
+
+  test("cmdWorkdir from gateCtx is threaded into runTests (root-config fallback uses repoRoot)", async () => {
+    let seenWorkdir = "";
+    const deps = makeDeps({
+      resolveGateContext: async () => ({
+        config: {} as any,
+        testCmd: "bun run test",
+        fullSuiteTimeout: 60,
+        cmdWorkdir: "/repo",
+      }),
+      runTests: async (_input: any, gateCtx: any) => {
+        seenWorkdir = gateCtx.cmdWorkdir;
+        return { passed: true, failed: 0, output: "", parsedSummary: { passed: 1, failed: 0, failures: [] }, timedOut: false };
+      },
+    });
+    await fullSuiteGateOp.execute(
+      { story: { id: "S-1" } as any, workdir: "/repo/packages/app" },
+      mockCtx,
+      deps,
+    );
+    expect(seenWorkdir).toBe("/repo");
   });
 });

--- a/test/unit/operations/lint-check.test.ts
+++ b/test/unit/operations/lint-check.test.ts
@@ -3,12 +3,18 @@ import { lintCheckOp } from "@/operations";
 import type { LintCheckDeps } from "@/operations";
 import type { Finding } from "@/findings";
 
-function ctxWithQuality(quality?: Record<string, unknown>) {
+function ctxWithQuality(quality?: Record<string, unknown>, opts: { hasOverride?: boolean; repoRoot?: string } = {}) {
   const config = { quality, execution: {} } as any;
   return {
     runtime: {},
     storyId: "US-003",
-    packageView: { packageDir: "packages/agent", config, select: (sel: any) => sel.select(config) },
+    packageView: {
+      packageDir: "packages/agent",
+      repoRoot: opts.repoRoot ?? "/repo",
+      hasOverride: opts.hasOverride ?? false,
+      config,
+      select: (sel: any) => sel.select(config),
+    },
   } as any;
 }
 
@@ -136,5 +142,29 @@ describe("lintCheckOp — AC10: per-package config override", () => {
       deps,
     );
     expect(seen).toBe("ruff check packages/agent");
+  });
+});
+
+describe("lintCheckOp — workdir routing: repoRoot vs packageDir", () => {
+  test("uses repoRoot as cwd when no per-package override (root config fallback)", async () => {
+    let seenWorkdir = "";
+    const deps = makeDeps({ runQualityCommand: async (o) => { seenWorkdir = o.workdir; return passedResult; } });
+    await lintCheckOp.execute(
+      { workdir: "/repo/packages/app", storyId: "US-003" },
+      ctxWithQuality({ commands: { lint: "bun run lint" } }, { hasOverride: false, repoRoot: "/repo" }),
+      deps,
+    );
+    expect(seenWorkdir).toBe("/repo");
+  });
+
+  test("uses input.workdir (packageDir) as cwd when per-package override exists", async () => {
+    let seenWorkdir = "";
+    const deps = makeDeps({ runQualityCommand: async (o) => { seenWorkdir = o.workdir; return passedResult; } });
+    await lintCheckOp.execute(
+      { workdir: "/repo/packages/lib", storyId: "US-003" },
+      ctxWithQuality({ commands: { lint: "echo ok" } }, { hasOverride: true, repoRoot: "/repo" }),
+      deps,
+    );
+    expect(seenWorkdir).toBe("/repo/packages/lib");
   });
 });

--- a/test/unit/operations/typecheck-check.test.ts
+++ b/test/unit/operations/typecheck-check.test.ts
@@ -3,12 +3,18 @@ import { typecheckCheckOp } from "@/operations";
 import type { TypecheckCheckDeps } from "@/operations";
 import type { Finding } from "@/findings";
 
-function ctxWithQuality(quality?: Record<string, unknown>) {
+function ctxWithQuality(quality?: Record<string, unknown>, opts: { hasOverride?: boolean; repoRoot?: string } = {}) {
   const config = { quality, execution: {} } as any;
   return {
     runtime: {},
     storyId: "US-003",
-    packageView: { packageDir: "packages/agent", config, select: (sel: any) => sel.select(config) },
+    packageView: {
+      packageDir: "packages/agent",
+      repoRoot: opts.repoRoot ?? "/repo",
+      hasOverride: opts.hasOverride ?? false,
+      config,
+      select: (sel: any) => sel.select(config),
+    },
   } as any;
 }
 
@@ -107,6 +113,30 @@ describe("typecheckCheckOp — AC4: execute returns success=true when command ex
       }),
     );
     expect(out.findings.every((f) => f.source === "typecheck")).toBe(true);
+  });
+});
+
+describe("typecheckCheckOp — workdir routing: repoRoot vs packageDir", () => {
+  test("uses repoRoot as cwd when no per-package override (root config fallback)", async () => {
+    let seenWorkdir = "";
+    const deps = makeDeps({ runQualityCommand: async (o) => { seenWorkdir = o.workdir; return passedResult; } });
+    await typecheckCheckOp.execute(
+      { workdir: "/repo/packages/app", storyId: "US-003" },
+      ctxWithQuality({ commands: { typecheck: "bun run typecheck" } }, { hasOverride: false, repoRoot: "/repo" }),
+      deps,
+    );
+    expect(seenWorkdir).toBe("/repo");
+  });
+
+  test("uses input.workdir (packageDir) as cwd when per-package override exists", async () => {
+    let seenWorkdir = "";
+    const deps = makeDeps({ runQualityCommand: async (o) => { seenWorkdir = o.workdir; return passedResult; } });
+    await typecheckCheckOp.execute(
+      { workdir: "/repo/packages/lib", storyId: "US-003" },
+      ctxWithQuality({ commands: { typecheck: "tsc --noEmit" } }, { hasOverride: true, repoRoot: "/repo" }),
+      deps,
+    );
+    expect(seenWorkdir).toBe("/repo/packages/lib");
   });
 });
 

--- a/test/unit/operations/verify-scoped.test.ts
+++ b/test/unit/operations/verify-scoped.test.ts
@@ -3,12 +3,18 @@ import { verifyScopedOp, _verifyScopedDeps } from "@/operations";
 import type { VerifyScopedDeps } from "@/operations";
 import type { Finding } from "@/findings";
 
-function ctxWithQuality(quality?: Record<string, unknown>) {
+function ctxWithQuality(quality?: Record<string, unknown>, opts: { hasOverride?: boolean; repoRoot?: string } = {}) {
   const config = { quality, execution: {} } as any;
   return {
     runtime: {},
     storyId: "US-003",
-    packageView: { packageDir: "packages/agent", config, select: (s: any) => s.select(config) },
+    packageView: {
+      packageDir: "packages/agent",
+      repoRoot: opts.repoRoot ?? "/repo",
+      hasOverride: opts.hasOverride ?? false,
+      config,
+      select: (s: any) => s.select(config),
+    },
   } as any;
 }
 
@@ -249,6 +255,32 @@ describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
     expect(result.status).toBe("failed");
     expect(result.success).toBe(false);
     expect(result.findings.length).toBe(1);
+  });
+
+  test("workdir routing — uses repoRoot when no per-package override", async () => {
+    let seenWorkdir = "";
+    const deps = fakeDeps({
+      regression: async (opts) => { seenWorkdir = opts.workdir; return { status: "SUCCESS" as const, success: true, countsTowardEscalation: true, output: "" }; },
+    });
+    await verifyScopedOp.execute(
+      { workdir: "/repo/packages/app", storyId: "S-1", regressionMode: "per-story" },
+      ctxWithQuality({ commands: { test: "bun run test" } }, { hasOverride: false, repoRoot: "/repo" }),
+      deps,
+    );
+    expect(seenWorkdir).toBe("/repo");
+  });
+
+  test("workdir routing — uses input.workdir (packageDir) when per-package override exists", async () => {
+    let seenWorkdir = "";
+    const deps = fakeDeps({
+      regression: async (opts) => { seenWorkdir = opts.workdir; return { status: "SUCCESS" as const, success: true, countsTowardEscalation: true, output: "" }; },
+    });
+    await verifyScopedOp.execute(
+      { workdir: "/repo/packages/lib", storyId: "S-1", regressionMode: "per-story" },
+      ctxWithQuality({ commands: { test: "bun test" } }, { hasOverride: true, repoRoot: "/repo" }),
+      deps,
+    );
+    expect(seenWorkdir).toBe("/repo/packages/lib");
   });
 
   test("timeout → status=timeout, success=false", async () => {

--- a/test/unit/runtime/packages.test.ts
+++ b/test/unit/runtime/packages.test.ts
@@ -77,3 +77,31 @@ describe("PackageRegistry.hydrate — per-package merge", () => {
     expect(viewAbsolute).toBe(registry.resolve("packages/agent"));
   });
 });
+
+describe("PackageView.hasOverride and repoRoot", () => {
+  test("hasOverride=false and repoRoot exposed for unhydrated package (root-config fallback)", () => {
+    const loader = createConfigLoader(minConfig);
+    const registry = createPackageRegistry(loader, "/repo");
+    const view = registry.resolve("packages/app");
+    expect(view.hasOverride).toBe(false);
+    expect(view.repoRoot).toBe("/repo");
+  });
+
+  test("hasOverride=true for hydrated package with per-package override", async () => {
+    const loader = createConfigLoader(minConfig);
+    const registry = createPackageRegistry(loader, "/repo");
+    await registry.hydrate(["packages/lib"], async (_root, dir) =>
+      dir === "packages/lib" ? ({ quality: { commands: { lint: "echo ok" } } } as any) : null,
+    );
+    const view = registry.resolve("packages/lib");
+    expect(view.hasOverride).toBe(true);
+    expect(view.repoRoot).toBe("/repo");
+  });
+
+  test("hasOverride=false for repo() (root view)", () => {
+    const loader = createConfigLoader(minConfig);
+    const registry = createPackageRegistry(loader, "/repo");
+    expect(registry.repo().hasOverride).toBe(false);
+    expect(registry.repo().repoRoot).toBe("/repo");
+  });
+});


### PR DESCRIPTION
## Problem

In monorepo runs, story US-002 (a package with **no** per-package config override) would fail lint/typecheck/test even though the root-config command was correct. The command (e.g. `bun run lint`) was being executed with `cwd = packageDir` instead of `cwd = repoRoot`. Since root-config commands like `bun run lint` rely on `package.json` scripts and workspace tooling at the repo root, running them from a nested package directory fails.

Root cause: commit `56d53a1a` fixed a silent no-op bug (quality ops were reading config via a broken cast that always returned `undefined`), which correctly wired up the ops — but exposed a latent bug where `workdir: input.workdir` (packageDir) was always passed to `runQualityCommand`/`regression`, even for root-config fallbacks.

## Solution

Add `hasOverride` and `repoRoot` to `PackageView` at the `resolve()` layer, where the distinction between a hydrated per-package config and a root-config fallback is already known. Each quality op then routes:

- `hasOverride = true` → run from `packageDir` (per-package command, relative paths scoped to the package)
- `hasOverride = false` → run from `repoRoot` (root-config command, needs workspace tooling at the root)

`verify-scoped` applies the routing only to the `regression()` call — `selectScopedTests()` still receives `packageDir` for git diff/file detection. `full-suite-gate` threads `cmdWorkdir` through `FullSuiteGateContext` to keep the injectable `runTests` dep testable.

## Changes

- `src/runtime/packages.ts` — `PackageView` gains `hasOverride: boolean` and `repoRoot: string`; `createPackageView` and `resolve()` updated
- `src/operations/lint-check.ts` — route cwd via `hasOverride`
- `src/operations/typecheck-check.ts` — route cwd via `hasOverride`
- `src/operations/verify-scoped.ts` — route cwd via `hasOverride` for `regression()` call only; log accurate `cmdWorkdir`
- `src/operations/full-suite-gate.ts` — `cmdWorkdir` added to `FullSuiteGateContext`; `resolveGateContext` computes it; log accurate `cmdWorkdir`

## Test plan

- [ ] `test/unit/runtime/packages.test.ts` — 3 new tests: `hasOverride=false` for unhydrated package, `hasOverride=true` for hydrated package, `hasOverride=false` for `repo()` root view
- [ ] `test/unit/operations/lint-check.test.ts` — 2 new workdir routing tests
- [ ] `test/unit/operations/typecheck-check.test.ts` — 2 new workdir routing tests
- [ ] `test/unit/operations/verify-scoped.test.ts` — 2 new workdir routing tests
- [ ] `test/unit/operations/full-suite-gate.test.ts` — 1 new test verifying `cmdWorkdir` is threaded from `resolveGateContext` into `runTests`
- [ ] Full suite passing: 1077 tests, 0 failures
- [ ] Manual: reproduce with `fixtures/monorepo-tiny` — US-001 (per-package override) passes from `packageDir`; US-002 (root-config fallback) now passes from `repoRoot`