### PR TITLE
fix(verify): restore Pass 0 changed-test detection in scoped selection

### DIFF
--- a/src/execution/plan-inputs.ts
+++ b/src/execution/plan-inputs.ts
@@ -274,6 +274,14 @@ export async function assemblePlanInputsFromCtx(ctx: import("../pipeline/types")
         // "disabled" mode means the regression gate is fully off; treat as "deferred" for
         // verifyScopedOp (scope-level behavior unchanged — fullSuiteGateOp handles enabled=false).
         regressionMode: toVerifyScopedMode(ctx.config.execution?.regressionGate?.mode),
+        // Anchors for changed-test detection + path-convention mapping (restored Pass 0,
+        // language-agnostic + monorepo-correct). projectDir is the repo root; packageDirRelative
+        // scopes the git diff to the story's package (it equals story.workdir in monorepo mode,
+        // undefined for single-package — see PipelineContext.workdir invariant); resolvedTestPatterns
+        // is the ADR-009 SSOT. Use the same anchor as resolveTestFilePatterns above for consistency.
+        repoRoot: ctx.projectDir,
+        packagePrefix: packageDirRelative,
+        resolvedTestPatterns,
       }
     : undefined;
 

--- a/src/operations/verify-scoped.ts
+++ b/src/operations/verify-scoped.ts
@@ -4,7 +4,7 @@ import { testSummaryToFindings } from "../findings";
 import type { Finding } from "../findings/types";
 import { getLogger } from "../logger";
 import { _scopedSelectionDeps, parseTestOutput, selectScopedTests } from "../test-runners";
-import type { SelectScopedTestsResult, TestSummary } from "../test-runners";
+import type { ResolvedTestPatterns, SelectScopedTestsResult, TestSummary } from "../test-runners";
 import type { NaxIgnoreIndex } from "../utils/path-filters";
 import { regression } from "../verification/runners";
 import type { VerificationGateOptions, VerificationResult } from "../verification/types";
@@ -20,6 +20,12 @@ export interface VerifyScopedInput {
   readonly naxIgnoreIndex?: NaxIgnoreIndex;
   /** Regression-gate mode — controls SKIPPED behavior when no tests are mapped. */
   readonly regressionMode?: "deferred" | "per-story";
+  /** Absolute repo root — anchor for changed-test detection / mapping in monorepos. */
+  readonly repoRoot?: string;
+  /** Story workdir relative to repoRoot (e.g. "packages/core") — scopes the git diff. */
+  readonly packagePrefix?: string;
+  /** ADR-009 resolved test patterns (language-agnostic, per-package override-aware). */
+  readonly resolvedTestPatterns?: ResolvedTestPatterns;
 }
 
 export type VerifyScopedStatus = "passed" | "failed" | "skipped" | "timeout";
@@ -93,6 +99,9 @@ export const verifyScopedOp: DeterministicOperation<VerifyScopedInput, VerifySco
       scopeTestThreshold: quality.quality?.scopeTestThreshold,
       fallbackFullSuiteCommand: quality.quality?.commands?.test,
       naxIgnoreIndex: input.naxIgnoreIndex,
+      repoRoot: input.repoRoot,
+      packagePrefix: input.packagePrefix,
+      resolvedTestPatterns: input.resolvedTestPatterns,
     });
 
     // Deferred mode + no mapped tests + not a monorepo orchestrator → SKIP.

--- a/src/test-runners/scoped-selection.ts
+++ b/src/test-runners/scoped-selection.ts
@@ -15,6 +15,7 @@ import { getLogger } from "@/logger";
 import { DEFAULT_TEST_FILE_PATTERNS, globsToTestRegex } from "@/test-runners";
 import type { NaxIgnoreIndex } from "@/utils/path-filters";
 import { _smartRunnerDeps } from "../verification/smart-runner";
+import type { ResolvedTestPatterns } from "./resolver";
 
 const DEFAULT_SMART_RUNNER_CONFIG = {
   enabled: true,
@@ -65,6 +66,19 @@ export interface SelectScopedTestsInput {
   scopeTestThreshold?: number;
   fallbackFullSuiteCommand?: string;
   naxIgnoreIndex?: NaxIgnoreIndex;
+  /**
+   * Absolute repo root — anchor for changed-test detection and path-convention
+   * mapping in monorepos. Defaults to `workdir` for single-package layouts.
+   */
+  repoRoot?: string;
+  /** Story workdir relative to repoRoot (e.g. "packages/core") — scopes the git diff. */
+  packagePrefix?: string;
+  /**
+   * ADR-009 resolved test patterns. When present, `.regex` drives changed-file
+   * classification and `.globs` drives suffix derivation — language-agnostic and
+   * per-package override-aware. Falls back to `smartRunnerConfig.testFilePatterns`.
+   */
+  resolvedTestPatterns?: ResolvedTestPatterns;
 }
 
 export interface SelectScopedTestsResult {
@@ -100,15 +114,65 @@ export async function selectScopedTests(input: SelectScopedTestsInput): Promise<
     return { effectiveCommand: input.testCommand, isFullSuite: true, thresholdFallback: false, isMonorepoOrchestrator };
   }
 
+  // Anchors: prefer the ADR-009 resolved patterns + repo-root/package-prefix when the
+  // caller supplies them (language-agnostic, monorepo-correct). Fall back to the raw
+  // smart-runner patterns + workdir for single-package callers and unit tests.
+  const repoRoot = input.repoRoot ?? input.workdir;
+  const classifyRegex = input.resolvedTestPatterns?.regex
+    ? [...input.resolvedTestPatterns.regex]
+    : globsToTestRegex(smartCfg.testFilePatterns);
+  const mappingGlobs = input.resolvedTestPatterns?.globs
+    ? [...input.resolvedTestPatterns.globs]
+    : smartCfg.testFilePatterns;
+
+  // Pass 0 — changed test files detected directly from the git diff (restored from
+  // pre-#1084 verify.ts). A test file that changed in the story commit is already a
+  // test: run it directly, no source→test mapping needed. This is the language-agnostic
+  // path that catches Python `test_*.py`, Go `_test.go`, etc. (issue: smart-runner
+  // scoped selection was TS-centric after the builder-phase unification).
+  //
+  // NOTE: the threshold gate below is NOT in the historical verify.ts (which ran every
+  // changed test unconditionally). It was added here for parity with Pass 1/2 — capping
+  // the scoped command size. Side effect: a story changing > threshold test files falls
+  // back to the full suite (skipped in deferred mode, deferred to run-end).
+  const changedTestFiles = await _scopedSelectionDeps.getChangedTestFiles(
+    input.workdir,
+    repoRoot,
+    input.storyGitRef,
+    input.packagePrefix,
+    classifyRegex,
+    input.naxIgnoreIndex,
+  );
+  if (changedTestFiles.length > threshold) {
+    logger.warn(
+      "verify[scoped]",
+      `Changed test file count ${changedTestFiles.length} exceeds threshold ${threshold} — falling back to full suite`,
+      { storyId: input.storyId },
+    );
+    return fullSuite({ scopeTestFallback: true, thresholdFallback: true });
+  }
+  if (changedTestFiles.length > 0) {
+    logger.info("verify[scoped]", `Pass 0: ${changedTestFiles.length} changed test file(s) detected directly`, {
+      storyId: input.storyId,
+    });
+    return scoped(changedTestFiles);
+  }
+
   const nonTestFiles = await _scopedSelectionDeps.getChangedNonTestFiles(
     input.workdir,
     input.storyGitRef,
-    undefined,
-    globsToTestRegex(smartCfg.testFilePatterns),
+    input.packagePrefix,
+    classifyRegex,
     input.naxIgnoreIndex,
+    repoRoot,
   );
 
-  const pass1Files = await _scopedSelectionDeps.mapSourceToTests(nonTestFiles, input.workdir);
+  const pass1Files = await _scopedSelectionDeps.mapSourceToTests(
+    nonTestFiles,
+    repoRoot,
+    input.packagePrefix,
+    mappingGlobs,
+  );
   if (pass1Files.length > threshold) {
     logger.warn(
       "verify[scoped]",
@@ -128,11 +192,7 @@ export async function selectScopedTests(input: SelectScopedTestsInput): Promise<
     return fullSuite();
   }
 
-  const pass2Files = await _scopedSelectionDeps.importGrepFallback(
-    nonTestFiles,
-    input.workdir,
-    smartCfg.testFilePatterns,
-  );
+  const pass2Files = await _scopedSelectionDeps.importGrepFallback(nonTestFiles, input.workdir, mappingGlobs);
   if (pass2Files.length > threshold) {
     logger.warn(
       "verify[scoped]",
@@ -154,6 +214,7 @@ export async function selectScopedTests(input: SelectScopedTestsInput): Promise<
 /** Injectable deps for testing. Mirrors `_scopedDeps` from strategies/scoped.ts. */
 export const _scopedSelectionDeps = {
   getChangedNonTestFiles: _smartRunnerDeps.getChangedNonTestFiles,
+  getChangedTestFiles: _smartRunnerDeps.getChangedTestFiles,
   mapSourceToTests: _smartRunnerDeps.mapSourceToTests,
   importGrepFallback: _smartRunnerDeps.importGrepFallback,
   buildSmartTestCommand: _smartRunnerDeps.buildSmartTestCommand,

--- a/test/unit/operations/verify-scoped.test.ts
+++ b/test/unit/operations/verify-scoped.test.ts
@@ -283,6 +283,33 @@ describe("verifyScopedOp — ported ScopedStrategy behavior", () => {
     expect(seenWorkdir).toBe("/repo/packages/lib");
   });
 
+  test("forwards repoRoot/packagePrefix/resolvedTestPatterns to selectScopedTests (Pass 0 anchors)", async () => {
+    let seen: Record<string, unknown> | undefined;
+    const resolvedTestPatterns = { globs: ["tests/**/*.py"], pathspec: [], regex: [/test_.*\.py$/], testDirs: ["tests"] } as any;
+    const deps = fakeDeps({
+      selectScopedTests: async (input) => {
+        seen = input as unknown as Record<string, unknown>;
+        return { effectiveCommand: "uv run pytest", isFullSuite: true, thresholdFallback: false, isMonorepoOrchestrator: false };
+      },
+    });
+    await verifyScopedOp.execute(
+      {
+        workdir: "/repo/packages/core",
+        storyId: "S-1",
+        storyGitRef: "abc",
+        regressionMode: "per-story",
+        repoRoot: "/repo",
+        packagePrefix: "packages/core",
+        resolvedTestPatterns,
+      },
+      ctxWithQuality({ commands: { test: "uv run pytest" } }, { hasOverride: true, repoRoot: "/repo" }),
+      deps,
+    );
+    expect(seen?.repoRoot).toBe("/repo");
+    expect(seen?.packagePrefix).toBe("packages/core");
+    expect(seen?.resolvedTestPatterns).toBe(resolvedTestPatterns);
+  });
+
   test("timeout → status=timeout, success=false", async () => {
     const deps = fakeDeps({
       regression: async () => ({

--- a/test/unit/test-runners/scoped-selection.test.ts
+++ b/test/unit/test-runners/scoped-selection.test.ts
@@ -4,6 +4,7 @@ import { selectScopedTests, _scopedSelectionDeps } from "@/test-runners";
 function makeFakeDeps(overrides: Partial<typeof _scopedSelectionDeps> = {}) {
   return {
     getChangedNonTestFiles: async () => ["src/a.ts"],
+    getChangedTestFiles: async () => [] as string[],
     mapSourceToTests: async () => [] as string[],
     importGrepFallback: async () => [] as string[],
     buildSmartTestCommand: (files: string[], base: string) => `${base} ${files.join(" ")}`,
@@ -35,6 +36,58 @@ describe("selectScopedTests", () => {
     expect(result.isMonorepoOrchestrator).toBe(true);
     expect(result.isFullSuite).toBe(true);
     expect(result.effectiveCommand).toBe("turbo run test");
+  });
+
+  test("Pass 0: changed test files detected directly → scoped, no source→test mapping", async () => {
+    // Restores pre-#1084 behavior: a test file that changed in the story diff is
+    // already a test — run it directly, language-agnostically (e.g. Python test_*.py).
+    Object.assign(
+      _scopedSelectionDeps,
+      makeFakeDeps({
+        getChangedTestFiles: async () => ["/repo/pkg/tests/unit/test_fmp_client.py"],
+        getChangedNonTestFiles: async () => {
+          throw new Error("Pass 0 hit — source classification should not run");
+        },
+        mapSourceToTests: async () => {
+          throw new Error("Pass 0 hit — path-convention mapping should not run");
+        },
+      }),
+    );
+    const result = await selectScopedTests({
+      ...baseInput,
+      testScopedTemplate: "uv run pytest {{files}}",
+      scopeTestThreshold: 10,
+    });
+    expect(result.isFullSuite).toBe(false);
+    expect(result.effectiveCommand).toBe("uv run pytest '/repo/pkg/tests/unit/test_fmp_client.py'");
+    expect(result.scopeTestFallback).toBeUndefined();
+  });
+
+  test("Pass 0 above threshold → fallback to full suite", async () => {
+    const manyTests = Array.from({ length: 15 }, (_, i) => `/repo/pkg/tests/test_${i}.py`);
+    Object.assign(_scopedSelectionDeps, makeFakeDeps({ getChangedTestFiles: async () => manyTests }));
+    const result = await selectScopedTests({
+      ...baseInput,
+      scopeTestThreshold: 10,
+      fallbackFullSuiteCommand: "uv run pytest",
+    });
+    expect(result.isFullSuite).toBe(true);
+    expect(result.thresholdFallback).toBe(true);
+    expect(result.scopeTestFallback).toBe(true);
+    expect(result.effectiveCommand).toBe("uv run pytest");
+  });
+
+  test("Pass 0 empty → falls through to Pass 1 (source→test mapping)", async () => {
+    Object.assign(
+      _scopedSelectionDeps,
+      makeFakeDeps({
+        getChangedTestFiles: async () => [],
+        mapSourceToTests: async () => ["test/a.test.ts"],
+      }),
+    );
+    const result = await selectScopedTests({ ...baseInput, scopeTestThreshold: 10 });
+    expect(result.isFullSuite).toBe(false);
+    expect(result.effectiveCommand).toBe("bun test test/a.test.ts");
   });
 
   test("Pass 1 match below threshold → scoped command", async () => {


### PR DESCRIPTION
## Problem

For non-TypeScript repos, the implementer/test-writer could create and commit a test (e.g. Python `test_fmp_client.py`), yet the per-story scoped gate logged **"No mapped tests — deferring to run-end"** and skipped it. The committed tests were never executed at the scoped gate.

Reproduced against a real Python monorepo: a story that committed both `…/src/stock_core/data/adapters/_fmp_client.py` and `…/tests/unit/data/adapters/test_fmp_client.py` resolved to `isFullSuite=true` under **every** config variant (per-package patterns, root patterns, both `workdir` interpretations). It is **not** a misconfiguration — it's a code-level limitation.

## Root cause

`selectScopedTests` had only two TS-centric passes, both of which fail for Python:

- **Pass 1** (`mapSourceToTests`) builds candidates by appending a *suffix* (`.test.ts`-style) to a `src/`-stripped mirror path. Python uses a `test_` **prefix** and a different dir mirror, so it can never produce `test_fmp_client.py`.
- **Pass 2** (`importGrepFallback`) emits **slash**-separated search terms (`/_fmp_client`); Python imports are **dot**-separated (`from stock_core.data.adapters._fmp_client import …`), so they never match.

The language-agnostic signal — *the test file is already in the git diff* — was computed by `getChangedTestFiles`, but that helper had **zero production callers**. It used to be wired as "Pass 0" in `src/pipeline/stages/verify.ts` (added in #557), which was **deleted** by the builder-phase unification (#1084). The replacement op was built on the `strategies/scoped.ts` lineage that never had Pass 0, silently dropping three capabilities:

1. **Pass 0** — direct changed-test detection
2. **`packagePrefix`** threading (monorepo git scoping + mirror base)
3. **`resolvedTestPatterns`** (ADR-009 SSOT) instead of raw TS-default patterns

## Fix

Restore **Pass 0** ahead of Pass 1/2 in `selectScopedTests`, and thread `repoRoot` + `packagePrefix` + `resolvedTestPatterns` from `plan-inputs.ts` through `verifyScopedOp` into the selector. All three are optional and fall back to prior behavior (`workdir` + smart-runner patterns) when absent, so single-package callers and existing fixtures are unaffected.

New selection order: **Pass 0** (changed test files, run directly) → **Pass 1** (path-convention mapping, now with package prefix + SSOT patterns) → **Pass 2** (import-grep) → full-suite fallback. Pass 0 is threshold-gated for parity with Pass 1/2 (documented inline — this is the one intentional divergence from the historical verbatim behavior).

### Result for the repro

```
Before: verify[scoped]: No mapped tests — deferring to run-end (SKIPPED)
After:  verify[scoped]: Pass 0: 1 changed test file(s) detected directly
        cmd: uv run pytest -c pyproject.toml '…/tests/unit/data/adapters/test_fmp_client.py'
```

TS repos: no behavior change (Pass 0 finds changed `.test.ts`; otherwise falls through to Pass 1/2 as today).

## Test plan

- [x] 3 new `selectScopedTests` tests: Pass 0 direct detection (asserts Pass 1/2 not called), Pass 0 above-threshold fallback, Pass 0 empty → falls through to Pass 1
- [x] 1 new `verifyScopedOp` test: forwards `repoRoot`/`packagePrefix`/`resolvedTestPatterns` to the selector
- [x] End-to-end verified against the real Python monorepo (scoped command now runs the committed test)
- [x] Full suite: 9655 pass / 0 fail (unit 8601, integration 1039, ui 15)
- [x] typecheck + lint + all pre-commit gates clean

## Files

- `src/test-runners/scoped-selection.ts` — Pass 0 + anchor threading into Pass 1/2
- `src/operations/verify-scoped.ts` — new optional input fields
- `src/execution/plan-inputs.ts` — populate anchors (uses `packageDirRelative`, consistent with `resolveTestFilePatterns`)
- `test/unit/test-runners/scoped-selection.test.ts`, `test/unit/operations/verify-scoped.test.ts` — coverage